### PR TITLE
fix(goal): parse conversational route in CLI

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -816,14 +816,18 @@ On a host with the LoopX slash entry, start the long-running goal directly:
 ```
 
 For a manually integrated host, inspect the command pack and then start the
-same exact goal text through the guided CLI transaction:
+same exact conversational arguments through the guided CLI transaction:
 
 ```bash
 loopx bootstrap-command-pack --project .
 loopx start-goal --guided --project . \
-  --capability-route issue-fix \
-  --goal-text "Fix https://github.com/owner/repo/issues/123"
+  --slash-command-arguments="--capability-route issue-fix Fix https://github.com/owner/repo/issues/123"
 ```
+
+Typed callers that already own separate fields may instead pass
+`--capability-route issue-fix` with `--goal-text`. Generated conversational
+entries use the single raw-argument form so route parsing stays in the CLI
+rather than in model instructions.
 
 The explicit route switch does not bypass issue selection, authority, or
 validation. Without it, goal text never activates issue-fix. With it, the

--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -815,19 +815,12 @@ On a host with the LoopX slash entry, start the long-running goal directly:
 /loopx --capability-route issue-fix Fix https://github.com/owner/repo/issues/123
 ```
 
-For a manually integrated host, inspect the command pack and then start the
-same exact conversational arguments through the guided CLI transaction:
-
-```bash
-loopx bootstrap-command-pack --project .
-loopx start-goal --guided --project . \
-  --slash-command-arguments="--capability-route issue-fix Fix https://github.com/owner/repo/issues/123"
-```
-
+For a manually integrated host, run `loopx bootstrap-command-pack --project .`
+and pass the same complete arguments once through
+`loopx start-goal --guided --project . --slash-command-arguments="..."`.
 Typed callers that already own separate fields may instead pass
-`--capability-route issue-fix` with `--goal-text`. Generated conversational
-entries use the single raw-argument form so route parsing stays in the CLI
-rather than in model instructions.
+`--capability-route issue-fix` with `--goal-text`; the CLI owns route parsing in
+both forms.
 
 The explicit route switch does not bypass issue selection, authority, or
 validation. Without it, goal text never activates issue-fix. With it, the

--- a/docs/reference/protocols/loopx-goal-command-v0.md
+++ b/docs/reference/protocols/loopx-goal-command-v0.md
@@ -176,6 +176,10 @@ continue to use structured `--capability-route` plus `--goal-text`. These two
 input forms are mutually exclusive, and malformed or unsupported leading route
 switches fail closed before the guided transaction is built.
 
+Only the leading `--capability-route` switch is parsed. A later occurrence of
+the same text in the raw argument string is ordinary goal text and is not an
+error.
+
 `start-goal` projects that explicit switch as a typed
 `selected_capability_route`.
 This is a bootstrap-only selection, not later-turn authority. The guided

--- a/docs/reference/protocols/loopx-goal-command-v0.md
+++ b/docs/reference/protocols/loopx-goal-command-v0.md
@@ -167,6 +167,15 @@ caller must explicitly pass `--capability-route issue-fix` to `start-goal` (or
 use the equivalent explicit host switch). Issue/PR wording, a public URL, or the
 literal string `issue-fix` remain objective text only and grant no route.
 
+Conversational hosts must not ask the model to split that switch from the goal
+text and then rebuild separate CLI arguments. Their generated `/loopx` entry
+passes the complete visible argument string once through
+`start-goal --slash-command-arguments`; the CLI consumes only a leading typed
+route switch and treats the remainder as goal text. Direct integrations may
+continue to use structured `--capability-route` plus `--goal-text`. These two
+input forms are mutually exclusive, and malformed or unsupported leading route
+switches fail closed before the guided transaction is built.
+
 `start-goal` projects that explicit switch as a typed
 `selected_capability_route`.
 This is a bootstrap-only selection, not later-turn authority. The guided

--- a/examples/issue-fix-workflow-contract-smoke.py
+++ b/examples/issue-fix-workflow-contract-smoke.py
@@ -89,7 +89,8 @@ def main() -> int:
     ) in readme
     assert "loopx bootstrap-command-pack --project ." in readme
     assert "--capability-route issue-fix" in readme
