### PR TITLE
feat(pr-review): active cadence while review backlog remains

### DIFF
--- a/docs/reference/protocols/pr-review-command-v0.md
+++ b/docs/reference/protocols/pr-review-command-v0.md
@@ -87,6 +87,15 @@ head across unchanged and incomplete polls. It is a scheduling cursor only;
 callers still deduplicate Todo creation by exact target key and must not treat
 the cursor as evidence that a review happened.
 
+`review_backlog` gives the monitor a compact workload cadence hint. It counts
+open, non-draft PRs whose exact head is actionable and not yet recorded in
+`handled_exact_heads`, and returns `recommended_poll_interval_minutes`. While at
+least one unhandled PR remains, the recommendation is `3`; once the actionable
+backlog is empty, it drops to `15`. The hint is scheduling evidence only: it
+does not grant Todo, review, comment, or merge authority, and callers still
+advance the queue with an explicit handled cursor after exact-head review
+readback.
+
 `pull_request_review_queue_observation_v0` has exactly three observation
 states:
 

--- a/loopx/capabilities/pr_review_queue/core.py
+++ b/loopx/capabilities/pr_review_queue/core.py
@@ -9,6 +9,7 @@ from typing import Any
 OBSERVATION_SCHEMA_VERSION = "pull_request_review_queue_observation_v0"
 CANDIDATE_SCHEMA_VERSION = "pull_request_review_candidate_v0"
 TODO_PREVIEW_SCHEMA_VERSION = "pull_request_review_todo_preview_v0"
