### PR TITLE
fix(todo): require explicit lifecycle command

### DIFF
--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -75,7 +75,7 @@ def register_todo_command(
             "suggest",
             "capture-followups",
         ],
-        default="add",
+        default=None,
         help=(
             "Use add to append a checkbox todo, claim to soft-claim by registered "
             "agent id, list to read projected todos, update/complete/supersede to transition by todo_id, or "
@@ -415,6 +415,12 @@ def handle_todo_command(
         else render_todo_markdown
     )
     try:
+        if args.todo_command is None:
+            raise ValueError(
+                "`loopx todo` requires an explicit command; use `loopx todo add`, "
+                "`loopx todo claim`, `loopx todo update`, or another command shown "
+                "by `loopx todo --help`"
+            )
         validate_shared_todo_options(args)
         validate_capability_gap_options(args)
         if args.todo_command == "list":

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -81,6 +81,42 @@ def test_todo_handler_expands_shared_paths_and_keeps_suggest_project_only(
     assert "state_file" not in captured_suggest
 
 
+def test_todo_requires_explicit_command_without_mutating_state(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fail_if_add_is_called(**_kwargs: object) -> dict[str, object]:
+        pytest.fail("omitting the todo command must not fall back to todo add")
+
+    monkeypatch.setattr(todo_command, "add_goal_todo", fail_if_add_is_called)
+
+    exit_code = main(
+        [
+            "--format",
+            "json",
+            "todo",
+            "--goal-id",
+            "example-goal",
+            "--todo-id",
+            "todo_example",
+            "--role",
+            "agent",
+            "--text",
+            "Accidental replacement todo.",
+        ]
+    )
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["added"] is False
+    assert payload["error"] == (
+        "`loopx todo` requires an explicit command; use `loopx todo add`, "
+        "`loopx todo claim`, `loopx todo update`, or another command shown "
+        "by `loopx todo --help`"
+    )
+
+
 @pytest.mark.parametrize(
     "argv",
     [


### PR DESCRIPTION
## Problem

A real long-running Ark Goal attempted to claim and update a Todo while omitting the lifecycle verb. The optional positional command silently defaulted to add, so a sufficiently complete mistaken invocation could create a new Todo instead of transitioning the intended one.

## Change

Remove the implicit add fallback. Invocations must explicitly select add, claim, update, complete, or another documented lifecycle command. An omitted command now returns an actionable nonzero error before any state mutation.

## Evidence

- tests/test_cli_argument_diagnostics.py: 81 passed
- todo-cli-smoke: passed
- todo-lifecycle-cli-smoke: passed
- LoopX premerge gate: 17/17 passed, no holds

## Scope

Generic Todo CLI safety fix discovered by the LoopX-on-Ark no-adapter soak. No capability-specific Todo schema or Ark integration dependency.