### PR TITLE
feat(lark): sync human gates to Goal Channels

### DIFF
--- a/docs/architecture/rfcs/goal-channel-collaboration-v0.md
+++ b/docs/architecture/rfcs/goal-channel-collaboration-v0.md
@@ -85,6 +85,7 @@ loopx goal-channel setup --provider lark --goal-id <goal-id>
 loopx goal-channel target add --name <target> --provider lark ...
 loopx goal-channel setup --goal-id <goal-id> --target <target>
 loopx goal-channel attach --target <target> --goal-id <goal-a> --goal-id <goal-b>
+loopx goal-channel configure --goal-id <goal-id> --auto-notify-human-gates
 loopx goal-channel doctor --goal-id <goal-id>
 loopx goal-channel sync --goal-id <goal-id>
 loopx goal-channel notify-gate --goal-id <goal-id>
@@ -269,6 +270,32 @@ The message includes:
 It excludes local paths, raw active state, private logs, credentials, message
 ids, and raw provider payloads.
 
+Automatic delivery is disabled by default. After Goal Channel setup, preview
+and then enable it explicitly:
+
+```bash
+loopx goal-channel configure --goal-id <goal-id> --auto-notify-human-gates
+loopx goal-channel configure --goal-id <goal-id> --auto-notify-human-gates --execute
+```
+
+Once enabled, each successful non-dry-run `refresh-state` rebuilds quota from
+canonical LoopX state. It sends only when quota selects a human gate, and it
+reuses the same bot verification, semantic idempotency, cooldown, provider
+idempotency key, and message readback as `notify-gate`.
+
+Use `loopx refresh-state ... --suppress-external-sinks` to suppress delivery for
+one refresh without disabling the binding. Disable automatic delivery
+persistently with:
+
+```bash
+loopx goal-channel configure --goal-id <goal-id> --no-auto-notify-human-gates --execute
+```
+
+The opt-in is stored only in the project-local private Goal Channel binding.
+It does not grant repository or LoopX transition authority. Chat replies can
+provide context, but a gate changes only after LoopX validates and records the
+corresponding decision.
+
 ## Command Contract
 
 Each effectful command returns a compact packet:
@@ -338,14 +365,17 @@ Rules:
 
 The smallest useful implementation should be:
 
-1. Add `loopx goal-channel` with `setup`, `doctor`, `sync`, and `notify-gate`.
+1. Add `loopx goal-channel` with `setup`, `configure`, `doctor`, `sync`, and
+   `notify-gate`.
 2. Implement only the Lark provider.
 3. Reuse existing `lark-kanban` setup/sync and `loopx-lark` extension
    activation checks.
 4. Create or reuse one Lark group for one existing goal.
 5. Send and pin one compact Goal Control message.
 6. Send a human-gate notification with idempotency and readback.
-7. Store local-private binding and receipts under `.loopx/`.
+7. Optionally send LoopX-selected human gates after authorized `refresh-state`
+   writes.
+8. Store local-private binding, automation opt-in, and receipts under `.loopx/`.
 
 This slice proves the external collaboration entry point.
 
@@ -361,6 +391,8 @@ The first slice must prove:
 - a Goal Control message is sent, pinned, and readback verified;
 - human-gate notification respects cooldown and idempotency;
 - repeated notification retries do not duplicate visible messages;
+- automatic delivery is disabled by default and can be suppressed per refresh;
+- automatic delivery reads canonical quota and does not send for non-gate state;
 - doctor reports missing bot auth, missing channel, missing Kanban, or stale
   extension activation with typed blockers;
 - local-private binding files remain ignored and untracked;

--- a/docs/architecture/rfcs/goal-channel-collaboration-v0.md
+++ b/docs/architecture/rfcs/goal-channel-collaboration-v0.md
@@ -297,10 +297,19 @@ provide context, but a gate changes only after LoopX validates and records the
 corresponding decision.
 
 Automatic lifecycle delivery resolves the enabled, doctor-verified Lark
-extension before reading the private binding. The explicit local disable
-command is the only recovery exception: it may clear the opt-in while the
-extension or binding is incomplete, and it never enters provider code or
-performs an external write.
+extension before reading the private binding. Enabling automatic delivery
+requires the canonical project-local binding path; custom `--binding-path`
+values are rejected because `refresh-state` has no per-invocation path input.
+The explicit local disable command is the only recovery exception: it may clear
+the opt-in while the extension or binding is incomplete, and it never enters
+provider code or performs an external write.
+
+Enabling also writes an owner-only local marker containing only the enabled
+boolean. The lifecycle may read this marker before extension activation solely
+to distinguish a never-configured project from a configured sink whose
+extension became unavailable. The latter fails closed with a retryable
+`extension_unavailable` postcondition; the marker contains no provider ids,
+credentials, channel metadata, or raw payloads.
 
 ## Command Contract
 

--- a/docs/architecture/rfcs/goal-channel-collaboration-v0.md
+++ b/docs/architecture/rfcs/goal-channel-collaboration-v0.md
@@ -296,6 +296,12 @@ It does not grant repository or LoopX transition authority. Chat replies can
 provide context, but a gate changes only after LoopX validates and records the
 corresponding decision.
 
+Automatic lifecycle delivery resolves the enabled, doctor-verified Lark
+extension before reading the private binding. The explicit local disable
+command is the only recovery exception: it may clear the opt-in while the
+extension or binding is incomplete, and it never enters provider code or
+performs an external write.
+
 ## Command Contract
 
 Each effectful command returns a compact packet:

--- a/docs/architecture/rfcs/goal-channel-collaboration-v0.zh-CN.md
+++ b/docs/architecture/rfcs/goal-channel-collaboration-v0.zh-CN.md
@@ -272,6 +272,10 @@ loopx goal-channel configure --goal-id <goal-id> --no-auto-notify-human-gates --
 状态迁移权限。群聊回复可以补充 context，但只有经过 LoopX 校验并记录的 decision
 才能改变 gate 状态。
 
+自动生命周期投递会先解析已启用且 doctor 验证通过的 Lark extension，再读取私有
+binding。唯一的恢复例外是显式本地 disable 命令：即使 extension 或 binding
+不完整，它也可以清除 opt-in；该路径不会进入 provider 代码，也不会执行外部写。
+
 ## 命令契约
 
 每个 effectful command 返回紧凑 packet：

--- a/docs/architecture/rfcs/goal-channel-collaboration-v0.zh-CN.md
+++ b/docs/architecture/rfcs/goal-channel-collaboration-v0.zh-CN.md
@@ -76,6 +76,7 @@ loopx goal-channel setup --provider lark --goal-id <goal-id>
 loopx goal-channel target add --name <target> --provider lark ...
 loopx goal-channel setup --goal-id <goal-id> --target <target>
 loopx goal-channel attach --target <target> --goal-id <goal-a> --goal-id <goal-b>
+loopx goal-channel configure --goal-id <goal-id> --auto-notify-human-gates
 loopx goal-channel doctor --goal-id <goal-id>
 loopx goal-channel sync --goal-id <goal-id>
 loopx goal-channel notify-gate --goal-id <goal-id>
@@ -249,6 +250,28 @@ interaction-contract surface：
 消息不包含本地路径、raw active state、私有日志、凭据、message id 或 raw provider
 payload。
 
+自动投递默认关闭。完成 Goal Channel setup 后，先预览，再显式启用：
+
+```bash
+loopx goal-channel configure --goal-id <goal-id> --auto-notify-human-gates
+loopx goal-channel configure --goal-id <goal-id> --auto-notify-human-gates --execute
+```
+
+启用后，每次成功且非 dry-run 的 `refresh-state` 都会根据 LoopX canonical state
+重新计算 quota。只有 quota 选中 human gate 时才发送，并复用 `notify-gate`
+已有的 bot 身份校验、语义幂等、冷却、provider idempotency key 和消息回读。
+
+单次 refresh 可使用 `loopx refresh-state ... --suppress-external-sinks`
+临时抑制投递，而无需禁用 binding。持久关闭自动投递：
+
+```bash
+loopx goal-channel configure --goal-id <goal-id> --no-auto-notify-human-gates --execute
+```
+
+该 opt-in 只保存在项目本地私有的 Goal Channel binding 中，不授予仓库或 LoopX
+状态迁移权限。群聊回复可以补充 context，但只有经过 LoopX 校验并记录的 decision
+才能改变 gate 状态。
+
 ## 命令契约
 
 每个 effectful command 返回紧凑 packet：
@@ -317,13 +340,15 @@ goal_id + provider + operation + todo_id/gate_id + gate_text_hash + channel_id
 
 第一版最小可用实现应包括：
 
-1. 增加 `loopx goal-channel`，包含 `setup`、`doctor`、`sync` 和 `notify-gate`。
+1. 增加 `loopx goal-channel`，包含 `setup`、`configure`、`doctor`、`sync` 和
+   `notify-gate`。
 2. 只实现 Lark provider。
 3. 复用现有 `lark-kanban` setup/sync 和 `loopx-lark` extension activation checks。
 4. 为一个已有 goal 创建或复用一个 Lark 群。
 5. 发送并 pin 一条紧凑 Goal Control message。
 6. 发送带 idempotency 和 readback 的 human-gate notification。
-7. 将本地私有绑定和 receipt 保存到 `.loopx/`。
+7. 可选地在授权的 `refresh-state` 写回后发送 LoopX 选中的 human gate。
+8. 将本地私有绑定、automation opt-in 和 receipt 保存到 `.loopx/`。
 
 这个切片先验证外部协作入口。
 
@@ -338,6 +363,8 @@ goal_id + provider + operation + todo_id/gate_id + gate_text_hash + channel_id
 - Goal Control message 可以发送、pin，并通过 readback 验证；
 - human-gate notification 遵守 cooldown 和 idempotency；
 - 重试通知不会产生重复可见消息；
+- 自动投递默认关闭，并且可按单次 refresh 临时抑制；
+- 自动投递读取 canonical quota，非 gate 状态不发送；
 - doctor 能用类型化 blocker 报告缺 bot auth、缺 channel、缺 Kanban 或 stale
   extension activation；
 - 本地私有 binding 文件保持 ignored 且 untracked；

--- a/docs/architecture/rfcs/goal-channel-collaboration-v0.zh-CN.md
+++ b/docs/architecture/rfcs/goal-channel-collaboration-v0.zh-CN.md
@@ -273,8 +273,16 @@ loopx goal-channel configure --goal-id <goal-id> --no-auto-notify-human-gates --
 才能改变 gate 状态。
 
 自动生命周期投递会先解析已启用且 doctor 验证通过的 Lark extension，再读取私有
-binding。唯一的恢复例外是显式本地 disable 命令：即使 extension 或 binding
+binding。启用自动投递时必须使用项目本地 canonical binding 路径；由于
+`refresh-state` 没有逐次传入 binding path 的入口，自定义 `--binding-path`
+会被拒绝。唯一的恢复例外是显式本地 disable 命令：即使 extension 或 binding
 不完整，它也可以清除 opt-in；该路径不会进入 provider 代码，也不会执行外部写。
+
+启用时还会写入一个 owner-only 的本地 marker，其中只包含 enabled boolean。
+生命周期在 extension activation 前只允许读取这个 marker，用来区分“从未配置”
+和“已配置但 extension 后续不可用”。后者会通过可重试的
+`extension_unavailable` postcondition fail closed；marker 不包含 provider id、
+凭据、channel metadata 或 raw payload。
 
 ## 命令契约
 

