### PR TITLE
docs(book): add control plane course chapter and refresh course links

### DIFF
--- a/docs/book/chapters/00-reading-guide.md
+++ b/docs/book/chapters/00-reading-guide.md
@@ -37,25 +37,28 @@ LoopX Kernel 源码，也不需要理解所有 CLI 子命令。
 
 二者共享官方协议与源码事实，但不维护两份完整课程。Dev Book 会把预测行为所需的机制讲完整；
 当你需要判断规则优先级、定位具体 bounded context 或修改实现时，再沿章节末尾的入口进入课程。
+准备深入 Kernel 的开发者也可以直接进入
+[Control-Plane Course 独立章节](./12-control-plane-course.md)。
 
 - **多个短 Session 怎样组成长程任务？** 先读第 1、2 章，再下钻
-  [概念导读](/loopx/docs/development/control-plane-course/00-concept-primer/)与
-  [第 0 讲](/loopx/docs/development/control-plane-course/00-goal-control-plane-architecture/)，
-  再用[第 1 讲](/loopx/docs/development/control-plane-course/01-first-real-loop/)走一遍真实 Loop。
+  [概念导读](/loopx/docs/development/control-plane-course/00-concept-primer/)、
+  [第 1 讲：Harness 是 effectful program](/loopx/docs/development/control-plane-course/01-agent-loop-effectful-program/)与
+  [第 2 讲](/loopx/docs/development/control-plane-course/02-goal-control-plane-architecture/)，
+  再用[第 3 讲](/loopx/docs/development/control-plane-course/03-first-real-loop/)走一遍真实 Loop。
 - **状态、工作图与权限分别由谁拥有？** 先读第 3、4 章，再下钻
-  [第 2 讲](/loopx/docs/development/control-plane-course/02-state-substrate/)与
-  [第 3 讲](/loopx/docs/development/control-plane-course/03-work-graph-and-peers/)。
+  [第 4 讲](/loopx/docs/development/control-plane-course/04-state-substrate/)与
+  [第 5 讲](/loopx/docs/development/control-plane-course/05-work-graph-and-peers/)。
 - **Gate、Monitor、Replan 同时出现时哪条规则优先？** 先读第 5 章，再下钻
-  [第 4 讲](/loopx/docs/development/control-plane-course/04-quota-decision-kernel/)与
-  [第 5 讲](/loopx/docs/development/control-plane-course/05-host-scheduler-and-heartbeat/)。
+  [第 6 讲](/loopx/docs/development/control-plane-course/06-quota-decision-kernel/)与
+  [第 7 讲](/loopx/docs/development/control-plane-course/07-host-scheduler-and-heartbeat/)。
 - **长程任务怎样防止目标漂移与局部空转？** 先读第 6 章，再下钻
   [长程收敛专题](/loopx/docs/development/control-plane-course/topic-long-horizon-convergence/)与
-  [第 6 讲](/loopx/docs/development/control-plane-course/06-evidence-refresh-and-self-repair/)。
+  [第 8 讲](/loopx/docs/development/control-plane-course/08-evidence-refresh-and-self-repair/)。
 - **怎样修改规则并证明它可交付？** 先读第 10 至 13 章，再下钻
-  [第 7 讲](/loopx/docs/development/control-plane-course/07-engineering-a-control-plane-rule/)与
-  [第 8 讲](/loopx/docs/development/control-plane-course/08-autonomous-agent-quality-gates/)。
+  [第 9 讲](/loopx/docs/development/control-plane-course/09-engineering-a-control-plane-rule/)与
+  [第 10 讲](/loopx/docs/development/control-plane-course/10-autonomous-agent-quality-gates/)。
 - **Extension、领域能力与 Kernel 怎样组合？** 先读第 14 至 16 章，再下钻
-  [第 9 讲](/loopx/docs/development/control-plane-course/09-extension-layer/)。
+  [第 11 讲](/loopx/docs/development/control-plane-course/11-extension-layer/)。
 
 完成基础篇后：
 

--- a/docs/book/chapters/01-from-session-to-loop.md
+++ b/docs/book/chapters/01-from-session-to-loop.md
@@ -137,7 +137,7 @@ LoopX 的控制合同不绑定某一种业务流程。仓库中的 Control-Plane
 领域层提供可判定事实与 proposal，Provider 执行外部调用，Kernel 拥有跨领域生命周期。
 
 需要从三个 Showcase 进入架构、源码入口和完整 case 时，继续阅读
-[Control-Plane Course 第 0 讲](/loopx/docs/development/control-plane-course/00-goal-control-plane-architecture/)；
+[Control-Plane Course 第 2 讲](/loopx/docs/development/control-plane-course/02-goal-control-plane-architecture/)；
 第一次接触术语时可先看[概念导读](/loopx/docs/development/control-plane-course/00-concept-primer/)。
 
 ## 哪些状态必须外置

--- a/docs/book/chapters/03-one-turn.md
+++ b/docs/book/chapters/03-one-turn.md
@@ -161,9 +161,9 @@ frontier delta；最后重算 scheduler identity。不能因为 Monitor 本轮�
 Replan 修订 frontier；只有最终 interaction contract 才定义本轮行为。
 
 需要阅读完整 decision table、九类组合 case、源码 seam 与 smoke 时，进入
-[Control-Plane Course 第 4 讲](/loopx/docs/development/control-plane-course/04-quota-decision-kernel/)；
+[Control-Plane Course 第 6 讲](/loopx/docs/development/control-plane-course/06-quota-decision-kernel/)；
 Host、heartbeat、stateful backoff 和 scheduler receipt 的实现细节见
