### PR TITLE
feat(pr-review): move review depth into capability contracts

### DIFF
--- a/docs/reference/protocols/pr-review-command-v0.md
+++ b/docs/reference/protocols/pr-review-command-v0.md
@@ -17,6 +17,13 @@ observation to this same command. It reuses the existing GitHub scan and
 normalized review queue; it does not introduce a second crawler or a new write
 authority.
 
+The capability also owns the review-depth contract. The shared
+`agent_response_contract.review_execution_contract` defines required evidence,
+completion, freshness, finding, and verdict rules. Each PR carries a compact
+`review_plan` that binds those rules to one exact head and marks code-symbol and
+negative-walkthrough applicability. Host skills route and publish this packet;
+they must not maintain a second explanation checklist.
+
 Codex agents should use the dedicated `loopx-pr-review` skill for this slash
 command. Do not route `/loopx-pr-review` through the broader `loopx-project`
 workflow or the merge-focused `loopx-pr-merge` skill.
@@ -109,8 +116,35 @@ authority; callers must use normal LoopX Todo authority, `loopx-pr-review`, and
 Do not pipe that first packet through `jq` or another projection that only
 keeps `.summary` and `.review_sequence`; that drops
 `agent_response_contract`, `review_groups`, `pull_requests[].review_template`,
-and `pull_requests[].evidence_commands`, which are the fields that make the
-command a guided review instead of a statistics table.
+`pull_requests[].review_plan`, and `pull_requests[].evidence_commands`, which
+are the fields that make the command a guided review instead of a statistics
+table.
+
+## Capability-Owned Review Execution
+
+`pull_request_review_execution_contract_v1` is shared once per packet to avoid
+duplicating a large prompt for every PR in a 100-item queue. It requires these
+typed evidence groups before a verdict:
+
+- problem context and active caller;
+- architecture and ownership flow;
+- exact changed-line classification across production, tests/fixtures, docs,
+  generated output, and mechanical moves;
+- a 2-5 item exact-head symbol map for code-changing PRs, including caller,
+  state, branch, side effect, consumer, and failure ownership;
+- positive and applicable negative execution walkthroughs;
+- validation tied to changed invariants and failure cases;
+- strongest regression path, blast radius, recovery, minimum repair, and
+  regression test;
+- code-volume necessity and the highest-value behavior-preserving
+  simplification.
+
+The per-PR `pull_request_review_plan_v1` records the exact target, applicability,
+required evidence ids, and an initially `unverified`
+`pull_request_review_result_v1` skeleton. Metadata, labels, file counts, risk
+hints, and green CI cannot upgrade evidence to `verified`. A stale-head verdict
+is prohibited. Missing evidence remains `unverified` with a reason instead of
+being replaced by confident prose.
 
 When `--state all` is used, the command must preserve both lifecycle groups.
 The `--limit` value is applied per group so a busy open queue cannot consume the
@@ -308,7 +342,10 @@ absolute paths, private source bodies, or hidden CI artifacts.
     "queue_table_role": "preface_only",
     "required_packet_fields_to_preserve": [
       "agent_response_contract",
+      "agent_response_contract.review_execution_contract",
+      "result_completeness",
       "review_groups",
+      "pull_requests[].review_plan",
       "pull_requests[].review_template",
       "pull_requests[].evidence_commands"
     ],
@@ -343,17 +380,20 @@ The packet should let a reviewer move through PRs in order:
 2. Then use `review_groups.merged` for post-merge audit and follow-up quality.
 3. Use `evidence_commands`, key files, changed-file scale, and checks to open
    the actual PR body and diff.
-4. Read `main_regression_analysis` before filling risk prose. It is the CLI's
+4. Execute the PR's `review_plan` against
+   `agent_response_contract.review_execution_contract`; keep unavailable
+   evidence explicitly unverified.
+5. Read `main_regression_analysis` before filling risk prose. It is the CLI's
    concrete, generated view of potential main regressions, bug risks, and
    focused validation.
-5. Follow `agent_response_contract.explanation_depth_contract`, then let
-   agentloop fill the blank five-block template:
+6. Render the verified structured result through the blank five-block template:
    `动机`, `改动思路`, `具体改动`, `对主干的风险`, `我的整体评价`.
    Use each section's range as a depth signal for a reader unfamiliar with the
    subsystem, not as filler.
-6. Treat `metadata_risk_hint` only as queue-ordering metadata. It must not be
+7. Treat `metadata_risk_hint` only as queue-ordering metadata. It must not be
    copied as the final risk judgement.
-7. Decide `approve`, `request changes`, `defer`, or `merge after checks`.
+8. Recheck the exact head, then decide `approve`, `request changes`, `defer`, or
+   `merge after checks`.
 
 A response that only lists `Open` and `Merged` PRs, scale, and recommended next
 order is incomplete for `/loopx-pr-review`; it should continue into the
@@ -386,6 +426,10 @@ A first implementation is acceptable when:
   `main_regression_analysis`, evidence commands, explicit
   `review_groups.unmerged` / `review_groups.merged`, and a blank five-block
   review template;
+- the shared `pull_request_review_execution_contract_v1` owns typed evidence,
+  completion, freshness, findings-first, and verdict policy, while every PR has
+  a compact exact-head `pull_request_review_plan_v1` with an unverified result
+  skeleton;
 - the packet includes `agent_response_contract.table_only_response_allowed=false`
   and `agent_response_contract.required_packet_fields_to_preserve` so
   slash-command agents know a table-only chat answer is incomplete;

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -368,17 +368,18 @@ def main() -> int:
         pr_review_text = " ".join(pr_review_skill.read_text(encoding="utf-8").split())
         for phrase in (
             "loopx --format json pr-review --state all",
-            "agent_response_contract",
+            "thin host adapter",
+            "agent_response_contract.review_execution_contract",
             "review_groups",
+            "pull_requests[].review_plan",
             "pull_requests[].review_template",
             "pull_requests[].evidence_commands",
-            "Do not pipe the first packet through `jq`",
-            "Do not fill the five-block review from title, labels, changed-file counts, or metadata risk hints alone",
-            "submit a formal `REQUEST_CHANGES` review",
-            "A plain PR comment is not an adequate substitute for `REQUEST_CHANGES`",
-            "keep the workflow read-only only when the user explicitly says `local-only`",
-            "the GitHub review state must match the written verdict",
-            "route approval, merge, self-merge, and admin-bypass actions to `loopx-pr-merge`",
+            "Do not pipe the only copy through `jq`",
+            "completion_gate",
+            "never infer `verified` from title",
+            "formal `REQUEST_CHANGES`",
+            "Read the published review back",
+            "approval still routes through `loopx-pr-merge`",
         ):
             assert phrase in pr_review_text, phrase
         assert "Do not use this skill to approve" not in pr_review_text, pr_review_text

--- a/examples/pr-review-command-smoke.py
+++ b/examples/pr-review-command-smoke.py
@@ -50,48 +50,30 @@ def assert_public_safe(payload: dict[str, object]) -> None:
 
 
 def main() -> int:
-    skill_text = " ".join(PR_REVIEW_SKILL.read_text(encoding="utf-8").split())
+    skill_source = PR_REVIEW_SKILL.read_text(encoding="utf-8")
+    skill_text = " ".join(skill_source.split())
     for phrase in (
-        "Use when the visible request starts with `/loopx-pr-review`",
+        "This skill is a thin host adapter",
         "loopx --format json pr-review --state all",
-        "agent_response_contract",
-        "review_groups",
+        "agent_response_contract.review_execution_contract",
+        "pull_requests[].review_plan",
         "pull_requests[].review_template",
         "pull_requests[].evidence_commands",
-        "Do not pipe the first packet through `jq`",
-        "Do not fill the five-block review from title, labels, changed-file counts, or metadata risk hints alone",
-        "Each PR must receive its own evidence pass and standalone review card",
-        "Do not compress individual cards to cover more of the queue",
-        "Per-PR Evidence And Depth Gate",
-        "build a compact internal evidence record for that PR",
-        "Each card must stand on its own",
-        "one concrete positive walkthrough",
-        "one concrete negative or failure walkthrough",
-        "Motivation Causal Chain",
-        "who pays the cost",
-        "Implementation Execution Chain",
-        "authoritative input or state",
-        "Key Code Explanation Gate",
-        "`### 关键代码讲解` subsection inside `具体改动`",
-        "2-5 behavior-bearing symbols",
-        "exact-head `file:line` and symbol name",
-        "critical condition, branch, transition, or invariant",
-        "return value, receipt, projection, or downstream consumer",
-        "Include 1-3 short excerpts from the exact reviewed head",
-        "For a docs-only PR, use `### 关键内容讲解`",
-        "relationship map",
-        "state the minimum repair plus regression test",
-        "Code Volume And Simplification Review",
-        "Classify the volume as `necessary`, `partly avoidable`, or `not yet proven`",
-        "A code-volume conclusion without diff and call-site evidence is incomplete",
-        "submit a formal `REQUEST_CHANGES` review",
-        "A plain PR comment is not an adequate substitute for `REQUEST_CHANGES`",
-        "keep the workflow read-only only when the user explicitly says `local-only`",
-        "the GitHub review state must match the written verdict",
-        "After publication, include the GitHub review/comment URL",
-        "route approval, merge, self-merge, and admin-bypass actions to `loopx-pr-merge`",
+        "Apply `completion_gate` literally",
+        "Re-read the remote head immediately before verdict and publication",
+        "formal `REQUEST_CHANGES`",
+        "Read the published review back",
+        "Route approval, merge, self-merge, and admin bypass to `loopx-pr-merge`",
     ):
         assert phrase in skill_text, phrase
+    assert len(skill_source.splitlines()) <= 140, len(skill_source.splitlines())
+    for duplicated_contract_heading in (
+        "Per-PR Evidence And Depth Gate",
+        "Motivation Causal Chain",
+        "Implementation Execution Chain",
+        "Code Volume And Simplification Review",
+    ):
+        assert duplicated_contract_heading not in skill_source, duplicated_contract_heading
 
     assert _github_search_date("2026-06-28T00:00:00+08:00") == "2026-06-27"
     assert _github_search_date("2026-06-28T00:00:00Z") == "2026-06-28"
