### PR TITLE
fix(canary): resolve shared registry for premerge

### DIFF
--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -304,7 +304,6 @@ def main(argv: list[str] | None = None) -> int:
             "codex-cli-visible-driver-run",
             "codex-cli-visible-driver-plan",
             "codex-cli-visible-session-proof",
-            "canary",
             "demo",
             "doctor",
             "new-project-prompt",

--- a/tests/capabilities/test_change_quality.py
+++ b/tests/capabilities/test_change_quality.py
@@ -869,6 +869,64 @@ def test_premerge_cli_enforces_goal_receipt_policy(
     assert payload["gate"]["self_merge_allowed"] is False
 
 
+def test_premerge_cli_resolves_global_registry_after_successful_gate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo, registry, runtime_root = _fixture(tmp_path)
+    runtime_root.mkdir()
+    global_registry = runtime_root / "registry.global.json"
+    global_registry.write_text(registry.read_text(encoding="utf-8"), encoding="utf-8")
+    (repo / "app.py").write_text("value = 2\n", encoding="utf-8")
+    monkeypatch.chdir(repo)
+
+    def successful_gate(**kwargs: object) -> dict[str, object]:
+        assert kwargs["execute"] is True
+        return {
+            "ok": True,
+            "gate": {
+                "status": "passed",
+                "merge_gate_passed": True,
+                "self_merge_allowed": True,
+            },
+            "validation_summary": {
+                "selected_check_count": 1,
+                "executed_check_count": 1,
+                "failure_count": 0,
+            },
+            "recommended_pr_comment_fields": [],
+        }
+
+    monkeypatch.setattr(
+        "loopx.cli_commands.canary.build_premerge_validation_gate",
+        successful_gate,
+    )
+
+    exit_code = main(
+        [
+            "--runtime-root",
+            str(runtime_root),
+            "--format",
+            "json",
+            "canary",
+            "premerge",
+            "--from-git-diff",
+            "--git-diff-base",
+            "HEAD",
+            "--goal-id",
+            GOAL_ID,
+            "--no-progress",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["gate"]["merge_gate_passed"] is True
+    assert payload["change_quality_qualification"]["status"] == "disabled"
+    assert not (repo / ".loopx" / "registry.json").exists()
+
+
 def test_quality_skill_delivery_is_policy_conditional_and_host_neutral(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- let `canary premerge --goal-id` use the existing project-to-global registry fallback when a clean linked worktree has no local `.loopx/registry.json`
- add a CLI regression that completes a successful gate, reads the shared goal registry, and exits cleanly without creating project-local state

## Validation

- `pytest -q tests/capabilities/test_change_quality.py`: 20 passed
- `ruff check loopx/cli.py tests/capabilities/test_change_quality.py`: passed
- `loopx canary premerge --from-git-diff --goal-id loopx-meta --no-progress`: passed, 4 direct checks plus 6 risk-selected checks, no failures or manual holds
- exact change-quality receipt `cqr_1a4fbbaf4a1d722cac79`: valid
- `ruff format --check` still reports formatting debt in unchanged lines of the two existing files; this PR leaves that unrelated churn out

## Review

The behavior change is one removed exclusion in the shared CLI fallback. It does not add a canary-specific resolver or compatibility path. Explicit `--registry` arguments retain their existing authority.
