### PR TITLE
fix(deps): align setuptools security boundary

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,3 +1,4 @@
 mkdocs>=1.6,<2
 mkdocs-material>=9.6.0,<10
 pymdown-extensions>=10.0,<11
+setuptools>=83.0.0,<84

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools==82.0.1"]
+requires = ["setuptools==83.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/tests/test_dependency_security_boundaries.py
+++ b/tests/test_dependency_security_boundaries.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SETUPTOOLS_FLOOR = (83, 0, 0)
+
+
+def _version_tuple(value: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in value.split("."))
+
+
+def test_setuptools_security_floor_is_declared_at_each_dependabot_boundary() -> None:
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    build_requirements = project["build-system"]["requires"]
+    root_match = next(
+        re.fullmatch(r"setuptools==([0-9]+(?:\.[0-9]+)*)", requirement)
+        for requirement in build_requirements
+        if requirement.startswith("setuptools")
+    )
+    assert root_match is not None
+
+    docs_requirements = (ROOT / "docs" / "requirements-docs.txt").read_text(
+        encoding="utf-8"
+    )
+    docs_match = re.search(
+        r"^setuptools>=([0-9]+(?:\.[0-9]+)*),<([0-9]+)$",
+        docs_requirements,
+        flags=re.MULTILINE,
+    )
+    assert docs_match is not None
+
+    root_version = _version_tuple(root_match.group(1))
+    docs_floor = _version_tuple(docs_match.group(1))
+    assert root_version >= SETUPTOOLS_FLOOR
+    assert docs_floor == root_version
+    assert int(docs_match.group(2)) == root_version[0] + 1


### PR DESCRIPTION
## Summary

- raise the reproducible build backend pin from `setuptools==82.0.1` to the patched `83.0.0`
- declare the same security floor in `docs/requirements-docs.txt`, the manifest boundary attributed to Dependabot alert #4
- add a focused regression that keeps the root build pin and docs security floor aligned

## Why

The default-branch Dependabot rerun no longer failed with `security_update_dependency_not_found`, but the `/docs` update job still could not find an allowed `setuptools` dependency because that manifest did not declare it. Updating only the root build-system pin would fix the installed package while leaving the alert-owned update boundary unable to maintain itself.

## Validation

- `uvx --from pytest pytest -q tests/test_dependency_security_boundaries.py` (`1 passed`)
- `uvx ruff check tests/test_dependency_security_boundaries.py`
- `uv build --no-sources --out-dir /tmp/loopx-setuptools-dist`
- `uv run --python 3.11 --with-requirements docs/requirements-docs.txt mkdocs build --strict --site-dir /tmp/loopx-setuptools-docs-site`
- verified the docs environment imports `setuptools 83.0.0`
- `python examples/release-artifacts-smoke.py`
- `loopx check` on all changed paths (`0 errors`, `0 warnings`)
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` (`9/9 selected checks passed`, no manual holds)
- change-quality receipt `cqr_bc2c43489b68e66acc00` is valid for the committed diff

## Boundaries

- no runtime behavior, release publication, PyPI setting, alert dismissal, or permission change
- no credentials, local state, generated artifacts, or private evidence included
- requires independent review before merge because this changes the package build and security-update boundary
