### PR TITLE
docs(architecture): frame control plane as effect interpreter

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,6 +43,28 @@ The core repository intentionally avoids domain logic. A data experiment goal,
 a note-maintenance goal, and a harness self-improvement goal should share the
 same runtime and contract, but use different adapters.
 
+## Control Plane As Effect Interpreter
+
+The six layers are not only storage surfaces. Together they interpret one
+effect request per loop iteration:
+
+```text
+model -> effect request -> harness interprets effect -> observation -> model
+```
+
+The read model is the current state (`A`): registry, goal state, and run
+history. The projection is the observation (`F[B]`): status, attention queue,
+and compact run summaries. The decision is the effect interpreter
+(`A => F[QuotaDecision]`): quota, interaction contract, capability gates,
+work-lane routing, and scheduler hints decide whether and how the next effect
+may run. The data-encoded handler is the `next_effect` in the quota packet:
+CLI actions, scheduler ACK/failure hints, writeback, and spend.
+
+This is the same lens as the
+[Agent Loop Effect Interpreter RFC](architecture/rfcs/agent-loop-effect-interpreter-v0.md)
+and
+[Harness Is the Effectful Program](development/control-plane-course/01-agent-loop-effectful-program.md).
+
 ## Turn Decision Vocabulary
 
 Operator-facing docs and heartbeat prompts often summarize a turn as deliver,


### PR DESCRIPTION
## Summary

M4 architecture documentation alignment.

- Add `Control Plane As Effect Interpreter` to `docs/architecture.md`, mapping
  the six durable layers to the canonical
  `effect_request -> interpretation -> observation -> next_effect` loop and
  linking the RFC and Lecture 1.
- The new section names the read model, projection, effect interpreter, and
  data-encoded handler explicitly.

No runtime behavior changes.

## Validation

- `docs-governance-smoke`: passed.
- `loopx canary premerge --from-git-diff`: passed, `self_merge_allowed=true`,
  0 manual holds.
- Public boundary scan: passed.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`
