### PR TITLE
fix(control-plane): preserve semantic history continuity

### DIFF
--- a/docs/reference/protocols/goal-vision-replan-contract-v0.md
+++ b/docs/reference/protocols/goal-vision-replan-contract-v0.md
@@ -222,6 +222,34 @@ obligation. If evidence, successor state, blocker state, or a superseding
 vision packet still shows the vision is unmet, the acceptance gap remains
 authoritative and quota must continue to project replan work.
 
+### Semantic History Continuity
+
+`run_history.goals[].latest_runs` is a strictly bounded recency drill-down. It
+must not grow beyond its requested display limit to preserve older control
+records. Long-lived goal semantics instead use `goal_semantic_history_v0`, a
+per-agent read model whose size grows with participating agents rather than
+heartbeat count.
+
+Each agent lane independently selects the latest active vision (or explicit
+retirement), latest checkpoint, latest outcome-relevant checkpoint, latest
+autonomous-replan ACK, and latest material milestone. The goal also retains the
+latest compact human reward as the owner-correction slot. Repeated quota spend,
+monitor polling, promotion readiness, and ordinary refresh rows do not consume
+these semantic slots.
+
+The outcome-checkpoint slot retains its same-run qualification vision. A newer
+plain refresh may become the latest general checkpoint, but it cannot hide the
+older material checkpoint or borrow a later path delta. Likewise, another
+agent's qualified checkpoint cannot satisfy the selected lane. Goal-frontier
+readers prefer this semantic context and fall back to `latest_runs` only for
+older status payloads that do not carry the new read model.
+
+Agent-scoped status keeps only the selected agent's semantic lane plus the
+compact owner-correction slot on the hot path. Whole-goal, all-agent history
+remains available through unscoped status/history diagnostics. This keeps
+final-outcome continuity authoritative without turning a long heartbeat thread
+into an ever-growing CLI payload.
+
 ## Vision Continuation Audit
 
 Every selected todo is a bounded step toward the active per-agent vision, not a

--- a/examples/control_plane/run-history-agent-context-retention-smoke.py
+++ b/examples/control_plane/run-history-agent-context-retention-smoke.py
@@ -10,10 +10,15 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from loopx.control_plane.goals.goal_frontier import latest_agent_vision_from_status_payload
+from loopx.control_plane.goals.goal_frontier import (
+    latest_agent_vision_from_status_payload,
+)
+from loopx.control_plane.goals.goal_frontier.outcome_continuity import (
+    acceptance_gaps_from_outcome_checkpoint,
+    latest_outcome_vision_checkpoint_from_status_payload,
+)
 from loopx.control_plane.runtime.run_history import build_run_history
 from loopx.history import collect_history
-
 
 GOAL_ID = "agent-context-retention-goal"
 COORDINATION_PEER = "codex-coordination-peer"
@@ -33,6 +38,15 @@ def project_run_history(history: dict, *, display_limit: int = 3) -> dict:
         compact_run=lambda run: dict(run),
         quota_status=lambda goal: {},
         display_limit=display_limit,
+    )
+
+
+def semantic_agent_context(goal: dict, *, agent_id: str) -> dict:
+    semantic_history = goal["semantic_history"]
+    return next(
+        context
+        for context in semantic_history["agents"]
+        if context["agent_id"] == agent_id
     )
 
 
@@ -133,7 +147,9 @@ def write_fixture(root: Path) -> tuple[Path, Path]:
 
 
 def main() -> None:
-    with tempfile.TemporaryDirectory(prefix="loopx-agent-context-retention-") as raw_tmp:
+    with tempfile.TemporaryDirectory(
+        prefix="loopx-agent-context-retention-"
+    ) as raw_tmp:
         registry_path, runtime = write_fixture(Path(raw_tmp))
         runs_dir = runtime / "goals" / GOAL_ID / "runs"
         with (runs_dir / "index.jsonl").open("a", encoding="utf-8") as handle:
@@ -173,33 +189,33 @@ def main() -> None:
             "latest coordination",
             "latest product",
         ], latest_runs
-        assert any(
-            run.get("agent_id") == TARGET_PEER and run.get("agent_vision")
-            for run in latest_runs
-        ), latest_runs
-        assert any(
-            run.get("agent_id") == TARGET_PEER and run.get("autonomous_replan_ack")
-            for run in latest_runs
-        ), latest_runs
-        assert len(latest_runs) == 5, latest_runs
+        assert len(latest_runs) == 3, latest_runs
+        semantic_context = semantic_agent_context(goal, agent_id=TARGET_PEER)
+        assert semantic_context["latest_agent_vision_run"]["agent_vision"]
+        assert semantic_context["latest_autonomous_replan_ack_run"][
+            "autonomous_replan_ack"
+        ]
         projected_run_history = project_run_history(history)
-        projected_runs = projected_run_history["goals"][0]["latest_runs"]
-        assert any(
-            run.get("agent_id") == TARGET_PEER and run.get("agent_vision")
-            for run in projected_runs
-        ), projected_runs
-        assert any(
-            run.get("agent_id") == TARGET_PEER and run.get("autonomous_replan_ack")
-            for run in projected_runs
-        ), projected_runs
-        assert len(projected_runs) == 5, projected_runs
+        projected_goal = projected_run_history["goals"][0]
+        projected_runs = projected_goal["latest_runs"]
+        assert len(projected_runs) == 3, projected_runs
+        projected_context = semantic_agent_context(
+            projected_goal,
+            agent_id=TARGET_PEER,
+        )
+        assert projected_context["latest_agent_vision_run"]["agent_vision"]
+        assert projected_context["latest_autonomous_replan_ack_run"][
+            "autonomous_replan_ack"
+        ]
         vision = latest_agent_vision_from_status_payload(
             {"run_history": projected_run_history},
             goal_id=GOAL_ID,
             agent_id=TARGET_PEER,
         )
         assert vision and vision["agent_id"] == TARGET_PEER, vision
-        assert "global run window" in vision["vision_patch"]["replan_trigger_summary"], vision
+        assert (
+            "global run window" in vision["vision_patch"]["replan_trigger_summary"]
+        ), vision
 
         zero_budget_history = collect_history(
             registry_path=registry_path,
@@ -212,6 +228,10 @@ def main() -> None:
         assert zero_budget_projection["goals"][0]["latest_runs"] == [], (
             zero_budget_projection
         )
+        assert semantic_agent_context(
+            zero_budget_projection["goals"][0],
+            agent_id=TARGET_PEER,
+        )["latest_agent_vision_run"]["agent_vision"]
     with tempfile.TemporaryDirectory(prefix="loopx-agent-context-retired-") as raw_tmp:
         registry_path, runtime = write_fixture(Path(raw_tmp))
         runs_dir = runtime / "goals" / GOAL_ID / "runs"
@@ -254,6 +274,13 @@ def main() -> None:
             run.get("agent_id") == TARGET_PEER and run.get("agent_vision")
             for run in latest_runs
         ), latest_runs
+        assert (
+            semantic_agent_context(
+                history["goals"][0],
+                agent_id=TARGET_PEER,
+            )["vision_retired_at"]
+            == "2026-07-06T00:07:00+00:00"
+        )
         projected_run_history = project_run_history(history)
         projected_runs = projected_run_history["goals"][0]["latest_runs"]
         assert not any(
@@ -266,6 +293,119 @@ def main() -> None:
             agent_id=TARGET_PEER,
         )
         assert vision is None, vision
