### PR TITLE
fix(install): retire duplicate LoopX skills across roots

### DIFF
--- a/loopx/skill_install_readback.py
+++ b/loopx/skill_install_readback.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import shutil
 import subprocess
 import tempfile
 from typing import Any, Mapping, Sequence
@@ -14,6 +15,7 @@ SKILL_INSTALL_READBACK_SCHEMA_VERSION = "loopx_skill_install_readback_v0"
 SKILL_INSTALL_READBACK_FILENAME = ".loopx-skill-install.json"
 SKILL_INSTALL_OWNER = "loopx_install_script"
 SKILL_INSTALL_INTEGRATION_MODE = "fixed_install_script"
+LOOPX_MANAGED_SLASH_COMMAND_MARKER = "<!-- loopx-managed-slash-command:v1"
 PACKAGED_HOST_SKILL_IDS = [
     "loopx-project",
     "loopx-pr-program",
@@ -25,6 +27,143 @@ ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS = [
     "loopx",
     *PACKAGED_HOST_SKILL_IDS,
 ]
+
+
+def _user_home() -> Path:
+    return Path.home().expanduser()
+
+
+def alternate_loopx_skills_root(skills_dir: Path) -> Path | None:
+    """Return the alternate LoopX root that can shadow the target root.
+
+    The fixed installer historically wrote the same managed skill set into both
+    ``~/.codex/skills`` and ``~/.agents/skills``. ARK-managed agent sessions and
+    Codex sessions can both discover those roots, which duplicates LoopX skills
+    in the loaded skill catalog. Callers may explicitly pass an alternate root;
+    otherwise this returns the other well-known root when the target is one of
+    them.
+    """
+
+    codex_root = _user_home() / ".codex" / "skills"
+    agents_root = _user_home() / ".agents" / "skills"
+    try:
+        target = skills_dir.expanduser().resolve()
+    except OSError:
+        return None
+    if target == codex_root.expanduser().resolve():
+        return agents_root
+    if target == agents_root.expanduser().resolve():
+        return codex_root
+    return None
+
+
+def _managed_command_facade(path: Path) -> bool:
+    try:
+        existing = (path / "SKILL.md").read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return LOOPX_MANAGED_SLASH_COMMAND_MARKER in existing
+
+
+def retire_duplicate_managed_skills(
+    skills_dir: Path,
+    *,
+    alternate_root: Path | None = None,
+    execute: bool,
+) -> dict[str, Any]:
+    """Retire LoopX-managed skill copies from the alternate well-known root.
+
+    The fixed installer overwrites within the target root, but it historically
+    left an older managed copy in the other well-known root. That makes hosts
+    that discover both roots load duplicate LoopX skills. This helper retires
+    only copies that the alternate root's own readback records as LoopX-managed
+    (or command facades carrying the managed marker), so user-modified files
+    are never deleted.
+    """
+
+    target = Path(skills_dir).expanduser().resolve()
+    alternate = (
+        Path(alternate_root).expanduser().resolve()
+        if alternate_root
+        else alternate_loopx_skills_root(target)
+    )
+    retired: list[str] = []
+    would_retire: list[str] = []
+    skipped: list[str] = []
+    if alternate is None or not alternate.is_dir():
+        return {
+            "ok": True,
+            "schema_version": SKILL_INSTALL_READBACK_SCHEMA_VERSION,
+            "target_root": str(target),
+            "alternate_root": str(alternate) if alternate else None,
+            "retired": retired,
+            "would_retire": would_retire,
+            "skipped": skipped,
+            "reason": "no alternate LoopX skills root configured",
+        }
+
+    manifest_path = alternate / SKILL_INSTALL_READBACK_FILENAME
+    managed_ids: set[str] = set()
+    recorded_hashes: dict[str, str] = {}
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        manifest = None
+    if isinstance(manifest, dict):
+        raw_ids = manifest.get("materialized_skill_ids")
+        if isinstance(raw_ids, list):
+            managed_ids.update(
+                str(item).strip() for item in raw_ids if str(item or "").strip()
+            )
+        items = manifest.get("skills")
+        if isinstance(items, dict) and isinstance(items.get("items"), dict):
+            for skill_id, item in items["items"].items():
+                if isinstance(item, dict) and isinstance(item.get("sha256"), str):
+                    recorded_hashes[str(skill_id)] = item["sha256"]
+
+    candidate_dirs: list[Path] = []
+    if managed_ids:
+        candidate_dirs.extend(alternate / skill_id for skill_id in managed_ids)
+    if alternate.is_dir():
+        candidate_dirs.extend(
+            path
+            for path in sorted(
+                [*alternate.glob("loopx-*"), *alternate.glob("loop-global-*")]
+            )
+            if path.is_dir() and path not in candidate_dirs
+        )
+
+    for candidate in candidate_dirs:
+        if not candidate.is_dir() or not (candidate / "SKILL.md").is_file():
+            continue
+        skill_id = candidate.name
+        managed = skill_id in managed_ids
+        marker_managed = _managed_command_facade(candidate)
+        if not managed and not marker_managed:
+            skipped.append(skill_id)
+            continue
+        recorded_hash = recorded_hashes.get(skill_id)
+        if managed and recorded_hash and not marker_managed:
+            tree = hash_skill_tree(candidate)
+            if not tree.get("available") or tree.get("sha256") != recorded_hash:
+                skipped.append(skill_id)
+                continue
+        if execute:
+            shutil.rmtree(candidate)
+            retired.append(skill_id)
+        else:
+            would_retire.append(skill_id)
+
+    return {
+        "ok": True,
+        "schema_version": SKILL_INSTALL_READBACK_SCHEMA_VERSION,
+        "target_root": str(target),
+        "alternate_root": str(alternate),
+        "retired": retired,
+        "would_retire": would_retire,
+        "skipped": skipped,
+        "reason": "retired alternate LoopX-managed copies" if execute else "dry-run",
+    }
 
 
 def _sha256_file(path: Path) -> str:

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -17,6 +17,7 @@ Common environment variables:
   LOOPX_INSTALL_CANARY=0           Skip the loopx-canary executable.
   LOOPX_INSTALL_SKILL=0            Skip packaged workflow skills.
   LOOPX_SKILLS_DIR=/path           Install workflow skills into this host-native root.
+  LOOPX_SKILL_DEDUPE_OTHER_ROOT=1  Retire managed LoopX skill copies from the alternate well-known root.
   LOOPX_ENTRY_HOST_SURFACE=...     Bind generated $loopx to an exact host (ark-managed-agent).
   LOOPX_INSTALL_SLASH_COMMANDS=0   Skip Codex and Claude command skills.
   LOOPX_INSTALL_OPENCODE=0         Install the OpenCode goal bridge surface.
@@ -362,6 +363,7 @@ from pathlib import Path
 
 from loopx.skill_install_readback import (
     SKILL_INSTALL_READBACK_FILENAME,
+    retire_duplicate_managed_skills,
     write_skill_install_readback,
 )
 from loopx.slash_command_install import materialize_loopx_entry_skill
@@ -394,6 +396,12 @@ write_skill_install_readback(
     source_root=Path(os.environ["LOOPX_SKILL_INSTALL_SOURCE_ROOT"]),
     installed_at=os.environ["LOOPX_SKILL_INSTALLED_AT"],
 )
+if os.environ.get("LOOPX_SKILL_DEDUPE_OTHER_ROOT") == "1":
+    dedupe = retire_duplicate_managed_skills(
+        skills_dir=Path(os.environ["LOOPX_SKILL_INSTALL_DIR"]),
+        execute=True,
+    )
+    print(f"skill dedupe: {dedupe['reason']}")
 print(status)
 PY
     )"; then

