### PR TITLE
fix(issue-fix): pin approved base snapshot before branch creation

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -503,7 +503,7 @@ compatibility facade.
 | Explore progress graph | `explore_graph.enabled` + material `refresh-state` | Idempotently project material issue selection, reproduction, PR publication/terminal state, capability-gap lifecycle, and todo supersession into the two delivery/capability graph lanes; update configured row/visual sinks only when their semantic digests change. |
 | Acceptance fixture | `loopx issue-fix acceptance-fixture` | Prove failure-before, minimal patch, and pass-after in a deterministic fixture. |
 | Git branch fixture | `loopx issue-fix repo-branch-fixture` | Exercise the same repair contract through a temporary git branch. |
-| Caller repo branch | `loopx issue-fix caller-repo-branch` | Inspect an approved local repo, create/claim an issue branch, and run caller-declared validation. |
+| Caller repo branch | `loopx issue-fix caller-repo-branch` | Inspect an approved local repo, require a current local base snapshot before creating an issue branch, and run caller-declared validation without implicit remote refresh. |
 | Content bridge | `loopx content-ops issue-fix-*` | Reuse body-free public metadata/intake boundaries. |
 | Visible projection | `status`, `lark-kanban`, dashboard | Derive human-visible issue work, outcomes, gates, and Monthly Impact from the same kernel/domain state without becoming a second source of truth. |
 | Projection source reconcile | `lark-kanban sync-projection --reconcile-source` | Keep normal sync non-destructive; only a caller-attested complete source snapshot may preview and explicitly retire remote orphan rows plus stale local record mappings within that exact namespace. |

--- a/docs/capabilities/issue-fix/README.zh-CN.md
+++ b/docs/capabilities/issue-fix/README.zh-CN.md
@@ -462,7 +462,7 @@ Merged PR 不会直接执行任意 callback，rollout event 也不会授予新�
 | Projection source reconcile | `lark-kanban sync-projection --reconcile-source` | 普通 sync 保持非破坏；只有调用方声明输入是完整 source snapshot 后，才能先预览、再显式退役该 namespace 内的远端 orphan row 和本地 stale record mapping。 |
 | Acceptance fixture | `loopx issue-fix acceptance-fixture` | 在 deterministic fixture 中证明 failure-before、minimal patch、pass-after。 |
 | Git branch fixture | `loopx issue-fix repo-branch-fixture` | 在临时 git branch 中运行同一修复 contract。 |
-| Caller repo branch | `loopx issue-fix caller-repo-branch` | 检查获批本地 repo、创建/认领 issue branch、运行 caller-declared validation。 |
+| Caller repo branch | `loopx issue-fix caller-repo-branch` | 检查获批本地 repo；创建 issue branch 前要求本地 base snapshot 与 tracking ref 一致；不隐式刷新远端，并运行 caller-declared validation。 |
 | Content bridge | `loopx content-ops issue-fix-*` | 复用 body-free public metadata/intake 边界。 |
 | 可见投影 | `status`、`lark-kanban`、dashboard | 从同一 kernel/domain state 派生人可读 issue、outcome、gate 与 `Monthly Impact`，不建立第二套事实源。 |
 

--- a/docs/capabilities/issue-fix/protocols/issue-fix-acceptance-loop-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-acceptance-loop-v0.md
@@ -48,12 +48,14 @@ caller-declared validation command, and returns
 `issue_fix_caller_repo_branch_packet_v0`. The public packet records the repo
 label, issue branch, validation pass/fail, repo-relative changed files, and PR
 review readiness. Before creating a new issue branch, it records a typed base