@@ -201,7 +183,7 @@ def main() -> int:
     template = first["review_template"]
     assert template["schema_version"] == "pr_review_five_block_template_v0", template
     assert "Empty scaffold only" in template["purpose"], template
-    assert "reader unfamiliar with the PR" in template["output_hint"], template
+    assert "review_execution_contract" in template["output_hint"], template
     labels = [section["label"] for section in template["sections"]]
     assert labels == ["动机", "改动思路", "具体改动", "对主干的风险", "我的整体评价"], template
     for section in template["sections"]:
@@ -220,7 +202,7 @@ def main() -> int:
         section for section in template["sections"] if section["label"] == "具体改动"
     )
     assert "### 关键代码讲解" in concrete_change["agent_instruction"], concrete_change
-    assert "2-5 个行为关键符号" in concrete_change["agent_instruction"], concrete_change
+    assert "2-5 behavior-bearing exact-head symbols" in concrete_change["agent_instruction"], concrete_change
     assert "headRefOid" in first["evidence_commands"][0], first["evidence_commands"]
     assert "headRefOid" in first["evidence_commands"][-1], first["evidence_commands"]
     assert template["review_order"][0] == "docs/guides/newcomer-command-path.md", template
@@ -406,8 +388,10 @@ def main() -> int:
     assert response_contract["queue_table_role"] == "preface_only", response_contract
     assert response_contract["required_packet_fields_to_preserve"] == [
         "agent_response_contract",
+        "agent_response_contract.review_execution_contract",
         "result_completeness",
         "review_groups",
+        "pull_requests[].review_plan",
         "pull_requests[].review_template",
         "pull_requests[].evidence_commands",
     ], response_contract
@@ -420,24 +404,56 @@ def main() -> int:
     ], response_contract
     depth = response_contract["explanation_depth_contract"]
     assert depth["schema_version"] == "pr_review_explanation_depth_v0", depth
+    assert depth["authority"] == "agent_response_contract.review_execution_contract", depth
     assert "may not know" in depth["reader_profile"], depth
-    assert len(depth["evidence_layers"]) == 4, depth
-    assert len(depth["necessity_questions"]) == 3, depth
-    assert depth["runtime_walkthroughs"]["positive"], depth
-    key_code = depth["key_code_explanation"]
-    assert key_code["schema_version"] == "pr_review_key_code_explanation_v0", key_code
-    assert key_code["required_for_code_changes"] is True, key_code
-    assert key_code["subsection"] == "关键代码讲解", key_code
-    assert len(key_code["per_symbol_fields"]) == 7, key_code
-    assert "short exact-head excerpts" in key_code["source_form"], key_code
-    assert key_code["docs_only_alternative"], key_code
-    assert "authority, permission, or scope bypass" in depth["risk_scan"], depth
-    assert "head SHA" in depth["freshness"], depth
-    assert any("Do not stop at the queue/table summary" in item for item in response_contract["instructions"])
-    assert any("open, closed, merged, today" in item for item in response_contract["instructions"])
-    assert any("drops agent_response_contract" in item or "Do not pipe the JSON packet" in item for item in response_contract["instructions"])
-    assert any("intended checked-out LoopX worktree" in item for item in response_contract["instructions"])
+    execution = response_contract["review_execution_contract"]
+    assert execution["schema_version"] == "pull_request_review_execution_contract_v1", execution
+    requirements = {
+        item["evidence_id"]: item for item in execution["evidence_requirements"]
+    }
+    assert set(requirements) == {
+        "problem_context",
+        "architecture_flow",
+        "changed_line_classification",
+        "symbol_map",
+        "walkthroughs",
+        "validation_matrix",
+        "failure_analysis",
+        "code_volume",
+    }, requirements
+    assert requirements["symbol_map"]["item_count"] == {"minimum": 2, "maximum": 5}
+    assert "caller_evidence" in requirements["symbol_map"]["item_fields"]
+    assert requirements["changed_line_classification"]["categories"] == [
+        "production",
+        "tests_or_fixtures",
+        "docs",
+        "generated",
+        "mechanical_moves",
+    ]
+    assert "negative_fields" in requirements["walkthroughs"]
+    assert "regression_test" in requirements["failure_analysis"]["fields"]
+    assert requirements["code_volume"]["verdict_values"] == [
+        "necessary",
+        "partly_avoidable",
+        "not_yet_proven",
+    ]
+    assert execution["completion_gate"]["metadata_only_verdict_allowed"] is False
+    assert execution["completion_gate"]["stale_head_verdict_allowed"] is False
+    assert execution["finding_contract"]["findings_first"] is True
+    first_plan = first["review_plan"]
+    assert first_plan["schema_version"] == "pull_request_review_plan_v1", first_plan
+    assert first_plan["applicability"]["docs_only"] is True, first_plan
+    assert first_plan["applicability"]["symbol_map_required"] is False, first_plan
+    assert "symbol_map" not in first_plan["required_evidence_ids"], first_plan
+    assert first_plan["result_template"]["target_exact_head"] == (
+        "773@7730000000000000000000000000000000000000"
+    ), first_plan
     merged = next(item for item in payload["pull_requests"] if item["number"] == 770)
+    merged_plan = merged["review_plan"]
+    assert merged_plan["applicability"]["code_change"] is True, merged_plan
+    assert merged_plan["applicability"]["symbol_map_required"] is True, merged_plan
+    assert merged_plan["applicability"]["negative_walkthrough_required"] is True, merged_plan
+    assert "symbol_map" in merged_plan["required_evidence_ids"], merged_plan
     merged_risk_hint = merged["metadata_risk_hint"]
     assert merged_risk_hint["level"] == "medium", merged_risk_hint
     merged_main_risk = merged["main_regression_analysis"]
@@ -508,7 +524,8 @@ def main() -> int:
     assert "final answer contract: queue/table is only a preface" in markdown, markdown
     assert "## Agent Output Contract" in markdown, markdown
     assert "Do not stop at the queue/table summary" in markdown, markdown
-    assert "explanation_depth_contract" in markdown, markdown
+    assert "agent_response_contract.review_execution_contract" in markdown, markdown
+    assert "review plan: exact_head=" in markdown, markdown
     assert "remote head SHA" in markdown, markdown
     assert "Required card headings: `动机`, `改动思路`, `具体改动`, `对主干的风险`, `我的整体评价`" in markdown, markdown
     assert "`关键代码讲解`" in markdown, markdown

--- a/examples/slash-command-catalog-smoke.py
+++ b/examples/slash-command-catalog-smoke.py
@@ -50,13 +50,17 @@ def main() -> int:
     assert pr_review["agent_contract"]["slash_prefix_dominates_intent"] is True, pr_review
     assert pr_review["agent_contract"]["stats_only_requires_explicit_opt_out"] is True, pr_review
     assert "agent_response_contract" in pr_review["agent_contract"]["authoritative_fields"], pr_review
+    assert "agent_response_contract.review_execution_contract" in pr_review["agent_contract"]["authoritative_fields"], pr_review
     assert "agent_response_contract.explanation_depth_contract" in pr_review["agent_contract"]["authoritative_fields"], pr_review
     assert "review_groups.unmerged" in pr_review["agent_contract"]["authoritative_fields"], pr_review
     assert "review_groups.merged" in pr_review["agent_contract"]["authoritative_fields"], pr_review
     assert "agent_response_contract.required_final_sections" in pr_review["agent_contract"]["authoritative_fields"], pr_review
     assert pr_review["agent_contract"]["required_packet_fields_to_preserve"] == [
         "agent_response_contract",
+        "agent_response_contract.review_execution_contract",
+        "result_completeness",
         "review_groups",
+        "pull_requests[].review_plan",
         "pull_requests[].review_template",
         "pull_requests[].evidence_commands",
     ], pr_review

--- a/examples/slash-command-catalog-smoke.py
+++ b/examples/slash-command-catalog-smoke.py
@@ -50,14 +50,12 @@ def main() -> int:
     assert pr_review["agent_contract"]["slash_prefix_dominates_intent"] is True, pr_review
     assert pr_review["agent_contract"]["stats_only_requires_explicit_opt_out"] is True, pr_review
     assert "agent_response_contract" in pr_review["agent_contract"]["authoritative_fields"], pr_review
-    assert "agent_response_contract.review_execution_contract" in pr_review["agent_contract"]["authoritative_fields"], pr_review
     assert "agent_response_contract.explanation_depth_contract" in pr_review["agent_contract"]["authoritative_fields"], pr_review
     assert "review_groups.unmerged" in pr_review["agent_contract"]["authoritative_fields"], pr_review
     assert "review_groups.merged" in pr_review["agent_contract"]["authoritative_fields"], pr_review
     assert "agent_response_contract.required_final_sections" in pr_review["agent_contract"]["authoritative_fields"], pr_review
     assert pr_review["agent_contract"]["required_packet_fields_to_preserve"] == [
         "agent_response_contract",
-        "agent_response_contract.review_execution_contract",
         "result_completeness",
         "review_groups",
         "pull_requests[].review_plan",
@@ -74,7 +72,7 @@ def main() -> int:
         "对主干的风险",
         "我的整体评价",
     ], final_contract
