### PR TITLE
perf(cli): fast-path version output

### DIFF
--- a/loopx/entrypoint.py
+++ b/loopx/entrypoint.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import sys
+
+from . import __version__
+
+
+def main(argv: list[str] | None = None) -> int:
+	raw_argv = sys.argv[1:] if argv is None else list(argv)
+	if raw_argv == ["--version"]:
+		print(f"loopx {__version__}")
+		return 0
+
+	from .cli import main as cli_main
+
+	return cli_main(raw_argv)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ test = [
 ]
 
 [project.scripts]
-loopx = "loopx.cli:main"
+loopx = "loopx.entrypoint:main"
 loopx-lark-provider = "loopx.extensions.lark.provider:main"
 loopx-openviking-semantic-preference = "loopx.extensions.openviking_semantic_preference.provider:main"
 

--- a/tests/test_cli_entrypoint.py
+++ b/tests/test_cli_entrypoint.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_isolated_script(script: str) -> subprocess.CompletedProcess[str]:
+	return subprocess.run(
+		[sys.executable, "-c", script],
+		cwd=REPO_ROOT,
+		env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+		text=True,
+		capture_output=True,
+		check=False,
+	)
+
+
+def test_version_flag_skips_full_cli_import() -> None:
+	script = """
+import contextlib
+import io
+import sys
+
+from loopx.entrypoint import main
+
+output = io.StringIO()
+with contextlib.redirect_stdout(output):
+    exit_code = main(["--version"])
+
+assert exit_code == 0
+assert output.getvalue().startswith("loopx ")
+assert "loopx.cli" not in sys.modules
+"""
+	completed = run_isolated_script(script)
+
+	assert completed.returncode == 0, completed.stderr
+
+
+def test_other_arguments_delegate_to_full_cli() -> None:
+	script = """
+from loopx.entrypoint import main
+
+raise SystemExit(main(["--format", "json", "version"]))
+"""
+	completed = run_isolated_script(script)
+
+	assert completed.returncode == 0, completed.stderr
+	payload = json.loads(completed.stdout)
+	assert payload["schema_version"] == "loopx_version_v0"
+
+
+def test_console_script_uses_lightweight_entrypoint() -> None:
+	project = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+	assert project["project"]["scripts"]["loopx"] == "loopx.entrypoint:main"


### PR DESCRIPTION
## Summary

- add a lightweight console entrypoint for the exact `loopx --version` path
- defer importing `loopx.cli` until another command needs the full command graph
- point the packaged `loopx` console script at the lightweight entrypoint

## Why

The existing console script imported `loopx.cli` before argparse could handle
`--version`. That eagerly loaded every command and capability module for a static
version string. Local installed-package measurements improved from roughly
657–2117 ms to 18.8–19.5 ms across five runs.

All non-fast-path arguments still delegate to the existing `loopx.cli:main`
implementation, so parser and command behavior remain centralized.

## Validation

- `pytest -q`: 1919 passed, 2 skipped
- `pytest -q tests/test_cli_entrypoint.py`: 3 passed
- `ruff check loopx/entrypoint.py tests/test_cli_entrypoint.py`: passed
- `python examples/cli-version-command-modularization-smoke.py`: passed
- `loopx canary premerge --from-git-diff --tier standard`: passed, no manual holds
- clean package install verified both `loopx --version` and JSON `loopx version`
