### PR TITLE
refactor(pr-review): make packet own review depth

### DIFF
--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -365,7 +365,12 @@ def main() -> int:
             assert phrase in compact_skill_text, phrase
         assert "JSON output still keeps the full payload" not in compact_skill_text, compact_skill_text
         pr_review_skill = codex_home / "skills" / "loopx-pr-review" / "SKILL.md"
-        pr_review_text = " ".join(pr_review_skill.read_text(encoding="utf-8").split())
+        installed_pr_review_text = pr_review_skill.read_text(encoding="utf-8")
+        canonical_pr_review_text = (
+            REPO_ROOT / "skills" / "loopx-pr-review" / "SKILL.md"
+        ).read_text(encoding="utf-8")
+        assert installed_pr_review_text == canonical_pr_review_text
+        pr_review_text = " ".join(installed_pr_review_text.split())
         for phrase in (
             "loopx --format json pr-review --state all",
             "agent_response_contract",
@@ -373,15 +378,16 @@ def main() -> int:
             "pull_requests[].review_template",
             "pull_requests[].evidence_commands",
             "Do not pipe the first packet through `jq`",
-            "Do not fill the five-block review from title, labels, changed-file counts, or metadata risk hints alone",
+            "The skill must not maintain a second checklist or repeat packet rules in host prose",
             "submit a formal `REQUEST_CHANGES` review",
-            "A plain PR comment is not an adequate substitute for `REQUEST_CHANGES`",
-            "keep the workflow read-only only when the user explicitly says `local-only`",
-            "the GitHub review state must match the written verdict",
-            "route approval, merge, self-merge, and admin-bypass actions to `loopx-pr-merge`",
+            "Do not leave actionable blockers only in chat",
+            "unless the user explicitly asks for `local-only`",
+            "The GitHub review state must match the verdict",
+            "route approval, merge, self-merge, and admin-bypass to `loopx-pr-merge`",
         ):
             assert phrase in pr_review_text, phrase
