### PR TITLE
feat(openviking): export public-safe LoopX run conclusions

### DIFF
--- a/examples/loopx-history-conclusion-recall-smoke.py
+++ b/examples/loopx-history-conclusion-recall-smoke.py
@@ -554,6 +554,213 @@ def _case_export_cleans_backup_when_live_is_valid(
     assert not backup.exists()
 
 
+def _case_export_defers_until_verified_backup_cleanup(
+    tmp_path: Path, monkeypatch
+) -> None:
+    goal = "recover-live-cleanup-retry"
+    result = _export_runs(
+        tmp_path,
+        monkeypatch,
+        goal_id=goal,
+        runs=[
+            {
+                "classification": "prior",
+                "generated_at": "2026-08-04T01:02:03Z",
+                "recommended_action": "published prior conclusion",
+            }
+        ],
+    )
+    corpus_out, manifest_path, prior_manifest, prior_documents = _corpus_snapshot(
+        result
+    )
+    backup = corpus_out.parent / f".{corpus_out.name}.loopx-backup"
+    history_export.shutil.copytree(corpus_out, backup)
+    original_rmtree = history_export.shutil.rmtree
+
+    def _leave_backup(path, *args, **kwargs) -> None:
+        if Path(path) == backup:
+            return
+        original_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(history_export.shutil, "rmtree", _leave_backup)
+    try:
+        _export_runs(
+            tmp_path,
+            monkeypatch,
+            goal_id=goal,
+            runs=[
+                {
+                    "classification": "replacement",
+                    "generated_at": "2026-08-04T04:05:06Z",
+                    "recommended_action": "must wait for backup cleanup",
+                }
+            ],
+        )
+    except RuntimeError as exc:
+        assert "backup cleanup is incomplete" in str(exc)
+    else:
+        raise AssertionError("incomplete backup cleanup must defer publication")
+
+    _assert_corpus_unchanged(
+        corpus_out, manifest_path, prior_manifest, prior_documents
+    )
+    assert backup.is_dir()
+
+    monkeypatch.setattr(history_export.shutil, "rmtree", original_rmtree)
+    result2 = _export_runs(
+        tmp_path,
+        monkeypatch,
+        goal_id=goal,
+        runs=[
+            {
+                "classification": "replacement",
+                "generated_at": "2026-08-04T04:05:06Z",
+                "recommended_action": "retry after cleanup succeeds",
+            }
+        ],
+    )
+    assert Path(result2["local_receipt"]["manifest_path"]).is_file()
+    assert not backup.exists()
+
+
+def _case_export_reports_post_publish_backup_cleanup_failure(
+    tmp_path: Path, monkeypatch
+) -> None:
+    goal = "post-publish-cleanup-retry"
+    _export_runs(
+        tmp_path,
+        monkeypatch,
+        goal_id=goal,
+        runs=[
+            {
+                "classification": "prior",
+                "generated_at": "2026-08-04T01:02:03Z",
+                "recommended_action": "published prior conclusion",
+            }
+        ],
+    )
+    corpus_out = tmp_path / "out" / goal / "history-conclusions"
+    backup = corpus_out.parent / f".{corpus_out.name}.loopx-backup"
+    original_rmtree = history_export.shutil.rmtree
+
+    def _leave_backup(path, *args, **kwargs) -> None:
+        if Path(path) == backup:
+            return
+        original_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(history_export.shutil, "rmtree", _leave_backup)
+    try:
+        _export_runs(
+            tmp_path,
+            monkeypatch,
+            goal_id=goal,
+            runs=[
+                {
+                    "classification": "replacement",
+                    "generated_at": "2026-08-04T04:05:06Z",
+                    "recommended_action": "must report cleanup failure",
+                }
+            ],
+        )
+    except RuntimeError as exc:
+        assert "backup cleanup is incomplete" in str(exc)
+    else:
+        raise AssertionError("post-publish cleanup failure must be reported")
+
+    assert backup.is_dir()
+    assert "must report cleanup failure" in next(corpus_out.glob("*.md")).read_text(
+        encoding="utf-8"
+    )
+
+
+def _case_export_refuses_unowned_backup_when_live_is_valid(
+    tmp_path: Path, monkeypatch
+) -> None:
+    goal = "recover-live-unowned-backup"
+    result = _export_runs(
+        tmp_path,
+        monkeypatch,
+        goal_id=goal,
+        runs=[
+            {
+                "classification": "prior",
+                "generated_at": "2026-08-04T01:02:03Z",
+                "recommended_action": "published prior conclusion",
+            }
+        ],
+    )
+    corpus_out = Path(result["local_receipt"]["out_dir"])
+    backup = corpus_out.parent / f".{corpus_out.name}.loopx-backup"
+    foreign = backup / "foreign.md"
+    backup.mkdir()
+    foreign.write_text("# maintained by another publisher", encoding="utf-8")
+
+    try:
+        _export_runs(
+            tmp_path,
+            monkeypatch,
+            goal_id=goal,
+            runs=[
+                {
+                    "classification": "replacement",
+                    "generated_at": "2026-08-04T04:05:06Z",
+                    "recommended_action": "must preserve the foreign backup",
+                }
+            ],
+        )
+    except RuntimeError as exc:
+        assert "unverified backup" in str(exc)
+    else:
+        raise AssertionError("unowned backup must block recovery")
+
+    assert foreign.read_text(encoding="utf-8").startswith("# maintained")
+    assert (corpus_out / ".loopx-history-conclusion-export.json").is_file()
+
+
+def _case_export_recovers_valid_backup_and_preserves_unverified_live(
+    tmp_path: Path, monkeypatch
+) -> None:
+    goal = "recover-invalid-live"
+    result = _export_runs(
+        tmp_path,
+        monkeypatch,
+        goal_id=goal,
+        runs=[
+            {
+                "classification": "prior",
+                "generated_at": "2026-08-04T01:02:03Z",
+                "recommended_action": "published prior conclusion",
+            }
+        ],
+    )
+    corpus_out = Path(result["local_receipt"]["out_dir"])
+    backup = corpus_out.parent / f".{corpus_out.name}.loopx-backup"
+    unverified_live = corpus_out.parent / f".{corpus_out.name}.loopx-unverified-live"
+    history_export.shutil.copytree(corpus_out, backup)
+    foreign = corpus_out / "foreign.md"
+    foreign.write_text("# maintained by another publisher", encoding="utf-8")
+
+    result2 = _export_runs(
+        tmp_path,
+        monkeypatch,
+        goal_id=goal,
+        runs=[
+            {
+                "classification": "replacement",
+                "generated_at": "2026-08-04T04:05:06Z",
+                "recommended_action": "recover from verified backup",
+            }
+        ],
+    )
+
+    assert Path(result2["local_receipt"]["manifest_path"]).is_file()
+    assert not backup.exists()
+    assert foreign.exists() is False
+    assert (unverified_live / "foreign.md").read_text(
+        encoding="utf-8"
+    ).startswith("# maintained")
+
+
 def _case_export_fails_closed_when_neither_live_nor_backup_is_valid(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -590,7 +797,7 @@ def _case_export_fails_closed_when_neither_live_nor_backup_is_valid(
         )
         raise AssertionError("should have raised")
     except RuntimeError as exc:
-        assert "neither could be verified" in str(exc)
+        assert "unverified backup" in str(exc)
 
 
 def _case_active_provider_rejects_exit_zero_unsuccessful_openviking_envelope(

--- a/examples/loopx-history-conclusion-recall-smoke.py
+++ b/examples/loopx-history-conclusion-recall-smoke.py
@@ -2,13 +2,18 @@
 """Focused smoke for LoopX history-conclusion export + resources-scope recall.
 
 Public-safe and offline: it does not require a live OpenViking backend, network,
-credentials, or raw transcripts. It pins the durable behaviors:
+credentials, or raw transcripts. It pins the durable end-to-end boundary
+behaviors, including negative cases for the review findings:
 
-1. Export drops any conclusion field carrying a local path or secret-like token
-   (public/private boundary enforcement via public_safe_compact_text).
-2. Runs with no substantive conclusion beyond classification are skipped as noise.
-3. The resources-scope recall helper validates its input contract and never
-   targets the peer-preference scope.
+1. Export drops any conclusion field carrying a local path or secret-like token.
+2. Runs with no substantive conclusion beyond classification are skipped.
+3. render/export reject an unsafe goal_id (path traversal) and never echo an
+   unsafe generated_at into the document.
+4. export retires the prior generation, so stale conclusions do not survive an
+   empty later history; and it never exposes the local path in the public
+   projection.
+5. The resources-scope recall helper validates its query/scope/limit contract
+   and sanitizes provider-produced summaries (drop-on-hit).
 """
 from __future__ import annotations
 
@@ -18,13 +23,23 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
+from loopx.extensions.openviking_semantic_preference import history_export  # noqa: E402
 from loopx.extensions.openviking_semantic_preference.history_export import (  # noqa: E402
     HISTORY_EXPORT_SCHEMA_VERSION,
     HISTORY_RECALL_SCHEMA_VERSION,
     conclusion_fields,
+    export_goal_conclusions,
     recall_history_conclusions,
     render_conclusion_markdown,
 )
+
+
+def _expect_value_error(fn, message: str) -> None:
+    try:
+        fn()
+    except ValueError:
+        return
+    raise AssertionError(message)
 
 
 def test_export_drops_local_paths_and_secrets() -> None:
@@ -39,52 +54,120 @@ def test_export_drops_local_paths_and_secrets() -> None:
             ]
         },
     }
-    labels = {label for label, _ in conclusion_fields(run)}
     texts = [text for _, text in conclusion_fields(run)]
-    # substantive safe fields survive
-    assert "recommended_action" in labels
     assert any("residual model" in t for t in texts)
-    # local path and secret rows are dropped, not exported
     assert not any("/Users/" in t for t in texts), "local path leaked"
     assert not any("ghp_" in t for t in texts), "secret token leaked"
 
 
 def test_noise_run_is_skipped() -> None:
-    noise = {"classification": "quota_slot_spent"}
-    assert render_conclusion_markdown("g", noise) is None
-    substantive = {
-        "classification": "did_something",
-        "recommended_action": "do the next bounded thing",
-    }
-    md = render_conclusion_markdown("g", substantive)
-    assert md is not None and "do the next bounded thing" in md
+    assert render_conclusion_markdown("goal-x", {"classification": "quota_slot_spent"}) is None
+    md = render_conclusion_markdown(
+        "goal-x", {"classification": "did_something", "recommended_action": "do the next thing"}
+    )
+    assert md is not None and "do the next thing" in md
+
+
+def test_render_rejects_unsafe_goal_id() -> None:
+    substantive = {"classification": "c", "recommended_action": "do it"}
+    for bad in ("../escaped", "a/b", "..", "."):
+        _expect_value_error(
+            lambda: render_conclusion_markdown(bad, substantive),
+            f"unsafe goal_id must raise: {bad!r}",
+        )
+
+
+def test_unsafe_generated_at_is_not_echoed() -> None:
+    md = render_conclusion_markdown(
+        "goal-x",
+        {
+            "classification": "c",
+            "recommended_action": "do it",
+            "generated_at": "/Users/attacker/`ls`",
+        },
+    )
+    assert md is not None
+    assert "/Users/" not in md, "unsafe generated_at leaked into document"
+    assert "generated_at: ``" in md, "unsafe timestamp should be dropped to empty"
+
+
+def test_export_rejects_unsafe_goal_id(tmp_path: Path) -> None:
+    _expect_value_error(
+        lambda: export_goal_conclusions(
+            goal_id="../escaped",
+            registry_path=tmp_path / "registry.json",
+            runtime_root=tmp_path,
+            out_dir=tmp_path / "out",
+        ),
+        "export must reject path-traversal goal_id before touching the filesystem",
+    )
+
+
+def test_export_retires_prior_generation_and_hides_local_path(tmp_path: Path, monkeypatch) -> None:
+    out = tmp_path / "out"
+    goal = "retire-me"
+    # seed a stale exported doc from a prior generation
+    (out / goal).mkdir(parents=True)
+    (out / goal / "stale.md").write_text("# stale conclusion", encoding="utf-8")
+
+    # later history is empty
+    monkeypatch.setattr(history_export, "collect_history", lambda **_: {"runs": []})
+    result = export_goal_conclusions(
+        goal_id=goal,
+        registry_path=tmp_path / "registry.json",
+        runtime_root=tmp_path,
+        out_dir=out,
+    )
+    # stale doc retired, nothing survives an empty history
+    assert not (out / goal / "stale.md").exists(), "stale conclusion survived empty history"
+    assert list((out / goal).glob("*.md")) == []
+    proj = result["public_projection"]
+    assert proj["retired_prior_generation"] == 1
+    assert proj["written"] == 0
+    # public projection must not expose a local filesystem path
+    assert "out_dir" not in proj
+    assert "/" not in "".join(str(v) for v in proj.values() if isinstance(v, str) and v != proj["target_scope_hint"])
+    # local path is only in the local receipt
+    assert result["local_receipt"]["out_dir"].endswith(f"out/{goal}")
 
 
 def test_recall_input_contract() -> None:
-    # empty query rejected
     for bad in ("", " "):
