### PR TITLE
feat(auto-research): require failure successors

### DIFF
--- a/docs/superpowers/specs/2026-08-06-auto-research-failure-successors-design.md
+++ b/docs/superpowers/specs/2026-08-06-auto-research-failure-successors-design.md
@@ -1,0 +1,366 @@
+# Bounded Auto-Research Failure Successors Design
+
+**Status:** Accepted direction; pending written-spec review before implementation.
+
+## Change Contract
+
+**Goal:** Ensure a retired auto-research hypothesis produces one bounded next
+control-plane outcome: a single data/measurement remediation, a new
+hypothesis-proposer todo, an extension-evolution proposal, or an explicit
+research-frontier exhaustion record.
+
+**Acceptance evidence:**
+
+- A negative-evidence fixture cannot finish as an implicit no-follow-up.
+- A declared data/measurement gap creates at most one remediation todo for its
+  hypothesis lineage and never creates a monitor.
+- A non-remediable retirement creates a proposer successor todo through the
+  existing role-successor lifecycle.
+- A remediated lineage that still fails creates a proposer successor or an
+  explicit `frontier_exhausted` outcome.
+- Every terminal research evaluation records one local evolution review before
+  completion, so an agent cannot silently stop after either a positive or
+  negative result.
+- A reproducible product-contract violation can create one bounded extension
+  evolution proposal without waiting for a user to identify the gap.
+- All resulting projections remain public-safe and use no network, scheduler,
+  service, or new package dependency.
+
+**Not in scope:**
+
+- Automatically inventing a research hypothesis, changing a strategy, or
+  relaxing thresholds.
+- Waiting for future data through a `continuous_monitor` todo.
+- Automatically editing, installing, enabling, upgrading, or publishing an
+  extension.
+- Creating a coordinator, a background agent, or a second research database.
+
+**Expected implementation boundary:**
+
+- `loopx/capabilities/auto_research/` owns the completion and role-successor
+  semantics.
+- `examples/auto-research-*.py` owns focused public regression proof.
+- `docs/reference/protocols/auto-research-*.md` owns the public contract.
+- A later extension-evolution proposal remains a normal LoopX todo, not a new
+  extension runtime.
+
+## Problem
+
+The current auto-research read model recognizes negative evidence and derives
+`retirement_candidates`. Its completion status then becomes
+`retirement_review_required`. The default evaluator/promoter role profile,
+however, declares successors only for positive dev/holdout paths. Once a
+retirement review is completed, no deterministic role successor is required.
+
+That lets an agent stop after a valid failed result even when the failure
+contains a reusable research constraint or exposes a bounded next question.
+The generic autonomous-replan mechanism detects repeated no-progress, but it
+does not know whether a specific research failure should repair measurement,
+change mechanism, or close the question.
+
+## Placement Rationale
+
+```text
+capability_id: auto-research
+provider_id: loopx-core
+origin: builtin
+placement: loopx/capabilities/auto_research/
+reason: The existing capability already owns research evidence, completion
+        status, worker roles, and role-declared successor todos. The new
+        behavior refines that lifecycle; it is not a provider-neutral
+        extension capability.
+```
+
+The later extension-evolution signal does not make a new extension. It is a
+public-safe proposal for a human- or agent-owned product todo. The existing
+extension runtime remains responsible only for provider lifecycle.
+
+## Design Principles
+
+1. **Every completed research result is an evolution input.** A terminal
+   evaluation must leave a durable constraint, successor, product-gap proposal,
+   or explicit exhaustion decision.
+2. **Negative evidence is progress.** A retired hypothesis must leave a
+   durable constraint and a visible next decision.
+3. **Data repair is exceptional and bounded.** A lineage gets at most one
+   declared data/measurement remediation. A weak metric does not by itself
+   qualify as a data gap.
+4. **No disguised parameter search.** A remediation may repair a declared
+   source, unit, corporate-action, proxy, split, or measurement defect. It may
+   not change thresholds, horizons, assets, or selection criteria to rescue the
+   original conclusion.
+5. **No future-data monitor.** If no current bounded action exists, the
+   research question closes explicitly. Future work can start from a new
+   contract when material is later available.
+6. **No fake automation.** The control plane creates a todo and enforces the
+   permitted outcome. The hypothesis proposer still writes the actual
+   evidence-backed proposal; the kernel never invents research content.
+7. **No external dependency.** All decisions derive from existing LoopX
+   rollout events, todo lineage, and local role-successor writes.
+
+## Completion Evolution Review
+
+Every terminal evaluator/promoter action (`supported`, `contradicted`,
+`retired`, `promoted`, or retry exhaustion) must derive and append one
+`research_evolution_review_v0` record before its source todo may complete.
+
+```json
+{
+  "schema_version": "research_evolution_review_v0",
+  "goal_id": "example-research",
+  "source_todo_id": "todo_distance_cache",
+  "hypothesis_id": "hyp_distance_cache",
+  "terminal_outcome": "contradicted",
+  "constraint_refs": ["research_constraint:distance_cache_regresses"],
+  "product_gap": {
+    "status": "none",
+    "fingerprint": null
+  },
+  "next_outcome": "propose_failure_successor"
+}
+```
+
+The review has exactly one `next_outcome`:
+
+| Next outcome | Meaning |
+| --- | --- |
+| `remediate_data_measurement` | The explicit repair budget remains and the defect is currently repairable. |
+| `propose_failure_successor` | A proposer must write a new, mechanism-changing hypothesis or explicit exhaustion. |
+| `extension_evolution_proposal` | Research exposed a bounded product or extension contract gap. |
+| `constraint_recorded` | A supported or promoted result has no unresolved, safe in-scope successor; its method constraint is still durable knowledge. |
+| `frontier_exhausted` | No current safe mechanism, material-preparation action, or product-gap proposal remains. |
+
+The system guarantee is deliberately about the **state transition**, not the
+quality of generated research prose: it guarantees that a completed research
+item cannot silently close without an evolution-review record and one of the
+five visible outcomes. The hypothesis-proposer lane remains accountable for
+the semantic content of a newly proposed hypothesis.
+
+## Failure Continuation Contract
+
+Introduce a compact projection and durable lifecycle record:
+`research_failure_continuation_v0`.
+
+```json
+{
+  "schema_version": "research_failure_continuation_v0",
+  "goal_id": "example-research",
+  "hypothesis_id": "hyp_distance_cache",
+  "source_todo_id": "todo_distance_cache",
+  "failure_kind": "mechanism_contradicted",
+  "failure_evidence_refs": ["research_evidence:hyp_distance_cache"],
+  "remediation_attempt_count": 0,
+  "remediation_attempt_limit": 1,
+  "remediation_allowed": false,
+  "monitor_allowed": false,
+  "required_next_outcomes": [
+    "propose_failure_successor",
+    "frontier_exhausted"
+  ]
+}
+```
+
+The record is public-safe. It records compact ids and evidence aliases only;
+it cannot contain raw evaluator logs, local paths, credentials, source bodies,
+or provider payloads.
+
+### Failure Kinds
+
+| Failure kind | Remediation allowed | Required next outcome |
+| --- | --- | --- |
+| `mechanism_contradicted` | No | Proposer successor or frontier exhaustion. |
+| `overfit_or_nonreplication` | No | Proposer successor with a changed mechanism, or frontier exhaustion. |
+| `guardrail_or_protected_boundary` | No | Proposer successor only if a safe new mechanism exists; otherwise exhaustion. |
+| `data_or_measurement_gap` | Yes, once | One remediation attempt, then re-evaluate. |
+| `unrecoverable_data_gap` | No | Proposer successor with a different currently available information set, or exhaustion. |
+| `retry_exhausted` | No | Proposer successor or exhaustion. |
+
+A data/measurement gap must be declared by the evaluator with a compact
+failure-evidence ref and a specific measurement scope. The kernel must not
+infer this classification merely from a poor score or a failing holdout.
+Absent an explicit declaration, the fail-closed default is
+`mechanism_contradicted` or the existing negative-evidence classification.
+
+### Repair Budget
+
+The repair count is computed from the parent hypothesis lineage and previous
+`research_failure_continuation_v0` records, not from how many times an agent
+retries a CLI command.
+
+- At count `0`, exactly one `remediate_data_measurement` successor is allowed
+  only for `data_or_measurement_gap`.
+- At count `1`, `remediation_allowed=false` permanently for the lineage.
+- A remediation retains the original research objective, protected scope, and
+  acceptance gates. It may correct only the declared measurement scope.
+- Its result must return to evaluation. A second negative result cannot reopen
+  remediation; it must produce a proposer successor or explicit exhaustion.
+
+## State Transitions
+
+```text
+evaluated
+  -> contradicted
+  -> failure_continuation_required
+       -> remediate_data_measurement      (only explicit gap and count=0)
+          -> evaluated
+       -> propose_failure_successor       (otherwise)
+          -> hypothesis_proposed | frontier_exhausted
+```
+
+`continuous_monitor` is not a legal edge in this state machine.
+
+### Completion Rule
+
+The evaluator/promoter may complete a failure-review todo only after one of
+these machine-visible deltas exists:
+
+1. an exactly linked `remediate_data_measurement` successor with remaining
+   repair budget;
+2. an exactly linked `propose_failure_successor` todo owned by the
+   hypothesis-proposer lane; or
+3. a durable `frontier_exhausted` record with a compact no-follow-up rationale.
+
+If none exists, the worker reports `failure_successor_required` and leaves the
+todo open. It must not use `no_followup=true`.
+
+### Proposer Successor Requirements
+
+`propose_failure_successor` is a manual research action, not an automatic
+idea generator. The proposer must select exactly one outcome:
+
+- **New hypothesis:** preserve the parent hypothesis and failure refs, name the
+  changed mechanism or available information set, and state why the change is
+  not a parameter relaxation.
+- **Frontier exhaustion:** record that no safe in-scope, currently executable
+  mechanism change exists. This closes the question without a monitor.
+
+The new hypothesis must not merely change a percentile cutoff, holding window,
+asset, time slice, or ranking threshold while keeping the same failed
+mechanism.
+
+## Local Implementation Shape
+
+### Read Model
+
+`research_state.py` derives a compact failure-continuation summary from
+retirement candidates and existing rollout evidence:
+
+- failure candidate ids and evidence aliases;
+- explicit data/measurement classification when recorded;
+- lineage repair count and remaining budget;
+- allowed successor actions;
+- whether explicit frontier exhaustion is the only permitted closeout.
+
+`build_auto_research_completion_status()` changes the negative path from
+`retirement_review_required` to `failure_successor_required` until a permitted
+delta is visible.
+
+### Role Profiles and Worker Runtime
+
+The evaluator/promoter profile declares failure successors in addition to its
+current positive-evidence successors:
+
+- create `remediate_data_measurement` only when the summary has
+  `remediation_allowed=true`;
+- otherwise create `propose_failure_successor` for `hypothesis-proposer`.
+
+The worker runtime reuses `apply_role_successor_todos()`. It must create the
+linked successor before calling the existing todo-completion helper. This keeps
+the behavior local, idempotent, quota-visible, and compatible with the current
+role-successor lifecycle.
+
+The hypothesis proposer profile adds `propose_failure_successor` to its
+allowed actions and states the three allowed outcomes above. No new coordinator
+or scheduler is introduced.
+
+### Durable Record
+
+The continuation decision is appended through the existing rollout-event
+mechanism so a later worker can recompute the budget and closeout state. The
+record must be idempotent for the same source todo and continuation outcome.
+
+## Extension Evolution Proposal (P1)
+
+P1 adds a separate, bounded product-improvement signal. It is not part of the
+P0 failure-successor transition and cannot change an extension automatically.
+
+The completion evolution review classifies a possible gap into one of two
+thresholds:
+
+| Gap class | Proposal threshold |
+| --- | --- |
+| `reproducible_product_contract_violation` | One research lineage is enough when a focused local fixture proves that a published or executable LoopX contract is violated. |
+| `repeated_extension_or_provider_gap` | The same public-safe fingerprint must occur in at least two distinct research lineages. |
+
+Eligible fingerprints are:
+
+- a repeated data/measurement validation gap that the current extension
+  contract cannot express;
+- a repeated provider boundary ambiguity that should fail closed earlier; or
+- a repeated missing control-plane successor that forces manual user
+  intervention.
+
+Single-source failures remain research constraints unless they prove the
+first-row product-contract violation. The proposal todo includes the compact
+fingerprint, source evidence refs, affected owner, a bounded contract change,
+explicit non-goals, and a focused validation target. It never installs,
+enables, upgrades, modifies, or publishes an extension.
+
+This rule covers the current gap: the documented research state machine permits
+`contradicted -> hypothesis_proposed`, but the executable evaluator completion
+has no matching successor rule. A focused fixture can reproduce that mismatch,
+so the evolution review may proactively create an auto-research product
+improvement proposal from one completed research lineage.
+
+## Test Plan
+
+Tests are written before implementation and exercise real local functions and
+todo lifecycle paths.
+
+1. **Negative evidence requires a delta.** A retired hypothesis produces
+   `failure_successor_required`; an evaluator completion without successor or
+   exhaustion is rejected.
+2. **Every terminal result receives an evolution review.** Supported,
+   contradicted, promoted, and retry-exhausted fixtures each emit one
+   `research_evolution_review_v0` before their source todo can close.
+3. **Default negative path creates proposer work.** A contradicted hypothesis
+   creates one linked `propose_failure_successor` todo for the registered
+   proposer lane and no monitor.
+4. **One repair limit.** An explicitly declared data/measurement gap creates
+   one remediation successor at count zero. After that remediation is recorded,
+   a second failure creates a proposer successor rather than another repair.
+5. **Explicit exhaustion is legal.** A durable `frontier_exhausted` record
+   permits no-follow-up without a monitor and remains visible in the frontier.
+6. **Parameter-relaxation guard.** A successor proposal lacking a changed
+   mechanism or measurement scope is rejected.
+7. **One-lineage contract violation can propose a product repair.** A fixture
+   showing a documented transition without a legal successor creates one
+   `extension_evolution_proposal`; a one-off data outage does not.
+8. **Public-safe projection.** Failure continuation and any P1 proposal reject
+   paths, URLs, credentials, raw logs, and provider payloads.
+
+## Documentation Changes
+
+Update the existing auto-research lane, state, and role-state-machine protocols
+to describe:
+
+- bounded remediation before failure successors;
+- no-monitor failure closeout;
+- proposer responsibility after retirement; and
+- the distinction between a research constraint and a repeated-gap extension
+  proposal.
+
+No first-screen product surface changes are part of this work.
+
+## Delivery Plan
+
+1. **P0:** Add the failure-continuation read model, role successors, durable
+   record, and focused regression smoke.
+2. **P1:** Add repeated-gap aggregation and normal extension-evolution proposal
+   todo generation without any provider mutation.
+3. **P2:** Update public protocols and compact smoke coverage for the complete
+   lifecycle.
+
+Each batch remains reviewable on its own. P0 is the first implementation
+segment because it directly prevents silent stopping after negative research
+evidence.