-        assert "Do not use this skill to approve" not in pr_review_text, pr_review_text
+        assert "Per-PR Evidence And Depth Gate" not in installed_pr_review_text
+        assert "Key Code Explanation Gate" not in installed_pr_review_text
         pr_program_skill = codex_home / "skills" / "loopx-pr-program" / "SKILL.md"
         pr_program_text = " ".join(pr_program_skill.read_text(encoding="utf-8").split())
         for phrase in (
@@ -398,7 +404,7 @@ def main() -> int:
         pr_review_metadata = pr_review_skill.parent / "agents" / "openai.yaml"
         pr_review_metadata_text = pr_review_metadata.read_text(encoding="utf-8")
         assert (
-            'short_description: "Review LoopX PRs with deep key-code explanations"'
+            'short_description: "Review PRs from LoopX evidence packets"'
             in pr_review_metadata_text
         ), pr_review_metadata_text
         assert "Guide agentloop" not in pr_review_metadata_text, pr_review_metadata_text

--- a/examples/pr-review-command-smoke.py
+++ b/examples/pr-review-command-smoke.py
@@ -50,7 +50,8 @@ def assert_public_safe(payload: dict[str, object]) -> None:
 
 
 def main() -> int:
-    skill_text = " ".join(PR_REVIEW_SKILL.read_text(encoding="utf-8").split())
+    raw_skill_text = PR_REVIEW_SKILL.read_text(encoding="utf-8")
+    skill_text = " ".join(raw_skill_text.split())
     for phrase in (
         "Use when the visible request starts with `/loopx-pr-review`",
         "loopx --format json pr-review --state all",
@@ -59,39 +60,27 @@ def main() -> int:
         "pull_requests[].review_template",
         "pull_requests[].evidence_commands",
         "Do not pipe the first packet through `jq`",
-        "Do not fill the five-block review from title, labels, changed-file counts, or metadata risk hints alone",
-        "Each PR must receive its own evidence pass and standalone review card",
-        "Do not compress individual cards to cover more of the queue",
-        "Per-PR Evidence And Depth Gate",
-        "build a compact internal evidence record for that PR",
-        "Each card must stand on its own",
-        "one concrete positive walkthrough",
-        "one concrete negative or failure walkthrough",
-        "Motivation Causal Chain",
-        "who pays the cost",
-        "Implementation Execution Chain",
-        "authoritative input or state",
-        "Key Code Explanation Gate",
-        "`### 关键代码讲解` subsection inside `具体改动`",
-        "2-5 behavior-bearing symbols",
-        "exact-head `file:line` and symbol name",
-        "critical condition, branch, transition, or invariant",
-        "return value, receipt, projection, or downstream consumer",
-        "Include 1-3 short excerpts from the exact reviewed head",
-        "For a docs-only PR, use `### 关键内容讲解`",
-        "relationship map",
-        "state the minimum repair plus regression test",
-        "Code Volume And Simplification Review",
-        "Classify the volume as `necessary`, `partly avoidable`, or `not yet proven`",
-        "A code-volume conclusion without diff and call-site evidence is incomplete",
+        "Do not reuse another PR's architecture, validation, or risk prose",
+        "rather than compressing individual cards into shallow summaries",
+        "The skill must not maintain a second checklist or repeat packet rules in host prose",
+        "Read the published review back and verify its state and rendered body",
         "submit a formal `REQUEST_CHANGES` review",
-        "A plain PR comment is not an adequate substitute for `REQUEST_CHANGES`",
-        "keep the workflow read-only only when the user explicitly says `local-only`",
-        "the GitHub review state must match the written verdict",
-        "After publication, include the GitHub review/comment URL",
-        "route approval, merge, self-merge, and admin-bypass actions to `loopx-pr-merge`",
+        "Do not leave actionable blockers only in chat",
+        "unless the user explicitly asks for `local-only`",
+        "The GitHub review state must match the verdict",
+        "Include the resulting GitHub review or comment URL",
+        "route approval, merge, self-merge, and admin-bypass to `loopx-pr-merge`",
     ):
         assert phrase in skill_text, phrase
+    for duplicated_heading in (
+        "Per-PR Evidence And Depth Gate",
+        "Key Code Explanation Gate",
+        "Motivation Causal Chain",
+        "Implementation Execution Chain",
+        "Code Volume And Simplification Review",
+    ):
+        assert duplicated_heading not in raw_skill_text, duplicated_heading
+    assert len(raw_skill_text.splitlines()) < 180, len(raw_skill_text.splitlines())
 
     assert _github_search_date("2026-06-28T00:00:00+08:00") == "2026-06-27"
     assert _github_search_date("2026-06-28T00:00:00Z") == "2026-06-28"
@@ -431,6 +420,15 @@ def main() -> int:
     assert len(key_code["per_symbol_fields"]) == 7, key_code
     assert "short exact-head excerpts" in key_code["source_form"], key_code
     assert key_code["docs_only_alternative"], key_code
+    scale_review = depth["implementation_scale_review"]
+    assert scale_review["classifications"] == [
+        "necessary",
+        "partly avoidable",
+        "not yet proven",
+    ], scale_review
+    assert "active callers" in scale_review["evidence"], scale_review
+    assert scale_review["simplification"], scale_review
+    assert "relationship map" in depth["related_pr_map"], depth
     assert "authority, permission, or scope bypass" in depth["risk_scan"], depth
     assert "head SHA" in depth["freshness"], depth
     assert any("Do not stop at the queue/table summary" in item for item in response_contract["instructions"])

--- a/examples/slash-command-install-smoke.py
+++ b/examples/slash-command-install-smoke.py
@@ -124,6 +124,10 @@ def main() -> int:
         assert "loopx-managed-slash-command:v1 command=/loopx surface=codex-skill-metadata" in codex_metadata_text
 
         assert not (codex_home / "prompts" / "loopx-pr-review.md").exists()
+        pr_review_facade = codex_home / "skills" / "loopx-pr-review" / "SKILL.md"
+        pr_review_facade_text = pr_review_facade.read_text(encoding="utf-8")
+        assert "Follow the installed skill's publication policy" in pr_review_facade_text
+        assert "This command is read-only; do not comment" not in pr_review_facade_text
 
         claude_skill = claude_home / "skills" / "loopx-global-summary" / "SKILL.md"
         claude_skill_text = claude_skill.read_text(encoding="utf-8")

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -45,9 +45,10 @@ REQUIRED_INSTALLED_SKILL_PHRASES = {
         "loopx --format json pr-review --state all",
         "agent_response_contract",
         "Do not pipe the first packet through `jq`",
+        "The skill must not maintain a second checklist or repeat packet rules in host prose",
         "submit a formal `REQUEST_CHANGES` review",
-        "A plain PR comment is not an adequate substitute for `REQUEST_CHANGES`",
-        "route approval, merge, self-merge, and admin-bypass actions to",
+        "Do not leave actionable blockers only in chat",
+        "route approval, merge, self-merge, and admin-bypass to",
     ),
     "loopx-pr-program": (
         "one `continuous_monitor` todo",

--- a/loopx/pr_review.py
+++ b/loopx/pr_review.py
@@ -623,7 +623,7 @@ def _review_template(item: dict[str, Any]) -> dict[str, Any]:
         _section(
             "我的整体评价",
             "150-300字",
-            "权衡价值与复杂度，列出实际检查或运行的验证，注明审阅的 head SHA，并给出精确结论；若阻塞，说明最小修复和复审所需证据。",
+            "权衡价值与复杂度，把实现规模评为 necessary、partly avoidable 或 not yet proven，并给出有证据的精简方向或说明没有安全缩减；列出实际检查或运行的验证，注明审阅的 head SHA，并给出精确结论；若阻塞，说明最小修复和复审所需证据。",
         ),
     ]
     return {
@@ -701,6 +701,12 @@ def _agent_response_contract() -> dict[str, Any]:
                 "source_form": "Use 1-3 short exact-head excerpts or equivalent pseudocode blocks, each followed by mechanism-rich explanation; do not paste large diff regions.",
                 "docs_only_alternative": "For a docs-only PR, explain the key policy or content anchors and how readers or tooling consume them.",
             },
+            "implementation_scale_review": {
+                "classifications": ["necessary", "partly avoidable", "not yet proven"],
+                "evidence": "Separate production behavior from tests, fixtures, docs, generated files, and mechanical moves; inspect active callers before judging size.",
+                "simplification": "Name the highest-value evidence-backed reduction and its preserving validation, or state that no safe reduction is supported.",
+            },
+            "related_pr_map": "When the selected set contains related PRs, add one compact relationship map after the standalone review cards; never replace a per-PR evidence pass with the map.",
             "risk_scan": [
                 "false-ready or false-success state",
                 "authority, permission, or scope bypass",

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -185,7 +185,7 @@ def _command_prompt_specs(*, cli_bin: str, include_legacy_aliases: bool) -> list
                 "Use the installed `loopx-pr-review` skill when available.",
                 f"Run `{cli_bin} --format json pr-review $ARGUMENTS` first and keep `agent_response_contract`, `review_groups`, `pull_requests[].review_template`, and `pull_requests[].evidence_commands` visible.",
                 "Do not reconstruct the PR queue manually from ad hoc GitHub calls before reading the LoopX packet.",
-                "This command is read-only; do not comment, approve, merge, rerun CI, or spend quota unless separately authorized.",
+                "Follow the installed skill's publication policy for review comments and REQUEST_CHANGES; approval, merge, CI reruns, and quota spending require their own authority.",
             ],
         },
     ]

