### PR TITLE
fix(quota): bind heartbeat spend to selected todo

### DIFF
--- a/docs/heartbeat-automation-prompt.md
+++ b/docs/heartbeat-automation-prompt.md
@@ -483,7 +483,7 @@ If the result says should_run=true:
    A plain state-only refresh is quota-neutral and cannot replace it. Then, for
    a minute-based heartbeat, spend one slot:
 
-   loopx --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id <GOAL_ID> --slots 1 --source heartbeat --execute
+   loopx --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id <GOAL_ID> --todo-id <SELECTED_TODO_ID> --slots 1 --source heartbeat --execute
 
    If the automation reserves a coarser fixed interval, set `--slots` to the
    number of scheduler minutes consumed by that completed turn.
@@ -599,7 +599,7 @@ boundary is already clear. Validate it, write back changed files / validation /
 critic / next action; for non-trivial feature slices, create a successor todo
 or write a compact no-follow-up rationale; append one accountable
 `refresh-state --delivery-outcome outcome_progress`, then exactly one
-`loopx --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id <GOAL_ID> --slots 1 --source heartbeat --execute`
+`loopx --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id <GOAL_ID> --todo-id <SELECTED_TODO_ID> --slots 1 --source heartbeat --execute`
 event for the completed turn. Only an optional state-only refresh belongs after
 spend. Use `--slots 1` for minute-based heartbeats; for coarser intervals,
 spend the scheduler minutes consumed by that turn.

--- a/docs/reference/protocols/host-integration-surface-v0.md
+++ b/docs/reference/protocols/host-integration-surface-v0.md
@@ -221,7 +221,7 @@ the host lacks authority. A host adapter may expose these write classes:
 | Gate decision | `loopx operator-gate --decision approve|reject|defer` | explicit controller/user decision, dry-run preview before write |
 | Human reward | `loopx reward ... --dry-run` then explicit write | run-bound judgment, public-safe reason, no score impersonation |
 | Soft claim or optional hard lease | `claimed_by` by default; explicit `loopx task-lease acquire/renew/transfer/release/inspect` when a host needs hard write-scope exclusion | `(goal_id, todo_id)` contention key; `task_lease_v0` is opt-in and is not enforced by `quota should-run` |
-| State refresh and quota spend | `refresh-state`, then `quota spend-slot --source heartbeat --execute` | validation evidence first, one spend per completed automatic turn |
+| State refresh and quota spend | `refresh-state`, then `quota spend-slot --todo-id <SELECTED_TODO_ID> --source heartbeat --execute` | validation evidence first, one spend per completed automatic turn, bound to the selected todo |
 
 The adapter must not translate a host approval, model confidence, browser click,
 frontstage action, server callback, or scheduler timer into a protected write
@@ -284,7 +284,7 @@ loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota s
 loopx todo claim --goal-id <goal-id> --todo-id <todo_id> --claimed-by <agent-id>
 loopx todo complete --goal-id <goal-id> --todo-id <todo_id> --claimed-by <agent-id> --evidence "<public-safe evidence>"
 loopx refresh-state --goal-id <goal-id> --agent-id <agent-id>
