### PR TITLE
feat(issue-fix): materialize grouped PR monitors

### DIFF
--- a/docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md
@@ -131,6 +131,8 @@ open PRs, merge, publish, or run destructive git without an explicit gate.
    the schedule and defaults to `30m`. A quiet replay with unchanged bucket
    membership is idempotent. The monitor poll lane, rather than repeated PR
    lifecycle execution, owns later cadence advancement.
+   With a public PR URL, `--execute-transition` fetches compact public metadata
+   automatically unless `--metadata-json` supplies a deterministic fixture.
 11. **Gate handling:** surface concrete gates instead of silently blocking. Safe
    metadata-only triage, public-code search, and focused smoke drafting may
    continue when those gates do not cover the selected action.

--- a/docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md
@@ -125,7 +125,12 @@ open PRs, merge, publish, or run destructive git without an explicit gate.
    `continuous_monitor` for each nonempty bucket, upsert/remove PR membership
    as state changes, and complete empty buckets. Never create one monitor per
    PR. Material PR work remains a one-shot advancement todo, and reviewer
-   notifications remain one PR per message.
+   notifications remain one PR per message. `pr-lifecycle
+   --execute-transition --goal-id <goal> --claimed-by <agent>` performs this
+   reconciliation through the generic todo API; `--monitor-cadence` controls
+   the schedule and defaults to `30m`. A quiet replay with unchanged bucket
+   membership is idempotent. The monitor poll lane, rather than repeated PR
+   lifecycle execution, owns later cadence advancement.
 11. **Gate handling:** surface concrete gates instead of silently blocking. Safe
    metadata-only triage, public-code search, and focused smoke drafting may
    continue when those gates do not cover the selected action.

--- a/docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md
@@ -130,7 +130,10 @@ open PRs, merge, publish, or run destructive git without an explicit gate.
    reconciliation through the generic todo API; `--monitor-cadence` controls
    the schedule and defaults to `30m`. A quiet replay with unchanged bucket
    membership is idempotent. The monitor poll lane, rather than repeated PR
-   lifecycle execution, owns later cadence advancement.
+   lifecycle execution, owns later cadence advancement. The creating issue-fix
+   agent remains the monitor's `claimed_by` owner across turns; another peer
+   cannot update, retire, reopen, or poll that monitor without explicit Todo
+   lifecycle authority.
    With a public PR URL, `--execute-transition` fetches compact public metadata
    automatically unless `--metadata-json` supplies a deterministic fixture.
 11. **Gate handling:** surface concrete gates instead of silently blocking. Safe

--- a/docs/capabilities/issue-fix/state-kernel-domain-state-case-study.zh-CN.md
+++ b/docs/capabilities/issue-fix/state-kernel-domain-state-case-study.zh-CN.md
@@ -229,7 +229,8 @@ lifecycle bucket 聚合，Kernel 只调度非空 bucket 的一个 monitor；真�
 advancement todo。`pr-lifecycle --execute-transition --goal-id <goal> --claimed-by <agent>`
 通过通用 Todo API 完成这笔物化事务；`--monitor-cadence` 控制调度周期，缺省为 `30m`。
 相同 bucket membership 的安静重放保持幂等，后续 cadence 推进由 monitor poll lane 负责，而不是
-反复执行 PR lifecycle transition。
+反复执行 PR lifecycle transition。给出公开 PR URL 时，`--execute-transition` 会自动读取紧凑的
+公开 metadata；只有确定性 fixture 才需要显式传 `--metadata-json`。
 
 ### 6. Terminal closeout 与继续运行
 

--- a/docs/capabilities/issue-fix/state-kernel-domain-state-case-study.zh-CN.md
+++ b/docs/capabilities/issue-fix/state-kernel-domain-state-case-study.zh-CN.md
@@ -226,7 +226,10 @@ metadata；CI pending 只继续 monitor，CI failure 和未处理的 changes req
 
 多个同类 PR 不需要一 PR 一 monitor。`issue_fix_pr_grouped_monitor_projection_v1` 按仓库和
 lifecycle bucket 聚合，Kernel 只调度非空 bucket 的一个 monitor；真正的 patch 仍是独立的一次性
-advancement todo。
+advancement todo。`pr-lifecycle --execute-transition --goal-id <goal> --claimed-by <agent>`
+通过通用 Todo API 完成这笔物化事务；`--monitor-cadence` 控制调度周期，缺省为 `30m`。
+相同 bucket membership 的安静重放保持幂等，后续 cadence 推进由 monitor poll lane 负责，而不是
+反复执行 PR lifecycle transition。
 
 ### 6. Terminal closeout 与继续运行
 

--- a/docs/capabilities/issue-fix/state-kernel-domain-state-case-study.zh-CN.md
+++ b/docs/capabilities/issue-fix/state-kernel-domain-state-case-study.zh-CN.md
@@ -229,7 +229,9 @@ lifecycle bucket 聚合，Kernel 只调度非空 bucket 的一个 monitor；真�
 advancement todo。`pr-lifecycle --execute-transition --goal-id <goal> --claimed-by <agent>`
 通过通用 Todo API 完成这笔物化事务；`--monitor-cadence` 控制调度周期，缺省为 `30m`。
 相同 bucket membership 的安静重放保持幂等，后续 cadence 推进由 monitor poll lane 负责，而不是
-反复执行 PR lifecycle transition。给出公开 PR URL 时，`--execute-transition` 会自动读取紧凑的
+反复执行 PR lifecycle transition。创建该 monitor 的 issue-fix Agent 会跨 turn 保持为
+`claimed_by` owner；其他 peer 未获得显式 Todo lifecycle authority 时不能更新、retire、重开或
+poll 该 monitor。给出公开 PR URL 时，`--execute-transition` 会自动读取紧凑的
 公开 metadata；只有确定性 fixture 才需要显式传 `--metadata-json`。
 
 ### 6. Terminal closeout 与继续运行

--- a/examples/bootstrap-command-pack-smoke.py
+++ b/examples/bootstrap-command-pack-smoke.py
@@ -231,8 +231,6 @@ def test_goal_text_invocation_plans_ranked_todos_before_activation() -> None:
         assert "--url <github-pr-url>" in pr_lifecycle_template
         assert "--goal-id" in pr_lifecycle_template
         assert str(payload["goal_id"]) in pr_lifecycle_template
-        assert "--project <approved-repo>" in pr_lifecycle_template
-        assert "--fetch-metadata" in pr_lifecycle_template
         assert "--claimed-by codex-test-agent" in pr_lifecycle_template
         assert "--execute-transition" in pr_lifecycle_template
         assert "issue_fix_reviewer_request_template" in commands

--- a/examples/bootstrap-command-pack-smoke.py
+++ b/examples/bootstrap-command-pack-smoke.py
@@ -231,6 +231,10 @@ def test_goal_text_invocation_plans_ranked_todos_before_activation() -> None:
         assert "--url <github-pr-url>" in pr_lifecycle_template
         assert "--goal-id" in pr_lifecycle_template
         assert str(payload["goal_id"]) in pr_lifecycle_template
+        assert "--project <approved-repo>" in pr_lifecycle_template
+        assert "--fetch-metadata" in pr_lifecycle_template
+        assert "--claimed-by codex-test-agent" in pr_lifecycle_template
+        assert "--execute-transition" in pr_lifecycle_template
         assert "issue_fix_reviewer_request_template" in commands
         reviewer_request_template = str(commands["issue_fix_reviewer_request_template"])
         assert "issue-fix reviewer-request" in reviewer_request_template

