### PR TITLE
test(release): validate capability usage guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,28 @@ content, or invent community attribution for a founder-only release. The
 release PR and final GitHub release body must preserve the same bilingual
 attribution.
 
+### Release Capability Usage Gate
+
+When a release introduces or materially changes an optional capability,
+workflow, managed skill, or host surface, the final GitHub release body must
+teach the user how to operate it. For every affected surface, include matching
+English and Chinese entries with:
+
+- exact activation or per-command/profile opt-in;
+- a minimum runnable validation or readback command;
+- exact disable, uninstall, envelope-removal, or rollback guidance;
+- the authority and privacy boundary that activation does not grant;
+- a canonical versioned documentation link.
+
+Save the complete final release body in an ignored or temporary Markdown file.
+Run `examples/release/release-readiness-doc-smoke.py --release-notes ...` with
+one `--surface` argument per affected surface before publication, then read the
+remote body back and run the same check again. A release with no applicable
+surface changes must use `--expect-no-optional-capability-changes` and include
+the validator's explicit bilingual no-change declarations. Never treat the
+existence of a checklist, a release PR draft, or architecture-only capability
+copy as proof that the final release body is usable.
+
 ## First-Screen Review Gate
 
 Treat the first visible screen of public product surfaces as owner-reviewed

--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -610,6 +610,43 @@ Every public release note or update note should also answer:
   language. Keep each group shorter than its English counterpart while
   preserving direct PR attribution and compatibility boundaries.
 
+### Final Release Body Usage Gate
+
+The release-note PR is not sufficient evidence. Before publishing, save the
+complete final GitHub release body to an ignored or temporary Markdown file and
+validate that exact file:
+
+```bash
+python3 examples/release/release-readiness-doc-smoke.py \
+  --release-notes <final-release-body.md> \
+  --surface "<new-or-materially-changed-surface>" \
+  --surface "<another-surface>"
+```
+
+Derive the repeated `--surface` values from the tag diff, merged PR inventory,
+and release claims. Each named surface must have a dedicated English
+`### <surface>` entry under `## Optional Capability Activation & Use` and a
+matching Chinese `#### <surface>` entry under `### 可选能力启用与使用`. Both
+entries must include these explicit fields:
+
+| English | Chinese | Required content |
+| --- | --- | --- |
+| `**Activation:**` | `**启用：**` | Exact install/enable command, or the exact per-command/profile opt-in when no persistent switch exists. |
+| `**Validation:**` | `**验证：**` | Minimum runnable status, readback, or verification command. |
+| `**Disable / rollback:**` | `**停用 / 回退：**` | Exact disable, uninstall, envelope removal, or rollback path. |
+| `**Authority boundary:**` | `**权限边界：**` | Write, merge, provider, privacy, and host limits that activation does not grant. |
+| `**Docs:**` | `**文档：**` | Canonical versioned documentation link. |
+
+Every entry needs at least one runnable `bash` block. A release with no new or
+materially changed optional capability, workflow, or host surface must instead
+run the gate with `--expect-no-optional-capability-changes` and include the
+exact bilingual declarations required by the validator. Omitting both a
+surface list and the explicit no-change decision fails closed.
+
+After publishing, read the complete remote body back with `jq -rj`, compare its
+hash with the reviewed local file, and run the same validator against the
+readback. Do not validate a draft and then publish a different body.
+
 ### Capability Narrative Gate
 
 For every new or materially changed capability, write the release claim in

--- a/examples/release/release-readiness-doc-smoke.py
+++ b/examples/release/release-readiness-doc-smoke.py
@@ -3,7 +3,10 @@
 
 from __future__ import annotations
 
+import argparse
 from pathlib import Path
+import re
+import tempfile
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -23,6 +26,25 @@ FORBIDDEN_PUBLIC_STRINGS = [
     "ACTIVE_GOAL_STATE.md:",
 ]
 
+ENGLISH_USAGE_HEADING = "## Optional Capability Activation & Use"
+CHINESE_USAGE_HEADING = "### 可选能力启用与使用"
+ENGLISH_NO_CHANGES = "No new optional capability activation is introduced in this release."
+CHINESE_NO_CHANGES = "本版本未新增可选能力启用入口。"
+ENGLISH_USAGE_FIELDS = (
+    "**Activation:**",
+    "**Validation:**",
+    "**Disable / rollback:**",
+    "**Authority boundary:**",
+    "**Docs:**",
+)
+CHINESE_USAGE_FIELDS = (
+    "**启用：**",
+    "**验证：**",
+    "**停用 / 回退：**",
+    "**权限边界：**",
+    "**文档：**",
+)
+
 
 def read(path: Path) -> str:
     if not path.exists():
