### PR TITLE
Auto Research: add terminal decisions and independent review

### DIFF
--- a/docs/reference/protocols/auto-research-lane-contract-v1.md
+++ b/docs/reference/protocols/auto-research-lane-contract-v1.md
@@ -25,8 +25,8 @@ research loop while LoopX stays decentralized?
 | Curator | `research_curator` | Defines or refreshes the public-safe research contract, metric, protected scope, and novelty boundary. | `research_contract_v0`, grounding refs. | Select winners, edit protected evaluators, or own executor queues. |
 | Hypothesis proposer | `hypothesis_proposer` | Proposes grounded, todo-backed hypotheses and parent-child refinements. | `research_hypothesis_v0`, agent todos, grounding refs. | Claim novelty from the same material used for ideation. |
 | Executor | `research_executor` | Runs one claimed hypothesis in an isolated worktree and produces split-aware results. | branch refs, eval result projections, `auto_research_evidence_packet_v0`. | Mutate protected scope, promote results, or hide failed attempts. |
-| Evaluator / promoter | `evaluator_promoter` | Converts scored attempts into promotion, retry, or retirement candidates under the contract policy. | `research_evidence_event_v0`, promotion or retirement candidate projections, gate todos. | Treat dev-only lift as promoted evidence or bypass owner gates. |
-| Product narrator | `product_narrator` | Renders the public-safe case story from projections for downstream product surfaces. | `research_evidence_graph_v0`, public docs, screenshots after first-screen review when needed. | Invent metrics, read private source bodies, or mutate source state. |
+| Evaluator / promoter | `evaluator_promoter` | Converts scored attempts into promotion, retry, or retirement candidates, then records an explicit terminal decision when the contract permits it. | `research_evidence_event_v0`, promotion or retirement candidate projections, `auto_research_terminal_decision_v0`, gate todos. | Treat dev-only lift as promoted evidence, bypass owner gates, or label its own review independent. |
+| Product narrator | `product_narrator` | Renders the public-safe case story from terminal decisions and projections for downstream product surfaces. | `research_evidence_graph_v0`, Explore result events, public docs, screenshots after first-screen review when needed. | Invent metrics, certify candidates as terminal, read private source bodies, or mutate research evidence. |
 
 No lane is privileged. A single Codex session may implement more than one role
 when it has the matching todo claim and boundary, but the graph must still show
@@ -99,9 +99,16 @@ there is no separate continuation projector or central research manager.
    agent-scoped quota or an explicitly claimed role-declared successor todo.
 4. An `evaluator_promoter` may promote only when dev evidence, held-out
    evidence, clean boundary, and required gates are present.
-5. A `product_narrator` may publish only from `research_evidence_graph_v0`
-   and related public-safe refs; first-screen public surface changes still obey
-   the first-screen review gate.
+5. A registered peer may claim independent review only when it differs from
+   both the hypothesis producer and terminal-decision agent, binds the exact
+   evidence-graph revision, and records `approve`, `reject`, or
+   `needs_more_evidence`. Review does not mutate research truth.
+6. A `product_narrator` may publish only from `research_evidence_graph_v0`,
+   an explicit terminal decision, and the current review projection;
+   independent approval is required for `confirmed` or `refuted` findings.
+   Without it, the finding remains `tentative`. Related evidence must stay
+   public-safe, and first-screen public surface changes still obey the
+   first-screen review gate.
 
 ## Gates
 
@@ -123,6 +130,11 @@ Promotion and retirement are both useful outcomes:
   guardrail failure, or repeated retry exhaustion;
 - retry candidate: unscored but resumable attempt with a branch/ref and
   `needs_retry` evidence.
+- terminal decision: a separate evidence-revision-bound `promoted` or
+  `retired` record; candidate status alone never creates one;
+- peer review: a separate receipt over the current terminal decision. A
+  same-agent review is visible but cannot produce a confirmed or refuted
+  finding.
 
 The product board should show all three. The user should see which result is
 worth merging, which direction saved future search time by failing clearly, and
@@ -137,6 +149,12 @@ An implementation satisfies this lane contract when:
   quota selection;
 - promotion and retirement candidates are derived from
   `research_evidence_graph_v0`, not fixture-only prose;
+- terminal results can be queried by exact hypothesis id, including history,
+  without loading raw transcripts;
+- stale evidence revisions and conflicting terminal decisions fail closed to a
+  tentative or blocked projection;
+- independent-review claims require a different registered peer and never
+  rewrite scored evidence or terminal decisions;
 - grounded ideation and novelty audit remain separate lanes;
 - no public surface needs a leader or coordinator agent to explain ownership;
 - public docs and projections contain no raw logs, private paths, credentials,

--- a/docs/reference/protocols/auto-research-role-state-machine-v0.md
+++ b/docs/reference/protocols/auto-research-role-state-machine-v0.md
@@ -35,7 +35,7 @@ cleanup are transition duties rather than separate permanent workers.
 | Research curator | `research_curator` | Keep the objective, editable scope, protected scope, metric, stop policy, and operator gates explicit. | `research_contract_v0`, protected-boundary notes, owner gate todos, public projection requests. | Pick winners, run experiments, or publish unsupported claims. |
 | Hypothesis proposer | `hypothesis_proposer` | Turn research ideas into todo-backed hypotheses, parent links, mechanism families, and bounded retire/successor decisions. | `research_hypothesis_v0`, successor todos, grounding refs, no-follow-up rationale. | Claim novelty from the same source used to ideate or delete negative evidence. |
 | Research executor | `research_executor` | Execute selected hypotheses in isolated worktrees and preserve dev or held-out attempt evidence. | branch refs, `research_evidence_event_v0`, retry packets. | Edit protected scope, hide failures, or promote results. |
-| Evaluator/promoter | `evaluator_promoter` | Classify evidence as supported, contradicted, retry-needed, promotion-ready, or retirement-ready. | evaluation summary, promotion candidate, retirement candidate, gate todo, projection-ready evidence. | Treat dev-only lift as promoted or override missing held-out evidence. |
+| Evaluator/promoter | `evaluator_promoter` | Classify evidence as supported, contradicted, retry-needed, promotion-ready, or retirement-ready, and record a terminal decision only after the required gate. | evaluation summary, promotion candidate, retirement candidate, `auto_research_terminal_decision_v0`, gate todo, projection-ready evidence. | Treat dev-only lift as promoted, override missing held-out evidence, or self-certify an independent review. |
 
 The role names are product-facing labels. A single Codex session may perform
 multiple roles only when it has the corresponding todo claim, capability, and
@@ -55,7 +55,7 @@ reintroducing a leader or coordinator agent.
 | Future role | Current v0 duty | Split trigger | Still must not |
 | --- | --- | --- | --- |
 | Gate steward | Research curator plus evidence verifier handle `operator_gate` and `promotion_gate` transitions. | Gates become frequent enough that wait reasons, owner questions, and unblock evidence need independent monitoring. | Approve its own gate, bypass owner decisions, or select experiments. |
-| Synthesis narrator | Read-only projection builder creates `research_evidence_graph_v0` from promoted/retired evidence. | Users need a continuously updated report lane that summarizes evidence without slowing runners or verifiers. | Certify scores, hide negative evidence, or mutate source records. |
+| Synthesis narrator | Read-only projection builder converts the evidence graph plus terminal decisions and reviews into queryable Explore results. | Users need a continuously updated report lane that summarizes evidence without slowing runners or verifiers. | Certify scores, hide negative evidence, or mutate source records. |
 | Frontier janitor | Hypothesis mapper and evidence verifier retire duplicates, exhausted retries, and no-follow-up branches. | The frontier grows large enough that stale hypotheses crowd out active research. | Delete evidence, rewrite todo ownership, or prune without a public rationale. |
 
 Promoting any future role requires a smoke update that proves the role is a
@@ -78,8 +78,8 @@ over the full graph.
 | `needs_retry` | Attempt is inconclusive but resumable from a ref or clearly bounded retry. | `frontier_selected`, `retired` |
 | `contradicted` | Evidence shows regression, correctness failure, or guardrail failure. | `retired`, `hypothesis_proposed` |
 | `promotion_gate` | Promotion requires held-out evidence, owner decision, merge gate, or public-boundary review. | `promoted`, `retired`, `operator_gate` |
-| `promoted` | Promotion policy accepted the result into the current best artifact. | `research_evidence_graph_v0` |
-| `retired` | The direction is no longer active; negative evidence remains queryable. | `research_evidence_graph_v0` |
+| `promoted` | Promotion policy accepted the result into the current best artifact. | peer review, Explore result projection |
+| `retired` | The direction is no longer active; negative evidence remains queryable. | peer review, Explore result projection |
 
 ## State Machine
 
@@ -137,9 +137,10 @@ flowchart TD
 | `evaluated -> contradicted` | Evidence verifier | regression, correctness failure, boundary violation, or novelty failure. |
 | `evaluated -> needs_retry` | Evidence verifier | unscored attempt with resumable ref or explicit bounded retry reason. |
 | `evaluated -> promotion_gate` | Evidence verifier | holdout candidate, clean boundary, pending owner/merge/publication decision. |
-| `promotion_gate -> promoted` | Research curator plus evidence verifier | held-out evidence when required, clean boundary, and applicable operator gate accepted. |
-| `supported|contradicted|needs_retry -> retired` | Hypothesis mapper plus evidence verifier | negative evidence, retry exhaustion, duplicate proof, or no-follow-up rationale. |
-| `promoted|retired -> research_evidence_graph_v0` | Read-only projection builder | projection refs only; no direct mutation of source records. |
+| `promotion_gate -> promoted` | Research curator plus evidence verifier | held-out evidence when required, clean boundary, applicable operator gate accepted, and an explicit evidence-revision-bound terminal decision. |
+| `supported|contradicted|needs_retry -> retired` | Hypothesis mapper plus evidence verifier | negative evidence, retry exhaustion, duplicate proof, or no-follow-up rationale plus an explicit retirement reason. |
+| `promoted|retired -> auto_research_peer_review_v0` | A registered peer distinct from producer and decision agent when independence is claimed | exact terminal-decision ref, exact evidence-graph revision, public-safe evidence refs, and approve/reject/needs-more-evidence verdict. |
+| `promoted|retired -> loopx_explore_result_event_v0` | Read-only projection builder | current evidence graph, terminal decision, and review projection refs only; no direct mutation of source records. |
 
 ## No-Leader Invariants
 
@@ -147,6 +148,10 @@ flowchart TD
 - `quota should-run --agent-id ...` selects only the current agent frontier.
 - Every executable hypothesis remains backed by a `todo_id` and `claimed_by`.
 - Promotion is evidence plus gate policy, not a persuasive summary.
+- A promotion or retirement candidate is not a terminal result; the terminal
+  decision is explicit and bound to one evidence-graph revision.
+- Peer review is a receipt over the decision. It cannot rewrite the hypothesis
+  or evidence, and same-agent review is never labeled independent.
 - A single promoted branch does not close a multi-round target by itself; when
   the role profile's continuation target is unmet, the last role in the cycle
   creates or links the next role-declared successor todo.

--- a/docs/reference/protocols/decentralized-auto-research-state-v0.md
+++ b/docs/reference/protocols/decentralized-auto-research-state-v0.md
@@ -65,6 +65,8 @@ agent.
 | `todo_item_v0` | `loopx todo` | Formal executable work, user gate, blocker, or monitor. Research work remains todo-backed. |
 | `research_hypothesis_v0` | proposed rollout event and optional domain pack | A hypothesis node linked to a todo, parent hypothesis, agent lane, mechanism family, and current status. |
 | `research_evidence_event_v0` | proposed `loopx_rollout_event_v0` specialization | Append-only evidence for an attempt: score, split, command label, branch, artifact refs, eval status, and boundary facts. |
