### PR TITLE
fix(integration-branch): adopt current head without reset

### DIFF
--- a/docs/capabilities/integration-branch/README.md
+++ b/docs/capabilities/integration-branch/README.md
@@ -81,6 +81,10 @@ SHA as ancestors. LoopX does not choose or generate the resolution; it only
 verifies the immutable result before the normal local publication and
 readback flow.
 
+When the supplied commit is already the integration branch head, execute only
+records the verified receipt. It does not reset or otherwise touch the checked
+out worktree.
+
 ## Boundary
 
 The capability is deliberately local:

--- a/loopx/capabilities/integration_branch/core.py
+++ b/loopx/capabilities/integration_branch/core.py
@@ -551,12 +551,14 @@ def sync_integration_branch(
         plan=status["plan"],
         resolved=resolved,
     )
-    _update_integration_branch(
-        repo,
-        branch=branch,
-        expected_old_sha=resolved["integration"]["sha"],
-        candidate_sha=candidate_sha,
-    )
+    branch_updated = candidate_sha != resolved["integration"]["sha"]
+    if branch_updated:
+        _update_integration_branch(
+            repo,
+            branch=branch,
+            expected_old_sha=resolved["integration"]["sha"],
+            candidate_sha=candidate_sha,
+        )
     plan = dict(status["plan"])
     plan["last_sync"] = {
         "base_sha": resolved["base"]["sha"],
@@ -579,7 +581,7 @@ def sync_integration_branch(
         "schema_version": SYNC_SCHEMA_VERSION,
         "status": "synced",
         "executed": True,
-        "updated": True,
+        "updated": branch_updated,
         "candidate_sha": candidate_sha,
         "candidate_tree_sha": candidate_tree_sha,
         "candidate_source": candidate_source,

--- a/tests/capabilities/test_integration_branch.py
+++ b/tests/capabilities/test_integration_branch.py
@@ -198,6 +198,30 @@ def test_merge_conflict_keeps_previous_integration_head(tmp_path: Path) -> None:
     assert integration_branch_status(repo_path=repo)["status"] == "in_sync"
 
 
+def test_adopt_current_integration_head_without_touching_worktree(
+    tmp_path: Path,
+) -> None:
+    repo = _repository(tmp_path)
+    _configure(repo)
+    _git(repo, "switch", "-c", "codex/local-integration", "main")
+    _git(repo, "merge", "--no-ff", "--no-edit", "feature-a")
+    _git(repo, "merge", "--no-ff", "--no-edit", "fix-b")
+    integration_head = _git(repo, "rev-parse", "HEAD")
+    (repo / "shared.txt").write_text("local diagnostic\n", encoding="utf-8")
+
+    synced = sync_integration_branch(
+        repo_path=repo,
+        candidate_ref=integration_head,
+        execute=True,
+    )
+
+    assert synced["status"] == "synced"
+    assert synced["updated"] is False
+    assert _git(repo, "rev-parse", "HEAD") == integration_head
+    assert (repo / "shared.txt").read_text(encoding="utf-8") == "local diagnostic\n"
+    assert integration_branch_status(repo_path=repo)["status"] == "in_sync"
+
+
 def test_dirty_checked_out_integration_worktree_fails_closed(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What changed

- Treat an already-current supplied integration candidate as a receipt adoption, without updating the branch ref or checked-out worktree.
- Return `updated=false` for that no-op publication path.
- Add a regression proving a dirty checked-out worktree remains untouched when its current head is adopted.
- Document the receipt-only behavior.

## Why

A maintainer may introduce LoopX after a long-lived integration branch already contains the exact base and source heads. The ancestry checks prove that candidate, but the previous execute path still ran `git reset --hard` on the checked-out integration worktree. No branch movement is necessary in this case.

## Impact

Existing rebuild and fail-closed dirty-worktree behavior is unchanged when the candidate differs from the current integration head. Adoption of an identical head now records the verified receipt without touching local files.

## Validation

- `python -m pytest -q tests/capabilities/test_integration_branch.py` — 6 passed
- `python -m ruff check ...` — passed
- `loopx canary premerge --from-git-diff --goal-id ark-agent-loop-goal` — passed, 14 checks, 0 failures, 0 manual holds
- Real multi-source integration branch adoption — `status=in_sync`, `updated=false`, branch SHA unchanged
- `python -m mypy ...` could not start because this host Python 3.13 lacks `_sqlite3`; traceback fails inside mypy's cache initialization before source analysis.
