### PR TITLE
docs: promote public homepage in README entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) [![Release](https://img.shields.io/github/v/release/huangruiteng/loopx?display_name=tag)](https://github.com/huangruiteng/loopx/releases/latest) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](pyproject.toml) [![Local first](https://img.shields.io/badge/control--plane-local--first-brightgreen.svg)](docs/public-private-boundary.md) [![Loop Agents](https://img.shields.io/badge/status-loop%20agents%20early-orange.svg)](docs/product/release-readiness.md)
 
-[Try LoopX](#try-loopx) · [See real loops](#evidence) · [How it works](#why-loopx) · [Hosted frontstage](https://huangruiteng.github.io/loopx/frontstage/) · [User manual](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [简体中文](README.zh-CN.md)
+[Public website](https://huangruiteng.github.io/loopx/) · [Try LoopX](#try-loopx) · [See real loops](#evidence) · [How it works](#why-loopx) · [User manual](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [简体中文](README.zh-CN.md)
 
 **把会干活的 Agent，接成可管理、可复盘、可持续改进的数字员工。**
 
@@ -134,8 +134,8 @@ todo, quota, evidence, and targeted wake remain visible.**
 
 More inspectable surfaces:
 
-- [Hosted frontstage](https://huangruiteng.github.io/loopx/frontstage/) and its
-  [public demo script](docs/outreach/frontstage-demo-script.md);
+- the [public homepage](https://huangruiteng.github.io/loopx/) for the product
+  narrative, quick start, and long-running evidence;
 - the [showcase catalog](docs/showcases/README.md), including
   [blocked-P0 safe rotation](docs/showcases/cases/0617-blocked-p0-safe-rotation.md),
   [LoopX self-iteration](docs/showcases/cases/0619-loopx-self-iteration.md), and
@@ -245,7 +245,7 @@ LoopX folds its control-plane mechanics into five questions:
 | Goal state and status | Tracks active state, todos, claims, gates, evidence, run history, and first-screen attention. | `loopx status`, `loopx diagnose`, `loopx review-packet` |
 | Quota and interaction contract | Decides whether a turn should deliver, ask, wait, self-repair, or stay quiet. | `loopx quota should-run`, [quota allocation](docs/quota-allocation.md) |
 | Agent runtime bridges | Keeps Codex App, Codex CLI, Claude Code, and generic workers aligned with the same guard. | `loopx heartbeat-prompt`, `loopx codex-cli-bootstrap-message`, `loopx worker-bridge` |
-| Operator surfaces | Renders compact status without making the browser the state authority. | `loopx serve-status`, [dashboard](apps/presentation/dashboard/README.md), [frontstage](https://huangruiteng.github.io/loopx/frontstage/) |
+| Operator surfaces | Renders compact status without making the browser the state authority. | `loopx serve-status`, [dashboard](apps/presentation/dashboard/README.md) |
 | External projections | Projects todos and gates into collaboration surfaces while LoopX remains authoritative. | `loopx lark-kanban`, [Lark Kanban adapter](docs/integrations/lark-kanban-control-plane-adapter.md) |
 | Domain capabilities | Packages repeatable work lanes such as issue fixing, content operations, value connector planning, ML experiment advice, benchmark evidence, and Explore. | `loopx issue-fix`, `loopx content-ops`, `loopx value-connectors`, `loopx ml-experiment`, `loopx benchmark`, [Explore](docs/capabilities/explore/README.md) |
 | Experimental context learning | Lets named registered agents trial provider-neutral Reward Memory through ignored, default-off project configuration. OpenViking is one provider option, not a global dependency. | `loopx reward-memory experiment-status`, [Reward Memory architecture](docs/reference/protocols/reward-memory-architecture-v0.md) |
@@ -336,7 +336,7 @@ quota, and handoff explicit.
 ### App and Projection Paths
 
 - Local read-first UI: [dashboard guide](apps/presentation/dashboard/README.md)
-- Public-safe product view: [hosted frontstage](https://huangruiteng.github.io/loopx/frontstage/)
+- Public product overview: [public homepage](https://huangruiteng.github.io/loopx/)
 - Feishu/Lark projection: [Lark Kanban adapter](docs/integrations/lark-kanban-control-plane-adapter.md)
 - Generic host integration: [integration guide](docs/integration.md)
 - Custom multi-agent runner:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) [![Release](https://img.shields.io/github/v/release/huangruiteng/loopx?display_name=tag)](https://github.com/huangruiteng/loopx/releases/latest) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](pyproject.toml) [![Local first](https://img.shields.io/badge/control--plane-local--first-brightgreen.svg)](docs/public-private-boundary.md) [![Loop Agents](https://img.shields.io/badge/status-loop%20agents%20early-orange.svg)](docs/product/release-readiness.md)
 
-[试用 LoopX](#试用-loopx) · [查看真实 Loop](#证据) · [理解工作原理](#为什么需要-loopx) · [Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/) · [用户手册](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [English](README.md)
+[产品首页](https://huangruiteng.github.io/loopx/) · [试用 LoopX](#试用-loopx) · [查看真实 Loop](#证据) · [理解工作原理](#为什么需要-loopx) · [用户手册](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [English](README.md)
 
 **把会干活的 Agent，接成可管理、可复盘、可持续改进的数字员工。**
 
@@ -120,8 +120,7 @@ targeted wake 同屏可见。**
 
 更多可检查入口：
 
-- [Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/) 与
-  [公开演示脚本](docs/outreach/frontstage-demo-script.md)；
+- [产品首页](https://huangruiteng.github.io/loopx/)：查看产品叙事、快速开始和长程证据；
 - [Showcase 目录](docs/showcases/README.md)，包括
   [Blocked P0 安全侧路](docs/showcases/cases/0617-blocked-p0-safe-rotation.md)、
   [LoopX 自迭代](docs/showcases/cases/0619-loopx-self-iteration.md)和
@@ -226,7 +225,7 @@ LoopX 把控制面归结为五个用户可以直接行动的问题：
 | Goal state 与 status | 跟踪 active state、todo、claim、gate、evidence、run history 和首屏关注点。 | `loopx status`、`loopx diagnose`、`loopx review-packet` |
 | Quota 与 interaction contract | 决定一轮应该执行、提问、等待、自修复还是静默。 | `loopx quota should-run`、[Quota Allocation](docs/quota-allocation.md) |
 | Agent runtime bridge | 让 Codex App、Codex CLI、Claude Code 和 generic worker 服从同一 guard。 | `loopx heartbeat-prompt`、`loopx codex-cli-bootstrap-message`、`loopx worker-bridge` |
-| Operator surface | 呈现紧凑状态，但不让浏览器成为状态事实源。 | `loopx serve-status`、[Dashboard](apps/presentation/dashboard/README.md)、[Frontstage](https://huangruiteng.github.io/loopx/frontstage/) |
+| Operator surface | 呈现紧凑状态，但不让浏览器成为状态事实源。 | `loopx serve-status`、[Dashboard](apps/presentation/dashboard/README.md) |
 | External projection | 把 todo / gate 投影到协作表面，同时保持 LoopX 权威。 | `loopx lark-kanban`、[Lark Kanban adapter](docs/integrations/lark-kanban-control-plane-adapter.md) |
 | Domain capability | 打包 Issue Fix、内容运营、value connector、ML 实验、benchmark 与 Explore 等可重复泳道。 | `loopx issue-fix`、`loopx content-ops`、`loopx value-connectors`、`loopx ml-experiment`、`loopx benchmark`、[Explore](docs/capabilities/explore/README.md) |
 | 实验性上下文学习 | 通过 ignored、默认关闭的项目配置，为明确注册的 agent 试用 provider-neutral Reward Memory；OpenViking 是 provider 之一，不是全局依赖。 | `loopx reward-memory experiment-status`、[Reward Memory 中文架构](docs/reference/protocols/reward-memory-architecture-v0.zh-CN.md) |
@@ -304,7 +303,7 @@ treatment 和 guardrail 的任务，不替代生产审批。先读
 ### App 与 Projection
 
 - 本地 read-first UI：[Dashboard Guide](apps/presentation/dashboard/README.md)
-- Public-safe 产品视图：[Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/)
+- 公开产品概览：[产品首页](https://huangruiteng.github.io/loopx/)
 - 飞书投影：[Lark Kanban Adapter](docs/integrations/lark-kanban-control-plane-adapter.md)
 - 通用 host 集成：[Integration Guide](docs/integration.md)
 - 自有 multi-agent runner：

--- a/apps/presentation/README.md
+++ b/apps/presentation/README.md
@@ -4,7 +4,9 @@ Browser applications that present LoopX state live here.
 
 - `dashboard/`: the React/Vite operator dashboard, frontstage routes, and
   developer cockpit.
-- `site/`: the static public homepage published at the GitHub Pages root.
+- `site/`: the static
+  [public homepage](https://huangruiteng.github.io/loopx/) published at the
+  GitHub Pages root.
 
 Apps in this directory consume public-safe LoopX projections and fixtures. They
 do not own control-plane state or write directly to LoopX registries.

--- a/apps/presentation/site/README.md
+++ b/apps/presentation/site/README.md
@@ -1,7 +1,8 @@
 # LoopX Public Website
 
-This directory owns the static, public-safe homepage published at the root of
-the LoopX GitHub Pages site. The dashboard exporter copies the compiled React
+This directory owns the static, public-safe
+[LoopX homepage](https://huangruiteng.github.io/loopx/) published at the root
+of the GitHub Pages site. The dashboard exporter copies the compiled React
 application to `/frontstage/`, then writes this homepage to the Pages root.
 
 `__LOOPX_BASE__` is replaced by the exporter so links and assets work both at

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ material available without putting all of it on one page.
 
 | You want to... | Start here | Continue with |
 | --- | --- | --- |
+| Understand LoopX before installing | [Public homepage](https://huangruiteng.github.io/loopx/) | [Project README](../README.md) |
 | Try LoopX in a repository | [Getting started](guides/getting-started.md) | [Newcomer command path](guides/newcomer-command-path.md) |
 | Run or recover a long-lived goal | [Operations](operations/README.md) | [Integration guide](integration.md) |
 | Understand the control plane | [Architecture](architecture.md) | [Concepts](concepts/README.md) |
@@ -16,9 +17,11 @@ material available without putting all of it on one page.
 | Build or review LoopX | [Developer guide](development/README.md) | [Testing and quality](development/testing-and-quality.md) |
 | Inspect real outcomes | [Showcases](showcases/README.md) | [Research and evidence](research/README.md) |
 
-The [project README](../README.md) is the product overview and shortest public
-quick start. The [public user manual](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg)
-provides a longer onboarding path.
+The [public homepage](https://huangruiteng.github.io/loopx/) is the shortest
+product overview. The [project README](../README.md) keeps the source-linked
+quick start and capability map, while the
+[public user manual](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) provides
+a longer onboarding path.
 
 ## Core References
 

--- a/docs/showcases/README.md
+++ b/docs/showcases/README.md
@@ -41,20 +41,15 @@ cd apps/presentation/dashboard
 npm run export:frontstage-share
 ```
 
-This writes `/tmp/loopx-frontstage-share-bundle` with the compiled
-dashboard, a sanitized `goal_channel_projection_v0` status fixture, direct
-`/frontstage/` static-route support, and a manifest. It is the foundation for a
-future GitHub Pages showcase: Pages should publish this generated artifact, not
-live registry files or local status exports.
-Once repository Pages is enabled for GitHub Actions, the same generated bundle
-is available as the
-[hosted frontstage](https://huangruiteng.github.io/loopx/frontstage/).
-That hosted route is intentionally case-first. It should help a new user or
-developer understand the showcased patterns before reading CLI output: public
-cases, efficiency evidence, and the public boundary come from this directory;
+This writes `/tmp/loopx-frontstage-share-bundle` with the static
+[public homepage](https://huangruiteng.github.io/loopx/), compiled dashboard, a
+sanitized `goal_channel_projection_v0` status fixture, direct `/frontstage/`
+static-route support, and a manifest. GitHub Pages publishes this generated
+artifact, not live registry files or local status exports. The interactive
+dashboard route remains an exporter compatibility surface, not a promoted
+public entry. New users should start from the homepage; public cases,
+efficiency evidence, and the public boundary come from this directory, while
 live local `statusUrl` feeds belong only to explicit ops-mode inspection.
-For a short external walkthrough, use the
-[frontstage demo script](../outreach/frontstage-demo-script.md).
 For animated outreach assets, start from the
 [showcase animation skill spike](../outreach/showcase-animation-skill-spike.md)
 and the

--- a/examples/showcase-catalog-smoke.py
+++ b/examples/showcase-catalog-smoke.py
@@ -238,8 +238,7 @@ def main() -> int:
     for phrase in (
         "Loop engineering for long-running AI agents and peer agent teams.",
         "A lightweight state kernel and agent-agnostic local control plane for",
-        "https://huangruiteng.github.io/loopx/frontstage/",
-        "docs/outreach/frontstage-demo-script.md",
+        "https://huangruiteng.github.io/loopx/",
         "## Advanced Paths",
         "docs/assets/long-running-loop-openviking-trajectory.png",
         "docs/assets/long-running-loop-ml-experiment-trajectory.png",
@@ -251,6 +250,13 @@ def main() -> int:
         "docs/showcases/cases/0619-dynamic-workflow-hardware-agent.html",
     ):
         assert phrase in repo_readme, phrase
+    hosted_frontstage = "https://huangruiteng.github.io/loopx/frontstage/"
+    assert hosted_frontstage not in repo_readme, (
+        "README must promote the public homepage instead of hosted frontstage"
+    )
+    assert hosted_frontstage not in showcase_index, (
+        "showcase index must not promote hosted frontstage"
+    )
 
     print("showcase-catalog-smoke ok")
     return 0


### PR DESCRIPTION
## Summary

- make the public homepage the primary website entry in the English and Chinese project READMEs
- add the homepage to the documentation and presentation README indexes
- stop promoting the hosted frontstage from README surfaces while retaining its implementation route as an explicit compatibility detail
- update the showcase catalog smoke so the homepage is required and hosted frontstage promotion is rejected

## Validation

- owner-approved rendered first-screen previews for `README.md`, `README.zh-CN.md`, and `docs/README.md`
- `python3 -m py_compile examples/showcase-catalog-smoke.py`
- `python3 examples/showcase-catalog-smoke.py`
- `python3 examples/docs-governance-smoke.py`
- `python3 examples/public_entry/readme-demo-surface-smoke.py`
- `uvx ruff check --ignore EXE001,I001 examples/showcase-catalog-smoke.py` (the ignored file-level rules reproduce unchanged on `origin/main`)
- public homepage HTTP 200 readback
- LoopX public-boundary scan: 0 warnings, 0 errors
- LoopX standard premerge canary: 4 direct checks and 16 selected checks, 0 failures, 0 warnings, 0 manual holds
- `git diff --check`

## Scope

This is a public documentation and regression-contract change only. It does not remove the frontstage implementation route or change Pages deployment behavior. Ignored preview HTML, browser state, screenshots, local state, and private artifacts are excluded.

## Risk

Low. The main residual risk is an external link becoming unavailable; the homepage returned HTTP 200 during validation, and the README smoke now guards the intended public-entry policy.
