### PR TITLE
fix(control-plane): require causal outcome-continuity waits

### DIFF
--- a/loopx/control_plane/goals/goal_frontier/__init__.py
+++ b/loopx/control_plane/goals/goal_frontier/__init__.py
@@ -69,6 +69,13 @@ TODO_TASK_CLASS_ADVANCEMENT = "advancement_task"
 TODO_TASK_CLASS_MONITOR = "continuous_monitor"
 LONG_TODO_CHAIN_ADVANCEMENT_THRESHOLD = 15
 LONG_TODO_CHAIN_OPEN_THRESHOLD = 20
+VISION_FRONTIER_TODO_DELTA_ACTIONS = {
+    "activate",
+    "create",
+    "reopen",
+    "resume",
+    "retain",
+}
 
 
 def safe_non_negative_int(value: Any) -> int:
@@ -497,6 +504,16 @@ def acceptance_gaps_from_agent_vision(
     }
     if acceptance:
         gap["acceptance_summary"] = acceptance
+    vision_todo_ids = [
+        todo_id
+        for value in (agent_vision.get("todo_delta") or [])
+        if isinstance(value, str)
+        and (parts := value.strip().partition(":"))[1]
+        and parts[0].strip().lower() in VISION_FRONTIER_TODO_DELTA_ACTIONS
+        and (todo_id := _compact_projection_text(parts[2], limit=120))
+    ]
+    if vision_todo_ids:
+        gap["vision_todo_ids"] = list(dict.fromkeys(vision_todo_ids))
     advancement_policy = _compact_projection_text(
         patch.get("advancement_policy"),
         limit=32,
@@ -1292,6 +1309,16 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                     "agent_id": agent_id,
                     "acceptance_summary": gap.get("acceptance_summary"),
                     "advancement_policy": gap.get("advancement_policy"),
+                    **{
+                        key: gap.get(key)
+                        for key in (
+                            "completed_todo_id",
+                            "completed_todo_count",
+                            "completed_todo_threshold",
+                            "completed_todo_ids",
+                        )
+                        if gap.get(key) is not None
+                    },
                 }
                 for gap in compact_acceptance_gaps[:3]
             ],

--- a/loopx/control_plane/goals/goal_frontier/outcome_continuity.py
+++ b/loopx/control_plane/goals/goal_frontier/outcome_continuity.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 from ...agents.agent_scope import agent_scope_item_claimed_by
@@ -22,6 +22,7 @@ REPEAT_VISION_REPLAN_SATISFYING_DELTA_KINDS = (
     "runnable_todo_set",
     "successor_or_supersede",
 )
+COMPLETED_TODO_CHAIN_REPLAN_THRESHOLD = 5
 
 
 def _compact_text(value: Any, *, limit: int) -> str | None:
@@ -326,11 +327,11 @@ def _iso_timestamp(value: Any) -> float | None:
     if not text:
         return None
     try:
-        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(text)
     except ValueError:
         return None
     if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
+        parsed = parsed.replace(tzinfo=UTC)
     return parsed.timestamp()
 
 
@@ -373,7 +374,7 @@ def acceptance_gaps_from_todo_completion_checkpoint(
     agent_todo_summary: dict[str, Any] | None,
     agent_id: str | None,
 ) -> list[dict[str, Any]]:
-    """Require a qualified outcome checkpoint after a scoped todo completion."""
+    """Require a checkpoint after a bounded chain of scoped completions."""
 
     if not isinstance(agent_vision, dict):
         return []
@@ -388,11 +389,16 @@ def acceptance_gaps_from_todo_completion_checkpoint(
         if isinstance(item, dict)
         and agent_scope_item_claimed_by(item) == agent_id
     ]
