### PR TITLE
feat(global-manager): add read-only global gates command

### DIFF
--- a/docs/reference/protocols/global-manager-command-v0.md
+++ b/docs/reference/protocols/global-manager-command-v0.md
@@ -10,9 +10,10 @@ lanes, and choose the next safe action without reading every thread.
 
 This protocol is not a general chat-command router yet. It defines the
 request, allowed sources, response shape, privacy boundary, and action ladder
-for Codex hosts, CLI wrappers, or dashboard command palettes. The first CLI
-wrapper is `loopx global-summary`, which returns the canonical
-`/loopx-global-summary` response.
+for Codex hosts, CLI wrappers, or dashboard command palettes. The implemented
+CLI wrappers are `loopx global-summary`, which returns the broad compact
+`/loopx-global-summary` digest, and `loopx global-gates`, which returns the
+focused current-state `/loopx-global-gates` inbox.
 
 ## Command Set
 
@@ -27,13 +28,19 @@ Recommended first commands:
 | `/loopx-pr-review` | Walk the current project's or explicit repository's open and merged GitHub PRs one by one with motivation, scope, checks, risks, and review prompts. | current open + merged PRs, optionally bounded by `--since` |
 | `/loop-goal-summary <goal id>` | Drill into one goal without scanning unrelated projects. | 24 hours |
 
+`/loopx-global-todos`, `/loopx-global-risks`, and `/loop-goal-summary` remain
+host-only manager commands under this protocol; they do not yet have dedicated
+CLI wrappers.
+
 Commands are read-only by default. They can propose follow-up actions, but
 they do not approve gates, promote suggested todos, spend quota, merge PRs,
 pause automations, or run destructive operations.
 
 Legacy `/loop-global-*` forms may be accepted as aliases during migration, but
 hosts should canonicalize command packets and user-facing help to the
-`/loopx-global-*` names.
+`/loopx-global-*` names. These are host/slash aliases, not CLI command names:
+unknown commands and legacy CLI aliases fail closed with help instead of
+falling back to a broader status or summary dump.
 
 | Legacy alias | Canonical command |
 | --- | --- |
@@ -73,6 +80,9 @@ Request rules:
 - `privacy_mode` defaults to `public_safe_summary`.
 - `goal_filter` and `agent_filter` narrow the read; omitted filters mean all
   registered goals or agents visible in the local control plane.
+- For `loopx global-gates`, `--agent-id` excludes goals where the selected
+  agent is not registered; an unavailable per-goal quota projection is not a
+  substitute for agent filtering.
 - `dry_run=true` is the default because the first implementation should be a
   report, not an executor.
 - Unknown commands must fail closed with a help packet, not a broad status
@@ -89,6 +99,11 @@ Implementations may read only compact LoopX control-plane surfaces:
 - run history summaries;
 - rollout event log summaries;
 - review packets for explicit goal drilldown.
+
+`loopx global-gates` reads the compact status projection. Status internally
+consumes compact run-history state to build its current attention queue, but
+the gates builder does not issue a second history read or expose history items
+in its response.
 
 They must not include raw transcripts, raw benchmark logs, raw connector
 payloads, credentials, local absolute paths, or private source bodies.
