### PR TITLE
refactor(heartbeat): move prompt support helpers into bounded modules

### DIFF
--- a/loopx/control_plane/heartbeat/agent.py
+++ b/loopx/control_plane/heartbeat/agent.py
@@ -1,0 +1,173 @@
+"""Heartbeat agent identity helpers inside the heartbeat bounded context."""
+
+from __future__ import annotations
+
+import shlex
+from typing import Any
+
+from ..agents.runtime_model import PEER_AGENT_PROFILE_SCHEMA_VERSION
+
+
+def normalize_agent_scope(value: Any) -> str | None:
+    candidate = " ".join(str(value or "").strip().split())
+    if not candidate:
+        return None
+    if len(candidate) > 180 or any(char in candidate for char in "<>"):
+        raise ValueError("agent scope must be compact text without angle brackets")
+    return candidate
+
+
+def normalize_agent_scopes(values: list[str] | tuple[str, ...] | None) -> list[str]:
+    scopes: list[str] = []
+    for value in values or []:
+        scope = normalize_agent_scope(value)
+        if scope and scope not in scopes:
+            scopes.append(scope)
+    return scopes
+
+
+def agent_profile_scopes(profile: dict[str, Any] | None) -> list[str]:
+    if not isinstance(profile, dict):
+        return []
+    raw_scopes: list[Any] = []
+    for key in ("scope_summary", "default_scope", "scope"):
+        value = profile.get(key)
+        if isinstance(value, list):
+            raw_scopes.extend(value)
+        elif value:
+            raw_scopes.append(value)
+    for key in ("scope_summaries", "default_scopes", "scopes"):
+        value = profile.get(key)
+        if isinstance(value, list):
+            raw_scopes.extend(value)
+    return normalize_agent_scopes(raw_scopes)
+
+
+def agent_profile_prompt_projection(profile: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(profile, dict):
+        return None
+    public_keys = {
+        "schema_version",
+        "agent_id",
+        "profile_role",
+        "scope_summary",
+        "default_scope",
+        "scope",
+        "scope_summaries",
+        "default_scopes",
+        "scopes",
+        "default_task_classes",
+        "vision_requirement",
+        "preferred_action_kinds",
+        "avoid_action_kinds",
+    }
+    projection = {key: value for key, value in profile.items() if key in public_keys}
+    projection["schema_version"] = PEER_AGENT_PROFILE_SCHEMA_VERSION
+    return projection or None
+
+
+def agent_prompt_command_args(*, agent_id: str | None, agent_scopes: list[str]) -> str:
+    parts: list[str] = []
+    if agent_id:
+        parts.extend(["--agent-id", agent_id])
+    for scope in agent_scopes:
+        parts.extend(["--agent-scope", scope])
+    return "".join(f" {shlex.quote(part)}" for part in parts)
+
+
+def build_peer_identity_required_error(
+    *,
+    goal_id: str,
+    cli_bin: str,
+    active_state_arg: str,
+    full: bool,
+    compact: bool,
+    brief: bool,
+    thin: bool,
+    registered_agents: list[str],
+) -> str:
+    mode_arg = (
+        " --thin"
+        if thin
+        else " --brief"
+        if brief
+        else " --compact"
+        if compact
+        else " --full"
+        if full
+        else ""
+    )
+    base = (
+        f"{cli_bin} heartbeat-prompt{mode_arg} "
+        f"--goal-id {shlex.quote(goal_id)}{active_state_arg}"
+    )
+    examples = "; ".join(
+        f"`{base} --agent-id {shlex.quote(agent)} "
+        "--agent-scope 'peer task claims and leases'`"
+        for agent in registered_agents[:2]
+    )
+    return (
+        "identity-aware peer heartbeat prompt required: "
+        f"coordination.registered_agents is configured for goal_id={goal_id!r}, "
+        "so automation prompts without --agent-id are not accepted. Regenerate each "
+        f"installed automation with its registered identity. Examples: {examples}."
+    )
+
+
+def render_peer_agent_scope_instruction(
+    *,
+    goal_id: str,
+    agent_id: str | None,
+    agent_scopes: list[str],
+    cli_bin: str,
+    compact: bool = False,
+    thin: bool = False,
+) -> str:
+    if not agent_id and not agent_scopes:
+        return ""
+    identity = agent_id or "<registered-agent-id>"
+    scope_text = "; ".join(agent_scopes) if agent_scopes else "registered peer lane"
+    scope_text = scope_text.rstrip(".!?")
+    claim_command = (
+        f"{cli_bin} todo claim --goal-id {goal_id} --todo-id <todo_id> "
+        f"--claimed-by {agent_id} --agent-id {agent_id}"
+        if agent_id
+        else f"{cli_bin} todo claim --goal-id {goal_id} --todo-id <todo_id> "
+        "--claimed-by <agent_id> --agent-id <agent_id>"
+    )
+    peer_rule = (
+        "You are an equal peer agent: claim or lease in-scope work; use an independent worktree "
+        "for repository writes; follow todo continuation policy. PR review is "
+        "user_action with a runnable successor; gate only exact merge/release/launch "
+        "authority. Task-scoped coordination grants no authority over other agents."
+    )
+    if thin:
+        return (
+            f"Equal peer `{identity}` (peer_v1); scope: {scope_text}. Claim/lease first; "
+            "independent repo worktree; todo continuation; no cross-agent authority; "
+            "no scope in todo metadata."
+        )
+    if compact:
+        return (
+            f"Agent identity and scope: agent_id `{identity}`; model: peer_v1; "
+            f"scope: {scope_text}. {peer_rule} Claim: `{claim_command}`. "
+            "Do not write scope into todo metadata."
+        )
+    return f"""Agent identity and scope:
+
+- agent_id: `{identity}`
+- agent_model: `peer_v1`
+- scope: {scope_text}
+
+{peer_rule}
+
+Before delivery, claim an in-scope open todo:
+
+```bash
+{claim_command}
+```
+
+If a todo is claimed or leased by another peer, choose another in-scope item or
+record no in-scope work internally. Only `NOTIFY` reports it; `DONT_NOTIFY` stays quiet.
+Scope belongs in the heartbeat prompt, not todo metadata.
+"""

--- a/loopx/control_plane/heartbeat/budget.py
+++ b/loopx/control_plane/heartbeat/budget.py
@@ -1,0 +1,66 @@
+"""Heartbeat prompt budget helpers inside the heartbeat bounded context."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+INTERFACE_BUDGET_CHARS = {
+    "full": 12_000,
+    "compact": 6_200,
+    "brief": 3_500,
+    "thin": 1_750,
+    "visible_goal": 4_000,
+}
+NATIVE_GOAL_HOST_MAX_CHARS = INTERFACE_BUDGET_CHARS["visible_goal"]
+
+
+def heartbeat_prompt_mode(
+    *,
+    full: bool = False,
+    compact: bool = False,
+    brief: bool = False,
+    thin: bool = False,
+) -> str:
+    if full:
+        return "full"
+    if thin:
+        return "thin"
+    if brief:
+        return "brief"
+    if compact:
+        return "compact"
+    return "thin"
+
+
+def prompt_budget_text(text: str, *, goal_id: str, active_state: str) -> str:
+    return text.replace(goal_id, "<GOAL_ID>").replace(active_state, "<ACTIVE_STATE>")
+
+
+def build_interface_budget(
+    *,
+    task_body: str,
+    goal_id: str,
+    active_state: str,
+    full: bool = False,
+    compact: bool = False,
+    brief: bool = False,
+    thin: bool = False,
+    native_goal_host: bool = False,
+) -> dict[str, Any]:
+    mode = (
+        "visible_goal"
+        if native_goal_host
+        else heartbeat_prompt_mode(full=full, compact=compact, brief=brief, thin=thin)
+    )
+    budget_text = prompt_budget_text(task_body, goal_id=goal_id, active_state=active_state)
+    budget_chars = len(budget_text)
+    max_chars = INTERFACE_BUDGET_CHARS[mode]
+    return {
+        "mode": mode,
+        "char_count": len(task_body),
+        "line_count": len(task_body.splitlines()),
+        "budget_char_count": budget_chars,
+        "max_chars": max_chars,
+        "within_budget": budget_chars <= max_chars,
+    }

--- a/loopx/control_plane/heartbeat/builder.py
+++ b/loopx/control_plane/heartbeat/builder.py
@@ -8,30 +8,6 @@ from typing import Any
 
 from ...agent_registry import normalize_registered_agents
 from ...ark_managed_agent_host import build_ark_managed_agent_host_contract
-from ...heartbeat_prompt import (
-    DEFAULT_MATERIAL_QUEUE_RULE,
-    DEFAULT_PERMISSION_RULE,
-    NATIVE_GOAL_HOST_MAX_CHARS,
-    agent_prompt_command_args,
-    agent_profile_prompt_projection,
-    agent_profile_scopes,
-    build_interface_budget,
-    build_peer_identity_required_error,
-    build_visible_goal_initial_runtime_capability_projection,
-    normalize_agent_scopes,
-    render_peer_agent_scope_instruction,
-    uses_ark_managed_agent_goal_host,
-    uses_native_goal_host_loop,
-    validate_visible_goal_policy_rule,
-)
-from ...project_prompt import (
-    render_accountable_progress_refresh_command,
-    render_available_capability_args,
-    render_cli_preflight,
-    render_quota_guard_command,
-    render_quota_spend_command,
-    render_refresh_state_command,
-)
 from ..agents.runtime_model import AgentRuntimeModel
 from ..quota.spend_sources import (
     DEFAULT_SLOT_SPEND_SOURCE,
@@ -45,6 +21,26 @@ from ..todos.contract import (
     normalize_required_capabilities,
     normalize_todo_claimed_by,
 )
+from .agent import (
+    agent_prompt_command_args,
+    agent_profile_prompt_projection,
+    agent_profile_scopes,
+    build_peer_identity_required_error,
+    normalize_agent_scopes,
+    render_peer_agent_scope_instruction,
+)
+from .budget import (
+    NATIVE_GOAL_HOST_MAX_CHARS,
+    build_interface_budget,
+)
+from .host import (
+    uses_ark_managed_agent_goal_host,
+    uses_native_goal_host_loop,
+)
+from .rules import (
+    DEFAULT_MATERIAL_QUEUE_RULE,
+    DEFAULT_PERMISSION_RULE,
+)
 from .task_body import (
     render_ark_managed_agent_goal_task_body,
     render_brief_heartbeat_task_body,
@@ -53,6 +49,18 @@ from .task_body import (
     render_thin_heartbeat_task_body,
     render_traex_visible_goal_task_body,
     render_visible_goal_task_body,
+)
+from .visible_goal import (
+    build_visible_goal_initial_runtime_capability_projection,
+    validate_visible_goal_policy_rule,
+)
+from ...project_prompt import (
+    render_accountable_progress_refresh_command,
+    render_available_capability_args,
+    render_cli_preflight,
+    render_quota_guard_command,
+    render_quota_spend_command,
+    render_refresh_state_command,
 )
 
 

--- a/loopx/control_plane/heartbeat/host.py
+++ b/loopx/control_plane/heartbeat/host.py
@@ -1,0 +1,64 @@
+"""Heartbeat host detection helpers inside the heartbeat bounded context."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..scheduler.execution_context import (
+    ExecutionMode,
+    HostSurface,
+    NATIVE_GOAL_RUNTIME_PROFILES,
+    SchedulerOwner,
+    SchedulerRuntimeProfile,
+    resolve_scheduler_execution_context,
+)
+
+
+def uses_native_goal_host_loop(
+    *,
+    runtime_profile: str | None,
+    scheduler_execution_context: dict[str, Any] | None,
+) -> bool:
+    if runtime_profile:
+        try:
+            profile = SchedulerRuntimeProfile(runtime_profile)
+        except ValueError:
+            return False
+        return profile in NATIVE_GOAL_RUNTIME_PROFILES
+    if scheduler_execution_context is None:
+        return False
+    resolution = resolve_scheduler_execution_context(scheduler_execution_context)
+    if not resolution.ok or resolution.context is None:
+        return False
+    context = resolution.context
+    if context.execution_mode is not ExecutionMode.INTERACTIVE:
+        return False
+    if context.host_surface is HostSurface.ARK_MANAGED_AGENT:
+        return context.scheduler_owner is SchedulerOwner.GOAL_RUNTIME
+    return (
+        context.host_surface in {HostSurface.CODEX_APP_SSH, HostSurface.CODEX_CLI}
+        and context.scheduler_owner is SchedulerOwner.AGENT_CLI_LOOP
+    )
+
+
+def uses_ark_managed_agent_goal_host(
+    *,
+    runtime_profile: str | None,
+    scheduler_execution_context: dict[str, Any] | None,
+) -> bool:
+    if runtime_profile:
+        try:
+            return (
+                SchedulerRuntimeProfile(runtime_profile)
+                is SchedulerRuntimeProfile.ARK_MANAGED_AGENT_GOAL
+            )
+        except ValueError:
+            return False
+    if scheduler_execution_context is None:
+        return False
+    resolution = resolve_scheduler_execution_context(scheduler_execution_context)
+    return bool(
+        resolution.ok
+        and resolution.context is not None
+        and resolution.context.host_surface is HostSurface.ARK_MANAGED_AGENT
+    )

