### PR TITLE
refactor(todo): centralize claim option validation

### DIFF
--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -29,6 +29,7 @@ from .todo_argument_validation import (
     validate_capability_gap_options,
     validate_shared_todo_options,
     validate_successor_routing_options,
+    validate_todo_claim_options,
 )
 from .todo_event import RolloutEventAppender, append_todo_rollout_event
 
@@ -478,69 +479,7 @@ def handle_todo_command(
                 dry_run=bool(args.dry_run),
             )
         elif args.todo_command == "claim":
-            if not args.todo_id:
-                raise ValueError("todo claim requires --todo-id")
-            if not args.claimed_by:
-                raise ValueError("todo claim requires --claimed-by")
-            if args.clear_claim:
-                raise ValueError("todo claim requires --claimed-by and does not support --clear-claim")
-            unsupported = [
-                flag
-                for flag, value in (
-                    ("--text", args.text),
-                    ("--status", args.status),
-                    ("--note", args.note),
-                    ("--evidence", args.evidence),
-                    ("--reason", args.reason),
-                    ("--task-class", args.task_class),
-                    ("--action-kind", args.action_kind),
-                    ("--task-repository", args.task_repository),
-                    ("--continuation-policy", args.continuation_policy),
-                    ("--required-write-scope", args.required_write_scopes),
-                    ("--required-capability", args.required_capabilities),
-                    ("--target-capability", args.target_capabilities),
-                    ("--explore-result-node-ref", args.explore_result_node_refs),
-                    ("--clear-explore-result-node-refs", args.clear_explore_result_node_refs),
-                    ("--decision-scope", args.decision_scope),
-                    ("--required-decision-scope", args.required_decision_scopes),
-                    ("--decision-outcome", args.decision_outcome),
-                    ("--bound-agent", args.bound_agent),
-                    ("--goal-bound", args.goal_bound),
-                    ("--blocks-agent", args.blocks_agent),
-                    ("--clear-blocks-agent", args.clear_blocks_agent),
-                    ("--excluded-agent", args.excluded_agents),
-                    ("--clear-excluded-agents", args.clear_excluded_agents),
-                    ("--global-gate", args.global_gate),
-                    ("--clear-global-gate", args.clear_global_gate),
-                    ("--unblocks-todo-id", args.unblocks_todo_id),
-                    ("--successor-todo-id", args.successor_todo_ids),
-                    ("--resume-when", args.resume_when),
-                    ("--target-key", args.monitor_target_key),
-                    ("--cadence", args.cadence),
-                    ("--next-due-at", args.next_due_at),
-                    ("--expires-at", args.expires_at),
-                    ("--no-follow-up", args.no_follow_up),
-                    ("--next-agent-todo", args.next_agent_todo),
-                    ("--next-user-todo", args.next_user_todo),
-                    ("--next-user-task-class", args.next_user_task_class),
-                    ("--next-claimed-by", args.next_claimed_by),
-                    ("--next-task-class", args.next_task_class),
-                    ("--next-action-kind", args.next_action_kind),
-                    ("--next-task-repository", args.next_task_repository),
-                    ("--next-required-capability", args.next_required_capabilities),
-                    ("--next-continuation-policy", args.next_continuation_policy),
-                    ("--next-excluded-agent", args.next_excluded_agents),
-                    ("--self-merged", args.self_merged),
-                    ("--follow-up", args.followups),
-                )
-                if value
-            ]
-            if unsupported:
-                raise ValueError(
-                    "todo claim only accepts --todo-id, --claimed-by, --agent-id, optional --role, "
-                    "--project, --state-file, and --dry-run; unsupported: "
-                    + ", ".join(unsupported)
-                )
+            validate_todo_claim_options(args)
             payload = update_goal_todo(
                 registry_path=registry_path,
                 goal_id=args.goal_id,

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -28,6 +28,7 @@ TODO_OPTION_FIELDS = (
     ("--clear-explore-result-node-refs", "clear_explore_result_node_refs"),
     ("--decision-scope", "decision_scope"),
     ("--required-decision-scope", "required_decision_scopes"),
+    ("--decision-outcome", "decision_outcome"),
     ("--claimed-by", "claimed_by"),
     ("--bound-agent", "bound_agent"),
     ("--goal-bound", "goal_bound"),
@@ -196,6 +197,27 @@ def unsupported_todo_options(
         for flag, field in TODO_OPTION_FIELDS
         if field not in allowed and getattr(args, field, None)
     ]
+
+
+def validate_todo_claim_options(args: argparse.Namespace) -> None:
+    if not args.todo_id:
+        raise ValueError("todo claim requires --todo-id")
+    if not args.claimed_by:
+        raise ValueError("todo claim requires --claimed-by")
+    if args.clear_claim:
+        raise ValueError(
+            "todo claim requires --claimed-by and does not support --clear-claim"
+        )
+    unsupported = unsupported_todo_options(
+        args,
+        allowed_fields={"role", "todo_id", "claimed_by", "agent_id", "state_file"},
+    )
+    if unsupported:
+        raise ValueError(
+            "todo claim only accepts --todo-id, --claimed-by, --agent-id, optional --role, "
+            "--project, --state-file, and --dry-run; unsupported: "
+            + ", ".join(unsupported)
+        )
 
 
 def validate_shared_todo_options(args: argparse.Namespace) -> None:

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -6,6 +6,7 @@ import pytest
 
 from loopx.cli import build_parser, main, output_format, resolve_global_output_format
 from loopx.cli_commands.quota import _validate_quota_command_request
+from loopx.cli_commands.todo_argument_validation import validate_todo_claim_options
 
 
 @pytest.mark.parametrize(
@@ -151,6 +152,55 @@ def test_quota_command_request_validation_preserves_exact_diagnostics(
 
     with pytest.raises(ValueError) as exc_info:
         _validate_quota_command_request(args)
+
+    assert str(exc_info.value) == expected
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected"),
+    [
+        ([], "todo claim requires --todo-id"),
+        (
+            ["--todo-id", "todo_example"],
+            "todo claim requires --claimed-by",
+        ),
+        (
+            [
+                "--todo-id",
+                "todo_example",
+                "--claimed-by",
+                "codex-example",
+                "--clear-claim",
+            ],
+            "todo claim requires --claimed-by and does not support --clear-claim",
+        ),
+        (
+            [
+                "--todo-id",
+                "todo_example",
+                "--claimed-by",
+                "codex-example",
+                "--decision-outcome",
+                "approve",
+                "--next-agent-todo",
+                "Continue the work.",
+            ],
+            "todo claim only accepts --todo-id, --claimed-by, --agent-id, optional --role, "
+            "--project, --state-file, and --dry-run; unsupported: "
+            "--decision-outcome, --next-agent-todo",
+        ),
+    ],
+)
+def test_todo_claim_validation_preserves_exact_diagnostics(
+    extra_args: list[str],
+    expected: str,
+) -> None:
+    args = build_parser().parse_args(
+        ["todo", "claim", "--goal-id", "example-goal", *extra_args]
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_todo_claim_options(args)
 
     assert str(exc_info.value) == expected
 


### PR DESCRIPTION
## Summary

- reuse the shared `TODO_OPTION_FIELDS` / `unsupported_todo_options` contract for `todo claim`
- move claim-specific requirements and diagnostics into the existing argument-validation owner
- add exact diagnostic coverage for required and unsupported claim options

## Simplification

- `handle_todo_command`: 177 to 169 statements, 153 to 147 decisions, 557 to 495 lines
- `todo.py` + `todo_argument_validation.py`: 1,235 to 1,196 production lines
- no new public option, state, or compatibility layer

## Validation

- 97 todo and CLI diagnostic pytest tests
- todo CLI, lifecycle, and capture-followups smokes
- CLI output budget regression smoke
- ruff, mypy, maintainability ratchet, public-boundary scan, and `git diff --check`
- premerge gate: 17/17 selected checks passed, no failures, skips, warnings, or manual holds
- exact change-quality receipt: `cqr_49a335de9f0cef082849`
