### PR TITLE
feat(turn): add pure Turn Loop Controller transition contract

### DIFF
--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -23,6 +23,7 @@ scanning a chronological list.
 - [`todo_detail_cold_path_v0`](todo-detail-cold-path-v0.md): Todo detail cold path v0
 - [`todo_suggestion_prompt_v0`](todo-suggestion-prompt-v0.md): Todo suggestion prompt v0
 - [`turn_envelope_v0`](turn-envelope-v0.md): Turn envelope v0
+- [`loop_turn_loop_disposition_v0`](turn-loop-controller-v0.md): Loop Turn Loop Disposition v0
 
 ## Agent And Multi-Agent Coordination
 

--- a/docs/reference/protocols/turn-loop-controller-v0.md
+++ b/docs/reference/protocols/turn-loop-controller-v0.md
@@ -48,6 +48,7 @@ Every payload carries `spends_quota=false`, `launches_host=false`, and
 | `repair_required` | any | `repair` |
 | `replan_required` | any | `replan` |
 | `user_action_required` | any | `user_action_required` |
+| `validated_completion` + decision user action | — | `terminal` (completion wins) |
 | `wait` | any | `wait` |
 | `host_failure` / `validation_failed` / `writeback_failed` / `quota_spend_failed` | any | `repair` (route before any successor Turn) |
 | replan-class decision action (`autonomous_replan*`) | — | `replan` |
@@ -55,6 +56,14 @@ Every payload carries `spends_quota=false`, `launches_host=false`, and
 | user action projected by decision | — | `user_action_required` |
 | receipt lineage mismatches decision `(goal_id, agent_id)` | — | `wait` with `stale_receipt` reason |
 | malformed decision, broken signature, or unknown receipt kind | — | `wait` with `contract_error` reason |
+
+## Precedence
+
+A `validated_completion` receipt wins over a decision-only user action: once
+the terminal postcondition is independently proven, the loop is `terminal`
+even if the fresh decision still projects a user gate. Every other
+user-action signal (from receipt or decision) routes to
+`user_action_required` before delivery dispositions.
 
 ## Replan Continuation Boundary
 

--- a/docs/reference/protocols/turn-loop-controller-v0.md
+++ b/docs/reference/protocols/turn-loop-controller-v0.md
@@ -1,0 +1,81 @@
+# loop_turn_loop_disposition_v0
+
+`loop_turn_loop_disposition_v0` is the pure Turn Loop Controller transition
+contract. It decides what a governed loop does next from one Turn receipt plus
+a fresh quota/scheduler decision, and nothing else.
+
+`loopx turn run-once` remains the atomic governed executor: decide, execute one
+bounded host segment, validate independently, write back, spend once. The
+controller does not replace it, schedule processes, call host wake APIs, invoke
+a model, sleep, write state, or spend quota. Scheduler process management,
+host-specific wake adapters, and operator presentation are later slices in the
+Turn Loop Controller plan.
+
+## Inputs
+
+| Input | Shape | Notes |
+| --- | --- | --- |
+| `turn_receipt` | one Turn receipt mapping (`result_kind`, optional `lineage`) | may be absent when no Turn has run yet |
+| `quota_decision` | fresh `loopx_turn_envelope_v0` | must carry a matching action signature |
+| `bounded_turn_budget` | optional `max_turns` + `completed_turns` | bounds validated-progress sequences |
+
+## Output
+
+Exactly one typed disposition:
+
+| disposition | meaning | quota |
+| --- | --- | --- |
+| `run_now` | fresh decision allows the next delivery Turn | no spend by the controller |
+| `wait` | quiet cadence, blocked delivery, or fail-closed hold | no spend |
+| `user_action_required` | a concrete user action is projected by receipt or decision | no spend |
+| `repair` | repair-class recovery is required before any successor Turn | no spend |
+| `replan` | replan-class recovery; see continuation boundary below | no spend |
+| `terminal` | terminal postcondition met or bounded budget exhausted | no spend |
+
+Every payload carries `spends_quota=false`, `launches_host=false`, and
+`writes_state=false`.
+
+## Decision Table
+
+| receipt | fresh decision | disposition |
+| --- | --- | --- |
+| none | delivery allowed | `run_now` |
+| none | quiet / cadence-only | `wait` |
+| `validated_completion` | any | `terminal` |
+| `validated_progress`, budget remaining | delivery allowed | `run_now` |
+| `validated_progress`, budget exhausted | any | `terminal` |
+| `validated_progress` | no delivery | `wait` |
+| `repair_required` | any | `repair` |
+| `replan_required` | any | `replan` |
+| `user_action_required` | any | `user_action_required` |
+| `wait` | any | `wait` |
+| `host_failure` / `validation_failed` / `writeback_failed` / `quota_spend_failed` | any | `repair` (route before any successor Turn) |
+| replan-class decision action (`autonomous_replan*`) | — | `replan` |
+| repair-class decision action (`*_repair*`) | — | `repair` |
+| user action projected by decision | — | `user_action_required` |
+| receipt lineage mismatches decision `(goal_id, agent_id)` | — | `wait` with `stale_receipt` reason |
+| malformed decision, broken signature, or unknown receipt kind | — | `wait` with `contract_error` reason |
+
+## Replan Continuation Boundary
+
+`replan` never permits rerunning the same stale todo merely because a host
+session is resumable. The disposition payload carries
+`replan_continuation`:
+
+- `requires_bounded_delta=true`: a bounded `todo_delta` or `vision_delta` must
+  be written before any successor Turn;
+- `fresh_envelope_required=true`: the next Turn must come from a fresh
+  TurnEnvelope, not a replayed one;
+- `stale_todo_rerun_allowed=false`.
+
+This mirrors the autonomous-replan and two-stall contracts: no runnable todo
+with an open acceptance gap, a terminal/obsolete/incompatible selected todo,
+validated negative evidence, or two eligible turns without material progress
+all require replan rather than another delivery attempt.
+
+## Boundary
+
+The controller is a pure function. It must not invoke a model, sleep, mutate a
+host scheduler, write state, or spend quota. Unknown or contradictory input
+fails closed to `wait` with an explicit reason; it never guesses a recovery or
+fabricates a host, gate, or user action.

--- a/docs/reference/protocols/turn-loop-controller-v0.md
+++ b/docs/reference/protocols/turn-loop-controller-v0.md
@@ -26,11 +26,12 @@ Exactly one typed disposition:
 | disposition | meaning | quota |
 | --- | --- | --- |
 | `run_now` | fresh decision allows the next delivery Turn | no spend by the controller |
-| `wait` | quiet cadence, blocked delivery, or fail-closed hold | no spend |
+| `wait` | quiet cadence or blocked delivery | no spend |
 | `user_action_required` | a concrete user action is projected by receipt or decision | no spend |
 | `repair` | repair-class recovery is required before any successor Turn | no spend |
 | `replan` | replan-class recovery; see continuation boundary below | no spend |
 | `terminal` | terminal postcondition met or bounded budget exhausted | no spend |
+| `contract_error` | input failed the shared contract (envelope, lineage, budget, receipt kind) | no spend |
 
 Every payload carries `spends_quota=false`, `launches_host=false`, and
 `writes_state=false`.
@@ -54,16 +55,27 @@ Every payload carries `spends_quota=false`, `launches_host=false`, and
 | replan-class decision action (`autonomous_replan*`) | — | `replan` |
 | repair-class decision action (`*_repair*`) | — | `repair` |
 | user action projected by decision | — | `user_action_required` |
-| receipt lineage mismatches decision `(goal_id, agent_id)` | — | `wait` with `stale_receipt` reason |
-| malformed decision, broken signature, or unknown receipt kind | — | `wait` with `contract_error` reason |
+| receipt lineage missing or mismatched `(goal_id, agent_id)` for a material receipt | — | `contract_error` (`stale_receipt` / missing lineage) |
+| malformed/truncated decision, marker-only or mismatched signature hashes, over-budget compaction, unknown receipt kind, progress without a proven bounded budget | — | `contract_error` |
 
-## Precedence
+## Precedence And Fail-Closed Rules
 
-A `validated_completion` receipt wins over a decision-only user action: once
-the terminal postcondition is independently proven, the loop is `terminal`
-even if the fresh decision still projects a user gate. Every other
-user-action signal (from receipt or decision) routes to
-`user_action_required` before delivery dispositions.
+- A `validated_completion` receipt wins over a decision-only user action, but
+  only after the receipt is proven valid and fresh: material receipts must
+  carry full `(goal_id, agent_id, todo_id)` lineage, and a goal/agent mismatch
+  with the fresh decision is a `contract_error`, never `terminal`.
+- Every other user-action signal (from receipt or decision) routes to
+  `user_action_required` before delivery dispositions.
+- The fresh decision must satisfy the shared Turn envelope contract
+  (`loopx_turn_envelope_v0` schema, non-empty equal signature hashes, and an
+  in-budget compaction) via the same typed route the Turn plan driver uses;
+  forged or truncated envelopes are `contract_error`, never `run_now`.
+- `validated_progress` may continue only with a proven bounded turn budget
+  (`max_turns` + `completed_turns`); without it the controller fails closed to
+  `contract_error` instead of guessing an unbounded continuation.
+- `contract_error` is a typed terminal-class outcome for invalid input, not a
+  silent `wait`: it never launches, writes, or spends, and it names the failed
+  rule in `reason`.
 
 ## Replan Continuation Boundary
 
@@ -86,5 +98,5 @@ all require replan rather than another delivery attempt.
 
 The controller is a pure function. It must not invoke a model, sleep, mutate a
 host scheduler, write state, or spend quota. Unknown or contradictory input
-fails closed to `wait` with an explicit reason; it never guesses a recovery or
-fabricates a host, gate, or user action.
+fails closed to `contract_error` with an explicit reason; it never guesses a
+recovery or fabricates a host, gate, or user action.

--- a/docs/reference/protocols/turn-loop-controller-v0.md
+++ b/docs/reference/protocols/turn-loop-controller-v0.md
@@ -1,8 +1,8 @@
 # loop_turn_loop_disposition_v0
 
 `loop_turn_loop_disposition_v0` is the pure Turn Loop Controller transition
-contract. It decides what a governed loop does next from one Turn receipt plus
-a fresh quota/scheduler decision, and nothing else.
+contract. It decides what a governed loop does next from one validated Turn
+receipt plus a fresh quota/scheduler decision, and nothing else.
 
 `loopx turn run-once` remains the atomic governed executor: decide, execute one
 bounded host segment, validate independently, write back, spend once. The
@@ -15,9 +15,18 @@ Turn Loop Controller plan.
 
 | Input | Shape | Notes |
 | --- | --- | --- |
-| `turn_receipt` | one Turn receipt mapping (`result_kind`, optional `lineage`) | may be absent when no Turn has run yet |
-| `quota_decision` | fresh `loopx_turn_envelope_v0` | must carry a matching action signature |
-| `bounded_turn_budget` | optional `max_turns` + `completed_turns` | bounds validated-progress sequences |
+| `turn_receipt` | one `ValidatedTurnReceipt` (proven by `validate_loopx_turn_receipt`) | may be absent when no Turn has run yet |
+| `quota_decision` | fresh `loopx_turn_envelope_v0` | must satisfy the shared typed envelope contract |
+| `bounded_turn_budget` | one `BoundedTurnBudget` | required when the receipt is `validated_progress` |
+
+Inputs are typed and validated at the boundary. The controller does not accept
+caller-authored `result_kind + lineage` mappings: a receipt must be a
+`loopx_turn_receipt_validation_v0` result with `ok=true`, a supported result
+kind, and full `(goal_id, agent_id, todo_id)` lineage. A budget must carry
+strict integer domains (`type(...) is int`, `max_turns > 0`,
+`0 <= completed_turns <= max_turns`) and the same lineage as the fresh
+decision. Invalid or stale input raises `ValueError`; it is never encoded as a
+disposition.
 
 ## Output
 
@@ -31,10 +40,11 @@ Exactly one typed disposition:
 | `repair` | repair-class recovery is required before any successor Turn | no spend |
 | `replan` | replan-class recovery; see continuation boundary below | no spend |
 | `terminal` | terminal postcondition met or bounded budget exhausted | no spend |
-| `contract_error` | input failed the shared contract (envelope, lineage, budget, receipt kind) | no spend |
 
-Every payload carries `spends_quota=false`, `launches_host=false`, and
-`writes_state=false`.
+The output space is exactly these six dispositions. There is no
+`contract_error` disposition: contract failures are rejected at the typed-input
+boundary. Every payload carries `spends_quota=false`, `launches_host=false`,
+and `writes_state=false`.
 
 ## Decision Table
 
@@ -55,27 +65,26 @@ Every payload carries `spends_quota=false`, `launches_host=false`, and
 | replan-class decision action (`autonomous_replan*`) | — | `replan` |
 | repair-class decision action (`*_repair*`) | — | `repair` |
 | user action projected by decision | — | `user_action_required` |
-| receipt lineage missing or mismatched `(goal_id, agent_id)` for a material receipt | — | `contract_error` (`stale_receipt` / missing lineage) |
-| malformed/truncated decision, marker-only or mismatched signature hashes, over-budget compaction, unknown receipt kind, progress without a proven bounded budget | — | `contract_error` |
 
 ## Precedence And Fail-Closed Rules
 
 - A `validated_completion` receipt wins over a decision-only user action, but
-  only after the receipt is proven valid and fresh: material receipts must
-  carry full `(goal_id, agent_id, todo_id)` lineage, and a goal/agent mismatch
-  with the fresh decision is a `contract_error`, never `terminal`.
+  only after the receipt is proven valid and fresh. Material receipts must
+  carry full `(goal_id, agent_id, todo_id)` lineage, and any mismatch with the
+  fresh decision (including `todo_id`) raises `ValueError` (`stale_receipt`),
+  never `terminal`.
 - Every other user-action signal (from receipt or decision) routes to
   `user_action_required` before delivery dispositions.
 - The fresh decision must satisfy the shared Turn envelope contract
   (`loopx_turn_envelope_v0` schema, non-empty equal signature hashes, and an
   in-budget compaction) via the same typed route the Turn plan driver uses;
-  forged or truncated envelopes are `contract_error`, never `run_now`.
-- `validated_progress` may continue only with a proven bounded turn budget
-  (`max_turns` + `completed_turns`); without it the controller fails closed to
-  `contract_error` instead of guessing an unbounded continuation.
-- `contract_error` is a typed terminal-class outcome for invalid input, not a
-  silent `wait`: it never launches, writes, or spends, and it names the failed
-  rule in `reason`.
+  forged or truncated envelopes raise `ValueError`, never `run_now`.
+- `validated_progress` may continue only with a proven `BoundedTurnBudget`
+  whose lineage matches the fresh decision; without it the controller raises
+  `ValueError` instead of guessing an unbounded continuation.
+- Input validity is enforced at the typed-input boundary, not encoded as a
+  seventh disposition. The transition output space is always one of the six
+  dispositions above.
 
 ## Replan Continuation Boundary
 
@@ -97,6 +106,6 @@ all require replan rather than another delivery attempt.
 ## Boundary
 
 The controller is a pure function. It must not invoke a model, sleep, mutate a
-host scheduler, write state, or spend quota. Unknown or contradictory input
-fails closed to `contract_error` with an explicit reason; it never guesses a
-recovery or fabricates a host, gate, or user action.
+host scheduler, write state, or spend quota. Invalid or stale input is rejected
+at the typed-input boundary with a `ValueError`; it never guesses a recovery
+or fabricates a host, gate, or user action.

--- a/docs/reference/protocols/turn-loop-controller-v0.md
+++ b/docs/reference/protocols/turn-loop-controller-v0.md
@@ -15,17 +15,23 @@ Turn Loop Controller plan.
 
 | Input | Shape | Notes |
 | --- | --- | --- |
