### PR TITLE
docs: add community health and issue intake paths

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,102 @@
+name: Bug Report
+description: Report reproducible incorrect or unexpected LoopX behavior.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve LoopX. Do not report an unpatched security vulnerability here; use [Private Vulnerability Reporting](https://github.com/huangruiteng/loopx/security/advisories/new). Remove credentials, private data, raw agent sessions, internal links, and local runtime state before submitting.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight
+      options:
+        - label: I searched existing issues and discussions for this behavior.
+          required: true
+        - label: This report is not an unpatched security vulnerability.
+          required: true
+        - label: The report and attachments contain no credentials or private/internal material.
+          required: true
+
+  - type: dropdown
+    id: issue-origin
+    attributes:
+      label: Issue origin
+      description: How was this behavior identified?
+      options:
+        - Observed or reproduced in a real environment
+        - Inferred by an AI agent and not yet observed or reproduced
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: LoopX version or commit
+      placeholder: "For example: v0.4.2 or af85aff"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: host
+    attributes:
+      label: Host or runtime surface
+      options:
+        - Codex App
+        - Codex CLI
+        - Claude Code
+        - OpenCode
+        - Custom or external worker
+        - Not host-specific
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Problem
+      description: Describe the incorrect behavior and why it matters.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Minimal reproduction
+      description: Provide the smallest public-safe sequence that reproduces the problem.
+      placeholder: |
+        1. Install or check out ...
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Sanitized diagnostics
+      description: Add relevant `loopx doctor`, error, or environment details after removing local paths, credentials, private state, and unrelated logs.
+      render: shell
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add public links, screenshots, or related issues when useful.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,14 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
+  - name: Ask a question
+    url: https://github.com/huangruiteng/loopx/discussions/categories/q-a
+    about: Get community help with usage, configuration, or design questions.
+  - name: Discord community
+    url: https://discord.gg/XmGgQyCFZd
+    about: Join informal onboarding, workflow, and show-and-tell conversations.
+  - name: Report a security vulnerability
+    url: https://github.com/huangruiteng/loopx/security/advisories/new
+    about: Privately report suspected unpatched vulnerabilities. Do not open a public issue.
   - name: Contributor task board
     url: https://github.com/huangruiteng/loopx/blob/main/CONTRIBUTOR_TASKS.md
     about: Start here for public, claimable work.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,96 @@
+name: Feature Request
+description: Propose a concrete LoopX product or documentation improvement.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the problem and smallest useful outcome before prescribing a large implementation. Keep examples public-safe and free of credentials, private state, and internal material.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight
+      options:
+        - label: I searched existing issues, discussions, and contributor tasks for this request.
+          required: true
+        - label: This request and its attachments contain no credentials or private/internal material.
+          required: true
+
+  - type: dropdown
+    id: request-origin
+    attributes:
+      label: Request origin
+      description: What evidence motivates this request?
+      options:
+        - Observed need in a real workflow
+        - Feedback from an assisted pilot or user
+        - Inferred by an AI agent and not yet observed
+        - Design or maintenance improvement
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or unmet outcome
+      description: What is difficult today, for whom, and what is the failure cost?
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: Show the workflow in which this capability would be used.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-outcome
+    attributes:
+      label: Proposed outcome
+      description: Describe the observable behavior you want, without requiring one implementation.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Product area
+      options:
+        - Goal, todo, and gate lifecycle
+        - Quota, scheduler, and heartbeat
+        - Issue-fix or another domain capability
+        - Host and runtime integration
+        - Dashboard and operator surfaces
+        - Extensions and external integrations
+        - Documentation and onboarding
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What existing command, extension, workflow, or smaller change did you consider?
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and non-goals
+      placeholder: |
+        In scope:
+        - ...
+
+        Out of scope:
+        - ...
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I may be able to help design, implement, document, or validate this request.

--- a/.github/ISSUE_TEMPLATE/show_and_tell.yml
+++ b/.github/ISSUE_TEMPLATE/show_and_tell.yml
@@ -1,0 +1,67 @@
+name: Show and Tell / Adoption
+description: Share a public-safe LoopX workflow, result, integration, or adoption story.
+title: "[Showcase]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Share what really ran, what LoopX changed, and what remains limited. This is not an endorsement channel. Remove private data, credentials, raw agent sessions, internal links, and sensitive logs.
+
+  - type: dropdown
+    id: adoption-stage
+    attributes:
+      label: Adoption stage
+      options:
+        - Experiment or demo
+        - Maintainer dogfood
+        - Assisted pilot
+        - Independent adoption
+        - Realized value in a continuing workflow
+    validations:
+      required: true
+
+  - type: textarea
+    id: workflow
+    attributes:
+      label: Project or workflow
+      description: Describe the public-safe task, runtime, and operating context.
+    validations:
+      required: true
+
+  - type: textarea
+    id: intervention
+    attributes:
+      label: How LoopX was used
+      description: Which lifecycle, control-plane, capability, or integration behavior mattered?
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Outcome and evidence
+      description: State the observed result and link inspectable artifacts, commands, or public evidence when available.
+    validations:
+      required: true
+
+  - type: textarea
+    id: limitations
+    attributes:
+      label: Limitations and remaining gaps
+      description: What was assisted, not independently reproduced, experimental, or still unresolved?
+    validations:
+      required: true
+
+  - type: textarea
+    id: artifacts
+    attributes:
+      label: Reproduction or artifacts
+      description: Add public repositories, docs, screenshots, or minimal steps that others can inspect or try.
+
+  - type: checkboxes
+    id: permission
+    attributes:
+      label: Permission and privacy
+      options:
+        - label: I have permission to share this material publicly and removed credentials, private data, internal links, and raw agent/runtime state.
+          required: true

--- a/COMMUNICATIONS.md
+++ b/COMMUNICATIONS.md
@@ -1,0 +1,40 @@
+# LoopX Communications
+
+This document identifies LoopX's official publication sources and separates
+them from informal community conversation.
+
+## Official Publication Sources
+
+- [GitHub Releases](https://github.com/huangruiteng/loopx/releases) is the
+  authoritative source for published versions and release notes.
+- [GitHub Discussions: Announcements](https://github.com/huangruiteng/loopx/discussions/categories/announcements)
+  is the authoritative source for project announcements that are not tied to
+  one release.
+- [GitHub Security Advisories](https://github.com/huangruiteng/loopx/security/advisories)
+  is the authoritative source for coordinated vulnerability disclosures.
+
+Repository documentation describes the current product and contributor
+contracts. Issues and pull requests are public work records, not general
+announcement channels.
+
+## Community Channels
+
+The [LoopX Discord community](https://discord.gg/XmGgQyCFZd), Lark group, and
+WeChat contact listed in the README are informal places to ask questions,
+compare workflows, and help other users. Messages in those channels do not
+replace a release, security advisory, merged repository contract, or published
+announcement.
+
+## Account Authenticity
+
+LoopX does not currently designate any standalone social-media account as an
+official publication source. An account that is not explicitly listed in this
+document is not an official LoopX account. Reposts, screenshots, personal
+accounts, and third-party communities may be useful, but they are not
+authoritative project communications.
+
+When sources conflict, prefer the official GitHub source for the relevant
+topic and ask for clarification in a public
+[Discussion](https://github.com/huangruiteng/loopx/discussions).
+
+For help choosing the right channel, see [SUPPORT.md](SUPPORT.md).

--- a/README.md
+++ b/README.md
@@ -464,6 +464,9 @@ gates or handoffs disappeared from view.
 - Join the [Discord community](https://discord.gg/XmGgQyCFZd), or use Lark or
   WeChat below.
 
+See [Support](SUPPORT.md) for channel routing and service boundaries, and
+[Communications](COMMUNICATIONS.md) for official publication sources.
+
 <p align="center">
   <a href="docs/assets/loopx-lark-developer-group.png"><img src="docs/assets/loopx-lark-developer-group.png" alt="LoopX Lark developer group QR code" width="280"></a>
   <a href="docs/assets/loopx-wechat-contact.png"><img src="docs/assets/loopx-wechat-contact.png" alt="LoopX WeChat contact QR code" width="220"></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -419,6 +419,9 @@ LoopX 还在早期，最需要真实长程 agent 项目里的反馈：控制面�
 - 参与社区讨论：可加入 [Discord 社区](https://discord.gg/XmGgQyCFZd)，也可在
   下方直接加入飞书群或通过微信申请入群。
 
+渠道分工与支持边界见 [Support](SUPPORT.md)，官方发布源见
+[Communications](COMMUNICATIONS.md)。
+
 <p align="center">
   <a href="docs/assets/loopx-lark-developer-group.png"><img src="docs/assets/loopx-lark-developer-group.png" alt="LoopX 飞书开发群二维码" width="280"></a>
   <a href="docs/assets/loopx-wechat-contact.png"><img src="docs/assets/loopx-wechat-contact.png" alt="LoopX 微信联系人二维码" width="220"></a>

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,39 @@
+# LoopX Support
+
+LoopX is an open-source project supported on a best-effort community basis.
+The project does not provide a response-time or resolution SLA, and it does not
+currently provide commercial support through this repository or its community
+channels.
+
+## Choose A Channel
+
+| Need | Channel | Use it for |
+| --- | --- | --- |
+| Reproducible bug or installation failure | [GitHub Issues](https://github.com/huangruiteng/loopx/issues/new/choose) | Public, sanitized reproduction steps for behavior that can be investigated or fixed in the repository. |
+| Feature request | [GitHub Issues](https://github.com/huangruiteng/loopx/issues/new/choose) | A concrete problem, desired outcome, alternatives, and the smallest useful product change. |
+| Usage or design question | [GitHub Discussions: Q&A](https://github.com/huangruiteng/loopx/discussions/categories/q-a) | Questions, configuration help, and design discussion that do not yet identify a repository bug. |
+| Security vulnerability | [Private Vulnerability Reporting](https://github.com/huangruiteng/loopx/security/advisories/new) | Suspected unpatched vulnerabilities. Do not post them in an issue, discussion, or chat. See [SECURITY.md](SECURITY.md). |
+| Informal peer help | [Discord](https://discord.gg/XmGgQyCFZd) | Onboarding, workflow comparison, show and tell, and community conversation. Chat is not an authoritative support or release record. |
+
+Public contributor work belongs on the
+[Contributor Task Board](CONTRIBUTOR_TASKS.md) or in the contributor-task issue
+form. Pull requests should follow [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Make A Useful Request
+
+For a bug or support question, include the LoopX version or commit, host/runtime
+surface, command or workflow, expected behavior, actual behavior, and the
+smallest public-safe reproduction you can provide. Search existing issues and
+discussions first.
+
+Remove credentials, private repository content, raw agent sessions, local
+runtime state, internal links, and sensitive logs before posting. If the
+material cannot be made public-safe, do not upload it to a public channel.
+
+Maintainers and community members may redirect requests to a better channel,
+close duplicates, or ask for a smaller reproduction. A public request does not
+guarantee investigation, a fix, a release date, or suitability for a
+production deployment.
+
+Official communication sources and account-authenticity rules are documented
+in [COMMUNICATIONS.md](COMMUNICATIONS.md).


### PR DESCRIPTION
## Summary

- add `COMMUNICATIONS.md` to define GitHub Releases, Discussions Announcements, and Security Advisories as the official publication sources, while treating unlisted social accounts and community chat as non-authoritative
- add `SUPPORT.md` to route bugs, feature requests, Q&A, security reports, and informal Discord help, with explicit best-effort, no-SLA, and no-commercial-support boundaries
- add structured Bug Report, Feature Request, and Show and Tell / Adoption issue forms; disable blank issues for contributors and add question, Discord, security, and contributor contact links
- link the new policies from the existing English and Chinese community sections without changing the README first screen

The issue-form structure borrows the useful public pattern of distinguishing real observations from AI-inferred reports, while keeping all fields specific to LoopX's public product and privacy boundaries.

## Validation

- custom GitHub issue-form schema check: 3 forms and chooser passed required keys, allowed input types, unique ids/labels/options, existing label, contact-link, and blank-issue checks
- public link readback: Releases, Discussions Announcements and Q&A, Security Advisories/private reporting, issue chooser, and the existing Discord invite
- `loopx check` across all 8 changed files: 0 errors, 0 warnings
- `git diff --cached --check`: passed
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: passed, 13 selected checks, 0 failures, 0 manual holds
- exact-scope change-quality receipt: `cqr_17472b37869d4a033b07`, valid for commit `58ab1645ef7131eb189db7161fc6cb5d57ad3376`

## Boundary

- no runtime or protocol behavior changes
- no private state, credentials, local paths, raw sessions, or internal material
- held for owner review; this PR is not self-merged

LoopX todo: `todo_e52e7b4b4ea2`
