### PR TITLE
fix(ci): repair public smoke bootstrap and global-gates manpage

### DIFF
--- a/examples/auto-research-quota-pause-smoke.py
+++ b/examples/auto-research-quota-pause-smoke.py
@@ -13,9 +13,14 @@ semantics without needing a real quota budget change.
 from __future__ import annotations
 
 import json
+import sys
 import tempfile
 from pathlib import Path
 from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.capabilities.auto_research.worker_runtime import (
     run_auto_research_worker_turn,

--- a/examples/auto-research-state-aware-wake-smoke.py
+++ b/examples/auto-research-state-aware-wake-smoke.py
@@ -12,9 +12,14 @@ Covers:
 from __future__ import annotations
 
 import json
+import sys
 import tempfile
 from pathlib import Path
 from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.capabilities.auto_research.demo_e2e import _seed_visible_demo_control_plane
 from loopx.capabilities.auto_research.demo_supervisor import (

--- a/examples/extension-presentation-surface-smoke.py
+++ b/examples/extension-presentation-surface-smoke.py
@@ -10,6 +10,10 @@ from pathlib import Path
 import sys
 import tempfile
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from loopx.extensions.presentation import (
     collect_active_extension_presentation_surfaces,
     default_extension_projection_root,

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -252,6 +252,7 @@ MANPAGE_COMMAND_HELP_ONLY = frozenset(
         "material-lifecycle",
         "demo",
         "dreaming",
+        "global-gates",
         "global-summary",
         "heartbeat-prequota",
         "import-doc-registry-authority",

--- a/man/loopx.1
+++ b/man/loopx.1
@@ -1,4 +1,4 @@
-.TH LOOPX 1 "" "LoopX 0.4.2" "User Commands"
+.TH LOOPX 1 "" "LoopX 0.4.4" "User Commands"
 .SH NAME
 loopx \- control-plane helper for long-running agent work
 .SH SYNOPSIS


### PR DESCRIPTION
## Summary

Repair a small set of Full Public Smokes that fail on `main`:

- Add repo-root `sys.path` bootstrap to three public smokes that import `loopx` modules:
  `examples/auto-research-quota-pause-smoke.py`,
  `examples/auto-research-state-aware-wake-smoke.py`,
  `examples/extension-presentation-surface-smoke.py`.
- Classify the new top-level `global-gates` command as help-only in
  `loopx/help_surface.py`, then regenerate `man/loopx.1` from `render_manpage()`.

## Validation

- `examples/run-smokes.py --script ...` with Python 3.11: 4/4 affected smokes pass
  (`auto-research-quota-pause`, `auto-research-state-aware-wake`,
  `extension-presentation-surface`, `cli-help-manpage`).
- `git diff --check`, `py_compile`, and `canary premerge` catalog/boundary runs pass.
- The merge gate still reports `quality_receipt_missing` because change-quality
  qualification is not part of this PR; merge remains owner/reviewer-gated.
