### PR TITLE
feat(goal-channel): reuse shared provider targets

### DIFF
--- a/docs/architecture/rfcs/goal-channel-collaboration-v0.md
+++ b/docs/architecture/rfcs/goal-channel-collaboration-v0.md
@@ -82,6 +82,9 @@ Suggested command surface:
 
 ```bash
 loopx goal-channel setup --provider lark --goal-id <goal-id>
+loopx goal-channel target add --name <target> --provider lark ...
+loopx goal-channel setup --goal-id <goal-id> --target <target>
+loopx goal-channel attach --target <target> --goal-id <goal-a> --goal-id <goal-b>
 loopx goal-channel doctor --goal-id <goal-id>
 loopx goal-channel sync --goal-id <goal-id>
 loopx goal-channel notify-gate --goal-id <goal-id>
@@ -144,6 +147,40 @@ raw Lark payloads, local file paths, or credentials. Public packets may expose
 booleans, counts, sanitized provider labels, and operator-safe URLs only when
 the caller has already chosen to show them.
 
+### Shared provider targets
+
+Several Goal Channels may reference one named local-private provider target.
+The target owns the reusable Lark chat and sender identity; each Goal binding
+continues to own its control message, Kanban, receipts, and cooldown state:
+
+```bash
+loopx goal-channel target add \
+  --name loopx-dev \
+  --provider lark \
+  --chat-id <private-chat-id> \
+  --bot-app-id <private-app-id> \
+  --execute
+
+loopx goal-channel attach \
+  --target loopx-dev \
+  --goal-id goal-a \
+  --goal-id goal-b \
+  --execute
+```
+
+The target store belongs under the resolved LoopX runtime root and is never a
+public or repository-tracked configuration. A target-linked Goal binding stores
+only `target_ref` plus Goal-local state; changing a target updates the resolved
+chat or sender for every referencing Goal without merging their state.
+After moving a target to another group, rerun bounded `attach` batches so each
+Goal can establish and verify its own control message in the new group.
+
+Machines do not synchronize private chat ids or authentication profiles. To
+use the same group from a workstation and a development host, configure the
+same target name independently on each machine. Inbound routing must reply to a
+specific gate message or carry an explicit Goal id; ordinary group text must
+never be inferred as belonging to one of several Goals.
+
 ## BYO Provider Identity
 
 Open-source LoopX should default to **Bring Your Own provider identity**:
@@ -167,8 +204,9 @@ operations. Goal Control messages, pins, and gate notifications always use the
 configured bot identity. It does not require or request
 `im:message.send_as_user`.
 
-Effectful setup requires an explicit `--bot-app-id cli_...`. LoopX verifies
-that it matches the selected `lark-cli` profile before adding the bot or
+Effectful direct setup requires an explicit `--bot-app-id cli_...`; target-based
+setup obtains that explicit selection from the local-private target. LoopX
+verifies that it matches the selected `lark-cli` profile before adding the bot or
 sending a message. Omitting the flag is a preview-only convenience, not
 authorization to select the default profile's bot.
 

--- a/docs/architecture/rfcs/goal-channel-collaboration-v0.zh-CN.md
+++ b/docs/architecture/rfcs/goal-channel-collaboration-v0.zh-CN.md
@@ -73,6 +73,9 @@ chat、pinned status、Kanban、notification receipts 和 provider-specific meta
 
 ```bash
 loopx goal-channel setup --provider lark --goal-id <goal-id>
+loopx goal-channel target add --name <target> --provider lark ...
+loopx goal-channel setup --goal-id <goal-id> --target <target>
+loopx goal-channel attach --target <target> --goal-id <goal-a> --goal-id <goal-b>
 loopx goal-channel doctor --goal-id <goal-id>
 loopx goal-channel sync --goal-id <goal-id>
 loopx goal-channel notify-gate --goal-id <goal-id>
@@ -133,6 +136,37 @@ chat id、member id、message id、profile name、raw Lark payload、本地文�
 只有当调用方明确选择展示时，公开 packet 才可以展示布尔值、计数、脱敏 provider
 label 和 operator-safe URL。
 
+### 共享 provider target
+
+多个 Goal Channel 可以引用同一个具名、本地私有的 provider target。target 持有
+可复用的 Lark 群和发送身份；每个 Goal binding 仍独立持有自己的控制消息、Kanban、
+receipt 和 cooldown 状态：
+
+```bash
+loopx goal-channel target add \
+  --name loopx-dev \
+  --provider lark \
+  --chat-id <private-chat-id> \
+  --bot-app-id <private-app-id> \
+  --execute
+
+loopx goal-channel attach \
+  --target loopx-dev \
+  --goal-id goal-a \
+  --goal-id goal-b \
+  --execute
+```
+
+target store 位于解析后的 LoopX runtime root 下，绝不能成为公开或提交进仓库的配置。
+引用 target 的 Goal binding 只保存 `target_ref` 和 Goal 本地状态；更新 target 会改变
+所有引用 Goal 解析到的群或 sender，但不会合并这些 Goal 的状态。
+target 换到另一个群后，应重新执行有界 `attach` 批次，让每个 Goal 在新群中分别建立并
+回读自己的控制消息。
+
+不同机器之间不自动同步私有 chat id 或认证 profile。若本机和开发机需要使用同一个群，
+应在两台机器上分别配置同名 target。未来接收群回复时，只能接受对具体 gate 消息的回复，
+或携带明确 Goal id 的操作；不得把普通群文本推断给多个 Goal 中的某一个。
+
 ## BYO Provider Identity
 
 开源 LoopX 应默认使用 **Bring Your Own provider identity**：
@@ -154,7 +188,8 @@ label 和 operator-safe URL。
 和 gate notification 始终使用已配置的 bot identity，不请求也不依赖
 `im:message.send_as_user`。
 
-执行 setup 时必须显式传入 `--bot-app-id cli_...`。LoopX 会验证该 app id
+直接执行 setup 时必须显式传入 `--bot-app-id cli_...`；target 模式则从本地私有
+target 取得这项明确选择。LoopX 会验证该 app id
 与所选 `lark-cli` profile 一致，再允许加 bot 或发消息。省略该参数只适用于
 preview，不代表可以静默选择默认 profile 的 bot。
 

--- a/loopx/cli_commands/goal_channel.py
+++ b/loopx/cli_commands/goal_channel.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any
 
@@ -10,12 +10,19 @@ from ..extensions.lark import (
     LARK_GOAL_CHANNEL_PERMISSION,
 )
 from ..extensions.lark.goal_channel import (
+    add_lark_goal_channel_target,
     default_goal_channel_binding_path,
+    default_goal_channel_target_path,
     doctor_lark_goal_channel,
+    goal_channel_target_for_name,
+    list_goal_channel_targets,
     notify_lark_goal_channel_gate,
+    read_goal_channel_binding,
+    read_goal_channel_targets,
     setup_lark_goal_channel,
     sync_lark_goal_channel,
 )
