### PR TITLE
fix(docs): govern hosted documentation index

### DIFF
--- a/examples/docs-governance-smoke.py
+++ b/examples/docs-governance-smoke.py
@@ -14,6 +14,7 @@ ROOT_DOCS = {
     "README.md",
     "architecture.md",
     "heartbeat-automation-prompt.md",
+    "index.md",
     "integration.md",
     "project-agent-todo-contract.md",
     "public-private-boundary.md",


### PR DESCRIPTION
## Summary

- register `docs/index.md` in the root documentation governance inventory
- restore the durable public smoke after the hosted documentation entry was added

## Motivation

PR #2789 added `docs/index.md` as the published documentation entry point. The
documentation governance smoke still treated that file as unexpected, causing
Full Public Smokes to fail on the exact current `main` head. The hosted entry is
intentional, so the inventory should govern it rather than rejecting it.

## Validation

- `python3 examples/docs-governance-smoke.py`
- `python3 examples/run-smokes.py --suite full-public --script examples/docs-governance-smoke.py --timeout-seconds 120 --jobs 1 --json`
- `loopx --format json check --scan-path examples/docs-governance-smoke.py`
- `loopx --format json canary premerge --from-git-diff`

The exact baseline Full Public Smokes run on `main` also contains four older,
independent failure fingerprints. They are tracked for serial repair and are
not modified by this focused change.
