### PR TITLE
feat(pr-program): add provider-neutral program tracking

### DIFF
--- a/docs/guides/custom-agent-runner-integration.md
+++ b/docs/guides/custom-agent-runner-integration.md
@@ -74,8 +74,8 @@ does not grant permission or satisfy a user gate.
 
 For `other-agent`, doctor intentionally does not inspect `~/.codex/skills`.
 CLI health and workflow delivery are separate checks. The custom host must
-deliver `loopx-project`, `loopx-pr-review`, `loopx-doc-registry`,
-and `loopx-self-repair` from the same LoopX revision through its own skill
+deliver `loopx-project`, `loopx-pr-program`, `loopx-pr-review`,
+`loopx-doc-registry`, and `loopx-self-repair` from the same LoopX revision through its own skill
 manifest or equivalent prompt injection. When the current goal enables
 `change_quality_qualification`, the onboarding packet also lists
 `loopx-change-quality` as an active project skill; deliver that workflow or its

--- a/docs/guides/custom-agent-runner-integration.zh-CN.md
+++ b/docs/guides/custom-agent-runner-integration.zh-CN.md
@@ -67,8 +67,8 @@ packet 会返回当前 doctor/install、bootstrap command pack、quota guard 和
 
 对于 `other-agent`，doctor 会有意跳过 `~/.codex/skills` 检查。CLI 健康与 workflow
 交付是两件事：custom host 仍需通过自己的 skill manifest 或等价 prompt injection，
-从同一 LoopX revision 交付 `loopx-project`、`loopx-pr-review`、
-`loopx-doc-registry` 和 `loopx-self-repair`。当当前 goal 启用
+从同一 LoopX revision 交付 `loopx-project`、`loopx-pr-program`、
+`loopx-pr-review`、`loopx-doc-registry` 和 `loopx-self-repair`。当当前 goal 启用
 `change_quality_qualification` 时，onboarding packet 会额外把
 `loopx-change-quality` 列为 active project skill；host 需要交付该 workflow，
 或注入等价的自包含 prepare packet 指令。随后 readback integration mode、

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -75,7 +75,8 @@ can discover user-installed skills:
   through `$loopx` or `/skills`. The primary `LoopX` command facade and
   `LoopX Project` workflow skill are separate entries: command facades set
   `allow_implicit_invocation: false`, while richer workflow skills such as
-  `loopx-project` and `loopx-pr-review` keep their normal implicit behavior.
+  `loopx-project`, `loopx-pr-program`, and `loopx-pr-review` keep their normal
+  implicit behavior.
 - Claude Code: lightweight user skills under `~/.claude/skills/loopx*`, so the
   command family can appear as Claude Code slash commands without enabling the
   opt-in MCP/hook adapter.
@@ -463,11 +464,23 @@ The reusable skills have intentionally narrow jobs:
 | Skill | Use it for | Do not use it for |
 | --- | --- | --- |
 | `loopx-project` | Connecting projects, reading status/quota/history, diagnosing LoopX, generating heartbeat/review packets, and refreshing state. | Reading private project documents by default or replacing the CLI as source of truth. |
+| `loopx-pr-program` | Reconciling a multi-PR/MR delivery program, preserving requirement/dependency priority, maintaining a roadmap, and monitoring material changes. | Deep per-PR review, provider-specific acquisition, approval, commenting, retargeting, closing, or merging. |
 | `loopx-pr-review` | Running `/loopx-pr-review`, preserving the `loopx pr-review` packet, and guiding per-PR five-block reviews. | Approving, commenting on, merging, self-merging, or admin-bypassing a PR. |
 | `loopx-doc-registry` | Registering durable project material and redacted authority-source metadata. | Copying raw doc bodies, internal URLs, or private comments into public repo docs. |
 | `loopx-material` | Operating an explicitly activated project's lossless material inventory, lifecycle, ranked-entry rebuild, bounded rerank, owner-gated apply, and rollback. | Ordinary one-off reading, project-specific source discovery, or mutating a material store merely because the project skill is discoverable. |
 | `loopx-change-quality` | Reviewing one exact final diff, optionally applying one bounded safe fix, and recording a policy-enforced receipt. | Acting when the goal policy is disabled, recursively reviewing reviewers, or replacing project-native validators. |
 | `loopx-self-repair` | Repairing surprising control-plane behavior, stale projection, tiny turns, or contradictory guard payloads. | Lowering gates, guessing around missing authority, or committing private runtime state. |
+
+Invoke `$loopx-pr-program` when one delivery goal spans several PRs or MRs and
+the queue must be reconciled over time. The skill accepts a provider-neutral
+snapshot, keeps one grouped LoopX monitor, and updates roadmap projections only
+for material changes. Run `loopx doctor` to read back the installed skill, and
+use its bundled `scripts/diff_snapshot.py --current <snapshot.json>` command to
+validate a first baseline. Installing the skill grants no source-control read or
+write authority and installs no provider adapter; acquisition stays with the
+authorized host environment. To disable the workflow, stop invoking it and
+remove only `~/.codex/skills/loopx-pr-program`; rerun the installer to restore
+the release-owned copy.
 
 Auto-research role guidance is worker-local: the visible worker launcher owns
 the `loopx-auto-research` playbook after it has projected a role profile,