--- a/loopx/control_plane/heartbeat/rules.py
+++ b/loopx/control_plane/heartbeat/rules.py
@@ -1,0 +1,51 @@
+"""Heartbeat prompt rule constants inside the heartbeat bounded context."""
+
+from __future__ import annotations
+
+
+DEFAULT_MATERIAL_QUEUE_RULE = "Do not consume the learning material queue unless the user explicitly asks."
+DEFAULT_PERMISSION_RULE = "Do not ask for permissions when the current Codex session is already trusted."
+USER_TODO_FINAL_MESSAGE_RULE = (
+    "`interaction_contract.user_channel.notify` controls output: `NOTIFY` -> concrete "
+    "action; otherwise quiet. `should_run`/due monitor and other-agent scoped todos "
+    "are not user prompts. Only inside `NOTIFY`, `action_required` without an action -> "
+    '"具体 user todo 未投影，需修复 LoopX 状态投影"; with `DONT_NOTIFY`, repair '
+    "the projection internally and stay quiet."
+)
+HEARTBEAT_NOTIFICATION_RULE_SHORT = (
+    "`user_channel.notify`: NOTIFY=Chinese action; DONT_NOTIFY=quiet. "
+    "Due/peer gate != prompt; missing NOTIFY action->"
+    "具体user todo未投影，需修复LoopX状态投影."
+)
+HEARTBEAT_VISION_WRITEBACK_RULE_SHORT = (
+    "writeback: no-change=`surface_only`/no spend; "
+    "unchanged->`--vision-unchanged-reason`; material->actual outcome."
+)
+SCHEDULER_HINT_APPLICATION_RULE = (
+    "`scheduler_hint` no-spend. host_action=pause_or_delete_current_heartbeat -> "
+    "automation_update stop once, verify, end; else apply_needed -> RRULE then "
+    "ack/failure_hint; ack_needed -> ack."
+)
+SCHEDULER_HINT_COMPACT_RULE = (
+    "host_action=pause_or_delete_current_heartbeat: automation_update stop; "
+    "else RRULE apply/ack/fail. No spend."
+)
+SCHEDULER_HINT_THIN_RULE = (
+    "host_action=pause_or_delete_current_heartbeat->automation_update stop(no-spend); "
+    "else RRULE/ack/fail."
+)
+RUNTIME_CAPABILITY_PROJECTION_THIN_RULE = (
+    "Observed capabilities -> `--available-capability`; never user gates."
+)
+RUNTIME_EXECUTION_ROUTING_RULE = (
+    "Normal turns use CLI `interaction_contract`; use `loopx-project` for "
+    "lifecycle/registry and `loopx-self-repair` for runtime/projection drift."
+)
+CODEX_NATIVE_GOAL_UNCHANGED_WAIT_RULE = """
+
+Native Codex `/goal` owns its blocked state. At the matching
+`scheduler_hint.unchanged_poll` limit, rerun quota once. If the same blocking
+condition remains for the third consecutive Goal turn and no meaningful progress
+is possible, call `update_goal` with `status=blocked`. This stops native Goal
+continuation without spending or completing LoopX. Only user `/goal resume`
+reactivates it; rerun quota after resume."""

