### PR TITLE
test(docs): guard m6 effect abstraction docs

### DIFF
--- a/examples/docs-governance-smoke.py
+++ b/examples/docs-governance-smoke.py
@@ -134,6 +134,8 @@ def assert_effect_interpreter_docs_are_canonical() -> None:
         "EffectNext",
         "EffectTurn",
         "Around Semantics",
+        "execution_mode",
+        "interpret_turn_result_packet",
     ):
         assert required in packet_doc, required
 
@@ -141,6 +143,8 @@ def assert_effect_interpreter_docs_are_canonical() -> None:
     for required in (
         "Composition And Around Semantics",
         "Handler Is Data, Not a Callable",
+        "General Effect-Program Abstraction",
+        "M6: General Effect-Program Abstraction",
         "Milestone Status",
     ):
         assert required in rfc, required
@@ -152,6 +156,7 @@ def assert_effect_interpreter_docs_are_canonical() -> None:
         read("docs/development/control-plane-course/01-agent-loop-effectful-program.md")
     )
     assert "Around 是数据，不是回调" in lecture
+    assert "CLI 是更高密度的 effect" in lecture
     for fragment in public_lecture_url_fragments:
         assert fragment in rfc, fragment
         assert fragment in lecture, fragment


### PR DESCRIPTION
## Summary

Guard M6 effect-abstraction docs in docs-governance-smoke.

- Require `execution_mode` and `interpret_turn_result_packet` in the packet
  reference.
- Require `General Effect-Program Abstraction` and M6 in the RFC.
- Require the Chinese CLI-density section in Lecture 1.

No runtime behavior changes.

## Validation

- `docs-governance-smoke`: passed.
- `python -m py_compile examples/docs-governance-smoke.py`: passed.
- `loopx canary premerge --from-git-diff`: passed, `self_merge_allowed=true`,
  0 manual holds.
- Public boundary scan: passed.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`
