### PR TITLE
test(control-plane): characterize outcome continuity gap

### DIFF
--- a/tests/control_plane/test_goal_outcome_continuity_characterization.py
+++ b/tests/control_plane/test_goal_outcome_continuity_characterization.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, cast
+
+from loopx.control_plane.scheduler.execution_context import (
+    scheduler_execution_context_for_runtime_profile,
+)
+from loopx.control_plane.testing.quota_fixtures import (
+    quota_status_payload,
+    quota_todo_item,
+)
+from loopx.quota import build_quota_should_run
+
+
+FIXTURE = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "control_plane"
+    / "goal_outcome_continuity_characterization_v0.json"
+)
+APP_SCHEDULER_CONTEXT = scheduler_execution_context_for_runtime_profile(
+    "codex_app_heartbeat"
+)
+_BANNED_KEYS = {
+    "credential",
+    "credentials",
+    "raw_log",
+    "raw_logs",
+    "raw_state",
+    "trajectory",
+    "trajectories",
+    "verifier_output",
+}
+
+
+def _load_case() -> dict[str, Any]:
+    payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == (
+        "goal_outcome_continuity_characterization_v0"
+    )
+    return cast(dict[str, Any], payload)
+
+
+def _walk(value: Any) -> Iterator[tuple[str, Any]]:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            yield str(key), child
+            yield from _walk(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk(child)
+    else:
+        yield "", value
+
+
+def _semantic_replan_required(case: dict[str, Any]) -> bool:
+    final_outcome = case["final_outcome"]
+    progress_events = case["progress_events"]
+    required_evidence = set(final_outcome["required_evidence"])
+    observed_evidence = set(final_outcome["evidence_refs"])
+    for event in progress_events:
+        observed_evidence.update(event["supporting_evidence"])
+    return final_outcome["state"] == "open" and not required_evidence.issubset(
+        observed_evidence
+    )
+
+
+def _progress_run(case: dict[str, Any], event: dict[str, Any]) -> dict[str, Any]:
+    agent_id = case["agent_id"]
+    return {
+        "classification": event["event_kind"],
+        "generated_at": event["generated_at"],
+        "agent_id": agent_id,
+        "progress_scope": "agent_lane",
+        "delivery_outcome": event["delivery_outcome"],
+        "vision_checkpoint": {
+            "schema_version": "vision_checkpoint_v0",
+            "agent_id": agent_id,
+            "required": True,
+            "satisfied": True,
+            "decision": "unchanged_with_reason",
+            "unchanged_reason": case["vision"]["unchanged_reason"],
+            "triggers": [
+                {
+                    "kind": "material_delivery_outcome",
+                    "delivery_outcome": "outcome_progress",
+                }
+            ],
+        },
+    }
+
+
+def _vision_run(case: dict[str, Any]) -> dict[str, Any]:
+    agent_id = case["agent_id"]
+    return {
+        "classification": "vision_replanned",
+        "generated_at": "2026-01-01T00:00:00Z",
+        "agent_id": agent_id,
+        "progress_scope": "agent_lane",
+        "agent_vision": {
+            "schema_version": "goal_vision_replan_contract_v0",
+            "agent_id": agent_id,
+            "state": case["vision"]["state"],
+            "vision_patch": {
+                "acceptance_summary": case["vision"]["acceptance_summary"],
+                "advancement_policy": case["vision"]["advancement_policy"],
+            },
+        },
+    }
+
+
+def _replay_current_path(case: dict[str, Any]) -> dict[str, Any]:
+    todo = case["current_todo"]
+    agent_id = case["agent_id"]
+    latest_runs = [
+        *(
+            _progress_run(case, event)
+            for event in reversed(case["progress_events"])
+        ),
+        _vision_run(case),
+    ]
+    status = quota_status_payload(
+        goal_id=case["case_id"],
+        status="active",
+        recommended_action=todo["text"],
+        agent_todo_items=[
+            quota_todo_item(
+                todo_id=todo["todo_id"],
+                priority=todo["priority"],
+                text=todo["text"],
+                status=todo["status"],
+                task_class=todo["task_class"],
+                action_kind=todo["action_kind"],
+                claimed_by=agent_id,
+            )
+        ],
+        claim_scope_agent_id=agent_id,
+        latest_runs=latest_runs,
+        coordination={
+            "agent_model": "peer_v1",
+            "registered_agents": [agent_id],
+        },
+    )
+    decision = build_quota_should_run(
+        status,
+        goal_id=case["case_id"],
+        agent_id=agent_id,
+        scheduler_execution_context=APP_SCHEDULER_CONTEXT,
+    )
+    return {
+        "decision": decision["decision"],
+        "effective_action": decision["effective_action"],
+        "selected_todo_id": decision["selected_todo"]["todo_id"],
+        "acceptance_gap_decision": decision["vision_continuation_audit"][
+            "decision"
+        ],
+        "replan_required": decision["goal_frontier_projection"][
+            "replan_required"
+        ],
+    }
+
+
+def test_replay_is_public_safe_and_oracle_is_independent() -> None:
+    case = _load_case()
+
+    for key, value in _walk(case):
+        assert key.lower() not in _BANNED_KEYS
+        if isinstance(value, str):
+            assert not value.startswith("/")
+            assert "file://" not in value
+
+    assert [event["event_kind"] for event in case["progress_events"]] == [
+        "milestone_closeout",
+        "release_completed",
+        "narrow_gate_cleared",
+    ]
+    assert case["final_outcome"]["evidence_refs"] == []
+    assert {
+        event["delivery_outcome"] for event in case["progress_events"]
+    } == {"outcome_progress"}
+    assert _semantic_replan_required(case) is True
+    assert case["independent_oracle"]["replan_required"] is True
+
+
+def test_final_outcome_evidence_changes_the_independent_oracle() -> None:
+    case = deepcopy(_load_case())
+    case["progress_events"][-1]["supporting_evidence"].extend(
+        case["final_outcome"]["required_evidence"]
+    )
+    case["progress_events"][-1]["satisfies_final_outcome"] = True
+
+    assert _semantic_replan_required(case) is False
+
+
+def test_current_path_misses_semantic_divergence_during_local_progress() -> None:
+    case = _load_case()
+
+    observed = _replay_current_path(case)
+
+    assert observed == case["characterized_current_path"]
+    assert observed["replan_required"] is not case["independent_oracle"][
+        "replan_required"
+    ]

--- a/tests/fixtures/control_plane/goal_outcome_continuity_characterization_v0.json
+++ b/tests/fixtures/control_plane/goal_outcome_continuity_characterization_v0.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "goal_outcome_continuity_characterization_v0",
+  "case_id": "local-progress-with-open-final-outcome",
+  "agent_id": "continuity-replay-agent",
+  "final_outcome": {
+    "claim": "One real host path is recoverable after partial execution without duplicating an effect or settlement.",
+    "state": "open",
+    "required_evidence": [
+      "real_host_path_receipt",
+      "fault_injection_retry_receipt",
+      "retired_competing_truth_source"
+    ],
+    "evidence_refs": []
+  },
+  "vision": {
+    "state": "vision_replanned",
+    "acceptance_summary": "Prove one real host path can resume partial execution without duplicate effects and remove its competing source of truth.",
+    "advancement_policy": "repeat_until_closed",
+    "unchanged_reason": "The current milestone sequence still applies."
+  },
+  "progress_events": [
+    {
+      "event_kind": "milestone_closeout",
+      "generated_at": "2026-01-01T00:01:00Z",
+      "delivery_outcome": "outcome_progress",
+      "supporting_evidence": [
+        "focused_regression_passed"
+      ],
+      "satisfies_final_outcome": false
+    },
+    {
+      "event_kind": "release_completed",
+      "generated_at": "2026-01-01T00:02:00Z",
+      "delivery_outcome": "outcome_progress",
+      "supporting_evidence": [
+        "package_release_completed"
+      ],
+      "satisfies_final_outcome": false
+    },
+    {
+      "event_kind": "narrow_gate_cleared",
+      "generated_at": "2026-01-01T00:03:00Z",
+      "delivery_outcome": "outcome_progress",
+      "supporting_evidence": [
+        "premerge_gate_passed"
+      ],
+      "satisfies_final_outcome": false
+    }
+  ],
+  "current_todo": {
+    "todo_id": "todo_continue_packet_mapping",
+    "priority": "P1",
+    "action_kind": "map_another_packet_shape",
+    "text": "[P1] Map another packet onto the shared vocabulary.",
+    "status": "open",
+    "task_class": "advancement_task"
+  },
+  "independent_oracle": {
+    "replan_required": true,
+    "rationale": "The final-outcome claim remains open and every progress event is supporting evidence only; another runnable milestone does not prove that the selected path serves the final outcome."
+  },
+  "characterized_current_path": {
+    "decision": "run",
+    "effective_action": "normal_run",
+    "selected_todo_id": "todo_continue_packet_mapping",
+    "acceptance_gap_decision": "acceptance_gap_open",
+    "replan_required": false
+  }
+}


