### PR TITLE
fix(canary): audit invoking source checkout

### DIFF
--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -1340,12 +1340,25 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
 )
 
 
-def build_quality_surface_catalog_audit() -> dict[str, Any]:
+def _quality_audit_source_root(candidate: Path | None) -> Path | None:
+    source_root = (candidate or REPO_ROOT).resolve()
+    required_paths = (
+        source_root / "pyproject.toml",
+        source_root / "loopx" / "canary" / "quality_surface_catalog.py",
+        source_root / "tests" / "canary" / "test_quality_surface_catalog.py",
+    )
+    return source_root if all(path.is_file() for path in required_paths) else None
+
+
+def build_quality_surface_catalog_audit(
+    *,
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
     """Audit quality-layer ownership for every high-risk canary profile."""
 
     return _build_quality_surface_catalog_audit(
         CURRENT_REPO_PROFILES,
-        repo_root=REPO_ROOT if (REPO_ROOT / "pyproject.toml").is_file() else None,
+        repo_root=_quality_audit_source_root(repo_root),
     )
 
 

--- a/loopx/cli_commands/canary.py
+++ b/loopx/cli_commands/canary.py
@@ -651,7 +651,9 @@ def handle_canary_command(
         )
         renderer = render_catalog_canary_coverage_audit_markdown
     elif args.canary_command == "quality-audit":
-        payload = build_quality_surface_catalog_audit()
+        payload = build_quality_surface_catalog_audit(
+            repo_root=_resolve_git_repo_root(Path.cwd())
+        )
         renderer = render_quality_surface_catalog_audit_markdown
     elif args.canary_command == "premerge":
         changed_files, git_diff_selector = _resolve_canary_changed_files(args)

--- a/tests/canary/test_quality_surface_catalog.py
+++ b/tests/canary/test_quality_surface_catalog.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from copy import deepcopy
 from pathlib import Path
+from types import SimpleNamespace
 
+import loopx.canary.planner as canary_planner
+import loopx.cli_commands.canary as canary_command
 from loopx.canary.planner import CURRENT_REPO_PROFILES
 from loopx.canary.quality_surface_catalog import (
     QUALITY_SURFACE_CATALOG,
@@ -28,6 +31,65 @@ def test_packaged_audit_keeps_classification_without_source_checkout() -> None:
 
     assert audit["ok"] is True
     assert audit["repository_reference_validation"] == "source_checkout_unavailable"
+
+
+def test_planner_quality_audit_prefers_explicit_source_checkout(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    packaged_root = tmp_path / "release"
+    (packaged_root / "loopx" / "canary").mkdir(parents=True)
+    (packaged_root / "pyproject.toml").write_text("", encoding="utf-8")
+    (packaged_root / "loopx" / "canary" / "quality_surface_catalog.py").write_text(
+        "",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(canary_planner, "REPO_ROOT", packaged_root)
+
+    packaged_audit = canary_planner.build_quality_surface_catalog_audit()
+    checkout_audit = canary_planner.build_quality_surface_catalog_audit(
+        repo_root=Path(__file__).resolve().parents[2]
+    )
+
+    assert packaged_audit["ok"] is True
+    assert (
+        packaged_audit["repository_reference_validation"]
+        == "source_checkout_unavailable"
+    )
+    assert checkout_audit["ok"] is True
+    assert checkout_audit["drift_count"] == 0
+    assert checkout_audit["repository_reference_validation"] == "performed"
+
+
+def test_quality_audit_cli_passes_invoking_checkout_root(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    captured: dict[str, Path] = {}
+
+    def build_audit(*, repo_root: Path) -> dict[str, bool]:
+        captured["repo_root"] = repo_root
+        return {"ok": True}
+
+    monkeypatch.setattr(
+        canary_command,
+        "_resolve_git_repo_root",
+        lambda candidate: tmp_path,
+    )
+    monkeypatch.setattr(
+        canary_command,
+        "build_quality_surface_catalog_audit",
+        build_audit,
+    )
+
+    result = canary_command.handle_canary_command(
+        SimpleNamespace(command="canary", canary_command="quality-audit"),
+        output_format=lambda args: "json",
+        print_payload=lambda payload, output_format, renderer: None,
+    )
+
+    assert result == 0
+    assert captured["repo_root"] == tmp_path
 
 
 def test_unclassified_high_risk_profile_is_drift() -> None:


### PR DESCRIPTION
## Summary

- resolve the invoking Git checkout for `loopx canary quality-audit`
- perform source-reference validation only when the selected tree contains the complete audit source and regression-test surface
- keep packaged or unrelated invocations useful by reporting source checkout unavailable instead of false missing-reference drift

## Validation

- checkout and packaged-invocation behavior checks passed
- focused tests: 11 passed
- full editable-install suite: 1766 passed, 2 skipped
- Ruff on changed files passed
- public boundary scan: 9 checks, 0 errors, 0 warnings
- `git diff --check` passed
- premerge: 4 direct checks and all 15 selected checks passed; no failures, warnings, or manual holds
- exact-scope change-quality receipt: `cqr_95125bad228a0bb3c166`

An exploratory repository-wide mypy run exposed 3,225 pre-existing errors outside this three-file diff, so it was not selected as the acceptance oracle for this change.
