### PR TITLE
refactor(status): move status contract projection into bounded module

### DIFF
--- a/loopx/control_plane/status/contract_projection.py
+++ b/loopx/control_plane/status/contract_projection.py
@@ -1,0 +1,31 @@
+"""Status contract projection inside the `status` bounded context."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..work_items.status_contract import (
+    build_contract_health_projection as _build_contract_health_projection,
+    build_status_contract as _build_status_contract,
+)
+
+
+STATUS_CONTRACT_SCHEMA_VERSION = 2
+MINIMUM_DASHBOARD_STATUS_CONTRACT_SCHEMA_VERSION = 2
+STATUS_CONTRACT_RELOAD_HINT = "scripts/macos-dashboard-launchagent.sh restart"
+STATUS_CONTRACT_SIGNAL_LIMIT = 3
+
+
+def build_status_contract() -> dict[str, Any]:
+    return _build_status_contract(
+        schema_version=STATUS_CONTRACT_SCHEMA_VERSION,
+        minimum_dashboard_schema_version=MINIMUM_DASHBOARD_STATUS_CONTRACT_SCHEMA_VERSION,
+        reload_hint=STATUS_CONTRACT_RELOAD_HINT,
+    )
+
+
+def build_contract_health_projection(contract: dict[str, Any]) -> dict[str, Any]:
+    return _build_contract_health_projection(
+        contract,
+        signal_limit=STATUS_CONTRACT_SIGNAL_LIMIT,
+    )

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -275,10 +275,6 @@ from .control_plane.agents.management_projection import (
 from .control_plane.runtime.stale_latest_run import (
     stale_latest_run_projection_warning as _stale_latest_run_projection_warning_read_model,
 )
-from .control_plane.work_items.status_contract import (
-    build_contract_health_projection as _build_contract_health_projection_read_model,
-    build_status_contract as _build_status_contract_read_model,
-)
 from .control_plane.todos.todo_summary import (
     MAX_DEFERRED_TODO_VISIBILITY_ITEMS as _TODO_SUMMARY_MAX_DEFERRED_TODO_VISIBILITY_ITEMS,
     MAX_DEPENDENCY_BLOCKERS as _TODO_SUMMARY_MAX_DEPENDENCY_BLOCKERS,
@@ -2941,18 +2937,19 @@ def compact_run(run: dict[str, Any]) -> dict[str, Any]:
 
 
 def build_status_contract() -> dict[str, Any]:
-    return _build_status_contract_read_model(
-        schema_version=STATUS_CONTRACT_SCHEMA_VERSION,
-        minimum_dashboard_schema_version=MINIMUM_DASHBOARD_STATUS_CONTRACT_SCHEMA_VERSION,
-        reload_hint=STATUS_CONTRACT_RELOAD_HINT,
+    from .control_plane.status.contract_projection import (
+        build_status_contract as _build_status_contract,
     )
+
+    return _build_status_contract()
 
 
 def build_contract_health_projection(contract: dict[str, Any]) -> dict[str, Any]:
-    return _build_contract_health_projection_read_model(
-        contract,
-        signal_limit=STATUS_CONTRACT_SIGNAL_LIMIT,
+    from .control_plane.status.contract_projection import (
+        build_contract_health_projection as _build_contract_health_projection,
     )
+
+    return _build_contract_health_projection(contract)
 
 
 def build_status_runtime_summary_context() -> StatusRuntimeSummaryContext:


### PR DESCRIPTION
## Change

Q4 first real replacement slice: `build_status_contract` and `build_contract_health_projection` move into `loopx/control_plane/status/contract_projection.py`, including their status-contract constants.

`loopx/status.py` keeps the public compatibility functions as thin local wrappers and retains the public constants that existing smokes read from the facade.

## Surfaces

- `loopx/control_plane/status/contract_projection.py`: new bounded status presentation module.
- `loopx/status.py`: facade wrappers delegate to the bounded module.

## Validation

- Full pytest: `2306 passed, 2 skipped`.
- Focused status/contract + import-boundary + maintainability ratchet: `26 passed`.
- Ruff: `All checks passed`.
- `loopx canary premerge --from-git-diff`: passed, `selected=17 failures=0`, `self_merge_allowed=true`.

No failures or skips beyond the pre-existing suite skips. No manual holds.

## Routing

Route: `codex-side-bypass`; not assigned to `codex-quality-qualification`.