### PR TITLE
refactor(todo): centralize suggest option validation

### DIFF
--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -31,6 +31,7 @@ from .todo_argument_validation import (
     validate_todo_archive_completed_options,
     validate_todo_claim_options,
     validate_todo_complete_options,
+    validate_todo_suggest_options,
     validate_todo_supersede_options,
     validate_todo_update_options,
 )
@@ -615,21 +616,7 @@ def handle_todo_command(
                 dry_run=not bool(args.execute),
             )
         elif args.todo_command == "suggest":
-            unsupported = unsupported_todo_options(
-                args,
-                allowed_fields={
-                    "agent_id",
-                    "suggestion_sources",
-                    "suggestion_limit",
-                    "suggestion_trigger",
-                },
-            )
-            if unsupported:
-                raise ValueError(
-                    "todo suggest only accepts --goal-id, optional --project, --agent-id, "
-                    "--from, --limit, --trigger, --dry-run, and --format; unsupported: "
-                    + ", ".join(unsupported)
-                )
+            validate_todo_suggest_options(args)
             payload = build_todo_suggestion_prompt_packet(
                 goal_id=args.goal_id,
                 project=Path(args.project).expanduser() if args.project else None,

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -349,6 +349,18 @@ def validate_todo_archive_completed_options(args: argparse.Namespace) -> None:
             raise ValueError(message)
 
 
+def validate_todo_suggest_options(args: argparse.Namespace) -> None:
+    unsupported = unsupported_todo_options(
+        args,
+        allowed_fields={"agent_id", "suggestion_sources", "suggestion_limit", "suggestion_trigger"},
+    )
+    if unsupported:
+        raise ValueError(
+            "todo suggest only accepts --goal-id, optional --project, --agent-id, "
+            "--from, --limit, --trigger, --dry-run, and --format; unsupported: " + ", ".join(unsupported)
+        )
+
+
 def validate_shared_todo_options(args: argparse.Namespace) -> None:
     agent_id_allowed_for_user_authoring = (
         args.todo_command == "add"

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -10,6 +10,7 @@ from loopx.cli_commands.todo_argument_validation import (
     validate_todo_archive_completed_options,
     validate_todo_claim_options,
     validate_todo_complete_options,
+    validate_todo_suggest_options,
     validate_todo_supersede_options,
     validate_todo_update_options,
 )
@@ -554,6 +555,54 @@ def test_todo_archive_completed_validation_accepts_role_and_limit() -> None:
     )
 
     validate_todo_archive_completed_options(args)
+
+
+def test_todo_suggest_validation_preserves_exact_unsupported_diagnostic(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(
+        [
+            "--format",
+            "json",
+            "todo",
+            "suggest",
+            "--goal-id",
+            "example-goal",
+            "--todo-id",
+            "todo_example",
+            "--note",
+            "not accepted",
+        ]
+    )
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"] == (
+        "todo suggest only accepts --goal-id, optional --project, --agent-id, "
+        "--from, --limit, --trigger, --dry-run, and --format; unsupported: "
+        "--todo-id, --note"
+    )
+
+
+def test_todo_suggest_validation_accepts_suggestion_scope_options() -> None:
+    args = build_parser().parse_args(
+        [
+            "todo",
+            "suggest",
+            "--goal-id",
+            "example-goal",
+            "--agent-id",
+            "codex-example",
+            "--from",
+            "recent-repo",
+            "--limit",
+            "3",
+            "--trigger",
+            "quality-watch",
+        ]
+    )
+
+    validate_todo_suggest_options(args)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- move `todo suggest` supported-option filtering and exact unsupported-option diagnostics into the existing todo argument-validation owner
- keep suggestion source, limit, trigger, agent scope, prompt packet, rollout, and output behavior unchanged
- add negative CLI coverage for exact diagnostics and positive coverage for all accepted suggestion-scope options

## Simplification

- `handle_todo_command`: 81 to 79 statements, 59 to 58 decisions, 340 to 326 lines
- combined `todo.py` plus `todo_argument_validation.py` production size: 1,173 to 1,172 lines

## Validation

- 140 focused todo lifecycle and CLI diagnostic tests passed
- todo CLI, lifecycle, archive, follow-up, suggestion, and output-budget smokes passed
- repository Ruff and mypy gates passed
- maintainability ratchet passed with no magnitude regression
- public/private boundary scan clean
- premerge: 17/17 selected checks passed; no failures, skips, warnings, or manual holds
- exact change-quality receipt: `cqr_bec3976000c17277f9e3`
