### PR TITLE
feat(content-ops): add provider-neutral item lifecycle

### DIFF
--- a/docs/capabilities/content-ops/README.md
+++ b/docs/capabilities/content-ops/README.md
@@ -8,6 +8,12 @@ Current implementation remains preview-level. It is useful because it gives real
 connector and review surfaces a safe packet format before raw material is copied
 or published.
 
+The capability also ships a provider-neutral item lifecycle for real local
+operations queues. It preserves stable item identity, revision-bound approval,
+delivery receipts, exact readback, and supersession without copying draft bodies
+or provider credentials into LoopX state. See
+[`content_ops_item_v0`](../../reference/protocols/content-ops-item-lifecycle-v0.md).
+
 ## Implemented Surface
 
 | Layer | Current path |
@@ -24,6 +30,9 @@ or published.
 - Raw chats, transcripts, credentials, logs, and local paths are not copied into
   public packets.
 - Publishing remains blocked until an explicit user decision.
+- Revising approved content invalidates the approval and any delivery intent.
+- Provider delivery and readback receipts must match the approved revision and
+  digest; the lifecycle helper performs no external write.
 
 ## Connector-First Ops Pattern
 

--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -72,6 +72,7 @@ scanning a chronological list.
 - [`issue_fix_acceptance_loop_v0`](issue-fix-acceptance-loop-v0.md): Issue-fix acceptance loop v0
 - [`value_connector_plan_v0`](value-connector-plan-v0.md): Value connector plan v0
 - [`x_public_channel_ops_v0`](x-public-channel-ops-v0.md): X public channel operations v0
+- [`content_ops_item_v0`](content-ops-item-lifecycle-v0.md): provider-neutral content item lifecycle v0
 
 ## Quality, Review, And Release
 

--- a/docs/reference/protocols/content-ops-item-lifecycle-v0.md
+++ b/docs/reference/protocols/content-ops-item-lifecycle-v0.md
@@ -1,0 +1,98 @@
+# content_ops_item_v0
+
+Status: provider-neutral content-item lifecycle contract v0.
+
+`content_ops_item_v0` gives the existing `content_ops` capability one stable
+identity and transition contract for articles, posts, replies, reposts, and
+profile updates. It is the state layer behind a managed operations queue. It is
+not a publisher and does not store draft bodies.
+
+## Item Boundary
+
+An item stores:
+
+- stable `item_id`, `item_kind`, and channel;
+- a positive revision plus exact `sha256:` content digest;
+- opaque `content_ref` and source refs owned by local/provider storage;
+- approval, delivery-intent, delivery, and readback receipts;
+- supersession lineage and the last applied event digest.
+
+The public record never stores post/article bodies, credentials, browser
+profiles, login state, media payloads, raw timelines, or private source maps.
+Unknown fields fail validation so an adapter cannot silently add them.
+
+## Lifecycle
+
+```text
+captured -> draft -> review_ready -> approved -> delivery_ready
+    |          |          |             |             |
+    +----------+----------+-------------+-------> published -> readback_verified
+                         \-> skipped
+                         \-> superseded
+```
+
+`delivery_ready` is optional. A provider may write a delivery receipt directly
+from `approved` when no scheduling intent is needed.
+
+Supported events are:
+
+- `revise`: increments the revision and clears approval/effect state;
+- `submit_review`;
+- `approve`: binds an owner-authorized approval ref to one revision, digest,
+  effect kind, optional account, and optional time window;
+- `set_delivery_intent`: selects a provider without performing an effect;
+- `record_delivery`: records a provider effect that already happened;
+- `verify_readback`: proves exact URL and digest readback;
+- `revoke_approval`, `skip`, and `supersede`.
+
+Every event supplies `expected_state` and `expected_revision`. The transition
+fails closed on stale state, stale revision, digest mismatch, provider/account
+mismatch, expired approval, or changed reuse of an event id. An exact retry of
+the latest event returns `already_applied`.
+
+## Authority
+
+The lifecycle validates that approval, intent, delivery, and readback refer to
+the same item revision. It does not create approval authority. The caller must
+resolve `approval_ref` from an authorized LoopX decision or provider-owned
+receipt before persisting an `approve` event.
+
+Likewise, `record_delivery` does not call a provider. X through Ego Lite, a
+document publisher, or another extension performs the external effect under
+its own authority and writes back a compact receipt. Every CLI packet reports
+`external_writes_performed=false`.
+
+## CLI
+
+Create a compact item:
+
+```bash
+loopx content-ops item-create \
+  --item-id launch-post-v1 \
+  --item-kind post \
+  --channel x \
+  --content-digest sha256:<digest> \
+  --content-ref draft:launch-post-v1 \
+  --created-at 2026-08-03T09:00:00+08:00 \
+  --format json
+```
+
+Apply one event from caller-owned JSON:
+
+```bash
+loopx content-ops item-transition \
+  --item-json item.json \
+  --event-json event.json \
+  --format json
+```
+
+The command returns the updated item, a read-only projection, and
+`content_ops_item_transition_receipt_v0`. Persistence remains caller-owned so
+private queues can stay ignored and provider-specific.
+
+## Relationship To X
+
+[`x_public_channel_ops_v0`](x-public-channel-ops-v0.md) remains the X-specific
+source, draft, approval, and result protocol. Its records may be projected into
+this generic lifecycle, while account calendars, exact drafts, and Ego Lite
+session state remain local.

