### PR TITLE
refactor(control-plane): build scheduler commands through effect program

### DIFF
--- a/loopx/canary/module_metric_baseline.json
+++ b/loopx/canary/module_metric_baseline.json
@@ -8,7 +8,7 @@
     "loopx/bootstrap_command_pack.py": {
       "any_count": 32,
       "dict_any_count": 0,
-      "lines": 2234
+      "lines": 2240
     },
     "loopx/canary/planner.py": {
       "any_count": 22,

--- a/loopx/codex_cli_scheduler.py
+++ b/loopx/codex_cli_scheduler.py
@@ -11,6 +11,7 @@ from .codex_cli_probe import (
     build_codex_cli_runtime_idle_detector,
     build_codex_cli_visible_driver_run_packet,
 )
+from .control_plane.effect_program import effect_program_from_ordered_steps
 
 
 def _scheduler_label(goal_id: str, agent_id: str | None) -> str:
@@ -195,6 +196,45 @@ def build_codex_cli_local_scheduler_tick(
     else:
         blocker_writeback_command = None
 
+    commands_program = effect_program_from_ordered_steps(
+        [
+            {
+                "id": "visible_driver_run",
+                "kind": "codex_cli_command",
+                "command": visible_driver_run_command,
+            },
+            {
+                "id": "runtime_idle_detector",
+                "kind": "codex_cli_command",
+                "command": runtime_idle_detector_command,
+            },
+            {
+                "id": "runtime_idle_detector_fixture",
+                "kind": "codex_cli_command",
+                "command": runtime_idle_fixture_command,
+            },
+            {
+                "id": "scheduler_tick",
+                "kind": "codex_cli_command",
+                "command": scheduler_tick_command,
+            },
+            {
+                "id": "candidate_codex_command",
+                "kind": "codex_cli_command",
+                "command": candidate_command or "",
+            },
+            {
+                "id": "blocker_writeback",
+                "kind": "codex_cli_command",
+                "command": blocker_writeback_command or "",
+            },
+        ],
+        execution_mode="serial",
+    )
+    commands = {
+        step.step_id: step.command for step in commands_program.steps
+    }
+
     return {
         "ok": True,
         "schema_version": "codex_cli_local_scheduler_tick_v0",
@@ -227,14 +267,7 @@ def build_codex_cli_local_scheduler_tick(
                 "Use external logging that excludes raw transcripts, session files, credentials, and private paths.",
             ],
         },
-        "commands": {
-            "visible_driver_run": visible_driver_run_command,
-            "runtime_idle_detector": runtime_idle_detector_command,
-            "runtime_idle_detector_fixture": runtime_idle_fixture_command,
-            "scheduler_tick": scheduler_tick_command,
-            "candidate_codex_command": candidate_command,
-            "blocker_writeback": blocker_writeback_command,
-        },
+        "commands": commands,
         "visible_driver_run_packet": {
             "schema_version": run_packet.get("schema_version"),
             "driver_mode": run_packet.get("driver_mode"),

--- a/tests/control_plane/test_codex_cli_scheduler_effect_program.py
+++ b/tests/control_plane/test_codex_cli_scheduler_effect_program.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from loopx.codex_cli_probe import classify_codex_cli_session_surface
+from loopx.codex_cli_scheduler import build_codex_cli_local_scheduler_tick
+from loopx.control_plane.effect_program import effect_program_from_ordered_steps
+
+PROJECT = Path("/tmp/public-codex-cli-project")
+GOAL_ID = "public-codex-cli-goal"
+AGENT_ID = "codex-side-bypass"
+
+FALLBACK_HELP_FIXTURE = {
+    "root": """
+Usage: codex [OPTIONS] [PROMPT]
+
+Commands:
+  exec      Run Codex non-interactively
+  resume    Resume a previous conversation
+""",
+    "exec": "Usage: codex exec [OPTIONS] [PROMPT]",
+    "resume": "Usage: codex resume [SESSION_ID]",
+}
+
+
+def test_scheduler_commands_round_trip_through_effect_program() -> None:
+    payload = build_codex_cli_local_scheduler_tick(
+        project=PROJECT,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        cli_bin="loopx",
+        codex_bin="codex",
+        probe_payload=classify_codex_cli_session_surface(
+            command_outputs=FALLBACK_HELP_FIXTURE
+        ),
+    )
+    commands = payload["commands"]
+
+    assert set(commands) == {
+        "visible_driver_run",
+        "runtime_idle_detector",
+        "runtime_idle_detector_fixture",
+        "scheduler_tick",
+        "candidate_codex_command",
+        "blocker_writeback",
+    }
+    program = effect_program_from_ordered_steps(
+        [
+            {"id": step_id, "kind": "codex_cli_command", "command": command}
+            for step_id, command in commands.items()
+            if command
+        ],
+        execution_mode="serial",
+    )
+    assert program.execution_mode == "serial"
+    assert {step.step_id: step.command for step in program.steps} == {
+        step_id: command
+        for step_id, command in commands.items()
+        if command
+    }


### PR DESCRIPTION
## Summary

R3 replacement-first change: Codex CLI local scheduler commands are built
through `EffectProgram`.

- `build_codex_cli_local_scheduler_tick` now models its command set as an
  ordered `EffectProgram` and renders the public `commands` mapping from it.
- Add a focused test that proves the command mapping round-trips through
  `effect_program_from_ordered_steps`.
- Refresh the maintainability baseline for `bootstrap_command_pack.py` after
  the R1 effect-program replacement.

No public packet behavior changes.

## Validation

- `python -m pytest tests/control_plane/test_codex_cli_scheduler_effect_program.py
  tests/canary/test_maintainability_ratchet.py`: passed.
- `codex-cli-local-scheduler-tick-smoke` and
  `codex-cli-local-scheduler-exec-smoke`: passed.
- `loopx canary premerge --from-git-diff`: passed, `self_merge_allowed=true`,
  0 manual holds.
- Public boundary scan: passed.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`