--- a/examples/auto-research-rollout-readpath-smoke.py
+++ b/examples/auto-research-rollout-readpath-smoke.py
@@ -16,6 +16,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.capabilities.auto_research.research_state import (  # noqa: E402
+    build_auto_research_completion_status,
     build_live_auto_research_projection,
     build_research_decision_candidates,
     build_research_evidence_graph_from_records,
@@ -276,8 +277,95 @@ def main() -> None:
             "hyp_bad_distance_cache"
         ), negative_decisions
         assert negative_decisions["retirement_candidates"][0]["negative_evidence_count"] == 1
+        assert negative_decisions["retirement_candidates"][0]["failure_kind"] == (
+            "mechanism_contradicted"
+        ), negative_decisions
+        assert negative_decisions["retirement_candidates"][0]["next_outcome"] == (
+            "propose_failure_successor"
+        ), negative_decisions
+        negative_completion = build_auto_research_completion_status(
+            negative_graph,
+            negative_decisions,
+        )
+        assert negative_completion["status"] == "failure_successor_required", negative_completion
+        assert negative_completion["next_action"] == "propose_failure_successor", negative_completion
+        assert negative_completion["failure_continuation"]["monitor_allowed"] is False, negative_completion
         assert_public_safe(negative_graph)
         assert_public_safe(negative_decisions)
