### PR TITLE
fix(release): restore main full-public qualification

### DIFF
--- a/examples/bootstrap-command-pack-smoke.py
+++ b/examples/bootstrap-command-pack-smoke.py
@@ -201,16 +201,11 @@ def test_goal_text_invocation_plans_ranked_todos_before_activation() -> None:
         assert "avoid management-only filler" in plan_prompt
         assert "Every new todo starts with `[P0]`, `[P1]`, or `[P2]`" in plan_prompt
         assert "Preserve that exact order" in plan_prompt
-        assert "GitHub issue/PR fix" in plan_prompt
-        assert "loopx issue-fix workflow-plan" in plan_prompt
-        assert "loopx issue-fix feasibility" in plan_prompt
-        assert "loopx issue-fix pr-lifecycle" in plan_prompt
-        assert "loopx issue-fix reviewer-request" in plan_prompt
-        assert "only on confirmed permission denial" in plan_prompt
-        assert "request or fallback comment is visible" in plan_prompt
-        assert "Never create one monitor per PR" in plan_prompt
-        assert "one PR per message" in plan_prompt
-        assert "arbitrary external comments, PR creation, merge" in plan_prompt
+        assert "selected_capability_route.capability_id=issue-fix" in plan_prompt
+        assert "never infer it from goal text or URLs" in plan_prompt
+        assert "Run workflow-plan and feasibility before implementation" in plan_prompt
+        assert "admitted successor or no-follow-up" in plan_prompt
+        assert "reconcile PR lifecycle one PR per message" in plan_prompt
         assert "issue_fix_workflow_plan_template" in commands
         issue_fix_template = str(commands["issue_fix_workflow_plan_template"])
         assert "issue-fix workflow-plan" in issue_fix_template
@@ -245,15 +240,13 @@ def test_goal_text_invocation_plans_ranked_todos_before_activation() -> None:
         assert "--progress-scope agent_lane" in refresh_command
         assert "--health-check" not in refresh_command
         assert "Same-priority items use that write order as the tie-breaker" in str(payload["message"])
-        assert "preview the issue-fix route:" in str(payload["message"])
+        assert "preview the issue-fix route:" not in str(payload["message"])
         assert "preview the issue-fix route before todo writeback" not in str(
             payload["message"]
         )
-        assert "PR lifecycle monitor" in str(payload["message"])
-        assert "default top requestable non-author reviewer" in str(payload["message"])
         domain_routes = goal_start["domain_route_hints"]
-        assert domain_routes["issue_fix_workflow"]["when"].startswith(
-            "goal text explicitly asks"
+        assert domain_routes["issue_fix_workflow"]["when"] == (
+            "selected_capability_route.capability_id is explicitly set to issue-fix"
         )
         assert "workflow-plan" in domain_routes["issue_fix_workflow"]["preview_command"]
         assert "feasibility" in domain_routes["issue_fix_workflow"]["decision_command"]

--- a/examples/loopx-project-skill-goal-text-precedence-smoke.py
+++ b/examples/loopx-project-skill-goal-text-precedence-smoke.py
@@ -21,8 +21,9 @@ def main() -> int:
     require("Recognized project-local goal-start command:" in text, "goal-start heading missing")
     require("- `/loopx <goal text>`" in text, "goal-text command missing")
     require("- `/loopx`\n" not in text, "bare /loopx should not be listed as project-local fallback")
-    require("If there is any non-whitespace text after `/loopx`, it is goal text." in text, "goal text precedence missing")
-    require("do not downgrade the request into a status or inspection turn" in compact, "downgrade guard missing")
+    require("Otherwise every non-whitespace character after `/loopx` is goal text." in compact, "goal text precedence missing")
+    require("Never infer a product capability route" in text, "implicit capability route guard missing")
+    require("Do not downgrade either form into a status or inspection turn." in compact, "downgrade guard missing")
     require("Bare `/loopx` is read/status-first" not in text, "bare /loopx status-first branch should not steer this skill")
     print("loopx-project-skill-goal-text-precedence-smoke ok")
     return 0

--- a/loopx/cli_commands/starter_bootstrap_registration.py
+++ b/loopx/cli_commands/starter_bootstrap_registration.py
@@ -13,6 +13,17 @@ from ..project_prompt import (
 )
 
 
+def _add_capability_route_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--capability-route",
+        choices=START_GOAL_CAPABILITY_ROUTES,
+        help=(
+            "Explicit product capability route for this goal start. Goal text never "
+            "selects a capability route."
+        ),
+    )
+
+
 def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) -> None:
     agent_onboard_parser = subparsers.add_parser(
         "agent-onboard",
@@ -79,14 +90,7 @@ def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) 
         action="append",
         help="Capability available in this host loop. Repeat for multiple capabilities.",
     )
-    bootstrap_command_pack_parser.add_argument(
-        "--capability-route",
-        choices=START_GOAL_CAPABILITY_ROUTES,
-        help=(
-            "Explicit product capability route for this goal start. Goal text never "
-            "selects a capability route."
-        ),
-    )
+    _add_capability_route_argument(bootstrap_command_pack_parser)
     bootstrap_command_pack_parser.add_argument(
         "--goal-text",
         help=(
@@ -136,14 +140,7 @@ def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) 
         action="append",
         help="Capability available in this host loop. Repeat for multiple capabilities.",
     )
-    start_goal_parser.add_argument(
-        "--capability-route",
-        choices=START_GOAL_CAPABILITY_ROUTES,
-        help=(
-            "Explicit product capability route for this goal start. Goal text never "
-            "selects a capability route."
-        ),
-    )
+    _add_capability_route_argument(start_goal_parser)
     start_goal_parser.add_argument(
         "--goal-text",
         required=True,


### PR DESCRIPTION
## Summary

- align the durable bootstrap smoke with explicit issue-fix route selection
- align the loopx-project skill smoke with the current goal-text precedence wording
- reuse one argparse owner for the identical `--capability-route` option

## Why

After #2749 merged, Full Public Smokes found three deterministic regressions. Two smokes still asserted the retired implicit issue-fix route, and the duplicated CLI option registration exceeded its module ownership budget by two lines.

## Validation

- three previously failing Full Public smokes: passed
- focused pytest: 49 passed
- Ruff: passed
- mypy: passed
- public boundary: 3 files clean
- change-quality receipt: `cqr_73d1251b024fe8d4b780`, exact scope valid
- `loopx canary premerge --from-git-diff --goal-id loopx-meta --timeout-seconds 300`: 6/6 passed, no warnings or holds

The onboarding smoke exceeded the initial 180-second local premerge limit, then passed independently and inside the authoritative 300-second rerun. No runtime behavior, permission boundary, or release claim changes in this PR.
