### PR TITLE
test(dashboard): make project asset smoke locale-neutral

### DIFF
--- a/examples/project/project-asset-next-eye-smoke.py
+++ b/examples/project/project-asset-next-eye-smoke.py
@@ -239,17 +239,17 @@ def assert_dashboard_first_screen_render_contract() -> None:
         encoding="utf-8"
     )
     for marker in (
-        "Project asset",
-        "Owner {item.projectOwner}",
-        "Gate {item.projectGate}",
-        "Next:",
-        "Stop:",
-        "UserTodoCallout",
-        "Agent todo",
-        "Validation",
-        "Quota",
-        "Agent command",
-        "Safe CLI Path",
+        'item.projectAssetSource === "legacy_raw_fallback"',
+        "item.projectOwner ?",
+        "item.projectGate ?",
+        "item.projectNextAction ?",
+        "item.projectStopCondition ?",
+        "<UserTodoCallout",
+        "{agentTodo.text}",
+        "formatLatestValidation(item.latestValidation)",
+        "buildQuotaView(item.quota)",
+        "{item.agentCommand ?",
+        "{item.safePathLabel}",
     ):
         assert marker in dashboard, marker
 


### PR DESCRIPTION
## Summary
- replace locale-specific first-screen copy assertions with the existing project-asset render expressions
- preserve the approved Chinese dashboard first screen while keeping owner, gate, next action, stop condition, todo, quota, validation, command, and safe-path coverage

## Validation
- `.venv/bin/python examples/project/project-asset-next-eye-smoke.py`
- `npm run smoke:action-packet`
- `npm run smoke:home-route`
- `npm run smoke:home-browser`
- `npm run build`
- `python -m mypy`
- `loopx check --scan-path examples/project/project-asset-next-eye-smoke.py`
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` (13/13 selected checks passed, no manual holds)
- change-quality receipt `cqr_eb255db5a325a01d60f0` verified for the exact committed diff

## Scope And Risk
- one public smoke file only; no runtime or first-screen product code changed
- no private state, generated logs, local paths, credentials, or benchmark evidence included
- residual risk is limited to future dashboard expression renames, which this smoke is intended to surface