### PR TITLE
refactor(todo): centralize capture follow-up validation

### DIFF
--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -29,6 +29,7 @@ from .todo_argument_validation import (
     validate_capability_gap_options,
     validate_shared_todo_options,
     validate_todo_archive_completed_options,
+    validate_todo_capture_followups_options,
     validate_todo_claim_options,
     validate_todo_complete_options,
     validate_todo_suggest_options,
@@ -627,33 +628,7 @@ def handle_todo_command(
             )
             payload["dry_run"] = True
         elif args.todo_command == "capture-followups":
-            if args.role:
-                raise ValueError("todo capture-followups always records agent todos; do not pass --role")
-            if args.claimed_by:
-                raise ValueError("todo capture-followups writes unclaimed todos; do not pass --claimed-by")
-            unsupported = unsupported_todo_options(
-                args,
-                allowed_fields={
-                    "text",
-                    "followups",
-                    "evidence",
-                    "task_class",
-                    "action_kind",
-                    "continuation_policy",
-                    "required_write_scopes",
-                    "required_capabilities",
-                    "target_capabilities",
-                    "required_decision_scopes",
-                    "state_file",
-                },
-            )
-            if unsupported:
-                raise ValueError(
-                    "todo capture-followups only accepts --goal-id, --follow-up, optional "
-                    "--text shorthand, --evidence, routing metadata, --project, --state-file, "
-                    "and --dry-run; unsupported: "
-                    + ", ".join(unsupported)
-                )
+            validate_todo_capture_followups_options(args)
             followups = list(args.followups or [])
             if args.text:
                 followups.append(args.text)

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -361,6 +361,30 @@ def validate_todo_suggest_options(args: argparse.Namespace) -> None:
         )
 
 
+def validate_todo_capture_followups_options(args: argparse.Namespace) -> None:
+    checks = (
+        (args.role, "todo capture-followups always records agent todos; do not pass --role"),
+        (args.claimed_by, "todo capture-followups writes unclaimed todos; do not pass --claimed-by"),
+    )
+    for triggered, message in checks:
+        if triggered:
+            raise ValueError(message)
+    unsupported = unsupported_todo_options(
+        args,
+        allowed_fields={
+            "text", "followups", "evidence", "task_class", "action_kind",
+            "continuation_policy", "required_write_scopes", "required_capabilities",
+            "target_capabilities", "required_decision_scopes", "state_file",
+        },
+    )
+    if unsupported:
+        raise ValueError(
+            "todo capture-followups only accepts --goal-id, --follow-up, optional "
+            "--text shorthand, --evidence, routing metadata, --project, --state-file, "
+            "and --dry-run; unsupported: " + ", ".join(unsupported)
+        )
+
+
 def validate_shared_todo_options(args: argparse.Namespace) -> None:
     agent_id_allowed_for_user_authoring = (
         args.todo_command == "add"

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -8,6 +8,7 @@ from loopx.cli import build_parser, main, output_format, resolve_global_output_f
 from loopx.cli_commands.quota import _validate_quota_command_request
 from loopx.cli_commands.todo_argument_validation import (
     validate_todo_archive_completed_options,
+    validate_todo_capture_followups_options,
     validate_todo_claim_options,
     validate_todo_complete_options,
     validate_todo_suggest_options,
@@ -603,6 +604,74 @@ def test_todo_suggest_validation_accepts_suggestion_scope_options() -> None:
     )
 
     validate_todo_suggest_options(args)
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected"),
+    [
+        (
+            ["--role", "agent"],
+            "todo capture-followups always records agent todos; do not pass --role",
+        ),
+        (
+            ["--claimed-by", "codex-example"],
+            "todo capture-followups writes unclaimed todos; do not pass --claimed-by",
+        ),
+        (
+            ["--todo-id", "todo_example", "--note", "not accepted"],
+            "todo capture-followups only accepts --goal-id, --follow-up, optional "
+            "--text shorthand, --evidence, routing metadata, --project, --state-file, "
+            "and --dry-run; unsupported: --todo-id, --note",
+        ),
+    ],
+)
+def test_todo_capture_followups_validation_preserves_exact_diagnostics(
+    extra_args: list[str],
+    expected: str,
+) -> None:
+    args = build_parser().parse_args(
+        ["todo", "capture-followups", "--goal-id", "example-goal", *extra_args]
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_todo_capture_followups_options(args)
+
+    assert str(exc_info.value) == expected
+
+
+def test_todo_capture_followups_validation_accepts_routing_options() -> None:
+    args = build_parser().parse_args(
+        [
+            "todo",
+            "capture-followups",
+            "--goal-id",
+            "example-goal",
+            "--follow-up",
+            "Continue.",
+            "--text",
+            "Then validate.",
+            "--evidence",
+            "tests/test_cli_argument_diagnostics.py",
+            "--task-class",
+            "advancement_task",
+            "--action-kind",
+            "implement",
+            "--continuation-policy",
+            "same_agent_non_delivery",
+            "--required-write-scope",
+            "tests/**",
+            "--required-capability",
+            "shell",
+            "--target-capability",
+            "quality",
+            "--required-decision-scope",
+            "merge",
+            "--state-file",
+            "ACTIVE_GOAL_STATE.md",
+        ]
+    )
+
+    validate_todo_capture_followups_options(args)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- move `todo capture-followups` role, claim, and unsupported-option validation into the existing todo argument-validation owner
- preserve exact diagnostics, accepted routing metadata, follow-up ordering, state mutation, and CLI output budgets
- reduce `handle_todo_command` from 79 to 73 statements, 58 to 55 decisions, and 326 to 300 lines; combined production lines fall from 1,172 to 1,171

## Validation
- 144 focused todo/control-plane tests
- todo CLI, lifecycle, archive, capture-followups, suggestion, and output-budget smokes
- repository fast Ruff lane and strict mypy
- maintainability ratchet, public-boundary smoke, py_compile, and diff hygiene
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 4 direct + 17 selected checks passed
- exact-scope change-quality receipt `cqr_eb50fac21468ace9d2b9` valid

No private state, credentials, local paths, generated logs, or benchmark evidence are included.