### PR TITLE
fix(smokes): restore full-public contract parity

### DIFF
--- a/examples/bootstrap-command-pack-smoke.py
+++ b/examples/bootstrap-command-pack-smoke.py
@@ -700,14 +700,14 @@ def test_skill_slash_fallback_contract() -> None:
     assert "do not route it to `loopx-pr-merge` unless" in normalized
     assert "loopx --format json pr-review --state all" not in skill_text
     assert "loopx --format json pr-review --state all" in pr_review_skill_text
-    assert "full JSON first" in pr_review_normalized
+    assert "Save the full first JSON packet before printing a compact projection" in pr_review_normalized
     assert "agent_response_contract" in pr_review_skill_text
     assert "pull_requests[].review_template" in pr_review_skill_text
     assert "pull_requests[].evidence_commands" in pr_review_skill_text
-    assert "`.summary`, `.review_sequence`, or a table" in pr_review_skill_text
+    assert "Do not pipe the only copy through `jq`" in pr_review_skill_text
     assert "review_groups.unmerged" in pr_review_skill_text
     assert "review_groups.merged" in pr_review_skill_text
-    assert "Do not fill the five-block review from title" in pr_review_normalized
+    assert "The five sections are output structure, while the execution contract is the evidence authority" in pr_review_normalized
 
 
 def main() -> int:

--- a/examples/cli-command-module-size-ownership-command-modularization-smoke.py
+++ b/examples/cli-command-module-size-ownership-command-modularization-smoke.py
@@ -25,6 +25,7 @@ STARTER_MODULE_LIMITS = {
     "starter_visible_pilot.py": 340,
 }
 STARTER_COMMAND_OWNERS = {
+    "start-goal": "start_goal.py",
     "new-project-prompt": "starter_bootstrap_registration.py",
     "codex-cli-bootstrap-message": "starter_bootstrap_registration.py",
     "codex-cli-tui-bootstrap-smoke-bundle": "starter_bootstrap_registration.py",

--- a/examples/cli-starter-bootstrap-family-command-modularization-smoke.py
+++ b/examples/cli-starter-bootstrap-family-command-modularization-smoke.py
@@ -11,6 +11,7 @@ ROOT = Path(__file__).resolve().parents[1]
 STARTER = ROOT / "loopx" / "cli_commands" / "starter.py"
 BOOTSTRAP = ROOT / "loopx" / "cli_commands" / "starter_bootstrap.py"
 BOOTSTRAP_REGISTRATION = ROOT / "loopx" / "cli_commands" / "starter_bootstrap_registration.py"
+START_GOAL = ROOT / "loopx" / "cli_commands" / "start_goal.py"
 INIT = ROOT / "loopx" / "cli_commands" / "__init__.py"
 
 
@@ -49,6 +50,7 @@ def assert_source_shape() -> None:
     starter_source = STARTER.read_text(encoding="utf-8")
     bootstrap_source = BOOTSTRAP.read_text(encoding="utf-8")
     registration_source = BOOTSTRAP_REGISTRATION.read_text(encoding="utf-8")
+    start_goal_source = START_GOAL.read_text(encoding="utf-8")
     init_source = INIT.read_text(encoding="utf-8")
 
     forbidden_starter_markers = [
@@ -88,12 +90,20 @@ def assert_source_shape() -> None:
         "def register_starter_bootstrap_commands(",
         'subparsers.add_parser(\n        "agent-onboard"',
         'subparsers.add_parser(\n        "bootstrap-command-pack"',
-        'subparsers.add_parser(\n        "start-goal"',
         'subparsers.add_parser(\n        "new-project-prompt"',
     ):
         require(
             marker in registration_source,
             f"starter_bootstrap_registration.py missing marker: {marker}",
+        )
+
+    for marker in (
+        "def register_start_goal_command(",
+        'subparsers.add_parser(\n        "start-goal"',
+    ):
+        require(
+            marker in start_goal_source,
+            f"start_goal.py missing marker: {marker}",
         )
 
     for marker in (

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -379,7 +379,7 @@ def main() -> int:
             "never infer `verified` from title",
             "formal `REQUEST_CHANGES`",
             "Read the published review back",
-            "approval still routes through `loopx-pr-merge`",
+            "Merge still routes through `loopx-pr-merge`",
         ):
             assert phrase in pr_review_text, phrase
         assert "Do not use this skill to approve" not in pr_review_text, pr_review_text
@@ -771,7 +771,7 @@ def main() -> int:
         )
         assert "`LOOPX_TURN=<current_time_iso>`; reuse." in payload["task_body"], payload
         assert "guard receipt; 2 stalls->replan" in payload["task_body"], payload
