### PR TITLE
fix: decode git subprocess output as UTF-8 on Windows

### DIFF
--- a/loopx/contract.py
+++ b/loopx/contract.py
@@ -103,6 +103,8 @@ def _git_probe(path: Path) -> dict[str, Any]:
         root = subprocess.run(
             ["git", "-C", str(target), "rev-parse", "--show-toplevel"],
             text=True,
+            encoding="utf-8",
+            errors="replace",
             capture_output=True,
             check=True,
         ).stdout.strip()
@@ -118,6 +120,8 @@ def _git_probe(path: Path) -> dict[str, Any]:
         subprocess.run(
             ["git", "-C", str(repo_root), "ls-files", "--error-unmatch", "--", rel_path],
             text=True,
+            encoding="utf-8",
+            errors="replace",
             capture_output=True,
             check=False,
         ).returncode
@@ -127,6 +131,8 @@ def _git_probe(path: Path) -> dict[str, Any]:
         subprocess.run(
             ["git", "-C", str(repo_root), "check-ignore", "-q", "--", rel_path],
             text=True,
+            encoding="utf-8",
+            errors="replace",
             capture_output=True,
             check=False,
         ).returncode
@@ -606,6 +612,8 @@ def _tracked_scan_files(scan_root: Path) -> list[Path]:
         root = subprocess.run(
             ["git", "-C", str(target), "rev-parse", "--show-toplevel"],
             text=True,
+            encoding="utf-8",
+            errors="replace",
             capture_output=True,
             check=True,
         ).stdout.strip()
@@ -623,6 +631,8 @@ def _tracked_scan_files(scan_root: Path) -> list[Path]:
     tracked = subprocess.run(
         ["git", "-C", str(repo_root), "ls-files", "-z", "--", rel_root],
         text=True,
+        encoding="utf-8",
+        errors="replace",
         capture_output=True,
         check=False,
     )

--- a/loopx/onboarding.py
+++ b/loopx/onboarding.py
@@ -37,6 +37,8 @@ def _git(project: Path, *args: str, timeout_seconds: float = 1.5) -> subprocess.
             check=False,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout_seconds,
         )
     except (OSError, subprocess.TimeoutExpired):

--- a/loopx/registry.py
+++ b/loopx/registry.py
@@ -120,6 +120,8 @@ def _registry_git_probe(path: Path) -> dict[str, Any]:
                 ["git", *args],
                 cwd=cwd,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 check=False,


### PR DESCRIPTION
git text subprocess probes (onboarding scan, registry probe, contract check/scan) used text=True without an explicit encoding, so on Chinese Windows the GBK locale default raised UnicodeDecodeError when git emitted UTF-8 paths or commit subjects, aborting 'loopx connect' and friends. Decode with encoding='utf-8' and errors='replace' for parity with the existing UTF-8 file I/O convention.

## Summary

-

## Issue Or Task

- Closes #
- Contributor task ID:

## Validation

- [ ] `python3 -m py_compile loopx/*.py`
- [ ] `loopx check --scan-root .`
- [ ] Other:

## Boundary Checklist

- [ ] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [ ] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [ ] I kept the change scoped to the linked issue/task.
