### PR TITLE
docs: document repository write collaborators

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -15,6 +15,26 @@ maintainer appointments, security-sensitive handling, and changes to this
 governance model. That tie-break role should be revisited when the active
 maintainer group grows.
 
+## Repository Developers With Write Access
+
+The following developers have, or have been invited to accept, GitHub's
+repository `write` role. Write access supports day-to-day pull-request and
+branch work within the repository rules. It does not by itself appoint someone
+as a maintainer or grant release, security, or governance authority.
+
+| GitHub account | Repository role | Access status |
+| --- | --- | --- |
+| [`@wujc12`](https://github.com/wujc12) | Write | Active |
+| [`@ZaynJarvis`](https://github.com/ZaynJarvis) | Write | Active |
+| [`@Hoey041`](https://github.com/Hoey041) | Write | Active |
+| [`@maxliux5`](https://github.com/maxliux5) | Write | Invitation pending |
+| [`@JackyCSer`](https://github.com/JackyCSer) | Write | Invitation pending |
+
+GitHub's repository settings are the operational source of truth for access.
+This public snapshot should be updated through a pull request when a write-role
+invitation is accepted, expires, or is revoked. Maintainer appointments remain
+subject to the process below.
+
 ## Project Roles
 
 ### Maintainers


### PR DESCRIPTION
## Summary

- document the current active GitHub `write` collaborators
- record the two new `write` invitations as pending until accepted
- keep operational write access distinct from maintainer, release, security, and governance authority

## GitHub access readback

- Active write: `wujc12`, `ZaynJarvis`, `Hoey041`
- Pending write invitation: `maxliux5`, `JackyCSer`

GitHub repository settings remain the operational source of truth. The pending rows should be updated after invitation acceptance, expiry, or revocation.

## Validation

- `git diff --check`
- `loopx check --scan-path GOVERNANCE.md` (9 checks, 0 errors, 0 warnings)
- GitHub collaborator and invitation API readback
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`
- exact-diff change-quality receipt `cqr_94bfa920d1dc06d61a2b`

## Merge

Not merged; this PR is ready for maintainer review.