### PR TITLE
docs: add hosted documentation site

### DIFF
--- a/.github/workflows/frontstage-pages.yml
+++ b/.github/workflows/frontstage-pages.yml
@@ -7,6 +7,8 @@ on:
       - ".github/workflows/frontstage-pages.yml"
       - "apps/presentation/dashboard/**"
       - "apps/presentation/site/**"
+      - "docs/**"
+      - "mkdocs.yaml"
       - "docs/showcases/**"
       - "docs/assets/long-running-loop-openviking-trajectory.png"
       - "docs/assets/long-running-loop-ml-experiment-trajectory.png"
@@ -22,6 +24,8 @@ on:
       - ".github/workflows/frontstage-pages.yml"
       - "apps/presentation/dashboard/**"
       - "apps/presentation/site/**"
+      - "docs/**"
+      - "mkdocs.yaml"
       - "docs/showcases/**"
       - "docs/assets/long-running-loop-openviking-trajectory.png"
       - "docs/assets/long-running-loop-ml-experiment-trajectory.png"
@@ -62,6 +66,15 @@ jobs:
         working-directory: apps/presentation/dashboard
         run: npm ci --include=dev --no-audit --no-fund --registry=https://registry.npmjs.org
 
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install docs dependencies
+        run: python -m pip install --disable-pip-version-check -r docs/requirements-docs.txt
+
       - name: Validate public showcase catalog
         run: python3 examples/showcase-catalog-smoke.py
 
@@ -72,6 +85,9 @@ jobs:
       - name: Export Pages frontstage artifact
         working-directory: apps/presentation/dashboard
         run: npm run export:frontstage-share -- --base /loopx/ --out-dir ../../../output/frontstage-pages
+
+      - name: Build documentation site
+        run: mkdocs build --strict --site-dir output/frontstage-pages/site/docs
 
       - name: Configure Pages
         if: github.event_name != 'pull_request'

--- a/.github/workflows/frontstage-pages.yml
+++ b/.github/workflows/frontstage-pages.yml
@@ -7,6 +7,8 @@ on:
       - ".github/workflows/frontstage-pages.yml"
       - "apps/presentation/dashboard/**"
       - "apps/presentation/site/**"
+      - "docs/**"
+      - "mkdocs.yaml"
       - "docs/showcases/**"
       - "docs/assets/long-running-loop-openviking-trajectory.png"
       - "docs/assets/long-running-loop-ml-experiment-trajectory.png"
@@ -22,6 +24,8 @@ on:
       - ".github/workflows/frontstage-pages.yml"
       - "apps/presentation/dashboard/**"
       - "apps/presentation/site/**"
+      - "docs/**"
+      - "mkdocs.yaml"
       - "docs/showcases/**"
       - "docs/assets/long-running-loop-openviking-trajectory.png"
       - "docs/assets/long-running-loop-ml-experiment-trajectory.png"
@@ -62,6 +66,15 @@ jobs:
         working-directory: apps/presentation/dashboard
         run: npm ci --include=dev --no-audit --no-fund --registry=https://registry.npmjs.org
 
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install docs dependencies
+        run: python -m pip install --disable-pip-version-check -r docs/requirements-docs.txt
+
       - name: Validate public showcase catalog
         run: python3 examples/showcase-catalog-smoke.py
 
@@ -72,6 +85,9 @@ jobs:
       - name: Export Pages frontstage artifact
         working-directory: apps/presentation/dashboard
         run: npm run export:frontstage-share -- --base /loopx/ --out-dir ../../../output/frontstage-pages
+
+      - name: Build documentation site
+        run: mkdocs build --site-dir output/frontstage-pages/site/docs
 
       - name: Configure Pages
         if: github.event_name != 'pull_request'

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .venv/
 .idea
 node_modules/