-        try:
-            recall_history_conclusions(query=bad, scope_uri="viking://user/x/resources/h")
-        except ValueError:
-            pass
-        else:  # pragma: no cover
-            raise AssertionError("empty query must raise")
-    # non-viking scope rejected (never targets peer memories by accident)
-    try:
-        recall_history_conclusions(query="q", scope_uri="/local/path")
-    except ValueError:
-        pass
-    else:  # pragma: no cover
-        raise AssertionError("non-viking scope must raise")
-    # out-of-range limit rejected
-    try:
-        recall_history_conclusions(
-            query="q", scope_uri="viking://user/x/resources/h", limit=99
+        _expect_value_error(
+            lambda: recall_history_conclusions(query=bad, scope_uri="viking://user/x/resources/h"),
+            "empty query must raise",
         )
-    except ValueError:
-        pass
-    else:  # pragma: no cover
-        raise AssertionError("out-of-range limit must raise")
+    _expect_value_error(
+        lambda: recall_history_conclusions(query="q", scope_uri="/local/path"),
+        "non-viking scope must raise",
+    )
+    _expect_value_error(
+        lambda: recall_history_conclusions(query="q", scope_uri="viking://user/x/resources/h", limit=99),
+        "out-of-range limit must raise",
+    )
+
+
+def test_recall_sanitizes_provider_summaries(monkeypatch) -> None:
+    scope = "viking://user/x/resources/h"
+
+    class _Completed:
+        returncode = 0
+        stdout = (
+            '{"result": {"resources": ['
+            f'{{"uri": "{scope}/a.md", "score": 0.9, "abstract": "safe conclusion about storage"}},'
+            f'{{"uri": "{scope}/b.md", "score": 0.8, "abstract": "leaked /Users/secret/report.md"}},'
+            '{"uri": "viking://user/x/peers/other/memories/z", "score": 0.7, "abstract": "out of scope"}'
+            "]}}"
+        )
+
+    monkeypatch.setattr(history_export.subprocess, "run", lambda *a, **k: _Completed())
+    out = recall_history_conclusions(query="storage", scope_uri=scope, ov_bin="ov")
+    summaries = [i["summary"] for i in out["items"]]
+    uris = [i["uri"] for i in out["items"]]
+    assert any("safe conclusion" in s for s in summaries)
+    assert not any("/Users/" in s for s in summaries), "unsafe provider summary leaked"
+    assert all(u.startswith(scope + "/") for u in uris), "out-of-scope uri returned"
+    assert out["dropped_unsafe"] >= 1
 
 
 def test_schema_versions_are_stable() -> None:
@@ -93,10 +176,44 @@ def test_schema_versions_are_stable() -> None:
 
 
 def main() -> int:
+    import tempfile
+
+    class _MonkeyPatch:
+        def __init__(self) -> None:
+            self._undo = []
+
+        def setattr(self, target, name, value=None):
+            if value is None:  # setattr(obj_attr_path, value) form unused here
+                raise NotImplementedError
+            old = getattr(target, name)
+            self._undo.append((target, name, old))
+            setattr(target, name, value)
+
+        def undo(self):
+            for target, name, old in reversed(self._undo):
+                setattr(target, name, old)
+
     test_export_drops_local_paths_and_secrets()
     test_noise_run_is_skipped()
+    test_render_rejects_unsafe_goal_id()
+    test_unsafe_generated_at_is_not_echoed()
     test_recall_input_contract()
     test_schema_versions_are_stable()
+
+    with tempfile.TemporaryDirectory() as d:
+        test_export_rejects_unsafe_goal_id(Path(d))
+    with tempfile.TemporaryDirectory() as d:
+        mp = _MonkeyPatch()
+        try:
+            test_export_retires_prior_generation_and_hides_local_path(Path(d), mp)
+        finally:
+            mp.undo()
+    mp = _MonkeyPatch()
+    try:
+        test_recall_sanitizes_provider_summaries(mp)
+    finally:
+        mp.undo()
+
     print("ok: loopx-history-conclusion-recall smoke passed")
     return 0
 

--- a/examples/loopx-history-conclusion-recall-smoke.py
+++ b/examples/loopx-history-conclusion-recall-smoke.py
@@ -518,6 +518,81 @@ def _case_export_recovers_backup_only_interrupted_publication(
     assert result["public_projection"]["retired_prior_generation"] == 1
 
 
+def _case_export_cleans_backup_when_live_is_valid(
+    tmp_path: Path, monkeypatch
+) -> None:
+    goal = "recover-live-backup"
+    result = _export_runs(
+        tmp_path,
+        monkeypatch,
+        goal_id=goal,
+        runs=[
+            {
+                "classification": "prior",
+                "generated_at": "2026-08-04T01:02:03Z",
+                "recommended_action": "published prior conclusion",
+            }
+        ],
+    )
+    corpus_out = Path(result["local_receipt"]["out_dir"])
+    backup = corpus_out.parent / f".{corpus_out.name}.loopx-backup"
+    history_export.shutil.copytree(corpus_out, str(backup))
+
+    result2 = _export_runs(
+        tmp_path,
+        monkeypatch,
+        goal_id=goal,
+        runs=[
+            {
+                "classification": "replacement",
+                "generated_at": "2026-08-04T04:05:06Z",
+                "recommended_action": "publish after live+backup recovery",
+            }
+        ],
+    )
+    assert Path(result2["local_receipt"]["manifest_path"]).is_file()
+    assert not backup.exists()
+
+
+def _case_export_fails_closed_when_neither_live_nor_backup_is_valid(
+    tmp_path: Path, monkeypatch
+) -> None:
+    goal = "recover-neither-valid"
+    result = _export_runs(
+        tmp_path,
+        monkeypatch,
+        goal_id=goal,
+        runs=[
+            {
+                "classification": "prior",
+                "generated_at": "2026-08-04T01:02:03Z",
+                "recommended_action": "published prior conclusion",
+            }
+        ],
+    )
+    corpus_out = Path(result["local_receipt"]["out_dir"])
+    backup = corpus_out.parent / f".{corpus_out.name}.loopx-backup"
+    manifest = corpus_out / ".loopx-history-conclusion-export.json"
+    manifest.unlink()
+    backup.mkdir()
+    try:
+        _export_runs(
+            tmp_path,
+            monkeypatch,
+            goal_id=goal,
+            runs=[
+                {
+                    "classification": "replacement",
+                    "generated_at": "2026-08-04T04:05:06Z",
+                    "recommended_action": "fails closed",
+                }
+            ],
+        )
+        raise AssertionError("should have raised")
+    except RuntimeError as exc:
+        assert "neither could be verified" in str(exc)
+
+
 def _case_active_provider_rejects_exit_zero_unsuccessful_openviking_envelope(
     monkeypatch,
 ) -> None:

--- a/examples/loopx-history-conclusion-recall-smoke.py
+++ b/examples/loopx-history-conclusion-recall-smoke.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Focused smoke for LoopX history-conclusion export + resources-scope recall.
+
+Public-safe and offline: it does not require a live OpenViking backend, network,
+credentials, or raw transcripts. It pins the durable behaviors:
+
+1. Export drops any conclusion field carrying a local path or secret-like token
+   (public/private boundary enforcement via public_safe_compact_text).
+2. Runs with no substantive conclusion beyond classification are skipped as noise.
+3. The resources-scope recall helper validates its input contract and never
+   targets the peer-preference scope.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from loopx.extensions.openviking_semantic_preference.history_export import (  # noqa: E402
+    HISTORY_EXPORT_SCHEMA_VERSION,
+    HISTORY_RECALL_SCHEMA_VERSION,
+    conclusion_fields,
+    recall_history_conclusions,
+    render_conclusion_markdown,
+)
+
+
+def test_export_drops_local_paths_and_secrets() -> None:
+    run = {
+        "classification": "example_conclusion",
+        "recommended_action": "freeze the cross-market alert contract before evidence",
+        "state": {
+            "progress": [
+                "Wrote artifact under /Users/someone/private/secret-report.md",
+                "token=ghp_abcdefghijklmnopqrstuvwxyz0123456789 committed by mistake",
+                "Validated the residual model on untouched folds",
+            ]
+        },
+    }
+    labels = {label for label, _ in conclusion_fields(run)}
+    texts = [text for _, text in conclusion_fields(run)]
+    # substantive safe fields survive
+    assert "recommended_action" in labels
+    assert any("residual model" in t for t in texts)
+    # local path and secret rows are dropped, not exported
+    assert not any("/Users/" in t for t in texts), "local path leaked"
+    assert not any("ghp_" in t for t in texts), "secret token leaked"
+
+
+def test_noise_run_is_skipped() -> None:
+    noise = {"classification": "quota_slot_spent"}
+    assert render_conclusion_markdown("g", noise) is None
+    substantive = {
+        "classification": "did_something",
+        "recommended_action": "do the next bounded thing",
+    }
+    md = render_conclusion_markdown("g", substantive)
+    assert md is not None and "do the next bounded thing" in md
+
+
+def test_recall_input_contract() -> None:
+    # empty query rejected
+    for bad in ("", " "):
+        try:
+            recall_history_conclusions(query=bad, scope_uri="viking://user/x/resources/h")
+        except ValueError:
+            pass
+        else:  # pragma: no cover
+            raise AssertionError("empty query must raise")
+    # non-viking scope rejected (never targets peer memories by accident)
+    try:
+        recall_history_conclusions(query="q", scope_uri="/local/path")
+    except ValueError:
+        pass
+    else:  # pragma: no cover
+        raise AssertionError("non-viking scope must raise")
+    # out-of-range limit rejected
+    try:
+        recall_history_conclusions(
+            query="q", scope_uri="viking://user/x/resources/h", limit=99
+        )
+    except ValueError:
+        pass
+    else:  # pragma: no cover
+        raise AssertionError("out-of-range limit must raise")
+
+
+def test_schema_versions_are_stable() -> None:
+    assert HISTORY_EXPORT_SCHEMA_VERSION == "loopx_history_conclusion_export_v0"
+    assert HISTORY_RECALL_SCHEMA_VERSION == "loopx_history_conclusion_recall_v0"
+
+
+def main() -> int:
+    test_export_drops_local_paths_and_secrets()
+    test_noise_run_is_skipped()
+    test_recall_input_contract()
+    test_schema_versions_are_stable()
+    print("ok: loopx-history-conclusion-recall smoke passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/loopx-history-conclusion-recall-smoke.py
+++ b/examples/loopx-history-conclusion-recall-smoke.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Focused smoke for LoopX history-conclusion export + resources-scope recall.
+"""Focused smoke for the atomic LoopX history-conclusion exporter.
 
 Public-safe and offline: it does not require a live OpenViking backend, network,
 credentials, or raw transcripts. It pins the durable end-to-end boundary
@@ -12,25 +12,31 @@ behaviors, including negative cases for the review findings:
 4. Export replaces only its manifest-owned prior generation, preserves foreign
    files, publishes unique documents, and leaves the prior corpus intact if
    staging fails.
-5. The resources-scope recall helper validates its query/scope/limit contract
-   and sanitizes provider-produced summaries and URIs (drop-on-hit).
+5. The extension-owned console entrypoint reaches the exporter without adding
+   a speculative OpenViking ingest or recall lifecycle.
 """
+
 from __future__ import annotations
 
+import contextlib
+import inspect
+import io
 import json
 import sys
+import tempfile
+import traceback
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from loopx.extensions.openviking_semantic_preference import history_export  # noqa: E402
+from loopx.extensions.openviking_semantic_preference import provider  # noqa: E402
 from loopx.extensions.openviking_semantic_preference.history_export import (  # noqa: E402
     HISTORY_EXPORT_SCHEMA_VERSION,
-    HISTORY_RECALL_SCHEMA_VERSION,
     conclusion_fields,
     export_goal_conclusions,
-    recall_history_conclusions,
+    main as export_main,
     render_conclusion_markdown,
 )
 
@@ -80,7 +86,7 @@ def _assert_corpus_unchanged(
     assert sorted(path.name for path in goal_out.glob("*.md")) == sorted(documents)
 
 
-def test_export_drops_local_paths_and_secrets() -> None:
+def _case_export_drops_local_paths_and_secrets() -> None:
     # Build the secret at runtime so this source file contains no literal
     # credential for the repo boundary scanner, while the sanitizer still sees a
     # real secret-shaped value at test time.
@@ -102,15 +108,19 @@ def test_export_drops_local_paths_and_secrets() -> None:
     assert not any("ghp_" in t for t in texts), "secret token leaked"
 
 
-def test_noise_run_is_skipped() -> None:
-    assert render_conclusion_markdown("goal-x", {"classification": "quota_slot_spent"}) is None
+def _case_noise_run_is_skipped() -> None:
+    assert (
+        render_conclusion_markdown("goal-x", {"classification": "quota_slot_spent"})
+        is None
+    )
     md = render_conclusion_markdown(
-        "goal-x", {"classification": "did_something", "recommended_action": "do the next thing"}
+        "goal-x",
+        {"classification": "did_something", "recommended_action": "do the next thing"},
     )
     assert md is not None and "do the next thing" in md
 
 
-def test_render_rejects_unsafe_goal_id() -> None:
+def _case_render_rejects_unsafe_goal_id() -> None:
     substantive = {"classification": "c", "recommended_action": "do it"}
     for bad in ("../escaped", "a/b", "..", "."):
         _expect_value_error(
@@ -119,7 +129,31 @@ def test_render_rejects_unsafe_goal_id() -> None:
         )
 
 
-def test_unsafe_generated_at_is_not_echoed() -> None:
+def _case_render_rejects_non_public_goal_id_surfaces() -> None:
+    substantive = {"classification": "c", "recommended_action": "do it"}
+    fake_secret = "ak_" + "a" * 16
+    fake_github_token = "ghp_" + "a" * 36
+    fake_aws_key = "AK" + "IA" + "A" * 16
+    fake_slack_token = "xox" + "b-" + "a" * 24
+    for bad in (
+        " leading-space",
+        "line\nbreak",
+        "control\x1fbyte",
+        "markdown`break",
+        "markdown|row",
+        "markdown[link]",
+        fake_secret,
+        fake_github_token,
+        fake_aws_key,
+        fake_slack_token,
+    ):
+        _expect_value_error(
+            lambda bad=bad: render_conclusion_markdown(bad, substantive),
+            f"non-public goal_id must raise before rendering: {bad!r}",
+        )
+
+
+def _case_unsafe_generated_at_is_not_echoed() -> None:
     md = render_conclusion_markdown(
         "goal-x",
         {
@@ -133,7 +167,7 @@ def test_unsafe_generated_at_is_not_echoed() -> None:
     assert "generated_at: ``" in md, "unsafe timestamp should be dropped to empty"
 
 
-def test_export_rejects_unsafe_goal_id(tmp_path: Path) -> None:
+def _case_export_rejects_unsafe_goal_id(tmp_path: Path) -> None:
     _expect_value_error(
         lambda: export_goal_conclusions(
             goal_id="../escaped",
@@ -145,7 +179,32 @@ def test_export_rejects_unsafe_goal_id(tmp_path: Path) -> None:
     )
 
 
-def test_export_preserves_foreign_files_when_retiring_owned_generation(
+def _case_export_rejects_non_public_goal_id_before_history_read(
+    tmp_path: Path, monkeypatch
+) -> None:
+    history_reads = 0
+
+    def _must_not_read_history(**kwargs):
+        del kwargs
+        nonlocal history_reads
+        history_reads += 1
+        raise AssertionError("unsafe goal_id reached history collection")
+
+    monkeypatch.setattr(history_export, "collect_history", _must_not_read_history)
+    _expect_value_error(
+        lambda: export_goal_conclusions(
+            goal_id="goal\n# injected",
+            registry_path=tmp_path / "registry.json",
+            runtime_root=tmp_path,
+            out_dir=tmp_path / "out",
+        ),
+        "non-public goal_id must raise before history collection",
+    )
+    assert history_reads == 0
+    assert not (tmp_path / "out").exists()
+
+
+def _case_export_preserves_foreign_files_when_retiring_owned_generation(
     tmp_path: Path, monkeypatch
 ) -> None:
     out = tmp_path / "out"
@@ -176,14 +235,100 @@ def test_export_preserves_foreign_files_when_retiring_owned_generation(
     assert proj["written"] == 0
     # public projection must not expose a local filesystem path
     assert "out_dir" not in proj
-    assert "/" not in "".join(str(v) for v in proj.values() if isinstance(v, str) and v != proj["target_scope_hint"])
+    assert "/" not in "".join(
+        str(v)
+        for v in proj.values()
+        if isinstance(v, str) and v != proj["target_scope_hint"]
+    )
     # local path is only in the local receipt
     assert result["local_receipt"]["out_dir"].endswith(
         f"out/{goal}/history-conclusions"
     )
 
 
-def test_export_uses_unique_names_and_reports_exact_document_count(
+def _case_export_refuses_foreign_file_inside_managed_corpus(
+    tmp_path: Path, monkeypatch
+) -> None:
+    first = _export_runs(
+        tmp_path,
+        monkeypatch,
+        goal_id="foreign-inside",
+        runs=[
+            {
+                "classification": "prior",
+                "recommended_action": "preserve the published conclusion",
+            }
+        ],
+    )
+    corpus_out, manifest_path, prior_manifest, prior_documents = _corpus_snapshot(first)
+    foreign = corpus_out / "foreign.md"
+    foreign.write_text("# maintained by another publisher", encoding="utf-8")
+
+    try:
+        _export_runs(
+            tmp_path,
+            monkeypatch,
+            goal_id="foreign-inside",
+            runs=[
+                {
+                    "classification": "replacement",
+                    "recommended_action": "must not delete foreign content",
+                }
+            ],
+        )
+    except RuntimeError as exc:
+        assert "unowned" in str(exc)
+    else:
+        raise AssertionError("unowned corpus file must block directory replacement")
+
+    assert foreign.read_text(encoding="utf-8").startswith("# maintained")
+    assert manifest_path.read_bytes() == prior_manifest
+    assert {
+        name: (corpus_out / name).read_bytes() for name in prior_documents
+    } == prior_documents
+
+
+def _case_export_refuses_modified_manifest_owned_document(
+    tmp_path: Path, monkeypatch
+) -> None:
+    first = _export_runs(
+        tmp_path,
+        monkeypatch,
+        goal_id="modified-owned",
+        runs=[
+            {
+                "classification": "prior",
+                "recommended_action": "preserve the published conclusion",
+            }
+        ],
+    )
+    corpus_out, manifest_path, prior_manifest, prior_documents = _corpus_snapshot(first)
+    owned_name = next(iter(prior_documents))
+    modified = b"# modified outside the exporter\n"
+    (corpus_out / owned_name).write_bytes(modified)
+
+    try:
+        _export_runs(
+            tmp_path,
+            monkeypatch,
+            goal_id="modified-owned",
+            runs=[
+                {
+                    "classification": "replacement",
+                    "recommended_action": "must not overwrite modified content",
+                }
+            ],
+        )
+    except RuntimeError as exc:
+        assert "digest" in str(exc)
+    else:
+        raise AssertionError("modified manifest-owned file must block replacement")
+
+    assert manifest_path.read_bytes() == prior_manifest
+    assert (corpus_out / owned_name).read_bytes() == modified
+
+
+def _case_export_uses_unique_names_and_reports_exact_document_count(
     tmp_path: Path, monkeypatch
 ) -> None:
     runs = [
@@ -208,7 +353,7 @@ def test_export_uses_unique_names_and_reports_exact_document_count(
     )
 
 
-def test_export_write_failure_preserves_prior_owned_corpus(
+def _case_export_write_failure_preserves_prior_owned_corpus(
     tmp_path: Path, monkeypatch
 ) -> None:
     out = tmp_path / "out"
@@ -236,7 +381,9 @@ def test_export_write_failure_preserves_prior_owned_corpus(
         }
         for index in range(2)
     ]
-    monkeypatch.setattr(history_export, "collect_history", lambda **_: {"runs": new_runs})
+    monkeypatch.setattr(
+        history_export, "collect_history", lambda **_: {"runs": new_runs}
+    )
     original_write_text = Path.write_text
     staged_document_writes = 0
 
@@ -261,12 +408,10 @@ def test_export_write_failure_preserves_prior_owned_corpus(
     else:
         raise AssertionError("staged write failure must propagate")
 
-    _assert_corpus_unchanged(
-        goal_out, manifest_path, prior_manifest, prior_documents
-    )
+    _assert_corpus_unchanged(goal_out, manifest_path, prior_manifest, prior_documents)
 
 
-def test_export_publish_failure_rolls_back_prior_owned_corpus(
+def _case_export_publish_failure_rolls_back_prior_owned_corpus(
     tmp_path: Path, monkeypatch
 ) -> None:
     out = tmp_path / "out"
@@ -326,202 +471,207 @@ def test_export_publish_failure_rolls_back_prior_owned_corpus(
         raise AssertionError("publication failure must propagate after rollback")
 
     assert failed
-    _assert_corpus_unchanged(
-        goal_out, manifest_path, prior_manifest, prior_documents
+    _assert_corpus_unchanged(goal_out, manifest_path, prior_manifest, prior_documents)
+
+
+def _case_export_recovers_backup_only_interrupted_publication(
+    tmp_path: Path, monkeypatch
+) -> None:
+    goal = "recover-backup"
+    first = _export_runs(
+        tmp_path,
+        monkeypatch,
+        goal_id=goal,
+        runs=[
+            {
+                "classification": "prior",
+                "generated_at": "2026-08-04T01:02:03Z",
+                "recommended_action": "published prior conclusion",
+            }
+        ],
+    )
+    corpus_out = Path(first["local_receipt"]["out_dir"])
+    goal_root = corpus_out.parent
+    foreign = goal_root / "foreign.md"
+    foreign.write_text("# maintained by another publisher", encoding="utf-8")
+    backup = corpus_out.parent / f".{corpus_out.name}.loopx-backup"
+    history_export.os.replace(corpus_out, backup)
+    assert backup.is_dir()
+    assert not corpus_out.exists()
+
+    result = _export_runs(
+        tmp_path,
+        monkeypatch,
+        goal_id=goal,
+        runs=[
+            {
+                "classification": "replacement",
+                "generated_at": "2026-08-04T04:05:06Z",
+                "recommended_action": "publish after backup recovery",
+            }
+        ],
     )
 
-
-def test_recall_input_contract() -> None:
-    for bad in ("", " "):
-        _expect_value_error(
-            lambda: recall_history_conclusions(query=bad, scope_uri="viking://user/x/resources/h"),
-            "empty query must raise",
-        )
-    fake_secret = "token" + "=" + "ghp_" + "a" * 36
-    for bad in ("/Users/private/query.txt", fake_secret):
-        _expect_value_error(
-            lambda bad=bad: recall_history_conclusions(
-                query=bad, scope_uri="viking://user/x/resources/h"
-            ),
-            "unsafe query must raise before invoking ov",
-        )
-    _expect_value_error(
-        lambda: recall_history_conclusions(query="q", scope_uri="/local/path"),
-        "non-viking scope must raise",
-    )
-    _expect_value_error(
-        lambda: recall_history_conclusions(query="q", scope_uri="viking://user/x/resources/h", limit=99),
-        "out-of-range limit must raise",
-    )
+    assert Path(result["local_receipt"]["manifest_path"]).is_file()
+    assert foreign.read_text(encoding="utf-8").startswith("# maintained")
+    assert not backup.exists()
+    assert result["public_projection"]["retired_prior_generation"] == 1
 
 
-def test_recall_rejects_unsafe_scope_and_drops_unsafe_returned_uris(
+def _case_active_provider_rejects_exit_zero_unsuccessful_openviking_envelope(
     monkeypatch,
 ) -> None:
-    fake_secret = "token" + "=" + "ghp_" + "a" * 36
-    unsafe_scopes = (
-        "viking://user/x/resources/h//Users/private/report",
-        "viking://user/x/resources/h/%252FUsers/private/report",
-        "viking://user/x/resources/h/%00injected",
-        "viking://user/x/resources/h\ninjected",
-        f"viking://user/x/resources/h/{fake_secret}",
-    )
-    calls = 0
-
-    def _must_not_run(*args, **kwargs):
-        nonlocal calls
-        calls += 1
-        raise AssertionError("unsafe scope must be rejected before invoking ov")
-
-    monkeypatch.setattr(history_export.subprocess, "run", _must_not_run)
-    for scope in unsafe_scopes:
-        _expect_value_error(
-            lambda scope=scope: recall_history_conclusions(
-                query="storage", scope_uri=scope, ov_bin="ov"
-            ),
-            f"unsafe scope must raise: {scope!r}",
-        )
-    assert calls == 0
-
-    scope = "viking://user/x/resources/h"
-
     class _Completed:
         returncode = 0
         stdout = json.dumps(
             {
-                "result": {
-                    "resources": [
-                        {
-                            "uri": f"{scope}/safe.md",
-                            "score": 0.9,
-                            "abstract": "safe conclusion",
-                        },
-                        {
-                            "uri": f"{scope}/unsafe-score.md",
-                            "score": fake_secret,
-                            "abstract": "unsafe score",
-                        },
-                        {
-                            "uri": f"{scope}//Users/private/report.md",
-                            "score": 0.8,
-                            "abstract": "unsafe path uri",
-                        },
-                        {
-                            "uri": f"{scope}/%252FUsers/private/report.md",
-                            "score": 0.75,
-                            "abstract": "encoded unsafe path uri",
-                        },
-                        {
-                            "uri": f"{scope}/line\nbreak.md",
-                            "score": 0.7,
-                            "abstract": "unsafe control uri",
-                        },
-                        {
-                            "uri": f"{scope}/%00control.md",
-                            "score": 0.65,
-                            "abstract": "encoded unsafe control uri",
-                        },
-                        {
-                            "uri": f"{scope}/{fake_secret}",
-                            "score": 0.6,
-                            "abstract": "unsafe secret uri",
-                        },
-                    ]
-                }
+                "ok": False,
+                "error": {"code": "index_unavailable"},
+                "result": {"resources": []},
             }
         )
 
-    monkeypatch.setattr(history_export.subprocess, "run", lambda *a, **k: _Completed())
-    result = recall_history_conclusions(
-        query="storage", scope_uri=scope, ov_bin="ov"
-    )
-    assert [item["uri"] for item in result["items"]] == [f"{scope}/safe.md"]
-    assert result["dropped_unsafe"] >= 5
-    serialized = json.dumps(result)
-    assert "/Users/" not in serialized
-    assert fake_secret not in serialized
-    assert "line\\nbreak" not in serialized
-
-
-def test_recall_sanitizes_provider_summaries(monkeypatch) -> None:
-    scope = "viking://user/x/resources/h"
-
-    class _Completed:
-        returncode = 0
-        stdout = (
-            '{"result": {"resources": ['
-            f'{{"uri": "{scope}/a.md", "score": 0.9, "abstract": "safe conclusion about storage"}},'
-            f'{{"uri": "{scope}/b.md", "score": 0.8, "abstract": "leaked /Users/secret/report.md"}},'
-            '{"uri": "viking://user/x/peers/other/memories/z", "score": 0.7, "abstract": "out of scope"}'
-            "]}}"
+    monkeypatch.setattr(provider.subprocess, "run", lambda *a, **k: _Completed())
+    try:
+        provider._run_ov(
+            "ov",
+            ["find", "-o", "json", "storage"],
+            cli_config=None,
+            timeout_seconds=25,
         )
-
-    monkeypatch.setattr(history_export.subprocess, "run", lambda *a, **k: _Completed())
-    out = recall_history_conclusions(query="storage", scope_uri=scope, ov_bin="ov")
-    summaries = [i["summary"] for i in out["items"]]
-    uris = [i["uri"] for i in out["items"]]
-    assert any("safe conclusion" in s for s in summaries)
-    assert not any("/Users/" in s for s in summaries), "unsafe provider summary leaked"
-    assert all(u.startswith(scope + "/") for u in uris), "out-of-scope uri returned"
-    assert out["dropped_unsafe"] >= 1
+    except RuntimeError as exc:
+        assert "unsuccessful response" in str(exc)
+    else:
+        raise AssertionError("OpenViking ok=false envelope must fail")
 
 
-def test_schema_versions_are_stable() -> None:
+def _case_extension_owned_entrypoint_reaches_atomic_export(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        history_export,
+        "collect_history",
+        lambda **kwargs: {
+            "runs": [
+                {
+                    "classification": "reachable",
+                    "recommended_action": f"export {kwargs['goal_id']}",
+                }
+            ]
+        },
+    )
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        assert (
+            export_main(
+                [
+                    "--goal-id",
+                    "reachable-goal",
+                    "--registry-path",
+                    str(tmp_path / "registry.json"),
+                    "--runtime-root",
+                    str(tmp_path),
+                    "--out-dir",
+                    str(tmp_path / "out"),
+                ]
+            )
+            == 0
+        )
+    exported = json.loads(output.getvalue())
+    assert exported["public_projection"]["written"] == 1
+    assert not hasattr(history_export, "recall_history_conclusions")
+    assert not hasattr(history_export, "refresh_exported_conclusions")
+
+
+def _case_schema_versions_are_stable() -> None:
     assert HISTORY_EXPORT_SCHEMA_VERSION == "loopx_history_conclusion_export_v0"
-    assert HISTORY_RECALL_SCHEMA_VERSION == "loopx_history_conclusion_recall_v0"
+
+
+class _MonkeyPatch:
+    _MISSING = object()
+
+    def __init__(self) -> None:
+        self._undo: list[tuple[object, str, object]] = []
+
+    def setattr(
+        self,
+        target: object,
+        name: str,
+        value: object,
+        *,
+        raising: bool = True,
+    ) -> None:
+        old = getattr(target, name, self._MISSING)
+        if old is self._MISSING and raising:
+            raise AttributeError(name)
+        self._undo.append((target, name, old))
+        setattr(target, name, value)
+
+    def undo(self) -> None:
+        for target, name, old in reversed(self._undo):
+            if old is self._MISSING:
+                delattr(target, name)
+            else:
+                setattr(target, name, old)
+
+
+def _discover_cases() -> list[tuple[str, object]]:
+    unexpected_pytest_cases = sorted(
+        name
+        for name, value in globals().items()
+        if name.startswith("test_")
+        and name != "test_history_conclusion_export_contract"
+        and inspect.isfunction(value)
+    )
+    if unexpected_pytest_cases:
+        raise AssertionError(
+            "history export contract cases must use the shared _case_ prefix: "
+            f"{unexpected_pytest_cases}"
+        )
+    cases = [
+        (name, value)
+        for name, value in globals().items()
+        if name.startswith("_case_") and inspect.isfunction(value)
+    ]
+    return sorted(cases, key=lambda item: item[1].__code__.co_firstlineno)
+
+
+def _run_cases() -> list[tuple[str, str]]:
+    failures: list[tuple[str, str]] = []
+    for name, case in _discover_cases():
+        monkeypatch = _MonkeyPatch()
+        with tempfile.TemporaryDirectory(prefix="loopx-history-export-smoke-") as tmp:
+            available = {
+                "tmp_path": Path(tmp),
+                "monkeypatch": monkeypatch,
+            }
+            parameters = inspect.signature(case).parameters
+            unknown = sorted(set(parameters) - set(available))
+            if unknown:
+                failures.append(
+                    (name, f"unsupported smoke fixtures: {', '.join(unknown)}")
+                )
+                continue
+            try:
+                case(**{key: available[key] for key in parameters})
+            except Exception:
+                failures.append((name, traceback.format_exc()))
+            finally:
+                monkeypatch.undo()
+    return failures
+
+
+def test_history_conclusion_export_contract() -> None:
+    assert not _run_cases()
 
 
 def main() -> int:
-    import tempfile
-
-    class _MonkeyPatch:
-        def __init__(self) -> None:
-            self._undo = []
-
-        def setattr(self, target, name, value=None):
-            if value is None:  # setattr(obj_attr_path, value) form unused here
-                raise NotImplementedError
-            old = getattr(target, name)
-            self._undo.append((target, name, old))
-            setattr(target, name, value)
-
-        def undo(self):
-            for target, name, old in reversed(self._undo):
-                setattr(target, name, old)
-
-    test_export_drops_local_paths_and_secrets()
-    test_noise_run_is_skipped()
-    test_render_rejects_unsafe_goal_id()
-    test_unsafe_generated_at_is_not_echoed()
-    test_recall_input_contract()
-    test_schema_versions_are_stable()
-
-    with tempfile.TemporaryDirectory() as directory:
-        test_export_rejects_unsafe_goal_id(Path(directory))
-    for test in (
-        test_export_preserves_foreign_files_when_retiring_owned_generation,
-        test_export_uses_unique_names_and_reports_exact_document_count,
-        test_export_write_failure_preserves_prior_owned_corpus,
-        test_export_publish_failure_rolls_back_prior_owned_corpus,
-    ):
-        directory = tempfile.TemporaryDirectory()
-        mp = _MonkeyPatch()
-        try:
-            test(Path(directory.name), mp)
-        finally:
-            mp.undo()
-            directory.cleanup()
-    for test in (
-        test_recall_rejects_unsafe_scope_and_drops_unsafe_returned_uris,
-        test_recall_sanitizes_provider_summaries,
-    ):
-        mp = _MonkeyPatch()
-        try:
-            test(mp)
-        finally:
-            mp.undo()
-
-    print("ok: loopx-history-conclusion-recall smoke passed")
+    failures = _run_cases()
+    if failures:
+        for name, failure in failures:
+            print(f"FAIL: {name}\n{failure}", file=sys.stderr)
+        return 1
+    print(f"ok: {len(_discover_cases())} history-conclusion export cases passed")
     return 0
 
 

--- a/examples/loopx-history-conclusion-recall-smoke.py
+++ b/examples/loopx-history-conclusion-recall-smoke.py
@@ -9,14 +9,15 @@ behaviors, including negative cases for the review findings:
 2. Runs with no substantive conclusion beyond classification are skipped.
 3. render/export reject an unsafe goal_id (path traversal) and never echo an
    unsafe generated_at into the document.
-4. export retires the prior generation, so stale conclusions do not survive an
-   empty later history; and it never exposes the local path in the public
-   projection.
+4. Export replaces only its manifest-owned prior generation, preserves foreign
+   files, publishes unique documents, and leaves the prior corpus intact if
+   staging fails.
 5. The resources-scope recall helper validates its query/scope/limit contract
-   and sanitizes provider-produced summaries (drop-on-hit).
+   and sanitizes provider-produced summaries and URIs (drop-on-hit).
 """
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -40,6 +41,43 @@ def _expect_value_error(fn, message: str) -> None:
     except ValueError:
         return
     raise AssertionError(message)
+
+
+def _export_runs(
+    tmp_path: Path,
+    monkeypatch,
+    *,
+    goal_id: str,
+    runs: list[dict],
+) -> dict:
+    monkeypatch.setattr(history_export, "collect_history", lambda **_: {"runs": runs})
+    return export_goal_conclusions(
+        goal_id=goal_id,
+        registry_path=tmp_path / "registry.json",
+        runtime_root=tmp_path,
+        out_dir=tmp_path / "out",
+    )
+
+
+def _corpus_snapshot(result: dict) -> tuple[Path, Path, bytes, dict[str, bytes]]:
+    receipt = result["local_receipt"]
+    goal_out = Path(receipt["out_dir"])
+    manifest_path = Path(receipt["manifest_path"])
+    documents = {
+        name: (goal_out / name).read_bytes() for name in receipt["owned_files"]
+    }
+    return goal_out, manifest_path, manifest_path.read_bytes(), documents
+
+
+def _assert_corpus_unchanged(
+    goal_out: Path,
+    manifest_path: Path,
+    manifest: bytes,
+    documents: dict[str, bytes],
+) -> None:
+    assert manifest_path.read_bytes() == manifest
+    assert {name: (goal_out / name).read_bytes() for name in documents} == documents
+    assert sorted(path.name for path in goal_out.glob("*.md")) == sorted(documents)
 
 
 def test_export_drops_local_paths_and_secrets() -> None:
@@ -107,32 +145,190 @@ def test_export_rejects_unsafe_goal_id(tmp_path: Path) -> None:
     )
 
 
-def test_export_retires_prior_generation_and_hides_local_path(tmp_path: Path, monkeypatch) -> None:
+def test_export_preserves_foreign_files_when_retiring_owned_generation(
+    tmp_path: Path, monkeypatch
+) -> None:
     out = tmp_path / "out"
     goal = "retire-me"
-    # seed a stale exported doc from a prior generation
-    (out / goal).mkdir(parents=True)
-    (out / goal / "stale.md").write_text("# stale conclusion", encoding="utf-8")
+    runs = [
+        {
+            "classification": "prior",
+            "generated_at": "2026-08-04T01:02:03Z",
+            "recommended_action": "retain only until the next generation",
+        }
+    ]
+    first = _export_runs(tmp_path, monkeypatch, goal_id=goal, runs=runs)
+    goal_out = out / goal
+    owned_files = set(first["local_receipt"]["owned_files"])
+    assert len(owned_files) == 1
+    foreign = goal_out / "foreign.md"
+    foreign.write_text("# maintained by another publisher", encoding="utf-8")
 
     # later history is empty
-    monkeypatch.setattr(history_export, "collect_history", lambda **_: {"runs": []})
-    result = export_goal_conclusions(
-        goal_id=goal,
-        registry_path=tmp_path / "registry.json",
-        runtime_root=tmp_path,
-        out_dir=out,
-    )
-    # stale doc retired, nothing survives an empty history
-    assert not (out / goal / "stale.md").exists(), "stale conclusion survived empty history"
-    assert list((out / goal).glob("*.md")) == []
+    result = _export_runs(tmp_path, monkeypatch, goal_id=goal, runs=[])
+    assert foreign.exists(), "exporter deleted a foreign markdown file"
+    corpus_out = Path(result["local_receipt"]["out_dir"])
+    assert all(not (corpus_out / name).exists() for name in owned_files)
+    assert list(goal_out.glob("*.md")) == [foreign]
+    assert list(corpus_out.glob("*.md")) == []
     proj = result["public_projection"]
-    assert proj["retired_prior_generation"] == 1
+    assert proj["retired_prior_generation"] == len(owned_files)
     assert proj["written"] == 0
     # public projection must not expose a local filesystem path
     assert "out_dir" not in proj
     assert "/" not in "".join(str(v) for v in proj.values() if isinstance(v, str) and v != proj["target_scope_hint"])
     # local path is only in the local receipt
-    assert result["local_receipt"]["out_dir"].endswith(f"out/{goal}")
+    assert result["local_receipt"]["out_dir"].endswith(
+        f"out/{goal}/history-conclusions"
+    )
+
+
+def test_export_uses_unique_names_and_reports_exact_document_count(
+    tmp_path: Path, monkeypatch
+) -> None:
+    runs = [
+        {
+            "classification": "same",
+            "generated_at": "2026-08-04T01:02:03Z",
+            "recommended_action": "first conclusion",
+        },
+        {
+            "classification": "same",
+            "generated_at": "2026-08-04T01:02:03Z",
+            "recommended_action": "second conclusion",
+        },
+    ]
+    result = _export_runs(tmp_path, monkeypatch, goal_id="collision", runs=runs)
+    documents = list(Path(result["local_receipt"]["out_dir"]).glob("*.md"))
+    assert len(documents) == 2, "same timestamp/classification overwrote a document"
+    assert len({path.name for path in documents}) == 2
+    assert result["public_projection"]["written"] == len(documents)
+    assert sorted(result["local_receipt"]["owned_files"]) == sorted(
+        path.name for path in documents
+    )
+
+
+def test_export_write_failure_preserves_prior_owned_corpus(
+    tmp_path: Path, monkeypatch
+) -> None:
+    out = tmp_path / "out"
+    goal = "atomic"
+    prior_runs = [
+        {
+            "classification": "prior",
+            "generated_at": "2026-08-04T01:02:03Z",
+            "recommended_action": "published prior conclusion",
+        }
+    ]
+    first = _export_runs(
+        tmp_path,
+        monkeypatch,
+        goal_id=goal,
+        runs=prior_runs,
+    )
+    goal_out, manifest_path, prior_manifest, prior_documents = _corpus_snapshot(first)
+
+    new_runs = [
+        {
+            "classification": "new",
+            "generated_at": "2026-08-04T04:05:06Z",
+            "recommended_action": f"new conclusion {index}",
+        }
+        for index in range(2)
+    ]
+    monkeypatch.setattr(history_export, "collect_history", lambda **_: {"runs": new_runs})
+    original_write_text = Path.write_text
+    staged_document_writes = 0
+
+    def _fail_second_staged_document(path: Path, data: str, **kwargs) -> int:
+        nonlocal staged_document_writes
+        if path.suffix == ".md" and path.parent != goal_out:
+            staged_document_writes += 1
+            if staged_document_writes == 2:
+                raise OSError("simulated staged write failure")
+        return original_write_text(path, data, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", _fail_second_staged_document)
+    try:
+        export_goal_conclusions(
+            goal_id=goal,
+            registry_path=tmp_path / "registry.json",
+            runtime_root=tmp_path,
+            out_dir=out,
+        )
+    except OSError as exc:
+        assert "simulated staged write failure" in str(exc)
+    else:
+        raise AssertionError("staged write failure must propagate")
+
+    _assert_corpus_unchanged(
+        goal_out, manifest_path, prior_manifest, prior_documents
+    )
+
+
+def test_export_publish_failure_rolls_back_prior_owned_corpus(
+    tmp_path: Path, monkeypatch
+) -> None:
+    out = tmp_path / "out"
+    goal = "rollback"
+    first = _export_runs(
+        tmp_path,
+        monkeypatch,
+        goal_id=goal,
+        runs=[
+            {
+                "classification": "prior",
+                "generated_at": "2026-08-04T01:02:03Z",
+                "recommended_action": "published prior conclusion",
+            }
+        ],
+    )
+    goal_out, manifest_path, prior_manifest, prior_documents = _corpus_snapshot(first)
+
+    monkeypatch.setattr(
+        history_export,
+        "collect_history",
+        lambda **_: {
+            "runs": [
+                {
+                    "classification": "new",
+                    "generated_at": "2026-08-04T04:05:06Z",
+                    "recommended_action": "replacement conclusion",
+                }
+            ]
+        },
+    )
+    original_replace = history_export.os.replace
+    failed = False
+
+    def _fail_manifest_publish(source: Path, destination: Path) -> None:
+        nonlocal failed
+        if (
+            not failed
+            and Path(source).name == "publish"
+            and Path(destination) == goal_out
+        ):
+            failed = True
+            raise OSError("simulated corpus publish failure")
+        original_replace(source, destination)
+
+    monkeypatch.setattr(history_export.os, "replace", _fail_manifest_publish)
+    try:
+        export_goal_conclusions(
+            goal_id=goal,
+            registry_path=tmp_path / "registry.json",
+            runtime_root=tmp_path,
+            out_dir=out,
+        )
+    except OSError as exc:
+        assert "simulated corpus publish failure" in str(exc)
+    else:
+        raise AssertionError("publication failure must propagate after rollback")
+
+    assert failed
+    _assert_corpus_unchanged(
+        goal_out, manifest_path, prior_manifest, prior_documents
+    )
 
 
 def test_recall_input_contract() -> None:
@@ -140,6 +336,14 @@ def test_recall_input_contract() -> None:
         _expect_value_error(
             lambda: recall_history_conclusions(query=bad, scope_uri="viking://user/x/resources/h"),
             "empty query must raise",
+        )
+    fake_secret = "token" + "=" + "ghp_" + "a" * 36
+    for bad in ("/Users/private/query.txt", fake_secret):
+        _expect_value_error(
+            lambda bad=bad: recall_history_conclusions(
+                query=bad, scope_uri="viking://user/x/resources/h"
+            ),
+            "unsafe query must raise before invoking ov",
         )
     _expect_value_error(
         lambda: recall_history_conclusions(query="q", scope_uri="/local/path"),
@@ -149,6 +353,94 @@ def test_recall_input_contract() -> None:
         lambda: recall_history_conclusions(query="q", scope_uri="viking://user/x/resources/h", limit=99),
         "out-of-range limit must raise",
     )
+
+
+def test_recall_rejects_unsafe_scope_and_drops_unsafe_returned_uris(
+    monkeypatch,
+) -> None:
+    fake_secret = "token" + "=" + "ghp_" + "a" * 36
+    unsafe_scopes = (
+        "viking://user/x/resources/h//Users/private/report",
+        "viking://user/x/resources/h/%252FUsers/private/report",
+        "viking://user/x/resources/h/%00injected",
+        "viking://user/x/resources/h\ninjected",
+        f"viking://user/x/resources/h/{fake_secret}",
+    )
+    calls = 0
+
+    def _must_not_run(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        raise AssertionError("unsafe scope must be rejected before invoking ov")
+
+    monkeypatch.setattr(history_export.subprocess, "run", _must_not_run)
+    for scope in unsafe_scopes:
+        _expect_value_error(
+            lambda scope=scope: recall_history_conclusions(
+                query="storage", scope_uri=scope, ov_bin="ov"
+            ),
+            f"unsafe scope must raise: {scope!r}",
+        )
+    assert calls == 0
+
+    scope = "viking://user/x/resources/h"
+
+    class _Completed:
+        returncode = 0
+        stdout = json.dumps(
+            {
+                "result": {
+                    "resources": [
+                        {
+                            "uri": f"{scope}/safe.md",
+                            "score": 0.9,
+                            "abstract": "safe conclusion",
+                        },
+                        {
+                            "uri": f"{scope}/unsafe-score.md",
+                            "score": fake_secret,
+                            "abstract": "unsafe score",
+                        },
+                        {
+                            "uri": f"{scope}//Users/private/report.md",
+                            "score": 0.8,
+                            "abstract": "unsafe path uri",
+                        },
+                        {
+                            "uri": f"{scope}/%252FUsers/private/report.md",
+                            "score": 0.75,
+                            "abstract": "encoded unsafe path uri",
+                        },
+                        {
+                            "uri": f"{scope}/line\nbreak.md",
+                            "score": 0.7,
+                            "abstract": "unsafe control uri",
+                        },
+                        {
+                            "uri": f"{scope}/%00control.md",
+                            "score": 0.65,
+                            "abstract": "encoded unsafe control uri",
+                        },
+                        {
+                            "uri": f"{scope}/{fake_secret}",
+                            "score": 0.6,
+                            "abstract": "unsafe secret uri",
+                        },
+                    ]
+                }
+            }
+        )
+
+    monkeypatch.setattr(history_export.subprocess, "run", lambda *a, **k: _Completed())
+    result = recall_history_conclusions(
+        query="storage", scope_uri=scope, ov_bin="ov"
+    )
+    assert [item["uri"] for item in result["items"]] == [f"{scope}/safe.md"]
+    assert result["dropped_unsafe"] >= 5
+    serialized = json.dumps(result)
+    assert "/Users/" not in serialized
+    assert fake_secret not in serialized
+    assert "line\\nbreak" not in serialized
 
 
 def test_recall_sanitizes_provider_summaries(monkeypatch) -> None:
@@ -204,19 +496,30 @@ def main() -> int:
     test_recall_input_contract()
     test_schema_versions_are_stable()
 
-    with tempfile.TemporaryDirectory() as d:
-        test_export_rejects_unsafe_goal_id(Path(d))
-    with tempfile.TemporaryDirectory() as d:
+    with tempfile.TemporaryDirectory() as directory:
+        test_export_rejects_unsafe_goal_id(Path(directory))
+    for test in (
+        test_export_preserves_foreign_files_when_retiring_owned_generation,
+        test_export_uses_unique_names_and_reports_exact_document_count,
+        test_export_write_failure_preserves_prior_owned_corpus,
+        test_export_publish_failure_rolls_back_prior_owned_corpus,
+    ):
+        directory = tempfile.TemporaryDirectory()
         mp = _MonkeyPatch()
         try:
-            test_export_retires_prior_generation_and_hides_local_path(Path(d), mp)
+            test(Path(directory.name), mp)
         finally:
             mp.undo()
-    mp = _MonkeyPatch()
-    try:
-        test_recall_sanitizes_provider_summaries(mp)
-    finally:
-        mp.undo()
+            directory.cleanup()
+    for test in (
+        test_recall_rejects_unsafe_scope_and_drops_unsafe_returned_uris,
+        test_recall_sanitizes_provider_summaries,
+    ):
+        mp = _MonkeyPatch()
+        try:
+            test(mp)
+        finally:
+            mp.undo()
 
     print("ok: loopx-history-conclusion-recall smoke passed")
     return 0

--- a/examples/loopx-history-conclusion-recall-smoke.py
+++ b/examples/loopx-history-conclusion-recall-smoke.py
@@ -43,13 +43,17 @@ def _expect_value_error(fn, message: str) -> None:
 
 
 def test_export_drops_local_paths_and_secrets() -> None:
+    # Build the secret at runtime so this source file contains no literal
+    # credential for the repo boundary scanner, while the sanitizer still sees a
+    # real secret-shaped value at test time.
+    fake_secret = "token" + "=" + "ghp_" + "a" * 36
     run = {
         "classification": "example_conclusion",
         "recommended_action": "freeze the cross-market alert contract before evidence",
         "state": {
             "progress": [
                 "Wrote artifact under /Users/someone/private/secret-report.md",
-                "token=ghp_abcdefghijklmnopqrstuvwxyz0123456789 committed by mistake",
+                f"{fake_secret} committed by mistake",
                 "Validated the residual model on untouched folds",
             ]
         },

--- a/loopx/extensions/openviking_semantic_preference/history_export.py
+++ b/loopx/extensions/openviking_semantic_preference/history_export.py
@@ -1,0 +1,232 @@
+"""Export sanitized LoopX run conclusions as public-safe documents.
+
+This is a delivery-unit helper co-located with the OpenViking semantic-preference
+provider family. It converts LoopX run-history conclusions into compact,
+public-safe markdown documents suitable for ingest into an OpenViking
+``resources`` scope, where they can later be recalled semantically.
+
+Design boundary: run conclusions are *documents/knowledge*, not provider-managed
+*peer preference memory*. They therefore target the ``resources`` scope and the
+generic ``ov find`` document-recall path, never the peer-preference contract in
+``project_peer.py``. This keeps the OpenViking ``memories`` (managed) vs
+``resources`` (documents) scope convention intact.
+
+Reuses:
+- ``loopx.history.collect_history`` to read run records (no bespoke JSON parsing).
+- ``loopx.control_plane.runtime.public_safety.public_safe_compact_text`` to drop
+  any field carrying local paths or secret-like tokens before it leaves the repo.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from ...control_plane.runtime.public_safety import public_safe_compact_text
+from ...history import collect_history
+
+HISTORY_EXPORT_SCHEMA_VERSION = "loopx_history_conclusion_export_v0"
+HISTORY_RECALL_SCHEMA_VERSION = "loopx_history_conclusion_recall_v0"
+
+_CONCLUSION_LIMIT = 400
+_MAX_PROGRESS_BULLETS = 3
+_SLUG_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _slug(value: str) -> str:
+    slug = _SLUG_RE.sub("-", value).strip("-")
+    return slug[:80] or "run"
+
+
+def conclusion_fields(run: dict[str, Any]) -> list[tuple[str, str]]:
+    """Return public-safe (label, text) conclusion pairs for one run.
+
+    Every value is passed through ``public_safe_compact_text`` so any row with a
+    local path or secret-like token is dropped rather than exported.
+    """
+    fields: list[tuple[str, str]] = []
+
+    def _add(label: str, raw: Any) -> None:
+        if not raw:
+            return
+        safe = public_safe_compact_text(raw, limit=_CONCLUSION_LIMIT)
+        if safe:
+            fields.append((label, safe))
+
+    _add("classification", run.get("classification"))
+    _add("recommended_action", run.get("recommended_action"))
+    _add("delivery_outcome", run.get("delivery_outcome"))
+
+    vision_patch = (run.get("agent_vision") or {}).get("vision_patch") or {}
+    _add("last_patch_summary", vision_patch.get("last_patch_summary"))
+    _add("vision_summary", vision_patch.get("vision_summary"))
+
+    progress = (run.get("state") or {}).get("progress") or []
+    for bullet in progress[-_MAX_PROGRESS_BULLETS:]:
+        _add("progress", bullet)
+
+    return fields
+
+
+def render_conclusion_markdown(goal_id: str, run: dict[str, Any]) -> str | None:
+    """Render one run's conclusions as public-safe markdown, or None if noise.
+
+    A run with no substantive conclusion beyond its classification (for example a
+    bare ``quota_slot_spent`` slot) is treated as noise and skipped.
+    """
+    fields = conclusion_fields(run)
+    substantive = [pair for pair in fields if pair[0] != "classification"]
+    if not substantive:
+        return None
+
+    generated_at = str(run.get("generated_at") or "")
+    lines = [
+        "# LoopX run conclusion",
+        "",
+        f"- goal: `{goal_id}`",
+        f"- generated_at: `{generated_at}`",
+        "",
+    ]
+    for label, text in fields:
+        lines.extend([f"## {label}", text, ""])
+    return "\n".join(lines)
+
+
+def export_goal_conclusions(
+    *,
+    goal_id: str,
+    registry_path: Path,
+    runtime_root: Path,
+    out_dir: Path,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """Export the most recent ``limit`` run conclusions for one goal.
+
+    Writes one public-safe markdown per substantive run under
+    ``out_dir/<goal_id>/`` and returns a compact summary. Per-goal and bounded by
+    ``limit`` so out-network embedding cost stays controlled.
+    """
+    history = collect_history(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        goal_id=goal_id,
+        limit=limit,
+    )
+    runs = history.get("runs") or []
+    goal_out = out_dir / goal_id
+    goal_out.mkdir(parents=True, exist_ok=True)
+
+    written = 0
+    skipped_noise = 0
+    for run in runs:
+        markdown = render_conclusion_markdown(goal_id, run)
+        if markdown is None:
+            skipped_noise += 1
+            continue
+        name = _slug(f"{run.get('generated_at') or ''}-{run.get('classification') or ''}")
+        (goal_out / f"{name}.md").write_text(markdown, encoding="utf-8")
+        written += 1
+
+    return {
+        "schema_version": HISTORY_EXPORT_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "runs_considered": len(runs),
+        "written": written,
+        "skipped_noise": skipped_noise,
+        "out_dir": str(goal_out),
+        "target_scope_hint": "openviking resources scope (documents), not peer memories",
+    }
+
+
+def recall_history_conclusions(
+    *,
+    query: str,
+    scope_uri: str,
+    ov_bin: str = "ov",
+    limit: int = 5,
+    timeout_seconds: int = 25,
+) -> dict[str, Any]:
+    """Semantically recall exported history conclusions from a resources scope.
+
+    This is the document-recall counterpart to the peer-preference ``_find`` in
+    ``provider.py``: it targets an arbitrary ``resources`` document scope (where
+    :func:`export_goal_conclusions` writes) instead of the provider-managed
+    preference contract, so it does not touch or reinterpret peer memories.
+
+    Runs one read-only ``ov find`` scoped to ``scope_uri`` and returns compact
+    ``{uri, score, summary}`` items filtered to that scope. No raw content beyond
+    the provider-produced abstract/overview is returned.
+    """
+    clean_query = str(query or "").strip()
+    if not 1 <= len(clean_query) <= 500:
+        raise ValueError("query must contain 1 to 500 characters")
+    if not scope_uri.startswith("viking://"):
+        raise ValueError("scope_uri must be a viking:// resource uri")
+    if not 1 <= int(limit) <= 20:
+        raise ValueError("limit must be between 1 and 20")
+
+    try:
+        completed = subprocess.run(
+            [
+                ov_bin,
+                "find",
+                "-o",
+                "json",
+                "-n",
+                str(min(int(limit) * 3, 20)),
+                "-u",
+                scope_uri,
+                clean_query,
+            ],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError("OpenViking find execution failed") from exc
+    if completed.returncode != 0:
+        raise RuntimeError("OpenViking find returned a non-zero exit")
+
+    try:
+        result = json.loads(completed.stdout[completed.stdout.find("{"):])
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise RuntimeError("OpenViking find returned unparseable output") from exc
+
+    payload = result.get("result") if isinstance(result, Mapping) else {}
+    rows: list[Any] = []
+    if isinstance(payload, Mapping):
+        for key in ("resources", "memories"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                rows.extend(value)
+
+    scope_prefix = f"{scope_uri.rstrip('/')}/"
+    items: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        uri = str(row.get("uri") or "").strip()
+        if not uri.startswith(scope_prefix):
+            continue
+        summary = str(row.get("abstract") or row.get("overview") or "").strip()
+        items.append(
+            {
+                "uri": uri,
+                "score": row.get("score"),
+                "summary": summary[:2_000],
+            }
+        )
+    items.sort(key=lambda item: item.get("score") or 0.0, reverse=True)
+    items = items[: int(limit)]
+
+    return {
+        "schema_version": HISTORY_RECALL_SCHEMA_VERSION,
+        "query": clean_query,
+        "scope_uri": scope_uri,
+        "item_count": len(items),
+        "items": items,
+    }

--- a/loopx/extensions/openviking_semantic_preference/history_export.py
+++ b/loopx/extensions/openviking_semantic_preference/history_export.py
@@ -1,41 +1,38 @@
-"""Export sanitized LoopX run conclusions as public-safe documents.
+"""Atomically export sanitized LoopX run conclusions as public-safe documents.
 
-This is a delivery-unit helper co-located with the OpenViking semantic-preference
-provider family. It converts LoopX run-history conclusions into compact,
-public-safe markdown documents suitable for ingest into an OpenViking
-``resources`` scope, where they can later be recalled semantically.
+This extension-owned command converts LoopX run-history conclusions into
+compact public-safe Markdown documents. It deliberately stops at a verified
+local corpus: OpenViking ingest and recall need a separate caller-owned
+capability and effect lifecycle.
 
 Design boundary: run conclusions are *documents/knowledge*, not provider-managed
-*peer preference memory*. They therefore target the ``resources`` scope and the
-generic ``ov find`` document-recall path, never the peer-preference contract in
-``project_peer.py``. This keeps the OpenViking ``memories`` (managed) vs
-``resources`` (documents) scope convention intact.
+*peer preference memory*. This exporter therefore does not extend or bypass the
+semantic-preference provider contract in ``provider.py``.
 
 Reuses:
 - ``loopx.history.collect_history`` to read run records (no bespoke JSON parsing).
 - ``loopx.control_plane.runtime.public_safety.public_safe_compact_text`` to drop
   any field carrying local paths or secret-like tokens before it leaves the repo.
 """
+
 from __future__ import annotations
 
+import argparse
 import hashlib
 import json
-import math
 import os
 import re
 import shutil
-import subprocess
+import sys
 import tempfile
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
-from urllib.parse import unquote, urlsplit
 
 from ...control_plane.runtime.public_safety import public_safe_compact_text
 from ...history import collect_history, validate_goal_id_path_segment
 
 HISTORY_EXPORT_SCHEMA_VERSION = "loopx_history_conclusion_export_v0"
-HISTORY_RECALL_SCHEMA_VERSION = "loopx_history_conclusion_recall_v0"
 
 _CONCLUSION_LIMIT = 400
 _MAX_PROGRESS_BULLETS = 3
@@ -46,7 +43,35 @@ _SLUG_RE = re.compile(r"[^A-Za-z0-9._-]+")
 _SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
 # Bounded ISO-8601-ish timestamp: digits, T/space, colon, dot, +/- and Z only.
 _TIMESTAMP_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}[T ][0-9:.+\-]{1,20}Z?$")
-_MAX_URI_LENGTH = 1_000
+_PUBLIC_GOAL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,120}$")
+_SECRET_SHAPED_GOAL_ID_RE = re.compile(
+    r"(?i)^(?:"
+    r"gh[pousr]_[A-Za-z0-9]{20,}|"
+    r"github_pat_[A-Za-z0-9_]{20,}|"
+    r"(?:AKIA|ASIA)[A-Z0-9]{16}|"
+    r"xox[baprs]-[A-Za-z0-9-]{10,}|"
+    r"AIza[A-Za-z0-9_-]{20,}|"
+    r"(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{12,}|"
+    r"npm_[A-Za-z0-9]{20,}|"
+    r"pypi-[A-Za-z0-9_-]{20,}"
+    r")$"
+)
+
+
+def _public_goal_id(value: Any) -> str:
+    raw = str(value or "")
+    goal_id = validate_goal_id_path_segment(raw)
+    if (
+        raw != goal_id
+        or not _PUBLIC_GOAL_ID_RE.fullmatch(goal_id)
+        or _SECRET_SHAPED_GOAL_ID_RE.fullmatch(goal_id)
+        or public_safe_compact_text(goal_id, limit=121) != goal_id
+    ):
+        raise ValueError(
+            "goal_id must be a public-safe token using letters, digits, dot, "
+            "colon, dash, or underscore"
+        )
+    return goal_id
 
 
 def _safe_generated_at(value: Any) -> str:
@@ -80,9 +105,9 @@ def _document_name(
     occurrence = digest_occurrences.get(digest, 0) + 1
     digest_occurrences[digest] = occurrence
     generated_at = _safe_generated_at(run.get("generated_at"))
-    classification = public_safe_compact_text(
-        run.get("classification"), limit=80
-    ) or "run"
+    classification = (
+        public_safe_compact_text(run.get("classification"), limit=80) or "run"
+    )
     prefix = _slug(f"{generated_at}-{classification}")[:56]
     duplicate_suffix = f"-{occurrence}" if occurrence > 1 else ""
     return f"{prefix}-{digest[:16]}{duplicate_suffix}.md"
@@ -145,6 +170,42 @@ def _read_owned_manifest(path: Path, *, goal_id: str) -> dict[str, str]:
     return owned
 
 
+def _validated_owned_generation(path: Path, *, goal_id: str) -> dict[str, str]:
+    if not path.exists():
+        return {}
+    if path.is_symlink() or not path.is_dir():
+        raise RuntimeError("history export generation must be a directory")
+    manifest_path = path / _MANIFEST_FILE
+    if manifest_path.is_symlink() or not manifest_path.is_file():
+        raise RuntimeError(
+            "existing history corpus lacks an exporter ownership manifest"
+        )
+    owned = _read_owned_manifest(manifest_path, goal_id=goal_id)
+    expected_names = {_MANIFEST_FILE, *owned}
+    actual_names = {item.name for item in path.iterdir()}
+    unowned = sorted(actual_names - expected_names)
+    if unowned:
+        raise RuntimeError(
+            f"history export generation contains unowned entries: {unowned}"
+        )
+    missing = sorted(expected_names - actual_names)
+    if missing:
+        raise RuntimeError(
+            f"history export generation is missing owned entries: {missing}"
+        )
+    for name, digest in owned.items():
+        document = path / name
+        if document.is_symlink() or not document.is_file():
+            raise RuntimeError(
+                f"manifest-owned history document is not a regular file: {name}"
+            )
+        if _sha256(document.read_bytes()) != digest:
+            raise RuntimeError(
+                f"manifest-owned history document digest does not match: {name}"
+            )
+    return owned
+
+
 def _validate_staged_generation(
     staged: Path,
     *,
@@ -166,17 +227,22 @@ def _publish_generation(
     manifest: Mapping[str, Any],
 ) -> int:
     corpus_out.parent.mkdir(parents=True, exist_ok=True)
-    if corpus_out.exists() and not (corpus_out / _MANIFEST_FILE).is_file():
-        raise RuntimeError(
-            "existing history corpus lacks an exporter ownership manifest"
-        )
-    prior_owned = _read_owned_manifest(
-        corpus_out / _MANIFEST_FILE,
-        goal_id=str(manifest["goal_id"]),
-    )
     backup = corpus_out.parent / f".{corpus_out.name}.loopx-backup"
     if backup.exists():
-        raise RuntimeError(f"stale history export backup requires inspection: {backup}")
+        if corpus_out.exists():
+            raise RuntimeError(
+                "history export has both live and backup generations; "
+                "manual inspection is required"
+            )
+        _validated_owned_generation(
+            backup,
+            goal_id=str(manifest["goal_id"]),
+        )
+        os.replace(backup, corpus_out)
+    prior_owned = _validated_owned_generation(
+        corpus_out,
+        goal_id=str(manifest["goal_id"]),
+    )
 
     with tempfile.TemporaryDirectory(
         prefix=f".{corpus_out.name}.loopx-stage-",
@@ -205,75 +271,6 @@ def _publish_generation(
         if backup.exists():
             shutil.rmtree(backup)
     return len(prior_owned)
-
-
-def _safe_viking_resource_uri(value: Any) -> str:
-    def _contains_control(text: str) -> bool:
-        return any(
-            character.isspace() or ord(character) < 32 or ord(character) == 127
-            for character in text
-        )
-
-    uri = str(value or "").strip()
-    if not uri or len(uri) > _MAX_URI_LENGTH:
-        raise ValueError("viking resource uri must contain 1 to 1000 characters")
-    if _contains_control(uri):
-        raise ValueError("viking resource uri must not contain whitespace or controls")
-    decoded = uri
-    for _ in range(3):
-        next_decoded = unquote(decoded)
-        if next_decoded == decoded:
-            break
-        decoded = next_decoded
-    if unquote(decoded) != decoded:
-        raise ValueError("viking resource uri is excessively encoded")
-    for candidate in (uri, decoded):
-        if _contains_control(candidate):
-            raise ValueError("viking resource uri must not contain whitespace or controls")
-        if public_safe_compact_text(candidate, limit=_MAX_URI_LENGTH) != candidate:
-            raise ValueError("viking resource uri contains an unsafe surface")
-        if "\\" in candidate:
-            raise ValueError("viking resource uri must not contain backslashes")
-
-    parsed = urlsplit(decoded)
-    if (
-        parsed.scheme != "viking"
-        or not parsed.netloc
-        or parsed.query
-        or parsed.fragment
-        or parsed.username is not None
-        or parsed.password is not None
-    ):
-        raise ValueError("scope_uri must be a structured viking:// resource uri")
-    decoded_path = parsed.path
-    path_segments = decoded_path.split("/")
-    if (
-        not decoded_path.startswith("/")
-        or any(segment in {"", ".", ".."} for segment in path_segments[1:])
-        or "resources" not in path_segments[1:]
-    ):
-        raise ValueError("scope_uri must identify a bounded resources path")
-    return uri
-
-
-def _is_descendant_resource_uri(uri: str, *, scope_uri: str) -> bool:
-    candidate = urlsplit(uri)
-    scope = urlsplit(scope_uri)
-    if candidate.scheme != scope.scheme or candidate.netloc != scope.netloc:
-        return False
-    candidate_segments = unquote(candidate.path).split("/")[1:]
-    scope_segments = unquote(scope.path).split("/")[1:]
-    return (
-        len(candidate_segments) > len(scope_segments)
-        and candidate_segments[: len(scope_segments)] == scope_segments
-    )
-
-
-def _safe_score(value: Any) -> float | None:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        return None
-    score = float(value)
-    return score if math.isfinite(score) else None
 
 
 def conclusion_fields(run: dict[str, Any]) -> list[tuple[str, str]]:
@@ -315,7 +312,7 @@ def render_conclusion_markdown(goal_id: str, run: dict[str, Any]) -> str | None:
     ``generated_at`` is echoed only when it matches a bounded timestamp shape, so
     neither can inject unsafe content into the document.
     """
-    safe_goal_id = validate_goal_id_path_segment(goal_id)
+    safe_goal_id = _public_goal_id(goal_id)
     fields = conclusion_fields(run)
     substantive = [pair for pair in fields if pair[0] != "classification"]
     if not substantive:
@@ -359,7 +356,7 @@ def export_goal_conclusions(
     - The local filesystem output path lives only in ``local_receipt`` and is
       never part of the ``public_projection``.
     """
-    safe_goal_id = validate_goal_id_path_segment(goal_id)
+    safe_goal_id = _public_goal_id(goal_id)
     history = collect_history(
         registry_path=registry_path,
         runtime_root=runtime_root,
@@ -417,110 +414,28 @@ def export_goal_conclusions(
     }
 
 
-def recall_history_conclusions(
-    *,
-    query: str,
-    scope_uri: str,
-    ov_bin: str = "ov",
-    limit: int = 5,
-    timeout_seconds: int = 25,
-) -> dict[str, Any]:
-    """Semantically recall exported history conclusions from a resources scope.
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--goal-id", required=True)
+    parser.add_argument("--registry-path", type=Path, required=True)
+    parser.add_argument("--runtime-root", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--limit", type=int, default=50)
+    return parser
 
-    This is the document-recall counterpart to the peer-preference ``_find`` in
-    ``provider.py``: it targets an arbitrary ``resources`` document scope (where
-    :func:`export_goal_conclusions` writes) instead of the provider-managed
-    preference contract, so it does not touch or reinterpret peer memories.
 
-    Runs one read-only ``ov find`` scoped to ``scope_uri`` and returns compact
-    ``{uri, score, summary}`` items filtered to that scope. Provider-produced
-    ``abstract``/``overview`` text is passed through ``public_safe_compact_text``
-    and any row whose summary carries a local path or secret-like token is
-    dropped, so the returned packet is public-safe end to end. Returned ``uri``
-    values are constrained to the requested ``scope_uri`` prefix.
-    """
-    clean_query = str(query or "").strip()
-    if not 1 <= len(clean_query) <= 500:
-        raise ValueError("query must contain 1 to 500 characters")
-    if public_safe_compact_text(clean_query, limit=500) != clean_query:
-        raise ValueError("query must be public-safe compact text")
-    safe_scope_uri = _safe_viking_resource_uri(scope_uri)
-    if not 1 <= int(limit) <= 20:
-        raise ValueError("limit must be between 1 and 20")
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    payload = export_goal_conclusions(
+        goal_id=args.goal_id,
+        registry_path=args.registry_path,
+        runtime_root=args.runtime_root,
+        out_dir=args.out_dir,
+        limit=args.limit,
+    )
+    json.dump(payload, sys.stdout, ensure_ascii=False)
+    return 0
 
-    try:
-        completed = subprocess.run(
-            [
-                ov_bin,
-                "find",
-                "-o",
-                "json",
-                "-n",
-                str(min(int(limit) * 3, 20)),
-                "-u",
-                safe_scope_uri,
-                clean_query,
-            ],
-            capture_output=True,
-            check=False,
-            text=True,
-            timeout=timeout_seconds,
-        )
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        raise RuntimeError("OpenViking find execution failed") from exc
-    if completed.returncode != 0:
-        raise RuntimeError("OpenViking find returned a non-zero exit")
 
-    try:
-        result = json.loads(completed.stdout[completed.stdout.find("{"):])
-    except (ValueError, json.JSONDecodeError) as exc:
-        raise RuntimeError("OpenViking find returned unparseable output") from exc
-
-    payload = result.get("result") if isinstance(result, Mapping) else {}
-    rows: list[Any] = []
-    if isinstance(payload, Mapping):
-        for key in ("resources", "memories"):
-            value = payload.get(key)
-            if isinstance(value, list):
-                rows.extend(value)
-
-    items: list[dict[str, Any]] = []
-    dropped_unsafe = 0
-    for row in rows:
-        if not isinstance(row, Mapping):
-            continue
-        try:
-            uri = _safe_viking_resource_uri(row.get("uri"))
-        except ValueError:
-            dropped_unsafe += 1
-            continue
-        if not _is_descendant_resource_uri(uri, scope_uri=safe_scope_uri):
-            continue
-        score = _safe_score(row.get("score"))
-        if score is None:
-            dropped_unsafe += 1
-            continue
-        raw_summary = row.get("abstract") or row.get("overview")
-        # Provider text is untrusted: sanitize end to end and drop on any hit.
-        summary = public_safe_compact_text(raw_summary, limit=2_000)
-        if not summary:
-            dropped_unsafe += 1
-            continue
-        items.append(
-            {
-                "uri": uri,
-                "score": score,
-                "summary": summary,
-            }
-        )
-    items.sort(key=lambda item: item["score"], reverse=True)
-    items = items[: int(limit)]
-
-    return {
-        "schema_version": HISTORY_RECALL_SCHEMA_VERSION,
-        "query": clean_query,
-        "scope_uri": safe_scope_uri,
-        "item_count": len(items),
-        "dropped_unsafe": dropped_unsafe,
-        "items": items,
-    }
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/extensions/openviking_semantic_preference/history_export.py
+++ b/loopx/extensions/openviking_semantic_preference/history_export.py
@@ -228,12 +228,26 @@ def _publish_generation(
 ) -> int:
     corpus_out.parent.mkdir(parents=True, exist_ok=True)
     backup = corpus_out.parent / f".{corpus_out.name}.loopx-backup"
-    if backup.exists():
-        if corpus_out.exists():
-            raise RuntimeError(
-                "history export has both live and backup generations; "
-                "manual inspection is required"
+    if backup.exists() and corpus_out.exists():
+        try:
+            _validated_owned_generation(
+                corpus_out,
+                goal_id=str(manifest["goal_id"]),
             )
+            shutil.rmtree(backup, ignore_errors=True)
+        except Exception:
+            try:
+                _validated_owned_generation(
+                    backup,
+                    goal_id=str(manifest["goal_id"]),
+                )
+                os.replace(backup, corpus_out)
+            except Exception:
+                raise RuntimeError(
+                    "history export has both live and backup generations "
+                    "and neither could be verified; manual inspection is required"
+                ) from None
+    elif backup.exists():
         _validated_owned_generation(
             backup,
             goal_id=str(manifest["goal_id"]),
@@ -269,7 +283,7 @@ def _publish_generation(
                 os.replace(backup, corpus_out)
             raise
         if backup.exists():
-            shutil.rmtree(backup)
+            shutil.rmtree(backup, ignore_errors=True)
     return len(prior_owned)
 
 

--- a/loopx/extensions/openviking_semantic_preference/history_export.py
+++ b/loopx/extensions/openviking_semantic_preference/history_export.py
@@ -220,6 +220,15 @@ def _validate_staged_generation(
         raise RuntimeError("staged history export manifest failed readback")
 
 
+def _remove_verified_backup(backup: Path) -> None:
+    shutil.rmtree(backup, ignore_errors=True)
+    if backup.exists():
+        raise RuntimeError(
+            "history export backup cleanup is incomplete; retry publication "
+            "after the verified backup can be removed"
+        )
+
+
 def _publish_generation(
     *,
     corpus_out: Path,
@@ -231,22 +240,42 @@ def _publish_generation(
     if backup.exists() and corpus_out.exists():
         try:
             _validated_owned_generation(
+                backup,
+                goal_id=str(manifest["goal_id"]),
+            )
+        except Exception:
+            raise RuntimeError(
+                "history export has both live and backup generations "
+                "and includes an unverified backup; manual inspection is required"
+            ) from None
+        try:
+            _validated_owned_generation(
                 corpus_out,
                 goal_id=str(manifest["goal_id"]),
             )
-            shutil.rmtree(backup, ignore_errors=True)
         except Exception:
+            unverified_live = (
+                corpus_out.parent / f".{corpus_out.name}.loopx-unverified-live"
+            )
+            if unverified_live.exists():
+                raise RuntimeError(
+                    "history export has an unverified live generation and "
+                    "its recovery quarantine already exists; manual inspection is required"
+                ) from None
+            os.replace(corpus_out, unverified_live)
             try:
-                _validated_owned_generation(
-                    backup,
-                    goal_id=str(manifest["goal_id"]),
-                )
                 os.replace(backup, corpus_out)
             except Exception:
-                raise RuntimeError(
-                    "history export has both live and backup generations "
-                    "and neither could be verified; manual inspection is required"
-                ) from None
+                try:
+                    os.replace(unverified_live, corpus_out)
+                except Exception:
+                    raise RuntimeError(
+                        "history export could not restore the unverified live "
+                        "generation after backup recovery failed; manual inspection is required"
+                    ) from None
+                raise
+        else:
+            _remove_verified_backup(backup)
     elif backup.exists():
         _validated_owned_generation(
             backup,
@@ -283,7 +312,7 @@ def _publish_generation(
                 os.replace(backup, corpus_out)
             raise
         if backup.exists():
-            shutil.rmtree(backup, ignore_errors=True)
+            _remove_verified_backup(backup)
     return len(prior_owned)
 
 

--- a/loopx/extensions/openviking_semantic_preference/history_export.py
+++ b/loopx/extensions/openviking_semantic_preference/history_export.py
@@ -18,12 +18,18 @@ Reuses:
 """
 from __future__ import annotations
 
+import hashlib
 import json
+import math
+import os
 import re
+import shutil
 import subprocess
+import tempfile
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
+from urllib.parse import unquote, urlsplit
 
 from ...control_plane.runtime.public_safety import public_safe_compact_text
 from ...history import collect_history, validate_goal_id_path_segment
@@ -33,9 +39,14 @@ HISTORY_RECALL_SCHEMA_VERSION = "loopx_history_conclusion_recall_v0"
 
 _CONCLUSION_LIMIT = 400
 _MAX_PROGRESS_BULLETS = 3
+_CORPUS_DIR = "history-conclusions"
+_MANIFEST_FILE = ".loopx-history-conclusion-export.json"
+_MANIFEST_SCHEMA_VERSION = "loopx_history_conclusion_export_manifest_v0"
 _SLUG_RE = re.compile(r"[^A-Za-z0-9._-]+")
+_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
 # Bounded ISO-8601-ish timestamp: digits, T/space, colon, dot, +/- and Z only.
 _TIMESTAMP_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}[T ][0-9:.+\-]{1,20}Z?$")
+_MAX_URI_LENGTH = 1_000
 
 
 def _safe_generated_at(value: Any) -> str:
@@ -53,6 +64,216 @@ def _safe_generated_at(value: Any) -> str:
 def _slug(value: str) -> str:
     slug = _SLUG_RE.sub("-", value).strip("-")
     return slug[:80] or "run"
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _document_name(
+    run: Mapping[str, Any],
+    markdown: str,
+    *,
+    digest_occurrences: dict[str, int],
+) -> str:
+    digest = _sha256(markdown.encode("utf-8"))
+    occurrence = digest_occurrences.get(digest, 0) + 1
+    digest_occurrences[digest] = occurrence
+    generated_at = _safe_generated_at(run.get("generated_at"))
+    classification = public_safe_compact_text(
+        run.get("classification"), limit=80
+    ) or "run"
+    prefix = _slug(f"{generated_at}-{classification}")[:56]
+    duplicate_suffix = f"-{occurrence}" if occurrence > 1 else ""
+    return f"{prefix}-{digest[:16]}{duplicate_suffix}.md"
+
+
+def _manifest_payload(
+    *,
+    goal_id: str,
+    documents: Mapping[str, bytes],
+) -> dict[str, Any]:
+    return {
+        "schema_version": _MANIFEST_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "files": [
+            {"name": name, "sha256": _sha256(data)}
+            for name, data in sorted(documents.items())
+        ],
+    }
+
+
+def _write_manifest(path: Path, payload: Mapping[str, Any]) -> None:
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _read_owned_manifest(path: Path, *, goal_id: str) -> dict[str, str]:
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError("history export manifest is unreadable") from exc
+    if not isinstance(payload, Mapping):
+        raise RuntimeError("history export manifest must be an object")
+    if payload.get("schema_version") != _MANIFEST_SCHEMA_VERSION:
+        raise RuntimeError("history export manifest schema is unsupported")
+    if payload.get("goal_id") != goal_id:
+        raise RuntimeError("history export manifest goal does not match output")
+    files = payload.get("files")
+    if not isinstance(files, list):
+        raise RuntimeError("history export manifest files must be a list")
+
+    owned: dict[str, str] = {}
+    for item in files:
+        if not isinstance(item, Mapping):
+            raise RuntimeError("history export manifest file entry must be an object")
+        name = str(item.get("name") or "")
+        digest = str(item.get("sha256") or "")
+        if (
+            not name
+            or Path(name).name != name
+            or not name.endswith(".md")
+            or not _SHA256_RE.fullmatch(digest)
+            or name in owned
+        ):
+            raise RuntimeError("history export manifest contains an invalid file entry")
+        owned[name] = digest
+    return owned
+
+
+def _validate_staged_generation(
+    staged: Path,
+    *,
+    documents: Mapping[str, bytes],
+    manifest: Mapping[str, Any],
+) -> None:
+    for name, expected in documents.items():
+        if (staged / name).read_bytes() != expected:
+            raise RuntimeError(f"staged history document failed readback: {name}")
+    staged_manifest = json.loads((staged / _MANIFEST_FILE).read_text(encoding="utf-8"))
+    if staged_manifest != manifest:
+        raise RuntimeError("staged history export manifest failed readback")
+
+
+def _publish_generation(
+    *,
+    corpus_out: Path,
+    documents: Mapping[str, bytes],
+    manifest: Mapping[str, Any],
+) -> int:
+    corpus_out.parent.mkdir(parents=True, exist_ok=True)
+    if corpus_out.exists() and not (corpus_out / _MANIFEST_FILE).is_file():
+        raise RuntimeError(
+            "existing history corpus lacks an exporter ownership manifest"
+        )
+    prior_owned = _read_owned_manifest(
+        corpus_out / _MANIFEST_FILE,
+        goal_id=str(manifest["goal_id"]),
+    )
+    backup = corpus_out.parent / f".{corpus_out.name}.loopx-backup"
+    if backup.exists():
+        raise RuntimeError(f"stale history export backup requires inspection: {backup}")
+
+    with tempfile.TemporaryDirectory(
+        prefix=f".{corpus_out.name}.loopx-stage-",
+        dir=corpus_out.parent,
+    ) as temp_dir:
+        staged = Path(temp_dir) / "publish"
+        staged.mkdir()
+        for name, data in sorted(documents.items()):
+            (staged / name).write_text(data.decode("utf-8"), encoding="utf-8")
+        _write_manifest(staged / _MANIFEST_FILE, manifest)
+        _validate_staged_generation(
+            staged,
+            documents=documents,
+            manifest=manifest,
+        )
+
+        had_output = corpus_out.exists()
+        if had_output:
+            os.replace(corpus_out, backup)
+        try:
+            os.replace(staged, corpus_out)
+        except Exception:
+            if had_output and backup.exists() and not corpus_out.exists():
+                os.replace(backup, corpus_out)
+            raise
+        if backup.exists():
+            shutil.rmtree(backup)
+    return len(prior_owned)
+
+
+def _safe_viking_resource_uri(value: Any) -> str:
+    def _contains_control(text: str) -> bool:
+        return any(
+            character.isspace() or ord(character) < 32 or ord(character) == 127
+            for character in text
+        )
+
+    uri = str(value or "").strip()
+    if not uri or len(uri) > _MAX_URI_LENGTH:
+        raise ValueError("viking resource uri must contain 1 to 1000 characters")
+    if _contains_control(uri):
+        raise ValueError("viking resource uri must not contain whitespace or controls")
+    decoded = uri
+    for _ in range(3):
+        next_decoded = unquote(decoded)
+        if next_decoded == decoded:
+            break
+        decoded = next_decoded
+    if unquote(decoded) != decoded:
+        raise ValueError("viking resource uri is excessively encoded")
+    for candidate in (uri, decoded):
+        if _contains_control(candidate):
+            raise ValueError("viking resource uri must not contain whitespace or controls")
+        if public_safe_compact_text(candidate, limit=_MAX_URI_LENGTH) != candidate:
+            raise ValueError("viking resource uri contains an unsafe surface")
+        if "\\" in candidate:
+            raise ValueError("viking resource uri must not contain backslashes")
+
+    parsed = urlsplit(decoded)
+    if (
+        parsed.scheme != "viking"
+        or not parsed.netloc
+        or parsed.query
+        or parsed.fragment
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        raise ValueError("scope_uri must be a structured viking:// resource uri")
+    decoded_path = parsed.path
+    path_segments = decoded_path.split("/")
+    if (
+        not decoded_path.startswith("/")
+        or any(segment in {"", ".", ".."} for segment in path_segments[1:])
+        or "resources" not in path_segments[1:]
+    ):
+        raise ValueError("scope_uri must identify a bounded resources path")
+    return uri
+
+
+def _is_descendant_resource_uri(uri: str, *, scope_uri: str) -> bool:
+    candidate = urlsplit(uri)
+    scope = urlsplit(scope_uri)
+    if candidate.scheme != scope.scheme or candidate.netloc != scope.netloc:
+        return False
+    candidate_segments = unquote(candidate.path).split("/")[1:]
+    scope_segments = unquote(scope.path).split("/")[1:]
+    return (
+        len(candidate_segments) > len(scope_segments)
+        and candidate_segments[: len(scope_segments)] == scope_segments
+    )
+
+
+def _safe_score(value: Any) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    score = float(value)
+    return score if math.isfinite(score) else None
 
 
 def conclusion_fields(run: dict[str, Any]) -> list[tuple[str, str]]:
@@ -123,17 +344,18 @@ def export_goal_conclusions(
 ) -> dict[str, Any]:
     """Export the most recent ``limit`` run conclusions for one goal.
 
-    Writes one public-safe markdown per substantive run under
-    ``out_dir/<goal_id>/`` and returns a summary split into a public-safe
-    projection and a local-only publication receipt.
+    Writes one public-safe markdown per substantive run under the exporter-owned
+    ``out_dir/<goal_id>/history-conclusions/`` corpus and returns a summary split
+    into a public-safe projection and a local-only publication receipt.
 
     Boundary contract:
     - ``goal_id`` is validated as a single path segment before it is used as a
       directory component, so an unsafe id (``../escaped``) cannot escape
       ``out_dir``.
-    - Each generation clears the goal's prior exported markdown before writing,
-      so stale conclusions do not survive when later history is empty or fully
-      redacted (generation-retirement contract).
+    - A private manifest identifies only this exporter's documents. The owned
+      corpus directory is fully staged and read back before one atomic directory
+      replacement, while unrelated files under ``out_dir/<goal_id>/`` are never
+      moved or deleted.
     - The local filesystem output path lives only in ``local_receipt`` and is
       never part of the ``public_projection``.
     """
@@ -145,37 +367,40 @@ def export_goal_conclusions(
         limit=limit,
     )
     runs = history.get("runs") or []
-    goal_out = out_dir / safe_goal_id
-    goal_out.mkdir(parents=True, exist_ok=True)
+    goal_root = out_dir / safe_goal_id
+    corpus_out = goal_root / _CORPUS_DIR
+    manifest_path = corpus_out / _MANIFEST_FILE
 
-    # Generation retirement: remove the prior generation's exported documents so
-    # a later empty/redacted history cannot leave stale conclusions behind.
-    retired = 0
-    for stale in goal_out.glob("*.md"):
-        stale.unlink()
-        retired += 1
-
-    written = 0
+    documents: dict[str, bytes] = {}
+    digest_occurrences: dict[str, int] = {}
     skipped_noise = 0
     for run in runs:
         markdown = render_conclusion_markdown(safe_goal_id, run)
         if markdown is None:
             skipped_noise += 1
             continue
-        generated_at = _safe_generated_at(run.get("generated_at"))
-        classification = public_safe_compact_text(
-            run.get("classification"), limit=80
-        ) or "run"
-        name = _slug(f"{generated_at}-{classification}")
-        (goal_out / f"{name}.md").write_text(markdown, encoding="utf-8")
-        written += 1
+        name = _document_name(
+            run,
+            markdown,
+            digest_occurrences=digest_occurrences,
+        )
+        if name in documents:
+            raise RuntimeError("history export generated a duplicate document name")
+        documents[name] = markdown.encode("utf-8")
+
+    manifest = _manifest_payload(goal_id=safe_goal_id, documents=documents)
+    retired = _publish_generation(
+        corpus_out=corpus_out,
+        documents=documents,
+        manifest=manifest,
+    )
 
     return {
         "public_projection": {
             "schema_version": HISTORY_EXPORT_SCHEMA_VERSION,
             "goal_id": safe_goal_id,
             "runs_considered": len(runs),
-            "written": written,
+            "written": len(documents),
             "skipped_noise": skipped_noise,
             "retired_prior_generation": retired,
             "target_scope_hint": (
@@ -185,7 +410,9 @@ def export_goal_conclusions(
         "local_receipt": {
             # Local filesystem path is intentionally kept out of the public
             # projection above.
-            "out_dir": str(goal_out),
+            "out_dir": str(corpus_out),
+            "manifest_path": str(manifest_path),
+            "owned_files": sorted(documents),
         },
     }
 
@@ -215,8 +442,9 @@ def recall_history_conclusions(
     clean_query = str(query or "").strip()
     if not 1 <= len(clean_query) <= 500:
         raise ValueError("query must contain 1 to 500 characters")
-    if not scope_uri.startswith("viking://"):
-        raise ValueError("scope_uri must be a viking:// resource uri")
+    if public_safe_compact_text(clean_query, limit=500) != clean_query:
+        raise ValueError("query must be public-safe compact text")
+    safe_scope_uri = _safe_viking_resource_uri(scope_uri)
     if not 1 <= int(limit) <= 20:
         raise ValueError("limit must be between 1 and 20")
 
@@ -230,7 +458,7 @@ def recall_history_conclusions(
                 "-n",
                 str(min(int(limit) * 3, 20)),
                 "-u",
-                scope_uri,
+                safe_scope_uri,
                 clean_query,
             ],
             capture_output=True,
@@ -256,14 +484,21 @@ def recall_history_conclusions(
             if isinstance(value, list):
                 rows.extend(value)
 
-    scope_prefix = f"{scope_uri.rstrip('/')}/"
     items: list[dict[str, Any]] = []
     dropped_unsafe = 0
     for row in rows:
         if not isinstance(row, Mapping):
             continue
-        uri = str(row.get("uri") or "").strip()
-        if not uri.startswith(scope_prefix):
+        try:
+            uri = _safe_viking_resource_uri(row.get("uri"))
+        except ValueError:
+            dropped_unsafe += 1
+            continue
+        if not _is_descendant_resource_uri(uri, scope_uri=safe_scope_uri):
+            continue
+        score = _safe_score(row.get("score"))
+        if score is None:
+            dropped_unsafe += 1
             continue
         raw_summary = row.get("abstract") or row.get("overview")
         # Provider text is untrusted: sanitize end to end and drop on any hit.
@@ -274,17 +509,17 @@ def recall_history_conclusions(
         items.append(
             {
                 "uri": uri,
-                "score": row.get("score"),
+                "score": score,
                 "summary": summary,
             }
         )
-    items.sort(key=lambda item: item.get("score") or 0.0, reverse=True)
+    items.sort(key=lambda item: item["score"], reverse=True)
     items = items[: int(limit)]
 
     return {
         "schema_version": HISTORY_RECALL_SCHEMA_VERSION,
         "query": clean_query,
-        "scope_uri": scope_uri,
+        "scope_uri": safe_scope_uri,
         "item_count": len(items),
         "dropped_unsafe": dropped_unsafe,
         "items": items,

--- a/loopx/extensions/openviking_semantic_preference/history_export.py
+++ b/loopx/extensions/openviking_semantic_preference/history_export.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from typing import Any
 
 from ...control_plane.runtime.public_safety import public_safe_compact_text
-from ...history import collect_history
+from ...history import collect_history, validate_goal_id_path_segment
 
 HISTORY_EXPORT_SCHEMA_VERSION = "loopx_history_conclusion_export_v0"
 HISTORY_RECALL_SCHEMA_VERSION = "loopx_history_conclusion_recall_v0"
@@ -34,6 +34,20 @@ HISTORY_RECALL_SCHEMA_VERSION = "loopx_history_conclusion_recall_v0"
 _CONCLUSION_LIMIT = 400
 _MAX_PROGRESS_BULLETS = 3
 _SLUG_RE = re.compile(r"[^A-Za-z0-9._-]+")
+# Bounded ISO-8601-ish timestamp: digits, T/space, colon, dot, +/- and Z only.
+_TIMESTAMP_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}[T ][0-9:.+\-]{1,20}Z?$")
+
+
+def _safe_generated_at(value: Any) -> str:
+    """Return a bounded timestamp string, or empty string if not safe.
+
+    Never trust the raw run field as content: only echo it when it matches a
+    tight timestamp shape, otherwise drop it entirely.
+    """
+    text = str(value or "").strip()
+    if text and _TIMESTAMP_RE.match(text):
+        return text
+    return ""
 
 
 def _slug(value: str) -> str:
@@ -75,18 +89,22 @@ def render_conclusion_markdown(goal_id: str, run: dict[str, Any]) -> str | None:
     """Render one run's conclusions as public-safe markdown, or None if noise.
 
     A run with no substantive conclusion beyond its classification (for example a
-    bare ``quota_slot_spent`` slot) is treated as noise and skipped.
+    bare ``quota_slot_spent`` slot) is treated as noise and skipped. ``goal_id``
+    is validated against the canonical single-path-segment contract and
+    ``generated_at`` is echoed only when it matches a bounded timestamp shape, so
+    neither can inject unsafe content into the document.
     """
+    safe_goal_id = validate_goal_id_path_segment(goal_id)
     fields = conclusion_fields(run)
     substantive = [pair for pair in fields if pair[0] != "classification"]
     if not substantive:
         return None
 
-    generated_at = str(run.get("generated_at") or "")
+    generated_at = _safe_generated_at(run.get("generated_at"))
     lines = [
         "# LoopX run conclusion",
         "",
-        f"- goal: `{goal_id}`",
+        f"- goal: `{safe_goal_id}`",
         f"- generated_at: `{generated_at}`",
         "",
     ]
@@ -106,38 +124,69 @@ def export_goal_conclusions(
     """Export the most recent ``limit`` run conclusions for one goal.
 
     Writes one public-safe markdown per substantive run under
-    ``out_dir/<goal_id>/`` and returns a compact summary. Per-goal and bounded by
-    ``limit`` so out-network embedding cost stays controlled.
+    ``out_dir/<goal_id>/`` and returns a summary split into a public-safe
+    projection and a local-only publication receipt.
+
+    Boundary contract:
+    - ``goal_id`` is validated as a single path segment before it is used as a
+      directory component, so an unsafe id (``../escaped``) cannot escape
+      ``out_dir``.
+    - Each generation clears the goal's prior exported markdown before writing,
+      so stale conclusions do not survive when later history is empty or fully
+      redacted (generation-retirement contract).
+    - The local filesystem output path lives only in ``local_receipt`` and is
+      never part of the ``public_projection``.
     """
+    safe_goal_id = validate_goal_id_path_segment(goal_id)
     history = collect_history(
         registry_path=registry_path,
         runtime_root=runtime_root,
-        goal_id=goal_id,
+        goal_id=safe_goal_id,
         limit=limit,
     )
     runs = history.get("runs") or []
-    goal_out = out_dir / goal_id
+    goal_out = out_dir / safe_goal_id
     goal_out.mkdir(parents=True, exist_ok=True)
+
+    # Generation retirement: remove the prior generation's exported documents so
+    # a later empty/redacted history cannot leave stale conclusions behind.
+    retired = 0
+    for stale in goal_out.glob("*.md"):
+        stale.unlink()
+        retired += 1
 
     written = 0
     skipped_noise = 0
     for run in runs:
-        markdown = render_conclusion_markdown(goal_id, run)
+        markdown = render_conclusion_markdown(safe_goal_id, run)
         if markdown is None:
             skipped_noise += 1
             continue
-        name = _slug(f"{run.get('generated_at') or ''}-{run.get('classification') or ''}")
+        generated_at = _safe_generated_at(run.get("generated_at"))
+        classification = public_safe_compact_text(
+            run.get("classification"), limit=80
+        ) or "run"
+        name = _slug(f"{generated_at}-{classification}")
         (goal_out / f"{name}.md").write_text(markdown, encoding="utf-8")
         written += 1
 
     return {
-        "schema_version": HISTORY_EXPORT_SCHEMA_VERSION,
-        "goal_id": goal_id,
-        "runs_considered": len(runs),
-        "written": written,
-        "skipped_noise": skipped_noise,
-        "out_dir": str(goal_out),
-        "target_scope_hint": "openviking resources scope (documents), not peer memories",
+        "public_projection": {
+            "schema_version": HISTORY_EXPORT_SCHEMA_VERSION,
+            "goal_id": safe_goal_id,
+            "runs_considered": len(runs),
+            "written": written,
+            "skipped_noise": skipped_noise,
+            "retired_prior_generation": retired,
+            "target_scope_hint": (
+                "openviking resources scope (documents), not peer memories"
+            ),
+        },
+        "local_receipt": {
+            # Local filesystem path is intentionally kept out of the public
+            # projection above.
+            "out_dir": str(goal_out),
+        },
     }
 
 
@@ -157,8 +206,11 @@ def recall_history_conclusions(
     preference contract, so it does not touch or reinterpret peer memories.
 
     Runs one read-only ``ov find`` scoped to ``scope_uri`` and returns compact
-    ``{uri, score, summary}`` items filtered to that scope. No raw content beyond
-    the provider-produced abstract/overview is returned.
+    ``{uri, score, summary}`` items filtered to that scope. Provider-produced
+    ``abstract``/``overview`` text is passed through ``public_safe_compact_text``
+    and any row whose summary carries a local path or secret-like token is
+    dropped, so the returned packet is public-safe end to end. Returned ``uri``
+    values are constrained to the requested ``scope_uri`` prefix.
     """
     clean_query = str(query or "").strip()
     if not 1 <= len(clean_query) <= 500:
@@ -206,18 +258,24 @@ def recall_history_conclusions(
 
     scope_prefix = f"{scope_uri.rstrip('/')}/"
     items: list[dict[str, Any]] = []
+    dropped_unsafe = 0
     for row in rows:
         if not isinstance(row, Mapping):
             continue
         uri = str(row.get("uri") or "").strip()
         if not uri.startswith(scope_prefix):
             continue
-        summary = str(row.get("abstract") or row.get("overview") or "").strip()
+        raw_summary = row.get("abstract") or row.get("overview")
+        # Provider text is untrusted: sanitize end to end and drop on any hit.
+        summary = public_safe_compact_text(raw_summary, limit=2_000)
+        if not summary:
+            dropped_unsafe += 1
+            continue
         items.append(
             {
                 "uri": uri,
                 "score": row.get("score"),
-                "summary": summary[:2_000],
+                "summary": summary,
             }
         )
     items.sort(key=lambda item: item.get("score") or 0.0, reverse=True)
@@ -228,5 +286,6 @@ def recall_history_conclusions(
         "query": clean_query,
         "scope_uri": scope_uri,
         "item_count": len(items),
+        "dropped_unsafe": dropped_unsafe,
         "items": items,
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ test = [
 [project.scripts]
 loopx = "loopx.entrypoint:main"
 loopx-lark-provider = "loopx.extensions.lark.provider:main"
+loopx-openviking-history-export = "loopx.extensions.openviking_semantic_preference.history_export:main"
 loopx-openviking-semantic-preference = "loopx.extensions.openviking_semantic_preference.provider:main"
 
 [tool.setuptools.packages.find]

--- a/tests/extensions/test_openviking_history_export.py
+++ b/tests/extensions/test_openviking_history_export.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SMOKE = ROOT / "examples" / "loopx-history-conclusion-recall-smoke.py"
+
+
+def _load_contract() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "loopx_history_conclusion_export_contract",
+        SMOKE,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("history-conclusion export contract is not importable")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_history_conclusion_export_contract() -> None:
+    contract = _load_contract()
+    assert not contract._run_cases()


### PR DESCRIPTION
## Summary

Add an extension-owned, atomic exporter that turns substantive LoopX run conclusions into a public-safe local document corpus.

- `export_goal_conclusions` reads run records through `collect_history`, sanitizes conclusion fields, and writes one Markdown document per substantive run.
- Publication is manifest-owned and atomic: the exporter stages and readbacks a complete corpus before replacement, preserves foreign files outside the corpus, fails closed on unowned or corrupted generations, and restores a verified backup when possible.
- The command deliberately stops at a verified local corpus. OpenViking ingest, `ov find` recall, and refresh cadence need a separate caller-owned capability and effect lifecycle; they are not shipped by this PR.

## Placement Rationale

Run conclusions are documents/knowledge, not provider-managed peer-preference memory. The exporter is co-located with the OpenViking semantic-preference extension because it reuses `collect_history` and the existing public-safety boundary without widening the peer-preference provider contract.

## Public/Private Boundary

- Validates goal identifiers before content or path use.
- Drops unsafe conclusion text and timestamps.
- Keeps local filesystem paths only in the local publication receipt, never the public projection.
- Rejects unowned, altered, or unrecoverable corpus generations rather than overwriting them.

## Validation

- `python3 examples/loopx-history-conclusion-recall-smoke.py` — 23 focused exporter/recovery cases passed.
- `python3 -m py_compile loopx/extensions/openviking_semantic_preference/history_export.py`
- `loopx check --scan-root .` — public-boundary scan clean.
- `git diff --check`

## Scope

- No live OpenViking request, network dependency, credentials, raw transcripts, or private paths.
- No change to peer preference behavior, runtime scoring, or automatic corpus ingestion.
