### PR TITLE
docs(control-plane): add status bounded context to layout

### DIFF
--- a/docs/product/core-control-plane/bounded-context-layout.md
+++ b/docs/product/core-control-plane/bounded-context-layout.md
@@ -16,6 +16,7 @@ New control-plane code should live under `loopx.control_plane`:
 | `todos` | Todo parsing summaries, todo-derived attention helpers, and todo handoff summaries. |
 | `agents` | Agent-scope filtering, lane recommendation, capability gates, subagent activity, and the reusable multi-agent execution kernel. |
 | `quota` | Quota-specific control-plane helpers. |
+| `status` | Status collection assembly, runtime summaries, agent-lane status projection, and other status read models. |
 | `scheduler` | Scheduler-facing monitor display and cadence helpers. |
 | `runtime` | Runtime/session projections and run-compaction helpers. |
 | `handoff` | Handoff readiness, handoff state, handoff-run classification, cross-runtime review packets, and exact review-decision batching. |


### PR DESCRIPTION
## Summary

M2 docs alignment for the status bounded context.

- Add `status` to the package-shape table in
  `docs/product/core-control-plane/bounded-context-layout.md`, naming status
  collection assembly, runtime summaries, agent-lane projection, and other
  status read models.

No runtime behavior changes.

## Validation

- `docs-governance-smoke`: passed.
- `loopx canary premerge --from-git-diff`: passed, `self_merge_allowed=true`,
  0 manual holds.
- Public boundary scan: passed.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`
