### PR TITLE
chore(security): route Dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+
+updates:
+  - package-ecosystem: pip
+    directories:
+      - "/"
+      - "/docs"
+      - "/packages/loopx-finance-value-discovery"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    groups:
+      python-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: "/apps/presentation/dashboard"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    groups:
+      dashboard-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    groups:
+      actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/apps/presentation/dashboard/package-lock.json
+++ b/apps/presentation/dashboard/package-lock.json
@@ -1493,9 +1493,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -1529,9 +1529,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1548,7 +1548,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/apps/presentation/dashboard/package.json
+++ b/apps/presentation/dashboard/package.json
@@ -43,6 +43,6 @@
     "vite": "^8.2.1"
   },
   "overrides": {
-    "postcss": "8.5.18"
+    "postcss": "8.5.26"
   }
 }


### PR DESCRIPTION
## Summary

- add explicit security-only Dependabot routes for the repository's Python, dashboard npm, and GitHub Actions manifests
- patch the dashboard PostCSS override from 8.5.18 to 8.5.26 and refresh the lockfile
- keep regular Dependabot version-update PRs disabled with `open-pull-requests-limit: 0`

## Why

The current dynamic security-update run cannot map the Python advisory to a manifest directory, while the dashboard has a directly resolvable PostCSS advisory. This change makes manifest ownership explicit and fixes the dependency that has an available release.

The remaining setuptools advisory is intentionally left open: its reported fixed version, 83.0.0, is not available on PyPI yet. This PR does not dismiss or waive that alert.

## Validation

- Dependabot YAML parsed with the expected ecosystem and directory assertions
- `npm ci --ignore-scripts --registry=https://registry.npmjs.org/`
- `npm ls postcss --all` (8.5.26)
- `npm audit --json` (0 vulnerabilities)
- `npm run build`
- `git diff --check`
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`
- LoopX change-quality receipt `cqr_a0589b1159df60d9eac9` passed and verified

The dashboard build retains its existing large-chunk warning. This PR requires independent review because it changes security automation configuration.
