### PR TITLE
fix(readme): publish verified star history

### DIFF
--- a/.github/workflows/frontstage-pages.yml
+++ b/.github/workflows/frontstage-pages.yml
@@ -2,9 +2,13 @@ name: Frontstage Pages
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "37 */6 * * *"
   pull_request:
     paths:
       - ".github/workflows/frontstage-pages.yml"
+      - "README.md"
+      - "README.zh-CN.md"
       - "apps/presentation/dashboard/**"
       - "apps/presentation/site/**"
       - "docs/**"
@@ -14,14 +18,18 @@ on:
       - "docs/assets/long-running-loop-ml-experiment-trajectory.png"
       - "examples/export-frontstage-share-bundle.mjs"
       - "examples/frontstage-share-bundle-smoke.mjs"
+      - "examples/readme-star-history-smoke.py"
       - "examples/goal-channel-frontstage-fixture.py"
       - "examples/showcase-catalog-smoke.py"
       - "examples/status.example.json"
+      - "scripts/render-star-history.py"
   push:
     branches:
       - main
     paths:
       - ".github/workflows/frontstage-pages.yml"
+      - "README.md"
+      - "README.zh-CN.md"
       - "apps/presentation/dashboard/**"
       - "apps/presentation/site/**"
       - "docs/**"
@@ -31,9 +39,11 @@ on:
       - "docs/assets/long-running-loop-ml-experiment-trajectory.png"
       - "examples/export-frontstage-share-bundle.mjs"
       - "examples/frontstage-share-bundle-smoke.mjs"
+      - "examples/readme-star-history-smoke.py"
       - "examples/goal-channel-frontstage-fixture.py"
       - "examples/showcase-catalog-smoke.py"
       - "examples/status.example.json"
+      - "scripts/render-star-history.py"
 
 permissions:
   actions: read
@@ -78,6 +88,9 @@ jobs:
       - name: Validate public showcase catalog
         run: python3 examples/showcase-catalog-smoke.py
 
+      - name: Validate README star history
+        run: python3 examples/readme-star-history-smoke.py
+
       - name: Validate public-safe frontstage bundle
         working-directory: apps/presentation/dashboard
         run: npm run smoke:frontstage-share-bundle
@@ -85,6 +98,41 @@ jobs:
       - name: Export Pages frontstage artifact
         working-directory: apps/presentation/dashboard
         run: npm run export:frontstage-share -- --base /loopx/ --out-dir ../../../output/frontstage-pages
+
+      - name: Fetch complete GitHub stargazer history
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            count_before="$(gh api "/repos/$GITHUB_REPOSITORY" --jq .stargazers_count)"
+            gh api --paginate --slurp \
+              --header "Accept: application/vnd.github.star+json" \
+              --header "X-GitHub-Api-Version: 2026-03-10" \
+              "/repos/$GITHUB_REPOSITORY/stargazers?per_page=100" \
+              > "$RUNNER_TEMP/loopx-stargazers.json"
+            count_after="$(gh api "/repos/$GITHUB_REPOSITORY" --jq .stargazers_count)"
+            fetched_count="$(jq '[.[][]] | length' "$RUNNER_TEMP/loopx-stargazers.json")"
+            if [[ "$count_before" == "$count_after" && "$fetched_count" == "$count_after" ]]; then
+              printf '%s\n' "$count_after" > "$RUNNER_TEMP/loopx-stargazers-count"
+              break
+            fi
+            if [[ "$attempt" == 3 ]]; then
+              echo "stargazer snapshot changed or was incomplete: before=$count_before fetched=$fetched_count after=$count_after" >&2
+              exit 1
+            fi
+            sleep 5
+          done
+
+      - name: Generate verified public star history
+        if: github.event_name != 'pull_request'
+        run: |
+          python3 scripts/render-star-history.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --input-json "$RUNNER_TEMP/loopx-stargazers.json" \
+            --expected-count "$(cat "$RUNNER_TEMP/loopx-stargazers-count")" \
+            --output output/frontstage-pages/site/site-assets/star-history.svg
 
       - name: Build documentation site
         run: mkdocs build --strict --site-dir output/frontstage-pages/site/docs

