### PR TITLE
fix(install): isolate skill promotion from caller cwd

### DIFF
--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -63,10 +63,15 @@ def source_git_commit(root: Path = REPO_ROOT) -> str:
     return commit
 
 
-def run_install(env: dict[str, str], release_id: str) -> subprocess.CompletedProcess[str]:
+def run_install(
+    env: dict[str, str],
+    release_id: str,
+    *,
+    cwd: Path = REPO_ROOT,
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [str(INSTALL_SCRIPT)],
-        cwd=REPO_ROOT,
+        cwd=cwd,
         env={**env, "LOOPX_RELEASE_ID": release_id},
         check=True,
         capture_output=True,
@@ -207,7 +212,15 @@ def main() -> int:
         }
         source_commit = source_git_commit()
 
-        install = run_install(env, "install-smoke-initial")
+        shadow_cwd = root / "shadow-checkout"
+        shadow_package = shadow_cwd / "loopx"
+        shadow_package.mkdir(parents=True)
+        (shadow_package / "__init__.py").write_text(
+            '"""Deliberately incomplete package that must not shadow the release."""\n',
+            encoding="utf-8",
+        )
+
+        install = run_install(env, "install-smoke-initial", cwd=shadow_cwd)
         assert "loopx installed locally" in install.stdout, install.stdout
         assert "promotion-readiness evidence is missing" in install.stderr, install.stderr
         assert "non-blocking" in install.stderr, install.stderr

--- a/examples/release/local-install-promotion-boundary-smoke.py
+++ b/examples/release/local-install-promotion-boundary-smoke.py
@@ -179,11 +179,43 @@ def assert_explicit_promotion_is_auditable() -> None:
         assert default_release["promotion_mode"] == "explicit_override", default_release
 
 
+def assert_skill_preflight_failure_preserves_default() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-promotion-skill-preflight-") as tmp:
+        root = Path(tmp)
+        env, bin_dir, releases_dir = base_env(root)
+        env["LOOPX_PROMOTE_DEFAULT"] = "1"
+        env["LOOPX_INSTALL_SKILL"] = "1"
+        skills_dir = root / "workspace" / ".agents" / "skills"
+        env["LOOPX_SKILLS_DIR"] = str(skills_dir)
+        env["LOOPX_ENTRY_HOST_SURFACE"] = "ark-managed-agent"
+
+        user_skill = skills_dir / "loopx" / "SKILL.md"
+        user_skill.parent.mkdir(parents=True)
+        user_skill.write_text("# User-owned LoopX skill\n", encoding="utf-8")
+        default = bin_dir / "loopx"
+        default.write_text("#!/usr/bin/env bash\nexit 41\n", encoding="utf-8")
+        default.chmod(0o755)
+
+        install = run_install(
+            env,
+            release_id="blocked-skill-preflight",
+            check=False,
+        )
+
+        assert install.returncode != 0, install.stdout
+        assert "exact-host entry skill cannot be materialized" in install.stderr
+        assert not default.is_symlink(), default
+        assert "exit 41" in default.read_text(encoding="utf-8"), default
+        assert not (releases_dir / "blocked-skill-preflight").exists(), releases_dir
+        assert user_skill.read_text(encoding="utf-8") == "# User-owned LoopX skill\n"
+
+
 def main() -> int:
     assert_untrusted_checkout_is_canary_only()
     assert_untrusted_checkout_preserves_implicit_default_skill_root()
     assert_exact_host_install_rejects_user_owned_entry_skill()
     assert_explicit_promotion_is_auditable()
