### PR TITLE
fix(release): restore v0.4.0 public smoke qualification

### DIFF
--- a/examples/capability-extension-registry-smoke.py
+++ b/examples/capability-extension-registry-smoke.py
@@ -2,11 +2,10 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 import subprocess
 import sys
 import tempfile
-
+from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -58,6 +57,7 @@ next_real_step = "Keep explicit enablement bounded."
 
     baseline = run_cli(runtime_root, "capability", "list")
     assert [item["id"] for item in baseline["capabilities"]] == [
+        "integration-branch-reconcile",
         "change-quality-qualification",
         "issue-fix",
         "decision-context",

--- a/examples/issue-fix-capability-gap-metrics-smoke.py
+++ b/examples/issue-fix-capability-gap-metrics-smoke.py
@@ -8,7 +8,6 @@ import sys
 import tempfile
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 CONTROL_PLANE_EXAMPLES = ROOT / "examples" / "control_plane"
 for path in (ROOT, CONTROL_PLANE_EXAMPLES):
@@ -134,11 +133,11 @@ def main() -> int:
             "--repo",
             "public-fixture/widgets",
             "--period-start",
-            "2026-07-01T00:00:00Z",
+            "2000-01-01T00:00:00Z",
             "--period-end",
-            "2026-08-01T00:00:00Z",
+            "2100-01-01T00:00:00Z",
             "--generated-at",
-            "2026-08-01T00:01:00Z",
+            "2100-01-01T00:01:00Z",
         )
         partial = run_cli(registry_path, *common_args)
         assert partial["supplement"]["coverage"]["capability_gap"] == {
@@ -152,7 +151,7 @@ def main() -> int:
             registry_path,
             *common_args,
             "--capability-gap-coverage-start",
-            "2026-07-01T00:00:00Z",
+            "2000-01-01T00:00:00Z",
         )
         counts = complete["supplement"]["counts"]
         assert counts["loopx_capability_gaps_found"] == 1, complete
@@ -162,7 +161,7 @@ def main() -> int:
             "source": "loopx_rollout_event_log",
             "observed_gaps": 1,
             "complete": True,
-            "complete_from": "2026-07-01T00:00:00Z",
+            "complete_from": "2000-01-01T00:00:00Z",
         }, complete
         assert complete["source_summary"]["rollout_event_rows"] >= 4, complete
 

--- a/examples/issue-fix-discovered-issue-promotion-smoke.py
+++ b/examples/issue-fix-discovered-issue-promotion-smoke.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
-
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
@@ -31,7 +30,6 @@ from loopx.domain_packs.issue_fix import (  # noqa: E402
     upsert_issue_fix_feasibility_ledger_jsonl,
     upsert_issue_fix_pr_lifecycle_ledger_jsonl,
 )
