### PR TITLE
docs: model CLI packet as higher-density effect

### DIFF
--- a/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
+++ b/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
@@ -220,6 +220,24 @@ middleware stack:
 7. Does evidence, trace, and budget continuity survive the host effect
    through writeback, ACK, and spend?
 
+### CLI Is a Higher-Density Effect
+
+A single tool call is `ToolInput => F[ToolOutput]`. A LoopX CLI packet is a
+higher-density effect: one command can carry permission, budget, parameter
+validation, external execution, failure semantics, scheduler ACK, and
+writeback in the same request. The model still only proposes effect requests;
+the harness interprets them into CLI actions.
+
+If a vendor API later supports serial tool calls or interleaved reasoning,
+that does not change the LoopX shape. It becomes an execution mode inside the
+interpreter:
+
+- serial, parallel, and interleaved are execution strategies, not new state
+  machines;
+- `effect_request -> interpretation -> observation -> next_effect` stays
+  stable;
+- `next_effect` changes from one CLI command to an ordered effect program.
+
 ## State Machine As Interpretation Table
 
 Instead of teaching state machines as a list of enum values, teach each state

--- a/docs/development/control-plane-course/01-agent-loop-effectful-program.md
+++ b/docs/development/control-plane-course/01-agent-loop-effectful-program.md
@@ -129,6 +129,20 @@ around 决策时，问七件事：
 7. host effect 之后，evidence、trace、budget 是否通过 writeback / ACK / spend
    继续成立？
 
+## CLI 是更高密度的 effect
+
+单个 tool call 是 `ToolInput => F[ToolOutput]`。LoopX 的 CLI packet 是一条更高
+密度的 effect：一条命令可以把权限、预算、参数校验、外部执行、失败语义、scheduler
+ACK 和 writeback 都编码进同一个 request。模型仍然只提出 effect request，harness
+负责解释并决定下一步执行什么。
+
+如果未来厂商 API 原生支持 serial tool calls 或 interleaved reasoning，对 LoopX
+来说只是解释器内部的一种 execution mode：
+
+- 串行、并行、交错是 execution strategy，不是新的状态机；
+- `effect_request -> interpretation -> observation -> next_effect` 仍然稳定；
+- `next_effect` 从一条 CLI 命令变成一段有序 effect program。
+
 ## 读代码前先问五个问题
 
 1. 这个 effect request 是谁提出的？

--- a/docs/reference/effect-interpreter-packet.md
+++ b/docs/reference/effect-interpreter-packet.md
@@ -95,6 +95,11 @@ collapsed into a generic exception handler: `owner_missing`,
 `repair_missing`, and `decision_owner` stay visible because `ask_owner` and
 `repair_bridge` lead to different next effects.
 
+A CLI packet is a higher-density effect than a single tool call: one command
+can carry permission, budget, validation, execution, failure semantics, ACK,
+and writeback. Vendor serial or interleaved tool APIs are execution modes
+inside the interpreter, not new state machines.
+
 ## Relationship To State Machines
 
 Each state family is an interpretation table over this lens:


### PR DESCRIPTION
## Summary

Model the CLI packet as a higher-density effect in the public docs.

- RFC: add `CLI Is a Higher-Density Effect`, stating that serial, parallel,
  and interleaved tool APIs are execution modes inside the interpreter.
- Lecture 1: add the same framing in Chinese.
- Packet reference: add a short paragraph to the around-semantics section.

No runtime behavior changes.

## Validation

- `docs-governance-smoke`: passed.
- `loopx canary premerge --from-git-diff`: passed, `self_merge_allowed=true`,
  0 manual holds.
- Public boundary scan: passed; only public lecture links are cited.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`
