### PR TITLE
fix(release): restore v0.4.1 qualification

### DIFF
--- a/examples/canary/catalog-run-e2e-smoke.py
+++ b/examples/canary/catalog-run-e2e-smoke.py
@@ -24,7 +24,10 @@ def assert_release_readiness_gets_no_write_argument() -> None:
     normalized = normalize_canary_command("python3 examples/canary/canary-promotion-readiness-smoke.py")
     assert normalized["ok"] is True, normalized
     assert "--no-write-evidence" in normalized["argv"], normalized
-    assert normalized["injected_args"] == ["--no-write-evidence"], normalized
+    assert normalized["injected_args"] == [
+        "--no-write-evidence",
+        "--dashboard-mode=skip",
+    ], normalized
 
 
 def assert_preview_does_not_execute_or_write() -> None:

--- a/examples/canary/smoke-suite-runner-smoke.py
+++ b/examples/canary/smoke-suite-runner-smoke.py
@@ -48,6 +48,7 @@ def assert_full_public_preview_injects_safe_group_args() -> None:
         for check in payload["selected_checks"]
     }
     assert "--no-write-evidence" in by_script["examples/canary/canary-promotion-readiness-smoke.py"]["argv"], payload
+    assert "--dashboard-mode=skip" in by_script["examples/canary/canary-promotion-readiness-smoke.py"]["argv"], payload
     assert "--skip-browser" in by_script["examples/dashboard-demo-readiness-smoke.py"]["argv"], payload
 
 

--- a/examples/capability-extension-registry-smoke.py
+++ b/examples/capability-extension-registry-smoke.py
@@ -63,6 +63,7 @@ next_real_step = "Keep explicit enablement bounded."
         "decision-context",
         "project-skill-delivery",
         "material-lifecycle",
+        "agent-turn-recall",
         "semantic-preference",
         "reward-memory",
         "periodic-report",

--- a/examples/cli-help-manpage-smoke.py
+++ b/examples/cli-help-manpage-smoke.py
@@ -211,7 +211,11 @@ def assert_installer_manpage_surface() -> None:
             env=env,
             text=True,
             capture_output=True,
-            check=True,
+        )
+        assert install.returncode == 0, (
+            install.returncode,
+            install.stdout,
+            install.stderr,
         )
         assert f"- manpage: {man_root / 'man1' / 'loopx.1.gz'}" in install.stdout, install.stdout
 

