### PR TITLE
refactor(todo): centralize update option validation

### DIFF
--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -30,6 +30,7 @@ from .todo_argument_validation import (
     validate_shared_todo_options,
     validate_successor_routing_options,
     validate_todo_claim_options,
+    validate_todo_update_options,
 )
 from .todo_event import RolloutEventAppender, append_todo_rollout_event
 
@@ -493,75 +494,7 @@ def handle_todo_command(
                 dry_run=bool(args.dry_run),
             )
         elif args.todo_command == "update":
-            if not args.todo_id:
-                raise ValueError("todo update requires --todo-id")
-            if args.claimed_by and args.clear_claim:
-                raise ValueError("todo update accepts either --claimed-by or --clear-claim, not both")
-            if args.explore_result_node_refs and args.clear_explore_result_node_refs:
-                raise ValueError(
-                    "todo update accepts either --explore-result-node-ref or "
-                    "--clear-explore-result-node-refs, not both"
-                )
-            if not any([
-                args.text,
-                args.followups,
-                args.status,
-                args.note,
-                args.evidence,
-                args.reason,
-                args.task_class,
-                args.action_kind,
-                args.task_repository,
-                args.continuation_policy,
-                args.required_write_scopes,
-                args.required_capabilities,
-                args.target_capabilities,
-                args.capability_gap_status,
-                args.explore_result_node_refs,
-                args.clear_explore_result_node_refs,
-                args.decision_scope,
-                args.required_decision_scopes,
-                args.claimed_by,
-                args.bound_agent,
-                args.goal_bound,
-                args.blocks_agent,
-                args.clear_blocks_agent,
-                args.excluded_agents,
-                args.clear_excluded_agents,
-                args.global_gate,
-                args.clear_global_gate,
-                args.unblocks_todo_id,
-                args.successor_todo_ids,
-                args.resume_when,
-                args.clear_resume_when,
-                args.no_follow_up,
-                args.monitor_target_key,
-                args.cadence,
-                args.next_due_at,
-                args.expires_at,
-                args.clear_claim,
-            ]):
-                raise ValueError("todo update requires at least one mutable todo field")
-            if args.no_follow_up and not (args.note or args.reason or args.evidence):
-                raise ValueError("--no-follow-up requires --note, --reason, or --evidence")
-            if args.decision_outcome:
-                raise ValueError(
-                    "todo update does not accept --decision-outcome; use todo complete"
-                )
-            if args.followups:
-                raise ValueError("todo update does not support --follow-up; use `todo capture-followups`")
-            if args.next_claimed_by:
-                raise ValueError("todo update does not support --next-claimed-by")
-            if args.next_task_repository:
-                raise ValueError("todo update does not support --next-task-repository")
-            if args.next_required_capabilities:
-                raise ValueError("todo update does not support --next-required-capability")
-            if args.next_continuation_policy:
-                raise ValueError("todo update does not support --next-continuation-policy")
-            if args.next_excluded_agents:
-                raise ValueError("todo update does not support --next-excluded-agent")
-            if args.self_merged:
-                raise ValueError("todo update does not support --self-merged")
+            validate_todo_update_options(args)
             payload = update_goal_todo(
                 registry_path=registry_path,
                 goal_id=args.goal_id,

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -67,6 +67,44 @@ TODO_OPTION_FIELDS = (
     ("--execute", "execute"),
 )
 
+_TODO_UPDATE_MUTABLE_FIELDS = (
+    "text", "followups", "status", "note", "evidence", "reason", "task_class",
+    "action_kind", "task_repository", "continuation_policy", "required_write_scopes",
+    "required_capabilities", "target_capabilities", "capability_gap_status",
+    "explore_result_node_refs", "clear_explore_result_node_refs", "decision_scope",
+    "required_decision_scopes", "claimed_by", "bound_agent", "goal_bound",
+    "blocks_agent", "clear_blocks_agent", "excluded_agents", "clear_excluded_agents",
+    "global_gate", "clear_global_gate", "unblocks_todo_id", "successor_todo_ids",
+    "resume_when", "clear_resume_when", "no_follow_up", "monitor_target_key",
+    "cadence", "next_due_at", "expires_at", "clear_claim",
+)
+
+_TODO_UPDATE_UNSUPPORTED_FIELDS = (
+    (
+        "decision_outcome",
+        "todo update does not accept --decision-outcome; use todo complete",
+    ),
+    (
+        "followups",
+        "todo update does not support --follow-up; use `todo capture-followups`",
+    ),
+    ("next_claimed_by", "todo update does not support --next-claimed-by"),
+    (
+        "next_task_repository",
+        "todo update does not support --next-task-repository",
+    ),
+    (
+        "next_required_capabilities",
+        "todo update does not support --next-required-capability",
+    ),
+    (
+        "next_continuation_policy",
+        "todo update does not support --next-continuation-policy",
+    ),
+    ("next_excluded_agents", "todo update does not support --next-excluded-agent"),
+    ("self_merged", "todo update does not support --self-merged"),
+)
+
 
 def register_todo_linkage_arguments(
     todo_parser: argparse.ArgumentParser,
@@ -218,6 +256,27 @@ def validate_todo_claim_options(args: argparse.Namespace) -> None:
             "--project, --state-file, and --dry-run; unsupported: "
             + ", ".join(unsupported)
         )
+
+
+def validate_todo_update_options(args: argparse.Namespace) -> None:
+    if not args.todo_id:
+        raise ValueError("todo update requires --todo-id")
+    if args.claimed_by and args.clear_claim:
+        raise ValueError(
+            "todo update accepts either --claimed-by or --clear-claim, not both"
+        )
+    if args.explore_result_node_refs and args.clear_explore_result_node_refs:
+        raise ValueError(
+            "todo update accepts either --explore-result-node-ref or "
+            "--clear-explore-result-node-refs, not both"
+        )
+    if not any(getattr(args, field) for field in _TODO_UPDATE_MUTABLE_FIELDS):
+        raise ValueError("todo update requires at least one mutable todo field")
+    if args.no_follow_up and not (args.note or args.reason or args.evidence):
+        raise ValueError("--no-follow-up requires --note, --reason, or --evidence")
+    for field, message in _TODO_UPDATE_UNSUPPORTED_FIELDS:
+        if getattr(args, field):
+            raise ValueError(message)
 
 
 def validate_shared_todo_options(args: argparse.Namespace) -> None:

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -6,7 +6,10 @@ import pytest
 
 from loopx.cli import build_parser, main, output_format, resolve_global_output_format
 from loopx.cli_commands.quota import _validate_quota_command_request
-from loopx.cli_commands.todo_argument_validation import validate_todo_claim_options
+from loopx.cli_commands.todo_argument_validation import (
+    validate_todo_claim_options,
+    validate_todo_update_options,
+)
 
 
 @pytest.mark.parametrize(
@@ -203,6 +206,96 @@ def test_todo_claim_validation_preserves_exact_diagnostics(
         validate_todo_claim_options(args)
 
     assert str(exc_info.value) == expected
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected"),
+    [
+        ([], "todo update requires --todo-id"),
+        (
+            [
+                "--todo-id",
+                "todo_example",
+                "--claimed-by",
+                "codex-example",
+                "--clear-claim",
+            ],
+            "todo update accepts either --claimed-by or --clear-claim, not both",
+        ),
+        (
+            ["--todo-id", "todo_example"],
+            "todo update requires at least one mutable todo field",
+        ),
+        (
+            [
+                "--todo-id",
+                "todo_example",
+                "--no-follow-up",
+            ],
+            "--no-follow-up requires --note, --reason, or --evidence",
+        ),
+        (
+            [
+                "--todo-id",
+                "todo_example",
+                "--note",
+                "validated",
+                "--decision-outcome",
+                "approve",
+            ],
+            "todo update does not accept --decision-outcome; use todo complete",
+        ),
+        (
+            [
+                "--todo-id",
+                "todo_example",
+                "--next-required-capability",
+                "network",
+            ],
+            "todo update requires at least one mutable todo field",
+        ),
+        (
+            [
+                "--todo-id",
+                "todo_example",
+                "--note",
+                "validated",
+                "--next-required-capability",
+                "network",
+            ],
+            "todo update does not support --next-required-capability",
+        ),
+    ],
+)
+def test_todo_update_validation_preserves_exact_diagnostics(
+    extra_args: list[str],
+    expected: str,
+) -> None:
+    args = build_parser().parse_args(
+        ["todo", "update", "--goal-id", "example-goal", *extra_args]
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_todo_update_options(args)
+
+    assert str(exc_info.value) == expected
+
+
+def test_todo_update_validation_accepts_a_mutable_field() -> None:
+    args = build_parser().parse_args(
+        [
+            "todo",
+            "update",
+            "--goal-id",
+            "example-goal",
+            "--todo-id",
+            "todo_example",
+            "--note",
+            "validated",
+        ]
+    )
+
+    validate_todo_update_options(args)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- move `todo update` argument validation into the existing todo validation owner
- preserve exact diagnostics and option precedence with focused contract tests
- reduce `handle_todo_command` from 169 to 144 statements, 147 to 129 decisions, and 495 to 427 lines
- reduce combined `todo.py` plus `todo_argument_validation.py` production size from 1,196 to 1,188 lines

## Validation

- `python -m pytest -q tests/control_plane/test_todo*.py tests/test_cli_argument_diagnostics.py` (105 passed)
- todo CLI, lifecycle, and follow-up capture smokes
- CLI output budget regression smoke
- Ruff checks on changed files
- MyPy
- control-plane maintainability ratchet
- `loopx check` public/private boundary scan
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` (17/17)
- exact change-quality receipt `cqr_13b234343ea949cae8a9`
