### PR TITLE
fix(control-plane): verify replan delta evidence

### DIFF
--- a/docs/reference/protocols/goal-vision-replan-contract-v0.md
+++ b/docs/reference/protocols/goal-vision-replan-contract-v0.md
@@ -379,9 +379,15 @@ a `replan_noop` and must not clear the obligation.
 `refresh-state` does not treat a caller-supplied delta kind as proof. A
 `runnable_todo_set` claim must resolve to a scoped open advancement todo. A
 `watch_lane_continuation` claim must resolve to a scoped monitor with a target,
-cadence, next due time, and expiry or resume condition, and it cannot settle a
-`repeat_until_closed` vision. Rejected claims remain visible in the repair delta
-contract and the acknowledgement is a no-op when no verified delta remains.
+parseable cadence and next due time, plus an unexpired expiry or unresolved
+resume condition; it cannot settle a `repeat_until_closed` vision. Todo scope
+uses the canonical claim, exclusion, and removed-continuation predicate.
+`successor_or_supersede` must resolve a completed Todo to an existing scoped
+open advancement successor, while `no_followup` must resolve the canonical
+terminal closure proof. Every frontier-clearing delta kind requires an evidence
+resolver; kinds without one cannot form ACK evidence. Rejected claims remain
+visible in the repair delta contract and the acknowledgement is a no-op when no
+verified frontier delta remains.
 
 ### Bad Case: ACK Hidden By Scheduler Accounting
 

--- a/docs/reference/protocols/goal-vision-replan-contract-v0.md
+++ b/docs/reference/protocols/goal-vision-replan-contract-v0.md
@@ -376,6 +376,13 @@ A valid replan writes at least one bounded delta:
 An acknowledgement without a vision, todo, acceptance, or no-follow-up delta is
 a `replan_noop` and must not clear the obligation.
 
+`refresh-state` does not treat a caller-supplied delta kind as proof. A
+`runnable_todo_set` claim must resolve to a scoped open advancement todo. A
+`watch_lane_continuation` claim must resolve to a scoped monitor with a target,
+cadence, next due time, and expiry or resume condition, and it cannot settle a
+`repeat_until_closed` vision. Rejected claims remain visible in the repair delta
+contract and the acknowledgement is a no-op when no verified delta remains.
+
 ### Bad Case: ACK Hidden By Scheduler Accounting
 
 Observed failure: a monitor-only lane correctly projected

--- a/examples/autonomous-replan-obligation-smoke.py
+++ b/examples/autonomous-replan-obligation-smoke.py
@@ -559,6 +559,52 @@ def assert_replan_ack_without_delta_is_noop() -> None:
         assert guard["heartbeat_recommendation"]["recommended_mode"] == "autonomous_replan_required", guard
 
 
