### PR TITLE
docs(rfc): fix shared-goal source references

### DIFF
--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0-evidence.zh-CN.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0-evidence.zh-CN.md
@@ -1,7 +1,7 @@
 # 验证说明：NoKV canonical coordination provider（v0）
 
 - 配套 RFC：[多端共享 Goal 的在线权威与可插拔状态 Provider (v0)](./shared-goal-authority-state-provider-v0.zh-CN.md)
-- 参考实现与探针：[`examples/nokv-shadow-provider/`](../../../examples/nokv-shadow-provider/)
+- 参考实现与探针：`examples/nokv-shadow-provider/`
 - 证据范围：canonical coordination aggregate、target-scoped conflict、内部 CAS
   rebase 与历史 operation receipt 重放
 

--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
@@ -165,14 +165,14 @@ Integration classes used below:
 Source anchors for the classifications include
 [`architecture.md`](../../architecture.md),
 [`event-store-migration-bridge-v0`](../../reference/protocols/event-store-migration-bridge-v0.md),
-[`task_lease.py`](../../../loopx/control_plane/work_items/task_lease.py),
-[`cli_rollout.py`](../../../loopx/cli_rollout.py),
-[`status_projection_cache.py`](../../../loopx/control_plane/runtime/status_projection_cache.py),
-[`slot_accounting.py`](../../../loopx/control_plane/quota/slot_accounting.py),
-[`global_registry.py`](../../../loopx/global_registry.py), and the host state in
-[`scheduler/state.py`](../../../loopx/control_plane/scheduler/state.py),
-[`turn_driver/codex_cli.py`](../../../loopx/control_plane/turn_driver/codex_cli.py),
-and [`pi-goal-loop-runtime.mjs`](../../../loopx/pi_goal_mode/pi-goal-loop-runtime.mjs).
+`loopx/control_plane/work_items/task_lease.py`,
+`loopx/cli_rollout.py`,
+`loopx/control_plane/runtime/status_projection_cache.py`,
+`loopx/control_plane/quota/slot_accounting.py`,
+`loopx/global_registry.py`, and the host state in
+`loopx/control_plane/scheduler/state.py`,
+`loopx/control_plane/turn_driver/codex_cli.py`,
+and `loopx/pi_goal_mode/pi-goal-loop-runtime.mjs`.
 
 ## 4. What Goes Into This Coordination Ledger
 
@@ -618,7 +618,7 @@ evidence; those ledgers retain the owners defined in Section 3.
 ## Appendix A: What This Evidence Proves
 
 The reference provider and probes live in
-[`examples/nokv-shadow-provider/`](../../../examples/nokv-shadow-provider/),
+`examples/nokv-shadow-provider/`,
 with a companion
 [`evidence document`](./shared-goal-authority-state-provider-v0-evidence.zh-CN.md).
 The deterministic candidate in this PR proves only the claim/receipt core:

--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
@@ -139,14 +139,14 @@ owner，新 host 或 extension 也可以新增本地 artifact，而无需修改�
 上述分类的源码锚点包括
 [`architecture.md`](../../architecture.md)、
 [`event-store-migration-bridge-v0`](../../reference/protocols/event-store-migration-bridge-v0.md)、
-[`task_lease.py`](../../../loopx/control_plane/work_items/task_lease.py)、
-[`cli_rollout.py`](../../../loopx/cli_rollout.py)、
-[`status_projection_cache.py`](../../../loopx/control_plane/runtime/status_projection_cache.py)、
-[`slot_accounting.py`](../../../loopx/control_plane/quota/slot_accounting.py)、
-[`global_registry.py`](../../../loopx/global_registry.py)，以及这些 host state：
-[`scheduler/state.py`](../../../loopx/control_plane/scheduler/state.py)、
-[`turn_driver/codex_cli.py`](../../../loopx/control_plane/turn_driver/codex_cli.py) 和
-[`pi-goal-loop-runtime.mjs`](../../../loopx/pi_goal_mode/pi-goal-loop-runtime.mjs)。
+`loopx/control_plane/work_items/task_lease.py`、
+`loopx/cli_rollout.py`、
+`loopx/control_plane/runtime/status_projection_cache.py`、
+`loopx/control_plane/quota/slot_accounting.py`、
+`loopx/global_registry.py`，以及这些 host state：
+`loopx/control_plane/scheduler/state.py`、
+`loopx/control_plane/turn_driver/codex_cli.py` 和
+`loopx/pi_goal_mode/pi-goal-loop-runtime.mjs`。
 
 ## 4. 这本协调账里到底放什么
 
@@ -542,7 +542,7 @@ history、quota、scheduler 或 evidence 的通用存储抽象，这些账继续
 ## 附录 A：这版证据能证明什么
 
 Reference provider 与 probe 位于
-[`examples/nokv-shadow-provider/`](../../../examples/nokv-shadow-provider/)，并有
+`examples/nokv-shadow-provider/`，并有
 [配套证据文档](./shared-goal-authority-state-provider-v0-evidence.zh-CN.md)。本 PR 的
 deterministic candidate 只证明 claim/receipt core：state 与 receipt 的 same-CAS、
 并发 claim、A/B/A 原始 receipt 重放、request-digest mismatch、crash boundary 恢复，


### PR DESCRIPTION
## Summary

- Fix the strict MkDocs build failure introduced by source-code links in the shared-goal authority RFC.
- Render repository source files and `examples/nokv-shadow-provider/` as code paths instead of Markdown links, because those targets live outside `docs/` and are not pages in the documentation site.
- Keep actual documentation-to-documentation links clickable in the English RFC, Chinese RFC, and evidence note.

## Issue Or Task

- Unblocks the `Frontstage Pages` check for #2822 and other documentation PRs based on current `main`.
- Contributor task ID:

## Validation

- [x] `mkdocs build --strict --site-dir /tmp/loopx-shared-goal-docs-site`
- [x] `python examples/docs-governance-smoke.py`
- [x] `loopx check` on the three changed RFC files
- [x] `git diff --check`

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
