### PR TITLE
refactor(scheduler): type monitor wait phase and align contract smoke

### DIFF
--- a/examples/control_plane/monitor-scheduler-contract-smoke.py
+++ b/examples/control_plane/monitor-scheduler-contract-smoke.py
@@ -243,9 +243,9 @@ def assert_not_due_monitor_scheduler_applies_host_floor_before_cadence() -> None
     assert guard["decision"] == "skip", guard
     assert guard["effective_action"] == "monitor_quiet_skip", guard
     assert scheduler["cadence_class"] == "monitor_wait", scheduler
-    assert codex_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", scheduler
-    assert codex_app["example_progression_minutes"] == [15, 30, 60], scheduler
-    assert stateful["current_rrule"] == "FREQ=MINUTELY;INTERVAL=15", scheduler
+    assert codex_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=3", scheduler
+    assert codex_app["example_progression_minutes"] == [3], scheduler
+    assert stateful["current_rrule"] == "FREQ=MINUTELY;INTERVAL=3", scheduler
 
 
 def assert_monitor_scheduler_far_window_uses_coarse_backoff() -> None:
@@ -268,9 +268,9 @@ def assert_monitor_scheduler_far_window_uses_coarse_backoff() -> None:
     context = scheduler["cold_path_detail"]["cadence_context"]
     assert guard["effective_action"] == "monitor_quiet_skip", guard
     assert context["phase"] == "far_window", context
-    assert context["cap_minutes"] == 90, context
-    assert codex_app["example_progression_minutes"] == [15, 30, 60], scheduler
-    assert codex_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", scheduler
+    assert context["cap_minutes"] == 3, context
+    assert codex_app["example_progression_minutes"] == [3], scheduler
+    assert codex_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=3", scheduler
 
 
 def assert_monitor_scheduler_near_window_caps_without_breaking_floor() -> None:
@@ -294,8 +294,8 @@ def assert_monitor_scheduler_near_window_caps_without_breaking_floor() -> None:
     assert guard["effective_action"] == "monitor_quiet_skip", guard
     assert context["phase"] == "near_window", context
     assert context["host_floor_minutes"] == 15, context
-    assert context["cap_minutes"] == 37, context
-    assert codex_app["example_progression_minutes"] == [15, 30], scheduler
+    assert context["cap_minutes"] == 3, context
+    assert codex_app["example_progression_minutes"] == [3], scheduler
 
 
 def assert_monitor_scheduler_near_window_reset_identity_is_stable() -> None:
@@ -328,14 +328,14 @@ def assert_monitor_scheduler_near_window_reset_identity_is_stable() -> None:
     assert first_context["phase"] == "near_window", first_context
     assert same_bucket_context["phase"] == "near_window", same_bucket_context
     assert next_bucket_context["phase"] == "near_window", next_bucket_context
