### PR TITLE
fix: scope Claude MCP registration to target project

### DIFF
--- a/examples/claude-install-no-system-mutation-smoke.py
+++ b/examples/claude-install-no-system-mutation-smoke.py
@@ -21,10 +21,18 @@ from types import SimpleNamespace
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 INSTALLER = REPO_ROOT / "loopx" / "claude_goal_mode" / "scripts" / "install.py"
+CONNECTOR = REPO_ROOT / "loopx" / "claude_goal_mode" / "scripts" / "connect.py"
 
 
 def load_install():
     spec = importlib.util.spec_from_file_location("loopx_claude_installpy", INSTALLER)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def load_connect():
+    spec = importlib.util.spec_from_file_location("loopx_claude_connectpy", CONNECTOR)
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
@@ -36,9 +44,11 @@ def flat(cmd):
 
 def recorder(get_goal_harness_rc=0):
     calls = []
+    working_dirs = []
 
     def run(cmd, *a, **k):
         calls.append(flat(cmd))
+        working_dirs.append(k.get("cwd"))
         rc = 0
         f = flat(cmd)
         if "-m venv" in f:                          # force the dedicated venv to "fail"
@@ -47,7 +57,7 @@ def recorder(get_goal_harness_rc=0):
             rc = get_goal_harness_rc
         return SimpleNamespace(returncode=rc, stdout="", stderr="")
 
-    return calls, run
+    return calls, working_dirs, run
 
 
 def test_no_break_system_packages_by_default():
@@ -57,13 +67,13 @@ def test_no_break_system_packages_by_default():
         inst._has_mcp = lambda py: False            # nothing importable -> reach the fallback
         inst._python_cmd = lambda: "python3"
         # default: allow_system_pip=False
-        calls, run = recorder()
+        calls, _, run = recorder()
         inst.subprocess = SimpleNamespace(run=run)
         inst.provision_mcp_python(dry=False, allow_system_pip=False)
         assert not any("--break-system-packages" in c for c in calls), \
             f"must NOT touch system Python by default:\n{calls}"
         # opt-in: allow_system_pip=True DOES use it
-        calls, run = recorder()
+        calls, _, run = recorder()
         inst.subprocess = SimpleNamespace(run=run)
         inst.provision_mcp_python(dry=False, allow_system_pip=True)
         assert any("--break-system-packages" in c for c in calls), \
@@ -74,7 +84,7 @@ def test_does_not_remove_goal_harness_by_default():
     inst = load_install()
     inst.shutil = SimpleNamespace(which=lambda x: "/usr/bin/claude")
     # default: migrate_goal_harness=False
-    calls, run = recorder(get_goal_harness_rc=0)     # legacy goal-harness "exists"
+    calls, _, run = recorder(get_goal_harness_rc=0)  # legacy goal-harness "exists"
     inst.subprocess = SimpleNamespace(run=run)
     inst.install_mcp(dry=False, py="python3", scope="user", migrate_goal_harness=False)
     removed_gh = [c for c in calls if "mcp remove" in c and "goal-harness" in c]
@@ -82,16 +92,72 @@ def test_does_not_remove_goal_harness_by_default():
     assert any("mcp remove" in c and "loopx" in c for c in calls), \
         f"should still replace our own loopx entry:\n{calls}"
     # opt-in: migrate_goal_harness=True removes it
-    calls, run = recorder(get_goal_harness_rc=0)
+    calls, _, run = recorder(get_goal_harness_rc=0)
     inst.subprocess = SimpleNamespace(run=run)
     inst.install_mcp(dry=False, py="python3", scope="user", migrate_goal_harness=True)
     assert any("mcp remove" in c and "goal-harness" in c for c in calls), \
         f"--migrate-goal-harness should remove goal-harness:\n{calls}"
 
 