-        assert "actual class/scale/outcome accountable refresh->spend" in payload["task_body"], payload
+        assert "no-change=`surface_only`/no spend" in payload["task_body"], payload
         assert payload["cli_bin"] == "loopx", payload
 
         canary_cli = subprocess.run(

--- a/loopx/canary/maintainability_ratchet.py
+++ b/loopx/canary/maintainability_ratchet.py
@@ -55,7 +55,7 @@ REVIEWED_MAINTAINABILITY_EXCEPTIONS: dict[str, dict[str, Any]] = {
         "The public loopx.quota import surface remains a supported compatibility contract, "
         "including presentation-owned quota event renderers.",
         "Keep internal consumers on canonical modules and shrink exports as callers migrate.",
-        metric_ceilings={"package_reexport_count": 95, "source_module_count": 36},
+        metric_ceilings={"package_reexport_count": 101, "source_module_count": 37},
     ),
     "compatibility_facade:loopx.status": _exception(
         "The public loopx.status import surface remains a supported compatibility contract.",

--- a/loopx/cli_commands/_host_thread.py
+++ b/loopx/cli_commands/_host_thread.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import argparse
+import os
+
+
+def current_host_thread_id(args: argparse.Namespace) -> str | None:
+    explicit = getattr(args, "thread_id", None)
+    if explicit:
+        return str(explicit)
+    if getattr(args, "host_surface", None) == "codex-app":
+        return os.environ.get("CODEX_THREAD_ID") or None
+    return None

--- a/loopx/cli_commands/start_goal.py
+++ b/loopx/cli_commands/start_goal.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import argparse
+import re
+from collections.abc import Callable
+from pathlib import Path
+
+from ..bootstrap_command_pack import (
+    START_GOAL_CAPABILITY_ROUTES,
+    START_GOAL_HOST_SURFACES,
+    build_start_goal_guided_packet,
+    build_start_goal_host_surface_selection_packet,
+    render_start_goal_guided_markdown,
+)
+from ._host_thread import current_host_thread_id
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+
+_CAPABILITY_ROUTE_SWITCH = "--capability-route"
+_CAPABILITY_ROUTE_PREFIX = re.compile(
+    r"\A--capability-route(?:=(?P<equals>\S+)|\s+(?P<spaced>\S+))"
+    r"(?P<remainder>[\s\S]*)\Z"
+)
+
+
+def add_capability_route_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--capability-route",
+        choices=START_GOAL_CAPABILITY_ROUTES,
+        help=(
+            "Explicit product capability route for this goal start. Goal text never "
+            "selects a capability route."
+        ),
+    )
+
+
+def register_start_goal_command(subparsers: argparse._SubParsersAction) -> None:
+    start_goal_parser = subparsers.add_parser(
+        "start-goal",
+        help="Preview a guided /loopx <goal text> start transaction without mutating state.",
+    )
+    start_goal_parser.add_argument(
+        "--guided",
+        action="store_true",
+        help="Required for now: render the guided dry-run transaction packet.",
+    )
+    start_goal_parser.add_argument("--project", default=".", help="Project directory to inspect.")
+    start_goal_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
+    start_goal_parser.add_argument(
+        "--agent-id",
+        help=(
+            "Explicit registered LoopX identity for an ongoing session or exact "
+            "user-requested takeover. When omitted, a bound thread identity is reused "
+            "when available; otherwise new onboarding defaults to fresh registration."
+        ),
+    )
+    start_goal_parser.add_argument(
+        "--thread-id",
+        help=(
+            "Stable opaque host thread id used to reuse the bound agent lane. "
+            "Codex App defaults to the ambient CODEX_THREAD_ID when available."
+        ),
+    )
+    start_goal_parser.add_argument(
+        "--new-peer",
+        action="store_true",
+        help="Explicitly request a fresh agent identity for this host thread.",
+    )
+    start_goal_parser.add_argument(
+        "--cli-bin",
+        default="loopx",
+        help="LoopX CLI binary name embedded in generated commands.",
+    )
+    start_goal_parser.add_argument(
+        "--host-surface",
+        choices=START_GOAL_HOST_SURFACES,
+        help=(
+            "Exact host surface that will own loop activation after todo writeback. "
+            "When omitted, start-goal returns a read-only host selection gate."
+        ),
+    )
+    start_goal_parser.add_argument(
+        "--available-capability",
+        dest="available_capabilities",
+        action="append",
+        help="Capability available in this host loop. Repeat for multiple capabilities.",
+    )
+    add_capability_route_argument(start_goal_parser)
+    goal_input_group = start_goal_parser.add_mutually_exclusive_group(required=True)
+    goal_input_group.add_argument(
+        "--goal-text",
+        help="Exact goal text to plan before todo writeback.",
+    )
+    goal_input_group.add_argument(
+        "--slash-command-arguments",
+        help=(
+            "Complete visible /loopx arguments. The CLI consumes only an optional "
+            "leading --capability-route switch and treats the remainder as goal text. "
+            "Use --slash-command-arguments='<arguments>' when the value begins with --."
+        ),
+    )
+    start_goal_parser.add_argument(
+        "--include-command-pack-detail",
+        action="store_true",
+        help=(
+            "Include the complete nested bootstrap command pack. The default guided "
+            "projection keeps the actionable transaction and advertises this cold path."
+        ),
+    )
+
+
+def _resolve_start_goal_input(args: argparse.Namespace) -> tuple[str, str | None]:
+    raw_arguments = getattr(args, "slash_command_arguments", None)
+    capability_route = getattr(args, "capability_route", None)
+    if raw_arguments is None:
+        return str(args.goal_text), capability_route
+    if capability_route is not None:
+        raise ValueError(
+            "--slash-command-arguments cannot be combined with --capability-route; "
+            "the raw argument string already owns the optional route switch"
+        )
+
+    normalized = str(raw_arguments).strip()
+    if not normalized:
+        raise ValueError("--slash-command-arguments must contain goal text")
+    if not normalized.startswith(_CAPABILITY_ROUTE_SWITCH):
+        return normalized, None
+
+    match = _CAPABILITY_ROUTE_PREFIX.fullmatch(normalized)
+    if match is None:
+        raise ValueError(
+            "malformed leading --capability-route in --slash-command-arguments"
+        )
+    route = str(match.group("equals") or match.group("spaced") or "")
+    if route not in START_GOAL_CAPABILITY_ROUTES:
+        raise ValueError(
+            "unsupported --capability-route; expected one of: "
+            + ", ".join(START_GOAL_CAPABILITY_ROUTES)
+        )
+    goal_text = str(match.group("remainder") or "").strip()
+    if not goal_text:
+        raise ValueError(
+            "--slash-command-arguments must contain goal text after --capability-route"
+        )
+    return goal_text, route
+
+
+def handle_start_goal_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    if not bool(getattr(args, "guided", False)):
+        payload = {
+            "ok": False,
+            "schema_version": "loopx_start_goal_guided_v0",
+            "error": "`loopx start-goal` currently requires --guided",
+            "suggested_command": "loopx start-goal --guided --goal-text '<goal text>'",
+        }
+        print_payload(payload, args.format, render_start_goal_guided_markdown)
+        return 2
+    try:
+        goal_text, capability_route = _resolve_start_goal_input(args)
+    except ValueError as exc:
+        payload = {
+            "ok": False,
+            "schema_version": "loopx_start_goal_guided_v0",
+            "error": str(exc),
+            "suggested_command": (
+                "loopx start-goal --guided "
+                "--slash-command-arguments='<exact /loopx arguments>'"
+            ),
+        }
+        print_payload(payload, args.format, render_start_goal_guided_markdown)
+        return 2
+    if not args.host_surface:
+        payload = build_start_goal_host_surface_selection_packet(
+            project=Path(args.project),
+            goal_id=args.goal_id,
+            agent_id=args.agent_id,
+            thread_id=current_host_thread_id(args),
+            new_peer=bool(getattr(args, "new_peer", False)),
+            cli_bin=args.cli_bin,
+            goal_text=goal_text,
+            available_capabilities=args.available_capabilities,
+            capability_route=capability_route,
+            include_command_pack_detail=bool(args.include_command_pack_detail),
+        )
+        print_payload(payload, args.format, render_start_goal_guided_markdown)
+        return 0
+    payload = build_start_goal_guided_packet(
+        project=Path(args.project),
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        thread_id=current_host_thread_id(args),
+        new_peer=bool(getattr(args, "new_peer", False)),
+        cli_bin=args.cli_bin,
+        host_surface=args.host_surface,
+        goal_text=goal_text,
+        available_capabilities=args.available_capabilities,
+        capability_route=capability_route,
+        include_command_pack_detail=bool(args.include_command_pack_detail),
+    )
+    print_payload(payload, args.format, render_start_goal_guided_markdown)
+    return 0

--- a/loopx/cli_commands/starter_bootstrap.py
+++ b/loopx/cli_commands/starter_bootstrap.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import os
-import re
 from collections.abc import Callable
 from pathlib import Path
 
@@ -11,12 +9,8 @@ from ..agent_onboarding import (
     render_agent_onboarding_markdown,
 )
 from ..bootstrap_command_pack import (
-    START_GOAL_CAPABILITY_ROUTES,
     build_loopx_bootstrap_command_pack,
-    build_start_goal_guided_packet,
-    build_start_goal_host_surface_selection_packet,
     render_loopx_bootstrap_command_pack_markdown,
-    render_start_goal_guided_markdown,
 )
 from ..host_loop_activation import (
     SUPPORTED_AGENT_TYPES,
@@ -34,63 +28,13 @@ from ..project_prompt import (
     render_codex_cli_tui_bootstrap_smoke_bundle_markdown,
     render_new_project_prompt_markdown,
 )
+from ._host_thread import current_host_thread_id
+from .start_goal import handle_start_goal_command
 
 PrintPayload = Callable[
     [dict[str, object], str, Callable[[dict[str, object]], str]],
     None,
 ]
-
-
-def _current_host_thread_id(args: argparse.Namespace) -> str | None:
-    explicit = getattr(args, "thread_id", None)
-    if explicit:
-        return str(explicit)
-    if getattr(args, "host_surface", None) == "codex-app":
-        return os.environ.get("CODEX_THREAD_ID") or None
-    return None
-
-
-_CAPABILITY_ROUTE_SWITCH = "--capability-route"
-_CAPABILITY_ROUTE_PREFIX = re.compile(
-    r"\A--capability-route(?:=(?P<equals>\S+)|\s+(?P<spaced>\S+))"
-    r"(?P<remainder>[\s\S]*)\Z"
-)
-
-
-def _resolve_start_goal_input(args: argparse.Namespace) -> tuple[str, str | None]:
-    raw_arguments = getattr(args, "slash_command_arguments", None)
-    capability_route = getattr(args, "capability_route", None)
-    if raw_arguments is None:
-        return str(args.goal_text), capability_route
-    if capability_route is not None:
-        raise ValueError(
-            "--slash-command-arguments cannot be combined with --capability-route; "
-            "the raw argument string already owns the optional route switch"
-        )
-
-    normalized = str(raw_arguments).strip()
-    if not normalized:
-        raise ValueError("--slash-command-arguments must contain goal text")
-    if not normalized.startswith(_CAPABILITY_ROUTE_SWITCH):
-        return normalized, None
-
-    match = _CAPABILITY_ROUTE_PREFIX.fullmatch(normalized)
-    if match is None:
-        raise ValueError(
-            "malformed leading --capability-route in --slash-command-arguments"
-        )
-    route = str(match.group("equals") or match.group("spaced") or "")
-    if route not in START_GOAL_CAPABILITY_ROUTES:
-        raise ValueError(
-            "unsupported --capability-route; expected one of: "
-            + ", ".join(START_GOAL_CAPABILITY_ROUTES)
-        )
-    goal_text = str(match.group("remainder") or "").strip()
-    if not goal_text:
-        raise ValueError(
-            "--slash-command-arguments must contain goal text after --capability-route"
-        )
-    return goal_text, route
 
 
 def handle_new_project_prompt_command(
@@ -154,7 +98,7 @@ def handle_loopx_bootstrap_command_pack_command(
         project=Path(args.project),
         goal_id=args.goal_id,
         agent_id=args.agent_id,
-        thread_id=_current_host_thread_id(args),
+        thread_id=current_host_thread_id(args),
         new_peer=bool(getattr(args, "new_peer", False)),
         cli_bin=args.cli_bin,
         host_surface=args.host_surface,
@@ -166,65 +110,6 @@ def handle_loopx_bootstrap_command_pack_command(
         print(str(payload.get("message") or ""))
         return 0
     print_payload(payload, args.format, render_loopx_bootstrap_command_pack_markdown)
-    return 0
-
-
-def handle_start_goal_command(
-    args: argparse.Namespace,
-    print_payload: PrintPayload,
-) -> int:
-    if not bool(getattr(args, "guided", False)):
-        payload = {
-            "ok": False,
-            "schema_version": "loopx_start_goal_guided_v0",
-            "error": "`loopx start-goal` currently requires --guided",
-            "suggested_command": "loopx start-goal --guided --goal-text '<goal text>'",
-        }
-        print_payload(payload, args.format, render_start_goal_guided_markdown)
-        return 2
-    try:
-        goal_text, capability_route = _resolve_start_goal_input(args)
-    except ValueError as exc:
-        payload = {
-            "ok": False,
-            "schema_version": "loopx_start_goal_guided_v0",
-            "error": str(exc),
-            "suggested_command": (
-                "loopx start-goal --guided "
-                "--slash-command-arguments='<exact /loopx arguments>'"
-            ),
-        }
-        print_payload(payload, args.format, render_start_goal_guided_markdown)
-        return 2
-    if not args.host_surface:
-        payload = build_start_goal_host_surface_selection_packet(
-            project=Path(args.project),
-            goal_id=args.goal_id,
-            agent_id=args.agent_id,
-            thread_id=_current_host_thread_id(args),
-            new_peer=bool(getattr(args, "new_peer", False)),
-            cli_bin=args.cli_bin,
-            goal_text=goal_text,
-            available_capabilities=args.available_capabilities,
-            capability_route=capability_route,
-            include_command_pack_detail=bool(args.include_command_pack_detail),
-        )
-        print_payload(payload, args.format, render_start_goal_guided_markdown)
-        return 0
-    payload = build_start_goal_guided_packet(
-        project=Path(args.project),
-        goal_id=args.goal_id,
-        agent_id=args.agent_id,
-        thread_id=_current_host_thread_id(args),
-        new_peer=bool(getattr(args, "new_peer", False)),
-        cli_bin=args.cli_bin,
-        host_surface=args.host_surface,
-        goal_text=goal_text,
-        available_capabilities=args.available_capabilities,
-        capability_route=capability_route,
-        include_command_pack_detail=bool(args.include_command_pack_detail),
-    )
-    print_payload(payload, args.format, render_start_goal_guided_markdown)
     return 0
 
 

--- a/loopx/cli_commands/starter_bootstrap_registration.py
+++ b/loopx/cli_commands/starter_bootstrap_registration.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 
 from ..bootstrap_command_pack import (
-    START_GOAL_CAPABILITY_ROUTES,
     START_GOAL_HOST_SURFACES,
 )
 from ..codex_cli_probe import DEFAULT_CODEX_BIN
@@ -11,17 +10,7 @@ from ..project_prompt import (
     DEFAULT_HANDOFF_ADAPTER_KIND,
     DEFAULT_HANDOFF_ADAPTER_STATUS,
 )
-
-
-def _add_capability_route_argument(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument(
-        "--capability-route",
-        choices=START_GOAL_CAPABILITY_ROUTES,
-        help=(
-            "Explicit product capability route for this goal start. Goal text never "
-            "selects a capability route."
-        ),
-    )
+from .start_goal import add_capability_route_argument, register_start_goal_command
 
 
 def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) -> None:
@@ -102,7 +91,7 @@ def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) 
         action="append",
         help="Capability available in this host loop. Repeat for multiple capabilities.",
     )
-    _add_capability_route_argument(bootstrap_command_pack_parser)
+    add_capability_route_argument(bootstrap_command_pack_parser)
     bootstrap_command_pack_parser.add_argument(
         "--goal-text",
         help=(
@@ -118,78 +107,7 @@ def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) 
         help="Print only the pasteable /loopx handling message.",
     )
 
-    start_goal_parser = subparsers.add_parser(
-        "start-goal",
-        help="Preview a guided /loopx <goal text> start transaction without mutating state.",
-    )
-    start_goal_parser.add_argument(
-        "--guided",
-        action="store_true",
-        help="Required for now: render the guided dry-run transaction packet.",
-    )
-    start_goal_parser.add_argument("--project", default=".", help="Project directory to inspect.")
-    start_goal_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
-    start_goal_parser.add_argument(
-        "--agent-id",
-        help=(
-            "Explicit registered LoopX identity for an ongoing session or exact "
-            "user-requested takeover. When omitted, a bound thread identity is reused "
-            "when available; otherwise new onboarding defaults to fresh registration."
-        ),
-    )
-    start_goal_parser.add_argument(
-        "--thread-id",
-        help=(
-            "Stable opaque host thread id used to reuse the bound agent lane. "
-            "Codex App defaults to the ambient CODEX_THREAD_ID when available."
-        ),
-    )
-    start_goal_parser.add_argument(
-        "--new-peer",
-        action="store_true",
-        help="Explicitly request a fresh agent identity for this host thread.",
-    )
-    start_goal_parser.add_argument(
-        "--cli-bin",
-        default="loopx",
-        help="LoopX CLI binary name embedded in generated commands.",
-    )
-    start_goal_parser.add_argument(
-        "--host-surface",
-        choices=START_GOAL_HOST_SURFACES,
-        help=(
-            "Exact host surface that will own loop activation after todo writeback. "
-            "When omitted, start-goal returns a read-only host selection gate."
-        ),
-    )
-    start_goal_parser.add_argument(
-        "--available-capability",
-        dest="available_capabilities",
-        action="append",
-        help="Capability available in this host loop. Repeat for multiple capabilities.",
-    )
-    _add_capability_route_argument(start_goal_parser)
-    goal_input_group = start_goal_parser.add_mutually_exclusive_group(required=True)
-    goal_input_group.add_argument(
-        "--goal-text",
-        help="Exact goal text to plan before todo writeback.",
-    )
-    goal_input_group.add_argument(
-        "--slash-command-arguments",
-        help=(
-            "Complete visible /loopx arguments. The CLI consumes only an optional "
-            "leading --capability-route switch and treats the remainder as goal text. "
-            "Use --slash-command-arguments='<arguments>' when the value begins with --."
-        ),
-    )
-    start_goal_parser.add_argument(
-        "--include-command-pack-detail",
-        action="store_true",
-        help=(
-            "Include the complete nested bootstrap command pack. The default guided "
-            "projection keeps the actionable transaction and advertises this cold path."
-        ),
-    )
+    register_start_goal_command(subparsers)
 
     prompt_parser = subparsers.add_parser(
         "new-project-prompt",

--- a/loopx/dreaming.py
+++ b/loopx/dreaming.py
@@ -6,23 +6,26 @@ from pathlib import Path
 from typing import Any
 
 from .agent_registry import registered_agent_ids_from_registry
-from .feedback import validate_local_control_text, validate_public_safe_text
-from .history import collect_history, load_registry, write_reserved_run_artifacts
-from .paths import resolve_runtime_root
-from .registry import registry_goals
-from .runtime import validate_goal_id_path_segment
 from .control_plane.runtime.public_safety import public_safe_compact_text
-from .status import (
-    DREAMING_ADVISORY_CLASSIFICATIONS,
-    STATUS_NEUTRAL_CLASSIFICATIONS,
-)
-from .state_refresh import now_local
-from .todos import add_goal_todo, update_goal_todo
 from .control_plane.runtime.shared_runtime_material_projection import (
     finalize_material_projection,
     prepare_material_projection_route,
 )
-
+from .control_plane.runtime.status_classifications import (
+    DREAMING_ADVISORY_CLASSIFICATIONS,
+)
+from .feedback import validate_local_control_text, validate_public_safe_text
+from .history import (
+    STATUS_NEUTRAL_CLASSIFICATIONS,
+    collect_history,
+    load_registry,
+    write_reserved_run_artifacts,
+)
+from .paths import resolve_runtime_root
+from .registry import registry_goals
+from .runtime import validate_goal_id_path_segment
+from .state_refresh import now_local
+from .todos import add_goal_todo, update_goal_todo
 
 DREAMING_DRY_RUN_SCHEMA_VERSION = "dreaming_dry_run_proposal_v0"
 DREAMING_PROPOSAL_SCHEMA_VERSION = "dreaming_proposal_v0"

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -131,6 +131,10 @@ COMMAND_GROUPS: list[dict[str, object]] = [
                 "purpose": "Generate a copy-paste project connection prompt for an agent.",
             },
             {
+                "command": "loopx bind-agent-thread",
+                "purpose": "Persist one stable host thread binding to an already registered LoopX agent.",
+            },
+            {
                 "command": "loopx codex-cli-bootstrap-message",
                 "purpose": "Generate the visible Codex CLI TUI setup message.",
             },

--- a/man/loopx.1
+++ b/man/loopx.1
@@ -113,6 +113,9 @@ Create or connect project\-local state.
 \fBloopx new\-project\-prompt\fR
 Generate a copy\-paste project connection prompt for an agent.
 .TP
+\fBloopx bind\-agent\-thread\fR
+Persist one stable host thread binding to an already registered LoopX agent.
+.TP
 \fBloopx codex\-cli\-bootstrap\-message\fR
 Generate the visible Codex CLI TUI setup message.
 .TP


### PR DESCRIPTION
## Summary

Restore exact-main Full Public Smokes contract parity for run 31245205641.

- Align `bootstrap-command-pack-smoke` with the capability-owned `loopx-pr-review` skill contract: full JSON packet preservation, no single-copy `jq` projection, and five-section evidence authority.
- Move `start-goal` argument parsing, handler, and parser registration into a cohesive `start_goal.py` owner; share host-thread resolution via `_host_thread.py` so `starter_bootstrap.py` and `starter_bootstrap_registration.py` return below their enforced size budgets.
- Classify `bind-agent-thread` in the canonical command catalog and regenerate `man/loopx.1`.
- Refresh `install-local-smoke` and starter-family module ownership checks to current public contracts.

## Validation

- Focused smokes passed with Python 3.11: `bootstrap-command-pack-smoke`, `cli-command-module-size-ownership-command-modularization-smoke`, `cli-help-manpage-smoke`, `cli-starter-bootstrap-family-command-modularization-smoke`, `install-local-smoke`, and `canary-promotion-readiness-smoke`.
- Pytest passed: `test_start_goal_compact_projection.py` + `test_slash_command_install.py` (53 passed), `test_cli_output_budget.py` (15 passed), `test_cli_output_differential.py` (12 passed).
- Standard premerge canary passed; `loopx check --scan-path .` public boundary clean; `git diff --check` clean.
- Full Public shard 1: all checks except `canary-promotion-readiness-smoke` pass under the normal 120s window. That check passes standalone in ~151s in this local environment, so the local 120s concurrent-run timeout is environment load, not a contract failure.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`