+from ..extensions.lark.goal_channel_contracts import binding_for_goal, operation_packet
 from ..extensions.runtime import (
     default_extension_state_file,
     resolve_extension_activation,
@@ -52,6 +59,10 @@ def register_goal_channel_commands(
     )
     add_subcommand_format(setup)
     _add_common_args(setup)
+    setup.add_argument(
+        "--target",
+        help="Reuse a named local-private provider target instead of direct channel flags.",
+    )
     setup.add_argument("--provider", default="lark", choices=["lark"])
     setup.add_argument("--chat-id", help="Reuse an existing Lark group chat.")
     setup.add_argument("--chat-name")
@@ -71,6 +82,51 @@ def register_goal_channel_commands(
     setup.add_argument("--bot-display-name")
     setup.add_argument("--cli-bin")
     setup.add_argument("--execute", action="store_true")
+
+    attach = sub.add_parser(
+        "attach",
+        help="Attach up to eight goals to one shared provider target.",
+    )
+    add_subcommand_format(attach)
+    attach.add_argument("--target", required=True)
+    attach.add_argument("--goal-id", action="append", required=True)
+    attach.add_argument("--target-path", help=argparse.SUPPRESS)
+    attach.add_argument("--execute", action="store_true")
+
+    target = sub.add_parser(
+        "target",
+        help="Manage local-private shared provider targets.",
+    )
+    target_sub = target.add_subparsers(
+        dest="goal_channel_target_command", required=True
+    )
+    target_add = target_sub.add_parser(
+        "add",
+        help="Create or update one local-private shared provider target.",
+    )
+    add_subcommand_format(target_add)
+    target_add.add_argument("--name", required=True)
+    target_add.add_argument("--provider", default="lark", choices=["lark"])
+    target_add.add_argument("--chat-id", required=True)
+    target_add.add_argument("--chat-name")
+    target_add.add_argument(
+        "--identity-mode",
+        default="local_user",
+        choices=["local_user", "project_bot"],
+    )
+    target_add.add_argument("--sender-profile")
+    target_add.add_argument("--sender-identity", default="bot", choices=["bot"])
+    target_add.add_argument("--bot-app-id", required=True)
+    target_add.add_argument("--bot-display-name")
+    target_add.add_argument("--cli-bin")
+    target_add.add_argument("--target-path", help=argparse.SUPPRESS)
+    target_add.add_argument("--execute", action="store_true")
+    target_list = target_sub.add_parser(
+        "list",
+        help="List configured target names without exposing private provider values.",
+    )
+    add_subcommand_format(target_list)
+    target_list.add_argument("--target-path", help=argparse.SUPPRESS)
 
     doctor = sub.add_parser(
         "doctor",
@@ -105,11 +161,12 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
         "--binding-path",
         help="Local-private Goal Channel binding path beside the project registry.",
     )
+    parser.add_argument("--target-path", help=argparse.SUPPRESS)
 
 
 def _error_packet(
     *,
-    goal_id: str,
+    goal_id: str | None,
     operation: str,
     execute: bool,
     blocker: str,
@@ -131,6 +188,152 @@ def _error_packet(
         "private_provider_payload_captured": False,
         "blocker": blocker,
     }
+
+
+def _target_path(args: argparse.Namespace, runtime_root: Path) -> Path:
+    value = getattr(args, "target_path", None)
+    return (
+        Path(str(value)).expanduser()
+        if value
+        else default_goal_channel_target_path(runtime_root)
+    )
+
+
+def _provider_target(
+    *,
+    target_path: Path,
+    target_name: str,
+) -> dict[str, Any] | None:
+    return goal_channel_target_for_name(
+        read_goal_channel_targets(target_path),
+        target_name,
+    )
+
+
+def _binding_target_name(binding_path: Path, goal_id: str) -> str:
+    binding = binding_for_goal(read_goal_channel_binding(binding_path), goal_id) or {}
+    return str(binding.get("target_ref") or "")
+
+
+def _source_context(
+    *,
+    registry: dict[str, Any],
+    registry_path: Path,
+    goal_id: str,
+    binding_path_arg: str | None = None,
+) -> tuple[dict[str, Any], Path, Path]:
+    source_route = resolve_goal_source_runtime_route(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        registry=registry,
+    )
+    source_registry_path = Path(str(source_route["source_registry"]))
+    source_registry = (
+        registry
+        if source_registry_path.expanduser().resolve()
+        == registry_path.expanduser().resolve()
+        else load_registry(source_registry_path)
+    )
+    binding_path = (
+        Path(binding_path_arg).expanduser()
+        if binding_path_arg
+        else default_goal_channel_binding_path(source_registry_path)
+    )
+    return source_registry, source_registry_path, binding_path
+
+
+def _attach_goals(
+    *,
+    registry: dict[str, Any],
+    registry_path: Path,
+    goal_ids: list[str],
+    target_name: str,
+    provider_target: Mapping[str, Any],
+    execute: bool,
+) -> dict[str, Any]:
+    unique_goal_ids = list(dict.fromkeys(str(goal_id) for goal_id in goal_ids))
+    if not unique_goal_ids:
+        return operation_packet(
+            ok=False,
+            goal_id=None,
+            operation="attach",
+            execute=execute,
+            status="blocked",
+            blocker="goal_selection_required",
+            public_summary="attach requires at least one goal",
+            details={"goal_count": 0, "completed_count": 0},
+        )
+    if len(unique_goal_ids) > 8:
+        return operation_packet(
+            ok=False,
+            goal_id=None,
+            operation="attach",
+            execute=execute,
+            status="blocked",
+            blocker="bounded_batch_exceeded",
+            public_summary="attach accepts at most eight goals per invocation",
+            details={"goal_count": len(unique_goal_ids), "completed_count": 0},
+        )
+    results: list[dict[str, Any]] = []
+    external_write_performed = False
+    readback_verified = True
+    for goal_id in unique_goal_ids:
+        source_registry, source_registry_path, binding_path = _source_context(
+            registry=registry,
+            registry_path=registry_path,
+            goal_id=goal_id,
+        )
+        result = setup_lark_goal_channel(
+            registry=source_registry,
+            registry_path=source_registry_path,
+            goal_id=goal_id,
+            binding_path=binding_path,
+            target_name=target_name,
+            provider_target=provider_target,
+            execute=execute,
+        )
+        external_write_performed = bool(
+            external_write_performed or result.get("external_write_performed") is True
+        )
+        readback_verified = bool(
+            readback_verified and result.get("readback_verified") is True
+        )
+        results.append(
+            {
+                "goal_id": goal_id,
+                "ok": bool(result.get("ok")),
+                "status": str(result.get("status") or ""),
+                **(
+                    {"blocker": str(result["blocker"])} if result.get("blocker") else {}
+                ),
+            }
+        )
+        if execute and not result.get("ok"):
+            break
+    ok = len(results) == len(unique_goal_ids) and all(item["ok"] for item in results)
+    return operation_packet(
+        ok=ok,
+        goal_id=None,
+        operation="attach",
+        execute=execute,
+        status="configured" if execute and ok else "preview_ready" if ok else "blocked",
+        blocker=None if ok else "goal_attach_failed",
+        public_summary=(
+            "attached the selected goals to one shared provider target"
+            if execute and ok
+            else "previewed the selected shared-target attachments"
+            if ok
+            else "shared-target attachment stopped at the first failed goal"
+        ),
+        external_write_performed=external_write_performed,
+        readback_verified=bool(execute and ok and readback_verified),
+        details={
+            "target_name": target_name,
+            "goal_count": len(unique_goal_ids),
+            "completed_count": len(results),
+            "results": results,
+        },
+    )
 
 
 def _quota_packet(
@@ -167,29 +370,12 @@ def handle_goal_channel_command(
         return None
     command = str(args.goal_channel_command)
     execute = bool(getattr(args, "execute", False))
-    goal_id = str(args.goal_id)
+    goal_id = str(args.goal_id) if command not in {"attach", "target"} else None
     registry = load_registry(registry_path)
     runtime_root = resolve_runtime_root(
         registry,
         runtime_root_arg,
         registry_path=registry_path,
-    )
-    source_route = resolve_goal_source_runtime_route(
-        registry_path=registry_path,
-        goal_id=goal_id,
-        registry=registry,
-    )
-    source_registry_path = Path(str(source_route["source_registry"]))
-    source_registry = (
-        registry
-        if source_registry_path.expanduser().resolve()
-        == registry_path.expanduser().resolve()
-        else load_registry(source_registry_path)
-    )
-    binding_path = (
-        Path(args.binding_path).expanduser()
-        if args.binding_path
-        else default_goal_channel_binding_path(source_registry_path)
     )
     try:
         activation = resolve_extension_activation(
@@ -207,59 +393,145 @@ def handle_goal_channel_command(
         )
     else:
         try:
-            if command == "setup":
-                payload = setup_lark_goal_channel(
-                    registry=source_registry,
-                    registry_path=source_registry_path,
-                    goal_id=goal_id,
-                    binding_path=binding_path,
-                    chat_id=args.chat_id,
-                    chat_name=args.chat_name,
-                    base_url=args.base_url,
-                    base_token=args.base_token,
-                    table_id=args.table_id,
-                    identity_mode=args.identity_mode,
-                    sender_profile=args.sender_profile,
-                    sender_identity=args.sender_identity,
-                    bot_app_id=getattr(args, "bot_app_id", None),
-                    bot_display_name=args.bot_display_name,
-                    cli_bin=args.cli_bin,
-                    execute=execute,
+            target_path = _target_path(args, runtime_root)
+            if command == "target":
+                target_command = str(args.goal_channel_target_command)
+                if target_command == "add":
+                    payload = add_lark_goal_channel_target(
+                        target_path=target_path,
+                        target_name=args.name,
+                        chat_id=args.chat_id,
+                        chat_name=args.chat_name,
+                        identity_mode=args.identity_mode,
+                        sender_profile=args.sender_profile,
+                        sender_identity=args.sender_identity,
+                        bot_app_id=args.bot_app_id,
+                        bot_display_name=args.bot_display_name,
+                        cli_bin=args.cli_bin,
+                        execute=execute,
+                    )
+                elif target_command == "list":
+                    payload = list_goal_channel_targets(target_path=target_path)
+                else:
+                    raise ValueError(
+                        f"unknown goal-channel target command: {target_command}"
+                    )
+            elif command == "attach":
+                target_name = str(args.target)
+                provider_target = _provider_target(
+                    target_path=target_path,
+                    target_name=target_name,
                 )
-            elif command == "doctor":
-                payload = doctor_lark_goal_channel(
-                    registry=source_registry,
-                    registry_path=source_registry_path,
-                    goal_id=goal_id,
-                    binding_path=binding_path,
-                )
-            elif command == "sync":
-                payload = sync_lark_goal_channel(
-                    registry=source_registry,
-                    registry_path=source_registry_path,
-                    goal_id=goal_id,
-                    binding_path=binding_path,
-                    agent_id=args.agent_id,
-                    execute=execute,
-                )
-            elif command == "notify-gate":
-                payload = notify_lark_goal_channel_gate(
-                    registry=source_registry,
-                    goal_id=goal_id,
-                    binding_path=binding_path,
-                    quota_packet=_quota_packet(
+                if provider_target is None:
+                    payload = _error_packet(
+                        goal_id=None,
+                        operation="attach",
+                        execute=execute,
+                        blocker="provider_target_missing",
+                        summary="configure the named shared provider target first",
+                    )
+                else:
+                    payload = _attach_goals(
+                        registry=registry,
                         registry_path=registry_path,
-                        runtime_root_arg=runtime_root_arg,
-                        goal_id=goal_id,
-                        agent_id=args.agent_id,
-                    ),
-                    cooldown_seconds=max(0, args.cooldown_seconds),
-                    execute=execute,
-                )
+                        goal_ids=list(args.goal_id),
+                        target_name=target_name,
+                        provider_target=provider_target,
+                        execute=execute,
+                    )
             else:
-                raise ValueError(f"unknown goal-channel command: {command}")
+                assert goal_id is not None
+                source_registry, source_registry_path, binding_path = _source_context(
+                    registry=registry,
+                    registry_path=registry_path,
+                    goal_id=goal_id,
+                    binding_path_arg=getattr(args, "binding_path", None),
+                )
+                target_name = str(getattr(args, "target", None) or "")
+                if not target_name:
+                    target_name = _binding_target_name(binding_path, goal_id)
+                provider_target = (
+                    _provider_target(
+                        target_path=target_path,
+                        target_name=target_name,
+                    )
+                    if target_name
+                    else None
+                )
+                if target_name and provider_target is None:
+                    payload = _error_packet(
+                        goal_id=goal_id,
+                        operation=command.replace("-", "_"),
+                        execute=execute,
+                        blocker="provider_target_missing",
+                        summary="configure the named shared provider target first",
+                    )
+                elif command == "setup":
+                    payload = setup_lark_goal_channel(
+                        registry=source_registry,
+                        registry_path=source_registry_path,
+                        goal_id=goal_id,
+                        binding_path=binding_path,
+                        target_name=target_name or None,
+                        provider_target=provider_target,
+                        chat_id=args.chat_id,
+                        chat_name=args.chat_name,
+                        base_url=args.base_url,
+                        base_token=args.base_token,
+                        table_id=args.table_id,
+                        identity_mode=args.identity_mode,
+                        sender_profile=args.sender_profile,
+                        sender_identity=args.sender_identity,
+                        bot_app_id=getattr(args, "bot_app_id", None),
+                        bot_display_name=args.bot_display_name,
+                        cli_bin=args.cli_bin,
+                        execute=execute,
+                    )
+                elif command == "doctor":
+                    payload = doctor_lark_goal_channel(
+                        registry=source_registry,
+                        registry_path=source_registry_path,
+                        goal_id=goal_id,
+                        binding_path=binding_path,
+                        provider_target=provider_target,
+                    )
+                elif command == "sync":
+                    payload = sync_lark_goal_channel(
+                        registry=source_registry,
+                        registry_path=source_registry_path,
+                        goal_id=goal_id,
+                        binding_path=binding_path,
+                        provider_target=provider_target,
+                        agent_id=args.agent_id,
+                        execute=execute,
+                    )
+                elif command == "notify-gate":
+                    payload = notify_lark_goal_channel_gate(
+                        registry=source_registry,
+                        goal_id=goal_id,
+                        binding_path=binding_path,
+                        provider_target=provider_target,
+                        quota_packet=_quota_packet(
+                            registry_path=registry_path,
+                            runtime_root_arg=runtime_root_arg,
+                            goal_id=goal_id,
+                            agent_id=args.agent_id,
+                        ),
+                        cooldown_seconds=max(0, args.cooldown_seconds),
+                        execute=execute,
+                    )
+                else:
+                    raise ValueError(f"unknown goal-channel command: {command}")
             if payload.get("ok"):
                 payload["extension_activation"] = activation
+        except ValueError:
+            payload = _error_packet(
+                goal_id=goal_id,
+                operation=command.replace("-", "_"),
+                execute=execute,
+                blocker="invalid_configuration",
+                summary="the Goal Channel configuration is invalid",
+            )
         except Exception:
             payload = _error_packet(
                 goal_id=goal_id,

--- a/loopx/extensions/lark/goal_channel.py
+++ b/loopx/extensions/lark/goal_channel.py
@@ -13,16 +13,30 @@ from .goal_channel_runtime import (
     sync_lark_goal_channel,
 )
 from .goal_channel_setup import setup_lark_goal_channel
+from .goal_channel_targets import (
+    GOAL_CHANNEL_TARGETS_SCHEMA_VERSION,
+    add_lark_goal_channel_target,
+    default_goal_channel_target_path,
+    goal_channel_target_for_name,
+    list_goal_channel_targets,
+    read_goal_channel_targets,
+)
 
 
 __all__ = [
     "DEFAULT_GATE_COOLDOWN_SECONDS",
     "GOAL_CHANNEL_BINDING_SCHEMA_VERSION",
     "GOAL_CHANNEL_OPERATION_SCHEMA_VERSION",
+    "GOAL_CHANNEL_TARGETS_SCHEMA_VERSION",
+    "add_lark_goal_channel_target",
     "default_goal_channel_binding_path",
+    "default_goal_channel_target_path",
     "doctor_lark_goal_channel",
     "notify_lark_goal_channel_gate",
+    "goal_channel_target_for_name",
+    "list_goal_channel_targets",
     "read_goal_channel_binding",
+    "read_goal_channel_targets",
     "setup_lark_goal_channel",
     "sync_lark_goal_channel",
 ]

--- a/loopx/extensions/lark/goal_channel_contracts.py
+++ b/loopx/extensions/lark/goal_channel_contracts.py
@@ -86,10 +86,43 @@ def goal_from_registry(
 def binding_for_goal(
     payload: Mapping[str, Any],
     goal_id: str,
+    *,
+    provider_target: Mapping[str, Any] | None = None,
 ) -> dict[str, Any] | None:
     bindings = payload.get("bindings")
     binding = bindings.get(goal_id) if isinstance(bindings, Mapping) else None
-    return dict(binding) if isinstance(binding, Mapping) else None
+    if not isinstance(binding, Mapping):
+        return None
+    resolved = dict(binding)
+    target_ref = str(resolved.get("target_ref") or "")
+    if not target_ref or provider_target is None:
+        return resolved
+    if str(provider_target.get("name") or "") != target_ref:
+        raise ValueError("Goal Channel provider target does not match target_ref")
+    if str(provider_target.get("provider") or "") != str(
+        resolved.get("provider") or ""
+    ):
+        raise ValueError("Goal Channel provider target does not match provider")
+    target_channel = provider_target.get("channel")
+    target_identity = provider_target.get("identity")
+    if not isinstance(target_channel, Mapping) or not isinstance(
+        target_identity, Mapping
+    ):
+        raise ValueError("Goal Channel provider target is incomplete")
+    binding_channel = resolved.get("channel")
+    binding_channel = (
+        dict(binding_channel) if isinstance(binding_channel, Mapping) else {}
+    )
+    resolved["channel"] = {
+        **dict(target_channel),
+        **(
+            {"pinned_message_id": binding_channel["pinned_message_id"]}
+            if binding_channel.get("pinned_message_id")
+            else {}
+        ),
+    }
+    resolved["identity"] = dict(target_identity)
+    return resolved
 
 
 def save_goal_binding(
@@ -137,7 +170,7 @@ def parse_time(value: Any) -> datetime | None:
 def operation_packet(
     *,
     ok: bool,
-    goal_id: str,
+    goal_id: str | None,
     operation: str,
     execute: bool,
     status: str,

--- a/loopx/extensions/lark/goal_channel_runtime.py
+++ b/loopx/extensions/lark/goal_channel_runtime.py
@@ -58,11 +58,12 @@ def doctor_lark_goal_channel(
     registry_path: Path,
     goal_id: str,
     binding_path: Path,
+    provider_target: Mapping[str, Any] | None = None,
     runner: CommandRunner = default_subprocess_runner,
 ) -> dict[str, Any]:
     goal_from_registry(registry, goal_id)
     payload = read_goal_channel_binding(binding_path)
-    binding = binding_for_goal(payload, goal_id)
+    binding = binding_for_goal(payload, goal_id, provider_target=provider_target)
     if binding is None:
         return operation_packet(
             ok=False,
@@ -185,13 +186,14 @@ def sync_lark_goal_channel(
     registry_path: Path,
     goal_id: str,
     binding_path: Path,
+    provider_target: Mapping[str, Any] | None = None,
     agent_id: str | None = None,
     execute: bool = False,
     runner: CommandRunner = default_subprocess_runner,
 ) -> dict[str, Any]:
     goal_from_registry(registry, goal_id)
     payload = read_goal_channel_binding(binding_path)
-    binding = binding_for_goal(payload, goal_id)
+    binding = binding_for_goal(payload, goal_id, provider_target=provider_target)
     if binding is None:
         return operation_packet(
             ok=False,
@@ -309,14 +311,15 @@ def notify_lark_goal_channel_gate(
     goal_id: str,
     binding_path: Path,
     quota_packet: Mapping[str, Any],
+    provider_target: Mapping[str, Any] | None = None,
     cooldown_seconds: int = DEFAULT_GATE_COOLDOWN_SECONDS,
     execute: bool = False,
     runner: CommandRunner = default_subprocess_runner,
 ) -> dict[str, Any]:
     goal = goal_from_registry(registry, goal_id)
     payload = read_goal_channel_binding(binding_path)
-    binding = binding_for_goal(payload, goal_id)
-    if binding is None:
+    raw_binding = binding_for_goal(payload, goal_id)
+    if raw_binding is None:
         return operation_packet(
             ok=False,
             goal_id=goal_id,
@@ -326,6 +329,8 @@ def notify_lark_goal_channel_gate(
             blocker="channel_binding_missing",
             public_summary="configure the Goal Channel before notifying a human gate",
         )
+    binding = binding_for_goal(payload, goal_id, provider_target=provider_target)
+    assert binding is not None
     if binding.get("enabled") is not True:
         return operation_packet(
             ok=False,
@@ -555,7 +560,7 @@ def notify_lark_goal_channel_gate(
         "message_id": message_id,
         "verified_at": now_iso(),
     }
-    mutable_binding = dict(binding)
+    mutable_binding = dict(raw_binding)
     mutable_binding["receipts"] = mutable_receipts
     save_goal_binding(
         binding_path=binding_path,

--- a/loopx/extensions/lark/goal_channel_setup.py
+++ b/loopx/extensions/lark/goal_channel_setup.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import hashlib
 import json
+import re
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -65,6 +67,7 @@ def _save_recovery_binding(
     bindings_payload: Mapping[str, Any],
     goal_id: str,
     existing: Mapping[str, Any],
+    target_name: str | None,
     chat_id: str,
     chat_name: str,
     identity_mode: str,
@@ -75,32 +78,80 @@ def _save_recovery_binding(
     cli_bin: str,
 ) -> None:
     recovery = dict(existing)
+    channel = _mapping(existing.get("channel"))
+    identity = _mapping(existing.get("identity"))
+    if target_name:
+        channel = {
+            **(
+                {"pinned_message_id": channel["pinned_message_id"]}
+                if channel.get("pinned_message_id")
+                else {}
+            )
+        }
+        identity = {}
+    else:
+        channel.update({"chat_id": chat_id, "chat_name": chat_name})
+        identity = {
+            "mode": identity_mode,
+            "sender_profile": sender_profile,
+            "sender_identity": sender_identity,
+            "bot_app_id": bot_app_id,
+            "bot_display_name": bot_display_name,
+            "cli_bin": cli_bin,
+        }
     recovery.update(
         {
             "goal_id": goal_id,
             "provider": "lark",
             "enabled": False,
-            "channel": {
-                **_mapping(existing.get("channel")),
-                "chat_id": chat_id,
-                "chat_name": chat_name,
-            },
-            "identity": {
-                "mode": identity_mode,
-                "sender_profile": sender_profile,
-                "sender_identity": sender_identity,
-                "bot_app_id": bot_app_id,
-                "bot_display_name": bot_display_name,
-                "cli_bin": cli_bin,
-            },
+            "channel": channel,
+            "identity": identity,
             "receipts": _mapping(existing.get("receipts")),
         }
     )
+    if target_name:
+        recovery["target_ref"] = target_name
     save_goal_binding(
         binding_path=binding_path,
         payload=bindings_payload,
         goal_id=goal_id,
         binding=recovery,
+    )
+
+
+def _goal_kanban_config_path(registry_path: Path, goal_id: str) -> Path:
+    default_path = default_lark_kanban_config_path(registry_path)
+    slug = re.sub(r"[^a-zA-Z0-9._-]+", "-", goal_id).strip("-._") or "goal"
+    digest = hashlib.sha256(goal_id.encode("utf-8")).hexdigest()[:8]
+    return (
+        default_path.parent
+        / "goal-channels"
+        / f"{slug[:48]}-{digest}"
+        / default_path.name
+    )
+
+
+def _resolved_binding(
+    *,
+    raw_binding: Mapping[str, Any],
+    goal_id: str,
+    target_name: str | None,
+    provider_target: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    if not target_name:
+        return dict(raw_binding)
+    target_binding = {
+        **raw_binding,
+        "provider": "lark",
+        "target_ref": target_name,
+    }
+    return (
+        binding_for_goal(
+            {"bindings": {goal_id: target_binding}},
+            goal_id,
+            provider_target=provider_target,
+        )
+        or {}
     )
 
 
@@ -110,6 +161,8 @@ def setup_lark_goal_channel(
     registry_path: Path,
     goal_id: str,
     binding_path: Path,
+    target_name: str | None = None,
+    provider_target: Mapping[str, Any] | None = None,
     kanban_config_path: Path | None = None,
     chat_id: str | None = None,
     chat_name: str | None = None,
@@ -127,7 +180,34 @@ def setup_lark_goal_channel(
 ) -> dict[str, Any]:
     goal = goal_from_registry(registry, goal_id)
     bindings_payload = read_goal_channel_binding(binding_path)
-    existing = binding_for_goal(bindings_payload, goal_id) or {}
+    raw_existing = binding_for_goal(bindings_payload, goal_id) or {}
+    existing_target_name = str(raw_existing.get("target_ref") or "")
+    effective_target_name = str(target_name or existing_target_name or "") or None
+    if effective_target_name:
+        if provider_target is None:
+            raise ValueError("Goal Channel shared target is required")
+        if any(
+            value is not None
+            for value in (
+                chat_id,
+                chat_name,
+                identity_mode,
+                sender_profile,
+                sender_identity,
+                bot_app_id,
+                bot_display_name,
+                cli_bin,
+            )
+        ):
+            raise ValueError(
+                "Goal Channel --target cannot be combined with channel or identity flags"
+            )
+    existing = _resolved_binding(
+        raw_binding=raw_existing,
+        goal_id=goal_id,
+        target_name=effective_target_name,
+        provider_target=provider_target,
+    )
     existing_channel = _mapping(existing.get("channel"))
     existing_identity = _mapping(existing.get("identity"))
 
@@ -326,7 +406,8 @@ def setup_lark_goal_channel(
                 binding_path=binding_path,
                 bindings_payload=bindings_payload,
                 goal_id=goal_id,
-                existing=existing,
+                existing=raw_existing,
+                target_name=effective_target_name,
                 chat_id=effective_chat_id,
                 chat_name=effective_chat_name,
                 identity_mode=effective_mode,
@@ -337,7 +418,13 @@ def setup_lark_goal_channel(
                 cli_bin=effective_cli_bin,
             )
             bindings_payload = read_goal_channel_binding(binding_path)
-            existing = binding_for_goal(bindings_payload, goal_id) or {}
+            raw_existing = binding_for_goal(bindings_payload, goal_id) or {}
+            existing = _resolved_binding(
+                raw_binding=raw_existing,
+                goal_id=goal_id,
+                target_name=effective_target_name,
+                provider_target=provider_target,
+            )
         else:
             effective_chat_id = "oc_preview"
     elif execute:
@@ -428,8 +515,14 @@ def setup_lark_goal_channel(
             external_write_performed=bool(external_writes),
         )
 
-    effective_kanban_path = (
-        kanban_config_path or default_lark_kanban_config_path(registry_path)
+    existing_kanban = _mapping(raw_existing.get("kanban"))
+    existing_kanban_path = str(existing_kanban.get("config_path") or "")
+    effective_kanban_path = kanban_config_path or (
+        Path(existing_kanban_path).expanduser()
+        if existing_kanban_path
+        else _goal_kanban_config_path(registry_path, goal_id)
+        if effective_target_name
+        else default_lark_kanban_config_path(registry_path)
     )
     kanban = setup_lark_kanban_board(
         config_path=effective_kanban_path,
@@ -647,35 +740,44 @@ def setup_lark_goal_channel(
             "message_id": control_message_id,
             "verified_at": now_iso(),
         }
+        saved_channel = {"pinned_message_id": control_message_id}
+        saved_identity: dict[str, Any] = {}
+        if not effective_target_name:
+            saved_channel.update(
+                {
+                    "chat_id": effective_chat_id,
+                    "chat_name": effective_chat_name,
+                }
+            )
+            saved_identity = {
+                "mode": effective_mode,
+                "sender_profile": effective_profile,
+                "sender_identity": effective_identity,
+                "bot_app_id": effective_app_id,
+                "bot_display_name": effective_bot_name,
+                "cli_bin": effective_cli_bin,
+            }
+        saved_binding: dict[str, Any] = {
+            "goal_id": goal_id,
+            "provider": "lark",
+            "enabled": True,
+            "channel": saved_channel,
+            "kanban": {
+                "config_path": str(effective_kanban_path),
+                "base_token": str(board.get("base_token") or ""),
+                "table_id": str(board.get("table_id") or ""),
+                "base_url": kanban_url,
+            },
+            "identity": saved_identity,
+            "receipts": mutable_receipts,
+        }
+        if effective_target_name:
+            saved_binding["target_ref"] = effective_target_name
         save_goal_binding(
             binding_path=binding_path,
             payload=bindings_payload,
             goal_id=goal_id,
-            binding={
-                "goal_id": goal_id,
-                "provider": "lark",
-                "enabled": True,
-                "channel": {
-                    "chat_id": effective_chat_id,
-                    "chat_name": effective_chat_name,
-                    "pinned_message_id": control_message_id,
-                },
-                "kanban": {
-                    "config_path": str(effective_kanban_path),
-                    "base_token": str(board.get("base_token") or ""),
-                    "table_id": str(board.get("table_id") or ""),
-                    "base_url": kanban_url,
-                },
-                "identity": {
-                    "mode": effective_mode,
-                    "sender_profile": effective_profile,
-                    "sender_identity": effective_identity,
-                    "bot_app_id": effective_app_id,
-                    "bot_display_name": effective_bot_name,
-                    "cli_bin": effective_cli_bin,
-                },
-                "receipts": mutable_receipts,
-            },
+            binding=saved_binding,
         )
     return operation_packet(
         ok=True,

--- a/loopx/extensions/lark/goal_channel_targets.py
+++ b/loopx/extensions/lark/goal_channel_targets.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from ...control_plane.runtime.public_safety import public_safe_compact_text
+from .goal_channel_contracts import operation_packet
+from .goal_channel_transport import APP_ID_PATTERN, CHAT_ID_PATTERN
+from .presentation.kanban import DEFAULT_CLI_BIN
+from .private_json import write_private_json_atomic
+
+
+GOAL_CHANNEL_TARGETS_SCHEMA_VERSION = "loopx_goal_channel_provider_targets_v0"
+TARGET_NAME_PATTERN = re.compile(r"[a-z0-9][a-z0-9._-]{0,63}")
+
+
+def default_goal_channel_target_path(runtime_root: Path) -> Path:
+    return runtime_root.expanduser().resolve() / "goal-channel-targets.json"
+
+
+def read_goal_channel_targets(path: Path) -> dict[str, Any]:
+    target_path = path.expanduser()
+    if not target_path.exists():
+        return {
+            "schema_version": GOAL_CHANNEL_TARGETS_SCHEMA_VERSION,
+            "targets": {},
+        }
+    payload = json.loads(target_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("Goal Channel target root must be a JSON object")
+    if payload.get("schema_version") != GOAL_CHANNEL_TARGETS_SCHEMA_VERSION:
+        raise ValueError(
+            f"Goal Channel targets must use {GOAL_CHANNEL_TARGETS_SCHEMA_VERSION}"
+        )
+    if not isinstance(payload.get("targets"), dict):
+        raise ValueError("Goal Channel targets require an object `targets`")
+    return payload
+
+
+def goal_channel_target_for_name(
+    payload: Mapping[str, Any],
+    target_name: str,
+) -> dict[str, Any] | None:
+    targets = payload.get("targets")
+    target = targets.get(target_name) if isinstance(targets, Mapping) else None
+    return dict(target) if isinstance(target, Mapping) else None
+
+
+def _normalized_target_name(value: str) -> str:
+    target_name = str(value or "").strip()
+    if not TARGET_NAME_PATTERN.fullmatch(target_name):
+        raise ValueError(
+            "Goal Channel target name must use lowercase letters, digits, '.', '_', "
+            "or '-' and begin with a letter or digit"
+        )
+    return target_name
+
+
+def _normalized_lark_target(
+    *,
+    target_name: str,
+    chat_id: str,
+    chat_name: str | None,
+    identity_mode: str | None,
+    sender_profile: str | None,
+    sender_identity: str | None,
+    bot_app_id: str | None,
+    bot_display_name: str | None,
+    cli_bin: str | None,
+) -> dict[str, Any]:
+    safe_name = _normalized_target_name(target_name)
+    safe_chat_id = str(chat_id or "").strip()
+    if not CHAT_ID_PATTERN.fullmatch(safe_chat_id):
+        raise ValueError("Lark Goal Channel target chat id must begin with oc_")
+    mode = str(identity_mode or "local_user")
+    if mode not in {"local_user", "project_bot"}:
+        raise ValueError(
+            "Lark Goal Channel identity mode must be local_user or project_bot"
+        )
+    identity = str(sender_identity or "bot")
+    if identity != "bot":
+        raise ValueError("Lark Goal Channel messages require bot sender identity")
+    app_id = str(bot_app_id or "").strip()
+    if not APP_ID_PATTERN.fullmatch(app_id):
+        raise ValueError("Lark Goal Channel target bot app id must begin with cli_")
+    profile = str(sender_profile or "")
+    bot_name = str(bot_display_name or "")
+    if mode == "project_bot" and (not profile or not bot_name):
+        raise ValueError(
+            "project_bot targets require sender profile and bot display name"
+        )
+    return {
+        "name": safe_name,
+        "provider": "lark",
+        "enabled": True,
+        "channel": {
+            "chat_id": safe_chat_id,
+            "chat_name": public_safe_compact_text(chat_name or safe_name, limit=60),
+        },
+        "identity": {
+            "mode": mode,
+            "sender_profile": profile,
+            "sender_identity": identity,
+            "bot_app_id": app_id,
+            "bot_display_name": bot_name,
+            "cli_bin": str(cli_bin or DEFAULT_CLI_BIN),
+        },
+    }
+
+
+def add_lark_goal_channel_target(
+    *,
+    target_path: Path,
+    target_name: str,
+    chat_id: str,
+    chat_name: str | None = None,
+    identity_mode: str | None = None,
+    sender_profile: str | None = None,
+    sender_identity: str | None = None,
+    bot_app_id: str | None = None,
+    bot_display_name: str | None = None,
+    cli_bin: str | None = None,
+    execute: bool = False,
+) -> dict[str, Any]:
+    target = _normalized_lark_target(
+        target_name=target_name,
+        chat_id=chat_id,
+        chat_name=chat_name,
+        identity_mode=identity_mode,
+        sender_profile=sender_profile,
+        sender_identity=sender_identity,
+        bot_app_id=bot_app_id,
+        bot_display_name=bot_display_name,
+        cli_bin=cli_bin,
+    )
+    payload = read_goal_channel_targets(target_path)
+    targets = dict(payload.get("targets") or {})
+    existing = targets.get(target["name"])
+    changed = existing != target
+    if execute and changed:
+        targets[str(target["name"])] = target
+        write_private_json_atomic(
+            target_path,
+            {
+                "schema_version": GOAL_CHANNEL_TARGETS_SCHEMA_VERSION,
+                "targets": targets,
+            },
+        )
+        readback = read_goal_channel_targets(target_path)
+        if goal_channel_target_for_name(readback, str(target["name"])) != target:
+            return operation_packet(
+                ok=False,
+                goal_id=None,
+                operation="target_add",
+                execute=True,
+                status="failed",
+                blocker="readback_mismatch",
+                public_summary="the shared Goal Channel target could not be read back",
+            )
+    status = (
+        "configured"
+        if execute and changed
+        else "already_configured"
+        if execute
+        else "preview_ready"
+    )
+    return operation_packet(
+        ok=True,
+        goal_id=None,
+        operation="target_add",
+        execute=execute,
+        status=status,
+        public_summary=(
+            "configured one local-private shared Goal Channel target"
+            if execute and changed
+            else "the shared Goal Channel target is already configured"
+            if execute
+            else "previewed one shared Goal Channel target"
+        ),
+        readback_verified=bool(execute),
+        details={
+            "target_name": target["name"],
+            "changed": changed,
+            "target_count": len(set(targets) | {str(target["name"])}),
+        },
+    )
+
+
+def list_goal_channel_targets(*, target_path: Path) -> dict[str, Any]:
+    payload = read_goal_channel_targets(target_path)
+    targets = payload.get("targets")
+    items = [
+        {
+            "target_name": name,
+            "provider": str(target.get("provider") or ""),
+            "enabled": target.get("enabled") is True,
+        }
+        for name, target in sorted(
+            targets.items() if isinstance(targets, Mapping) else []
+        )
+        if isinstance(target, Mapping)
+    ]
+    return operation_packet(
+        ok=True,
+        goal_id=None,
+        operation="target_list",
+        execute=False,
+        status="ready",
+        public_summary="listed configured shared Goal Channel targets",
+        readback_verified=True,
+        details={"target_count": len(items), "items": items},
+    )

--- a/tests/extensions/test_lark_goal_channel.py
+++ b/tests/extensions/test_lark_goal_channel.py
@@ -16,9 +16,7 @@ from loopx.extensions.lark.goal_channel import (
     setup_lark_goal_channel,
     sync_lark_goal_channel,
 )
-from loopx.extensions.lark.goal_channel_contracts import (
-    write_goal_channel_binding,
-)
+from loopx.extensions.lark.goal_channel_contracts import write_goal_channel_binding
 from loopx.extensions.lark.presentation.kanban import (
     lark_kanban_schema_payload,
     save_lark_kanban_board_config,
@@ -150,7 +148,9 @@ def _fake_runner(
         if "+messages-send" in args:
             text = args[args.index("--text") + 1]
             message_id = (
-                GATE_MESSAGE_ID if text.startswith("LoopX human gate") else CONTROL_MESSAGE_ID
+                GATE_MESSAGE_ID
+                if text.startswith("LoopX human gate")
+                else CONTROL_MESSAGE_ID
             )
             sent_texts[message_id] = text
             return _result({"ok": True, "data": {"message_id": message_id}})
@@ -223,6 +223,26 @@ def _write_binding(binding_path: Path, kanban_path: Path) -> None:
     )
 
 
+def _provider_target() -> dict[str, Any]:
+    return {
+        "name": "loopx-dev",
+        "provider": "lark",
+        "enabled": True,
+        "channel": {
+            "chat_id": CHAT_ID,
+            "chat_name": "LoopX Development",
+        },
+        "identity": {
+            "mode": "local_user",
+            "sender_profile": "",
+            "sender_identity": "bot",
+            "bot_app_id": "cli_public_fixture",
+            "bot_display_name": "",
+            "cli_bin": "lark-cli",
+        },
+    }
+
+
 def _assert_public_packet(payload: dict[str, Any]) -> None:
     serialized = json.dumps(payload, ensure_ascii=False)
     assert "oc_" not in serialized
@@ -232,6 +252,102 @@ def _assert_public_packet(payload: dict[str, Any]) -> None:
     assert str(Path.home()) not in serialized
     assert "sender_profile" not in serialized
     assert "config_path" not in serialized
+
+
+def test_target_setup_keeps_shared_provider_values_out_of_goal_binding(
+    tmp_path: Path,
+) -> None:
+    registry_path = tmp_path / ".loopx" / "registry.json"
+    binding_path = tmp_path / ".loopx" / "goal-channel.json"
+    calls: list[list[str]] = []
+    runner = _fake_runner(calls)
+
+    result = setup_lark_goal_channel(
+        registry=_registry(tmp_path),
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        target_name="loopx-dev",
+        provider_target=_provider_target(),
+        execute=True,
+        runner=runner,
+    )
+
+    assert result["ok"] is True
+    raw = read_goal_channel_binding(binding_path)["bindings"][GOAL_ID]
+    assert raw["target_ref"] == "loopx-dev"
+    assert raw["channel"] == {"pinned_message_id": CONTROL_MESSAGE_ID}
+    assert raw["identity"] == {}
+    assert "goal-channels" in raw["kanban"]["config_path"]
+    assert CHAT_ID not in json.dumps(raw)
+    assert "cli_public_fixture" not in json.dumps(raw)
+
+    doctor = doctor_lark_goal_channel(
+        registry=_registry(tmp_path),
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        provider_target=_provider_target(),
+        runner=runner,
+    )
+    assert doctor["ok"] is True
+
+    notified = notify_lark_goal_channel_gate(
+        registry=_registry(tmp_path),
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        provider_target=_provider_target(),
+        quota_packet={
+            "state": "operator_gate",
+            "notify_user_on_gate": True,
+            "gate_prompt": "Approve the bounded external write.",
+        },
+        execute=True,
+        runner=_fake_runner([]),
+    )
+    assert notified["ok"] is True
+    after_notify = read_goal_channel_binding(binding_path)["bindings"][GOAL_ID]
+    assert len(after_notify["receipts"]) == 2
+    assert CHAT_ID not in json.dumps(after_notify)
+    assert "cli_public_fixture" not in json.dumps(after_notify)
+
+
+def test_two_goals_share_target_but_keep_kanban_and_receipts_separate(
+    tmp_path: Path,
+) -> None:
+    second_goal_id = "goal-second-public-fixture"
+    registry = _registry(tmp_path)
+    registry["goals"].append(
+        {
+            **registry["goals"][0],
+            "id": second_goal_id,
+            "objective": "Deliver a second isolated Goal Channel projection.",
+        }
+    )
+    registry_path = tmp_path / ".loopx" / "registry.json"
+    binding_path = tmp_path / ".loopx" / "goal-channel.json"
+    runner = _fake_runner([])
+
+    for goal_id in (GOAL_ID, second_goal_id):
+        result = setup_lark_goal_channel(
+            registry=registry,
+            registry_path=registry_path,
+            goal_id=goal_id,
+            binding_path=binding_path,
+            target_name="loopx-dev",
+            provider_target=_provider_target(),
+            execute=True,
+            runner=runner,
+        )
+        assert result["ok"] is True
+
+    bindings = read_goal_channel_binding(binding_path)["bindings"]
+    first = bindings[GOAL_ID]
+    second = bindings[second_goal_id]
+    assert first["target_ref"] == second["target_ref"] == "loopx-dev"
+    assert first["kanban"]["config_path"] != second["kanban"]["config_path"]
+    assert set(first["receipts"]).isdisjoint(second["receipts"])
+    assert CHAT_ID not in json.dumps(bindings)
 
 
 def test_setup_is_preview_only_and_does_not_write_binding(tmp_path: Path) -> None:
@@ -348,9 +464,10 @@ def test_setup_execute_persists_private_binding_after_verified_pin(
         if "+messages-send" in args
         and not args[args.index("--text") + 1].startswith("LoopX human gate")
     )
-    assert "Kanban: https://example.invalid/base/public-fixture" in control_send[
-        control_send.index("--text") + 1
-    ]
+    assert (
+        "Kanban: https://example.invalid/base/public-fixture"
+        in control_send[control_send.index("--text") + 1]
+    )
     _assert_public_packet(payload)
 
 
@@ -476,7 +593,9 @@ def test_setup_retry_reuses_verified_chat_after_later_failure(
 
     assert retry["ok"] is True
     assert not any("+chat-create" in args for args in retry_calls)
-    assert read_goal_channel_binding(binding_path)["bindings"][GOAL_ID]["enabled"] is True
+    assert (
+        read_goal_channel_binding(binding_path)["bindings"][GOAL_ID]["enabled"] is True
+    )
     _assert_public_packet(first)
     _assert_public_packet(retry)
 
@@ -534,7 +653,9 @@ def test_setup_retry_adds_missing_bot_without_recreating_chat(
 
     assert payload["ok"] is True
     assert not any("+chat-create" in args for args in calls)
-    add_bot = next(args for args in calls if "chat.members" in args and "create" in args)
+    add_bot = next(
+        args for args in calls if "chat.members" in args and "create" in args
+    )
     assert add_bot[add_bot.index("--member-id-type") + 1] == "app_id"
     assert json.loads(add_bot[add_bot.index("--data") + 1]) == {
         "id_list": ["cli_public_fixture"]
@@ -543,7 +664,9 @@ def test_setup_retry_adds_missing_bot_without_recreating_chat(
         "+messages-send" in args and args[args.index("--as") + 1] == "bot"
         for args in calls
     )
-    assert read_goal_channel_binding(binding_path)["bindings"][GOAL_ID]["enabled"] is True
+    assert (
+        read_goal_channel_binding(binding_path)["bindings"][GOAL_ID]["enabled"] is True
+    )
     _assert_public_packet(payload)
 
 
@@ -600,9 +723,7 @@ def test_notify_gate_is_idempotent_after_verified_send(tmp_path: Path) -> None:
         "gate_prompt": "Approve the bounded external write.",
         "recommended_action": "Wait for the owner decision.",
         "user_todo_summary": {
-            "first_executable_items": [
-                {"text": "Approve the bounded external write."}
-            ]
+            "first_executable_items": [{"text": "Approve the bounded external write."}]
         },
     }
 

--- a/tests/extensions/test_lark_goal_channel_targets.py
+++ b/tests/extensions/test_lark_goal_channel_targets.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from loopx.cli import build_parser
+from loopx.cli_commands import goal_channel as goal_channel_cli
+from loopx.extensions.lark.goal_channel import (
+    GOAL_CHANNEL_BINDING_SCHEMA_VERSION,
+    add_lark_goal_channel_target,
+    list_goal_channel_targets,
+)
+from loopx.extensions.lark.goal_channel_contracts import binding_for_goal
+
+
+GOAL_ID = "goal-public-fixture"
+CHAT_ID = "oc_public_fixture"
+CONTROL_MESSAGE_ID = "om_control_public_fixture"
+
+
+def _provider_target() -> dict[str, Any]:
+    return {
+        "name": "loopx-dev",
+        "provider": "lark",
+        "enabled": True,
+        "channel": {
+            "chat_id": CHAT_ID,
+            "chat_name": "LoopX Development",
+        },
+        "identity": {
+            "mode": "local_user",
+            "sender_profile": "",
+            "sender_identity": "bot",
+            "bot_app_id": "cli_public_fixture",
+            "bot_display_name": "",
+            "cli_bin": "lark-cli",
+        },
+    }
+
+
+def _assert_public_packet(payload: dict[str, Any]) -> None:
+    serialized = json.dumps(payload, ensure_ascii=False)
+    assert "oc_" not in serialized
+    assert "om_" not in serialized
+    assert "cli_public_fixture" not in serialized
+    assert str(Path.home()) not in serialized
+
+
+def test_shared_target_store_is_local_private_and_lists_only_public_names(
+    tmp_path: Path,
+) -> None:
+    target_path = tmp_path / "runtime" / "goal-channel-targets.json"
+
+    preview = add_lark_goal_channel_target(
+        target_path=target_path,
+        target_name="loopx-dev",
+        chat_id=CHAT_ID,
+        chat_name="LoopX Development",
+        bot_app_id="cli_public_fixture",
+    )
+    assert preview["ok"] is True
+    assert preview["status"] == "preview_ready"
+    assert not target_path.exists()
+
+    configured = add_lark_goal_channel_target(
+        target_path=target_path,
+        target_name="loopx-dev",
+        chat_id=CHAT_ID,
+        chat_name="LoopX Development",
+        bot_app_id="cli_public_fixture",
+        execute=True,
+    )
+    assert configured["ok"] is True
+    assert configured["status"] == "configured"
+    assert target_path.stat().st_mode & 0o777 == 0o600
+
+    listed = list_goal_channel_targets(target_path=target_path)
+    assert listed["details"] == {
+        "target_count": 1,
+        "items": [{"target_name": "loopx-dev", "provider": "lark", "enabled": True}],
+    }
+    _assert_public_packet(configured)
+    _assert_public_packet(listed)
+
+
+def test_binding_resolves_shared_target_without_merging_goal_local_state() -> None:
+    payload = {
+        "schema_version": GOAL_CHANNEL_BINDING_SCHEMA_VERSION,
+        "bindings": {
+            GOAL_ID: {
+                "goal_id": GOAL_ID,
+                "provider": "lark",
+                "target_ref": "loopx-dev",
+                "enabled": True,
+                "channel": {"pinned_message_id": CONTROL_MESSAGE_ID},
+                "identity": {},
+                "kanban": {"base_url": "https://example.invalid/base/goal"},
+                "receipts": {"goal-local-receipt": {"kind": "control_message"}},
+            }
+        },
+    }
+    changed_target = _provider_target()
+    changed_target["channel"] = {
+        "chat_id": "oc_updated_public_fixture",
+        "chat_name": "Updated shared group",
+    }
+
+    resolved = binding_for_goal(
+        payload,
+        GOAL_ID,
+        provider_target=changed_target,
+    )
+
+    assert resolved is not None
+    assert resolved["channel"] == {
+        "chat_id": "oc_updated_public_fixture",
+        "chat_name": "Updated shared group",
+        "pinned_message_id": CONTROL_MESSAGE_ID,
+    }
+    assert resolved["identity"] == changed_target["identity"]
+    assert resolved["receipts"] == payload["bindings"][GOAL_ID]["receipts"]
+
+
+def test_shared_target_cli_parses_add_setup_and_bounded_attach() -> None:
+    parser = build_parser()
+    target = parser.parse_args(
+        [
+            "goal-channel",
+            "target",
+            "add",
+            "--name",
+            "loopx-dev",
+            "--chat-id",
+            CHAT_ID,
+            "--bot-app-id",
+            "cli_public_fixture",
+        ]
+    )
+    setup = parser.parse_args(
+        ["goal-channel", "setup", "--goal-id", GOAL_ID, "--target", "loopx-dev"]
+    )
+    attach = parser.parse_args(
+        [
+            "goal-channel",
+            "attach",
+            "--target",
+            "loopx-dev",
+            "--goal-id",
+            GOAL_ID,
+            "--goal-id",
+            "goal-second-public-fixture",
+        ]
+    )
+
+    assert target.goal_channel_target_command == "add"
+    assert setup.target == "loopx-dev"
+    assert attach.goal_id == [GOAL_ID, "goal-second-public-fixture"]
+
+    bounded = goal_channel_cli._attach_goals(
+        registry={},
+        registry_path=Path("registry.json"),
+        goal_ids=[f"goal-{index}" for index in range(9)],
+        target_name="loopx-dev",
+        provider_target=_provider_target(),
+        execute=True,
+    )
+    assert bounded["ok"] is False
+    assert bounded["blocker"] == "bounded_batch_exceeded"
+
+
+def test_effectful_attach_stops_after_first_failed_goal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempted: list[str] = []
+    monkeypatch.setattr(
+        goal_channel_cli,
+        "_source_context",
+        lambda **kwargs: (
+            {"goals": []},
+            tmp_path / ".loopx" / "registry.json",
+            tmp_path / ".loopx" / "goal-channel.json",
+        ),
+    )
+
+    def setup(**kwargs: Any) -> dict[str, Any]:
+        goal_id = str(kwargs["goal_id"])
+        attempted.append(goal_id)
+        ok = goal_id != "goal-fail"
+        return {
+            "ok": ok,
+            "status": "configured" if ok else "failed",
+            "blocker": None if ok else "provider_api_failed",
+            "external_write_performed": ok,
+            "readback_verified": ok,
+        }
+
+    monkeypatch.setattr(goal_channel_cli, "setup_lark_goal_channel", setup)
+
+    result = goal_channel_cli._attach_goals(
+        registry={},
+        registry_path=tmp_path / "registry.json",
+        goal_ids=["goal-ok", "goal-fail", "goal-never-attempted"],
+        target_name="loopx-dev",
+        provider_target=_provider_target(),
+        execute=True,
+    )
+
+    assert result["ok"] is False
+    assert result["details"]["completed_count"] == 2
+    assert result["external_write_performed"] is True
+    assert attempted == ["goal-ok", "goal-fail"]


### PR DESCRIPTION
## Summary
- add named, local-private Lark provider targets that multiple Goal Channel bindings can reference
- add `goal-channel setup --target` and bounded `goal-channel attach` while keeping control messages, Kanban state, receipts, and cooldowns Goal-local
- resolve target configuration only at setup/runtime entry points; the gate decision and notification send/readback contract remain unchanged

## Validation
- `pytest`: 2171 passed, 2 skipped
- focused Goal Channel tests: 105 passed
- Ruff on changed Python, mypy, and `git diff --check`: passed
- standard LoopX premerge: 13/13 passed, 0 failures, 0 warnings, no manual holds
- change-quality: `cqr_25435f10532e2421dc07` for fingerprint `25435f10532e2421dc070398db8378a542f1bbc40119be4c29a000b1fa348568`

## Safety
- no chat ids, bot profiles, credentials, local paths, or private runtime state are committed
- the same target alias can be configured independently on each machine; target values are not copied into Goal state
- inbound reply routing remains Goal-explicit
