### PR TITLE
refactor(state): simplify refresh output projections

### DIFF
--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -625,6 +625,96 @@ def build_state_refresh_record(
     return record
 
 
+def _build_state_refresh_output_projections(
+    *,
+    record: dict[str, Any],
+    registry_path: Path,
+    runtime_root: Path,
+    project: Path | None,
+    json_path: Path,
+    markdown_path: Path,
+    index_path: Path,
+    dry_run: bool,
+    autonomous_replan_recorded_requested: bool,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Project one refresh record into its compact index and CLI response."""
+
+    record_state = record.get("state") if isinstance(record.get("state"), dict) else {}
+    record_frontmatter = record_state.get("frontmatter") or {}
+    index_record = {
+        field: record[field]
+        for field in (
+            "generated_at", "goal_id", "classification", "recommended_action",
+            "recommended_action_source", "health_check",
+        )
+    }
+    index_record.update({
+        "json_path": str(json_path),
+        "markdown_path": str(markdown_path),
+        "state": {
+            "sha256_16": record_state.get("sha256_16"),
+            "frontmatter": {"updated_at": record_frontmatter.get("updated_at")},
+        },
+        "runtime_projection_route": record["runtime_projection_route"],
+    })
+    for field in ("delivery_batch_scale", "delivery_outcome", "delivery_workspace"):
+        if field in record:
+            index_record[field] = record[field]
+
+    replan_ack = record.get("autonomous_replan_ack") or {}
+    if autonomous_replan_recorded_requested:
+        index_record["autonomous_replan_ack"] = replan_ack
+        if replan_ack.get("requested_classification"):
+            index_record["requested_classification"] = replan_ack["requested_classification"]
+
+    agent_vision = record.get("agent_vision")
+    if isinstance(agent_vision, dict):
+        index_record["agent_vision"] = {
+            field: agent_vision.get(field)
+            for field in (
+                "schema_version", "agent_id", "state", "vision_patch",
+                "todo_delta", "vision_budget",
+            )
+        }
+        if isinstance(agent_vision.get("path_delta"), dict):
+            index_record["agent_vision"]["path_delta"] = agent_vision["path_delta"]
+
+    for field in ("vision_checkpoint", "progress_scope", "agent_id", "agent_lane"):
+        if field in record:
+            index_record[field] = record[field]
+
+    payload: dict[str, Any] = {
+        "ok": True,
+        "dry_run": dry_run,
+        "appended": not dry_run,
+        "registry": str(registry_path),
+        "runtime_root": str(runtime_root),
+        "project": str(project) if project else None,
+    }
+    payload.update({
+        field: record.get(field)
+        for field in ("goal_id", "classification", "progress_scope", "agent_id", "agent_lane")
+    })
+    payload.update({
+        "autonomous_replan_recorded": bool(replan_ack.get("recorded")),
+        "autonomous_replan_recorded_requested": autonomous_replan_recorded_requested,
+        "repair_delta_contract": replan_ack.get("delta_contract"),
+        "json_path": str(json_path),
+        "markdown_path": str(markdown_path),
+        "index_path": str(index_path),
+    })
+    payload.update({
+        field: record.get(field)
+        for field in (
+            "agent_vision", "vision_checkpoint", "recommended_action",
+            "recommended_action_source", "active_state_next_action_update",
+            "generated_at", "health_check",
+        )
+    })
+    payload.update(record)
+    return index_record, payload
+
+
 def render_state_refresh_markdown(payload: dict[str, Any]) -> str:
     state = payload.get("state") if isinstance(payload.get("state"), dict) else {}
     frontmatter = state.get("frontmatter") if isinstance(state.get("frontmatter"), dict) else {}
@@ -928,7 +1018,6 @@ def refresh_state_run(
     agent_vision: dict[str, Any] | None = None
     existing_agent_vision: dict[str, Any] | None = None
     autonomous_replan_frontier_identity: str | None = None
-    existing_runs: list[dict[str, Any]] = []
     if normalized_agent_id and (
         agent_vision_packet is not None
         or normalized_vision_unchanged_reason
@@ -950,6 +1039,13 @@ def refresh_state_run(
             goal_id=safe_goal_id,
             agent_id=normalized_agent_id,
         )
+        if autonomous_replan_recorded:
+            autonomous_replan_frontier_identity = (
+                latest_blocked_successor_frontier_identity(
+                    newest_first_runs,
+                    agent_id=normalized_agent_id,
+                )
+            )
     if agent_vision_packet is not None:
         agent_vision = normalize_goal_vision_update(
             agent_vision_packet,
@@ -958,21 +1054,6 @@ def refresh_state_run(
             existing_agent_vision=existing_agent_vision,
             merge_patch=merge_agent_vision_patch,
             require_path_delta_for_durable_change=autonomous_replan_recorded,
-        )
-    if autonomous_replan_recorded:
-        newest_first_runs = [
-            run
-            for _, run in sorted(
-                enumerate(existing_runs),
-                key=lambda item: (str(item[1].get("generated_at") or ""), item[0]),
-                reverse=True,
-            )
-        ]
-        autonomous_replan_frontier_identity = (
-            latest_blocked_successor_frontier_identity(
-                newest_first_runs,
-                agent_id=normalized_agent_id or None,
-            )
         )
     generated_at = now_local()
     active_state_next_action_update: dict[str, Any] | None = None
@@ -1097,10 +1178,6 @@ def refresh_state_run(
             }
     if active_state_next_action_update:
         record["active_state_next_action_update"] = active_state_next_action_update
-    if agent_vision:
-        record["agent_vision"] = agent_vision
-    if vision_checkpoint:
-        record["vision_checkpoint"] = vision_checkpoint
     compact_route = compact_runtime_projection_route(runtime_projection_route)
     compact_route["projection_enabled"] = bool(sync_global)
     compact_route["projection_marker_field"] = "shared_runtime_projection"
@@ -1109,90 +1186,17 @@ def refresh_state_run(
     runs_dir = runtime_root / "goals" / safe_goal_id / "runs"
     json_path, markdown_path = unique_run_paths(runs_dir, generated_at)
     index_path = runs_dir / "index.jsonl"
-    index_record = {
-        "generated_at": generated_at,
-        "goal_id": safe_goal_id,
-        "classification": classification,
-        "recommended_action": action,
-        "recommended_action_source": recommended_action_source,
-        "health_check": record["health_check"],
-        "json_path": str(json_path),
-        "markdown_path": str(markdown_path),
-    }
-    record_state = record.get("state") if isinstance(record.get("state"), dict) else {}
-    record_frontmatter = (
-        record_state.get("frontmatter")
-        if isinstance(record_state.get("frontmatter"), dict)
-        else {}
+    index_record, payload = _build_state_refresh_output_projections(
+        record=record,
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        project=resolved_project,
+        json_path=json_path,
+        markdown_path=markdown_path,
+        index_path=index_path,
+        dry_run=dry_run,
+        autonomous_replan_recorded_requested=bool(autonomous_replan_recorded),
     )
-    index_record["state"] = {
-        "sha256_16": record_state.get("sha256_16"),
-        "frontmatter": {
-            "updated_at": record_frontmatter.get("updated_at"),
-        },
-    }
-    index_record["runtime_projection_route"] = compact_route
-    if normalized_delivery_batch_scale:
-        index_record["delivery_batch_scale"] = normalized_delivery_batch_scale
-    if normalized_delivery_outcome:
-        index_record["delivery_outcome"] = normalized_delivery_outcome
-    if delivery_workspace:
-        index_record["delivery_workspace"] = delivery_workspace
-    if autonomous_replan_recorded:
-        index_record["autonomous_replan_ack"] = record["autonomous_replan_ack"]
-        if requested_classification != classification:
-            index_record["requested_classification"] = requested_classification
-    if agent_vision:
-        indexed_agent_vision = {
-            "schema_version": agent_vision.get("schema_version"),
-            "agent_id": agent_vision.get("agent_id"),
-            "state": agent_vision.get("state"),
-            "vision_patch": agent_vision.get("vision_patch")
-            if isinstance(agent_vision.get("vision_patch"), dict)
-            else {},
-            "todo_delta": agent_vision.get("todo_delta")
-            if isinstance(agent_vision.get("todo_delta"), list)
-            else [],
-            "vision_budget": agent_vision.get("vision_budget"),
-        }
-        if isinstance(agent_vision.get("path_delta"), dict):
-            indexed_agent_vision["path_delta"] = agent_vision["path_delta"]
-        index_record["agent_vision"] = indexed_agent_vision
-    if vision_checkpoint:
-        index_record["vision_checkpoint"] = vision_checkpoint
-    if normalized_progress_scope:
-        index_record["progress_scope"] = normalized_progress_scope
-    if normalized_agent_id:
-        index_record["agent_id"] = normalized_agent_id
-    if normalized_progress_scope == AGENT_LANE_PROGRESS_SCOPE and normalized_agent_id:
-        index_record["agent_lane"] = normalized_agent_lane or normalized_agent_id
-    payload = {
-        "ok": True,
-        "dry_run": dry_run,
-        "appended": not dry_run,
-        "registry": str(registry_path),
-        "runtime_root": str(runtime_root),
-        "project": str(resolved_project) if resolved_project else None,
-        "goal_id": safe_goal_id,
-        "classification": classification,
-        "progress_scope": record.get("progress_scope"),
-        "agent_id": record.get("agent_id"),
-        "agent_lane": record.get("agent_lane"),
-        "autonomous_replan_recorded": effective_autonomous_replan_recorded,
-        "autonomous_replan_recorded_requested": bool(autonomous_replan_recorded),
-        "repair_delta_contract": repair_delta_contract,
-        "agent_vision": agent_vision,
-        "vision_checkpoint": vision_checkpoint,
-        "recommended_action": action,
-        "recommended_action_source": recommended_action_source,
-        "active_state_next_action_update": active_state_next_action_update,
-        "generated_at": generated_at,
-        "health_check": record["health_check"],
-        "json_path": str(json_path),
-        "markdown_path": str(markdown_path),
-        "index_path": str(index_path),
-        **record,
-    }
     if dry_run:
         expected_write_scopes = ["runtime_history"]
         if active_state_next_action_update and active_state_next_action_update.get("would_update"):

--- a/tests/test_state_refresh_projections.py
+++ b/tests/test_state_refresh_projections.py
@@ -1,0 +1,97 @@
+from pathlib import Path
+
+from loopx import state_refresh
+
+
+def test_refresh_output_projections_preserve_optional_run_contracts() -> None:
+    delta_contract = {"schema_version": "repair_delta_contract_v0", "delta_present": True}
+    agent_vision = {
+        "schema_version": "goal_vision_v0",
+        "agent_id": "quality-agent",
+        "state": "vision_active",
+        "vision_patch": {"acceptance_summary": "Keep simplification measurable."},
+        "todo_delta": ["Simplify the projection owner."],
+        "vision_budget": {"status": "within_budget"},
+        "path_delta": {"changed": ["projection assembly"]},
+        "validation": {"budget_checked": True},
+    }
+    record = {
+        "generated_at": "2026-07-31T00:00:00+00:00",
+        "goal_id": "projection-fixture",
+        "classification": "validated_progress",
+        "recommended_action": "continue the measured simplification",
+        "recommended_action_source": "explicit_arg",
+        "health_check": "state_file 1/1",
+        "state": {
+            "path": "/ignored/project/state.md",
+            "sha256_16": "0123456789abcdef",
+            "frontmatter": {"updated_at": "2026-07-30T23:59:00+00:00", "status": "active"},
+            "next_action": ["continue"],
+        },
+        "runtime_projection_route": {"status": "resolved", "route_id": "route-1"},
+        "delivery_batch_scale": "single_surface",
+        "delivery_outcome": "outcome_progress",
+        "delivery_workspace": {"workspace_kind": "independent_git_worktree"},
+        "autonomous_replan_ack": {
+            "recorded": True,
+            "requested": True,
+            "requested_classification": "repair_completed",
+            "delta_contract": delta_contract,
+        },
+        "agent_vision": agent_vision,
+        "vision_checkpoint": {"decision": "patched", "satisfied": True},
+        "progress_scope": "agent_lane",
+        "agent_id": "quality-agent",
+        "agent_lane": "quality",
+        "active_state_next_action_update": {"updated": True},
+    }
+
+    index_record, payload = state_refresh._build_state_refresh_output_projections(
+        record=record,
+        registry_path=Path("/registry.json"),
+        runtime_root=Path("/runtime"),
+        project=Path("/project"),
+        json_path=Path("/runtime/run.json"),
+        markdown_path=Path("/runtime/run.md"),
+        index_path=Path("/runtime/index.jsonl"),
+        dry_run=False,
+        autonomous_replan_recorded_requested=True,
+    )
+
+    assert index_record["state"] == {
+        "sha256_16": "0123456789abcdef",
+        "frontmatter": {"updated_at": "2026-07-30T23:59:00+00:00"},
+    }
+    assert index_record["requested_classification"] == "repair_completed"
+    assert index_record["agent_vision"] == {
+        key: agent_vision[key]
+        for key in (
+            "schema_version",
+            "agent_id",
+            "state",
+            "vision_patch",
+            "todo_delta",
+            "vision_budget",
+            "path_delta",
+        )
+    }
+    assert "validation" not in index_record["agent_vision"]
+    for field in (
+        "delivery_batch_scale",
+        "delivery_outcome",
+        "delivery_workspace",
+        "autonomous_replan_ack",
+        "vision_checkpoint",
+        "progress_scope",
+        "agent_id",
+        "agent_lane",
+    ):
+        assert index_record[field] == record[field]
+
+    assert payload["appended"] is True
+    assert payload["autonomous_replan_recorded"] is True
+    assert payload["autonomous_replan_recorded_requested"] is True
+    assert payload["repair_delta_contract"] is delta_contract
+    assert payload["active_state_next_action_update"] == {"updated": True}
+    assert payload["agent_vision"] is agent_vision
+    assert payload["state"] is record["state"]


### PR DESCRIPTION
## Summary

- centralize refresh run, index, and CLI response projection assembly in one owner-local helper
- reuse the already validated refresh record instead of rebuilding optional delivery, vision, replan, and agent fields
- remove duplicate run ordering and redundant record writes
- add a focused parity test for optional projection fields

## Simplification

Exact `origin/main` comparison:

| Metric | Before | After |
| --- | ---: | ---: |
| `refresh_state_run` statements | 208 | 174 |
| `refresh_state_run` decisions | 116 | 93 |
| function lines | 530 | 444 |
| production module lines | 1,258 | 1,255 |

No new generic projection framework or public API is introduced.

## Validation

- 29 focused pytest cases passed
- 8 refresh-state regression smokes passed, covering unique paths, dry-run correctness, shared-runtime projection, vision budgets, next-action projection, workspace causality, and history reservation
- Ruff passed for changed Python files
- repository-declared mypy set passed
- public-boundary scan passed over `loopx/` and `tests/`
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` passed 12 selected checks with no manual holds
- exact-scope change-quality receipt: `cqr_4038cce0dc5e26232198`
