### PR TITLE
refactor(quota): centralize command validation

### DIFF
--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -67,6 +67,29 @@ QUOTA_DETAIL_SECTIONS = (
 )
 
 
+def _validate_quota_command_request(args: argparse.Namespace) -> None:
+    command = args.quota_command
+    if command not in {"status", "plan"} and not args.goal_id:
+        raise ValueError(f"`loopx quota {command}` requires --goal-id")
+    scheduler_commands = {
+        "scheduler-ack",
+        "scheduler-ack-current",
+        "scheduler-fail-current",
+    }
+    if command in scheduler_commands and not args.agent_id:
+        raise ValueError(f"`loopx quota {command}` requires --agent-id")
+    if command == "void-slot" and not args.void_generated_at:
+        raise ValueError("`loopx quota void-slot` requires --void-generated-at")
+    if (
+        command not in {"status", "plan", "should-run"}
+        and args.dry_run
+        and args.execute
+    ):
+        raise ValueError(
+            f"`loopx quota {command}` accepts only one of --dry-run or --execute"
+        )
+
+
 def _quota_detail_sections_from_args(args: argparse.Namespace) -> frozenset[str]:
     sections = set(getattr(args, "include_details", None) or ())
     if bool(getattr(args, "include_scheduler_detail", False)):
@@ -515,9 +538,8 @@ def handle_quota_command(
             "scheduler-fail-current",
         }:
             scheduler_context = _scheduler_execution_context_from_args(args)
+        _validate_quota_command_request(args)
         if args.quota_command == "should-run":