--- a/examples/lark-goal-channel-human-gate-delivery-smoke.py
+++ b/examples/lark-goal-channel-human-gate-delivery-smoke.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Smoke-test active user gate delivery through the Lark Goal Channel lifecycle."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from loopx.extensions.bundled import bundled_extension_manifest
+from loopx.extensions.lark.goal_channel_contracts import (
+    GOAL_CHANNEL_BINDING_SCHEMA_VERSION,
+    read_goal_channel_binding,
+    semantic_key,
+    write_goal_channel_binding,
+)
+from loopx.extensions.lark.goal_channel_lifecycle import (
+    sync_human_gate_after_refresh,
+)
+from loopx.extensions.runtime import (
+    default_extension_state_file,
+    install_extension,
+)
+from loopx.control_plane.runtime.public_safety import public_safe_compact_text
+from loopx.paths import registry_project_root
+from loopx.quota import build_quota_should_run
+from loopx.status import collect_status
+
+
+GOAL_ID = "goal-channel-human-gate-smoke"
+GATE_TODO_ID = "todo_gate_fixture"
+CHAT_ID = "oc_public_fixture"
+MESSAGE_ID = "om_public_fixture"
+APP_ID = "cli_public_fixture"
+
+
+def result(payload: object) -> dict[str, object]:
+    return {
+        "returncode": 0,
+        "stdout": json.dumps(payload),
+        "stderr": "",
+        "timed_out": False,
+    }
+
+
+class FakeLarkRunner:
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+        self.sent_text = ""
+
+    def __call__(
+        self,
+        args: list[str],
+        cwd: Path | None,
+        timeout: float | None,
+    ) -> dict[str, object]:
+        self.calls.append(args)
+        if "auth" in args and "status" in args:
+            return result(
+                {
+                    "ok": True,
+                    "appId": APP_ID,
+                    "identities": {
+                        "bot": {
+                            "available": True,
+                            "verified": True,
+                            "appName": "LoopX Bot",
+                        }
+                    },
+                }
+            )
+        if "chats" in args and "get" in args:
+            return result({"ok": True})
+        if "+messages-send" in args:
+            self.sent_text = args[args.index("--text") + 1]
+            return result({"ok": True, "data": {"message_id": MESSAGE_ID}})
+        if "+messages-mget" in args:
+            return result(
+                {
+                    "ok": True,
+                    "data": {
+                        "items": [
+                            {
+                                "message_id": MESSAGE_ID,
+                                "body": {"content": self.sent_text},
+                            }
+                        ]
+                    },
+                }
+            )
+        raise AssertionError(f"unexpected Lark command: {args}")
+
+
+def write_project(root: Path) -> tuple[Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_path = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".loopx" / "registry.json"
+    binding_path = project / ".loopx" / "goal-channel.json"
+    state_path.parent.mkdir(parents=True)
+    registry_path.parent.mkdir(parents=True)
+    state_path.write_text(
+        "---\n"
+        "status: active\n"
+        "owner_mode: goal\n"
+        'objective: "Deliver one public-safe human gate fixture."\n'
+        "updated_at: 2026-08-08T00:00:00+00:00\n"
+        f"adapter_id: {GOAL_ID}\n"
+        "---\n\n"
+        "# Active Goal State\n\n"
+        "## Objective\n\n"
+        "Deliver one public-safe human gate fixture.\n\n"
+        "## User Todo / Owner Review Reading Queue\n\n"
+        "- [ ] [P0] Approve the bounded external write.\n"
+        f"  <!-- loopx:todo todo_id={GATE_TODO_ID} status=open "
+        "task_class=user_gate action_kind=approve_external_write "
+        "global_gate=true -->\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P1] Wait for owner approval.\n"
+        "  <!-- loopx:todo todo_id=todo_agent_fixture status=blocked "
+        "task_class=advancement_task action_kind=external_write -->\n\n"
+        "## Next Action\n\n"
+        "- Wait for owner approval.\n",
+        encoding="utf-8",
+    )
+    registry_path.write_text(
+        json.dumps(
+            {
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "objective": "Deliver one public-safe human gate fixture.",
+                        "repo": str(project),
+                        "state_file": str(state_path),
+                        "adapter": {
+                            "kind": "read_only_project_map_v0",
+                            "status": "connected-read-only",
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    write_goal_channel_binding(
+        binding_path,
+        {
+            "schema_version": GOAL_CHANNEL_BINDING_SCHEMA_VERSION,
+            "bindings": {
+                GOAL_ID: {
+                    "goal_id": GOAL_ID,
+                    "provider": "lark",
+                    "enabled": True,
+                    "channel": {
+                        "chat_id": CHAT_ID,
+                        "chat_name": f"LoopX - {GOAL_ID}",
+                    },
+                    "kanban": {},
+                    "identity": {
+                        "mode": "project_bot",
+                        "sender_profile": "",
+                        "sender_identity": "bot",
+                        "bot_app_id": APP_ID,
+                        "bot_display_name": "LoopX Bot",
+                        "cli_bin": "lark-cli",
+                    },
+                    "automation": {
+                        "human_gate_auto_notify_enabled": True,
+                    },
+                    "receipts": {},
+                }
+            },
+        },
+    )
+    install_extension(
+        bundled_extension_manifest("loopx-lark"),
+        state_file=default_extension_state_file(runtime),
+        execute=True,
+    )
+    return registry_path, binding_path
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(
+        prefix="loopx-goal-channel-human-gate-"
+    ) as raw:
+        registry_path, binding_path = write_project(Path(raw))
+        runner = FakeLarkRunner()
+        first = sync_human_gate_after_refresh(
+            registry_path=registry_path,
+            runtime_root_override=None,
+            goal_id=GOAL_ID,
+            agent_id=None,
+            external_sink_delivery_authorized=True,
+            runner=runner,
+        )
+        send_count = sum("+messages-send" in args for args in runner.calls)
+        second = sync_human_gate_after_refresh(
+            registry_path=registry_path,
+            runtime_root_override=None,
+            goal_id=GOAL_ID,
+            agent_id=None,
+            external_sink_delivery_authorized=True,
+            runner=runner,
+        )
+
+        assert first["status"] == "sent_verified", first
+        assert first["external_write_performed"] is True, first
+        assert first["readback_verified"] is True, first
+        notification = first["notification"]
+        status = collect_status(
+            registry_path=registry_path,
+            runtime_root_override=str(Path(raw) / "runtime"),
+            scan_roots=[registry_project_root(registry_path)],
+            limit=20,
+            goal_id=GOAL_ID,
+        )
+        quota = build_quota_should_run(status, goal_id=GOAL_ID)
+        expected_key = semantic_key(
+            GOAL_ID,
+            "lark",
+            "notify_gate",
+            GATE_TODO_ID,
+            public_safe_compact_text(quota["gate_prompt"], limit=900),
+            CHAT_ID,
+        )
+        assert notification["idempotency_key"] == expected_key, notification
+        assert second["status"] == "already_sent", second
+        assert sum("+messages-send" in args for args in runner.calls) == send_count
+        receipts = read_goal_channel_binding(binding_path)["bindings"][GOAL_ID][
+            "receipts"
+        ]
+        assert expected_key in receipts, receipts
+        assert "Approve the bounded external write." in runner.sent_text
+        assert "LoopX remains the source of truth" not in runner.sent_text
+        public_packet = json.dumps(first, ensure_ascii=False)
+        assert CHAT_ID not in public_packet
+        assert MESSAGE_ID not in public_packet
+        assert str(Path(raw)) not in public_packet
+
+    print("lark-goal-channel-human-gate-delivery-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/lark-goal-channel-human-gate-delivery-smoke.py
+++ b/examples/lark-goal-channel-human-gate-delivery-smoke.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -16,9 +18,6 @@ from loopx.extensions.lark.goal_channel_contracts import (
     read_goal_channel_binding,
     semantic_key,
     write_goal_channel_binding,
-)
-from loopx.extensions.lark.goal_channel_lifecycle import (
-    sync_human_gate_after_refresh,
 )
 from loopx.extensions.runtime import (
     default_extension_state_file,
@@ -37,61 +36,86 @@ MESSAGE_ID = "om_public_fixture"
 APP_ID = "cli_public_fixture"
 
 
-def result(payload: object) -> dict[str, object]:
-    return {
-        "returncode": 0,
-        "stdout": json.dumps(payload),
-        "stderr": "",
-        "timed_out": False,
+def write_fake_lark_cli(root: Path) -> tuple[Path, Path]:
+    bin_dir = root / "bin"
+    state_path = root / "fake-lark-state.json"
+    executable = bin_dir / "lark-cli"
+    bin_dir.mkdir(parents=True)
+    executable.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, os, sys\n"
+        "from pathlib import Path\n"
+        f"state_path = Path({str(state_path)!r})\n"
+        "state = json.loads(state_path.read_text()) if state_path.exists() else "
+        "{'calls': [], 'sent_text': ''}\n"
+        "args = sys.argv[1:]\n"
+        "state['calls'].append(args)\n"
+        "if 'auth' in args and 'status' in args:\n"
+        f"    payload = {{'ok': True, 'appId': {APP_ID!r}, 'identities': "
+        "{'bot': {'available': True, 'verified': True, 'appName': 'LoopX Bot'}}}\n"
+        "elif 'chats' in args and 'get' in args:\n"
+        "    payload = {'ok': True}\n"
+        "elif '+messages-send' in args:\n"
+        "    state['sent_text'] = args[args.index('--text') + 1]\n"
+        f"    payload = {{'ok': True, 'data': {{'message_id': {MESSAGE_ID!r}}}}}\n"
+        "elif '+messages-mget' in args:\n"
+        f"    payload = {{'ok': True, 'data': {{'items': [{{'message_id': "
+        f"{MESSAGE_ID!r}, 'body': {{'content': state['sent_text']}}}}]}}}}\n"
+        "else:\n"
+        "    raise SystemExit('unexpected fake lark command: ' + ' '.join(args))\n"
+        "state_path.write_text(json.dumps(state))\n"
+        "print(json.dumps(payload))\n",
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
+    return bin_dir, state_path
+
+
+def run_refresh(
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    project: Path,
+    bin_dir: Path,
+) -> dict[str, object]:
+    environment = {
+        **os.environ,
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1]),
     }
-
-
-class FakeLarkRunner:
-    def __init__(self) -> None:
-        self.calls: list[list[str]] = []
-        self.sent_text = ""
-
-    def __call__(
-        self,
-        args: list[str],
-        cwd: Path | None,
-        timeout: float | None,
-    ) -> dict[str, object]:
-        self.calls.append(args)
-        if "auth" in args and "status" in args:
-            return result(
-                {
-                    "ok": True,
-                    "appId": APP_ID,
-                    "identities": {
-                        "bot": {
-                            "available": True,
-                            "verified": True,
-                            "appName": "LoopX Bot",
-                        }
-                    },
-                }
-            )
-        if "chats" in args and "get" in args:
-            return result({"ok": True})
-        if "+messages-send" in args:
-            self.sent_text = args[args.index("--text") + 1]
-            return result({"ok": True, "data": {"message_id": MESSAGE_ID}})
-        if "+messages-mget" in args:
-            return result(
-                {
-                    "ok": True,
-                    "data": {
-                        "items": [
-                            {
-                                "message_id": MESSAGE_ID,
-                                "body": {"content": self.sent_text},
-                            }
-                        ]
-                    },
-                }
-            )
-        raise AssertionError(f"unexpected Lark command: {args}")
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime_root),
+            "--format",
+            "json",
+            "refresh-state",
+            "--goal-id",
+            GOAL_ID,
+            "--project",
+            str(project),
+            "--classification",
+            "validated",
+            "--recommended-action",
+            "Wait for owner approval.",
+            "--no-global-sync",
+        ],
+        cwd=project,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            f"refresh-state failed\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+        )
+    return json.loads(completed.stdout)
 
 
 def write_project(root: Path) -> tuple[Path, Path]:
@@ -181,6 +205,9 @@ def write_project(root: Path) -> tuple[Path, Path]:
         state_file=default_extension_state_file(runtime),
         execute=True,
     )
+    binding = read_goal_channel_binding(binding_path)
+    binding["bindings"][GOAL_ID]["identity"]["cli_bin"] = "lark-cli"
+    write_goal_channel_binding(binding_path, binding)
     return registry_path, binding_path
 
 
@@ -189,24 +216,28 @@ def main() -> None:
         prefix="loopx-goal-channel-human-gate-"
     ) as raw:
         registry_path, binding_path = write_project(Path(raw))
-        runner = FakeLarkRunner()
-        first = sync_human_gate_after_refresh(
+        bin_dir, fake_state_path = write_fake_lark_cli(Path(raw))
+        project = registry_path.parent.parent
+        runtime_root = Path(raw) / "runtime"
+        first_refresh = run_refresh(
             registry_path=registry_path,
-            runtime_root_override=None,
-            goal_id=GOAL_ID,
-            agent_id=None,
-            external_sink_delivery_authorized=True,
-            runner=runner,
+            runtime_root=runtime_root,
+            project=project,
+            bin_dir=bin_dir,
         )
-        send_count = sum("+messages-send" in args for args in runner.calls)
-        second = sync_human_gate_after_refresh(
+        first = first_refresh["goal_channel_gate_sync"]
+        first_fake_state = json.loads(fake_state_path.read_text(encoding="utf-8"))
+        send_count = sum(
+            "+messages-send" in args for args in first_fake_state["calls"]
+        )
+        second_refresh = run_refresh(
             registry_path=registry_path,
-            runtime_root_override=None,
-            goal_id=GOAL_ID,
-            agent_id=None,
-            external_sink_delivery_authorized=True,
-            runner=runner,
+            runtime_root=runtime_root,
+            project=project,
+            bin_dir=bin_dir,
         )
+        second = second_refresh["goal_channel_gate_sync"]
+        second_fake_state = json.loads(fake_state_path.read_text(encoding="utf-8"))
 
         assert first["status"] == "sent_verified", first
         assert first["external_write_performed"] is True, first
@@ -230,13 +261,16 @@ def main() -> None:
         )
         assert notification["idempotency_key"] == expected_key, notification
         assert second["status"] == "already_sent", second
-        assert sum("+messages-send" in args for args in runner.calls) == send_count
+        assert (
+            sum("+messages-send" in args for args in second_fake_state["calls"])
+            == send_count
+        )
         receipts = read_goal_channel_binding(binding_path)["bindings"][GOAL_ID][
             "receipts"
         ]
         assert expected_key in receipts, receipts
-        assert "Approve the bounded external write." in runner.sent_text
-        assert "LoopX remains the source of truth" not in runner.sent_text
+        assert "Approve the bounded external write." in second_fake_state["sent_text"]
+        assert "LoopX remains the source of truth" not in second_fake_state["sent_text"]
         public_packet = json.dumps(first, ensure_ascii=False)
         assert CHAT_ID not in public_packet
         assert MESSAGE_ID not in public_packet

--- a/loopx/canary/qualification_profiles.py
+++ b/loopx/canary/qualification_profiles.py
@@ -5,6 +5,42 @@ from typing import Any
 
 CONTROL_PLANE_QUALIFICATION_PROFILES: tuple[dict[str, Any], ...] = (
     {
+        "id": "lark-goal-channel-human-gate-delivery",
+        "title": "Lark Goal Channel human-gate delivery",
+        "quality_risk": "high",
+        "purpose": (
+            "Qualify opt-in user-gate delivery from canonical active state and "
+            "quota through the verified Lark Goal Channel transport boundary."
+        ),
+        "catalog_families": [
+            "Work Routing",
+            "State And Boundary",
+        ],
+        "trigger_hints": (
+            "lark goal channel",
+            "human gate delivery",
+            "goal-channel",
+            "loopx/cli_commands/project_lifecycle.py",
+            "loopx/extensions/lark/goal_channel_lifecycle.py",
+            "loopx/extensions/lark/goal_channel_runtime.py",
+            "examples/lark-goal-channel-human-gate-delivery-smoke.py",
+            "docs/architecture/rfcs/goal-channel-collaboration-v0.md",
+        ),
+        "checks": [
+            {
+                "command": (
+                    "python3 "
+                    "examples/lark-goal-channel-human-gate-delivery-smoke.py"
+                ),
+                "tier": "default",
+                "reason": (
+                    "guards canonical user-gate selection, stable gate identity, "
+                    "bot send/readback, receipt persistence, and duplicate suppression"
+                ),
+            },
+        ],
+    },
+    {
         "id": "change-quality-exact-receipt",
         "title": "Change-quality exact-scope receipt integrity",
         "quality_risk": "high",

--- a/loopx/canary/quality_surface_catalog.py
+++ b/loopx/canary/quality_surface_catalog.py
@@ -72,7 +72,11 @@ QUALITY_SURFACE_CATALOG: tuple[dict[str, Any], ...] = (
                 "examples/change-quality-qualification-smoke.py"
             ),
             "catalog_canary": _covered("change-quality-exact-receipt"),
-            "host_upgrade": _covered("examples/install-local-smoke.py"),
+            "host_upgrade": _not_applicable(
+                "This surface is exercised through the packaged CLI entrypoint in "
+                "its durable smoke; installation continuity is owned by the "
+                "separate install-update quality surface."
+            ),
             "model_behavior": _not_applicable(
                 "This catalogued surface proves deterministic scope and receipt integrity; "
                 "reviewer competence remains a provider responsibility and a receipt is "

--- a/loopx/canary/quality_surface_catalog.py
+++ b/loopx/canary/quality_surface_catalog.py
@@ -365,6 +365,51 @@ QUALITY_SURFACE_CATALOG: tuple[dict[str, Any], ...] = (
         },
     },
     {
+        "surface_id": "lark-goal-channel-human-gate-delivery",
+        "title": "Lark Goal Channel human-gate delivery",
+        "risk": "high",
+        "canary_profile_id": "lark-goal-channel-human-gate-delivery",
+        "owner_paths": [
+            "loopx/cli_commands/project_lifecycle.py",
+            "loopx/extensions/lark/goal_channel_lifecycle.py",
+            "loopx/extensions/lark/goal_channel_runtime.py",
+        ],
+        "semantic_oracle": {
+            "source_kind": "specification",
+            "refs": [
+                "docs/architecture/rfcs/goal-channel-collaboration-v0.md"
+            ],
+            "independence_rationale": (
+                "The Goal Channel RFC defines opt-in delivery, canonical quota "
+                "selection, gate identity, suppression, idempotency, readback, "
+                "and public/private boundaries before the lifecycle and transport "
+                "implementations are exercised."
+            ),
+        },
+        "layers": {
+            "unit_contract": _covered(
+                "tests/extensions/test_lark_goal_channel.py",
+                "tests/extensions/test_lark_goal_channel_lifecycle.py",
+                "tests/cli_commands/test_project_lifecycle_goal_channel.py",
+            ),
+            "durable_smoke": _covered(
+                "examples/lark-goal-channel-human-gate-delivery-smoke.py"
+            ),
+            "catalog_canary": _covered(
+                "lark-goal-channel-human-gate-delivery"
+            ),
+            "host_upgrade": _covered("examples/install-local-smoke.py"),
+            "model_behavior": _not_applicable(
+                "Gate selection and provider delivery safety are deterministic "
+                "control-plane and transport contracts."
+            ),
+            "release_gate": _covered(
+                "loopx canary premerge "
+                "--profile lark-goal-channel-human-gate-delivery"
+            ),
+        },
+    },
+    {
         "surface_id": "new-user-onboarding",
         "title": "New-user goal start and host activation",
         "risk": "high",

--- a/loopx/canary/smoke_profiles.py
+++ b/loopx/canary/smoke_profiles.py
@@ -78,6 +78,7 @@ SMOKE_SUITE_PROFILE_MANIFEST: dict[str, dict[str, Any]] = {
             "capability-extension",
             "extension",
             "lark-event",
+            "lark-goal-channel",
             "lark-inbox",
             "openviking-extension",
         ],

--- a/loopx/cli_commands/goal_channel.py
+++ b/loopx/cli_commands/goal_channel.py
@@ -11,6 +11,7 @@ from ..extensions.lark import (
 )
 from ..extensions.lark.goal_channel import (
     add_lark_goal_channel_target,
+    configure_lark_goal_channel_automation,
     default_goal_channel_binding_path,
     default_goal_channel_target_path,
     doctor_lark_goal_channel,
@@ -127,6 +128,27 @@ def register_goal_channel_commands(
     )
     add_subcommand_format(target_list)
     target_list.add_argument("--target-path", help=argparse.SUPPRESS)
+
+    configure = sub.add_parser(
+        "configure",
+        help="Configure an existing Goal Channel. Dry-run unless --execute.",
+    )
+    add_subcommand_format(configure)
+    _add_common_args(configure)
+    automation = configure.add_mutually_exclusive_group(required=True)
+    automation.add_argument(
+        "--auto-notify-human-gates",
+        dest="auto_notify_human_gates",
+        action="store_true",
+        help="Send LoopX-selected human gates after authorized refresh-state writes.",
+    )
+    automation.add_argument(
+        "--no-auto-notify-human-gates",
+        dest="auto_notify_human_gates",
+        action="store_false",
+        help="Disable automatic human gate notifications.",
+    )
+    configure.add_argument("--execute", action="store_true")
 
     doctor = sub.add_parser(
         "doctor",
@@ -377,6 +399,32 @@ def handle_goal_channel_command(
         runtime_root_arg,
         registry_path=registry_path,
     )
+    if command == "configure" and not bool(args.auto_notify_human_gates):
+        assert goal_id is not None
+        source_registry, _, binding_path = _source_context(
+            registry=registry,
+            registry_path=registry_path,
+            goal_id=goal_id,
+            binding_path_arg=getattr(args, "binding_path", None),
+        )
+        try:
+            payload = configure_lark_goal_channel_automation(
+                registry=source_registry,
+                goal_id=goal_id,
+                binding_path=binding_path,
+                human_gate_auto_notify=False,
+                execute=execute,
+            )
+        except Exception:
+            payload = _error_packet(
+                goal_id=goal_id,
+                operation="configure",
+                execute=execute,
+                blocker="provider_api_failed",
+                summary="the Goal Channel automation setting could not be updated",
+            )
+        print_payload(payload, output_format(args), render_goal_channel_markdown)
+        return 0 if payload.get("ok") else 1
     try:
         activation = resolve_extension_activation(
             LARK_EXTENSION_ID,
@@ -485,6 +533,14 @@ def handle_goal_channel_command(
                         bot_app_id=getattr(args, "bot_app_id", None),
                         bot_display_name=args.bot_display_name,
                         cli_bin=args.cli_bin,
+                        execute=execute,
+                    )
+                elif command == "configure":
+                    payload = configure_lark_goal_channel_automation(
+                        registry=source_registry,
+                        goal_id=goal_id,
+                        binding_path=binding_path,
+                        human_gate_auto_notify=bool(args.auto_notify_human_gates),
                         execute=execute,
                     )
                 elif command == "doctor":

--- a/loopx/cli_commands/goal_channel.py
+++ b/loopx/cli_commands/goal_channel.py
@@ -399,6 +399,39 @@ def handle_goal_channel_command(
         runtime_root_arg,
         registry_path=registry_path,
     )
+    if command == "configure" and bool(args.auto_notify_human_gates):
+        assert goal_id is not None
+        _, source_registry_path, binding_path = _source_context(
+            registry=registry,
+            registry_path=registry_path,
+            goal_id=goal_id,
+            binding_path_arg=getattr(args, "binding_path", None),
+        )
+        default_binding_path = default_goal_channel_binding_path(
+            source_registry_path
+        )
+    else:
+        binding_path = None
+        default_binding_path = None
+    if (
+        command == "configure"
+        and bool(args.auto_notify_human_gates)
+        and binding_path is not None
+        and default_binding_path is not None
+        and binding_path.resolve() != default_binding_path.resolve()
+    ):
+        payload = _error_packet(
+            goal_id=goal_id,
+            operation="configure",
+            execute=execute,
+            blocker="noncanonical_binding_path",
+            summary=(
+                "automatic human gate delivery requires the project-local "
+                "default Goal Channel binding"
+            ),
+        )
+        print_payload(payload, output_format(args), render_goal_channel_markdown)
+        return 1
     if command == "configure" and not bool(args.auto_notify_human_gates):
         assert goal_id is not None
         source_registry, _, binding_path = _source_context(

--- a/loopx/cli_commands/project_lifecycle.py
+++ b/loopx/cli_commands/project_lifecycle.py
@@ -103,6 +103,26 @@ def _lark_explore_graph_syncer(
     return sync
 
 
+def _apply_external_sink_postcondition(
+    payload: dict[str, object],
+    *,
+    sink_result: Mapping[str, object],
+    warning: str,
+    error: str,
+) -> None:
+    postcondition = (
+        sink_result.get("delivery_postcondition")
+        if isinstance(sink_result.get("delivery_postcondition"), Mapping)
+        else {}
+    )
+    if not sink_result.get("enabled") or postcondition.get("satisfied"):
+        return
+    payload.setdefault("warnings", []).append(warning)
+    if postcondition.get("blocks_delivery"):
+        payload["ok"] = False
+        payload["error"] = error
+
+
 def _inline_agent_vision_packet(args: argparse.Namespace) -> dict[str, object] | None:
     patch = {
         field: str(value).strip()
@@ -586,22 +606,18 @@ def handle_project_lifecycle_command(
                 ),
             )
             payload["explore_graph_sync"] = graph_sync
-            graph_postcondition = (
-                graph_sync.get("delivery_postcondition")
-                if isinstance(graph_sync.get("delivery_postcondition"), dict)
-                else {}
-            )
-            if graph_sync.get("enabled") and not graph_postcondition.get("satisfied"):
-                payload.setdefault("warnings", []).append(
+            _apply_external_sink_postcondition(
+                payload,
+                sink_result=graph_sync,
+                warning=(
                     "enabled Explore Graph delivery postcondition is unsatisfied; "
                     "the unchanged sink digest keeps it retryable"
-                )
-                if graph_postcondition.get("blocks_delivery"):
-                    payload["ok"] = False
-                    payload["error"] = (
-                        "enabled Explore Graph sync/readback failed after the material "
-                        "refresh; retry it before delivery"
-                    )
+                ),
+                error=(
+                    "enabled Explore Graph sync/readback failed after the material "
+                    "refresh; retry it before delivery"
+                ),
+            )
             try:
                 gate_sync = sync_human_gate_after_refresh(
                     registry_path=registry_path,
@@ -612,7 +628,7 @@ def handle_project_lifecycle_command(
                         args.suppress_external_sinks
                     ),
                 )
-            except Exception as exc:
+            except Exception:
                 gate_sync = {
                     "schema_version": "loopx_goal_channel_gate_auto_delivery_v0",
                     "ok": False,
@@ -624,25 +640,21 @@ def handle_project_lifecycle_command(
                         "satisfied": False,
                         "blocks_delivery": True,
                     },
-                    "error": str(exc),
+                    "error_code": "goal_channel_gate_sync_failed",
                 }
             payload["goal_channel_gate_sync"] = gate_sync
-            gate_postcondition = (
-                gate_sync.get("delivery_postcondition")
-                if isinstance(gate_sync.get("delivery_postcondition"), dict)
-                else {}
-            )
-            if gate_sync.get("enabled") and not gate_postcondition.get("satisfied"):
-                payload.setdefault("warnings", []).append(
+            _apply_external_sink_postcondition(
+                payload,
+                sink_result=gate_sync,
+                warning=(
                     "enabled Goal Channel human-gate delivery postcondition is "
                     "unsatisfied; the notification remains retryable"
-                )
-                if gate_postcondition.get("blocks_delivery"):
-                    payload["ok"] = False
-                    payload["error"] = (
-                        "enabled Goal Channel human-gate notification/readback failed "
-                        "after the refresh; retry it before delivery"
-                    )
+                ),
+                error=(
+                    "enabled Goal Channel human-gate notification/readback failed "
+                    "after the refresh; retry it before delivery"
+                ),
+            )
         print_payload(payload, fmt, render_state_refresh_markdown)
         return 0 if payload.get("ok") else 1
 

--- a/loopx/cli_commands/project_lifecycle.py
+++ b/loopx/cli_commands/project_lifecycle.py
@@ -24,6 +24,7 @@ from ..extensions.runtime import (
     resolve_extension_activation,
 )
 from ..extensions.lark.goal_channel_lifecycle import (
+    goal_channel_gate_sync_failure,
     sync_human_gate_after_refresh,
 )
 from ..history import load_registry
@@ -629,19 +630,10 @@ def handle_project_lifecycle_command(
                     ),
                 )
             except Exception:
-                gate_sync = {
-                    "schema_version": "loopx_goal_channel_gate_auto_delivery_v0",
-                    "ok": False,
-                    "enabled": True,
-                    "status": "failed",
-                    "external_write_performed": False,
-                    "readback_verified": False,
-                    "delivery_postcondition": {
-                        "satisfied": False,
-                        "blocks_delivery": True,
-                    },
-                    "error_code": "goal_channel_gate_sync_failed",
-                }
+                gate_sync = goal_channel_gate_sync_failure(
+                    registry_path=registry_path,
+                    goal_id=args.goal_id,
+                )
             payload["goal_channel_gate_sync"] = gate_sync
             _apply_external_sink_postcondition(
                 payload,

--- a/loopx/cli_commands/project_lifecycle.py
+++ b/loopx/cli_commands/project_lifecycle.py
@@ -23,6 +23,9 @@ from ..extensions.runtime import (
     default_extension_state_file,
     resolve_extension_activation,
 )
+from ..extensions.lark.goal_channel_lifecycle import (
+    sync_human_gate_after_refresh,
+)
 from ..history import load_registry
 from ..feedback import LESSON_KINDS, append_human_reward, compact_reward, render_reward_markdown
 from ..operator_gate import (
@@ -598,6 +601,47 @@ def handle_project_lifecycle_command(
                     payload["error"] = (
                         "enabled Explore Graph sync/readback failed after the material "
                         "refresh; retry it before delivery"
+                    )
+            try:
+                gate_sync = sync_human_gate_after_refresh(
+                    registry_path=registry_path,
+                    runtime_root_override=args.runtime_root,
+                    goal_id=args.goal_id,
+                    agent_id=args.agent_id,
+                    external_sink_delivery_authorized=not bool(
+                        args.suppress_external_sinks
+                    ),
+                )
+            except Exception as exc:
+                gate_sync = {
+                    "schema_version": "loopx_goal_channel_gate_auto_delivery_v0",
+                    "ok": False,
+                    "enabled": True,
+                    "status": "failed",
+                    "external_write_performed": False,
+                    "readback_verified": False,
+                    "delivery_postcondition": {
+                        "satisfied": False,
+                        "blocks_delivery": True,
+                    },
+                    "error": str(exc),
+                }
+            payload["goal_channel_gate_sync"] = gate_sync
+            gate_postcondition = (
+                gate_sync.get("delivery_postcondition")
+                if isinstance(gate_sync.get("delivery_postcondition"), dict)
+                else {}
+            )
+            if gate_sync.get("enabled") and not gate_postcondition.get("satisfied"):
+                payload.setdefault("warnings", []).append(
+                    "enabled Goal Channel human-gate delivery postcondition is "
+                    "unsatisfied; the notification remains retryable"
+                )
+                if gate_postcondition.get("blocks_delivery"):
+                    payload["ok"] = False
+                    payload["error"] = (
+                        "enabled Goal Channel human-gate notification/readback failed "
+                        "after the refresh; retry it before delivery"
                     )
         print_payload(payload, fmt, render_state_refresh_markdown)
         return 0 if payload.get("ok") else 1

--- a/loopx/extensions/lark/goal_channel.py
+++ b/loopx/extensions/lark/goal_channel.py
@@ -8,6 +8,7 @@ from .goal_channel_contracts import (
     read_goal_channel_binding,
 )
 from .goal_channel_runtime import (
+    configure_lark_goal_channel_automation,
     doctor_lark_goal_channel,
     notify_lark_goal_channel_gate,
     sync_lark_goal_channel,
@@ -29,6 +30,7 @@ __all__ = [
     "GOAL_CHANNEL_OPERATION_SCHEMA_VERSION",
     "GOAL_CHANNEL_TARGETS_SCHEMA_VERSION",
     "add_lark_goal_channel_target",
+    "configure_lark_goal_channel_automation",
     "default_goal_channel_binding_path",
     "default_goal_channel_target_path",
     "doctor_lark_goal_channel",

--- a/loopx/extensions/lark/goal_channel_contracts.py
+++ b/loopx/extensions/lark/goal_channel_contracts.py
@@ -16,6 +16,9 @@ GOAL_CHANNEL_BINDING_SCHEMA_VERSION = "loopx_goal_channel_lark_binding_v0"
 GOAL_CHANNEL_OPERATION_SCHEMA_VERSION = "loopx_goal_channel_operation_v0"
 DEFAULT_GATE_COOLDOWN_SECONDS = 3600
 HUMAN_GATE_AUTO_NOTIFY_SETTING = "human_gate_auto_notify_enabled"
+HUMAN_GATE_AUTO_NOTIFY_MARKER_SCHEMA_VERSION = (
+    "loopx_goal_channel_auto_notify_marker_v0"
+)
 PRIVATE_PACKET_KEYS = {
     "base_token",
     "chat_id",
@@ -134,6 +137,53 @@ def human_gate_auto_notify_enabled(binding: Mapping[str, Any] | None) -> bool:
         else {}
     )
     return automation.get(HUMAN_GATE_AUTO_NOTIFY_SETTING) is True
+
+
+def human_gate_auto_notify_marker_path(
+    binding_path: Path,
+    goal_id: str,
+) -> Path:
+    safe_goal_id = str(goal_id or "").strip()
+    if (
+        not safe_goal_id
+        or safe_goal_id in {".", ".."}
+        or "/" in safe_goal_id
+        or "\\" in safe_goal_id
+    ):
+        raise ValueError("Goal Channel goal id must be a single path segment")
+    return binding_path.with_name(
+        f"{binding_path.stem}.{safe_goal_id}.human-gate-auto-notify.json"
+    )
+
+
+def human_gate_auto_notify_marker_enabled(path: Path) -> bool:
+    marker_path = path.expanduser()
+    if not marker_path.exists():
+        return False
+    try:
+        payload = json.loads(marker_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return True
+    return bool(
+        isinstance(payload, Mapping)
+        and payload.get("schema_version")
+        == HUMAN_GATE_AUTO_NOTIFY_MARKER_SCHEMA_VERSION
+        and payload.get("enabled") is True
+    )
+
+
+def write_human_gate_auto_notify_marker(path: Path) -> None:
+    write_private_json_atomic(
+        path,
+        {
+            "schema_version": HUMAN_GATE_AUTO_NOTIFY_MARKER_SCHEMA_VERSION,
+            "enabled": True,
+        },
+    )
+
+
+def clear_human_gate_auto_notify_marker(path: Path) -> None:
+    path.expanduser().unlink(missing_ok=True)
 
 
 def quota_human_gate_identity(quota_packet: Mapping[str, Any]) -> str:

--- a/loopx/extensions/lark/goal_channel_contracts.py
+++ b/loopx/extensions/lark/goal_channel_contracts.py
@@ -15,6 +15,7 @@ from .private_json import write_private_json_atomic
 GOAL_CHANNEL_BINDING_SCHEMA_VERSION = "loopx_goal_channel_lark_binding_v0"
 GOAL_CHANNEL_OPERATION_SCHEMA_VERSION = "loopx_goal_channel_operation_v0"
 DEFAULT_GATE_COOLDOWN_SECONDS = 3600
+HUMAN_GATE_AUTO_NOTIFY_SETTING = "human_gate_auto_notify_enabled"
 PRIVATE_PACKET_KEYS = {
     "base_token",
     "chat_id",
@@ -123,6 +124,24 @@ def binding_for_goal(
     }
     resolved["identity"] = dict(target_identity)
     return resolved
+
+
+def human_gate_auto_notify_enabled(binding: Mapping[str, Any] | None) -> bool:
+    automation = (
+        binding.get("automation")
+        if isinstance(binding, Mapping)
+        and isinstance(binding.get("automation"), Mapping)
+        else {}
+    )
+    return automation.get(HUMAN_GATE_AUTO_NOTIFY_SETTING) is True
+
+
+def quota_selects_human_gate(quota_packet: Mapping[str, Any]) -> bool:
+    return bool(
+        quota_packet.get("state") == "operator_gate"
+        or quota_packet.get("notify_user_on_gate") is True
+        or quota_packet.get("notify_user_on_open_todo") is True
+    )
 
 
 def save_goal_binding(

--- a/loopx/extensions/lark/goal_channel_contracts.py
+++ b/loopx/extensions/lark/goal_channel_contracts.py
@@ -136,6 +136,26 @@ def human_gate_auto_notify_enabled(binding: Mapping[str, Any] | None) -> bool:
     return automation.get(HUMAN_GATE_AUTO_NOTIFY_SETTING) is True
 
 
+def quota_human_gate_identity(quota_packet: Mapping[str, Any]) -> str:
+    summary = quota_packet.get("user_todo_summary")
+    summary = summary if isinstance(summary, Mapping) else {}
+    for key in ("gate_open_items", "first_open_items"):
+        items = summary.get(key)
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, Mapping):
+                continue
+            identity = str(item.get("todo_id") or item.get("gate_id") or "").strip()
+            if identity:
+                return identity
+    return str(
+        quota_packet.get("gate_id")
+        or quota_packet.get("operator_gate_id")
+        or "unidentified_gate"
+    ).strip()
+
+
 def quota_selects_human_gate(quota_packet: Mapping[str, Any]) -> bool:
     return bool(
         quota_packet.get("state") == "operator_gate"

--- a/loopx/extensions/lark/goal_channel_lifecycle.py
+++ b/loopx/extensions/lark/goal_channel_lifecycle.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ...control_plane.runtime.runtime_projection_route import (
+    resolve_goal_source_runtime_route,
+)
+from ...history import load_registry
+from ...paths import registry_project_root
+from ...quota import build_quota_should_run
+from ...status import collect_status
+from ..runtime import default_extension_state_file, resolve_extension_activation
+from . import LARK_EXTENSION_ID, LARK_GOAL_CHANNEL_PERMISSION
+from .goal_channel_contracts import (
+    binding_for_goal,
+    default_goal_channel_binding_path,
+    human_gate_auto_notify_enabled,
+    quota_selects_human_gate,
+    read_goal_channel_binding,
+)
+from .goal_channel_runtime import auto_notify_lark_goal_channel_gate
+from .goal_channel_targets import (
+    default_goal_channel_target_path,
+    goal_channel_target_for_name,
+    read_goal_channel_targets,
+)
+
+
+def _inactive_result(status: str) -> dict[str, Any]:
+    return {
+        "schema_version": "loopx_goal_channel_gate_auto_delivery_v0",
+        "ok": True,
+        "enabled": False,
+        "status": status,
+        "external_write_performed": False,
+        "readback_verified": False,
+        "delivery_postcondition": {
+            "satisfied": True,
+            "blocks_delivery": False,
+        },
+    }
+
+
+def sync_human_gate_after_refresh(
+    *,
+    registry_path: Path,
+    runtime_root_override: str | None,
+    goal_id: str,
+    agent_id: str | None,
+    external_sink_delivery_authorized: bool,
+) -> dict[str, Any]:
+    invoked_registry = load_registry(registry_path)
+    source_route = resolve_goal_source_runtime_route(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        registry=invoked_registry,
+    )
+    source_registry_path = Path(str(source_route["source_registry"]))
+    source_registry = (
+        invoked_registry
+        if source_registry_path.expanduser().resolve()
+        == registry_path.expanduser().resolve()
+        else load_registry(source_registry_path)
+    )
+    if source_registry_path.parent.name != ".loopx":
+        return _inactive_result("project_binding_unavailable")
+    binding_path = default_goal_channel_binding_path(source_registry_path)
+    binding_payload = read_goal_channel_binding(binding_path)
+    raw_binding = binding_for_goal(binding_payload, goal_id)
+    target_name = str((raw_binding or {}).get("target_ref") or "")
+    provider_target = (
+        goal_channel_target_for_name(
+            read_goal_channel_targets(
+                default_goal_channel_target_path(runtime_root)
+            ),
+            target_name,
+        )
+        if target_name
+        else None
+    )
+    if target_name and provider_target is None:
+        return {
+            "schema_version": "loopx_goal_channel_gate_auto_delivery_v0",
+            "ok": False,
+            "enabled": True,
+            "status": "provider_target_missing",
+            "external_write_performed": False,
+            "readback_verified": False,
+            "blocker": "provider_target_missing",
+            "delivery_postcondition": {
+                "satisfied": False,
+                "blocks_delivery": True,
+            },
+        }
+    binding = binding_for_goal(
+        binding_payload,
+        goal_id,
+        provider_target=provider_target,
+    )
+    if not human_gate_auto_notify_enabled(binding):
+        return auto_notify_lark_goal_channel_gate(
+            registry=source_registry,
+            goal_id=goal_id,
+            binding_path=binding_path,
+            quota_packet={},
+            provider_target=provider_target,
+            external_sink_delivery_authorized=external_sink_delivery_authorized,
+        )
+    if not external_sink_delivery_authorized:
+        return auto_notify_lark_goal_channel_gate(
+            registry=source_registry,
+            goal_id=goal_id,
+            binding_path=binding_path,
+            quota_packet={},
+            provider_target=provider_target,
+            external_sink_delivery_authorized=False,
+        )
+
+    runtime_root = (
+        Path(runtime_root_override).expanduser().resolve()
+        if runtime_root_override
+        else Path(str(source_route["source_runtime_root"]))
+    )
+    status = collect_status(
+        registry_path=source_registry_path,
+        runtime_root_override=str(runtime_root),
+        scan_roots=[registry_project_root(source_registry_path)],
+        limit=20,
+        goal_id=goal_id,
+    )
+    quota_packet = build_quota_should_run(
+        status,
+        goal_id=goal_id,
+        agent_id=agent_id,
+    )
+    cooldown = quota_packet.get("user_gate_notification_cooldown")
+    cooldown_active = bool(
+        isinstance(cooldown, dict)
+        and cooldown.get("notification_suppressed") is True
+    )
+    if not quota_selects_human_gate(quota_packet) or cooldown_active:
+        return auto_notify_lark_goal_channel_gate(
+            registry=source_registry,
+            goal_id=goal_id,
+            binding_path=binding_path,
+            quota_packet=quota_packet,
+            provider_target=provider_target,
+            external_sink_delivery_authorized=True,
+        )
+
+    activation = resolve_extension_activation(
+        LARK_EXTENSION_ID,
+        state_file=default_extension_state_file(runtime_root),
+        required_permissions=(LARK_GOAL_CHANNEL_PERMISSION,),
+    )
+    result = auto_notify_lark_goal_channel_gate(
+        registry=source_registry,
+        goal_id=goal_id,
+        binding_path=binding_path,
+        quota_packet=quota_packet,
+        provider_target=provider_target,
+        external_sink_delivery_authorized=external_sink_delivery_authorized,
+    )
+    result["extension_activation"] = activation
+    return result

--- a/loopx/extensions/lark/goal_channel_lifecycle.py
+++ b/loopx/extensions/lark/goal_channel_lifecycle.py
@@ -68,6 +68,44 @@ def _extension_unavailable_result(*, configured: bool) -> dict[str, Any]:
     }
 
 
+def goal_channel_gate_sync_failure(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    status: str = "failed",
+    blocker: str = "goal_channel_gate_sync_failed",
+) -> dict[str, Any]:
+    configured = False
+    try:
+        invoked_registry = load_registry(registry_path)
+        source_route = resolve_goal_source_runtime_route(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            registry=invoked_registry,
+        )
+        source_registry_path = Path(str(source_route["source_registry"]))
+        if source_registry_path.parent.name == ".loopx":
+            binding_path = default_goal_channel_binding_path(source_registry_path)
+            configured = human_gate_auto_notify_marker_enabled(
+                human_gate_auto_notify_marker_path(binding_path, goal_id)
+            )
+    except (OSError, ValueError):
+        configured = False
+    return {
+        "schema_version": "loopx_goal_channel_gate_auto_delivery_v0",
+        "ok": not configured,
+        "enabled": configured,
+        "status": status if configured else "not_configured",
+        "external_write_performed": False,
+        "readback_verified": False,
+        **({"blocker": blocker} if configured else {}),
+        "delivery_postcondition": {
+            "satisfied": not configured,
+            "blocks_delivery": configured,
+        },
+    }
+
+
 def sync_human_gate_after_refresh(
     *,
     registry_path: Path,
@@ -109,19 +147,26 @@ def sync_human_gate_after_refresh(
         return _extension_unavailable_result(
             configured=human_gate_auto_notify_marker_enabled(marker_path)
         )
-    binding_payload = read_goal_channel_binding(binding_path)
-    raw_binding = binding_for_goal(binding_payload, goal_id)
-    target_name = str((raw_binding or {}).get("target_ref") or "")
-    provider_target = (
-        goal_channel_target_for_name(
-            read_goal_channel_targets(
-                default_goal_channel_target_path(runtime_root)
-            ),
-            target_name,
+    try:
+        binding_payload = read_goal_channel_binding(binding_path)
+        raw_binding = binding_for_goal(binding_payload, goal_id)
+        target_name = str((raw_binding or {}).get("target_ref") or "")
+        provider_target = (
+            goal_channel_target_for_name(
+                read_goal_channel_targets(
+                    default_goal_channel_target_path(runtime_root)
+                ),
+                target_name,
+            )
+            if target_name
+            else None
         )
-        if target_name
-        else None
-    )
+    except (OSError, ValueError):
+        return goal_channel_gate_sync_failure(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            blocker="invalid_goal_channel_binding",
+        )
     if target_name and provider_target is None:
         return {
             "schema_version": "loopx_goal_channel_gate_auto_delivery_v0",

--- a/loopx/extensions/lark/goal_channel_lifecycle.py
+++ b/loopx/extensions/lark/goal_channel_lifecycle.py
@@ -25,6 +25,10 @@ from .goal_channel_targets import (
     goal_channel_target_for_name,
     read_goal_channel_targets,
 )
+from .presentation.kanban import (
+    CommandRunner,
+    default_subprocess_runner,
+)
 
 
 def _inactive_result(status: str) -> dict[str, Any]:
@@ -42,6 +46,13 @@ def _inactive_result(status: str) -> dict[str, Any]:
     }
 
 
+def _extension_unavailable_result() -> dict[str, Any]:
+    return {
+        **_inactive_result("extension_unavailable"),
+        "enabled": False,
+    }
+
+
 def sync_human_gate_after_refresh(
     *,
     registry_path: Path,
@@ -49,6 +60,7 @@ def sync_human_gate_after_refresh(
     goal_id: str,
     agent_id: str | None,
     external_sink_delivery_authorized: bool,
+    runner: CommandRunner = default_subprocess_runner,
 ) -> dict[str, Any]:
     invoked_registry = load_registry(registry_path)
     source_route = resolve_goal_source_runtime_route(
@@ -65,6 +77,19 @@ def sync_human_gate_after_refresh(
     )
     if source_registry_path.parent.name != ".loopx":
         return _inactive_result("project_binding_unavailable")
+    runtime_root = (
+        Path(runtime_root_override).expanduser().resolve()
+        if runtime_root_override
+        else Path(str(source_route["source_runtime_root"]))
+    )
+    try:
+        activation = resolve_extension_activation(
+            LARK_EXTENSION_ID,
+            state_file=default_extension_state_file(runtime_root),
+            required_permissions=(LARK_GOAL_CHANNEL_PERMISSION,),
+        )
+    except (OSError, ValueError):
+        return _extension_unavailable_result()
     binding_path = default_goal_channel_binding_path(source_registry_path)
     binding_payload = read_goal_channel_binding(binding_path)
     raw_binding = binding_for_goal(binding_payload, goal_id)
@@ -117,11 +142,6 @@ def sync_human_gate_after_refresh(
             external_sink_delivery_authorized=False,
         )
 
-    runtime_root = (
-        Path(runtime_root_override).expanduser().resolve()
-        if runtime_root_override
-        else Path(str(source_route["source_runtime_root"]))
-    )
     status = collect_status(
         registry_path=source_registry_path,
         runtime_root_override=str(runtime_root),
@@ -149,11 +169,6 @@ def sync_human_gate_after_refresh(
             external_sink_delivery_authorized=True,
         )
 
-    activation = resolve_extension_activation(
-        LARK_EXTENSION_ID,
-        state_file=default_extension_state_file(runtime_root),
-        required_permissions=(LARK_GOAL_CHANNEL_PERMISSION,),
-    )
     result = auto_notify_lark_goal_channel_gate(
         registry=source_registry,
         goal_id=goal_id,
@@ -161,6 +176,7 @@ def sync_human_gate_after_refresh(
         quota_packet=quota_packet,
         provider_target=provider_target,
         external_sink_delivery_authorized=external_sink_delivery_authorized,
+        runner=runner,
     )
     result["extension_activation"] = activation
     return result

--- a/loopx/extensions/lark/goal_channel_lifecycle.py
+++ b/loopx/extensions/lark/goal_channel_lifecycle.py
@@ -16,6 +16,8 @@ from .goal_channel_contracts import (
     binding_for_goal,
     default_goal_channel_binding_path,
     human_gate_auto_notify_enabled,
+    human_gate_auto_notify_marker_enabled,
+    human_gate_auto_notify_marker_path,
     quota_selects_human_gate,
     read_goal_channel_binding,
 )
@@ -46,7 +48,21 @@ def _inactive_result(status: str) -> dict[str, Any]:
     }
 
 
-def _extension_unavailable_result() -> dict[str, Any]:
+def _extension_unavailable_result(*, configured: bool) -> dict[str, Any]:
+    if configured:
+        return {
+            "schema_version": "loopx_goal_channel_gate_auto_delivery_v0",
+            "ok": False,
+            "enabled": True,
+            "status": "extension_unavailable",
+            "external_write_performed": False,
+            "readback_verified": False,
+            "blocker": "extension_unavailable",
+            "delivery_postcondition": {
+                "satisfied": False,
+                "blocks_delivery": True,
+            },
+        }
     return {
         **_inactive_result("extension_unavailable"),
         "enabled": False,
@@ -82,6 +98,8 @@ def sync_human_gate_after_refresh(
         if runtime_root_override
         else Path(str(source_route["source_runtime_root"]))
     )
+    binding_path = default_goal_channel_binding_path(source_registry_path)
+    marker_path = human_gate_auto_notify_marker_path(binding_path, goal_id)
     try:
         activation = resolve_extension_activation(
             LARK_EXTENSION_ID,
@@ -89,8 +107,9 @@ def sync_human_gate_after_refresh(
             required_permissions=(LARK_GOAL_CHANNEL_PERMISSION,),
         )
     except (OSError, ValueError):
-        return _extension_unavailable_result()
-    binding_path = default_goal_channel_binding_path(source_registry_path)
+        return _extension_unavailable_result(
+            configured=human_gate_auto_notify_marker_enabled(marker_path)
+        )
     binding_payload = read_goal_channel_binding(binding_path)
     raw_binding = binding_for_goal(binding_payload, goal_id)
     target_name = str((raw_binding or {}).get("target_ref") or "")

--- a/loopx/extensions/lark/goal_channel_lifecycle.py
+++ b/loopx/extensions/lark/goal_channel_lifecycle.py
@@ -18,7 +18,6 @@ from .goal_channel_contracts import (
     human_gate_auto_notify_enabled,
     human_gate_auto_notify_marker_enabled,
     human_gate_auto_notify_marker_path,
-    quota_selects_human_gate,
     read_goal_channel_binding,
 )
 from .goal_channel_runtime import auto_notify_lark_goal_channel_gate
@@ -142,50 +141,22 @@ def sync_human_gate_after_refresh(
         goal_id,
         provider_target=provider_target,
     )
-    if not human_gate_auto_notify_enabled(binding):
-        return auto_notify_lark_goal_channel_gate(
-            registry=source_registry,
+    quota_packet: dict[str, Any] = {}
+    if (
+        human_gate_auto_notify_enabled(binding)
+        and external_sink_delivery_authorized
+    ):
+        status = collect_status(
+            registry_path=source_registry_path,
+            runtime_root_override=str(runtime_root),
+            scan_roots=[registry_project_root(source_registry_path)],
+            limit=20,
             goal_id=goal_id,
-            binding_path=binding_path,
-            quota_packet={},
-            provider_target=provider_target,
-            external_sink_delivery_authorized=external_sink_delivery_authorized,
         )
-    if not external_sink_delivery_authorized:
-        return auto_notify_lark_goal_channel_gate(
-            registry=source_registry,
+        quota_packet = build_quota_should_run(
+            status,
             goal_id=goal_id,
-            binding_path=binding_path,
-            quota_packet={},
-            provider_target=provider_target,
-            external_sink_delivery_authorized=False,
-        )
-
-    status = collect_status(
-        registry_path=source_registry_path,
-        runtime_root_override=str(runtime_root),
-        scan_roots=[registry_project_root(source_registry_path)],
-        limit=20,
-        goal_id=goal_id,
-    )
-    quota_packet = build_quota_should_run(
-        status,
-        goal_id=goal_id,
-        agent_id=agent_id,
-    )
-    cooldown = quota_packet.get("user_gate_notification_cooldown")
-    cooldown_active = bool(
-        isinstance(cooldown, dict)
-        and cooldown.get("notification_suppressed") is True
-    )
-    if not quota_selects_human_gate(quota_packet) or cooldown_active:
-        return auto_notify_lark_goal_channel_gate(
-            registry=source_registry,
-            goal_id=goal_id,
-            binding_path=binding_path,
-            quota_packet=quota_packet,
-            provider_target=provider_target,
-            external_sink_delivery_authorized=True,
+            agent_id=agent_id,
         )
 
     result = auto_notify_lark_goal_channel_gate(
@@ -197,5 +168,6 @@ def sync_human_gate_after_refresh(
         external_sink_delivery_authorized=external_sink_delivery_authorized,
         runner=runner,
     )
-    result["extension_activation"] = activation
+    if quota_packet:
+        result["extension_activation"] = activation
     return result

--- a/loopx/extensions/lark/goal_channel_runtime.py
+++ b/loopx/extensions/lark/goal_channel_runtime.py
@@ -8,10 +8,12 @@ from typing import Any
 from .goal_channel_contracts import (
     DEFAULT_GATE_COOLDOWN_SECONDS,
     binding_for_goal,
+    clear_human_gate_auto_notify_marker,
     gate_message,
     goal_from_registry,
     goal_objective,
     human_gate_auto_notify_enabled,
+    human_gate_auto_notify_marker_path,
     now_iso,
     operation_packet,
     parse_time,
@@ -21,6 +23,7 @@ from .goal_channel_contracts import (
     read_goal_channel_binding,
     save_goal_binding,
     semantic_key,
+    write_human_gate_auto_notify_marker,
 )
 from .goal_channel_transport import (
     APP_ID_PATTERN,
@@ -88,6 +91,7 @@ def configure_lark_goal_channel_automation(
         )
     current = human_gate_auto_notify_enabled(binding)
     changed = current != human_gate_auto_notify
+    marker_path = human_gate_auto_notify_marker_path(binding_path, goal_id)
     if execute and changed:
         mutable_binding = dict(binding)
         automation = _mapping(binding.get("automation"))
@@ -99,6 +103,11 @@ def configure_lark_goal_channel_automation(
             goal_id=goal_id,
             binding=mutable_binding,
         )
+    if execute:
+        if human_gate_auto_notify:
+            write_human_gate_auto_notify_marker(marker_path)
+        else:
+            clear_human_gate_auto_notify_marker(marker_path)
     return operation_packet(
         ok=True,
         goal_id=goal_id,
@@ -496,18 +505,6 @@ def notify_lark_goal_channel_gate(
             blocker="state_transition_rejected",
             public_summary="LoopX has not selected a human gate notification",
         )
-    cooldown = quota_packet.get("user_gate_notification_cooldown")
-    if isinstance(cooldown, Mapping) and cooldown.get("notification_suppressed") is True:
-        return operation_packet(
-            ok=False,
-            goal_id=goal_id,
-            operation="notify_gate",
-            execute=execute,
-            status="suppressed",
-            blocker="notification_cooldown_active",
-            public_summary="the current human gate notification is in cooldown",
-        )
-
     channel = _mapping(binding.get("channel"))
     identity_config = _mapping(binding.get("identity"))
     kanban = _mapping(binding.get("kanban"))
@@ -563,13 +560,33 @@ def notify_lark_goal_channel_gate(
             for receipt_key, receipt in receipts.items()
             if receipt_key != key
         }
+    same_gate_receipts = [
+        receipt
+        for receipt in receipts.values()
+        if isinstance(receipt, Mapping)
+        and receipt.get("kind") == "gate_notification"
+        and str(receipt.get("gate_identity") or "") == gate_identity
+    ]
+    cooldown = quota_packet.get("user_gate_notification_cooldown")
+    if (
+        same_gate_receipts
+        and isinstance(cooldown, Mapping)
+        and cooldown.get("notification_suppressed") is True
+    ):
+        return operation_packet(
+            ok=False,
+            goal_id=goal_id,
+            operation="notify_gate",
+            execute=execute,
+            status="suppressed",
+            blocker="notification_cooldown_active",
+            public_summary="the current human gate notification is in cooldown",
+        )
     latest_gate_time = max(
         (
             parsed
-            for receipt in receipts.values()
-            if isinstance(receipt, Mapping)
-            and receipt.get("kind") == "gate_notification"
-            and (parsed := parse_time(receipt.get("verified_at"))) is not None
+            for receipt in same_gate_receipts
+            if (parsed := parse_time(receipt.get("verified_at"))) is not None
         ),
         default=None,
     )
@@ -705,6 +722,7 @@ def notify_lark_goal_channel_gate(
     mutable_receipts = dict(receipts)
     mutable_receipts[key] = {
         "kind": "gate_notification",
+        "gate_identity": gate_identity,
         "message_id": message_id,
         "verified_at": now_iso(),
     }

--- a/loopx/extensions/lark/goal_channel_runtime.py
+++ b/loopx/extensions/lark/goal_channel_runtime.py
@@ -483,8 +483,28 @@ def notify_lark_goal_channel_gate(
             blocker="channel_binding_missing",
             public_summary="configure the Goal Channel before notifying a human gate",
         )
+    target_ref = str(raw_binding.get("target_ref") or "")
+    if target_ref and provider_target is None:
+        return operation_packet(
+            ok=False,
+            goal_id=goal_id,
+            operation="notify_gate",
+            execute=execute,
+            status="blocked",
+            blocker="provider_target_missing",
+            public_summary="configure the referenced shared provider target first",
+        )
     binding = binding_for_goal(payload, goal_id, provider_target=provider_target)
-    assert binding is not None
+    if binding is None:
+        return operation_packet(
+            ok=False,
+            goal_id=goal_id,
+            operation="notify_gate",
+            execute=execute,
+            status="blocked",
+            blocker="channel_binding_incomplete",
+            public_summary="complete Goal Channel setup before notifying a human gate",
+        )
     if binding.get("enabled") is not True:
         return operation_packet(
             ok=False,

--- a/loopx/extensions/lark/goal_channel_runtime.py
+++ b/loopx/extensions/lark/goal_channel_runtime.py
@@ -11,10 +11,12 @@ from .goal_channel_contracts import (
     gate_message,
     goal_from_registry,
     goal_objective,
+    human_gate_auto_notify_enabled,
     now_iso,
     operation_packet,
     parse_time,
     provider_idempotency_key,
+    quota_selects_human_gate,
     read_goal_channel_binding,
     save_goal_binding,
     semantic_key,
@@ -50,6 +52,148 @@ from .presentation.kanban import (
 
 def _mapping(value: Any) -> dict[str, Any]:
     return dict(value) if isinstance(value, Mapping) else {}
+
+
+def configure_lark_goal_channel_automation(
+    *,
+    registry: Mapping[str, Any],
+    goal_id: str,
+    binding_path: Path,
+    human_gate_auto_notify: bool,
+    execute: bool = False,
+) -> dict[str, Any]:
+    goal_from_registry(registry, goal_id)
+    payload = read_goal_channel_binding(binding_path)
+    binding = binding_for_goal(payload, goal_id)
+    if binding is None:
+        return operation_packet(
+            ok=False,
+            goal_id=goal_id,
+            operation="configure",
+            execute=execute,
+            status="blocked",
+            blocker="channel_binding_missing",
+            public_summary="configure the Goal Channel before enabling automation",
+        )
+    if binding.get("enabled") is not True:
+        return operation_packet(
+            ok=False,
+            goal_id=goal_id,
+            operation="configure",
+            execute=execute,
+            status="blocked",
+            blocker="channel_binding_incomplete",
+            public_summary="complete Goal Channel setup before enabling automation",
+        )
+    current = human_gate_auto_notify_enabled(binding)
+    changed = current != human_gate_auto_notify
+    if execute and changed:
+        mutable_binding = dict(binding)
+        automation = _mapping(binding.get("automation"))
+        automation["human_gate_auto_notify_enabled"] = human_gate_auto_notify
+        mutable_binding["automation"] = automation
+        save_goal_binding(
+            binding_path=binding_path,
+            payload=payload,
+            goal_id=goal_id,
+            binding=mutable_binding,
+        )
+    return operation_packet(
+        ok=True,
+        goal_id=goal_id,
+        operation="configure",
+        execute=execute,
+        status="configured" if execute else "preview_ready",
+        public_summary=(
+            "enabled automatic human gate notifications for this Goal Channel"
+            if execute and human_gate_auto_notify
+            else "disabled automatic human gate notifications for this Goal Channel"
+            if execute
+            else "previewed the Goal Channel automation change"
+        ),
+        readback_verified=bool(
+            execute
+            and human_gate_auto_notify_enabled(
+                binding_for_goal(read_goal_channel_binding(binding_path), goal_id)
+            )
+            == human_gate_auto_notify
+        ),
+        details={
+            "changed": changed,
+            "human_gate_auto_notify_enabled": human_gate_auto_notify,
+        },
+    )
+
+
+def auto_notify_lark_goal_channel_gate(
+    *,
+    registry: Mapping[str, Any],
+    goal_id: str,
+    binding_path: Path,
+    quota_packet: Mapping[str, Any],
+    provider_target: Mapping[str, Any] | None = None,
+    external_sink_delivery_authorized: bool,
+    runner: CommandRunner = default_subprocess_runner,
+) -> dict[str, Any]:
+    goal_from_registry(registry, goal_id)
+    payload = read_goal_channel_binding(binding_path)
+    binding = binding_for_goal(
+        payload,
+        goal_id,
+        provider_target=provider_target,
+    )
+    enabled = human_gate_auto_notify_enabled(binding)
+    result: dict[str, Any] = {
+        "schema_version": "loopx_goal_channel_gate_auto_delivery_v0",
+        "ok": True,
+        "enabled": enabled,
+        "status": "not_configured" if binding is None else "disabled",
+        "external_write_performed": False,
+        "readback_verified": False,
+        "delivery_postcondition": {
+            "satisfied": True,
+            "blocks_delivery": False,
+        },
+    }
+    if not enabled:
+        return result
+    if not external_sink_delivery_authorized:
+        result["status"] = "external_sink_suppressed"
+        return result
+
+    notification = notify_lark_goal_channel_gate(
+        registry=registry,
+        goal_id=goal_id,
+        binding_path=binding_path,
+        quota_packet=quota_packet,
+        provider_target=provider_target,
+        execute=True,
+        runner=runner,
+    )
+    result["notification"] = notification
+    blocker = str(notification.get("blocker") or "")
+    result["status"] = (
+        "not_selected"
+        if blocker == "state_transition_rejected"
+        else "cooldown"
+        if blocker == "notification_cooldown_active"
+        else str(notification.get("status") or "failed")
+    )
+    result["external_write_performed"] = bool(
+        notification.get("external_write_performed")
+    )
+    result["readback_verified"] = bool(notification.get("readback_verified"))
+    safe_noop = blocker in {
+        "notification_cooldown_active",
+        "state_transition_rejected",
+    }
+    satisfied = bool(notification.get("ok")) or safe_noop
+    result["ok"] = satisfied
+    result["delivery_postcondition"] = {
+        "satisfied": satisfied,
+        "blocks_delivery": not satisfied,
+    }
+    return result
 
 
 def doctor_lark_goal_channel(
@@ -341,12 +485,7 @@ def notify_lark_goal_channel_gate(
             blocker="channel_binding_incomplete",
             public_summary="complete Goal Channel setup before notifying a human gate",
         )
-    needs_notification = bool(
-        quota_packet.get("state") == "operator_gate"
-        or quota_packet.get("notify_user_on_gate") is True
-        or quota_packet.get("notify_user_on_open_todo") is True
-    )
-    if not needs_notification:
+    if not quota_selects_human_gate(quota_packet):
         return operation_packet(
             ok=False,
             goal_id=goal_id,

--- a/loopx/extensions/lark/goal_channel_runtime.py
+++ b/loopx/extensions/lark/goal_channel_runtime.py
@@ -16,6 +16,7 @@ from .goal_channel_contracts import (
     operation_packet,
     parse_time,
     provider_idempotency_key,
+    quota_human_gate_identity,
     quota_selects_human_gate,
     read_goal_channel_binding,
     save_goal_binding,
@@ -75,7 +76,7 @@ def configure_lark_goal_channel_automation(
             blocker="channel_binding_missing",
             public_summary="configure the Goal Channel before enabling automation",
         )
-    if binding.get("enabled") is not True:
+    if human_gate_auto_notify and binding.get("enabled") is not True:
         return operation_packet(
             ok=False,
             goal_id=goal_id,
@@ -520,7 +521,15 @@ def notify_lark_goal_channel_gate(
         quota_packet=quota_packet,
         kanban_url=str(kanban.get("base_url") or ""),
     )
-    key = semantic_key(goal_id, "lark", "notify_gate", question, chat_id)
+    gate_identity = quota_human_gate_identity(quota_packet)
+    key = semantic_key(
+        goal_id,
+        "lark",
+        "notify_gate",
+        gate_identity,
+        question,
+        chat_id,
+    )
     receipts = _mapping(binding.get("receipts"))
     existing_receipt = _mapping(receipts.get(key))
     if existing_receipt:

--- a/loopx/extensions/lark/goal_channel_setup.py
+++ b/loopx/extensions/lark/goal_channel_setup.py
@@ -106,6 +106,7 @@ def _save_recovery_binding(
             "enabled": False,
             "channel": channel,
             "identity": identity,
+            "automation": _mapping(existing.get("automation")),
             "receipts": _mapping(existing.get("receipts")),
         }
     )
@@ -769,6 +770,7 @@ def setup_lark_goal_channel(
                 "base_url": kanban_url,
             },
             "identity": saved_identity,
+            "automation": _mapping(raw_existing.get("automation")),
             "receipts": mutable_receipts,
         }
         if effective_target_name:

--- a/tests/cli_commands/test_project_lifecycle_goal_channel.py
+++ b/tests/cli_commands/test_project_lifecycle_goal_channel.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from loopx.cli_commands import project_lifecycle
+
+
+def _args(*, suppress_external_sinks: bool = False) -> argparse.Namespace:
+    return argparse.Namespace(
+        command="refresh-state",
+        goal_id="goal-public-fixture",
+        project=None,
+        state_file=None,
+        classification="validated",
+        recommended_action=None,
+        next_action=None,
+        delivery_batch_scale=None,
+        delivery_outcome=None,
+        delivery_workspace_path=None,
+        agent_id="agent-public-fixture",
+        agent_lane=None,
+        progress_scope=None,
+        autonomous_replan_recorded=False,
+        repair_delta_kinds=None,
+        agent_vision_json=None,
+        vision_state=None,
+        vision_summary=None,
+        vision_role_scope=None,
+        vision_acceptance=None,
+        vision_advancement_policy=None,
+        vision_replan_trigger=None,
+        vision_dreaming_policy=None,
+        vision_last_patch=None,
+        vision_todo_delta=None,
+        vision_unchanged_reason=None,
+        available_capabilities=None,
+        dry_run=False,
+        no_global_sync=False,
+        suppress_external_sinks=suppress_external_sinks,
+        runtime_root=None,
+        subcommand_format="json",
+        format=None,
+    )
+
+
+@pytest.mark.parametrize(
+    ("gate_sync", "expected_exit", "expected_ok"),
+    [
+        (
+            {
+                "ok": True,
+                "enabled": True,
+                "status": "sent_verified",
+                "delivery_postcondition": {
+                    "satisfied": True,
+                    "blocks_delivery": False,
+                },
+            },
+            0,
+            True,
+        ),
+        (
+            {
+                "ok": False,
+                "enabled": True,
+                "status": "failed",
+                "delivery_postcondition": {
+                    "satisfied": False,
+                    "blocks_delivery": True,
+                },
+            },
+            1,
+            False,
+        ),
+    ],
+)
+def test_refresh_state_applies_goal_channel_delivery_postcondition(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    gate_sync: dict[str, Any],
+    expected_exit: int,
+    expected_ok: bool,
+) -> None:
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        project_lifecycle,
+        "refresh_state_run",
+        lambda **kwargs: {
+            "ok": True,
+            "appended": True,
+            "dry_run": False,
+            "classification": "validated",
+        },
+    )
+    monkeypatch.setattr(
+        project_lifecycle,
+        "sync_explore_graph_after_material_refresh",
+        lambda **kwargs: {
+            "enabled": False,
+            "delivery_postcondition": {
+                "satisfied": True,
+                "blocks_delivery": False,
+            },
+        },
+    )
+    monkeypatch.setattr(
+        project_lifecycle,
+        "sync_human_gate_after_refresh",
+        lambda **kwargs: gate_sync,
+    )
+
+    result = project_lifecycle.handle_project_lifecycle_command(
+        _args(),
+        registry_path=tmp_path / ".loopx" / "registry.json",
+        print_payload=lambda payload, fmt, renderer: captured.update(payload),
+        output_format=lambda args: "json",
+        append_cli_rollout_event=lambda *args, **kwargs: {},
+    )
+
+    assert result == expected_exit
+    assert captured["ok"] is expected_ok
+    assert captured["goal_channel_gate_sync"] == gate_sync
+    if expected_ok:
+        assert "error" not in captured
+    else:
+        assert "human-gate notification/readback failed" in captured["error"]
+
+
+def test_refresh_state_forwards_external_sink_suppression(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_kwargs: dict[str, Any] = {}
+    monkeypatch.setattr(
+        project_lifecycle,
+        "refresh_state_run",
+        lambda **kwargs: {
+            "ok": True,
+            "appended": True,
+            "dry_run": False,
+            "classification": "validated",
+        },
+    )
+    monkeypatch.setattr(
+        project_lifecycle,
+        "sync_explore_graph_after_material_refresh",
+        lambda **kwargs: {
+            "enabled": False,
+            "delivery_postcondition": {
+                "satisfied": True,
+                "blocks_delivery": False,
+            },
+        },
+    )
+
+    def sync_gate(**kwargs: Any) -> dict[str, Any]:
+        captured_kwargs.update(kwargs)
+        return {
+            "ok": True,
+            "enabled": True,
+            "status": "external_sink_suppressed",
+            "delivery_postcondition": {
+                "satisfied": True,
+                "blocks_delivery": False,
+            },
+        }
+
+    monkeypatch.setattr(
+        project_lifecycle,
+        "sync_human_gate_after_refresh",
+        sync_gate,
+    )
+
+    result = project_lifecycle.handle_project_lifecycle_command(
+        _args(suppress_external_sinks=True),
+        registry_path=tmp_path / ".loopx" / "registry.json",
+        print_payload=lambda payload, fmt, renderer: None,
+        output_format=lambda args: "json",
+        append_cli_rollout_event=lambda *args, **kwargs: {},
+    )
+
+    assert result == 0
+    assert captured_kwargs["external_sink_delivery_authorized"] is False

--- a/tests/cli_commands/test_project_lifecycle_goal_channel.py
+++ b/tests/cli_commands/test_project_lifecycle_goal_channel.py
@@ -185,3 +185,59 @@ def test_refresh_state_forwards_external_sink_suppression(
 
     assert result == 0
     assert captured_kwargs["external_sink_delivery_authorized"] is False
+
+
+def test_refresh_state_redacts_goal_channel_exception_details(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        project_lifecycle,
+        "refresh_state_run",
+        lambda **kwargs: {
+            "ok": True,
+            "appended": True,
+            "dry_run": False,
+            "classification": "validated",
+        },
+    )
+    monkeypatch.setattr(
+        project_lifecycle,
+        "sync_explore_graph_after_material_refresh",
+        lambda **kwargs: {
+            "enabled": False,
+            "delivery_postcondition": {
+                "satisfied": True,
+                "blocks_delivery": False,
+            },
+        },
+    )
+
+    def fail_with_private_details(**kwargs: Any) -> dict[str, Any]:
+        raise ValueError(
+            f"private binding failed at {tmp_path}/.loopx/goal-channel.json "
+            "for oc_private_fixture"
+        )
+
+    monkeypatch.setattr(
+        project_lifecycle,
+        "sync_human_gate_after_refresh",
+        fail_with_private_details,
+    )
+
+    result = project_lifecycle.handle_project_lifecycle_command(
+        _args(),
+        registry_path=tmp_path / ".loopx" / "registry.json",
+        print_payload=lambda payload, fmt, renderer: captured.update(payload),
+        output_format=lambda args: "json",
+        append_cli_rollout_event=lambda *args, **kwargs: {},
+    )
+
+    serialized = str(captured)
+    assert result == 1
+    assert captured["goal_channel_gate_sync"]["error_code"] == (
+        "goal_channel_gate_sync_failed"
+    )
+    assert str(tmp_path) not in serialized
+    assert "oc_private_fixture" not in serialized

--- a/tests/cli_commands/test_project_lifecycle_goal_channel.py
+++ b/tests/cli_commands/test_project_lifecycle_goal_channel.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from loopx.cli_commands import project_lifecycle
+from loopx.extensions.lark.goal_channel_contracts import (
+    human_gate_auto_notify_marker_path,
+    write_human_gate_auto_notify_marker,
+)
 
 
 def _args(*, suppress_external_sinks: bool = False) -> argparse.Namespace:
@@ -192,6 +197,27 @@ def test_refresh_state_redacts_goal_channel_exception_details(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, Any] = {}
+    registry_path = tmp_path / ".loopx" / "registry.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "goals": [
+                    {
+                        "id": "goal-public-fixture",
+                        "repo": str(tmp_path),
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    write_human_gate_auto_notify_marker(
+        human_gate_auto_notify_marker_path(
+            registry_path.parent / "goal-channel.json",
+            "goal-public-fixture",
+        )
+    )
     monkeypatch.setattr(
         project_lifecycle,
         "refresh_state_run",
@@ -228,7 +254,7 @@ def test_refresh_state_redacts_goal_channel_exception_details(
 
     result = project_lifecycle.handle_project_lifecycle_command(
         _args(),
-        registry_path=tmp_path / ".loopx" / "registry.json",
+        registry_path=registry_path,
         print_payload=lambda payload, fmt, renderer: captured.update(payload),
         output_format=lambda args: "json",
         append_cli_rollout_event=lambda *args, **kwargs: {},
@@ -236,7 +262,7 @@ def test_refresh_state_redacts_goal_channel_exception_details(
 
     serialized = str(captured)
     assert result == 1
-    assert captured["goal_channel_gate_sync"]["error_code"] == (
+    assert captured["goal_channel_gate_sync"]["blocker"] == (
         "goal_channel_gate_sync_failed"
     )
     assert str(tmp_path) not in serialized

--- a/tests/extensions/test_lark_goal_channel.py
+++ b/tests/extensions/test_lark_goal_channel.py
@@ -10,6 +10,8 @@ import pytest
 from loopx.cli_commands import goal_channel as goal_channel_cli
 from loopx.extensions.lark.goal_channel import (
     GOAL_CHANNEL_BINDING_SCHEMA_VERSION,
+    auto_notify_lark_goal_channel_gate,
+    configure_lark_goal_channel_automation,
     doctor_lark_goal_channel,
     notify_lark_goal_channel_gate,
     read_goal_channel_binding,
@@ -469,6 +471,149 @@ def test_setup_execute_persists_private_binding_after_verified_pin(
         in control_send[control_send.index("--text") + 1]
     )
     _assert_public_packet(payload)
+
+
+def test_configure_auto_notify_is_preview_first_and_persists_private_opt_in(
+    tmp_path: Path,
+) -> None:
+    binding_path = tmp_path / ".loopx" / "goal-channel.json"
+    binding_path.parent.mkdir(parents=True)
+    kanban_path = tmp_path / ".loopx" / "lark-kanban.json"
+    _write_binding(binding_path, kanban_path)
+    original_bytes = binding_path.read_bytes()
+
+    preview = configure_lark_goal_channel_automation(
+        registry=_registry(tmp_path),
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        human_gate_auto_notify=True,
+        execute=False,
+    )
+
+    assert preview["ok"] is True
+    assert preview["status"] == "preview_ready"
+    assert preview["details"]["human_gate_auto_notify_enabled"] is True
+    assert binding_path.read_bytes() == original_bytes
+
+    applied = configure_lark_goal_channel_automation(
+        registry=_registry(tmp_path),
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        human_gate_auto_notify=True,
+        execute=True,
+    )
+
+    assert applied["ok"] is True
+    assert applied["status"] == "configured"
+    assert applied["readback_verified"] is True
+    binding = read_goal_channel_binding(binding_path)["bindings"][GOAL_ID]
+    assert binding["automation"]["human_gate_auto_notify_enabled"] is True
+    assert binding["channel"]["chat_id"] == CHAT_ID
+    assert binding_path.stat().st_mode & 0o777 == 0o600
+    _assert_public_packet(preview)
+    _assert_public_packet(applied)
+
+
+def test_auto_notify_gate_is_disabled_by_default_and_suppressible(
+    tmp_path: Path,
+) -> None:
+    binding_path = tmp_path / ".loopx" / "goal-channel.json"
+    binding_path.parent.mkdir(parents=True)
+    kanban_path = tmp_path / ".loopx" / "lark-kanban.json"
+    _write_binding(binding_path, kanban_path)
+    quota_packet = {
+        "state": "operator_gate",
+        "notify_user_on_gate": True,
+        "gate_prompt": "Approve the bounded external write.",
+    }
+    calls: list[list[str]] = []
+
+    disabled = auto_notify_lark_goal_channel_gate(
+        registry=_registry(tmp_path),
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        quota_packet=quota_packet,
+        external_sink_delivery_authorized=True,
+        runner=_fake_runner(calls),
+    )
+    assert disabled["ok"] is True
+    assert disabled["enabled"] is False
+    assert disabled["status"] == "disabled"
+    assert calls == []
+
+    configure_lark_goal_channel_automation(
+        registry=_registry(tmp_path),
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        human_gate_auto_notify=True,
+        execute=True,
+    )
+    suppressed = auto_notify_lark_goal_channel_gate(
+        registry=_registry(tmp_path),
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        quota_packet=quota_packet,
+        external_sink_delivery_authorized=False,
+        runner=_fake_runner(calls),
+    )
+    assert suppressed["ok"] is True
+    assert suppressed["enabled"] is True
+    assert suppressed["status"] == "external_sink_suppressed"
+    assert calls == []
+
+
+def test_auto_notify_gate_sends_only_for_quota_selected_gate(
+    tmp_path: Path,
+) -> None:
+    binding_path = tmp_path / ".loopx" / "goal-channel.json"
+    binding_path.parent.mkdir(parents=True)
+    kanban_path = tmp_path / ".loopx" / "lark-kanban.json"
+    save_lark_kanban_board_config(
+        kanban_path,
+        base_token="base_public_fixture",
+        table_id="tbl_public_fixture",
+        base_url="https://example.invalid/base/public-fixture",
+    )
+    _write_binding(binding_path, kanban_path)
+    configure_lark_goal_channel_automation(
+        registry=_registry(tmp_path),
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        human_gate_auto_notify=True,
+        execute=True,
+    )
+    calls: list[list[str]] = []
+    runner = _fake_runner(calls)
+
+    no_gate = auto_notify_lark_goal_channel_gate(
+        registry=_registry(tmp_path),
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        quota_packet={"state": "eligible"},
+        external_sink_delivery_authorized=True,
+        runner=runner,
+    )
+    assert no_gate["ok"] is True
+    assert no_gate["status"] == "not_selected"
+    assert not any("+messages-send" in args for args in calls)
+
+    gate = auto_notify_lark_goal_channel_gate(
+        registry=_registry(tmp_path),
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        quota_packet={
+            "state": "operator_gate",
+            "notify_user_on_gate": True,
+            "gate_prompt": "Approve the bounded external write.",
+        },
+        external_sink_delivery_authorized=True,
+        runner=runner,
+    )
+    assert gate["ok"] is True
+    assert gate["status"] == "sent_verified"
+    assert gate["external_write_performed"] is True
+    assert gate["readback_verified"] is True
+    assert sum("+messages-send" in args for args in calls) == 1
 
 
 def test_setup_inherits_existing_bot_identity_when_flags_are_omitted(
@@ -1022,6 +1167,58 @@ def test_cli_checks_extension_before_reading_private_binding(
     assert result == 1
     assert captured["blocker"] == "extension_unavailable"
     assert "not-json" not in json.dumps(captured)
+
+
+def test_cli_can_disable_auto_notify_when_extension_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry_path = tmp_path / ".loopx" / "registry.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(json.dumps(_registry(tmp_path)), encoding="utf-8")
+    binding_path = tmp_path / ".loopx" / "goal-channel.json"
+    kanban_path = tmp_path / ".loopx" / "lark-kanban.json"
+    _write_binding(binding_path, kanban_path)
+    configure_lark_goal_channel_automation(
+        registry=_registry(tmp_path),
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        human_gate_auto_notify=True,
+        execute=True,
+    )
+    captured: dict[str, Any] = {}
+
+    def unavailable(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise ValueError("extension unavailable")
+
+    monkeypatch.setattr(goal_channel_cli, "resolve_extension_activation", unavailable)
+
+    result = goal_channel_cli.handle_goal_channel_command(
+        argparse.Namespace(
+            command="goal-channel",
+            goal_channel_command="configure",
+            goal_id=GOAL_ID,
+            binding_path=str(binding_path),
+            auto_notify_human_gates=False,
+            execute=True,
+            subcommand_format="json",
+            format=None,
+        ),
+        registry_path=registry_path,
+        runtime_root_arg=None,
+        print_payload=lambda payload, fmt, renderer: captured.update(payload),
+        output_format=lambda args: "json",
+    )
+
+    assert result == 0
+    assert captured["ok"] is True
+    assert captured["readback_verified"] is True
+    assert (
+        read_goal_channel_binding(binding_path)["bindings"][GOAL_ID]["automation"][
+            "human_gate_auto_notify_enabled"
+        ]
+        is False
+    )
 
 
 def test_cli_global_registry_routes_binding_to_source_registry_from_any_cwd(

--- a/tests/extensions/test_lark_goal_channel.py
+++ b/tests/extensions/test_lark_goal_channel.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 
 from loopx.cli_commands import goal_channel as goal_channel_cli
+from loopx.extensions.lark import goal_channel_contracts
 from loopx.extensions.lark.goal_channel import (
     GOAL_CHANNEL_BINDING_SCHEMA_VERSION,
     auto_notify_lark_goal_channel_gate,
@@ -508,6 +509,11 @@ def test_configure_auto_notify_is_preview_first_and_persists_private_opt_in(
     assert applied["readback_verified"] is True
     binding = read_goal_channel_binding(binding_path)["bindings"][GOAL_ID]
     assert binding["automation"]["human_gate_auto_notify_enabled"] is True
+    marker_path = goal_channel_contracts.human_gate_auto_notify_marker_path(
+        binding_path,
+        GOAL_ID,
+    )
+    assert goal_channel_contracts.human_gate_auto_notify_marker_enabled(marker_path)
     assert binding["channel"]["chat_id"] == CHAT_ID
     assert binding_path.stat().st_mode & 0o777 == 0o600
     _assert_public_packet(preview)
@@ -540,6 +546,11 @@ def test_configure_can_disable_auto_notify_for_incomplete_binding(
     persisted = read_goal_channel_binding(binding_path)["bindings"][GOAL_ID]
     assert persisted["enabled"] is False
     assert persisted["automation"]["human_gate_auto_notify_enabled"] is False
+    marker_path = goal_channel_contracts.human_gate_auto_notify_marker_path(
+        binding_path,
+        GOAL_ID,
+    )
+    assert marker_path.exists() is False
     _assert_public_packet(payload)
 
 
@@ -966,7 +977,6 @@ def test_notify_gate_distinguishes_different_gate_ids_with_same_question(
         goal_id=GOAL_ID,
         binding_path=binding_path,
         quota_packet=quota("todo_gate_one"),
-        cooldown_seconds=0,
         execute=True,
         runner=runner,
     )
@@ -975,7 +985,6 @@ def test_notify_gate_distinguishes_different_gate_ids_with_same_question(
         goal_id=GOAL_ID,
         binding_path=binding_path,
         quota_packet=quota("todo_gate_two"),
-        cooldown_seconds=0,
         execute=True,
         runner=runner,
     )
@@ -1054,6 +1063,16 @@ def test_notify_gate_respects_quota_cooldown_without_external_call(
     binding_path.parent.mkdir(parents=True)
     kanban_path = tmp_path / ".loopx" / "lark-kanban.json"
     _write_binding(binding_path, kanban_path)
+    binding = read_goal_channel_binding(binding_path)
+    binding["bindings"][GOAL_ID]["receipts"] = {
+        "sha256:prior-reminder": {
+            "kind": "gate_notification",
+            "gate_identity": "todo_gate_fixture",
+            "message_id": GATE_MESSAGE_ID,
+            "verified_at": "2026-08-08T00:00:00+00:00",
+        }
+    }
+    write_goal_channel_binding(binding_path, binding)
     calls: list[list[str]] = []
 
     payload = notify_lark_goal_channel_gate(
@@ -1064,6 +1083,15 @@ def test_notify_gate_respects_quota_cooldown_without_external_call(
             "state": "operator_gate",
             "notify_user_on_gate": True,
             "gate_prompt": "Approve the bounded external write.",
+            "user_todo_summary": {
+                "gate_open_items": [
+                    {
+                        "todo_id": "todo_gate_fixture",
+                        "task_class": "user_gate",
+                        "text": "Approve the bounded external write.",
+                    }
+                ]
+            },
             "user_gate_notification_cooldown": {
                 "notification_suppressed": True,
             },
@@ -1304,6 +1332,49 @@ def test_cli_can_disable_auto_notify_when_extension_is_unavailable(
             "human_gate_auto_notify_enabled"
         ]
         is False
+    )
+
+
+def test_cli_rejects_custom_binding_path_for_auto_notify(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry_path = tmp_path / ".loopx" / "registry.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(json.dumps(_registry(tmp_path)), encoding="utf-8")
+    custom_binding = tmp_path / ".loopx" / "custom-goal-channel.json"
+    _write_binding(custom_binding, tmp_path / ".loopx" / "lark-kanban.json")
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        goal_channel_cli,
+        "resolve_extension_activation",
+        lambda *args, **kwargs: {"status": "active"},
+    )
+
+    result = goal_channel_cli.handle_goal_channel_command(
+        argparse.Namespace(
+            command="goal-channel",
+            goal_channel_command="configure",
+            goal_id=GOAL_ID,
+            binding_path=str(custom_binding),
+            auto_notify_human_gates=True,
+            execute=True,
+            subcommand_format="json",
+            format=None,
+        ),
+        registry_path=registry_path,
+        runtime_root_arg=None,
+        print_payload=lambda payload, fmt, renderer: captured.update(payload),
+        output_format=lambda args: "json",
+    )
+
+    assert result == 1
+    assert captured["blocker"] == "noncanonical_binding_path"
+    assert (
+        read_goal_channel_binding(custom_binding)["bindings"][GOAL_ID].get(
+            "automation"
+        )
+        is None
     )
 
 

--- a/tests/extensions/test_lark_goal_channel.py
+++ b/tests/extensions/test_lark_goal_channel.py
@@ -514,6 +514,35 @@ def test_configure_auto_notify_is_preview_first_and_persists_private_opt_in(
     _assert_public_packet(applied)
 
 
+def test_configure_can_disable_auto_notify_for_incomplete_binding(
+    tmp_path: Path,
+) -> None:
+    binding_path = tmp_path / ".loopx" / "goal-channel.json"
+    binding_path.parent.mkdir(parents=True)
+    kanban_path = tmp_path / ".loopx" / "lark-kanban.json"
+    _write_binding(binding_path, kanban_path)
+    binding = read_goal_channel_binding(binding_path)
+    goal_binding = binding["bindings"][GOAL_ID]
+    goal_binding["enabled"] = False
+    goal_binding["automation"] = {"human_gate_auto_notify_enabled": True}
+    write_goal_channel_binding(binding_path, binding)
+
+    payload = configure_lark_goal_channel_automation(
+        registry=_registry(tmp_path),
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        human_gate_auto_notify=False,
+        execute=True,
+    )
+
+    assert payload["ok"] is True
+    assert payload["readback_verified"] is True
+    persisted = read_goal_channel_binding(binding_path)["bindings"][GOAL_ID]
+    assert persisted["enabled"] is False
+    assert persisted["automation"]["human_gate_auto_notify_enabled"] is False
+    _assert_public_packet(payload)
+
+
 def test_auto_notify_gate_is_disabled_by_default_and_suppressible(
     tmp_path: Path,
 ) -> None:
@@ -898,6 +927,63 @@ def test_notify_gate_is_idempotent_after_verified_send(tmp_path: Path) -> None:
     assert sum("+messages-send" in args for args in calls) == send_count
     _assert_public_packet(first)
     _assert_public_packet(second)
+
+
+def test_notify_gate_distinguishes_different_gate_ids_with_same_question(
+    tmp_path: Path,
+) -> None:
+    binding_path = tmp_path / ".loopx" / "goal-channel.json"
+    binding_path.parent.mkdir(parents=True)
+    kanban_path = tmp_path / ".loopx" / "lark-kanban.json"
+    save_lark_kanban_board_config(
+        kanban_path,
+        base_token="base_public_fixture",
+        table_id="tbl_public_fixture",
+        base_url="https://example.invalid/base/public-fixture",
+    )
+    _write_binding(binding_path, kanban_path)
+    calls: list[list[str]] = []
+    runner = _fake_runner(calls)
+
+    def quota(todo_id: str) -> dict[str, Any]:
+        return {
+            "state": "operator_gate",
+            "notify_user_on_gate": True,
+            "gate_prompt": "Approve the bounded external write.",
+            "user_todo_summary": {
+                "gate_open_items": [
+                    {
+                        "todo_id": todo_id,
+                        "task_class": "user_gate",
+                        "text": "Approve the bounded external write.",
+                    }
+                ]
+            },
+        }
+
+    first = notify_lark_goal_channel_gate(
+        registry=_registry(tmp_path),
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        quota_packet=quota("todo_gate_one"),
+        cooldown_seconds=0,
+        execute=True,
+        runner=runner,
+    )
+    second = notify_lark_goal_channel_gate(
+        registry=_registry(tmp_path),
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        quota_packet=quota("todo_gate_two"),
+        cooldown_seconds=0,
+        execute=True,
+        runner=runner,
+    )
+
+    assert first["status"] == "sent_verified"
+    assert second["status"] == "sent_verified"
+    assert first["idempotency_key"] != second["idempotency_key"]
+    assert sum("+messages-send" in args for args in calls) == 2
 
 
 def test_notify_gate_resends_when_existing_receipt_readback_is_stale(

--- a/tests/extensions/test_lark_goal_channel.py
+++ b/tests/extensions/test_lark_goal_channel.py
@@ -997,6 +997,38 @@ def test_notify_gate_distinguishes_different_gate_ids_with_same_question(
     assert sum("+messages-send" in args for args in calls) == 2
 
 
+def test_notify_gate_reports_missing_shared_target_for_direct_caller(
+    tmp_path: Path,
+) -> None:
+    binding_path = tmp_path / ".loopx" / "goal-channel.json"
+    binding_path.parent.mkdir(parents=True)
+    kanban_path = tmp_path / ".loopx" / "lark-kanban.json"
+    _write_binding(binding_path, kanban_path)
+    binding = read_goal_channel_binding(binding_path)
+    binding["bindings"][GOAL_ID]["target_ref"] = "missing-target"
+    binding["bindings"][GOAL_ID]["channel"] = {}
+    binding["bindings"][GOAL_ID]["identity"] = {}
+    write_goal_channel_binding(binding_path, binding)
+
+    payload = notify_lark_goal_channel_gate(
+        registry=_registry(tmp_path),
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        quota_packet={
+            "state": "operator_gate",
+            "notify_user_on_gate": True,
+            "gate_prompt": "Approve the bounded external write.",
+        },
+        execute=True,
+        runner=_fake_runner([]),
+    )
+
+    assert payload["ok"] is False
+    assert payload["status"] == "blocked"
+    assert payload["blocker"] == "provider_target_missing"
+    _assert_public_packet(payload)
+
+
 def test_notify_gate_resends_when_existing_receipt_readback_is_stale(
     tmp_path: Path,
 ) -> None:

--- a/tests/extensions/test_lark_goal_channel.py
+++ b/tests/extensions/test_lark_goal_channel.py
@@ -11,13 +11,15 @@ from loopx.cli_commands import goal_channel as goal_channel_cli
 from loopx.extensions.lark import goal_channel_contracts
 from loopx.extensions.lark.goal_channel import (
     GOAL_CHANNEL_BINDING_SCHEMA_VERSION,
-    auto_notify_lark_goal_channel_gate,
     configure_lark_goal_channel_automation,
     doctor_lark_goal_channel,
     notify_lark_goal_channel_gate,
     read_goal_channel_binding,
     setup_lark_goal_channel,
     sync_lark_goal_channel,
+)
+from loopx.extensions.lark.goal_channel_runtime import (
+    auto_notify_lark_goal_channel_gate,
 )
 from loopx.extensions.lark.goal_channel_contracts import write_goal_channel_binding
 from loopx.extensions.lark.presentation.kanban import (

--- a/tests/extensions/test_lark_goal_channel_lifecycle.py
+++ b/tests/extensions/test_lark_goal_channel_lifecycle.py
@@ -196,7 +196,7 @@ def test_refresh_lifecycle_no_gate_checks_extension_without_delivery(
     assert result["ok"] is True
     assert result["enabled"] is True
     assert result["status"] == "not_selected"
-    assert "extension_activation" not in result
+    assert result["extension_activation"] == {"status": "active"}
 
 
 def test_refresh_lifecycle_extension_failure_prevents_private_binding_read(

--- a/tests/extensions/test_lark_goal_channel_lifecycle.py
+++ b/tests/extensions/test_lark_goal_channel_lifecycle.py
@@ -60,22 +60,21 @@ def _binding(registry_path: Path, *, enabled: bool) -> None:
     )
 
 
-def test_refresh_lifecycle_does_not_load_extension_without_opt_in(
+def test_refresh_lifecycle_checks_extension_before_private_opt_in(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     registry_path = _registry(tmp_path)
-    called = False
+    calls: list[Path] = []
 
-    def unexpected(*args: Any, **kwargs: Any) -> dict[str, Any]:
-        nonlocal called
-        called = True
-        raise AssertionError("extension activation must remain lazy")
+    def activate(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        calls.append(Path(kwargs["state_file"]))
+        return {"status": "active"}
 
     monkeypatch.setattr(
         goal_channel_lifecycle,
         "resolve_extension_activation",
-        unexpected,
+        activate,
     )
 
     result = goal_channel_lifecycle.sync_human_gate_after_refresh(
@@ -89,7 +88,7 @@ def test_refresh_lifecycle_does_not_load_extension_without_opt_in(
     assert result["ok"] is True
     assert result["enabled"] is False
     assert result["status"] == "not_configured"
-    assert called is False
+    assert calls == [tmp_path / "runtime" / "extensions" / "state.json"]
 
 
 def test_refresh_lifecycle_shared_registry_without_source_binding_is_safe_noop(
@@ -127,21 +126,24 @@ def test_refresh_lifecycle_shared_registry_without_source_binding_is_safe_noop(
     assert result["status"] == "project_binding_unavailable"
 
 
-def test_refresh_lifecycle_suppression_skips_extension_and_quota(
+def test_refresh_lifecycle_suppression_checks_extension_but_skips_quota(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     registry_path = _registry(tmp_path)
     _binding(registry_path, enabled=True)
 
-    def unexpected(*args: Any, **kwargs: Any) -> dict[str, Any]:
-        raise AssertionError("suppressed delivery must not load external dependencies")
+    activation_calls = 0
 
-    monkeypatch.setattr(
-        goal_channel_lifecycle,
-        "resolve_extension_activation",
-        unexpected,
-    )
+    def activate(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        nonlocal activation_calls
+        activation_calls += 1
+        return {"status": "active"}
+
+    def unexpected(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("suppressed delivery must not rebuild quota")
+
+    monkeypatch.setattr(goal_channel_lifecycle, "resolve_extension_activation", activate)
     monkeypatch.setattr(goal_channel_lifecycle, "collect_status", unexpected)
 
     result = goal_channel_lifecycle.sync_human_gate_after_refresh(
@@ -155,9 +157,10 @@ def test_refresh_lifecycle_suppression_skips_extension_and_quota(
     assert result["ok"] is True
     assert result["enabled"] is True
     assert result["status"] == "external_sink_suppressed"
+    assert activation_calls == 1
 
 
-def test_refresh_lifecycle_no_gate_does_not_load_extension(
+def test_refresh_lifecycle_no_gate_checks_extension_without_delivery(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -174,13 +177,10 @@ def test_refresh_lifecycle_no_gate_does_not_load_extension(
         lambda status, **kwargs: {"state": "eligible"},
     )
 
-    def unexpected(*args: Any, **kwargs: Any) -> dict[str, Any]:
-        raise AssertionError("no selected gate must not load the Lark extension")
-
     monkeypatch.setattr(
         goal_channel_lifecycle,
         "resolve_extension_activation",
-        unexpected,
+        lambda *args, **kwargs: {"status": "active"},
     )
 
     result = goal_channel_lifecycle.sync_human_gate_after_refresh(
@@ -195,6 +195,34 @@ def test_refresh_lifecycle_no_gate_does_not_load_extension(
     assert result["enabled"] is True
     assert result["status"] == "not_selected"
     assert "extension_activation" not in result
+
+
+def test_refresh_lifecycle_extension_failure_prevents_private_binding_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry_path = _registry(tmp_path)
+    binding_path = registry_path.parent / "goal-channel.json"
+    binding_path.write_text("not-json", encoding="utf-8")
+    monkeypatch.setattr(
+        goal_channel_lifecycle,
+        "resolve_extension_activation",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            ValueError("extension unavailable")
+        ),
+    )
+
+    result = goal_channel_lifecycle.sync_human_gate_after_refresh(
+        registry_path=registry_path,
+        runtime_root_override=None,
+        goal_id=GOAL_ID,
+        agent_id=None,
+        external_sink_delivery_authorized=True,
+    )
+
+    assert result["ok"] is True
+    assert result["enabled"] is False
+    assert result["status"] == "extension_unavailable"
 
 
 def test_refresh_lifecycle_reads_quota_then_delivers_selected_gate(

--- a/tests/extensions/test_lark_goal_channel_lifecycle.py
+++ b/tests/extensions/test_lark_goal_channel_lifecycle.py
@@ -9,7 +9,9 @@ import pytest
 from loopx.extensions.lark import goal_channel_lifecycle
 from loopx.extensions.lark.goal_channel_contracts import (
     GOAL_CHANNEL_BINDING_SCHEMA_VERSION,
+    human_gate_auto_notify_marker_path,
     read_goal_channel_binding,
+    write_human_gate_auto_notify_marker,
     write_goal_channel_binding,
 )
 
@@ -223,6 +225,42 @@ def test_refresh_lifecycle_extension_failure_prevents_private_binding_read(
     assert result["ok"] is True
     assert result["enabled"] is False
     assert result["status"] == "extension_unavailable"
+
+
+def test_refresh_lifecycle_configured_extension_failure_blocks_delivery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry_path = _registry(tmp_path)
+    binding_path = registry_path.parent / "goal-channel.json"
+    _binding(registry_path, enabled=True)
+    write_human_gate_auto_notify_marker(
+        human_gate_auto_notify_marker_path(binding_path, GOAL_ID)
+    )
+    monkeypatch.setattr(
+        goal_channel_lifecycle,
+        "resolve_extension_activation",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            ValueError("extension unavailable")
+        ),
+    )
+
+    result = goal_channel_lifecycle.sync_human_gate_after_refresh(
+        registry_path=registry_path,
+        runtime_root_override=None,
+        goal_id=GOAL_ID,
+        agent_id=None,
+        external_sink_delivery_authorized=True,
+    )
+
+    assert result["ok"] is False
+    assert result["enabled"] is True
+    assert result["status"] == "extension_unavailable"
+    assert result["blocker"] == "extension_unavailable"
+    assert result["delivery_postcondition"] == {
+        "satisfied": False,
+        "blocks_delivery": True,
+    }
 
 
 def test_refresh_lifecycle_reads_quota_then_delivers_selected_gate(

--- a/tests/extensions/test_lark_goal_channel_lifecycle.py
+++ b/tests/extensions/test_lark_goal_channel_lifecycle.py
@@ -14,6 +14,10 @@ from loopx.extensions.lark.goal_channel_contracts import (
     write_human_gate_auto_notify_marker,
     write_goal_channel_binding,
 )
+from loopx.extensions.lark.goal_channel_targets import (
+    GOAL_CHANNEL_TARGETS_SCHEMA_VERSION,
+)
+from loopx.extensions.lark.private_json import write_private_json_atomic
 
 
 GOAL_ID = "goal-public-fixture"
@@ -60,6 +64,41 @@ def _binding(registry_path: Path, *, enabled: bool) -> None:
             },
         },
     )
+
+
+def _target_binding(registry_path: Path) -> dict[str, Any]:
+    payload = read_goal_channel_binding(registry_path.parent / "goal-channel.json")
+    binding = payload["bindings"][GOAL_ID]
+    binding["target_ref"] = "shared-lark"
+    binding["channel"] = {}
+    binding["identity"] = {}
+    write_goal_channel_binding(registry_path.parent / "goal-channel.json", payload)
+    target = {
+        "name": "shared-lark",
+        "provider": "lark",
+        "enabled": True,
+        "channel": {
+            "chat_id": "oc_public_fixture",
+            "chat_name": "Shared Goal Channel",
+        },
+        "identity": {
+            "mode": "local_user",
+            "sender_profile": "",
+            "sender_identity": "bot",
+            "bot_app_id": "cli_public_fixture",
+            "bot_display_name": "",
+            "cli_bin": "lark-cli",
+        },
+    }
+    write_private_json_atomic(
+        Path(json.loads(registry_path.read_text())["common_runtime_root"])
+        / "goal-channel-targets.json",
+        {
+            "schema_version": GOAL_CHANNEL_TARGETS_SCHEMA_VERSION,
+            "targets": {"shared-lark": target},
+        },
+    )
+    return target
 
 
 def test_refresh_lifecycle_checks_extension_before_private_opt_in(
@@ -330,3 +369,99 @@ def test_refresh_lifecycle_reads_quota_then_delivers_selected_gate(
         ][GOAL_ID]["automation"]["human_gate_auto_notify_enabled"]
         is True
     )
+
+
+def test_refresh_lifecycle_resolves_shared_provider_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry_path = _registry(tmp_path)
+    _binding(registry_path, enabled=True)
+    expected_target = _target_binding(registry_path)
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        goal_channel_lifecycle,
+        "resolve_extension_activation",
+        lambda *args, **kwargs: {"status": "active"},
+    )
+    monkeypatch.setattr(
+        goal_channel_lifecycle,
+        "collect_status",
+        lambda **kwargs: {"status": "fixture"},
+    )
+    monkeypatch.setattr(
+        goal_channel_lifecycle,
+        "build_quota_should_run",
+        lambda status, **kwargs: {
+            "state": "operator_gate",
+            "notify_user_on_gate": True,
+            "gate_prompt": "Approve the bounded external write.",
+        },
+    )
+
+    def deliver(**kwargs: Any) -> dict[str, Any]:
+        captured.update(kwargs)
+        return {
+            "ok": True,
+            "enabled": True,
+            "status": "sent_verified",
+            "delivery_postcondition": {
+                "satisfied": True,
+                "blocks_delivery": False,
+            },
+        }
+
+    monkeypatch.setattr(
+        goal_channel_lifecycle,
+        "auto_notify_lark_goal_channel_gate",
+        deliver,
+    )
+
+    result = goal_channel_lifecycle.sync_human_gate_after_refresh(
+        registry_path=registry_path,
+        runtime_root_override=None,
+        goal_id=GOAL_ID,
+        agent_id=None,
+        external_sink_delivery_authorized=True,
+    )
+
+    assert result["status"] == "sent_verified"
+    assert captured["provider_target"] == expected_target
+    raw_binding = read_goal_channel_binding(
+        registry_path.parent / "goal-channel.json"
+    )["bindings"][GOAL_ID]
+    assert raw_binding["target_ref"] == "shared-lark"
+    assert raw_binding["channel"] == {}
+    assert raw_binding["identity"] == {}
+
+
+def test_refresh_lifecycle_missing_shared_target_blocks_delivery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry_path = _registry(tmp_path)
+    _binding(registry_path, enabled=True)
+    payload = read_goal_channel_binding(registry_path.parent / "goal-channel.json")
+    payload["bindings"][GOAL_ID]["target_ref"] = "missing-target"
+    write_goal_channel_binding(registry_path.parent / "goal-channel.json", payload)
+    monkeypatch.setattr(
+        goal_channel_lifecycle,
+        "resolve_extension_activation",
+        lambda *args, **kwargs: {"status": "active"},
+    )
+
+    result = goal_channel_lifecycle.sync_human_gate_after_refresh(
+        registry_path=registry_path,
+        runtime_root_override=None,
+        goal_id=GOAL_ID,
+        agent_id=None,
+        external_sink_delivery_authorized=True,
+    )
+
+    assert result["ok"] is False
+    assert result["enabled"] is True
+    assert result["status"] == "provider_target_missing"
+    assert result["delivery_postcondition"] == {
+        "satisfied": False,
+        "blocks_delivery": True,
+    }

--- a/tests/extensions/test_lark_goal_channel_lifecycle.py
+++ b/tests/extensions/test_lark_goal_channel_lifecycle.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from loopx.extensions.lark import goal_channel_lifecycle
+from loopx.extensions.lark.goal_channel_contracts import (
+    GOAL_CHANNEL_BINDING_SCHEMA_VERSION,
+    read_goal_channel_binding,
+    write_goal_channel_binding,
+)
+
+
+GOAL_ID = "goal-public-fixture"
+
+
+def _registry(tmp_path: Path) -> Path:
+    registry_path = tmp_path / ".loopx" / "registry.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "common_runtime_root": str(tmp_path / "runtime"),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "objective": "Deliver a public-safe collaboration channel.",
+                        "repo": str(tmp_path),
+                        "state_file": str(tmp_path / "ACTIVE_GOAL_STATE.md"),
+                        "adapter": {"kind": "read_only_project_map_v0"},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return registry_path
+
+
+def _binding(registry_path: Path, *, enabled: bool) -> None:
+    write_goal_channel_binding(
+        registry_path.parent / "goal-channel.json",
+        {
+            "schema_version": GOAL_CHANNEL_BINDING_SCHEMA_VERSION,
+            "bindings": {
+                GOAL_ID: {
+                    "goal_id": GOAL_ID,
+                    "provider": "lark",
+                    "enabled": True,
+                    "automation": {
+                        "human_gate_auto_notify_enabled": enabled,
+                    },
+                    "receipts": {},
+                }
+            },
+        },
+    )
+
+
+def test_refresh_lifecycle_does_not_load_extension_without_opt_in(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry_path = _registry(tmp_path)
+    called = False
+
+    def unexpected(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        nonlocal called
+        called = True
+        raise AssertionError("extension activation must remain lazy")
+
+    monkeypatch.setattr(
+        goal_channel_lifecycle,
+        "resolve_extension_activation",
+        unexpected,
+    )
+
+    result = goal_channel_lifecycle.sync_human_gate_after_refresh(
+        registry_path=registry_path,
+        runtime_root_override=None,
+        goal_id=GOAL_ID,
+        agent_id=None,
+        external_sink_delivery_authorized=True,
+    )
+
+    assert result["ok"] is True
+    assert result["enabled"] is False
+    assert result["status"] == "not_configured"
+    assert called is False
+
+
+def test_refresh_lifecycle_shared_registry_without_source_binding_is_safe_noop(
+    tmp_path: Path,
+) -> None:
+    registry_path = tmp_path / "runtime" / "registry.global.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "registry_role": "global-local",
+                "common_runtime_root": str(registry_path.parent),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "objective": "Deliver a public-safe collaboration channel.",
+                        "repo": str(tmp_path),
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = goal_channel_lifecycle.sync_human_gate_after_refresh(
+        registry_path=registry_path,
+        runtime_root_override=None,
+        goal_id=GOAL_ID,
+        agent_id=None,
+        external_sink_delivery_authorized=True,
+    )
+
+    assert result["ok"] is True
+    assert result["enabled"] is False
+    assert result["status"] == "project_binding_unavailable"
+
+
+def test_refresh_lifecycle_suppression_skips_extension_and_quota(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry_path = _registry(tmp_path)
+    _binding(registry_path, enabled=True)
+
+    def unexpected(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("suppressed delivery must not load external dependencies")
+
+    monkeypatch.setattr(
+        goal_channel_lifecycle,
+        "resolve_extension_activation",
+        unexpected,
+    )
+    monkeypatch.setattr(goal_channel_lifecycle, "collect_status", unexpected)
+
+    result = goal_channel_lifecycle.sync_human_gate_after_refresh(
+        registry_path=registry_path,
+        runtime_root_override=None,
+        goal_id=GOAL_ID,
+        agent_id="agent-public-fixture",
+        external_sink_delivery_authorized=False,
+    )
+
+    assert result["ok"] is True
+    assert result["enabled"] is True
+    assert result["status"] == "external_sink_suppressed"
+
+
+def test_refresh_lifecycle_no_gate_does_not_load_extension(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry_path = _registry(tmp_path)
+    _binding(registry_path, enabled=True)
+    monkeypatch.setattr(
+        goal_channel_lifecycle,
+        "collect_status",
+        lambda **kwargs: {"status": "fixture"},
+    )
+    monkeypatch.setattr(
+        goal_channel_lifecycle,
+        "build_quota_should_run",
+        lambda status, **kwargs: {"state": "eligible"},
+    )
+
+    def unexpected(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("no selected gate must not load the Lark extension")
+
+    monkeypatch.setattr(
+        goal_channel_lifecycle,
+        "resolve_extension_activation",
+        unexpected,
+    )
+
+    result = goal_channel_lifecycle.sync_human_gate_after_refresh(
+        registry_path=registry_path,
+        runtime_root_override=None,
+        goal_id=GOAL_ID,
+        agent_id=None,
+        external_sink_delivery_authorized=True,
+    )
+
+    assert result["ok"] is True
+    assert result["enabled"] is True
+    assert result["status"] == "not_selected"
+    assert "extension_activation" not in result
+
+
+def test_refresh_lifecycle_reads_quota_then_delivers_selected_gate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry_path = _registry(tmp_path)
+    _binding(registry_path, enabled=True)
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        goal_channel_lifecycle,
+        "resolve_extension_activation",
+        lambda *args, **kwargs: {"status": "active"},
+    )
+    monkeypatch.setattr(
+        goal_channel_lifecycle,
+        "collect_status",
+        lambda **kwargs: {"status": "fixture"},
+    )
+    monkeypatch.setattr(
+        goal_channel_lifecycle,
+        "build_quota_should_run",
+        lambda status, **kwargs: {
+            "state": "operator_gate",
+            "notify_user_on_gate": True,
+            "gate_prompt": "Approve the bounded external write.",
+        },
+    )
+
+    def deliver(**kwargs: Any) -> dict[str, Any]:
+        captured.update(kwargs)
+        return {
+            "schema_version": "loopx_goal_channel_gate_auto_delivery_v0",
+            "ok": True,
+            "enabled": True,
+            "status": "sent_verified",
+            "external_write_performed": True,
+            "readback_verified": True,
+            "delivery_postcondition": {
+                "satisfied": True,
+                "blocks_delivery": False,
+            },
+        }
+
+    monkeypatch.setattr(
+        goal_channel_lifecycle,
+        "auto_notify_lark_goal_channel_gate",
+        deliver,
+    )
+
+    result = goal_channel_lifecycle.sync_human_gate_after_refresh(
+        registry_path=registry_path,
+        runtime_root_override=None,
+        goal_id=GOAL_ID,
+        agent_id="agent-public-fixture",
+        external_sink_delivery_authorized=True,
+    )
+
+    assert result["status"] == "sent_verified"
+    assert result["extension_activation"] == {"status": "active"}
+    assert captured["quota_packet"]["state"] == "operator_gate"
+    assert captured["external_sink_delivery_authorized"] is True
+    assert (
+        read_goal_channel_binding(registry_path.parent / "goal-channel.json")[
+            "bindings"
+        ][GOAL_ID]["automation"]["human_gate_auto_notify_enabled"]
+        is True
+    )

--- a/tests/extensions/test_lark_goal_channel_lifecycle.py
+++ b/tests/extensions/test_lark_goal_channel_lifecycle.py
@@ -266,6 +266,70 @@ def test_refresh_lifecycle_extension_failure_prevents_private_binding_read(
     assert result["status"] == "extension_unavailable"
 
 
+def test_refresh_lifecycle_unconfigured_malformed_binding_is_safe_noop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry_path = _registry(tmp_path)
+    binding_path = registry_path.parent / "goal-channel.json"
+    binding_path.write_text("not-json", encoding="utf-8")
+    monkeypatch.setattr(
+        goal_channel_lifecycle,
+        "resolve_extension_activation",
+        lambda *args, **kwargs: {"status": "active"},
+    )
+
+    result = goal_channel_lifecycle.sync_human_gate_after_refresh(
+        registry_path=registry_path,
+        runtime_root_override=None,
+        goal_id=GOAL_ID,
+        agent_id=None,
+        external_sink_delivery_authorized=True,
+    )
+
+    assert result["ok"] is True
+    assert result["enabled"] is False
+    assert result["status"] == "not_configured"
+    assert result["delivery_postcondition"] == {
+        "satisfied": True,
+        "blocks_delivery": False,
+    }
+
+
+def test_refresh_lifecycle_configured_malformed_binding_blocks_delivery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry_path = _registry(tmp_path)
+    binding_path = registry_path.parent / "goal-channel.json"
+    binding_path.write_text("not-json", encoding="utf-8")
+    write_human_gate_auto_notify_marker(
+        human_gate_auto_notify_marker_path(binding_path, GOAL_ID)
+    )
+    monkeypatch.setattr(
+        goal_channel_lifecycle,
+        "resolve_extension_activation",
+        lambda *args, **kwargs: {"status": "active"},
+    )
+
+    result = goal_channel_lifecycle.sync_human_gate_after_refresh(
+        registry_path=registry_path,
+        runtime_root_override=None,
+        goal_id=GOAL_ID,
+        agent_id=None,
+        external_sink_delivery_authorized=True,
+    )
+
+    assert result["ok"] is False
+    assert result["enabled"] is True
+    assert result["status"] == "failed"
+    assert result["blocker"] == "invalid_goal_channel_binding"
+    assert result["delivery_postcondition"] == {
+        "satisfied": False,
+        "blocks_delivery": True,
+    }
+
+
 def test_refresh_lifecycle_configured_extension_failure_blocks_delivery(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- add an explicit, project-local opt-in for delivering LoopX-selected human gates to an existing Lark Goal Channel
- run delivery after successful non-dry-run `refresh-state` writeback, using canonical status/quota as the trigger and the configured bot as the sender
- preserve LoopX as the source of truth: chat replies provide context only and do not approve or mutate gates
- reuse Goal Channel identity verification, gate-scoped idempotency, cooldown, provider idempotency keys, message readback, and private receipts
- fail closed when a previously enabled sink loses its extension, support per-refresh suppression, and keep local recovery disable available
- add a real CLI `refresh-state` smoke, quality-surface/profile coverage, English/Chinese RFC updates, and simplify the lifecycle to one delivery call
- rebase onto the shared provider-target layer from #2884 so target-linked goals resolve chat/sender from runtime targets while keeping receipts, Kanban, cooldown, and control messages goal-local

## Issue Or Task

- Related RFC: #2817
- Contributor task ID:

## Validation

- [x] `python3 -m py_compile loopx/*.py`
- [x] `loopx check --scan-root .`
- [x] Other:
  - `pytest -q tests/extensions tests/cli_commands/test_project_lifecycle_goal_channel.py tests/test_cli_argument_diagnostics.py` — 263 passed
  - `python examples/lark-goal-channel-human-gate-delivery-smoke.py`
  - `loopx canary smoke-suite --profile extension-runtime` — 10/10 passed
  - `mkdocs build --strict`
  - exact-scope `loopx canary premerge --tier standard` — 9 catalog checks, 8 risk-profile smokes, public-boundary scan, 0 manual holds
  - real Lark bot transport smoke completed separately with send and message readback verification

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