+        assert_public_safe(negative_completion)
+
+        data_gap_graph = build_research_evidence_graph_from_records(
+            goal_id=GOAL_ID,
+            hypotheses=[
+                {
+                    "schema_version": "research_hypothesis_v0",
+                    "hypothesis_id": "hyp_data_gap",
+                    "parent_hypothesis_id": None,
+                    "todo_id": "todo_auto_research_data_gap",
+                    "claimed_by": AGENT_ID,
+                    "mechanism_family": "price_normalization",
+                    "hypothesis": "Normalize the declared price field before scoring.",
+                    "status": "contradicted",
+                    "grounding_refs": [GROUNDING_REF],
+                    "blocked_by": ["evidence_or_boundary_guardrail_failed"],
+                }
+            ],
+            evidence_events=[
+                {
+                    "schema_version": "research_evidence_event_v0",
+                    "hypothesis_id": "hyp_data_gap",
+                    "todo_id": "todo_auto_research_data_gap",
+                    "agent_id": AGENT_ID,
+                    "attempt": 1,
+                    "split": "dev",
+                    "metric": {
+                        "name": METRIC_NAME,
+                        "value": 0.8,
+                        "direction": "maximize",
+                    },
+                    "baseline_metric": 1.0,
+                    "eval_status": "scored",
+                    "primary_metric_status": "regressed",
+                    "failure_kind": "data_or_measurement_gap",
+                    "measurement_scope": "adjusted_price_field",
+                    "remediation_attempt": False,
+                    "artifact_refs": ["public_eval_summary:data_gap_initial"],
+                    "protected_scope_clean": True,
+                },
+                {
+                    "schema_version": "research_evidence_event_v0",
+                    "hypothesis_id": "hyp_data_gap",
+                    "todo_id": "todo_auto_research_data_gap",
+                    "agent_id": AGENT_ID,
+                    "attempt": 2,
+                    "split": "holdout",
+                    "metric": {
+                        "name": METRIC_NAME,
+                        "value": 0.7,
+                        "direction": "maximize",
+                    },
+                    "baseline_metric": 1.0,
+                    "eval_status": "scored",
+                    "primary_metric_status": "regressed",
+                    "failure_kind": "data_or_measurement_gap",
+                    "measurement_scope": "adjusted_price_field",
+                    "remediation_attempt": True,
+                    "artifact_refs": ["public_eval_summary:data_gap_remediation"],
+                    "protected_scope_clean": True,
+                },
+            ],
+            metric_name=METRIC_NAME,
+            metric_direction="maximize",
+            baseline_metric=1.0,
+            source_kind="public_records",
+        )
+        data_gap_decisions = build_research_decision_candidates(data_gap_graph)
+        data_gap_candidate = data_gap_decisions["retirement_candidates"][0]
+        assert data_gap_candidate["remediation_attempt_count"] == 1, data_gap_candidate
+        assert data_gap_candidate["remediation_allowed"] is False, data_gap_candidate
+        assert data_gap_candidate["next_outcome"] == "propose_failure_successor", data_gap_candidate
+        assert_public_safe(data_gap_graph)
+        assert_public_safe(data_gap_decisions)
 
         live_payload = build_live_auto_research_projection(
             goal_id=GOAL_ID,

--- a/examples/auto-research-rollout-readpath-smoke.py
+++ b/examples/auto-research-rollout-readpath-smoke.py
@@ -370,6 +370,34 @@ def main() -> None:
         assert missing_lineage_resolution["unresolved"] is True, missing_lineage_resolution
         assert_public_safe(missing_lineage_resolution)
 
+        selected_todo_fallback_resolution = build_research_failure_continuation_resolution(
+            {
+                "retirement_candidates": [
+                    {
+                        "hypothesis_id": "hyp_selected_summary_failure",
+                        "todo_id": "todo_selected_summary",
+                        "failure_kind": "mechanism_contradicted",
+                        "measurement_scope": None,
+                        "remediation_attempt_count": 0,
+                        "remediation_attempt_limit": 1,
+                        "next_outcome": "propose_failure_successor",
+                    }
+                ]
+            },
+            selected_todo_id="todo_selected_summary",
+            require_selected_failure_match=True,
+        )
+        assert selected_todo_fallback_resolution["failure_continuation"] is None, (
+            selected_todo_fallback_resolution
+        )
+        assert selected_todo_fallback_resolution["matched_candidate_count"] == 0, (
+            selected_todo_fallback_resolution
+        )
+        assert selected_todo_fallback_resolution["unresolved"] is True, (
+            selected_todo_fallback_resolution
+        )
+        assert_public_safe(selected_todo_fallback_resolution)
+
         data_gap_graph = build_research_evidence_graph_from_records(
             goal_id=GOAL_ID,
             hypotheses=[

--- a/examples/auto-research-rollout-readpath-smoke.py
+++ b/examples/auto-research-rollout-readpath-smoke.py
@@ -20,6 +20,7 @@ from loopx.capabilities.auto_research.research_state import (  # noqa: E402
     build_live_auto_research_projection,
     build_research_decision_candidates,
     build_research_evidence_graph_from_records,
+    build_research_failure_continuation_resolution,
     build_research_evidence_graph_from_rollout_events,
 )
 from loopx.rollout_event_log import load_rollout_events, rollout_event_log_path  # noqa: E402
@@ -293,6 +294,81 @@ def main() -> None:
         assert_public_safe(negative_graph)
         assert_public_safe(negative_decisions)
         assert_public_safe(negative_completion)
+
+        ordinary_retry_graph = dict(negative_graph)
+        ordinary_retry_node = dict(negative_graph["nodes"][0])
+        ordinary_retry_node.update(
+            {
+                "hypothesis_id": "hyp_retry_still_available",
+                "todo_id": "todo_auto_research_retry_001",
+                "status": "needs_retry",
+                "negative_evidence_count": 0,
+                "failure_kind": None,
+            }
+        )
+        ordinary_retry_graph["nodes"] = [ordinary_retry_node]
+        ordinary_retry_decisions = build_research_decision_candidates(ordinary_retry_graph)
+        assert ordinary_retry_decisions["retirement_candidates"] == [], ordinary_retry_decisions
+        ordinary_retry_completion = build_auto_research_completion_status(
+            ordinary_retry_graph,
+            ordinary_retry_decisions,
+        )
+        assert ordinary_retry_completion["failure_continuation"] is None, ordinary_retry_completion
+        assert ordinary_retry_completion["status"] == "active", ordinary_retry_completion
+        assert_public_safe(ordinary_retry_decisions)
+        assert_public_safe(ordinary_retry_completion)
+
+        ambiguous_failure_graph = dict(negative_graph)
+        second_failure_node = dict(negative_graph["nodes"][0])
+        second_failure_node.update(
+            {
+                "hypothesis_id": "hyp_bad_distance_cache_second",
+                "todo_id": "todo_auto_research_bad_002",
+            }
+        )
+        ambiguous_failure_graph["nodes"] = [
+            dict(negative_graph["nodes"][0]),
+            second_failure_node,
+        ]
+        ambiguous_failure_decisions = build_research_decision_candidates(ambiguous_failure_graph)
+        ambiguous_failure_completion = build_auto_research_completion_status(
+            ambiguous_failure_graph,
+            ambiguous_failure_decisions,
+        )
+        assert ambiguous_failure_completion["status"] == "failure_successor_required", ambiguous_failure_completion
+        assert ambiguous_failure_completion["failure_continuation"] is None, ambiguous_failure_completion
+        assert ambiguous_failure_completion["failure_continuation_ambiguous"] is True, (
+            ambiguous_failure_completion
+        )
+        assert_public_safe(ambiguous_failure_decisions)
+        assert_public_safe(ambiguous_failure_completion)
+
+        missing_lineage_resolution = build_research_failure_continuation_resolution(
+            {
+                "retirement_candidates": [
+                    {
+                        "hypothesis_id": "hyp_other_failure",
+                        "todo_id": "todo_other",
+                        "failure_kind": "mechanism_contradicted",
+                        "measurement_scope": None,
+                        "remediation_attempt_count": 0,
+                        "remediation_attempt_limit": 1,
+                        "next_outcome": "propose_failure_successor",
+                    }
+                ]
+            },
+            selected_todo_id="todo_selected_summary",
+            selected_lineage_todo_id="todo_expected",
+            require_selected_failure_match=True,
+        )
+        assert missing_lineage_resolution["failure_continuation"] is None, (
+            missing_lineage_resolution
+        )
+        assert missing_lineage_resolution["matched_candidate_count"] == 0, (
+            missing_lineage_resolution
+        )
+        assert missing_lineage_resolution["unresolved"] is True, missing_lineage_resolution
+        assert_public_safe(missing_lineage_resolution)
 
         data_gap_graph = build_research_evidence_graph_from_records(
             goal_id=GOAL_ID,

--- a/examples/auto-research-rollout-readpath-smoke.py
+++ b/examples/auto-research-rollout-readpath-smoke.py
@@ -15,7 +15,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from loopx.capabilities.auto_research.evidence_packet import _compact_public_text  # noqa: E402
 from loopx.capabilities.auto_research.research_state import (  # noqa: E402
+    _compact_optional_text,
     build_auto_research_completion_status,
     build_live_auto_research_projection,
     build_research_decision_candidates,
@@ -528,5 +530,19 @@ def main() -> None:
     print("auto-research-rollout-readpath-smoke ok")
 
 
+def _test_compact_optional_text_dot_guard() -> None:
+    """Regression: compacting long text must not produce '..' (parent-directory marker)."""
+    long_text = "a" * 219 + "b."
+    result = _compact_optional_text(long_text, field="live.title", default="fallback", max_len=220)
+    assert ".." not in result, f"unexpected .. in compacted text: {result!r}"
+    _compact_public_text(result, field="live.title", max_len=220)
+    long_text_no_dot = "a" * 219 + "c"
+    result2 = _compact_optional_text(long_text_no_dot, field="live.title", default="fallback", max_len=220)
+    assert ".." not in result2, f"unexpected .. in compacted text: {result2!r}"
+    _compact_public_text(result2, field="live.title", max_len=220)
+    print("compact-optional-text-dot-guard ok")
+
+
 if __name__ == "__main__":
+    _test_compact_optional_text_dot_guard()
     main()

--- a/examples/auto-research-worker-turn-smoke.py
+++ b/examples/auto-research-worker-turn-smoke.py
@@ -781,6 +781,62 @@ def main() -> int:
         runtime_root = temp / "runtime"
         write_summary_state(state_file)
         write_registry(registry, project=project, state_file=state_file, runtime_root=runtime_root)
+        self_referential_summary = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text="[P0-auto-research-live] Summarize a self-referential retired branch.",
+            task_class="advancement_task",
+            action_kind="summarize_evidence",
+            claimed_by=EVALUATOR_AGENT_ID,
+            dry_run=False,
+        )
+        append_negative_fixture_evidence(
+            registry=registry,
+            runtime_root=runtime_root,
+            temp=temp,
+            hypothesis_id="hyp_summary_id_failure",
+            todo_id=self_referential_summary["todo_id"],
+        )
+        workspace = project / "visible-workspace"
+        workspace.mkdir()
+
+        self_referential_turn = run_worker_turn(
+            registry=registry,
+            runtime_root=runtime_root,
+            workspace=workspace,
+            agent_id=EVALUATOR_AGENT_ID,
+            execute=True,
+            complete=True,
+        )
+        assert (
+            self_referential_turn["frontier"]["frontier"]["completion"]["status"]
+            == "failure_successor_required"
+        ), self_referential_turn
+        assert self_referential_turn["evaluation_summary"]["failure_continuation"] is None, (
+            self_referential_turn
+        )
+        assert self_referential_turn["successor_todos"]["successors"] == [], self_referential_turn
+        assert self_referential_turn["completion"] == {
+            "requested": True,
+            "executed": False,
+            "reason": "failure_successor_lineage_unresolved",
+        }, self_referential_turn
+        state_text = state_file.read_text(encoding="utf-8")
+        assert (
+            f"todo_id={self_referential_summary['todo_id']} status=done" not in state_text
+        ), state_text
+        assert_public_safe(self_referential_turn)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        project = temp / "project"
+        project.mkdir()
+        state_file = project / "ACTIVE_GOAL_STATE.md"
+        registry = temp / "registry.json"
+        runtime_root = temp / "runtime"
+        write_summary_state(state_file)
+        write_registry(registry, project=project, state_file=state_file, runtime_root=runtime_root)
         positive_evidence = add_goal_todo(
             registry_path=registry,
             goal_id=GOAL_ID,

--- a/examples/auto-research-worker-turn-smoke.py
+++ b/examples/auto-research-worker-turn-smoke.py
@@ -264,6 +264,49 @@ def append_fixture_evidence(
     assert_public_safe(appended)
 
 
+def append_negative_fixture_evidence(
+    *,
+    registry: Path,
+    runtime_root: Path,
+    temp: Path,
+    hypothesis_id: str,
+    todo_id: str,
+    failure_kind: str | None = None,
+    measurement_scope: str | None = None,
+    remediation_attempt: bool = False,
+) -> None:
+    result = eval_result("dev", value=0.75)
+    result["primary_metric_status"] = "regressed"
+    if failure_kind:
+        result["failure_kind"] = failure_kind
+    if measurement_scope:
+        result["measurement_scope"] = measurement_scope
+    if remediation_attempt:
+        result["remediation_attempt"] = True
+    packet = build_auto_research_evidence_packet(
+        contract=research_contract(goal_id=GOAL_ID),
+        eval_results=[result],
+        hypothesis_id=hypothesis_id,
+        todo_id=todo_id,
+        agent_id=EVIDENCE_AGENT_ID,
+        claimed_by=EVIDENCE_AGENT_ID,
+        mechanism_family=MECHANISM_FAMILY,
+        hypothesis=f"{HYPOTHESIS_TEXT} Failure {hypothesis_id}.",
+        grounding_refs=[GROUNDING_REF],
+        branch_ref="codex/auto-research-worker-turn-smoke",
+    )
+    packet_path = temp / f"{hypothesis_id}.public.json"
+    packet_path.write_text(json.dumps(packet, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    appended = append_auto_research_rollout_events(
+        packet_path=str(packet_path),
+        registry_path=registry,
+        runtime_root_arg=str(runtime_root),
+        dry_run=False,
+    )
+    assert appended["appended_count"] == 2, appended
+    assert_public_safe(appended)
+
+
 def main() -> int:
     with tempfile.TemporaryDirectory() as temp_dir:
         temp = Path(temp_dir)
@@ -490,6 +533,119 @@ def main() -> int:
         for successor_id in curator_successor_ids:
             assert successor_id in state_text, state_text
         assert_public_safe(curator_handoff)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        project = temp / "project"
+        project.mkdir()
+        state_file = project / "ACTIVE_GOAL_STATE.md"
+        registry = temp / "registry.json"
+        runtime_root = temp / "runtime"
+        write_summary_state(state_file)
+        write_registry(registry, project=project, state_file=state_file, runtime_root=runtime_root)
+        failure_review = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text="[P0-auto-research-live] Summarize retired evidence.",
+            task_class="advancement_task",
+            action_kind="summarize_evidence",
+            claimed_by=EVALUATOR_AGENT_ID,
+            dry_run=False,
+        )
+        append_negative_fixture_evidence(
+            registry=registry,
+            runtime_root=runtime_root,
+            temp=temp,
+            hypothesis_id="hyp_failure_successor",
+            todo_id="todo_failure_successor",
+        )
+        workspace = project / "visible-workspace"
+        workspace.mkdir()
+
+        failure_turn = run_worker_turn(
+            registry=registry,
+            runtime_root=runtime_root,
+            workspace=workspace,
+            agent_id=EVALUATOR_AGENT_ID,
+            execute=True,
+            complete=True,
+        )
+        successors = failure_turn["successor_todos"]["successors"]
+        assert len(successors) == 1, failure_turn
+        assert successors[0]["claimed_by"] == HYPOTHESIS_AGENT_ID, failure_turn
+        assert successors[0]["action_kind"] == "propose_failure_successor", failure_turn
+        assert failure_turn["evaluation_summary"]["failure_continuation"]["monitor_allowed"] is False, failure_turn
+        assert failure_turn["completion"]["successor_todo_ids"] == [successors[0]["todo_id"]], failure_turn
+        state_text = state_file.read_text(encoding="utf-8")
+        assert f"todo_id={failure_review['todo_id']} status=done" in state_text, state_text
+        assert "continuous_monitor" not in state_text, state_text
+        assert_public_safe(failure_turn)
+
+        proposer_successors = auto_research_successor_specs_for_action(
+            role_id="hypothesis_proposer",
+            action="propose_failure_successor",
+        )
+        assert proposer_successors == [], proposer_successors
+        classified_failure_successors = auto_research_successor_specs_for_action(
+            role_id="evaluator_promoter",
+            action="classify_evidence",
+        )
+        assert {
+            successor["action_kind"] for successor in classified_failure_successors
+        } == {
+            "remediate_data_measurement",
+            "propose_failure_successor",
+        }, classified_failure_successors
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        project = temp / "project"
+        project.mkdir()
+        state_file = project / "ACTIVE_GOAL_STATE.md"
+        registry = temp / "registry.json"
+        runtime_root = temp / "runtime"
+        write_summary_state(state_file)
+        write_registry(registry, project=project, state_file=state_file, runtime_root=runtime_root)
+        data_gap_review = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text="[P0-auto-research-live] Summarize a declared data gap.",
+            task_class="advancement_task",
+            action_kind="summarize_evidence",
+            claimed_by=EVALUATOR_AGENT_ID,
+            dry_run=False,
+        )
+        append_negative_fixture_evidence(
+            registry=registry,
+            runtime_root=runtime_root,
+            temp=temp,
+            hypothesis_id="hyp_data_gap_successor",
+            todo_id="todo_data_gap_successor",
+            failure_kind="data_or_measurement_gap",
+            measurement_scope="adjusted_price_field",
+        )
+        workspace = project / "visible-workspace"
+        workspace.mkdir()
+
+        data_gap_turn = run_worker_turn(
+            registry=registry,
+            runtime_root=runtime_root,
+            workspace=workspace,
+            agent_id=EVALUATOR_AGENT_ID,
+            execute=True,
+            complete=True,
+        )
+        successors = data_gap_turn["successor_todos"]["successors"]
+        assert len(successors) == 1, data_gap_turn
+        assert successors[0]["claimed_by"] == EXECUTOR_AGENT_ID, data_gap_turn
+        assert successors[0]["action_kind"] == "remediate_data_measurement", data_gap_turn
+        assert data_gap_turn["evaluation_summary"]["failure_continuation"]["remediation_attempt_limit"] == 1, data_gap_turn
+        state_text = state_file.read_text(encoding="utf-8")
+        assert f"todo_id={data_gap_review['todo_id']} status=done" in state_text, state_text
+        assert "continuous_monitor" not in state_text, state_text
+        assert_public_safe(data_gap_turn)
 
     with tempfile.TemporaryDirectory() as temp_dir:
         temp = Path(temp_dir)

--- a/examples/auto-research-worker-turn-smoke.py
+++ b/examples/auto-research-worker-turn-smoke.py
@@ -274,9 +274,12 @@ def append_negative_fixture_evidence(
     failure_kind: str | None = None,
     measurement_scope: str | None = None,
     remediation_attempt: bool = False,
+    eval_status: str = "scored",
+    primary_metric_status: str = "regressed",
 ) -> None:
     result = eval_result("dev", value=0.75)
-    result["primary_metric_status"] = "regressed"
+    result["eval_status"] = eval_status
+    result["primary_metric_status"] = primary_metric_status
     if failure_kind:
         result["failure_kind"] = failure_kind
     if measurement_scope:
@@ -371,6 +374,81 @@ def main() -> int:
             complete=False,
         )
         assert_no_action(evaluator_execute, agent_id=EVALUATOR_AGENT_ID)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        supervisor = build_auto_research_demo_supervisor_plan(
+            goal_id=GOAL_ID,
+            agent_specs=LANES,
+            session_name="loopx-auto-research-resume-lineage-smoke",
+            cli_bin="loopx",
+            codex_bin="codex",
+            tmux_bin="tmux",
+            reasoning_effort="high",
+        )
+        visible_control, registry, runtime_root = _seed_visible_demo_control_plane(
+            demo_root=temp,
+            goal_id=GOAL_ID,
+            objective="Verify seeded evaluator summaries retain executor lineage.",
+            supervisor=supervisor,
+        )
+        seeded_todos = visible_control["seeded_todos"]
+        executor_seed = next(item for item in seeded_todos if item["agent_id"] == EXECUTOR_AGENT_ID)
+        evaluator_seed = next(item for item in seeded_todos if item["agent_id"] == EVALUATOR_AGENT_ID)
+        assert evaluator_seed["resume_when"] == f"todo_done:{executor_seed['todo_id']}", visible_control
+        append_negative_fixture_evidence(
+            registry=registry,
+            runtime_root=Path(runtime_root),
+            temp=temp,
+            hypothesis_id="hyp_seeded_retry_exhausted",
+            todo_id=executor_seed["todo_id"],
+            failure_kind="retry_exhausted",
+            eval_status="failed_to_run",
+            primary_metric_status="inconclusive",
+        )
+        executor_completion = complete_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=executor_seed["todo_id"],
+            role="agent",
+            claimed_by=EXECUTOR_AGENT_ID,
+            agent_id=EXECUTOR_AGENT_ID,
+            note="lane-authored exhausted retry evidence was appended",
+            evidence="public-safe evidence packet recorded retry exhaustion",
+            no_followup=True,
+            self_merged=True,
+            dry_run=False,
+        )
+        assert executor_completion["completed"] is True, executor_completion
+        workspace = temp / "visible-workspace"
+        workspace.mkdir()
+
+        seeded_failure_turn = run_worker_turn(
+            registry=registry,
+            runtime_root=runtime_root,
+            workspace=workspace,
+            agent_id=EVALUATOR_AGENT_ID,
+            execute=True,
+            complete=True,
+        )
+        assert seeded_failure_turn["selected_todo_id"] == evaluator_seed["todo_id"], seeded_failure_turn
+        assert seeded_failure_turn["selected_action"] == "summarize_evidence", seeded_failure_turn
+        assert (
+            seeded_failure_turn["frontier"]["frontier"]["selected"]["resume_when"]
+            == f"todo_done:{executor_seed['todo_id']}"
+        ), seeded_failure_turn
+        assert (
+            seeded_failure_turn["evaluation_summary"]["failure_continuation"]["source_todo_id"]
+            == executor_seed["todo_id"]
+        ), seeded_failure_turn
+        successors = seeded_failure_turn["successor_todos"]["successors"]
+        assert len(successors) == 1, seeded_failure_turn
+        assert successors[0]["action_kind"] == "propose_failure_successor", seeded_failure_turn
+        assert successors[0]["unblocks_todo_id"] == evaluator_seed["todo_id"], seeded_failure_turn
+        assert seeded_failure_turn["completion"]["successor_todo_ids"] == [
+            successors[0]["todo_id"]
+        ], seeded_failure_turn
+        assert_public_safe(seeded_failure_turn)
 
     with tempfile.TemporaryDirectory() as temp_dir:
         temp = Path(temp_dir)
@@ -543,11 +621,31 @@ def main() -> int:
         runtime_root = temp / "runtime"
         write_summary_state(state_file)
         write_registry(registry, project=project, state_file=state_file, runtime_root=runtime_root)
-        failure_review = add_goal_todo(
+        first_failure_evidence = add_goal_todo(
             registry_path=registry,
             goal_id=GOAL_ID,
             role="agent",
-            text="[P0-auto-research-live] Summarize retired evidence.",
+            text="[P0-auto-research-live] Evaluate the first failed evidence branch.",
+            task_class="advancement_task",
+            action_kind="run_dev_eval",
+            claimed_by=EXECUTOR_AGENT_ID,
+            dry_run=False,
+        )
+        second_failure_evidence = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text="[P0-auto-research-live] Evaluate the second failed evidence branch.",
+            task_class="advancement_task",
+            action_kind="run_dev_eval",
+            claimed_by=EXECUTOR_AGENT_ID,
+            dry_run=False,
+        )
+        unrelated_summary = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text="[P0-auto-research-live] Summarize an independent evidence branch.",
             task_class="advancement_task",
             action_kind="summarize_evidence",
             claimed_by=EVALUATOR_AGENT_ID,
@@ -557,8 +655,280 @@ def main() -> int:
             registry=registry,
             runtime_root=runtime_root,
             temp=temp,
+            hypothesis_id="hyp_first_failure",
+            todo_id=first_failure_evidence["todo_id"],
+        )
+        append_negative_fixture_evidence(
+            registry=registry,
+            runtime_root=runtime_root,
+            temp=temp,
+            hypothesis_id="hyp_second_failure",
+            todo_id=second_failure_evidence["todo_id"],
+        )
+        workspace = project / "visible-workspace"
+        workspace.mkdir()
+
+        unrelated_turn = run_worker_turn(
+            registry=registry,
+            runtime_root=runtime_root,
+            workspace=workspace,
+            agent_id=EVALUATOR_AGENT_ID,
+            execute=True,
+            complete=True,
+        )
+        assert unrelated_turn["evaluation_summary"]["failure_continuation"] is None, unrelated_turn
+        assert unrelated_turn["successor_todos"]["successors"] == [], unrelated_turn
+        assert unrelated_turn["completion"] == {
+            "requested": True,
+            "executed": False,
+            "reason": "failure_successor_lineage_unresolved",
+        }, unrelated_turn
+        state_text = state_file.read_text(encoding="utf-8")
+        assert f"todo_id={unrelated_summary['todo_id']} status=done" not in state_text, state_text
+        assert "propose_failure_successor" not in state_text, state_text
+        assert_public_safe(unrelated_turn)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        project = temp / "project"
+        project.mkdir()
+        state_file = project / "ACTIVE_GOAL_STATE.md"
+        registry = temp / "registry.json"
+        runtime_root = temp / "runtime"
+        write_summary_state(state_file)
+        write_registry(registry, project=project, state_file=state_file, runtime_root=runtime_root)
+        retry_evidence = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text="[P0-auto-research-live] Retry one pending evidence branch.",
+            task_class="advancement_task",
+            action_kind="run_dev_eval",
+            claimed_by=EXECUTOR_AGENT_ID,
+            dry_run=False,
+        )
+        other_failure_evidence = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text="[P0-auto-research-live] Evaluate a separately retired evidence branch.",
+            task_class="advancement_task",
+            action_kind="run_dev_eval",
+            claimed_by=EXECUTOR_AGENT_ID,
+            dry_run=False,
+        )
+        missing_match_summary = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text="[P0-auto-research-live] Summarize the retry evidence branch.",
+            task_class="advancement_task",
+            action_kind="summarize_evidence",
+            claimed_by=EVALUATOR_AGENT_ID,
+            unblocks_todo_id=retry_evidence["todo_id"],
+            dry_run=False,
+        )
+        append_negative_fixture_evidence(
+            registry=registry,
+            runtime_root=runtime_root,
+            temp=temp,
+            hypothesis_id="hyp_retry_pending",
+            todo_id=retry_evidence["todo_id"],
+            eval_status="failed_to_run",
+            primary_metric_status="inconclusive",
+        )
+        append_negative_fixture_evidence(
+            registry=registry,
+            runtime_root=runtime_root,
+            temp=temp,
+            hypothesis_id="hyp_other_retired",
+            todo_id=other_failure_evidence["todo_id"],
+        )
+        workspace = project / "visible-workspace"
+        workspace.mkdir()
+
+        missing_match_turn = run_worker_turn(
+            registry=registry,
+            runtime_root=runtime_root,
+            workspace=workspace,
+            agent_id=EVALUATOR_AGENT_ID,
+            execute=True,
+            complete=True,
+        )
+        assert (
+            missing_match_turn["frontier"]["frontier"]["completion"]["status"]
+            == "failure_successor_required"
+        ), missing_match_turn
+        assert missing_match_turn["evaluation_summary"]["failure_continuation"] is None, (
+            missing_match_turn
+        )
+        assert missing_match_turn["successor_todos"]["successors"] == [], missing_match_turn
+        assert missing_match_turn["completion"] == {
+            "requested": True,
+            "executed": False,
+            "reason": "failure_successor_lineage_unresolved",
+        }, missing_match_turn
+        state_text = state_file.read_text(encoding="utf-8")
+        assert f"todo_id={missing_match_summary['todo_id']} status=done" not in state_text, state_text
+        assert_public_safe(missing_match_turn)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        project = temp / "project"
+        project.mkdir()
+        state_file = project / "ACTIVE_GOAL_STATE.md"
+        registry = temp / "registry.json"
+        runtime_root = temp / "runtime"
+        write_summary_state(state_file)
+        write_registry(registry, project=project, state_file=state_file, runtime_root=runtime_root)
+        positive_evidence = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text="[P0-auto-research-live] Evaluate the supported evidence branch.",
+            task_class="advancement_task",
+            action_kind="run_dev_eval",
+            claimed_by=EXECUTOR_AGENT_ID,
+            dry_run=False,
+        )
+        unrelated_failure_evidence = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text="[P0-auto-research-live] Evaluate an unrelated failed evidence branch.",
+            task_class="advancement_task",
+            action_kind="run_dev_eval",
+            claimed_by=EXECUTOR_AGENT_ID,
+            dry_run=False,
+        )
+        resume_gate = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text="[P0-auto-research-live] Complete an independent summary gate.",
+            task_class="advancement_task",
+            action_kind="run_dev_eval",
+            claimed_by=EXECUTOR_AGENT_ID,
+            dry_run=False,
+        )
+        positive_summary = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text="[P0-auto-research-live] Summarize the supported evidence branch.",
+            task_class="advancement_task",
+            action_kind="summarize_evidence",
+            claimed_by=EVALUATOR_AGENT_ID,
+            unblocks_todo_id=positive_evidence["todo_id"],
+            resume_when=f"todo_done:{resume_gate['todo_id']}",
+            dry_run=False,
+        )
+        append_fixture_evidence(
+            registry=registry,
+            runtime_root=runtime_root,
+            temp=temp,
+            hypothesis_id="hyp_positive_branch",
+            todo_id=positive_evidence["todo_id"],
+            dev_metric=1.4,
+            holdout_metric=1.5,
+        )
+        append_negative_fixture_evidence(
+            registry=registry,
+            runtime_root=runtime_root,
+            temp=temp,
+            hypothesis_id="hyp_unrelated_failure",
+            todo_id=unrelated_failure_evidence["todo_id"],
+        )
+        append_negative_fixture_evidence(
+            registry=registry,
+            runtime_root=runtime_root,
+            temp=temp,
+            hypothesis_id="hyp_resume_gate_failure",
+            todo_id=resume_gate["todo_id"],
+        )
+        resume_gate_completion = complete_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=resume_gate["todo_id"],
+            role="agent",
+            claimed_by=EXECUTOR_AGENT_ID,
+            agent_id=EXECUTOR_AGENT_ID,
+            note="independent gate completed for summary lineage priority coverage",
+            evidence="public-safe gate evidence",
+            no_followup=True,
+            self_merged=True,
+            dry_run=False,
+        )
+        assert resume_gate_completion["completed"] is True, resume_gate_completion
+        workspace = project / "visible-workspace"
+        workspace.mkdir()
+
+        positive_turn = run_worker_turn(
+            registry=registry,
+            runtime_root=runtime_root,
+            workspace=workspace,
+            agent_id=EVALUATOR_AGENT_ID,
+            execute=True,
+            complete=True,
+        )
+        assert positive_turn["evaluation_summary"]["failure_continuation"] is None, positive_turn
+        assert (
+            positive_turn["frontier"]["frontier"]["completion"]["status"]
+            == "promotion_review_required"
+        ), positive_turn
+        assert (
+            positive_turn["frontier"]["frontier"]["selected"]["unblocks_todo_id"]
+            == positive_evidence["todo_id"]
+        ), positive_turn
+        assert (
+            positive_turn["frontier"]["frontier"]["selected"]["resume_when"]
+            == f"todo_done:{resume_gate['todo_id']}"
+        ), positive_turn
+        successors = positive_turn["successor_todos"]["successors"]
+        assert len(successors) == 1, positive_turn
+        assert successors[0]["claimed_by"] == CURATOR_AGENT_ID, positive_turn
+        assert successors[0]["action_kind"] == "review_research_contract", positive_turn
+        assert positive_turn["completion"]["successor_todo_ids"] == [successors[0]["todo_id"]], positive_turn
+        state_text = state_file.read_text(encoding="utf-8")
+        assert f"todo_id={positive_summary['todo_id']} status=done" in state_text, state_text
+        assert_public_safe(positive_turn)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        project = temp / "project"
+        project.mkdir()
+        state_file = project / "ACTIVE_GOAL_STATE.md"
+        registry = temp / "registry.json"
+        runtime_root = temp / "runtime"
+        write_summary_state(state_file)
+        write_registry(registry, project=project, state_file=state_file, runtime_root=runtime_root)
+        failure_evidence = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text="[P0-auto-research-live] Evaluate retired evidence.",
+            task_class="advancement_task",
+            action_kind="run_dev_eval",
+            claimed_by=EXECUTOR_AGENT_ID,
+            dry_run=False,
+        )
+        failure_review = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text="[P0-auto-research-live] Summarize retired evidence.",
+            task_class="advancement_task",
+            action_kind="summarize_evidence",
+            claimed_by=EVALUATOR_AGENT_ID,
+            unblocks_todo_id=failure_evidence["todo_id"],
+            dry_run=False,
+        )
+        append_negative_fixture_evidence(
+            registry=registry,
+            runtime_root=runtime_root,
+            temp=temp,
             hypothesis_id="hyp_failure_successor",
-            todo_id="todo_failure_successor",
+            todo_id=failure_evidence["todo_id"],
         )
         workspace = project / "visible-workspace"
         workspace.mkdir()
