### PR TITLE
docs: align README navigation with canonical owners

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,10 +395,11 @@ loopx check \
 
 ## Advanced Documentation
 
-Start with the path that matches your role. Use the hosted
+Start with the path that matches your current task. Use the hosted
 [documentation portal](https://huangruiteng.github.io/loopx/docs/) for the
 published docs site; the [documentation index](docs/README.md) remains the
-complete source map.
+complete source map. This list stays selective; each category index owns its
+deeper documents and versioned protocols.
 
 ### Use and Operate
 
@@ -406,46 +407,62 @@ complete source map.
   diagnose, daily workflow, heartbeats, dashboard, development, and commands.
 - [User Manual](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg):
   public onboarding, concepts, FAQ, and selected cases.
-- [Showcase Catalog](docs/showcases/README.md): public-safe cases and evidence
-  labels.
-- [Update Notes](docs/update-notes/README.md): public-safe progress notes.
+- [Operations](docs/operations/README.md): goal continuation, todo, cadence,
+  attention, and authority workflows.
+- [Quota Allocation](docs/quota-allocation.md) and
+  [Heartbeat Automation Prompt](docs/heartbeat-automation-prompt.md): scheduler
+  eligibility, spend, and scheduled continuation.
+- [Dashboard](apps/presentation/dashboard/README.md) and
+  [Status Data Contract](docs/status-data-contract.md): operator-facing state
+  and projection contracts.
 - [Release Readiness](docs/product/release-readiness.md): install/update paths,
   compatibility gates, release notes, and safe-to-depend-on surfaces.
-- [Dashboard](apps/presentation/dashboard/README.md) and
-  [Status Data Contract](docs/status-data-contract.md).
 
 ### Understand the Control Plane
 
 - [Architecture](docs/architecture.md): lifetime-goal invariant and kernel.
 - [State Interaction Model](docs/state-interaction-model.md): actors, stores,
   interaction contract, and writeback.
-- [Interaction Pattern Catalog](docs/concepts/interaction-pattern-catalog.md):
-  reusable routing, gate, evidence, projection, and planning patterns.
-- [Loop Engineering Principles and Pitfalls](docs/product/foundations/loop-engineering-principles-and-pitfalls.md)
-  and the
-  [Chinese version](docs/product/foundations/loop-engineering-principles-and-pitfalls.zh.md).
-- [Control-Plane Developer Course](docs/development/control-plane-course/README.md):
-  nine Chinese, code-led lectures.
+- [Concepts](docs/concepts/README.md): reusable routing, gate, evidence,
+  projection, and planning patterns.
+- [Product Foundations](docs/product/foundations/README.md): Loop Engineering
+  principles, project-level reward, and reward-style replanning.
 - [Product Vision](docs/product/vision.md): the broader Loop Agent direction.
 
 ### Integrate and Extend
 
 - [Integration Guide](docs/integration.md)
 - [Custom Agent Runner Integration](docs/guides/custom-agent-runner-integration.md)
-- [Worker Bridge Install Contract](docs/integrations/worker-bridge-install-contract.md)
+- [Integrations](docs/integrations/README.md): runtime, host, collaboration, and
+  external-system adapters, including worker bridge and Lark.
 - [Extensions and Capabilities](docs/reference/extensions.md)
-- [Codex App Host Command Registry](docs/reference/protocols/codex-app-host-command-registry-v0.md)
-- [Heartbeat Automation Prompt](docs/heartbeat-automation-prompt.md)
-- [Lark Kanban Adapter](docs/integrations/lark-kanban-control-plane-adapter.md)
-- [Reward Memory Architecture](docs/reference/protocols/reward-memory-architecture-v0.md)
 
-### Validate and Govern
+### Build and Review LoopX
 
-- [Quota Allocation](docs/quota-allocation.md)
-- [Public/Private Boundary](docs/public-private-boundary.md)
-- [Benchmark Developer Workflow](docs/development/benchmark-developer-workflow.md)
-- [Project-Level Reward Model](docs/product/foundations/project-level-reward-model.md)
+- [Developer Guide](docs/development/README.md): contributor workflows,
+  benchmark development, documentation layout, and quality gates.
+- [Reference and Protocols](docs/reference/README.md): stable contracts and
+  versioned implementation protocols, including host command and reward memory
+  architecture.
+- [Control-Plane Developer Course](docs/development/control-plane-course/README.md):
+  nine Chinese, code-led lectures.
+- [Testing and Quality](docs/development/testing-and-quality.md): validation
+  layers and risk-based checks.
+- [Public/Private Boundary](docs/public-private-boundary.md): safe fixtures,
+  examples, evidence, and publication.
+
+### Inspect Outcomes
+
+- [Showcase Catalog](docs/showcases/README.md): public-safe cases and evidence
+  labels.
+- [Research and Evidence](docs/research/README.md): benchmark investigations
+  and source-backed findings.
+- [Update Notes](docs/update-notes/README.md): public-safe progress notes.
+
+### Project and Community
+
 - [Project Governance](GOVERNANCE.md)
+- [Contributing](CONTRIBUTING.md) and [Contributor Tasks](CONTRIBUTOR_TASKS.md)
 - [Authors and Contributors](AUTHORS.md)
 - [Project History](docs/project/history.md)
 - [Name and Marks](TRADEMARKS.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -356,8 +356,9 @@ loopx check \
 
 ## 进阶文档
 
-按你的角色选择入口；[线上文档](https://huangruiteng.github.io/loopx/docs/)
-提供发布后的浏览入口，[完整文档索引](docs/README.md)仍是权威地图。
+按当前任务选择入口；[线上文档](https://huangruiteng.github.io/loopx/docs/)
+提供发布后的浏览入口，[完整文档索引](docs/README.md)仍是权威地图。这里仅保留
+精选入口；每个分类索引负责承接更深层的文档和版本化协议。
 
 ### 使用与运维
 
@@ -365,43 +366,56 @@ loopx check \
   dashboard、开发和命令参考。
 - [用户手册](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg)：
   公开 onboarding、概念、FAQ 和案例。
-- [Showcase Catalog](docs/showcases/README.md)：public-safe 案例和 evidence label。
-- [Update Notes](docs/update-notes/README.md)：公开安全的进展记录。
+- [Operations](docs/operations/README.md)：goal continuation、todo、cadence、
+  attention 和 authority 工作流。
+- [Quota Allocation](docs/quota-allocation.md)与
+  [Heartbeat Automation Prompt](docs/heartbeat-automation-prompt.md)：scheduler
+  eligibility、spend 和定时续跑。
+- [Dashboard](apps/presentation/dashboard/README.md)与
+  [Status Data Contract](docs/status-data-contract.md)：面向操作者的状态与投影契约。
 - [Release Readiness](docs/product/release-readiness.md)：安装升级、兼容性 gate、
   release note 和稳定表面。
-- [Dashboard](apps/presentation/dashboard/README.md)与
-  [Status Data Contract](docs/status-data-contract.md)。
 
 ### 理解控制面
 
 - [Architecture](docs/architecture.md)：lifetime-goal invariant 与 kernel。
 - [State Interaction Model](docs/state-interaction-model.md)：actor、store、
   interaction contract 与 writeback。
-- [Interaction Pattern Catalog](docs/concepts/interaction-pattern-catalog.md)：可复用
-  routing、gate、evidence、projection 与 planning pattern。
-- [Loop Engineering 原则与陷阱（中文）](docs/product/foundations/loop-engineering-principles-and-pitfalls.zh.md)
-  及[英文版](docs/product/foundations/loop-engineering-principles-and-pitfalls.md)。
-- [控制面开发者 9 讲](docs/development/control-plane-course/README.md)。
+- [Concepts](docs/concepts/README.md)：可复用的 routing、gate、evidence、
+  projection 与 planning pattern。
+- [Product Foundations](docs/product/foundations/README.md)：Loop Engineering
+  原则、project-level reward 和 reward-style replanning。
 - [Product Vision](docs/product/vision.md)：更广义的 Loop Agent 产品方向。
 
 ### 集成与扩展
 
 - [Integration Guide](docs/integration.md)
 - [Custom Agent Runner 中文指南](docs/guides/custom-agent-runner-integration.zh-CN.md)
-- [Worker Bridge Install Contract](docs/integrations/worker-bridge-install-contract.md)
+- [Integrations](docs/integrations/README.md)：runtime、host、协作和外部系统 adapter，
+  包括 worker bridge 与 Lark。
 - [Extensions and Capabilities](docs/reference/extensions.md)
-- [Codex App Host Command Registry](docs/reference/protocols/codex-app-host-command-registry-v0.md)
-- [Heartbeat Automation Prompt](docs/heartbeat-automation-prompt.md)
-- [Lark Kanban Adapter](docs/integrations/lark-kanban-control-plane-adapter.md)
-- [Reward Memory 中文架构](docs/reference/protocols/reward-memory-architecture-v0.zh-CN.md)
 
-### 验证与治理
+### 构建与评审 LoopX
 
-- [Quota Allocation](docs/quota-allocation.md)
-- [Public/Private Boundary](docs/public-private-boundary.md)
-- [Benchmark Developer Workflow](docs/development/benchmark-developer-workflow.md)
-- [Project-Level Reward Model](docs/product/foundations/project-level-reward-model.md)
+- [Developer Guide](docs/development/README.md)：贡献者工作流、benchmark 开发、
+  文档布局和质量 gate。
+- [Reference and Protocols](docs/reference/README.md)：稳定契约和版本化实现协议，
+  包括 host command 与 reward memory architecture。
+- [控制面开发者 9 讲](docs/development/control-plane-course/README.md)。
+- [Testing and Quality](docs/development/testing-and-quality.md)：分层验证与风险检查。
+- [Public/Private Boundary](docs/public-private-boundary.md)：安全的 fixture、示例、
+  evidence 与发布边界。
+
+### 查看结果与证据
+
+- [Showcase Catalog](docs/showcases/README.md)：public-safe 案例和 evidence label。
+- [Research and Evidence](docs/research/README.md)：benchmark 调查和有来源的结论。
+- [Update Notes](docs/update-notes/README.md)：公开安全的进展记录。
+
+### 项目与社区
+
 - [Project Governance](GOVERNANCE.md)
+- [Contributing](CONTRIBUTING.md)与[Contributor Tasks](CONTRIBUTOR_TASKS.md)
 - [Authors and Contributors](AUTHORS.md)
 - [Project History](docs/project/history.md)
 - [Name and Marks](TRADEMARKS.md)

--- a/examples/docs-governance-smoke.py
+++ b/examples/docs-governance-smoke.py
@@ -81,6 +81,13 @@ def compact(text: str) -> str:
     return " ".join(text.split())
 
 
+def subsection(text: str, heading: str) -> str:
+    marker = f"### {heading}"
+    assert marker in text, marker
+    body = text.split(marker, 1)[1]
+    return body.split("\n### ", 1)[0].split("\n## ", 1)[0]
+
+
 def assert_local_doc_links_resolve() -> None:
     for source in DOCS.rglob("*"):
         if source.suffix.lower() not in {".md", ".html"}:
@@ -115,6 +122,8 @@ def assert_local_doc_links_resolve() -> None:
 
 def main() -> int:
     docs_index = read("docs/README.md")
+    root_readme = read("README.md")
+    root_readme_zh = read("README.zh-CN.md")
     auto_research_command_path = read("docs/guides/auto-research-command-path.md")
     codex_cli_tui_loop = read("docs/product/runtimes/codex-cli/codex-cli-tui-loop.md")
     project_agent_contract = read("docs/project-agent-todo-contract.md")
@@ -140,6 +149,77 @@ def main() -> int:
         "development/testing-and-quality.md",
     ]:
         assert required in docs_index, required
+
+    navigation_contracts = {
+        "Use and Operate": [
+            "docs/operations/README.md",
+            "docs/quota-allocation.md",
+            "docs/heartbeat-automation-prompt.md",
+            "docs/status-data-contract.md",
+        ],
+        "Understand the Control Plane": [
+            "docs/concepts/README.md",
+            "docs/product/foundations/README.md",
+            "docs/product/vision.md",
+        ],
+        "Integrate and Extend": [
+            "docs/integration.md",
+            "docs/integrations/README.md",
+        ],
+        "Build and Review LoopX": [
+            "docs/development/README.md",
+            "docs/reference/README.md",
+            "docs/development/control-plane-course/README.md",
+            "docs/development/testing-and-quality.md",
+            "docs/public-private-boundary.md",
+        ],
+        "Inspect Outcomes": [
+            "docs/showcases/README.md",
+            "docs/research/README.md",
+            "docs/update-notes/README.md",
+        ],
+        "Project and Community": [
+            "GOVERNANCE.md",
+            "CONTRIBUTING.md",
+            "CONTRIBUTOR_TASKS.md",
+            "AUTHORS.md",
+            "docs/project/history.md",
+            "TRADEMARKS.md",
+        ],
+    }
+    navigation_contracts_zh = {
+        "使用与运维": navigation_contracts["Use and Operate"],
+        "理解控制面": navigation_contracts["Understand the Control Plane"],
+        "集成与扩展": navigation_contracts["Integrate and Extend"],
+        "构建与评审 LoopX": navigation_contracts["Build and Review LoopX"],
+        "查看结果与证据": navigation_contracts["Inspect Outcomes"],
+        "项目与社区": navigation_contracts["Project and Community"],
+    }
+    for readme, contracts in (
+        (root_readme, navigation_contracts),
+        (root_readme_zh, navigation_contracts_zh),
+    ):
+        for heading, required_links in contracts.items():
+            section = subsection(readme, heading)
+            for required in required_links:
+                assert required in section, f"{heading}: {required}"
+
+    assert "### Validate and Govern" not in root_readme
+    assert "### 验证与治理" not in root_readme_zh
+    advanced_docs = root_readme.split("## Advanced Documentation", 1)[1].split(
+        "\n## ", 1
+    )[0]
+    advanced_docs_zh = root_readme_zh.split("## 进阶文档", 1)[1].split(
+        "\n## ", 1
+    )[0]
+    for deep_link in [
+        "docs/development/benchmark-developer-workflow.md",
+        "docs/product/foundations/project-level-reward-model.md",
+        "docs/reference/protocols/reward-memory-architecture-v0.md",
+        "docs/reference/protocols/reward-memory-architecture-v0.zh-CN.md",
+    ]:
+        assert deep_link not in advanced_docs
+        assert deep_link not in advanced_docs_zh
 
     for path in [
         "docs/archive/README.md",


### PR DESCRIPTION
## Summary

- replace the README's ambiguous `Validate and Govern` catch-all with task-oriented routes that mirror the canonical docs information architecture
- route operations, product foundations, integrations/protocols, contributor validation, evidence, and project governance through their owning indexes
- keep English and Chinese navigation in sync and add a focused governance smoke for section ownership

## Root cause

The project README maintained a second, coarse hand-curated taxonomy beside `docs/README.md`. Later documents were appended by title similarity, so quota, benchmark workflow, product reward, protocols, and project governance accumulated in the same bucket even though they have different audiences and owners.

## Validation

- `python3 examples/docs-governance-smoke.py`
- `python3 examples/public_entry/readme-demo-surface-smoke.py`
- `python3 -m py_compile examples/docs-governance-smoke.py`
- `git diff --check`
- `loopx check --scan-path README.md --scan-path README.zh-CN.md --scan-path examples/docs-governance-smoke.py`

All checks passed. No document paths moved, so existing external links remain stable. The candidate files contain no private state, credentials, raw evidence, or local paths introduced by this change.