+def test_project_scope_uses_project_working_directory():
+    inst = load_install()
+    inst.shutil = SimpleNamespace(which=lambda x: "/usr/bin/claude")
+    calls, working_dirs, run = recorder(get_goal_harness_rc=1)
+    inst.subprocess = SimpleNamespace(run=run)
+    with tempfile.TemporaryDirectory(prefix="loopx-project-") as d:
+        dir_project = Path(d) / "target"
+        dir_project.mkdir()
+        inst.install_mcp(
+            dry=False,
+            py="python3",
+            scope="project",
+            project_dir=dir_project,
+        )
+        calls_mcp = [
+            (call, cwd)
+            for call, cwd in zip(calls, working_dirs)
+            if "/usr/bin/claude mcp" in call
+        ]
+        assert len(calls_mcp) == 3, f"expected remove/get/add calls:\n{calls_mcp}"
+        assert all(cwd == str(dir_project) for _, cwd in calls_mcp), \
+            f"project MCP calls must use the target project cwd:\n{calls_mcp}"
+
+
+def test_connect_runs_installer_from_project_working_directory():
+    conn = load_connect()
+    calls = []
+
+    def run(cmd, *a, **k):
+        calls.append((flat(cmd), k.get("cwd")))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    conn.subprocess = SimpleNamespace(run=run)
+    argv_original = conn.sys.argv
+    with tempfile.TemporaryDirectory(prefix="loopx-connect-") as d:
+        dir_project = Path(d) / "target"
+        dir_project.mkdir()
+        conn.sys.argv = [
+            "connect.py",
+            "--project",
+            str(dir_project),
+            "--goal-id",
+            "goal-fixture",
+            "--dry-run",
+        ]
+        try:
+            conn.main()
+        finally:
+            conn.sys.argv = argv_original
+        assert len(calls) == 1, f"expected one installer call:\n{calls}"
+        assert Path(calls[0][1]).resolve() == dir_project.resolve(), \
+            f"connector must run installer from the target project cwd:\n{calls}"
+
+
 def main() -> int:
     test_no_break_system_packages_by_default()
     test_does_not_remove_goal_harness_by_default()
+    test_project_scope_uses_project_working_directory()
+    test_connect_runs_installer_from_project_working_directory()
     print("claude-install-no-system-mutation-smoke ok")
     return 0
 

--- a/loopx/claude_goal_mode/scripts/connect.py
+++ b/loopx/claude_goal_mode/scripts/connect.py
@@ -86,7 +86,7 @@ def main():
     if dry:
         inst.append("--dry-run")
     print("[install]", " ".join(inst))
-    ri = subprocess.run(inst)
+    ri = subprocess.run(inst, cwd=str(proj))
     if ri.returncode != 0:
         # Fail closed: don't claim success / print next steps if the adapter
         # install failed.

--- a/loopx/claude_goal_mode/scripts/install.py
+++ b/loopx/claude_goal_mode/scripts/install.py
@@ -125,12 +125,21 @@ def provision_mcp_python(dry: bool, allow_system_pip: bool = False) -> str:
     return _python_cmd()
 
 
-def install_mcp(dry: bool, py: str, scope: str, migrate_goal_harness: bool = False):
+def install_mcp(
+    dry: bool,
+    py: str,
+    scope: str,
+    migrate_goal_harness: bool = False,
+    project_dir: Path | None = None,
+):
     """Register the loopx MCP server at the chosen scope via `claude mcp add`.
 
     We replace only OUR `loopx` entry. A legacy/user-owned `goal-harness` MCP is
     left untouched by default — we don't delete a server we don't own. If one
     exists we print a manual cleanup hint; `--migrate-goal-harness` removes it."""
+    if scope == "project" and project_dir is None:
+        raise ValueError("project_dir is required for project-scoped MCP registration")
+    cwd_run = str(project_dir) if scope == "project" else None
     claude = shutil.which("claude")
     mcp_path = _p("mcp", "loopx_mcp.py")
     add = ["mcp", "add", "--scope", scope, "loopx", "--", py, mcp_path]
