### PR TITLE
refactor(todo): centralize list option validation

### DIFF
--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -25,13 +25,13 @@ from ..todos import (
 from .todo_argument_validation import (
     register_todo_linkage_arguments,
     register_todo_successor_creation_arguments,
-    unsupported_todo_options,
     validate_capability_gap_options,
     validate_shared_todo_options,
     validate_todo_archive_completed_options,
     validate_todo_capture_followups_options,
     validate_todo_claim_options,
     validate_todo_complete_options,
+    validate_todo_list_options,
     validate_todo_suggest_options,
     validate_todo_supersede_options,
     validate_todo_update_options,
@@ -390,16 +390,7 @@ def handle_todo_command(
         validate_shared_todo_options(args)
         validate_capability_gap_options(args)
         if args.todo_command == "list":
-            unsupported = unsupported_todo_options(
-                args,
-                allowed_fields={"role", "todo_id", "status", "agent_id", "state_file"},
-            )
-            if unsupported:
-                raise ValueError(
-                    "todo list only accepts --goal-id, optional --role, --status, --todo-id, "
-                    "--agent-id, --project, --state-file, --dry-run, and --format; unsupported: "
-                    + ", ".join(unsupported)
-                )
+            validate_todo_list_options(args)
             payload = list_goal_todos(
                 registry_path=registry_path,
                 goal_id=args.goal_id,

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -236,6 +236,21 @@ def unsupported_todo_options(
     ]
 
 
+def _validate_todo_option_subset(args: argparse.Namespace, allowed_fields: Iterable[str], error_prefix: str) -> None:
+    unsupported = unsupported_todo_options(args, allowed_fields=allowed_fields)
+    if unsupported:
+        raise ValueError(error_prefix + ", ".join(unsupported))
+
+
+def validate_todo_list_options(args: argparse.Namespace) -> None:
+    _validate_todo_option_subset(
+        args,
+        {"role", "todo_id", "status", "agent_id", "state_file"},
+        "todo list only accepts --goal-id, optional --role, --status, --todo-id, "
+        "--agent-id, --project, --state-file, --dry-run, and --format; unsupported: ",
+    )
+
+
 def validate_todo_claim_options(args: argparse.Namespace) -> None:
     if not args.todo_id:
         raise ValueError("todo claim requires --todo-id")
@@ -245,16 +260,12 @@ def validate_todo_claim_options(args: argparse.Namespace) -> None:
         raise ValueError(
             "todo claim requires --claimed-by and does not support --clear-claim"
         )
-    unsupported = unsupported_todo_options(
+    _validate_todo_option_subset(
         args,
-        allowed_fields={"role", "todo_id", "claimed_by", "agent_id", "state_file"},
+        {"role", "todo_id", "claimed_by", "agent_id", "state_file"},
+        "todo claim only accepts --todo-id, --claimed-by, --agent-id, optional --role, "
+        "--project, --state-file, and --dry-run; unsupported: ",
     )
-    if unsupported:
-        raise ValueError(
-            "todo claim only accepts --todo-id, --claimed-by, --agent-id, optional --role, "
-            "--project, --state-file, and --dry-run; unsupported: "
-            + ", ".join(unsupported)
-        )
 
 
 def validate_todo_update_options(args: argparse.Namespace) -> None:
@@ -350,15 +361,12 @@ def validate_todo_archive_completed_options(args: argparse.Namespace) -> None:
 
 
 def validate_todo_suggest_options(args: argparse.Namespace) -> None:
-    unsupported = unsupported_todo_options(
+    _validate_todo_option_subset(
         args,
-        allowed_fields={"agent_id", "suggestion_sources", "suggestion_limit", "suggestion_trigger"},
+        {"agent_id", "suggestion_sources", "suggestion_limit", "suggestion_trigger"},
+        "todo suggest only accepts --goal-id, optional --project, --agent-id, "
+        "--from, --limit, --trigger, --dry-run, and --format; unsupported: ",
     )
-    if unsupported:
-        raise ValueError(
-            "todo suggest only accepts --goal-id, optional --project, --agent-id, "
-            "--from, --limit, --trigger, --dry-run, and --format; unsupported: " + ", ".join(unsupported)
-        )
 
 
 def validate_todo_capture_followups_options(args: argparse.Namespace) -> None:
@@ -369,20 +377,17 @@ def validate_todo_capture_followups_options(args: argparse.Namespace) -> None:
     for triggered, message in checks:
         if triggered:
             raise ValueError(message)
-    unsupported = unsupported_todo_options(
+    _validate_todo_option_subset(
         args,
-        allowed_fields={
+        {
             "text", "followups", "evidence", "task_class", "action_kind",
             "continuation_policy", "required_write_scopes", "required_capabilities",
             "target_capabilities", "required_decision_scopes", "state_file",
         },
+        "todo capture-followups only accepts --goal-id, --follow-up, optional "
+        "--text shorthand, --evidence, routing metadata, --project, --state-file, "
+        "and --dry-run; unsupported: ",
     )
-    if unsupported:
-        raise ValueError(
-            "todo capture-followups only accepts --goal-id, --follow-up, optional "
-            "--text shorthand, --evidence, routing metadata, --project, --state-file, "
-            "and --dry-run; unsupported: " + ", ".join(unsupported)
-        )
 
 
 def validate_shared_todo_options(args: argparse.Namespace) -> None:

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -11,6 +11,7 @@ from loopx.cli_commands.todo_argument_validation import (
     validate_todo_capture_followups_options,
     validate_todo_claim_options,
     validate_todo_complete_options,
+    validate_todo_list_options,
     validate_todo_suggest_options,
     validate_todo_supersede_options,
     validate_todo_update_options,
@@ -79,6 +80,56 @@ def test_quota_include_detail_rejects_non_should_run_command(
     assert payload["error"] == (
         "--include-detail is only valid with `quota should-run`"
     )
+
+
+def test_todo_list_validation_preserves_exact_unsupported_diagnostic() -> None:
+    args = build_parser().parse_args(
+        [
+            "todo",
+            "list",
+            "--goal-id",
+            "example-goal",
+            "--note",
+            "not accepted",
+            "--evidence",
+            "not accepted",
+        ]
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_todo_list_options(args)
+
+    assert str(exc_info.value) == (
+        "todo list only accepts --goal-id, optional --role, --status, --todo-id, "
+        "--agent-id, --project, --state-file, --dry-run, and --format; unsupported: "
+        "--note, --evidence"
+    )
+
+
+def test_todo_list_validation_accepts_read_filters() -> None:
+    args = build_parser().parse_args(
+        [
+            "todo",
+            "list",
+            "--goal-id",
+            "example-goal",
+            "--role",
+            "agent",
+            "--status",
+            "open",
+            "--todo-id",
+            "todo_example",
+            "--agent-id",
+            "codex-example",
+            "--project",
+            ".",
+            "--state-file",
+            "ACTIVE_GOAL_STATE.md",
+            "--dry-run",
+        ]
+    )
+
+    validate_todo_list_options(args)
 
 
 def test_deprecated_scheduler_detail_alias_is_hidden_from_help(


### PR DESCRIPTION
## Summary
- move `todo list` option filtering and diagnostics into the existing todo argument-validation owner
- reuse one ordered option-subset rejection helper across list, claim, suggest, and capture-followups
- preserve list filters, read-model behavior, output budgets, and exact unsupported-option ordering

## Simplification
- `handle_todo_command`: 73 -> 71 statements, 55 -> 54 decisions, 300 -> 291 lines
- combined `todo.py` + `todo_argument_validation.py`: 1,171 -> 1,167 lines

## Validation
- 152 focused todo tests passed
- 9 focused public smokes passed
- changed-file and repository fast Ruff passed
- strict mypy and changed Python compile passed
- output-budget, maintainability, and public-boundary checks passed
- exact change-quality receipt `cqr_ee727cb8703110f32ae4` is valid
- risk-based premerge passed 17/17 selected checks with no failures or manual holds

No private state, credentials, local paths, generated logs, or benchmark evidence are included.