### PR TITLE
release: LoopX v0.4.0

### DIFF
--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/man/loopx.1
+++ b/man/loopx.1
@@ -1,4 +1,4 @@
-.TH LOOPX 1 "" "LoopX 0.3.0" "User Commands"
+.TH LOOPX 1 "" "LoopX 0.4.0" "User Commands"
 .SH NAME
 loopx \- control-plane helper for long-running agent work
 .SH SYNOPSIS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.3.0"
+version = "0.4.0"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Release candidate

Prepare LoopX `v0.4.0` by synchronizing the canonical package version across the runtime, packaging metadata, and man page.

This is a minor capability release from the current `v0.3.0` baseline. The release range adds Integration Branch support, the planner-worker execution slice, source-backed Issue Fix candidate admission, start-goal capability routing, Decision Context source coverage, and control-plane reliability work. This PR deliberately contains only the three version mirrors; release notes, exact-commit qualification, tag promotion, `stable`, and the GitHub Release follow after this commit lands on `main`.

## Scope

- `loopx.__version__`: `0.3.0` -> `0.4.0`
- `pyproject.toml`: `0.3.0` -> `0.4.0`
- `man/loopx.1`: `0.3.0` -> `0.4.0`

## Community contributors

The final English and Chinese release-note sections will prominently credit first-time external contributor [@maxliux5](https://github.com/maxliux5) for the provider-neutral planner-worker contract/runtime and experimental TraeX provider delivered in #2578. Product changes remain the primary release narrative.

## Validation

- `python examples/release/release-version-contract-smoke.py`
- `python examples/release/release-readiness-doc-smoke.py`
- `LOOPX_PYTHON=/usr/local/bin/python python examples/fresh-clone-quickstart-smoke.py`
- `LOOPX_PYTHON=/usr/local/bin/python python examples/release/codex-cli-no-clone-release-verification-smoke.py`
- `LOOPX_PYTHON=/usr/local/bin/python python examples/loopx-update-smoke.py`
- `python -m py_compile loopx/__init__.py`
- `git diff --check`
- `loopx check --scan-path loopx/__init__.py --scan-path pyproject.toml --scan-path man/loopx.1`
- `loopx canary premerge --from-git-diff`
- `uv run --no-project --with build python -m build`
- `uv run --no-project --with twine twine check dist/loopx-0.4.0.tar.gz dist/loopx-0.4.0-py3-none-any.whl`

The first fresh-clone attempt selected macOS `/usr/bin/python3` 3.9.6 and correctly failed the supported-runtime gate. Re-running with the available Python 3.13 interpreter passed. Setuptools also emitted its existing license-table deprecation warning; this narrow release PR does not broaden into packaging cleanup.

Exact release-commit qualification and the full bilingual release-note validator remain post-merge gates before any tag or release is published. No benchmark or realized-outcome uplift is claimed.
