### PR TITLE
docs(star-history): refine chart presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ surface.
 ## Star History
 
 <p align="center">
-  <a href="https://github.com/huangruiteng/loopx/stargazers"><img src="https://huangruiteng.github.io/loopx/site-assets/star-history.svg" alt="LoopX GitHub star history from verified snapshots" width="900"></a><br>
+  <a href="https://github.com/huangruiteng/loopx/stargazers"><img src="https://huangruiteng.github.io/loopx/site-assets/star-history.svg" alt="LoopX GitHub star history from verified snapshots" width="800"></a><br>
   <sub>Generated every six hours from GitHub's official stargazer timestamps using a repository-authorized workflow. A snapshot is published only when the fetched rows match GitHub's current star count; GitHub's image cache may delay refreshes.</sub>
 </p>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -509,7 +509,7 @@ Loop 的 terminal acceptance、补足独立采用与 outcome evidence，并打�
 ## Star 趋势
 
 <p align="center">
-  <a href="https://github.com/huangruiteng/loopx/stargazers"><img src="https://huangruiteng.github.io/loopx/site-assets/star-history.svg" alt="LoopX GitHub Star 历史趋势，来自已校验快照" width="900"></a><br>
+  <a href="https://github.com/huangruiteng/loopx/stargazers"><img src="https://huangruiteng.github.io/loopx/site-assets/star-history.svg" alt="LoopX GitHub Star 历史趋势，来自已校验快照" width="800"></a><br>
   <sub>由仓库授权的 workflow 每 6 小时基于 GitHub 官方 stargazer 时间戳生成；仅当拉取条数与 GitHub 当前 Star 总数一致时发布。GitHub 图片缓存可能延迟刷新。</sub>
 </p>
 

--- a/examples/readme-star-history-smoke.py
+++ b/examples/readme-star-history-smoke.py
@@ -73,9 +73,13 @@ def main() -> int:
         svg = output.read_text(encoding="utf-8")
         root = ET.fromstring(svg)
         assert root.tag.endswith("svg")
+        assert root.attrib["viewBox"] == "0 0 800 500"
         assert 'role="img" aria-labelledby="title desc"' in svg
         assert "@media (prefers-color-scheme: dark)" in svg
-        assert "huangruiteng/loopx · 4 stars · updated 2026-08-06" in svg
+        assert "4 stars · updated Aug 6, 2026" in svg
+        assert '<text x="25" y="18" class="legend">huangruiteng/loopx</text>' in svg
+        assert "GitHub stars" in svg
+        assert "<polygon" not in svg
         assert "<script" not in svg.lower()
         assert "http://" not in svg.replace("http://www.w3.org/2000/svg", "")
         assert "https://" not in svg
@@ -83,7 +87,7 @@ def main() -> int:
         empty_output = temp / "empty.svg"
         _render([], empty_output)
         empty_svg = empty_output.read_text(encoding="utf-8")
-        assert "huangruiteng/loopx · 0 stars · updated 2026-08-06" in empty_svg
+        assert "0 stars · updated Aug 6, 2026" in empty_svg
 
         mismatch = _render(
             [{"starred_at": "2026-08-01T09:45:00Z"}],
@@ -100,10 +104,11 @@ def main() -> int:
     }
     for readme, sections in readme_sections.items():
         text = readme.read_text(encoding="utf-8")
+        positions = [text.index(section) for section in sections]
         assert text.count(IMAGE_URL) == 1, readme
         assert "https://github.com/huangruiteng/loopx/stargazers" in text, readme
+        assert 'width="800"' in text[positions[1] : positions[2]], readme
         assert "star-history.dera.page" not in text, readme
-        positions = [text.index(section) for section in sections]
         assert positions == sorted(positions), (readme, sections)
         assert "\n## " not in text[positions[-1] + len(sections[-1]) :], readme
 

--- a/scripts/render-star-history.py
+++ b/scripts/render-star-history.py
@@ -39,17 +39,36 @@ def _load_stargazers(path: Path) -> list[date]:
     return dates
 
 
-def _nice_ceiling(value: int) -> int:
+def _nice_scale(value: int, *, target_intervals: int = 7) -> tuple[int, int]:
     if value <= 1:
-        return 1
-    rough_step = value / 4
+        return 1, 1
+    rough_step = value / target_intervals
     magnitude = 10 ** math.floor(math.log10(rough_step))
     scaled_step = rough_step / magnitude
     factor = next(
         candidate for candidate in (1, 2, 2.5, 5, 10) if scaled_step <= candidate
     )
