### PR TITLE
fix(integration-branch): enforce local plan boundary

### DIFF
--- a/docs/capabilities/integration-branch/README.md
+++ b/docs/capabilities/integration-branch/README.md
@@ -28,6 +28,11 @@ Source order is significant. `configure` validates all refs but writes only
 `.loopx/integration-branch.json`. A different existing plan requires explicit
 `--replace`, which also clears its old sync receipt.
 
+An alternate `--plan-file` must still resolve below the repository's `.loopx/`
+state root. Paths outside that root, traversal, and symlink escapes fail closed.
+The selected path must also be untracked and covered by the repository's ignore
+rules so the reported local ignored-state boundary remains true.
+
 ## Detect review drift
 
 ```bash

--- a/loopx/capabilities/integration_branch/core.py
+++ b/loopx/capabilities/integration_branch/core.py
@@ -44,12 +44,44 @@ def _repository_root(repo_path: str | Path) -> Path:
 
 
 def _plan_path(repo: Path, plan_file: str | Path | None) -> Path:
+    state_root = (repo / ".loopx").resolve()
+    if not state_root.is_relative_to(repo):
+        raise IntegrationBranchError(
+            "repository `.loopx` state root must not resolve outside the repository"
+        )
     if plan_file is None:
-        return repo / DEFAULT_PLAN_PATH
+        return state_root / DEFAULT_PLAN_PATH.name
     candidate = Path(plan_file).expanduser()
-    return (
+    resolved = (
         candidate.resolve() if candidate.is_absolute() else (repo / candidate).resolve()
     )
+    if resolved == state_root or not resolved.is_relative_to(state_root):
+        raise IntegrationBranchError(
+            "integration branch plan must remain under the repository `.loopx` "
+            "state root"
+        )
+    return resolved
+
+
+def _assert_ignored_plan(repo: Path, path: Path) -> None:
+    relative = path.relative_to(repo).as_posix()
+    tracked = _git(
+        repo,
+        "ls-files",
+        "--error-unmatch",
+        "--",
+        relative,
+        check=False,
+    )
+    if tracked.returncode == 0:
+        raise IntegrationBranchError(
+            "integration branch plan must be local ignored state, not a tracked file"
+        )
+    ignored = _git(repo, "check-ignore", "--quiet", "--", relative, check=False)
+    if ignored.returncode != 0:
+        raise IntegrationBranchError(
+            "integration branch plan must be ignored by the repository before use"
+        )
 
 
 def _resolve_commit(repo: Path, ref: str) -> str:
@@ -264,6 +296,7 @@ def configure_integration_branch(
 ) -> dict[str, Any]:
     repo = _repository_root(repo_path)
     path = _plan_path(repo, plan_file)
+    _assert_ignored_plan(repo, path)
     plan = _validate_plan(
         repo,
         {
@@ -316,6 +349,7 @@ def integration_branch_status(
 ) -> dict[str, Any]:
     repo = _repository_root(repo_path)
     path = _plan_path(repo, plan_file)
+    _assert_ignored_plan(repo, path)
     plan = _read_plan(repo, path)
     resolved = _resolved_state(repo, plan)
     reasons = _drift_reasons(plan, resolved)
@@ -551,6 +585,7 @@ def sync_integration_branch(
         plan=status["plan"],
         resolved=resolved,
     )
+    _assert_ignored_plan(repo, Path(status["plan_file"]))
     branch_updated = candidate_sha != resolved["integration"]["sha"]
     if branch_updated:
         _update_integration_branch(

--- a/tests/capabilities/test_integration_branch.py
+++ b/tests/capabilities/test_integration_branch.py
@@ -40,6 +40,7 @@ def _repository(tmp_path: Path) -> Path:
     _git(repo, "init", "-b", "main")
     _git(repo, "config", "user.name", "LoopX Test")
     _git(repo, "config", "user.email", "loopx@example.invalid")
+    _commit(repo, ".gitignore", ".loopx/\n", "ignore LoopX state")
     _commit(repo, "shared.txt", "base\n", "base")
 
     _git(repo, "switch", "-c", "feature-a")
@@ -86,6 +87,67 @@ def test_configure_is_preview_first_and_idempotent(tmp_path: Path) -> None:
             repo_path=repo,
             base_ref="main",
             integration_branch="main",
+            source_refs=["feature-a"],
+        )
+
+
+def test_plan_file_must_remain_under_loopx_state_root(tmp_path: Path) -> None:
+    repo = _repository(tmp_path)
+    outside_plan = tmp_path / "outside.json"
+
+    for plan_file in (outside_plan, Path(".loopx/../outside.json")):
+        with pytest.raises(IntegrationBranchError, match="must remain under"):
+            configure_integration_branch(
+                repo_path=repo,
+                base_ref="main",
+                integration_branch="codex/local-integration",
+                source_refs=["feature-a"],
+                plan_file=plan_file,
+                execute=True,
+            )
+    assert not outside_plan.exists()
+
+    configured = configure_integration_branch(
+        repo_path=repo,
+        base_ref="main",
+        integration_branch="codex/local-integration",
+        source_refs=["feature-a"],
+        plan_file=Path(".loopx/custom-integration.json"),
+        execute=True,
+    )
+    assert Path(configured["plan_file"]).is_file()
+
+
+def test_plan_file_rejects_symlink_escape(tmp_path: Path) -> None:
+    repo = _repository(tmp_path)
+    state_root = repo / ".loopx"
+    state_root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (state_root / "escape").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(IntegrationBranchError, match="must remain under"):
+        configure_integration_branch(
+            repo_path=repo,
+            base_ref="main",
+            integration_branch="codex/local-integration",
+            source_refs=["feature-a"],
+            plan_file=Path(".loopx/escape/integration.json"),
+            execute=True,
+        )
+    assert not (outside / "integration.json").exists()
+
+
+def test_plan_file_must_be_ignored_local_state(tmp_path: Path) -> None:
+    repo = _repository(tmp_path)
+    _git(repo, "rm", ".gitignore")
+    _git(repo, "commit", "-m", "stop ignoring LoopX state")
+
+    with pytest.raises(IntegrationBranchError, match="must be ignored"):
+        configure_integration_branch(
+            repo_path=repo,
+            base_ref="main",
+            integration_branch="codex/local-integration",
             source_refs=["feature-a"],
         )
 
@@ -287,3 +349,38 @@ def test_cli_configure_and_status_json(tmp_path: Path, capsys) -> None:
     status = json.loads(capsys.readouterr().out)
     assert status["status"] == "drifted"
     assert status["drift_reasons"] == [{"kind": "never_synced"}]
+
+
+def test_cli_rejects_plan_file_outside_loopx_state_root(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    repo = _repository(tmp_path)
+    outside_plan = tmp_path / "outside.json"
+
+    assert (
+        main(
+            [
+                "--format",
+                "json",
+                "integration-branch",
+                "configure",
+                "--repo-path",
+                str(repo),
+                "--base-ref",
+                "main",
+                "--integration-branch",
+                "codex/local-integration",
+                "--source-branch",
+                "feature-a",
+                "--plan-file",
+                str(outside_plan),
+                "--execute",
+            ]
+        )
+        == 2
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "invalid_state"
+    assert "must remain under" in payload["error"]
+    assert not outside_plan.exists()


### PR DESCRIPTION
## Summary

- constrain `integration-branch --plan-file` to the repository `.loopx/` state root
- reject traversal, absolute-path, and symlink escapes before any plan write
- require plan files to remain untracked and ignored, matching the CLI's local-state contract
- add focused API and CLI regressions plus capability documentation

## Validation

- focused capability/catalog tests: 24 passed
- full pytest suite: 1776 passed, 2 repository-marked skips
- Ruff on changed Python files: passed
- mypy: 15 source files passed
- Python compile and `git diff --check`: passed
- public/private boundary scan: 3 files clean
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 14/14 selected checks passed, 0 failures, 0 warnings, 0 manual holds
- change-quality receipt: `cqr_a2ddf45699dc2c208dc0` (exact committed scope, valid)

## Scope

Single-purpose runtime-boundary fix with matching tests and docs. No local state, credentials, raw logs, private links, or generated artifacts are included.