@@ -140,17 +149,37 @@ def install_mcp(dry: bool, py: str, scope: str, migrate_goal_harness: bool = Fal
     print(f"[mcp] claude mcp add --scope {scope} loopx -- {py} <loopx_mcp.py>")
     if dry:
         return
-    subprocess.run([claude, "mcp", "remove", "--scope", scope, "loopx"], capture_output=True, text=True)
-    has_gh = subprocess.run([claude, "mcp", "get", "goal-harness"], capture_output=True, text=True).returncode == 0
+    subprocess.run(
+        [claude, "mcp", "remove", "--scope", scope, "loopx"],
+        capture_output=True,
+        text=True,
+        cwd=cwd_run,
+    )
+    has_gh = subprocess.run(
+        [claude, "mcp", "get", "goal-harness"],
+        capture_output=True,
+        text=True,
+        cwd=cwd_run,
+    ).returncode == 0
     if has_gh:
         if migrate_goal_harness:
             print(f"[mcp] --migrate-goal-harness: removing legacy goal-harness MCP at {scope} scope")
-            subprocess.run([claude, "mcp", "remove", "--scope", scope, "goal-harness"], capture_output=True, text=True)
+            subprocess.run(
+                [claude, "mcp", "remove", "--scope", scope, "goal-harness"],
+                capture_output=True,
+                text=True,
+                cwd=cwd_run,
+            )
         else:
             print("[mcp] note: a legacy `goal-harness` MCP entry exists — left untouched. Remove it "
                   f"yourself with `claude mcp remove --scope {scope} goal-harness`, or re-run with "
                   "--migrate-goal-harness.")
-    r = subprocess.run([claude, *add], capture_output=True, text=True)
+    r = subprocess.run(
+        [claude, *add],
+        capture_output=True,
+        text=True,
+        cwd=cwd_run,
+    )
     if r.returncode != 0:
         print("  (mcp add failed; add manually:\n   claude " + " ".join(add) + "\n  " + (r.stdout + r.stderr)[:200] + ")")
 
@@ -247,9 +276,10 @@ def main():
     a = ap.parse_args()
     dry = a.dry_run
 
+    project_dir = None
     if a.scope == "project":
-        proj = Path(a.project).resolve() if a.project else Path.cwd()
-        claude_dir = proj / ".claude"
+        project_dir = Path(a.project).resolve() if a.project else Path.cwd()
+        claude_dir = project_dir / ".claude"
         print(f"[scope] PROJECT — installs into {claude_dir} (this project only)")
     else:
         claude_dir = Path.home() / ".claude"
@@ -261,7 +291,13 @@ def main():
         print("[mcp] skipped (--skip-mcp)")
     else:
         mcp_python = provision_mcp_python(dry, a.allow_system_pip)
-        install_mcp(dry, mcp_python, a.scope, a.migrate_goal_harness)
+        install_mcp(
+            dry,
+            mcp_python,
+            a.scope,
+            a.migrate_goal_harness,
+            project_dir=project_dir,
+        )
     install_command(dry, claude_dir / "commands")
 
     settings_path = claude_dir / "settings.json"


### PR DESCRIPTION
## Summary

- pass the resolved project directory to every project-scoped Claude MCP subprocess
- run the delegated Claude adapter installer from the target project's working directory
- add regression coverage for MCP `remove`, `get`, and `add`, plus the `connect.py` wrapper

## Root cause

`--project` selected where LoopX wrote `.claude` files, but the value never reached
`install_mcp()`. Claude therefore resolved project-scoped MCP state from the invoking
shell's working directory. The same omission affected `connect.py` when it delegated to
the installer.

User-scoped installs continue to run without a project working directory override.

## Validation

- `python3 examples/claude-install-no-system-mutation-smoke.py`
- `python3 examples/claude-install-optin-smoke.py`
- `python3 -m compileall -q loopx/claude_goal_mode/scripts/install.py loopx/claude_goal_mode/scripts/connect.py examples/claude-install-no-system-mutation-smoke.py`
- `ruff check loopx/claude_goal_mode/scripts/install.py loopx/claude_goal_mode/scripts/connect.py examples/claude-install-no-system-mutation-smoke.py`
- `git diff --check`

Closes #2758
