### PR TITLE
feat(control-plane): add ordered effect program shape

### DIFF
--- a/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
+++ b/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
@@ -262,6 +262,8 @@ parallel and equally important:
 - `interpret_turn_result_packet` as the second real interpreter.
 - `EffectNext.execution_mode` for `serial`, `parallel`, and `interleaved`
   execution strategy.
+- `EffectProgram` and `effect_program_from_ordered_steps` as a read-only shape
+  over existing `guided_transaction.ordered_steps`.
 - around semantics encoded in `capability_gate`, `interaction_contract`,
   `work_lane_contract`, and `scheduler_hint`.
 - focused tests and docs that pin the lens.
@@ -270,8 +272,6 @@ parallel and equally important:
 
 - A minimal interpreter protocol or composition helper used by runtime code,
   not only by tests.
-- A data-encoded ordered effect program shape that turns `cli_actions` into
-  executable steps.
 - A real host or turn-driver caller that executes an ordered effect program
   while preserving failure, cancellation, permission, and budget semantics.
 

--- a/docs/reference/effect-interpreter-packet.md
+++ b/docs/reference/effect-interpreter-packet.md
@@ -105,6 +105,17 @@ can carry permission, budget, validation, execution, failure semantics, ACK,
 and writeback. Vendor serial or interleaved tool APIs are execution modes
 inside the interpreter, not new state machines.
 
+## Ordered Effect Program
+
+`loopx.control_plane.effect_program.effect_program_from_ordered_steps` maps an
+existing `guided_transaction.ordered_steps` value onto `EffectProgram`:
+
+- `EffectStep` keeps `step_id`, `kind`, `command`, and `purpose`;
+- `EffectProgram` keeps ordered steps and an optional `execution_mode`.
+
+This is still a read-only lens. The executor remains host-driven until a
+LoopX runtime caller owns multi-step execution.
+
 ## Relationship To State Machines
 
 Each state family is an interpretation table over this lens:

--- a/loopx/control_plane/effect_program.py
+++ b/loopx/control_plane/effect_program.py
@@ -51,8 +51,55 @@ class EffectTurn:
     next_effect: EffectNext
 
 
+@dataclass(frozen=True)
+class EffectStep:
+    step_id: str | None = None
+    kind: str | None = None
+    command: str | None = None
+    purpose: str | None = None
+
+
+@dataclass(frozen=True)
+class EffectProgram:
+    steps: tuple[EffectStep, ...] = ()
+    execution_mode: str | None = None
+
+
 def _mapping(value: Any) -> Mapping[str, Any]:
     return value if isinstance(value, Mapping) else {}
+
+
+def effect_program_from_ordered_steps(
+    ordered_steps: Sequence[Mapping[str, Any]],
+    *,
+    execution_mode: str | None = None,
+) -> EffectProgram:
+    """Map existing `guided_transaction.ordered_steps` onto an effect program."""
+
+    steps: list[EffectStep] = []
+    for step in ordered_steps:
+        if not isinstance(step, Mapping):
+            continue
+        steps.append(
+            EffectStep(
+                step_id=str(step.get("id") or "") or None,
+                kind=str(step.get("kind") or "") or None,
+                command=(
+                    str(
+                        step.get("command")
+                        or step.get("command_template")
+                        or step.get("prompt")
+                        or ""
+                    )
+                    or None
+                ),
+                purpose=str(step.get("purpose") or "") or None,
+            )
+        )
+    return EffectProgram(
+        steps=tuple(steps),
+        execution_mode=str(execution_mode or "") or None,
+    )
 
 
 def interpret_quota_should_run_packet(

--- a/tests/control_plane/test_effect_program_ordered_steps.py
+++ b/tests/control_plane/test_effect_program_ordered_steps.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from loopx.control_plane.effect_program import effect_program_from_ordered_steps
+
+
+def test_ordered_steps_map_to_effect_program() -> None:
+    steps = [
+        {
+            "id": "select_host_surface",
+            "kind": "host_surface_selection_gate",
+            "purpose": "select the current host before mutation",
+        },
+        {
+            "id": "bootstrap_goal",
+            "kind": "bootstrap",
+            "command": "loopx start-goal --guided",
+            "purpose": "connect the goal before planning",
+        },
+        {
+            "id": "add_todo",
+            "kind": "todo_add",
+            "command_template": "loopx todo add --goal-id loopx-meta",
+            "purpose": "record the first bounded business todo",
+        },
+    ]
+
+    program = effect_program_from_ordered_steps(
+        steps,
+        execution_mode="serial",
+    )
+
+    assert program.execution_mode == "serial"
+    assert len(program.steps) == 3
+    assert program.steps[0].step_id == "select_host_surface"
+    assert program.steps[0].kind == "host_surface_selection_gate"
+    assert program.steps[1].command == "loopx start-goal --guided"
+    assert program.steps[2].command == "loopx todo add --goal-id loopx-meta"
+    assert program.steps[2].purpose == "record the first bounded business todo"
+
+
+def test_ordered_steps_ignore_non_mapping_entries() -> None:
+    program = effect_program_from_ordered_steps(
+        [
+            "not-a-step",
+            {"id": "step-a", "kind": "bootstrap"},
+        ]
+    )
+
+    assert len(program.steps) == 1
+    assert program.steps[0].step_id == "step-a"
+    assert program.steps[0].command is None


### PR DESCRIPTION
## Summary

M6 ordered effect program shape over a real existing structure.

- Add `EffectStep` and `EffectProgram` to `effect_program.py`.
- Add `effect_program_from_ordered_steps` mapping existing
  `guided_transaction.ordered_steps` onto the shape.
- Add focused tests and update RFC/packet-reference inventories.

The executor remains host-driven; this PR does not add a runtime executor
before a LoopX caller owns multi-step execution.

No runtime behavior changes.

## Validation

- `python -m pytest tests/control_plane/test_effect_program_ordered_steps.py
  tests/control_plane/test_effect_interpreter_packet.py
  tests/control_plane/test_effect_turn_turn_result.py`: 8 passed.
- `ruff check --select E,F`: passed.
- `docs-governance-smoke`: passed.
- `loopx canary premerge --from-git-diff`: passed, `self_merge_allowed=true`,
  0 manual holds.
- Public boundary scan: passed.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`
