### PR TITLE
refactor(todo): centralize archive option validation

### DIFF
--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -28,6 +28,7 @@ from .todo_argument_validation import (
     unsupported_todo_options,
     validate_capability_gap_options,
     validate_shared_todo_options,
+    validate_todo_archive_completed_options,
     validate_todo_claim_options,
     validate_todo_complete_options,
     validate_todo_supersede_options,
@@ -603,28 +604,7 @@ def handle_todo_command(
                 dry_run=bool(args.dry_run),
             )
         elif args.todo_command == "archive-completed":
-            if args.decision_outcome:
-                raise ValueError(
-                    "todo archive-completed does not support --decision-outcome"
-                )
-            if args.claimed_by or args.clear_claim:
-                raise ValueError("todo archive-completed does not support --claimed-by or --clear-claim")
-            if args.clear_blocks_agent or args.excluded_agents or args.clear_excluded_agents or args.next_excluded_agents:
-                raise ValueError("todo archive-completed does not support executor exclusions")
-            if args.next_claimed_by:
-                raise ValueError("todo archive-completed does not support --next-claimed-by")
-            if args.next_task_repository or args.next_required_capabilities:
-                raise ValueError(
-                    "todo archive-completed does not support successor routing metadata"
-                )
-            if args.self_merged:
-                raise ValueError("todo archive-completed does not support --self-merged")
-            if args.no_follow_up:
-                raise ValueError("todo archive-completed does not support --no-follow-up")
-            if args.followups:
-                raise ValueError("todo archive-completed does not support --follow-up; use `todo capture-followups`")
-            if args.successor_todo_ids:
-                raise ValueError("todo archive-completed does not support --successor-todo-id")
+            validate_todo_archive_completed_options(args)
             payload = archive_completed_todos(
                 registry_path=registry_path,
                 goal_id=args.goal_id,

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -332,6 +332,23 @@ def validate_todo_supersede_options(args: argparse.Namespace) -> None:
         raise ValueError("todo supersede does not update target or monitor schedule metadata; use todo update before supersede")
 
 
+def validate_todo_archive_completed_options(args: argparse.Namespace) -> None:
+    checks = (
+        (args.decision_outcome, "todo archive-completed does not support --decision-outcome"),
+        (args.claimed_by or args.clear_claim, "todo archive-completed does not support --claimed-by or --clear-claim"),
+        (any(getattr(args, field) for field in ("clear_blocks_agent", "excluded_agents", "clear_excluded_agents", "next_excluded_agents")), "todo archive-completed does not support executor exclusions"),
+        (args.next_claimed_by, "todo archive-completed does not support --next-claimed-by"),
+        (args.next_task_repository or args.next_required_capabilities, "todo archive-completed does not support successor routing metadata"),
+        (args.self_merged, "todo archive-completed does not support --self-merged"),
+        (args.no_follow_up, "todo archive-completed does not support --no-follow-up"),
+        (args.followups, "todo archive-completed does not support --follow-up; use `todo capture-followups`"),
+        (args.successor_todo_ids, "todo archive-completed does not support --successor-todo-id"),
+    )
+    for triggered, message in checks:
+        if triggered:
+            raise ValueError(message)
+
+
 def validate_shared_todo_options(args: argparse.Namespace) -> None:
     agent_id_allowed_for_user_authoring = (
         args.todo_command == "add"

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -7,6 +7,7 @@ import pytest
 from loopx.cli import build_parser, main, output_format, resolve_global_output_format
 from loopx.cli_commands.quota import _validate_quota_command_request
 from loopx.cli_commands.todo_argument_validation import (
+    validate_todo_archive_completed_options,
     validate_todo_claim_options,
     validate_todo_complete_options,
     validate_todo_supersede_options,
@@ -480,6 +481,79 @@ def test_todo_supersede_validation_accepts_successor_creation() -> None:
     )
 
     validate_todo_supersede_options(args)
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected"),
+    [
+        (
+            ["--decision-outcome", "approve"],
+            "todo archive-completed does not support --decision-outcome",
+        ),
+        (
+            ["--claimed-by", "codex-example"],
+            "todo archive-completed does not support --claimed-by or --clear-claim",
+        ),
+        (
+            ["--excluded-agent", "codex-example"],
+            "todo archive-completed does not support executor exclusions",
+        ),
+        (
+            ["--next-claimed-by", "codex-example"],
+            "todo archive-completed does not support --next-claimed-by",
+        ),
+        (
+            ["--next-task-repository", "git:github.com/example/repo"],
+            "todo archive-completed does not support successor routing metadata",
+        ),
+        (
+            ["--self-merged"],
+            "todo archive-completed does not support --self-merged",
+        ),
+        (
+            ["--no-follow-up"],
+            "todo archive-completed does not support --no-follow-up",
+        ),
+        (
+            ["--follow-up", "Continue."],
+            "todo archive-completed does not support --follow-up; "
+            "use `todo capture-followups`",
+        ),
+        (
+            ["--successor-todo-id", "todo_successor"],
+            "todo archive-completed does not support --successor-todo-id",
+        ),
+    ],
+)
+def test_todo_archive_completed_validation_preserves_exact_diagnostics(
+    extra_args: list[str],
+    expected: str,
+) -> None:
+    args = build_parser().parse_args(
+        ["todo", "archive-completed", "--goal-id", "example-goal", *extra_args]
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_todo_archive_completed_options(args)
+
+    assert str(exc_info.value) == expected
+
+
+def test_todo_archive_completed_validation_accepts_role_and_limit() -> None:
+    args = build_parser().parse_args(
+        [
+            "todo",
+            "archive-completed",
+            "--goal-id",
+            "example-goal",
+            "--role",
+            "user",
+            "--max-active-done",
+            "7",
+        ]
+    )
+
+    validate_todo_archive_completed_options(args)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- move `todo archive-completed` unsupported-option validation into the existing todo argument-validation owner
- preserve ordered exact diagnostics in a compact local rule table
- retain accepted role and active-done-limit behavior with focused regression coverage

## Simplification

- `handle_todo_command`: 98 -> 81 statements, 73 -> 59 decision points, 361 -> 340 lines
- combined `todo.py` + `todo_argument_validation.py`: 1,176 -> 1,173 lines
- no product behavior or CLI output contract change

## Validation

- 138 focused todo and CLI diagnostics tests
- todo CLI, lifecycle, archive-completed, follow-up capture, and output-budget smokes
- Ruff, mypy, py_compile, maintainability ratchet, and public-boundary scans
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 17/17 selected checks passed, no failures/skips/manual holds
- change-quality receipt: `cqr_e2485bd07b988c13e6a4` (valid exact scope)