### PR TITLE
feat(memory): add autonomous agent turn recall

### DIFF
--- a/docs/capabilities/agent-turn-recall/README.md
+++ b/docs/capabilities/agent-turn-recall/README.md
@@ -1,0 +1,84 @@
+# Agent Turn Recall
+
+`agent-turn-recall` prepares memory guidance for an autonomous agent turn when
+there may be no new user prompt. It composes existing LoopX surfaces instead of
+introducing another memory store:
+
+- quota and Todo projection select the current work;
+- Agent Turn Recall builds the bounded situation and query;
+- Reward Memory enforces corpus, identity, authority, freshness, and lifecycle;
+- the configured context provider performs read-only retrieval.
+
+The capability is default-off. A goal must explicitly enable a Reward Memory
+experiment for the agent and configure the `agent_workflow.turn_admission`
+surface.
+
+## Turn Contract
+
+`agent_turn_situation_v0` includes the agent, goal, project, selected Todo,
+phase, recent outcomes, and next intent. It records
+`user_prompt_included=false`; chat text is not a fallback input. The material
+fields produce a `situation_fingerprint`. Combining that fingerprint with the
+host-provided `turn_instance_id` produces a `turn_recall_id`.
+
+This gives two useful identities:
+
+- a changed Todo, target, phase, or intent changes the situation fingerprint;
+- a new turn changes the recall id and recalls again, even when the situation
+  is otherwise unchanged.
+
+Repeated execution with the same recall id may reuse one ignored local receipt.
+The receipt stores only the compact private context needed to reproduce that
+turn's guidance; it never stores provider payloads, credentials, or query text.
+
+## Usage
+
+Preview without provider access:
+
+```bash
+# Persist the exact packet already used for turn routing in ignored local state.
+loopx quota should-run ... --format json > .local/turn-quota.json
+
+loopx agent-turn-recall \
+  --goal-id <goal-id> \
+  --agent-id <agent-id> \
+  --turn-instance-id <iso-turn-id> \
+  --quota-decision-json .local/turn-quota.json \
+  --format json
+```
+
+Recall after quota/Todo selection:
+
+```bash
+loopx agent-turn-recall \
+  --goal-id <goal-id> \
+  --agent-id <agent-id> \
+  --turn-instance-id <iso-turn-id> \
+  --quota-decision-json .local/turn-quota.json \
+  --execute \
+  --format json
+```
+
+The command consumes the exact quota packet instead of rebuilding status. This
+keeps turn admission bounded and ensures the recall query uses the same selected
+Todo and interaction state that the host is following. `-` may be used to read
+the packet from stdin when the host owns a safe pipeline.
+
+The result carries a private `context.guidance` list for agent reasoning. It is
+not action authority. The agent must still obey the current interaction
+contract, capability gates, write scopes, and user gates.
+
+Retrieval relevance and action applicability remain separate. Recalled
+guidance is conditional private context; the agent must compare it with the
+exact turn situation and current authority before acting.
+
+## Freshness And Failure
+
+Active Reward Memory records may carry `lifecycle.expires_at`. Retrieval ignores
+the record at or after that timestamp. Wrong user, peer, project, session, or
+surface scope is rejected before provider application.
+
+Provider and application failures preserve an empty base context, do not create
+a user gate, do not spend quota, and do not deliver to external sinks. The host
+can therefore call this capability at turn admission without making memory
+availability a prerequisite for safe autonomous progress.

--- a/loopx/capabilities/agent_turn_recall/__init__.py
+++ b/loopx/capabilities/agent_turn_recall/__init__.py
@@ -1,0 +1,17 @@
+from .core import (
+    AGENT_TURN_RECALL_CONTEXT_SCHEMA_VERSION,
+    AGENT_TURN_RECALL_SCHEMA_VERSION,
+    AGENT_TURN_SITUATION_SCHEMA_VERSION,
+    build_agent_turn_recall_preview,
+    build_agent_turn_situation,
+    run_agent_turn_recall,
+)
+
+__all__ = [
+    "AGENT_TURN_RECALL_CONTEXT_SCHEMA_VERSION",
+    "AGENT_TURN_RECALL_SCHEMA_VERSION",
+    "AGENT_TURN_SITUATION_SCHEMA_VERSION",
+    "build_agent_turn_recall_preview",
+    "build_agent_turn_situation",
+    "run_agent_turn_recall",
+]

