### PR TITLE
test(control-plane): cover monitor quiet around semantics

### DIFF
--- a/tests/control_plane/test_effect_interpreter_packet.py
+++ b/tests/control_plane/test_effect_interpreter_packet.py
@@ -100,3 +100,45 @@ def test_quota_should_run_capability_gate_is_structured_around_decision() -> Non
         "--target-capability network" in action
         for action in turn.next_effect.cli_actions
     )
+
+
+def test_effect_turn_keeps_monitor_quiet_around_decision_data_visible() -> None:
+    packet = {
+        "decision": "skip",
+        "should_run": False,
+        "effective_action": "monitor_quiet_skip",
+        "recommended_action": "quiet until the next material transition",
+        "interaction_contract": {
+            "mode": "monitor_quiet_skip",
+            "user_channel": {"notify": "DONT_NOTIFY", "action_required": False},
+            "cli_channel": {"next_cli_actions": []},
+        },
+        "work_lane_contract": {
+            "lane": "continuous_monitor",
+            "obligation": "attempt_due_monitor",
+            "must_attempt_work": False,
+        },
+        "scheduler_hint": {
+            "action": "no_spend",
+            "cadence_class": "monitor_wait",
+        },
+    }
+    turn = interpret_quota_should_run_packet(
+        packet,
+        goal_id=GOAL_ID,
+        agent_id="codex-fixture",
+        capabilities=["network", "external_evidence_poll"],
+    )
+
+    # A quiet turn must not be rewritten into a runnable next effect or a
+    # spend. The around decision stays visible in typed packet slots.
+    assert turn.interpretation.interaction_mode == "monitor_quiet_skip"
+    assert turn.interpretation.route == "continuous_monitor"
+    assert turn.observation.decision == "skip"
+    assert turn.observation.should_run is False
+    assert turn.observation.effective_action == "monitor_quiet_skip"
+    assert turn.next_effect.cli_actions == ()
+    assert turn.next_effect.scheduler_action == "no_spend"
+    assert turn.next_effect.cadence_class == "monitor_wait"
+    assert turn.next_effect.ack_cli_args == ()
+    assert turn.next_effect.failure_cli_args == ()


### PR DESCRIPTION
## Summary

M3 focused test for monitor-quiet around semantics.

- Add a test proving `monitor_quiet_skip` stays visible in
  `EffectInterpretation` / `EffectObservation` and is not rewritten into a
  runnable next effect or spend by `EffectNext`.
- The quiet turn keeps `scheduler_action=no_spend` and empty ACK/failure hints.

No runtime behavior changes.

## Validation

- `python -m pytest tests/control_plane/test_effect_interpreter_packet.py`:
  3 passed.
- `ruff check --select E,F`: passed.
- `loopx canary premerge --from-git-diff`: passed, `self_merge_allowed=true`,
  0 manual holds.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`
