### PR TITLE
docs: classify Auto Research KNN demo as public

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ experiment independently.
 
 ### Auto Research
 
-**Redacted owner-run showcase: proposer, executor, and evaluator/promoter agents
+**Reproducible public KNN demo: proposer, executor, and evaluator/promoter agents
 iterate in parallel while todo, quota, evidence, and targeted wake remain
 visible.**
 
@@ -139,9 +139,12 @@ visible.**
   <img src="docs/assets/auto-research-multi-agent-showcase.png" alt="Auto Research multi-agent workspace with proposer, executor, evaluator/promoter, todo, quota, evidence, and targeted wake activity">
 </a>
 
-This redacted screenshot demonstrates the control-plane shape of one owner-run
-workflow. It does not establish a production research result, company or
-employer endorsement, or an independently reproducible evaluation.
+This screenshot comes from LoopX's built-in exact-KNN demo. The public task,
+editable and protected files, deterministic CPU evaluator, and dev/held-out
+commands all live in this repository. Follow the
+[showcase walkthrough](docs/product/use-cases/auto-research/decentralized-auto-research-showcase.md)
+or the [command path](docs/guides/auto-research-command-path.md) to reproduce the
+workflow; it is a demo result, not a production research claim.
 
 ### Used In Real Projects
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -116,15 +116,18 @@ owner-run showcase，不代表连续算力执行、独立复现、生产结果�
 
 ### Auto Research
 
-**经过脱敏的 owner-run showcase：Proposer、executor、evaluator/promoter
-并行迭代，todo、quota、证据与 targeted wake 同屏可见。**
+**可复现的公开 KNN demo：Proposer、executor、evaluator/promoter 并行迭代，
+todo、quota、证据与 targeted wake 同屏可见。**
 
 <a href="docs/assets/auto-research-multi-agent-showcase.png">
   <img src="docs/assets/auto-research-multi-agent-showcase.png" alt="Auto Research 多 Agent 工作区：proposer、executor、evaluator/promoter、todo、quota、证据与 targeted wake 同屏推进">
 </a>
 
-这张脱敏截图只用于说明一次 owner-run 工作流的控制面形态，不构成生产研究结果、
-公司或雇主背书，也不是可供第三方独立复现的评测证据。
+这张截图来自 LoopX 内置的 exact-KNN demo。公开 task、可编辑与受保护文件、
+deterministic CPU evaluator、dev / held-out 命令均在仓库内。可按
+[showcase walkthrough](docs/product/use-cases/auto-research/decentralized-auto-research-showcase.md)
+或 [command path](docs/guides/auto-research-command-path.md)复现工作流；它是 demo
+结果，不是生产研究结论。
 
 ### 真实项目中的使用
 

--- a/examples/public_entry/readme-demo-surface-smoke.py
+++ b/examples/public_entry/readme-demo-surface-smoke.py
@@ -25,7 +25,14 @@ def main() -> int:
     cross_runtime_index = read("docs/product/use-cases/cross-runtime/README.md")
     getting_started = read("docs/guides/getting-started.md")
     compact_readme = compact(readme)
+    compact_readme_zh = "".join(readme_zh.split())
     compact_demo = compact(demo)
+    auto_research = readme.split("### Auto Research", 1)[1].split(
+        "### Used In Real Projects", 1
+    )[0]
+    auto_research_zh = readme_zh.split("### Auto Research", 1)[1].split(
+        "### 真实项目中的使用", 1
+    )[0]
 
     for required in [
         '<div align="center">',
@@ -89,7 +96,7 @@ def main() -> int:
 
     for required in [
         "company or employer endorsement",
-        "independently reproducible evaluation",
+        "independent reproduction",
     ]:
         assert required in compact_readme, required
     for required in [
@@ -97,7 +104,23 @@ def main() -> int:
         "公司或雇主背书",
         "第三方独立复现",
     ]:
-        assert required in compact(readme_zh), required
+        assert required.replace(" ", "") in compact_readme_zh, required
+
+    for required in [
+        "Reproducible public KNN demo",
+        "deterministic CPU evaluator",
+        "docs/product/use-cases/auto-research/decentralized-auto-research-showcase.md",
+    ]:
+        assert required in auto_research, required
+    assert "redacted" not in auto_research.lower()
+
+    for required in [
+        "可复现的公开 KNN demo",
+        "deterministic CPU evaluator",
+        "docs/product/use-cases/auto-research/decentralized-auto-research-showcase.md",
+    ]:
+        assert required in auto_research_zh, required
+    assert "脱敏" not in auto_research_zh
 
     for required in [
         "`$loopx <complex task>`",


### PR DESCRIPTION
## Summary

- Correct the Auto Research README evidence label introduced in #2853: the pictured multi-role run is the repository's public exact-KNN demo, not a redacted private workflow.
- Link the English and Chinese descriptions to the canonical showcase walkthrough and command path while preserving the separate redacted boundary for Auto ML.
- Add section-scoped regression checks so Auto Research cannot be mislabeled as redacted again while Auto ML keeps its independent-reproduction disclaimer.

## Product And Architecture Judgment

The classification should follow the evidence owner. Auto Research already ships a public task, fixed editable/protected file boundary, deterministic CPU evaluator, dev and held-out commands, and a documented reproduction path. Reusing those canonical surfaces is more accurate and smaller than adding another evidence or redaction contract. This PR changes presentation only; it does not alter runtime, benchmark scoring, permissions, or publication authority.

## Validation

- `python3 examples/public_entry/readme-demo-surface-smoke.py`
- `python3 examples/docs-governance-smoke.py`
- `python3 -m py_compile examples/public_entry/readme-demo-surface-smoke.py`
- `loopx check --scan-path README.md --scan-path README.zh-CN.md --scan-path examples/public_entry/readme-demo-surface-smoke.py`
- `git diff --check`
- `loopx canary premerge --from-git-diff --goal-id loopx-meta --tier quick --no-progress`

All checks passed. The premerge gate reported no failures, skips, warnings, or manual holds and allowed self-merge. Exact-scope change-quality receipt: `cqr_5d07563081793c3ccbf7`.

## Boundary

No local state, credentials, raw sessions, private links, generated logs, or benchmark artifacts are included. The Auto ML redaction and endorsement boundaries remain unchanged.
