### PR TITLE
fix(lark): resolve Goal Channel board paths

### DIFF
--- a/loopx/extensions/lark/goal_channel_runtime.py
+++ b/loopx/extensions/lark/goal_channel_runtime.py
@@ -58,6 +58,26 @@ def _mapping(value: Any) -> dict[str, Any]:
     return dict(value) if isinstance(value, Mapping) else {}
 
 
+def _resolve_kanban_config_path(
+    *,
+    registry_path: Path,
+    configured_path: Any,
+) -> Path:
+    raw_path = str(configured_path or "").strip()
+    if not raw_path:
+        return default_lark_kanban_config_path(registry_path).expanduser().resolve()
+    path = Path(raw_path).expanduser()
+    if path.is_absolute():
+        return path
+    source_registry = registry_path.expanduser().resolve()
+    project_root = (
+        source_registry.parent.parent
+        if source_registry.parent.name == ".loopx"
+        else source_registry.parent
+    )
+    return project_root / path
+
+
 def configure_lark_goal_channel_automation(
     *,
     registry: Mapping[str, Any],
@@ -286,9 +306,10 @@ def doctor_lark_goal_channel(
             message_id=pinned_message_id,
         )
     )
-    kanban_path = Path(
-        str(kanban.get("config_path") or default_lark_kanban_config_path(registry_path))
-    ).expanduser()
+    kanban_path = _resolve_kanban_config_path(
+        registry_path=registry_path,
+        configured_path=kanban.get("config_path"),
+    )
     board_payload = read_lark_kanban_local_config(kanban_path)
     board_config = lark_kanban_config_from_payload(board_payload)
     kanban_result = lark_kanban_doctor(
@@ -369,7 +390,10 @@ def sync_lark_goal_channel(
             public_summary="complete Goal Channel setup before syncing it",
         )
     kanban = _mapping(binding.get("kanban"))
-    kanban_path = Path(str(kanban.get("config_path") or "")).expanduser()
+    kanban_path = _resolve_kanban_config_path(
+        registry_path=registry_path,
+        configured_path=kanban.get("config_path"),
+    )
     board_payload = read_lark_kanban_local_config(kanban_path)
     config = lark_kanban_config_from_payload(board_payload)
     if config is None:

--- a/tests/extensions/test_lark_goal_channel.py
+++ b/tests/extensions/test_lark_goal_channel.py
@@ -1192,6 +1192,77 @@ def test_doctor_requires_live_control_message_and_pin(tmp_path: Path) -> None:
     _assert_public_packet(payload)
 
 
+def test_relative_kanban_path_resolves_from_source_registry_across_worktrees(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source"
+    caller = tmp_path / "caller"
+    registry_path = source / ".loopx" / "registry.json"
+    binding_path = source / ".loopx" / "goal-channel.json"
+    kanban_path = source / ".loopx" / "lark-kanban.json"
+    binding_path.parent.mkdir(parents=True)
+    caller.mkdir()
+    save_lark_kanban_board_config(
+        kanban_path,
+        base_token="base_public_fixture",
+        table_id="tbl_public_fixture",
+    )
+    _write_binding(binding_path, kanban_path)
+    binding = read_goal_channel_binding(binding_path)
+    binding["bindings"][GOAL_ID]["kanban"]["config_path"] = ".loopx/lark-kanban.json"
+    write_goal_channel_binding(binding_path, binding)
+    observed: dict[str, object] = {}
+
+    def sync_todos(
+        config: object,
+        *,
+        config_path: Path,
+        **_kwargs: object,
+    ) -> dict[str, object]:
+        observed["config"] = config
+        observed["config_path"] = config_path
+        return {
+            "ok": True,
+            "todo_count": 0,
+            "successful_write_count": 0,
+            "external_write_performed": False,
+            "records": [],
+        }
+
+    monkeypatch.setattr(
+        "loopx.extensions.lark.goal_channel_runtime.sync_loopx_todos_to_lark_kanban",
+        sync_todos,
+    )
+    monkeypatch.chdir(caller)
+    relative_registry_path = Path("..") / registry_path.relative_to(tmp_path)
+
+    doctor = doctor_lark_goal_channel(
+        registry=_registry(source),
+        registry_path=relative_registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        runner=_fake_runner([]),
+    )
+    sync = sync_lark_goal_channel(
+        registry=_registry(source),
+        registry_path=relative_registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        execute=False,
+        runner=_fake_runner([]),
+    )
+
+    assert doctor["blocker"] == "readback_mismatch"
+    assert doctor["details"]["kanban_ready"] is True
+    assert sync["ok"] is True
+    assert sync["status"] == "preview_ready"
+    assert sync["details"]["kanban_ready"] is True
+    assert observed["config_path"] == kanban_path
+    _assert_public_packet(doctor)
+    _assert_public_packet(sync)
+
+
 def test_partial_binding_blocks_doctor_sync_and_notify(tmp_path: Path) -> None:
     registry_path = tmp_path / ".loopx" / "registry.json"
     binding_path = tmp_path / ".loopx" / "goal-channel.json"


### PR DESCRIPTION
## Summary
- resolve relative Goal Channel Kanban config paths from the source registry project root
- preserve absolute path behavior and normalize default paths
- cover doctor and sync calls made from a sibling worktree with a relative registry path

## Bug
A binding with `config_path: .loopx/lark-kanban.json` was resolved relative to the caller's current directory. Goal Channel doctor/sync therefore reported `kanban_binding_missing` when invoked from another worktree even though the source project binding was valid. Review also caught a relative-registry double-prefix edge case, now covered by the regression test.

## Validation
- `pytest -q tests/extensions/test_lark_goal_channel.py` (30 passed)
- Goal Channel human-gate delivery smoke
- extension-runtime risk profile (8/8 passed)
- `ruff`, `compileall`, and `git diff --check`
- `loopx canary premerge --from-git-diff` (10/10 passed)