### PR TITLE
fix(quota): reload unchanged monitor writeback state

### DIFF
--- a/loopx/control_plane/quota/monitor_poll.py
+++ b/loopx/control_plane/quota/monitor_poll.py
@@ -274,7 +274,7 @@ def _reload_status_after_monitor_writeback(
         return deepcopy(status_payload), {
             "schema_version": "monitor_poll_status_reload_warning_v0",
             "reason": (
-                "material monitor writeback persisted, but a fresh status "
+                "monitor todo writeback persisted, but a fresh status "
                 "projection could not be collected"
             ),
             "error_type": type(exc).__name__,
@@ -659,7 +659,7 @@ def record_quota_monitor_poll_for_decision(
 
     after_status = deepcopy(status_payload)
     status_reload_warning = None
-    if execute and material_change:
+    if execute and todo_writeback:
         after_status, status_reload_warning = _reload_status_after_monitor_writeback(
             status_payload,
             status_reloader=status_reloader,

--- a/tests/control_plane/test_monitor_followthrough_contract.py
+++ b/tests/control_plane/test_monitor_followthrough_contract.py
@@ -16,7 +16,7 @@ from loopx.control_plane.testing.canary_harness import (
     write_fixture_registry,
 )
 from loopx.control_plane.todos.contract import resolve_next_user_task_class
-from loopx.quota import record_quota_monitor_poll
+from loopx.quota import build_quota_should_run, record_quota_monitor_poll
 from loopx.status import collect_status
 from loopx.todos import add_goal_todo, list_goal_todos, update_goal_todo
 
@@ -174,6 +174,64 @@ def test_material_poll_reloads_status_and_projects_declared_successor(
     assert result["after"]["selected_todo"]["todo_id"] == successor["todo_id"]
     assert result["after"]["effective_action"] == "normal_run"
     assert "Validate the exact merged release head." in state.read_text(encoding="utf-8")
+
+
+def test_unchanged_due_poll_reloads_status_before_followthrough_decision(
+    tmp_path: Path,
+) -> None:
+    registry, runtime, _state = _write_fixture(tmp_path)
+    monitor = _add_monitor(
+        registry,
+        text="Poll a public release target.",
+        target_key="public-release:42",
+        next_due_at="2000-01-01T00:00:00+00:00",
+    )
+    status_payload = collect_status(
+        registry_path=registry,
+        runtime_root_override=str(runtime),
+        scan_roots=[Path(__file__).resolve()],
+        limit=20,
+    )
+    reloaded_status: dict | None = None
+
+    def reload_status() -> dict:
+        nonlocal reloaded_status
+        reloaded_status = collect_status(
+            registry_path=registry,
+            runtime_root_override=str(runtime),
+            scan_roots=[Path(__file__).resolve()],
+            limit=20,
+        )
+        return reloaded_status
+
+    result = record_quota_monitor_poll(
+        status_payload,
+        goal_id=GOAL_ID,
+        registry_path=registry,
+        execute=True,
+        source="heartbeat",
+        agent_id=AGENT_ID,
+        todo_id=monitor["todo_id"],
+        target_key="public-release:42",
+        result_hash="unchanged-42",
+        status_reloader=reload_status,
+    )
+
+    assert result["todo_writeback"]["material_change"] is False
+    assert reloaded_status is not None
+    fresh = build_quota_should_run(
+        reloaded_status,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+    assert result["after"]["should_run"] == fresh["should_run"]
+    assert result["after"]["effective_action"] == fresh["effective_action"]
+    assert result["after"].get("selected_todo") == fresh.get("selected_todo")
+    assert result["decision_summary"]["after"]["should_run"] == fresh["should_run"]
+    assert (
+        result["decision_summary"]["after"]["effective_action"]
+        == fresh["effective_action"]
+    )
 
 
 def test_material_poll_user_action_does_not_block_existing_advancement(


### PR DESCRIPTION
## Summary
- reload projected Goal status after every persisted monitor Todo writeback
- keep post-poll `after` and `decision_summary.after` aligned with the newly persisted `next_due_at`
- add regression coverage for an unchanged due monitor poll

## Validation
- `uv run pytest -q tests/control_plane/test_monitor_followthrough_contract.py tests/control_plane/test_monitor_poll_cli_projection.py tests/control_plane/test_monitor_replan_agent_scope.py tests/control_plane/test_goal_vision_blocked_successor.py`
- `uv run python examples/control_plane/monitor-poll-writeback-smoke.py`
- `uv run ruff check loopx/control_plane/quota/monitor_poll.py tests/control_plane/test_monitor_followthrough_contract.py`
- `uv run loopx --format json canary premerge --from-git-diff` (13/13 selected checks passed, no failures, warnings, or manual holds)

## Merge hold
Runtime control-plane behavior change; leave for independent review.