### PR TITLE
refactor(quota): consume EffectTurn in TurnEnvelope runtime path

### DIFF
--- a/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
+++ b/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
@@ -270,14 +270,17 @@ parallel and equally important:
   `interpret_turn_result_packet` (#2956).
 - R3 replacement: Codex CLI local scheduler commands are built through
   `EffectProgram` (#2957).
+- R5 replacement: quota should-run TurnEnvelope derives its canonical action,
+  writeback, and scheduler slots through `interpret_quota_should_run_packet`.
 - around semantics encoded in `capability_gate`, `interaction_contract`,
   `work_lane_contract`, and `scheduler_hint`.
 - focused tests and docs that pin the lens.
 
 ### What Is Missing
 
-- A minimal interpreter protocol or composition helper used by runtime code,
-  not only by tests.
+- A minimal interpreter protocol or composition helper shared by both runtime
+  quota and turn-result consumers, once a second runtime caller needs the same
+  envelope.
 - A real host or turn-driver caller that executes an ordered effect program
   while preserving failure, cancellation, permission, and budget semantics.
 
@@ -297,12 +300,13 @@ framework that no runtime uses.
 
 ### Replacement Status
 
-R1, R2, and R3 are complete:
+R1, R2, R3, and R5 are complete:
 
 - R1 bootstrap guided rendering through `EffectProgram` (#2955);
 - R2 turn executor result-kind resolution through `interpret_turn_result_packet`
   (#2956);
 - R3 Codex CLI scheduler command set through `EffectProgram` (#2957).
+- R5 quota should-run TurnEnvelope through `interpret_quota_should_run_packet`.
 
 R4 remains pending and must not be implemented until a real multi-step
 host/turn-driver caller executes an ordered effect program.
@@ -342,7 +346,9 @@ Phases:
   bounded modules.
 - Q5: Extract heartbeat prompt builders into bounded modules.
 - Q6: Make CLI quota, turn driver, and bootstrap construction consume
-  `EffectTurn` / `EffectProgram`.
+  `EffectTurn` / `EffectProgram`. In progress: quota should-run TurnEnvelope
+  now consumes `interpret_quota_should_run_packet`; turn driver and bootstrap
+  already consume `interpret_turn_result_packet` / `effect_program_from_ordered_steps`.
 - Q7: Add quality gates and focused tests for each extraction.
 - Q8: Re-evaluate M6 only after the gates pass.
 

--- a/loopx/control_plane/quota/turn_envelope.py
+++ b/loopx/control_plane/quota/turn_envelope.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 from hashlib import sha256
 from typing import Any
 
+from ..effect_program import EffectTurn, interpret_quota_should_run_packet
 from ..scheduler.execution_context import (
     SchedulerExecutionContextResolution,
     render_scheduler_execution_args,
@@ -378,13 +379,36 @@ def _boundary(payload: Mapping[str, Any]) -> dict[str, Any]:
     return boundary
 
 
-def _scheduler(payload: Mapping[str, Any]) -> dict[str, Any]:
+def _quota_effect_turn(payload: Mapping[str, Any]) -> EffectTurn:
+    agent_identity = _mapping(payload.get("agent_identity"))
+    agent_id = str(
+        payload.get("agent_id") or agent_identity.get("agent_id") or ""
+    ).strip() or None
+    return interpret_quota_should_run_packet(
+        payload,
+        goal_id=str(payload.get("goal_id") or "") or None,
+        agent_id=agent_id,
+    )
+
+
+def _scheduler(
+    payload: Mapping[str, Any],
+    turn: EffectTurn | None = None,
+) -> dict[str, Any]:
     source = _mapping(payload.get("scheduler_hint"))
-    scheduler: dict[str, Any] = {
-        field: source[field]
-        for field in ("action", "cadence_class", "reason_code", "spend_policy")
-        if source.get(field) is not None
-    }
+    effect_turn = turn or _quota_effect_turn(payload)
+    scheduler: dict[str, Any] = {}
+    action = effect_turn.next_effect.scheduler_action or source.get("action")
+    cadence_class = (
+        effect_turn.next_effect.cadence_class or source.get("cadence_class")
+    )
+    if action is not None:
+        scheduler["action"] = action
+    if cadence_class is not None:
+        scheduler["cadence_class"] = cadence_class
+    for field in ("reason_code", "spend_policy"):
+        if source.get(field) is not None:
+            scheduler[field] = source[field]
     codex_app = _mapping(source.get("codex_app"))
     if not codex_app:
         return scheduler
@@ -603,15 +627,20 @@ def _contract_capsule(
     return capsule
 
 
-def _action_projection(payload: Mapping[str, Any]) -> dict[str, Any]:
-    agent_identity = _mapping(payload.get("agent_identity"))
-    agent_id = str(
-        payload.get("agent_id") or agent_identity.get("agent_id") or ""
-    ).strip() or None
+def _action_projection(
+    payload: Mapping[str, Any],
+    turn: EffectTurn | None = None,
+) -> dict[str, Any]:
+    effect_turn = turn or _quota_effect_turn(payload)
+    agent_id = effect_turn.request.agent_id
     interaction = _mapping(payload.get("interaction_contract"))
     agent_channel = _mapping(interaction.get("agent_channel"))
     cli_channel = _mapping(interaction.get("cli_channel"))
-    recommended_action = _text(payload.get("recommended_action"), limit=480)
+    recommended_action = _text(
+        effect_turn.observation.recommended_action
+        or payload.get("recommended_action"),
+        limit=480,
+    )
     action = {
         "recommended_action": recommended_action,
         "primary_action": _text(agent_channel.get("primary_action"), limit=480),
@@ -624,10 +653,11 @@ def _action_projection(payload: Mapping[str, Any]) -> dict[str, Any]:
         ),
     }
     user = _user_channel(interaction, payload)
-    scheduler = _scheduler(payload)
+    scheduler = _scheduler(payload, turn=effect_turn)
     writeback = {
         "next_cli_actions": _text_list(
-            cli_channel.get("next_cli_actions"),
+            list(effect_turn.next_effect.cli_actions)
+            or cli_channel.get("next_cli_actions"),
             limit=5,
             item_limit=420,
         ),

--- a/tests/test_turn_envelope.py
+++ b/tests/test_turn_envelope.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pytest
 
+from loopx.control_plane.effect_program import interpret_quota_should_run_packet
 from loopx.control_plane.quota.turn_envelope import (
     TURN_ENVELOPE_BUDGET_BYTES,
     build_turn_envelope,
@@ -258,6 +259,25 @@ def test_turn_envelope_preserves_action_boundary_and_writeback() -> None:
     assert envelope["action"]["selected_todo"]["continuation_policy"] == (
         "same_agent_non_delivery"
     )
+
+
+def test_turn_envelope_derives_canonical_slots_through_effect_turn() -> None:
+    source = _full_decision()
+    turn = interpret_quota_should_run_packet(
+        source,
+        goal_id="fixture-goal",
+        agent_id="codex-fixture",
+    )
+    envelope = build_turn_envelope(source)
+
+    assert envelope["action"]["recommended_action"] == (
+        turn.observation.recommended_action
+    )
+    assert envelope["writeback"]["next_cli_actions"] == list(
+        turn.next_effect.cli_actions
+    )
+    assert envelope["scheduler"]["action"] == turn.next_effect.scheduler_action
+    assert envelope["scheduler"]["cadence_class"] == turn.next_effect.cadence_class
     assert envelope["action"]["must_attempt"] is True
     assert envelope["user"] == {
         "action_required": False,


### PR DESCRIPTION
## Summary

Q6 first slice: make the real  runtime path consume `interpret_quota_should_run_packet` instead of parsing raw payload fields directly for the canonical slots.

- `build_turn_envelope` now derives `action.recommended_action`, `writeback.next_cli_actions`, and `scheduler.action` / `cadence_class` through `EffectTurn`.
- `quota_action_signature_document` and the CLI turn-envelope view use the same interpreter, so the parity contract is preserved.
- Adds a focused test proving the envelope's canonical slots match `interpret_quota_should_run_packet`.
- Updates the effect-interpreter RFC replacement status with R5 and marks Q6 in progress.

No public CLI output changes.

## Validation

- `tests/control_plane` + turn driver/envelope tests: `910 passed`
- turn envelope tests: `29 passed`
- maintainability ratchet: clean
- ruff: passed
- `loopx canary premerge --from-git-diff`: `selected=13 failures=0`, `self_merge_allowed=true`, public boundary passed