### PR TITLE
feat(canary): ratchet core module size and type density

### DIFF
--- a/loopx/canary/maintainability_ratchet.py
+++ b/loopx/canary/maintainability_ratchet.py
@@ -5,14 +5,20 @@ from __future__ import annotations
 import ast
 from collections import Counter
 from importlib.util import resolve_name
+import json
 from pathlib import Path
 import subprocess
 from typing import Any, Mapping, Sequence
 
 
 MAINTAINABILITY_REPORT_SCHEMA_VERSION = "control_plane_maintainability_report_v0"
+MODULE_METRIC_BASELINE_SCHEMA_VERSION = "control_plane_module_metric_baseline_v0"
 DECISION_STATEMENT_LIMIT = 90
 DECISION_POINT_LIMIT = 60
+MODULE_LINE_LIMIT = 1500
+MODULE_ANY_LIMIT = 300
+MODULE_DICT_ANY_LIMIT = 300
+MODULE_METRIC_BASELINE_PATH = Path(__file__).with_name("module_metric_baseline.json")
 
 CONTROL_PLANE_FORBIDDEN_DEPENDENCY_PREFIXES = (
     "loopx.benchmark_adapters",
@@ -497,6 +503,124 @@ def collect_compatibility_facades(repository_root: Path) -> list[dict[str, Any]]
     return findings
 
 
+def _is_benchmark_module_path(path: Path) -> bool:
+    parts = path.as_posix().split("/")
+    return any(
+        part in {
+            "benchmark_adapters",
+            "benchmarks",
+        }
+        or part.startswith("benchmark")
+        or part.startswith("bench_")
+        or part.startswith("terminal_bench")
+        or part.startswith("skillsbench")
+        or part.startswith("agentissue")
+        or part.startswith("agents_last_exam")
+        for part in parts
+    )
+
+
+def module_metric_baseline(baseline_path: Path) -> dict[str, dict[str, int]]:
+    payload = json.loads(baseline_path.read_text(encoding="utf-8"))
+    if payload.get("schema_version") != MODULE_METRIC_BASELINE_SCHEMA_VERSION:
+        raise ValueError(
+            f"unexpected module metric baseline schema: "
+            f"{payload.get('schema_version')!r}"
+        )
+    ceilings = payload.get("module_metric_ceilings")
+    if not isinstance(ceilings, dict):
+        raise ValueError("module metric baseline must contain module_metric_ceilings")
+    normalized: dict[str, dict[str, int]] = {}
+    for path, metrics in ceilings.items():
+        if not isinstance(metrics, dict):
+            raise ValueError(f"module metric baseline entry must be an object: {path}")
+        normalized[str(path)] = {
+            key: int(metrics[key])
+            for key in ("lines", "any_count", "dict_any_count")
+            if key in metrics
+        }
+    return normalized
+
+
+def module_metrics(path: Path) -> dict[str, int]:
+    source = path.read_text(encoding="utf-8")
+    lines = len(source.splitlines())
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return {"lines": lines, "any_count": 0, "dict_any_count": 0}
+    any_count = 0
+    dict_any_count = 0
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and node.id == "Any":
+            any_count += 1
+        if (
+            isinstance(node, ast.Subscript)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "dict"
+            and isinstance(node.slice, ast.Tuple)
+            and len(node.slice.elts) == 2
+        ):
+            key, value = node.slice.elts
+            if (
+                isinstance(key, ast.Constant)
+                and key.value == "str"
+                and isinstance(value, ast.Name)
+                and value.id == "Any"
+            ):
+                dict_any_count += 1
+    return {
+        "lines": lines,
+        "any_count": any_count,
+        "dict_any_count": dict_any_count,
+    }
+
+
+def collect_module_metric_findings(
+    repository_root: Path,
+    *,
+    tracked_paths: set[Path] | None = None,
+    baseline_path: Path | None = None,
+) -> list[dict[str, Any]]:
+    package_root = repository_root / "loopx"
+    baseline = module_metric_baseline(
+        baseline_path or MODULE_METRIC_BASELINE_PATH
+    )
+    paths = sorted(package_root.rglob("*.py"))
+    if tracked_paths is not None:
+        paths = [path for path in paths if path in tracked_paths]
+    findings: list[dict[str, Any]] = []
+    for path in paths:
+        if _is_benchmark_module_path(path):
+            continue
+        relative = path.relative_to(repository_root).as_posix()
+        metrics = module_metrics(path)
+        ceilings = baseline.get(relative) or {
+            "lines": MODULE_LINE_LIMIT,
+            "any_count": MODULE_ANY_LIMIT,
+            "dict_any_count": MODULE_DICT_ANY_LIMIT,
+        }
+        regressions = {
+            metric: actual
+            for metric, actual in metrics.items()
+            if actual > ceilings.get(metric, 0)
+        }
+        if not regressions:
+            continue
+        findings.append(
+            {
+                "id": _finding_id("module_metric_budget", relative),
+                "category": "module_metric_budget",
+                "path": relative,
+                "module": _module_name(path, package_root),
+                "metrics": metrics,
+                "metric_ceilings": ceilings,
+                "regressions": regressions,
+            }
+        )
+    return sorted(findings, key=lambda item: str(item["id"]))
+
+
 def evaluate_maintainability_findings(
     findings: Sequence[Mapping[str, Any]],
     *,
@@ -607,6 +731,10 @@ def build_control_plane_maintainability_report(
             tracked_paths=tracked_paths,
         ),
         *collect_compatibility_facades(repository_root),
+        *collect_module_metric_findings(
+            repository_root,
+            tracked_paths=tracked_paths,
+        ),
     ]
     evaluation = evaluate_maintainability_findings(
         sorted(findings, key=lambda item: str(item["id"])),
@@ -618,6 +746,10 @@ def build_control_plane_maintainability_report(
         "policy": {
             "decision_statement_limit": DECISION_STATEMENT_LIMIT,
             "decision_point_limit": DECISION_POINT_LIMIT,
+            "module_line_limit": MODULE_LINE_LIMIT,
+            "module_any_limit": MODULE_ANY_LIMIT,
+            "module_dict_any_limit": MODULE_DICT_ANY_LIMIT,
+            "module_metric_baseline_path": MODULE_METRIC_BASELINE_PATH.name,
             "exception_contract": (
                 "stable finding id plus non-empty reason and retirement_plan; "
                 "metric-bearing debt also requires non-increasing metric ceilings; "
@@ -627,8 +759,9 @@ def build_control_plane_maintainability_report(
             "repository_scope_decision": (
                 "This profile intentionally replaces the repository-wide exact Python line "
                 "budget with semantic checks for control-plane modules and the supported "
-                "quota/status compatibility facades; it does not retain a coarse all-file "
-                "hotspot limit."
+                "quota/status compatibility facades; it also ratchets per-module line and "
+                "type-density metrics from a checked-in baseline while keeping the current "
+                "modules grandfathered. It does not retain a coarse all-file hotspot limit."
             ),
         },
         **evaluation,

--- a/loopx/canary/module_metric_baseline.json
+++ b/loopx/canary/module_metric_baseline.json
@@ -1,0 +1,100 @@
+{
+  "default_limits": {
+    "any_count": 300,
+    "dict_any_count": 300,
+    "lines": 1500
+  },
+  "module_metric_ceilings": {
+    "loopx/bootstrap_command_pack.py": {
+      "any_count": 32,
+      "dict_any_count": 0,
+      "lines": 2234
+    },
+    "loopx/canary/planner.py": {
+      "any_count": 22,
+      "dict_any_count": 0,
+      "lines": 1983
+    },
+    "loopx/capabilities/auto_research/demo_e2e.py": {
+      "any_count": 0,
+      "dict_any_count": 0,
+      "lines": 1735
+    },
+    "loopx/capabilities/catalog.py": {
+      "any_count": 8,
+      "dict_any_count": 0,
+      "lines": 1819
+    },
+    "loopx/capabilities/content_ops/surface.py": {
+      "any_count": 40,
+      "dict_any_count": 0,
+      "lines": 1956
+    },
+    "loopx/capabilities/issue_fix/cli.py": {
+      "any_count": 5,
+      "dict_any_count": 0,
+      "lines": 1822
+    },
+    "loopx/codex_cli_probe.py": {
+      "any_count": 37,
+      "dict_any_count": 0,
+      "lines": 1530
+    },
+    "loopx/control_plane/agents/agent_scope.py": {
+      "any_count": 107,
+      "dict_any_count": 0,
+      "lines": 1578
+    },
+    "loopx/control_plane/goals/goal_frontier.py": {
+      "any_count": 130,
+      "dict_any_count": 0,
+      "lines": 2225
+    },
+    "loopx/extensions/lark/presentation/explore_results.py": {
+      "any_count": 58,
+      "dict_any_count": 0,
+      "lines": 1965
+    },
+    "loopx/extensions/lark/presentation/kanban.py": {
+      "any_count": 95,
+      "dict_any_count": 0,
+      "lines": 2791
+    },
+    "loopx/heartbeat_prompt.py": {
+      "any_count": 17,
+      "dict_any_count": 0,
+      "lines": 1563
+    },
+    "loopx/history.py": {
+      "any_count": 51,
+      "dict_any_count": 0,
+      "lines": 1508
+    },
+    "loopx/presentation/renderers/status_markdown.py": {
+      "any_count": 47,
+      "dict_any_count": 0,
+      "lines": 1570
+    },
+    "loopx/quota.py": {
+      "any_count": 219,
+      "dict_any_count": 0,
+      "lines": 2946
+    },
+    "loopx/status.py": {
+      "any_count": 180,
+      "dict_any_count": 0,
+      "lines": 3076
+    },
+    "loopx/todos.py": {
+      "any_count": 48,
+      "dict_any_count": 0,
+      "lines": 2116
+    },
+    "loopx/worker_bridge.py": {
+      "any_count": 28,
+      "dict_any_count": 0,
+      "lines": 1574
+    }
+  },
+  "schema_version": "control_plane_module_metric_baseline_v0"
+}

--- a/tests/canary/test_maintainability_ratchet.py
+++ b/tests/canary/test_maintainability_ratchet.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 from pathlib import Path
 
 from loopx.canary.maintainability_ratchet import (
+    MODULE_METRIC_BASELINE_SCHEMA_VERSION,
     build_control_plane_maintainability_report,
     collect_dependency_debt,
+    collect_module_metric_findings,
     collect_oversized_decision_functions,
     evaluate_maintainability_findings,
+    module_metrics,
     render_control_plane_maintainability_report,
 )
 
@@ -28,6 +31,72 @@ def test_current_repository_debt_is_reviewed_without_line_count_pins() -> None:
     assert set(report["category_counts"]) == {"compatibility_facade"}
     assert report["category_counts"].get("oversized_decision_function", 0) == 0
     assert report["reviewed_exception_count"] == report["finding_count"]
+
+
+def test_current_module_metric_budget_keeps_existing_modules_grandfathered() -> None:
+    report = build_control_plane_maintainability_report(REPOSITORY_ROOT)
+
+    assert report["ok"] is True, render_control_plane_maintainability_report(report)
+    assert report["policy"]["module_line_limit"] == 1500
+    assert report["policy"]["module_any_limit"] == 300
+    assert report["policy"]["module_dict_any_limit"] == 300
+    assert report["category_counts"].get("module_metric_budget", 0) == 0
+    assert report["unreviewed_count"] == 0
+
+
+def test_module_metric_ratchet_detects_new_oversized_module(tmp_path: Path) -> None:
+    module_path = tmp_path / "loopx" / "sample.py"
+    module_path.parent.mkdir(parents=True)
+    module_path.write_text(
+        "\n".join(["# padding"] * 1501),
+        encoding="utf-8",
+    )
+    tracked_paths = {module_path}
+
+    findings = collect_module_metric_findings(
+        tmp_path,
+        tracked_paths=tracked_paths,
+    )
+
+    assert len(findings) == 1
+    assert findings[0]["category"] == "module_metric_budget"
+    assert findings[0]["path"] == "loopx/sample.py"
+    assert findings[0]["metrics"]["lines"] == 1501
+    assert findings[0]["regressions"] == {"lines": 1501}
+
+
+def test_module_metric_ratchet_rejects_growth_above_checked_in_baseline(
+    tmp_path: Path,
+) -> None:
+    module_path = tmp_path / "loopx" / "sample.py"
+    module_path.parent.mkdir(parents=True)
+    module_path.write_text(
+        "from typing import Any\n"
+        "value: dict[str, Any] = {}\n"
+        "extra = 'padding'\n",
+        encoding="utf-8",
+    )
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(
+        (
+            '{"schema_version": "'
+            + MODULE_METRIC_BASELINE_SCHEMA_VERSION
+            + '", "default_limits": {"lines": 1500, "any_count": 300, '
+            '"dict_any_count": 300}, "module_metric_ceilings": {'
+            '"loopx/sample.py": {"lines": 2, "any_count": 1, "dict_any_count": 1}}}'
+        ),
+        encoding="utf-8",
+    )
+
+    findings = collect_module_metric_findings(
+        tmp_path,
+        tracked_paths={module_path},
+        baseline_path=baseline_path,
+    )
+
+    assert len(findings) == 1
+    assert findings[0]["regressions"] == {"lines": 3}
+    assert module_metrics(module_path)["any_count"] == 1
 
 
 def test_reviewed_exception_lifecycle_rejects_new_debt_and_stale_entries() -> None:


### PR DESCRIPTION
## Summary

- add a checked-in `module_metric_baseline.json` for non-benchmark `loopx` modules
- ratchet per-module `lines`, `any_count`, and `dict[str, Any]` counts against that baseline
- existing oversized modules are grandfathered at their current metric ceilings; growth beyond the ceiling fails the maintainability ratchet
- new modules must stay within the default limits (1500 lines, 300 `Any`, 300 `dict[str, Any]`)
- add focused pytest coverage and update the maintainability policy description

## Why

The long-term refactor needs a low-risk way to prevent control-plane files from growing further before they are split. This change is read-only for existing behavior: it only makes future module growth visible and failing in the existing canary.

## Scope Boundary

This PR intentionally does not touch `task_lease.py`, todo claim/lease/receipt paths, coordination authority/provider seams, or the NoKV RFC surfaces. It only extends the existing canary/ratchet test system.

## Validation

- `tests/canary/test_maintainability_ratchet.py`: 9 passed
- `examples/control_plane/control-plane-maintainability-ratchet-smoke.py`: passed
- changed Python compile and `git diff --check`: passed
- standard premerge canary: all selected checks and risk-profile smokes passed, 0 failures, 0 manual holds