+    with tempfile.TemporaryDirectory(prefix="loopx-semantic-long-thread-") as raw_tmp:
+        registry_path, runtime = write_fixture(Path(raw_tmp))
+        runs_dir = runtime / "goals" / GOAL_ID / "runs"
+        with (runs_dir / "index.jsonl").open("a", encoding="utf-8") as handle:
+            semantic_runs = [
+                {
+                    "generated_at": "2026-07-08T00:00:00+00:00",
+                    "goal_id": GOAL_ID,
+                    "classification": "state_refreshed",
+                    "agent_id": TARGET_PEER,
+                    "recommended_action": "plain refresh",
+                    "vision_checkpoint": {
+                        "schema_version": "vision_checkpoint_v0",
+                        "agent_id": TARGET_PEER,
+                        "required": False,
+                        "satisfied": True,
+                        "decision": "not_required",
+                        "triggers": [{"kind": "heartbeat_refresh"}],
+                    },
+                },
+                *[
+                    {
+                        "generated_at": f"2026-07-07T00:00:{second:02d}+00:00",
+                        "goal_id": GOAL_ID,
+                        "classification": "quota_slot_spent",
+                        "agent_id": TARGET_PEER,
+                        "recommended_action": "neutral heartbeat accounting",
+                    }
+                    for second in range(30)
+                ],
+                {
+                    "generated_at": "2026-07-06T02:00:00+00:00",
+                    "goal_id": GOAL_ID,
+                    "classification": "human_reward_recorded",
+                    "agent_id": TARGET_PEER,
+                    "human_reward": {
+                        "recorded_at": "2026-07-06T02:00:00+00:00",
+                        "decision": "correct_direction",
+                        "reward": "positive",
+                        "reason_summary": "Keep final-outcome evidence authoritative.",
+                    },
+                },
+                {
+                    "generated_at": "2026-07-06T01:00:00+00:00",
+                    "goal_id": GOAL_ID,
+                    "classification": "milestone_closeout",
+                    "agent_id": TARGET_PEER,
+                    "delivery_outcome": "outcome_progress",
+                    "vision_checkpoint": {
+                        "schema_version": "vision_checkpoint_v0",
+                        "agent_id": TARGET_PEER,
+                        "required": True,
+                        "satisfied": True,
+                        "decision": "unchanged_with_reason",
+                        "triggers": [
+                            {
+                                "kind": "material_delivery_outcome",
+                                "delivery_outcome": "outcome_progress",
+                            }
+                        ],
+                    },
+                },
+            ]
+            for semantic_run in semantic_runs:
+                handle.write(json.dumps(semantic_run, ensure_ascii=False) + "\n")
+
+        history = collect_history(
+            registry_path=registry_path,
+            runtime_root=runtime,
+            goal_id=GOAL_ID,
+            limit=30,
+        )
+        projected_run_history = project_run_history(history, display_limit=30)
+        projected_goal = projected_run_history["goals"][0]
+        assert len(projected_goal["latest_runs"]) == 30, projected_goal
+        context = semantic_agent_context(projected_goal, agent_id=TARGET_PEER)
+        assert (
+            context["latest_vision_checkpoint_run"]["vision_checkpoint"]["decision"]
+            == "not_required"
+        )
+        assert (
+            context["latest_outcome_vision_checkpoint_run"]["vision_checkpoint"][
+                "triggers"
+            ][0]["delivery_outcome"]
+            == "outcome_progress"
+        )
+        assert context["latest_material_milestone_run"]["delivery_outcome"] == (
+            "outcome_progress"
+        )
+        assert (
+            projected_goal["semantic_history"]["latest_owner_correction_run"][
+                "human_reward"
+            ]["decision"]
+            == "correct_direction"
+        )
+        assert "quota_slot_spent" not in json.dumps(
+            projected_goal["semantic_history"],
+            ensure_ascii=False,
+        )
+        status = {"run_history": projected_run_history}
+        vision = latest_agent_vision_from_status_payload(
+            status,
+            goal_id=GOAL_ID,
+            agent_id=TARGET_PEER,
+        )
+        checkpoint = latest_outcome_vision_checkpoint_from_status_payload(
+            status,
+            goal_id=GOAL_ID,
+            agent_id=TARGET_PEER,
+        )
+        gaps = acceptance_gaps_from_outcome_checkpoint(vision, checkpoint)
+        assert len(gaps) == 1, gaps
+        assert gaps[0]["kind"] == "vision_outcome_checkpoint_required", gaps
     print("run-history-agent-context-retention-smoke ok")
 
 

