### PR TITLE
Add the official Dev Book learning path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) [![Release](https://img.shields.io/github/v/release/huangruiteng/loopx?display_name=tag)](https://github.com/huangruiteng/loopx/releases/latest) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](pyproject.toml) [![Local first](https://img.shields.io/badge/control--plane-local--first-brightgreen.svg)](docs/public-private-boundary.md) [![Loop Agents](https://img.shields.io/badge/status-loop%20agents%20early-orange.svg)](docs/product/release-readiness.md)
 
-[Public website](https://huangruiteng.github.io/loopx/) · [Docs](https://huangruiteng.github.io/loopx/docs/) · [Try LoopX](#try-loopx) · [See real loops](#evidence) · [How it works](#why-loopx) · [User manual](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [简体中文](README.zh-CN.md)
+[Try LoopX](#try-loopx) · [Developer Book](https://cocolord.github.io/loopx-book/en/) · [See real loops](#evidence) · [How it works](#why-loopx) · [Hosted frontstage](https://huangruiteng.github.io/loopx/frontstage/) · [User manual](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [简体中文](README.zh-CN.md)
 
 **把会干活的 Agent，接成可管理、可复盘、可持续改进的数字员工。**
 
@@ -134,8 +134,8 @@ todo, quota, evidence, and targeted wake remain visible.**
 
 More inspectable surfaces:
 
-- the [public homepage](https://huangruiteng.github.io/loopx/) for the product
-  narrative, quick start, and long-running evidence;
+- [Hosted frontstage](https://huangruiteng.github.io/loopx/frontstage/) and its
+  [public demo script](docs/outreach/frontstage-demo-script.md);
 - the [showcase catalog](docs/showcases/README.md), including
   [blocked-P0 safe rotation](docs/showcases/cases/0617-blocked-p0-safe-rotation.md),
   [LoopX self-iteration](docs/showcases/cases/0619-loopx-self-iteration.md), and
@@ -245,7 +245,7 @@ LoopX folds its control-plane mechanics into five questions:
 | Goal state and status | Tracks active state, todos, claims, gates, evidence, run history, and first-screen attention. | `loopx status`, `loopx diagnose`, `loopx review-packet` |
 | Quota and interaction contract | Decides whether a turn should deliver, ask, wait, self-repair, or stay quiet. | `loopx quota should-run`, [quota allocation](docs/quota-allocation.md) |
 | Agent runtime bridges | Keeps Codex App, Codex CLI, Claude Code, and generic workers aligned with the same guard. | `loopx heartbeat-prompt`, `loopx codex-cli-bootstrap-message`, `loopx worker-bridge` |
-| Operator surfaces | Renders compact status without making the browser the state authority. | `loopx serve-status`, [dashboard](apps/presentation/dashboard/README.md) |
+| Operator surfaces | Renders compact status without making the browser the state authority. | `loopx serve-status`, [dashboard](apps/presentation/dashboard/README.md), [frontstage](https://huangruiteng.github.io/loopx/frontstage/) |
 | External projections | Projects todos and gates into collaboration surfaces while LoopX remains authoritative. | `loopx lark-kanban`, [Lark Kanban adapter](docs/integrations/lark-kanban-control-plane-adapter.md) |
 | Domain capabilities | Packages repeatable work lanes such as issue fixing, content operations, value connector planning, ML experiment advice, benchmark evidence, and Explore. | `loopx issue-fix`, `loopx content-ops`, `loopx value-connectors`, `loopx ml-experiment`, `loopx benchmark`, [Explore](docs/capabilities/explore/README.md) |
 | Experimental context learning | Lets named registered agents trial provider-neutral Reward Memory through ignored, default-off project configuration. OpenViking is one provider option, not a global dependency. | `loopx reward-memory experiment-status`, [Reward Memory architecture](docs/reference/protocols/reward-memory-architecture-v0.md) |
@@ -336,8 +336,7 @@ quota, and handoff explicit.
 ### App and Projection Paths
 
 - Local read-first UI: [dashboard guide](apps/presentation/dashboard/README.md)
-- Public product overview: [public homepage](https://huangruiteng.github.io/loopx/)
-- Documentation portal: [hosted docs](https://huangruiteng.github.io/loopx/docs/)
+- Public-safe product view: [hosted frontstage](https://huangruiteng.github.io/loopx/frontstage/)
 - Feishu/Lark projection: [Lark Kanban adapter](docs/integrations/lark-kanban-control-plane-adapter.md)
 - Generic host integration: [integration guide](docs/integration.md)
 - Custom multi-agent runner:
@@ -383,10 +382,8 @@ loopx check \
 
 ## Advanced Documentation
 
-Start with the path that matches your role. Use the hosted
-[documentation portal](https://huangruiteng.github.io/loopx/docs/) for the
-published docs site; the [documentation index](docs/README.md) remains the
-complete source map.
+Start with the path that matches your role. The
+[documentation index](docs/README.md) remains the complete map.
 
 ### Use and Operate
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) [![Release](https://img.shields.io/github/v/release/huangruiteng/loopx?display_name=tag)](https://github.com/huangruiteng/loopx/releases/latest) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](pyproject.toml) [![Local first](https://img.shields.io/badge/control--plane-local--first-brightgreen.svg)](docs/public-private-boundary.md) [![Loop Agents](https://img.shields.io/badge/status-loop%20agents%20early-orange.svg)](docs/product/release-readiness.md)
 
-[产品首页](https://huangruiteng.github.io/loopx/) · [文档](https://huangruiteng.github.io/loopx/docs/) · [试用 LoopX](#试用-loopx) · [查看真实 Loop](#证据) · [理解工作原理](#为什么需要-loopx) · [用户手册](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [English](README.md)
+[试用 LoopX](#试用-loopx) · [开发者手册](https://cocolord.github.io/loopx-book/) · [查看真实 Loop](#证据) · [理解工作原理](#为什么需要-loopx) · [Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/) · [用户手册](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [English](README.md)
 
 **把会干活的 Agent，接成可管理、可复盘、可持续改进的数字员工。**
 
@@ -120,7 +120,8 @@ targeted wake 同屏可见。**
 
 更多可检查入口：
 
-- [产品首页](https://huangruiteng.github.io/loopx/)：查看产品叙事、快速开始和长程证据；
+- [Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/) 与
+  [公开演示脚本](docs/outreach/frontstage-demo-script.md)；
 - [Showcase 目录](docs/showcases/README.md)，包括
   [Blocked P0 安全侧路](docs/showcases/cases/0617-blocked-p0-safe-rotation.md)、
   [LoopX 自迭代](docs/showcases/cases/0619-loopx-self-iteration.md)和
@@ -225,7 +226,7 @@ LoopX 把控制面归结为五个用户可以直接行动的问题：
 | Goal state 与 status | 跟踪 active state、todo、claim、gate、evidence、run history 和首屏关注点。 | `loopx status`、`loopx diagnose`、`loopx review-packet` |
 | Quota 与 interaction contract | 决定一轮应该执行、提问、等待、自修复还是静默。 | `loopx quota should-run`、[Quota Allocation](docs/quota-allocation.md) |
 | Agent runtime bridge | 让 Codex App、Codex CLI、Claude Code 和 generic worker 服从同一 guard。 | `loopx heartbeat-prompt`、`loopx codex-cli-bootstrap-message`、`loopx worker-bridge` |
-| Operator surface | 呈现紧凑状态，但不让浏览器成为状态事实源。 | `loopx serve-status`、[Dashboard](apps/presentation/dashboard/README.md) |
+| Operator surface | 呈现紧凑状态，但不让浏览器成为状态事实源。 | `loopx serve-status`、[Dashboard](apps/presentation/dashboard/README.md)、[Frontstage](https://huangruiteng.github.io/loopx/frontstage/) |
 | External projection | 把 todo / gate 投影到协作表面，同时保持 LoopX 权威。 | `loopx lark-kanban`、[Lark Kanban adapter](docs/integrations/lark-kanban-control-plane-adapter.md) |
 | Domain capability | 打包 Issue Fix、内容运营、value connector、ML 实验、benchmark 与 Explore 等可重复泳道。 | `loopx issue-fix`、`loopx content-ops`、`loopx value-connectors`、`loopx ml-experiment`、`loopx benchmark`、[Explore](docs/capabilities/explore/README.md) |
 | 实验性上下文学习 | 通过 ignored、默认关闭的项目配置，为明确注册的 agent 试用 provider-neutral Reward Memory；OpenViking 是 provider 之一，不是全局依赖。 | `loopx reward-memory experiment-status`、[Reward Memory 中文架构](docs/reference/protocols/reward-memory-architecture-v0.zh-CN.md) |
@@ -303,8 +304,7 @@ treatment 和 guardrail 的任务，不替代生产审批。先读
 ### App 与 Projection
 
 - 本地 read-first UI：[Dashboard Guide](apps/presentation/dashboard/README.md)
-- 公开产品概览：[产品首页](https://huangruiteng.github.io/loopx/)
-- 文档门户：[线上文档](https://huangruiteng.github.io/loopx/docs/)
+- Public-safe 产品视图：[Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/)
 - 飞书投影：[Lark Kanban Adapter](docs/integrations/lark-kanban-control-plane-adapter.md)
 - 通用 host 集成：[Integration Guide](docs/integration.md)
 - 自有 multi-agent runner：
@@ -347,8 +347,7 @@ loopx check \
 
 ## 进阶文档
 
-按你的角色选择入口；[线上文档](https://huangruiteng.github.io/loopx/docs/)
-提供发布后的浏览入口，[完整文档索引](docs/README.md)仍是权威地图。
+按你的角色选择入口；[完整文档索引](docs/README.md)仍是权威地图。
 
 ### 使用与运维
 

--- a/apps/presentation/site/home.css
+++ b/apps/presentation/site/home.css
@@ -262,8 +262,8 @@ body[data-language="zh"] .hero h1 { font-size: clamp(3.2rem, 4.2vw, 4.5rem); let
 .shield-icon::before { width: 0.8rem; height: 0.92rem; border: 1px solid #b7d5ff; border-radius: 0.55rem 0.55rem 0.7rem 0.7rem; content: ""; transform: scaleX(0.82); }
 .paper-icon::before { width: 0.72rem; height: 0.94rem; border: 1px solid #8f89ff; border-radius: 0.08rem; background: linear-gradient(#8f89ff, #8f89ff) 50% 45% / 54% 1px no-repeat; content: ""; }
 
-.product-section, .capability-section, .evidence-section, .quickstart-section, footer { width: min(100% - 3rem, 1320px); margin-inline: auto; }
-.product-section, .capability-section, .evidence-section, .quickstart-section { padding: clamp(6rem, 10vw, 9rem) 0; }
+.product-section, .capability-section, .learn-section, .evidence-section, .quickstart-section, footer { width: min(100% - 3rem, 1320px); margin-inline: auto; }
+.product-section, .capability-section, .learn-section, .evidence-section, .quickstart-section { padding: clamp(6rem, 10vw, 9rem) 0; }
 .product-section { border-top: 1px solid rgba(131, 165, 219, 0.12); }
 .section-heading { max-width: 52rem; }
 .section-heading h2, .evidence-heading h2, .quickstart-section h2 { margin: 0; color: #f4f1ec; font-family: var(--serif); font-size: clamp(2.6rem, 4.5vw, 4.4rem); font-weight: 500; letter-spacing: -0.045em; line-height: 1.06; }
@@ -283,6 +283,19 @@ body[data-language="zh"] .hero h1 { font-size: clamp(3.2rem, 4.2vw, 4.5rem); let
 .capability-number { color: var(--blue); font-family: var(--mono); font-size: 0.72rem; }
 .capability-grid h3 { margin: 6rem 0 0.8rem; font-size: 1.18rem; }
 .capability-grid p { margin: 0; color: #7d8ca3; font-size: 0.88rem; line-height: 1.65; }
+.learn-section { border-top: 1px solid rgba(131, 165, 219, 0.12); }
+.learn-heading { align-items: start; }
+.learn-intro { display: grid; gap: 1.25rem; }
+.learn-intro p { margin: 0; color: var(--muted); font-size: 1rem; line-height: 1.75; }
+.learn-intro a { width: max-content; color: var(--blue-soft); font-size: 0.9rem; font-weight: 650; transition: color 180ms ease; }
+.learn-intro a:hover, .learn-intro a:focus-visible { color: #fff; }
+.learn-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; margin-top: 4rem; }
+.learn-card { display: grid; min-height: 19rem; padding: 1.6rem; border: 1px solid rgba(126, 163, 219, 0.2); border-radius: 0.75rem; background: linear-gradient(145deg, rgba(10, 21, 41, 0.84), rgba(5, 12, 25, 0.9)); transition: border-color 180ms ease, background 180ms ease, transform 180ms ease; }
+.learn-card:hover, .learn-card:focus-visible { border-color: rgba(110, 171, 255, 0.72); background: linear-gradient(145deg, rgba(18, 37, 69, 0.9), rgba(6, 14, 29, 0.94)); transform: translateY(-3px); }
+.learn-card > span { color: var(--blue); font-family: var(--mono); font-size: 0.7rem; letter-spacing: 0.08em; }
+.learn-card h3 { align-self: end; margin: 4.2rem 0 0.85rem; color: #edf2f8; font-size: 1.2rem; font-weight: 600; }
+.learn-card p { margin: 0; color: #7f8da2; font-size: 0.86rem; line-height: 1.7; }
+.learn-card b { align-self: end; margin-top: 1.5rem; color: #9bc8ff; font-size: 0.78rem; font-weight: 650; }
 .evidence-section { border-top: 1px solid rgba(131, 165, 219, 0.12); }
 .evidence-heading { display: grid; grid-template-columns: 1.1fr 0.9fr; align-items: end; gap: 5rem; }
 .evidence-heading > p { margin: 0; }
@@ -409,9 +422,12 @@ footer p { text-align: center; } footer > div { justify-self: end; display: flex
   .hero-copy { max-width: 38rem; }.hero h1 { font-size: clamp(3rem, 11vw, 4.8rem); }.hero-actions { max-width: 34rem; }
   .control-visual { width: 100%; max-width: 44rem; margin: 2.4rem auto 0; padding-inline: 2rem; }
   .proof-strip { grid-template-columns: 1fr; gap: 0.8rem; }.proof-item, .proof-item:first-child { padding: 0.8rem 0; }.proof-item + .proof-item { border-top: 1px solid rgba(125, 156, 203, 0.18); border-left: 0; }
-  .product-section, .capability-section, .evidence-section, .quickstart-section, footer { width: min(100% - 2rem, 720px); }
+  .product-section, .capability-section, .learn-section, .evidence-section, .quickstart-section, footer { width: min(100% - 2rem, 720px); }
   .split-heading, .quickstart-section, .evidence-heading { grid-template-columns: 1fr; gap: 3rem; }
   .split-heading > p { margin-top: 1rem; }.state-flow { grid-template-columns: repeat(2, 1fr); }
+  .learn-grid { grid-template-columns: 1fr; }
+  .learn-card { min-height: 15rem; }
+  .learn-card h3 { margin-top: 2.8rem; }
   .evidence-heading > p { margin-top: 0; }
   .terminal-demo-line { grid-template-columns: 0.7rem 4.4rem minmax(0, 1fr); }
   .terminal-demo-line > b { grid-column: 3; }

--- a/apps/presentation/site/home.js
+++ b/apps/presentation/site/home.js
@@ -24,6 +24,7 @@ P0/P1/P2 todos，让我能看到当前要做什么、什么被 gate 卡住、
 const zh = {
   "nav.product": "产品",
   "nav.workflow": "工作方式",
+  "nav.learn": "学习",
   "nav.showcases": "案例",
   "nav.docs": "文档",
   "nav.github": "GitHub",
@@ -90,6 +91,19 @@ const zh = {
   "capabilities.gateBody": "P0 等待决策时保持可见，独立的 P1、P2 线路可以安全继续。",
   "capabilities.evidence": "结果驱动",
   "capabilities.evidenceBody": "每轮运行都把验证、归属、审查和交接证据写入下一轮闭环。",
+  "learn.eyebrow": "官方开发者手册",
+  "learn.title": "选择你的 LoopX 学习路径。",
+  "learn.body": "这本中英双语、协议优先的 Dev Book 面向希望理解控制面、接入真实项目或沿正确 owner 边界参与贡献的开发者。",
+  "learn.openBook": "打开开发者手册 →",
+  "learn.foundations": "理解控制面",
+  "learn.foundationsBody": "从 Session 与 Goal 出发，建立持久状态、权限、受治理 Turn 和恢复机制的完整模型。",
+  "learn.readFoundations": "从基础开始 ↗",
+  "learn.onboarding": "接入现有项目",
+  "learn.onboardingBody": "让 Agent 建立 Goal、identity、Host 与 Git 边界，再用可观察结果验收接入。",
+  "learn.readOnboarding": "查看项目接入 ↗",
+  "learn.contribute": "参与 LoopX 贡献",
+  "learn.contributeBody": "沿协议定位源码 owner，选择正确的贡献表面，完成验证并准备聚焦 PR。",
+  "learn.readContribute": "打开贡献地图 ↗",
   "showcase.eyebrow": "来自真实闭环的证据",
   "showcase.title": "跨越 200+ 小时，依然清晰可读。",
   "showcase.body": "两条公开安全的真实轨迹，保留了多轮 Agent 推进中的交付、决策、证据分支与恢复过程。",
@@ -159,6 +173,8 @@ const zh = {
 const textTargets = document.querySelectorAll("[data-i18n]");
 const htmlTargets = document.querySelectorAll("[data-i18n-html]");
 const ariaTargets = document.querySelectorAll("[data-i18n-aria]");
+const developerBookTargets = document.querySelectorAll("[data-devbook-path]");
+const developerBookOrigin = "https://cocolord.github.io/loopx-book";
 textTargets.forEach((target) => { target.dataset.english = target.textContent; });
 htmlTargets.forEach((target) => { target.dataset.englishHtml = target.innerHTML; });
 ariaTargets.forEach((target) => { target.dataset.englishAria = target.getAttribute("aria-label") ?? ""; });
@@ -175,6 +191,10 @@ function applyLanguage(nextLanguage, updateUrl = false) {
   });
   ariaTargets.forEach((target) => {
     target.setAttribute("aria-label", language === "zh" ? (zh[target.dataset.i18nAria] ?? target.dataset.englishAria) : target.dataset.englishAria);
+  });
+  developerBookTargets.forEach((target) => {
+    const localePrefix = language === "zh" ? "" : "/en";
+    target.setAttribute("href", `${developerBookOrigin}${localePrefix}${target.dataset.devbookPath}`);
   });
   prepareHeroWaves();
   document.querySelectorAll("[data-language-toggle]").forEach((toggle) => {

--- a/apps/presentation/site/index.html
+++ b/apps/presentation/site/index.html
@@ -28,6 +28,7 @@
       <nav class="desktop-nav" aria-label="Primary navigation">
         <a href="#product" data-i18n="nav.product">Product</a>
         <a href="#workflow" data-i18n="nav.workflow">How it works</a>
+        <a href="https://cocolord.github.io/loopx-book/en/" data-devbook-path="/" data-i18n="nav.learn">Learn</a>
         <a href="#showcases" data-i18n="nav.showcases">Showcases</a>
         <a href="__LOOPX_BASE__docs/" data-i18n="nav.docs">Docs</a>
         <button class="language-toggle" type="button" data-language-toggle aria-label="切换为中文">中文</button>
@@ -42,6 +43,7 @@
       <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation" hidden>
         <a href="#product" data-i18n="nav.product">Product</a>
         <a href="#workflow" data-i18n="nav.workflow">How it works</a>
+        <a href="https://cocolord.github.io/loopx-book/en/" data-devbook-path="/" data-i18n="nav.learn">Learn</a>
         <a href="#showcases" data-i18n="nav.showcases">Showcases</a>
         <a href="__LOOPX_BASE__docs/" data-i18n="nav.docs">Docs</a>
         <a href="https://github.com/huangruiteng/loopx" data-i18n="nav.github">GitHub</a>
@@ -174,6 +176,39 @@
           <article><span class="capability-number">02</span><h3 data-i18n="capabilities.runtime">Cross-runtime</h3><p data-i18n="capabilities.runtimeBody">Change the executor or host without reconstructing the objective from chat history.</p></article>
           <article><span class="capability-number">03</span><h3 data-i18n="capabilities.gate">Gate aware</h3><p data-i18n="capabilities.gateBody">A blocked P0 stays visible while independent P1 and P2 lanes continue safely.</p></article>
           <article><span class="capability-number">04</span><h3 data-i18n="capabilities.evidence">Outcome driven</h3><p data-i18n="capabilities.evidenceBody">Every run writes validation, ownership, review, and handoff evidence into the next loop.</p></article>
+        </div>
+      </section>
+
+      <section class="learn-section reveal" id="learn" aria-labelledby="learn-title">
+        <div class="section-heading split-heading learn-heading">
+          <div>
+            <p class="eyebrow" data-i18n="learn.eyebrow">Official developer book</p>
+            <h2 id="learn-title" data-i18n="learn.title">Choose your path into LoopX.</h2>
+          </div>
+          <div class="learn-intro">
+            <p data-i18n="learn.body">A bilingual, protocol-first guide for developers who want to understand the control plane, connect a real project, or contribute along the right ownership boundary.</p>
+            <a href="https://cocolord.github.io/loopx-book/en/" data-devbook-path="/" data-i18n="learn.openBook">Open the Developer Book →</a>
+          </div>
+        </div>
+        <div class="learn-grid">
+          <a class="learn-card" href="https://cocolord.github.io/loopx-book/en/chapters/01-from-session-to-loop" data-devbook-path="/chapters/01-from-session-to-loop">
+            <span>01</span>
+            <h3 data-i18n="learn.foundations">Understand the control plane</h3>
+            <p data-i18n="learn.foundationsBody">Build the model from sessions and Goals through durable state, authority, governed turns, and recovery.</p>
+            <b data-i18n="learn.readFoundations">Start with foundations ↗</b>
+          </a>
+          <a class="learn-card" href="https://cocolord.github.io/loopx-book/en/chapters/05-connect-existing-project" data-devbook-path="/chapters/05-connect-existing-project">
+            <span>02</span>
+            <h3 data-i18n="learn.onboarding">Connect an existing project</h3>
+            <p data-i18n="learn.onboardingBody">Let your Agent establish the Goal, identity, Host, and Git boundary, then verify the result.</p>
+            <b data-i18n="learn.readOnboarding">Follow project onboarding ↗</b>
+          </a>
+          <a class="learn-card" href="https://cocolord.github.io/loopx-book/en/chapters/source-protocol-map" data-devbook-path="/chapters/source-protocol-map">
+            <span>03</span>
+            <h3 data-i18n="learn.contribute">Contribute to LoopX</h3>
+            <p data-i18n="learn.contributeBody">Trace protocols to source ownership, choose the right contribution surface, validate it, and prepare a focused PR.</p>
+            <b data-i18n="learn.readContribute">Open the contribution map ↗</b>
+          </a>
         </div>
       </section>
 
@@ -322,7 +357,7 @@
     <footer>
       <a class="brand footer-brand" href="#top"><span class="brand-mark" aria-hidden="true">∞</span><span>LoopX</span></a>
       <p data-i18n="footer.tagline">Keep the loop moving. Keep the judgment human.</p>
-      <div><a href="https://github.com/huangruiteng/loopx">GitHub</a><a href="__LOOPX_BASE__frontstage/" data-i18n="footer.frontstage">Frontstage</a><a href="__LOOPX_BASE__docs/" data-i18n="nav.docs">Docs</a></div>
+      <div><a href="https://github.com/huangruiteng/loopx">GitHub</a><a href="https://cocolord.github.io/loopx-book/en/" data-devbook-path="/" data-i18n="nav.learn">Learn</a><a href="__LOOPX_BASE__frontstage/" data-i18n="footer.frontstage">Frontstage</a><a href="__LOOPX_BASE__docs/" data-i18n="nav.docs">Docs</a></div>
     </footer>
   </body>
 </html>

--- a/examples/frontstage-share-bundle-smoke.mjs
+++ b/examples/frontstage-share-bundle-smoke.mjs
@@ -102,6 +102,19 @@ const homepageHtml = await readFile(resolve(siteDir, "index.html"), "utf8");
 if (!homepageHtml.includes("Your agents keep") || !homepageHtml.includes('class="button button-secondary" href="#showcases"')) {
   throw new Error("homepage root is missing the LoopX hero or curated evidence CTA");
 }
+for (const learnContract of [
+  'id="learn"',
+  'data-i18n="nav.learn"',
+  'data-devbook-path="/"',
+  'data-devbook-path="/chapters/01-from-session-to-loop"',
+  'data-devbook-path="/chapters/05-connect-existing-project"',
+  'data-devbook-path="/chapters/source-protocol-map"',
+  "Official developer book",
+]) {
+  if (!homepageHtml.includes(learnContract)) {
+    throw new Error(`homepage is missing the official developer-book path: ${learnContract}`);
+  }
+}
 if (!homepageHtml.includes('data-hero-wave="progress"') || !homepageHtml.includes('data-hero-wave="judgment"')) {
   throw new Error("homepage hero must retain the finite semantic keyword wave");
 }
@@ -152,6 +165,12 @@ for (const assetName of [
 const homepageScript = await readFile(resolve(siteDir, "site-assets/home.js"), "utf8");
 if (!homepageScript.includes('"hero.eyebrow": "长程目标控制面"') || !homepageScript.includes('requestedLanguage === "zh" ? "zh" : "en"')) {
   throw new Error("homepage language switch must include the public-safe Chinese locale and default to English");
+}
+if (
+  !homepageScript.includes('const developerBookOrigin = "https://cocolord.github.io/loopx-book"')
+  || !homepageScript.includes('language === "zh" ? "" : "/en"')
+) {
+  throw new Error("homepage Learn links must route English and Chinese readers to matching developer-book locales");
 }
 for (const promptContract of [
   "Connect the current project to LoopX",
@@ -214,6 +233,9 @@ if (!homepageCss.includes("@keyframes terminal-line-in") || !homepageCss.include
 if (!homepageCss.includes("@keyframes hero-word-wave") || !homepageCss.includes("var(--char-delay, 0ms)") || !homepageCss.includes("animation: none !important; color: inherit")) {
   throw new Error("homepage hero keyword wave must be staggered, finite, and reduced-motion safe");
 }
+if (!homepageCss.includes(".learn-section") || !homepageCss.includes(".learn-grid") || !homepageCss.includes(".learn-card")) {
+  throw new Error("homepage must provide a responsive visual path into the official developer book");
+}
 if (!homepageHtml.includes('href="/loopx/site-assets/home.css"') || homepageHtml.includes("__LOOPX_BASE__")) {
   throw new Error("homepage assets did not resolve against the GitHub Pages base");
 }
@@ -242,6 +264,14 @@ if (
 }
 if (manifest.content_sources?.public_homepage !== "apps/presentation/site") {
   throw new Error(`manifest homepage source mismatch: ${JSON.stringify(manifest.content_sources)}`);
+}
+const readme = await readFile(resolve(repoRoot, "README.md"), "utf8");
+const chineseReadme = await readFile(resolve(repoRoot, "README.zh-CN.md"), "utf8");
+if (!readme.includes("[Developer Book](https://cocolord.github.io/loopx-book/en/)")) {
+  throw new Error("English README must expose the official Developer Book entry");
+}
+if (!chineseReadme.includes("[开发者手册](https://cocolord.github.io/loopx-book/)")) {
+  throw new Error("Chinese README must expose the official developer-book entry");
 }
 const homepageEvidenceAssets = manifest.content_sources?.homepage_evidence_assets ?? [];
 for (const assetPath of [


### PR DESCRIPTION
## Summary
- add `Learn` to the desktop, mobile, and footer navigation of the public LoopX homepage
- add a focused three-path Developer Book section for control-plane foundations, project onboarding, and LoopX contributions
- route English visitors to `/loopx-book/en/` and Chinese visitors to `/loopx-book/` without changing the agent-first Hero CTA
- add matching Developer Book entries to the English and Chinese repository README first screens
- guard the published routes, locale switching, responsive styling, and README entries in the existing frontstage bundle smoke

## Published dependency
- the branded bilingual Dev Book is already deployed at https://cocolord.github.io/loopx-book/
- Dev Book PR: https://github.com/cocolord/loopx-book/pull/5
- Pages workflow: https://github.com/cocolord/loopx-book/actions/runs/31003400151

## Validation
- `npm run build`
- `npm run smoke:frontstage-share-bundle`
- `python3 examples/frontstage-pages-workflow-smoke.py`
- `node --check apps/presentation/site/home.js`
- real Chrome checks at 1440px, 1024px, and 390px for locale-aware links, mobile navigation, and unchanged primary CTA
- all eight Chinese/English Developer Book target routes returned HTTP 200
- `loopx check --scan-path ...` — public boundary clean for all six changed paths; three pre-existing registry projection warnings are outside this diff
- `loopx canary premerge --from-git-diff` — passed, 16 selected, 0 failures, 0 manual holds

## Boundaries
- the current copy-setup-prompt Hero action remains primary
- no LoopX runtime, control-plane, permission, benchmark, or evidence-policy behavior changes
- the Dev Book remains an independently maintained VitePress publication

Co-authored-by: TRAE CLI <noreply@bytedance.com>