### PR TITLE
feat(issue-fix): project change-quality gate in workflow-plan

### DIFF
--- a/loopx/capabilities/issue_fix/workflow_plan.py
+++ b/loopx/capabilities/issue_fix/workflow_plan.py
@@ -15,6 +15,16 @@ from .repository_context import (
 )
 
 ISSUE_FIX_WORKFLOW_PLAN_PACKET_SCHEMA_VERSION = "issue_fix_workflow_plan_packet_v0"
+ISSUE_FIX_QUALITY_GATE_PLAN_SCHEMA_VERSION = "issue_fix_quality_gate_plan_v0"
+ISSUE_FIX_QUALITY_GATE_ACTION_KIND = "issue_fix_pre_pr_quality_gate"
+_ISSUE_FIX_QUALITY_GATE_PREPARE_COMMAND = (
+    "loopx change-quality prepare --goal-id <goal-id> "
+    "--repo-path <worktree> --base-ref origin/main --format json"
+)
+_ISSUE_FIX_QUALITY_GATE_RECORD_COMMAND = (
+    "loopx change-quality record --goal-id <goal-id> "
+    "--repo-path <worktree> --result-json <result.json> --format json"
+)
 ISSUE_FIX_GOAL_CANDIDATE_DISCOVERY_COMMAND_TEMPLATE = (
     "gh issue list --repo "
     '"$(gh repo view --json nameWithOwner --jq .nameWithOwner)" '
@@ -191,6 +201,72 @@ def _resolution_route_candidates(
             ),
         },
     ]
+
+
+def _quality_gate_plan(
+    *,
+    repo_label: str,
+    issue_label: str,
+    enabled: bool,
+) -> dict[str, Any]:
+    """Project a typed pre-PR quality gate checkpoint.
+
+    This is a contract-only projection: it never reads a registry, never calls
+    ``loopx change-quality``, and never runs git diffs.  It only describes the
+    command shape and todo preview that a downstream executor may use after it
+    has independently confirmed change-quality policy for a specific goal and
+    worktree.
+
+    Two states:
+
+    * ``not_configured`` — default callers without a runnable proceed candidate
+      see an empty gate and no new todo.
+    * ``projected`` — an admitted proceed candidate projects a P1 todo preview,
+      prepare/record command previews, and a scope-fingerprint requirement.
+
+    ``completed`` is intentionally absent from this preview-only builder; the
+    real gate is advanced by a downstream executor that owns the change-quality
+    receipt.
+    """
+    base = {
+        "schema_version": ISSUE_FIX_QUALITY_GATE_PLAN_SCHEMA_VERSION,
+        "external_writes_performed": False,
+        "registry_read_performed": False,
+    }
+    if not enabled:
+        return {
+            **base,
+            "status": "not_configured",
+            "gate_required": False,
+            "todo_preview": None,
+            "command_preview": None,
+            "quality_policy_projected": False,
+        }
+    todo_preview = _todo_preview(
+        planner_order=0,
+        role="agent",
+        priority="P1",
+        task_class="advancement_task",
+        action_kind=ISSUE_FIX_QUALITY_GATE_ACTION_KIND,
+        text=(
+            f"[P1] Run change-quality prepare for {repo_label} {issue_label} "
+            "on the final diff before opening the PR; review reuse and "
+            "simplification findings, record the receipt, and only proceed "
+            "when the scope fingerprint matches."
+        ),
+        depends_on=["issue_fix_validated_fix_artifact_v0"],
+        next_command_preview=_ISSUE_FIX_QUALITY_GATE_PREPARE_COMMAND,
+    )
+    return {
+        **base,
+        "status": "projected",
+        "gate_required": True,
+        "todo_preview": todo_preview,
+        "command_preview": _ISSUE_FIX_QUALITY_GATE_PREPARE_COMMAND,
+        "result_record_command_preview": _ISSUE_FIX_QUALITY_GATE_RECORD_COMMAND,
+        "quality_policy_projected": True,
+        "record_requires_matching_scope_fingerprint": True,
+    }
 
 
 def _post_pr_lifecycle_monitor_plan() -> dict[str, Any]:
