### PR TITLE
refactor(control-plane): move status agent lane projection into status bounded context

### DIFF
--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -11,7 +11,7 @@ from ..control_plane.runtime.status_projection_cache import (
     resolve_status_projection_cache_runtime_root,
     write_status_projection_cache,
 )
-from ..control_plane.status_agent_lane_projection import (
+from ..control_plane.status.agent_lane_projection import (
     compact_agent_lane_status_payload_for_display,
 )
 from ..control_plane.todos.contract import normalize_todo_claimed_by

--- a/loopx/control_plane/status/__init__.py
+++ b/loopx/control_plane/status/__init__.py
@@ -1,0 +1,6 @@
+"""Status bounded-context read models and projections.
+
+Status projections turn registry, run history, active state, and todo read
+models into agent/operator-visible observations. Quota and CLI callers consume
+these projections; they do not reimplement status facts.
+"""

--- a/loopx/control_plane/status/agent_lane_projection.py
+++ b/loopx/control_plane/status/agent_lane_projection.py
@@ -1,7 +1,8 @@
+"""Agent-lane status projection inside the `status` bounded context."""
+
 from __future__ import annotations
 
 from typing import Any
-
 
 AGENT_LANE_STATUS_PAYLOAD_COMPACTION_SCHEMA_VERSION = (
     "agent_lane_status_payload_compaction_v0"

--- a/tests/control_plane/test_status_agent_lane_projection.py
+++ b/tests/control_plane/test_status_agent_lane_projection.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import json
 
-from loopx.control_plane.status_agent_lane_projection import (
+from loopx.control_plane.status.agent_lane_projection import (
     compact_agent_lane_status_payload_for_display,
 )
 from loopx.control_plane.todos.quota_summary import (
     compact_agent_lane_todos_for_status_display,
 )
-
 
 AGENT_ID = "codex-quality"
 GOAL_ID = "status-budget-goal"


### PR DESCRIPTION
## Summary

Second M2 bounded-context alignment slice for status projections.

- Add `loopx/control_plane/status/` as the status bounded-context package.
- Move `status_agent_lane_projection.py` into
  `status/agent_lane_projection.py`.
- Update the CLI and focused-test imports to the canonical path.
- Add a package docstring that names status as the projection owner for
  registry, run history, active state, and todo read models.

No runtime behavior changes.

## Validation

- `python -m pytest tests/control_plane/test_status_agent_lane_projection.py
  tests/control_plane/test_status_collection_material_capability_wiring.py`:
  4 passed.
- `examples/control_plane/status-collection-readmodel-smoke.py`: passed.
- `examples/control_plane/status-markdown-smoke.py`: passed.
- `loopx canary premerge --from-git-diff`: passed, `self_merge_allowed=true`,
  0 manual holds.
- Public boundary scan: passed.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`
