### PR TITLE
test(install): align PR review metadata expectation

### DIFF
--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -398,7 +398,7 @@ def main() -> int:
         pr_review_metadata = pr_review_skill.parent / "agents" / "openai.yaml"
         pr_review_metadata_text = pr_review_metadata.read_text(encoding="utf-8")
         assert (
-            'short_description: "Guide AgentLoop through LoopX PR review queues"'
+            'short_description: "Review LoopX PRs with deep key-code explanations"'
             in pr_review_metadata_text
         ), pr_review_metadata_text
         assert "Guide agentloop" not in pr_review_metadata_text, pr_review_metadata_text


### PR DESCRIPTION
## Summary

- align the installer smoke expectation with the current LoopX PR Review metadata shipped by #2860
- keep the regression repair to one assertion string; no runtime or skill behavior changes

## Root cause

PR #2860 intentionally changed the packaged short description to describe deep key-code explanations, but the broader installer smoke still expected the previous queue-oriented text. Full Public Smokes therefore failed after successfully installing the current skill metadata.

## Validation

- supported Python 3.13: `python3 examples/install-local-smoke.py`
- `python3 -m py_compile examples/install-local-smoke.py`
- `uv run --with "mypy>=1.18,<2" mypy`
- `uv run --with ruff ruff check examples/install-local-smoke.py`
- `loopx check --scan-path examples/install-local-smoke.py`: 0 errors, 0 warnings
- `loopx canary premerge --from-git-diff`: standard tier passed, 5/5 selected checks
- change-quality receipt `cqr_6e87adc8483d178348d4`: pass
- `git diff --check`

## Scope and risk

Changed surface: `examples/install-local-smoke.py` only. No private state, credentials, local paths, raw logs, runtime behavior, permissions, or release behavior are included. No validation failures, skips, or manual holds remain. The installer, packaged-install, update, maintainability, and public-boundary canaries are sufficient for this metadata-only regression.