### PR TITLE
refactor(control-plane): move goal frontier replan rules into bounded context

### DIFF
--- a/docs/development/control-plane-course/09-engineering-a-control-plane-rule.md
+++ b/docs/development/control-plane-course/09-engineering-a-control-plane-rule.md
@@ -768,7 +768,7 @@ receipt = record_supervisor_receipt(
 6. `loopx/control_plane/agents/supervisor_events.py`
 7. `loopx/control_plane/agents/supervisor_inject.py`
 8. `loopx/control_plane/agents/runtime_model.py`
-9. `loopx/control_plane/goals/goal_frontier_replan_rules.py`
+9. `loopx/control_plane/goals/goal_frontier/replan_rules.py`
 10. `tests/control_plane/test_goal_frontier_replan_rules.py`
 11. `examples/control_plane/goal-frontier-replan-rules-smoke.py`
 

--- a/docs/development/control-plane-course/topic-long-horizon-convergence.md
+++ b/docs/development/control-plane-course/topic-long-horizon-convergence.md
@@ -1616,7 +1616,7 @@ LoopX 已经提供的通用机制包括：
 | --- | --- | --- |
 | 本轮决策 | `loopx/quota.py::build_quota_should_run` | 多种 source facts 怎样收敛成一个 interaction decision |
 | Agent-facing packet | `loopx/control_plane/work_items/interaction_contract.py::build_interaction_contract` | selected work、gate、replan、terminal 是否完整投影 |
-| Goal frontier replan | `loopx/control_plane/goals/goal_frontier_replan_rules.py::select_goal_frontier_replan_rule` | runnable、gate、succession gap、monitor exhaustion 的优先级 |
+| Goal frontier replan | `loopx/control_plane/goals/goal_frontier/replan_rules.py::select_goal_frontier_replan_rule` | runnable、gate、succession gap、monitor exhaustion 的优先级 |
 | Vision checkpoint | `loopx/state_refresh.py::build_vision_checkpoint` | material closeout 后如何防止局部目标替代长期方向 |
 | Todo succession | `loopx/control_plane/todos/succession_warning.py::build_open_parent_successor_advisory`、`loopx/control_plane/todos/completion_policy.py::resolve_completion_policy` | successor 为什么只记录 lineage，open parent 为什么仍需显式 complete/defer |
 | Turn transaction | `loopx/control_plane/turn_driver/executor.py::run_loopx_turn_once` | phase failure 怎样恢复，何时允许 commit |

--- a/examples/canary/catalog-planner-smoke.py
+++ b/examples/canary/catalog-planner-smoke.py
@@ -264,7 +264,7 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
 
     frontier_rule_payload = build_catalog_canary_plan(
         changed_files=[
-            "loopx/control_plane/goals/goal_frontier_replan_rules.py",
+            "loopx/control_plane/goals/goal_frontier/replan_rules.py",
         ],
         surfaces=["ordered goal frontier replan policy"],
         max_checks_per_profile=5,

--- a/loopx/canary/qualification_profiles.py
+++ b/loopx/canary/qualification_profiles.py
@@ -184,7 +184,7 @@ CONTROL_PLANE_QUALIFICATION_PROFILES: tuple[dict[str, Any], ...] = (
             "goal_frontier_replan_rules",
             "loopx/control_plane/goals/goal_frontier/__init__.py",
             "loopx/control_plane/goals/goal_frontier/terminal.py",
-            "loopx/control_plane/goals/goal_frontier_replan_rules.py",
+            "loopx/control_plane/goals/goal_frontier/replan_rules.py",
             "goal-frontier-replan-rules-smoke.py",
         ),
         "checks": [

--- a/loopx/canary/quality_surface_catalog.py
+++ b/loopx/canary/quality_surface_catalog.py
@@ -184,7 +184,7 @@ QUALITY_SURFACE_CATALOG: tuple[dict[str, Any], ...] = (
         "owner_paths": [
             "loopx/control_plane/goals/goal_frontier/__init__.py",
             "loopx/control_plane/goals/goal_frontier/terminal.py",
-            "loopx/control_plane/goals/goal_frontier_replan_rules.py",
+            "loopx/control_plane/goals/goal_frontier/replan_rules.py",
             "loopx/control_plane/work_items/autonomous_replan_ack.py",
         ],
         "semantic_oracle": {

--- a/loopx/control_plane/goals/goal_frontier/__init__.py
+++ b/loopx/control_plane/goals/goal_frontier/__init__.py
@@ -20,17 +20,17 @@ from ...work_items.autonomous_replan_obligation import (
     build_autonomous_replan_obligation_payload,
 )
 from ...work_items.repair_delta import repair_delta_kinds_have_frontier_delta
-from ..goal_frontier_replan_rules import (
-    GoalFrontierReplanFacts,
-    GoalFrontierReplanRule,
-    select_goal_frontier_replan_rule,
-)
 from ..goal_vision_policy import goal_vision_repeats_advancement_until_closed
 from ..goal_vision_state import (
     goal_vision_state_is_closed,
     goal_vision_state_requires_successor,
 )
 from ..goal_vision_wait import build_goal_vision_wait_state
+from .replan_rules import (
+    GoalFrontierReplanFacts,
+    GoalFrontierReplanRule,
+    select_goal_frontier_replan_rule,
+)
 from .terminal import (
     GOAL_TERMINAL_SOURCE_COMPLETENESS_SCHEMA_VERSION,  # noqa: F401
     GOAL_TERMINAL_STATE_SCHEMA_VERSION,  # noqa: F401

--- a/loopx/control_plane/goals/goal_frontier/replan_rules.py
+++ b/loopx/control_plane/goals/goal_frontier/replan_rules.py
@@ -1,8 +1,10 @@
+"""Goal-frontier replan rule selection: the decision interpreter for the
+`goal_frontier` bounded context."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-
 
 GOAL_FRONTIER_REPLAN_RULE_DECISION_SCHEMA_VERSION = (
     "goal_frontier_replan_rule_decision_v0"

--- a/tests/control_plane/test_goal_frontier_replan_rules.py
+++ b/tests/control_plane/test_goal_frontier_replan_rules.py
@@ -7,7 +7,7 @@ import pytest
 from loopx.control_plane.goals.goal_frontier import (
     derive_goal_frontier_replan_obligation_from_summaries,
 )
-from loopx.control_plane.goals.goal_frontier_replan_rules import (
+from loopx.control_plane.goals.goal_frontier.replan_rules import (
     GOAL_FRONTIER_REPLAN_RULE_ORDER,
     GoalFrontierReplanFacts,
     GoalFrontierReplanRule,


### PR DESCRIPTION
## Summary

M2 bounded-context alignment for the goal-frontier replan decision.

- Move `loopx/control_plane/goals/goal_frontier_replan_rules.py` into the
  `goal_frontier` package as `goal_frontier/replan_rules.py`.
- Update the internal import, focused test import, canary profile paths,
  catalog smoke fixture, and course docs to the canonical bounded-context path.
- Add a module docstring that names the module as the replan decision
  interpreter inside the `goal_frontier` bounded context.

No runtime behavior changes.

## Validation

- `python -m pytest tests/control_plane/test_goal_frontier_replan_rules.py
  tests/control_plane/test_effect_interpreter_packet.py`: 21 passed.
- `examples/control_plane/goal-frontier-replan-rules-smoke.py`: passed.
- `examples/canary/catalog-planner-smoke.py`: passed.
- `loopx canary premerge --from-git-diff`: passed, `self_merge_allowed=true`,
  0 manual holds.
- Public boundary scan: passed.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`
