### PR TITLE
docs(skill): require full-PR bilingual review coverage

### DIFF
--- a/docs/reference/protocols/pr-review-command-v0.md
+++ b/docs/reference/protocols/pr-review-command-v0.md
@@ -184,11 +184,13 @@ starts with `/loopx-pr-review`, words such as `open`, `closed`, `merged`,
 skip the review. Downgrade only for explicit opt-out phrases such as `只统计`,
 `只列出`, `stats only`, `list only`, `不要 review`, or `不用分析`.
 
-The published review is bilingual: one detailed Chinese five-block review plus
-one concise English machine verdict (`APPROVE`, `REQUEST_CHANGES`, or the
-author-owned `COMMENTED` fallback). The Chinese review carries the depth and
-evidence; the English verdict carries the machine-readable state and validation
-summary.
+The published review is a full-PR bilingual review: one complete Chinese
+five-block review covering every changed surface, key symbol, positive and
+negative path, and validation, plus one concise English machine verdict
+(`APPROVE`, `REQUEST_CHANGES`, or the author-owned `COMMENTED` fallback). The
+Chinese review carries the depth and evidence; the English verdict carries the
+machine-readable state and validation summary. A findings-only or blocker-only
+body is not a complete PR review.
 
 ## Source Reads
 

--- a/examples/pr-review-command-smoke.py
+++ b/examples/pr-review-command-smoke.py
@@ -64,10 +64,12 @@ def main() -> int:
         "formal `REQUEST_CHANGES`",
         "Read the published review back",
         "Route approval, merge, self-merge, and admin bypass to `loopx-pr-merge`",
-        "Bilingual Review Format",
+        "Full PR Review And Bilingual Format",
+        "findings-only or blocker-only body is incomplete",
+        "Cover every changed surface and key symbols",
         "详细中文评审",
         "英文简短结论",
-        "one detailed Chinese five-block review plus one concise English verdict",
+        "complete Chinese five-block review plus one concise English verdict",
     ):
         assert phrase in skill_text, phrase
     assert len(skill_source.splitlines()) <= 140, len(skill_source.splitlines())

--- a/skills/loopx-pr-review/SKILL.md
+++ b/skills/loopx-pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: loopx-pr-review
-description: Use for `/loopx-pr-review` or evidence-backed PR queue review. Run `loopx pr-review` first, execute the capability-owned review plan for each selected exact head, then publish bilingual reviews (detailed Chinese plus concise English) that match the verified findings. Use `loopx-pr-merge` for approval or merge actions.
+description: Use for `/loopx-pr-review` or evidence-backed PR queue review. Run `loopx pr-review` first, execute the capability-owned review plan for each selected exact head, then publish full bilingual PR reviews (complete Chinese five-block review plus one concise English verdict) that match the verified findings. Use `loopx-pr-merge` for approval or merge actions.
 ---
 
 # LoopX PR Review
@@ -95,24 +95,25 @@ review back, verify its state and rendered body, and return its URL. Merge
 still routes through `loopx-pr-merge`; an `APPROVE` is not merge authority.
 Do not leave a public blocker only in chat.
 
-## Bilingual Review Format
+## Full PR Review And Bilingual Format
 
-For every selected PR, publish two public artifacts:
+Every review must cover the whole PR, not only the top finding. Read the full
+diff/checks, then explain motivation, architecture, changed files/symbols,
+positive and negative paths, risk across the whole diff, validation, and
+overall judgment. A findings-only or blocker-only body is incomplete.
 
-1. **详细中文评审** - the five-block review as a standalone Chinese
-   review/comment, starting with `### Review: <结论>` or `### 结论：...`,
-   including the exact reviewed head. This is the detail carrier: motivation,
-   approach, concrete changes, main risk, and overall judgment stay in Chinese
-   with repo-relative evidence.
-2. **英文简短结论** - a concise English machine verdict (`APPROVE`,
-   `REQUEST_CHANGES`, or the author-owned `COMMENTED` fallback) stating the
-   exact head, verdict, key finding, and validation.
+Publish two artifacts:
 
-Produce bilingual reviews: one detailed Chinese five-block review plus one
-concise English verdict. This is required even when this skill only produces
-the read-only review and a later `loopx-pr-merge` action publishes the GitHub
-verdict. Do not replace the Chinese detail with an English-only body. Read both
-published artifacts back.
+1. **详细中文评审** - a standalone Chinese full-PR review with the exact head
+   and five sections: `动机`, `改动思路`, `具体改动`, `对主干的风险`,
+   `我的整体评价`. Cover every changed surface and key symbols, not just the
+   main finding.
+2. **英文简短结论** - a concise English verdict (`APPROVE`,
+   `REQUEST_CHANGES`, or the author-owned `COMMENTED` fallback) with exact
+   head, verdict, key finding, and validation.
+
+Do not publish before the Chinese section covers the entire PR. Read both
+artifacts back.
 
 ## Autonomous Queue
 

--- a/skills/loopx-pr-review/agents/openai.yaml
+++ b/skills/loopx-pr-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "LoopX PR Review"
   short_description: "Review LoopX PRs with deep key-code explanations"
-  default_prompt: "Use $loopx-pr-review to review the selected PRs with exact-head evidence, detailed key-code execution explanations, risk analysis, validation, and bilingual reviews: one detailed Chinese five-block review plus one concise English verdict."
+  default_prompt: "Use $loopx-pr-review to review the entire PR with exact-head evidence, full changed-file/symbol coverage, detailed key-code execution explanations, risk analysis, validation, and bilingual reviews: one complete Chinese five-block review plus one concise English verdict."


### PR DESCRIPTION
## Summary

Follow-up to #2941. The bilingual format existed, but reviews could still be findings-only or blocker-only. This change makes the contract explicit:

- Every PR review must be a whole-PR review covering every changed surface, key symbols, positive and negative paths, validation, and overall judgment.
- The Chinese detailed review must be a complete five-block review, not a single-point finding.
- The English verdict remains concise but must not replace the full Chinese review.

## Validation

- `examples/pr-review-command-smoke.py`: passed with new full-PR contract assertions.
- `examples/docs-governance-smoke.py`: passed.
- `loopx canary premerge --from-git-diff --tier standard --no-progress`: passed, `self_merge_allowed=true`, 0 failures, 0 manual holds.
- `git diff --check`: passed.