### PR TITLE
feat(pr-review): rotate through projected PR candidates

### DIFF
--- a/docs/reference/protocols/pr-review-command-v0.md
+++ b/docs/reference/protocols/pr-review-command-v0.md
@@ -78,14 +78,23 @@ loopx --format json pr-review --repo owner/repo --state open \
 persists these public-safe cursors in `handled_exact_heads`. Candidate emission
 alone is not a completion receipt: callers must add the cursor only after
 review-result readback proves that exact head was handled. A newly supplied
-cursor must match the prior packet's candidate; a caller cannot skip an
-unselected PR by naming it handled. A new head is a new candidate even when the
-prior head was handled.
+cursor must match the prior packet's candidate or one of its
+`projected_candidate_exact_heads`; a caller cannot skip an unselected PR by
+naming it handled. A new head is a new candidate even when the prior head was
+handled.
 
 `pending_candidate_exact_head` preserves the last selected but unhandled exact
 head across unchanged and incomplete polls. It is a scheduling cursor only;
 callers still deduplicate Todo creation by exact target key and must not treat
 the cursor as evidence that a review happened.
+
+`projected_candidate_exact_heads` persists every candidate that has been emitted
+but not yet completed. An unchanged poll skips those projected exact heads and
+selects the next unprojected, unhandled PR in the existing review sequence, so
+the monitor keeps rotating through the backlog instead of waiting on one PR.
+When every actionable PR has already been projected, `candidate` is `None` and
+`pending_candidate_exact_head` remains the last pending cursor. A material
+transition on an already projected exact head still re-selects that head.
 
 `review_backlog` gives the monitor a compact workload cadence hint. It counts
 open, non-draft PRs whose exact head is actionable and not yet recorded in
@@ -102,11 +111,10 @@ states:
 - `not_observed`: the source or packet slice was incomplete. Preserve the
   previous baseline and do not claim the queue is unchanged.
 - `observed_unchanged`: a complete observation has the same queue fingerprint.
-  Do not create a duplicate exact-head Todo. When an explicit handled cursor
-  advances the scheduling state, the packet may select the next unhandled
-  backlog PR while preserving this observation state. An unhandled candidate
-  can remain selected across polls until the caller supplies its completion
-  cursor.
+  Do not create a duplicate exact-head Todo for a projected candidate. The
+  packet selects the next unprojected, unhandled backlog PR so the queue keeps
+  rotating. An unhandled candidate remains in `projected_candidate_exact_heads`
+  until the caller supplies its completion cursor.
 - `material_transition`: a complete observation changed an exact head, review
   decision, check state, draft state, mergeability, or open-queue membership.
 
@@ -114,7 +122,9 @@ The repository-scoped fingerprint contains only compact public PR metadata.
 Persisted `items` carry only PR number and item fingerprint, so the autonomous
 packet does not duplicate the full review queue. The capability selects at
 most one unhandled, non-draft open PR in the existing `pr-review` sequence:
-changed PRs first, then the unchanged backlog after an explicit handled cursor.
+changed PRs first, then an unchanged poll rotates to the next unprojected
+candidate. Projected-but-unhandled candidates are skipped until they are
+handled or their exact head materially changes.
 It emits a
 `pull_request_review_todo_preview_v0` bound to its exact head. The preview may
 route to initial review, re-review after changes, or merge-readiness

--- a/examples/pr-review-command-smoke.py
+++ b/examples/pr-review-command-smoke.py
@@ -293,15 +293,17 @@ def main() -> int:
     assert (
         unchanged["autonomous_review"]["observation_state"] == "observed_unchanged"
     ), unchanged
-    assert unchanged["autonomous_review"]["candidate"] is None, unchanged
+    assert unchanged["autonomous_review"]["candidate"]["number"] == 771, unchanged
+    assert (
+        unchanged["autonomous_review"]["projected_candidate_count"] == 2
+    ), unchanged
     progressed_observation = progressed["autonomous_review"]
     assert (
         progressed_observation["observation_state"] == "observed_unchanged"
     ), progressed
     assert progressed_observation["candidate"]["number"] == 771, progressed
     assert (
-        progressed_observation["candidate_selection_reason"]
-        == "unhandled_backlog_progression"
+        progressed_observation["projected_candidate_count"] == 1
     ), progressed
     assert progressed_observation["handled_exact_head_count"] == 1, progressed
 

