### PR TITLE
fix(control-plane): require outcome-qualified replans

### DIFF
--- a/docs/reference/protocols/goal-vision-replan-contract-v0.md
+++ b/docs/reference/protocols/goal-vision-replan-contract-v0.md
@@ -191,6 +191,25 @@ For the same `agent_id`, a newer satisfied checkpoint with `patched`,
 `unchanged_with_reason`, or `retired_or_superseded` supersedes older
 `missing_required` checkpoints; `not_required` does not.
 
+A satisfied checkpoint is protocol-complete, but a material closeout also has
+to qualify its relationship to the final outcome. For an open vision, the same
+refresh must name the active `acceptance_summary`, attach public-safe
+`goal_path_delta_v0.evidence_refs`, and record one of these decisions:
+
+- `continue` or `no_change` when the new evidence supports the final-outcome
+  path and the delivery did not report `outcome_gap`; or
+- `replan` when the evidence contradicts or leaves the path open and the same
+  refresh records an autonomous replan with a real frontier delta.
+
+An older path delta, an unchanged-with-reason decision, or an unrelated
+runnable todo does not qualify the material closeout. Quota projects
+`vision_outcome_checkpoint_required` ahead of ordinary runnable work until a
+fresh evidence-linked continuation or replan is recorded. The same rule
+applies when a same-agent advancement todo was completed after the latest
+qualifying checkpoint. Todo completion is therefore the checkpoint timing
+signal, not proof that the final acceptance contract is done; the evidence
+decides whether to continue, replan/supersede, or close.
+
 Checkpoint and autonomous-replan ACK packets are protocol records, not semantic
 completion proof. A future monitor schedule is also not completion proof; it
 only says when to poll. A recent same-agent ACK may suppress duplicate

--- a/loopx/control_plane/goals/goal_frontier/__init__.py
+++ b/loopx/control_plane/goals/goal_frontier/__init__.py
@@ -26,6 +26,7 @@ from ..goal_vision_state import (
     goal_vision_state_requires_successor,
 )
 from ..goal_vision_wait import build_goal_vision_wait_state