-[第 5 讲](/loopx/docs/development/control-plane-course/05-host-scheduler-and-heartbeat/)。
+[第 7 讲](/loopx/docs/development/control-plane-course/07-host-scheduler-and-heartbeat/)。
 
 ### Quota 是决策编译器，不是余额检查
 
@@ -192,7 +192,7 @@ Quota 的正确模型是从 source facts 按稳定 precedence 编译成 interact
 跳过 validation。这些都是把局部信号当成全局授权。
 
 完整决策 table、九类组合 case 和规则优先级见
-[Control-Plane Course 第 4 讲](/loopx/docs/development/control-plane-course/04-quota-decision-kernel/)。
+[Control-Plane Course 第 6 讲](/loopx/docs/development/control-plane-course/06-quota-decision-kernel/)。
 
 ## Bounded Delivery 的五段闭环
 
@@ -275,7 +275,7 @@ Validation 缺失最危险，因为它把内部信心当成了外部事实。Wri
 quota 和 monitor 在读取决策前已过时。
 
 这个证据阶梯的完整实验见
-[Control-Plane Course 第 6 讲](/loopx/docs/development/control-plane-course/06-evidence-refresh-and-self-repair/)，
+[Control-Plane Course 第 8 讲](/loopx/docs/development/control-plane-course/08-evidence-refresh-and-self-repair/)，
 其中包含每层的失败回放和修复路径。
 
 ## Evidence、Receipt 与 Observation
@@ -398,7 +398,7 @@ no-change streak，M2 也会打断 M1。最终两个 monitor 的 consecutive_no_
 
 这个 per-lane 设计也适用于多 agent 场景：每个 agent 的 monitor 是独立 lane，共享的是同一个
 frontier 读模型，但 no-change 判断是 per-lane 的。实现细节和交错实验见
-[Control-Plane Course 第 6 讲](/loopx/docs/development/control-plane-course/06-evidence-refresh-and-self-repair/)。
+[Control-Plane Course 第 8 讲](/loopx/docs/development/control-plane-course/08-evidence-refresh-and-self-repair/)。
 
 ## 一轮何时结束
 

--- a/docs/book/chapters/04-runtime-boundaries.md
+++ b/docs/book/chapters/04-runtime-boundaries.md
@@ -174,7 +174,7 @@ Self-Repair 修补控制面缺口；Terminal audit 防止“Todo 都勾完了”
 更完整的双 Showcase 回放、Evidence Delta 判据、独立 oracle 与收敛实验见
 [长程任务如何收敛](/loopx/docs/development/control-plane-course/topic-long-horizon-convergence/)；
 证据、Refresh、Spend 与 repair delta 的源码路径见
-[Control-Plane Course 第 6 讲](/loopx/docs/development/control-plane-course/06-evidence-refresh-and-self-repair/)。
+[Control-Plane Course 第 8 讲](/loopx/docs/development/control-plane-course/08-evidence-refresh-and-self-repair/)。
 
 ## Projection Gap 的处理顺序
 
@@ -230,7 +230,7 @@ Goal-level replan 先于 monitor quiet 或 agent-scope wait。否则系统可能
 
 如果 baseline 缺失但 agent 仍声称 unchanged，quota 会产生 `vision_checkpoint_missing` gap。这不是
 为了惩罚，而是为了防止 agent 在 never-checked 状态上积累错误假设。完整失败回放见
-[Control-Plane Course 第 6 讲](/loopx/docs/development/control-plane-course/06-evidence-refresh-and-self-repair/)。
+[Control-Plane Course 第 8 讲](/loopx/docs/development/control-plane-course/08-evidence-refresh-and-self-repair/)。
 
 ## Terminal Closure
 

--- a/docs/book/chapters/08-extension-placement.md
+++ b/docs/book/chapters/08-extension-placement.md
@@ -260,7 +260,7 @@ generic runner 要求 manifest 和 runtime 的权限都为空。发消息、写�
 
 如果你要设计的不只是 standalone package，而是 Explore、Domain State、Capability Pack、
 multi-agent preset、Provider 或 presentation 的组合，继续阅读
-[Control-Plane Course 第 9 讲](/loopx/docs/development/control-plane-course/09-extension-layer/)。
+[Control-Plane Course 第 11 讲](/loopx/docs/development/control-plane-course/11-extension-layer/)。
 它解释这些扩展面怎样复用 Kernel，而不是创建第二套 Goal、Todo、Quota 或 Scheduler。
 
 下一章会从官方 `extension init` 生成这套结构，再只修改 request/response domain contract。

