### PR TITLE
Fix blocked todo count in global summary

### DIFF
--- a/loopx/summary_all.py
+++ b/loopx/summary_all.py
@@ -315,7 +315,7 @@ def build_summary_all(
             "headline": headline,
             "progress_count": len(recent_progress),
             "open_gate_count": len(gates),
-            "runnable_todo_count": len(todos),
+            "runnable_todo_count": runnable_count,
             "waiting_lane_count": waiting_count,
             "risk_count": len(risks),
             "source_surfaces": SOURCE_SURFACES,

--- a/tests/test_summary_all.py
+++ b/tests/test_summary_all.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import loopx.summary_all as summary_all
+
+
+def test_blocked_visible_todo_is_not_counted_as_runnable(monkeypatch, tmp_path) -> None:
+    status_payload = {
+        "attention_queue": {
+            "items": [{"goal_id": "blocked-goal", "waiting_on": "user"}],
+        },
+        "global_registry": {"findings": []},
+    }
+    quota_payload = {
+        "goal_id": "blocked-goal",
+        "state": "operator_gate",
+        "recommended_action": "Wait for approval.",
+        "agent_lane_next_action": {
+            "todo_id": "todo-blocked",
+            "text": "Run after approval.",
+            "status": "open",
+        },
+        "user_todo_summary": {
+            "open_count": 1,
+            "items": [{"todo_id": "gate-1", "text": "Approve this run?"}],
+        },
+        "interaction_contract": {
+            "user_channel": {
+                "action_required": True,
+                "question": "Approve this run?",
+            },
+        },
+    }
+
+    monkeypatch.setattr(summary_all, "collect_status", lambda **_: status_payload)
+    monkeypatch.setattr(summary_all, "load_registry", lambda _: {})
+    monkeypatch.setattr(summary_all, "resolve_runtime_root", lambda *_: tmp_path)
+    monkeypatch.setattr(summary_all, "collect_history", lambda **_: {"runs": []})
+    monkeypatch.setattr(
+        summary_all,
+        "build_quota_should_run",
+        lambda *_args, **_kwargs: quota_payload,
+    )
+
+    payload = summary_all.build_summary_all(
+        registry_path=tmp_path / "registry.json",
+        runtime_root_override=None,
+        scan_roots=[],
+        agent_id=None,
+        time_range="24h",
+        limit=5,
+    )
+
+    assert payload["groups"]["runnable_agent_work"] == []
+    assert len(payload["todos"]) == 1
+    assert payload["summary"]["runnable_todo_count"] == 0


### PR DESCRIPTION
## Summary

- report only executable lanes in `summary.runnable_todo_count`
- keep blocked todos visible in the general `todos` projection
- add regression coverage for an `operator_gate` lane waiting on the user

## Root cause

`build_summary_all()` computed the filtered `runnable_count`, but serialized
`len(todos)` instead. The latter includes visible blocked work, so an
`operator_gate` goal could produce an empty `runnable_agent_work` group while
reporting one runnable todo.

## User impact

Global manager summaries now distinguish work that is visible from work that
can actually run, preventing blocked work from inflating the runnable count.

## Validation

- `python -m pytest -q -n 2 tests` (`1916 passed, 2 skipped`)
- `python examples/project/global-manager-command-cli-smoke.py`
- targeted Ruff checks for the changed files
- `loopx canary premerge --from-git-diff --tier standard` (`passed`, no manual holds)