@@ -576,6 +946,15 @@ def main() -> int:
         assert successors[0]["claimed_by"] == HYPOTHESIS_AGENT_ID, failure_turn
         assert successors[0]["action_kind"] == "propose_failure_successor", failure_turn
         assert failure_turn["evaluation_summary"]["failure_continuation"]["monitor_allowed"] is False, failure_turn
+        assert (
+            failure_turn["evaluation_summary"]["failure_continuation"]["source_todo_id"]
+            == failure_evidence["todo_id"]
+        ), failure_turn
+        assert (
+            failure_turn["frontier"]["frontier"]["selected"]["unblocks_todo_id"]
+            == failure_evidence["todo_id"]
+        ), failure_turn
+        assert successors[0]["unblocks_todo_id"] == failure_review["todo_id"], failure_turn
         assert failure_turn["completion"]["successor_todo_ids"] == [successors[0]["todo_id"]], failure_turn
         state_text = state_file.read_text(encoding="utf-8")
         assert f"todo_id={failure_review['todo_id']} status=done" in state_text, state_text
@@ -607,6 +986,16 @@ def main() -> int:
         runtime_root = temp / "runtime"
         write_summary_state(state_file)
         write_registry(registry, project=project, state_file=state_file, runtime_root=runtime_root)
+        data_gap_evidence = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text="[P0-auto-research-live] Evaluate the declared data gap.",
+            task_class="advancement_task",
+            action_kind="run_dev_eval",
+            claimed_by=EXECUTOR_AGENT_ID,
+            dry_run=False,
+        )
         data_gap_review = add_goal_todo(
             registry_path=registry,
             goal_id=GOAL_ID,
@@ -615,6 +1004,7 @@ def main() -> int:
             task_class="advancement_task",
             action_kind="summarize_evidence",
             claimed_by=EVALUATOR_AGENT_ID,
+            unblocks_todo_id=data_gap_evidence["todo_id"],
             dry_run=False,
         )
         append_negative_fixture_evidence(
@@ -622,7 +1012,7 @@ def main() -> int:
             runtime_root=runtime_root,
             temp=temp,
             hypothesis_id="hyp_data_gap_successor",
-            todo_id="todo_data_gap_successor",
+            todo_id=data_gap_evidence["todo_id"],
             failure_kind="data_or_measurement_gap",
             measurement_scope="adjusted_price_field",
         )
@@ -646,6 +1036,75 @@ def main() -> int:
         assert f"todo_id={data_gap_review['todo_id']} status=done" in state_text, state_text
         assert "continuous_monitor" not in state_text, state_text
         assert_public_safe(data_gap_turn)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        project = temp / "project"