--- a/docs/book/chapters/12-control-plane-course.md
+++ b/docs/book/chapters/12-control-plane-course.md
@@ -1,0 +1,39 @@
+# Control-Plane Developer Course
+
+> 面向准备修改 LoopX Kernel、CLI、状态投影、调度或扩展能力的开发者。
+
+## 与 Dev Book 的关系
+
+Dev Book 给外部开发者一条“从机制模型到接入/贡献”的完整路径；Control-Plane
+Developer Course 是独立章节，面向需要进入源码实现、判断规则优先级、定位 bounded
+context 或新增一条控制面规则的开发者。
+
+两者共享官方协议与源码事实，但不维护两份完整课程：
+
+- Dev Book 讲清楚预测行为所需的机制；
+- Course 提供 Showcase 推导、decision table、源码领读、实验与 review 问题。
+
+## 课程地图
+
+| 课程章节 | 主题 | 适合在读完 Dev Book 哪部分后进入 |
+|---|---|---|
+| [概念导读：先把 LoopX 放进一张图](/loopx/docs/development/control-plane-course/00-concept-primer/) | 有限上下文、外置状态与核心概念总图 | 第 1、2 章后 |
+| [长程任务如何收敛](/loopx/docs/development/control-plane-course/topic-long-horizon-convergence/) | 方向、证据、Delta、活性与终局不变量 | 第 6 章后 |
+| [第 1 讲：Harness 是 effectful program](/loopx/docs/development/control-plane-course/01-agent-loop-effectful-program/) | harness 是 agent loop 的 effect interpreter | 第 1 至 6 章后 |
+| [第 2 讲：从三个 Showcase 理解 LoopX 架构](/loopx/docs/development/control-plane-course/02-goal-control-plane-architecture/) | Agent / Provider / Capability / Kernel 分工 | 第 2 章后 |
+| [第 3 讲：从 Showcase 到第一次真实 Loop](/loopx/docs/development/control-plane-course/03-first-real-loop/) | guided start、todo、quota、refresh、spend | 第 1 至 6 章后 |
+| [第 4 讲：状态底座与可重放事实](/loopx/docs/development/control-plane-course/04-state-substrate/) | registry、event、active state、run history、projection | 第 3 章后 |
+| [第 5 讲：Todo 工作图与 Peer 协作](/loopx/docs/development/control-plane-course/05-work-graph-and-peers/) | claim、lease、handoff、equal peer | 第 4 章后 |
+| [第 6 讲：Quota 决策内核与 Interaction Contract](/loopx/docs/development/control-plane-course/06-quota-decision-kernel/) | `should-run`、route、mode、interaction contract | 第 5 章后 |
+| [第 7 讲：Host、Heartbeat 与 Stateful Backoff](/loopx/docs/development/control-plane-course/07-host-scheduler-and-heartbeat/) | execution context、RRULE、ACK、backoff | 第 5、6 章后 |
+| [第 8 讲：证据、Refresh 与 Self-Repair](/loopx/docs/development/control-plane-course/08-evidence-refresh-and-self-repair/) | material progress、replan、repair delta | 第 6 章后 |
+| [第 9 讲：如何给 Control Plane 增加一条规则](/loopx/docs/development/control-plane-course/09-engineering-a-control-plane-rule/) | invariant、ordered rules、schema、smoke | 第 10 至 13 章后 |
+| [第 10 讲：Agent 自主写代码时的分层质量门禁](/loopx/docs/development/control-plane-course/10-autonomous-agent-quality-gates/) | 确定性测试、canary、模型行为、release gate | 第 13 章后 |
+| [第 11 讲：扩展层、Explore 与领域产品](/loopx/docs/development/control-plane-course/11-extension-layer/) | 默认关闭的 Graph/Harness、领域产品 | 第 14 至 16 章后 |
+
+## 与 Effect Interpreter RFC 的关系
+
+课程第 1 讲与
+[Agent Loop Effect Interpreter RFC](/loopx/docs/architecture/rfcs/agent-loop-effect-interpreter-v0/)
+共用同一套语言：harness 是 agent loop 外面的 effectful program，状态机只是
+interpretation table。进入 Kernel 实现前，建议先读第 1 讲，再按需要进入后续专题。

--- a/docs/book/chapters/source-change-control-plane-rule.md
+++ b/docs/book/chapters/source-change-control-plane-rule.md
@@ -425,7 +425,7 @@ Characterization 证明“过去如此”，不证明“应该如此”。发现
 
 需要把这套方法映射到 Kernel bounded context、ordered rule、schema、projection 和 smoke 的真实
 源码链时，继续阅读
-[Control-Plane Course 第 7 讲](/loopx/docs/development/control-plane-course/07-engineering-a-control-plane-rule/)。
+[Control-Plane Course 第 9 讲](/loopx/docs/development/control-plane-course/09-engineering-a-control-plane-rule/)。
 本章负责外部贡献的端到端方法；课程负责更深的实现推导与评审练习。
 
 下一章把这项规则修复从本地验证推进到 PR：如何选择质量层、组织 commit、扫描公开边界，并给

--- a/docs/book/chapters/source-validation-to-pr.md
+++ b/docs/book/chapters/source-validation-to-pr.md
@@ -513,7 +513,7 @@ observed in target environment
 
 需要为不同风险 surface 选择 deterministic test、decision replay、canary、模型行为验证或
 release gate 时，继续阅读
-[Control-Plane Course 第 8 讲](/loopx/docs/development/control-plane-course/08-autonomous-agent-quality-gates/)。
+[Control-Plane Course 第 10 讲](/loopx/docs/development/control-plane-course/10-autonomous-agent-quality-gates/)。
 课程提供组合风险 case；本章保留从本地证据到公开 PR 的交付主线。
 
 至此，你完成了开发者贡献中的一条 Control-Plane 路径：从贡献地图选择 owner，沿协议链定位

--- a/docs/book/chapters/state-substrate.md
+++ b/docs/book/chapters/state-substrate.md
@@ -186,7 +186,7 @@ command 写入的 transition 才算。
 区分这三者的实践意义：每次写回前，确认要写入的是 goal/event state（transition）而不是 turn
 journal（临时记录）；每次读取 decision 前，确认读的是 goal/event state 而不是 run history 的旧
 投影。完整三类 ledger 的源码路径和实验见
-[Control-Plane Course 第 6 讲](/loopx/docs/development/control-plane-course/06-evidence-refresh-and-self-repair/)。
+[Control-Plane Course 第 8 讲](/loopx/docs/development/control-plane-course/08-evidence-refresh-and-self-repair/)。
 
 ## Canonical、Workbench、Projection 与外部事实
 
