### PR TITLE
refactor(todo): centralize add option validation

### DIFF
--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -27,6 +27,7 @@ from .todo_argument_validation import (
     register_todo_successor_creation_arguments,
     validate_capability_gap_options,
     validate_shared_todo_options,
+    validate_todo_add_options,
     validate_todo_archive_completed_options,
     validate_todo_capture_followups_options,
     validate_todo_claim_options,
@@ -403,42 +404,7 @@ def handle_todo_command(
                 runtime_root_arg=runtime_root_arg,
             )
         elif args.todo_command == "add":
-            if args.decision_outcome:
-                raise ValueError(
-                    "todo add does not accept --decision-outcome; record it on completion"
-                )
-            if args.followups:
-                raise ValueError("todo add does not support --follow-up; use `todo capture-followups`")
-            if not args.role:
-                raise ValueError("todo add requires --role")
-            if not args.text:
-                raise ValueError("todo add requires --text")
-            if args.clear_claim:
-                raise ValueError("todo add accepts --claimed-by but not --clear-claim")
-            if args.clear_explore_result_node_refs:
-                raise ValueError(
-                    "todo add accepts --explore-result-node-ref but not --clear-explore-result-node-refs"
-                )
-            if args.next_claimed_by:
-                raise ValueError("todo add does not support --next-claimed-by")
-            if args.next_task_repository:
-                raise ValueError("todo add does not support --next-task-repository")
-            if args.next_required_capabilities:
-                raise ValueError("todo add does not support --next-required-capability")
-            if args.next_continuation_policy:
-                raise ValueError("todo add does not support --next-continuation-policy")
-            if args.next_excluded_agents:
-                raise ValueError("todo add does not support --next-excluded-agent")
-            if args.clear_excluded_agents:
-                raise ValueError("todo add does not support --clear-excluded-agents")
-            if args.clear_blocks_agent:
-                raise ValueError("todo add does not support --clear-blocks-agent")
-            if args.self_merged:
-                raise ValueError("todo add does not support --self-merged")
-            if args.no_follow_up:
-                raise ValueError("todo add does not support --no-follow-up")
-            if args.successor_todo_ids:
-                raise ValueError("todo add does not support --successor-todo-id; use todo update/complete to link existing successor work")
+            validate_todo_add_options(args)
             payload = add_goal_todo(
                 registry_path=registry_path,
                 goal_id=args.goal_id,

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -105,6 +105,26 @@ _TODO_UPDATE_UNSUPPORTED_FIELDS = (
     ("self_merged", "todo update does not support --self-merged"),
 )
 
+_TODO_ADD_INITIAL_RULES = (
+    ("decision_outcome", True, "does not accept --decision-outcome; record it on completion"),
+    ("followups", True, "does not support --follow-up; use `todo capture-followups`"),
+    ("role", False, "requires --role"),
+    ("text", False, "requires --text"),
+    ("clear_claim", True, "accepts --claimed-by but not --clear-claim"),
+    (
+        "clear_explore_result_node_refs",
+        True,
+        "accepts --explore-result-node-ref but not --clear-explore-result-node-refs",
+    ),
+)
+_TODO_ADD_UNSUPPORTED_FIELDS = (
+    "next_claimed_by", "next_task_repository", "next_required_capabilities",
+    "next_continuation_policy", "next_excluded_agents", "clear_excluded_agents",
+    "clear_blocks_agent", "self_merged", "no_follow_up",
+)
+_TODO_OPTION_FLAGS = {field: flag for flag, field in TODO_OPTION_FIELDS}
+
+
 def register_todo_linkage_arguments(
     todo_parser: argparse.ArgumentParser,
 ) -> None:
@@ -249,6 +269,17 @@ def validate_todo_list_options(args: argparse.Namespace) -> None:
         "todo list only accepts --goal-id, optional --role, --status, --todo-id, "
         "--agent-id, --project, --state-file, --dry-run, and --format; unsupported: ",
     )
+
+
+def validate_todo_add_options(args: argparse.Namespace) -> None:
+    for field, reject_when_present, message in _TODO_ADD_INITIAL_RULES:
+        if bool(getattr(args, field)) is reject_when_present:
+            raise ValueError(f"todo add {message}")
+    for field in _TODO_ADD_UNSUPPORTED_FIELDS:
+        if getattr(args, field):
+            raise ValueError(f"todo add does not support {_TODO_OPTION_FLAGS[field]}")
+    if args.successor_todo_ids:
+        raise ValueError("todo add does not support --successor-todo-id; use todo update/complete to link existing successor work")
 
 
 def validate_todo_claim_options(args: argparse.Namespace) -> None:

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -7,6 +7,7 @@ import pytest
 from loopx.cli import build_parser, main, output_format, resolve_global_output_format
 from loopx.cli_commands.quota import _validate_quota_command_request
 from loopx.cli_commands.todo_argument_validation import (
+    validate_todo_add_options,
     validate_todo_archive_completed_options,
     validate_todo_capture_followups_options,
     validate_todo_claim_options,
@@ -130,6 +131,97 @@ def test_todo_list_validation_accepts_read_filters() -> None:
     )
 
     validate_todo_list_options(args)
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected"),
+    [
+        ([], "todo add requires --role"),
+        (["--role", "agent"], "todo add requires --text"),
+        (
+            [
+                "--role",
+                "agent",
+                "--text",
+                "Continue.",
+                "--decision-outcome",
+                "approve",
+                "--follow-up",
+                "Later.",
+            ],
+            "todo add does not accept --decision-outcome; record it on completion",
+        ),
+        (
+            [
+                "--role",
+                "agent",
+                "--text",
+                "Continue.",
+                "--clear-explore-result-node-refs",
+            ],
+            "todo add accepts --explore-result-node-ref but not "
+            "--clear-explore-result-node-refs",
+        ),
+        (
+            [
+                "--role",
+                "agent",
+                "--text",
+                "Continue.",
+                "--next-required-capability",
+                "network",
+            ],
+            "todo add does not support --next-required-capability",
+        ),
+        (
+            [
+                "--role",
+                "agent",
+                "--text",
+                "Continue.",
+                "--successor-todo-id",
+                "todo_successor",
+            ],
+            "todo add does not support --successor-todo-id; use todo update/complete "
+            "to link existing successor work",
+        ),
+    ],
+)
+def test_todo_add_validation_preserves_exact_diagnostics(
+    extra_args: list[str],
+    expected: str,
+) -> None:
+    args = build_parser().parse_args(
+        ["todo", "add", "--goal-id", "example-goal", *extra_args]
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_todo_add_options(args)
+
+    assert str(exc_info.value) == expected
+
+
+def test_todo_add_validation_accepts_add_fields() -> None:
+    args = build_parser().parse_args(
+        [
+            "todo",
+            "add",
+            "--goal-id",
+            "example-goal",
+            "--role",
+            "agent",
+            "--text",
+            "Continue.",
+            "--claimed-by",
+            "codex-example",
+            "--required-capability",
+            "shell",
+            "--explore-result-node-ref",
+            "result_1",
+        ]
+    )
+
+    validate_todo_add_options(args)
 
 
 def test_deprecated_scheduler_detail_alias_is_hidden_from_help(


### PR DESCRIPTION
## Summary

- move `todo add` option rejection into the existing argument-validation owner
- reuse canonical option-to-flag metadata for unsupported add fields
- preserve exact diagnostics with focused negative and accepted-field coverage

## Simplification

`handle_todo_command` moves from 71 statements / 54 decisions / 291 lines to
40 statements / 38 decisions / 256 lines. The two production modules together
move from 1,167 to 1,164 lines, so the extraction reduces both branch density
and net production volume.

## Validation

- `python -m mypy`: passed, 15 configured source files
- repository fast Ruff lane and changed-file Ruff: passed
- focused pytest: 153 passed
- focused todo, output-budget, maintainability, and public-boundary smokes: passed
- `loopx check`: 9 checks passed
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 17/17 selected checks passed
- change-quality receipt `cqr_2b7eba814ebce7ed205d`: exact-scope valid
- failures/skips/manual holds: none

The selected coverage exercises exact diagnostics, accepted add fields,
end-to-end todo CLI/lifecycle behavior, agent-facing output budgets, and the
control-plane/canary risk profiles.
