### PR TITLE
fix(benchmark): reject fractional EdgeBench counts

### DIFF
--- a/examples/edgebench-benchmark-adapter-smoke.py
+++ b/examples/edgebench-benchmark-adapter-smoke.py
@@ -178,6 +178,39 @@ def test_contracts() -> None:
         assert invalid["first_blocker"] == "edgebench_pass_rate_out_of_range"
         assert_boundary(invalid)
 
+    for field in ("total_rounds", "agent_submissions", "auto_submissions"):
+        invalid = reduce_edgebench_final_result(
+            task_id="ad_placement_optimization",
+            run_id=f"edgebench-smoke-fractional-{field}",
+            result={
+                "best_pass_rate": 0.5,
+                "total_rounds": 1,
+                "agent_submissions": 1,
+                "auto_submissions": 0,
+                "runtime_seconds": 60.0,
+                field: 1.5,
+            },
+        )
+        assert invalid["countable"] is False
+        assert invalid["first_blocker"] == "edgebench_submission_count_invalid"
+        assert_boundary(invalid)
+
+    invalid_resume = reduce_edgebench_final_result(
+        task_id="ad_placement_optimization",
+        run_id="edgebench-smoke-fractional-resume",
+        result={
+            "best_pass_rate": 0.5,
+            "total_rounds": 1,
+            "agent_submissions": 1,
+            "auto_submissions": 0,
+            "runtime_seconds": 60.0,
+            "resume_count": 1.5,
+        },
+    )
+    assert invalid_resume["countable"] is False
+    assert invalid_resume["first_blocker"] == "edgebench_resume_count_invalid"
+    assert_boundary(invalid_resume)
+
 
 def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(

--- a/loopx/benchmark_adapters/edgebench.py
+++ b/loopx/benchmark_adapters/edgebench.py
@@ -38,6 +38,10 @@ def _optional_number(value: Any) -> float | None:
 def _optional_non_negative_int(value: Any) -> int | None:
     if value is None or isinstance(value, bool):
         return None
+    if isinstance(value, float) and (
+        not math.isfinite(value) or not value.is_integer()
+    ):
+        return None
     try:
         number = int(value)
     except (TypeError, ValueError):
@@ -240,12 +244,27 @@ def reduce_edgebench_final_result(
         if isinstance(best_round, str) and best_round.strip()
         else None
     )
+    invalid_submission_count = any(
+        raw is not None and parsed is None
+        for raw, parsed in (
+            (result.get("total_rounds"), total_rounds),
+            (result.get("agent_submissions"), agent_submissions),
+            (result.get("auto_submissions"), auto_submissions),
+        )
+    )
+    invalid_resume_count = (
+        result.get("resume_count") is not None and resume_count is None
+    )
 
     blockers: list[str] = []
     if best_score is None and best_pass_rate is None:
         blockers.append("edgebench_best_metric_missing")
     if best_pass_rate is not None and not 0.0 <= best_pass_rate <= 1.0:
         blockers.append("edgebench_pass_rate_out_of_range")
+    if invalid_submission_count:
+        blockers.append("edgebench_submission_count_invalid")
+    if invalid_resume_count:
+        blockers.append("edgebench_resume_count_invalid")
     if total_rounds is None or total_rounds <= 0:
         blockers.append("edgebench_submission_rounds_missing")
     elif (


### PR DESCRIPTION
## Summary
- reject fractional compact submission and resume counts instead of truncating them with `int()`
- return stable fail-closed blockers for invalid submission and resume counts
- add regression coverage for each count field

## Bug
A value such as `agent_submissions: 1.5` was silently converted to `1`, which could mark malformed EdgeBench output as countable and corrupt compact result accounting.

## Validation
- `python examples/edgebench-benchmark-adapter-smoke.py`
- focused benchmark adapter test suite (62 tests)
- `ruff` and `compileall`
- `loopx canary premerge --from-git-diff` (automatic checks 7/7; benchmark-sensitive manual review intentionally held)
