### PR TITLE
fix(install): publish durable Pages bootstrap

### DIFF
--- a/.github/workflows/frontstage-pages.yml
+++ b/.github/workflows/frontstage-pages.yml
@@ -23,6 +23,7 @@ on:
       - "examples/showcase-catalog-smoke.py"
       - "examples/status.example.json"
       - "scripts/render-star-history.py"
+      - "scripts/install-from-github.sh"
   push:
     branches:
       - main
@@ -44,6 +45,7 @@ on:
       - "examples/showcase-catalog-smoke.py"
       - "examples/status.example.json"
       - "scripts/render-star-history.py"
+      - "scripts/install-from-github.sh"
 
 permissions:
   actions: read

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ runtime dependencies outside the standard library.
 Install without cloning:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
 export PATH="$HOME/.local/bin:$PATH"
 loopx doctor
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -168,7 +168,7 @@ Git；Python package 除标准库外没有 runtime 依赖。
 无需 clone，直接安装：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
 export PATH="$HOME/.local/bin:$PATH"
 loopx doctor
 ```

--- a/apps/presentation/site/index.html
+++ b/apps/presentation/site/index.html
@@ -276,7 +276,7 @@
         </div>
         <div class="terminal-card">
           <div class="terminal-bar"><span></span><span></span><span></span><small>terminal</small></div>
-          <pre><code><b>$</b> curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+          <pre><code><b>$</b> curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
 <b>$</b> export PATH="$HOME/.local/bin:$PATH"
 <b>$</b> loopx doctor
 <b>$</b> cd /path/to/your-project

--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -122,7 +122,7 @@ export LOOPX_RUNTIME_ROOT="$HOME/.codex/loopx"
 Install or repair the CLI when needed:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
 export PATH="$HOME/.local/bin:$PATH"
 loopx doctor
 ```

--- a/docs/guides/custom-agent-runner-integration.md
+++ b/docs/guides/custom-agent-runner-integration.md
@@ -50,7 +50,7 @@ repository edits, and one-off tool use can remain Agent work.
 Install the CLI on the machine that owns the project workspace:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
 export PATH="$HOME/.local/bin:$PATH"
 loopx doctor --agent-type other-agent
 ```

--- a/docs/guides/custom-agent-runner-integration.zh-CN.md
+++ b/docs/guides/custom-agent-runner-integration.zh-CN.md
@@ -44,7 +44,7 @@ transition policy 可复用时，才值得新增 Capability；外部实现放在
 先在拥有项目 workspace 的机器上安装 CLI：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
 export PATH="$HOME/.local/bin:$PATH"
 loopx doctor --agent-type other-agent
 ```

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -25,7 +25,7 @@ state, but it cannot make an agent continue automatically.
 Connect the current project to LoopX.
 Do not clone the LoopX repository for ordinary use. If `loopx` is not on PATH,
 install or repair it with the official no-clone installer:
-curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
 export PATH="$HOME/.local/bin:$PATH"
 
 Then run `loopx doctor`. Work only from the current project root:
@@ -201,7 +201,7 @@ First-run path:
 Connect this repo to LoopX from this visible Codex CLI TUI. Do not clone the
 LoopX repository for ordinary use. If `loopx` is not on PATH, install or repair
 it with the official no-clone installer:
-curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
 
 Then run `loopx doctor`. Work only from this project root: if LoopX state
 already exists, reuse it and do not create or overwrite a goal or the active objective; if the project
@@ -345,7 +345,7 @@ python3 examples/fresh-clone-quickstart-smoke.py
 Install or update LoopX without cloning the repository:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
 export PATH="$HOME/.local/bin:$PATH"
 loopx doctor
 ```

--- a/docs/guides/newcomer-command-path.md
+++ b/docs/guides/newcomer-command-path.md
@@ -52,7 +52,7 @@ Use this when an agent asks for the manual shell path, or when you are setting
 up a fresh terminal without an agent driving the first step:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
 export PATH="$HOME/.local/bin:$PATH"
 loopx doctor
 loopx slash-commands --install

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ Claude Code, OpenCode, Cursor, or a custom runner executes bounded turns.
 ## Quick Start
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
 export PATH="$HOME/.local/bin:$PATH"
 loopx doctor
 

--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -12,7 +12,7 @@ which control-plane surfaces are safe to build on.
 For a first-time user, prefer the no-clone archive installer:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
 export PATH="$HOME/.local/bin:$PATH"
 loopx doctor
 ```