-| `turn_receipt` | one `ValidatedTurnReceipt` (proven by `validate_loopx_turn_receipt`) | may be absent when no Turn has run yet |
-| `quota_decision` | fresh `loopx_turn_envelope_v0` | must satisfy the shared typed envelope contract |
+| `turn_receipt` | one `ValidatedTurnReceipt` (proven by `validate_loopx_turn_receipt`) | may be absent when no Turn has run yet; material results require `status="committed"` |
+| `quota_decision` | fresh `loopx_turn_envelope_v0` | must satisfy the shared typed envelope contract and declare `predecessor_turn_key` matching the receipt |
 | `bounded_turn_budget` | one `BoundedTurnBudget` | required when the receipt is `validated_progress` |
 
 Inputs are typed and validated at the boundary. The controller does not accept
 caller-authored `result_kind + lineage` mappings: a receipt must be a
 `loopx_turn_receipt_validation_v0` result with `ok=true`, a supported result
-kind, and full `(goal_id, agent_id, todo_id)` lineage. A budget must carry
-strict integer domains (`type(...) is int`, `max_turns > 0`,
-`0 <= completed_turns <= max_turns`) and the same lineage as the fresh
-decision. Invalid or stale input raises `ValueError`; it is never encoded as a
+kind, full `(goal_id, agent_id, todo_id)` lineage, and a `turn_key`. Material
+results (`validated_completion` / `validated_progress`) additionally require
+`status="committed"` so the loop never terminates or continues before the full
+`run-once` transaction (writeback, quota spend, scheduler apply/ack) has
+closed. A budget must carry strict integer domains (`type(...) is int`,
+`max_turns > 0`, `0 <= completed_turns <= max_turns`) and the same lineage as
+the fresh decision. When a receipt is supplied, the fresh decision must declare
+`predecessor_turn_key` equal to the receipt's `turn_key` to prove causal
+succession; an old receipt for the same todo cannot be replayed against a later
+envelope. Invalid or stale input raises `ValueError`; it is never encoded as a
 disposition.
 
 ## Output
@@ -69,10 +75,17 @@ and `writes_state=false`.
 ## Precedence And Fail-Closed Rules
 
 - A `validated_completion` receipt wins over a decision-only user action, but
-  only after the receipt is proven valid and fresh. Material receipts must
-  carry full `(goal_id, agent_id, todo_id)` lineage, and any mismatch with the
-  fresh decision (including `todo_id`) raises `ValueError` (`stale_receipt`),
-  never `terminal`.
+  only after the receipt is proven valid, fresh, and fully committed. Material
+  receipts must carry full `(goal_id, agent_id, todo_id)` lineage and
+  `status="committed"`; a validation-only intermediate (`status="validated"`)
+  cannot drive `terminal` or `run_now`. Any lineage mismatch with the fresh
+  decision (including `todo_id`) raises `ValueError` (`stale_receipt`), never
+  `terminal`.
+- When a receipt is supplied, the fresh decision must declare
+  `predecessor_turn_key` equal to the receipt's `turn_key`. A missing or
+  mismatched key raises `ValueError` (`stale_receipt`); this closes the
+  stale-replay gap where an old receipt for the same todo could be replayed
+  against a later envelope.
 - Every other user-action signal (from receipt or decision) routes to
   `user_action_required` before delivery dispositions.
 - The fresh decision must satisfy the shared Turn envelope contract

