### PR TITLE
docs(readme): tighten community QR layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,24 +452,14 @@ gates or handoffs disappeared from view.
 - Use [GitHub Issues](https://github.com/huangruiteng/loopx/issues) for
   reproducible bugs, install problems, and feature requests.
 - Open PRs for docs fixes, showcase writeups, and small public-safe examples.
-- Chinese-speaking users and contributors can join the Lark developer group.
-  To join the WeChat group, add `huangrt00` and include `LoopX` in the friend
-  request.
+- Join community discussion through Lark or WeChat below.
 
 <p align="center">
-  <a href="docs/assets/loopx-lark-developer-group.png"><img src="docs/assets/loopx-lark-developer-group.png" alt="LoopX Lark developer group QR code" width="320"></a><br>
-  <strong>Lark developer group</strong>
+  <a href="docs/assets/loopx-lark-developer-group.png"><img src="docs/assets/loopx-lark-developer-group.png" alt="LoopX Lark developer group QR code" width="280"></a>
+  <a href="docs/assets/loopx-wechat-contact.png"><img src="docs/assets/loopx-wechat-contact.png" alt="LoopX WeChat contact QR code" width="220"></a>
 </p>
-
 <p align="center">
-  <a href="docs/assets/loopx-wechat-contact.png"><img src="docs/assets/loopx-wechat-contact.png" alt="LoopX WeChat contact QR code" width="280"></a><br>
-  <strong>WeChat: <code>huangrt00</code></strong><br>
-  Mention LoopX for a group invitation
-</p>
-
-<p align="center">
-  <img src="docs/assets/loopx-logo.png" alt="LoopX logo" width="96"><br>
-  LoopX project mark
+  <sub><strong>Lark:</strong> scan to join directly<br><strong>WeChat: <code>huangrt00</code></strong> · mention LoopX in the friend request</sub>
 </p>
 
 ## Contributing

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -408,23 +408,14 @@ LoopX 还在早期，最需要真实长程 agent 项目里的反馈：控制面�
 - 可复现 bug、安装问题、功能建议：请提
   [GitHub Issue](https://github.com/huangruiteng/loopx/issues)。
 - 文档修正、showcase 补充、小型 public-safe 示例：欢迎开 PR。
-- 中文用户与贡献者可以加入飞书开发群；加入微信群请添加微信 `huangrt00`，
-  好友申请备注 `LoopX`。
+- 参与社区讨论：可在下方直接加入飞书群，或通过微信申请入群。
 
 <p align="center">
-  <a href="docs/assets/loopx-lark-developer-group.png"><img src="docs/assets/loopx-lark-developer-group.png" alt="LoopX 开发群二维码" width="320"></a><br>
-  <strong>飞书开发群</strong>
+  <a href="docs/assets/loopx-lark-developer-group.png"><img src="docs/assets/loopx-lark-developer-group.png" alt="LoopX 飞书开发群二维码" width="280"></a>
+  <a href="docs/assets/loopx-wechat-contact.png"><img src="docs/assets/loopx-wechat-contact.png" alt="LoopX 微信联系人二维码" width="220"></a>
 </p>
-
 <p align="center">
-  <a href="docs/assets/loopx-wechat-contact.png"><img src="docs/assets/loopx-wechat-contact.png" alt="LoopX 微信联系人二维码" width="280"></a><br>
-  <strong>微信：<code>huangrt00</code></strong><br>
-  添加好友，备注 LoopX 后邀请入群
-</p>
-
-<p align="center">
-  <img src="docs/assets/loopx-logo.png" alt="LoopX 标志" width="96"><br>
-  LoopX 项目标志
+  <sub><strong>飞书：</strong>扫码直接加入<br><strong>微信：<code>huangrt00</code></strong> · 好友申请备注 LoopX</sub>
 </p>
 
 ## 贡献


### PR DESCRIPTION
## Summary

- place the Lark and WeChat community QR images side by side on wide README views
- let the images wrap naturally into a vertical layout on narrow/mobile views
- keep both images clickable at full resolution and retain the stable public WeChat contact text
- remove duplicate captions and the redundant project-logo block
- apply the same hierarchy in the English and Chinese READMEs

## Validation

- rendered and visually inspected desktop and 430 px mobile layouts
- `python3 examples/public_entry/readme-demo-surface-smoke.py`
- `python3 examples/docs-governance-smoke.py`
- `python3 examples/frontstage-pages-workflow-smoke.py`
- `loopx check --scan-path README.md --scan-path README.zh-CN.md`: 0 errors, 0 warnings
- standard LoopX premerge canary: 13/13 passed; self-merge allowed
- `git diff --check`

README-only; no runtime, workflow, protocol, or permission behavior changes.
