### PR TITLE
fix(status): restore dashboard output budget

### DIFF
--- a/loopx/control_plane/runtime/promotion_readiness.py
+++ b/loopx/control_plane/runtime/promotion_readiness.py
@@ -20,8 +20,8 @@ PROMOTION_READINESS_RECOMMENDED_ACTION_DASHBOARD_SKIPPED = (
 )
 
 PROMOTION_READINESS_PROXY_NOTE = (
-    "canary promotion-readiness projection from the runtime release ledger with legacy goal-history fallback; "
-    "exact evidence stays in append-only artifacts"
+    "canary readiness from runtime ledger or legacy goal history; exact evidence stays "
+    "in append-only artifacts"
 )
 PROMOTION_READINESS_WRITEBACK_COMMAND = (
     "python3 examples/canary/canary-promotion-readiness-smoke.py"


### PR DESCRIPTION
## Summary

- shorten the promotion-readiness proxy note without changing its authority or evidence semantics
- restore the Dashboard status hot-path budget after #2727

## Validation

- `python examples/control_plane/hot-path-interface-budget-smoke.py` (Dashboard 18,181/18,200; quota 12,549/12,550)
- `pytest -q tests/control_plane/test_cli_output_budget.py` (15 passed)
- `loopx canary premerge --from-git-diff` (16 selected checks passed, no failures or manual holds; self-merge allowed)
- `git diff --check`

This is a text-only projection compaction. It does not change readiness selection, freshness, evidence, permissions, or writes.
