### PR TITLE
docs(rfc): track r1-r3 replacements and defer r4 executor

### DIFF
--- a/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
+++ b/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
@@ -48,7 +48,7 @@ that model over time.
 | M3 Focused test families | Mostly complete (#2916-#2918, #2925, #2929) |
 | M4 Architecture documentation | Mostly complete (#2921, #2923, #2924) |
 | M5 Steady-state review | Mostly complete (#2922, #2931) |
-| M6 General effect-program abstraction | In progress (#2938, #2939, #2940, #2942, #2943, #2945) |
+| M6 General effect-program abstraction | In progress (#2938, #2939, #2940, #2942, #2943, #2945, #2949, #2955, #2956, #2957) |
 
 ## Why This Matters
 
@@ -264,6 +264,12 @@ parallel and equally important:
   execution strategy.
 - `EffectProgram` and `effect_program_from_ordered_steps` as a read-only shape
   over existing `guided_transaction.ordered_steps`.
+- R1 replacement: bootstrap guided rendering reads `ordered_steps` through
+  `EffectProgram` (#2955).
+- R2 replacement: turn executor resolves result kind through
+  `interpret_turn_result_packet` (#2956).
+- R3 replacement: Codex CLI local scheduler commands are built through
+  `EffectProgram` (#2957).
 - around semantics encoded in `capability_gate`, `interaction_contract`,
   `work_lane_contract`, and `scheduler_hint`.
 - focused tests and docs that pin the lens.
@@ -274,6 +280,8 @@ parallel and equally important:
   not only by tests.
 - A real host or turn-driver caller that executes an ordered effect program
   while preserving failure, cancellation, permission, and budget semantics.
+
+R4 remains deferred until that real multi-step executor caller exists.
 
 ### When To Generalize
 


### PR DESCRIPTION
## Summary

Track replacement-first progress in the RFC.

- Mark M6 as in progress with R1-R3 PRs (#2955, #2956, #2957).
- Record the three real runtime replacements in the abstraction inventory.
- Explicitly defer R4 (ordered effect executor) until a real multi-step
  host/turn-driver caller exists.

No runtime behavior changes.

## Validation

- `docs-governance-smoke`: passed.
- `loopx canary premerge --from-git-diff`: passed, `self_merge_allowed=true`,
  0 manual holds.
- Public boundary scan: passed.

## Routing

- continuation-policy: `independent_handoff`
- excluded-agent: `codex-quality-qualification`
- claimed-by: `codex-side-bypass`
