### PR TITLE
refactor(goal): classify native Goal hosts together

### DIFF
--- a/docs/reference/protocols/loopx-goal-command-v0.md
+++ b/docs/reference/protocols/loopx-goal-command-v0.md
@@ -30,6 +30,11 @@ When the user provides text after `/loopx`, the host should:
      `update_goal(status=blocked)` to block only that host Goal; keep the
      registered LoopX goal active and resume the host with `/goal resume`.
    - `codex-cli`: set the visible Codex CLI TUI to `/goal <task_body>`.
+   - `codex-ide-plugin`: set the visible IDE composer task to
+     `/goal <task_body>` through the same `codex_cli` runtime profile.
+   - `ark-managed-agent`: submit the generated `<task_body>` once as a native
+     Goal. The Goal runtime owns continuation and terminal evaluation; do not
+     wrap its inner iterations in LoopX Turn or resubmit at phase boundaries.
    - `claude-code`: arm LoopX with `/loopx <task>`, then run native `/loop`.
    - `opencode`: call `loopx_goal_activate` from the installed LoopX OpenCode
      bridge; the bridge gates idle continuation and timer wakes through
@@ -50,6 +55,20 @@ loopx agent-onboard --list-agent-types
 Ambiguous values such as `codex` must fail closed because Codex App automation,
 Codex App over SSH, the IDE plugin, and Codex CLI use different host-loop
 activation paths.
+
+Codex App SSH, Codex CLI/IDE, and Ark Managed Agent form one native Goal host
+family. They share the stable `loopx_goal_prompt_v0` body, the 4,000-character
+host budget, per-continuation `quota should-run` packets, durable LoopX
+writeback, and non-heartbeat quota accounting. Their continuation owner remains
+an explicit host contract:
+
+| Native Goal host | Activation | Continuation and blocked-state owner |
+| --- | --- | --- |
+| Codex App SSH / Codex CLI / Codex IDE | Set a visible `/goal <task_body>`. | Native Codex Goal; after the unchanged limit it may call `update_goal(status=blocked)`, and only user `/goal resume` reactivates it. |
+| Ark Managed Agent | Submit the same prompt family once. | Managed Agent Goal runtime and its durable journal; LoopX must not emulate `/goal resume` or blindly resubmit. |
+
+This family is a prompt, quota, and state-boundary abstraction, not a claim that
+all hosts have the same transport or lifecycle API.
 
 The `codex-app-ssh` task body is an interactive Goal contract, not a scheduled
 heartbeat. It must fit the Codex `/goal` text limit, call `quota should-run`

--- a/loopx/control_plane/scheduler/execution_context.py
+++ b/loopx/control_plane/scheduler/execution_context.py
@@ -43,6 +43,15 @@ class SchedulerRuntimeProfile(str, Enum):
     GENERIC_CLI_OUTER_CONTROLLER = "outer_controller"
 
 