@@ -351,7 +351,7 @@ run_recorded(R1, tests_passed_at=commit-a)
   operator 与 Agent 读取的聚合表面。
 
 如果你准备修改 registry、event、Domain State、replay 或 projection builder，继续阅读
-[Control-Plane Course 第 2 讲](/loopx/docs/development/control-plane-course/02-state-substrate/)。
+[Control-Plane Course 第 4 讲](/loopx/docs/development/control-plane-course/04-state-substrate/)。
 它从 Issue-Fix、Auto ML 与 Auto Research 的事实归属进入源码路径和实验；本章继续作为外部
 开发者的概念入口。
 

--- a/docs/book/chapters/work-graph-and-authority.md
+++ b/docs/book/chapters/work-graph-and-authority.md
@@ -326,7 +326,7 @@ claim、workspace guard、Gate 和 writeback 仍逐 Todo 生效。跨设备在�
   claim、optional lease、capability 与 Host 边界。
 
 如果改动涉及 equal peer、lifecycle authority、handoff、dependency 或 successor，继续阅读
-[Control-Plane Course 第 3 讲](/loopx/docs/development/control-plane-course/03-work-graph-and-peers/)。
+[Control-Plane Course 第 5 讲](/loopx/docs/development/control-plane-course/05-work-graph-and-peers/)。
 课程提供组合 case 与源码领读；本章保留外部贡献者需要的工作图和权限模型。
 
 下一章把这些状态与权限编译成一次受治理的 Turn：谁应行动、谁应等待、哪个 channel 应通知，以及

--- a/docs/book/en/chapters/00-reading-guide.md
+++ b/docs/book/en/chapters/00-reading-guide.md
@@ -43,25 +43,28 @@ course. The Dev Book explains enough mechanism to predict behavior. Follow its c
 the course when you need rule precedence, bounded-context placement, or implementation detail. The deep
 course is currently maintained in Chinese; the English Dev Book keeps the mechanism needed for its main
 paths self-contained.
+Developers ready to enter Kernel implementation can go directly to the
+[independent Control-Plane Course chapter](./12-control-plane-course.md).
 
 - **How do short sessions compose into long-running work?** Read Chapters 1 and 2, then descend into the
-  [concept primer](/loopx/docs/development/control-plane-course/00-concept-primer/) and
-  [Lesson 0](/loopx/docs/development/control-plane-course/00-goal-control-plane-architecture/), then walk
-  through a real Loop in [Lesson 1](/loopx/docs/development/control-plane-course/01-first-real-loop/).
+  [concept primer](/loopx/docs/development/control-plane-course/00-concept-primer/),
+  [Lesson 1: Harness is the effectful program](/loopx/docs/development/control-plane-course/01-agent-loop-effectful-program/),
+  and [Lesson 2](/loopx/docs/development/control-plane-course/02-goal-control-plane-architecture/), then walk
+  through a real Loop in [Lesson 3](/loopx/docs/development/control-plane-course/03-first-real-loop/).
 - **Who owns state, the work graph, and authority?** Read Chapters 3 and 4, then descend into
-  [Lesson 2](/loopx/docs/development/control-plane-course/02-state-substrate/) and
-  [Lesson 3](/loopx/docs/development/control-plane-course/03-work-graph-and-peers/).
+  [Lesson 4](/loopx/docs/development/control-plane-course/04-state-substrate/) and
+  [Lesson 5](/loopx/docs/development/control-plane-course/05-work-graph-and-peers/).
 - **Which rule wins when a Gate, Monitor, and Replan coexist?** Read Chapter 5, then descend into
-  [Lesson 4](/loopx/docs/development/control-plane-course/04-quota-decision-kernel/) and
-  [Lesson 5](/loopx/docs/development/control-plane-course/05-host-scheduler-and-heartbeat/).
+  [Lesson 6](/loopx/docs/development/control-plane-course/06-quota-decision-kernel/) and
+  [Lesson 7](/loopx/docs/development/control-plane-course/07-host-scheduler-and-heartbeat/).
 - **How does long-running work avoid drift and local loops?** Read Chapter 6, then descend into
   [long-horizon convergence](/loopx/docs/development/control-plane-course/topic-long-horizon-convergence/)
-  and [Lesson 6](/loopx/docs/development/control-plane-course/06-evidence-refresh-and-self-repair/).
+  and [Lesson 8](/loopx/docs/development/control-plane-course/08-evidence-refresh-and-self-repair/).
 - **How do I change a rule and prove it is deliverable?** Read Chapters 10 through 13, then descend into
-  [Lesson 7](/loopx/docs/development/control-plane-course/07-engineering-a-control-plane-rule/) and
-  [Lesson 8](/loopx/docs/development/control-plane-course/08-autonomous-agent-quality-gates/).
+  [Lesson 9](/loopx/docs/development/control-plane-course/09-engineering-a-control-plane-rule/) and
+  [Lesson 10](/loopx/docs/development/control-plane-course/10-autonomous-agent-quality-gates/).
 - **How do Extensions, domain capabilities, and the Kernel compose?** Read Chapters 14 through 16, then
-  descend into [Lesson 9](/loopx/docs/development/control-plane-course/09-extension-layer/).
+  descend into [Lesson 11](/loopx/docs/development/control-plane-course/11-extension-layer/).
 
 After those chapters:
 

--- a/docs/book/en/chapters/01-from-session-to-loop.md
+++ b/docs/book/en/chapters/01-from-session-to-loop.md
@@ -140,7 +140,7 @@ completion state machine. The domain layer supplies decidable facts and proposal
 external calls, and the Kernel owns cross-domain lifecycle.
 
 For the complete Showcase derivation, architecture, and source entrypoints, continue to
