### PR TITLE
fix(todos): keep todo list JSON identities unique

### DIFF
--- a/examples/cli-control-plane-command-modularization-smoke.py
+++ b/examples/cli-control-plane-command-modularization-smoke.py
@@ -45,7 +45,11 @@ def assert_source_shape() -> None:
     assert_contains(init_text, "handle_quota_command", "__init__")
     assert "todo_parser = sub.add_parser" not in cli_text
     assert "quota_parser = sub.add_parser" not in cli_text
-    assert_contains(cli_text, "register_todo_command(sub)", "cli.py")
+    assert_contains(
+        cli_text,
+        "register_todo_command(sub, add_subcommand_format)",
+        "cli.py",
+    )
     assert_contains(cli_text, "register_quota_command(sub)", "cli.py")
     assert_contains(cli_text, "handle_todo_command(", "cli.py")
     assert_contains(cli_text, "handle_quota_command(", "cli.py")

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -276,7 +276,7 @@ def build_parser() -> LoopXArgumentParser:
     register_dreaming_commands(sub, add_subcommand_format)
     register_evidence_log_command(sub, add_subcommand_format)
     register_explore_commands(sub, add_subcommand_format)
-    register_todo_command(sub)
+    register_todo_command(sub, add_subcommand_format)
     register_task_lease_command(sub, add_subcommand_format)
     register_quota_command(sub)
 
@@ -735,6 +735,7 @@ def main(argv: list[str] | None = None) -> int:
             args,
             registry_path=registry_path,
             runtime_root_arg=args.runtime_root,
+            format_name=output_format(args),
             print_payload=print_payload,
             append_cli_rollout_event=append_cli_rollout_event,
         )

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -46,7 +46,10 @@ PrintPayload = Callable[
 ]
 
 
-def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
+def register_todo_command(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
     todo_parser = subparsers.add_parser(
         "todo",
         help="Add a user or agent todo to a goal's active state.",
@@ -56,6 +59,7 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
             "unsupported combinations fail before state is read or written."
         ),
     )
