### PR TITLE
docs: list OpenViking first among partners

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,9 +446,9 @@ complete source map.
 LoopX welcomes collaboration with other open-source projects to build the
 long-running agent ecosystem. Our confirmed partners include:
 
-- [NoKV](https://github.com/NoKV-Lab/NoKV) - AI native distributed file system
 - [OpenViking](https://github.com/volcengine/OpenViking) - Self-evolving
   context database for AI agents
+- [NoKV](https://github.com/NoKV-Lab/NoKV) - AI native distributed file system
 
 <a id="community--feedback"></a>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -404,9 +404,9 @@ loopx check \
 
 LoopX 欢迎与其他开源项目协作，共建长程 Agent 生态。已确认的合作伙伴包括：
 
-- [NoKV](https://github.com/NoKV-Lab/NoKV) - AI 原生分布式文件系统
 - [OpenViking](https://github.com/volcengine/OpenViking) - 面向 AI Agent 的自进化
   上下文数据库
+- [NoKV](https://github.com/NoKV-Lab/NoKV) - AI 原生分布式文件系统
 
 ## 用户群与反馈
 


### PR DESCRIPTION
## Summary
- list OpenViking before NoKV in the English Partner Projects section
- apply the same ordering in the Chinese README
- keep all partner descriptions and links unchanged

## Validation
- `python3 examples/public_entry/readme-demo-surface-smoke.py`
- `python3 examples/issue-fix-capability-guide-smoke.py`
- `python3 examples/docs-governance-smoke.py`
- `loopx check --scan-path README.md --scan-path README.zh-CN.md`
- `loopx canary premerge --from-git-diff` (13/13 passed; no manual holds; self-merge allowed)
- `git diff --check`

## Boundary
- only partner ordering changed in the two public README files
- no runtime behavior, first-screen content, private state, credentials, generated logs, local paths, or internal links changed