--- a/skills/loopx-pr-review/SKILL.md
+++ b/skills/loopx-pr-review/SKILL.md
@@ -1,36 +1,30 @@
 ---
 name: loopx-pr-review
-description: Use when the visible request starts with `/loopx-pr-review` or asks LoopX to review a repository PR queue by time window, open/unmerged status, merged/closed status, or current-day PR activity. Run `loopx pr-review` first, preserve the full packet contract, then read PR evidence and produce detailed per-PR reviews with the five required blocks, exact-head key-code explanations, code-volume necessity, and concrete simplification analysis. For an open PR, publish validated actionable findings by default and submit REQUEST_CHANGES when blockers are found; keep review local only when the user explicitly asks for local-only or dry-run output. Use `loopx-pr-merge` for approval, merge, self-merge, or admin-bypass actions.
+description: Use when the visible request starts with `/loopx-pr-review` or asks LoopX to review a repository PR queue by time window or state. Run `loopx pr-review` first, preserve its full packet, execute per-PR evidence commands, and follow the packet-owned response contract. Publish validated review findings for open PRs by default; use `loopx-pr-merge` for approval or merge actions.
 ---
 
 # LoopX PR Review
 
-## Routing Boundary
+## Routing And Publication
 
-Use this skill for `/loopx-pr-review` and for requests such as:
+Use this skill for PR queue review, including open, merged, closed, current-day,
+or explicit time-window requests. The `/loopx-pr-review` prefix means review,
+not a table-only inventory, unless the user explicitly asks for stats or a list
+only.
 
