### PR TITLE
docs: add OLUD verification marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,3 +506,5 @@ surface.
 ## License
 
 MIT. See [LICENSE](LICENSE).
+
+[osai-verify: eb42dd9cf910399988f0]: #


### PR DESCRIPTION
## Summary

- add the OLUD repository-claim marker to the root README
- use a hidden Markdown reference so the marker does not change rendered documentation

## Validation

- exact marker count: 1
- `git diff --check`
- `python3 examples/release/release-readiness-doc-smoke.py`
- `loopx check --scan-path README.md` (9 checks, 0 errors, 0 warnings)

## Boundary

The marker is a public ownership-verification token supplied for `huangruiteng/loopx`. No credentials, private state, runtime behavior, or first-screen content are changed.
