### PR TITLE
fix(smokes): align installer and paused-goal contracts

### DIFF
--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -372,9 +372,14 @@ def main() -> int:
             "pull_requests[].evidence_commands",
             "Do not pipe the first packet through `jq`",
             "Do not fill the five-block review from title, labels, changed-file counts, or metadata risk hints alone",
-            "Do not use this skill to approve",
+            "submit a formal `REQUEST_CHANGES` review",
+            "A plain PR comment is not an adequate substitute for `REQUEST_CHANGES`",
+            "keep the workflow read-only only when the user explicitly says `local-only`",
+            "the GitHub review state must match the written verdict",
+            "route approval, merge, self-merge, and admin-bypass actions to `loopx-pr-merge`",
         ):
             assert phrase in pr_review_text, phrase
+        assert "Do not use this skill to approve" not in pr_review_text, pr_review_text
         pr_review_metadata = pr_review_skill.parent / "agents" / "openai.yaml"
         pr_review_metadata_text = pr_review_metadata.read_text(encoding="utf-8")
         assert (

--- a/examples/project/configure-goal-smoke.py
+++ b/examples/project/configure-goal-smoke.py
@@ -617,17 +617,31 @@ def main() -> int:
         assert disabled_goal["spawn_policy"]["max_children"] == 0, disabled_goal
         assert disabled_goal["spawn_policy"]["allowed_domains"] == [], disabled_goal
 
-        invalid = payload(run_cli(
+        paused = payload(run_cli(
             registry_path,
             "configure-goal",
             "--goal-id",
             GOAL_ID,
             "--quota-compute",
             "0",
+        ))
+        assert paused["ok"] is True, paused
+        assert paused["dry_run"] is True, paused
+        assert paused["changed"] is True, paused
+        assert paused["after"]["quota"]["compute"] == 0.0, paused
+        assert goal_from_registry(registry_path)["quota"]["compute"] == 0.5, paused
+
+        invalid = payload(run_cli(
+            registry_path,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--quota-compute",
+            "-0.1",
             check=False,
         ))
         assert invalid["ok"] is False, invalid
-        assert "greater than 0" in invalid["error"], invalid
+        assert "greater than or equal to 0" in invalid["error"], invalid
 
         invalid_replace = payload(run_cli(
             registry_path,

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -45,7 +45,9 @@ REQUIRED_INSTALLED_SKILL_PHRASES = {
         "loopx --format json pr-review --state all",
         "agent_response_contract",
         "Do not pipe the first packet through `jq`",
-        "Do not use this skill to approve",
+        "submit a formal `REQUEST_CHANGES` review",
+        "A plain PR comment is not an adequate substitute for `REQUEST_CHANGES`",
+        "route approval, merge, self-merge, and admin-bypass actions to",
     ),
     "loopx-doc-registry": (
         "Use even when the user does not mention LoopX or doc registry",


### PR DESCRIPTION
## Summary

- align the installed `loopx-pr-review` doctor contract with the current formal `REQUEST_CHANGES` and merge-routing semantics
- update the installer smoke to verify the same durable skill contract
- update the configure-goal smoke so zero compute quota is a valid hard pause while negative quota remains invalid

This repairs the four deterministic contract failures reported by [Full Public Smokes run 30903639323](https://github.com/huangruiteng/loopx/actions/runs/30903639323).

## Validation

- `loopx canary premerge --from-git-diff --goal-id loopx-meta --timeout-seconds 600` (16/16 selected checks passed; no holds or skips)
- `examples/install-local-smoke.py`
- `examples/fresh-clone-quickstart-smoke.py`
- `examples/pr-review-command-smoke.py`
- `examples/canary/canary-promotion-readiness-smoke.py`
- `examples/project/configure-goal-smoke.py` (isolated with a 600-second per-check timeout)
- repository `mypy` configuration
- full-worktree and exact-diff public/private boundary scans
- `git diff --check origin/main...HEAD`

No private state, credentials, local paths, generated logs, or runtime evidence are included.
