### PR TITLE
fix(control-plane): bound file lock acquisition

### DIFF
--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -11,6 +11,7 @@ scanning a chronological list.
 - [`decision_scope_v0`](decision-scope-v0.md): Decision scope v0
 - [`event_sourced_state_contract_v0`](event-sourced-state-contract-v0.md): Event-sourced state contract v0
 - [`event_store_migration_bridge_v0`](event-store-migration-bridge-v0.md): Event store migration bridge v0
+- [`file_lock_acquisition_v0`](file-lock-acquisition-v0.md): Bounded file-lock acquisition and operator recovery v0
 - [`global_manager_command_v0`](global-manager-command-v0.md): Global manager command v0
 - [`goal_vision_replan_contract_v0`](goal-vision-replan-contract-v0.md): Goal vision replan contract v0
 - [`local_state_write_correctness_v0`](local-state-write-correctness-v0.md): Local state write correctness v0

--- a/docs/reference/protocols/file-lock-acquisition-v0.md
+++ b/docs/reference/protocols/file-lock-acquisition-v0.md
@@ -1,0 +1,46 @@
+# File Lock Acquisition v0
+
+LoopX uses sibling POSIX `flock` files to serialize local read-modify-write
+operations. A lock file is durable metadata; the kernel lock, not the file's
+existence, determines ownership. Operators and automation must never delete a
+lock file to recover a waiter.
+
+## Acquisition Policies
+
+| Policy | Deadline | Timeout behavior |
+| --- | ---: | --- |
+| `mutation` | 5 seconds | Stop the command and require holder inspection before a manual retry. |
+| `monitor` | 1 second | Stop the poll; do not tight-loop. Retry only on a later scheduled poll after inspection. |
+| `single_flight` | no wait | Return an ordinary duplicate/no-op result without recording an incident. |
+
+`exclusive_file_lock` uses `LOCK_EX | LOCK_NB`, a monotonic deadline, and a
+bounded sleep between attempts. A deadline raises
+`LockAcquireTimeoutError` with `error_code=lock_acquire_timeout`. The former
+unbounded `LOCK_EX` wait is not part of this contract.
+
+## Holder And Incident Records
+
+After acquisition, the holder overwrites the lock file with public-safe JSON:
+
+- stable hashed `lock_id` (never an absolute target path);
+- PID, agent id, operation, policy, and acquisition time;
+- release time after a normal exit.
+
+A timeout appends one `file_lock_incident_v0` row to the sibling
+`*.lock.incidents.jsonl` channel. That append uses `O_APPEND` directly and does
+not acquire the blocked lock. The row contains holder and waiter identities,
+wait duration, policy, and an `operator_action`. Failure to append an incident
+does not hide or delay the typed timeout.
+
+## Operator Recovery
+
+1. Inspect the recorded holder PID, agent, operation, and acquisition time.
+2. Confirm that the process is still present and actually stalled.
+3. Terminate the process only after that confirmation and within the operator's
+   existing authority.
+4. Retry according to the policy after the process exits. Do not delete the
+   lock file; a later owner will overwrite its metadata.
+
+An absent PID or stale metadata is evidence to investigate, not permission to
+remove a lock file. The kernel releases `flock` ownership when its process or
+file descriptor exits.

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -34,6 +34,7 @@ from ..control_plane.scheduler.execution_context import (
     SchedulerRuntimeProfile,
     scheduler_execution_context_for_runtime_profile,
 )
