### PR TITLE
docs(integration): add minimal custom-runtime CLI turn example

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,9 +229,11 @@ the [Codex App host command registry contract](docs/reference/protocols/codex-ap
 the [Codex CLI packaged install path](docs/product/runtimes/codex-cli/codex-cli-packaged-install.md),
 or the [Claude Code adapter](loopx/claude_goal_mode/README.md).
 
-For custom runners, read
+For custom runners, start with the
+[minimal custom runtime example](docs/guides/minimal-custom-runtime-example.md)
+(`python3 examples/custom-runtime-minimal-cli-turn-smoke.py`), then the full
 [Embed LoopX in Your Agent Runner](docs/guides/custom-agent-runner-integration.md)
-and the [worker bridge install contract](docs/integrations/worker-bridge-install-contract.md).
+guide and the [worker bridge install contract](docs/integrations/worker-bridge-install-contract.md).
 The core tick is deliberately small:
 
 ```text
@@ -376,7 +378,8 @@ quota, and handoff explicit.
 - Feishu/Lark projection: [Lark Kanban adapter](docs/integrations/lark-kanban-control-plane-adapter.md)
 - Generic host integration: [integration guide](docs/integration.md)
 - Custom multi-agent runner:
-  [custom runner integration](docs/guides/custom-agent-runner-integration.md)
+  [minimal custom runtime example](docs/guides/minimal-custom-runtime-example.md),
+  then [custom runner integration](docs/guides/custom-agent-runner-integration.md)
 
 Optional projections make state easier to inspect; they do not become the
 source of truth.
@@ -455,6 +458,7 @@ deeper documents and versioned protocols.
 ### Integrate and Extend
 
 - [Integration Guide](docs/integration.md)
+- [Minimal Custom Runtime Example](docs/guides/minimal-custom-runtime-example.md)
 - [Custom Agent Runner Integration](docs/guides/custom-agent-runner-integration.md)
 - [Integrations](docs/integrations/README.md): runtime, host, collaboration, and
   external-system adapters, including worker bridge and Lark.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -208,7 +208,9 @@ loopx start-goal --guided --project . --goal-text "你的长程目标"
 [Codex CLI packaged install](docs/product/runtimes/codex-cli/codex-cli-packaged-install.md)和
 [Claude Code adapter](loopx/claude_goal_mode/README.md)。
 
-自有 runner 请读
+自有 runner 请先看
+[最小自定义 Runtime 示例](docs/guides/minimal-custom-runtime-example.zh-CN.md)
+（`python3 examples/custom-runtime-minimal-cli-turn-smoke.py`），再读完整的
 [把 LoopX 嵌入你的 Agent Runner](docs/guides/custom-agent-runner-integration.zh-CN.md)
 与 [Worker Bridge Install Contract](docs/integrations/worker-bridge-install-contract.md)。
 核心 tick 很小：
@@ -339,7 +341,8 @@ treatment 和 guardrail 的任务，不替代生产审批。先读
 - 飞书投影：[Lark Kanban Adapter](docs/integrations/lark-kanban-control-plane-adapter.md)
 - 通用 host 集成：[Integration Guide](docs/integration.md)
 - 自有 multi-agent runner：
-  [Custom Runner 中文指南](docs/guides/custom-agent-runner-integration.zh-CN.md)
+  [最小自定义 Runtime 示例](docs/guides/minimal-custom-runtime-example.zh-CN.md)，
+  再看 [Custom Runner 中文指南](docs/guides/custom-agent-runner-integration.zh-CN.md)
 
 可选 projection 让状态更易检查，但不会成为新的事实源。
 
@@ -412,6 +415,7 @@ loopx check \
 ### 集成与扩展
 
 - [Integration Guide](docs/integration.md)
+- [最小自定义 Runtime 示例](docs/guides/minimal-custom-runtime-example.zh-CN.md)
 - [Custom Agent Runner 中文指南](docs/guides/custom-agent-runner-integration.zh-CN.md)
 - [Integrations](docs/integrations/README.md)：runtime、host、协作和外部系统 adapter，
   包括 worker bridge 与 Lark。

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -4,6 +4,8 @@ Guides are task-oriented paths for people starting or operating LoopX.
 
 - [Getting started](getting-started.md)
 - [Newcomer command path](newcomer-command-path.md)
+- [Minimal custom runtime example](minimal-custom-runtime-example.md)
+- [Minimal custom runtime example (中文)](minimal-custom-runtime-example.zh-CN.md)
 - [Custom Agent runner integration](custom-agent-runner-integration.md)
 - [Custom Agent runner integration (中文)](custom-agent-runner-integration.zh-CN.md)
 - [Auto-research command path](auto-research-command-path.md)

--- a/docs/guides/custom-agent-runner-integration.md
+++ b/docs/guides/custom-agent-runner-integration.md
@@ -8,6 +8,12 @@ You do not need to replace that runtime or move domain orchestration into
 LoopX. Keep your runner, and use LoopX as the durable control-plane contract
 between turns.
 
+Want the shortest public contract first? Start with the
+[minimal custom runtime example](minimal-custom-runtime-example.md) and run
+`python3 examples/custom-runtime-minimal-cli-turn-smoke.py`. The advanced typed
+Turn path is separate:
+`python3 examples/loopx-turn-fake-host-walkthrough-smoke.py`.
+
 The shortest useful mental model has three pieces:
 
 | Piece | Owns | Does not own |

--- a/docs/guides/custom-agent-runner-integration.zh-CN.md
+++ b/docs/guides/custom-agent-runner-integration.zh-CN.md
@@ -6,6 +6,11 @@
 开发者。你不需要替换现有 runtime，也不需要把领域编排搬进 LoopX。保留自己的 runner，
 把 LoopX 作为跨 Turn 的持久控制面合同即可。
 
+想先看最短公共契约？从
+[最小自定义 Runtime 示例](minimal-custom-runtime-example.zh-CN.md) 开始，并运行
+`python3 examples/custom-runtime-minimal-cli-turn-smoke.py`。进阶 typed Turn 路径是另一条：
+`python3 examples/loopx-turn-fake-host-walkthrough-smoke.py`。
+
 最小心智模型只有三部分：
 
 | 部件 | 负责什么 | 不负责什么 |

--- a/docs/guides/minimal-custom-runtime-example.md
+++ b/docs/guides/minimal-custom-runtime-example.md
@@ -1,0 +1,88 @@
+# Minimal Custom Runtime Example
+
+[简体中文](minimal-custom-runtime-example.zh-CN.md)
+
+LoopX is agent-loop agnostic, but most hosts do **not** need a typed runtime
+adapter. This page is the short contract requested by
+[issue #2835](https://github.com/huangruiteng/loopx/issues/2835).
+
+There are two integration depths. Start with path A unless you need
+programmatic commit/replay/recovery.
+
+## Path A — Mainstream: skill + wake + LoopX CLI
+
+Pieces:
+
+| Piece | Owns | Does not own |
+| --- | --- | --- |
+| **Host wake** | When a turn starts (cron, task queue, visible `/goal`, native loop, or a human) | Todo/gate/quota/evidence stores |
+| **Lightweight skill / re-entry instruction** | How the agent reads a fresh packet, claims work, validates, and writes back | A second state machine |
+| **LoopX CLI** | Durable goal, todos, claims, gates, evidence, refresh, quota, scheduler hints | Model tools and host process lifecycle |
+
+Canonical turn:
+
+```text
+host wake
+  -> lightweight skill / re-entry instruction
+  -> loopx status
+  -> loopx quota should-run
+  -> loopx todo claim
+  -> agent executes one bounded slice
+  -> independent validation of the real postcondition
+  -> loopx todo complete (evidence) + refresh-state
+  -> loopx quota spend-slot --execute
+  -> host applies scheduler_hint for the next wake
+```
+
+Executable public smoke (synthetic fixture only):
+
+```bash
+python3 examples/custom-runtime-minimal-cli-turn-smoke.py
+```
+
+The smoke proves the shipped CLI sequence on a temporary project: claim one
+todo, write a public marker file, validate the marker, complete with evidence,
+refresh state, and spend one controller slot. It does not copy private logs,
+credentials, or live agent transcripts.
+
+For day-to-day onboarding commands (`agent-onboard`, skill delivery, scheduler
+ACK), use the longer
+[Embed LoopX in Your Agent Runner](custom-agent-runner-integration.md) guide.
+
+## Path B — Advanced: typed LoopX Turn adapter
+
+Use this when a host must drive an external worker programmatically and needs
+preview/commit/replay/recovery semantics rather than a cooperative agent that
+calls the CLI itself:
+
+```text
+fresh LoopX decision / TurnEnvelope
+  -> host adapter
+  -> loopx_turn_result_v0
+  -> independent effect validation
+  -> durable commit / replay / recovery
+```
+
+Executable public smoke:
+
+```bash
+python3 examples/loopx-turn-fake-host-walkthrough-smoke.py
+```
+
+Path B is optional. It does not replace path A for Codex, Claude Code, Cursor,
+shell, Grok Build, or other cooperative hosts.
+
+## What a custom runtime must not do
+
+- Implement a second Todo, gate, evidence, quota, or scheduler store.
+- Spend quota before validated durable writeback.
+- Treat model completion text as proof without reading the real artifact.
+- Commit `.loopx/`, live `ACTIVE_GOAL_STATE.md`, credentials, or raw sessions.
+- Silently switch a visible host into hidden unattended execution.
+
+## Related surfaces
+
+- [Custom agent runner integration](custom-agent-runner-integration.md)
+- [Runtime connector catalog](../integrations/runtime-connector-catalog.md)
+- [Host integration surface v0](../reference/protocols/host-integration-surface-v0.md)
+- [LoopX Turn fake-host walkthrough smoke](../../examples/loopx-turn-fake-host-walkthrough-smoke.py)

--- a/docs/guides/minimal-custom-runtime-example.zh-CN.md
+++ b/docs/guides/minimal-custom-runtime-example.zh-CN.md
@@ -1,0 +1,83 @@
+# 最小自定义 Runtime 示例
+
+[English](minimal-custom-runtime-example.md)
+
+LoopX 对 agent loop 保持中立，但大多数宿主**不需要**实现 typed runtime
+adapter。本页对应
+[issue #2835](https://github.com/huangruiteng/loopx/issues/2835)
+要求的最短接入契约。
+
+有两种接入深度。除非你需要程序化的 commit/replay/recovery，否则从路径 A 开始。
+
+## 路径 A — 主流：skill + 唤醒 + LoopX CLI
+
+| 部件 | 负责 | 不负责 |
+| --- | --- | --- |
+| **宿主唤醒** | 何时开始一轮（cron、队列、可见 `/goal`、原生 loop 或人工） | Todo/gate/quota/证据存储 |
+| **轻量 skill / 再进入指令** | agent 如何读取新鲜 packet、认领工作、校验并写回 | 第二套状态机 |
+| **LoopX CLI** | 持久 goal、todo、claim、gate、证据、refresh、quota、scheduler hint | 模型工具与宿主进程生命周期 |
+
+标准一轮：
+
+```text
+宿主唤醒
+  -> 轻量 skill / 再进入指令
+  -> loopx status
+  -> loopx quota should-run
+  -> loopx todo claim
+  -> agent 执行一个有界切片
+  -> 独立校验真实后置条件
+  -> loopx todo complete（evidence）+ refresh-state
+  -> loopx quota spend-slot --execute
+  -> 宿主应用 scheduler_hint，准备下一次唤醒
+```
+
+可执行公共 smoke（仅合成 fixture）：
+
+```bash
+python3 examples/custom-runtime-minimal-cli-turn-smoke.py
+```
+
+该 smoke 在临时项目上验证已发布 CLI 序列：认领 todo、写入公开 marker、
+校验 marker、带 evidence 完成、refresh，并花费一个 controller slot。
+它不会复制私有日志、凭证或真实 agent transcript。
+
+日常 onboarding（`agent-onboard`、skill 投递、scheduler ACK）见更长的
+[把 LoopX 嵌入你的 Agent Runner](custom-agent-runner-integration.zh-CN.md)。
+
+## 路径 B — 进阶：typed LoopX Turn adapter
+
+当宿主需要以程序方式驱动外部 worker，并需要 preview/commit/replay/recovery
+语义时，使用此路径，而不是依赖协作式 agent 自行调用 CLI：
+
+```text
+新鲜 LoopX decision / TurnEnvelope
+  -> host adapter
+  -> loopx_turn_result_v0
+  -> 独立 effect 校验
+  -> 持久 commit / replay / recovery
+```
+
+可执行公共 smoke：
+
+```bash
+python3 examples/loopx-turn-fake-host-walkthrough-smoke.py
+```
+
+路径 B 是可选的。它不取代 Codex、Claude Code、Cursor、shell、Grok Build
+等协作式宿主上的路径 A。
+
+## 自定义 runtime 不应做的事
+
+- 再实现一套 Todo / gate / 证据 / quota / scheduler 存储。
+- 在验证写回之前 `spend-slot`。
+- 把模型完成文本当成证明，而不读取真实产物。
+- 提交 `.loopx/`、活的 `ACTIVE_GOAL_STATE.md`、凭证或原始 session。
+- 把可见宿主静默切换成隐藏无人值守执行。
+
+## 相关页面
+
+- [Custom agent runner integration](custom-agent-runner-integration.md)
+- [Runtime connector catalog](../integrations/runtime-connector-catalog.md)
+- [Host integration surface v0](../reference/protocols/host-integration-surface-v0.md)
+- [LoopX Turn fake-host walkthrough smoke](../../examples/loopx-turn-fake-host-walkthrough-smoke.py)

--- a/examples/custom-runtime-minimal-cli-turn-smoke.py
+++ b/examples/custom-runtime-minimal-cli-turn-smoke.py
@@ -18,18 +18,9 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
-
-from loopx.cli import main as loopx_cli_main  # noqa: E402
-from loopx.control_plane.testing.canary_harness import (  # noqa: E402
-    runtime_root_from_registry,
-    write_fixture_registry,
-)
-from loopx.status import parse_active_state_todos  # noqa: E402
-
 
 GOAL_ID = "custom-runtime-min"
 AGENT_ID = "custom-host-agent"
@@ -56,6 +47,9 @@ REENTRY_INSTRUCTION = """
 
 def run_cli(registry_path: Path, *args: str) -> dict[str, Any]:
     """Drive the shipped LoopX CLI entrypoint (not a reimplemented client)."""
+    from loopx.cli import main as loopx_cli_main
+    from loopx.control_plane.testing.canary_harness import runtime_root_from_registry
+
     runtime_root = runtime_root_from_registry(registry_path)
     argv = [
         "--registry",
@@ -80,6 +74,8 @@ def run_cli(registry_path: Path, *args: str) -> dict[str, Any]:
 
 
 def write_project_fixture(root: Path) -> tuple[Path, Path, Path]:
+    from loopx.control_plane.testing.canary_harness import write_fixture_registry
+
     project = root / "project"
     runtime = root / "runtime"
     project.mkdir()
@@ -111,6 +107,8 @@ def write_project_fixture(root: Path) -> tuple[Path, Path, Path]:
 
 
 def assert_mainstream_cli_turn() -> None:
+    from loopx.status import parse_active_state_todos
+
     assert WAKE_TRIGGER, "host must own a wake trigger"
     assert "quota should-run" in REENTRY_INSTRUCTION
     assert "spend-slot" in REENTRY_INSTRUCTION

--- a/examples/custom-runtime-minimal-cli-turn-smoke.py
+++ b/examples/custom-runtime-minimal-cli-turn-smoke.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Mainstream custom-runtime contract: skill + host wake + one LoopX CLI turn.
+
+This is the lightweight cooperative-agent path described in issue #2835:
+host-owned wake, a short re-entry instruction (skill), and LoopX CLI for
+status/quota/claim/execute/validate/writeback/refresh/spend. It is not a
+typed Turn adapter; that advanced path is covered separately by
+``examples/loopx-turn-fake-host-walkthrough-smoke.py``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.cli import main as loopx_cli_main  # noqa: E402
+from loopx.control_plane.testing.canary_harness import (  # noqa: E402
+    runtime_root_from_registry,
+    write_fixture_registry,
+)
+from loopx.status import parse_active_state_todos  # noqa: E402
+
+
+GOAL_ID = "custom-runtime-min"
+AGENT_ID = "custom-host-agent"
+MARKER_NAME = "public-marker.txt"
+MARKER_BODY = "ok-from-custom-runtime\n"
+ADVANCED_TURN_SMOKE = (
+    REPO_ROOT / "examples" / "loopx-turn-fake-host-walkthrough-smoke.py"
+)
+
+# Host-owned wake trigger: cron, scheduler callback, visible /goal, or a human.
+WAKE_TRIGGER = "host_scheduler_tick"
+
+# Lightweight skill / re-entry instruction injected by the host. It must not
+# cache previous packets or invent LoopX state stores.
+REENTRY_INSTRUCTION = """
+1. Read fresh `loopx status` and `loopx quota should-run` for this goal/agent.
+2. Obey user gates; claim one eligible agent todo before write-capable work.
+3. Execute one bounded slice; validate the real postcondition yourself.
+4. Write back todo/evidence via LoopX CLI, then `refresh-state`.
+5. `quota spend-slot --execute` only after validated durable writeback.
+6. Apply any scheduler_hint on the host; start the next wake from step 1.
+""".strip()
+
+
+def run_cli(registry_path: Path, *args: str) -> dict[str, Any]:
+    """Drive the shipped LoopX CLI entrypoint (not a reimplemented client)."""
+    runtime_root = runtime_root_from_registry(registry_path)
+    argv = [
+        "--registry",
+        str(registry_path),
+        "--runtime-root",
+        str(runtime_root),
+        "--format",
+        "json",
+        *args,
+    ]
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        code = loopx_cli_main(argv)
+    raw = buf.getvalue().strip()
+    payload: dict[str, Any] = json.loads(raw) if raw else {}
+    if code != 0:
+        raise AssertionError(
+            f"loopx {' '.join(args)} failed ({code}): "
+            f"{json.dumps(payload, ensure_ascii=False)[:1200]}"
+        )
+    return payload
+
+
+def write_project_fixture(root: Path) -> tuple[Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    project.mkdir()
+    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Active Goal State\n\n"
+        "## Objective\n\n"
+        "Prove the mainstream custom-runtime CLI turn contract.\n\n"
+        "## Agent Todo\n\n",
+        encoding="utf-8",
+    )
+    registry_path = project / ".loopx" / "registry.json"
+    write_fixture_registry(
+        project=project,
+        runtime_root=runtime,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        domain="custom-runtime-fixture",
+        adapter_kind="generic_project_goal_v0",
+        registered_agents=[AGENT_ID],
+        quota_allowed_slots=5,
+    )
+    return project, registry_path, state_file
+
+
+def assert_mainstream_cli_turn() -> None:
+    assert WAKE_TRIGGER, "host must own a wake trigger"
+    assert "quota should-run" in REENTRY_INSTRUCTION
+    assert "spend-slot" in REENTRY_INSTRUCTION
+    assert ADVANCED_TURN_SMOKE.is_file(), ADVANCED_TURN_SMOKE
+
+    with tempfile.TemporaryDirectory(prefix="loopx-custom-runtime-min-") as tmp:
+        project, registry_path, state_file = write_project_fixture(Path(tmp))
+
+        status = run_cli(registry_path, "status", "--scan-root", str(project))
+        assert status.get("ok") is True, status
+
+        added = run_cli(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            "Write one synthetic public marker file.",
+        )
+        todo_id = added["todo_id"]
+        assert todo_id.startswith("todo_"), added
+
+        claimed = run_cli(
+            registry_path,
+            "todo",
+            "claim",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            todo_id,
+            "--claimed-by",
+            AGENT_ID,
+            "--agent-id",
+            AGENT_ID,
+        )
+        assert claimed.get("changed") is True, claimed
+        assert claimed.get("claimed_by") == AGENT_ID, claimed
+
+        guard = run_cli(
+            registry_path,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--runtime-profile",
+            "generic_cli",
+            "--scan-path",
+            str(project),
+        )
+        assert guard.get("should_run") is True, guard
+        assert guard.get("state") == "eligible", guard
+
+        # Host/agent executes one bounded slice outside LoopX stores.
+        marker = project / MARKER_NAME
+        marker.write_text(MARKER_BODY, encoding="utf-8")
+        # Independent validation: real artifact, not the agent's claim alone.
+        assert marker.read_text(encoding="utf-8") == MARKER_BODY
+
+        completed = run_cli(
+            registry_path,
+            "todo",
+            "complete",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            todo_id,
+            "--claimed-by",
+            AGENT_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--evidence",
+            "public marker written under project root",
+            "--no-follow-up",
+        )
+        assert completed.get("changed") is True, completed
+        assert completed.get("no_followup") is True, completed
+
+        summary = parse_active_state_todos(state_file.read_text(encoding="utf-8"))
+        item = next(
+            row
+            for row in summary["agent_todos"]["items"]
+            if row.get("todo_id") == todo_id
+        )
+        assert item.get("done") is True, item
+
+        refreshed = run_cli(
+            registry_path,
+            "refresh-state",
+            "--goal-id",
+            GOAL_ID,
+            "--no-global-sync",
+        )
+        assert refreshed.get("ok") is True, refreshed
+        assert refreshed.get("appended") is True, refreshed
+
+        spent = run_cli(
+            registry_path,
+            "quota",
+            "spend-slot",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--slots",
+            "1",
+            "--source",
+            "controller",
+            "--execute",
+            "--scan-path",
+            str(project),
+        )
+        assert spent.get("ok") is True, spent
+        assert spent.get("appended") is True, spent
+        after = spent["quota_event"]["after"]
+        assert after["spent_slots"] == 1, spent
+        assert after["allowed_slots"] == 5, spent
+
+
+def main() -> int:
+    assert_mainstream_cli_turn()
+    print("custom-runtime-minimal-cli-turn-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -83,6 +83,7 @@ nav:
       - guides/README.md
       - Quick Start: guides/getting-started.md
       - Newcomer Command Path: guides/newcomer-command-path.md
+      - Minimal Custom Runtime Example: guides/minimal-custom-runtime-example.md
       - Custom Runner Integration: guides/custom-agent-runner-integration.md
       - Auto Research Command Path: guides/auto-research-command-path.md
   - Concepts:


### PR DESCRIPTION
## Summary

- Add a public-safe mainstream custom-runtime smoke: host wake + lightweight re-entry skill + one full LoopX CLI turn (status → should-run → claim → bounded work → validate → complete → refresh → spend-slot).
- Add bilingual short guide that separates path A (CLI cooperative) from path B (typed Turn adapter via the existing fake-host walkthrough).
- Link the example from README, guides index, mkdocs nav, and the custom runner guide so the agent-loop-agnostic contract is discoverable.

## Issue Or Task

- Closes #2835
- Contributor task ID: docs/integration (custom runtime minimal example)

## Validation

- [x] `python examples/custom-runtime-minimal-cli-turn-smoke.py`
- [x] `python examples/loopx-turn-fake-host-walkthrough-smoke.py`
- [x] `python -m py_compile examples/custom-runtime-minimal-cli-turn-smoke.py`
- [x] `python -m ruff check examples/custom-runtime-minimal-cli-turn-smoke.py`
- [x] `loopx check --scan-path examples/custom-runtime-minimal-cli-turn-smoke.py --scan-path docs/guides/minimal-custom-runtime-example.md --scan-path docs/guides/minimal-custom-runtime-example.zh-CN.md --scan-path docs/guides/custom-agent-runner-integration.md --scan-path docs/guides/custom-agent-runner-integration.zh-CN.md --scan-path docs/guides/README.md --scan-path README.md --scan-path README.zh-CN.md --scan-path mkdocs.yaml` (public boundary scan clean)

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.

## Design notes

Maintainer guidance on #2835 asked for both:

1. ~50-line mainstream skill + wake + CLI sequence (this PR's smoke/guide)
2. separate typed-adapter example (already shipped as `examples/loopx-turn-fake-host-walkthrough-smoke.py`; this PR only cross-links it)