-[Control-Plane Course Lesson 0](/loopx/docs/development/control-plane-course/00-goal-control-plane-architecture/).
+[Control-Plane Course Lesson 2](/loopx/docs/development/control-plane-course/02-goal-control-plane-architecture/).
 Use the [concept primer](/loopx/docs/development/control-plane-course/00-concept-primer/) first when the
 vocabulary is new.
 

--- a/docs/book/en/chapters/03-one-turn.md
+++ b/docs/book/en/chapters/03-one-turn.md
@@ -172,9 +172,9 @@ Monitor says when to observe, and Replan revises the frontier. Only the final in
 defines this turn's behavior.
 
 For the complete decision table, nine combined cases, source seams, and smokes, use
-[Control-Plane Course Lesson 4](/loopx/docs/development/control-plane-course/04-quota-decision-kernel/).
+[Control-Plane Course Lesson 6](/loopx/docs/development/control-plane-course/06-quota-decision-kernel/).
 Host, heartbeat, stateful backoff, and scheduler receipt implementation details are in
-[Lesson 5](/loopx/docs/development/control-plane-course/05-host-scheduler-and-heartbeat/).
+[Lesson 7](/loopx/docs/development/control-plane-course/07-host-scheduler-and-heartbeat/).
 
 ### Quota is a decision compiler, not a balance check
 
@@ -208,7 +208,7 @@ check because "there was quota before," and skipping validation because "the use
 These all treat a local signal as global authorization.
 
 For the complete decision table, nine combined cases, and rule precedence, see
-[Control-Plane Course Lesson 4](/loopx/docs/development/control-plane-course/04-quota-decision-kernel/).
+[Control-Plane Course Lesson 6](/loopx/docs/development/control-plane-course/06-quota-decision-kernel/).
 
 ## The five-stage bounded-delivery loop
 
@@ -296,7 +296,7 @@ artifacts or chat records. Missing Refresh is the most subtle: on the surface th
 but quota and monitor are actually reading a decision from before the state was refreshed.
 
 For complete experiments on this evidence ladder, see
-[Control-Plane Course Lesson 6](/loopx/docs/development/control-plane-course/06-evidence-refresh-and-self-repair/),
+[Control-Plane Course Lesson 8](/loopx/docs/development/control-plane-course/08-evidence-refresh-and-self-repair/),
 which includes failure replay and repair paths for each layer.
 
 ## Evidence, Receipt, and Observation
@@ -430,7 +430,7 @@ B2...) does not cause mutual zeroing.
 This per-lane design also applies to multi-agent scenarios: each agent's monitor is an independent
 lane; they share the same frontier read model, but no-change judgment is per-lane. Implementation
 details and interleaving experiments are in
-[Control-Plane Course Lesson 6](/loopx/docs/development/control-plane-course/06-evidence-refresh-and-self-repair/).
+[Control-Plane Course Lesson 8](/loopx/docs/development/control-plane-course/08-evidence-refresh-and-self-repair/).
 
 ## How a turn ends
 

--- a/docs/book/en/chapters/04-runtime-boundaries.md
+++ b/docs/book/en/chapters/04-runtime-boundaries.md
@@ -191,7 +191,7 @@ For the complete paired-Showcase replay, evidence-delta criteria, independent or
 experiments, use
 [Long-horizon convergence](/loopx/docs/development/control-plane-course/topic-long-horizon-convergence/).
 For evidence, refresh, spend, and repair delta source paths, see
-[Control-Plane Course Lesson 6](/loopx/docs/development/control-plane-course/06-evidence-refresh-and-self-repair/).
+[Control-Plane Course Lesson 8](/loopx/docs/development/control-plane-course/08-evidence-refresh-and-self-repair/).
 
 ## Handle a projection gap in order
 
@@ -249,7 +249,7 @@ For subsequent rounds, claiming unchanged requires:
 If the baseline is missing but the agent still claims unchanged, quota will produce a
 `vision_checkpoint_missing` gap. This is not a punishment, but a guard against the agent accumulating
 wrong assumptions on a never-checked state. For the full failure replay, see
-[Control-Plane Course Lesson 6](/loopx/docs/development/control-plane-course/06-evidence-refresh-and-self-repair/).
+[Control-Plane Course Lesson 8](/loopx/docs/development/control-plane-course/08-evidence-refresh-and-self-repair/).
 
 ## Terminal closure
 

--- a/docs/book/en/chapters/08-extension-placement.md
+++ b/docs/book/en/chapters/08-extension-placement.md
@@ -242,7 +242,7 @@ Shared code may justify a helper. It does not prove a need for independent insta
 
 If you are designing more than a standalone package—such as Explore, Domain State, a Capability Pack,
 multi-agent preset, Provider, or presentation composition—continue to
-[Control-Plane Course Lesson 9](/loopx/docs/development/control-plane-course/09-extension-layer/). It
+[Control-Plane Course Lesson 11](/loopx/docs/development/control-plane-course/11-extension-layer/). It
 explains how these extension surfaces reuse the Kernel instead of creating a second Goal, Todo, quota, or
 scheduler.
 

