### PR TITLE
fix(scheduler): bound goal-runtime defer recheck to earliest frontier transition

### DIFF
--- a/docs/reference/protocols/host-integration-surface-v0.md
+++ b/docs/reference/protocols/host-integration-surface-v0.md
@@ -141,7 +141,9 @@ recheck deadline. The deadline makes a due monitor runnable even without a push
 signal; provider-specific CI/review observation remains owned by its capability
 connector. This is the machine continuation contract. The Goal prompt is not
 rewritten to teach waiting policy, and the model is not used as a mechanical
-polling loop.
+polling loop. When the frontier carries explicit `next_due_at` values, the
+deadline is the earliest exact due time; the coarser host cadence floor remains
+an automation concern and must not delay a Goal-runtime wake past that boundary.
 
 `defer` is a whole-frontier decision, not a per-PR wait. A quiet CI/review
 monitor remains auxiliary context while any independent advancement todo is

--- a/loopx/control_plane/scheduler/execution_context.py
+++ b/loopx/control_plane/scheduler/execution_context.py
@@ -408,6 +408,8 @@ def scheduler_execution_context_for_turn(
 
 def build_goal_runtime_continuation(
     scheduler_hint: Mapping[str, Any],
+    *,
+    frontier_recheck_after_seconds: int | None = None,
 ) -> dict[str, Any]:
     action = str(scheduler_hint.get("action") or "")
     if action == "run_now":
@@ -431,11 +433,19 @@ def build_goal_runtime_continuation(
         },
     }
     if disposition is GoalRuntimeContinuationDisposition.DEFER:
-        host_cadence = scheduler_hint.get("codex_app")
-        host_cadence = host_cadence if isinstance(host_cadence, Mapping) else {}
-        recommended_interval = host_cadence.get("recommended_interval_minutes")
-        if isinstance(recommended_interval, int) and recommended_interval > 0:
-            continuation["recheck_after_seconds"] = recommended_interval * 60
+        if (
+            isinstance(frontier_recheck_after_seconds, int)
+            and frontier_recheck_after_seconds > 0
+        ):
+            continuation["recheck_after_seconds"] = frontier_recheck_after_seconds
+            continuation["recheck_source"] = "frontier_earliest_material_transition"
+        else:
+            host_cadence = scheduler_hint.get("codex_app")
+            host_cadence = host_cadence if isinstance(host_cadence, Mapping) else {}
+            recommended_interval = host_cadence.get("recommended_interval_minutes")
+            if isinstance(recommended_interval, int) and recommended_interval > 0:
+                continuation["recheck_after_seconds"] = recommended_interval * 60
+        if continuation.get("recheck_after_seconds") is not None:
             continuation["wake_policy"] = "state_change_or_deadline"
     return continuation
 