-    assert "--goal-text \"Fix https://github.com/owner/repo/issues/123\"" in readme
+    assert "--slash-command-arguments=" in readme
+    assert "single raw-argument form" in readme
     assert "loopx issue-fix workflow-plan" in readme
     assert "loopx issue-fix feasibility" in readme
     assert "loopx issue-fix pr-lifecycle" in readme
@@ -103,6 +104,8 @@ def main() -> int:
     assert "explicit gates" in readme
     assert "## Explicit Issue-Fix Capability Route" in loopx_goal_command
     assert "Goal text never selects a product capability" in loopx_goal_command
+    assert "start-goal --slash-command-arguments" in loopx_goal_command
+    assert "switches fail closed before the guided transaction" in loopx_goal_command
     assert "loopx issue-fix workflow-plan" in loopx_goal_command
     assert "--repository-context-json <compact-context.json>" in loopx_goal_command
     assert "--goal-id <goal-id>" in loopx_goal_command

--- a/examples/issue-fix-workflow-contract-smoke.py
+++ b/examples/issue-fix-workflow-contract-smoke.py
@@ -90,7 +90,7 @@ def main() -> int:
     assert "loopx bootstrap-command-pack --project ." in readme
     assert "--capability-route issue-fix" in readme
     assert "--slash-command-arguments=" in readme
-    assert "single raw-argument form" in readme
+    assert "CLI owns route parsing" in readme
     assert "loopx issue-fix workflow-plan" in readme
     assert "loopx issue-fix feasibility" in readme
     assert "loopx issue-fix pr-lifecycle" in readme
@@ -106,6 +106,9 @@ def main() -> int:
     assert "Goal text never selects a product capability" in loopx_goal_command
     assert "start-goal --slash-command-arguments" in loopx_goal_command
     assert "switches fail closed before the guided transaction" in loopx_goal_command
+    assert "Only the leading `--capability-route` switch is parsed" in loopx_goal_command
+    assert "is ordinary goal text and is not an" in loopx_goal_command
+    assert "error." in loopx_goal_command
     assert "loopx issue-fix workflow-plan" in loopx_goal_command
     assert "--repository-context-json <compact-context.json>" in loopx_goal_command
     assert "--goal-id <goal-id>" in loopx_goal_command

--- a/loopx/cli_commands/starter_bootstrap.py
+++ b/loopx/cli_commands/starter_bootstrap.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 from collections.abc import Callable
 from pathlib import Path
 
