### PR TITLE
fix(quota): make a paused Goal an authoritative terminal decision (supersedes #2447)

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -31,8 +31,19 @@ Examples:
   minute-slots.
 - `0.3`: 30% duty cycle, roughly 7.2 hours per day or 30% of scheduling
   minute-slots.
-- `0`: compute-paused. The goal remains visible but should not receive
-  automatic Codex turns.
+- `0`: compute-paused. This is a **Goal-level hard pause**: the goal stays
+  visible but receives no automatic Codex turns, and `quota should-run` returns
+  a single authoritative paused contract. Because the pause is a typed terminal
+  decision evaluated before any selector lane is built, no capability-bridge,
+  workspace, replan, monitor, or inbox lane can leave a contradicting execution
+  signal underneath it (`should_run=false`, all automatic permissions false,
+  `DONT_NOTIFY`, scheduler never `run_now`, no quota spend). Set it with
+  `loopx configure-goal --quota-compute 0`; negative values are rejected.
+
+  This is different from a single agent's `monitor_only` work mode.
+  `quota.compute=0` pauses the **whole Goal** for every agent and every lane;
+  `monitor_only` is a per-agent lane state where one agent still runs bounded
+  read-only monitor polls while the Goal itself remains active for other work.
 
 The number can be interpreted as either a duty cycle or a relative weight,
 depending on the executor:

--- a/loopx/cli_commands/registry_admin.py
+++ b/loopx/cli_commands/registry_admin.py
@@ -248,7 +248,7 @@ def register_registry_admin_commands(subparsers: argparse._SubParsersAction) -> 
         ),
     )
     configure_goal_parser.add_argument("--goal-id", required=True, help="Goal id to configure.")
-    configure_goal_parser.add_argument("--quota-compute", type=float, help="Per-goal quota compute multiplier.")
+    configure_goal_parser.add_argument("--quota-compute", type=float, help="Per-goal quota compute multiplier. 0 hard-pauses the whole Goal (all automatic agent turns stop); negative values are rejected.")
     configure_goal_parser.add_argument("--quota-window-hours", type=float, help="Quota rolling window in hours.")
     configure_goal_parser.add_argument(
         "--self-repair-enabled",

--- a/loopx/configure_goal.py
+++ b/loopx/configure_goal.py
@@ -154,6 +154,14 @@ def _positive_number(value: float | None, *, field: str) -> float | None:
     return float(value)
 
 
+def _non_negative_number(value: float | None, *, field: str) -> float | None:
+    if value is None:
+        return None
+    if value < 0:
+        raise ValueError(f"{field} must be greater than or equal to 0")
+    return float(value)
+
+
 def _non_negative_int(value: int | None, *, field: str) -> int | None:
     if value is None:
         return None
@@ -548,7 +556,7 @@ def configure_goal(
                 + ", ".join(EXPLORE_HARNESS_PROFILES)
             )
 
-    quota_compute = _positive_number(quota_compute, field="quota_compute")
+    quota_compute = _non_negative_number(quota_compute, field="quota_compute")
     quota_window_hours = _positive_number(quota_window_hours, field="quota_window_hours")
     max_children = _non_negative_int(max_children, field="max_children")
     allowed_domains = _clean_domains(allowed_domains)

--- a/loopx/control_plane/scheduler/automation_liveness.py
+++ b/loopx/control_plane/scheduler/automation_liveness.py
@@ -36,6 +36,20 @@ def build_automation_liveness(payload: dict[str, Any]) -> dict[str, Any]:
             "stuck for two more eligible turns"
         ),
     }