--- a/loopx/control_plane/heartbeat/task_body.py
+++ b/loopx/control_plane/heartbeat/task_body.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from ...heartbeat_prompt import (
+from .rules import (
     CODEX_NATIVE_GOAL_UNCHANGED_WAIT_RULE,
     DEFAULT_MATERIAL_QUEUE_RULE,
     DEFAULT_PERMISSION_RULE,

--- a/loopx/control_plane/heartbeat/visible_goal.py
+++ b/loopx/control_plane/heartbeat/visible_goal.py
@@ -1,0 +1,86 @@
+"""Visible Goal host policy helpers inside the heartbeat bounded context."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from ..agents.capability_gate import (
+    runtime_capabilities_for_cli_projection,
+)
+from ..work_items.runtime_capability_reentry import (
+    RUNTIME_CAPABILITY_REENTRY_SCHEMA_VERSION,
+)
+
+
+VISIBLE_GOAL_INITIAL_RUNTIME_CAPABILITY_PROJECTION_SCHEMA_VERSION = (
+    "visible_goal_initial_runtime_capability_projection_v0"
+)
+VISIBLE_GOAL_INITIAL_RUNTIME_CAPABILITY_LIMIT = 8
+VISIBLE_GOAL_HOST_CONTROL_CAPABILITIES = frozenset(
+    {
+        "automation_update",
+        "current_time",
+        "first_turn_receipt",
+        "heartbeat_prequota",
+        "loop",
+        "loopx_turn",
+        "rrule",
+        "scheduler_execution_context",
+        "turn_instance_id",
+    }
+)
+VISIBLE_GOAL_HEARTBEAT_ONLY_POLICY_PATTERNS = (
+    re.compile(r"(?<![a-z0-9_/])/loop(?![a-z0-9_-])", re.IGNORECASE),
+    re.compile(r"\bautomation(?:[\s_-]+update)?\b", re.IGNORECASE),
+    re.compile(r"\bheartbeat(?:[\s_-]+prequota)?\b", re.IGNORECASE),
+    re.compile(r"\brrule\b", re.IGNORECASE),
+    re.compile(r"\breceipt\b|\bfirst[\s_-]*turn[\s_-]*receipt\b", re.IGNORECASE),
+    re.compile(r"\bcurrent[\s_-]*time(?:[\s_-]*iso)?\b", re.IGNORECASE),
+    re.compile(r"\bloopx[\s_-]*turn\b", re.IGNORECASE),
+    re.compile(r"\bturn[\s_-]*instance[\s_-]*id\b", re.IGNORECASE),
+    re.compile(r"\bscheduler(?:[\s_-]*execution[\s_-]*context)?\b", re.IGNORECASE),
+)
+
+
+def build_visible_goal_initial_runtime_capability_projection(
+    available_capabilities: Any,
+) -> dict[str, Any] | None:
+    capabilities = [
+        capability
+        for capability in runtime_capabilities_for_cli_projection(
+            available_capabilities
+        )
+        if capability not in VISIBLE_GOAL_HOST_CONTROL_CAPABILITIES
+    ]
+    if not capabilities:
+        return None
+    if len(capabilities) > VISIBLE_GOAL_INITIAL_RUNTIME_CAPABILITY_LIMIT:
+        raise ValueError(
+            "visible Goal initial runtime capabilities exceed the limit of "
+            f"{VISIBLE_GOAL_INITIAL_RUNTIME_CAPABILITY_LIMIT}"
+        )
+    return {
+        "schema_version": (
+            VISIBLE_GOAL_INITIAL_RUNTIME_CAPABILITY_PROJECTION_SCHEMA_VERSION
+        ),
+        "source": "activation_available_capabilities",
+        "scope": "visible_goal_session",
+        "capabilities": capabilities,
+        "capability_count": len(capabilities),
+        "max_capabilities": VISIBLE_GOAL_INITIAL_RUNTIME_CAPABILITY_LIMIT,
+        "first_quota_path": "task_body.quota_guard_command",
+        "user_gate": False,
+        "durable_grant_written": False,
+        "dynamic_reentry_schema_version": RUNTIME_CAPABILITY_REENTRY_SCHEMA_VERSION,
+    }
+
+
+def validate_visible_goal_policy_rule(*, field: str, value: str) -> None:
+    if any(
+        pattern.search(value)
+        for pattern in VISIBLE_GOAL_HEARTBEAT_ONLY_POLICY_PATTERNS
+    ):
+        raise ValueError(
+            f"visible Goal {field} contains heartbeat-only control vocabulary"
+        )

--- a/loopx/heartbeat_prompt.py
+++ b/loopx/heartbeat_prompt.py
@@ -1,419 +1,97 @@
+"""Public heartbeat prompt compatibility surface."""
+
 from __future__ import annotations
 
-import re
-import shlex
 from typing import Any
 
-from .control_plane.scheduler.execution_context import (
-    ExecutionMode,
-    HostSurface,
-    NATIVE_GOAL_RUNTIME_PROFILES,
-    SchedulerOwner,
-    SchedulerRuntimeProfile,
-    resolve_scheduler_execution_context,
+from .control_plane.heartbeat.agent import (
+    agent_prompt_command_args,
+    agent_profile_prompt_projection,
+    agent_profile_scopes,
+    build_peer_identity_required_error,
+    normalize_agent_scope,
+    normalize_agent_scopes,
+    render_peer_agent_scope_instruction,
 )
-from .control_plane.agents.capability_gate import (
-    runtime_capabilities_for_cli_projection,
+from .control_plane.heartbeat.budget import (
+    INTERFACE_BUDGET_CHARS,
+    NATIVE_GOAL_HOST_MAX_CHARS,
+    build_interface_budget,
+    heartbeat_prompt_mode,
+    prompt_budget_text,
 )
-from .control_plane.agents.runtime_model import (
-    PEER_AGENT_PROFILE_SCHEMA_VERSION,
+from .control_plane.heartbeat.host import (
+    uses_ark_managed_agent_goal_host,
+    uses_native_goal_host_loop,
 )
-from .control_plane.work_items.runtime_capability_reentry import (
-    RUNTIME_CAPABILITY_REENTRY_SCHEMA_VERSION,
+from .control_plane.heartbeat.rules import (
+    CODEX_NATIVE_GOAL_UNCHANGED_WAIT_RULE,
+    DEFAULT_MATERIAL_QUEUE_RULE,
+    DEFAULT_PERMISSION_RULE,
+    HEARTBEAT_NOTIFICATION_RULE_SHORT,
+    HEARTBEAT_VISION_WRITEBACK_RULE_SHORT,
+    RUNTIME_CAPABILITY_PROJECTION_THIN_RULE,
+    RUNTIME_EXECUTION_ROUTING_RULE,
+    SCHEDULER_HINT_APPLICATION_RULE,
+    SCHEDULER_HINT_COMPACT_RULE,
+    SCHEDULER_HINT_THIN_RULE,
+    USER_TODO_FINAL_MESSAGE_RULE,
 )
-
-
-DEFAULT_MATERIAL_QUEUE_RULE = "Do not consume the learning material queue unless the user explicitly asks."
-DEFAULT_PERMISSION_RULE = "Do not ask for permissions when the current Codex session is already trusted."
-USER_TODO_FINAL_MESSAGE_RULE = (
-    "`interaction_contract.user_channel.notify` controls output: `NOTIFY` -> concrete "
-    "action; otherwise quiet. `should_run`/due monitor and other-agent scoped todos "
-    "are not user prompts. Only inside `NOTIFY`, `action_required` without an action -> "
-    '"具体 user todo 未投影，需修复 LoopX 状态投影"; with `DONT_NOTIFY`, repair '
-    "the projection internally and stay quiet."
-)
-HEARTBEAT_NOTIFICATION_RULE_SHORT = (
-    "`user_channel.notify`: NOTIFY=Chinese action; DONT_NOTIFY=quiet. "
-    "Due/peer gate != prompt; missing NOTIFY action->"
-    "具体user todo未投影，需修复LoopX状态投影."
-)
-HEARTBEAT_VISION_WRITEBACK_RULE_SHORT = (
-    "writeback: no-change=`surface_only`/no spend; "
-    "unchanged->`--vision-unchanged-reason`; material->actual outcome."
-)
-SCHEDULER_HINT_APPLICATION_RULE = (
-    "`scheduler_hint` no-spend. host_action=pause_or_delete_current_heartbeat -> "
-    "automation_update stop once, verify, end; else apply_needed -> RRULE then "
-    "ack/failure_hint; ack_needed -> ack."
-)
-SCHEDULER_HINT_COMPACT_RULE = (
-    "host_action=pause_or_delete_current_heartbeat: automation_update stop; "
-    "else RRULE apply/ack/fail. No spend."
-)
-SCHEDULER_HINT_THIN_RULE = (
-    "host_action=pause_or_delete_current_heartbeat->automation_update stop(no-spend); "
-    "else RRULE/ack/fail."
-)
-RUNTIME_CAPABILITY_PROJECTION_THIN_RULE = (
-    "Observed capabilities -> `--available-capability`; never user gates."
-)
-RUNTIME_EXECUTION_ROUTING_RULE = (
-    "Normal turns use CLI `interaction_contract`; use `loopx-project` for "
-    "lifecycle/registry and `loopx-self-repair` for runtime/projection drift."
-)
-CODEX_NATIVE_GOAL_UNCHANGED_WAIT_RULE = """
-
-Native Codex `/goal` owns its blocked state. At the matching
-`scheduler_hint.unchanged_poll` limit, rerun quota once. If the same blocking
-condition remains for the third consecutive Goal turn and no meaningful progress
-is possible, call `update_goal` with `status=blocked`. This stops native Goal
-continuation without spending or completing LoopX. Only user `/goal resume`
-reactivates it; rerun quota after resume."""
-INTERFACE_BUDGET_CHARS = {
-    "full": 12_000,
-    "compact": 6_200,
-    "brief": 3_500,
-    "thin": 1_750,
-    "visible_goal": 4_000,
-}
-NATIVE_GOAL_HOST_MAX_CHARS = INTERFACE_BUDGET_CHARS["visible_goal"]
-VISIBLE_GOAL_INITIAL_RUNTIME_CAPABILITY_PROJECTION_SCHEMA_VERSION = (
-    "visible_goal_initial_runtime_capability_projection_v0"
-)
-VISIBLE_GOAL_INITIAL_RUNTIME_CAPABILITY_LIMIT = 8
-VISIBLE_GOAL_HOST_CONTROL_CAPABILITIES = frozenset(
-    {
-        "automation_update",
-        "current_time",
-        "first_turn_receipt",
-        "heartbeat_prequota",
-        "loop",
-        "loopx_turn",
-        "rrule",
-        "scheduler_execution_context",
-        "turn_instance_id",
-    }
-)
-VISIBLE_GOAL_HEARTBEAT_ONLY_POLICY_PATTERNS = (
-    re.compile(r"(?<![a-z0-9_/])/loop(?![a-z0-9_-])", re.IGNORECASE),
-    re.compile(r"\bautomation(?:[\s_-]+update)?\b", re.IGNORECASE),
-    re.compile(r"\bheartbeat(?:[\s_-]+prequota)?\b", re.IGNORECASE),
-    re.compile(r"\brrule\b", re.IGNORECASE),
-    re.compile(r"\breceipt\b|\bfirst[\s_-]*turn[\s_-]*receipt\b", re.IGNORECASE),
-    re.compile(r"\bcurrent[\s_-]*time(?:[\s_-]*iso)?\b", re.IGNORECASE),
-    re.compile(r"\bloopx[\s_-]*turn\b", re.IGNORECASE),
-    re.compile(r"\bturn[\s_-]*instance[\s_-]*id\b", re.IGNORECASE),
-    re.compile(r"\bscheduler(?:[\s_-]*execution[\s_-]*context)?\b", re.IGNORECASE),
+from .control_plane.heartbeat.visible_goal import (
+    VISIBLE_GOAL_HEARTBEAT_ONLY_POLICY_PATTERNS,
+    VISIBLE_GOAL_HOST_CONTROL_CAPABILITIES,
+    VISIBLE_GOAL_INITIAL_RUNTIME_CAPABILITY_LIMIT,
+    VISIBLE_GOAL_INITIAL_RUNTIME_CAPABILITY_PROJECTION_SCHEMA_VERSION,
+    build_visible_goal_initial_runtime_capability_projection,
+    validate_visible_goal_policy_rule,
 )
 
-
-def uses_native_goal_host_loop(
-    *,
-    runtime_profile: str | None,
-    scheduler_execution_context: dict[str, Any] | None,
-) -> bool:
-    if runtime_profile:
-        try:
-            profile = SchedulerRuntimeProfile(runtime_profile)
-        except ValueError:
-            return False
-        return profile in NATIVE_GOAL_RUNTIME_PROFILES
-    if scheduler_execution_context is None:
-        return False
-    resolution = resolve_scheduler_execution_context(scheduler_execution_context)
-    if not resolution.ok or resolution.context is None:
-        return False
-    context = resolution.context
-    if context.execution_mode is not ExecutionMode.INTERACTIVE:
-        return False
-    if context.host_surface is HostSurface.ARK_MANAGED_AGENT:
-        return context.scheduler_owner is SchedulerOwner.GOAL_RUNTIME
-    return (
-        context.host_surface in {HostSurface.CODEX_APP_SSH, HostSurface.CODEX_CLI}
-        and context.scheduler_owner is SchedulerOwner.AGENT_CLI_LOOP
-    )
-
-
-def uses_ark_managed_agent_goal_host(
-    *,
-    runtime_profile: str | None,
-    scheduler_execution_context: dict[str, Any] | None,
-) -> bool:
-    if runtime_profile:
-        try:
-            return (
-                SchedulerRuntimeProfile(runtime_profile)
-                is SchedulerRuntimeProfile.ARK_MANAGED_AGENT_GOAL
-            )
-        except ValueError:
-            return False
-    if scheduler_execution_context is None:
-        return False
-    resolution = resolve_scheduler_execution_context(scheduler_execution_context)
-    return bool(
-        resolution.ok
-        and resolution.context is not None
-        and resolution.context.host_surface is HostSurface.ARK_MANAGED_AGENT
-    )
-
-
-def heartbeat_prompt_mode(
-    *,
-    full: bool = False,
-    compact: bool = False,
-    brief: bool = False,
-    thin: bool = False,
-) -> str:
-    if full:
-        return "full"
-    if thin:
-        return "thin"
-    if brief:
-        return "brief"
-    if compact:
-        return "compact"
-    return "thin"
-
-
-def prompt_budget_text(text: str, *, goal_id: str, active_state: str) -> str:
-    return text.replace(goal_id, "<GOAL_ID>").replace(active_state, "<ACTIVE_STATE>")
-
-
-def normalize_agent_scope(value: Any) -> str | None:
-    candidate = " ".join(str(value or "").strip().split())
-    if not candidate:
-        return None
-    if len(candidate) > 180 or any(char in candidate for char in "<>"):
-        raise ValueError("agent scope must be compact text without angle brackets")
-    return candidate
-
-
-def normalize_agent_scopes(values: list[str] | tuple[str, ...] | None) -> list[str]:
-    scopes: list[str] = []
-    for value in values or []:
-        scope = normalize_agent_scope(value)
-        if scope and scope not in scopes:
-            scopes.append(scope)
-    return scopes
-
-
-def build_visible_goal_initial_runtime_capability_projection(
-    available_capabilities: Any,
-) -> dict[str, Any] | None:
-    capabilities = [
-        capability
-        for capability in runtime_capabilities_for_cli_projection(
-            available_capabilities
-        )
-        if capability not in VISIBLE_GOAL_HOST_CONTROL_CAPABILITIES
-    ]
-    if not capabilities:
-        return None
-    if len(capabilities) > VISIBLE_GOAL_INITIAL_RUNTIME_CAPABILITY_LIMIT:
-        raise ValueError(
-            "visible Goal initial runtime capabilities exceed the limit of "
-            f"{VISIBLE_GOAL_INITIAL_RUNTIME_CAPABILITY_LIMIT}"
-        )
-    return {
-        "schema_version": (
-            VISIBLE_GOAL_INITIAL_RUNTIME_CAPABILITY_PROJECTION_SCHEMA_VERSION
-        ),
-        "source": "activation_available_capabilities",
-        "scope": "visible_goal_session",
-        "capabilities": capabilities,
-        "capability_count": len(capabilities),
-        "max_capabilities": VISIBLE_GOAL_INITIAL_RUNTIME_CAPABILITY_LIMIT,
-        "first_quota_path": "task_body.quota_guard_command",
-        "user_gate": False,
-        "durable_grant_written": False,
-        "dynamic_reentry_schema_version": RUNTIME_CAPABILITY_REENTRY_SCHEMA_VERSION,
-    }
-
-
-def validate_visible_goal_policy_rule(*, field: str, value: str) -> None:
-    if any(
-        pattern.search(value)
-        for pattern in VISIBLE_GOAL_HEARTBEAT_ONLY_POLICY_PATTERNS
-    ):
-        raise ValueError(
-            f"visible Goal {field} contains heartbeat-only control vocabulary"
-        )
-
-
-def agent_profile_scopes(profile: dict[str, Any] | None) -> list[str]:
-    if not isinstance(profile, dict):
-        return []
-    raw_scopes: list[Any] = []
-    for key in ("scope_summary", "default_scope", "scope"):
-        value = profile.get(key)
-        if isinstance(value, list):
-            raw_scopes.extend(value)
-        elif value:
-            raw_scopes.append(value)
-    for key in ("scope_summaries", "default_scopes", "scopes"):
-        value = profile.get(key)
-        if isinstance(value, list):
-            raw_scopes.extend(value)
-    return normalize_agent_scopes(raw_scopes)
-
-
-def agent_profile_prompt_projection(profile: dict[str, Any] | None) -> dict[str, Any] | None:
-    if not isinstance(profile, dict):
-        return None
-    public_keys = {
-        "schema_version",
-        "agent_id",
-        "profile_role",
-        "scope_summary",
-        "default_scope",
-        "scope",
-        "scope_summaries",
-        "default_scopes",
-        "scopes",
-        "default_task_classes",
-        "vision_requirement",
-        "preferred_action_kinds",
-        "avoid_action_kinds",
-    }
-    projection = {key: value for key, value in profile.items() if key in public_keys}
-    projection["schema_version"] = PEER_AGENT_PROFILE_SCHEMA_VERSION
-    return projection or None
-
-
-def agent_prompt_command_args(*, agent_id: str | None, agent_scopes: list[str]) -> str:
-    parts: list[str] = []
-    if agent_id:
-        parts.extend(["--agent-id", agent_id])
-    for scope in agent_scopes:
-        parts.extend(["--agent-scope", scope])
-    return "".join(f" {shlex.quote(part)}" for part in parts)
-
-
-def build_peer_identity_required_error(
-    *,
-    goal_id: str,
-    cli_bin: str,
-    active_state_arg: str,
-    full: bool,
-    compact: bool,
-    brief: bool,
-    thin: bool,
-    registered_agents: list[str],
-) -> str:
-    mode_arg = (
-        " --thin"
-        if thin
-        else " --brief"
-        if brief
-        else " --compact"
-        if compact
-        else " --full"
-        if full
-        else ""
-    )
-    base = (
-        f"{cli_bin} heartbeat-prompt{mode_arg} "
-        f"--goal-id {shlex.quote(goal_id)}{active_state_arg}"
-    )
-    examples = "; ".join(
-        f"`{base} --agent-id {shlex.quote(agent)} "
-        "--agent-scope 'peer task claims and leases'`"
-        for agent in registered_agents[:2]
-    )
-    return (
-        "identity-aware peer heartbeat prompt required: "
-        f"coordination.registered_agents is configured for goal_id={goal_id!r}, "
-        "so automation prompts without --agent-id are not accepted. Regenerate each "
-        f"installed automation with its registered identity. Examples: {examples}."
-    )
-
-
-def render_peer_agent_scope_instruction(
-    *,
-    goal_id: str,
-    agent_id: str | None,
-    agent_scopes: list[str],
-    cli_bin: str,
-    compact: bool = False,
-    thin: bool = False,
-) -> str:
-    if not agent_id and not agent_scopes:
-        return ""
-    identity = agent_id or "<registered-agent-id>"
-    scope_text = "; ".join(agent_scopes) if agent_scopes else "registered peer lane"
-    scope_text = scope_text.rstrip(".!?")
-    claim_command = (
-        f"{cli_bin} todo claim --goal-id {goal_id} --todo-id <todo_id> "
-        f"--claimed-by {agent_id} --agent-id {agent_id}"
-        if agent_id
-        else f"{cli_bin} todo claim --goal-id {goal_id} --todo-id <todo_id> "
-        "--claimed-by <agent_id> --agent-id <agent_id>"
-    )
-    peer_rule = (
-        "You are an equal peer agent: claim or lease in-scope work; use an independent worktree "
-        "for repository writes; follow todo continuation policy. PR review is "
-        "user_action with a runnable successor; gate only exact merge/release/launch "
-        "authority. Task-scoped coordination grants no authority over other agents."
-    )
-    if thin:
-        return (
-            f"Equal peer `{identity}` (peer_v1); scope: {scope_text}. Claim/lease first; "
-            "independent repo worktree; todo continuation; no cross-agent authority; "
-            "no scope in todo metadata."
-        )
-    if compact:
-        return (
-            f"Agent identity and scope: agent_id `{identity}`; model: peer_v1; "
-            f"scope: {scope_text}. {peer_rule} Claim: `{claim_command}`. "
-            "Do not write scope into todo metadata."
-        )
-    return f"""Agent identity and scope:
-
-- agent_id: `{identity}`
-- agent_model: `peer_v1`
-- scope: {scope_text}
-
-{peer_rule}
-
-Before delivery, claim an in-scope open todo:
-
-```bash
-{claim_command}
-```
-
-If a todo is claimed or leased by another peer, choose another in-scope item or
-record no in-scope work internally. Only `NOTIFY` reports it; `DONT_NOTIFY` stays quiet.
-Scope belongs in the heartbeat prompt, not todo metadata.
-"""
-
-
-def build_interface_budget(
-    *,
-    task_body: str,
-    goal_id: str,
-    active_state: str,
-    full: bool = False,
-    compact: bool = False,
-    brief: bool = False,
-    thin: bool = False,
-    native_goal_host: bool = False,
-) -> dict[str, Any]:
-    mode = (
-        "visible_goal"
-        if native_goal_host
-        else heartbeat_prompt_mode(full=full, compact=compact, brief=brief, thin=thin)
-    )
-    budget_text = prompt_budget_text(task_body, goal_id=goal_id, active_state=active_state)
-    budget_chars = len(budget_text)
-    max_chars = INTERFACE_BUDGET_CHARS[mode]
-    return {
-        "mode": mode,
-        "char_count": len(task_body),
-        "line_count": len(task_body.splitlines()),
-        "budget_char_count": budget_chars,
-        "max_chars": max_chars,
-        "within_budget": budget_chars <= max_chars,
-    }
+__all__ = [
+    "CODEX_NATIVE_GOAL_UNCHANGED_WAIT_RULE",
+    "DEFAULT_MATERIAL_QUEUE_RULE",
+    "DEFAULT_PERMISSION_RULE",
+    "HEARTBEAT_NOTIFICATION_RULE_SHORT",
+    "HEARTBEAT_VISION_WRITEBACK_RULE_SHORT",
+    "INTERFACE_BUDGET_CHARS",
+    "NATIVE_GOAL_HOST_MAX_CHARS",
+    "RUNTIME_CAPABILITY_PROJECTION_THIN_RULE",
+    "RUNTIME_EXECUTION_ROUTING_RULE",
+    "SCHEDULER_HINT_APPLICATION_RULE",
+    "SCHEDULER_HINT_COMPACT_RULE",
+    "SCHEDULER_HINT_THIN_RULE",
+    "USER_TODO_FINAL_MESSAGE_RULE",
+    "VISIBLE_GOAL_HEARTBEAT_ONLY_POLICY_PATTERNS",
+    "VISIBLE_GOAL_HOST_CONTROL_CAPABILITIES",
+    "VISIBLE_GOAL_INITIAL_RUNTIME_CAPABILITY_LIMIT",
+    "VISIBLE_GOAL_INITIAL_RUNTIME_CAPABILITY_PROJECTION_SCHEMA_VERSION",
+    "_render_goal_task_body",
+    "agent_prompt_command_args",
+    "agent_profile_prompt_projection",
+    "agent_profile_scopes",
+    "build_heartbeat_prompt",
+    "build_heartbeat_prompt_error_payload",
+    "build_interface_budget",
+    "build_peer_identity_required_error",
+    "build_visible_goal_initial_runtime_capability_projection",
+    "heartbeat_prompt_mode",
+    "normalize_agent_scope",
+    "normalize_agent_scopes",
+    "prompt_budget_text",
+    "render_ark_managed_agent_goal_task_body",
+    "render_brief_heartbeat_task_body",
+    "render_compact_heartbeat_task_body",
+    "render_heartbeat_generator_inputs_markdown",
+    "render_heartbeat_prompt_error_markdown",
+    "render_heartbeat_prompt_markdown",
+    "render_heartbeat_task_body",
+    "render_peer_agent_scope_instruction",
+    "render_thin_heartbeat_task_body",
+    "render_traex_visible_goal_task_body",
+    "render_visible_goal_task_body",
+    "uses_ark_managed_agent_goal_host",
+    "uses_native_goal_host_loop",
+    "validate_visible_goal_policy_rule",
+]
 
 
 def build_heartbeat_prompt(**kwargs):

--- a/tests/control_plane/test_heartbeat_prompt_support.py
+++ b/tests/control_plane/test_heartbeat_prompt_support.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import pytest
+
+from loopx.control_plane.heartbeat.agent import (
+    agent_prompt_command_args,
+    agent_profile_scopes,
+    normalize_agent_scopes,
+)
+from loopx.control_plane.heartbeat.budget import (
+    build_interface_budget,
+    heartbeat_prompt_mode,
+    prompt_budget_text,
+)
+from loopx.control_plane.heartbeat.host import (
+    uses_ark_managed_agent_goal_host,
+    uses_native_goal_host_loop,
+)
+from loopx.control_plane.heartbeat.visible_goal import (
+    build_visible_goal_initial_runtime_capability_projection,
+    validate_visible_goal_policy_rule,
+)
+from loopx.heartbeat_prompt import (
+    build_heartbeat_prompt,
+    render_heartbeat_prompt_markdown,
+)
+
+
+def test_heartbeat_prompt_mode_defaults_to_thin() -> None:
+    assert heartbeat_prompt_mode() == "thin"
+    assert heartbeat_prompt_mode(full=True) == "full"
+    assert heartbeat_prompt_mode(compact=True) == "compact"
+    assert heartbeat_prompt_mode(brief=True) == "brief"
+    assert heartbeat_prompt_mode(thin=True) == "thin"
+
+
+def test_prompt_budget_text_redacts_goal_and_active_state() -> None:
+    rendered = prompt_budget_text(
+        "goal loopx-meta at state file",
+        goal_id="loopx-meta",
+        active_state="file",
+    )
+    assert "<GOAL_ID>" in rendered
+    assert "<ACTIVE_STATE>" in rendered
+    assert "loopx-meta" not in rendered
+    assert "file" not in rendered
+
+
+def test_interface_budget_uses_visible_goal_mode() -> None:
+    budget = build_interface_budget(
+        task_body="short task body",
+        goal_id="loopx-meta",
+        active_state="active",
+        native_goal_host=True,
+    )
+    assert budget["mode"] == "visible_goal"
+    assert budget["max_chars"] == 4000
+    assert budget["within_budget"] is True
+
+
+def test_agent_scope_normalization_dedupes_and_rejects_angle_brackets() -> None:
+    assert normalize_agent_scopes(["a b", "a  b", "c"]) == ["a b", "c"]
+    with pytest.raises(ValueError, match="angle brackets"):
+        normalize_agent_scopes(["bad<scope>"])
+
+
+def test_agent_profile_scopes_reads_common_profile_keys() -> None:
+    profile = {"scope_summary": "one", "default_scopes": ["two three"]}
+    assert agent_profile_scopes(profile) == ["one", "two three"]
+
+
+def test_agent_prompt_command_args_quotes_scopes() -> None:
+    args = agent_prompt_command_args(
+        agent_id="codex-main-control",
+        agent_scopes=["peer task claims"],
+    )
+    assert "--agent-id codex-main-control" in args
+    assert "--agent-scope 'peer task claims'" in args
+
+
+def test_host_detection_prefers_runtime_profile() -> None:
+    assert (
+        uses_native_goal_host_loop(
+            runtime_profile="codex_cli",
+            scheduler_execution_context=None,
+        )
+        is True
+    )
+    assert (
+        uses_native_goal_host_loop(
+            runtime_profile="generic_cli",
+            scheduler_execution_context=None,
+        )
+        is False
+    )
+    assert (
+        uses_ark_managed_agent_goal_host(
+            runtime_profile="ark_managed_agent_goal",
+            scheduler_execution_context=None,
+        )
+        is True
+    )
+
+
+def test_visible_goal_capability_projection_filters_control_vocabulary() -> None:
+    projection = build_visible_goal_initial_runtime_capability_projection(
+        ["loop", "network", "external_evidence_poll"]
+    )
+    assert projection is not None
+    assert "loop" not in projection["capabilities"]
+    assert projection["capabilities"] == ["network", "external_evidence_poll"]
+    assert projection["scope"] == "visible_goal_session"
+
+
+def test_visible_goal_policy_rejects_heartbeat_only_vocabulary() -> None:
+    with pytest.raises(ValueError, match="heartbeat-only"):
+        validate_visible_goal_policy_rule(
+            field="permission_rule",
+            value="use rrule now",
+        )
+
+
+def test_public_facade_still_builds_and_renders_prompts() -> None:
+    payload = build_heartbeat_prompt(goal_id="loopx-meta")
+    assert payload["ok"] is True
+    assert payload["goal_id"] == "loopx-meta"
+    assert payload["task_body"]
+    assert render_heartbeat_prompt_markdown(payload)


### PR DESCRIPTION
## Summary

Move the remaining heartbeat prompt support logic out of `loopx/heartbeat_prompt.py` into bounded heartbeat modules:

- `loopx/control_plane/heartbeat/rules.py`: prompt lifecycle rules
- `loopx/control_plane/heartbeat/budget.py`: interface budget helpers
- `loopx/control_plane/heartbeat/host.py`: native/Ark host detection
- `loopx/control_plane/heartbeat/agent.py`: agent identity/scope/profile helpers
- `loopx/control_plane/heartbeat/visible_goal.py`: visible Goal capability projection and policy validation

`loopx/heartbeat_prompt.py` is now a thin compatibility surface (481 -> 159 lines) with an explicit `__all__`, and the prompt builder/task body renderers consume the bounded modules directly.

Adds focused pytest coverage for the moved helpers while preserving the public import surface.

## Validation

- `tests/control_plane`: `830 passed`
- Focused heartbeat/host/CLI budget tests: `157 passed`
- New focused helper tests: `10 passed`
- maintainability ratchet: clean, no new exceptions
- ruff: passed
- `loopx canary premerge --from-git-diff`: `selected=15 failures=0`, `self_merge_allowed=true`

No runtime behavior changes.