### PR TITLE
feat(control-plane): add core effect program abstraction

### DIFF
--- a/docs/reference/effect-interpreter-packet.md
+++ b/docs/reference/effect-interpreter-packet.md
@@ -9,6 +9,20 @@ effect_request -> interpretation -> observation -> next_effect
 It does not add a new runtime contract. It names the existing packet fields
 that already play each role.
 
+## Code Lens
+
+`loopx.control_plane.effect_program.interpret_quota_should_run_packet` maps an
+existing `quota should-run` packet onto the canonical slots:
+
+- `EffectRequest`
+- `EffectInterpretation`
+- `EffectObservation`
+- `EffectTurn`
+
+The function is intentionally read-only. It does not replace quota decision
+logic or add a second runtime; it gives refactor and test code one stable
+abstraction for reading the effect program shape.
+
 ## Canonical Example
 
 ### 1. Effect Request

--- a/loopx/canary/qualification_profiles.py
+++ b/loopx/canary/qualification_profiles.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any
 
-
 CONTROL_PLANE_QUALIFICATION_PROFILES: tuple[dict[str, Any], ...] = (
     {
         "id": "lark-goal-channel-human-gate-delivery",
@@ -273,6 +272,7 @@ CONTROL_PLANE_QUALIFICATION_PROFILES: tuple[dict[str, Any], ...] = (
             "loopx/project_prompt.py",
             "loopx/quota.py",
             "loopx/status.py",
+            "loopx/control_plane/effect_program.py",
             "loopx/review_packet.py",
             "loopx/heartbeat_prompt.py",
             "loopx/todos.py",

--- a/loopx/control_plane/effect_program.py
+++ b/loopx/control_plane/effect_program.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class EffectRequest:
+    kind: str
+    source: str
+    goal_id: str | None = None
+    agent_id: str | None = None
+    capabilities: tuple[str, ...] = ()
+    context: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class EffectInterpretation:
+    route: str
+    obligation: str
+    interaction_mode: str
+    capability_action: str | None = None
+    cadence_class: str | None = None
+
+
+@dataclass(frozen=True)
+class EffectObservation:
+    decision: str
+    should_run: bool
+    effective_action: str
+    recommended_action: str
+    next_cli_actions: tuple[str, ...] = ()
+    protocol_summary: str | None = None
+
+
+@dataclass(frozen=True)
+class EffectTurn:
+    request: EffectRequest
+    interpretation: EffectInterpretation
+    observation: EffectObservation
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def interpret_quota_should_run_packet(
+    packet: Mapping[str, Any],
+    *,
+    goal_id: str | None = None,
+    agent_id: str | None = None,
+    capabilities: Sequence[str] = (),
+) -> EffectTurn:
+    """Map an existing `quota should-run` packet onto canonical effect slots."""
+
+    interaction = _mapping(packet.get("interaction_contract"))
+    lane = _mapping(packet.get("work_lane_contract"))
+    scheduler = _mapping(packet.get("scheduler_hint"))
+    cli_channel = _mapping(interaction.get("cli_channel"))
+    gate = packet.get("capability_gate")
+    protocol = _mapping(packet.get("protocol_action_packet"))
+
+    request = EffectRequest(
+        kind="quota_should_run",
+        source="agent_or_host",
+        goal_id=goal_id,
+        agent_id=agent_id,
+        capabilities=tuple(capabilities),
+    )
+    interpretation = EffectInterpretation(
+        route=str(lane.get("lane") or ""),
+        obligation=str(lane.get("obligation") or ""),
+        interaction_mode=str(interaction.get("mode") or ""),
+        capability_action=(
+            str(gate.get("action")) if isinstance(gate, Mapping) else None
+        ),
+        cadence_class=str(scheduler.get("cadence_class") or None) or None,
+    )
+    observation = EffectObservation(
+        decision=str(packet.get("decision") or ""),
+        should_run=bool(packet.get("should_run")),
+        effective_action=str(packet.get("effective_action") or ""),
+        recommended_action=str(packet.get("recommended_action") or ""),
+        next_cli_actions=tuple(
+            str(action)
+            for action in cli_channel.get("next_cli_actions", [])
+            if str(action).strip()
+        ),
+        protocol_summary=(
+            str(protocol.get("summary")) if protocol.get("summary") else None
+        ),
+    )
+    return EffectTurn(
+        request=request,
+        interpretation=interpretation,
+        observation=observation,
+    )

--- a/tests/control_plane/test_effect_interpreter_packet.py
+++ b/tests/control_plane/test_effect_interpreter_packet.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from loopx.control_plane.effect_program import (
+    interpret_quota_should_run_packet,
+)
 from loopx.control_plane.testing.quota_fixtures import quota_status_payload
 from loopx.quota import build_quota_should_run
 
@@ -28,24 +31,28 @@ def _advancement_payload() -> dict:
 
 def test_quota_should_run_exposes_canonical_effect_slots() -> None:
     packet = build_quota_should_run(_advancement_payload(), goal_id=GOAL_ID)
+    turn = interpret_quota_should_run_packet(
+        packet,
+        goal_id=GOAL_ID,
+        agent_id="codex-fixture",
+        capabilities=["shell", "filesystem_write"],
+    )
 
     # interpretation
-    assert packet["work_lane_contract"]["lane"] == "advancement_task"
-    assert packet["work_lane_contract"]["obligation"] == (
-        "advance_one_bounded_segment"
-    )
-    assert packet["interaction_contract"]["mode"] == "bounded_delivery"
+    assert turn.request.kind == "quota_should_run"
+    assert turn.request.goal_id == GOAL_ID
+    assert turn.request.agent_id == "codex-fixture"
+    assert turn.request.capabilities == ("shell", "filesystem_write")
+    assert turn.interpretation.route == "advancement_task"
+    assert turn.interpretation.obligation == "advance_one_bounded_segment"
+    assert turn.interpretation.interaction_mode == "bounded_delivery"
 
     # observation
-    assert packet["decision"] == "run"
-    assert packet["should_run"] is True
-    assert packet["effective_action"] == "normal_run"
-    assert packet["recommended_action"] == "[P1] Advance the bounded slice."
-    assert "lane=advancement_task" in packet["protocol_action_packet"]["summary"]
+    assert turn.observation.decision == "run"
+    assert turn.observation.should_run is True
+    assert turn.observation.effective_action == "normal_run"
+    assert turn.observation.recommended_action == "[P1] Advance the bounded slice."
+    assert "lane=advancement_task" in turn.observation.protocol_summary
 
     # next effect
-    assert isinstance(
-        packet["interaction_contract"]["cli_channel"]["next_cli_actions"],
-        list,
-    )
-    assert packet["interaction_contract"]["cli_channel"]["next_cli_actions"]
+    assert turn.observation.next_cli_actions


### PR DESCRIPTION
## Summary

Add the most basic core effect-program abstraction to support ongoing control-plane refactors.

- Add `loopx/control_plane/effect_program.py` with:
  - `EffectRequest`
  - `EffectInterpretation`
  - `EffectObservation`
  - `EffectTurn`
  - `interpret_quota_should_run_packet()`
- The function maps an existing `quota should-run` packet onto canonical effect slots without changing runtime behavior.
- Update `test_effect_interpreter_packet.py` to consume the abstraction instead of ad hoc field assertions.
- Document the code lens in `docs/reference/effect-interpreter-packet.md` and register the module in canary qualification trigger hints.

## Validation

- New pytest module: 1 passed.
- Ruff, `py_compile`, `docs-governance-smoke`, standard premerge canary, and public boundary scan: passed.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`