### PR TITLE
test(control-plane): map real bootstrap ordered steps to effect program

### DIFF
--- a/tests/control_plane/test_effect_program_ordered_steps.py
+++ b/tests/control_plane/test_effect_program_ordered_steps.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
+from loopx.bootstrap_command_pack import build_start_goal_guided_packet
 from loopx.control_plane.effect_program import effect_program_from_ordered_steps
 
 
@@ -49,3 +53,58 @@ def test_ordered_steps_ignore_non_mapping_entries() -> None:
     assert len(program.steps) == 1
     assert program.steps[0].step_id == "step-a"
     assert program.steps[0].command is None
+
+
+def test_real_bootstrap_ordered_steps_map_to_effect_program(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    state_file = (
+        project / ".codex" / "goals" / "guided-program-goal" / "ACTIVE_GOAL_STATE.md"
+    )
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text("# Active Goal State\n", encoding="utf-8")
+    registry = project / ".loopx" / "registry.json"
+    registry.parent.mkdir(parents=True)
+    registry.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "goals": [
+                    {
+                        "id": "guided-program-goal",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": str(state_file.relative_to(project)),
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": ["codex-guided-program"],
+                        },
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    payload = build_start_goal_guided_packet(
+        project=project,
+        goal_id="guided-program-goal",
+        agent_id="codex-guided-program",
+        cli_bin="loopx",
+        host_surface="codex-app",
+        goal_text="Ship a bounded public issue triage workflow.",
+        available_capabilities=["network"],
+        include_command_pack_detail=False,
+    )
+    transaction = payload["guided_transaction"]
+    program = effect_program_from_ordered_steps(
+        transaction["ordered_steps"],
+        execution_mode="serial",
+    )
+
+    assert program.execution_mode == "serial"
+    assert program.steps
+    assert program.steps[0].step_id == "inspect_connection"
+    assert program.steps[0].kind == "read_only"


### PR DESCRIPTION
## Summary

M6 integration test: real bootstrap ordered steps into `EffectProgram`.

- Add a test that calls `build_start_goal_guided_packet` on a minimal
  project registry and maps its real `guided_transaction.ordered_steps` to
  `EffectProgram`.
- Proves the ordered effect program shape consumes the existing bootstrap
  producer output, not only synthetic fixtures.

No runtime behavior changes.

## Validation

- `python -m pytest tests/control_plane/test_effect_program_ordered_steps.py`:
  3 passed.
- `ruff check --select E,F`: passed.
- `loopx canary premerge --from-git-diff`: passed, `self_merge_allowed=true`,
  0 manual holds.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`
