### PR TITLE
test(control-plane): refresh heartbeat monitor fixture

### DIFF
--- a/examples/control_plane/heartbeat-quota-flow-smoke.py
+++ b/examples/control_plane/heartbeat-quota-flow-smoke.py
@@ -196,7 +196,9 @@ def write_monitor_fixture(root: Path) -> tuple[Path, Path, Path]:
         "- [x] [P1] Approve the private one-instance execution boundary before any real run.\n\n"
         "## Agent Todo\n\n"
         "- [ ] [P2] Meta canary/readiness observation lane: keep status observable and repair only material transitions.\n"
-        "  <!-- loopx:todo todo_id=todo_77fad979d712 task_class=continuous_monitor cadence=15m next_due_at=2099-01-01T00:00:00Z -->\n",
+        "  <!-- loopx:todo todo_id=todo_77fad979d712 task_class=continuous_monitor "
+        "claimed_by=codex-main-control target_key=heartbeat-flow-readiness cadence=15m "
+        "next_due_at=2099-01-01T00:00:00Z expires_at=2100-01-01T00:00:00Z -->\n",
         encoding="utf-8",
     )
     registry_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

- align the heartbeat quota-flow fixture with the current `watch_lane_continuation` repair-delta contract
- give the synthetic continuous monitor an explicit owner, stable target, and bounded expiry
- restore the previously failing full-public shard without weakening runtime validation

## Validation

- `python examples/control_plane/heartbeat-quota-flow-smoke.py`
- 45 focused repair-delta, monitor ownership, and goal-successor tests
- exact previously failing full-public shard on Python 3.11: 100/100 passed, zero timeouts
- release version, readiness-doc, and exact-release-commit qualification smokes
- repository-declared strict mypy scope: 15 files passed
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 5/5 selected checks passed, no manual holds
- public/private boundary and exact change-quality receipt passed

## Scope

This changes one durable public smoke fixture only. It does not change quota, scheduler, monitor, or release runtime behavior. No private state, raw logs, credentials, or local paths are included.

One advisory direct mypy run against this smoke reports existing strict-typing findings; the file is outside the repository-declared mypy scope, whose configured gate passes.
