### PR TITLE
docs(course): renumber control-plane lectures

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -118,7 +118,7 @@ to the Kernel lifecycle. Providers supply the external facts behind the lane,
 capabilities validate them and propose typed transitions, and the Kernel owns
 claim, gate, monitor, quota, writeback, recovery, and terminal closure. See the
 [concept primer](development/control-plane-course/00-concept-primer.md) and
-[state substrate lecture](development/control-plane-course/02-state-substrate.md).
+[state substrate lecture](development/control-plane-course/04-state-substrate.md).
 
 ## Current Dependency Budget
 

--- a/docs/development/control-plane-course/00-concept-primer.md
+++ b/docs/development/control-plane-course/00-concept-primer.md
@@ -6,7 +6,7 @@
 > 多轮结果仍属于同一个可恢复、可审计的生命周期。
 
 建议时长：35 分钟。本导读面向第一次接触 LoopX 的读者；读完后再进入
-[第 0 讲](00-goal-control-plane-architecture.md)的架构和代码路径。
+[第 2 讲](02-goal-control-plane-architecture.md)的架构和代码路径。
 
 ## 先接受两个工程预设
 
@@ -483,15 +483,15 @@ LoopX 提供的是让这些能力可以被组合、约束、观察和恢复的�
 
 | 想继续理解的问题 | 对应课程 |
 | --- | --- |