@@ -443,6 +453,8 @@ def build_goal_runtime_continuation(
 def apply_scheduler_execution_context(
     result: dict[str, Any],
     resolution: SchedulerExecutionContextResolution,
+    *,
+    frontier_recheck_after_seconds: int | None = None,
 ) -> dict[str, Any]:
     """Scope a generic cadence hint to the selected runtime owner."""
 
@@ -485,7 +497,10 @@ def apply_scheduler_execution_context(
         return result
 
     goal_runtime_continuation = (
-        build_goal_runtime_continuation(result)
+        build_goal_runtime_continuation(
+            result,
+            frontier_recheck_after_seconds=frontier_recheck_after_seconds,
+        )
         if context.scheduler_owner is SchedulerOwner.GOAL_RUNTIME
         else None
     )

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -319,6 +319,42 @@ def _monitor_cadence_minutes(value: Any) -> int | None:
     return amount
 
 
+FRONTIER_RECHECK_SUMMARY_KEYS = (
+    "current_agent_claimed_monitor_items",
+    "monitor_open_items",
+    "gate_open_items",
+    "deferred_resume_candidates",
+    "current_agent_deferred_resume_candidates",
+    "resume_blocked_items",
+    "current_agent_monitor_blocked_resume_candidates",
+    "current_agent_handoff_gates",
+)
+
+
+def _todo_summary_items(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for summary_key in ("agent_todo_summary", "user_todo_summary"):
+        summary = payload.get(summary_key)
+        if not isinstance(summary, dict):
+            continue
+        for key in FRONTIER_RECHECK_SUMMARY_KEYS:
+            values = summary.get(key)
+            if not isinstance(values, list):
+                continue
+            for value in values:
+                if not isinstance(value, dict):
+                    continue
+                todo_id = str(value.get("todo_id") or "")
+                target_key = str(value.get("target_key") or "")
+                identity = (todo_id, target_key, str(value.get("index") or ""))
+                if identity in seen:
+                    continue
+                seen.add(identity)
+                items.append(value)
+    return items
+
+
 def _monitor_wait_items(payload: dict[str, Any]) -> list[dict[str, Any]]:
     summary = payload.get("agent_todo_summary")
     if not isinstance(summary, dict):
@@ -339,6 +375,50 @@ def _monitor_wait_items(payload: dict[str, Any]) -> list[dict[str, Any]]:
                 seen_ids.add(todo_id)
             items.append(value)
     return items
+
+
+def _frontier_transition_item_identity(item: dict[str, Any]) -> str:
+    for key in ("todo_id", "target_key", "action_kind", "title", "text"):
+        value = str(item.get(key) or "").strip()
+        if value:
+            return value
+    return str(item.get("index") or "frontier_transition")
+
+
+def _frontier_recheck_plan(
+    payload: dict[str, Any],
+    *,
+    current_time: datetime,
+) -> dict[str, Any] | None:
+    deadlines: list[dict[str, Any]] = []
+    for item in _todo_summary_items(payload):
+        timestamp = _parse_monitor_timestamp(item.get("next_due_at"))
+        if timestamp is None or timestamp <= current_time:
+            continue
+        task_class = str(item.get("task_class") or "").strip()
+        if not task_class:
+            action_kind = str(item.get("action_kind") or "").strip().lower()
+            if "monitor" in action_kind:
+                task_class = "continuous_monitor"
+            elif "gate" in action_kind or "approval" in action_kind:
+                task_class = "user_gate"
+        deadlines.append(
+            {
+                "identity": _frontier_transition_item_identity(item),
+                "source": task_class or "frontier_todo",
+                "next_due_at": timestamp.isoformat(),
+                "seconds_until_due": _seconds_until(timestamp, current_time),
+            }
+        )
+    if not deadlines:
+        return None
+    selected = min(deadlines, key=lambda item: item["seconds_until_due"])
+    return {
+        "frontier_recheck_after_seconds": selected["seconds_until_due"],
+        "frontier_recheck_source": selected["source"],
+        "frontier_recheck_identity": selected["identity"],
+        "frontier_recheck_candidate_count": len(deadlines),
+    }
 
 
 def _monitor_item_identity(item: dict[str, Any]) -> str:
@@ -465,6 +545,7 @@ def _monitor_wait_cadence_plan(payload: dict[str, Any]) -> dict[str, Any] | None
             continue
         plans.append(plan)
 
+    frontier_recheck = _frontier_recheck_plan(payload, current_time=current_time)
     if not plans:
         if expired_count:
             return {
@@ -474,8 +555,9 @@ def _monitor_wait_cadence_plan(payload: dict[str, Any]) -> dict[str, Any] | None
                 "base_progression_minutes": MONITOR_WAIT_PROGRESSION_MINUTES,
                 "progression_minutes": None,
                 "reset_profile": None,
+                **(frontier_recheck or {}),
             }
-        return None
+        return frontier_recheck
 
     selected = min(
         plans,
@@ -485,17 +567,41 @@ def _monitor_wait_cadence_plan(payload: dict[str, Any]) -> dict[str, Any] | None
             str(plan.get("selected_monitor_identity") or ""),
         ),
     )
+    monitor_recheck_after_seconds = min(
+        (
+            int(plan["seconds_until_due"])
+            for plan in plans
+            if isinstance(plan.get("seconds_until_due"), int)
+            and int(plan["seconds_until_due"]) > 0
+        ),
+        default=None,
+    )
+    if (
+        isinstance(frontier_recheck, dict)
+        and isinstance(frontier_recheck.get("frontier_recheck_after_seconds"), int)
+    ):
+        frontier_recheck_after_seconds = int(
+            frontier_recheck["frontier_recheck_after_seconds"]
+        )
+        if (
+            monitor_recheck_after_seconds is None
+            or frontier_recheck_after_seconds < monitor_recheck_after_seconds
+        ):
+            monitor_recheck_after_seconds = frontier_recheck_after_seconds
+        else:
+            frontier_recheck["frontier_recheck_after_seconds"] = (
+                monitor_recheck_after_seconds
+            )
+            frontier_recheck["frontier_recheck_source"] = "continuous_monitor"
+            frontier_recheck["frontier_recheck_identity"] = selected[
+                "selected_monitor_identity"
+            ]
+    else:
+        frontier_recheck = {}
     return {
         **selected,
-        "frontier_recheck_after_seconds": min(
-            (
-                int(plan["seconds_until_due"])
-                for plan in plans
-                if isinstance(plan.get("seconds_until_due"), int)
-                and int(plan["seconds_until_due"]) > 0
-            ),
-            default=None,
-        ),
+        **frontier_recheck,
+        "frontier_recheck_after_seconds": monitor_recheck_after_seconds,
         "base_progression_minutes": MONITOR_WAIT_PROGRESSION_MINUTES,
         "candidate_count": len(plans),
         "expired_monitor_count": expired_count,

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -353,6 +353,10 @@ def _minutes_until(value: datetime, current_time: datetime) -> int:
     return max(1, int(math.ceil((value - current_time).total_seconds() / 60)))
 
 
+def _seconds_until(value: datetime, current_time: datetime) -> int:
+    return max(1, int(math.ceil((value - current_time).total_seconds())))
+
+
 def _cap_monitor_progression(*, cap_minutes: int, host_floor_minutes: int) -> list[int]:
     safe_cap = max(1, int(cap_minutes))
     safe_floor = max(1, int(host_floor_minutes))
@@ -432,6 +436,11 @@ def _monitor_wait_item_plan(
         "selected_target_key": item.get("target_key"),
         "host_floor_minutes": host_floor,
         "cap_minutes": cap_minutes,
+        "seconds_until_due": (
+            _seconds_until(next_due_at, current_time)
+            if next_due_at is not None and next_due_at > current_time
+            else None
+        ),
         "cadence_minutes": cadence_minutes,
         "next_due_at": next_due_at.isoformat() if next_due_at is not None else None,
         "expires_at": expires_at.isoformat() if expires_at is not None else None,
@@ -478,6 +487,15 @@ def _monitor_wait_cadence_plan(payload: dict[str, Any]) -> dict[str, Any] | None
     )
     return {
         **selected,
+        "frontier_recheck_after_seconds": min(
+            (
+                int(plan["seconds_until_due"])
+                for plan in plans
+                if isinstance(plan.get("seconds_until_due"), int)
+                and int(plan["seconds_until_due"]) > 0
+            ),
+            default=None,
+        ),
         "base_progression_minutes": MONITOR_WAIT_PROGRESSION_MINUTES,
         "candidate_count": len(plans),
         "expired_monitor_count": expired_count,
@@ -518,6 +536,7 @@ class _SchedulerHintBuilder:
         reset_profile_snapshot_override: dict[str, Any] | None = None,
         cadence_context_detail: dict[str, Any] | None = None,
         advance_same_identity: bool = True,
+        frontier_recheck_after_seconds: int | None = None,
     ) -> dict[str, Any]:
         local_cadence_progression = cadence_progression_override or [
             min(codex_interval * (multiplier**step), codex_max) for step in range(3)
@@ -907,7 +926,11 @@ class _SchedulerHintBuilder:
                 scheduler_hint["cold_path_detail"]["cadence_context"] = (
                     cadence_context_detail
                 )
-        return apply_scheduler_execution_context(scheduler_hint, self.execution_context)
+        return apply_scheduler_execution_context(
+            scheduler_hint,
+            self.execution_context,
+            frontier_recheck_after_seconds=frontier_recheck_after_seconds,
+        )
 
 
 def build_scheduler_hint(
@@ -1181,6 +1204,11 @@ def build_scheduler_hint(
             ),
             reset_profile_snapshot_override=monitor_reset_profile,
             cadence_context_detail=monitor_plan,
+            frontier_recheck_after_seconds=(
+                monitor_plan.get("frontier_recheck_after_seconds")
+                if isinstance(monitor_plan, dict)
+                else None
+            ),
         )
 
     if arbitration.disposition == SchedulerDisposition.QUIET_WAIT:

--- a/loopx/control_plane/todos/handoff_gate.py
+++ b/loopx/control_plane/todos/handoff_gate.py
@@ -155,6 +155,7 @@ def _compact_handoff_gate(
         "route_continuation_reason",
         "route_id",
         "route_key",
+        "next_due_at",
     ):
         value = gate.get(key)
         if value is not None:

--- a/loopx/control_plane/todos/quota_summary.py
+++ b/loopx/control_plane/todos/quota_summary.py
@@ -38,6 +38,7 @@ from .route_continuation import build_todo_route_continuation_lanes
 from .succession_warning import build_todo_succession_warning_lanes
 from .summary_item import compact_todo_summary_item, todo_summary_source_items
 from .user_gate import is_user_gate_todo_item
+from ..runtime.time import now_utc, parse_timestamp
 
 MONITOR_DUE_ITEM_LIMIT = 1
 TODO_BACKLOG_ITEM_LIMIT = 8
@@ -636,6 +637,15 @@ def _compact_quota_payload_item(item: Any) -> Any:
     return compact
 
 
+def _quota_payload_item_priority(item: Any, current_time: Any) -> tuple[int, float, int]:
+    if not isinstance(item, dict):
+        return (2, 0.0, 0)
+    next_due_at = parse_timestamp(item.get("next_due_at"))
+    if next_due_at is not None and next_due_at > current_time:
+        return (0, next_due_at.timestamp(), int(item.get("index") or 0))
+    return (1, 0.0, int(item.get("index") or 0))
+
+
 def _compact_quota_payload_item_list(
     items: Any,
     *,
@@ -643,7 +653,12 @@ def _compact_quota_payload_item_list(
 ) -> list[Any]:
     if not isinstance(items, list):
         return []
-    return [_compact_quota_payload_item(item) for item in items[:limit]]
+    current_time = now_utc()
+    ordered = sorted(
+        items,
+        key=lambda item: _quota_payload_item_priority(item, current_time),
+    )
+    return [_compact_quota_payload_item(item) for item in ordered[:limit]]
 
 
 def _compact_quota_payload_claim_scope(value: Any) -> Any:

--- a/tests/control_plane/test_scheduler_execution_context.py
+++ b/tests/control_plane/test_scheduler_execution_context.py
@@ -373,6 +373,96 @@ def test_goal_runtime_defer_uses_earliest_frontier_transition() -> None:
     assert "frontier_recheck" not in hint
 
 
+def test_goal_runtime_defer_uses_user_gate_deadline_before_monitors() -> None:
+    from loopx.control_plane.scheduler import scheduler_hint as scheduler_hint_mod
+
+    context = scheduler_execution_context_for_runtime_profile(
+        SchedulerRuntimeProfile.ARK_MANAGED_AGENT_GOAL
+    )
+    now = datetime(2026, 8, 2, 6, 0, 0, tzinfo=UTC)
+    payload = _monitor_wait_payload()
+    payload["agent_todo_summary"] = {
+        "monitor_open_items": [
+            {
+                "todo_id": "todo_ci",
+                "target_key": "pr-ci",
+                "cadence": "60m",
+                "next_due_at": (now + timedelta(minutes=45)).isoformat(),
+            }
+        ],
+        "gate_open_items": [
+            {
+                "todo_id": "todo_gate",
+                "task_class": "user_gate",
+                "next_due_at": (now + timedelta(minutes=10)).isoformat(),
+            }
+        ],
+    }
+
+    original_now = scheduler_hint_mod.now_utc
+    scheduler_hint_mod.now_utc = lambda: now
+    try:
+        hint = build_scheduler_hint(
+            payload,
+            include_detail=True,
+            scheduler_execution_context=context,
+        )
+    finally:
+        scheduler_hint_mod.now_utc = original_now
+
+    continuation = hint["goal_runtime_continuation"]
+    assert continuation["recheck_after_seconds"] == 10 * 60
+    assert continuation["recheck_source"] == "frontier_earliest_material_transition"
+    assert hint["cold_path_detail"]["cadence_context"][
+        "frontier_recheck_source"
+    ] == "user_gate"
+
+
+def test_goal_runtime_defer_uses_non_monitor_frontier_without_monitor_deadline() -> None:
+    from loopx.control_plane.scheduler import scheduler_hint as scheduler_hint_mod
+
+    context = scheduler_execution_context_for_runtime_profile(
+        SchedulerRuntimeProfile.ARK_MANAGED_AGENT_GOAL
+    )
+    now = datetime(2026, 8, 2, 6, 0, 0, tzinfo=UTC)
+    payload = _monitor_wait_payload()
+    payload["agent_todo_summary"] = {
+        "monitor_open_items": [
+            {
+                "todo_id": "todo_monitor",
+                "target_key": "pr-review",
+                "cadence": "60m",
+            }
+        ],
+        "deferred_resume_candidates": [
+            {
+                "todo_id": "todo_resume",
+                "task_class": "advancement_task",
+                "resume_ready": True,
+                "next_due_at": (now + timedelta(minutes=7)).isoformat(),
+            }
+        ],
+    }
+
+    original_now = scheduler_hint_mod.now_utc
+    scheduler_hint_mod.now_utc = lambda: now
+    try:
+        hint = build_scheduler_hint(
+            payload,
+            include_detail=True,
+            scheduler_execution_context=context,
+        )
+    finally:
+        scheduler_hint_mod.now_utc = original_now
+
+    continuation = hint["goal_runtime_continuation"]
+    assert continuation["recheck_after_seconds"] == 7 * 60
+    assert continuation["recheck_source"] == "frontier_earliest_material_transition"
+    assert hint["cold_path_detail"]["cadence_context"][
+        "frontier_recheck_source"
+    ] == "advancement_task"
+
+
 def test_goal_runtime_defer_uses_exact_due_inside_host_floor() -> None:
     from loopx.control_plane.scheduler import scheduler_hint as scheduler_hint_mod
 

--- a/tests/control_plane/test_scheduler_execution_context.py
+++ b/tests/control_plane/test_scheduler_execution_context.py
@@ -418,6 +418,107 @@ def test_goal_runtime_defer_uses_user_gate_deadline_before_monitors() -> None:
     ] == "user_gate"
 
 
+def test_quota_payload_compaction_preserves_earliest_frontier_deadline() -> None:
+    from loopx.control_plane.scheduler import monitor_todo as monitor_todo_mod
+    from loopx.control_plane.scheduler import scheduler_hint as scheduler_hint_mod
+    from loopx.control_plane.todos import quota_summary as quota_summary_mod
+
+    context = scheduler_execution_context_for_runtime_profile(
+        SchedulerRuntimeProfile.ARK_MANAGED_AGENT_GOAL
+    )
+    now = datetime(2026, 8, 2, 6, 0, 0, tzinfo=UTC)
+    agent_id = "frontier-deadline-agent"
+    watch_lane_ack = {
+        "classification": "autonomous_replan_recorded",
+        "generated_at": now.isoformat(),
+        "agent_id": agent_id,
+        "autonomous_replan_ack": {
+            "schema_version": "autonomous_replan_ack_v0",
+            "recorded": True,
+            "source": "fixture",
+            "delta_contract": {
+                "schema_version": "repair_delta_contract_v0",
+                "delta_present": True,
+                "delta_kinds": ["watch_lane_continuation"],
+            },
+        },
+    }
+    status = quota_status_payload(
+        goal_id="frontier-deadline-compaction-fixture",
+        status="active",
+        recommended_action="Wait for the next monitor transition.",
+        agent_todos={
+            "schema_version": "todo_summary_v0",
+            "source_section": "Agent Todo",
+            "total_count": 3,
+            "open_count": 3,
+            "done_count": 0,
+            "deferred_count": 0,
+            "monitor_open_items": [
+                {
+                    "todo_id": "todo_unscheduled_monitor_a",
+                    "index": 0,
+                    "status": "open",
+                    "task_class": "continuous_monitor",
+                    "text": "[P1] Unscheduled monitor A",
+                    "target_key": "unscheduled-monitor-a",
+                    "cadence": "60m",
+                },
+                {
+                    "todo_id": "todo_unscheduled_monitor_b",
+                    "index": 1,
+                    "status": "open",
+                    "task_class": "continuous_monitor",
+                    "text": "[P1] Unscheduled monitor B",
+                    "target_key": "unscheduled-monitor-b",
+                    "cadence": "60m",
+                },
+                {
+                    "todo_id": "todo_earliest_monitor",
+                    "index": 2,
+                    "status": "open",
+                    "task_class": "continuous_monitor",
+                    "text": "[P1] Earliest monitor",
+                    "target_key": "earliest-monitor",
+                    "cadence": "60m",
+                    "next_due_at": (now + timedelta(minutes=10)).isoformat(),
+                },
+            ],
+        },
+        latest_runs=[watch_lane_ack],
+        claim_scope_agent_id=agent_id,
+        coordination={"registered_agents": [agent_id]},
+    )
+
+    original_scheduler_now = scheduler_hint_mod.now_utc
+    original_monitor_now = monitor_todo_mod.now_utc
+    original_quota_now = quota_summary_mod.now_utc
+    scheduler_hint_mod.now_utc = lambda: now
+    monitor_todo_mod.now_utc = lambda: now
+    quota_summary_mod.now_utc = lambda: now
+    try:
+        quota = build_quota_should_run(
+            status,
+            goal_id="frontier-deadline-compaction-fixture",
+            agent_id=agent_id,
+            scheduler_execution_context=context,
+        )
+    finally:
+        scheduler_hint_mod.now_utc = original_scheduler_now
+        monitor_todo_mod.now_utc = original_monitor_now
+        quota_summary_mod.now_utc = original_quota_now
+
+    compacted_monitors = quota["agent_todo_summary"]["monitor_open_items"]
+    assert [item["todo_id"] for item in compacted_monitors] == [
+        "todo_earliest_monitor",
+        "todo_unscheduled_monitor_a",
+    ]
+    continuation = quota["scheduler_hint"]["goal_runtime_continuation"]
+    assert continuation["disposition"] == "defer"
+    assert continuation["recheck_after_seconds"] == 10 * 60
+    assert continuation["recheck_source"] == "frontier_earliest_material_transition"
+
+
 def test_goal_runtime_defer_uses_non_monitor_frontier_without_monitor_deadline() -> None:
     from loopx.control_plane.scheduler import scheduler_hint as scheduler_hint_mod
 

--- a/tests/control_plane/test_scheduler_execution_context.py
+++ b/tests/control_plane/test_scheduler_execution_context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from itertools import product
 
 import pytest
@@ -322,6 +323,106 @@ def test_goal_runtime_mixed_frontier_continues_runnable_advancement() -> None:
     assert quota["scheduler_hint"]["goal_runtime_continuation"]["disposition"] == (
         "continue_now"
     )
+
+
+def test_goal_runtime_defer_uses_earliest_frontier_transition() -> None:
+    """The typed Defer recheck must follow the soonest due monitor on the
+    whole frontier, not a later monitor or the generic backoff interval."""
+
+    from loopx.control_plane.scheduler import scheduler_hint as scheduler_hint_mod
+
+    context = scheduler_execution_context_for_runtime_profile(
+        SchedulerRuntimeProfile.ARK_MANAGED_AGENT_GOAL
+    )
+    now = datetime(2026, 8, 2, 6, 0, 0, tzinfo=UTC)
+    payload = _monitor_wait_payload()
+    payload["agent_todo_summary"] = {
+        "monitor_open_items": [
+            {
+                "todo_id": "todo_soon",
+                "target_key": "pr-ci-soon",
+                "cadence": "60m",
+                "next_due_at": (now + timedelta(minutes=20)).isoformat(),
+            },
+            {
+                "todo_id": "todo_later",
+                "target_key": "pr-review-later",
+                "cadence": "60m",
+                "next_due_at": (now + timedelta(minutes=120)).isoformat(),
+            },
+        ]
+    }
+
+    original_now = scheduler_hint_mod.now_utc
+    scheduler_hint_mod.now_utc = lambda: now
+    try:
+        hint = build_scheduler_hint(
+            payload,
+            scheduler_execution_context=context,
+        )
+    finally:
+        scheduler_hint_mod.now_utc = original_now
+
+    continuation = hint["goal_runtime_continuation"]
+    assert continuation["disposition"] == "defer"
+    # The Goal deadline is derived from the frontier, independent of the
+    # coarser host-automation cadence buckets.
+    assert continuation["recheck_after_seconds"] == 20 * 60
+    assert continuation["recheck_source"] == "frontier_earliest_material_transition"
+    assert continuation["wake_policy"] == "state_change_or_deadline"
+    assert "frontier_recheck" not in hint
+
+
+def test_goal_runtime_defer_uses_exact_due_inside_host_floor() -> None:
+    from loopx.control_plane.scheduler import scheduler_hint as scheduler_hint_mod
+
+    context = scheduler_execution_context_for_runtime_profile(
+        SchedulerRuntimeProfile.ARK_MANAGED_AGENT_GOAL
+    )
+    now = datetime(2026, 8, 2, 6, 0, 0, tzinfo=UTC)
+    payload = _monitor_wait_payload()
+    payload["agent_todo_summary"] = {
+        "monitor_open_items": [
+            {
+                "todo_id": "todo_due_soon",
+                "target_key": "pr-ci-due-soon",
+                "cadence": "60m",
+                "next_due_at": (now + timedelta(minutes=5)).isoformat(),
+            }
+        ]
+    }
+
+    original_now = scheduler_hint_mod.now_utc
+    scheduler_hint_mod.now_utc = lambda: now
+    try:
+        hint = build_scheduler_hint(
+            payload,
+            scheduler_execution_context=context,
+        )
+    finally:
+        scheduler_hint_mod.now_utc = original_now
+
+    continuation = hint["goal_runtime_continuation"]
+    assert continuation["recheck_after_seconds"] == 5 * 60
+    assert continuation["recheck_source"] == "frontier_earliest_material_transition"
+
+
+def test_goal_runtime_defer_falls_back_to_codex_interval_without_frontier() -> None:
+    context = scheduler_execution_context_for_runtime_profile(
+        SchedulerRuntimeProfile.ARK_MANAGED_AGENT_GOAL
+    )
+
+    hint = build_scheduler_hint(
+        _monitor_wait_payload(),
+        scheduler_execution_context=context,
+    )
+
+    continuation = hint["goal_runtime_continuation"]
+    assert continuation["disposition"] == "defer"
+    assert "recheck_source" not in continuation
+    assert continuation["recheck_after_seconds"] == 15 * 60
+    assert continuation["wake_policy"] == "state_change_or_deadline"
+    assert "frontier_recheck" not in hint
 
 
 def test_non_goal_runtime_does_not_receive_goal_continuation() -> None:


### PR DESCRIPTION
## Problem
A Goal-runtime Defer must wake no later than the earliest explicit material-transition deadline on the whole quiet frontier. The existing fallback came from the generic host cadence buckets (15 → 30 → 60 minutes), which can over-sleep a monitor whose next_due_at is sooner. The cadence floor is useful for host automation, but it is not the exact frontier deadline.

This matters only when the whole frontier is quiet. If another issue or advancement Todo is runnable, LoopX projects ContinueNow and the Goal keeps working instead of deferring for CI/review.

## Change
- Preserve exact seconds until each future next_due_at while computing the monitor plan and select the earliest across the frontier.
- Thread that value privately through the scheduler builder into goal_runtime_continuation; do not duplicate it as a new top-level hot-path field.
- Defer emits recheck_source=frontier_earliest_material_transition and the compact wake_policy=state_change_or_deadline from #2731. Without an explicit frontier deadline it keeps the existing cadence fallback.
- Document that the exact Goal deadline is independent of coarser host-automation cadence buckets.

## Regression coverage
- two monitors due in 20m and 120m select 20m;
- a monitor due in 5m yields 300 seconds even though the host cadence floor is 15m;
- no explicit frontier deadline falls back to the existing 15m cadence;
- no top-level frontier_recheck is added to scheduler_hint.

## Verification
- focused scheduler/quota suite: 159 passed;
- hot-path-interface-budget-smoke: quota_should_run_json 12,549/12,550;
- premerge-validation-gate-smoke: passed;
- git diff --check: passed.

Stacked on #2731.