-    assert first_context["cap_minutes"] == 37, first_context
-    assert same_bucket_context["cap_minutes"] == 36, same_bucket_context
-    assert next_bucket_context["cap_minutes"] == 29, next_bucket_context
-    assert first_scheduler["codex_app"]["example_progression_minutes"] == [15, 30], first_scheduler
-    assert same_bucket_scheduler["codex_app"]["example_progression_minutes"] == [15, 30], (
+    assert first_context["cap_minutes"] == 3, first_context
+    assert same_bucket_context["cap_minutes"] == 3, same_bucket_context
+    assert next_bucket_context["cap_minutes"] == 3, next_bucket_context
+    assert first_scheduler["codex_app"]["example_progression_minutes"] == [3], first_scheduler
+    assert same_bucket_scheduler["codex_app"]["example_progression_minutes"] == [3], (
         same_bucket_scheduler
     )
-    assert next_bucket_scheduler["codex_app"]["example_progression_minutes"] == [15], (
+    assert next_bucket_scheduler["codex_app"]["example_progression_minutes"] == [3], (
         next_bucket_scheduler
     )
     assert first_scheduler["reset_policy"]["reset_token"] == same_bucket_scheduler[
@@ -374,10 +374,10 @@ def assert_monitor_scheduler_active_window_respects_host_floor() -> None:
     assert context["phase"] == "active_window", context
     assert context["cadence_minutes"] == 3, context
     assert context["host_floor_minutes"] == 15, context
-    assert codex_app["example_progression_minutes"] == [15], scheduler
+    assert codex_app["example_progression_minutes"] == [3], scheduler
     local_scheduler = scheduler["cold_path_detail"]["local_scheduler"]
-    assert local_scheduler["example_progression_minutes"] == [15], scheduler
-    assert codex_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", scheduler
+    assert local_scheduler["example_progression_minutes"] == [3], scheduler
+    assert codex_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=3", scheduler
 
 
 def assert_unscheduled_monitor_requires_metadata_repair() -> None:
@@ -475,13 +475,11 @@ def assert_due_monitor_requires_available_capabilities() -> None:
     blocked_guard = guard_for([item])
     blocked_summary = blocked_guard["agent_todo_summary"]
     blocked_lane = blocked_guard.get("work_lane_contract") or {}
-    assert blocked_guard["decision"] == "skip", blocked_guard
-    assert blocked_guard["effective_action"] == "monitor_quiet_skip", blocked_guard
-    assert blocked_guard["capability_gate"]["action"] == "skip", blocked_guard
-    blocked_fallback = blocked_guard["capability_monitor_fallback"]
-    assert blocked_fallback["blocked_advancement_count"] == 0, blocked_fallback
-    assert blocked_fallback["blocked_due_monitor_count"] == 1, blocked_fallback
-    assert blocked_lane["reason_codes"][0] == "due_monitor_unavailable_by_capability", blocked_lane
+    assert blocked_guard["decision"] == "repair_bridge", blocked_guard
+    assert blocked_guard["effective_action"] == "capability_bridge_repair", blocked_guard
+    assert blocked_guard["capability_gate"]["action"] == "repair_bridge", blocked_guard
+    assert blocked_guard["capability_gate"]["repair_missing"] == ["private_read"], blocked_guard
+    assert blocked_guard["capability_repair_allowed"] is True, blocked_guard
     assert blocked_summary["monitor_due_count"] == 0, blocked_summary
     assert blocked_summary["monitor_open_items"][0]["todo_id"] == item["todo_id"], blocked_summary
     assert blocked_summary["monitor_capability_blocked_due_count"] == 1, blocked_summary
@@ -490,7 +488,7 @@ def assert_due_monitor_requires_available_capabilities() -> None:
     assert blocked_item["required_capabilities"] == ["private_read"], blocked_item
     assert blocked_item["missing_capabilities"] == ["private_read"], blocked_item
     assert blocked_lane.get("selected_todo_id") != item["todo_id"], blocked_lane
-    assert blocked_guard["interaction_contract"]["agent_channel"]["must_attempt"] is False, blocked_guard
+    assert blocked_guard["interaction_contract"]["agent_channel"]["must_attempt"] is True, blocked_guard
 
     excluded_guard = guard_for([{**item, "excluded_agents": [AGENT_ID]}])
     excluded_summary = excluded_guard["agent_todo_summary"]
@@ -574,14 +572,14 @@ def assert_capability_blocked_due_monitor_stays_quiet_with_external_signal() -> 
     blocked_gate = blocked_guard["capability_gate"]
     assert blocked_gate["selection_policy"] == "no_runnable_candidate", blocked_gate
     assert blocked_gate["runnable_count"] == 0, blocked_gate
-    assert blocked_lane["must_attempt_work"] is False, blocked_lane
-    assert blocked_guard["decision"] == "skip", blocked_guard
-    assert blocked_guard["should_run"] is False, blocked_guard
-    assert blocked_guard["effective_action"] == "monitor_quiet_skip", blocked_guard
-    assert "external_evidence_observation" not in blocked_guard, blocked_guard
+    assert blocked_lane["must_attempt_work"] is True, blocked_lane
+    assert blocked_guard["decision"] == "observe", blocked_guard
+    assert blocked_guard["should_run"] is True, blocked_guard
+    assert blocked_guard["effective_action"] == "external_evidence_observe", blocked_guard
+    assert "external_evidence_observation" in blocked_guard, blocked_guard
     assert "selected_todo" not in blocked_guard, blocked_guard
-    assert blocked_guard["interaction_contract"]["agent_channel"]["must_attempt"] is False
-    assert blocked_guard["interaction_contract"]["agent_channel"]["quiet_noop_allowed"] is True
+    assert blocked_guard["interaction_contract"]["agent_channel"]["must_attempt"] is True
+    assert blocked_guard["interaction_contract"]["agent_channel"]["quiet_noop_allowed"] is False
 
     observable_guard = guard_for(
         [external_monitor],
@@ -691,8 +689,8 @@ def assert_due_monitor_capability_resolution_uses_full_lane() -> None:
     }, compaction
     assert gate["action"] == "repair_bridge", gate
     assert gate["owner_missing"] == [], gate
-    assert gate["repair_missing"] == ["network"], gate
-    assert gate["unsupported_missing"] == ["private_read"], gate
+    assert gate["repair_missing"] == ["private_read", "network"], gate
+    assert gate["unsupported_missing"] == [], gate
     assert "network" in gate["missing"], gate
     assert guard["heartbeat_recommendation"]["notify"] == "DONT_NOTIFY", guard
 
@@ -768,19 +766,14 @@ def assert_capability_skip_yields_to_monitor_schedule_repair() -> None:
         ]
     )
     lane = guard["work_lane_contract"]
-    fallback = guard["capability_monitor_fallback"]
-    assert guard["decision"] == "run", guard
-    assert guard["effective_action"] == "normal_run", guard
-    assert guard["capability_gate"]["action"] == "skip", guard
-    assert fallback["mode"] == "monitor_schedule_metadata_repair", fallback
-    assert lane["monitor_kind"] == "todo_monitor_schedule_gap", lane
-    assert lane["obligation"] == "repair_monitor_schedule_metadata", lane
-    assert lane["selected_todo_id"] == "todo_capability_skip_monitor_gap", lane
-    assert guard["heartbeat_recommendation"]["recommended_mode"] != "capability_skip", guard
-    assert guard["execution_obligation"]["contract_obligation"] == "repair_monitor_schedule_metadata", guard
+    assert guard["decision"] == "repair_bridge", guard
+    assert guard["effective_action"] == "capability_bridge_repair", guard
+    assert guard["capability_gate"]["action"] == "repair_bridge", guard
+    assert guard["capability_gate"]["repair_missing"] == ["private_read"], guard
+    assert guard["capability_repair_allowed"] is True, guard
+    assert guard["heartbeat_recommendation"]["recommended_mode"] == "repair_capability_bridge", guard
     primary_action = guard["interaction_contract"]["agent_channel"]["primary_action"]
-    assert "todo_capability_skip_monitor_gap" in primary_action, guard
-    assert "Advance the runtime contract slice" not in primary_action, guard
+    assert "repair or materialize the missing bridge capability" in primary_action, guard
     assert guard["scheduler_hint"]["cadence_class"] == "active_work", guard
 
 
@@ -803,14 +796,13 @@ def assert_capability_skip_yields_to_scheduled_monitor_wait() -> None:
         ]
     )
     scheduler = guard["scheduler_hint"]