--- a/docs/product/runtimes/codex-cli/codex-cli-first-run-rehearsal.md
+++ b/docs/product/runtimes/codex-cli/codex-cli-first-run-rehearsal.md
@@ -32,7 +32,7 @@ From the user's project repo:
 3. The agent installs or repairs LoopX when needed, using:
 
    ```bash
-   curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+   curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
    export PATH="$HOME/.local/bin:$PATH"
    loopx doctor
    ```

--- a/docs/product/runtimes/codex-cli/codex-cli-packaged-install.md
+++ b/docs/product/runtimes/codex-cli/codex-cli-packaged-install.md
@@ -18,7 +18,7 @@ LoopX helps their project.
 For a fresh machine, the installer can be run without a manual clone:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
 export PATH="$HOME/.local/bin:$PATH"
 loopx doctor
 ```

--- a/docs/product/runtimes/codex-cli/codex-cli-tui-loop.md
+++ b/docs/product/runtimes/codex-cli/codex-cli-tui-loop.md
@@ -24,7 +24,7 @@ The best first-run experience is one TUI setup message:
 Connect this repo to LoopX from this visible Codex CLI TUI. Do not clone the
 LoopX repository for ordinary use. If `loopx` is not on PATH, install or repair
 it with the official no-clone installer:
-curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
 
 Then run `loopx doctor`. Work only from this project root: if LoopX state
 already exists, reuse it and do not create or overwrite a goal; if the project

--- a/docs/reference/protocols/host-integration-surface-v0.md
+++ b/docs/reference/protocols/host-integration-surface-v0.md
@@ -77,7 +77,7 @@ no-clone path is:
 
 ```bash
 curl -fsSL \
-  https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh \
+  https://huangruiteng.github.io/loopx/install.sh \
   | env LOOPX_SKILLS_DIR=<PROJECT_WORKSPACE>/.agents/skills \
       LOOPX_ENTRY_HOST_SURFACE=ark-managed-agent \
       LOOPX_INSTALL_SLASH_COMMANDS=0 bash

--- a/examples/benchmark-case-active-state-contract-smoke.py
+++ b/examples/benchmark-case-active-state-contract-smoke.py
@@ -158,7 +158,7 @@ def test_case_loopx_install_payload_uses_official_product_lifecycle() -> None:
     assert payload["product_path_primary_route"] == "prompt_driven_case_local_loopx_cli"
     command = str(payload["command"])
     assert "/app/.local/bin/loopx" in command
-    assert "install-from-github.sh" in command
+    assert "huangruiteng.github.io/loopx/install.sh" in command
     assert " bootstrap " in command
     assert " configure-goal " in command
     assert " todo add " in command

--- a/examples/codex-cli-bootstrap-message-smoke.py
+++ b/examples/codex-cli-bootstrap-message-smoke.py
@@ -48,7 +48,7 @@ MUST_HAVE = (
     "refresh-state",
     "quota spend-slot",
     "Do not spend quota for a setup-only turn",
-    "install-from-github.sh",
+    "huangruiteng.github.io/loopx/install.sh",
 )
 
 
@@ -58,7 +58,7 @@ def assert_message_contract(payload: dict[str, object]) -> None:
     assert payload["invocation_mode"] == "codex_cli_setup_then_goal_mode", payload
     assert payload["goal_id"] == GOAL_ID, payload
     assert payload["agent_id"] == AGENT_ID, payload
-    assert "install-from-github.sh" in str(payload["install_repair_command"]), payload
+    assert "huangruiteng.github.io/loopx/install.sh" in str(payload["install_repair_command"]), payload
     assert payload["existing_goal_probe_command"] == payload["quota_guard_command"], payload
     assert "heartbeat-prompt --thin" in str(payload["heartbeat_prompt_command"]), payload
     assert "heartbeat-prompt --thin" in str(payload["heartbeat_prompt_json_command"]), payload