--- a/loopx/capabilities/pr_review_queue/core.py
+++ b/loopx/capabilities/pr_review_queue/core.py
@@ -149,6 +149,15 @@ def _previous_candidate_exact_head(value: Any, *, repository: str) -> str | None
     return _exact_head_key(number, head_oid)
 
 
+def _previous_projected_exact_heads(value: Any, *, repository: str) -> list[str]:
+    observation = _previous_observation(value)
+    if str(observation.get("repository") or "").strip() != repository:
+        return []
+    return _normalize_handled_exact_heads(
+        observation.get("projected_candidate_exact_heads")
+    )
+
+
 def _candidate_action(item: Mapping[str, Any]) -> tuple[str, str] | None:
     if item.get("is_draft") is True or _upper(item.get("state"), "OPEN") != "OPEN":
         return None
@@ -256,6 +265,16 @@ def build_pull_request_review_queue_observation(
     previous_candidate = _previous_candidate_exact_head(
         previous_observation, repository=normalized_repository
     )
+    previous_projected = set(
+        _previous_projected_exact_heads(
+            previous_observation,
+            repository=normalized_repository,
+        )
+    )
+    if previous_candidate:
+        previous_projected.add(previous_candidate)
+    projected_set = set(previous_projected)
+    allowed_supplied.update(previous_projected)
     if previous_candidate:
         allowed_supplied.add(previous_candidate)
     unexpected_handled = [
@@ -274,6 +293,15 @@ def build_pull_request_review_queue_observation(
         key=lambda item: (int(item.split("@", 1)[0]), item),
     )
     handled_set = set(handled)
+    projected_set = {
+        key
+        for key in projected_set
+        if key not in handled_set
+    }
+    projected_sorted = sorted(
+        projected_set,
+        key=lambda item: (int(item.split("@", 1)[0]), item),
+    )
     previous_fingerprint = (
         str(
             previous.get("queue_fingerprint")
@@ -312,9 +340,11 @@ def build_pull_request_review_queue_observation(
             ),
             "handled_exact_heads": handled,
             "handled_exact_head_count": len(handled),
+            "projected_candidate_exact_heads": projected_sorted,
+            "projected_candidate_count": len(projected_sorted),
             "selection_policy": (
-                "first unhandled changed PR, then first unhandled backlog PR, "
-                "in the existing pr-review sequence; exact head required"
+                "rotate through unprojected unhandled PRs in the existing "
+                "pr-review sequence; exact head required"
             ),
             "write_authority_granted": False,
             "external_write_performed": False,
@@ -349,6 +379,15 @@ def build_pull_request_review_queue_observation(
     }
     active_handled = [item for item in handled if item in current_exact_heads]
     handled_set = set(active_handled)
+    projected_set = {
+        key
+        for key in projected_set
+        if key in current_exact_heads and key not in handled_set
+    }
+    projected_sorted = sorted(
+        projected_set,
+        key=lambda item: (int(item.split("@", 1)[0]), item),
+    )
 
     queue_items = [
         {key: item[key] for key in ("number", "fingerprint")}
@@ -388,10 +427,10 @@ def build_pull_request_review_queue_observation(
             if candidate is not None:
                 candidate_selection_reason = "unhandled_material_transition"
                 break
-    if candidate is None and handled:
+    if candidate is None:
         for item in ranked_items:
             exact_head_key = _exact_head_key(item.get("number"), item.get("head_oid"))
-            if exact_head_key in handled_set:
+            if exact_head_key in handled_set or exact_head_key in projected_set:
                 continue
             candidate = _candidate_packet(item, repository=normalized_repository)
             if candidate is not None:
@@ -409,6 +448,12 @@ def build_pull_request_review_queue_observation(
         and previous_candidate not in handled_set
     ):
         pending_candidate_exact_head = previous_candidate
+    if candidate_exact_head is not None:
+        projected_set.add(candidate_exact_head)
+    projected_sorted = sorted(
+        projected_set,
+        key=lambda item: (int(item.split("@", 1)[0]), item),
+    )
 
     review_backlog = _review_backlog(
         ranked_items,
@@ -441,9 +486,11 @@ def build_pull_request_review_queue_observation(
         "review_backlog": review_backlog,
         "handled_exact_heads": active_handled,
         "handled_exact_head_count": len(active_handled),
+        "projected_candidate_exact_heads": projected_sorted,
+        "projected_candidate_count": len(projected_sorted),
         "selection_policy": (
-            "first unhandled changed PR, then first unhandled backlog PR, in the "
-            "existing pr-review sequence; exact head required"
+            "rotate through unprojected unhandled PRs in the existing "
+            "pr-review sequence; exact head required"
         ),
         "write_authority_granted": False,
         "external_write_performed": False,

--- a/tests/capabilities/test_pr_review_queue.py
+++ b/tests/capabilities/test_pr_review_queue.py
@@ -106,8 +106,49 @@ def test_unchanged_observation_emits_no_duplicate_candidate() -> None:
 
     assert repeated["observation_state"] == "observed_unchanged"
     assert repeated["changed_pr_numbers"] == []
-    assert repeated["candidate"] is None
-    assert repeated["pending_candidate_exact_head"] == f"1@{1:040d}"
+    assert repeated["candidate"]["number"] == 2
+    assert repeated["pending_candidate_exact_head"] == f"2@{2:040d}"
+
+
+def test_round_robin_rotates_through_projected_candidates() -> None:
+    first = _observe([_pr(1), _pr(2), _pr(3)])
+    assert first["candidate"]["number"] == 1
+    assert first["projected_candidate_exact_heads"] == [f"1@{1:040d}"]
+
+    second = _observe([_pr(1), _pr(2), _pr(3)], previous=first)
+    assert second["candidate"]["number"] == 2
+    assert second["projected_candidate_exact_heads"] == [
+        f"1@{1:040d}",
+        f"2@{2:040d}",
+    ]
+
+    third = _observe([_pr(1), _pr(2), _pr(3)], previous=second)
+    assert third["candidate"]["number"] == 3
+    assert third["projected_candidate_exact_heads"] == [
+        f"1@{1:040d}",
+        f"2@{2:040d}",
+        f"3@{3:040d}",
+    ]
+
+    exhausted = _observe([_pr(1), _pr(2), _pr(3)], previous=third)
+    assert exhausted["candidate"] is None
+    assert exhausted["pending_candidate_exact_head"] == f"3@{3:040d}"
+    assert exhausted["projected_candidate_count"] == 3
+
+
+def test_round_robin_accepts_handled_rotated_candidate() -> None:
+    first = _observe([_pr(1), _pr(2)])
+    second = _observe([_pr(1), _pr(2)], previous=first)
+
+    assert second["candidate"]["number"] == 2
+    handled_second = _observe(
+        [_pr(1), _pr(2)],
+        previous=second,
+        handled=[f"2@{2:040d}"],
+    )
+    assert handled_second["handled_exact_heads"] == [f"2@{2:040d}"]
+    assert handled_second["candidate"] is None
+    assert handled_second["projected_candidate_exact_heads"] == [f"1@{1:040d}"]
 
 
 def test_handled_exact_head_advances_unchanged_backlog() -> None:
@@ -123,7 +164,8 @@ def test_handled_exact_head_advances_unchanged_backlog() -> None:
 
     still_pending = _observe([_pr(1), _pr(2)], previous=repeated)
     assert still_pending["observation_state"] == "observed_unchanged"
-    assert still_pending["candidate"]["number"] == 2
+    assert still_pending["candidate"] is None
+    assert still_pending["pending_candidate_exact_head"] == f"2@{2:040d}"
 
 
 def test_handled_changed_pr_does_not_strand_unchanged_backlog() -> None:


### PR DESCRIPTION
## Summary

- add `projected_candidate_exact_heads` to `pull_request_review_queue_observation_v0`
- an unchanged poll skips already-projected, unhandled exact heads and selects the next unprojected PR in the existing review sequence
- material transitions on an already-projected exact head still re-select that head
- handled cursors may now reference any previously projected candidate, not only the last candidate
- update the command smoke, protocol docs, and focused tests to cover round-robin progression

## Why

The previous capability kept selecting the same pending candidate until it was handled, so a monitor would wait on one PR (for example a self-authored PR routed to another reviewer) while the rest of the open queue stayed untouched. The queue should keep rotating while review work remains.

## Validation

- focused capability tests: 21 passed
- `examples/pr-review-command-smoke.py`: passed
- changed Python compile checks and `git diff --check`: passed
- standard premerge canary: all selected checks and risk-profile smokes passed, 0 failures, 0 manual holds