+NATIVE_GOAL_RUNTIME_PROFILES = frozenset(
+    {
+        SchedulerRuntimeProfile.ARK_MANAGED_AGENT_GOAL,
+        SchedulerRuntimeProfile.CODEX_APP_SSH_VISIBLE,
+        SchedulerRuntimeProfile.CODEX_CLI_VISIBLE,
+    }
+)
+
+
 _SCHEDULER_RUNTIME_PROFILE_CONTEXTS = {
     SchedulerRuntimeProfile.ARK_MANAGED_AGENT_GOAL: (
         HostSurface.ARK_MANAGED_AGENT,

--- a/loopx/heartbeat_prompt.py
+++ b/loopx/heartbeat_prompt.py
@@ -18,6 +18,7 @@ from .project_prompt import (
 from .control_plane.scheduler.execution_context import (
     ExecutionMode,
     HostSurface,
+    NATIVE_GOAL_RUNTIME_PROFILES,
     SchedulerOwner,
     SchedulerRuntimeProfile,
     resolve_scheduler_execution_context,
@@ -79,11 +80,10 @@ INTERFACE_BUDGET_CHARS = {
     "thin": 1_750,
     "visible_goal": 4_000,
 }
-CODEX_VISIBLE_GOAL_MAX_CHARS = INTERFACE_BUDGET_CHARS["visible_goal"]
-ARK_MANAGED_AGENT_GOAL_MAX_CHARS = CODEX_VISIBLE_GOAL_MAX_CHARS
+NATIVE_GOAL_HOST_MAX_CHARS = INTERFACE_BUDGET_CHARS["visible_goal"]
 
 
-def uses_visible_goal_host_loop(
+def uses_native_goal_host_loop(
     *,
     runtime_profile: str | None,
     scheduler_execution_context: dict[str, Any] | None,
@@ -93,11 +93,7 @@ def uses_visible_goal_host_loop(
             profile = SchedulerRuntimeProfile(runtime_profile)
         except ValueError:
             return False
-        return profile in {
-            SchedulerRuntimeProfile.ARK_MANAGED_AGENT_GOAL,
-            SchedulerRuntimeProfile.CODEX_APP_SSH_VISIBLE,
-            SchedulerRuntimeProfile.CODEX_CLI_VISIBLE,
-        }
+        return profile in NATIVE_GOAL_RUNTIME_PROFILES
     if scheduler_execution_context is None:
         return False
     resolution = resolve_scheduler_execution_context(scheduler_execution_context)
@@ -332,11 +328,11 @@ def build_interface_budget(
     compact: bool = False,
     brief: bool = False,
     thin: bool = False,
-    visible_goal: bool = False,
+    native_goal_host: bool = False,
 ) -> dict[str, Any]:
     mode = (
         "visible_goal"
-        if visible_goal
+        if native_goal_host
         else heartbeat_prompt_mode(full=full, compact=compact, brief=brief, thin=thin)
     )
     budget_text = prompt_budget_text(task_body, goal_id=goal_id, active_state=active_state)
@@ -375,7 +371,7 @@ def build_heartbeat_prompt(
 ) -> dict[str, Any]:
     if not (full or compact or brief or thin):
         thin = True
-    visible_goal = uses_visible_goal_host_loop(
+    native_goal_host = uses_native_goal_host_loop(
         runtime_profile=runtime_profile,
         scheduler_execution_context=scheduler_execution_context,
     )
@@ -450,13 +446,13 @@ def build_heartbeat_prompt(
         available_capabilities=normalized_available_capabilities,
         runtime_profile=runtime_profile,
         scheduler_execution_context=scheduler_execution_context,
-        heartbeat_turn_receipt=not visible_goal,
+        heartbeat_turn_receipt=not native_goal_host,
     )
     quota_spend_command = render_quota_spend_command(
         goal_id,
         source=(
             VISIBLE_GOAL_SLOT_SPEND_SOURCE
-            if visible_goal
+            if native_goal_host
             else DEFAULT_SLOT_SPEND_SOURCE
         ),
         cli_bin=cli_bin,
@@ -491,7 +487,7 @@ def build_heartbeat_prompt(
     thin_prompt_command = f"{cli_bin} heartbeat-prompt --thin --goal-id {goal_id}{active_state_arg}{agent_args}{capability_args}{scheduler_args}"
     if ark_managed_agent_goal:
         task_body_renderer = render_ark_managed_agent_goal_task_body
-    elif visible_goal:
+    elif native_goal_host:
         task_body_renderer = render_visible_goal_task_body
     elif thin:
         task_body_renderer = render_thin_heartbeat_task_body
@@ -519,18 +515,15 @@ def build_heartbeat_prompt(
         brief_prompt_command=brief_prompt_command,
         thin_prompt_command=thin_prompt_command,
     )
-    if visible_goal and len(task_body) > CODEX_VISIBLE_GOAL_MAX_CHARS:
-        raise ValueError(
-            "generated visible /goal task body exceeds the Codex 4000-character "
-            "limit; shorten agent scopes or project-specific prompt rules"
+    if native_goal_host and len(task_body) > NATIVE_GOAL_HOST_MAX_CHARS:
+        host_limit = (
+            "Ark Managed Agent goal prompt"
+            if ark_managed_agent_goal
+            else "visible Codex /goal task body"
         )
-    if (
-        ark_managed_agent_goal
-        and len(task_body) > ARK_MANAGED_AGENT_GOAL_MAX_CHARS
-    ):
         raise ValueError(
-            "generated Ark Managed Agent goal prompt exceeds the 4000-character "
-            "host budget; shorten agent scopes or project-specific prompt rules"
+            f"generated {host_limit} exceeds the 4000-character host budget; "
+            "shorten agent scopes or project-specific prompt rules"
         )
     payload = {
         "ok": True,
@@ -577,7 +570,7 @@ def build_heartbeat_prompt(
             compact=compact,
             brief=brief,
             thin=thin,
-            visible_goal=visible_goal,
+            native_goal_host=native_goal_host,
         ),
         "task_body": task_body,
     }

--- a/tests/test_host_loop_activation.py
+++ b/tests/test_host_loop_activation.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import pytest
 
-from loopx.heartbeat_prompt import build_heartbeat_prompt
+from loopx.heartbeat_prompt import (
+    build_heartbeat_prompt,
+    uses_native_goal_host_loop,
+)
 from loopx.host_loop_activation import (
     AgentTypeError,
     agent_type_for_host_surface,
@@ -65,6 +68,26 @@ def test_first_class_hosts_bind_one_runtime_profile(
     assert scheduler_command_binding_for_agent_type(agent_type) == {
         "runtime_profile": runtime_profile
     }
+
+
+@pytest.mark.parametrize(
+    ("runtime_profile", "expected"),
+    (
+        ("ark_managed_agent_goal", True),
+        ("codex_app_ssh_goal", True),
+        ("codex_cli", True),
+        ("codex_app_heartbeat", False),
+        ("claude_code", False),
+    ),
+)
+def test_native_goal_host_family_is_profile_driven(
+    runtime_profile: str,
+    expected: bool,
+) -> None:
+    assert uses_native_goal_host_loop(
+        runtime_profile=runtime_profile,
+        scheduler_execution_context=None,
+    ) is expected
 
 
 @pytest.mark.parametrize(
@@ -141,6 +164,27 @@ def test_native_codex_goal_wait_rule_matches_blocked_resume_contract() -> None:
         assert "Only user `/goal resume`" in body
         assert "reactivates it; rerun quota after resume" in body
     assert "call `update_goal` with `status=blocked`" not in managed_body
+
+
+@pytest.mark.parametrize(
+    ("runtime_profile", "expected_host"),
+    (
+        ("ark_managed_agent_goal", "Ark Managed Agent goal prompt"),
+        ("codex_app_ssh_goal", "visible Codex /goal task body"),
+        ("codex_cli", "visible Codex /goal task body"),
+    ),
+)
+def test_native_goal_budget_error_names_the_actual_host(
+    runtime_profile: str,
+    expected_host: str,
+) -> None:
+    with pytest.raises(ValueError, match=expected_host):
+        build_heartbeat_prompt(
+            goal_id="oversized-native-goal",
+            thin=True,
+            runtime_profile=runtime_profile,
+            permission_rule="x" * 4_000,
+        )
 
 
 def test_accountable_refresh_preserves_explicit_validated_turn_semantics() -> None:


### PR DESCRIPTION
## Summary

- define Ark Managed Agent, Codex App SSH, Codex CLI, and Codex IDE as one native Goal runtime-profile family
- preserve distinct continuation ownership: Codex uses native blocked/resume state, while Ark remains one-shot and Goal-runtime-owned
- fix native Goal prompt budget validation so Ark reports its own host error instead of the Codex `/goal` error
- document the shared prompt/quota/state boundary and the lifecycle split

## Validation

- `python -m pytest -q tests/test_host_loop_activation.py tests/test_ark_managed_agent_host.py tests/control_plane/test_scheduler_execution_context.py` (166 passed)
- `uv run --no-project --with "ruff>=0.12,<0.16" ruff check ...`
- `LOOPX_PYTHON="$(command -v python)" python -m loopx.cli --format json canary premerge --from-git-diff --tier standard --no-progress` (17/17 selected checks passed; public-boundary scan clean; no manual holds)

The first premerge attempt selected system Python 3.9 inside `scripts/loopx` and failed the peer-agent aggregate before product assertions. Re-running with the repository-supported Python 3.13 passed the peer-agent smoke and the complete premerge gate.

## Scope

No new scheduler, lifecycle layer, schema family, private state, or internal material is introduced.