### PR TITLE
feat(decision-context): expose required source coverage

### DIFF
--- a/docs/capabilities/decision-context/README.md
+++ b/docs/capabilities/decision-context/README.md
@@ -77,6 +77,13 @@ If a provider is unavailable, the capability fails open to the remaining
 authority sources and records provider health. It does not block the Core
 lifecycle or silently advance source cursors.
 
+The assembly also emits `decision_source_coverage_v0`. This public-safe receipt
+summarizes scan status, exact-read completeness, and uncovered P0 sources by
+priority. Incomplete P0 coverage does not block safe LoopX lifecycle work, but
+the caller must label the conclusion as partial or exact-read the missing
+authority through another path. Fail-open must not masquerade as complete
+context coverage.
+
 ## Three Auditable Outputs
 
 | Output | Answers | Typical contents |

--- a/docs/capabilities/decision-context/README.zh-CN.md
+++ b/docs/capabilities/decision-context/README.zh-CN.md
@@ -69,6 +69,11 @@ Decision Context 不会：
 如果 provider 不可用，它会记录 provider health，并 fail open 到剩余 authority
 source；不会阻断 Core lifecycle，也不会静默推进 source cursor。
 
+Assembly 还会输出 `decision_source_coverage_v0`。它把每个优先级的扫描状态、
+exact-read 完整度和未覆盖的 P0 source 投影为公开安全的回执。`P0 incomplete`
+不阻断安全的 LoopX lifecycle，但调用方必须显式标记结论为部分覆盖，或者先通过
+其他 authority 路径补齐 exact read；不能把 fail-open 误写成“所有关键上下文已检查”。
+
 ## 三类可审计产物
 
 | 产物 | 回答的问题 | 典型内容 |

