### PR TITLE
refactor(todo): centralize command path expansion

### DIFF
--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -374,6 +374,13 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
     todo_parser.add_argument("--execute", action="store_true", help="For archive-completed, write the active-state edit.")
 
 
+def _todo_path_args(args: argparse.Namespace) -> dict[str, Path | None]:
+    return {
+        "project": Path(args.project).expanduser() if args.project else None,
+        "state_file": Path(args.state_file).expanduser() if args.state_file else None,
+    }
+
+
 def handle_todo_command(
     args: argparse.Namespace,
     *,
@@ -399,8 +406,7 @@ def handle_todo_command(
                 status=args.status,
                 todo_id=args.todo_id,
                 agent_id=args.agent_id,
-                project=Path(args.project).expanduser() if args.project else None,
-                state_file=Path(args.state_file).expanduser() if args.state_file else None,
+                **_todo_path_args(args),
                 runtime_root_arg=runtime_root_arg,
             )
         elif args.todo_command == "add":
@@ -436,8 +442,7 @@ def handle_todo_command(
                     "next_due_at": args.next_due_at,
                     "expires_at": args.expires_at,
                 },
-                project=Path(args.project).expanduser() if args.project else None,
-                state_file=Path(args.state_file).expanduser() if args.state_file else None,
+                **_todo_path_args(args),
                 dry_run=bool(args.dry_run),
             )
         elif args.todo_command == "claim":
@@ -450,8 +455,7 @@ def handle_todo_command(
                 claimed_by=args.claimed_by,
                 agent_id=args.agent_id,
                 claim_only=True,
-                project=Path(args.project).expanduser() if args.project else None,
-                state_file=Path(args.state_file).expanduser() if args.state_file else None,
+                **_todo_path_args(args),
                 dry_run=bool(args.dry_run),
             )
         elif args.todo_command == "update":
@@ -503,8 +507,7 @@ def handle_todo_command(
                     "expires_at": args.expires_at,
                 },
                 clear_claim=bool(args.clear_claim),
-                project=Path(args.project).expanduser() if args.project else None,
-                state_file=Path(args.state_file).expanduser() if args.state_file else None,
+                **_todo_path_args(args),
                 dry_run=bool(args.dry_run),
             )
         elif args.todo_command == "complete":
@@ -534,8 +537,7 @@ def handle_todo_command(
                 self_merged=bool(args.self_merged),
                 agent_id=args.agent_id,
                 authority_reason=args.authority_reason,
-                project=Path(args.project).expanduser() if args.project else None,
-                state_file=Path(args.state_file).expanduser() if args.state_file else None,
+                **_todo_path_args(args),
                 dry_run=bool(args.dry_run),
             )
         elif args.todo_command == "supersede":
@@ -558,8 +560,7 @@ def handle_todo_command(
                 next_excluded_agents=args.next_excluded_agents,
                 agent_id=args.agent_id,
                 authority_reason=args.authority_reason,
-                project=Path(args.project).expanduser() if args.project else None,
-                state_file=Path(args.state_file).expanduser() if args.state_file else None,
+                **_todo_path_args(args),
                 dry_run=bool(args.dry_run),
             )
         elif args.todo_command == "archive-completed":
@@ -569,8 +570,7 @@ def handle_todo_command(
                 goal_id=args.goal_id,
                 role=args.role or "agent",
                 max_active_done=args.max_active_done,
-                project=Path(args.project).expanduser() if args.project else None,
-                state_file=Path(args.state_file).expanduser() if args.state_file else None,
+                **_todo_path_args(args),
                 dry_run=not bool(args.execute),
             )
         elif args.todo_command == "suggest":
@@ -600,8 +600,7 @@ def handle_todo_command(
                 required_capabilities=args.required_capabilities,
                 target_capabilities=args.target_capabilities,
                 required_decision_scopes=args.required_decision_scopes,
-                project=Path(args.project).expanduser() if args.project else None,
-                state_file=Path(args.state_file).expanduser() if args.state_file else None,
+                **_todo_path_args(args),
                 dry_run=bool(args.dry_run),
             )
         else:

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
 from loopx.cli import build_parser, main, output_format, resolve_global_output_format
+from loopx.cli_commands import todo as todo_command
 from loopx.cli_commands.quota import _validate_quota_command_request
 from loopx.cli_commands.todo_argument_validation import (
     validate_todo_add_options,
@@ -17,6 +19,66 @@ from loopx.cli_commands.todo_argument_validation import (
     validate_todo_supersede_options,
     validate_todo_update_options,
 )
+
+
+def test_todo_handler_expands_shared_paths_and_keeps_suggest_project_only(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    captured_list: dict[str, object] = {}
+    captured_suggest: dict[str, object] = {}
+
+    def fake_list_goal_todos(**kwargs: object) -> dict[str, object]:
+        captured_list.update(kwargs)
+        return {"ok": True, "dry_run": True}
+
+    def fake_suggestion_packet(**kwargs: object) -> dict[str, object]:
+        captured_suggest.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(todo_command, "list_goal_todos", fake_list_goal_todos)
+    monkeypatch.setattr(
+        todo_command,
+        "build_todo_suggestion_prompt_packet",
+        fake_suggestion_packet,
+    )
+    common = {
+        "registry_path": tmp_path / "registry.json",
+        "runtime_root_arg": None,
+        "print_payload": lambda *_args: None,
+        "append_cli_rollout_event": lambda *_args, **_kwargs: {},
+    }
+
+    list_args = build_parser().parse_args(
+        [
+            "todo",
+            "list",
+            "--goal-id",
+            "example-goal",
+            "--project",
+            "~/project",
+            "--state-file",
+            "~/ACTIVE_GOAL_STATE.md",
+        ]
+    )
+    assert todo_command.handle_todo_command(list_args, **common) == 0
+    assert captured_list["project"] == tmp_path / "project"
+    assert captured_list["state_file"] == tmp_path / "ACTIVE_GOAL_STATE.md"
+
+    suggest_args = build_parser().parse_args(
+        [
+            "todo",
+            "suggest",
+            "--goal-id",
+            "example-goal",
+            "--project",
+            "~/project",
+        ]
+    )
+    assert todo_command.handle_todo_command(suggest_args, **common) == 0
+    assert captured_suggest["project"] == tmp_path / "project"
+    assert "state_file" not in captured_suggest
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- centralize repeated `project` / `state_file` expansion in the todo CLI owner
- keep `suggest` project-only and preserve branch-specific validation before path resolution
- add focused regression coverage for `~` expansion and the suggest boundary

## Simplification

- `handle_todo_command`: 40 -> 40 statements, 38 -> 22 decision points, 256 -> 248 lines
- combined `todo.py` + argument validation: 1,164 -> 1,163 lines
- no new module, protocol field, compatibility layer, or output change

## Validation

- changed-file Ruff: passed
- repository fast Ruff lane: passed
- mypy: passed
- pytest: 1,762 passed, 2 skipped
- focused todo/output-budget/modularization/maintainability/public-boundary smokes: passed
- `loopx check` on changed paths: passed
- change-quality receipt: `cqr_fe7e69a51044cb731b1f` valid
- premerge canary: 17/17 passed

An exploratory whole-tree `ruff check loopx tests` remains red on 390 inherited findings outside this diff; the repository-declared fast lane and both changed files are green.