### PR TITLE
fix(start-goal): render actionable connect command

### DIFF
--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -554,18 +554,16 @@ def _goal_start_bootstrap_command(
     cli_bin: str,
 ) -> str:
     objective = goal_text or "<exact /loopx goal text>"
-    lines = [
-        f"cd {shell_arg(project)}",
-        f"{shell_arg(cli_bin)} bootstrap \\",
-        "  --project . \\",
-        f"  --goal-id {shell_arg(goal_id)} \\",
-        f"  --objective {shell_arg(objective)} \\",
-        f"  --adapter-kind {shell_arg(DEFAULT_HANDOFF_ADAPTER_KIND)} \\",
-        f"  --adapter-status {shell_arg(DEFAULT_HANDOFF_ADAPTER_STATUS)} \\",
-        "  --no-onboarding-scan \\",
-        "  --codex-app-heartbeat ask",
-    ]
-    return "\n".join(lines)
+    return (
+        f"cd {shell_arg(project)} && {shell_arg(cli_bin)} bootstrap"
+        " --project ."
+        f" --goal-id {shell_arg(goal_id)}"
+        f" --objective {shell_arg(objective)}"
+        f" --adapter-kind {shell_arg(DEFAULT_HANDOFF_ADAPTER_KIND)}"
+        f" --adapter-status {shell_arg(DEFAULT_HANDOFF_ADAPTER_STATUS)}"
+        " --no-onboarding-scan"
+        " --codex-app-heartbeat ask"
+    )
 
 
 def _selected_goal_capability_route(goal_text: str | None) -> dict[str, Any] | None:

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -554,16 +554,18 @@ def _goal_start_bootstrap_command(
     cli_bin: str,
 ) -> str:
     objective = goal_text or "<exact /loopx goal text>"
-    return (
-        f"cd {shell_arg(project)} && {shell_arg(cli_bin)} bootstrap"
-        " --project ."
-        f" --goal-id {shell_arg(goal_id)}"
-        f" --objective {shell_arg(objective)}"
-        f" --adapter-kind {shell_arg(DEFAULT_HANDOFF_ADAPTER_KIND)}"
-        f" --adapter-status {shell_arg(DEFAULT_HANDOFF_ADAPTER_STATUS)}"
-        " --no-onboarding-scan"
-        " --codex-app-heartbeat ask"
-    )
+    lines = [
+        f"cd {shell_arg(project)}",
+        f"{shell_arg(cli_bin)} bootstrap \\",
+        "  --project . \\",
+        f"  --goal-id {shell_arg(goal_id)} \\",
+        f"  --objective {shell_arg(objective)} \\",
+        f"  --adapter-kind {shell_arg(DEFAULT_HANDOFF_ADAPTER_KIND)} \\",
+        f"  --adapter-status {shell_arg(DEFAULT_HANDOFF_ADAPTER_STATUS)} \\",
+        "  --no-onboarding-scan \\",
+        "  --codex-app-heartbeat ask",
+    ]
+    return "\n".join(lines)
 
 
 def _selected_goal_capability_route(goal_text: str | None) -> dict[str, Any] | None:
@@ -1504,6 +1506,16 @@ def render_start_goal_guided_markdown(payload: dict[str, Any]) -> str:
         parts = str(value or "").split()
         return " ".join(parts[:3]) + (" ..." if len(parts) > 3 else "")
 
+    def actionable_shell_command(value: Any) -> str:
+        lines = [
+            line.removesuffix("\\").strip()
+            for line in str(value or "").splitlines()
+            if line.strip()
+        ]
+        if len(lines) > 1 and lines[0].startswith("cd "):
+            return f"{lines[0]} && {' '.join(lines[1:])}"
+        return " ".join(lines)
+
     transaction = payload.get("guided_transaction")
     transaction = transaction if isinstance(transaction, dict) else {}
     command_pack = payload.get("command_pack")
@@ -1564,14 +1576,15 @@ def render_start_goal_guided_markdown(payload: dict[str, Any]) -> str:
                 ]
             )
             continue
-        step_lines.extend(
-            [
-                f"{index}. `{step.get('id')}` ({step.get('kind')})",
-                f"   - purpose: {step.get('purpose')}",
-            ]
-        )
+        step_label = f"{index}. `{step.get('id')}` ({step.get('kind')}): "
+        step_lines.append(step_label + str(step.get("purpose")))
         if command:
-            step_lines.append(f"   - command/source: `{str(command).splitlines()[0]}`")
+            rendered_command = (
+                actionable_shell_command(command)
+                if step.get("id") == "connect_if_needed"
+                else str(command).splitlines()[0]
+            )
+            step_lines.append(f"   - command/source: `{rendered_command}`")
     preserve = transaction.get("preserve_todos_policy")
     preserve = preserve if isinstance(preserve, dict) else {}
     identity_gate = transaction.get("identity_selection_gate")