+        project.mkdir()
+        state_file = project / "ACTIVE_GOAL_STATE.md"
+        registry = temp / "registry.json"
+        runtime_root = temp / "runtime"
+        write_summary_state(state_file)
+        write_registry(registry, project=project, state_file=state_file, runtime_root=runtime_root)
+        retry_evidence = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text="[P0-auto-research-live] Retry the exhausted evidence branch.",
+            task_class="advancement_task",
+            action_kind="run_dev_eval",
+            claimed_by=EXECUTOR_AGENT_ID,
+            dry_run=False,
+        )
+        retry_review = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text="[P0-auto-research-live] Summarize exhausted retry evidence.",
+            task_class="advancement_task",
+            action_kind="summarize_evidence",
+            claimed_by=EVALUATOR_AGENT_ID,
+            unblocks_todo_id=retry_evidence["todo_id"],
+            dry_run=False,
+        )
+        append_negative_fixture_evidence(
+            registry=registry,
+            runtime_root=runtime_root,
+            temp=temp,
+            hypothesis_id="hyp_retry_exhausted",
+            todo_id=retry_evidence["todo_id"],
+            failure_kind="retry_exhausted",
+            eval_status="failed_to_run",
+            primary_metric_status="inconclusive",
+        )
+        workspace = project / "visible-workspace"
+        workspace.mkdir()
+
+        retry_turn = run_worker_turn(
+            registry=registry,
+            runtime_root=runtime_root,
+            workspace=workspace,
+            agent_id=EVALUATOR_AGENT_ID,
+            execute=True,
+            complete=True,
+        )
+        successors = retry_turn["successor_todos"]["successors"]
+        assert len(successors) == 1, retry_turn
+        assert successors[0]["claimed_by"] == HYPOTHESIS_AGENT_ID, retry_turn
+        assert successors[0]["action_kind"] == "propose_failure_successor", retry_turn
+        assert (
+            retry_turn["evaluation_summary"]["failure_continuation"]["failure_kind"]
+            == "retry_exhausted"
+        ), retry_turn
+        assert (
+            retry_turn["evaluation_summary"]["failure_continuation"]["source_todo_id"]
+            == retry_evidence["todo_id"]
+        ), retry_turn
+        assert successors[0]["unblocks_todo_id"] == retry_review["todo_id"], retry_turn
+        assert retry_turn["completion"]["successor_todo_ids"] == [successors[0]["todo_id"]], retry_turn
+        state_text = state_file.read_text(encoding="utf-8")
+        assert f"todo_id={retry_review['todo_id']} status=done" in state_text, state_text
+        assert_public_safe(retry_turn)
 
     with tempfile.TemporaryDirectory() as temp_dir:
         temp = Path(temp_dir)

--- a/examples/auto-research-worker-turn-smoke.py
+++ b/examples/auto-research-worker-turn-smoke.py
@@ -1253,6 +1253,93 @@ def main() -> int:
         assert frontier_completion["status"] == "target_reached", target_reached
         assert target_reached["frontier"]["frontier"]["selected"] is None, target_reached
         assert_public_safe(target_reached)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        project = temp / "project"
+        project.mkdir()
+        state_file = project / "ACTIVE_GOAL_STATE.md"
+        registry = temp / "registry.json"
+        runtime_root = temp / "runtime"
+        write_summary_state(state_file)
+        write_registry(registry, project=project, state_file=state_file, runtime_root=runtime_root)
+        failure_evidence = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text="[P0-auto-research-live] Evaluate a retired evidence branch for lineage dedup.",
+            task_class="advancement_task",
+            action_kind="run_dev_eval",
+            claimed_by=EXECUTOR_AGENT_ID,
+            dry_run=False,
+        )
+        first_summary = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text="[P0-auto-research-live] First summary of the retired evidence branch.",
+            task_class="advancement_task",
+            action_kind="summarize_evidence",
+            claimed_by=EVALUATOR_AGENT_ID,
+            unblocks_todo_id=failure_evidence["todo_id"],
+            dry_run=False,
+        )
+        second_summary = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text="[P0-auto-research-live] Second summary of the same retired evidence branch.",
+            task_class="advancement_task",
+            action_kind="summarize_evidence",
+            claimed_by=EVALUATOR_AGENT_ID,
+            unblocks_todo_id=failure_evidence["todo_id"],
+            dry_run=False,
+        )
+        append_negative_fixture_evidence(
+            registry=registry,
+            runtime_root=runtime_root,
+            temp=temp,
+            hypothesis_id="hyp_lineage_dedup_failure",
+            todo_id=failure_evidence["todo_id"],
+        )
+        workspace = project / "visible-workspace"
+        workspace.mkdir()
+
+        first_turn = run_worker_turn(
+            registry=registry,
+            runtime_root=runtime_root,
+            workspace=workspace,
+            agent_id=EVALUATOR_AGENT_ID,
+            execute=True,
+            complete=True,
+        )
+        first_successors = first_turn["successor_todos"]["successors"]
+        assert len(first_successors) == 1, first_turn
+        assert first_successors[0]["action_kind"] == "propose_failure_successor", first_turn
+        assert first_successors[0]["claimed_by"] == HYPOTHESIS_AGENT_ID, first_turn
+        first_successor_text = first_successors[0]["todo_command"]
+        assert ".." not in first_successor_text, f"successor text contains ..: {first_successor_text!r}"
+        assert_public_safe(first_turn)
+
+        second_turn = run_worker_turn(
+            registry=registry,
+            runtime_root=runtime_root,
+            workspace=workspace,
+            agent_id=EVALUATOR_AGENT_ID,
+            execute=True,
+            complete=True,
+        )
+        second_successors = second_turn["successor_todos"]["successors"]
+        assert len(second_successors) == 1, second_turn
+        second_successor = second_successors[0]
+        assert second_successor["already_exists"] is True, (
+            f"second successor should be deduplicated, got: {second_successor}"
+        )
+        assert second_successor["todo_id"] == first_successors[0]["todo_id"], (
+            f"second successor should have the same todo_id, got: {second_successor['todo_id']}"
+        )
+        assert_public_safe(second_turn)
+
     return 0
 
 

--- a/loopx/capabilities/auto_research/evidence_packet.py
+++ b/loopx/capabilities/auto_research/evidence_packet.py
@@ -77,7 +77,7 @@ def _compact_public_text(value: Any, *, field: str, max_len: int = 240) -> str:
         raise ValueError(f"{field} must be non-empty")
     if len(text) > max_len:
         raise ValueError(f"{field} is too long for a compact public-safe field")
-    if ".." in text:
+    if ".." in text.replace("...", ""):
         raise ValueError(f"{field} must not contain parent-directory markers")
     if _ABSOLUTE_PATH_RE.search(text) or text.startswith(("/", "~")):
         raise ValueError(f"{field} must use a public alias, not a local/private path")

--- a/loopx/capabilities/auto_research/evidence_packet.py
+++ b/loopx/capabilities/auto_research/evidence_packet.py
@@ -38,6 +38,14 @@ EVIDENCE_STATUSES = {
 METRIC_DIRECTIONS = {"maximize", "minimize"}
 NEGATIVE_PRIMARY_METRIC_STATUSES = {"failed", "regressed"}
 RETRY_PRIMARY_METRIC_STATUSES = {"inconclusive"}
+RESEARCH_FAILURE_KINDS = {
+    "data_or_measurement_gap",
+    "guardrail_or_protected_boundary",
+    "mechanism_contradicted",
+    "overfit_or_nonreplication",
+    "retry_exhausted",
+    "unrecoverable_data_gap",
+}
 
 _TOKEN_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_.:-]{0,95}$")
 _SHA256_RE = re.compile(r"^[A-Fa-f0-9]{64}$")
@@ -91,6 +99,16 @@ def _compact_public_token(value: Any, *, field: str) -> str:
 
 def _compact_public_text_list(values: Iterable[Any] | None, *, field: str) -> list[str]:
     return [_compact_public_text(value, field=f"{field}[]") for value in values or []]
+
+
+def _compact_optional_failure_kind(value: Any, *, field: str) -> str | None:
+    if value is None or str(value).strip() == "":
+        return None
+    kind = _compact_public_token(value, field=field)
+    if kind not in RESEARCH_FAILURE_KINDS:
+        choices = ", ".join(sorted(RESEARCH_FAILURE_KINDS))
+        raise ValueError(f"{field} must be one of {choices}")
+    return kind
 
 
 def _finite_float(value: float | int | str | None, *, field: str) -> float | None:
@@ -300,6 +318,9 @@ def _normalize_benchmark_eval_result(
             baseline=baseline,
             direction=direction,
         ),