--- a/loopx/capabilities/decision_context/assembler.py
+++ b/loopx/capabilities/decision_context/assembler.py
@@ -28,6 +28,7 @@ from .sources import (
 
 DECISION_CONTEXT_ASSEMBLY_SCHEMA_VERSION = "decision_context_assembly_v0"
 DECISION_CURSOR_CHECKPOINT_SCHEMA_VERSION = "decision_cursor_checkpoint_v0"
+DECISION_SOURCE_COVERAGE_SCHEMA_VERSION = "decision_source_coverage_v0"
 
 
 def _packet_ref(prefix: str, packet: Mapping[str, Any]) -> str:
@@ -140,6 +141,67 @@ class _CollectedSource:
     exact_reads: tuple[DecisionSourceExactRead, ...]
     exact_read_failed: bool
     receipt: Mapping[str, Any]
+
+
+def _source_coverage(
+    collected_sources: Sequence[_CollectedSource],
+) -> dict[str, Any]:
+    """Project whether every P0 source was scanned and exactly read when needed."""
+
+    priority_rows: list[dict[str, Any]] = []
+    incomplete_required_source_ids: list[str] = []
+    for priority in ("p0", "p1", "p2"):
+        sources = [
+            collected
+            for collected in collected_sources
+            if collected.source.priority == priority
+        ]
+        status_counts = {
+            status: sum(
+                1 for collected in sources if collected.scan.status == status
+            )
+            for status in ("completed", "no_change", "failed", "unavailable")
+        }
+        exact_read_incomplete_count = sum(
+            1 for collected in sources if collected.exact_read_failed
+        )
+        complete_count = sum(
+            1
+            for collected in sources
+            if collected.scan.status in {"completed", "no_change"}
+            and not collected.exact_read_failed
+        )
+        priority_rows.append(
+            {
+                "priority": priority,
+                "source_count": len(sources),
+                "complete_count": complete_count,
+                "exact_read_incomplete_count": exact_read_incomplete_count,
+                "status_counts": status_counts,
+            }
+        )
+        if priority == "p0":
+            incomplete_required_source_ids.extend(
+                collected.source.source_id
+                for collected in sources
+                if collected.scan.status not in {"completed", "no_change"}
+                or collected.exact_read_failed
+            )
+
+    incomplete_required_source_ids.sort()
+    return {
+        "schema_version": DECISION_SOURCE_COVERAGE_SCHEMA_VERSION,
+        "required_priority": "p0",
+        "status": (
+            "complete" if not incomplete_required_source_ids else "incomplete"
+        ),
+        "complete": not incomplete_required_source_ids,
+        "incomplete_required_source_ids": incomplete_required_source_ids,
+        "priority_rows": priority_rows,
+        "fail_open_preserved": True,
+        "raw_context_captured": False,
+        "private_locators_captured": False,
+    }
 
 
 def _unavailable_source_scan(
@@ -724,6 +786,7 @@ def assemble_decision_evidence(
         "visibility": "public_safe",
         "source_manifest": manifest,
         "source_scan_receipts": source_scan_receipts,
+        "source_coverage": _source_coverage(collected_sources),
         "context_retrieval_receipt": retrieval_receipt,
         "evidence_packet": evidence,
         "cursor_checkpoint": checkpoint,

--- a/tests/capabilities/test_decision_context_assembler.py
+++ b/tests/capabilities/test_decision_context_assembler.py
@@ -209,6 +209,12 @@ def test_assembler_rebases_authority_recall_and_cursor_without_raw_capture() -> 
     serialized = json.dumps(packet, sort_keys=True)
 
     assert packet["schema_version"] == "decision_context_assembly_v0"
+    assert packet["source_coverage"]["schema_version"] == (
+        "decision_source_coverage_v0"
+    )
+    assert packet["source_coverage"]["status"] == "complete"
+    assert packet["source_coverage"]["complete"] is True
+    assert packet["source_coverage"]["incomplete_required_source_ids"] == []
     assert (
         packet["evidence_packet"]["recalled_claims"][0]["exact_read_verified"] is True
     )
@@ -314,6 +320,23 @@ def test_source_failure_fails_open_and_preserves_cursor() -> None:
     serialized = json.dumps(packet, sort_keys=True)
 
     assert packet["source_scan_receipts"][0]["status"] == "unavailable"
+    assert packet["source_coverage"]["status"] == "incomplete"
+    assert packet["source_coverage"]["complete"] is False
+    assert packet["source_coverage"]["incomplete_required_source_ids"] == [
+        "source:owner"
+    ]
+    assert packet["source_coverage"]["priority_rows"][0] == {
+        "priority": "p0",
+        "source_count": 1,
+        "complete_count": 0,
+        "exact_read_incomplete_count": 0,
+        "status_counts": {
+            "completed": 0,
+            "no_change": 0,
+            "failed": 0,
+            "unavailable": 1,
+        },
+    }
     assert packet["context_retrieval_receipt"]["status"] == "unavailable"
     assert packet["cursor_checkpoint"]["sources"][0]["disposition"] == "preserve"
     assert assembly.proposed_cursors == {}
@@ -416,6 +439,10 @@ def test_exact_read_failure_does_not_advance_cursor() -> None:
     packet = assembly.public_packet()
     assert packet["source_scan_receipts"][0]["changed_count"] == 1
     assert packet["source_scan_receipts"][0]["exact_read_count"] == 0
+    assert packet["source_coverage"]["status"] == "incomplete"
+    assert packet["source_coverage"]["priority_rows"][0][
+        "exact_read_incomplete_count"
+    ] == 1
     assert packet["cursor_checkpoint"]["sources"][0]["disposition"] == "preserve"
     assert assembly.proposed_cursors == {}
 
@@ -434,6 +461,7 @@ def test_no_change_scan_can_checkpoint_after_validated_writeback() -> None:
 
     packet = assembly.public_packet()
     assert packet["source_scan_receipts"][0]["status"] == "no_change"
+    assert packet["source_coverage"]["status"] == "complete"
     assert packet["cursor_checkpoint"]["sources"][0]["disposition"] == (
         "ready_after_writeback"
     )


### PR DESCRIPTION
## Summary
- emit a public-safe `decision_source_coverage_v0` receipt from Decision Context assembly
- report per-priority scan status, exact-read incompleteness, and uncovered P0 source IDs
- document that fail-open preserves lifecycle progress but cannot be presented as complete context coverage

## Validation
- `python -m pytest tests/capabilities/test_decision_context_assembler.py tests/capabilities/test_decision_context_packets.py tests/capabilities/test_decision_context_sources.py tests/capabilities/test_decision_context_profile.py tests/capabilities/test_decision_context_outcome_feedback.py tests/capabilities/test_decision_context_runtime.py -q` (66 passed)
- `uvx ruff check --ignore BLE001 ...`
- `python -m compileall -q ...`
- `loopx canary premerge --from-git-diff` (17 selected checks passed; public boundary passed)
- `git diff --check`

## Boundary
The change is provider-neutral and default-off. No private source names, locators, chat content, credentials, or local paths are included.