--- a/examples/issue-fix-pr-lifecycle-smoke.py
+++ b/examples/issue-fix-pr-lifecycle-smoke.py
@@ -196,7 +196,7 @@ def main() -> int:
     )
     assert blocked_pending["transition"]["material_change"] is False
     assert blocked_pending["grouped_monitor_projection"]["target_key"] == (
-        "github-pr-state-checks-pending"
+        "github-pr-state-huangruiteng--loopx-checks-pending"
     )
 
     stale = build_issue_fix_pr_lifecycle_monitor_packet(
@@ -239,7 +239,7 @@ def main() -> int:
         quiet["grouped_monitor_projection"]
         | {
             "state_bucket": "review_required",
-            "target_key": "github-pr-state-review-required",
+            "target_key": "github-pr-state-huangruiteng--loopx-review-required",
             "action_kind": "issue_fix_pr_state_review_required_monitor",
             "member_key": "huangruiteng/loopx#1715",
             "member_operation": "upsert",
@@ -275,7 +275,7 @@ def main() -> int:
     assert_packet_shape(approved)
     assert approved["grouped_monitor_projection"]["state_bucket"] == "ready_to_merge"
     assert approved["grouped_monitor_projection"]["target_key"] == (
-        "github-pr-state-ready-to-merge"
+        "github-pr-state-huangruiteng--loopx-ready-to-merge"
     )
     for alias in ("#1700", "issue_1700", "issues/1700", "issue 1700"):
         alias_packet = build_issue_fix_pr_lifecycle_monitor_packet(

--- a/examples/issue-fix-workflow-plan-smoke.py
+++ b/examples/issue-fix-workflow-plan-smoke.py
@@ -124,6 +124,10 @@ def assert_workflow_shape(payload: dict[str, Any]) -> None:
     assert feasibility["writes_loopx_todo"] is False
     post_pr = payload["post_pr_lifecycle_monitor_plan"]
     assert post_pr["schema_version"] == "issue_fix_post_pr_lifecycle_monitor_plan_v1"
+    assert "--goal-id <goal-id>" in post_pr["command_preview"]
+    assert "--claimed-by <agent-id>" in post_pr["command_preview"]
+    assert "--execute-transition" in post_pr["command_preview"]
+    assert "--fetch-metadata" not in post_pr["command_preview"]
     assert post_pr["creates_per_pr_continuous_monitor_todo"] is False, post_pr
     assert post_pr["monitor_scope"] == "lifecycle_state_bucket", post_pr
     assert post_pr["materializes_nonempty_buckets_only"] is True, post_pr

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -775,10 +775,6 @@ def build_loopx_bootstrap_command_pack(
     mutation_confirmation_required = bool(inspection.get("mutation_confirmation_required"))
     normalized_goal_text = " ".join(goal_text.split()) if goal_text else None
     explicit_goal_start = bool(normalized_goal_text)
-    issue_fix_commands = build_issue_fix_goal_command_templates(
-        cli_bin=cli_bin,
-        goal_id=resolved_goal_id,
-    )
     issue_fix_hint_commands = build_issue_fix_goal_command_templates(
         cli_bin=cli_bin,
         goal_id="<goal-id>",
@@ -811,6 +807,11 @@ def build_loopx_bootstrap_command_pack(
         available_capabilities=available_capabilities,
     )
     selected_agent_id = host_loop_activation.get("agent_id")
+    issue_fix_commands = build_issue_fix_goal_command_templates(
+        cli_bin=cli_bin,
+        goal_id=resolved_goal_id,
+        agent_id=str(selected_agent_id) if selected_agent_id else "<agent-id>",
+    )
     activation_allowed = bool(host_loop_activation.get("activation_allowed"))
     activation_commands = host_loop_activation.get("commands")
     activation_commands = activation_commands if isinstance(activation_commands, dict) else {}

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -255,9 +255,9 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "write_boundary": "verified configured secondary sends plus compact receipt or stale-queue state writeback; no per-PR continuous monitor, arbitrary comment, push, merge, or publish",
             },
             {
-                "command": "loopx issue-fix pr-lifecycle --url <github-pr-url> --goal-id <goal-id> --format json",
-                "purpose": "Project public PR lifecycle state into a successor, monitor continuation, user gate, or no-follow-up transition.",
-                "write_boundary": "writes compact project-local domain state when goal or ledger context is provided; no external comment, PR creation, merge, raw logs, or body/comment capture",
+                "command": "loopx issue-fix pr-lifecycle --url <github-pr-url> --project <repo> --fetch-metadata --goal-id <goal-id> --claimed-by <agent-id> --execute-transition --format json",
+                "purpose": "Project public PR lifecycle state and reconcile its grouped monitor, successor, user gate, or no-follow-up transition.",
+                "write_boundary": "reads compact public PR metadata and writes compact project-local domain state plus generic LoopX todos; no external comment, PR creation, merge, raw logs, or body/comment capture",
             },
             {
                 "command": "loopx issue-fix outcome --goal-id <goal-id> --repo <owner/repo> --issue-ref <issue-ref> --pr-ref <pr-ref> --format json",

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from .registry import CapabilityRegistry
+from .issue_fix.workflow_plan import build_issue_fix_pr_lifecycle_command
 
 from ..extensions.runtime import extension_catalog_entries
 
@@ -255,7 +256,12 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "write_boundary": "verified configured secondary sends plus compact receipt or stale-queue state writeback; no per-PR continuous monitor, arbitrary comment, push, merge, or publish",
             },
             {
-                "command": "loopx issue-fix pr-lifecycle --url <github-pr-url> --project <repo> --fetch-metadata --goal-id <goal-id> --claimed-by <agent-id> --execute-transition --format json",
+                "command": build_issue_fix_pr_lifecycle_command(
+                    cli_bin="loopx",
+                    goal_id="<goal-id>",
+                    agent_id="<agent-id>",
+                    project="<repo>",
+                ),
                 "purpose": "Project public PR lifecycle state and reconcile its grouped monitor, successor, user gate, or no-follow-up transition.",
                 "write_boundary": "reads compact public PR metadata and writes compact project-local domain state plus generic LoopX todos; no external comment, PR creation, merge, raw logs, or body/comment capture",
             },

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -64,6 +64,10 @@ from .pr_lifecycle import (
     validate_issue_fix_pr_lifecycle_monitor_packet,
 )
 from .pr_lifecycle_rollout import append_pr_merge_rollout_event
+from .pr_monitor_materialization import (
+    DEFAULT_ISSUE_FIX_MONITOR_CADENCE,
+    materialize_issue_fix_grouped_monitors,
+)
 from .provider_hooks import IssueFixReviewerProviderHooksFactory
 from . import pr_gate_reconcile_cli
 from .reviewer_cli import (
@@ -620,8 +624,9 @@ def register_issue_fix_commands(
         "--execute-transition",
         action="store_true",
         help=(
-            "Write the correction transition into the existing LoopX todo state. "
-            "Requires --goal-id, --claimed-by, --maintainer-correction-json, and a registry."
+            "Write the lifecycle transition and reconcile grouped monitors in "
+            "the existing LoopX todo state. Requires --goal-id, --claimed-by, "
+            "and a registry."
         ),
     )
     pr_lifecycle_parser.add_argument(
@@ -630,6 +635,14 @@ def register_issue_fix_commands(
         help=(
             "Registered agent that claims an actionable patch successor or is blocked "
             "by the generated concrete user gate."
+        ),
+    )
+    pr_lifecycle_parser.add_argument(
+        "--monitor-cadence",
+        default=DEFAULT_ISSUE_FIX_MONITOR_CADENCE,
+        help=(
+            "Cadence for grouped PR lifecycle continuous monitors materialized "
+            "by --execute-transition (default: 30m)."
         ),
     )
     pr_gate_reconcile_cli.register_pr_gate_reconciliation_command(issue_fix_sub)
@@ -1231,10 +1244,16 @@ def handle_issue_fix_command(
                 raise ValueError(
                     "--fetch-metadata cannot be combined with --metadata-json"
                 )
-            if args.execute_transition and not args.maintainer_correction_json:
+            if args.execute_transition and args.no_write_domain_state:
                 raise ValueError(
-                    "--execute-transition requires --maintainer-correction-json"
+                    "--execute-transition cannot be combined with --no-write-domain-state"
                 )
+            if args.execute_transition and registry_path is None:
+                raise ValueError("--execute-transition requires a LoopX registry")
+            if args.execute_transition and not args.goal_id:
+                raise ValueError("--execute-transition requires --goal-id")
+            if args.execute_transition and not args.claimed_by:
+                raise ValueError("--execute-transition requires --claimed-by")
             payload = build_issue_fix_pr_lifecycle_monitor_packet(
                 repo=args.repo,
                 pr_ref=args.pr_ref,
@@ -1288,14 +1307,23 @@ def handle_issue_fix_command(
                     )
             transition = payload.get("transition")
             if args.execute_transition:
-                if registry_path is None:
-                    raise ValueError("--execute-transition requires a LoopX registry")
-                if not args.goal_id:
-                    raise ValueError("--execute-transition requires --goal-id")
-                if not args.claimed_by:
-                    raise ValueError("--execute-transition requires --claimed-by")
                 if not isinstance(transition, dict):
                     raise ValueError("PR lifecycle transition is missing")
+                grouped_monitor_writeback = materialize_issue_fix_grouped_monitors(
+                    registry_path=registry_path,
+                    goal_id=args.goal_id,
+                    project=Path(args.project).expanduser(),
+                    ledger_path=ledger_path,
+                    claimed_by=args.claimed_by,
+                    cadence=args.monitor_cadence,
+                    generated_at=str(payload.get("generated_at") or generated_at),
+                )
+                payload["grouped_monitor_writeback"] = grouped_monitor_writeback
+                grouped_monitor_projection = payload.get("grouped_monitor_projection")
+                if isinstance(grouped_monitor_projection, dict):
+                    grouped_monitor_projection["todo_write_performed"] = bool(
+                        grouped_monitor_writeback.get("write_performed")
+                    )
                 decision = str(transition.get("decision") or "")
                 if decision in {"runnable_successor", "user_gate"}:
                     role = str(transition.get("role") or "agent")
@@ -1348,6 +1376,26 @@ def handle_issue_fix_command(
                         ),
                         "path_recorded": False,
                     }
+                grouped_write_performed = bool(
+                    grouped_monitor_writeback.get("write_performed")
+                )
+                transition_write_performed = bool(payload.get("todo_write_performed"))
+                payload["todo_write_performed"] = bool(
+                    grouped_write_performed or transition_write_performed
+                )
+                if grouped_write_performed and not transition_write_performed:
+                    payload["todo_write"] = {
+                        "schema_version": "issue_fix_pr_lifecycle_todo_write_v1",
+                        "write_performed": True,
+                        "grouped_monitor_write_performed": True,
+                        "transition_write_performed": False,
+                        "path_recorded": False,
+                    }
+                writeback_contract = payload.get("writeback_contract")
+                if isinstance(writeback_contract, dict):
+                    writeback_contract["todo_write_performed"] = bool(
+                        payload["todo_write_performed"]
+                    )
                 validation = validate_issue_fix_pr_lifecycle_monitor_packet(payload)
                 payload["validation"] = validation
                 payload["ok"] = bool(validation["ok"])

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -1244,6 +1244,10 @@ def handle_issue_fix_command(
                 raise ValueError(
                     "--fetch-metadata cannot be combined with --metadata-json"
                 )
+            fetch_metadata = bool(
+                args.fetch_metadata
+                or (args.execute_transition and args.url and not args.metadata_json)
+            )
             if args.execute_transition and args.no_write_domain_state:
                 raise ValueError(
                     "--execute-transition cannot be combined with --no-write-domain-state"
@@ -1262,7 +1266,7 @@ def handle_issue_fix_command(
                 provider_payload=_load_json_object(args.metadata_json)
                 if args.metadata_json
                 else None,
-                fetch_metadata=args.fetch_metadata,
+                fetch_metadata=fetch_metadata,
                 fetch_timeout_seconds=args.fetch_timeout_seconds,
                 maintainer_correction_input=(
                     _load_json_object(args.maintainer_correction_json)

--- a/loopx/capabilities/issue_fix/pr_lifecycle.py
+++ b/loopx/capabilities/issue_fix/pr_lifecycle.py
@@ -570,6 +570,19 @@ def _observation_fingerprint(observation: Mapping[str, Any]) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
 
 
+def issue_fix_grouped_monitor_identity(
+    *, repository: str, state_bucket: str
+) -> tuple[str, str]:
+    """Return stable repository-scoped monitor target and action identities."""
+
+    repository_key = repository.casefold().replace("/", "--")
+    bucket_key = state_bucket.replace("_", "-")
+    return (
+        f"github-pr-state-{repository_key}-{bucket_key}",
+        f"issue_fix_pr_state_{state_bucket}_monitor",
+    )
+
+
 def _grouped_monitor_projection(
     observation: Mapping[str, Any], transition: Mapping[str, Any]
 ) -> dict[str, Any]:
@@ -608,17 +621,18 @@ def _grouped_monitor_projection(
 
     terminal = state_bucket == "terminal"
     member_key = f"{observation.get('repo')}#{observation.get('number')}"
-    target_key = (
-        None if terminal else f"github-pr-state-{state_bucket.replace('_', '-')}"
+    repository = str(observation.get("repo") or "unknown")
+    target_key, action_kind = issue_fix_grouped_monitor_identity(
+        repository=repository,
+        state_bucket=state_bucket,
     )
     return {
         "schema_version": ISSUE_FIX_PR_GROUPED_MONITOR_PROJECTION_SCHEMA_VERSION,
         "scope": "repository_pr_lifecycle_state",
+        "repository": repository,
         "state_bucket": state_bucket,
-        "target_key": target_key,
-        "action_kind": (
-            None if terminal else f"issue_fix_pr_state_{state_bucket}_monitor"
-        ),
+        "target_key": None if terminal else target_key,
+        "action_kind": None if terminal else action_kind,
         "member_key": member_key,
         "member_operation": "remove" if terminal else "upsert",
         "materialize_nonempty_bucket_monitor": not terminal,
@@ -988,7 +1002,9 @@ def build_issue_fix_pr_lifecycle_monitor_packet(
         "first_screen": {
             "waiting_on": transition["role"],
             "user_action_required": transition["role"] == "user",
-            "agent_can_continue": transition["decision"] == "runnable_successor",
+            "agent_can_continue": transition["decision"] != "user_gate",
+            "current_pr_actionable": transition["decision"] == "runnable_successor",
+            "immediate_repoll_required": False,
             "next_safe_action": transition["reason"],
         },
         "writeback_contract": {

--- a/loopx/capabilities/issue_fix/pr_monitor_materialization.py
+++ b/loopx/capabilities/issue_fix/pr_monitor_materialization.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from ...control_plane.scheduler.monitor_todo import (
+    monitor_next_due_at,
+    parse_monitor_counter,
+)
+from ...control_plane.todos.active_state_editing import section_bounds, todo_blocks
+from ...todos import (
+    add_goal_todo,
+    complete_goal_todo,
+    resolve_todo_state,
+    update_goal_todo,
+)
+
+ISSUE_FIX_GROUPED_MONITOR_WRITEBACK_SCHEMA_VERSION = (
+    "issue_fix_grouped_monitor_writeback_v0"
+)
+DEFAULT_ISSUE_FIX_MONITOR_CADENCE = "30m"
+
+
+def _load_lifecycle_rows(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line_number, raw_line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        if not raw_line.strip():
+            continue
+        try:
+            row = json.loads(raw_line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"issue-fix PR lifecycle ledger line {line_number} is invalid JSON"
+            ) from exc
+        if not isinstance(row, dict):
+            raise TypeError(
+                f"issue-fix PR lifecycle ledger line {line_number} must be an object"
+            )
+        rows.append(row)
+    return rows
+
+
+def _active_grouped_monitors(
+    rows: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    grouped: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        projection = row.get("grouped_monitor_projection")
+        if not isinstance(projection, Mapping):
+            continue
+        if projection.get("materialize_nonempty_bucket_monitor") is not True:
+            continue
+        target_key = str(projection.get("target_key") or "").strip()
+        member_key = str(projection.get("member_key") or "").strip()
+        action_kind = str(projection.get("action_kind") or "").strip()
+        state_bucket = str(projection.get("state_bucket") or "").strip()
+        repository = str(projection.get("repository") or "").strip()
+        if (
+            not target_key
+            or not member_key
+            or not action_kind
+            or not state_bucket
+            or not repository
+        ):
+            continue
+        group = grouped.setdefault(
+            target_key,
+            {
+                "target_key": target_key,
+                "action_kind": action_kind,
+                "state_bucket": state_bucket,
+                "repository": repository,
+                "member_keys": set(),
+            },
+        )
+        group["member_keys"].add(member_key)
+    return grouped
+
+
+def _existing_issue_fix_monitors(
+    *, registry_path: Path, goal_id: str, project: Path
+) -> dict[str, dict[str, Any]]:
+    _resolved_project, _state_file, _text, lines = resolve_todo_state(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        project=project,
+    )
+    bounds = section_bounds(lines, "agent")
+    if not bounds:
+        return {}
+    start, end, section = bounds
+    monitors: dict[str, dict[str, Any]] = {}
+    for item in todo_blocks(
+        lines,
+        start,
+        end,
+        role="agent",
+        source_section=section,
+    ):
+        target_key = str(item.get("target_key") or "").strip()
+        action_kind = str(item.get("action_kind") or "").strip()
+        if (
+            item.get("task_class") == "continuous_monitor"
+            and target_key.startswith("github-pr-state-")
+            and action_kind.startswith("issue_fix_pr_state_")
+        ):
+            monitors[target_key] = item
+    return monitors
+
+
+def _group_fingerprint(member_keys: set[str]) -> str:
+    encoded = json.dumps(sorted(member_keys), separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()[:16]
+
+
+def materialize_issue_fix_grouped_monitors(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    project: Path,
+    ledger_path: Path,
+    claimed_by: str,
+    cadence: str,
+    generated_at: str,
+) -> dict[str, Any]:
+    """Reconcile issue-fix PR lifecycle buckets into generic monitor todos."""
+
+    groups = _active_grouped_monitors(_load_lifecycle_rows(ledger_path))
+    existing = _existing_issue_fix_monitors(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        project=project,
+    )
+    next_due_at = monitor_next_due_at(
+        generated_at=generated_at,
+        cadence=cadence,
+    )
+    if next_due_at is None:
+        raise ValueError("issue-fix grouped monitor cadence must be parseable")
+
+    writes: list[dict[str, Any]] = []
+    for target_key, group in sorted(groups.items()):
+        member_keys = set(group["member_keys"])
+        result_hash = _group_fingerprint(member_keys)
+        previous = existing.get(target_key)
+        previous_hash = str((previous or {}).get("result_hash") or "")
+        reopening = bool((previous or {}).get("done"))
+        material_change = reopening or previous_hash != result_hash
+        previous_no_change = parse_monitor_counter(
+            (previous or {}).get("consecutive_no_change")
+        )
+        monitor_metadata = {
+            "target_key": target_key,
+            "cadence": cadence,
+            "next_due_at": next_due_at,
+            "last_checked_at": generated_at,
+            "result_hash": result_hash,
+            "consecutive_no_change": (
+                "0" if material_change else str(previous_no_change + 1)
+            ),
+            "material_change": "true" if material_change else "false",
+        }
+        reason = (
+            f"Issue-fix PR lifecycle bucket {group['state_bucket']} contains "
+            f"{len(member_keys)} active member(s)."
+        )
+        if previous:
+            schedule_complete = bool(
+                str(previous.get("cadence") or "").strip() == cadence
+                and str(previous.get("next_due_at") or "").strip()
+            )
+            if not reopening and not material_change and schedule_complete:
+                writes.append(
+                    {
+                        "operation": "unchanged",
+                        "target_key": target_key,
+                        "write_performed": False,
+                    }
+                )
+                continue
+            result = update_goal_todo(
+                registry_path=registry_path,
+                goal_id=goal_id,
+                todo_id=str(previous["todo_id"]),
+                role="agent",
+                status="open" if reopening else None,
+                reason=reason,
+                monitor_metadata=monitor_metadata,
+                no_followup=False if reopening else None,
+                agent_id=claimed_by,
+                project=project,
+            )
+            writes.append(
+                {
+                    "operation": "update",
+                    "target_key": target_key,
+                    "write_performed": bool(result.get("changed")),
+                }
+            )
+            continue
+        result = add_goal_todo(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            role="agent",
+            text=(
+                f"[P2] Monitor {group['repository']} issue-fix PR lifecycle "
+                f"bucket {group['state_bucket']} for material changes."
+            ),
+            task_class="continuous_monitor",
+            action_kind=str(group["action_kind"]),
+            claimed_by=claimed_by,
+            monitor_metadata=monitor_metadata,
+            project=project,
+        )
+        writes.append(
+            {
+                "operation": "add",
+                "target_key": target_key,
+                "write_performed": bool(
+                    result.get("added") or result.get("metadata_updated")
+                ),
+            }
+        )
+
+    for target_key, item in sorted(existing.items()):
+        if target_key in groups or item.get("done") is True:
+            continue
+        result = complete_goal_todo(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            todo_id=str(item["todo_id"]),
+            role="agent",
+            evidence=f"Issue-fix PR lifecycle bucket {target_key} is empty.",
+            no_followup=True,
+            claimed_by=str(item.get("claimed_by") or claimed_by),
+            agent_id=claimed_by,
+            project=project,
+        )
+        writes.append(
+            {
+                "operation": "complete",
+                "target_key": target_key,
+                "write_performed": bool(result.get("changed")),
+            }
+        )
+
+    return {
+        "schema_version": ISSUE_FIX_GROUPED_MONITOR_WRITEBACK_SCHEMA_VERSION,
+        "write_performed": any(item["write_performed"] for item in writes),
+        "path_recorded": False,
+        "active_bucket_count": len(groups),
+        "active_member_count": sum(
+            len(group["member_keys"]) for group in groups.values()
+        ),
+        "next_due_at": next_due_at if groups else None,
+        "writes": writes,
+    }

--- a/loopx/capabilities/issue_fix/pr_monitor_materialization.py
+++ b/loopx/capabilities/issue_fix/pr_monitor_materialization.py
@@ -10,11 +10,10 @@ from ...control_plane.scheduler.monitor_todo import (
     monitor_next_due_at,
     parse_monitor_counter,
 )
-from ...control_plane.todos.active_state_editing import section_bounds, todo_blocks
 from ...todos import (
     add_goal_todo,
     complete_goal_todo,
-    resolve_todo_state,
+    list_goal_todos,
     update_goal_todo,
 )
 
@@ -87,23 +86,16 @@ def _active_grouped_monitors(
 def _existing_issue_fix_monitors(
     *, registry_path: Path, goal_id: str, project: Path
 ) -> dict[str, dict[str, Any]]:
-    _resolved_project, _state_file, _text, lines = resolve_todo_state(
+    payload = list_goal_todos(
         registry_path=registry_path,
         goal_id=goal_id,
+        role="agent",
         project=project,
     )
-    bounds = section_bounds(lines, "agent")
-    if not bounds:
-        return {}
-    start, end, section = bounds
     monitors: dict[str, dict[str, Any]] = {}
-    for item in todo_blocks(
-        lines,
-        start,
-        end,
-        role="agent",
-        source_section=section,
-    ):
+    for item in payload.get("todos") or []:
+        if not isinstance(item, dict):
+            continue
         target_key = str(item.get("target_key") or "").strip()
         action_kind = str(item.get("action_kind") or "").strip()
         if (

--- a/loopx/capabilities/issue_fix/reviewer_notification_drain.py
+++ b/loopx/capabilities/issue_fix/reviewer_notification_drain.py
@@ -12,6 +12,7 @@ from ...domain_packs.issue_fix import (
     persist_issue_fix_reviewer_notification_state,
 )
 from .cli_input import load_jsonl_rows
+from .pr_lifecycle import issue_fix_grouped_monitor_identity
 from .reviewer_notification import (
     CommandRunner,
     NotificationSinkAdapter,
@@ -100,12 +101,14 @@ def _row_with_live_lifecycle_facts(
     fresh_grouped = dict(grouped) if isinstance(grouped, Mapping) else {}
     fresh_grouped["state_bucket"] = state_bucket
     terminal = state_bucket == "terminal"
-    fresh_grouped["target_key"] = (
-        None if terminal else f"github-pr-state-{state_bucket.replace('_', '-')}"
+    repository = str(fresh_observation.get("repo") or "unknown")
+    target_key, action_kind = issue_fix_grouped_monitor_identity(
+        repository=repository,
+        state_bucket=state_bucket,
     )
-    fresh_grouped["action_kind"] = (
-        None if terminal else f"issue_fix_pr_state_{state_bucket}_monitor"
-    )
+    fresh_grouped["repository"] = repository
+    fresh_grouped["target_key"] = None if terminal else target_key
+    fresh_grouped["action_kind"] = None if terminal else action_kind
     fresh_grouped["member_operation"] = "remove" if terminal else "upsert"
     fresh_grouped["materialize_nonempty_bucket_monitor"] = not terminal
     updated["grouped_monitor_projection"] = fresh_grouped

--- a/loopx/capabilities/issue_fix/workflow_plan.py
+++ b/loopx/capabilities/issue_fix/workflow_plan.py
@@ -88,8 +88,6 @@ def build_issue_fix_goal_command_templates(
         "issue_fix_pr_lifecycle_template": (
             f"{cli} issue-fix pr-lifecycle "
             "--url <github-pr-url> "
-            "--project <approved-repo> "
-            "--fetch-metadata "
             f"--goal-id {goal} "
             f"--claimed-by {agent} "
             "--execute-transition "

--- a/loopx/capabilities/issue_fix/workflow_plan.py
+++ b/loopx/capabilities/issue_fix/workflow_plan.py
@@ -50,7 +50,7 @@ def match_issue_fix_goal_intent(goal_text: str | None) -> str | None:
 
 
 def build_issue_fix_goal_command_templates(
-    *, cli_bin: str, goal_id: str
+    *, cli_bin: str, goal_id: str, agent_id: str = "<agent-id>"
 ) -> dict[str, str]:
     """Return the capability-owned commands projected into goal-start packets."""
 
@@ -59,6 +59,11 @@ def build_issue_fix_goal_command_templates(
         goal_id
         if goal_id.startswith("<") and goal_id.endswith(">")
         else shlex.quote(goal_id)
+    )
+    agent = (
+        agent_id
+        if agent_id.startswith("<") and agent_id.endswith(">")
+        else shlex.quote(agent_id)
     )
     return {
         "issue_fix_workflow_plan_template": (
@@ -83,7 +88,11 @@ def build_issue_fix_goal_command_templates(
         "issue_fix_pr_lifecycle_template": (
             f"{cli} issue-fix pr-lifecycle "
             "--url <github-pr-url> "
+            "--project <approved-repo> "
+            "--fetch-metadata "
             f"--goal-id {goal} "
+            f"--claimed-by {agent} "
+            "--execute-transition "
             "--format json"
         ),
         "issue_fix_reviewer_request_template": (

--- a/loopx/capabilities/issue_fix/workflow_plan.py
+++ b/loopx/capabilities/issue_fix/workflow_plan.py
@@ -49,6 +49,44 @@ def match_issue_fix_goal_intent(goal_text: str | None) -> str | None:
     return "issue_fix_intent" if _ISSUE_FIX_TARGET.search(text) and has_action else None
 
 
+def _command_arg(value: str) -> str:
+    if value.startswith("<") and value.endswith(">"):
+        return value
+    return shlex.quote(value)
+
+
+def build_issue_fix_pr_lifecycle_command(
+    *,
+    cli_bin: str,
+    goal_id: str,
+    agent_id: str,
+    project: str | None = None,
+) -> str:
+    """Build the canonical executable PR lifecycle reconciliation command."""
+
+    parts = [
+        shlex.quote(cli_bin),
+        "issue-fix",
+        "pr-lifecycle",
+        "--url",
+        "<github-pr-url>",
+    ]
+    if project:
+        parts.extend(["--project", _command_arg(project)])
+    parts.extend(
+        [
+            "--goal-id",
+            _command_arg(goal_id),
+            "--claimed-by",
+            _command_arg(agent_id),
+            "--execute-transition",
+            "--format",
+            "json",
+        ]
+    )
+    return " ".join(parts)
+
+
 def build_issue_fix_goal_command_templates(
     *, cli_bin: str, goal_id: str, agent_id: str = "<agent-id>"
 ) -> dict[str, str]:
@@ -59,11 +97,6 @@ def build_issue_fix_goal_command_templates(
         goal_id
         if goal_id.startswith("<") and goal_id.endswith(">")
         else shlex.quote(goal_id)
-    )
-    agent = (
-        agent_id
-        if agent_id.startswith("<") and agent_id.endswith(">")
-        else shlex.quote(agent_id)
     )
     return {
         "issue_fix_workflow_plan_template": (
@@ -85,13 +118,10 @@ def build_issue_fix_goal_command_templates(
             f"--goal-id {goal} "
             "--format json"
         ),
-        "issue_fix_pr_lifecycle_template": (
-            f"{cli} issue-fix pr-lifecycle "
-            "--url <github-pr-url> "
-            f"--goal-id {goal} "
-            f"--claimed-by {agent} "
-            "--execute-transition "
-            "--format json"
+        "issue_fix_pr_lifecycle_template": build_issue_fix_pr_lifecycle_command(
+            cli_bin=cli_bin,
+            goal_id=goal_id,
+            agent_id=agent_id,
         ),
         "issue_fix_reviewer_request_template": (
             f"{cli} issue-fix reviewer-request "
@@ -203,9 +233,11 @@ def _resolution_route_candidates(
 def _post_pr_lifecycle_monitor_plan() -> dict[str, Any]:
     return {
         "schema_version": "issue_fix_post_pr_lifecycle_monitor_plan_v1",
-        "command_preview": (
-            "loopx issue-fix pr-lifecycle --url <github-pr-url> "
-            "--metadata-json <public-pr-state.json> --format json"
+        "command_preview": build_issue_fix_pr_lifecycle_command(
+            cli_bin="loopx",
+            goal_id="<goal-id>",
+            agent_id="<agent-id>",
+            project="<approved-repo>",
         ),
         "creates_per_pr_continuous_monitor_todo": False,
         "monitor_scope": "lifecycle_state_bucket",

--- a/tests/capabilities/test_issue_fix_grouped_monitor_materialization.py
+++ b/tests/capabilities/test_issue_fix_grouped_monitor_materialization.py
@@ -5,6 +5,9 @@ import io
 import json
 from pathlib import Path
 
+import pytest
+
+from loopx.capabilities.issue_fix import pr_lifecycle
 from loopx.capabilities.issue_fix.pr_lifecycle import (
     build_issue_fix_pr_lifecycle_monitor_packet,
 )
@@ -257,3 +260,57 @@ def test_pr_lifecycle_execute_materializes_pending_monitor_and_keeps_goal_runnab
     assert active.count("task_class=continuous_monitor") == 1
     assert "target_key=github-pr-state-huangruiteng--loopx-checks-pending" in active
     assert "task_class=advancement_task" in active
+
+
+def test_pr_lifecycle_execute_fetches_public_metadata_by_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project, state, registry = _fixture(tmp_path)
+
+    def fake_fetch(reference: dict, *, timeout_seconds: int) -> dict:
+        assert reference["repo"] == "huangruiteng/loopx"
+        assert timeout_seconds == 10
+        return {
+            "state": "OPEN",
+            "reviewDecision": "REVIEW_REQUIRED",
+            "mergeStateStatus": "CLEAN",
+            "statusCheckRollup": [{"name": "integration", "status": "IN_PROGRESS"}],
+        }
+
+    monkeypatch.setattr(
+        pr_lifecycle,
+        "fetch_github_pr_lifecycle_payload",
+        fake_fetch,
+    )
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        assert (
+            cli_main(
+                [
+                    "--registry",
+                    str(registry),
+                    "--format",
+                    "json",
+                    "issue-fix",
+                    "pr-lifecycle",
+                    "--url",
+                    "https://github.com/huangruiteng/loopx/pull/101",
+                    "--goal-id",
+                    GOAL_ID,
+                    "--project",
+                    str(project),
+                    "--claimed-by",
+                    AGENT_ID,
+                    "--execute-transition",
+                    "--generated-at",
+                    "2026-08-01T16:00:00Z",
+                ]
+            )
+            == 0
+        )
+
+    payload = json.loads(output.getvalue())
+    assert payload["ok"] is True
+    assert payload["external_reads_performed"] is True
+    assert state.read_text(encoding="utf-8").count("task_class=continuous_monitor") == 1

--- a/tests/capabilities/test_issue_fix_grouped_monitor_materialization.py
+++ b/tests/capabilities/test_issue_fix_grouped_monitor_materialization.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+from pathlib import Path
+
+from loopx.capabilities.issue_fix.pr_lifecycle import (
+    build_issue_fix_pr_lifecycle_monitor_packet,
+)
+from loopx.capabilities.issue_fix.pr_monitor_materialization import (
+    materialize_issue_fix_grouped_monitors,
+)
+from loopx.cli import main as cli_main
+from loopx.domain_packs.issue_fix import (
+    upsert_issue_fix_pr_lifecycle_ledger_jsonl,
+)
+
+GOAL_ID = "issue-fix-monitor-goal"
+AGENT_ID = "issue-fix-worker"
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
+    project = tmp_path / "repo"
+    state = project / "ACTIVE_GOAL_STATE.md"
+    state.parent.mkdir(parents=True)
+    state.write_text(
+        "## User Todo / Owner Review Reading Queue\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P0] Continue independent issue-fix work.\n"
+        "  <!-- loopx:todo todo_id=todo_advancement status=open "
+        "task_class=advancement_task claimed_by=issue-fix-worker -->\n",
+        encoding="utf-8",
+    )
+    registry = tmp_path / "registry.global.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": state.name,
+                        "adapter": {"kind": "harness_self_improvement"},
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": [AGENT_ID],
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    return project, state, registry
+
+
+def _packet(
+    number: int,
+    *,
+    state: str = "OPEN",
+    owner: str = "huangruiteng",
+    repo: str = "loopx",
+) -> dict:
+    status_rollup = (
+        [{"name": "integration", "status": "IN_PROGRESS"}]
+        if state == "OPEN"
+        else [{"name": "integration", "conclusion": "SUCCESS"}]
+    )
+    return build_issue_fix_pr_lifecycle_monitor_packet(
+        url=f"https://github.com/{owner}/{repo}/pull/{number}",
+        provider_payload={
+            "state": state,
+            "reviewDecision": "REVIEW_REQUIRED",
+            "mergeStateStatus": "CLEAN",
+            "statusCheckRollup": status_rollup,
+        },
+        generated_at="2026-08-01T16:00:00Z",
+    )
+
+
+def test_grouped_monitor_materialization_is_one_per_bucket_and_retires_empty_bucket(
+    tmp_path: Path,
+) -> None:
+    project, state, registry = _fixture(tmp_path)
+    ledger = tmp_path / "pr-lifecycle.jsonl"
+    first = _packet(101)
+    second = _packet(102)
+    upsert_issue_fix_pr_lifecycle_ledger_jsonl(ledger, first)
+    upsert_issue_fix_pr_lifecycle_ledger_jsonl(ledger, second)
+
+    created = materialize_issue_fix_grouped_monitors(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        project=project,
+        ledger_path=ledger,
+        claimed_by=AGENT_ID,
+        cadence="30m",
+        generated_at="2026-08-01T16:00:00Z",
+    )
+
+    assert created["write_performed"] is True
+    assert created["active_bucket_count"] == 1
+    assert created["active_member_count"] == 2
+    assert created["next_due_at"] == "2026-08-02T00:30:00+08:00"
+    active = state.read_text(encoding="utf-8")
+    assert active.count("task_class=continuous_monitor") == 1
+    assert "target_key=github-pr-state-huangruiteng--loopx-checks-pending" in active
+    assert "cadence=30m" in active
+    assert "next_due_at=2026-08-02T00:30:00%2B08:00" in active
+
+    unchanged = materialize_issue_fix_grouped_monitors(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        project=project,
+        ledger_path=ledger,
+        claimed_by=AGENT_ID,
+        cadence="30m",
+        generated_at="2026-08-01T16:01:00Z",
+    )
+    assert unchanged["active_bucket_count"] == 1
+    assert unchanged["write_performed"] is False
+    assert state.read_text(encoding="utf-8").count("task_class=continuous_monitor") == 1
+
+    upsert_issue_fix_pr_lifecycle_ledger_jsonl(ledger, _packet(101, state="MERGED"))
+    upsert_issue_fix_pr_lifecycle_ledger_jsonl(ledger, _packet(102, state="MERGED"))
+    retired = materialize_issue_fix_grouped_monitors(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        project=project,
+        ledger_path=ledger,
+        claimed_by=AGENT_ID,
+        cadence="30m",
+        generated_at="2026-08-01T16:02:00Z",
+    )
+
+    assert retired["active_bucket_count"] == 0
+    assert retired["write_performed"] is True
+    final_state = state.read_text(encoding="utf-8")
+    assert "status=done" in final_state
+    assert (
+        "evidence=Issue-fix%20PR%20lifecycle%20bucket%20"
+        "github-pr-state-huangruiteng--loopx-checks-pending%20is%20empty."
+    ) in final_state
+
+    upsert_issue_fix_pr_lifecycle_ledger_jsonl(ledger, _packet(103))
+    reopened = materialize_issue_fix_grouped_monitors(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        project=project,
+        ledger_path=ledger,
+        claimed_by=AGENT_ID,
+        cadence="30m",
+        generated_at="2026-08-01T16:03:00Z",
+    )
+    assert reopened["write_performed"] is True
+    reopened_state = state.read_text(encoding="utf-8")
+    assert reopened_state.count("task_class=continuous_monitor") == 1
+    assert "status=open" in reopened_state
+    assert "no_followup=true" not in reopened_state
+
+
+def test_grouped_monitors_are_isolated_per_repository(tmp_path: Path) -> None:
+    project, state, registry = _fixture(tmp_path)
+    ledger = tmp_path / "pr-lifecycle.jsonl"
+    upsert_issue_fix_pr_lifecycle_ledger_jsonl(ledger, _packet(101))
+    upsert_issue_fix_pr_lifecycle_ledger_jsonl(
+        ledger,
+        _packet(202, owner="openai", repo="codex"),
+    )
+
+    result = materialize_issue_fix_grouped_monitors(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        project=project,
+        ledger_path=ledger,
+        claimed_by=AGENT_ID,
+        cadence="30m",
+        generated_at="2026-08-01T16:00:00Z",
+    )
+
+    assert result["active_bucket_count"] == 2
+    assert result["active_member_count"] == 2
+    active = state.read_text(encoding="utf-8")
+    assert active.count("task_class=continuous_monitor") == 2
+    assert "target_key=github-pr-state-huangruiteng--loopx-checks-pending" in active
+    assert "target_key=github-pr-state-openai--codex-checks-pending" in active
+
+
+def test_pr_lifecycle_execute_materializes_pending_monitor_and_keeps_goal_runnable(
+    tmp_path: Path,
+) -> None:
+    project, state, registry = _fixture(tmp_path)
+    metadata = tmp_path / "pr.json"
+    metadata.write_text(
+        json.dumps(
+            {
+                "state": "OPEN",
+                "reviewDecision": "REVIEW_REQUIRED",
+                "mergeStateStatus": "CLEAN",
+                "statusCheckRollup": [{"name": "integration", "status": "IN_PROGRESS"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        assert (
+            cli_main(
+                [
+                    "--registry",
+                    str(registry),
+                    "--format",
+                    "json",
+                    "issue-fix",
+                    "pr-lifecycle",
+                    "--url",
+                    "https://github.com/huangruiteng/loopx/pull/101",
+                    "--metadata-json",
+                    str(metadata),
+                    "--goal-id",
+                    GOAL_ID,
+                    "--project",
+                    str(project),
+                    "--claimed-by",
+                    AGENT_ID,
+                    "--execute-transition",
+                    "--generated-at",
+                    "2026-08-01T16:00:00Z",
+                ]
+            )
+            == 0
+        )
+    payload = json.loads(output.getvalue())
+
+    assert payload["ok"] is True
+    assert payload["transition"]["decision"] == "monitor_continuation"
+    assert payload["first_screen"] == (
+        payload["first_screen"]
+        | {
+            "agent_can_continue": True,
+            "current_pr_actionable": False,
+            "immediate_repoll_required": False,
+        }
+    )
+    assert payload["grouped_monitor_writeback"] == (
+        payload["grouped_monitor_writeback"]
+        | {
+            "write_performed": True,
+            "active_bucket_count": 1,
+            "active_member_count": 1,
+        }
+    )
+    assert payload["todo_write_performed"] is True
+    active = state.read_text(encoding="utf-8")
+    assert active.count("task_class=continuous_monitor") == 1
+    assert "target_key=github-pr-state-huangruiteng--loopx-checks-pending" in active
+    assert "task_class=advancement_task" in active

--- a/tests/capabilities/test_issue_fix_grouped_monitor_materialization.py
+++ b/tests/capabilities/test_issue_fix_grouped_monitor_materialization.py
@@ -9,22 +9,34 @@ from pathlib import Path
 import pytest
 
 from loopx.capabilities.issue_fix import pr_lifecycle
+from loopx.capabilities.catalog import BUILTIN_CAPABILITIES
 from loopx.capabilities.issue_fix.pr_lifecycle import (
     build_issue_fix_pr_lifecycle_monitor_packet,
 )
 from loopx.capabilities.issue_fix.pr_monitor_materialization import (
     materialize_issue_fix_grouped_monitors,
 )
+from loopx.capabilities.issue_fix.workflow_plan import (
+    build_issue_fix_goal_command_templates,
+    build_issue_fix_pr_lifecycle_command,
+)
 from loopx.cli import main as cli_main
+from loopx.control_plane.scheduler.monitor_poll_writeback import (
+    write_monitor_poll_todo_state,
+)
 from loopx.domain_packs.issue_fix import (
     upsert_issue_fix_pr_lifecycle_ledger_jsonl,
 )
+from loopx.todos import list_goal_todos
 
 GOAL_ID = "issue-fix-monitor-goal"
 AGENT_ID = "issue-fix-worker"
+PEER_AGENT_ID = "issue-fix-peer"
 
 
-def _fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
+def _fixture(
+    tmp_path: Path, *, registered_agents: list[str] | None = None
+) -> tuple[Path, Path, Path]:
     project = tmp_path / "repo"
     state = project / "ACTIVE_GOAL_STATE.md"
     state.parent.mkdir(parents=True)
@@ -49,7 +61,7 @@ def _fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
                         "adapter": {"kind": "harness_self_improvement"},
                         "coordination": {
                             "agent_model": "peer_v1",
-                            "registered_agents": [AGENT_ID],
+                            "registered_agents": registered_agents or [AGENT_ID],
                         },
                     }
                 ]
@@ -58,6 +70,20 @@ def _fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
         encoding="utf-8",
     )
     return project, state, registry
+
+
+def _monitor_todos(registry: Path, project: Path) -> list[dict]:
+    payload = list_goal_todos(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="agent",
+        project=project,
+    )
+    return [
+        item
+        for item in payload["todos"]
+        if item.get("task_class") == "continuous_monitor"
+    ]
 
 
 def _packet(
@@ -193,6 +219,154 @@ def test_grouped_monitors_are_isolated_per_repository(tmp_path: Path) -> None:
     assert active.count("task_class=continuous_monitor") == 2
     assert "target_key=github-pr-state-huangruiteng--loopx-checks-pending" in active
     assert "target_key=github-pr-state-openai--codex-checks-pending" in active
+
+
+def test_grouped_monitor_keeps_creator_ownership_across_turns_and_due_poll(
+    tmp_path: Path,
+) -> None:
+    project, state, registry = _fixture(
+        tmp_path,
+        registered_agents=[AGENT_ID, PEER_AGENT_ID],
+    )
+    ledger = tmp_path / "pr-lifecycle.jsonl"
+    upsert_issue_fix_pr_lifecycle_ledger_jsonl(ledger, _packet(101))
+
+    created = materialize_issue_fix_grouped_monitors(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        project=project,
+        ledger_path=ledger,
+        claimed_by=AGENT_ID,
+        cadence="30m",
+        generated_at="2026-08-01T16:00:00Z",
+    )
+    assert created["write_performed"] is True
+    monitors = _monitor_todos(registry, project)
+    assert len(monitors) == 1
+    monitor = monitors[0]
+    assert monitor["claimed_by"] == AGENT_ID
+    todo_id = monitor["todo_id"]
+
+    state_before_peer_poll = state.read_text(encoding="utf-8")
+    with pytest.raises(ValueError, match=f"claimed_by={AGENT_ID!r}"):
+        write_monitor_poll_todo_state(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=todo_id,
+            result_hash=monitor["result_hash"],
+            generated_at="2026-08-01T16:30:00Z",
+            execute=True,
+            agent_id=PEER_AGENT_ID,
+        )
+    assert state.read_text(encoding="utf-8") == state_before_peer_poll
+
+    polled = write_monitor_poll_todo_state(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        result_hash=monitor["result_hash"],
+        generated_at="2026-08-01T16:30:00Z",
+        execute=True,
+        agent_id=AGENT_ID,
+    )
+    assert polled is not None
+    assert polled["todo_update"]["mutation_authority"]["actor_agent_id"] == (
+        AGENT_ID
+    )
+    assert datetime.fromisoformat(polled["next_due_at"]).timestamp() == (
+        datetime.fromisoformat("2026-08-01T17:00:00+00:00").timestamp()
+    )
+
+    upsert_issue_fix_pr_lifecycle_ledger_jsonl(ledger, _packet(102))
+    state_before_peer_attempt = state.read_text(encoding="utf-8")
+    with pytest.raises(ValueError, match=f"claimed_by={AGENT_ID!r}"):
+        materialize_issue_fix_grouped_monitors(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            project=project,
+            ledger_path=ledger,
+            claimed_by=PEER_AGENT_ID,
+            cadence="30m",
+            generated_at="2026-08-01T16:31:00Z",
+        )
+    assert state.read_text(encoding="utf-8") == state_before_peer_attempt
+
+    changed_by_creator = materialize_issue_fix_grouped_monitors(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        project=project,
+        ledger_path=ledger,
+        claimed_by=AGENT_ID,
+        cadence="30m",
+        generated_at="2026-08-01T16:31:00Z",
+    )
+    assert changed_by_creator["write_performed"] is True
+    monitors = _monitor_todos(registry, project)
+    assert len(monitors) == 1
+    assert monitors[0]["todo_id"] == todo_id
+    assert monitors[0]["claimed_by"] == AGENT_ID
+
+    upsert_issue_fix_pr_lifecycle_ledger_jsonl(ledger, _packet(101, state="MERGED"))
+    upsert_issue_fix_pr_lifecycle_ledger_jsonl(ledger, _packet(102, state="MERGED"))
+    retired_by_creator = materialize_issue_fix_grouped_monitors(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        project=project,
+        ledger_path=ledger,
+        claimed_by=AGENT_ID,
+        cadence="30m",
+        generated_at="2026-08-01T16:32:00Z",
+    )
+    assert retired_by_creator["write_performed"] is True
+    assert _monitor_todos(registry, project)[0]["status"] == "done"
+
+    upsert_issue_fix_pr_lifecycle_ledger_jsonl(ledger, _packet(103))
+    reopened_by_creator = materialize_issue_fix_grouped_monitors(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        project=project,
+        ledger_path=ledger,
+        claimed_by=AGENT_ID,
+        cadence="30m",
+        generated_at="2026-08-01T16:33:00Z",
+    )
+    assert reopened_by_creator["write_performed"] is True
+    reopened = _monitor_todos(registry, project)[0]
+    assert reopened["todo_id"] == todo_id
+    assert reopened["status"] == "open"
+    assert reopened["claimed_by"] == AGENT_ID
+
+
+def test_pr_lifecycle_command_contract_is_shared_by_all_operator_surfaces() -> None:
+    canonical = build_issue_fix_pr_lifecycle_command(
+        cli_bin="loopx",
+        goal_id="goal-fixture",
+        agent_id="agent-fixture",
+    )
+    templates = build_issue_fix_goal_command_templates(
+        cli_bin="loopx",
+        goal_id="goal-fixture",
+        agent_id="agent-fixture",
+    )
+    assert templates["issue_fix_pr_lifecycle_template"] == canonical
+
+    issue_fix = next(item for item in BUILTIN_CAPABILITIES if item["id"] == "issue-fix")
+    catalog_command = next(
+        item["command"]
+        for item in issue_fix["commands"]
+        if "issue-fix pr-lifecycle" in item["command"]
+    )
+    assert catalog_command == build_issue_fix_pr_lifecycle_command(
+        cli_bin="loopx",
+        goal_id="<goal-id>",
+        agent_id="<agent-id>",
+        project="<repo>",
+    )
+    for command in (canonical, catalog_command):
+        assert "--goal-id" in command
+        assert "--claimed-by" in command
+        assert "--execute-transition" in command
+        assert "--fetch-metadata" not in command
 
 
 def test_pr_lifecycle_execute_materializes_pending_monitor_and_keeps_goal_runnable(

--- a/tests/capabilities/test_issue_fix_grouped_monitor_materialization.py
+++ b/tests/capabilities/test_issue_fix_grouped_monitor_materialization.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import io
 import json
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -106,12 +107,15 @@ def test_grouped_monitor_materialization_is_one_per_bucket_and_retires_empty_buc
     assert created["write_performed"] is True
     assert created["active_bucket_count"] == 1
     assert created["active_member_count"] == 2
-    assert created["next_due_at"] == "2026-08-02T00:30:00+08:00"
+    assert datetime.fromisoformat(created["next_due_at"]).timestamp() == (
+        datetime.fromisoformat("2026-08-01T16:30:00+00:00").timestamp()
+    )
     active = state.read_text(encoding="utf-8")
     assert active.count("task_class=continuous_monitor") == 1
     assert "target_key=github-pr-state-huangruiteng--loopx-checks-pending" in active
     assert "cadence=30m" in active
-    assert "next_due_at=2026-08-02T00:30:00%2B08:00" in active
+    encoded_next_due_at = created["next_due_at"].replace("+", "%2B")
+    assert f"next_due_at={encoded_next_due_at}" in active
 
     unchanged = materialize_issue_fix_grouped_monitors(
         registry_path=registry,


### PR DESCRIPTION
## What changed

- materialize `issue_fix_pr_grouped_monitor_projection_v1` into generic LoopX `continuous_monitor` todos
- keep exactly one monitor per repository and lifecycle bucket, with deterministic membership fingerprints and idempotent quiet replay
- retire empty buckets and reopen them when members return
- make the capability-owned `pr-lifecycle` command packet execute the transition with the selected agent identity
- preserve independent advancement work while the current PR is only waiting for CI or review

## Why

The issue-fix capability already projected grouped PR monitor state, but no runtime path consumed that projection. `todo_write_performed` therefore remained false, and long-running Goals could repeatedly poll one pending PR instead of scheduling a monitor and continuing other eligible work.

The existing target key also omitted the repository even though the protocol described repository-scoped buckets. That could merge same-state PRs from different repositories into one monitor.

This change closes the missing capability-to-Todo transaction. It does not add Goal or heartbeat prompt instructions.

## User and developer impact

`loopx issue-fix pr-lifecycle --execute-transition` now reconciles compact PR lifecycle domain state into generic Todo state. Pending CI/review becomes scheduled monitor work, while failed checks, requested changes, and user gates retain their existing one-shot transition behavior. Generated host command packets include the executable flags and selected agent identity.

## Validation

- focused pytest: 5 passed
- bootstrap command-pack smoke
- issue-fix PR lifecycle smoke
- maintainer-correction smoke
- issue-fix workflow-plan smoke
- agent-facing CLI output budget regression smoke
- `loopx canary premerge --from-git-diff --tier standard`: 18/18 selected checks passed
- public boundary scan: 12 files clean
- `git diff --check`
