### PR TITLE
test(control-plane): add M6 quality gates for RFC module budgets

### DIFF
--- a/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
+++ b/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
@@ -48,7 +48,7 @@ that model over time.
 | M3 Focused test families | Mostly complete (#2916-#2918, #2925, #2929) |
 | M4 Architecture documentation | Mostly complete (#2921, #2923, #2924) |
 | M5 Steady-state review | Mostly complete (#2922, #2931) |
-| M6 General effect-program abstraction | In progress; Q3 complete (#2963-#2965), Q4 in progress; quality gate pending (#2938-#2959) |
+| M6 General effect-program abstraction | In progress; Q3-Q6 complete (#2963-#2965, #2967-#2983); quality gate pending (Q7) |
 
 ## Why This Matters
 
@@ -349,7 +349,10 @@ Phases:
   `EffectTurn` / `EffectProgram`. In progress: quota should-run TurnEnvelope
   now consumes `interpret_quota_should_run_packet`; turn driver and bootstrap
   already consume `interpret_turn_result_packet` / `effect_program_from_ordered_steps`.
-- Q7: Add quality gates and focused tests for each extraction.
+- Q7: Add quality gates and focused tests for each extraction. In progress:
+  RFC module budgets are ratcheted in `module_metric_baseline.json` and a
+  focused M6 quality-gate pytest pins the hot-module ceilings plus the runtime
+  `EffectTurn` consumption.
 - Q8: Re-evaluate M6 only after the gates pass.
 
 ### Replacement-First Rule

--- a/loopx/canary/module_metric_baseline.json
+++ b/loopx/canary/module_metric_baseline.json
@@ -68,7 +68,7 @@
     "loopx/heartbeat_prompt.py": {
       "any_count": 17,
       "dict_any_count": 0,
-      "lines": 1565
+      "lines": 1199
     },
     "loopx/history.py": {
       "any_count": 51,
@@ -83,12 +83,12 @@
     "loopx/quota.py": {
       "any_count": 219,
       "dict_any_count": 0,
-      "lines": 2946
+      "lines": 1999
     },
     "loopx/status.py": {
       "any_count": 180,
       "dict_any_count": 0,
-      "lines": 3076
+      "lines": 1999
     },
     "loopx/todos.py": {
       "any_count": 48,

--- a/tests/control_plane/test_m6_quality_gates.py
+++ b/tests/control_plane/test_m6_quality_gates.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from loopx.canary.maintainability_ratchet import (
+    build_control_plane_maintainability_report,
+    module_metric_baseline,
+    module_metrics,
+)
+from loopx.control_plane.effect_program import interpret_quota_should_run_packet
+from loopx.control_plane.quota.turn_envelope import build_turn_envelope
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+MODULE_METRIC_BASELINE_PATH = (
+    REPOSITORY_ROOT / "loopx" / "canary" / "module_metric_baseline.json"
+)
+RFC_MODULE_BUDGETS = {
+    "loopx/quota.py": 1999,
+    "loopx/status.py": 1999,
+    "loopx/heartbeat_prompt.py": 1199,
+}
+
+
+def test_m6_rfc_module_budgets_are_enforced_by_the_ratchet_baseline() -> None:
+    baseline = module_metric_baseline(MODULE_METRIC_BASELINE_PATH)
+
+    for relative_path, rfc_ceiling in RFC_MODULE_BUDGETS.items():
+        ceiling = baseline[relative_path]["lines"]
+        assert ceiling <= rfc_ceiling, relative_path
+        actual = module_metrics(REPOSITORY_ROOT / relative_path)["lines"]
+        assert actual <= ceiling, relative_path
+
+
+def test_m6_maintainability_ratchet_has_no_unreviewed_debt() -> None:
+    report = build_control_plane_maintainability_report(REPOSITORY_ROOT)
+
+    assert report["ok"] is True
+    assert report["unreviewed_count"] == 0
+    assert report["stale_exception_count"] == 0
+    assert report["category_counts"].get("module_metric_budget", 0) == 0
+
+
+def test_quota_turn_envelope_consumes_effect_turn_at_runtime() -> None:
+    payload = {
+        "ok": True,
+        "goal_id": "fixture-goal",
+        "agent_identity": {"agent_id": "codex-fixture"},
+        "decision": "run",
+        "should_run": True,
+        "effective_action": "normal_run",
+        "recommended_action": "advance one bounded slice",
+        "interaction_contract": {
+            "schema_version": "loopx_interaction_contract_v0",
+            "mode": "bounded_delivery",
+            "user_channel": {
+                "action_required": False,
+                "notify": "DONT_NOTIFY",
+            },
+            "agent_channel": {
+                "must_attempt": True,
+                "delivery_allowed": True,
+                "quiet_noop_allowed": False,
+                "primary_action": "advance one slice",
+            },
+            "cli_channel": {
+                "next_cli_actions": [
+                    "loopx refresh-state --goal-id fixture-goal --execute"
+                ],
+                "spend_allowed_now": False,
+                "spend_after_validation": True,
+                "spend_policy": "spend once after validated writeback",
+            },
+        },
+        "scheduler_hint": {
+            "action": "run_now",
+            "cadence_class": "active_work",
+            "codex_app": {
+                "apply": "none_already_applied",
+                "host_action": "none",
+            },
+        },
+        "work_lane_contract": {
+            "lane": "advancement_task",
+            "obligation": "advance_bounded_segment",
+        },
+    }
+    turn = interpret_quota_should_run_packet(payload)
+    envelope = build_turn_envelope(payload)
+
+    assert envelope["action"]["recommended_action"] == (
+        turn.observation.recommended_action
+    )
+    assert envelope["writeback"]["next_cli_actions"] == list(
+        turn.next_effect.cli_actions
+    )
+    assert envelope["scheduler"]["action"] == turn.next_effect.scheduler_action
+    assert envelope["scheduler"]["cadence_class"] == turn.next_effect.cadence_class


### PR DESCRIPTION
## Summary

Q7 first slice: turn the RFC's M6 quality gates into durable ratchet and pytest constraints.

- Lowers `loopx/canary/module_metric_baseline.json` ceilings for `loopx/quota.py` (1999), `loopx/status.py` (1999), and `loopx/heartbeat_prompt.py` (1199) to match the RFC hot-module gates.
- Adds `tests/control_plane/test_m6_quality_gates.py` pinning:
  - RFC module ceilings are enforced by the module-metric baseline;
  - the maintainability ratchet has no unreviewed debt or stale exceptions;
  - `quota should-run --turn-envelope` derives canonical slots through `interpret_quota_should_run_packet` at runtime.
- Updates the RFC milestone table and Q7 phase status.

No runtime behavior changes.

## Validation

- M6 quality-gate pytest + maintainability ratchet: `5 passed`
- CLI output budget + import boundary + quota parity: `32 passed`
- ruff: passed
- `loopx canary premerge --from-git-diff`: `selected=16 failures=0`, `self_merge_allowed=true`, public boundary passed