@@ -552,6 +565,7 @@ the pieces you intend to drop:
 ```bash
 rm -f ~/.local/bin/loopx ~/.local/bin/loopx-canary
 rm -rf ~/.codex/skills/loopx-project \
+       ~/.codex/skills/loopx-pr-program \
        ~/.codex/skills/loopx-pr-review \
        ~/.codex/skills/loopx-doc-registry \
        ~/.codex/skills/loopx-self-repair

--- a/examples/codex-cli-packaged-install-smoke.py
+++ b/examples/codex-cli-packaged-install-smoke.py
@@ -118,6 +118,7 @@ def main() -> None:
 
         for skill in (
             "loopx-project",
+            "loopx-pr-program",
             "loopx-pr-review",
             "loopx-doc-registry",
             "loopx-self-repair",

--- a/examples/fresh-clone-quickstart-smoke.py
+++ b/examples/fresh-clone-quickstart-smoke.py
@@ -80,6 +80,7 @@ def main() -> int:
         assert f"- manpage: {man_root / 'man1' / 'loopx.1.gz'}" in install.stdout, install.stdout
         assert f"- canary executable: {bin_dir / 'loopx-canary'}" in install.stdout, install.stdout
         assert f"- skill: {codex_home / 'skills' / 'loopx-project'}" in install.stdout, install.stdout
+        assert f"- skill: {codex_home / 'skills' / 'loopx-pr-program'}" in install.stdout, install.stdout
         assert f"- skill: {codex_home / 'skills' / 'loopx-pr-review'}" in install.stdout, install.stdout
         assert "promotion-readiness evidence is missing" in install.stderr, install.stderr
         assert "non-blocking" in install.stderr, install.stderr
@@ -99,6 +100,7 @@ def main() -> int:
             encoding="utf-8"
         )
         assert (codex_home / "skills" / "loopx-project" / "SKILL.md").is_file()
+        assert (codex_home / "skills" / "loopx-pr-program" / "SKILL.md").is_file()
         assert (codex_home / "skills" / "loopx-pr-review" / "SKILL.md").is_file()
         assert (codex_home / "skills" / "loopx-self-repair" / "SKILL.md").is_file()
 
@@ -112,6 +114,7 @@ def main() -> int:
         assert doctor["install_freshness"]["status"] == "unknown", doctor
         assert "install-from-github.sh" in doctor["install_freshness"]["upgrade_command"], doctor
         assert doctor["skills"]["loopx-project"]["exists"] is True, doctor
+        assert doctor["skills"]["loopx-pr-program"]["exists"] is True, doctor
         assert doctor["skills"]["loopx-pr-review"]["exists"] is True, doctor
         assert doctor["skills"]["loopx-self-repair"]["exists"] is True, doctor
 

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -225,6 +225,7 @@ def main() -> int:
             in install.stdout
         ), install.stdout
         assert f"- skill: {codex_home / 'skills' / 'loopx-doc-registry'}" in install.stdout, install.stdout
+        assert f"- skill: {codex_home / 'skills' / 'loopx-pr-program'}" in install.stdout, install.stdout
         assert f"- skill: {codex_home / 'skills' / 'loopx-pr-review'}" in install.stdout, install.stdout
         assert f"- skill: {codex_home / 'skills' / 'loopx-project'}" in install.stdout, install.stdout
         assert f"- skill: {codex_home / 'skills' / 'loopx-self-repair'}" in install.stdout, install.stdout
@@ -325,6 +326,7 @@ def main() -> int:
         assert set(skill_readback["materialized_skill_ids"]) == {
             "loopx",
             "loopx-doc-registry",
+            "loopx-pr-program",
             "loopx-pr-review",
             "loopx-project",
             "loopx-self-repair",
@@ -380,6 +382,19 @@ def main() -> int:
         ):
             assert phrase in pr_review_text, phrase
         assert "Do not use this skill to approve" not in pr_review_text, pr_review_text
+        pr_program_skill = codex_home / "skills" / "loopx-pr-program" / "SKILL.md"
+        pr_program_text = " ".join(pr_program_skill.read_text(encoding="utf-8").split())
+        for phrase in (
+            "one `continuous_monitor` todo",
+            "result_completeness.complete=true",
+            "diff_snapshot.py",
+            "Product requirements set priority",
+            "Quiet monitor polls",
+        ):
+            assert phrase in pr_program_text, phrase
+        assert (
+            pr_program_skill.parent / "scripts" / "diff_snapshot.py"
+        ).is_file()
         pr_review_metadata = pr_review_skill.parent / "agents" / "openai.yaml"
         pr_review_metadata_text = pr_review_metadata.read_text(encoding="utf-8")
         assert (
@@ -472,6 +487,7 @@ def main() -> int:
         ).is_file()
         for implicit_skill_name in (
             "loopx-project",
+            "loopx-pr-program",
             "loopx-pr-review",
             "loopx-doc-registry",
             "loopx-self-repair",
@@ -544,6 +560,8 @@ def main() -> int:
         assert doctor_payload["globally_visible_project_skills"] == [], doctor_payload
         assert doctor_payload["skills"]["loopx-project"]["exists"] is True, doctor_payload
         assert doctor_payload["skills"]["loopx-project"]["required_phrases"] is True, doctor_payload
+        assert doctor_payload["skills"]["loopx-pr-program"]["exists"] is True, doctor_payload
+        assert doctor_payload["skills"]["loopx-pr-program"]["required_phrases"] is True, doctor_payload
         assert doctor_payload["skills"]["loopx-pr-review"]["exists"] is True, doctor_payload
         assert doctor_payload["skills"]["loopx-pr-review"]["required_phrases"] is True, doctor_payload
         assert doctor_payload["skills"]["loopx-doc-registry"]["exists"] is True, doctor_payload
@@ -594,7 +612,7 @@ def main() -> int:
         assert "installed_skill_delivery_hints: `True`" in doctor_markdown, doctor_markdown
         assert (
             "installed_required_skills: "
-            "`loopx-doc-registry,loopx-pr-review,loopx-project,loopx-self-repair`"
+            "`loopx-doc-registry,loopx-pr-program,loopx-pr-review,loopx-project,loopx-self-repair`"
             in doctor_markdown
         ), doctor_markdown
         assert "loopx_canary_realpath:" in doctor_markdown, doctor_markdown
@@ -636,6 +654,7 @@ def main() -> int:
             repo_root=REPO_ROOT,
             skills={
                 "loopx-project": {"exists": True, "required_phrases": True},
+                "loopx-pr-program": {"exists": True, "required_phrases": True},
                 "loopx-pr-review": {"exists": True, "required_phrases": True},
                 "loopx-doc-registry": {"exists": True, "required_phrases": True},
                 "loopx-self-repair": {"exists": True, "required_phrases": True},
@@ -653,6 +672,7 @@ def main() -> int:
             repo_root=REPO_ROOT,
             skills={
                 "loopx-project": {"exists": True, "required_phrases": True},
+                "loopx-pr-program": {"exists": True, "required_phrases": True},
                 "loopx-pr-review": {"exists": True, "required_phrases": True},
                 "loopx-doc-registry": {"exists": True, "required_phrases": True},
                 "loopx-self-repair": {"exists": True, "required_phrases": True},
@@ -668,6 +688,7 @@ def main() -> int:
             repo_root=REPO_ROOT,
             skills={
                 "loopx-project": {"exists": True, "required_phrases": True},
+                "loopx-pr-program": {"exists": True, "required_phrases": True},
                 "loopx-pr-review": {"exists": True, "required_phrases": True},
                 "loopx-doc-registry": {"exists": True, "required_phrases": True},
                 "loopx-self-repair": {"exists": True, "required_phrases": True},

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -49,6 +49,13 @@ REQUIRED_INSTALLED_SKILL_PHRASES = {
         "A plain PR comment is not an adequate substitute for `REQUEST_CHANGES`",
         "route approval, merge, self-merge, and admin-bypass actions to",
     ),
+    "loopx-pr-program": (
+        "one `continuous_monitor` todo",
+        "result_completeness.complete=true",
+        "diff_snapshot.py",
+        "Product requirements set priority",
+        "Quiet monitor polls",
+    ),
     "loopx-doc-registry": (
         "Use even when the user does not mention LoopX or doc registry",
         "use `.loopx/registry.json` as the project-local doc registry",

--- a/loopx/skill_install_readback.py
+++ b/loopx/skill_install_readback.py
@@ -16,6 +16,7 @@ SKILL_INSTALL_OWNER = "loopx_install_script"
 SKILL_INSTALL_INTEGRATION_MODE = "fixed_install_script"
 PACKAGED_HOST_SKILL_IDS = [
     "loopx-project",
+    "loopx-pr-program",
     "loopx-pr-review",
     "loopx-doc-registry",
     "loopx-self-repair",

--- a/skills/loopx-pr-program/SKILL.md
+++ b/skills/loopx-pr-program/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: loopx-pr-program
+description: "Use when LoopX must manage a multi-PR or multi-MR delivery program across one or more repositories: inventory current change requests, reconcile new/merged/closed or retargeted work, preserve requirement and dependency priorities, maintain a roadmap document, or monitor material lifecycle/check/review changes over time. Use provider-neutral snapshots and one grouped continuous monitor; do not use for deep per-PR code review, approval, commenting, or merge actions."
+---
+
+# LoopX PR Program
+
+Manage a delivery program as durable LoopX state instead of rebuilding a queue
+from chat memory. Keep source acquisition provider-local, normalize observations
+into one public contract, and write back only material transitions.
+
+## Route The Request
+
+Use this workflow when the user asks to manage, prioritize, reconcile, document,
+or monitor several pull requests or merge requests. Route a deep review of each
+selected PR to `loopx-pr-review`. Route approval, comments, reruns, branch
+retargeting, closing, or merging to the normal provider-specific workflow and
+require the corresponding authority.
+
+Treat document maintenance and monitor creation as writes. A request to update
+the roadmap or keep monitoring the program authorizes those scoped writes; an
+ordinary status question remains read-only.
+
+## Start From LoopX State
+
+Start or join the project goal before material work. Represent the program with
+one advancement todo for the current reconciliation and one
+`continuous_monitor` todo for recurring observation. Do not create one monitor
+todo per change request.
+
+Use a stable monitor identity:
+
+```text
+task_class=continuous_monitor
+action_kind=pr_program_reconcile
+target_key=pr-program-<stable-program-id>
+cadence=<user cadence or 30m>
+```
+
+Preserve `claimed_by`, `last_checked_at`, `next_due_at`, `result_hash`,
+`consecutive_no_change`, and `material_change`. Quiet monitor polls keep
+liveness but do not count as delivery progress, rewrite roadmap documents, or
+spend progress quota.
+
+## Acquire A Complete Snapshot
+
+Use any authorized source-control read interface available in the current
+environment. Prefer one batch query for inventory and targeted reads for the
+items that changed. Never encode a private transport command, executable name,
+credential, internal hostname, or document token in this skill, repository
+examples, committed fixtures, or public evidence.
+
+Normalize observations using
+[`references/snapshot-contract.md`](references/snapshot-contract.md). Mark
+`result_completeness.complete=true` only after proving the requested repository,
+author, state, and time-window inventory is exhaustive. An incomplete current
+snapshot must not make absent rows look closed or removed.
+Do not advance the durable baseline or grouped-monitor `result_hash` from an
+incomplete snapshot; otherwise a partial page can create false remove/re-add
+transitions on the next poll.
+
+Store raw and normalized snapshots under an ignored owner-local directory such
+as `.local/loopx/pr-program/<program-id>/`. Verify the path with
+`git check-ignore` before writing. If no ignored path is available, use a
+temporary directory and keep only a redacted evidence summary in LoopX state.
+
+## Reconcile Material Changes
+
+Run the bundled delta helper before manually comparing rows:
+
+```bash
+python skills/loopx-pr-program/scripts/diff_snapshot.py \
+  --previous <previous.json> \
+  --current <current.json> \
+  --output <delta.json>
+```
+
+Omit `--previous` for the first baseline. The helper treats lifecycle, draft,
+target branch, head revision, checks, review, work item, requirement, theme,
+priority, and dependency changes as material. Timestamp-only movement is
+observation noise. Read the actual description, latest review context, checks,
+and changed-file evidence for every added or materially changed row before
+updating the program judgment.
+
+Do not infer motivation or priority from title, number, author, age, or green CI
+alone. Product requirements set priority. Correctness dependencies and real
+merge gates determine order within a priority. Record a requirement gap
+explicitly when no change request implements part of the requested behavior;
+do not call the requirement complete because a neighboring parameter or feature
+landed.
+
+## Project The Program
+
+Keep one canonical program projection with three sections:
+
+1. completed work, grouped by product theme;
+2. pending work, grouped by product theme, with archived or superseded
+   development stacks nested under the surviving change request;
+3. merge priority, ordered first by explicit product priority, then dependency,
+   correctness risk, and current merge gate.
+
+Keep links at the end of each compact row. Preserve the target document's
+existing heading, color, callout, and strike-through conventions. Update only
+the affected blocks, refetch them after writing, and verify that unrelated
+content and resource blocks remain unchanged.
+
+For every priority row, distinguish these facts:
+
+- shipped behavior and requirement coverage;
+- dependency or recommended merge order;
+- current checks, review, and external work-item gates;
+- missing implementation or validation that no existing change request covers.
+
+## Write Back And Continue
+
+After a validated material change:
+
+1. update the grouped monitor `result_hash` and reset
+   `consecutive_no_change=0`;
+2. update the roadmap and refetch the changed sections;
+3. complete the reconciliation todo with compact evidence and create a
+   successor only when concrete follow-up remains;
+4. refresh LoopX state with the actual delivery classification and outcome;
+5. spend quota only after the state and document writeback are validated.
+
+After a quiet poll, update monitor scheduling metadata and increment
+`consecutive_no_change`; do not produce a synthetic progress event.
+
+## Public And Private Boundary
+
+Commit only the provider-neutral contract, algorithm, and redacted fixtures.
+Keep private provider adapters, source commands, raw comments, internal URLs,
+document ids, snapshots, and organization-specific prioritization outside the
+public repository. Before staging changes to this skill or its resources, scan
+the exact paths for private hostnames, executable names, credentials, local
+absolute paths, and raw operating context.

--- a/skills/loopx-pr-program/SKILL.md
+++ b/skills/loopx-pr-program/SKILL.md
@@ -89,6 +89,31 @@ explicitly when no change request implements part of the requested behavior;
 do not call the requirement complete because a neighboring parameter or feature
 landed.
 
+## Compose With An Integration Branch
+
+When several selected change requests belong to one repository, compose this
+program view with LoopX's `integration-branch-reconcile` capability. Keep the
+ownership split explicit:
+
+- this skill decides which changes belong in the candidate and why;
+- the integration-branch plan records their ordered local source refs and
+  proves what exact code is composed.
+
+Do not populate the plan from every open or P0 change request automatically.
+Select sources from explicit program scope, dependency order, and current
+review intent. Refresh the local refs through the authorized host workflow,
+then verify that each selected ref resolves to the observed `head_sha` before
+configuring or syncing the integration branch. A mismatch is source evidence
+drift, not permission to merge a stale local ref.
+
+Use the same grouped program monitor to read both the normalized change-request
+delta and `loopx integration-branch status --format json`. Treat base/source
+movement, an unexpected integration head, and merge conflict as material
+program evidence. A monitor poll remains read-only: it may report that the
+candidate needs reconciliation, but it must not run `sync --execute` by itself.
+That command is a separate, explicit local write and never grants authority to
+push, retarget, approve, or merge a remote change request.
+
 ## Project The Program
 
 Keep one canonical program projection with three sections:

--- a/skills/loopx-pr-program/SKILL.md
+++ b/skills/loopx-pr-program/SKILL.md
@@ -55,9 +55,11 @@ Normalize observations using
 `result_completeness.complete=true` only after proving the requested repository,
 author, state, and time-window inventory is exhaustive. An incomplete current
 snapshot must not make absent rows look closed or removed.
-Do not advance the durable baseline or grouped-monitor `result_hash` from an
-incomplete snapshot; otherwise a partial page can create false remove/re-add
-transitions on the next poll.
+Persist the structured scope fingerprint with the baseline. Do not advance the
+durable baseline or grouped-monitor `result_hash` from an incomplete snapshot
+or when the previous and current scope fingerprints differ; otherwise a partial
+page or narrowed query can create false remove/re-add transitions on the next
+poll.
 
 Store raw and normalized snapshots under an ignored owner-local directory such
 as `.local/loopx/pr-program/<program-id>/`. Verify the path with

--- a/skills/loopx-pr-program/agents/openai.yaml
+++ b/skills/loopx-pr-program/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "LoopX PR Program"
+  short_description: "Track cross-repository PR programs and material changes"
+  default_prompt: "Use $loopx-pr-program to reconcile a provider-neutral PR/MR snapshot, preserve requirement and dependency priorities, and write back only material changes."

--- a/skills/loopx-pr-program/references/snapshot-contract.md
+++ b/skills/loopx-pr-program/references/snapshot-contract.md
@@ -1,0 +1,103 @@
+# PR Program Snapshot Contract
+
+Use `loopx_pr_program_snapshot_v0` as the provider-neutral boundary between
+source acquisition and LoopX program reconciliation. Keep source-specific
+commands and credentials outside the snapshot producer committed to LoopX.
+
+## Shape
+
+```json
+{
+  "schema_version": "loopx_pr_program_snapshot_v0",
+  "program_id": "runtime-reliability",
+  "generated_at": "2026-08-06T10:00:00Z",
+  "result_completeness": {
+    "complete": true,
+    "scope": "all open change requests in the selected repositories"
+  },
+  "requirements": [
+    {
+      "id": "runtime-parameters",
+      "title": "Expose runtime quality and latency controls",
+      "priority": "P0",
+      "coverage": "partial"
+    }
+  ],
+  "change_requests": [
+    {
+      "ref": "example/runtime#42",
+      "repository": "example/runtime",
+      "number": 42,
+      "url": "https://example.invalid/example/runtime/changes/42",
+      "title": "feat(runtime): expose quality control",
+      "state": "open",
+      "draft": true,
+      "target_branch": "main",
+      "head_sha": "0123456789abcdef",
+      "updated_at": "2026-08-06T09:55:00Z",
+      "checks": "passed",
+      "review": "pending",
+      "work_item": "action_required",
+      "theme": "runtime parameters",
+      "priority": "P0",
+      "requirement_ids": ["runtime-parameters"],
+      "depends_on": [],
+      "supersedes": [],
+      "description_digest": "sha256:public-safe-digest",
+      "review_digest": "sha256:public-safe-digest"
+    }
+  ]
+}
+```
+
+## Required Invariants
+
+- `program_id`, `generated_at`, `result_completeness`, `requirements`, and
+  `change_requests` must be present.
+- `ref` is the stable unique key. Prefer `repository#number`; do not use title.
+- `result_completeness.complete` controls removal semantics. Missing rows are
+  removals only when the current inventory is complete. Incomplete snapshots
+  must not replace the durable baseline or monitor result hash.
+- `updated_at` is observational. It must not trigger a material transition by
+  itself.
+- `description_digest` and `review_digest` may prove content movement without
+  storing raw private text.
+- `requirements[].priority` is the product priority. A change request may have a
+  lower effective priority only when the owner explicitly records that choice.
+- `coverage` is `none`, `partial`, or `complete`. Do not infer `complete` from a
+  merged neighbor.
+
+Normalize lifecycle values as follows:
+
+| Field | Values |
+| --- | --- |
+| `state` | `open`, `merged`, `closed`, `unknown` |
+| `checks` | `passed`, `failed`, `pending`, `unknown` |
+| `review` | `pending`, `approved`, `changes_requested`, `unknown` |
+| `work_item` | `passed`, `failed`, `action_required`, `unknown` |
+| `priority` | `P0`, `P1`, `P2`, or `unclassified` |
+
+## Material Fields
+
+The delta helper considers these fields material:
+
+- `title`, `state`, `draft`, `target_branch`, and `head_sha`;
+- `checks`, `review`, and `work_item`;
+- `theme`, `priority`, `requirement_ids`, `depends_on`, and `supersedes`;
+- `description_digest` and `review_digest`;
+- requirement title, priority, and coverage.
+
+Treat additions and complete-snapshot removals as material. Treat
+`generated_at` and timestamp-only `updated_at` changes as observation-only.
+
+## Privacy Checklist
+
+Before committing any fixture or example derived from a real program, verify:
+
+- repository names, URLs, change request titles, people, and comments are
+  public;
+- no credential, token, private executable name, internal hostname, local path,
+  or document id remains;
+- raw comments and descriptions are replaced with public-safe digests unless
+  their public text is intentionally part of the fixture;
+- the fixture is minimal and proves a reusable semantic invariant.