+    if recommended_mode == "quota_paused":
+        return {
+            **base,
+            "keep_active": False,
+            "pause_allowed": True,
+            "pause_policy": (
+                "pause or delete the recurring automation now; only an explicit "
+                "quota resume with quota.compute > 0 should recreate or resume it"
+            ),
+            "automation_action": "stop_quota_paused",
+            "reason": "Goal-level compute quota is paused",
+            "next_trigger": "explicit quota resume with quota.compute > 0",
+            "spend_policy": "no quota spend for paused automation shutdown",
+        }
     if effective_action == "agent_monitor_only":
         return {
             **base,

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -1023,6 +1023,48 @@ def build_scheduler_hint(
         }
 
     heartbeat_recommendation = _dict_or_empty(payload.get("heartbeat_recommendation"))
+    if heartbeat_recommendation.get("recommended_mode") == "quota_paused":
+        return apply_scheduler_execution_context(
+            {
+                "schema_version": SCHEDULER_HINT_SCHEMA_VERSION,
+                "source": "quota.should-run",
+                "action": "stop_until_explicit_resume",
+                "cadence_class": "quota_paused",
+                "reason_code": "quota_paused",
+                "reason": (
+                    "Goal-level compute quota is paused; recurring host automation "
+                    "must stop until quota.compute is explicitly raised above 0"
+                ),
+                "spend_policy": "no quota spend for paused automation shutdown",
+                "codex_app": {
+                    "apply": "pause_or_delete_current_heartbeat_if_possible",
+                    "host_tool": "automation_update",
+                    "host_action": "pause_or_delete_current_heartbeat",
+                    "host_action_required": True,
+                    "attempt_limit": 1,
+                    "verify_host_result": True,
+                    "ack_required": False,
+                    "resume_trigger": "explicit quota resume with quota.compute > 0",
+                    "no_spend_for_host_action": True,
+                },
+                "unchanged_poll": {
+                    "local_scheduler": "stop",
+                    "codex_cli_tui": "exit",
+                    CODEX_APP_SSH_GOAL_RUNTIME_KEY: "complete_host_goal",
+                    "claude_code_loop": "stop",
+                    "final_quota_replan_check_enabled": False,
+                    "spend_policy": "no quota spend while the Goal is paused",
+                },
+                "unchanged_identity_keys": list(
+                    _scheduler_identity_keys(
+                        cadence_class="quota_paused",
+                        execution_context=execution_context,
+                    )
+                ),
+            },
+            execution_context,
+        )
+
     execution_obligation = _dict_or_empty(payload.get("execution_obligation"))
     automation_liveness = _dict_or_empty(payload.get("automation_liveness"))
     spend_policy = (

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -2458,6 +2458,7 @@ def _build_quota_paused_should_run_payload(
     requested_agent_id: str | None,
     item: dict[str, Any],
     plan: dict[str, Any],
+    goal_health_ok: bool,
     include_scheduler_detail: bool,
     codex_app_current_rrule: Any,
     resolved_scheduler_context: SchedulerExecutionContextResolution,
@@ -2491,8 +2492,8 @@ def _build_quota_paused_should_run_payload(
         heartbeat_recommendation=heartbeat_recommendation,
     )
     payload: dict[str, Any] = {
-        "ok": True,
-        "status_health_ok": True,
+        "ok": goal_health_ok,
+        "status_health_ok": goal_health_ok,
         "mode": "should-run",
         "goal_id": safe_goal_id,
         "decision": "skip",
@@ -2592,6 +2593,7 @@ def build_quota_should_run(
                 requested_agent_id=agent_id,
                 item=item,
                 plan=plan,
+                goal_health_ok=goal_health_ok,
                 include_scheduler_detail=include_scheduler_detail,
                 codex_app_current_rrule=codex_app_current_rrule,
                 resolved_scheduler_context=resolved_scheduler_context,

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -2432,6 +2432,115 @@ def _build_quota_should_run_payload(
     return payload
 
 
+QUOTA_PAUSED_MODE = "quota_paused"
+
+
+def _quota_item_is_paused(item: dict[str, Any]) -> bool:
+    """Return True when a plan item carries a Goal-level hard pause.
+
+    A paused Goal (`quota.compute<=0`) is a typed terminal decision: it is
+    evaluated before the selector builds any capability, workspace, replan,
+    monitor, or inbox candidate, so no lane can emit a contradicting execution
+    signal underneath the pause.
+    """
+
+    quota = item.get("quota") if isinstance(item.get("quota"), dict) else {}
+    if str(quota.get("state") or "") == "paused":
+        return True
+    compute = quota.get("compute")
+    return isinstance(compute, (int, float)) and not isinstance(compute, bool) and compute <= 0
+
+
+def _build_quota_paused_should_run_payload(
+    status_payload: dict[str, Any],
+    *,
+    safe_goal_id: str,
+    requested_agent_id: str | None,
+    item: dict[str, Any],
+    plan: dict[str, Any],
+    include_scheduler_detail: bool,
+    codex_app_current_rrule: Any,
+    resolved_scheduler_context: SchedulerExecutionContextResolution,
+) -> dict[str, Any]:
+    """Project one canonical paused contract with no contradicting lane authority.
+
+    The whole Goal is hard-paused, so every automatic authority field resolves to
+    the same terminal decision: `should_run=false`, all delivery/repair
+    permissions false, `DONT_NOTIFY`, no quota spend, and a scheduler cadence that
+    is never `run_now`. No capability_gate, workspace_guard, replan, monitor, or
+    inbox candidate is constructed here.
+    """
+
+    quota = item.get("quota") if isinstance(item.get("quota"), dict) else {}
+    quota = {**quota, "state": "paused"}
+    reason = str(
+        quota.get("reason")
+        or "compute quota is 0; the whole Goal is hard-paused and automatic agent turns stop"
+    )
+    agent_identity = build_quota_agent_identity(item, agent_id=requested_agent_id)
+    heartbeat_recommendation = {
+        "source": "quota.should-run",
+        "recommended_mode": QUOTA_PAUSED_MODE,
+        "notify": "DONT_NOTIFY",
+        "reason": reason,
+        "spend_policy": "do not append quota spend while the Goal is paused",
+    }
+    execution_obligation = _execution_obligation(
+        should_run=False,
+        effective_action="quota_skip",
+        heartbeat_recommendation=heartbeat_recommendation,
+    )
+    payload: dict[str, Any] = {
+        "ok": True,
+        "status_health_ok": True,
+        "mode": "should-run",
+        "goal_id": safe_goal_id,
+        "decision": "skip",
+        "should_run": False,
+        "normal_delivery_allowed": False,
+        "recovery_delivery_allowed": False,
+        "self_repair_allowed": False,
+        "capability_repair_allowed": False,
+        "workspace_repair_allowed": False,
+        "effective_action": "quota_skip",
+        "actionable_by_codex": False,
+        "reason": reason,
+        "quota": quota,
+        "state": "paused",
+        "safe_bypass_allowed": False,
+        "waiting_on": item.get("waiting_on"),
+        "status": item.get("status"),
+        "lifecycle_phase": item.get("lifecycle_phase"),
+        "lifecycle_flags": item.get("lifecycle_flags"),
+        "source": item.get("source"),
+        "recommended_action": reason,
+        "requires_user_action": False,
+        "heartbeat_recommendation": heartbeat_recommendation,
+        "execution_obligation": execution_obligation,
+        "plan_summary": plan.get("summary"),
+        "todo_write_hint": build_todo_write_hint(safe_goal_id),
+    }
+    payload = _attach_agent_identity_contracts(
+        payload=payload,
+        agent_identity=agent_identity,
+    )
+    payload["automation_liveness"] = build_automation_liveness(payload)
+    payload["interaction_contract"] = build_interaction_contract(
+        payload,
+        available_capabilities=None,
+        scheduler_execution_context=resolved_scheduler_context,
+    )
+    payload["scheduler_hint"] = _scheduler_hint(
+        payload,
+        include_detail=include_scheduler_detail,
+        available_capabilities=None,
+        codex_app_current_rrule=codex_app_current_rrule,
+        scheduler_execution_context=resolved_scheduler_context,
+    )
+    payload["protocol_action_packet"] = build_protocol_action_packet(payload)
+    return payload
+
+
 def build_quota_should_run(
     status_payload: dict[str, Any],
     *,
@@ -2476,6 +2585,17 @@ def build_quota_should_run(
         None,
     )
     if item:
+        if _quota_item_is_paused(item):
+            return _build_quota_paused_should_run_payload(
+                status_payload,
+                safe_goal_id=safe_goal_id,
+                requested_agent_id=agent_id,
+                item=item,
+                plan=plan,
+                include_scheduler_detail=include_scheduler_detail,
+                codex_app_current_rrule=codex_app_current_rrule,
+                resolved_scheduler_context=resolved_scheduler_context,
+            )
         prepared = _prepare_quota_should_run_item(
             status_payload,
             safe_goal_id=safe_goal_id,

--- a/tests/control_plane/test_quota_paused_precedence.py
+++ b/tests/control_plane/test_quota_paused_precedence.py
@@ -8,6 +8,8 @@ import pytest
 from loopx.configure_goal import configure_goal
 from loopx.control_plane.scheduler.execution_context import (
     GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT,
+    SchedulerRuntimeProfile,
+    scheduler_execution_context_for_runtime_profile,
 )
 from loopx.control_plane.testing.quota_fixtures import (
     quota_status_payload,
@@ -82,7 +84,11 @@ def _assert_authoritatively_paused(payload: dict) -> None:
     assert payload["heartbeat_recommendation"]["notify"] == "DONT_NOTIFY"
     assert payload["execution_obligation"]["must_attempt_work"] is False
     assert payload["interaction_contract"]["mode"] == "skip"
-    assert payload["scheduler_hint"]["action"] != "run_now"
+    assert payload["automation_liveness"]["keep_active"] is False
+    assert payload["automation_liveness"]["pause_allowed"] is True
+    assert payload["automation_liveness"]["automation_action"] == "stop_quota_paused"
+    assert payload["scheduler_hint"]["action"] == "stop_until_explicit_resume"
+    assert payload["scheduler_hint"]["cadence_class"] == "quota_paused"
     # No selector lane should have been constructed under the pause.
     for lane_key in (
         "capability_gate",
@@ -132,6 +138,51 @@ def test_paused_quota_preempts_workspace_repair(
 
     _assert_authoritatively_paused(payload)
     assert "workspace_guard" not in payload
+
+
+def test_paused_quota_stops_codex_app_heartbeat_until_explicit_resume() -> None:
+    payload = build_quota_should_run(
+        _paused_status(),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        codex_app_current_rrule="FREQ=MINUTELY;INTERVAL=30",
+        scheduler_execution_context=scheduler_execution_context_for_runtime_profile(
+            SchedulerRuntimeProfile.CODEX_APP_HEARTBEAT
+        ),
+    )
+
+    _assert_authoritatively_paused(payload)
+    liveness = payload["automation_liveness"]
+    assert liveness["next_trigger"] == "explicit quota resume with quota.compute > 0"
+    assert liveness["spend_policy"] == "no quota spend for paused automation shutdown"
+
+    scheduler = payload["scheduler_hint"]
+    assert scheduler["reason_code"] == "quota_paused"
+    codex_app = scheduler["codex_app"]
+    assert codex_app["applicability"] == "applicable"
+    assert codex_app["apply"] == "pause_or_delete_current_heartbeat_if_possible"
+    assert codex_app["host_action"] == "pause_or_delete_current_heartbeat"
+    assert codex_app["host_action_required"] is True
+    assert codex_app["ack_required"] is False
+    assert codex_app["resume_trigger"] == "explicit quota resume with quota.compute > 0"
+    assert "recommended_rrule" not in codex_app
+
+
+def test_paused_quota_preserves_unhealthy_status_fact() -> None:
+    status_payload = _paused_status()
+    status_payload["contract"] = {"error_diagnostics": []}
+    status_payload["global_registry"] = {"ok": False}
+
+    payload = build_quota_should_run(
+        status_payload,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        scheduler_execution_context=GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT,
+    )
+
+    _assert_authoritatively_paused(payload)
+    assert payload["ok"] is False
+    assert payload["status_health_ok"] is False
 
 
 def _paused_status_with_due_monitor() -> dict:

--- a/tests/control_plane/test_quota_paused_precedence.py
+++ b/tests/control_plane/test_quota_paused_precedence.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from loopx.configure_goal import configure_goal
+from loopx.control_plane.scheduler.execution_context import (
+    GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT,
+)
+from loopx.control_plane.testing.quota_fixtures import (
+    quota_status_payload,
+    quota_todo_item,
+)
+from loopx.quota import build_quota_should_run
+
+
+GOAL_ID = "paused-quota-precedence-fixture"
+AGENT_ID = "codex-paused-agent"
+
+
+def _paused_status(*, required_capabilities: list[str] | None = None) -> dict:
+    todo = quota_todo_item(
+        todo_id="todo_paused_delivery",
+        title="Advance paused delivery.",
+        claimed_by=AGENT_ID,
+        required_capabilities=required_capabilities or [],
+    )
+    return quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        recommended_action="Advance the delivery.",
+        agent_todo_items=[todo],
+        quota_state="paused",
+        quota_extra={"compute": 0, "reason": "paused fixture"},
+        coordination={
+            "agent_model": "peer_v1",
+            "registered_agents": [AGENT_ID],
+        },
+    )
+
+
+def _find_execution_signals(obj: object, path: str = "") -> list[tuple[str, object]]:
+    """Collect any nested field that would assert executable work or an active run.
+
+    A hard-paused Goal must not carry a contradicting execution signal anywhere in
+    the payload: no lane may leave `must_attempt_work=true`, no channel may allow
+    delivery, and no scheduler field may request `run_now`.
+    """
+
+    hits: list[tuple[str, object]] = []
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            here = f"{path}/{key}"
+            if key == "must_attempt_work" and value is True:
+                hits.append((here, value))
+            if key == "delivery_allowed" and value is True:
+                hits.append((here, value))
+            if key in {"action", "recommended_mode", "mode"} and value == "run_now":
+                hits.append((here, value))
+            hits.extend(_find_execution_signals(value, here))
+    elif isinstance(obj, list):
+        for index, value in enumerate(obj):
+            hits.extend(_find_execution_signals(value, f"{path}[{index}]"))
+    return hits
+
+
+def _assert_authoritatively_paused(payload: dict) -> None:
+    assert payload["state"] == "paused"
+    assert payload["decision"] == "skip"
+    assert payload["should_run"] is False
+    assert payload["effective_action"] == "quota_skip"
+    assert payload["actionable_by_codex"] is False
+    assert payload["normal_delivery_allowed"] is False
+    assert payload["recovery_delivery_allowed"] is False
+    assert payload["self_repair_allowed"] is False
+    assert payload["capability_repair_allowed"] is False
+    assert payload["workspace_repair_allowed"] is False
+    assert payload["requires_user_action"] is False
+    assert payload["heartbeat_recommendation"]["recommended_mode"] == "quota_paused"
+    assert payload["heartbeat_recommendation"]["notify"] == "DONT_NOTIFY"
+    assert payload["execution_obligation"]["must_attempt_work"] is False
+    assert payload["interaction_contract"]["mode"] == "skip"
+    assert payload["scheduler_hint"]["action"] != "run_now"
+    # No selector lane should have been constructed under the pause.
+    for lane_key in (
+        "capability_gate",
+        "workspace_guard",
+        "work_lane_contract",
+        "autonomous_replan_obligation",
+        "autonomous_replan_decision",
+        "scoped_user_gate_fallback",
+    ):
+        assert lane_key not in payload, f"paused payload leaked lane `{lane_key}`"
+    # And nothing nested may contradict the pause with an execution signal.
+    contradictions = _find_execution_signals(payload)
+    assert contradictions == [], f"paused payload has execution signals: {contradictions}"
+
+
+def test_paused_quota_preempts_capability_bridge_repair() -> None:
+    payload = build_quota_should_run(
+        _paused_status(required_capabilities=["network"]),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        available_capabilities=[],
+        scheduler_execution_context=GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT,
+    )
+
+    _assert_authoritatively_paused(payload)
+    assert "capability_gate" not in payload
+
+
+def test_paused_quota_preempts_workspace_repair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "loopx.quota.build_agent_workspace_guard",
+        lambda *args, **kwargs: {
+            "schema_version": "agent_workspace_guard_v1",
+            "reason": "workspace fixture requires relocation",
+            "required_action": "rerun from the assigned worktree",
+        },
+    )
+
+    payload = build_quota_should_run(
+        _paused_status(),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        scheduler_execution_context=GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT,
+    )
+
+    _assert_authoritatively_paused(payload)
+    assert "workspace_guard" not in payload
+
+
+def _paused_status_with_due_monitor() -> dict:
+    monitor_todo = quota_todo_item(
+        todo_id="todo_paused_monitor",
+        title="Poll the paused monitor.",
+        task_class="monitor_task",
+        claimed_by=AGENT_ID,
+        next_due_at="2000-01-01T00:00:00+00:00",
+        expires_at="2000-01-02T00:00:00+00:00",
+    )
+    return quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        recommended_action="Poll the monitor.",
+        agent_todo_items=[monitor_todo],
+        quota_state="paused",
+        quota_extra={"compute": 0, "reason": "paused fixture"},
+        coordination={"agent_model": "peer_v1", "registered_agents": [AGENT_ID]},
+    )
+
+
+def _paused_status_with_user_gate() -> dict:
+    gate_todo = quota_todo_item(
+        todo_id="todo_paused_user_gate",
+        role="user",
+        title="Owner must approve the paused delivery.",
+        blocks_agent=AGENT_ID,
+    )
+    delivery_todo = quota_todo_item(
+        todo_id="todo_paused_delivery",
+        title="Advance paused delivery.",
+        claimed_by=AGENT_ID,
+    )
+    return quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        recommended_action="Advance the delivery.",
+        agent_todo_items=[delivery_todo],
+        user_todo_items=[gate_todo],
+        quota_state="paused",
+        quota_extra={"compute": 0, "reason": "paused fixture"},
+        coordination={"agent_model": "peer_v1", "registered_agents": [AGENT_ID]},
+    )
+
+
+def _paused_status_no_runnable_candidate() -> dict:
+    return quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        recommended_action="Nothing runnable.",
+        agent_todo_items=[],
+        quota_state="paused",
+        quota_extra={"compute": 0, "reason": "paused fixture"},
+        coordination={"agent_model": "peer_v1", "registered_agents": [AGENT_ID]},
+    )
+
+
+@pytest.mark.parametrize(
+    "lane",
+    [
+        "capability_gap",
+        "due_monitor",
+        "user_gate",
+        "no_runnable_candidate",
+        "baseline",
+    ],
+)
+def test_paused_quota_is_authoritative_across_lanes(lane: str) -> None:
+    """A hard-paused Goal preempts every selector lane with one consistent contract.
+
+    Whatever capability gap, due monitor, user gate, or empty-frontier fallback the
+    inputs would otherwise route to, the paused Goal short-circuits before any lane
+    is constructed, so all authority fields agree on the terminal skip.
+    """
+
+    if lane == "capability_gap":
+        status_payload = _paused_status(required_capabilities=["network"])
+        available_capabilities: list[str] | None = []
+    elif lane == "due_monitor":
+        status_payload = _paused_status_with_due_monitor()
+        available_capabilities = None
+    elif lane == "user_gate":
+        status_payload = _paused_status_with_user_gate()
+        available_capabilities = None
+    elif lane == "no_runnable_candidate":
+        status_payload = _paused_status_no_runnable_candidate()
+        available_capabilities = None
+    else:
+        status_payload = _paused_status()
+        available_capabilities = None
+
+    payload = build_quota_should_run(
+        status_payload,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        available_capabilities=available_capabilities,
+        scheduler_execution_context=GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT,
+    )
+
+    _assert_authoritatively_paused(payload)
+
+
+def test_configure_goal_accepts_zero_compute_as_pause(tmp_path: Path) -> None:
+    registry = tmp_path / "registry.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "repo": str(tmp_path),
+                        "quota": {"compute": 1.0, "window_hours": 24},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = configure_goal(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        quota_compute=0,
+        execute=True,
+    )
+
+    assert result["written"] is True
+    stored = json.loads(registry.read_text(encoding="utf-8"))
+    assert stored["goals"][0]["quota"]["compute"] == 0
+
+
+def test_configure_goal_rejects_negative_compute(tmp_path: Path) -> None:
+    registry = tmp_path / "registry.json"
+    registry.write_text(
+        json.dumps({"goals": [{"id": GOAL_ID, "repo": str(tmp_path)}]}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="greater than or equal to 0"):
+        configure_goal(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            quota_compute=-0.1,
+            execute=False,
+        )


### PR DESCRIPTION
## Why this exists (supersedes #2447)

`quota.compute=0` is a Goal-level hard pause, but the previous implementation was not authoritative. A paused Goal could still be promoted into capability or workspace repair, and `configure-goal --quota-compute 0` was rejected.

This PR makes the pause one terminal control-plane contract: no delivery, repair, monitor, inbox, or recurring host heartbeat remains runnable until quota is explicitly resumed.

## What changed

1. `--quota-compute 0` is accepted as a hard pause; negative values remain invalid.
2. The selector short-circuits paused Goals before capability, workspace, replan, monitor, user-gate, or inbox lanes are constructed.
3. Paused automation liveness now returns `keep_active=false` and permits the recurring automation to stop.
4. A typed `quota_paused` scheduler hint asks Codex App to pause or delete the current heartbeat, recommends no replacement RRULE, requires no scheduler ACK, and resumes only after `quota.compute > 0`.
5. Execution remains paused when status health is unhealthy, but the returned `ok` and `status_health_ok` fields preserve the real false health fact.
6. The quota allocation reference distinguishes a Goal-level hard pause from one agent's `monitor_only` lane.

## Review repairs

This head addresses both findings from the prior `REQUEST_CHANGES` review:

- recurring Codex App wakeups no longer survive the hard pause;
- the paused terminal projection no longer rewrites unhealthy status as healthy.

The scheduler repair lives in the existing scheduler bounded context and reuses `apply_scheduler_execution_context`; the selector-front terminal design remains unchanged.

## Verification

- exact head: `ccc4282dc1f53aa4330e805f5cbf591e62255e4f`
- paused precedence suite: 11 passed, including Codex App host-action/RRULE behavior and paused-plus-unhealthy status
- complete quota/scheduler/heartbeat test cluster: passed
- Ruff on all changed Python surfaces: passed
- `git diff --check`: passed
- public/private boundary scan: clean
- `loopx canary premerge --from-git-diff`: exit 0; direct checks, compile, 9 catalog canaries, risk-profile smokes, and public-boundary checks passed
- rebased onto current `origin/main` before the maintainer repair was pushed

No production action or external scheduler mutation was performed by these tests.