-            if not args.goal_id:
-                raise ValueError("`loopx quota should-run` requires --goal-id")
             payload = build_live_quota_should_run_decision(
                 status_payload,
                 goal_id=args.goal_id,
@@ -610,10 +632,6 @@ def handle_quota_command(
                         heartbeat_stall_observation = "not_applicable"
                     heartbeat_receipt_ready = True
         elif args.quota_command == "monitor-poll":
-            if not args.goal_id:
-                raise ValueError("`loopx quota monitor-poll` requires --goal-id")
-            if args.dry_run and args.execute:
-                raise ValueError("`loopx quota monitor-poll` accepts only one of --dry-run or --execute")
             payload = record_quota_monitor_poll(
                 status_payload,
                 goal_id=args.goal_id,
@@ -645,12 +663,6 @@ def handle_quota_command(
                 ),
             )
         elif args.quota_command in {"scheduler-ack", "scheduler-ack-current"}:
-            if not args.goal_id:
-                raise ValueError(f"`loopx quota {args.quota_command}` requires --goal-id")
-            if not args.agent_id:
-                raise ValueError(f"`loopx quota {args.quota_command}` requires --agent-id")
-            if args.dry_run and args.execute:
-                raise ValueError(f"`loopx quota {args.quota_command}` accepts only one of --dry-run or --execute")
             payload = record_quota_scheduler_ack(
                 status_payload,
                 goal_id=args.goal_id,
@@ -669,12 +681,6 @@ def handle_quota_command(
                 operator_inbox_urgency_projector=operator_inbox_urgency_projector,
             )
         elif args.quota_command == "scheduler-fail-current":
-            if not args.goal_id:
-                raise ValueError("`loopx quota scheduler-fail-current` requires --goal-id")
-            if not args.agent_id:
-                raise ValueError("`loopx quota scheduler-fail-current` requires --agent-id")
-            if args.dry_run and args.execute:
-                raise ValueError("`loopx quota scheduler-fail-current` accepts only one of --dry-run or --execute")
             observed_rrule = str(args.codex_app_current_rrule or "").strip()
             if not observed_rrule:
                 host_observation = resolve_codex_app_automation_rrule(
@@ -705,10 +711,6 @@ def handle_quota_command(
                 failure_kind=args.failure_kind,
             )
         elif args.quota_command == "spend-slot":
-            if not args.goal_id:
-                raise ValueError("`loopx quota spend-slot` requires --goal-id")
-            if args.dry_run and args.execute:
-                raise ValueError("`loopx quota spend-slot` accepts only one of --dry-run or --execute")
             payload = spend_quota_slot(
                 status_payload,
                 goal_id=args.goal_id,
@@ -720,12 +722,6 @@ def handle_quota_command(
                 operator_inbox_urgency_projector=operator_inbox_urgency_projector,
             )
         elif args.quota_command == "void-slot":
-            if not args.goal_id:
-                raise ValueError("`loopx quota void-slot` requires --goal-id")
-            if not args.void_generated_at:
-                raise ValueError("`loopx quota void-slot` requires --void-generated-at")
-            if args.dry_run and args.execute:
-                raise ValueError("`loopx quota void-slot` accepts only one of --dry-run or --execute")
             payload = void_quota_slot(
                 status_payload,
                 goal_id=args.goal_id,

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -5,6 +5,7 @@ import json
 import pytest
 
 from loopx.cli import build_parser, main, output_format, resolve_global_output_format
+from loopx.cli_commands.quota import _validate_quota_command_request
 
 
 @pytest.mark.parametrize(
@@ -81,6 +82,77 @@ def test_deprecated_scheduler_detail_alias_is_hidden_from_help(
     help_text = capsys.readouterr().out
     assert "--include-detail" in help_text
     assert "--include-scheduler-detail" not in help_text
+
+
+@pytest.mark.parametrize(
+    (
+        "command",
+        "goal_id",
+        "agent_id",
+        "void_generated_at",
+        "dry_run",
+        "execute",
+        "expected",
+    ),
+    [
+        (
+            "should-run",
+            None,
+            None,
+            None,
+            False,
+            False,
+            "`loopx quota should-run` requires --goal-id",
+        ),
+        (
+            "scheduler-ack-current",
+            "goal",
+            None,
+            None,
+            False,
+            False,
+            "`loopx quota scheduler-ack-current` requires --agent-id",
+        ),
+        (
+            "spend-slot",
+            "goal",
+            None,
+            None,
+            True,
+            True,
+            "`loopx quota spend-slot` accepts only one of --dry-run or --execute",
+        ),
+        (
+            "void-slot",
+            "goal",
+            None,
+            None,
+            True,
+            True,
+            "`loopx quota void-slot` requires --void-generated-at",
+        ),
+    ],
+)
+def test_quota_command_request_validation_preserves_exact_diagnostics(
+    command: str,
+    goal_id: str | None,
+    agent_id: str | None,
+    void_generated_at: str | None,
+    dry_run: bool,
+    execute: bool,
+    expected: str,
+) -> None:
+    args = build_parser().parse_args(["quota", command])
+    args.goal_id = goal_id
+    args.agent_id = agent_id
+    args.void_generated_at = void_generated_at
+    args.dry_run = dry_run
+    args.execute = execute
+
+    with pytest.raises(ValueError) as exc_info:
+        _validate_quota_command_request(args)
+
+    assert str(exc_info.value) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- centralize quota command request validation in one quota-owned helper
- preserve the existing diagnostics and validation order for goal, agent, void timestamp, and execution-mode checks
- add focused negative-path coverage for representative command classes

## Motivation and design

`handle_quota_command` repeated the same request invariants across six dispatch branches. The extraction keeps those rules beside the quota command owner and leaves dispatch direct; it does not introduce a generic command-validation framework.

The outer handler drops from 148 to 121 statements and from 100 to 81 decision points. Its function span drops by 27 lines, and the production module is four lines smaller overall.

## Validation

- `ruff check` on both changed Python files
- `mypy`
- full pytest suite: 1,701 passed, 2 skipped
- focused monitor writeback, scheduler acknowledgement, heartbeat quota-flow, CLI output-budget, and maintainability smokes
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 17 selected checks passed, no failures or manual holds
- strict exact-diff change-quality receipt verified

No generated logs, credentials, private state, or local paths are included.