+| `auto_research_terminal_decision_v0` | `validation` rollout event specialization | Explicit `promoted` or `retired` result bound to one evidence-graph revision; promotion and retirement candidates do not imply this record. |
+| `auto_research_peer_review_v0` | `validation` rollout event specialization | Approve, reject, or needs-more-evidence review receipt bound to one terminal decision and evidence-graph revision. |
 | `dataset_window_contract_v0` | `loopx/ml_experiment.py` | Train/dev/held-out window or split contract, including missing-window policy. |
 | `agent_lane_next_action_v0` | `quota should-run --agent-id ...` | The current agent's selected frontier item; it does not replace the global state graph. |
 | `operator_gate` | `loopx operator-gate`, review packet | Promotion, merge, private-material, or publication decision. |
@@ -168,6 +170,7 @@ carry source refs and remain recomputable from source state.
 | --- | --- |
 | `decentralized_research_frontier_v0` | Per-agent queue of runnable or blocked hypotheses after quota, claim, capability, and boundary checks. |
 | `research_evidence_graph_v0` | Read-only graph joining hypotheses, todos, attempts, branches, metrics, gates, and promotion decisions. |
+| `auto_research_terminal_result_projection_v0` | Deterministic projection of terminal decisions and review state into existing Explore nodes, findings, and lineage edges. |
 
 ### `decentralized_research_frontier_v0`
 
@@ -278,6 +281,14 @@ Already available:
   `research_hypothesis` and `research_evidence` rollout events back into
   `research_evidence_graph_v0` and derives promotion/retirement candidates for
   the live frontier.
+- `loopx auto-research decide` validates a candidate against current evidence,
+  then records an evidence-revision-bound terminal decision.
+- `loopx auto-research review` records a review receipt; with
+  `--require-independent`, the reviewer must be a different registered peer
+  from both producer and decision agent.
+- `loopx auto-research results` returns exact current and historical terminal
+  state by hypothesis id. `project-results` writes deterministic existing
+  Explore node/finding events, and repeated execution is idempotent.
 
 Needed next:
 
@@ -295,6 +306,9 @@ An implementation is acceptable when:
 - `needs_retry` keeps resumable evidence instead of collapsing into `done`;
 - grounded ideation and novelty audit are separated;
 - held-out promotion is explicit;
+- terminal decisions remain separate from promotion and retirement candidates;
+- same-agent review remains visible but cannot confirm or refute a finding;
+- stale evidence revisions and conflicting terminal decisions fail closed;
 - user-facing research summaries derive from compact frontier and evidence
   graph refs, not a bespoke kernel packet;
 - public projections contain no raw logs, private paths, credentials, or raw