-| Kernel、Capability Pack、Domain State 怎样分层？ | [第 0 讲](00-goal-control-plane-architecture.md) |
-| 一个 goal 第一次怎样真正跑起来？ | [第 1 讲](01-first-real-loop.md) |
-| registry、event、active state、projection 各自拥有什么？ | [第 2 讲](02-state-substrate.md) |
-| todo、claim、lease、gate 和 equal peer 怎样组合？ | [第 3 讲](03-work-graph-and-peers.md) |
-| should-run 怎样压成 interaction contract，以及它与 typed Turn 枚举有何不同？ | [第 4 讲](04-quota-decision-kernel.md)、[architecture Turn vocabulary](../../architecture.md#turn-decision-vocabulary) |
-| scheduler、heartbeat、RRULE 和 ACK 的边界是什么？ | [第 5 讲](05-host-scheduler-and-heartbeat.md) |
-| evidence、replan 和 self-repair 何时触发？ | [第 6 讲](06-evidence-refresh-and-self-repair.md) |
-| 怎样实现和验证一条新的控制面规则？ | [第 7 讲](07-engineering-a-control-plane-rule.md) |
-| 自主 Agent 交付需要哪些分层质量门禁？ | [第 8 讲](08-autonomous-agent-quality-gates.md) |
-| Extension、Explore、Reward Memory 与领域产品怎样复用 Kernel？ | [第 9 讲](09-extension-layer.md) |
+| Kernel、Capability Pack、Domain State 怎样分层？ | [第 2 讲](02-goal-control-plane-architecture.md) |
+| 一个 goal 第一次怎样真正跑起来？ | [第 3 讲](03-first-real-loop.md) |
+| registry、event、active state、projection 各自拥有什么？ | [第 4 讲](04-state-substrate.md) |
+| todo、claim、lease、gate 和 equal peer 怎样组合？ | [第 5 讲](05-work-graph-and-peers.md) |
+| should-run 怎样压成 interaction contract，以及它与 typed Turn 枚举有何不同？ | [第 6 讲](06-quota-decision-kernel.md)、[architecture Turn vocabulary](../../architecture.md#turn-decision-vocabulary) |
+| scheduler、heartbeat、RRULE 和 ACK 的边界是什么？ | [第 7 讲](07-host-scheduler-and-heartbeat.md) |
+| evidence、replan 和 self-repair 何时触发？ | [第 8 讲](08-evidence-refresh-and-self-repair.md) |
+| 怎样实现和验证一条新的控制面规则？ | [第 9 讲](09-engineering-a-control-plane-rule.md) |
+| 自主 Agent 交付需要哪些分层质量门禁？ | [第 10 讲](10-autonomous-agent-quality-gates.md) |
+| Extension、Explore、Reward Memory 与领域产品怎样复用 Kernel？ | [第 11 讲](11-extension-layer.md) |
 
-完成导读后，从[第 0 讲](00-goal-control-plane-architecture.md)开始按真实代码路径学习。
+完成导读后，从[第 2 讲](02-goal-control-plane-architecture.md)开始按真实代码路径学习。

--- a/docs/development/control-plane-course/01-agent-loop-effectful-program.md
+++ b/docs/development/control-plane-course/01-agent-loop-effectful-program.md
@@ -1,4 +1,4 @@
-# 第 0 讲：Harness 是 effectful program
+# 第 1 讲：Harness 是 effectful program
 
 > 建议时长：30 分钟。先建立心智模型，不进入具体状态枚举。
 

--- a/docs/development/control-plane-course/02-goal-control-plane-architecture.md
+++ b/docs/development/control-plane-course/02-goal-control-plane-architecture.md
@@ -1,4 +1,4 @@
-# 第 0 讲：从三个 Showcase 理解 LoopX 架构
+# 第 2 讲：从三个 Showcase 理解 LoopX 架构
 
 > **本讲结论：** LoopX 让不同领域的长程 Agent 复用同一套外置目标、工作、权限、证据与
 > 恢复内核。Issue-Fix、Single-Agent Auto ML 和 Multi-Agent Auto Research 的业务状态完全
@@ -135,8 +135,8 @@ fact，使下一轮可以重新计算 frontier：
 和下一步恢复路径。长程稳定的目标，是让错误可发现、可归因、可恢复；即使 Agent 犯错，
 已提交事实仍然有效，系统仍能形成下一步 frontier。
 
-这也是后续课程的索引：第 1 讲解释 packet 与一次 Turn，第 3 讲解释 claim、successor 和
-handoff，第 5 讲解释 monitor cadence 与 quiet wake，第 6 讲解释 evidence、reconcile 和
+这也是后续课程的索引：第 3 讲解释 packet 与一次 Turn，第 5 讲解释 claim、successor 和
+handoff，第 7 讲解释 monitor cadence 与 quiet wake，第 8 讲解释 evidence、reconcile 和
 self-repair。这里先记住一个判断标准：**稳定不是不中断，而是每次中断后都能从外置事实恢复。**
 
 ### 一条交付主线，怎样反哺执行系统
@@ -531,7 +531,7 @@ sequenceDiagram
 - spend 晚于验证与写回；
 - scheduler proposal 在 host apply 并形成 ACK 前仍未结算。
 
-第 4 到第 6 讲会分别展开 quota decision、host scheduler 和 evidence/writeback。第 0 讲只需
+第 6 到第 8 讲会分别展开 quota decision、host scheduler 和 evidence/writeback。第 2 讲只需
 确认：这些阶段让长程工作可以被重放、归因和恢复。
 
 ## 多个协作状态机，不是一个巨型枚举
@@ -591,8 +591,8 @@ runtime event、cancel 和 retry。接入 LoopX 时，只需对齐四个面：
 | Auto Research role 怎样声明 | `build_auto_research_preset_summary` | `examples/auto-research-dev-thin-preset-smoke.py` |
 | 每个研究 lane 怎样重新进入 Kernel | `load_auto_research_worker_frontier`、`run_auto_research_worker_turn` | `examples/auto-research-worker-turn-smoke.py` |
 | 研究证据怎样形成决策 | `build_research_decision_candidates`、`build_auto_research_completion_status` | `examples/auto-research-layered-e2e-acceptance-smoke.py` |
-| 通用 Kernel 怎样选择本轮动作 | `build_quota_should_run`、`build_interaction_contract` | 第 4 讲的 quota smokes |
-| 一轮结果怎样写回并恢复 | `run_loopx_turn_once`、`refresh-state` | 第 5、6 讲的 transaction / refresh smokes |
+| 通用 Kernel 怎样选择本轮动作 | `build_quota_should_run`、`build_interaction_contract` | 第 6 讲的 quota smokes |
+| 一轮结果怎样写回并恢复 | `run_loopx_turn_once`、`refresh-state` | 第 7、8 讲的 transaction / refresh smokes |
 
 这条阅读路线同时覆盖 high-level product loop 和 low-level implementation seam。开发者先问
 “这个函数把哪种领域事实翻译成哪种通用 transition”，再看 schema、fingerprint、ordered
@@ -624,14 +624,14 @@ replan 或 self-repair”的整体心智模型，可以先读
 
 | 后续讲次 | Issue-Fix | Single-Agent Auto ML | Auto Research |
 | --- | --- | --- | --- |
-| 第 1 讲 | 从目标到第一个 fix todo | 从候选到一次 bounded experiment Turn | 从 research question 到初始 role todo |
-| 第 2 讲 | feasibility / PR lifecycle 与 Kernel state | task/result ledger、Graph 与外部事实 | evidence event、graph 与 projection |
-| 第 3 讲 | patch successor、monitor、review handoff | launch、monitor、evaluate、replan 工作图 | role claim、lane successor、equal peer |
-| 第 4 讲 | checks pending 为何 quiet | capacity/defer 与 promotion gate | per-agent frontier 与 promotion gate |
-| 第 5 讲 | PR monitor cadence 与外部 readback | training/eval monitor 与分层 backoff | worker loop、no-action 与重新唤醒 |
-| 第 6 讲 | validation、notification receipt、terminal | 模型证据、infra diagnosis、no-promote | dev/holdout evidence、retirement、completion |
-| 第 7、8 讲 | lifecycle rule 与 PR delivery oracle | experiment contract 与 promotion oracle | evidence rule 与独立 oracle |
-| 第 9 讲 | Capability Pack 与 Domain State | ML pack + Explore Graph/Harness | thin preset 与 multi-agent 产品层 |
+| 第 3 讲 | 从目标到第一个 fix todo | 从候选到一次 bounded experiment Turn | 从 research question 到初始 role todo |
+| 第 4 讲 | feasibility / PR lifecycle 与 Kernel state | task/result ledger、Graph 与外部事实 | evidence event、graph 与 projection |
+| 第 5 讲 | patch successor、monitor、review handoff | launch、monitor、evaluate、replan 工作图 | role claim、lane successor、equal peer |
+| 第 6 讲 | checks pending 为何 quiet | capacity/defer 与 promotion gate | per-agent frontier 与 promotion gate |
+| 第 7 讲 | PR monitor cadence 与外部 readback | training/eval monitor 与分层 backoff | worker loop、no-action 与重新唤醒 |
+| 第 8 讲 | validation、notification receipt、terminal | 模型证据、infra diagnosis、no-promote | dev/holdout evidence、retirement、completion |
+| 第 9、10 讲 | lifecycle rule 与 PR delivery oracle | experiment contract 与 promotion oracle | evidence rule 与独立 oracle |
+| 第 11 讲 | Capability Pack 与 Domain State | ML pack + Explore Graph/Harness | thin preset 与 multi-agent 产品层 |
 
 ## 课后检查
 

--- a/docs/development/control-plane-course/03-first-real-loop.md
+++ b/docs/development/control-plane-course/03-first-real-loop.md
@@ -1,4 +1,4 @@
-# 第 1 讲：从 Showcase 到第一次真实 Loop
+# 第 3 讲：从 Showcase 到第一次真实 Loop
 
 > **本讲结论：** 第一次真实 Loop 不是“heartbeat 调一次模型”，而是外置 source state 被
 > 编译成适合有限上下文的 CLI packet 和 bounded action，执行结果经验证写回，再由
@@ -6,11 +6,11 @@
 
 ## 本讲在课程中的位置
 
-[第 0 讲](00-goal-control-plane-architecture.md)已经从 Issue-Fix、Single-Agent Auto ML
+[第 2 讲](02-goal-control-plane-architecture.md)已经从 Issue-Fix、Single-Agent Auto ML
 与 Auto Research 三条产品闭环推导出 Kernel、Capability Pack、Domain State、host/runtime
 和外部事实源的边界。
 本讲不再展开领域判断，而是沿共同生命周期跑通第一次真实 Loop。
-全课由第 0 讲架构导论和 9 讲专题组成，每讲只增加一个主要抽象：
+全课由第 2 讲架构导论和第 3 到第 11 讲专题组成，每讲只增加一个主要抽象：
 
 | 讲次 | 新增的主要抽象 | 学完后能回答的问题 |
 | --- | --- | --- |
@@ -39,7 +39,7 @@
 
 ## 先把三个 Showcase 压成一轮
 
-第 0 讲看到的是完整产品闭环。本讲只截取其中一轮，观察 LoopX 如何把长期状态变成
+第 2 讲看到的是完整产品闭环。本讲只截取其中一轮，观察 LoopX 如何把长期状态变成
 一次可提交的小变化：
 
 | Showcase 中的一轮 | 本轮输入 | Bounded action | 可接受回执 | 下一轮依据 |
@@ -590,7 +590,7 @@ effective_action = _effective_action(...)
 ### “Supervisor 就是主 agent”
 
 不是。当前 peer 模型没有 primary/side 的运行时层级。可选 supervisor 是 equal peer
-上的观察和 proposal overlay；第 7 讲用它演示规则设计，第 9 讲说明它与其他扩展能力
+上的观察和 proposal overlay；第 9 讲用它演示规则设计，第 11 讲说明它与其他扩展能力
 如何复用同一个 kernel。
 
 ## 本讲源码与 smoke 地图
@@ -646,7 +646,7 @@ state_key   = scheduler_hint.codex_app.stateful_backoff
 RRULE       = FREQ=MINUTELY;INTERVAL=3
 ```
 
-课堂上可以逐条对照自己的状态文件。实验还应故意漏写一次 material refresh 的 vision decision，观察后续 quota 产生 `vision_checkpoint_missing`；第 6 讲会完整复盘这个失败案例。
+课堂上可以逐条对照自己的状态文件。实验还应故意漏写一次 material refresh 的 vision decision，观察后续 quota 产生 `vision_checkpoint_missing`；第 8 讲会完整复盘这个失败案例。
 
 ## 课后检查
 

--- a/docs/development/control-plane-course/04-state-substrate.md
+++ b/docs/development/control-plane-course/04-state-substrate.md
@@ -1,4 +1,4 @@
-# 第 2 讲：状态底座与可重放事实
+# 第 4 讲：状态底座与可重放事实
 
 > **本讲结论：** Canonical event/state contract 拥有长期事实；active state、status 和
 > dashboard 是可重建 read model；session context 不能替代 project memory。
@@ -133,7 +133,7 @@ next decision = replay(project memory) + inspect(fresh environment)
 
 Project memory 的充分性标准是：更换 session 后，新的 peer 仍能从 durable state
 重建同一 objective、authority boundary、open frontier、gate、next probe 和 stop
-condition。它不要求逐字复现旧推理。第 3 讲会把这个要求进一步写成 handoff 的
+condition。它不要求逐字复现旧推理。第 5 讲会把这个要求进一步写成 handoff 的
 不动点检查。
 
 可以把这看成长期任务的“最小可恢复状态”，而不是“最大可记忆内容”。外置状态应优先保存：

--- a/docs/development/control-plane-course/05-work-graph-and-peers.md
+++ b/docs/development/control-plane-course/05-work-graph-and-peers.md
@@ -1,4 +1,4 @@
-# 第 3 讲：Todo 工作图与 Peer 协作
+# 第 5 讲：Todo 工作图与 Peer 协作
 
 > **本讲结论：** Todo 定义工作生命周期；claim、lease、capability、workspace 和 gate 是五种
 > 不同约束；handoff 传递可恢复 frontier，不创造永久 leader。
@@ -254,7 +254,7 @@ Lease 丢失应 fail closed。一个 worker 不应该在 lease 过期后继续�
 生命周期与幂等合同由 `tests/control_plane/test_task_lease.py` 和
 `examples/control_plane/task-lease-runtime-smoke.py` 看护。
 
-第 7 讲介绍的 supervisor 目前只产生观察和提议。若未来增加 supervisor 建议的
+第 9 讲介绍的 supervisor 目前只产生观察和提议。若未来增加 supervisor 建议的
 temporary execution branch，对应 branch lease 也只能授权该分支执行，不能继承
 source todo、source quota 或 source durable memory。
 

--- a/docs/development/control-plane-course/06-quota-decision-kernel.md
+++ b/docs/development/control-plane-course/06-quota-decision-kernel.md
@@ -1,4 +1,4 @@
-# 第 4 讲：Quota 决策内核与 Interaction Contract
+# 第 6 讲：Quota 决策内核与 Interaction Contract
 
 > **本讲结论：** `quota should-run` 是只读决策编译器：它把 source facts 编译成 typed
 > interaction contract 与 scheduler hint；host 消费决定，不重新实现决定。

--- a/docs/development/control-plane-course/07-host-scheduler-and-heartbeat.md
+++ b/docs/development/control-plane-course/07-host-scheduler-and-heartbeat.md
@@ -1,4 +1,4 @@
-# 第 5 讲：Host、Heartbeat 与 Stateful Backoff
+# 第 7 讲：Host、Heartbeat 与 Stateful Backoff
 
 > **本讲结论：** Host 拥有唤醒和外部 effect，LoopX 拥有 cadence proposal 与验证规则；
 > 只有绑定 proposal identity 的 host readback 才能形成 durable scheduler ACK。

--- a/docs/development/control-plane-course/08-evidence-refresh-and-self-repair.md
+++ b/docs/development/control-plane-course/08-evidence-refresh-and-self-repair.md
@@ -1,4 +1,4 @@
-# 第 6 讲：证据、Refresh 与 Self-Repair
+# 第 8 讲：证据、Refresh 与 Self-Repair
 
 > **本讲结论：** Artifact 只有经过 validation、writeback、refresh 和一次性 spend，才成为
 > material progress；replan 或 repair 必须留下 bounded state delta，不能只写 ACK。
@@ -130,7 +130,7 @@ commit:<sha>
 smoke:todo-lifecycle-cli
 run:<opaque-run-id>
 event:<event-id>
-doc:docs/development/control-plane-course/01-first-real-loop.md
+doc:docs/development/control-plane-course/03-first-real-loop.md
 ```
 
 ## Bounded Delivery 的证据标准
@@ -364,10 +364,10 @@ checkpoint 证明。
 
 应用记忆后仍需生成 influence/application receipt，并在当前 artifact 上验证技术主张。当前
 todo、gate、fresh observation 和 source-of-truth 始终高于 recalled experience。更完整的
-provider 与 default-off 边界见[第 9 讲的 Reward Memory](09-extension-layer.md#reward-memory)。
+provider 与 default-off 边界见[第 11 讲的 Reward Memory](11-extension-layer.md#reward-memory)。
 
 开发 connector 或 inbox 时，应先把 signal 归一化为 public-safe evidence，再由
-现有 Core State 承接 anchor。第 9 讲的 Lark Event Inbox 展示了这一边界；不要
+现有 Core State 承接 anchor。第 11 讲的 Lark Event Inbox 展示了这一边界；不要
 为每种外部信号新增一个 quota 分支。
 
 ## Replan 与 Dreaming
@@ -463,7 +463,7 @@ Self-repair 不允许：
 
 ## 失败回放：漏写 Vision Checkpoint
 
-用第 1 讲的贯穿实验复现。以下 id 都是占位符：
+用第 3 讲的贯穿实验复现。以下 id 都是占位符：
 
 ```text
 goal_id = <goal-id>
@@ -754,7 +754,7 @@ if normalized_progress_scope == "agent_lane":
 
 ### 4. Projection gap 把 prose 漂移升级成 repair
 
-`loopx/control_plane/quota/projection_repair.py::build_state_projection_gap_repair_hint` 的输入来自第 2 讲的 status projection。当 active prose 看起来可执行、结构化 agent todo 却为零时，它返回 self-repair hint，而不是让 quota 安静等待。
+`loopx/control_plane/quota/projection_repair.py::build_state_projection_gap_repair_hint` 的输入来自第 4 讲的 status projection。当 active prose 看起来可执行、结构化 agent todo 却为零时，它返回 self-repair hint，而不是让 quota 安静等待。
 
 领读时追这条反向路径：
 

--- a/docs/development/control-plane-course/09-engineering-a-control-plane-rule.md
+++ b/docs/development/control-plane-course/09-engineering-a-control-plane-rule.md
@@ -1,4 +1,4 @@
-# 第 7 讲：如何给 Control Plane 增加一条规则
+# 第 9 讲：如何给 Control Plane 增加一条规则
 
 > **本讲结论：** 一条 control-plane 规则必须闭合 source、decision、effect、receipt 与
 > validation；没有真实 call site 和兼容合同的未来能力，应停留在文档或 todo。
@@ -473,7 +473,7 @@ Smoke 应同时证明：
 
 ## 测试策略
 
-本讲只保留规则开发的入口；完整分层、频率、模型行为门和发布门见[第 8 讲](08-autonomous-agent-quality-gates.md)。
+本讲只保留规则开发的入口；完整分层、频率、模型行为门和发布门见[第 10 讲](10-autonomous-agent-quality-gates.md)。
 
 测试先回答“这个状态和规则合理吗”，再验证实现是否符合。共享 quota/status/todo 行为可以先加 parity fixture 描述现状，但 fixture 不是授权书；如果现状与 independently reviewed invariant 冲突，应修规则并增加负向或 mutation coverage，不能刷新 golden 把错误合法化。
 
@@ -501,7 +501,7 @@ Smoke 应同时证明：
 loopx canary premerge --from-git-diff
 ```
 
-一个 hand-picked smoke 不足以覆盖 runtime/quota/scheduler/todo/install/dashboard 边界。是否增加 output budget、actual-default model qualification、full-public 或 outcome baseline，由第 8 讲的风险门禁决定，不能让每个小 patch 都等待最高成本矩阵。
+一个 hand-picked smoke 不足以覆盖 runtime/quota/scheduler/todo/install/dashboard 边界。是否增加 output budget、actual-default model qualification、full-public 或 outcome baseline，由第 10 讲的风险门禁决定，不能让每个小 patch 都等待最高成本矩阵。
 
 ## 练习：设计一个 `pause_branch` Proposal
 
@@ -780,4 +780,4 @@ receipt = record_supervisor_receipt(
 4. Migration reader 为什么应保留，但旧字段不能继续出现在 live config？
 5. 哪类 invariant 值得未来用 Lean/TLA+，哪类只需 focused smoke？
 
-下一讲把这套工程顺序扩成自主交付门禁：什么必须进入 PR 快速门，什么适合 canary、低频模型行为验证或 release gate，以及 agent 何时必须停止自动合并。扩展层顺延到第 9 讲。
+下一讲把这套工程顺序扩成自主交付门禁：什么必须进入 PR 快速门，什么适合 canary、低频模型行为验证或 release gate，以及 agent 何时必须停止自动合并。扩展层顺延到第 11 讲。

--- a/docs/development/control-plane-course/10-autonomous-agent-quality-gates.md
+++ b/docs/development/control-plane-course/10-autonomous-agent-quality-gates.md
@@ -1,4 +1,4 @@
-# 第 8 讲：Agent 自主写代码时的分层质量门禁
+# 第 10 讲：Agent 自主写代码时的分层质量门禁
 
 > **本讲结论：** 先用独立 oracle 定义正确语义，再按风险选择 deterministic test、canary、
 > 模型行为验证与 release gate；当前实现输出不能反过来定义正确答案。
@@ -584,7 +584,7 @@ ready，返回值仍固定 `automatic_release_promotion_allowed=False`，owner d
 在 [PR #2320](https://github.com/huangruiteng/loopx/pull/2320) 中，goal-frontier replan
 从隐式 `if` 链提取成 ordered rules；它没有新增 public payload，
 但它仍是 high-risk change：一次顺序漂移就可能让 agent 在已有工作时错误 replan，或在
-frontier 耗尽时永久等待。第 7 讲解释了实现结构；这里关注门禁怎样证明“移动了政策，但
+frontier 耗尽时永久等待。第 9 讲解释了实现结构；这里关注门禁怎样证明“移动了政策，但
 没有改变政策”。
 
 第一层是完整 decision table。每个 case 不只设置目标条件，还叠加一个更低优先级条件，

--- a/docs/development/control-plane-course/11-extension-layer.md
+++ b/docs/development/control-plane-course/11-extension-layer.md
@@ -1,4 +1,4 @@
-# 第 9 讲：扩展层、Explore 与 Multi-Agent 产品
+# 第 11 讲：扩展层、Explore 与 Multi-Agent 产品
 
 > **本讲结论：** Extension 交付可选 provider、domain facts、capability 或 presentation；
 > 它复用同一份 goal、todo、quota、scheduler、evidence 与 handoff contract，不创建第二个
@@ -29,7 +29,7 @@ Memory 或 Lark Event Inbox。
 
 ## 从 Auto Research 反推 Extension Contract
 
-第 0 讲把 Auto Research 当作产品 Showcase；本讲把它拆成一个可复用 extension：
+第 2 讲把 Auto Research 当作产品 Showcase；本讲把它拆成一个可复用 extension：
 
 | Surface | Auto Research 提供 | 继续由通用层拥有 |
 | --- | --- | --- |
@@ -1006,7 +1006,7 @@ kernel 代码、supervisor 为什么不能借扩展层获得 durable leader auth
 
 ## 课程结束后的能力标准
 
-完成第 0 到第 9 讲后，一个新开发者不需要记住所有 CLI 参数，但应该能够独立完成三件事：
+完成第 1 到第 11 讲后，一个新开发者不需要记住所有 CLI 参数，但应该能够独立完成三件事：
 
 1. 从 `$loopx <task>` 追到 registry、todo、quota、interaction contract、scheduler、refresh 和 spend；
 2. 遇到卡住或矛盾状态时，判断是执行失败、projection gap、host drift 还是缺少用户 authority；

--- a/docs/development/control-plane-course/README.md
+++ b/docs/development/control-plane-course/README.md
@@ -5,7 +5,7 @@
 > 编译成一轮可执行的 CLI packet。Issue-Fix、Single-Agent Auto ML、Auto Research 等领域
 > 增加专属判断，但不创建第二套控制面。
 
-这套课程由概念导读、第 0 讲 Harness effectful-program、架构导论和 9 讲专题组成，面向准备修改 LoopX kernel、CLI、
+这套课程由概念导读、第 1 讲 Harness effectful-program、第 2 讲架构导论和第 3 到第 11 讲专题组成，面向准备修改 LoopX kernel、CLI、
 状态投影、调度或扩展能力的开发者。它先从模型上下文为什么不能承担长期状态讲起，再用
 三个端到端 Showcase 推导 ownership，最后沿真实 transition 进入状态机、CLI、核心函数和测试。
 
@@ -124,30 +124,31 @@ receipt、projection、replan 与 self-repair；随后再进入下面的代码�
 | --- | --- | --- |
 | 导读 | [先把 LoopX 放进一张图](00-concept-primer.md) | 有限上下文为何需要外置状态，原生 Goal 与 LoopX 如何递进，核心概念怎样组成一条生命周期？ |
 | 专题 | [长程任务如何收敛：不跑偏、不陷入局部循环](topic-long-horizon-convergence.md) | 如何用方向、权限、证据、Delta、活性与终局不变量，让复杂任务持续接力而不把忙碌误判为进展？ |
-| [第 0 讲](00-agent-loop-effectful-program.md) | Harness 是 effectful program | Harness 为什么是 agent loop 的 effect interpreter，状态机为什么只是 interpretation table？ |
-| [架构导论](00-goal-control-plane-architecture.md) | 从三个 Showcase 理解 LoopX 架构 | Issue-Fix、Single-Agent Auto ML 与 Auto Research 如何按 Agent / Provider / Capability / Kernel 分工并复用同一控制面？ |
-| [第 1 讲](01-first-real-loop.md) | 从 Showcase 到第一次真实 Loop | 用户只说一句目标后，guided start、todo、heartbeat、quota、refresh 和 spend 如何串起来？ |
-| [第 2 讲](02-state-substrate.md) | 状态底座与可重放事实 | registry、event、active state、run history 和 projection 分别拥有什么事实？ |
-| [第 3 讲](03-work-graph-and-peers.md) | Todo 工作图与 Peer 协作 | equal peer 如何 claim、显式委托 lifecycle authority、handoff 材料前沿，而不恢复 primary/side 层级？ |
-| [第 4 讲](04-quota-decision-kernel.md) | Quota 决策内核与 Interaction Contract | `should-run` 如何压成 operator-facing mode，以及它与 `LoopXTurnRoute` / `LoopXTurnResultKind` 的关系？ |
-| [第 5 讲](05-host-scheduler-and-heartbeat.md) | Host、Heartbeat 与 Stateful Backoff | LoopX 决策、heartbeat prompt、execution context、Codex App RRULE 和 ACK 各自负责什么？ |
-| [第 6 讲](06-evidence-refresh-and-self-repair.md) | 证据、Refresh 与 Self-Repair | 什么算 material progress，何时必须 replan，连续无推进如何形成可验证 repair delta？ |
-| [第 7 讲](07-engineering-a-control-plane-rule.md) | 如何给 Control Plane 增加一条规则 | 如何从 invariant、ordered rules、schema、projection 到 smoke 完成一次可审计变更？ |
-| [第 8 讲](08-autonomous-agent-quality-gates.md) | Agent 自主写代码时的分层质量门禁 | 如何按风险选择确定性测试、canary、模型行为验证与 release gate，既保护质量又不阻断普通迭代？ |
-| [第 9 讲](09-extension-layer.md) | 扩展层、Explore 与领域产品 | 默认关闭的 Graph/Harness、Single-Agent Auto ML、Auto Research 和 Supervisor 如何复用 kernel？ |
+| [第 1 讲](01-agent-loop-effectful-program.md) | Harness 是 effectful program | Harness 为什么是 agent loop 的 effect interpreter，状态机为什么只是 interpretation table？ |
+| [第 2 讲](02-goal-control-plane-architecture.md) | 从三个 Showcase 理解 LoopX 架构 | Issue-Fix、Single-Agent Auto ML 与 Auto Research 如何按 Agent / Provider / Capability / Kernel 分工并复用同一控制面？ |
+| [第 3 讲](03-first-real-loop.md) | 从 Showcase 到第一次真实 Loop | 用户只说一句目标后，guided start、todo、heartbeat、quota、refresh 和 spend 如何串起来？ |
+| [第 4 讲](04-state-substrate.md) | 状态底座与可重放事实 | registry、event、active state、run history 和 projection 分别拥有什么事实？ |
+| [第 5 讲](05-work-graph-and-peers.md) | Todo 工作图与 Peer 协作 | equal peer 如何 claim、显式委托 lifecycle authority、handoff 材料前沿，而不恢复 primary/side 层级？ |
+| [第 6 讲](06-quota-decision-kernel.md) | Quota 决策内核与 Interaction Contract | `should-run` 如何压成 operator-facing mode，以及它与 `LoopXTurnRoute` / `LoopXTurnResultKind` 的关系？ |
+| [第 7 讲](07-host-scheduler-and-heartbeat.md) | Host、Heartbeat 与 Stateful Backoff | LoopX 决策、heartbeat prompt、execution context、Codex App RRULE 和 ACK 各自负责什么？ |
+| [第 8 讲](08-evidence-refresh-and-self-repair.md) | 证据、Refresh 与 Self-Repair | 什么算 material progress，何时必须 replan，连续无推进如何形成可验证 repair delta？ |
+| [第 9 讲](09-engineering-a-control-plane-rule.md) | 如何给 Control Plane 增加一条规则 | 如何从 invariant、ordered rules、schema、projection 到 smoke 完成一次可审计变更？ |
+| [第 10 讲](10-autonomous-agent-quality-gates.md) | Agent 自主写代码时的分层质量门禁 | 如何按风险选择确定性测试、canary、模型行为验证与 release gate，既保护质量又不阻断普通迭代？ |
+| [第 11 讲](11-extension-layer.md) | 扩展层、Explore 与领域产品 | 默认关闭的 Graph/Harness、Single-Agent Auto ML、Auto Research 和 Supervisor 如何复用 kernel？ |
 
 ## 建议学习方式
 
 面向潜在合作方、自编排 runner 或远端开发机接入者的一小时分享，建议使用“导读 + 长程收敛
 专题”；专题正文已给出 60 分钟主讲路线，延伸实验和代码领读可以留作课后材料。
 
-准备系统开发 LoopX 的读者先读导读，再读第 0 讲 effectful-program，再读架构导论，最后按
-1 到 9 的顺序进行。架构导论从 Issue-Fix、Single-Agent Auto ML 与 Auto Research 推导共同架构，
-第 1 讲运行端到端路径，第 2 到 6 讲拆开状态、工作图、决策、host 和证据，第 7 讲把这些
-知识收束成工程变更方法，第 8 讲建立自主交付的质量门禁，第 9 讲再系统讨论扩展层。
+准备系统开发 LoopX 的读者先读导读，再读第 1 讲 effectful-program，再读第 2 讲架构导论，最后按
+3 到 11 的顺序进行。第 2 讲架构导论从 Issue-Fix、Single-Agent Auto ML 与 Auto Research
+推导共同架构，第 3 讲运行端到端路径，第 4 到 8 讲拆开状态、工作图、决策、host 和证据，
+第 9 讲把这些知识收束成工程变更方法，第 10 讲建立自主交付的质量门禁，第 11 讲再系统
+讨论扩展层。
 
-只准备开发 Capability Pack 的读者，可以先读 0、2、4、6、9，再按改动涉及的 Kernel
-边界补读 3、5、7、8。准备修改 Kernel 的读者应按完整顺序阅读，因为 quota、scheduler、
+只准备开发 Capability Pack 的读者，可以先读 2、4、6、8、11，再按改动涉及的 Kernel
+边界补读 5、7、9、10。准备修改 Kernel 的读者应按完整顺序阅读，因为 quota、scheduler、
 todo 和 evidence 的局部规则会在同一轮组合生效。
 
 不要从模块文件头一路向下读。每讲的“核心代码领读”会给出函数级入口，先搜索目标函数，再沿 bounded-context helper 向下读。运行实验时使用临时 goal 和测试仓库，不要把课程占位 id 当作真实配置。

--- a/docs/development/control-plane-course/topic-long-horizon-convergence.md
+++ b/docs/development/control-plane-course/topic-long-horizon-convergence.md
@@ -9,7 +9,7 @@
 建议时长：60 分钟。问题定义 8 分钟、核心闭环 12 分钟、防跑偏 10 分钟、防循环 12 分钟、
 双 Showcase 回放 10 分钟、接入边界与问答 8 分钟。
 
-本讲是一篇可以独立分享的课程专题。第一次接触 LoopX 的读者不必先读完第 0 到第 9 讲；
+本讲是一篇可以独立分享的课程专题。第一次接触 LoopX 的读者不必先读完第 1 到第 11 讲；
 需要补充概念时可回到[概念导读](00-concept-primer.md)，需要进入实现时再沿本讲末尾的阅读
 路线下钻。
 
@@ -173,7 +173,7 @@ def translate_domain_observation(kernel_snapshot, provider, pack):
 schema 和 proposal 属于 pack，最终是否执行仍由 Kernel 判断。
 
 一小时分享讲到这条边界即可。需要设计新 pack 时，再深入
-[第 2 讲：Core State、Domain State 与 Runtime Artifact](02-state-substrate.md#core-statedomain-state-与-runtime-artifact)、
+[第 4 讲：Core State、Domain State 与 Runtime Artifact](04-state-substrate.md#core-statedomain-state-与-runtime-artifact)、
 [Domain Capability Packs](../../product/domain-capability-packs.md)和
 [Issue-Fix State Kernel × Domain State 案例](../../capabilities/issue-fix/state-kernel-domain-state-case-study.zh-CN.md)。
 
@@ -1647,12 +1647,12 @@ happy-path smoke。
 ## 延伸阅读
 
 1. [概念导读：先把 LoopX 放进一张图](00-concept-primer.md)
-2. [第 0 讲：从三个 Showcase 理解 LoopX 架构](00-goal-control-plane-architecture.md)
-3. [第 1 讲：从 Showcase 到第一次真实 Loop](01-first-real-loop.md)
-4. [第 5 讲：Host、Heartbeat 与 Stateful Backoff](05-host-scheduler-and-heartbeat.md)
-5. [第 6 讲：证据、Refresh 与 Self-Repair](06-evidence-refresh-and-self-repair.md)
-6. [第 8 讲：Agent 自主写代码时的分层质量门禁](08-autonomous-agent-quality-gates.md)
-7. [第 9 讲：扩展层、Explore 与 Multi-Agent 产品](09-extension-layer.md)
+2. [第 2 讲：从三个 Showcase 理解 LoopX 架构](02-goal-control-plane-architecture.md)
+3. [第 3 讲：从 Showcase 到第一次真实 Loop](03-first-real-loop.md)
+4. [第 7 讲：Host、Heartbeat 与 Stateful Backoff](07-host-scheduler-and-heartbeat.md)
+5. [第 8 讲：证据、Refresh 与 Self-Repair](08-evidence-refresh-and-self-repair.md)
+6. [第 10 讲：Agent 自主写代码时的分层质量门禁](10-autonomous-agent-quality-gates.md)
+7. [第 11 讲：扩展层、Explore 与 Multi-Agent 产品](11-extension-layer.md)
 8. [Long-Horizon Agent State Protocol](../../reference/protocols/long-horizon-agent-state-protocol-v0.md)
 9. [Goal / Vision / Replan Contract](../../reference/protocols/goal-vision-replan-contract-v0.md)
 10. [Core Control-Plane State Machine](../../product/core-control-plane/state-machine.md)

--- a/docs/reference/effect-interpreter-packet.md
+++ b/docs/reference/effect-interpreter-packet.md
@@ -66,4 +66,4 @@ input effect -> interpreter -> decision -> observation -> next effect
 See the
 [Agent Loop Effect Interpreter RFC](../architecture/rfcs/agent-loop-effect-interpreter-v0.md)
 and
-[Harness Is the Effectful Program](../development/control-plane-course/00-agent-loop-effectful-program.md).
+[Harness Is the Effectful Program](../development/control-plane-course/01-agent-loop-effectful-program.md).


### PR DESCRIPTION
## Summary

Renumber the control-plane developer course to remove duplicate lecture numbers.

- New numbering:
  - `00-concept-primer.md` stays the concept primer
  - `01-agent-loop-effectful-program.md` = Lecture 1: Harness is the effectful program
  - `02-goal-control-plane-architecture.md` = Lecture 2: architecture
  - `03-first-real-loop.md` through `11-extension-layer.md` = Lectures 3-11
- Updated all internal filenames, link labels, lecture references, course map, and suggested reading order.
- Updated `architecture.md` and `effect-interpreter-packet.md` references to the renamed files.

## Validation

- `docs-governance-smoke`: passed.
- Standard premerge canary: all selected checks passed, 0 failures, 0 timeouts.
- Public boundary scan and `git diff --check`: passed.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`