### PR TITLE
refactor(scheduler): simplify hint projection builder

### DIFF
--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -5,12 +5,14 @@ import json
 import math
 import re
 from collections.abc import Collection, Mapping
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any
 
 from ..runtime.time import now_utc, utc_isoformat
 from . import ack as scheduler_ack
 from .arbitration import (
+    SchedulerArbitration,
     SchedulerDisposition,
     build_scheduler_arbitration,
 )
@@ -54,10 +56,33 @@ MONITOR_WAIT_PHASE_RANK = {
     "cadence_only": 2,
     "far_window": 3,
 }
+SCHEDULER_IDENTITY_KEYS = (
+    "goal_id",
+    "agent_identity.agent_id",
+    "effective_action",
+    "heartbeat_recommendation.recommended_mode",
+    "interaction_contract.mode",
+    "recommended_action",
+)
+MONITOR_WAIT_IDENTITY_KEYS = SCHEDULER_IDENTITY_KEYS[:-1]
 
 build_codex_app_scheduler_ack_event = scheduler_ack.build_codex_app_scheduler_ack_event
 build_scheduler_ack_plan = scheduler_ack.build_scheduler_ack_plan
 scheduler_backoff_packet = scheduler_ack.scheduler_backoff_packet
+
+
+def _stable_digest(value: Any, *, length: int) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=True,
+        sort_keys=True,
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:length]
+
+
+def _dict_or_empty(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
 
 
 def _scheduler_progression_interval_elapsed(
@@ -455,167 +480,27 @@ def _monitor_wait_cadence_plan(payload: dict[str, Any]) -> dict[str, Any] | None
     }
 
 
-def build_scheduler_hint(
-    payload: dict[str, Any],
-    *,
-    user_action_required: bool = False,
-    agent_scope_frontier_actions: Collection[str] = (),
-    include_detail: bool = False,
-    codex_app_scheduler_state: dict[str, Any] | None = None,
-    available_capabilities: Any = None,
-    codex_app_current_rrule: Any = None,
-    scheduler_execution_context: (
-        Mapping[str, Any] | SchedulerExecutionContextResolution | None
-    ) = None,
-) -> dict[str, Any]:
-    """Project host-runtime cadence/backoff policy from a quota decision.
+@dataclass(frozen=True)
+class _SchedulerHintBuilder:
+    payload: dict[str, Any]
+    execution_context: SchedulerExecutionContextResolution
+    arbitration: SchedulerArbitration
+    spend_policy: Any
+    scheduler_ack_capabilities: Any
+    codex_app_scheduler_state: dict[str, Any] | None
+    codex_app_current_rrule: Any
+    include_detail: bool
 
-    This helper is intentionally pure: callers provide the few quota-local
-    classification facts it needs, and it returns the public scheduler contract
-    without reading files, mutating state, or depending on the full quota module.
-    """
-
-    execution_context = resolve_scheduler_execution_context(
-        scheduler_execution_context
-    )
-    if not execution_context.ok:
-        return {
-            "schema_version": SCHEDULER_HINT_SCHEMA_VERSION,
-            "source": "quota.should-run",
-            "action": "repair_scheduler_execution_context",
-            "cadence_class": "control_plane_repair",
-            "reason_code": "invalid_scheduler_execution_context",
-            "reason": (
-                "scheduler ownership is missing or contradictory; repair the "
-                "typed execution context before applying cadence"
-            ),
-            "spend_policy": "no quota spend for scheduler context repair",
-            "execution_context": execution_context.projection(),
-            "execution_phase": {
-                "schema_version": "scheduler_execution_phase_v0",
-                "disposition": "contract_error",
-                "completed": False,
-                "apply_needed": False,
-                "ack_needed": False,
-                "acknowledged": False,
-            },
-            "codex_app": {
-                "applicability": "blocked_invalid_context",
-                "apply": "none",
-                "host_action": "none",
-                "ack_required": False,
-            },
-            "unchanged_poll": {
-                "local_scheduler": "stop_until_context_repaired",
-                "codex_cli_tui": "stop_until_context_repaired",
-                "claude_code_loop": "stop_until_context_repaired",
-                "final_quota_replan_check_enabled": False,
-                "spend_policy": "no quota spend for scheduler context repair",
-            },
-            "consistency_error": {
-                "source": "scheduler_execution_context",
-                "errors": list(execution_context.errors),
-            },
-        }
-
-    def contextualize(result: dict[str, Any]) -> dict[str, Any]:
-        return apply_scheduler_execution_context(result, execution_context)
-
-    heartbeat_recommendation = (
-        payload.get("heartbeat_recommendation")
-        if isinstance(payload.get("heartbeat_recommendation"), dict)
-        else {}
-    )
-    execution_obligation = (
-        payload.get("execution_obligation")
-        if isinstance(payload.get("execution_obligation"), dict)
-        else {}
-    )
-    automation_liveness = (
-        payload.get("automation_liveness")
-        if isinstance(payload.get("automation_liveness"), dict)
-        else {}
-    )
-    spend_policy = (
-        automation_liveness.get("spend_policy")
-        or execution_obligation.get("spend_policy")
-        or heartbeat_recommendation.get("spend_policy")
-    )
-    capability_gate = (
-        payload.get("capability_gate")
-        if isinstance(payload.get("capability_gate"), dict)
-        else {}
-    )
-    scheduler_ack_capabilities = (
-        available_capabilities
-        if available_capabilities is not None
-        else capability_gate.get("available")
-        if isinstance(capability_gate.get("available"), list)
-        else []
-    )
-    base_identity_keys = [
-        "goal_id",
-        "agent_identity.agent_id",
-        "effective_action",
-        "heartbeat_recommendation.recommended_mode",
-        "interaction_contract.mode",
-        "recommended_action",
-    ]
-    monitor_wait_identity_keys = [
-        "goal_id",
-        "agent_identity.agent_id",
-        "effective_action",
-        "heartbeat_recommendation.recommended_mode",
-        "interaction_contract.mode",
-    ]
-    agent_scope_action_set = {str(value) for value in agent_scope_frontier_actions}
-    arbitration = build_scheduler_arbitration(
-        payload,
-        agent_scope_frontier_actions=agent_scope_action_set,
-    )
-
-    def identity_value(path: str) -> Any:
-        current: Any = payload
+    def _identity_value(self, path: str) -> Any:
+        current: Any = self.payload
         for part in path.split("."):
             if not isinstance(current, dict):
                 return None
             current = current.get(part)
         return current
 
-    if arbitration.disposition == SchedulerDisposition.TERMINAL_STOP:
-        return contextualize({
-            "schema_version": SCHEDULER_HINT_SCHEMA_VERSION,
-            "source": "quota.should-run",
-            "action": "stop_until_explicit_resume",
-            "cadence_class": "terminal_no_followup",
-            "reason_code": arbitration.reason_code,
-            "reason": (
-                "validated closure evidence derives no-follow-up and confirms no "
-                "remaining frontier; recurring polling must stop until resume"
-            ),
-            "spend_policy": "no quota spend for terminal automation shutdown",
-            "codex_app": {
-                "apply": "pause_or_delete_current_heartbeat_if_possible",
-                "host_tool": "automation_update",
-                "host_action": "pause_or_delete_current_heartbeat",
-                "host_action_required": True,
-                "attempt_limit": 1,
-                "verify_host_result": True,
-                "ack_required": False,
-                "resume_trigger": "explicit goal resume or newly projected work",
-                "no_spend_for_host_action": True,
-            },
-            "unchanged_poll": {
-                "local_scheduler": "stop",
-                "codex_cli_tui": "exit",
-                "claude_code_loop": "stop",
-                "final_quota_replan_check_enabled": False,
-                "spend_policy": "no quota spend for terminal loop stop",
-            },
-            "unchanged_identity_keys": base_identity_keys,
-        })
-
-    def hint(
+    def build(
+        self,
         *,
         action: str,
         cadence_class: str,
@@ -631,8 +516,7 @@ def build_scheduler_hint(
         advance_same_identity: bool = True,
     ) -> dict[str, Any]:
         local_cadence_progression = cadence_progression_override or [
-            min(codex_interval * (multiplier**step), codex_max)
-            for step in range(3)
+            min(codex_interval * (multiplier**step), codex_max) for step in range(3)
         ]
         codex_host_max = min(max(1, codex_max), CODEX_APP_MAX_INTERVAL_MINUTES)
         codex_cadence_progression: list[int] = []
@@ -643,16 +527,8 @@ def build_scheduler_hint(
                 or codex_cadence_progression[-1] != bounded_interval
             ):
                 codex_cadence_progression.append(bounded_interval)
-        codex_initial_interval = (
-            codex_cadence_progression[0]
-            if codex_cadence_progression
-            else min(codex_interval, codex_host_max)
-        )
-        local_initial_interval = (
-            local_cadence_progression[0]
-            if local_cadence_progression
-            else codex_interval
-        )
+        codex_initial_interval = codex_cadence_progression[0]
+        local_initial_interval = local_cadence_progression[0]
         final_replan_check = {
             "enabled": cli_limit is not None or claude_limit is not None,
             "trigger": "before_unchanged_poll_after_limit",
@@ -662,12 +538,12 @@ def build_scheduler_hint(
             "if_unchanged": "apply_after_limit_without_spend",
             "spend_policy": "no quota spend for final replan check or loop stop",
         }
-        identity_keys = (
-            monitor_wait_identity_keys
+        identity_keys = list(
+            MONITOR_WAIT_IDENTITY_KEYS
             if cadence_class == "monitor_wait"
-            else base_identity_keys
+            else SCHEDULER_IDENTITY_KEYS
         )
-        identity_snapshot = {key: identity_value(key) for key in identity_keys}
+        identity_snapshot = {key: self._identity_value(key) for key in identity_keys}
         codex_rrule = rrule_for_minutes(codex_initial_interval)
         profile_snapshot = {
             "cadence_class": cadence_class,
@@ -680,43 +556,17 @@ def build_scheduler_hint(
             "claude_code_loop_unchanged_poll_limit": claude_limit,
         }
         reset_profile_snapshot = reset_profile_snapshot_override or profile_snapshot
-        reset_token_payload = {
-            "action": action,
-            "identity_snapshot": identity_snapshot,
-            "profile_snapshot": reset_profile_snapshot,
-        }
-        reset_token = hashlib.sha256(
-            json.dumps(
-                reset_token_payload,
-                ensure_ascii=True,
-                sort_keys=True,
-                default=str,
-            ).encode("utf-8")
-        ).hexdigest()[:16]
-        identity_signature = hashlib.sha256(
-            json.dumps(
-                identity_snapshot,
-                ensure_ascii=True,
-                sort_keys=True,
-                default=str,
-            ).encode("utf-8")
-        ).hexdigest()[:12]
-        profile_signature = hashlib.sha256(
-            json.dumps(
-                profile_snapshot,
-                ensure_ascii=True,
-                sort_keys=True,
-                default=str,
-            ).encode("utf-8")
-        ).hexdigest()[:12]
-        reset_profile_signature = hashlib.sha256(
-            json.dumps(
-                reset_profile_snapshot,
-                ensure_ascii=True,
-                sort_keys=True,
-                default=str,
-            ).encode("utf-8")
-        ).hexdigest()[:12]
+        reset_token = _stable_digest(
+            {
+                "action": action,
+                "identity_snapshot": identity_snapshot,
+                "profile_snapshot": reset_profile_snapshot,
+            },
+            length=16,
+        )
+        identity_signature = _stable_digest(identity_snapshot, length=12)
+        profile_signature = _stable_digest(profile_snapshot, length=12)
+        reset_profile_signature = _stable_digest(reset_profile_snapshot, length=12)
         reset_policy_detail = {
             "schema_version": SCHEDULER_RESET_POLICY_SCHEMA_VERSION,
             "source": "quota.should-run",
@@ -767,11 +617,7 @@ def build_scheduler_hint(
             "final_quota_replan_check": final_replan_check,
             "no_spend_for_stop": True,
         }
-        scheduler_state = (
-            codex_app_scheduler_state
-            if isinstance(codex_app_scheduler_state, dict)
-            else {}
-        )
+        scheduler_state = _dict_or_empty(self.codex_app_scheduler_state)
         scheduler_now = now_utc()
         all_host_update_failures = retained_scheduler_host_update_failures(
             normalize_scheduler_host_update_failures(
@@ -796,8 +642,10 @@ def build_scheduler_hint(
         state_status = cadence_decision.state_status
         current_interval = codex_cadence_progression[current_index]
         current_rrule = rrule_for_minutes(current_interval)
-        last_applied_rrule = str(scheduler_state.get("last_applied_rrule") or "").strip()
-        observed_host_rrule = normalize_scheduler_rrule(codex_app_current_rrule)
+        last_applied_rrule = str(
+            scheduler_state.get("last_applied_rrule") or ""
+        ).strip()
+        observed_host_rrule = normalize_scheduler_rrule(self.codex_app_current_rrule)
         effective_host_rrule = observed_host_rrule or last_applied_rrule
         host_update_failures = retained_scheduler_host_update_failures(
             all_host_update_failures,
@@ -819,10 +667,12 @@ def build_scheduler_hint(
             and not observed_host_rrule
             and state_status == "same_identity"
         ):
-            current_rrule_already_applied = _monitor_rrule_applied_within_stale_tolerance(
-                cadence_class=cadence_class,
-                last_applied_rrule=effective_host_rrule,
-                current_rrule=current_rrule,
+            current_rrule_already_applied = (
+                _monitor_rrule_applied_within_stale_tolerance(
+                    cadence_class=cadence_class,
+                    last_applied_rrule=effective_host_rrule,
+                    current_rrule=current_rrule,
+                )
             )
         host_decision = decide_scheduler_host_transition(
             state_status=state_status,
@@ -881,8 +731,7 @@ def build_scheduler_hint(
                 else (
                     "none_recorded_host_failure"
                     if host_failure_suppressed
-                    else
-                    "ack_observed_rrule_without_update"
+                    else "ack_observed_rrule_without_update"
                     if host_match_ack_needed
                     else "none"
                 )
@@ -893,16 +742,13 @@ def build_scheduler_hint(
                 else (
                     "skip_automation_update_for_recorded_host_failure"
                     if host_failure_suppressed
-                    else
-                    "quota_scheduler_ack_from_matching_host_observation"
+                    else "quota_scheduler_ack_from_matching_host_observation"
                     if host_match_ack_needed
                     else "skip_automation_update_when_apply_needed_false"
                 )
             ),
             "rrule_source": (
-                "scheduler_hint.codex_app.recommended_rrule"
-                if apply_needed
-                else None
+                "scheduler_hint.codex_app.recommended_rrule" if apply_needed else None
             ),
             "stateful_backoff": {
                 "schema_version": CODEX_APP_STATEFUL_BACKOFF_SCHEMA_VERSION,
@@ -917,16 +763,15 @@ def build_scheduler_hint(
             },
             "no_spend_for_cadence_change": True,
         }
+        stateful_backoff = codex_app["stateful_backoff"]
         if host_update_failures:
-            codex_app["stateful_backoff"]["host_update_failures"] = [
+            stateful_backoff["host_update_failures"] = [
                 dict(failure) for failure in host_update_failures
             ]
         if recorded_host_failure:
-            codex_app["stateful_backoff"]["host_update_failure"] = dict(
-                recorded_host_failure
-            )
+            stateful_backoff["host_update_failure"] = dict(recorded_host_failure)
         if observed_host_rrule:
-            codex_app["stateful_backoff"]["host_observation"] = {
+            stateful_backoff["host_observation"] = {
                 "source": "quota_should_run_host_observation",
                 "current_rrule": observed_host_rrule,
                 "status": (
@@ -935,44 +780,42 @@ def build_scheduler_hint(
                     else "drift_detected"
                 ),
             }
+        goal_id = self.payload.get("goal_id")
+        agent_id = self._identity_value("agent_identity.agent_id")
         if apply_needed:
             codex_app["recommended_rrule"] = current_rrule
-            if payload.get("goal_id") and identity_value("agent_identity.agent_id"):
+            if goal_id and agent_id:
                 codex_app["failure_hint"] = build_codex_app_scheduler_failure_hint(
-                    goal_id=payload.get("goal_id"),
-                    agent_id=identity_value("agent_identity.agent_id"),
+                    goal_id=goal_id,
+                    agent_id=agent_id,
                     failed_rrule=current_rrule,
                     observed_host_rrule=effective_host_rrule,
-                    available_capabilities=scheduler_ack_capabilities,
+                    available_capabilities=self.scheduler_ack_capabilities,
                 )
-        if ack_needed:
-            if payload.get("goal_id") and identity_value("agent_identity.agent_id"):
-                codex_app["ack_hint"] = build_codex_app_scheduler_ack_hint(
-                    goal_id=payload.get("goal_id"),
-                    agent_id=identity_value("agent_identity.agent_id"),
-                    applied_rrule=current_rrule,
-                    reset_token=reset_token,
-                    identity_signature=identity_signature,
-                    available_capabilities=scheduler_ack_capabilities,
-                    after=(
-                        "automation_update_rrule_success"
-                        if apply_needed
-                        else "matching_host_rrule_observed"
-                    ),
-                    # An ACK hint is executable only after either a successful
-                    # host update or a matching host readback. Carry that proof
-                    # and the originating identity so scheduler-ack-current
-                    # cannot recompute an unbound hint and silently no-op.
-                    host_match_observed=True,
-                )
+        if ack_needed and goal_id and agent_id:
+            codex_app["ack_hint"] = build_codex_app_scheduler_ack_hint(
+                goal_id=goal_id,
+                agent_id=agent_id,
+                applied_rrule=current_rrule,
+                reset_token=reset_token,
+                identity_signature=identity_signature,
+                available_capabilities=self.scheduler_ack_capabilities,
+                after=(
+                    "automation_update_rrule_success"
+                    if apply_needed
+                    else "matching_host_rrule_observed"
+                ),
+                # Bind the host proof to the originating identity.
+                host_match_observed=True,
+            )
         scheduler_hint = {
             "schema_version": SCHEDULER_HINT_SCHEMA_VERSION,
             "source": "quota.should-run",
             "action": action,
             "cadence_class": cadence_class,
-            "reason_code": arbitration.reason_code,
+            "reason_code": self.arbitration.reason_code,
             "reason": reason,
-            "spend_policy": spend_policy,
+            "spend_policy": self.spend_policy,
             "codex_app": codex_app,
             "unchanged_poll": {
                 "limits": {
@@ -987,7 +830,9 @@ def build_scheduler_hint(
                 },
                 "final_quota_replan_check_enabled": final_replan_check["enabled"],
                 "final_quota_replan_check_action": (
-                    final_replan_check["action"] if final_replan_check["enabled"] else None
+                    final_replan_check["action"]
+                    if final_replan_check["enabled"]
+                    else None
                 ),
                 "spend_policy": final_replan_check["spend_policy"],
             },
@@ -1022,7 +867,7 @@ def build_scheduler_hint(
         )
         if notification_cooldown:
             scheduler_hint["user_gate_notification_cooldown"] = notification_cooldown
-        if include_detail:
+        if self.include_detail:
             scheduler_hint["cold_path_detail"] = {
                 "schema_version": SCHEDULER_HINT_DETAIL_SCHEMA_VERSION,
                 "source": "quota.should-run",
@@ -1034,11 +879,143 @@ def build_scheduler_hint(
                 "stateful_backoff_detail": stateful_backoff_detail,
             }
             if cadence_context_detail:
-                scheduler_hint["cold_path_detail"]["cadence_context"] = cadence_context_detail
-        return contextualize(scheduler_hint)
+                scheduler_hint["cold_path_detail"]["cadence_context"] = (
+                    cadence_context_detail
+                )
+        return apply_scheduler_execution_context(scheduler_hint, self.execution_context)
 
+
+def build_scheduler_hint(
+    payload: dict[str, Any],
+    *,
+    user_action_required: bool = False,
+    agent_scope_frontier_actions: Collection[str] = (),
+    include_detail: bool = False,
+    codex_app_scheduler_state: dict[str, Any] | None = None,
+    available_capabilities: Any = None,
+    codex_app_current_rrule: Any = None,
+    scheduler_execution_context: (
+        Mapping[str, Any] | SchedulerExecutionContextResolution | None
+    ) = None,
+) -> dict[str, Any]:
+    """Project host-runtime cadence/backoff policy from a quota decision.
+
+    This helper is intentionally pure: callers provide the few quota-local
+    classification facts it needs, and it returns the public scheduler contract
+    without reading files, mutating state, or depending on the full quota module.
+    """
+
+    execution_context = resolve_scheduler_execution_context(scheduler_execution_context)
+    if not execution_context.ok:
+        return {
+            "schema_version": SCHEDULER_HINT_SCHEMA_VERSION,
+            "source": "quota.should-run",
+            "action": "repair_scheduler_execution_context",
+            "cadence_class": "control_plane_repair",
+            "reason_code": "invalid_scheduler_execution_context",
+            "reason": (
+                "scheduler ownership is missing or contradictory; repair the "
+                "typed execution context before applying cadence"
+            ),
+            "spend_policy": "no quota spend for scheduler context repair",
+            "execution_context": execution_context.projection(),
+            "execution_phase": {
+                "schema_version": "scheduler_execution_phase_v0",
+                "disposition": "contract_error",
+                "completed": False,
+                "apply_needed": False,
+                "ack_needed": False,
+                "acknowledged": False,
+            },
+            "codex_app": {
+                "applicability": "blocked_invalid_context",
+                "apply": "none",
+                "host_action": "none",
+                "ack_required": False,
+            },
+            "unchanged_poll": {
+                "local_scheduler": "stop_until_context_repaired",
+                "codex_cli_tui": "stop_until_context_repaired",
+                "claude_code_loop": "stop_until_context_repaired",
+                "final_quota_replan_check_enabled": False,
+                "spend_policy": "no quota spend for scheduler context repair",
+            },
+            "consistency_error": {
+                "source": "scheduler_execution_context",
+                "errors": list(execution_context.errors),
+            },
+        }
+
+    heartbeat_recommendation = _dict_or_empty(payload.get("heartbeat_recommendation"))
+    execution_obligation = _dict_or_empty(payload.get("execution_obligation"))
+    automation_liveness = _dict_or_empty(payload.get("automation_liveness"))
+    spend_policy = (
+        automation_liveness.get("spend_policy")
+        or execution_obligation.get("spend_policy")
+        or heartbeat_recommendation.get("spend_policy")
+    )
+    capability_gate = _dict_or_empty(payload.get("capability_gate"))
+    scheduler_ack_capabilities = (
+        available_capabilities
+        if available_capabilities is not None
+        else capability_gate.get("available")
+        if isinstance(capability_gate.get("available"), list)
+        else []
+    )
+    agent_scope_action_set = {str(value) for value in agent_scope_frontier_actions}
+    arbitration = build_scheduler_arbitration(
+        payload,
+        agent_scope_frontier_actions=agent_scope_action_set,
+    )
+
+    if arbitration.disposition == SchedulerDisposition.TERMINAL_STOP:
+        return apply_scheduler_execution_context(
+            {
+                "schema_version": SCHEDULER_HINT_SCHEMA_VERSION,
+                "source": "quota.should-run",
+                "action": "stop_until_explicit_resume",
+                "cadence_class": "terminal_no_followup",
+                "reason_code": arbitration.reason_code,
+                "reason": (
+                    "validated closure evidence derives no-follow-up and confirms no "
+                    "remaining frontier; recurring polling must stop until resume"
+                ),
+                "spend_policy": "no quota spend for terminal automation shutdown",
+                "codex_app": {
+                    "apply": "pause_or_delete_current_heartbeat_if_possible",
+                    "host_tool": "automation_update",
+                    "host_action": "pause_or_delete_current_heartbeat",
+                    "host_action_required": True,
+                    "attempt_limit": 1,
+                    "verify_host_result": True,
+                    "ack_required": False,
+                    "resume_trigger": "explicit goal resume or newly projected work",
+                    "no_spend_for_host_action": True,
+                },
+                "unchanged_poll": {
+                    "local_scheduler": "stop",
+                    "codex_cli_tui": "exit",
+                    "claude_code_loop": "stop",
+                    "final_quota_replan_check_enabled": False,
+                    "spend_policy": "no quota spend for terminal loop stop",
+                },
+                "unchanged_identity_keys": list(SCHEDULER_IDENTITY_KEYS),
+            },
+            execution_context,
+        )
+
+    builder = _SchedulerHintBuilder(
+        payload=payload,
+        execution_context=execution_context,
+        arbitration=arbitration,
+        spend_policy=spend_policy,
+        scheduler_ack_capabilities=scheduler_ack_capabilities,
+        codex_app_scheduler_state=codex_app_scheduler_state,
+        codex_app_current_rrule=codex_app_current_rrule,
+        include_detail=include_detail,
+    )
     if arbitration.disposition == SchedulerDisposition.AGENT_MONITOR_ONLY_WAIT:
-        return hint(
+        return builder.build(
             action="backoff_agent_monitor_only",
             cadence_class="agent_monitor_only",
             reason=(
@@ -1052,7 +1029,7 @@ def build_scheduler_hint(
         )
 
     if arbitration.disposition == SchedulerDisposition.CONSISTENCY_REPAIR:
-        result = hint(
+        result = builder.build(
             action="repair_interaction_contract_projection",
             cadence_class="control_plane_repair",
             reason=(
@@ -1069,7 +1046,7 @@ def build_scheduler_hint(
         return result
 
     if arbitration.disposition == SchedulerDisposition.HUMAN_GATE:
-        return hint(
+        return builder.build(
             action="backoff_waiting_for_user",
             cadence_class="human_gate",
             reason=(
@@ -1094,7 +1071,7 @@ def build_scheduler_hint(
             and isinstance(agent_channel, Mapping)
             and agent_channel.get("delivery_allowed") is False
         )
-        return hint(
+        return builder.build(
             action="run_now",
             cadence_class="active_work",
             reason=(
@@ -1109,7 +1086,7 @@ def build_scheduler_hint(
         )
 
     if arbitration.disposition == SchedulerDisposition.UNCHANGED_WAIT:
-        return hint(
+        return builder.build(
             action="backoff_until_fresh_evidence",
             cadence_class="unchanged_noop",
             reason=(
@@ -1123,7 +1100,7 @@ def build_scheduler_hint(
         )
 
     if arbitration.disposition == SchedulerDisposition.AGENT_SCOPE_WAIT:
-        return hint(
+        return builder.build(
             action="backoff_until_reassigned",
             cadence_class="agent_scope_wait",
             reason=(
@@ -1161,7 +1138,7 @@ def build_scheduler_hint(
             and isinstance(monitor_plan.get("reset_profile"), dict)
             else None
         )
-        return hint(
+        return builder.build(
             action="backoff_until_material_transition",
             cadence_class="monitor_wait",
             reason=(
@@ -1180,7 +1157,7 @@ def build_scheduler_hint(
         )
 
     if arbitration.disposition == SchedulerDisposition.QUIET_WAIT:
-        return hint(
+        return builder.build(
             action="backoff_until_state_change",
             cadence_class="quiet_wait",
             reason=(


### PR DESCRIPTION
## Summary

- extract cadence packet assembly into one owner-local `_SchedulerHintBuilder`
- consolidate stable digests and scheduler identity keys without changing public JSON
- reduce `build_scheduler_hint` from 739 lines / 124 statements / 75 decisions to 286 / 41 / 19; reduce module nonblank lines from 1,138 to 1,110

## Validation

- exact JSON parity with `origin/main` across active, detailed, human-gate, monitor-state, terminal, agent-scope, and invalid-context cases
- 179 focused scheduler tests
- quota scheduler compaction, policy, and quota-plan smokes
- `ruff check`, repository-configured `mypy`, public-boundary scan, and `git diff --check`
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 17/17 selected checks passed, no manual holds
- change-quality receipt `cqr_5aa45463caa4c590e2f6`: valid, no blockers

Behavior is intentionally unchanged; compact/detail output, stateful backoff, ACK/failure hints, monitor windows, and execution-context projection remain exact.