### PR TITLE
feat(control-plane): typed core packet contracts with producer wiring

### DIFF
--- a/loopx/control_plane/quota/decision_summary.py
+++ b/loopx/control_plane/quota/decision_summary.py
@@ -24,13 +24,22 @@ class QuotaDecisionPacket(TypedDict, total=False):
     self_repair_allowed: bool
     capability_repair_allowed: bool
     workspace_repair_allowed: bool
+    state: str
+    safe_bypass_allowed: bool
+    safe_bypass_kind: str
+    blocked_action_scope: str
+    compute: float
+    window_hours: int
+    slot_minutes: int
+    spent_slots: int
+    allowed_slots: int
     capability_gate: dict[str, Any]
     interaction_contract: dict[str, Any]
     scheduler_hint: dict[str, Any]
     reason: str
 
 
-def compact_quota_decision(decision: dict[str, Any]) -> dict[str, Any]:
+def compact_quota_decision(decision: dict[str, Any]) -> QuotaDecisionPacket:
     quota = decision.get("quota") if isinstance(decision.get("quota"), dict) else {}
     return {
         "should_run": bool(decision.get("should_run")),

--- a/loopx/control_plane/quota/decision_summary.py
+++ b/loopx/control_plane/quota/decision_summary.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TypedDict
 
 from ...state_projection import actions_are_projection_aligned
 from ..goals.contract_health import project_contract_health_for_goal
@@ -12,6 +12,22 @@ from ..goals.goal_frontier import (
 )
 from ..todos.contract import normalize_todo_claimed_by
 from ..work_items.work_lane import work_lane_contract_is_due_monitor_attempt
+
+
+class QuotaDecisionPacket(TypedDict, total=False):
+    goal_id: str
+    decision: str
+    should_run: bool
+    effective_action: str
+    normal_delivery_allowed: bool
+    recovery_delivery_allowed: bool
+    self_repair_allowed: bool
+    capability_repair_allowed: bool
+    workspace_repair_allowed: bool
+    capability_gate: dict[str, Any]
+    interaction_contract: dict[str, Any]
+    scheduler_hint: dict[str, Any]
+    reason: str
 
 
 def compact_quota_decision(decision: dict[str, Any]) -> dict[str, Any]:

--- a/loopx/control_plane/todos/summary_item.py
+++ b/loopx/control_plane/todos/summary_item.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, TypedDict
 
 from .contract import (
     normalize_removed_todo_continuation_policy,
@@ -93,6 +93,19 @@ TODO_SUMMARY_SOURCE_KEYS = (
     "unclaimed_monitor_blocked_resume_candidates",
     "items",
 )
+
+
+class TodoSummaryItemDict(TypedDict, total=False):
+    index: int
+    text: str
+    todo_id: str
+    status: str
+    priority: str
+    task_class: str
+    action_kind: str
+    claimed_by: str
+    required_capabilities: list[str]
+    target_key: str
 
 
 def compact_todo_summary_item(

--- a/loopx/control_plane/todos/summary_item.py
+++ b/loopx/control_plane/todos/summary_item.py
@@ -98,22 +98,67 @@ TODO_SUMMARY_SOURCE_KEYS = (
 class TodoSummaryItemDict(TypedDict, total=False):
     index: int
     text: str
+    schema_version: str
     todo_id: str
+    role: str
     status: str
     priority: str
+    title: str
+    archive_state: str
+    source_section: str
     task_class: str
     action_kind: str
-    claimed_by: str
+    task_domain: str
+    capability_binding_ref: str
+    task_repository: str
+    continuation_policy: str
+    removed_continuation_policy: str
+    required_write_scopes: list[str]
     required_capabilities: list[str]
+    target_capabilities: list[str]
+    decision_scope: Any
+    required_decision_scopes: list[Any]
+    decision_outcome: str
+    decision_scope_outcomes: list[Any]
+    claimed_by: str
+    bound_agent: str
+    goal_bound: bool
+    blocks_agent: str
+    excluded_agents: list[str]
+    global_gate: bool
+    unblocks_todo_id: str
+    resume_when: str
+    resume_condition: Any
+    resume_ready: bool
+    no_followup: bool
+    successor_todo_ids: list[str]
     target_key: str
+    cadence: str
+    next_due_at: str
+    expires_at: str
+    last_checked_at: str
+    result_hash: str
+    consecutive_no_change: int
+    material_change: bool
+    max_no_change_before_replan: int
+    route_continuation_replan_required: bool
+    route_continuation_reason: str
+    route_id: str
+    route_key: str
+    completed_at: str
+    updated_at: str
+    superseded_by: str
+    handoff_note: Any
+    continuation_hint: str
+    reason: str
 
 
 def compact_todo_summary_item(
     item: dict[str, Any],
     *,
     text: str | None = None,
-) -> dict[str, Any]:
-    compact: dict[str, Any] = {
+) -> TodoSummaryItemDict:
+    compact: TodoSummaryItemDict = {
         "index": item.get("index"),
         "text": text if text is not None else item.get("text"),
     }

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -47,6 +47,11 @@ class InteractionContractPacket(TypedDict, total=False):
     user_channel: dict[str, Any]
     agent_channel: dict[str, Any]
     cli_channel: dict[str, Any]
+    response_plan: dict[str, Any]
+    required_reads: list[dict[str, Any]]
+    post_writeback_actions: list[str]
+    vision_continuation_audit: dict[str, Any]
+    vision_wait_state: dict[str, Any]
     fallback_policy: dict[str, Any]
 
 
@@ -1214,7 +1219,7 @@ def build_interaction_contract(
     scheduler_execution_context: (
         Mapping[str, Any] | SchedulerExecutionContextResolution | None
     ) = None,
-) -> dict[str, Any]:
+) -> InteractionContractPacket:
     execution_obligation = (
         payload.get("execution_obligation")
         if isinstance(payload.get("execution_obligation"), dict)
@@ -1274,7 +1279,7 @@ def build_interaction_contract(
         delivery_allowed=delivery_allowed,
         quiet_noop_allowed=quiet_noop_allowed,
     )
-    contract = {
+    contract: InteractionContractPacket = {
         "schema_version": INTERACTION_CONTRACT_SCHEMA_VERSION,
         "mode": mode,
         "user_channel": user_channel,

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import shlex
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, TypedDict
 
 from ..agents.agent_scope_frontier import (
     AgentScopeFrontierAction,
@@ -39,6 +39,15 @@ INTERACTION_CONTRACT_SCHEMA_VERSION = "loopx_interaction_contract_v0"
 INTERACTION_RESPONSE_PLAN_SCHEMA_VERSION = "interaction_response_plan_v0"
 PROTOCOL_ACTION_PACKET_SCHEMA_VERSION = "protocol_action_packet_v0"
 PROTOCOL_ACTION_PACKET_LLM_POLICY = "no_api"
+
+
+class InteractionContractPacket(TypedDict, total=False):
+    schema_version: str
+    mode: str
+    user_channel: dict[str, Any]
+    agent_channel: dict[str, Any]
+    cli_channel: dict[str, Any]
+    fallback_policy: dict[str, Any]
 
 
 def _blocked_successor_wait_observation_required(payload: dict[str, Any]) -> bool:

--- a/tests/control_plane/test_core_packet_contracts.py
+++ b/tests/control_plane/test_core_packet_contracts.py
@@ -2,10 +2,17 @@ from __future__ import annotations
 
 from typing import Any, TypedDict, get_type_hints
 
-from loopx.control_plane.quota.decision_summary import QuotaDecisionPacket
-from loopx.control_plane.todos.summary_item import TodoSummaryItemDict
+from loopx.control_plane.quota.decision_summary import (
+    QuotaDecisionPacket,
+    compact_quota_decision,
+)
+from loopx.control_plane.todos.summary_item import (
+    TodoSummaryItemDict,
+    compact_todo_summary_item,
+)
 from loopx.control_plane.work_items.interaction_contract import (
     InteractionContractPacket,
+    build_interaction_contract,
 )
 
 
@@ -16,51 +23,62 @@ def _shape_ok(packet: dict[str, Any], contract: type[TypedDict]) -> bool:
 
 
 def test_todo_summary_item_contract_accepts_representative_packet() -> None:
-    packet: dict[str, Any] = {
-        "index": 1,
-        "text": "Review PR #1",
-        "todo_id": "todo_abc",
-        "status": "open",
-        "priority": "P1",
-        "task_class": "advancement_task",
-        "action_kind": "review_pull_request_exact_head",
-        "claimed_by": "codex-side-bypass",
-        "required_capabilities": ["network"],
-        "target_key": "github-pr-review:owner/repo#1@abc",
-    }
+    packet = compact_todo_summary_item(
+        {
+            "todo_id": "todo_abc",
+            "text": "Review PR #1",
+            "status": "open",
+            "priority": "P1",
+            "task_class": "advancement_task",
+            "action_kind": "review_pull_request_exact_head",
+            "claimed_by": "codex-side-bypass",
+            "required_capabilities": ["network"],
+            "target_key": "github-pr-review:owner/repo#1@abc",
+        }
+    )
 
     assert _shape_ok(packet, TodoSummaryItemDict)
 
 
 def test_quota_decision_packet_accepts_representative_packet() -> None:
-    packet: dict[str, Any] = {
-        "goal_id": "loopx-meta",
-        "decision": "run",
-        "should_run": True,
-        "effective_action": "normal_run",
-        "normal_delivery_allowed": True,
-        "recovery_delivery_allowed": False,
-        "self_repair_allowed": False,
-        "capability_repair_allowed": False,
-        "workspace_repair_allowed": False,
-        "capability_gate": {"action": "run"},
-        "interaction_contract": {"mode": "bounded_delivery"},
-        "scheduler_hint": {"recommended_interval_minutes": 3},
-        "reason": "runnable work",
-    }
+    packet = compact_quota_decision(
+        {
+            "goal_id": "loopx-meta",
+            "decision": "run",
+            "should_run": True,
+            "effective_action": "normal_run",
+            "normal_delivery_allowed": True,
+            "recovery_delivery_allowed": False,
+            "self_repair_allowed": False,
+            "capability_repair_allowed": False,
+            "workspace_repair_allowed": False,
+            "state": "normal",
+            "safe_bypass_allowed": False,
+            "safe_bypass_kind": None,
+            "blocked_action_scope": None,
+            "quota": {
+                "compute": 1.0,
+                "window_hours": 24,
+                "slot_minutes": 1,
+                "spent_slots": 3,
+                "allowed_slots": 10,
+            },
+            "reason": "runnable work",
+        }
+    )
 
     assert _shape_ok(packet, QuotaDecisionPacket)
 
 
 def test_interaction_contract_packet_accepts_representative_packet() -> None:
-    packet: dict[str, Any] = {
-        "schema_version": "loopx_interaction_contract_v0",
-        "mode": "bounded_delivery",
-        "user_channel": {"action_required": False},
-        "agent_channel": {"must_attempt": True},
-        "cli_channel": {"spend_allowed_now": False},
-        "fallback_policy": {"do_not_cancel_on_block": True},
-    }
+    packet = build_interaction_contract(
+        {
+            "goal_id": "loopx-meta",
+            "effective_action": "normal_run",
+            "agent_identity": {"agent_id": "codex-quality-qualification"},
+            "heartbeat_recommendation": {"recommended_mode": "bounded_delivery"},
+        }
+    )
 
     assert _shape_ok(packet, InteractionContractPacket)
 

--- a/tests/control_plane/test_core_packet_contracts.py
+++ b/tests/control_plane/test_core_packet_contracts.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Any, TypedDict, get_type_hints
+
+from loopx.control_plane.quota.decision_summary import QuotaDecisionPacket
+from loopx.control_plane.todos.summary_item import TodoSummaryItemDict
+from loopx.control_plane.work_items.interaction_contract import (
+    InteractionContractPacket,
+)
+
+
+def _shape_ok(packet: dict[str, Any], contract: type[TypedDict]) -> bool:
+    annotations = set(get_type_hints(contract))
+    required = set(getattr(contract, "__required_keys__", frozenset()))
+    return required <= set(packet) and set(packet) <= annotations
+
+
+def test_todo_summary_item_contract_accepts_representative_packet() -> None:
+    packet: dict[str, Any] = {
+        "index": 1,
+        "text": "Review PR #1",
+        "todo_id": "todo_abc",
+        "status": "open",
+        "priority": "P1",
+        "task_class": "advancement_task",
+        "action_kind": "review_pull_request_exact_head",
+        "claimed_by": "codex-side-bypass",
+        "required_capabilities": ["network"],
+        "target_key": "github-pr-review:owner/repo#1@abc",
+    }
+
+    assert _shape_ok(packet, TodoSummaryItemDict)
+
+
+def test_quota_decision_packet_accepts_representative_packet() -> None:
+    packet: dict[str, Any] = {
+        "goal_id": "loopx-meta",
+        "decision": "run",
+        "should_run": True,
+        "effective_action": "normal_run",
+        "normal_delivery_allowed": True,
+        "recovery_delivery_allowed": False,
+        "self_repair_allowed": False,
+        "capability_repair_allowed": False,
+        "workspace_repair_allowed": False,
+        "capability_gate": {"action": "run"},
+        "interaction_contract": {"mode": "bounded_delivery"},
+        "scheduler_hint": {"recommended_interval_minutes": 3},
+        "reason": "runnable work",
+    }
+
+    assert _shape_ok(packet, QuotaDecisionPacket)
+
+
+def test_interaction_contract_packet_accepts_representative_packet() -> None:
+    packet: dict[str, Any] = {
+        "schema_version": "loopx_interaction_contract_v0",
+        "mode": "bounded_delivery",
+        "user_channel": {"action_required": False},
+        "agent_channel": {"must_attempt": True},
+        "cli_channel": {"spend_allowed_now": False},
+        "fallback_policy": {"do_not_cancel_on_block": True},
+    }
+
+    assert _shape_ok(packet, InteractionContractPacket)
+
+
+def test_packet_contracts_reject_unknown_keys() -> None:
+    assert not _shape_ok({"unknown": True}, TodoSummaryItemDict)
+    assert not _shape_ok({"unknown": True}, QuotaDecisionPacket)
+    assert not _shape_ok({"unknown": True}, InteractionContractPacket)


### PR DESCRIPTION
## Summary

- add `TodoSummaryItemDict`, `QuotaDecisionPacket`, and `InteractionContractPacket` TypedDict contracts in their nearest owning modules
- wire the contracts into their real producers:
  - `compact_todo_summary_item` returns `TodoSummaryItemDict`
  - `compact_quota_decision` returns `QuotaDecisionPacket`
  - `build_interaction_contract` returns `InteractionContractPacket`
- update focused tests to call the real producers and verify returned packet shapes
- add shape rejection tests for unknown keys

## Why

A contract that is never used is just documentation. This MR makes the contracts part of the runtime type surface, then verifies the actual produced packets against them. It is a low-risk, test-system-first refactor step: no behavior change, only type annotations and shape validation.

## Validation

- `tests/control_plane/test_core_packet_contracts.py` + related control-plane tests: 34 passed
- changed Python compile and `git diff --check`: passed
- standard premerge canary: all executed checks passed, 0 blocking failures
- premerge advisory: `control-plane-maintainability-ratchet-smoke` reports one inherited baseline failure unrelated to this diff; recorded here per canary policy