+.worktrees/
 apps/dashboard/public/*.local.json
 apps/presentation/dashboard/public/*.local.json
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) [![Release](https://img.shields.io/github/v/release/huangruiteng/loopx?display_name=tag)](https://github.com/huangruiteng/loopx/releases/latest) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](pyproject.toml) [![Local first](https://img.shields.io/badge/control--plane-local--first-brightgreen.svg)](docs/public-private-boundary.md) [![Loop Agents](https://img.shields.io/badge/status-loop%20agents%20early-orange.svg)](docs/product/release-readiness.md)
 
-[Public website](https://huangruiteng.github.io/loopx/) · [Try LoopX](#try-loopx) · [See real loops](#evidence) · [How it works](#why-loopx) · [User manual](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [简体中文](README.zh-CN.md)
+[Public website](https://huangruiteng.github.io/loopx/) · [Docs](https://huangruiteng.github.io/loopx/docs/) · [Try LoopX](#try-loopx) · [See real loops](#evidence) · [How it works](#why-loopx) · [User manual](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [简体中文](README.zh-CN.md)
 
 **把会干活的 Agent，接成可管理、可复盘、可持续改进的数字员工。**
 
@@ -337,6 +337,7 @@ quota, and handoff explicit.
 
 - Local read-first UI: [dashboard guide](apps/presentation/dashboard/README.md)
 - Public product overview: [public homepage](https://huangruiteng.github.io/loopx/)
+- Documentation portal: [hosted docs](https://huangruiteng.github.io/loopx/docs/)
 - Feishu/Lark projection: [Lark Kanban adapter](docs/integrations/lark-kanban-control-plane-adapter.md)
 - Generic host integration: [integration guide](docs/integration.md)
 - Custom multi-agent runner:
@@ -382,8 +383,10 @@ loopx check \
 
 ## Advanced Documentation
 
-Start with the path that matches your role. The
-[documentation index](docs/README.md) remains the complete map.
+Start with the path that matches your role. Use the hosted
+[documentation portal](https://huangruiteng.github.io/loopx/docs/) for the
+published docs site; the [documentation index](docs/README.md) remains the
+complete source map.
 
 ### Use and Operate
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) [![Release](https://img.shields.io/github/v/release/huangruiteng/loopx?display_name=tag)](https://github.com/huangruiteng/loopx/releases/latest) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](pyproject.toml) [![Local first](https://img.shields.io/badge/control--plane-local--first-brightgreen.svg)](docs/public-private-boundary.md) [![Loop Agents](https://img.shields.io/badge/status-loop%20agents%20early-orange.svg)](docs/product/release-readiness.md)
 
-[Try LoopX](#try-loopx) · [See real loops](#evidence) · [How it works](#why-loopx) · [Hosted frontstage](https://huangruiteng.github.io/loopx/frontstage/) · [User manual](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [简体中文](README.zh-CN.md)
+[Public website](https://huangruiteng.github.io/loopx/) · [Try LoopX](#try-loopx) · [See real loops](#evidence) · [How it works](#why-loopx) · [User manual](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [简体中文](README.zh-CN.md)
 
 **把会干活的 Agent，接成可管理、可复盘、可持续改进的数字员工。**
 
@@ -134,8 +134,8 @@ todo, quota, evidence, and targeted wake remain visible.**
 
 More inspectable surfaces:
 
-- [Hosted frontstage](https://huangruiteng.github.io/loopx/frontstage/) and its
-  [public demo script](docs/outreach/frontstage-demo-script.md);
+- the [public homepage](https://huangruiteng.github.io/loopx/) for the product
+  narrative, quick start, and long-running evidence;
 - the [showcase catalog](docs/showcases/README.md), including
   [blocked-P0 safe rotation](docs/showcases/cases/0617-blocked-p0-safe-rotation.md),
   [LoopX self-iteration](docs/showcases/cases/0619-loopx-self-iteration.md), and
@@ -245,7 +245,7 @@ LoopX folds its control-plane mechanics into five questions:
 | Goal state and status | Tracks active state, todos, claims, gates, evidence, run history, and first-screen attention. | `loopx status`, `loopx diagnose`, `loopx review-packet` |
 | Quota and interaction contract | Decides whether a turn should deliver, ask, wait, self-repair, or stay quiet. | `loopx quota should-run`, [quota allocation](docs/quota-allocation.md) |
 | Agent runtime bridges | Keeps Codex App, Codex CLI, Claude Code, and generic workers aligned with the same guard. | `loopx heartbeat-prompt`, `loopx codex-cli-bootstrap-message`, `loopx worker-bridge` |
-| Operator surfaces | Renders compact status without making the browser the state authority. | `loopx serve-status`, [dashboard](apps/presentation/dashboard/README.md), [frontstage](https://huangruiteng.github.io/loopx/frontstage/) |
+| Operator surfaces | Renders compact status without making the browser the state authority. | `loopx serve-status`, [dashboard](apps/presentation/dashboard/README.md) |
 | External projections | Projects todos and gates into collaboration surfaces while LoopX remains authoritative. | `loopx lark-kanban`, [Lark Kanban adapter](docs/integrations/lark-kanban-control-plane-adapter.md) |
 | Domain capabilities | Packages repeatable work lanes such as issue fixing, content operations, value connector planning, ML experiment advice, benchmark evidence, and Explore. | `loopx issue-fix`, `loopx content-ops`, `loopx value-connectors`, `loopx ml-experiment`, `loopx benchmark`, [Explore](docs/capabilities/explore/README.md) |
 | Experimental context learning | Lets named registered agents trial provider-neutral Reward Memory through ignored, default-off project configuration. OpenViking is one provider option, not a global dependency. | `loopx reward-memory experiment-status`, [Reward Memory architecture](docs/reference/protocols/reward-memory-architecture-v0.md) |
@@ -336,7 +336,7 @@ quota, and handoff explicit.
 ### App and Projection Paths
 
 - Local read-first UI: [dashboard guide](apps/presentation/dashboard/README.md)
-- Public-safe product view: [hosted frontstage](https://huangruiteng.github.io/loopx/frontstage/)
+- Public product overview: [public homepage](https://huangruiteng.github.io/loopx/)
 - Feishu/Lark projection: [Lark Kanban adapter](docs/integrations/lark-kanban-control-plane-adapter.md)
 - Generic host integration: [integration guide](docs/integration.md)
 - Custom multi-agent runner:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) [![Release](https://img.shields.io/github/v/release/huangruiteng/loopx?display_name=tag)](https://github.com/huangruiteng/loopx/releases/latest) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](pyproject.toml) [![Local first](https://img.shields.io/badge/control--plane-local--first-brightgreen.svg)](docs/public-private-boundary.md) [![Loop Agents](https://img.shields.io/badge/status-loop%20agents%20early-orange.svg)](docs/product/release-readiness.md)
 
-[Try LoopX](#try-loopx) · [See real loops](#evidence) · [How it works](#why-loopx) · [Hosted frontstage](https://huangruiteng.github.io/loopx/frontstage/) · [User manual](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [简体中文](README.zh-CN.md)
+[Try LoopX](#try-loopx) · [See real loops](#evidence) · [How it works](#why-loopx) · [Docs](https://huangruiteng.github.io/loopx/docs/) · [Hosted frontstage](https://huangruiteng.github.io/loopx/frontstage/) · [User manual](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [简体中文](README.zh-CN.md)
 
 **把会干活的 Agent，接成可管理、可复盘、可持续改进的数字员工。**
 
@@ -336,6 +336,7 @@ quota, and handoff explicit.
 ### App and Projection Paths
 
 - Local read-first UI: [dashboard guide](apps/presentation/dashboard/README.md)
+- Documentation portal: [hosted docs](https://huangruiteng.github.io/loopx/docs/)
 - Public-safe product view: [hosted frontstage](https://huangruiteng.github.io/loopx/frontstage/)
 - Feishu/Lark projection: [Lark Kanban adapter](docs/integrations/lark-kanban-control-plane-adapter.md)
 - Generic host integration: [integration guide](docs/integration.md)
@@ -382,8 +383,10 @@ loopx check \
 
 ## Advanced Documentation
 
-Start with the path that matches your role. The
-[documentation index](docs/README.md) remains the complete map.
+Start with the path that matches your role. Use the hosted
+[documentation portal](https://huangruiteng.github.io/loopx/docs/) for the
+published docs site; the [documentation index](docs/README.md) remains the
+complete source map.
 
 ### Use and Operate
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) [![Release](https://img.shields.io/github/v/release/huangruiteng/loopx?display_name=tag)](https://github.com/huangruiteng/loopx/releases/latest) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](pyproject.toml) [![Local first](https://img.shields.io/badge/control--plane-local--first-brightgreen.svg)](docs/public-private-boundary.md) [![Loop Agents](https://img.shields.io/badge/status-loop%20agents%20early-orange.svg)](docs/product/release-readiness.md)
 
-[试用 LoopX](#试用-loopx) · [查看真实 Loop](#证据) · [理解工作原理](#为什么需要-loopx) · [Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/) · [用户手册](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [English](README.md)
+[产品首页](https://huangruiteng.github.io/loopx/) · [试用 LoopX](#试用-loopx) · [查看真实 Loop](#证据) · [理解工作原理](#为什么需要-loopx) · [用户手册](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [English](README.md)
 
 **把会干活的 Agent，接成可管理、可复盘、可持续改进的数字员工。**
 
@@ -120,8 +120,7 @@ targeted wake 同屏可见。**
 
 更多可检查入口：
 
-- [Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/) 与
-  [公开演示脚本](docs/outreach/frontstage-demo-script.md)；
+- [产品首页](https://huangruiteng.github.io/loopx/)：查看产品叙事、快速开始和长程证据；
 - [Showcase 目录](docs/showcases/README.md)，包括
   [Blocked P0 安全侧路](docs/showcases/cases/0617-blocked-p0-safe-rotation.md)、
   [LoopX 自迭代](docs/showcases/cases/0619-loopx-self-iteration.md)和
@@ -226,7 +225,7 @@ LoopX 把控制面归结为五个用户可以直接行动的问题：
 | Goal state 与 status | 跟踪 active state、todo、claim、gate、evidence、run history 和首屏关注点。 | `loopx status`、`loopx diagnose`、`loopx review-packet` |
 | Quota 与 interaction contract | 决定一轮应该执行、提问、等待、自修复还是静默。 | `loopx quota should-run`、[Quota Allocation](docs/quota-allocation.md) |
 | Agent runtime bridge | 让 Codex App、Codex CLI、Claude Code 和 generic worker 服从同一 guard。 | `loopx heartbeat-prompt`、`loopx codex-cli-bootstrap-message`、`loopx worker-bridge` |
-| Operator surface | 呈现紧凑状态，但不让浏览器成为状态事实源。 | `loopx serve-status`、[Dashboard](apps/presentation/dashboard/README.md)、[Frontstage](https://huangruiteng.github.io/loopx/frontstage/) |
+| Operator surface | 呈现紧凑状态，但不让浏览器成为状态事实源。 | `loopx serve-status`、[Dashboard](apps/presentation/dashboard/README.md) |
 | External projection | 把 todo / gate 投影到协作表面，同时保持 LoopX 权威。 | `loopx lark-kanban`、[Lark Kanban adapter](docs/integrations/lark-kanban-control-plane-adapter.md) |
 | Domain capability | 打包 Issue Fix、内容运营、value connector、ML 实验、benchmark 与 Explore 等可重复泳道。 | `loopx issue-fix`、`loopx content-ops`、`loopx value-connectors`、`loopx ml-experiment`、`loopx benchmark`、[Explore](docs/capabilities/explore/README.md) |
 | 实验性上下文学习 | 通过 ignored、默认关闭的项目配置，为明确注册的 agent 试用 provider-neutral Reward Memory；OpenViking 是 provider 之一，不是全局依赖。 | `loopx reward-memory experiment-status`、[Reward Memory 中文架构](docs/reference/protocols/reward-memory-architecture-v0.zh-CN.md) |
@@ -304,7 +303,7 @@ treatment 和 guardrail 的任务，不替代生产审批。先读
 ### App 与 Projection
 
 - 本地 read-first UI：[Dashboard Guide](apps/presentation/dashboard/README.md)
-- Public-safe 产品视图：[Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/)
+- 公开产品概览：[产品首页](https://huangruiteng.github.io/loopx/)
 - 飞书投影：[Lark Kanban Adapter](docs/integrations/lark-kanban-control-plane-adapter.md)
 - 通用 host 集成：[Integration Guide](docs/integration.md)
 - 自有 multi-agent runner：

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) [![Release](https://img.shields.io/github/v/release/huangruiteng/loopx?display_name=tag)](https://github.com/huangruiteng/loopx/releases/latest) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](pyproject.toml) [![Local first](https://img.shields.io/badge/control--plane-local--first-brightgreen.svg)](docs/public-private-boundary.md) [![Loop Agents](https://img.shields.io/badge/status-loop%20agents%20early-orange.svg)](docs/product/release-readiness.md)
 
-[产品首页](https://huangruiteng.github.io/loopx/) · [试用 LoopX](#试用-loopx) · [查看真实 Loop](#证据) · [理解工作原理](#为什么需要-loopx) · [用户手册](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [English](README.md)
+[产品首页](https://huangruiteng.github.io/loopx/) · [文档](https://huangruiteng.github.io/loopx/docs/) · [试用 LoopX](#试用-loopx) · [查看真实 Loop](#证据) · [理解工作原理](#为什么需要-loopx) · [用户手册](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [English](README.md)
 
 **把会干活的 Agent，接成可管理、可复盘、可持续改进的数字员工。**
 
@@ -304,6 +304,7 @@ treatment 和 guardrail 的任务，不替代生产审批。先读
 
 - 本地 read-first UI：[Dashboard Guide](apps/presentation/dashboard/README.md)
 - 公开产品概览：[产品首页](https://huangruiteng.github.io/loopx/)
+- 文档门户：[线上文档](https://huangruiteng.github.io/loopx/docs/)
 - 飞书投影：[Lark Kanban Adapter](docs/integrations/lark-kanban-control-plane-adapter.md)
 - 通用 host 集成：[Integration Guide](docs/integration.md)
 - 自有 multi-agent runner：
@@ -346,7 +347,8 @@ loopx check \
 
 ## 进阶文档
 
-按你的角色选择入口；[完整文档索引](docs/README.md)仍是权威地图。
+按你的角色选择入口；[线上文档](https://huangruiteng.github.io/loopx/docs/)
+提供发布后的浏览入口，[完整文档索引](docs/README.md)仍是权威地图。
 
 ### 使用与运维
 

--- a/apps/presentation/README.md
+++ b/apps/presentation/README.md
@@ -4,7 +4,9 @@ Browser applications that present LoopX state live here.
 
 - `dashboard/`: the React/Vite operator dashboard, frontstage routes, and
   developer cockpit.
-- `site/`: the static public homepage published at the GitHub Pages root.
+- `site/`: the static
+  [public homepage](https://huangruiteng.github.io/loopx/) published at the
+  GitHub Pages root.
 
 Apps in this directory consume public-safe LoopX projections and fixtures. They
 do not own control-plane state or write directly to LoopX registries.

--- a/apps/presentation/site/README.md
+++ b/apps/presentation/site/README.md
@@ -1,7 +1,8 @@
 # LoopX Public Website
 
-This directory owns the static, public-safe homepage published at the root of
-the LoopX GitHub Pages site. The dashboard exporter copies the compiled React
+This directory owns the static, public-safe
+[LoopX homepage](https://huangruiteng.github.io/loopx/) published at the root
+of the GitHub Pages site. The dashboard exporter copies the compiled React
 application to `/frontstage/`, then writes this homepage to the Pages root.
 
 `__LOOPX_BASE__` is replaced by the exporter so links and assets work both at

--- a/apps/presentation/site/index.html
+++ b/apps/presentation/site/index.html
@@ -29,7 +29,7 @@
         <a href="#product" data-i18n="nav.product">Product</a>
         <a href="#workflow" data-i18n="nav.workflow">How it works</a>
         <a href="#showcases" data-i18n="nav.showcases">Showcases</a>
-        <a href="https://github.com/huangruiteng/loopx/tree/main/docs" data-i18n="nav.docs">Docs</a>
+        <a href="__LOOPX_BASE__docs/" data-i18n="nav.docs">Docs</a>
         <button class="language-toggle" type="button" data-language-toggle aria-label="切换为中文">中文</button>
       </nav>
       <a class="github-link" href="https://github.com/huangruiteng/loopx" aria-label="LoopX on GitHub">
@@ -43,7 +43,7 @@
         <a href="#product" data-i18n="nav.product">Product</a>
         <a href="#workflow" data-i18n="nav.workflow">How it works</a>
         <a href="#showcases" data-i18n="nav.showcases">Showcases</a>
-        <a href="https://github.com/huangruiteng/loopx/tree/main/docs" data-i18n="nav.docs">Docs</a>
+        <a href="__LOOPX_BASE__docs/" data-i18n="nav.docs">Docs</a>
         <a href="https://github.com/huangruiteng/loopx" data-i18n="nav.github">GitHub</a>
         <button class="language-toggle mobile-language-toggle" type="button" data-language-toggle aria-label="切换为中文">中文</button>
       </nav>
@@ -322,7 +322,7 @@
     <footer>
       <a class="brand footer-brand" href="#top"><span class="brand-mark" aria-hidden="true">∞</span><span>LoopX</span></a>
       <p data-i18n="footer.tagline">Keep the loop moving. Keep the judgment human.</p>
-      <div><a href="https://github.com/huangruiteng/loopx">GitHub</a><a href="__LOOPX_BASE__frontstage/" data-i18n="footer.frontstage">Frontstage</a><a href="https://github.com/huangruiteng/loopx/tree/main/docs" data-i18n="nav.docs">Docs</a></div>
+      <div><a href="https://github.com/huangruiteng/loopx">GitHub</a><a href="__LOOPX_BASE__frontstage/" data-i18n="footer.frontstage">Frontstage</a><a href="__LOOPX_BASE__docs/" data-i18n="nav.docs">Docs</a></div>
     </footer>
   </body>
 </html>

--- a/apps/presentation/site/index.html
+++ b/apps/presentation/site/index.html
@@ -29,7 +29,7 @@
         <a href="#product" data-i18n="nav.product">Product</a>
         <a href="#workflow" data-i18n="nav.workflow">How it works</a>
         <a href="#showcases" data-i18n="nav.showcases">Showcases</a>
-        <a href="https://github.com/huangruiteng/loopx/tree/main/docs" data-i18n="nav.docs">Docs</a>
+        <a href="__LOOPX_BASE__docs/" data-i18n="nav.docs">Docs</a>
         <button class="language-toggle" type="button" data-language-toggle aria-label="切换为中文">中文</button>
       </nav>
       <a class="github-link" href="https://github.com/huangruiteng/loopx" aria-label="LoopX on GitHub">
@@ -43,7 +43,7 @@
         <a href="#product" data-i18n="nav.product">Product</a>
         <a href="#workflow" data-i18n="nav.workflow">How it works</a>
         <a href="#showcases" data-i18n="nav.showcases">Showcases</a>
-        <a href="https://github.com/huangruiteng/loopx/tree/main/docs" data-i18n="nav.docs">Docs</a>
+        <a href="__LOOPX_BASE__docs/" data-i18n="nav.docs">Docs</a>
         <a href="https://github.com/huangruiteng/loopx" data-i18n="nav.github">GitHub</a>
         <button class="language-toggle mobile-language-toggle" type="button" data-language-toggle aria-label="切换为中文">中文</button>
       </nav>

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ material available without putting all of it on one page.
 
 | You want to... | Start here | Continue with |
 | --- | --- | --- |
+| Understand LoopX before installing | [Public homepage](https://huangruiteng.github.io/loopx/) | [Project README](../README.md) |
 | Try LoopX in a repository | [Getting started](guides/getting-started.md) | [Newcomer command path](guides/newcomer-command-path.md) |
 | Run or recover a long-lived goal | [Operations](operations/README.md) | [Integration guide](integration.md) |
 | Understand the control plane | [Architecture](architecture.md) | [Concepts](concepts/README.md) |
@@ -16,9 +17,11 @@ material available without putting all of it on one page.
 | Build or review LoopX | [Developer guide](development/README.md) | [Testing and quality](development/testing-and-quality.md) |
 | Inspect real outcomes | [Showcases](showcases/README.md) | [Research and evidence](research/README.md) |
 
-The [project README](../README.md) is the product overview and shortest public
-quick start. The [public user manual](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg)
-provides a longer onboarding path.
+The [public homepage](https://huangruiteng.github.io/loopx/) is the shortest
+product overview. The [project README](../README.md) keeps the source-linked
+quick start and capability map, while the
+[public user manual](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) provides
+a longer onboarding path.
 
 ## Core References
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -9,7 +9,7 @@ not need these documents to start LoopX.
 
 ## Start Here / 从这里开始
 
-1. Read [Contributing](../../CONTRIBUTING.md) for repository boundaries and the
+1. Read [Contributing](https://github.com/huangruiteng/loopx/blob/main/CONTRIBUTING.md) for repository boundaries and the
    pull-request checklist.
 2. Follow the [control-plane developer course](control-plane-course/README.md)
    for a nine-lecture, code-led path through the real CLI, state machine, and
@@ -25,7 +25,7 @@ not need these documents to start LoopX.
 6. Follow the [documentation layout policy](documentation-layout.md) before
    adding or moving public documentation.
 
-1. 先阅读[贡献指南](../../CONTRIBUTING.md)，了解仓库边界和 PR 检查项。
+1. 先阅读[贡献指南](https://github.com/huangruiteng/loopx/blob/main/CONTRIBUTING.md)，了解仓库边界和 PR 检查项。
 2. 按顺序学习[控制面开发者 9 讲](control-plane-course/README.md)，沿真实 CLI、
    状态机、核心函数和分层质量门禁建立代码心智模型。
 3. 修改 agent-facing 输出、调度决策、todo/gate 语义、新用户接入或发布流程前，

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -910,7 +910,8 @@ The dashboard should answer, before raw log drill-down:
 - what is waiting on evidence;
 - what boundary cannot be crossed yet.
 
-See [apps/presentation/dashboard/README.md](../../apps/presentation/dashboard/README.md).
+See
+[apps/presentation/dashboard/README.md](https://github.com/huangruiteng/loopx/blob/main/apps/presentation/dashboard/README.md).
 
 ## Public / Private Boundary
 
@@ -982,7 +983,7 @@ that omits dashboard validation; the runtime evidence records that skip.
 
 Start here:
 
-- [Documentation index](../README.md)
+- [Documentation index](https://github.com/huangruiteng/loopx/blob/main/docs/README.md)
 - [Showcase catalog](../showcases/README.md)
 - [State interaction model](../state-interaction-model.md)
 - [Interaction pattern catalog](../concepts/interaction-pattern-catalog.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,79 @@
+# Welcome to LoopX
+
+LoopX is the local control plane for long-running AI agent work. It keeps
+objectives, gates, todos, evidence, quota, and handoffs stable while Codex,
+Claude Code, OpenCode, Cursor, or a custom runner executes bounded turns.
+
+## Choose Your Path
+
+<div class="grid cards" markdown>
+
+-   :material-rocket-launch-outline: **Start using LoopX**
+
+    Install the CLI, connect a project, inspect the current gate, and start a
+    real goal from your agent.
+
+    [:octicons-arrow-right-24: Getting started](guides/getting-started.md)
+
+-   :material-map-marker-path: **Understand the control plane**
+
+    Learn how goals, user gates, agent todos, quota, evidence, and handoffs fit
+    into one durable state kernel.
+
+    [:octicons-arrow-right-24: Concepts](concepts/README.md)
+
+-   :material-console-line: **Operate a long task**
+
+    Use status, quota, review packets, and the local dashboard without making
+    the browser the source of truth.
+
+    [:octicons-arrow-right-24: Operations](operations/README.md)
+
+-   :material-source-branch: **Build or extend LoopX**
+
+    Work from the developer guide, testing policy, protocol references, and
+    public/private boundary checks.
+
+    [:octicons-arrow-right-24: Development](development/README.md)
+
+</div>
+
+## Quick Start
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+loopx doctor
+
+cd /path/to/your-project
+loopx connect
+loopx status
+```
+
+Then start real work from your agent:
+
+```text
+/loopx <complex task>
+```
+
+## Core Commands
+
+| Need | Command |
+| --- | --- |
+| Check installation | `loopx doctor` |
+| Inspect current state | `loopx status` |
+| Decide whether a turn may run | `loopx quota should-run --goal-id <goal-id>` |
+| Manage user and agent todos | `loopx todo --help` |
+| Build a handoff packet | `loopx review-packet --goal-id <goal-id>` |
+| Serve local dashboard data | `loopx serve-status --global-registry --port 8766` |
+
+## Source Of Truth
+
+The docs site is a published read model over repository Markdown. The canonical
+source remains the Markdown in `docs/`, while project-local runtime state stays
+ignored and private.
+
+- [Project README](https://github.com/huangruiteng/loopx#readme)
+- [Public/private boundary](public-private-boundary.md)
+- [Status data contract](status-data-contract.md)
+- [Release readiness](product/release-readiness.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,79 @@
+# Welcome to LoopX
+
+LoopX is the local control plane for long-running AI agent work. It keeps
+objectives, gates, todos, evidence, quota, and handoffs stable while Codex,
+Claude Code, OpenCode, Cursor, or a custom runner executes bounded turns.
+
+## Choose Your Path
+
+<div class="grid cards" markdown>
+
+-   :material-rocket-launch-outline: **Start using LoopX**
+
+    Install the CLI, connect a project, inspect the current gate, and start a
+    real goal from your agent.
+
+    [:octicons-arrow-right-24: Getting started](guides/getting-started.md)
+
+-   :material-map-marker-path: **Understand the control plane**
+
+    Learn how goals, user gates, agent todos, quota, evidence, and handoffs fit
+    into one durable state kernel.
+
+    [:octicons-arrow-right-24: Concepts](concepts/README.md)
+
+-   :material-console-line: **Operate a long task**
+
+    Use status, quota, review packets, and the local dashboard/frontstage without
+    making the browser the source of truth.
+
+    [:octicons-arrow-right-24: Operations](operations/README.md)
+
+-   :material-source-branch: **Build or extend LoopX**
+
+    Work from the developer guide, testing policy, protocol references, and
+    public/private boundary checks.
+
+    [:octicons-arrow-right-24: Development](development/README.md)
+
+</div>
+
+## Quick Start
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+loopx doctor
+
+cd /path/to/your-project
+loopx connect
+loopx status
+```
+
+Then start real work from your agent:
+
+```text
+/loopx <complex task>
+```
+
+## Core Commands
+
+| Need | Command |
+| --- | --- |
+| Check installation | `loopx doctor` |
+| Inspect current state | `loopx status` |
+| Decide whether a turn may run | `loopx quota should-run --goal-id <goal-id>` |
+| Manage user and agent todos | `loopx todo --help` |
+| Build a handoff packet | `loopx review-packet --goal-id <goal-id>` |
+| Serve local dashboard data | `loopx serve-status --global-registry --port 8766` |
+
+## Source Of Truth
+
+The docs site is a published read model over repository Markdown. The canonical
+source remains the Markdown in `docs/`, while project-local runtime state stays
+ignored and private.
+
+- [Project README](https://github.com/huangruiteng/loopx#readme)
+- [Public/private boundary](public-private-boundary.md)
+- [Status data contract](status-data-contract.md)
+- [Release readiness](product/release-readiness.md)

--- a/docs/product/core-control-plane/state-machine.md
+++ b/docs/product/core-control-plane/state-machine.md
@@ -12,19 +12,19 @@ public-safe map over the current repository contracts, especially:
   derived runtime names;
 - [`interaction-catalog.md`](interaction-catalog.md) for reusable interaction
   patterns;
-- [`loopx/control_plane/todos/contract.py`](../../../loopx/control_plane/todos/contract.py) for todo status,
+- [`loopx/control_plane/todos/contract.py`](https://github.com/huangruiteng/loopx/blob/main/loopx/control_plane/todos/contract.py) for todo status,
   task class, decision scope, resume, claim, and monitor metadata fields;
-- [`loopx/quota.py`](../../../loopx/quota.py) for `quota should-run`, runtime
+- [`loopx/quota.py`](https://github.com/huangruiteng/loopx/blob/main/loopx/quota.py) for `quota should-run`, runtime
   states, `effective_action`, `interaction_contract`, spend, and monitor poll
   contracts;
-- [`loopx/control_plane/scheduler/scheduler_hint.py`](../../../loopx/control_plane/scheduler/scheduler_hint.py)
+- [`loopx/control_plane/scheduler/scheduler_hint.py`](https://github.com/huangruiteng/loopx/blob/main/loopx/control_plane/scheduler/scheduler_hint.py)
   for cadence/backoff/reset-token behavior;
 - [`goal_vision_replan_contract_v0`](../../reference/protocols/goal-vision-replan-contract-v0.md)
   for bounded per-agent vision, replan transitions, and goal-route projection;
 - cross-agent handoff gate states in
-  [`loopx/control_plane/todos/handoff_gate.py`](../../../loopx/control_plane/todos/handoff_gate.py);
-- [`loopx/project_map.py`](../../../loopx/project_map.py) and
-  [`loopx/bootstrap.py`](../../../loopx/bootstrap.py) for project registration,
+  [`loopx/control_plane/todos/handoff_gate.py`](https://github.com/huangruiteng/loopx/blob/main/loopx/control_plane/todos/handoff_gate.py);
+- [`loopx/project_map.py`](https://github.com/huangruiteng/loopx/blob/main/loopx/project_map.py) and
+  [`loopx/bootstrap.py`](https://github.com/huangruiteng/loopx/blob/main/loopx/bootstrap.py) for project registration,
   read-only-map opt-in, global sync, and host-loop activation.
 
 ## How The Machines Compose

--- a/docs/project/history.md
+++ b/docs/project/history.md
@@ -66,5 +66,7 @@ public [release archive](https://github.com/huangruiteng/loopx/releases).
 - Keep private operating context, raw trajectories, internal links, and local
   paths out of the public timeline.
 
-See [AUTHORS.md](../../AUTHORS.md) for creator and contributor attribution and
-[GOVERNANCE.md](../../GOVERNANCE.md) for the current maintainer model.
+See [AUTHORS.md](https://github.com/huangruiteng/loopx/blob/main/AUTHORS.md) for
+creator and contributor attribution and
+[GOVERNANCE.md](https://github.com/huangruiteng/loopx/blob/main/GOVERNANCE.md)
+for the current maintainer model.

--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -1100,7 +1100,7 @@ Codex turn actually consumes quota. The smallest public-safe event is
 ```
 
 The public fixture is
-[`examples/quota-slot-spend-event.example.json`](../examples/quota-slot-spend-event.example.json).
+[`examples/quota-slot-spend-event.example.json`](https://github.com/huangruiteng/loopx/blob/main/examples/quota-slot-spend-event.example.json).
 
 Validation rule:
 

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,0 +1,3 @@
+mkdocs>=1.6,<2
+mkdocs-material>=9.6.0,<10
+pymdown-extensions>=10.0,<11

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,0 +1,2 @@
+mkdocs-material>=9.6.0,<10
+pymdown-extensions>=10.0

--- a/docs/showcases/README.md
+++ b/docs/showcases/README.md
@@ -41,20 +41,15 @@ cd apps/presentation/dashboard
 npm run export:frontstage-share
 ```
 
-This writes `/tmp/loopx-frontstage-share-bundle` with the compiled
-dashboard, a sanitized `goal_channel_projection_v0` status fixture, direct
-`/frontstage/` static-route support, and a manifest. It is the foundation for a
-future GitHub Pages showcase: Pages should publish this generated artifact, not
-live registry files or local status exports.
-Once repository Pages is enabled for GitHub Actions, the same generated bundle
-is available as the
-[hosted frontstage](https://huangruiteng.github.io/loopx/frontstage/).
-That hosted route is intentionally case-first. It should help a new user or
-developer understand the showcased patterns before reading CLI output: public
-cases, efficiency evidence, and the public boundary come from this directory;
+This writes `/tmp/loopx-frontstage-share-bundle` with the static
+[public homepage](https://huangruiteng.github.io/loopx/), compiled dashboard, a
+sanitized `goal_channel_projection_v0` status fixture, direct `/frontstage/`
+static-route support, and a manifest. GitHub Pages publishes this generated
+artifact, not live registry files or local status exports. The interactive
+dashboard route remains an exporter compatibility surface, not a promoted
+public entry. New users should start from the homepage; public cases,
+efficiency evidence, and the public boundary come from this directory, while
 live local `statusUrl` feeds belong only to explicit ops-mode inspection.
-For a short external walkthrough, use the
-[frontstage demo script](../outreach/frontstage-demo-script.md).
 For animated outreach assets, start from the
 [showcase animation skill spike](../outreach/showcase-animation-skill-spike.md)
 and the

--- a/examples/frontstage-share-bundle-smoke.mjs
+++ b/examples/frontstage-share-bundle-smoke.mjs
@@ -111,6 +111,12 @@ if (!homepageHtml.includes('class="hero-phrase"')) {
 if (!homepageHtml.includes('href="/loopx/frontstage/"')) {
   throw new Error("homepage footer must retain the Frontstage entry");
 }
+if (!homepageHtml.includes('href="/loopx/docs/"')) {
+  throw new Error("homepage navigation must link to the hosted docs portal");
+}
+if (homepageHtml.includes('https://github.com/huangruiteng/loopx/tree/main/docs')) {
+  throw new Error("homepage Docs links must not bypass the hosted docs portal");
+}
 if (!homepageHtml.includes('data-copy-key="agentSetup"') || !homepageHtml.includes("One message to your current agent") || !homepageHtml.includes('href="#quickstart"')) {
   throw new Error("homepage must make the localized agent setup prompt the primary first-run path");
 }
@@ -228,7 +234,10 @@ const manifest = JSON.parse(await readFile(resolve(outDir, "frontstage-share-man
 if (manifest.base !== "/loopx/") {
   throw new Error(`manifest base mismatch: ${manifest.base}`);
 }
-if (manifest.homepage_entry !== "site/index.html" || manifest.frontstage_entry !== "site/frontstage/index.html") {
+if (
+  manifest.homepage_entry !== "site/index.html" ||
+  manifest.frontstage_entry !== "site/frontstage/index.html"
+) {
   throw new Error(`manifest entries mismatch: ${JSON.stringify(manifest)}`);
 }
 if (manifest.content_sources?.public_homepage !== "apps/presentation/site") {

--- a/examples/frontstage-share-bundle-smoke.mjs
+++ b/examples/frontstage-share-bundle-smoke.mjs
@@ -111,6 +111,9 @@ if (!homepageHtml.includes('class="hero-phrase"')) {
 if (!homepageHtml.includes('href="/loopx/frontstage/"')) {
   throw new Error("homepage footer must retain the Frontstage entry");
 }
+if (!homepageHtml.includes('href="/loopx/docs/"')) {
+  throw new Error("homepage navigation must link to the hosted docs portal");
+}
 if (!homepageHtml.includes('data-copy-key="agentSetup"') || !homepageHtml.includes("One message to your current agent") || !homepageHtml.includes('href="#quickstart"')) {
   throw new Error("homepage must make the localized agent setup prompt the primary first-run path");
 }
@@ -228,7 +231,10 @@ const manifest = JSON.parse(await readFile(resolve(outDir, "frontstage-share-man
 if (manifest.base !== "/loopx/") {
   throw new Error(`manifest base mismatch: ${manifest.base}`);
 }
-if (manifest.homepage_entry !== "site/index.html" || manifest.frontstage_entry !== "site/frontstage/index.html") {
+if (
+  manifest.homepage_entry !== "site/index.html" ||
+  manifest.frontstage_entry !== "site/frontstage/index.html"
+) {
   throw new Error(`manifest entries mismatch: ${JSON.stringify(manifest)}`);
 }
 if (manifest.content_sources?.public_homepage !== "apps/presentation/site") {

--- a/examples/showcase-catalog-smoke.py
+++ b/examples/showcase-catalog-smoke.py
@@ -238,8 +238,7 @@ def main() -> int:
     for phrase in (
         "Loop engineering for long-running AI agents and peer agent teams.",
         "A lightweight state kernel and agent-agnostic local control plane for",
-        "https://huangruiteng.github.io/loopx/frontstage/",
-        "docs/outreach/frontstage-demo-script.md",
+        "https://huangruiteng.github.io/loopx/",
         "## Advanced Paths",
         "docs/assets/long-running-loop-openviking-trajectory.png",
         "docs/assets/long-running-loop-ml-experiment-trajectory.png",
@@ -251,6 +250,13 @@ def main() -> int:
         "docs/showcases/cases/0619-dynamic-workflow-hardware-agent.html",
     ):
         assert phrase in repo_readme, phrase
+    hosted_frontstage = "https://huangruiteng.github.io/loopx/frontstage/"
+    assert hosted_frontstage not in repo_readme, (
+        "README must promote the public homepage instead of hosted frontstage"
+    )
+    assert hosted_frontstage not in showcase_index, (
+        "showcase index must not promote hosted frontstage"
+    )
 
     print("showcase-catalog-smoke ok")
     return 0

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,0 +1,133 @@
+site_name: LoopX
+site_url: https://huangruiteng.github.io/loopx/docs/
+repo_url: https://github.com/huangruiteng/loopx
+edit_uri: edit/main/docs/
+docs_dir: docs
+site_dir: output/docs-site
+use_directory_urls: true
+exclude_docs: |
+  /README.md
+  archive/**
+  research/long-horizon-agent-benchmarks/*.json
+  showcases/**/*.html
+  showcases/showcase-animation-prototype.html
+  showcases/showcase-catalog.json
+
+theme:
+  name: material
+  logo: assets/loopx-logo.png
+  favicon: assets/loopx-logo.png
+  palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: white
+      accent: blue
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: black
+      accent: blue
+      toggle:
+        icon: material/brightness-2
+        name: Switch to system preference
+  features:
+    - content.action.edit
+    - content.code.copy
+    - content.tabs.link
+    - navigation.instant
+    - navigation.instant.progress
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.sections
+    - navigation.indexes
+    - navigation.top
+    - navigation.path
+    - search.highlight
+    - search.share
+    - toc.follow
+
+plugins:
+  - search
+
+markdown_extensions:
+  - attr_list
+  - def_list
+  - md_in_html
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - guides/README.md
+      - Quick Start: guides/getting-started.md
+      - Newcomer Command Path: guides/newcomer-command-path.md
+      - Custom Runner Integration: guides/custom-agent-runner-integration.md
+      - Auto Research Command Path: guides/auto-research-command-path.md
+  - Concepts:
+      - concepts/README.md
+      - Interaction Patterns: concepts/interaction-pattern-catalog.md
+      - State Interaction Model: state-interaction-model.md
+      - Quota Allocation: quota-allocation.md
+  - Operations:
+      - operations/README.md
+      - Attention Queue: operations/attention-queue.md
+      - Long Task Cadence: operations/long-task-cadence-policy.md
+      - Authority Sources: operations/authority-source-registration.md
+  - Capabilities:
+      - capabilities/README.md
+      - Issue Fix: capabilities/issue-fix/README.md
+      - Change Quality: capabilities/change-quality/README.md
+      - Explore: capabilities/explore/README.md
+      - Material Lifecycle: capabilities/material-lifecycle/README.md
+      - Value Connectors: capabilities/value-connectors/README.md
+  - Integrations:
+      - integrations/README.md
+      - Worker Bridge: integrations/worker-bridge-install-contract.md
+      - Lark Kanban: integrations/lark-kanban-control-plane-adapter.md
+      - Runtime Connector Catalog: integrations/runtime-connector-catalog.md
+  - Reference:
+      - reference/README.md
+      - Extensions: reference/extensions.md
+      - Benchmark Architecture: reference/benchmark-architecture.md
+      - Protocols: reference/protocols/README.md
+      - Contracts: reference/contracts/README.md
+  - Development:
+      - development/README.md
+      - Testing And Quality: development/testing-and-quality.md
+      - Documentation Layout: development/documentation-layout.md
+      - Benchmark Workflow: development/benchmark-developer-workflow.md
+      - Control Plane Course: development/control-plane-course/README.md
+  - Product:
+      - product/README.md
+      - Vision: product/vision.md
+      - Release Readiness: product/release-readiness.md
+      - Surfaces: product/surfaces/README.md
+      - Runtimes: product/runtimes/README.md
+      - Foundations: product/foundations/README.md
+  - Showcases:
+      - showcases/README.md
+      - Frontend Surface: showcases/frontend-surface.md
+      - Blocked P0 Safe Rotation: showcases/cases/0617-blocked-p0-safe-rotation.md
+      - LoopX Self Iteration: showcases/cases/0619-loopx-self-iteration.md
+      - PR Issue Auto Fix: showcases/cases/0624-pr-issue-auto-fix.md

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,0 +1,129 @@
+site_name: LoopX
+site_url: https://huangruiteng.github.io/loopx/docs/
+repo_url: https://github.com/huangruiteng/loopx
+edit_uri: edit/main/docs/
+docs_dir: docs
+site_dir: output/docs-site
+use_directory_urls: true
+exclude_docs: |
+  archive/**
+  research/long-horizon-agent-benchmarks/*.json
+  showcases/**/*.html
+  showcases/showcase-animation-prototype.html
+  showcases/showcase-catalog.json
+
+theme:
+  name: material
+  logo: assets/loopx-logo.png
+  favicon: assets/loopx-logo.png
+  palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: white
+      accent: blue
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: black
+      accent: blue
+      toggle:
+        icon: material/brightness-2
+        name: Switch to system preference
+  features:
+    - content.action.edit
+    - content.code.copy
+    - content.tabs.link
+    - navigation.instant
+    - navigation.instant.progress
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.sections
+    - navigation.indexes
+    - navigation.top
+    - navigation.path
+    - search.highlight
+    - search.share
+    - toc.follow
+
+plugins:
+  - search
+
+markdown_extensions:
+  - attr_list
+  - def_list
+  - md_in_html
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - guides/README.md
+      - Quick Start: guides/getting-started.md
+      - Newcomer Command Path: guides/newcomer-command-path.md
+      - Custom Runner Integration: guides/custom-agent-runner-integration.md
+      - Auto Research Command Path: guides/auto-research-command-path.md
+  - Concepts:
+      - concepts/README.md
+      - Interaction Patterns: concepts/interaction-pattern-catalog.md
+      - State Interaction Model: state-interaction-model.md
+      - Quota Allocation: quota-allocation.md
+  - Operations:
+      - operations/README.md
+      - Attention Queue: operations/attention-queue.md
+      - Long Task Cadence: operations/long-task-cadence-policy.md
+      - Authority Sources: operations/authority-source-registration.md
+  - Capabilities:
+      - capabilities/README.md
+      - Issue Fix: capabilities/issue-fix/README.md
+      - Change Quality: capabilities/change-quality/README.md
+      - Explore: capabilities/explore/README.md
+      - Material Lifecycle: capabilities/material-lifecycle/README.md
+      - Value Connectors: capabilities/value-connectors/README.md
+  - Integrations:
+      - integrations/README.md
+      - Worker Bridge: integrations/worker-bridge-install-contract.md
+      - Lark Kanban: integrations/lark-kanban-control-plane-adapter.md
+      - Runtime Connector Catalog: integrations/runtime-connector-catalog.md
+  - Reference:
+      - reference/README.md
+      - Extensions: reference/extensions.md
+      - Benchmark Architecture: reference/benchmark-architecture.md
+      - Protocols: reference/protocols/README.md
+      - Contracts: reference/contracts/README.md
+  - Development:
+      - development/README.md
+      - Testing And Quality: development/testing-and-quality.md
+      - Documentation Layout: development/documentation-layout.md
+      - Benchmark Workflow: development/benchmark-developer-workflow.md
+      - Control Plane Course: development/control-plane-course/README.md
+  - Product:
+      - product/README.md
+      - Vision: product/vision.md
+      - Release Readiness: product/release-readiness.md
+      - Surfaces: product/surfaces/README.md
+      - Runtimes: product/runtimes/README.md
+      - Foundations: product/foundations/README.md
+  - Showcases:
+      - showcases/README.md
+      - Frontend Surface: showcases/frontend-surface.md
+      - Blocked P0 Safe Rotation: showcases/cases/0617-blocked-p0-safe-rotation.md
+      - LoopX Self Iteration: showcases/cases/0619-loopx-self-iteration.md
+      - PR Issue Auto Fix: showcases/cases/0624-pr-issue-auto-fix.md

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -69,6 +69,9 @@ markdown_extensions:
       line_spans: __span
       pygments_lang_class: true
   - pymdownx.inlinehilite
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - toc:
       permalink: true
 


