### PR TITLE
fix(auto-research): replace raw exception string with public error code

### DIFF
--- a/examples/decentralized-auto-research-frontier-smoke.py
+++ b/examples/decentralized-auto-research-frontier-smoke.py
@@ -117,7 +117,33 @@ def main() -> None:
     assert blocked.returncode == 1, blocked.stdout
     blocked_payload = json.loads(blocked.stdout)
     assert blocked_payload["ok"] is False, blocked_payload
+    assert blocked_payload["error_code"] == "auto_research_invalid_input", blocked_payload
     assert "public alias" in blocked_payload["error"], blocked_payload
+
+    missing_path = f"{bad_path}.missing"
+    missing_args = [
+        "auto-research",
+        "frontier",
+        "--fixture",
+        missing_path,
+        "--agent-id",
+        "codex-side-bypass",
+    ]
+    missing_json = run_cli(
+        ["--format", "json", *missing_args],
+        check=False,
+    )
+    assert missing_json.returncode == 1, missing_json.stdout
+    missing_payload = json.loads(missing_json.stdout)
+    assert missing_payload["error_code"] == "auto_research_io_failed", missing_payload
+    assert missing_payload["error"] == "Auto Research could not access a required resource.", missing_payload
+    assert missing_path not in missing_json.stdout, missing_json.stdout
+
+    missing_markdown = run_cli(["--format", "markdown", *missing_args], check=False)
+    assert missing_markdown.returncode == 1, missing_markdown.stdout
+    assert "error_code: `auto_research_io_failed`" in missing_markdown.stdout
+    assert "error: `Auto Research could not access a required resource.`" in missing_markdown.stdout
+    assert missing_path not in missing_markdown.stdout, missing_markdown.stdout
 
     docs = (REPO_ROOT / "docs/reference/protocols/decentralized-auto-research-state-v0.md").read_text(
         encoding="utf-8"

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -1303,7 +1303,7 @@ def handle_auto_research_command(
                 "`worker-turn`, `worker-loop`, `demo-supervisor`, `demo-e2e`, "
                 "or `start` subcommand"
             )
-    except Exception as exc:
+    except Exception:
         payload = {
             "ok": False,
             "mode": "auto-research",

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -1307,7 +1307,7 @@ def handle_auto_research_command(
         payload = {
             "ok": False,
             "mode": "auto-research",
-            "error": str(exc),
+            "error_code": "AUTO_RESEARCH_COMMAND_FAILED",
         }
     print_payload(payload, output_format(args, "auto_research_format"), render_auto_research_markdown)
     return 0 if payload.get("ok") else 1

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -43,6 +43,7 @@ from ...control_plane.agents.multi_agent.visible_launch_policy import (
     resolve_codex_trust_workspace,
     resolve_visible_launch_policy,
 )
+from ...control_plane.runtime.public_safety import public_safe_compact_text
 from ...history import load_registry
 from ...paths import resolve_runtime_root
 from ...quota import build_quota_should_run
@@ -62,6 +63,9 @@ AddFormat = Callable[[argparse.ArgumentParser], None]
 
 AUTO_RESEARCH_DEMO_GOAL_PREFIX = "loopx-auto-research-demo"
 AUTO_RESEARCH_START_AGENT_ID = "auto-research-operator"
+AUTO_RESEARCH_COMMAND_FAILED_ERROR_CODE = "auto_research_command_failed"
+AUTO_RESEARCH_INVALID_INPUT_ERROR_CODE = "auto_research_invalid_input"
+AUTO_RESEARCH_IO_FAILED_ERROR_CODE = "auto_research_io_failed"
 AUTO_RESEARCH_SUBCOMMANDS = frozenset(
     {
         "append-evidence",
@@ -76,6 +80,31 @@ AUTO_RESEARCH_SUBCOMMANDS = frozenset(
         "worker-turn",
     }
 )
+
+
+def _public_auto_research_error(exc: Exception) -> tuple[str, str]:
+    """Project an internal exception into a stable, public-safe CLI error."""
+
+    if isinstance(exc, json.JSONDecodeError):
+        return (
+            AUTO_RESEARCH_INVALID_INPUT_ERROR_CODE,
+            "Auto Research input must be valid JSON.",
+        )
+    if isinstance(exc, OSError):
+        return (
+            AUTO_RESEARCH_IO_FAILED_ERROR_CODE,
+            "Auto Research could not access a required resource.",
+        )
+    if isinstance(exc, ValueError):
+        public_message = public_safe_compact_text(str(exc), limit=220)
+        return (
+            AUTO_RESEARCH_INVALID_INPUT_ERROR_CODE,
+            public_message or "Auto Research input is invalid.",
+        )
+    return (
+        AUTO_RESEARCH_COMMAND_FAILED_ERROR_CODE,
+        "Auto Research command failed unexpectedly.",
+    )
 
 
 def rewrite_auto_research_question_argv(argv: list[str]) -> list[str]:
@@ -1303,11 +1332,13 @@ def handle_auto_research_command(
                 "`worker-turn`, `worker-loop`, `demo-supervisor`, `demo-e2e`, "
                 "or `start` subcommand"
             )
-    except Exception:
+    except Exception as exc:
+        error_code, public_error = _public_auto_research_error(exc)
         payload = {
             "ok": False,
             "mode": "auto-research",
-            "error_code": "AUTO_RESEARCH_COMMAND_FAILED",
+            "error_code": error_code,
+            "error": public_error,
         }
     print_payload(payload, output_format(args, "auto_research_format"), render_auto_research_markdown)
     return 0 if payload.get("ok") else 1

--- a/loopx/capabilities/auto_research/human_view.py
+++ b/loopx/capabilities/auto_research/human_view.py
@@ -15,6 +15,15 @@ from .user_contract import AUTO_RESEARCH_USER_CONTRACT_SCHEMA_VERSION
 AUTO_RESEARCH_DEMO_E2E_SCHEMA_VERSION = "auto_research_demo_e2e_result_v0"
 
 
+def _render_failure(payload: dict[str, object]) -> str:
+    lines = ["# LoopX Auto Research", "", "- ok: `False`"]
+    if payload.get("error_code"):
+        lines.append(f"- error_code: `{payload.get('error_code')}`")
+    if payload.get("error"):
+        lines.append(f"- error: `{payload.get('error')}`")
+    return "\n".join(lines) + "\n"
+
+
 def _join_or_none(values: object) -> str:
     if isinstance(values, list) and values:
         return ", ".join(str(item) for item in values)
@@ -302,7 +311,7 @@ def _render_user_contract(payload: dict[str, object]) -> str:
 
 def render_auto_research_projection_markdown(payload: dict[str, object]) -> str:
     if not payload.get("ok"):
-        return f"# LoopX Auto Research\n\n- ok: `False`\n- error: `{payload.get('error')}`\n"
+        return _render_failure(payload)
     if "frontier" not in payload or "evidence_graph" not in payload:
         return _render_generic(payload)
     frontier = _dict_value(payload, "frontier")
@@ -666,7 +675,7 @@ def _render_generic(payload: dict[str, object]) -> str:
 
 def render_auto_research_markdown(payload: dict[str, object]) -> str:
     if not payload.get("ok"):
-        return f"# LoopX Auto Research\n\n- ok: `False`\n- error: `{payload.get('error')}`\n"
+        return _render_failure(payload)
     schema = payload.get("schema_version")
     if schema == "auto_research_worker_turn_v0":
         return _render_worker_turn(payload)


### PR DESCRIPTION
The top-level Auto Research CLI handler previously returned `str(exc)` in its public payload. Exceptions such as `FileNotFoundError` can contain local filesystem paths, while expected validation failures carry useful public-safe guidance.

## Summary

- classify JSON, I/O, validation, and unexpected failures into stable public error codes;
- preserve actionable validation details after the repository's public-safety filter;
- retain the compatible `error` field alongside `error_code`;
- render both fields in JSON and Markdown instead of producing `error: None`;
- cover malformed public evidence and missing-resource paths without exposing the submitted path.

## Validation

- [x] `python3 examples/decentralized-auto-research-frontier-smoke.py`
- [x] `python3 examples/auto-research-user-contract-entry-smoke.py`
- [x] `python3 examples/auto-research-start-markdown-commands-smoke.py`
- [x] `python3 examples/auto-research-rollout-readpath-smoke.py`
- [x] focused Ruff fatal-error checks for the three changed Python files
- [x] `loopx canary premerge --from-git-diff --git-diff-base b0c8e31569365e915efce36924b46a1128d66990 --tier standard`

The premerge gate selected the Auto Research kernel/frontier smokes, maintainability ratchet, Python compilation, diff hygiene, and public/private boundary scan. All passed with no warnings or manual holds, and the gate reported `self_merge_allowed=true`.

## Boundary Checklist

- [x] No credentials, private state, raw traces, internal links, or local machine paths are committed.
- [x] Failure output preserves public-safe diagnostics without returning raw I/O exceptions.
- [x] The change remains scoped to the Auto Research CLI error boundary and its durable smoke coverage.
