### PR TITLE
docs(rfc): recommend bootstrap as first effect executor

### DIFF
--- a/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
+++ b/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
@@ -472,6 +472,9 @@ Steps:
    `serial` / `parallel` / `interleaved` semantics with focused tests.
 4. Introduce a data-encoded ordered effect program shape and a real executor
    seam when a host or turn-driver caller can execute multiple steps.
+   The first executor candidate is the guided bootstrap transaction, because
+   `guided_transaction.ordered_steps` already form a real ordered effect
+   program consumed by hosts; the turn driver can later reuse the same shape.
 5. Keep failure, cancellation, permission, and budget semantics structured
    across every interpreter. No catch-all wrapper.
 
@@ -535,8 +538,8 @@ Large smokes remain only as thin end-to-end checks.
   turn result, status, or monitor poll?
 - At what point should `next_effect` stop being a flat CLI tuple and become an
   ordered effect program with `execution_mode`?
-- Which runtime path should become the first ordered-effect executor: guided
-  bootstrap transaction, turn driver, or Codex CLI scheduler?
+- Confirm the guided bootstrap transaction as the first ordered-effect
+  executor path; the turn driver can reuse the same shape later.
 - When should `EffectProgram` become runtime-owned rather than host-driven?
 
 ## Success Metrics


### PR DESCRIPTION
## Summary

Recommend the first ordered-effect executor path in the RFC.

- M6 now names the guided bootstrap transaction as the first executor
  candidate because `guided_transaction.ordered_steps` already form a real
  ordered effect program consumed by hosts.
- Open question updated to confirm that path, with turn driver reusing the
  same shape later.

No runtime behavior changes.

## Validation

- `docs-governance-smoke`: passed.
- `loopx canary premerge --from-git-diff`: passed, `self_merge_allowed=true`,
  0 manual holds.
- Public boundary scan: passed.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`
