### PR TITLE
fix(pr-review): publish blocking review decisions

### DIFF
--- a/examples/pr-review-command-smoke.py
+++ b/examples/pr-review-command-smoke.py
@@ -71,8 +71,12 @@ def main() -> int:
         "Code Volume And Simplification Review",
         "Classify the volume as `necessary`, `partly avoidable`, or `not yet proven`",
         "A code-volume conclusion without diff and call-site evidence is incomplete",
-        "Do not use this skill to approve",
-        "Route those decisions to `loopx-pr-merge`",
+        "submit a formal `REQUEST_CHANGES` review",
+        "A plain PR comment is not an adequate substitute for `REQUEST_CHANGES`",
+        "keep the workflow read-only only when the user explicitly says `local-only`",
+        "the GitHub review state must match the written verdict",
+        "After publication, include the GitHub review/comment URL",
+        "route approval, merge, self-merge, and admin-bypass actions to `loopx-pr-merge`",
     ):
         assert phrase in skill_text, phrase
 

--- a/skills/loopx-pr-review/SKILL.md
+++ b/skills/loopx-pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: loopx-pr-review
-description: Use when the visible request starts with `/loopx-pr-review` or asks LoopX to review a repository PR queue by time window, open/unmerged status, merged/closed status, or current-day PR activity. Run `loopx pr-review` first, preserve the full packet contract, then read PR evidence and produce per-PR reviews with the five required blocks, including code-volume necessity and concrete simplification analysis. Do not use for approving, commenting on, merging, self-merging, or admin-bypassing a specific PR; use `loopx-pr-merge` for those actions.
+description: Use when the visible request starts with `/loopx-pr-review` or asks LoopX to review a repository PR queue by time window, open/unmerged status, merged/closed status, or current-day PR activity. Run `loopx pr-review` first, preserve the full packet contract, then read PR evidence and produce per-PR reviews with the five required blocks, including code-volume necessity and concrete simplification analysis. For an open PR, publish validated actionable findings by default and submit REQUEST_CHANGES when blockers are found; keep review local only when the user explicitly asks for local-only or dry-run output. Use `loopx-pr-merge` for approval, merge, self-merge, or admin-bypass actions.
 ---
 
 # LoopX PR Review
@@ -14,12 +14,21 @@ Use this skill for `/loopx-pr-review` and for requests such as:
 - review PRs since a timestamp;
 - show the merged PRs that need post-merge audit.
 
-Do not use this skill to approve, request changes on GitHub, post PR comments,
-merge, self-merge, or admin-bypass. Route those decisions to `loopx-pr-merge`.
+This skill owns evidence-backed review publication for open PRs. After the
+review is complete:
 
-`/loopx-pr-review` is a read-only review workflow. It may use GitHub metadata,
-PR bodies, changed files, checks, and diffs, but it must not mutate GitHub or
-LoopX state.
+- submit a formal `REQUEST_CHANGES` review when one or more validated blocking
+  findings remain;
+- otherwise post the review findings or no-blocker result as a normal PR
+  review/comment, unless approval was explicitly requested;
+- keep the workflow read-only only when the user explicitly says `local-only`,
+  `dry-run`, `不要评论`, `不要提交 review`, or equivalent;
+- route approval, merge, self-merge, and admin-bypass actions to
+  `loopx-pr-merge`.
+
+Do not leave actionable blockers only in chat. A plain PR comment is not an
+adequate substitute for `REQUEST_CHANGES` when the evidence-based verdict is
+that the open PR should not merge.
 
 ## First Command
 
@@ -114,6 +123,13 @@ Record the remote `headRefOid` before deep review and query it again before the
 verdict. If it changed, review the new head instead of carrying forward stale
 findings. Use a clean read-only worktree at the exact head when local execution
 or line-level evidence is useful, and name the reviewed short SHA in the answer.
+
+Before publishing a review, query `headRefOid` one final time. Build the public
+review body from the exact reviewed head, remove local paths, private context,
+raw logs, credentials, and internal-only links, then submit it with literal-safe
+GitHub text handling. Read the resulting review back and verify its state and
+rendered body. Avoid duplicate reviews when the same reviewer has already
+submitted an equivalent decision for the same head.
 
 Do not fill the five-block review from title, labels, changed-file counts, or
 metadata risk hints alone. `metadata_risk_hint` is only for queue ordering.