@@ -557,6 +633,19 @@ def build_issue_fix_workflow_plan_packet(
     ]
     if branch_plan["status"] == "needs_approved_repo_context":
         readiness_blockers.insert(0, "approved_repo_context_missing")
+
+    quality_gate_enabled = (
+        preflight_decision.get("candidate_runnable") is True
+        and preflight_decision.get("route") == "proceed"
+    )
+    quality_gate = _quality_gate_plan(
+        repo_label=repo_label,
+        issue_label=issue_label,
+        enabled=bool(quality_gate_enabled),
+    )
+    if quality_gate_enabled:
+        readiness_blockers.append("quality_gate_not_run")
+
     review_packet_preview = {
         "schema_version": "issue_fix_pr_review_packet_v0",
         "ready": False,
@@ -672,7 +761,8 @@ def build_issue_fix_workflow_plan_packet(
         "agent_can_continue": True,
         "top_agent_todo": agent_todos[0],
         "top_gate": user_gates[0] if user_gates else None,
-        "next_safe_action": preflight_next_action or (
+        "next_safe_action": preflight_next_action
+        or (
             (
                 "inspect current repository evidence for "
                 f"{', '.join(unresolved_context)}; ground what is available and "
@@ -705,9 +795,7 @@ def build_issue_fix_workflow_plan_packet(
         "repository_context_input_contract": repository_context_input_contract(),
         "repository_context": repository_context,
         "candidate_preflight": candidate_preflight,
-        "candidate_fix_workflow_allowed": preflight_decision.get(
-            "candidate_runnable"
-        )
+        "candidate_fix_workflow_allowed": preflight_decision.get("candidate_runnable")
         is True,
         "first_screen": first_screen,
         "branch_plan": branch_plan,
@@ -716,6 +804,7 @@ def build_issue_fix_workflow_plan_packet(
         "post_pr_lifecycle_monitor_plan": post_pr_monitor,
         "ordered_loopx_todo_writeback_preview": ordered_previews,
         "validation_plan": validation_plan,
+        "quality_gate_plan": quality_gate,
         "review_packet_preview": review_packet_preview,
         "external_reads_performed": bool(
             metadata_packet["external_reads_performed"]
@@ -828,9 +917,13 @@ def validate_issue_fix_workflow_plan_packet(
             preflight_projection.get("schema_version")
             != "issue_fix_candidate_preflight_domain_state_projection_v0"
         ):
-            errors.append("candidate_preflight domain_state_projection has wrong schema")
+            errors.append(
+                "candidate_preflight domain_state_projection has wrong schema"
+            )
         if preflight_projection.get("stream") != "candidate-preflight":
-            errors.append("candidate_preflight domain_state_projection has wrong stream")
+            errors.append(
+                "candidate_preflight domain_state_projection has wrong stream"
+            )
         if preflight_projection.get("write_performed") is not False:
             errors.append(
                 "workflow-plan builder must leave candidate preflight write pending"
@@ -936,6 +1029,42 @@ def validate_issue_fix_workflow_plan_packet(
     if post_pr.get("raw_check_logs_captured") is not False:
         errors.append("post PR lifecycle plan must not capture raw check logs")
 
+    quality_gate = packet.get("quality_gate_plan")
+    if not isinstance(quality_gate, Mapping):
+        errors.append("quality_gate_plan is required")
+        quality_gate = {}
+    if quality_gate.get("schema_version") != (
+        ISSUE_FIX_QUALITY_GATE_PLAN_SCHEMA_VERSION
+    ):
+        errors.append("quality gate plan has wrong schema")
+    if quality_gate.get("status") not in {
+        "not_configured",
+        "projected",
+    }:
+        errors.append("quality gate plan has invalid status")
+    if quality_gate.get("external_writes_performed") is not False:
+        errors.append("quality gate plan must not perform external writes")
+    if quality_gate.get("registry_read_performed") is not False:
+        errors.append("quality gate plan must not read registry")
+    if quality_gate.get("status") == "projected":
+        if quality_gate.get("gate_required") is not True:
+            errors.append("projected quality gate must declare gate_required=True")
+        if quality_gate.get("todo_preview") is None:
+            errors.append("projected quality gate must include a todo preview")
+        if quality_gate.get("command_preview") is None:
+            errors.append("projected quality gate must include a command preview")
+        if quality_gate.get("record_requires_matching_scope_fingerprint") is not True:
+            errors.append(
+                "projected quality gate must require matching scope fingerprint"
+            )
+    elif quality_gate.get("status") == "not_configured":
+        if quality_gate.get("gate_required") is not False:
+            errors.append(
+                "not_configured quality gate must declare gate_required=False"
+            )
+        if quality_gate.get("todo_preview") is not None:
+            errors.append("not_configured quality gate must not include a todo preview")
+
     previews = packet.get("ordered_loopx_todo_writeback_preview")
     if not isinstance(previews, Sequence) or isinstance(previews, (str, bytes)):
         errors.append("ordered_loopx_todo_writeback_preview must be a list")
@@ -967,8 +1096,7 @@ def validate_issue_fix_workflow_plan_packet(
             "issue_fix_branch_validation",
         }
         if any(
-            isinstance(preview, Mapping)
-            and preview.get("action_kind") in forbidden
+            isinstance(preview, Mapping) and preview.get("action_kind") in forbidden
             for preview in previews
         ):
             errors.append("deduped candidate must not project new patch-planning todos")

--- a/tests/capabilities/test_issue_fix_quality_gate_projection.py
+++ b/tests/capabilities/test_issue_fix_quality_gate_projection.py
@@ -1,0 +1,138 @@
+"""Quality-gate projection in issue-fix workflow-plan.
+
+Four semantic scenarios:
+  1. Default packet — gate is not_configured, no blocker, validates clean.
+  2. Admitted + proceed candidate — gate is projected with side-effect-free
+     todo/command contract, blocker is added, validates clean.
+  3. Wrong schema version — validator rejects.
+  4. False side-effect claim (registry_read=True) — validator rejects.
+"""
+
+from __future__ import annotations
+
+from loopx.capabilities.issue_fix.candidate_evidence import (
+    build_public_github_candidate_preflight_input,
+)
+from loopx.capabilities.issue_fix.workflow_plan import (
+    ISSUE_FIX_QUALITY_GATE_PLAN_SCHEMA_VERSION,
+    build_issue_fix_workflow_plan_packet,
+    validate_issue_fix_workflow_plan_packet,
+)
+
+GENERATED_AT = "2026-07-30T12:00:00Z"
+REPO = "volcengine/OpenViking"
+ISSUE = "#3305"
+
+
+def _source_receipts() -> dict[str, dict[str, object]]:
+    return {
+        field: {
+            "provider": "github_graphql",
+            "observed_at": GENERATED_AT,
+            "query_fingerprint": f"sha256:{field}",
+            "page_count": 1,
+            "result_count": 0,
+            "complete": True,
+            "truncated": False,
+            "raw_provider_payload_captured": False,
+        }
+        for field in (
+            "numeric_pr_evidence",
+            "semantic_pr_evidence",
+            "maintainer_comment_evidence",
+        )
+    }
+
+
+def _admitted_proceed_preflight() -> dict[str, object]:
+    """Canonical preflight input → admitted + proceed (no manual override)."""
+    return build_public_github_candidate_preflight_input(
+        repo=REPO,
+        issue_ref=ISSUE,
+        issue_state="OPEN",
+        closing_pull_requests=[],
+        cross_referenced_pull_requests=[],
+        maintainer_comments=[],
+        generated_at=GENERATED_AT,
+        source_receipts=_source_receipts(),
+    )
+
+
+def _proceed_packet() -> dict[str, object]:
+    return build_issue_fix_workflow_plan_packet(
+        repo=REPO,
+        issue_ref=ISSUE,
+        candidate_preflight_input=_admitted_proceed_preflight(),
+    )
+
+
+def test_default_not_configured_no_blocker_valid() -> None:
+    packet = build_issue_fix_workflow_plan_packet()
+    gate = packet["quality_gate_plan"]
+    blockers = packet["review_packet_preview"]["readiness_blockers"]
+
+    assert gate["status"] == "not_configured"
+    assert gate["gate_required"] is False
+    assert gate["todo_preview"] is None
+    assert gate["command_preview"] is None
+    assert gate["registry_read_performed"] is False
+    assert gate["external_writes_performed"] is False
+    assert "quality_gate_not_run" not in blockers
+
+    v = validate_issue_fix_workflow_plan_packet(packet)
+    assert v["ok"] is True, v["errors"]
+
+
+def test_admitted_proceed_projects_side_effect_free_gate() -> None:
+    packet = _proceed_packet()
+    gate = packet["quality_gate_plan"]
+    blockers = packet["review_packet_preview"]["readiness_blockers"]
+    todo = gate["todo_preview"]
+
+    assert gate["status"] == "projected"
+    assert gate["gate_required"] is True
+    assert gate["schema_version"] == ISSUE_FIX_QUALITY_GATE_PLAN_SCHEMA_VERSION
+
+    assert todo is not None
+    assert todo["action_kind"] == "issue_fix_pre_pr_quality_gate"
+    assert todo["priority"] == "P1"
+    assert todo["would_write"] is False
+    assert todo["requires_execute_flag"] is True
+    assert "change-quality prepare" in todo["next_command_preview"]
+
+    assert "change-quality prepare" in gate["command_preview"]
+    assert gate["result_record_command_preview"] is not None
+    assert gate["record_requires_matching_scope_fingerprint"] is True
+
+    assert gate["registry_read_performed"] is False
+    assert gate["external_writes_performed"] is False
+
+    assert "quality_gate_not_run" in blockers
+
+    v = validate_issue_fix_workflow_plan_packet(packet)
+    assert v["ok"] is True, v["errors"]
+
+
+def test_wrong_schema_fails_validation() -> None:
+    packet = build_issue_fix_workflow_plan_packet()
+    broken = dict(packet)
+    broken["quality_gate_plan"] = dict(
+        packet["quality_gate_plan"],
+        schema_version="bogus_v99",
+    )
+    v = validate_issue_fix_workflow_plan_packet(broken)
+    assert v["ok"] is False
+    assert any("wrong schema" in e for e in v["errors"])
+
+
+def test_false_side_effect_claim_fails_validation() -> None:
+    """Validator must enforce that the plan never claims registry reads."""
+    packet = _proceed_packet()
+    broken = dict(packet)
+    broken["quality_gate_plan"] = dict(
+        packet["quality_gate_plan"],
+        registry_read_performed=True,
+    )
+    v = validate_issue_fix_workflow_plan_packet(broken)
+    assert v["ok"] is False
+    assert any("registry" in e for e in v["errors"])


### PR DESCRIPTION
## 动机

Issue-fix 工作流的 workflow-plan dry-run 目前不投影质量门禁，下游 executor 缺少 typed checkpoint contract。数字员工在 issue-to-PR 流程中需要一个结构化的 pre-PR quality gate 预览，以便在可行性决策时就知道后续有 change-quality 这一步。

## 改动思路

在 issue-fix workflow-plan packet 中新增 `quality_gate_plan` section，作为纯契约投影：
- 不读取 registry
- 不执行 change-quality
- 不运行 git diff

仅当 candidate 为 admitted + proceed 时投影：P1 todo preview、prepare/record command preview、scope fingerprint 要求。默认调用者看到 `not_configured`，不新增 todo 或 blocker。

## 关键代码

- `_quality_gate_plan()`：两个状态（`not_configured` / `projected`），共享同一组 side-effect-free 字段
- `build_issue_fix_workflow_plan_packet()`：基于 preflight decision 决定是否启用 gate
- `validate_issue_fix_workflow_plan_packet()`：校验 schema、状态耦合、无副作用声明

## 验证

```
tests/capabilities/test_issue_fix_quality_gate_projection.py — 4 passed
tests/capabilities/ -k issue_fix — 31 passed
git diff --check — 0 errors
ruff format — clean
change-quality simplify findings — 0
```

## 风险与未覆盖

- `completed` 状态未在 preview builder 中实现（由下游 executor 推进真实 gate）
- 仅投影契约，不包含真实 change-quality 执行集成（后续 checkpoint）

## 关联

Stage 3 — PR Issue-Fix Digital Employee quality dimension checkpoint.