### PR TITLE
docs: sharpen LoopX stateful control-plane narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <img src="docs/assets/loopx-social-preview.png" alt="LoopX loop engineering social preview banner" width="560">
 
-**The local control plane for long-running AI agent work.**
+**The open, provider-neutral, stateful control plane for long-running agents.**
 
 <sub>Keep objectives, gates, todos, evidence, quota, and handoffs stable while Codex, Claude Code, Cursor, or your own runtime executes bounded turns.</sub>
 
@@ -20,10 +20,10 @@
 
 ---
 
-A lightweight state kernel and agent-agnostic local control plane for loop
-engineering, LoopX keeps long-running work reviewable, restartable, and easier
-to hand off across turns, tools, and agents. It does not replace your agent
-runtime.
+Open and provider-neutral, LoopX is a lightweight state kernel and local-first
+control plane for loop engineering. It keeps long-running work reviewable,
+restartable, and easier to hand off across turns, tools, and agents without
+replacing the runtime that performs the work.
 
 **Loop engineering for long-running AI agents and peer agent teams.**
 
@@ -56,6 +56,10 @@ Codex / Claude Code / Cursor / shell agent executes one turn
    ▼
 write evidence + handoff + next todo ─▶ quota decides the next tick
 ```
+
+Agent runtimes execute the work. LoopX governs the state that lets engineering,
+research, discovery, and operations loops continue across runs. It is not
+another agent framework or a provider-specific orchestration runtime.
 
 ![LoopX control-plane board](docs/assets/control-plane-board.svg)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 <img src="docs/assets/loopx-social-preview.png" alt="LoopX Loop Engineering 展示图" width="560">
 
-**面向长程 AI Agent 工作的本地控制面。**
+**面向长程 Agent 的开放、有状态、Provider-neutral 控制面。**
 
 <sub>Codex、Claude Code、Cursor 或自有 runtime 负责一次次有界执行；LoopX 让目标、gate、todo、证据、quota 和交接跨轮次保持稳定。</sub>
 
@@ -20,9 +20,9 @@
 
 ---
 
-LoopX 是一个轻量 state kernel，也是 agent-agnostic 的本地 Loop Engineering
-控制面。它不替代 agent runtime，而是让跨轮次、跨工具、跨 agent 的工作可审阅、
-可恢复、可接力。
+LoopX 是开放且 Provider-neutral 的轻量 state kernel，也是 local-first
+的 Loop Engineering 控制面。它不替代真正执行任务的 agent runtime，而是让
+跨轮次、跨工具、跨 agent 的工作可审阅、可恢复、可接力。
 
 > 让 Loop 持续向前，让关键判断留在人手里。
 
@@ -50,6 +50,10 @@ Codex / Claude Code / Cursor / shell agent 执行一轮
    ▼
 写回证据 + handoff + next todo ─▶ quota 决定下一次 tick
 ```
+
+Agent runtime 负责执行，LoopX 负责治理跨运行延续的控制状态，让工程、
+研究、discovery 和运营 Loop 能持续推进。它不是又一个 agent framework，也不是
+绑定某一 Provider 的编排 runtime。
 
 ![LoopX control-plane board](docs/assets/control-plane-board.svg)
 

