### PR TITLE
docs(course): add harness effectful program lecture

### DIFF
--- a/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
+++ b/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
@@ -9,14 +9,19 @@
 
 ## Summary
 
-LoopX should be explained, designed, and tested as **the effect interpreter
-around an agent loop**, not as a collection of disconnected state machines.
+LoopX harness should be explained, designed, and tested as **the effectful
+program around an agent loop**, not as a collection of disconnected state
+machines.
 
 The canonical shape is:
 
 ```text
 model -> effect request -> harness interprets effect -> observation -> model
 ```
+
+The agent loop is the loop. The harness is the effectful program that
+interprets each effect request and returns an observation to the next model
+step.
 
 LoopX's job is the middle two steps: it receives an effect request from an
 agent or host, decides whether and how to interpret it, writes back an
@@ -78,7 +83,7 @@ A => F[B]
 `F` captures the external world: persistence, permissions, budgets, timing,
 notifications, scheduling, evidence, and failure.
 
-LoopX is best understood as that `F` around a long-running agent loop:
+LoopX harness is best understood as that `F` around a long-running agent loop:
 
 ```text
 GoalState => F[QuotaDecision]
@@ -162,7 +167,7 @@ state machine detail.
 Steps:
 
 1. Merge this RFC.
-2. Add `Lecture 0: Agent Loop Is an Effectful Program` to
+2. Add `Lecture 0: Harness Is the Effectful Program` to
    `docs/development/control-plane-course/`.
 3. Rewrite `docs/product/core-control-plane/state-machine.md` to include an
    interpretation-table section for each state family.
@@ -329,6 +334,6 @@ Large smokes remain only as thin end-to-end checks.
 
 ## Conclusion
 
-LoopX is not "a set of state machines". It is the effect interpreter around a
-long-running agent loop. This RFC makes that story explicit and gives the
-refactor and test work a stable target.
+LoopX harness is not "a set of state machines". It is the effectful program
+and effect interpreter around a long-running agent loop. This RFC makes that
+story explicit and gives the refactor and test work a stable target.

--- a/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
+++ b/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
@@ -23,6 +23,9 @@ The agent loop is the loop. The harness is the effectful program that
 interprets each effect request and returns an observation to the next model
 step.
 
+The framing builds on the public lecture series by 齐梦星空, especially
+[主线一：Agent Loop 里的小魔法：函数的组合(3)](https://www.xiaohongshu.com/discovery/item/6a057524000000003701f6aa?source=webshare&xhsshare=pc_web&xsec_token=CBDnukhtey6qJ1aXATVJtv4edjVUnZB1_yebMpqJdNLfc=&xsec_source=pc_share).
+
 LoopX's job is the middle two steps: it receives an effect request from an
 agent or host, decides whether and how to interpret it, writes back an
 observation, and returns control to the next loop iteration.
@@ -337,3 +340,9 @@ Large smokes remain only as thin end-to-end checks.
 LoopX harness is not "a set of state machines". It is the effectful program
 and effect interpreter around a long-running agent loop. This RFC makes that
 story explicit and gives the refactor and test work a stable target.
+
+## References
+
+- 齐梦星空, *主线一：Agent Loop 是 effectful program(1)*.
+- 齐梦星空, *主线一：Tool Calling 是 Kleisli arrow(2)*.
+- 齐梦星空, [*主线一：Agent Loop 里的小魔法：函数的组合(3)*](https://www.xiaohongshu.com/discovery/item/6a057524000000003701f6aa?source=webshare&xhsshare=pc_web&xsec_token=CBDnukhtey6qJ1aXATVJtv4edjVUnZB1_yebMpqJdNLfc=&xsec_source=pc_share).

--- a/docs/development/control-plane-course/00-agent-loop-effectful-program.md
+++ b/docs/development/control-plane-course/00-agent-loop-effectful-program.md
@@ -10,6 +10,8 @@ interpreter。agent loop 是被解释的循环，harness 才是解释外部 effe
 
 全文参考：
 [Agent Loop Effect Interpreter RFC](../../architecture/rfcs/agent-loop-effect-interpreter-v0.md)。
+公开来源：
+[主线一：Agent Loop 里的小魔法：函数的组合(3)](https://www.xiaohongshu.com/discovery/item/6a057524000000003701f6aa?source=webshare&xhsshare=pc_web&xsec_token=CBDnukhtey6qJ1aXATVJtv4edjVUnZB1_yebMpqJdNLfc=&xsec_source=pc_share)。
 
 ## 一个最朴素的 Agent Loop
 

--- a/docs/development/control-plane-course/00-agent-loop-effectful-program.md
+++ b/docs/development/control-plane-course/00-agent-loop-effectful-program.md
@@ -1,0 +1,124 @@
+# 第 0 讲：Harness 是 effectful program
+
+> 建议时长：30 分钟。先建立心智模型，不进入具体状态枚举。
+
+## 这一讲要建立的判断
+
+Harness 不是“一堆状态机”，而是 agent loop 的 effectful program 和 effect
+interpreter。agent loop 是被解释的循环，harness 才是解释外部 effect 的程序；
+状态机只是 harness 内部的决策表。
+
+全文参考：
+[Agent Loop Effect Interpreter RFC](../../architecture/rfcs/agent-loop-effect-interpreter-v0.md)。
+
+## 一个最朴素的 Agent Loop
+
+```text
+while true:
+  response = llm_api.invoke(messages)
+  if not response.tool_calls:
+    return response.final_answer
+  observations = [tools[call.name].invoke(call.args) for call in response.tool_calls]
+  messages += [response.message] + observations
+```
+
+把 tool call 推广到所有外部动作，就得到控制面真正在解释的形状：
+
+```text
+model -> effect request -> harness interprets effect -> observation -> model
+```
+
+模型输出的是动作请求，不是动作本身。真正的执行、权限、预算、调度、失败恢复、
+证据沉淀都发生在 harness 这一侧。
+
+## 为什么 harness 是这个解释器
+
+普通 Agent 只在当前上下文里推理。LoopX 把一个长程任务的有限上下文之外的
+目标、todo、authority、quota、evidence、cadence 和 recovery 状态外置，再把
+当前状态编译成一轮可执行的 CLI packet。
+
+用纯函数和 effect 的差别表达：
+
+```text
+A => B        // 普通计算：给定状态，算出结果
+A => F[B]     // effectful：结果活在外部世界
+```
+
+LoopX harness 是那个 `F`：
+
+```text
+GoalState => F[QuotaDecision]
+```
+
+## Effect Request 到 Observation 的映射
+
+| Agent loop 环节 | LoopX 对应物 |
+|---|---|
+| Agent loop | 每轮 automation、heartbeat、PR monitor、持续重构 |
+| Effect request | `todo add`、`quota spend`、`refresh-state`、`notify`、`monitor poll`、`bind-agent-thread` |
+| Harness interprets effect | `quota should-run` + `interaction_contract` + `capability_gate` + `work_lane_contract` + `scheduler_hint` |
+| Observation | quota packet、run history、evidence log、状态 writeback |
+| Middleware 挂载点 | user gate、capability bridge、scheduler ACK、cooldown、外部 evidence poll |
+
+## State Machine 是 Interpretation Table
+
+每个状态机都回答同一组问题：
+
+```text
+输入 effect | 解释器 | 决策 | observation | 下一 effect
+```
+
+例子：monitor scheduler。
+
+```text
+Monitor cadence / due horizon
+  -> scheduler interpreter
+  -> host RRULE / initial interval
+  -> scheduler_hint packet
+  -> next heartbeat or monitor poll
+```
+
+例子：quota runtime。
+
+```text
+Agent proposes next bounded turn
+  -> quota interpreter
+  -> run / gate / wait / repair / quiet
+  -> quota packet + interaction contract
+  -> execute, ask owner, observe, repair, or no-op
+```
+
+## 读代码前先问五个问题
+
+1. 这个 effect request 是谁提出的？
+2. 哪个 interpreter 决定它能否执行？
+3. 决策输出了什么 observation？
+4. observation 如何回灌到下一轮模型上下文？
+5. 失败、取消、权限、预算和证据在哪里被解释？
+
+## 实验
+
+运行一次真实 CLI：
+
+```bash
+loopx --format json quota should-run \
+  --goal-id loopx-meta \
+  --agent-id codex-quality-qualification \
+  --available-capability network \
+  --available-capability external_evidence_poll \
+  --codex-app
+```
+
+在输出里找到：
+
+- `interaction_contract`：解释后的本轮协议；
+- `capability_gate`：权限解释；
+- `scheduler_hint`：时间解释；
+- `work_lane_contract`：路由解释；
+- `recommended_action`：observation 指向的下一 effect。
+
+## Review 问题
+
+- 如果把状态机文档写成 interpretation table，哪个状态维度最容易被讲清楚？
+- 为什么 `quota should-run` 是解释器而不是另一个状态机？
+- 一个新的 capability 应该解释哪一类 effect request，输出什么 observation？

--- a/docs/development/control-plane-course/README.md
+++ b/docs/development/control-plane-course/README.md
@@ -5,7 +5,7 @@
 > 编译成一轮可执行的 CLI packet。Issue-Fix、Single-Agent Auto ML、Auto Research 等领域
 > 增加专属判断，但不创建第二套控制面。
 
-这套课程由概念导读、第 0 讲架构导论和 9 讲专题组成，面向准备修改 LoopX kernel、CLI、
+这套课程由概念导读、第 0 讲 Harness effectful-program、架构导论和 9 讲专题组成，面向准备修改 LoopX kernel、CLI、
 状态投影、调度或扩展能力的开发者。它先从模型上下文为什么不能承担长期状态讲起，再用
 三个端到端 Showcase 推导 ownership，最后沿真实 transition 进入状态机、CLI、核心函数和测试。
 
@@ -44,7 +44,7 @@ Pack 增加领域泳道。看板只是 projection；canonical state 和 typed tr
 transition；State Kernel 拥有通用生命周期。Domain State 和 receipt 是跨角色传递的紧凑
 工件，Extension 是 provider 的交付边界，都不新增 control-plane owner。
 
-[第 0 讲](00-goal-control-plane-architecture.md)先完整走过这三个案例。后续每讲再放大其中
+架构导论先完整走过这三个案例。后续每讲再放大其中
 一个共同机制；读者可以始终回到“PR 下一步为什么是 monitor”“外部训练任务为什么不能
 自动算作模型证据”“研究假设为什么需要 holdout successor”这类具体问题，而不是在抽象
 名词之间跳转。
@@ -124,7 +124,8 @@ receipt、projection、replan 与 self-repair；随后再进入下面的代码�
 | --- | --- | --- |
 | 导读 | [先把 LoopX 放进一张图](00-concept-primer.md) | 有限上下文为何需要外置状态，原生 Goal 与 LoopX 如何递进，核心概念怎样组成一条生命周期？ |
 | 专题 | [长程任务如何收敛：不跑偏、不陷入局部循环](topic-long-horizon-convergence.md) | 如何用方向、权限、证据、Delta、活性与终局不变量，让复杂任务持续接力而不把忙碌误判为进展？ |
-| [第 0 讲](00-goal-control-plane-architecture.md) | 从三个 Showcase 理解 LoopX 架构 | Issue-Fix、Single-Agent Auto ML 与 Auto Research 如何按 Agent / Provider / Capability / Kernel 分工并复用同一控制面？ |
+| [第 0 讲](00-agent-loop-effectful-program.md) | Harness 是 effectful program | Harness 为什么是 agent loop 的 effect interpreter，状态机为什么只是 interpretation table？ |
+| [架构导论](00-goal-control-plane-architecture.md) | 从三个 Showcase 理解 LoopX 架构 | Issue-Fix、Single-Agent Auto ML 与 Auto Research 如何按 Agent / Provider / Capability / Kernel 分工并复用同一控制面？ |
 | [第 1 讲](01-first-real-loop.md) | 从 Showcase 到第一次真实 Loop | 用户只说一句目标后，guided start、todo、heartbeat、quota、refresh 和 spend 如何串起来？ |
 | [第 2 讲](02-state-substrate.md) | 状态底座与可重放事实 | registry、event、active state、run history 和 projection 分别拥有什么事实？ |
 | [第 3 讲](03-work-graph-and-peers.md) | Todo 工作图与 Peer 协作 | equal peer 如何 claim、显式委托 lifecycle authority、handoff 材料前沿，而不恢复 primary/side 层级？ |
@@ -140,8 +141,8 @@ receipt、projection、replan 与 self-repair；随后再进入下面的代码�
 面向潜在合作方、自编排 runner 或远端开发机接入者的一小时分享，建议使用“导读 + 长程收敛
 专题”；专题正文已给出 60 分钟主讲路线，延伸实验和代码领读可以留作课后材料。
 
-准备系统开发 LoopX 的读者先读导读，再按 0 到 9 的顺序进行。第 0 讲从 Issue-Fix、
-Single-Agent Auto ML 与 Auto Research 推导共同架构，
+准备系统开发 LoopX 的读者先读导读，再读第 0 讲 effectful-program，再读架构导论，最后按
+1 到 9 的顺序进行。架构导论从 Issue-Fix、Single-Agent Auto ML 与 Auto Research 推导共同架构，
 第 1 讲运行端到端路径，第 2 到 6 讲拆开状态、工作图、决策、host 和证据，第 7 讲把这些
 知识收束成工程变更方法，第 8 讲建立自主交付的质量门禁，第 9 讲再系统讨论扩展层。
 

--- a/docs/product/core-control-plane/state-machine.md
+++ b/docs/product/core-control-plane/state-machine.md
@@ -56,6 +56,33 @@ The top-level loop is simple:
 5. State changes return through LoopX write APIs, not through dashboard text or
    chat memory.
 
+## State Machine As Effect Interpretation Table
+
+Every state machine below can be read through the same lens:
+
+```text
+input effect -> interpreter -> decision -> observation -> next effect
+```
+
+This is the model described in the
+[Agent Loop Effect Interpreter RFC](../../architecture/rfcs/agent-loop-effect-interpreter-v0.md).
+The agent loop is the loop. The harness is the effectful program. The state
+machine is not the product; it is the decision table inside that effect
+interpreter.
+
+| State family | Input effect | Interpreter | Decision | Observation | Next effect |
+|---|---|---|---|---|---|
+| Todo lifecycle | Agent proposes work, claim, completion, or blocker | Todo projection and authority rules | `open` / `claimed` / `deferred` / `blocked` / `done` / `superseded` | Todo summary and frontier | Next runnable todo or successor |
+| Quota runtime | Agent proposes a bounded turn | `quota should-run` | `run` / `gate` / `wait` / `repair` / `quiet` | Quota packet + `interaction_contract` | Execute, ask owner, observe, repair, or no-op |
+| Scheduler / heartbeat | Host asks when to wake again | Scheduler hint and ACK rules | Host RRULE / initial interval / backoff | `scheduler_hint` packet | Next heartbeat or monitor poll |
+| Gate and capability | Agent requests an effect with external authority | Capability and user gate rules | `repair_bridge` / `ask_owner` / allow / block | Gate packet and primary action | Repair, ask, execute, or stop |
+| Vision and replan | Agent closes or continues a bounded stage | Replan and vision rules | Continue / replan / watch / close | `goal_frontier_projection` + `vision_continuation_audit` | Next advancement or successor |
+| Monitor | Host polls a target | Monitor scheduler and evidence rules | Due / future / quiet / external observe | Monitor poll event and scheduler hint | Next poll or material transition |
+
+Each table row should answer: who owns the source state, who may interpret the
+effect, what decision is legal, what observation is returned, and what effect
+should come next.
+
 ## 1. Todo Lifecycle Machine
 
 Todo is the smallest executable or waiting unit. Current source fields include


### PR DESCRIPTION
## Summary

Implement M0 of the Agent Loop Effect Interpreter RFC.

- Add `Lecture 0: Harness Is the Effectful Program` to the control-plane course.
- Reframe the RFC language to emphasize that the harness is the effectful program, while the agent loop is the loop being interpreted.
- Add an interpretation-table section to `state-machine.md` covering todo, quota, scheduler, gate, vision, and monitor state families.
- Update course navigation and RFC wording to use the same harness-effect-interpreter vocabulary.

## Validation

- `examples/docs-governance-smoke.py`: passed.
- Standard premerge canary: all selected checks passed, 0 failures, 0 timeouts.
- Public boundary scan and `git diff --check`: passed.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`