### PR TITLE
feat(material): settle intake ranking disposition

### DIFF
--- a/loopx/capabilities/material_lifecycle/__init__.py
+++ b/loopx/capabilities/material_lifecycle/__init__.py
@@ -29,13 +29,6 @@ from .explore_execution import (
     MaterialExploreExecution,
     execute_material_explore_intent,
 )
-from .inventory import (
-    MATERIAL_LIFECYCLE_STATES,
-    MATERIAL_MIGRATION_PLAN_SCHEMA_VERSION,
-    MATERIAL_STORE_INVENTORY_SCHEMA_VERSION,
-    build_material_migration_plan,
-    build_material_store_inventory,
-)
 from .intake import (
     MATERIAL_CANDIDATE_INTAKE_APPLY_RECEIPT_SCHEMA_VERSION,
     MATERIAL_CANDIDATE_INTAKE_PROPOSAL_SCHEMA_VERSION,
@@ -47,6 +40,13 @@ from .intake import (
     apply_material_candidate_intake,
     build_material_candidate_intake_proposal,
     rollback_material_candidate_intake,
+)
+from .inventory import (
+    MATERIAL_LIFECYCLE_STATES,
+    MATERIAL_MIGRATION_PLAN_SCHEMA_VERSION,
+    MATERIAL_STORE_INVENTORY_SCHEMA_VERSION,
+    build_material_migration_plan,
+    build_material_store_inventory,
 )
 from .lifecycle import (
     MATERIAL_LIFECYCLE_RECEIPT_SCHEMA_VERSION,
@@ -87,13 +87,18 @@ from .rebuild import (
     build_material_ranked_entry_rebuild_plan,
     derive_material_ranked_entry_ref,
 )
+from .settlement import (
+    MATERIAL_INTAKE_RANKING_SETTLEMENT_SCHEMA_VERSION,
+    build_material_intake_ranking_settlement,
+)
 
 __all__ = [
     "MATERIAL_CANDIDATE_INTAKE_APPLY_RECEIPT_SCHEMA_VERSION",
     "MATERIAL_CANDIDATE_INTAKE_PROPOSAL_SCHEMA_VERSION",
     "MATERIAL_CANDIDATE_INTAKE_ROLLBACK_RECEIPT_SCHEMA_VERSION",
-    "MATERIAL_EXPLORE_INTENT_SCHEMA_VERSION",
     "MATERIAL_EXPLORE_EXECUTION_RECEIPT_SCHEMA_VERSION",
+    "MATERIAL_EXPLORE_INTENT_SCHEMA_VERSION",
+    "MATERIAL_INTAKE_RANKING_SETTLEMENT_SCHEMA_VERSION",
     "MATERIAL_LIFECYCLE_ARCHITECTURE_SCHEMA_VERSION",
     "MATERIAL_LIFECYCLE_RECEIPT_SCHEMA_VERSION",
     "MATERIAL_LIFECYCLE_STATES",
@@ -118,19 +123,20 @@ __all__ = [
     "MaterialDecisionPlanning",
     "MaterialDecisionPolicy",
     "MaterialDecisionPolicyResult",
+    "MaterialDualReadReconciliation",
     "MaterialExploreCandidate",
     "MaterialExploreExecution",
-    "MaterialDualReadReconciliation",
     "MaterialInventoryProvider",
     "MaterialMigrationApplyProvider",
     "MaterialMigrationPreparation",
-    "MaterialStagedStore",
     "MaterialStagedCandidate",
+    "MaterialStagedStore",
     "MaterialStoreSnapshot",
-    "apply_material_migration",
     "apply_material_candidate_intake",
+    "apply_material_migration",
     "build_material_candidate_intake_proposal",
     "build_material_explore_intent",
+    "build_material_intake_ranking_settlement",
     "build_material_lifecycle_architecture_packet",
     "build_material_lifecycle_receipt",
     "build_material_migration_plan",
@@ -149,7 +155,7 @@ __all__ = [
     "plan_material_decision_actions",
     "prepare_material_migration",
     "project_material_skill_target",
-    "rollback_material_migration",
     "rollback_material_candidate_intake",
+    "rollback_material_migration",
     "uninstall_project_material_skill",
 ]

--- a/loopx/capabilities/material_lifecycle/architecture.py
+++ b/loopx/capabilities/material_lifecycle/architecture.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 from .decision_planning import MATERIAL_EXPLORE_INTENT_SCHEMA_VERSION
-from .inventory import (
-    MATERIAL_MIGRATION_PLAN_SCHEMA_VERSION,
-    MATERIAL_STORE_INVENTORY_SCHEMA_VERSION,
-)
 from .intake import (
     MATERIAL_CANDIDATE_INTAKE_APPLY_RECEIPT_SCHEMA_VERSION,
     MATERIAL_CANDIDATE_INTAKE_PROPOSAL_SCHEMA_VERSION,
     MATERIAL_CANDIDATE_INTAKE_ROLLBACK_RECEIPT_SCHEMA_VERSION,
+)
+from .inventory import (
+    MATERIAL_MIGRATION_PLAN_SCHEMA_VERSION,
+    MATERIAL_STORE_INVENTORY_SCHEMA_VERSION,
 )
 from .lifecycle import MATERIAL_LIFECYCLE_RECEIPT_SCHEMA_VERSION
 from .ranking import (
@@ -24,6 +24,7 @@ from .rebuild import (
     MATERIAL_RANKED_ENTRY_REBUILD_APPLY_RECEIPT_SCHEMA_VERSION,
     MATERIAL_RANKED_ENTRY_REBUILD_PLAN_SCHEMA_VERSION,
 )
+from .settlement import MATERIAL_INTAKE_RANKING_SETTLEMENT_SCHEMA_VERSION
 
 MATERIAL_LIFECYCLE_ARCHITECTURE_SCHEMA_VERSION = "material_lifecycle_architecture_v0"
 
@@ -45,6 +46,7 @@ def build_material_lifecycle_architecture_packet() -> dict[str, object]:
             MATERIAL_CANDIDATE_INTAKE_PROPOSAL_SCHEMA_VERSION,
             MATERIAL_CANDIDATE_INTAKE_APPLY_RECEIPT_SCHEMA_VERSION,
             MATERIAL_CANDIDATE_INTAKE_ROLLBACK_RECEIPT_SCHEMA_VERSION,
+            MATERIAL_INTAKE_RANKING_SETTLEMENT_SCHEMA_VERSION,
             MATERIAL_STORE_INVENTORY_SCHEMA_VERSION,
             MATERIAL_MIGRATION_PLAN_SCHEMA_VERSION,
             MATERIAL_LIFECYCLE_RECEIPT_SCHEMA_VERSION,
@@ -76,6 +78,9 @@ def build_material_lifecycle_architecture_packet() -> dict[str, object]:
             "candidate_intake_adapter": (
                 "source_backed_owner_gated_append_apply_and_rollback"
             ),
+            "ranking_settlement": (
+                "project_classified_completion_receipt_joining_intake_and_ranking"
+            ),
         },
         "lifecycle": [
             "snapshot",
@@ -87,6 +92,7 @@ def build_material_lifecycle_architecture_packet() -> dict[str, object]:
             "lossless_ranked_entry_rebuild",
             "bounded_explore_intent",
             "source_backed_candidate_intake",
+            "candidate_intake_ranking_settlement",
             "audited_apply",
         ],
         "invariants": [
@@ -107,6 +113,9 @@ def build_material_lifecycle_architecture_packet() -> dict[str, object]:
             "proposal_and_apply_receipt_remain_separate",
             "candidate_intake_requires_exact_read_content_backing_and_cas",
             "candidate_intake_appends_exactly_one_without_rewriting_existing_records",
+            "every_candidate_intake_records_one_ranking_disposition",
+            "high_value_candidate_intake_requires_verified_ranked_membership",
+            "intake_and_ranking_keep_separate_receipts_and_authority_transitions",
             "automation_prompts_do_not_own_source_lists_or_ranking_rules",
         ],
         "next_stage": ("private_decision_driven_rerank_dogfood_then_owner_gated_apply"),

--- a/loopx/capabilities/material_lifecycle/settlement.py
+++ b/loopx/capabilities/material_lifecycle/settlement.py
@@ -1,0 +1,238 @@
+"""Completion contract joining candidate intake to its ranking disposition."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from ._validation import (
+    capability_contract,
+    compact_text,
+    compact_token,
+    iso_timestamp,
+    packet_ref,
+    positive_int,
+    token_list,
+)
+
+MATERIAL_INTAKE_RANKING_SETTLEMENT_SCHEMA_VERSION = (
+    "material_intake_ranking_settlement_v0"
+)
+
+_VALUE_CLASSIFICATIONS = {"high_value", "standard"}
+_RANKING_DISPOSITIONS = {"top_window", "ranked_backlog", "no_change"}
+
+
+def _required_bool(value: Any, *, field: str) -> bool:
+    if not isinstance(value, bool):
+        raise TypeError(f"{field} must be a boolean")
+    return value
+
+
+def build_material_intake_ranking_settlement(
+    *,
+    goal_id: str,
+    settlement_id: str,
+    material_ref: str,
+    observed_at: str,
+    decision_evidence_ref: str,
+    value_classification: str,
+    ranking_disposition: str,
+    intake_before_revision: str,
+    intake_after_revision: str,
+    ranking_before_revision: str,
+    ranking_after_revision: str,
+    intake_receipt_ref: str,
+    ranking_receipt_ref: str,
+    owner_gate_ref: str,
+    validation_ref: str,
+    top_window_size: int,
+    authority_readback_verified: bool,
+    ranking_source_contains_material_verified: bool,
+    ranked_membership_verified: bool,
+    target_rank: int | None = None,
+    projection_receipt_ref: str | None = None,
+    rollback_ref: str | None = None,
+    displaced_to_backlog_refs: Sequence[str] | None = None,
+    no_change_reason: str | None = None,
+) -> dict[str, Any]:
+    """Build a public-safe receipt only after intake and ranking are settled."""
+
+    classification = compact_token(
+        value_classification,
+        field="value_classification",
+    )
+    if classification not in _VALUE_CLASSIFICATIONS:
+        raise ValueError(f"unsupported value_classification: {classification}")
+    disposition = compact_token(
+        ranking_disposition,
+        field="ranking_disposition",
+    )
+    if disposition not in _RANKING_DISPOSITIONS:
+        raise ValueError(f"unsupported ranking_disposition: {disposition}")
+    if classification == "high_value" and disposition == "no_change":
+        raise ValueError("high_value material requires ranked membership")
+
+    normalized_material_ref = compact_token(material_ref, field="material_ref")
+    normalized_intake_receipt_ref = compact_token(
+        intake_receipt_ref,
+        field="intake_receipt_ref",
+    )
+    normalized_ranking_receipt_ref = compact_token(
+        ranking_receipt_ref,
+        field="ranking_receipt_ref",
+    )
+    if normalized_intake_receipt_ref == normalized_ranking_receipt_ref:
+        raise ValueError("intake and ranking receipts must remain separate")
+
+    intake_before = compact_token(
+        intake_before_revision,
+        field="intake_before_revision",
+    )
+    intake_after = compact_token(
+        intake_after_revision,
+        field="intake_after_revision",
+    )
+    ranking_before = compact_token(
+        ranking_before_revision,
+        field="ranking_before_revision",
+    )
+    ranking_after = compact_token(
+        ranking_after_revision,
+        field="ranking_after_revision",
+    )
+    if intake_before == intake_after:
+        raise ValueError("candidate intake must advance the authority revision")
+    readback_verified = _required_bool(
+        authority_readback_verified,
+        field="authority_readback_verified",
+    )
+    source_contains_material = _required_bool(
+        ranking_source_contains_material_verified,
+        field="ranking_source_contains_material_verified",
+    )
+    membership_verified = _required_bool(
+        ranked_membership_verified,
+        field="ranked_membership_verified",
+    )
+    if not readback_verified:
+        raise ValueError("authority_readback_verified must be true")
+    if not source_contains_material:
+        raise ValueError("ranking source must contain the candidate material")
+
+    window_size = positive_int(top_window_size, field="top_window_size")
+    displaced_refs = token_list(
+        displaced_to_backlog_refs,
+        field="displaced_to_backlog_refs",
+    )
+    if normalized_material_ref in displaced_refs:
+        raise ValueError("the settled material cannot be displaced to backlog")
+    normalized_target_rank: int | None = None
+    if target_rank is not None:
+        normalized_target_rank = positive_int(target_rank, field="target_rank")
+
+    if disposition == "no_change":
+        if normalized_target_rank is not None:
+            raise ValueError("no_change cannot include target_rank")
+        if membership_verified:
+            raise ValueError("no_change cannot claim ranked membership")
+        if displaced_refs:
+            raise ValueError("no_change cannot displace ranked materials")
+        if no_change_reason is None:
+            raise ValueError("no_change requires no_change_reason")
+        if ranking_before == ranking_after:
+            if projection_receipt_ref is not None:
+                raise ValueError(
+                    "no_change without a shared rerank cannot include "
+                    "projection_receipt_ref"
+                )
+            if rollback_ref is not None:
+                raise ValueError(
+                    "no_change without a shared rerank cannot include rollback_ref"
+                )
+        elif projection_receipt_ref is None or rollback_ref is None:
+            raise ValueError(
+                "no_change in a shared rerank requires projection and rollback refs"
+            )
+    else:
+        if ranking_before == ranking_after:
+            raise ValueError("ranked placement must advance the ranking revision")
+        if normalized_target_rank is None:
+            raise ValueError("ranked placement requires target_rank")
+        if disposition == "top_window" and normalized_target_rank > window_size:
+            raise ValueError("top_window target_rank exceeds top_window_size")
+        if disposition == "ranked_backlog" and normalized_target_rank <= window_size:
+            raise ValueError("ranked_backlog target_rank must follow the top window")
+        if disposition == "ranked_backlog" and displaced_refs:
+            raise ValueError("ranked_backlog cannot displace ranked materials")
+        if not membership_verified:
+            raise ValueError("ranked placement requires verified membership")
+        if projection_receipt_ref is None:
+            raise ValueError("ranked placement requires projection_receipt_ref")
+        if rollback_ref is None:
+            raise ValueError("ranked placement requires rollback_ref")
+        if no_change_reason is not None:
+            raise ValueError("no_change_reason is only valid for no_change")
+
+    settlement: dict[str, Any] = {
+        "schema_version": MATERIAL_INTAKE_RANKING_SETTLEMENT_SCHEMA_VERSION,
+        "goal_id": compact_token(goal_id, field="goal_id"),
+        "settlement_id": compact_token(settlement_id, field="settlement_id"),
+        "material_ref": normalized_material_ref,
+        "observed_at": iso_timestamp(observed_at, field="observed_at"),
+        "decision_evidence_ref": compact_token(
+            decision_evidence_ref,
+            field="decision_evidence_ref",
+        ),
+        "value_classification": classification,
+        "ranking_disposition": disposition,
+        "intake_before_revision": intake_before,
+        "intake_after_revision": intake_after,
+        "ranking_before_revision": ranking_before,
+        "ranking_after_revision": ranking_after,
+        "intake_receipt_ref": normalized_intake_receipt_ref,
+        "ranking_receipt_ref": normalized_ranking_receipt_ref,
+        "owner_gate_ref": compact_token(
+            owner_gate_ref,
+            field="owner_gate_ref",
+        ),
+        "validation_ref": compact_token(
+            validation_ref,
+            field="validation_ref",
+        ),
+        "top_window_size": window_size,
+        "target_rank": normalized_target_rank,
+        "displaced_to_backlog_refs": displaced_refs,
+        "status": "settled",
+        "verification": {
+            "candidate_intake_completed": True,
+            "ranking_disposition_recorded": True,
+            "ranking_source_contains_material_verified": True,
+            "authority_readback_verified": True,
+            "ranked_membership_verified": membership_verified,
+        },
+        "visibility": "public_safe",
+        "capability": capability_contract(packet_role="intake_ranking_settlement"),
+        "raw_content_captured": False,
+        "private_locations_captured": False,
+    }
+    if projection_receipt_ref is not None:
+        settlement["projection_receipt_ref"] = compact_token(
+            projection_receipt_ref,
+            field="projection_receipt_ref",
+        )
+    if rollback_ref is not None:
+        settlement["rollback_ref"] = compact_token(
+            rollback_ref,
+            field="rollback_ref",
+        )
+    if no_change_reason is not None:
+        settlement["no_change_reason"] = compact_text(
+            no_change_reason,
+            field="no_change_reason",
+        )
+    settlement["settlement_ref"] = packet_ref(
+        "material-intake-ranking-settlement",
+        settlement,
+    )
+    return settlement

--- a/skills/loopx-material/SKILL.md
+++ b/skills/loopx-material/SKILL.md
@@ -107,7 +107,30 @@ Do not start Explore merely because the current list feels incomplete. Explore
 begins only from a named evidence gap, bounded query plan, budget, and stop
 condition.
 
-### 4. Rebuild Ranked Entries
+### 4. Settle Candidate Ranking
+
+Before reporting candidate intake complete, settle its ranking against the
+current Decision Context:
+
+- record exactly one disposition: `top_window`, `ranked_backlog`, or
+  `no_change`;
+- let the project adapter classify value from exact-read evidence, current
+  objectives, overlap, and artifact convertibility rather than tier alone;
+- require high-value materials to gain verified membership in the Top-N or
+  explicit ranked backlog;
+- require a reason for `no_change` and use it only for standard-value or
+  substantially duplicative materials;
+- keep candidate intake and ranking as separate receipts and, when ranking
+  changes, separate authority revisions; then join them with an intake-ranking
+  settlement receipt;
+- preserve displaced Top-N entries in the ranked backlog and preserve protected
+  anchors unless changed Decision Context or explicit owner authority moves
+  them.
+
+If ranking apply, readback, projection, or rollback readiness fails, repair or
+roll back before reporting the intake as complete.
+
+### 5. Rebuild Ranked Entries
 
 A ranked entry must represent one independently sortable reading or action
 unit, not a display bucket.
@@ -125,7 +148,7 @@ Splitting is semantic, not mechanical. Group materials only when they jointly
 support one decision or learning outcome; separate materials whose value,
 urgency, reader action, or evidence maturity differs.
 
-### 5. Propose A Bounded Rerank
+### 6. Propose A Bounded Rerank
 
 Rerank from revision-bound Decision Context evidence.
 
@@ -136,7 +159,7 @@ Rerank from revision-bound Decision Context evidence.
 - Emit a no-change proposal when evidence does not justify movement.
 - Keep proposal and apply receipt separate.
 
-### 6. Build A Readable Projection
+### 7. Build A Readable Projection
 
 The managed catalog remains authority, but operators need a readable view.
 Build that view from exact-read-backed presentation records:
@@ -153,7 +176,7 @@ LoopX owns validation, rendering, and the content-free receipt contract. The
 project adapter owns source parsing and supplies already-promoted display
 records. One-time legacy parsing and migration scripts remain project-local.
 
-### 7. Apply With A Lossless Gate
+### 8. Apply With A Lossless Gate
 
 Preview first. Apply only when all are true:
 
@@ -193,10 +216,12 @@ A complete material operation reports:
 - backup and source-digest verification;
 - parsed and canonical counts;
 - lifecycle-count delta;
+- intake ranking disposition and value classification;
 - ranked-entry count and maximum primary-member count;
 - exact coverage and duplicate count;
 - promoted/rejected exact-read evidence;
 - proposal and apply receipt references;
+- intake-ranking settlement receipt reference;
 - rollback result;
 - next bounded action or explicit no-change.
 

--- a/tests/capabilities/test_material_lifecycle_contracts.py
+++ b/tests/capabilities/test_material_lifecycle_contracts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from loopx.capabilities.material_lifecycle import (
+    build_material_intake_ranking_settlement,
     build_material_lifecycle_architecture_packet,
     build_material_lifecycle_receipt,
     build_material_migration_plan,
@@ -55,6 +56,171 @@ def test_architecture_positions_material_lifecycle_as_default_off_sibling() -> N
     assert packet["provider_boundaries"]["raw_material_store"] == (
         "private_external_authority"
     )
+    assert "material_intake_ranking_settlement_v0" in packet["contract_schemas"]
+    assert (
+        "high_value_candidate_intake_requires_verified_ranked_membership"
+        in packet["invariants"]
+    )
+
+
+def test_high_value_intake_settles_into_top_window() -> None:
+    settlement = build_material_intake_ranking_settlement(
+        goal_id="goal:material-example",
+        settlement_id="settlement:material-42",
+        material_ref="material:42",
+        observed_at=OBSERVED_AT,
+        decision_evidence_ref="decision-evidence:42",
+        value_classification="high_value",
+        ranking_disposition="top_window",
+        intake_before_revision="revision:41",
+        intake_after_revision="revision:42",
+        ranking_before_revision="revision:42",
+        ranking_after_revision="revision:43",
+        intake_receipt_ref="receipt:intake-42",
+        ranking_receipt_ref="receipt:ranking-42",
+        owner_gate_ref="gate:ranking-42",
+        validation_ref="validation:ranking-42",
+        top_window_size=30,
+        target_rank=7,
+        authority_readback_verified=True,
+        ranking_source_contains_material_verified=True,
+        ranked_membership_verified=True,
+        projection_receipt_ref="receipt:projection-43",
+        rollback_ref="revision:42",
+        displaced_to_backlog_refs=["material:old-30"],
+    )
+
+    assert settlement["status"] == "settled"
+    assert settlement["ranking_disposition"] == "top_window"
+    assert settlement["verification"]["ranked_membership_verified"] is True
+    assert settlement["displaced_to_backlog_refs"] == ["material:old-30"]
+
+
+def test_standard_intake_can_settle_as_a_reasoned_no_change() -> None:
+    settlement = build_material_intake_ranking_settlement(
+        goal_id="goal:material-example",
+        settlement_id="settlement:material-42",
+        material_ref="material:42",
+        observed_at=OBSERVED_AT,
+        decision_evidence_ref="decision-evidence:42",
+        value_classification="standard",
+        ranking_disposition="no_change",
+        intake_before_revision="revision:41",
+        intake_after_revision="revision:42",
+        ranking_before_revision="revision:42",
+        ranking_after_revision="revision:42",
+        intake_receipt_ref="receipt:intake-42",
+        ranking_receipt_ref="receipt:ranking-no-change-42",
+        owner_gate_ref="gate:ranking-42",
+        validation_ref="validation:ranking-42",
+        top_window_size=30,
+        authority_readback_verified=True,
+        ranking_source_contains_material_verified=True,
+        ranked_membership_verified=False,
+        no_change_reason="Substantially overlaps an already ranked action unit.",
+    )
+
+    assert settlement["ranking_disposition"] == "no_change"
+    assert settlement["ranking_before_revision"] == settlement["ranking_after_revision"]
+    assert settlement["no_change_reason"].startswith("Substantially overlaps")
+
+
+def test_high_value_intake_cannot_settle_without_ranked_membership() -> None:
+    with pytest.raises(ValueError, match="requires ranked membership"):
+        build_material_intake_ranking_settlement(
+            goal_id="goal:material-example",
+            settlement_id="settlement:material-42",
+            material_ref="material:42",
+            observed_at=OBSERVED_AT,
+            decision_evidence_ref="decision-evidence:42",
+            value_classification="high_value",
+            ranking_disposition="no_change",
+            intake_before_revision="revision:41",
+            intake_after_revision="revision:42",
+            ranking_before_revision="revision:42",
+            ranking_after_revision="revision:42",
+            intake_receipt_ref="receipt:intake-42",
+            ranking_receipt_ref="receipt:ranking-no-change-42",
+            owner_gate_ref="gate:ranking-42",
+            validation_ref="validation:ranking-42",
+            top_window_size=30,
+            authority_readback_verified=True,
+            ranking_source_contains_material_verified=True,
+            ranked_membership_verified=False,
+            no_change_reason="No movement requested.",
+        )
+
+
+def test_ranking_settlement_enforces_source_containment_and_rank_window() -> None:
+    common = {
+        "goal_id": "goal:material-example",
+        "settlement_id": "settlement:material-42",
+        "material_ref": "material:42",
+        "observed_at": OBSERVED_AT,
+        "decision_evidence_ref": "decision-evidence:42",
+        "value_classification": "high_value",
+        "ranking_disposition": "ranked_backlog",
+        "intake_before_revision": "revision:41",
+        "intake_after_revision": "revision:42",
+        "ranking_before_revision": "revision:41",
+        "ranking_after_revision": "revision:43",
+        "intake_receipt_ref": "receipt:intake-42",
+        "ranking_receipt_ref": "receipt:ranking-42",
+        "owner_gate_ref": "gate:ranking-42",
+        "validation_ref": "validation:ranking-42",
+        "top_window_size": 30,
+        "target_rank": 31,
+        "authority_readback_verified": True,
+        "ranking_source_contains_material_verified": False,
+        "ranked_membership_verified": True,
+        "projection_receipt_ref": "receipt:projection-43",
+        "rollback_ref": "revision:42",
+    }
+    with pytest.raises(ValueError, match="must contain"):
+        build_material_intake_ranking_settlement(**common)
+
+    common["ranking_source_contains_material_verified"] = True
+    common["target_rank"] = 30
+    with pytest.raises(ValueError, match="must follow the top window"):
+        build_material_intake_ranking_settlement(**common)
+
+    common["target_rank"] = 31
+    common["ranked_membership_verified"] = "yes"
+    with pytest.raises(TypeError, match="must be a boolean"):
+        build_material_intake_ranking_settlement(**common)
+
+
+def test_no_change_can_share_a_batch_rerank_revision() -> None:
+    settlement = build_material_intake_ranking_settlement(
+        goal_id="goal:material-example",
+        settlement_id="settlement:material-42",
+        material_ref="material:42",
+        observed_at=OBSERVED_AT,
+        decision_evidence_ref="decision-evidence:42",
+        value_classification="standard",
+        ranking_disposition="no_change",
+        intake_before_revision="revision:39",
+        intake_after_revision="revision:40",
+        ranking_before_revision="revision:42",
+        ranking_after_revision="revision:43",
+        intake_receipt_ref="receipt:intake-42",
+        ranking_receipt_ref="receipt:shared-ranking-43",
+        owner_gate_ref="gate:ranking-43",
+        validation_ref="validation:ranking-43",
+        top_window_size=30,
+        authority_readback_verified=True,
+        ranking_source_contains_material_verified=True,
+        ranked_membership_verified=False,
+        projection_receipt_ref="receipt:projection-43",
+        rollback_ref="revision:42",
+        no_change_reason="Substantially overlaps an already ranked action unit.",
+    )
+
+    assert settlement["ranking_before_revision"] == "revision:42"
+    assert settlement["ranking_after_revision"] == "revision:43"
+    assert settlement["verification"][
+        "ranking_source_contains_material_verified"
+    ] is True
 
 
 def test_inventory_is_deterministic_read_only_and_content_free() -> None:


### PR DESCRIPTION
## Summary

- add a public-safe Material Lifecycle settlement contract that joins candidate intake to one explicit ranking disposition
- require high-value materials to have verified Top-N or ranked-backlog membership
- support reasoned no-change dispositions, including shared batch reranks, while preserving separate intake and ranking receipts
- document the completion rule in the managed loopx-material skill and architecture packet

## Validation

- `python -m pytest -q tests/capabilities/test_material_lifecycle*.py` — 47 passed
- `python -m mypy` — passed
- focused Ruff check — passed
- LoopX public-boundary scan for all five changed paths — passed
- `loopx canary premerge --from-git-diff --goal-id career-loopx-decision-advisor` — passed
- change-quality receipt `cqr_5d02cceba3318d66e3fc` — valid

## Boundaries

- no provider implementation, private catalog data, raw material content, local path, or runtime state is included
- the contract is default-off and provider-neutral; project adapters remain responsible for value classification and source readback
- this PR does not change an existing ranking or automatically mutate a material store