-- review today's open and merged PRs;
-- list the unmerged PR queue and take me through review;
-- review PRs since a timestamp;
-- show the merged PRs that need post-merge audit.
+For open PRs, publish the evidence-backed result unless the user explicitly asks
+for `local-only`, `dry-run`, `不要评论`, `不要提交 review`, or equivalent:
 
-This skill owns evidence-backed review publication for open PRs. After the
-review is complete:
-
-- submit a formal `REQUEST_CHANGES` review when one or more validated blocking
+- submit a formal `REQUEST_CHANGES` review when validated merge-blocking
   findings remain;
-- otherwise post the review findings or no-blocker result as a normal PR
-  review/comment, unless approval was explicitly requested;
-- keep the workflow read-only only when the user explicitly says `local-only`,
-  `dry-run`, `不要评论`, `不要提交 review`, or equivalent;
-- route approval, merge, self-merge, and admin-bypass actions to
-  `loopx-pr-merge`.
+- otherwise publish the findings or no-blocker result as a normal review or
+  comment unless approval was explicitly requested;
+- route approval, merge, self-merge, and admin-bypass to `loopx-pr-merge`.
 
-Do not leave actionable blockers only in chat. A plain PR comment is not an
-adequate substitute for `REQUEST_CHANGES` when the evidence-based verdict is
-that the open PR should not merge.
+Do not leave actionable blockers only in chat or replace a blocking formal
+review with a plain comment.
 
-## First Command
+## Start From The Capability Packet
 
 Run the LoopX CLI before manual GitHub calls:
 
@@ -38,22 +32,20 @@ Run the LoopX CLI before manual GitHub calls:
 loopx --format json pr-review --state all
 ```
 
-Translate user filters only into these CLI options:
+Translate user filters only into supported options:
 
 - `--repo owner/repo` for an explicit repository;
 - `--since ISO` for an explicit time window;
-- `--state open`, `--state merged`, or `--state all` for state filters.
+- `--state open`, `--state merged`, or `--state all` for state filters;
 - `--limit N` when the user explicitly requests a bounded batch.
 
 Default to the current `gh` repository, `--state all`, and the CLI's normal
-100-PR group limit. Treat words like
-`today`, `open`, `closed`, or `merged` as review-queue filters. They do not
-mean "stats only" unless the user explicitly says `只统计`, `只列出`,
-`stats only`, `list only`, `不要 review`, or `不用分析`.
+group limit. Words such as `today`, `open`, `closed`, and `merged` are filters,
+not permission to stop after listing metadata.
 
 ## Preserve The Packet
 
-Keep these fields in model context from the first CLI packet:
+Keep these fields from the first CLI result in model context:
 
 - `agent_response_contract`;
 - `result_completeness`;
@@ -61,50 +53,18 @@ Keep these fields in model context from the first CLI packet:
 - `pull_requests[].review_template`;
 - `pull_requests[].evidence_commands`.
 
-Do not pipe the first packet through `jq` or another projection that only keeps
+Do not pipe the first packet through `jq` or another projection that keeps only
 `.summary`, `.review_sequence`, or a table. If a compact view is useful, save
-the full JSON first and then print the contract-bearing fields:
+the full JSON first and print a derivative view from that saved packet.
 
-```bash
-packet="$(mktemp)"
-loopx --format json pr-review --state all [--repo owner/repo] [--since ISO] > "$packet"
-python3 - "$packet" <<'PY'
-import json
-import sys
-p = json.load(open(sys.argv[1]))
-print(json.dumps({
-  "agent_response_contract": p.get("agent_response_contract"),
-  "result_completeness": p.get("result_completeness"),
-  "review_groups": p.get("review_groups"),
-  "pull_requests": [
-    {
-      "number": pr.get("number"),
-      "title": pr.get("title"),
-      "review_template": pr.get("review_template"),
-      "evidence_commands": pr.get("evidence_commands"),
-    }
-    for pr in p.get("pull_requests", [])
-  ],
-}, ensure_ascii=False, indent=2))
-PY
-rm -f "$packet"
-```
+When the user asks for `all`, `every`, `全部`, `每个`, or an exhaustive window,
+require `result_completeness.complete=true` before review. Otherwise rerun with
+`--limit <result_completeness.recommended_limit>` until complete and treat the
+latest full packet as the queue source of truth.
 
-## Require Complete Exhaustive Queues
+## Autonomous Queue Routing
 
-When the user asks for `all`, `every`, `全部`, `每个`, or an exhaustive time
-window, do not start reviewing until `result_completeness.complete=true`.
-When it is false, rerun the same first command with
-`--limit <result_completeness.recommended_limit>`. Repeat until complete,
-preserving the latest full packet as the queue source of truth. Never infer
-completeness from `summary.total_pr_count`, a count equal to the limit, or the
-absence of a pagination error.
-
-## Autonomous Monitor Route
-
-For a recurring PR monitor, use the built-in `pull-request-review` capability
-instead of inferring queue state from monitor timing or a remembered chat
-summary:
+For a recurring monitor, use the capability's observation route:
 
 ```bash
 loopx --format json pr-review --repo owner/repo --state open \