--- a/apps/presentation/site/home.js
+++ b/apps/presentation/site/home.js
@@ -27,9 +27,9 @@ const zh = {
   "nav.showcases": "案例",
   "nav.docs": "文档",
   "nav.github": "GitHub",
-  "hero.eyebrow": "长程目标控制面",
+  "hero.eyebrow": "开放 · 有状态 · Provider-neutral",
   "hero.title": "Agent <span class=\"hero-phrase\"><span class=\"hero-wave\" data-hero-wave=\"progress\">持续推进</span>。</span><br />判断始终<span class=\"hero-phrase\"><span class=\"hero-wave\" data-hero-wave=\"judgment\">由你掌握</span>。</span>",
-  "hero.body": "面向跨会话、跨运行时、跨宿主的长程任务控制面，把权限状态、Gate、Todo、Quota、Evidence、恢复与交接组织在同一闭环中。",
+  "hero.body": "面向长程 Agent 的开放、有状态、Provider-neutral 控制面，把权限状态、Gate、Todo、Quota、Evidence、恢复与交接组织在同一闭环中。",
   "hero.copyPrompt": "复制 Agent 安装指令",
   "hero.promptCopied": "已复制，请粘贴给当前 Agent",
   "hero.copyFailed": "复制失败，请打开安装指南",
@@ -66,9 +66,9 @@ const zh = {
   "proof.sideLanesBody": "不绕过权限，独立工作仍可继续。",
   "proof.outcomes": "可审查结果",
   "proof.outcomesBody": "每次状态流转都为下一轮留下证据。",
-  "product.eyebrow": "一个持久的状态内核",
+  "product.eyebrow": "一个有状态控制面",
   "product.title": "让长程工作始终受控。",
-  "product.body": "LoopX 让目标生命周期、权限、恢复、干预、验证与结果在每次 Agent 运行之间保持一致。",
+  "product.body": "Agent runtime 负责执行；LoopX 治理跨运行延续的控制状态，让工程、研究、discovery 与运营 Loop 能持续推进。",
   "flow.goal": "长期目标",
   "flow.goalBody": "一个稳定方向",
   "flow.gate": "权限 Gate",
@@ -79,9 +79,9 @@ const zh = {
   "flow.evidenceBody": "经过验证的结果",
   "flow.next": "下一轮运行",
   "flow.nextBody": "可恢复地推进",
-  "capabilities.eyebrow": "跨会话、跨运行时、跨宿主",
-  "capabilities.title": "面向长程 Agent 的可治理连续性。",
-  "capabilities.body": "Codex App、Codex CLI、Claude Code、OpenCode 与自定义 Runner 可以共享同一套目标生命周期，同时让每个 Agent 保持明确边界。",
+  "capabilities.eyebrow": "跨 Provider、运行时与宿主",
+  "capabilities.title": "一套有状态控制面，连接不同 Agent Runtime。",
+  "capabilities.body": "Codex App、Codex CLI、Claude Code、OpenCode 与自定义 Runner 可以共享同一套有状态目标生命周期，同时让每个 Agent 保持明确边界。",
   "capabilities.state": "持久状态",
   "capabilities.stateBody": "目标、用户决策、Todo、Claim、Quota、运行历史与交接不会随会话结束而丢失。",
   "capabilities.runtime": "跨运行时",
@@ -188,8 +188,8 @@ function applyLanguage(nextLanguage, updateUrl = false) {
   }
   document.title = language === "zh" ? "LoopX — 让长程目标持续推进" : "LoopX — Keep the loop moving";
   document.querySelector('meta[name="description"]')?.setAttribute("content", language === "zh"
-    ? "LoopX 是面向跨会话、跨运行时与跨宿主长程 Agent 工作的目标级控制面。"
-    : "LoopX is a goal-level control plane for long-horizon agent work across sessions, runtimes, and hosts.");
+    ? "LoopX 是面向长程 Agent 的开放、有状态、Provider-neutral 控制面。"
+    : "LoopX is the open, provider-neutral, stateful control plane for long-running agents across sessions, runtimes, and hosts.");
   if (updateUrl) {
     const url = new URL(window.location.href);
     if (language === "zh") url.searchParams.set("lang", "zh");

--- a/apps/presentation/site/index.html
+++ b/apps/presentation/site/index.html
@@ -6,12 +6,12 @@
     <meta name="theme-color" content="#050914" />
     <meta
       name="description"
-      content="LoopX is a goal-level control plane for long-horizon agent work across sessions, runtimes, and hosts."
+      content="LoopX is the open, provider-neutral, stateful control plane for long-running agents across sessions, runtimes, and hosts."
     />
     <meta property="og:title" content="LoopX — Keep the loop moving" />
     <meta
       property="og:description"
-      content="Your agents keep the night shift. You keep the judgment."
+      content="The open, provider-neutral, stateful control plane for long-running agents."
     />
     <link rel="icon" href="data:," />
     <title>LoopX — Keep the loop moving</title>
@@ -53,10 +53,10 @@
       <section class="hero" aria-labelledby="hero-title">
         <div class="hero-grid" aria-hidden="true"></div>
         <div class="hero-copy">
-          <p class="eyebrow" data-i18n="hero.eyebrow">Goal-level control plane</p>
+          <p class="eyebrow" data-i18n="hero.eyebrow">Open · provider-neutral · stateful</p>
           <h1 id="hero-title" data-i18n-html="hero.title">Your agents keep<br /> the <span class="hero-phrase"><span class="hero-wave" data-hero-wave="progress">night shift</span>.</span><br />You keep the <span class="hero-phrase"><span class="hero-wave" data-hero-wave="judgment">judgment</span>.</span></h1>
           <p class="hero-body" data-i18n="hero.body">
-            A durable control plane for long-horizon work across sessions, runtimes, and hosts—keeping authority, gates, todos, quota, evidence, recovery, and handoffs in one loop.
+            An open, provider-neutral, stateful control plane for long-running agents—keeping authority, gates, todos, quota, evidence, recovery, and handoffs in one loop.
           </p>
           <div class="hero-actions">
             <button
@@ -150,9 +150,9 @@
 
       <section class="product-section reveal" id="product" aria-labelledby="product-title">
         <div class="section-heading">
-          <p class="eyebrow" data-i18n="product.eyebrow">One durable state kernel</p>
+          <p class="eyebrow" data-i18n="product.eyebrow">One stateful control plane</p>
           <h2 id="product-title" data-i18n="product.title">Long-running work stays governed.</h2>
-          <p data-i18n="product.body">LoopX keeps the goal lifecycle, authority, recovery, intervention, validation, and outcomes coherent across every agent run.</p>
+          <p data-i18n="product.body">Agent runtimes execute the work. LoopX governs the state that lets engineering, research, discovery, and operations loops continue coherently across runs.</p>
         </div>
         <div class="state-flow" id="workflow">
           <div class="flow-line" aria-hidden="true"><i></i></div>
@@ -166,8 +166,8 @@
 
       <section class="capability-section reveal" aria-labelledby="capability-title">
         <div class="section-heading split-heading">
-          <div><p class="eyebrow" data-i18n="capabilities.eyebrow">Across sessions, runtimes, and hosts</p><h2 id="capability-title" data-i18n="capabilities.title">Governed continuity for long-horizon agents.</h2></div>
-          <p data-i18n="capabilities.body">Codex App, Codex CLI, Claude Code, OpenCode, and custom runners can share one goal lifecycle while each agent stays inside an explicit scope.</p>
+          <div><p class="eyebrow" data-i18n="capabilities.eyebrow">Across providers, runtimes, and hosts</p><h2 id="capability-title" data-i18n="capabilities.title">One governed loop across agent runtimes.</h2></div>
+          <p data-i18n="capabilities.body">Codex App, Codex CLI, Claude Code, OpenCode, and custom runners can share one stateful goal lifecycle while each agent stays inside an explicit scope.</p>
         </div>
         <div class="capability-grid">
           <article><span class="capability-number">01</span><h3 data-i18n="capabilities.state">Durable state</h3><p data-i18n="capabilities.stateBody">Goals, user decisions, todos, claims, quota, run history, and handoffs survive session boundaries.</p></article>

--- a/examples/public_entry/readme-demo-surface-smoke.py
+++ b/examples/public_entry/readme-demo-surface-smoke.py
@@ -39,7 +39,7 @@ def main() -> int:
         "docs/assets/loopx-social-preview.png",
         "LoopX loop engineering social preview banner",
         "Loop engineering for long-running AI agents and peer agent teams.",
-        "A lightweight state kernel and agent-agnostic local control plane for",
+        "The open, provider-neutral, stateful control plane for long-running agents.",
         "Keep objectives, gates, todos, evidence, quota, and handoffs stable",
         "## Why LoopX",
         "objective / issue / project",

--- a/examples/showcase-catalog-smoke.py
+++ b/examples/showcase-catalog-smoke.py
@@ -266,7 +266,7 @@ def main() -> int:
         assert phrase in feedback_loop, phrase
     for phrase in (
         "Loop engineering for long-running AI agents and peer agent teams.",
-        "A lightweight state kernel and agent-agnostic local control plane for",
+        "The open, provider-neutral, stateful control plane for long-running agents.",
         "https://huangruiteng.github.io/loopx/",
         "## Advanced Paths",
         "docs/assets/long-running-loop-openviking-trajectory.png",


### PR DESCRIPTION
## Summary

- position LoopX consistently as the open, provider-neutral, stateful control plane for long-running agents
- clarify the product boundary: agent runtimes execute work while LoopX governs durable cross-run state
- keep `local-first` as a deployment and trust property, and preserve the existing runtime/provider integrations
- update the two public-entry smoke contracts that pinned the previous canonical sentence

## Review

The English and Chinese README first screens and the public homepage first screen were previewed locally and approved by the owner before this PR was opened.

## Validation

- `python3 examples/frontstage-pages-workflow-smoke.py`
- `python3 examples/frontstage-two-surface-strategy-smoke.py`
- `python3 examples/showcase-catalog-smoke.py`
- `python3 examples/public_entry/readme-demo-surface-smoke.py`
- `node --check apps/presentation/site/home.js`
- `loopx check` on all six changed public files: 0 errors, 0 warnings
- `loopx canary premerge --from-git-diff`: 16 selected checks passed, 0 failures, 0 warnings, 0 manual holds
- change-quality receipt: `cqr_c4c9c6b1f30eba720000` (`pass`)
