### PR TITLE
refactor(quota): extract policy constants read model with re-export parity

### DIFF
--- a/loopx/control_plane/quota/policy_constants.py
+++ b/loopx/control_plane/quota/policy_constants.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Pure quota policy constants owned by the quota read model.
+
+``loopx.quota`` re-exports these names for compatibility. No module in this
+file may import from ``loopx.quota``.
+"""
+
+
+DEFAULT_COMPUTE_QUOTA = 1.0
+DEFAULT_WINDOW_HOURS = 24
+DEFAULT_SLOT_MINUTES = 1
+
+FOCUS_WAIT_LIFECYCLE_MARKERS = {
+    "continuation_boundary",
+    "focus_wait",
+}
+
+FOCUS_WAIT_REASON = (
+    "focus wait: delivery lane has a continuation boundary or missing novelty; "
+    "wait for new evidence, owner input, external eval, or a clean baseline before "
+    "spending delivery compute"
+)
+
+AUTONOMOUS_CANDIDATE_CONTEXT_FIELDS = (
+    "source",
+    "open_count",
+    "task_class",
+    "items",
+)
+
+SELF_REPAIR_SPEND_ACTIONS = {
+    "control_plane_health_repair",
+    "control_plane_projection_repair",
+    "state_projection_gap_repair",
+    "boundary_projection_repair",
+    "todo_decision_scope_projection_repair",
+}
+
+MONITOR_DUE_ITEM_LIMIT = 1

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -115,6 +115,16 @@ from .control_plane.quota.spend_sources import (
     DEFAULT_SLOT_SPEND_SOURCE,
 )
 from .control_plane.quota.states import QUOTA_STATE_ORDER
+from .control_plane.quota.policy_constants import (
+    AUTONOMOUS_CANDIDATE_CONTEXT_FIELDS,
+    DEFAULT_COMPUTE_QUOTA,
+    DEFAULT_SLOT_MINUTES,
+    DEFAULT_WINDOW_HOURS,
+    FOCUS_WAIT_LIFECYCLE_MARKERS,
+    FOCUS_WAIT_REASON,
+    MONITOR_DUE_ITEM_LIMIT,
+    SELF_REPAIR_SPEND_ACTIONS,
+)
 from .control_plane.runtime.decision_freshness import (
     decision_freshness_warning as _decision_freshness_warning,
 )
@@ -194,38 +204,12 @@ _PUBLIC_COMPAT_REEXPORTS = {
 }
 
 
-DEFAULT_COMPUTE_QUOTA = 1.0
-DEFAULT_WINDOW_HOURS = 24
-DEFAULT_SLOT_MINUTES = 1
 AUTONOMOUS_REPLAN_ACK_NEUTRAL_CLASSIFICATIONS = {
     QUOTA_SLOT_SPENT_CLASSIFICATION,
     QUOTA_SLOT_VOIDED_CLASSIFICATION,
     QUOTA_SCHEDULER_ACK_CLASSIFICATION,
     "delivery_completion_spend_accounted_v0",
 }
-FOCUS_WAIT_LIFECYCLE_MARKERS = {
-    "continuation_boundary",
-    "focus_wait",
-}
-FOCUS_WAIT_REASON = (
-    "focus wait: delivery lane has a continuation boundary or missing novelty; "
-    "wait for new evidence, owner input, external eval, or a clean baseline before "
-    "spending delivery compute"
-)
-AUTONOMOUS_CANDIDATE_CONTEXT_FIELDS = (
-    "source",
-    "open_count",
-    "task_class",
-    "items",
-)
-SELF_REPAIR_SPEND_ACTIONS = {
-    "control_plane_health_repair",
-    "control_plane_projection_repair",
-    "state_projection_gap_repair",
-    "boundary_projection_repair",
-    "todo_decision_scope_projection_repair",
-}
-MONITOR_DUE_ITEM_LIMIT = 1
 
 def _validate_goal_id_path_segment(goal_id: str) -> str:
     value = goal_id.strip()

--- a/tests/control_plane/test_quota_policy_reexport.py
+++ b/tests/control_plane/test_quota_policy_reexport.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import loopx.control_plane.quota.policy_constants as policy_constants
+import loopx.quota as quota
+
+
+REEXPORTED_NAMES = (
+    "DEFAULT_COMPUTE_QUOTA",
+    "DEFAULT_WINDOW_HOURS",
+    "DEFAULT_SLOT_MINUTES",
+    "FOCUS_WAIT_LIFECYCLE_MARKERS",
+    "FOCUS_WAIT_REASON",
+    "AUTONOMOUS_CANDIDATE_CONTEXT_FIELDS",
+    "SELF_REPAIR_SPEND_ACTIONS",
+    "MONITOR_DUE_ITEM_LIMIT",
+)
+
+
+def test_quota_reexports_policy_constants_unchanged() -> None:
+    for name in REEXPORTED_NAMES:
+        status_value = getattr(quota, name)
+        read_model_value = getattr(policy_constants, name)
+        assert status_value == read_model_value
+        assert type(status_value) is type(read_model_value)
+
+
+def test_quota_policy_values_are_stable() -> None:
+    assert quota.DEFAULT_COMPUTE_QUOTA == 1.0
+    assert quota.DEFAULT_WINDOW_HOURS == 24
+    assert quota.DEFAULT_SLOT_MINUTES == 1
+    assert "focus_wait" in quota.FOCUS_WAIT_LIFECYCLE_MARKERS
+    assert quota.MONITOR_DUE_ITEM_LIMIT == 1


### PR DESCRIPTION
## Summary

- extract `DEFAULT_COMPUTE_QUOTA`, `DEFAULT_WINDOW_HOURS`, `DEFAULT_SLOT_MINUTES`, `FOCUS_WAIT_LIFECYCLE_MARKERS`, `FOCUS_WAIT_REASON`, `AUTONOMOUS_CANDIDATE_CONTEXT_FIELDS`, `SELF_REPAIR_SPEND_ACTIONS`, and `MONITOR_DUE_ITEM_LIMIT` from `loopx/quota.py` into `loopx/control_plane/quota/policy_constants.py`
- keep `loopx.quota` re-exporting the same names so external imports remain unchanged
- add parity tests asserting re-exported values and types are stable

## Why

This is a low-risk second slice of the long-term `quota.py` decomposition: pure policy constants move to a bounded quota read model, while the compatibility facade stays untouched.

## Validation

- `tests/control_plane/test_quota_policy_reexport.py` + related tests: 13 passed
- changed Python compile and `git diff --check`: passed
- standard premerge canary: all executed checks passed except one inherited baseline failure
- premerge baseline notes:
  - `control-plane-maintainability-ratchet-smoke` advisory failure unrelated to this diff
  - `monitor-scheduler-contract-smoke` failure reproducible on clean `origin/main` (scheduler sub-floor cadence contract not yet updated)