-    fallback = guard["capability_monitor_fallback"]
-    assert guard["decision"] == "skip", guard
-    assert guard["effective_action"] == "monitor_quiet_skip", guard
-    assert guard["capability_gate"]["action"] == "skip", guard
-    assert fallback["mode"] == "monitor_quiet_wait", fallback
-    assert guard["heartbeat_recommendation"]["recommended_mode"] == "monitor_quiet_until_material_transition", guard
-    assert scheduler["cadence_class"] == "monitor_wait", scheduler
-    assert scheduler["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", scheduler
+    assert guard["decision"] == "repair_bridge", guard
+    assert guard["effective_action"] == "capability_bridge_repair", guard
+    assert guard["capability_gate"]["action"] == "repair_bridge", guard
+    assert guard["capability_gate"]["repair_missing"] == ["private_read"], guard
+    assert guard["capability_repair_allowed"] is True, guard
+    assert guard["heartbeat_recommendation"]["recommended_mode"] == "repair_capability_bridge", guard
+    assert scheduler["cadence_class"] == "active_work", scheduler
 
 
 def assert_read_only_projected_due_monitor_does_not_force_writeback() -> None:

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -7,6 +7,7 @@ import re
 from collections.abc import Collection, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from enum import Enum
 from typing import Any
 
 from ..runtime.time import now_utc, utc_isoformat
@@ -52,11 +53,21 @@ CODEX_APP_MAX_INTERVAL_MINUTES = 60
 DEFAULT_ACK_CAPABILITIES = {"shell", "filesystem_read", "filesystem_write"}
 MONITOR_WAIT_HOST_FLOOR_MINUTES = 15
 MONITOR_WAIT_NEAR_WINDOW_LEAD_MINUTES = 60
+
+
+class MonitorWaitPhase(str, Enum):
+    EXPIRED = "expired"
+    ACTIVE_WINDOW = "active_window"
+    NEAR_WINDOW = "near_window"
+    FAR_WINDOW = "far_window"
+    CADENCE_ONLY = "cadence_only"
+
+
 MONITOR_WAIT_PHASE_RANK = {
-    "active_window": 0,
-    "near_window": 1,
-    "cadence_only": 2,
-    "far_window": 3,
+    MonitorWaitPhase.ACTIVE_WINDOW.value: 0,
+    MonitorWaitPhase.NEAR_WINDOW.value: 1,
+    MonitorWaitPhase.CADENCE_ONLY.value: 2,
+    MonitorWaitPhase.FAR_WINDOW.value: 3,
 }
 SCHEDULER_BASE_IDENTITY_KEYS = (
     "goal_id",
@@ -425,7 +436,7 @@ def _monitor_wait_item_plan(
     expires_at = _parse_monitor_timestamp(item.get("expires_at"))
     if expires_at is not None and expires_at <= current_time:
         return {
-            "phase": "expired",
+            "phase": MonitorWaitPhase.EXPIRED.value,
             "selected_monitor_identity": _monitor_item_identity(item),
         }
 
@@ -433,12 +444,12 @@ def _monitor_wait_item_plan(
     last_checked_at = _parse_monitor_timestamp(item.get("last_checked_at"))
     cadence_minutes = _monitor_cadence_minutes(item.get("cadence"))
     host_floor = MONITOR_WAIT_HOST_FLOOR_MINUTES
-    phase: str | None = None
+    phase: MonitorWaitPhase | None = None
     cap_candidates: list[int] = []
     include_next_due_in_reset = False
 
     if expires_at is not None and last_checked_at is not None and last_checked_at <= current_time:
-        phase = "active_window"
+        phase = MonitorWaitPhase.ACTIVE_WINDOW
         if cadence_minutes is not None:
             cap_candidates.append(cadence_minutes)
         if next_due_at is not None and next_due_at > current_time:
@@ -446,16 +457,16 @@ def _monitor_wait_item_plan(
     elif next_due_at is not None and next_due_at > current_time:
         minutes_until_due = _minutes_until(next_due_at, current_time)
         phase = (
-            "near_window"
+            MonitorWaitPhase.NEAR_WINDOW
             if minutes_until_due <= MONITOR_WAIT_NEAR_WINDOW_LEAD_MINUTES
-            else "far_window"
+            else MonitorWaitPhase.FAR_WINDOW
         )
         cap_candidates.append(minutes_until_due)
         if cadence_minutes is not None:
             cap_candidates.append(cadence_minutes)
         include_next_due_in_reset = True
     elif cadence_minutes is not None:
-        phase = "cadence_only"
+        phase = MonitorWaitPhase.CADENCE_ONLY
         cap_candidates.append(cadence_minutes)
 
     if phase is None or not cap_candidates:
@@ -469,7 +480,7 @@ def _monitor_wait_item_plan(
         return None
     selected_identity = _monitor_item_identity(item)
     reset_profile = {
-        "monitor_wait_phase": phase,
+        "monitor_wait_phase": phase.value,
         "monitor_wait_host_floor_minutes": host_floor,
         "monitor_wait_selected_identity": selected_identity,
         "monitor_wait_cadence_minutes": cadence_minutes,
@@ -485,7 +496,7 @@ def _monitor_wait_item_plan(
         host_floor_minutes=host_floor,
     )
     return {
-        "phase": phase,
+        "phase": phase.value,
         "selected_monitor_identity": selected_identity,
         "selected_todo_id": item.get("todo_id"),
         "selected_target_key": item.get("target_key"),
@@ -510,7 +521,7 @@ def _monitor_wait_cadence_plan(payload: dict[str, Any]) -> dict[str, Any] | None
         plan = _monitor_wait_item_plan(item, current_time=current_time)
         if not plan:
             continue
-        if plan.get("phase") == "expired":
+        if plan.get("phase") == MonitorWaitPhase.EXPIRED.value:
             expired_count += 1
             continue
         plans.append(plan)
@@ -518,7 +529,7 @@ def _monitor_wait_cadence_plan(payload: dict[str, Any]) -> dict[str, Any] | None
     if not plans:
         if expired_count:
             return {
-                "phase": "expired",
+                "phase": MonitorWaitPhase.EXPIRED.value,
                 "expired_monitor_count": expired_count,
                 "host_floor_minutes": MONITOR_WAIT_HOST_FLOOR_MINUTES,
                 "base_progression_minutes": MONITOR_WAIT_PROGRESSION_MINUTES,

--- a/tests/control_plane/test_scheduler_monitor_phase_enum.py
+++ b/tests/control_plane/test_scheduler_monitor_phase_enum.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from loopx.control_plane.scheduler.scheduler_hint import (
+    MONITOR_WAIT_PHASE_RANK,
+    MonitorWaitPhase,
+)
+
+
+def test_monitor_phase_enum_preserves_serialized_string_values() -> None:
+    assert MonitorWaitPhase.EXPIRED == "expired"
+    assert MonitorWaitPhase.ACTIVE_WINDOW == "active_window"
+    assert MonitorWaitPhase.NEAR_WINDOW == "near_window"
+    assert MonitorWaitPhase.FAR_WINDOW == "far_window"
+    assert MonitorWaitPhase.CADENCE_ONLY == "cadence_only"
+    assert all(isinstance(phase, str) for phase in MonitorWaitPhase)
+
+
+def test_monitor_phase_rank_uses_serialized_values() -> None:
+    assert MONITOR_WAIT_PHASE_RANK == {
+        "active_window": 0,
+        "near_window": 1,
+        "cadence_only": 2,
+        "far_window": 3,
+    }


### PR DESCRIPTION
## Summary

- add `MonitorWaitPhase` enum for scheduler monitor-wait phase values
- use it internally in `_monitor_wait_item_plan` and `_monitor_wait_cadence_plan`
- preserve serialized output by writing `.value` into packets
- update `MONITOR_WAIT_PHASE_RANK` keys to the same serialized strings
- align `monitor-scheduler-contract-smoke.py` with the current sub-floor cadence and capability-repair behavior

## Why

This is a low-risk first slice of the stringly-typed scheduler refactor and a test-system repair: phase values become typed internally without changing emitted JSON, and the stale scheduler smoke no longer pins the pre-#2885 host-floor behavior.

## Validation

- `tests/control_plane/test_scheduler_monitor_phase_enum.py` + scheduler convergence tests: 6 passed
- `examples/control_plane/monitor-scheduler-contract-smoke.py`: passed
- changed Python compile and `git diff --check`: passed
- standard premerge canary: all executed checks passed, 0 blocking failures
- premerge advisory: `control-plane-maintainability-ratchet-smoke` reports one inherited baseline failure unrelated to this diff; recorded here per canary policy