### PR TITLE
security: add reporting policy and dependency review

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,24 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are developed on `main` and released in the latest published
+version of LoopX. Earlier releases are not maintained as separate security
+branches; users should upgrade to the latest release before reporting a
+version-specific regression.
+
+## Reporting A Vulnerability
+
+Please report suspected vulnerabilities through
+[GitHub Private Vulnerability Reporting](https://github.com/huangruiteng/loopx/security/advisories/new).
+Do not open a public issue, discussion, or pull request for an unpatched
+vulnerability.
+
+A useful report includes:
+
+- the affected LoopX version or commit;
+- the affected surface and expected security boundary;
+- minimal reproduction steps or a proof of concept;
+- the potential impact and any known mitigations; and
+- a way to contact the reporter for follow-up.
+
+Do not include credentials, private user data, or unrelated internal material.
+If a reproduction needs sensitive evidence, describe how the maintainers can
+obtain it through the private report instead of attaching it publicly.
+
+The maintainers aim to acknowledge a report within five business days. After
+triage, they will coordinate scope, remediation, release, and disclosure with
+the reporter. Please allow time for a fix and advisory before publishing
+technical details that would put users at risk.
+
+## Scope
+
+This policy covers LoopX source code, distributed packages, installation
+paths, and repository-owned automation. Vulnerabilities that exist only in an
+upstream dependency should normally be reported to that project; report them
+to LoopX as well when LoopX's usage or configuration creates additional risk.


### PR DESCRIPTION
## Summary

- add a public `SECURITY.md` that routes unpatched vulnerability reports to GitHub Private Vulnerability Reporting
- add a read-only dependency review workflow for every pull request
- pin the official checkout and dependency review actions to reviewed release commits

Repository settings enabled separately and verified before this PR:

- Private Vulnerability Reporting
- vulnerability alerts and the dependency graph
- Dependabot Security Updates

The repository settings are active now. The dependency review check becomes active after this workflow reaches `main`.

## Security boundary

- workflow permissions are limited to `contents: read`
- no `pull_request_target`, PR comment permission, automatic merge, or version-update policy
- security report details stay in GitHub's private advisory channel rather than public issues

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/dependency-review.yml`
- `loopx check --scan-path SECURITY.md --scan-path .github/workflows/dependency-review.yml`
- GitHub API readback for private reporting, vulnerability alerts, automated security fixes, and dependency-graph SBOM availability
- `git diff --check origin/main...HEAD`
- `loopx canary premerge --from-git-diff --goal-id loopx-meta --tier standard`: passed, 0 failures, 0 warnings, 0 manual holds
- exact-scope change-quality receipt: `cqr_789dddb1a6aad30a7153`

## Merge decision

Ready for maintainer review. This PR is intentionally not self-merged because it introduces a repository security workflow.
