### PR TITLE
docs: extend effectful program lecture citations

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,6 +64,8 @@ This is the same lens as the
 [Agent Loop Effect Interpreter RFC](architecture/rfcs/agent-loop-effect-interpreter-v0.md)
 and
 [Harness Is the Effectful Program](development/control-plane-course/01-agent-loop-effectful-program.md).
+The public framing comes from 齐梦星空,
+[主线一：Agent Loop 是 effectful program(1)](https://www.xiaohongshu.com/discovery/item/6a01d501000000003700c5de?source=webshare&xhsshare=pc_web&xsec_token=ABqpNuladcxhev099wLKw8M3ilhKBua0BQXNpxnBZEGkc=&xsec_source=pc_share).
 
 ## Turn Decision Vocabulary
 

--- a/docs/product/core-control-plane/README.md
+++ b/docs/product/core-control-plane/README.md
@@ -42,6 +42,8 @@ See the
 [Agent Loop Effect Interpreter RFC](../../architecture/rfcs/agent-loop-effect-interpreter-v0.md)
 and
 [Harness Is the Effectful Program](../../development/control-plane-course/01-agent-loop-effectful-program.md).
+The public framing comes from 齐梦星空,
+[主线一：Agent Loop 是 effectful program(1)](https://www.xiaohongshu.com/discovery/item/6a01d501000000003700c5de?source=webshare&xhsshare=pc_web&xsec_token=ABqpNuladcxhev099wLKw8M3ilhKBua0BQXNpxnBZEGkc=&xsec_source=pc_share).
 
 ## Execution Ownership
 

--- a/docs/reference/effect-interpreter-packet.md
+++ b/docs/reference/effect-interpreter-packet.md
@@ -107,3 +107,5 @@ See the
 [Agent Loop Effect Interpreter RFC](../architecture/rfcs/agent-loop-effect-interpreter-v0.md)
 and
 [Harness Is the Effectful Program](../development/control-plane-course/01-agent-loop-effectful-program.md).
+The public framing comes from 齐梦星空,
+[主线一：Agent Loop 是 effectful program(1)](https://www.xiaohongshu.com/discovery/item/6a01d501000000003700c5de?source=webshare&xhsshare=pc_web&xsec_token=ABqpNuladcxhev099wLKw8M3ilhKBua0BQXNpxnBZEGkc=&xsec_source=pc_share).


### PR DESCRIPTION
## Summary

Extend the public "Agent Loop 是 effectful program(1)" citation to the
remaining "Harness Is the Effectful Program" anchors.

- `docs/architecture.md`
- `docs/reference/effect-interpreter-packet.md`
- `docs/product/core-control-plane/README.md`

No runtime behavior changes.

## Validation

- `docs-governance-smoke`: passed.
- `loopx canary premerge --from-git-diff`: passed, `self_merge_allowed=true`,
  0 manual holds.
- Public boundary scan: passed; no internal lecture links added.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`
