### PR TITLE
refactor(todo): centralize supersede option validation

### DIFF
--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -28,9 +28,9 @@ from .todo_argument_validation import (
     unsupported_todo_options,
     validate_capability_gap_options,
     validate_shared_todo_options,
-    validate_successor_routing_options,
     validate_todo_claim_options,
     validate_todo_complete_options,
+    validate_todo_supersede_options,
     validate_todo_update_options,
 )
 from .todo_event import RolloutEventAppender, append_todo_rollout_event
@@ -579,44 +579,7 @@ def handle_todo_command(
                 dry_run=bool(args.dry_run),
             )
         elif args.todo_command == "supersede":
-            if not args.todo_id:
-                raise ValueError("todo supersede requires --todo-id")
-            if args.explore_result_node_refs or args.clear_explore_result_node_refs:
-                raise ValueError(
-                    "todo supersede does not update --explore-result-node-ref; use todo update first"
-                )
-            if args.decision_outcome:
-                raise ValueError(
-                    "todo supersede does not accept --decision-outcome; use todo complete"
-                )
-            if args.claimed_by:
-                raise ValueError(
-                    "todo supersede does not support --claimed-by; use --next-claimed-by "
-                    "to assign the successor, or omit it to inherit the superseded todo "
-                    "owner when present"
-                )
-            if args.clear_claim:
-                raise ValueError("todo supersede does not support --clear-claim")
-            if args.self_merged:
-                raise ValueError("todo supersede does not support --self-merged")
-            if args.no_follow_up:
-                raise ValueError("todo supersede does not support --no-follow-up")
-            if args.followups:
-                raise ValueError("todo supersede does not support --follow-up; use `todo capture-followups`")
-            if args.continuation_policy:
-                raise ValueError(
-                    "todo supersede does not update --continuation-policy; use todo update first"
-                )
-            validate_successor_routing_options(args)
-            if args.blocks_agent or args.clear_blocks_agent or args.excluded_agents or args.clear_excluded_agents or args.global_gate or args.clear_global_gate or args.unblocks_todo_id or args.resume_when:
-                raise ValueError("todo supersede does not update current todo routing metadata; use todo update first")
-            if args.successor_todo_ids:
-                raise ValueError("todo supersede does not support --successor-todo-id; use --next-agent-todo or update the source todo before supersede")
-            if args.monitor_target_key or args.cadence or args.next_due_at or args.expires_at:
-                raise ValueError(
-                    "todo supersede does not update target or monitor schedule metadata; "
-                    "use todo update before supersede"
-                )
+            validate_todo_supersede_options(args)
             payload = supersede_goal_todo(
                 registry_path=registry_path,
                 goal_id=args.goal_id,

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -304,6 +304,34 @@ def validate_todo_complete_options(args: argparse.Namespace) -> None:
     validate_successor_routing_options(args)
 
 
+def validate_todo_supersede_options(args: argparse.Namespace) -> None:
+    if not args.todo_id:
+        raise ValueError("todo supersede requires --todo-id")
+    if args.explore_result_node_refs or args.clear_explore_result_node_refs:
+        raise ValueError("todo supersede does not update --explore-result-node-ref; use todo update first")
+    if args.decision_outcome:
+        raise ValueError("todo supersede does not accept --decision-outcome; use todo complete")
+    if args.claimed_by:
+        raise ValueError("todo supersede does not support --claimed-by; use --next-claimed-by to assign the successor, or omit it to inherit the superseded todo owner when present")
+    if args.clear_claim:
+        raise ValueError("todo supersede does not support --clear-claim")
+    if args.self_merged:
+        raise ValueError("todo supersede does not support --self-merged")
+    if args.no_follow_up:
+        raise ValueError("todo supersede does not support --no-follow-up")
+    if args.followups:
+        raise ValueError("todo supersede does not support --follow-up; use `todo capture-followups`")
+    if args.continuation_policy:
+        raise ValueError("todo supersede does not update --continuation-policy; use todo update first")
+    validate_successor_routing_options(args)
+    if any(getattr(args, field) for field in ("blocks_agent", "clear_blocks_agent", "excluded_agents", "clear_excluded_agents", "global_gate", "clear_global_gate", "unblocks_todo_id", "resume_when")):
+        raise ValueError("todo supersede does not update current todo routing metadata; use todo update first")
+    if args.successor_todo_ids:
+        raise ValueError("todo supersede does not support --successor-todo-id; use --next-agent-todo or update the source todo before supersede")
+    if any(getattr(args, field) for field in ("monitor_target_key", "cadence", "next_due_at", "expires_at")):
+        raise ValueError("todo supersede does not update target or monitor schedule metadata; use todo update before supersede")
+
+
 def validate_shared_todo_options(args: argparse.Namespace) -> None:
     agent_id_allowed_for_user_authoring = (
         args.todo_command == "add"

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -9,6 +9,7 @@ from loopx.cli_commands.quota import _validate_quota_command_request
 from loopx.cli_commands.todo_argument_validation import (
     validate_todo_claim_options,
     validate_todo_complete_options,
+    validate_todo_supersede_options,
     validate_todo_update_options,
 )
 
@@ -395,6 +396,90 @@ def test_todo_complete_validation_accepts_no_follow_up_with_evidence() -> None:
     )
 
     validate_todo_complete_options(args)
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected"),
+    [
+        ([], "todo supersede requires --todo-id"),
+        (
+            ["--todo-id", "todo_example", "--explore-result-node-ref", "result_1"],
+            "todo supersede does not update --explore-result-node-ref; "
+            "use todo update first",
+        ),
+        (
+            ["--todo-id", "todo_example", "--decision-outcome", "approve"],
+            "todo supersede does not accept --decision-outcome; use todo complete",
+        ),
+        (
+            ["--todo-id", "todo_example", "--claimed-by", "codex-example"],
+            "todo supersede does not support --claimed-by; use --next-claimed-by "
+            "to assign the successor, or omit it to inherit the superseded todo "
+            "owner when present",
+        ),
+        (
+            ["--todo-id", "todo_example", "--self-merged"],
+            "todo supersede does not support --self-merged",
+        ),
+        (
+            ["--todo-id", "todo_example", "--no-follow-up"],
+            "todo supersede does not support --no-follow-up",
+        ),
+        (
+            ["--todo-id", "todo_example", "--continuation-policy", "same_agent_non_delivery"],
+            "todo supersede does not update --continuation-policy; use todo update first",
+        ),
+        (
+            ["--todo-id", "todo_example", "--next-user-todo", "Approve."],
+            "--next-user-todo requires explicit --next-user-task-class "
+            "user_action|user_gate",
+        ),
+        (
+            ["--todo-id", "todo_example", "--blocks-agent", "codex-example"],
+            "todo supersede does not update current todo routing metadata; "
+            "use todo update first",
+        ),
+        (
+            ["--todo-id", "todo_example", "--successor-todo-id", "todo_successor"],
+            "todo supersede does not support --successor-todo-id; "
+            "use --next-agent-todo or update the source todo before supersede",
+        ),
+        (
+            ["--todo-id", "todo_example", "--target-key", "monitor"],
+            "todo supersede does not update target or monitor schedule metadata; "
+            "use todo update before supersede",
+        ),
+    ],
+)
+def test_todo_supersede_validation_preserves_exact_diagnostics(
+    extra_args: list[str],
+    expected: str,
+) -> None:
+    args = build_parser().parse_args(
+        ["todo", "supersede", "--goal-id", "example-goal", *extra_args]
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_todo_supersede_options(args)
+
+    assert str(exc_info.value) == expected
+
+
+def test_todo_supersede_validation_accepts_successor_creation() -> None:
+    args = build_parser().parse_args(
+        [
+            "todo",
+            "supersede",
+            "--goal-id",
+            "example-goal",
+            "--todo-id",
+            "todo_example",
+            "--next-agent-todo",
+            "Continue.",
+        ]
+    )
+
+    validate_todo_supersede_options(args)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- move `todo supersede` option validation into the existing todo argument-validation owner
- reuse the shared successor-routing validator
- preserve exact diagnostics and accepted successor-creation behavior with focused tests

## Simplification

- `handle_todo_command`: 122 -> 98 statements, 96 -> 73 decision points, 398 -> 361 lines
- combined `todo.py` + `todo_argument_validation.py`: 1,185 -> 1,176 lines
- no product behavior or CLI output contract change

## Validation

- 128 focused todo and CLI diagnostics tests
- todo CLI, lifecycle, follow-up capture, and output-budget smokes
- Ruff, mypy, py_compile, maintainability ratchet, public-boundary scan
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 17/17 selected checks passed, no failures/skips/manual holds
- change-quality receipt: `cqr_116b65cbf67b62a0bcb4` (valid exact scope)