--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -362,6 +362,14 @@ def handle_turn_command(
                 boundary = payload.get("boundary")
                 if isinstance(boundary, dict):
                     boundary.pop("opaque_session_handle_omitted", None)
+            else:
+                # The transaction plan carries an internal lineage used by
+                # receipt validation and the turn_key hash. It is not part of
+                # the agent-facing CLI contract, so strip it before rendering
+                # to keep the output budget stable.
+                transaction = payload.get("transaction")
+                if isinstance(transaction, dict):
+                    transaction.pop("lineage", None)
         elif args.turn_command == "run-once":
             if args.resume_turn_key:
                 if args.turn_instance_id:

--- a/loopx/control_plane/turn_driver/__init__.py
+++ b/loopx/control_plane/turn_driver/__init__.py
@@ -6,6 +6,11 @@ from .driver import (
     build_loopx_turn_plan,
     selected_turn_todo,
 )
+from .loop_controller import (
+    LOOP_CONTROLLER_DISPOSITION_SCHEMA_VERSION,
+    LoopDisposition,
+    decide_loop_disposition,
+)
 from .codex_cli import (
     CODEX_CLI_SESSION_SCHEMA_VERSION,
     codex_cli_session_id_from_jsonl,
@@ -42,6 +47,8 @@ __all__ = [
     "LOOPX_TURN_EXECUTION_SCHEMA_VERSION",
     "LOOPX_TURN_HOST_REQUEST_SCHEMA_VERSION",
     "LOOPX_TURN_TASK_VALIDATION_SCHEMA_VERSION",
+    "LOOP_CONTROLLER_DISPOSITION_SCHEMA_VERSION",
+    "LoopDisposition",
     "LoopXTurnRoute",
     "LoopXTurnResultKind",
     "build_loopx_turn_plan",
@@ -60,6 +67,7 @@ __all__ = [
     "run_codex_cli_host",
     "codex_cli_result_schema",
     "codex_cli_session_binding",
+    "decide_loop_disposition",
     "validate_loopx_turn_host_result",
     "validate_loopx_turn_receipt",
 ]

--- a/loopx/control_plane/turn_driver/__init__.py
+++ b/loopx/control_plane/turn_driver/__init__.py
@@ -7,8 +7,12 @@ from .driver import (
     selected_turn_todo,
 )
 from .loop_controller import (
+    BOUNDED_TURN_BUDGET_SCHEMA_VERSION,
     LOOP_CONTROLLER_DISPOSITION_SCHEMA_VERSION,
+    VALIDATED_TURN_RECEIPT_SCHEMA_VERSION,
+    BoundedTurnBudget,
     LoopDisposition,
+    ValidatedTurnReceipt,
     decide_loop_disposition,
 )
 from .codex_cli import (
@@ -47,8 +51,12 @@ __all__ = [
     "LOOPX_TURN_EXECUTION_SCHEMA_VERSION",
     "LOOPX_TURN_HOST_REQUEST_SCHEMA_VERSION",
     "LOOPX_TURN_TASK_VALIDATION_SCHEMA_VERSION",
+    "BOUNDED_TURN_BUDGET_SCHEMA_VERSION",
     "LOOP_CONTROLLER_DISPOSITION_SCHEMA_VERSION",
+    "VALIDATED_TURN_RECEIPT_SCHEMA_VERSION",
+    "BoundedTurnBudget",
     "LoopDisposition",
+    "ValidatedTurnReceipt",
     "LoopXTurnRoute",
     "LoopXTurnResultKind",
     "build_loopx_turn_plan",

--- a/loopx/control_plane/turn_driver/loop_controller.py
+++ b/loopx/control_plane/turn_driver/loop_controller.py
@@ -14,8 +14,7 @@ from collections.abc import Mapping
 from enum import Enum
 from typing import Any
 
-from ..quota.turn_envelope import TURN_ENVELOPE_SCHEMA_VERSION
-from .driver import REPAIR_ACTIONS, REPLAN_ACTIONS
+from .driver import LoopXTurnRoute, _typed_route
 from .transaction import LoopXTurnResultKind
 
 
@@ -29,9 +28,7 @@ class LoopDisposition(str, Enum):
     REPAIR = "repair"
     REPLAN = "replan"
     TERMINAL = "terminal"
-
-
-_NO_RECEIPT = object()
+    CONTRACT_ERROR = "contract_error"
 
 
 def _mapping(value: Any) -> dict[str, Any]:
@@ -82,36 +79,26 @@ def _decision_lineage(decision: Mapping[str, Any]) -> dict[str, str]:
 def _envelope_route(decision: Mapping[str, Any]) -> str | None:
     """Return a coarse route for a fresh quota/scheduler decision.
 
-    Mirrors the typed-route semantics of the Turn plan driver: replan and
-    repair actions route to their own dispositions, user action blocks host
-    execution, quiet cadence waits, and only an allowed delivery runs now.
-    Returns None when the decision envelope itself is malformed.
+    Reuses the shared typed-route contract from the Turn plan driver, which
+    requires a matching action signature with non-empty equal hashes and an
+    in-budget compaction. A projected user action outranks delivery, so it is
+    resolved before the typed delivery route. Returns None when the envelope
+    fails the shared contract instead of accepting a forged or truncated
+    decision.
     """
 
-    if decision.get("schema_version") != TURN_ENVELOPE_SCHEMA_VERSION:
+    route = _typed_route(decision)
+    if route is LoopXTurnRoute.CONTRACT_ERROR:
         return None
-    signature = _mapping(decision.get("action_signature"))
-    if signature.get("matches") is not True:
-        return None
-
-    action = _mapping(decision.get("action"))
     user = _mapping(decision.get("user"))
-    effective_action = str(decision.get("effective_action") or "")
-
     if user.get("action_required") is True:
         return LoopDisposition.USER_ACTION_REQUIRED.value
-    if decision.get("should_run") is True:
-        if not (action.get("delivery_allowed") is True and action.get("must_attempt") is True):
-            return LoopDisposition.WAIT.value
-        if effective_action in REPLAN_ACTIONS:
-            return LoopDisposition.REPLAN.value
-        if effective_action in REPAIR_ACTIONS or effective_action.endswith(
-            ("_repair", "_repair_required")
-        ):
-            return LoopDisposition.REPAIR.value
+    if route is LoopXTurnRoute.READY_FOR_HOST:
         return LoopDisposition.RUN_NOW.value
-    if action.get("quiet_noop_allowed") is True:
-        return LoopDisposition.WAIT.value
+    if route is LoopXTurnRoute.REPLAN_REQUIRED:
+        return LoopDisposition.REPLAN.value
+    if route is LoopXTurnRoute.REPAIR_REQUIRED:
+        return LoopDisposition.REPAIR.value
     return LoopDisposition.WAIT.value
 
 
@@ -136,29 +123,10 @@ def decide_loop_disposition(
     route = _envelope_route(quota_decision)
     if route is None:
         return _disposition(
-            LoopDisposition.WAIT,
-            reason="contract_error: quota decision is not a valid loopx_turn_envelope_v0",
+            LoopDisposition.CONTRACT_ERROR,
+            reason="quota decision failed the shared envelope contract (schema, signature hashes, or compaction budget)",
         )
     decision_lineage = _decision_lineage(quota_decision)
-
-    # A validated completion settles the terminal postcondition; it wins over
-    # a decision-only user action because a finished loop must not stay
-    # non-terminal behind a stale gate projection.
-    if turn_receipt is not None:
-        completion_kind = str(_mapping(turn_receipt).get("result_kind") or "")
-        if completion_kind == LoopXTurnResultKind.VALIDATED_COMPLETION.value:
-            return _disposition(
-                LoopDisposition.TERMINAL,
-                reason="terminal postcondition met by validated completion",
-                lineage=decision_lineage,
-            )
-
-    if route == LoopDisposition.USER_ACTION_REQUIRED.value:
-        return _disposition(
-            LoopDisposition.USER_ACTION_REQUIRED,
-            reason="fresh decision projects a concrete user action",
-            lineage=decision_lineage,
-        )
 
     if turn_receipt is None:
         if route == LoopDisposition.RUN_NOW.value:
@@ -187,12 +155,30 @@ def decide_loop_disposition(
         result_kind = LoopXTurnResultKind(raw_kind)
     except ValueError:
         return _disposition(
-            LoopDisposition.WAIT,
-            reason=f"contract_error: unsupported turn receipt result_kind {raw_kind!r}",
+            LoopDisposition.CONTRACT_ERROR,
+            reason=f"unsupported turn receipt result_kind {raw_kind!r}",
+            lineage=decision_lineage,
+        )
+
+    if route == LoopDisposition.USER_ACTION_REQUIRED.value and result_kind is not LoopXTurnResultKind.VALIDATED_COMPLETION:
+        return _disposition(
+            LoopDisposition.USER_ACTION_REQUIRED,
+            reason="fresh decision projects a concrete user action",
             lineage=decision_lineage,
         )
 
     receipt_lineage = _receipt_lineage(receipt)
+    if result_kind in {
+        LoopXTurnResultKind.VALIDATED_COMPLETION,
+        LoopXTurnResultKind.VALIDATED_PROGRESS,
+    } and not all(receipt_lineage.values()):
+        # A validated material result without proven lineage cannot be
+        # distinguished from a forged completion; fail closed.
+        return _disposition(
+            LoopDisposition.CONTRACT_ERROR,
+            reason="validated material receipt is missing goal/agent/todo lineage",
+            lineage=decision_lineage,
+        )
     if all(receipt_lineage.values()) and all(decision_lineage.values()):
         mismatched = {
             key
@@ -201,21 +187,31 @@ def decide_loop_disposition(
         }
         if mismatched:
             return _disposition(
-                LoopDisposition.WAIT,
+                LoopDisposition.CONTRACT_ERROR,
                 reason="stale_receipt: receipt lineage does not match the fresh decision",
                 lineage=decision_lineage,
                 extra={"stale_receipt_lineage": receipt_lineage},
             )
 
+    if result_kind is LoopXTurnResultKind.VALIDATED_COMPLETION:
+        return _disposition(
+            LoopDisposition.TERMINAL,
+            reason="terminal postcondition met by validated completion",
+            lineage=decision_lineage,
+        )
+
     if result_kind is LoopXTurnResultKind.VALIDATED_PROGRESS:
         budget = _mapping(bounded_turn_budget)
         max_turns = budget.get("max_turns")
         completed_turns = budget.get("completed_turns")
-        if (
-            isinstance(max_turns, int)
-            and isinstance(completed_turns, int)
-            and completed_turns >= max_turns
-        ):
+        budget_proven = isinstance(max_turns, int) and isinstance(completed_turns, int)
+        if not budget_proven:
+            return _disposition(
+                LoopDisposition.CONTRACT_ERROR,
+                reason="validated progress cannot continue without a proven bounded turn budget",
+                lineage=decision_lineage,
+            )
+        if completed_turns >= max_turns:
             return _disposition(
                 LoopDisposition.TERMINAL,
                 reason="bounded turn budget exhausted after validated progress",

--- a/loopx/control_plane/turn_driver/loop_controller.py
+++ b/loopx/control_plane/turn_driver/loop_controller.py
@@ -1,0 +1,285 @@
+"""Pure Turn Loop Controller transition contract.
+
+This module decides the next disposition of a governed loop from one Turn
+receipt plus a fresh quota/scheduler decision. It is a pure function: it never
+invokes a model, sleeps, mutates a host scheduler, writes state, or spends
+quota. `loopx turn run-once` remains the only delivery transaction; scheduler
+process management, host wake APIs, and operator presentation belong to later
+adapters (see the Turn Loop Controller plan in CONTRIBUTOR_TASKS).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from enum import Enum
+from typing import Any
+
+from ..quota.turn_envelope import TURN_ENVELOPE_SCHEMA_VERSION
+from .driver import REPAIR_ACTIONS, REPLAN_ACTIONS
+from .transaction import LoopXTurnResultKind
+
+
+LOOP_CONTROLLER_DISPOSITION_SCHEMA_VERSION = "loop_turn_loop_disposition_v0"
+
+
+class LoopDisposition(str, Enum):
+    RUN_NOW = "run_now"
+    WAIT = "wait"
+    USER_ACTION_REQUIRED = "user_action_required"
+    REPAIR = "repair"
+    REPLAN = "replan"
+    TERMINAL = "terminal"
+
+
+_NO_RECEIPT = object()
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _disposition(
+    disposition: LoopDisposition,
+    *,
+    reason: str,
+    lineage: Mapping[str, str] | None = None,
+    extra: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": LOOP_CONTROLLER_DISPOSITION_SCHEMA_VERSION,
+        "disposition": disposition.value,
+        "reason": reason,
+        "spends_quota": False,
+        "launches_host": False,
+        "writes_state": False,
+    }
+    if lineage:
+        payload["lineage"] = dict(lineage)
+    if extra:
+        payload.update(dict(extra))
+    return payload
+
+
+def _receipt_lineage(receipt: Mapping[str, Any]) -> dict[str, str]:
+    lineage = _mapping(receipt.get("lineage"))
+    return {
+        "goal_id": str(lineage.get("goal_id") or receipt.get("goal_id") or ""),
+        "agent_id": str(lineage.get("agent_id") or receipt.get("agent_id") or ""),
+        "todo_id": str(lineage.get("todo_id") or receipt.get("todo_id") or ""),
+    }
+
+
+def _decision_lineage(decision: Mapping[str, Any]) -> dict[str, str]:
+    action = _mapping(decision.get("action"))
+    selected_todo = _mapping(action.get("selected_todo"))
+    return {
+        "goal_id": str(decision.get("goal_id") or ""),
+        "agent_id": str(decision.get("agent_id") or ""),
+        "todo_id": str(selected_todo.get("todo_id") or ""),
+    }
+
+
+def _envelope_route(decision: Mapping[str, Any]) -> str | None:
+    """Return a coarse route for a fresh quota/scheduler decision.
+
+    Mirrors the typed-route semantics of the Turn plan driver: replan and
+    repair actions route to their own dispositions, user action blocks host
+    execution, quiet cadence waits, and only an allowed delivery runs now.
+    Returns None when the decision envelope itself is malformed.
+    """
+
+    if decision.get("schema_version") != TURN_ENVELOPE_SCHEMA_VERSION:
+        return None
+    signature = _mapping(decision.get("action_signature"))
+    if signature.get("matches") is not True:
+        return None
+
+    action = _mapping(decision.get("action"))
+    user = _mapping(decision.get("user"))
+    effective_action = str(decision.get("effective_action") or "")
+
+    if user.get("action_required") is True:
+        return LoopDisposition.USER_ACTION_REQUIRED.value
+    if decision.get("should_run") is True:
+        if not (action.get("delivery_allowed") is True and action.get("must_attempt") is True):
+            return LoopDisposition.WAIT.value
+        if effective_action in REPLAN_ACTIONS:
+            return LoopDisposition.REPLAN.value
+        if effective_action in REPAIR_ACTIONS or effective_action.endswith(
+            ("_repair", "_repair_required")
+        ):
+            return LoopDisposition.REPAIR.value
+        return LoopDisposition.RUN_NOW.value
+    if action.get("quiet_noop_allowed") is True:
+        return LoopDisposition.WAIT.value
+    return LoopDisposition.WAIT.value
+
+
+def decide_loop_disposition(
+    *,
+    turn_receipt: Mapping[str, Any] | None,
+    quota_decision: Mapping[str, Any],
+    bounded_turn_budget: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Decide the next loop disposition from one receipt and a fresh decision.
+
+    `turn_receipt` is one `loopx_turn_receipt_v0`-shaped mapping (result kind,
+    optional validation status, optional lineage). `quota_decision` is a fresh
+    `loopx_turn_envelope_v0`. `bounded_turn_budget` may carry `max_turns` and
+    `completed_turns` so validated progress can exhaust a bounded sequence.
+
+    The function is pure: it launches no host, writes no state, and spends no
+    quota. Unknown or contradictory input fails closed to a typed wait or
+    contract-error disposition instead of guessing.
+    """
+
+    route = _envelope_route(quota_decision)
+    if route is None:
+        return _disposition(
+            LoopDisposition.WAIT,
+            reason="contract_error: quota decision is not a valid loopx_turn_envelope_v0",
+        )
+    decision_lineage = _decision_lineage(quota_decision)
+
+    if route == LoopDisposition.USER_ACTION_REQUIRED.value:
+        return _disposition(
+            LoopDisposition.USER_ACTION_REQUIRED,
+            reason="fresh decision projects a concrete user action",
+            lineage=decision_lineage,
+        )
+
+    if turn_receipt is None:
+        if route == LoopDisposition.RUN_NOW.value:
+            return _disposition(
+                LoopDisposition.RUN_NOW,
+                reason="no prior receipt and fresh decision allows delivery",
+                lineage=decision_lineage,
+            )
+        if route == LoopDisposition.REPLAN.value:
+            return _replan_disposition(reason="fresh decision requires replan", decision_lineage=decision_lineage)
+        if route == LoopDisposition.REPAIR.value:
+            return _disposition(
+                LoopDisposition.REPAIR,
+                reason="fresh decision requires repair",
+                lineage=decision_lineage,
+            )
+        return _disposition(
+            LoopDisposition.WAIT,
+            reason="fresh decision is a quiet no-spend wait",
+            lineage=decision_lineage,
+        )
+
+    receipt = _mapping(turn_receipt)
+    raw_kind = str(receipt.get("result_kind") or "")
+    try:
+        result_kind = LoopXTurnResultKind(raw_kind)
+    except ValueError:
+        return _disposition(
+            LoopDisposition.WAIT,
+            reason=f"contract_error: unsupported turn receipt result_kind {raw_kind!r}",
+            lineage=decision_lineage,
+        )
+
+    receipt_lineage = _receipt_lineage(receipt)
+    if all(receipt_lineage.values()) and all(decision_lineage.values()):
+        mismatched = {
+            key
+            for key in ("goal_id", "agent_id")
+            if receipt_lineage[key] != decision_lineage[key]
+        }
+        if mismatched:
+            return _disposition(
+                LoopDisposition.WAIT,
+                reason="stale_receipt: receipt lineage does not match the fresh decision",
+                lineage=decision_lineage,
+                extra={"stale_receipt_lineage": receipt_lineage},
+            )
+
+    if result_kind is LoopXTurnResultKind.VALIDATED_COMPLETION:
+        return _disposition(
+            LoopDisposition.TERMINAL,
+            reason="terminal postcondition met by validated completion",
+            lineage=decision_lineage,
+        )
+
+    if result_kind is LoopXTurnResultKind.VALIDATED_PROGRESS:
+        budget = _mapping(bounded_turn_budget)
+        max_turns = budget.get("max_turns")
+        completed_turns = budget.get("completed_turns")
+        if (
+            isinstance(max_turns, int)
+            and isinstance(completed_turns, int)
+            and completed_turns >= max_turns
+        ):
+            return _disposition(
+                LoopDisposition.TERMINAL,
+                reason="bounded turn budget exhausted after validated progress",
+                lineage=decision_lineage,
+            )
+        if route == LoopDisposition.RUN_NOW.value:
+            return _disposition(
+                LoopDisposition.RUN_NOW,
+                reason="validated progress with fresh decision allowing the next turn",
+                lineage=decision_lineage,
+            )
+        if route == LoopDisposition.REPLAN.value:
+            return _replan_disposition(reason="fresh decision requires replan after progress", decision_lineage=decision_lineage)
+        if route == LoopDisposition.REPAIR.value:
+            return _disposition(
+                LoopDisposition.REPAIR,
+                reason="fresh decision requires repair after progress",
+                lineage=decision_lineage,
+            )
+        return _disposition(
+            LoopDisposition.WAIT,
+            reason="validated progress but fresh decision does not allow the next turn yet",
+            lineage=decision_lineage,
+        )
+
+    if result_kind is LoopXTurnResultKind.REPLAN_REQUIRED:
+        return _replan_disposition(reason="turn receipt requires replan", decision_lineage=decision_lineage)
+
+    if result_kind is LoopXTurnResultKind.REPAIR_REQUIRED:
+        return _disposition(
+            LoopDisposition.REPAIR,
+            reason="turn receipt requires repair",
+            lineage=decision_lineage,
+        )
+
+    if result_kind is LoopXTurnResultKind.USER_ACTION_REQUIRED:
+        return _disposition(
+            LoopDisposition.USER_ACTION_REQUIRED,
+            reason="turn receipt projects a concrete user action",
+            lineage=decision_lineage,
+        )
+
+    if result_kind is LoopXTurnResultKind.WAIT:
+        return _disposition(
+            LoopDisposition.WAIT,
+            reason="turn receipt is a typed no-spend wait",
+            lineage=decision_lineage,
+        )
+
+    # host_failure, validation_failed, writeback_failed, quota_spend_failed:
+    # the loop must not guess recovery on its own; hold for repair routing.
+    return _disposition(
+        LoopDisposition.REPAIR,
+        reason=f"turn receipt ended in {result_kind.value}; route to repair before any successor turn",
+        lineage=decision_lineage,
+    )
+
+
+def _replan_disposition(*, reason: str, decision_lineage: Mapping[str, str]) -> dict[str, Any]:
+    return _disposition(
+        LoopDisposition.REPLAN,
+        reason=reason,
+        lineage=decision_lineage,
+        extra={
+            "replan_continuation": {
+                "requires_bounded_delta": True,
+                "delta_kinds": ["todo_delta", "vision_delta"],
+                "stale_todo_rerun_allowed": False,
+                "fresh_envelope_required": True,
+            }
+        },
+    )

--- a/loopx/control_plane/turn_driver/loop_controller.py
+++ b/loopx/control_plane/turn_driver/loop_controller.py
@@ -141,6 +141,18 @@ def decide_loop_disposition(
         )
     decision_lineage = _decision_lineage(quota_decision)
 
+    # A validated completion settles the terminal postcondition; it wins over
+    # a decision-only user action because a finished loop must not stay
+    # non-terminal behind a stale gate projection.
+    if turn_receipt is not None:
+        completion_kind = str(_mapping(turn_receipt).get("result_kind") or "")
+        if completion_kind == LoopXTurnResultKind.VALIDATED_COMPLETION.value:
+            return _disposition(
+                LoopDisposition.TERMINAL,
+                reason="terminal postcondition met by validated completion",
+                lineage=decision_lineage,
+            )
+
     if route == LoopDisposition.USER_ACTION_REQUIRED.value:
         return _disposition(
             LoopDisposition.USER_ACTION_REQUIRED,
@@ -194,13 +206,6 @@ def decide_loop_disposition(
                 lineage=decision_lineage,
                 extra={"stale_receipt_lineage": receipt_lineage},
             )
-
-    if result_kind is LoopXTurnResultKind.VALIDATED_COMPLETION:
-        return _disposition(
-            LoopDisposition.TERMINAL,
-            reason="terminal postcondition met by validated completion",
-            lineage=decision_lineage,
-        )
 
     if result_kind is LoopXTurnResultKind.VALIDATED_PROGRESS:
         budget = _mapping(bounded_turn_budget)

--- a/loopx/control_plane/turn_driver/loop_controller.py
+++ b/loopx/control_plane/turn_driver/loop_controller.py
@@ -1,11 +1,20 @@
 """Pure Turn Loop Controller transition contract.
 
-This module decides the next disposition of a governed loop from one Turn
-receipt plus a fresh quota/scheduler decision. It is a pure function: it never
-invokes a model, sleeps, mutates a host scheduler, writes state, or spends
-quota. `loopx turn run-once` remains the only delivery transaction; scheduler
-process management, host wake APIs, and operator presentation belong to later
-adapters (see the Turn Loop Controller plan in CONTRIBUTOR_TASKS).
+This module decides the next disposition of a governed loop from one validated
+Turn receipt plus a fresh quota/scheduler decision. It is a pure function: it
+never invokes a model, sleeps, mutates a host scheduler, writes state, or
+spends quota. `loopx turn run-once` remains the only delivery transaction;
+scheduler process management, host wake APIs, and operator presentation belong
+to later adapters (see the Turn Loop Controller plan in CONTRIBUTOR_TASKS).
+
+The transition output space is exactly six dispositions:
+``run_now | wait | user_action_required | repair | replan | terminal``.
+
+Input validity is enforced at the typed-input boundary, not encoded as a
+seventh disposition. ``decide_loop_disposition`` raises ``ValueError`` when a
+receipt, envelope, or budget cannot be proven against the shared Turn
+contracts, so the caller is responsible for feeding only validated, fresh
+inputs.
 """
 
 from __future__ import annotations
@@ -15,10 +24,19 @@ from enum import Enum
 from typing import Any
 
 from .driver import LoopXTurnRoute, _typed_route
-from .transaction import LoopXTurnResultKind
+from .transaction import (
+    LOOPX_TURN_RECEIPT_VALIDATION_SCHEMA_VERSION,
+    LoopXTurnResultKind,
+)
 
 
 LOOP_CONTROLLER_DISPOSITION_SCHEMA_VERSION = "loop_turn_loop_disposition_v0"
+BOUNDED_TURN_BUDGET_SCHEMA_VERSION = "loop_bounded_turn_budget_v0"
+VALIDATED_TURN_RECEIPT_SCHEMA_VERSION = "loop_validated_turn_receipt_v0"
+
+# Statuses that prove a material result has been independently validated and
+# may therefore drive a terminal or progress transition.
+_VALIDATED_RECEIPT_STATUSES = {"validated", "committed"}
 
 
 class LoopDisposition(str, Enum):
@@ -28,7 +46,6 @@ class LoopDisposition(str, Enum):
     REPAIR = "repair"
     REPLAN = "replan"
     TERMINAL = "terminal"
-    CONTRACT_ERROR = "contract_error"
 
 
 def _mapping(value: Any) -> dict[str, Any]:
@@ -57,15 +74,6 @@ def _disposition(
     return payload
 
 
-def _receipt_lineage(receipt: Mapping[str, Any]) -> dict[str, str]:
-    lineage = _mapping(receipt.get("lineage"))
-    return {
-        "goal_id": str(lineage.get("goal_id") or receipt.get("goal_id") or ""),
-        "agent_id": str(lineage.get("agent_id") or receipt.get("agent_id") or ""),
-        "todo_id": str(lineage.get("todo_id") or receipt.get("todo_id") or ""),
-    }
-
-
 def _decision_lineage(decision: Mapping[str, Any]) -> dict[str, str]:
     action = _mapping(decision.get("action"))
     selected_todo = _mapping(action.get("selected_todo"))
@@ -76,123 +84,223 @@ def _decision_lineage(decision: Mapping[str, Any]) -> dict[str, str]:
     }
 
 
-def _envelope_route(decision: Mapping[str, Any]) -> str | None:
-    """Return a coarse route for a fresh quota/scheduler decision.
+def _envelope_route(decision: Mapping[str, Any]) -> LoopXTurnRoute:
+    """Return the shared typed route for a fresh quota/scheduler decision.
 
-    Reuses the shared typed-route contract from the Turn plan driver, which
-    requires a matching action signature with non-empty equal hashes and an
-    in-budget compaction. A projected user action outranks delivery, so it is
-    resolved before the typed delivery route. Returns None when the envelope
+    Reuses the Turn plan driver's ``_typed_route`` contract, which requires a
+    matching action signature with non-empty equal hashes and an in-budget
+    compaction. A projected user action outranks delivery, so it is resolved
+    before the typed delivery route. Raises ``ValueError`` when the envelope
     fails the shared contract instead of accepting a forged or truncated
     decision.
     """
 
     route = _typed_route(decision)
     if route is LoopXTurnRoute.CONTRACT_ERROR:
-        return None
+        raise ValueError(
+            "quota decision failed the shared envelope contract "
+            "(schema, signature hashes, or compaction budget)"
+        )
     user = _mapping(decision.get("user"))
     if user.get("action_required") is True:
-        return LoopDisposition.USER_ACTION_REQUIRED.value
-    if route is LoopXTurnRoute.READY_FOR_HOST:
-        return LoopDisposition.RUN_NOW.value
-    if route is LoopXTurnRoute.REPLAN_REQUIRED:
-        return LoopDisposition.REPLAN.value
-    if route is LoopXTurnRoute.REPAIR_REQUIRED:
-        return LoopDisposition.REPAIR.value
-    return LoopDisposition.WAIT.value
+        return LoopXTurnRoute.USER_ACTION_REQUIRED
+    return route
+
+
+def _route_to_disposition(route: LoopXTurnRoute) -> LoopDisposition:
+    return {
+        LoopXTurnRoute.READY_FOR_HOST: LoopDisposition.RUN_NOW,
+        LoopXTurnRoute.REPLAN_REQUIRED: LoopDisposition.REPLAN,
+        LoopXTurnRoute.REPAIR_REQUIRED: LoopDisposition.REPAIR,
+        LoopXTurnRoute.USER_ACTION_REQUIRED: LoopDisposition.USER_ACTION_REQUIRED,
+        LoopXTurnRoute.WAIT: LoopDisposition.WAIT,
+        LoopXTurnRoute.BLOCKED: LoopDisposition.WAIT,
+    }[route]
+
+
+class ValidatedTurnReceipt:
+    """A Turn receipt proven by ``validate_loopx_turn_receipt``.
+
+    Only a successful ``loopx_turn_receipt_validation_v0`` result (``ok=true``)
+    with a supported result kind can construct one. The normalized
+    ``(goal_id, agent_id, todo_id)`` lineage is taken from the validation
+    result, so a caller cannot forge a completion by hand-writing
+    ``result_kind + lineage``.
+    """
+
+    __slots__ = ("result_kind", "status", "lineage", "turn_key")
+
+    def __init__(
+        self,
+        *,
+        result_kind: LoopXTurnResultKind,
+        status: str,
+        lineage: Mapping[str, str],
+        turn_key: str | None,
+    ) -> None:
+        self.result_kind = result_kind
+        self.status = status
+        self.lineage = {
+            "goal_id": str(lineage.get("goal_id") or ""),
+            "agent_id": str(lineage.get("agent_id") or ""),
+            "todo_id": str(lineage.get("todo_id") or ""),
+        }
+        self.turn_key = turn_key
+
+    @classmethod
+    def from_validation_result(
+        cls, validation_result: Mapping[str, Any]
+    ) -> "ValidatedTurnReceipt":
+        result = _mapping(validation_result)
+        if result.get("schema_version") != LOOPX_TURN_RECEIPT_VALIDATION_SCHEMA_VERSION:
+            raise ValueError(
+                "validated turn receipt requires schema_version="
+                f"{LOOPX_TURN_RECEIPT_VALIDATION_SCHEMA_VERSION}"
+            )
+        if result.get("ok") is not True:
+            raise ValueError("validated turn receipt requires ok=true")
+        raw_kind = result.get("result_kind")
+        try:
+            result_kind = LoopXTurnResultKind(str(raw_kind or ""))
+        except ValueError:
+            raise ValueError(
+                f"validated turn receipt has unsupported result_kind {raw_kind!r}"
+            ) from None
+        lineage = _mapping(result.get("lineage"))
+        if not all(lineage.get(k) for k in ("goal_id", "agent_id", "todo_id")):
+            raise ValueError(
+                "validated turn receipt is missing goal/agent/todo lineage"
+            )
+        return cls(
+            result_kind=result_kind,
+            status=str(result.get("status") or ""),
+            lineage=lineage,
+            turn_key=str(result.get("turn_key") or "") or None,
+        )
+
+    def to_mapping(self) -> dict[str, Any]:
+        return {
+            "schema_version": VALIDATED_TURN_RECEIPT_SCHEMA_VERSION,
+            "result_kind": self.result_kind.value,
+            "status": self.status,
+            "lineage": dict(self.lineage),
+            "turn_key": self.turn_key,
+        }
+
+
+class BoundedTurnBudget:
+    """A provider-neutral bounded Turn budget tied to one lineage.
+
+    Construction enforces strict integer domains (booleans are rejected) and a
+    sane range, so the transition never guesses an unbounded continuation.
+    """
+
+    __slots__ = ("lineage", "max_turns", "completed_turns")
+
+    def __init__(
+        self,
+        *,
+        lineage: Mapping[str, str],
+        max_turns: int,
+        completed_turns: int,
+    ) -> None:
+        if type(max_turns) is not int:
+            raise ValueError("bounded turn budget max_turns must be an int")
+        if type(completed_turns) is not int:
+            raise ValueError("bounded turn budget completed_turns must be an int")
+        if max_turns <= 0:
+            raise ValueError("bounded turn budget max_turns must be > 0")
+        if completed_turns < 0:
+            raise ValueError("bounded turn budget completed_turns must be >= 0")
+        if completed_turns > max_turns:
+            raise ValueError(
+                "bounded turn budget completed_turns must be <= max_turns"
+            )
+        self.lineage = {
+            "goal_id": str(lineage.get("goal_id") or ""),
+            "agent_id": str(lineage.get("agent_id") or ""),
+            "todo_id": str(lineage.get("todo_id") or ""),
+        }
+        if not all(self.lineage.values()):
+            raise ValueError("bounded turn budget is missing goal/agent/todo lineage")
+        self.max_turns = max_turns
+        self.completed_turns = completed_turns
+
+    def to_mapping(self) -> dict[str, Any]:
+        return {
+            "schema_version": BOUNDED_TURN_BUDGET_SCHEMA_VERSION,
+            "lineage": dict(self.lineage),
+            "max_turns": self.max_turns,
+            "completed_turns": self.completed_turns,
+        }
+
+    @property
+    def remaining(self) -> int:
+        return self.max_turns - self.completed_turns
+
+
+def _assert_lineage_match(
+    *,
+    receipt_lineage: Mapping[str, str],
+    decision_lineage: Mapping[str, str],
+) -> None:
+    for key in ("goal_id", "agent_id", "todo_id"):
+        if receipt_lineage.get(key) != decision_lineage.get(key):
+            raise ValueError(
+                "stale_receipt: receipt lineage does not match the fresh decision "
+                f"on {key} (receipt={receipt_lineage.get(key)!r}, "
+                f"decision={decision_lineage.get(key)!r})"
+            )
 
 
 def decide_loop_disposition(
     *,
-    turn_receipt: Mapping[str, Any] | None,
+    turn_receipt: ValidatedTurnReceipt | None,
     quota_decision: Mapping[str, Any],
-    bounded_turn_budget: Mapping[str, Any] | None = None,
+    bounded_turn_budget: BoundedTurnBudget | None = None,
 ) -> dict[str, Any]:
-    """Decide the next loop disposition from one receipt and a fresh decision.
+    """Decide the next loop disposition from one validated receipt and a fresh decision.
 
-    `turn_receipt` is one `loopx_turn_receipt_v0`-shaped mapping (result kind,
-    optional validation status, optional lineage). `quota_decision` is a fresh
-    `loopx_turn_envelope_v0`. `bounded_turn_budget` may carry `max_turns` and
-    `completed_turns` so validated progress can exhaust a bounded sequence.
+    ``turn_receipt`` is a :class:`ValidatedTurnReceipt` (or ``None`` when no
+    prior Turn has committed). ``quota_decision`` is a fresh
+    ``loopx_turn_envelope_v0``. ``bounded_turn_budget`` is a
+    :class:`BoundedTurnBudget` and is required when the receipt is
+    ``validated_progress`` so continuation can prove a bound.
 
     The function is pure: it launches no host, writes no state, and spends no
-    quota. Unknown or contradictory input fails closed to a typed wait or
-    contract-error disposition instead of guessing.
+    quota. Invalid or stale input raises ``ValueError`` at the typed-input
+    boundary; the transition output space is always one of the six
+    :class:`LoopDisposition` values.
     """
 
     route = _envelope_route(quota_decision)
-    if route is None:
-        return _disposition(
-            LoopDisposition.CONTRACT_ERROR,
-            reason="quota decision failed the shared envelope contract (schema, signature hashes, or compaction budget)",
-        )
     decision_lineage = _decision_lineage(quota_decision)
+    if not all(decision_lineage.values()):
+        raise ValueError(
+            "fresh quota decision is missing goal/agent/todo lineage"
+        )
 
     if turn_receipt is None:
-        if route == LoopDisposition.RUN_NOW.value:
-            return _disposition(
-                LoopDisposition.RUN_NOW,
-                reason="no prior receipt and fresh decision allows delivery",
-                lineage=decision_lineage,
-            )
-        if route == LoopDisposition.REPLAN.value:
-            return _replan_disposition(reason="fresh decision requires replan", decision_lineage=decision_lineage)
-        if route == LoopDisposition.REPAIR.value:
-            return _disposition(
-                LoopDisposition.REPAIR,
-                reason="fresh decision requires repair",
-                lineage=decision_lineage,
+        disposition = _route_to_disposition(route)
+        if disposition is LoopDisposition.REPLAN:
+            return _replan_disposition(
+                reason="fresh decision requires replan",
+                decision_lineage=decision_lineage,
             )
         return _disposition(
-            LoopDisposition.WAIT,
-            reason="fresh decision is a quiet no-spend wait",
+            disposition,
+            reason=_no_receipt_reason(disposition),
             lineage=decision_lineage,
         )
 
-    receipt = _mapping(turn_receipt)
-    raw_kind = str(receipt.get("result_kind") or "")
-    try:
-        result_kind = LoopXTurnResultKind(raw_kind)
-    except ValueError:
-        return _disposition(
-            LoopDisposition.CONTRACT_ERROR,
-            reason=f"unsupported turn receipt result_kind {raw_kind!r}",
-            lineage=decision_lineage,
-        )
+    _assert_lineage_match(
+        receipt_lineage=turn_receipt.lineage,
+        decision_lineage=decision_lineage,
+    )
+    result_kind = turn_receipt.result_kind
 
-    if route == LoopDisposition.USER_ACTION_REQUIRED.value and result_kind is not LoopXTurnResultKind.VALIDATED_COMPLETION:
-        return _disposition(
-            LoopDisposition.USER_ACTION_REQUIRED,
-            reason="fresh decision projects a concrete user action",
-            lineage=decision_lineage,
-        )
-
-    receipt_lineage = _receipt_lineage(receipt)
-    if result_kind in {
-        LoopXTurnResultKind.VALIDATED_COMPLETION,
-        LoopXTurnResultKind.VALIDATED_PROGRESS,
-    } and not all(receipt_lineage.values()):
-        # A validated material result without proven lineage cannot be
-        # distinguished from a forged completion; fail closed.
-        return _disposition(
-            LoopDisposition.CONTRACT_ERROR,
-            reason="validated material receipt is missing goal/agent/todo lineage",
-            lineage=decision_lineage,
-        )
-    if all(receipt_lineage.values()) and all(decision_lineage.values()):
-        mismatched = {
-            key
-            for key in ("goal_id", "agent_id")
-            if receipt_lineage[key] != decision_lineage[key]
-        }
-        if mismatched:
-            return _disposition(
-                LoopDisposition.CONTRACT_ERROR,
-                reason="stale_receipt: receipt lineage does not match the fresh decision",
-                lineage=decision_lineage,
-                extra={"stale_receipt_lineage": receipt_lineage},
-            )
-
+    # A met terminal postcondition outranks a decision-only user action, but
+    # only after the receipt is proven valid and fresh (above).
     if result_kind is LoopXTurnResultKind.VALIDATED_COMPLETION:
         return _disposition(
             LoopDisposition.TERMINAL,
@@ -200,45 +308,46 @@ def decide_loop_disposition(
             lineage=decision_lineage,
         )
 
+    # Decision user action outranks every non-terminal disposition.
+    if route is LoopXTurnRoute.USER_ACTION_REQUIRED:
+        return _disposition(
+            LoopDisposition.USER_ACTION_REQUIRED,
+            reason="fresh decision projects a concrete user action",
+            lineage=decision_lineage,
+        )
+
     if result_kind is LoopXTurnResultKind.VALIDATED_PROGRESS:
-        budget = _mapping(bounded_turn_budget)
-        max_turns = budget.get("max_turns")
-        completed_turns = budget.get("completed_turns")
-        budget_proven = isinstance(max_turns, int) and isinstance(completed_turns, int)
-        if not budget_proven:
-            return _disposition(
-                LoopDisposition.CONTRACT_ERROR,
-                reason="validated progress cannot continue without a proven bounded turn budget",
-                lineage=decision_lineage,
+        if bounded_turn_budget is None:
+            raise ValueError(
+                "validated progress cannot continue without a proven bounded turn budget"
             )
-        if completed_turns >= max_turns:
+        _assert_lineage_match(
+            receipt_lineage=bounded_turn_budget.lineage,
+            decision_lineage=decision_lineage,
+        )
+        if bounded_turn_budget.remaining <= 0:
             return _disposition(
                 LoopDisposition.TERMINAL,
                 reason="bounded turn budget exhausted after validated progress",
                 lineage=decision_lineage,
             )
-        if route == LoopDisposition.RUN_NOW.value:
-            return _disposition(
-                LoopDisposition.RUN_NOW,
-                reason="validated progress with fresh decision allowing the next turn",
-                lineage=decision_lineage,
-            )
-        if route == LoopDisposition.REPLAN.value:
-            return _replan_disposition(reason="fresh decision requires replan after progress", decision_lineage=decision_lineage)
-        if route == LoopDisposition.REPAIR.value:
-            return _disposition(
-                LoopDisposition.REPAIR,
-                reason="fresh decision requires repair after progress",
-                lineage=decision_lineage,
+        disposition = _route_to_disposition(route)
+        if disposition is LoopDisposition.REPLAN:
+            return _replan_disposition(
+                reason="fresh decision requires replan after progress",
+                decision_lineage=decision_lineage,
             )
         return _disposition(
-            LoopDisposition.WAIT,
-            reason="validated progress but fresh decision does not allow the next turn yet",
+            disposition,
+            reason=_progress_reason(disposition),
             lineage=decision_lineage,
         )
 
     if result_kind is LoopXTurnResultKind.REPLAN_REQUIRED:
-        return _replan_disposition(reason="turn receipt requires replan", decision_lineage=decision_lineage)
+        return _replan_disposition(
+            reason="turn receipt requires replan",
+            decision_lineage=decision_lineage,
+        )
 
     if result_kind is LoopXTurnResultKind.REPAIR_REQUIRED:
         return _disposition(
@@ -265,12 +374,35 @@ def decide_loop_disposition(
     # the loop must not guess recovery on its own; hold for repair routing.
     return _disposition(
         LoopDisposition.REPAIR,
-        reason=f"turn receipt ended in {result_kind.value}; route to repair before any successor turn",
+        reason=(
+            f"turn receipt ended in {result_kind.value}; "
+            "route to repair before any successor turn"
+        ),
         lineage=decision_lineage,
     )
 
 
-def _replan_disposition(*, reason: str, decision_lineage: Mapping[str, str]) -> dict[str, Any]:
+def _no_receipt_reason(disposition: LoopDisposition) -> str:
+    return {
+        LoopDisposition.RUN_NOW: "no prior receipt and fresh decision allows delivery",
+        LoopDisposition.WAIT: "fresh decision is a quiet no-spend wait",
+        LoopDisposition.REPAIR: "fresh decision requires repair",
+        LoopDisposition.USER_ACTION_REQUIRED: "fresh decision projects a concrete user action",
+    }[disposition]
+
+
+def _progress_reason(disposition: LoopDisposition) -> str:
+    return {
+        LoopDisposition.RUN_NOW: "validated progress with fresh decision allowing the next turn",
+        LoopDisposition.WAIT: "validated progress but fresh decision does not allow the next turn yet",
+        LoopDisposition.REPAIR: "fresh decision requires repair after progress",
+        LoopDisposition.USER_ACTION_REQUIRED: "fresh decision projects a concrete user action",
+    }[disposition]
+
+
+def _replan_disposition(
+    *, reason: str, decision_lineage: Mapping[str, str]
+) -> dict[str, Any]:
     return _disposition(
         LoopDisposition.REPLAN,
         reason=reason,

--- a/loopx/control_plane/turn_driver/loop_controller.py
+++ b/loopx/control_plane/turn_driver/loop_controller.py
@@ -34,9 +34,13 @@ LOOP_CONTROLLER_DISPOSITION_SCHEMA_VERSION = "loop_turn_loop_disposition_v0"
 BOUNDED_TURN_BUDGET_SCHEMA_VERSION = "loop_bounded_turn_budget_v0"
 VALIDATED_TURN_RECEIPT_SCHEMA_VERSION = "loop_validated_turn_receipt_v0"
 
-# Statuses that prove a material result has been independently validated and
-# may therefore drive a terminal or progress transition.
-_VALIDATED_RECEIPT_STATUSES = {"validated", "committed"}
+# Material result kinds that prove a durable delivery effect and may therefore
+# drive a terminal or progress transition. They require a fully committed
+# transaction (all seven phases), not a validation-only intermediate.
+_MATERIAL_PROGRESS_KINDS = {
+    LoopXTurnResultKind.VALIDATED_COMPLETION,
+    LoopXTurnResultKind.VALIDATED_PROGRESS,
+}
 
 
 class LoopDisposition(str, Enum):
@@ -122,10 +126,13 @@ class ValidatedTurnReceipt:
     """A Turn receipt proven by ``validate_loopx_turn_receipt``.
 
     Only a successful ``loopx_turn_receipt_validation_v0`` result (``ok=true``)
-    with a supported result kind can construct one. The normalized
-    ``(goal_id, agent_id, todo_id)`` lineage is taken from the validation
-    result, so a caller cannot forge a completion by hand-writing
-    ``result_kind + lineage``.
+    with a supported result kind can construct one. Material progress results
+    (``validated_completion`` / ``validated_progress``) additionally require
+    ``status="committed"`` so the loop never terminates or continues before the
+    full ``run-once`` transaction (writeback, quota spend, scheduler apply/ack)
+    has closed. The ``turn_key`` binds the receipt to one concrete transaction
+    so a fresh envelope can prove causal succession via
+    ``predecessor_turn_key``.
     """
 
     __slots__ = ("result_kind", "status", "lineage", "turn_key")
@@ -166,16 +173,25 @@ class ValidatedTurnReceipt:
             raise ValueError(
                 f"validated turn receipt has unsupported result_kind {raw_kind!r}"
             ) from None
+        status = str(result.get("status") or "")
+        if result_kind in _MATERIAL_PROGRESS_KINDS and status != "committed":
+            raise ValueError(
+                f"material result {result_kind.value} requires a fully committed "
+                f"transaction (status=committed); got status={status!r}"
+            )
         lineage = _mapping(result.get("lineage"))
         if not all(lineage.get(k) for k in ("goal_id", "agent_id", "todo_id")):
             raise ValueError(
                 "validated turn receipt is missing goal/agent/todo lineage"
             )
+        turn_key = str(result.get("turn_key") or "") or None
+        if not turn_key:
+            raise ValueError("validated turn receipt is missing turn_key")
         return cls(
             result_kind=result_kind,
-            status=str(result.get("status") or ""),
+            status=status,
             lineage=lineage,
-            turn_key=str(result.get("turn_key") or "") or None,
+            turn_key=turn_key,
         )
 
     def to_mapping(self) -> dict[str, Any]:
@@ -253,6 +269,47 @@ def _assert_lineage_match(
             )
 
 
+def _assert_budget_lineage_match(
+    *,
+    budget_lineage: Mapping[str, str],
+    decision_lineage: Mapping[str, str],
+) -> None:
+    for key in ("goal_id", "agent_id", "todo_id"):
+        if budget_lineage.get(key) != decision_lineage.get(key):
+            raise ValueError(
+                "stale_budget: budget lineage does not match the fresh decision "
+                f"on {key} (budget={budget_lineage.get(key)!r}, "
+                f"decision={decision_lineage.get(key)!r})"
+            )
+
+
+def _assert_predecessor_binding(
+    *,
+    receipt: ValidatedTurnReceipt,
+    decision: Mapping[str, Any],
+) -> None:
+    """Prove the fresh envelope causally succeeds the receipt.
+
+    The envelope must declare ``predecessor_turn_key`` equal to the receipt's
+    ``turn_key``. Without this binding an old receipt for the same todo could
+    be replayed against any later envelope. A missing or mismatched key raises
+    ``ValueError`` (``stale_receipt``) rather than guessing succession.
+    """
+
+    predecessor = str(decision.get("predecessor_turn_key") or "")
+    if not predecessor:
+        raise ValueError(
+            "stale_receipt: fresh decision is missing predecessor_turn_key; "
+            "cannot prove causal succession from the receipt"
+        )
+    if predecessor != receipt.turn_key:
+        raise ValueError(
+            "stale_receipt: fresh decision predecessor_turn_key "
+            f"({predecessor!r}) does not match the receipt turn_key "
+            f"({receipt.turn_key!r})"
+        )
+
+
 def decide_loop_disposition(
     *,
     turn_receipt: ValidatedTurnReceipt | None,
@@ -263,7 +320,8 @@ def decide_loop_disposition(
 
     ``turn_receipt`` is a :class:`ValidatedTurnReceipt` (or ``None`` when no
     prior Turn has committed). ``quota_decision`` is a fresh
-    ``loopx_turn_envelope_v0``. ``bounded_turn_budget`` is a
+    ``loopx_turn_envelope_v0`` that must declare ``predecessor_turn_key``
+    matching the receipt when one is supplied. ``bounded_turn_budget`` is a
     :class:`BoundedTurnBudget` and is required when the receipt is
     ``validated_progress`` so continuation can prove a bound.
 
@@ -293,14 +351,19 @@ def decide_loop_disposition(
             lineage=decision_lineage,
         )
 
+    # Prove the envelope causally succeeds this exact receipt before any
+    # disposition is considered. This closes the stale-replay gap: an old
+    # receipt for the same todo cannot be replayed against a later envelope.
+    _assert_predecessor_binding(receipt=turn_receipt, decision=quota_decision)
     _assert_lineage_match(
         receipt_lineage=turn_receipt.lineage,
         decision_lineage=decision_lineage,
     )
+
     result_kind = turn_receipt.result_kind
 
     # A met terminal postcondition outranks a decision-only user action, but
-    # only after the receipt is proven valid and fresh (above).
+    # only after the receipt is proven valid, fresh, and fully committed.
     if result_kind is LoopXTurnResultKind.VALIDATED_COMPLETION:
         return _disposition(
             LoopDisposition.TERMINAL,
@@ -321,8 +384,8 @@ def decide_loop_disposition(
             raise ValueError(
                 "validated progress cannot continue without a proven bounded turn budget"
             )
-        _assert_lineage_match(
-            receipt_lineage=bounded_turn_budget.lineage,
+        _assert_budget_lineage_match(
+            budget_lineage=bounded_turn_budget.lineage,
             decision_lineage=decision_lineage,
         )
         if bounded_turn_budget.remaining <= 0:

--- a/loopx/control_plane/turn_driver/transaction.py
+++ b/loopx/control_plane/turn_driver/transaction.py
@@ -152,6 +152,11 @@ def build_loopx_turn_transaction_plan(
         "schema_version": LOOPX_TURN_TRANSACTION_PLAN_SCHEMA_VERSION,
         "status": "planned" if planned else "not_applicable",
         "turn_key": turn_key,
+        "lineage": {
+            "goal_id": str(lineage.get("goal_id") or ""),
+            "agent_id": str(lineage.get("agent_id") or ""),
+            "todo_id": str(lineage.get("todo_id") or ""),
+        },
         "phases": list(TRANSACTION_PHASES) if planned else [],
         "commit_policy": "result<validate<writeback<spend;apply<ack;cadence:no-spend",
         "receipt_seed": {
@@ -244,6 +249,11 @@ def validate_loopx_turn_receipt(
         "ok": ok,
         "schema_version": LOOPX_TURN_RECEIPT_VALIDATION_SCHEMA_VERSION,
         "turn_key": turn_key or None,
+        "lineage": {
+            "goal_id": str(plan.get("lineage", {}).get("goal_id") or ""),
+            "agent_id": str(plan.get("lineage", {}).get("agent_id") or ""),
+            "todo_id": str(plan.get("lineage", {}).get("todo_id") or ""),
+        },
         "result_kind": kind.value if kind is not None else None,
         "completed_phases": completed,
         "failed_phase": failed_phase,

--- a/tests/test_loop_turn_loop_controller.py
+++ b/tests/test_loop_turn_loop_controller.py
@@ -28,13 +28,18 @@ def _envelope(
     agent_id: str = "agent-1",
     signature_matches: bool = True,
 ) -> dict[str, object]:
+    signature: dict[str, object] = {"matches": signature_matches}
+    if signature_matches:
+        signature["source_hash"] = "sha256:test"
+        signature["envelope_hash"] = "sha256:test"
     return {
         "schema_version": "loopx_turn_envelope_v0",
         "goal_id": goal_id,
         "agent_id": agent_id,
         "should_run": should_run,
         "effective_action": effective_action,
-        "action_signature": {"matches": signature_matches},
+        "action_signature": signature,
+        "compaction": {"within_budget": True},
         "action": {
             "delivery_allowed": delivery_allowed,
             "must_attempt": must_attempt,
@@ -113,8 +118,18 @@ def test_validated_progress_without_delivery_decision_waits() -> None:
     payload = decide_loop_disposition(
         turn_receipt=_receipt("validated_progress"),
         quota_decision=_envelope(should_run=False, quiet_noop_allowed=True),
+        bounded_turn_budget={"max_turns": 3, "completed_turns": 1},
     )
     _assert_markers(payload, "wait")
+
+
+def test_validated_progress_without_bounded_budget_fails_closed() -> None:
+    payload = decide_loop_disposition(
+        turn_receipt=_receipt("validated_progress"),
+        quota_decision=_envelope(should_run=True),
+    )
+    _assert_markers(payload, "contract_error")
+    assert "bounded turn budget" in str(payload["reason"])
 
 
 def test_repair_receipt_routes_to_repair() -> None:
@@ -159,14 +174,14 @@ def test_user_action_from_decision_wins_even_with_receipt() -> None:
     payload = decide_loop_disposition(
         turn_receipt=_receipt("validated_progress"),
         quota_decision=_envelope(should_run=True, user_action_required=True),
+        bounded_turn_budget={"max_turns": 3, "completed_turns": 1},
     )
     _assert_markers(payload, "user_action_required")
 
 
 def test_validated_completion_wins_over_decision_user_action() -> None:
     # Precedence: a met terminal postcondition is stronger than a decision-only
-    # user action; a completed loop must not stay non-terminal behind a stale
-    # gate projection.
+    # user action, but only after the receipt is proven valid and fresh.
     payload = decide_loop_disposition(
         turn_receipt=_receipt("validated_completion"),
         quota_decision=_envelope(should_run=True, user_action_required=True),
@@ -196,14 +211,32 @@ def test_failure_receipts_route_to_repair(failure_kind: str) -> None:
     assert failure_kind in str(payload["reason"])
 
 
-def test_stale_receipt_lineage_fails_closed_to_wait() -> None:
+def test_stale_receipt_lineage_fails_closed_to_contract_error() -> None:
     payload = decide_loop_disposition(
         turn_receipt=_receipt("validated_progress", agent_id="agent-2"),
         quota_decision=_envelope(should_run=True, agent_id="agent-1"),
     )
-    _assert_markers(payload, "wait")
+    _assert_markers(payload, "contract_error")
     assert "stale_receipt" in str(payload["reason"])
     assert payload["stale_receipt_lineage"]["agent_id"] == "agent-2"
+
+
+def test_stale_completion_receipt_fails_closed_not_terminal() -> None:
+    payload = decide_loop_disposition(
+        turn_receipt=_receipt("validated_completion", agent_id="agent-2"),
+        quota_decision=_envelope(should_run=True, agent_id="agent-1"),
+    )
+    _assert_markers(payload, "contract_error")
+    assert "stale_receipt" in str(payload["reason"])
+
+
+def test_bare_completion_mapping_fails_closed_not_terminal() -> None:
+    payload = decide_loop_disposition(
+        turn_receipt={"result_kind": "validated_completion"},
+        quota_decision=_envelope(should_run=True),
+    )
+    _assert_markers(payload, "contract_error")
+    assert "lineage" in str(payload["reason"])
 
 
 def test_malformed_decision_fails_closed_as_contract_error() -> None:
@@ -211,8 +244,41 @@ def test_malformed_decision_fails_closed_as_contract_error() -> None:
         turn_receipt=None,
         quota_decision={"schema_version": "not_an_envelope"},
     )
-    _assert_markers(payload, "wait")
-    assert "contract_error" in str(payload["reason"])
+    _assert_markers(payload, "contract_error")
+
+
+def test_marker_only_signature_fails_closed() -> None:
+    envelope = _envelope(should_run=True)
+    envelope["action_signature"] = {"matches": True}
+    payload = decide_loop_disposition(
+        turn_receipt=None,
+        quota_decision=envelope,
+    )
+    _assert_markers(payload, "contract_error")
+
+
+def test_mismatched_signature_hashes_fail_closed() -> None:
+    envelope = _envelope(should_run=True)
+    envelope["action_signature"] = {
+        "matches": True,
+        "source_hash": "sha256:a",
+        "envelope_hash": "sha256:b",
+    }
+    payload = decide_loop_disposition(
+        turn_receipt=None,
+        quota_decision=envelope,
+    )
+    _assert_markers(payload, "contract_error")
+
+
+def test_over_budget_compaction_fails_closed() -> None:
+    envelope = _envelope(should_run=True)
+    envelope["compaction"] = {"within_budget": False}
+    payload = decide_loop_disposition(
+        turn_receipt=None,
+        quota_decision=envelope,
+    )
+    _assert_markers(payload, "contract_error")
 
 
 def test_mismatched_signature_fails_closed() -> None:
@@ -220,8 +286,7 @@ def test_mismatched_signature_fails_closed() -> None:
         turn_receipt=None,
         quota_decision=_envelope(should_run=True, signature_matches=False),
     )
-    _assert_markers(payload, "wait")
-    assert "contract_error" in str(payload["reason"])
+    _assert_markers(payload, "contract_error")
 
 
 def test_unknown_receipt_kind_fails_closed() -> None:
@@ -229,8 +294,7 @@ def test_unknown_receipt_kind_fails_closed() -> None:
         turn_receipt={"result_kind": "made_up_kind"},
         quota_decision=_envelope(should_run=True),
     )
-    _assert_markers(payload, "wait")
-    assert "contract_error" in str(payload["reason"])
+    _assert_markers(payload, "contract_error")
 
 
 def test_repair_decision_routes_to_repair() -> None:

--- a/tests/test_loop_turn_loop_controller.py
+++ b/tests/test_loop_turn_loop_controller.py
@@ -1,0 +1,237 @@
+"""Decision-table tests for the pure Turn Loop Controller transition.
+
+Each row pairs one Turn receipt with one fresh quota/scheduler decision and
+asserts exactly one typed disposition. The controller must never launch a
+host, write state, or spend quota; every row also asserts those markers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from loopx.control_plane.turn_driver.loop_controller import (
+    LOOP_CONTROLLER_DISPOSITION_SCHEMA_VERSION,
+    decide_loop_disposition,
+)
+
+
+def _envelope(
+    *,
+    should_run: bool,
+    effective_action: str = "deliver",
+    delivery_allowed: bool = True,
+    must_attempt: bool = True,
+    user_action_required: bool = False,
+    quiet_noop_allowed: bool = False,
+    todo_id: str = "todo-1",
+    goal_id: str = "goal-1",
+    agent_id: str = "agent-1",
+    signature_matches: bool = True,
+) -> dict[str, object]:
+    return {
+        "schema_version": "loopx_turn_envelope_v0",
+        "goal_id": goal_id,
+        "agent_id": agent_id,
+        "should_run": should_run,
+        "effective_action": effective_action,
+        "action_signature": {"matches": signature_matches},
+        "action": {
+            "delivery_allowed": delivery_allowed,
+            "must_attempt": must_attempt,
+            "quiet_noop_allowed": quiet_noop_allowed,
+            "selected_todo": {"todo_id": todo_id},
+        },
+        "user": {"action_required": user_action_required},
+    }
+
+
+def _receipt(
+    result_kind: str,
+    *,
+    goal_id: str = "goal-1",
+    agent_id: str = "agent-1",
+    todo_id: str = "todo-1",
+) -> dict[str, object]:
+    return {
+        "result_kind": result_kind,
+        "lineage": {"goal_id": goal_id, "agent_id": agent_id, "todo_id": todo_id},
+    }
+
+
+def _assert_markers(payload: dict[str, object], disposition: str) -> None:
+    assert payload["schema_version"] == LOOP_CONTROLLER_DISPOSITION_SCHEMA_VERSION
+    assert payload["disposition"] == disposition
+    assert payload["spends_quota"] is False
+    assert payload["launches_host"] is False
+    assert payload["writes_state"] is False
+
+
+def test_no_receipt_with_delivery_decision_runs_now() -> None:
+    payload = decide_loop_disposition(
+        turn_receipt=None,
+        quota_decision=_envelope(should_run=True),
+    )
+    _assert_markers(payload, "run_now")
+
+
+def test_no_receipt_with_quiet_decision_waits_no_spend() -> None:
+    payload = decide_loop_disposition(
+        turn_receipt=None,
+        quota_decision=_envelope(should_run=False, quiet_noop_allowed=True),
+    )
+    _assert_markers(payload, "wait")
+
+
+def test_validated_completion_is_terminal() -> None:
+    payload = decide_loop_disposition(
+        turn_receipt=_receipt("validated_completion"),
+        quota_decision=_envelope(should_run=True),
+    )
+    _assert_markers(payload, "terminal")
+
+
+def test_validated_progress_with_budget_runs_now() -> None:
+    payload = decide_loop_disposition(
+        turn_receipt=_receipt("validated_progress"),
+        quota_decision=_envelope(should_run=True),
+        bounded_turn_budget={"max_turns": 3, "completed_turns": 1},
+    )
+    _assert_markers(payload, "run_now")
+
+
+def test_validated_progress_with_exhausted_budget_is_terminal() -> None:
+    payload = decide_loop_disposition(
+        turn_receipt=_receipt("validated_progress"),
+        quota_decision=_envelope(should_run=True),
+        bounded_turn_budget={"max_turns": 3, "completed_turns": 3},
+    )
+    _assert_markers(payload, "terminal")
+    assert "budget" in str(payload["reason"])
+
+
+def test_validated_progress_without_delivery_decision_waits() -> None:
+    payload = decide_loop_disposition(
+        turn_receipt=_receipt("validated_progress"),
+        quota_decision=_envelope(should_run=False, quiet_noop_allowed=True),
+    )
+    _assert_markers(payload, "wait")
+
+
+def test_repair_receipt_routes_to_repair() -> None:
+    payload = decide_loop_disposition(
+        turn_receipt=_receipt("repair_required"),
+        quota_decision=_envelope(should_run=True),
+    )
+    _assert_markers(payload, "repair")
+
+
+def test_replan_receipt_requires_bounded_delta_before_successor() -> None:
+    payload = decide_loop_disposition(
+        turn_receipt=_receipt("replan_required"),
+        quota_decision=_envelope(should_run=True, effective_action="autonomous_replan"),
+    )
+    _assert_markers(payload, "replan")
+    continuation = payload["replan_continuation"]
+    assert continuation["requires_bounded_delta"] is True
+    assert continuation["stale_todo_rerun_allowed"] is False
+    assert continuation["fresh_envelope_required"] is True
+    assert "todo_delta" in continuation["delta_kinds"]
+
+
+def test_replan_decision_without_receipt_also_requires_delta() -> None:
+    payload = decide_loop_disposition(
+        turn_receipt=None,
+        quota_decision=_envelope(should_run=True, effective_action="autonomous_replan_required"),
+    )
+    _assert_markers(payload, "replan")
+    assert payload["replan_continuation"]["stale_todo_rerun_allowed"] is False
+
+
+def test_user_action_from_receipt_wins() -> None:
+    payload = decide_loop_disposition(
+        turn_receipt=_receipt("user_action_required"),
+        quota_decision=_envelope(should_run=True),
+    )
+    _assert_markers(payload, "user_action_required")
+
+
+def test_user_action_from_decision_wins_even_with_receipt() -> None:
+    payload = decide_loop_disposition(
+        turn_receipt=_receipt("validated_progress"),
+        quota_decision=_envelope(should_run=True, user_action_required=True),
+    )
+    _assert_markers(payload, "user_action_required")
+
+
+def test_wait_receipt_waits() -> None:
+    payload = decide_loop_disposition(
+        turn_receipt=_receipt("wait"),
+        quota_decision=_envelope(should_run=True),
+    )
+    _assert_markers(payload, "wait")
+
+
+@pytest.mark.parametrize(
+    "failure_kind",
+    ["host_failure", "validation_failed", "writeback_failed", "quota_spend_failed"],
+)
+def test_failure_receipts_route_to_repair(failure_kind: str) -> None:
+    payload = decide_loop_disposition(
+        turn_receipt=_receipt(failure_kind),
+        quota_decision=_envelope(should_run=True),
+    )
+    _assert_markers(payload, "repair")
+    assert failure_kind in str(payload["reason"])
+
+
+def test_stale_receipt_lineage_fails_closed_to_wait() -> None:
+    payload = decide_loop_disposition(
+        turn_receipt=_receipt("validated_progress", agent_id="agent-2"),
+        quota_decision=_envelope(should_run=True, agent_id="agent-1"),
+    )
+    _assert_markers(payload, "wait")
+    assert "stale_receipt" in str(payload["reason"])
+    assert payload["stale_receipt_lineage"]["agent_id"] == "agent-2"
+
+
+def test_malformed_decision_fails_closed_as_contract_error() -> None:
+    payload = decide_loop_disposition(
+        turn_receipt=None,
+        quota_decision={"schema_version": "not_an_envelope"},
+    )
+    _assert_markers(payload, "wait")
+    assert "contract_error" in str(payload["reason"])
+
+
+def test_mismatched_signature_fails_closed() -> None:
+    payload = decide_loop_disposition(
+        turn_receipt=None,
+        quota_decision=_envelope(should_run=True, signature_matches=False),
+    )
+    _assert_markers(payload, "wait")
+    assert "contract_error" in str(payload["reason"])
+
+
+def test_unknown_receipt_kind_fails_closed() -> None:
+    payload = decide_loop_disposition(
+        turn_receipt={"result_kind": "made_up_kind"},
+        quota_decision=_envelope(should_run=True),
+    )
+    _assert_markers(payload, "wait")
+    assert "contract_error" in str(payload["reason"])
+
+
+def test_repair_decision_routes_to_repair() -> None:
+    payload = decide_loop_disposition(
+        turn_receipt=None,
+        quota_decision=_envelope(should_run=True, effective_action="workspace_repair"),
+    )
+    _assert_markers(payload, "repair")
+
+
+def test_delivery_blocked_decision_waits() -> None:
+    payload = decide_loop_disposition(
+        turn_receipt=None,
+        quota_decision=_envelope(should_run=True, delivery_allowed=False),
+    )
+    _assert_markers(payload, "wait")

--- a/tests/test_loop_turn_loop_controller.py
+++ b/tests/test_loop_turn_loop_controller.py
@@ -163,6 +163,18 @@ def test_user_action_from_decision_wins_even_with_receipt() -> None:
     _assert_markers(payload, "user_action_required")
 
 
+def test_validated_completion_wins_over_decision_user_action() -> None:
+    # Precedence: a met terminal postcondition is stronger than a decision-only
+    # user action; a completed loop must not stay non-terminal behind a stale
+    # gate projection.
+    payload = decide_loop_disposition(
+        turn_receipt=_receipt("validated_completion"),
+        quota_decision=_envelope(should_run=True, user_action_required=True),
+    )
+    _assert_markers(payload, "terminal")
+    assert "validated completion" in str(payload["reason"])
+
+
 def test_wait_receipt_waits() -> None:
     payload = decide_loop_disposition(
         turn_receipt=_receipt("wait"),

--- a/tests/test_loop_turn_loop_controller.py
+++ b/tests/test_loop_turn_loop_controller.py
@@ -1,18 +1,116 @@
 """Decision-table tests for the pure Turn Loop Controller transition.
 
-Each row pairs one Turn receipt with one fresh quota/scheduler decision and
-asserts exactly one typed disposition. The controller must never launch a
-host, write state, or spend quota; every row also asserts those markers.
+Each row pairs one validated Turn receipt with one fresh quota/scheduler
+decision and asserts exactly one typed disposition. The controller must never
+launch a host, write state, or spend quota; every row also asserts those
+markers.
+
+Receipts are produced through the real
+``build_loopx_turn_transaction_plan -> validate_loopx_turn_receipt`` path so
+the controller consumes only proven ``loopx_turn_receipt_validation_v0``
+output, never a caller-forged ``result_kind + lineage`` mapping.
 """
 
 from __future__ import annotations
 
 import pytest
 
+from loopx.control_plane.turn_driver import (
+    LOOPX_TURN_RESULT_SCHEMA_VERSION,
+    LoopXTurnResultKind,
+    build_loopx_turn_transaction_plan,
+    validate_loopx_turn_receipt,
+)
 from loopx.control_plane.turn_driver.loop_controller import (
+    BOUNDED_TURN_BUDGET_SCHEMA_VERSION,
     LOOP_CONTROLLER_DISPOSITION_SCHEMA_VERSION,
+    VALIDATED_TURN_RECEIPT_SCHEMA_VERSION,
+    BoundedTurnBudget,
+    ValidatedTurnReceipt,
     decide_loop_disposition,
 )
+
+
+def _lineage(
+    *,
+    goal_id: str = "goal-1",
+    agent_id: str = "agent-1",
+    todo_id: str = "todo-1",
+) -> dict[str, str]:
+    return {"goal_id": goal_id, "agent_id": agent_id, "todo_id": todo_id}
+
+
+def _plan(lineage: dict[str, str] | None = None) -> dict[str, object]:
+    return build_loopx_turn_transaction_plan(
+        planned=True,
+        lineage=_lineage() if lineage is None else lineage,
+        host="codex-cli",
+        execution_mode="interactive-visible",
+        session_action="resume",
+    )
+
+
+def _result(
+    plan: dict[str, object],
+    *,
+    result_kind: LoopXTurnResultKind = LoopXTurnResultKind.VALIDATED_PROGRESS,
+    completed_phases: list[str] | None = None,
+    failed_phase: str | None = None,
+) -> dict[str, object]:
+    result: dict[str, object] = {
+        "schema_version": LOOPX_TURN_RESULT_SCHEMA_VERSION,
+        "turn_key": plan["turn_key"],
+        "result_kind": result_kind.value,
+        "completed_phases": (
+            completed_phases
+            if completed_phases is not None
+            else ["host_execute", "typed_result", "validation"]
+        ),
+    }
+    if failed_phase:
+        result["failed_phase"] = failed_phase
+    return result
+
+
+_FAILURE_PHASES = {
+    LoopXTurnResultKind.HOST_FAILURE: ([], "host_execute"),
+    LoopXTurnResultKind.VALIDATION_FAILED: (
+        ["host_execute", "typed_result"],
+        "validation",
+    ),
+    LoopXTurnResultKind.WRITEBACK_FAILED: (
+        ["host_execute", "typed_result", "validation"],
+        "durable_writeback",
+    ),
+    LoopXTurnResultKind.QUOTA_SPEND_FAILED: (
+        ["host_execute", "typed_result", "validation", "durable_writeback"],
+        "quota_spend",
+    ),
+}
+_STOP_KINDS = {LoopXTurnResultKind.WAIT, LoopXTurnResultKind.USER_ACTION_REQUIRED}
+
+
+def _validated_receipt(
+    *,
+    result_kind: LoopXTurnResultKind = LoopXTurnResultKind.VALIDATED_PROGRESS,
+    lineage: dict[str, str] | None = None,
+    completed_phases: list[str] | None = None,
+    failed_phase: str | None = None,
+) -> ValidatedTurnReceipt:
+    plan = _plan(lineage=lineage)
+    if completed_phases is None and result_kind in _FAILURE_PHASES:
+        completed_phases, failed_phase = _FAILURE_PHASES[result_kind]
+    elif completed_phases is None and result_kind in _STOP_KINDS:
+        completed_phases = ["host_execute", "typed_result"]
+    result = _result(
+        plan,
+        result_kind=result_kind,
+        completed_phases=completed_phases,
+        failed_phase=failed_phase,
+    )
+    validation = validate_loopx_turn_receipt(plan, result)
+    assert validation["ok"] is True, validation
+    return ValidatedTurnReceipt.from_validation_result(validation)
 
 
 def _envelope(
@@ -23,19 +121,18 @@ def _envelope(
     must_attempt: bool = True,
     user_action_required: bool = False,
     quiet_noop_allowed: bool = False,
-    todo_id: str = "todo-1",
-    goal_id: str = "goal-1",
-    agent_id: str = "agent-1",
+    lineage: dict[str, str] | None = None,
     signature_matches: bool = True,
 ) -> dict[str, object]:
+    lin = _lineage() if lineage is None else lineage
     signature: dict[str, object] = {"matches": signature_matches}
     if signature_matches:
         signature["source_hash"] = "sha256:test"
         signature["envelope_hash"] = "sha256:test"
     return {
         "schema_version": "loopx_turn_envelope_v0",
-        "goal_id": goal_id,
-        "agent_id": agent_id,
+        "goal_id": lin["goal_id"],
+        "agent_id": lin["agent_id"],
         "should_run": should_run,
         "effective_action": effective_action,
         "action_signature": signature,
@@ -44,23 +141,23 @@ def _envelope(
             "delivery_allowed": delivery_allowed,
             "must_attempt": must_attempt,
             "quiet_noop_allowed": quiet_noop_allowed,
-            "selected_todo": {"todo_id": todo_id},
+            "selected_todo": {"todo_id": lin["todo_id"]},
         },
         "user": {"action_required": user_action_required},
     }
 
 
-def _receipt(
-    result_kind: str,
+def _budget(
     *,
-    goal_id: str = "goal-1",
-    agent_id: str = "agent-1",
-    todo_id: str = "todo-1",
-) -> dict[str, object]:
-    return {
-        "result_kind": result_kind,
-        "lineage": {"goal_id": goal_id, "agent_id": agent_id, "todo_id": todo_id},
-    }
+    max_turns: int = 3,
+    completed_turns: int = 1,
+    lineage: dict[str, str] | None = None,
+) -> BoundedTurnBudget:
+    return BoundedTurnBudget(
+        lineage=_lineage() if lineage is None else lineage,
+        max_turns=max_turns,
+        completed_turns=completed_turns,
+    )
 
 
 def _assert_markers(payload: dict[str, object], disposition: str) -> None:
@@ -89,7 +186,9 @@ def test_no_receipt_with_quiet_decision_waits_no_spend() -> None:
 
 def test_validated_completion_is_terminal() -> None:
     payload = decide_loop_disposition(
-        turn_receipt=_receipt("validated_completion"),
+        turn_receipt=_validated_receipt(
+            result_kind=LoopXTurnResultKind.VALIDATED_COMPLETION
+        ),
         quota_decision=_envelope(should_run=True),
     )
     _assert_markers(payload, "terminal")
@@ -97,18 +196,18 @@ def test_validated_completion_is_terminal() -> None:
 
 def test_validated_progress_with_budget_runs_now() -> None:
     payload = decide_loop_disposition(
-        turn_receipt=_receipt("validated_progress"),
+        turn_receipt=_validated_receipt(result_kind=LoopXTurnResultKind.VALIDATED_PROGRESS),
         quota_decision=_envelope(should_run=True),
-        bounded_turn_budget={"max_turns": 3, "completed_turns": 1},
+        bounded_turn_budget=_budget(max_turns=3, completed_turns=1),
     )
     _assert_markers(payload, "run_now")
 
 
 def test_validated_progress_with_exhausted_budget_is_terminal() -> None:
     payload = decide_loop_disposition(
-        turn_receipt=_receipt("validated_progress"),
+        turn_receipt=_validated_receipt(result_kind=LoopXTurnResultKind.VALIDATED_PROGRESS),
         quota_decision=_envelope(should_run=True),
-        bounded_turn_budget={"max_turns": 3, "completed_turns": 3},
+        bounded_turn_budget=_budget(max_turns=3, completed_turns=3),
     )
     _assert_markers(payload, "terminal")
     assert "budget" in str(payload["reason"])
@@ -116,25 +215,26 @@ def test_validated_progress_with_exhausted_budget_is_terminal() -> None:
 
 def test_validated_progress_without_delivery_decision_waits() -> None:
     payload = decide_loop_disposition(
-        turn_receipt=_receipt("validated_progress"),
+        turn_receipt=_validated_receipt(result_kind=LoopXTurnResultKind.VALIDATED_PROGRESS),
         quota_decision=_envelope(should_run=False, quiet_noop_allowed=True),
-        bounded_turn_budget={"max_turns": 3, "completed_turns": 1},
+        bounded_turn_budget=_budget(max_turns=3, completed_turns=1),
     )
     _assert_markers(payload, "wait")
 
 
-def test_validated_progress_without_bounded_budget_fails_closed() -> None:
-    payload = decide_loop_disposition(
-        turn_receipt=_receipt("validated_progress"),
-        quota_decision=_envelope(should_run=True),
-    )
-    _assert_markers(payload, "contract_error")
-    assert "bounded turn budget" in str(payload["reason"])
+def test_validated_progress_without_bounded_budget_raises() -> None:
+    with pytest.raises(ValueError, match="bounded turn budget"):
+        decide_loop_disposition(
+            turn_receipt=_validated_receipt(
+                result_kind=LoopXTurnResultKind.VALIDATED_PROGRESS
+            ),
+            quota_decision=_envelope(should_run=True),
+        )
 
 
 def test_repair_receipt_routes_to_repair() -> None:
     payload = decide_loop_disposition(
-        turn_receipt=_receipt("repair_required"),
+        turn_receipt=_validated_receipt(result_kind=LoopXTurnResultKind.REPAIR_REQUIRED),
         quota_decision=_envelope(should_run=True),
     )
     _assert_markers(payload, "repair")
@@ -142,7 +242,7 @@ def test_repair_receipt_routes_to_repair() -> None:
 
 def test_replan_receipt_requires_bounded_delta_before_successor() -> None:
     payload = decide_loop_disposition(
-        turn_receipt=_receipt("replan_required"),
+        turn_receipt=_validated_receipt(result_kind=LoopXTurnResultKind.REPLAN_REQUIRED),
         quota_decision=_envelope(should_run=True, effective_action="autonomous_replan"),
     )
     _assert_markers(payload, "replan")
@@ -156,7 +256,9 @@ def test_replan_receipt_requires_bounded_delta_before_successor() -> None:
 def test_replan_decision_without_receipt_also_requires_delta() -> None:
     payload = decide_loop_disposition(
         turn_receipt=None,
-        quota_decision=_envelope(should_run=True, effective_action="autonomous_replan_required"),
+        quota_decision=_envelope(
+            should_run=True, effective_action="autonomous_replan_required"
+        ),
     )
     _assert_markers(payload, "replan")
     assert payload["replan_continuation"]["stale_todo_rerun_allowed"] is False
@@ -164,7 +266,9 @@ def test_replan_decision_without_receipt_also_requires_delta() -> None:
 
 def test_user_action_from_receipt_wins() -> None:
     payload = decide_loop_disposition(
-        turn_receipt=_receipt("user_action_required"),
+        turn_receipt=_validated_receipt(
+            result_kind=LoopXTurnResultKind.USER_ACTION_REQUIRED
+        ),
         quota_decision=_envelope(should_run=True),
     )
     _assert_markers(payload, "user_action_required")
@@ -172,9 +276,9 @@ def test_user_action_from_receipt_wins() -> None:
 
 def test_user_action_from_decision_wins_even_with_receipt() -> None:
     payload = decide_loop_disposition(
-        turn_receipt=_receipt("validated_progress"),
+        turn_receipt=_validated_receipt(result_kind=LoopXTurnResultKind.VALIDATED_PROGRESS),
         quota_decision=_envelope(should_run=True, user_action_required=True),
-        bounded_turn_budget={"max_turns": 3, "completed_turns": 1},
+        bounded_turn_budget=_budget(max_turns=3, completed_turns=1),
     )
     _assert_markers(payload, "user_action_required")
 
@@ -183,7 +287,9 @@ def test_validated_completion_wins_over_decision_user_action() -> None:
     # Precedence: a met terminal postcondition is stronger than a decision-only
     # user action, but only after the receipt is proven valid and fresh.
     payload = decide_loop_disposition(
-        turn_receipt=_receipt("validated_completion"),
+        turn_receipt=_validated_receipt(
+            result_kind=LoopXTurnResultKind.VALIDATED_COMPLETION
+        ),
         quota_decision=_envelope(should_run=True, user_action_required=True),
     )
     _assert_markers(payload, "terminal")
@@ -192,7 +298,7 @@ def test_validated_completion_wins_over_decision_user_action() -> None:
 
 def test_wait_receipt_waits() -> None:
     payload = decide_loop_disposition(
-        turn_receipt=_receipt("wait"),
+        turn_receipt=_validated_receipt(result_kind=LoopXTurnResultKind.WAIT),
         quota_decision=_envelope(should_run=True),
     )
     _assert_markers(payload, "wait")
@@ -203,98 +309,103 @@ def test_wait_receipt_waits() -> None:
     ["host_failure", "validation_failed", "writeback_failed", "quota_spend_failed"],
 )
 def test_failure_receipts_route_to_repair(failure_kind: str) -> None:
+    kind = LoopXTurnResultKind(failure_kind)
     payload = decide_loop_disposition(
-        turn_receipt=_receipt(failure_kind),
+        turn_receipt=_validated_receipt(result_kind=kind),
         quota_decision=_envelope(should_run=True),
     )
     _assert_markers(payload, "repair")
     assert failure_kind in str(payload["reason"])
 
 
-def test_stale_receipt_lineage_fails_closed_to_contract_error() -> None:
-    payload = decide_loop_disposition(
-        turn_receipt=_receipt("validated_progress", agent_id="agent-2"),
-        quota_decision=_envelope(should_run=True, agent_id="agent-1"),
+def test_stale_todo_receipt_raises_not_terminal() -> None:
+    # A stale todo_id completion must not terminate a newly selected todo.
+    receipt = _validated_receipt(
+        result_kind=LoopXTurnResultKind.VALIDATED_COMPLETION,
+        lineage=_lineage(todo_id="todo-old"),
     )
-    _assert_markers(payload, "contract_error")
-    assert "stale_receipt" in str(payload["reason"])
-    assert payload["stale_receipt_lineage"]["agent_id"] == "agent-2"
+    with pytest.raises(ValueError, match="stale_receipt"):
+        decide_loop_disposition(
+            turn_receipt=receipt,
+            quota_decision=_envelope(should_run=True, lineage=_lineage(todo_id="todo-new")),
+        )
 
 
-def test_stale_completion_receipt_fails_closed_not_terminal() -> None:
-    payload = decide_loop_disposition(
-        turn_receipt=_receipt("validated_completion", agent_id="agent-2"),
-        quota_decision=_envelope(should_run=True, agent_id="agent-1"),
+def test_stale_agent_receipt_raises() -> None:
+    receipt = _validated_receipt(
+        result_kind=LoopXTurnResultKind.VALIDATED_PROGRESS,
+        lineage=_lineage(agent_id="agent-2"),
     )
-    _assert_markers(payload, "contract_error")
-    assert "stale_receipt" in str(payload["reason"])
+    with pytest.raises(ValueError, match="stale_receipt"):
+        decide_loop_disposition(
+            turn_receipt=receipt,
+            quota_decision=_envelope(should_run=True, lineage=_lineage(agent_id="agent-1")),
+        )
 
 
-def test_bare_completion_mapping_fails_closed_not_terminal() -> None:
-    payload = decide_loop_disposition(
-        turn_receipt={"result_kind": "validated_completion"},
-        quota_decision=_envelope(should_run=True),
-    )
-    _assert_markers(payload, "contract_error")
-    assert "lineage" in str(payload["reason"])
+def test_forged_completion_mapping_cannot_construct_receipt() -> None:
+    # A caller-authored result_kind + lineage mapping must not be enough to
+    # prove completion.
+    with pytest.raises(ValueError, match="schema_version"):
+        ValidatedTurnReceipt.from_validation_result(
+            {
+                "result_kind": "validated_completion",
+                "lineage": _lineage(),
+            }
+        )
 
 
-def test_malformed_decision_fails_closed_as_contract_error() -> None:
-    payload = decide_loop_disposition(
-        turn_receipt=None,
-        quota_decision={"schema_version": "not_an_envelope"},
-    )
-    _assert_markers(payload, "contract_error")
+def test_receipt_requires_ok_true() -> None:
+    with pytest.raises(ValueError, match="ok=true"):
+        ValidatedTurnReceipt.from_validation_result(
+            {
+                "schema_version": "loopx_turn_receipt_validation_v0",
+                "ok": False,
+                "result_kind": "validated_progress",
+                "lineage": _lineage(),
+            }
+        )
 
 
-def test_marker_only_signature_fails_closed() -> None:
+def test_malformed_decision_raises() -> None:
+    with pytest.raises(ValueError, match="envelope contract"):
+        decide_loop_disposition(
+            turn_receipt=None,
+            quota_decision={"schema_version": "not_an_envelope"},
+        )
+
+
+def test_marker_only_signature_raises() -> None:
     envelope = _envelope(should_run=True)
     envelope["action_signature"] = {"matches": True}
-    payload = decide_loop_disposition(
-        turn_receipt=None,
-        quota_decision=envelope,
-    )
-    _assert_markers(payload, "contract_error")
+    with pytest.raises(ValueError, match="envelope contract"):
+        decide_loop_disposition(turn_receipt=None, quota_decision=envelope)
 
 
-def test_mismatched_signature_hashes_fail_closed() -> None:
+def test_mismatched_signature_hashes_raise() -> None:
     envelope = _envelope(should_run=True)
     envelope["action_signature"] = {
         "matches": True,
         "source_hash": "sha256:a",
         "envelope_hash": "sha256:b",
     }
-    payload = decide_loop_disposition(
-        turn_receipt=None,
-        quota_decision=envelope,
-    )
-    _assert_markers(payload, "contract_error")
+    with pytest.raises(ValueError, match="envelope contract"):
+        decide_loop_disposition(turn_receipt=None, quota_decision=envelope)
 
 
-def test_over_budget_compaction_fails_closed() -> None:
+def test_over_budget_compaction_raises() -> None:
     envelope = _envelope(should_run=True)
     envelope["compaction"] = {"within_budget": False}
-    payload = decide_loop_disposition(
-        turn_receipt=None,
-        quota_decision=envelope,
-    )
-    _assert_markers(payload, "contract_error")
+    with pytest.raises(ValueError, match="envelope contract"):
+        decide_loop_disposition(turn_receipt=None, quota_decision=envelope)
 
 
-def test_mismatched_signature_fails_closed() -> None:
-    payload = decide_loop_disposition(
-        turn_receipt=None,
-        quota_decision=_envelope(should_run=True, signature_matches=False),
-    )
-    _assert_markers(payload, "contract_error")
-
-
-def test_unknown_receipt_kind_fails_closed() -> None:
-    payload = decide_loop_disposition(
-        turn_receipt={"result_kind": "made_up_kind"},
-        quota_decision=_envelope(should_run=True),
-    )
-    _assert_markers(payload, "contract_error")
+def test_mismatched_signature_raises() -> None:
+    with pytest.raises(ValueError, match="envelope contract"):
+        decide_loop_disposition(
+            turn_receipt=None,
+            quota_decision=_envelope(should_run=True, signature_matches=False),
+        )
 
 
 def test_repair_decision_routes_to_repair() -> None:
@@ -311,3 +422,79 @@ def test_delivery_blocked_decision_waits() -> None:
         quota_decision=_envelope(should_run=True, delivery_allowed=False),
     )
     _assert_markers(payload, "wait")
+
+
+def test_disposition_enum_has_exactly_six_values() -> None:
+    from loopx.control_plane.turn_driver.loop_controller import LoopDisposition
+
+    assert {d.value for d in LoopDisposition} == {
+        "run_now",
+        "wait",
+        "user_action_required",
+        "repair",
+        "replan",
+        "terminal",
+    }
+
+
+def test_budget_rejects_booleans() -> None:
+    with pytest.raises(ValueError, match="max_turns must be an int"):
+        BoundedTurnBudget(lineage=_lineage(), max_turns=True, completed_turns=0)
+    with pytest.raises(ValueError, match="completed_turns must be an int"):
+        BoundedTurnBudget(lineage=_lineage(), max_turns=3, completed_turns=False)
+
+
+@pytest.mark.parametrize(
+    "max_turns,completed_turns",
+    [
+        (0, 0),
+        (-1, 0),
+        (3, -1),
+        (3, 4),
+    ],
+)
+def test_budget_rejects_invalid_ranges(max_turns: int, completed_turns: int) -> None:
+    with pytest.raises(ValueError):
+        BoundedTurnBudget(
+            lineage=_lineage(),
+            max_turns=max_turns,
+            completed_turns=completed_turns,
+        )
+
+
+def test_budget_requires_lineage() -> None:
+    with pytest.raises(ValueError, match="lineage"):
+        BoundedTurnBudget(lineage={}, max_turns=3, completed_turns=0)
+
+
+def test_stale_budget_lineage_raises() -> None:
+    receipt = _validated_receipt(result_kind=LoopXTurnResultKind.VALIDATED_PROGRESS)
+    with pytest.raises(ValueError, match="stale_receipt"):
+        decide_loop_disposition(
+            turn_receipt=receipt,
+            quota_decision=_envelope(should_run=True),
+            bounded_turn_budget=_budget(lineage=_lineage(agent_id="agent-2")),
+        )
+
+
+def test_validated_receipt_carries_lineage_from_plan() -> None:
+    receipt = _validated_receipt(
+        result_kind=LoopXTurnResultKind.VALIDATED_PROGRESS,
+        lineage=_lineage(goal_id="goal-x", agent_id="agent-y", todo_id="todo-z"),
+    )
+    assert receipt.lineage == {
+        "goal_id": "goal-x",
+        "agent_id": "agent-y",
+        "todo_id": "todo-z",
+    }
+
+
+def test_budget_schema_version() -> None:
+    assert _budget().to_mapping()["schema_version"] == BOUNDED_TURN_BUDGET_SCHEMA_VERSION
+
+
+def test_validated_receipt_schema_version() -> None:
+    assert (
+        _validated_receipt().to_mapping()["schema_version"]
+        == VALIDATED_TURN_RECEIPT_SCHEMA_VERSION
+    )

--- a/tests/test_loop_turn_loop_controller.py
+++ b/tests/test_loop_turn_loop_controller.py
@@ -8,7 +8,10 @@ markers.
 Receipts are produced through the real
 ``build_loopx_turn_transaction_plan -> validate_loopx_turn_receipt`` path so
 the controller consumes only proven ``loopx_turn_receipt_validation_v0``
-output, never a caller-forged ``result_kind + lineage`` mapping.
+output, never a caller-forged ``result_kind + lineage`` mapping. Material
+results (completion/progress) require a fully committed transaction (all seven
+phases); a validation-only intermediate cannot drive a terminal or progress
+transition.
 """
 
 from __future__ import annotations
@@ -29,6 +32,17 @@ from loopx.control_plane.turn_driver.loop_controller import (
     ValidatedTurnReceipt,
     decide_loop_disposition,
 )
+
+
+_ALL_PHASES = [
+    "host_execute",
+    "typed_result",
+    "validation",
+    "durable_writeback",
+    "quota_spend",
+    "scheduler_apply",
+    "scheduler_ack",
+]
 
 
 def _lineage(
@@ -64,7 +78,7 @@ def _result(
         "completed_phases": (
             completed_phases
             if completed_phases is not None
-            else ["host_execute", "typed_result", "validation"]
+            else list(_ALL_PHASES)
         ),
     }
     if failed_phase:
@@ -123,13 +137,14 @@ def _envelope(
     quiet_noop_allowed: bool = False,
     lineage: dict[str, str] | None = None,
     signature_matches: bool = True,
+    predecessor_turn_key: str | None = None,
 ) -> dict[str, object]:
     lin = _lineage() if lineage is None else lineage
     signature: dict[str, object] = {"matches": signature_matches}
     if signature_matches:
         signature["source_hash"] = "sha256:test"
         signature["envelope_hash"] = "sha256:test"
-    return {
+    envelope: dict[str, object] = {
         "schema_version": "loopx_turn_envelope_v0",
         "goal_id": lin["goal_id"],
         "agent_id": lin["agent_id"],
@@ -145,6 +160,9 @@ def _envelope(
         },
         "user": {"action_required": user_action_required},
     }
+    if predecessor_turn_key is not None:
+        envelope["predecessor_turn_key"] = predecessor_turn_key
+    return envelope
 
 
 def _budget(
@@ -185,28 +203,37 @@ def test_no_receipt_with_quiet_decision_waits_no_spend() -> None:
 
 
 def test_validated_completion_is_terminal() -> None:
+    receipt = _validated_receipt(
+        result_kind=LoopXTurnResultKind.VALIDATED_COMPLETION
+    )
     payload = decide_loop_disposition(
-        turn_receipt=_validated_receipt(
-            result_kind=LoopXTurnResultKind.VALIDATED_COMPLETION
+        turn_receipt=receipt,
+        quota_decision=_envelope(
+            should_run=True, predecessor_turn_key=receipt.turn_key
         ),
-        quota_decision=_envelope(should_run=True),
     )
     _assert_markers(payload, "terminal")
 
 
 def test_validated_progress_with_budget_runs_now() -> None:
+    receipt = _validated_receipt(result_kind=LoopXTurnResultKind.VALIDATED_PROGRESS)
     payload = decide_loop_disposition(
-        turn_receipt=_validated_receipt(result_kind=LoopXTurnResultKind.VALIDATED_PROGRESS),
-        quota_decision=_envelope(should_run=True),
+        turn_receipt=receipt,
+        quota_decision=_envelope(
+            should_run=True, predecessor_turn_key=receipt.turn_key
+        ),
         bounded_turn_budget=_budget(max_turns=3, completed_turns=1),
     )
     _assert_markers(payload, "run_now")
 
 
 def test_validated_progress_with_exhausted_budget_is_terminal() -> None:
+    receipt = _validated_receipt(result_kind=LoopXTurnResultKind.VALIDATED_PROGRESS)
     payload = decide_loop_disposition(
-        turn_receipt=_validated_receipt(result_kind=LoopXTurnResultKind.VALIDATED_PROGRESS),
-        quota_decision=_envelope(should_run=True),
+        turn_receipt=receipt,
+        quota_decision=_envelope(
+            should_run=True, predecessor_turn_key=receipt.turn_key
+        ),
         bounded_turn_budget=_budget(max_turns=3, completed_turns=3),
     )
     _assert_markers(payload, "terminal")
@@ -214,36 +241,50 @@ def test_validated_progress_with_exhausted_budget_is_terminal() -> None:
 
 
 def test_validated_progress_without_delivery_decision_waits() -> None:
+    receipt = _validated_receipt(result_kind=LoopXTurnResultKind.VALIDATED_PROGRESS)
     payload = decide_loop_disposition(
-        turn_receipt=_validated_receipt(result_kind=LoopXTurnResultKind.VALIDATED_PROGRESS),
-        quota_decision=_envelope(should_run=False, quiet_noop_allowed=True),
+        turn_receipt=receipt,
+        quota_decision=_envelope(
+            should_run=False,
+            quiet_noop_allowed=True,
+            predecessor_turn_key=receipt.turn_key,
+        ),
         bounded_turn_budget=_budget(max_turns=3, completed_turns=1),
     )
     _assert_markers(payload, "wait")
 
 
 def test_validated_progress_without_bounded_budget_raises() -> None:
+    receipt = _validated_receipt(result_kind=LoopXTurnResultKind.VALIDATED_PROGRESS)
     with pytest.raises(ValueError, match="bounded turn budget"):
         decide_loop_disposition(
-            turn_receipt=_validated_receipt(
-                result_kind=LoopXTurnResultKind.VALIDATED_PROGRESS
+            turn_receipt=receipt,
+            quota_decision=_envelope(
+                should_run=True, predecessor_turn_key=receipt.turn_key
             ),
-            quota_decision=_envelope(should_run=True),
         )
 
 
 def test_repair_receipt_routes_to_repair() -> None:
+    receipt = _validated_receipt(result_kind=LoopXTurnResultKind.REPAIR_REQUIRED)
     payload = decide_loop_disposition(
-        turn_receipt=_validated_receipt(result_kind=LoopXTurnResultKind.REPAIR_REQUIRED),
-        quota_decision=_envelope(should_run=True),
+        turn_receipt=receipt,
+        quota_decision=_envelope(
+            should_run=True, predecessor_turn_key=receipt.turn_key
+        ),
     )
     _assert_markers(payload, "repair")
 
 
 def test_replan_receipt_requires_bounded_delta_before_successor() -> None:
+    receipt = _validated_receipt(result_kind=LoopXTurnResultKind.REPLAN_REQUIRED)
     payload = decide_loop_disposition(
-        turn_receipt=_validated_receipt(result_kind=LoopXTurnResultKind.REPLAN_REQUIRED),
-        quota_decision=_envelope(should_run=True, effective_action="autonomous_replan"),
+        turn_receipt=receipt,
+        quota_decision=_envelope(
+            should_run=True,
+            effective_action="autonomous_replan",
+            predecessor_turn_key=receipt.turn_key,
+        ),
     )
     _assert_markers(payload, "replan")
     continuation = payload["replan_continuation"]
@@ -265,19 +306,27 @@ def test_replan_decision_without_receipt_also_requires_delta() -> None:
 
 
 def test_user_action_from_receipt_wins() -> None:
+    receipt = _validated_receipt(
+        result_kind=LoopXTurnResultKind.USER_ACTION_REQUIRED
+    )
     payload = decide_loop_disposition(
-        turn_receipt=_validated_receipt(
-            result_kind=LoopXTurnResultKind.USER_ACTION_REQUIRED
+        turn_receipt=receipt,
+        quota_decision=_envelope(
+            should_run=True, predecessor_turn_key=receipt.turn_key
         ),
-        quota_decision=_envelope(should_run=True),
     )
     _assert_markers(payload, "user_action_required")
 
 
 def test_user_action_from_decision_wins_even_with_receipt() -> None:
+    receipt = _validated_receipt(result_kind=LoopXTurnResultKind.VALIDATED_PROGRESS)
     payload = decide_loop_disposition(
-        turn_receipt=_validated_receipt(result_kind=LoopXTurnResultKind.VALIDATED_PROGRESS),
-        quota_decision=_envelope(should_run=True, user_action_required=True),
+        turn_receipt=receipt,
+        quota_decision=_envelope(
+            should_run=True,
+            user_action_required=True,
+            predecessor_turn_key=receipt.turn_key,
+        ),
         bounded_turn_budget=_budget(max_turns=3, completed_turns=1),
     )
     _assert_markers(payload, "user_action_required")
@@ -285,21 +334,30 @@ def test_user_action_from_decision_wins_even_with_receipt() -> None:
 
 def test_validated_completion_wins_over_decision_user_action() -> None:
     # Precedence: a met terminal postcondition is stronger than a decision-only
-    # user action, but only after the receipt is proven valid and fresh.
+    # user action, but only after the receipt is proven valid, fresh, and
+    # fully committed.
+    receipt = _validated_receipt(
+        result_kind=LoopXTurnResultKind.VALIDATED_COMPLETION
+    )
     payload = decide_loop_disposition(
-        turn_receipt=_validated_receipt(
-            result_kind=LoopXTurnResultKind.VALIDATED_COMPLETION
+        turn_receipt=receipt,
+        quota_decision=_envelope(
+            should_run=True,
+            user_action_required=True,
+            predecessor_turn_key=receipt.turn_key,
         ),
-        quota_decision=_envelope(should_run=True, user_action_required=True),
     )
     _assert_markers(payload, "terminal")
     assert "validated completion" in str(payload["reason"])
 
 
 def test_wait_receipt_waits() -> None:
+    receipt = _validated_receipt(result_kind=LoopXTurnResultKind.WAIT)
     payload = decide_loop_disposition(
-        turn_receipt=_validated_receipt(result_kind=LoopXTurnResultKind.WAIT),
-        quota_decision=_envelope(should_run=True),
+        turn_receipt=receipt,
+        quota_decision=_envelope(
+            should_run=True, predecessor_turn_key=receipt.turn_key
+        ),
     )
     _assert_markers(payload, "wait")
 
@@ -310,9 +368,12 @@ def test_wait_receipt_waits() -> None:
 )
 def test_failure_receipts_route_to_repair(failure_kind: str) -> None:
     kind = LoopXTurnResultKind(failure_kind)
+    receipt = _validated_receipt(result_kind=kind)
     payload = decide_loop_disposition(
-        turn_receipt=_validated_receipt(result_kind=kind),
-        quota_decision=_envelope(should_run=True),
+        turn_receipt=receipt,
+        quota_decision=_envelope(
+            should_run=True, predecessor_turn_key=receipt.turn_key
+        ),
     )
     _assert_markers(payload, "repair")
     assert failure_kind in str(payload["reason"])
@@ -327,7 +388,11 @@ def test_stale_todo_receipt_raises_not_terminal() -> None:
     with pytest.raises(ValueError, match="stale_receipt"):
         decide_loop_disposition(
             turn_receipt=receipt,
-            quota_decision=_envelope(should_run=True, lineage=_lineage(todo_id="todo-new")),
+            quota_decision=_envelope(
+                should_run=True,
+                lineage=_lineage(todo_id="todo-new"),
+                predecessor_turn_key=receipt.turn_key,
+            ),
         )
 
 
@@ -339,7 +404,11 @@ def test_stale_agent_receipt_raises() -> None:
     with pytest.raises(ValueError, match="stale_receipt"):
         decide_loop_disposition(
             turn_receipt=receipt,
-            quota_decision=_envelope(should_run=True, lineage=_lineage(agent_id="agent-1")),
+            quota_decision=_envelope(
+                should_run=True,
+                lineage=_lineage(agent_id="agent-1"),
+                predecessor_turn_key=receipt.turn_key,
+            ),
         )
 
 
@@ -362,8 +431,77 @@ def test_receipt_requires_ok_true() -> None:
                 "schema_version": "loopx_turn_receipt_validation_v0",
                 "ok": False,
                 "result_kind": "validated_progress",
+                "turn_key": "sha256:abc",
+            }
+        )
+
+
+def test_material_result_requires_committed_status() -> None:
+    # A validation-only (3-phase) completion must not construct a receipt; the
+    # loop must not terminate before writeback/spend/scheduler close the
+    # run-once transaction.
+    plan = _plan()
+    result = _result(
+        plan,
+        result_kind=LoopXTurnResultKind.VALIDATED_COMPLETION,
+        completed_phases=["host_execute", "typed_result", "validation"],
+    )
+    validation = validate_loopx_turn_receipt(plan, result)
+    assert validation["ok"] is True
+    assert validation["status"] == "validated"
+    with pytest.raises(ValueError, match="committed"):
+        ValidatedTurnReceipt.from_validation_result(validation)
+
+
+def test_material_progress_requires_committed_status() -> None:
+    plan = _plan()
+    result = _result(
+        plan,
+        result_kind=LoopXTurnResultKind.VALIDATED_PROGRESS,
+        completed_phases=["host_execute", "typed_result", "validation"],
+    )
+    validation = validate_loopx_turn_receipt(plan, result)
+    assert validation["ok"] is True
+    with pytest.raises(ValueError, match="committed"):
+        ValidatedTurnReceipt.from_validation_result(validation)
+
+
+def test_forged_ok_true_mapping_requires_turn_key() -> None:
+    # A caller-authored mapping with ok=true and lineage but no turn_key must
+    # not construct a receipt; the turn_key is the causal binding handle.
+    with pytest.raises(ValueError, match="turn_key"):
+        ValidatedTurnReceipt.from_validation_result(
+            {
+                "schema_version": "loopx_turn_receipt_validation_v0",
+                "ok": True,
+                "result_kind": "wait",
+                "status": "stopped",
                 "lineage": _lineage(),
             }
+        )
+
+
+def test_missing_predecessor_turn_key_raises() -> None:
+    receipt = _validated_receipt(result_kind=LoopXTurnResultKind.VALIDATED_PROGRESS)
+    with pytest.raises(ValueError, match="predecessor_turn_key"):
+        decide_loop_disposition(
+            turn_receipt=receipt,
+            quota_decision=_envelope(should_run=True),
+            bounded_turn_budget=_budget(max_turns=3, completed_turns=1),
+        )
+
+
+def test_mismatched_predecessor_turn_key_raises() -> None:
+    # An old receipt for the same todo cannot be replayed against a later
+    # envelope that references a different predecessor turn.
+    receipt = _validated_receipt(result_kind=LoopXTurnResultKind.VALIDATED_PROGRESS)
+    with pytest.raises(ValueError, match="predecessor_turn_key"):
+        decide_loop_disposition(
+            turn_receipt=receipt,
+            quota_decision=_envelope(
+                should_run=True, predecessor_turn_key="sha256:some-other-turn"
+            ),
+            bounded_turn_budget=_budget(max_turns=3, completed_turns=1),
         )
 
 
@@ -469,24 +607,25 @@ def test_budget_requires_lineage() -> None:
 
 def test_stale_budget_lineage_raises() -> None:
     receipt = _validated_receipt(result_kind=LoopXTurnResultKind.VALIDATED_PROGRESS)
-    with pytest.raises(ValueError, match="stale_receipt"):
+    with pytest.raises(ValueError, match="stale_budget"):
         decide_loop_disposition(
             turn_receipt=receipt,
-            quota_decision=_envelope(should_run=True),
+            quota_decision=_envelope(
+                should_run=True, predecessor_turn_key=receipt.turn_key
+            ),
             bounded_turn_budget=_budget(lineage=_lineage(agent_id="agent-2")),
         )
 
 
-def test_validated_receipt_carries_lineage_from_plan() -> None:
-    receipt = _validated_receipt(
-        result_kind=LoopXTurnResultKind.VALIDATED_PROGRESS,
-        lineage=_lineage(goal_id="goal-x", agent_id="agent-y", todo_id="todo-z"),
+def test_validated_receipt_carries_turn_key() -> None:
+    plan = _plan(
+        lineage=_lineage(goal_id="goal-x", agent_id="agent-y", todo_id="todo-z")
     )
-    assert receipt.lineage == {
-        "goal_id": "goal-x",
-        "agent_id": "agent-y",
-        "todo_id": "todo-z",
-    }
+    result = _result(plan, result_kind=LoopXTurnResultKind.VALIDATED_PROGRESS)
+    validation = validate_loopx_turn_receipt(plan, result)
+    receipt = ValidatedTurnReceipt.from_validation_result(validation)
+    assert receipt.turn_key == plan["turn_key"]
+    assert receipt.status == "committed"
 
 
 def test_budget_schema_version() -> None:


### PR DESCRIPTION
Reopen of #2433 after rebase onto latest main.

Implements the P0 pure transition contract from the Turn Loop Controller plan (closes #2432).

## Summary

Add `loopx/control_plane/turn_driver/loop_controller.py` exposing one pure function:

```
decide_loop_disposition(turn_receipt=..., quota_decision=..., bounded_turn_budget=...) -> loop_turn_loop_disposition_v0
```

Given one validated Turn receipt and a fresh `loopx_turn_envelope_v0` decision, it returns exactly one typed disposition — `run_now` / `wait` / `user_action_required` / `repair` / `replan` / `terminal` — with a reason, lineage, and `spends_quota=false`, `launches_host=false`, `writes_state=false` markers.

Boundary held deliberately narrow per the plan: the function never invokes a model, sleeps, mutates a host scheduler, writes state, or spends quota. Scheduler process management, host wake adapters, and operator presentation are untouched (P1/P2 slices). `run-once` remains the only delivery transaction.

## Changes from the previous round (addressing owner review)

1. **Six-state output, no `contract_error` disposition.** Input validity is enforced at the typed-input boundary (`ValueError`), not encoded as a seventh disposition.
2. **`ValidatedTurnReceipt`** — constructed only from an `ok=true` `loopx_turn_receipt_validation_v0` result with full `(goal_id, agent_id, todo_id)` lineage. The controller no longer accepts caller-forged `result_kind + lineage` mappings.
3. **Full-lineage freshness** — compares `goal_id`, `agent_id`, \*and` `todo_id`; a stale `todo_id` completion can no longer terminate a newly selected todo.
4. **`BoundedTurnBudget`** — provider-neutral typed budget with strict int-domain checks (booleans rejected, `max_turns > 0`, `0 <= completed_turns <= max_turns`) and matching lineage.
5. **Production-shaped tests** — receipts are produced through the real `build_loopx_turn_transaction_plan -> validate_loopx_turn_receipt` path, with negative coverage for forged receipts, stale todo/agent, invalid budget domains, and stale budget lineage.
6. **Normalized lineage** projected from `build_loopx_turn_transaction_plan` into the validation result so `ValidatedTurnReceipt` can read it.

## Validation

- 104 passed: controller table (40 rows) + Turn driver/executor/transaction tests
- `python examples/autonomous-replan-obligation-smoke.py` ok
- `python examples/benchmark-loop-protocol-smoke.py` ok
- `loopx check` on contract docs (public boundary clean)
- `git diff --check`