@@ -113,258 +73,66 @@ loopx --format json pr-review --repo owner/repo --state open \
   [--handled-exact-head NUMBER@HEAD_OID]
 ```
 
-Treat `autonomous_review.observation_state` literally:
+Follow `autonomous_review` literally. Incomplete observation is not unchanged;
+a selected candidate is not mutation authority; and a head is handled only
+after the formal review was published and read back for that exact head. Let
+normal Todo authority materialize any candidate.
 
-- `not_observed` means the complete queue was not obtained. Preserve the prior
-  fingerprint, retry later, and never report this as unchanged.
-- `observed_unchanged` means a complete exact fingerprint matched. Do not
-  recreate the same review Todo. When an explicit handled cursor is present,
-  the packet may expose the next unhandled backlog candidate without changing
-  this observation state. Deduplicate by exact target key while an unhandled
-  candidate remains selected across polls.
-- `material_transition` may expose one exact-head candidate. Materialize it
-  only through normal Todo authority, then run this review skill for deep
-  evidence and publication.
+## Execute Evidence Per PR
 
-The candidate is a scheduling preview, not permission to review, comment,
-approve, push, or merge. This skill still owns evidence-backed review
-publication; `loopx-pr-merge` still owns approval and merge policy.
+Review `review_groups.unmerged` first, then `review_groups.merged`. A queue table
+may be a short preface, but is not the review result.
 
-After publishing and reading back the formal review result for the candidate's
-exact head, pass `--handled-exact-head NUMBER@HEAD_OID` on the next complete
-poll. Never infer handled state from candidate selection alone. Preserve the
-returned `handled_exact_heads` through later observation packets; a changed
-head must be reviewed again.
+For every selected PR:
 
-## Review Flow
+1. Run its `evidence_commands`, or equivalent targeted PR body, checks,
+   changed-file, and patch reads.
+2. For code changes, inspect the behavior-bearing definitions and active call
+   sites, not only changed hunks.
+3. Keep evidence and conclusions specific to that PR. Do not reuse another
+   PR's architecture, validation, or risk prose.
+4. Record the remote `headRefOid` before deep review and query it again before
+   the verdict. Restart on a changed head.
+5. Use a clean read-only exact-head worktree when execution or line-level
+   evidence is needed, and name the reviewed short SHA.
 
-Review `review_groups.unmerged` first, then `review_groups.merged`. A queue
-table can be a short preface, but stopping at the table is incomplete for
-`/loopx-pr-review`.
+Do not fill a review from title, labels, changed-file counts, or
+`metadata_risk_hint`; that hint only orders the queue. If the queue is too large,
+review the highest-priority subset and name what remains rather than compressing
+individual cards into shallow summaries.
 
-For each selected PR, read the PR evidence before writing the review. Prefer the
-packet's `evidence_commands`; equivalent targeted `gh pr view`, `gh pr diff
---name-only`, and `gh pr diff --patch` commands are acceptable when needed.
-Each PR must receive its own evidence pass and standalone review card. Do not
-reuse one PR's architecture, validation, or risk statements as queue-wide prose.
-For code-changing PRs, also read the definitions and surrounding active call
-sites of the behavior-bearing symbols; the changed hunk alone is insufficient.
+## Capability-Owned Output Contract
 
-Treat `agent_response_contract.explanation_depth_contract` and each
-`review_template.sections[].agent_instruction` as the canonical detail policy.
-The skill owns routing and evidence discipline; it must not maintain a second,
-competing explanation checklist. For older packets without the depth contract,
-still explain context, architecture, implementation, validation, necessity, and
-risk for a reader who may not know the subsystem.
+Treat `agent_response_contract`, especially `explanation_depth_contract`, and
+each `review_template.sections[].agent_instruction` as authoritative. They own
+the required sections, explanation depth, key-code walkthroughs, implementation
+scale judgment, related-PR mapping, validation, and risk coverage. The skill
+must not maintain a second checklist or repeat packet rules in host prose.
 
-Record the remote `headRefOid` before deep review and query it again before the
-verdict. If it changed, review the new head instead of carrying forward stale
-findings. Use a clean read-only worktree at the exact head when local execution
-or line-level evidence is useful, and name the reviewed short SHA in the answer.
+Use the packet's blank template as structure, never as evidence or example
+content. Distinguish the author's intended behavior from what the exact diff,
+active call sites, checks, and focused reproductions prove. For older packets
+without the depth contract, explain context, architecture, implementation,
+validation, necessity, and risk for a reader unfamiliar with the subsystem.
 
-Before publishing a review, query `headRefOid` one final time. Build the public
-review body from the exact reviewed head, remove local paths, private context,
-raw logs, credentials, and internal-only links, then submit it with literal-safe
-GitHub text handling. Read the resulting review back and verify its state and
-rendered body. Avoid duplicate reviews when the same reviewer has already
-submitted an equivalent decision for the same head.
+## Publish Fresh, Public-Safe Results
 
-Do not fill the five-block review from title, labels, changed-file counts, or
-metadata risk hints alone. `metadata_risk_hint` is only for queue ordering.
+Immediately before publication, query `headRefOid` again. Build the review from
+the exact reviewed head; remove local paths, private context, raw logs,
+credentials, and internal-only links; and submit with literal-safe text
+handling. The GitHub review state must match the verdict.
 
-If the queue is too large for one response, review the highest-priority PRs
-first and say which PRs remain. Do not compress individual cards to cover more
-of the queue, and do not silently replace review with a summary.
-
-## Per-PR Evidence And Depth Gate
-
-Before drafting each card, build a compact internal evidence record for that PR.
-This is preparation for the five required headings, not a sixth output section.
-At minimum, record:
-
-- the reviewed base and head SHA, PR body claim, changed paths, and exact check
-  state;
-- the old behavior and affected caller, plus the intended observable result;
-- the entry point, important symbols, active call site, state or data flow, and
-  ownership or authority boundary;
-- a 2-5 symbol key-code map with exact-head lines, inputs/pre-state, critical
-  branches or invariants, calls/side effects, outputs/consumers, and failure
-  ownership;
-- the changed-line breakdown by production, tests/fixtures, docs, generated
-  files, and mechanical moves;
-- focused validation tied to the changed invariant, including failures, skipped
-  checks, and material cases that remain untested;
-- the strongest concrete regression scenario and the code path that permits or
-  prevents it;
-- the code-volume verdict and one evidence-backed simplification opportunity,
-  or an explicit statement that no safe reduction is supported.
-
-Do not draft the verdict while any applicable item above is still inferred only
-from the title, PR description, labels, or metadata hint. Read the relevant diff
-and symbol, run or inspect focused validation where feasible, and mark evidence
-that cannot be obtained as unverified. Each card must stand on its own for a
-reader who has not read the PR body or another card in the queue.
-
-Detailed means mechanism-rich, not repetitive. Explain how the implementation
-works and why the evidence supports the conclusion instead of paraphrasing the
-PR body. For runtime, selector, policy, state, authority, lifecycle, installer,
-or bridge changes, include both:
-
-- one concrete positive walkthrough from input or user action to observable
-  outcome; and
-- one concrete negative or failure walkthrough showing rejection, fallback,
-  stale state, malformed input, or missing capability behavior.
-
-The two chains below are the minimum interpretation of the packet's canonical
-depth contract. They do not add output headings or compete with packet-specific
-instructions; use the same evidence to satisfy both when they overlap.
-
-### Key Code Explanation Gate
-
-For every code-changing PR, put a `### 关键代码讲解` subsection inside
-`具体改动`; this is a subsection, not a sixth top-level review block. Select
-2-5 behavior-bearing symbols in proportion to the PR. Prefer the entry point,
-decision helper, state transition or provider call, receipt/projection builder,
-and failure or rollback owner. Do not choose symbols merely because their files
-have the most changed lines.
-
-For each selected symbol, explain all applicable items:
-
-- exact-head `file:line` and symbol name;
-- responsibility and before/after behavior;
-- input or authoritative pre-state;
-- critical condition, branch, transition, or invariant;
-- important callee, side effect, or persisted write;
-- return value, receipt, projection, or downstream consumer;
-- rejection, fallback, retry, rollback, or error owner.
-
-Include 1-3 short excerpts from the exact reviewed head, or equivalent
-pseudocode when quoting would obscure the mechanism. Follow every excerpt with
-an explanation of why the branch exists and how callers observe it. Do not paste
-large diff regions, restate code token by token, list filenames without control
-flow, or name symbols without explaining execution semantics. Read enough
-unchanged surrounding code to identify the real caller and owner boundary.
-
-For a docs-only PR, use `### 关键内容讲解` instead and explain the policy or
-content anchors, their intended reader/tool consumer, and any precedence or
-compatibility effect. Do not invent code symbols for a documentation-only diff.
-
-### Motivation Causal Chain
-
-Under `动机`, connect the feature objective to the real workflow:
-
-1. name the old caller or operator path and the action that enters it;
-2. explain the failure, ambiguity, repeated work, or unsafe default;
-3. state who pays the cost and how it compounds in a long-running loop;
-4. explain why the nearest existing mechanism or a smaller call-site fix is
-   insufficient, or say explicitly when it would be sufficient;
-5. name the intended observable outcome, non-goals, and active-call-site
-   evidence that makes the need real rather than hypothetical.
-
-Include one compact before/after scenario. Distinguish the PR author's claim
-from behavior independently proven by the diff, call sites, tests, or a
-reproduction.
-
-### Implementation Execution Chain
-
-Across `改动思路` and `具体改动`, describe an executable model rather than a
-file inventory. Identify the caller and public entry point, authoritative
-input or state, decision symbol, resulting transition or provider call,
-observable receipt or projection, and the component that owns failure,
-fallback, or retry.
-
-Trace at least one concrete input through those symbols to the final output.
-Use the key-code subsection to show the critical condition or transition with a
-short exact-head excerpt or equivalent pseudocode, then connect it to the
-surrounding caller and downstream consumer.
-Map important changed files to their role in that chain and distinguish
-production behavior from adapters, compatibility plumbing, fixtures, and
-validation. For a related multi-PR set, add a compact relationship map after
-the standalone five-block cards explaining whether the PRs compose, overlap,
-depend on one another, or solve different layers. The map never replaces the
-per-PR evidence pass or five required headings.
-
-For a blocking finding, name the triggering input or state, trace it to the
-incorrect outcome, cite the narrowest file/line or symbol, and state the minimum
-repair plus regression test. When no blocker is found, say so explicitly and
-still name residual risk and the strongest missing validation. Do not use
-generic phrases such as "CI is green", "low risk", or "looks reasonable" as a
-substitute for this evidence.
-
-## Code Volume And Simplification Review
-
-For every selected PR, analyze whether its code volume is necessary for the
-shipped behavior and name concrete simplification opportunities. Do not treat a
-large diff as a defect by itself or reward a small diff that hides complexity.
-
-- Establish the changed-line shape from the exact reviewed base and head with
-  `git diff --stat`, `git diff --numstat`, or equivalent evidence. Separate
-  production code from tests/fixtures, docs, generated files, and mechanical
-  moves before judging implementation size.
-- Inspect the largest changed production files and the affected symbols, active
-  call sites, and compatibility contracts. Use line count to locate review
-  hotspots, not as the verdict.
-- Classify the volume as `necessary`, `partly avoidable`, or `not yet proven`.
-  Necessary volume may include a cohesive shipped behavior, a real migration or
-  compatibility contract, and focused semantic or regression coverage.
-- Look for avoidable volume in duplicated domain rules, speculative providers or
-  extension points without a caller, compatibility wrappers without a real
-  consumer, parameter-heavy helpers that join unrelated behavior, repeated
-  fixture assertions, and old entry points that should have been removed.
-- Propose a reduction only when it preserves the intended behavior and evidence.
-  Cite the file or symbol, explain what can be deleted or collapsed, and name the
-  validation that would keep the smaller version honest. If no safe reduction is
-  supported by the diff, explicitly say the volume is justified.
-
-Keep the five-heading output contract: put the measured shape and structural
-hotspots under `具体改动`, and put the necessity verdict plus the highest-value
-simplification direction under `我的整体评价`. A code-volume conclusion without
-diff and call-site evidence is incomplete.
-
-## Output Contract
-
-Lead with a one-line evidence-based verdict and highest-severity reason. Then use
-exactly these five headings for each reviewed PR:
-
-1. `动机`
-2. `改动思路`
-3. `具体改动`
-4. `对主干的风险`
-5. `我的整体评价`
-
-Use the packet's blank `review_template` as the required structure and minimum
-detail signal, not as fake/example content. Fill each section only after reading
-PR body, files, checks, and diff. Follow the packet's per-section ranges and
-instructions as the normal per-PR depth target rather than optional aggregate
-guidance. Going shorter is acceptable only when the PR genuinely has less
-applicable surface, and the card must still satisfy the per-PR evidence gate.
-For code-changing PRs, `具体改动` is incomplete without `### 关键代码讲解` and
-the required symbol-level execution semantics. A final chat summary may be
-short only after the detailed public review has been published and linked.
-Avoid title-only summaries such as "improves docs" or "low risk", and
-distinguish intended behavior from what the implementation and validation
-actually prove.
-
-For an open PR, the GitHub review state must match the written verdict:
-
-- any remaining P0/P1 blocker, or another explicitly merge-blocking finding:
-  `REQUEST_CHANGES`;
-- non-blocking findings only: normal review/comment unless the user explicitly
-  requests approval;
-- no findings: report that clearly and route approval through `loopx-pr-merge`
-  when approval is requested.
-
-After publication, include the GitHub review/comment URL in the user-facing
-summary. If GitHub rejects the requested review state, report the exact reason
-and do not imply that the PR status was updated.
+Read the published review back and verify its state and rendered body. Avoid an
+equivalent duplicate review from the same reviewer on the same head. Include
+the resulting GitHub review or comment URL in the user-facing summary. If
+GitHub rejects the requested state, report the exact failure and do not imply
+that publication succeeded.
 
 ## Failure And Fallback
 