--- a/README.md
+++ b/README.md
@@ -511,7 +511,10 @@ surface.
 
 ## Star History
 
-[![LoopX Star History](https://star-history.dera.page/svg?repos=huangruiteng/loopx&type=date&legend=top-left)](https://star-history.dera.page/#huangruiteng/loopx&type=date&legend=top-left)
+<p align="center">
+  <a href="https://github.com/huangruiteng/loopx/stargazers"><img src="https://huangruiteng.github.io/loopx/site-assets/star-history.svg" alt="LoopX GitHub star history from verified snapshots" width="900"></a><br>
+  <sub>Generated every six hours from GitHub's official stargazer timestamps using a repository-authorized workflow. A snapshot is published only when the fetched rows match GitHub's current star count; GitHub's image cache may delay refreshes.</sub>
+</p>
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -463,7 +463,10 @@ Loop 的 terminal acceptance、补足独立采用与 outcome evidence，并打�
 
 ## Star 趋势
 
-[![LoopX Star 趋势](https://star-history.dera.page/svg?repos=huangruiteng/loopx&type=date&legend=top-left)](https://star-history.dera.page/#huangruiteng/loopx&type=date&legend=top-left)
+<p align="center">
+  <a href="https://github.com/huangruiteng/loopx/stargazers"><img src="https://huangruiteng.github.io/loopx/site-assets/star-history.svg" alt="LoopX GitHub Star 历史趋势，来自已校验快照" width="900"></a><br>
+  <sub>由仓库授权的 workflow 每 6 小时基于 GitHub 官方 stargazer 时间戳生成；仅当拉取条数与 GitHub 当前 Star 总数一致时发布。GitHub 图片缓存可能延迟刷新。</sub>
+</p>
 
 ## License
 

--- a/examples/frontstage-pages-workflow-smoke.py
+++ b/examples/frontstage-pages-workflow-smoke.py
@@ -25,6 +25,8 @@ def main() -> int:
 
     for needle in [
         "workflow_dispatch:",
+        "schedule:",
+        'cron: "37 */6 * * *"',
         "pull_request:",
         "branches:",
         "actions: read",
@@ -40,6 +42,14 @@ def main() -> int:
         "apps/presentation/site/**",
         "examples/showcase-catalog-smoke.py",
         "python3 examples/showcase-catalog-smoke.py",
+        "examples/readme-star-history-smoke.py",
+        "python3 examples/readme-star-history-smoke.py",
+        "scripts/render-star-history.py",
+        "application/vnd.github.star+json",
+        "X-GitHub-Api-Version: 2026-03-10",
+        'jq \'[.[][]] | length\'',
+        "--expected-count",
+        "output/frontstage-pages/site/site-assets/star-history.svg",
         "npm run smoke:frontstage-share-bundle",
         "npm run export:frontstage-share -- --base /loopx/ --out-dir ../../../output/frontstage-pages",
         "actions/configure-pages@v6",

--- a/examples/readme-star-history-smoke.py
+++ b/examples/readme-star-history-smoke.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Validate the deterministic README star-history generation path."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "render-star-history.py"
+IMAGE_URL = "https://huangruiteng.github.io/loopx/site-assets/star-history.svg"
+
+
+def _fixture_count(fixture: object) -> int:
+    if not isinstance(fixture, list):
+        return 0
+    return sum(len(item) if isinstance(item, list) else 1 for item in fixture)
+
+
+def _render(
+    fixture: object,
+    output: Path,
+    *,
+    expected_count: int | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    fixture_path = output.with_suffix(".json")
+    fixture_path.write_text(json.dumps(fixture), encoding="utf-8")
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            "huangruiteng/loopx",
+            "--input-json",
+            str(fixture_path),
+            "--expected-count",
+            str(_fixture_count(fixture) if expected_count is None else expected_count),
+            "--as-of",
+            "2026-08-06",
+            "--output",
+            str(output),
+        ],
+        check=check,
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-star-history-") as tmp:
+        temp = Path(tmp)
+        output = temp / "history.svg"
+        _render(
+            [
+                [
+                    {"starred_at": "2026-05-01T00:00:00Z"},
+                    {"starred_at": "2026-05-01T12:00:00Z"},
+                ],
+                [
+                    {"starred_at": "2026-07-15T08:30:00Z"},
+                    {"starred_at": "2026-08-01T09:45:00Z"},
+                ],
+            ],
+            output,
+        )
+        svg = output.read_text(encoding="utf-8")
+        root = ET.fromstring(svg)
+        assert root.tag.endswith("svg")
+        assert 'role="img" aria-labelledby="title desc"' in svg
+        assert "@media (prefers-color-scheme: dark)" in svg
+        assert "huangruiteng/loopx · 4 stars · updated 2026-08-06" in svg
+        assert "<script" not in svg.lower()
+        assert "http://" not in svg.replace("http://www.w3.org/2000/svg", "")
+        assert "https://" not in svg
+
+        empty_output = temp / "empty.svg"
+        _render([], empty_output)
+        empty_svg = empty_output.read_text(encoding="utf-8")
+        assert "huangruiteng/loopx · 0 stars · updated 2026-08-06" in empty_svg
+
+        mismatch = _render(
+            [{"starred_at": "2026-08-01T09:45:00Z"}],
+            temp / "incomplete.svg",
+            expected_count=2,
+            check=False,
+        )
+        assert mismatch.returncode != 0
+        assert "snapshot is incomplete: expected 2, got 1" in mismatch.stderr
+
+    readme_sections = {
+        ROOT / "README.md": ("## Current Status", "## Star History", "## License"),
+        ROOT / "README.zh-CN.md": ("## 当前状态", "## Star 趋势", "## License"),
+    }
+    for readme, sections in readme_sections.items():
+        text = readme.read_text(encoding="utf-8")
+        assert text.count(IMAGE_URL) == 1, readme
+        assert "https://github.com/huangruiteng/loopx/stargazers" in text, readme
+        assert "star-history.dera.page" not in text, readme
+        positions = [text.index(section) for section in sections]
+        assert positions == sorted(positions), (readme, sections)
+        assert "\n## " not in text[positions[-1] + len(sections[-1]) :], readme
+
+    print("readme star history smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render-star-history.py
+++ b/scripts/render-star-history.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Render a public GitHub stargazer timeline as a self-hosted SVG."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from collections import Counter
+from datetime import date, datetime, timedelta, timezone
+from html import escape
+from pathlib import Path
+from typing import Any
+
+
+REPO_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+
+def _parse_date(value: str, *, field: str) -> date:
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).date()
+    except ValueError as exc:
+        raise ValueError(f"{field} must be an ISO-8601 timestamp or date") from exc
+
+
+def _load_stargazers(path: Path) -> list[date]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        raise ValueError("stargazer input must be a JSON array")
+    rows: list[Any] = []
+    for item in payload:
+        rows.extend(item if isinstance(item, list) else [item])
+    dates: list[date] = []
+    for index, item in enumerate(rows):
+        if not isinstance(item, dict) or not isinstance(item.get("starred_at"), str):
+            raise ValueError(f"stargazer row {index} must contain starred_at")
+        dates.append(_parse_date(item["starred_at"], field="starred_at"))
+    return dates
+
+
+def _nice_ceiling(value: int) -> int:
+    if value <= 1:
+        return 1
+    rough_step = value / 4
+    magnitude = 10 ** math.floor(math.log10(rough_step))
+    scaled_step = rough_step / magnitude
+    factor = next(
+        candidate for candidate in (1, 2, 2.5, 5, 10) if scaled_step <= candidate
+    )
+    step = factor * magnitude
+    return int(math.ceil(value / step) * step)
+
+
+def _timeline(stars: list[date], *, as_of: date) -> list[tuple[date, int]]:
+    counts = Counter(star for star in stars if star <= as_of)
+    if not counts:
+        return [(as_of - timedelta(days=30), 0), (as_of, 0)]
+    total = 0
+    points: list[tuple[date, int]] = []
+    for day in sorted(counts):
+        total += counts[day]
+        points.append((day, total))
+    if points[-1][0] < as_of:
+        points.append((as_of, total))
+    return points
+
+
+def render_svg(repo: str, stars: list[date], *, as_of: date) -> str:
+    points = _timeline(stars, as_of=as_of)
+    total = points[-1][1]
+    start = points[0][0]
+    span_days = max((as_of - start).days, 1)
+    width, height = 960, 420
+    left, right, top, bottom = 78, 28, 72, 62
+    plot_width = width - left - right
+    plot_height = height - top - bottom
+    y_max = _nice_ceiling(total)
+
+    def x_for(day: date) -> float:
+        return left + ((day - start).days / span_days) * plot_width
+
+    def y_for(value: int) -> float:
+        return top + plot_height - (value / y_max) * plot_height
+
+    chart_points = [(x_for(day), y_for(value)) for day, value in points]
+    line = " ".join(f"{x:.1f},{y:.1f}" for x, y in chart_points)
+    area = (
+        f"{left},{top + plot_height} "
+        + line
+        + f" {left + plot_width},{top + plot_height}"
+    )
+
+    y_grid: list[str] = []
+    for index in range(5):
+        value = round(y_max * index / 4)
+        y = y_for(value)
+        y_grid.append(
+            f'<line x1="{left}" y1="{y:.1f}" x2="{left + plot_width}" y2="{y:.1f}" class="grid"/>'
+            f'<text x="{left - 14}" y="{y + 4:.1f}" class="axis" text-anchor="end">{value}</text>'
+        )
+
+    x_labels: list[str] = []
+    for index in range(5):
+        day = start + timedelta(days=round(span_days * index / 4))
+        x = x_for(day)
+        anchor = "start" if index == 0 else "end" if index == 4 else "middle"
+        x_labels.append(
+            f'<text x="{x:.1f}" y="{top + plot_height + 34}" class="axis" text-anchor="{anchor}">{day:%Y-%m-%d}</text>'
+        )
+
+    safe_repo = escape(repo)
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" role="img" aria-labelledby="title desc">
+  <title id="title">{safe_repo} GitHub star history</title>
+  <desc id="desc">Cumulative public GitHub stars through {as_of.isoformat()}: {total}.</desc>
+  <style>
+    .background {{ fill: #ffffff; }}
+    .grid {{ stroke: #dbe5f3; stroke-width: 1; }}
+    .axis {{ fill: #65748a; font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }}
+    .title {{ fill: #0d1b2f; font: 600 22px ui-sans-serif, system-ui, sans-serif; }}
+    .meta {{ fill: #65748a; font: 13px ui-sans-serif, system-ui, sans-serif; }}
+    .area {{ fill: url(#area-gradient); }}
+    .line {{ fill: none; stroke: #2f80ed; stroke-width: 4; stroke-linecap: round; stroke-linejoin: round; }}
+    .point {{ fill: #ffffff; stroke: #2f80ed; stroke-width: 3; }}
+    @media (prefers-color-scheme: dark) {{
+      .background {{ fill: #07101f; }}
+      .grid {{ stroke: #21324a; }}
+      .axis, .meta {{ fill: #91a2b9; }}
+      .title {{ fill: #e8eef7; }}
+      .point {{ fill: #07101f; }}
+    }}
+  </style>
+  <defs>
+    <linearGradient id="area-gradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2f80ed" stop-opacity="0.32"/>
+      <stop offset="100%" stop-color="#2f80ed" stop-opacity="0.03"/>
+    </linearGradient>
+  </defs>
+  <rect width="{width}" height="{height}" rx="12" class="background"/>
+  <text x="{left}" y="36" class="title">GitHub Star History</text>
+  <text x="{left}" y="57" class="meta">{safe_repo} · {total} stars · updated {as_of.isoformat()}</text>
+  {''.join(y_grid)}
+  {''.join(x_labels)}
+  <polygon points="{area}" class="area"/>
+  <polyline points="{line}" class="line"/>
+  <circle cx="{chart_points[-1][0]:.1f}" cy="{chart_points[-1][1]:.1f}" r="5" class="point"/>
+</svg>
+'''
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--input-json", type=Path, required=True)
+    parser.add_argument("--expected-count", type=int, required=True)
+    parser.add_argument("--as-of")
+    args = parser.parse_args()
+
+    if not isinstance(args.repo, str) or not REPO_PATTERN.fullmatch(args.repo):
+        parser.error("--repo must be an owner/name GitHub repository")
+    as_of = (
+        _parse_date(args.as_of, field="as_of")
+        if args.as_of
+        else datetime.now(timezone.utc).date()
+    )
+    stars = _load_stargazers(args.input_json)
+    if args.expected_count < 0:
+        parser.error("--expected-count must be non-negative")
+    if len(stars) != args.expected_count:
+        parser.error(
+            f"stargazer snapshot is incomplete: expected {args.expected_count}, "
+            f"got {len(stars)}"
+        )
+    future_dates = [star for star in stars if star > as_of]
+    if future_dates:
+        parser.error(
+            f"stargazer snapshot contains {len(future_dates)} future timestamp(s)"
+        )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(render_svg(args.repo, stars, as_of=as_of), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- replace the third-party README chart with a LoopX-hosted deterministic SVG
- fetch complete `starred_at` rows through the repository-authorized GitHub Actions token every six hours
- publish only when the fetched row count matches stable GitHub counts before and after pagination
- keep raw stargazer rows in the Actions temporary directory; publish only date-level aggregate counts
- restore focused renderer and workflow regression smokes

## Diagnosis
At verification time GitHub reported 3,223 stars while the cached third-party SVG was still scaled around 2k and advertised a 24-hour cache lifetime. LoopX recently gained hundreds of stars per day, so that cache window creates a material display error. GitHub also restricted stargazer-list access in July 2026 to repository admins and collaborators, making unauthorised third-party history fetches unreliable.

References:
- https://docs.github.com/en/rest/activity/starring
- https://www.star-history.com/blog/github-stargazer-api-restriction/

## Validation
- live official snapshot: count before = fetched rows = count after = 3,223
- rendered SVG readback: `huangruiteng/loopx · 3223 stars · updated 2026-08-07`
- `python3 examples/readme-star-history-smoke.py`
- `python3 examples/frontstage-pages-workflow-smoke.py`
- `python3 examples/public_entry/readme-demo-surface-smoke.py`
- `python3 examples/issue-fix-capability-guide-smoke.py`
- `python3 examples/docs-governance-smoke.py`
- Python compile checks for all changed Python files
- `loopx check` over all six changed paths
- `loopx canary premerge --from-git-diff` (16/16 passed, no manual holds)
- `git diff --check`

`actionlint` was not installed locally; the repository workflow contract smoke covers the new schedule, API media type/version, exact-count gate, renderer invocation, and output path.

## Residual behavior
- GitHub scheduled workflows may be delayed; the prior verified Pages deployment remains live when a fetch is incomplete or changes during pagination.
- GitHub image caching can still delay README refreshes, which is stated under the chart. The source Pages asset has a much shorter cache lifetime than the replaced 24-hour third-party response.