+    add_subcommand_format(todo_parser)
     todo_parser.add_argument(
         "todo_command",
         nargs="?",
@@ -395,6 +399,7 @@ def handle_todo_command(
     runtime_root_arg: str | None,
     print_payload: PrintPayload,
     append_cli_rollout_event: RolloutEventAppender,
+    format_name: str | None = None,
 ) -> int:
     renderer = (
         render_todo_suggestion_prompt_markdown
@@ -635,5 +640,9 @@ def handle_todo_command(
         runtime_root_arg=runtime_root_arg,
         append_cli_rollout_event=append_cli_rollout_event,
     )
-    print_payload(payload, args.format, renderer)
+    print_payload(
+        payload,
+        format_name or str(getattr(args, "format", None) or "markdown"),
+        renderer,
+    )
     return 0 if payload.get("ok") else 1

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -318,13 +318,17 @@ def _merge_todo_projection_fields(
         "event_only_todo_ids": [],
         "overlaid_todo_ids": [],
     }
+
+    # A todo_id is goal-wide identity. Merge both sources before splitting by
+    # role so an event-projected role change replaces the stale Markdown item.
+    by_id: dict[str, dict[str, Any]] = {}
+    order: list[str] = []
+    markdown_ids: set[str] = set()
+    markdown_ids_by_role: dict[str, set[str]] = {"user": set(), "agent": set()}
+    event_ids: set[str] = set()
+    event_order: list[str] = []
     for role in ("user", "agent"):
         markdown_items = _summary_items(markdown_fields, role)
-        event_items = _summary_items(event_fields, role)
-        if not markdown_items and not event_items:
-            continue
-        by_id: dict[str, dict[str, Any]] = {}
-        order: list[str] = []
         for item in markdown_items:
             todo_id = normalize_todo_id(item.get("todo_id")) or build_todo_id(
                 role=role,
@@ -334,9 +338,12 @@ def _merge_todo_projection_fields(
             )
             if todo_id not in by_id:
                 order.append(todo_id)
+            markdown_ids.add(todo_id)
+            markdown_ids_by_role[role].add(todo_id)
             by_id[todo_id] = dict(item)
-        markdown_ids = set(order)
-        event_ids: set[str] = set()
+
+    for role in ("user", "agent"):
+        event_items = _summary_items(event_fields, role)
         for item in event_items:
             todo_id = normalize_todo_id(item.get("todo_id")) or build_todo_id(
                 role=role,
@@ -344,20 +351,39 @@ def _merge_todo_projection_fields(
                 index=item.get("index"),
                 text=item.get("text"),
             )
-            event_ids.add(todo_id)
             if todo_id not in by_id:
                 order.append(todo_id)
-                overlay["event_only_todo_ids"].append(todo_id)
-            else:
-                overlay["overlaid_todo_ids"].append(todo_id)
+            if todo_id not in event_ids:
+                event_order.append(todo_id)
+                event_ids.add(todo_id)
             by_id[todo_id] = dict(item)
-        overlay["markdown_only_todo_ids"].extend(sorted(markdown_ids - event_ids))
+
+    markdown_only_todo_ids: list[str] = []
+    seen_markdown_only_ids: set[str] = set()
+    for role in ("user", "agent"):
+        for todo_id in sorted(markdown_ids_by_role[role] - event_ids):
+            if todo_id not in seen_markdown_only_ids:
+                markdown_only_todo_ids.append(todo_id)
+                seen_markdown_only_ids.add(todo_id)
+    overlay["markdown_only_todo_ids"] = markdown_only_todo_ids
+    overlay["event_only_todo_ids"] = [
+        todo_id for todo_id in event_order if todo_id not in markdown_ids
+    ]
+    overlay["overlaid_todo_ids"] = [
+        todo_id for todo_id in event_order if todo_id in markdown_ids
+    ]
+
+    for todo_id in order:
+        item = by_id[todo_id]
+        final_role = "user" if item.get("role") == "user" else "agent"
+        merged_items[final_role].append(item)
+
+    for role in ("user", "agent"):
         source_section = str(
             (markdown_fields.get(f"{role}_todos") or {}).get("source_section")
             or (event_fields.get(f"{role}_todos") or {}).get("source_section")
             or TODO_SECTION_HEADINGS[role]
         )
-        merged_items[role] = [by_id[todo_id] for todo_id in order]
         source_sections[role] = source_section
 
     resume_source_items = [*merged_items["user"], *merged_items["agent"]]

--- a/tests/control_plane/test_todo_list_agent_lane_projection.py
+++ b/tests/control_plane/test_todo_list_agent_lane_projection.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 from loopx.control_plane.todos.contract import encode_metadata_value
@@ -15,6 +18,7 @@ from loopx.todos import list_goal_todos
 GOAL_ID = "todo-list-agent-lane-goal"
 AGENT_ID = "codex-quality-qualification"
 OTHER_AGENT_ID = "codex-other-agent"
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _todo_line(
@@ -291,10 +295,26 @@ def test_event_projection_role_change_keeps_one_todo_identity(tmp_path: Path) ->
         )
     )
 
-    payload = list_goal_todos(
-        registry_path=registry_path,
-        goal_id=GOAL_ID,
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "todo",
+            "list",
+            "--format",
+            "json",
+            "--goal-id",
+            GOAL_ID,
+        ],
+        cwd=REPO_ROOT,
+        env={**os.environ, "LOOPX_REGISTRY": str(registry_path)},
+        check=False,
+        capture_output=True,
+        text=True,
     )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
 
     todo_ids = [item["todo_id"] for item in payload["todos"]]
     assert len(todo_ids) == len(set(todo_ids))

--- a/tests/control_plane/test_todo_list_agent_lane_projection.py
+++ b/tests/control_plane/test_todo_list_agent_lane_projection.py
@@ -5,6 +5,11 @@ from pathlib import Path
 
 from loopx.control_plane.todos.contract import encode_metadata_value
 from loopx.control_plane.todos.markdown import render_todo_markdown
+from loopx.event_sourced_state import (
+    AppendOnlyStateEventStore,
+    TODO_ADDED,
+    make_state_event,
+)
 from loopx.todos import list_goal_todos
 
 GOAL_ID = "todo-list-agent-lane-goal"
@@ -264,3 +269,53 @@ def test_explicit_done_filter_remains_a_full_detail_cold_path(
     assert len(payload["agent_todos"]["items"]) == 220
     assert "returned_todo_count" not in payload
     assert "todo_list_projection" not in payload
+
+
+def test_event_projection_role_change_keeps_one_todo_identity(tmp_path: Path) -> None:
+    registry_path, state_file = _write_fixture(tmp_path)
+    store = AppendOnlyStateEventStore(state_file.with_name("events.jsonl"))
+    store.append(
+        make_state_event(
+            event_id="evt-role-change",
+            goal_id=GOAL_ID,
+            event_type=TODO_ADDED,
+            refs={"todo_id": "todo_agent_unclaimed"},
+            payload={
+                "role": "user",
+                "title": "Review the formerly unclaimed advancement.",
+                "task_class": "user_action",
+                "bound_agent": AGENT_ID,
+            },
+            recorded_at="2026-08-04T00:00:00Z",
+            producer="todo-list-role-change-regression",
+        )
+    )
+
+    payload = list_goal_todos(
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+    )
+
+    todo_ids = [item["todo_id"] for item in payload["todos"]]
+    assert len(todo_ids) == len(set(todo_ids))
+    assert payload["todo_count"] == len(todo_ids)
+    matching = [
+        item
+        for item in payload["todos"]
+        if item["todo_id"] == "todo_agent_unclaimed"
+    ]
+    assert len(matching) == 1
+    assert matching[0]["role"] == "user"
+    assert all(
+        item["todo_id"] != "todo_agent_unclaimed"
+        for item in payload["agent_todos"]["items"]
+    )
+    assert payload["projection_overlay"]["overlaid_todo_ids"] == [
+        "todo_agent_unclaimed"
+    ]
+    assert "todo_agent_unclaimed" not in payload["projection_overlay"][
+        "event_only_todo_ids"
+    ]
+    assert "todo_agent_unclaimed" not in payload["projection_overlay"][
+        "markdown_only_todo_ids"
+    ]


### PR DESCRIPTION
## Summary

- merge Markdown active-state and event-projection todos by goal-wide `todo_id` before splitting them into user and agent lanes
- let the event projection replace stale Markdown role data while preserving existing overlay diagnostics and ordering
- add a regression test that proves top-level JSON todo identities remain unique across a cross-role projection overlay

## Root cause

`_merge_todo_projection_fields` deduplicated items independently inside each role. When an event-projected todo had the same `todo_id` as a Markdown todo but a different role, both role buckets retained a copy and the flattened `todos` array emitted the identity twice.

## User impact

`loopx todo list --format json` now emits one top-level todo per `todo_id` for projection-overlay reads. Consumers no longer need to deduplicate cross-role copies, and the event-projected role is authoritative.

## Validation

- `uv run --with 'pytest>=8,<9' python -m pytest tests/control_plane -q` — 708 passed
- `uv run --with 'pytest>=8,<9' python -m pytest tests/control_plane/test_todo_list_agent_lane_projection.py -q` — 3 passed
- `python3 examples/control_plane/todo-list-event-projection-smoke.py` — passed
- `uv run --with 'ruff>=0.12,<0.16' ruff check loopx/todos.py tests/control_plane/test_todo_list_agent_lane_projection.py` — passed
- `uv run loopx canary premerge --from-git-diff` — 17 selected checks passed, 0 failures, 0 warnings, 0 manual holds

No validation failures or skips. The system Python did not include pytest, so pytest was run in an isolated uv environment. The candidate paths passed the public/private boundary scan; generated `uv.lock` and local environment state were excluded.

Fixes #2762