+    assert_skill_preflight_failure_preserves_default()
     print("local-install-promotion-boundary-smoke ok")
     return 0
 

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -209,7 +209,7 @@ warn_stale_promotion_readiness() {
   local python_bin="${LOOPX_PYTHON:-python3}"
   local runtime_root="${LOOPX_RUNTIME_ROOT:-$codex_home/loopx}"
   local gate_json
-  gate_json="$(PYTHONPATH="$repo_root${PYTHONPATH:+:$PYTHONPATH}" "$python_bin" -m loopx.cli --runtime-root "$runtime_root" --format json promotion-gate 2>/dev/null || true)"
+  gate_json="$(PYTHONSAFEPATH=1 PYTHONPATH="$repo_root${PYTHONPATH:+:$PYTHONPATH}" "$python_bin" -m loopx.cli --runtime-root "$runtime_root" --format json promotion-gate 2>/dev/null || true)"
   if [[ -z "$gate_json" ]]; then
     return 0
   fi
@@ -353,6 +353,7 @@ install_workflow_skills() {
         LOOPX_SKILL_INSTALLED_AT="$installed_at" \
         LOOPX_SKILL_ENTRY_CLI_BIN="$entry_cli_bin" \
         LOOPX_SKILL_ENTRY_HOST_SURFACE="$entry_host_surface" \
+        PYTHONSAFEPATH=1 \
         PYTHONPATH="$source_root${PYTHONPATH:+:$PYTHONPATH}" \
         "${LOOPX_PYTHON:-python3}" - <<'PY'
 import os
@@ -410,6 +411,47 @@ PY
   rm -rf "$skill_install_lock"
   skill_install_lock_owned=0
   skill_install_lock=""
+}
+
+preflight_workflow_skills() {
+  local skills_source="$1"
+  local source_root="$2"
+  local entry_cli_bin="$3"
+  if [[ "$install_skill" == "0" || ! -d "$skills_source" ]]; then
+    return 0
+  fi
+
+  LOOPX_SKILL_INSTALL_DIR="$skills_dir" \
+    LOOPX_SKILL_ENTRY_CLI_BIN="$entry_cli_bin" \
+    LOOPX_SKILL_ENTRY_HOST_SURFACE="$entry_host_surface" \
+    PYTHONSAFEPATH=1 \
+    PYTHONPATH="$source_root${PYTHONPATH:+:$PYTHONPATH}" \
+    "${LOOPX_PYTHON:-python3}" - <<'PY'
+import os
+import sys
+from pathlib import Path
+
+from loopx.skill_install_readback import SKILL_INSTALL_READBACK_FILENAME
+from loopx.slash_command_install import materialize_loopx_entry_skill
+
+result = materialize_loopx_entry_skill(
+    skills_dir=Path(os.environ["LOOPX_SKILL_INSTALL_DIR"]),
+    execute=False,
+    cli_bin=os.environ["LOOPX_SKILL_ENTRY_CLI_BIN"],
+    host_surface=os.environ.get("LOOPX_SKILL_ENTRY_HOST_SURFACE") or None,
+)
+if os.environ.get("LOOPX_SKILL_ENTRY_HOST_SURFACE") and result["status"] in {
+    "preserved_existing_loopx_skill",
+    "skipped_user_file",
+}:
+    readback = Path(os.environ["LOOPX_SKILL_INSTALL_DIR"]) / SKILL_INSTALL_READBACK_FILENAME
+    print(
+        "loopx installer error: exact-host entry skill cannot be materialized "
+        f"(status={result['status']}, path={result['path']}, readback={readback})",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+PY
 }
 
 verify_default_promotion() {
@@ -639,6 +681,10 @@ chmod +x "$release_tmp/scripts/loopx"
 mv "$release_tmp" "$release_dir"
 release_tmp=""
 if ! validate_release_candidate "$release_dir"; then
+  rm -rf "$release_dir"
+  exit 1
+fi
+if ! preflight_workflow_skills "$release_dir/skills" "$release_dir" "$bin_dir/loopx"; then
   rm -rf "$release_dir"
   exit 1
 fi


### PR DESCRIPTION
## Summary

- isolate installer-owned Python imports from the caller's current working directory with `PYTHONSAFEPATH=1`
- preflight workflow-skill imports and exact-host entry materialization before switching the default `loopx` executable
- keep the previous default executable active and remove the candidate release when skill preflight fails
- add durable regressions for an incomplete shadow `loopx` package and a promotion-blocking user-owned exact-host skill

## Product and architecture judgment

The installer previously allowed caller CWD state to select an unrelated Python package and performed default promotion before workflow-skill validation. That could report a failed install while leaving a newly activated CLI and partially updated skills. The change keeps source ownership in the existing installer and entry-skill contracts: a read-only preflight closes the known failure boundary, while the real install still uses the established lock and materialization path. No new installer framework or public protocol is introduced.

## Validation

- `bash -n scripts/install-local.sh`
- focused Ruff checks passed
- `python examples/install-local-smoke.py` passed, including the shadow-package CWD fixture
- `python examples/release/local-install-promotion-boundary-smoke.py` passed, including fail-closed default preservation
- `pytest tests/test_slash_command_install.py -q`: 37 passed
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 18 selected checks passed; 0 failures, warnings, or manual holds
- strict change-quality receipt `cqr_30041cb378b680be97a4` is valid for the exact 3-file diff

## Boundary

No credentials, private runtime state, generated logs, local paths, benchmark evidence, or unrelated artifacts are included. The generated local dependency lock was excluded.