@@ -41,13 +63,217 @@ def assert_contains(text: str, needle: str, label: str) -> None:
 
 def validate_boundary(path: Path) -> None:
     text = read(path)
-    label = str(path.relative_to(ROOT))
+    try:
+        label = str(path.relative_to(ROOT))
+    except ValueError:
+        label = path.name
     for forbidden in FORBIDDEN_PUBLIC_STRINGS:
         if forbidden in text:
             raise AssertionError(f"{label} contains forbidden string {forbidden!r}")
 
 
+def heading_level(line: str) -> int | None:
+    match = re.match(r"^(#+)\s+", line)
+    return len(match.group(1)) if match else None
+
+
+def section(text: str, heading: str) -> str:
+    lines = text.splitlines()
+    try:
+        start = lines.index(heading)
+    except ValueError as exc:
+        raise AssertionError(f"release notes missing heading {heading!r}") from exc
+
+    level = heading_level(heading)
+    assert level is not None
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        candidate_level = heading_level(lines[index])
+        if candidate_level is not None and candidate_level <= level:
+            end = index
+            break
+    return "\n".join(lines[start + 1 : end])
+
+
+def validate_surface_entry(
+    *,
+    usage_section: str,
+    heading: str,
+    required_fields: tuple[str, ...],
+    language: str,
+) -> None:
+    entry = section(usage_section, heading)
+    for field in required_fields:
+        assert_contains(entry, field, f"{language} usage entry {heading!r}")
+    if "```bash" not in entry:
+        raise AssertionError(f"{language} usage entry {heading!r} has no runnable bash example")
+    docs_field = re.escape(required_fields[-1])
+    if not re.search(rf"{docs_field}[^\n]*https://[^)\s]+", entry):
+        raise AssertionError(
+            f"{language} usage entry {heading!r} has no canonical link in its docs field"
+        )
+
+
+def validate_release_notes(
+    path: Path,
+    *,
+    surfaces: list[str],
+    expect_no_optional_capability_changes: bool,
+) -> None:
+    validate_boundary(path)
+    body = read(path)
+    if body.count("```") % 2:
+        raise AssertionError("release notes contain an unbalanced fenced code block")
+
+    english = section(body, ENGLISH_USAGE_HEADING)
+    chinese_summary = section(body, "## 中文摘要")
+    chinese = section(chinese_summary, CHINESE_USAGE_HEADING)
+
+    if expect_no_optional_capability_changes:
+        if surfaces:
+            raise AssertionError(
+                "--expect-no-optional-capability-changes cannot be combined with --surface"
+            )
+        assert_contains(english, ENGLISH_NO_CHANGES, "English no-change declaration")
+        assert_contains(chinese, CHINESE_NO_CHANGES, "Chinese no-change declaration")
+        return
+
+    if not surfaces:
+        raise AssertionError(
+            "release-note validation requires at least one --surface or "
+            "--expect-no-optional-capability-changes"
+        )
+
+    if len(set(surfaces)) != len(surfaces):
+        raise AssertionError("release-note validation received duplicate --surface values")
+
+    for surface in surfaces:
+        validate_surface_entry(
+            usage_section=english,
+            heading=f"### {surface}",
+            required_fields=ENGLISH_USAGE_FIELDS,
+            language="English",
+        )
+        validate_surface_entry(
+            usage_section=chinese,
+            heading=f"#### {surface}",
+            required_fields=CHINESE_USAGE_FIELDS,
+            language="Chinese",
+        )
+
+
+def validate_release_notes_gate_self_test() -> None:
+    valid = f"""# Example
+
+{ENGLISH_USAGE_HEADING}
+
+### Example Surface
+
+**Activation:** Enable the example.
+
+**Validation:** Read it back.
+
+**Disable / rollback:** Disable the example.
+
+**Authority boundary:** No authority is granted.
+
+**Docs:** https://example.com/docs.
+
+```bash
+loopx example --check
+```
+
+## Validation
+
+## 中文摘要
+
+{CHINESE_USAGE_HEADING}
+
+#### Example Surface
+
+**启用：**启用示例。
+
+**验证：**读回示例。
+
+**停用 / 回退：**停用示例。
+
+**权限边界：**不授予额外权限。
+
+**文档：**https://example.com/docs。
+
+```bash
+loopx example --check
+```
+
+### 验证
+"""
+    invalid = valid.replace("**Disable / rollback:**", "", 1)
+    no_changes = f"""# Example
+
+{ENGLISH_USAGE_HEADING}
+
+{ENGLISH_NO_CHANGES}
+
+## 中文摘要
+
+{CHINESE_USAGE_HEADING}
+
+{CHINESE_NO_CHANGES}
+
+### 验证
+"""
+    with tempfile.TemporaryDirectory() as tmp:
+        valid_path = Path(tmp) / "valid.md"
+        invalid_path = Path(tmp) / "invalid.md"
+        no_changes_path = Path(tmp) / "no-changes.md"
+        valid_path.write_text(valid, encoding="utf-8")
+        invalid_path.write_text(invalid, encoding="utf-8")
+        no_changes_path.write_text(no_changes, encoding="utf-8")
+        validate_release_notes(
+            valid_path,
+            surfaces=["Example Surface"],
+            expect_no_optional_capability_changes=False,
+        )
+        validate_release_notes(
+            no_changes_path,
+            surfaces=[],
+            expect_no_optional_capability_changes=True,
+        )
+        try:
+            validate_release_notes(
+                invalid_path,
+                surfaces=["Example Surface"],
+                expect_no_optional_capability_changes=False,
+            )
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError("release-note gate accepted a missing rollback field")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--release-notes",
+        type=Path,
+        help="Validate an exact final GitHub release body stored in this file.",
+    )
+    parser.add_argument(
+        "--surface",
+        action="append",
+        default=[],
+        help="New or materially changed optional capability/workflow/host surface. Repeatable.",
+    )
+    parser.add_argument(
+        "--expect-no-optional-capability-changes",
+        action="store_true",
+        help="Require explicit bilingual declarations that this release adds no optional surface.",
+    )
+    return parser.parse_args()
+
+
 def main() -> None:
