### PR TITLE
refactor(control-plane): move status runtime summaries into status bounded context

### DIFF
--- a/examples/control_plane/decision-freshness-readmodel-smoke.py
+++ b/examples/control_plane/decision-freshness-readmodel-smoke.py
@@ -15,7 +15,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx import status as status_module  # noqa: E402
-from loopx.control_plane import status_runtime_summaries  # noqa: E402
+from loopx.control_plane.status import runtime_summaries as status_runtime_summaries  # noqa: E402
 from loopx.control_plane.runtime import decision_freshness as decision_read_model  # noqa: E402
 from loopx.control_plane.runtime import event_ledger as event_ledger_read_model  # noqa: E402
 

--- a/examples/control_plane/event-ledger-readmodel-smoke.py
+++ b/examples/control_plane/event-ledger-readmodel-smoke.py
@@ -15,7 +15,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx import status as status_module  # noqa: E402
-from loopx.control_plane import status_runtime_summaries  # noqa: E402
+from loopx.control_plane.status import runtime_summaries as status_runtime_summaries  # noqa: E402
 from loopx.control_plane.runtime import event_ledger as event_ledger_read_model  # noqa: E402
 
 

--- a/examples/control_plane/status-runtime-summaries-readmodel-smoke.py
+++ b/examples/control_plane/status-runtime-summaries-readmodel-smoke.py
@@ -15,7 +15,7 @@ if str(ROOT) not in sys.path:
 
 from loopx import status as status_module  # noqa: E402
 from loopx.control_plane.runtime.time import now_utc, parse_timestamp, utc_isoformat  # noqa: E402
-from loopx.control_plane.status_runtime_summaries import (  # noqa: E402
+from loopx.control_plane.status.runtime_summaries import (  # noqa: E402
     StatusRuntimeSummaryContext,
     build_status_runtime_summaries,
 )

--- a/loopx/control_plane/status/runtime_summaries.py
+++ b/loopx/control_plane/status/runtime_summaries.py
@@ -1,10 +1,12 @@
+"""Status runtime summaries inside the `status` bounded context."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Iterable
 
-from .runtime.decision_freshness import (
+from ..runtime.decision_freshness import (
     DECISION_FRESHNESS_CLASSIFICATION_PREFIXES,
     DECISION_FRESHNESS_ITEM_LIMIT,
     DECISION_FRESHNESS_PROXY_NOTE,
@@ -12,15 +14,15 @@ from .runtime.decision_freshness import (
     build_decision_freshness_summary,
     decision_event_kinds as _decision_event_kinds_read_model,
 )
-from .runtime.event_ledger import (
+from ..runtime.event_ledger import (
     blank_event_class_counts,
     build_event_ledger_summary,
     event_ledger_event_class as _event_ledger_event_class_read_model,
 )
-from .runtime.promotion_readiness import build_promotion_readiness_summary
-from .runtime.run_history import build_run_history
-from .quota.usage_summary import build_usage_summary
-from .todos.todo_index import build_todo_index
+from ..runtime.promotion_readiness import build_promotion_readiness_summary
+from ..runtime.run_history import build_run_history
+from ..quota.usage_summary import build_usage_summary
+from ..todos.todo_index import build_todo_index
 
 
 StatusCallback = Callable[..., Any]

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -12,7 +12,7 @@ from .control_plane.status_collection import (
     StatusCollectionContext,
     collect_status as _collect_status_read_model,
 )
-from .control_plane.status_runtime_summaries import (
+from .control_plane.status.runtime_summaries import (
     StatusRuntimeSummaryContext,
     build_status_runtime_summaries as _build_status_runtime_summaries_read_model,
 )


### PR DESCRIPTION
## Summary

Third M2 bounded-context alignment slice for status projections.

- Move `status_runtime_summaries.py` into
  `loopx/control_plane/status/runtime_summaries.py`.
- Update `loopx.status`, focused examples, and direct read-model smokes to the
  canonical `status.runtime_summaries` import path.
- Adjust internal relative imports from the new package depth and add a module
  docstring that names the status bounded context.

No runtime behavior changes.

## Validation

- Focused status pytest modules: 4 passed.
- `status-runtime-summaries-readmodel-smoke`: passed.
- `event-ledger-readmodel-smoke`: passed.
- `decision-freshness-readmodel-smoke`: passed.
- `usage-summary-smoke`, `promotion-readiness-readmodel-smoke`,
  `run-history-readmodel-smoke`, `todo-index-rollout-status-smoke`, and
  `session-runtime-readonly-projection-smoke`: passed.
- `loopx canary premerge --from-git-diff`: passed, `self_merge_allowed=true`,
  0 manual holds.
- Public boundary scan: passed.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`
