### PR TITLE
fix(host-mode): preserve existing identity selection

### DIFF
--- a/loopx/host_mode_planner.py
+++ b/loopx/host_mode_planner.py
@@ -728,7 +728,13 @@ def build_host_mode_plan(
                 suggestions=SUPPORTED_TURN_HOST_IDENTITIES,
             )
         normalized_host_identity = candidate
-    identity = _identity_state(agent_id=agent_id, registered_agents=registered_agents)
+    # Host-mode planning continues an existing goal; fresh identity creation
+    # belongs to the onboarding entry points that opt into that policy.
+    identity = _identity_state(
+        agent_id=agent_id,
+        registered_agents=registered_agents,
+        fresh_agent_default=False,
+    )
     raw_scoped = identity.get("selected_agent_id")
     scoped_agent_id = str(raw_scoped) if raw_scoped else None
 

--- a/tests/test_host_mode_planner.py
+++ b/tests/test_host_mode_planner.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from loopx.host_mode_planner import build_host_mode_plan
+
+
+def test_host_mode_plan_preserves_existing_goal_identity_selection() -> None:
+    plan = build_host_mode_plan(
+        goal_id="fixture-goal",
+        user_intent="watch_each_turn",
+        host_capabilities=["visible_session"],
+        registered_agents=["codex-existing"],
+        host_identity="codex-cli",
+    )
+
+    assert plan["agent_id"] == "codex-existing"
+    assert plan["identity_contract"] == {
+        "schema_version": "loopx_host_loop_identity_selection_v0",
+        "agent_model": "peer_v1",
+        "state": "single_registered_agent_selected",
+        "activation_allowed": True,
+        "selected_agent_id": "codex-existing",
+        "registered_agents": ["codex-existing"],
+        "action_required": False,
+    }


### PR DESCRIPTION
## Summary

- restore the host-mode planner after the fresh-agent onboarding identity resolver added a required policy input
- keep fresh identity creation owned by onboarding while host-mode planning preserves existing-goal identity selection
- add a focused unit regression alongside the two existing public host-mode smokes

## Root cause

PR #2773 made the shared identity resolver's `fresh_agent_default` policy explicit. The onboarding and host-loop call sites were updated, but the read-only host-mode planner still called the resolver with the old signature. Both public host-mode smokes therefore failed before producing a plan.

## Fix

The host-mode planner now explicitly selects the existing-goal continuation policy without exposing or duplicating an onboarding option through its CLI. A focused unit test protects the single-registered-agent continuation behavior.

## Validation

- 72 focused host-mode and host-loop pytest cases passed
- 17 compact start-goal projection pytest cases passed
- `examples/host-mode-plan-smoke.py` passed
- `examples/project/host-mode-plan-cli-smoke.py` passed
- standard premerge canary passed with no failures, warnings, skips, or manual holds
- public/private boundary scan passed for both changed files
