### PR TITLE
docs: list NoKV and OpenViking as partners

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,15 @@ complete source map.
 - [Project History](docs/project/history.md)
 - [Name and Marks](TRADEMARKS.md)
 
+## Partner Projects
+
+LoopX welcomes collaboration with other open-source projects to build the
+long-running agent ecosystem. Our confirmed partners include:
+
+- [NoKV](https://github.com/NoKV-Lab/NoKV) - AI native distributed file system
+- [OpenViking](https://github.com/volcengine/OpenViking) - Self-evolving
+  context database for AI agents
+
 <a id="community--feedback"></a>
 
 ## Community and Feedback

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -400,6 +400,14 @@ loopx check \
 - [Project History](docs/project/history.md)
 - [Name and Marks](TRADEMARKS.md)
 
+## 合作伙伴项目
+
+LoopX 欢迎与其他开源项目协作，共建长程 Agent 生态。已确认的合作伙伴包括：
+
+- [NoKV](https://github.com/NoKV-Lab/NoKV) - AI 原生分布式文件系统
+- [OpenViking](https://github.com/volcengine/OpenViking) - 面向 AI Agent 的自进化
+  上下文数据库
+
 ## 用户群与反馈
 
 LoopX 还在早期，最需要真实长程 agent 项目里的反馈：控制面帮到了哪里、哪里太重，


### PR DESCRIPTION
## Summary
- add a Partner Projects section to the English README
- add the matching Chinese section
- link the official NoKV and OpenViking repositories

This mirrors the reciprocal public partner listing already present in OpenViking's README.

## Validation
- `python3 examples/public_entry/readme-demo-surface-smoke.py`
- `python3 examples/issue-fix-capability-guide-smoke.py`
- `python3 examples/docs-governance-smoke.py`
- `loopx check --scan-path README.md --scan-path README.zh-CN.md`
- `loopx canary premerge --from-git-diff` (13/13 passed; no manual holds)
- `git diff --check`

## Boundary
- only public README files changed
- no local/private state, credentials, generated logs, or internal links included