### PR TITLE
[WIP]feat(issue-fix): add sequential portfolio-plan command

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -839,13 +839,25 @@ single-repository or mixed-repository, explicit issue list. Automatic issue
 ranking/selection and bounded concurrency remain future work and are not
 introduced here.
 
+The simplest input is the repository's issues list URL or repo URL; LoopX
+enumerates its open issues via `gh issue list`:
+
 ```bash
 loopx issue-fix portfolio-plan \
-  --repo owner/repo --issues 5,7,12 \
+  --url https://github.com/owner/repo/issues \
+  --max-issues 5 \
   --goal-id <goal-id> --agent-id <agent-id> \
   --repo-path /path/to/approved/repo --base-branch origin/main \
   --execute
 ```
+
+For an explicit list, use `--repo owner/repo --issues 5,7,12` (or repeat
+`--url` with single-issue URLs). `--max-issues` caps auto-enumeration (default
+5); `--enumerated-issues-json` swaps a curated JSON list of numbers for the
+`gh` call (offline preview or pre-screened backlog). When `--execute` is used
+without `--goal-id`/`--agent-id`, the single registered project goal and its
+single registered agent are auto-resolved, so a project with one goal+agent can
+run the command with just the URL.
 
 Each candidate reuses the single-issue `workflow-plan` builder for body-free
 metadata intake and branch grounding; the portfolio emits only compact

--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -504,6 +504,7 @@ compatibility facade.
 | Acceptance fixture | `loopx issue-fix acceptance-fixture` | Prove failure-before, minimal patch, and pass-after in a deterministic fixture. |
 | Git branch fixture | `loopx issue-fix repo-branch-fixture` | Exercise the same repair contract through a temporary git branch. |
 | Caller repo branch | `loopx issue-fix caller-repo-branch` | Inspect an approved local repo, create/claim an issue branch, and run caller-declared validation. |
+| Sequential portfolio | `loopx issue-fix portfolio-plan` | Compose an explicit issue list into chained advancement todos: issue 1 runs immediately, issues 2..N stay deferred behind `resume_when=todo_done:<previous issue todo id>` and resume after the previous issue reaches a PR-ready or terminal disposition. Reuses the single-issue workflow-plan builder per candidate and adds no second ledger. |
 | Content bridge | `loopx content-ops issue-fix-*` | Reuse body-free public metadata/intake boundaries. |
 | Visible projection | `status`, `lark-kanban`, dashboard | Derive human-visible issue work, outcomes, gates, and Monthly Impact from the same kernel/domain state without becoming a second source of truth. |
 | Projection source reconcile | `lark-kanban sync-projection --reconcile-source` | Keep normal sync non-destructive; only a caller-attested complete source snapshot may preview and explicitly retire remote orphan rows plus stale local record mappings within that exact namespace. |
@@ -827,6 +828,44 @@ loopx start-goal --guided --project . \
 The conversational entry does not bypass issue selection, authority, or
 validation. It creates the durable goal/todo/host-loop route from which the
 issue-fix commands below can be executed.
+
+## Sequential Portfolio
+
+`loopx issue-fix portfolio-plan` turns an explicit list of issues into a
+sequential portfolio so a long-running employee can work through them one at a
+time without an operator re-pointing the loop at each issue. It is the first
+slice of the longer-term multi-repository portfolio roadmap item: sequential,
+single-repository or mixed-repository, explicit issue list. Automatic issue
+ranking/selection and bounded concurrency remain future work and are not
+introduced here.
+
+```bash
+loopx issue-fix portfolio-plan \
+  --repo owner/repo --issues 5,7,12 \
+  --goal-id <goal-id> --agent-id <agent-id> \
+  --repo-path /path/to/approved/repo --base-branch origin/main \
+  --execute
+```
+
+Each candidate reuses the single-issue `workflow-plan` builder for body-free
+metadata intake and branch grounding; the portfolio emits only compact
+candidate rows plus a chained todo preview. With `--execute`, it writes one
+`issue_fix_portfolio_advancement` advancement todo per issue:
+
+- issue 1 is written `open` and claimed by `--agent-id`, so it is immediately
+  runnable;
+- issues 2..N are written `deferred` with
+  `resume_when=todo_done:<previous issue todo id>`.
+
+When the agent marks an issue's todo done (PR created, or `comment_only` /
+`triage_only` terminal disposition), the next issue's `todo_done` resume
+condition becomes satisfied and the existing deferred-resume frontier advances
+it on a later bounded turn. Each PR keeps its own `continuous_monitor` todo so
+unmerged PRs coexist quietly while the next issue advances; the heartbeat stays
+generic and discovers portfolio work through ordinary status/quota/todo
+projection. The portfolio adds no parallel ledger: feasibility rows remain
+keyed by `{repo, issue_ref}` in the existing issue-fix domain state and are
+written lazily by the agent as each issue advances.
 
 ## Feasibility Decision
 

