### PR TITLE
refactor(status): move monitor display projections into bounded module

### DIFF
--- a/loopx/control_plane/status/monitor_display_projection.py
+++ b/loopx/control_plane/status/monitor_display_projection.py
@@ -1,0 +1,69 @@
+"""Monitor-display status projections inside the `status` bounded context."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..scheduler.monitor_display import (
+    attention_item_is_monitor_quiet_display_candidate as _attention_item_is_monitor_quiet_display_candidate,
+    normalize_monitor_quiet_attention_display as _normalize_monitor_quiet_attention_display,
+    quiet_monitor_display_action as _quiet_monitor_display_action,
+    todo_summary_lane_items as _todo_summary_lane_items,
+    todo_summary_open_count as _todo_summary_open_count,
+)
+from ..todos.todo_summary import (
+    MAX_STATUS_TODOS_PER_ROLE,
+    open_todo_items,
+    todo_item_is_actionable_open,
+)
+
+
+MONITOR_DISPLAY_SCHEMA_VERSION = "monitor_quiet_display_v0"
+MONITOR_DISPLAY_STOP_CONDITION = (
+    "stop until a material monitor transition, regression, or concrete blocker appears"
+)
+MONITOR_DISPLAY_FALLBACK_ACTION = (
+    "No immediate agent work; keep the monitor quiet until a material monitor "
+    "transition, regression, or concrete blocker appears."
+)
+MONITOR_SIGNAL_WAITING_ON = "monitor_signal"
+
+
+def todo_summary_open_count(summary: dict[str, Any] | None) -> int:
+    return _todo_summary_open_count(
+        summary,
+        open_todo_items=open_todo_items,
+        todo_item_is_actionable_open=todo_item_is_actionable_open,
+        fallback_limit=MAX_STATUS_TODOS_PER_ROLE,
+    )
+
+
+def todo_summary_lane_items(summary: dict[str, Any] | None, lane: str) -> list[dict[str, Any]]:
+    return _todo_summary_lane_items(summary, lane)
+
+
+def attention_item_is_monitor_quiet_display_candidate(item: dict[str, Any]) -> bool:
+    return _attention_item_is_monitor_quiet_display_candidate(
+        item,
+        open_todo_items=open_todo_items,
+        todo_item_is_actionable_open=todo_item_is_actionable_open,
+        fallback_limit=MAX_STATUS_TODOS_PER_ROLE,
+    )
+
+
+def quiet_monitor_display_action(raw_action: str | None) -> str:
+    return _quiet_monitor_display_action(
+        raw_action,
+        fallback_action=MONITOR_DISPLAY_FALLBACK_ACTION,
+    )
+
+
+def normalize_monitor_quiet_attention_display(item: dict[str, Any]) -> None:
+    _normalize_monitor_quiet_attention_display(
+        item,
+        is_monitor_quiet_display_candidate=attention_item_is_monitor_quiet_display_candidate,
+        display_fallback_action=MONITOR_DISPLAY_FALLBACK_ACTION,
+        monitor_signal_waiting_on=MONITOR_SIGNAL_WAITING_ON,
+        monitor_display_schema_version=MONITOR_DISPLAY_SCHEMA_VERSION,
+        monitor_display_stop_condition=MONITOR_DISPLAY_STOP_CONDITION,
+    )

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -107,13 +107,6 @@ from .control_plane.work_items.delivery_signals import (
     outcome_gap_streak as _outcome_gap_streak_read_model,
     small_delivery_batch_scale_streak as _small_delivery_batch_scale_streak_read_model,
 )
-from .control_plane.scheduler.monitor_display import (
-    attention_item_is_monitor_quiet_display_candidate as _attention_item_is_monitor_quiet_display_candidate,
-    normalize_monitor_quiet_attention_display as _normalize_monitor_quiet_attention_display,
-    quiet_monitor_display_action as _quiet_monitor_display_action,
-    todo_summary_lane_items as _todo_summary_lane_items,
-    todo_summary_open_count as _todo_summary_open_count,
-)
 from .control_plane.runtime.run_compaction import (
     RUN_BASE_COMPACT_FIELDS,
     attach_run_summary_projections as _attach_run_summary_projections_read_model,
@@ -239,7 +232,6 @@ from .control_plane.todos.todo_summary import (
     project_asset_todo_summary,
     sync_connected_attention_action_from_todos as _sync_connected_attention_action_from_todos_read_model,
     todo_lane_items as todo_lane_items,
-    todo_item_is_actionable_open,
     todo_item_is_deferred as todo_item_is_deferred,
     todo_item_is_due_monitor as todo_item_is_due_monitor,
     todo_item_missing_monitor_schedule as todo_item_missing_monitor_schedule,
@@ -2468,43 +2460,43 @@ def active_state_todo_attention_item(
 
 
 def todo_summary_open_count(summary: dict[str, Any] | None) -> int:
-    return _todo_summary_open_count(
-        summary,
-        open_todo_items=open_todo_items,
-        todo_item_is_actionable_open=todo_item_is_actionable_open,
-        fallback_limit=MAX_STATUS_TODOS_PER_ROLE,
+    from .control_plane.status.monitor_display_projection import (
+        todo_summary_open_count as _todo_summary_open_count,
     )
+
+    return _todo_summary_open_count(summary)
 
 
 def todo_summary_lane_items(summary: dict[str, Any] | None, lane: str) -> list[dict[str, Any]]:
+    from .control_plane.status.monitor_display_projection import (
+        todo_summary_lane_items as _todo_summary_lane_items,
+    )
+
     return _todo_summary_lane_items(summary, lane)
 
 
 def attention_item_is_monitor_quiet_display_candidate(item: dict[str, Any]) -> bool:
-    return _attention_item_is_monitor_quiet_display_candidate(
-        item,
-        open_todo_items=open_todo_items,
-        todo_item_is_actionable_open=todo_item_is_actionable_open,
-        fallback_limit=MAX_STATUS_TODOS_PER_ROLE,
+    from .control_plane.status.monitor_display_projection import (
+        attention_item_is_monitor_quiet_display_candidate as _attention_item_is_monitor_quiet_display_candidate,
     )
+
+    return _attention_item_is_monitor_quiet_display_candidate(item)
 
 
 def quiet_monitor_display_action(raw_action: str | None) -> str:
-    return _quiet_monitor_display_action(
-        raw_action,
-        fallback_action=MONITOR_DISPLAY_FALLBACK_ACTION,
+    from .control_plane.status.monitor_display_projection import (
+        quiet_monitor_display_action as _quiet_monitor_display_action,
     )
+
+    return _quiet_monitor_display_action(raw_action)
 
 
 def normalize_monitor_quiet_attention_display(item: dict[str, Any]) -> None:
-    _normalize_monitor_quiet_attention_display(
-        item,
-        is_monitor_quiet_display_candidate=attention_item_is_monitor_quiet_display_candidate,
-        display_fallback_action=MONITOR_DISPLAY_FALLBACK_ACTION,
-        monitor_signal_waiting_on=MONITOR_SIGNAL_WAITING_ON,
-        monitor_display_schema_version=MONITOR_DISPLAY_SCHEMA_VERSION,
-        monitor_display_stop_condition=MONITOR_DISPLAY_STOP_CONDITION,
+    from .control_plane.status.monitor_display_projection import (
+        normalize_monitor_quiet_attention_display as _normalize_monitor_quiet_attention_display,
     )
+
+    _normalize_monitor_quiet_attention_display(item)
 
 
 def merge_global_registry_attention_findings(


### PR DESCRIPTION
## Change

Q4 ninth status extraction slice: monitor-display and todo-summary projections move into `loopx/control_plane/status/monitor_display_projection.py`:

- `todo_summary_open_count`
- `todo_summary_lane_items`
- `attention_item_is_monitor_quiet_display_candidate`
- `quiet_monitor_display_action`
- `normalize_monitor_quiet_attention_display`

`loopx.status` keeps the public compatibility functions as thin local wrappers.

## Surfaces

- `loopx/control_plane/status/monitor_display_projection.py`: new bounded status projection module.
- `loopx/status.py`: facade wrappers delegate to the bounded module.

## Validation

- Full pytest: `2306 passed, 2 skipped`.
- Focused status/todo/monitor/contract/import-boundary/maintainability: `23 passed`.
- Ruff: `All checks passed`.
- `loopx canary premerge --from-git-diff`: passed, `selected=17 failures=0`, `self_merge_allowed=true`.

No failures or skips beyond the pre-existing suite skips. No manual holds.

## Routing

Route: `codex-side-bypass`; not assigned to `codex-quality-qualification`.