@@ -10,6 +11,7 @@ from ..agent_onboarding import (
     render_agent_onboarding_markdown,
 )
 from ..bootstrap_command_pack import (
+    START_GOAL_CAPABILITY_ROUTES,
     build_loopx_bootstrap_command_pack,
     build_start_goal_guided_packet,
     build_start_goal_host_surface_selection_packet,
@@ -46,6 +48,49 @@ def _current_host_thread_id(args: argparse.Namespace) -> str | None:
     if getattr(args, "host_surface", None) == "codex-app":
         return os.environ.get("CODEX_THREAD_ID") or None
     return None
+
+
+_CAPABILITY_ROUTE_SWITCH = "--capability-route"
+_CAPABILITY_ROUTE_PREFIX = re.compile(
+    r"\A--capability-route(?:=(?P<equals>\S+)|\s+(?P<spaced>\S+))"
+    r"(?P<remainder>[\s\S]*)\Z"
+)
+
+
+def _resolve_start_goal_input(args: argparse.Namespace) -> tuple[str, str | None]:
+    raw_arguments = getattr(args, "slash_command_arguments", None)
+    capability_route = getattr(args, "capability_route", None)
+    if raw_arguments is None:
+        return str(args.goal_text), capability_route
+    if capability_route is not None:
+        raise ValueError(
+            "--slash-command-arguments cannot be combined with --capability-route; "
+            "the raw argument string already owns the optional route switch"
+        )
+
+    normalized = str(raw_arguments).strip()
+    if not normalized:
+        raise ValueError("--slash-command-arguments must contain goal text")
+    if not normalized.startswith(_CAPABILITY_ROUTE_SWITCH):
+        return normalized, None
+
+    match = _CAPABILITY_ROUTE_PREFIX.fullmatch(normalized)
+    if match is None:
+        raise ValueError(
+            "malformed leading --capability-route in --slash-command-arguments"
+        )
+    route = str(match.group("equals") or match.group("spaced") or "")
+    if route not in START_GOAL_CAPABILITY_ROUTES:
+        raise ValueError(
+            "unsupported --capability-route; expected one of: "
+            + ", ".join(START_GOAL_CAPABILITY_ROUTES)
+        )
+    goal_text = str(match.group("remainder") or "").strip()
+    if not goal_text:
+        raise ValueError(
+            "--slash-command-arguments must contain goal text after --capability-route"
+        )
+    return goal_text, route
 
 
 def handle_new_project_prompt_command(
@@ -137,6 +182,20 @@ def handle_start_goal_command(
         }
         print_payload(payload, args.format, render_start_goal_guided_markdown)
         return 2
+    try:
+        goal_text, capability_route = _resolve_start_goal_input(args)
+    except ValueError as exc:
+        payload = {
+            "ok": False,
+            "schema_version": "loopx_start_goal_guided_v0",
+            "error": str(exc),
+            "suggested_command": (
+                "loopx start-goal --guided "
+                "--slash-command-arguments='<exact /loopx arguments>'"
+            ),
+        }
+        print_payload(payload, args.format, render_start_goal_guided_markdown)
+        return 2
     if not args.host_surface:
         payload = build_start_goal_host_surface_selection_packet(
             project=Path(args.project),
@@ -145,9 +204,9 @@ def handle_start_goal_command(
             thread_id=_current_host_thread_id(args),
             new_peer=bool(getattr(args, "new_peer", False)),
             cli_bin=args.cli_bin,
-            goal_text=args.goal_text,
+            goal_text=goal_text,
             available_capabilities=args.available_capabilities,
-            capability_route=args.capability_route,
+            capability_route=capability_route,
             include_command_pack_detail=bool(args.include_command_pack_detail),
         )
         print_payload(payload, args.format, render_start_goal_guided_markdown)
@@ -160,9 +219,9 @@ def handle_start_goal_command(
         new_peer=bool(getattr(args, "new_peer", False)),
         cli_bin=args.cli_bin,
         host_surface=args.host_surface,
-        goal_text=args.goal_text,
+        goal_text=goal_text,
         available_capabilities=args.available_capabilities,
-        capability_route=args.capability_route,
+        capability_route=capability_route,
         include_command_pack_detail=bool(args.include_command_pack_detail),
     )
     print_payload(payload, args.format, render_start_goal_guided_markdown)

--- a/loopx/cli_commands/starter_bootstrap_registration.py
+++ b/loopx/cli_commands/starter_bootstrap_registration.py
@@ -169,7 +169,19 @@ def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) 
         help="Capability available in this host loop. Repeat for multiple capabilities.",
     )
     _add_capability_route_argument(start_goal_parser)
-    start_goal_parser.add_argument("--goal-text", required=True, help="Exact goal text to plan before todo writeback.")
+    goal_input_group = start_goal_parser.add_mutually_exclusive_group(required=True)
+    goal_input_group.add_argument(
+        "--goal-text",
+        help="Exact goal text to plan before todo writeback.",
+    )
+    goal_input_group.add_argument(
+        "--slash-command-arguments",
+        help=(
+            "Complete visible /loopx arguments. The CLI consumes only an optional "
+            "leading --capability-route switch and treats the remainder as goal text. "
+            "Use --slash-command-arguments='<arguments>' when the value begins with --."
+        ),
+    )
     start_goal_parser.add_argument(
         "--include-command-pack-detail",
         action="store_true",

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -108,6 +108,30 @@ def _opencode_command_body(spec: dict[str, Any]) -> str:
     ) + "\n"
 
 
+def _loopx_start_goal_arguments_instruction(
+    *,
+    cli_bin: str,
+    host_surface: str | None,
+) -> str:
+    selected_host = host_surface or "<exact-current-host>"
+    instruction = (
+        "If arguments are present, pass the complete visible command arguments "
+        "unchanged as one value to "
+        f'`{cli_bin} start-goal --guided --project . --slash-command-arguments='
+        f'"<complete visible $ARGUMENTS>" --host-surface {selected_host}`. '
+        "The CLI, not the model, owns parsing the optional leading typed "
+        "`--capability-route issue-fix` switch and preserving the remaining goal "
+        "text. Never split and recompose the switch. Never infer a route from "
+        "issue/PR wording or URLs."
+    )
+    if host_surface is None:
+        instruction += (
+            " If the host is unclear, omit the host flag once and follow the "
+            "returned host-surface selection gate."
+        )
+    return instruction
+
+
 def _command_prompt_specs(*, cli_bin: str, include_legacy_aliases: bool) -> list[dict[str, Any]]:
     specs: list[dict[str, Any]] = [
         {
@@ -118,7 +142,10 @@ def _command_prompt_specs(*, cli_bin: str, include_legacy_aliases: bool) -> list
             "instructions": [
                 "Visible command arguments: `$ARGUMENTS`.",
                 "Before start-goal, identify the exact current host: use `codex-app` for the desktop app with automation tools, `codex-app-ssh` for the desktop app over SSH without automation tools, `codex-ide-plugin` only for the IDE plugin, `codex-cli-tui` for the terminal TUI, `opencode` for OpenCode, `traex-cli` for the TraeX terminal TUI, `pi` for Pi, or `ark-managed-agent` for Ark Managed Agent.",
-                f"If arguments are present, parse only an optional leading `--capability-route issue-fix` as an explicit product-route switch, remove that prefix from the task text, and pass it to `{cli_bin} start-goal --guided --project . --goal-text \"<remaining exact arguments>\" --host-surface <exact-current-host>`. Without that switch, preserve all arguments as task text and do not add a capability route. Never infer a route from issue/PR wording or URLs. If the host is unclear, omit the host flag once and follow the returned host-surface selection gate.",
+                _loopx_start_goal_arguments_instruction(
+                    cli_bin=cli_bin,
+                    host_surface=None,
+                ),
                 f"Treat the returned `ordered_steps` as a required transaction. On first connection, run its bootstrap command and resolve the returned agent-identity gate before planning; a stable unbound host thread is a new session and defaults to fresh registration. Then plan and execute at least one business `{cli_bin} todo add` derived from `$ARGUMENTS` before substantive task work. Encode priority in the todo text such as `[P0]`; `{cli_bin} todo add` has no `--priority` flag. Do not continue until LoopX status shows that business Agent Todo.",
                 f"If `selected_capability_route` is present, run its entry and admission commands before substantive implementation, and treat `{cli_bin} capability show <capability-id> --format json` as the authoritative later-transition command surface. Use capability-owned commands for listed external transitions instead of substituting provider CLIs. Keep capability facts in capability-owned state; generic Todos remain scheduling records.",
                 f"Before dependent work, persist material scope, acceptance, or non-goal changes in current Todo evidence and the next executable Todo; then run `{cli_bin} refresh-state` and verify quota readback. Chat/model summaries are not durable state.",
@@ -245,14 +272,9 @@ def materialize_loopx_entry_skill(
             "This entry skill is installed for the exact current host "
             f"`{host_surface}`; do not infer or substitute another host surface."
         )
-        instructions[2] = (
-            f"If arguments are present, parse only an optional leading "
-            "`--capability-route issue-fix` as an explicit product-route switch, "
-            "remove that prefix from the task text, and pass it to "
-            f'`{cli_bin} start-goal --guided --project . --goal-text "<remaining exact arguments>" '
-            f"--host-surface {host_surface}`. Without that switch, preserve all "
-            "arguments as task text and do not add a capability route. Never infer "
-            "a route from issue/PR wording or URLs."
+        instructions[2] = _loopx_start_goal_arguments_instruction(
+            cli_bin=cli_bin,
+            host_surface=host_surface,
         )
         spec = {**spec, "instructions": instructions}
     skill_path = skills_dir / "loopx" / "SKILL.md"

--- a/tests/control_plane/test_start_goal_compact_projection.py
+++ b/tests/control_plane/test_start_goal_compact_projection.py
@@ -8,6 +8,8 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from loopx.bootstrap_command_pack import (
     GUIDED_COMMAND_PACK_PROJECTION_SCHEMA_VERSION,
     build_loopx_bootstrap_command_pack,
@@ -111,6 +113,34 @@ def _invoke_detail_command(command: str) -> dict[str, Any]:
     payload = json.loads(output.getvalue())
     assert isinstance(payload, dict)
     return payload
+
+
+def _invoke_ark_start_goal_cli(
+    project: Path,
+    *goal_input_args: str,
+) -> tuple[int, dict[str, Any]]:
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(
+            [
+                "--format",
+                "json",
+                "start-goal",
+                "--guided",
+                "--project",
+                str(project),
+                "--goal-id",
+                GOAL_ID,
+                "--agent-id",
+                AGENT_ID,
+                "--host-surface",
+                "ark-managed-agent",
+                *goal_input_args,
+            ]
+        )
+    payload = json.loads(output.getvalue())
+    assert isinstance(payload, dict)
+    return exit_code, payload
 
 
 def test_default_projection_preserves_host_actions_and_json_anchors(
@@ -1082,6 +1112,89 @@ def test_cli_without_host_returns_read_only_host_selection_gate(
     ide = next(choice for choice in choices if choice["host_surface"] == "codex-ide-plugin")
     assert "--host-surface codex-ide-plugin" in ide["rerun_command"]
     assert "--capability-route issue-fix" in ide["rerun_command"]
+
+
+@pytest.mark.parametrize(
+    "raw_arguments",
+    [
+        "--capability-route issue-fix Fix the selected public issue.",
+        "--capability-route=issue-fix Fix the selected public issue.",
+    ],
+)
+def test_cli_parses_typed_route_from_complete_slash_arguments(
+    tmp_path: Path,
+    raw_arguments: str,
+) -> None:
+    project = _write_connected_project(tmp_path)
+    exit_code, payload = _invoke_ark_start_goal_cli(
+        project,
+        f"--slash-command-arguments={raw_arguments}",
+    )
+
+    assert exit_code == 0
+    assert payload["goal_text"] == "Fix the selected public issue."
+    selected_route = payload["guided_transaction"]["selected_capability_route"]
+    assert selected_route["capability_id"] == "issue-fix"
+    assert selected_route["selection_source"] == "explicit_capability_route"
+    canonical_command = payload["command_pack"]["canonical_cli_command"]
+    assert "--capability-route issue-fix" in canonical_command
+    assert "--goal-text 'Fix the selected public issue.'" in canonical_command
+
+
+def test_cli_preserves_unrouted_complete_slash_arguments_as_goal_text(
+    tmp_path: Path,
+) -> None:
+    project = _write_connected_project(tmp_path)
+    exit_code, payload = _invoke_ark_start_goal_cli(
+        project,
+        "--slash-command-arguments",
+        "Investigate issue-fix wording without selecting a route.",
+    )
+
+    assert exit_code == 0
+    assert payload["goal_text"] == (
+        "Investigate issue-fix wording without selecting a route."
+    )
+    assert "selected_capability_route" not in payload["guided_transaction"]
+
+
+@pytest.mark.parametrize(
+    ("raw_arguments", "extra_args", "expected_error"),
+    [
+        (
+            "Fix the selected public issue.",
+            ["--capability-route", "issue-fix"],
+            "cannot be combined with --capability-route",
+        ),
+        (
+            "--capability-route unknown Fix the selected public issue.",
+            [],
+            "unsupported --capability-route; expected one of: issue-fix",
+        ),
+        (
+            "--capability-route issue-fix",
+            [],
+            "must contain goal text after --capability-route",
+        ),
+    ],
+)
+def test_cli_rejects_ambiguous_or_unsupported_slash_route_input(
+    tmp_path: Path,
+    raw_arguments: str,
+    extra_args: list[str],
+    expected_error: str,
+) -> None:
+    project = _write_connected_project(tmp_path)
+    exit_code, payload = _invoke_ark_start_goal_cli(
+        project,
+        "--slash-command-arguments",
+        raw_arguments,
+        *extra_args,
+    )
+
+    assert exit_code == 2
+    assert payload["ok"] is False
+    assert expected_error in payload["error"]
 
 
 def test_ark_managed_agent_plans_todos_before_one_shot_goal_activation(

--- a/tests/test_slash_command_install.py
+++ b/tests/test_slash_command_install.py
@@ -45,7 +45,9 @@ def test_host_materialization_installs_generated_loopx_entry_skill(
     assert 'name: "loopx"' in skill_text
     assert "`ark-managed-agent` for Ark Managed Agent" in skill_text
     assert "Ark Managed Agent one-shot Goal submission" in skill_text
-    assert "optional leading `--capability-route issue-fix`" in skill_text
+    assert "--slash-command-arguments" in skill_text
+    assert "The CLI, not the model, owns parsing" in skill_text
+    assert "Never split and recompose the switch" in skill_text
     assert "Never infer a route from issue/PR wording or URLs" in skill_text
     assert "run its exact CLI `interaction_contract` or quota command first" in skill_text
     assert "do not call `start-goal` or bootstrap another goal" in skill_text
@@ -76,6 +78,8 @@ def test_host_materialization_can_bind_exact_managed_agent_surface(
     assert "exact current host `ark-managed-agent`" in skill_text
     assert "--host-surface ark-managed-agent" in skill_text
     assert "--host-surface <exact-current-host>" not in skill_text
+    assert "--slash-command-arguments" in skill_text
+    assert "The CLI, not the model, owns parsing" in skill_text
     assert "before substantive task work" in skill_text
     assert "has no `--priority` flag" in skill_text
     assert "Before dependent work, persist material scope" in skill_text
@@ -85,7 +89,7 @@ def test_host_materialization_can_bind_exact_managed_agent_surface(
     assert "capability show <capability-id> --format json" in skill_text
     assert "instead of substituting provider CLIs" in skill_text
     assert "generic Todos remain scheduling records" in skill_text
-    assert "do not add a capability route" in skill_text
+    assert "Never infer a route" in skill_text
     assert "run its exact CLI `interaction_contract` or quota command first" in skill_text
     assert "Only when no active goal contract is present" in skill_text
 


### PR DESCRIPTION
## Problem

The generated `/loopx` entry previously asked the model to split an optional leading `--capability-route issue-fix` switch from the visible task and rebuild separate `start-goal` arguments. If that transformation drops the switch, the guided transaction still starts but no typed capability route or issue-fix admission contract is installed.

## Change

- add mutually exclusive `start-goal --slash-command-arguments` and structured `--goal-text` inputs
- parse only an exact leading typed route switch in the CLI; preserve the remainder as goal text
- fail closed for malformed, unsupported, or ambiguously duplicated route inputs
- keep structured `--capability-route` plus `--goal-text` for typed callers
- generate conversational entry skills that pass complete visible arguments once instead of asking the model to split and recompose them
- update the canonical Goal protocol, issue-fix usage guide, and durable workflow smoke

## Boundaries

- no capability inference from issue or PR wording
- no Todo schema or admission-state changes
- no host-adapter dependency
- no external repository publication behavior

## Validation

- `python3 -m pytest -q tests/control_plane/test_start_goal_compact_projection.py tests/test_slash_command_install.py` — 46 passed
- `python3 examples/issue-fix-workflow-contract-smoke.py` — passed
- focused Ruff check — passed (existing unrelated `SIM114` excluded)
- `loopx canary premerge --from-git-diff` — 18/18 passed, 0 failures, 0 manual holds
- public/private boundary scan — passed