### PR TITLE
refactor(scheduler): extract monitor wait read model

### DIFF
--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -302,6 +302,7 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
             "monitor_target",
             "monitor_poll_writeback",
             "loopx/control_plane/scheduler/monitor_todo.py",
+            "loopx/control_plane/scheduler/monitor_wait.py",
             "loopx/control_plane/scheduler/monitor_poll_writeback.py",
             "loopx/control_plane/scheduler/monitor_target.py",
             "loopx/control_plane/scheduler/scheduler_hint.py",

--- a/loopx/canary/qualification_profiles.py
+++ b/loopx/canary/qualification_profiles.py
@@ -223,6 +223,7 @@ CONTROL_PLANE_QUALIFICATION_PROFILES: tuple[dict[str, Any], ...] = (
             "route_binding",
             "loopx/control_plane/scheduler/ack.py",
             "loopx/control_plane/scheduler/scheduler_hint.py",
+            "loopx/control_plane/scheduler/monitor_wait.py",
             "loopx/control_plane/scheduler/state.py",
             "loopx/control_plane/scheduler/state_transition_rules.py",
             "loopx/cli_commands/quota",

--- a/loopx/canary/quality_surface_catalog.py
+++ b/loopx/canary/quality_surface_catalog.py
@@ -137,6 +137,7 @@ QUALITY_SURFACE_CATALOG: tuple[dict[str, Any], ...] = (
         "owner_paths": [
             "loopx/control_plane/quota/live_decision.py",
             "loopx/control_plane/scheduler/ack.py",
+            "loopx/control_plane/scheduler/monitor_wait.py",
             "loopx/control_plane/scheduler/scheduler_hint.py",
             "loopx/control_plane/scheduler/state.py",
             "loopx/control_plane/scheduler/state_transition_rules.py",

--- a/loopx/control_plane/scheduler/monitor_wait.py
+++ b/loopx/control_plane/scheduler/monitor_wait.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import math
+from datetime import datetime
+from typing import Any
+
+from ..runtime.time import now_utc
+from ..todos.frontier_deadline import todo_summary_frontier_deadline
+from .monitor_todo import monitor_cadence_delta
+from .time import parse_scheduler_timestamp
+
+MONITOR_WAIT_PROGRESSION_MINUTES = [15, 30, 60]
+MONITOR_WAIT_HOST_FLOOR_MINUTES = 15
+MONITOR_WAIT_NEAR_WINDOW_LEAD_MINUTES = 60
+MONITOR_WAIT_PHASE_RANK = {
+    "active_window": 0,
+    "near_window": 1,
+    "cadence_only": 2,
+    "far_window": 3,
+}
+
+
+def _parse_monitor_timestamp(value: Any) -> datetime | None:
+    return parse_scheduler_timestamp(value)
+
+
+def _monitor_cadence_minutes(value: Any) -> int | None:
+    cadence_delta = monitor_cadence_delta(value)
+    if cadence_delta is None:
+        return None
+    return max(1, math.ceil(cadence_delta.total_seconds() / 60))
+
+
+def _monitor_wait_items(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    summary = payload.get("agent_todo_summary")
+    if not isinstance(summary, dict):
+        return []
+    items: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for key in ("current_agent_claimed_monitor_items", "monitor_open_items"):
+        values = summary.get(key)
+        if not isinstance(values, list):
+            continue
+        for value in values:
+            if not isinstance(value, dict):
+                continue
+            todo_id = str(value.get("todo_id") or "")
+            if todo_id and todo_id in seen_ids:
+                continue
+            if todo_id:
+                seen_ids.add(todo_id)
+            items.append(value)
+    return items
+
+
+def _monitor_item_identity(item: dict[str, Any]) -> str:
+    for key in ("todo_id", "target_key", "action_kind", "title"):
+        value = str(item.get(key) or "").strip()
+        if value:
+            return value
+    return str(item.get("index") or "monitor")
+
+
+def _minutes_until(value: datetime, current_time: datetime) -> int:
+    return max(1, math.ceil((value - current_time).total_seconds() / 60))
+
+
+def _cap_monitor_progression(*, cap_minutes: int, host_floor_minutes: int) -> list[int]:
+    safe_cap = max(1, int(cap_minutes))
+    safe_floor = max(1, int(host_floor_minutes))
+    # Keep host RRULEs on stable buckets; the exact due horizon still gates routing.
+    progression = [
+        max(safe_floor, interval)
+        for interval in MONITOR_WAIT_PROGRESSION_MINUTES
+        if interval <= safe_cap
+    ]
+    return progression or [safe_floor]
+
+
+def _monitor_wait_item_plan(
+    item: dict[str, Any],
+    *,
+    current_time: datetime,
+) -> dict[str, Any] | None:
+    expires_at = _parse_monitor_timestamp(item.get("expires_at"))
+    if expires_at is not None and expires_at <= current_time:
+        return {
+            "phase": "expired",
+            "selected_monitor_identity": _monitor_item_identity(item),
+        }
+
+    next_due_at = _parse_monitor_timestamp(item.get("next_due_at"))
+    last_checked_at = _parse_monitor_timestamp(item.get("last_checked_at"))
+    cadence_minutes = _monitor_cadence_minutes(item.get("cadence"))
+    host_floor = MONITOR_WAIT_HOST_FLOOR_MINUTES
+    phase: str | None = None
+    cap_candidates: list[int] = []
+    include_next_due_in_reset = False
+
+    if expires_at is not None and last_checked_at is not None and last_checked_at <= current_time:
+        phase = "active_window"
+        if cadence_minutes is not None:
+            cap_candidates.append(cadence_minutes)
+        if next_due_at is not None and next_due_at > current_time:
+            cap_candidates.append(_minutes_until(next_due_at, current_time))
+    elif next_due_at is not None and next_due_at > current_time:
+        minutes_until_due = _minutes_until(next_due_at, current_time)
+        phase = (
+            "near_window"
+            if minutes_until_due <= MONITOR_WAIT_NEAR_WINDOW_LEAD_MINUTES
+            else "far_window"
+        )
+        cap_candidates.append(minutes_until_due)
+        include_next_due_in_reset = True
+    elif cadence_minutes is not None:
+        phase = "cadence_only"
+        cap_candidates.append(cadence_minutes)
+
+    if phase is None or not cap_candidates:
+        return None
+
+    # Fifteen minutes is the quiet-monitor backoff floor, not a deadline floor.
+    # A tighter explicit cadence or due horizon must wake the host in time.
+    cap_minutes = min(cap_candidates)
+    host_floor = min(host_floor, cap_minutes)
+    selected_identity = _monitor_item_identity(item)
+    reset_profile = {
+        "monitor_wait_phase": phase,
+        "monitor_wait_host_floor_minutes": host_floor,
+        "monitor_wait_selected_identity": selected_identity,
+        "monitor_wait_cadence_minutes": cadence_minutes,
+        "monitor_wait_window_start_at": (
+            next_due_at.isoformat()
+            if include_next_due_in_reset and next_due_at is not None
+            else None
+        ),
+        "monitor_wait_window_end_at": expires_at.isoformat() if expires_at is not None else None,
+    }
+    progression = _cap_monitor_progression(
+        cap_minutes=cap_minutes,
+        host_floor_minutes=host_floor,
+    )
+    return {
+        "phase": phase,
+        "selected_monitor_identity": selected_identity,
+        "selected_todo_id": item.get("todo_id"),
+        "selected_target_key": item.get("target_key"),
+        "host_floor_minutes": host_floor,
+        "cap_minutes": cap_minutes,
+        "cadence_minutes": cadence_minutes,
+        "next_due_at": next_due_at.isoformat() if next_due_at is not None else None,
+        "expires_at": expires_at.isoformat() if expires_at is not None else None,
+        "last_checked_at": last_checked_at.isoformat() if last_checked_at is not None else None,
+        "progression_minutes": progression,
+        "reset_profile": reset_profile,
+    }
+
+
+def build_monitor_wait_cadence_plan(
+    payload: dict[str, Any],
+    *,
+    current_time: datetime | None = None,
+) -> dict[str, Any] | None:
+    """Build phase-aware monitor backoff without turning due horizon into identity."""
+
+    current_time = current_time or now_utc()
+    plans: list[dict[str, Any]] = []
+    expired_count = 0
+    for item in _monitor_wait_items(payload):
+        plan = _monitor_wait_item_plan(item, current_time=current_time)
+        if not plan:
+            continue
+        if plan.get("phase") == "expired":
+            expired_count += 1
+            continue
+        plans.append(plan)
+
+    frontier_deadline = todo_summary_frontier_deadline(
+        payload.get("agent_todo_summary"),
+        current_time=current_time,
+    )
+    if (
+        isinstance(frontier_deadline, dict)
+        and frontier_deadline.get("source") == "continuous_monitor"
+    ):
+        frontier_plan = _monitor_wait_item_plan(
+            {
+                "title": frontier_deadline.get("identity"),
+                "next_due_at": frontier_deadline.get("next_due_at"),
+            },
+            current_time=current_time,
+        )
+        if frontier_plan and not any(
+            plan.get("selected_monitor_identity")
+            == frontier_plan.get("selected_monitor_identity")
+            and plan.get("next_due_at") == frontier_plan.get("next_due_at")
+            for plan in plans
+        ):
+            plans.append(frontier_plan)
+
+    if not plans:
+        if expired_count:
+            return {
+                "phase": "expired",
+                "expired_monitor_count": expired_count,
+                "host_floor_minutes": MONITOR_WAIT_HOST_FLOOR_MINUTES,
+                "base_progression_minutes": MONITOR_WAIT_PROGRESSION_MINUTES,
+                "progression_minutes": None,
+                "reset_profile": None,
+            }
+        return None
+
+    selected = min(
+        plans,
+        key=lambda plan: (
+            int(plan.get("cap_minutes") or 10**9),
+            MONITOR_WAIT_PHASE_RANK.get(str(plan.get("phase") or ""), 99),
+            str(plan.get("selected_monitor_identity") or ""),
+        ),
+    )
+    return {
+        **selected,
+        "base_progression_minutes": MONITOR_WAIT_PROGRESSION_MINUTES,
+        "candidate_count": len(plans),
+        "expired_monitor_count": expired_count,
+    }

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -2,17 +2,13 @@ from __future__ import annotations
 
 import hashlib
 import json
-import math
 from collections.abc import Collection, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any
 
 from ..runtime.time import now_utc, utc_isoformat
-from ..todos.frontier_deadline import (
-    build_frontier_recheck_plan,
-    todo_summary_frontier_deadline,
-)
+from ..todos.frontier_deadline import build_frontier_recheck_plan
 from . import ack as scheduler_ack
 from .arbitration import (
     SchedulerArbitration,
@@ -26,7 +22,12 @@ from .execution_context import (
     apply_scheduler_execution_context,
     resolve_scheduler_execution_context,
 )
-from .monitor_todo import monitor_cadence_delta
+from .monitor_wait import (
+    MONITOR_WAIT_HOST_FLOOR_MINUTES,
+    MONITOR_WAIT_PROGRESSION_MINUTES,
+    _parse_monitor_timestamp,  # noqa: F401  # re-exported for compatibility
+    build_monitor_wait_cadence_plan,
+)
 from .state import (
     CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
     CODEX_APP_SURFACE,
@@ -49,17 +50,8 @@ CODEX_APP_STATEFUL_BACKOFF_SCHEMA_VERSION = "codex_app_stateful_backoff_v0"
 CODEX_APP_SCHEDULER_ACK_HINT_SCHEMA_VERSION = "codex_app_scheduler_ack_hint_v0"
 CODEX_APP_SCHEDULER_FAILURE_HINT_SCHEMA_VERSION = "codex_app_scheduler_failure_hint_v0"
 USER_GATE_NOTIFICATION_COOLDOWN_SCHEMA_VERSION = "user_gate_notification_cooldown_v0"
-MONITOR_WAIT_PROGRESSION_MINUTES = [15, 30, 60]
 CODEX_APP_MAX_INTERVAL_MINUTES = 60
 DEFAULT_ACK_CAPABILITIES = {"shell", "filesystem_read", "filesystem_write"}
-MONITOR_WAIT_HOST_FLOOR_MINUTES = 15
-MONITOR_WAIT_NEAR_WINDOW_LEAD_MINUTES = 60
-MONITOR_WAIT_PHASE_RANK = {
-    "active_window": 0,
-    "near_window": 1,
-    "cadence_only": 2,
-    "far_window": 3,
-}
 SCHEDULER_BASE_IDENTITY_KEYS = (
     "goal_id",
     "agent_identity.agent_id",
@@ -334,208 +326,6 @@ def build_codex_app_scheduler_failure_hint(
     return {
         "schema_version": CODEX_APP_SCHEDULER_FAILURE_HINT_SCHEMA_VERSION,
         "cli_args": cli_args,
-    }
-
-
-def _parse_monitor_timestamp(value: Any) -> datetime | None:
-    return parse_scheduler_timestamp(value)
-
-
-def _monitor_cadence_minutes(value: Any) -> int | None:
-    cadence_delta = monitor_cadence_delta(value)
-    if cadence_delta is None:
-        return None
-    return max(1, math.ceil(cadence_delta.total_seconds() / 60))
-
-
-def _monitor_wait_items(payload: dict[str, Any]) -> list[dict[str, Any]]:
-    summary = payload.get("agent_todo_summary")
-    if not isinstance(summary, dict):
-        return []
-    items: list[dict[str, Any]] = []
-    seen_ids: set[str] = set()
-    for key in ("current_agent_claimed_monitor_items", "monitor_open_items"):
-        values = summary.get(key)
-        if not isinstance(values, list):
-            continue
-        for value in values:
-            if not isinstance(value, dict):
-                continue
-            todo_id = str(value.get("todo_id") or "")
-            if todo_id and todo_id in seen_ids:
-                continue
-            if todo_id:
-                seen_ids.add(todo_id)
-            items.append(value)
-    return items
-
-
-def _monitor_item_identity(item: dict[str, Any]) -> str:
-    for key in ("todo_id", "target_key", "action_kind", "title"):
-        value = str(item.get(key) or "").strip()
-        if value:
-            return value
-    return str(item.get("index") or "monitor")
-
-
-def _minutes_until(value: datetime, current_time: datetime) -> int:
-    return max(1, math.ceil((value - current_time).total_seconds() / 60))
-
-
-def _cap_monitor_progression(*, cap_minutes: int, host_floor_minutes: int) -> list[int]:
-    safe_cap = max(1, int(cap_minutes))
-    safe_floor = max(1, int(host_floor_minutes))
-    # Keep host RRULEs on stable buckets; the exact due horizon still gates routing.
-    progression = [
-        max(safe_floor, interval)
-        for interval in MONITOR_WAIT_PROGRESSION_MINUTES
-        if interval <= safe_cap
-    ]
-    return progression or [safe_floor]
-
-
-def _monitor_wait_item_plan(
-    item: dict[str, Any],
-    *,
-    current_time: datetime,
-) -> dict[str, Any] | None:
-    expires_at = _parse_monitor_timestamp(item.get("expires_at"))
-    if expires_at is not None and expires_at <= current_time:
-        return {
-            "phase": "expired",
-            "selected_monitor_identity": _monitor_item_identity(item),
-        }
-
-    next_due_at = _parse_monitor_timestamp(item.get("next_due_at"))
-    last_checked_at = _parse_monitor_timestamp(item.get("last_checked_at"))
-    cadence_minutes = _monitor_cadence_minutes(item.get("cadence"))
-    host_floor = MONITOR_WAIT_HOST_FLOOR_MINUTES
-    phase: str | None = None
-    cap_candidates: list[int] = []
-    include_next_due_in_reset = False
-
-    if expires_at is not None and last_checked_at is not None and last_checked_at <= current_time:
-        phase = "active_window"
-        if cadence_minutes is not None:
-            cap_candidates.append(cadence_minutes)
-        if next_due_at is not None and next_due_at > current_time:
-            cap_candidates.append(_minutes_until(next_due_at, current_time))
-    elif next_due_at is not None and next_due_at > current_time:
-        minutes_until_due = _minutes_until(next_due_at, current_time)
-        phase = (
-            "near_window"
-            if minutes_until_due <= MONITOR_WAIT_NEAR_WINDOW_LEAD_MINUTES
-            else "far_window"
-        )
-        cap_candidates.append(minutes_until_due)
-        include_next_due_in_reset = True
-    elif cadence_minutes is not None:
-        phase = "cadence_only"
-        cap_candidates.append(cadence_minutes)
-
-    if phase is None or not cap_candidates:
-        return None
-
-    # Fifteen minutes is the quiet-monitor backoff floor, not a deadline floor.
-    # A tighter explicit cadence or due horizon must wake the host in time.
-    cap_minutes = min(cap_candidates)
-    host_floor = min(host_floor, cap_minutes)
-    selected_identity = _monitor_item_identity(item)
-    reset_profile = {
-        "monitor_wait_phase": phase,
-        "monitor_wait_host_floor_minutes": host_floor,
-        "monitor_wait_selected_identity": selected_identity,
-        "monitor_wait_cadence_minutes": cadence_minutes,
-        "monitor_wait_window_start_at": (
-            next_due_at.isoformat()
-            if include_next_due_in_reset and next_due_at is not None
-            else None
-        ),
-        "monitor_wait_window_end_at": expires_at.isoformat() if expires_at is not None else None,
-    }
-    progression = _cap_monitor_progression(
-        cap_minutes=cap_minutes,
-        host_floor_minutes=host_floor,
-    )
-    return {
-        "phase": phase,
-        "selected_monitor_identity": selected_identity,
-        "selected_todo_id": item.get("todo_id"),
-        "selected_target_key": item.get("target_key"),
-        "host_floor_minutes": host_floor,
-        "cap_minutes": cap_minutes,
-        "cadence_minutes": cadence_minutes,
-        "next_due_at": next_due_at.isoformat() if next_due_at is not None else None,
-        "expires_at": expires_at.isoformat() if expires_at is not None else None,
-        "last_checked_at": last_checked_at.isoformat() if last_checked_at is not None else None,
-        "progression_minutes": progression,
-        "reset_profile": reset_profile,
-    }
-
-
-def _monitor_wait_cadence_plan(payload: dict[str, Any]) -> dict[str, Any] | None:
-    """Build phase-aware monitor backoff without turning due horizon into identity."""
-
-    current_time = now_utc()
-    plans: list[dict[str, Any]] = []
-    expired_count = 0
-    for item in _monitor_wait_items(payload):
-        plan = _monitor_wait_item_plan(item, current_time=current_time)
-        if not plan:
-            continue
-        if plan.get("phase") == "expired":
-            expired_count += 1
-            continue
-        plans.append(plan)
-
-    frontier_deadline = todo_summary_frontier_deadline(
-        payload.get("agent_todo_summary"),
-        current_time=current_time,
-    )
-    if (
-        isinstance(frontier_deadline, dict)
-        and frontier_deadline.get("source") == "continuous_monitor"
-    ):
-        frontier_plan = _monitor_wait_item_plan(
-            {
-                "title": frontier_deadline.get("identity"),
-                "next_due_at": frontier_deadline.get("next_due_at"),
-            },
-            current_time=current_time,
-        )
-        if frontier_plan and not any(
-            plan.get("selected_monitor_identity")
-            == frontier_plan.get("selected_monitor_identity")
-            and plan.get("next_due_at") == frontier_plan.get("next_due_at")
-            for plan in plans
-        ):
-            plans.append(frontier_plan)
-
-    if not plans:
-        if expired_count:
-            return {
-                "phase": "expired",
-                "expired_monitor_count": expired_count,
-                "host_floor_minutes": MONITOR_WAIT_HOST_FLOOR_MINUTES,
-                "base_progression_minutes": MONITOR_WAIT_PROGRESSION_MINUTES,
-                "progression_minutes": None,
-                "reset_profile": None,
-            }
-        return None
-
-    selected = min(
-        plans,
-        key=lambda plan: (
-            int(plan.get("cap_minutes") or 10**9),
-            MONITOR_WAIT_PHASE_RANK.get(str(plan.get("phase") or ""), 99),
-            str(plan.get("selected_monitor_identity") or ""),
-        ),
-    )
-    return {
-        **selected,
-        "base_progression_minutes": MONITOR_WAIT_PROGRESSION_MINUTES,
-        "candidate_count": len(plans),
-        "expired_monitor_count": expired_count,
     }
 
 
@@ -1263,7 +1053,10 @@ def build_scheduler_hint(
         )
 
     if arbitration.disposition == SchedulerDisposition.MONITOR_WAIT:
-        monitor_plan = _monitor_wait_cadence_plan(payload)
+        monitor_plan = build_monitor_wait_cadence_plan(
+            payload,
+            current_time=now_utc(),
+        )
         monitor_progression = (
             monitor_plan.get("progression_minutes")
             if isinstance(monitor_plan, dict)


### PR DESCRIPTION
## Summary

Extract the monitor-wait read model out of `scheduler_hint.py` into `loopx/control_plane/scheduler/monitor_wait.py`, preserving behavior and re-export compatibility.

- Moved monitor cadence parsing, wait-item planning, frontier-deadline projection, progression selection, and the phase-aware cadence plan into one bounded module.
- `scheduler_hint.py` now imports `build_monitor_wait_cadence_plan` and re-exports `_parse_monitor_timestamp` for existing consumers.
- Registered the new module in control-plane canary planner, qualification profile, and quality surface catalog owner paths.

## Validation

- `examples/control_plane/monitor-scheduler-contract-smoke.py`: passed.
- Pytest scheduler/monitor related suites: 243 passed.
- `py_compile`, `git diff --check`, Ruff on the changed scheduler modules, and public boundary scan: passed.
- Standard premerge canary: one inherited `control-plane-maintainability-ratchet-smoke` failure from the existing module-metric baseline for `planner.py`, `capabilities/catalog.py`, `heartbeat_prompt.py`, and `todos.py`; this is addressed separately by PR #2896 and is not introduced by this diff.

## Dependencies

- Stacked on #2899 (`fix(scheduler): honor monitor heartbeat deadlines`), which owns the deadline behavior this module preserves.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`