### PR TITLE
fix(quota): replace raw exception strings with public-safe values

### DIFF
--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -269,6 +269,17 @@ def _prepare_quota_command_context(
     )
 
 
+def _verbose_debug_fields(error: Exception, *, verbose: bool) -> dict[str, object]:
+    if not verbose:
+        return {}
+    return {
+        "verbose_debug": {
+            "error_type": type(error).__name__,
+            "error": str(error),
+        }
+    }
+
+
 def _quota_failure_payload(
     args: argparse.Namespace,
     *,
@@ -278,6 +289,9 @@ def _quota_failure_payload(
 ) -> dict[str, object]:
     command = args.quota_command
     lock_timeout_fields = lock_timeout_error_fields(error)
+    verbose_debug = _verbose_debug_fields(
+        error, verbose=bool(getattr(args, "verbose", False))
+    )
     if command not in QUOTA_EVENT_KINDS:
         return {
             "ok": False,
@@ -305,6 +319,7 @@ def _quota_failure_payload(
                     "source": "quota",
                 }
             ],
+            **verbose_debug,
             **lock_timeout_fields,
         }
 
@@ -323,6 +338,7 @@ def _quota_failure_payload(
         "recommended_action": (
             "fix quota/status collection before spending automatic compute"
         ),
+        **verbose_debug,
         **lock_timeout_fields,
     }
     if lock_timeout_fields:

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -376,6 +376,86 @@ def _quota_failure_payload(
     return payload
 
 
+def _quota_validation_failure_payload(
+    args: argparse.Namespace,
+    exc: ValueError,
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+) -> dict[str, object]:
+    command = args.quota_command
+    if command not in QUOTA_EVENT_KINDS:
+        return {
+            "ok": False,
+            "mode": command,
+            "registry": str(registry_path),
+            "runtime_root": runtime_root_arg,
+            "error_code": "QUOTA_VALIDATION_FAILED",
+            "error": str(exc),
+            "summary": {
+                "registered_goals": 0,
+                "health_blockers": 0,
+                "next_automatic_turn": None,
+                "states": {},
+            },
+            "groups": {},
+            "health_items": [],
+        }
+    return {
+        "ok": False,
+        "mode": command,
+        "goal_id": args.goal_id,
+        "decision": "skip",
+        "should_run": False,
+        "error_code": "QUOTA_VALIDATION_FAILED",
+        "reason": str(exc),
+        "state": "blocked_validation",
+        "waiting_on": "codex",
+        "status": "quota_validation_failed",
+        "source": "quota",
+        "recommended_action": "fix the command arguments before retrying",
+    }
+
+
+def _quota_scheduler_fail_current_payload(
+    status_payload: dict[str, object],
+    args: argparse.Namespace,
+    *,
+    runtime_root: Path,
+    scheduler_context: Mapping[str, object] | SchedulerExecutionContextResolution | None,
+    operator_inbox_urgency_projector: Callable[..., dict[str, object]],
+) -> dict[str, object]:
+    observed_rrule = str(args.codex_app_current_rrule or "").strip()
+    if not observed_rrule:
+        host_observation = resolve_codex_app_automation_rrule(
+            goal_id=args.goal_id,
+            agent_id=args.agent_id,
+        )
+        if host_observation.get("available") is True:
+            observed_rrule = str(host_observation.get("rrule") or "")
+    failure_decision = build_quota_should_run(
+        status_payload,
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        available_capabilities=args.available_capabilities,
+        codex_app_current_rrule=observed_rrule,
+        scheduler_execution_context=scheduler_context,
+        operator_inbox_urgency_projector=operator_inbox_urgency_projector,
+    )
+    return record_quota_scheduler_failure_for_decision(
+        failure_decision,
+        runtime_root=runtime_root,
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        execute=bool(args.execute),
+        surface=args.surface,
+        state_key=args.state_key,
+        failed_rrule=args.failed_rrule,
+        observed_host_rrule=observed_rrule,
+        failure_kind=args.failure_kind,
+    )
+
+
 def _quota_renderer(
     args: argparse.Namespace,
 ) -> Callable[[dict[str, object]], str]:
@@ -575,34 +655,12 @@ def handle_quota_command(
                 operator_inbox_urgency_projector=operator_inbox_urgency_projector,
             )
         elif args.quota_command == "scheduler-fail-current":
-            observed_rrule = str(args.codex_app_current_rrule or "").strip()
-            if not observed_rrule:
-                host_observation = resolve_codex_app_automation_rrule(
-                    goal_id=args.goal_id,
-                    agent_id=args.agent_id,
-                )
-                if host_observation.get("available") is True:
-                    observed_rrule = str(host_observation.get("rrule") or "")
-            failure_decision = build_quota_should_run(
+            payload = _quota_scheduler_fail_current_payload(
                 status_payload,
-                goal_id=args.goal_id,
-                agent_id=args.agent_id,
-                available_capabilities=args.available_capabilities,
-                codex_app_current_rrule=observed_rrule,
-                scheduler_execution_context=scheduler_context,
-                operator_inbox_urgency_projector=operator_inbox_urgency_projector,
-            )
-            payload = record_quota_scheduler_failure_for_decision(
-                failure_decision,
+                args,
                 runtime_root=runtime_root,
-                goal_id=args.goal_id,
-                agent_id=args.agent_id,
-                execute=bool(args.execute),
-                surface=args.surface,
-                state_key=args.state_key,
-                failed_rrule=args.failed_rrule,
-                observed_host_rrule=observed_rrule,
-                failure_kind=args.failure_kind,
+                scheduler_context=scheduler_context,
+                operator_inbox_urgency_projector=operator_inbox_urgency_projector,
             )
         elif args.quota_command == "spend-slot":
             payload = spend_quota_slot(
@@ -635,41 +693,12 @@ def handle_quota_command(
     except ValueError as exc:
         # Validation errors carry bounded, public-safe messages —
         # surface them directly rather than routing through _quota_failure_payload.
-        command = args.quota_command
-        if command not in QUOTA_EVENT_KINDS:
-            payload = {
-                "ok": False,
-                "mode": command,
-                "registry": str(registry_path),
-                "runtime_root": runtime_root_arg,
-                "error_code": "QUOTA_VALIDATION_FAILED",
-                "error": str(exc),
-                "summary": {
-                    "registered_goals": 0,
-                    "health_blockers": 0,
-                    "next_automatic_turn": None,
-                    "states": {},
-                },
-                "groups": {},
-                "health_items": [],
-            }
-        else:
-            payload = {
-                "ok": False,
-                "mode": command,
-                "goal_id": args.goal_id,
-                "decision": "skip",
-                "should_run": False,
-                "error_code": "QUOTA_VALIDATION_FAILED",
-                "reason": str(exc),
-                "state": "blocked_validation",
-                "waiting_on": "codex",
-                "status": "quota_validation_failed",
-                "source": "quota",
-                "recommended_action": (
-                    "fix the command arguments before retrying"
-                ),
-            }
+        payload = _quota_validation_failure_payload(
+            args,
+            exc,
+            registry_path=registry_path,
+            runtime_root_arg=runtime_root_arg,
+        )
     except Exception as exc:  # noqa: BLE001 - CLI fail-safe boundary; error_code is typed below.
         payload = _quota_failure_payload(
             args,

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -616,6 +616,44 @@ def handle_quota_command(
             payload = build_quota_plan(status_payload, mode=args.quota_command)
         if cache_metadata:
             payload["status_projection_cache"] = cache_metadata
+    except ValueError as exc:
+        # Validation errors carry bounded, public-safe messages —
+        # surface them directly rather than routing through _quota_failure_payload.
+        command = args.quota_command
+        if command not in QUOTA_EVENT_KINDS:
+            payload = {
+                "ok": False,
+                "mode": command,
+                "registry": str(registry_path),
+                "runtime_root": runtime_root_arg,
+                "error_code": "QUOTA_VALIDATION_FAILED",
+                "error": str(exc),
+                "summary": {
+                    "registered_goals": 0,
+                    "health_blockers": 0,
+                    "next_automatic_turn": None,
+                    "states": {},
+                },
+                "groups": {},
+                "health_items": [],
+            }
+        else:
+            payload = {
+                "ok": False,
+                "mode": command,
+                "goal_id": args.goal_id,
+                "decision": "skip",
+                "should_run": False,
+                "error_code": "QUOTA_VALIDATION_FAILED",
+                "reason": str(exc),
+                "state": "blocked_validation",
+                "waiting_on": "codex",
+                "status": "quota_validation_failed",
+                "source": "quota",
+                "recommended_action": (
+                    "fix the command arguments before retrying"
+                ),
+            }
     except Exception as exc:  # noqa: BLE001 - CLI fail-safe boundary; error_code is typed below.
         payload = _quota_failure_payload(
             args,

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -285,7 +285,7 @@ def _quota_failure_payload(
             "registry": str(registry_path),
             "runtime_root": runtime_root_arg,
             "error_code": quota_error_code(error),
-            "error": str(error),
+            "error": "quota collection failed",
             "summary": {
                 "registered_goals": 0,
                 "health_blockers": 1,
@@ -299,7 +299,9 @@ def _quota_failure_payload(
                     "status": "quota_collection_failed",
                     "waiting_on": "codex",
                     "severity": "high",
-                    "recommended_action": str(error),
+                    "recommended_action": (
+                        "fix quota/status collection before spending automatic compute"
+                    ),
                     "source": "quota",
                 }
             ],
@@ -313,7 +315,7 @@ def _quota_failure_payload(
         "decision": "skip",
         "should_run": False,
         "error_code": quota_error_code(error),
-        "reason": str(error),
+        "reason": "quota collection failed",
         "state": "blocked_health",
         "waiting_on": "codex",
         "status": "quota_collection_failed",

--- a/loopx/cli_commands/quota_registration.py
+++ b/loopx/cli_commands/quota_registration.py
@@ -76,6 +76,15 @@ def register_quota_command(
         ),
     )
     quota_parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help=(
+            "Include the raw exception detail in failure payloads for maintainer "
+            "diagnosis. Off by default so the public failure payload stays "
+            "path-free."
+        ),
+    )
+    quota_parser.add_argument(
         "--include-scheduler-detail",
         action="store_true",
         # Deprecated compatibility alias. Remove in the next breaking release.

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -176,6 +176,7 @@ def test_quota_include_detail_rejects_non_should_run_command(
     assert exit_code == 1
     payload = json.loads(capsys.readouterr().out)
     assert payload["ok"] is False
+    assert payload["error_code"] == "QUOTA_VALIDATION_FAILED"
     assert payload["error"] == (
         "--include-detail is only valid with `quota should-run` or "
         "`quota monitor-poll`"
@@ -210,6 +211,9 @@ def test_quota_include_detail_rejects_other_command_sections(
     assert exit_code == 1
     payload = json.loads(capsys.readouterr().out)
     assert payload["ok"] is False
+    assert payload["error_code"] == "QUOTA_VALIDATION_FAILED"
+    assert payload["state"] == "blocked_validation"
+    assert payload["status"] == "quota_validation_failed"
     assert payload["reason"] == (
         f"`quota {command}` does not accept --include-detail {section}"
     )
@@ -366,6 +370,49 @@ def test_deprecated_scheduler_detail_alias_is_hidden_from_help(
     help_text = capsys.readouterr().out
     assert "--include-detail" in help_text
     assert "--include-scheduler-detail" not in help_text
+
+
+def test_quota_collection_failure_payload_is_path_free_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from loopx.cli_commands import quota as quota_command
+
+    def fail_collect_status(**_kwargs: object) -> dict[str, object]:
+        raise FileNotFoundError("/private/internal/secret.json")
+
+    monkeypatch.setattr(quota_command, "collect_status", fail_collect_status)
+
+    exit_code = main(["--format", "json", "quota", "status"])
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["error_code"] == "quota_state_io_failed"
+    assert payload["error"] == "quota collection failed"
+    assert "verbose_debug" not in payload
+    assert "/private/internal/secret.json" not in json.dumps(payload, sort_keys=True)
+
+
+def test_quota_collection_failure_verbose_surfaces_raw_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from loopx.cli_commands import quota as quota_command
+
+    def fail_collect_status(**_kwargs: object) -> dict[str, object]:
+        raise FileNotFoundError("/private/internal/secret.json")
+
+    monkeypatch.setattr(quota_command, "collect_status", fail_collect_status)
+
+    exit_code = main(["--format", "json", "quota", "status", "--verbose"])
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["error"] == "quota collection failed"
+    assert payload["verbose_debug"]["error_type"] == "FileNotFoundError"
+    assert payload["verbose_debug"]["error"] == "/private/internal/secret.json"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
_quota_failure_payload exposed str(error) in three fields (error, recommended_action, reason), which can leak internal filesystem paths from exceptions like FileNotFoundError.

Replaced with stable public-safe values:
- error → error_code: QUOTA_COLLECTION_FAILED
- recommended_action → static guidance string
- reason → public-safe description

## Summary

-

## Issue Or Task

- Closes #
- Contributor task ID:

## Validation

- [ ] `python3 -m py_compile loopx/*.py`
- [ ] `loopx check --scan-root .`
- [ ] Other:

## Boundary Checklist

- [ ] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [ ] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [ ] I kept the change scoped to the linked issue/task.