--- a/loopx/control_plane/goals/goal_frontier/__init__.py
+++ b/loopx/control_plane/goals/goal_frontier/__init__.py
@@ -33,6 +33,8 @@ from .replan_rules import (
 )
 from .semantic_history import (
     latest_agent_vision_from_runs as latest_agent_vision_from_runs,
+)
+from .semantic_history import (
     latest_agent_vision_from_status_payload,
     latest_autonomous_replan_ack_from_status_payload,
     latest_missing_vision_checkpoint_from_status_payload,

--- a/loopx/control_plane/goals/goal_frontier/__init__.py
+++ b/loopx/control_plane/goals/goal_frontier/__init__.py
@@ -13,7 +13,6 @@ from ...agents.runtime_model import peer_work_key, select_peer_for_work
 from ...work_items.autonomous_replan_ack import (
     autonomous_replan_ack_matches_agent,
     autonomous_replan_ack_matches_frontier,
-    latest_autonomous_replan_ack_for_projection,
 )
 from ...work_items.autonomous_replan_obligation import (
     AUTONOMOUS_REPLAN_STALL_THRESHOLD,
@@ -31,6 +30,12 @@ from .replan_rules import (
     GoalFrontierReplanFacts,
     GoalFrontierReplanRule,
     select_goal_frontier_replan_rule,
+)
+from .semantic_history import (
+    latest_agent_vision_from_runs as latest_agent_vision_from_runs,
+    latest_agent_vision_from_status_payload,
+    latest_autonomous_replan_ack_from_status_payload,
+    latest_missing_vision_checkpoint_from_status_payload,
 )
 from .terminal import (
     GOAL_TERMINAL_SOURCE_COMPLETENESS_SCHEMA_VERSION,  # noqa: F401
@@ -62,11 +67,6 @@ TODO_TASK_CLASS_ADVANCEMENT = "advancement_task"
 TODO_TASK_CLASS_MONITOR = "continuous_monitor"
 LONG_TODO_CHAIN_ADVANCEMENT_THRESHOLD = 15
 LONG_TODO_CHAIN_OPEN_THRESHOLD = 20
-VISION_CHECKPOINT_SATISFIED_DECISIONS = {
-    "patched",
-    "retired_or_superseded",
-    "unchanged_with_reason",
-}
 
 
 def safe_non_negative_int(value: Any) -> int:
@@ -414,187 +414,6 @@ def _compact_projection_text(value: Any, *, limit: int = 360) -> str | None:
     if not text:
         return None
     return text[:limit]
-
-
-def _latest_runs_for_goal(
-    status_payload: dict[str, Any],
-    *,
-    goal_id: str,
-) -> list[dict[str, Any]]:
-    run_history = (
-        status_payload.get("run_history")
-        if isinstance(status_payload.get("run_history"), dict)
-        else {}
-    )
-    goals = run_history.get("goals") if isinstance(run_history.get("goals"), list) else []
-    goal = next(
-        (
-            item
-            for item in goals
-            if isinstance(item, dict) and str(item.get("id") or "") == goal_id
-        ),
-        None,
-    )
-    latest_runs = goal.get("latest_runs") if isinstance(goal, dict) else None
-    return [item for item in latest_runs if isinstance(item, dict)] if isinstance(latest_runs, list) else []
-
-
-def _run_agent_id_matches(run: dict[str, Any], *, agent_id: str | None) -> bool:
-    if not agent_id:
-        return True
-    run_agent_id = str(run.get("agent_id") or "").strip()
-    return not run_agent_id or run_agent_id == agent_id
-
-
-def _run_retires_prior_agent_vision(
-    run: dict[str, Any],
-    *,
-    agent_id: str | None,
-) -> bool:
-    if not _run_agent_id_matches(run, agent_id=agent_id):
-        return False
-    checkpoint = (
-        run.get("vision_checkpoint")
-        if isinstance(run.get("vision_checkpoint"), dict)
-        else {}
-    )
-    if isinstance(checkpoint, dict) and checkpoint:
-        checkpoint_agent_id = str(
-            checkpoint.get("agent_id") or run.get("agent_id") or ""
-        ).strip()
-        if agent_id and checkpoint_agent_id and checkpoint_agent_id != agent_id:
-            return False
-        if (
-            checkpoint.get("satisfied") is True
-            and str(checkpoint.get("decision") or "").strip() == "retired_or_superseded"
-        ):
-            return True
-    return False
-
-
-def latest_agent_vision_from_status_payload(
-    status_payload: dict[str, Any],
-    *,
-    goal_id: str,
-    agent_id: str | None,
-) -> dict[str, Any] | None:
-    """Return the newest compact agent vision packet visible in run history."""
-
-    return latest_agent_vision_from_runs(
-        _latest_runs_for_goal(status_payload, goal_id=goal_id),
-        goal_id=goal_id,
-        agent_id=agent_id,
-    )
-
-
-def latest_agent_vision_from_runs(
-    runs: list[dict[str, Any]],
-    *,
-    goal_id: str,
-    agent_id: str | None,
-) -> dict[str, Any] | None:
-    """Return the newest active vision from newest-first compact run records."""
-
-    for run in runs:
-        vision = run.get("agent_vision")
-        if not isinstance(vision, dict):
-            if _run_retires_prior_agent_vision(run, agent_id=agent_id):
-                return None
-            continue
-        vision_agent_id = str(vision.get("agent_id") or run.get("agent_id") or "").strip()
-        if agent_id and vision_agent_id and vision_agent_id != agent_id:
-            continue
-        patch = vision.get("vision_patch") if isinstance(vision.get("vision_patch"), dict) else {}
-        if not patch:
-            continue
-        result = {
-            "schema_version": vision.get("schema_version"),
-            "goal_id": goal_id,
-            "agent_id": vision_agent_id or agent_id,
-            "state": vision.get("state"),
-            "vision_patch": patch,
-            "todo_delta": vision.get("todo_delta")
-            if isinstance(vision.get("todo_delta"), list)
-            else [],
-            "vision_budget": vision.get("vision_budget")
-            if isinstance(vision.get("vision_budget"), dict)
-            else None,
-            "generated_at": run.get("generated_at"),
-        }
-        if isinstance(vision.get("path_delta"), dict):
-            result["path_delta"] = vision["path_delta"]
-        return result
-    return None
-
-
-def latest_missing_vision_checkpoint_from_status_payload(
-    status_payload: dict[str, Any],
-    *,
-    goal_id: str,
-    agent_id: str | None,
-) -> dict[str, Any] | None:
-    """Return the newest unsatisfied per-agent vision checkpoint in run history."""
-
-    for run in _latest_runs_for_goal(status_payload, goal_id=goal_id):
-        checkpoint = run.get("vision_checkpoint")
-        if not isinstance(checkpoint, dict):
-            continue
-        checkpoint_agent_id = str(
-            checkpoint.get("agent_id") or run.get("agent_id") or ""
-        ).strip()
-        if agent_id and checkpoint_agent_id != agent_id:
-            continue
-        if not agent_id and checkpoint_agent_id:
-            continue
-        decision = str(checkpoint.get("decision") or "").strip()
-        if (
-            checkpoint.get("satisfied") is True
-            and decision in VISION_CHECKPOINT_SATISFIED_DECISIONS
-        ):
-            return None
-        if checkpoint.get("required") is not True:
-            continue
-        if checkpoint.get("satisfied") is not False:
-            continue
-        if decision != "missing_required":
-            continue
-        return {
-            "schema_version": checkpoint.get("schema_version"),
-            "goal_id": goal_id,
-            "agent_id": checkpoint_agent_id or agent_id,
-            "decision": checkpoint.get("decision"),
-            "triggers": checkpoint.get("triggers")
-            if isinstance(checkpoint.get("triggers"), list)
-            else [],
-            "required_resolution": checkpoint.get("required_resolution")
-            if isinstance(checkpoint.get("required_resolution"), list)
-            else [],
-            "missing_baseline": checkpoint.get("missing_baseline") is True,
-            "generated_at": run.get("generated_at"),
-        }
-    return None
-
-
-def latest_autonomous_replan_ack_from_status_payload(
-    status_payload: dict[str, Any],
-    *,
-    goal_id: str,
-    agent_id: str | None,
-    neutral_classifications: set[str],
-) -> dict[str, Any] | None:
-    """Return the newest agent-scoped durable replan ACK visible in run history."""
-
-    if not agent_id:
-        return None
-    latest_runs = [
-        run
-        for run in _latest_runs_for_goal(status_payload, goal_id=goal_id)
-        if _run_agent_id_matches(run, agent_id=agent_id)
-    ]
-    return latest_autonomous_replan_ack_for_projection(
-        latest_runs,
-        neutral_classifications=neutral_classifications,
-    )
 
 
 def projected_autonomous_replan_ack_for_agent(

--- a/loopx/control_plane/goals/goal_frontier/outcome_continuity.py
+++ b/loopx/control_plane/goals/goal_frontier/outcome_continuity.py
@@ -34,15 +34,15 @@ def _dict_field(value: dict[str, Any], key: str) -> dict[str, Any]:
     return field if isinstance(field, dict) else {}
 
 
-def _latest_runs_for_goal(
+def _run_history_goal(
     status_payload: dict[str, Any],
     *,
     goal_id: str,
-) -> list[dict[str, Any]]:
+) -> dict[str, Any] | None:
     run_history = _dict_field(status_payload, "run_history")
     goals_value = run_history.get("goals")
     goals: list[Any] = goals_value if isinstance(goals_value, list) else []
-    goal = next(
+    return next(
         (
             item
             for item in goals
@@ -50,12 +50,54 @@ def _latest_runs_for_goal(
         ),
         None,
     )
+
+
+def _latest_runs_for_goal(
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+) -> list[dict[str, Any]]:
+    goal = _run_history_goal(status_payload, goal_id=goal_id)
     latest_runs = goal.get("latest_runs") if isinstance(goal, dict) else None
     return (
         [item for item in latest_runs if isinstance(item, dict)]
         if isinstance(latest_runs, list)
         else []
     )
+
+
+def _outcome_checkpoint_runs_for_goal(
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+    agent_id: str | None,
+) -> list[dict[str, Any]]:
+    """Prefer the per-agent semantic slot and fall back to legacy run lists."""
+
+    goal = _run_history_goal(status_payload, goal_id=goal_id)
+    semantic_history = goal.get("semantic_history") if isinstance(goal, dict) else None
+    if agent_id and isinstance(semantic_history, dict):
+        contexts = semantic_history.get("agents")
+        context = (
+            next(
+                (
+                    item
+                    for item in contexts
+                    if isinstance(item, dict)
+                    and str(item.get("agent_id") or "").strip() == agent_id
+                ),
+                None,
+            )
+            if isinstance(contexts, list)
+            else None
+        )
+        checkpoint_run = (
+            context.get("latest_outcome_vision_checkpoint_run")
+            if isinstance(context, dict)
+            else None
+        )
+        return [checkpoint_run] if isinstance(checkpoint_run, dict) else []
+    return _latest_runs_for_goal(status_payload, goal_id=goal_id)
 
 
 def latest_outcome_vision_checkpoint_from_status_payload(
@@ -66,7 +108,11 @@ def latest_outcome_vision_checkpoint_from_status_payload(
 ) -> dict[str, Any] | None:
     """Return the newest outcome-relevant per-agent vision checkpoint."""
 
-    for run in _latest_runs_for_goal(status_payload, goal_id=goal_id):
+    for run in _outcome_checkpoint_runs_for_goal(
+        status_payload,
+        goal_id=goal_id,
+        agent_id=agent_id,
+    ):
         checkpoint = run.get("vision_checkpoint")
         if not isinstance(checkpoint, dict):
             continue

--- a/loopx/control_plane/goals/goal_frontier/semantic_history.py
+++ b/loopx/control_plane/goals/goal_frontier/semantic_history.py
@@ -6,7 +6,6 @@ from ...work_items.autonomous_replan_ack import (
     latest_autonomous_replan_ack_for_projection,
 )
 
-
 VISION_CHECKPOINT_SATISFIED_DECISIONS = {
     "patched",
     "retired_or_superseded",

--- a/loopx/control_plane/goals/goal_frontier/semantic_history.py
+++ b/loopx/control_plane/goals/goal_frontier/semantic_history.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ...work_items.autonomous_replan_ack import (
+    latest_autonomous_replan_ack_for_projection,
+)
+
+
+VISION_CHECKPOINT_SATISFIED_DECISIONS = {
+    "patched",
+    "retired_or_superseded",
+    "unchanged_with_reason",
+}
+
+
+def _run_history_goal(
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+) -> dict[str, Any] | None:
+    run_history = (
+        status_payload.get("run_history")
+        if isinstance(status_payload.get("run_history"), dict)
+        else {}
+    )
+    goals = (
+        run_history.get("goals") if isinstance(run_history.get("goals"), list) else []
+    )
+    return next(
+        (
+            item
+            for item in goals
+            if isinstance(item, dict) and str(item.get("id") or "") == goal_id
+        ),
+        None,
+    )
+
+
+def _latest_runs_for_goal(
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+) -> list[dict[str, Any]]:
+    goal = _run_history_goal(status_payload, goal_id=goal_id)
+    latest_runs = goal.get("latest_runs") if isinstance(goal, dict) else None
+    return (
+        [item for item in latest_runs if isinstance(item, dict)]
+        if isinstance(latest_runs, list)
+        else []
+    )
+
+
+def _semantic_agent_context_for_goal(
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+    agent_id: str | None,
+) -> tuple[bool, dict[str, Any] | None]:
+    """Return whether semantic history is authoritative and its agent lane."""
+
+    if not agent_id:
+        return False, None
+    goal = _run_history_goal(status_payload, goal_id=goal_id)
+    semantic_history = goal.get("semantic_history") if isinstance(goal, dict) else None
+    if not isinstance(semantic_history, dict):
+        return False, None
+    contexts = semantic_history.get("agents")
+    if not isinstance(contexts, list):
+        return True, None
+    return True, next(
+        (
+            context
+            for context in contexts
+            if isinstance(context, dict)
+            and str(context.get("agent_id") or "").strip() == agent_id
+        ),
+        None,
+    )
+
+
+def _run_agent_id_matches(run: dict[str, Any], *, agent_id: str | None) -> bool:
+    if not agent_id:
+        return True
+    run_agent_id = str(run.get("agent_id") or "").strip()
+    return not run_agent_id or run_agent_id == agent_id
+
+
+def _run_retires_prior_agent_vision(
+    run: dict[str, Any],
+    *,
+    agent_id: str | None,
+) -> bool:
+    if not _run_agent_id_matches(run, agent_id=agent_id):
+        return False
+    checkpoint = (
+        run.get("vision_checkpoint")
+        if isinstance(run.get("vision_checkpoint"), dict)
+        else {}
+    )
+    checkpoint_agent_id = str(
+        checkpoint.get("agent_id") or run.get("agent_id") or ""
+    ).strip()
+    if agent_id and checkpoint_agent_id and checkpoint_agent_id != agent_id:
+        return False
+    return bool(
+        checkpoint.get("satisfied") is True
+        and str(checkpoint.get("decision") or "").strip() == "retired_or_superseded"
+    )
+
+
+def latest_agent_vision_from_status_payload(
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+    agent_id: str | None,
+) -> dict[str, Any] | None:
+    """Return the newest compact agent vision packet visible in run history."""
+
+    semantic_history_present, context = _semantic_agent_context_for_goal(
+        status_payload,
+        goal_id=goal_id,
+        agent_id=agent_id,
+    )
+    if semantic_history_present:
+        if not isinstance(context, dict) or context.get("vision_retired_at"):
+            return None
+        vision_run = context.get("latest_agent_vision_run")
+        return (
+            latest_agent_vision_from_runs(
+                [vision_run],
+                goal_id=goal_id,
+                agent_id=agent_id,
+            )
+            if isinstance(vision_run, dict)
+            else None
+        )
+    return latest_agent_vision_from_runs(
+        _latest_runs_for_goal(status_payload, goal_id=goal_id),
+        goal_id=goal_id,
+        agent_id=agent_id,
+    )
+
+
+def latest_agent_vision_from_runs(
+    runs: list[dict[str, Any]],
+    *,
+    goal_id: str,
+    agent_id: str | None,
+) -> dict[str, Any] | None:
+    """Return the newest active vision from newest-first compact run records."""
+
+    for run in runs:
+        vision = run.get("agent_vision")
+        if not isinstance(vision, dict):
+            if _run_retires_prior_agent_vision(run, agent_id=agent_id):
+                return None
+            continue
+        vision_agent_id = str(
+            vision.get("agent_id") or run.get("agent_id") or ""
+        ).strip()
+        if agent_id and vision_agent_id and vision_agent_id != agent_id:
+            continue
+        patch = (
+            vision.get("vision_patch")
+            if isinstance(vision.get("vision_patch"), dict)
+            else {}
+        )
+        if not patch:
+            continue
+        result = {
+            "schema_version": vision.get("schema_version"),
+            "goal_id": goal_id,
+            "agent_id": vision_agent_id or agent_id,
+            "state": vision.get("state"),
+            "vision_patch": patch,
+            "todo_delta": vision.get("todo_delta")
+            if isinstance(vision.get("todo_delta"), list)
+            else [],
+            "vision_budget": vision.get("vision_budget")
+            if isinstance(vision.get("vision_budget"), dict)
+            else None,
+            "generated_at": run.get("generated_at"),
+        }
+        if isinstance(vision.get("path_delta"), dict):
+            result["path_delta"] = vision["path_delta"]
+        return result
+    return None
+
+
+def _latest_missing_vision_checkpoint_from_runs(
+    runs: list[dict[str, Any]],
+    *,
+    goal_id: str,
+    agent_id: str | None,
+) -> dict[str, Any] | None:
+    for run in runs:
+        checkpoint = run.get("vision_checkpoint")
+        if not isinstance(checkpoint, dict):
+            continue
+        checkpoint_agent_id = str(
+            checkpoint.get("agent_id") or run.get("agent_id") or ""
+        ).strip()
+        if agent_id and checkpoint_agent_id != agent_id:
+            continue
+        if not agent_id and checkpoint_agent_id:
+            continue
+        decision = str(checkpoint.get("decision") or "").strip()
+        if (
+            checkpoint.get("satisfied") is True
+            and decision in VISION_CHECKPOINT_SATISFIED_DECISIONS
+        ):
+            return None
+        if checkpoint.get("required") is not True:
+            continue
+        if checkpoint.get("satisfied") is not False:
+            continue
+        if decision != "missing_required":
+            continue
+        return {
+            "schema_version": checkpoint.get("schema_version"),
+            "goal_id": goal_id,
+            "agent_id": checkpoint_agent_id or agent_id,
+            "decision": checkpoint.get("decision"),
+            "triggers": checkpoint.get("triggers")
+            if isinstance(checkpoint.get("triggers"), list)
+            else [],
+            "required_resolution": checkpoint.get("required_resolution")
+            if isinstance(checkpoint.get("required_resolution"), list)
+            else [],
+            "missing_baseline": checkpoint.get("missing_baseline") is True,
+            "generated_at": run.get("generated_at"),
+        }
+    return None
+
+
+def latest_missing_vision_checkpoint_from_status_payload(
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+    agent_id: str | None,
+) -> dict[str, Any] | None:
+    """Return the newest unsatisfied per-agent vision checkpoint in run history."""
+
+    semantic_history_present, context = _semantic_agent_context_for_goal(
+        status_payload,
+        goal_id=goal_id,
+        agent_id=agent_id,
+    )
+    if semantic_history_present:
+        checkpoint_run = (
+            context.get("latest_vision_checkpoint_run")
+            if isinstance(context, dict)
+            else None
+        )
+        return _latest_missing_vision_checkpoint_from_runs(
+            [checkpoint_run] if isinstance(checkpoint_run, dict) else [],
+            goal_id=goal_id,
+            agent_id=agent_id,
+        )
+    return _latest_missing_vision_checkpoint_from_runs(
+        _latest_runs_for_goal(status_payload, goal_id=goal_id),
+        goal_id=goal_id,
+        agent_id=agent_id,
+    )
+
+
+def latest_autonomous_replan_ack_from_status_payload(
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+    agent_id: str | None,
+    neutral_classifications: set[str],
+) -> dict[str, Any] | None:
+    """Return the newest agent-scoped durable replan ACK visible in run history."""
+
+    if not agent_id:
+        return None
+    semantic_history_present, context = _semantic_agent_context_for_goal(
+        status_payload,
+        goal_id=goal_id,
+        agent_id=agent_id,
+    )
+    if semantic_history_present:
+        ack_run = (
+            context.get("latest_autonomous_replan_ack_run")
+            if isinstance(context, dict)
+            else None
+        )
+        latest_runs = [ack_run] if isinstance(ack_run, dict) else []
+    else:
+        latest_runs = [
+            run
+            for run in _latest_runs_for_goal(status_payload, goal_id=goal_id)
+            if _run_agent_id_matches(run, agent_id=agent_id)
+        ]
+    return latest_autonomous_replan_ack_for_projection(
+        latest_runs,
+        neutral_classifications=neutral_classifications,
+    )

--- a/loopx/control_plane/runtime/run_context_retention.py
+++ b/loopx/control_plane/runtime/run_context_retention.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Callable
-
+from collections.abc import Callable
+from typing import Any
 
 GOAL_SEMANTIC_HISTORY_SCHEMA_VERSION = "goal_semantic_history_v0"
 SEMANTIC_CONTEXT_RUN_FIELDS = (

--- a/loopx/control_plane/runtime/run_context_retention.py
+++ b/loopx/control_plane/runtime/run_context_retention.py
@@ -1,13 +1,218 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable
 
 
-PER_AGENT_CONTEXT_RUN_FIELDS = (
-    "agent_vision",
-    "vision_checkpoint",
-    "autonomous_replan_ack",
+GOAL_SEMANTIC_HISTORY_SCHEMA_VERSION = "goal_semantic_history_v0"
+SEMANTIC_CONTEXT_RUN_FIELDS = (
+    "latest_agent_vision_run",
+    "latest_vision_checkpoint_run",
+    "latest_outcome_vision_checkpoint_run",
+    "latest_autonomous_replan_ack_run",
+    "latest_material_milestone_run",
 )
+SEMANTIC_CONTEXT_RUN_PAYLOAD_FIELDS = {
+    "latest_agent_vision_run": (
+        "generated_at",
+        "agent_id",
+        "agent_vision",
+    ),
+    "latest_vision_checkpoint_run": (
+        "generated_at",
+        "agent_id",
+        "vision_checkpoint",
+    ),
+    "latest_outcome_vision_checkpoint_run": (
+        "generated_at",
+        "agent_id",
+        "agent_vision",
+        "vision_checkpoint",
+    ),
+    "latest_autonomous_replan_ack_run": (
+        "generated_at",
+        "agent_id",
+        "autonomous_replan_ack",
+    ),
+    "latest_material_milestone_run": (
+        "generated_at",
+        "agent_id",
+        "classification",
+        "delivery_outcome",
+    ),
+}
+OWNER_CORRECTION_RUN_PAYLOAD_FIELDS = (
+    "generated_at",
+    "agent_id",
+    "classification",
+    "human_reward",
+)
+MATERIAL_DELIVERY_OUTCOMES = {
+    "outcome_gap",
+    "outcome_progress",
+    "primary_goal_outcome",
+}
+OUTCOME_VISION_CHECKPOINT_TRIGGER_KINDS = {
+    "autonomous_replan_recorded",
+    "material_delivery_outcome",
+}
+
+
+RunCompactor = Callable[[dict[str, Any]], dict[str, Any]]
+
+
+def _agent_id_for_run(run: dict[str, Any]) -> str:
+    checkpoint = (
+        run.get("vision_checkpoint")
+        if isinstance(run.get("vision_checkpoint"), dict)
+        else {}
+    )
+    vision = (
+        run.get("agent_vision") if isinstance(run.get("agent_vision"), dict) else {}
+    )
+    return str(
+        run.get("agent_id")
+        or checkpoint.get("agent_id")
+        or vision.get("agent_id")
+        or ""
+    ).strip()
+
+
+def _run_retires_agent_vision(run: dict[str, Any]) -> bool:
+    checkpoint = run.get("vision_checkpoint")
+    return bool(
+        isinstance(checkpoint, dict)
+        and checkpoint.get("satisfied") is True
+        and str(checkpoint.get("decision") or "").strip() == "retired_or_superseded"
+    )
+
+
+def _run_has_outcome_vision_checkpoint(run: dict[str, Any]) -> bool:
+    checkpoint = run.get("vision_checkpoint")
+    if not isinstance(checkpoint, dict):
+        return False
+    return any(
+        isinstance(trigger, dict)
+        and str(trigger.get("kind") or "").strip()
+        in OUTCOME_VISION_CHECKPOINT_TRIGGER_KINDS
+        for trigger in (checkpoint.get("triggers") or [])
+    )
+
+
+def goal_semantic_history_from_runs(
+    runs: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Select time-bounded control semantics from newest-first run history.
+
+    The result grows with participating agents, not heartbeat count. Recent
+    drill-down rows remain a separate strictly bounded list.
+    """
+
+    contexts: dict[str, dict[str, Any]] = {}
+    resolved_agent_vision: set[str] = set()
+    latest_owner_correction_run: dict[str, Any] | None = None
+
+    for run in runs:
+        if latest_owner_correction_run is None and isinstance(
+            run.get("human_reward"), dict
+        ):
+            latest_owner_correction_run = run
+
+        agent_id = _agent_id_for_run(run)
+        if not agent_id:
+            continue
+        context = contexts.setdefault(agent_id, {"agent_id": agent_id})
+
+        checkpoint = run.get("vision_checkpoint")
+        if "latest_vision_checkpoint_run" not in context and isinstance(
+            checkpoint, dict
+        ):
+            context["latest_vision_checkpoint_run"] = run
+
+        if agent_id not in resolved_agent_vision:
+            if _run_retires_agent_vision(run):
+                context["vision_retired_at"] = run.get("generated_at")
+                resolved_agent_vision.add(agent_id)
+            elif isinstance(run.get("agent_vision"), dict):
+                context["latest_agent_vision_run"] = run
+                resolved_agent_vision.add(agent_id)
+
+        if (
+            "latest_outcome_vision_checkpoint_run" not in context
+            and _run_has_outcome_vision_checkpoint(run)
+        ):
+            context["latest_outcome_vision_checkpoint_run"] = run
+
+        if "latest_autonomous_replan_ack_run" not in context and isinstance(
+            run.get("autonomous_replan_ack"), dict
+        ):
+            context["latest_autonomous_replan_ack_run"] = run
+
+        if (
+            "latest_material_milestone_run" not in context
+            and str(run.get("delivery_outcome") or "").strip()
+            in MATERIAL_DELIVERY_OUTCOMES
+        ):
+            context["latest_material_milestone_run"] = run
+
+    semantic_history: dict[str, Any] = {
+        "schema_version": GOAL_SEMANTIC_HISTORY_SCHEMA_VERSION,
+        "agents": [
+            context
+            for context in contexts.values()
+            if any(field in context for field in SEMANTIC_CONTEXT_RUN_FIELDS)
+            or "vision_retired_at" in context
+        ],
+    }
+    if latest_owner_correction_run is not None:
+        semantic_history["latest_owner_correction_run"] = latest_owner_correction_run
+    return semantic_history
+
+
+def compact_goal_semantic_history(
+    value: Any,
+    *,
+    compact_run: RunCompactor,
+) -> dict[str, Any] | None:
+    """Compact selected semantic runs through the canonical run compactor."""
+
+    if not isinstance(value, dict):
+        return None
+    agents: list[dict[str, Any]] = []
+    for raw_context in value.get("agents") or []:
+        if not isinstance(raw_context, dict):
+            continue
+        agent_id = str(raw_context.get("agent_id") or "").strip()
+        if not agent_id:
+            continue
+        context: dict[str, Any] = {"agent_id": agent_id}
+        retired_at = str(raw_context.get("vision_retired_at") or "").strip()
+        if retired_at:
+            context["vision_retired_at"] = retired_at
+        for field in SEMANTIC_CONTEXT_RUN_FIELDS:
+            run = raw_context.get(field)
+            if isinstance(run, dict):
+                compacted_run = compact_run(run)
+                context[field] = {
+                    key: compacted_run[key]
+                    for key in SEMANTIC_CONTEXT_RUN_PAYLOAD_FIELDS[field]
+                    if key in compacted_run
+                }
+        if len(context) > 1:
+            agents.append(context)
+
+    compact: dict[str, Any] = {
+        "schema_version": GOAL_SEMANTIC_HISTORY_SCHEMA_VERSION,
+        "agents": agents,
+    }
+    owner_correction_run = value.get("latest_owner_correction_run")
+    if isinstance(owner_correction_run, dict):
+        compacted_run = compact_run(owner_correction_run)
+        compact["latest_owner_correction_run"] = {
+            key: compacted_run[key]
+            for key in OWNER_CORRECTION_RUN_PAYLOAD_FIELDS
+            if key in compacted_run
+        }
+    return compact if agents or "latest_owner_correction_run" in compact else None
 
 
 def latest_runs_with_agent_context(
@@ -15,46 +220,11 @@ def latest_runs_with_agent_context(
     *,
     limit: int,
 ) -> list[dict[str, Any]]:
-    """Keep recent runs plus each agent's newest durable context per field."""
+    """Return a strict recent-run drill-down window.
+
+    Durable control semantics live in ``goal_semantic_history_v0`` instead of
+    expanding this display list beyond its advertised limit.
+    """
 
     bounded = max(0, limit)
-    if bounded == 0:
-        return []
-    selected = list(runs[:bounded])
-    selected_ids = {id(run) for run in selected}
-    retained_context_fields: set[tuple[str, str]] = set()
-    retired_agent_visions: set[str] = set()
-
-    for run in runs:
-        agent_id = str(run.get("agent_id") or "").strip()
-        if not agent_id:
-            continue
-        fields_to_retain: list[str] = []
-        checkpoint = (
-            run.get("vision_checkpoint")
-            if isinstance(run.get("vision_checkpoint"), dict)
-            else {}
-        )
-        if (
-            checkpoint.get("satisfied") is True
-            and str(checkpoint.get("decision") or "").strip()
-            == "retired_or_superseded"
-        ):
-            retired_agent_visions.add(agent_id)
-            retained_context_fields.add((agent_id, "agent_vision"))
-
-        for field in PER_AGENT_CONTEXT_RUN_FIELDS:
-            context_key = (agent_id, field)
-            if context_key in retained_context_fields:
-                continue
-            if not isinstance(run.get(field), dict):
-                continue
-            if field == "agent_vision" and agent_id in retired_agent_visions:
-                continue
-            retained_context_fields.add(context_key)
-            fields_to_retain.append(field)
-
-        if fields_to_retain and id(run) not in selected_ids:
-            selected.append(run)
-            selected_ids.add(id(run))
-    return selected
+    return list(runs[:bounded])

--- a/loopx/control_plane/runtime/run_history.py
+++ b/loopx/control_plane/runtime/run_history.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from typing import Any, Callable, Optional
 
 from ...boundary_authority import checkpointed_boundary_authority_summary
-from .run_context_retention import latest_runs_with_agent_context
+from .run_context_retention import (
+    compact_goal_semantic_history,
+    latest_runs_with_agent_context,
+)
 
 
 LatestRun = Callable[[dict[str, Any]], Optional[dict[str, Any]]]
@@ -79,6 +82,10 @@ def build_run_history(
                 latest_runs,
                 limit=display_limit,
             )
+        semantic_history = compact_goal_semantic_history(
+            goal.get("semantic_history"),
+            compact_run=compact_run,
+        )
         goals.append(
             {
                 "id": goal.get("id"),
@@ -104,6 +111,7 @@ def build_run_history(
                 "subagent_activity": subagent_activity,
                 "latest_status_run": compact_run(current_run) if current_run else None,
                 "latest_runs": latest_runs,
+                "semantic_history": semantic_history,
             }
         )
 

--- a/loopx/control_plane/status/agent_lane_projection.py
+++ b/loopx/control_plane/status/agent_lane_projection.py
@@ -69,6 +69,44 @@ def _compact_run(value: Any) -> dict[str, Any] | None:
     return compact or None
 
 
+def _agent_semantic_goal(value: Any, *, agent_id: str) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    semantic_history = value.get("semantic_history")
+    if not isinstance(semantic_history, dict):
+        return None
+    contexts = semantic_history.get("agents")
+    current_context = (
+        next(
+            (
+                context
+                for context in contexts
+                if isinstance(context, dict)
+                and str(context.get("agent_id") or "").strip() == agent_id
+            ),
+            None,
+        )
+        if isinstance(contexts, list)
+        else None
+    )
+    owner_correction = semantic_history.get("latest_owner_correction_run")
+    if not isinstance(current_context, dict) and not isinstance(
+        owner_correction,
+        dict,
+    ):
+        return None
+    compact_history: dict[str, Any] = {
+        "schema_version": semantic_history.get("schema_version"),
+        "agents": [current_context] if isinstance(current_context, dict) else [],
+    }
+    if isinstance(owner_correction, dict):
+        compact_history["latest_owner_correction_run"] = owner_correction
+    return {
+        "id": value.get("id"),
+        "semantic_history": compact_history,
+    }
+
+
 def _compact_run_history(payload: dict[str, object], *, agent_id: str) -> bool:
     history = payload.get("run_history")
     if not isinstance(history, dict):
@@ -80,6 +118,15 @@ def _compact_run_history(payload: dict[str, object], *, agent_id: str) -> bool:
         for run in visible_runs
         if isinstance(run, dict) and str(run.get("agent_id") or "").strip() == agent_id
     ]
+    goals = history.get("goals")
+    semantic_goals = [
+        compact_goal
+        for compact_goal in (
+            _agent_semantic_goal(goal, agent_id=agent_id)
+            for goal in (goals if isinstance(goals, list) else [])
+        )
+        if compact_goal
+    ]
     compact = {
         key: history[key]
         for key in ("available", "run_count", "goal_count")
@@ -88,6 +135,8 @@ def _compact_run_history(payload: dict[str, object], *, agent_id: str) -> bool:
     latest_agent_run = _compact_run(agent_runs[0]) if agent_runs else None
     if latest_agent_run:
         compact["latest_agent_run"] = latest_agent_run
+    if semantic_goals:
+        compact["goals"] = semantic_goals
     compact["payload_compaction"] = {
         "schema_version": AGENT_LANE_STATUS_HISTORY_COMPACTION_SCHEMA_VERSION,
         "agent_id": agent_id,
@@ -96,6 +145,7 @@ def _compact_run_history(payload: dict[str, object], *, agent_id: str) -> bool:
             0,
             len(visible_runs) - int(latest_agent_run is not None),
         ),
+        "visible_semantic_goal_count": len(semantic_goals),
         "full_detail_cold_path": "status without --agent-id or history",
     }
     payload["run_history"] = compact

--- a/loopx/history.py
+++ b/loopx/history.py
@@ -7,6 +7,7 @@ from typing import Any, Callable
 from .authority import goal_authority_registry_summary
 from .control_plane import compact_control_plane_policy
 from .control_plane.runtime.run_context_retention import (
+    goal_semantic_history_from_runs,
     latest_runs_with_agent_context,
 )
 from .control_plane.runtime.run_index_duplicates import (
@@ -763,6 +764,7 @@ def collect_history(
             "unique_runs": len(runs),
             "latest_status_run": latest_status_run(runs),
             "latest_runs": latest_runs_with_agent_context(runs, limit=limit),
+            "semantic_history": goal_semantic_history_from_runs(runs),
         }
         if registry_member:
             for field in REGISTRY_ATTENTION_FIELDS:

--- a/loopx/history.py
+++ b/loopx/history.py
@@ -6,10 +6,7 @@ from typing import Any, Callable
 
 from .authority import goal_authority_registry_summary
 from .control_plane import compact_control_plane_policy
-from .control_plane.runtime.run_context_retention import (
-    goal_semantic_history_from_runs,
-    latest_runs_with_agent_context,
-)
+from .control_plane.runtime.run_context_retention import goal_semantic_history_from_runs, latest_runs_with_agent_context
 from .control_plane.runtime.run_index_duplicates import (
     classify_index_duplicate_records,
     duplicate_repair_decision,

--- a/tests/control_plane/test_run_context_retention.py
+++ b/tests/control_plane/test_run_context_retention.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from loopx.control_plane.runtime.run_context_retention import (
+    GOAL_SEMANTIC_HISTORY_SCHEMA_VERSION,
+    compact_goal_semantic_history,
+    goal_semantic_history_from_runs,
+    latest_runs_with_agent_context,
+)
+from loopx.control_plane.status.agent_lane_projection import (
+    compact_agent_lane_status_payload_for_display,
+)
+
+AGENT_ID = "quality-agent"
+OTHER_AGENT_ID = "other-agent"
+
+
+def _run(
+    generated_at: str,
+    *,
+    agent_id: str = AGENT_ID,
+    classification: str = "state_refreshed",
+    **fields: object,
+) -> dict[str, object]:
+    return {
+        "generated_at": generated_at,
+        "goal_id": "semantic-goal",
+        "agent_id": agent_id,
+        "classification": classification,
+        **fields,
+    }
+
+
+def _checkpoint(
+    *,
+    decision: str,
+    delivery_outcome: str | None = None,
+) -> dict[str, object]:
+    triggers = []
+    if delivery_outcome:
+        triggers.append(
+            {
+                "kind": "material_delivery_outcome",
+                "delivery_outcome": delivery_outcome,
+            }
+        )
+    return {
+        "schema_version": "vision_checkpoint_v0",
+        "agent_id": AGENT_ID,
+        "required": True,
+        "satisfied": True,
+        "decision": decision,
+        "triggers": triggers,
+    }
+
+
+def _agent_context(history: dict[str, object], agent_id: str) -> dict[str, object]:
+    return next(
+        context
+        for context in history["agents"]  # type: ignore[index]
+        if context["agent_id"] == agent_id
+    )
+
+
+def test_semantic_history_uses_independent_agent_slots() -> None:
+    runs = [
+        _run(
+            "2026-08-09T00:05:00Z",
+            vision_checkpoint=_checkpoint(decision="not_required"),
+        ),
+        _run(
+            "2026-08-09T00:04:00Z",
+            classification="quota_slot_spent",
+        ),
+        _run(
+            "2026-08-09T00:03:00Z",
+            classification="human_reward_recorded",
+            human_reward={"decision": "correct_direction"},
+        ),
+        _run(
+            "2026-08-09T00:02:00Z",
+            classification="milestone_closeout",
+            delivery_outcome="outcome_progress",
+            vision_checkpoint=_checkpoint(
+                decision="unchanged_with_reason",
+                delivery_outcome="outcome_progress",
+            ),
+        ),
+        _run(
+            "2026-08-09T00:01:00Z",
+            agent_vision={
+                "agent_id": AGENT_ID,
+                "state": "vision_replanned",
+                "vision_patch": {"acceptance_summary": "Prove the outcome."},
+            },
+            autonomous_replan_ack={"recorded": True},
+        ),
+        _run(
+            "2026-08-09T00:00:00Z",
+            agent_id=OTHER_AGENT_ID,
+            agent_vision={
+                "agent_id": OTHER_AGENT_ID,
+                "state": "vision_replanned",
+                "vision_patch": {"acceptance_summary": "Other lane."},
+            },
+        ),
+    ]
+
+    semantic_history = goal_semantic_history_from_runs(runs)
+    context = _agent_context(semantic_history, AGENT_ID)
+
+    assert semantic_history["schema_version"] == GOAL_SEMANTIC_HISTORY_SCHEMA_VERSION
+    assert context["latest_vision_checkpoint_run"] is runs[0]
+    assert context["latest_outcome_vision_checkpoint_run"] is runs[3]
+    assert context["latest_material_milestone_run"] is runs[3]
+    assert context["latest_agent_vision_run"] is runs[4]
+    assert context["latest_autonomous_replan_ack_run"] is runs[4]
+    assert semantic_history["latest_owner_correction_run"] is runs[2]
+    assert (
+        _agent_context(semantic_history, OTHER_AGENT_ID)["latest_agent_vision_run"]
+        is runs[5]
+    )
+
+
+def test_retirement_prevents_stale_vision_selection() -> None:
+    runs = [
+        _run(
+            "2026-08-09T00:02:00Z",
+            vision_checkpoint=_checkpoint(decision="retired_or_superseded"),
+        ),
+        _run(
+            "2026-08-09T00:01:00Z",
+            agent_vision={
+                "agent_id": AGENT_ID,
+                "state": "vision_replanned",
+                "vision_patch": {"acceptance_summary": "Stale vision."},
+            },
+        ),
+    ]
+
+    context = _agent_context(goal_semantic_history_from_runs(runs), AGENT_ID)
+
+    assert context["vision_retired_at"] == "2026-08-09T00:02:00Z"
+    assert "latest_agent_vision_run" not in context
+
+
+def test_recent_runs_are_strictly_bounded() -> None:
+    runs = [
+        _run(
+            f"2026-08-09T00:00:{second:02d}Z",
+            classification="quota_slot_spent",
+        )
+        for second in range(40)
+    ]
+
+    assert latest_runs_with_agent_context(runs, limit=30) == runs[:30]
+    assert latest_runs_with_agent_context(runs, limit=0) == []
+
+
+def test_agent_lane_status_keeps_only_selected_semantic_context() -> None:
+    raw_history = goal_semantic_history_from_runs(
+        [
+            _run(
+                "2026-08-09T00:02:00Z",
+                agent_vision={
+                    "agent_id": AGENT_ID,
+                    "state": "vision_replanned",
+                    "vision_patch": {"acceptance_summary": "Current lane."},
+                },
+            ),
+            _run(
+                "2026-08-09T00:01:00Z",
+                agent_id=OTHER_AGENT_ID,
+                agent_vision={
+                    "agent_id": OTHER_AGENT_ID,
+                    "state": "vision_replanned",
+                    "vision_patch": {"acceptance_summary": "Other lane."},
+                },
+            ),
+        ]
+    )
+    semantic_history = compact_goal_semantic_history(
+        raw_history,
+        compact_run=lambda run: deepcopy(run),
+    )
+    payload: dict[str, object] = {
+        "run_history": {
+            "available": True,
+            "goal_count": 1,
+            "run_count": 2,
+            "recent_runs": [],
+            "goals": [
+                {
+                    "id": "semantic-goal",
+                    "semantic_history": semantic_history,
+                }
+            ],
+        }
+    }
+
+    compact_agent_lane_status_payload_for_display(payload, agent_id=AGENT_ID)
+
+    run_history = payload["run_history"]
+    assert isinstance(run_history, dict)
+    goals = run_history["goals"]
+    assert isinstance(goals, list)
+    contexts = goals[0]["semantic_history"]["agents"]
+    assert [context["agent_id"] for context in contexts] == [AGENT_ID]


### PR DESCRIPTION
## Summary

- keep `run_history.goals[].latest_runs` strictly bounded by its advertised display limit
- preserve per-agent vision, checkpoint, outcome checkpoint, replan ACK, material milestone, and owner-correction semantics in a compact `goal_semantic_history_v0` read model
- make goal-frontier readers prefer the semantic lane while retaining compatibility with older payloads
- keep agent-scoped status bounded to the selected agent and add long-thread replay coverage

## Product and architecture judgment

Long-running heartbeat traffic could push an outcome-relevant checkpoint outside the recent display window, allowing neutral progress rows or a newer plain refresh to hide an unresolved final-outcome gap. The change separates recency drill-down from control semantics: the former is strictly bounded, while the latter grows with participating agents rather than heartbeat count. It reuses the canonical run compactor and existing goal-frontier contracts instead of adding a second store or scheduler policy.

The principal compatibility risk is status payload evolution. Readers therefore fall back to legacy `latest_runs` when `goal_semantic_history_v0` is absent, and the agent hot path projects only one semantic lane plus compact owner correction.

## Validation

- `python -m mypy` — passed (15 repository-declared strict targets)
- strict Ruff checks on new semantic-history surfaces and E/F checks across all changed Python — passed
- `PYTHONPATH=$PWD python -m pytest -q tests/control_plane` — 856 passed
- long-thread semantic-history replay smoke — passed
- quota/replan decision-plane smoke — passed
- control-plane maintainability ratchet — passed with zero unreviewed findings
- standard `loopx canary premerge --from-git-diff` — 18/18 passed, 0 warnings, 0 manual holds
- public/private boundary scan — 10 files clean
- exact-diff change-quality receipt — `cqr_cece08842022cf24ae95`

No benchmark jobs, scoring behavior, task semantics, permission boundaries, or public evidence policy are changed.