-If `loopx pr-review` is unavailable, first repair the LoopX install or run the
-checked-out LoopX CLI from the intended worktree. Do not reconstruct the whole
-queue manually from GitHub and call it a successful `/loopx-pr-review` run.
+If `loopx pr-review` is unavailable, repair the LoopX install or use the intended
+checked-out LoopX CLI. Do not reconstruct the queue manually and call it a
+successful `/loopx-pr-review` run.
 
-If a selected PR needs approval, merge, self-merge, or admin-bypass, finish the
-review first and route that action to `loopx-pr-merge`. Blocking findings do not
-need a second authorization step: publish them and submit `REQUEST_CHANGES` by
-default unless the user explicitly requested a local-only review.
+Finish the evidence-backed review before routing any separately authorized
+approval or merge action to `loopx-pr-merge`.

--- a/skills/loopx-pr-review/agents/openai.yaml
+++ b/skills/loopx-pr-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "LoopX PR Review"
-  short_description: "Review LoopX PRs with deep key-code explanations"
-  default_prompt: "Use $loopx-pr-review to review the selected PRs with exact-head evidence, detailed key-code execution explanations, risk analysis, validation, and the required five-block verdict."
+  short_description: "Review PRs from LoopX evidence packets"
+  default_prompt: "Use $loopx-pr-review to preserve the LoopX PR-review packet, execute exact-head evidence commands, follow its response contract, and publish the resulting review when authorized by policy."


