### PR TITLE
feat: reconcile local integration branches

### DIFF
--- a/docs/capabilities/README.md
+++ b/docs/capabilities/README.md
@@ -22,6 +22,9 @@ propose a typed transition through the existing Kernel contract.
 
 Current capability paths:
 
+- [integration-branch](integration-branch/README.md): detect when a reviewed
+  feature or fix branch has moved, then preview or safely rebuild one local
+  integration branch from exact current source heads.
 - [decision-context](decision-context/README.md)
   ([中文](decision-context/README.zh-CN.md),
   [architecture](../reference/protocols/decision-context-architecture-v0.md)):

--- a/docs/capabilities/integration-branch/README.md
+++ b/docs/capabilities/integration-branch/README.md
@@ -60,6 +60,27 @@ Execute requires a clean checked-out integration worktree. A dirty worktree,
 merge conflict, missing ref, or concurrent plan/input/integration movement
 fails closed before candidate publication.
 
+When ordered source heads require an intentional manual conflict resolution,
+build and validate that commit outside LoopX, then let LoopX verify and adopt
+it through the same receipt boundary:
+
+```bash
+loopx integration-branch sync \
+  --repo-path . \
+  --candidate-ref <resolved-commit> \
+  --format json
+loopx integration-branch sync \
+  --repo-path . \
+  --candidate-ref <resolved-commit> \
+  --execute \
+  --format json
+```
+
+The supplied commit must contain the configured base and every exact source
+SHA as ancestors. LoopX does not choose or generate the resolution; it only
+verifies the immutable result before the normal local publication and
+readback flow.
+
 ## Boundary
 
 The capability is deliberately local:

--- a/docs/capabilities/integration-branch/README.md
+++ b/docs/capabilities/integration-branch/README.md
@@ -1,0 +1,70 @@
+# Integration Branch Reconcile
+
+Long-running repository work often has two simultaneous truths:
+
+- each feature or fix stays on its own reviewable branch;
+- one local integration branch must contain the latest reviewed form of every
+  source branch.
+
+`integration-branch-reconcile` makes the second truth machine-readable. It
+stores an ordered plan under ignored `.loopx/` state, compares current refs
+with the last successful sync receipt, and rebuilds the integration branch
+through a temporary detached worktree.
+
+## Configure
+
+```bash
+loopx integration-branch configure \
+  --repo-path . \
+  --base-ref origin/main \
+  --integration-branch codex/local-integration \
+  --source-branch codex/feature-a \
+  --source-branch codex/fix-b \
+  --execute \
+  --format json
+```
+
+Source order is significant. `configure` validates all refs but writes only
+`.loopx/integration-branch.json`. A different existing plan requires explicit
+`--replace`, which also clears its old sync receipt.
+
+## Detect review drift
+
+```bash
+loopx integration-branch status --repo-path . --format json
+```
+
+The first status is `drifted` with `never_synced`. After a successful sync,
+LoopX records the exact base, source, and integration SHAs. A later rebase,
+review fix, or additional source commit becomes `base_ref_moved`,
+`source_ref_moved`, or `integration_head_changed`.
+
+## Preview and sync
+
+```bash
+loopx integration-branch sync --repo-path . --format json
+loopx integration-branch sync --repo-path . --execute --format json
+```
+
+Both paths build the candidate by merging the resolved source SHAs in order
+from the resolved base SHA. Preview removes its temporary worktree without
+changing refs. Execute updates the local integration branch only after every
+merge succeeds, then writes and rereads the receipt.
+
+If the integration branch is checked out, its worktree must be clean. A dirty
+worktree, merge conflict, missing ref, or concurrent plan/input/integration
+movement fails closed before candidate publication.
+
+## Boundary
+
+The capability is deliberately local:
+
+- it never fetches or pushes;
+- it never changes a source branch;
+- it never creates, retargets, approves, or merges a PR;
+- it never updates a protected base branch;
+- v0 uses ordered merge commits and does not squash or rewrite source history.
+
+Fetch or update source refs through the repository's normal workflow before
+running `status` or `sync`. Human review and aggregate merge authority remain
+outside this capability.

--- a/docs/capabilities/integration-branch/README.md
+++ b/docs/capabilities/integration-branch/README.md
@@ -51,9 +51,14 @@ from the resolved base SHA. Preview removes its temporary worktree without
 changing refs. Execute updates the local integration branch only after every
 merge succeeds, then writes and rereads the receipt.
 