-    latest_item = max(
-        completed_items,
+    completed_items = [
+        item
+        for item in completed_items
+        if _iso_timestamp(item.get("completed_at")) is not None
+    ]
+    completed_items.sort(
         key=lambda item: _iso_timestamp(item.get("completed_at")) or 0.0,
-        default=None,
+        reverse=True,
     )
+    latest_item = completed_items[0] if completed_items else None
     if not isinstance(latest_item, dict):
         return []
     completed_at = _iso_timestamp(latest_item.get("completed_at"))
@@ -409,6 +415,23 @@ def acceptance_gaps_from_todo_completion_checkpoint(
     ):
         return []
 
+    qualified_checkpoint_at = (
+        checkpoint_generated_at
+        if isinstance(checkpoint, dict)
+        and checkpoint_generated_at is not None
+        and _checkpoint_covers_completed_todo(agent_vision, checkpoint)
+        else None
+    )
+    uncheckpointed_items = [
+        item
+        for item in completed_items
+        if qualified_checkpoint_at is None
+        or (_iso_timestamp(item.get("completed_at")) or 0.0)
+        > qualified_checkpoint_at
+    ]
+    if len(uncheckpointed_items) < COMPLETED_TODO_CHAIN_REPLAN_THRESHOLD:
+        return []
+
     patch = _dict_field(agent_vision, "vision_patch")
     return [
         {
@@ -416,7 +439,8 @@ def acceptance_gaps_from_todo_completion_checkpoint(
             "source": "recent_completed_advancement_todo",
             "agent_id": agent_id or agent_vision.get("agent_id"),
             "replan_trigger_summary": (
-                "completed advancement work has no later final-outcome checkpoint"
+                "a completed advancement Todo chain has no later final-outcome "
+                "checkpoint"
             ),
             "acceptance_summary": (
                 _compact_text(patch.get("acceptance_summary"), limit=420)
@@ -425,6 +449,15 @@ def acceptance_gaps_from_todo_completion_checkpoint(
             "advancement_policy": patch.get("advancement_policy"),
             "completed_todo_id": latest_item.get("todo_id"),
             "completed_at": latest_item.get("completed_at"),
+            "completed_todo_count": len(uncheckpointed_items),
+            "completed_todo_threshold": COMPLETED_TODO_CHAIN_REPLAN_THRESHOLD,
+            "completed_todo_ids": [
+                item.get("todo_id")
+                for item in uncheckpointed_items[
+                    :COMPLETED_TODO_CHAIN_REPLAN_THRESHOLD
+                ]
+                if item.get("todo_id")
+            ],
             "checkpoint_generated_at": (
                 checkpoint.get("generated_at")
                 if isinstance(checkpoint, dict)

--- a/loopx/control_plane/goals/goal_vision_wait.py
+++ b/loopx/control_plane/goals/goal_vision_wait.py
@@ -12,7 +12,6 @@ from ..todos.contract import (
 )
 from ..todos.deferred_resume import todo_summary_blocked_successor_items
 
-
 GOAL_VISION_WAIT_STATE_SCHEMA_VERSION = "goal_vision_wait_state_v0"
 VISION_ACCEPTANCE_GAP_KIND = "vision_acceptance_gap"
 
@@ -91,6 +90,89 @@ def _compact_resume_condition(value: Any) -> dict[str, Any]:
     return compact
 
 
+def _acceptance_gap_causal_todo_ids(
+    gaps: list[dict[str, Any]],
+) -> set[str]:
+    todo_ids: set[str] = set()
+    for gap in gaps:
+        for key in (
+            "todo_id",
+            "current_todo_id",
+            "blocked_todo_id",
+            "completed_todo_id",
+            "successor_todo_id",
+        ):
+            todo_id = normalize_todo_id(gap.get(key))
+            if todo_id:
+                todo_ids.add(todo_id)
+        for key in (
+            "vision_todo_ids",
+            "lineage_todo_ids",
+            "successor_todo_ids",
+            "completed_todo_ids",
+        ):
+            values = gap.get(key) if isinstance(gap.get(key), list) else []
+            todo_ids.update(
+                todo_id
+                for value in values
+                if (todo_id := normalize_todo_id(value))
+            )
+    return todo_ids
+
+
+def _causal_blocked_successor_items(
+    candidates: list[dict[str, Any]],
+    *,
+    causal_todo_ids: set[str],
+) -> list[dict[str, Any]]:
+    """Keep only waits in the active vision's explicit Todo lineage."""
+
+    if not causal_todo_ids:
+        return []
+    lineage_ids = set(causal_todo_ids)
+    changed = True
+    while changed:
+        changed = False
+        for item in candidates:
+            todo_id = normalize_todo_id(item.get("todo_id"))
+            condition = (
+                item.get("resume_condition")
+                if isinstance(item.get("resume_condition"), dict)
+                else {}
+            )
+            target_todo_id = normalize_todo_id(
+                condition.get("target_todo_id") or condition.get("target")
+            )
+            successor_todo_ids = {
+                successor_todo_id
+                for value in (
+                    item.get("successor_todo_ids")
+                    if isinstance(item.get("successor_todo_ids"), list)
+                    else []
+                )
+                if (successor_todo_id := normalize_todo_id(value))
+            }
+            if not (
+                (todo_id and todo_id in lineage_ids)
+                or (target_todo_id and target_todo_id in lineage_ids)
+                or successor_todo_ids.intersection(lineage_ids)
+            ):
+                continue
+            expanded = {
+                value
+                for value in (todo_id, target_todo_id, *successor_todo_ids)
+                if value
+            }
+            if not expanded.issubset(lineage_ids):
+                lineage_ids.update(expanded)
+                changed = True
+    return [
+        item
+        for item in candidates
+        if normalize_todo_id(item.get("todo_id")) in lineage_ids
+    ]
+
+
 def build_goal_vision_wait_state(
     *,
     agent_todo_summary: dict[str, Any] | None,
@@ -111,6 +193,8 @@ def build_goal_vision_wait_state(
     if selectable_advancement_count > 0:
         return None
 
+    causal_todo_ids = _acceptance_gap_causal_todo_ids(gaps)
+
     blocker_items = (
         agent_todo_summary.get("current_agent_blocker_items")
         if isinstance(agent_todo_summary, dict)
@@ -128,15 +212,17 @@ def build_goal_vision_wait_state(
         and str(item.get("reason") or "").strip()
         and normalize_todo_claimed_by(item.get("claimed_by"))
         == safe_agent_id
+        and normalize_todo_id(item.get("todo_id")) in causal_todo_ids
     ]
-    candidates = (
-        todo_summary_blocked_successor_items(
-            agent_todo_summary or {},
-            agent_id=agent_id,
+    candidates = []
+    if not blocker_items:
+        candidates = _causal_blocked_successor_items(
+            todo_summary_blocked_successor_items(
+                agent_todo_summary or {},
+                agent_id=agent_id,
+            ),
+            causal_todo_ids=causal_todo_ids,
         )
-        if not blocker_items
-        else []
-    )
     if candidates:
         selected = candidates[0]
         waiting_todo_ids = [

--- a/loopx/control_plane/todos/quota_summary.py
+++ b/loopx/control_plane/todos/quota_summary.py
@@ -123,7 +123,7 @@ QUOTA_PAYLOAD_LANE_LIMITS = {
     "current_agent_claimed_advancement_items": QUOTA_PAYLOAD_VISIBILITY_LANE_LIMIT,
     "current_agent_claimed_monitor_items": QUOTA_PAYLOAD_VISIBILITY_LANE_LIMIT,
     "current_agent_blocker_items": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
-    "recent_completed_advancement_items": 5,
+    "recent_completed_advancement_items": 3,
     "claimed_by_others_items": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
     "other_agent_scoped_items": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
     "other_agent_bound_user_action_items": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,

--- a/tests/control_plane/test_goal_vision_blocked_successor.py
+++ b/tests/control_plane/test_goal_vision_blocked_successor.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from copy import deepcopy
 import json
+from copy import deepcopy
 
 import pytest
 
@@ -31,7 +31,6 @@ from loopx.quota import build_quota_should_run, render_quota_should_run_markdown
 from loopx.state_refresh import build_state_refresh_record, refresh_state_run
 from loopx.status import autonomous_replan_obligation_from_runs, compact_run
 
-
 GOAL_ID = "vision-blocked-successor-fixture"
 AGENT_ID = "codex-side-agent"
 PRIMARY_AGENT = "codex-primary-agent"
@@ -49,6 +48,7 @@ def _vision_run(
     state: str = "vision_drift_detected",
     missing_checkpoint: bool = False,
     advancement_policy: str = "repeat_until_closed",
+    vision_todo_ids: list[str] | None = None,
 ) -> dict:
     run = {
         "classification": "vision_blocked_successor_fixture",
@@ -59,6 +59,14 @@ def _vision_run(
             "schema_version": "goal_vision_replan_contract_v0",
             "agent_id": AGENT_ID,
             "state": state,
+            "todo_delta": [
+                f"activate:{todo_id}"
+                for todo_id in (
+                    vision_todo_ids
+                    if vision_todo_ids is not None
+                    else [BLOCKER_ID]
+                )
+            ],
             "vision_patch": {
                 "acceptance_summary": "Deliver the exact successor after its prerequisite clears.",
                 "replan_trigger_summary": "The successor acceptance remains open.",
@@ -230,7 +238,11 @@ def _current_agent_blocker_status_payload(
             "agent_model": "peer_v1",
             "registered_agents": [PRIMARY_AGENT, AGENT_ID],
         },
-        latest_runs=latest_runs if latest_runs is not None else [_vision_run()],
+        latest_runs=(
+            latest_runs
+            if latest_runs is not None
+            else [_vision_run(vision_todo_ids=[PROJECTED_BLOCKER_ID])]
+        ),
     )
 
 
@@ -293,7 +305,16 @@ def test_current_agent_blocker_outranks_exact_blocked_successor() -> None:
         reason="Candidate promotion requires controller assignment.",
     )
 
-    guard = _quota(_status_payload(extra_agent_items=[blocker]))
+    guard = _quota(
+        _status_payload(
+            extra_agent_items=[blocker],
+            latest_runs=[
+                _vision_run(
+                    vision_todo_ids=[PROJECTED_BLOCKER_ID, BLOCKER_ID]
+                )
+            ],
+        )
+    )
 
     wait = guard["goal_frontier_projection"]["vision_wait_state"]
     assert wait["reason_code"] == "current_agent_blocker"
@@ -351,7 +372,10 @@ def test_blocker_delta_ack_clears_existing_vision_replan_obligation() -> None:
         },
     }
     payload = _current_agent_blocker_status_payload(
-        latest_runs=[ack, _vision_run()]
+        latest_runs=[
+            ack,
+            _vision_run(vision_todo_ids=[PROJECTED_BLOCKER_ID]),
+        ]
     )
     item = payload["attention_queue"]["items"][0]
     item["autonomous_replan_obligation"] = obligation
@@ -502,24 +526,48 @@ def test_exact_blocked_successor_defers_only_open_vision_gap(
     ) in markdown
 
 
-def test_agent_claimed_wait_outranks_unclaimed_cross_domain_wait() -> None:
+def test_unrelated_deferred_waits_do_not_hide_open_vision_gap() -> None:
     guard = _quota(_cross_domain_wait_status_payload())
 
-    assert guard["decision"] == "agent_scope_wait"
-    wait = guard["goal_frontier_projection"]["vision_wait_state"]
-    assert wait["selected_todo_id"] == CLAIMED_WAITING_ID
-    assert wait["selected_todo_claimed_by"] == AGENT_ID
-    assert wait["waiting_todo_ids"] == [
-        CLAIMED_WAITING_ID,
-        CROSS_DOMAIN_WAITING_ID,
-    ]
+    assert guard["decision"] == "autonomous_replan_required"
+    assert "vision_wait_state" not in guard["goal_frontier_projection"]
+    assert guard["goal_frontier_projection"]["acceptance_gaps"][0]["kind"] == (
+        "vision_acceptance_gap"
+    )
 
     status_payload = _cross_domain_wait_status_payload()
     attach_agent_lane_next_actions(status_payload, agent_id=AGENT_ID)
     item = status_payload["attention_queue"]["items"][0]
-    status_wait = item["goal_frontier_projection"]["vision_wait_state"]
-    assert status_wait["selected_todo_id"] == CLAIMED_WAITING_ID
-    assert status_wait["waiting_todo_ids"] == wait["waiting_todo_ids"]
+    assert "vision_wait_state" not in item["goal_frontier_projection"]
+    assert item["goal_frontier_projection"]["replan_required"] is True
+
+
+def test_exact_successor_lineage_excludes_unrelated_deferred_waits() -> None:
+    unrelated = quota_todo_item(
+        todo_id=CLAIMED_WAITING_ID,
+        index=3,
+        text="[P0] Wait for an unrelated release capability.",
+        status="deferred",
+        claimed_by=AGENT_ID,
+        required_capabilities=["benchmark_runner"],
+        resume_when="capacity_available:benchmark_runner",
+    )
+
+    guard = _quota(_status_payload(extra_agent_items=[unrelated]))
+
+    wait = guard["goal_frontier_projection"]["vision_wait_state"]
+    assert wait["selected_todo_id"] == WAITING_ID
+    assert wait["waiting_todo_ids"] == [WAITING_ID]
+
+
+def test_exact_wait_without_explicit_vision_lineage_requires_replan() -> None:
+    guard = _quota(
+        _status_payload(latest_runs=[_vision_run(vision_todo_ids=[])])
+    )
+
+    assert guard["decision"] == "autonomous_replan_required"
+    assert "vision_wait_state" not in guard["goal_frontier_projection"]
+    assert guard["goal_frontier_projection"]["replan_required"] is True
 
 
 def test_two_identical_blocked_successor_waits_trigger_bounded_replan() -> None:

--- a/tests/control_plane/test_goal_vision_succession.py
+++ b/tests/control_plane/test_goal_vision_succession.py
@@ -17,7 +17,6 @@ from loopx.control_plane.todos.quota_summary import (
 )
 from loopx.control_plane.todos.todo_summary import compact_todo_group
 
-
 AGENT_ID = "fixture-agent"
 
 
@@ -94,7 +93,10 @@ def test_successor_vision_replan_precedes_existing_work(
             "unclaimed_open_count": 0,
             "executable_backlog_items": [todo],
         },
-        work_lane_contract={"lane": "advancement_task", "must_attempt_work": True},
+        work_lane_contract={
+            "lane": "advancement_task",
+            "must_attempt_work": True,
+        },
         agent_id=AGENT_ID,
         existing_replan_obligation=None,
         acceptance_gaps=gaps,
@@ -153,6 +155,26 @@ def test_other_agent_work_does_not_satisfy_scoped_repeat_vision() -> None:
     assert obligation["agent_id"] == AGENT_ID
     assert obligation["triggers"][0]["kind"] == "vision_acceptance_gap"
     assert obligation["todo_actions"][0]["action"] == "add"
+
+
+def test_open_vision_projects_only_active_todo_delta_lineage() -> None:
+    active_vision = vision("vision_active")
+    active_vision["todo_delta"] = [
+        "complete:todo_previous",
+        "activate:todo_current",
+        "create:todo_successor",
+        "supersede:todo_obsolete",
+    ]
+
+    gaps = acceptance_gaps_from_agent_vision(
+        active_vision,
+        goal_status="active",
+    )
+
+    assert gaps[0]["vision_todo_ids"] == [
+        "todo_current",
+        "todo_successor",
+    ]
 
 
 def _outcome_vision(
@@ -262,7 +284,7 @@ def test_fresh_replan_checkpoint_requires_frontier_delta(
         ("2026-07-12T00:03:00Z", False),
     ],
 )
-def test_completed_todo_requires_a_later_outcome_checkpoint(
+def test_completed_todo_chain_requires_a_later_outcome_checkpoint(
     checkpoint_generated_at: str,
     expects_gap: bool,
 ) -> None:
@@ -274,10 +296,11 @@ def test_completed_todo_requires_a_later_outcome_checkpoint(
     summary = {
         "recent_completed_advancement_items": [
             {
-                "todo_id": "todo_completed_milestone",
+                "todo_id": f"todo_completed_milestone_{index}",
                 "claimed_by": AGENT_ID,
-                "completed_at": "2026-07-12T00:02:00Z",
+                "completed_at": f"2026-07-12T00:02:0{index}Z",
             }
+            for index in range(5)
         ]
     }
 
@@ -289,6 +312,121 @@ def test_completed_todo_requires_a_later_outcome_checkpoint(
     )
 
     assert bool(gaps) is expects_gap
+    if expects_gap:
+        assert gaps[0]["completed_todo_count"] == 5
+        assert gaps[0]["completed_todo_threshold"] == 5
+
+
+def test_four_completed_todos_do_not_force_a_chain_checkpoint() -> None:
+    active_vision = _outcome_vision(
+        generated_at="2026-07-12T00:01:00Z",
+        evidence_refs=["result:bounded-progress"],
+    )
+    summary = {
+        "recent_completed_advancement_items": [
+            {
+                "todo_id": f"todo_completed_slice_{index}",
+                "claimed_by": AGENT_ID,
+                "completed_at": f"2026-07-12T00:02:0{index}Z",
+            }
+            for index in range(4)
+        ]
+    }
+
+    assert (
+        acceptance_gaps_from_todo_completion_checkpoint(
+            active_vision,
+            _material_checkpoint(generated_at="2026-07-12T00:01:00Z"),
+            agent_todo_summary=summary,
+            agent_id=AGENT_ID,
+        )
+        == []
+    )
+
+
+def test_qualified_checkpoint_resets_the_completed_todo_chain() -> None:
+    active_vision = _outcome_vision(
+        generated_at="2026-07-12T00:02:00Z",
+        evidence_refs=["result:checkpointed-milestone"],
+    )
+    checkpoint = _material_checkpoint(generated_at="2026-07-12T00:02:00Z")
+    completed_at = [
+        "2026-07-12T00:01:00Z",
+        "2026-07-12T00:03:00Z",
+        "2026-07-12T00:04:00Z",
+        "2026-07-12T00:05:00Z",
+        "2026-07-12T00:06:00Z",
+    ]
+    summary = {
+        "recent_completed_advancement_items": [
+            {
+                "todo_id": f"todo_completed_slice_{index}",
+                "claimed_by": AGENT_ID,
+                "completed_at": timestamp,
+            }
+            for index, timestamp in enumerate(completed_at)
+        ]
+    }
+
+    assert (
+        acceptance_gaps_from_todo_completion_checkpoint(
+            active_vision,
+            checkpoint,
+            agent_todo_summary=summary,
+            agent_id=AGENT_ID,
+        )
+        == []
+    )
+
+
+def test_completed_chain_replan_precedes_runnable_advancement() -> None:
+    active_vision = _outcome_vision(
+        generated_at="2026-07-12T00:01:00Z",
+        evidence_refs=["result:bounded-progress"],
+    )
+    completed_items = [
+        {
+            "todo_id": f"todo_completed_slice_{index}",
+            "claimed_by": AGENT_ID,
+            "completed_at": f"2026-07-12T00:02:0{index}Z",
+        }
+        for index in range(5)
+    ]
+    gaps = acceptance_gaps_from_todo_completion_checkpoint(
+        active_vision,
+        _material_checkpoint(generated_at="2026-07-12T00:01:00Z"),
+        agent_todo_summary={
+            "recent_completed_advancement_items": completed_items,
+        },
+        agent_id=AGENT_ID,
+    )
+    runnable = {
+        "todo_id": "todo_next_slice",
+        "status": "open",
+        "task_class": "advancement_task",
+        "claimed_by": AGENT_ID,
+    }
+
+    obligation = derive_goal_frontier_replan_obligation_from_summaries(
+        user_todo_summary={"open_count": 0},
+        agent_todo_summary={
+            "open_count": 1,
+            "current_agent_claimed_open_count": 1,
+            "current_agent_claimed_advancement_count": 1,
+            "unclaimed_open_count": 0,
+            "executable_backlog_items": [runnable],
+        },
+        work_lane_contract={"lane": "advancement_task", "must_attempt_work": True},
+        agent_id=AGENT_ID,
+        existing_replan_obligation=None,
+        acceptance_gaps=gaps,
+    )
+
+    assert obligation is not None
+    trigger = obligation["triggers"][0]
+    assert trigger["kind"] == "vision_outcome_checkpoint_required"
+    assert trigger["completed_todo_count"] == 5
+    assert trigger["completed_todo_threshold"] == 5
 
 
 def test_plain_refresh_after_completed_todo_does_not_clear_checkpoint_gap() -> None:
@@ -300,10 +438,11 @@ def test_plain_refresh_after_completed_todo_does_not_clear_checkpoint_gap() -> N
     summary = {
         "recent_completed_advancement_items": [
             {
-                "todo_id": "todo_completed_milestone",
+                "todo_id": f"todo_completed_milestone_{index}",
                 "claimed_by": AGENT_ID,
-                "completed_at": "2026-07-12T00:02:00Z",
+                "completed_at": f"2026-07-12T00:02:0{index}Z",
             }
+            for index in range(5)
         ]
     }
 
@@ -456,6 +595,15 @@ def test_recent_completed_advancement_projection_is_agent_scoped() -> None:
         "todo_current_completed_7",
         "todo_current_completed_6",
         "todo_current_completed_5",
-        "todo_current_completed_4",
-        "todo_current_completed_3",
     ]
+    gaps = acceptance_gaps_from_todo_completion_checkpoint(
+        _outcome_vision(
+            generated_at="2026-07-12T00:02:00Z",
+            evidence_refs=["result:checkpointed-milestone"],
+        ),
+        _material_checkpoint(generated_at="2026-07-12T00:02:00Z"),
+        agent_todo_summary=summary,
+        agent_id=AGENT_ID,
+    )
+    assert gaps[0]["completed_todo_count"] == 5
+    assert gaps[0]["completed_todo_threshold"] == 5

--- a/tests/control_plane/test_monitor_replan_agent_scope.py
+++ b/tests/control_plane/test_monitor_replan_agent_scope.py
@@ -16,7 +16,6 @@ from loopx.control_plane.testing.quota_fixtures import (
 )
 from loopx.quota import build_quota_should_run
 
-
 GOAL_ID = "monitor-replan-agent-scope-fixture"
 AGENT_ID = "codex-quality-agent"
 PEER_AGENT_ID = "codex-delivery-peer"
@@ -267,6 +266,7 @@ def test_three_peer_status_quota_and_monitor_recommendations_stay_agent_scoped()
                     "schema_version": "goal_vision_replan_contract_v0",
                     "agent_id": AGENT_ID,
                     "state": "vision_active",
+                    "todo_delta": ["activate:todo_quality_prerequisite"],
                     "vision_patch": {
                         "acceptance_summary": (
                             "Keep quality qualification advancing until closed."
@@ -415,6 +415,9 @@ def _combined_user_frontier_guard(*, user_task_class: str) -> dict:
                     "schema_version": "goal_vision_replan_contract_v0",
                     "agent_id": AGENT_ID,
                     "state": "vision_active",
+                    "todo_delta": [
+                        "activate:todo_blocked_release_baseline"
+                    ],
                     "vision_patch": {
                         "acceptance_summary": (
                             "Keep release qualification advancing until closed."


### PR DESCRIPTION
## Summary

- require an open vision acceptance gap to identify the active Todo lineage before blocked/deferred work can suppress replanning
- traverse only explicit blocker target/successor edges, excluding unrelated deferred Todo items
- require an outcome checkpoint after five scoped advancement completions even when another runnable Todo exists
- keep the hot quota payload cap at three while evaluating the rule against the full completion history

## Validation

- 101 focused control-plane tests passed after rebasing onto latest `origin/main`
- Ruff passed on all changed Python files
- repository-configured strict mypy passed on 15 source files
- compile and git diff checks passed
- strict change-quality receipt: `cqr_2991b158ca95f06c3921`
- premerge selected 17 canaries: 16 passed; the sole `quota_should_run_json` budget failure reproduces exactly on detached `origin/main` and this branch (12,591 vs 12,550), so this diff adds zero bytes to that payload

## Scope

This PR changes outcome-continuity selection and its focused regression coverage only. It does not alter installer behavior, the recent-completion payload display cap, or begin the M7.1 typed Effect Program runtime work.