--- a/examples/auto-research-terminal-results-cli-smoke.py
+++ b/examples/auto-research-terminal-results-cli-smoke.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Exercise the shipped Auto Research terminal-result CLI lifecycle."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from examples.auto_research_lightweight_fixture import (  # noqa: E402
+    AGENT_ID,
+    GOAL_ID,
+    HYPOTHESIS_ID,
+    HYPOTHESIS_TEXT,
+    MECHANISM_FAMILY,
+    TODO_ID,
+    write_contract_and_results,
+)
+
+
+PROMOTER = "evaluator-promoter"
+REVIEWER = "independent-reviewer"
+
+
+def run_cli(
+    registry: Path,
+    *args: str,
+    expect_ok: bool = True,
+) -> dict[str, Any]:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry),
+            "--format",
+            "json",
+            "auto-research",
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    if expect_ok:
+        assert result.returncode == 0 and payload["ok"] is True, (result, payload)
+    else:
+        assert result.returncode != 0 and payload["ok"] is False, (result, payload)
+    return payload
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        runtime_root = temp / "runtime"
+        project = temp / "project"
+        project.mkdir()
+        registry = temp / "registry.json"
+        registry.write_text(
+            json.dumps(
+                {
+                    "schema_version": "0.1",
+                    "common_runtime_root": str(runtime_root),
+                    "goals": [
+                        {
+                            "id": GOAL_ID,
+                            "repo": str(project),
+                            "state_file": "ACTIVE_GOAL_STATE.md",
+                            "adapter": {
+                                "kind": "fixture",
+                                "status": "connected-read-only",
+                            },
+                            "coordination": {
+                                "agent_model": "peer_v1",
+                                "registered_agents": [
+                                    AGENT_ID,
+                                    PROMOTER,
+                                    REVIEWER,
+                                ],
+                            },
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        contract, dev, holdout = write_contract_and_results(temp)
+        packet_path = temp / "packet.json"
+        packet = run_cli(
+            registry,
+            "evidence",
+            "--contract",
+            str(contract),
+            "--eval-result",
+            str(dev),
+            "--eval-result",
+            str(holdout),
+            "--hypothesis-id",
+            HYPOTHESIS_ID,
+            "--todo-id",
+            TODO_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--claimed-by",
+            AGENT_ID,
+            "--mechanism-family",
+            MECHANISM_FAMILY,
+            "--hypothesis",
+            HYPOTHESIS_TEXT,
+        )
+        packet_path.write_text(json.dumps(packet), encoding="utf-8")
+        run_cli(
+            registry,
+            "append-evidence",
+            "--packet",
+            str(packet_path),
+        )
+        unregistered = run_cli(
+            registry,
+            "decide",
+            "--goal-id",
+            GOAL_ID,
+            "--hypothesis-id",
+            HYPOTHESIS_ID,
+            "--outcome",
+            "promoted",
+            "--reason",
+            "holdout_validated",
+            "--agent-id",
+            "unregistered-promoter",
+            "--execute",
+            expect_ok=False,
+        )
+        assert "not registered" in unregistered["error"], unregistered
+        run_cli(
+            registry,
+            "decide",
+            "--goal-id",
+            GOAL_ID,
+            "--hypothesis-id",
+            HYPOTHESIS_ID,
+            "--outcome",
+            "promoted",
+            "--reason",
+            "holdout_validated",
+            "--agent-id",
+            PROMOTER,
+            "--evidence-ref",
+            "decision:heldout",
+            "--execute",
+        )
+        self_review = run_cli(
+            registry,
+            "review",
+            "--goal-id",
+            GOAL_ID,
+            "--hypothesis-id",
+            HYPOTHESIS_ID,
+            "--reviewer-agent-id",
+            PROMOTER,
+            "--verdict",
+            "approve",
+            "--execute",
+        )
+        assert self_review["review"]["independent"] is False, self_review
+        run_cli(
+            registry,
+            "review",
+            "--goal-id",
+            GOAL_ID,
+            "--hypothesis-id",
+            HYPOTHESIS_ID,
+            "--reviewer-agent-id",
+            REVIEWER,
+            "--verdict",
+            "approve",
+            "--require-independent",
+            "--evidence-ref",
+            "review:independent",
+            "--execute",
+        )
+        result = run_cli(
+            registry,
+            "results",
+            "--goal-id",
+            GOAL_ID,
+            "--hypothesis-id",
+            HYPOTHESIS_ID,
+            "--include-history",
+        )
+        assert result["results"][0]["finding_status"] == "confirmed", result
+        first = run_cli(
+            registry,
+            "project-results",
+            "--goal-id",
+            GOAL_ID,
+            "--execute",
+        )
+        second = run_cli(
+            registry,
+            "project-results",
+            "--goal-id",
+            GOAL_ID,
+            "--execute",
+        )
+        assert first["appended_count"] > 0, first
+        assert second["appended_count"] == 0, second
+        assert second["reused_count"] == second["event_count"], second
+        readback = run_cli(
+            registry,
+            "results",
+            "--goal-id",
+            GOAL_ID,
+            "--hypothesis-id",
+            HYPOTHESIS_ID,
+        )
+        assert readback["explore_projection"]["state"] == "current", readback
+    print("auto-research-terminal-results-cli-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/auto-research-terminal-results-smoke.py
+++ b/examples/auto-research-terminal-results-smoke.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+"""Exercise evidence-bound Auto Research terminal results and reviews."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.auto_research.evidence_packet import (  # noqa: E402
+    RESEARCH_EVIDENCE_EVENT_SCHEMA_VERSION,
+    RESEARCH_HYPOTHESIS_SCHEMA_VERSION,
+)
+from loopx.capabilities.auto_research.research_state import (  # noqa: E402
+    build_research_evidence_graph_from_records,
+)
+from loopx.capabilities.auto_research.terminal_results import (  # noqa: E402
+    build_peer_review_event,
+    build_terminal_decision_event,
+    build_terminal_result_explore_events,
+    build_terminal_result_query,
+)
+from loopx.capabilities.explore.result_log import (  # noqa: E402
+    build_explore_result_projection,
+)
+GOAL_ID = "terminal-result-fixture"
+BASELINE = 0.0
+PRODUCER = "research-executor"
+PROMOTER = "evaluator-promoter"
+REVIEWER = "independent-reviewer"
+REGISTERED_AGENTS = [
+    PRODUCER,
+    PROMOTER,
+    REVIEWER,
+    "second-independent-reviewer",
+]
+
+
+def hypothesis(
+    hypothesis_id: str,
+    *,
+    text: str,
+    status: str,
+    parent: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": RESEARCH_HYPOTHESIS_SCHEMA_VERSION,
+        "hypothesis_id": hypothesis_id,
+        "parent_hypothesis_id": parent,
+        "todo_id": f"todo_{hypothesis_id}",
+        "claimed_by": PRODUCER,
+        "mechanism_family": "finance_style_claim",
+        "hypothesis": text,
+        "status": status,
+        "grounding_refs": [],
+        "novelty_audit_ref": None,
+        "blocked_by": (
+            ["evidence_or_boundary_guardrail_failed"]
+            if status == "contradicted"
+            else []
+        ),
+    }
+
+
+def evidence(
+    hypothesis_id: str,
+    *,
+    split: str,
+    value: float,
+    metric_status: str,
+    attempt: int = 1,
+) -> dict[str, Any]:
+    return {
+        "schema_version": RESEARCH_EVIDENCE_EVENT_SCHEMA_VERSION,
+        "hypothesis_id": hypothesis_id,
+        "todo_id": f"todo_{hypothesis_id}",
+        "agent_id": PRODUCER,
+        "attempt": attempt,
+        "split": split,
+        "metric": {
+            "name": "research_quality",
+            "value": value,
+            "direction": "maximize",
+        },
+        "baseline_metric": BASELINE,
+        "eval_status": "scored",
+        "primary_metric_status": metric_status,
+        "artifact_refs": [f"evidence:{hypothesis_id}:{split}:{attempt}"],
+        "protected_scope_clean": True,
+        "raw_logs_recorded": False,
+        "private_artifacts_recorded": False,
+    }
+
+
+def fixture_graph() -> tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]]]:
+    hypotheses = [
+        hypothesis(
+            "value_case",
+            text="The candidate satisfies the preregistered company-value gate.",
+            status="supported",
+        ),
+        hypothesis(
+            "persistent_alpha",
+            text="The candidate has persistent benchmark-adjusted alpha.",
+            status="contradicted",
+        ),
+        hypothesis(
+            "single_window_alpha",
+            text="One frozen window contains positive benchmark-adjusted alpha.",
+            status="supported",
+        ),
+        hypothesis(
+            "walk_forward_alpha",
+            text="The single-window alpha persists across rolling held-out windows.",
+            status="contradicted",
+            parent="single_window_alpha",
+        ),
+        hypothesis(
+            "duplicate_route",
+            text="A duplicate route should retire without becoming a refuted finding.",
+            status="active",
+        ),
+    ]
+    evidence_events = [
+        evidence("value_case", split="dev", value=0.6, metric_status="improved"),
+        evidence(
+            "value_case",
+            split="holdout",
+            value=0.4,
+            metric_status="improved",
+        ),
+        evidence(
+            "persistent_alpha",
+            split="holdout",
+            value=-0.5,
+            metric_status="regressed",
+        ),
+        evidence(
+            "single_window_alpha",
+            split="dev",
+            value=0.7,
+            metric_status="improved",
+        ),
+        evidence(
+            "walk_forward_alpha",
+            split="holdout",
+            value=-0.2,
+            metric_status="regressed",
+        ),
+    ]
+    graph = build_research_evidence_graph_from_records(
+        goal_id=GOAL_ID,
+        hypotheses=hypotheses,
+        evidence_events=evidence_events,
+        metric_name="research_quality",
+        metric_direction="maximize",
+        baseline_metric=BASELINE,
+    )
+    return graph, hypotheses, evidence_events
+
+
+def terminal_events(graph: dict[str, Any]) -> list[dict[str, Any]]:
+    value = build_terminal_decision_event(
+        evidence_graph=graph,
+        hypothesis_id="value_case",
+        outcome="promoted",
+        reason="holdout_validated",
+        decided_by=PROMOTER,
+        evidence_refs=["decision:value_case"],
+        recorded_at="2026-08-08T00:00:00Z",
+    )
+    persistent = build_terminal_decision_event(
+        evidence_graph=graph,
+        hypothesis_id="persistent_alpha",
+        outcome="retired",
+        reason="contradicted",
+        decided_by=PROMOTER,
+        evidence_refs=["decision:persistent_alpha"],
+        recorded_at="2026-08-08T00:00:01Z",
+    )
+    rolling = build_terminal_decision_event(
+        evidence_graph=graph,
+        hypothesis_id="walk_forward_alpha",
+        outcome="retired",
+        reason="contradicted",
+        decided_by=PROMOTER,
+        evidence_refs=["decision:walk_forward_alpha"],
+        recorded_at="2026-08-08T00:00:02Z",
+    )
+    duplicate = build_terminal_decision_event(
+        evidence_graph=graph,
+        hypothesis_id="duplicate_route",
+        outcome="retired",
+        reason="duplicate",
+        decided_by=PROMOTER,
+        evidence_refs=["decision:duplicate_route"],
+        recorded_at="2026-08-08T00:00:03Z",
+    )
+    return [value, persistent, rolling, duplicate]
+
+
+def reviews(
+    graph: dict[str, Any],
+    decisions: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    self_review = build_peer_review_event(
+        evidence_graph=graph,
+        rollout_events=decisions,
+        hypothesis_id="value_case",
+        reviewer_agent_id=PROMOTER,
+        verdict="approve",
+        evidence_refs=["review:self"],
+        registered_agent_ids=REGISTERED_AGENTS,
+        recorded_at="2026-08-08T00:01:00Z",
+    )
+    independent = [
+        build_peer_review_event(
+            evidence_graph=graph,
+            rollout_events=decisions,
+            hypothesis_id=hypothesis_id,
+            reviewer_agent_id=REVIEWER,
+            verdict="approve",
+            evidence_refs=[f"review:{hypothesis_id}"],
+            require_independent=True,
+            registered_agent_ids=REGISTERED_AGENTS,
+            recorded_at=f"2026-08-08T00:01:0{index}Z",
+        )
+        for index, hypothesis_id in enumerate(
+            ["value_case", "persistent_alpha", "walk_forward_alpha"],
+            start=1,
+        )
+    ]
+    try:
+        build_peer_review_event(
+            evidence_graph=graph,
+            rollout_events=decisions,
+            hypothesis_id="value_case",
+            reviewer_agent_id=PROMOTER,
+            verdict="approve",
+            require_independent=True,
+            registered_agent_ids=REGISTERED_AGENTS,
+        )
+    except ValueError as exc:
+        assert "distinct" in str(exc), exc
+    else:
+        raise AssertionError("same-agent independent review must fail")
+    try:
+        build_peer_review_event(
+            evidence_graph=graph,
+            rollout_events=decisions,
+            hypothesis_id="value_case",
+            reviewer_agent_id="unregistered-reviewer",
+            verdict="approve",
+            registered_agent_ids=REGISTERED_AGENTS,
+        )
+    except ValueError as exc:
+        assert "not registered" in str(exc), exc
+    else:
+        raise AssertionError("unregistered peer review must fail")
+    return [self_review, *independent]
+
+
+def assert_query_semantics(
+    graph: dict[str, Any],
+    decisions: list[dict[str, Any]],
+    review_events: list[dict[str, Any]],
+) -> dict[str, Any]:
+    query = build_terminal_result_query(
+        evidence_graph=graph,
+        rollout_events=[*decisions, *review_events],
+        registered_agent_ids=REGISTERED_AGENTS,
+        include_history=True,
+    )
+    by_id = {item["hypothesis_id"]: item for item in query["results"]}
+    assert by_id["value_case"]["finding_status"] == "confirmed", by_id
+    assert by_id["persistent_alpha"]["finding_status"] == "refuted", by_id
+    assert by_id["single_window_alpha"]["finding_status"] == "tentative", by_id
+    assert by_id["walk_forward_alpha"]["finding_status"] == "refuted", by_id
+    assert by_id["duplicate_route"]["finding_status"] is None, by_id
+    assert by_id["value_case"]["peer_review"]["independent"] is True, by_id
+    assert by_id["value_case"]["terminal_decision"]["outcome"] == "promoted", by_id
+
+    self_review_only = build_terminal_result_query(
+        evidence_graph=graph,
+        rollout_events=[*decisions, review_events[0]],
+        registered_agent_ids=REGISTERED_AGENTS,
+        hypothesis_id="value_case",
+    )["results"][0]
+    assert self_review_only["finding_status"] == "tentative", self_review_only
+    assert self_review_only["peer_review"]["state"] == "self_review_only", self_review_only
+    forged_self_review = {
+        **review_events[0],
+        "details": {
+            **review_events[0]["details"],
+            "independent": True,
+        },
+    }
+    forged = build_terminal_result_query(
+        evidence_graph=graph,
+        rollout_events=[*decisions, forged_self_review],
+        registered_agent_ids=REGISTERED_AGENTS,
+        hypothesis_id="value_case",
+    )["results"][0]
+    assert forged["peer_review"]["state"] == "self_review_only", forged
+    assert forged["finding_status"] == "tentative", forged
+
+    removed_reviewer = build_terminal_result_query(
+        evidence_graph=graph,
+        rollout_events=[*decisions, *review_events],
+        registered_agent_ids=[PRODUCER, PROMOTER],
+        hypothesis_id="value_case",
+    )["results"][0]
+    assert removed_reviewer["peer_review"]["state"] == "self_review_only", removed_reviewer
+    assert removed_reviewer["finding_status"] == "tentative", removed_reviewer
+
+    conflict = build_terminal_decision_event(
+        evidence_graph=graph,
+        hypothesis_id="value_case",
+        outcome="retired",
+        reason="duplicate",
+        decided_by="alternate-promoter",
+        recorded_at="2026-08-08T00:02:00Z",
+    )
+    conflicted = build_terminal_result_query(
+        evidence_graph=graph,
+        rollout_events=[*decisions, conflict, *review_events],
+        registered_agent_ids=REGISTERED_AGENTS,
+        hypothesis_id="value_case",
+    )["results"][0]
+    assert conflicted["decision_state"] == "conflict", conflicted
+    assert conflicted["finding_status"] == "tentative", conflicted
+
+    review_reject = build_peer_review_event(
+        evidence_graph=graph,
+        rollout_events=decisions,
+        hypothesis_id="value_case",
+        reviewer_agent_id="second-independent-reviewer",
+        verdict="reject",
+        require_independent=True,
+        registered_agent_ids=REGISTERED_AGENTS,
+        recorded_at="2026-08-08T00:03:00Z",
+    )
+    review_conflict = build_terminal_result_query(
+        evidence_graph=graph,
+        rollout_events=[*decisions, *review_events, review_reject],
+        registered_agent_ids=REGISTERED_AGENTS,
+        hypothesis_id="value_case",
+    )["results"][0]
+    assert review_conflict["peer_review"]["state"] == "conflict", review_conflict
+    assert review_conflict["finding_status"] == "tentative", review_conflict
+
+    stale_graph = build_research_evidence_graph_from_records(
+        goal_id=GOAL_ID,
+        hypotheses=[
+            hypothesis(
+                "value_case",
+                text="The candidate satisfies the preregistered company-value gate.",
+                status="supported",
+            )
+        ],
+        evidence_events=[
+            evidence("value_case", split="dev", value=0.6, metric_status="improved"),
+            evidence(
+                "value_case",
+                split="holdout",
+                value=0.4,
+                metric_status="improved",
+            ),
+            evidence(
+                "value_case",
+                split="holdout",
+                value=0.45,
+                metric_status="improved",
+                attempt=2,
+            ),
+        ],
+        metric_name="research_quality",
+        metric_direction="maximize",
+        baseline_metric=BASELINE,
+    )
+    stale = build_terminal_result_query(
+        evidence_graph=stale_graph,
+        rollout_events=[*decisions, *review_events],
+        registered_agent_ids=REGISTERED_AGENTS,
+        hypothesis_id="value_case",
+    )["results"][0]
+    assert stale["decision_state"] == "stale", stale
+    assert stale["finding_status"] == "tentative", stale
+
+    unrelated_hypothesis = hypothesis(
+        "unrelated_route",
+        text="An unrelated hypothesis should not stale another terminal decision.",
+        status="active",
+    )
+    unrelated_graph = build_research_evidence_graph_from_records(
+        goal_id=GOAL_ID,
+        hypotheses=[
+            *fixture_graph()[1],
+            unrelated_hypothesis,
+        ],
+        evidence_events=fixture_graph()[2],
+        metric_name="research_quality",
+        metric_direction="maximize",
+        baseline_metric=BASELINE,
+    )
+    still_current = build_terminal_result_query(
+        evidence_graph=unrelated_graph,
+        rollout_events=[*decisions, *review_events],
+        registered_agent_ids=REGISTERED_AGENTS,
+        hypothesis_id="value_case",
+    )["results"][0]
+    assert still_current["decision_state"] == "current", still_current
+    assert still_current["finding_status"] == "confirmed", still_current
+    return query
+
+
+def assert_projection(query: dict[str, Any]) -> None:
+    events = build_terminal_result_explore_events(query=query)
+    repeated = build_terminal_result_explore_events(query=query)
+    assert events == repeated
+    assert [event["event_id"] for event in events] == [
+        event["event_id"] for event in repeated
+    ]
+    projection = build_explore_result_projection(events, goal_id=GOAL_ID)
+    findings = {
+        item["finding"]: item["status"] for item in projection["findings"]
+    }
+    assert findings == {
+        "The candidate satisfies the preregistered company-value gate.": "confirmed",
+        "The candidate has persistent benchmark-adjusted alpha.": "refuted",
+        "One frozen window contains positive benchmark-adjusted alpha.": "tentative",
+        "The single-window alpha persists across rolling held-out windows.": "refuted",
+    }, findings
+    edges = [edge for edge in projection["edges"] if edge["edge_type"] == "leads_to"]
+    assert len(edges) == 1, edges
+    assert projection["counts"]["finding_count"] == 4, projection
+
+
+def main() -> int:
+    graph, _, _ = fixture_graph()
+    decisions = terminal_events(graph)
+    review_events = reviews(graph, decisions)
+    query = assert_query_semantics(graph, decisions, review_events)
+    assert_projection(query)
+    print("auto-research-terminal-results-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -32,6 +32,12 @@ from .worker_runtime import run_auto_research_worker_turn
 from .rollout_append import (
     append_auto_research_rollout_events as _append_auto_research_rollout_events,
 )
+from .terminal_results import (
+    decide_terminal_result,
+    project_terminal_results,
+    query_terminal_results,
+    review_terminal_result,
+)
 from .user_contract import (
     build_auto_research_user_contract,
     infer_auto_research_output_language,
@@ -71,10 +77,14 @@ AUTO_RESEARCH_SUBCOMMANDS = frozenset(
         "append-evidence",
         "capture-live-evidence",
         "contract",
+        "decide",
         "demo-e2e",
         "demo-supervisor",
         "evidence",
         "frontier",
+        "project-results",
+        "results",
+        "review",
         "start",
         "worker-loop",
         "worker-turn",
@@ -418,6 +428,80 @@ def register_auto_research_commands(
     append_parser.add_argument(
         "--output",
         help="Write the append result JSON to this path without recording the path in LoopX state.",
+    )
+
+    decide_parser = auto_research_sub.add_parser(
+        "decide",
+        help="Record an evidence-bound terminal decision for one Auto Research hypothesis.",
+    )
+    add_subcommand_format(decide_parser)
+    decide_parser.add_argument("--goal-id", required=True)
+    decide_parser.add_argument("--hypothesis-id", required=True)
+    decide_parser.add_argument("--outcome", choices=["promoted", "retired"], required=True)
+    decide_parser.add_argument(
+        "--reason",
+        choices=[
+            "contradicted",
+            "duplicate",
+            "holdout_validated",
+            "operator_rejected",
+            "retry_exhausted",
+            "superseded",
+        ],
+        required=True,
+    )
+    decide_parser.add_argument("--agent-id", required=True)
+    decide_parser.add_argument("--evidence-ref", action="append", default=[])
+    decide_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Append the terminal decision. Omit to preview the validated decision.",
+    )
+
+    review_parser = auto_research_sub.add_parser(
+        "review",
+        help="Record a review receipt bound to the current terminal decision and evidence graph revision.",
+    )
+    add_subcommand_format(review_parser)
+    review_parser.add_argument("--goal-id", required=True)
+    review_parser.add_argument("--hypothesis-id", required=True)
+    review_parser.add_argument("--reviewer-agent-id", required=True)
+    review_parser.add_argument(
+        "--verdict",
+        choices=["approve", "needs_more_evidence", "reject"],
+        required=True,
+    )
+    review_parser.add_argument("--evidence-ref", action="append", default=[])
+    review_parser.add_argument(
+        "--require-independent",
+        action="store_true",
+        help="Reject a reviewer who produced the hypothesis or terminal decision.",
+    )
+    review_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Append the review receipt. Omit to preview the validated receipt.",
+    )
+
+    results_parser = auto_research_sub.add_parser(
+        "results",
+        help="Query current terminal decisions and review state by exact hypothesis id.",
+    )
+    add_subcommand_format(results_parser)
+    results_parser.add_argument("--goal-id", required=True)
+    results_parser.add_argument("--hypothesis-id")
+    results_parser.add_argument("--include-history", action="store_true")
+
+    project_results_parser = auto_research_sub.add_parser(
+        "project-results",
+        help="Project terminal Auto Research decisions into the existing Explore result log.",
+    )
+    add_subcommand_format(project_results_parser)
+    project_results_parser.add_argument("--goal-id", required=True)
+    project_results_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Append the deterministic Explore events. Omit to preview.",
     )
 
     live_evidence_parser = auto_research_sub.add_parser(
@@ -1122,6 +1206,45 @@ def handle_auto_research_command(
                     json.dumps(payload, indent=2, sort_keys=True) + "\n",
                     encoding="utf-8",
                 )
+        elif args.auto_research_command == "decide":
+            payload = decide_terminal_result(
+                registry_path=registry_path,
+                runtime_root_arg=runtime_root_arg,
+                goal_id=args.goal_id,
+                hypothesis_id=args.hypothesis_id,
+                outcome=args.outcome,
+                reason=args.reason,
+                decided_by=args.agent_id,
+                evidence_refs=args.evidence_ref,
+                dry_run=not args.execute,
+            )
+        elif args.auto_research_command == "review":
+            payload = review_terminal_result(
+                registry_path=registry_path,
+                runtime_root_arg=runtime_root_arg,
+                goal_id=args.goal_id,
+                hypothesis_id=args.hypothesis_id,
+                reviewer_agent_id=args.reviewer_agent_id,
+                verdict=args.verdict,
+                evidence_refs=args.evidence_ref,
+                require_independent=args.require_independent,
+                dry_run=not args.execute,
+            )
+        elif args.auto_research_command == "results":
+            payload = query_terminal_results(
+                registry_path=registry_path,
+                runtime_root_arg=runtime_root_arg,
+                goal_id=args.goal_id,
+                hypothesis_id=args.hypothesis_id,
+                include_history=args.include_history,
+            )
+        elif args.auto_research_command == "project-results":
+            payload = project_terminal_results(
+                registry_path=registry_path,
+                runtime_root_arg=runtime_root_arg,
+                goal_id=args.goal_id,
+                dry_run=not args.execute,
+            )
         elif args.auto_research_command == "capture-live-evidence":
             payload = capture_live_codex_e2e_evidence(
                 packet_path=args.packet,
@@ -1328,7 +1451,8 @@ def handle_auto_research_command(
         else:
             raise ValueError(
                 "auto-research requires the `contract`, `frontier`, `evidence`, "
-                "`append-evidence`, `capture-live-evidence`, "
+                "`append-evidence`, `decide`, `review`, `results`, "
+                "`project-results`, `capture-live-evidence`, "
                 "`worker-turn`, `worker-loop`, `demo-supervisor`, `demo-e2e`, "
                 "or `start` subcommand"
             )

--- a/loopx/capabilities/auto_research/human_view.py
+++ b/loopx/capabilities/auto_research/human_view.py
@@ -661,6 +661,95 @@ def _render_evidence_packet(payload: dict[str, object]) -> str:
     return "\n".join(lines) + "\n"
 
 
+def _render_terminal_result(payload: dict[str, object]) -> str:
+    decision = _dict_value(payload, "decision")
+    review = _dict_value(payload, "review")
+    lines = [
+        "# LoopX Auto Research Terminal Result",
+        "",
+        f"- schema: `{payload.get('schema_version')}`",
+        f"- goal_id: `{payload.get('goal_id')}`",
+        f"- dry_run: `{payload.get('dry_run')}`",
+        f"- appended: `{payload.get('appended')}`",
+        f"- reused: `{payload.get('reused')}`",
+    ]
+    if decision:
+        lines.extend(
+            [
+                f"- hypothesis_id: `{decision.get('hypothesis_id')}`",
+                f"- outcome: `{decision.get('outcome')}`",
+                f"- reason: `{decision.get('reason')}`",
+                f"- evidence_graph_revision: `{decision.get('evidence_graph_revision')}`",
+            ]
+        )
+    if review:
+        lines.extend(
+            [
+                f"- hypothesis_id: `{review.get('hypothesis_id')}`",
+                f"- verdict: `{review.get('verdict')}`",
+                f"- independent: `{review.get('independent')}`",
+                f"- evidence_graph_revision: `{review.get('evidence_graph_revision')}`",
+            ]
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _render_terminal_result_query(payload: dict[str, object]) -> str:
+    lines = [
+        "# LoopX Auto Research Results",
+        "",
+        f"- schema: `{payload.get('schema_version')}`",
+        f"- goal_id: `{payload.get('goal_id')}`",
+        f"- evidence_graph_revision: `{payload.get('evidence_graph_revision')}`",
+        f"- result_count: `{payload.get('result_count')}`",
+        "",
+        "## Results",
+        "",
+    ]
+    results = payload.get("results") if isinstance(payload.get("results"), list) else []
+    if not results:
+        lines.append("- none")
+    for result in results:
+        if not isinstance(result, dict):
+            continue
+        decision = _dict_value(result, "terminal_decision")
+        review = _dict_value(result, "peer_review")
+        lines.extend(
+            [
+                f"- `{result.get('hypothesis_id')}`: {result.get('hypothesis')}",
+                f"  - research_status: `{result.get('research_status')}`",
+                f"  - decision_state: `{result.get('decision_state')}`",
+                f"  - terminal_outcome: `{decision.get('outcome')}`",
+                f"  - terminal_reason: `{decision.get('reason')}`",
+                f"  - finding_status: `{result.get('finding_status')}`",
+                f"  - review_state: `{review.get('state')}`",
+                f"  - review_verdict: `{review.get('verdict')}`",
+                f"  - independent_review: `{review.get('independent')}`",
+            ]
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _render_terminal_result_projection(payload: dict[str, object]) -> str:
+    projection = _dict_value(payload, "explore_projection")
+    counts = _dict_value(projection, "counts")
+    return "\n".join(
+        [
+            "# LoopX Auto Research Result Projection",
+            "",
+            f"- schema: `{payload.get('schema_version')}`",
+            f"- goal_id: `{payload.get('goal_id')}`",
+            f"- dry_run: `{payload.get('dry_run')}`",
+            f"- result_count: `{payload.get('result_count')}`",
+            f"- event_count: `{payload.get('event_count')}`",
+            f"- appended_count: `{payload.get('appended_count')}`",
+            f"- reused_count: `{payload.get('reused_count')}`",
+            f"- node_count: `{counts.get('node_count')}`",
+            f"- finding_count: `{counts.get('finding_count')}`",
+        ]
+    ) + "\n"
+
+
 def _render_generic(payload: dict[str, object]) -> str:
     lines = [
         "# LoopX Auto Research",
@@ -693,4 +782,13 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
         return _render_live_evidence(payload)
     if schema == "auto_research_evidence_packet_v0":
         return _render_evidence_packet(payload)
+    if schema in {
+        "auto_research_terminal_decision_v0",
+        "auto_research_peer_review_v0",
+    }:
+        return _render_terminal_result(payload)
+    if schema == "auto_research_terminal_result_query_v0":
+        return _render_terminal_result_query(payload)
+    if schema == "auto_research_terminal_result_projection_v0":
+        return _render_terminal_result_projection(payload)
     return render_auto_research_projection_markdown(payload)

--- a/loopx/capabilities/auto_research/research_state.py
+++ b/loopx/capabilities/auto_research/research_state.py
@@ -411,6 +411,8 @@ def build_research_evidence_graph_from_records(
                 "parent_hypothesis_id": item["parent_hypothesis_id"],
                 "todo_id": item["todo_id"],
                 "claimed_by": item["claimed_by"],
+                "mechanism_family": item["mechanism_family"],
+                "hypothesis": item["hypothesis"],
                 "status": item["status"],
                 "grounding_refs": item["grounding_refs"],
                 "novelty_audit_ref": item["novelty_audit_ref"],

--- a/loopx/capabilities/auto_research/role_profiles.py
+++ b/loopx/capabilities/auto_research/role_profiles.py
@@ -123,8 +123,16 @@ AUTO_RESEARCH_ROLE_PROFILE_ALIASES = {
 AUTO_RESEARCH_ROLE_PROFILES: dict[str, dict[str, object]] = {
     "research_curator": {
         "phase": "contract",
-        "allowed_actions": ["write_research_contract", "review_research_contract"],
-        "write_scope": ["research_contract_v0", "todo_item_v0"],
+        "allowed_actions": [
+            "write_research_contract",
+            "review_research_contract",
+            "review_terminal_decision",
+        ],
+        "write_scope": [
+            "research_contract_v0",
+            "auto_research_peer_review_v0",
+            "todo_item_v0",
+        ],
         "handoff": ["Create the first hypothesis-proposer todo."],
         "successor_todos": [
             _successor("review_research_contract", AUTO_RESEARCH_NEXT_HYPOTHESIS_SUCCESSOR_CONDITION, "hypothesis-proposer", "hypothesis_proposer", "propose_hypothesis", AUTO_RESEARCH_REFINED_HYPOTHESIS_SUCCESSOR_TEXT),
@@ -159,8 +167,13 @@ AUTO_RESEARCH_ROLE_PROFILES: dict[str, dict[str, object]] = {
             "write_evaluation_summary",
             "classify_evidence",
             "review_promotion_readiness",
+            "record_terminal_decision",
         ],
-        "write_scope": ["research_evidence_graph_v0", "todo_item_v0"],
+        "write_scope": [
+            "research_evidence_graph_v0",
+            "auto_research_terminal_decision_v0",
+            "todo_item_v0",
+        ],
         "handoff": ["Add a role-declared successor todo when evidence needs another bounded split."],
         "successor_todos": [
             _successor("summarize_evidence", AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION, "research-curator", "research_curator", "review_research_contract", AUTO_RESEARCH_CURATOR_REVIEW_SUCCESSOR_TEXT),
@@ -186,6 +199,8 @@ AUTO_RESEARCH_ACTION_ROLE_IDS = {
     "summarize_evidence": "evaluator_promoter",
     "write_evaluation_summary": "evaluator_promoter",
     "review_promotion_readiness": "evaluator_promoter",
+    "record_terminal_decision": "evaluator_promoter",
+    "review_terminal_decision": "research_curator",
 }
 
 AUTO_RESEARCH_SEED_TITLES = {
@@ -199,6 +214,8 @@ AUTO_RESEARCH_SEED_TITLES = {
     "review_research_contract": "Re-check the research contract and protected scope for the next collective round.",
     "review_hypothesis_frontier": "Review the hypothesis frontier and record whether another bounded candidate is needed.",
     "review_promotion_readiness": "Review promotion readiness and record the current evidence gap.",
+    "record_terminal_decision": "Record one evidence-revision-bound promoted or retired result after the required gate.",
+    "review_terminal_decision": "Independently review one terminal decision without rewriting research evidence.",
 }
 
 KNN_DEMO_VISIBLE_FIRST_STEP_COMMON = (

--- a/loopx/capabilities/auto_research/terminal_result_contract.py
+++ b/loopx/capabilities/auto_research/terminal_result_contract.py
@@ -1,0 +1,422 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping, Sequence
+
+from .evidence_packet import (
+    _compact_public_text_list,
+    _compact_public_token,
+)
+from .research_state import build_research_decision_candidates
+from ...rollout_event_log import build_rollout_event
+
+
+AUTO_RESEARCH_TERMINAL_DECISION_SCHEMA_VERSION = (
+    "auto_research_terminal_decision_v0"
+)
+AUTO_RESEARCH_PEER_REVIEW_SCHEMA_VERSION = "auto_research_peer_review_v0"
+AUTO_RESEARCH_TERMINAL_RESULT_QUERY_SCHEMA_VERSION = (
+    "auto_research_terminal_result_query_v0"
+)
+
+TERMINAL_OUTCOMES = {"promoted", "retired"}
+RETIREMENT_REASONS = {
+    "contradicted",
+    "duplicate",
+    "operator_rejected",
+    "retry_exhausted",
+    "superseded",
+}
+PEER_REVIEW_VERDICTS = {"approve", "needs_more_evidence", "reject"}
+
+
+def _canonical_digest(value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def research_evidence_graph_revision(evidence_graph: Mapping[str, Any]) -> str:
+    return f"sha256:{_canonical_digest(dict(evidence_graph))}"
+
+
+def hypothesis_evidence_revision(
+    evidence_graph: Mapping[str, Any],
+    hypothesis_id: str,
+) -> str:
+    node = _hypothesis_node(evidence_graph, hypothesis_id)
+    scoped_evidence = {
+        "goal_id": str(evidence_graph.get("goal_id") or ""),
+        "metric": dict(evidence_graph.get("metric") or {}),
+        "node": node,
+    }
+    return f"sha256:{_canonical_digest(scoped_evidence)}"
+
+
+def _stable_ref(prefix: str, values: Sequence[object]) -> str:
+    encoded = json.dumps(
+        [str(value or "") for value in values],
+        ensure_ascii=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return f"{prefix}_{hashlib.sha256(encoded).hexdigest()[:16]}"
+
+
+def _event_classification(event: Mapping[str, Any]) -> str:
+    return str(event.get("classification") or "")
+
+
+def _event_details(event: Mapping[str, Any]) -> dict[str, Any]:
+    details = event.get("details")
+    return dict(details) if isinstance(details, Mapping) else {}
+
+
+def _event_decision_ref(event: Mapping[str, Any]) -> str:
+    causality = event.get("causality")
+    if not isinstance(causality, Mapping):
+        return ""
+    return str(causality.get("decision_id") or "")
+
+
+def _hypothesis_node(
+    evidence_graph: Mapping[str, Any],
+    hypothesis_id: str,
+) -> dict[str, Any]:
+    matches = [
+        dict(node)
+        for node in evidence_graph.get("nodes") or []
+        if isinstance(node, Mapping)
+        and str(node.get("hypothesis_id") or "") == hypothesis_id
+    ]
+    if len(matches) != 1:
+        raise ValueError(
+            f"hypothesis_id must resolve to exactly one evidence graph node: {hypothesis_id}"
+        )
+    return matches[0]
+
+
+def _terminal_decision_events(
+    rollout_events: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    return [
+        dict(event)
+        for event in rollout_events
+        if _event_classification(event)
+        == AUTO_RESEARCH_TERMINAL_DECISION_SCHEMA_VERSION
+    ]
+
+
+def _peer_review_events(
+    rollout_events: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    return [
+        dict(event)
+        for event in rollout_events
+        if _event_classification(event) == AUTO_RESEARCH_PEER_REVIEW_SCHEMA_VERSION
+    ]
+
+
+def _decision_view(event: Mapping[str, Any]) -> dict[str, Any]:
+    details = _event_details(event)
+    return {
+        "decision_ref": _event_decision_ref(event),
+        "event_id": str(event.get("event_id") or ""),
+        "recorded_at": str(event.get("recorded_at") or ""),
+        "goal_id": str(event.get("goal_id") or ""),
+        "hypothesis_id": str(details.get("hypothesis_id") or ""),
+        "outcome": str(details.get("outcome") or ""),
+        "reason": str(details.get("reason") or ""),
+        "decided_by": str(event.get("agent_id") or ""),
+        "evidence_graph_revision": str(
+            details.get("evidence_graph_revision") or ""
+        ),
+        "hypothesis_evidence_revision": str(
+            details.get("hypothesis_evidence_revision") or ""
+        ),
+        "evidence_refs": list(event.get("artifact_refs") or []),
+    }
+
+
+def _review_view(
+    event: Mapping[str, Any],
+    *,
+    registered_agent_ids: Sequence[str],
+) -> dict[str, Any]:
+    details = _event_details(event)
+    reviewer_agent_id = str(event.get("agent_id") or "")
+    decision_agent_id = str(details.get("decision_agent_id") or "")
+    producer_agent_id = str(details.get("producer_agent_id") or "")
+    registered = set(registered_agent_ids)
+    independently_separated = reviewer_agent_id not in {
+        decision_agent_id,
+        producer_agent_id,
+    }
+    return {
+        "review_ref": _event_decision_ref(event),
+        "event_id": str(event.get("event_id") or ""),
+        "recorded_at": str(event.get("recorded_at") or ""),
+        "goal_id": str(event.get("goal_id") or ""),
+        "hypothesis_id": str(details.get("hypothesis_id") or ""),
+        "decision_ref": str(details.get("decision_ref") or ""),
+        "verdict": str(details.get("verdict") or ""),
+        "reviewer_agent_id": reviewer_agent_id,
+        "decision_agent_id": decision_agent_id,
+        "producer_agent_id": producer_agent_id,
+        "independent": bool(details.get("independent"))
+        and reviewer_agent_id in registered
+        and independently_separated,
+        "evidence_graph_revision": str(
+            details.get("evidence_graph_revision") or ""
+        ),
+        "hypothesis_evidence_revision": str(
+            details.get("hypothesis_evidence_revision") or ""
+        ),
+        "evidence_refs": list(event.get("artifact_refs") or []),
+    }
+
+
+def _validate_terminal_decision(
+    *,
+    evidence_graph: Mapping[str, Any],
+    hypothesis_id: str,
+    outcome: str,
+    reason: str,
+) -> dict[str, Any]:
+    node = _hypothesis_node(evidence_graph, hypothesis_id)
+    normalized_outcome = _compact_public_token(outcome, field="outcome")
+    if normalized_outcome not in TERMINAL_OUTCOMES:
+        raise ValueError(
+            "outcome must be one of: " + ", ".join(sorted(TERMINAL_OUTCOMES))
+        )
+    normalized_reason = _compact_public_token(reason, field="reason")
+    decisions = build_research_decision_candidates(dict(evidence_graph))
+    validated_ids = {
+        str(item.get("hypothesis_id") or "")
+        for item in decisions.get("validated_promotion_candidates") or []
+    }
+    retirement_ids = {
+        str(item.get("hypothesis_id") or "")
+        for item in decisions.get("retirement_candidates") or []
+    }
+    if normalized_outcome == "promoted":
+        if normalized_reason != "holdout_validated":
+            raise ValueError("promoted decisions require reason=holdout_validated")
+        if hypothesis_id not in validated_ids:
+            raise ValueError(
+                "promoted decisions require a validated holdout promotion candidate"
+            )
+    else:
+        if normalized_reason not in RETIREMENT_REASONS:
+            raise ValueError(
+                "retired decision reason must be one of: "
+                + ", ".join(sorted(RETIREMENT_REASONS))
+            )
+        if normalized_reason == "contradicted" and hypothesis_id not in retirement_ids:
+            raise ValueError(
+                "retired reason=contradicted requires negative or guardrail evidence"
+            )
+    return node
+
+
+def build_terminal_decision_event(
+    *,
+    evidence_graph: Mapping[str, Any],
+    hypothesis_id: str,
+    outcome: str,
+    reason: str,
+    decided_by: str,
+    evidence_refs: Sequence[str] | None = None,
+    recorded_at: str | None = None,
+) -> dict[str, Any]:
+    hypothesis = _compact_public_token(hypothesis_id, field="hypothesis_id")
+    decider = _compact_public_token(decided_by, field="decided_by")
+    node = _validate_terminal_decision(
+        evidence_graph=evidence_graph,
+        hypothesis_id=hypothesis,
+        outcome=outcome,
+        reason=reason,
+    )
+    normalized_outcome = _compact_public_token(outcome, field="outcome")
+    normalized_reason = _compact_public_token(reason, field="reason")
+    graph_revision = research_evidence_graph_revision(evidence_graph)
+    hypothesis_revision = hypothesis_evidence_revision(
+        evidence_graph,
+        hypothesis,
+    )
+    refs = _compact_public_text_list(evidence_refs, field="evidence_refs")
+    decision_ref = _stable_ref(
+        "research_decision",
+        [
+            evidence_graph.get("goal_id"),
+            hypothesis,
+            hypothesis_revision,
+        ],
+    )
+    return build_rollout_event(
+        goal_id=str(evidence_graph.get("goal_id") or ""),
+        event_kind="validation",
+        agent_id=decider,
+        todo_id=str(node.get("todo_id") or ""),
+        agent_role="evaluator_promoter",
+        decision_id=decision_ref,
+        from_state=str(node.get("status") or ""),
+        to_state=normalized_outcome,
+        status=normalized_outcome,
+        classification=AUTO_RESEARCH_TERMINAL_DECISION_SCHEMA_VERSION,
+        labels=[
+            "auto_research",
+            "terminal_decision",
+            normalized_outcome,
+            normalized_reason,
+        ],
+        summary=(
+            f"Auto Research terminal decision {hypothesis}: "
+            f"{normalized_outcome} ({normalized_reason})."
+        ),
+        artifact_refs=refs,
+        details={
+            "hypothesis_id": hypothesis,
+            "outcome": normalized_outcome,
+            "reason": normalized_reason,
+            "evidence_graph_revision": graph_revision,
+            "hypothesis_evidence_revision": hypothesis_revision,
+        },
+        recorded_at=recorded_at,
+    )
+
+
+def _current_terminal_decision(
+    *,
+    rollout_events: Sequence[Mapping[str, Any]],
+    hypothesis_id: str,
+    hypothesis_evidence_revision: str,
+) -> dict[str, Any]:
+    current = [
+        _decision_view(event)
+        for event in _terminal_decision_events(rollout_events)
+        if str(_event_details(event).get("hypothesis_id") or "") == hypothesis_id
+        and str(
+            _event_details(event).get("hypothesis_evidence_revision") or ""
+        )
+        == hypothesis_evidence_revision
+    ]
+    signatures = {
+        (
+            item["decision_ref"],
+            item["outcome"],
+            item["reason"],
+            item["decided_by"],
+        )
+        for item in current
+    }
+    if len(signatures) > 1:
+        raise ValueError(
+            f"conflicting terminal decisions for current evidence revision: {hypothesis_id}"
+        )
+    if not current:
+        raise ValueError(
+            f"no terminal decision exists for current evidence revision: {hypothesis_id}"
+        )
+    return current[-1]
+
+
+def build_peer_review_event(
+    *,
+    evidence_graph: Mapping[str, Any],
+    rollout_events: Sequence[Mapping[str, Any]],
+    hypothesis_id: str,
+    reviewer_agent_id: str,
+    verdict: str,
+    evidence_refs: Sequence[str] | None = None,
+    require_independent: bool = False,
+    registered_agent_ids: Sequence[str] | None = None,
+    recorded_at: str | None = None,
+) -> dict[str, Any]:
+    hypothesis = _compact_public_token(hypothesis_id, field="hypothesis_id")
+    reviewer = _compact_public_token(
+        reviewer_agent_id,
+        field="reviewer_agent_id",
+    )
+    normalized_verdict = _compact_public_token(verdict, field="verdict")
+    if normalized_verdict not in PEER_REVIEW_VERDICTS:
+        raise ValueError(
+            "verdict must be one of: "
+            + ", ".join(sorted(PEER_REVIEW_VERDICTS))
+        )
+    registered = {
+        _compact_public_token(agent_id, field="registered_agent_ids[]")
+        for agent_id in registered_agent_ids or []
+    }
+    if reviewer not in registered:
+        raise ValueError(
+            f"reviewer_agent_id is not registered for this research goal: {reviewer}"
+        )
+    node = _hypothesis_node(evidence_graph, hypothesis)
+    graph_revision = research_evidence_graph_revision(evidence_graph)
+    hypothesis_revision = hypothesis_evidence_revision(
+        evidence_graph,
+        hypothesis,
+    )
+    decision = _current_terminal_decision(
+        rollout_events=rollout_events,
+        hypothesis_id=hypothesis,
+        hypothesis_evidence_revision=hypothesis_revision,
+    )
+    producer = str(node.get("claimed_by") or "")
+    decision_agent = str(decision.get("decided_by") or "")
+    independent = reviewer not in {producer, decision_agent}
+    if require_independent and not independent:
+        raise ValueError(
+            "independent peer review requires a reviewer distinct from both "
+            "the hypothesis producer and terminal decision agent"
+        )
+    refs = _compact_public_text_list(evidence_refs, field="evidence_refs")
+    review_ref = _stable_ref(
+        "research_review",
+        [
+            evidence_graph.get("goal_id"),
+            hypothesis,
+            decision["decision_ref"],
+            hypothesis_revision,
+            reviewer,
+            normalized_verdict,
+        ],
+    )
+    return build_rollout_event(
+        goal_id=str(evidence_graph.get("goal_id") or ""),
+        event_kind="validation",
+        agent_id=reviewer,
+        todo_id=str(node.get("todo_id") or ""),
+        agent_role="evaluator_promoter",
+        decision_id=review_ref,
+        source_event_id=str(decision.get("event_id") or ""),
+        status=normalized_verdict,
+        classification=AUTO_RESEARCH_PEER_REVIEW_SCHEMA_VERSION,
+        labels=[
+            "auto_research",
+            "peer_review",
+            normalized_verdict,
+            "independent" if independent else "self_review",
+        ],
+        summary=(
+            f"Auto Research review {hypothesis}: {normalized_verdict}; "
+            f"independent={str(independent).lower()}."
+        ),
+        artifact_refs=refs,
+        details={
+            "hypothesis_id": hypothesis,
+            "decision_ref": decision["decision_ref"],
+            "verdict": normalized_verdict,
+            "decision_agent_id": decision_agent,
+            "producer_agent_id": producer,
+            "independent": independent,
+            "evidence_graph_revision": graph_revision,
+            "hypothesis_evidence_revision": hypothesis_revision,
+        },
+        recorded_at=recorded_at,
+    )

--- a/loopx/capabilities/auto_research/terminal_result_projection.py
+++ b/loopx/capabilities/auto_research/terminal_result_projection.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from ..explore.result_log import (
+    build_explore_edge_event,
+    build_explore_finding_event,
+    build_explore_node_event,
+)
+
+
+def _now_iso() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def explore_result_ids(hypothesis_id: str) -> tuple[str, str]:
+    suffix = hashlib.sha256(hypothesis_id.encode("utf-8")).hexdigest()[:16]
+    return f"research_{suffix}", f"finding_{suffix}"
+
+
+def _projection_timestamp(record: Mapping[str, Any]) -> str:
+    decision = record.get("terminal_decision")
+    review = record.get("peer_review")
+    review_rows = review.get("reviews") if isinstance(review, Mapping) else []
+    if isinstance(review_rows, list) and review_rows:
+        return str(review_rows[-1].get("recorded_at") or _now_iso())
+    if isinstance(decision, Mapping):
+        return str(decision.get("recorded_at") or _now_iso())
+    history = record.get("decision_history")
+    if isinstance(history, list) and history:
+        return str(history[-1].get("recorded_at") or _now_iso())
+    return "1970-01-01T00:00:00Z"
+
+
+def build_terminal_result_explore_events(
+    *,
+    query: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    goal_id = str(query.get("goal_id") or "")
+    node_ids = {
+        str(record.get("hypothesis_id") or ""): explore_result_ids(
+            str(record.get("hypothesis_id") or "")
+        )[0]
+        for record in query.get("results") or []
+        if isinstance(record, Mapping)
+        and (
+            record.get("finding_status")
+            or record.get("decision_state") != "pending"
+        )
+    }
+    events: list[dict[str, Any]] = []
+    for raw_record in query.get("results") or []:
+        if not isinstance(raw_record, Mapping):
+            continue
+        record = dict(raw_record)
+        if (
+            record["decision_state"] == "pending"
+            and not record.get("finding_status")
+        ):
+            continue
+        hypothesis_id = str(record["hypothesis_id"])
+        node_id, finding_id = explore_result_ids(hypothesis_id)
+        decision = record.get("terminal_decision")
+        review = record.get("peer_review")
+        timestamp = _projection_timestamp(record)
+        if record["decision_state"] == "conflict":
+            node_status = "blocked"
+            blocked_reason = "Conflicting terminal decisions exist for the current evidence revision."
+        elif record["decision_state"] == "stale":
+            node_status = "exploring"
+            blocked_reason = None
+        elif isinstance(decision, Mapping) and decision.get("outcome") == "promoted":
+            node_status = "resolved"
+            blocked_reason = None
+        elif record["decision_state"] == "pending":
+            node_status = "exploring"
+            blocked_reason = None
+        else:
+            node_status = "dead_end"
+            blocked_reason = None
+        evidence_refs = []
+        if isinstance(decision, Mapping):
+            evidence_refs.extend(decision.get("evidence_refs") or [])
+        if isinstance(review, Mapping):
+            for row in review.get("reviews") or []:
+                if isinstance(row, Mapping):
+                    evidence_refs.extend(row.get("evidence_refs") or [])
+        events.append(
+            build_explore_node_event(
+                goal_id=goal_id,
+                node_id=node_id,
+                node_kind="hypothesis",
+                title=str(record.get("hypothesis") or hypothesis_id),
+                status=node_status,
+                summary=(
+                    f"Auto Research hypothesis {hypothesis_id}; "
+                    f"decision_state={record['decision_state']}; "
+                    f"review_state={review.get('state') if isinstance(review, Mapping) else 'not_applicable'}."
+                ),
+                blocked_reason=blocked_reason,
+                parent_id=node_ids.get(str(record.get("parent_hypothesis_id") or "")),
+                agent_id=str(record.get("producer_agent_id") or ""),
+                evidence_refs=sorted(set(evidence_refs)),
+                tags=[
+                    "auto_research",
+                    str(record.get("mechanism_family") or "research"),
+                    record["decision_state"],
+                ],
+                recorded_at=timestamp,
+            )
+        )
+        parent = str(record.get("parent_hypothesis_id") or "")
+        if parent and parent in node_ids:
+            events.append(
+                build_explore_edge_event(
+                    goal_id=goal_id,
+                    from_node=node_ids[parent],
+                    to_node=node_id,
+                    edge_type="leads_to",
+                    summary="A later Auto Research hypothesis extends the earlier research path.",
+                    recorded_at=timestamp,
+                )
+            )
+        finding_status = record.get("finding_status")
+        if not finding_status:
+            continue
+        outcome = (
+            str(decision.get("outcome") or "")
+            if isinstance(decision, Mapping)
+            else "stale"
+        )
+        reason = (
+            str(decision.get("reason") or "")
+            if isinstance(decision, Mapping)
+            else "evidence_revision_changed"
+        )
+        events.append(
+            build_explore_finding_event(
+                goal_id=goal_id,
+                finding_id=finding_id,
+                node_id=node_id,
+                title=str(record.get("hypothesis") or hypothesis_id),
+                status=str(finding_status),
+                summary=(
+                    f"Terminal outcome={outcome}; reason={reason}; "
+                    f"review_state={review.get('state') if isinstance(review, Mapping) else 'not_applicable'}; "
+                    f"review_verdict={review.get('verdict') if isinstance(review, Mapping) else None}."
+                ),
+                agent_id=str(
+                    decision.get("decided_by")
+                    if isinstance(decision, Mapping)
+                    else record.get("producer_agent_id")
+                ),
+                evidence_refs=sorted(set(evidence_refs)),
+                tags=[
+                    "auto_research",
+                    hypothesis_id,
+                    outcome,
+                    str(finding_status),
+                ],
+                recorded_at=timestamp,
+            )
+        )
+    return events

--- a/loopx/capabilities/auto_research/terminal_result_query.py
+++ b/loopx/capabilities/auto_research/terminal_result_query.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from .evidence_packet import _compact_public_token
+from .terminal_result_contract import (
+    AUTO_RESEARCH_TERMINAL_RESULT_QUERY_SCHEMA_VERSION,
+    _decision_view,
+    _event_details,
+    _peer_review_events,
+    _review_view,
+    _terminal_decision_events,
+    hypothesis_evidence_revision,
+    research_evidence_graph_revision,
+)
+
+
+def _review_resolution(
+    *,
+    reviews: Sequence[Mapping[str, Any]],
+    decision_ref: str,
+    hypothesis_revision: str,
+    registered_agent_ids: Sequence[str],
+) -> dict[str, Any]:
+    matching = [
+        _review_view(
+            review,
+            registered_agent_ids=registered_agent_ids,
+        )
+        for review in reviews
+        if str(_event_details(review).get("decision_ref") or "") == decision_ref
+        and str(
+            _event_details(review).get("hypothesis_evidence_revision") or ""
+        )
+        == hypothesis_revision
+    ]
+    independent = [item for item in matching if item["independent"]]
+    verdicts = {item["verdict"] for item in independent}
+    if len(verdicts) > 1:
+        return {
+            "state": "conflict",
+            "independent": True,
+            "verdict": None,
+            "reviews": matching,
+        }
+    if independent:
+        return {
+            "state": "independent_reviewed",
+            "independent": True,
+            "verdict": independent[-1]["verdict"],
+            "reviews": matching,
+        }
+    if matching:
+        return {
+            "state": "self_review_only",
+            "independent": False,
+            "verdict": matching[-1]["verdict"],
+            "reviews": matching,
+        }
+    return {
+        "state": "unreviewed",
+        "independent": False,
+        "verdict": None,
+        "reviews": [],
+    }
+
+
+def _result_record(
+    *,
+    evidence_graph: Mapping[str, Any],
+    node: Mapping[str, Any],
+    graph_revision: str,
+    decisions: Sequence[Mapping[str, Any]],
+    reviews: Sequence[Mapping[str, Any]],
+    registered_agent_ids: Sequence[str],
+) -> dict[str, Any]:
+    hypothesis_id = str(node.get("hypothesis_id") or "")
+    hypothesis_revision = hypothesis_evidence_revision(
+        evidence_graph,
+        hypothesis_id,
+    )
+    history = [
+        _decision_view(event)
+        for event in decisions
+        if str(_event_details(event).get("hypothesis_id") or "") == hypothesis_id
+    ]
+    current = [
+        item
+        for item in history
+        if item["hypothesis_evidence_revision"] == hypothesis_revision
+    ]
+    current_signatures = {
+        (
+            item["decision_ref"],
+            item["outcome"],
+            item["reason"],
+            item["decided_by"],
+        )
+        for item in current
+    }
+    conflict = len(current_signatures) > 1
+    decision = current[-1] if len(current_signatures) == 1 else None
+    stale = bool(history) and not decision and not conflict
+    prior_assertion = any(
+        item["outcome"] == "promoted"
+        or (
+            item["outcome"] == "retired"
+            and item["reason"] == "contradicted"
+        )
+        for item in history
+        if item["hypothesis_evidence_revision"] != hypothesis_revision
+    )
+    review = (
+        _review_resolution(
+            reviews=reviews,
+            decision_ref=decision["decision_ref"],
+            hypothesis_revision=hypothesis_revision,
+            registered_agent_ids=registered_agent_ids,
+        )
+        if decision
+        else {
+            "state": "not_applicable",
+            "independent": False,
+            "verdict": None,
+            "reviews": [],
+        }
+    )
+    finding_status = None
+    if conflict or stale:
+        finding_status = "tentative"
+    elif not decision and str(node.get("status") or "") == "supported":
+        finding_status = "tentative"
+    elif decision and decision["outcome"] == "promoted":
+        finding_status = (
+            "confirmed"
+            if review["state"] == "independent_reviewed"
+            and review["verdict"] == "approve"
+            else "tentative"
+        )
+    elif (
+        decision
+        and decision["outcome"] == "retired"
+        and decision["reason"] == "contradicted"
+    ):
+        finding_status = (
+            "refuted"
+            if review["state"] == "independent_reviewed"
+            and review["verdict"] == "approve"
+            else "tentative"
+        )
+    elif decision and decision["outcome"] == "retired" and prior_assertion:
+        finding_status = "tentative"
+    return {
+        "hypothesis_id": hypothesis_id,
+        "parent_hypothesis_id": str(node.get("parent_hypothesis_id") or ""),
+        "todo_id": str(node.get("todo_id") or ""),
+        "producer_agent_id": str(node.get("claimed_by") or ""),
+        "mechanism_family": str(node.get("mechanism_family") or ""),
+        "hypothesis": str(node.get("hypothesis") or hypothesis_id),
+        "research_status": str(node.get("status") or ""),
+        "evidence_graph_revision": graph_revision,
+        "hypothesis_evidence_revision": hypothesis_revision,
+        "decision_state": (
+            "conflict"
+            if conflict
+            else "current"
+            if decision
+            else "stale"
+            if stale
+            else "pending"
+        ),
+        "terminal_decision": decision,
+        "peer_review": review,
+        "finding_status": finding_status,
+        "decision_history": history,
+    }
+
+
+def build_terminal_result_query(
+    *,
+    evidence_graph: Mapping[str, Any],
+    rollout_events: Sequence[Mapping[str, Any]],
+    registered_agent_ids: Sequence[str],
+    hypothesis_id: str | None = None,
+    include_history: bool = False,
+) -> dict[str, Any]:
+    graph_revision = research_evidence_graph_revision(evidence_graph)
+    decisions = _terminal_decision_events(rollout_events)
+    reviews = _peer_review_events(rollout_events)
+    requested = (
+        _compact_public_token(hypothesis_id, field="hypothesis_id")
+        if hypothesis_id
+        else None
+    )
+    records = [
+        _result_record(
+            evidence_graph=evidence_graph,
+            node=node,
+            graph_revision=graph_revision,
+            decisions=decisions,
+            reviews=reviews,
+            registered_agent_ids=registered_agent_ids,
+        )
+        for node in evidence_graph.get("nodes") or []
+        if isinstance(node, Mapping)
+        and (requested is None or str(node.get("hypothesis_id") or "") == requested)
+    ]
+    if requested and not records:
+        raise ValueError(f"unknown hypothesis_id: {requested}")
+    if not include_history:
+        records = [
+            {
+                key: value
+                for key, value in record.items()
+                if key != "decision_history"
+            }
+            for record in records
+        ]
+    return {
+        "ok": True,
+        "schema_version": AUTO_RESEARCH_TERMINAL_RESULT_QUERY_SCHEMA_VERSION,
+        "goal_id": str(evidence_graph.get("goal_id") or ""),
+        "evidence_graph_revision": graph_revision,
+        "hypothesis_id": requested,
+        "include_history": include_history,
+        "result_count": len(records),
+        "results": records,
+        "boundary": {
+            "raw_logs_recorded": False,
+            "private_artifacts_recorded": False,
+            "absolute_paths_recorded": False,
+        },
+    }

--- a/loopx/capabilities/auto_research/terminal_results.py
+++ b/loopx/capabilities/auto_research/terminal_results.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from .research_state import build_research_evidence_graph_from_rollout_events
+from .terminal_result_contract import (
+    AUTO_RESEARCH_PEER_REVIEW_SCHEMA_VERSION,
+    AUTO_RESEARCH_TERMINAL_DECISION_SCHEMA_VERSION,
+    _decision_view,
+    _event_decision_ref,
+    _review_view,
+    build_peer_review_event,
+    build_terminal_decision_event,
+)
+from .terminal_result_projection import (
+    build_terminal_result_explore_events,
+    explore_result_ids,
+)
+from .terminal_result_query import build_terminal_result_query
+from ..explore.result_log import (
+    append_explore_result_events,
+    build_explore_result_projection,
+    explore_result_log_path,
+    load_explore_result_events_strict,
+)
+from ...agent_registry import (
+    registered_agent_ids_from_registry,
+    require_registered_agent_id,
+)
+from ...history import load_registry
+from ...paths import resolve_runtime_root
+from ...rollout_event_log import (
+    append_rollout_event,
+    load_rollout_events,
+    rollout_event_log_path,
+)
+
+
+AUTO_RESEARCH_TERMINAL_RESULT_PROJECTION_SCHEMA_VERSION = (
+    "auto_research_terminal_result_projection_v0"
+)
+
+
+def _append_validation_event_once(
+    *,
+    log_path: Path,
+    event: Mapping[str, Any],
+    rollout_events: Sequence[Mapping[str, Any]],
+    dry_run: bool,
+) -> dict[str, Any]:
+    decision_ref = _event_decision_ref(event)
+    matching = [
+        dict(existing)
+        for existing in rollout_events
+        if _event_decision_ref(existing) == decision_ref
+    ]
+    if len(matching) > 1:
+        raise ValueError(f"duplicate validation decision ref: {decision_ref}")
+    if matching:
+        existing = matching[0]
+        comparable_existing = _validation_event_semantics(existing)
+        comparable_new = _validation_event_semantics(event)
+        if comparable_existing != comparable_new:
+            raise ValueError(f"conflicting validation decision ref: {decision_ref}")
+        return {"appended": False, "reused": True, "event": existing}
+    if not dry_run:
+        append_rollout_event(log_path, event)
+    return {
+        "appended": not dry_run,
+        "reused": False,
+        "event": dict(event),
+    }
+
+
+def _validation_event_semantics(event: Mapping[str, Any]) -> dict[str, Any]:
+    comparable = {
+        key: value
+        for key, value in event.items()
+        if key not in {"event_id", "recorded_at"}
+    }
+    details = comparable.get("details")
+    if isinstance(details, Mapping):
+        comparable["details"] = {
+            key: value
+            for key, value in details.items()
+            if key != "evidence_graph_revision"
+        }
+    return comparable
+
+
+def _load_runtime_state(
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    goal_id: str,
+) -> tuple[Path, list[dict[str, Any]], dict[str, Any]]:
+    registry = load_registry(registry_path)
+    runtime_root = resolve_runtime_root(registry, runtime_root_arg)
+    rollout_path = rollout_event_log_path(runtime_root, goal_id)
+    rollout_events = load_rollout_events(rollout_path)
+    evidence_graph = build_research_evidence_graph_from_rollout_events(
+        goal_id=goal_id,
+        rollout_events=rollout_events,
+    )
+    return runtime_root, rollout_events, evidence_graph
+
+
+def decide_terminal_result(
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    goal_id: str,
+    hypothesis_id: str,
+    outcome: str,
+    reason: str,
+    decided_by: str,
+    evidence_refs: Sequence[str] | None,
+    dry_run: bool,
+) -> dict[str, Any]:
+    runtime_root, rollout_events, evidence_graph = _load_runtime_state(
+        registry_path=registry_path,
+        runtime_root_arg=runtime_root_arg,
+        goal_id=goal_id,
+    )
+    decider = require_registered_agent_id(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        agent_id=decided_by,
+        field="decided_by",
+    )
+    event = build_terminal_decision_event(
+        evidence_graph=evidence_graph,
+        hypothesis_id=hypothesis_id,
+        outcome=outcome,
+        reason=reason,
+        decided_by=decider,
+        evidence_refs=evidence_refs,
+    )
+    write = _append_validation_event_once(
+        log_path=rollout_event_log_path(runtime_root, goal_id),
+        event=event,
+        rollout_events=rollout_events,
+        dry_run=dry_run,
+    )
+    return {
+        "ok": True,
+        "schema_version": AUTO_RESEARCH_TERMINAL_DECISION_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "dry_run": dry_run,
+        "decision": _decision_view(write["event"]),
+        "appended": write["appended"],
+        "reused": write["reused"],
+    }
+
+
+def review_terminal_result(
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    goal_id: str,
+    hypothesis_id: str,
+    reviewer_agent_id: str,
+    verdict: str,
+    evidence_refs: Sequence[str] | None,
+    require_independent: bool,
+    dry_run: bool,
+) -> dict[str, Any]:
+    runtime_root, rollout_events, evidence_graph = _load_runtime_state(
+        registry_path=registry_path,
+        runtime_root_arg=runtime_root_arg,
+        goal_id=goal_id,
+    )
+    reviewer = require_registered_agent_id(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        agent_id=reviewer_agent_id,
+        field="reviewer_agent_id",
+    )
+    event = build_peer_review_event(
+        evidence_graph=evidence_graph,
+        rollout_events=rollout_events,
+        hypothesis_id=hypothesis_id,
+        reviewer_agent_id=reviewer,
+        verdict=verdict,
+        evidence_refs=evidence_refs,
+        require_independent=require_independent,
+        registered_agent_ids=registered_agent_ids_from_registry(
+            registry_path,
+            goal_id,
+        ),
+    )
+    write = _append_validation_event_once(
+        log_path=rollout_event_log_path(runtime_root, goal_id),
+        event=event,
+        rollout_events=rollout_events,
+        dry_run=dry_run,
+    )
+    return {
+        "ok": True,
+        "schema_version": AUTO_RESEARCH_PEER_REVIEW_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "dry_run": dry_run,
+        "review": _review_view(
+            write["event"],
+            registered_agent_ids=registered_agent_ids_from_registry(
+                registry_path,
+                goal_id,
+            ),
+        ),
+        "appended": write["appended"],
+        "reused": write["reused"],
+    }
+
+
+def query_terminal_results(
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    goal_id: str,
+    hypothesis_id: str | None,
+    include_history: bool,
+) -> dict[str, Any]:
+    runtime_root, rollout_events, evidence_graph = _load_runtime_state(
+        registry_path=registry_path,
+        runtime_root_arg=runtime_root_arg,
+        goal_id=goal_id,
+    )
+    query = build_terminal_result_query(
+        evidence_graph=evidence_graph,
+        rollout_events=rollout_events,
+        registered_agent_ids=registered_agent_ids_from_registry(
+            registry_path,
+            goal_id,
+        ),
+        hypothesis_id=hypothesis_id,
+        include_history=include_history,
+    )
+    explore_events = load_explore_result_events_strict(
+        explore_result_log_path(runtime_root, goal_id),
+        goal_id=goal_id,
+    )
+    projection = build_explore_result_projection(
+        explore_events,
+        goal_id=goal_id,
+        finding_limit=max(1, len(explore_events)),
+    )
+    expected_nodes = {
+        explore_result_ids(str(record.get("hypothesis_id") or ""))[0]
+        for record in query["results"]
+        if record.get("finding_status")
+        or record.get("decision_state") != "pending"
+    }
+    projected_nodes = {
+        str(node.get("node_id") or "")
+        for node in projection.get("nodes") or []
+    }
+    expected_findings = {
+        explore_result_ids(str(record.get("hypothesis_id") or ""))[1]: str(
+            record.get("finding_status") or ""
+        )
+        for record in query["results"]
+        if record.get("finding_status")
+    }
+    projected_findings = {
+        str(finding.get("finding_id") or ""): str(finding.get("status") or "")
+        for finding in projection.get("findings") or []
+    }
+    node_current = expected_nodes.issubset(projected_nodes)
+    finding_current = all(
+        projected_findings.get(finding_id) == status
+        for finding_id, status in expected_findings.items()
+    )
+    query["explore_projection"] = {
+        "state": (
+            "current"
+            if (expected_nodes or expected_findings) and node_current and finding_current
+            else "not_required"
+            if not expected_nodes and not expected_findings
+            else "missing_or_stale"
+        ),
+        "expected_node_ids": sorted(expected_nodes),
+        "projected_node_ids": sorted(expected_nodes & projected_nodes),
+        "expected_findings": expected_findings,
+        "projected_findings": {
+            finding_id: projected_findings.get(finding_id)
+            for finding_id in sorted(expected_findings)
+            if finding_id in projected_findings
+        },
+        "counts": projection.get("counts"),
+    }
+    return query
+
+
+def project_terminal_results(
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    goal_id: str,
+    dry_run: bool,
+) -> dict[str, Any]:
+    runtime_root, rollout_events, evidence_graph = _load_runtime_state(
+        registry_path=registry_path,
+        runtime_root_arg=runtime_root_arg,
+        goal_id=goal_id,
+    )
+    query = build_terminal_result_query(
+        evidence_graph=evidence_graph,
+        rollout_events=rollout_events,
+        registered_agent_ids=registered_agent_ids_from_registry(
+            registry_path,
+            goal_id,
+        ),
+        include_history=True,
+    )
+    events = build_terminal_result_explore_events(query=query)
+    write = (
+        {
+            "requested_event_count": len(events),
+            "appended_event_count": 0,
+            "reused_event_count": 0,
+        }
+        if dry_run
+        else append_explore_result_events(
+            explore_result_log_path(runtime_root, goal_id),
+            events,
+            expected_goal_id=goal_id,
+        )
+    )
+    projection = build_explore_result_projection(
+        events,
+        goal_id=goal_id,
+        finding_limit=max(1, len(events)),
+    )
+    return {
+        "ok": True,
+        "schema_version": AUTO_RESEARCH_TERMINAL_RESULT_PROJECTION_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "dry_run": dry_run,
+        "evidence_graph_revision": query["evidence_graph_revision"],
+        "result_count": query["result_count"],
+        "event_count": len(events),
+        "would_append_count": len(events),
+        "appended_count": write["appended_event_count"],
+        "reused_count": write["reused_event_count"],
+        "results": query["results"],
+        "explore_projection": projection,
+        "boundary": query["boundary"],
+    }

--- a/loopx/capabilities/auto_research/worker_runtime.py
+++ b/loopx/capabilities/auto_research/worker_runtime.py
@@ -48,6 +48,8 @@ SUPPORTED_WORKER_ACTIONS = {
     "summarize_evidence",
     "write_evaluation_summary",
     "review_promotion_readiness",
+    "record_terminal_decision",
+    "review_terminal_decision",
 }
 AppendEvidence = Callable[[str], dict[str, object]]
 AUTO_RESEARCH_STATE_SUMMARY_MODE = "rollout_evidence_summary"
@@ -58,6 +60,8 @@ MANUAL_RESEARCH_REQUIRED_ACTIONS = {
     "run_dev_eval",
     "run_holdout_eval",
     "write_evidence",
+    "record_terminal_decision",
+    "review_terminal_decision",
 }
 SUMMARY_ACTIONS = {
     "classify_evidence",

--- a/loopx/capabilities/auto_research/worker_skill/SKILL.md
+++ b/loopx/capabilities/auto_research/worker_skill/SKILL.md
@@ -229,11 +229,44 @@ Verification checklist:
 - boundary says protected scope stayed clean;
 - negative evidence remains queryable.
 
+When evidence reaches a terminal boundary:
+
+- use `loopx auto-research decide` to record `promoted` or `retired`; a
+  promotion candidate is not a terminal result;
+- bind the decision to the current evidence graph revision and keep the
+  decision evidence refs public-safe;
+- use `loopx auto-research review --require-independent` only from a different
+  registered peer than both the hypothesis producer and decision agent;
+- treat self-review as visible review evidence, never as independent review;
+- use `loopx auto-research project-results` after decisions and reviews so
+  exact `loopx auto-research results` queries can verify Explore readback.
+
+Example terminal path:
+
+```bash
+loopx auto-research decide \
+  --goal-id "$LOOPX_GOAL_ID" \
+  --hypothesis-id "<hypothesis-id>" \
+  --outcome promoted \
+  --reason holdout_validated \
+  --agent-id "$LOOPX_AGENT_ID" \
+  --execute
+
+loopx auto-research review \
+  --goal-id "$LOOPX_GOAL_ID" \
+  --hypothesis-id "<hypothesis-id>" \
+  --reviewer-agent-id "$LOOPX_AGENT_ID" \
+  --verdict approve \
+  --require-independent \
+  --execute
+```
+
 Must not:
 
 - bypass an owner/operator gate;
 - certify a showcase claim;
 - rewrite the hypothesis graph to make the result look cleaner.
+- label the same producer or decision agent as an independent reviewer.
 
 ## Projection Narrator
 
@@ -250,9 +283,13 @@ Allowed actions:
 Useful command:
 
 ```bash
-loopx --format json auto-research frontier \
+loopx --format json auto-research project-results \
   --goal-id "$LOOPX_GOAL_ID" \
-  --agent-id "$LOOPX_AGENT_ID"
+  --execute
+
+loopx --format json auto-research results \
+  --goal-id "$LOOPX_GOAL_ID" \
+  --include-history
 ```
 
 Must stop before:

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -1599,6 +1599,26 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "purpose": "Create an isolated goal and launch visible role-scoped workers through the shared multi-agent runtime.",
                 "write_boundary": "local goal, workspace, and visible launcher state; no publication, benchmark submission, or protected external action",
             },
+            {
+                "command": "loopx auto-research decide --goal-id <goal-id> --hypothesis-id <id> --outcome <promoted|retired> --reason <reason> --agent-id <agent-id> --execute",
+                "purpose": "Record one terminal research decision after current evidence satisfies the promotion or retirement contract.",
+                "write_boundary": "one public-safe validation event bound to the current hypothesis evidence revision",
+            },
+            {
+                "command": "loopx auto-research review --goal-id <goal-id> --hypothesis-id <id> --reviewer-agent-id <peer-id> --verdict <verdict> --require-independent --execute",
+                "purpose": "Record a registered-peer review receipt without rewriting the research evidence or terminal decision.",
+                "write_boundary": "one public-safe validation receipt; independent mode rejects producer and decision-agent self-review",
+            },
+            {
+                "command": "loopx auto-research results --goal-id <goal-id> [--hypothesis-id <id>] [--include-history]",
+                "purpose": "Read exact current and historical terminal outcomes, review state, and Explore readback.",
+                "write_boundary": "read-only projection over rollout and Explore result events",
+            },
+            {
+                "command": "loopx auto-research project-results --goal-id <goal-id> --execute",
+                "purpose": "Project current terminal outcomes into deterministic existing Explore node and finding events.",
+                "write_boundary": "goal-scoped Explore result log only; repeated projection is idempotent",
+            },
         ],
         "implemented_protocols": [
             {
@@ -1611,10 +1631,32 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "module": "loopx.capabilities.auto_research.research_state",
                 "doc": "docs/reference/protocols/decentralized-auto-research-state-v0.md",
             },
+            {
+                "schema_version": "auto_research_terminal_decision_v0",
+                "module": "loopx.capabilities.auto_research.terminal_result_contract",
+                "doc": "docs/reference/protocols/decentralized-auto-research-state-v0.md",
+            },
+            {
+                "schema_version": "auto_research_peer_review_v0",
+                "module": "loopx.capabilities.auto_research.terminal_result_contract",
+                "doc": "docs/reference/protocols/auto-research-lane-contract-v1.md",
+            },
+            {
+                "schema_version": "auto_research_terminal_result_query_v0",
+                "module": "loopx.capabilities.auto_research.terminal_result_query",
+                "doc": "docs/reference/protocols/decentralized-auto-research-state-v0.md",
+            },
+            {
+                "schema_version": "auto_research_terminal_result_projection_v0",
+                "module": "loopx.capabilities.auto_research.terminal_results",
+                "doc": "docs/reference/protocols/decentralized-auto-research-state-v0.md",
+            },
         ],
         "smokes": [
             "python3 examples/auto-research-user-contract-entry-smoke.py",
             "python3 examples/auto-research-worker-turn-smoke.py",
+            "python3 examples/auto-research-terminal-results-smoke.py",
+            "python3 examples/auto-research-terminal-results-cli-smoke.py",
         ],
         "docs": [
             "docs/guides/auto-research-command-path.md",
@@ -1623,6 +1665,8 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
         "boundaries": [
             "The preset reuses shared control-plane and multi-agent contracts; it is not a second scheduler or runner.",
             "Completion and uplift require role-authored evidence and projected outcomes; the launcher does not manufacture research results.",
+            "Promotion and retirement candidates are not terminal decisions; explicit decisions bind one hypothesis evidence revision.",
+            "Same-agent review remains visible but cannot be labeled independent or upgrade a finding to confirmed or refuted.",
         ],
         "next_real_step": (
             "Use the one-question entrypoint for bounded research and preserve every promoted or rejected outcome in canonical evidence."


### PR DESCRIPTION
## Summary

- add hypothesis-scoped terminal decisions for promoted, retired, and contradicted Auto Research hypotheses
- require a registered peer distinct from both producer and decision agent before a result can become confirmed or refuted
- expose current and historical terminal results through CLI and human views, then project them deterministically into the existing Explore result layer
- preserve candidate and manual-research boundaries: rollout candidates never become terminal results automatically

## Why

Auto Research already had hypothesis promotion and retirement, but those state transitions were not a durable answer to "what is the final result?" A role named evaluator existed, but there was no review receipt that proved the reviewer was independent. This change keeps ownership inside Auto Research and reuses Explore as the finding store instead of adding a core contract or a second result store.

## Changed surfaces

- runtime/API: terminal decision and peer-review contracts, result query, projection service, CLI and human rendering
- protocols: candidate versus terminal semantics, role separation, evidence revision binding, projection rules
- validation: semantic and CLI smokes for review conflicts, stale evidence, idempotence, forgery resistance, and distinct value/alpha hypotheses

## Validation

- `python3 examples/auto-research-terminal-results-smoke.py`
- `python3 examples/auto-research-terminal-results-cli-smoke.py`
- all `examples/auto-research-*-smoke.py` and `examples/decentralized-auto-research-*-smoke.py`
- capability catalog and slash-command discovery smokes
- `loopx canary premerge --from-git-diff`: 16 executed, 16 passed, 0 failures
- `python3 -m compileall -q ...`
- public/private boundary scan and `git diff --check`
- `loopx check`: 0 errors; 2 unrelated pre-existing state-projection warnings for other goals

## Known environment gap

- `pytest` was not installed in the active Python environment (`No module named pytest`), so no dependency was installed implicitly. The repository's focused executable smokes and premerge canary were used instead.

## Review hold

This changes Auto Research runtime behavior and its terminal evidence policy. It is intentionally left open for maintainer review and is not a self-merge candidate.
