### PR TITLE
docs(course): frame state machines as interpretation tables

### DIFF
--- a/docs/development/control-plane-course/README.md
+++ b/docs/development/control-plane-course/README.md
@@ -13,6 +13,10 @@
 卡片，claim、gate、monitor、writeback 等 Kernel operator 决定卡片能否移动，Capability
 Pack 增加领域泳道。看板只是 projection；canonical state 和 typed transition 才是控制合同。
 
+贯穿全课的另一种判定是 effect interpreter：模型提出 effect request，harness 解释后返回
+observation，再把 next effect 交回 host。每个状态机都是解释器内部的一张 interpretation
+table，而不是独立产品。
+
 ## 课程先建立一个递进
 
 普通 Agent 对话主要依赖当前 transcript。Codex 原生 Goal 再向外走一步：通过持久 goal object


### PR DESCRIPTION
## Summary

M4 course index alignment.

- Add the effect-interpreter framing to
  `docs/development/control-plane-course/README.md`: model proposes an effect
  request, harness interprets it and returns an observation, and state
  machines are interpretation tables inside the harness.

No runtime behavior changes.

## Validation

- `docs-governance-smoke`: passed.
- `loopx canary premerge --from-git-diff`: passed, `self_merge_allowed=true`,
  0 manual holds.
- Public boundary scan: passed.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`