--- a/tests/test_ark_managed_agent_host.py
+++ b/tests/test_ark_managed_agent_host.py
@@ -23,6 +23,7 @@ from loopx.skill_install_readback import (
     PACKAGED_HOST_SKILL_IDS,
     SKILL_INSTALL_READBACK_FILENAME,
     inspect_skill_install_readback,
+    retire_duplicate_managed_skills,
     write_skill_install_readback,
 )
 from loopx.slash_command_install import materialize_loopx_entry_skill
@@ -322,6 +323,47 @@ def test_skill_readback_records_the_resolved_archive_revision(
     assert readback["ready"] is True
     assert readback["source_revision"] == resolved_commit
     assert readback["source_revision_matches"] is True
+
+
+def test_retire_duplicate_managed_skills_removes_only_loopx_managed_copies(
+    tmp_path: Path,
+) -> None:
+    codex_skills = tmp_path / ".codex" / "skills"
+    agents_skills = tmp_path / ".agents" / "skills"
+    _materialize_workflow_skills(codex_skills)
+    _materialize_workflow_skills(agents_skills)
+    facade = agents_skills / "loopx-global-gates" / "SKILL.md"
+    facade.parent.mkdir(parents=True)
+    facade.write_text(
+        "<!-- loopx-managed-slash-command:v1 command=/loopx-global-gates -->\n",
+        encoding="utf-8",
+    )
+    user_file = agents_skills / "loopx-project" / "SKILL.md"
+    user_file.write_text(
+        user_file.read_text(encoding="utf-8") + "\nuser-edit\n",
+        encoding="utf-8",
+    )
+
+    dry = retire_duplicate_managed_skills(
+        codex_skills,
+        alternate_root=agents_skills,
+        execute=False,
+    )
+    assert dry["ok"] is True
+    assert "loopx-global-gates" in dry["would_retire"]
+    assert "loopx-project" in dry["skipped"]
+    assert agents_skills.is_dir()
+
+    applied = retire_duplicate_managed_skills(
+        codex_skills,
+        alternate_root=agents_skills,
+        execute=True,
+    )
+    assert applied["ok"] is True
+    assert "loopx-global-gates" in applied["retired"]
+    assert not (agents_skills / "loopx-global-gates").exists()
+    assert (agents_skills / "loopx-project").exists()
+    assert (codex_skills / "loopx-project").exists()
 
 
 def _write_continuity_fixture(tmp_path: Path) -> tuple[Path, Path, Path]:


### PR DESCRIPTION
## Summary

Fix the fixed installer so it can retire duplicate LoopX skill copies from the
alternate well-known root instead of leaving both `~/.codex/skills` and
`~/.agents/skills` populated. ARK-managed agent sessions and Codex sessions can
discover both roots, which made the loaded skill catalog show LoopX skills
twice.

## Changes

- `loopx/skill_install_readback.py`:
  - Add `alternate_loopx_skills_root` to resolve the alternate root.
  - Add `retire_duplicate_managed_skills` to retire only LoopX-managed copies:
    workflow skills are checked against the alternate root's install readback
    digest, and command facades must carry the managed slash-command marker.
- `scripts/install-local.sh`:
  - When `LOOPX_SKILL_DEDUPE_OTHER_ROOT=1`, call the retire helper after the
    normal overwrite install so the other well-known root stops shadowing it.
  - Document the new environment variable in `--help`.
- `tests/test_ark_managed_agent_host.py`:
  - Add a regression test that retires managed duplicates, skips user-modified
    workflow copies, and preserves the target root.

## Validation

- New focused test passes.
- `tests/test_ark_managed_agent_host.py` + `tests/test_slash_command_install.py`: 50 passed.
- `examples/slash-command-install-smoke.py` and `examples/install-local-smoke.py` pass.
- `bash -n scripts/install-local.sh`, `py_compile`, and `git diff --check` pass.
