### PR TITLE
feat(dash): surface waiting lane host-neutral as agent

### DIFF
--- a/examples/session-dash-panel-smoke.py
+++ b/examples/session-dash-panel-smoke.py
@@ -170,6 +170,13 @@ def test_projection_is_read_only_and_fleet_shaped() -> None:
     assert goal["open_agent_todos"] == 1
     assert goal["status_bucket"] == "active"
 
+    # ``codex`` waiting classification is surfaced host-neutral as ``agent``
+    # so the panel reads the same for Codex, Pi, or any agent host.
+    meta_session = next(s for s in sessions if s["session_id"] == "codex-main-control")
+    meta_goal = meta_session["goals"][0]
+    assert meta_goal["waiting_on"] == "agent"
+    assert meta_goal["waiting_on"] != "codex"
+
     # no internal machinery in the projection that humans can't read
     assert "truth_contract" not in projection
     assert "work_lane" not in projection

--- a/loopx/presentation/projections/session_dash.py
+++ b/loopx/presentation/projections/session_dash.py
@@ -161,6 +161,12 @@ def _goal_entry(
         or _text(run_goal.get("waiting_on"))
         or "auto"
     )
+    # ``codex`` is LoopX's classification for an agent-actionable lane; surface
+    # it with the host-neutral ``agent`` word so the panel reads the same for
+    # Codex, Pi, or any other agent host. Both words classify identically in
+    # the bucket logic below.
+    if waiting_on == "codex":
+        waiting_on = "agent"
     display_name = (
         _text(status_item.get("display_name"), limit=120)
         or _text(run_goal.get("display_name"), limit=120)


### PR DESCRIPTION
The session dash panel displayed **Waiting on: codex** for goals whose latest run classification is codex-ready (`CODEX_READY_CLASSIFICATIONS`). That reads as a product reference (Codex CLI) even though the lane is actionable by any agent host — Pi, Codex, etc. `codex` is LoopX's internal classification for an agent-actionable lane (`session_runtime_status_waiting_on` treats `agent`/`codex` as synonyms).

Change: map the `codex` waiting classification to the host-neutral **agent** word at the session-dash projection layer. Both words classify identically in the status-bucket logic, so bucket behavior is unchanged.

- `loopx/presentation/projections/session_dash.py`: `waiting_on == "codex"` → `"agent"` with a comment explaining the synonym.
- `examples/session-dash-panel-smoke.py`: asserts a codex-classified fixture goal projects `waiting_on == "agent"`.

Validation: session-dash-panel-smoke OK (14 tests), static-site-presentation-smoke OK, cli-command-module-contract OK, ruff/py_compile/diff-check clean. Verified live: `loopx-goal` now projects `waiting_on=agent` (was `codex`), `status_bucket` unchanged.