### PR DESCRIPTION
## Summary

- add a synthetic public-safe replay where three locally successful `outcome_progress` events still leave the final-outcome evidence open
- characterize the current quota-to-scheduler path: it reports `acceptance_gap_open` but suppresses replan while any runnable advancement todo remains
- keep expected semantics independent through evidence-coverage and mutation checks

This PR changes validation only. The follow-up rule change should make a completed todo sequence trigger a semantic outcome checkpoint, replanning only when final acceptance evidence remains open.

## Validation

- `pytest`: 37 focused goal-frontier, vision-succession, and outcome-continuity tests passed
- `ruff`: passed for the new test
- repository `mypy`: 15 configured production modules passed
- extra strict `mypy`: new test passed
- quota replan decision-plane smoke: passed
- goal vision replan contract smoke: passed
- public-boundary scan: 2 files, 0 errors, 0 warnings
- JSON parse and `git diff --check`: passed
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: passed; 0 failures, 0 warnings, 0 manual holds; no catalog canaries were selected for this test-only diff

Coverage is sufficient for this characterization-only slice because the fixture is synthetic, the replay exercises the real quota builder and scheduler context, the expected result comes from an independent semantic oracle, and no runtime behavior changes.

## Excluded

- no runtime or scheduler rule change
- no private state, raw sessions, logs, trajectories, credentials, local paths, or generated artifacts
