### PR TITLE
feat(release): publish verified package artifacts

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,0 +1,186 @@
+name: Release Artifacts
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/release-artifacts.yml"
+      - "examples/release-artifacts-smoke.py"
+      - "loopx/**"
+      - "pyproject.toml"
+      - "README.md"
+      - "scripts/release_artifacts.py"
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing GitHub Release tag containing this release tooling"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-artifacts-${{ github.event.release.tag_name || inputs.tag || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    if: github.repository == 'huangruiteng/loopx'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    outputs:
+      release-tag: ${{ steps.identity.outputs.release-tag }}
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.release.tag_name || inputs.tag || github.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Resolve and validate release identity
+        id: identity
+        env:
+          EVENT_RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          release_tag="${EVENT_RELEASE_TAG:-${INPUT_RELEASE_TAG:-}}"
+          if [[ -z "${release_tag}" ]]; then
+            release_tag="$(python scripts/release_artifacts.py expected-tag)"
+          fi
+          python scripts/release_artifacts.py validate-tag "${release_tag}"
+          source_date_epoch="$(git show -s --format=%ct HEAD)"
+          echo "release-tag=${release_tag}" >> "${GITHUB_OUTPUT}"
+          echo "RELEASE_TAG=${release_tag}" >> "${GITHUB_ENV}"
+          echo "SOURCE_DATE_EPOCH=${source_date_epoch}" >> "${GITHUB_ENV}"
+          echo "PYTHONHASHSEED=0" >> "${GITHUB_ENV}"
+
+      - name: Install release build tools
+        run: python -m pip install --disable-pip-version-check build==1.4.4 twine==6.2.0
+
+      - name: Build wheel and source distribution
+        run: python -m build --sdist --wheel --outdir dist/packages
+
+      - name: Normalize source distribution metadata
+        run: >-
+          python scripts/release_artifacts.py normalize-sdist
+          --dist-dir dist/packages
+          --source-date-epoch "${SOURCE_DATE_EPOCH}"
+
+      - name: Validate package metadata
+        run: python -m twine check dist/packages/*
+
+      - name: Generate and verify checksums
+        run: |
+          set -euo pipefail
+          python scripts/release_artifacts.py write-checksums \
+            --dist-dir dist/packages \
+            --output dist/SHA256SUMS
+          python scripts/release_artifacts.py verify-checksums \
+            --dist-dir dist/packages \
+            --checksum-file dist/SHA256SUMS
+
+      - name: Verify wheel in a clean environment
+        run: |
+          set -euo pipefail
+          python -m venv "${RUNNER_TEMP}/loopx-wheel"
+          "${RUNNER_TEMP}/loopx-wheel/bin/python" -m pip install \
+            --disable-pip-version-check \
+            --no-deps \
+            dist/packages/*.whl
+          test "$("${RUNNER_TEMP}/loopx-wheel/bin/loopx" --version)" = \
+            "loopx ${RELEASE_TAG#v}"
+
+      - name: Exercise release contract smoke
+        run: python examples/release-artifacts-smoke.py
+
+      - name: Attest release packages and checksum manifest
+        if: github.event_name != 'pull_request'
+        uses: actions/attest@v4
+        with:
+          subject-path: |
+            dist/packages/*
+            dist/SHA256SUMS
+
+      - name: Upload validated release bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: loopx-${{ steps.identity.outputs.release-tag }}
+          path: dist
+          if-no-files-found: error
+          retention-days: 30
+
+  upload-release:
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.build.outputs.release-tag }}
+
+      - name: Download validated release bundle
+        uses: actions/download-artifact@v7
+        with:
+          name: loopx-${{ needs.build.outputs.release-tag }}
+          path: dist
+
+      - name: Verify checksums before upload
+        run: >-
+          python scripts/release_artifacts.py verify-checksums
+          --dist-dir dist/packages
+          --checksum-file dist/SHA256SUMS
+
+      - name: Upload immutable GitHub Release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.build.outputs.release-tag }}
+        run: |
+          set -euo pipefail
+          gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null
+          gh release upload "${RELEASE_TAG}" \
+            dist/packages/* \
+            dist/SHA256SUMS \
+            --repo "${GITHUB_REPOSITORY}"
+
+  publish-pypi:
+    if: >-
+      github.event_name != 'pull_request' &&
+      vars.PYPI_PUBLISH_ENABLED == 'true'
+    needs:
+      - build
+      - upload-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/project/loopx/
+    steps:
+      - name: Download validated release bundle
+        uses: actions/download-artifact@v7
+        with:
+          name: loopx-${{ needs.build.outputs.release-tag }}
+          path: dist
+
+      - name: Publish distributions with PyPI Trusted Publishing
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
+        with:
+          packages-dir: dist/packages

--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -95,9 +95,34 @@ Before moving `stable`, maintainers should:
   `loopx update --execute` when the check recommends or when they want to
   refresh to the named stable release.
 
-This is a lightweight GitHub release contract, not a PyPI publishing
-requirement. A future package registry can reuse the same version/tag contract
-instead of inventing a second release identity.
+The release workflow builds a wheel and source distribution from the tagged
+commit. Its release assets include a canonical `SHA256SUMS` file, and GitHub
+records build-provenance attestations for both packages and the checksum
+manifest. Verify a downloaded bundle before installation:
+
+```bash
+sha256sum --check SHA256SUMS
+gh attestation verify loopx-X.Y.Z-py3-none-any.whl --repo huangruiteng/loopx
+gh attestation verify loopx-X.Y.Z.tar.gz --repo huangruiteng/loopx
+```
+
+The checksum proves that the downloaded bytes match the release manifest. The
+attestation separately binds those bytes to the repository, workflow, commit,
+and build event; neither mechanism claims that the package is vulnerability
+free.
+
+PyPI publication is an explicit, fail-closed extension of the same build. The
+release workflow publishes only when maintainers have configured all of these:
+
+- a PyPI project named `loopx` with a Trusted Publisher for
+  `huangruiteng/loopx` and `.github/workflows/release-artifacts.yml`;
+- a protected GitHub environment named `pypi` that matches the Trusted
+  Publisher configuration;
+- the repository variable `PYPI_PUBLISH_ENABLED=true`.
+
+Do not add a long-lived PyPI token. Without every condition above, GitHub
+Release packages and their verification material are still produced, while
+the PyPI job remains skipped.
 
 ## Public Release Timeline
 

--- a/examples/release-artifacts-smoke.py
+++ b/examples/release-artifacts-smoke.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Exercise the public release artifact identity and checksum contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import gzip
+import hashlib
+import io
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "release_artifacts.py"
+SPEC = importlib.util.spec_from_file_location("release_artifacts", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+release_artifacts = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = release_artifacts
+SPEC.loader.exec_module(release_artifacts)
+
+
+def run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--project-root", str(ROOT), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def write_sdist(path: Path, *, mtime: int) -> None:
+    with path.open("wb") as raw_stream:
+        with gzip.GzipFile(filename="", mode="wb", fileobj=raw_stream, mtime=mtime) as gzip_stream:
+            with tarfile.open(fileobj=gzip_stream, mode="w", format=tarfile.PAX_FORMAT) as archive:
+                payload = b"fixture package metadata\n"
+                member = tarfile.TarInfo("loopx-fixture/PKG-INFO")
+                member.size = len(payload)
+                member.mtime = mtime
+                archive.addfile(member, io.BytesIO(payload))
+
+
+def digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def main() -> int:
+    identity = release_artifacts.load_identity(ROOT)
+    assert identity.name == "loopx", identity
+    assert run("expected-tag").stdout.strip() == identity.tag
+    assert run("validate-tag", identity.tag).returncode == 0
+
+    invalid_tag = run("validate-tag", "v999.0.0")
+    assert invalid_tag.returncode == 2, invalid_tag
+    assert "does not match package tag" in invalid_tag.stderr, invalid_tag.stderr
+
+    with tempfile.TemporaryDirectory(prefix="loopx-release-artifacts-") as temporary:
+        root = Path(temporary)
+        dist_dir = root / "packages"
+        dist_dir.mkdir()
+        wheel = dist_dir / f"loopx-{identity.version}-py3-none-any.whl"
+        sdist = dist_dir / f"loopx-{identity.version}.tar.gz"
+        wheel.write_bytes(b"wheel fixture\n")
+        write_sdist(sdist, mtime=1_700_000_001)
+        checksums = root / "SHA256SUMS"
+
+        normalized = run(
+            "normalize-sdist",
+            "--dist-dir",
+            str(dist_dir),
+            "--source-date-epoch",
+            "1700000000",
+        )
+        assert normalized.returncode == 0, normalized
+        normalized_digest = digest(sdist)
+        write_sdist(sdist, mtime=1_700_000_099)
+        normalized_again = run(
+            "normalize-sdist",
+            "--dist-dir",
+            str(dist_dir),
+            "--source-date-epoch",
+            "1700000000",
+        )
+        assert normalized_again.returncode == 0, normalized_again
+        assert digest(sdist) == normalized_digest
+
+        written = run(
+            "write-checksums",
+            "--dist-dir",
+            str(dist_dir),
+            "--output",
+            str(checksums),
+        )
+        assert written.returncode == 0, written
+        manifest = checksums.read_text(encoding="ascii")
+        lines = manifest.splitlines()
+        assert len(lines) == 2, lines
+        assert lines == sorted(lines, key=lambda line: line.split("  ", 1)[1]), lines
+        assert all(len(line.split("  ", 1)[0]) == 64 for line in lines), lines
+
+        verified = run(
+            "verify-checksums",
+            "--dist-dir",
+            str(dist_dir),
+            "--checksum-file",
+            str(checksums),
+        )
+        assert verified.returncode == 0, verified
+
+        wheel.write_bytes(b"tampered wheel\n")
+        tampered = run(
+            "verify-checksums",
+            "--dist-dir",
+            str(dist_dir),
+            "--checksum-file",
+            str(checksums),
+        )
+        assert tampered.returncode == 2, tampered
+        assert "does not match release distributions" in tampered.stderr, tampered.stderr
+
+        extra = dist_dir / "unexpected.txt"
+        extra.write_text("not a release asset\n", encoding="utf-8")
+        rejected = run(
+            "write-checksums",
+            "--dist-dir",
+            str(dist_dir),
+            "--output",
+            str(checksums),
+        )
+        assert rejected.returncode == 2, rejected
+        assert "unexpected files" in rejected.stderr, rejected.stderr
+
+    workflow = (ROOT / ".github" / "workflows" / "release-artifacts.yml").read_text(
+        encoding="utf-8"
+    )
+    required_contract = (
+        "release:\n    types: [published]",
+        "python scripts/release_artifacts.py validate-tag",
+        "python scripts/release_artifacts.py normalize-sdist",
+        "python scripts/release_artifacts.py write-checksums",
+        "python scripts/release_artifacts.py verify-checksums",
+        "uses: actions/attest@v4",
+        "gh release upload",
+        "vars.PYPI_PUBLISH_ENABLED == 'true'",
+        "environment:\n      name: pypi",
+        "pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33",
+    )
+    for text in required_contract:
+        assert text in workflow, text
+    assert "password:" not in workflow
+    assert "--clobber" not in workflow
+
+    print("release-artifacts-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=69"]
+requires = ["setuptools==82.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,7 +8,8 @@ version = "0.4.2"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [{ name = "LoopX contributors" }]
 dependencies = []
 

--- a/scripts/release_artifacts.py
+++ b/scripts/release_artifacts.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Validate LoopX release identity and produce canonical SHA-256 manifests."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import copy
+import gzip
+import hashlib
+import io
+import sys
+import tarfile
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class ReleaseArtifactError(ValueError):
+    """Raised when release inputs do not satisfy the public release contract."""
+
+
+@dataclass(frozen=True)
+class ReleaseIdentity:
+    name: str
+    version: str
+
+    @property
+    def tag(self) -> str:
+        return f"v{self.version}"
+
+    @property
+    def distribution_prefix(self) -> str:
+        return self.name.replace("-", "_")
+
+
+def _module_version(path: Path) -> str:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for statement in tree.body:
+        if not isinstance(statement, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = statement.targets if isinstance(statement, ast.Assign) else [statement.target]
+        if not any(isinstance(target, ast.Name) and target.id == "__version__" for target in targets):
+            continue
+        value = statement.value
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            return value.value
+    raise ReleaseArtifactError(f"missing literal __version__ in {path}")
+
+
+def load_identity(project_root: Path) -> ReleaseIdentity:
+    pyproject_path = project_root / "pyproject.toml"
+    payload = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    project = payload.get("project")
+    if not isinstance(project, dict):
+        raise ReleaseArtifactError(f"missing [project] table in {pyproject_path}")
+    name = project.get("name")
+    version = project.get("version")
+    if not isinstance(name, str) or not name:
+        raise ReleaseArtifactError("project.name must be a non-empty string")
+    if not isinstance(version, str) or not version:
+        raise ReleaseArtifactError("project.version must be a non-empty string")
+    module_version = _module_version(project_root / "loopx" / "__init__.py")
+    if module_version != version:
+        raise ReleaseArtifactError(
+            f"version mismatch: pyproject.toml={version!r}, loopx.__version__={module_version!r}"
+        )
+    return ReleaseIdentity(name=name, version=version)
+
+
+def distribution_files(dist_dir: Path, identity: ReleaseIdentity) -> tuple[Path, ...]:
+    if not dist_dir.is_dir():
+        raise ReleaseArtifactError(f"distribution directory does not exist: {dist_dir}")
+    prefix = f"{identity.distribution_prefix}-{identity.version}"
+    wheel_files = sorted(dist_dir.glob(f"{prefix}-*.whl"))
+    sdist_files = sorted(dist_dir.glob(f"{prefix}.tar.gz"))
+    if len(wheel_files) != 1 or len(sdist_files) != 1:
+        raise ReleaseArtifactError(
+            "expected exactly one wheel and one sdist for "
+            f"{identity.name} {identity.version}; found wheels={len(wheel_files)}, "
+            f"sdists={len(sdist_files)}"
+        )
+    expected = tuple(sorted((*wheel_files, *sdist_files), key=lambda path: path.name))
+    unexpected = sorted(
+        path.name
+        for path in dist_dir.iterdir()
+        if path.is_file() and path not in expected
+    )
+    if unexpected:
+        raise ReleaseArtifactError(f"unexpected files in distribution directory: {unexpected}")
+    return expected
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def render_manifest(files: tuple[Path, ...]) -> str:
+    return "".join(f"{sha256(path)}  {path.name}\n" for path in files)
+
+
+def _safe_archive_name(name: str) -> bool:
+    path = Path(name)
+    return bool(name) and not path.is_absolute() and ".." not in path.parts
+
+
+def normalize_sdist(dist_dir: Path, identity: ReleaseIdentity, source_date_epoch: int) -> None:
+    if source_date_epoch < 0:
+        raise ReleaseArtifactError("source date epoch must be non-negative")
+    files = distribution_files(dist_dir, identity)
+    sdist = next(path for path in files if path.name.endswith(".tar.gz"))
+    temporary = sdist.with_name(f".{sdist.name}.tmp")
+    try:
+        with tarfile.open(sdist, mode="r:gz") as source:
+            members = sorted(source.getmembers(), key=lambda member: member.name)
+            if any(not _safe_archive_name(member.name) for member in members):
+                raise ReleaseArtifactError(f"sdist contains an unsafe archive path: {sdist}")
+            payloads = {
+                member.name: source.extractfile(member).read()
+                for member in members
+                if member.isfile()
+            }
+        with temporary.open("wb") as raw_stream:
+            with gzip.GzipFile(
+                filename="",
+                mode="wb",
+                fileobj=raw_stream,
+                mtime=source_date_epoch,
+            ) as gzip_stream:
+                with tarfile.open(
+                    fileobj=gzip_stream,
+                    mode="w",
+                    format=tarfile.PAX_FORMAT,
+                ) as target:
+                    for member in members:
+                        normalized = copy.copy(member)
+                        normalized.mtime = source_date_epoch
+                        normalized.uid = 0
+                        normalized.gid = 0
+                        normalized.uname = ""
+                        normalized.gname = ""
+                        normalized.pax_headers = {
+                            key: value
+                            for key, value in member.pax_headers.items()
+                            if key not in {"atime", "ctime", "gid", "gname", "mtime", "uid", "uname"}
+                        }
+                        data = io.BytesIO(payloads[member.name]) if member.isfile() else None
+                        target.addfile(normalized, data)
+        temporary.replace(sdist)
+    except (OSError, tarfile.TarError) as exc:
+        raise ReleaseArtifactError(f"cannot normalize sdist {sdist}: {exc}") from exc
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+    print(f"normalized {sdist} with SOURCE_DATE_EPOCH={source_date_epoch}")
+
+
+def write_manifest(dist_dir: Path, output: Path, identity: ReleaseIdentity) -> None:
+    files = distribution_files(dist_dir, identity)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_name(f".{output.name}.tmp")
+    temporary.write_text(render_manifest(files), encoding="ascii")
+    temporary.replace(output)
+    print(f"wrote {output} for {len(files)} distributions")
+
+
+def verify_manifest(dist_dir: Path, checksum_file: Path, identity: ReleaseIdentity) -> None:
+    files = distribution_files(dist_dir, identity)
+    expected = render_manifest(files)
+    try:
+        observed = checksum_file.read_text(encoding="ascii")
+    except (OSError, UnicodeError) as exc:
+        raise ReleaseArtifactError(f"cannot read checksum manifest {checksum_file}: {exc}") from exc
+    if observed != expected:
+        raise ReleaseArtifactError(
+            f"checksum manifest does not match release distributions: {checksum_file}"
+        )
+    print(f"verified {checksum_file} for {len(files)} distributions")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project-root", type=Path, default=Path.cwd())
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("expected-tag", help="print the tag required by package metadata")
+    validate = subparsers.add_parser("validate-tag", help="validate a release tag")
+    validate.add_argument("tag")
+
+    normalize = subparsers.add_parser("normalize-sdist", help="normalize sdist metadata")
+    normalize.add_argument("--dist-dir", type=Path, required=True)
+    normalize.add_argument("--source-date-epoch", type=int, required=True)
+
+    write = subparsers.add_parser("write-checksums", help="write a canonical SHA256SUMS file")
+    write.add_argument("--dist-dir", type=Path, required=True)
+    write.add_argument("--output", type=Path, required=True)
+
+    verify = subparsers.add_parser("verify-checksums", help="verify a canonical SHA256SUMS file")
+    verify.add_argument("--dist-dir", type=Path, required=True)
+    verify.add_argument("--checksum-file", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        identity = load_identity(args.project_root.resolve())
+        if args.command == "expected-tag":
+            print(identity.tag)
+        elif args.command == "validate-tag":
+            if args.tag != identity.tag:
+                raise ReleaseArtifactError(
+                    f"release tag {args.tag!r} does not match package tag {identity.tag!r}"
+                )
+            print(f"validated release tag {args.tag}")
+        elif args.command == "normalize-sdist":
+            normalize_sdist(args.dist_dir, identity, args.source_date_epoch)
+        elif args.command == "write-checksums":
+            write_manifest(args.dist_dir, args.output, identity)
+        elif args.command == "verify-checksums":
+            verify_manifest(args.dist_dir, args.checksum_file, identity)
+        else:
+            parser.error(f"unsupported command: {args.command}")
+    except ReleaseArtifactError as exc:
+        print(f"release artifact error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- build one wheel and one sdist from the release tag, normalize build metadata, and fail closed on tag/version drift
- publish canonical `SHA256SUMS` plus GitHub provenance attestations, then upload immutable GitHub Release assets without `--clobber`
- keep PyPI Trusted Publishing disabled unless the protected `pypi` environment and `PYPI_PUBLISH_ENABLED=true` are explicitly configured
- document checksum/attestation verification and pin the package build backend

## Validation

- `python examples/release-artifacts-smoke.py`
- two independent builds produced identical wheel and normalized-sdist SHA-256 digests
- `python -m twine check` on the final wheel and normalized sdist
- clean Python 3.11 wheel and sdist installs report `loopx 0.4.2`
- `actionlint v1.7.12`
- `ruff 0.15.7`
- repository `mypy` target set
- `loopx check` public/private boundary scan
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` (18/18 selected checks passed)
- change-quality receipt `cqr_78da997ca2758b5a60ac` is valid for the exact final diff

## Manual hold

Live PyPI publication was not attempted. The package name is currently unclaimed and the repository has no `pypi` environment; enabling Trusted Publishing remains an explicit maintainer production action. No credentials, local state, generated packages, or raw logs are included.