--- a/loopx/capabilities/content_ops/cli.py
+++ b/loopx/capabilities/content_ops/cli.py
@@ -7,6 +7,15 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from ..issue_fix.content_ops_cli import (
+    handle_content_ops_issue_fix_command,
+    register_content_ops_issue_fix_commands,
+)
+from .item_lifecycle import (
+    apply_content_ops_item_event,
+    build_content_ops_item_packet,
+    render_content_ops_item_packet_markdown,
+)
 from .surface import (
     build_content_ops_chatview_report_packet,
     build_content_ops_exploration_plan_packet,
@@ -23,11 +32,6 @@ from .surface import (
     render_content_ops_public_handle_observation_markdown,
     render_content_ops_walkthrough_artifact_markdown,
 )
-from ..issue_fix.content_ops_cli import (
-    handle_content_ops_issue_fix_command,
-    register_content_ops_issue_fix_commands,
-)
-
 
 PrintPayload = Callable[
     [dict[str, object], str, Callable[[dict[str, object]], str]],
@@ -350,6 +354,40 @@ def register_content_ops_commands(
         default="2026-06-23T00:00:00Z",
         help="Public-safe generated_at timestamp for the walkthrough artifact.",
     )
+    item_create_parser = content_ops_sub.add_parser(
+        "item-create",
+        help="Create one provider-neutral content_ops_item_v0 without draft bodies.",
+    )
+    add_subcommand_format(item_create_parser)
+    item_create_parser.add_argument("--item-id", required=True)
+    item_create_parser.add_argument(
+        "--item-kind",
+        required=True,
+        choices=("article", "post", "profile_update", "reply", "repost"),
+    )
+    item_create_parser.add_argument("--channel", required=True)
+    item_create_parser.add_argument("--content-digest", required=True)
+    item_create_parser.add_argument("--content-ref", required=True)
+    item_create_parser.add_argument("--source-ref", action="append", default=[])
+    item_create_parser.add_argument("--created-at", required=True)
+    item_transition_parser = content_ops_sub.add_parser(
+        "item-transition",
+        help=(
+            "Apply one provider-neutral content item event and emit the updated "
+            "item plus a compact transition receipt."
+        ),
+    )
+    add_subcommand_format(item_transition_parser)
+    item_transition_parser.add_argument(
+        "--item-json",
+        required=True,
+        help="Path to content_ops_item_v0 JSON, or '-' for stdin.",
+    )
+    item_transition_parser.add_argument(
+        "--event-json",
+        required=True,
+        help="Path to a content item event JSON object.",
+    )
 
 
 def handle_content_ops_command(
@@ -434,13 +472,30 @@ def handle_content_ops_command(
                 generated_at=args.generated_at,
             )
             renderer = render_content_ops_walkthrough_artifact_markdown
+        elif args.content_ops_command == "item-create":
+            payload = build_content_ops_item_packet(
+                item_id=args.item_id,
+                item_kind=args.item_kind,
+                channel=args.channel,
+                content_digest=args.content_digest,
+                content_ref=args.content_ref,
+                source_refs=args.source_ref,
+                created_at=args.created_at,
+            )
+            renderer = render_content_ops_item_packet_markdown
+        elif args.content_ops_command == "item-transition":
+            payload = apply_content_ops_item_event(
+                _load_json_object(args.item_json),
+                _load_json_object(args.event_json),
+            )
+            renderer = render_content_ops_item_packet_markdown
         else:
             raise ValueError(
                 "content-ops requires `preview`, `exploration-plan`, "
                 "`issue-fix-intake`, `issue-fix-metadata-preview`, "
                 "`observe-public-handle`, `project-private-connector-gate`, "
                 "`aggregate-packets`, `project-chatview-report`, or "
-                "`walkthrough-artifact`"
+                "`walkthrough-artifact`, `item-create`, or `item-transition`"
             )
     except Exception as exc:
         payload = {

--- a/loopx/capabilities/content_ops/item_lifecycle.py
+++ b/loopx/capabilities/content_ops/item_lifecycle.py
@@ -1,0 +1,843 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+from .schemas import (
+    CONTENT_OPS_ITEM_PACKET_SCHEMA_VERSION,
+    CONTENT_OPS_ITEM_PROJECTION_SCHEMA_VERSION,
+    CONTENT_OPS_ITEM_SCHEMA_VERSION,
+    CONTENT_OPS_ITEM_TRANSITION_PACKET_SCHEMA_VERSION,
+    CONTENT_OPS_ITEM_TRANSITION_RECEIPT_SCHEMA_VERSION,
+)
+
+ALLOWED_ITEM_KINDS = {"article", "post", "profile_update", "reply", "repost"}
+ALLOWED_ITEM_STATES = {
+    "captured",
+    "draft",
+    "review_ready",
+    "approved",
+    "delivery_ready",
+    "published",
+    "readback_verified",
+    "skipped",
+    "superseded",
+}
+ALLOWED_EFFECT_KINDS = {"profile_update", "publish", "reply", "repost"}
+TERMINAL_STATES = {"readback_verified", "skipped", "superseded"}
+
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_ITEM_KEYS = {
+    "schema_version",
+    "item_id",
+    "item_kind",
+    "channel",
+    "state",
+    "revision",
+    "content_digest",
+    "content_ref",
+    "source_refs",
+    "approval",
+    "delivery_intent",
+    "delivery_receipt",
+    "readback_receipt",
+    "superseded_by",
+    "terminal_reason",
+    "last_event",
+    "created_at",
+    "updated_at",
+    "autopublish_allowed",
+}
+
+
+def _token(value: Any, label: str) -> str:
+    text = str(value or "").strip()
+    if not _TOKEN_RE.fullmatch(text):
+        raise ValueError(f"{label} must be an opaque token")
+    return text
+
+
+def _digest(value: Any, label: str) -> str:
+    text = str(value or "").strip()
+    if not _DIGEST_RE.fullmatch(text):
+        raise ValueError(f"{label} must use sha256:<64 lowercase hex chars>")
+    return text
+
+
+def _timestamp(value: Any, label: str) -> str:
+    text = str(value or "").strip()
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise ValueError(f"{label} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{label} must include a timezone")
+    return text
+
+
+def _timestamp_value(value: Any, label: str) -> datetime:
+    return datetime.fromisoformat(_timestamp(value, label))
+
+
+def _public_url(value: Any, label: str) -> str:
+    text = str(value or "").strip()
+    parsed = urlsplit(text)
+    if parsed.scheme != "https" or not parsed.hostname:
+        raise ValueError(f"{label} must be a public https URL")
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise ValueError(f"{label} must not contain credentials, query, or fragment")
+    host = parsed.hostname.lower().rstrip(".")
+    if host == "localhost" or host.endswith((".localhost", ".local")):
+        raise ValueError(f"{label} must not target a local host")
+    return urlunsplit(("https", parsed.netloc, parsed.path or "/", "", ""))
+
+
+def _short_reason(value: Any, label: str) -> str:
+    text = " ".join(str(value or "").split())
+    if not text or len(text) > 180:
+        raise ValueError(f"{label} must contain 1-180 public-safe characters")
+    lowered = text.lower()
+    if any(
+        marker in lowered for marker in ("/users/", "/private/", "bearer ", "secret")
+    ):
+        raise ValueError(f"{label} must not contain private paths or credentials")
+    return text
+
+
+def _source_refs(values: Sequence[Any] | None) -> list[str]:
+    refs = [_token(value, "source_ref") for value in values or []]
+    if len(refs) != len(set(refs)):
+        raise ValueError("source_refs must be unique")
+    return refs
+
+
+def _event_digest(event: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        event, ensure_ascii=True, sort_keys=True, separators=(",", ":")
+    )
+    return "sha256:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _record(
+    value: Any,
+    label: str,
+    *,
+    required: set[str],
+    optional: set[str] | None = None,
+) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{label} must be an object or null")
+    record = dict(value)
+    optional = optional or set()
+    missing = sorted(required - set(record))
+    extra = sorted(set(record) - required - optional)
+    if missing or extra:
+        raise ValueError(
+            f"{label} fields invalid: missing={missing}, unsupported={extra}"
+        )
+    return record
+
+
+def _validate_effect_records(item: Mapping[str, Any]) -> None:
+    approval = _record(
+        item.get("approval"),
+        "approval",
+        required={
+            "approval_ref",
+            "revision",
+            "content_digest",
+            "effect_kind",
+            "account_ref",
+            "valid_from",
+            "valid_until",
+        },
+    )
+    intent = _record(
+        item.get("delivery_intent"),
+        "delivery_intent",
+        required={
+            "provider_id",
+            "effect_kind",
+            "account_ref",
+            "not_before",
+            "not_after",
+        },
+    )
+    delivery = _record(
+        item.get("delivery_receipt"),
+        "delivery_receipt",
+        required={
+            "provider_id",
+            "effect_kind",
+            "account_ref",
+            "content_digest",
+            "public_url",
+            "receipt_ref",
+            "recorded_at",
+        },
+    )
+    readback = _record(
+        item.get("readback_receipt"),
+        "readback_receipt",
+        required={"public_url", "content_digest", "readback_ref", "verified_at"},
+    )
+
+    state = str(item["state"])
+    if state in {"approved", "delivery_ready", "published", "readback_verified"}:
+        if approval is None:
+            raise ValueError(f"{state} item requires approval")
+    elif approval is not None:
+        raise ValueError(f"{state} item must not retain approval")
+    if state == "delivery_ready" and intent is None:
+        raise ValueError("delivery_ready item requires delivery_intent")
+    if intent is not None and state not in {
+        "delivery_ready",
+        "published",
+        "readback_verified",
+    }:
+        raise ValueError(f"{state} item must not retain delivery_intent")
+    if state in {"published", "readback_verified"} and delivery is None:
+        raise ValueError(f"{state} item requires delivery_receipt")
+    if delivery is not None and state not in {"published", "readback_verified"}:
+        raise ValueError(f"{state} item must not retain delivery_receipt")
+    if state == "readback_verified" and readback is None:
+        raise ValueError("readback_verified item requires readback_receipt")
+    if readback is not None and state != "readback_verified":
+        raise ValueError(f"{state} item must not retain readback_receipt")
+
+    if approval is not None:
+        _token(approval["approval_ref"], "approval.approval_ref")
+        if approval["revision"] != item["revision"]:
+            raise ValueError("approval revision does not match item revision")
+        if (
+            _digest(approval["content_digest"], "approval.content_digest")
+            != item["content_digest"]
+        ):
+            raise ValueError("approval content_digest does not match item")
+        if approval["effect_kind"] not in ALLOWED_EFFECT_KINDS:
+            raise ValueError("approval effect_kind is invalid")
+        if approval["account_ref"] is not None:
+            _token(approval["account_ref"], "approval.account_ref")
+        for field in ("valid_from", "valid_until"):
+            if approval[field] is not None:
+                _timestamp(approval[field], f"approval.{field}")
+    if intent is not None:
+        _token(intent["provider_id"], "delivery_intent.provider_id")
+        if intent["effect_kind"] != approval["effect_kind"]:
+            raise ValueError("delivery_intent effect_kind does not match approval")
+        if intent["account_ref"] is not None:
+            _token(intent["account_ref"], "delivery_intent.account_ref")
+        if (
+            approval.get("account_ref")
+            and intent["account_ref"] != approval["account_ref"]
+        ):
+            raise ValueError("delivery_intent account_ref does not match approval")
+        for field in ("not_before", "not_after"):
+            if intent[field] is not None:
+                _timestamp(intent[field], f"delivery_intent.{field}")
+    if delivery is not None:
+        _token(delivery["provider_id"], "delivery_receipt.provider_id")
+        _token(delivery["receipt_ref"], "delivery_receipt.receipt_ref")
+        _timestamp(delivery["recorded_at"], "delivery_receipt.recorded_at")
+        _public_url(delivery["public_url"], "delivery_receipt.public_url")
+        if delivery["effect_kind"] != approval["effect_kind"]:
+            raise ValueError("delivery_receipt effect_kind does not match approval")
+        if (
+            _digest(delivery["content_digest"], "delivery_receipt.content_digest")
+            != item["content_digest"]
+        ):
+            raise ValueError("delivery_receipt content_digest does not match item")
+        expected_provider = intent.get("provider_id") if intent else None
+        if expected_provider and delivery["provider_id"] != expected_provider:
+            raise ValueError("delivery_receipt provider_id does not match intent")
+        expected_account = (
+            intent.get("account_ref") if intent else approval.get("account_ref")
+        )
+        if delivery["account_ref"] is not None:
+            _token(delivery["account_ref"], "delivery_receipt.account_ref")
+        if expected_account and delivery["account_ref"] != expected_account:
+            raise ValueError("delivery_receipt account_ref does not match approval")
+    if readback is not None:
+        _token(readback["readback_ref"], "readback_receipt.readback_ref")
+        _timestamp(readback["verified_at"], "readback_receipt.verified_at")
+        if (
+            _public_url(readback["public_url"], "readback_receipt.public_url")
+            != delivery["public_url"]
+        ):
+            raise ValueError("readback_receipt public_url does not match delivery")
+        if (
+            _digest(readback["content_digest"], "readback_receipt.content_digest")
+            != item["content_digest"]
+        ):
+            raise ValueError("readback_receipt content_digest does not match item")
+
+
+def _require_item(item: Mapping[str, Any]) -> dict[str, Any]:
+    candidate = copy.deepcopy(dict(item))
+    extra = sorted(set(candidate) - _ITEM_KEYS)
+    if extra:
+        raise ValueError(f"content item contains unsupported fields: {extra}")
+    if candidate.get("schema_version") != CONTENT_OPS_ITEM_SCHEMA_VERSION:
+        raise ValueError("content item schema_version is invalid")
+    _token(candidate.get("item_id"), "item_id")
+    if candidate.get("item_kind") not in ALLOWED_ITEM_KINDS:
+        raise ValueError(f"item_kind must be one of {sorted(ALLOWED_ITEM_KINDS)}")
+    _token(candidate.get("channel"), "channel")
+    if candidate.get("state") not in ALLOWED_ITEM_STATES:
+        raise ValueError(f"state must be one of {sorted(ALLOWED_ITEM_STATES)}")
+    revision = candidate.get("revision")
+    if isinstance(revision, bool) or not isinstance(revision, int) or revision < 1:
+        raise ValueError("revision must be a positive integer")
+    _digest(candidate.get("content_digest"), "content_digest")
+    _token(candidate.get("content_ref"), "content_ref")
+    _source_refs(candidate.get("source_refs"))
+    _timestamp(candidate.get("created_at"), "created_at")
+    _timestamp(candidate.get("updated_at"), "updated_at")
+    if candidate.get("autopublish_allowed") is not False:
+        raise ValueError("autopublish_allowed must be false")
+    last_event = _record(
+        candidate.get("last_event"),
+        "last_event",
+        required={"event_id", "event_digest", "action"},
+    )
+    if last_event is not None:
+        _token(last_event["event_id"], "last_event.event_id")
+        _digest(last_event["event_digest"], "last_event.event_digest")
+        _token(last_event["action"], "last_event.action")
+    if candidate.get("superseded_by") is not None:
+        _token(candidate["superseded_by"], "superseded_by")
+    if candidate.get("terminal_reason") is not None:
+        _short_reason(candidate["terminal_reason"], "terminal_reason")
+    if candidate["state"] == "superseded" and not candidate.get("superseded_by"):
+        raise ValueError("superseded item requires superseded_by")
+    if candidate.get("superseded_by") and candidate["state"] != "superseded":
+        raise ValueError("only a superseded item may set superseded_by")
+    if candidate["state"] in {"skipped", "superseded"}:
+        if not candidate.get("terminal_reason"):
+            raise ValueError(f"{candidate['state']} item requires terminal_reason")
+    elif candidate.get("terminal_reason") is not None:
+        raise ValueError("non-terminal item must not set terminal_reason")
+    _validate_effect_records(candidate)
+    return candidate
+
+
+def build_content_ops_item(
+    *,
+    item_id: str,
+    item_kind: str,
+    channel: str,
+    content_digest: str,
+    content_ref: str,
+    source_refs: Sequence[str] | None = None,
+    created_at: str,
+) -> dict[str, Any]:
+    """Create a compact content item without copying draft content into LoopX."""
+
+    if item_kind not in ALLOWED_ITEM_KINDS:
+        raise ValueError(f"item_kind must be one of {sorted(ALLOWED_ITEM_KINDS)}")
+    timestamp = _timestamp(created_at, "created_at")
+    item = {
+        "schema_version": CONTENT_OPS_ITEM_SCHEMA_VERSION,
+        "item_id": _token(item_id, "item_id"),
+        "item_kind": item_kind,
+        "channel": _token(channel, "channel"),
+        "state": "captured",
+        "revision": 1,
+        "content_digest": _digest(content_digest, "content_digest"),
+        "content_ref": _token(content_ref, "content_ref"),
+        "source_refs": _source_refs(source_refs),
+        "approval": None,
+        "delivery_intent": None,
+        "delivery_receipt": None,
+        "readback_receipt": None,
+        "superseded_by": None,
+        "terminal_reason": None,
+        "last_event": None,
+        "created_at": timestamp,
+        "updated_at": timestamp,
+        "autopublish_allowed": False,
+    }
+    return _require_item(item)
+
+
+def validate_content_ops_item(item: Mapping[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    try:
+        _require_item(item)
+    except ValueError as exc:
+        errors.append(str(exc))
+    return {
+        "ok": not errors,
+        "schema_version": CONTENT_OPS_ITEM_SCHEMA_VERSION,
+        "errors": errors,
+    }
+
+
+def _require_event(event: Mapping[str, Any]) -> tuple[dict[str, Any], str]:
+    candidate = copy.deepcopy(dict(event))
+    required = {
+        "event_id",
+        "action",
+        "expected_state",
+        "expected_revision",
+        "occurred_at",
+    }
+    missing = sorted(key for key in required if key not in candidate)
+    extra = sorted(set(candidate) - required - {"payload"})
+    if missing or extra:
+        raise ValueError(
+            f"event fields invalid: missing={missing}, unsupported={extra}"
+        )
+    candidate["event_id"] = _token(candidate["event_id"], "event_id")
+    candidate["occurred_at"] = _timestamp(candidate["occurred_at"], "occurred_at")
+    revision = candidate["expected_revision"]
+    if isinstance(revision, bool) or not isinstance(revision, int) or revision < 1:
+        raise ValueError("expected_revision must be a positive integer")
+    if candidate["expected_state"] not in ALLOWED_ITEM_STATES:
+        raise ValueError("expected_state is invalid")
+    if not isinstance(candidate.get("payload", {}), Mapping):
+        raise TypeError("event payload must be an object")
+    candidate["payload"] = dict(candidate.get("payload") or {})
+    return candidate, _event_digest(candidate)
+
+
+def _payload(
+    payload: Mapping[str, Any],
+    *,
+    required: set[str],
+    optional: set[str] | None = None,
+) -> dict[str, Any]:
+    optional = optional or set()
+    missing = sorted(required - set(payload))
+    extra = sorted(set(payload) - required - optional)
+    if missing or extra:
+        raise ValueError(
+            f"event payload fields invalid: missing={missing}, unsupported={extra}"
+        )
+    return dict(payload)
+
+
+def _clear_effect_state(item: dict[str, Any]) -> None:
+    item["approval"] = None
+    item["delivery_intent"] = None
+    item["delivery_receipt"] = None
+    item["readback_receipt"] = None
+
+
+def _assert_delivery_window(item: Mapping[str, Any], occurred_at: str) -> None:
+    observed = _timestamp_value(occurred_at, "occurred_at")
+    approval = item.get("approval") if isinstance(item.get("approval"), Mapping) else {}
+    intent = (
+        item.get("delivery_intent")
+        if isinstance(item.get("delivery_intent"), Mapping)
+        else {}
+    )
+    for field, is_lower in (
+        ("valid_from", True),
+        ("valid_until", False),
+        ("not_before", True),
+        ("not_after", False),
+    ):
+        raw = approval.get(field) if field.startswith("valid_") else intent.get(field)
+        if raw is None:
+            continue
+        boundary = _timestamp_value(raw, field)
+        if (is_lower and observed < boundary) or (not is_lower and observed > boundary):
+            raise ValueError(f"delivery occurred outside {field}")
+
+
+def _transition(item: dict[str, Any], event: Mapping[str, Any]) -> None:
+    action = str(event["action"])
+    state = str(item["state"])
+    payload = dict(event["payload"])
+
+    if action == "revise":
+        if state not in {
+            "captured",
+            "draft",
+            "review_ready",
+            "approved",
+            "delivery_ready",
+        }:
+            raise ValueError(f"revise is not allowed from {state}")
+        values = _payload(
+            payload,
+            required={"content_digest", "content_ref"},
+            optional={"source_refs"},
+        )
+        item["revision"] += 1
+        item["content_digest"] = _digest(values["content_digest"], "content_digest")
+        item["content_ref"] = _token(values["content_ref"], "content_ref")
+        if "source_refs" in values:
+            if not isinstance(values["source_refs"], list):
+                raise ValueError("source_refs must be a list")
+            item["source_refs"] = _source_refs(values["source_refs"])
+        _clear_effect_state(item)
+        item["state"] = "draft"
+        return
+
+    if action == "submit_review":
+        if state not in {"captured", "draft"}:
+            raise ValueError(f"submit_review is not allowed from {state}")
+        _payload(payload, required=set())
+        item["state"] = "review_ready"
+        return
+
+    if action == "approve":
+        if state != "review_ready":
+            raise ValueError(f"approve is not allowed from {state}")
+        values = _payload(
+            payload,
+            required={"approval_ref", "revision", "content_digest", "effect_kind"},
+            optional={"account_ref", "valid_from", "valid_until"},
+        )
+        if values["revision"] != item["revision"]:
+            raise ValueError("approval revision does not match current item revision")
+        if (
+            _digest(values["content_digest"], "content_digest")
+            != item["content_digest"]
+        ):
+            raise ValueError("approval content_digest does not match current item")
+        effect_kind = str(values["effect_kind"])
+        if effect_kind not in ALLOWED_EFFECT_KINDS:
+            raise ValueError(
+                f"effect_kind must be one of {sorted(ALLOWED_EFFECT_KINDS)}"
+            )
+        approval = {
+            "approval_ref": _token(values["approval_ref"], "approval_ref"),
+            "revision": item["revision"],
+            "content_digest": item["content_digest"],
+            "effect_kind": effect_kind,
+            "account_ref": _token(values["account_ref"], "account_ref")
+            if values.get("account_ref")
+            else None,
+            "valid_from": _timestamp(values["valid_from"], "valid_from")
+            if values.get("valid_from")
+            else None,
+            "valid_until": _timestamp(values["valid_until"], "valid_until")
+            if values.get("valid_until")
+            else None,
+        }
+        if (
+            approval["valid_from"]
+            and approval["valid_until"]
+            and _timestamp_value(approval["valid_from"], "valid_from")
+            > _timestamp_value(approval["valid_until"], "valid_until")
+        ):
+            raise ValueError("valid_from must not be after valid_until")
+        item["approval"] = approval
+        item["state"] = "approved"
+        return
+
+    if action == "set_delivery_intent":
+        if state != "approved":
+            raise ValueError(f"set_delivery_intent is not allowed from {state}")
+        values = _payload(
+            payload,
+            required={"provider_id", "effect_kind"},
+            optional={"account_ref", "not_before", "not_after"},
+        )
+        approval = dict(item["approval"])
+        if values["effect_kind"] != approval["effect_kind"]:
+            raise ValueError("delivery intent effect_kind does not match approval")
+        account_ref = (
+            _token(values["account_ref"], "account_ref")
+            if values.get("account_ref")
+            else approval.get("account_ref")
+        )
+        if approval.get("account_ref") and account_ref != approval["account_ref"]:
+            raise ValueError("delivery intent account_ref does not match approval")
+        intent = {
+            "provider_id": _token(values["provider_id"], "provider_id"),
+            "effect_kind": values["effect_kind"],
+            "account_ref": account_ref,
+            "not_before": _timestamp(values["not_before"], "not_before")
+            if values.get("not_before")
+            else None,
+            "not_after": _timestamp(values["not_after"], "not_after")
+            if values.get("not_after")
+            else None,
+        }
+        if (
+            intent["not_before"]
+            and intent["not_after"]
+            and _timestamp_value(intent["not_before"], "not_before")
+            > _timestamp_value(intent["not_after"], "not_after")
+        ):
+            raise ValueError("not_before must not be after not_after")
+        item["delivery_intent"] = intent
+        item["state"] = "delivery_ready"
+        return
+
+    if action == "record_delivery":
+        if state not in {"approved", "delivery_ready"}:
+            raise ValueError(f"record_delivery is not allowed from {state}")
+        values = _payload(
+            payload,
+            required={
+                "provider_id",
+                "effect_kind",
+                "content_digest",
+                "public_url",
+                "receipt_ref",
+            },
+            optional={"account_ref"},
+        )
+        approval = dict(item["approval"])
+        if values["effect_kind"] != approval["effect_kind"]:
+            raise ValueError("delivery effect_kind does not match approval")
+        if (
+            _digest(values["content_digest"], "content_digest")
+            != approval["content_digest"]
+        ):
+            raise ValueError("delivery content_digest does not match approval")
+        intent = dict(item["delivery_intent"] or {})
+        provider_id = _token(values["provider_id"], "provider_id")
+        if intent and provider_id != intent["provider_id"]:
+            raise ValueError("delivery provider_id does not match intent")
+        account_ref = (
+            _token(values["account_ref"], "account_ref")
+            if values.get("account_ref")
+            else intent.get("account_ref") or approval.get("account_ref")
+        )
+        expected_account = intent.get("account_ref") or approval.get("account_ref")
+        if expected_account and account_ref != expected_account:
+            raise ValueError("delivery account_ref does not match approval or intent")
+        _assert_delivery_window(item, str(event["occurred_at"]))
+        item["delivery_receipt"] = {
+            "provider_id": provider_id,
+            "effect_kind": values["effect_kind"],
+            "account_ref": account_ref,
+            "content_digest": item["content_digest"],
+            "public_url": _public_url(values["public_url"], "public_url"),
+            "receipt_ref": _token(values["receipt_ref"], "receipt_ref"),
+            "recorded_at": event["occurred_at"],
+        }
+        item["state"] = "published"
+        return
+
+    if action == "verify_readback":
+        if state != "published":
+            raise ValueError(f"verify_readback is not allowed from {state}")
+        values = _payload(
+            payload,
+            required={"public_url", "content_digest", "readback_ref"},
+        )
+        delivery = dict(item["delivery_receipt"])
+        public_url = _public_url(values["public_url"], "public_url")
+        if public_url != delivery["public_url"]:
+            raise ValueError("readback public_url does not match delivery receipt")
+        if (
+            _digest(values["content_digest"], "content_digest")
+            != delivery["content_digest"]
+        ):
+            raise ValueError("readback content_digest does not match delivery receipt")
+        item["readback_receipt"] = {
+            "public_url": public_url,
+            "content_digest": item["content_digest"],
+            "readback_ref": _token(values["readback_ref"], "readback_ref"),
+            "verified_at": event["occurred_at"],
+        }
+        item["state"] = "readback_verified"
+        return
+
+    if action == "revoke_approval":
+        if state not in {"approved", "delivery_ready"}:
+            raise ValueError(f"revoke_approval is not allowed from {state}")
+        values = _payload(payload, required={"reason"})
+        _clear_effect_state(item)
+        _short_reason(values["reason"], "reason")
+        item["state"] = "review_ready"
+        return
+
+    if action == "skip":
+        if state in {"published", *TERMINAL_STATES}:
+            raise ValueError(f"skip is not allowed from {state}")
+        values = _payload(payload, required={"reason"})
+        _clear_effect_state(item)
+        item["terminal_reason"] = _short_reason(values["reason"], "reason")
+        item["state"] = "skipped"
+        return
+
+    if action == "supersede":
+        if state in {"published", *TERMINAL_STATES}:
+            raise ValueError(f"supersede is not allowed from {state}")
+        values = _payload(payload, required={"successor_item_id", "reason"})
+        successor = _token(values["successor_item_id"], "successor_item_id")
+        if successor == item["item_id"]:
+            raise ValueError("successor_item_id must differ from item_id")
+        _clear_effect_state(item)
+        item["superseded_by"] = successor
+        item["terminal_reason"] = _short_reason(values["reason"], "reason")
+        item["state"] = "superseded"
+        return
+
+    raise ValueError(f"unsupported content item action {action!r}")
+
+
+def project_content_ops_item(item: Mapping[str, Any]) -> dict[str, Any]:
+    current = _require_item(item)
+    state = str(current["state"])
+    next_actions = {
+        "captured": ["revise", "submit_review", "skip", "supersede"],
+        "draft": ["revise", "submit_review", "skip", "supersede"],
+        "review_ready": ["revise", "approve", "skip", "supersede"],
+        "approved": [
+            "revise",
+            "set_delivery_intent",
+            "record_delivery",
+            "revoke_approval",
+            "skip",
+            "supersede",
+        ],
+        "delivery_ready": [
+            "revise",
+            "record_delivery",
+            "revoke_approval",
+            "skip",
+            "supersede",
+        ],
+        "published": ["verify_readback"],
+        "readback_verified": [],
+        "skipped": [],
+        "superseded": [],
+    }[state]
+    delivery = current.get("delivery_receipt") or {}
+    return {
+        "schema_version": CONTENT_OPS_ITEM_PROJECTION_SCHEMA_VERSION,
+        "item_id": current["item_id"],
+        "item_kind": current["item_kind"],
+        "channel": current["channel"],
+        "state": state,
+        "revision": current["revision"],
+        "approval_present": current.get("approval") is not None,
+        "delivery_intent_present": current.get("delivery_intent") is not None,
+        "published_url": delivery.get("public_url"),
+        "readback_verified": current.get("readback_receipt") is not None,
+        "terminal": state in TERMINAL_STATES,
+        "superseded_by": current.get("superseded_by"),
+        "next_actions": next_actions,
+        "truth_contract": {
+            "projection_is_writable": False,
+            "external_effect_authority": "none",
+            "autopublish_allowed": False,
+        },
+    }
+
+
+def build_content_ops_item_packet(**kwargs: Any) -> dict[str, Any]:
+    item = build_content_ops_item(**kwargs)
+    return {
+        "ok": True,
+        "schema_version": CONTENT_OPS_ITEM_PACKET_SCHEMA_VERSION,
+        "item": item,
+        "projection": project_content_ops_item(item),
+        "external_reads_performed": False,
+        "external_writes_performed": False,
+        "autopublish_allowed": False,
+    }
+
+
+def apply_content_ops_item_event(
+    item: Mapping[str, Any], event: Mapping[str, Any]
+) -> dict[str, Any]:
+    current = _require_item(item)
+    normalized_event, event_digest = _require_event(event)
+    last_event = current.get("last_event")
+    if (
+        isinstance(last_event, Mapping)
+        and last_event.get("event_id") == normalized_event["event_id"]
+    ):
+        if last_event.get("event_digest") != event_digest:
+            raise ValueError("event_id was already used with different content")
+        return {
+            "ok": True,
+            "schema_version": CONTENT_OPS_ITEM_TRANSITION_PACKET_SCHEMA_VERSION,
+            "item": current,
+            "projection": project_content_ops_item(current),
+            "receipt": {
+                "schema_version": CONTENT_OPS_ITEM_TRANSITION_RECEIPT_SCHEMA_VERSION,
+                "status": "already_applied",
+                "event_id": normalized_event["event_id"],
+                "event_digest": event_digest,
+                "from_state": current["state"],
+                "to_state": current["state"],
+                "revision": current["revision"],
+            },
+            "external_reads_performed": False,
+            "external_writes_performed": False,
+            "autopublish_allowed": False,
+        }
+    if normalized_event["expected_state"] != current["state"]:
+        raise ValueError("event expected_state does not match current item state")
+    if normalized_event["expected_revision"] != current["revision"]:
+        raise ValueError("event expected_revision does not match current item revision")
+
+    before_state = str(current["state"])
+    updated = copy.deepcopy(current)
+    _transition(updated, normalized_event)
+    updated["updated_at"] = normalized_event["occurred_at"]
+    updated["last_event"] = {
+        "event_id": normalized_event["event_id"],
+        "event_digest": event_digest,
+        "action": normalized_event["action"],
+    }
+    _require_item(updated)
+    return {
+        "ok": True,
+        "schema_version": CONTENT_OPS_ITEM_TRANSITION_PACKET_SCHEMA_VERSION,
+        "item": updated,
+        "projection": project_content_ops_item(updated),
+        "receipt": {
+            "schema_version": CONTENT_OPS_ITEM_TRANSITION_RECEIPT_SCHEMA_VERSION,
+            "status": "applied",
+            "event_id": normalized_event["event_id"],
+            "event_digest": event_digest,
+            "from_state": before_state,
+            "to_state": updated["state"],
+            "revision": updated["revision"],
+        },
+        "external_reads_performed": False,
+        "external_writes_performed": False,
+        "autopublish_allowed": False,
+    }
+
+
+def render_content_ops_item_packet_markdown(packet: Mapping[str, Any]) -> str:
+    if not packet.get("ok"):
+        return f"# LoopX Content Item\n\n- error: `{packet.get('error')}`\n"
+    projection = (
+        packet.get("projection")
+        if isinstance(packet.get("projection"), Mapping)
+        else {}
+    )
+    receipt = (
+        packet.get("receipt") if isinstance(packet.get("receipt"), Mapping) else {}
+    )
+    lines = [
+        "# LoopX Content Item",
+        "",
+        f"- item_id: `{projection.get('item_id')}`",
+        f"- state: `{projection.get('state')}`",
+        f"- revision: `{projection.get('revision')}`",
+        f"- approval_present: `{projection.get('approval_present')}`",
+        f"- readback_verified: `{projection.get('readback_verified')}`",
+        f"- external_writes_performed: `{packet.get('external_writes_performed')}`",
+    ]
+    if receipt:
+        lines.extend(
+            [
+                f"- transition_status: `{receipt.get('status')}`",
+                f"- transition: `{receipt.get('from_state')} -> {receipt.get('to_state')}`",
+            ]
+        )
+    return "\n".join(lines) + "\n"

--- a/loopx/capabilities/content_ops/schemas.py
+++ b/loopx/capabilities/content_ops/schemas.py
@@ -25,6 +25,15 @@ CONTENT_OPS_CHATVIEW_CONNECTOR_REPORT_SCHEMA_VERSION = (
 CONTENT_OPS_WALKTHROUGH_ARTIFACT_SCHEMA_VERSION = (
     "content_ops_walkthrough_artifact_v0"
 )
+CONTENT_OPS_ITEM_SCHEMA_VERSION = "content_ops_item_v0"
+CONTENT_OPS_ITEM_PACKET_SCHEMA_VERSION = "content_ops_item_packet_v0"
+CONTENT_OPS_ITEM_TRANSITION_PACKET_SCHEMA_VERSION = (
+    "content_ops_item_transition_packet_v0"
+)
+CONTENT_OPS_ITEM_TRANSITION_RECEIPT_SCHEMA_VERSION = (
+    "content_ops_item_transition_receipt_v0"
+)
+CONTENT_OPS_ITEM_PROJECTION_SCHEMA_VERSION = "content_ops_item_projection_v0"
 CONTENT_OPS_EXPLORATION_PLAN_PACKET_SCHEMA_VERSION = (
     "content_ops_exploration_plan_packet_v0"
 )

--- a/tests/test_content_ops_item_lifecycle.py
+++ b/tests/test_content_ops_item_lifecycle.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from loopx.capabilities.content_ops.item_lifecycle import (
+    apply_content_ops_item_event,
+    build_content_ops_item,
+    project_content_ops_item,
+    validate_content_ops_item,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DIGEST_V1 = "sha256:" + "1" * 64
+DIGEST_V2 = "sha256:" + "2" * 64
+
+
+def _item() -> dict[str, object]:
+    return build_content_ops_item(
+        item_id="partner-launch-reply-v1",
+        item_kind="reply",
+        channel="x",
+        content_digest=DIGEST_V1,
+        content_ref="draft:partner-launch-reply-v1",
+        source_refs=["source:partner-launch-post"],
+        created_at="2026-08-03T09:00:00+08:00",
+    )
+
+
+def _event(
+    item: dict[str, object],
+    event_id: str,
+    action: str,
+    payload: dict[str, object] | None = None,
+    occurred_at: str = "2026-08-03T09:05:00+08:00",
+) -> dict[str, object]:
+    return {
+        "event_id": event_id,
+        "action": action,
+        "expected_state": item["state"],
+        "expected_revision": item["revision"],
+        "occurred_at": occurred_at,
+        "payload": payload or {},
+    }
+
+
+def _apply(
+    item: dict[str, object],
+    event_id: str,
+    action: str,
+    payload: dict[str, object] | None = None,
+    occurred_at: str = "2026-08-03T09:05:00+08:00",
+) -> dict[str, object]:
+    packet = apply_content_ops_item_event(
+        item,
+        _event(item, event_id, action, payload, occurred_at),
+    )
+    assert packet["external_writes_performed"] is False
+    return packet["item"]
+
+
+def test_full_item_lifecycle_requires_bound_approval_and_exact_readback() -> None:
+    item = _apply(_item(), "event-review", "submit_review")
+    item = _apply(
+        item,
+        "event-approve",
+        "approve",
+        {
+            "approval_ref": "decision:partner-launch-reply-v1",
+            "revision": 1,
+            "content_digest": DIGEST_V1,
+            "effect_kind": "reply",
+            "account_ref": "account:maintainer",
+            "valid_from": "2026-08-03T09:00:00+08:00",
+            "valid_until": "2026-08-03T12:00:00+08:00",
+        },
+    )
+    item = _apply(
+        item,
+        "event-intent",
+        "set_delivery_intent",
+        {
+            "provider_id": "ego-lite",
+            "effect_kind": "reply",
+            "account_ref": "account:maintainer",
+            "not_before": "2026-08-03T09:30:00+08:00",
+            "not_after": "2026-08-03T11:00:00+08:00",
+        },
+    )
+    item = _apply(
+        item,
+        "event-delivery",
+        "record_delivery",
+        {
+            "provider_id": "ego-lite",
+            "effect_kind": "reply",
+            "account_ref": "account:maintainer",
+            "content_digest": DIGEST_V1,
+            "public_url": "https://x.com/example/status/123",
+            "receipt_ref": "receipt:x-reply-123",
+        },
+        occurred_at="2026-08-03T10:00:00+08:00",
+    )
+    item = _apply(
+        item,
+        "event-readback",
+        "verify_readback",
+        {
+            "public_url": "https://x.com/example/status/123",
+            "content_digest": DIGEST_V1,
+            "readback_ref": "readback:x-reply-123",
+        },
+        occurred_at="2026-08-03T10:01:00+08:00",
+    )
+
+    assert validate_content_ops_item(item)["ok"] is True
+    projection = project_content_ops_item(item)
+    assert projection["state"] == "readback_verified"
+    assert projection["terminal"] is True
+    assert projection["readback_verified"] is True
+    assert projection["published_url"] == "https://x.com/example/status/123"
+    assert projection["truth_contract"]["external_effect_authority"] == "none"
+
+
+def test_revision_invalidates_prior_approval_and_effect_intent() -> None:
+    item = _apply(_item(), "event-review", "submit_review")
+    item = _apply(
+        item,
+        "event-approve",
+        "approve",
+        {
+            "approval_ref": "decision:partner-launch-reply-v1",
+            "revision": 1,
+            "content_digest": DIGEST_V1,
+            "effect_kind": "reply",
+        },
+    )
+    item = _apply(
+        item,
+        "event-revise",
+        "revise",
+        {
+            "content_digest": DIGEST_V2,
+            "content_ref": "draft:partner-launch-reply-v2",
+        },
+    )
+
+    assert item["state"] == "draft"
+    assert item["revision"] == 2
+    assert item["approval"] is None
+    assert item["delivery_intent"] is None
+
+
+def test_approval_and_delivery_fail_closed_on_binding_or_window_mismatch() -> None:
+    item = _apply(_item(), "event-review", "submit_review")
+    with pytest.raises(ValueError, match="approval content_digest"):
+        _apply(
+            item,
+            "event-bad-approval",
+            "approve",
+            {
+                "approval_ref": "decision:partner-launch-reply-v1",
+                "revision": 1,
+                "content_digest": DIGEST_V2,
+                "effect_kind": "reply",
+            },
+        )
+
+    item = _apply(
+        item,
+        "event-approve",
+        "approve",
+        {
+            "approval_ref": "decision:partner-launch-reply-v1",
+            "revision": 1,
+            "content_digest": DIGEST_V1,
+            "effect_kind": "reply",
+            "valid_until": "2026-08-03T09:30:00+08:00",
+        },
+    )
+    with pytest.raises(ValueError, match="outside valid_until"):
+        _apply(
+            item,
+            "event-late-delivery",
+            "record_delivery",
+            {
+                "provider_id": "ego-lite",
+                "effect_kind": "reply",
+                "content_digest": DIGEST_V1,
+                "public_url": "https://x.com/example/status/123",
+                "receipt_ref": "receipt:x-reply-123",
+            },
+            occurred_at="2026-08-03T10:00:00+08:00",
+        )
+
+
+def test_event_retry_is_idempotent_and_changed_reuse_is_rejected() -> None:
+    item = _item()
+    event = _event(item, "event-review", "submit_review")
+    first = apply_content_ops_item_event(item, event)
+    retried = apply_content_ops_item_event(first["item"], event)
+    assert retried["receipt"]["status"] == "already_applied"
+    changed = dict(event)
+    changed["occurred_at"] = "2026-08-03T09:06:00+08:00"
+    with pytest.raises(ValueError, match="different content"):
+        apply_content_ops_item_event(first["item"], changed)
+
+
+def test_superseded_item_is_terminal_and_links_successor() -> None:
+    item = _apply(
+        _item(),
+        "event-supersede",
+        "supersede",
+        {
+            "successor_item_id": "partner-launch-reply-v2",
+            "reason": "A newer draft replaces this review packet.",
+        },
+    )
+    assert item["state"] == "superseded"
+    assert item["superseded_by"] == "partner-launch-reply-v2"
+    assert project_content_ops_item(item)["next_actions"] == []
+    with pytest.raises(ValueError, match="submit_review is not allowed"):
+        _apply(item, "event-review", "submit_review")
+
+
+def test_forged_state_or_embedded_body_is_rejected() -> None:
+    forged = _item()
+    forged["state"] = "published"
+    validation = validate_content_ops_item(forged)
+    assert validation["ok"] is False
+    assert "published item requires approval" in validation["errors"][0]
+
+    embedded = _item()
+    embedded["post_body"] = "private draft body"
+    validation = validate_content_ops_item(embedded)
+    assert validation["ok"] is False
+    assert "unsupported fields" in validation["errors"][0]
+
+
+def test_cli_creates_and_transitions_an_item_without_external_effects(
+    tmp_path: Path,
+) -> None:
+    create = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "content-ops",
+            "item-create",
+            "--item-id",
+            "launch-post-v1",
+            "--item-kind",
+            "post",
+            "--channel",
+            "x",
+            "--content-digest",
+            DIGEST_V1,
+            "--content-ref",
+            "draft:launch-post-v1",
+            "--created-at",
+            "2026-08-03T09:00:00+08:00",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    created = json.loads(create.stdout)
+    assert created["projection"]["state"] == "captured"
+    assert created["external_writes_performed"] is False
+
+    item_path = tmp_path / "item.json"
+    event_path = tmp_path / "event.json"
+    item_path.write_text(json.dumps(created["item"]), encoding="utf-8")
+    event_path.write_text(
+        json.dumps(_event(created["item"], "event-review", "submit_review")),
+        encoding="utf-8",
+    )
+    transition = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "content-ops",
+            "item-transition",
+            "--item-json",
+            str(item_path),
+            "--event-json",
+            str(event_path),
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    transitioned = json.loads(transition.stdout)
+    assert transitioned["projection"]["state"] == "review_ready"
+    assert transitioned["receipt"]["status"] == "applied"
+    assert transitioned["external_writes_performed"] is False


### PR DESCRIPTION
## Summary

- add a stable `content_ops_item_v0` lifecycle for articles, posts, replies, reposts, and profile updates
- bind approval, delivery intent, delivery receipt, and public readback to one exact revision and content digest
- expose `content-ops item-create` and `item-transition` without storing draft bodies or performing external writes
- document the provider boundary and keep connector credentials/session state outside core

## Validation

- `uv run --extra test pytest -q tests/test_content_ops_item_lifecycle.py` (7 passed)
- all 10 existing content-ops smokes passed
- targeted Ruff format/check passed
- targeted `loopx check` passed with 0 errors and 0 warnings
- `loopx canary premerge --from-git-diff` passed: 17 checks, 0 failures, 0 manual holds

## Coverage rationale

The tests cover the full revision-to-readback path plus stale approval, expired windows, event idempotency, supersession, forged state, and embedded-body rejection. Existing content-ops smokes cover compatibility with the shipped preview and connector surfaces. No provider call, public post, credential, private draft, or local path is included.