### PR TITLE
fix(capability): expose unknown capability gaps as agent-resolvable

### DIFF
--- a/docs/development/control-plane-course/03-work-graph-and-peers.md
+++ b/docs/development/control-plane-course/03-work-graph-and-peers.md
@@ -391,6 +391,13 @@ Capability 是 preflight 条件，不是 permission：
 
 权限仍来自 goal boundary、user gate、workspace policy 和 host authority。
 
+未知或非 owner-held 的缺失能力会作为 `repair_missing` 暴露给 agent，而不是
+直接跳过。Agent 必须自己判断能否满足：例如独立 worktree/branch 可以由当前
+runtime 自证，就执行 repair 并写回 `capability_gap_status=fixed`；不能证明就写
+blocker。分支/worktree 的最终约束仍由 `--task-repository`、
+`--required-write-scope` 和 workspace guard 执行，不要在 capability gate 里
+维护能力名清单。
+
 `target_capability` 则表示 todo 正在构建或修复什么能力，不是执行这个 todo 的硬前提。
 
 ## Workspace Guard：把写入位置变成状态

--- a/loopx/control_plane/agents/capability_gate.py
+++ b/loopx/control_plane/agents/capability_gate.py
@@ -54,9 +54,7 @@ def _capability_missing_action(missing: list[str]) -> str:
         return "run"
     if missing_set & CAPABILITY_OWNER_GATE_HINTS:
         return "ask_owner"
-    if missing_set & CAPABILITY_REPAIR_BRIDGE_HINTS:
-        return "repair_bridge"
-    return "skip"
+    return "repair_bridge"
 
 
 def _capability_resolution(missing: list[str]) -> dict[str, Any]:
@@ -68,13 +66,7 @@ def _capability_resolution(missing: list[str]) -> dict[str, Any]:
     repair_missing = [
         capability
         for capability in missing
-        if capability in CAPABILITY_REPAIR_BRIDGE_HINTS
-    ]
-    unsupported_missing = [
-        capability
-        for capability in missing
         if capability not in CAPABILITY_OWNER_GATE_HINTS
-        and capability not in CAPABILITY_REPAIR_BRIDGE_HINTS
     ]
     action = _capability_missing_action(missing)
     decision_owner = (
@@ -101,20 +93,12 @@ def _capability_resolution(missing: list[str]) -> dict[str, Any]:
                 "capabilities": repair_missing,
             }
         )
-    if unsupported_missing:
-        resolution_steps.append(
-            {
-                "owner": "capability_gate",
-                "action": "unsupported",
-                "capabilities": unsupported_missing,
-            }
-        )
     return {
         "action": action,
         "decision_owner": decision_owner,
         "owner_missing": owner_missing,
         "repair_missing": repair_missing,
-        "unsupported_missing": unsupported_missing,
+        "unsupported_missing": [],
         "resolution_steps": resolution_steps,
     }
 

--- a/tests/control_plane/test_capability_gate.py
+++ b/tests/control_plane/test_capability_gate.py
@@ -56,9 +56,10 @@ def _gate(
     ),
     [
         (["shell"], "run", "agent", None),
+        (["project_branch"], "repair_bridge", "agent", "repair_missing"),
         (["network"], "repair_bridge", "agent", "repair_missing"),
         (["credentials"], "ask_owner", "user", "owner_missing"),
-        (["gpu_runner"], "skip", "capability_gate", "unsupported_missing"),
+        (["gpu_runner"], "repair_bridge", "agent", "repair_missing"),
     ],
 )
 def test_missing_capability_decision_table(


### PR DESCRIPTION
## Summary

- capability gate now routes every non-owner-held missing capability through the existing `repair_bridge` path instead of an opaque `skip`
- unknown capability names are surfaced as `repair_missing`, so the agent can inspect the block and decide whether it can satisfy the capability
- the gate no longer maintains a hardcoded capability-name exception list
- branch/worktree policy remains owned by `workspace_guard`, `--task-repository`, `--required-write-scope`, and repository governance
- open agent todos no longer rely on `project_branch` as a manually declared runtime capability

## Why

`project_branch` was an ad hoc todo token, not a defined runtime capability. A hardcoded exception for it would teach the control plane about one accidental name. The real fix is to let the agent perceive any capability block and self-resolve it when it can prove the capability, or write a blocker when it cannot.

## Validation

- capability gate decision table covers `project_branch` and unknown tokens as `repair_bridge` without naming them in production logic
- `tests/control_plane/test_capability_gate.py` + `test_runtime_capability_reentry.py`: 17 passed
- changed Python compile and `git diff --check`: passed
- standard premerge canary: all executed checks passed, 0 blocking failures
- premerge advisory: `control-plane-maintainability-ratchet-smoke` reports one inherited baseline failure unrelated to this diff; recorded here per canary policy