### PR TITLE
docs(rfc): track effect interpreter milestone status

### DIFF
--- a/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
+++ b/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
@@ -36,6 +36,18 @@ This RFC establishes the mental model, defines canonical packet semantics,
 and gives a milestone plan for aligning documentation, code, and tests with
 that model over time.
 
+## Milestone Status
+
+| Milestone | Status |
+|---|---|
+| M0 RFC and Lecture 0 | Merged (#2905, #2906, #2908) |
+| M1 Canonical packet example | Merged (#2907, #2910) |
+| M1.5 Composition lens | Merged (#2911) |
+| M2 Bounded context alignment | Partial (#2912-#2915, #2919) |
+| M3 Focused test families | Partial (#2916-#2918) |
+| M4 Architecture documentation | Pending |
+| M5 Steady-state review | Pending |
+
 ## Why This Matters
 
 Today, LoopX has many correct but hard-to-explain pieces:


### PR DESCRIPTION
## Summary

Track RFC milestone status in the public RFC.

- Add a `Milestone Status` table after the summary, mapping M0-M5 to merged
  PRs or pending status so maintainers and readers can see the current
  alignment without reconstructing history from commit messages.

No runtime behavior changes.

## Validation

- `docs-governance-smoke`: passed.
- `loopx canary premerge --from-git-diff`: passed, `self_merge_allowed=true`,
  0 manual holds.
- Public boundary scan: passed.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`