+        "failure_kind": result.get("failure_kind"),
+        "measurement_scope": result.get("measurement_scope"),
+        "remediation_attempt": result.get("remediation_attempt"),
         "artifact_refs": result.get("artifact_refs") or [
             f"public_eval:{split}:{result.get('metric_name') or metric['name']}",
             _command_artifact_ref(command, field=f"eval_result.{split}.command"),
@@ -350,6 +371,22 @@ def validate_research_evidence_event(item: dict[str, Any]) -> dict[str, Any]:
     direction = _compact_public_token(metric.get("direction"), field="evidence.metric.direction")
     if direction not in METRIC_DIRECTIONS:
         raise ValueError("evidence.metric.direction must be maximize or minimize")
+    failure_kind = _compact_optional_failure_kind(
+        item.get("failure_kind"),
+        field="failure_kind",
+    )
+    measurement_scope = (
+        _compact_public_text(item.get("measurement_scope"), field="measurement_scope")
+        if item.get("measurement_scope")
+        else None
+    )
+    remediation_attempt = bool(item.get("remediation_attempt"))
+    if failure_kind == "data_or_measurement_gap" and not measurement_scope:
+        raise ValueError("data or measurement gaps require measurement_scope")
+    if remediation_attempt and failure_kind != "data_or_measurement_gap":
+        raise ValueError(
+            "remediation attempts require data_or_measurement_gap failure_kind"
+        )
     return {
         "schema_version": schema,
         "hypothesis_id": _compact_public_token(item.get("hypothesis_id"), field="hypothesis_id"),
@@ -368,6 +405,9 @@ def validate_research_evidence_event(item: dict[str, Any]) -> dict[str, Any]:
             item.get("primary_metric_status"),
             field="primary_metric_status",
         ),
+        "failure_kind": failure_kind,
+        "measurement_scope": measurement_scope,
+        "remediation_attempt": remediation_attempt,
         "artifact_refs": _compact_public_text_list(item.get("artifact_refs"), field="artifact_refs"),
         "protected_scope_clean": bool(item.get("protected_scope_clean")),
         "raw_logs_recorded": False,
@@ -417,6 +457,9 @@ def _eval_result_to_evidence_event(
         "baseline_metric": metric.get("baseline", result.get("baseline_metric")),
         "eval_status": result.get("eval_status"),
         "primary_metric_status": result.get("primary_metric_status"),
+        "failure_kind": result.get("failure_kind"),
+        "measurement_scope": result.get("measurement_scope"),
+        "remediation_attempt": result.get("remediation_attempt"),
         "artifact_refs": artifact_refs,
         "protected_scope_clean": bool(result.get("protected_scope_clean")),
     }
@@ -712,6 +755,9 @@ def build_auto_research_rollout_events(
                     "metric_direction": metric["direction"],
                     "baseline_metric": evidence["baseline_metric"],
                     "primary_metric_status": evidence["primary_metric_status"],
+                    "failure_kind": evidence["failure_kind"] or "",
+                    "measurement_scope": evidence["measurement_scope"] or "",
+                    "remediation_attempt": evidence["remediation_attempt"],
                     "eval_status": evidence["eval_status"],
                     "protected_scope_clean": evidence["protected_scope_clean"],
                 },

--- a/loopx/capabilities/auto_research/research_state.py
+++ b/loopx/capabilities/auto_research/research_state.py
@@ -713,8 +713,14 @@ def build_research_failure_continuation_resolution(
     ]
     lineage_todo_id = str(selected_lineage_todo_id or "").strip()
     selected_id = str(selected_todo_id or "").strip()
-    selection_bound = bool(lineage_todo_id or selected_id)
-    selected_parent_todo_id = lineage_todo_id or selected_id
+    selection_bound = bool(lineage_todo_id) if require_selected_failure_match else bool(
+        lineage_todo_id or selected_id
+    )
+    selected_parent_todo_id = (
+        lineage_todo_id
+        if require_selected_failure_match
+        else lineage_todo_id or selected_id
+    )
     matched = (
         [
             candidate
@@ -753,9 +759,8 @@ def build_research_failure_continuation_resolution(
         "selection_bound": selection_bound,
         "ambiguous": not selection_bound and len(candidates) > 1,
         "unresolved": require_selected_failure_match
-        and selection_bound
         and bool(candidates)
-        and len(matched) != 1,
+        and (not lineage_todo_id or len(matched) != 1),
     }
 
 

--- a/loopx/capabilities/auto_research/research_state.py
+++ b/loopx/capabilities/auto_research/research_state.py
@@ -220,6 +220,21 @@ def _todo_frontier_item(
             max_len=220,
         ),
     }
+    unblocks_todo_id = _compact_optional_token(
+        item.get("unblocks_todo_id"),
+        field="live.unblocks_todo_id",
+        default="",
+    )
+    if unblocks_todo_id:
+        summary["unblocks_todo_id"] = unblocks_todo_id
+    resume_when = _compact_optional_text(
+        item.get("resume_when"),
+        field="live.resume_when",
+        default="",
+        max_len=160,
+    )
+    if resume_when:
+        summary["resume_when"] = resume_when
     if blocked_by:
         summary["blocked_by"] = _compact_public_text(blocked_by, field="live.blocked_by", max_len=160)
     else:
@@ -371,14 +386,14 @@ def _default_failure_kind(
     *,
     status: str,
     events: list[dict[str, Any]],
-) -> str:
+) -> str | None:
     explicit = [event for event in events if event.get("failure_kind")]
     if explicit:
         return str(explicit[-1]["failure_kind"])
     if any(not event["protected_scope_clean"] for event in events):
         return "guardrail_or_protected_boundary"
     if status == "needs_retry":
-        return "retry_exhausted"
+        return None
     return "mechanism_contradicted"
 
 
@@ -613,8 +628,9 @@ def build_research_decision_candidates(evidence_graph: dict[str, Any]) -> dict[s
             baseline=baseline,
             direction=direction,
         )
-        if status in {"contradicted", "retired"} or negative_count > 0:
-            failure_kind = str(raw_node.get("failure_kind") or "")
+        failure_kind = str(raw_node.get("failure_kind") or "")
+        retry_exhausted = status == "needs_retry" and failure_kind == "retry_exhausted"
+        if status in {"contradicted", "retired"} or negative_count > 0 or retry_exhausted:
             if failure_kind not in RESEARCH_FAILURE_KINDS:
                 failure_kind = (
                     "guardrail_or_protected_boundary"
@@ -635,7 +651,13 @@ def build_research_decision_candidates(evidence_graph: dict[str, Any]) -> dict[s
                     "status": status,
                     "negative_evidence_count": negative_count,
                     "evidence_event_count": evidence_count,
-                    "reason": "negative_or_guardrail_evidence" if negative_count else f"status:{status}",
+                    "reason": (
+                        "retry_exhausted"
+                        if retry_exhausted
+                        else "negative_or_guardrail_evidence"
+                        if negative_count
+                        else f"status:{status}"
+                    ),
                     "failure_kind": failure_kind,
                     "measurement_scope": raw_node.get("measurement_scope"),
                     "remediation_attempt_count": remediation_attempt_count,
@@ -676,30 +698,83 @@ def build_research_decision_candidates(evidence_graph: dict[str, Any]) -> dict[s
     }
 
 
-def build_research_failure_continuation(
+def build_research_failure_continuation_resolution(
     decision_candidates: dict[str, list[dict[str, Any]]],
-) -> dict[str, Any] | None:
+    *,
+    selected_todo_id: str | None = None,
+    selected_lineage_todo_id: str | None = None,
+    allow_unbound_singleton: bool = False,
+    require_selected_failure_match: bool = False,
+) -> dict[str, Any]:
     candidates = [
         dict(candidate)
         for candidate in decision_candidates.get("retirement_candidates") or []
         if isinstance(candidate, dict)
     ]
-    if not candidates:
-        return None
-    candidate = sorted(
-        candidates,
-        key=lambda item: str(item.get("hypothesis_id") or ""),
-    )[0]
+    lineage_todo_id = str(selected_lineage_todo_id or "").strip()
+    selected_id = str(selected_todo_id or "").strip()
+    selection_bound = bool(lineage_todo_id or selected_id)
+    selected_parent_todo_id = lineage_todo_id or selected_id
+    matched = (
+        [
+            candidate
+            for candidate in candidates
+            if str(candidate.get("todo_id") or "").strip() == selected_parent_todo_id
+        ]
+        if selection_bound
+        else []
+    )
+    candidate = (
+        matched[0]
+        if selection_bound and len(matched) == 1
+        else candidates[0]
+        if allow_unbound_singleton and not selection_bound and len(candidates) == 1
+        else None
+    )
+    continuation = (
+        {
+            "hypothesis_id": candidate["hypothesis_id"],
+            "source_todo_id": candidate["todo_id"],
+            "failure_kind": candidate["failure_kind"],
+            "measurement_scope": candidate.get("measurement_scope"),
+            "remediation_attempt_count": candidate["remediation_attempt_count"],
+            "remediation_attempt_limit": candidate["remediation_attempt_limit"],
+            "next_outcome": candidate["next_outcome"],
+            "monitor_allowed": False,
+        }
+        if candidate
+        else None
+    )
     return {
-        "hypothesis_id": candidate["hypothesis_id"],
-        "source_todo_id": candidate["todo_id"],
-        "failure_kind": candidate["failure_kind"],
-        "measurement_scope": candidate.get("measurement_scope"),
-        "remediation_attempt_count": candidate["remediation_attempt_count"],
-        "remediation_attempt_limit": candidate["remediation_attempt_limit"],
-        "next_outcome": candidate["next_outcome"],
-        "monitor_allowed": False,
+        "failure_continuation": continuation,
+        "retirement_candidate_count": len(candidates),
+        "matched_candidate_count": len(matched),
+        "lineage_todo_id": lineage_todo_id or None,
+        "selection_bound": selection_bound,
+        "ambiguous": not selection_bound and len(candidates) > 1,
+        "unresolved": require_selected_failure_match
+        and selection_bound
+        and bool(candidates)
+        and len(matched) != 1,
     }
+
+
+def build_research_failure_continuation(
+    decision_candidates: dict[str, list[dict[str, Any]]],
+    *,
+    selected_todo_id: str | None = None,
+    selected_lineage_todo_id: str | None = None,
+    allow_unbound_singleton: bool = True,
+    require_selected_failure_match: bool = False,
+) -> dict[str, Any] | None:
+    resolution = build_research_failure_continuation_resolution(
+        decision_candidates,
+        selected_todo_id=selected_todo_id,
+        selected_lineage_todo_id=selected_lineage_todo_id,
+        allow_unbound_singleton=allow_unbound_singleton,
+        require_selected_failure_match=require_selected_failure_match,
+    )
+    return resolution["failure_continuation"]
 
 
 def _holdout_metric_sequence_from_graph(evidence_graph: dict[str, Any]) -> list[float]:
@@ -757,7 +832,11 @@ def build_auto_research_completion_status(
     validated_count = len(decisions.get("validated_promotion_candidates") or [])
     promotion_count = len(decisions.get("promotion_candidates") or [])
     retirement_count = len(decisions.get("retirement_candidates") or [])
-    failure_continuation = build_research_failure_continuation(decisions)
+    failure_resolution = build_research_failure_continuation_resolution(
+        decisions,
+        allow_unbound_singleton=True,
+    )
+    failure_continuation = failure_resolution["failure_continuation"]
 
     status = "active"
     next_action = "continue_frontier"
@@ -803,6 +882,7 @@ def build_auto_research_completion_status(
         "promotion_candidate_count": promotion_count,
         "retirement_candidate_count": retirement_count,
         "failure_continuation": failure_continuation,
+        "failure_continuation_ambiguous": failure_resolution["ambiguous"],
     }
 
 

--- a/loopx/capabilities/auto_research/research_state.py
+++ b/loopx/capabilities/auto_research/research_state.py
@@ -103,9 +103,16 @@ def _compact_optional_text(value: Any, *, field: str, default: str, max_len: int
     if value is None or str(value).strip() == "":
         return default
     text = " ".join(str(value).strip().split())
-    _compact_public_text(text, field=field, max_len=max(len(text), max_len))
     if len(text) > max_len:
-        text = text[: max_len - 1].rstrip() + "."
+        prefix = text[: max_len - 1].rstrip()
+        if prefix.endswith(".") and not prefix.endswith(".."):
+            text = prefix
+        else:
+            text = prefix.rstrip(".") + "."
+    # Strip trailing dot-runs so public text validation does not flag them
+    # as parent-directory markers (text may arrive with "..." from upstream).
+    while text.endswith(".."):
+        text = text[:-1]
     return _compact_public_text(text, field=field, max_len=max_len)
 
 

--- a/loopx/capabilities/auto_research/research_state.py
+++ b/loopx/capabilities/auto_research/research_state.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from .evidence_packet import (
     METRIC_DIRECTIONS,
+    RESEARCH_FAILURE_KINDS,
     RESEARCH_EVIDENCE_EVENT_SCHEMA_VERSION,
     RESEARCH_HYPOTHESIS_SCHEMA_VERSION,
     _compact_public_text,
@@ -321,6 +322,9 @@ def _research_evidence_from_rollout_event(event: dict[str, Any]) -> dict[str, An
             "baseline_metric": details.get("baseline_metric"),
             "eval_status": details.get("eval_status") or event.get("status"),
             "primary_metric_status": details.get("primary_metric_status") or "inconclusive",
+            "failure_kind": details.get("failure_kind") or None,
+            "measurement_scope": details.get("measurement_scope") or None,
+            "remediation_attempt": bool(details.get("remediation_attempt")),
             "artifact_refs": event.get("artifact_refs") or [],
             "protected_scope_clean": bool(details.get("protected_scope_clean")),
         }
@@ -363,6 +367,44 @@ def _best_metric(events: list[dict[str, Any]], *, split: str, direction: str) ->
     return max(values, key=lambda value: _metric_rank_key(value, direction=direction))
 
 
+def _default_failure_kind(
+    *,
+    status: str,
+    events: list[dict[str, Any]],
+) -> str:
+    explicit = [event for event in events if event.get("failure_kind")]
+    if explicit:
+        return str(explicit[-1]["failure_kind"])
+    if any(not event["protected_scope_clean"] for event in events):
+        return "guardrail_or_protected_boundary"
+    if status == "needs_retry":
+        return "retry_exhausted"
+    return "mechanism_contradicted"
+
+
+def _failure_measurement_scope(events: list[dict[str, Any]]) -> str | None:
+    values = [
+        str(event.get("measurement_scope") or "").strip()
+        for event in events
+        if event.get("measurement_scope")
+    ]
+    return values[-1] if values else None
+
+
+def _ancestor_hypothesis_ids(
+    hypothesis_id: str,
+    *,
+    hypotheses: dict[str, dict[str, Any]],
+) -> set[str]:
+    ancestor_ids: set[str] = set()
+    current_id = hypothesis_id
+    while current_id and current_id not in ancestor_ids:
+        ancestor_ids.add(current_id)
+        current = hypotheses.get(current_id) or {}
+        current_id = str(current.get("parent_hypothesis_id") or "").strip()
+    return ancestor_ids
+
+
 def build_research_evidence_graph_from_records(
     *,
     goal_id: str,
@@ -385,6 +427,7 @@ def build_research_evidence_graph_from_records(
     scored_events = [event for event in events if event["eval_status"] == "scored"]
     best_dev = _best_metric(scored_events, split="dev", direction=direction)
     best_holdout = _best_metric(scored_events, split="holdout", direction=direction)
+    hypotheses_by_id = {item["hypothesis_id"]: item for item in hypotheses}
     events_by_hypothesis: dict[str, list[dict[str, Any]]] = {}
     for event in events:
         events_by_hypothesis.setdefault(event["hypothesis_id"], []).append(event)
@@ -405,6 +448,24 @@ def build_research_evidence_graph_from_records(
         item_splits = sorted({event["split"] for event in item_events if event.get("split")})
         item_negative_count = len([event for event in item_events if _is_negative_evidence_event(event)])
         item_retry_count = len([event for event in item_events if _is_retry_evidence_event(event)])
+        item_failure_kind = (
+            _default_failure_kind(status=item["status"], events=item_events)
+            if item["status"] in {"contradicted", "retired", "needs_retry"}
+            or item_negative_count
+            else None
+        )
+        lineage_ids = _ancestor_hypothesis_ids(
+            item["hypothesis_id"],
+            hypotheses=hypotheses_by_id,
+        )
+        remediation_attempt_count = len(
+            [
+                event
+                for event in events
+                if event["hypothesis_id"] in lineage_ids
+                and event.get("remediation_attempt")
+            ]
+        )
         nodes.append(
             {
                 "hypothesis_id": item["hypothesis_id"],
@@ -431,6 +492,9 @@ def build_research_evidence_graph_from_records(
                 ),
                 "negative_evidence_count": item_negative_count,
                 "needs_retry_count": item_retry_count,
+                "failure_kind": item_failure_kind,
+                "measurement_scope": _failure_measurement_scope(item_events),
+                "remediation_attempt_count": remediation_attempt_count,
                 "source_kind": source,
             }
         )
@@ -454,6 +518,9 @@ def build_research_evidence_graph_from_records(
         "needs_retry_count": len(
             [event for event in events if _is_retry_evidence_event(event)]
         ) + len([item for item in hypotheses if item["status"] == "needs_retry"]),
+        "remediation_attempt_count": len(
+            [event for event in events if event.get("remediation_attempt")]
+        ),
         "nodes": nodes,
         "source_kind": source,
     }
@@ -547,6 +614,20 @@ def build_research_decision_candidates(evidence_graph: dict[str, Any]) -> dict[s
             direction=direction,
         )
         if status in {"contradicted", "retired"} or negative_count > 0:
+            failure_kind = str(raw_node.get("failure_kind") or "")
+            if failure_kind not in RESEARCH_FAILURE_KINDS:
+                failure_kind = (
+                    "guardrail_or_protected_boundary"
+                    if status == "contradicted" and negative_count
+                    else "mechanism_contradicted"
+                )
+            remediation_attempt_count = int(
+                raw_node.get("remediation_attempt_count") or 0
+            )
+            remediation_allowed = (
+                failure_kind == "data_or_measurement_gap"
+                and remediation_attempt_count < 1
+            )
             retirement_candidates.append(
                 {
                     "hypothesis_id": hypothesis_id,
@@ -555,6 +636,16 @@ def build_research_decision_candidates(evidence_graph: dict[str, Any]) -> dict[s
                     "negative_evidence_count": negative_count,
                     "evidence_event_count": evidence_count,
                     "reason": "negative_or_guardrail_evidence" if negative_count else f"status:{status}",
+                    "failure_kind": failure_kind,
+                    "measurement_scope": raw_node.get("measurement_scope"),
+                    "remediation_attempt_count": remediation_attempt_count,
+                    "remediation_attempt_limit": 1,
+                    "remediation_allowed": remediation_allowed,
+                    "next_outcome": (
+                        "remediate_data_measurement"
+                        if remediation_allowed
+                        else "propose_failure_successor"
+                    ),
                     "source_kind": source_kind,
                 }
             )
@@ -582,6 +673,32 @@ def build_research_decision_candidates(evidence_graph: dict[str, Any]) -> dict[s
         "validated_promotion_candidates": validated_promotion_candidates,
         "promotion_candidates": promotion_candidates,
         "retirement_candidates": retirement_candidates,
+    }
+
+
+def build_research_failure_continuation(
+    decision_candidates: dict[str, list[dict[str, Any]]],
+) -> dict[str, Any] | None:
+    candidates = [
+        dict(candidate)
+        for candidate in decision_candidates.get("retirement_candidates") or []
+        if isinstance(candidate, dict)
+    ]
+    if not candidates:
+        return None
+    candidate = sorted(
+        candidates,
+        key=lambda item: str(item.get("hypothesis_id") or ""),
+    )[0]
+    return {
+        "hypothesis_id": candidate["hypothesis_id"],
+        "source_todo_id": candidate["todo_id"],
+        "failure_kind": candidate["failure_kind"],
+        "measurement_scope": candidate.get("measurement_scope"),
+        "remediation_attempt_count": candidate["remediation_attempt_count"],
+        "remediation_attempt_limit": candidate["remediation_attempt_limit"],
+        "next_outcome": candidate["next_outcome"],
+        "monitor_allowed": False,
     }
 
 
@@ -640,6 +757,7 @@ def build_auto_research_completion_status(
     validated_count = len(decisions.get("validated_promotion_candidates") or [])
     promotion_count = len(decisions.get("promotion_candidates") or [])
     retirement_count = len(decisions.get("retirement_candidates") or [])
+    failure_continuation = build_research_failure_continuation(decisions)
 
     status = "active"
     next_action = "continue_frontier"
@@ -662,10 +780,13 @@ def build_auto_research_completion_status(
         required_actions = ["boundary_scan", "promotion_decision"]
         reason = "validated_promotion_candidate_pending_decision"
     elif retirement_count:
-        status = "retirement_review_required"
-        next_action = "review_retirement_candidate"
-        required_actions = ["retirement_decision"]
-        reason = "retirement_candidate_pending_decision"
+        status = "failure_successor_required"
+        next_action = str(
+            (failure_continuation or {}).get("next_outcome")
+            or "propose_failure_successor"
+        )
+        required_actions = [next_action]
+        reason = "retirement_candidate_requires_successor_or_exhaustion"
 
     return {
         "schema_version": AUTO_RESEARCH_COMPLETION_STATUS_SCHEMA_VERSION,
@@ -681,6 +802,7 @@ def build_auto_research_completion_status(
         "dev_candidate_pending_holdout_count": dev_pending_count,
         "promotion_candidate_count": promotion_count,
         "retirement_candidate_count": retirement_count,
+        "failure_continuation": failure_continuation,
     }
 
 

--- a/loopx/capabilities/auto_research/role_profiles.py
+++ b/loopx/capabilities/auto_research/role_profiles.py
@@ -13,6 +13,8 @@ AUTO_RESEARCH_REFINED_DEV_SUCCESSOR_TEXT = "[P0-auto-research-live] Run the refi
 AUTO_RESEARCH_CURATOR_REVIEW_SUCCESSOR_TEXT = "[P0-auto-research-live] Re-check the research contract and protected scope after {source_todo_id}, then keep the next collective round honest."
 AUTO_RESEARCH_HYPOTHESIS_FRONTIER_REVIEW_SUCCESSOR_TEXT = "[P0-auto-research-live] Review the current hypothesis frontier after {source_todo_id}, record whether another candidate is needed, and keep the round participation visible."
 AUTO_RESEARCH_PROMOTION_READINESS_REVIEW_SUCCESSOR_TEXT = "[P0-auto-research-live] Review promotion readiness after {source_todo_id}, record the current evidence gap, and wait for the holdout handoff."
+AUTO_RESEARCH_DATA_MEASUREMENT_REMEDIATION_SUCCESSOR_TEXT = "[P0-auto-research-live] Repair the one declared data or measurement gap from {source_todo_id} without changing thresholds, horizons, assets, or acceptance gates; return to evidence evaluation."
+AUTO_RESEARCH_FAILURE_PROPOSER_SUCCESSOR_TEXT = "[P0-auto-research-live] From the retired evidence linked to {source_todo_id}, propose one changed-mechanism hypothesis or explicitly exhaust the frontier; do not relax parameters or create a future-data monitor."
 AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE = (
     "loopx todo add --goal-id {goal_id_shell} --role agent "
     "--text {text_shell} --task-class {task_class_shell} "
@@ -54,6 +56,22 @@ AUTO_RESEARCH_REFINED_DEV_SUCCESSOR_CONDITION = _all(
     ),
     _condition("decision_summary.dev_candidate_pending_holdout_count", "eq", 0, "dev_candidate_already_pending_holdout"),
 )
+AUTO_RESEARCH_FAILURE_REMEDIATION_SUCCESSOR_CONDITION = _all(
+    _condition(
+        "decision_summary.failure_continuation.next_outcome",
+        "eq",
+        "remediate_data_measurement",
+        "failure_remediation_not_required",
+    ),
+)
+AUTO_RESEARCH_FAILURE_PROPOSER_SUCCESSOR_CONDITION = _all(
+    _condition(
+        "decision_summary.failure_continuation.next_outcome",
+        "eq",
+        "propose_failure_successor",
+        "failure_proposer_successor_not_required",
+    ),
+)
 
 AUTO_RESEARCH_CONTINUATION_POLICY = {
     "schema_version": "auto_research_continuation_policy_v0",
@@ -65,7 +83,7 @@ AUTO_RESEARCH_CONTINUATION_POLICY = {
     ),
     "no_followup_rule": (
         "no-follow-up is valid only after the target is reached, a blocker/user gate is "
-        "projected, or evidence-backed retirement closes the frontier"
+        "projected, or a proposer explicitly exhausts an evidence-backed retired frontier"
     ),
 }
 
@@ -132,7 +150,11 @@ AUTO_RESEARCH_ROLE_PROFILES: dict[str, dict[str, object]] = {
     },
     "hypothesis_proposer": {
         "phase": "hypothesis",
-        "allowed_actions": ["propose_hypothesis", "review_hypothesis_frontier"],
+        "allowed_actions": [
+            "propose_hypothesis",
+            "propose_failure_successor",
+            "review_hypothesis_frontier",
+        ],
         "write_scope": ["research_hypothesis_v0", "todo_item_v0"],
         "handoff": ["Create or unblock a research-executor todo."],
         "successor_todos": [
@@ -142,7 +164,11 @@ AUTO_RESEARCH_ROLE_PROFILES: dict[str, dict[str, object]] = {
     },
     "research_executor": {
         "phase": "evidence",
-        "allowed_actions": ["run_dev_eval", "run_holdout_eval"],
+        "allowed_actions": [
+            "run_dev_eval",
+            "run_holdout_eval",
+            "remediate_data_measurement",
+        ],
         "write_scope": ["auto_research_evidence_packet_v0", "rollout_event_log"],
         "handoff": [
             "Append scored evidence, complete the selected todo, and create the declared successor todo when the role profile says another split is due."
@@ -170,6 +196,14 @@ AUTO_RESEARCH_ROLE_PROFILES: dict[str, dict[str, object]] = {
             _successor("review_promotion_readiness", AUTO_RESEARCH_NEXT_HYPOTHESIS_SUCCESSOR_CONDITION, "research-curator", "research_curator", "review_research_contract", AUTO_RESEARCH_CURATOR_REVIEW_SUCCESSOR_TEXT),
             _successor("review_promotion_readiness", AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION, "research-curator", "research_curator", "review_research_contract", AUTO_RESEARCH_CURATOR_REVIEW_SUCCESSOR_TEXT),
             _successor("review_promotion_readiness", AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION, "hypothesis-proposer", "hypothesis_proposer", "review_hypothesis_frontier", AUTO_RESEARCH_HYPOTHESIS_FRONTIER_REVIEW_SUCCESSOR_TEXT),
+            _successor("classify_evidence", AUTO_RESEARCH_FAILURE_REMEDIATION_SUCCESSOR_CONDITION, "research-executor", "research_executor", "remediate_data_measurement", AUTO_RESEARCH_DATA_MEASUREMENT_REMEDIATION_SUCCESSOR_TEXT),
+            _successor("summarize_evidence", AUTO_RESEARCH_FAILURE_REMEDIATION_SUCCESSOR_CONDITION, "research-executor", "research_executor", "remediate_data_measurement", AUTO_RESEARCH_DATA_MEASUREMENT_REMEDIATION_SUCCESSOR_TEXT),
+            _successor("write_evaluation_summary", AUTO_RESEARCH_FAILURE_REMEDIATION_SUCCESSOR_CONDITION, "research-executor", "research_executor", "remediate_data_measurement", AUTO_RESEARCH_DATA_MEASUREMENT_REMEDIATION_SUCCESSOR_TEXT),
+            _successor("review_promotion_readiness", AUTO_RESEARCH_FAILURE_REMEDIATION_SUCCESSOR_CONDITION, "research-executor", "research_executor", "remediate_data_measurement", AUTO_RESEARCH_DATA_MEASUREMENT_REMEDIATION_SUCCESSOR_TEXT),
+            _successor("classify_evidence", AUTO_RESEARCH_FAILURE_PROPOSER_SUCCESSOR_CONDITION, "hypothesis-proposer", "hypothesis_proposer", "propose_failure_successor", AUTO_RESEARCH_FAILURE_PROPOSER_SUCCESSOR_TEXT),
+            _successor("summarize_evidence", AUTO_RESEARCH_FAILURE_PROPOSER_SUCCESSOR_CONDITION, "hypothesis-proposer", "hypothesis_proposer", "propose_failure_successor", AUTO_RESEARCH_FAILURE_PROPOSER_SUCCESSOR_TEXT),
+            _successor("write_evaluation_summary", AUTO_RESEARCH_FAILURE_PROPOSER_SUCCESSOR_CONDITION, "hypothesis-proposer", "hypothesis_proposer", "propose_failure_successor", AUTO_RESEARCH_FAILURE_PROPOSER_SUCCESSOR_TEXT),
+            _successor("review_promotion_readiness", AUTO_RESEARCH_FAILURE_PROPOSER_SUCCESSOR_CONDITION, "hypothesis-proposer", "hypothesis_proposer", "propose_failure_successor", AUTO_RESEARCH_FAILURE_PROPOSER_SUCCESSOR_TEXT),
         ],
     },
 }
@@ -178,9 +212,11 @@ AUTO_RESEARCH_ACTION_ROLE_IDS = {
     "write_research_contract": "research_curator",
     "review_research_contract": "research_curator",
     "propose_hypothesis": "hypothesis_proposer",
+    "propose_failure_successor": "hypothesis_proposer",
     "review_hypothesis_frontier": "hypothesis_proposer",
     "run_dev_eval": "research_executor",
     "run_holdout_eval": "research_executor",
+    "remediate_data_measurement": "research_executor",
     "write_evidence": "research_executor",
     "classify_evidence": "evaluator_promoter",
     "summarize_evidence": "evaluator_promoter",
@@ -191,9 +227,11 @@ AUTO_RESEARCH_ACTION_ROLE_IDS = {
 AUTO_RESEARCH_SEED_TITLES = {
     "write_research_contract": "Write the public-safe research contract for the shared demo hypothesis.",
     "propose_hypothesis": "Map the first shared idea into a todo-backed research hypothesis.",
+    "propose_failure_successor": "Propose one changed-mechanism successor from retired evidence or explicitly exhaust the research frontier.",
     "claim_attempt": "Claim one visible attempt boundary for the selected hypothesis.",
     "run_dev_eval": "Run the selected hypothesis on the dev split, write public-safe evidence, append it, and capture live evidence.",
     "run_holdout_eval": "Run held-out validation for the dev-supported hypothesis, append public-safe evidence, and summarize promotion readiness.",
+    "remediate_data_measurement": "Repair one declared data or measurement gap without changing the research mechanism or acceptance gates.",
     "write_evaluation_summary": "Verify the evidence packet and open the next validation or promotion gate.",
     "summarize_evidence": "Summarize dev evidence and hand off holdout validation when the hypothesis is supported.",
     "review_research_contract": "Re-check the research contract and protected scope for the next collective round.",

--- a/loopx/capabilities/auto_research/worker_runtime.py
+++ b/loopx/capabilities/auto_research/worker_runtime.py
@@ -20,6 +20,7 @@ from .research_state import (
     build_live_auto_research_projection,
     build_research_decision_candidates,
     build_research_evidence_graph_from_rollout_events,
+    build_research_failure_continuation,
     normalize_auto_research_action,
 )
 from ...control_plane.agents.multi_agent.role_successor import (
@@ -43,6 +44,8 @@ SUPPORTED_WORKER_ACTIONS = {
     "review_hypothesis_frontier",
     "run_dev_eval",
     "run_holdout_eval",
+    "remediate_data_measurement",
+    "propose_failure_successor",
     "write_evidence",
     "classify_evidence",
     "summarize_evidence",
@@ -55,8 +58,10 @@ AUTO_RESEARCH_MANUAL_RESEARCH_REQUIRED_MODE = "manual_research_required"
 MANUAL_RESEARCH_REQUIRED_ACTIONS = {
     "write_research_contract",
     "propose_hypothesis",
+    "propose_failure_successor",
     "run_dev_eval",
     "run_holdout_eval",
+    "remediate_data_measurement",
     "write_evidence",
 }
 SUMMARY_ACTIONS = {
@@ -166,6 +171,7 @@ def _write_evaluation_summary_artifact(
         rollout_events=rollout_events,
     )
     decisions = build_research_decision_candidates(graph)
+    failure_continuation = build_research_failure_continuation(decisions)
     holdout_metrics = _holdout_metric_sequence(rollout_events)
     metric = graph.get("metric") if isinstance(graph.get("metric"), dict) else {}
     baseline = graph.get("baseline_metric")
@@ -197,6 +203,7 @@ def _write_evaluation_summary_artifact(
             "validated_promotion_candidate_count": len(decisions.get("validated_promotion_candidates") or []),
             "promotion_candidate_count": len(decisions.get("promotion_candidates") or []),
             "retirement_candidate_count": len(decisions.get("retirement_candidates") or []),
+            "failure_continuation": failure_continuation,
             "holdout_metric_sequence": holdout_metrics,
             "holdout_improvement_count": holdout_improvements,
         },
@@ -271,6 +278,18 @@ def _maybe_add_role_successor_todos(
     decision_summary: dict[str, object],
     execute: bool,
 ) -> dict[str, object]:
+    successor_specs = auto_research_successor_specs_for_action(
+        role_id=role_id,
+        action=action,
+    )
+    failure_continuation = decision_summary.get("failure_continuation")
+    if isinstance(failure_continuation, dict):
+        next_outcome = str(failure_continuation.get("next_outcome") or "")
+        successor_specs = [
+            spec
+            for spec in successor_specs
+            if spec.get("action_kind") == next_outcome
+        ]
     return apply_role_successor_todos(
         registry_path=registry_path,
         goal_id=goal_id,
@@ -278,7 +297,7 @@ def _maybe_add_role_successor_todos(
         current_agent_id=agent_id,
         role_id=role_id,
         action=action,
-        successor_specs=auto_research_successor_specs_for_action(role_id=role_id, action=action),
+        successor_specs=successor_specs,
         decision_summary=decision_summary,
         execute=execute,
     )
@@ -585,6 +604,9 @@ def run_auto_research_worker_turn(
                 ],
                 "validated_promotion_candidate_count": artifact["decision_summary"][
                     "validated_promotion_candidate_count"
+                ],
+                "failure_continuation": artifact["decision_summary"][
+                    "failure_continuation"
                 ],
             },
             "successor_todos": successor_todos,

--- a/loopx/capabilities/auto_research/worker_runtime.py
+++ b/loopx/capabilities/auto_research/worker_runtime.py
@@ -20,12 +20,16 @@ from .research_state import (
     build_live_auto_research_projection,
     build_research_decision_candidates,
     build_research_evidence_graph_from_rollout_events,
-    build_research_failure_continuation,
+    build_research_failure_continuation_resolution,
     normalize_auto_research_action,
 )
 from ...control_plane.agents.multi_agent.role_successor import (
     apply_role_successor_todos,
     first_successor_followup,
+)
+from ...control_plane.todos.contract import (
+    normalize_supported_todo_resume_when,
+    normalize_todo_id,
 )
 from ...history import load_registry
 from ...paths import resolve_runtime_root
@@ -161,6 +165,8 @@ def _write_evaluation_summary_artifact(
     output_path: Path,
     goal_id: str,
     todo_id: str,
+    lineage_todo_id: str | None,
+    require_selected_failure_match: bool,
     agent_id: str,
 ) -> dict[str, object]:
     registry = load_registry(registry_path)
@@ -171,7 +177,14 @@ def _write_evaluation_summary_artifact(
         rollout_events=rollout_events,
     )
     decisions = build_research_decision_candidates(graph)
-    failure_continuation = build_research_failure_continuation(decisions)
+    failure_resolution = build_research_failure_continuation_resolution(
+        decisions,
+        selected_todo_id=todo_id,
+        selected_lineage_todo_id=lineage_todo_id,
+        require_selected_failure_match=require_selected_failure_match,
+    )
+    failure_continuation = failure_resolution["failure_continuation"]
+    failure_continuation_unresolved = bool(failure_resolution["unresolved"])
     holdout_metrics = _holdout_metric_sequence(rollout_events)
     metric = graph.get("metric") if isinstance(graph.get("metric"), dict) else {}
     baseline = graph.get("baseline_metric")
@@ -204,6 +217,7 @@ def _write_evaluation_summary_artifact(
             "promotion_candidate_count": len(decisions.get("promotion_candidates") or []),
             "retirement_candidate_count": len(decisions.get("retirement_candidates") or []),
             "failure_continuation": failure_continuation,
+            "failure_continuation_unresolved": failure_continuation_unresolved,
             "holdout_metric_sequence": holdout_metrics,
             "holdout_improvement_count": holdout_improvements,
         },
@@ -221,6 +235,83 @@ def _write_evaluation_summary_artifact(
     }
     _write_json(output_path, artifact)
     return artifact
+
+
+def _selected_failure_lineage_todo_id(selected: dict[str, object]) -> str | None:
+    unblocks_todo_id = normalize_todo_id(selected.get("unblocks_todo_id"))
+    if unblocks_todo_id:
+        return unblocks_todo_id
+    resume_when = normalize_supported_todo_resume_when(selected.get("resume_when"))
+    if not resume_when:
+        return None
+    kind, _separator, target = resume_when.partition(":")
+    return normalize_todo_id(target) if kind == "todo_done" else None
+
+
+def _failure_lineage_unresolved_result(
+    *,
+    goal_id: str,
+    agent_id: str,
+    todo_id: str,
+    action: str,
+    artifact: dict[str, object],
+    frontier_packet: dict[str, object],
+    complete_selected_todo: bool,
+) -> dict[str, object]:
+    decision_summary = artifact["decision_summary"]
+    return {
+        "ok": True,
+        "schema_version": AUTO_RESEARCH_WORKER_TURN_SCHEMA_VERSION,
+        "mode": "execute",
+        "goal_id": goal_id,
+        "agent_id": agent_id,
+        "selected_todo_id": todo_id,
+        "selected_action": action,
+        "executed": True,
+        "summary_mode": AUTO_RESEARCH_STATE_SUMMARY_MODE,
+        "artifact": _artifact_summary("evaluation_summary", filename="evaluation-summary.public.json"),
+        "artifact_status": artifact["summary"]["status"],
+        "claim_allowed": artifact["summary"]["claim_allowed"],
+        "promotion_decision_made": artifact["summary"]["promotion_decision_made"],
+        "role_id": auto_research_role_id_for_action(action),
+        "evaluation_summary": {
+            "claim_allowed": artifact["summary"]["claim_allowed"],
+            "best_dev_metric": artifact["evidence_graph_summary"]["best_dev_metric"],
+            "best_holdout_metric": artifact["evidence_graph_summary"]["best_holdout_metric"],
+            "holdout_metric_sequence": artifact["evidence_graph_summary"][
+                "holdout_metric_sequence"
+            ],
+            "holdout_improvement_count": decision_summary["holdout_improvement_count"],
+            "validated_promotion_candidate_count": decision_summary[
+                "validated_promotion_candidate_count"
+            ],
+            "failure_continuation": None,
+        },
+        "successor_todos": {
+            "schema_version": "multi_agent_role_successor_todos_v0",
+            "source": "role_profile_todo_command_template",
+            "needed": False,
+            "executed": False,
+            "role_id": auto_research_role_id_for_action(action),
+            "action": action,
+            "successors": [],
+            "skipped": [],
+            "reason": "failure_successor_lineage_unresolved",
+        },
+        "followup": None,
+        "completion": {
+            "requested": complete_selected_todo,
+            "executed": False,
+            "reason": "failure_successor_lineage_unresolved",
+        },
+        "frontier": frontier_packet,
+        "public_boundary": {
+            "raw_logs_recorded": False,
+            "private_artifacts_recorded": False,
+            "absolute_paths_recorded": False,
+            "credentials_recorded": False,
+        },
+    }
 
 
 def _manual_research_required_result(
@@ -458,6 +549,11 @@ def run_auto_research_worker_turn(
     raw_action = str((selected or {}).get("allowed_action") or "")
     action = normalize_auto_research_action(raw_action)
     todo_id = str((selected or {}).get("todo_id") or "")
+    lineage_todo_id = (
+        _selected_failure_lineage_todo_id(selected)
+        if isinstance(selected, dict)
+        else None
+    )
     if not selected or not todo_id:
         completion = (
             frontier_packet["frontier"].get("completion")
@@ -543,14 +639,35 @@ def run_auto_research_worker_turn(
                 complete_selected_todo=complete_selected_todo,
                 frontier_packet=frontier_packet,
             )
+        frontier_completion = (
+            frontier_packet["frontier"].get("completion")
+            if isinstance(frontier_packet.get("frontier"), dict)
+            else None
+        )
+        require_selected_failure_match = bool(
+            isinstance(frontier_completion, dict)
+            and frontier_completion.get("status") == "failure_successor_required"
+        )
         artifact = _write_evaluation_summary_artifact(
             registry_path=registry_path,
             runtime_root_arg=runtime_root_arg,
             output_path=evaluation_summary_path,
             goal_id=goal_id,
             todo_id=todo_id,
+            lineage_todo_id=lineage_todo_id,
+            require_selected_failure_match=require_selected_failure_match,
             agent_id=agent_id,
         )
+        if artifact["decision_summary"]["failure_continuation_unresolved"]:
+            return _failure_lineage_unresolved_result(
+                goal_id=goal_id,
+                agent_id=agent_id,
+                todo_id=todo_id,
+                action=action,
+                artifact=artifact,
+                frontier_packet=frontier_packet,
+                complete_selected_todo=complete_selected_todo,
+            )
         role_id = auto_research_role_id_for_action(action)
         successor_todos = _maybe_add_role_successor_todos(
             registry_path=registry_path,

--- a/loopx/capabilities/auto_research/worker_runtime.py
+++ b/loopx/capabilities/auto_research/worker_runtime.py
@@ -381,6 +381,9 @@ def _maybe_add_role_successor_todos(
             for spec in successor_specs
             if spec.get("action_kind") == next_outcome
         ]
+    text_source_todo_id = None
+    if isinstance(failure_continuation, dict):
+        text_source_todo_id = str(failure_continuation.get("source_todo_id") or "") or None
     return apply_role_successor_todos(
         registry_path=registry_path,
         goal_id=goal_id,
@@ -391,6 +394,7 @@ def _maybe_add_role_successor_todos(
         successor_specs=successor_specs,
         decision_summary=decision_summary,
         execute=execute,
+        text_source_todo_id=text_source_todo_id,
     )
 
 

--- a/loopx/control_plane/agents/multi_agent/role_successor.py
+++ b/loopx/control_plane/agents/multi_agent/role_successor.py
@@ -172,8 +172,15 @@ def apply_role_successor_todos(
     successor_specs: Iterable[object],
     decision_summary: Mapping[str, object],
     execute: bool,
+    text_source_todo_id: str | None = None,
 ) -> dict[str, object]:
-    """Preview or create role-declared successor todos through LoopX state."""
+    """Preview or create role-declared successor todos through LoopX state.
+
+    When text_source_todo_id is provided, it is used for rendering the
+    successor text (so the title is stable across different summary todos
+    that review the same failure lineage).  source_todo_id is still used
+    for the unblocks_todo_id binding.
+    """
 
     specs = [dict(spec) for spec in successor_specs if isinstance(spec, Mapping)]
     if not specs:
@@ -197,7 +204,7 @@ def apply_role_successor_todos(
         )
         action_kind = str(spec.get("action_kind") or "advance_todo")
         task_class = str(spec.get("task_class") or "advancement_task")
-        text = str(spec.get("text") or f"Run {action_kind}.")
+        raw_text = str(spec.get("text") or f"Run {action_kind}.")
         claimed_by = _resolve_successor_target_agent(
             registry_path=registry_path,
             goal_id=goal_id,
@@ -205,9 +212,9 @@ def apply_role_successor_todos(
             spec=spec,
         )
         text = _render_successor_text(
-            text=text,
+            text=raw_text,
             goal_id=goal_id,
-            source_todo_id=source_todo_id,
+            source_todo_id=text_source_todo_id or source_todo_id,
             target_agent_id=claimed_by,
             task_class=task_class,
             action_kind=action_kind,


### PR DESCRIPTION
## Summary
- Require each retired auto-research hypothesis to create exactly one normal LoopX successor: a single declared data/measurement remediation when its lineage has no prior remediation, otherwise a manual `propose_failure_successor` todo.
- Persist public-safe failure classification, measurement scope, and remediation-attempt evidence in existing research evidence rollout details; derive the continuation from the existing read model.
- Reuse existing role-successor and todo-completion control-plane paths. The proposer successor remains a manual decision point and has no automatic dev-evaluation edge. Failed research never creates a future-data monitor.

## Changed Surfaces
- `loopx/capabilities/auto_research/evidence_packet.py`
- `loopx/capabilities/auto_research/research_state.py`
- `loopx/capabilities/auto_research/role_profiles.py`
- `loopx/capabilities/auto_research/worker_runtime.py`
- Focused public smokes in `examples/auto-research-*.py`
- Accepted design contract in `docs/superpowers/specs/2026-08-06-auto-research-failure-successors-design.md`

## Validation
- Passed focused smokes: `auto-research-rollout-readpath`, `auto-research-worker-turn`, `auto-research-evidence-writer`, `auto-research-knn-continuation`, `auto-research-role-successor-completion`, and `multi-agent-role-successor-todos`.
- Passed `loopx canary premerge --from-git-diff --git-diff-base origin/main --goal-id loopx-product --tier standard`: Python compile checks, 9 catalog canaries, 8 risk-profile smokes, and public/private boundary scan all passed.
- Checked staged diff scope and ran a public-boundary scan; no private paths, raw evidence, credentials, or generated logs are included.

## Holds
- No benchmark jobs, extension mutation, scheduler changes, or external dependency changes were run.
- This PR is review-only. Do not self-merge or merge without owner authorization.