-    assert "per-section ranges" in final_contract["section_length_hint"], final_contract
+    assert "review_template ranges" in final_contract["section_length_hint"], final_contract
     assert "may not know" in final_contract["reader_profile"], final_contract
     assert "remote head" in final_contract["freshness_policy"], final_contract
     assert "do not reconstruct" in pr_review["agent_contract"]["manual_gh_policy"], pr_review

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -235,6 +235,21 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
         ],
         "implemented_protocols": [
             {
+                "schema_version": "pull_request_review_execution_contract_v1",
+                "module": "loopx.capabilities.pr_review_queue.review_contract",
+                "doc": "docs/reference/protocols/pr-review-command-v0.md",
+            },
+            {
+                "schema_version": "pull_request_review_plan_v1",
+                "module": "loopx.capabilities.pr_review_queue.review_contract",
+                "doc": "docs/reference/protocols/pr-review-command-v0.md",
+            },
+            {
+                "schema_version": "pull_request_review_result_v1",
+                "module": "loopx.capabilities.pr_review_queue.review_contract",
+                "doc": "docs/reference/protocols/pr-review-command-v0.md",
+            },
+            {
                 "schema_version": "pull_request_review_queue_observation_v0",
                 "module": "loopx.capabilities.pr_review_queue.core",
                 "doc": "docs/reference/protocols/pr-review-command-v0.md",
@@ -256,6 +271,7 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
         ],
         "docs": ["docs/reference/protocols/pr-review-command-v0.md"],
         "boundaries": [
+            "The shared execution contract owns review depth, evidence completeness, exact-head freshness, symbol-map, walkthrough, validation, failure, and code-volume requirements; host skills only route and publish it.",
             "A queue is observed only when result_completeness.complete=true; partial or failed reads are not_observed and never count as unchanged.",
             "Fingerprints cover exact head, review decision, check state, draft state, and mergeability for every open PR.",
             "One observation emits at most one exact-head advancement Todo preview; unchanged observations emit no duplicate candidate and may advance only from an explicit handled exact-head cursor.",

--- a/loopx/capabilities/pr_review_queue/__init__.py
+++ b/loopx/capabilities/pr_review_queue/__init__.py
@@ -1,5 +1,17 @@
-"""Deterministic observation for autonomous pull-request review queues."""
+"""Deterministic observation and review contracts for pull-request queues."""
 
 from .core import build_pull_request_review_queue_observation
+from .review_contract import (
+    build_agent_response_contract,
+    build_review_execution_contract,
+    build_review_plan,
+    build_review_template,
+)
 
-__all__ = ["build_pull_request_review_queue_observation"]
+__all__ = [
+    "build_agent_response_contract",
+    "build_pull_request_review_queue_observation",
+    "build_review_execution_contract",
+    "build_review_plan",
+    "build_review_template",
+]

--- a/loopx/capabilities/pr_review_queue/review_contract.py
+++ b/loopx/capabilities/pr_review_queue/review_contract.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+REQUIRED_FINAL_SECTIONS = [
+    "动机",
+    "改动思路",
+    "具体改动",
+    "对主干的风险",
+    "我的整体评价",
+]
+
+CODE_AREAS = {
+    "product_runtime",
+    "app_or_ui_surface",
+    "ci_or_release",
+    "build_or_config",
+}
+
+NEGATIVE_PATH_AREAS = CODE_AREAS | {"public_entry_or_policy"}
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _as_sequence(value: Any) -> Sequence[Any]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return value
+    return ()
+
+
+def _line_churn(item: Mapping[str, Any]) -> int:
+    try:
+        return int(item.get("additions") or 0) + int(item.get("deletions") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _review_order(
+    key_files: Sequence[Mapping[str, Any]], *, limit: int = 5
+) -> list[str]:
+    ranked = sorted(key_files, key=_line_churn, reverse=True)
+    return [str(item.get("path") or "") for item in ranked[:limit] if item.get("path")]
+
+
+def _section(label: str, word_hint: str, instruction: str) -> dict[str, str]:
+    return {
+        "label": label,
+        "word_hint": word_hint,
+        "content": "",
+        "agent_instruction": instruction,
+    }
+
+
+def build_review_template(item: Mapping[str, Any]) -> dict[str, Any]:
+    key_files = [
+        candidate
+        for candidate in _as_sequence(item.get("key_files"))
+        if isinstance(candidate, Mapping)
+    ]
+    return {
+        "schema_version": "pr_review_five_block_template_v0",
+        "purpose": "Empty scaffold only; fill it from the verified review evidence, not PR metadata.",
+        "sections": [
+            _section(
+                "动机",
+                "200-350字",
+                "Use evidence `problem_context`: old behavior, affected caller, concrete cost, before/after outcome, and why the nearest smaller fix is or is not enough.",
+            ),
+            _section(
+                "改动思路",
+                "300-500字",
+                "Use `architecture_flow` and `walkthroughs`: entry point, authoritative state, decision boundary, positive path, alternative, and ownership trade-off.",
+            ),
+            _section(
+                "具体改动",
+                "450-800字",
+                "Use `changed_line_classification` and `symbol_map`. Code changes require `### 关键代码讲解` for 2-5 behavior-bearing exact-head symbols; docs-only changes use `### 关键内容讲解`.",
+            ),
+            _section(
+                "对主干的风险",
+                "250-500字",
+                "Use `failure_analysis`, `walkthroughs.negative`, and `validation_matrix`; trace each finding from triggering state to observed outcome and minimum repair.",
+            ),
+            _section(
+                "我的整体评价",
+                "150-300字",
+                "Use `code_volume`, validation results, residual risk, and exact-head freshness to state the verdict and the evidence needed for re-review.",
+            ),
+        ],
+        "review_order": _review_order(key_files),
+        "output_hint": (
+            "Render the verified structured result using the five sections. "
+            "The capability-owned review_execution_contract is the evidence and completeness authority."
+        ),
+    }
+
+
+def build_review_execution_contract() -> dict[str, Any]:
+    return {
+        "schema_version": "pull_request_review_execution_contract_v1",
+        "purpose": (
+            "Define the evidence that must exist before a detailed review verdict; "
+            "host skills route this contract but must not reimplement it."
+        ),
+        "evidence_status_values": ["verified", "unverified", "not_applicable"],
+        "evidence_requirements": [
+            {
+                "evidence_id": "problem_context",
+                "required_when": "always",
+                "fields": [
+                    "author_claim",
+                    "old_behavior",
+                    "affected_caller_or_operator",
+                    "compounding_cost",
+                    "before_after_scenario",
+                    "smaller_fix_analysis",
+                    "observable_outcome",
+                    "non_goals",
+                ],
+            },
+            {
+                "evidence_id": "architecture_flow",
+                "required_when": "always",
+                "fields": [
+                    "entry_point",
+                    "authoritative_input_or_state",
+                    "decision_owner",
+                    "side_effect_or_transition",
+                    "receipt_or_consumer",
+                    "failure_or_retry_owner",
+                ],
+            },
+            {
+                "evidence_id": "changed_line_classification",
+                "required_when": "always",
+                "categories": [
+                    "production",
+                    "tests_or_fixtures",
+                    "docs",
+                    "generated",
+                    "mechanical_moves",
+                ],
+                "fields": ["files", "additions", "deletions", "behavior_role"],
+                "rule": "Classify the exact base..head diff before judging code volume.",
+            },
+            {
+                "evidence_id": "symbol_map",
+                "required_when": "code_change",
+                "item_count": {"minimum": 2, "maximum": 5},
+                "item_fields": [
+                    "path",
+                    "line",
+                    "symbol",
+                    "responsibility",
+                    "before_after_behavior",
+                    "input_or_pre_state",
+                    "critical_branch_or_invariant",
+                    "callee_or_side_effect",
+                    "return_or_consumer",
+                    "failure_fallback_or_retry_owner",
+                    "caller_evidence",
+                ],
+                "source_rule": (
+                    "Use exact-head definitions plus unchanged surrounding callers; "
+                    "select symbols by behavior, not diff size."
+                ),
+            },
+            {
+                "evidence_id": "walkthroughs",
+                "required_when": "always",
+                "positive_fields": [
+                    "trigger",
+                    "ordered_symbols_or_steps",
+                    "state_transitions",
+                    "observable_result",
+                ],
+                "negative_required_when": (
+                    "runtime, selector, policy, authority, lifecycle, installer, bridge, "
+                    "or public-entry contract changes"
+                ),
+                "negative_fields": [
+                    "triggering_input_or_state",
+                    "ordered_symbols_or_steps",
+                    "rejection_fallback_or_wrong_outcome",
+                    "error_or_retry_owner",
+                ],
+            },
+            {
+                "evidence_id": "validation_matrix",
+                "required_when": "always",
+                "item_fields": [
+                    "invariant_or_case",
+                    "command_or_check",
+                    "status",
+                    "result",
+                    "required",
+                    "skip_or_failure_reason",
+                ],
+                "required_cases": [
+                    "changed invariant positive case",
+                    "material negative or failure case when applicable",
+                    "repository-required checks",
+                ],
+            },
+            {
+                "evidence_id": "failure_analysis",
+                "required_when": "always",
+                "fields": [
+                    "strongest_regression_scenario",
+                    "triggering_state",
+                    "permitting_or_preventing_code_path",
+                    "blast_radius",
+                    "observability",
+                    "rollback_or_recovery",
+                    "minimum_repair",
+                    "regression_test",
+                ],
+            },
+            {
+                "evidence_id": "code_volume",
+                "required_when": "always",
+                "verdict_values": ["necessary", "partly_avoidable", "not_yet_proven"],
+                "fields": [
+                    "changed_line_shape",
+                    "largest_production_hotspots",
+                    "active_call_site_evidence",
+                    "compatibility_or_migration_need",
+                    "verdict",
+                    "highest_value_simplification",
+                    "behavior_preserving_validation",
+                ],
+            },
+        ],
+        "finding_contract": {
+            "findings_first": True,
+            "required_fields": [
+                "severity",
+                "trigger",
+                "code_path",
+                "incorrect_or_risky_outcome",
+                "location",
+                "minimum_repair",
+                "regression_test",
+            ],
+            "no_finding_rule": (
+                "Say no blocking finding explicitly, then name residual risk and the "
+                "strongest missing validation."
+            ),
+        },
+        "completion_gate": {
+            "metadata_only_verdict_allowed": False,
+            "required_status": "Every applicable evidence item is verified or explicitly unverified with a reason.",
+            "code_change_symbol_minimum": 2,
+            "exact_head_recheck_required": True,
+            "stale_head_verdict_allowed": False,
+            "required_final_sections": REQUIRED_FINAL_SECTIONS,
+        },
+        "verdict_policy": {
+            "open_pr_blocking_finding": "REQUEST_CHANGES",
+            "open_pr_non_blocking_finding": "COMMENT",
+            "open_pr_no_finding": "COMMENT unless approval was explicitly requested through merge policy",
+            "merged_pr": "POST_MERGE_AUDIT_COMMENT when a new actionable finding exists",
+            "publication_exceptions": [
+                "explicit local-only request",
+                "private or security-sensitive finding",
+            ],
+        },
+    }
+
+
+def build_review_plan(item: Mapping[str, Any]) -> dict[str, Any]:
+    areas = {
+        str(area) for area, count in _as_mapping(item.get("areas")).items() if count
+    }
+    code_change = bool(areas & CODE_AREAS)
+    docs_only = bool(areas) and areas <= {"public_docs", "public_entry_or_policy"}
+    required_evidence = [
+        "problem_context",
+        "architecture_flow",
+        "changed_line_classification",
+        "walkthroughs",
+        "validation_matrix",
+        "failure_analysis",
+        "code_volume",
+    ]
+    if code_change:
+        required_evidence.insert(3, "symbol_map")
+    number = item.get("number")
+    head_oid = str(item.get("head_oid") or "").strip()
+    target_key = f"{number}@{head_oid}" if number and head_oid else None
+    return {
+        "schema_version": "pull_request_review_plan_v1",
+        "contract_ref": "agent_response_contract.review_execution_contract",
+        "target": {
+            "number": number,
+            "base_ref": item.get("base_ref"),
+            "head_oid": head_oid or None,
+            "exact_head_key": target_key,
+        },
+        "applicability": {
+            "areas": sorted(areas),
+            "code_change": code_change,
+            "docs_only": docs_only,
+            "symbol_map_required": code_change,
+            "negative_walkthrough_required": bool(areas & NEGATIVE_PATH_AREAS),
+        },
+        "required_evidence_ids": required_evidence,
+        "result_template": {
+            "schema_version": "pull_request_review_result_v1",
+            "target_exact_head": target_key,
+            "evidence": {
+                evidence_id: {"status": "unverified"}
+                for evidence_id in required_evidence
+            },
+            "findings": [],
+            "residual_risk": "",
+            "verdict": "unverified",
+        },
+    }
+
+
+def build_agent_response_contract() -> dict[str, Any]:
+    return {
+        "schema_version": "pr_review_agent_response_contract_v0",
+        "table_only_response_allowed": False,
+        "slash_prefix_dominates_intent": True,
+        "stats_only_requires_explicit_opt_out": True,
+        "queue_table_role": "preface_only",
+        "default_review_scope": (
+            "Review PRs in review_groups.unmerged first, then review_groups.merged, "
+            "bounded by the requested limit."
+        ),
+        "required_packet_fields_to_preserve": [
+            "agent_response_contract",
+            "agent_response_contract.review_execution_contract",
+            "result_completeness",
+            "review_groups",
+            "pull_requests[].review_plan",
+            "pull_requests[].review_template",
+            "pull_requests[].evidence_commands",
+        ],
+        "stats_only_opt_out_examples": [
+            "只统计",
+            "只列出",
+            "stats only",
+            "list only",
+            "不要 review",
+            "不用分析",
+        ],
+        "required_final_sections": REQUIRED_FINAL_SECTIONS,
+        "review_execution_contract": build_review_execution_contract(),
+        "explanation_depth_contract": {
+            "schema_version": "pr_review_explanation_depth_v0",
+            "authority": "agent_response_contract.review_execution_contract",
+            "reader_profile": "A technically curious reader who may not know this PR or subsystem.",
+            "verdict_preface": "Lead with one evidence-based verdict and the highest-severity reason.",
+            "freshness": "Record and recheck the remote head SHA; do not publish a stale verdict.",
+        },
+        "instructions": [
+            "Use review_groups as the queue and require result_completeness.complete=true for exhaustive review.",
+            "Execute each pull_requests[].review_plan against the shared review_execution_contract before drafting prose.",
+            "Do not infer verified evidence from title, labels, changed-file counts, metadata_risk_hint, or green CI alone.",
+            "Recheck the exact remote head before verdict and publication.",
+            "Render the verified result through pull_requests[].review_template; host skills must not maintain a competing depth checklist.",
+        ],
+    }

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -43,11 +43,11 @@ REQUIRED_INSTALLED_SKILL_PHRASES = {
     ),
     "loopx-pr-review": (
         "loopx --format json pr-review --state all",
-        "agent_response_contract",
-        "Do not pipe the first packet through `jq`",
-        "submit a formal `REQUEST_CHANGES` review",
-        "A plain PR comment is not an adequate substitute for `REQUEST_CHANGES`",
-        "route approval, merge, self-merge, and admin-bypass actions to",
+        "thin host adapter",
+        "agent_response_contract.review_execution_contract",
+        "pull_requests[].review_plan",
+        "completion_gate",
+        "loopx-pr-merge",
     ),
     "loopx-pr-program": (
         "one `continuous_monitor` todo",

--- a/loopx/pr_review.py
+++ b/loopx/pr_review.py
@@ -3,15 +3,20 @@ from __future__ import annotations
 import json
 import re
 import subprocess
+from collections.abc import Mapping
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any
 
+from .capabilities.pr_review_queue import (
+    build_agent_response_contract,
+    build_review_plan,
+    build_review_template,
+)
 from .control_plane.runtime.time import now_utc_iso
 from .presentation.markdown import as_dict as _as_dict
 from .presentation.markdown import as_list as _as_list
 from .presentation.public_safety import public_safe_boundary, redact_public_text
-
 
 COMMAND = "/loopx-pr-review"
 SCHEMA_VERSION = "loopx_pr_review_command_response_v0"
@@ -456,10 +461,6 @@ def _int_or_zero(value: object) -> int:
         return 0
 
 
-def _file_churn(item: dict[str, Any]) -> int:
-    return _int_or_zero(item.get("additions")) + _int_or_zero(item.get("deletions"))
-
-
 def _check_brief_phrase(checks: dict[str, Any]) -> str:
     counts = _as_dict(checks.get("counts"))
     if checks.get("failures"):
@@ -471,11 +472,6 @@ def _check_brief_phrase(checks: dict[str, Any]) -> str:
     if int(checks.get("total") or 0) == 0:
         return "无 checks"
     return str(checks.get("summary") or "unknown")
-
-
-def _review_order(files: list[dict[str, Any]], *, limit: int = 5) -> list[str]:
-    ranked = sorted(files, key=_file_churn, reverse=True)
-    return [str(file.get("path") or "") for file in ranked[:limit] if file.get("path")]
 
 
 def _metadata_risk_hint(pr: dict[str, Any], files: list[dict[str, Any]], checks: dict[str, Any]) -> dict[str, Any]:
@@ -585,148 +581,6 @@ def _main_regression_analysis(pr: dict[str, Any], files: list[dict[str, Any]]) -
         "bug_risks": bug_risks[:5],
         "verification_focus": verification_focus[:5],
         "post_merge_review": state == "MERGED" or bool(pr.get("mergedAt") or pr.get("merged_at")),
-    }
-
-
-def _section(label: str, word_hint: str, instruction: str) -> dict[str, str]:
-    return {
-        "label": label,
-        "word_hint": word_hint,
-        "content": "",
-        "agent_instruction": instruction,
-    }
-
-
-def _review_template(item: dict[str, Any]) -> dict[str, Any]:
-    key_files = [file for file in _as_list(item.get("key_files")) if isinstance(file, dict)]
-    sections = [
-        _section(
-            "动机",
-            "200-350字",
-            "解释旧行为、具体痛点、受影响的用户或调用方、目标结果与必要性；说明不合并会继续付出什么代价，以及需求来自活跃调用方还是未来设想。",
-        ),
-        _section(
-            "改动思路",
-            "300-500字",
-            "解释所选架构、改动前后的控制流或数据流、所有权边界、关键不变量和替代方案取舍；为不熟悉子系统的读者给出一条正向运行链路，并点明承载关键决策的符号。",
-        ),
-        _section(
-            "具体改动",
-            "450-800字",
-            "把关键文件和符号映射到行为，覆盖接口、配置或状态、兼容路径、测试与文档；代码型 PR 必须包含 `### 关键代码讲解`，选 2-5 个行为关键符号，结合精确 head 的短代码片段或等价伪代码，逐个解释输入/前置状态、关键分支或不变量、调用/副作用、输出消费者与失败路径；说明各部分如何协作，并给出一个具体输入到输出的例子。纯文档 PR 改为讲解关键政策或内容锚点。",
-        ),
-        _section(
-            "对主干的风险",
-            "250-500字",
-            "按严重度列出有文件或符号证据的发现，评估爆炸半径、兼容性、权限、默认副作用、失败与回滚、可观测性和缺失覆盖；策略或生命周期改动必须解释一条负向链路。",
-        ),
-        _section(
-            "我的整体评价",
-            "150-300字",
-            "权衡价值与复杂度，列出实际检查或运行的验证，注明审阅的 head SHA，并给出精确结论；若阻塞，说明最小修复和复审所需证据。",
-        ),
-    ]
-    return {
-        "schema_version": "pr_review_five_block_template_v0",
-        "purpose": "Empty scaffold only; agentloop fills it after reading PR body and diff.",
-        "sections": sections,
-        "review_order": _review_order(key_files),
-        "output_hint": "Write for a reader unfamiliar with the PR: explain context, architecture, implementation, validation, necessity, and risk with concrete evidence. For code changes, include a detailed key-code subsection grounded in exact-head symbols and short excerpts or equivalent pseudocode. Follow each section's range as a depth signal, not filler.",
-    }
-
-
-def _agent_response_contract() -> dict[str, Any]:
-    return {
-        "schema_version": "pr_review_agent_response_contract_v0",
-        "table_only_response_allowed": False,
-        "slash_prefix_dominates_intent": True,
-        "stats_only_requires_explicit_opt_out": True,
-        "queue_table_role": "preface_only",
-        "default_review_scope": "Review PRs in review_groups.unmerged first, then review_groups.merged, bounded by the requested limit.",
-        "required_packet_fields_to_preserve": [
-            "agent_response_contract",
-            "result_completeness",
-            "review_groups",
-            "pull_requests[].review_template",
-            "pull_requests[].evidence_commands",
-        ],
-        "stats_only_opt_out_examples": [
-            "只统计",
-            "只列出",
-            "stats only",
-            "list only",
-            "不要 review",
-            "不用分析",
-        ],
-        "required_final_sections": [
-            "动机",
-            "改动思路",
-            "具体改动",
-            "对主干的风险",
-            "我的整体评价",
-        ],
-        "explanation_depth_contract": {
-            "schema_version": "pr_review_explanation_depth_v0",
-            "reader_profile": "A technically curious reader who may not know this PR or subsystem.",
-            "verdict_preface": "Lead with one evidence-based merge verdict and the highest-severity reason before the five sections.",
-            "evidence_layers": [
-                "problem: old behavior, concrete pain, affected caller, and before/after scenario",
-                "architecture: entry point, control/data flow, ownership, state, authority, and failure boundary",
-                "implementation: important files and symbols, behavior changes, compatibility plumbing, tests, and docs",
-                "validation: checks and focused reproductions tied to invariants, including untested or environment-blocked cases",
-            ],
-            "necessity_questions": [
-                "What remains broken or expensive without this PR?",
-                "Why is a smaller call-site fix insufficient, or why would it be sufficient?",
-                "Which plausible alternative was rejected and what trade-off was chosen?",
-            ],
-            "runtime_walkthroughs": {
-                "positive": "Trace one user or host action through calls/state to the observable result.",
-                "negative_when": "For selectors, policy, authority, lifecycle, or bridge changes, trace one rejection or failure case.",
-            },
-            "key_code_explanation": {
-                "schema_version": "pr_review_key_code_explanation_v0",
-                "required_for_code_changes": True,
-                "subsection": "关键代码讲解",
-                "symbol_count": "Select 2-5 behavior-bearing symbols, proportional to the PR; do not choose by diff size alone.",
-                "per_symbol_fields": [
-                    "exact-head file and line plus symbol name",
-                    "responsibility and before/after behavior",
-                    "inputs or authoritative pre-state",
-                    "critical branch, transition, or invariant",
-                    "callee, side effect, or persisted write",
-                    "return value, receipt, or downstream consumer",
-                    "failure, fallback, rejection, or retry ownership",
-                ],
-                "source_form": "Use 1-3 short exact-head excerpts or equivalent pseudocode blocks, each followed by mechanism-rich explanation; do not paste large diff regions.",
-                "docs_only_alternative": "For a docs-only PR, explain the key policy or content anchors and how readers or tooling consume them.",
-            },
-            "risk_scan": [
-                "false-ready or false-success state",
-                "authority, permission, or scope bypass",
-                "unexpected default-on installation or side effect",
-                "compatibility or persisted-state migration gap",
-                "host-specific assumption presented as host-neutral",
-                "duplicated truth, stale projection, or lifecycle leak",
-                "missing negative test, rollback behavior, or error observability",
-                "scope inflation or speculative abstraction without an active caller",
-            ],
-            "freshness": "Record the remote head SHA before review and query it again before the verdict; restart if it changed.",
-        },
-        "instructions": [
-            "Run loopx pr-review first and use review_groups as the queue.",
-            "Before treating the queue as exhaustive, require result_completeness.complete=true. If it is false and the user asked for all/every PR, rerun with result_completeness.recommended_limit and preserve the new full packet.",
-            "When the visible message starts with /loopx-pr-review, treat words such as open, closed, merged, today, or time windows as filters, not as permission to return stats only.",
-            "Do not stop at the queue/table summary when the user invokes /loopx-pr-review.",
-            "Do not pipe the JSON packet through jq or another projection that drops agent_response_contract, result_completeness, review_groups, pull_requests[].review_template, or pull_requests[].evidence_commands before planning the final answer.",
-            "For each selected PR, run the evidence_commands or equivalent PR body/diff reads before filling the five sections.",
-            "For every code-changing PR, put a detailed `关键代码讲解` subsection under `具体改动`; explain 2-5 exact-head symbols with short excerpts or equivalent pseudocode, surrounding callers, state transitions, consumers, and failure ownership.",
-            "Follow explanation_depth_contract and the per-section instructions; the packet, rather than host-specific skill prose, is the canonical explanation-depth contract.",
-            "Lead with actionable findings, explain repository-specific terms on first use, and distinguish intended behavior from implementation and validation evidence.",
-            "Do not fill the five sections from metadata_risk_hint alone; metadata_risk_hint is only queue-ordering context.",
-            "Use the installed loopx command or the intended checked-out LoopX worktree; if using python -m loopx.cli from a checkout, first confirm that checkout includes this response contract.",
-            "Only treat the request as stats/list-only when the user explicitly opts out of review with wording such as 只统计, 只列出, stats only, list only, 不要 review, or 不用分析; then say that no detailed PR review was performed.",
-        ],
     }
 
 
@@ -915,7 +769,8 @@ def _normalize_pr(pr: dict[str, Any]) -> dict[str, Any]:
         if number
         else [],
     }
-    item["review_template"] = _review_template(item)
+    item["review_plan"] = build_review_plan(item)
+    item["review_template"] = build_review_template(item)
     return item
 
 
@@ -1076,9 +931,10 @@ def build_pr_review_packet(
             },
             "source": source,
             "include": [
-            "pull_request_list",
-            "result_completeness",
-            "review_groups",
+                "pull_request_list",
+                "result_completeness",
+                "review_groups",
+                "review_plan",
                 "review_template",
                 "agent_response_contract",
                 "change_scope",
@@ -1109,7 +965,7 @@ def build_pr_review_packet(
         "review_sequence": review_sequence,
         "review_groups": review_groups,
         "pull_requests": normalized,
-        "agent_response_contract": _agent_response_contract(),
+        "agent_response_contract": build_agent_response_contract(),
         "actions": [
             {
                 "action_id": "act_review_next_pr",
@@ -1176,9 +1032,9 @@ def render_pr_review_markdown(payload: dict[str, Any]) -> str:
         "## Agent Output Contract",
         "",
         "- Do not stop at the queue/table summary.",
-        "- Do not collapse this packet to `.summary` and `.review_sequence` only; preserve `agent_response_contract`, `review_groups`, `pull_requests[].review_template`, and `pull_requests[].evidence_commands`.",
+        "- Do not collapse this packet to `.summary` and `.review_sequence` only; preserve the paths named by `agent_response_contract.required_packet_fields_to_preserve`.",
         "- For each selected PR, read PR body/files/diff/checks first, then return one review card.",
-        "- Follow `agent_response_contract.explanation_depth_contract`; explain the PR for a technically curious reader who may not know the subsystem.",
+        "- Execute each `pull_requests[].review_plan` against `agent_response_contract.review_execution_contract`; that capability-owned contract is the evidence and completeness authority.",
         "- Code-changing PRs must include a `关键代码讲解` subsection under `具体改动`, grounded in exact-head symbols and short excerpts or equivalent pseudocode.",
         "- Bind the verdict to the remote head SHA and recheck it before answering.",
         "- Required card headings: `动机`, `改动思路`, `具体改动`, `对主干的风险`, `我的整体评价`.",
@@ -1220,6 +1076,7 @@ def render_pr_review_markdown(payload: dict[str, Any]) -> str:
 
     for pr in [item for item in _as_list(payload.get("pull_requests")) if isinstance(item, dict)]:
         template = _as_dict(pr.get("review_template"))
+        review_plan = _as_dict(pr.get("review_plan"))
         lines.extend(
             [
                 "",
@@ -1237,6 +1094,15 @@ def render_pr_review_markdown(payload: dict[str, Any]) -> str:
                 f"- checks: {_as_dict(pr.get('checks')).get('summary')}",
             ]
         )
+        applicability = _as_dict(review_plan.get("applicability"))
+        if review_plan:
+            lines.append(
+                "- review plan: "
+                f"exact_head=`{_as_dict(review_plan.get('target')).get('exact_head_key') or 'unresolved'}`; "
+                f"code_change=`{applicability.get('code_change')}`; "
+                f"symbol_map_required=`{applicability.get('symbol_map_required')}`; "
+                f"negative_walkthrough_required=`{applicability.get('negative_walkthrough_required')}`"
+            )
         risk_hint = _as_dict(pr.get("metadata_risk_hint"))
         if risk_hint:
             lines.append(

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -183,7 +183,7 @@ def _command_prompt_specs(*, cli_bin: str, include_legacy_aliases: bool) -> list
             "instructions": [
                 "Visible command arguments: `$ARGUMENTS`.",
                 "Use the installed `loopx-pr-review` skill when available.",
-                f"Run `{cli_bin} --format json pr-review $ARGUMENTS` first and keep `agent_response_contract`, `review_groups`, `pull_requests[].review_template`, and `pull_requests[].evidence_commands` visible.",
+                f"Run `{cli_bin} --format json pr-review $ARGUMENTS` first and keep `agent_response_contract.review_execution_contract`, `review_groups`, `pull_requests[].review_plan`, `pull_requests[].review_template`, and `pull_requests[].evidence_commands` visible.",
                 "Do not reconstruct the PR queue manually from ad hoc GitHub calls before reading the LoopX packet.",
                 "This command is read-only; do not comment, approve, merge, rerun CI, or spend quota unless separately authorized.",
             ],

--- a/loopx/slash_commands.py
+++ b/loopx/slash_commands.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from .presentation.markdown import markdown_code, markdown_table_row, markdown_table_separator
-
+from .presentation.markdown import (
+    markdown_code,
+    markdown_table_row,
+    markdown_table_separator,
+)
 
 SCHEMA_VERSION = "loopx_slash_command_catalog_v0"
 
@@ -120,7 +123,7 @@ def build_slash_command_catalog(
         _command(
             command="/loopx-pr-review",
             scope="repo",
-            intent="Run the pr-review CLI first, then review the generated unmerged and merged PR groups one by one with the blank five-block template.",
+            intent="Run the pr-review CLI first, execute each capability-owned exact-head review plan, then render the verified result through the five-block template.",
             mutation_policy="read_only; does not comment, approve, merge, or spend quota",
             cli_reference=f"{cli_bin} pr-review [--repo owner/repo] [--state open|merged|all] [--since ISO]",
             agent_contract={
@@ -135,16 +138,21 @@ def build_slash_command_catalog(
                 "stats_only_requires_explicit_opt_out": True,
                 "authoritative_fields": [
                     "agent_response_contract",
+                    "agent_response_contract.review_execution_contract",
                     "agent_response_contract.explanation_depth_contract",
                     "review_groups.unmerged",
                     "review_groups.merged",
+                    "pull_requests[].review_plan",
                     "pull_requests[].review_template",
                     "pull_requests[].evidence_commands",
                     "agent_response_contract.required_final_sections",
                 ],
                 "required_packet_fields_to_preserve": [
                     "agent_response_contract",
+                    "agent_response_contract.review_execution_contract",
+                    "result_completeness",
                     "review_groups",
+                    "pull_requests[].review_plan",
                     "pull_requests[].review_template",
                     "pull_requests[].evidence_commands",
                 ],
@@ -165,8 +173,8 @@ def build_slash_command_catalog(
                         "对主干的风险",
                         "我的整体评价",
                     ],
-                    "evidence_before_filling": "Read each selected PR body/files/diff/checks before filling the sections.",
-                    "section_length_hint": "Use the per-section ranges in pull_requests[].review_template as depth signals; explain context, architecture, implementation, validation, necessity, and risk without filler.",
+                    "evidence_before_filling": "Execute each selected pull_requests[].review_plan against the shared review_execution_contract before filling the sections.",
+                    "section_length_hint": "Render verified evidence through the per-section ranges in pull_requests[].review_template without creating a competing host checklist.",
                     "reader_profile": "A technically curious reader who may not know the PR or subsystem.",
                     "freshness_policy": "Record the remote head before review, recheck it before the verdict, and restart if it changed.",
                 },
@@ -176,8 +184,9 @@ def build_slash_command_catalog(
                 ),
                 "json_projection_policy": (
                     "Do not pipe the first JSON packet to a summary-only projection. "
-                    "The agent must keep agent_response_contract, review_groups, "
-                    "pull_requests[].review_template, and pull_requests[].evidence_commands "
+                    "The agent must keep the capability review_execution_contract, "
+                    "review_groups, pull_requests[].review_plan, review_template, and "
+                    "evidence_commands "
                     "visible before planning the final answer."
                 ),
             },

--- a/loopx/slash_commands.py
+++ b/loopx/slash_commands.py
@@ -123,7 +123,7 @@ def build_slash_command_catalog(
         _command(
             command="/loopx-pr-review",
             scope="repo",
-            intent="Run the pr-review CLI first, execute each capability-owned exact-head review plan, then render the verified result through the five-block template.",
+            intent="Run pr-review, execute each exact-head review plan, then render verified evidence through the five-block template.",
             mutation_policy="read_only; does not comment, approve, merge, or spend quota",
             cli_reference=f"{cli_bin} pr-review [--repo owner/repo] [--state open|merged|all] [--since ISO]",
             agent_contract={
@@ -138,7 +138,6 @@ def build_slash_command_catalog(
                 "stats_only_requires_explicit_opt_out": True,
                 "authoritative_fields": [
                     "agent_response_contract",
-                    "agent_response_contract.review_execution_contract",
                     "agent_response_contract.explanation_depth_contract",
                     "review_groups.unmerged",
                     "review_groups.merged",
@@ -149,7 +148,6 @@ def build_slash_command_catalog(
                 ],
                 "required_packet_fields_to_preserve": [
                     "agent_response_contract",
-                    "agent_response_contract.review_execution_contract",
                     "result_completeness",
                     "review_groups",
                     "pull_requests[].review_plan",
@@ -173,8 +171,8 @@ def build_slash_command_catalog(
                         "对主干的风险",
                         "我的整体评价",
                     ],
-                    "evidence_before_filling": "Execute each selected pull_requests[].review_plan against the shared review_execution_contract before filling the sections.",
-                    "section_length_hint": "Render verified evidence through the per-section ranges in pull_requests[].review_template without creating a competing host checklist.",
+                    "evidence_before_filling": "Execute each selected review_plan before filling the sections.",
+                    "section_length_hint": "Use review_template ranges to render verified evidence without a competing host checklist.",
                     "reader_profile": "A technically curious reader who may not know the PR or subsystem.",
                     "freshness_policy": "Record the remote head before review, recheck it before the verdict, and restart if it changed.",
                 },
@@ -184,9 +182,7 @@ def build_slash_command_catalog(
                 ),
                 "json_projection_policy": (
                     "Do not pipe the first JSON packet to a summary-only projection. "
-                    "The agent must keep the capability review_execution_contract, "
-                    "review_groups, pull_requests[].review_plan, review_template, and "
-                    "evidence_commands "
+                    "Keep the response contract, review groups, plans, templates, and evidence commands "
                     "visible before planning the final answer."
                 ),
             },

--- a/skills/loopx-pr-review/SKILL.md
+++ b/skills/loopx-pr-review/SKILL.md
@@ -1,110 +1,97 @@
 ---
 name: loopx-pr-review
-description: Use when the visible request starts with `/loopx-pr-review` or asks LoopX to review a repository PR queue by time window, open/unmerged status, merged/closed status, or current-day PR activity. Run `loopx pr-review` first, preserve the full packet contract, then read PR evidence and produce detailed per-PR reviews with the five required blocks, exact-head key-code explanations, code-volume necessity, and concrete simplification analysis. For an open PR, publish validated actionable findings by default and submit REQUEST_CHANGES when blockers are found; keep review local only when the user explicitly asks for local-only or dry-run output. Use `loopx-pr-merge` for approval, merge, self-merge, or admin-bypass actions.
+description: Use for `/loopx-pr-review` or evidence-backed PR queue review. Run `loopx pr-review` first, execute the capability-owned review plan for each selected exact head, then publish a review state that matches the verified findings. Use `loopx-pr-merge` for approval or merge actions.
 ---
 
 # LoopX PR Review
 
-## Routing Boundary
+This skill is a thin host adapter. The built-in `pull-request-review`
+capability owns review depth, evidence requirements, completeness, and verdict
+policy through the CLI packet. Do not copy those rules into this skill or
+replace them with a host-specific checklist.
 
-Use this skill for `/loopx-pr-review` and for requests such as:
+## Route
 
-- review today's open and merged PRs;
-- list the unmerged PR queue and take me through review;
-- review PRs since a timestamp;
-- show the merged PRs that need post-merge audit.
+Use this skill for `/loopx-pr-review`, explicit PR reviews, or review queues by
+state or time window. Route approval, merge, self-merge, and admin bypass to
+`loopx-pr-merge` after the evidence review is complete.
 
-This skill owns evidence-backed review publication for open PRs. After the
-review is complete:
-
-- submit a formal `REQUEST_CHANGES` review when one or more validated blocking
-  findings remain;
-- otherwise post the review findings or no-blocker result as a normal PR
-  review/comment, unless approval was explicitly requested;
-- keep the workflow read-only only when the user explicitly says `local-only`,
-  `dry-run`, `不要评论`, `不要提交 review`, or equivalent;
-- route approval, merge, self-merge, and admin-bypass actions to
-  `loopx-pr-merge`.
-
-Do not leave actionable blockers only in chat. A plain PR comment is not an
-adequate substitute for `REQUEST_CHANGES` when the evidence-based verdict is
-that the open PR should not merge.
-
-## First Command
-
-Run the LoopX CLI before manual GitHub calls:
+Run the LoopX CLI before ad hoc GitHub reads:
 
 ```bash
 loopx --format json pr-review --state all
 ```
 
-Translate user filters only into these CLI options:
+Translate only explicit filters:
 
-- `--repo owner/repo` for an explicit repository;
-- `--since ISO` for an explicit time window;
-- `--state open`, `--state merged`, or `--state all` for state filters.
-- `--limit N` when the user explicitly requests a bounded batch.
+- `--repo owner/repo`
+- `--since ISO`
+- `--state open|merged|all`
+- `--limit N`
 
-Default to the current `gh` repository, `--state all`, and the CLI's normal
-100-PR group limit. Treat words like
-`today`, `open`, `closed`, or `merged` as review-queue filters. They do not
-mean "stats only" unless the user explicitly says `只统计`, `只列出`,
-`stats only`, `list only`, `不要 review`, or `不用分析`.
+Words such as `today`, `open`, or `merged` are filters, not permission to
+return a table only. Stats-only output requires an explicit opt-out such as
+`只统计`, `只列出`, `stats only`, or `不要 review`.
 
 ## Preserve The Packet
 
-Keep these fields in model context from the first CLI packet:
+Save the full first JSON packet before printing a compact projection. Keep all
+paths named by `agent_response_contract.required_packet_fields_to_preserve`,
+especially:
 
-- `agent_response_contract`;
-- `result_completeness`;
-- `review_groups`;
-- `pull_requests[].review_template`;
-- `pull_requests[].evidence_commands`.
+- `agent_response_contract.review_execution_contract`
+- `result_completeness`
+- `review_groups`
+- `pull_requests[].review_plan`
+- `pull_requests[].review_template`
+- `pull_requests[].evidence_commands`
 
-Do not pipe the first packet through `jq` or another projection that only keeps
-`.summary`, `.review_sequence`, or a table. If a compact view is useful, save
-the full JSON first and then print the contract-bearing fields:
+Do not pipe the only copy through `jq`. When an exhaustive request has
+`result_completeness.complete=false`, rerun with its `recommended_limit` before
+reviewing.
 
-```bash
-packet="$(mktemp)"
-loopx --format json pr-review --state all [--repo owner/repo] [--since ISO] > "$packet"
-python3 - "$packet" <<'PY'
-import json
-import sys
-p = json.load(open(sys.argv[1]))
-print(json.dumps({
-  "agent_response_contract": p.get("agent_response_contract"),
-  "result_completeness": p.get("result_completeness"),
-  "review_groups": p.get("review_groups"),
-  "pull_requests": [
-    {
-      "number": pr.get("number"),
-      "title": pr.get("title"),
-      "review_template": pr.get("review_template"),
-      "evidence_commands": pr.get("evidence_commands"),
-    }
-    for pr in p.get("pull_requests", [])
-  ],
-}, ensure_ascii=False, indent=2))
-PY
-rm -f "$packet"
-```
+## Execute One Review Plan
 
-## Require Complete Exhaustive Queues
+Review `review_groups.unmerged` first, then `review_groups.merged`. For every
+selected PR:
 
-When the user asks for `all`, `every`, `全部`, `每个`, or an exhaustive time
-window, do not start reviewing until `result_completeness.complete=true`.
-When it is false, rerun the same first command with
-`--limit <result_completeness.recommended_limit>`. Repeat until complete,
-preserving the latest full packet as the queue source of truth. Never infer
-completeness from `summary.total_pr_count`, a count equal to the limit, or the
-absence of a pagination error.
+1. Record the packet's exact head and run its `evidence_commands`, plus focused
+   repository-native validation when applicable.
+2. Fill `review_plan.result_template` using the shared
+   `agent_response_contract.review_execution_contract`. Preserve `unverified`
+   for missing evidence and give the reason; never infer `verified` from title,
+   labels, metadata risk, changed-file counts, or green CI alone.
+3. Apply `completion_gate` literally. If an applicable requirement is missing,
+   do not manufacture a detailed verdict; name the evidence gap.
+4. Render the verified result through `review_template`. The five sections are
+   output structure, while the execution contract is the evidence authority.
+5. Re-read the remote head immediately before verdict and publication. Restart
+   the evidence pass if it changed.
 
-## Autonomous Monitor Route
+Each PR gets an independent evidence pass and standalone card. A queue table is
+only a preface. For large queues, finish fewer complete cards and name the
+remainder instead of compressing every review into metadata prose.
 
-For a recurring PR monitor, use the built-in `pull-request-review` capability
-instead of inferring queue state from monitor timing or a remembered chat
-summary:
+## Publish And Read Back
+
+For an open PR, publish validated actionable findings by default unless the
+user explicitly requested local-only/dry-run output or the finding contains
+private or security-sensitive material.
+
+- Remaining blocking finding: formal `REQUEST_CHANGES`.
+- Non-blocking finding: normal review/comment.
+- No finding: say so; approval still routes through `loopx-pr-merge`.
+- Merged PR: publish a post-merge audit comment only for a new actionable
+  finding; avoid duplicating an equivalent exact-head result.
+
+Build public text from the exact reviewed head. Remove local paths, private
+context, raw logs, credentials, and internal-only links. Read the published
+review back, verify its state and rendered body, and return its URL. Do not
+leave a public blocker only in chat.
+
+## Autonomous Queue
+
+For recurring observation, use the same capability:
 
 ```bash
 loopx --format json pr-review --repo owner/repo --state open \
@@ -113,258 +100,13 @@ loopx --format json pr-review --repo owner/repo --state open \
   [--handled-exact-head NUMBER@HEAD_OID]
 ```
 
-Treat `autonomous_review.observation_state` literally:
+Treat `not_observed`, `observed_unchanged`, and `material_transition`
+literally. A candidate is scheduling evidence only; it grants no Todo, review,
+comment, approval, push, or merge authority. Supply `--handled-exact-head` only
+after exact-head review-result readback proves completion.
 
-- `not_observed` means the complete queue was not obtained. Preserve the prior
-  fingerprint, retry later, and never report this as unchanged.
-- `observed_unchanged` means a complete exact fingerprint matched. Do not
-  recreate the same review Todo. When an explicit handled cursor is present,
-  the packet may expose the next unhandled backlog candidate without changing
-  this observation state. Deduplicate by exact target key while an unhandled
-  candidate remains selected across polls.
-- `material_transition` may expose one exact-head candidate. Materialize it
-  only through normal Todo authority, then run this review skill for deep
-  evidence and publication.
+## Failure
 
-The candidate is a scheduling preview, not permission to review, comment,
-approve, push, or merge. This skill still owns evidence-backed review
-publication; `loopx-pr-merge` still owns approval and merge policy.
-
-After publishing and reading back the formal review result for the candidate's
-exact head, pass `--handled-exact-head NUMBER@HEAD_OID` on the next complete
-poll. Never infer handled state from candidate selection alone. Preserve the
-returned `handled_exact_heads` through later observation packets; a changed
-head must be reviewed again.
-
-## Review Flow
-
-Review `review_groups.unmerged` first, then `review_groups.merged`. A queue
-table can be a short preface, but stopping at the table is incomplete for
-`/loopx-pr-review`.
-
-For each selected PR, read the PR evidence before writing the review. Prefer the
-packet's `evidence_commands`; equivalent targeted `gh pr view`, `gh pr diff
---name-only`, and `gh pr diff --patch` commands are acceptable when needed.
-Each PR must receive its own evidence pass and standalone review card. Do not
-reuse one PR's architecture, validation, or risk statements as queue-wide prose.
-For code-changing PRs, also read the definitions and surrounding active call
-sites of the behavior-bearing symbols; the changed hunk alone is insufficient.
-
-Treat `agent_response_contract.explanation_depth_contract` and each
-`review_template.sections[].agent_instruction` as the canonical detail policy.
-The skill owns routing and evidence discipline; it must not maintain a second,
-competing explanation checklist. For older packets without the depth contract,
-still explain context, architecture, implementation, validation, necessity, and
-risk for a reader who may not know the subsystem.
-
-Record the remote `headRefOid` before deep review and query it again before the
-verdict. If it changed, review the new head instead of carrying forward stale
-findings. Use a clean read-only worktree at the exact head when local execution
-or line-level evidence is useful, and name the reviewed short SHA in the answer.
-
-Before publishing a review, query `headRefOid` one final time. Build the public
-review body from the exact reviewed head, remove local paths, private context,
-raw logs, credentials, and internal-only links, then submit it with literal-safe
-GitHub text handling. Read the resulting review back and verify its state and
-rendered body. Avoid duplicate reviews when the same reviewer has already
-submitted an equivalent decision for the same head.
-
-Do not fill the five-block review from title, labels, changed-file counts, or
-metadata risk hints alone. `metadata_risk_hint` is only for queue ordering.
-
-If the queue is too large for one response, review the highest-priority PRs
-first and say which PRs remain. Do not compress individual cards to cover more
-of the queue, and do not silently replace review with a summary.
-
-## Per-PR Evidence And Depth Gate
-
-Before drafting each card, build a compact internal evidence record for that PR.
-This is preparation for the five required headings, not a sixth output section.
-At minimum, record:
-
-- the reviewed base and head SHA, PR body claim, changed paths, and exact check
-  state;
-- the old behavior and affected caller, plus the intended observable result;
-- the entry point, important symbols, active call site, state or data flow, and
-  ownership or authority boundary;
-- a 2-5 symbol key-code map with exact-head lines, inputs/pre-state, critical
-  branches or invariants, calls/side effects, outputs/consumers, and failure
-  ownership;
-- the changed-line breakdown by production, tests/fixtures, docs, generated
-  files, and mechanical moves;
-- focused validation tied to the changed invariant, including failures, skipped
-  checks, and material cases that remain untested;
-- the strongest concrete regression scenario and the code path that permits or
-  prevents it;
-- the code-volume verdict and one evidence-backed simplification opportunity,
-  or an explicit statement that no safe reduction is supported.
-
-Do not draft the verdict while any applicable item above is still inferred only
-from the title, PR description, labels, or metadata hint. Read the relevant diff
-and symbol, run or inspect focused validation where feasible, and mark evidence
-that cannot be obtained as unverified. Each card must stand on its own for a
-reader who has not read the PR body or another card in the queue.
-
-Detailed means mechanism-rich, not repetitive. Explain how the implementation
-works and why the evidence supports the conclusion instead of paraphrasing the
-PR body. For runtime, selector, policy, state, authority, lifecycle, installer,
-or bridge changes, include both:
-
-- one concrete positive walkthrough from input or user action to observable
-  outcome; and
-- one concrete negative or failure walkthrough showing rejection, fallback,
-  stale state, malformed input, or missing capability behavior.
-
-The two chains below are the minimum interpretation of the packet's canonical
-depth contract. They do not add output headings or compete with packet-specific
-instructions; use the same evidence to satisfy both when they overlap.
-
-### Key Code Explanation Gate
-
-For every code-changing PR, put a `### 关键代码讲解` subsection inside
-`具体改动`; this is a subsection, not a sixth top-level review block. Select
-2-5 behavior-bearing symbols in proportion to the PR. Prefer the entry point,
-decision helper, state transition or provider call, receipt/projection builder,
-and failure or rollback owner. Do not choose symbols merely because their files
-have the most changed lines.
-
-For each selected symbol, explain all applicable items:
-
-- exact-head `file:line` and symbol name;
-- responsibility and before/after behavior;
-- input or authoritative pre-state;
-- critical condition, branch, transition, or invariant;
-- important callee, side effect, or persisted write;
-- return value, receipt, projection, or downstream consumer;
-- rejection, fallback, retry, rollback, or error owner.
-
-Include 1-3 short excerpts from the exact reviewed head, or equivalent
-pseudocode when quoting would obscure the mechanism. Follow every excerpt with
-an explanation of why the branch exists and how callers observe it. Do not paste
-large diff regions, restate code token by token, list filenames without control
-flow, or name symbols without explaining execution semantics. Read enough
-unchanged surrounding code to identify the real caller and owner boundary.
-
-For a docs-only PR, use `### 关键内容讲解` instead and explain the policy or
-content anchors, their intended reader/tool consumer, and any precedence or
-compatibility effect. Do not invent code symbols for a documentation-only diff.
-
-### Motivation Causal Chain
-
-Under `动机`, connect the feature objective to the real workflow:
-
-1. name the old caller or operator path and the action that enters it;
-2. explain the failure, ambiguity, repeated work, or unsafe default;
-3. state who pays the cost and how it compounds in a long-running loop;
-4. explain why the nearest existing mechanism or a smaller call-site fix is
-   insufficient, or say explicitly when it would be sufficient;
-5. name the intended observable outcome, non-goals, and active-call-site
-   evidence that makes the need real rather than hypothetical.
-
-Include one compact before/after scenario. Distinguish the PR author's claim
-from behavior independently proven by the diff, call sites, tests, or a
-reproduction.
-
-### Implementation Execution Chain
-
-Across `改动思路` and `具体改动`, describe an executable model rather than a
-file inventory. Identify the caller and public entry point, authoritative
-input or state, decision symbol, resulting transition or provider call,
-observable receipt or projection, and the component that owns failure,
-fallback, or retry.
-
-Trace at least one concrete input through those symbols to the final output.
-Use the key-code subsection to show the critical condition or transition with a
-short exact-head excerpt or equivalent pseudocode, then connect it to the
-surrounding caller and downstream consumer.
-Map important changed files to their role in that chain and distinguish
-production behavior from adapters, compatibility plumbing, fixtures, and
-validation. For a related multi-PR set, add a compact relationship map after
-the standalone five-block cards explaining whether the PRs compose, overlap,
-depend on one another, or solve different layers. The map never replaces the
-per-PR evidence pass or five required headings.
-
-For a blocking finding, name the triggering input or state, trace it to the
-incorrect outcome, cite the narrowest file/line or symbol, and state the minimum
-repair plus regression test. When no blocker is found, say so explicitly and
-still name residual risk and the strongest missing validation. Do not use
-generic phrases such as "CI is green", "low risk", or "looks reasonable" as a
-substitute for this evidence.
-
-## Code Volume And Simplification Review
-
-For every selected PR, analyze whether its code volume is necessary for the
-shipped behavior and name concrete simplification opportunities. Do not treat a
-large diff as a defect by itself or reward a small diff that hides complexity.
-
-- Establish the changed-line shape from the exact reviewed base and head with
-  `git diff --stat`, `git diff --numstat`, or equivalent evidence. Separate
-  production code from tests/fixtures, docs, generated files, and mechanical
-  moves before judging implementation size.
-- Inspect the largest changed production files and the affected symbols, active
-  call sites, and compatibility contracts. Use line count to locate review
-  hotspots, not as the verdict.
-- Classify the volume as `necessary`, `partly avoidable`, or `not yet proven`.
-  Necessary volume may include a cohesive shipped behavior, a real migration or
-  compatibility contract, and focused semantic or regression coverage.
-- Look for avoidable volume in duplicated domain rules, speculative providers or
-  extension points without a caller, compatibility wrappers without a real
-  consumer, parameter-heavy helpers that join unrelated behavior, repeated
-  fixture assertions, and old entry points that should have been removed.
-- Propose a reduction only when it preserves the intended behavior and evidence.
-  Cite the file or symbol, explain what can be deleted or collapsed, and name the
-  validation that would keep the smaller version honest. If no safe reduction is
-  supported by the diff, explicitly say the volume is justified.
-
-Keep the five-heading output contract: put the measured shape and structural
-hotspots under `具体改动`, and put the necessity verdict plus the highest-value
-simplification direction under `我的整体评价`. A code-volume conclusion without
-diff and call-site evidence is incomplete.
-
-## Output Contract
-
-Lead with a one-line evidence-based verdict and highest-severity reason. Then use
-exactly these five headings for each reviewed PR:
-
-1. `动机`
-2. `改动思路`
-3. `具体改动`
-4. `对主干的风险`
-5. `我的整体评价`
-
-Use the packet's blank `review_template` as the required structure and minimum
-detail signal, not as fake/example content. Fill each section only after reading
-PR body, files, checks, and diff. Follow the packet's per-section ranges and
-instructions as the normal per-PR depth target rather than optional aggregate
-guidance. Going shorter is acceptable only when the PR genuinely has less
-applicable surface, and the card must still satisfy the per-PR evidence gate.
-For code-changing PRs, `具体改动` is incomplete without `### 关键代码讲解` and
-the required symbol-level execution semantics. A final chat summary may be
-short only after the detailed public review has been published and linked.
-Avoid title-only summaries such as "improves docs" or "low risk", and
-distinguish intended behavior from what the implementation and validation
-actually prove.
-
-For an open PR, the GitHub review state must match the written verdict:
-
-- any remaining P0/P1 blocker, or another explicitly merge-blocking finding:
-  `REQUEST_CHANGES`;
-- non-blocking findings only: normal review/comment unless the user explicitly
-  requests approval;
-- no findings: report that clearly and route approval through `loopx-pr-merge`
-  when approval is requested.
-
-After publication, include the GitHub review/comment URL in the user-facing
-summary. If GitHub rejects the requested review state, report the exact reason
-and do not imply that the PR status was updated.
-
-## Failure And Fallback
-
-If `loopx pr-review` is unavailable, first repair the LoopX install or run the
-checked-out LoopX CLI from the intended worktree. Do not reconstruct the whole
-queue manually from GitHub and call it a successful `/loopx-pr-review` run.
-
-If a selected PR needs approval, merge, self-merge, or admin-bypass, finish the
-review first and route that action to `loopx-pr-merge`. Blocking findings do not
-need a second authorization step: publish them and submit `REQUEST_CHANGES` by
-default unless the user explicitly requested a local-only review.
+If `loopx pr-review` is unavailable, repair the LoopX install or use the
+intended checked-out CLI. Do not reconstruct the queue manually and call it a
+successful `/loopx-pr-review` run.

--- a/tests/capabilities/test_pr_review_contract.py
+++ b/tests/capabilities/test_pr_review_contract.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from loopx.capabilities.pr_review_queue import (
+    build_agent_response_contract,
+    build_review_plan,
+    build_review_template,
+)
+
+
+def _item(*, areas: dict[str, int]) -> dict[str, object]:
+    return {
+        "number": 42,
+        "base_ref": "main",
+        "head_oid": "a" * 40,
+        "areas": areas,
+        "key_files": [
+            {"path": "src/runtime.py", "additions": 20, "deletions": 5},
+            {"path": "tests/test_runtime.py", "additions": 30, "deletions": 0},
+        ],
+    }
+
+
+def test_execution_contract_owns_deep_review_requirements() -> None:
+    response = build_agent_response_contract()
+
+    assert response["required_packet_fields_to_preserve"] == [
+        "agent_response_contract",
+        "agent_response_contract.review_execution_contract",
+        "result_completeness",
+        "review_groups",
+        "pull_requests[].review_plan",
+        "pull_requests[].review_template",
+        "pull_requests[].evidence_commands",
+    ]
+    contract = response["review_execution_contract"]
+    assert contract["schema_version"] == "pull_request_review_execution_contract_v1"
+    requirements = {
+        item["evidence_id"]: item for item in contract["evidence_requirements"]
+    }
+    assert set(requirements) == {
+        "problem_context",
+        "architecture_flow",
+        "changed_line_classification",
+        "symbol_map",
+        "walkthroughs",
+        "validation_matrix",
+        "failure_analysis",
+        "code_volume",
+    }
+    assert requirements["symbol_map"]["item_count"] == {
+        "minimum": 2,
+        "maximum": 5,
+    }
+    assert "caller_evidence" in requirements["symbol_map"]["item_fields"]
+    assert "negative_fields" in requirements["walkthroughs"]
+    assert "regression_test" in requirements["failure_analysis"]["fields"]
+    assert contract["completion_gate"]["metadata_only_verdict_allowed"] is False
+    assert contract["completion_gate"]["stale_head_verdict_allowed"] is False
+    assert contract["finding_contract"]["findings_first"] is True
+
+
+def test_runtime_plan_requires_symbol_map_and_negative_walkthrough() -> None:
+    plan = build_review_plan(_item(areas={"product_runtime": 1, "test_or_example": 1}))
+
+    assert plan["target"] == {
+        "number": 42,
+        "base_ref": "main",
+        "head_oid": "a" * 40,
+        "exact_head_key": f"42@{'a' * 40}",
+    }
+    assert plan["applicability"]["code_change"] is True
+    assert plan["applicability"]["symbol_map_required"] is True
+    assert plan["applicability"]["negative_walkthrough_required"] is True
+    assert "symbol_map" in plan["required_evidence_ids"]
+    assert set(plan["result_template"]["evidence"]) == set(
+        plan["required_evidence_ids"]
+    )
+    assert all(
+        item["status"] == "unverified"
+        for item in plan["result_template"]["evidence"].values()
+    )
+
+
+def test_docs_plan_does_not_invent_code_symbols() -> None:
+    item = _item(areas={"public_docs": 2})
+    item["key_files"] = [{"path": "docs/design.md", "additions": 15, "deletions": 2}]
+
+    plan = build_review_plan(item)
+    template = build_review_template(item)
+
+    assert plan["applicability"]["docs_only"] is True
+    assert plan["applicability"]["symbol_map_required"] is False
+    assert "symbol_map" not in plan["required_evidence_ids"]
+    concrete = next(
+        section for section in template["sections"] if section["label"] == "具体改动"
+    )
+    assert "### 关键内容讲解" in concrete["agent_instruction"]
+    assert template["review_order"] == ["docs/design.md"]


### PR DESCRIPTION
## Summary

- Move PR review depth, evidence, freshness, finding, and verdict rules into the built-in `pull-request-review` capability.
- Emit one shared typed execution contract plus a compact exact-head review plan and unverified result skeleton per PR.
- Reduce `loopx-pr-review` to a thin host adapter and align slash-command discovery, installer freshness, protocol docs, and smokes with that boundary.

## Why

The previous skill and root command duplicated a long prose checklist. Hosts could drop or reinterpret it, and queue packets did not carry a typed completion contract. The capability now owns the durable review contract while skills only route, execute, publish, and read back its packet.

## Validation

- 46 focused capability, queue, registry, doctor, and update tests passed.
- PR review, slash catalog/install, capability registry, and Python 3.11 local-install smokes passed.
- Repository mypy, focused Ruff, Python compile, diff hygiene, and public-boundary scans passed.
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 18/18 selected checks passed, no manual holds.
- Exact-scope change-quality receipt: `cqr_d51b1124281f8a904537` (`valid`).
