### PR TITLE
fix(lark): preserve partial Kanban write receipts

### DIFF
--- a/loopx/extensions/lark/goal_channel_runtime.py
+++ b/loopx/extensions/lark/goal_channel_runtime.py
@@ -237,6 +237,8 @@ def sync_lark_goal_channel(
     )
     ok = bool(result.get("ok"))
     provider_write_ok = ok
+    successful_write_count = int(result.get("successful_write_count") or 0)
+    external_write_performed = bool(result.get("external_write_performed"))
     records = [
         record for record in result.get("records") or [] if isinstance(record, Mapping)
     ]
@@ -285,15 +287,18 @@ def sync_lark_goal_channel(
             else "previewed the Goal Channel Kanban sync"
             if ok
             else "the Goal Channel Kanban sync failed readback"
-            if execute
+            if execute and provider_write_ok
+            else "the Goal Channel Kanban sync failed after partial provider writes"
+            if execute and external_write_performed
             else "the Goal Channel Kanban sync failed"
         ),
-        external_write_performed=bool(execute and result.get("ok") and records),
+        external_write_performed=external_write_performed,
         readback_verified=readback_verified,
         details={
             "kanban_ready": True,
             "todo_count": int(result.get("todo_count") or 0),
             "record_count": len(records),
+            "successful_write_count": successful_write_count,
         },
     )
 

