### PR TITLE
chore(release): prepare v0.4.2

### DIFF
--- a/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
+++ b/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
@@ -564,6 +564,7 @@ def main() -> int:
         assert set(delivery["required_skill_ids"]) == {
             "loopx",
             "loopx-project",
+            "loopx-pr-program",
             "loopx-pr-review",
             "loopx-doc-registry",
             "loopx-self-repair",

--- a/examples/release/local-install-promotion-boundary-smoke.py
+++ b/examples/release/local-install-promotion-boundary-smoke.py
@@ -82,6 +82,7 @@ def assert_untrusted_checkout_is_canary_only() -> None:
         expected_skill_ids = {
             "loopx",
             "loopx-doc-registry",
+            "loopx-pr-program",
             "loopx-pr-review",
             "loopx-project",
             "loopx-self-repair",

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/man/loopx.1
+++ b/man/loopx.1
@@ -1,4 +1,4 @@
-.TH LOOPX 1 "" "LoopX 0.4.1" "User Commands"
+.TH LOOPX 1 "" "LoopX 0.4.2" "User Commands"
 .SH NAME
 loopx \- control-plane helper for long-running agent work
 .SH SYNOPSIS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.4.1"
+version = "0.4.2"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- bump the package, runtime, and manpage version mirrors to `0.4.2`
- align release-facing onboarding and local-install smoke expectations with the shipped `loopx-pr-program` skill

## Validation

- exact release qualification: `ready_for_owner_release` on `c94e188fa484fbf79a5e6190942162810861ad29`
- pytest: 2121 passed, 2 skipped
- Full Public: 631/631 scripts passed across 7 isolated shards; 0 failures, timeouts, or warnings
- premerge risk canary: 18/18 selected checks passed; 0 failures or manual holds
- live actual-default Doubao portfolio: 15 scenarios x 2 repeats, 30 calls, 4/4 contrasts passed
- Ruff, mypy, `py_compile`, release/version/readiness contracts, install/update/host smokes, and public-boundary checks passed
- change-quality receipt: `cqr_78ca1c5235cc92fe5211`

The first premerge invocation used the default 120-second per-check budget and timed out only the already-passing `install-local-smoke.py` at 120.009 seconds. The unchanged 18-check selection passed with the supported 300-second budget.

GitHub-hosted checks may be delayed or fail while the official GitHub Actions incident remains under investigation, so this PR does not claim hosted-green evidence. No benchmark job, leaderboard action, persisted-state migration, or long-horizon outcome-uplift claim is part of this release.

## Scope and boundary

This is a single-purpose release metadata and durable smoke-expectation update. The tracked diff contains no credentials, private state, local paths, generated logs, raw model responses, or benchmark evidence.
