### PR TITLE
test(replan): keep bounded monitor fixture unexpired

### DIFF
--- a/examples/autonomous-replan-obligation-smoke.py
+++ b/examples/autonomous-replan-obligation-smoke.py
@@ -651,7 +651,7 @@ def assert_watch_replan_ack_requires_bounded_state_evidence() -> None:
         state_path.write_text(
             state_path.read_text(encoding="utf-8").replace(
                 "next_due_at=2026-08-01T13:00:00Z",
-                "next_due_at=2026-08-01T13:00:00Z expires_at=2026-08-02T13:00:00Z",
+                "next_due_at=2026-08-01T13:00:00Z expires_at=2099-08-02T13:00:00Z",
             ),
             encoding="utf-8",
         )


### PR DESCRIPTION
## Problem

The autonomous replan smoke used a bounded monitor expiry fixed at 2026-08-02T13:00:00Z. Once wall clock time passed that instant, the positive fixture became an expired monitor and the main-branch premerge gate failed deterministically.

## Change

Move only the positive fixture expiry to a stable far-future instant. The negative fixture still omits expiry and continues to prove fail-closed behavior.

## Validation

- autonomous-replan-obligation smoke passed
- premerge canary passed all 5 selected checks and allowed self-merge
- git diff check passed

The file has pre-existing repository Ruff findings around executable mode and import layout; this one-line fixture correction does not touch them.