### PR TITLE
feat(control-plane): add turn result effect interpreter

### DIFF
--- a/docs/reference/effect-interpreter-packet.md
+++ b/docs/reference/effect-interpreter-packet.md
@@ -12,7 +12,8 @@ that already play each role.
 ## Code Lens
 
 `loopx.control_plane.effect_program.interpret_quota_should_run_packet` maps an
-existing `quota should-run` packet onto the canonical slots:
+existing `quota should-run` packet onto the canonical slots, and
+`interpret_turn_result_packet` maps an existing `loopx_turn_result_v0` packet:
 
 - `EffectRequest`
 - `EffectInterpretation`
@@ -20,9 +21,10 @@ existing `quota should-run` packet onto the canonical slots:
 - `EffectNext`
 - `EffectTurn`
 
-The function is intentionally read-only. It does not replace quota decision
-logic or add a second runtime; it gives refactor and test code one stable
-abstraction for reading the effect program shape.
+Both functions are intentionally read-only. They do not replace quota
+decision or turn-settlement logic; they give refactor and test code one
+stable abstraction for reading the effect program shape across packet
+families.
 
 ## Canonical Example
 

--- a/loopx/control_plane/effect_program.py
+++ b/loopx/control_plane/effect_program.py
@@ -123,3 +123,82 @@ def interpret_quota_should_run_packet(
         observation=observation,
         next_effect=next_effect,
     )
+
+
+def interpret_turn_result_packet(
+    packet: Mapping[str, Any],
+    *,
+    goal_id: str | None = None,
+    agent_id: str | None = None,
+    capabilities: Sequence[str] = (),
+) -> EffectTurn:
+    """Map an existing `loopx_turn_result_v0` packet onto canonical slots."""
+
+    scheduler = _mapping(packet.get("scheduler_hint"))
+    codex_app = _mapping(scheduler.get("codex_app"))
+    ack_hint = _mapping(codex_app.get("ack_hint"))
+    failure_hint = _mapping(codex_app.get("failure_hint"))
+    completed_phases = tuple(
+        str(phase)
+        for phase in packet.get("completed_phases", [])
+        if str(phase).strip()
+    )
+    failed_phase = str(packet.get("failed_phase") or "") or None
+    result_kind = str(packet.get("result_kind") or "")
+
+    request = EffectRequest(
+        kind="turn_result",
+        source="host",
+        goal_id=goal_id,
+        agent_id=agent_id,
+        capabilities=tuple(capabilities),
+        context={
+            "completed_phases": completed_phases,
+            "failed_phase": failed_phase,
+            "classification": packet.get("classification"),
+            "delivery_outcome": packet.get("delivery_outcome"),
+        },
+    )
+    interpretation = EffectInterpretation(
+        route="turn_result_settlement",
+        obligation="settle_turn_receipt",
+        interaction_mode="host_result",
+        cadence_class=str(scheduler.get("cadence_class") or None) or None,
+    )
+    observation = EffectObservation(
+        decision=result_kind,
+        should_run=False,
+        effective_action=str(packet.get("effective_action") or result_kind),
+        recommended_action=(
+            str(packet.get("recommended_action") or "")
+            or "settle the turn receipt"
+        ),
+        protocol_summary=(
+            str(packet.get("summary")) if packet.get("summary") else None
+        ),
+    )
+    next_effect = EffectNext(
+        cli_actions=tuple(
+            str(action)
+            for action in packet.get("next_cli_actions", [])
+            if str(action).strip()
+        ),
+        scheduler_action=str(scheduler.get("action") or None) or None,
+        cadence_class=str(scheduler.get("cadence_class") or None) or None,
+        ack_cli_args=tuple(
+            str(arg)
+            for arg in ack_hint.get("cli_args", [])
+            if str(arg).strip()
+        ),
+        failure_cli_args=tuple(
+            str(arg)
+            for arg in failure_hint.get("cli_args", [])
+            if str(arg).strip()
+        ),
+    )
+    return EffectTurn(
+        request=request,
+        interpretation=interpretation,
+        observation=observation,
+        next_effect=next_effect,
+    )

