### PR TITLE
test: align full public smokes with compact contracts

### DIFF
--- a/examples/codex-cli-bootstrap-message-smoke.py
+++ b/examples/codex-cli-bootstrap-message-smoke.py
@@ -124,7 +124,13 @@ def assert_docs_surface_codex_cli_quickstart() -> None:
     getting_started = (REPO_ROOT / "docs/guides/getting-started.md").read_text(encoding="utf-8")
     product_contract = (REPO_ROOT / "docs/product/codex-cli-tui-loop.md").read_text(encoding="utf-8")
 
-    for text in (readme, getting_started, product_contract):
+    assert "Codex CLI" in readme, readme[:500]
+    assert "Visible `/goal <task_body>`; no hidden headless execution by default" in readme
+    assert "docs/product/codex-cli-packaged-install.md" in readme
+    assert "docs/product/loopx-turn-codex-cli-quickstart.md" in readme
+    assert "loopx codex-cli-bootstrap-message" in readme
+
+    for text in (getting_started, product_contract):
         assert "Codex CLI" in text and "TUI" in text, text[:500]
         assert "Connect this repo to LoopX" in text, text[:500]
         assert "Do not clone the" in text, text[:500]
@@ -133,32 +139,29 @@ def assert_docs_surface_codex_cli_quickstart() -> None:
     for text in (getting_started, product_contract):
         assert "loopx codex-cli-bootstrap-message --project . --goal-id <goal-id>" in text, text[:500]
 
-    normalized_readme = " ".join(readme.split())
     normalized_getting_started = " ".join(getting_started.split())
     normalized_product_contract = " ".join(product_contract.split())
     assert "<project repo URL or current repo>" not in readme, readme
     assert "<project repo URL or current repo>" not in getting_started, getting_started
     assert "<项目仓库链接或当前 repo>" not in readme, readme
     assert "<项目仓库链接或当前 repo>" not in getting_started, getting_started
-    assert "Connect the current project to LoopX." in readme, readme
     assert "Connect the current project to LoopX." in getting_started, getting_started
-    assert "Hidden `codex exec` is not the default bootstrap path" in normalized_readme, readme
-    assert "paste one setup message" in normalized_readme, readme
-    assert "install, connect, and status check" in normalized_readme, readme
-    assert "heartbeat automation to start at 3 minutes" in normalized_readme, readme
+    assert "do not use hidden headless execution" in normalized_getting_started
+    assert "one TUI setup message" in normalized_product_contract
+    assert "install or reuse LoopX" in normalized_getting_started
+    assert "starts at 3 minutes" in normalized_getting_started
     assert (
         "set the current Codex CLI goal to `/goal <thin task_body>`"
         in normalized_product_contract
         or "set the current Codex CLI goal to `/goal <thin task_body>`"
         in normalized_getting_started
     ), product_contract
-    assert "reuse it" in normalized_readme, readme
+    assert "reuse it" in normalized_getting_started, getting_started
     assert "loopx codex-cli-bootstrap-message --project . --goal-id <goal-id>" not in readme, readme
     assert (
-        "status, current user gate, top agent todo, and next safe action" in normalized_readme
-        or "report the goal id, current user gate, top agent todo, and next safe action"
+        "report the active state id, current user gate, top agent todo, and next safe action"
         in normalized_getting_started
-    ), readme
+    ), getting_started
     assert "first-run path should not require you to understand registry paths" in normalized_getting_started, getting_started
     assert "setup-first rewrite of the App onboarding experience" in normalized_getting_started, getting_started
     assert "Codex App gets a heartbeat automation body that starts at 3 minutes" in normalized_getting_started, getting_started

--- a/examples/control_plane/control-plane-integrated-canary-smoke.py
+++ b/examples/control_plane/control-plane-integrated-canary-smoke.py
@@ -456,7 +456,8 @@ def assert_event_todo_completion_successor_state_machine(
     assert routed["decision"] == "run", routed
     assert routed["effective_action"] == "normal_run", routed
     assert routed["agent_lane_next_action"]["todo_id"] == successor_id, routed
-    assert routed["agent_lane_next_action"]["title"] == SUCCESSOR_TODO_TITLE, routed
+    assert routed["agent_lane_next_action"]["text"] == f"[P1] {SUCCESSOR_TODO_TITLE}", routed
+    assert "title" not in routed["agent_lane_next_action"], routed
     assert routed["agent_lane_next_action"]["preserves_goal_next_action"] is True, routed
     assert routed["active_state_next_action"] == "Keep the fixture-only integrated canary under two minutes.", routed
     assert routed["interaction_contract"]["mode"] == "bounded_delivery", routed

--- a/examples/control_plane/heartbeat-prompt-smoke.py
+++ b/examples/control_plane/heartbeat-prompt-smoke.py
@@ -736,8 +736,7 @@ def main() -> int:
 
     getting_started = GETTING_STARTED.read_text(encoding="utf-8")
     assert "docs/guides/getting-started.md" in readme, readme
-    assert "loopx heartbeat-prompt --thin" in readme, readme
-    assert "heartbeat automation to start at 3 minutes" in readme, readme
+    assert "loopx heartbeat-prompt" in readme, readme
     assert "quota should-run.scheduler_hint" in readme, readme
     assert "loopx quota spend-slot" in readme, readme
     assert "Generate a guarded Codex App heartbeat body" in getting_started, getting_started

--- a/examples/control_plane/quota-contract-smoke.py
+++ b/examples/control_plane/quota-contract-smoke.py
@@ -234,76 +234,25 @@ def main() -> int:
         label="quota doc",
     )
 
