### PR TITLE
fix(start-goal): make blocked activation explicit

### DIFF
--- a/examples/bootstrap-command-pack-smoke.py
+++ b/examples/bootstrap-command-pack-smoke.py
@@ -427,6 +427,11 @@ def test_start_goal_guided_requires_explicit_goal_for_multi_goal_project() -> No
             ], choice
         commands = payload["command_pack"]["commands"]
         assert set(commands) == {"doctor", "status", "goal_selection_choices"}, commands
+        assert payload["command_pack"]["host_loop_activation"] == {
+            "activation_state": "goal_selection_required",
+            "activation_allowed": False,
+            "activation_required_after_todo_write": False,
+        }, payload
         assert payload["safety_contract"]["writes_registry"] is False, payload
         assert payload["safety_contract"]["creates_heartbeat"] is False, payload
         assert_packet_summary_refs(

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -1112,6 +1112,7 @@ def _build_multi_goal_start_selection_packet(
         "host_loop_activation": {
             "activation_state": "goal_selection_required",
             "activation_allowed": False,
+            "activation_required_after_todo_write": False,
         },
         "available_slash_commands": slash_command_catalog,
         "onboarding_hint": slash_command_catalog["onboarding"],

--- a/tests/control_plane/test_actual_default_model_behavior_portfolio.py
+++ b/tests/control_plane/test_actual_default_model_behavior_portfolio.py
@@ -336,6 +336,17 @@ def test_live_packet_builder_uses_production_blocking_gate_plan(tmp_path: Path) 
         "status",
         "goal_selection_choices",
     }
+    selection_activation = packets["onboarding_goal_selection_gate"][
+        "command_pack"
+    ]["host_loop_activation"]
+    assert selection_activation == {
+        "activation_state": "goal_selection_required",
+        "activation_allowed": False,
+        "activation_required_after_todo_write": False,
+    }
+    assert onboarding_entry_semantic_contract(
+        packets["onboarding_goal_selection_gate"]
+    )["host_loop_activation_after_todo_write"] is False
     gate = packets["turn_human_gate"]
     assert gate["mode"] == "should-run"
     gate_signature = quota_action_signature_document(gate)


### PR DESCRIPTION
## Summary

- make the blocked multi-goal `host_loop_activation` state explicitly declare `activation_required_after_todo_write: false`
- lock the production packet and onboarding semantic contract in the focused portfolio test
- preserve the same public behavior in the durable bootstrap command-pack smoke

## Motivation

The actual-default onboarding model gate correctly selected the `select_goal` route but twice disagreed on `host_loop_activation_after_todo_write`. The production packet omitted the source boolean in the blocked state, leaving the model to infer a default that the deterministic oracle already defines as `false`.

This change removes that ambiguity at the source. It does not relax the source-alignment oracle, change the route, add a prompt exception, or introduce another abstraction.

## Validation

- `python -m ruff check tests loopx/canary loopx/control_plane loopx/domain_packs loopx/presentation`
- `python -m mypy`
- `python -m pytest -q` (`1802 passed, 2 skipped`)
- `python examples/bootstrap-command-pack-smoke.py`
- `python examples/control_plane/cli-output-budget-regression-smoke.py`
- public/private boundary scan for all three changed files
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`
- exact change-quality receipt `cqr_361bea066d2f20d2e2b4`

## Residual Gate

The real Ark portfolio was not rerun from this checkout because the locally available credential was rejected by the provider with HTTP 401. Deterministic qualification is complete; release publication must still obtain a fresh actual-default live receipt with a valid runtime-injected credential.

No local state, credentials, raw model responses, packet dumps, or private evidence are included.