+REVIEW_BACKLOG_SCHEMA_VERSION = "pr_review_queue_backlog_v0"
 
 OBSERVATION_STATES = {
     "not_observed",
@@ -211,6 +212,30 @@ def _candidate_packet(
     }
 
 
+def _review_backlog(
+    items: Sequence[Mapping[str, Any]],
+    *,
+    handled_set: set[str],
+    pending_candidate_exact_head: str | None,
+) -> dict[str, Any]:
+    actionable_unhandled_count = 0
+    for item in items:
+        exact_head_key = _exact_head_key(item.get("number"), item.get("head_oid"))
+        if exact_head_key is None or exact_head_key in handled_set:
+            continue
+        if _candidate_action(item) is None:
+            continue
+        actionable_unhandled_count += 1
+    active = actionable_unhandled_count > 0 or bool(pending_candidate_exact_head)
+    return {
+        "schema_version": REVIEW_BACKLOG_SCHEMA_VERSION,
+        "actionable_unhandled_count": actionable_unhandled_count,
+        "pending_candidate_exact_head": pending_candidate_exact_head,
+        "recommended_poll_interval_minutes": 3 if active else 15,
+        "recommended_cadence": "active_review" if active else "quiet_wait",
+    }
+
+
 def build_pull_request_review_queue_observation(
     *,
     repository: str | None,
@@ -248,6 +273,7 @@ def build_pull_request_review_queue_observation(
         },
         key=lambda item: (int(item.split("@", 1)[0]), item),
     )
+    handled_set = set(handled)
     previous_fingerprint = (
         str(
             previous.get("queue_fingerprint")
@@ -258,6 +284,11 @@ def build_pull_request_review_queue_observation(
     )
     previous_items = list(_previous_items(previous_observation).values())
     if result_completeness.get("complete") is not True:
+        pending_candidate_exact_head = (
+            previous_candidate
+            if previous_candidate and previous_candidate not in handled_set
+            else None
+        )
         return {
             "schema_version": OBSERVATION_SCHEMA_VERSION,
             "repository": normalized_repository or None,
@@ -273,10 +304,11 @@ def build_pull_request_review_queue_observation(
             "candidate": None,
             "candidate_count": 0,
             "candidate_selection_reason": None,
-            "pending_candidate_exact_head": (
-                previous_candidate
-                if previous_candidate and previous_candidate not in set(handled)
-                else None
+            "pending_candidate_exact_head": pending_candidate_exact_head,
+            "review_backlog": _review_backlog(
+                pull_requests,
+                handled_set=handled_set,
+                pending_candidate_exact_head=pending_candidate_exact_head,
             ),
             "handled_exact_heads": handled,
             "handled_exact_head_count": len(handled),
@@ -378,6 +410,12 @@ def build_pull_request_review_queue_observation(
     ):
         pending_candidate_exact_head = previous_candidate
 
+    review_backlog = _review_backlog(
+        ranked_items,
+        handled_set=handled_set,
+        pending_candidate_exact_head=pending_candidate_exact_head,
+    )
+
     return {
         "schema_version": OBSERVATION_SCHEMA_VERSION,
         "repository": normalized_repository or None,
@@ -400,6 +438,7 @@ def build_pull_request_review_queue_observation(
         "candidate_count": 1 if candidate else 0,
         "candidate_selection_reason": candidate_selection_reason,
         "pending_candidate_exact_head": pending_candidate_exact_head,
+        "review_backlog": review_backlog,
         "handled_exact_heads": active_handled,
         "handled_exact_head_count": len(active_handled),
         "selection_policy": (

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -390,12 +390,31 @@ def _cap_monitor_progression(*, cap_minutes: int, host_floor_minutes: int) -> li
     safe_cap = max(1, int(cap_minutes))
     safe_floor = max(1, int(host_floor_minutes))
     # Keep host RRULEs on stable buckets; the exact due horizon still gates routing.
+    if safe_cap < safe_floor:
+        return [safe_cap]
     progression = [
         max(safe_floor, interval)
         for interval in MONITOR_WAIT_PROGRESSION_MINUTES
         if interval <= safe_cap
     ]
     return progression or [safe_floor]
+
+
+def _select_monitor_cap_minutes(
+    cap_candidates: list[int],
+    *,
+    host_floor_minutes: int,
+) -> int | None:
+    tight_candidates = [
+        candidate
+        for candidate in cap_candidates
+        if candidate is not None and candidate < host_floor_minutes
+    ]
+    if tight_candidates:
+        return max(1, min(tight_candidates))
+    if not cap_candidates:
+        return None
+    return max(host_floor_minutes, min(cap_candidates))
 
 
 def _monitor_wait_item_plan(
@@ -421,9 +440,9 @@ def _monitor_wait_item_plan(
     if expires_at is not None and last_checked_at is not None and last_checked_at <= current_time:
         phase = "active_window"
         if cadence_minutes is not None:
-            cap_candidates.append(max(host_floor, cadence_minutes))
+            cap_candidates.append(cadence_minutes)
         if next_due_at is not None and next_due_at > current_time:
-            cap_candidates.append(max(host_floor, _minutes_until(next_due_at, current_time)))
+            cap_candidates.append(_minutes_until(next_due_at, current_time))
     elif next_due_at is not None and next_due_at > current_time:
         minutes_until_due = _minutes_until(next_due_at, current_time)
         phase = (
@@ -431,16 +450,23 @@ def _monitor_wait_item_plan(
             if minutes_until_due <= MONITOR_WAIT_NEAR_WINDOW_LEAD_MINUTES
             else "far_window"
         )
-        cap_candidates.append(max(host_floor, minutes_until_due))
+        cap_candidates.append(minutes_until_due)
+        if cadence_minutes is not None:
+            cap_candidates.append(cadence_minutes)
         include_next_due_in_reset = True
     elif cadence_minutes is not None:
         phase = "cadence_only"
-        cap_candidates.append(max(host_floor, cadence_minutes))
+        cap_candidates.append(cadence_minutes)
 
     if phase is None or not cap_candidates:
         return None
 
-    cap_minutes = max(host_floor, min(cap_candidates))
+    cap_minutes = _select_monitor_cap_minutes(
+        cap_candidates,
+        host_floor_minutes=host_floor,
+    )
+    if cap_minutes is None:
+        return None
     selected_identity = _monitor_item_identity(item)
     reset_profile = {
         "monitor_wait_phase": phase,
@@ -1247,11 +1273,17 @@ def build_scheduler_hint(
             if isinstance(monitor_plan, dict)
             else None
         )
+        monitor_cap_minutes = (
+            int(monitor_plan.get("cap_minutes"))
+            if isinstance(monitor_plan, dict)
+            and str(monitor_plan.get("cap_minutes") or "").strip().isdigit()
+            else MONITOR_WAIT_HOST_FLOOR_MINUTES
+        )
         monitor_reset_profile = (
             {
                 "cadence_class": "monitor_wait",
-                "codex_app_initial_interval_minutes": MONITOR_WAIT_HOST_FLOOR_MINUTES,
-                "codex_app_initial_rrule": rrule_for_minutes(MONITOR_WAIT_HOST_FLOOR_MINUTES),
+                "codex_app_initial_interval_minutes": monitor_cap_minutes,
+                "codex_app_initial_rrule": rrule_for_minutes(monitor_cap_minutes),
                 "codex_app_max_interval_minutes": 60,
                 "unchanged_poll_backoff_multiplier": 2,
                 "local_scheduler_unchanged_poll_limit": 3,
@@ -1269,7 +1301,7 @@ def build_scheduler_hint(
                 "monitor-only quiet polls should remain alive but use a slower "
                 "cadence until material evidence, a blocker, or replan obligation appears"
             ),
-            codex_interval=15,
+            codex_interval=monitor_cap_minutes,
             codex_max=60,
             cli_limit=3,
             claude_limit=3,

--- a/tests/capabilities/test_pr_review_queue.py
+++ b/tests/capabilities/test_pr_review_queue.py
@@ -242,3 +242,60 @@ def test_approved_transition_routes_to_merge_policy_without_granting_it() -> Non
     assert todo["action_kind"] == "qualify_pull_request_merge_readiness"
     assert "route any merge through repository policy" in todo["text"]
     assert approved["write_authority_granted"] is False
+
+
+def test_review_backlog_keeps_active_cadence_until_all_handled() -> None:
+    first = _observe([_pr(1), _pr(2), _pr(3)])
+
+    assert first["review_backlog"]["actionable_unhandled_count"] == 3
+    assert first["review_backlog"]["recommended_poll_interval_minutes"] == 3
+    assert first["review_backlog"]["recommended_cadence"] == "active_review"
+
+    after_one = _observe(
+        [_pr(1), _pr(2), _pr(3)],
+        previous=first,
+        handled=[f"1@{1:040d}"],
+    )
+    assert after_one["candidate"]["number"] == 2
+    assert after_one["review_backlog"]["actionable_unhandled_count"] == 2
+    assert after_one["review_backlog"]["recommended_poll_interval_minutes"] == 3
+
+    after_two = _observe(
+        [_pr(1), _pr(2), _pr(3)],
+        previous=after_one,
+        handled=[f"2@{2:040d}"],
+    )
+    assert after_two["candidate"]["number"] == 3
+    assert after_two["review_backlog"]["actionable_unhandled_count"] == 1
+    assert after_two["review_backlog"]["recommended_poll_interval_minutes"] == 3
+
+    after_three = _observe(
+        [_pr(1), _pr(2), _pr(3)],
+        previous=after_two,
+        handled=[f"3@{3:040d}"],
+    )
+    assert after_three["candidate"] is None
+    assert after_three["review_backlog"]["actionable_unhandled_count"] == 0
+    assert after_three["review_backlog"]["recommended_poll_interval_minutes"] == 15
+    assert after_three["review_backlog"]["recommended_cadence"] == "quiet_wait"
+
+
+def test_review_backlog_ignores_draft_prs_for_active_cadence() -> None:
+    mixed = _observe([_pr(1, draft=True), _pr(2)])
+
+    assert mixed["review_backlog"]["actionable_unhandled_count"] == 1
+    assert mixed["review_backlog"]["recommended_poll_interval_minutes"] == 3
+
+    only_draft = _observe([_pr(1, draft=True)])
+
+    assert only_draft["review_backlog"]["actionable_unhandled_count"] == 0
+    assert only_draft["review_backlog"]["recommended_poll_interval_minutes"] == 15
+    assert only_draft["review_backlog"]["recommended_cadence"] == "quiet_wait"
+
+
+def test_incomplete_observation_preserves_active_backlog_when_pending() -> None:
+    baseline = _observe([_pr(1), _pr(2)])
+    incomplete = _observe([_pr(1), _pr(2)], complete=False, previous=baseline)
+
+    assert incomplete["review_backlog"]["actionable_unhandled_count"] == 2
+    assert incomplete["review_backlog"]["recommended_poll_interval_minutes"] == 3

--- a/tests/control_plane/test_scheduler_backoff_convergence.py
+++ b/tests/control_plane/test_scheduler_backoff_convergence.py
@@ -17,12 +17,18 @@ HOST_30 = "FREQ=MINUTELY;INTERVAL=30"
 HOST_3 = "FREQ=MINUTELY;INTERVAL=3"
 HOST_6 = "FREQ=MINUTELY;INTERVAL=6"
 HOST_10 = "FREQ=MINUTELY;INTERVAL=10"
+HOST_7 = "FREQ=MINUTELY;INTERVAL=7"
 APP_CONTEXT = scheduler_execution_context_for_runtime_profile(
     "codex_app_heartbeat"
 )
 
 
-def _monitor_decision(*, now: datetime, minutes_until_due: int) -> dict:
+def _monitor_decision(
+    *,
+    now: datetime,
+    minutes_until_due: int,
+    cadence: str = "3m",
+) -> dict:
     return {
         "goal_id": GOAL_ID,
         "agent_identity": {"agent_id": AGENT_ID},
@@ -49,7 +55,7 @@ def _monitor_decision(*, now: datetime, minutes_until_due: int) -> dict:
                     "todo_id": "todo_scheduler_convergence",
                     "task_class": "continuous_monitor",
                     "target_key": "scheduler-convergence",
-                    "cadence": "3m",
+                    "cadence": cadence,
                     "next_due_at": (
                         now + timedelta(minutes=minutes_until_due)
                     ).isoformat(),
@@ -121,26 +127,26 @@ def _ack_state(hint: dict, *, applied_rrule: str, generated_at: datetime) -> dic
     return event["scheduler_ack_event"]["scheduler_state"]
 
 
-def test_monitor_ack_settles_before_progression_and_avoids_15_30_15_flip(
+def test_monitor_ack_settles_before_progression_and_avoids_3_6_3_flip(
     monkeypatch,
 ) -> None:
     now = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
     decision = _monitor_decision(now=now, minutes_until_due=31)
     first = _hint(monkeypatch, decision, now=now)
     first_app = first["codex_app"]
-    assert first_app["recommended_rrule"] == HOST_15
+    assert first_app["recommended_rrule"] == HOST_3
 
-    settled_state = _ack_state(first, applied_rrule=HOST_15, generated_at=now)
+    settled_state = _ack_state(first, applied_rrule=HOST_3, generated_at=now)
     immediate = _hint(
         monkeypatch,
         decision,
         now=now,
         scheduler_state=settled_state,
-        host_rrule=HOST_15,
+        host_rrule=HOST_3,
     )
     immediate_app = immediate["codex_app"]
     assert immediate_app["stateful_backoff"]["state_status"] == "same_identity"
-    assert immediate_app["stateful_backoff"]["current_rrule"] == HOST_15
+    assert immediate_app["stateful_backoff"]["current_rrule"] == HOST_3
     assert immediate_app["stateful_backoff"]["apply_needed"] is False
     assert immediate_app["stateful_backoff"]["host_observation"]["status"] == (
         "matches_recommended"
@@ -152,20 +158,31 @@ def test_monitor_ack_settles_before_progression_and_avoids_15_30_15_flip(
         decision,
         now=now + timedelta(minutes=2),
         scheduler_state=settled_state,
-        host_rrule=HOST_15,
+        host_rrule=HOST_3,
     )
     near_due_app = near_due["codex_app"]
-    assert near_due_app["example_progression_minutes"] == [15]
-    assert near_due_app["stateful_backoff"]["current_rrule"] == HOST_15
+    assert near_due_app["example_progression_minutes"] == [3]
+    assert near_due_app["stateful_backoff"]["current_rrule"] == HOST_3
     assert near_due_app["stateful_backoff"]["apply_needed"] is False
     assert "recommended_rrule" not in near_due_app
+
+
+def test_monitor_near_due_under_floor_uses_tight_cadence(monkeypatch) -> None:
+    now = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    decision = _monitor_decision(now=now, minutes_until_due=7, cadence="30m")
+    first = _hint(monkeypatch, decision, now=now)
+
+    first_app = first["codex_app"]
+    assert first_app["recommended_rrule"] == HOST_7
+    assert first_app["example_progression_minutes"] == [7]
+    assert first["cadence_class"] == "monitor_wait"
 
 
 def test_monitor_progression_advances_after_elapsed_interval_and_then_converges(
     monkeypatch,
 ) -> None:
     now = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
-    decision = _monitor_decision(now=now, minutes_until_due=119)
+    decision = _monitor_decision(now=now, minutes_until_due=119, cadence="30m")
     first = _hint(monkeypatch, decision, now=now)
     settled_15 = _ack_state(first, applied_rrule=HOST_15, generated_at=now)
 


### PR DESCRIPTION
## Summary

- add `review_backlog` to `pull_request_review_queue_observation_v0`
- count open, non-draft, unhandled actionable exact heads
- recommend a 3-minute poll while review work remains and 15 minutes once the backlog is empty
- let the scheduler honor explicit monitor cadence/due values below the default 15-minute host floor
- document the hint as scheduling evidence only, with no Todo/review/comment/merge authority

## Why

A long-running PR review monitor needs to know whether the queue still has actionable work after the current candidate. The old packet exposed only one candidate and a pending cursor, so a monitor could back off to 15 minutes even while many unhandled PRs remained. The scheduler also clamped every monitor cadence/due below 15 minutes back up to the floor, making the hint ineffective.

## Validation

- focused capability tests: `tests/capabilities/test_pr_review_queue.py` + `tests/capabilities/test_pr_review_contract.py` passed
- scheduler convergence tests: 200 passed across `tests/control_plane/test_scheduler_*`
- `python3 -m py_compile` on changed Python files
- `git diff --check`
- standard premerge canary: all selected checks and risk-profile smokes passed, 0 failures, 0 manual holds