+def assert_bare_successor_claim_does_not_clear_replan() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-autonomous-replan-") as tmp:
+        registry_path, runtime = write_fixture(
+            Path(tmp),
+            include_replan_signals=False,
+            periodic_run_count=20,
+        )
+        refresh = run_cli(
+            "refresh-state",
+            "--goal-id",
+            GOAL_ID,
+            "--classification",
+            "autonomous_replan_recorded",
+            "--autonomous-replan-recorded",
+            "--repair-delta-kind",
+            "successor_or_supersede",
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+
+        assert refresh["classification"] == "replan_noop", refresh
+        delta = refresh["repair_delta_contract"]
+        assert delta["delta_present"] is False, delta
+        assert delta["delta_kinds"] == [], delta
+        assert delta["rejected_claims"] == [
+            {
+                "kind": "successor_or_supersede",
+                "reason": "no completed todo links a scoped open advancement successor",
+            }
+        ], delta
+        assert refresh["vision_checkpoint"]["decision"] == "missing_required", refresh
+
+        guard = run_cli(
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        assert guard["autonomous_replan_obligation"]["required"] is True, guard
+        assert guard["heartbeat_recommendation"]["recommended_mode"] == (
+            "autonomous_replan_required"
+        ), guard
+
+
 def assert_watch_replan_ack_requires_bounded_state_evidence() -> None:
     with tempfile.TemporaryDirectory(prefix="loopx-autonomous-replan-") as tmp:
         registry_path, runtime = write_fixture(
@@ -654,6 +700,7 @@ def main() -> int:
     assert_validated_classification_without_ack_does_not_clear_replan()
     assert_refresh_state_structured_ack_clears_replan()
     assert_replan_ack_without_delta_is_noop()
+    assert_bare_successor_claim_does_not_clear_replan()
     assert_watch_replan_ack_requires_bounded_state_evidence()
     assert_no_replan_obligation_without_signal()
     print("autonomous-replan-obligation-smoke ok")

--- a/examples/autonomous-replan-obligation-smoke.py
+++ b/examples/autonomous-replan-obligation-smoke.py
@@ -559,6 +559,73 @@ def assert_replan_ack_without_delta_is_noop() -> None:
         assert guard["heartbeat_recommendation"]["recommended_mode"] == "autonomous_replan_required", guard
 
 
+def assert_watch_replan_ack_requires_bounded_state_evidence() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-autonomous-replan-") as tmp:
+        registry_path, runtime = write_fixture(
+            Path(tmp),
+            include_replan_signals=False,
+            periodic_run_count=20,
+        )
+        state_path = (
+            registry_path.parent.parent
+            / ".codex"
+            / "goals"
+            / GOAL_ID
+            / "ACTIVE_GOAL_STATE.md"
+        )
+        state_text = state_path.read_text(encoding="utf-8")
+        advancement = "- [ ] [P1] Advance the next bounded project hardening slice.\n"
+        monitor = (
+            "- [ ] [P1] Watch the external review transition.\n"
+            "  <!-- loopx:todo todo_id=todo_123456789abc status=open "
+            "task_class=continuous_monitor target_key=review cadence=30m "
+            "next_due_at=2026-08-01T13:00:00Z -->\n"
+        )
+        state_path.write_text(
+            state_text.replace(advancement, monitor),
+            encoding="utf-8",
+        )
+
+        rejected = run_cli(
+            "refresh-state",
+            "--goal-id",
+            GOAL_ID,
+            "--classification",
+            "autonomous_replan_recorded",
+            "--autonomous-replan-recorded",
+            "--repair-delta-kind",
+            "watch_lane_continuation",
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        assert rejected["classification"] == "replan_noop", rejected
+        assert rejected["repair_delta_contract"]["delta_present"] is False, rejected
+        assert rejected["repair_delta_contract"]["rejected_claims"], rejected
+
+        state_path.write_text(
+            state_path.read_text(encoding="utf-8").replace(
+                "next_due_at=2026-08-01T13:00:00Z",
+                "next_due_at=2026-08-01T13:00:00Z expires_at=2026-08-02T13:00:00Z",
+            ),
+            encoding="utf-8",
+        )
+        accepted = run_cli(
+            "refresh-state",
+            "--goal-id",
+            GOAL_ID,
+            "--classification",
+            "autonomous_replan_recorded",
+            "--autonomous-replan-recorded",
+            "--repair-delta-kind",
+            "watch_lane_continuation",
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        assert accepted["autonomous_replan_recorded"] is True, accepted
+        evidence = accepted["repair_delta_contract"]["auto_evidence"]
+        assert evidence[0]["todo_ids"] == ["todo_123456789abc"], evidence
+
+
 def assert_no_replan_obligation_without_signal() -> None:
     with tempfile.TemporaryDirectory(prefix="loopx-autonomous-replan-") as tmp:
         registry_path, runtime = write_fixture(Path(tmp), include_replan_signals=False)
@@ -587,6 +654,7 @@ def main() -> int:
     assert_validated_classification_without_ack_does_not_clear_replan()
     assert_refresh_state_structured_ack_clears_replan()
     assert_replan_ack_without_delta_is_noop()
+    assert_watch_replan_ack_requires_bounded_state_evidence()
     assert_no_replan_obligation_without_signal()
     print("autonomous-replan-obligation-smoke ok")
     return 0

--- a/loopx/control_plane/todos/quota_summary.py
+++ b/loopx/control_plane/todos/quota_summary.py
@@ -247,7 +247,7 @@ def _terminal_closure_proof_is_valid(
     )
 
 
-def _validated_todo_source_contract(
+def validate_todo_source_contract(
     value: dict[str, Any],
 ) -> tuple[dict[str, Any], dict[str, Any] | None]:
     proof = value.get("source_proof")
@@ -445,7 +445,7 @@ def summarize_user_todos_for_quota(
 ) -> dict[str, Any] | None:
     if not isinstance(value, dict):
         return None
-    source_completeness, closure_intent = _validated_todo_source_contract(value)
+    source_completeness, closure_intent = validate_todo_source_contract(value)
     all_open_items = sorted(
         todo_summary_source_items(value),
         key=todo_projection_sort_key,

--- a/loopx/control_plane/work_items/repair_delta.py
+++ b/loopx/control_plane/work_items/repair_delta.py
@@ -1,7 +1,16 @@
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
+from typing import Any
 
+from ..todos.contract import (
+    TODO_STATUS_OPEN,
+    TODO_TASK_CLASS_ADVANCEMENT,
+    TODO_TASK_CLASS_MONITOR,
+    normalize_todo_claimed_by,
+    normalize_todo_status,
+)
+from ..todos.projection import todo_item_is_actionable_open, todo_item_task_class
 
 REPAIR_DELTA_KIND_CHOICES = (
     "effective_action",
@@ -61,3 +70,97 @@ def repair_delta_kinds_have_frontier_delta(values: Iterable[str] | None) -> bool
         }
         & FRONTIER_REPLAN_ACK_DELTA_KINDS
     )
+
+
+def validate_repair_delta_claims(
+    values: Iterable[str],
+    *,
+    agent_todo_summary: dict[str, Any] | None,
+    agent_id: str | None,
+    advancement_policy: str,
+    next_action_changed: bool,
+    vision_patch_written: bool,
+) -> tuple[list[str], list[dict[str, Any]], list[dict[str, str]]]:
+    items = (
+        agent_todo_summary.get("items")
+        if isinstance(agent_todo_summary, dict)
+        and isinstance(agent_todo_summary.get("items"), list)
+        else []
+    )
+    normalized_agent_id = normalize_todo_claimed_by(agent_id)
+    scoped = [
+        item
+        for item in items
+        if isinstance(item, dict)
+        and (
+            not normalized_agent_id
+            or not normalize_todo_claimed_by(item.get("claimed_by"))
+            or normalize_todo_claimed_by(item.get("claimed_by"))
+            == normalized_agent_id
+        )
+    ]
+    runnable_ids = [
+        item.get("todo_id")
+        for item in scoped
+        if todo_item_is_actionable_open(item)
+        and todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+        and item.get("todo_id")
+    ]
+    bounded_watch_ids = [
+        item.get("todo_id")
+        for item in scoped
+        if item.get("done") is not True
+        and (normalize_todo_status(item.get("status")) or TODO_STATUS_OPEN)
+        == TODO_STATUS_OPEN
+        and todo_item_task_class(item) == TODO_TASK_CLASS_MONITOR
+        and str(item.get("target_key") or "").strip()
+        and str(item.get("cadence") or "").strip()
+        and str(item.get("next_due_at") or "").strip()
+        and (
+            str(item.get("expires_at") or "").strip()
+            or str(item.get("resume_when") or "").strip()
+        )
+        and item.get("todo_id")
+    ]
+
+    accepted: list[str] = []
+    evidence: list[dict[str, Any]] = []
+    rejected: list[dict[str, str]] = []
+    for kind in values:
+        reason = ""
+        todo_ids: list[str] = []
+        if kind == "runnable_todo_set":
+            todo_ids = runnable_ids
+            reason = "no scoped open advancement todo exists"
+        elif kind == "watch_lane_continuation":
+            todo_ids = bounded_watch_ids
+            reason = (
+                "repeat_until_closed vision requires advancement"
+                if advancement_policy == "repeat_until_closed"
+                else (
+                    "no scoped monitor has target, cadence, next due, and expiry "
+                    "or resume condition"
+                )
+            )
+            if advancement_policy == "repeat_until_closed":
+                todo_ids = []
+        elif kind == "active_state_next_action" and not next_action_changed:
+            reason = "active-state Next Action did not change"
+        elif kind == "goal_vision_patch" and not vision_patch_written:
+            reason = "no vision patch was written"
+        else:
+            accepted.append(kind)
+            continue
+
+        if todo_ids:
+            accepted.append(kind)
+            evidence.append(
+                {
+                    "kind": kind,
+                    "source": "active_state_agent_todos",
+                    "todo_ids": todo_ids,
+                }
+            )
+        else:
+            rejected.append({"kind": kind, "reason": reason})
+    return accepted, evidence, rejected

--- a/loopx/control_plane/work_items/repair_delta.py
+++ b/loopx/control_plane/work_items/repair_delta.py
@@ -1,16 +1,32 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from datetime import datetime
 from typing import Any
 
+from ..runtime.time import now_utc
+from ..scheduler.monitor_todo import monitor_cadence_delta
 from ..todos.contract import (
-    TODO_STATUS_OPEN,
+    TODO_STATUS_DONE,
     TODO_TASK_CLASS_ADVANCEMENT,
+    TODO_TASK_CLASS_BLOCKER,
     TODO_TASK_CLASS_MONITOR,
     normalize_todo_claimed_by,
+    normalize_todo_id,
+    normalize_todo_no_followup,
+    normalize_todo_resume_when,
     normalize_todo_status,
 )
-from ..todos.projection import todo_item_is_actionable_open, todo_item_task_class
+from ..todos.projection import (
+    todo_item_claimed_by_agent_or_unclaimed,
+    todo_item_expires_at,
+    todo_item_is_actionable_open,
+    todo_item_is_expired_monitor,
+    todo_item_next_due_at,
+    todo_item_task_class,
+)
+from ..todos.quota_summary import validate_todo_source_contract
+from ..todos.todo_summary import todo_successor_todo_ids
 
 REPAIR_DELTA_KIND_CHOICES = (
     "effective_action",
@@ -72,6 +88,108 @@ def repair_delta_kinds_have_frontier_delta(values: Iterable[str] | None) -> bool
     )
 
 
+def _todo_is_done(item: dict[str, Any]) -> bool:
+    return bool(
+        item.get("done") is True
+        or normalize_todo_status(item.get("status")) == TODO_STATUS_DONE
+    )
+
+
+def _bounded_watch_todo_ids(
+    items: list[dict[str, Any]],
+    *,
+    observed_at: datetime,
+) -> list[str]:
+    todo_ids: list[str] = []
+    for item in items:
+        if not (
+            todo_item_is_actionable_open(item)
+            and todo_item_task_class(item) == TODO_TASK_CLASS_MONITOR
+            and str(item.get("target_key") or "").strip()
+            and monitor_cadence_delta(item.get("cadence")) is not None
+        ):
+            continue
+        next_due_at = todo_item_next_due_at(item)
+        if next_due_at is None:
+            continue
+        expires_text = str(item.get("expires_at") or "").strip()
+        expires_at = todo_item_expires_at(item)
+        if expires_text and expires_at is None:
+            continue
+        if expires_at is not None and (
+            todo_item_is_expired_monitor(item, now=observed_at)
+            or expires_at <= next_due_at
+        ):
+            continue
+        resume_when = normalize_todo_resume_when(item.get("resume_when"))
+        if resume_when and item.get("resume_ready") is True:
+            continue
+        if expires_at is None and not resume_when:
+            continue
+        todo_id = normalize_todo_id(item.get("todo_id"))
+        if todo_id:
+            todo_ids.append(todo_id)
+    return todo_ids
+
+
+def _terminal_no_followup_todo_ids(
+    summary: dict[str, Any] | None,
+    *,
+    items: list[dict[str, Any]],
+) -> list[str]:
+    if not isinstance(summary, dict):
+        return []
+    completeness, intent = validate_todo_source_contract(summary)
+    if not (
+        completeness.get("status") == "valid"
+        and completeness.get("role") == "agent"
+        and completeness.get("terminal_closure") == "valid"
+        and isinstance(intent, dict)
+        and intent.get("kind") == "no_followup"
+        and intent.get("source") == "todo_no_followup"
+    ):
+        return []
+    return [
+        todo_id
+        for item in items
+        if _todo_is_done(item)
+        and normalize_todo_no_followup(item.get("no_followup")) is True
+        and (todo_id := normalize_todo_id(item.get("todo_id")))
+    ]
+
+
+def _successor_transition_todo_ids(
+    items: list[dict[str, Any]],
+    *,
+    agent_id: str | None,
+) -> list[str]:
+    by_id = {
+        todo_id: item
+        for item in items
+        if (todo_id := normalize_todo_id(item.get("todo_id")))
+    }
+    evidence_ids: list[str] = []
+    for source in items:
+        source_id = normalize_todo_id(source.get("todo_id"))
+        if not source_id or not _todo_is_done(source):
+            continue
+        for successor_id in todo_successor_todo_ids(source, items=items):
+            successor = by_id.get(successor_id)
+            if not successor or not (
+                todo_item_claimed_by_agent_or_unclaimed(
+                    successor,
+                    agent_id=agent_id,
+                )
+                and todo_item_is_actionable_open(successor)
+                and todo_item_task_class(successor) == TODO_TASK_CLASS_ADVANCEMENT
+            ):
+                continue
+            for todo_id in (source_id, successor_id):
+                if todo_id not in evidence_ids:
+                    evidence_ids.append(todo_id)
+    return evidence_ids
+
+
 def validate_repair_delta_claims(
     values: Iterable[str],
     *,
@@ -80,6 +198,7 @@ def validate_repair_delta_claims(
     advancement_policy: str,
     next_action_changed: bool,
     vision_patch_written: bool,
+    observed_at: datetime | None = None,
 ) -> tuple[list[str], list[dict[str, Any]], list[dict[str, str]]]:
     items = (
         agent_todo_summary.get("items")
@@ -92,11 +211,9 @@ def validate_repair_delta_claims(
         item
         for item in items
         if isinstance(item, dict)
-        and (
-            not normalized_agent_id
-            or not normalize_todo_claimed_by(item.get("claimed_by"))
-            or normalize_todo_claimed_by(item.get("claimed_by"))
-            == normalized_agent_id
+        and todo_item_claimed_by_agent_or_unclaimed(
+            item,
+            agent_id=normalized_agent_id,
         )
     ]
     runnable_ids = [
@@ -106,22 +223,25 @@ def validate_repair_delta_claims(
         and todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
         and item.get("todo_id")
     ]
-    bounded_watch_ids = [
+    blocker_ids = [
         item.get("todo_id")
         for item in scoped
-        if item.get("done") is not True
-        and (normalize_todo_status(item.get("status")) or TODO_STATUS_OPEN)
-        == TODO_STATUS_OPEN
-        and todo_item_task_class(item) == TODO_TASK_CLASS_MONITOR
-        and str(item.get("target_key") or "").strip()
-        and str(item.get("cadence") or "").strip()
-        and str(item.get("next_due_at") or "").strip()
-        and (
-            str(item.get("expires_at") or "").strip()
-            or str(item.get("resume_when") or "").strip()
-        )
+        if todo_item_is_actionable_open(item)
+        and todo_item_task_class(item) == TODO_TASK_CLASS_BLOCKER
         and item.get("todo_id")
     ]
+    bounded_watch_ids = _bounded_watch_todo_ids(
+        scoped,
+        observed_at=observed_at or now_utc(),
+    )
+    successor_transition_ids = _successor_transition_todo_ids(
+        items,
+        agent_id=normalized_agent_id,
+    )
+    no_followup_ids = _terminal_no_followup_todo_ids(
+        agent_todo_summary,
+        items=items,
+    )
 
     accepted: list[str] = []
     evidence: list[dict[str, Any]] = []
@@ -129,27 +249,47 @@ def validate_repair_delta_claims(
     for kind in values:
         reason = ""
         todo_ids: list[str] = []
+        if kind not in FRONTIER_REPLAN_ACK_DELTA_KINDS:
+            accepted.append(kind)
+            continue
         if kind == "runnable_todo_set":
             todo_ids = runnable_ids
             reason = "no scoped open advancement todo exists"
+        elif kind == "blocker":
+            todo_ids = blocker_ids
+            reason = "no scoped open blocker todo exists"
         elif kind == "watch_lane_continuation":
             todo_ids = bounded_watch_ids
             reason = (
                 "repeat_until_closed vision requires advancement"
                 if advancement_policy == "repeat_until_closed"
                 else (
-                    "no scoped monitor has target, cadence, next due, and expiry "
-                    "or resume condition"
+                    "no scoped monitor has a valid target, cadence, next due, "
+                    "and unexpired expiry or unresolved resume condition"
                 )
             )
             if advancement_policy == "repeat_until_closed":
                 todo_ids = []
+        elif kind == "successor_or_supersede":
+            todo_ids = successor_transition_ids
+            reason = "no completed todo links a scoped open advancement successor"
+        elif kind == "no_followup":
+            todo_ids = no_followup_ids
+            reason = "no validated terminal todo no-follow-up closure exists"
         elif kind == "active_state_next_action" and not next_action_changed:
             reason = "active-state Next Action did not change"
         elif kind == "goal_vision_patch" and not vision_patch_written:
             reason = "no vision patch was written"
-        else:
+        elif kind in {"active_state_next_action", "goal_vision_patch"}:
             accepted.append(kind)
+            continue
+        else:
+            rejected.append(
+                {
+                    "kind": kind,
+                    "reason": "frontier delta kind has no evidence resolver",
+                }
+            )
             continue
 
         if todo_ids:

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -20,6 +20,7 @@ from .control_plane.agents.workspace_guard import capture_delivery_workspace
 from .control_plane.work_items.repair_delta import (
     REPAIR_DELTA_KIND_CHOICES as REPAIR_DELTA_KIND_CHOICES,
     normalize_repair_delta_kinds,
+    validate_repair_delta_claims,
 )
 from .control_plane.work_items.autonomous_replan_ack import (
     latest_blocked_successor_frontier_identity,
@@ -48,6 +49,7 @@ from .control_plane.goals.goal_frontier import latest_agent_vision_from_runs
 from .registry import registry_goals, resolve_state_file
 from .runtime import validate_goal_id_path_segment
 from .state_projection import state_projection_gap_warning
+from .control_plane.todos.active_state_todo_parser import parse_active_state_todos
 from .control_plane.todos.contract import (
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_BLOCKER,
@@ -191,11 +193,31 @@ def build_repair_delta_contract(
     requested_delta_kinds: list[str],
     active_state_next_action_update: dict[str, Any] | None,
     agent_vision: dict[str, Any] | None,
+    existing_agent_vision: dict[str, Any] | None,
+    state_text: str,
+    agent_id: str | None,
     dry_run: bool,
 ) -> dict[str, Any]:
-    delta_kinds = list(requested_delta_kinds)
-    evidence: list[dict[str, Any]] = []
     update = active_state_next_action_update or {}
+    todo_fields = parse_active_state_todos(state_text, item_limit=None)
+    effective_vision = agent_vision or existing_agent_vision or {}
+    vision_patch = (
+        effective_vision.get("vision_patch")
+        if isinstance(effective_vision.get("vision_patch"), dict)
+        else {}
+    )
+    delta_kinds, evidence, rejected_claims = validate_repair_delta_claims(
+        requested_delta_kinds,
+        agent_todo_summary=(
+            todo_fields.get("agent_todos")
+            if isinstance(todo_fields.get("agent_todos"), dict)
+            else None
+        ),
+        agent_id=agent_id,
+        advancement_policy=str(vision_patch.get("advancement_policy") or "").strip(),
+        next_action_changed=bool(update.get("would_update")),
+        vision_patch_written=agent_vision is not None,
+    )
     if update.get("updated") is True:
         if "active_state_next_action" not in delta_kinds:
             delta_kinds.append("active_state_next_action")
@@ -232,7 +254,7 @@ def build_repair_delta_contract(
             }
         )
 
-    return {
+    contract = {
         "schema_version": REPAIR_DELTA_CONTRACT_SCHEMA_VERSION,
         "required": True,
         "delta_present": bool(delta_kinds),
@@ -240,6 +262,9 @@ def build_repair_delta_contract(
         "auto_evidence": evidence,
         "accepted_without_delta": False,
     }
+    if rejected_claims:
+        contract["rejected_claims"] = rejected_claims
+    return contract
 
 
 def build_vision_checkpoint(
@@ -1093,6 +1118,9 @@ def refresh_state_run(
             requested_delta_kinds=normalized_repair_delta_kinds,
             active_state_next_action_update=active_state_next_action_update,
             agent_vision=agent_vision,
+            existing_agent_vision=existing_agent_vision,
+            state_text=state_text,
+            agent_id=normalized_agent_id or None,
             dry_run=dry_run,
         )
         if not repair_delta_contract["delta_present"]:

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -20,6 +20,7 @@ from .control_plane.agents.workspace_guard import capture_delivery_workspace
 from .control_plane.work_items.repair_delta import (
     REPAIR_DELTA_KIND_CHOICES as REPAIR_DELTA_KIND_CHOICES,
     normalize_repair_delta_kinds,
+    repair_delta_kinds_have_frontier_delta,
     validate_repair_delta_claims,
 )
 from .control_plane.work_items.autonomous_replan_ack import (
@@ -257,7 +258,7 @@ def build_repair_delta_contract(
     contract = {
         "schema_version": REPAIR_DELTA_CONTRACT_SCHEMA_VERSION,
         "required": True,
-        "delta_present": bool(delta_kinds),
+        "delta_present": repair_delta_kinds_have_frontier_delta(delta_kinds),
         "delta_kinds": delta_kinds,
         "auto_evidence": evidence,
         "accepted_without_delta": False,
@@ -1111,6 +1112,7 @@ def refresh_state_run(
         action, recommended_action_source = derive_recommended_action_with_source(state_text)
     validate_local_control_text("recommended_action", action)
     repair_delta_contract: dict[str, Any] | None = None
+    validated_repair_delta_kinds: list[str] = []
     requested_classification = classification
     effective_autonomous_replan_recorded = bool(autonomous_replan_recorded)
     if autonomous_replan_recorded:
@@ -1122,6 +1124,9 @@ def refresh_state_run(
             state_text=state_text,
             agent_id=normalized_agent_id or None,
             dry_run=dry_run,
+        )
+        validated_repair_delta_kinds = list(
+            repair_delta_contract.get("delta_kinds") or []
         )
         if not repair_delta_contract["delta_present"]:
             classification = _noop_classification_for(classification)
@@ -1136,7 +1141,7 @@ def refresh_state_run(
         delivery_outcome=normalized_delivery_outcome,
         autonomous_replan_recorded=bool(autonomous_replan_recorded),
         active_state_next_action_update=active_state_next_action_update,
-        repair_delta_kinds=normalized_repair_delta_kinds,
+        repair_delta_kinds=validated_repair_delta_kinds,
     )
     delivery_workspace = None
     if normalized_delivery_outcome in ACCOUNTABLE_DELIVERY_OUTCOMES:

--- a/tests/control_plane/test_repair_delta_claims.py
+++ b/tests/control_plane/test_repair_delta_claims.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 from loopx.control_plane.work_items.repair_delta import validate_repair_delta_claims
 
 
@@ -10,14 +12,16 @@ def _validate(
     *,
     items: tuple[dict, ...],
     advancement_policy: str = "as_needed",
+    summary: dict | None = None,
 ) -> tuple[list[str], list[dict], list[dict]]:
     return validate_repair_delta_claims(
         [kind],
-        agent_todo_summary=_summary(*items),
+        agent_todo_summary=summary or _summary(*items),
         agent_id="quality-agent",
         advancement_policy=advancement_policy,
         next_action_changed=False,
         vision_patch_written=False,
+        observed_at=datetime(2026, 8, 1, tzinfo=timezone.utc),
     )
 
 
@@ -65,6 +69,42 @@ def test_runnable_todo_claim_records_todo_evidence() -> None:
     assert rejected == []
 
 
+def test_runnable_todo_claim_rejects_excluded_agent() -> None:
+    accepted, evidence, rejected = _validate(
+        "runnable_todo_set",
+        items=(
+            {
+                "todo_id": "todo_123456789abc",
+                "status": "open",
+                "task_class": "advancement_task",
+                "excluded_agents": ["quality-agent"],
+            },
+        ),
+    )
+
+    assert accepted == []
+    assert evidence == []
+    assert rejected[0]["reason"] == "no scoped open advancement todo exists"
+
+
+def test_runnable_todo_claim_rejects_removed_continuation_policy() -> None:
+    accepted, evidence, rejected = _validate(
+        "runnable_todo_set",
+        items=(
+            {
+                "todo_id": "todo_123456789abc",
+                "status": "open",
+                "task_class": "advancement_task",
+                "removed_continuation_policy": "review_handoff",
+            },
+        ),
+    )
+
+    assert accepted == []
+    assert evidence == []
+    assert rejected[0]["reason"] == "no scoped open advancement todo exists"
+
+
 def test_watch_claim_requires_bounded_schedule() -> None:
     accepted, evidence, rejected = _validate(
         "watch_lane_continuation",
@@ -83,7 +123,7 @@ def test_watch_claim_requires_bounded_schedule() -> None:
 
     assert accepted == []
     assert evidence == []
-    assert "expiry or resume condition" in rejected[0]["reason"]
+    assert "expiry or unresolved resume condition" in rejected[0]["reason"]
 
 
 def test_watch_claim_requires_non_repeating_vision_and_records_evidence() -> None:
@@ -115,3 +155,159 @@ def test_watch_claim_requires_non_repeating_vision_and_records_evidence() -> Non
     assert repeat_rejected[0]["reason"] == (
         "repeat_until_closed vision requires advancement"
     )
+
+
+def test_watch_claim_rejects_malformed_or_expired_schedule() -> None:
+    for monitor in (
+        {
+            "cadence": "whenever",
+            "next_due_at": "not-a-time",
+            "expires_at": "also-not-a-time",
+        },
+        {
+            "cadence": "30m",
+            "next_due_at": "2020-01-01T00:00:00Z",
+            "expires_at": "2020-01-02T00:00:00Z",
+        },
+    ):
+        accepted, evidence, rejected = _validate(
+            "watch_lane_continuation",
+            items=(
+                {
+                    "todo_id": "todo_123456789abc",
+                    "status": "open",
+                    "task_class": "continuous_monitor",
+                    "claimed_by": "quality-agent",
+                    "target_key": "review",
+                    **monitor,
+                },
+            ),
+        )
+
+        assert accepted == []
+        assert evidence == []
+        assert rejected
+
+
+def test_watch_claim_rejects_satisfied_resume_condition() -> None:
+    accepted, evidence, rejected = _validate(
+        "watch_lane_continuation",
+        items=(
+            {
+                "todo_id": "todo_123456789abc",
+                "status": "open",
+                "task_class": "continuous_monitor",
+                "claimed_by": "quality-agent",
+                "target_key": "review",
+                "cadence": "30m",
+                "next_due_at": "2026-08-01T13:00:00Z",
+                "resume_when": "todo_done:todo_dependency123",
+                "resume_ready": True,
+            },
+        ),
+    )
+
+    assert accepted == []
+    assert evidence == []
+    assert rejected
+
+
+def test_successor_claim_requires_real_scoped_transition() -> None:
+    source = {
+        "todo_id": "todo_source123456",
+        "status": "done",
+        "done": True,
+        "task_class": "advancement_task",
+    }
+    accepted, evidence, rejected = _validate(
+        "successor_or_supersede",
+        items=(source,),
+    )
+
+    assert accepted == []
+    assert evidence == []
+    assert rejected[0]["reason"] == (
+        "no completed todo links a scoped open advancement successor"
+    )
+
+    successor = {
+        "todo_id": "todo_successor123",
+        "status": "open",
+        "task_class": "advancement_task",
+        "claimed_by": "quality-agent",
+    }
+    source["successor_todo_ids"] = [successor["todo_id"]]
+    accepted, evidence, rejected = _validate(
+        "successor_or_supersede",
+        items=(source, successor),
+    )
+
+    assert accepted == ["successor_or_supersede"]
+    assert evidence[0]["todo_ids"] == [source["todo_id"], successor["todo_id"]]
+    assert rejected == []
+
+
+def test_no_followup_claim_requires_validated_terminal_closure() -> None:
+    item = {
+        "todo_id": "todo_source123456",
+        "status": "done",
+        "done": True,
+        "task_class": "advancement_task",
+        "action_kind": "finish_slice",
+        "no_followup": True,
+    }
+    accepted, evidence, rejected = _validate("no_followup", items=(item,))
+
+    assert accepted == []
+    assert evidence == []
+    assert rejected[0]["reason"] == (
+        "no validated terminal todo no-follow-up closure exists"
+    )
+
+    summary = {
+        "schema_version": "todo_summary_v0",
+        "source_section": "Agent Todo",
+        "total_count": 1,
+        "open_count": 0,
+        "done_count": 1,
+        "deferred_count": 0,
+        "items": [item],
+        "monitor_open_items": [],
+        "deferred_items": [],
+        "deferred_resume_candidates": [],
+        "monitor_due_count": 0,
+        "monitor_schedule_gap_count": 0,
+        "source_proof": {
+            "schema_version": "todo_source_proof_v0",
+            "role": "agent",
+            "item_count": 1,
+            "derived": True,
+        },
+        "terminal_closure_proof": {
+            "schema_version": "todo_terminal_closure_proof_v0",
+            "role": "agent",
+            "source_section": "Agent Todo",
+            "item_count": 1,
+            "all_todos_done": True,
+            "monitor_open_count": 0,
+            "successor_gap_count": 0,
+            "route_replan_count": 0,
+            "no_followup_count": 1,
+            "derived": True,
+        },
+        "closure_intent": {
+            "schema_version": "todo_closure_intent_v0",
+            "kind": "no_followup",
+            "derived": True,
+            "count": 1,
+        },
+    }
+    accepted, evidence, rejected = _validate(
+        "no_followup",
+        items=(item,),
+        summary=summary,
+    )
+
+    assert accepted == ["no_followup"]
+    assert evidence[0]["todo_ids"] == [item["todo_id"]]
+    assert rejected == []

--- a/tests/control_plane/test_repair_delta_claims.py
+++ b/tests/control_plane/test_repair_delta_claims.py
@@ -1,0 +1,117 @@
+from loopx.control_plane.work_items.repair_delta import validate_repair_delta_claims
+
+
+def _summary(*items: dict) -> dict:
+    return {"items": list(items)}
+
+
+def _validate(
+    kind: str,
+    *,
+    items: tuple[dict, ...],
+    advancement_policy: str = "as_needed",
+) -> tuple[list[str], list[dict], list[dict]]:
+    return validate_repair_delta_claims(
+        [kind],
+        agent_todo_summary=_summary(*items),
+        agent_id="quality-agent",
+        advancement_policy=advancement_policy,
+        next_action_changed=False,
+        vision_patch_written=False,
+    )
+
+
+def test_runnable_todo_claim_requires_scoped_advancement() -> None:
+    accepted, evidence, rejected = _validate(
+        "runnable_todo_set",
+        items=(
+            {
+                "todo_id": "todo_123456789abc",
+                "status": "open",
+                "task_class": "advancement_task",
+                "claimed_by": "other-agent",
+            },
+            {
+                "todo_id": "todo_deferred12345",
+                "status": "open",
+                "task_class": "advancement_task",
+                "claimed_by": "quality-agent",
+                "resume_when": "todo_done:todo_dependency123",
+                "resume_ready": False,
+            },
+        ),
+    )
+
+    assert accepted == []
+    assert evidence == []
+    assert rejected[0]["reason"] == "no scoped open advancement todo exists"
+
+
+def test_runnable_todo_claim_records_todo_evidence() -> None:
+    accepted, evidence, rejected = _validate(
+        "runnable_todo_set",
+        items=(
+            {
+                "todo_id": "todo_123456789abc",
+                "status": "open",
+                "task_class": "advancement_task",
+                "claimed_by": "quality-agent",
+            },
+        ),
+    )
+
+    assert accepted == ["runnable_todo_set"]
+    assert evidence[0]["todo_ids"] == ["todo_123456789abc"]
+    assert rejected == []
+
+
+def test_watch_claim_requires_bounded_schedule() -> None:
+    accepted, evidence, rejected = _validate(
+        "watch_lane_continuation",
+        items=(
+            {
+                "todo_id": "todo_123456789abc",
+                "status": "open",
+                "task_class": "continuous_monitor",
+                "claimed_by": "quality-agent",
+                "target_key": "review",
+                "cadence": "30m",
+                "next_due_at": "2026-08-01T13:00:00Z",
+            },
+        ),
+    )
+
+    assert accepted == []
+    assert evidence == []
+    assert "expiry or resume condition" in rejected[0]["reason"]
+
+
+def test_watch_claim_requires_non_repeating_vision_and_records_evidence() -> None:
+    monitor = {
+        "todo_id": "todo_123456789abc",
+        "status": "open",
+        "task_class": "continuous_monitor",
+        "claimed_by": "quality-agent",
+        "target_key": "review",
+        "cadence": "30m",
+        "next_due_at": "2026-08-01T13:00:00Z",
+        "expires_at": "2026-08-02T13:00:00Z",
+    }
+
+    accepted, evidence, rejected = _validate(
+        "watch_lane_continuation",
+        items=(monitor,),
+    )
+    repeat_accepted, _, repeat_rejected = _validate(
+        "watch_lane_continuation",
+        items=(monitor,),
+        advancement_policy="repeat_until_closed",
+    )
+
+    assert accepted == ["watch_lane_continuation"]
+    assert evidence[0]["todo_ids"] == ["todo_123456789abc"]
+    assert rejected == []
+    assert repeat_accepted == []
+    assert repeat_rejected[0]["reason"] == (
+        "repeat_until_closed vision requires advancement"
+    )


### PR DESCRIPTION
## Problem

`refresh-state` accepted caller-declared replan delta kinds as sufficient evidence. A worker could therefore acknowledge `watch_lane_continuation` with an unbounded or unscoped monitor and clear the replan obligation without leaving a usable frontier.

## Change

- Resolve `runnable_todo_set` to a scoped, actionable open advancement Todo.
- Resolve `watch_lane_continuation` to a scoped monitor with target, cadence, next due time, and an expiry or resume boundary.
- Keep `repeat_until_closed` visions on an advancement frontier instead of settling them with a watch lane.
- Preserve rejected claim reasons and Todo IDs as readback evidence.
- Document the contract and cover the real CLI refresh path.

## Validation

- `python3 -m pytest tests/control_plane/test_repair_delta_claims.py tests/test_state_refresh_projections.py -q`
- `python3 examples/autonomous-replan-obligation-smoke.py`
- `python3 examples/control_plane/quota-replan-decision-plane-smoke.py`
- `./scripts/loopx canary premerge --from-git-diff` (13/13 selected checks passed)