### PR TITLE
feat(control-plane): add composition around semantics

### DIFF
--- a/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
+++ b/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
@@ -23,8 +23,10 @@ The agent loop is the loop. The harness is the effectful program that
 interprets each effect request and returns an observation to the next model
 step.
 
-The framing builds on the public lecture series by 齐梦星空, especially
-[主线一：Agent Loop 里的小魔法：函数的组合(3)](https://www.xiaohongshu.com/discovery/item/6a057524000000003701f6aa?source=webshare&xhsshare=pc_web&xsec_token=CBDnukhtey6qJ1aXATVJtv4edjVUnZB1_yebMpqJdNLfc=&xsec_source=pc_share).
+The framing builds on the public lecture series by 齐梦星空:
+[主线一：Tool Calling 是 Kleisli arrow(2)](https://www.xiaohongshu.com/discovery/item/6a02f388000000003502b2d6?source=webshare&xhsshare=pc_web&xsec_token=ABHcIpzpd2RlhAaRr9sZZ-q1OIfRgt7rvG2jn7GUO3tNo=&xsec_source=pc_share)
+and
+[主线一：Agent Loop 里的小魔法：函数的组合(3)](https://www.xiaohongshu.com/discovery/item/6a057524000000003701f6aa?source=webshare&xhsshare=pc_web&xsec_token=AB43lNCJ5ULmfTrGfeTLWd2-jQ6q8nFMGyNAd-tlXJ1uw=&xsec_source=pc_share).
 
 LoopX's job is the middle two steps: it receives an effect request from an
 agent or host, decides whether and how to interpret it, writes back an
@@ -138,6 +140,73 @@ naming discipline over existing packet fields. A new packet may add an
 `effect_interpretation` envelope only when a real caller needs one canonical
 place to read all four slots.
 
+## Composition And Around Semantics
+
+The canonical loop is one effectful step:
+
+```text
+GoalState => F[QuotaDecision]
+```
+
+The public lecture series distinguishes three layers of composition:
+
+| Composition | Shape | LoopX counterpart |
+|---|---|---|
+| Function composition | `A => B`, `B => C` | Read model -> projection -> decision |
+| Kleisli composition | `A => F[B]`, `B => F[C]` | One bounded turn, host effect, validated writeback |
+| Middleware composition | `(A => F[B]) => (A => F[B])` | Around decisions in `capability_gate`, `interaction_contract`, `work_lane_contract`, `scheduler_hint` |
+
+LoopX does not expose a generic Python middleware registry. Its around
+semantics are declarative and packet-shaped.
+
+### Handler Is Data, Not a Callable
+
+Runtime middleware receives a `handler` callable and decides whether to call
+it, call it once, retry, fallback, or short-circuit. LoopX cannot receive a
+model or host callable across context and session boundaries. Instead, the
+interpreter returns a `next_effect` in the packet: CLI actions, scheduler
+ACK, and failure hint. The host or the next automation turn invokes that
+data-encoded handler.
+
+This keeps the power of around style while making the handler durable and
+replayable:
+
+- short-circuit: `decision` and `effective_action` can say `skip`, `wait`,
+  `monitor_quiet_skip`, `repair_bridge`, or `ask_owner` without pretending
+  the original effect ran;
+- rewrite: `work_lane_contract` can preempt ordinary advancement with a due
+  monitor or Lark inbox, and `capability_gate` can rewrite the next effect to
+  materialize the missing capability first;
+- settle: `scheduler_hint.ack_hint` and `failure_hint` tell the host how to
+  commit success or failure, while `unchanged_poll` bounds repeated attempts.
+
+Failure, cancellation, permission, and budget stay visible in typed packet
+fields instead of being swallowed by a catch-all wrapper:
+
+| Around layer | Packet field | Short-circuit examples | Rewrite examples |
+|---|---|---|---|
+| Capability | `capability_gate` | `ask_owner`, `repair_bridge`, `unsupported` | Repair todo and CLI actions for the missing capability |
+| Interaction | `interaction_contract` | User channel `action_required`, `mode` | Primary action, protocol action, next CLI actions |
+| Work lane | `work_lane_contract` | Monitor or inbox preemption, `must_attempt_work=false` | Selected lane, obligation, `next_lane` |
+| Scheduler | `scheduler_hint` | Pause/delete heartbeat, no-spend quiet | RRULE, cadence class, stateful backoff |
+
+The order of these around layers is a contract, not an implementation detail.
+Changing the order changes which gate is observed first, which monitor can
+preempt ordinary work, and whether an ACK is still expected after a failed
+host update. Such changes need parity fixtures and focused tests.
+
+Review a LoopX around decision with the same questions the lecture asks of a
+middleware stack:
+
+1. Which effect request is being interpreted?
+2. Which around layer owns the decision, and what observation does it emit?
+3. Can it short-circuit without pretending the effect ran?
+4. Where is the data-encoded handler (`next_effect`)?
+5. Are failure, cancellation, permission, and budget structured or swallowed?
+6. Is the around-layer order explicit and tested?
+7. Does evidence, trace, and budget continuity survive the host effect
+   through writeback, ACK, and spend?
+
 ## State Machine As Interpretation Table
 
 Instead of teaching state machines as a list of enum values, teach each state
@@ -202,6 +271,29 @@ Acceptance criteria:
 - A reader can trace one real packet from effect request to observation.
 - No CLI output budget regression.
 - No new runtime contract without a real caller.
+
+### M1.5: Composition Lens
+
+**Goal**: Make the around semantics visible in the canonical packet lens.
+
+Steps:
+
+1. Document the three composition layers and the data-encoded handler in this
+   RFC and Lecture 1.
+2. Extend `EffectTurn` with `next_effect` so all four semantic slots are
+   represented in code, not only in prose.
+3. Add a focused test proving a capability gate is a structured around
+   decision: it short-circuits, rewrites the next effect, and keeps
+   permission semantics visible.
+4. Cite the public Tool Calling and Function Composition sources in public
+   docs. Never cite internal lecture material.
+
+Acceptance criteria:
+
+- A reader can answer where `next_effect` is encoded for a real packet.
+- The code lens covers `effect_request`, `interpretation`, `observation`, and
+  `next_effect`.
+- No runtime behavior changes.
 
 ### M2: Bounded Context Alignment
 
@@ -343,6 +435,7 @@ story explicit and gives the refactor and test work a stable target.
 
 ## References
 
-- 齐梦星空, *主线一：Agent Loop 是 effectful program(1)*.
-- 齐梦星空, *主线一：Tool Calling 是 Kleisli arrow(2)*.
-- 齐梦星空, [*主线一：Agent Loop 里的小魔法：函数的组合(3)*](https://www.xiaohongshu.com/discovery/item/6a057524000000003701f6aa?source=webshare&xhsshare=pc_web&xsec_token=CBDnukhtey6qJ1aXATVJtv4edjVUnZB1_yebMpqJdNLfc=&xsec_source=pc_share).
+- 齐梦星空,
+  [*主线一：Tool Calling 是 Kleisli arrow(2)*](https://www.xiaohongshu.com/discovery/item/6a02f388000000003502b2d6?source=webshare&xhsshare=pc_web&xsec_token=ABHcIpzpd2RlhAaRr9sZZ-q1OIfRgt7rvG2jn7GUO3tNo=&xsec_source=pc_share).
+- 齐梦星空,
+  [*主线一：Agent Loop 里的小魔法：函数的组合(3)*](https://www.xiaohongshu.com/discovery/item/6a057524000000003701f6aa?source=webshare&xhsshare=pc_web&xsec_token=AB43lNCJ5ULmfTrGfeTLWd2-jQ6q8nFMGyNAd-tlXJ1uw=&xsec_source=pc_share).

--- a/docs/development/control-plane-course/01-agent-loop-effectful-program.md
+++ b/docs/development/control-plane-course/01-agent-loop-effectful-program.md
@@ -11,7 +11,8 @@ interpreter。agent loop 是被解释的循环，harness 才是解释外部 effe
 全文参考：
 [Agent Loop Effect Interpreter RFC](../../architecture/rfcs/agent-loop-effect-interpreter-v0.md)。
 公开来源：
-[主线一：Agent Loop 里的小魔法：函数的组合(3)](https://www.xiaohongshu.com/discovery/item/6a057524000000003701f6aa?source=webshare&xhsshare=pc_web&xsec_token=CBDnukhtey6qJ1aXATVJtv4edjVUnZB1_yebMpqJdNLfc=&xsec_source=pc_share)。
+[主线一：Tool Calling 是 Kleisli arrow(2)](https://www.xiaohongshu.com/discovery/item/6a02f388000000003502b2d6?source=webshare&xhsshare=pc_web&xsec_token=ABHcIpzpd2RlhAaRr9sZZ-q1OIfRgt7rvG2jn7GUO3tNo=&xsec_source=pc_share)、
+[主线一：Agent Loop 里的小魔法：函数的组合(3)](https://www.xiaohongshu.com/discovery/item/6a057524000000003701f6aa?source=webshare&xhsshare=pc_web&xsec_token=AB43lNCJ5ULmfTrGfeTLWd2-jQ6q8nFMGyNAd-tlXJ1uw=&xsec_source=pc_share)。
 
 ## 一个最朴素的 Agent Loop
 
@@ -89,6 +90,43 @@ Agent proposes next bounded turn
   -> quota packet + interaction contract
   -> execute, ask owner, observe, repair, or no-op
 ```
+
+## 组合：Around 是数据，不是回调
+
+公开课程把组合分成三层：
+
+| 组合 | 形状 | LoopX 对应物 |
+|---|---|---|
+| 函数组合 | `A => B`、`B => C` | read model -> projection -> decision |
+| Kleisli 组合 | `A => F[B]`、`B => F[C]` | 一轮 bounded turn、host effect、validated writeback |
+| Middleware 组合 | `(A => F[B]) => (A => F[B])` | `capability_gate`、`interaction_contract`、`work_lane_contract`、`scheduler_hint` |
+
+很多 runtime 的 around 逻辑会拿到 `handler`：一个可继续执行主流程的回调，
+然后决定是否调用、调用几次、失败后怎样 fallback。LoopX 不能跨上下文和 session
+传递一个可调用对象。它的 `handler` 是数据：packet 里的 `next_effect` 编码下一组
+CLI 动作、scheduler ACK 和 failure hint，由 host 或下一轮 automation 执行。
+
+这个差异不是缺一个 middleware 层，而是控制面的合理形状：
+
+- 可以 short-circuit：`decision` / `effective_action` 直接表达
+  `skip`、`wait`、`monitor_quiet_skip`、`repair_bridge`、`ask_owner`，不会假装原
+  effect 已经执行；
+- 可以 rewrite：`capability_gate` 把下一步改写成先补能力，`work_lane_contract`
+  可以用 due monitor 或 Lark inbox 抢占普通 advancement；
+- 可以 settle：`scheduler_hint` 的 ACK / failure hint 告诉 host 如何提交成功或
+  失败，`unchanged_poll` 限制重复轮询。
+
+失败、取消、权限和预算必须保持结构化，不能被一个通用 catch 吞掉。看一个
+around 决策时，问七件事：
+
+1. 它在解释哪个 effect request？
+2. 哪个 around layer 拥有决策，输出什么 observation？
+3. 它能否 short-circuit，而且不假装原 effect 已执行？
+4. `next_effect` 在哪里被编码？
+5. 失败、取消、权限、预算是否仍然结构化可见？
+6. around layer 的先后顺序是否明确并有测试？
+7. host effect 之后，evidence、trace、budget 是否通过 writeback / ACK / spend
+   继续成立？
 
 ## 读代码前先问五个问题
 

--- a/docs/reference/effect-interpreter-packet.md
+++ b/docs/reference/effect-interpreter-packet.md
@@ -17,6 +17,7 @@ existing `quota should-run` packet onto the canonical slots:
 - `EffectRequest`
 - `EffectInterpretation`
 - `EffectObservation`
+- `EffectNext`
 - `EffectTurn`
 
 The function is intentionally read-only. It does not replace quota decision
@@ -66,8 +67,33 @@ The observation points back into the loop:
 | Packet field | Role |
 |---|---|
 | `interaction_contract.cli_channel.next_cli_actions` | Next CLI effects |
+| `scheduler_hint.action` | Scheduler around decision |
+| `scheduler_hint.cadence_class` | Cadence for the next host wake |
 | `scheduler_hint.codex_app.ack_hint.cli_args` | Host ACK effect |
 | `scheduler_hint.codex_app.failure_hint.cli_args` | Host failure effect |
+
+`EffectTurn.next_effect` is the code lens for this slot. It keeps the
+data-encoded handler visible: the host invokes the CLI actions and settles
+success or failure through the ACK/failure hints instead of LoopX holding a
+callable across turns.
+
+## Around Semantics
+
+`capability_gate`, `interaction_contract`, `work_lane_contract`, and
+`scheduler_hint` are around decisions over the canonical effect step, not
+separate feature modules:
+
+| Around layer | Can short-circuit | Can rewrite |
+|---|---|---|
+| `capability_gate` | `ask_owner`, `repair_bridge`, `unsupported` | Repair todo and next CLI actions |
+| `interaction_contract` | `action_required`, `mode` | Primary/protocol action and notification |
+| `work_lane_contract` | Monitor/inbox preemption, `must_attempt_work=false` | Lane, obligation, `next_lane` |
+| `scheduler_hint` | Pause/delete heartbeat, no-spend quiet | RRULE, cadence, stateful backoff |
+
+The ordering and effect semantics are contracts. A capability gate must not be
+collapsed into a generic exception handler: `owner_missing`,
+`repair_missing`, and `decision_owner` stay visible because `ask_owner` and
+`repair_bridge` lead to different next effects.
 
 ## Relationship To State Machines
 

--- a/loopx/control_plane/effect_program.py
+++ b/loopx/control_plane/effect_program.py
@@ -30,8 +30,16 @@ class EffectObservation:
     should_run: bool
     effective_action: str
     recommended_action: str
-    next_cli_actions: tuple[str, ...] = ()
     protocol_summary: str | None = None
+
+
+@dataclass(frozen=True)
+class EffectNext:
+    cli_actions: tuple[str, ...] = ()
+    scheduler_action: str | None = None
+    cadence_class: str | None = None
+    ack_cli_args: tuple[str, ...] = ()
+    failure_cli_args: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -39,6 +47,7 @@ class EffectTurn:
     request: EffectRequest
     interpretation: EffectInterpretation
     observation: EffectObservation
+    next_effect: EffectNext
 
 
 def _mapping(value: Any) -> Mapping[str, Any]:
@@ -57,6 +66,9 @@ def interpret_quota_should_run_packet(
     interaction = _mapping(packet.get("interaction_contract"))
     lane = _mapping(packet.get("work_lane_contract"))
     scheduler = _mapping(packet.get("scheduler_hint"))
+    codex_app = _mapping(scheduler.get("codex_app"))
+    ack_hint = _mapping(codex_app.get("ack_hint"))
+    failure_hint = _mapping(codex_app.get("failure_hint"))
     cli_channel = _mapping(interaction.get("cli_channel"))
     gate = packet.get("capability_gate")
     protocol = _mapping(packet.get("protocol_action_packet"))
@@ -82,17 +94,32 @@ def interpret_quota_should_run_packet(
         should_run=bool(packet.get("should_run")),
         effective_action=str(packet.get("effective_action") or ""),
         recommended_action=str(packet.get("recommended_action") or ""),
-        next_cli_actions=tuple(
+        protocol_summary=(
+            str(protocol.get("summary")) if protocol.get("summary") else None
+        ),
+    )
+    next_effect = EffectNext(
+        cli_actions=tuple(
             str(action)
             for action in cli_channel.get("next_cli_actions", [])
             if str(action).strip()
         ),
-        protocol_summary=(
-            str(protocol.get("summary")) if protocol.get("summary") else None
+        scheduler_action=str(scheduler.get("action") or None) or None,
+        cadence_class=str(scheduler.get("cadence_class") or None) or None,
+        ack_cli_args=tuple(
+            str(arg)
+            for arg in ack_hint.get("cli_args", [])
+            if str(arg).strip()
+        ),
+        failure_cli_args=tuple(
+            str(arg)
+            for arg in failure_hint.get("cli_args", [])
+            if str(arg).strip()
         ),
     )
     return EffectTurn(
         request=request,
         interpretation=interpretation,
         observation=observation,
+        next_effect=next_effect,
     )

--- a/tests/control_plane/test_effect_interpreter_packet.py
+++ b/tests/control_plane/test_effect_interpreter_packet.py
@@ -55,4 +55,48 @@ def test_quota_should_run_exposes_canonical_effect_slots() -> None:
     assert "lane=advancement_task" in turn.observation.protocol_summary
 
     # next effect
-    assert turn.observation.next_cli_actions
+    assert turn.next_effect.cli_actions
+    assert turn.next_effect.cli_actions[0].startswith("loopx refresh-state")
+    assert turn.next_effect.scheduler_action
+    assert turn.next_effect.cadence_class
+
+
+def test_quota_should_run_capability_gate_is_structured_around_decision() -> None:
+    todo_text = "[P1] Network-only slice."
+    payload = quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        agent_todo_items=[
+            {
+                "index": 1,
+                "text": todo_text,
+                "role": "agent",
+                "status": "open",
+                "priority": "P1",
+                "task_class": "advancement_task",
+                "required_capabilities": ["network"],
+            }
+        ],
+        recommended_action=todo_text,
+        next_action=todo_text,
+    )
+    packet = build_quota_should_run(payload, goal_id=GOAL_ID)
+    turn = interpret_quota_should_run_packet(
+        packet,
+        goal_id=GOAL_ID,
+        agent_id="codex-fixture",
+        capabilities=["shell"],
+    )
+
+    # The gate is an around decision: it short-circuits the original effect
+    # and rewrites the next effect, but permission semantics stay visible.
+    assert turn.interpretation.capability_action == "repair_bridge"
+    assert turn.observation.decision == "repair_bridge"
+    assert turn.observation.effective_action == "capability_bridge_repair"
+    assert packet.get("capability_gate", {}).get("action") == "repair_bridge"
+    assert packet.get("capability_gate", {}).get("owner_missing") == []
+    assert turn.next_effect.cli_actions
+    assert any(
+        "--target-capability network" in action
+        for action in turn.next_effect.cli_actions
+    )


### PR DESCRIPTION
## Summary

Complete the RFC's composition/around semantics and the four-slot code lens.

- RFC: add `Composition And Around Semantics` (function/Kleisli/middleware
  composition, data-encoded handler, around-layer ordering, seven review
  questions) and the M1.5 milestone.
- Lecture 1: add the around-composition story and cite the two public
  Xiaohongshu sources.
- `effect_program.py`: add `EffectNext`; `EffectTurn.next_effect` now
  represents the fourth canonical slot (CLI actions, scheduler action/cadence,
  ACK/failure hints).
- Packet reference: document the code lens and around semantics for
  `capability_gate`, `interaction_contract`, `work_lane_contract`,
  `scheduler_hint`.
- Test: add a focused capability-gate around decision test and update the
  canonical slot test.

## Validation

- `python -m pytest tests/control_plane/test_effect_interpreter_packet.py`:
  2 passed.
- `ruff check`: passed.
- `examples/docs-governance-smoke.py`: passed.
- `loopx canary premerge --from-git-diff`: passed, `self_merge_allowed=true`,
  0 manual holds.
- Public boundary scan: passed.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`