+from . import outcome_continuity
 from .replan_rules import (
     GoalFrontierReplanFacts,
     GoalFrontierReplanRule,
@@ -47,8 +48,7 @@ AUTONOMOUS_REPLAN_DECISION_SCHEMA_VERSION = "autonomous_replan_decision_v0"
 AUTONOMOUS_REPLAN_SCOPE_SCHEMA_VERSION = "autonomous_replan_scope_v0"
 AUTONOMOUS_REPLAN_OBLIGATION_SCHEMA_VERSION = "autonomous_replan_obligation_v0"
 REPEAT_VISION_REPLAN_SATISFYING_DELTA_KINDS = (
-    "runnable_todo_set",
-    "successor_or_supersede",
+    outcome_continuity.REPEAT_VISION_REPLAN_SATISFYING_DELTA_KINDS
 )
 AUTONOMOUS_REPLAN_REQUIRED_MODE = "autonomous_replan_required"
 FRONTIER_EXHAUSTED_MONITOR_TRIGGER = "frontier_exhausted_monitor_lane"
@@ -56,7 +56,6 @@ MONITOR_NO_CHANGE_STREAK_TRIGGER = "monitor_no_change_streak"
 LONG_TODO_CHAIN_TRIGGER = "long_todo_chain"
 VISION_ACCEPTANCE_GAP_TRIGGER = "vision_acceptance_gap"
 VISION_SUCCESSOR_GAP_TRIGGER = "vision_successor_required"
-VISION_CHECKPOINT_MISSING_TRIGGER = "vision_checkpoint_missing"
 VISION_PROFILE_MISSING_TRIGGER = "required_agent_vision_missing"
 TODO_SUCCESSION_GAP_TRIGGER = "completed_advancement_without_successor"
 TODO_TASK_CLASS_ADVANCEMENT = "advancement_task"
@@ -724,48 +723,6 @@ def acceptance_gaps_from_agent_profile_requirement(
     ]
 
 
-def acceptance_gaps_from_vision_checkpoint(
-    checkpoint: dict[str, Any] | None,
-) -> list[dict[str, Any]]:
-    """Convert a missing per-agent vision checkpoint into a frontier gap."""
-
-    if not isinstance(checkpoint, dict):
-        return []
-    trigger_kinds = [
-        str(trigger.get("kind") or "").strip()
-        for trigger in (checkpoint.get("triggers") or [])
-        if isinstance(trigger, dict) and str(trigger.get("kind") or "").strip()
-    ]
-    trigger_text = ", ".join(trigger_kinds[:3]) or "required vision checkpoint"
-    missing_baseline = checkpoint.get("missing_baseline") is True
-    gap: dict[str, Any] = {
-        "kind": VISION_CHECKPOINT_MISSING_TRIGGER,
-        "source": "latest_vision_checkpoint",
-        "agent_id": checkpoint.get("agent_id"),
-        "decision": checkpoint.get("decision"),
-        "replan_trigger_summary": (
-            "refresh-state tried to keep vision unchanged without a persisted "
-            f"per-agent baseline; triggers={trigger_text}"
-            if missing_baseline
-            else "refresh-state closed a material segment without a per-agent vision "
-            f"decision; triggers={trigger_text}"
-        ),
-        "acceptance_summary": (
-            "Write a bounded agent vision patch, or retire/supersede the frontier "
-            "with an explicit rationale."
-            if missing_baseline
-            else "Write a bounded agent vision patch, record an unchanged reason, "
-            "or retire/supersede the frontier with an explicit rationale."
-        ),
-    }
-    if missing_baseline:
-        gap["missing_baseline"] = True
-    generated_at = _compact_projection_text(checkpoint.get("generated_at"), limit=80)
-    if generated_at:
-        gap["generated_at"] = generated_at
-    return [gap]
-
-
 def build_vision_continuation_audit(
     *,
     goal_id: str | None = None,
@@ -1373,6 +1330,11 @@ def derive_goal_frontier_replan_obligation_from_summaries(
         in {VISION_SUCCESSOR_GAP_TRIGGER, VISION_PROFILE_MISSING_TRIGGER}
         for item in compact_acceptance_gaps
     )
+    outcome_checkpoint_replan_required = any(
+        item.get("kind")
+        == outcome_continuity.VISION_OUTCOME_CHECKPOINT_REQUIRED_TRIGGER
+        for item in compact_acceptance_gaps
+    )
     acceptance_allows_watch_lane_continuation = bool(
         compact_acceptance_gaps
         and not any(
@@ -1418,6 +1380,9 @@ def derive_goal_frontier_replan_obligation_from_summaries(
             total_frontier_advancement=total_frontier_advancement,
             acceptance_gap_count=len(compact_acceptance_gaps),
             selectable_frontier_advancement=selectable_frontier_advancement,
+            outcome_checkpoint_replan_required=(
+                outcome_checkpoint_replan_required
+            ),
             acceptance_allows_watch_lane_continuation=(
                 acceptance_allows_watch_lane_continuation
             ),
@@ -1785,6 +1750,13 @@ def build_goal_frontier_projection_context_from_status(
         goal_id=goal_id,
         agent_id=agent_id,
     )
+    latest_vision_checkpoint = (
+        outcome_continuity.latest_outcome_vision_checkpoint_from_status_payload(
+            status_payload,
+            goal_id=goal_id,
+            agent_id=agent_id,
+        )
+    )
     source_acceptance_gaps = (
         acceptance_gaps_from_agent_profile_requirement(
             agent_profile,
@@ -1796,7 +1768,19 @@ def build_goal_frontier_projection_context_from_status(
             latest_agent_vision,
             goal_status=goal_status,
         )
-        + acceptance_gaps_from_vision_checkpoint(latest_missing_vision_checkpoint)
+        + outcome_continuity.acceptance_gaps_from_vision_checkpoint(
+            latest_missing_vision_checkpoint
+        )
+        + outcome_continuity.acceptance_gaps_from_outcome_checkpoint(
+            latest_agent_vision,
+            latest_vision_checkpoint,
+        )
+        + outcome_continuity.acceptance_gaps_from_todo_completion_checkpoint(
+            latest_agent_vision,
+            latest_vision_checkpoint,
+            agent_todo_summary=agent_todo_summary,
+            agent_id=agent_id,
+        )
     )
     if _terminal_no_followup_resolves_vision_checkpoint(
         user_todo_summary=user_todo_summary,
@@ -1806,7 +1790,8 @@ def build_goal_frontier_projection_context_from_status(
         source_acceptance_gaps = [
             gap
             for gap in source_acceptance_gaps
-            if gap.get("kind") != VISION_CHECKPOINT_MISSING_TRIGGER
+            if gap.get("kind")
+            != outcome_continuity.VISION_CHECKPOINT_MISSING_TRIGGER
         ]
     replan_obligation = align_autonomous_replan_guidance_with_acceptance_policy(
         replan_obligation,

--- a/loopx/control_plane/goals/goal_frontier/outcome_continuity.py
+++ b/loopx/control_plane/goals/goal_frontier/outcome_continuity.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from ...agents.agent_scope import agent_scope_item_claimed_by
+from ...work_items.repair_delta import repair_delta_kinds_have_frontier_delta
+from ..goal_vision_state import goal_vision_state_is_closed
+
+VISION_OUTCOME_CHECKPOINT_REQUIRED_TRIGGER = "vision_outcome_checkpoint_required"
+VISION_CHECKPOINT_MISSING_TRIGGER = "vision_checkpoint_missing"
+VISION_OUTCOME_CHECKPOINT_MATERIAL_OUTCOMES = {
+    "outcome_gap",
+    "outcome_progress",
+    "primary_goal_outcome",
+}
+VISION_OUTCOME_CHECKPOINT_CONTINUATION_OUTCOMES = {
+    "continue",
+    "no_change",
+}
+REPEAT_VISION_REPLAN_SATISFYING_DELTA_KINDS = (
+    "runnable_todo_set",
+    "successor_or_supersede",
+)
+
+
+def _compact_text(value: Any, *, limit: int) -> str | None:
+    text = " ".join(str(value or "").strip().split())
+    return text[:limit] if text else None
+
+
+def _dict_field(value: dict[str, Any], key: str) -> dict[str, Any]:
+    field = value.get(key)
+    return field if isinstance(field, dict) else {}
+
+
+def _latest_runs_for_goal(
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+) -> list[dict[str, Any]]:
+    run_history = _dict_field(status_payload, "run_history")
+    goals_value = run_history.get("goals")
+    goals: list[Any] = goals_value if isinstance(goals_value, list) else []
+    goal = next(
+        (
+            item
+            for item in goals
+            if isinstance(item, dict) and str(item.get("id") or "") == goal_id
+        ),
+        None,
+    )
+    latest_runs = goal.get("latest_runs") if isinstance(goal, dict) else None
+    return (
+        [item for item in latest_runs if isinstance(item, dict)]
+        if isinstance(latest_runs, list)
+        else []
+    )
+
+
+def latest_outcome_vision_checkpoint_from_status_payload(
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+    agent_id: str | None,
+) -> dict[str, Any] | None:
+    """Return the newest outcome-relevant per-agent vision checkpoint."""
+
+    for run in _latest_runs_for_goal(status_payload, goal_id=goal_id):
+        checkpoint = run.get("vision_checkpoint")
+        if not isinstance(checkpoint, dict):
+            continue
+        checkpoint_agent_id = str(
+            checkpoint.get("agent_id") or run.get("agent_id") or ""
+        ).strip()
+        if agent_id and checkpoint_agent_id != agent_id:
+            continue
+        if not agent_id and checkpoint_agent_id:
+            continue
+        trigger_kinds = {
+            str(trigger.get("kind") or "").strip()
+            for trigger in (checkpoint.get("triggers") or [])
+            if isinstance(trigger, dict)
+            and str(trigger.get("kind") or "").strip()
+        }
+        if not (
+            "material_delivery_outcome" in trigger_kinds
+            or "autonomous_replan_recorded" in trigger_kinds
+        ):
+            continue
+        result: dict[str, Any] = {
+            "schema_version": checkpoint.get("schema_version"),
+            "goal_id": goal_id,
+            "agent_id": checkpoint_agent_id or agent_id,
+            "required": checkpoint.get("required") is True,
+            "satisfied": checkpoint.get("satisfied") is True,
+            "decision": checkpoint.get("decision"),
+            "triggers": checkpoint.get("triggers")
+            if isinstance(checkpoint.get("triggers"), list)
+            else [],
+            "repair_delta_kinds": checkpoint.get("repair_delta_kinds")
+            if isinstance(checkpoint.get("repair_delta_kinds"), list)
+            else [],
+            "generated_at": run.get("generated_at"),
+        }
+        run_vision = run.get("agent_vision")
+        if isinstance(run_vision, dict):
+            result["qualification_agent_vision"] = {
+                "agent_id": run_vision.get("agent_id") or checkpoint_agent_id,
+                "state": run_vision.get("state"),
+                "vision_patch": _dict_field(run_vision, "vision_patch"),
+                "path_delta": _dict_field(run_vision, "path_delta"),
+                "generated_at": run.get("generated_at"),
+            }
+        return result
+    return None
+
+
+def acceptance_gaps_from_vision_checkpoint(
+    checkpoint: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    """Convert a missing per-agent vision checkpoint into a frontier gap."""
+
+    if not isinstance(checkpoint, dict):
+        return []
+    trigger_kinds = [
+        str(trigger.get("kind") or "").strip()
+        for trigger in (checkpoint.get("triggers") or [])
+        if isinstance(trigger, dict) and str(trigger.get("kind") or "").strip()
+    ]
+    trigger_text = ", ".join(trigger_kinds[:3]) or "required vision checkpoint"
+    missing_baseline = checkpoint.get("missing_baseline") is True
+    gap: dict[str, Any] = {
+        "kind": VISION_CHECKPOINT_MISSING_TRIGGER,
+        "source": "latest_vision_checkpoint",
+        "agent_id": checkpoint.get("agent_id"),
+        "decision": checkpoint.get("decision"),
+        "replan_trigger_summary": (
+            "refresh-state tried to keep vision unchanged without a persisted "
+            f"per-agent baseline; triggers={trigger_text}"
+            if missing_baseline
+            else "refresh-state closed a material segment without a per-agent vision "
+            f"decision; triggers={trigger_text}"
+        ),
+        "acceptance_summary": (
+            "Write a bounded agent vision patch, or retire/supersede the frontier "
+            "with an explicit rationale."
+            if missing_baseline
+            else "Write a bounded agent vision patch, record an unchanged reason, "
+            "or retire/supersede the frontier with an explicit rationale."
+        ),
+    }
+    if missing_baseline:
+        gap["missing_baseline"] = True
+    generated_at = _compact_text(checkpoint.get("generated_at"), limit=80)
+    if generated_at:
+        gap["generated_at"] = generated_at
+    return [gap]
+
+
+def acceptance_gaps_from_outcome_checkpoint(
+    agent_vision: dict[str, Any] | None,
+    checkpoint: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    """Require a fresh evidence-linked path decision after material closeout."""
+
+    if not isinstance(agent_vision, dict) or not isinstance(checkpoint, dict):
+        return []
+    if goal_vision_state_is_closed(str(agent_vision.get("state") or "")):
+        return []
+    qualification_vision_value = checkpoint.get("qualification_agent_vision")
+    qualification_vision = (
+        qualification_vision_value
+        if isinstance(qualification_vision_value, dict)
+        else agent_vision
+    )
+    vision_agent_id = str(qualification_vision.get("agent_id") or "").strip()
+    checkpoint_agent_id = str(checkpoint.get("agent_id") or "").strip()
+    if (
+        vision_agent_id
+        and checkpoint_agent_id
+        and vision_agent_id != checkpoint_agent_id
+    ):
+        return []
+
+    triggers = [
+        trigger
+        for trigger in (checkpoint.get("triggers") or [])
+        if isinstance(trigger, dict)
+    ]
+    delivery_outcomes = [
+        outcome
+        for trigger in triggers
+        if trigger.get("kind") == "material_delivery_outcome"
+        and (
+            outcome := _compact_text(
+                trigger.get("delivery_outcome"),
+                limit=32,
+            )
+        )
+        in VISION_OUTCOME_CHECKPOINT_MATERIAL_OUTCOMES
+    ]
+    if not delivery_outcomes:
+        return []
+
+    patch = _dict_field(qualification_vision, "vision_patch")
+    current_patch = _dict_field(agent_vision, "vision_patch")
+    claim = _compact_text(patch.get("acceptance_summary"), limit=420)
+    path_delta = _dict_field(qualification_vision, "path_delta")
+    path_outcome = _compact_text(path_delta.get("outcome"), limit=32)
+    evidence_refs = [
+        evidence_ref
+        for value in (path_delta.get("evidence_refs") or [])
+        if (evidence_ref := _compact_text(value, limit=140))
+    ][:4]
+    fresh_vision_patch = bool(
+        checkpoint.get("decision") == "patched"
+        and checkpoint.get("generated_at")
+        and checkpoint.get("generated_at")
+        == qualification_vision.get("generated_at")
+    )
+    autonomous_replan_recorded = any(
+        trigger.get("kind") == "autonomous_replan_recorded"
+        for trigger in triggers
+    )
+    frontier_delta_recorded = repair_delta_kinds_have_frontier_delta(
+        checkpoint.get("repair_delta_kinds")
+    )
+    outcome_gap_reported = "outcome_gap" in delivery_outcomes
+    continuation_checkpoint_complete = bool(
+        checkpoint.get("satisfied") is True
+        and fresh_vision_patch
+        and claim
+        and evidence_refs
+        and path_outcome in VISION_OUTCOME_CHECKPOINT_CONTINUATION_OUTCOMES
+        and not outcome_gap_reported
+    )
+    replan_checkpoint_complete = bool(
+        checkpoint.get("satisfied") is True
+        and fresh_vision_patch
+        and claim
+        and evidence_refs
+        and path_outcome == "replan"
+        and autonomous_replan_recorded
+        and frontier_delta_recorded
+    )
+    if continuation_checkpoint_complete or replan_checkpoint_complete:
+        return []
+
+    gap: dict[str, Any] = {
+        "kind": VISION_OUTCOME_CHECKPOINT_REQUIRED_TRIGGER,
+        "source": "latest_vision_checkpoint",
+        "agent_id": checkpoint.get("agent_id") or agent_vision.get("agent_id"),
+        "replan_trigger_summary": (
+            "a material milestone closed without a fresh evidence-linked final-outcome "
+            "path decision"
+        ),
+        "acceptance_summary": _compact_text(
+            current_patch.get("acceptance_summary"),
+            limit=420,
+        )
+        or claim
+        or "Name the active final-outcome claim and its authoritative evidence.",
+        "advancement_policy": current_patch.get("advancement_policy"),
+        "checkpoint_decision": checkpoint.get("decision"),
+        "delivery_outcomes": delivery_outcomes[:3],
+        "fresh_vision_patch": fresh_vision_patch,
+        "path_outcome": path_outcome,
+        "evidence_ref_count": len(evidence_refs),
+        "required_path_outcomes": ["continue", "no_change", "replan"],
+    }
+    generated_at = _compact_text(checkpoint.get("generated_at"), limit=80)
+    if generated_at:
+        gap["generated_at"] = generated_at
+    return [gap]
+
+
+def _iso_timestamp(value: Any) -> float | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.timestamp()
+
+
+def _checkpoint_covers_completed_todo(
+    agent_vision: dict[str, Any],
+    checkpoint: dict[str, Any],
+) -> bool:
+    if checkpoint.get("satisfied") is not True:
+        return False
+    trigger_kinds = {
+        str(trigger.get("kind") or "").strip()
+        for trigger in (checkpoint.get("triggers") or [])
+        if isinstance(trigger, dict) and str(trigger.get("kind") or "").strip()
+    }
+    material_checkpoint = any(
+        trigger.get("kind") == "material_delivery_outcome"
+        and str(trigger.get("delivery_outcome") or "").strip()
+        in VISION_OUTCOME_CHECKPOINT_MATERIAL_OUTCOMES
+        for trigger in (checkpoint.get("triggers") or [])
+        if isinstance(trigger, dict)
+    )
+    if material_checkpoint:
+        return not acceptance_gaps_from_outcome_checkpoint(agent_vision, checkpoint)
+    if "autonomous_replan_recorded" not in trigger_kinds:
+        return False
+    repair_delta_kinds = {
+        str(value or "").strip()
+        for value in (checkpoint.get("repair_delta_kinds") or [])
+        if str(value or "").strip()
+    }
+    return bool(
+        repair_delta_kinds & set(REPEAT_VISION_REPLAN_SATISFYING_DELTA_KINDS)
+    )
+
+
+def acceptance_gaps_from_todo_completion_checkpoint(
+    agent_vision: dict[str, Any] | None,
+    checkpoint: dict[str, Any] | None,
+    *,
+    agent_todo_summary: dict[str, Any] | None,
+    agent_id: str | None,
+) -> list[dict[str, Any]]:
+    """Require a qualified outcome checkpoint after a scoped todo completion."""
+
+    if not isinstance(agent_vision, dict):
+        return []
+    if goal_vision_state_is_closed(str(agent_vision.get("state") or "")):
+        return []
+    if not agent_id:
+        return []
+    summary = agent_todo_summary if isinstance(agent_todo_summary, dict) else {}
+    completed_items = [
+        item
+        for item in (summary.get("recent_completed_advancement_items") or [])
+        if isinstance(item, dict)
+        and agent_scope_item_claimed_by(item) == agent_id
+    ]
+    latest_item = max(
+        completed_items,
+        key=lambda item: _iso_timestamp(item.get("completed_at")) or 0.0,
+        default=None,
+    )
+    if not isinstance(latest_item, dict):
+        return []
+    completed_at = _iso_timestamp(latest_item.get("completed_at"))
+    if completed_at is None:
+        return []
+    checkpoint_generated_at = _iso_timestamp(
+        checkpoint.get("generated_at") if isinstance(checkpoint, dict) else None
+    )
+    if (
+        isinstance(checkpoint, dict)
+        and checkpoint_generated_at is not None
+        and checkpoint_generated_at >= completed_at
+        and _checkpoint_covers_completed_todo(agent_vision, checkpoint)
+    ):
+        return []
+
+    patch = _dict_field(agent_vision, "vision_patch")
+    return [
+        {
+            "kind": VISION_OUTCOME_CHECKPOINT_REQUIRED_TRIGGER,
+            "source": "recent_completed_advancement_todo",
+            "agent_id": agent_id or agent_vision.get("agent_id"),
+            "replan_trigger_summary": (
+                "completed advancement work has no later final-outcome checkpoint"
+            ),
+            "acceptance_summary": (
+                _compact_text(patch.get("acceptance_summary"), limit=420)
+                or "Name the active final-outcome claim and its authoritative evidence."
+            ),
+            "advancement_policy": patch.get("advancement_policy"),
+            "completed_todo_id": latest_item.get("todo_id"),
+            "completed_at": latest_item.get("completed_at"),
+            "checkpoint_generated_at": (
+                checkpoint.get("generated_at")
+                if isinstance(checkpoint, dict)
+                else None
+            ),
+            "required_path_outcomes": ["continue", "no_change", "replan"],
+        }
+    ]

--- a/loopx/control_plane/goals/goal_frontier/replan_rules.py
+++ b/loopx/control_plane/goals/goal_frontier/replan_rules.py
@@ -44,6 +44,7 @@ class GoalFrontierReplanFacts:
     total_frontier_advancement: int = 0
     acceptance_gap_count: int = 0
     selectable_frontier_advancement: int = 0
+    outcome_checkpoint_replan_required: bool = False
     acceptance_allows_watch_lane_continuation: bool = False
     long_todo_chain_triggered: bool = False
     long_todo_chain_acknowledged: bool = False
@@ -114,11 +115,18 @@ def select_goal_frontier_replan_rule(
             facts.acceptance_gap_count > 0
             and (
                 facts.successor_vision_required
+                or facts.outcome_checkpoint_replan_required
                 or facts.selectable_frontier_advancement == 0
             )
-            and not facts.acceptance_allows_watch_lane_continuation,
+            and (
+                facts.outcome_checkpoint_replan_required
+                or not facts.acceptance_allows_watch_lane_continuation
+            ),
             True,
-            "the scoped vision gap has no satisfying runnable frontier",
+            (
+                "the scoped vision gap lacks a fresh evidence-linked outcome "
+                "checkpoint or satisfying runnable frontier"
+            ),
         ),
         (
             GoalFrontierReplanRule.LONG_TODO_CHAIN,

--- a/loopx/control_plane/todos/quota_summary.py
+++ b/loopx/control_plane/todos/quota_summary.py
@@ -123,6 +123,7 @@ QUOTA_PAYLOAD_LANE_LIMITS = {
     "current_agent_claimed_advancement_items": QUOTA_PAYLOAD_VISIBILITY_LANE_LIMIT,
     "current_agent_claimed_monitor_items": QUOTA_PAYLOAD_VISIBILITY_LANE_LIMIT,
     "current_agent_blocker_items": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
+    "recent_completed_advancement_items": 5,
     "claimed_by_others_items": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
     "other_agent_scoped_items": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
     "other_agent_bound_user_action_items": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
@@ -481,6 +482,12 @@ def summarize_user_todos_for_quota(
         and str(item.get("reason") or "").strip()
     ]
     agent_id = str((agent_identity or {}).get("agent_id") or "").strip()
+    recent_completed_advancement_items = [
+        compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+        for item in (value.get("recent_completed_advancement_items") or [])
+        if isinstance(item, dict)
+        if not agent_id or agent_scope_item_claimed_by(item) == agent_id
+    ]
     current_agent_blocker_items = [
         item
         for item in blocker_items
@@ -512,6 +519,7 @@ def summarize_user_todos_for_quota(
         "active_next_action_executable_items": lanes.active_next_action_executable_items,
         "backlog_items": lanes.display_open_items[:TODO_BACKLOG_ITEM_LIMIT],
         "executable_backlog_items": lanes.executable_items[:TODO_BACKLOG_ITEM_LIMIT],
+        "recent_completed_advancement_items": recent_completed_advancement_items,
     }
     if blocker_items:
         summary["blocker_open_count"] = len(blocker_items)

--- a/loopx/control_plane/todos/todo_summary.py
+++ b/loopx/control_plane/todos/todo_summary.py
@@ -68,6 +68,7 @@ MAX_DEFERRED_TODO_VISIBILITY_ITEMS = 8
 MAX_MONITOR_DUE_ITEMS = 1
 MAX_DEPENDENCY_BLOCKERS = 4
 MAX_COMPLETED_SUCCESSION_WARNING_ITEMS = 5
+MAX_RECENT_COMPLETED_ADVANCEMENT_ITEMS = MAX_TODO_VISIBILITY_LANE_ITEMS
 
 TODO_ITEM_SCHEMA_VERSION = "todo_item_v0"
 TODO_SUCCESSION_WARNING_SCHEMA_VERSION = "todo_succession_warning_v0"
@@ -1235,6 +1236,22 @@ def compact_todo_group(
         lanes.done_items,
         all_items=items,
     )
+    recent_completed_advancement_items = [
+        compact_todo_item(item)
+        for item in sorted(
+            (
+                item
+                for item in lanes.done_items
+                if todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+                and str(item.get("completed_at") or "").strip()
+            ),
+            key=_completed_succession_sort_key,
+            reverse=True,
+        )[:MAX_RECENT_COMPLETED_ADVANCEMENT_ITEMS]
+    ]
+    for item in recent_completed_advancement_items:
+        for key in ("note", "evidence", "reason"):
+            item.pop(key, None)
     handoff_gates = build_todo_handoff_gate_states(items)
     route_replan_required = any(
         item.get("route_continuation_replan_required") is True
@@ -1308,6 +1325,9 @@ def compact_todo_group(
             for item in lanes.projected_deferred_items
             if item.get("resume_ready") is True
         ][:MAX_DEFERRED_TODO_VISIBILITY_ITEMS],
+        "recent_completed_advancement_items": (
+            recent_completed_advancement_items
+        ),
         "items": lanes.budgeted_items if item_limit is None else lanes.budgeted_items[:item_limit],
     }
     if include_task_orchestration_authority:

--- a/tests/control_plane/test_goal_frontier_replan_rules.py
+++ b/tests/control_plane/test_goal_frontier_replan_rules.py
@@ -50,6 +50,16 @@ from loopx.control_plane.goals.goal_frontier.replan_rules import (
         ),
         (
             {
+                "acceptance_gap_count": 1,
+                "selectable_frontier_advancement": 1,
+                "outcome_checkpoint_replan_required": True,
+                "acceptance_allows_watch_lane_continuation": True,
+            },
+            GoalFrontierReplanRule.VISION_ACCEPTANCE_GAP,
+            True,
+        ),
+        (
+            {
                 "long_todo_chain_triggered": True,
                 "selectable_frontier_advancement": 15,
             },

--- a/tests/control_plane/test_goal_outcome_continuity_characterization.py
+++ b/tests/control_plane/test_goal_outcome_continuity_characterization.py
@@ -71,7 +71,8 @@ def _semantic_replan_required(case: dict[str, Any]) -> bool:
 
 def _progress_run(case: dict[str, Any], event: dict[str, Any]) -> dict[str, Any]:
     agent_id = case["agent_id"]
-    return {
+    satisfies_final_outcome = event["satisfies_final_outcome"] is True
+    run: dict[str, Any] = {
         "classification": event["event_kind"],
         "generated_at": event["generated_at"],
         "agent_id": agent_id,
@@ -82,8 +83,9 @@ def _progress_run(case: dict[str, Any], event: dict[str, Any]) -> dict[str, Any]
             "agent_id": agent_id,
             "required": True,
             "satisfied": True,
-            "decision": "unchanged_with_reason",
-            "unchanged_reason": case["vision"]["unchanged_reason"],
+            "decision": (
+                "patched" if satisfies_final_outcome else "unchanged_with_reason"
+            ),
             "triggers": [
                 {
                     "kind": "material_delivery_outcome",
@@ -92,6 +94,30 @@ def _progress_run(case: dict[str, Any], event: dict[str, Any]) -> dict[str, Any]
             ],
         },
     }
+    if satisfies_final_outcome:
+        run["agent_vision"] = {
+            "schema_version": "goal_vision_replan_contract_v0",
+            "agent_id": agent_id,
+            "state": case["vision"]["state"],
+            "vision_patch": {
+                "acceptance_summary": case["vision"]["acceptance_summary"],
+                "advancement_policy": case["vision"]["advancement_policy"],
+            },
+            "path_delta": {
+                "schema_version": "goal_path_delta_v0",
+                "outcome": "continue",
+                "prior_assumption": "The milestone path still serves the final outcome.",
+                "observed_reality": "The final-outcome evidence is now present.",
+                "retained": ["Continue the evidence-backed milestone path."],
+                "evidence_refs": event["supporting_evidence"],
+            },
+        }
+        run["vision_checkpoint"]["agent_vision_state"] = case["vision"]["state"]
+    else:
+        run["vision_checkpoint"]["unchanged_reason"] = case["vision"][
+            "unchanged_reason"
+        ]
+    return run
 
 
 def _vision_run(case: dict[str, Any]) -> dict[str, Any]:
@@ -151,10 +177,15 @@ def _replay_current_path(case: dict[str, Any]) -> dict[str, Any]:
         agent_id=agent_id,
         scheduler_execution_context=APP_SCHEDULER_CONTEXT,
     )
+    selected_todo = decision.get("selected_todo")
     return {
         "decision": decision["decision"],
         "effective_action": decision["effective_action"],
-        "selected_todo_id": decision["selected_todo"]["todo_id"],
+        "selected_todo_id": (
+            selected_todo.get("todo_id")
+            if isinstance(selected_todo, dict)
+            else None
+        ),
         "acceptance_gap_decision": decision["vision_continuation_audit"][
             "decision"
         ],
@@ -194,14 +225,16 @@ def test_final_outcome_evidence_changes_the_independent_oracle() -> None:
     case["progress_events"][-1]["satisfies_final_outcome"] = True
 
     assert _semantic_replan_required(case) is False
+    assert _replay_current_path(case)["replan_required"] is False
 
 
-def test_current_path_misses_semantic_divergence_during_local_progress() -> None:
+def test_repaired_path_replans_semantic_divergence_during_local_progress() -> None:
     case = _load_case()
 
     observed = _replay_current_path(case)
 
-    assert observed == case["characterized_current_path"]
-    assert observed["replan_required"] is not case["independent_oracle"][
+    assert observed["acceptance_gap_decision"] == "acceptance_gap_open"
+    assert observed["replan_required"] is case["independent_oracle"][
         "replan_required"
     ]
+    assert case["characterized_legacy_path"]["replan_required"] is False

--- a/tests/control_plane/test_goal_vision_succession.py
+++ b/tests/control_plane/test_goal_vision_succession.py
@@ -6,6 +6,16 @@ from loopx.control_plane.goals.goal_frontier import (
     acceptance_gaps_from_agent_vision,
     derive_goal_frontier_replan_obligation_from_summaries,
 )
+from loopx.control_plane.goals.goal_frontier.outcome_continuity import (
+    acceptance_gaps_from_outcome_checkpoint,
+    acceptance_gaps_from_todo_completion_checkpoint,
+    latest_outcome_vision_checkpoint_from_status_payload,
+)
+from loopx.control_plane.todos.quota_summary import (
+    compact_quota_todo_summary_for_payload,
+    summarize_user_todos_for_quota,
+)
+from loopx.control_plane.todos.todo_summary import compact_todo_group
 
 
 AGENT_ID = "fixture-agent"
@@ -143,3 +153,309 @@ def test_other_agent_work_does_not_satisfy_scoped_repeat_vision() -> None:
     assert obligation["agent_id"] == AGENT_ID
     assert obligation["triggers"][0]["kind"] == "vision_acceptance_gap"
     assert obligation["todo_actions"][0]["action"] == "add"
+
+
+def _outcome_vision(
+    *,
+    generated_at: str = "2026-07-12T00:01:00Z",
+    outcome: str = "continue",
+    evidence_refs: list[str] | None = None,
+) -> dict[str, object]:
+    packet = vision("vision_active")
+    packet["generated_at"] = generated_at
+    packet["path_delta"] = {
+        "schema_version": "goal_path_delta_v0",
+        "outcome": outcome,
+        "evidence_refs": evidence_refs or [],
+    }
+    return packet
+
+
+def _material_checkpoint(
+    *,
+    generated_at: str = "2026-07-12T00:01:00Z",
+    decision: str = "patched",
+    autonomous_replan_recorded: bool = False,
+    repair_delta_kinds: list[str] | None = None,
+) -> dict[str, object]:
+    triggers: list[dict[str, object]] = [
+        {
+            "kind": "material_delivery_outcome",
+            "delivery_outcome": "outcome_progress",
+        }
+    ]
+    if autonomous_replan_recorded:
+        triggers.insert(0, {"kind": "autonomous_replan_recorded"})
+    return {
+        "schema_version": "vision_checkpoint_v0",
+        "agent_id": AGENT_ID,
+        "required": True,
+        "satisfied": True,
+        "decision": decision,
+        "triggers": triggers,
+        "repair_delta_kinds": repair_delta_kinds or [],
+        "generated_at": generated_at,
+    }
+
+
+def test_material_unchanged_checkpoint_rejects_stale_planning_evidence() -> None:
+    active_vision = _outcome_vision(
+        generated_at="2026-07-12T00:00:00Z",
+        evidence_refs=["todo:planned-stage"],
+    )
+    checkpoint = _material_checkpoint(decision="unchanged_with_reason")
+
+    gaps = acceptance_gaps_from_outcome_checkpoint(active_vision, checkpoint)
+
+    assert len(gaps) == 1
+    assert gaps[0]["kind"] == "vision_outcome_checkpoint_required"
+    assert gaps[0]["fresh_vision_patch"] is False
+
+
+def test_fresh_evidence_linked_continue_checkpoint_preserves_frontier() -> None:
+    active_vision = _outcome_vision(evidence_refs=["result:final-outcome-receipt"])
+    checkpoint = _material_checkpoint()
+
+    assert acceptance_gaps_from_outcome_checkpoint(active_vision, checkpoint) == []
+
+
+def test_unsatisfied_material_checkpoint_cannot_preserve_frontier() -> None:
+    active_vision = _outcome_vision(evidence_refs=["result:final-outcome-receipt"])
+    checkpoint = {**_material_checkpoint(), "satisfied": False}
+
+    gaps = acceptance_gaps_from_outcome_checkpoint(active_vision, checkpoint)
+
+    assert len(gaps) == 1
+    assert gaps[0]["kind"] == "vision_outcome_checkpoint_required"
+
+
+@pytest.mark.parametrize(
+    ("repair_delta_kinds", "expects_gap"),
+    [
+        ([], True),
+        (["monitor_target"], True),
+        (["successor_or_supersede"], False),
+    ],
+)
+def test_fresh_replan_checkpoint_requires_frontier_delta(
+    repair_delta_kinds: list[str],
+    expects_gap: bool,
+) -> None:
+    active_vision = _outcome_vision(
+        outcome="replan",
+        evidence_refs=["result:outcome-conflict"],
+    )
+    checkpoint = _material_checkpoint(
+        autonomous_replan_recorded=True,
+        repair_delta_kinds=repair_delta_kinds,
+    )
+
+    gaps = acceptance_gaps_from_outcome_checkpoint(active_vision, checkpoint)
+
+    assert bool(gaps) is expects_gap
+
+
+@pytest.mark.parametrize(
+    ("checkpoint_generated_at", "expects_gap"),
+    [
+        ("2026-07-12T00:01:00Z", True),
+        ("2026-07-12T00:03:00Z", False),
+    ],
+)
+def test_completed_todo_requires_a_later_outcome_checkpoint(
+    checkpoint_generated_at: str,
+    expects_gap: bool,
+) -> None:
+    active_vision = _outcome_vision(
+        generated_at=checkpoint_generated_at,
+        evidence_refs=["result:completed-milestone"],
+    )
+    checkpoint = _material_checkpoint(generated_at=checkpoint_generated_at)
+    summary = {
+        "recent_completed_advancement_items": [
+            {
+                "todo_id": "todo_completed_milestone",
+                "claimed_by": AGENT_ID,
+                "completed_at": "2026-07-12T00:02:00Z",
+            }
+        ]
+    }
+
+    gaps = acceptance_gaps_from_todo_completion_checkpoint(
+        active_vision,
+        checkpoint,
+        agent_todo_summary=summary,
+        agent_id=AGENT_ID,
+    )
+
+    assert bool(gaps) is expects_gap
+
+
+def test_plain_refresh_after_completed_todo_does_not_clear_checkpoint_gap() -> None:
+    active_vision = _outcome_vision(generated_at="2026-07-12T00:00:00Z")
+    checkpoint = {
+        **_material_checkpoint(generated_at="2026-07-12T00:03:00Z"),
+        "triggers": [{"kind": "heartbeat_refresh"}],
+    }
+    summary = {
+        "recent_completed_advancement_items": [
+            {
+                "todo_id": "todo_completed_milestone",
+                "claimed_by": AGENT_ID,
+                "completed_at": "2026-07-12T00:02:00Z",
+            }
+        ]
+    }
+
+    gaps = acceptance_gaps_from_todo_completion_checkpoint(
+        active_vision,
+        checkpoint,
+        agent_todo_summary=summary,
+        agent_id=AGENT_ID,
+    )
+
+    assert len(gaps) == 1
+    assert gaps[0]["kind"] == "vision_outcome_checkpoint_required"
+
+
+def test_plain_refresh_does_not_supersede_older_material_checkpoint() -> None:
+    status = {
+        "run_history": {
+            "goals": [
+                {
+                    "id": "goal-outcome",
+                    "latest_runs": [
+                        {
+                            "agent_id": AGENT_ID,
+                            "generated_at": "2026-07-12T00:03:00Z",
+                            "vision_checkpoint": {
+                                "agent_id": AGENT_ID,
+                                "satisfied": True,
+                                "decision": "not_required",
+                                "triggers": [{"kind": "heartbeat_refresh"}],
+                            },
+                        },
+                        {
+                            "agent_id": AGENT_ID,
+                            "generated_at": "2026-07-12T00:02:00Z",
+                            "vision_checkpoint": _material_checkpoint(
+                                generated_at="2026-07-12T00:02:00Z",
+                                decision="unchanged_with_reason",
+                            ),
+                        },
+                    ],
+                }
+            ]
+        }
+    }
+
+    checkpoint = latest_outcome_vision_checkpoint_from_status_payload(
+        status,
+        goal_id="goal-outcome",
+        agent_id=AGENT_ID,
+    )
+
+    assert checkpoint is not None
+    assert checkpoint["generated_at"] == "2026-07-12T00:02:00Z"
+
+
+def test_later_vision_patch_does_not_invalidate_qualified_checkpoint() -> None:
+    qualified_vision = _outcome_vision(
+        generated_at="2026-07-12T00:02:00Z",
+        evidence_refs=["result:qualified-milestone"],
+    )
+    status = {
+        "run_history": {
+            "goals": [
+                {
+                    "id": "goal-outcome",
+                    "latest_runs": [
+                        {
+                            "agent_id": AGENT_ID,
+                            "generated_at": "2026-07-12T00:03:00Z",
+                            "agent_vision": _outcome_vision(
+                                generated_at="2026-07-12T00:03:00Z",
+                                outcome="replan",
+                                evidence_refs=["result:new-planning-evidence"],
+                            ),
+                        },
+                        {
+                            "agent_id": AGENT_ID,
+                            "generated_at": "2026-07-12T00:02:00Z",
+                            "agent_vision": qualified_vision,
+                            "vision_checkpoint": _material_checkpoint(
+                                generated_at="2026-07-12T00:02:00Z",
+                            ),
+                        },
+                    ],
+                }
+            ]
+        }
+    }
+    checkpoint = latest_outcome_vision_checkpoint_from_status_payload(
+        status,
+        goal_id="goal-outcome",
+        agent_id=AGENT_ID,
+    )
+
+    assert checkpoint is not None
+    assert (
+        acceptance_gaps_from_outcome_checkpoint(
+            _outcome_vision(generated_at="2026-07-12T00:03:00Z"),
+            checkpoint,
+        )
+        == []
+    )
+
+
+def test_recent_completed_advancement_projection_is_agent_scoped() -> None:
+    source = compact_todo_group(
+        [
+            *[
+                {
+                    "todo_id": f"todo_current_completed_{minute}",
+                    "role": "agent",
+                    "status": "done",
+                    "done": True,
+                    "text": "Complete a current-agent milestone.",
+                    "task_class": "advancement_task",
+                    "claimed_by": AGENT_ID,
+                    "completed_at": f"2026-07-12T00:0{minute}:00Z",
+                }
+                for minute in range(1, 8)
+            ],
+            {
+                "todo_id": "todo_other_completed",
+                "role": "agent",
+                "status": "done",
+                "done": True,
+                "text": "Complete another agent milestone.",
+                "task_class": "advancement_task",
+                "claimed_by": "other-agent",
+                "completed_at": "2026-07-12T00:08:00Z",
+            },
+        ],
+        source_section="Agent Todo",
+        role="agent",
+        include_empty_source=True,
+        item_limit=None,
+    )
+
+    summary = summarize_user_todos_for_quota(
+        source,
+        agent_identity={"agent_id": AGENT_ID},
+    )
+
+    assert summary is not None
+    assert len(summary["recent_completed_advancement_items"]) == 7
+    payload = compact_quota_todo_summary_for_payload(summary)
+    assert [
+        item["todo_id"]
+        for item in payload["recent_completed_advancement_items"]
+    ] == [
+        "todo_current_completed_7",
+        "todo_current_completed_6",
+        "todo_current_completed_5",
+        "todo_current_completed_4",
+        "todo_current_completed_3",
+    ]

--- a/tests/fixtures/control_plane/goal_outcome_continuity_characterization_v0.json
+++ b/tests/fixtures/control_plane/goal_outcome_continuity_characterization_v0.json
@@ -59,7 +59,7 @@
     "replan_required": true,
     "rationale": "The final-outcome claim remains open and every progress event is supporting evidence only; another runnable milestone does not prove that the selected path serves the final outcome."
   },
-  "characterized_current_path": {
+  "characterized_legacy_path": {
     "decision": "run",
     "effective_action": "normal_run",
     "selected_todo_id": "todo_continue_packet_mapping",


### PR DESCRIPTION
## Summary

- characterize the gap where locally successful material milestones and a runnable successor could hide an open final-outcome acceptance claim
- require each material closeout to pair the active acceptance claim with fresh same-run `goal_path_delta` evidence and an explicit `continue`/`no_change` or evidence-backed `replan` decision
- project five agent-scoped recent advancement completions from a bounded sixteen-row source buffer so a completed Todo chain cannot disappear before a qualified outcome checkpoint
- make `vision_outcome_checkpoint_required` preempt ordinary runnable work and monitor quiet-wait, while preserving user gates and qualified terminal/superseding paths

## Design

The implementation reuses the existing `acceptance_summary`, `goal_path_delta_v0`, `vision_checkpoint_v0`, repair-delta kinds, and Todo lifecycle. It adds no LLM semantic judge, benchmark/Effect-specific policy, or new persisted Todo schema. Outcome reduction lives in the existing goal-frontier bounded context; the hot `goal_frontier/__init__.py` module is smaller than before this PR.

Todo completion is a checkpoint timing signal, not unconditional proof or unconditional replan. A same-refresh checkpoint may continue when authoritative evidence supports the final path; otherwise it must record a real replan/frontier delta, supersede, or close the vision.

## Validation

- full repository pytest: 2443 passed, 2 skipped
- focused goal-frontier/outcome-continuity/maintainability tests: passed
- Ruff on all changed Python paths: passed
- repository-configured mypy (15 production modules): passed
- isolated strict mypy for the new outcome-continuity module: passed
- quota replan decision-plane, goal-vision contract, CLI output-budget, and maintainability-ratchet smokes: passed
- public-boundary scan: 10 files, 0 errors, 0 warnings
- `git diff --check`: passed
- LoopX exact-diff change-quality and risk-based premerge: recorded in the final PR review comment

## Excluded

- no benchmark scoring, runner, task-semantic, permission, scheduler cadence, or quota-spend change
- no private state, raw sessions, logs, trajectories, credentials, local paths, or generated artifacts
