### PR TITLE
docs(skill): require full-PR interpretation depth

### DIFF
--- a/docs/reference/protocols/pr-review-command-v0.md
+++ b/docs/reference/protocols/pr-review-command-v0.md
@@ -192,6 +192,11 @@ Chinese review carries the depth and evidence; the English verdict carries the
 machine-readable state and validation summary. A findings-only or blocker-only
 body is not a complete PR review.
 
+Each complete PR review must also include whole-PR interpretation depth:
+per-file responsibility mapping, 2-5 key symbol explanations with exact-head
+references, one positive runtime walkthrough, one negative/fail-closed
+walkthrough, per-surface validation, and an overall judgment for the entire PR.
+
 ## Source Reads
 
 Implementations may read compact public PR surfaces:

--- a/examples/pr-review-command-smoke.py
+++ b/examples/pr-review-command-smoke.py
@@ -70,9 +70,13 @@ def main() -> int:
         "详细中文评审",
         "英文简短结论",
         "complete Chinese five-block review plus one concise English verdict",
+        "Full PR Interpretation Depth",
+        "Walk one positive path",
+        "Walk one negative path",
+        "omits whole files/modules is incomplete",
     ):
         assert phrase in skill_text, phrase
-    assert len(skill_source.splitlines()) <= 140, len(skill_source.splitlines())
+    assert len(skill_source.splitlines()) <= 180, len(skill_source.splitlines())
     for duplicated_contract_heading in (
         "Per-PR Evidence And Depth Gate",
         "Motivation Causal Chain",

--- a/skills/loopx-pr-review/SKILL.md
+++ b/skills/loopx-pr-review/SKILL.md
@@ -115,6 +115,26 @@ Publish two artifacts:
 Do not publish before the Chinese section covers the entire PR. Read both
 artifacts back.
 
+## Full PR Interpretation Depth
+
+A complete review is a whole-PR interpretation, not a checklist or findings
+summary. For each selected PR:
+
+1. Read every changed file and map each file to its responsibility, inputs,
+   outputs, and key symbols.
+2. Pick 2-5 behavior-bearing symbols and explain before/after behavior,
+   critical branches, callers/callees, side effects, and failure paths.
+3. Walk one positive path from user/host action to observable result.
+4. Walk one negative path (invalid input, permission, timeout, corrupt state,
+   private boundary, or rollback) and show where it fails closed.
+5. Cover all changed surfaces in the five sections: motivation, approach,
+   concrete changes, main risk, overall judgment.
+6. List validation per surface and name anything not independently verified.
+7. State overall judgment for the entire PR, not only for the top finding.
+
+A review that only repeats the PR body, only discusses one blocker, or omits
+whole files/modules is incomplete and must be reworked.
+
 ## Autonomous Queue
 
 For recurring observation, use the same capability:

--- a/skills/loopx-pr-review/agents/openai.yaml
+++ b/skills/loopx-pr-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "LoopX PR Review"
   short_description: "Review LoopX PRs with deep key-code explanations"
-  default_prompt: "Use $loopx-pr-review to review the entire PR with exact-head evidence, full changed-file/symbol coverage, detailed key-code execution explanations, risk analysis, validation, and bilingual reviews: one complete Chinese five-block review plus one concise English verdict."
+  default_prompt: "Use $loopx-pr-review to interpret the entire PR: read every changed file, explain key symbols and control/data flow, walk positive and negative paths, cover all surfaces in the Chinese five-block review, and append one concise English verdict."


### PR DESCRIPTION
## Summary

Follow-up to #2944. The full-PR review requirement existed, but reviews could still be surface summaries rather than whole-PR interpretations. This change makes the depth explicit:

- Read every changed file and map it to responsibility, inputs, outputs, and key symbols.
- Explain 2-5 behavior-bearing symbols with exact-head references.
- Walk one positive path and one negative/fail-closed path.
- Cover all surfaces in the Chinese five-block review.
- List validation per surface and state overall judgment for the entire PR.
- A review that only repeats the PR body, only discusses one blocker, or omits whole files/modules is incomplete.

## Validation

- `examples/pr-review-command-smoke.py`: passed with new interpretation-depth assertions.
- `examples/docs-governance-smoke.py`: passed.
- Skill file remains bounded at 158 lines (new smoke limit 180).
- `git diff --check`: passed.