-    step = factor * magnitude
-    return int(math.ceil(value / step) * step)
+    step = max(1, int(factor * magnitude))
+    return int(math.ceil(value / step) * step), step
+
+
+def _format_count(value: int) -> str:
+    if value < 1_000:
+        return str(value)
+    scaled = value / 1_000
+    return f"{scaled:.0f}k" if scaled.is_integer() else f"{scaled:.1f}k"
+
+
+def _format_tick_date(day: date, *, span_days: int) -> str:
+    if span_days >= 730:
+        return str(day.year)
+    if span_days >= 120:
+        return f"{day:%b} {day.year}"
+    return f"{day:%b} {day.day}"
+
+
+def _format_display_date(day: date) -> str:
+    return f"{day:%b} {day.day}, {day.year}"
 
 
 def _timeline(stars: list[date], *, as_of: date) -> list[tuple[date, int]]:
@@ -71,11 +90,11 @@ def render_svg(repo: str, stars: list[date], *, as_of: date) -> str:
     total = points[-1][1]
     start = points[0][0]
     span_days = max((as_of - start).days, 1)
-    width, height = 960, 420
-    left, right, top, bottom = 78, 28, 72, 62
+    width, height = 800, 500
+    left, right, top, bottom = 76, 30, 108, 72
     plot_width = width - left - right
     plot_height = height - top - bottom
-    y_max = _nice_ceiling(total)
+    y_max, y_step = _nice_scale(total)
 
     def x_for(day: date) -> float:
         return left + ((day - start).days / span_days) * plot_width
@@ -85,63 +104,69 @@ def render_svg(repo: str, stars: list[date], *, as_of: date) -> str:
 
     chart_points = [(x_for(day), y_for(value)) for day, value in points]
     line = " ".join(f"{x:.1f},{y:.1f}" for x, y in chart_points)
-    area = (
-        f"{left},{top + plot_height} "
-        + line
-        + f" {left + plot_width},{top + plot_height}"
-    )
-
     y_grid: list[str] = []
-    for index in range(5):
-        value = round(y_max * index / 4)
+    value = 0
+    while value <= y_max:
         y = y_for(value)
         y_grid.append(
             f'<line x1="{left}" y1="{y:.1f}" x2="{left + plot_width}" y2="{y:.1f}" class="grid"/>'
-            f'<text x="{left - 14}" y="{y + 4:.1f}" class="axis" text-anchor="end">{value}</text>'
+            f'<text x="{left - 12}" y="{y + 4:.1f}" class="axis" text-anchor="end">{_format_count(value)}</text>'
         )
+        value += y_step
 
     x_labels: list[str] = []
-    for index in range(5):
-        day = start + timedelta(days=round(span_days * index / 4))
+    for index in range(6):
+        day = start + timedelta(days=round(span_days * index / 5))
         x = x_for(day)
-        anchor = "start" if index == 0 else "end" if index == 4 else "middle"
+        anchor = "start" if index == 0 else "end" if index == 5 else "middle"
         x_labels.append(
-            f'<text x="{x:.1f}" y="{top + plot_height + 34}" class="axis" text-anchor="{anchor}">{day:%Y-%m-%d}</text>'
+            f'<text x="{x:.1f}" y="{top + plot_height + 28}" class="axis" text-anchor="{anchor}">{_format_tick_date(day, span_days=span_days)}</text>'
         )
 
     safe_repo = escape(repo)
