### PR TITLE
fix(canary): point stale readiness warnings to writeback

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -801,8 +801,10 @@ readiness evidence, `quota should-run` also includes
 `should_run`, but it lets heartbeat workers and dashboards report release
 readiness blockers from the shared run-history projection without parsing
 `doctor`, dashboard copy, or chat reports. Before promoting the local release
-snapshot, run the canary promotion-readiness smoke and confirm fresh evidence in
-status or doctor output.
+snapshot, run `python3 examples/canary/canary-promotion-readiness-smoke.py` and
+confirm fresh evidence in status or doctor output. The
+`--no-write-evidence` form remains the non-mutating validation path and therefore
+does not clear this warning.
 Connected delivery goals also include `goal_boundary` when the registry has
 boundary data. That field carries the adapter status, allowed write scope,
 parent-approval scopes, registry guards, next probe, and stop condition. It is

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -2237,6 +2237,10 @@ heartbeat worker report that the release snapshot should not be promoted until
 fresh canary promotion-readiness evidence is written back to the shared
 run-history projection. This keeps release readiness in queryable control-plane
 state instead of relying on dashboard prose, `doctor` output, or a chat thread.
+The warning message names the writeback command,
+`python3 examples/canary/canary-promotion-readiness-smoke.py`. A run with
+`--no-write-evidence` validates the canary without refreshing this durable
+projection and cannot clear the warning.
 
 ## Usage Summary
 

--- a/examples/control_plane/runtime-freshness-warning-readmodel-smoke.py
+++ b/examples/control_plane/runtime-freshness-warning-readmodel-smoke.py
@@ -124,7 +124,10 @@ def assert_promotion_readiness_warning() -> None:
     assert warning["requires_readiness_run"] is True, warning
     assert warning["goal_id"] == TARGET_GOAL, warning
     assert warning["json_exists"] is True, warning
-    assert "promotion readiness evidence" in warning["message"], warning
+    assert warning["message"].endswith(
+        "python3 examples/canary/canary-promotion-readiness-smoke.py"
+    ), warning
+    assert "--no-write-evidence" not in warning["message"], warning
 
     missing_status = {
         "promotion_readiness_summary": {
@@ -139,6 +142,10 @@ def assert_promotion_readiness_warning() -> None:
     assert missing_warning is not None, missing_warning
     assert missing_warning["available"] is False, missing_warning
     assert missing_warning["reason"] == "no canary promotion readiness run found in sampled history"
+    assert missing_warning["message"].endswith(
+        "python3 examples/canary/canary-promotion-readiness-smoke.py"
+    ), missing_warning
+    assert "--no-write-evidence" not in missing_warning["message"], missing_warning
 
 
 def main() -> int:

--- a/examples/control_plane/status-markdown-smoke.py
+++ b/examples/control_plane/status-markdown-smoke.py
@@ -423,7 +423,11 @@ def assert_promotion_readiness_warning_in_quota_guard() -> None:
     assert stale_warning["age_hours"] == 25.0, stale_warning
     stale_markdown = render_quota_should_run_markdown(stale_payload)
     assert "promotion_readiness_warning: status=stale requires_readiness_run=True" in stale_markdown, stale_markdown
-    assert "promotion_readiness_action: promotion readiness evidence is missing, stale, or unknown" in stale_markdown, stale_markdown
+    assert (
+        "promotion_readiness_action: python3 examples/canary/canary-promotion-readiness-smoke.py"
+        in stale_markdown
+    ), stale_markdown
+    assert "promotion-readiness-smoke.py --no-write-evidence" not in stale_markdown, stale_markdown
     assert "promotion_readiness_evidence: goal=loopx-meta" in stale_markdown, stale_markdown
     assert "age_hours=25.0" in stale_markdown, stale_markdown
     assert "artifacts=True/True" in stale_markdown, stale_markdown
@@ -449,6 +453,11 @@ def assert_promotion_readiness_warning_in_quota_guard() -> None:
     assert missing_warning["available"] is False, missing_warning
     missing_markdown = render_quota_should_run_markdown(missing_payload)
     assert "promotion_readiness_warning: status=missing requires_readiness_run=True" in missing_markdown, missing_markdown
+    assert (
+        "promotion_readiness_action: python3 examples/canary/canary-promotion-readiness-smoke.py"
+        in missing_markdown
+    ), missing_markdown
+    assert "promotion-readiness-smoke.py --no-write-evidence" not in missing_markdown, missing_markdown
     assert "promotion_readiness_reason: no canary promotion readiness run found in sampled history" in missing_markdown, missing_markdown
 
     fresh_payload = build_quota_should_run(

--- a/loopx/control_plane/runtime/promotion_readiness.py
+++ b/loopx/control_plane/runtime/promotion_readiness.py
@@ -7,9 +7,10 @@ from typing import Any, Callable
 PROMOTION_READINESS_PROXY_NOTE = (
     "canary promotion-readiness projection from append-only run history; exact evidence stays in run artifacts"
 )
-PROMOTION_READINESS_WARNING_MESSAGE = (
-    "promotion readiness evidence is missing, stale, or unknown; run canary readiness smoke"
+PROMOTION_READINESS_WRITEBACK_COMMAND = (
+    "python3 examples/canary/canary-promotion-readiness-smoke.py"
 )
+PROMOTION_READINESS_WARNING_MESSAGE = PROMOTION_READINESS_WRITEBACK_COMMAND
 
 ParseTimestamp = Callable[[Any], Any]
 FreshnessBuilder = Callable[[dict[str, Any]], dict[str, Any]]


### PR DESCRIPTION
## Summary

- make stale or missing promotion-readiness warnings return the exact evidence-writeback command through the existing action field
- preserve `--no-write-evidence` as validation-only behavior and document that it cannot refresh durable readiness
- add stale/missing projection regressions without adding another quota hot-path field

## Validation

- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 18/18 selected checks passed, 0 manual holds
- `examples/control_plane/runtime-freshness-warning-readmodel-smoke.py`: passed
- `examples/control_plane/status-markdown-smoke.py`: passed
- `examples/canary/canary-promotion-no-write-contract-smoke.py`: passed
- `examples/control_plane/hot-path-interface-budget-smoke.py`: passed; quota JSON 12,520/12,550 characters
- focused quota/output-budget pytest: 19 passed
- repository mypy target set: passed
- `loopx check --scan-path .`: 0 errors, 0 warnings
- exact-scope change-quality receipt: valid

## Scope and hygiene

- no new protocol field or schema
- no private state, credentials, local paths, generated logs, or `uv.lock`
- full-file Ruff still reports the pre-existing unused `NEW_PLANNED_ACTION` import in `status-markdown-smoke.py`; the same finding reproduces on `origin/main` and is intentionally outside this PR