--- a/docs/book/en/chapters/12-control-plane-course.md
+++ b/docs/book/en/chapters/12-control-plane-course.md
@@ -1,0 +1,45 @@
+# Control-Plane Developer Course
+
+> For developers who plan to modify LoopX Kernel, CLI, state projection,
+> scheduler, or extension behavior.
+
+## Relationship to the Dev Book
+
+The Dev Book gives external developers a complete path from mechanism model to
+project onboarding or contribution. The Control-Plane Developer Course is an
+independent chapter for developers who need to enter implementation source,
+judge rule precedence, locate bounded contexts, or add a new control-plane
+rule.
+
+Both share the official protocols and source as authority, but do not maintain
+two copies of the full course:
+
+- the Dev Book explains enough mechanism to predict behavior;
+- the Course provides Showcase derivations, decision tables, source
+  walkthroughs, experiments, and review questions.
+
+## Course map
+
+| Course chapter | Topic | Best entry point in the Dev Book |
+|---|---|---|
+| [Concept primer](/loopx/docs/development/control-plane-course/00-concept-primer/) | Limited context, externalized state, core concepts | After Chapters 1-2 |
+| [Long-horizon convergence](/loopx/docs/development/control-plane-course/topic-long-horizon-convergence/) | Direction, evidence, delta, liveness, terminal invariants | After Chapter 6 |
+| [Lesson 1: Harness is the effectful program](/loopx/docs/development/control-plane-course/01-agent-loop-effectful-program/) | Harness as the agent-loop effect interpreter | After Chapters 1-6 |
+| [Lesson 2: Architecture from three showcases](/loopx/docs/development/control-plane-course/02-goal-control-plane-architecture/) | Agent / Provider / Capability / Kernel ownership | After Chapter 2 |
+| [Lesson 3: First real loop](/loopx/docs/development/control-plane-course/03-first-real-loop/) | Guided start, todo, quota, refresh, spend | After Chapters 1-6 |
+| [Lesson 4: State substrate](/loopx/docs/development/control-plane-course/04-state-substrate/) | Registry, events, active state, run history, projection | After Chapter 3 |
+| [Lesson 5: Work graph and peers](/loopx/docs/development/control-plane-course/05-work-graph-and-peers/) | Claim, lease, handoff, equal peers | After Chapter 4 |
+| [Lesson 6: Quota kernel and interaction contract](/loopx/docs/development/control-plane-course/06-quota-decision-kernel/) | `should-run`, route, mode, interaction contract | After Chapter 5 |
+| [Lesson 7: Host, heartbeat, stateful backoff](/loopx/docs/development/control-plane-course/07-host-scheduler-and-heartbeat/) | Execution context, RRULE, ACK, backoff | After Chapters 5-6 |
+| [Lesson 8: Evidence, refresh, self-repair](/loopx/docs/development/control-plane-course/08-evidence-refresh-and-self-repair/) | Material progress, replan, repair delta | After Chapter 6 |
+| [Lesson 9: Add a control-plane rule](/loopx/docs/development/control-plane-course/09-engineering-a-control-plane-rule/) | Invariants, ordered rules, schemas, smokes | After Chapters 10-13 |
+| [Lesson 10: Layered quality gates](/loopx/docs/development/control-plane-course/10-autonomous-agent-quality-gates/) | Deterministic tests, canaries, model behavior, release gates | After Chapter 13 |
+| [Lesson 11: Extensions and domain products](/loopx/docs/development/control-plane-course/11-extension-layer/) | Explore, Graph/Harness, domain products | After Chapters 14-16 |
+
+## Relationship to the Effect Interpreter RFC
+
+Lesson 1 and the
+[Agent Loop Effect Interpreter RFC](/loopx/docs/architecture/rfcs/agent-loop-effect-interpreter-v0/)
+share one language: the harness is the effectful program around an agent loop,
+and state machines are interpretation tables. Start with Lesson 1 before
+entering Kernel implementation topics.

--- a/docs/book/en/chapters/source-change-control-plane-rule.md
+++ b/docs/book/en/chapters/source-change-control-plane-rule.md
@@ -426,7 +426,7 @@ Before changing a rule, confirm:
 
 To map this method onto real Kernel bounded contexts, ordered rules, schemas, projections, and smoke
 paths, continue to
-[Control-Plane Course Lesson 7](/loopx/docs/development/control-plane-course/07-engineering-a-control-plane-rule/).
+[Control-Plane Course Lesson 9](/loopx/docs/development/control-plane-course/09-engineering-a-control-plane-rule/).
 This chapter owns the external contribution method; the course owns the deeper implementation derivation
 and review exercises.
 

--- a/docs/book/en/chapters/source-validation-to-pr.md
+++ b/docs/book/en/chapters/source-validation-to-pr.md
@@ -518,7 +518,7 @@ Before opening the PR, confirm:
 
 When a risk surface requires choosing among deterministic tests, decision replay, canaries, model-behavior
 validation, or release gates, continue to
-[Control-Plane Course Lesson 8](/loopx/docs/development/control-plane-course/08-autonomous-agent-quality-gates/).
+[Control-Plane Course Lesson 10](/loopx/docs/development/control-plane-course/10-autonomous-agent-quality-gates/).
 The course provides combined risk cases; this chapter keeps the delivery path from local evidence to a
 public PR.
 

--- a/docs/book/en/chapters/state-substrate.md
+++ b/docs/book/en/chapters/state-substrate.md
@@ -199,7 +199,7 @@ The practical significance of distinguishing these three: before every write-bac
 to goal/event state (a transition) and not to the turn journal (temporary records); before every decision
 read, confirm you are reading goal/event state and not an old projection from run history. For complete
 source paths and experiments on the three ledgers, see
-[Control-Plane Course Lesson 6](/loopx/docs/development/control-plane-course/06-evidence-refresh-and-self-repair/).
+[Control-Plane Course Lesson 8](/loopx/docs/development/control-plane-course/08-evidence-refresh-and-self-repair/).
 
 ## Canonical state, workbench, projection, and external fact
 
