### PR TITLE
fix(quota): honor allowed_slots=0 as a real cap instead of unlimited

### DIFF
--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -508,7 +508,7 @@ def quota_status(
         payload["blocked_action_scope"] = "delivery_focus"
         payload["focus_wait"] = True
     elif waiting_on == "codex":
-        if allowed_slots > 0 and spent_slots >= allowed_slots:
+        if spent_slots >= allowed_slots:
             state = "throttled"
             reason = f"{compute:g} compute quota spent {spent_slots}/{allowed_slots} slots in this window"
         else:

--- a/tests/control_plane/test_quota_zero_allowed_slots.py
+++ b/tests/control_plane/test_quota_zero_allowed_slots.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import pytest
+
+from loopx.quota import goal_quota_config, quota_status
+
+
+GOAL_ID = "zero-allowed-slots-fixture"
+
+
+def _goal(**quota: object) -> dict[str, object]:
+    return {
+        "id": GOAL_ID,
+        "quota": {
+            "compute": 1.0,
+            "window_hours": 24,
+            "slot_minutes": 1,
+            **quota,
+        },
+    }
+
+
+@pytest.mark.parametrize("spent_slots", [0, 1, 99])
+def test_zero_allowed_slots_throttles_instead_of_running_unbounded(
+    spent_slots: int,
+) -> None:
+    """`allowed_slots: 0` is the strictest cap, not an absence of one.
+
+    `docs/quota-allocation.md` documents `allowed_slots` as an explicit override
+    for "a deliberately stricter experimental cap", and states that
+    `spent_slots >= allowed_slots` must project `throttled`. Treating 0 as
+    unlimited inverts the operator's intent on the safety mechanism itself.
+    """
+
+    payload = quota_status(
+        _goal(allowed_slots=0, spent_slots=spent_slots), waiting_on="codex"
+    )
+
+    assert payload["allowed_slots"] == 0, payload
+    assert payload["state"] == "throttled", payload
+    assert "0" in payload["reason"], payload
+
+
+@pytest.mark.parametrize(
+    ("allowed_slots", "spent_slots", "expected"),
+    [
+        (1, 0, "eligible"),
+        (1, 1, "throttled"),
+        (10, 9, "eligible"),
+        (10, 10, "throttled"),
+        (10, 11, "throttled"),
+    ],
+)
+def test_nonzero_allowed_slots_boundary_is_unchanged(
+    allowed_slots: int, spent_slots: int, expected: str
+) -> None:
+    payload = quota_status(
+        _goal(allowed_slots=allowed_slots, spent_slots=spent_slots),
+        waiting_on="codex",
+    )
+
+    assert payload["state"] == expected, payload
+
+
+def test_zero_compute_still_reports_paused_not_throttled() -> None:
+    """`compute: 0` is the pause control and keeps precedence over the cap."""
+
+    payload = quota_status(
+        _goal(compute=0, allowed_slots=0, spent_slots=5), waiting_on="codex"
+    )
+
+    assert payload["state"] == "paused", payload
+
+
+def test_window_derived_default_stays_eligible_for_normal_config() -> None:
+    """The documented default must not collapse to a throttling cap."""
+
+    config = goal_quota_config(_goal(compute=0.01))
+
+    assert config["allowed_slots"] == 14, config
+    assert (
+        quota_status(_goal(compute=0.01, spent_slots=0), waiting_on="codex")["state"]
+        == "eligible"
+    )


### PR DESCRIPTION
## Summary

- Drop the `allowed_slots > 0` guard in `quota_status`, so a zero cap throttles
  instead of short-circuiting to `eligible`.
- Add focused regression coverage for the zero cap, the non-zero boundary, and
  `paused` precedence.

Production diff is one line. The rest is tests.

## Issue Or Task

- Closes #2876
- Contributor task ID: n/a (fail-open found by review)

## What Changed

`loopx/quota.py:511`:

```diff
-        if allowed_slots > 0 and spent_slots >= allowed_slots:
+        if spent_slots >= allowed_slots:
```

`allowed_slots > 0` was the only place in the module that special-cased zero, so
`spent_slots=99, allowed_slots=0` projected `eligible`. Because `state` feeds
`normal_delivery_allowed` (`quota.py:1551`) and `eligible_spend`
(`control_plane/quota/slot_accounting.py:443`), the setting that most obviously
means "spend nothing" left every downstream gate green while `spent_slots` grew
without bound.

`docs/quota-allocation.md:1115` already states the intended contract — 
`spent_slots >= allowed_slots` must project `throttled` — and
`docs/quota-allocation.md:98` lists "a deliberately stricter experimental cap" as
a reason to set `allowed_slots` explicitly. So this restores documented behavior
rather than introducing new behavior; no doc change is needed.

`compute <= 0` is handled earlier (`quota.py:486`) and is untouched, so `paused`
keeps precedence and a goal can no longer sit at `compute: 1.0` with
`allowed_slots: 0` and stay eligible forever.

## Behavior Change Worth Your Call

`allowed_slots` can also reach 0 without an explicit override, since the default
is rounded (`quota.py:398`). With the shipped defaults (`window_hours=24`,
`slot_minutes=1`) that is unreachable — `compute=0.01` still yields 14, and
`compute<=0` is caught by `paused` first — so it requires the documented
"non-minute scheduler" case, e.g. `window_hours=1, slot_minutes=60, compute=0.4`
→ `round(0.4)` → `0`.

Those configurations move from *silently unlimited* to *throttled*. I believe
throttled is the correct reading of "zero slots" and it is the fail-closed
direction for a spend limiter, but if you would rather the window-derived default
floor at 1 when `compute > 0`, that is a product decision — say the word and I
will follow up. I deliberately left the derivation untouched here to keep this
diff to the fail-open itself.

## Validation

Run on Linux / CPython 3.11 (CI is ubuntu-only), container run as a non-root user.

- [x] `python -m ruff check loopx/quota.py tests/control_plane/test_quota_zero_allowed_slots.py` — clean
- [x] `python -m mypy` — `Success: no issues found in 15 source files`
- [x] `python -m pytest -q tests/control_plane/test_quota_zero_allowed_slots.py` — 10 passed
- [x] quota-adjacent suites — 50 passed (`test_quota_slot_accounting`, `test_quota_plan_policy`, `test_quota_run_decision`, `test_quota_paused_precedence`, `test_quota_markdown_renderers`)
- [x] `git diff --check` — clean

The production change is a single line inside one `elif` branch of `quota_status`;
the tests above exercise that branch and its neighbours (non-zero boundary,
`paused` precedence, the window-derived default). I scoped validation to that
blast radius rather than re-running the whole suite for a one-line guard removal.

Behavior before/after, same fixture:

```
                     before        after
allowed=1 spent=  1  throttled     throttled     <- unchanged
allowed=0 spent=  0  eligible      throttled
allowed=0 spent=  1  eligible      throttled
allowed=0 spent= 99  eligible      throttled
```

## Tests

`tests/control_plane/test_quota_zero_allowed_slots.py`, 10 cases. The 3 zero-cap
cases fail on `main` and pass here; the other 7 pass on **both**, which is the
point — they pin that the non-zero boundary, `paused` precedence, and the
window-derived default are all unaffected by the change.

- `test_zero_allowed_slots_throttles_instead_of_running_unbounded[0|1|99]` — the fail-open itself.
- `test_nonzero_allowed_slots_boundary_is_unchanged` — `(1,0)`, `(1,1)`, `(10,9)`, `(10,10)`, `(10,11)`; guards against turning this into an off-by-one.
- `test_zero_compute_still_reports_paused_not_throttled` — `compute: 0` keeps precedence over the cap.
- `test_window_derived_default_stays_eligible_for_normal_config` — a normal `compute=0.01` goal still derives 14 slots and stays `eligible`.

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
