### PR TITLE
docs(pr-review): require formal APPROVE when no blockers remain

### DIFF
--- a/skills/loopx-pr-review/SKILL.md
+++ b/skills/loopx-pr-review/SKILL.md
@@ -79,15 +79,21 @@ user explicitly requested local-only/dry-run output or the finding contains
 private or security-sensitive material.
 
 - Remaining blocking finding: formal `REQUEST_CHANGES`.
-- Non-blocking finding: normal review/comment.
-- No finding: say so; approval still routes through `loopx-pr-merge`.
+- Non-blocking finding with no blockers: formal `APPROVE`, not a bare comment.
+  When the GitHub account is the PR author and GitHub rejects self-approval,
+  record the same approval conclusion as a `COMMENTED` review or PR comment
+  titled `Approval conclusion (author-owned PR; GitHub blocks formal self-approval)`
+  so the verdict remains public and machine-visible.
+- Non-blocking finding with only P2 suggestions: still `APPROVE`; keep the P2
+  items in the review body rather than downgrading the verdict.
 - Merged PR: publish a post-merge audit comment only for a new actionable
   finding; avoid duplicating an equivalent exact-head result.
 
 Build public text from the exact reviewed head. Remove local paths, private
 context, raw logs, credentials, and internal-only links. Read the published
-review back, verify its state and rendered body, and return its URL. Do not
-leave a public blocker only in chat.
+review back, verify its state and rendered body, and return its URL. Merge
+still routes through `loopx-pr-merge`; an `APPROVE` is not merge authority.
+Do not leave a public blocker only in chat.
 
 ## Autonomous Queue
 


### PR DESCRIPTION
## Summary

- PR review publication now requires a formal `APPROVE` when the review finds no blockers, instead of only posting a comment.
- Keeps P2 suggestions in the approval body; `REQUEST_CHANGES` remains for blockers.
- Documents the GitHub self-approval constraint: when the authenticated account owns the PR, record the same approval conclusion as a `COMMENTED` review/PR comment titled `Approval conclusion (author-owned PR; GitHub blocks formal self-approval)`.
- Clarifies that `APPROVE` is not merge authority; merge still routes through `loopx-pr-merge`.

## Validation

- `git diff --check` clean.
- Existing `loopx --format json pr-review --state all` and skill routing anchors preserved.
- Full bootstrap smoke was attempted in an independent worktree but the local system Python 3.9 cannot import current main (`dataclass(slots=True)` requires Python 3.10+); failure is environment-only and reproduces before this change.