### PR TITLE
fix(ci): keep hot-path interface budgets lean when new fields are empty

### DIFF
--- a/loopx/control_plane/runtime/run_history.py
+++ b/loopx/control_plane/runtime/run_history.py
@@ -111,9 +111,10 @@ def build_run_history(
                 "subagent_activity": subagent_activity,
                 "latest_status_run": compact_run(current_run) if current_run else None,
                 "latest_runs": latest_runs,
-                "semantic_history": semantic_history,
             }
         )
+        if semantic_history is not None:
+            goals[-1]["semantic_history"] = semantic_history
 
     recent_runs = [
         compact_run(run)

--- a/loopx/control_plane/todos/quota_summary.py
+++ b/loopx/control_plane/todos/quota_summary.py
@@ -519,8 +519,9 @@ def summarize_user_todos_for_quota(
         "active_next_action_executable_items": lanes.active_next_action_executable_items,
         "backlog_items": lanes.display_open_items[:TODO_BACKLOG_ITEM_LIMIT],
         "executable_backlog_items": lanes.executable_items[:TODO_BACKLOG_ITEM_LIMIT],
-        "recent_completed_advancement_items": recent_completed_advancement_items,
     }
+    if recent_completed_advancement_items:
+        summary["recent_completed_advancement_items"] = recent_completed_advancement_items
     if blocker_items:
         summary["blocker_open_count"] = len(blocker_items)
     if current_agent_blocker_items:

--- a/loopx/control_plane/todos/todo_summary.py
+++ b/loopx/control_plane/todos/todo_summary.py
@@ -1325,11 +1325,10 @@ def compact_todo_group(
             for item in lanes.projected_deferred_items
             if item.get("resume_ready") is True
         ][:MAX_DEFERRED_TODO_VISIBILITY_ITEMS],
-        "recent_completed_advancement_items": (
-            recent_completed_advancement_items
-        ),
         "items": lanes.budgeted_items if item_limit is None else lanes.budgeted_items[:item_limit],
     }
+    if recent_completed_advancement_items:
+        summary["recent_completed_advancement_items"] = recent_completed_advancement_items
     if include_task_orchestration_authority:
         summary["task_orchestration_authority"] = _task_orchestration_authority(
             lanes,


### PR DESCRIPTION
## Summary

Recent control-plane additions (semantic history and recent completed advancement tracking) added new fields to hot-path payloads even when empty, pushing `quota_should_run_json` and `dashboard_status_json` over their interface budgets and failing Full Public Smokes.

This change keeps the hot path lean:

- `todo_summary.py` / `quota_summary.py`: only emit `recent_completed_advancement_items` when non-empty.
- `run_history.py`: only emit `semantic_history` when a compact semantic history actually exists.

## Validation

- `python3 examples/control_plane/hot-path-interface-budget-smoke.py` passes locally.
- Focused pytest suites pass: `test_goal_vision_succession`, `test_run_context_retention`, `test_quota_run_decision`, `test_quota_cli_projection`.
- `py_compile` and `git diff --check` pass.