-snapshot and requires the approved local base branch to match its local
-tracking ref. A stale, ahead, or diverged base fails closed before branch
-creation. The command never refreshes remote refs implicitly; callers that need
-new remote evidence must fetch and reconcile it explicitly. It does not expose
-the local repo path, validation stdout or stderr, raw issue body/comment
-content, external remotes, or raw git output.
+snapshot, requires the approved local base branch to match its local tracking
+ref, creates from that immutable revision, and reads the new branch back against
+the snapshot. A stale, ahead, or diverged base fails closed before branch
+creation. An already-created issue branch remains claimable when the old base
+branch is no longer present. The command never refreshes remote refs
+implicitly; callers that need new remote evidence must fetch and reconcile it
+explicitly. It does not expose the local repo path, validation stdout or stderr,
+raw issue body/comment content, external remotes, or raw git output.
 Without `--execute`, the command is a dry-run plan and does not inspect or
 modify the local repository.
 

--- a/docs/capabilities/issue-fix/protocols/issue-fix-acceptance-loop-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-acceptance-loop-v0.md
@@ -47,8 +47,13 @@ This mode creates or claims a `codex/` issue branch, runs only the
 caller-declared validation command, and returns
 `issue_fix_caller_repo_branch_packet_v0`. The public packet records the repo
 label, issue branch, validation pass/fail, repo-relative changed files, and PR
-review readiness. It does not expose the local repo path, validation stdout or
-stderr, raw issue body/comment content, external remotes, or raw git output.
+review readiness. Before creating a new issue branch, it records a typed base
+snapshot and requires the approved local base branch to match its local
+tracking ref. A stale, ahead, or diverged base fails closed before branch
+creation. The command never refreshes remote refs implicitly; callers that need
+new remote evidence must fetch and reconcile it explicitly. It does not expose
+the local repo path, validation stdout or stderr, raw issue body/comment
+content, external remotes, or raw git output.
 Without `--execute`, the command is a dry-run plan and does not inspect or
 modify the local repository.
 

--- a/examples/issue-fix-acceptance-loop-smoke.py
+++ b/examples/issue-fix-acceptance-loop-smoke.py
@@ -96,6 +96,17 @@ def _run_git(workspace: Path, args: list[str]) -> None:
     )
 
 
+def _git_output(workspace: Path, args: list[str]) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=workspace,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    ).stdout.strip()
+
+
 def _write_fixture_repo(workspace: Path, *, fixed: bool = False) -> None:
     operator = "+" if fixed else "-"
     (workspace / "calculator.py").write_text(
@@ -317,6 +328,59 @@ def main() -> int:
         )
         assert branch_probe.returncode == 1
         _assert_no_local_paths(stale_payload)