-loopx quota spend-slot --goal-id <goal-id> --slots 1 --source heartbeat --execute --agent-id <agent-id>
+loopx quota spend-slot --goal-id <goal-id> --todo-id <selected-todo-id> --slots 1 --source heartbeat --execute --agent-id <agent-id>
 ```
 
 When a host explicitly advertises `task_lease_v0`, it must also expose the

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -800,6 +800,7 @@ def handle_quota_command(
                 agent_id=args.agent_id,
                 available_capabilities=args.available_capabilities,
                 operator_inbox_urgency_projector=operator_inbox_urgency_projector,
+                todo_id=args.todo_id,
             )
         elif args.quota_command == "void-slot":
             payload = void_quota_slot(

--- a/loopx/control_plane/quota/slot_accounting.py
+++ b/loopx/control_plane/quota/slot_accounting.py
@@ -19,7 +19,7 @@ from ..agents.workspace_guard import (
     build_delivery_workspace_guard,
     delivery_workspace_repository,
 )
-from ..todos.contract import normalize_todo_claimed_by
+from ..todos.contract import normalize_todo_claimed_by, normalize_todo_id
 from ..work_items.delivery_outcome import (
     ACCOUNTABLE_DELIVERY_OUTCOMES,
     normalize_delivery_outcome,
@@ -31,6 +31,33 @@ QUOTA_SLOT_VOIDED_CLASSIFICATION = "quota_slot_voided"
 
 QuotaDecisionBuilder = Callable[[dict[str, Any]], dict[str, Any]]
 QuotaStatusBuilder = Callable[..., dict[str, Any]]
+
+
+def _todo_binding_error(
+    *,
+    source: str,
+    before: dict[str, Any],
+    requested_todo_id: str | None,
+) -> str | None:
+    selected = before.get("selected_todo") if isinstance(before.get("selected_todo"), dict) else {}
+    selected_todo_id = normalize_todo_id(selected.get("todo_id"))
+    if requested_todo_id and selected_todo_id and requested_todo_id != selected_todo_id:
+        return (
+            f"quota spend todo binding mismatch: selected todo is "
+            f"{selected_todo_id} but --todo-id is {requested_todo_id}; "
+            "complete or update the selected todo first, or record a replan"
+        )
+    if (
+        source == DEFAULT_SLOT_SPEND_SOURCE
+        and before.get("normal_delivery_allowed") is True
+        and selected_todo_id
+        and not requested_todo_id
+    ):
+        return (
+            f"quota spend requires --todo-id {selected_todo_id} for heartbeat "
+            "delivery so the accounted turn is bound to the selected todo"
+        )
+    return None
 
 
 def _now_local() -> str:
@@ -180,10 +207,32 @@ def build_quota_slot_preview_for_decision(
     slots: int = 1,
     agent_id: str | None = None,
     workspace_path: Path | None = None,
+    todo_id: str | None = None,
+    source: str = DEFAULT_SLOT_SPEND_SOURCE,
 ) -> dict[str, Any]:
     safe_goal_id = _validate_goal_id_path_segment(str(goal_id or ""))
     safe_slots = max(1, _int_number(slots, default=1))
     safe_requested_agent_id = normalize_todo_claimed_by(agent_id)
+    normalized_todo_id = normalize_todo_id(todo_id) if todo_id else None
+    binding_error = _todo_binding_error(
+        source=source,
+        before=before,
+        requested_todo_id=normalized_todo_id,
+    )
+    if binding_error:
+        return {
+            "ok": False,
+            "mode": "spend-slot",
+            "dry_run": True,
+            "goal_id": safe_goal_id,
+            "slots": safe_slots,
+            "agent_id": safe_requested_agent_id,
+            "appended": False,
+            "registry_mutated": False,
+            "reason": binding_error,
+            "before": before,
+            "after": None,
+        }
     safe_bypass_requested = (
         (
             before.get("state") == "operator_gate"
@@ -386,6 +435,7 @@ def build_quota_slot_preview_for_decision(
             "recomputes spent_slots from quota_slot_spent events still inside window_hours, "
             "so the visible total can stay flat if an older spend expires."
         ),
+        "todo_id": normalized_todo_id,
         "safe_bypass_spend": safe_bypass_spend,
         "self_repair_spend": self_repair_spend,
         "capability_repair_spend": capability_repair_spend,
@@ -502,6 +552,7 @@ def build_quota_slot_spend_event(
         "quota_event": {
             "event_type": QUOTA_SLOT_SPENT_CLASSIFICATION,
             "source": safe_source,
+            "todo_id": preview.get("todo_id"),
             "slots": slots,
             "reason_summary": (
                 f"{slots} automatic agent slot(s) completed under an eligible quota guard"

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -20,6 +20,7 @@ from ..scheduler.execution_context import (
 from ..todos.contract import (
     TODO_TASK_CLASS_MONITOR,
     TODO_TASK_CLASS_USER_ACTION,
+    normalize_todo_id,
 )
 from ..todos.projection import todo_item_task_class
 from ..todos.user_gate import open_todo_count
@@ -39,6 +40,21 @@ INTERACTION_CONTRACT_SCHEMA_VERSION = "loopx_interaction_contract_v0"
 INTERACTION_RESPONSE_PLAN_SCHEMA_VERSION = "interaction_response_plan_v0"
 PROTOCOL_ACTION_PACKET_SCHEMA_VERSION = "protocol_action_packet_v0"
 PROTOCOL_ACTION_PACKET_LLM_POLICY = "no_api"
+
+
+def _heartbeat_spend_command(
+    goal_id: str,
+    *,
+    scoped_cli_args: str,
+    payload: dict[str, Any],
+) -> str:
+    selected = payload.get("selected_todo") if isinstance(payload.get("selected_todo"), dict) else {}
+    todo_id = normalize_todo_id(selected.get("todo_id"))
+    todo_arg = f" --todo-id {todo_id}" if todo_id else ""
+    return (
+        f"loopx quota spend-slot --goal-id {goal_id} --slots 1 "
+        f"--source heartbeat --execute{todo_arg}{scoped_cli_args}"
+    )
 
 
 def _blocked_successor_wait_observation_required(payload: dict[str, Any]) -> bool:
@@ -647,7 +663,7 @@ def interaction_next_cli_actions(
                 f"loopx todo complete --goal-id {goal_id} --todo-id {monitor_todo_id}{lifecycle_actor_args} --evidence '<validated gate evidence>'",
                 f"loopx todo update --goal-id {goal_id} --todo-id {gated_todo_id}{lifecycle_actor_args} --note '<public-safe gate repair reason>'",
                 f"loopx refresh-state --goal-id {goal_id} --classification standing_monitor_gate_repair_recorded --delivery-batch-scale single_surface --delivery-outcome outcome_progress{scoped_cli_args}",
-                f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute{scoped_cli_args}",
+                _heartbeat_spend_command(goal_id, scoped_cli_args=scoped_cli_args, payload=payload),
             ]
         route_candidates = (
             agent_scope_frontier.get("route_continuation_replan_candidates")
@@ -658,7 +674,7 @@ def interaction_next_cli_actions(
             return [
                 f"loopx todo add --goal-id {goal_id} --role agent --text '<public-safe route continuation advancement todo>'",
                 f"loopx refresh-state --goal-id {goal_id} --classification route_continuation_replan_recorded --delivery-batch-scale single_surface --delivery-outcome outcome_progress{scoped_cli_args}",
-                f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute{scoped_cli_args}",
+                _heartbeat_spend_command(goal_id, scoped_cli_args=scoped_cli_args, payload=payload),
             ]
         candidates = (
             agent_scope_frontier.get("deferred_resume_candidates")
@@ -669,12 +685,12 @@ def interaction_next_cli_actions(
         todo_id = str(first_candidate.get("todo_id") or "<todo_id>")
         return [
             (
-                f"loopx todo update --goal-id {goal_id} --todo-id {todo_id}"
-                f"{lifecycle_actor_args} --status open --clear-resume-when "
-                "--note '<public-safe successor replan reason>'"
+            f"loopx todo update --goal-id {goal_id} --todo-id {todo_id}"
+            f"{lifecycle_actor_args} --status open --clear-resume-when "
+            "--note '<public-safe successor replan reason>'"
             ),
             f"loopx refresh-state --goal-id {goal_id} --classification successor_replan_recorded --delivery-batch-scale single_surface --delivery-outcome outcome_progress{scoped_cli_args}",
-            f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute{scoped_cli_args}",
+            _heartbeat_spend_command(goal_id, scoped_cli_args=scoped_cli_args, payload=payload),
         ]
     if (
         mode == AgentScopeFrontierAction.AGENT_SCOPE_WAIT.value
@@ -693,7 +709,7 @@ def interaction_next_cli_actions(
         return [
             "read approved controller/job/marker/writeback surfaces only",
             f"loopx refresh-state --goal-id {goal_id} --classification <compact_blocker_or_transition>{scoped_cli_args}",
-            f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute{scoped_cli_args}",
+            _heartbeat_spend_command(goal_id, scoped_cli_args=scoped_cli_args, payload=payload),
         ]
     if mode == "agent_workspace_repair":
         return [
@@ -743,7 +759,7 @@ def interaction_next_cli_actions(
             (
                 "if the replan writeback records an accountable delta such as "
                 "outcome_progress or primary_goal_outcome, run "
-                f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute{scoped_cli_args}; "
+                f"{_heartbeat_spend_command(goal_id, scoped_cli_args=scoped_cli_args, payload=payload)}; "
                 "otherwise do not spend for surface_only watch-lane continuation/no-followup"
             ),
         ])
@@ -760,7 +776,7 @@ def interaction_next_cli_actions(
         return [
             *capability_resolution_actions,
             f"loopx refresh-state --goal-id {goal_id} --classification <validated_progress>{scoped_cli_args}",
-            f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute{scoped_cli_args}",
+            _heartbeat_spend_command(goal_id, scoped_cli_args=scoped_cli_args, payload=payload),
         ]
     if mode in {"user_gate", "user_todo_blocker_push", "user_action_required"}:
         return [

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -810,7 +810,10 @@ def build_quota_slot_preview(
     slots: int = 1,
     agent_id: str | None = None,
     workspace_path: Path | None = None,
-    available_capabilities: Any = None, operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
+    available_capabilities: Any = None,
+    operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
+    todo_id: str | None = None,
+    source: str = DEFAULT_SLOT_SPEND_SOURCE,
 ) -> dict[str, Any]:
     safe_goal_id = str(goal_id or "").strip()
     before = build_quota_should_run(
@@ -834,6 +837,8 @@ def build_quota_slot_preview(
         ),
         quota_status_builder=quota_status,
         self_repair_spend_actions=SELF_REPAIR_SPEND_ACTIONS,
+        todo_id=todo_id,
+        source=source,
     )
 
 
@@ -1024,7 +1029,9 @@ def spend_quota_slot(
     source: str = DEFAULT_SLOT_SPEND_SOURCE,
     agent_id: str | None = None,
     workspace_path: Path | None = None,
-    available_capabilities: Any = None, operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
+    available_capabilities: Any = None,
+    operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
+    todo_id: str | None = None,
 ) -> dict[str, Any]:
     safe_goal_id = _validate_goal_id_path_segment(str(goal_id or ""))
     preview = build_quota_slot_preview(
@@ -1033,7 +1040,10 @@ def spend_quota_slot(
         slots=slots,
         agent_id=agent_id,
         workspace_path=workspace_path,
-        available_capabilities=available_capabilities, operator_inbox_urgency_projector=operator_inbox_urgency_projector,
+        available_capabilities=available_capabilities,
+        operator_inbox_urgency_projector=operator_inbox_urgency_projector,
+        todo_id=todo_id,
+        source=source,
     )
     if not preview.get("ok"):
         return preview

--- a/tests/control_plane/test_quota_slot_accounting.py
+++ b/tests/control_plane/test_quota_slot_accounting.py
@@ -439,3 +439,112 @@ def test_same_agent_spend_blocks_duplicate_completion(tmp_path: Path) -> None:
     )
 
     assert _preview(runtime, agent_id=AGENT_A)["ok"] is False
+
+
+def _normal_run_before(*, todo_id: str) -> dict[str, Any]:
+    quota = {
+        "compute": 1.0,
+        "window_hours": 24,
+        "slot_minutes": 1,
+        "spent_slots": 0,
+        "allowed_slots": 1440,
+    }
+    return {
+        "ok": True,
+        "goal_id": GOAL_ID,
+        "should_run": True,
+        "normal_delivery_allowed": True,
+        "effective_action": "normal_run",
+        "state": "eligible",
+        "safe_bypass_allowed": False,
+        "quota": quota,
+        "selected_todo": {"todo_id": todo_id},
+    }
+
+
+def _normal_run_status(runtime: Path) -> dict[str, Any]:
+    quota = {
+        "compute": 1.0,
+        "window_hours": 24,
+        "slot_minutes": 1,
+        "spent_slots": 0,
+        "allowed_slots": 1440,
+    }
+    return {
+        "runtime_root": str(runtime),
+        "attention_queue": {"items": [{"goal_id": GOAL_ID}]},
+        "run_history": {"goals": [{"id": GOAL_ID, "quota": quota}]},
+    }
+
+
+def test_heartbeat_spend_requires_todo_binding(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    before = _normal_run_before(todo_id="todo_selected_binding")
+
+    preview = build_quota_slot_preview_for_decision(
+        _normal_run_status(runtime),
+        goal_id=GOAL_ID,
+        before=before,
+        after_decision=lambda _: {
+            **before,
+            "quota": {**before["quota"], "spent_slots": 1},
+        },
+        quota_status_builder=lambda goal, **_: goal["quota"],
+        self_repair_spend_actions=frozenset(),
+        agent_id=None,
+        source="heartbeat",
+    )
+
+    assert preview["ok"] is False
+    assert "requires --todo-id todo_selected_binding" in preview["reason"]
+
+
+def test_heartbeat_spend_rejects_mismatched_todo_binding(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    before = _normal_run_before(todo_id="todo_selected_binding")
+
+    preview = build_quota_slot_preview_for_decision(
+        _normal_run_status(runtime),
+        goal_id=GOAL_ID,
+        before=before,
+        after_decision=lambda _: {
+            **before,
+            "quota": {**before["quota"], "spent_slots": 1},
+        },
+        quota_status_builder=lambda goal, **_: goal["quota"],
+        self_repair_spend_actions=frozenset(),
+        agent_id=None,
+        todo_id="todo_other_binding",
+        source="heartbeat",
+    )
+
+    assert preview["ok"] is False
+    assert "binding mismatch" in preview["reason"]
+
+
+def test_heartbeat_spend_records_matching_todo_binding(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    before = _normal_run_before(todo_id="todo_selected_binding")
+
+    preview = build_quota_slot_preview_for_decision(
+        _normal_run_status(runtime),
+        goal_id=GOAL_ID,
+        before=before,
+        after_decision=lambda _: {
+            **before,
+            "quota": {**before["quota"], "spent_slots": 1},
+        },
+        quota_status_builder=lambda goal, **_: goal["quota"],
+        self_repair_spend_actions=frozenset(),
+        agent_id=None,
+        todo_id="todo_selected_binding",
+        source="heartbeat",
+    )
+    event = build_quota_slot_spend_event(
+        preview,
+        self_repair_spend_actions=frozenset(),
+        source="heartbeat",
+    )
+
+    assert preview["ok"] is True
+    assert event["quota_event"]["todo_id"] == "todo_selected_binding"


### PR DESCRIPTION
## Summary

The core mechanism gap behind the M6 closeout drift was that `quota spend-slot --source heartbeat` could account a turn without naming which todo the agent actually delivered. Quota selected `todo_0d99070eedbd` while the agent closed `todo_1bdf176b57b6`, and nothing in the writeback surface made that mismatch visible.

This PR makes the normal heartbeat path carry the binding:

- `interaction_contract.cli_channel.next_cli_actions` now emits `--todo-id <selected>` on heartbeat spend commands when the quota decision has a selected todo.
- `quota spend-slot --todo-id` is threaded through `spend_quota_slot` into the preview and the `quota_slot_spent` event.
- Heartbeat spend with `normal_delivery_allowed=true` and a selected todo now requires `--todo-id`; a mismatched id fails closed with an actionable message.
- Docs show the bound command shape; focused tests cover missing, mismatched, and matching bindings.

This is intentionally the smallest generic mechanism: no RFC-specific rule, no subjective semantic gate. It makes the existing selection contract auditable at the exact accounting boundary.

## Validation

- `tests/control_plane`: `836 passed`
- New slot-accounting binding tests: `3 passed`
- ruff: passed
- `loopx canary premerge --from-git-diff`: `selected=18 failures=0`, `self_merge_allowed=true`, public boundary passed

No behavior change for non-heartbeat sources (`adapter`, `controller`, `visible-goal`).