-
 
 PRIVATE_PATTERNS = [
     re.compile(r"/Users/[A-Za-z0-9._-]+/"),
@@ -320,6 +318,12 @@ def main() -> int:
         observation = feasibility_rows[0]["observation"]
         assert observation["issue_ref"] == "issues_42"
         assert observation["repository_context"]["repository_revision"] == "a" * 40
+        projected_todo = feasibility_rows[0]["transition"]["projected_todo"]
+        assert projected_todo["target_key"] == (
+            "issue-fix:example/public-repo:issues_42"
+        )
+        assert "issues_42" in projected_todo["text"]
+        assert "discovered-vector-input" not in projected_todo["text"]
         assert feasibility_rows[0]["generated_at"] == source["generated_at"]
         assert feasibility_rows[0]["promotion_lineage"]["source_issue_ref"] == (
             "discovered-vector-input"

--- a/examples/issue-fix-workflow-e2e-smoke.py
+++ b/examples/issue-fix-workflow-e2e-smoke.py
@@ -9,7 +9,6 @@ import sys
 from pathlib import Path
 from typing import Any
 
-
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
@@ -18,16 +17,15 @@ from loopx.capabilities.issue_fix.acceptance_loop import (  # noqa: E402
     build_issue_fix_acceptance_fixture_packet,
     build_issue_fix_repo_branch_fixture_packet,
 )
-from loopx.capabilities.issue_fix.intake_surface import (  # noqa: E402
-    build_content_ops_issue_fix_metadata_preview_packet,
-)
 from loopx.capabilities.issue_fix.feasibility import (  # noqa: E402
     build_issue_fix_feasibility_packet,
+)
+from loopx.capabilities.issue_fix.intake_surface import (  # noqa: E402
+    build_content_ops_issue_fix_metadata_preview_packet,
 )
 from loopx.capabilities.issue_fix.workflow_plan import (  # noqa: E402
     build_issue_fix_workflow_plan_packet,
 )
-
 
 PRIVATE_PATTERNS = [
     re.compile(r"/Users/[A-Za-z0-9._-]+/"),
@@ -125,20 +123,19 @@ def test_metadata_to_ordered_todos_and_gates() -> None:
     assert plan["todo_write_performed"] is False, plan
     assert [todo["planner_order"] for todo in plan["ordered_loopx_todo_writeback_preview"]] == [
         1,
-        2,
-        3,
     ], plan
-    assert todo_by_action(plan, "issue_fix_public_metadata_classification")["role"] == "agent"
-    assert todo_by_action(plan, "issue_fix_feasibility_decision")["priority"] == "P0"
-    gated_read = todo_by_action(plan, "approve_github_issue_body_or_comment_read")
-    assert gated_read["role"] == "user", gated_read
-    assert gated_read["priority"] == "P0", gated_read
-    assert gated_read["would_write"] is False, gated_read
+    collect_evidence = todo_by_action(plan, "issue_fix_collect_candidate_evidence")
+    assert collect_evidence["role"] == "agent", collect_evidence
+    assert collect_evidence["priority"] == "P0", collect_evidence
+    assert collect_evidence["would_write"] is False, collect_evidence
+    assert plan["candidate_preflight"]["admission"]["state"] == "evidence_required"
+    assert plan["first_screen"]["user_action_required"] is False, plan
     action_kinds = {
         todo["action_kind"] for todo in plan["ordered_loopx_todo_writeback_preview"]
     }
     assert "issue_fix_branch_validation" not in action_kinds, action_kinds
     assert "issue_fix_pr_lifecycle_monitor" not in action_kinds, action_kinds
+    assert "approve_github_issue_body_or_comment_read" not in action_kinds, action_kinds
     routes = {route["route"]: route for route in plan["resolution_route_candidates"]}
     assert set(routes) == {"fix_pr", "comment_only", "triage_only"}, routes
     assert routes["fix_pr"]["next_action_kind"] == "issue_fix_branch_validation"

--- a/loopx/capabilities/issue_fix/discovered_issue_promotion.py
+++ b/loopx/capabilities/issue_fix/discovered_issue_promotion.py
@@ -25,7 +25,6 @@ from .metadata_preview import (
 )
 from .pr_lifecycle import validate_issue_fix_pr_lifecycle_monitor_packet
 
-
 ISSUE_FIX_DISCOVERED_ISSUE_PROMOTION_INPUT_SCHEMA_VERSION = (
     "issue_fix_discovered_issue_promotion_input_v0"
 )
@@ -621,6 +620,15 @@ def promote_issue_fix_feasibility_packet(
             separators=(",", ":"),
         ).encode("utf-8")
     ).hexdigest()[:16]
+    transition = promoted.get("transition")
+    if isinstance(transition, dict):
+        projected_todo = transition.get("projected_todo")
+        if isinstance(projected_todo, dict):
+            projected_todo["target_key"] = f"issue-fix:{repo}:{canonical_ref}"
+            projected_todo["text"] = str(projected_todo.get("text") or "").replace(
+                f"{repo} {source_issue_ref}",
+                f"{repo} {canonical_ref}",
+            )
     promoted["domain_state_key"] = {"repo": repo, "issue_ref": canonical_ref}
     projection = promoted.get("domain_state_projection")
     if not isinstance(projection, dict):

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -5,29 +5,33 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
-from ..quota import (
-    build_quota_plan,
-    build_quota_should_run,
-    record_quota_monitor_poll,
-    record_quota_scheduler_ack,
-    spend_quota_slot,
-    void_quota_slot,
+from ..control_plane.quota.cli_projection import (
+    compact_quota_should_run_cli_payload,
 )
-from ..status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, collect_status
-from ..rollout_event_log import load_rollout_events, rollout_event_log_path
-from ..upgrade import resolve_codex_app_automation_rrule
+from ..control_plane.quota.heartbeat_receipt import (
+    fail_heartbeat_receipt,
+    find_heartbeat_receipt,
+    heartbeat_receipt_view,
+)
+from ..control_plane.quota.live_decision import build_live_quota_should_run_decision
 from ..control_plane.quota.monitor_poll import find_quota_monitor_poll_turn
+from ..control_plane.quota.scheduler_ack import (
+    record_quota_scheduler_failure_for_decision,
+)
 from ..control_plane.quota.spend_sources import (
     DEFAULT_SLOT_SPEND_SOURCE,
     VALID_SLOT_SPEND_SOURCES,
 )
-from ..control_plane.quota.cli_projection import (
-    compact_quota_should_run_cli_payload,
-)
 from ..control_plane.quota.turn_envelope import build_turn_envelope
-from ..control_plane.quota.live_decision import build_live_quota_should_run_decision
-from ..control_plane.quota.scheduler_ack import (
-    record_quota_scheduler_failure_for_decision,
+from ..control_plane.runtime.status_projection_cache import (
+    load_status_projection_cache,
+    resolve_status_projection_cache_runtime_root,
+    write_status_projection_cache,
+)
+from ..control_plane.scheduler.execution_context import (
+    SchedulerExecutionContextResolution,
+    SchedulerRuntimeProfile,
+    scheduler_execution_context_for_runtime_profile,
 )
 from ..presentation.renderers.quota_event_markdown import (
     render_quota_monitor_poll_markdown,
@@ -39,27 +43,27 @@ from ..presentation.renderers.quota_markdown import (
     render_quota_scheduler_failure_markdown,
     render_quota_should_run_markdown,
 )
-from ..control_plane.scheduler.execution_context import (
-    SchedulerExecutionContextResolution,
-    SchedulerRuntimeProfile,
-    scheduler_execution_context_for_runtime_profile,
+from ..presentation.renderers.turn_envelope_markdown import (
+    render_turn_envelope_markdown,
 )
-from ..control_plane.runtime.status_projection_cache import (
-    load_status_projection_cache,
-    resolve_status_projection_cache_runtime_root,
-    write_status_projection_cache,
+from ..quota import (
+    build_quota_plan,
+    build_quota_should_run,
+    record_quota_monitor_poll,
+    record_quota_scheduler_ack,
+    spend_quota_slot,
+    void_quota_slot,
 )
+from ..status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, collect_status
 from ..turn_identity import normalize_turn_instance_id
-from ..presentation.renderers.turn_envelope_markdown import render_turn_envelope_markdown
+from ..upgrade import resolve_codex_app_automation_rrule
 from .lark_inbox import build_lark_operator_inbox_urgency_projector
-
 
 PrintPayload = Callable[
     [dict[str, object], str, Callable[[dict[str, object]], str]],
     None,
 ]
 RolloutEventAppender = Callable[..., dict[str, object]]
-HEARTBEAT_RECEIPT_SCHEMA_VERSION = "heartbeat_quota_receipt_v0"
 QUOTA_DETAIL_SECTIONS = (
     "scheduler",
     "agent-todos",
@@ -131,72 +135,6 @@ def _quota_detail_sections_from_args(args: argparse.Namespace) -> frozenset[str]
         sections.update(QUOTA_DETAIL_SECTIONS)
         sections.discard("all")
     return frozenset(sections)
-
-
-def _find_heartbeat_receipt(
-    runtime_root: Path,
-    *,
-    goal_id: str,
-    agent_id: str,
-    turn_instance_id: str,
-) -> dict[str, object] | None:
-    events = load_rollout_events(rollout_event_log_path(runtime_root, goal_id))
-    for event in reversed(events):
-        if (
-            event.get("event_kind") == "quota_should_run"
-            and str(event.get("goal_id") or "") == goal_id
-            and str(event.get("agent_id") or "") == agent_id
-            and str(event.get("run_id") or "") == turn_instance_id
-        ):
-            return event
-    return None
-
-
-def _heartbeat_receipt_view(
-    event: Mapping[str, object],
-    *,
-    turn_instance_id: str,
-    status: str,
-) -> dict[str, object]:
-    details = event.get("details") if isinstance(event.get("details"), Mapping) else {}
-    return {
-        "schema_version": HEARTBEAT_RECEIPT_SCHEMA_VERSION,
-        "turn_instance_id": turn_instance_id,
-        "status": status,
-        "stall_observation": str(details.get("stall_observation") or "not_applicable"),
-        "event_id": event.get("event_id"),
-        "recorded_at": event.get("recorded_at"),
-    }
-
-
-def _fail_heartbeat_receipt(
-    payload: dict[str, object],
-    *,
-    turn_instance_id: str,
-    stall_observation: str,
-    reason: str,
-) -> None:
-    payload.update(
-        {
-            "ok": False,
-            "decision": "skip",
-            "should_run": False,
-            "effective_action": "heartbeat_receipt_write_failed",
-            "state": "blocked_health",
-            "waiting_on": "codex",
-            "reason": reason,
-            "recommended_action": (
-                "retry quota should-run with the same --turn-instance-id after "
-                "repairing heartbeat receipt writeback"
-            ),
-            "heartbeat_receipt": {
-                "schema_version": HEARTBEAT_RECEIPT_SCHEMA_VERSION,
-                "turn_instance_id": turn_instance_id,
-                "status": "write_failed",
-                "stall_observation": stall_observation,
-            },
-        }
-    )
 
 
 def default_public_scan_root() -> str:
@@ -712,7 +650,7 @@ def handle_quota_command(
                 operator_inbox_urgency_projector=operator_inbox_urgency_projector,
             )
             if heartbeat_turn_id:
-                heartbeat_receipt_existing = _find_heartbeat_receipt(
+                heartbeat_receipt_existing = find_heartbeat_receipt(
                     runtime_root,
                     goal_id=args.goal_id,
                     agent_id=args.agent_id,
@@ -921,7 +859,7 @@ def handle_quota_command(
         if heartbeat_turn_id and args.quota_command == "should-run":
             if not heartbeat_receipt_ready:
                 prior_reason = str(payload.get("reason") or "").strip()
-                _fail_heartbeat_receipt(
+                fail_heartbeat_receipt(
                     payload,
                     turn_instance_id=heartbeat_turn_id,
                     stall_observation=heartbeat_stall_observation,
@@ -932,7 +870,7 @@ def handle_quota_command(
                     ),
                 )
             elif heartbeat_receipt_existing:
-                payload["heartbeat_receipt"] = _heartbeat_receipt_view(
+                payload["heartbeat_receipt"] = heartbeat_receipt_view(
                     heartbeat_receipt_existing,
                     turn_instance_id=heartbeat_turn_id,
                     status="replayed",
@@ -972,7 +910,7 @@ def handle_quota_command(
                     allow_failed=True,
                     idempotency_fields=["goal_id", "event_kind", "agent_id", "run_id"],
                 )
-                receipt = _find_heartbeat_receipt(
+                receipt = find_heartbeat_receipt(
                     runtime_root,
                     goal_id=args.goal_id,
                     agent_id=args.agent_id,
@@ -984,13 +922,13 @@ def handle_quota_command(
                         if isinstance(payload.get("rollout_event"), Mapping)
                         else {}
                     )
-                    payload["heartbeat_receipt"] = _heartbeat_receipt_view(
+                    payload["heartbeat_receipt"] = heartbeat_receipt_view(
                         receipt,
                         turn_instance_id=heartbeat_turn_id,
                         status="committed" if rollout_event.get("appended") else "replayed",
                     )
                 else:
-                    _fail_heartbeat_receipt(
+                    fail_heartbeat_receipt(
                         payload,
                         turn_instance_id=heartbeat_turn_id,
                         stall_observation=heartbeat_stall_observation,

--- a/loopx/control_plane/quota/heartbeat_receipt.py
+++ b/loopx/control_plane/quota/heartbeat_receipt.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+from ...rollout_event_log import load_rollout_events, rollout_event_log_path
+
+HEARTBEAT_RECEIPT_SCHEMA_VERSION = "heartbeat_quota_receipt_v0"
+
+
+def find_heartbeat_receipt(
+    runtime_root: Path,
+    *,
+    goal_id: str,
+    agent_id: str,
+    turn_instance_id: str,
+) -> dict[str, object] | None:
+    events = load_rollout_events(rollout_event_log_path(runtime_root, goal_id))
+    for event in reversed(events):
+        if (
+            event.get("event_kind") == "quota_should_run"
+            and str(event.get("goal_id") or "") == goal_id
+            and str(event.get("agent_id") or "") == agent_id
+            and str(event.get("run_id") or "") == turn_instance_id
+        ):
+            return event
+    return None
+
+
+def heartbeat_receipt_view(
+    event: Mapping[str, object],
+    *,
+    turn_instance_id: str,
+    status: str,
+) -> dict[str, object]:
+    details = event.get("details") if isinstance(event.get("details"), Mapping) else {}
+    return {
+        "schema_version": HEARTBEAT_RECEIPT_SCHEMA_VERSION,
+        "turn_instance_id": turn_instance_id,
+        "status": status,
+        "stall_observation": str(details.get("stall_observation") or "not_applicable"),
+        "event_id": event.get("event_id"),
+        "recorded_at": event.get("recorded_at"),
+    }
+
+
+def fail_heartbeat_receipt(
+    payload: dict[str, object],
+    *,
+    turn_instance_id: str,
+    stall_observation: str,
+    reason: str,
+) -> None:
+    payload.update(
+        {
+            "ok": False,
+            "decision": "skip",
+            "should_run": False,
+            "effective_action": "heartbeat_receipt_write_failed",
+            "state": "blocked_health",
+            "waiting_on": "codex",
+            "reason": reason,
+            "recommended_action": (
+                "retry quota should-run with the same --turn-instance-id after "
+                "repairing heartbeat receipt writeback"
+            ),
+            "heartbeat_receipt": {
+                "schema_version": HEARTBEAT_RECEIPT_SCHEMA_VERSION,
+                "turn_instance_id": turn_instance_id,
+                "status": "write_failed",
+                "stall_observation": stall_observation,
+            },
+        }
+    )

--- a/man/loopx.1
+++ b/man/loopx.1
@@ -147,6 +147,9 @@ Run contract and public/private boundary checks.
 \fBloopx change\-quality \-\-help\fR
 Qualify one exact final diff against an enabled project policy and receipt contract.
 .TP
+\fBloopx integration\-branch \-\-help\fR
+Detect reviewed source\-branch drift and rebuild one local integration branch.
+.TP
 \fBloopx registry\fR
 Inspect registered goals and adapters.
 .TP


### PR DESCRIPTION
## Summary

- retarget promoted issue-fix successor todos to the canonical issue key and text
- restore current capability, evidence-first workflow, metrics-window, and generated manpage smoke contracts
- move heartbeat receipt helpers into the quota bounded context so the quota CLI remains under its module-size budget

## Validation

- focused pytest: 64 passed
- six previously failing public smokes: passed
- heartbeat quota and monitor writeback smokes: passed
- Ruff F/I and touched-module py_compile: passed
- `loopx canary premerge --from-git-diff`: passed, 18 checks, 0 failures, 0 manual holds
- full-public sweep: 628/628 executed; four checks hit local parallel timing limits, then all four passed serially (promotion readiness 114.9s, installer 104.5s, promotion concurrency 88.2s, TraeX probe passed)
- public/private boundary scan and `git diff --check`: passed

## Scope

No version, release-note, provider, credential, benchmark-score, or persisted-state contract changes. No private state, raw evidence, or generated local artifacts are included. The v0.4.0 tag and public release remain held until exact-commit GitHub checks and the manual actual-default model gate pass.