### PR TITLE
test(docs): guard effect interpreter canonical docs

### DIFF
--- a/examples/docs-governance-smoke.py
+++ b/examples/docs-governance-smoke.py
@@ -120,6 +120,35 @@ def assert_local_doc_links_resolve() -> None:
                 )
 
 
+def assert_effect_interpreter_docs_are_canonical() -> None:
+    packet_doc = compact(read("docs/reference/effect-interpreter-packet.md"))
+    for required in (
+        "EffectRequest",
+        "EffectInterpretation",
+        "EffectObservation",
+        "EffectNext",
+        "EffectTurn",
+        "Around Semantics",
+    ):
+        assert required in packet_doc, required
+
+    rfc = compact(read("docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md"))
+    for required in (
+        "Composition And Around Semantics",
+        "Handler Is Data, Not a Callable",
+        "Milestone Status",
+    ):
+        assert required in rfc, required
+
+    architecture = compact(read("docs/architecture.md"))
+    assert "Control Plane As Effect Interpreter" in architecture
+
+    lecture = compact(
+        read("docs/development/control-plane-course/01-agent-loop-effectful-program.md")
+    )
+    assert "Around 是数据，不是回调" in lecture
+
+
 def main() -> int:
     docs_index = read("docs/README.md")
     root_readme = read("README.md")
@@ -287,6 +316,7 @@ def main() -> int:
     )
 
     assert_local_doc_links_resolve()
+    assert_effect_interpreter_docs_are_canonical()
 
     collaboration_rfc = read(
         "docs/architecture/rfcs/agent-im-openviking-collaboration-v0.md"


### PR DESCRIPTION
## Summary

M5 steady-state docs guard.

- Add `assert_effect_interpreter_docs_are_canonical()` to
  `examples/docs-governance-smoke.py`.
- The check requires the packet reference, RFC, architecture page, and Lecture
  1 to keep the canonical effect slots and around-semantics vocabulary.

No runtime behavior changes.

## Validation

- `docs-governance-smoke`: passed.
- `python -m py_compile examples/docs-governance-smoke.py`: passed.
- `loopx canary premerge --from-git-diff`: passed, `self_merge_allowed=true`,
  0 manual holds.
- Public boundary scan: passed.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`