+    legend_width = min(260, max(154, 34 + len(repo) * 7))
+    display_date = _format_display_date(as_of)
     return f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" role="img" aria-labelledby="title desc">
   <title id="title">{safe_repo} GitHub star history</title>
   <desc id="desc">Cumulative public GitHub stars through {as_of.isoformat()}: {total}.</desc>
   <style>
     .background {{ fill: #ffffff; }}
-    .grid {{ stroke: #dbe5f3; stroke-width: 1; }}
-    .axis {{ fill: #65748a; font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }}
-    .title {{ fill: #0d1b2f; font: 600 22px ui-sans-serif, system-ui, sans-serif; }}
-    .meta {{ fill: #65748a; font: 13px ui-sans-serif, system-ui, sans-serif; }}
-    .area {{ fill: url(#area-gradient); }}
-    .line {{ fill: none; stroke: #2f80ed; stroke-width: 4; stroke-linecap: round; stroke-linejoin: round; }}
-    .point {{ fill: #ffffff; stroke: #2f80ed; stroke-width: 3; }}
+    .grid {{ stroke: #e5e7eb; stroke-width: 1; stroke-dasharray: 3 5; }}
+    .axis-line {{ stroke: #9ca3af; stroke-width: 1.5; }}
+    .axis {{ fill: #667085; font: 12px ui-sans-serif, system-ui, sans-serif; }}
+    .axis-title {{ fill: #667085; font: 12px ui-sans-serif, system-ui, sans-serif; }}
+    .title {{ fill: #101828; font: 600 22px ui-sans-serif, system-ui, sans-serif; }}
+    .meta {{ fill: #667085; font: 13px ui-sans-serif, system-ui, sans-serif; }}
+    .legend-box {{ fill: #ffffff; stroke: #d0d5dd; stroke-width: 1; }}
+    .legend {{ fill: #344054; font: 12px ui-sans-serif, system-ui, sans-serif; }}
+    .legend-dot {{ fill: #f05235; }}
+    .line {{ fill: none; stroke: #f05235; stroke-width: 3.5; stroke-linecap: round; stroke-linejoin: round; }}
+    .point {{ fill: #ffffff; stroke: #f05235; stroke-width: 3; }}
     @media (prefers-color-scheme: dark) {{
-      .background {{ fill: #07101f; }}
-      .grid {{ stroke: #21324a; }}
-      .axis, .meta {{ fill: #91a2b9; }}
-      .title {{ fill: #e8eef7; }}
-      .point {{ fill: #07101f; }}
+      .background {{ fill: #0d1117; }}
+      .grid {{ stroke: #30363d; }}
+      .axis-line {{ stroke: #6e7681; }}
+      .axis, .axis-title, .meta {{ fill: #8b949e; }}
+      .title {{ fill: #f0f6fc; }}
+      .legend-box {{ fill: #161b22; stroke: #30363d; }}
+      .legend {{ fill: #c9d1d9; }}
+      .point {{ fill: #0d1117; }}
     }}
   </style>
-  <defs>
-    <linearGradient id="area-gradient" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#2f80ed" stop-opacity="0.32"/>
-      <stop offset="100%" stop-color="#2f80ed" stop-opacity="0.03"/>
-    </linearGradient>
-  </defs>
-  <rect width="{width}" height="{height}" rx="12" class="background"/>
-  <text x="{left}" y="36" class="title">GitHub Star History</text>
-  <text x="{left}" y="57" class="meta">{safe_repo} · {total} stars · updated {as_of.isoformat()}</text>
+  <rect width="{width}" height="{height}" class="background"/>
+  <text x="{width / 2:.0f}" y="34" class="title" text-anchor="middle">Star History</text>
+  <text x="{width / 2:.0f}" y="56" class="meta" text-anchor="middle">{total:,} stars · updated {display_date}</text>
+  <g transform="translate({left},72)">
+    <rect width="{legend_width}" height="28" rx="6" class="legend-box"/>
+    <circle cx="13" cy="14" r="4" class="legend-dot"/>
+    <text x="25" y="18" class="legend">{safe_repo}</text>
+  </g>
   {''.join(y_grid)}
   {''.join(x_labels)}
-  <polygon points="{area}" class="area"/>
+  <line x1="{left}" y1="{top}" x2="{left}" y2="{top + plot_height}" class="axis-line"/>
+  <line x1="{left}" y1="{top + plot_height}" x2="{left + plot_width}" y2="{top + plot_height}" class="axis-line"/>
+  <text x="20" y="{top + plot_height / 2:.1f}" class="axis-title" text-anchor="middle" transform="rotate(-90 20 {top + plot_height / 2:.1f})">GitHub stars</text>
+  <text x="{left + plot_width / 2:.1f}" y="{height - 16}" class="axis-title" text-anchor="middle">Date</text>
   <polyline points="{line}" class="line"/>
   <circle cx="{chart_points[-1][0]:.1f}" cy="{chart_points[-1][1]:.1f}" r="5" class="point"/>
 </svg>


### PR DESCRIPTION
## Summary

- restyle the self-hosted star-history SVG as a compact `800x500` line chart
- replace the filled dashboard treatment with abbreviated axes, lighter grids, a repository legend, and light/dark system themes
- keep the official stargazer source, completeness gate, workflow, and Pages URL unchanged
- render the bilingual README chart at its native 800px width

## Why

Mainstream repositories generally present star history as quiet supporting evidence. LoopX's previous `960x420` filled chart was visually heavier than the familiar Star History convention and made its real early-flat/late-growth data shape harder to scan. Third-party charts were also stale for LoopX, so this keeps the verified self-hosted data path and only refines presentation.

## Validation

- `python3 examples/readme-star-history-smoke.py`
- `python3 examples/frontstage-pages-workflow-smoke.py`
- `npm run smoke:frontstage-share-bundle`
- production frontstage export
- `python3 examples/showcase-catalog-smoke.py`
- `mkdocs build --strict`
- repository-declared `python -m mypy` (15 files)
- `loopx check` on all four changed files: 0 errors, 0 warnings
- complete 3,344-row stargazer snapshot rendered and inspected in light, dark, desktop, and narrow views
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 14 selected checks passed, 0 failures, 0 holds
- change-quality receipt `cqr_fe89266cbad35e58db32`: valid

An additional latest-Ruff probe is not a repository gate for these scripts and reports existing baseline EXE/import/modernization rules in both touched files; this PR does not mix that unrelated cleanup into the visual change.

## Boundaries

- no fetch, token, workflow, publication, or completeness semantics changed
- no external chart or font dependency added
- no credentials, private state, generated star data, screenshots, or local paths committed