@@ -371,7 +371,7 @@ This chapter owns the learning sequence, not the complete schemas. For state cha
   for Agent and operator-facing aggregation.
 
 If you plan to change registry, event, Domain State, replay, or projection builders, continue to
-[Control-Plane Course Lesson 2](/loopx/docs/development/control-plane-course/02-state-substrate/). It enters
+[Control-Plane Course Lesson 4](/loopx/docs/development/control-plane-course/04-state-substrate/). It enters
 source paths and experiments through fact ownership in Issue-Fix, Auto ML, and Auto Research. This chapter
 remains the external developer's conceptual entrypoint.
 

--- a/docs/book/en/chapters/work-graph-and-authority.md
+++ b/docs/book/en/chapters/work-graph-and-authority.md
@@ -338,7 +338,7 @@ For work-graph or authority changes, start with:
   for claims, optional leases, capability, and Host boundaries.
 
 For changes involving equal peers, lifecycle authority, handoff, dependencies, or successors, continue to
-[Control-Plane Course Lesson 3](/loopx/docs/development/control-plane-course/03-work-graph-and-peers/).
+[Control-Plane Course Lesson 5](/loopx/docs/development/control-plane-course/05-work-graph-and-peers/).
 The course provides combined cases and source walkthroughs; this chapter preserves the work-graph and
 authority model needed by external contributors.
 

--- a/docs/book/en/index.md
+++ b/docs/book/en/index.md
@@ -29,6 +29,13 @@ existing project or contribute to LoopX.
 
     [:octicons-arrow-right-24: Make a contribution](chapters/source-protocol-map.md)
 
+-   :material-school: **Control-Plane Course**
+
+    For developers entering Kernel, CLI, state projection, or scheduler implementation, with Showcases,
+    decision tables, and source walkthroughs.
+
+    [:octicons-arrow-right-24: Enter the developer course](chapters/12-control-plane-course.md)
+
 </div>
 
 ## What this book helps you do
@@ -49,7 +56,7 @@ the Kernel. It gives external developers a stable path for deciding:
 - how to decide whether a capability belongs in core, a Capability, a Provider, a Host, a projection, or an
   independently delivered Extension.
 
-## Two independent practice paths
+## Three parallel learning paths
 
 After the control-plane chapters, choose the path that matches your job:
 
@@ -57,9 +64,12 @@ After the control-plane chapters, choose the path that matches your job:
    [Connect an existing Git project](./chapters/05-connect-existing-project.md).
 2. **Make a developer contribution:** begin with the
    [Developer contribution map](./chapters/source-protocol-map.md).
+3. **Control-Plane Course:** enter Kernel implementation through the
+   [independent course chapter](./chapters/12-control-plane-course.md).
 
 The paths share the same foundations but are independent. Project onboarding does not require a LoopX
-source change. Contributions are not limited to Kernel maintainers: you can work on the Control Plane,
+source change. Contributions are not limited to Kernel maintainers, and the Course takes the Dev Book's
+mechanism model further into implementation, rules, and validation. You can work on the Control Plane,
 Capabilities and Domain State, Providers, Host or Runner integration, projections, documentation and
 fixtures, or Extension and package lifecycle. An Extension is one delivery choice for independently
 versioned or optional functionality, not the default shape of every contribution.

--- a/docs/book/index.md
+++ b/docs/book/index.md
@@ -27,6 +27,12 @@
 
     [:octicons-arrow-right-24: 参与开发者贡献](chapters/source-protocol-map.md)
 
+-   :material-school: **Control-Plane Course**
+
+    面向准备进入 Kernel、CLI、状态投影或调度实现的开发者，提供 Showcase、decision table 与源码领读。
+
+    [:octicons-arrow-right-24: 进入开发者课程](chapters/12-control-plane-course.md)
+
 </div>
 
 ## 这本书解决什么问题
@@ -45,15 +51,17 @@
 - 如何判断一项能力应进入 Core、Capability、Provider、Host、Projection，还是作为 Extension
   独立交付。
 
-## 两条并列实践主线
+## 三条并列学习主线
 
 完成第一部分后，可以按需求选择：
 
 1. **接入现有项目：** 从[连接你的 Git 项目](./chapters/05-connect-existing-project.md)开始；
 2. **开发者贡献：** 从[开发者贡献地图与协议入口](./chapters/source-protocol-map.md)开始。
+3. **Control-Plane Course：** 准备深入 Kernel 实现时，从
+   [独立课程章节](./chapters/12-control-plane-course.md)开始。
 
-两条主线共享同一套控制面基础，但互不依赖。项目接入不要求修改 LoopX；开发者贡献也不只属于
-Kernel 核心维护者。你可以沿 Control Plane、Capability、Provider、Host/Runner、
+三条主线共享同一套控制面基础，但互不依赖。项目接入不要求修改 LoopX；开发者贡献也不只属于
+Kernel 核心维护者；课程则把 Dev Book 的机制模型进一步推进到实现、规则与验证。你可以沿 Control Plane、Capability、Provider、Host/Runner、
 Projection/Docs/fixtures 或 Extension/package lifecycle 中的一条边界完成贡献，其中
 Extension 只是可独立版本化和交付的一种路径。
 

