### PR TITLE
refactor(todo): centralize complete option validation

### DIFF
--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -30,6 +30,7 @@ from .todo_argument_validation import (
     validate_shared_todo_options,
     validate_successor_routing_options,
     validate_todo_claim_options,
+    validate_todo_complete_options,
     validate_todo_update_options,
 )
 from .todo_event import RolloutEventAppender, append_todo_rollout_event
@@ -547,36 +548,7 @@ def handle_todo_command(
                 dry_run=bool(args.dry_run),
             )
         elif args.todo_command == "complete":
-            if not args.todo_id:
-                raise ValueError("todo complete requires --todo-id")
-            if args.explore_result_node_refs or args.clear_explore_result_node_refs:
-                raise ValueError(
-                    "todo complete does not update --explore-result-node-ref; use todo update first"
-                )
-            if args.claimed_by and args.clear_claim:
-                raise ValueError("todo complete accepts either --claimed-by or --clear-claim, not both")
-            if args.task_repository or args.bound_agent or args.goal_bound or args.blocks_agent or args.clear_blocks_agent or args.excluded_agents or args.clear_excluded_agents or args.global_gate or args.clear_global_gate or args.unblocks_todo_id or args.resume_when:
-                raise ValueError("todo complete does not update current todo routing metadata; use todo update first")
-            if args.monitor_target_key or args.cadence or args.next_due_at or args.expires_at:
-                raise ValueError(
-                    "todo complete does not update target or monitor schedule metadata; "
-                    "use todo update before completion"
-                )
-            if args.no_follow_up and (args.next_agent_todo or args.next_user_todo):
-                raise ValueError("--no-follow-up cannot be combined with successor todos")
-            if args.no_follow_up and args.successor_todo_ids:
-                raise ValueError("--no-follow-up cannot be combined with successor todos")
-            if args.successor_todo_ids and (args.next_agent_todo or args.next_user_todo):
-                raise ValueError("--successor-todo-id links existing work and cannot be combined with --next-agent-todo or --next-user-todo")
-            if args.no_follow_up and not (args.note or args.evidence):
-                raise ValueError("--no-follow-up requires --note or --evidence")
-            if args.followups:
-                raise ValueError("todo complete does not support --follow-up; use `todo capture-followups`")
-            if args.continuation_policy:
-                raise ValueError(
-                    "todo complete does not update --continuation-policy; use todo update first"
-                )
-            validate_successor_routing_options(args)
+            validate_todo_complete_options(args)
             payload = complete_goal_todo(
                 registry_path=registry_path,
                 goal_id=args.goal_id,

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -105,7 +105,6 @@ _TODO_UPDATE_UNSUPPORTED_FIELDS = (
     ("self_merged", "todo update does not support --self-merged"),
 )
 
-
 def register_todo_linkage_arguments(
     todo_parser: argparse.ArgumentParser,
 ) -> None:
@@ -277,6 +276,32 @@ def validate_todo_update_options(args: argparse.Namespace) -> None:
     for field, message in _TODO_UPDATE_UNSUPPORTED_FIELDS:
         if getattr(args, field):
             raise ValueError(message)
+
+
+def validate_todo_complete_options(args: argparse.Namespace) -> None:
+    if not args.todo_id:
+        raise ValueError("todo complete requires --todo-id")
+    if args.explore_result_node_refs or args.clear_explore_result_node_refs:
+        raise ValueError("todo complete does not update --explore-result-node-ref; use todo update first")
+    if args.claimed_by and args.clear_claim:
+        raise ValueError("todo complete accepts either --claimed-by or --clear-claim, not both")
+    if any(getattr(args, field) for field in ("task_repository", "bound_agent", "goal_bound", "blocks_agent", "clear_blocks_agent", "excluded_agents", "clear_excluded_agents", "global_gate", "clear_global_gate", "unblocks_todo_id", "resume_when")):
+        raise ValueError("todo complete does not update current todo routing metadata; use todo update first")
+    if any(getattr(args, field) for field in ("monitor_target_key", "cadence", "next_due_at", "expires_at")):
+        raise ValueError("todo complete does not update target or monitor schedule metadata; use todo update before completion")
+    if args.no_follow_up and (args.next_agent_todo or args.next_user_todo):
+        raise ValueError("--no-follow-up cannot be combined with successor todos")
+    if args.no_follow_up and args.successor_todo_ids:
+        raise ValueError("--no-follow-up cannot be combined with successor todos")
+    if args.successor_todo_ids and (args.next_agent_todo or args.next_user_todo):
+        raise ValueError("--successor-todo-id links existing work and cannot be combined with --next-agent-todo or --next-user-todo")
+    if args.no_follow_up and not (args.note or args.evidence):
+        raise ValueError("--no-follow-up requires --note or --evidence")
+    if args.followups:
+        raise ValueError("todo complete does not support --follow-up; use `todo capture-followups`")
+    if args.continuation_policy:
+        raise ValueError("todo complete does not update --continuation-policy; use todo update first")
+    validate_successor_routing_options(args)
 
 
 def validate_shared_todo_options(args: argparse.Namespace) -> None:

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -8,6 +8,7 @@ from loopx.cli import build_parser, main, output_format, resolve_global_output_f
 from loopx.cli_commands.quota import _validate_quota_command_request
 from loopx.cli_commands.todo_argument_validation import (
     validate_todo_claim_options,
+    validate_todo_complete_options,
     validate_todo_update_options,
 )
 
@@ -296,6 +297,104 @@ def test_todo_update_validation_accepts_a_mutable_field() -> None:
     )
 
     validate_todo_update_options(args)
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected"),
+    [
+        ([], "todo complete requires --todo-id"),
+        (
+            ["--todo-id", "todo_example", "--explore-result-node-ref", "result_1"],
+            "todo complete does not update --explore-result-node-ref; "
+            "use todo update first",
+        ),
+        (
+            [
+                "--todo-id",
+                "todo_example",
+                "--claimed-by",
+                "codex-example",
+                "--clear-claim",
+            ],
+            "todo complete accepts either --claimed-by or --clear-claim, not both",
+        ),
+        (
+            ["--todo-id", "todo_example", "--task-repository", "git:example/repo"],
+            "todo complete does not update current todo routing metadata; "
+            "use todo update first",
+        ),
+        (
+            ["--todo-id", "todo_example", "--cadence", "1h"],
+            "todo complete does not update target or monitor schedule metadata; "
+            "use todo update before completion",
+        ),
+        (
+            [
+                "--todo-id",
+                "todo_example",
+                "--no-follow-up",
+                "--next-agent-todo",
+                "Continue.",
+            ],
+            "--no-follow-up cannot be combined with successor todos",
+        ),
+        (
+            [
+                "--todo-id",
+                "todo_example",
+                "--successor-todo-id",
+                "todo_successor",
+                "--next-agent-todo",
+                "Continue.",
+            ],
+            "--successor-todo-id links existing work and cannot be combined with "
+            "--next-agent-todo or --next-user-todo",
+        ),
+        (
+            ["--todo-id", "todo_example", "--no-follow-up"],
+            "--no-follow-up requires --note or --evidence",
+        ),
+        (
+            ["--todo-id", "todo_example", "--continuation-policy", "same_agent_non_delivery"],
+            "todo complete does not update --continuation-policy; use todo update first",
+        ),
+        (
+            ["--todo-id", "todo_example", "--next-user-todo", "Approve."],
+            "--next-user-todo requires explicit --next-user-task-class "
+            "user_action|user_gate",
+        ),
+    ],
+)
+def test_todo_complete_validation_preserves_exact_diagnostics(
+    extra_args: list[str],
+    expected: str,
+) -> None:
+    args = build_parser().parse_args(
+        ["todo", "complete", "--goal-id", "example-goal", *extra_args]
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_todo_complete_options(args)
+
+    assert str(exc_info.value) == expected
+
+
+def test_todo_complete_validation_accepts_no_follow_up_with_evidence() -> None:
+    args = build_parser().parse_args(
+        [
+            "todo",
+            "complete",
+            "--goal-id",
+            "example-goal",
+            "--todo-id",
+            "todo_example",
+            "--no-follow-up",
+            "--evidence",
+            "validated",
+        ]
+    )
+
+    validate_todo_complete_options(args)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- move `todo complete` argument validation into the existing todo validation owner
- preserve exact diagnostics, validation ordering, and successor-routing checks with focused contract tests
- reduce `handle_todo_command` from 144 to 122 statements, 129 to 96 decisions, and 427 to 398 lines
- reduce combined `todo.py` plus `todo_argument_validation.py` production size from 1,188 to 1,185 lines

## Validation

- `python -m pytest -q tests/control_plane/test_todo*.py tests/test_cli_argument_diagnostics.py` (116 passed)
- todo CLI, lifecycle, and follow-up capture smokes
- CLI output budget regression smoke
- Ruff checks on changed files
- MyPy
- control-plane maintainability ratchet
- `loopx check` public/private boundary scan
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` (17/17)
- exact change-quality receipt `cqr_2c87ca8c7fccd86af2f4`