-If the integration branch is checked out, its worktree must be clean. A dirty
-worktree, merge conflict, missing ref, or concurrent plan/input/integration
-movement fails closed before candidate publication.
+Rebuilding merge commits can change `candidate_sha` timestamps between preview
+and execute. Compare `candidate_tree_sha` for stable content identity; execute
+also records it in the receipt.
+
+Preview remains read-only even when the integration branch worktree is dirty.
+Execute requires a clean checked-out integration worktree. A dirty worktree,
+merge conflict, missing ref, or concurrent plan/input/integration movement
+fails closed before candidate publication.
 
 ## Boundary
 

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -14,6 +14,80 @@ CAPABILITY_DETAIL_SCHEMA_VERSION = "loopx_capability_detail_v0"
 
 BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
     {
+        "id": "integration-branch-reconcile",
+        "origin": "builtin",
+        "visibility": "public",
+        "provider_id": "loopx-core",
+        "title": "Local integration branch reconciliation",
+        "status": "active-preview",
+        "real_world_anchor": (
+            "long-running repository work with independently reviewed feature branches"
+        ),
+        "user_value": (
+            "Keep one local integration branch aligned with the latest ordered "
+            "feature and fix heads without mutating or pushing those source branches."
+        ),
+        "entry_command": (
+            "loopx integration-branch status --repo-path <repo> --format json"
+        ),
+        "commands": [
+            {
+                "command": (
+                    "loopx integration-branch configure --repo-path <repo> "
+                    "--base-ref <base> --integration-branch <branch> "
+                    "--source-branch <branch>... --execute --format json"
+                ),
+                "purpose": "Write one ordered project-local branch plan with no sync receipt.",
+                "write_boundary": "ignored local plan only; no git ref or remote write",
+            },
+            {
+                "command": (
+                    "loopx integration-branch status --repo-path <repo> --format json"
+                ),
+                "purpose": "Compare current base, source, and integration heads with the last successful sync.",
+                "write_boundary": "read-only local git refs and ignored plan",
+            },
+            {
+                "command": (
+                    "loopx integration-branch sync --repo-path <repo> "
+                    "[--execute] --format json"
+                ),
+                "purpose": "Preview or atomically publish an ordered merge candidate to the local integration branch.",
+                "write_boundary": "local integration branch and ignored receipt only; no source or remote write",
+            },
+        ],
+        "implemented_protocols": [
+            {
+                "schema_version": "loopx_integration_branch_plan_v0",
+                "module": "loopx.capabilities.integration_branch.core",
+                "doc": "docs/capabilities/integration-branch/README.md",
+            },
+            {
+                "schema_version": "loopx_integration_branch_status_v0",
+                "module": "loopx.capabilities.integration_branch.core",
+                "doc": "docs/capabilities/integration-branch/README.md",
+            },
+            {
+                "schema_version": "loopx_integration_branch_sync_v0",
+                "module": "loopx.capabilities.integration_branch.core",
+                "doc": "docs/capabilities/integration-branch/README.md",
+            },
+        ],
+        "smokes": ["python -m pytest tests/capabilities/test_integration_branch.py -q"],
+        "docs": ["docs/capabilities/integration-branch/README.md"],
+        "boundaries": [
+            "The plan is project-local and ignored; it records refs and sync receipts, not credentials, review bodies, or private evidence.",
+            "Sync uses exact resolved source heads and updates only the configured local integration branch after every ordered merge succeeds.",
+            "Dirty checked-out integration worktrees, merge conflicts, missing refs, and concurrent plan/input/integration movement fail closed before publication.",
+            "The capability never fetches, pushes, force-pushes, retargets PRs, merges protected branches, or changes source refs.",
+            "v0 uses ordered merge commits; it does not rewrite or squash source history.",
+        ],
+        "next_real_step": (
+            "Configure one local feature stack, change a source head after review, "
+            "and verify status reports drift before sync restores an exact readback."
+        ),
+    },
+    {
         "id": "change-quality-qualification",
         "origin": "builtin",
         "visibility": "public",

--- a/loopx/capabilities/integration_branch/__init__.py
+++ b/loopx/capabilities/integration_branch/__init__.py
@@ -1,0 +1,13 @@
+"""Local integration-branch reconciliation."""
+
+from .core import (
+    configure_integration_branch,
+    integration_branch_status,
+    sync_integration_branch,
+)
+
+__all__ = [
+    "configure_integration_branch",
+    "integration_branch_status",
+    "sync_integration_branch",
+]

--- a/loopx/capabilities/integration_branch/cli.py
+++ b/loopx/capabilities/integration_branch/cli.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+
+from .core import (
+    IntegrationBranchError,
+    configure_integration_branch,
+    integration_branch_status,
+    sync_integration_branch,
+)
+
+
+def _render(payload: dict[str, object]) -> str:
+    lines = ["# Integration Branch Reconcile", ""]
+    for key in ("status", "sync_required", "changed", "updated", "plan_file"):
+        if key in payload:
+            lines.append(f"- {key}: `{payload.get(key)}`")
+    reasons = payload.get("drift_reasons")
+    if isinstance(reasons, list):
+        lines.append(f"- drift_reason_count: `{len(reasons)}`")
+        for reason in reasons:
+            if isinstance(reason, dict):
+                lines.append(f"  - `{reason.get('kind')}`")
+    return "\n".join(lines) + "\n"
+
+
+def _add_common_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--repo-path", default=".")
+    parser.add_argument("--plan-file")
+
+
+def register_integration_branch_commands(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    parser = subparsers.add_parser(
+        "integration-branch",
+        help="Detect source-branch drift and safely rebuild one local integration branch.",
+    )
+    commands = parser.add_subparsers(
+        dest="integration_branch_command",
+        required=True,
+    )
+
+    configure = commands.add_parser(
+        "configure",
+        help="Preview or write the ordered local integration-branch plan.",
+    )
+    add_subcommand_format(configure)
+    _add_common_arguments(configure)
+    configure.add_argument("--base-ref", required=True)
+    configure.add_argument("--integration-branch", required=True)
+    configure.add_argument(
+        "--source-branch", action="append", default=[], required=True
+    )
+    configure.add_argument("--replace", action="store_true")
+    configure.add_argument("--execute", action="store_true")
+
+    status = commands.add_parser(
+        "status",
+        help="Compare current base, source, and integration heads with the last sync receipt.",
+    )
+    add_subcommand_format(status)
+    _add_common_arguments(status)
+
+    sync = commands.add_parser(
+        "sync",
+        help="Merge exact current source heads in order through a temporary worktree.",
+    )
+    add_subcommand_format(sync)
+    _add_common_arguments(sync)
+    sync.add_argument("--execute", action="store_true")
+
+
+def handle_integration_branch_command(
+    args: argparse.Namespace,
+    *,
+    output_format: Callable[..., str],
+    print_payload: Callable[[dict[str, object], str, Callable], None],
+) -> int | None:
+    if args.command != "integration-branch":
+        return None
+    try:
+        if args.integration_branch_command == "configure":
+            payload = configure_integration_branch(
+                repo_path=args.repo_path,
+                base_ref=args.base_ref,
+                integration_branch=args.integration_branch,
+                source_refs=args.source_branch,
+                plan_file=args.plan_file,
+                replace=args.replace,
+                execute=args.execute,
+            )
+        elif args.integration_branch_command == "status":
+            payload = integration_branch_status(
+                repo_path=args.repo_path,
+                plan_file=args.plan_file,
+            )
+        else:
+            payload = sync_integration_branch(
+                repo_path=args.repo_path,
+                plan_file=args.plan_file,
+                execute=args.execute,
+            )
+    except IntegrationBranchError as exc:
+        payload = {
+            "ok": False,
+            "schema_version": "loopx_integration_branch_error_v0",
+            "status": "invalid_state",
+            "error": str(exc),
+        }
+        print_payload(payload, output_format(args), _render)
+        return 2
+    print_payload(payload, output_format(args), _render)
+    return 0 if payload.get("ok") else 1

--- a/loopx/capabilities/integration_branch/cli.py
+++ b/loopx/capabilities/integration_branch/cli.py
@@ -70,6 +70,13 @@ def register_integration_branch_commands(
     )
     add_subcommand_format(sync)
     _add_common_arguments(sync)
+    sync.add_argument(
+        "--candidate-ref",
+        help=(
+            "Use a manually resolved candidate commit after verifying it contains "
+            "the configured base and every exact source head."
+        ),
+    )
     sync.add_argument("--execute", action="store_true")
 
 
@@ -101,6 +108,7 @@ def handle_integration_branch_command(
             payload = sync_integration_branch(
                 repo_path=args.repo_path,
                 plan_file=args.plan_file,
+                candidate_ref=args.candidate_ref,
                 execute=args.execute,
             )
     except IntegrationBranchError as exc:

--- a/loopx/capabilities/integration_branch/core.py
+++ b/loopx/capabilities/integration_branch/core.py
@@ -464,11 +464,6 @@ def sync_integration_branch(
 
     resolved = status["resolved"]
     branch = str(status["plan"]["integration_branch"])
-    checked_out_path = _worktree_for_branch(repo, branch)
-    if checked_out_path is not None and not _clean_worktree(checked_out_path):
-        raise IntegrationBranchError(
-            f"integration branch worktree is dirty: {checked_out_path}"
-        )
 
     candidate_sha, failure = _build_candidate(repo, resolved)
     if failure is not None:

--- a/loopx/capabilities/integration_branch/core.py
+++ b/loopx/capabilities/integration_branch/core.py
@@ -68,6 +68,11 @@ def _resolve_optional_commit(repo: Path, ref: str) -> str | None:
     return result.stdout.strip() if result.returncode == 0 else None
 
 
+def _resolve_tree(repo: Path, commit_sha: str) -> str:
+    result = _git(repo, "rev-parse", "--verify", f"{commit_sha}^{{tree}}")
+    return result.stdout.strip()
+
+
 def _validate_branch_name(repo: Path, branch: str) -> str:
     normalized = branch.strip()
     if not normalized:
@@ -452,13 +457,19 @@ def sync_integration_branch(
     repo = _repository_root(repo_path)
     status = integration_branch_status(repo_path=repo, plan_file=plan_file)
     if not status["sync_required"]:
+        integration_sha = status["resolved"]["integration"]["sha"]
         return {
             "ok": True,
             "schema_version": SYNC_SCHEMA_VERSION,
             "status": "already_in_sync",
             "executed": execute,
             "updated": False,
-            "candidate_sha": status["resolved"]["integration"]["sha"],
+            "candidate_sha": integration_sha,
+            "candidate_tree_sha": (
+                _resolve_tree(repo, integration_sha)
+                if isinstance(integration_sha, str)
+                else None
+            ),
             "status_packet": status,
         }
 
@@ -477,6 +488,7 @@ def sync_integration_branch(
             "status_packet": status,
         }
     assert candidate_sha is not None
+    candidate_tree_sha = _resolve_tree(repo, candidate_sha)
     if not execute:
         return {
             "ok": True,
@@ -485,6 +497,7 @@ def sync_integration_branch(
             "executed": False,
             "updated": False,
             "candidate_sha": candidate_sha,
+            "candidate_tree_sha": candidate_tree_sha,
             "status_packet": status,
             "write_boundary": "temporary detached worktree only; integration and source refs unchanged",
         }
@@ -505,6 +518,7 @@ def sync_integration_branch(
     plan["last_sync"] = {
         "base_sha": resolved["base"]["sha"],
         "integration_sha": candidate_sha,
+        "candidate_tree_sha": candidate_tree_sha,
         "sources": [
             {"ref": source["ref"], "sha": source["sha"]}
             for source in resolved["sources"]
@@ -523,6 +537,7 @@ def sync_integration_branch(
         "executed": True,
         "updated": True,
         "candidate_sha": candidate_sha,
+        "candidate_tree_sha": candidate_tree_sha,
         "status_packet": refreshed,
         "write_boundary": (
             "local integration branch and ignored sync receipt only; "

--- a/loopx/capabilities/integration_branch/core.py
+++ b/loopx/capabilities/integration_branch/core.py
@@ -1,0 +1,536 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+PLAN_SCHEMA_VERSION = "loopx_integration_branch_plan_v0"
+STATUS_SCHEMA_VERSION = "loopx_integration_branch_status_v0"
+SYNC_SCHEMA_VERSION = "loopx_integration_branch_sync_v0"
+DEFAULT_PLAN_PATH = Path(".loopx/integration-branch.json")
+ZERO_SHA = "0" * 40
+
+
+class IntegrationBranchError(ValueError):
+    """A fail-closed integration-branch contract error."""
+
+
+def _git(
+    repo: Path,
+    *args: str,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "git command failed"
+        raise IntegrationBranchError(detail)
+    return result
+
+
+def _repository_root(repo_path: str | Path) -> Path:
+    requested = Path(repo_path).expanduser().resolve()
+    result = _git(requested, "rev-parse", "--show-toplevel")
+    return Path(result.stdout.strip()).resolve()
+
+
+def _plan_path(repo: Path, plan_file: str | Path | None) -> Path:
+    if plan_file is None:
+        return repo / DEFAULT_PLAN_PATH
+    candidate = Path(plan_file).expanduser()
+    return (
+        candidate.resolve() if candidate.is_absolute() else (repo / candidate).resolve()
+    )
+
+
+def _resolve_commit(repo: Path, ref: str) -> str:
+    result = _git(repo, "rev-parse", "--verify", f"{ref}^{{commit}}")
+    return result.stdout.strip()
+
+
+def _resolve_optional_commit(repo: Path, ref: str) -> str | None:
+    result = _git(
+        repo,
+        "rev-parse",
+        "--verify",
+        f"{ref}^{{commit}}",
+        check=False,
+    )
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def _validate_branch_name(repo: Path, branch: str) -> str:
+    normalized = branch.strip()
+    if not normalized:
+        raise IntegrationBranchError("integration branch must not be empty")
+    _git(repo, "check-ref-format", "--branch", normalized)
+    return normalized
+
+
+def _normalize_source_refs(source_refs: Sequence[str]) -> list[str]:
+    normalized = [ref.strip() for ref in source_refs if ref.strip()]
+    if not normalized:
+        raise IntegrationBranchError("at least one source branch is required")
+    if len(set(normalized)) != len(normalized):
+        raise IntegrationBranchError("source branches must be unique and ordered")
+    return normalized
+
+
+def _validate_plan(repo: Path, raw: Mapping[str, Any]) -> dict[str, Any]:
+    if raw.get("schema_version") != PLAN_SCHEMA_VERSION:
+        raise IntegrationBranchError(
+            f"integration branch plan must use `{PLAN_SCHEMA_VERSION}`"
+        )
+    base_ref = str(raw.get("base_ref") or "").strip()
+    if not base_ref:
+        raise IntegrationBranchError("integration branch plan requires `base_ref`")
+    integration_branch = _validate_branch_name(
+        repo, str(raw.get("integration_branch") or "")
+    )
+    source_value = raw.get("source_refs")
+    if not isinstance(source_value, list) or not all(
+        isinstance(ref, str) for ref in source_value
+    ):
+        raise IntegrationBranchError(
+            "integration branch plan requires string list `source_refs`"
+        )
+    source_refs = _normalize_source_refs(source_value)
+    integration_ref = f"refs/heads/{integration_branch}"
+    if base_ref in {integration_branch, integration_ref}:
+        raise IntegrationBranchError(
+            "integration branch must not also be the configured base ref"
+        )
+    if integration_branch in source_refs or integration_ref in source_refs:
+        raise IntegrationBranchError(
+            "integration branch must not also be a source branch"
+        )
+    last_sync = raw.get("last_sync")
+    if last_sync is not None and not isinstance(last_sync, Mapping):
+        raise IntegrationBranchError("`last_sync` must be an object or null")
+    return {
+        "schema_version": PLAN_SCHEMA_VERSION,
+        "base_ref": base_ref,
+        "integration_branch": integration_branch,
+        "source_refs": source_refs,
+        "last_sync": dict(last_sync) if isinstance(last_sync, Mapping) else None,
+    }
+
+
+def _read_plan(repo: Path, path: Path) -> dict[str, Any]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise IntegrationBranchError(
+            f"integration branch plan not found: {path}"
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise IntegrationBranchError(
+            f"integration branch plan is not valid JSON: {exc}"
+        ) from exc
+    if not isinstance(raw, Mapping):
+        raise IntegrationBranchError("integration branch plan must be a JSON object")
+    return _validate_plan(repo, raw)
+
+
+def _write_plan(path: Path, plan: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as temporary:
+        json.dump(plan, temporary, ensure_ascii=False, indent=2)
+        temporary.write("\n")
+        temporary.flush()
+        os.fsync(temporary.fileno())
+        temporary_path = Path(temporary.name)
+    os.replace(temporary_path, path)
+
+
+def _resolved_state(repo: Path, plan: Mapping[str, Any]) -> dict[str, Any]:
+    integration_branch = str(plan["integration_branch"])
+    return {
+        "base": {
+            "ref": plan["base_ref"],
+            "sha": _resolve_commit(repo, str(plan["base_ref"])),
+        },
+        "integration": {
+            "branch": integration_branch,
+            "sha": _resolve_optional_commit(repo, f"refs/heads/{integration_branch}"),
+        },
+        "sources": [
+            {"ref": ref, "sha": _resolve_commit(repo, str(ref))}
+            for ref in plan["source_refs"]
+        ],
+    }
+
+
+def _drift_reasons(
+    plan: Mapping[str, Any],
+    resolved: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    receipt = plan.get("last_sync")
+    if not isinstance(receipt, Mapping):
+        return [{"kind": "never_synced"}]
+
+    reasons: list[dict[str, Any]] = []
+    base = resolved["base"]
+    if receipt.get("base_sha") != base["sha"]:
+        reasons.append(
+            {
+                "kind": "base_ref_moved",
+                "ref": base["ref"],
+                "previous_sha": receipt.get("base_sha"),
+                "current_sha": base["sha"],
+            }
+        )
+
+    integration = resolved["integration"]
+    if integration["sha"] is None:
+        reasons.append(
+            {
+                "kind": "integration_branch_missing",
+                "branch": integration["branch"],
+            }
+        )
+    elif receipt.get("integration_sha") != integration["sha"]:
+        reasons.append(
+            {
+                "kind": "integration_head_changed",
+                "branch": integration["branch"],
+                "previous_sha": receipt.get("integration_sha"),
+                "current_sha": integration["sha"],
+            }
+        )
+
+    receipt_sources = receipt.get("sources")
+    normalized_receipt_sources = (
+        receipt_sources if isinstance(receipt_sources, list) else []
+    )
+    previous_by_ref = {
+        str(item.get("ref")): item.get("sha")
+        for item in normalized_receipt_sources
+        if isinstance(item, Mapping)
+    }
+    current_refs = [str(item["ref"]) for item in resolved["sources"]]
+    if list(previous_by_ref) != current_refs:
+        reasons.append(
+            {
+                "kind": "source_set_changed",
+                "previous_refs": list(previous_by_ref),
+                "current_refs": current_refs,
+            }
+        )
+    for source in resolved["sources"]:
+        previous_sha = previous_by_ref.get(str(source["ref"]))
+        if previous_sha != source["sha"]:
+            reasons.append(
+                {
+                    "kind": "source_ref_moved",
+                    "ref": source["ref"],
+                    "previous_sha": previous_sha,
+                    "current_sha": source["sha"],
+                }
+            )
+    return reasons
+
+
+def configure_integration_branch(
+    *,
+    repo_path: str | Path,
+    base_ref: str,
+    integration_branch: str,
+    source_refs: Sequence[str],
+    plan_file: str | Path | None = None,
+    replace: bool = False,
+    execute: bool = False,
+) -> dict[str, Any]:
+    repo = _repository_root(repo_path)
+    path = _plan_path(repo, plan_file)
+    plan = _validate_plan(
+        repo,
+        {
+            "schema_version": PLAN_SCHEMA_VERSION,
+            "base_ref": base_ref,
+            "integration_branch": integration_branch,
+            "source_refs": list(source_refs),
+            "last_sync": None,
+        },
+    )
+    resolved = _resolved_state(repo, plan)
+
+    existing: dict[str, Any] | None = None
+    if path.exists():
+        existing = _read_plan(repo, path)
+        same_definition = all(
+            existing[key] == plan[key]
+            for key in ("base_ref", "integration_branch", "source_refs")
+        )
+        if same_definition:
+            plan = existing
+        elif not replace:
+            raise IntegrationBranchError(
+                "integration branch plan already exists with different values; "
+                "pass `--replace` to reset its sync receipt"
+            )
+
+    changed = existing != plan
+    if execute and changed:
+        _write_plan(path, plan)
+    return {
+        "ok": True,
+        "schema_version": PLAN_SCHEMA_VERSION,
+        "status": "configured" if execute else "preview",
+        "changed": changed,
+        "executed": execute,
+        "plan_file": str(path),
+        "plan": plan,
+        "resolved": resolved,
+        "write_boundary": (
+            "local ignored plan only; no branch, source ref, remote, or PR write"
+        ),
+    }
+
+
+def integration_branch_status(
+    *,
+    repo_path: str | Path,
+    plan_file: str | Path | None = None,
+) -> dict[str, Any]:
+    repo = _repository_root(repo_path)
+    path = _plan_path(repo, plan_file)
+    plan = _read_plan(repo, path)
+    resolved = _resolved_state(repo, plan)
+    reasons = _drift_reasons(plan, resolved)
+    return {
+        "ok": True,
+        "schema_version": STATUS_SCHEMA_VERSION,
+        "status": "in_sync" if not reasons else "drifted",
+        "sync_required": bool(reasons),
+        "plan_file": str(path),
+        "plan": plan,
+        "resolved": resolved,
+        "drift_reasons": reasons,
+        "write_boundary": "read-only local git refs and ignored plan",
+    }
+
+
+def _worktree_for_branch(repo: Path, branch: str) -> Path | None:
+    result = _git(repo, "worktree", "list", "--porcelain")
+    current_path: Path | None = None
+    target_ref = f"refs/heads/{branch}"
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            current_path = Path(line.removeprefix("worktree ")).resolve()
+        elif line == f"branch {target_ref}":
+            return current_path
+        elif not line:
+            current_path = None
+    return None
+
+
+def _clean_worktree(path: Path) -> bool:
+    return not _git(
+        path,
+        "status",
+        "--porcelain",
+        "--untracked-files=all",
+    ).stdout.strip()
+
+
+def _build_candidate(
+    repo: Path,
+    resolved: Mapping[str, Any],
+) -> tuple[str | None, dict[str, Any] | None]:
+    temporary_root = Path(tempfile.mkdtemp(prefix="loopx-integration-branch-"))
+    worktree = temporary_root / "candidate"
+    added = False
+    try:
+        _git(
+            repo,
+            "worktree",
+            "add",
+            "--detach",
+            "--quiet",
+            str(worktree),
+            resolved["base"]["sha"],
+        )
+        added = True
+        for source in resolved["sources"]:
+            result = _git(
+                worktree,
+                "-c",
+                "commit.gpgSign=false",
+                "merge",
+                "--no-ff",
+                "--no-edit",
+                "--no-gpg-sign",
+                source["sha"],
+                check=False,
+            )
+            if result.returncode != 0:
+                detail = result.stderr.strip() or result.stdout.strip()
+                return None, {
+                    "status": "merge_failed",
+                    "source_ref": source["ref"],
+                    "source_sha": source["sha"],
+                    "error": detail,
+                }
+        return _resolve_commit(worktree, "HEAD"), None
+    finally:
+        if added:
+            _git(repo, "worktree", "remove", "--force", str(worktree), check=False)
+        shutil.rmtree(temporary_root, ignore_errors=True)
+
+
+def _update_integration_branch(
+    repo: Path,
+    *,
+    branch: str,
+    expected_old_sha: str | None,
+    candidate_sha: str,
+) -> None:
+    ref = f"refs/heads/{branch}"
+    current_sha = _resolve_optional_commit(repo, ref)
+    if current_sha != expected_old_sha:
+        raise IntegrationBranchError(
+            "integration branch changed while the candidate was being built; rerun sync"
+        )
+    checked_out_path = _worktree_for_branch(repo, branch)
+    if checked_out_path is not None:
+        if not _clean_worktree(checked_out_path):
+            raise IntegrationBranchError(
+                f"integration branch worktree is dirty: {checked_out_path}"
+            )
+        _git(checked_out_path, "reset", "--hard", candidate_sha)
+        return
+    _git(repo, "update-ref", ref, candidate_sha, expected_old_sha or ZERO_SHA)
+
+
+def _assert_inputs_unchanged(
+    repo: Path,
+    *,
+    plan_path: Path,
+    plan: Mapping[str, Any],
+    resolved: Mapping[str, Any],
+) -> None:
+    if _read_plan(repo, plan_path) != plan:
+        raise IntegrationBranchError(
+            "integration branch plan changed while the candidate was being built; "
+            "rerun sync"
+        )
+    if _resolve_commit(repo, str(resolved["base"]["ref"])) != resolved["base"]["sha"]:
+        raise IntegrationBranchError(
+            "base ref changed while the candidate was being built; rerun sync"
+        )
+    for source in resolved["sources"]:
+        if _resolve_commit(repo, str(source["ref"])) != source["sha"]:
+            raise IntegrationBranchError(
+                f"source ref `{source['ref']}` changed while the candidate was "
+                "being built; rerun sync"
+            )
+
+
+def sync_integration_branch(
+    *,
+    repo_path: str | Path,
+    plan_file: str | Path | None = None,
+    execute: bool = False,
+) -> dict[str, Any]:
+    repo = _repository_root(repo_path)
+    status = integration_branch_status(repo_path=repo, plan_file=plan_file)
+    if not status["sync_required"]:
+        return {
+            "ok": True,
+            "schema_version": SYNC_SCHEMA_VERSION,
+            "status": "already_in_sync",
+            "executed": execute,
+            "updated": False,
+            "candidate_sha": status["resolved"]["integration"]["sha"],
+            "status_packet": status,
+        }
+
+    resolved = status["resolved"]
+    branch = str(status["plan"]["integration_branch"])
+    checked_out_path = _worktree_for_branch(repo, branch)
+    if checked_out_path is not None and not _clean_worktree(checked_out_path):
+        raise IntegrationBranchError(
+            f"integration branch worktree is dirty: {checked_out_path}"
+        )
+
+    candidate_sha, failure = _build_candidate(repo, resolved)
+    if failure is not None:
+        return {
+            "ok": False,
+            "schema_version": SYNC_SCHEMA_VERSION,
+            **failure,
+            "executed": False,
+            "updated": False,
+            "integration_unchanged": True,
+            "status_packet": status,
+        }
+    assert candidate_sha is not None
+    if not execute:
+        return {
+            "ok": True,
+            "schema_version": SYNC_SCHEMA_VERSION,
+            "status": "preview_ready",
+            "executed": False,
+            "updated": False,
+            "candidate_sha": candidate_sha,
+            "status_packet": status,
+            "write_boundary": "temporary detached worktree only; integration and source refs unchanged",
+        }
+
+    _assert_inputs_unchanged(
+        repo,
+        plan_path=Path(status["plan_file"]),
+        plan=status["plan"],
+        resolved=resolved,
+    )
+    _update_integration_branch(
+        repo,
+        branch=branch,
+        expected_old_sha=resolved["integration"]["sha"],
+        candidate_sha=candidate_sha,
+    )
+    plan = dict(status["plan"])
+    plan["last_sync"] = {
+        "base_sha": resolved["base"]["sha"],
+        "integration_sha": candidate_sha,
+        "sources": [
+            {"ref": source["ref"], "sha": source["sha"]}
+            for source in resolved["sources"]
+        ],
+    }
+    _write_plan(Path(status["plan_file"]), plan)
+    refreshed = integration_branch_status(repo_path=repo, plan_file=plan_file)
+    if refreshed["sync_required"]:
+        raise IntegrationBranchError(
+            "integration branch sync did not produce an in-sync readback"
+        )
+    return {
+        "ok": True,
+        "schema_version": SYNC_SCHEMA_VERSION,
+        "status": "synced",
+        "executed": True,
+        "updated": True,
+        "candidate_sha": candidate_sha,
+        "status_packet": refreshed,
+        "write_boundary": (
+            "local integration branch and ignored sync receipt only; "
+            "source refs and remotes unchanged"
+        ),
+    }

--- a/loopx/capabilities/integration_branch/core.py
+++ b/loopx/capabilities/integration_branch/core.py
@@ -448,10 +448,42 @@ def _assert_inputs_unchanged(
             )
 
 
+def _resolve_supplied_candidate(
+    repo: Path,
+    *,
+    candidate_ref: str,
+    resolved: Mapping[str, Any],
+) -> str:
+    candidate_sha = _resolve_commit(repo, candidate_ref)
+    required_inputs = [
+        ("base", resolved["base"]["ref"], resolved["base"]["sha"]),
+        *[
+            ("source", source["ref"], source["sha"])
+            for source in resolved["sources"]
+        ],
+    ]
+    for kind, ref, sha in required_inputs:
+        result = _git(
+            repo,
+            "merge-base",
+            "--is-ancestor",
+            str(sha),
+            candidate_sha,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise IntegrationBranchError(
+                f"supplied candidate `{candidate_ref}` does not contain "
+                f"{kind} `{ref}` at `{sha}`"
+            )
+    return candidate_sha
+
+
 def sync_integration_branch(
     *,
     repo_path: str | Path,
     plan_file: str | Path | None = None,
+    candidate_ref: str | None = None,
     execute: bool = False,
 ) -> dict[str, Any]:
     repo = _repository_root(repo_path)
@@ -476,17 +508,25 @@ def sync_integration_branch(
     resolved = status["resolved"]
     branch = str(status["plan"]["integration_branch"])
 
-    candidate_sha, failure = _build_candidate(repo, resolved)
-    if failure is not None:
-        return {
-            "ok": False,
-            "schema_version": SYNC_SCHEMA_VERSION,
-            **failure,
-            "executed": False,
-            "updated": False,
-            "integration_unchanged": True,
-            "status_packet": status,
-        }
+    candidate_source = "supplied" if candidate_ref is not None else "built"
+    if candidate_ref is not None:
+        candidate_sha = _resolve_supplied_candidate(
+            repo,
+            candidate_ref=candidate_ref,
+            resolved=resolved,
+        )
+    else:
+        candidate_sha, failure = _build_candidate(repo, resolved)
+        if failure is not None:
+            return {
+                "ok": False,
+                "schema_version": SYNC_SCHEMA_VERSION,
+                **failure,
+                "executed": False,
+                "updated": False,
+                "integration_unchanged": True,
+                "status_packet": status,
+            }
     assert candidate_sha is not None
     candidate_tree_sha = _resolve_tree(repo, candidate_sha)
     if not execute:
@@ -498,8 +538,11 @@ def sync_integration_branch(
             "updated": False,
             "candidate_sha": candidate_sha,
             "candidate_tree_sha": candidate_tree_sha,
+            "candidate_source": candidate_source,
             "status_packet": status,
-            "write_boundary": "temporary detached worktree only; integration and source refs unchanged",
+            "write_boundary": (
+                "candidate commit read only; integration and source refs unchanged"
+            ),
         }
 
     _assert_inputs_unchanged(
@@ -519,6 +562,7 @@ def sync_integration_branch(
         "base_sha": resolved["base"]["sha"],
         "integration_sha": candidate_sha,
         "candidate_tree_sha": candidate_tree_sha,
+        "candidate_source": candidate_source,
         "sources": [
             {"ref": source["ref"], "sha": source["sha"]}
             for source in resolved["sources"]
@@ -538,6 +582,7 @@ def sync_integration_branch(
         "updated": True,
         "candidate_sha": candidate_sha,
         "candidate_tree_sha": candidate_tree_sha,
+        "candidate_source": candidate_source,
         "status_packet": refreshed,
         "write_boundary": (
             "local integration branch and ignored sync receipt only; "

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -14,6 +14,10 @@ from .capabilities.change_quality.cli import (
     handle_change_quality_command,
     register_change_quality_commands,
 )
+from .capabilities.integration_branch.cli import (
+    handle_integration_branch_command,
+    register_integration_branch_commands,
+)
 from .capabilities.decision_context.cli import (
     handle_decision_context_command,
     register_decision_context_commands,
@@ -216,6 +220,8 @@ def build_parser() -> LoopXArgumentParser:
 
     register_change_quality_commands(sub, add_subcommand_format)
 
+    register_integration_branch_commands(sub, add_subcommand_format)
+
     register_content_ops_commands(sub, add_subcommand_format)
 
     register_decision_context_commands(sub, add_subcommand_format)
@@ -408,6 +414,14 @@ def main(argv: list[str] | None = None) -> int:
     )
     if change_quality_result is not None:
         return change_quality_result
+
+    integration_branch_result = handle_integration_branch_command(
+        args,
+        output_format=output_format,
+        print_payload=print_payload,
+    )
+    if integration_branch_result is not None:
+        return integration_branch_result
 
     if args.command == "ml-experiment":
         return handle_ml_experiment_command(args, output_format=output_format, print_payload=print_payload)

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -167,6 +167,10 @@ COMMAND_GROUPS: list[dict[str, object]] = [
                 "command": "loopx change-quality --help",
                 "purpose": "Qualify one exact final diff against an enabled project policy and receipt contract.",
             },
+            {
+                "command": "loopx integration-branch --help",
+                "purpose": "Detect reviewed source-branch drift and rebuild one local integration branch.",
+            },
             {"command": "loopx registry", "purpose": "Inspect registered goals and adapters."},
             {"command": "loopx sync-global", "purpose": "Merge project state into the shared registry."},
             {

--- a/tests/capabilities/test_capability_extension_registry.py
+++ b/tests/capabilities/test_capability_extension_registry.py
@@ -23,6 +23,7 @@ from loopx.extensions.runtime import (
 )
 
 BUILTIN_IDS = [
+    "integration-branch-reconcile",
     "change-quality-qualification",
     "issue-fix",
     "decision-context",

--- a/tests/capabilities/test_integration_branch.py
+++ b/tests/capabilities/test_integration_branch.py
@@ -105,6 +105,11 @@ def test_sync_detects_review_updates_and_rebuilds_exact_heads(
     assert _git(repo, "branch", "--list", "codex/local-integration") == ""
 
     synced = sync_integration_branch(repo_path=repo, execute=True)
+    assert synced["candidate_tree_sha"] == preview["candidate_tree_sha"]
+    assert (
+        synced["status_packet"]["plan"]["last_sync"]["candidate_tree_sha"]
+        == preview["candidate_tree_sha"]
+    )
     first_integration_head = str(synced["candidate_sha"])
     assert synced["status"] == "synced"
     assert integration_branch_status(repo_path=repo)["status"] == "in_sync"

--- a/tests/capabilities/test_integration_branch.py
+++ b/tests/capabilities/test_integration_branch.py
@@ -174,6 +174,10 @@ def test_dirty_checked_out_integration_worktree_fails_closed(
     _git(repo, "switch", "codex/local-integration")
     (repo / "shared.txt").write_text("dirty\n", encoding="utf-8")
 
+    preview = sync_integration_branch(repo_path=repo)
+    assert preview["status"] == "preview_ready"
+    assert preview["updated"] is False
+
     with pytest.raises(IntegrationBranchError, match="worktree is dirty"):
         sync_integration_branch(repo_path=repo, execute=True)
 

--- a/tests/capabilities/test_integration_branch.py
+++ b/tests/capabilities/test_integration_branch.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from loopx.capabilities.integration_branch import (
+    configure_integration_branch,
+    integration_branch_status,
+    sync_integration_branch,
+)
+from loopx.capabilities.integration_branch.core import IntegrationBranchError
+from loopx.cli import main
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _commit(repo: Path, path: str, content: str, message: str) -> str:
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    _git(repo, "add", path)
+    _git(repo, "commit", "-m", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _repository(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.name", "LoopX Test")
+    _git(repo, "config", "user.email", "loopx@example.invalid")
+    _commit(repo, "shared.txt", "base\n", "base")
+
+    _git(repo, "switch", "-c", "feature-a")
+    _commit(repo, "a.txt", "a1\n", "feature a")
+    _git(repo, "switch", "main")
+
+    _git(repo, "switch", "-c", "fix-b")
+    _commit(repo, "b.txt", "b1\n", "fix b")
+    _git(repo, "switch", "main")
+    return repo
+
+
+def _configure(repo: Path) -> dict[str, object]:
+    return configure_integration_branch(
+        repo_path=repo,
+        base_ref="main",
+        integration_branch="codex/local-integration",
+        source_refs=["feature-a", "fix-b"],
+        execute=True,
+    )
+
+
+def test_configure_is_preview_first_and_idempotent(tmp_path: Path) -> None:
+    repo = _repository(tmp_path)
+
+    preview = configure_integration_branch(
+        repo_path=repo,
+        base_ref="main",
+        integration_branch="codex/local-integration",
+        source_refs=["feature-a", "fix-b"],
+    )
+    plan_path = Path(preview["plan_file"])
+    assert preview["status"] == "preview"
+    assert not plan_path.exists()
+
+    configured = _configure(repo)
+    repeated = _configure(repo)
+    assert configured["changed"] is True
+    assert repeated["changed"] is False
+    assert json.loads(plan_path.read_text(encoding="utf-8"))["last_sync"] is None
+
+    with pytest.raises(IntegrationBranchError, match="configured base ref"):
+        configure_integration_branch(
+            repo_path=repo,
+            base_ref="main",
+            integration_branch="main",
+            source_refs=["feature-a"],
+        )
+
+
+def test_sync_detects_review_updates_and_rebuilds_exact_heads(
+    tmp_path: Path,
+) -> None:
+    repo = _repository(tmp_path)
+    _configure(repo)
+
+    initial = integration_branch_status(repo_path=repo)
+    assert initial["status"] == "drifted"
+    assert initial["drift_reasons"] == [{"kind": "never_synced"}]
+
+    preview = sync_integration_branch(repo_path=repo)
+    assert preview["status"] == "preview_ready"
+    assert _git(repo, "branch", "--list", "codex/local-integration") == ""
+
+    synced = sync_integration_branch(repo_path=repo, execute=True)
+    first_integration_head = str(synced["candidate_sha"])
+    assert synced["status"] == "synced"
+    assert integration_branch_status(repo_path=repo)["status"] == "in_sync"
+    for source in ("feature-a", "fix-b"):
+        _git(
+            repo,
+            "merge-base",
+            "--is-ancestor",
+            source,
+            "codex/local-integration",
+        )
+
+    _git(repo, "switch", "feature-a")
+    updated_source_head = _commit(repo, "a.txt", "a2\n", "review fix")
+    _git(repo, "switch", "main")
+
+    drifted = integration_branch_status(repo_path=repo)
+    assert _git(repo, "rev-parse", "codex/local-integration") == first_integration_head
+    assert {reason["kind"] for reason in drifted["drift_reasons"]} == {
+        "source_ref_moved"
+    }
+
+    resynced = sync_integration_branch(repo_path=repo, execute=True)
+    assert resynced["status"] == "synced"
+    assert resynced["candidate_sha"] != first_integration_head
+    _git(
+        repo,
+        "merge-base",
+        "--is-ancestor",
+        updated_source_head,
+        "codex/local-integration",
+    )
+    assert _git(repo, "rev-parse", "feature-a") == updated_source_head
+    assert integration_branch_status(repo_path=repo)["status"] == "in_sync"
+
+
+def test_merge_conflict_keeps_previous_integration_head(tmp_path: Path) -> None:
+    repo = _repository(tmp_path)
+    _configure(repo)
+    first = sync_integration_branch(repo_path=repo, execute=True)
+    old_head = str(first["candidate_sha"])
+
+    _git(repo, "switch", "feature-a")
+    _commit(repo, "shared.txt", "from-a\n", "feature a shared change")
+    _git(repo, "switch", "fix-b")
+    _commit(repo, "shared.txt", "from-b\n", "fix b shared change")
+    _git(repo, "switch", "main")
+
+    failed = sync_integration_branch(repo_path=repo, execute=True)
+    assert failed["ok"] is False
+    assert failed["status"] == "merge_failed"
+    assert failed["source_ref"] == "fix-b"
+    assert failed["integration_unchanged"] is True
+    assert _git(repo, "rev-parse", "codex/local-integration") == old_head
+
+
+def test_dirty_checked_out_integration_worktree_fails_closed(
+    tmp_path: Path,
+) -> None:
+    repo = _repository(tmp_path)
+    _configure(repo)
+    sync_integration_branch(repo_path=repo, execute=True)
+
+    source_worktree = tmp_path / "source-worktree"
+    _git(repo, "worktree", "add", str(source_worktree), "feature-a")
+    _commit(source_worktree, "a.txt", "a2\n", "review update")
+    _git(repo, "switch", "codex/local-integration")
+    (repo / "shared.txt").write_text("dirty\n", encoding="utf-8")
+
+    with pytest.raises(IntegrationBranchError, match="worktree is dirty"):
+        sync_integration_branch(repo_path=repo, execute=True)
+
+
+def test_cli_configure_and_status_json(tmp_path: Path, capsys) -> None:
+    repo = _repository(tmp_path)
+    common = [
+        "--format",
+        "json",
+        "integration-branch",
+    ]
+    assert (
+        main(
+            [
+                *common,
+                "configure",
+                "--repo-path",
+                str(repo),
+                "--base-ref",
+                "main",
+                "--integration-branch",
+                "codex/local-integration",
+                "--source-branch",
+                "feature-a",
+                "--source-branch",
+                "fix-b",
+                "--execute",
+            ]
+        )
+        == 0
+    )
+    configured = json.loads(capsys.readouterr().out)
+    assert configured["status"] == "configured"
+
+    assert (
+        main(
+            [
+                *common,
+                "status",
+                "--repo-path",
+                str(repo),
+            ]
+        )
+        == 0
+    )
+    status = json.loads(capsys.readouterr().out)
+    assert status["status"] == "drifted"
+    assert status["drift_reasons"] == [{"kind": "never_synced"}]

--- a/tests/capabilities/test_integration_branch.py
+++ b/tests/capabilities/test_integration_branch.py
@@ -165,6 +165,38 @@ def test_merge_conflict_keeps_previous_integration_head(tmp_path: Path) -> None:
     assert failed["integration_unchanged"] is True
     assert _git(repo, "rev-parse", "codex/local-integration") == old_head
 
+    _git(repo, "switch", "-c", "manual-resolution", "main")
+    _git(repo, "merge", "--no-ff", "--no-edit", "feature-a")
+    merge = subprocess.run(
+        ["git", "-C", str(repo), "merge", "--no-ff", "--no-edit", "fix-b"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert merge.returncode != 0
+    (repo / "shared.txt").write_text("resolved\n", encoding="utf-8")
+    _git(repo, "add", "shared.txt")
+    _git(repo, "commit", "--no-edit")
+    resolved_head = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "switch", "main")
+
+    with pytest.raises(IntegrationBranchError, match="does not contain source"):
+        sync_integration_branch(repo_path=repo, candidate_ref="main")
+
+    preview = sync_integration_branch(repo_path=repo, candidate_ref=resolved_head)
+    assert preview["status"] == "preview_ready"
+    assert preview["candidate_source"] == "supplied"
+
+    synced = sync_integration_branch(
+        repo_path=repo,
+        candidate_ref=resolved_head,
+        execute=True,
+    )
+    assert synced["status"] == "synced"
+    assert synced["candidate_sha"] == resolved_head
+    assert synced["status_packet"]["plan"]["last_sync"]["candidate_source"] == "supplied"
+    assert integration_branch_status(repo_path=repo)["status"] == "in_sync"
+
 
 def test_dirty_checked_out_integration_worktree_fails_closed(
     tmp_path: Path,


### PR DESCRIPTION
## Summary

- Add the built-in `integration-branch-reconcile` capability with `configure`, `status`, and `sync` CLI commands.
- Persist one ordered, ignored local plan plus the exact base/source/integration SHA receipt from the last successful sync.
- Rebuild candidates in a temporary detached worktree and publish only after every ordered merge succeeds.
- Detect review-driven source-head changes, base movement, integration drift, missing refs, dirty checked-out integration worktrees, conflicts, and concurrent input movement.

## Why

LoopX already documents using a stable integration branch while independent feature and fix PRs wait for review, but that policy had no executable reconciliation contract. Agents therefore had to remember which reviewed source heads were present and manually replay updates into the local integration branch.

This v0 keeps that responsibility local and machine-readable without changing generic Todo state or coupling the workflow to one issue, repository, or PR provider.

## Safety boundary

- No fetch, push, force-push, PR mutation, protected-branch merge, or source-ref update.
- Preview is the default; mutation requires `sync --execute`.
- The checked-out integration worktree must be clean.
- Merge failure leaves the previous integration head and receipt unchanged.
- v0 uses ordered merge commits; it does not squash or rewrite source history.

## Scope / simplification

The implementation is one capability, one plan/receipt schema, and three commands. It deliberately omits remote synchronization, PR-platform APIs, background monitoring, Todo schema changes, and conflict auto-resolution. Most of the diff is fail-closed git handling, focused tests, and the public contract.

## Validation

- `python -m pytest tests/capabilities/test_integration_branch.py tests/capabilities/test_capability_extension_registry.py -q` — 19 passed
- `PYTHONPATH=$PWD python -m pytest -q` — 1769 passed, 2 skipped
- `python -m ruff check loopx/capabilities/integration_branch tests/capabilities/test_integration_branch.py`
- `python -m loopx.cli canary premerge --from-git-diff --git-diff-base origin/main --tier standard` — 17/17 selected checks passed; public boundary 10 files / 0 hits
- `git diff --check origin/main...HEAD`