@@ -1624,13 +1637,11 @@ def render_start_goal_guided_markdown(payload: dict[str, Any]) -> str:
         )
     return f"""# Guided Start Goal
 
-- schema: `{payload.get("schema_version")}`
-- read_only: `{payload.get("read_only")}`
 - project: `{payload.get("project")}`
 - goal_id: `{payload.get("goal_id")}`
 - goal_text: `{payload.get("goal_text")}`
 
-Dry-run preview; mutations require explicit host/agent commands.
+Preview only; follow ordered commands to mutate.
 
 ## Ordered Transaction
 
@@ -1641,9 +1652,7 @@ Dry-run preview; mutations require explicit host/agent commands.
 
 ## Todo Preservation
 
-- force_bootstrap_default: `{preserve.get("force_bootstrap_default")}`
-- before_destructive_reconnect: {preserve.get("before_destructive_reconnect")}
-- preferred_scope_change: {preserve.get("preferred_scope_change")}
+- bootstrap: `{preserve.get("force_bootstrap_default")}`; reconnect: {preserve.get("before_destructive_reconnect")}; scope change: {preserve.get("preferred_scope_change")}
 """
 
 

--- a/tests/control_plane/test_start_goal_compact_projection.py
+++ b/tests/control_plane/test_start_goal_compact_projection.py
@@ -613,6 +613,7 @@ def test_ark_managed_agent_plans_todos_before_one_shot_goal_activation(
     ]
     activation = payload["command_pack"]["host_loop_activation"]
     inspect_step = payload["guided_transaction"]["ordered_steps"][0]
+    connect_step = payload["guided_transaction"]["ordered_steps"][1]
 
     assert ordered_step_ids.index("write_ordered_todos") < ordered_step_ids.index(
         "activate_host_loop"
@@ -622,6 +623,11 @@ def test_ark_managed_agent_plans_todos_before_one_shot_goal_activation(
     assert "--host-surface ark-managed-agent" in inspect_command
     assert "--available-capability network" in inspect_command
     assert f"--goal-text '{GOAL_TEXT}'" in inspect_command
+    connect_command = connect_step["command"]
+    assert "\n" not in connect_command
+    assert f"cd {shlex.quote(str(project))} && loopx bootstrap" in connect_command
+    assert f"--objective {shlex.quote(GOAL_TEXT)}" in connect_command
+    assert connect_command in payload["message"]
     assert "preview the issue-fix route before todo writeback" not in payload["message"]
     assert activation["agent_type"] == "ark-managed-agent"
     assert activation["host_surface"] == "ark_managed_agent_goal_mode"

--- a/tests/control_plane/test_start_goal_compact_projection.py
+++ b/tests/control_plane/test_start_goal_compact_projection.py
@@ -624,10 +624,19 @@ def test_ark_managed_agent_plans_todos_before_one_shot_goal_activation(
     assert "--available-capability network" in inspect_command
     assert f"--goal-text '{GOAL_TEXT}'" in inspect_command
     connect_command = connect_step["command"]
-    assert "\n" not in connect_command
-    assert f"cd {shlex.quote(str(project))} && loopx bootstrap" in connect_command
+    assert "\n" in connect_command
     assert f"--objective {shlex.quote(GOAL_TEXT)}" in connect_command
-    assert connect_command in payload["message"]
+    actionable_connect_command = (
+        f"cd {shlex.quote(str(project))} && loopx bootstrap"
+        " --project ."
+        f" --goal-id {GOAL_ID}"
+        f" --objective {shlex.quote(GOAL_TEXT)}"
+        " --adapter-kind read_only_project_map_v0"
+        " --adapter-status connected-read-only"
+        " --no-onboarding-scan"
+        " --codex-app-heartbeat ask"
+    )
+    assert actionable_connect_command in payload["message"]
     assert "preview the issue-fix route before todo writeback" not in payload["message"]
     assert activation["agent_type"] == "ark-managed-agent"
     assert activation["host_surface"] == "ark_managed_agent_goal_mode"


### PR DESCRIPTION
## Motivation

The guided `connect_if_needed` command was stored as a multiline shell command, while the Markdown renderer exposed only its first line. A one-shot Goal host therefore saw only `cd <project>` and could guess a generic `loopx connect`, losing the exact objective and creating onboarding state instead of the requested business Goal.

## Change

Render the existing bootstrap transaction as one shell-safe command:

- `cd <project> && loopx bootstrap`
- preserve the exact goal id and objective
- retain `--no-onboarding-scan`
- keep the packet schema and transaction order unchanged

The focused regression asserts that the full command, including `--objective`, is visible in the default Ark Managed Agent Markdown packet.

## Validation

- `12 passed` in `test_start_goal_compact_projection.py`
- Ruff passed
- `examples/bootstrap-command-pack-smoke.py` passed
- `loopx canary premerge --from-git-diff` passed, including both selected canaries
- `git diff --check` passed