@@ -155,6 +170,17 @@ payloads, credentials, local absolute paths, or private source bodies.
 }
 ```
 
+Focused gate responses follow these relation rules:
+
+- a formal user gate comes from the interaction contract or a formal open
+  user-gate todo, not merely from the count of all open user todos;
+- `blocks` uses the gate todo's `unblocks_todo_id` when present, then a verified
+  decision-scope relation, and otherwise falls back to the goal scope rather
+  than guessing from the selected runnable todo;
+- `waiting_on=user_or_controller` is routing metadata, not a new gate-owner
+  enum; gate owners continue to use the protocol's user, controller,
+  registered-agent, or external-system owner classes.
+
 ## Action Ladder
 
 Responses may include actions, but each action must declare its authority:
@@ -195,8 +221,13 @@ or omission, not the material itself.
 A first implementation is acceptable when:
 
 - command responses are read-only by default;
+- `loopx global-summary` and `loopx global-gates` emit their matching canonical
+  command responses, while the remaining manager commands stay host-only;
 - each command names its compact LoopX source surfaces;
-- gates name owner, blocked todo or scope, question, and next safe action;
+- gates name owner, formally related blocked todo or goal scope, question, and
+  next safe action;
+- agent filtering excludes goals where the selected agent is not registered;
+- unknown commands and legacy CLI aliases fail closed with help;
 - actions declare approval and ownership requirements;
 - risks carry public-safe evidence refs;
 - no raw logs, transcripts, credentials, local paths, or private source bodies

--- a/examples/project/global-manager-command-cli-smoke.py
+++ b/examples/project/global-manager-command-cli-smoke.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Smoke-test the public-safe `loopx global-summary` command."""
+"""Smoke-test the public-safe global manager CLI commands."""
 
 from __future__ import annotations
 
@@ -12,6 +12,9 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+GOAL_ID = "smoke-goal"
+AGENT_ID = "codex-smoke"
+BLOCKED_TODO_ID = "todo_blocked"
 PRIVATE_PATTERNS = [
     re.compile(r"/" + r"Users/[A-Za-z0-9._-]+/"),
     re.compile(r"/" + r"private/"),
@@ -25,72 +28,123 @@ def assert_public_safe(payload: dict[str, object]) -> None:
     text = json.dumps(payload, ensure_ascii=False)
     for pattern in PRIVATE_PATTERNS:
         if pattern.search(text):
-            raise AssertionError(f"global-summary payload leaked private pattern {pattern.pattern!r}")
-    if "/loopx-summary-all" in text:
-        raise AssertionError("global-summary payload should not expose the superseded /loopx-summary-all alias")
-
-
-def main() -> int:
-    with tempfile.TemporaryDirectory(prefix="loopx-global-summary-smoke-") as tmp:
-        root = Path(tmp)
-        runtime = root / "runtime"
-        registry = root / "registry.global.json"
-        registry.write_text(
-            json.dumps(
-                {
-                    "common_runtime_root": str(runtime),
-                    "goals": [
-                        {
-                            "id": "smoke-goal",
-                            "objective": "Smoke global summary.",
-                            "domain": "loopx-smoke",
-                            "status": "active",
-                            "adapter": {"kind": "read_only_project_map_v0", "status": "connected-read-only"},
-                        }
-                    ],
-                },
-                ensure_ascii=False,
-            ),
-            encoding="utf-8",
-        )
-        runs = runtime / "goals" / "smoke-goal" / "runs"
-        runs.mkdir(parents=True)
-        runs.joinpath("index.jsonl").write_text(
-            json.dumps(
-                {
-                    "generated_at": "2026-06-26T00:00:00+00:00",
-                    "classification": "smoke_progress",
-                    "recommended_action": "Continue the next public-safe smoke step.",
-                    "json_exists": True,
-                    "markdown_exists": True,
-                },
-                ensure_ascii=False,
+            raise AssertionError(
+                f"global manager payload leaked private pattern {pattern.pattern!r}"
             )
-            + "\n",
-            encoding="utf-8",
-        )
+    if "/loopx-summary-all" in text:
+        raise AssertionError("global manager payload exposed a superseded alias")
 
-        proc = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "loopx.cli",
-                "--format",
-                "json",
-                "--registry",
-                str(registry),
-                "--runtime-root",
-                str(runtime),
-                "global-summary",
-                "--limit",
-                "5",
-            ],
-            cwd=REPO_ROOT,
-            check=True,
-            text=True,
-            capture_output=True,
+
+def run_cli(
+    *,
+    registry: Path,
+    runtime: Path,
+    command: str,
+    output_format: str,
+    command_args: list[str] | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            output_format,
+            "--registry",
+            str(registry),
+            "--runtime-root",
+            str(runtime),
+            command,
+            *(command_args or []),
+        ],
+        cwd=REPO_ROOT,
+        check=check,
+        text=True,
+        capture_output=True,
+    )
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    registry = root / "registry.global.json"
+    run_index = runtime / "goals" / GOAL_ID / "runs" / "index.jsonl"
+    state.parent.mkdir(parents=True)
+    state.write_text(
+        "---\n"
+        "status: active\n"
+        f"goal_id: {GOAL_ID}\n"
+        "updated_at: 2026-06-26T00:00:00+00:00\n"
+        "---\n\n"
+        "# Global Manager CLI Smoke\n\n"
+        "## User Todo\n\n"
+        "- [ ] [P0] Approve the public-safe blocked delivery.\n"
+        "  <!-- loopx:todo todo_id=todo_gate_approve status=open "
+        "task_class=user_gate action_kind=approve "
+        f"blocks_agent={AGENT_ID} unblocks_todo_id={BLOCKED_TODO_ID} -->\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P0] Deliver the approved public-safe change.\n"
+        f"  <!-- loopx:todo todo_id={BLOCKED_TODO_ID} status=open "
+        f"task_class=advancement_task claimed_by={AGENT_ID} -->\n\n"
+        "## Next Action\n\n"
+        "- Approve the public-safe blocked delivery.\n",
+        encoding="utf-8",
+    )
+    registry.write_text(
+        json.dumps(
+            {
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "objective": "Smoke global manager commands.",
+                        "domain": "loopx-smoke",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": str(state.relative_to(project)),
+                        "adapter": {
+                            "kind": "read_only_project_map_v0",
+                            "status": "connected-read-only",
+                        },
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": [AGENT_ID],
+                        },
+                    }
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    run_index.parent.mkdir(parents=True)
+    run_index.write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-06-26T00:00:00+00:00",
+                "classification": "smoke_progress",
+                "recommended_action": "Continue the next public-safe smoke step.",
+                "json_exists": True,
+                "markdown_exists": True,
+            },
+            ensure_ascii=False,
         )
-    payload = json.loads(proc.stdout)
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry, runtime, state, run_index
+
+
+def snapshot_files(paths: list[Path]) -> dict[Path, tuple[bytes, int]]:
+    return {
+        path: (path.read_bytes(), path.stat().st_mtime_ns)
+        for path in paths
+    }
+
+
+def assert_summary_payload(payload: dict[str, object]) -> None:
     assert payload["schema_version"] == "global_manager_command_response_v0", payload
     request = payload["request"]
     assert request["command"] == "/loopx-global-summary", request
@@ -101,6 +155,82 @@ def main() -> int:
     assert payload["boundary"]["absolute_paths_recorded"] is False, payload["boundary"]
     assert "groups" in payload and "recent_progress" in payload["groups"], payload
     assert_public_safe(payload)
+
+
+def assert_gates_payload(payload: dict[str, object]) -> None:
+    assert payload["ok"] is True, payload
+    request = payload["request"]
+    assert request["command"] == "/loopx-global-gates", request
+    assert request["legacy_aliases"] == ["/loop-global-gates"], request
+    assert request["cli_command"] == "loopx global-gates", request
+    assert request["dry_run"] is True, request
+    assert payload["summary"]["open_gate_count"] == 1, payload
+    assert payload["gates"][0]["blocks"] == [BLOCKED_TODO_ID], payload
+    assert_public_safe(payload)
+
+
+def assert_gates_markdown(markdown: str, *, private_root: Path) -> None:
+    assert "# LoopX Global Gates" in markdown, markdown
+    assert "`/loopx-global-gates`" in markdown, markdown
+    assert f"`{GOAL_ID}`" in markdown, markdown
+    assert f"blocks=`{BLOCKED_TODO_ID}`" in markdown, markdown
+    assert "Recent Progress" not in markdown, markdown
+    assert "Risks" not in markdown, markdown
+    assert str(private_root) not in markdown, markdown
+
+
+def assert_error_envelope(root: Path, *, runtime: Path) -> None:
+    error_registry = root / "private" / "error-registry"
+    error_registry.mkdir(parents=True)
+    error_proc = run_cli(
+        registry=error_registry,
+        runtime=runtime,
+        command="global-gates",
+        output_format="json",
+        check=False,
+    )
+    assert error_proc.returncode != 0, error_proc
+    payload = json.loads(error_proc.stdout)
+    assert payload["request"]["command"] == "/loopx-global-gates", payload
+    assert str(error_registry) not in error_proc.stdout, error_proc.stdout
+    assert "<local-path-redacted>" in error_proc.stdout, error_proc.stdout
+    assert_public_safe(payload)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-global-manager-smoke-") as tmp:
+        root = Path(tmp)
+        registry, runtime, state, run_index = write_fixture(root)
+        files = [registry, state, run_index]
+        before = snapshot_files(files)
+
+        summary_proc = run_cli(
+            registry=registry,
+            runtime=runtime,
+            command="global-summary",
+            output_format="json",
+            command_args=["--agent-id", AGENT_ID, "--limit", "5"],
+        )
+        gates_proc = run_cli(
+            registry=registry,
+            runtime=runtime,
+            command="global-gates",
+            output_format="json",
+            command_args=["--agent-id", AGENT_ID, "--limit", "5"],
+        )
+        markdown_proc = run_cli(
+            registry=registry,
+            runtime=runtime,
+            command="global-gates",
+            output_format="markdown",
+            command_args=["--agent-id", AGENT_ID, "--limit", "5"],
+        )
+
+        assert_summary_payload(json.loads(summary_proc.stdout))
+        assert_gates_payload(json.loads(gates_proc.stdout))
+        assert_gates_markdown(markdown_proc.stdout, private_root=root)
+        assert snapshot_files(files) == before
+        assert_error_envelope(root, runtime=runtime)
 
     print("global-manager-command-cli-smoke ok")
     return 0

--- a/examples/project/global-manager-command-cli-smoke.py
+++ b/examples/project/global-manager-command-cli-smoke.py
@@ -197,6 +197,47 @@ def assert_error_envelope(root: Path, *, runtime: Path) -> None:
     assert_public_safe(payload)
 
 
+def assert_unhealthy_status_envelope(
+    root: Path, *, registry: Path, runtime: Path
+) -> None:
+    unhealthy_registry = root / "unhealthy-registry.json"
+    unhealthy_payload = json.loads(registry.read_text(encoding="utf-8"))
+    del unhealthy_payload["goals"][0]["domain"]
+    unhealthy_registry.write_text(
+        json.dumps(unhealthy_payload, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    status_proc = run_cli(
+        registry=unhealthy_registry,
+        runtime=runtime,
+        command="status",
+        output_format="json",
+        check=False,
+    )
+    status_payload = json.loads(status_proc.stdout)
+    assert status_payload["ok"] is False, status_proc
+    assert "attention_queue" in status_payload, status_payload
+    assert "error" not in status_payload, status_payload
+
+    gates_proc = run_cli(
+        registry=unhealthy_registry,
+        runtime=runtime,
+        command="global-gates",
+        output_format="json",
+        check=False,
+    )
+    assert gates_proc.returncode != 0, gates_proc
+    payload = json.loads(gates_proc.stdout)
+    assert payload["ok"] is False, payload
+    assert payload["error"] == "Global status source unavailable.", payload
+    assert "summary" not in payload, payload
+    assert "gates" not in payload, payload
+    assert "lanes" not in payload, payload
+    assert str(root) not in gates_proc.stdout, gates_proc.stdout
+    assert_public_safe(payload)
+
+
 def main() -> int:
     with tempfile.TemporaryDirectory(prefix="loopx-global-manager-smoke-") as tmp:
         root = Path(tmp)
@@ -231,6 +272,11 @@ def main() -> int:
         assert_gates_markdown(markdown_proc.stdout, private_root=root)
         assert snapshot_files(files) == before
         assert_error_envelope(root, runtime=runtime)
+        assert_unhealthy_status_envelope(
+            root,
+            registry=registry,
+            runtime=runtime,
+        )
 
     print("global-manager-command-cli-smoke ok")
     return 0

--- a/examples/project/global-manager-command-protocol-smoke.py
+++ b/examples/project/global-manager-command-protocol-smoke.py
@@ -98,6 +98,15 @@ def main() -> int:
         "Action Ladder",
         "Privacy Boundary",
         "global_manager_command_response_v0",
+        "loopx global-summary",
+        "loopx global-gates",
+        "compact run-history",
+        "unblocks_todo_id",
+        "goal scope",
+        "waiting_on=user_or_controller",
+        "not registered",
+        "host-only",
+        "fail closed",
         "python3 examples/project/global-manager-command-protocol-smoke.py",
     ]:
         assert_contains(contract, needle, "global manager command contract")

--- a/examples/slash-command-catalog-smoke.py
+++ b/examples/slash-command-catalog-smoke.py
@@ -40,6 +40,10 @@ def main() -> int:
         assert command in commands, commands
     assert "/loop-global-summary" in commands["/loopx-global-summary"]["legacy_aliases"]
     assert "/loopx-summary-all" not in json.dumps(payload)
+    global_gates = commands["/loopx-global-gates"]
+    assert global_gates["implementation_status"] == "available", global_gates
+    assert global_gates["cli_reference"] == "loopx global-gates", global_gates
+    assert global_gates["legacy_aliases"] == ["/loop-global-gates"], global_gates
     project_start = commands["/loopx <goal text>"]
     assert "loopx start-goal --guided --project . --goal-text" in project_start["cli_reference"], project_start
     assert "bootstrap-command-pack --project . --goal-text" not in project_start["cli_reference"], project_start
@@ -87,6 +91,7 @@ def main() -> int:
     assert "# LoopX Slash Commands" in markdown, markdown
     assert "`/loopx-global-summary`" in markdown, markdown
     assert "`loopx global-summary`" in markdown, markdown
+    assert "`loopx global-gates`" in markdown, markdown
     assert "`/loopx-pr-review`" in markdown, markdown
     assert "`loopx pr-review [--repo owner/repo] [--state open\\|merged\\|all] [--since ISO]`" in markdown, markdown
     assert "Agent contract: run the CLI reference first" in markdown, markdown

--- a/examples/slash-command-install-smoke.py
+++ b/examples/slash-command-install-smoke.py
@@ -131,6 +131,12 @@ def main() -> int:
         assert "surface=claude-skills" in claude_skill_text
         assert "global-summary" in claude_skill_text
 
+        claude_gates_skill = claude_home / "skills" / "loopx-global-gates" / "SKILL.md"
+        claude_gates_skill_text = claude_gates_skill.read_text(encoding="utf-8")
+        assert "loopx global-gates" in claude_gates_skill_text
+        assert "This command is read-only" in claude_gates_skill_text
+        assert "global-summary" not in claude_gates_skill_text
+
         rerun = json.loads(
             run_cli(
                 "--format",

--- a/loopx/cli_commands/summary_all.py
+++ b/loopx/cli_commands/summary_all.py
@@ -4,7 +4,13 @@ import argparse
 from collections.abc import Callable
 from pathlib import Path
 
-from ..summary_all import build_summary_all, render_summary_all_markdown
+from ..summary_all import (
+    build_global_gates,
+    build_global_gates_error,
+    build_summary_all,
+    render_global_gates_markdown,
+    render_summary_all_markdown,
+)
 
 
 PrintPayload = Callable[
@@ -23,28 +29,68 @@ def _scan_roots(args: argparse.Namespace) -> list[Path]:
     return scan_roots or [Path(args.scan_root).expanduser()]
 
 
+def _add_current_manager_flags(
+    parser: argparse.ArgumentParser,
+    *,
+    agent_help: str,
+    limit_help: str,
+) -> None:
+    parser.add_argument("--agent-id", help=agent_help)
+    parser.add_argument("--limit", type=int, default=8, help=limit_help)
+    parser.add_argument(
+        "--scan-root",
+        default=default_public_scan_root(),
+        help=(
+            "Public files to scan for obvious private material. "
+            "Defaults to the LoopX install root."
+        ),
+    )
+    parser.add_argument(
+        "--scan-path",
+        action="append",
+        default=[],
+        help=(
+            "Specific public file or directory to scan. Repeatable. "
+            "Overrides --scan-root when set."
+        ),
+    )
+
+
 def register_summary_all_command(
     subparsers: argparse._SubParsersAction,
     add_subcommand_format: Callable[[argparse.ArgumentParser], None],
 ) -> None:
     parser = subparsers.add_parser(
         "global-summary",
-        help="Read a public-safe /loopx-global-summary progress digest; see `loopx slash-commands` for slash help.",
+        help=(
+            "Read a public-safe /loopx-global-summary progress digest; "
+            "see `loopx slash-commands` for slash help."
+        ),
     )
     add_subcommand_format(parser)
-    parser.add_argument("--agent-id", help="Registered agent id for agent-lane quota projection.")
-    parser.add_argument("--time-range", default="24h", help="Recent progress window, e.g. 24h or 7d.")
-    parser.add_argument("--limit", type=int, default=8, help="Maximum items per digest section.")
-    parser.add_argument(
-        "--scan-root",
-        default=default_public_scan_root(),
-        help="Public files to scan for obvious private material. Defaults to the LoopX install root.",
+    _add_current_manager_flags(
+        parser,
+        agent_help="Registered agent id for agent-lane quota projection.",
+        limit_help="Maximum items per digest section.",
     )
     parser.add_argument(
-        "--scan-path",
-        action="append",
-        default=[],
-        help="Specific public file or directory to scan. Repeatable. Overrides --scan-root when set.",
+        "--time-range",
+        default="24h",
+        help="Recent progress window, e.g. 24h or 7d.",
+    )
+
+    gates_parser = subparsers.add_parser(
+        "global-gates",
+        help=(
+            "Read public-safe /loopx-global-gates user/controller decisions; "
+            "see `loopx slash-commands` for slash help."
+        ),
+    )
+    add_subcommand_format(gates_parser)
+    _add_current_manager_flags(
+        gates_parser,
+        agent_help="Registered agent id used to narrow gate projection.",
+        limit_help="Maximum returned gate count.",
     )
 
 
@@ -56,8 +102,22 @@ def handle_summary_all_command(
     output_format: FormatSelector,
     print_payload: PrintPayload,
 ) -> int | None:
-    if args.command != "global-summary":
+    if args.command not in {"global-summary", "global-gates"}:
         return None
+    if args.command == "global-gates":
+        try:
+            payload = build_global_gates(
+                registry_path=registry_path,
+                runtime_root_override=runtime_root_arg,
+                scan_roots=_scan_roots(args),
+                agent_id=args.agent_id,
+                limit=max(1, args.limit),
+            )
+        except Exception as exc:
+            payload = build_global_gates_error(exc)
+        print_payload(payload, output_format(args), render_global_gates_markdown)
+        return 0 if payload.get("ok") else 1
+
     try:
         payload = build_summary_all(
             registry_path=registry_path,

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -149,7 +149,8 @@ def _command_prompt_specs(*, cli_bin: str, include_legacy_aliases: bool) -> list
             "argument_hint": "[optional focus]",
             "instructions": [
                 "Visible command arguments: `$ARGUMENTS`.",
-                f"Run `{cli_bin} global-summary` first, then focus the answer on open gates, blocked work, owner decisions, and exact next questions.",
+                f"Run `{cli_bin} global-gates` first and summarize formal open gates, "
+                "blocked todo or goal scope, owner routing, and exact next questions.",
                 "This command is read-only unless the user explicitly asks for a state update.",
             ],
         },

--- a/loopx/slash_commands.py
+++ b/loopx/slash_commands.py
@@ -95,9 +95,8 @@ def build_slash_command_catalog(
             scope="global",
             intent="List open user/controller gates and what each blocks.",
             mutation_policy="read_only",
-            cli_reference=f"{cli_bin} slash-commands; use {cli_bin} global-summary for the current compact global packet",
+            cli_reference=f"{cli_bin} global-gates",
             legacy_aliases=legacy_gates,
-            implementation_status="host_command_defined",
         ),
         _command(
             command="/loopx-global-todos",

--- a/loopx/summary_all.py
+++ b/loopx/summary_all.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
 from .control_plane.runtime.time import now_utc, now_utc_iso
+from .control_plane.todos.decision_scope import todo_gate_relation
+from .control_plane.todos.user_gate import open_user_gate_todo_items
 from .history import collect_history, load_registry
 from .paths import resolve_runtime_root
 from .presentation.markdown import as_dict as _as_dict
@@ -15,6 +17,7 @@ from .status import collect_status
 
 
 COMMAND = "/loopx-global-summary"
+GLOBAL_GATES_COMMAND = "/loopx-global-gates"
 LEGACY_COMMAND_ALIASES = {
     "/loopx-summary-all": COMMAND,
     "/loop-global-summary": COMMAND,
@@ -29,6 +32,13 @@ SOURCE_SURFACES = [
     "quota should-run summaries",
     "active-state todo projections",
     "run history index summaries",
+]
+
+GLOBAL_GATES_SOURCE_SURFACES = [
+    "status attention queue",
+    "quota should-run summaries",
+    "active-state todo projections",
+    "compact run-history projection consumed by status",
 ]
 
 LANE_PRIORITY = {
@@ -182,6 +192,298 @@ def _gate_from_item(
         "question": _redact_text(question),
         "next_safe_action": "Wait for the projected user/controller decision before running the blocked path.",
     }
+
+
+def _quota_matches_agent_scope(
+    quota_payload: dict[str, Any],
+    *,
+    agent_id: str | None,
+) -> bool:
+    if not agent_id:
+        return True
+    if quota_payload.get("ok") is False:
+        return False
+    identity = _as_dict(quota_payload.get("agent_identity"))
+    return str(identity.get("agent_id") or "") == agent_id
+
+
+def _agent_todo_candidates(quota_payload: dict[str, Any]) -> list[dict[str, Any]]:
+    candidates: list[dict[str, Any]] = []
+    seen: set[tuple[object, object, object]] = set()
+
+    def add_candidate(value: object) -> None:
+        if not isinstance(value, dict):
+            return
+        item_key = (value.get("todo_id"), value.get("index"), value.get("text"))
+        if item_key in seen:
+            return
+        seen.add(item_key)
+        candidates.append(value)
+
+    add_candidate(quota_payload.get("selected_todo"))
+    add_candidate(quota_payload.get("agent_lane_next_action"))
+    summary = _as_dict(quota_payload.get("agent_todo_summary"))
+    for key in (
+        "first_open_items",
+        "first_executable_items",
+        "items",
+        "open_items",
+        "backlog_items",
+        "executable_backlog_items",
+    ):
+        for item in _as_list(summary.get(key)):
+            add_candidate(item)
+    return candidates
+
+
+def _blocked_refs_for_gate(
+    gate_item: dict[str, Any] | None,
+    *,
+    quota_payload: dict[str, Any],
+    goal_id: str,
+) -> list[str]:
+    if not gate_item:
+        return [goal_id]
+    exact_todo_id = str(gate_item.get("unblocks_todo_id") or "").strip()
+    if exact_todo_id:
+        return [exact_todo_id]
+    for agent_item in _agent_todo_candidates(quota_payload):
+        relation = todo_gate_relation(gate_item, agent_item)
+        if not relation or relation.get("state") not in {
+            "gate_targets_todo",
+            "gate_covers_action",
+        }:
+            continue
+        todo_id = str(agent_item.get("todo_id") or "").strip()
+        if todo_id:
+            return [todo_id]
+    return [goal_id]
+
+
+def _global_gate_from_item(
+    item: dict[str, Any],
+    *,
+    quota_payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    interaction = _as_dict(quota_payload.get("interaction_contract"))
+    user_channel = _as_dict(interaction.get("user_channel"))
+    user_summary = _as_dict(quota_payload.get("user_todo_summary"))
+    formal_gates = open_user_gate_todo_items(user_summary)
+    formal_gate = formal_gates[0] if formal_gates else None
+    action_required = user_channel.get("action_required") is True
+    waiting_on = str(item.get("waiting_on") or "").strip()
+    controller_routed = waiting_on in {"controller", "user_or_controller"}
+    if not action_required and not formal_gate and not controller_routed:
+        return None
+
+    if formal_gate or (action_required and waiting_on != "user_or_controller"):
+        owner = "user"
+    else:
+        owner = "controller"
+    goal_id = str(item.get("goal_id") or quota_payload.get("goal_id") or "").strip()
+    question = (
+        user_channel.get("question")
+        or item.get("operator_question")
+        or (formal_gate or {}).get("text")
+        or (formal_gate or {}).get("title")
+        or quota_payload.get("recommended_action")
+        or item.get("recommended_action")
+    )
+    gate_id = (
+        quota_payload.get("gate_id")
+        or (formal_gate or {}).get("todo_id")
+        or f"{goal_id}:{owner}-gate"
+    )
+    return {
+        "gate_id": str(gate_id),
+        "goal_id": goal_id,
+        "owner": owner,
+        "waiting_on": waiting_on or owner,
+        "blocks": _blocked_refs_for_gate(
+            formal_gate,
+            quota_payload=quota_payload,
+            goal_id=goal_id,
+        ),
+        "question": _redact_text(question),
+        "next_safe_action": (
+            "Wait for the projected user/controller decision before "
+            "running the blocked path."
+        ),
+    }
+
+
+def _collect_global_gate_state(
+    status_payload: dict[str, Any],
+    *,
+    agent_id: str | None,
+    limit: int,
+) -> dict[str, list[dict[str, Any]]]:
+    queue = _as_dict(status_payload.get("attention_queue"))
+    queue_items = [
+        item for item in _as_list(queue.get("items")) if isinstance(item, dict)
+    ]
+    gates: list[dict[str, Any]] = []
+    lanes: list[dict[str, Any]] = []
+    seen_goal_ids: set[str] = set()
+    for item in queue_items:
+        goal_id = str(item.get("goal_id") or "").strip()
+        if not goal_id or goal_id in seen_goal_ids:
+            continue
+        seen_goal_ids.add(goal_id)
+        quota_payload = _build_goal_quota(
+            status_payload,
+            goal_id=goal_id,
+            agent_id=agent_id,
+        )
+        if not _quota_matches_agent_scope(quota_payload, agent_id=agent_id):
+            continue
+        gate = _global_gate_from_item(item, quota_payload=quota_payload)
+        if not gate:
+            continue
+        gates.append(gate)
+        lanes.append(_lane_from_item(item, quota_payload=quota_payload))
+        if len(gates) >= limit:
+            break
+    return {"gates": gates, "lanes": lanes}
+
+
+def _global_gates_request() -> dict[str, Any]:
+    return {
+        "schema_version": "global_manager_command_request_v0",
+        "command": GLOBAL_GATES_COMMAND,
+        "legacy_aliases": ["/loop-global-gates"],
+        "cli_command": "loopx global-gates",
+        "include": ["gates", "blocked_work", "next_questions"],
+        "privacy_mode": "public_safe_summary",
+        "dry_run": True,
+    }
+
+
+def build_global_gates(
+    *,
+    registry_path: Path,
+    runtime_root_override: str | None,
+    scan_roots: list[Path],
+    agent_id: str | None,
+    limit: int,
+) -> dict[str, Any]:
+    normalized_limit = max(1, limit)
+    status_payload = collect_status(
+        registry_path=registry_path,
+        runtime_root_override=runtime_root_override,
+        scan_roots=scan_roots,
+        limit=normalized_limit,
+    )
+    state = _collect_global_gate_state(
+        status_payload,
+        agent_id=agent_id,
+        limit=normalized_limit,
+    )
+    gates = state["gates"]
+    lanes = state["lanes"]
+    gate_count = len(gates)
+    noun = "gate requires" if gate_count == 1 else "gates require"
+    actions = []
+    if gates:
+        actions = [
+            {
+                "action_id": "act_read_gate_detail",
+                "kind": "read_more",
+                "requires_user_approval": False,
+                "requires_maintainer_authority": False,
+                "preview": (
+                    "Run `loopx quota should-run --goal-id <goal>` for one "
+                    "blocked lane."
+                ),
+            },
+            {
+                "action_id": "act_ask_gate_owner",
+                "kind": "ask_user",
+                "requires_user_approval": False,
+                "requires_maintainer_authority": False,
+                "preview": "Surface the projected gate question without changing state.",
+            },
+        ]
+    return {
+        "ok": True,
+        "schema_version": SCHEMA_VERSION,
+        "request": _global_gates_request(),
+        "generated_at": _now_iso(),
+        "summary": {
+            "headline": f"{gate_count} open user/controller {noun} a decision.",
+            "open_gate_count": gate_count,
+            "blocked_lane_count": len(lanes),
+            "source_surfaces": GLOBAL_GATES_SOURCE_SURFACES,
+        },
+        "groups": {
+            "user_gates": [gate for gate in gates if gate.get("owner") == "user"],
+            "controller_gates": [
+                gate for gate in gates if gate.get("owner") == "controller"
+            ],
+            "blocked_work": lanes,
+        },
+        "gates": gates,
+        "lanes": lanes,
+        "actions": actions,
+        "omissions": [
+            (
+                "Raw logs, raw transcripts, connector payloads, credential values, "
+                "local paths, and private source bodies were intentionally omitted."
+            ),
+            "Recent progress and unrelated risks are outside this focused command.",
+        ],
+        "boundary": BOUNDARY,
+    }
+
+
+def build_global_gates_error(error: object) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "schema_version": SCHEMA_VERSION,
+        "request": _global_gates_request(),
+        "generated_at": _now_iso(),
+        "error": _redact_text(error),
+        "omissions": [
+            "Raw/private failure details and local paths were intentionally omitted."
+        ],
+        "boundary": BOUNDARY,
+    }
+
+
+def render_global_gates_markdown(payload: dict[str, Any]) -> str:
+    if not payload.get("ok"):
+        return "# LoopX Global Gates\n\n- ok: `False`\n- error: " + _redact_text(
+            payload.get("error")
+        )
+
+    summary = _as_dict(payload.get("summary"))
+    lines = [
+        "# LoopX Global Gates",
+        "",
+        f"- command: `{_as_dict(payload.get('request')).get('command')}`",
+        f"- open_gate_count: `{summary.get('open_gate_count')}`",
+        "",
+        "## Gates",
+    ]
+    gates = [item for item in _as_list(payload.get("gates")) if isinstance(item, dict)]
+    if not gates:
+        lines.append("- none")
+    for gate in gates:
+        blocked_refs = ", ".join(str(item) for item in _as_list(gate.get("blocks")))
+        lines.append(
+            "- "
+            f"`{gate.get('goal_id')}` owner=`{gate.get('owner')}` "
+            f"waiting_on=`{gate.get('waiting_on')}` blocks=`{blocked_refs}`: "
+            f"{gate.get('question')} Next: {gate.get('next_safe_action')}"
+        )
+    lines.extend(
+        [
+            "",
+            "## Boundary",
+            "- raw/private material omitted; local paths are not recorded.",
+        ]
+    )
+    return "\n".join(lines)
 
 
 def _todo_from_quota(goal_id: str, quota_payload: dict[str, Any]) -> dict[str, Any] | None:

--- a/loopx/summary_all.py
+++ b/loopx/summary_all.py
@@ -276,10 +276,7 @@ def _global_gate_from_item(
     if not action_required and not formal_gate and not controller_routed:
         return None
 
-    if formal_gate or (action_required and waiting_on != "user_or_controller"):
-        owner = "user"
-    else:
-        owner = "controller"
+    owner = "user" if formal_gate or action_required else "controller"
     goal_id = str(item.get("goal_id") or quota_payload.get("goal_id") or "").strip()
     question = (
         user_channel.get("question")
@@ -341,7 +338,15 @@ def _collect_global_gate_state(
         if not gate:
             continue
         gates.append(gate)
-        lanes.append(_lane_from_item(item, quota_payload=quota_payload))
+        lane = _lane_from_item(item, quota_payload=quota_payload)
+        verified_todo_ids = {
+            str(blocked_ref)
+            for blocked_ref in _as_list(gate.get("blocks"))
+            if str(blocked_ref) != goal_id
+        }
+        if str(lane.get("top_todo_id") or "") not in verified_todo_ids:
+            lane.pop("top_todo_id", None)
+        lanes.append(lane)
         if len(gates) >= limit:
             break
     return {"gates": gates, "lanes": lanes}

--- a/loopx/summary_all.py
+++ b/loopx/summary_all.py
@@ -264,6 +264,7 @@ def _global_gate_from_item(
     item: dict[str, Any],
     *,
     quota_payload: dict[str, Any],
+    agent_id: str | None,
 ) -> dict[str, Any] | None:
     interaction = _as_dict(quota_payload.get("interaction_contract"))
     user_channel = _as_dict(interaction.get("user_channel"))
@@ -272,7 +273,9 @@ def _global_gate_from_item(
     formal_gate = formal_gates[0] if formal_gates else None
     action_required = user_channel.get("action_required") is True
     waiting_on = str(item.get("waiting_on") or "").strip()
-    controller_routed = waiting_on in {"controller", "user_or_controller"}
+    controller_routed = waiting_on in {"controller", "user_or_controller"} and (
+        not agent_id or quota_payload.get("state") == "operator_gate"
+    )
     if not action_required and not formal_gate and not controller_routed:
         return None
 
@@ -334,7 +337,11 @@ def _collect_global_gate_state(
         )
         if not _quota_matches_agent_scope(quota_payload, agent_id=agent_id):
             continue
-        gate = _global_gate_from_item(item, quota_payload=quota_payload)
+        gate = _global_gate_from_item(
+            item,
+            quota_payload=quota_payload,
+            agent_id=agent_id,
+        )
         if not gate:
             continue
         gates.append(gate)

--- a/loopx/summary_all.py
+++ b/loopx/summary_all.py
@@ -379,6 +379,8 @@ def build_global_gates(
         scan_roots=scan_roots,
         limit=normalized_limit,
     )
+    if status_payload.get("ok") is not True:
+        return build_global_gates_error("Global status source unavailable.")
     state = _collect_global_gate_state(
         status_payload,
         agent_id=agent_id,

--- a/tests/test_summary_all.py
+++ b/tests/test_summary_all.py
@@ -3,6 +3,44 @@ from __future__ import annotations
 import loopx.summary_all as summary_all
 
 
+def patch_manager_reads(
+    monkeypatch,
+    *,
+    status_payload: dict[str, object],
+    quota_payloads: dict[str, dict[str, object]],
+) -> None:
+    monkeypatch.setattr(summary_all, "collect_status", lambda **_: status_payload)
+    monkeypatch.setattr(
+        summary_all,
+        "build_quota_should_run",
+        lambda _status, *, goal_id, agent_id: quota_payloads[goal_id],
+    )
+
+
+def build_global_gates(tmp_path, *, agent_id=None, limit=8):
+    return summary_all.build_global_gates(
+        registry_path=tmp_path / "registry.json",
+        runtime_root_override=None,
+        scan_roots=[],
+        agent_id=agent_id,
+        limit=limit,
+    )
+
+
+def controller_quota(goal_id: str, *, agent_id: str | None = None) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "ok": True,
+        "goal_id": goal_id,
+        "state": "operator_gate",
+        "recommended_action": "Wait for the controller decision.",
+        "user_todo_summary": {"open_count": 0, "gate_open_items": []},
+        "interaction_contract": {"user_channel": {"action_required": False}},
+    }
+    if agent_id:
+        payload["agent_identity"] = {"agent_id": agent_id, "registered": True}
+    return payload
+
+
 def test_blocked_visible_todo_is_not_counted_as_runnable(monkeypatch, tmp_path) -> None:
     status_payload = {
         "attention_queue": {
@@ -53,3 +91,382 @@ def test_blocked_visible_todo_is_not_counted_as_runnable(monkeypatch, tmp_path) 
     assert payload["groups"]["runnable_agent_work"] == []
     assert len(payload["todos"]) == 1
     assert payload["summary"]["runnable_todo_count"] == 0
+    assert payload["gates"] == [
+        {
+            "gate_id": "blocked-goal:user-gate",
+            "goal_id": "blocked-goal",
+            "owner": "user",
+            "blocks": ["gate-1"],
+            "question": "Approve this run?",
+            "next_safe_action": (
+                "Wait for the projected user/controller decision before "
+                "running the blocked path."
+            ),
+        }
+    ]
+
+
+def test_global_gates_uses_formal_exact_todo_link(monkeypatch, tmp_path) -> None:
+    status_payload = {
+        "attention_queue": {"items": [{"goal_id": "linked-goal", "waiting_on": "user"}]}
+    }
+    quota_payload = {
+        "ok": True,
+        "goal_id": "linked-goal",
+        "state": "operator_gate",
+        "recommended_action": "Wait for approval.",
+        "agent_todo_summary": {
+            "first_open_items": [{"todo_id": "todo-blocked", "status": "blocked"}],
+        },
+        "user_todo_summary": {
+            "open_count": 1,
+            "gate_open_items": [
+                {
+                    "todo_id": "gate-1",
+                    "task_class": "user_gate",
+                    "text": "Approve this run?",
+                    "unblocks_todo_id": "todo-blocked",
+                }
+            ],
+        },
+        "interaction_contract": {
+            "user_channel": {
+                "action_required": True,
+                "question": "Approve this run?",
+            },
+        },
+    }
+    patch_manager_reads(
+        monkeypatch,
+        status_payload=status_payload,
+        quota_payloads={"linked-goal": quota_payload},
+    )
+
+    payload = build_global_gates(tmp_path)
+
+    assert payload["gates"] == [
+        {
+            "gate_id": "gate-1",
+            "goal_id": "linked-goal",
+            "owner": "user",
+            "waiting_on": "user",
+            "blocks": ["todo-blocked"],
+            "question": "Approve this run?",
+            "next_safe_action": (
+                "Wait for the projected user/controller decision before "
+                "running the blocked path."
+            ),
+        }
+    ]
+
+
+def test_global_gates_prefers_explicit_action_required_metadata(monkeypatch, tmp_path) -> None:
+    status_payload = {
+        "attention_queue": {
+            "items": [
+                {
+                    "goal_id": "action-required-goal",
+                    "waiting_on": "user",
+                    "operator_question": "Lower-precedence operator question?",
+                }
+            ]
+        }
+    }
+    quota_payload = {
+        "ok": True,
+        "goal_id": "action-required-goal",
+        "gate_id": "explicit-quota-gate",
+        "recommended_action": "Lower-precedence recommendation.",
+        "user_todo_summary": {"open_count": 0, "gate_open_items": []},
+        "interaction_contract": {
+            "user_channel": {
+                "action_required": True,
+                "question": "Scoped user question?",
+            }
+        },
+    }
+    patch_manager_reads(
+        monkeypatch,
+        status_payload=status_payload,
+        quota_payloads={"action-required-goal": quota_payload},
+    )
+
+    payload = build_global_gates(tmp_path)
+
+    gate = payload["gates"][0]
+    assert gate["gate_id"] == "explicit-quota-gate"
+    assert gate["owner"] == "user"
+    assert gate["question"] == "Scoped user question?"
+    assert gate["blocks"] == ["action-required-goal"]
+
+
+def test_global_gates_does_not_treat_plain_user_todo_as_gate(monkeypatch, tmp_path) -> None:
+    status_payload = {
+        "attention_queue": {"items": [{"goal_id": "plain-user-todo", "waiting_on": "agent"}]}
+    }
+    quota_payload = {
+        "ok": True,
+        "goal_id": "plain-user-todo",
+        "state": "operator_gate",
+        "user_todo_summary": {
+            "open_count": 1,
+            "first_open_items": [
+                {
+                    "todo_id": "user-action-1",
+                    "task_class": "user_action",
+                    "text": "Review this later.",
+                }
+            ],
+        },
+        "interaction_contract": {"user_channel": {"action_required": False}},
+    }
+    patch_manager_reads(
+        monkeypatch,
+        status_payload=status_payload,
+        quota_payloads={"plain-user-todo": quota_payload},
+    )
+
+    payload = build_global_gates(tmp_path)
+
+    assert payload["gates"] == []
+    assert payload["summary"]["open_gate_count"] == 0
+
+
+def test_global_gates_uses_decision_scope_then_goal_fallback(monkeypatch, tmp_path) -> None:
+    scope = {"kind": "production", "granularity": "project", "scope_key": "deploy"}
+    status_payload = {
+        "attention_queue": {
+            "items": [
+                {"goal_id": "scoped-goal", "waiting_on": "user"},
+                {
+                    "goal_id": "controller-goal",
+                    "waiting_on": "controller",
+                    "operator_question": "Should the controller attach this adapter?",
+                },
+            ]
+        }
+    }
+    scoped_quota = {
+        "ok": True,
+        "goal_id": "scoped-goal",
+        "state": "operator_gate",
+        "agent_todo_summary": {
+            "first_open_items": [
+                {
+                    "todo_id": "deploy-todo",
+                    "status": "blocked",
+                    "required_decision_scopes": [scope],
+                }
+            ]
+        },
+        "user_todo_summary": {
+            "open_count": 1,
+            "gate_open_items": [
+                {
+                    "todo_id": "deploy-gate",
+                    "task_class": "user_gate",
+                    "text": "Approve production deployment?",
+                    "decision_scope": scope,
+                }
+            ],
+        },
+        "interaction_contract": {"user_channel": {"action_required": True}},
+    }
+    controller_payload = controller_quota("controller-goal")
+    controller_payload["agent_lane_next_action"] = {
+        "todo_id": "selected-runnable-todo",
+        "status": "open",
+    }
+    patch_manager_reads(
+        monkeypatch,
+        status_payload=status_payload,
+        quota_payloads={
+            "scoped-goal": scoped_quota,
+            "controller-goal": controller_payload,
+        },
+    )
+
+    payload = build_global_gates(tmp_path)
+
+    assert payload["gates"][0]["blocks"] == ["deploy-todo"]
+    controller_gate = payload["gates"][1]
+    assert controller_gate["owner"] == "controller"
+    assert controller_gate["waiting_on"] == "controller"
+    assert controller_gate["question"] == "Should the controller attach this adapter?"
+    assert controller_gate["blocks"] == ["controller-goal"]
+
+
+def test_global_gates_preserves_shared_route_with_supported_owner(monkeypatch, tmp_path) -> None:
+    status_payload = {
+        "attention_queue": {
+            "items": [
+                {
+                    "goal_id": "shared-goal",
+                    "waiting_on": "user_or_controller",
+                    "operator_question": "Who should resolve this gate?",
+                }
+            ]
+        }
+    }
+    patch_manager_reads(
+        monkeypatch,
+        status_payload=status_payload,
+        quota_payloads={"shared-goal": controller_quota("shared-goal")},
+    )
+
+    payload = build_global_gates(tmp_path)
+
+    gate = payload["gates"][0]
+    assert gate["owner"] == "controller"
+    assert gate["waiting_on"] == "user_or_controller"
+    assert gate["owner"] != "user_or_controller"
+
+
+def test_global_gates_filters_every_group_to_requested_agent(monkeypatch, tmp_path) -> None:
+    status_payload = {
+        "attention_queue": {
+            "items": [
+                {
+                    "goal_id": "included-goal",
+                    "waiting_on": "controller",
+                    "operator_question": "Resolve included gate?",
+                },
+                {
+                    "goal_id": "excluded-goal",
+                    "waiting_on": "controller",
+                    "operator_question": "Resolve excluded gate?",
+                },
+            ]
+        }
+    }
+    patch_manager_reads(
+        monkeypatch,
+        status_payload=status_payload,
+        quota_payloads={
+            "included-goal": controller_quota(
+                "included-goal", agent_id="codex-main-control"
+            ),
+            "excluded-goal": controller_quota("excluded-goal", agent_id="other-agent"),
+        },
+    )
+
+    payload = build_global_gates(tmp_path, agent_id="codex-main-control")
+
+    assert [gate["goal_id"] for gate in payload["gates"]] == ["included-goal"]
+    assert [lane["goal_id"] for lane in payload["lanes"]] == ["included-goal"]
+    assert [lane["goal_id"] for lane in payload["groups"]["blocked_work"]] == [
+        "included-goal"
+    ]
+    assert payload["summary"]["open_gate_count"] == 1
+    assert payload["summary"]["blocked_lane_count"] == 1
+
+
+def test_global_gates_scans_until_gate_limit_after_normalization(monkeypatch, tmp_path) -> None:
+    non_gate_items = [
+        {"goal_id": f"ordinary-{index}", "waiting_on": "agent"} for index in range(40)
+    ]
+    status_payload = {
+        "attention_queue": {
+            "items": [
+                *non_gate_items,
+                {"goal_id": "late-gate", "waiting_on": "controller"},
+            ]
+        }
+    }
+    quota_payloads = {
+        item["goal_id"]: {
+            "ok": True,
+            "goal_id": item["goal_id"],
+            "user_todo_summary": {"open_count": 0},
+            "interaction_contract": {"user_channel": {"action_required": False}},
+        }
+        for item in non_gate_items
+    }
+    quota_payloads["late-gate"] = controller_quota("late-gate")
+    patch_manager_reads(
+        monkeypatch,
+        status_payload=status_payload,
+        quota_payloads=quota_payloads,
+    )
+
+    payload = build_global_gates(tmp_path, limit=1)
+
+    assert [gate["goal_id"] for gate in payload["gates"]] == ["late-gate"]
+
+
+def test_global_gates_empty_payload_has_focused_public_contract(monkeypatch, tmp_path) -> None:
+    calls = {"status": 0}
+
+    def collect_status(**_kwargs):
+        calls["status"] += 1
+        return {"attention_queue": {"items": []}}
+
+    monkeypatch.setattr(summary_all, "collect_status", collect_status)
+
+    payload = build_global_gates(tmp_path)
+
+    assert calls == {"status": 1}
+    assert payload["gates"] == []
+    assert payload["lanes"] == []
+    assert payload["actions"] == []
+    assert payload["generated_at"]
+    assert payload["summary"]["source_surfaces"] == [
+        "status attention queue",
+        "quota should-run summaries",
+        "active-state todo projections",
+        "compact run-history projection consumed by status",
+    ]
+    assert "recent_progress" not in payload
+    assert "risks" not in payload
+    assert payload["boundary"] == summary_all.BOUNDARY
+
+
+def test_global_gates_applies_limit_in_queue_order(monkeypatch, tmp_path) -> None:
+    goal_ids = ["first-gate", "second-gate", "third-gate"]
+    status_payload = {
+        "attention_queue": {
+            "items": [
+                {"goal_id": goal_id, "waiting_on": "controller"} for goal_id in goal_ids
+            ]
+        }
+    }
+    patch_manager_reads(
+        monkeypatch,
+        status_payload=status_payload,
+        quota_payloads={goal_id: controller_quota(goal_id) for goal_id in goal_ids},
+    )
+
+    payload = build_global_gates(tmp_path, limit=2)
+
+    assert [gate["goal_id"] for gate in payload["gates"]] == goal_ids[:2]
+    assert [lane["goal_id"] for lane in payload["lanes"]] == goal_ids[:2]
+    assert all(action["requires_user_approval"] is False for action in payload["actions"])
+    assert all(action["requires_maintainer_authority"] is False for action in payload["actions"])
+
+
+def test_global_gates_error_redacts_paths_and_renderer_stays_focused(tmp_path) -> None:
+    private_path = tmp_path / "private-state.json"
+
+    error_payload = summary_all.build_global_gates_error(
+        RuntimeError(f"failed to read {private_path}")
+    )
+    markdown = summary_all.render_global_gates_markdown(
+        {
+            "ok": True,
+            "request": {"command": "/loopx-global-gates"},
+            "summary": {"open_gate_count": 0},
+            "gates": [],
+            "boundary": summary_all.BOUNDARY,
+        }
+    )
+
+    assert error_payload["ok"] is False
+    assert error_payload["request"]["command"] == "/loopx-global-gates"
+    assert str(private_path) not in error_payload["error"]
+    assert "<local-path-redacted>" in error_payload["error"]
+    assert error_payload["generated_at"]
+    assert error_payload["boundary"] == summary_all.BOUNDARY
+    assert "- none" in markdown
+    assert "Recent Progress" not in markdown
+    assert "Risks" not in markdown
+    assert "## Lanes" not in markdown

--- a/tests/test_summary_all.py
+++ b/tests/test_summary_all.py
@@ -160,13 +160,13 @@ def test_global_gates_uses_formal_exact_todo_link(monkeypatch, tmp_path) -> None
     ]
 
 
-def test_global_gates_prefers_explicit_action_required_metadata(monkeypatch, tmp_path) -> None:
+def test_global_gates_action_required_owns_shared_route(monkeypatch, tmp_path) -> None:
     status_payload = {
         "attention_queue": {
             "items": [
                 {
                     "goal_id": "action-required-goal",
-                    "waiting_on": "user",
+                    "waiting_on": "user_or_controller",
                     "operator_question": "Lower-precedence operator question?",
                 }
             ]
@@ -196,6 +196,7 @@ def test_global_gates_prefers_explicit_action_required_metadata(monkeypatch, tmp
     gate = payload["gates"][0]
     assert gate["gate_id"] == "explicit-quota-gate"
     assert gate["owner"] == "user"
+    assert gate["waiting_on"] == "user_or_controller"
     assert gate["question"] == "Scoped user question?"
     assert gate["blocks"] == ["action-required-goal"]
 
@@ -289,11 +290,13 @@ def test_global_gates_uses_decision_scope_then_goal_fallback(monkeypatch, tmp_pa
     payload = build_global_gates(tmp_path)
 
     assert payload["gates"][0]["blocks"] == ["deploy-todo"]
+    assert payload["groups"]["blocked_work"][0]["top_todo_id"] == "deploy-todo"
     controller_gate = payload["gates"][1]
     assert controller_gate["owner"] == "controller"
     assert controller_gate["waiting_on"] == "controller"
     assert controller_gate["question"] == "Should the controller attach this adapter?"
     assert controller_gate["blocks"] == ["controller-goal"]
+    assert "top_todo_id" not in payload["groups"]["blocked_work"][1]
 
 
 def test_global_gates_preserves_shared_route_with_supported_owner(monkeypatch, tmp_path) -> None:

--- a/tests/test_summary_all.py
+++ b/tests/test_summary_all.py
@@ -108,6 +108,7 @@ def test_blocked_visible_todo_is_not_counted_as_runnable(monkeypatch, tmp_path) 
 
 def test_global_gates_uses_formal_exact_todo_link(monkeypatch, tmp_path) -> None:
     status_payload = {
+        "ok": True,
         "attention_queue": {"items": [{"goal_id": "linked-goal", "waiting_on": "user"}]}
     }
     quota_payload = {
@@ -162,6 +163,7 @@ def test_global_gates_uses_formal_exact_todo_link(monkeypatch, tmp_path) -> None
 
 def test_global_gates_action_required_owns_shared_route(monkeypatch, tmp_path) -> None:
     status_payload = {
+        "ok": True,
         "attention_queue": {
             "items": [
                 {
@@ -203,6 +205,7 @@ def test_global_gates_action_required_owns_shared_route(monkeypatch, tmp_path) -
 
 def test_global_gates_does_not_treat_plain_user_todo_as_gate(monkeypatch, tmp_path) -> None:
     status_payload = {
+        "ok": True,
         "attention_queue": {"items": [{"goal_id": "plain-user-todo", "waiting_on": "agent"}]}
     }
     quota_payload = {
@@ -236,6 +239,7 @@ def test_global_gates_does_not_treat_plain_user_todo_as_gate(monkeypatch, tmp_pa
 def test_global_gates_uses_decision_scope_then_goal_fallback(monkeypatch, tmp_path) -> None:
     scope = {"kind": "production", "granularity": "project", "scope_key": "deploy"}
     status_payload = {
+        "ok": True,
         "attention_queue": {
             "items": [
                 {"goal_id": "scoped-goal", "waiting_on": "user"},
@@ -301,6 +305,7 @@ def test_global_gates_uses_decision_scope_then_goal_fallback(monkeypatch, tmp_pa
 
 def test_global_gates_preserves_shared_route_with_supported_owner(monkeypatch, tmp_path) -> None:
     status_payload = {
+        "ok": True,
         "attention_queue": {
             "items": [
                 {
@@ -327,6 +332,7 @@ def test_global_gates_preserves_shared_route_with_supported_owner(monkeypatch, t
 
 def test_global_gates_filters_every_group_to_requested_agent(monkeypatch, tmp_path) -> None:
     status_payload = {
+        "ok": True,
         "attention_queue": {
             "items": [
                 {
@@ -369,6 +375,7 @@ def test_global_gates_scans_until_gate_limit_after_normalization(monkeypatch, tm
         {"goal_id": f"ordinary-{index}", "waiting_on": "agent"} for index in range(40)
     ]
     status_payload = {
+        "ok": True,
         "attention_queue": {
             "items": [
                 *non_gate_items,
@@ -402,7 +409,7 @@ def test_global_gates_empty_payload_has_focused_public_contract(monkeypatch, tmp
 
     def collect_status(**_kwargs):
         calls["status"] += 1
-        return {"attention_queue": {"items": []}}
+        return {"ok": True, "attention_queue": {"items": []}}
 
     monkeypatch.setattr(summary_all, "collect_status", collect_status)
 
@@ -424,9 +431,27 @@ def test_global_gates_empty_payload_has_focused_public_contract(monkeypatch, tmp
     assert payload["boundary"] == summary_all.BOUNDARY
 
 
+def test_global_gates_fails_closed_when_status_source_is_unhealthy(
+    monkeypatch, tmp_path
+) -> None:
+    status_payload = {"ok": False, "attention_queue": {"items": []}}
+    monkeypatch.setattr(summary_all, "collect_status", lambda **_: status_payload)
+
+    payload = build_global_gates(tmp_path)
+
+    assert payload["ok"] is False
+    assert payload["error"] == "Global status source unavailable."
+    assert payload["request"]["command"] == "/loopx-global-gates"
+    assert "summary" not in payload
+    assert "gates" not in payload
+    assert "lanes" not in payload
+    assert payload["boundary"] == summary_all.BOUNDARY
+
+
 def test_global_gates_applies_limit_in_queue_order(monkeypatch, tmp_path) -> None:
     goal_ids = ["first-gate", "second-gate", "third-gate"]
     status_payload = {
+        "ok": True,
         "attention_queue": {
             "items": [
                 {"goal_id": goal_id, "waiting_on": "controller"} for goal_id in goal_ids

--- a/tests/test_summary_all.py
+++ b/tests/test_summary_all.py
@@ -330,6 +330,86 @@ def test_global_gates_preserves_shared_route_with_supported_owner(monkeypatch, t
     assert gate["owner"] != "user_or_controller"
 
 
+def test_global_gates_agent_scope_drops_goal_controller_route_when_quota_is_runnable(
+    monkeypatch, tmp_path
+) -> None:
+    agent_id = "codex-runnable"
+    status_payload = {
+        "ok": True,
+        "attention_queue": {
+            "items": [
+                {
+                    "goal_id": "runnable-goal",
+                    "waiting_on": "controller",
+                    "operator_question": "Resolve another lane's gate?",
+                }
+            ]
+        },
+    }
+    quota_payload = {
+        "ok": True,
+        "goal_id": "runnable-goal",
+        "state": "eligible",
+        "agent_identity": {"agent_id": agent_id, "registered": True},
+        "selected_todo": {"todo_id": "runnable-todo", "status": "open"},
+        "agent_lane_next_action": {
+            "todo_id": "runnable-todo",
+            "status": "open",
+        },
+        "user_todo_summary": {"open_count": 0, "gate_open_items": []},
+        "interaction_contract": {"user_channel": {"action_required": False}},
+    }
+    patch_manager_reads(
+        monkeypatch,
+        status_payload=status_payload,
+        quota_payloads={"runnable-goal": quota_payload},
+    )
+
+    payload = build_global_gates(tmp_path, agent_id=agent_id)
+
+    assert payload["gates"] == []
+    assert payload["lanes"] == []
+    assert payload["groups"]["blocked_work"] == []
+    assert payload["summary"]["open_gate_count"] == 0
+    assert payload["summary"]["blocked_lane_count"] == 0
+
+
+def test_global_gates_agent_scope_preserves_scoped_controller_gate(
+    monkeypatch, tmp_path
+) -> None:
+    agent_id = "codex-controller-gated"
+    status_payload = {
+        "ok": True,
+        "attention_queue": {
+            "items": [
+                {
+                    "goal_id": "controller-gated-goal",
+                    "waiting_on": "controller",
+                    "operator_question": "Resolve this scoped controller gate?",
+                }
+            ]
+        },
+    }
+    patch_manager_reads(
+        monkeypatch,
+        status_payload=status_payload,
+        quota_payloads={
+            "controller-gated-goal": controller_quota(
+                "controller-gated-goal", agent_id=agent_id
+            )
+        },
+    )
+
+    payload = build_global_gates(tmp_path, agent_id=agent_id)
+
+    assert [gate["goal_id"] for gate in payload["gates"]] == [
+        "controller-gated-goal"
+    ]
+    assert payload["gates"][0]["owner"] == "controller"
+    assert payload["lanes"][0]["status"] == "operator_gate"
+    assert payload["groups"]["blocked_work"] == payload["lanes"]
+
+
 def test_global_gates_filters_every_group_to_requested_agent(monkeypatch, tmp_path) -> None:
     status_payload = {
         "ok": True,


### PR DESCRIPTION
## Summary

- add a dedicated public-safe, read-only `loopx global-gates` projection and CLI command
- route `/loopx-global-gates` host surfaces through the focused CLI while leaving global todos and risks host-only
- document the focused protocol and add unit, CLI, host catalog, installer, and protocol regression coverage

## Why

`/loopx-global-gates` already existed as a host command intent, but it was routed through the broader `global-summary` fallback. This change gives it a focused implementation that reports only verified user/controller decisions and blocked work without exposing progress or risk history.

## Behavior

- resolves blocked todo IDs only through an exact `unblocks_todo_id` or a verified decision-scope relation, with goal fallback when causality is unproven
- preserves shared `user_or_controller` routing separately from the supported `user` or `controller` owner class
- filters every focused group to a requested registered agent and applies limits after normalization
- keeps JSON and Markdown output read-only and redacts local paths from error envelopes
- fails closed for unsupported CLI aliases and the summary-only `--time-range` flag

## Validation

- [x] `python -m pytest -q tests/test_summary_all.py` (`11 passed`)
- [x] global-manager CLI and protocol smokes
- [x] slash-command catalog, installer, and Codex host registry smokes
- [x] focused help and fail-closed CLI probes
- [x] Ruff and full strict-config mypy
- [x] ten-file public-boundary scan
- [x] standard premerge canary (`18/18` selected checks passed)

## Scope

This implements the GH-C61 `/loopx-global-gates` slice only. `/loopx-global-todos` and `/loopx-global-risks` remain host-defined for later work.