+    normalized_readme = " ".join(readme.split())
+    assert_contains(readme, "loopx quota should-run", label="README")
+    assert_contains(readme, "loopx quota spend-slot", label="README")
     assert_contains(
-        readme,
-        "The `next_automatic_turn` reported by `quota plan` is only an advisory scheduling hint",
+        normalized_readme,
+        "Automatic turns must check quota first and append spend only after validated writeback.",
+        label="README",
+    )
+    assert_contains(
+        normalized_readme,
+        "Quiet skips, preflight failures, and dry-run previews do not spend.",
         label="README",
     )
     assert_contains(
         readme,
-        "it chooses the highest-compute eligible goal",
+        "Scheduler cadence follows `quota should-run.scheduler_hint`",
         label="README",
     )
-    assert_contains(
-        readme,
-        "operator-gated, focus-waiting, waiting, throttled, paused, and health-blocked goals stay out of the eligible lane",
-        label="README",
-    )
-    assert_contains(
-        readme,
-        "`control_plane.self_repair.enabled=true` lets `quota should-run` return a bounded `decision=self_repair` contract",
-        label="README",
-    )
-    assert_contains(
-        readme,
-        "missing policy defaults off",
-        label="README",
-    )
-    assert_contains(
-        readme,
-        "`gate_prompt` or `operator_question`, the target heartbeat should proactively ask that concrete user/operator gate",
-        label="README",
-    )
-    assert_contains(
-        readme,
-        "do not call the turn \"no new user action\" while they remain open",
-        label="README",
-    )
-    assert_contains(
-        readme,
-        "its report still has to list existing open user todos",
-        label="README",
-    )
-    assert_contains(
-        readme,
-        "`notify_user_on_open_todo=true`",
-        label="README",
-    )
-    assert_contains(
-        readme,
-        "skip delivery work and quota spend for that blocker-push turn",
-        label="README",
-    )
-    assert_contains(
-        readme,
-        "`safe_bypass_allowed=true`, the heartbeat may still do one bounded read-only steering or analysis step",
-        label="README",
-    )
-    assert_contains(
-        readme,
-        "See `docs/quota-allocation.md` for the full allocation contract",
-        label="README",
-    )
-    assert_contains(
-        readme,
-        "After an automatic turn actually spends delivery compute, append one spend event",
-        label="README",
-    )
-    assert_contains(
-        readme,
-        "Do not append spend for quiet `should_run=false` skips, preflight failures, or pure dry-run previews",
-        label="README",
-    )
+    assert_contains(readme, "[Quota Allocation](docs/quota-allocation.md)", label="README")
     assert_contains(
         status_contract,
         "`loopx quota status` and `loopx quota plan` derive an agent-facing grouping from this same status payload",

--- a/examples/control_plane/refresh-state-shared-runtime-projection-smoke.py
+++ b/examples/control_plane/refresh-state-shared-runtime-projection-smoke.py
@@ -548,6 +548,8 @@ def main() -> None:
             AGENT_ID,
             "--available-capability",
             "shell",
+            "--include-detail",
+            "vision",
             cwd=project,
             shared_runtime=shared_runtime,
         )

--- a/examples/loopx-turn-codex-cli-quickstart-smoke.py
+++ b/examples/loopx-turn-codex-cli-quickstart-smoke.py
@@ -39,6 +39,12 @@ def main() -> int:
         "scenario owner",
         "loopx-turn-codex-cli-e2e-smoke.py",
         "codex_cli_model_requires_newer_codex",
+        "--real-codex-cli",
+        "--turn-count 3",
+        "validation_status=passed",
+        "session_resumed=true",
+        "committed_turn_count=3",
+        "three quota spends",
     ]:
         assert required in compact_text, required
 
@@ -55,17 +61,8 @@ def main() -> int:
     link = "loopx-turn-codex-cli-quickstart.md"
     assert link in product_index, "product index link"
     assert f"product/{link}" in docs_index, "docs index link"
-    for required in [
-        "Try Governed Turns Locally",
-        "--real-codex-cli",
-        "--turn-count 3",
-        "status=committed",
-        "validation_status=passed",
-        "session_resumed=true",
-        "committed_turn_count=3",
-        "quota_slot_spend_count=3",
-    ]:
-        assert required in readme, f"README local Turn quickstart: {required}"
+    assert "docs/product/loopx-turn-codex-cli-quickstart.md" in readme
+    assert "LoopX Turn for Codex CLI" in readme
 
     print("loopx-turn-codex-cli-quickstart-smoke ok")
     return 0


### PR DESCRIPTION
## Summary

- keep README smokes focused on stable entry points and links while detailed operator contracts stay in canonical docs
- align agent-lane assertions with intentional title deduplication in the compact quota payload
- request the explicit vision cold path when a smoke needs full acceptance-gap evidence

## Why

`main@7c3524b2` has passing Python Tests but failing Full Public Smokes. The failures combine stale README copy assertions after the landing-page simplification with integration assertions that still read fields intentionally omitted by the quota hot-path compactor. This change updates the durable smoke contracts without restoring removed README detail or weakening runtime behavior.

## Validation

- focused changed smoke scripts: bootstrap, Turn quickstart, heartbeat prompt, quota contract, and integrated canary passed
- `tests/control_plane/test_quota_cli_projection.py` and `tests/control_plane/test_cli_output_budget.py`: 22 passed
- `git diff --check`: passed
- the two shared-runtime refresh smokes are left for GitHub Linux validation because the local macOS fixture status subprocess stalls against local runtime discovery; the exact CI failure is addressed by requesting `--include-detail vision`
