### PR TITLE
docs(skill): require bilingual PR review format

### DIFF
--- a/docs/reference/protocols/pr-review-command-v0.md
+++ b/docs/reference/protocols/pr-review-command-v0.md
@@ -184,6 +184,12 @@ starts with `/loopx-pr-review`, words such as `open`, `closed`, `merged`,
 skip the review. Downgrade only for explicit opt-out phrases such as `只统计`,
 `只列出`, `stats only`, `list only`, `不要 review`, or `不用分析`.
 
+The published review is bilingual: one detailed Chinese five-block review plus
+one concise English machine verdict (`APPROVE`, `REQUEST_CHANGES`, or the
+author-owned `COMMENTED` fallback). The Chinese review carries the depth and
+evidence; the English verdict carries the machine-readable state and validation
+summary.
+
 ## Source Reads
 
 Implementations may read compact public PR surfaces:

--- a/examples/pr-review-command-smoke.py
+++ b/examples/pr-review-command-smoke.py
@@ -64,6 +64,10 @@ def main() -> int:
         "formal `REQUEST_CHANGES`",
         "Read the published review back",
         "Route approval, merge, self-merge, and admin bypass to `loopx-pr-merge`",
+        "Bilingual Review Format",
+        "详细中文评审",
+        "英文简短结论",
+        "one detailed Chinese five-block review plus one concise English verdict",
     ):
         assert phrase in skill_text, phrase
     assert len(skill_source.splitlines()) <= 140, len(skill_source.splitlines())

--- a/skills/loopx-pr-review/SKILL.md
+++ b/skills/loopx-pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: loopx-pr-review
-description: Use for `/loopx-pr-review` or evidence-backed PR queue review. Run `loopx pr-review` first, execute the capability-owned review plan for each selected exact head, then publish a review state that matches the verified findings. Use `loopx-pr-merge` for approval or merge actions.
+description: Use for `/loopx-pr-review` or evidence-backed PR queue review. Run `loopx pr-review` first, execute the capability-owned review plan for each selected exact head, then publish bilingual reviews (detailed Chinese plus concise English) that match the verified findings. Use `loopx-pr-merge` for approval or merge actions.
 ---
 
 # LoopX PR Review
@@ -94,6 +94,25 @@ context, raw logs, credentials, and internal-only links. Read the published
 review back, verify its state and rendered body, and return its URL. Merge
 still routes through `loopx-pr-merge`; an `APPROVE` is not merge authority.
 Do not leave a public blocker only in chat.
+
+## Bilingual Review Format
+
+For every selected PR, publish two public artifacts:
+
+1. **详细中文评审** - the five-block review as a standalone Chinese
+   review/comment, starting with `### Review: <结论>` or `### 结论：...`,
+   including the exact reviewed head. This is the detail carrier: motivation,
+   approach, concrete changes, main risk, and overall judgment stay in Chinese
+   with repo-relative evidence.
+2. **英文简短结论** - a concise English machine verdict (`APPROVE`,
+   `REQUEST_CHANGES`, or the author-owned `COMMENTED` fallback) stating the
+   exact head, verdict, key finding, and validation.
+
+Produce bilingual reviews: one detailed Chinese five-block review plus one
+concise English verdict. This is required even when this skill only produces
+the read-only review and a later `loopx-pr-merge` action publishes the GitHub
+verdict. Do not replace the Chinese detail with an English-only body. Read both
+published artifacts back.
 
 ## Autonomous Queue
 

--- a/skills/loopx-pr-review/agents/openai.yaml
+++ b/skills/loopx-pr-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "LoopX PR Review"
   short_description: "Review LoopX PRs with deep key-code explanations"
-  default_prompt: "Use $loopx-pr-review to review the selected PRs with exact-head evidence, detailed key-code execution explanations, risk analysis, validation, and the required five-block verdict."
+  default_prompt: "Use $loopx-pr-review to review the selected PRs with exact-head evidence, detailed key-code execution explanations, risk analysis, validation, and bilingual reviews: one detailed Chinese five-block review plus one concise English verdict."


### PR DESCRIPTION
## Summary

Root-cause fix for PR reviews drifting to English-only bodies. The `loopx-pr-review` skill and `pr_review_command_v0` protocol now require two public artifacts per reviewed PR:

1. Detailed Chinese five-block review (`动机 / 改动思路 / 具体改动 / 对主干的风险 / 我的整体评价`).
2. Concise English machine verdict (`APPROVE`, `REQUEST_CHANGES`, or author-owned `COMMENTED` fallback).

This matches the established format in #2880 and prevents future review comments from replacing the Chinese detail with an English-only verdict.

## Validation

- `examples/pr-review-command-smoke.py`: passed, with new skill-contract assertions.
- `examples/docs-governance-smoke.py`: passed.
- `loopx canary premerge --from-git-diff --tier standard --no-progress`: passed, `self_merge_allowed=true`, 0 failures, 0 manual holds.
- `git diff --check`: passed.

No runtime behavior changed.