### PR TITLE
fix(opencode): bump opencode-goal-plugin pin to 0.7.0 for the goal bridge

### DIFF
--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -22,7 +22,7 @@ EXISTING_LOOPX_CAPABILITY_SKILL_SIGNATURES = (
 )
 OPENCODE_GOAL_DEPENDENCIES = {
     "@opencode-ai/plugin": ">=1.17.15 <2",
-    "opencode-goal-plugin": "0.6.5",
+    "opencode-goal-plugin": "0.7.0",
 }
 
 

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -772,7 +772,7 @@ fi
 # loopx OpenCode goal bridge: OPT-IN, OFF by default. Static OpenCode commands
 # remain part of the ordinary slash-command install; this flag additionally
 # provisions the plugin, runtime, and pinned dependencies. The bridge wraps
-# opencode-goal-plugin@0.6.5 and gates idle continuation plus timer wakes
+# opencode-goal-plugin@0.7.0 and gates idle continuation plus timer wakes
 # through LoopX quota should-run. Install manually with:
 #   loopx slash-commands --install --surface opencode --with-goal-bridge
 install_opencode="${LOOPX_INSTALL_OPENCODE:-0}"

--- a/tests/test_slash_command_install.py
+++ b/tests/test_slash_command_install.py
@@ -206,7 +206,7 @@ def test_opencode_install_writes_commands_bridge_and_pinned_dependencies(
     assert "quota" in runtime_text
     assert "terminal_no_followup" in runtime_text
     package_text = package.read_text(encoding="utf-8")
-    assert '"opencode-goal-plugin": "0.6.5"' in package_text
+    assert '"opencode-goal-plugin": "0.7.0"' in package_text
     assert '"@opencode-ai/plugin": ">=1.17.15 <2"' in package_text
     assert _row(payload, "opencode_goal_bridge")["status"] == "created"
 


### PR DESCRIPTION
## Summary

Bump the pinned `opencode-goal-plugin` dependency for the OpenCode goal bridge from `0.6.5` to `0.7.0` in `OPENCODE_GOAL_DEPENDENCIES` (`loopx/slash_command_install.py`), update the matching install-test assertion, and align the `scripts/install-local.sh` bridge comment with the new pin.

## Why 0.7.0

The 0.6.6-0.7.0 line adds:

- **0.6.6** per-session state sharding (independent sessions in one project run/recover concurrently, automatic migration)
- **0.6.7** deterministic `/goal` command handling and complete 11-tool registration on clean installs (`@opencode-ai/plugin` is no longer a runtime dependency of the plugin)
- **0.6.8** same-session multi-process lease safety (`session_owned_elsewhere`, passive-mode contender, immutable per-owner claims)
- **0.7.0** lifecycle visibility (`/goal status` reports active/paused/blocked, `lifecycleMessages`/`lifecycleMessenger` options), hardened terminal persistence/rollback

## Compatibility verification

Verified against the published 0.7.0 tarball that every API the LoopX goal bridge consumes is unchanged:

- `GoalPlugin(context, { auditor })` factory signature
- `auditor` completion-audit option (used for LoopX terminal no-follow-up validation)
- All 11 goal tools plus `no_active_goal` error code
- Hooks: `event` (session.idle), `chat.message`, `command.execute.before`, `config`, `dispose`

The `@opencode-ai/plugin` pin range is retained because `loopx-goal.js` imports its `tool` helper.

## Local validation

- `pytest tests/test_slash_command_install.py` — 18 passed
- Full suite: 1917 passed, 3 skipped (one pre-existing environment-only failure in `test_extension_scaffold.py` also fails on `main`; requires venv creation unavailable in this environment)
- Canary install + `loopx slash-commands --install --surface opencode --with-goal-bridge` writes `opencode-goal-plugin: "0.7.0"` into the config `package.json`
- End-to-end smoke on real OpenCode host: `loopx_goal_activate` succeeds and `goal_status` reports `Completion audit: custom completion auditor` (LoopX auditor hook accepted by 0.7.0)
- Bridge runtime suite: `node --test tests/opencode_goal_bridge_runtime.test.mjs` — 16 passed

## Notes

- Removed a stale in-progress cherry-pick state (`git cherry-pick --quit`): its 3 target commits were pre-0.7.0 duplicates of work already merged into `main` via #2389, and would have reverted the current opt-in bridge design.
- `scripts/install-local.sh` comment referenced `opencode-goal-plugin@0.6.5`; aligned to `0.7.0`.