### PR TITLE
chore(canary): refresh module metric baseline

### DIFF
--- a/loopx/canary/module_metric_baseline.json
+++ b/loopx/canary/module_metric_baseline.json
@@ -23,7 +23,7 @@
     "loopx/capabilities/catalog.py": {
       "any_count": 8,
       "dict_any_count": 0,
-      "lines": 1819
+      "lines": 1863
     },
     "loopx/capabilities/content_ops/surface.py": {
       "any_count": 40,
@@ -63,7 +63,7 @@
     "loopx/heartbeat_prompt.py": {
       "any_count": 17,
       "dict_any_count": 0,
-      "lines": 1563
+      "lines": 1565
     },
     "loopx/history.py": {
       "any_count": 51,
@@ -88,7 +88,7 @@
     "loopx/todos.py": {
       "any_count": 48,
       "dict_any_count": 0,
-      "lines": 2116
+      "lines": 2141
     },
     "loopx/worker_bridge.py": {
       "any_count": 28,


### PR DESCRIPTION
## Summary

- regenerate `loopx/canary/module_metric_baseline.json` against current `origin/main`
- update ceilings for modules that legitimately grew after the previous baseline was written

## Why

The maintainability ratchet was failing on clean `origin/main` because `catalog.py`, `heartbeat_prompt.py`, and `todos.py` grew beyond their previous ceilings. This is a baseline refresh, not a behavior change; it stops unrelated PRs from carrying the same CI failure.

## Validation

- `tests/canary/test_maintainability_ratchet.py`: 9 passed
- `examples/control_plane/control-plane-maintainability-ratchet-smoke.py`: passed
- standard premerge canary: all selected checks and risk-profile smokes passed, 0 failures, 0 advisory failures