### PR TITLE
docs: align architecture inventory with shipped Turn contracts

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 # Architecture
 
-LoopX has six durable control-plane layers, plus an optional read-only probe
-surface that is not a peer layer.
+LoopX has six durable control-plane layers, plus an optional probe surface
+whose execution policy requires read-only observation; it is not a peer layer.
 
 1. **Registry**: lists known goals, their repos, adapters, authority sources,
    status, and guards.
@@ -13,11 +13,13 @@ surface that is not a peer layer.
    goal may consume.
 
 **Optional probe surface (not a seventh layer):** goals may register a
-project-specific read-only `next_probe` via bootstrap `--next-probe`. Status may
-label a goal `pre-tick-runnable` when such a probe is configured. There is no
-shipped `pre_tick` module or adapter pre-tick package; treat the probe as an
-optional planned/operator surface until a dedicated read-only pre-tick command
-exists.
+project-specific `next_probe` command via bootstrap `--next-probe`. Registration
+stores the command as free-form text and does not validate that it is read-only;
+heartbeat and operator policy require any executed observation to be read-only.
+The `pre-tick-runnable` adapter status is declared separately and is not inferred
+from `next_probe`. There is no shipped `pre_tick` module or adapter pre-tick
+package, so keep probe registration, execution policy, and adapter status as
+separate contracts.
 
 ```text
 project goal state

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,21 +1,28 @@
 # Architecture
 
-LoopX has seven layers.
+LoopX has six durable control-plane layers, plus an optional read-only probe
+surface that is not a peer layer.
 
 1. **Registry**: lists known goals, their repos, adapters, authority sources,
    status, and guards.
 2. **Goal state**: the active state file for one goal.
-3. **Adapter pre-tick**: a read-only project-specific probe.
-4. **Run log**: JSON and Markdown reports saved per goal.
-5. **Run history**: compact indexes consumed by agents, heartbeats, and UI.
-6. **Status / attention queue**: first-screen summary of who needs to act next.
-7. **Compute quota**: local policy for how much automatic agent compute each
+3. **Run log**: JSON and Markdown reports saved per goal.
+4. **Run history**: compact indexes consumed by agents, heartbeats, and UI.
+5. **Status / attention queue**: first-screen summary of who needs to act next.
+6. **Compute quota**: local policy for how much automatic agent compute each
    goal may consume.
+
+**Optional probe surface (not a seventh layer):** goals may register a
+project-specific read-only `next_probe` via bootstrap `--next-probe`. Status may
+label a goal `pre-tick-runnable` when such a probe is configured. There is no
+shipped `pre_tick` module or adapter pre-tick package; treat the probe as an
+optional planned/operator surface until a dedicated read-only pre-tick command
+exists.
 
 ```text
 project goal state
   + private registry
-  + project adapter
+  + optional next_probe
         |
         v
 shared runtime root
@@ -34,9 +41,34 @@ The core repository intentionally avoids domain logic. A data experiment goal,
 a note-maintenance goal, and a harness self-improvement goal should share the
 same runtime and contract, but use different adapters.
 
+## Turn Decision Vocabulary
+
+Operator-facing docs and heartbeat prompts often summarize a turn as deliver,
+wait, ask, replan, repair, or stay quiet. That shorthand describes interaction
+intent; it is not the typed packet vocabulary carried by the Turn contracts.
+
+Typed Turn decisions use two enums in `loopx/control_plane/turn_driver/`:
+
+| Contract | When | Members |
+| --- | --- | --- |
+| `LoopXTurnRoute` | Before host execution | `ready_for_host`, `repair_required`, `replan_required`, `user_action_required`, `wait`, `blocked`, `contract_error` |
+| `LoopXTurnResultKind` | After host execution | `validated_progress`, `validated_completion`, `repair_required`, `replan_required`, `user_action_required`, `wait`, `host_failure`, `validation_failed`, `writeback_failed`, `quota_spend_failed` |
+
+Important distinctions the shorthand erases:
+
+- prose "deliver" splits into `validated_progress` versus `validated_completion`;
+- failure kinds (`host_failure`, `validation_failed`, `writeback_failed`,
+  `quota_spend_failed`) are first-class post-execution results;
+- "stay quiet" is a notification / monitor behavior (for example
+  `monitor_quiet_skip` or heartbeat `DONT_NOTIFY`), not a member of either enum.
+
+Quota `interaction_contract` and heartbeat guidance may still use the operator
+shorthand. When implementing or reviewing Turn adapters, prefer the enums above
+over the six-verb prose list.
+
 ## Runtime Responsibility Model
 
