### PR TITLE
refactor(goal): split terminal frontier read model

### DIFF
--- a/loopx/canary/module_metric_baseline.json
+++ b/loopx/canary/module_metric_baseline.json
@@ -45,10 +45,15 @@
       "dict_any_count": 0,
       "lines": 1578
     },
-    "loopx/control_plane/goals/goal_frontier.py": {
-      "any_count": 130,
+    "loopx/control_plane/goals/goal_frontier/__init__.py": {
+      "any_count": 115,
       "dict_any_count": 0,
-      "lines": 2225
+      "lines": 2056
+    },
+    "loopx/control_plane/goals/goal_frontier/terminal.py": {
+      "any_count": 15,
+      "dict_any_count": 0,
+      "lines": 180
     },
     "loopx/extensions/lark/presentation/explore_results.py": {
       "any_count": 58,

--- a/loopx/canary/qualification_profiles.py
+++ b/loopx/canary/qualification_profiles.py
@@ -183,7 +183,8 @@ CONTROL_PLANE_QUALIFICATION_PROFILES: tuple[dict[str, Any], ...] = (
         "trigger_hints": (
             "goal frontier replan",
             "goal_frontier_replan_rules",
-            "loopx/control_plane/goals/goal_frontier.py",
+            "loopx/control_plane/goals/goal_frontier/__init__.py",
+            "loopx/control_plane/goals/goal_frontier/terminal.py",
             "loopx/control_plane/goals/goal_frontier_replan_rules.py",
             "goal-frontier-replan-rules-smoke.py",
         ),

--- a/loopx/canary/quality_surface_catalog.py
+++ b/loopx/canary/quality_surface_catalog.py
@@ -181,7 +181,8 @@ QUALITY_SURFACE_CATALOG: tuple[dict[str, Any], ...] = (
         "risk": "high",
         "canary_profile_id": "goal-frontier-replan-rules",
         "owner_paths": [
-            "loopx/control_plane/goals/goal_frontier.py",
+            "loopx/control_plane/goals/goal_frontier/__init__.py",
+            "loopx/control_plane/goals/goal_frontier/terminal.py",
             "loopx/control_plane/goals/goal_frontier_replan_rules.py",
             "loopx/control_plane/work_items/autonomous_replan_ack.py",
         ],

--- a/loopx/control_plane/goals/goal_frontier/__init__.py
+++ b/loopx/control_plane/goals/goal_frontier/__init__.py
@@ -2,36 +2,43 @@ from __future__ import annotations
 
 from typing import Any
 
-from ..agents.agent_scope import (
+from ...agents.agent_scope import (
     agent_scope_blocking_handoff_gates,
     agent_scope_count_advancement_items,
     agent_scope_item_claimed_by,
     agent_scope_item_claimed_by_agent_or_unclaimed,
 )
-from ..agents.profile import agent_profile_requires_vision
-from ..agents.runtime_model import peer_work_key, select_peer_for_work
-from ..work_items.autonomous_replan_ack import (
-    autonomous_replan_ack_matches_frontier,
+from ...agents.profile import agent_profile_requires_vision
+from ...agents.runtime_model import peer_work_key, select_peer_for_work
+from ...work_items.autonomous_replan_ack import (
     autonomous_replan_ack_matches_agent,
+    autonomous_replan_ack_matches_frontier,
     latest_autonomous_replan_ack_for_projection,
 )
-from ..work_items.autonomous_replan_obligation import (
+from ...work_items.autonomous_replan_obligation import (
     AUTONOMOUS_REPLAN_STALL_THRESHOLD,
     build_autonomous_replan_obligation_payload,
 )
-from ..work_items.repair_delta import repair_delta_kinds_have_frontier_delta
-from .goal_frontier_replan_rules import (
+from ...work_items.repair_delta import repair_delta_kinds_have_frontier_delta
+from ..goal_frontier_replan_rules import (
     GoalFrontierReplanFacts,
     GoalFrontierReplanRule,
     select_goal_frontier_replan_rule,
 )
-from .goal_vision_policy import goal_vision_repeats_advancement_until_closed
-from .goal_vision_state import (
+from ..goal_vision_policy import goal_vision_repeats_advancement_until_closed
+from ..goal_vision_state import (
     goal_vision_state_is_closed,
     goal_vision_state_requires_successor,
 )
-from .goal_vision_wait import build_goal_vision_wait_state
-
+from ..goal_vision_wait import build_goal_vision_wait_state
+from .terminal import (
+    GOAL_TERMINAL_SOURCE_COMPLETENESS_SCHEMA_VERSION,  # noqa: F401
+    GOAL_TERMINAL_STATE_SCHEMA_VERSION,  # noqa: F401
+    VISION_CHECKPOINT_NO_FOLLOWUP_RESOLUTION,  # noqa: F401
+    _terminal_no_followup_resolves_vision_checkpoint,
+    derive_goal_terminal_state,
+    goal_frontier_is_terminal_no_followup,  # noqa: F401
+)
 
 GOAL_FRONTIER_PROJECTION_SCHEMA_VERSION = "goal_frontier_projection_v0"
 VISION_CONTINUATION_AUDIT_SCHEMA_VERSION = "vision_continuation_audit_v0"
@@ -44,8 +51,6 @@ REPEAT_VISION_REPLAN_SATISFYING_DELTA_KINDS = (
     "successor_or_supersede",
 )
 AUTONOMOUS_REPLAN_REQUIRED_MODE = "autonomous_replan_required"
-GOAL_TERMINAL_STATE_SCHEMA_VERSION = "goal_terminal_state_v0"
-GOAL_TERMINAL_SOURCE_COMPLETENESS_SCHEMA_VERSION = "goal_terminal_source_completeness_v0"
 FRONTIER_EXHAUSTED_MONITOR_TRIGGER = "frontier_exhausted_monitor_lane"
 MONITOR_NO_CHANGE_STREAK_TRIGGER = "monitor_no_change_streak"
 LONG_TODO_CHAIN_TRIGGER = "long_todo_chain"
@@ -63,7 +68,6 @@ VISION_CHECKPOINT_SATISFIED_DECISIONS = {
     "retired_or_superseded",
     "unchanged_with_reason",
 }
-VISION_CHECKPOINT_NO_FOLLOWUP_RESOLUTION = "record_no_followup"
 
 
 def safe_non_negative_int(value: Any) -> int:
@@ -71,179 +75,6 @@ def safe_non_negative_int(value: Any) -> int:
         return max(0, int(value or 0))
     except (TypeError, ValueError):
         return 0
-
-
-def _strict_zero(value: Any) -> bool:
-    return type(value) is int and value == 0
-
-
-def _terminal_todo_source_state(
-    summary: dict[str, Any] | None,
-    *,
-    role: str,
-) -> tuple[str, bool]:
-    if not isinstance(summary, dict):
-        return "missing", False
-    completeness = summary.get("source_completeness")
-    if not (
-        isinstance(completeness, dict)
-        and completeness.get("schema_version") == "todo_source_completeness_v0"
-        and completeness.get("status") == "valid"
-        and completeness.get("source") == "structured_todo_projection"
-        and completeness.get("role") == role
-        and completeness.get("terminal_closure") == "valid"
-    ):
-        return "invalid", False
-    total = summary.get("total_count")
-    done = summary.get("done_count")
-    deferred = summary.get("deferred_count")
-    if not (
-        type(total) is int
-        and total >= 0
-        and type(done) is int
-        and done == total
-        and _strict_zero(summary.get("open_count"))
-        and _strict_zero(deferred)
-        and _strict_zero(summary.get("monitor_due_count"))
-        and _strict_zero(summary.get("monitor_schedule_gap_count"))
-        and isinstance(summary.get("monitor_open_items"), list)
-        and not summary.get("monitor_open_items")
-    ):
-        return "invalid", False
-    intent = summary.get("closure_intent")
-    has_no_followup_intent = bool(
-        isinstance(intent, dict)
-        and intent.get("schema_version") == "todo_closure_intent_v0"
-        and intent.get("kind") == "no_followup"
-        and intent.get("derived") is True
-        and intent.get("source") == "todo_no_followup"
-        and type(intent.get("count")) is int
-        and 0 < intent.get("count") <= done
-    )
-    return "valid", has_no_followup_intent
-
-
-def _projection_has_empty_terminal_frontier(projection: dict[str, Any] | None) -> bool:
-    if not isinstance(projection, dict):
-        return False
-
-    normalized = projection.get("normalized_progress")
-    frontier = projection.get("remaining_advancement_frontier")
-    monitors = projection.get("monitor_only_lanes")
-    successors = projection.get("deferred_successors")
-    if not all(isinstance(value, dict) for value in (normalized, frontier, monitors, successors)):
-        return False
-
-    required_keys = (
-        (normalized, {"user_open_count", "agent_open_count", "agent_advancement_open_count", "agent_monitor_open_count", "agent_monitor_due_count"}),
-        (frontier, {"current_agent_claimed_advancement_count", "unclaimed_advancement_count", "other_agent_claimed_advancement_count"}),
-        (monitors, {"present", "quiet_until_material_transition"}),
-        (successors, {"ready_count", "blocked_count", "current_agent_ready_count"}),
-    )
-    if any(not keys.issubset(values) for values, keys in required_keys):
-        return False
-
-    projected_counts = (
-        normalized.get("user_open_count"),
-        normalized.get("agent_open_count"),
-        normalized.get("agent_advancement_open_count"),
-        normalized.get("agent_monitor_open_count"),
-        normalized.get("agent_monitor_due_count"),
-        frontier.get("current_agent_claimed_advancement_count"),
-        frontier.get("unclaimed_advancement_count"),
-        frontier.get("other_agent_claimed_advancement_count"),
-        successors.get("ready_count"),
-        successors.get("blocked_count"),
-        successors.get("current_agent_ready_count"),
-    )
-    return (
-        all(_strict_zero(value) for value in projected_counts)
-        and monitors.get("present") is False
-        and monitors.get("quiet_until_material_transition") is False
-        and projection.get("acceptance_gaps") == []
-        and projection.get("autonomy_blockers") == []
-        and projection.get("replan_required") is False
-    )
-
-
-def derive_goal_terminal_state(
-    *,
-    user_todo_summary: dict[str, Any] | None,
-    agent_todo_summary: dict[str, Any] | None,
-    projection: dict[str, Any],
-) -> tuple[dict[str, Any], dict[str, Any] | None]:
-    source_completeness, source_closure_confirmed = _terminal_todo_source_contract(
-        user_todo_summary=user_todo_summary,
-        agent_todo_summary=agent_todo_summary,
-    )
-    if not (
-        source_closure_confirmed
-        and _projection_has_empty_terminal_frontier(projection)
-    ):
-        return source_completeness, None
-    return source_completeness, {
-        "schema_version": GOAL_TERMINAL_STATE_SCHEMA_VERSION,
-        "kind": "no_followup",
-        "derived": True,
-        "source": "validated_goal_closure",
-    }
-
-
-def _terminal_todo_source_contract(
-    *,
-    user_todo_summary: dict[str, Any] | None,
-    agent_todo_summary: dict[str, Any] | None,
-) -> tuple[dict[str, Any], bool]:
-    user_status, user_intent = _terminal_todo_source_state(user_todo_summary, role="user")
-    agent_status, agent_intent = _terminal_todo_source_state(agent_todo_summary, role="agent")
-    source_completeness = {
-        "schema_version": GOAL_TERMINAL_SOURCE_COMPLETENESS_SCHEMA_VERSION,
-        "user_todos": user_status,
-        "agent_todos": agent_status,
-    }
-    return (
-        source_completeness,
-        user_status == agent_status == "valid" and (user_intent or agent_intent),
-    )
-
-
-def _terminal_no_followup_resolves_vision_checkpoint(
-    *,
-    user_todo_summary: dict[str, Any] | None,
-    agent_todo_summary: dict[str, Any] | None,
-    checkpoint: dict[str, Any] | None,
-) -> bool:
-    if not isinstance(checkpoint, dict):
-        return False
-    required_resolution = checkpoint.get("required_resolution")
-    if not (
-        isinstance(required_resolution, list)
-        and VISION_CHECKPOINT_NO_FOLLOWUP_RESOLUTION in required_resolution
-    ):
-        return False
-    _, source_closure_confirmed = _terminal_todo_source_contract(
-        user_todo_summary=user_todo_summary,
-        agent_todo_summary=agent_todo_summary,
-    )
-    return source_closure_confirmed
-
-
-def goal_frontier_is_terminal_no_followup(*, projection: dict[str, Any] | None) -> bool:
-    if not _projection_has_empty_terminal_frontier(projection):
-        return False
-    terminal_state = projection.get("terminal_state")
-    completeness = projection.get("source_completeness")
-    return bool(
-        isinstance(terminal_state, dict)
-        and terminal_state.get("schema_version") == GOAL_TERMINAL_STATE_SCHEMA_VERSION
-        and terminal_state.get("kind") == "no_followup"
-        and terminal_state.get("derived") is True
-        and terminal_state.get("source") == "validated_goal_closure"
-        and isinstance(completeness, dict)
-        and completeness.get("schema_version") == GOAL_TERMINAL_SOURCE_COMPLETENESS_SCHEMA_VERSION
-        and completeness.get("user_todos") == "valid"
-        and completeness.get("agent_todos") == "valid"
-    )
 
 
 def select_autonomous_replan_obligation(

--- a/loopx/control_plane/goals/goal_frontier/terminal.py
+++ b/loopx/control_plane/goals/goal_frontier/terminal.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from typing import Any
+
+GOAL_TERMINAL_STATE_SCHEMA_VERSION = "goal_terminal_state_v0"
+GOAL_TERMINAL_SOURCE_COMPLETENESS_SCHEMA_VERSION = "goal_terminal_source_completeness_v0"
+VISION_CHECKPOINT_NO_FOLLOWUP_RESOLUTION = "record_no_followup"
+
+
+def _strict_zero(value: Any) -> bool:
+    return type(value) is int and value == 0
+
+
+def _terminal_todo_source_state(
+    summary: dict[str, Any] | None,
+    *,
+    role: str,
+) -> tuple[str, bool]:
+    if not isinstance(summary, dict):
+        return "missing", False
+    completeness = summary.get("source_completeness")
+    if not (
+        isinstance(completeness, dict)
+        and completeness.get("schema_version") == "todo_source_completeness_v0"
+        and completeness.get("status") == "valid"
+        and completeness.get("source") == "structured_todo_projection"
+        and completeness.get("role") == role
+        and completeness.get("terminal_closure") == "valid"
+    ):
+        return "invalid", False
+    total = summary.get("total_count")
+    done = summary.get("done_count")
+    deferred = summary.get("deferred_count")
+    if not (
+        type(total) is int
+        and total >= 0
+        and type(done) is int
+        and done == total
+        and _strict_zero(summary.get("open_count"))
+        and _strict_zero(deferred)
+        and _strict_zero(summary.get("monitor_due_count"))
+        and _strict_zero(summary.get("monitor_schedule_gap_count"))
+        and isinstance(summary.get("monitor_open_items"), list)
+        and not summary.get("monitor_open_items")
+    ):
+        return "invalid", False
+    intent = summary.get("closure_intent")
+    has_no_followup_intent = bool(
+        isinstance(intent, dict)
+        and intent.get("schema_version") == "todo_closure_intent_v0"
+        and intent.get("kind") == "no_followup"
+        and intent.get("derived") is True
+        and intent.get("source") == "todo_no_followup"
+        and type(intent.get("count")) is int
+        and 0 < intent.get("count") <= done
+    )
+    return "valid", has_no_followup_intent
+
+
+def _projection_has_empty_terminal_frontier(projection: dict[str, Any] | None) -> bool:
+    if not isinstance(projection, dict):
+        return False
+
+    normalized = projection.get("normalized_progress")
+    frontier = projection.get("remaining_advancement_frontier")
+    monitors = projection.get("monitor_only_lanes")
+    successors = projection.get("deferred_successors")
+    if not all(isinstance(value, dict) for value in (normalized, frontier, monitors, successors)):
+        return False
+
+    required_keys = (
+        (normalized, {"user_open_count", "agent_open_count", "agent_advancement_open_count", "agent_monitor_open_count", "agent_monitor_due_count"}),
+        (frontier, {"current_agent_claimed_advancement_count", "unclaimed_advancement_count", "other_agent_claimed_advancement_count"}),
+        (monitors, {"present", "quiet_until_material_transition"}),
+        (successors, {"ready_count", "blocked_count", "current_agent_ready_count"}),
+    )
+    if any(not keys.issubset(values) for values, keys in required_keys):
+        return False
+
+    projected_counts = (
+        normalized.get("user_open_count"),
+        normalized.get("agent_open_count"),
+        normalized.get("agent_advancement_open_count"),
+        normalized.get("agent_monitor_open_count"),
+        normalized.get("agent_monitor_due_count"),
+        frontier.get("current_agent_claimed_advancement_count"),
+        frontier.get("unclaimed_advancement_count"),
+        frontier.get("other_agent_claimed_advancement_count"),
+        successors.get("ready_count"),
+        successors.get("blocked_count"),
+        successors.get("current_agent_ready_count"),
+    )
+    return (
+        all(_strict_zero(value) for value in projected_counts)
+        and monitors.get("present") is False
+        and monitors.get("quiet_until_material_transition") is False
+        and projection.get("acceptance_gaps") == []
+        and projection.get("autonomy_blockers") == []
+        and projection.get("replan_required") is False
+    )
+
+
+def _terminal_todo_source_contract(
+    *,
+    user_todo_summary: dict[str, Any] | None,
+    agent_todo_summary: dict[str, Any] | None,
+) -> tuple[dict[str, Any], bool]:
+    user_status, user_intent = _terminal_todo_source_state(user_todo_summary, role="user")
+    agent_status, agent_intent = _terminal_todo_source_state(agent_todo_summary, role="agent")
+    source_completeness = {
+        "schema_version": GOAL_TERMINAL_SOURCE_COMPLETENESS_SCHEMA_VERSION,
+        "user_todos": user_status,
+        "agent_todos": agent_status,
+    }
+    return (
+        source_completeness,
+        user_status == agent_status == "valid" and (user_intent or agent_intent),
+    )
+
+
+def derive_goal_terminal_state(
+    *,
+    user_todo_summary: dict[str, Any] | None,
+    agent_todo_summary: dict[str, Any] | None,
+    projection: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    source_completeness, source_closure_confirmed = _terminal_todo_source_contract(
+        user_todo_summary=user_todo_summary,
+        agent_todo_summary=agent_todo_summary,
+    )
+    if not (
+        source_closure_confirmed
+        and _projection_has_empty_terminal_frontier(projection)
+    ):
+        return source_completeness, None
+    return source_completeness, {
+        "schema_version": GOAL_TERMINAL_STATE_SCHEMA_VERSION,
+        "kind": "no_followup",
+        "derived": True,
+        "source": "validated_goal_closure",
+    }
+
+
+def _terminal_no_followup_resolves_vision_checkpoint(
+    *,
+    user_todo_summary: dict[str, Any] | None,
+    agent_todo_summary: dict[str, Any] | None,
+    checkpoint: dict[str, Any] | None,
+) -> bool:
+    if not isinstance(checkpoint, dict):
+        return False
+    required_resolution = checkpoint.get("required_resolution")
+    if not (
+        isinstance(required_resolution, list)
+        and VISION_CHECKPOINT_NO_FOLLOWUP_RESOLUTION in required_resolution
+    ):
+        return False
+    _, source_closure_confirmed = _terminal_todo_source_contract(
+        user_todo_summary=user_todo_summary,
+        agent_todo_summary=agent_todo_summary,
+    )
+    return source_closure_confirmed
+
+
+def goal_frontier_is_terminal_no_followup(*, projection: dict[str, Any] | None) -> bool:
+    if not _projection_has_empty_terminal_frontier(projection):
+        return False
+    terminal_state = projection.get("terminal_state")
+    completeness = projection.get("source_completeness")
+    return bool(
+        isinstance(terminal_state, dict)
+        and terminal_state.get("schema_version") == GOAL_TERMINAL_STATE_SCHEMA_VERSION
+        and terminal_state.get("kind") == "no_followup"
+        and terminal_state.get("derived") is True
+        and terminal_state.get("source") == "validated_goal_closure"
+        and isinstance(completeness, dict)
+        and completeness.get("schema_version") == GOAL_TERMINAL_SOURCE_COMPLETENESS_SCHEMA_VERSION
+        and completeness.get("user_todos") == "valid"
+        and completeness.get("agent_todos") == "valid"
+    )


### PR DESCRIPTION
## Summary

Start the `goal_frontier` package split by extracting the terminal no-follow-up read model out of the monolithic `goal_frontier.py`.

- Converted `loopx/control_plane/goals/goal_frontier.py` into `goal_frontier/__init__.py`.
- Added `goal_frontier/terminal.py` with terminal-state source completeness, empty-frontier validation, vision-checkpoint no-follow-up resolution, and public `derive_goal_terminal_state` / `goal_frontier_is_terminal_no_followup`.
- Preserved import compatibility: `goal_frontier/__init__.py` re-exports the moved constants and functions, and adjusted relative imports for the new package depth.
- Updated canary owner paths and the module metric baseline for the new package files.

## Validation

- Pytest goal-frontier/quota/change-quality suites: 335 passed (230 + 105).
- Relevant smoke scripts importing `goal_frontier`: all passed.
- `py_compile`, Ruff on the new package, `git diff --check`, and public boundary scan: passed.
- Standard premerge canary: all selected checks passed, 0 failures, 0 timeouts.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`