--- a/examples/control_plane/control-plane-integrated-canary-smoke.py
+++ b/examples/control_plane/control-plane-integrated-canary-smoke.py
@@ -459,7 +459,9 @@ def assert_event_todo_completion_successor_state_machine(
     assert routed["agent_lane_next_action"]["text"] == f"[P1] {SUCCESSOR_TODO_TITLE}", routed
     assert "title" not in routed["agent_lane_next_action"], routed
     assert routed["agent_lane_next_action"]["preserves_goal_next_action"] is True, routed
-    assert routed["active_state_next_action"] == "Keep the fixture-only integrated canary under two minutes.", routed
+    assert "active_state_next_action" not in routed, routed
+    assert routed["goal_route_hint"]["selected_action_differs_from_durable"] is True, routed
+    assert routed["goal_route_hint"]["goal_next_action_mutation"] == "none", routed
     assert routed["interaction_contract"]["mode"] == "bounded_delivery", routed
     assert routed["scheduler_hint"]["action"] == "run_now", routed
     return successor_id

--- a/examples/control_plane/quota-contract-smoke.py
+++ b/examples/control_plane/quota-contract-smoke.py
@@ -165,7 +165,7 @@ def main() -> int:
     )
     assert_contains(
         quota_doc,
-        "report release readiness blockers from the shared run-history projection",
+        "report release readiness blockers from the shared runtime release ledger",
         label="quota doc",
     )
     assert_contains(

--- a/examples/control_plane/runtime-handoff-status-read-path-smoke.py
+++ b/examples/control_plane/runtime-handoff-status-read-path-smoke.py
@@ -235,7 +235,9 @@ def assert_quota_read_path(*, runtime_root: Path, registry_path: Path) -> None:
     assert payload["ok"] is True, payload
     assert payload["decision"] == "run", payload
     assert payload["effective_action"] == "normal_run", payload
-    assert payload["active_state_next_action"] == GOAL_NEXT_ACTION, payload
+    assert "active_state_next_action" not in payload, payload
+    assert payload["goal_route_hint"]["selected_action_differs_from_durable"] is True, payload
+    assert payload["goal_route_hint"]["goal_next_action_mutation"] == "none", payload
     next_action = payload["agent_lane_next_action"]
     assert next_action["todo_id"] == TODO_ID, payload
     assert next_action["claimed_by"] == AGENT_ID, payload

--- a/examples/project/goal-vision-replan-contract-smoke.py
+++ b/examples/project/goal-vision-replan-contract-smoke.py
@@ -25,7 +25,9 @@ PRIVATE_MARKERS = [
     "/" + "tmp" + "/",
     "api" + "_key",
     "pass" + "word",
-    "sec" + "ret",
+    "client" + "_secret",
+    "app" + "_secret",
+    "secret" + "_key",
 ]
 
 

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/loopx/canary/runner.py
+++ b/loopx/canary/runner.py
@@ -17,7 +17,10 @@ CANARY_RUN_SCHEMA_VERSION = "catalog_canary_run_v0"
 CANARY_SMOKE_SUITE_RUN_SCHEMA_VERSION = "canary_smoke_suite_run_v0"
 CANARY_SMOKE_SUITE_PROFILE_SCHEMA_VERSION = "canary_smoke_suite_profiles_v0"
 NO_WRITE_ARGS_BY_SCRIPT = {
-    "canary-promotion-readiness-smoke.py": ["--no-write-evidence"],
+    "canary-promotion-readiness-smoke.py": [
+        "--no-write-evidence",
+        "--dashboard-mode=skip",
+    ],
     "dashboard-demo-readiness-smoke.py": ["--skip-browser"],
 }
 EXPLICIT_GROUPED_SMOKES = {

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -59,24 +59,19 @@ from ..status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, collect_status
 from ..turn_identity import normalize_turn_instance_id
 from ..upgrade import resolve_codex_app_automation_rrule
 from .lark_inbox import build_lark_operator_inbox_urgency_projector
+from .quota_request import (
+    QUOTA_DETAIL_SECTIONS,
+    QUOTA_MONITOR_POLL_DETAIL_SECTIONS,
+    QUOTA_SHOULD_RUN_DETAIL_SECTIONS,
+    quota_detail_sections_from_args,
+    validate_quota_command_request,
+)
 
 PrintPayload = Callable[
     [dict[str, object], str, Callable[[dict[str, object]], str]],
     None,
 ]
 RolloutEventAppender = Callable[..., dict[str, object]]
-QUOTA_SHOULD_RUN_DETAIL_SECTIONS = (
-    "scheduler",
-    "agent-todos",
-    "user-todos",
-    "goal-boundary",
-    "vision",
-)
-QUOTA_MONITOR_POLL_DETAIL_SECTIONS = ("decisions",)
-QUOTA_DETAIL_SECTIONS = (
-    *QUOTA_SHOULD_RUN_DETAIL_SECTIONS,
-    *QUOTA_MONITOR_POLL_DETAIL_SECTIONS,
-)
 QUOTA_EVENT_KINDS = {
     "should-run": "quota_should_run",
     "monitor-poll": "quota_monitor_poll",
@@ -109,43 +104,6 @@ class _QuotaCommandContext:
     operator_inbox_urgency_projector: Callable[..., dict[str, object]]
     detail_sections: frozenset[str]
     heartbeat_turn_id: str | None
-
-
-def _validate_quota_command_request(args: argparse.Namespace) -> None:
-    command = args.quota_command
-    if command not in {"status", "plan"} and not args.goal_id:
-        raise ValueError(f"`loopx quota {command}` requires --goal-id")
-    scheduler_commands = {
-        "scheduler-ack",
-        "scheduler-ack-current",
-        "scheduler-fail-current",
-    }
-    if command in scheduler_commands and not args.agent_id:
-        raise ValueError(f"`loopx quota {command}` requires --agent-id")
-    if command == "void-slot" and not args.void_generated_at:
-        raise ValueError("`loopx quota void-slot` requires --void-generated-at")
-    if (
-        command not in {"status", "plan", "should-run"}
-        and args.dry_run
-        and args.execute
-    ):
-        raise ValueError(
-            f"`loopx quota {command}` accepts only one of --dry-run or --execute"
-        )
-
-
-def _quota_detail_sections_from_args(args: argparse.Namespace) -> frozenset[str]:
-    sections = set(getattr(args, "include_details", None) or ())
-    if bool(getattr(args, "include_scheduler_detail", False)):
-        sections.add("scheduler")
-    if "all" in sections:
-        sections.update(
-            QUOTA_MONITOR_POLL_DETAIL_SECTIONS
-            if args.quota_command == "monitor-poll"
-            else QUOTA_SHOULD_RUN_DETAIL_SECTIONS
-        )
-        sections.discard("all")
-    return frozenset(sections)
 
 
 def default_public_scan_root() -> str:
@@ -520,7 +478,7 @@ def _prepare_quota_command_context(
         if command in QUOTA_SCHEDULER_COMMANDS
         else None
     )
-    _validate_quota_command_request(args)
+    validate_quota_command_request(args)
     return _QuotaCommandContext(
         runtime_root=runtime_root,
         scan_roots=scan_roots,
@@ -530,7 +488,7 @@ def _prepare_quota_command_context(
         cache_metadata=cache_metadata,
         scheduler_context=scheduler_context,
         operator_inbox_urgency_projector=operator_inbox_urgency_projector,
-        detail_sections=_quota_detail_sections_from_args(args),
+        detail_sections=quota_detail_sections_from_args(args),
         heartbeat_turn_id=heartbeat_turn_id,
     )
 

--- a/loopx/cli_commands/quota_request.py
+++ b/loopx/cli_commands/quota_request.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import argparse
+
+QUOTA_SHOULD_RUN_DETAIL_SECTIONS = (
+    "scheduler",
+    "agent-todos",
+    "user-todos",
+    "goal-boundary",
+    "vision",
+)
+QUOTA_MONITOR_POLL_DETAIL_SECTIONS = ("decisions",)
+QUOTA_DETAIL_SECTIONS = (
+    *QUOTA_SHOULD_RUN_DETAIL_SECTIONS,
+    *QUOTA_MONITOR_POLL_DETAIL_SECTIONS,
+)
+
+
+def validate_quota_command_request(args: argparse.Namespace) -> None:
+    command = args.quota_command
+    if command not in {"status", "plan"} and not args.goal_id:
+        raise ValueError(f"`loopx quota {command}` requires --goal-id")
+    scheduler_commands = {
+        "scheduler-ack",
+        "scheduler-ack-current",
+        "scheduler-fail-current",
+    }
+    if command in scheduler_commands and not args.agent_id:
+        raise ValueError(f"`loopx quota {command}` requires --agent-id")
+    if command == "void-slot" and not args.void_generated_at:
+        raise ValueError("`loopx quota void-slot` requires --void-generated-at")
+    if (
+        command not in {"status", "plan", "should-run"}
+        and args.dry_run
+        and args.execute
+    ):
+        raise ValueError(
+            f"`loopx quota {command}` accepts only one of --dry-run or --execute"
+        )
+
+
+def quota_detail_sections_from_args(args: argparse.Namespace) -> frozenset[str]:
+    sections = set(getattr(args, "include_details", None) or ())
+    if bool(getattr(args, "include_scheduler_detail", False)):
+        sections.add("scheduler")
+    if "all" in sections:
+        sections.update(
+            QUOTA_MONITOR_POLL_DETAIL_SECTIONS
+            if args.quota_command == "monitor-poll"
+            else QUOTA_SHOULD_RUN_DETAIL_SECTIONS
+        )
+        sections.discard("all")
+    return frozenset(sections)

--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -27,16 +27,13 @@ from ..presentation.renderers.status_markdown import render_status_markdown
 from ..quota import build_quota_should_run
 from ..review_packet import build_review_packet, render_review_packet_markdown
 from ..status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, collect_status
+from .status_registration import default_public_scan_root, register_status_commands
 
 PrintPayload = Callable[
     [dict[str, object], str, Callable[[dict[str, object]], str]],
     None,
 ]
 FormatSelector = Callable[..., str]
-
-
-def default_public_scan_root() -> str:
-    return str(Path(__file__).resolve().parents[2])
 
 
 def _scan_roots(args: argparse.Namespace) -> list[Path]:
@@ -88,177 +85,6 @@ def _trim_run_history_for_status_display(
                 "status display limit"
             ),
         }
-
-
-def register_status_commands(
-    subparsers: argparse._SubParsersAction,
-    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
-) -> None:
-    check_parser = subparsers.add_parser("check", help="Run a read-only contract and public/private boundary check.")
-    check_parser.add_argument("--scan-root", default=".", help="Public files to scan for obvious private material.")
-    check_parser.add_argument(
-        "--scan-path",
-        action="append",
-        default=[],
-        help="Specific public file or directory to scan. Repeatable. Overrides --scan-root when set.",
-    )
-    check_parser.add_argument("--limit", type=int, default=5)
-
-    status_parser = subparsers.add_parser("status", help="Show a first-screen goal status and attention queue.")
-    add_subcommand_format(status_parser)
-    status_parser.add_argument(
-        "--scan-root",
-        default=default_public_scan_root(),
-        help="Public files to scan for obvious private material. Defaults to the LoopX install root.",
-    )
-    status_parser.add_argument(
-        "--scan-path",
-        action="append",
-        default=[],
-        help="Specific public file or directory to scan. Repeatable. Overrides --scan-root when set.",
-    )
-    status_parser.add_argument("--limit", type=int, default=5)
-    status_parser.add_argument(
-        "--goal-id",
-        help=(
-            "Optional goal id to focus the status projection. The default remains "
-            "the global dashboard/status view."
-        ),
-    )
-    status_parser.add_argument(
-        "--agent-id",
-        help=(
-            "Registered agent id for adding agent-lane next-action projection "
-            "to matching status queue items."
-        ),
-    )
-    status_parser.add_argument(
-        "--available-capability",
-        dest="available_capabilities",
-        action="append",
-        help=(
-            "Declare a capability available in the current execution envelope. "
-            "Repeat for multiple capabilities; capability-gated status fields "
-            "remain absent by default."
-        ),
-    )
-    status_parser.add_argument(
-        "--include-task-graph",
-        action="store_true",
-        help=(
-            "Include the optional task_graph_projection_v0 on status items. "
-            "Default status output keeps this graph on the cold path to stay "
-            "inside the dashboard hot-path budget."
-        ),
-    )
-    status_parser.add_argument(
-        "--use-projection-cache",
-        action="store_true",
-        help=(
-            "Read a fresh status_projection_cache_v0 snapshot before running "
-            "the full status collector. Misses and expired snapshots fall back "
-            "to the full collector."
-        ),
-    )
-    status_parser.add_argument(
-        "--write-projection-cache",
-        action="store_true",
-        help="Write the collected status projection to the cache after a full collection.",
-    )
-    status_parser.add_argument(
-        "--projection-cache-ttl-seconds",
-        type=int,
-        default=120,
-        help="Freshness window for --use-projection-cache. Defaults to 120 seconds.",
-    )
-
-    diagnose_parser = subparsers.add_parser(
-        "diagnose",
-        help="Build a LoopX diagnostic evidence packet for the user's agent to reason over.",
-    )
-    add_subcommand_format(diagnose_parser)
-    diagnose_parser.add_argument("--goal-id", help="Goal id to diagnose. Defaults to the first attention item.")
-    diagnose_parser.add_argument(
-        "--agent-id",
-        help=(
-            "Registered agent id for identity-scoped quota/todo projection. "
-            "Use this for multi-agent goals and heartbeat-driven diagnosis."
-        ),
-    )
-    diagnose_parser.add_argument(
-        "--available-capability",
-        dest="available_capabilities",
-        action="append",
-        help=(
-            "Declare a capability available in the current agent environment. "
-            "Repeat for multiple capabilities so diagnose uses the same runtime "
-            "envelope as quota should-run."
-        ),
-    )
-    diagnose_parser.add_argument(
-        "--scan-root",
-        default=default_public_scan_root(),
-        help="Public files to scan for obvious private material. Defaults to the LoopX install root.",
-    )
-    diagnose_parser.add_argument(
-        "--scan-path",
-        action="append",
-        default=[],
-        help="Specific public file or directory to scan. Repeatable. Overrides --scan-root when set.",
-    )
-    diagnose_parser.add_argument("--limit", type=int, default=5)
-
-    review_packet_parser = subparsers.add_parser(
-        "review-packet",
-        help=(
-            "Generate a CLI-visible Review Packet from the current status contract, "
-            "including agent-scoped evidence-log read hints when available."
-        ),
-    )
-    review_packet_parser.add_argument("--goal-id", required=True, help="Goal id to package for review or handoff.")
-    review_packet_parser.add_argument(
-        "--action-kind",
-        choices=["reward", "controller", "codex", "evidence", "health"],
-        help="Override inferred action kind. Defaults to the goal's current attention item.",
-    )
-    review_packet_parser.add_argument("--review-url", help="Optional dashboard review URL to include in the packet.")
-    review_packet_parser.add_argument(
-        "--scan-root",
-        default=default_public_scan_root(),
-        help="Public files to scan for obvious private material. Defaults to the LoopX install root.",
-    )
-    review_packet_parser.add_argument(
-        "--scan-path",
-        action="append",
-        default=[],
-        help="Specific public file or directory to scan. Repeatable. Overrides --scan-root when set.",
-    )
-    review_packet_parser.add_argument(
-        "--handoff-only",
-        action="store_true",
-        help="Print only the target project-agent handoff in markdown output; JSON output returns a minimized handoff payload.",
-    )
-    review_packet_parser.add_argument(
-        "--format",
-        dest="review_packet_format",
-        choices=["markdown", "json"],
-        help="Output format for review-packet. This mirrors the global --format flag and may appear after the subcommand.",
-    )
-    review_packet_parser.add_argument(
-        "--agent-id",
-        help="Registered agent id for adding read-only agent-member status to the review packet.",
-    )
-    review_packet_parser.add_argument(
-        "--available-capability",
-        dest="available_capabilities",
-        action="append",
-        help=(
-            "Declare a capability available in the current execution envelope. "
-            "Repeat for multiple capabilities; capability-gated review fields "
-            "remain absent by default."
-        ),
-    )
-    review_packet_parser.add_argument("--limit", type=int, default=5)
 
 
 def review_packet_handoff_only_payload(payload: dict[str, object]) -> dict[str, object]:

--- a/loopx/cli_commands/status_registration.py
+++ b/loopx/cli_commands/status_registration.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+
+def default_public_scan_root() -> str:
+    return str(Path(__file__).resolve().parents[2])
+
+
+def register_status_commands(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    check_parser = subparsers.add_parser(
+        "check",
+        help="Run a read-only contract and public/private boundary check.",
+    )
+    check_parser.add_argument(
+        "--scan-root",
+        default=".",
+        help="Public files to scan for obvious private material.",
+    )
+    check_parser.add_argument(
+        "--scan-path",
+        action="append",
+        default=[],
+        help=(
+            "Specific public file or directory to scan. Repeatable. "
+            "Overrides --scan-root when set."
+        ),
+    )
+    check_parser.add_argument("--limit", type=int, default=5)
+
+    status_parser = subparsers.add_parser(
+        "status",
+        help="Show a first-screen goal status and attention queue.",
+    )
+    add_subcommand_format(status_parser)
+    status_parser.add_argument(
+        "--scan-root",
+        default=default_public_scan_root(),
+        help=(
+            "Public files to scan for obvious private material. "
+            "Defaults to the LoopX install root."
+        ),
+    )
+    status_parser.add_argument(
+        "--scan-path",
+        action="append",
+        default=[],
+        help=(
+            "Specific public file or directory to scan. Repeatable. "
+            "Overrides --scan-root when set."
+        ),
+    )
+    status_parser.add_argument("--limit", type=int, default=5)
+    status_parser.add_argument(
+        "--goal-id",
+        help=(
+            "Optional goal id to focus the status projection. The default remains "
+            "the global dashboard/status view."
+        ),
+    )
+    status_parser.add_argument(
+        "--agent-id",
+        help=(
+            "Registered agent id for adding agent-lane next-action projection "
+            "to matching status queue items."
+        ),
+    )
+    status_parser.add_argument(
+        "--available-capability",
+        dest="available_capabilities",
+        action="append",
+        help=(
+            "Declare a capability available in the current execution envelope. "
+            "Repeat for multiple capabilities; capability-gated status fields "
+            "remain absent by default."
+        ),
+    )
+    status_parser.add_argument(
+        "--include-task-graph",
+        action="store_true",
+        help=(
+            "Include the optional task_graph_projection_v0 on status items. "
+            "Default status output keeps this graph on the cold path to stay "
+            "inside the dashboard hot-path budget."
+        ),
+    )
+    status_parser.add_argument(
+        "--use-projection-cache",
+        action="store_true",
+        help=(
+            "Read a fresh status_projection_cache_v0 snapshot before running "
+            "the full status collector. Misses and expired snapshots fall back "
+            "to the full collector."
+        ),
+    )
+    status_parser.add_argument(
+        "--write-projection-cache",
+        action="store_true",
+        help=(
+            "Write the collected status projection to the cache after a full "
+            "collection."
+        ),
+    )
+    status_parser.add_argument(
+        "--projection-cache-ttl-seconds",
+        type=int,
+        default=120,
+        help="Freshness window for --use-projection-cache. Defaults to 120 seconds.",
+    )
+
+    diagnose_parser = subparsers.add_parser(
+        "diagnose",
+        help=(
+            "Build a LoopX diagnostic evidence packet for the user's agent to "
+            "reason over."
+        ),
+    )
+    add_subcommand_format(diagnose_parser)
+    diagnose_parser.add_argument(
+        "--goal-id",
+        help="Goal id to diagnose. Defaults to the first attention item.",
+    )
+    diagnose_parser.add_argument(
+        "--agent-id",
+        help=(
+            "Registered agent id for identity-scoped quota/todo projection. "
+            "Use this for multi-agent goals and heartbeat-driven diagnosis."
+        ),
+    )
+    diagnose_parser.add_argument(
+        "--available-capability",
+        dest="available_capabilities",
+        action="append",
+        help=(
+            "Declare a capability available in the current agent environment. "
+            "Repeat for multiple capabilities so diagnose uses the same runtime "
+            "envelope as quota should-run."
+        ),
+    )
+    diagnose_parser.add_argument(
+        "--scan-root",
+        default=default_public_scan_root(),
+        help=(
+            "Public files to scan for obvious private material. "
+            "Defaults to the LoopX install root."
+        ),
+    )
+    diagnose_parser.add_argument(
+        "--scan-path",
+        action="append",
+        default=[],
+        help=(
+            "Specific public file or directory to scan. Repeatable. "
+            "Overrides --scan-root when set."
+        ),
+    )
+    diagnose_parser.add_argument("--limit", type=int, default=5)
+
+    review_packet_parser = subparsers.add_parser(
+        "review-packet",
+        help=(
+            "Generate a CLI-visible Review Packet from the current status contract, "
+            "including agent-scoped evidence-log read hints when available."
+        ),
+    )
+    review_packet_parser.add_argument(
+        "--goal-id",
+        required=True,
+        help="Goal id to package for review or handoff.",
+    )
+    review_packet_parser.add_argument(
+        "--action-kind",
+        choices=["reward", "controller", "codex", "evidence", "health"],
+        help=(
+            "Override inferred action kind. Defaults to the goal's current "
+            "attention item."
+        ),
+    )
+    review_packet_parser.add_argument(
+        "--review-url",
+        help="Optional dashboard review URL to include in the packet.",
+    )
+    review_packet_parser.add_argument(
+        "--scan-root",
+        default=default_public_scan_root(),
+        help=(
+            "Public files to scan for obvious private material. "
+            "Defaults to the LoopX install root."
+        ),
+    )
+    review_packet_parser.add_argument(
+        "--scan-path",
+        action="append",
+        default=[],
+        help=(
+            "Specific public file or directory to scan. Repeatable. "
+            "Overrides --scan-root when set."
+        ),
+    )
+    review_packet_parser.add_argument(
+        "--handoff-only",
+        action="store_true",
+        help=(
+            "Print only the target project-agent handoff in markdown output; "
+            "JSON output returns a minimized handoff payload."
+        ),
+    )
+    review_packet_parser.add_argument(
+        "--format",
+        dest="review_packet_format",
+        choices=["markdown", "json"],
+        help=(
+            "Output format for review-packet. This mirrors the global --format "
+            "flag and may appear after the subcommand."
+        ),
+    )
+    review_packet_parser.add_argument(
+        "--agent-id",
+        help=(
+            "Registered agent id for adding read-only agent-member status to "
+            "the review packet."
+        ),
+    )
+    review_packet_parser.add_argument(
+        "--available-capability",
+        dest="available_capabilities",
+        action="append",
+        help=(
+            "Declare a capability available in the current execution envelope. "
+            "Repeat for multiple capabilities; capability-gated review fields "
+            "remain absent by default."
+        ),
+    )
+    review_packet_parser.add_argument("--limit", type=int, default=5)

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -201,8 +201,16 @@ COMMAND_GROUPS: list[dict[str, object]] = [
                 "purpose": "Resolve a portable weekly profile, evaluate report triggers, and compose provider-neutral run receipts.",
             },
             {"command": "loopx auto-research", "purpose": "Project public-safe research frontiers."},
+            {
+                "command": "loopx agent-turn-recall",
+                "purpose": "Prepare goal-scoped memory guidance for one admitted autonomous agent turn.",
+            },
             {"command": "loopx multi-agent", "purpose": "Launch visible role-scoped Codex TUI agents."},
             {"command": "loopx canary", "purpose": "Plan or run catalog-informed smoke profiles."},
+            {
+                "command": "loopx promotion-readiness",
+                "purpose": "Record release-scoped canary readiness evidence in the shared runtime ledger.",
+            },
             {"command": "loopx benchmark", "purpose": "Use fixture-only benchmark runner skeletons by default."},
         ],
     },

--- a/man/loopx.1
+++ b/man/loopx.1
@@ -1,4 +1,4 @@
-.TH LOOPX 1 "" "LoopX 0.4.0" "User Commands"
+.TH LOOPX 1 "" "LoopX 0.4.1" "User Commands"
 .SH NAME
 loopx \- control-plane helper for long-running agent work
 .SH SYNOPSIS
@@ -186,11 +186,17 @@ Resolve a portable weekly profile, evaluate report triggers, and compose provide
 \fBloopx auto\-research\fR
 Project public\-safe research frontiers.
 .TP
+\fBloopx agent\-turn\-recall\fR
+Prepare goal\-scoped memory guidance for one admitted autonomous agent turn.
+.TP
 \fBloopx multi\-agent\fR
 Launch visible role\-scoped Codex TUI agents.
 .TP
 \fBloopx canary\fR
 Plan or run catalog\-informed smoke profiles.
+.TP
+\fBloopx promotion\-readiness\fR
+Record release\-scoped canary readiness evidence in the shared runtime ledger.
 .TP
 \fBloopx benchmark\fR
 Use fixture\-only benchmark runner skeletons by default.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.4.0"
+version = "0.4.1"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -7,7 +7,7 @@ import pytest
 
 from loopx.cli import build_parser, main, output_format, resolve_global_output_format
 from loopx.cli_commands import todo as todo_command
-from loopx.cli_commands.quota import _validate_quota_command_request
+from loopx.cli_commands.quota_request import validate_quota_command_request
 from loopx.cli_commands.todo_argument_validation import (
     validate_todo_add_options,
     validate_todo_archive_completed_options,
@@ -398,7 +398,7 @@ def test_quota_command_request_validation_preserves_exact_diagnostics(
     args.execute = execute
 
     with pytest.raises(ValueError) as exc_info:
-        _validate_quota_command_request(args)
+        validate_quota_command_request(args)
 
     assert str(exc_info.value) == expected
 


### PR DESCRIPTION
## Summary

- restore the current `main` release qualification path by keeping the grouped promotion canary non-writing and independent of optional dashboard dependencies
- align capability, help/manpage, status, quota, runtime-handoff, and goal-vision validation surfaces with the current contracts
- move cohesive quota request and status parser registration code into their owning CLI modules so hot files remain within the module-size budget
- bump the canonical package and generated manpage version to `0.4.1`

This PR is limited to the release-readiness blocker found on current `main`. It does not include any unmerged feature PR.

## Validation

- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: passed, 4 direct checks plus 18 risk-selected checks, no failures, warnings, or manual holds
- strict change-quality receipt: `cqr_8e73d2fb27b441c0c0e8`, exact 18-file scope, valid
- focused pytest: 113 passed
- local full pytest: 1914 passed and 2 skipped; 2 subprocess tests initially imported an unrelated editable checkout, then both passed when the release worktree was bound explicitly with `PYTHONPATH`
- Ruff 0.15.22 CI command: passed
- repository mypy command: passed
- CLI help/manpage smoke: passed
- promotion-readiness canary in non-writing dashboard-skip mode: passed
- catalog run E2E smoke: passed
- package/manpage version contract: `0.4.1`
- `git diff --check` and public/private boundary scan: passed

## Coverage And Holds

The local dashboard browser path was skipped because optional dashboard dependencies are not installed in the release worktree; the standalone dashboard readiness smoke remains a separate public check. GitHub Python Tests and Full Public Smokes are required before merge. No manual hold is being waived.

No credentials, local state, raw run logs, private source material, or absolute local paths are included.