--- a/loopx/capabilities/agent_turn_recall/cli.py
+++ b/loopx/capabilities/agent_turn_recall/cli.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import tempfile
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+from ...history import load_registry
+from ...materials import find_registry_goal, goal_repo
+from ..reward_memory.experiment import (
+    resolve_reward_memory_experiment,
+    resolve_reward_memory_surface_config,
+)
+from .core import (
+    AGENT_TURN_RECALL_SCHEMA_VERSION,
+    AGENT_TURN_RECALL_SURFACE_ID,
+    build_agent_turn_recall_preview,
+    build_agent_turn_situation,
+    run_agent_turn_recall,
+)
+
+
+AGENT_TURN_RECALL_RECEIPT_SCHEMA_VERSION = "agent_turn_recall_receipt_v0"
+_SAFE_PATH_TOKEN = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _mapping(value: object) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _render(payload: dict[str, object]) -> str:
+    lines = ["# Agent Turn Recall", ""]
+    for key in (
+        "status",
+        "goal_id",
+        "agent_id",
+        "surface_id",
+        "provider_call_count",
+    ):
+        if payload.get(key) is not None:
+            lines.append(f"- {key}: `{payload[key]}`")
+    context = payload.get("context")
+    guidance = context.get("guidance") if isinstance(context, Mapping) else None
+    if isinstance(guidance, list):
+        lines.append(f"- guidance_count: `{len(guidance)}`")
+    return "\n".join(lines) + "\n"
+
+
+def register_agent_turn_recall_commands(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    parser = subparsers.add_parser(
+        "agent-turn-recall",
+        help="Recall scoped memory from the current autonomous Goal/Todo situation.",
+    )
+    add_subcommand_format(parser)
+    parser.add_argument("--goal-id", required=True)
+    parser.add_argument("--agent-id", required=True)
+    parser.add_argument("--turn-instance-id", required=True)
+    parser.add_argument(
+        "--quota-decision-json",
+        required=True,
+        help="Exact quota should-run JSON path, or - for stdin.",
+    )
+    parser.add_argument("--session-ref")
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Run the configured provider and write one ignored same-turn receipt.",
+    )
+    parser.add_argument(
+        "--force-refresh",
+        action="store_true",
+        help="Ignore a matching same-turn receipt and query the provider again.",
+    )
+
+
+def _goal_repo(registry_path: Path, goal_id: str) -> Path:
+    goal = find_registry_goal(load_registry(registry_path), goal_id)
+    repo = goal_repo(goal) if goal else None
+    if repo is None or not repo.is_dir():
+        raise ValueError(f"goal `{goal_id}` repository is unavailable")
+    return repo
+
+
+def _receipt_path(repo: Path, agent_id: str) -> Path:
+    token = _SAFE_PATH_TOKEN.sub("-", agent_id).strip("-") or "agent"
+    return repo / ".local" / "loopx" / "agent-turn-recall" / f"{token}.json"
+
+
+def _quota_decision(path_value: str) -> dict[str, Any]:
+    try:
+        if path_value == "-":
+            payload = json.load(sys.stdin)
+        else:
+            payload = json.loads(
+                Path(path_value).expanduser().read_text(encoding="utf-8")
+            )
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("quota decision must be readable JSON") from exc
+    if not isinstance(payload, dict) or payload.get("mode") != "should-run":
+        raise ValueError("quota decision must be one quota should-run object")
+    return payload
+
+
+def _load_receipt(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("schema_version") != AGENT_TURN_RECALL_RECEIPT_SCHEMA_VERSION:
+        return None
+    return payload
+
+
+def _write_receipt(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=path.name + ".", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def _identity_scope(config: Mapping[str, Any]) -> dict[str, str | None]:
+    route = resolve_reward_memory_surface_config(
+        config,
+        AGENT_TURN_RECALL_SURFACE_ID,
+    )
+    routes = route.get("recall_corpora")
+    if not isinstance(routes, list) or not routes:
+        raise ValueError("agent turn recall surface has no corpus")
+    identity: dict[str, str | None] | None = None
+    for item in routes:
+        corpus = item.get("corpus") if isinstance(item, Mapping) else None
+        scope = corpus.get("scope") if isinstance(corpus, Mapping) else None
+        if not isinstance(scope, Mapping):
+            raise ValueError("agent turn recall corpus scope is invalid")
+        current = {
+            key: str(scope.get(key) or "").strip() or None
+            for key in (
+                "workspace_ref",
+                "project_ref",
+                "user_ref",
+                "peer_ref",
+                "session_ref",
+            )
+        }
+        if identity is not None and current != identity:
+            raise ValueError("agent turn recall corpora must share one identity scope")
+        identity = current
+    assert identity is not None
+    return identity
+
+
+def _read_authority_checkpoints(
+    config: Mapping[str, Any], goal_id: str
+) -> dict[str, dict[str, Any]]:
+    route = resolve_reward_memory_surface_config(
+        config,
+        AGENT_TURN_RECALL_SURFACE_ID,
+    )
+    checkpoints: dict[str, dict[str, Any]] = {}
+    for item in route["recall_corpora"]:
+        corpus = item["corpus"]
+        scope = corpus["scope"]
+        checkpoint = {
+            "verified": True,
+            "corpus_id": corpus["corpus_id"],
+            "workspace_ref": scope["workspace_ref"],
+            "project_ref": scope["project_ref"],
+            "surface_id": AGENT_TURN_RECALL_SURFACE_ID,
+            "read_authority": corpus["read_authority"],
+            "source_ref": f"registry:{goal_id}:reward-memory",
+        }
+        for field in ("user_ref", "peer_ref", "session_ref"):
+            if scope.get(field):
+                checkpoint[field] = scope[field]
+        checkpoints[corpus["corpus_id"]] = checkpoint
+    return checkpoints
+
+
+def _deduplicated_payload(
+    receipt: Mapping[str, Any],
+    *,
+    goal_id: str,
+    agent_id: str,
+) -> dict[str, Any] | None:
+    context = receipt.get("context")
+    if not isinstance(context, Mapping):
+        return None
+    return {
+        "ok": True,
+        "schema_version": AGENT_TURN_RECALL_SCHEMA_VERSION,
+        "status": "deduplicated",
+        "goal_id": goal_id,
+        "agent_id": agent_id,
+        "surface_id": AGENT_TURN_RECALL_SURFACE_ID,
+        "turn_recall_id": receipt.get("turn_recall_id"),
+        "situation_fingerprint": receipt.get("situation_fingerprint"),
+        "context": dict(context),
+        "provider_call_count": 0,
+        "same_turn_receipt_reused": True,
+        "source_status": receipt.get("source_status"),
+        "grants_new_action_authority": False,
+        "quota_spend_performed": False,
+        "external_writes_performed": False,
+        "suppress_external_sinks": True,
+    }
+
+
+def handle_agent_turn_recall_command(
+    args: argparse.Namespace,
+    *,
+    registry_path: Path,
+    output_format: Callable[..., str],
+    print_payload: Callable[[dict[str, object], str, Callable], None],
+) -> int | None:
+    if args.command != "agent-turn-recall":
+        return None
+    try:
+        goal_repo = _goal_repo(registry_path, args.goal_id)
+        experiment_status, config = resolve_reward_memory_experiment(
+            registry_path=registry_path,
+            goal_id=args.goal_id,
+            agent_id=args.agent_id,
+        )
+        if config is None:
+            payload: dict[str, Any] = {
+                "ok": True,
+                "schema_version": AGENT_TURN_RECALL_SCHEMA_VERSION,
+                "status": "disabled",
+                "goal_id": args.goal_id,
+                "agent_id": args.agent_id,
+                "experiment": experiment_status,
+                "provider_call_count": 0,
+                "grants_new_action_authority": False,
+                "quota_spend_performed": False,
+                "external_writes_performed": False,
+                "suppress_external_sinks": True,
+            }
+        else:
+            identity = _identity_scope(config)
+            quota_decision = _quota_decision(args.quota_decision_json)
+            if quota_decision.get("goal_id") != args.goal_id:
+                raise ValueError("quota decision goal_id does not match --goal-id")
+            decision_agent = _mapping(quota_decision.get("agent_identity")).get(
+                "agent_id"
+            )
+            if decision_agent and decision_agent != args.agent_id:
+                raise ValueError("quota decision agent_id does not match --agent-id")
+            situation = build_agent_turn_situation(
+                quota_decision,
+                goal_id=args.goal_id,
+                agent_id=args.agent_id,
+                turn_instance_id=args.turn_instance_id,
+                workspace_ref=str(identity["workspace_ref"] or ""),
+                project_ref=str(identity["project_ref"] or ""),
+                user_ref=identity["user_ref"],
+                session_ref=args.session_ref,
+            )
+            receipt_path = _receipt_path(goal_repo, args.agent_id)
+            previous = None if args.force_refresh else _load_receipt(receipt_path)
+            deduplicated = (
+                _deduplicated_payload(
+                    previous,
+                    goal_id=args.goal_id,
+                    agent_id=args.agent_id,
+                )
+                if previous
+                and previous.get("turn_recall_id") == situation["turn_recall_id"]
+                else None
+            )
+            if deduplicated is not None:
+                payload = deduplicated
+            elif not args.execute:
+                payload = build_agent_turn_recall_preview(situation) | {
+                    "goal_id": args.goal_id,
+                    "agent_id": args.agent_id,
+                    "experiment": experiment_status,
+                }
+            else:
+                payload = run_agent_turn_recall(
+                    config,
+                    situation,
+                    observed_at=args.turn_instance_id,
+                    read_authority_checkpoints=_read_authority_checkpoints(
+                        config, args.goal_id
+                    ),
+                ) | {
+                    "goal_id": args.goal_id,
+                    "agent_id": args.agent_id,
+                    "experiment": experiment_status,
+                }
+                if payload.get("status") in {"applied", "not_available"}:
+                    _write_receipt(
+                        receipt_path,
+                        {
+                            "schema_version": AGENT_TURN_RECALL_RECEIPT_SCHEMA_VERSION,
+                            "turn_recall_id": payload.get("turn_recall_id"),
+                            "situation_fingerprint": payload.get(
+                                "situation_fingerprint"
+                            ),
+                            "source_status": payload.get("status"),
+                            "context": payload.get("context"),
+                        },
+                    )
+                    payload["same_turn_receipt_written"] = True
+    except (OSError, TypeError, ValueError) as exc:
+        payload = {
+            "ok": False,
+            "schema_version": AGENT_TURN_RECALL_SCHEMA_VERSION,
+            "status": "invalid_request",
+            "goal_id": args.goal_id,
+            "agent_id": args.agent_id,
+            "error": str(exc),
+            "provider_call_count": 0,
+            "grants_new_action_authority": False,
+            "quota_spend_performed": False,
+            "external_writes_performed": False,
+            "suppress_external_sinks": True,
+        }
+    print_payload(payload, output_format(args), _render)
+    return 0 if payload.get("ok") else 2

--- a/loopx/capabilities/agent_turn_recall/cli.py
+++ b/loopx/capabilities/agent_turn_recall/cli.py
@@ -52,7 +52,7 @@ def _render(payload: dict[str, object]) -> str:
 
 
 def register_agent_turn_recall_commands(
-    subparsers: argparse._SubParsersAction,
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
     add_subcommand_format: Callable[[argparse.ArgumentParser], None],
 ) -> None:
     parser = subparsers.add_parser(
@@ -83,8 +83,11 @@ def register_agent_turn_recall_commands(
 
 def _goal_repo(registry_path: Path, goal_id: str) -> Path:
     goal = find_registry_goal(load_registry(registry_path), goal_id)
-    repo = goal_repo(goal) if goal else None
-    if repo is None or not repo.is_dir():
+    resolved = goal_repo(goal) if goal else None
+    if resolved is None:
+        raise ValueError(f"goal `{goal_id}` repository is unavailable")
+    repo = Path(resolved)
+    if not repo.is_dir():
         raise ValueError(f"goal `{goal_id}` repository is unavailable")
     return repo
 
@@ -107,6 +110,27 @@ def _quota_decision(path_value: str) -> dict[str, Any]:
     if not isinstance(payload, dict) or payload.get("mode") != "should-run":
         raise ValueError("quota decision must be one quota should-run object")
     return payload
+
+
+def _validate_quota_identity(
+    quota_decision: Mapping[str, Any],
+    *,
+    goal_id: str,
+    agent_id: str,
+    turn_instance_id: str,
+) -> None:
+    if quota_decision.get("goal_id") != goal_id:
+        raise ValueError("quota decision goal_id does not match --goal-id")
+    decision_agent = _mapping(quota_decision.get("agent_identity")).get("agent_id")
+    if decision_agent != agent_id:
+        raise ValueError("quota decision agent_id does not match --agent-id")
+    receipt = _mapping(quota_decision.get("heartbeat_receipt"))
+    if receipt.get("turn_instance_id") != turn_instance_id:
+        raise ValueError(
+            "quota decision turn_instance_id does not match --turn-instance-id"
+        )
+    if receipt.get("status") not in {"committed", "replayed"}:
+        raise ValueError("quota decision heartbeat receipt is not committed")
 
 
 def _load_receipt(path: Path) -> dict[str, Any] | None:
@@ -163,6 +187,16 @@ def _identity_scope(config: Mapping[str, Any]) -> dict[str, str | None]:
         identity = current
     assert identity is not None
     return identity
+
+
+def _resolve_session_ref(
+    identity: Mapping[str, str | None], requested: str | None
+) -> str | None:
+    configured = str(identity.get("session_ref") or "").strip() or None
+    requested = str(requested or "").strip() or None
+    if configured and requested and configured != requested:
+        raise ValueError("--session-ref does not match the configured corpus scope")
+    return configured or requested
 
 
 def _read_authority_checkpoints(
@@ -226,7 +260,7 @@ def handle_agent_turn_recall_command(
     *,
     registry_path: Path,
     output_format: Callable[..., str],
-    print_payload: Callable[[dict[str, object], str, Callable], None],
+    print_payload: Callable[..., None],
 ) -> int | None:
     if args.command != "agent-turn-recall":
         return None
@@ -254,13 +288,12 @@ def handle_agent_turn_recall_command(
         else:
             identity = _identity_scope(config)
             quota_decision = _quota_decision(args.quota_decision_json)
-            if quota_decision.get("goal_id") != args.goal_id:
-                raise ValueError("quota decision goal_id does not match --goal-id")
-            decision_agent = _mapping(quota_decision.get("agent_identity")).get(
-                "agent_id"
+            _validate_quota_identity(
+                quota_decision,
+                goal_id=args.goal_id,
+                agent_id=args.agent_id,
+                turn_instance_id=args.turn_instance_id,
             )
-            if decision_agent and decision_agent != args.agent_id:
-                raise ValueError("quota decision agent_id does not match --agent-id")
             situation = build_agent_turn_situation(
                 quota_decision,
                 goal_id=args.goal_id,
@@ -269,7 +302,7 @@ def handle_agent_turn_recall_command(
                 workspace_ref=str(identity["workspace_ref"] or ""),
                 project_ref=str(identity["project_ref"] or ""),
                 user_ref=identity["user_ref"],
-                session_ref=args.session_ref,
+                session_ref=_resolve_session_ref(identity, args.session_ref),
             )
             receipt_path = _receipt_path(goal_repo, args.agent_id)
             previous = None if args.force_refresh else _load_receipt(receipt_path)

--- a/loopx/capabilities/agent_turn_recall/core.py
+++ b/loopx/capabilities/agent_turn_recall/core.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from ...control_plane.runtime.public_safety import public_safe_compact_text
+from ..context_providers.base import ContextProvider
+from ..reward_memory.runtime_hooks import run_reward_memory_automatic_recall_hook
+
+
+AGENT_TURN_SITUATION_SCHEMA_VERSION = "agent_turn_situation_v0"
+AGENT_TURN_RECALL_CONTEXT_SCHEMA_VERSION = "agent_turn_recall_context_v0"
+AGENT_TURN_RECALL_SCHEMA_VERSION = "agent_turn_recall_v0"
+AGENT_TURN_RECALL_SURFACE_ID = "agent_workflow.turn_admission"
+MAX_RECENT_OUTCOMES = 3
+
+
+def _compact(value: object, *, limit: int) -> str | None:
+    return public_safe_compact_text(value, limit=limit) or None
+
+
+def _mapping(value: object) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _canonical_hash(value: object) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _recent_outcomes(quota_decision: Mapping[str, Any]) -> list[str]:
+    candidates: list[object] = []
+    latest_run = _mapping(quota_decision.get("latest_run"))
+    candidates.extend(
+        [
+            latest_run.get("classification"),
+            quota_decision.get("latest_run_recommended_action"),
+        ]
+    )
+    handoff = _mapping(quota_decision.get("handoff_readiness"))
+    candidates.append(_mapping(handoff.get("post_handoff_latest_run")).get("classification"))
+    result: list[str] = []
+    for value in candidates:
+        text = _compact(value, limit=180)
+        if not text or text in result:
+            continue
+        result.append(text)
+        if len(result) >= MAX_RECENT_OUTCOMES:
+            break
+    return result
+
+
+def _selected_todo(quota_decision: Mapping[str, Any]) -> dict[str, Any]:
+    selected = _mapping(quota_decision.get("selected_todo"))
+    compact: dict[str, Any] = {}
+    for key in (
+        "todo_id",
+        "priority",
+        "task_class",
+        "action_kind",
+        "target_key",
+        "task_repository",
+        "claimed_by",
+        "next_due_at",
+        "expires_at",
+    ):
+        if selected.get(key) is not None:
+            compact[key] = selected[key]
+    text = _compact(selected.get("text"), limit=320)
+    if text:
+        compact["text"] = text
+    if not compact:
+        fallback = _compact(quota_decision.get("recommended_action"), limit=320)
+        if fallback:
+            compact["text"] = fallback
+    return compact
+
+
+def build_agent_turn_situation(
+    quota_decision: Mapping[str, Any],
+    *,
+    goal_id: str,
+    agent_id: str,
+    turn_instance_id: str,
+    workspace_ref: str,
+    project_ref: str,
+    user_ref: str | None = None,
+    session_ref: str | None = None,
+) -> dict[str, Any]:
+    """Build a bounded prompt-independent situation for one autonomous turn."""
+
+    selected = _selected_todo(quota_decision)
+    status_health_ok = quota_decision.get("status_health_ok") is True
+    conflict_state = (
+        "clear"
+        if status_health_ok
+        and not quota_decision.get("state_projection_gap")
+        and not quota_decision.get("decision_freshness_warning")
+        else "unresolved"
+    )
+    situation: dict[str, Any] = {
+        "schema_version": AGENT_TURN_SITUATION_SCHEMA_VERSION,
+        "goal_id": str(goal_id).strip(),
+        "agent_id": str(agent_id).strip(),
+        "turn_instance_id": str(turn_instance_id).strip(),
+        "workspace_ref": str(workspace_ref).strip(),
+        "project_ref": str(project_ref).strip(),
+        "phase": _compact(
+            quota_decision.get("lifecycle_phase")
+            or quota_decision.get("effective_action")
+            or quota_decision.get("state"),
+            limit=120,
+        ),
+        "decision": _compact(quota_decision.get("decision"), limit=80),
+        "selected_todo": selected,
+        "recent_outcomes": _recent_outcomes(quota_decision),
+        "next_intent": _compact(
+            quota_decision.get("recommended_action"), limit=320
+        ),
+        "conflict_state": conflict_state,
+        "status_health_ok": status_health_ok,
+        "user_prompt_included": False,
+    }
+    if user_ref:
+        situation["user_ref"] = str(user_ref).strip()
+    if session_ref:
+        situation["session_ref"] = str(session_ref).strip()
+    fingerprint_input = {
+        key: value
+        for key, value in situation.items()
+        if key not in {"turn_instance_id"}
+    }
+    situation["situation_fingerprint"] = _canonical_hash(fingerprint_input)
+    situation["turn_recall_id"] = _canonical_hash(
+        {
+            "turn_instance_id": situation["turn_instance_id"],
+            "situation_fingerprint": situation["situation_fingerprint"],
+        }
+    )
+    return situation
+
+
+def _turn_query(situation: Mapping[str, Any]) -> dict[str, str]:
+    selected = _mapping(situation.get("selected_todo"))
+    fields = [
+        f"agent={situation.get('agent_id')}",
+        f"goal={situation.get('goal_id')}",
+        f"project={situation.get('project_ref')}",
+        f"phase={situation.get('phase') or 'unknown'}",
+        f"todo={selected.get('text') or selected.get('todo_id') or 'none'}",
+    ]
+    for key in ("action_kind", "target_key"):
+        if selected.get(key):
+            fields.append(f"{key}={selected[key]}")
+    if situation.get("next_intent"):
+        fields.append(f"intent={situation['next_intent']}")
+    outcomes = situation.get("recent_outcomes")
+    if isinstance(outcomes, Sequence) and not isinstance(outcomes, (str, bytes)):
+        if outcomes:
+            fields.append("recent=" + "; ".join(map(str, outcomes)))
+    query = _compact(" | ".join(fields), limit=500) or "autonomous agent turn"
+    todo_ref = selected.get("todo_id") or selected.get("action_kind") or "unselected"
+    summary = _compact(
+        f"turn admission for {situation.get('goal_id')} {todo_ref} "
+        f"during {situation.get('phase') or 'unknown'}",
+        limit=220,
+    )
+    return {"query": query, "query_summary": summary or "agent turn admission"}
+
+
+def build_agent_turn_recall_preview(
+    situation: Mapping[str, Any],
+) -> dict[str, Any]:
+    query = _turn_query(situation)
+    return {
+        "ok": True,
+        "schema_version": AGENT_TURN_RECALL_SCHEMA_VERSION,
+        "status": "preview",
+        "surface_id": AGENT_TURN_RECALL_SURFACE_ID,
+        "turn_recall_id": situation.get("turn_recall_id"),
+        "situation_fingerprint": situation.get("situation_fingerprint"),
+        "context": {
+            "schema_version": AGENT_TURN_RECALL_CONTEXT_SCHEMA_VERSION,
+            "situation": dict(situation),
+            "guidance": [],
+        },
+        "query_evidence": {
+            "query_digest": _canonical_hash(query["query"]),
+            "query_summary": query["query_summary"],
+            "exact_query_exposed": False,
+        },
+        "provider_call_count": 0,
+        "execute_required_for_recall": True,
+        "grants_new_action_authority": False,
+        "quota_spend_performed": False,
+        "external_writes_performed": False,
+        "suppress_external_sinks": True,
+    }
+
+
+def run_agent_turn_recall(
+    config: Mapping[str, Any],
+    situation: Mapping[str, Any],
+    *,
+    observed_at: str,
+    read_authority_checkpoints: Mapping[str, Mapping[str, Any]],
+    provider: ContextProvider | None = None,
+) -> dict[str, Any]:
+    """Recall guidance and inject it into this turn's private reasoning context."""
+
+    query = _turn_query(situation)
+    context = {
+        "schema_version": AGENT_TURN_RECALL_CONTEXT_SCHEMA_VERSION,
+        "situation": dict(situation),
+        "guidance": [],
+    }
+
+    def apply_guidance(
+        base_output: Any,
+        items: tuple[Any, ...],
+    ) -> Mapping[str, Any]:
+        guidance = [
+            {
+                "candidate_ref": item.candidate_ref,
+                "target_class": item.target_class,
+                "content_summary": item.content_summary,
+            }
+            for item in items
+        ]
+        return {
+            "outcome": "applied",
+            "output": dict(base_output) | {"guidance": guidance},
+            "memory_refs": [item.memory_ref for item in items],
+            "reasoning_summary": (
+                "recalled guidance was injected into the exact private turn context; "
+                "the agent still decides applicability and receives no new authority"
+            ),
+            "current_artifact_verified": situation.get("conflict_state") == "clear",
+        }
+
+    result = run_reward_memory_automatic_recall_hook(
+        config,
+        surface_id=AGENT_TURN_RECALL_SURFACE_ID,
+        base_output=context,
+        workspace_ref=str(situation.get("workspace_ref") or ""),
+        project_ref=str(situation.get("project_ref") or ""),
+        user_ref=str(situation.get("user_ref") or "") or None,
+        peer_ref=f"agent:{situation.get('agent_id')}",
+        session_ref=str(situation.get("session_ref") or "") or None,
+        revision_ref=str(situation.get("situation_fingerprint") or ""),
+        queries=[query],
+        observed_at=observed_at,
+        freshness_context={
+            "source_truth_current": situation.get("status_health_ok") is True,
+            "source_revision": str(situation.get("situation_fingerprint") or ""),
+            "age_seconds": 0,
+        },
+        conflict_state=str(situation.get("conflict_state") or "unresolved"),
+        read_authority_checkpoints=read_authority_checkpoints,
+        application_id=(
+            "turn-recall-"
+            + str(situation.get("turn_recall_id") or "").removeprefix("sha256:")[:20]
+        ),
+        artifact_ref=str(situation.get("situation_fingerprint") or ""),
+        apply_memory=apply_guidance,
+        provider=provider,
+    )
+    telemetry = _mapping(result.get("telemetry"))
+    return {
+        "ok": result.get("ok") is True,
+        "schema_version": AGENT_TURN_RECALL_SCHEMA_VERSION,
+        "status": result.get("status"),
+        "surface_id": AGENT_TURN_RECALL_SURFACE_ID,
+        "turn_recall_id": situation.get("turn_recall_id"),
+        "situation_fingerprint": situation.get("situation_fingerprint"),
+        "context": result.get("output", context),
+        "application": result.get("application"),
+        "recall_attempts": result.get("recall_attempts", []),
+        "telemetry": telemetry,
+        "provider_call_count": int(telemetry.get("provider_call_count") or 0),
+        "fail_open": True,
+        "fail_open_preserved_base": result.get("fail_open_preserved_base"),
+        "provider_failure_is_user_gate": False,
+        "grants_new_action_authority": False,
+        "quota_spend_performed": False,
+        "external_writes_performed": False,
+        "raw_provider_payload_captured": False,
+        "suppress_external_sinks": True,
+    }

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -758,6 +758,80 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
         ),
     },
     {
+        "id": "agent-turn-recall",
+        "origin": "builtin",
+        "visibility": "public",
+        "provider_id": "loopx-core",
+        "title": "Autonomous agent turn recall",
+        "status": "active-preview",
+        "default_enabled": False,
+        "real_world_anchor": (
+            "long-running autonomous agent turns without a fresh user prompt"
+        ),
+        "user_value": (
+            "Recall temporary agent-scoped guidance from the current Goal, Todo, "
+            "phase, recent outcome, and next intent before autonomous work begins."
+        ),
+        "entry_command": (
+            "loopx agent-turn-recall --goal-id <goal-id> --agent-id <agent-id> "
+            "--turn-instance-id <id> --quota-decision-json <quota.json> "
+            "--execute --format json"
+        ),
+        "commands": [
+            {
+                "command": (
+                    "loopx agent-turn-recall --goal-id <goal-id> --agent-id "
+                    "<agent-id> --turn-instance-id <id> --quota-decision-json "
+                    "<quota.json> --format json"
+                ),
+                "purpose": "Preview the bounded situation, semantic query identity, and exact opt-in route without provider access.",
+                "write_boundary": "read-only status/quota/config projection; no provider, receipt, quota, or external write",
+            },
+            {
+                "command": (
+                    "loopx agent-turn-recall --goal-id <goal-id> --agent-id "
+                    "<agent-id> --turn-instance-id <id> --quota-decision-json "
+                    "<quota.json> --execute --format json"
+                ),
+                "purpose": "Recall exact-scope guidance and inject it into one private turn context.",
+                "write_boundary": "provider read plus one ignored local same-turn receipt; no quota spend or external sink delivery",
+            },
+        ],
+        "implemented_protocols": [
+            {
+                "schema_version": "agent_turn_situation_v0",
+                "module": "loopx.capabilities.agent_turn_recall.core",
+                "doc": "docs/capabilities/agent-turn-recall/README.md",
+            },
+            {
+                "schema_version": "agent_turn_recall_context_v0",
+                "module": "loopx.capabilities.agent_turn_recall.core",
+                "doc": "docs/capabilities/agent-turn-recall/README.md",
+            },
+            {
+                "schema_version": "agent_turn_recall_v0",
+                "module": "loopx.capabilities.agent_turn_recall.core",
+                "doc": "docs/capabilities/agent-turn-recall/README.md",
+            },
+        ],
+        "smokes": [
+            "python -m pytest tests/capabilities/test_agent_turn_recall.py -q"
+        ],
+        "docs": ["docs/capabilities/agent-turn-recall/README.md"],
+        "boundaries": [
+            "The capability is default-off and reuses reward-memory corpus, scope, freshness, authority, and provider guards.",
+            "The semantic query is built from durable turn state; a user prompt is neither required nor copied into the situation.",
+            "Provider content is injected only into the private agent context, is suppressed from external sinks, and grants no new action authority.",
+            "A matching receipt deduplicates retries inside one turn; a new turn instance recalls again even when the material situation is unchanged.",
+            "Provider, application, and receipt failures are fail-open, are not user gates, and never spend quota.",
+            "Project-specific habits, task ids, PR rules, provider URIs, and credentials stay in ignored local config or provider-owned memory.",
+        ],
+        "next_real_step": (
+            "Promote the dogfooded host hook after repeated turn-admission "
+            "readback confirms exact scope, expiry, and retry deduplication."
+        ),
+    },
+    {
         "id": "semantic-preference",
         "origin": "builtin",
         "visibility": "public",

--- a/loopx/capabilities/reward_memory/application.py
+++ b/loopx/capabilities/reward_memory/application.py
@@ -177,6 +177,10 @@ def build_active_reward_memory_record(
             json.dumps(identity, sort_keys=True).encode("utf-8")
         ).hexdigest()[:20]
     )
+    active_lifecycle: dict[str, Any] = {"state": "active"}
+    expires_at = record["lifecycle"].get("expires_at")
+    if expires_at:
+        active_lifecycle["expires_at"] = expires_at
     return {
         "schema_version": REWARD_MEMORY_ACTIVE_RECORD_SCHEMA_VERSION,
         "activation_ref": activation_ref,
@@ -195,7 +199,7 @@ def build_active_reward_memory_record(
             "guard_passed": True,
             "review_ref": reviewed_candidate["review"]["review_ref"],
         },
-        "lifecycle": {"state": "active"},
+        "lifecycle": active_lifecycle,
         "privacy": {"raw_content_captured": False},
         "provider_write_performed": False,
         "external_writes_performed": False,
@@ -472,6 +476,7 @@ def _active_item(
     corpus: Mapping[str, Any],
     *,
     surface_id: str,
+    observed_at: str,
 ) -> RewardMemoryRecallItem | None:
     try:
         envelope = json.loads(item.content)
@@ -492,6 +497,15 @@ def _active_item(
         or lifecycle.get("state") != "active"
     ):
         return None
+    expires_at = lifecycle.get("expires_at")
+    if expires_at:
+        try:
+            expires = datetime.fromisoformat(str(expires_at).replace("Z", "+00:00"))
+            observed = datetime.fromisoformat(observed_at.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        if expires.tzinfo is None or observed.tzinfo is None or observed >= expires:
+            return None
     return RewardMemoryRecallItem(
         memory_ref=item.resource_ref,
         candidate_ref=_token(envelope.get("candidate_ref"), "candidate_ref"),
@@ -597,6 +611,7 @@ def execute_reward_memory_recall(
                 provider_item,
                 corpus,
                 surface_id=request["surface_id"],
+                observed_at=request["observed_at"],
             )
             if active is None:
                 continue

--- a/loopx/capabilities/reward_memory/candidate_review.py
+++ b/loopx/capabilities/reward_memory/candidate_review.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import re
 from collections.abc import Mapping, Sequence
+from datetime import datetime
 from typing import Any
 
 from ...control_plane.runtime.public_safety import public_safe_compact_text
@@ -60,6 +61,19 @@ def _boolean(mapping: Mapping[str, Any], key: str) -> bool:
     if not isinstance(value, bool):
         raise ValueError(f"{key} must be a boolean")
     return value
+
+
+def _optional_timestamp(value: object, label: str) -> str | None:
+    if value in (None, ""):
+        return None
+    result = str(value).strip()
+    try:
+        parsed = datetime.fromisoformat(result.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{label} must be an ISO timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{label} must include a timezone")
+    return result
 
 
 def _tokens(value: object, label: str, *, maximum: int) -> list[str]:
@@ -247,6 +261,10 @@ def build_reward_memory_candidate(
     target_class = str(proposal.get("target_class") or "").strip()
     if target_class not in TARGET_CLASS_IDS:
         raise ValueError("target_class must be a durable reusable memory class")
+    lifecycle: dict[str, Any] = {"state": "candidate", "supersedes_refs": []}
+    expires_at = _optional_timestamp(proposal.get("expires_at"), "expires_at")
+    if expires_at:
+        lifecycle["expires_at"] = expires_at
     candidate: dict[str, Any] = {
         "schema_version": REWARD_MEMORY_CANDIDATE_SCHEMA_VERSION,
         "target_class": target_class,
@@ -262,7 +280,7 @@ def build_reward_memory_candidate(
             "requested_action_scopes",
             maximum=MAX_ACTION_SCOPES,
         ),
-        "lifecycle": {"state": "candidate", "supersedes_refs": []},
+        "lifecycle": lifecycle,
         "privacy": {"raw_content_captured": False},
     }
     candidate["candidate_ref"] = _candidate_ref(candidate)
@@ -321,6 +339,9 @@ def review_reward_memory_candidate(
         if isinstance(lifecycle, Mapping)
         else []
     )
+    expires_at = (
+        lifecycle.get("expires_at") if isinstance(lifecycle, Mapping) else None
+    )
     if decision == "retire" and state != "active":
         raise ValueError("retire requires an active reviewed record")
     if decision != "retire" and state != "candidate":
@@ -336,6 +357,8 @@ def review_reward_memory_candidate(
             "state": "active",
             "supersedes_refs": supersedes_refs,
         }
+        if expires_at:
+            record["lifecycle"]["expires_at"] = expires_at
         status = "active"
     elif decision == "edit":
         old_ref = str(record.get("candidate_ref") or "")
@@ -349,6 +372,8 @@ def review_reward_memory_candidate(
             "state": "candidate",
             "supersedes_refs": [old_ref],
         }
+        if expires_at:
+            record["lifecycle"]["expires_at"] = expires_at
         status = "review_ready"
     elif decision == "reject":
         record["lifecycle"] = {

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -10,6 +10,10 @@ from .capabilities.content_ops.cli import (
     handle_content_ops_command,
     register_content_ops_commands,
 )
+from .capabilities.agent_turn_recall.cli import (
+    handle_agent_turn_recall_command,
+    register_agent_turn_recall_commands,
+)
 from .capabilities.change_quality.cli import (
     handle_change_quality_command,
     register_change_quality_commands,
@@ -233,6 +237,8 @@ def build_parser() -> LoopXArgumentParser:
     register_issue_fix_commands(sub, add_subcommand_format)
 
     register_reward_memory_commands(sub, add_subcommand_format)
+
+    register_agent_turn_recall_commands(sub, add_subcommand_format)
 
     register_review_batch_commands(sub, add_subcommand_format)
 
@@ -514,6 +520,15 @@ def main(argv: list[str] | None = None) -> int:
     )
     if reward_memory_result is not None:
         return reward_memory_result
+
+    agent_turn_recall_result = handle_agent_turn_recall_command(
+        args,
+        registry_path=registry_path,
+        output_format=output_format,
+        print_payload=print_payload,
+    )
+    if agent_turn_recall_result is not None:
+        return agent_turn_recall_result
 
     decision_context_result = handle_decision_context_command(
         args,

--- a/tests/capabilities/test_agent_turn_recall.py
+++ b/tests/capabilities/test_agent_turn_recall.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from loopx.capabilities.agent_turn_recall.core import (
+    build_agent_turn_recall_preview,
+    build_agent_turn_situation,
+    run_agent_turn_recall,
+)
+from loopx.capabilities.context_providers.base import (
+    ContextProviderItem,
+    ContextProviderRetrieval,
+)
+from loopx.capabilities.reward_memory.experiment import (
+    load_reward_memory_experiment_config,
+    resolve_reward_memory_surface_config,
+)
+
+
+SURFACE = "agent_workflow.turn_admission"
+SCOPE_REF = "viking://user/example/memories/preferences"
+
+
+class RecallProvider:
+    provider_id = "openviking"
+
+    def __init__(self, content: str | None = None, *, unavailable: bool = False) -> None:
+        self.content = content
+        self.unavailable = unavailable
+        self.calls = 0
+        self.queries: list[str] = []
+
+    def retrieve(self, **kwargs: Any) -> ContextProviderRetrieval:
+        self.calls += 1
+        self.queries.append(str(kwargs["query"]))
+        if self.unavailable:
+            raise RuntimeError("provider unavailable")
+        items = (
+            (
+                ContextProviderItem(
+                    resource_ref=f"{SCOPE_REF}/turn-habit.json",
+                    summary="Scoped turn guidance.",
+                    content=self.content,
+                    score=0.97,
+                ),
+            )
+            if self.content
+            else ()
+        )
+        return ContextProviderRetrieval(
+            provider=self.provider_id,
+            namespace=str(kwargs["namespace"]),
+            status="completed",
+            query_summary=str(kwargs["query_summary"]),
+            observed_at=str(kwargs["observed_at"]),
+            search_performed=True,
+            read_performed=bool(items),
+            items=items,
+            requested_limit=int(kwargs["max_results"]),
+        )
+
+
+def quota_decision(*, phase: str = "reviewing", target_key: str = "pr:123") -> dict[str, Any]:
+    return {
+        "ok": True,
+        "status_health_ok": True,
+        "decision": "run",
+        "lifecycle_phase": phase,
+        "recommended_action": "Review, refine, validate, and close the selected work.",
+        "latest_run_recommended_action": "Inspect the exact diff before changing it.",
+        "selected_todo": {
+            "todo_id": "todo_123",
+            "text": "Review and refine the selected pull request.",
+            "action_kind": "review_refine_merge",
+            "target_key": target_key,
+            "claimed_by": "pilot",
+        },
+    }
+
+
+def situation(
+    *,
+    phase: str = "reviewing",
+    target_key: str = "pr:123",
+    turn: str = "2026-08-02T10:00:00+00:00",
+    agent_id: str = "pilot",
+) -> dict[str, Any]:
+    return build_agent_turn_situation(
+        quota_decision(phase=phase, target_key=target_key),
+        goal_id="goal",
+        agent_id=agent_id,
+        turn_instance_id=turn,
+        workspace_ref="workspace:example",
+        project_ref="github:example/repo",
+        user_ref="user:example",
+    )
+
+
+def raw_config(*, peer_ref: str = "agent:pilot") -> dict[str, Any]:
+    scope = {
+        "workspace_ref": "workspace:example",
+        "project_ref": "github:example/repo",
+        "user_ref": "user:example",
+        "peer_ref": peer_ref,
+        "surface_ids": [SURFACE],
+    }
+    corpus = {
+        "corpus_id": "agent_turn_preferences",
+        "class_id": "soft_preference",
+        "provider_id": "openviking",
+        "owner_ref": "example_owner",
+        "source_of_truth": "reviewed_scoped_feedback",
+        "read_authority": "actor_scoped",
+        "write_authority": "provider_managed",
+        "scope": scope,
+        "freshness": {"mode": "source_truth_bound"},
+        "lifecycle": {"state": "active", "supersedes": []},
+        "retrieval": {
+            "index_required": True,
+            "readback_required": True,
+            "application_receipt_required": True,
+        },
+        "maintenance": {
+            "writeback_triggers": ["reviewed_scoped_feedback"],
+            "closure_policy": "write_exact_readback_then_recall",
+            "retirement_authority": "example_owner",
+        },
+        "privacy": {"visibility": "private", "raw_content_in_registry": False},
+        "provider_scope_ref_digest": hashlib.sha256(
+            SCOPE_REF.encode("utf-8")
+        ).hexdigest()[:16],
+    }
+    policy = {
+        "schema_version": "reward_memory_standing_policy_v0",
+        "policy_id": "policy:example:agent-turn",
+        "enabled": True,
+        "auto_activate": True,
+        "owner_ref": "example_owner",
+        "reviewer_ref": "agent:example-reviewer",
+        "authority_source_ref": "policy:example:agent-turn",
+        "scope": scope,
+        "allowed_target_classes": ["soft_preference"],
+        "allowed_source_kinds": ["explicit_user_instruction"],
+        "allowed_actor_roles": ["verified_project_owner_or_operator"],
+        "allowed_action_scopes": ["agent_turn:guidance"],
+        "raw_content_captured": False,
+    }
+    return {
+        "schema_version": "reward_memory_experiment_config_v1",
+        "project_provider_binding": {
+            "provider_id": "openviking",
+            "namespace": "reward_memory",
+            "timeout_seconds": 30,
+            "minimum_provider_version": "0.4.9",
+            "corpus_scopes": [
+                {"corpus_id": corpus["corpus_id"], "scope_ref": SCOPE_REF}
+            ],
+        },
+        "corpora": [{"corpus": corpus, "standing_policy": policy}],
+        "surfaces": [
+            {
+                "surface_id": SURFACE,
+                "adapter": "scoped_feedback",
+                "corpus_ids": [corpus["corpus_id"]],
+                "ingest_corpus_id": corpus["corpus_id"],
+                "recall_profile": {
+                    "profile_id": "agent_turn_v1",
+                    "mode": "bounded_agentic_search",
+                    "max_queries": 1,
+                    "limit": 4,
+                },
+            }
+        ],
+        "automation": {
+            "automatic_recall": True,
+            "automatic_ingest": False,
+            "fail_open": True,
+        },
+    }
+
+
+def normalized_config(tmp_path: Path, *, peer_ref: str = "agent:pilot") -> dict[str, Any]:
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps(raw_config(peer_ref=peer_ref)), encoding="utf-8")
+    return load_reward_memory_experiment_config(
+        project=tmp_path,
+        config_path="config.json",
+    )
+
+
+def active_record(config: dict[str, Any], *, expires_at: str) -> str:
+    corpus = resolve_reward_memory_surface_config(config, SURFACE)["corpus"]
+    return json.dumps(
+        {
+            "schema_version": "reward_memory_active_record_v0",
+            "corpus_id": corpus["corpus_id"],
+            "candidate_ref": "candidate:turn-habit",
+            "target_class": corpus["class_id"],
+            "content_summary": (
+                "After merging an origin-task change, report the refinements and "
+                "ask that task to update its integration branch from main."
+            ),
+            "scope": corpus["scope"],
+            "lifecycle": {"state": "active", "expires_at": expires_at},
+        }
+    )
+
+
+def checkpoints(config: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    route = resolve_reward_memory_surface_config(config, SURFACE)
+    return {
+        item["corpus"]["corpus_id"]: {
+            "verified": True,
+            "corpus_id": item["corpus"]["corpus_id"],
+            "workspace_ref": item["corpus"]["scope"]["workspace_ref"],
+            "project_ref": item["corpus"]["scope"]["project_ref"],
+            "user_ref": item["corpus"]["scope"]["user_ref"],
+            "peer_ref": item["corpus"]["scope"]["peer_ref"],
+            "surface_id": SURFACE,
+            "read_authority": item["corpus"]["read_authority"],
+            "source_ref": "registry:goal:reward-memory",
+        }
+        for item in route["recall_corpora"]
+    }
+
+
+def test_situation_is_prompt_independent_and_fingerprints_material_changes() -> None:
+    first = situation(turn="2026-08-02T10:00:00+00:00")
+    retry = situation(turn="2026-08-02T10:00:00+00:00")
+    next_turn = situation(turn="2026-08-02T10:03:00+00:00")
+    phase_change = situation(phase="merged")
+    target_change = situation(target_key="pr:124")
+
+    assert first["user_prompt_included"] is False
+    assert first["situation_fingerprint"] == retry["situation_fingerprint"]
+    assert first["turn_recall_id"] == retry["turn_recall_id"]
+    assert first["situation_fingerprint"] == next_turn["situation_fingerprint"]
+    assert first["turn_recall_id"] != next_turn["turn_recall_id"]
+    assert first["situation_fingerprint"] != phase_change["situation_fingerprint"]
+    assert first["situation_fingerprint"] != target_change["situation_fingerprint"]
+    preview = build_agent_turn_recall_preview(first)
+    assert preview["query_evidence"]["exact_query_exposed"] is False
+    assert preview["provider_call_count"] == 0
+
+
+def test_recall_injects_private_guidance_without_granting_authority(tmp_path: Path) -> None:
+    config = normalized_config(tmp_path)
+    provider = RecallProvider(
+        active_record(config, expires_at="2026-08-03T00:00:00+00:00")
+    )
+
+    result = run_agent_turn_recall(
+        config,
+        situation(),
+        observed_at="2026-08-02T10:00:00+00:00",
+        read_authority_checkpoints=checkpoints(config),
+        provider=provider,
+    )
+
+    assert result["status"] == "applied"
+    assert result["provider_call_count"] == 1
+    assert len(result["context"]["guidance"]) == 1
+    assert "integration branch" in result["context"]["guidance"][0]["content_summary"]
+    assert result["grants_new_action_authority"] is False
+    assert result["quota_spend_performed"] is False
+    assert result["suppress_external_sinks"] is True
+    assert "Review and refine" in provider.queries[0]
+
+
+def test_wrong_peer_blocks_before_provider_call(tmp_path: Path) -> None:
+    config = normalized_config(tmp_path, peer_ref="agent:other")
+    provider = RecallProvider()
+
+    result = run_agent_turn_recall(
+        config,
+        situation(),
+        observed_at="2026-08-02T10:00:00+00:00",
+        read_authority_checkpoints=checkpoints(config),
+        provider=provider,
+    )
+
+    assert result["status"] == "not_available"
+    assert provider.calls == 0
+    assert result["recall_attempts"][0]["status"] == "guard_blocked"
+    assert "peer_ref_scope_mismatch" in result["recall_attempts"][0]["reason_codes"]
+
+
+def test_expired_memory_is_not_injected(tmp_path: Path) -> None:
+    config = normalized_config(tmp_path)
+    provider = RecallProvider(
+        active_record(config, expires_at="2026-08-02T09:59:59+00:00")
+    )
+
+    result = run_agent_turn_recall(
+        config,
+        situation(),
+        observed_at="2026-08-02T10:00:00+00:00",
+        read_authority_checkpoints=checkpoints(config),
+        provider=provider,
+    )
+
+    assert result["status"] == "not_available"
+    assert result["context"]["guidance"] == []
+    assert provider.calls == 1
+
+
+def test_provider_failure_fails_open_without_user_gate(tmp_path: Path) -> None:
+    config = normalized_config(tmp_path)
+    provider = RecallProvider(unavailable=True)
+
+    result = run_agent_turn_recall(
+        config,
+        situation(),
+        observed_at="2026-08-02T10:00:00+00:00",
+        read_authority_checkpoints=checkpoints(config),
+        provider=provider,
+    )
+
+    assert result["status"] == "provider_unavailable"
+    assert result["context"]["guidance"] == []
+    assert result["provider_failure_is_user_gate"] is False
+    assert result["grants_new_action_authority"] is False

--- a/tests/capabilities/test_agent_turn_recall.py
+++ b/tests/capabilities/test_agent_turn_recall.py
@@ -5,10 +5,26 @@ import json
 from pathlib import Path
 from typing import Any
 
+import pytest
+
+from loopx.capabilities.agent_turn_recall.cli import (
+    _deduplicated_payload,
+    _load_receipt,
+    _resolve_session_ref,
+    _validate_quota_identity,
+    _write_receipt,
+)
 from loopx.capabilities.agent_turn_recall.core import (
     build_agent_turn_recall_preview,
     build_agent_turn_situation,
     run_agent_turn_recall,
+)
+from loopx.capabilities.reward_memory.application import (
+    build_active_reward_memory_record,
+)
+from loopx.capabilities.reward_memory.candidate_review import (
+    build_reward_memory_candidate,
+    review_reward_memory_candidate,
 )
 from loopx.capabilities.context_providers.base import (
     ContextProviderItem,
@@ -27,7 +43,9 @@ SCOPE_REF = "viking://user/example/memories/preferences"
 class RecallProvider:
     provider_id = "openviking"
 
-    def __init__(self, content: str | None = None, *, unavailable: bool = False) -> None:
+    def __init__(
+        self, content: str | None = None, *, unavailable: bool = False
+    ) -> None:
         self.content = content
         self.unavailable = unavailable
         self.calls = 0
@@ -63,7 +81,9 @@ class RecallProvider:
         )
 
 
-def quota_decision(*, phase: str = "reviewing", target_key: str = "pr:123") -> dict[str, Any]:
+def quota_decision(
+    *, phase: str = "reviewing", target_key: str = "pr:123"
+) -> dict[str, Any]:
     return {
         "ok": True,
         "status_health_ok": True,
@@ -182,7 +202,9 @@ def raw_config(*, peer_ref: str = "agent:pilot") -> dict[str, Any]:
     }
 
 
-def normalized_config(tmp_path: Path, *, peer_ref: str = "agent:pilot") -> dict[str, Any]:
+def normalized_config(
+    tmp_path: Path, *, peer_ref: str = "agent:pilot"
+) -> dict[str, Any]:
     path = tmp_path / "config.json"
     path.write_text(json.dumps(raw_config(peer_ref=peer_ref)), encoding="utf-8")
     return load_reward_memory_experiment_config(
@@ -246,7 +268,9 @@ def test_situation_is_prompt_independent_and_fingerprints_material_changes() -> 
     assert preview["provider_call_count"] == 0
 
 
-def test_recall_injects_private_guidance_without_granting_authority(tmp_path: Path) -> None:
+def test_recall_injects_private_guidance_without_granting_authority(
+    tmp_path: Path,
+) -> None:
     config = normalized_config(tmp_path)
     provider = RecallProvider(
         active_record(config, expires_at="2026-08-03T00:00:00+00:00")
@@ -323,3 +347,128 @@ def test_provider_failure_fails_open_without_user_gate(tmp_path: Path) -> None:
     assert result["context"]["guidance"] == []
     assert result["provider_failure_is_user_gate"] is False
     assert result["grants_new_action_authority"] is False
+
+
+def test_quota_identity_requires_exact_agent_and_turn_receipt() -> None:
+    turn = "2026-08-02T10:00:00+00:00"
+    decision = quota_decision() | {
+        "goal_id": "goal",
+        "agent_identity": {"agent_id": "pilot"},
+        "heartbeat_receipt": {
+            "turn_instance_id": turn,
+            "status": "committed",
+        },
+    }
+
+    _validate_quota_identity(
+        decision,
+        goal_id="goal",
+        agent_id="pilot",
+        turn_instance_id=turn,
+    )
+    with pytest.raises(ValueError, match="agent_id"):
+        _validate_quota_identity(
+            decision,
+            goal_id="goal",
+            agent_id="other",
+            turn_instance_id=turn,
+        )
+    with pytest.raises(ValueError, match="turn_instance_id"):
+        _validate_quota_identity(
+            decision,
+            goal_id="goal",
+            agent_id="pilot",
+            turn_instance_id="2026-08-02T10:01:00+00:00",
+        )
+    with pytest.raises(ValueError, match="not committed"):
+        _validate_quota_identity(
+            decision
+            | {
+                "heartbeat_receipt": {
+                    "turn_instance_id": turn,
+                    "status": "write_failed",
+                }
+            },
+            goal_id="goal",
+            agent_id="pilot",
+            turn_instance_id=turn,
+        )
+
+
+def test_configured_session_scope_is_canonical() -> None:
+    identity = {"session_ref": "session:configured"}
+
+    assert _resolve_session_ref(identity, None) == "session:configured"
+    assert _resolve_session_ref(identity, "session:configured") == "session:configured"
+    with pytest.raises(ValueError, match="configured corpus scope"):
+        _resolve_session_ref(identity, "session:other")
+
+
+def test_same_turn_receipt_round_trip_reuses_private_context(tmp_path: Path) -> None:
+    receipt_path = tmp_path / "pilot.json"
+    receipt = {
+        "schema_version": "agent_turn_recall_receipt_v0",
+        "turn_recall_id": "sha256:turn",
+        "situation_fingerprint": "sha256:situation",
+        "source_status": "applied",
+        "context": {
+            "schema_version": "agent_turn_recall_context_v0",
+            "guidance": [{"content_summary": "Use the scoped workflow."}],
+        },
+    }
+
+    _write_receipt(receipt_path, receipt)
+    loaded = _load_receipt(receipt_path)
+    assert loaded == receipt
+    deduplicated = _deduplicated_payload(loaded or {}, goal_id="goal", agent_id="pilot")
+    assert deduplicated is not None
+    assert deduplicated["status"] == "deduplicated"
+    assert deduplicated["provider_call_count"] == 0
+    assert deduplicated["same_turn_receipt_reused"] is True
+
+
+def test_expiry_survives_candidate_review_and_activation(tmp_path: Path) -> None:
+    config = normalized_config(tmp_path)
+    corpus = resolve_reward_memory_surface_config(config, SURFACE)["corpus"]
+    expires_at = "2026-08-03T00:00:00+00:00"
+    candidate = build_reward_memory_candidate(
+        {
+            "target_class": "soft_preference",
+            "content_summary": "Use the scoped workflow for this temporary task.",
+            "expires_at": expires_at,
+            "source": {
+                "source_kind": "explicit_user_instruction",
+                "source_ref": "user:instruction",
+                "actor_ref": "user:example",
+                "actor_role": "verified_project_owner_or_operator",
+            },
+            "scope": corpus["scope"],
+            "reasoning": {
+                "summary": "Explicit temporary preference.",
+                "confidence": "high",
+            },
+            "guard_context": {
+                "source_freshness": "current",
+                "conflict_state": "clear",
+                "current_artifact_verified": True,
+            },
+            "requested_action_scopes": [],
+            "raw_content_captured": False,
+        }
+    )
+    reviewed = review_reward_memory_candidate(
+        candidate,
+        {
+            "decision": "accept",
+            "reviewer_ref": "agent:reviewer",
+            "review_ref": "review:temporary-preference",
+            "reasoning_summary": "The preference is explicit and bounded.",
+        },
+    )
+    active = build_active_reward_memory_record(
+        reviewed,
+        corpus,
+        activated_at="2026-08-02T10:00:00+00:00",
+    )
+
+    assert active["lifecycle"] == {"state": "active", "expires_at": expires_at}

--- a/tests/capabilities/test_capability_extension_registry.py
+++ b/tests/capabilities/test_capability_extension_registry.py
@@ -29,6 +29,7 @@ BUILTIN_IDS = [
     "decision-context",
     "project-skill-delivery",
     "material-lifecycle",
+    "agent-turn-recall",
     "semantic-preference",
     "reward-memory",
     "periodic-report",


### PR DESCRIPTION
## Summary

- add an opt-in `agent-turn-recall` capability that derives a bounded situation envelope from the exact quota-selected Todo and recalls scoped guidance without depending on a user prompt
- reuse Reward Memory provider routing and add `expires_at` lifecycle filtering instead of introducing another memory store
- bind execution to the exact goal, agent, committed heartbeat turn, and configured identity scope; deduplicate retries with an ignored same-turn receipt
- preserve fail-open behavior with explicit no-authority, no-quota-spend, and no-external-delivery semantics
- document the host integration contract and register the built-in default-off capability

## Validation

- 67 focused capability, Reward Memory, catalog, architecture-boundary, and maintainability tests passed; 9 directly cover Agent Turn Recall
- Ruff passed on the changed runtime and tests
- isolated mypy passed for the Agent Turn Recall CLI and core
- `loopx check` passed on all 10 changed paths with 0 errors and 0 warnings
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` passed with no failures or manual holds; self-merge is allowed
- exact change-quality receipt `cqr_eb9ecab03fc853c31a43` is valid for fingerprint `eb9ecab03fc853c31a43ae6a440564428179d59ad88eb555b26cc75586b10a77`

## Scope notes

A proposed live-model qualification layer was removed during self-review because it did not prove this deterministic recall contract and introduced unrelated coupling. Final coverage is deterministic. A non-required full-suite run reached 672 passing tests before an unrelated existing monitor-poll child stopped making progress; focused, architecture, risk-selected, and CI gates own this final scope.

No private memories, provider credentials, local configuration, receipts, or dogfood payloads are included.
