### PR TITLE
docs(control-plane): explain state machines as interpretation tables

### DIFF
--- a/docs/product/core-control-plane/README.md
+++ b/docs/product/core-control-plane/README.md
@@ -31,6 +31,18 @@ rediscovering state from chat history or private planning notes. The rule seam
 map is intentionally behavior-preserving: it names extraction seams and parity
 checks before the refactor branch moves control-plane code.
 
+The state machines in this folder are interpretation tables inside the
+harness's effect interpreter:
+
+```text
+effect request -> interpretation -> observation -> next effect
+```
+
+See the
+[Agent Loop Effect Interpreter RFC](../../architecture/rfcs/agent-loop-effect-interpreter-v0.md)
+and
+[Harness Is the Effectful Program](../../development/control-plane-course/01-agent-loop-effectful-program.md).
+
 ## Execution Ownership
 
 These graphs describe Kernel state and legal transitions. The surrounding turn


### PR DESCRIPTION
## Summary

M4 product docs alignment.

- Add an effect-interpreter framing paragraph to
  `docs/product/core-control-plane/README.md`, explaining that the state
  machines are interpretation tables inside the harness and linking the RFC
  and Lecture 1.

No runtime behavior changes.

## Validation

- `docs-governance-smoke`: passed.
- `loopx canary premerge --from-git-diff`: passed, `self_merge_allowed=true`,
  0 manual holds.
- Public boundary scan: passed.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`
