### PR TITLE
fix(heartbeat): keep standard prompt within interface budget

### DIFF
--- a/loopx/heartbeat_prompt.py
+++ b/loopx/heartbeat_prompt.py
@@ -685,7 +685,11 @@ def build_heartbeat_prompt(
         "registered_agents": normalized_registered_agents,
         "runtime_profile": runtime_profile,
         "scheduler_execution_context": scheduler_execution_context,
-        "visible_goal_host": visible_goal_host,
+        **(
+            {"visible_goal_host": visible_goal_host}
+            if visible_goal_host
+            else {}
+        ),
         **(
             {
                 "initial_runtime_capability_projection": (

--- a/tests/test_host_loop_activation.py
+++ b/tests/test_host_loop_activation.py
@@ -463,6 +463,12 @@ def test_opencode_activation_uses_bridge_tool_and_generic_cli_quota() -> None:
     assert "--runtime-profile generic_cli" in packet["commands"]["heartbeat_prompt"]
 
 
+def test_standard_heartbeat_omits_inactive_visible_goal_host() -> None:
+    payload = build_heartbeat_prompt(goal_id="standard-heartbeat-fixture", thin=True)
+
+    assert "visible_goal_host" not in payload
+
+
 def test_traex_cli_is_an_exact_visible_goal_host_on_the_generic_cli_loop() -> None:
     assert normalize_agent_type("traex") == "traex-cli"
     assert normalize_agent_type("TraeX CLI") == "traex-cli"


### PR DESCRIPTION
## Summary

- omit the inactive `visible_goal_host` marker from ordinary heartbeat JSON
- preserve the explicit `traex-cli` host projection
- add a focused regression assertion for the standard heartbeat contract

## Motivation and design

The standard heartbeat payload reached 31 top-level keys against its durable 30-key hot-path budget after TraeX support added a host marker that was `null` for every ordinary heartbeat. Conditional projection removes information-free hot-path state while keeping the explicit visible-goal contract unchanged. It follows the adjacent optional projection pattern and does not add a compatibility wrapper or raise the budget.

## Validation

- `hot-path-interface-budget-smoke.py`: passed; heartbeat JSON is 30/30 top-level keys
- focused host-loop and CLI budget tests: 86 passed
- heartbeat prompt, quota flow, status/quota/review parity, active-state budget, and performance smokes: passed
- peer-agent runtime and onboarding host-loop smokes: passed
- repository-configured strict mypy: passed for 15 source files
- public/private boundary scan: 9 checks, 0 warnings
- diff-based premerge canary: 15/15 selected checks passed; no failures, skips, or manual holds
- exact-scope change-quality receipt: valid

The first premerge attempt used a 180-second per-check limit and timed out the composite peer-agent runtime smoke. That smoke passed independently with the supported Python runtime, and the authoritative 300-second rerun passed all 15 checks.

## Risk

Low and localized to heartbeat JSON shape. Generic consumers already use optional lookups, while TraeX tests continue to require `visible_goal_host=traex-cli` on the explicit host path.