### PR DESCRIPTION
## Summary

- Add a hosted documentation site for LoopX using repository-backed Markdown under `docs/`.
- Add `mkdocs.yaml`, `docs/index.md`, and `docs/requirements-docs.txt`.
- Update the Pages workflow to install docs dependencies and build the docs site into `output/frontstage-pages/site/docs`.
- Link the public homepage and README to the hosted documentation portal while keeping the existing Markdown docs as the source of truth.
- Enable and validate a fork Pages preview for the generated site.

Preview:

- Home: https://steven-kid.github.io/loopx/
- Docs: https://steven-kid.github.io/loopx/docs/

Screenshots:

![Docs page preview](https://raw.githubusercontent.com/steven-kid/loopx/gh-pages/screenshots/deployed-docs.png)

## Issue Or Task

- Closes #
- Contributor task ID:

## Validation

- [x] `python3 -m py_compile loopx/*.py`
- [x] `loopx check --scan-root .`
- [x] `npm run smoke:frontstage-share-bundle`
- [x] `python3 -m mkdocs build --site-dir /tmp/loopx-mkdocs-site`
- [x] Verified deployed Pages preview:
  - https://steven-kid.github.io/loopx/
  - https://steven-kid.github.io/loopx/docs/
- [x] Captured deployed-page screenshots with Playwright:
  - `/tmp/loopx-screenshots/deployed-home.png`
  - `/tmp/loopx-screenshots/deployed-docs.png`

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