+
+    with tempfile.TemporaryDirectory(prefix="loopx-pinned-base-smoke-") as tmp:
+        fixture_root = Path(tmp)
+        remote_path = fixture_root / "remote.git"
+        repo_path = fixture_root / "repo"
+        remote_path.mkdir()
+        repo_path.mkdir()
+        _run_git(remote_path, ["init", "--bare"])
+        _init_fixture_git_repo(repo_path)
+        _run_git(repo_path, ["remote", "add", "origin", str(remote_path)])
+        _run_git(repo_path, ["push", "--set-upstream", "origin", "main"])
+        approved_revision = _git_output(repo_path, ["rev-parse", "main"])
+        _run_git(repo_path, ["checkout", "-b", "moving-base"])
+        (repo_path / "later-base.txt").write_text("later\n", encoding="utf-8")
+        _run_git(repo_path, ["add", "later-base.txt"])
+        _run_git(repo_path, ["commit", "-m", "Prepare a later base revision"])
+        later_revision = _git_output(repo_path, ["rev-parse", "HEAD"])
+        _run_git(repo_path, ["checkout", "-b", "caller-start", "main"])
+        hook = repo_path / ".git" / "hooks" / "post-checkout"
+        hook.write_text(
+            "#!/bin/sh\n"
+            f"git update-ref refs/heads/main {later_revision}\n",
+            encoding="utf-8",
+        )
+        hook.chmod(0o755)
+
+        pinned_payload = _run_caller_repo_json_command(
+            repo_path,
+            issue_branch="codex/issue-123-pinned-base",
+        )
+        pinned_branch = pinned_payload["caller_repo_branch"]
+        assert pinned_branch["base_snapshot"]["base_revision"] == approved_revision
+        assert _git_output(repo_path, ["rev-parse", "HEAD"]) == approved_revision
+        assert _git_output(repo_path, ["rev-parse", "main"]) == later_revision
+        _assert_no_local_paths(pinned_payload)
+
+    with tempfile.TemporaryDirectory(prefix="loopx-existing-branch-smoke-") as tmp:
+        repo_path = Path(tmp)
+        _init_fixture_git_repo(repo_path)
+        issue_branch = "codex/issue-123-existing-without-base"
+        _run_git(repo_path, ["checkout", "-b", issue_branch])
+        _run_git(repo_path, ["branch", "-D", "main"])
+
+        existing_payload = _run_caller_repo_json_command(
+            repo_path,
+            issue_branch=issue_branch,
+        )
+        existing_branch = existing_payload["caller_repo_branch"]
+        assert existing_branch["branch_action"] == "claimed_current"
+        assert existing_branch["base_snapshot"]["relation"] == "not_inspected"
+        assert existing_branch["base_snapshot"]["base_revision"] is None
+        assert existing_branch["validation"]["executed"] is True
+        _assert_no_local_paths(existing_payload)
 
     markdown = subprocess.run(
         [

--- a/examples/issue-fix-acceptance-loop-smoke.py
+++ b/examples/issue-fix-acceptance-loop-smoke.py
@@ -44,6 +44,7 @@ def _run_caller_repo_json_command(
     repo_path: Path,
     *,
     issue_branch: str = "codex/issue-123-public-metadata-fixture",
+    expect_success: bool = True,
 ) -> dict[str, Any]:
     result = subprocess.run(
         [
@@ -72,8 +73,10 @@ def _run_caller_repo_json_command(
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        check=True,
+        check=expect_success,
     )
+    if not expect_success and result.returncode == 0:
+        raise AssertionError("caller repo branch mode unexpectedly succeeded")
     if result.stderr.strip():
         raise AssertionError(f"unexpected stderr: {result.stderr}")
     payload = json.loads(result.stdout)
@@ -241,6 +244,8 @@ def main() -> int:
         assert caller_branch["branch_action"] == "created"
         assert caller_branch["branch_ready"] is True
         assert caller_branch["issue_branch"] == "codex/issue-123-public-metadata-fixture"
+        assert caller_branch["base_snapshot"]["relation"] == "no_tracking_ref"
+        assert caller_branch["base_snapshot"]["tracking_ref_refresh_performed"] is False
         assert caller_branch["validation"]["executed"] is True
         assert caller_branch["validation"]["passed"] is False
         assert caller_payload["review_packet"]["ready"] is False
@@ -261,6 +266,57 @@ def main() -> int:
         assert caller_ready_payload["review_packet"]["external_pr_created"] is False
         assert caller_ready_payload["review_packet"]["merge_performed"] is False
         _assert_no_local_paths(caller_ready_payload)
+
+    with tempfile.TemporaryDirectory(prefix="loopx-stale-base-smoke-") as tmp:
+        fixture_root = Path(tmp)
+        remote_path = fixture_root / "remote.git"
+        repo_path = fixture_root / "repo"
+        updater_path = fixture_root / "updater"
+        remote_path.mkdir()
+        repo_path.mkdir()
+        _run_git(remote_path, ["init", "--bare"])
+        _init_fixture_git_repo(repo_path)
+        _run_git(repo_path, ["remote", "add", "origin", str(remote_path)])
+        _run_git(repo_path, ["push", "--set-upstream", "origin", "main"])
+        current_payload = _run_caller_repo_json_command(
+            repo_path,
+            issue_branch="codex/issue-123-current-base",
+        )
+        assert current_payload["ok"] is True
+        current_snapshot = current_payload["caller_repo_branch"]["base_snapshot"]
+        assert current_snapshot["relation"] == "current"
+        assert current_snapshot["base_revision"] == current_snapshot["tracking_revision"]
+        _run_git(
+            fixture_root,
+            ["clone", "--branch", "main", str(remote_path), str(updater_path)],
+        )
+        _run_git(updater_path, ["config", "user.name", "LoopX Fixture"])
+        _run_git(
+            updater_path,
+            ["config", "user.email", "loopx-fixture@example.invalid"],
+        )
+        (updater_path / "remote-change.txt").write_text("new baseline\n", encoding="utf-8")
+        _run_git(updater_path, ["add", "remote-change.txt"])
+        _run_git(updater_path, ["commit", "-m", "Advance tracked baseline"])
+        _run_git(updater_path, ["push", "origin", "main"])
+        _run_git(repo_path, ["fetch", "origin", "main"])
+
+        stale_payload = _run_caller_repo_json_command(
+            repo_path,
+            issue_branch="codex/issue-123-stale-base",
+            expect_success=False,
+        )
+        assert stale_payload["ok"] is False
+        assert "base_branch does not match its local tracking ref" in stale_payload["error"]
+        branch_probe = subprocess.run(
+            ["git", "show-ref", "--verify", "--quiet", "refs/heads/codex/issue-123-stale-base"],
+            cwd=repo_path,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert branch_probe.returncode == 1
+        _assert_no_local_paths(stale_payload)
 
     markdown = subprocess.run(
         [

--- a/loopx/capabilities/issue_fix/acceptance_loop.py
+++ b/loopx/capabilities/issue_fix/acceptance_loop.py
@@ -184,12 +184,12 @@ def _base_snapshot(workspace: Path, base_branch: str) -> dict[str, Any]:
     else:
         base_is_ancestor = _run_git_capture(
             workspace,
-            ["merge-base", "--is-ancestor", base_branch, tracking_ref],
+            ["merge-base", "--is-ancestor", base_revision, tracking_revision],
             expected_exit_codes=(0, 1),
         ).returncode == 0
         tracking_is_ancestor = _run_git_capture(
             workspace,
-            ["merge-base", "--is-ancestor", tracking_ref, base_branch],
+            ["merge-base", "--is-ancestor", tracking_revision, base_revision],
             expected_exit_codes=(0, 1),
         ).returncode == 0
         if base_is_ancestor:
@@ -683,9 +683,8 @@ def build_issue_fix_caller_repo_branch_packet(
         dirty_before = bool(_git_status_lines(workspace))
         branch_exists = _git_branch_exists(workspace, branch)
         base_exists = _git_branch_exists(workspace, base)
-        if not base_exists:
-            raise RuntimeError("base_branch does not exist in the approved local repo")
-        base_snapshot = _base_snapshot(workspace, base)
+        if base_exists:
+            base_snapshot = _base_snapshot(workspace, base)
         if current_branch == branch:
             branch_action = "claimed_current"
         else:
@@ -700,19 +699,26 @@ def build_issue_fix_caller_repo_branch_packet(
                 _require_passed(step)
                 branch_action = "claimed_existing"
             else:
+                if not base_exists:
+                    raise RuntimeError("base_branch does not exist in the approved local repo")
                 if base_snapshot["relation"] not in {"current", "no_tracking_ref"}:
                     raise RuntimeError(
                         "refusing to create an issue branch because base_branch does "
                         "not match its local tracking ref; refresh or reconcile the "
                         "approved base, then rerun"
                     )
-                if current_branch != base:
-                    step = _run_git_step(workspace, ["checkout", base], "git checkout approved base branch")
-                    git_steps.append(step)
-                    _require_passed(step)
-                step = _run_git_step(workspace, ["checkout", "-b", branch], "git create approved issue branch")
+                base_revision = str(base_snapshot["base_revision"])
+                step = _run_git_step(
+                    workspace,
+                    ["checkout", "-b", branch, base_revision],
+                    "git create approved issue branch from base snapshot",
+                )
                 git_steps.append(step)
                 _require_passed(step)
+                if _git_ref_oid(workspace, branch) != base_revision:
+                    raise RuntimeError(
+                        "created issue branch does not match the approved base snapshot"
+                    )
                 branch_action = "created"
         if not validation_command:
             raise ValueError("validation_command is required when --execute is used")

--- a/loopx/capabilities/issue_fix/acceptance_loop.py
+++ b/loopx/capabilities/issue_fix/acceptance_loop.py
@@ -153,6 +153,64 @@ def _git_status_lines(workspace: Path) -> list[str]:
     return [line for line in result.stdout.splitlines() if line.strip()]
 
 
+def _git_ref_oid(workspace: Path, ref: str) -> str:
+    result = _run_git_capture(
+        workspace, ["rev-parse", "--verify", f"{ref}^{{commit}}"]
+    )
+    oid = result.stdout.strip()
+    if not oid:
+        raise RuntimeError(f"git ref {ref} did not resolve to a commit")
+    return oid
+
+
+def _base_snapshot(workspace: Path, base_branch: str) -> dict[str, Any]:
+    base_revision = _git_ref_oid(workspace, base_branch)
+    upstream = _run_git_capture(
+        workspace,
+        [
+            "for-each-ref",
+            "--format=%(upstream:short)",
+            f"refs/heads/{base_branch}",
+        ],
+    )
+    tracking_ref = upstream.stdout.strip() or None
+    tracking_revision = (
+        _git_ref_oid(workspace, tracking_ref) if tracking_ref is not None else None
+    )
+    if tracking_revision is None:
+        relation = "no_tracking_ref"
+    elif tracking_revision == base_revision:
+        relation = "current"
+    else:
+        base_is_ancestor = _run_git_capture(
+            workspace,
+            ["merge-base", "--is-ancestor", base_branch, tracking_ref],
+            expected_exit_codes=(0, 1),
+        ).returncode == 0
+        tracking_is_ancestor = _run_git_capture(
+            workspace,
+            ["merge-base", "--is-ancestor", tracking_ref, base_branch],
+            expected_exit_codes=(0, 1),
+        ).returncode == 0
+        if base_is_ancestor:
+            relation = "behind_tracking_ref"
+        elif tracking_is_ancestor:
+            relation = "ahead_of_tracking_ref"
+        else:
+            relation = "diverged_from_tracking_ref"
+    return {
+        "schema_version": "issue_fix_base_snapshot_v0",
+        "base_branch": base_branch,
+        "base_revision": base_revision,
+        "tracking_ref": tracking_ref,
+        "tracking_revision": tracking_revision,
+        "relation": relation,
+        "tracking_ref_refresh_performed": False,
+        "external_remote_used": False,
+        "local_path_captured": False,
+    }
+
+
 def _changed_files(workspace: Path, *, base_branch: str) -> tuple[list[str], bool]:
     files: list[str] = []
     truncated = False
@@ -603,6 +661,17 @@ def build_issue_fix_caller_repo_branch_packet(
         "local_path_captured": False,
     }
     branch_action = "dry_run"
+    base_snapshot: dict[str, Any] = {
+        "schema_version": "issue_fix_base_snapshot_v0",
+        "base_branch": base,
+        "base_revision": None,
+        "tracking_ref": None,
+        "tracking_revision": None,
+        "relation": "not_inspected",
+        "tracking_ref_refresh_performed": False,
+        "external_remote_used": False,
+        "local_path_captured": False,
+    }
     changed_files: list[str] = []
     changed_files_truncated = False
 
@@ -614,6 +683,9 @@ def build_issue_fix_caller_repo_branch_packet(
         dirty_before = bool(_git_status_lines(workspace))
         branch_exists = _git_branch_exists(workspace, branch)
         base_exists = _git_branch_exists(workspace, base)
+        if not base_exists:
+            raise RuntimeError("base_branch does not exist in the approved local repo")
+        base_snapshot = _base_snapshot(workspace, base)
         if current_branch == branch:
             branch_action = "claimed_current"
         else:
@@ -628,8 +700,12 @@ def build_issue_fix_caller_repo_branch_packet(
                 _require_passed(step)
                 branch_action = "claimed_existing"
             else:
-                if not base_exists:
-                    raise RuntimeError("base_branch does not exist in the approved local repo")
+                if base_snapshot["relation"] not in {"current", "no_tracking_ref"}:
+                    raise RuntimeError(
+                        "refusing to create an issue branch because base_branch does "
+                        "not match its local tracking ref; refresh or reconcile the "
+                        "approved base, then rerun"
+                    )
                 if current_branch != base:
                     step = _run_git_step(workspace, ["checkout", base], "git checkout approved base branch")
                     git_steps.append(step)
@@ -663,6 +739,7 @@ def build_issue_fix_caller_repo_branch_packet(
         "issue_branch": branch,
         "branch_action": branch_action,
         "branch_ready": execute and branch_action in {"claimed_current", "claimed_existing", "created"},
+        "base_snapshot": base_snapshot,
         "external_remote_used": False,
         "local_path_captured": False,
         "validation": validation_command_result,
@@ -842,6 +919,28 @@ def validate_issue_fix_caller_repo_branch_packet(packet: Mapping[str, Any]) -> d
         errors.append("caller repo branch must not use external remote")
     if artifact.get("local_path_captured") is not False:
         errors.append("caller repo branch local path must not be captured")
+    base_snapshot = (
+        artifact.get("base_snapshot")
+        if isinstance(artifact.get("base_snapshot"), Mapping)
+        else {}
+    )
+    if base_snapshot.get("schema_version") != "issue_fix_base_snapshot_v0":
+        errors.append("caller repo branch base snapshot has wrong schema")
+    if base_snapshot.get("relation") not in {
+        "not_inspected",
+        "no_tracking_ref",
+        "current",
+        "behind_tracking_ref",
+        "ahead_of_tracking_ref",
+        "diverged_from_tracking_ref",
+    }:
+        errors.append("caller repo branch base snapshot has invalid relation")
+    if base_snapshot.get("external_remote_used") is not False:
+        errors.append("caller repo branch base snapshot must not use an external remote")
+    if base_snapshot.get("tracking_ref_refresh_performed") is not False:
+        errors.append("caller repo branch base snapshot must not refresh tracking refs")
+    if base_snapshot.get("local_path_captured") is not False:
+        errors.append("caller repo branch base snapshot must not capture local paths")
     validation = (
         artifact.get("validation")
         if isinstance(artifact.get("validation"), Mapping)


### PR DESCRIPTION
## Problem

A long-running issue-fix worker can inspect an old local base branch while its local tracking ref already points at a newer repository snapshot. It may then qualify an issue against code that no longer exists and create work from stale evidence.

## Contract

- Record `issue_fix_base_snapshot_v0` in the caller-repo branch artifact.
- Before creating a new issue branch, require the approved local base to match its existing local tracking ref.
- Fail closed for behind, ahead, or diverged bases.
- Never fetch or refresh remote refs implicitly; the caller owns explicit refresh/reconciliation.
- Preserve existing behavior for repositories without a tracking ref and for already-created issue branches.
- Keep local paths and raw git output outside the public packet.

## Validation

- `python3 examples/issue-fix-acceptance-loop-smoke.py`
- `python3 examples/issue-fix-workflow-contract-smoke.py`
- `python3 -m pytest -q tests/capabilities/test_issue_fix_candidate_evidence.py tests/test_ark_managed_agent_issue_fix_matrix.py` (23 passed)
- `python3 -m loopx.cli canary premerge --from-git-diff --format json` (18/18, no failures or holds)
- public-boundary scan clean

This PR is intentionally Draft for user review.