### PR TITLE
feat(host): add typed Goal continuation contract

### DIFF
--- a/docs/reference/protocols/ark-managed-agent-goal-continuity-qualification-v0.md
+++ b/docs/reference/protocols/ark-managed-agent-goal-continuity-qualification-v0.md
@@ -17,6 +17,7 @@ an execution envelope.
 | Goal boundary, todo frontier, claims, evidence, quota, and leases | LoopX registry, active state, and event/runtime stores | Run a fresh `quota should-run`; never reconstruct the frontier from chat memory or an old prompt. |
 | Installed LoopX CLI and workflow skills | One fixed installer release | Read back one CLI/skills revision. Codex and Managed Agent differ only in the installer target root. |
 | Goal evaluation phase and terminal result | Goal host durable journal and event readback | Rehydrate before evaluating another completion. A journal existing on disk is not by itself proof that rehydration occurred. |
+| Continue, defer, or complete decision | `quota should-run.scheduler_hint.goal_runtime_continuation` | Consume the typed disposition and state identity; never derive wake behavior from the Goal prompt or evaluator prose. |
 | Host session id and in-memory transcript | Host session | Non-authoritative. It may help locate events, but its survival is not a continuity requirement. |
 
 ## Recovery sequence
@@ -26,12 +27,14 @@ After a pause, host replacement, or ambiguous transport failure:
 1. reopen the expected workspace and verify its repository identity;
 2. run installer/doctor readback and reject mixed CLI/skill revisions;
 3. read current LoopX status and run `quota should-run`;
-4. reconcile the selected todo, claim or lease, evidence, and workspace diff;
-5. inspect Goal-host events before retrying an activation whose admission is
+4. consume `goal_runtime_continuation_v0`; continue immediately, durably defer
+   for its bounded recheck, or complete the host Goal as directed;
+5. reconcile the selected todo, claim or lease, evidence, and workspace diff;
+6. inspect Goal-host events before retrying an activation whose admission is
    unknown;
-6. regenerate the current `task_body` from LoopX state and submit it once only
+7. regenerate the current `task_body` from LoopX state and submit it once only
    when the readback proves another activation is needed; and
-7. require both validated LoopX writeback and Goal-host terminal evidence
+8. require both validated LoopX writeback and Goal-host terminal evidence
    before calling the recovery complete.
 
 The regenerated prompt may be textually identical when the durable frontier

--- a/docs/reference/protocols/ark-managed-agent-goal-continuity-qualification-v0.md
+++ b/docs/reference/protocols/ark-managed-agent-goal-continuity-qualification-v0.md
@@ -17,7 +17,7 @@ an execution envelope.
 | Goal boundary, todo frontier, claims, evidence, quota, and leases | LoopX registry, active state, and event/runtime stores | Run a fresh `quota should-run`; never reconstruct the frontier from chat memory or an old prompt. |
 | Installed LoopX CLI and workflow skills | One fixed installer release | Read back one CLI/skills revision. Codex and Managed Agent differ only in the installer target root. |
 | Goal evaluation phase and terminal result | Goal host durable journal and event readback | Rehydrate before evaluating another completion. A journal existing on disk is not by itself proof that rehydration occurred. |
-| Continue, defer, or complete decision | `quota should-run.scheduler_hint.goal_runtime_continuation` | Consume the typed disposition, state identity, and defer wake policy; never derive wake behavior from the Goal prompt or evaluator prose. |
+| Continue, defer, or complete decision | `quota should-run.scheduler_hint.goal_runtime_continuation` | Consume the typed disposition and defer wake policy; read reason and state identity from the sibling scheduler fields named by the Host contract. Never derive wake behavior from the Goal prompt or evaluator prose. |
 | Host session id and in-memory transcript | Host session | Non-authoritative. It may help locate events, but its survival is not a continuity requirement. |
 
 ## Recovery sequence
@@ -27,9 +27,10 @@ After a pause, host replacement, or ambiguous transport failure:
 1. reopen the expected workspace and verify its repository identity;
 2. run installer/doctor readback and reject mixed CLI/skill revisions;
 3. read current LoopX status and run `quota should-run`;
-4. consume `goal_runtime_continuation_v0`; continue immediately, durably defer
-   until a fresh quota identity changes or the bounded recheck deadline arrives,
-   or complete the host Goal as directed;
+4. consume `goal_runtime_continuation_v0` plus the sibling scheduler reason and
+   reset identity; continue immediately, durably defer until the identity
+   changes or the bounded recheck deadline arrives, or complete the host Goal
+   as directed;
 5. reconcile the selected todo, claim or lease, evidence, and workspace diff;
 6. inspect Goal-host events before retrying an activation whose admission is
    unknown;

--- a/docs/reference/protocols/ark-managed-agent-goal-continuity-qualification-v0.md
+++ b/docs/reference/protocols/ark-managed-agent-goal-continuity-qualification-v0.md
@@ -17,7 +17,7 @@ an execution envelope.
 | Goal boundary, todo frontier, claims, evidence, quota, and leases | LoopX registry, active state, and event/runtime stores | Run a fresh `quota should-run`; never reconstruct the frontier from chat memory or an old prompt. |
 | Installed LoopX CLI and workflow skills | One fixed installer release | Read back one CLI/skills revision. Codex and Managed Agent differ only in the installer target root. |
 | Goal evaluation phase and terminal result | Goal host durable journal and event readback | Rehydrate before evaluating another completion. A journal existing on disk is not by itself proof that rehydration occurred. |
