### PR TITLE
test(finance): enforce observation evidence reference invariants

### DIFF
--- a/packages/loopx-finance-value-discovery/CONTRACT.md
+++ b/packages/loopx-finance-value-discovery/CONTRACT.md
@@ -69,6 +69,11 @@ typed and compared with the frozen rule to produce `passed` or `failed`.
 Providers may instead report `missing` or `conflict`. The first `failed`,
 `missing`, or `conflict` result blocks the case, and every later observation
 must be `not_run`.
+
+Evidence references are state-dependent: `observed` observations require at
+least one reference, `conflict` observations require at least two references,
+and `not_run` observations must contain none.
+
 Running a later gate after a blocker is rejected as an invalid input rather
 than silently accepted.
 

--- a/tests/extensions/test_finance_contract_gate_replay.py
+++ b/tests/extensions/test_finance_contract_gate_replay.py
@@ -122,6 +122,36 @@ def test_gate_order_and_short_circuit_are_enforced() -> None:
         build_finance_case_evaluation(premature_not_run)
 
 
+@pytest.mark.parametrize(
+    ("index", "observation_state", "evidence_refs", "message"),
+    [
+        (0, "observed", [], "observed values require evidence_refs"),
+        (
+            2,
+            "conflict",
+            ["filing-primary"],
+            "conflicts require at least two evidence_refs",
+        ),
+        (4, "not_run", ["valuation-bridge"], "not_run cannot include evidence_refs"),
+    ],
+)
+def test_gate_observation_states_enforce_evidence_ref_invariants(
+    index: int,
+    observation_state: str,
+    evidence_refs: list[str],
+    message: str,
+) -> None:
+    payload = _example()
+    observation = payload["observations"][index]
+    observation["observation_state"] = observation_state
+    if observation_state != "observed":
+        observation["value"] = None
+    observation["evidence_refs"] = evidence_refs
+
+    with pytest.raises(ValueError, match=message):
+        build_finance_case_evaluation(payload)
+
+
 def test_provider_cannot_declare_pass_fail_or_change_value_type() -> None:
     declared_result = _example()
     declared_result["observations"][0]["state"] = "passed"

--- a/tests/extensions/test_finance_contract_gate_replay.py
+++ b/tests/extensions/test_finance_contract_gate_replay.py
@@ -123,26 +123,35 @@ def test_gate_order_and_short_circuit_are_enforced() -> None:
 
 
 @pytest.mark.parametrize(
-    ("index", "observation_state", "evidence_refs", "message"),
+    ("gate_id", "observation_state", "evidence_refs", "message"),
     [
-        (0, "observed", [], "observed values require evidence_refs"),
+        ("universe", "observed", [], "observed values require evidence_refs"),
         (
-            2,
+            "evidence_quality",
             "conflict",
             ["filing-primary"],
             "conflicts require at least two evidence_refs",
         ),
-        (4, "not_run", ["valuation-bridge"], "not_run cannot include evidence_refs"),
+        (
+            "de_beta_residual",
+            "not_run",
+            ["valuation-bridge"],
+            "not_run cannot include evidence_refs",
+        ),
     ],
 )
 def test_gate_observation_states_enforce_evidence_ref_invariants(
-    index: int,
+    gate_id: str,
     observation_state: str,
     evidence_refs: list[str],
     message: str,
 ) -> None:
     payload = _example()
-    observation = payload["observations"][index]
+    observation = next(
+        observation
+        for observation in payload["observations"]
+        if observation["gate_id"] == gate_id
+    )
     observation["observation_state"] = observation_state
     if observation_state != "observed":
         observation["value"] = None


### PR DESCRIPTION
## Summary
- add parameterized coverage for invalid observation evidence-reference states
- preserve the fail-closed boundary for observed, conflicting, and skipped finance gate observations
- keep production logic and provider behavior unchanged

Closes #2815.

## Test plan
- [x] `python3 examples/finance-value-discovery-extension-smoke.py`
- [x] `python -m pytest tests/extensions/test_finance_contract_gate_replay.py -q` (23 passed)
- [x] `python -m pytest tests/extensions/test_finance_beta_and_metric_packs.py -q` (28 passed)
- [x] `python -m pytest tests/extensions/test_finance_value_discovery_extension.py -q` (15 passed)
- [x] `git diff --check`

The pytest commands ran in an isolated Python 3.14 virtual environment because the host Python installations did not include pytest.

Made with [Cursor](https://cursor.com)