### PR TITLE
feat(turn): govern validated Todo completion

### DIFF
--- a/docs/reference/protocols/loopx-turn-v0.md
+++ b/docs/reference/protocols/loopx-turn-v0.md
@@ -312,6 +312,15 @@ Every attempted tick returns one result kind:
 | `validation_failed` | Host output exists but task validation failed or is inconclusive. | Preserve failure evidence and route to repair/replan. |
 | `writeback_failed` | Validated work could not be durably recorded. | Do not spend; retry idempotent writeback before more delivery. |
 
+`validated_completion` is admitted only when the Turn caller supplies an
+explicit Todo lifecycle adapter. After independent validation, the adapter must
+authorize and complete the selected Todo through the existing Todo lifecycle,
+then return a compact outcome for that same Todo: linked successors, an
+authorized `no_followup` record, or `active_goal` continuation. The durable
+Turn journal records that outcome before quota spend. A Todo completion alone
+never terminates the goal; a fresh decision owns successor selection and goal
+termination.
+
 `repair_required` and `replan_required` are distinct. Repair preserves the
 current task intent. Replan changes the runnable todo set or route because the
 existing task no longer advances the goal. Replan is required when any of the

--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -27,7 +27,7 @@ from ..control_plane.runtime.status_projection_cache import (
 from ..quota import spend_quota_slot
 from ..state_refresh import refresh_state_run
 from ..status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, collect_status
-from ..todos import update_goal_todo
+from ..todos import complete_goal_todo, update_goal_todo
 from .lark_inbox import build_lark_operator_inbox_urgency_projector
 
 
@@ -484,6 +484,42 @@ def handle_turn_command(
                     sync_global=not bool(args.no_global_sync),
                 )
 
+            def completion_writeback(result: dict[str, object]) -> dict[str, object]:
+                todo_id = str(selected_todo.get("todo_id") or "")
+                if not todo_id:
+                    raise ValueError(
+                        "validated_completion requires one selected todo for lifecycle writeback"
+                    )
+                completion = complete_goal_todo(
+                    registry_path=registry_path,
+                    goal_id=args.goal_id,
+                    todo_id=todo_id,
+                    role="agent",
+                    completion_turn_key=str(result["turn_key"]),
+                    evidence=(
+                        "LoopX Turn validated completion: "
+                        + str(result.get("summary") or result["classification"])
+                    ),
+                    note=str(result["next_action"]),
+                    agent_id=args.agent_id,
+                    project=None,
+                    dry_run=False,
+                )
+                refresh = writeback(result)
+                return {
+                    "ok": bool(completion.get("ok")) and bool(refresh.get("ok")),
+                    # A completed Todo is idempotent under Turn replay: after an
+                    # interrupted journal write, the retry may observe it done.
+                    "appended": bool(completion.get("completed")) and bool(
+                        refresh.get("appended")
+                    ),
+                    "classification": refresh.get("classification"),
+                    "completion": {
+                        "todo_id": completion.get("todo_id"),
+                        "continuation": "active_goal",
+                    },
+                }
+
             def current_status() -> dict[str, object]:
                 return collect_status(
                     registry_path=registry_path,
@@ -562,6 +598,7 @@ def handle_turn_command(
                 retry_failed=bool(args.retry_failed_turn),
                 task_validator=task_validator,
                 writeback=writeback if args.execute else None,
+                completion_writeback=completion_writeback if args.execute else None,
                 spend=spend if args.execute else None,
                 scheduler=scheduler if args.execute else None,
             )

--- a/loopx/control_plane/todos/contract.py
+++ b/loopx/control_plane/todos/contract.py
@@ -1074,7 +1074,14 @@ _TODO_METADATA_FIELD_SCHEMA = (
             _nonempty_metadata_text,
             write_normalizer=_truthy_value,
         )
-        for key in ("note", "evidence", "reason", "completed_at", "updated_at")
+        for key in (
+            "note",
+            "evidence",
+            "reason",
+            "completed_at",
+            "updated_at",
+            "completion_turn_key",
+        )
     ),
     _TodoMetadataField(
         "superseded_by",
@@ -1207,6 +1214,7 @@ def format_todo_metadata_line(
     max_no_change_before_replan: str | None = None,
     note: str | None = None,
     evidence: str | None = None,
+    completion_turn_key: str | None = None,
     reason: str | None = None,
     completed_at: str | None = None,
     updated_at: str | None = None,

--- a/loopx/control_plane/todos/event_writeback.py
+++ b/loopx/control_plane/todos/event_writeback.py
@@ -319,6 +319,7 @@ def complete_event_projected_goal_todo(
     registered_agents: list[str],
     updated_at: str,
     dry_run: bool,
+    completion_turn_key: str | None = None,
 ) -> dict[str, Any]:
     item = dict(context["item"])
     role = str(context["role"])
@@ -400,6 +401,8 @@ def complete_event_projected_goal_todo(
     }
     if evidence:
         completion_payload["evidence"] = evidence
+    if completion_turn_key:
+        completion_payload["completion_turn_key"] = completion_turn_key
     if note:
         completion_payload["note"] = note
     if no_followup:

--- a/loopx/control_plane/todos/line_update.py
+++ b/loopx/control_plane/todos/line_update.py
@@ -70,6 +70,7 @@ def apply_todo_update_to_lines(
     role: str | None = None,
     note: str | None = None,
     evidence: str | None = None,
+    completion_turn_key: str | None = None,
     reason: str | None = None,
     task_class: str | None = None,
     action_kind: str | None = None,
@@ -173,6 +174,7 @@ def apply_todo_update_to_lines(
     for key, value in (
         ("note", note),
         ("evidence", evidence),
+        ("completion_turn_key", completion_turn_key),
         ("reason", reason),
         ("task_class", task_class),
         ("action_kind", action_kind),

--- a/loopx/control_plane/turn_driver/executor.py
+++ b/loopx/control_plane/turn_driver/executor.py
@@ -44,6 +44,7 @@ TURN_KEY_RE = re.compile(r"^sha256:(?P<digest>[0-9a-f]{64})$")
 
 MATERIAL_HOST_RESULT_KINDS = {
     LoopXTurnResultKind.VALIDATED_PROGRESS,
+    LoopXTurnResultKind.VALIDATED_COMPLETION,
     LoopXTurnResultKind.REPAIR_REQUIRED,
     LoopXTurnResultKind.REPLAN_REQUIRED,
 }
@@ -68,6 +69,7 @@ HOST_RESULT_FIELDS = {
 }
 
 Writeback = Callable[[dict[str, Any]], dict[str, Any]]
+CompletionWriteback = Callable[[dict[str, Any]], dict[str, Any]]
 Spend = Callable[[], dict[str, Any]]
 Scheduler = Callable[[dict[str, Any]], dict[str, Any]]
 HostRunner = Callable[[Mapping[str, Any]], dict[str, Any]]
@@ -236,6 +238,8 @@ def _normalize_host_path_delta(
 def validate_loopx_turn_host_result(
     plan: Mapping[str, Any],
     value: Mapping[str, Any],
+    *,
+    completion_writeback_configured: bool = False,
 ) -> dict[str, Any]:
     result = dict(value)
     errors: list[str] = []
@@ -255,7 +259,10 @@ def validate_loopx_turn_host_result(
     except ValueError:
         kind = None
         errors.append("unsupported host result kind")
-    if kind is LoopXTurnResultKind.VALIDATED_COMPLETION:
+    if (
+        kind is LoopXTurnResultKind.VALIDATED_COMPLETION
+        and not completion_writeback_configured
+    ):
         errors.append("validated_completion requires a todo lifecycle adapter")
     if kind not in MATERIAL_HOST_RESULT_KINDS | STOP_HOST_RESULT_KINDS:
         if kind is not LoopXTurnResultKind.VALIDATED_COMPLETION:
@@ -731,6 +738,7 @@ def _host_result_stage(
     *,
     host_runner: HostRunner | None,
     argv: Sequence[str] | None,
+    completion_writeback_configured: bool,
     project: Path,
     timeout_seconds: float,
     journal: dict[str, Any],
@@ -785,7 +793,11 @@ def _host_result_stage(
         result = dict(host_observation["value"])
         completed_phases = list(TRANSACTION_PHASES[:2])
 
-    validation = validate_loopx_turn_host_result(plan, result or {})
+    validation = validate_loopx_turn_host_result(
+        plan,
+        result or {},
+        completion_writeback_configured=completion_writeback_configured,
+    )
     if not validation.get("ok"):
         failure = _host_failure(
             plan,
@@ -918,6 +930,41 @@ def _task_validation_stage(
     return completed_phases, None
 
 
+def _completion_writeback_outcome(
+    payload: Mapping[str, Any],
+    *,
+    plan: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    completion = payload.get("completion")
+    if not isinstance(completion, Mapping):
+        return None
+    envelope = plan.get("turn_envelope")
+    action = envelope.get("action") if isinstance(envelope, Mapping) else None
+    selected_todo = action.get("selected_todo") if isinstance(action, Mapping) else None
+    expected_todo_id = (
+        str(selected_todo.get("todo_id") or "")
+        if isinstance(selected_todo, Mapping)
+        else ""
+    )
+    todo_id = str(completion.get("todo_id") or "")
+    continuation = completion.get("continuation")
+    if not expected_todo_id or todo_id != expected_todo_id:
+        return None
+    if continuation not in {"successor", "no_followup", "active_goal"}:
+        return None
+    outcome = {"todo_id": todo_id, "continuation": continuation}
+    if continuation == "successor":
+        successor_todo_ids = completion.get("successor_todo_ids")
+        if (
+            not isinstance(successor_todo_ids, list)
+            or not successor_todo_ids
+            or not all(isinstance(item, str) and item for item in successor_todo_ids)
+        ):
+            return None
+        outcome["successor_todo_ids"] = list(successor_todo_ids)
+    return outcome
+
+
 def _transaction_closeout_stage(
     plan: Mapping[str, Any],
     result: dict[str, Any],
@@ -927,11 +974,32 @@ def _transaction_closeout_stage(
     journal_path: Path,
     effects: dict[str, bool],
     writeback: Writeback,
+    completion_writeback: CompletionWriteback | None,
     spend: Spend,
     scheduler: Scheduler,
 ) -> dict[str, Any]:
     if "durable_writeback" not in completed_phases:
-        writeback_payload = writeback(result)
+        if result.get("result_kind") == LoopXTurnResultKind.VALIDATED_COMPLETION.value:
+            if completion_writeback is None:
+                raise ValueError("validated_completion requires a todo lifecycle adapter")
+            writeback_payload = completion_writeback(result)
+            completion_outcome = _completion_writeback_outcome(
+                writeback_payload,
+                plan=plan,
+            )
+            if completion_outcome is None:
+                writeback_payload = {
+                    "ok": False,
+                    "appended": False,
+                    "reason": "todo lifecycle adapter returned an invalid completion outcome",
+                }
+            else:
+                writeback_payload = {
+                    **writeback_payload,
+                    "completion": completion_outcome,
+                }
+        else:
+            writeback_payload = writeback(result)
         if not writeback_payload.get("ok") or not writeback_payload.get("appended"):
             failure = _host_failure(
                 plan,
@@ -961,7 +1029,14 @@ def _transaction_closeout_stage(
         completed_phases = list(TRANSACTION_PHASES[:4])
         journal.update(
             completed_phases=completed_phases,
-            writeback=_compact_callback(writeback_payload),
+            writeback={
+                **_compact_callback(writeback_payload),
+                **(
+                    {"completion": writeback_payload["completion"]}
+                    if isinstance(writeback_payload.get("completion"), dict)
+                    else {}
+                ),
+            },
         )
         _write_journal(journal_path, journal)
 
@@ -1048,6 +1123,7 @@ def run_loopx_turn_once(
     retry_failed: bool = False,
     task_validator: TaskValidator | None = None,
     writeback: Writeback | None = None,
+    completion_writeback: CompletionWriteback | None = None,
     spend: Spend | None = None,
     scheduler: Scheduler | None = None,
 ) -> dict[str, Any]:
@@ -1139,6 +1215,7 @@ def run_loopx_turn_once(
             request,
             host_runner=host_runner,
             argv=argv,
+            completion_writeback_configured=completion_writeback is not None,
             project=project,
             timeout_seconds=timeout_seconds,
             journal=journal,
@@ -1169,6 +1246,7 @@ def run_loopx_turn_once(
             journal_path=journal_path,
             effects=effects,
             writeback=writeback,
+            completion_writeback=completion_writeback,
             spend=spend,
             scheduler=scheduler,
         )

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -1533,6 +1533,7 @@ def complete_goal_todo(
     role: str | None = None,
     decision_outcome: str | None = None,
     evidence: str | None = None,
+    completion_turn_key: str | None = None,
     note: str | None = None,
     no_followup: bool = False,
     successor_todo_ids: list[str] | None = None,
@@ -1630,6 +1631,28 @@ def complete_goal_todo(
             decision_outcome=effective_decision_outcome,
             decision_target=decision_target,
         )
+        existing_completion_turn_key = str(
+            completion_todo.get("completion_turn_key") or ""
+        )
+        if completion_match and str(completion_todo.get("status") or "") == TODO_STATUS_DONE:
+            if completion_turn_key and completion_turn_key == existing_completion_turn_key:
+                return {
+                    "ok": True,
+                    "dry_run": dry_run,
+                    "completed": True,
+                    "idempotent_replay": True,
+                    "changed": False,
+                    "goal_id": goal_id,
+                    "todo_id": todo_id,
+                    "status": TODO_STATUS_DONE,
+                    "mutation_authority": mutation_authority,
+                    "state_file": str(resolved_state_file),
+                    "project": str(resolved_project) if resolved_project else None,
+                }
+            if completion_turn_key:
+                raise ValueError(
+                    "todo is already completed under a different completion_turn_key"
+                )
         normalized_successor_todo_ids = normalize_todo_id_list(successor_todo_ids)
         if successor_todo_ids and not normalized_successor_todo_ids:
             raise ValueError("successor_todo_ids must contain public todo_<letters-digits-underscore-hyphen> tokens")
@@ -1690,6 +1713,7 @@ def complete_goal_todo(
                     goal_id=goal_id,
                     context=event_context,
                     evidence=evidence,
+                    completion_turn_key=completion_turn_key,
                     note=note,
                     no_followup=no_followup,
                     successor_todo_ids=normalized_successor_todo_ids,
@@ -1721,6 +1745,7 @@ def complete_goal_todo(
             decision_outcome=effective_decision_outcome,
             note=note,
             evidence=evidence,
+            completion_turn_key=completion_turn_key,
             claimed_by=effective_claimed_by,
             clear_claim=clear_claim,
             no_followup=True if no_followup else None,

--- a/tests/test_loopx_turn_driver.py
+++ b/tests/test_loopx_turn_driver.py
@@ -22,6 +22,7 @@ from loopx.control_plane.turn_driver import (
 )
 from loopx.control_plane.turn_driver.codex_cli import _store_codex_cli_session
 from loopx.control_plane.quota.live_decision import bind_scheduler_followup_cli_routes
+from loopx.todos import complete_goal_todo
 
 
 def _envelope(
@@ -1134,6 +1135,120 @@ raise SystemExit(0 if artifact.read_text(encoding="utf-8") == "validated" else 7
         "fixture_progress",
         "quota_slot_spent",
     ]
+
+
+def test_turn_run_once_cli_completes_selected_todo_after_validation(
+    tmp_path: Path,
+) -> None:
+    project, runtime, registry = _write_live_fixture(tmp_path)
+    host_project = tmp_path / "isolated-host-workspace"
+    host_project.mkdir()
+    host_script = """
+import json
+import pathlib
+import sys
+request = json.load(sys.stdin)
+pathlib.Path("completion-artifact.txt").write_text("completed", encoding="utf-8")
+json.dump({
+    "schema_version": "loopx_turn_result_v0",
+    "turn_key": request["turn_key"],
+    "result_kind": "validated_completion",
+    "completed_phases": ["host_execute", "typed_result"],
+    "classification": "fixture_completion",
+    "recommended_action": "Refresh the active goal after completion.",
+    "next_action": "Select the next Todo from a fresh decision.",
+    "delivery_batch_scale": "implementation",
+    "delivery_outcome": "outcome_progress",
+    "vision_unchanged_reason": "The active goal may have further work.",
+    "summary": "One public fixture completed."
+}, sys.stdout)
+"""
+    validation_script = """
+import json
+import pathlib
+import sys
+json.load(sys.stdin)
+artifact = pathlib.Path("completion-artifact.txt")
+raise SystemExit(0 if artifact.read_text(encoding="utf-8") == "completed" else 7)
+"""
+    output = io.StringIO()
+    argv = [
+        "--registry",
+        str(registry),
+        "--runtime-root",
+        str(runtime),
+        "--format",
+        "json",
+        "turn",
+        "run-once",
+        "--goal-id",
+        "loopx-turn-fixture",
+        "--agent-id",
+        "codex-fixture",
+        "--project",
+        str(host_project),
+        "--host-adapter-command-json",
+        json.dumps([sys.executable, "-c", host_script]),
+        "--validation-command-json",
+        json.dumps([sys.executable, "-c", validation_script]),
+        "--scan-root",
+        str(project),
+        "--no-global-sync",
+        "--execute",
+    ]
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(argv)
+
+    payload = json.loads(output.getvalue())
+    assert exit_code == 0, payload
+    assert payload["status"] == "committed"
+    assert payload["effects"]["state_written"] is True
+    assert payload["effects"]["quota_spent"] is True
+    journal_path = next(
+        (runtime / "goals" / "loopx-turn-fixture" / "turns").glob("*.json")
+    )
+    journal = json.loads(journal_path.read_text(encoding="utf-8"))
+    assert journal["writeback"]["completion"] == {
+        "todo_id": "todo_fixture0001",
+        "continuation": "active_goal",
+    }
+    state_path = (
+        project
+        / ".codex"
+        / "goals"
+        / "loopx-turn-fixture"
+        / "ACTIVE_GOAL_STATE.md"
+    )
+    state = state_path.read_text(encoding="utf-8")
+    assert "todo_id=todo_fixture0001 status=done" in state
+    assert "LoopX%20Turn%20validated%20completion" in state
+    assert f"completion_turn_key={payload['resume_turn_key']}" in state
+
+    recovered_completion = complete_goal_todo(
+        registry_path=registry,
+        goal_id="loopx-turn-fixture",
+        todo_id="todo_fixture0001",
+        role="agent",
+        agent_id="codex-fixture",
+        completion_turn_key=payload["resume_turn_key"],
+    )
+    assert recovered_completion["idempotent_replay"] is True
+    assert recovered_completion["changed"] is False
+
+    replayed_output = io.StringIO()
+    with contextlib.redirect_stdout(replayed_output):
+        replayed_exit_code = cli_main(
+            [
+                *argv[:-1],
+                "--resume-turn-key",
+                payload["resume_turn_key"],
+                "--execute",
+            ]
+        )
+    replayed = json.loads(replayed_output.getvalue())
+    assert replayed_exit_code == 0, replayed
+    assert replayed["replayed"] is True
+    assert not any(replayed["effects"].values())
 
 
 def test_turn_run_once_commits_independently_validated_progress(

--- a/tests/test_loopx_turn_executor.py
+++ b/tests/test_loopx_turn_executor.py
@@ -58,15 +58,31 @@ def _host_result(plan: dict[str, object], *, kind: str = "validated_progress") -
         "result_kind": kind,
         "completed_phases": ["host_execute", "typed_result"],
     }
-    if kind == "validated_progress":
+    if kind in {"validated_progress", "validated_completion"}:
         result.update(
-            classification="fixture_progress",
-            recommended_action="Continue the public fixture",
-            next_action="Run the next public fixture check",
+            classification=(
+                "fixture_progress"
+                if kind == "validated_progress"
+                else "fixture_completion"
+            ),
+            recommended_action=(
+                "Continue the public fixture."
+                if kind == "validated_progress"
+                else "Refresh the active goal after this Todo completion."
+            ),
+            next_action=(
+                "Run the next public fixture check."
+                if kind == "validated_progress"
+                else "Select the next Todo from a fresh decision."
+            ),
             delivery_batch_scale="implementation",
             delivery_outcome="outcome_progress",
             vision_unchanged_reason="The fixture objective is unchanged after validated progress.",
-            summary="One public fixture advanced.",
+            summary=(
+                "One public fixture advanced."
+                if kind == "validated_progress"
+                else "One public fixture completed."
+            ),
         )
     return result
 
@@ -250,6 +266,195 @@ def test_run_once_commits_once_and_replays_without_duplicate_effects(tmp_path: P
     assert not any(replay["effects"].values())
     assert count_path.read_text(encoding="utf-8") == "1"
     assert calls == {"writeback": 1, "spend": 1, "scheduler": 1}
+
+
+def test_validated_completion_requires_explicit_lifecycle_writeback(
+    tmp_path: Path,
+) -> None:
+    plan = _plan()
+    result_path = tmp_path / "result.json"
+    result_path.write_text(
+        json.dumps(_host_result(plan, kind="validated_completion")),
+        encoding="utf-8",
+    )
+    calls = {"writeback": 0, "completion": 0, "spend": 0, "scheduler": 0}
+
+    def writeback(_result: dict[str, object]) -> dict[str, object]:
+        calls["writeback"] += 1
+        return {"ok": True, "appended": True}
+
+    def spend() -> dict[str, object]:
+        calls["spend"] += 1
+        return {"ok": True, "appended": True}
+
+    def scheduler(_spend: dict[str, object]) -> dict[str, object]:
+        calls["scheduler"] += 1
+        return {"completed": True, "acknowledged": True}
+
+    payload = run_loopx_turn_once(
+        plan,
+        host_argv=_host_argv(result_path, tmp_path / "host-count"),
+        project=tmp_path,
+        runtime_root=tmp_path / "runtime",
+        goal_id="fixture-goal",
+        timeout_seconds=5,
+        execute=True,
+        task_validator=_passing_validator,
+        writeback=writeback,
+        spend=spend,
+        scheduler=scheduler,
+    )
+
+    assert payload["result_kind"] == "validation_failed"
+    assert payload["receipt"]["failed_phase"] == "validation"
+    assert calls == {"writeback": 0, "completion": 0, "spend": 0, "scheduler": 0}
+
+
+def test_validated_completion_commits_once_with_lifecycle_outcome(
+    tmp_path: Path,
+) -> None:
+    plan = _plan()
+    result_path = tmp_path / "result.json"
+    result_path.write_text(
+        json.dumps(_host_result(plan, kind="validated_completion")),
+        encoding="utf-8",
+    )
+    calls = {"writeback": 0, "completion": 0, "spend": 0, "scheduler": 0}
+    writeback, spend, scheduler = _callbacks(calls)
+
+    def completion_writeback(_result: dict[str, object]) -> dict[str, object]:
+        calls["completion"] += 1
+        return {
+            "ok": True,
+            "appended": True,
+            "completion": {
+                "todo_id": "todo_fixture0001",
+                "continuation": "active_goal",
+            },
+        }
+
+    kwargs = {
+        "host_argv": _host_argv(result_path, tmp_path / "host-count"),
+        "project": tmp_path,
+        "runtime_root": tmp_path / "runtime",
+        "goal_id": "fixture-goal",
+        "timeout_seconds": 5,
+        "execute": True,
+        "task_validator": _passing_validator,
+        "writeback": writeback,
+        "completion_writeback": completion_writeback,
+        "spend": spend,
+        "scheduler": scheduler,
+    }
+    first = run_loopx_turn_once(plan, **kwargs)
+    replay = run_loopx_turn_once(plan, **kwargs)
+
+    assert first["status"] == "committed"
+    assert first["effects"]["state_written"] is True
+    assert first["effects"]["quota_spent"] is True
+    assert replay["replayed"] is True
+    assert not any(replay["effects"].values())
+    assert calls == {"writeback": 0, "completion": 1, "spend": 1, "scheduler": 1}
+    assert _journal(tmp_path / "runtime")["writeback"]["completion"] == {
+        "todo_id": "todo_fixture0001",
+        "continuation": "active_goal",
+    }
+
+
+def test_invalid_completion_outcome_fails_closed_without_spending(
+    tmp_path: Path,
+) -> None:
+    plan = _plan()
+    calls = {"completion": 0, "spend": 0, "scheduler": 0}
+    writeback, _spend, _scheduler = _callbacks(calls)
+
+    def completion_writeback(_result: dict[str, object]) -> dict[str, object]:
+        calls["completion"] += 1
+        return {
+            "ok": True,
+            "appended": True,
+            "completion": {"todo_id": "todo_other", "continuation": "active_goal"},
+        }
+
+    payload = run_loopx_turn_once(
+        plan,
+        host_runner=lambda _request: _host_result(plan, kind="validated_completion"),
+        project=tmp_path,
+        runtime_root=tmp_path / "runtime",
+        goal_id="fixture-goal",
+        timeout_seconds=5,
+        execute=True,
+        task_validator=_passing_validator,
+        writeback=writeback,
+        completion_writeback=completion_writeback,
+        spend=lambda: calls.__setitem__("spend", calls["spend"] + 1) or {
+            "ok": True,
+            "appended": True,
+        },
+        scheduler=lambda _spend: calls.__setitem__("scheduler", calls["scheduler"] + 1)
+        or {"completed": True, "acknowledged": True},
+    )
+
+    assert payload["receipt"]["result_kind"] == "writeback_failed"
+    assert payload["receipt"]["failed_phase"] == "durable_writeback"
+    assert calls == {"completion": 1, "spend": 0, "scheduler": 0}
+
+
+def test_validated_completion_recovers_after_writeback_without_repeating_completion(
+    tmp_path: Path,
+) -> None:
+    plan = _plan()
+    calls = {"completion": 0, "spend": 0, "scheduler": 0}
+
+    def completion_writeback(_result: dict[str, object]) -> dict[str, object]:
+        calls["completion"] += 1
+        return {
+            "ok": True,
+            "appended": True,
+            "completion": {
+                "todo_id": "todo_fixture0001",
+                "continuation": "active_goal",
+            },
+        }
+
+    def interrupted_spend() -> dict[str, object]:
+        calls["spend"] += 1
+        raise SystemExit(8)
+
+    def scheduler(_spend: dict[str, object]) -> dict[str, object]:
+        calls["scheduler"] += 1
+        return {"completed": True, "acknowledged": True}
+
+    def healthy_spend() -> dict[str, object]:
+        calls["spend"] += 1
+        return {"ok": True, "appended": True}
+
+    common = {
+        "host_runner": lambda _request: _host_result(
+            plan,
+            kind="validated_completion",
+        ),
+        "project": tmp_path,
+        "runtime_root": tmp_path / "runtime",
+        "goal_id": "fixture-goal",
+        "timeout_seconds": 5,
+        "execute": True,
+        "task_validator": _passing_validator,
+        "writeback": lambda _result: {"ok": True, "appended": True},
+        "completion_writeback": completion_writeback,
+        "scheduler": scheduler,
+    }
+    with pytest.raises(SystemExit):
+        run_loopx_turn_once(plan, spend=interrupted_spend, **common)
+
+    recovered = run_loopx_turn_once(
+        plan,
+        spend=healthy_spend,
+        **common,
+    )
+
+    assert recovered["status"] == "committed"
+    assert calls == {"completion": 1, "spend": 2, "scheduler": 1}
 
 
 def test_run_once_recovers_after_process_exit_before_writeback(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #2837.

## Summary
- Admit `validated_completion` only through an explicit Todo lifecycle writeback adapter after independent validation.
- Complete the selected Todo through the existing authority path and persist its Turn lineage key, preventing recovery from repeating completion before quota spend.
- Record a compact continuation outcome, preserve goal-level fresh-decision authority, and document the protocol boundary.

## Validation
- `uv run --with pytest python -m pytest -q tests/test_loopx_turn_driver.py tests/test_loopx_turn_executor.py tests/test_loopx_turn_transaction.py tests/control_plane/test_todo_mutation_authority.py` (101 passed)
- `git diff --check`
- Bugbot: no findings
- IDE diagnostics: clean

## Changed surfaces and coverage rationale
- Turn executor admission, durable writeback, replay, recovery, and quota ordering are covered by executor and transaction tests.
- CLI completion, Todo authority, persisted lineage-key idempotency, and independent validation are covered by driver and Todo-authority tests.
- No benchmark jobs, permission-boundary changes, or private artifacts are included. Ruff was unavailable in this environment; focused tests, syntax compilation, diagnostics, and whitespace validation passed.