-| Continue, defer, or complete decision | `quota should-run.scheduler_hint.goal_runtime_continuation` | Consume the typed disposition and state identity; never derive wake behavior from the Goal prompt or evaluator prose. |
+| Continue, defer, or complete decision | `quota should-run.scheduler_hint.goal_runtime_continuation` | Consume the typed disposition, state identity, and defer wake policy; never derive wake behavior from the Goal prompt or evaluator prose. |
 | Host session id and in-memory transcript | Host session | Non-authoritative. It may help locate events, but its survival is not a continuity requirement. |
 
 ## Recovery sequence
@@ -28,7 +28,8 @@ After a pause, host replacement, or ambiguous transport failure:
 2. run installer/doctor readback and reject mixed CLI/skill revisions;
 3. read current LoopX status and run `quota should-run`;
 4. consume `goal_runtime_continuation_v0`; continue immediately, durably defer
-   for its bounded recheck, or complete the host Goal as directed;
+   until a fresh quota identity changes or the bounded recheck deadline arrives,
+   or complete the host Goal as directed;
 5. reconcile the selected todo, claim or lease, evidence, and workspace diff;
 6. inspect Goal-host events before retrying an activation whose admission is
    unknown;

--- a/docs/reference/protocols/host-integration-surface-v0.md
+++ b/docs/reference/protocols/host-integration-surface-v0.md
@@ -131,6 +131,15 @@ with a successor host Goal after screening, implementation, review, or another
 ordinary phase transition. Durable policy remains in current `quota
 should-run.interaction_contract`, active state, todos, vision, and writeback.
 
+For `--runtime-profile ark_managed_agent_goal`, the same quota read also emits
+`scheduler_hint.goal_runtime_continuation` with schema
+`goal_runtime_continuation_v0`. Its disposition is `continue_now`, `defer`, or
+`complete`; deferred results include a bounded `recheck_after_seconds`, while
+`state_identity` lets the host discard a stale timer after the frontier
+changes. This is the machine continuation contract. The Goal prompt is not
+rewritten to teach waiting policy, and the model is not asked to infer a wake
+time from prose.
+
 A dependent work step may begin only after material upstream results have
 crossed the durable boundary: update the current todo evidence and the next
 executable todo with any scope, acceptance, or non-goal delta, then refresh