--- a/examples/dev-book-publication-smoke.py
+++ b/examples/dev-book-publication-smoke.py
@@ -37,21 +37,23 @@ CHAPTERS = (
     "09-extension-scaffold",
     "10-extension-lifecycle",
     "11-engineering-boundaries",
+    "12-control-plane-course",
     "appendix-reference",
 )
 
 COURSE_PAGES = (
     "00-concept-primer",
-    "00-goal-control-plane-architecture",
-    "01-first-real-loop",
-    "02-state-substrate",
-    "03-work-graph-and-peers",
-    "04-quota-decision-kernel",
-    "05-host-scheduler-and-heartbeat",
-    "06-evidence-refresh-and-self-repair",
-    "07-engineering-a-control-plane-rule",
-    "08-autonomous-agent-quality-gates",
-    "09-extension-layer",
+    "01-agent-loop-effectful-program",
+    "02-goal-control-plane-architecture",
+    "03-first-real-loop",
+    "04-state-substrate",
+    "05-work-graph-and-peers",
+    "06-quota-decision-kernel",
+    "07-host-scheduler-and-heartbeat",
+    "08-evidence-refresh-and-self-repair",
+    "09-engineering-a-control-plane-rule",
+    "10-autonomous-agent-quality-gates",
+    "11-extension-layer",
     "topic-long-horizon-convergence",
 )
 
@@ -65,7 +67,7 @@ def validate_rendered_site(site_dir: Path) -> None:
         "index.html": ("LoopX Developer Book", "English edition", "MkDocs Material"),
         "chapters/00-reading-guide/index.html": (
             "Dev Book 与 Control-Plane Course 如何配合",
-            "/loopx/docs/development/control-plane-course/04-quota-decision-kernel/",
+            "/loopx/docs/development/control-plane-course/06-quota-decision-kernel/",
         ),
         "chapters/01-from-session-to-loop/index.html": (
             "从一次会话到长程任务",
@@ -79,7 +81,7 @@ def validate_rendered_site(site_dir: Path) -> None:
         "index.html": ("LoopX Developer Book", "简体中文版", "MkDocs Material"),
         "chapters/00-reading-guide/index.html": (
             "How the Dev Book and Control-Plane Course work together",
-            "/loopx/docs/development/control-plane-course/04-quota-decision-kernel/",
+            "/loopx/docs/development/control-plane-course/06-quota-decision-kernel/",
         ),
         "chapters/01-from-session-to-loop/index.html": (
             "From one session to long-running work",
@@ -230,13 +232,13 @@ def main() -> int:
             "PR Issue Fix",
             "Single-Agent Auto ML",
             "Multi-Agent Auto Research",
-            "/loopx/docs/development/control-plane-course/00-goal-control-plane-architecture/",
+            "/loopx/docs/development/control-plane-course/02-goal-control-plane-architecture/",
         ),
         "chapters/03-one-turn.md": (
             "Decision Pipeline",
             "identity",
             "capability and workspace eligibility",
-            "/loopx/docs/development/control-plane-course/04-quota-decision-kernel/",
+            "/loopx/docs/development/control-plane-course/06-quota-decision-kernel/",
         ),
         "chapters/04-runtime-boundaries.md": (
             "Material Evidence Delta",
@@ -248,13 +250,13 @@ def main() -> int:
             "PR Issue Fix",
             "Single-Agent Auto ML",
             "Multi-Agent Auto Research",
-            "/loopx/docs/development/control-plane-course/00-goal-control-plane-architecture/",
+            "/loopx/docs/development/control-plane-course/02-goal-control-plane-architecture/",
         ),
         "en/chapters/03-one-turn.md": (
             "Decision pipeline",
             "Identity",
             "capability and workspace eligibility",
-            "/loopx/docs/development/control-plane-course/04-quota-decision-kernel/",
+            "/loopx/docs/development/control-plane-course/06-quota-decision-kernel/",
         ),
         "en/chapters/04-runtime-boundaries.md": (
             "Material evidence delta",

--- a/mkdocs.book.en.yaml
+++ b/mkdocs.book.en.yaml
@@ -53,6 +53,8 @@ nav:
   - Home: index.md
   - Start:
       - How to use this book: chapters/00-reading-guide.md
+  - Developer Course:
+      - Control-Plane Course: chapters/12-control-plane-course.md
   - Part I — Control-plane foundations:
       - 1. From one session to long-running work: chapters/01-from-session-to-loop.md
       - 2. Sessions, Codex Goal, and LoopX: chapters/02-session-goal-loopx.md

--- a/mkdocs.book.zh.yaml
+++ b/mkdocs.book.zh.yaml
@@ -56,6 +56,8 @@ nav:
   - 首页: index.md
   - 开始:
       - 如何使用本书: chapters/00-reading-guide.md
+  - 开发者课程:
+      - Control-Plane Course: chapters/12-control-plane-course.md
   - 第一部分：控制面基础:
       - 1. 从一次会话到长程任务: chapters/01-from-session-to-loop.md
       - 2. 会话、Codex Goal 与 LoopX: chapters/02-session-goal-loopx.md


### PR DESCRIPTION
## Summary

Update the unified Dev Book and make the Control-Plane Course an independent
chapter.

- Add `chapters/12-control-plane-course.md` (zh) and
  `chapters/12-control-plane-course.md` (en) with the full course map and
  Effect Interpreter RFC pointer.
- Add the chapter to both MkDocs book navs and the zh/en book index cards.
- Refresh all Dev Book course links and lesson labels to the current lecture
  numbering (`01`-`11` plus concept primer and long-horizon topic).
- Update `dev-book-publication-smoke` for the new chapter and current course
  page slugs.

No runtime behavior changes.

## Validation

- `dev-book-publication-smoke`: passed.
- `docs-governance-smoke`: passed.
- `loopx canary premerge --from-git-diff`: passed, `self_merge_allowed=true`,
  0 manual holds.
- Canary reported one advisory inherited failure in
  `control-plane-maintainability-ratchet-smoke` that did not mention changed
  files; it does not block this docs-only diff.
- Public boundary scan: passed.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`