--- a/loopx/extensions/lark/presentation/kanban.py
+++ b/loopx/extensions/lark/presentation/kanban.py
@@ -2278,6 +2278,8 @@ def sync_loopx_todos_to_lark_kanban(
                 "commands": commands,
                 "config_path": str(config_path) if config_path else None,
                 "schema_check": schema_check,
+                "successful_write_count": 0,
+                "external_write_performed": False,
                 "error": _schema_check_error(schema_check),
             }
     local, record_map, _, _ = _load_lark_todo_record_map(
@@ -2290,6 +2292,7 @@ def sync_loopx_todos_to_lark_kanban(
     )
 
     results: list[dict[str, Any]] = []
+    successful_write_count = 0
     ok = True
     for block in todos:
         todo_id = str(block.get("todo_id") or "").strip()
@@ -2307,6 +2310,11 @@ def sync_loopx_todos_to_lark_kanban(
         )
         commands.append(result)
         record_id = _extract_created_record_id(result.get("json")) or record_map.get(key)
+        write_succeeded = bool(
+            execute and result.get("executed") and result.get("ok")
+        )
+        if write_succeeded:
+            successful_write_count += 1
         if execute and result.get("ok") and record_id:
             record_map[key] = record_id
         results.append(
@@ -2346,6 +2354,11 @@ def sync_loopx_todos_to_lark_kanban(
             )
             if execute and result.get("ok") and record_id:
                 record_map[key] = record_id
+            write_succeeded = bool(
+                execute and result.get("executed") and result.get("ok")
+            )
+            if write_succeeded:
+                successful_write_count += 1
             results.append(
                 {
                     "todo_id": todo_id,
@@ -2358,7 +2371,7 @@ def sync_loopx_todos_to_lark_kanban(
             if execute and not result.get("ok"):
                 break
 
-    if execute and ok:
+    if execute and successful_write_count:
         _persist_lark_todo_record_map(config, config_path=config_path, local=local, record_map=record_map)
 
     return {
@@ -2383,6 +2396,8 @@ def sync_loopx_todos_to_lark_kanban(
         "records": results,
         "commands": commands,
         "config_path": str(config_path) if config_path else None,
+        "successful_write_count": successful_write_count,
+        "external_write_performed": bool(successful_write_count),
     }
 
 

--- a/tests/extensions/test_lark_goal_channel.py
+++ b/tests/extensions/test_lark_goal_channel.py
@@ -1015,6 +1015,8 @@ def test_sync_requires_remote_record_readback(
         lambda *args, **kwargs: {
             "ok": True,
             "todo_count": 1,
+            "successful_write_count": 1,
+            "external_write_performed": True,
             "records": [
                 {
                     "todo_id": "todo_public_one",
@@ -1072,8 +1074,19 @@ def test_sync_preserves_provider_failure_blocker(
         "loopx.extensions.lark.goal_channel_runtime.sync_loopx_todos_to_lark_kanban",
         lambda *args, **kwargs: {
             "ok": False,
-            "todo_count": 1,
-            "records": [],
+            "todo_count": 2,
+            "successful_write_count": 1,
+            "external_write_performed": True,
+            "records": [
+                {
+                    "todo_id": "todo_public_one",
+                    "record_id": "rec_public_one",
+                },
+                {
+                    "todo_id": "todo_public_two",
+                    "record_id": None,
+                },
+            ],
         },
     )
 
@@ -1088,6 +1101,10 @@ def test_sync_preserves_provider_failure_blocker(
 
     assert payload["ok"] is False
     assert payload["blocker"] == "provider_api_failed"
-    assert payload["external_write_performed"] is False
+    assert payload["public_summary"] == (
+        "the Goal Channel Kanban sync failed after partial provider writes"
+    )
+    assert payload["external_write_performed"] is True
     assert payload["readback_verified"] is False
+    assert payload["details"]["successful_write_count"] == 1
     _assert_public_packet(payload)

--- a/tests/extensions/test_lark_kanban_schema_preflight.py
+++ b/tests/extensions/test_lark_kanban_schema_preflight.py
@@ -9,8 +9,8 @@ from loopx.extensions.lark.presentation.kanban import (
     lark_kanban_schema_payload,
     read_lark_kanban_local_config,
     save_lark_kanban_board_config,
-    sync_loopx_todos_to_lark_kanban,
     sync_loopx_projection_to_lark_kanban,
+    sync_loopx_todos_to_lark_kanban,
     write_lark_kanban_local_config,
 )
 
@@ -230,23 +230,17 @@ def test_partial_todo_sync_persists_successful_record_for_retry(
         encoding="utf-8",
     )
     state_file.write_text(
-        "\n".join(
-            [
-                "# Active Goal State",
-                "",
-                "## User Todo / Owner Review Reading Queue",
-                "",
-                "## Agent Todo",
-                "",
-                "- [ ] [P1] First public todo",
-                "  <!-- loopx:todo todo_id=todo_public_one status=open "
-                "task_class=advancement_task -->",
-                "- [ ] [P1] Second public todo",
-                "  <!-- loopx:todo todo_id=todo_public_two status=open "
-                "task_class=advancement_task -->",
-                "",
-            ]
-        ),
+        """# Active Goal State
+
+## User Todo / Owner Review Reading Queue
+
+## Agent Todo
+
+- [ ] [P1] First public todo
+  <!-- loopx:todo todo_id=todo_public_one status=open task_class=advancement_task -->
+- [ ] [P1] Second public todo
+  <!-- loopx:todo todo_id=todo_public_two status=open task_class=advancement_task -->
+""",
         encoding="utf-8",
     )
     config = LarkKanbanConfig(

--- a/tests/extensions/test_lark_kanban_schema_preflight.py
+++ b/tests/extensions/test_lark_kanban_schema_preflight.py
@@ -9,6 +9,7 @@ from loopx.extensions.lark.presentation.kanban import (
     lark_kanban_schema_payload,
     read_lark_kanban_local_config,
     save_lark_kanban_board_config,
+    sync_loopx_todos_to_lark_kanban,
     sync_loopx_projection_to_lark_kanban,
     write_lark_kanban_local_config,
 )
@@ -202,3 +203,162 @@ def test_complete_remote_list_replaces_stale_local_record_id(tmp_path: Path) -> 
         "rec_stale_fixture"
     )
     assert sum("+record-upsert" in args for args in calls) == 1
+
+
+def test_partial_todo_sync_persists_successful_record_for_retry(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    registry_path = project / ".loopx" / "registry.json"
+    state_file = project / "ACTIVE_GOAL_STATE.md"
+    config_path = project / ".loopx" / "lark-kanban.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "common_runtime_root": str(tmp_path / "runtime"),
+                "goals": [
+                    {
+                        "id": "goal_public_fixture",
+                        "repo": str(project),
+                        "state_file": str(state_file),
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    state_file.write_text(
+        "\n".join(
+            [
+                "# Active Goal State",
+                "",
+                "## User Todo / Owner Review Reading Queue",
+                "",
+                "## Agent Todo",
+                "",
+                "- [ ] [P1] First public todo",
+                "  <!-- loopx:todo todo_id=todo_public_one status=open "
+                "task_class=advancement_task -->",
+                "- [ ] [P1] Second public todo",
+                "  <!-- loopx:todo todo_id=todo_public_two status=open "
+                "task_class=advancement_task -->",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    config = LarkKanbanConfig(
+        base_token="base_public_fixture",
+        table_id="tbl_public_fixture",
+        cli_bin="lark-cli",
+        identity="user",
+    )
+    save_lark_kanban_board_config(
+        config_path,
+        base_token=config.base_token,
+        table_id=config.table_id,
+        cli_bin=config.cli_bin,
+        identity=config.identity,
+    )
+    calls: list[list[str]] = []
+    upsert_count = 0
+
+    def runner(
+        args: list[str], cwd: Path | None, timeout: float | None
+    ) -> dict[str, object]:
+        nonlocal upsert_count
+        calls.append(args)
+        if "+field-list" in args:
+            return _result(
+                {
+                    "ok": True,
+                    "data": {"fields": lark_kanban_schema_payload()["fields"]},
+                }
+            )
+        if "+record-list" in args:
+            return _result(
+                {
+                    "ok": True,
+                    "data": {
+                        "fields": ["LoopX Goal ID", "LoopX Todo ID"],
+                        "data": [],
+                        "record_id_list": [],
+                        "has_more": True,
+                    },
+                }
+            )
+        if "+record-upsert" in args:
+            upsert_count += 1
+            todo_id = json.loads(args[args.index("--json") + 1])["LoopX Todo ID"]
+            if upsert_count == 1:
+                assert todo_id == "todo_public_one"
+                assert "--record-id" not in args
+                return _result(
+                    {"ok": True, "data": {"record_id": "rec_public_one"}}
+                )
+            if upsert_count == 2:
+                assert todo_id == "todo_public_two"
+                return {
+                    "returncode": 1,
+                    "stdout": json.dumps(
+                        {
+                            "ok": False,
+                            "error": {"message": "fixture second write failed"},
+                        }
+                    ),
+                    "stderr": "",
+                    "timed_out": False,
+                }
+            if upsert_count == 3:
+                assert todo_id == "todo_public_one"
+                assert args[args.index("--record-id") + 1] == "rec_public_one"
+                return _result(
+                    {"ok": True, "data": {"record_id": "rec_public_one"}}
+                )
+            if upsert_count == 4:
+                assert todo_id == "todo_public_two"
+                assert "--record-id" not in args
+                return _result(
+                    {"ok": True, "data": {"record_id": "rec_public_two"}}
+                )
+        raise AssertionError(args)
+
+    first = sync_loopx_todos_to_lark_kanban(
+        config,
+        registry_path=registry_path,
+        goal_id="goal_public_fixture",
+        config_path=config_path,
+        execute=True,
+        runner=runner,
+    )
+
+    assert first["ok"] is False
+    assert first["successful_write_count"] == 1
+    assert first["external_write_performed"] is True
+    persisted_after_failure = read_lark_kanban_local_config(config_path)[
+        "todo_records"
+    ]
+    assert persisted_after_failure[
+        "goal_public_fixture:todo_public_one"
+    ] == "rec_public_one"
+    assert "goal_public_fixture:todo_public_two" not in persisted_after_failure
+
+    second = sync_loopx_todos_to_lark_kanban(
+        config,
+        registry_path=registry_path,
+        goal_id="goal_public_fixture",
+        config_path=config_path,
+        execute=True,
+        runner=runner,
+    )
+
+    assert second["ok"] is True
+    assert second["successful_write_count"] == 2
+    assert second["external_write_performed"] is True
+    persisted_after_retry = read_lark_kanban_local_config(config_path)["todo_records"]
+    assert persisted_after_retry == {
+        "goal_public_fixture:todo_public_one": "rec_public_one",
+        "goal_public_fixture:todo_public_two": "rec_public_two",
+    }


### PR DESCRIPTION
## Summary

- Report successful Goal Channel Kanban writes even when a later upsert fails.
- Persist confirmed Todo-to-record mappings after partial success so retries update existing rows instead of creating duplicates.
- Distinguish partial provider failure from readback mismatch in the public operation packet.

## Issue Or Task

- Follow-up to the post-merge audit on #2822: https://github.com/huangruiteng/loopx/pull/2822#issuecomment-5224371288
- Contributor task ID: N/A

## Validation

- [x] `python3 -m py_compile loopx/*.py`
- [x] `loopx check --scan-root .`
- [x] Other: 25 focused Lark tests passed; Ruff and `git diff --check` passed; exact four-file standard premerge canary passed 9 selected checks with 0 failures and 0 manual holds.

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