--- a/tests/control_plane/test_effect_turn_turn_result.py
+++ b/tests/control_plane/test_effect_turn_turn_result.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from loopx.control_plane.effect_program import interpret_turn_result_packet
+
+GOAL_ID = "effect-interpreter-fixture"
+
+
+def _result_packet(
+    *,
+    result_kind: str,
+    failed_phase: str | None = None,
+) -> dict:
+    packet: dict = {
+        "schema_version": "loopx_turn_result_v0",
+        "turn_key": "sha256:fixture",
+        "result_kind": result_kind,
+        "completed_phases": ["host_execute", "typed_result"],
+        "classification": "fixture_progress",
+        "recommended_action": "Continue the public fixture.",
+        "delivery_outcome": "outcome_progress",
+        "summary": "One public fixture advanced.",
+        "next_cli_actions": [
+            "loopx refresh-state --goal-id effect-interpreter-fixture"
+        ],
+    }
+    if failed_phase:
+        packet["failed_phase"] = failed_phase
+    return packet
+
+
+def test_turn_result_packet_maps_to_effect_turn() -> None:
+    turn = interpret_turn_result_packet(
+        _result_packet(result_kind="validated_progress"),
+        goal_id=GOAL_ID,
+        agent_id="codex-fixture",
+    )
+
+    assert turn.request.kind == "turn_result"
+    assert turn.request.source == "host"
+    assert turn.request.goal_id == GOAL_ID
+    assert turn.request.agent_id == "codex-fixture"
+    assert turn.request.context["completed_phases"] == (
+        "host_execute",
+        "typed_result",
+    )
+    assert turn.interpretation.route == "turn_result_settlement"
+    assert turn.interpretation.obligation == "settle_turn_receipt"
+    assert turn.observation.decision == "validated_progress"
+    assert turn.observation.should_run is False
+    assert turn.observation.recommended_action == "Continue the public fixture."
+    assert turn.next_effect.cli_actions == (
+        "loopx refresh-state --goal-id effect-interpreter-fixture",
+    )
+
+
+def test_turn_result_failure_preserves_failed_phase() -> None:
+    packet = _result_packet(
+        result_kind="host_failure",
+        failed_phase="host_execute",
+    )
+    packet["scheduler_hint"] = {
+        "action": "failure_settle",
+        "cadence_class": "repair",
+        "codex_app": {
+            "failure_hint": {
+                "cli_args": [
+                    "quota",
+                    "scheduler-ack-current",
+                    "--failure",
+                    "--execute",
+                ]
+            }
+        },
+    }
+    turn = interpret_turn_result_packet(packet, goal_id=GOAL_ID)
+
+    assert turn.request.context["failed_phase"] == "host_execute"
+    assert turn.observation.decision == "host_failure"
+    assert turn.observation.should_run is False
+    assert turn.next_effect.scheduler_action == "failure_settle"
+    assert turn.next_effect.cadence_class == "repair"
+    assert turn.next_effect.failure_cli_args == (
+        "quota",
+        "scheduler-ack-current",
+        "--failure",
+        "--execute",
+    )


### PR DESCRIPTION
## Summary

M6 first step: add the second real effect interpreter.

- Add `interpret_turn_result_packet` to `effect_program.py`, mapping
  `loopx_turn_result_v0` onto `EffectTurn`.
- Preserve `completed_phases`, `failed_phase`, classification, delivery
  outcome, recommended action, CLI actions, and ACK/failure hints in the
  canonical slots.
- Add focused tests for progress and failure result packets.
- Update the packet reference to document both interpreters as read-only
  lenses.

No runtime behavior changes.

## Validation

- `python -m pytest tests/control_plane/test_effect_turn_turn_result.py
  tests/control_plane/test_effect_interpreter_packet.py`: 6 passed.
- `ruff check --select E,F`: passed.
- `loopx canary premerge --from-git-diff`: passed, `self_merge_allowed=true`,
  0 manual holds.
- Public boundary scan: passed.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`
