### PR TITLE
fix #2760: preserve sandbox and project on resume

### DIFF
--- a/loopx/control_plane/turn_driver/codex_cli.py
+++ b/loopx/control_plane/turn_driver/codex_cli.py
@@ -341,8 +341,12 @@ def _codex_command(
         command = [
             codex_bin,
             "exec",
-            "resume",
             "--skip-git-repo-check",
+            "-C",
+            str(project),
+            "resume",
+            "-c",
+            f'sandbox_mode="{sandbox}"',
             "--output-schema",
             str(schema_path),
             "--output-last-message",

--- a/tests/test_loopx_turn_codex_cli.py
+++ b/tests/test_loopx_turn_codex_cli.py
@@ -142,6 +142,7 @@ def test_codex_cli_host_starts_then_resumes_opaque_session(
         runtime_root=runtime_root,
         project=project,
         codex_bin=str(executable),
+        sandbox="workspace-write",
         timeout_seconds=5,
     )
     with pytest.raises(RuntimeError, match="binding changed after planning"):
@@ -161,6 +162,7 @@ def test_codex_cli_host_starts_then_resumes_opaque_session(
         runtime_root=runtime_root,
         project=project,
         codex_bin=str(executable),
+        sandbox="workspace-write",
         timeout_seconds=5,
     )
 
@@ -172,6 +174,12 @@ def test_codex_cli_host_starts_then_resumes_opaque_session(
     assert "resume" not in argv_rows[0]
     assert "resume" in argv_rows[1]
     assert "session-fixture-0001" in argv_rows[1]
+    resume_argv = argv_rows[1]
+    assert resume_argv[resume_argv.index("-c") + 1] == (
+        'sandbox_mode="workspace-write"'
+    )
+    assert resume_argv[resume_argv.index("-C") + 1] == str(project)
+    assert resume_argv.index("-C") < resume_argv.index("resume")
 
     envelope = first_request["turn_envelope"]
     assert isinstance(envelope, dict)


### PR DESCRIPTION
## Summary

- Preserve the requested sandbox policy when resuming a Codex CLI session.
- Pin resumed turns to the intended project with the parent `exec -C` option.
- Add regression coverage for the sandbox override, project path, and valid option order.

## Root cause and impact

The resume branch validated `sandbox` but did not pass it to Codex, so resumed
`workspace-write` turns could silently fall back to the configured default. It also relied on
the spawning process cwd instead of expressing the project root in the command contract.

`-C` is an `exec` option rather than a `resume` option, so it must appear before the resume
subcommand. The updated command preserves both values without widening permissions.

Fixes #2760.

## Validation

- `pytest -q tests/test_loopx_turn_codex_cli.py` — 8 passed
- Full pytest with coverage — 1999 passed, 2 skipped, 55.35% coverage
- Required-scope Ruff — passed
- Strict mypy scope — 15 files passed
- Codex CLI 0.147 parser check for `exec -C ... resume -c sandbox_mode=...` — passed
- `loopx canary premerge --from-git-diff` — 9 selected checks passed, no manual holds
