### PR TITLE
feat(control-plane): add effect execution mode

### DIFF
--- a/docs/reference/effect-interpreter-packet.md
+++ b/docs/reference/effect-interpreter-packet.md
@@ -69,6 +69,7 @@ The observation points back into the loop:
 | Packet field | Role |
 |---|---|
 | `interaction_contract.cli_channel.next_cli_actions` | Next CLI effects |
+| `execution_mode` | Execution strategy (`serial` / `parallel` / `interleaved`) for an ordered effect program |
 | `scheduler_hint.action` | Scheduler around decision |
 | `scheduler_hint.cadence_class` | Cadence for the next host wake |
 | `scheduler_hint.codex_app.ack_hint.cli_args` | Host ACK effect |
@@ -77,7 +78,9 @@ The observation points back into the loop:
 `EffectTurn.next_effect` is the code lens for this slot. It keeps the
 data-encoded handler visible: the host invokes the CLI actions and settles
 success or failure through the ACK/failure hints instead of LoopX holding a
-callable across turns.
+callable across turns. `execution_mode` is the data-encoded strategy when the
+next effect is an ordered effect program; it defaults to `None` when the
+packet does not declare one.
 
 ## Around Semantics
 

--- a/loopx/control_plane/effect_program.py
+++ b/loopx/control_plane/effect_program.py
@@ -36,6 +36,7 @@ class EffectObservation:
 @dataclass(frozen=True)
 class EffectNext:
     cli_actions: tuple[str, ...] = ()
+    execution_mode: str | None = None
     scheduler_action: str | None = None
     cadence_class: str | None = None
     ack_cli_args: tuple[str, ...] = ()
@@ -103,6 +104,15 @@ def interpret_quota_should_run_packet(
             str(action)
             for action in cli_channel.get("next_cli_actions", [])
             if str(action).strip()
+        ),
+        execution_mode=(
+            str(
+                packet.get("execution_mode")
+                or codex_app.get("execution_mode")
+                or scheduler.get("execution_mode")
+                or None
+            )
+            or None
         ),
         scheduler_action=str(scheduler.get("action") or None) or None,
         cadence_class=str(scheduler.get("cadence_class") or None) or None,
@@ -182,6 +192,15 @@ def interpret_turn_result_packet(
             str(action)
             for action in packet.get("next_cli_actions", [])
             if str(action).strip()
+        ),
+        execution_mode=(
+            str(
+                packet.get("execution_mode")
+                or codex_app.get("execution_mode")
+                or scheduler.get("execution_mode")
+                or None
+            )
+            or None
         ),
         scheduler_action=str(scheduler.get("action") or None) or None,
         cadence_class=str(scheduler.get("cadence_class") or None) or None,

--- a/tests/control_plane/test_effect_interpreter_packet.py
+++ b/tests/control_plane/test_effect_interpreter_packet.py
@@ -148,6 +148,7 @@ def test_effect_turn_carries_scheduler_ack_and_failure_hints() -> None:
     packet = {
         "decision": "run",
         "should_run": True,
+        "execution_mode": "interleaved",
         "effective_action": "normal_run",
         "recommended_action": "advance the bounded segment",
         "interaction_contract": {
@@ -200,6 +201,7 @@ def test_effect_turn_carries_scheduler_ack_and_failure_hints() -> None:
         "loopx refresh-state --goal-id effect-interpreter-fixture",
         "loopx quota spend-slot --goal-id effect-interpreter-fixture",
     )
+    assert turn.next_effect.execution_mode == "interleaved"
     assert turn.next_effect.scheduler_action == "apply_rrule"
     assert turn.next_effect.cadence_class == "active_work"
     assert turn.next_effect.ack_cli_args == (

--- a/tests/control_plane/test_effect_turn_turn_result.py
+++ b/tests/control_plane/test_effect_turn_turn_result.py
@@ -14,6 +14,7 @@ def _result_packet(
         "schema_version": "loopx_turn_result_v0",
         "turn_key": "sha256:fixture",
         "result_kind": result_kind,
+        "execution_mode": "serial",
         "completed_phases": ["host_execute", "typed_result"],
         "classification": "fixture_progress",
         "recommended_action": "Continue the public fixture.",
@@ -51,6 +52,7 @@ def test_turn_result_packet_maps_to_effect_turn() -> None:
     assert turn.next_effect.cli_actions == (
         "loopx refresh-state --goal-id effect-interpreter-fixture",
     )
+    assert turn.next_effect.execution_mode == "serial"
 
 
 def test_turn_result_failure_preserves_failed_phase() -> None:


### PR DESCRIPTION
## Summary

M6 second step: data-encode execution strategy.

- Add `execution_mode` to `EffectNext` with `serial` / `parallel` /
  `interleaved` semantics.
- Both existing interpreters read `execution_mode` from the packet or
  scheduler detail when present.
- Add focused assertions for quota and turn-result packets.
- Document the field in the packet reference.

No runtime behavior changes.

## Validation

- `python -m pytest tests/control_plane/test_effect_interpreter_packet.py
  tests/control_plane/test_effect_turn_turn_result.py
  tests/control_plane/test_effect_turn_work_lane_routing.py`: 7 passed.
- `ruff check --select E,F`: passed.
- `docs-governance-smoke`: passed.
- `loopx canary premerge --from-git-diff`: passed, `self_merge_allowed=true`,
  0 manual holds.
- Public boundary scan: passed.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`