--- a/examples/issue-fix-portfolio-smoke.py
+++ b/examples/issue-fix-portfolio-smoke.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+GOAL_ID = "issue-fix-portfolio-smoke"
+AGENT_ID = "issue-fix-portfolio-agent"
+
+# A clearly fixture repository so the smoke never implies real issue state and
+# never touches the network (--fetch-metadata is off).
+REPO_LABEL = "example-owner/example-repo"
+ISSUE_NUMBERS = "101,102,103"
+
+
+def run_cli(registry: Path, args: list[str]) -> dict[str, Any]:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry),
+            "--format",
+            "json",
+            *args,
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def write_fixture(root: Path) -> tuple[Path, Path]:
+    project = root / "project"
+    project.mkdir()
+    state_file = project / "ACTIVE_GOAL_STATE.md"
+    state_file.write_text(
+        "# Issue Fix Portfolio Smoke\n\n"
+        "## User Todo / Owner Review Reading Queue\n\n"
+        "## Agent Todo\n",
+        encoding="utf-8",
+    )
+    registry = root / "registry.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "repo": str(project),
+                        "state_file": str(state_file),
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": [AGENT_ID],
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    return project, registry
+
+
+def _assert(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def _boundary_clean(flags: dict[str, Any]) -> bool:
+    return all(not value for value in flags.values())
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        project, registry = write_fixture(root)
+
+        read_only = run_cli(
+            registry,
+            [
+                "issue-fix",
+                "portfolio-plan",
+                "--repo",
+                REPO_LABEL,
+                "--issues",
+                ISSUE_NUMBERS,
+            ],
+        )
+        _assert(bool(read_only.get("ok")), "read-only portfolio packet must be ok")
+        _assert(
+            read_only.get("schema_version") == "issue_fix_portfolio_packet_v0",
+            "read-only packet schema_version must be issue_fix_portfolio_packet_v0",
+        )
+        _assert(
+            read_only.get("candidate_count") == 3,
+            "read-only packet must list 3 candidates",
+        )
+        chain = read_only.get("chain") or []
+        _assert(len(chain) == 3, "read-only packet must list 3 chain entries")
+        _assert(
+            chain[0]["status"] == "open"
+            and chain[0]["resume_depends_on_order"] is None
+            and chain[0]["resume_when_pattern"] is None,
+            "issue 1 must be open with no resume dependency",
+        )
+        _assert(
+            chain[1]["status"] == "deferred"
+            and chain[1]["resume_depends_on_order"] == 1
+            and chain[1]["resume_when_pattern"] == "todo_done:{previous_issue_todo_id}",
+            "issue 2 must be deferred behind issue 1's todo_done",
+        )
+        _assert(
+            chain[2]["status"] == "deferred"
+            and chain[2]["resume_depends_on_order"] == 2,
+            "issue 3 must be deferred behind issue 2's todo_done",
+        )
+        _assert(
+            not read_only.get("todo_write_performed"),
+            "read-only packet must not perform todo writes",
+        )
+        _assert(
+            _boundary_clean(read_only.get("boundary_flags") or {}),
+            "read-only packet must stay body-free and path-free",
+        )
+
+        applied = run_cli(
+            registry,
+            [
+                "issue-fix",
+                "portfolio-plan",
+                "--repo",
+                REPO_LABEL,
+                "--issues",
+                ISSUE_NUMBERS,
+                "--execute",
+                "--goal-id",
+                GOAL_ID,
+                "--agent-id",
+                AGENT_ID,
+                "--project",
+                str(project),
+            ],
+        )
+        _assert(bool(applied.get("ok")), "apply packet must be ok")
+        _assert(
+            applied.get("todo_write_performed") is True,
+            "apply packet must report todo_write_performed",
+        )
+        todos = applied.get("applied_todos") or []
+        _assert(len(todos) == 3, "apply must write 3 chained todos")
+        todo_ids = [entry.get("todo_id") for entry in todos]
+        _assert(
+            len({tid for tid in todo_ids if tid}) == 3,
+            "each applied todo must have a unique todo_id",
+        )
+
+        first = todos[0]
+        _assert(
+            first["status"] == "open"
+            and first["claimed_by"] == AGENT_ID
+            and first["resume_when"] is None,
+            "issue 1 todo must be open, claimed by the agent, and have no resume_when",
+        )
+
+        for index in (1, 2):
+            entry = todos[index]
+            previous = todos[index - 1]
+            expected_resume = f"todo_done:{previous['todo_id']}"
+            _assert(
+                entry["status"] == "deferred"
+                and entry["resume_when"] == expected_resume,
+                f"issue {index + 1} todo must be deferred behind "
+                f"{previous['todo_id']!r} via {expected_resume!r}, got status="
+                f"{entry.get('status')!r} resume_when={entry.get('resume_when')!r}",
+            )
+            _assert(
+                entry["action_kind"] == "issue_fix_portfolio_advancement",
+                "applied todos must use the issue_fix_portfolio_advancement action kind",
+            )
+            _assert(
+                bool(entry["task_repository"]),
+                "applied todos must carry a task_repository pin",
+            )
+
+        _assert(
+            _boundary_clean(applied.get("boundary_flags") or {}),
+            "apply packet must keep the public/private boundary clean",
+        )
+
+        # The state file must persist the deferred chain so the heartbeat can
+        # project resume readiness on a later bounded turn.
+        state_text = (project / "ACTIVE_GOAL_STATE.md").read_text(encoding="utf-8")
+        _assert(
+            "resume_when=" in state_text and "todo_done:" in state_text,
+            "state file must persist resume_when todo_done linkage for deferred issues",
+        )
+        _assert(
+            state_text.count("issue_fix_portfolio_advancement") == 3,
+            "state file must record all three advancement todos",
+        )
+
+    print("issue-fix-portfolio-smoke: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/issue-fix-portfolio-smoke.py
+++ b/examples/issue-fix-portfolio-smoke.py
@@ -211,6 +211,69 @@ def main() -> int:
             "state file must record all three advancement todos",
         )
 
+        # A list/repo URL must auto-enumerate into candidate issues, and with
+        # --execute but no --goal-id/--agent-id the single registered goal+agent
+        # must be auto-resolved so a user can type just the URL.
+        override_path = root / "enum-override.json"
+        override_path.write_text("[201,202]", encoding="utf-8")
+        enumerated = run_cli(
+            registry,
+            [
+                "issue-fix",
+                "portfolio-plan",
+                "--url",
+                "https://github.com/example-owner/example-repo/issues",
+                "--enumerated-issues-json",
+                str(override_path),
+                "--max-issues",
+                "8",
+            ],
+        )
+        _assert(bool(enumerated.get("ok")), "enumerated portfolio packet must be ok")
+        enum_log = (enumerated.get("enumeration") or {}).get("enumerated_repos") or []
+        _assert(len(enum_log) == 1, "enumeration log must record the one repo URL")
+        _assert(
+            enum_log[0]["source"] == "caller_override"
+            and enum_log[0]["numbers"] == [201, 202],
+            "enumeration override must record the curated numbers in order",
+        )
+        enum_candidates = enumerated.get("candidates") or []
+        _assert(
+            [c.get("number") for c in enum_candidates] == [201, 202],
+            "list URL must expand into one candidate per enumerated issue",
+        )
+
+        auto_applied = run_cli(
+            registry,
+            [
+                "issue-fix",
+                "portfolio-plan",
+                "--url",
+                "https://github.com/example-owner/example-repo/issues",
+                "--enumerated-issues-json",
+                str(override_path),
+                "--max-issues",
+                "8",
+                "--execute",
+                "--project",
+                str(project),
+            ],
+        )
+        _assert(bool(auto_applied.get("ok")), "auto-resolved apply must be ok")
+        auto_todos = auto_applied.get("applied_todos") or []
+        _assert(len(auto_todos) == 2, "auto-resolved apply must write 2 todos")
+        _assert(
+            auto_todos[0]["status"] == "open"
+            and auto_todos[0]["claimed_by"] == AGENT_ID,
+            "auto-resolved apply must claim issue 1 with the single registered agent",
+        )
+        _assert(
+            auto_todos[1]["status"] == "deferred"
+            and auto_todos[1]["resume_when"]
+            == f"todo_done:{auto_todos[0]['todo_id']}",
+            "auto-resolved apply must still chain issue 2 behind issue 1",
+        )
+
     print("issue-fix-portfolio-smoke: PASS")
     return 0
 

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -91,6 +91,11 @@ from .workflow_plan import (
     build_issue_fix_workflow_plan_packet,
     render_issue_fix_workflow_plan_markdown,
 )
+from .portfolio import (
+    apply_issue_fix_portfolio,
+    build_issue_fix_portfolio_packet,
+    render_issue_fix_portfolio_markdown,
+)
 
 
 PrintPayload = Callable[
@@ -919,6 +924,107 @@ def register_issue_fix_commands(
     )
     _add_generated_at_arg(caller_branch_parser, artifact="the artifact")
 
+    portfolio_parser = issue_fix_sub.add_parser(
+        "portfolio-plan",
+        help=(
+            "Plan a sequential portfolio of issues as chained advancement todos. "
+            "Issue 1 runs immediately; issues 2..N resume after the previous issue "
+            "reaches a PR-ready or terminal disposition."
+        ),
+    )
+    add_subcommand_format(portfolio_parser)
+    portfolio_parser.add_argument(
+        "--repo",
+        default=None,
+        help=(
+            "Public-safe repository label (owner/repo) used with --issues when no "
+            "--url is provided. Required with --issues."
+        ),
+    )
+    portfolio_parser.add_argument(
+        "--issues",
+        default=None,
+        help=(
+            "Comma-separated issue numbers to fix in --repo, e.g. 5,7,12. "
+            "Combined with --url entries; at least one source is required."
+        ),
+    )
+    portfolio_parser.add_argument(
+        "--url",
+        action="append",
+        default=None,
+        help=(
+            "Public https://github.com/owner/repo/issues/123 URL. Repeat for "
+            "multiple issues. Combined with --issues; at least one source is "
+            "required."
+        ),
+    )
+    portfolio_parser.add_argument(
+        "--fetch-metadata",
+        action="store_true",
+        help=(
+            "Fetch body-free public GitHub metadata for each candidate issue with "
+            "gh api --jq. Only body-free fields are captured."
+        ),
+    )
+    portfolio_parser.add_argument(
+        "--fetch-timeout-seconds",
+        type=int,
+        default=10,
+        help="Per-candidate timeout for --fetch-metadata.",
+    )
+    portfolio_parser.add_argument(
+        "--repo-path",
+        default=None,
+        help=(
+            "Optional caller-approved local git repository path shared by all "
+            "candidates. Planning keeps this as a dry-run and never records the path."
+        ),
+    )
+    portfolio_parser.add_argument(
+        "--base-branch",
+        default="main",
+        help="Approved local base branch for the eventual issue branches.",
+    )
+    portfolio_parser.add_argument(
+        "--validation-label",
+        default="caller-declared validation",
+        help="Public-safe validation label stored in each candidate workflow plan.",
+    )
+    portfolio_parser.add_argument(
+        "--required-write-scope",
+        action="append",
+        default=None,
+        help=(
+            "Optional write-scope glob attached to every advancement todo for "
+            "future bounded-concurrency boundaries. Repeat for multiple scopes."
+        ),
+    )
+    portfolio_parser.add_argument(
+        "--goal-id",
+        default=None,
+        help="Goal id required to write the chained todos with --execute.",
+    )
+    portfolio_parser.add_argument(
+        "--agent-id",
+        default=None,
+        help="Registered agent id that claims issue 1 with --execute.",
+    )
+    portfolio_parser.add_argument(
+        "--project",
+        default=".",
+        help="Project root used to resolve the goal todo state with --execute.",
+    )
+    portfolio_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help=(
+            "Write the chained advancement todos. Without this flag, return a "
+            "read-only portfolio plan."
+        ),
+    )
+    _add_generated_at_arg(portfolio_parser, artifact="the portfolio plan")
+
 
 def handle_issue_fix_command(
     args: argparse.Namespace,
@@ -1726,6 +1832,51 @@ def handle_issue_fix_command(
                 generated_at=generated_at,
             )
             renderer = render_issue_fix_acceptance_loop_markdown
+        elif args.issue_fix_command == "portfolio-plan":
+            candidate_inputs: list[dict[str, Any]] = []
+            if args.issues:
+                if not args.repo:
+                    raise ValueError("--issues requires an explicit --repo owner/repo")
+                for token in args.issues.split(","):
+                    number = token.strip()
+                    if not number:
+                        continue
+                    if not number.isdigit():
+                        raise ValueError(
+                            "--issues entries must be numeric issue numbers"
+                        )
+                    candidate_inputs.append({"repo": args.repo, "issue_number": number})
+            for url in args.url or []:
+                url = str(url).strip()
+                if url:
+                    candidate_inputs.append({"url": url})
+            if not candidate_inputs:
+                raise ValueError("portfolio-plan requires --issues or --url")
+            plan = build_issue_fix_portfolio_packet(
+                candidate_inputs=candidate_inputs,
+                fetch_metadata=args.fetch_metadata,
+                fetch_timeout_seconds=args.fetch_timeout_seconds,
+                repo_path=args.repo_path,
+                base_branch=args.base_branch,
+                validation_label=args.validation_label,
+                generated_at=generated_at,
+            )
+            if args.execute:
+                if not args.goal_id:
+                    raise ValueError("--execute requires --goal-id")
+                if not args.agent_id:
+                    raise ValueError("--execute requires --agent-id")
+                payload = apply_issue_fix_portfolio(
+                    registry_path=registry_path or Path.cwd(),
+                    goal_id=args.goal_id,
+                    agent_id=args.agent_id,
+                    candidates=plan.get("candidates") or [],
+                    required_write_scopes=args.required_write_scope,
+                    project=Path(args.project) if args.project else None,
+                )
+            else:
+                payload = plan
+            renderer = render_issue_fix_portfolio_markdown
         else:
             raise ValueError(
                 "issue-fix requires `repository-memory-sync`, `promote-discovered-issue`, "
@@ -1734,7 +1885,7 @@ def handle_issue_fix_command(
                 "`metrics-supplement`, "
                 "`repository-snapshot`, `reviewer-plan`, "
                 "`reviewer-request`, `reviewer-notification-drain`, "
-                "`repo-branch-fixture`, or `caller-repo-branch`"
+                "`repo-branch-fixture`, `caller-repo-branch`, or `portfolio-plan`"
             )
     except Exception as exc:
         payload = {

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -37,6 +37,7 @@ from .discovered_issue_promotion import (
 )
 from .cli_input import (
     _MAX_INLINE_JSON_CHARS as _MAX_INLINE_JSON_CHARS,
+    load_json_list as _load_json_list,
     load_json_object as _load_json_object,
     load_jsonl_row as _load_jsonl_row,
     load_jsonl_rows as _load_jsonl_rows,
@@ -237,6 +238,36 @@ def _goal_boundary_authority_projection(
         else []
     )
     return [str(scope) for scope in scopes], True
+
+
+def _resolve_default_goal_and_agent(
+    registry_path: Path | None,
+) -> tuple[str | None, str | None]:
+    """Resolve the single registered goal and its single registered agent.
+
+    Used so a user can run `portfolio-plan --url <issues-list> --execute`
+    without retyping the goal/agent when the project has exactly one of each.
+    Returns ``(goal_id, agent_id)`` or ``(None, None)`` when ambiguous.
+    """
+
+    from ...registry import read_json, registry_goals
+    from ...agent_registry import registered_agent_ids_for_goal
+
+    if registry_path is None or not registry_path.exists():
+        return None, None
+    try:
+        goals = registry_goals(read_json(registry_path))
+    except Exception:
+        return None, None
+    if len(goals) != 1:
+        return None, None
+    goal = goals[0]
+    goal_id = str(goal.get("id") or "").strip() or None
+    if not goal_id:
+        return None, None
+    agents = registered_agent_ids_for_goal(goal)
+    agent_id = agents[0] if len(agents) == 1 else None
+    return goal_id, agent_id
 
 
 def register_issue_fix_commands(
@@ -1001,14 +1032,39 @@ def register_issue_fix_commands(
         ),
     )
     portfolio_parser.add_argument(
+        "--max-issues",
+        type=int,
+        default=5,
+        help=(
+            "Cap on open issues auto-enumerated from a list/repo --url. Ignored "
+            "for explicit --issues numbers."
+        ),
+    )
+    portfolio_parser.add_argument(
+        "--enumerated-issues-json",
+        default=None,
+        help=(
+            "Path to a JSON list of issue numbers (or '-' for stdin) used instead "
+            "of `gh issue list` when --url is a list/repo URL. Lets a curated "
+            "list or offline preview drive enumeration without network."
+        ),
+    )
+    portfolio_parser.add_argument(
         "--goal-id",
         default=None,
-        help="Goal id required to write the chained todos with --execute.",
+        help=(
+            "Goal id required to write the chained todos with --execute. When "
+            "omitted with --execute, the single registered project goal is used "
+            "if exactly one exists."
+        ),
     )
     portfolio_parser.add_argument(
         "--agent-id",
         default=None,
-        help="Registered agent id that claims issue 1 with --execute.",
+        help=(
+            "Registered agent id that claims issue 1 with --execute. When omitted "
+            "with --execute, the single registered agent for the goal is used."
+        ),
     )
     portfolio_parser.add_argument(
         "--project",
@@ -1852,6 +1908,14 @@ def handle_issue_fix_command(
                     candidate_inputs.append({"url": url})
             if not candidate_inputs:
                 raise ValueError("portfolio-plan requires --issues or --url")
+            enumerated_override: list[int] | None = None
+            if args.enumerated_issues_json:
+                raw_override = _load_json_list(args.enumerated_issues_json)
+                enumerated_override = [
+                    int(value)
+                    for value in raw_override
+                    if isinstance(value, int) and not isinstance(value, bool)
+                ]
             plan = build_issue_fix_portfolio_packet(
                 candidate_inputs=candidate_inputs,
                 fetch_metadata=args.fetch_metadata,
@@ -1860,16 +1924,34 @@ def handle_issue_fix_command(
                 base_branch=args.base_branch,
                 validation_label=args.validation_label,
                 generated_at=generated_at,
+                enumerate_max_issues=args.max_issues,
+                enumerated_issues_override=enumerated_override,
+                enumerate_timeout_seconds=args.fetch_timeout_seconds,
             )
             if args.execute:
-                if not args.goal_id:
-                    raise ValueError("--execute requires --goal-id")
-                if not args.agent_id:
-                    raise ValueError("--execute requires --agent-id")
+                resolved_registry = registry_path or Path.cwd()
+                goal_id = args.goal_id
+                agent_id = args.agent_id
+                if not goal_id or not agent_id:
+                    default_goal, default_agent = _resolve_default_goal_and_agent(
+                        resolved_registry
+                    )
+                    goal_id = goal_id or default_goal
+                    agent_id = agent_id or default_agent
+                if not goal_id:
+                    raise ValueError(
+                        "--execute requires --goal-id, or a single registered "
+                        "project goal to auto-resolve"
+                    )
+                if not agent_id:
+                    raise ValueError(
+                        "--execute requires --agent-id, or a single registered "
+                        "agent for the goal to auto-resolve"
+                    )
                 payload = apply_issue_fix_portfolio(
-                    registry_path=registry_path or Path.cwd(),
-                    goal_id=args.goal_id,
-                    agent_id=args.agent_id,
+                    registry_path=resolved_registry,
+                    goal_id=goal_id,
+                    agent_id=agent_id,
                     candidates=plan.get("candidates") or [],
                     required_write_scopes=args.required_write_scope,
                     project=Path(args.project) if args.project else None,

--- a/loopx/capabilities/issue_fix/cli_input.py
+++ b/loopx/capabilities/issue_fix/cli_input.py
@@ -9,7 +9,7 @@ from typing import Any
 _MAX_INLINE_JSON_CHARS = 1_048_576
 
 
-def load_json_object(input_text: str) -> dict[str, Any]:
+def _read_json_text(input_text: str) -> tuple[str, Any]:
     stripped = input_text.lstrip()
     if input_text == "-":
         source = "stdin"
@@ -29,8 +29,21 @@ def load_json_object(input_text: str) -> dict[str, Any]:
         payload = json.loads(raw)
     except json.JSONDecodeError:
         raise ValueError("JSON input is invalid") from None
+    return source, payload
+
+
+def load_json_object(input_text: str) -> dict[str, Any]:
+    _source, payload = _read_json_text(input_text)
     if not isinstance(payload, dict):
         raise ValueError("JSON input must contain an object")
+    return payload
+
+
+def load_json_list(input_text: str) -> list[Any]:
+    source, payload = _read_json_text(input_text)
+    del source
+    if not isinstance(payload, list):
+        raise ValueError("JSON input must contain a list")
     return payload
 
 

--- a/loopx/capabilities/issue_fix/portfolio.py
+++ b/loopx/capabilities/issue_fix/portfolio.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from typing import Any, Mapping
 from collections.abc import Sequence
+from urllib.parse import urlsplit, urlunsplit
 
 from ...repository_identity import normalize_repository_identity
 from ...control_plane.runtime.time import now_utc_iso
@@ -58,6 +60,149 @@ def _resolve_candidate_reference(candidate: Mapping[str, Any]) -> dict[str, Any]
     )
 
 
+def _classify_portfolio_url(url: str) -> dict[str, Any]:
+    """Classify a GitHub URL as a single issue or a repo/issues-list to enumerate.
+
+    Accepts ``/owner/repo/issues/N`` (single), ``/owner/repo/issues`` (list),
+    or ``/owner/repo`` (whole repo). List/repo URLs are enumerated into open
+    issues; query/fragment (e.g. ``?page=2``) is dropped because ``gh issue
+    list`` re-derives the open set.
+    """
+
+    parsed = urlsplit(url.strip())
+    if parsed.scheme != "https":
+        raise ValueError("portfolio URL must use https")
+    if (parsed.hostname or "").lower().rstrip(".") != "github.com":
+        raise ValueError("portfolio URL must use github.com")
+    if parsed.username or parsed.password:
+        raise ValueError("portfolio URL must not include credentials")
+    parts = [part for part in parsed.path.split("/") if part]
+    if len(parts) == 4 and parts[2] == "issues" and parts[3].isdigit():
+        return {
+            "kind": "single",
+            "url": urlunsplit(("https", "github.com", "/" + "/".join(parts), "", "")),
+        }
+    if len(parts) == 3 and parts[2] == "issues":
+        repo = f"{parts[0]}/{parts[1]}"
+        return {
+            "kind": "enumerate",
+            "repo": repo,
+            "repo_url": urlunsplit(("https", "github.com", f"/{parts[0]}/{parts[1]}", "", "")),
+        }
+    if len(parts) == 2:
+        repo = f"{parts[0]}/{parts[1]}"
+        return {
+            "kind": "enumerate",
+            "repo": repo,
+            "repo_url": urlunsplit(("https", "github.com", f"/{parts[0]}/{parts[1]}", "", "")),
+        }
+    raise ValueError(
+        "portfolio URL must be /owner/repo/issues/N, /owner/repo/issues, "
+        "or /owner/repo"
+    )
+
+
+def enumerate_open_issue_numbers(
+    repo: str,
+    *,
+    limit: int,
+    timeout: int = 10,
+) -> list[int]:
+    """Return open issue numbers for a repo via ``gh issue list`` (body-free)."""
+
+    if limit <= 0:
+        return []
+    result = subprocess.run(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number",
+            "--jq",
+            ".[].number",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise ValueError(
+            f"gh issue list failed for {repo}: "
+            f"{(result.stderr or '').strip() or 'no output'}"
+        )
+    numbers: list[int] = []
+    for line in result.stdout.splitlines():
+        token = line.strip()
+        if token.isdigit():
+            numbers.append(int(token))
+    return sorted(numbers)
+
+
+def _expand_candidate_inputs(
+    candidate_inputs: Sequence[Mapping[str, Any]],
+    *,
+    enumerate_max_issues: int,
+    enumerated_issues_override: Sequence[int] | None,
+    enumerate_timeout_seconds: int,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Expand list/repo URLs into single-issue candidate inputs.
+
+    Returns ``(expanded_inputs, enumeration_log)``. ``enumeration_log`` records
+    each enumerated repo and the numbers used, so the packet stays transparent
+    about where its candidates came from.
+    """
+
+    expanded: list[dict[str, Any]] = []
+    enumeration_log: list[dict[str, Any]] = []
+    for raw in candidate_inputs:
+        url = str(raw.get("url") or "").strip() or None
+        if url:
+            classified = _classify_portfolio_url(url)
+            if classified["kind"] == "single":
+                expanded.append({"url": classified["url"]})
+                continue
+            repo = str(classified["repo"])
+            if enumerated_issues_override is not None:
+                numbers = list(enumerated_issues_override)
+                source = "caller_override"
+            else:
+                numbers = enumerate_open_issue_numbers(
+                    repo,
+                    limit=enumerate_max_issues,
+                    timeout=enumerate_timeout_seconds,
+                )
+                source = "gh_issue_list"
+            numbers = sorted(set(int(n) for n in numbers if str(n).isdigit()))[
+                :enumerate_max_issues
+            ]
+            if not numbers:
+                raise ValueError(
+                    f"no open issues enumerated for {repo}; pass explicit "
+                    "--issues or check gh auth/repo access"
+                )
+            enumeration_log.append(
+                {
+                    "repo": repo,
+                    "source": source,
+                    "count": len(numbers),
+                    "numbers": numbers,
+                }
+            )
+            for number in numbers:
+                expanded.append({"repo": repo, "issue_number": str(number)})
+        else:
+            expanded.append(dict(raw))
+    return expanded, enumeration_log
+
+
 def _repo_url_from_reference(reference: Mapping[str, Any]) -> str | None:
     permalink = reference.get("permalink")
     if permalink:
@@ -93,6 +238,9 @@ def build_issue_fix_portfolio_packet(
     base_branch: str = "main",
     validation_label: str = "caller-declared validation",
     generated_at: str | None = None,
+    enumerate_max_issues: int = 5,
+    enumerated_issues_override: Sequence[int] | None = None,
+    enumerate_timeout_seconds: int = 10,
 ) -> dict[str, Any]:
     """Build a public-safe sequential portfolio plan without writing state.
 
@@ -102,11 +250,23 @@ def build_issue_fix_portfolio_packet(
     are deferred behind ``todo_done:<previous issue todo id>`` so the heartbeat
     advances them one at a time after the previous issue reaches a PR-ready (or
     terminal) disposition.
+
+    A candidate ``url`` may be a single issue (``/issues/N``), the issues list
+    page (``/issues``), or a repo (``/owner/repo``); list/repo URLs are
+    enumerated into open issues via ``gh issue list`` unless
+    ``enumerated_issues_override`` supplies a curated list.
     """
 
     timestamp = generated_at or now_utc_iso()
     if not candidate_inputs:
         raise ValueError("portfolio-plan requires at least one candidate issue")
+
+    candidate_inputs, enumeration_log = _expand_candidate_inputs(
+        candidate_inputs,
+        enumerate_max_issues=enumerate_max_issues,
+        enumerated_issues_override=enumerated_issues_override,
+        enumerate_timeout_seconds=enumerate_timeout_seconds,
+    )
 
     candidates: list[dict[str, Any]] = []
     chain: list[dict[str, Any]] = []
@@ -196,13 +356,18 @@ def build_issue_fix_portfolio_packet(
         "candidate_count": len(candidates),
         "candidates": candidates,
         "chain": chain,
+        "enumeration": {
+            "max_issues": enumerate_max_issues,
+            "override_used": enumerated_issues_override is not None,
+            "enumerated_repos": enumeration_log,
+        },
         "boundary_flags": merged_boundary,
         "external_reads_performed": bool(fetch_metadata),
         "external_writes_performed": False,
         "todo_write_performed": False,
         "next_safe_action": (
-            "Apply with --execute --goal-id --agent-id to write the chained "
-            "advancement todos; the heartbeat then advances one issue at a time."
+            "Apply with --execute to write the chained advancement todos; the "
+            "heartbeat then advances one issue at a time."
         ),
     }
 
@@ -349,6 +514,21 @@ def render_issue_fix_portfolio_markdown(payload: dict[str, Any]) -> str:
                 f"- order {entry.get('order')} `{entry.get('issue_ref')}`: "
                 f"status=`{entry.get('status')}`, "
                 f"resume_depends_on_order=`{entry.get('resume_depends_on_order')}`"
+            )
+
+    enumeration = payload.get("enumeration")
+    if isinstance(enumeration, Mapping) and enumeration.get("enumerated_repos"):
+        lines.append("")
+        lines.append("## Enumeration")
+        lines.append("")
+        lines.append(f"- max_issues: `{enumeration.get('max_issues')}`")
+        lines.append(f"- override_used: `{enumeration.get('override_used')}`")
+        for entry in enumeration.get("enumerated_repos") or []:
+            if not isinstance(entry, Mapping):
+                continue
+            lines.append(
+                f"- repo `{entry.get('repo')}`: source=`{entry.get('source')}`, "
+                f"count=`{entry.get('count')}`, numbers=`{entry.get('numbers')}`"
             )
 
     applied = payload.get("applied_todos")

--- a/loopx/capabilities/issue_fix/portfolio.py
+++ b/loopx/capabilities/issue_fix/portfolio.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+from collections.abc import Sequence
+
+from ...repository_identity import normalize_repository_identity
+from ...control_plane.runtime.time import now_utc_iso
+from ...todos import add_goal_todo
+from .metadata_preview import normalise_github_issue_reference
+from .workflow_plan import build_issue_fix_workflow_plan_packet
+
+ISSUE_FIX_PORTFOLIO_PACKET_SCHEMA_VERSION = "issue_fix_portfolio_packet_v0"
+PORTFOLIO_ADVANCEMENT_ACTION_KIND = "issue_fix_portfolio_advancement"
+PORTFOLIO_EXECUTION_MODEL = "sequential_pr_ready_advance"
+
+_BOUNDARY_FLAG_FIELDS = (
+    "issue_body_captured",
+    "comment_bodies_captured",
+    "response_payloads_captured",
+    "raw_logs_captured",
+    "local_paths_captured",
+    "private_repo_state_read",
+)
+
+
+def _portfolio_advance_todo_text(
+    repo_label: str,
+    issue_label: str,
+    permalink: str | None,
+) -> str:
+    link = f" ({permalink})" if permalink else ""
+    return (
+        f"[P0] Advance issue-fix for {repo_label} {issue_label}{link}: run "
+        "`loopx issue-fix workflow-plan` and `loopx issue-fix feasibility` for this "
+        "issue, pursue the selected route (fix_pr, comment_only, or triage_only), and "
+        "mark this todo done once the PR is created or the route reaches a terminal "
+        "disposition so the next portfolio issue can resume."
+    )
+
+
+def _resolve_candidate_reference(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    url = str(candidate.get("url") or "").strip() or None
+    repo = str(candidate.get("repo") or "").strip() or None
+    issue_number = candidate.get("issue_number")
+    if url:
+        return normalise_github_issue_reference(url=url)
+    if repo and issue_number is not None:
+        digits = str(issue_number).strip()
+        if not digits.isdigit():
+            raise ValueError(
+                "portfolio candidate issue_number must be a positive integer"
+            )
+        constructed = f"https://github.com/{repo}/issues/{digits}"
+        return normalise_github_issue_reference(url=constructed)
+    raise ValueError(
+        "portfolio candidate requires either a --url or a --repo plus an issue number"
+    )
+
+
+def _repo_url_from_reference(reference: Mapping[str, Any]) -> str | None:
+    permalink = reference.get("permalink")
+    if permalink:
+        for sep in ("/issues/", "/pull/"):
+            idx = permalink.find(sep)
+            if idx > 0:
+                return str(permalink[:idx])
+    repo = reference.get("repo")
+    if repo:
+        return f"https://github.com/{repo}"
+    return None
+
+
+def _boundary_flags_from_single_plan(single_plan: Mapping[str, Any]) -> dict[str, bool]:
+    return {field: bool(single_plan.get(field)) for field in _BOUNDARY_FLAG_FIELDS}
+
+
+def _merge_boundary_flags(flag_sets: list[Mapping[str, Any]]) -> dict[str, bool]:
+    merged = {field: False for field in _BOUNDARY_FLAG_FIELDS}
+    for flags in flag_sets:
+        for field in _BOUNDARY_FLAG_FIELDS:
+            if flags.get(field):
+                merged[field] = True
+    return merged
+
+
+def build_issue_fix_portfolio_packet(
+    *,
+    candidate_inputs: Sequence[Mapping[str, Any]],
+    fetch_metadata: bool = False,
+    fetch_timeout_seconds: int = 10,
+    repo_path: str | None = None,
+    base_branch: str = "main",
+    validation_label: str = "caller-declared validation",
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    """Build a public-safe sequential portfolio plan without writing state.
+
+    Each candidate reuses the single-issue workflow plan builder for body-free
+    metadata intake and branch grounding. The portfolio emits compact candidate
+    rows plus a chained todo preview: issue 1 is open and runnable, issues 2..N
+    are deferred behind ``todo_done:<previous issue todo id>`` so the heartbeat
+    advances them one at a time after the previous issue reaches a PR-ready (or
+    terminal) disposition.
+    """
+
+    timestamp = generated_at or now_utc_iso()
+    if not candidate_inputs:
+        raise ValueError("portfolio-plan requires at least one candidate issue")
+
+    candidates: list[dict[str, Any]] = []
+    chain: list[dict[str, Any]] = []
+    boundary_flag_sets: list[Mapping[str, Any]] = []
+
+    for index, raw_candidate in enumerate(candidate_inputs):
+        reference = _resolve_candidate_reference(raw_candidate)
+        repo_label = str(reference["repo"])
+        issue_label = str(reference["issue_ref"])
+        permalink = reference.get("permalink")
+        order = index + 1
+
+        single_plan = build_issue_fix_workflow_plan_packet(
+            repo=repo_label,
+            issue_ref=issue_label,
+            url=permalink,
+            provider_payload=None,
+            fetch_metadata=fetch_metadata,
+            fetch_timeout_seconds=fetch_timeout_seconds,
+            repo_path=repo_path,
+            base_branch=base_branch,
+            validation_label=validation_label,
+            generated_at=timestamp,
+        )
+        issue_signal = single_plan.get("issue_signal")
+        if not isinstance(issue_signal, Mapping):
+            issue_signal = {}
+        branch_plan = single_plan.get("branch_plan")
+        branch_status = (
+            branch_plan.get("status") if isinstance(branch_plan, Mapping) else None
+        )
+        single_boundary = _boundary_flags_from_single_plan(single_plan)
+        boundary_flag_sets.append(single_boundary)
+
+        task_repository = None
+        repo_url = _repo_url_from_reference(reference)
+        if repo_url:
+            task_repository = normalize_repository_identity(repo_url)
+
+        candidates.append(
+            {
+                "order": order,
+                "repo": repo_label,
+                "issue_ref": issue_label,
+                "number": reference.get("number"),
+                "permalink": permalink,
+                "kind": reference.get("kind"),
+                "state": issue_signal.get("state"),
+                "labels": list(issue_signal.get("labels") or []),
+                "branch_plan_status": branch_status,
+                "validation_label": validation_label,
+                "task_repository": task_repository,
+                "single_issue_workflow_plan_available": True,
+                "boundary_flags": single_boundary,
+            }
+        )
+
+        is_first = order == 1
+        chain.append(
+            {
+                "order": order,
+                "issue_ref": issue_label,
+                "repo": repo_label,
+                "status": "open" if is_first else "deferred",
+                "action_kind": PORTFOLIO_ADVANCEMENT_ACTION_KIND,
+                "task_repository": task_repository,
+                "todo_text": _portfolio_advance_todo_text(
+                    repo_label, issue_label, permalink
+                ),
+                "resume_depends_on_order": None if is_first else order - 1,
+                "resume_when_pattern": (
+                    None
+                    if is_first
+                    else "todo_done:{previous_issue_todo_id}"
+                ),
+                "claimed_by_first": is_first,
+            }
+        )
+
+    merged_boundary = _merge_boundary_flags(boundary_flag_sets)
+    return {
+        "ok": True,
+        "schema_version": ISSUE_FIX_PORTFOLIO_PACKET_SCHEMA_VERSION,
+        "mode": "issue-fix-portfolio-plan",
+        "generated_at": timestamp,
+        "execution_model": PORTFOLIO_EXECUTION_MODEL,
+        "candidate_count": len(candidates),
+        "candidates": candidates,
+        "chain": chain,
+        "boundary_flags": merged_boundary,
+        "external_reads_performed": bool(fetch_metadata),
+        "external_writes_performed": False,
+        "todo_write_performed": False,
+        "next_safe_action": (
+            "Apply with --execute --goal-id --agent-id to write the chained "
+            "advancement todos; the heartbeat then advances one issue at a time."
+        ),
+    }
+
+
+def apply_issue_fix_portfolio(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    agent_id: str,
+    candidates: Sequence[Mapping[str, Any]],
+    required_write_scopes: list[str] | None = None,
+    project: Path | None = None,
+) -> dict[str, Any]:
+    """Write the chained portfolio advancement todos for a sequential run.
+
+    Issue 1 is written open and claimed by ``agent_id`` so it is immediately
+    runnable. Issues 2..N are written deferred behind
+    ``resume_when=todo_done:<previous issue todo id>``. When the agent marks an
+    issue's todo done (PR created or route terminal), the next issue's
+    ``todo_done`` resume condition becomes satisfied and the heartbeat advances
+    it through the existing deferred-resume frontier.
+    """
+
+    if not candidates:
+        raise ValueError("portfolio apply requires at least one candidate issue")
+    if not agent_id:
+        raise ValueError("portfolio apply requires a registered --agent-id")
+
+    applied: list[dict[str, Any]] = []
+    previous_todo_id: str | None = None
+    boundary_flags = {field: False for field in _BOUNDARY_FLAG_FIELDS}
+
+    for index, candidate in enumerate(candidates):
+        order = index + 1
+        is_first = order == 1
+        resume_when = None if is_first else f"todo_done:{previous_todo_id}"
+        status = "open" if is_first else "deferred"
+        task_repository = candidate.get("task_repository")
+        todo_text = str(candidate.get("todo_text") or "")
+        if not todo_text:
+            todo_text = _portfolio_advance_todo_text(
+                repo_label=str(candidate.get("repo") or ""),
+                issue_label=str(candidate.get("issue_ref") or ""),
+                permalink=candidate.get("permalink"),
+            )
+
+        write_result = add_goal_todo(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            role="agent",
+            text=todo_text,
+            status=status,
+            task_class="advancement_task",
+            action_kind=PORTFOLIO_ADVANCEMENT_ACTION_KIND,
+            task_repository=task_repository,
+            required_write_scopes=required_write_scopes,
+            claimed_by=agent_id if is_first else None,
+            resume_when=resume_when,
+            project=project,
+            dry_run=False,
+        )
+        todo_id = str(write_result.get("todo_id") or "")
+        if not todo_id:
+            raise ValueError(
+                f"portfolio apply did not receive a todo_id for order {order}"
+            )
+
+        applied.append(
+            {
+                "order": order,
+                "issue_ref": candidate.get("issue_ref"),
+                "repo": candidate.get("repo"),
+                "todo_id": todo_id,
+                "status": write_result.get("status"),
+                "resume_when": write_result.get("resume_when"),
+                "resume_depends_on_order": None if is_first else order - 1,
+                "claimed_by": write_result.get("claimed_by"),
+                "action_kind": write_result.get("action_kind"),
+                "task_repository": write_result.get("task_repository"),
+            }
+        )
+        previous_todo_id = todo_id
+
+    return {
+        "ok": True,
+        "schema_version": ISSUE_FIX_PORTFOLIO_PACKET_SCHEMA_VERSION,
+        "mode": "issue-fix-portfolio-apply",
+        "execution_model": PORTFOLIO_EXECUTION_MODEL,
+        "applied_todo_count": len(applied),
+        "applied_todos": applied,
+        "boundary_flags": boundary_flags,
+        "external_writes_performed": False,
+        "todo_write_performed": True,
+        "next_safe_action": (
+            "Run `loopx status` and let the host heartbeat advance issue 1; mark "
+            "each issue's todo done once its PR is created or its route is terminal."
+        ),
+    }
+
+
+def render_issue_fix_portfolio_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# LoopX Issue Fix Portfolio Plan",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- schema_version: `{payload.get('schema_version')}`",
+        f"- execution_model: `{payload.get('execution_model')}`",
+        f"- candidate_count: `{payload.get('candidate_count', payload.get('applied_todo_count'))}`",
+        f"- todo_write_performed: `{payload.get('todo_write_performed')}`",
+        f"- external_writes_performed: `{payload.get('external_writes_performed')}`",
+    ]
+    boundary = payload.get("boundary_flags")
+    if isinstance(boundary, Mapping):
+        lines.append("")
+        lines.append("## Boundary")
+        for field in _BOUNDARY_FLAG_FIELDS:
+            lines.append(f"- {field}: `{boundary.get(field)}`")
+
+    candidates = payload.get("candidates")
+    if isinstance(candidates, list) and candidates:
+        lines.append("")
+        lines.append("## Candidates")
+        lines.append("")
+        lines.append("| order | repo | issue_ref | number | kind | branch_plan |")
+        lines.append("|-------|------|-----------|--------|------|-------------|")
+        for candidate in candidates:
+            if not isinstance(candidate, Mapping):
+                continue
+            lines.append(
+                f"| {candidate.get('order')} | `{candidate.get('repo')}` | "
+                f"`{candidate.get('issue_ref')}` | {candidate.get('number')} | "
+                f"`{candidate.get('kind')}` | `{candidate.get('branch_plan_status')}` |"
+            )
+
+    chain = payload.get("chain")
+    if isinstance(chain, list) and chain:
+        lines.append("")
+        lines.append("## Chain (sequential, PR-ready advance)")
+        lines.append("")
+        for entry in chain:
+            if not isinstance(entry, Mapping):
+                continue
+            lines.append(
+                f"- order {entry.get('order')} `{entry.get('issue_ref')}`: "
+                f"status=`{entry.get('status')}`, "
+                f"resume_depends_on_order=`{entry.get('resume_depends_on_order')}`"
+            )
+
+    applied = payload.get("applied_todos")
+    if isinstance(applied, list) and applied:
+        lines.append("")
+        lines.append("## Applied Todos")
+        lines.append("")
+        lines.append(
+            "| order | issue_ref | todo_id | status | resume_when | claimed_by |"
+        )
+        lines.append("|-------|-----------|---------|--------|-------------|-----------|")
+        for entry in applied:
+            if not isinstance(entry, Mapping):
+                continue
+            lines.append(
+                f"| {entry.get('order')} | `{entry.get('issue_ref')}` | "
+                f"`{entry.get('todo_id')}` | `{entry.get('status')}` | "
+                f"`{entry.get('resume_when')}` | `{entry.get('claimed_by')}` |"
+            )
+
+    next_action = payload.get("next_safe_action")
+    if next_action:
+        lines.append("")
+        lines.append("## Next Safe Action")
+        lines.append("")
+        lines.append(str(next_action))
+    return "\n".join(lines) + "\n"


### PR DESCRIPTION
## What

Add `loopx issue-fix portfolio-plan`: turn an explicit issue list into chained advancement todos so a long-running issue-fix employee works through them sequentially without an operator re-pointing the loop at each issue.

- issue 1 -> written `open` + claimed by `--agent-id` -> immediately runnable
- issues 2..N -> written `deferred` with `resume_when=todo_done:<previous issue todo id>`
- when an issue's todo is marked done (PR created, or `comment_only`/`triage_only` terminal), the next issue's `todo_done` resume condition fires and the existing deferred-resume frontier advances it on a later bounded turn

This is the **first sequential slice** of the longer-term "multi-repository issue portfolios with bounded concurrency" roadmap item. Automatic issue ranking/selection and bounded concurrency remain future work and are explicitly NOT introduced here.

## Changed surfaces

- `loopx/capabilities/issue_fix/portfolio.py` (new) -- `build_issue_fix_portfolio_packet` (read-only, reuses the single-issue `workflow-plan` builder per candidate) + `apply_issue_fix_portfolio` (writes N chained todos via `add_goal_todo`, capturing each return `todo_id` to wire the next `resume_when`) + markdown renderer
- `loopx/capabilities/issue_fix/cli.py` -- `portfolio-plan` subcommand + handler (no other issue-fix path changed)
- `examples/issue-fix-portfolio-smoke.py` (new) -- chain linkage + boundary smoke
- `docs/capabilities/issue-fix/README.md` -- one Implemented Surfaces row + a Sequential Portfolio subsection

No new ledger: feasibility rows stay keyed by `{repo, issue_ref}` in the existing issue-fix domain state and are written lazily by the agent. No scoring, permission, evidence-policy, or destructive-git change.

## Validation

`loopx canary premerge --from-git-diff`:
- Issue-Fix Surface smokes -- `workflow-contract`, `repository-context`, `feasibility`, `pr-lifecycle`, `json-input-boundary`, `capability-guide`: **PASS**
- Risk Profile smokes (8): **PASS**
- Public Boundary scan over the four changed paths: **PASS**
- ruff over the changed paths: **PASS**
- mypy: no new errors from this diff (pre-existing strict-mode errors unchanged)
- `examples/issue-fix-portfolio-smoke.py`: **PASS** (proves read-only chain preview, N chained applied todos whose `resume_when` references the real previous-issue `todo_id`, unique ids, body-free/path-free boundary, and state-file persistence of the `todo_done` linkage)

## Skips / holds

- `issue-fix-reviewer-recommendation-smoke` and `issue-fix-reviewer-request-smoke` fail in this Windows env with `PermissionError [WinError 5]` during temp `.git/objects` cleanup -- environmental, confirmed identical on a clean `origin/main` worktree, and unrelated to this diff (no reviewer or git-cleanup code touched).
- `issue-fix-discovered-issue-promotion-smoke` fails identically on clean `origin/main` (pre-existing, unrelated to this diff).

## Why the coverage is enough

Portfolio reuses two already-smoked contracts -- the single-issue `workflow-plan` builder (covered by `issue-fix-workflow-plan-smoke`) and the `add_goal_todo` + `resume_when=todo_done` + deferred-resume kernel (covered by `state-projection-gap-smoke`). The new smoke covers the only new contract: portfolio composition + correct `todo_done` chain linkage across N issues. No runtime/permission/evidence boundary is widened.

Not marking for self-merge: this adds runtime CLI behavior (a new issue-fix subcommand), so it needs review rather than the narrow-cleanup self-merge path.