--- a/skills/loopx-pr-program/references/snapshot-contract.md
+++ b/skills/loopx-pr-program/references/snapshot-contract.md
@@ -67,6 +67,20 @@ commands and credentials outside the snapshot producer committed to LoopX.
 - `coverage` is `none`, `partial`, or `complete`. Do not infer `complete` from a
   merged neighbor.
 
+## Integration-Branch Composition
+
+The snapshot is the remote lifecycle and requirement view; it is not an
+integration-branch plan. When the program uses a local integration candidate,
+map only explicitly selected change requests to the separate ignored
+`loopx_integration_branch_plan_v0` state.
+
+Before each reconcile, prove that the selected local source ref resolves to the
+snapshot row's `head_sha`. Feed the resulting
+`loopx_integration_branch_status_v0` readback into the grouped program monitor
+as additional evidence. Keep source ref names and sync receipts in ignored
+project-local state; do not add them to a public roadmap merely to make this
+composition work.
+
 Normalize lifecycle values as follows:
 
 | Field | Values |

--- a/skills/loopx-pr-program/references/snapshot-contract.md
+++ b/skills/loopx-pr-program/references/snapshot-contract.md
@@ -13,7 +13,12 @@ commands and credentials outside the snapshot producer committed to LoopX.
   "generated_at": "2026-08-06T10:00:00Z",
   "result_completeness": {
     "complete": true,
-    "scope": "all open change requests in the selected repositories"
+    "scope": {
+      "repositories": ["example/runtime"],
+      "states": ["open"],
+      "authors": [],
+      "time_window": {"since": null, "until": null}
+    }
   },
   "requirements": [
     {
@@ -55,9 +60,15 @@ commands and credentials outside the snapshot producer committed to LoopX.
 - `program_id`, `generated_at`, `result_completeness`, `requirements`, and
   `change_requests` must be present.
 - `ref` is the stable unique key. Prefer `repository#number`; do not use title.
-- `result_completeness.complete` controls removal semantics. Missing rows are
-  removals only when the current inventory is complete. Incomplete snapshots
-  must not replace the durable baseline or monitor result hash.
+- `result_completeness.scope` is a structured inventory identity. It must name
+  repository, state, author, and time-window filters explicitly; arrays are
+  unordered filter sets. The delta helper normalizes and hashes the complete
+  object, including any additional provider-neutral filters.
+- `result_completeness.complete` controls removal semantics only when the
+  previous and current scope fingerprints match. Missing rows are removals only
+  when the current inventory is complete for the same scope. Incomplete or
+  scope-mismatched snapshots must not replace the durable baseline or monitor
+  result hash.
 - `updated_at` is observational. It must not trigger a material transition by
   itself.
 - `description_digest` and `review_digest` may prove content movement without

--- a/skills/loopx-pr-program/scripts/diff_snapshot.py
+++ b/skills/loopx-pr-program/scripts/diff_snapshot.py
@@ -30,6 +30,83 @@ MATERIAL_FIELDS = (
     "review_digest",
 )
 REQUIREMENT_FIELDS = ("title", "priority", "coverage")
+SCOPE_FIELDS = ("repositories", "states", "authors", "time_window")
+
+
+def _normalized_scope_value(value: Any, *, path: str) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            str(key): _normalized_scope_value(item, path=f"{path}.{key}")
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+    if isinstance(value, list):
+        normalized = [
+            _normalized_scope_value(item, path=f"{path}[]") for item in value
+        ]
+        return sorted(
+            normalized,
+            key=lambda item: json.dumps(
+                item,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        )
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            raise ValueError(f"{path} must not contain an empty string")
+        return text
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    raise TypeError(f"{path} contains an unsupported value")
+
+
+def _scope_projection(payload: Mapping[str, Any]) -> dict[str, Any]:
+    completeness = payload.get("result_completeness")
+    if not isinstance(completeness, Mapping):
+        raise TypeError("result_completeness must be an object")
+    scope = completeness.get("scope")
+    if not isinstance(scope, Mapping):
+        raise TypeError("result_completeness.scope must be an object")
+    missing = [field for field in SCOPE_FIELDS if field not in scope]
+    if missing:
+        raise ValueError(
+            "result_completeness.scope is missing " + ", ".join(missing)
+        )
+    for field in ("repositories", "states", "authors"):
+        if not isinstance(scope.get(field), list):
+            raise TypeError(f"result_completeness.scope.{field} must be an array")
+    if not scope["repositories"]:
+        raise ValueError("result_completeness.scope.repositories must not be empty")
+    if not scope["states"]:
+        raise ValueError("result_completeness.scope.states must not be empty")
+    time_window = scope.get("time_window")
+    if not isinstance(time_window, Mapping):
+        raise TypeError("result_completeness.scope.time_window must be an object")
+    for field in ("since", "until"):
+        if field not in time_window:
+            raise ValueError(
+                f"result_completeness.scope.time_window is missing {field}"
+            )
+        if time_window[field] is not None and not isinstance(time_window[field], str):
+            raise TypeError(
+                f"result_completeness.scope.time_window.{field} must be a string or null"
+            )
+    normalized = _normalized_scope_value(scope, path="result_completeness.scope")
+    json.dumps(normalized, allow_nan=False)
+    return normalized
+
+
+def _scope_fingerprint(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        _scope_projection(payload),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def _load(path: Path) -> dict[str, Any]:
@@ -47,6 +124,7 @@ def _load(path: Path) -> dict[str, Any]:
     ):
         if field not in payload:
             raise ValueError(f"snapshot is missing {field}: {path}")
+    _scope_projection(payload)
     return payload
 
 
@@ -84,6 +162,7 @@ def _material_projection(payload: Mapping[str, Any]) -> dict[str, Any]:
     changes = _rows(payload, "change_requests", "ref")
     return {
         "program_id": payload.get("program_id"),
+        "scope": _scope_projection(payload),
         "requirements": {
             key: _project(row, REQUIREMENT_FIELDS)
             for key, row in sorted(requirements.items())
@@ -115,9 +194,25 @@ def build_delta(
     previous_requirements = (
         _rows(previous, "requirements", "id") if previous is not None else {}
     )
-    complete = bool(
+    current_scope_fingerprint = _scope_fingerprint(current)
+    previous_scope_fingerprint = (
+        _scope_fingerprint(previous) if previous is not None else None
+    )
+    scope_matches_previous = (
+        previous_scope_fingerprint is None
+        or previous_scope_fingerprint == current_scope_fingerprint
+    )
+    current_complete = bool(
         isinstance(current.get("result_completeness"), Mapping)
         and current["result_completeness"].get("complete") is True
+    )
+    complete = current_complete and scope_matches_previous
+    baseline_block_reason = (
+        None
+        if complete
+        else "scope_mismatch"
+        if not scope_matches_previous
+        else "incomplete_result"
     )
 
     added = sorted(set(current_changes) - set(previous_changes))
@@ -188,7 +283,11 @@ def build_delta(
         "generated_at": current.get("generated_at"),
         "baseline": previous is None,
         "baseline_advance_allowed": complete,
+        "baseline_block_reason": baseline_block_reason,
         "result_completeness": current.get("result_completeness"),
+        "scope_fingerprint": current_scope_fingerprint,
+        "previous_scope_fingerprint": previous_scope_fingerprint,
+        "scope_matches_previous": scope_matches_previous,
         "result_hash": observed_result_hash if complete else None,
         "observed_result_hash": observed_result_hash,
         "material_change": material_change,

--- a/skills/loopx-pr-program/scripts/diff_snapshot.py
+++ b/skills/loopx-pr-program/scripts/diff_snapshot.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Compare provider-neutral LoopX PR-program snapshots."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+SNAPSHOT_SCHEMA = "loopx_pr_program_snapshot_v0"
+DELTA_SCHEMA = "loopx_pr_program_delta_v0"
+MATERIAL_FIELDS = (
+    "title",
+    "state",
+    "draft",
+    "target_branch",
+    "head_sha",
+    "checks",
+    "review",
+    "work_item",
+    "theme",
+    "priority",
+    "requirement_ids",
+    "depends_on",
+    "supersedes",
+    "description_digest",
+    "review_digest",
+)
+REQUIREMENT_FIELDS = ("title", "priority", "coverage")
+
+
+def _load(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise TypeError(f"snapshot must be an object: {path}")
+    if payload.get("schema_version") != SNAPSHOT_SCHEMA:
+        raise ValueError(f"unsupported snapshot schema in {path}")
+    for field in (
+        "program_id",
+        "generated_at",
+        "result_completeness",
+        "requirements",
+        "change_requests",
+    ):
+        if field not in payload:
+            raise ValueError(f"snapshot is missing {field}: {path}")
+    return payload
+
+
+def _rows(
+    payload: Mapping[str, Any], field: str, key: str
+) -> dict[str, dict[str, Any]]:
+    raw_rows = payload.get(field)
+    if not isinstance(raw_rows, list):
+        raise TypeError(f"{field} must be an array")
+    result: dict[str, dict[str, Any]] = {}
+    for index, row in enumerate(raw_rows):
+        if not isinstance(row, dict):
+            raise TypeError(f"{field}[{index}] must be an object")
+        identity = str(row.get(key) or "").strip()
+        if not identity:
+            raise ValueError(f"{field}[{index}] is missing {key}")
+        if identity in result:
+            raise ValueError(f"duplicate {field} identity: {identity}")
+        result[identity] = row
+    return result
+
+
+def _changed_fields(
+    before: Mapping[str, Any], after: Mapping[str, Any], fields: tuple[str, ...]
+) -> list[str]:
+    return [field for field in fields if before.get(field) != after.get(field)]
+
+
+def _project(row: Mapping[str, Any], fields: tuple[str, ...]) -> dict[str, Any]:
+    return {field: row.get(field) for field in fields}
+
+
+def _material_projection(payload: Mapping[str, Any]) -> dict[str, Any]:
+    requirements = _rows(payload, "requirements", "id")
+    changes = _rows(payload, "change_requests", "ref")
+    return {
+        "program_id": payload.get("program_id"),
+        "requirements": {
+            key: _project(row, REQUIREMENT_FIELDS)
+            for key, row in sorted(requirements.items())
+        },
+        "change_requests": {
+            key: _project(row, MATERIAL_FIELDS) for key, row in sorted(changes.items())
+        },
+    }
+
+
+def _digest(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        _material_projection(payload),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def build_delta(
+    previous: Mapping[str, Any] | None, current: Mapping[str, Any]
+) -> dict[str, Any]:
+    current_changes = _rows(current, "change_requests", "ref")
+    current_requirements = _rows(current, "requirements", "id")
+    previous_changes = (
+        _rows(previous, "change_requests", "ref") if previous is not None else {}
+    )
+    previous_requirements = (
+        _rows(previous, "requirements", "id") if previous is not None else {}
+    )
+    complete = bool(
+        isinstance(current.get("result_completeness"), Mapping)
+        and current["result_completeness"].get("complete") is True
+    )
+
+    added = sorted(set(current_changes) - set(previous_changes))
+    absent = sorted(set(previous_changes) - set(current_changes))
+    removed = absent if complete else []
+    omitted_previous = [] if complete else absent
+    changed: list[dict[str, Any]] = []
+    observation_only: list[str] = []
+    for ref in sorted(set(previous_changes) & set(current_changes)):
+        before = previous_changes[ref]
+        after = current_changes[ref]
+        fields = _changed_fields(before, after, MATERIAL_FIELDS)
+        if fields:
+            changed.append(
+                {
+                    "ref": ref,
+                    "changed_fields": fields,
+                    "before": _project(before, tuple(fields)),
+                    "after": _project(after, tuple(fields)),
+                }
+            )
+        elif before.get("updated_at") != after.get("updated_at"):
+            observation_only.append(ref)
+
+    requirement_changes: list[dict[str, Any]] = []
+    omitted_previous_requirements: list[str] = []
+    for requirement_id in sorted(
+        set(previous_requirements) | set(current_requirements)
+    ):
+        before = previous_requirements.get(requirement_id)
+        after = current_requirements.get(requirement_id)
+        if before is None:
+            requirement_changes.append(
+                {
+                    "id": requirement_id,
+                    "change": "added",
+                }
+            )
+            continue
+        if after is None:
+            if complete:
+                requirement_changes.append(
+                    {
+                        "id": requirement_id,
+                        "change": "removed",
+                    }
+                )
+            else:
+                omitted_previous_requirements.append(requirement_id)
+            continue
+        fields = _changed_fields(before, after, REQUIREMENT_FIELDS)
+        if fields:
+            requirement_changes.append(
+                {
+                    "id": requirement_id,
+                    "change": "updated",
+                    "changed_fields": fields,
+                    "before": _project(before, tuple(fields)),
+                    "after": _project(after, tuple(fields)),
+                }
+            )
+
+    material_change = bool(added or removed or changed or requirement_changes)
+    observed_result_hash = _digest(current)
+    return {
+        "schema_version": DELTA_SCHEMA,
+        "program_id": current.get("program_id"),
+        "generated_at": current.get("generated_at"),
+        "baseline": previous is None,
+        "baseline_advance_allowed": complete,
+        "result_completeness": current.get("result_completeness"),
+        "result_hash": observed_result_hash if complete else None,
+        "observed_result_hash": observed_result_hash,
+        "material_change": material_change,
+        "summary": {
+            "added": len(added),
+            "removed": len(removed),
+            "changed": len(changed),
+            "requirement_changed": len(requirement_changes),
+            "observation_only": len(observation_only),
+            "omitted_previous": len(omitted_previous),
+            "omitted_previous_requirements": len(omitted_previous_requirements),
+            "unchanged": len(current_changes)
+            - len(added)
+            - len(changed)
+            - len(observation_only),
+        },
+        "added": added,
+        "removed": removed,
+        "changed": changed,
+        "requirement_changes": requirement_changes,
+        "observation_only": observation_only,
+        "omitted_previous": omitted_previous,
+        "omitted_previous_requirements": omitted_previous_requirements,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compare provider-neutral LoopX PR-program snapshots."
+    )
+    parser.add_argument("--previous", type=Path)
+    parser.add_argument("--current", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    previous = _load(args.previous) if args.previous else None
+    current = _load(args.current)
+    if previous and previous.get("program_id") != current.get("program_id"):
+        raise ValueError(
+            "previous and current snapshots use different program_id values"
+        )
+    rendered = json.dumps(build_delta(previous, current), ensure_ascii=False, indent=2)
+    if args.output:
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    else:
+        print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/loopx-project/SKILL.md
+++ b/skills/loopx-project/SKILL.md
@@ -114,6 +114,13 @@ contract. Do not handle `/loopx-pr-review` from this broader project skill, and
 do not route it to `loopx-pr-merge` unless the user later asks to approve,
 comment on, merge, self-merge, or admin-bypass a specific PR.
 
+When the request asks to inventory, prioritize, document, or continuously
+monitor a delivery program spanning several PRs or MRs, load the narrower
+`loopx-pr-program` skill after the project goal transaction is established.
+That skill owns provider-neutral snapshots, grouped monitor state, material
+change detection, and roadmap projection. Keep deep per-change review in
+`loopx-pr-review` and provider mutations in the separately authorized workflow.
+
 When a user has just connected a project, receives a guided start packet, or
 receives a bootstrap command pack for the first time, briefly tell them the
 usable commands instead of assuming they will inspect CLI help:

--- a/tests/capabilities/test_change_quality.py
+++ b/tests/capabilities/test_change_quality.py
@@ -934,6 +934,7 @@ def test_quality_skill_delivery_is_policy_conditional_and_host_neutral(
     assert inactive["required_skill_ids"] == [
         "loopx",
         "loopx-project",
+        "loopx-pr-program",
         "loopx-pr-review",
         "loopx-doc-registry",
         "loopx-self-repair",

--- a/tests/test_pr_program_snapshot_diff.py
+++ b/tests/test_pr_program_snapshot_diff.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "skills" / "loopx-pr-program" / "scripts" / "diff_snapshot.py"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("loopx_pr_program_diff", SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _snapshot(*, complete: bool, generated_at: str) -> dict[str, object]:
+    return {
+        "schema_version": "loopx_pr_program_snapshot_v0",
+        "program_id": "public-runtime-program",
+        "generated_at": generated_at,
+        "result_completeness": {"complete": complete, "scope": "fixture"},
+        "requirements": [
+            {
+                "id": "runtime-controls",
+                "title": "Expose runtime controls",
+                "priority": "P0",
+                "coverage": "partial",
+            }
+        ],
+        "change_requests": [
+            {
+                "ref": "example/runtime#42",
+                "title": "feat(runtime): expose quality control",
+                "state": "open",
+                "draft": True,
+                "target_branch": "main",
+                "head_sha": "a" * 40,
+                "updated_at": generated_at,
+                "checks": "passed",
+                "review": "pending",
+                "work_item": "action_required",
+                "theme": "runtime controls",
+                "priority": "P0",
+                "requirement_ids": ["runtime-controls"],
+                "depends_on": [],
+                "supersedes": [],
+                "description_digest": "sha256:description",
+                "review_digest": "sha256:review",
+            },
+            {
+                "ref": "example/runtime#41",
+                "title": "refactor(runtime): isolate role parameters",
+                "state": "open",
+                "draft": False,
+                "target_branch": "main",
+                "head_sha": "b" * 40,
+                "updated_at": generated_at,
+                "checks": "passed",
+                "review": "approved",
+                "work_item": "passed",
+                "theme": "runtime controls",
+                "priority": "P1",
+                "requirement_ids": ["runtime-controls"],
+                "depends_on": [],
+                "supersedes": [],
+                "description_digest": "sha256:description-41",
+                "review_digest": "sha256:review-41",
+            },
+        ],
+    }
+
+
+def test_incomplete_snapshot_does_not_treat_absent_row_as_removed() -> None:
+    module = _load_module()
+    previous = _snapshot(complete=True, generated_at="2026-08-06T09:00:00Z")
+    current = _snapshot(complete=False, generated_at="2026-08-06T10:00:00Z")
+    current["change_requests"] = current["change_requests"][:1]
+    current["requirements"] = []
+
+    delta = module.build_delta(previous, current)
+
+    assert delta["material_change"] is False
+    assert delta["baseline_advance_allowed"] is False
+    assert delta["result_hash"] is None
+    assert delta["observed_result_hash"]
+    assert delta["removed"] == []
+    assert delta["omitted_previous"] == ["example/runtime#41"]
+    assert delta["omitted_previous_requirements"] == ["runtime-controls"]
+    assert delta["observation_only"] == ["example/runtime#42"]
+
+
+def test_complete_snapshot_reports_material_gate_and_removal_changes() -> None:
+    module = _load_module()
+    previous = _snapshot(complete=True, generated_at="2026-08-06T09:00:00Z")
+    current = _snapshot(complete=True, generated_at="2026-08-06T10:00:00Z")
+    current["change_requests"] = current["change_requests"][:1]
+    current["change_requests"][0]["checks"] = "failed"
+
+    delta = module.build_delta(previous, current)
+
+    assert delta["material_change"] is True
+    assert delta["baseline_advance_allowed"] is True
+    assert delta["result_hash"] == delta["observed_result_hash"]
+    assert delta["removed"] == ["example/runtime#41"]
+    assert delta["changed"] == [
+        {
+            "ref": "example/runtime#42",
+            "changed_fields": ["checks"],
+            "before": {"checks": "passed"},
+            "after": {"checks": "failed"},
+        }
+    ]

--- a/tests/test_pr_program_snapshot_diff.py
+++ b/tests/test_pr_program_snapshot_diff.py
@@ -22,7 +22,15 @@ def _snapshot(*, complete: bool, generated_at: str) -> dict[str, object]:
         "schema_version": "loopx_pr_program_snapshot_v0",
         "program_id": "public-runtime-program",
         "generated_at": generated_at,
-        "result_completeness": {"complete": complete, "scope": "fixture"},
+        "result_completeness": {
+            "complete": complete,
+            "scope": {
+                "repositories": ["example/runtime"],
+                "states": ["open"],
+                "authors": [],
+                "time_window": {"since": None, "until": None},
+            },
+        },
         "requirements": [
             {
                 "id": "runtime-controls",
@@ -114,6 +122,26 @@ def test_complete_snapshot_reports_material_gate_and_removal_changes() -> None:
             "after": {"checks": "failed"},
         }
     ]
+
+
+def test_complete_snapshot_scope_mismatch_fails_closed() -> None:
+    module = _load_module()
+    previous = _snapshot(complete=True, generated_at="2026-08-06T09:00:00Z")
+    current = _snapshot(complete=True, generated_at="2026-08-06T10:00:00Z")
+    current["result_completeness"]["scope"]["repositories"] = ["example/other"]
+    current["change_requests"] = current["change_requests"][:1]
+    current["requirements"] = []
+
+    delta = module.build_delta(previous, current)
+
+    assert delta["scope_matches_previous"] is False
+    assert delta["baseline_advance_allowed"] is False
+    assert delta["baseline_block_reason"] == "scope_mismatch"
+    assert delta["result_hash"] is None
+    assert delta["removed"] == []
+    assert delta["omitted_previous"] == ["example/runtime#41"]
+    assert delta["omitted_previous_requirements"] == ["runtime-controls"]
+    assert delta["material_change"] is False
 
 
 def test_skill_composes_read_only_monitoring_with_integration_branch() -> None:

--- a/tests/test_pr_program_snapshot_diff.py
+++ b/tests/test_pr_program_snapshot_diff.py
@@ -6,6 +6,7 @@ from types import ModuleType
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = REPO_ROOT / "skills" / "loopx-pr-program" / "scripts" / "diff_snapshot.py"
+SKILL_PATH = REPO_ROOT / "skills" / "loopx-pr-program" / "SKILL.md"
 
 
 def _load_module() -> ModuleType:
@@ -113,3 +114,11 @@ def test_complete_snapshot_reports_material_gate_and_removal_changes() -> None:
             "after": {"checks": "failed"},
         }
     ]
+
+
+def test_skill_composes_read_only_monitoring_with_integration_branch() -> None:
+    skill = SKILL_PATH.read_text(encoding="utf-8")
+
+    assert "integration-branch-reconcile" in skill
+    assert "verify that each selected ref resolves to the observed `head_sha`" in skill
+    assert "must not run `sync --execute` by itself" in skill


### PR DESCRIPTION
## What

- add the implicit `$loopx-pr-program` workflow for multi-PR/MR inventory, prioritization, roadmap projection, and grouped monitoring
- define a provider-neutral snapshot contract and a deterministic material-delta helper
- compose selected same-repository changes with the existing local integration-branch capability while keeping monitor polls read-only
- install and read back the workflow across packaged host surfaces
- document activation, validation, authority, and rollback boundaries

## Why

Long-running delivery programs should not be rebuilt from chat memory or one monitor per change request. This workflow keeps one durable program baseline, separates product priority from merge gates, and prevents incomplete inventories from producing false removal/re-add transitions. When an integration candidate is useful, the program view chooses the explicit source set while the existing integration-branch receipt proves what exact local code is composed.

## Boundary

This change ships no source-control provider adapter and grants no external read or write authority. Raw acquisition commands, credentials, private URLs, comments, and snapshots remain host-local. A grouped monitor may read integration drift, but it never runs `sync --execute` or mutates remote change requests.

## Validation

- `loopx canary premerge --from-git-diff` (13/13 selected checks passed)
- `pytest -q tests/test_pr_program_snapshot_diff.py tests/test_ark_managed_agent_host.py tests/test_host_loop_activation.py` (89 passed)
- `python examples/install-local-smoke.py`
- `python examples/codex-cli-packaged-install-smoke.py`
- `python examples/fresh-clone-quickstart-smoke.py`
- skill quick validation, Ruff, compile, diff, and public-boundary checks passed