@@ -218,7 +218,7 @@ def main() -> int:
     assert "Fresh Repo Install Repair" in cli_markdown, cli_markdown
     assert "Post-Bootstrap Thin Loop Prompt" in cli_markdown, cli_markdown
     assert "Transcript-Free Validation Checklist" in cli_markdown, cli_markdown
-    assert "install-from-github.sh" in cli_markdown, cli_markdown
+    assert "huangruiteng.github.io/loopx/install.sh" in cli_markdown, cli_markdown
 
     cli_message_only = run_cli(
         "codex-cli-bootstrap-message",

--- a/examples/codex-cli-first-run-rehearsal-smoke.py
+++ b/examples/codex-cli-first-run-rehearsal-smoke.py
@@ -44,7 +44,7 @@ def assert_doc() -> None:
         "one-message Codex CLI TUI bootstrap",
         "proof-capture fixtures for later visible automation",
         "Start LoopX for this repo",
-        "install-from-github.sh",
+        "huangruiteng.github.io/loopx/install.sh",
         "loopx codex-cli-bootstrap-message --project . --goal-id <goal-id> --message-only",
         "loopx codex-cli-tui-bootstrap-smoke-bundle",
         "loopx --format json codex-cli-visible-attach-acceptance",
@@ -94,7 +94,7 @@ def assert_cli_surfaces_align() -> None:
     assert not message.startswith("/goal "), message
     assert "setup/bootstrap instruction" in normalized, message
     assert "/goal <thin task_body>" in normalized, message
-    assert "install-from-github.sh" in normalized, message
+    assert "huangruiteng.github.io/loopx/install.sh" in normalized, message
     assert "Codex CLI TUI" in normalized, message
     assert "quota should-run" in normalized, message
     assert "quota spend-slot" in normalized, message

--- a/examples/codex-cli-packaged-install-smoke.py
+++ b/examples/codex-cli-packaged-install-smoke.py
@@ -94,7 +94,7 @@ def main() -> None:
         assert "ok: `True`" in doctor.stdout, doctor.stdout
         assert "## Install Freshness" in doctor.stdout, doctor.stdout
         assert "release_manifest_available: `True`" in doctor.stdout, doctor.stdout
-        assert "install-from-github.sh" in doctor.stdout, doctor.stdout
+        assert "huangruiteng.github.io/loopx/install.sh" in doctor.stdout, doctor.stdout
         doctor_json = subprocess.run(
             [str(installed), "--format", "json", "doctor"],
             check=True,

--- a/examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py
+++ b/examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py
@@ -137,7 +137,7 @@ def main() -> None:
         assert bundle["agent_id"] == AGENT_ID, bundle
         assert "--message-only" in bundle["message_only_command"], bundle
         assert str(fresh_repo) in bundle["message_only_command"], bundle
-        assert "install-from-github.sh" in bundle["install_repair_command"], bundle
+        assert "huangruiteng.github.io/loopx/install.sh" in bundle["install_repair_command"], bundle
         assert "quota should-run" in bundle["quota_guard_command"], bundle
         assert "--agent-id codex-side-bypass" in bundle["quota_guard_command"], bundle
         assert "refresh-state --goal-id public-fresh-codex-cli-goal" in bundle["refresh_command"], bundle
@@ -181,7 +181,7 @@ def main() -> None:
         assert not message_only.startswith("/goal "), message_only
         assert "# Codex CLI LoopX Bootstrap Message" not in message_only, message_only
         assert "Fresh Repo Install Repair" not in message_only, message_only
-        assert "install-from-github.sh" in message_only, message_only
+        assert "huangruiteng.github.io/loopx/install.sh" in message_only, message_only
         assert "/goal <thin task_body>" in message_only, message_only
         assert "quota should-run" in message_only, message_only
         assert "refresh-state --goal-id public-fresh-codex-cli-goal" in message_only, message_only

--- a/examples/export-frontstage-share-bundle.mjs
+++ b/examples/export-frontstage-share-bundle.mjs
@@ -15,6 +15,7 @@ const statusFileName = "status.frontstage-share.json";
 const manifestFileName = "frontstage-share-manifest.json";
 const showcaseCatalogPath = "docs/showcases/showcase-catalog.json";
 const projectionFixturePath = "examples/goal-channel-frontstage-fixture.py";
+const installerScriptPath = "scripts/install-from-github.sh";
 const homepageEvidenceAssets = [
   "docs/assets/long-running-loop-openviking-trajectory.png",
   "docs/assets/long-running-loop-ml-experiment-trajectory.png",
@@ -93,6 +94,7 @@ async function copyHomepage(siteDir, base) {
   await writeFile(resolve(siteDir, "index.html"), html);
   await copyFile(resolve(homepageDir, "home.css"), resolve(assetDir, "home.css"));
   await copyFile(resolve(homepageDir, "home.js"), resolve(assetDir, "home.js"));
+  await copyFile(resolve(repoRoot, installerScriptPath), resolve(siteDir, "install.sh"));
   const evidenceDir = resolve(assetDir, "evidence");
   await mkdir(evidenceDir, { recursive: true });
   for (const assetPath of homepageEvidenceAssets) {
@@ -270,9 +272,11 @@ async function writeManifest(outDir, base, interactivePages) {
     site_dir: "site",
     status_fixture: `site/${statusFileName}`,
     homepage_entry: "site/index.html",
+    installer_entry: "site/install.sh",
     frontstage_entry: "site/frontstage/index.html",
     content_sources: {
       public_homepage: "apps/presentation/site",
+      installer_script: installerScriptPath,
       homepage_evidence_assets: homepageEvidenceAssets,
       primary_public_story: showcaseCatalogPath,
       interactive_case_pages: interactivePages,
@@ -303,7 +307,7 @@ async function collectTextFiles(rootDir) {
         await visit(path);
       } else if (entry.isFile()) {
         const info = await stat(path);
-        if (info.size <= 2_000_000 && /\.(css|html|js|json|md|txt)$/i.test(path)) {
+        if (info.size <= 2_000_000 && /\.(css|html|js|json|md|sh|txt)$/i.test(path)) {
           files.push(path);
         }
       }

--- a/examples/fresh-clone-quickstart-smoke.py
+++ b/examples/fresh-clone-quickstart-smoke.py
@@ -112,7 +112,7 @@ def main() -> int:
         assert doctor["package"]["release_root"] == str(release_root), doctor
         assert doctor["install_freshness"]["schema_version"] == "loopx_install_freshness_v0", doctor
         assert doctor["install_freshness"]["status"] == "unknown", doctor
-        assert "install-from-github.sh" in doctor["install_freshness"]["upgrade_command"], doctor
+        assert "huangruiteng.github.io/loopx/install.sh" in doctor["install_freshness"]["upgrade_command"], doctor
         assert doctor["skills"]["loopx-project"]["exists"] is True, doctor
         assert doctor["skills"]["loopx-pr-program"]["exists"] is True, doctor
         assert doctor["skills"]["loopx-pr-review"]["exists"] is True, doctor
@@ -144,7 +144,7 @@ def main() -> int:
         )
         assert bootstrap["ok"] is True, bootstrap
         assert bootstrap["goal_id"] == GOAL_ID, bootstrap
-        assert "install-from-github.sh" in bootstrap["install_repair_command"], bootstrap
+        assert "huangruiteng.github.io/loopx/install.sh" in bootstrap["install_repair_command"], bootstrap
         assert "loopx doctor" in bootstrap["install_repair_command"], bootstrap
         assert (project / ".loopx" / "registry.json").is_file(), bootstrap
         assert (project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md").is_file(), bootstrap

--- a/examples/frontstage-share-bundle-smoke.mjs
+++ b/examples/frontstage-share-bundle-smoke.mjs
@@ -63,7 +63,7 @@ async function collectGeneratedTextFiles(rootDir) {
         await visit(path);
       } else if (entry.isFile()) {
         const info = await stat(path);
-        if (info.size <= 2_000_000 && /\.(css|html|js|json|md|txt)$/i.test(path)) {
+        if (info.size <= 2_000_000 && /\.(css|html|js|json|md|sh|txt)$/i.test(path)) {
           files.push(path);
         }
       }
@@ -87,6 +87,7 @@ assertExists(resolve(siteDir, "index.html"));
 assertExists(resolve(siteDir, "frontstage/index.html"));
 assertExists(resolve(siteDir, "site-assets/home.css"));
 assertExists(resolve(siteDir, "site-assets/home.js"));
+assertExists(resolve(siteDir, "install.sh"));
 assertExists(resolve(siteDir, "site-assets/evidence/long-running-loop-openviking-trajectory.png"));
 assertExists(resolve(siteDir, "site-assets/evidence/long-running-loop-ml-experiment-trajectory.png"));
 assertExists(resolve(siteDir, "status.frontstage-share.json"));
@@ -120,8 +121,13 @@ if (homepageHtml.includes('https://github.com/huangruiteng/loopx/tree/main/docs'
 if (!homepageHtml.includes('data-copy-key="agentSetup"') || !homepageHtml.includes("One message to your current agent") || !homepageHtml.includes('href="#quickstart"')) {
   throw new Error("homepage must make the localized agent setup prompt the primary first-run path");
 }
-if (!homepageHtml.includes("scripts/install-from-github.sh | bash") || !homepageHtml.includes("loopx connect") || !homepageHtml.includes("Inspect installer")) {
+if (!homepageHtml.includes("huangruiteng.github.io/loopx/install.sh | bash") || !homepageHtml.includes("loopx connect") || !homepageHtml.includes("Inspect installer")) {
   throw new Error("homepage must retain the official manual setup fallback");
+}
+const publishedInstaller = await readFile(resolve(siteDir, "install.sh"), "utf8");
+const canonicalInstaller = await readFile(resolve(repoRoot, "scripts/install-from-github.sh"), "utf8");
+if (publishedInstaller !== canonicalInstaller) {
+  throw new Error("published installer must be byte-identical to scripts/install-from-github.sh");
 }
 if (!homepageHtml.includes("provider-neutral") || !homepageHtml.includes("stateful control plane") || !homepageHtml.includes("data-language-toggle")) {
   throw new Error("homepage must publish the official provider-neutral stateful positioning and language switch");
@@ -238,12 +244,16 @@ if (manifest.base !== "/loopx/") {
 }
 if (
   manifest.homepage_entry !== "site/index.html" ||
-  manifest.frontstage_entry !== "site/frontstage/index.html"
+  manifest.frontstage_entry !== "site/frontstage/index.html" ||
+  manifest.installer_entry !== "site/install.sh"
 ) {
   throw new Error(`manifest entries mismatch: ${JSON.stringify(manifest)}`);
 }
 if (manifest.content_sources?.public_homepage !== "apps/presentation/site") {
   throw new Error(`manifest homepage source mismatch: ${JSON.stringify(manifest.content_sources)}`);
+}
+if (manifest.content_sources?.installer_script !== "scripts/install-from-github.sh") {
+  throw new Error(`manifest installer source mismatch: ${JSON.stringify(manifest.content_sources)}`);
 }
 const homepageEvidenceAssets = manifest.content_sources?.homepage_evidence_assets ?? [];
 for (const assetPath of [

--- a/examples/harbor-host-codex-goal-agent-smoke.py
+++ b/examples/harbor-host-codex-goal-agent-smoke.py
@@ -185,7 +185,7 @@ def main() -> int:
     assert init_payload["prompt_driven_route_required"] is True, init_payload
     init_command = init_payload["command"]
     assert "mkdir -p" in init_command, init_command
-    assert "install-from-github.sh" in init_command, init_command
+    assert "huangruiteng.github.io/loopx/install.sh" in init_command, init_command
     assert "mv \"$tmp\"" in init_command, init_command
     assert " bootstrap " in init_command, init_command
     assert " configure-goal " in init_command, init_command

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -532,7 +532,7 @@ def main() -> int:
         assert freshness["manifest_source_git_commit_short"] == source_commit[:12], freshness
         assert freshness["manifest_source_revision"] == source_commit, freshness
         assert freshness["manifest_skills_digest"] == release_manifest["skills"]["digest"], freshness
-        assert "install-from-github.sh" in freshness["upgrade_command"], freshness
+        assert "huangruiteng.github.io/loopx/install.sh" in freshness["upgrade_command"], freshness
         assert "loopx doctor" in freshness["upgrade_command"], freshness
         assert doctor_payload["upgrade_hint"] == freshness, doctor_payload
         assert doctor_payload["path"]["loopx"] == str(wrapper), doctor_payload
@@ -631,7 +631,7 @@ def main() -> int:
         assert f"manifest_source_git_commit: `{source_commit[:12]}`" in doctor_markdown, doctor_markdown
         assert "manifest_source: `local_checkout` @ `n/a`" not in doctor_markdown, doctor_markdown
         assert "manifest_skills_digest:" in doctor_markdown, doctor_markdown
-        assert "install-from-github.sh" in doctor_markdown, doctor_markdown
+        assert "huangruiteng.github.io/loopx/install.sh" in doctor_markdown, doctor_markdown
         assert "latest_promotion_readiness: available=`True`" in doctor_markdown, doctor_markdown
         assert "freshness=`fresh`" in doctor_markdown, doctor_markdown
         assert "requires_readiness_run=`False`" in doctor_markdown, doctor_markdown
@@ -665,7 +665,7 @@ def main() -> int:
         assert stale_install["status"] == "stale", stale_install
         assert stale_install["requires_upgrade"] is True, stale_install
         assert stale_install["release_age_hours"] == 192.0, stale_install
-        assert "install-from-github.sh" in stale_install["no_clone_upgrade_command"], stale_install
+        assert "huangruiteng.github.io/loopx/install.sh" in stale_install["no_clone_upgrade_command"], stale_install
 
         fresh_install = build_install_freshness(
             command_path=wrapper,

--- a/examples/release/codex-cli-no-clone-release-verification-smoke.py
+++ b/examples/release/codex-cli-no-clone-release-verification-smoke.py
@@ -161,7 +161,7 @@ def assert_installed_release(
     assert not message.startswith("/goal "), message
     assert "setup/bootstrap instruction" in normalized_message, message
     assert "/goal <thin task_body>" in normalized_message, message
-    assert "install-from-github.sh" in normalized_message, message
+    assert "huangruiteng.github.io/loopx/install.sh" in normalized_message, message
     assert "Codex CLI TUI" in normalized_message, message
     assert "quota should-run" in normalized_message, message
     assert "quota spend-slot" in normalized_message, message

--- a/loopx/agent_onboarding.py
+++ b/loopx/agent_onboarding.py
@@ -14,6 +14,7 @@ from .host_loop_activation import (
     render_agent_type_catalog_markdown,
     scheduler_command_binding_for_agent_type,
 )
+from .install_contract import NO_CLONE_INSTALL_URL
 from .project_prompt import (
     render_available_capability_args,
     render_codex_cli_no_clone_preflight,
@@ -187,9 +188,7 @@ def _skill_delivery_contract(
                 "onboarding_required_for_install": False,
                 "install_script": "scripts/install-local.sh",
                 "no_clone_install_command": (
-                    "curl -fsSL "
-                    "https://raw.githubusercontent.com/huangruiteng/loopx/main/"
-                    "scripts/install-from-github.sh"
+                    f"curl -fsSL {NO_CLONE_INSTALL_URL}"
                     " | env "
                     f"LOOPX_SKILLS_DIR={shell_arg(f'{project}/.agents/skills')} "
                     "LOOPX_ENTRY_HOST_SURFACE=ark-managed-agent "

--- a/loopx/benchmark_case_state.py
+++ b/loopx/benchmark_case_state.py
@@ -9,6 +9,7 @@ from .control_plane.scheduler.execution_context import (
     render_scheduler_execution_args,
 )
 from .control_plane.todos.contract import build_todo_id
+from .install_contract import NO_CLONE_INSTALL_URL
 
 BENCHMARK_CASE_ACTIVE_STATE_SCHEMA_VERSION = (
     "loopx_benchmark_case_active_state_v1"
@@ -89,10 +90,7 @@ BENCHMARK_CASE_LOOPX_EXECUTION_STYLES = (
     BENCHMARK_CASE_LOOPX_PROMPT_DRIVEN_EXECUTION_STYLE,
     BENCHMARK_CASE_LOOPX_ORCHESTRATED_EXECUTION_STYLE,
 )
-BENCHMARK_CASE_LOOPX_OFFICIAL_INSTALLER_URL = (
-    "https://raw.githubusercontent.com/huangruiteng/loopx/main/"
-    "scripts/install-from-github.sh"
-)
+BENCHMARK_CASE_LOOPX_OFFICIAL_INSTALLER_URL = NO_CLONE_INSTALL_URL
 BENCHMARK_CASE_LOOPX_PRODUCT_PATH_PRIMARY_ROUTE = (
     "prompt_driven_case_local_loopx_cli"
 )

--- a/loopx/bootstrap.py
+++ b/loopx/bootstrap.py
@@ -18,6 +18,7 @@ from .execution_profile import (
     execution_profile_summary,
 )
 from .global_registry import sync_project_registry_to_global
+from .install_contract import NO_CLONE_INSTALL_URL
 from .onboarding import build_onboarding_scan
 from .orchestration import (
     DEFAULT_ORCHESTRATION_MODE,
@@ -33,7 +34,6 @@ DEFAULT_DOMAIN = "project-goal-control-plane"
 GENERIC_ONBOARDING_ADAPTER_KINDS = frozenset(
     {"generic_project_goal_v0", "read_only_project_map_v0"}
 )
-NO_CLONE_INSTALL_URL = "https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh"
 NO_CLONE_INSTALL_REPAIR_COMMAND = (
     f"curl -fsSL {NO_CLONE_INSTALL_URL} | bash\n"
     'export PATH="$HOME/.local/bin:$PATH"\n'

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -17,6 +17,7 @@ from .control_plane.runtime.promotion_readiness import (
     PROMOTION_READINESS_CLASSIFICATION,
     PROMOTION_READINESS_RUNTIME_INDEX,
 )
+from .install_contract import NO_CLONE_INSTALL_URL
 from .paths import DEFAULT_RUNTIME_ROOT, global_registry_path
 from .project_skill_delivery import discover_project_scoped_skill_ids
 from .registry_writability import probe_registry_write_path
@@ -33,7 +34,6 @@ PROMOTION_READINESS_CLASSIFICATIONS = {
 }
 PROMOTION_READINESS_FRESHNESS_HOURS = 24
 INSTALL_FRESHNESS_STALE_HOURS = 168
-NO_CLONE_INSTALL_URL = "https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh"
 RELEASE_ID_TIMESTAMP_RE = re.compile(r"^\d{8}T\d{6}Z$")
 REQUIRED_INSTALLED_SKILL_PHRASES = {
     "loopx-project": (

--- a/loopx/install_contract.py
+++ b/loopx/install_contract.py
@@ -1,0 +1,1 @@
+NO_CLONE_INSTALL_URL = "https://huangruiteng.github.io/loopx/install.sh"

--- a/loopx/project_prompt.py
+++ b/loopx/project_prompt.py
@@ -10,6 +10,7 @@ from .control_plane.scheduler.execution_context import (
     render_scheduler_execution_args,
 )
 from .control_plane.todos.contract import normalize_required_capabilities
+from .install_contract import NO_CLONE_INSTALL_URL
 
 DEFAULT_HANDOFF_OBJECTIVE = "<OBJECTIVE_FROM_GOAL_DOC>"
 DEFAULT_HANDOFF_DOMAIN = "<DOMAIN>"
@@ -17,7 +18,6 @@ DEFAULT_HANDOFF_ADAPTER_KIND = "read_only_project_map_v0"
 DEFAULT_HANDOFF_ADAPTER_STATUS = "connected-read-only"
 DEFAULT_HANDOFF_NEXT_PROBE = "(omit --next-probe until a read-only pre-tick command exists)"
 SHARED_GLOBAL_REGISTRY = '"$HOME/.codex/loopx/registry.global.json"'
-NO_CLONE_INSTALL_URL = "https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh"
 CODEX_CLI_VISIBLE_SCHEDULER_CONTEXT = {
     "host_surface": "codex_cli",
     "scheduler_owner": "agent_cli_loop",

--- a/loopx/self_update.py
+++ b/loopx/self_update.py
@@ -9,7 +9,8 @@ from typing import Any
 from urllib.parse import quote
 from urllib.request import Request, urlopen
 
-from .doctor import NO_CLONE_INSTALL_URL, collect_doctor
+from .doctor import collect_doctor
+from .install_contract import NO_CLONE_INSTALL_URL
 
 
 UPDATE_PLAN_SCHEMA_VERSION = "loopx_update_plan_v0"

--- a/tests/test_ark_managed_agent_host.py
+++ b/tests/test_ark_managed_agent_host.py
@@ -177,8 +177,7 @@ def test_host_requires_host_managed_loopx_skill_delivery(monkeypatch) -> None:
     assert contract["install_script"] == "scripts/install-local.sh"
     assert (
         contract["no_clone_install_command"] == "curl -fsSL "
-        "https://raw.githubusercontent.com/huangruiteng/loopx/main/"
-        "scripts/install-from-github.sh"
+        "https://huangruiteng.github.io/loopx/install.sh"
         " | env LOOPX_SKILLS_DIR=./.agents/skills "
         "LOOPX_ENTRY_HOST_SURFACE=ark-managed-agent "
         "LOOPX_INSTALL_SLASH_COMMANDS=0 bash"

--- a/tests/test_doctor_install_freshness.py
+++ b/tests/test_doctor_install_freshness.py
@@ -166,8 +166,8 @@ def test_main_channel_upgrade_command_preserves_source_ref(tmp_path: Path) -> No
 
     command = str(freshness["no_clone_upgrade_command"])
     assert (
-        "curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/"
-        "scripts/install-from-github.sh | env LOOPX_REF=main bash"
+        "curl -fsSL https://huangruiteng.github.io/loopx/install.sh "
+        "| env LOOPX_REF=main bash"
     ) in command
     assert freshness["upgrade_command"] == command
 
@@ -186,7 +186,7 @@ def test_stable_channel_upgrade_command_keeps_public_default(tmp_path: Path) -> 
 
     command = str(freshness["no_clone_upgrade_command"])
     assert "LOOPX_REF=" not in command
-    assert "scripts/install-from-github.sh | bash" in command
+    assert "huangruiteng.github.io/loopx/install.sh | bash" in command
     assert freshness["upgrade_command"] == command
 
 


### PR DESCRIPTION
## Summary

- publish the canonical `scripts/install-from-github.sh` as `/loopx/install.sh` through the existing GitHub Pages bundle
- move public docs, homepage copy, and generated runtime repair commands away from `raw.githubusercontent.com`
- keep the no-clone URL single-sourced in `loopx/install_contract.py`
- verify that the published installer is byte-identical to the canonical installer

Fixes #2821.

## Product and architecture

The public installer remained coupled to a host that can return 403 in some user networks. This change keeps the established GitHub archive installer and its behavior intact, but gives users a durable Pages entry point. It does not add a second installer, change release selection, enable PyPI publishing, or alter benchmark behavior.

## Validation

- `20 passed` in the focused doctor and Ark managed-agent pytest suite
- `frontstage-share-bundle-smoke: ok`
- Codex CLI bootstrap and first-run rehearsal smokes passed
- packaged installer smoke passed
- full local installer smoke passed with an extended timeout budget
- repository strict mypy configuration passed for 15 source files
- targeted Ruff and `git diff --check` passed
- `loopx check --scan-path .`: 0 errors, 0 warnings; 2,151 files scanned
- change-quality receipt: `cqr_f6effc1ea5faca6e63b6` (`valid`)

`loopx canary premerge --from-git-diff --goal-id loopx-meta` passed all 8 risk-profile smokes, the public-boundary check, Python compilation, and 8 of 9 catalog canaries. Its only failure was `examples/install-local-smoke.py` reaching the canary's fixed 120.005-second timeout; the same exact-head smoke completed successfully when run standalone with a larger timeout.

## Review notes

- The benchmark-sensitive file change only updates an installer URL assertion; scoring, runner behavior, task semantics, and evidence policy are unchanged.
- The README first-screen command and self-merge path were explicitly approved by the owner.
- No private state, credentials, local paths, raw logs, or generated artifacts are included.
