### PR TITLE
refactor(control-plane): move quota plan items into decision summary

### DIFF
--- a/loopx/control_plane/quota/decision_summary.py
+++ b/loopx/control_plane/quota/decision_summary.py
@@ -14,6 +14,18 @@ from ..todos.contract import normalize_todo_claimed_by
 from ..work_items.work_lane import work_lane_contract_is_due_monitor_attempt
 
 
+def quota_plan_items(plan: dict[str, Any]) -> list[dict[str, Any]]:
+    """Flatten quota plan state groups into ordered goal items."""
+
+    groups = plan.get("groups") if isinstance(plan.get("groups"), dict) else {}
+    items: list[dict[str, Any]] = []
+    for state_items in groups.values():
+        if not isinstance(state_items, list):
+            continue
+        items.extend(item for item in state_items if isinstance(item, dict))
+    return items
+
+
 def compact_quota_decision(decision: dict[str, Any]) -> dict[str, Any]:
     quota = decision.get("quota") if isinstance(decision.get("quota"), dict) else {}
     return {

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -67,6 +67,7 @@ from .control_plane.quota.stall_repair import (
 from .control_plane.quota.decision_summary import (
     goal_status_health_ok as _goal_status_health_ok,
     quota_decision_agent_id,
+    quota_plan_items as _quota_plan_items,
     refine_quota_recommended_action,
     resolve_quota_run_decision,
 )
@@ -1029,16 +1030,6 @@ def build_quota_plan(status_payload: dict[str, Any], *, mode: str = "status") ->
         "groups": groups,
         "health_items": health_items,
     }
-
-
-def _quota_plan_items(plan: dict[str, Any]) -> list[dict[str, Any]]:
-    groups = plan.get("groups") if isinstance(plan.get("groups"), dict) else {}
-    items: list[dict[str, Any]] = []
-    for state_items in groups.values():
-        if not isinstance(state_items, list):
-            continue
-        items.extend(item for item in state_items if isinstance(item, dict))
-    return items
 
 
 def _recent_reward_lessons(status_payload: dict[str, Any], *, goal_id: str) -> list[dict[str, Any]]:

--- a/tests/control_plane/test_quota_decision_summary.py
+++ b/tests/control_plane/test_quota_decision_summary.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from loopx.control_plane.quota.decision_summary import quota_plan_items
+
+
+def test_quota_plan_items_flattens_state_groups() -> None:
+    plan = {
+        "groups": {
+            "run": [],
+            "waiting": [
+                {"goal_id": "goal-a"},
+                {"goal_id": "goal-b"},
+            ],
+            "unknown": [{"goal_id": "goal-c"}],
+        }
+    }
+
+    assert quota_plan_items(plan) == [
+        {"goal_id": "goal-a"},
+        {"goal_id": "goal-b"},
+        {"goal_id": "goal-c"},
+    ]
+
+
+def test_quota_plan_items_ignores_non_mapping_groups() -> None:
+    assert quota_plan_items(
+        {"groups": {"run": "not-a-list", "waiting": [{"goal_id": "goal-a"}]}}
+    ) == [{"goal_id": "goal-a"}]


### PR DESCRIPTION
## Summary

M2 quota bounded-context alignment.

- Move `_quota_plan_items` from `loopx/quota.py` into
  `loopx/control_plane/quota/decision_summary.py` as `quota_plan_items`.
- Update the single quota caller and add focused tests for group flattening.

No runtime behavior changes.

## Validation

- `python -m pytest tests/control_plane/test_quota_decision_summary.py
  tests/control_plane/test_quota_plan_policy.py`: 12 passed.
- `loopx canary premerge --from-git-diff`: passed, `self_merge_allowed=true`,
  0 manual holds.
- Public boundary scan: passed.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`