+    args = parse_args()
     for path in [DOC, README, DOCS_INDEX, PRODUCT_INDEX]:
         validate_boundary(path)
 
@@ -92,6 +318,19 @@ def main() -> None:
         "same people, pull-request links, and concrete contribution scope",
         "Optional capability activation",
         "If no persistent switch exists",
+        "final GitHub release body",
+        "--release-notes <final-release-body.md>",
+        "--expect-no-optional-capability-changes",
+        "**Activation:**",
+        "**Validation:**",
+        "**Disable / rollback:**",
+        "**Authority boundary:**",
+        "**Docs:**",
+        "**启用：**",
+        "**验证：**",
+        "**停用 / 回退：**",
+        "**权限边界：**",
+        "**文档：**",
         "### Capability Narrative Gate",
         "**User outcome**",
         "**Shipped layer**",
@@ -111,6 +350,20 @@ def main() -> None:
     assert_contains(root_readme, "docs/product/release-readiness.md", "root README")
     assert_contains(docs_index, "product/release-readiness.md", "docs index")
     assert_contains(product_index, "release-readiness.md", "product index")
+
+    validate_release_notes_gate_self_test()
+    if args.release_notes is not None:
+        validate_release_notes(
+            args.release_notes,
+            surfaces=args.surface,
+            expect_no_optional_capability_changes=(
+                args.expect_no_optional_capability_changes
+            ),
+        )
+    elif args.surface or args.expect_no_optional_capability_changes:
+        raise AssertionError(
+            "--surface and --expect-no-optional-capability-changes require --release-notes"
+        )
 
     print("release-readiness-doc-smoke ok")
 


### PR DESCRIPTION
## Summary

- require the final GitHub Release body, not only its draft or checklist, to carry runnable bilingual usage for every new or materially changed optional capability, workflow, managed skill, or host surface
- extend the existing release-readiness smoke with a fail-closed `--release-notes` mode that checks activation, validation, disable/rollback, authority boundary, and canonical docs for each declared surface
- require an explicit bilingual no-change declaration when a release has no applicable optional surface changes

## Motivation

The v0.3.0 release initially described its new capabilities but omitted how to use them. The repository already documented the desired activation guidance, but the durable smoke only proved that the checklist text existed. This change validates the exact final release body before publication and again after remote readback.

## Validation

- exact v0.3.0 remote release-body readback passed for Change Quality, Decision Context, Material Lifecycle, and Managed Project Skills & Ark Managed Agent
- embedded positive, missing-rollback, and explicit-no-change validator cases passed
- missing `--surface` inventory failed closed as expected
- Ruff, mypy, and Python compile passed for the changed smoke
- `loopx check` passed on all three public changed files
- risk-based premerge passed 18/18 selected checks with 0 failures and 0 manual holds
- exact committed Change Quality receipt `cqr_b80126dd11a02d453163` is valid

No full pytest run was needed: the change is isolated to maintainer rules, release documentation, and one existing durable release smoke.