### PR DESCRIPTION
## Summary

- reduce the installed `loopx-pr-review` skill to routing, packet preservation, per-PR evidence, exact-head freshness, and publication discipline
- make the CLI packet the single owner of explanation depth, key-code walkthroughs, implementation-scale judgment, and related-PR mapping
- align installer fallback and doctor freshness checks, with regression ratchets against duplicated policy

The skill shrinks from 406 to 138 lines; the full diff is 145 additions and 362 deletions.

## Validation

- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: passed, 9/9 catalog canaries plus public-boundary check
- focused pytest: 44 passed
- `pr-review-command-smoke`, `slash-command-install-smoke`, `install-local-smoke`, and `release-version-contract-smoke`: passed
- Ruff on changed Python surfaces: passed with the repository smoke bootstrap E402 exception
- mypy baseline comparison: changed modules retain the same 45 existing diagnostics as `origin/main`; no new diagnostic
- `loopx check`: 0 errors, 0 warnings
- `git diff --check`: passed
- change-quality receipt: `cqr_79288ce30fa884d5755c`, exact scope valid

## Holds and coverage

No manual holds or skipped required checks. Coverage exercises the canonical skill, packaged/local install copies, stale-skill doctor detection, slash fallback, packet contract, and public/private boundary; this is sufficient for the changed review/install surfaces.

This PR intentionally does not install the unmerged skill into global user state and is left for independent review.