+from ..file_lock import lock_timeout_error_fields
 from ..presentation.renderers.quota_event_markdown import (
     render_quota_monitor_poll_markdown,
     render_quota_slot_preview_markdown,
@@ -501,6 +502,7 @@ def _quota_failure_payload(
     error: Exception,
 ) -> dict[str, object]:
     command = args.quota_command
+    lock_timeout_fields = lock_timeout_error_fields(error)
     if command not in QUOTA_EVENT_KINDS:
         return {
             "ok": False,
@@ -525,6 +527,7 @@ def _quota_failure_payload(
                     "source": "quota",
                 }
             ],
+            **lock_timeout_fields,
         }
 
     payload: dict[str, object] = {
@@ -541,7 +544,10 @@ def _quota_failure_payload(
         "recommended_action": (
             "fix quota/status collection before spending automatic compute"
         ),
+        **lock_timeout_fields,
     }
+    if lock_timeout_fields:
+        payload["recommended_action"] = "inspect the lock holder before retrying"
     if command == "monitor-poll":
         payload.update(
             {

--- a/loopx/cli_commands/task_lease.py
+++ b/loopx/cli_commands/task_lease.py
@@ -13,6 +13,8 @@ from ..control_plane.work_items.task_lease import (
     runtime_root_from_registry,
     transfer_task_lease,
 )
+from ..file_lock import LockAcquireTimeoutError
+from ..presentation.markdown import append_operator_action_markdown
 
 
 PrintPayload = Callable[
@@ -57,6 +59,7 @@ def render_task_lease_markdown(payload: dict[str, object]) -> str:
                 f"expires_at=`{conflict.get('expires_at')}` "
                 f"write_scopes=`{', '.join(conflict.get('write_scopes') or [])}`"
             )
+    append_operator_action_markdown(lines, payload)
     return "\n".join(lines)
 
 
@@ -203,6 +206,14 @@ def handle_task_lease_command(
             "error": str(exc),
             "error_code": exc.code,
             **exc.payload,
+        }
+    except LockAcquireTimeoutError as exc:
+        payload = {
+            "ok": False,
+            "schema_version": "task_lease_v0",
+            "action": getattr(args, "task_lease_command", None),
+            "error": str(exc),
+            **exc.to_payload(),
         }
     except Exception as exc:
         payload = {

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -13,6 +13,7 @@ from ..todo_suggestion_prompt import (
 )
 from ..todo_followups import capture_followup_todos
 from ..control_plane.todos.markdown import render_todo_markdown
+from ..file_lock import lock_timeout_error_fields
 from ..todos import (
     ARCHIVE_COMPLETED_DEFAULT_MAX_ACTIVE_DONE,
     archive_completed_todos,
@@ -632,6 +633,7 @@ def handle_todo_command(
             "role": args.role,
             "todo": args.text or "",
             "error": str(exc),
+            **lock_timeout_error_fields(exc),
         }
     append_todo_rollout_event(
         payload,

--- a/loopx/control_plane/quota/monitor_poll.py
+++ b/loopx/control_plane/quota/monitor_poll.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from ...file_lock import exclusive_file_lock
+from ...file_lock import LockAcquisitionPolicy, exclusive_file_lock
 from ...turn_identity import normalize_turn_instance_id
 from .decision_summary import compact_quota_decision, quota_decision_agent_id
 from .spend_sources import DEFAULT_SLOT_SPEND_SOURCE, VALID_SLOT_SPEND_SOURCES
@@ -475,7 +475,12 @@ def record_quota_monitor_poll_for_decision(
     index_path = runs_dir / "index.jsonl"
 
     if execute and normalized_turn_instance_id and not _index_lock_held:
-        with exclusive_file_lock(index_path):
+        with exclusive_file_lock(
+            index_path,
+            policy=LockAcquisitionPolicy.MONITOR,
+            agent_id=str(decision_agent_id),
+            operation="quota_monitor_poll_index",
+        ):
             existing = _find_monitor_poll_turn(
                 index_path,
                 goal_id=goal_id,

--- a/loopx/control_plane/todos/markdown.py
+++ b/loopx/control_plane/todos/markdown.py
@@ -89,6 +89,15 @@ def render_todo_markdown(payload: dict[str, Any]) -> str:
                 lines.append(f"- [{marker}] {text}{suffix}")
         if payload.get("error"):
             lines.append(f"- error: {payload.get('error')}")
+        if payload.get("operator_action"):
+            action = payload["operator_action"]
+            lines.append(f"- error_code: `{payload.get('error_code')}`")
+            lines.append(
+                "- operator_action: "
+                f"action={action.get('action')} "
+                f"holder_pid={action.get('holder_pid') or 'unknown'} "
+                f"retry_mode={action.get('retry_mode')}"
+            )
         return "\n".join(lines)
 
     lines = [
@@ -137,6 +146,15 @@ def render_todo_markdown(payload: dict[str, Any]) -> str:
         )
     if payload.get("error"):
         lines.append(f"- error: {payload.get('error')}")
+        if payload.get("operator_action"):
+            action = payload["operator_action"]
+            lines.append(f"- error_code: `{payload.get('error_code')}`")
+            lines.append(
+                "- operator_action: "
+                f"action={action.get('action')} "
+                f"holder_pid={action.get('holder_pid') or 'unknown'} "
+                f"retry_mode={action.get('retry_mode')}"
+            )
     elif "todo" in payload:
         marker = todo_marker_for_status(payload.get("status") or TODO_STATUS_OPEN)
         lines.extend(["", "## Todo", "", f"- [{marker}] {payload.get('todo')}"])

--- a/loopx/control_plane/work_items/task_lease.py
+++ b/loopx/control_plane/work_items/task_lease.py
@@ -471,7 +471,11 @@ def acquire_task_lease(
     lock_target = task_lease_lock_path(runtime_root=runtime_root, goal_id=goal_id)
     lease_path = task_lease_path(runtime_root=runtime_root, goal_id=goal_id, todo_id=todo_id)
     at = now_utc()
-    with exclusive_file_lock(lock_target):
+    with exclusive_file_lock(
+        lock_target,
+        agent_id=owner,
+        operation="task_lease_acquire",
+    ):
         todo = require_task_lease_owner_allowed(
             registry_path=registry_path,
             goal_id=goal_id,
@@ -586,7 +590,11 @@ def renew_task_lease(
     lock_target = task_lease_lock_path(runtime_root=runtime_root, goal_id=goal_id)
     lease_path = task_lease_path(runtime_root=runtime_root, goal_id=goal_id, todo_id=todo_id)
     at = now_utc()
-    with exclusive_file_lock(lock_target):
+    with exclusive_file_lock(
+        lock_target,
+        agent_id=owner,
+        operation="task_lease_renew",
+    ):
         require_task_lease_owner_allowed(
             registry_path=registry_path,
             goal_id=goal_id,
@@ -637,7 +645,11 @@ def transfer_task_lease(
     lock_target = task_lease_lock_path(runtime_root=runtime_root, goal_id=goal_id)
     lease_path = task_lease_path(runtime_root=runtime_root, goal_id=goal_id, todo_id=todo_id)
     at = now_utc()
-    with exclusive_file_lock(lock_target):
+    with exclusive_file_lock(
+        lock_target,
+        agent_id=owner,
+        operation="task_lease_transfer",
+    ):
         require_registered_task_lease_owner(
             registry_path=registry_path,
             goal_id=goal_id,
@@ -689,7 +701,11 @@ def release_task_lease(
     lock_target = task_lease_lock_path(runtime_root=runtime_root, goal_id=goal_id)
     lease_path = task_lease_path(runtime_root=runtime_root, goal_id=goal_id, todo_id=todo_id)
     at = now_utc()
-    with exclusive_file_lock(lock_target):
+    with exclusive_file_lock(
+        lock_target,
+        agent_id=owner,
+        operation="task_lease_release",
+    ):
         lease = read_lease(lease_path)
         assert_expected_version(lease, expected_version)
         if not lease:

--- a/loopx/extensions/lark/presentation/explore_singleflight.py
+++ b/loopx/extensions/lark/presentation/explore_singleflight.py
@@ -61,7 +61,7 @@ def explore_feishu_sync_singleflight(
     if target_key in held_targets:
         yield True
         return
-    with try_exclusive_file_lock(target) as lock_path:
+    with try_exclusive_file_lock(target, operation="lark_explore_sync") as lock_path:
         if lock_path is None:
             yield False
             return

--- a/loopx/file_lock.py
+++ b/loopx/file_lock.py
@@ -1,7 +1,16 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+import errno
+import hashlib
+import json
+import os
 from pathlib import Path
+import re
+import time
 from typing import Iterator
 
 try:  # pragma: no cover - exercised on POSIX hosts in integration smokes.
@@ -10,44 +19,364 @@ except ImportError:  # pragma: no cover
     fcntl = None  # type: ignore[assignment]
 
 
-@contextmanager
-def exclusive_file_lock(path: Path) -> Iterator[Path]:
-    """Hold a small sibling lock file for read-modify-write file updates."""
+LOCK_ACQUIRE_TIMEOUT_ERROR_CODE = "lock_acquire_timeout"
+LOCK_HOLDER_SCHEMA_VERSION = "file_lock_holder_v0"
+LOCK_INCIDENT_SCHEMA_VERSION = "file_lock_incident_v0"
+_SAFE_LABEL_PATTERN = re.compile(r"[^A-Za-z0-9._:@-]+")
 
-    lock_path = path.with_name(f"{path.name}.lock")
+
+class LockAcquisitionPolicy(str, Enum):
+    MUTATION = "mutation"
+    MONITOR = "monitor"
+    SINGLE_FLIGHT = "single_flight"
+
+
+@dataclass(frozen=True, slots=True)
+class LockPolicy:
+    timeout_seconds: float
+    poll_interval_seconds: float
+    retry_mode: str
+
+
+LOCK_POLICIES = {
+    LockAcquisitionPolicy.MUTATION: LockPolicy(
+        timeout_seconds=5.0,
+        poll_interval_seconds=0.05,
+        retry_mode="manual_after_holder_inspection",
+    ),
+    LockAcquisitionPolicy.MONITOR: LockPolicy(
+        timeout_seconds=1.0,
+        poll_interval_seconds=0.10,
+        retry_mode="next_scheduled_poll_after_holder_inspection",
+    ),
+    LockAcquisitionPolicy.SINGLE_FLIGHT: LockPolicy(
+        timeout_seconds=0.0,
+        poll_interval_seconds=0.0,
+        retry_mode="skip_duplicate_attempt",
+    ),
+}
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _safe_label(value: object, *, fallback: str) -> str:
+    compact = _SAFE_LABEL_PATTERN.sub("_", str(value or "").strip()).strip("._-")
+    return compact[:128] or fallback
+
+
+def _policy(value: LockAcquisitionPolicy | str) -> LockAcquisitionPolicy:
+    if isinstance(value, LockAcquisitionPolicy):
+        return value
+    return LockAcquisitionPolicy(str(value))
+
+
+def _lock_path(path: Path) -> Path:
+    return path.with_name(f"{path.name}.lock")
+
+
+def lock_incident_path(path: Path) -> Path:
+    lock_path = _lock_path(path)
+    return lock_path.with_name(f"{lock_path.name}.incidents.jsonl")
+
+
+def _lock_id(path: Path) -> str:
+    resolved = str(path.expanduser().resolve(strict=False)).encode("utf-8")
+    return hashlib.sha256(resolved).hexdigest()[:16]
+
+
+def _identity(
+    *,
+    agent_id: str | None,
+    operation: str | None,
+    policy: LockAcquisitionPolicy,
+) -> dict[str, object]:
+    return {
+        "pid": os.getpid(),
+        "agent_id": _safe_label(
+            agent_id or os.environ.get("LOOPX_AGENT_ID"),
+            fallback="unknown",
+        ),
+        "operation": _safe_label(operation or policy.value, fallback=policy.value),
+    }
+
+
+def _holder_record(
+    path: Path,
+    *,
+    agent_id: str | None,
+    operation: str | None,
+    policy: LockAcquisitionPolicy,
+) -> dict[str, object]:
+    return {
+        "schema_version": LOCK_HOLDER_SCHEMA_VERSION,
+        "lock_id": _lock_id(path),
+        "policy": policy.value,
+        **_identity(agent_id=agent_id, operation=operation, policy=policy),
+        "acquired_at": _utc_now_iso(),
+    }
+
+
+def _write_holder_record(lock_file, record: dict[str, object]) -> None:
+    lock_file.seek(0)
+    lock_file.truncate()
+    json.dump(record, lock_file, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+    lock_file.write("\n")
+    lock_file.flush()
+    os.fsync(lock_file.fileno())
+
+
+def _mark_released(lock_file, record: dict[str, object]) -> None:
+    released = {**record, "released_at": _utc_now_iso()}
+    try:
+        _write_holder_record(lock_file, released)
+    except OSError:
+        # Releasing the kernel lock is more important than refreshing advisory
+        # metadata; a future holder overwrites the complete record.
+        pass
+
+
+def _read_holder_record(lock_path: Path) -> dict[str, object]:
+    try:
+        payload = json.loads(lock_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    allowed = {
+        "schema_version",
+        "lock_id",
+        "policy",
+        "pid",
+        "agent_id",
+        "operation",
+        "acquired_at",
+        "released_at",
+    }
+    return {key: payload[key] for key in allowed if key in payload}
+
+
+def _operator_action(holder: dict[str, object], *, retry_mode: str) -> dict[str, object]:
+    return {
+        "required": True,
+        "action": "inspect_lock_holder",
+        "holder_pid": holder.get("pid"),
+        "retry_mode": retry_mode,
+        "steps": [
+            "Inspect the recorded holder PID and operation.",
+            "Confirm the process is stalled before terminating it.",
+            "Retry according to retry_mode after the holder exits.",
+            "Do not delete the lock file; the kernel lock is authoritative.",
+        ],
+    }
+
+
+def _append_incident(path: Path, record: dict[str, object]) -> bool:
+    incident_path = lock_incident_path(path)
+    incident_path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = (
+        json.dumps(record, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+        + "\n"
+    ).encode("utf-8")
+    try:
+        descriptor = os.open(
+            incident_path,
+            os.O_APPEND | os.O_CREAT | os.O_WRONLY,
+            0o600,
+        )
+        try:
+            os.write(descriptor, encoded)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+    except OSError:
+        return False
+    return True
+
+
+class LockAcquireTimeoutError(TimeoutError):
+    code = LOCK_ACQUIRE_TIMEOUT_ERROR_CODE
+
+    def __init__(
+        self,
+        *,
+        incident: dict[str, object],
+        incident_recorded: bool,
+        incident_channel: str,
+    ) -> None:
+        self.incident = incident
+        self.incident_recorded = incident_recorded
+        self.incident_channel = incident_channel
+        holder = incident.get("holder") if isinstance(incident.get("holder"), dict) else {}
+        super().__init__(
+            "file lock acquisition timed out"
+            + (f" while waiting for holder pid {holder.get('pid')}" if holder.get("pid") else "")
+        )
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "error_code": self.code,
+            "lock_timeout": self.incident,
+            "incident_recorded": self.incident_recorded,
+            "incident_channel": self.incident_channel,
+            "operator_action": self.incident["operator_action"],
+        }
+
+
+def lock_timeout_error_fields(error: BaseException) -> dict[str, object]:
+    if isinstance(error, LockAcquireTimeoutError):
+        return error.to_payload()
+    return {}
+
+
+def _timeout_error(
+    path: Path,
+    *,
+    policy: LockAcquisitionPolicy,
+    timeout_seconds: float,
+    waited_seconds: float,
+    started_at: str,
+    agent_id: str | None,
+    operation: str | None,
+) -> LockAcquireTimeoutError:
+    holder = _read_holder_record(_lock_path(path))
+    waiter = {
+        **_identity(agent_id=agent_id, operation=operation, policy=policy),
+        "started_at": started_at,
+        "timeout_seconds": round(timeout_seconds, 3),
+        "waited_seconds": round(waited_seconds, 3),
+    }
+    action = _operator_action(holder, retry_mode=LOCK_POLICIES[policy].retry_mode)
+    incident = {
+        "schema_version": LOCK_INCIDENT_SCHEMA_VERSION,
+        "error_code": LOCK_ACQUIRE_TIMEOUT_ERROR_CODE,
+        "recorded_at": _utc_now_iso(),
+        "lock_id": _lock_id(path),
+        "policy": policy.value,
+        "holder": holder,
+        "waiter": waiter,
+        "operator_action": action,
+    }
+    recorded = _append_incident(path, incident)
+    return LockAcquireTimeoutError(
+        incident=incident,
+        incident_recorded=recorded,
+        incident_channel=lock_incident_path(path).name,
+    )
+
+
+def _lock_is_busy(error: OSError) -> bool:
+    return isinstance(error, BlockingIOError) or error.errno in {
+        errno.EACCES,
+        errno.EAGAIN,
+    }
+
+
+@contextmanager
+def exclusive_file_lock(
+    path: Path,
+    *,
+    policy: LockAcquisitionPolicy | str = LockAcquisitionPolicy.MUTATION,
+    timeout_seconds: float | None = None,
+    poll_interval_seconds: float | None = None,
+    agent_id: str | None = None,
+    operation: str | None = None,
+) -> Iterator[Path]:
+    """Hold a sibling lock file with a finite POSIX acquisition deadline."""
+
+    selected_policy = _policy(policy)
+    defaults = LOCK_POLICIES[selected_policy]
+    timeout = defaults.timeout_seconds if timeout_seconds is None else max(0.0, timeout_seconds)
+    poll_interval = (
+        defaults.poll_interval_seconds
+        if poll_interval_seconds is None
+        else max(0.001, poll_interval_seconds)
+    )
+    lock_path = _lock_path(path)
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with lock_path.open("a", encoding="utf-8") as lock_file:
+    descriptor = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    with os.fdopen(descriptor, "r+", encoding="utf-8") as lock_file:
         if fcntl is not None:
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            started = time.monotonic()
+            started_at = _utc_now_iso()
+            deadline = started + timeout
+            while True:
+                try:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except OSError as exc:
+                    if not _lock_is_busy(exc):
+                        raise
+                    now = time.monotonic()
+                    if now >= deadline:
+                        raise _timeout_error(
+                            path,
+                            policy=selected_policy,
+                            timeout_seconds=timeout,
+                            waited_seconds=now - started,
+                            started_at=started_at,
+                            agent_id=agent_id,
+                            operation=operation,
+                        ) from None
+                    time.sleep(min(poll_interval, max(0.0, deadline - now)))
+        record = _holder_record(
+            path,
+            agent_id=agent_id,
+            operation=operation,
+            policy=selected_policy,
+        )
+        _write_holder_record(lock_file, record)
         try:
             yield lock_path
         finally:
+            _mark_released(lock_file, record)
             if fcntl is not None:
                 fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
 
 @contextmanager
-def try_exclusive_file_lock(path: Path) -> Iterator[Path | None]:
-    """Try to hold a sibling lock file without waiting for another process.
+def try_exclusive_file_lock(
+    path: Path,
+    *,
+    agent_id: str | None = None,
+    operation: str | None = None,
+) -> Iterator[Path | None]:
+    """Try once to hold a sibling lock file for single-flight work."""
 
-    ``None`` means another process already owns the lock.  POSIX ``flock`` is
-    the repository's existing cross-process lock primitive; hosts without it
-    retain the historical single-process behavior instead of inventing a
-    stale lock-file protocol.
-    """
-
-    lock_path = path.with_name(f"{path.name}.lock")
+    lock_path = _lock_path(path)
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with lock_path.open("a", encoding="utf-8") as lock_file:
+    descriptor = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    with os.fdopen(descriptor, "r+", encoding="utf-8") as lock_file:
         if fcntl is None:  # pragma: no cover - non-POSIX compatibility path.
-            yield lock_path
+            record = _holder_record(
+                path,
+                agent_id=agent_id,
+                operation=operation,
+                policy=LockAcquisitionPolicy.SINGLE_FLIGHT,
+            )
+            _write_holder_record(lock_file, record)
+            try:
+                yield lock_path
+            finally:
+                _mark_released(lock_file, record)
             return
         try:
             fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError:
+        except OSError as exc:
+            if not _lock_is_busy(exc):
+                raise
             yield None
             return
+        record = _holder_record(
+            path,
+            agent_id=agent_id,
+            operation=operation,
+            policy=LockAcquisitionPolicy.SINGLE_FLIGHT,
+        )
+        _write_holder_record(lock_file, record)
         try:
             yield lock_path
         finally:
+            _mark_released(lock_file, record)
             fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)

--- a/loopx/presentation/markdown.py
+++ b/loopx/presentation/markdown.py
@@ -36,3 +36,26 @@ def markdown_table_separator(column_count: int) -> str:
     if column_count < 1:
         raise ValueError("markdown table must have at least one column")
     return markdown_table_row(["---"] * column_count)
+
+
+def append_operator_action_markdown(
+    lines: list[str],
+    payload: dict[str, Any],
+) -> None:
+    action = as_dict(payload.get("operator_action"))
+    if not action:
+        return
+    if payload.get("error_code"):
+        lines.append(f"- error_code: `{markdown_scalar(payload.get('error_code'))}`")
+    if payload.get("incident_channel"):
+        lines.append(
+            f"- incident_channel: `{markdown_scalar(payload.get('incident_channel'))}`"
+        )
+    lines.append(
+        "- operator_action: "
+        f"action={markdown_scalar(action.get('action'))} "
+        f"holder_pid={markdown_scalar(action.get('holder_pid')) or 'unknown'} "
+        f"retry_mode={markdown_scalar(action.get('retry_mode'))}"
+    )
+    for step in as_list(action.get("steps")):
+        lines.append(f"  - {markdown_scalar(step)}")

--- a/loopx/presentation/renderers/quota_event_markdown.py
+++ b/loopx/presentation/renderers/quota_event_markdown.py
@@ -3,28 +3,28 @@ from __future__ import annotations
 from typing import Any
 
 from ...control_plane.quota.slot_accounting import QUOTA_SLOT_SPENT_CLASSIFICATION
-from ..markdown import as_dict
+from ..markdown import append_operator_action_markdown, as_dict
 
 
 def render_quota_monitor_poll_markdown(payload: dict[str, Any]) -> str:
     if payload.get("ok") is False:
-        return "\n".join(
-            [
-                "# LoopX Quota Monitor Poll",
-                "",
-                "- ok: `False`",
-                f"- mode: `{payload.get('mode') or 'monitor-poll'}`",
-                f"- goal_id: `{payload.get('goal_id') or ''}`",
-                f"- appended: `{bool(payload.get('appended'))}`",
-                f"- registry_mutated: `{bool(payload.get('registry_mutated'))}`",
-                f"- agent_id: `{payload.get('agent_id') or ''}`",
-                f"- source: `{payload.get('source') or ''}`",
-                f"- todo_id: `{payload.get('todo_id') or ''}`",
-                f"- target_key: `{payload.get('target_key') or ''}`",
-                f"- material_change: `{bool(payload.get('material_change'))}`",
-                f"- reason: {payload.get('reason') or 'monitor-poll rejected'}",
-            ]
-        )
+        lines = [
+            "# LoopX Quota Monitor Poll",
+            "",
+            "- ok: `False`",
+            f"- mode: `{payload.get('mode') or 'monitor-poll'}`",
+            f"- goal_id: `{payload.get('goal_id') or ''}`",
+            f"- appended: `{bool(payload.get('appended'))}`",
+            f"- registry_mutated: `{bool(payload.get('registry_mutated'))}`",
+            f"- agent_id: `{payload.get('agent_id') or ''}`",
+            f"- source: `{payload.get('source') or ''}`",
+            f"- todo_id: `{payload.get('todo_id') or ''}`",
+            f"- target_key: `{payload.get('target_key') or ''}`",
+            f"- material_change: `{bool(payload.get('material_change'))}`",
+            f"- reason: {payload.get('reason') or 'monitor-poll rejected'}",
+        ]
+        append_operator_action_markdown(lines, payload)
+        return "\n".join(lines)
     event = as_dict(payload.get("monitor_event"))
     before = as_dict(event.get("before"))
     todo_writeback = as_dict(event.get("todo_writeback"))
@@ -55,6 +55,7 @@ def render_quota_monitor_poll_markdown(payload: dict[str, Any]) -> str:
             f"last_checked_at={todo_writeback.get('last_checked_at')} "
             f"next_due_at={todo_writeback.get('next_due_at')}"
         )
+    append_operator_action_markdown(lines, payload)
     return "\n".join(lines)
 
 
@@ -111,4 +112,5 @@ def render_quota_slot_preview_markdown(payload: dict[str, Any]) -> str:
             )
     if payload.get("rolling_window_note"):
         lines.append(f"- rolling_window_note: {payload.get('rolling_window_note')}")
+    append_operator_action_markdown(lines, payload)
     return "\n".join(lines)

--- a/loopx/presentation/renderers/quota_markdown.py
+++ b/loopx/presentation/renderers/quota_markdown.py
@@ -10,7 +10,12 @@ from ...control_plane.quota.states import QUOTA_STATE_ORDER
 from ...control_plane.runtime.decision_freshness import (
     DECISION_FRESHNESS_WARNING_ITEM_LIMIT,
 )
-from ..markdown import as_dict, as_list, markdown_scalar
+from ..markdown import (
+    append_operator_action_markdown,
+    as_dict,
+    as_list,
+    markdown_scalar,
+)
 
 
 def _append_fallback_projection_markdown(
@@ -267,6 +272,7 @@ def render_quota_markdown(payload: dict[str, Any]) -> str:
                 lines.append(f"  - agent_command: `{item.get('agent_command')}`")
             if item.get("next_handoff_condition"):
                 lines.append(f"  - next_handoff_condition: {item.get('next_handoff_condition')}")
+    append_operator_action_markdown(lines, payload)
     return "\n".join(lines)
 
 
@@ -297,6 +303,7 @@ def render_quota_scheduler_ack_markdown(payload: dict[str, Any]) -> str:
         lines.append(f"- scheduler_state_path: `{payload.get('scheduler_state_path')}`")
     if payload.get("reason"):
         lines.append(f"- reason: {payload.get('reason')}")
+    append_operator_action_markdown(lines, payload)
     return "\n".join(lines)
 
 
@@ -326,6 +333,7 @@ def render_quota_scheduler_failure_markdown(payload: dict[str, Any]) -> str:
         lines.append(f"- scheduler_state_path: `{payload.get('scheduler_state_path')}`")
     if payload.get("reason"):
         lines.append(f"- reason: {payload.get('reason')}")
+    append_operator_action_markdown(lines, payload)
     return "\n".join(lines)
 
 
@@ -1094,4 +1102,5 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             f"next_automatic_turn={summary.get('next_automatic_turn') or 'none'} "
             f"{state_text}"
         )
+    append_operator_action_markdown(lines, payload)
     return "\n".join(lines)

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -935,7 +935,11 @@ def add_goal_todo(
         state_file=state_file,
     )
 
-    with exclusive_file_lock(resolved_state_file):
+    with exclusive_file_lock(
+        resolved_state_file,
+        agent_id=agent_id or claimed_by,
+        operation="todo_add",
+    ):
         original = resolved_state_file.read_text(encoding="utf-8")
         lines = original.splitlines()
         updated_at = now_local()
@@ -1202,7 +1206,11 @@ def update_goal_todo(
         project=project,
         state_file=state_file,
     )
-    with exclusive_file_lock(resolved_state_file):
+    with exclusive_file_lock(
+        resolved_state_file,
+        agent_id=agent_id or claimed_by,
+        operation="todo_update",
+    ):
         original = resolved_state_file.read_text(encoding="utf-8")
         lines = original.splitlines()
         updated_at = now_local()
@@ -1543,7 +1551,11 @@ def complete_goal_todo(
         project=project,
         state_file=state_file,
     )
-    with exclusive_file_lock(resolved_state_file):
+    with exclusive_file_lock(
+        resolved_state_file,
+        agent_id=agent_id or claimed_by,
+        operation="todo_complete",
+    ):
         original = resolved_state_file.read_text(encoding="utf-8")
         lines = original.splitlines()
         updated_at = now_local()
@@ -1852,7 +1864,11 @@ def supersede_goal_todo(
         project=project,
         state_file=state_file,
     )
-    with exclusive_file_lock(resolved_state_file):
+    with exclusive_file_lock(
+        resolved_state_file,
+        agent_id=agent_id,
+        operation="todo_supersede",
+    ):
         original = resolved_state_file.read_text(encoding="utf-8")
         lines = original.splitlines()
         updated_at = now_local()
@@ -2054,7 +2070,7 @@ def archive_completed_todos(
         state_file=state_file,
     )
 
-    with exclusive_file_lock(resolved_state_file):
+    with exclusive_file_lock(resolved_state_file, operation="todo_archive_completed"):
         original = resolved_state_file.read_text(encoding="utf-8")
         lines = original.splitlines()
         archive_result = archive_completed_todo_lines(

--- a/tests/test_file_lock.py
+++ b/tests/test_file_lock.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from loopx.file_lock import (
+    LOCK_ACQUIRE_TIMEOUT_ERROR_CODE,
+    LockAcquireTimeoutError,
+    exclusive_file_lock,
+    fcntl,
+    lock_incident_path,
+    try_exclusive_file_lock,
+)
+from loopx.presentation.markdown import append_operator_action_markdown
+
+
+pytestmark = pytest.mark.skipif(fcntl is None, reason="POSIX flock is required")
+
+
+def _start_stalled_holder(target: Path) -> subprocess.Popen[str]:
+    script = """
+import sys
+import time
+from pathlib import Path
+from loopx.file_lock import exclusive_file_lock
+
+with exclusive_file_lock(
+    Path(sys.argv[1]),
+    timeout_seconds=1.0,
+    agent_id="holder-agent",
+    operation="stalled-holder",
+):
+    print("ready", flush=True)
+    time.sleep(30)
+"""
+    process = subprocess.Popen(
+        [sys.executable, "-c", script, str(target)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert process.stdout is not None
+    assert process.stdout.readline().strip() == "ready"
+    return process
+
+
+def _stop(process: subprocess.Popen[str]) -> None:
+    process.terminate()
+    try:
+        process.wait(timeout=3)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=3)
+
+
+def test_exclusive_lock_persists_public_safe_holder_metadata(tmp_path: Path) -> None:
+    target = tmp_path / "state.json"
+
+    with exclusive_file_lock(
+        target,
+        agent_id="agent-a",
+        operation="todo-update",
+    ) as lock_path:
+        holder = json.loads(lock_path.read_text(encoding="utf-8"))
+        assert holder["pid"] > 0
+        assert holder["agent_id"] == "agent-a"
+        assert holder["operation"] == "todo-update"
+        assert holder["acquired_at"].endswith("Z")
+        assert "released_at" not in holder
+
+    released = json.loads(lock_path.read_text(encoding="utf-8"))
+    assert released["released_at"].endswith("Z")
+    assert lock_path.exists()
+
+
+def test_stalled_holder_times_out_and_records_independent_incident(tmp_path: Path) -> None:
+    target = tmp_path / "todos.md"
+    process = _start_stalled_holder(target)
+    try:
+        with pytest.raises(LockAcquireTimeoutError) as raised:
+            with exclusive_file_lock(
+                target,
+                timeout_seconds=0.15,
+                poll_interval_seconds=0.02,
+                agent_id="waiter-agent",
+                operation="todo-add",
+            ):
+                pytest.fail("waiter unexpectedly acquired the stalled lock")
+
+        error = raised.value
+        payload = error.to_payload()
+        assert payload["error_code"] == LOCK_ACQUIRE_TIMEOUT_ERROR_CODE
+        assert payload["incident_recorded"] is True
+        incident = payload["lock_timeout"]
+        assert incident["holder"]["pid"] == process.pid
+        assert incident["holder"]["agent_id"] == "holder-agent"
+        assert incident["waiter"]["agent_id"] == "waiter-agent"
+        assert incident["waiter"]["waited_seconds"] >= 0.1
+        assert incident["operator_action"]["retry_mode"] == (
+            "manual_after_holder_inspection"
+        )
+        markdown_lines: list[str] = []
+        append_operator_action_markdown(markdown_lines, payload)
+        markdown = "\n".join(markdown_lines)
+        assert "error_code: `lock_acquire_timeout`" in markdown
+        assert f"holder_pid={process.pid}" in markdown
+        assert "Do not delete the lock file" in markdown
+
+        rows = lock_incident_path(target).read_text(encoding="utf-8").splitlines()
+        recorded = json.loads(rows[-1])
+        assert recorded["error_code"] == LOCK_ACQUIRE_TIMEOUT_ERROR_CODE
+        assert recorded["lock_id"] == incident["lock_id"]
+        assert str(target) not in rows[-1]
+    finally:
+        _stop(process)
+
+    assert target.with_name(f"{target.name}.lock").exists()
+
+
+def test_single_flight_returns_none_without_timeout_incident(tmp_path: Path) -> None:
+    target = tmp_path / "sync.json"
+    process = _start_stalled_holder(target)
+    try:
+        with try_exclusive_file_lock(target, operation="duplicate-sync") as lock_path:
+            assert lock_path is None
+        assert not lock_incident_path(target).exists()
+    finally:
+        _stop(process)


### PR DESCRIPTION
## Summary

- replace unbounded blocking `flock(LOCK_EX)` with `LOCK_EX | LOCK_NB`, monotonic deadlines, and bounded polling
- raise structured `lock_acquire_timeout` errors with public-safe holder/waiter metadata and actionable operator recovery
- append incidents through an independent `O_APPEND` JSONL channel, while preserving lock files as durable metadata
- distinguish mutation, monitor, and single-flight acquisition policies; project lock incidents through todo, quota, and task-lease CLI output
- document operator inspection and add a real cross-process stalled-holder regression

## Product and architecture judgment

The issue is a control-plane liveness failure: one live but stalled lock holder can otherwise strand every waiter indefinitely. The implementation keeps the existing POSIX kernel-lock authority and adds one reusable acquisition contract in `loopx/file_lock.py`, rather than introducing caller-specific stale-file deletion or retry loops. Mutation callers stop after five seconds, monitor callers stop after one second and defer to a later scheduled poll, and single-flight callers remain immediate no-ops when another owner is active.

Holder and incident records expose only a hashed lock id plus sanitized PID/agent/operation/timestamps. Absolute target paths and private state are not projected. Recovery explicitly requires inspecting the process before termination and forbids deleting the lock file.

## Validation

- `python -m pytest -q tests/test_file_lock.py tests/control_plane/test_task_lease.py tests/control_plane/test_todo_mutation_authority.py tests/test_cli_argument_diagnostics.py tests/control_plane/test_monitor_poll_cli_projection.py tests/control_plane/test_quota_slot_accounting.py` (152 passed)
- `python examples/control_plane/todo-concurrent-write-lock-smoke.py`
- Ruff checks on every changed Python path
- `git diff --check`
- `loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard` (4 direct checks and 18 selected checks passed; 0 failures, warnings, skips, or manual holds; public/private boundary clean; self-merge allowed)

## Merge decision

The change is single-purpose, has synthetic stalled-holder coverage plus existing concurrency/control-plane coverage, and the risk-based premerge gate reports no manual hold. Merge after GitHub checks are green.

Fixes #2756