-The seven layers above describe durable control-plane surfaces. They do not
+The six durable layers above describe control-plane surfaces. They do not
 describe who performs each step of a turn. For runtime ownership, use four
 responsibilities:
 
@@ -174,7 +206,7 @@ remains available when an adapter is absent.
 
 LoopX should optimize for **lifetime goals**: durable intentions that
 may outlive a single thread, executor, project phase, or plan. This is a
-product invariant, not an eighth storage layer.
+product invariant, not an additional storage layer.
 
 A lifetime goal must be stable enough that a future human or agent can recover
 what the goal is, what currently defines it, who may change it, and what the

--- a/docs/development/control-plane-course/00-concept-primer.md
+++ b/docs/development/control-plane-course/00-concept-primer.md
@@ -96,8 +96,11 @@ LoopX 不否定这层能力，而是继续外置两层：
 
 1. **外置目标**：Goal 让 objective 与一次 prompt 分离；
 2. **外置结构化状态**：LoopX 记录 goal 之外的 frontier、authority、evidence、cadence 与 recovery；
-3. **外置过程协议**：LoopX 每轮把当前结构化状态编译成 compact CLI packet，告诉 executor
-   当前应 deliver、wait、ask、replan、repair 还是 quiet，以及验证后怎样 writeback/spend。
+3. **外置过程协议**：LoopX 每轮把当前结构化状态编译成 compact CLI packet。Operator 侧常用
+   deliver / wait / ask / replan / repair / quiet 描述意图；typed Turn 合同则使用
+   `LoopXTurnRoute` 与 `LoopXTurnResultKind`（含 progress/completion 分裂与 failure kinds）。
+   验证后怎样 writeback/spend 以这些合同为准，见
+   [architecture overview](../../architecture.md#turn-decision-vocabulary)。
 
 ```text
 finite model context
@@ -484,7 +487,7 @@ LoopX 提供的是让这些能力可以被组合、约束、观察和恢复的�
 | 一个 goal 第一次怎样真正跑起来？ | [第 1 讲](01-first-real-loop.md) |
 | registry、event、active state、projection 各自拥有什么？ | [第 2 讲](02-state-substrate.md) |
 | todo、claim、lease、gate 和 equal peer 怎样组合？ | [第 3 讲](03-work-graph-and-peers.md) |
-| should-run 为什么会返回 deliver、wait、ask、repair 或 quiet？ | [第 4 讲](04-quota-decision-kernel.md) |
+| should-run 怎样压成 interaction contract，以及它与 typed Turn 枚举有何不同？ | [第 4 讲](04-quota-decision-kernel.md)、[architecture Turn vocabulary](../../architecture.md#turn-decision-vocabulary) |
 | scheduler、heartbeat、RRULE 和 ACK 的边界是什么？ | [第 5 讲](05-host-scheduler-and-heartbeat.md) |
 | evidence、replan 和 self-repair 何时触发？ | [第 6 讲](06-evidence-refresh-and-self-repair.md) |
 | 怎样实现和验证一条新的控制面规则？ | [第 7 讲](07-engineering-a-control-plane-rule.md) |

--- a/docs/development/control-plane-course/01-first-real-loop.md
+++ b/docs/development/control-plane-course/01-first-real-loop.md
@@ -111,7 +111,7 @@ LoopX 不把整个 registry、event ledger、run history 和所有 todo 直接�
 | Packet 层 | 典型内容 | 为什么必须保留 |
 | --- | --- | --- |
 | Identity | goal、agent lane、selected todo、snapshot/lineage | 防止把结果写到另一个目标或旧状态 |
-| Decision | mode、primary action、user/agent/CLI channel | 区分 deliver、wait、ask、repair 与 quiet |
+| Decision | mode、primary action、user/agent/CLI channel | 区分 operator-facing deliver/wait/ask/repair/quiet 与 typed Turn route/result |
 | Proof boundary | required evidence、gate、workspace/capability guard | 防止“做过”或“能做”冒充可提交 |
 | Closeout | refresh、receipt、spend、scheduler ACK 命令 | 让本轮结果进入下一轮可重放事实 |
 

--- a/docs/development/control-plane-course/README.md
+++ b/docs/development/control-plane-course/README.md
@@ -128,7 +128,7 @@ receipt、projection、replan 与 self-repair；随后再进入下面的代码�
 | [第 1 讲](01-first-real-loop.md) | 从 Showcase 到第一次真实 Loop | 用户只说一句目标后，guided start、todo、heartbeat、quota、refresh 和 spend 如何串起来？ |
 | [第 2 讲](02-state-substrate.md) | 状态底座与可重放事实 | registry、event、active state、run history 和 projection 分别拥有什么事实？ |
 | [第 3 讲](03-work-graph-and-peers.md) | Todo 工作图与 Peer 协作 | equal peer 如何 claim、显式委托 lifecycle authority、handoff 材料前沿，而不恢复 primary/side 层级？ |
-| [第 4 讲](04-quota-decision-kernel.md) | Quota 决策内核与 Interaction Contract | `should-run` 如何把复杂状态压成 deliver、wait、ask、repair 或 quiet？ |
+| [第 4 讲](04-quota-decision-kernel.md) | Quota 决策内核与 Interaction Contract | `should-run` 如何压成 operator-facing mode，以及它与 `LoopXTurnRoute` / `LoopXTurnResultKind` 的关系？ |
 | [第 5 讲](05-host-scheduler-and-heartbeat.md) | Host、Heartbeat 与 Stateful Backoff | LoopX 决策、heartbeat prompt、execution context、Codex App RRULE 和 ACK 各自负责什么？ |
 | [第 6 讲](06-evidence-refresh-and-self-repair.md) | 证据、Refresh 与 Self-Repair | 什么算 material progress，何时必须 replan，连续无推进如何形成可验证 repair delta？ |
 | [第 7 讲](07-engineering-a-control-plane-rule.md) | 如何给 Control Plane 增加一条规则 | 如何从 invariant、ordered rules、schema、projection 到 smoke 完成一次可审计变更？ |

--- a/docs/development/control-plane-course/topic-long-horizon-convergence.md
+++ b/docs/development/control-plane-course/topic-long-horizon-convergence.md
@@ -91,7 +91,7 @@ Judge 可以判断“是否完成”，却未必能告诉下一轮“路线为�
 | Evidence / Receipt | observation、revision、scope、effect 与 lineage | 不自动授予下一步权限 |
 | Domain State | 某个 pack 的紧凑领域 observation、判断与稳定 identity | 不拥有 quota、claim、permission 或外部真相 |
 | Capability / Provider | 领域事实归一化；外部 effect 与 readback | 不拥有通用 lifecycle |
-| Quota / Interaction Contract | 将当前状态编译为本轮 deliver、wait、ask、repair 或 quiet | 不执行 Agent runtime |
+| Quota / Interaction Contract | 将当前状态编译为本轮 operator-facing mode（deliver / wait / ask / repair / quiet 等简述）；typed Turn 见 `LoopXTurnRoute` / `LoopXTurnResultKind` | 不执行 Agent runtime |
 | Turn / Scheduler | 一次有界执行；决定何时再次唤醒 | 不把“被唤醒”当成进展 |
 
 其中 Capability 与 Provider 容易混淆：
@@ -264,7 +264,7 @@ flowchart TD
   V["Vision<br/>长期方向与角色边界"]
   G["Goal + Acceptance<br/>当前阶段交付与完成条件"]
   F["Frontier<br/>todo · gate · monitor · successor"]
-  Q["Quota / Interaction Contract<br/>deliver · wait · ask · replan · repair · quiet"]
+  Q["Quota / Interaction Contract<br/>operator mode · typed TurnRoute / TurnResultKind"]
   T["Bounded Turn<br/>推理 · 工具 · 一次有界动作"]
   P["Provider Effect / Observation<br/>external truth · readback"]
   E["Validation + Receipt<br/>source · lineage · freshness · scope"]


### PR DESCRIPTION
## Summary
- Correct `docs/architecture.md` so LoopX has six durable layers; `next_probe` / pre-tick is an optional probe surface, not a peer layer.
- Document typed `LoopXTurnRoute` and `LoopXTurnResultKind` (including progress/completion split and failure kinds) instead of presenting the six-verb operator shorthand as the packet vocabulary.
- Lightly align control-plane course entry points so they point at the architecture Turn vocabulary.

Fixes #2761

## Test plan
- [x] `python3 -m loopx.cli check --scan-path docs/architecture.md --scan-path docs/development/control-plane-course/...` (public boundary clean)
- [x] `git diff --check`
- [x] Maintainer skim: architecture opening inventory + Turn Decision Vocabulary section match `loopx/control_plane/turn_driver/`


Made with [Cursor](https://cursor.com)