--- a/docs/reference/protocols/host-integration-surface-v0.md
+++ b/docs/reference/protocols/host-integration-surface-v0.md
@@ -134,11 +134,19 @@ should-run.interaction_contract`, active state, todos, vision, and writeback.
 For `--runtime-profile ark_managed_agent_goal`, the same quota read also emits
 `scheduler_hint.goal_runtime_continuation` with schema
 `goal_runtime_continuation_v0`. Its disposition is `continue_now`, `defer`, or
-`complete`; deferred results include a bounded `recheck_after_seconds`, while
-`state_identity` lets the host discard a stale timer after the frontier
-changes. This is the machine continuation contract. The Goal prompt is not
-rewritten to teach waiting policy, and the model is not asked to infer a wake
-time from prose.
+`complete`. A deferred result includes a bounded `recheck_after_seconds` and a
+typed `wake_policy=state_change_or_deadline`: the host reruns quota when a
+durable frontier write changes the fresh `state_identity`, or no later than the
+recheck deadline. The deadline makes a due monitor runnable even without a push
+signal; provider-specific CI/review observation remains owned by its capability
+connector. This is the machine continuation contract. The Goal prompt is not
+rewritten to teach waiting policy, and the model is not used as a mechanical
+polling loop.
+
+`defer` is a whole-frontier decision, not a per-PR wait. A quiet CI/review
+monitor remains auxiliary context while any independent advancement todo is
+runnable, so that mixed frontier projects `continue_now`. Only a frontier with
+no executable advancement or due monitor may enter the deferred wake policy.
 
 A dependent work step may begin only after material upstream results have
 crossed the durable boundary: update the current todo evidence and the next

--- a/docs/reference/protocols/host-integration-surface-v0.md
+++ b/docs/reference/protocols/host-integration-surface-v0.md
@@ -136,12 +136,19 @@ For `--runtime-profile ark_managed_agent_goal`, the same quota read also emits
 `goal_runtime_continuation_v0`. Its disposition is `continue_now`, `defer`, or
 `complete`. A deferred result includes a bounded `recheck_after_seconds` and a
 typed `wake_policy=state_change_or_deadline`: the host reruns quota when a
-durable frontier write changes the fresh `state_identity`, or no later than the
-recheck deadline. The deadline makes a due monitor runnable even without a push
-signal; provider-specific CI/review observation remains owned by its capability
-connector. This is the machine continuation contract. The Goal prompt is not
-rewritten to teach waiting policy, and the model is not used as a mechanical
-polling loop.
+durable frontier write changes the sibling `scheduler_hint.reset_policy`
+identity, or no later than the recheck deadline. The continuation packet does
+not duplicate that identity or `scheduler_hint.reason_code`; their source refs
+are declared by the Host contract. The deadline makes a due monitor runnable
+even without a push signal; provider-specific CI/review observation remains
+owned by its capability connector. This is the machine continuation contract.
+The Goal prompt is not rewritten to teach waiting policy, and the model is not
+used as a mechanical polling loop.
+
+The state identity includes the selected Todo id, action, target, claim owner,
+and capability binding ref. Switching work or admission authority therefore
+wakes the Goal even when the rendered recommendation is unchanged; diagnostic
+notes and other non-contract detail do not create a wakeup.
 
 `defer` is a whole-frontier decision, not a per-PR wait. A quiet CI/review
 monitor remains auxiliary context while any independent advancement todo is

--- a/loopx/ark_managed_agent_host.py
+++ b/loopx/ark_managed_agent_host.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from typing import Any
 
+from .control_plane.scheduler.execution_context import (
+    GOAL_RUNTIME_CONTINUATION_SCHEMA_VERSION,
+)
 from .control_plane.work_items.runtime_capability_reentry import (
     RUNTIME_CAPABILITY_REENTRY_SCHEMA_VERSION,
 )
-
 
 ARK_MANAGED_AGENT_HOST = "ark-managed-agent"
 ARK_MANAGED_AGENT_HOST_CONTRACT_SCHEMA_VERSION = (
@@ -31,6 +33,12 @@ def build_ark_managed_agent_host_contract() -> dict[str, Any]:
         "phase_handoff_allowed": False,
         "loopx_turn_driver_required": False,
         "session_state_authoritative": False,
+        "goal_runtime_continuation": {
+            "source_ref": "quota_should_run.scheduler_hint.goal_runtime_continuation",
+            "packet_schema_version": GOAL_RUNTIME_CONTINUATION_SCHEMA_VERSION,
+            "dispositions": ["continue_now", "defer", "complete"],
+            "goal_prompt_mutated": False,
+        },
         "runtime_capability_reentry": {
             "source_ref": (
                 "quota_should_run.interaction_contract.cli_channel."

--- a/loopx/ark_managed_agent_host.py
+++ b/loopx/ark_managed_agent_host.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from .control_plane.scheduler.execution_context import (
     GOAL_RUNTIME_CONTINUATION_SCHEMA_VERSION,
-    GOAL_RUNTIME_WAKE_POLICY_SCHEMA_VERSION,
 )
 from .control_plane.work_items.runtime_capability_reentry import (
     RUNTIME_CAPABILITY_REENTRY_SCHEMA_VERSION,
@@ -38,9 +37,7 @@ def build_ark_managed_agent_host_contract() -> dict[str, Any]:
             "source_ref": "quota_should_run.scheduler_hint.goal_runtime_continuation",
             "packet_schema_version": GOAL_RUNTIME_CONTINUATION_SCHEMA_VERSION,
             "dispositions": ["continue_now", "defer", "complete"],
-            "defer_wake_policy_schema_version": (
-                GOAL_RUNTIME_WAKE_POLICY_SCHEMA_VERSION
-            ),
+            "defer_wake_policy": "state_change_or_deadline",
             "goal_prompt_mutated": False,
         },
         "runtime_capability_reentry": {

--- a/loopx/ark_managed_agent_host.py
+++ b/loopx/ark_managed_agent_host.py
@@ -38,6 +38,10 @@ def build_ark_managed_agent_host_contract() -> dict[str, Any]:
             "packet_schema_version": GOAL_RUNTIME_CONTINUATION_SCHEMA_VERSION,
             "dispositions": ["continue_now", "defer", "complete"],
             "defer_wake_policy": "state_change_or_deadline",
+            "reason_source_ref": "quota_should_run.scheduler_hint.reason_code",
+            "state_identity_source_ref": (
+                "quota_should_run.scheduler_hint.reset_policy"
+            ),
             "goal_prompt_mutated": False,
         },
         "runtime_capability_reentry": {

--- a/loopx/ark_managed_agent_host.py
+++ b/loopx/ark_managed_agent_host.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from .control_plane.scheduler.execution_context import (
     GOAL_RUNTIME_CONTINUATION_SCHEMA_VERSION,
+    GOAL_RUNTIME_WAKE_POLICY_SCHEMA_VERSION,
 )
 from .control_plane.work_items.runtime_capability_reentry import (
     RUNTIME_CAPABILITY_REENTRY_SCHEMA_VERSION,
@@ -37,6 +38,9 @@ def build_ark_managed_agent_host_contract() -> dict[str, Any]:
             "source_ref": "quota_should_run.scheduler_hint.goal_runtime_continuation",
             "packet_schema_version": GOAL_RUNTIME_CONTINUATION_SCHEMA_VERSION,
             "dispositions": ["continue_now", "defer", "complete"],
+            "defer_wake_policy_schema_version": (
+                GOAL_RUNTIME_WAKE_POLICY_SCHEMA_VERSION
+            ),
             "goal_prompt_mutated": False,
         },
         "runtime_capability_reentry": {

--- a/loopx/control_plane/scheduler/execution_context.py
+++ b/loopx/control_plane/scheduler/execution_context.py
@@ -7,6 +7,7 @@ from enum import Enum
 from typing import Any
 
 SCHEDULER_EXECUTION_CONTEXT_SCHEMA_VERSION = "scheduler_execution_context_v0"
+GOAL_RUNTIME_CONTINUATION_SCHEMA_VERSION = "goal_runtime_continuation_v0"
 
 
 class HostSurface(str, Enum):
@@ -41,6 +42,12 @@ class SchedulerRuntimeProfile(str, Enum):
     CLAUDE_CODE_VISIBLE = "claude_code"
     GENERIC_CLI_AGENT_LOOP = "generic_cli"
     GENERIC_CLI_OUTER_CONTROLLER = "outer_controller"
+
+
+class GoalRuntimeContinuationDisposition(str, Enum):
+    CONTINUE_NOW = "continue_now"
+    DEFER = "defer"
+    COMPLETE = "complete"
 
 
 NATIVE_GOAL_RUNTIME_PROFILES = frozenset(
@@ -399,6 +406,39 @@ def scheduler_execution_context_for_turn(
     )
 
 
+def build_goal_runtime_continuation(
+    scheduler_hint: Mapping[str, Any],
+) -> dict[str, Any]:
+    action = str(scheduler_hint.get("action") or "")
+    if action == "run_now":
+        disposition = GoalRuntimeContinuationDisposition.CONTINUE_NOW
+    elif action == "stop_until_explicit_resume":
+        disposition = GoalRuntimeContinuationDisposition.COMPLETE
+    else:
+        disposition = GoalRuntimeContinuationDisposition.DEFER
+
+    reset_policy = scheduler_hint.get("reset_policy")
+    reset_policy = reset_policy if isinstance(reset_policy, Mapping) else {}
+    continuation = {
+        "schema_version": GOAL_RUNTIME_CONTINUATION_SCHEMA_VERSION,
+        "source": "quota.should-run.scheduler_hint",
+        "disposition": disposition.value,
+        "reason_code": scheduler_hint.get("reason_code"),
+        "state_identity": {
+            key: reset_policy[key]
+            for key in ("reset_token", "identity_signature")
+            if reset_policy.get(key) is not None
+        },
+    }
+    if disposition is GoalRuntimeContinuationDisposition.DEFER:
+        host_cadence = scheduler_hint.get("codex_app")
+        host_cadence = host_cadence if isinstance(host_cadence, Mapping) else {}
+        recommended_interval = host_cadence.get("recommended_interval_minutes")
+        if isinstance(recommended_interval, int) and recommended_interval > 0:
+            continuation["recheck_after_seconds"] = recommended_interval * 60
+    return continuation
+
+
 def apply_scheduler_execution_context(
     result: dict[str, Any],
     resolution: SchedulerExecutionContextResolution,
@@ -443,6 +483,12 @@ def apply_scheduler_execution_context(
             cold_path["execution_phase"] = execution_phase
         return result
 
+    goal_runtime_continuation = (
+        build_goal_runtime_continuation(result)
+        if context.scheduler_owner is SchedulerOwner.GOAL_RUNTIME
+        else None
+    )
+
     result["execution_context"] = resolution.projection()
     result["codex_app"] = {
         "applicability": "not_applicable",
@@ -479,4 +525,6 @@ def apply_scheduler_execution_context(
             "selected scheduler owner requires no Codex App apply or ACK"
         ),
     }
+    if goal_runtime_continuation is not None:
+        result["goal_runtime_continuation"] = goal_runtime_continuation
     return result

--- a/loopx/control_plane/scheduler/execution_context.py
+++ b/loopx/control_plane/scheduler/execution_context.py
@@ -8,6 +8,7 @@ from typing import Any
 
 SCHEDULER_EXECUTION_CONTEXT_SCHEMA_VERSION = "scheduler_execution_context_v0"
 GOAL_RUNTIME_CONTINUATION_SCHEMA_VERSION = "goal_runtime_continuation_v0"
+GOAL_RUNTIME_WAKE_POLICY_SCHEMA_VERSION = "goal_runtime_wake_policy_v0"
 
 
 class HostSurface(str, Enum):
@@ -436,6 +437,11 @@ def build_goal_runtime_continuation(
         recommended_interval = host_cadence.get("recommended_interval_minutes")
         if isinstance(recommended_interval, int) and recommended_interval > 0:
             continuation["recheck_after_seconds"] = recommended_interval * 60
+            continuation["wake_policy"] = {
+                "schema_version": GOAL_RUNTIME_WAKE_POLICY_SCHEMA_VERSION,
+                "mode": "state_change_or_deadline",
+                "state_change_source": "fresh_quota_state_identity",
+            }
     return continuation
 
 

--- a/loopx/control_plane/scheduler/execution_context.py
+++ b/loopx/control_plane/scheduler/execution_context.py
@@ -8,7 +8,6 @@ from typing import Any
 
 SCHEDULER_EXECUTION_CONTEXT_SCHEMA_VERSION = "scheduler_execution_context_v0"
 GOAL_RUNTIME_CONTINUATION_SCHEMA_VERSION = "goal_runtime_continuation_v0"
-GOAL_RUNTIME_WAKE_POLICY_SCHEMA_VERSION = "goal_runtime_wake_policy_v0"
 
 
 class HostSurface(str, Enum):
@@ -437,11 +436,7 @@ def build_goal_runtime_continuation(
         recommended_interval = host_cadence.get("recommended_interval_minutes")
         if isinstance(recommended_interval, int) and recommended_interval > 0:
             continuation["recheck_after_seconds"] = recommended_interval * 60
-            continuation["wake_policy"] = {
-                "schema_version": GOAL_RUNTIME_WAKE_POLICY_SCHEMA_VERSION,
-                "mode": "state_change_or_deadline",
-                "state_change_source": "fresh_quota_state_identity",
-            }
+            continuation["wake_policy"] = "state_change_or_deadline"
     return continuation
 
 

--- a/loopx/control_plane/scheduler/execution_context.py
+++ b/loopx/control_plane/scheduler/execution_context.py
@@ -50,6 +50,19 @@ class GoalRuntimeContinuationDisposition(str, Enum):
     COMPLETE = "complete"
 
 
+GOAL_RUNTIME_DEFER_ACTIONS = frozenset(
+    {
+        "backoff_agent_monitor_only",
+        "backoff_until_fresh_evidence",
+        "backoff_until_material_transition",
+        "backoff_until_reassigned",
+        "backoff_until_state_change",
+        "backoff_waiting_for_user",
+        "repair_interaction_contract_projection",
+    }
+)
+
+
 NATIVE_GOAL_RUNTIME_PROFILES = frozenset(
     {
         SchedulerRuntimeProfile.ARK_MANAGED_AGENT_GOAL,
@@ -414,29 +427,25 @@ def build_goal_runtime_continuation(
         disposition = GoalRuntimeContinuationDisposition.CONTINUE_NOW
     elif action == "stop_until_explicit_resume":
         disposition = GoalRuntimeContinuationDisposition.COMPLETE
-    else:
+    elif action in GOAL_RUNTIME_DEFER_ACTIONS:
         disposition = GoalRuntimeContinuationDisposition.DEFER
+    else:
+        raise ValueError(f"unsupported Goal runtime scheduler action: {action or 'missing'}")
 
-    reset_policy = scheduler_hint.get("reset_policy")
-    reset_policy = reset_policy if isinstance(reset_policy, Mapping) else {}
     continuation = {
         "schema_version": GOAL_RUNTIME_CONTINUATION_SCHEMA_VERSION,
-        "source": "quota.should-run.scheduler_hint",
         "disposition": disposition.value,
-        "reason_code": scheduler_hint.get("reason_code"),
-        "state_identity": {
-            key: reset_policy[key]
-            for key in ("reset_token", "identity_signature")
-            if reset_policy.get(key) is not None
-        },
     }
     if disposition is GoalRuntimeContinuationDisposition.DEFER:
         host_cadence = scheduler_hint.get("codex_app")
         host_cadence = host_cadence if isinstance(host_cadence, Mapping) else {}
         recommended_interval = host_cadence.get("recommended_interval_minutes")
-        if isinstance(recommended_interval, int) and recommended_interval > 0:
-            continuation["recheck_after_seconds"] = recommended_interval * 60
-            continuation["wake_policy"] = "state_change_or_deadline"
+        if not isinstance(recommended_interval, int) or recommended_interval <= 0:
+            raise ValueError(
+                "deferred Goal runtime continuation requires a positive recheck interval"
+            )
+        continuation["recheck_after_seconds"] = recommended_interval * 60
+        continuation["wake_policy"] = "state_change_or_deadline"
     return continuation
 
 

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -17,6 +17,7 @@ from .arbitration import (
     build_scheduler_arbitration,
 )
 from .execution_context import (
+    SchedulerOwner,
     SchedulerExecutionContextResolution,
     SchedulerRuntimeProfile,
     apply_scheduler_execution_context,
@@ -57,15 +58,25 @@ MONITOR_WAIT_PHASE_RANK = {
     "cadence_only": 2,
     "far_window": 3,
 }
-SCHEDULER_IDENTITY_KEYS = (
+SCHEDULER_BASE_IDENTITY_KEYS = (
     "goal_id",
     "agent_identity.agent_id",
     "effective_action",
     "heartbeat_recommendation.recommended_mode",
     "interaction_contract.mode",
+)
+SCHEDULER_FRONTIER_IDENTITY_KEYS = (
+    "selected_todo.todo_id",
+    "selected_todo.action_kind",
+    "selected_todo.target_key",
+    "selected_todo.claimed_by",
+    "selected_todo.capability_binding_ref",
+)
+SCHEDULER_IDENTITY_KEYS = (
+    *SCHEDULER_BASE_IDENTITY_KEYS,
     "recommended_action",
 )
-MONITOR_WAIT_IDENTITY_KEYS = SCHEDULER_IDENTITY_KEYS[:-1]
+MONITOR_WAIT_IDENTITY_KEYS = SCHEDULER_BASE_IDENTITY_KEYS
 CODEX_APP_SSH_GOAL_RUNTIME_KEY = SchedulerRuntimeProfile.CODEX_APP_SSH_VISIBLE.value
 CODEX_NATIVE_GOAL_BLOCK_ACTION = "update_goal_blocked_keep_loopx_active"
 CODEX_NATIVE_GOAL_RESUME_TRIGGER = "explicit_codex_goal_resume"
@@ -87,6 +98,28 @@ def _stable_digest(value: Any, *, length: int) -> str:
 
 def _dict_or_empty(value: Any) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
+
+
+def _scheduler_identity_keys(
+    *,
+    cadence_class: str,
+    execution_context: SchedulerExecutionContextResolution,
+) -> tuple[str, ...]:
+    base_keys = (
+        MONITOR_WAIT_IDENTITY_KEYS
+        if cadence_class == "monitor_wait"
+        else SCHEDULER_IDENTITY_KEYS
+    )
+    context = execution_context.context if execution_context.ok else None
+    if context is None or context.scheduler_owner is not SchedulerOwner.GOAL_RUNTIME:
+        return base_keys
+    if cadence_class == "monitor_wait":
+        return (*base_keys, *SCHEDULER_FRONTIER_IDENTITY_KEYS)
+    return (
+        *base_keys[:-1],
+        *SCHEDULER_FRONTIER_IDENTITY_KEYS,
+        base_keys[-1],
+    )
 
 
 def _scheduler_progression_interval_elapsed(
@@ -543,9 +576,10 @@ class _SchedulerHintBuilder:
             "spend_policy": "no quota spend for final replan check or loop stop",
         }
         identity_keys = list(
-            MONITOR_WAIT_IDENTITY_KEYS
-            if cadence_class == "monitor_wait"
-            else SCHEDULER_IDENTITY_KEYS
+            _scheduler_identity_keys(
+                cadence_class=cadence_class,
+                execution_context=self.execution_context,
+            )
         )
         identity_snapshot = {key: self._identity_value(key) for key in identity_keys}
         codex_rrule = rrule_for_minutes(codex_initial_interval)
@@ -1026,7 +1060,12 @@ def build_scheduler_hint(
                     "final_quota_replan_check_enabled": False,
                     "spend_policy": "no quota spend for terminal loop stop",
                 },
-                "unchanged_identity_keys": list(SCHEDULER_IDENTITY_KEYS),
+                "unchanged_identity_keys": list(
+                    _scheduler_identity_keys(
+                        cadence_class="terminal_no_followup",
+                        execution_context=execution_context,
+                    )
+                ),
             },
             execution_context,
         )

--- a/tests/control_plane/test_scheduler_execution_context.py
+++ b/tests/control_plane/test_scheduler_execution_context.py
@@ -5,8 +5,8 @@ from itertools import product
 import pytest
 
 from loopx.control_plane.scheduler.execution_context import (
-    ExecutionMode,
     GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT,
+    ExecutionMode,
     HostSurface,
     SchedulerOwner,
     SchedulerRuntimeProfile,
@@ -19,7 +19,6 @@ from loopx.control_plane.scheduler.scheduler_hint import build_scheduler_hint
 from loopx.control_plane.work_items.interaction_contract import (
     interaction_next_cli_actions,
 )
-
 
 VALID_COMBINATIONS = {
     ("ark_managed_agent", "goal_runtime", "interactive"),
@@ -240,6 +239,76 @@ def test_codex_app_runtime_profile_preserves_host_backoff() -> None:
     assert hint["cold_path_detail"]["execution_phase"]["apply_needed"] is True
 
 
+def test_goal_runtime_projects_typed_immediate_continuation() -> None:
+    context = scheduler_execution_context_for_runtime_profile(
+        SchedulerRuntimeProfile.ARK_MANAGED_AGENT_GOAL
+    )
+
+    hint = build_scheduler_hint(
+        _active_payload(),
+        scheduler_execution_context=context,
+    )
+
+    assert hint["goal_runtime_continuation"] == {
+        "schema_version": "goal_runtime_continuation_v0",
+        "source": "quota.should-run.scheduler_hint",
+        "disposition": "continue_now",
+        "reason_code": "interaction_agent_attempt_required",
+        "state_identity": {
+            "reset_token": hint["reset_policy"]["reset_token"],
+            "identity_signature": hint["reset_policy"]["identity_signature"],
+        },
+    }
+
+
+def test_goal_runtime_projects_typed_defer_with_recheck_delay() -> None:
+    context = scheduler_execution_context_for_runtime_profile(
+        SchedulerRuntimeProfile.ARK_MANAGED_AGENT_GOAL
+    )
+
+    hint = build_scheduler_hint(
+        _monitor_wait_payload(),
+        scheduler_execution_context=context,
+    )
+
+    continuation = hint["goal_runtime_continuation"]
+    assert continuation["disposition"] == "defer"
+    assert continuation["recheck_after_seconds"] == 15 * 60
+    assert continuation["state_identity"]["reset_token"]
+    assert hint["execution_phase"]["disposition"] == "goal_runtime_owned"
+
+
+def test_non_goal_runtime_does_not_receive_goal_continuation() -> None:
+    context = scheduler_execution_context_for_runtime_profile(
+        SchedulerRuntimeProfile.CODEX_CLI_VISIBLE
+    )
+
+    hint = build_scheduler_hint(
+        _monitor_wait_payload(),
+        scheduler_execution_context=context,
+    )
+
+    assert "goal_runtime_continuation" not in hint
+
+
+def test_goal_runtime_terminal_stop_projects_complete() -> None:
+    context = scheduler_execution_context_for_runtime_profile(
+        SchedulerRuntimeProfile.ARK_MANAGED_AGENT_GOAL
+    )
+    payload = _monitor_wait_payload()
+    payload["effective_action"] = "terminal_no_followup"
+    payload["interaction_contract"]["mode"] = "terminal_no_followup"
+
+    hint = build_scheduler_hint(
+        payload,
+        scheduler_execution_context=context,
+    )
+
+    assert hint["action"] == "stop_until_explicit_resume"
+    assert hint["goal_runtime_continuation"]["disposition"] == "complete"
+    assert "recheck_after_seconds" not in hint["goal_runtime_continuation"]
+
+
 @pytest.mark.parametrize(
     ("profile", "runtime_key"),
     (
@@ -366,9 +435,11 @@ def test_codex_app_monitor_quiet_retry_uses_turn_receipt() -> None:
     )
 
     assert actions == [
-        "on missing/write_failed heartbeat_receipt only: loopx --format json "
-        "quota should-run --goal-id codex-heartbeat-fixture --agent-id "
-        'codex-fixture --codex-app --turn-instance-id "${LOOPX_TURN:?}"'
+        (
+            "on missing/write_failed heartbeat_receipt only: loopx --format json "
+            "quota should-run --goal-id codex-heartbeat-fixture --agent-id "
+            'codex-fixture --codex-app --turn-instance-id "${LOOPX_TURN:?}"'
+        )
     ]
 
 

--- a/tests/control_plane/test_scheduler_execution_context.py
+++ b/tests/control_plane/test_scheduler_execution_context.py
@@ -279,11 +279,7 @@ def test_goal_runtime_projects_typed_defer_with_recheck_delay() -> None:
     continuation = hint["goal_runtime_continuation"]
     assert continuation["disposition"] == "defer"
     assert continuation["recheck_after_seconds"] == 15 * 60
-    assert continuation["wake_policy"] == {
-        "schema_version": "goal_runtime_wake_policy_v0",
-        "mode": "state_change_or_deadline",
-        "state_change_source": "fresh_quota_state_identity",
-    }
+    assert continuation["wake_policy"] == "state_change_or_deadline"
     assert continuation["state_identity"]["reset_token"]
     assert hint["execution_phase"]["disposition"] == "goal_runtime_owned"
 

--- a/tests/control_plane/test_scheduler_execution_context.py
+++ b/tests/control_plane/test_scheduler_execution_context.py
@@ -16,9 +16,14 @@ from loopx.control_plane.scheduler.execution_context import (
     scheduler_runtime_profile_for_execution_context,
 )
 from loopx.control_plane.scheduler.scheduler_hint import build_scheduler_hint
+from loopx.control_plane.testing.quota_fixtures import (
+    quota_status_payload,
+    quota_todo_item,
+)
 from loopx.control_plane.work_items.interaction_contract import (
     interaction_next_cli_actions,
 )
+from loopx.quota import build_quota_should_run
 
 VALID_COMBINATIONS = {
     ("ark_managed_agent", "goal_runtime", "interactive"),
@@ -274,8 +279,53 @@ def test_goal_runtime_projects_typed_defer_with_recheck_delay() -> None:
     continuation = hint["goal_runtime_continuation"]
     assert continuation["disposition"] == "defer"
     assert continuation["recheck_after_seconds"] == 15 * 60
+    assert continuation["wake_policy"] == {
+        "schema_version": "goal_runtime_wake_policy_v0",
+        "mode": "state_change_or_deadline",
+        "state_change_source": "fresh_quota_state_identity",
+    }
     assert continuation["state_identity"]["reset_token"]
     assert hint["execution_phase"]["disposition"] == "goal_runtime_owned"
+
+
+def test_goal_runtime_mixed_frontier_continues_runnable_advancement() -> None:
+    context = scheduler_execution_context_for_runtime_profile(
+        SchedulerRuntimeProfile.ARK_MANAGED_AGENT_GOAL
+    )
+    status = quota_status_payload(
+        goal_id="mixed-frontier-fixture",
+        status="active",
+        recommended_action="Fix the next issue while the PR monitor is quiet.",
+        agent_todo_items=[
+            quota_todo_item(
+                todo_id="todo_next_issue",
+                title="Fix the next independent issue.",
+                task_class="advancement_task",
+                priority="P0",
+            ),
+            quota_todo_item(
+                todo_id="todo_pr_monitor",
+                title="Monitor the earlier PR for CI and review changes.",
+                task_class="continuous_monitor",
+                priority="P1",
+                target_key="github-pr-state-open",
+                cadence="30m",
+                next_due_at="2099-01-01T00:00:00+00:00",
+            ),
+        ],
+    )
+
+    quota = build_quota_should_run(
+        status,
+        goal_id="mixed-frontier-fixture",
+        scheduler_execution_context=context,
+    )
+
+    assert quota["work_lane_contract"]["lane"] == "advancement_task"
+    assert quota["goal_frontier_projection"]["monitor_only_lanes"]["present"] is False
+    assert quota["scheduler_hint"]["goal_runtime_continuation"]["disposition"] == (
+        "continue_now"
+    )
 
 
 def test_non_goal_runtime_does_not_receive_goal_continuation() -> None:

--- a/tests/control_plane/test_scheduler_execution_context.py
+++ b/tests/control_plane/test_scheduler_execution_context.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from itertools import product
 
 import pytest
 
 from loopx.control_plane.scheduler.execution_context import (
+    build_goal_runtime_continuation,
     GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT,
     ExecutionMode,
     HostSurface,
@@ -256,13 +258,7 @@ def test_goal_runtime_projects_typed_immediate_continuation() -> None:
 
     assert hint["goal_runtime_continuation"] == {
         "schema_version": "goal_runtime_continuation_v0",
-        "source": "quota.should-run.scheduler_hint",
         "disposition": "continue_now",
-        "reason_code": "interaction_agent_attempt_required",
-        "state_identity": {
-            "reset_token": hint["reset_policy"]["reset_token"],
-            "identity_signature": hint["reset_policy"]["identity_signature"],
-        },
     }
 
 
@@ -280,8 +276,106 @@ def test_goal_runtime_projects_typed_defer_with_recheck_delay() -> None:
     assert continuation["disposition"] == "defer"
     assert continuation["recheck_after_seconds"] == 15 * 60
     assert continuation["wake_policy"] == "state_change_or_deadline"
-    assert continuation["state_identity"]["reset_token"]
+    assert hint["reset_policy"]["reset_token"]
     assert hint["execution_phase"]["disposition"] == "goal_runtime_owned"
+
+
+def test_goal_runtime_continuation_rejects_unknown_scheduler_action() -> None:
+    with pytest.raises(ValueError, match="unsupported Goal runtime scheduler action"):
+        build_goal_runtime_continuation({"action": "future_unmapped_action"})
+
+
+def test_goal_runtime_defer_requires_bounded_recheck_interval() -> None:
+    with pytest.raises(ValueError, match="positive recheck interval"):
+        build_goal_runtime_continuation(
+            {
+                "action": "backoff_until_state_change",
+                "codex_app": {"recommended_interval_minutes": None},
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "changed_value"),
+    (
+        ("todo_id", "todo_frontier002"),
+        ("action_kind", "issue_fix_reviewer_request"),
+        ("target_key", "issue-fix:owner/repo:issue_43"),
+        ("claimed_by", "codex-review"),
+        ("capability_binding_ref", "issue-fix:feasibility-e5f6a7b8"),
+    ),
+)
+@pytest.mark.parametrize("waiting", (False, True), ids=("continue_now", "defer"))
+def test_goal_runtime_identity_rotates_on_selected_todo_contract_change(
+    field: str,
+    changed_value: str,
+    waiting: bool,
+) -> None:
+    context = scheduler_execution_context_for_runtime_profile(
+        SchedulerRuntimeProfile.ARK_MANAGED_AGENT_GOAL
+    )
+    first_payload = _monitor_wait_payload() if waiting else _active_payload()
+    first_payload["selected_todo"] = {
+        "todo_id": "todo_frontier001",
+        "action_kind": "issue_fix_branch_validation",
+        "target_key": "issue-fix:owner/repo:issue_42",
+        "claimed_by": "codex-fixture",
+        "capability_binding_ref": "issue-fix:feasibility-a1b2c3d4",
+    }
+    second_payload = deepcopy(first_payload)
+    second_payload["selected_todo"][field] = changed_value
+
+    first = build_scheduler_hint(
+        first_payload,
+        scheduler_execution_context=context,
+    )
+    second = build_scheduler_hint(
+        second_payload,
+        scheduler_execution_context=context,
+    )
+
+    expected_disposition = "defer" if waiting else "continue_now"
+    assert first["goal_runtime_continuation"]["disposition"] == expected_disposition
+    assert second["goal_runtime_continuation"]["disposition"] == expected_disposition
+    assert first["reset_policy"]["reset_token"] != second["reset_policy"][
+        "reset_token"
+    ]
+    assert first["reset_policy"]["identity_signature"] != second[
+        "reset_policy"
+    ]["identity_signature"]
+
+
+def test_goal_runtime_identity_ignores_non_contract_selected_todo_detail() -> None:
+    context = scheduler_execution_context_for_runtime_profile(
+        SchedulerRuntimeProfile.ARK_MANAGED_AGENT_GOAL
+    )
+    first_payload = _active_payload()
+    first_payload["selected_todo"] = {
+        "todo_id": "todo_frontier001",
+        "action_kind": "issue_fix_branch_validation",
+        "target_key": "issue-fix:owner/repo:issue_42",
+        "claimed_by": "codex-fixture",
+        "capability_binding_ref": "issue-fix:feasibility-a1b2c3d4",
+        "note": "first diagnostic note",
+    }
+    second_payload = deepcopy(first_payload)
+    second_payload["selected_todo"]["note"] = "unrelated diagnostic refresh"
+
+    first = build_scheduler_hint(
+        first_payload,
+        scheduler_execution_context=context,
+    )
+    second = build_scheduler_hint(
+        second_payload,
+        scheduler_execution_context=context,
+    )
+
+    assert first["reset_policy"]["reset_token"] == second["reset_policy"][
+        "reset_token"
+    ]
+    assert first["goal_runtime_continuation"] == second[
+        "goal_runtime_continuation"
+    ]
 
 
 def test_goal_runtime_mixed_frontier_continues_runnable_advancement() -> None:

--- a/tests/test_ark_managed_agent_host.py
+++ b/tests/test_ark_managed_agent_host.py
@@ -107,6 +107,14 @@ def test_goal_prompt_projects_goal_only_host_contract() -> None:
         "phase_handoff_allowed": False,
         "loopx_turn_driver_required": False,
         "session_state_authoritative": False,
+        "goal_runtime_continuation": {
+            "source_ref": (
+                "quota_should_run.scheduler_hint.goal_runtime_continuation"
+            ),
+            "packet_schema_version": "goal_runtime_continuation_v0",
+            "dispositions": ["continue_now", "defer", "complete"],
+            "goal_prompt_mutated": False,
+        },
         "runtime_capability_reentry": {
             "source_ref": (
                 "quota_should_run.interaction_contract.cli_channel."

--- a/tests/test_ark_managed_agent_host.py
+++ b/tests/test_ark_managed_agent_host.py
@@ -113,7 +113,7 @@ def test_goal_prompt_projects_goal_only_host_contract() -> None:
             ),
             "packet_schema_version": "goal_runtime_continuation_v0",
             "dispositions": ["continue_now", "defer", "complete"],
-            "defer_wake_policy_schema_version": "goal_runtime_wake_policy_v0",
+            "defer_wake_policy": "state_change_or_deadline",
             "goal_prompt_mutated": False,
         },
         "runtime_capability_reentry": {

--- a/tests/test_ark_managed_agent_host.py
+++ b/tests/test_ark_managed_agent_host.py
@@ -113,6 +113,7 @@ def test_goal_prompt_projects_goal_only_host_contract() -> None:
             ),
             "packet_schema_version": "goal_runtime_continuation_v0",
             "dispositions": ["continue_now", "defer", "complete"],
+            "defer_wake_policy_schema_version": "goal_runtime_wake_policy_v0",
             "goal_prompt_mutated": False,
         },
         "runtime_capability_reentry": {

--- a/tests/test_ark_managed_agent_host.py
+++ b/tests/test_ark_managed_agent_host.py
@@ -114,6 +114,10 @@ def test_goal_prompt_projects_goal_only_host_contract() -> None:
             "packet_schema_version": "goal_runtime_continuation_v0",
             "dispositions": ["continue_now", "defer", "complete"],
             "defer_wake_policy": "state_change_or_deadline",
+            "reason_source_ref": "quota_should_run.scheduler_hint.reason_code",
+            "state_identity_source_ref": (
+                "quota_should_run.scheduler_hint.reset_policy"
+            ),
             "goal_prompt_mutated": False,
         },
         "runtime_capability_reentry": {


### PR DESCRIPTION
## Motivation

A one-shot Goal host needs a machine decision for continue, wait, or finish without asking the model or Goal prompt to infer scheduler behavior. That decision must follow the current durable Todo frontier, not incidental diagnostic refreshes.

## Changes

- project `goal_runtime_continuation_v0` only for `scheduler_owner=goal_runtime`
- expose `continue_now`, `defer`, and `complete`; every defer has a positive bounded deadline and `wake_policy=state_change_or_deadline`
- keep reason and state identity single-sourced in sibling `scheduler_hint.reason_code` and `scheduler_hint.reset_policy`
- include selected Todo id, action, target, claim owner, and capability binding ref in Goal-runtime identity
- leave Codex App/CLI identity keys and hot-path output unchanged
- reject unknown scheduler actions and defer packets without a recheck interval
- preserve whole-frontier semantics: an independent runnable Todo wins over an auxiliary quiet monitor

## Validation

- combined focused pytest after #2728: 209 passed
- hot-path budgets: quota 12,549/12,550; Dashboard 18,181/18,200
- `loopx canary premerge --from-git-diff`: 18 selected checks passed, 0 failures, 0 manual holds; self-merge allowed
- public/private boundary, compile, maintainability, scheduler authority, peer continuation, heartbeat/quota, and diff checks: passed

No Ark adapter cross-repository golden test is added. This PR validates the LoopX-owned host/scheduler contract deterministically; adapter transport conformance remains outside this repository.
