### PR TITLE
docs(rfc): add canonical effect packet example

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,8 @@ a longer onboarding path.
 - [Heartbeat automation prompt](heartbeat-automation-prompt.md): scheduled
   continuation contract.
 - [Status data contract](status-data-contract.md): status and dashboard payloads.
+- [Effect interpreter packet](reference/effect-interpreter-packet.md): canonical
+  effect-request/interpretation/observation lens for `quota should-run`.
 - [Public/private boundary](public-private-boundary.md): what may be retained or
   published.
 - [Release readiness](product/release-readiness.md): supported v0.x install,

--- a/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
+++ b/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
@@ -192,7 +192,7 @@ semantic slots visible in docs and smokes.
 Steps:
 
 1. Add a public-safe documentation section describing the four slots for
-   `quota should-run`.
+   `quota should-run` (`docs/reference/effect-interpreter-packet.md`).
 2. Add a focused pytest or smoke that asserts the mapping from raw inputs to
    the canonical interpretation fields.
 3. Keep the existing payload fields unchanged.

--- a/docs/reference/effect-interpreter-packet.md
+++ b/docs/reference/effect-interpreter-packet.md
@@ -1,0 +1,69 @@
+# Effect Interpreter Packet
+
+This page documents the canonical read lens for `quota should-run`:
+
+```text
+effect_request -> interpretation -> observation -> next_effect
+```
+
+It does not add a new runtime contract. It names the existing packet fields
+that already play each role.
+
+## Canonical Example
+
+### 1. Effect Request
+
+The agent or host proposes the next bounded turn. The inputs include:
+
+- `goal_id`
+- `agent_id`
+- `available_capabilities`
+- host surface and scheduler execution context
+- current host RRULE where relevant
+
+### 2. Interpretation
+
+The harness interprets the request through:
+
+| Packet field | Role |
+|---|---|
+| `work_lane_contract.lane` | Route: advancement, monitor, gate, or wait |
+| `work_lane_contract.obligation` | What the selected route must do |
+| `interaction_contract.mode` | The host-facing interaction mode |
+| `capability_gate.action` | Capability decision when a gate is present |
+| `scheduler_hint.cadence_class` | Timing decision for the next host wake |
+
+### 3. Observation
+
+The decision is returned as:
+
+| Packet field | Role |
+|---|---|
+| `decision` | Run, skip, observe, or repair |
+| `should_run` | Whether compute is allowed |
+| `effective_action` | Machine-visible effective action |
+| `recommended_action` | Next concrete action text |
+| `protocol_action_packet.summary` | Compact actor-facing summary |
+
+### 4. Next Effect
+
+The observation points back into the loop:
+
+| Packet field | Role |
+|---|---|
+| `interaction_contract.cli_channel.next_cli_actions` | Next CLI effects |
+| `scheduler_hint.codex_app.ack_hint.cli_args` | Host ACK effect |
+| `scheduler_hint.codex_app.failure_hint.cli_args` | Host failure effect |
+
+## Relationship To State Machines
+
+Each state family is an interpretation table over this lens:
+
+```text
+input effect -> interpreter -> decision -> observation -> next effect
+```
+
+See the
+[Agent Loop Effect Interpreter RFC](../architecture/rfcs/agent-loop-effect-interpreter-v0.md)
+and
+[Harness Is the Effectful Program](../development/control-plane-course/00-agent-loop-effectful-program.md).

--- a/tests/control_plane/test_effect_interpreter_packet.py
+++ b/tests/control_plane/test_effect_interpreter_packet.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from loopx.control_plane.testing.quota_fixtures import quota_status_payload
+from loopx.quota import build_quota_should_run
+
+GOAL_ID = "effect-interpreter-fixture"
+
+
+def _advancement_payload() -> dict:
+    todo_text = "[P1] Advance the bounded slice."
+    return quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        agent_todo_items=[
+            {
+                "index": 1,
+                "text": todo_text,
+                "role": "agent",
+                "status": "open",
+                "priority": "P1",
+                "task_class": "advancement_task",
+            }
+        ],
+        recommended_action=todo_text,
+        next_action=todo_text,
+    )
+
+
+def test_quota_should_run_exposes_canonical_effect_slots() -> None:
+    packet = build_quota_should_run(_advancement_payload(), goal_id=GOAL_ID)
+
+    # interpretation
+    assert packet["work_lane_contract"]["lane"] == "advancement_task"
+    assert packet["work_lane_contract"]["obligation"] == (
+        "advance_one_bounded_segment"
+    )
+    assert packet["interaction_contract"]["mode"] == "bounded_delivery"
+
+    # observation
+    assert packet["decision"] == "run"
+    assert packet["should_run"] is True
+    assert packet["effective_action"] == "normal_run"
+    assert packet["recommended_action"] == "[P1] Advance the bounded slice."
+    assert "lane=advancement_task" in packet["protocol_action_packet"]["summary"]
+
+    # next effect
+    assert isinstance(
+        packet["interaction_contract"]["cli_channel"]["next_cli_actions"],
+        list,
+    )
+    assert packet["interaction_contract"]["cli_channel"]["next_cli_actions"]


### PR DESCRIPTION
## Summary

Implement M1 of the Agent Loop Effect Interpreter RFC.

- Add `docs/reference/effect-interpreter-packet.md` documenting the canonical `effect_request / interpretation / observation / next_effect` lens for `quota should-run`.
- Add `tests/control_plane/test_effect_interpreter_packet.py` asserting the canonical slots are present and consistent in a runnable advancement packet.
- Link the new doc from the RFC and docs README.

## Validation

- New pytest module: 1 passed.
- `docs-governance-smoke`, Ruff, `git diff --check`, standard premerge canary, and public boundary scan: passed.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`