@@ -216,12 +232,26 @@ Avoid title-only summaries such as "improves docs" or "low risk", and
 distinguish intended behavior from what the implementation and validation
 actually prove.
 
+For an open PR, the GitHub review state must match the written verdict:
+
+- any remaining P0/P1 blocker, or another explicitly merge-blocking finding:
+  `REQUEST_CHANGES`;
+- non-blocking findings only: normal review/comment unless the user explicitly
+  requests approval;
+- no findings: report that clearly and route approval through `loopx-pr-merge`
+  when approval is requested.
+
+After publication, include the GitHub review/comment URL in the user-facing
+summary. If GitHub rejects the requested review state, report the exact reason
+and do not imply that the PR status was updated.
+
 ## Failure And Fallback
 
 If `loopx pr-review` is unavailable, first repair the LoopX install or run the
 checked-out LoopX CLI from the intended worktree. Do not reconstruct the whole
 queue manually from GitHub and call it a successful `/loopx-pr-review` run.
 
-If a selected PR needs an approve/hold/merge action, finish the read-only review
-first, then route the action to `loopx-pr-merge` or ask for explicit merge
-authorization.
+If a selected PR needs approval, merge, self-merge, or admin-bypass, finish the
+review first and route that action to `loopx-pr-merge`. Blocking findings do not
+need a second authorization step: publish them and submit `REQUEST_CHANGES` by
+default unless the user explicitly requested a local-only review.

--- a/skills/loopx-pr-review/agents/openai.yaml
+++ b/skills/loopx-pr-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "LoopX PR Review"
   short_description: "Guide AgentLoop through LoopX PR review queues"
-  default_prompt: "Use /loopx-pr-review to fetch the PR queue, preserve the full packet contract, build a separate evidence record for every selected PR, and produce standalone five-block reviews with concrete control-flow, validation, risk, code-volume, and simplification analysis. Bound the batch instead of compressing individual PR cards."
+  default_prompt: "Use /loopx-pr-review to fetch the PR queue, preserve the full packet contract, build a separate evidence record for every selected PR, and produce standalone five-block reviews with concrete control-flow, validation, risk, code-volume, and simplification analysis. Publish validated findings for open PRs and submit REQUEST_CHANGES when blockers remain unless the user explicitly requests a local-only review. Bound the batch instead of compressing individual PR cards."


### PR DESCRIPTION
## Summary

- make validated merge blockers publish as a formal `REQUEST_CHANGES` review
- keep review read-only only when the user explicitly requests local-only or dry-run behavior
- require exact-head verification, public/private boundary checks, literal-safe publication, and review readback
- align packaged skill metadata and the focused command smoke with the updated contract

## Motivation

The review skill previously defaulted to read-only analysis even when it found actionable blockers. That could leave the pull request mergeable while the actual decision existed only in chat. The updated contract makes the GitHub review state match the maintainer decision while preserving an explicit local-only escape hatch.

## Validation

- `loopx canary premerge --from-git-diff`: passed
  - `pr-review-command-smoke`
  - `value-connectors-github-public-probe-smoke`
  - `control-plane-maintainability-ratchet`
  - changed-file compile and public-boundary scans
- `pytest -q tests/test_packaged_skill_metadata.py`: 1 passed
- `examples/bootstrap-command-pack-smoke.py`: passed
- `git diff --check origin/main...HEAD`: passed
- broad unscoped `loopx check` was stopped after it expanded into repository-wide worktree traversal; the scoped premerge boundary scan completed cleanly instead

Failures: none. Warnings: none. Manual holds: none.

## Self-merge rationale

This is a small, single-purpose skill and regression-smoke update. It does not change runtime behavior, permissions, benchmark semantics, evidence policy, or production delivery. The user explicitly authorized self-merge, and the premerge gate reports `merge_gate_passed=true` and `self_merge_allowed=true`.
