### PR TITLE
fix(integration-branch): preserve reviewed source updates

### DIFF
--- a/docs/capabilities/integration-branch/README.md
+++ b/docs/capabilities/integration-branch/README.md
@@ -8,7 +8,7 @@ Long-running repository work often has two simultaneous truths:
 
 `integration-branch-reconcile` makes the second truth machine-readable. It
 stores an ordered plan under ignored `.loopx/` state, compares current refs
-with the last successful sync receipt, and rebuilds the integration branch
+with the last successful sync receipt, and reconciles the integration branch
 through a temporary detached worktree.
 
 ## Configure
@@ -51,10 +51,14 @@ loopx integration-branch sync --repo-path . --format json
 loopx integration-branch sync --repo-path . --execute --format json
 ```
 
-Both paths build the candidate by merging the resolved source SHAs in order
-from the resolved base SHA. Preview removes its temporary worktree without
-changing refs. Execute updates the local integration branch only after every
-merge succeeds, then writes and rereads the receipt.
+After the first sync, a source branch that only advances to a descendant is
+merged onto the last verified integration head. This preserves earlier merge
+and conflict-resolution decisions while incorporating the reviewed update. If
+the base, source set, integration head, or source ancestry no longer matches
+the receipt, LoopX rebuilds from the resolved base and all source SHAs in
+order. Preview removes its temporary worktree without changing refs. Execute
+updates the local integration branch only after every merge succeeds, then
+writes and rereads the receipt.
 
 Rebuilding merge commits can change `candidate_sha` timestamps between preview
 and execute. Compare `candidate_tree_sha` for stable content identity; execute

--- a/loopx/capabilities/integration_branch/core.py
+++ b/loopx/capabilities/integration_branch/core.py
@@ -391,7 +391,9 @@ def _clean_worktree(path: Path) -> bool:
 
 def _build_candidate(
     repo: Path,
-    resolved: Mapping[str, Any],
+    *,
+    start_sha: str,
+    sources: Sequence[Mapping[str, Any]],
 ) -> tuple[str | None, dict[str, Any] | None]:
     temporary_root = Path(tempfile.mkdtemp(prefix="loopx-integration-branch-"))
     worktree = temporary_root / "candidate"
@@ -404,10 +406,10 @@ def _build_candidate(
             "--detach",
             "--quiet",
             str(worktree),
-            resolved["base"]["sha"],
+            start_sha,
         )
         added = True
-        for source in resolved["sources"]:
+        for source in sources:
             result = _git(
                 worktree,
                 "-c",
@@ -432,6 +434,60 @@ def _build_candidate(
         if added:
             _git(repo, "worktree", "remove", "--force", str(worktree), check=False)
         shutil.rmtree(temporary_root, ignore_errors=True)
+
+
+def _is_ancestor(repo: Path, ancestor: str, descendant: str) -> bool:
+    return (
+        _git(
+            repo,
+            "merge-base",
+            "--is-ancestor",
+            ancestor,
+            descendant,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def _incremental_sources(
+    repo: Path,
+    *,
+    plan: Mapping[str, Any],
+    resolved: Mapping[str, Any],
+) -> list[Mapping[str, Any]] | None:
+    receipt = plan.get("last_sync")
+    if not isinstance(receipt, Mapping):
+        return None
+    integration_sha = resolved["integration"]["sha"]
+    if (
+        not isinstance(integration_sha, str)
+        or receipt.get("integration_sha") != integration_sha
+        or receipt.get("base_sha") != resolved["base"]["sha"]
+    ):
+        return None
+
+    receipt_sources = receipt.get("sources")
+    if not isinstance(receipt_sources, list) or len(receipt_sources) != len(
+        resolved["sources"]
+    ):
+        return None
+
+    moved: list[Mapping[str, Any]] = []
+    for previous, current in zip(receipt_sources, resolved["sources"], strict=True):
+        if not isinstance(previous, Mapping) or previous.get("ref") != current["ref"]:
+            return None
+        previous_sha = previous.get("sha")
+        if previous_sha == current["sha"]:
+            continue
+        if not isinstance(previous_sha, str) or not _is_ancestor(
+            repo,
+            previous_sha,
+            str(current["sha"]),
+        ):
+            return None
+        moved.append(current)
+    return moved or None
 
 
 def _update_integration_branch(
@@ -491,10 +547,7 @@ def _resolve_supplied_candidate(
     candidate_sha = _resolve_commit(repo, candidate_ref)
     required_inputs = [
         ("base", resolved["base"]["ref"], resolved["base"]["sha"]),
-        *[
-            ("source", source["ref"], source["sha"])
-            for source in resolved["sources"]
-        ],
+        *[("source", source["ref"], source["sha"]) for source in resolved["sources"]],
     ]
     for kind, ref, sha in required_inputs:
         result = _git(
@@ -550,7 +603,23 @@ def sync_integration_branch(
             resolved=resolved,
         )
     else:
-        candidate_sha, failure = _build_candidate(repo, resolved)
+        incremental_sources = _incremental_sources(
+            repo,
+            plan=status["plan"],
+            resolved=resolved,
+        )
+        if incremental_sources is not None:
+            candidate_source = "incremental"
+            start_sha = str(resolved["integration"]["sha"])
+            sources = incremental_sources
+        else:
+            start_sha = str(resolved["base"]["sha"])
+            sources = resolved["sources"]
+        candidate_sha, failure = _build_candidate(
+            repo,
+            start_sha=start_sha,
+            sources=sources,
+        )
         if failure is not None:
             return {
                 "ok": False,

--- a/tests/capabilities/test_integration_branch.py
+++ b/tests/capabilities/test_integration_branch.py
@@ -152,7 +152,7 @@ def test_plan_file_must_be_ignored_local_state(tmp_path: Path) -> None:
         )
 
 
-def test_sync_detects_review_updates_and_rebuilds_exact_heads(
+def test_sync_detects_review_updates_and_reconciles_exact_heads(
     tmp_path: Path,
 ) -> None:
     repo = _repository(tmp_path)
@@ -196,6 +196,7 @@ def test_sync_detects_review_updates_and_rebuilds_exact_heads(
 
     resynced = sync_integration_branch(repo_path=repo, execute=True)
     assert resynced["status"] == "synced"
+    assert resynced["candidate_source"] == "incremental"
     assert resynced["candidate_sha"] != first_integration_head
     _git(
         repo,
@@ -206,6 +207,23 @@ def test_sync_detects_review_updates_and_rebuilds_exact_heads(
     )
     assert _git(repo, "rev-parse", "feature-a") == updated_source_head
     assert integration_branch_status(repo_path=repo)["status"] == "in_sync"
+
+    _git(repo, "switch", "feature-a")
+    (repo / "a.txt").write_text("a3\n", encoding="utf-8")
+    _git(repo, "add", "a.txt")
+    _git(repo, "commit", "--amend", "--no-edit")
+    rebased_source_head = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "switch", "main")
+
+    rebuilt = sync_integration_branch(repo_path=repo, execute=True)
+    assert rebuilt["candidate_source"] == "built"
+    _git(
+        repo,
+        "merge-base",
+        "--is-ancestor",
+        rebased_source_head,
+        "codex/local-integration",
+    )
 
 
 def test_merge_conflict_keeps_previous_integration_head(tmp_path: Path) -> None:
@@ -256,8 +274,26 @@ def test_merge_conflict_keeps_previous_integration_head(tmp_path: Path) -> None:
     )
     assert synced["status"] == "synced"
     assert synced["candidate_sha"] == resolved_head
-    assert synced["status_packet"]["plan"]["last_sync"]["candidate_source"] == "supplied"
+    assert (
+        synced["status_packet"]["plan"]["last_sync"]["candidate_source"] == "supplied"
+    )
     assert integration_branch_status(repo_path=repo)["status"] == "in_sync"
+
+    _git(repo, "switch", "feature-a")
+    updated_source_head = _commit(repo, "a.txt", "a2\n", "review fix")
+    _git(repo, "switch", "main")
+
+    resynced = sync_integration_branch(repo_path=repo, execute=True)
+    assert resynced["status"] == "synced"
+    assert resynced["candidate_source"] == "incremental"
+    assert _git(repo, "show", "codex/local-integration:shared.txt") == "resolved"
+    _git(
+        repo,
+        "merge-base",
+        "--is-ancestor",
+        updated_source_head,
+        "codex/local-integration",
+    )
 
 
 def test_adopt_current_integration_head_without_touching_worktree(


### PR DESCRIPTION
## What changed

- reuse the last verified integration head when only source branches advance by descendant commits
- merge only those reviewed source updates, preserving prior merge/conflict-resolution decisions
- fall back to the existing full rebuild when the base, source set, integration head, or source ancestry changes
- cover descendant review updates, rewritten source heads, and a prior manual conflict resolution

## Why

A full replay from the base can re-open conflicts that were already resolved in the verified integration branch whenever an MR receives an ordinary review commit. The sync receipt already proves the previous aggregate, so descendant-only updates can be reconciled safely from that point.

## Validation

- `pytest -q tests/capabilities/test_integration_branch.py` — 6 passed
- `python -m ruff check ...` — passed
- `python -m ruff format --check ...` — passed
- `loopx canary premerge --from-git-diff` — 14 selected checks passed, 0 failures, 0 manual holds
