### PR TITLE
test(control-plane): characterize core settlement effects

### DIFF
--- a/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
+++ b/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
@@ -174,6 +174,41 @@ The public lecture series distinguishes three layers of composition:
 LoopX does not expose a generic Python middleware registry. Its around
 semantics are declarative and packet-shaped.
 
+### Bounded Kleisli Runtime Decision
+
+M7 uses Kleisli composition as an execution requirement, not as decorative
+terminology. The selected turn-closeout slice should be explainable as a
+sequence of typed steps:
+
+```text
+A => F[B]
+B => F[C]
+A => F[C]
+```
+
+For this slice, `F` must preserve a receipt-bearing result with explicit
+cancellation, permission-denial, budget-rejection, and settlement outcomes.
+Composition may be implemented with a closeout-local `bind`, `flat_map`, or
+`and_then` seam, but M7.2 must prove the semantics rather than standardize one
+method name. Its focused tests must cover:
+
+- identity: adding the typed no-op step does not change receipts or effects;
+- associativity: regrouping the same ordered steps does not change their
+  receipts, short-circuit point, or externally visible effect sequence;
+- ordered short-circuit: a typed failure prevents later effects without
+  erasing the failure kind;
+- replay: a durable receipt skips an already committed effect; and
+- non-commutativity: writeback, spend, and host handoff may not be reordered.
+
+The runtime contract has two first-class callers. The default Codex App path
+settles a normal LoopX turn through data-encoded CLI effects across agent and
+host boundaries. The isolated turn driver executes the same settlement shape
+through in-process callbacks. They should share the plan, receipt, effect
+identity, and failure algebra, but they need not share one executor because
+their authority boundaries differ. A generic `Kleisli`, middleware stack,
+executor registry, or general `Effect` monad remains premature until shared
+execution ownership, not just similar packet fields, is proven.
+
 ### Handler Is Data, Not a Callable
 
 Runtime middleware receives a `handler` callable and decides whether to call
@@ -432,30 +467,48 @@ builders compute their decisions and then map them onto `EffectTurn`. M7 must
 not react by making every state family implement one protocol. It must first
 prove that a typed effect runtime removes one real orchestration split-brain.
 
-M7.0: inventory real multi-step runtime candidates. Compare at least turn
-closeout, guided bootstrap, and quota-to-host scheduling. For each candidate,
-name the executor owner, externally visible effects, idempotency key,
-settlement receipt, partial-failure boundary, and old source of truth that
-would be deleted. Guided bootstrap is a candidate, not a preselected answer:
-some ordered steps belong to the model, user, or host and cannot safely run in
-one in-process executor.
+M7.0: inventory real multi-step runtime candidates. The selected core is
+normal-turn settlement from a stable quota decision through validated
+writeback and exactly-once spend. It has two real adapters: the default Codex
+App interaction path and the isolated turn driver. Scheduler apply and ACK
+remain delegated host handoffs. Guided bootstrap was not selected because some
+ordered steps belong to the model, user, or host; quota-to-host scheduling was
+not selected because LoopX cannot settle the external automation mutation
+itself.
 
 M7.1: characterize the selected vertical slice before adding a protocol.
 Capture parity fixtures for legal and illegal transitions, partial execution,
-retry, cancellation, permission denial, budget rejection, and settlement.
+retry, cancellation, permission denial, budget rejection, and settlement. The
+durable transfer must include cancellation at writeback and scheduler handoff,
+permission denial at host execution and quota spend, and spend-budget
+rejection after writeback. This stage preserves current runtime behavior,
+including any split projection that M7.2 is expected to repair. It must also
+characterize the default Codex App selection-drift seam: after the selected
+Todo is completed and writeback advances the frontier, spend must still settle
+the original effect identity rather than bind to a newly selected successor.
 
-M7.2: replace that slice with one typed plan/receipt path. A plan step must
-carry a stable kind, owner, precondition, idempotency identity, and expected
-receipt. Raw mappings and free-form CLI commands may remain compatibility
-payloads, but they are not the semantic execution contract. Delete the old
-builder or settlement path in the same stage.
+M7.2: replace the core settlement truth with one typed plan/receipt algebra. A
+plan step must carry a stable kind, owner, precondition, idempotency identity,
+and expected receipt. First, make the default Codex App path bind completion,
+refresh, and spend to the original quota-turn effect identity instead of a
+fresh Todo selection. Then make the isolated turn driver consume the same
+algebra. Each replacement PR must delete its corresponding manual command or
+settlement truth. Raw mappings and free-form CLI commands may remain
+compatibility payloads, but they are not the semantic execution contract. The
+composition must satisfy the identity, associativity, short-circuit, replay,
+and ordering properties defined above, keep cancellation, permission denial,
+and budget rejection distinct, and leave scheduler apply or ACK outside the
+agent-owned settlement boundary.
 
-M7.3: generalize only after a second runtime caller needs the proven plan and
-receipt semantics. At that point, extract the smallest shared interpreter or
-executor protocol; do not add a registry or generic composition framework.
-`quota should-run` may derive both its packet and effect projection from one
-canonical decision plan, but constructing `EffectTurn` earlier is not itself
-an acceptance condition.
+M7.3: after both M7.2 adapters consume the proven plan and receipt semantics,
+compare their execution ownership. Extract the smallest shared executor or
+Kleisli-like bind protocol only if it deletes duplicate orchestration without
+crossing the Codex App agent/host boundary. Do not add a registry or generic
+composition framework. `quota should-run` may derive both its packet and
+effect projection from one canonical decision plan, but constructing
+`EffectTurn` earlier is not itself an acceptance condition. If the two callers
+share only the algebra and not an executor boundary, close M7.3 with a
+structured no-follow-up decision and keep their executors local.
 
 M7.4: expand one bounded family at a time only when it removes duplicate
 knowledge. Todo, monitor, capability, scheduler, and gate state machines keep

--- a/tests/control_plane/test_quota_slot_accounting.py
+++ b/tests/control_plane/test_quota_slot_accounting.py
@@ -11,7 +11,6 @@ from loopx.control_plane.quota.slot_accounting import (
     build_quota_slot_spend_event,
 )
 
-
 GOAL_ID = "quota-slot-accounting-fixture"
 AGENT_A = "codex-monitor-a"
 AGENT_B = "codex-monitor-b"
@@ -520,6 +519,45 @@ def test_heartbeat_spend_rejects_mismatched_todo_binding(tmp_path: Path) -> None
 
     assert preview["ok"] is False
     assert "binding mismatch" in preview["reason"]
+
+
+def test_heartbeat_spend_reselection_strands_completed_todo_settlement(
+    tmp_path: Path,
+) -> None:
+    runtime = tmp_path / "runtime"
+    _write_run_index(
+        runtime,
+        [
+            _run(
+                "2026-01-01T00:01:00+00:00",
+                classification="validated_progress",
+                delivery_outcome="outcome_progress",
+            )
+        ],
+    )
+    before = _normal_run_before(todo_id="todo_new_successor")
+
+    preview = build_quota_slot_preview_for_decision(
+        _normal_run_status(runtime),
+        goal_id=GOAL_ID,
+        before=before,
+        after_decision=lambda _: {
+            **before,
+            "quota": {**before["quota"], "spent_slots": 1},
+        },
+        quota_status_builder=lambda goal, **_: goal["quota"],
+        self_repair_spend_actions=frozenset(),
+        agent_id=None,
+        todo_id="todo_completed_delivery",
+        source="heartbeat",
+    )
+
+    # M7.1 characterizes the current split-brain: an accountable delivery is
+    # present, but spend rebinds against a fresh selection instead of the
+    # original turn identity. M7.2 replaces this behavior.
+    assert preview["ok"] is False
+    assert "selected todo is todo_new_successor" in preview["reason"]
+    assert "--todo-id is todo_completed_delivery" in preview["reason"]
 
 
 def test_heartbeat_spend_records_matching_todo_binding(tmp_path: Path) -> None:

--- a/tests/test_loopx_turn_executor.py
+++ b/tests/test_loopx_turn_executor.py
@@ -577,6 +577,251 @@ def test_run_once_resumes_after_writeback_without_duplicate_effects(tmp_path: Pa
     assert calls == {"writeback": 1, "spend": 1, "scheduler": 1}
 
 
+def test_cancellation_before_writeback_preserves_prefix_and_resumes(
+    tmp_path: Path,
+) -> None:
+    plan = _plan()
+    calls = {"host": 0, "writeback": 0, "spend": 0}
+
+    def host(_request: dict[str, object]) -> dict[str, object]:
+        calls["host"] += 1
+        return _host_result(plan)
+
+    def cancelled_writeback(_result: dict[str, object]) -> dict[str, object]:
+        calls["writeback"] += 1
+        raise KeyboardInterrupt
+
+    common = {
+        "host_runner": host,
+        "project": tmp_path,
+        "runtime_root": tmp_path / "runtime",
+        "goal_id": "fixture-goal",
+        "timeout_seconds": 5,
+        "execute": True,
+        "task_validator": _passing_validator,
+        "spend": lambda: calls.__setitem__("spend", calls["spend"] + 1)
+        or {"ok": True, "appended": True},
+        "scheduler": lambda _spend: {"completed": True, "acknowledged": True},
+    }
+    with pytest.raises(KeyboardInterrupt):
+        run_loopx_turn_once(plan, writeback=cancelled_writeback, **common)
+
+    assert _journal(tmp_path / "runtime")["completed_phases"] == [
+        "host_execute",
+        "typed_result",
+        "validation",
+    ]
+    recovered = run_loopx_turn_once(
+        plan,
+        writeback=lambda _result: calls.__setitem__(
+            "writeback", calls["writeback"] + 1
+        )
+        or {"ok": True, "appended": True},
+        **common,
+    )
+
+    assert recovered["status"] == "committed"
+    assert calls == {"host": 1, "writeback": 2, "spend": 1}
+
+
+def test_cancellation_during_scheduler_preserves_settlement_and_resumes(
+    tmp_path: Path,
+) -> None:
+    plan = _plan()
+    calls = {"host": 0, "writeback": 0, "spend": 0, "scheduler": 0}
+
+    def host(_request: dict[str, object]) -> dict[str, object]:
+        calls["host"] += 1
+        return _host_result(plan)
+
+    def writeback(_result: dict[str, object]) -> dict[str, object]:
+        calls["writeback"] += 1
+        return {"ok": True, "appended": True}
+
+    def spend() -> dict[str, object]:
+        calls["spend"] += 1
+        return {"ok": True, "appended": True}
+
+    def cancelled_scheduler(_spend: dict[str, object]) -> dict[str, object]:
+        calls["scheduler"] += 1
+        raise KeyboardInterrupt
+
+    common = {
+        "host_runner": host,
+        "project": tmp_path,
+        "runtime_root": tmp_path / "runtime",
+        "goal_id": "fixture-goal",
+        "timeout_seconds": 5,
+        "execute": True,
+        "task_validator": _passing_validator,
+        "writeback": writeback,
+        "spend": spend,
+    }
+    with pytest.raises(KeyboardInterrupt):
+        run_loopx_turn_once(plan, scheduler=cancelled_scheduler, **common)
+
+    assert _journal(tmp_path / "runtime")["completed_phases"] == [
+        "host_execute",
+        "typed_result",
+        "validation",
+        "durable_writeback",
+        "quota_spend",
+    ]
+
+    def healthy_scheduler(_spend: dict[str, object]) -> dict[str, object]:
+        calls["scheduler"] += 1
+        return {"completed": True, "acknowledged": True}
+
+    recovered = run_loopx_turn_once(plan, scheduler=healthy_scheduler, **common)
+
+    assert recovered["status"] == "committed"
+    assert calls == {"host": 1, "writeback": 1, "spend": 1, "scheduler": 2}
+
+
+def test_permission_denial_from_host_is_typed_and_explicitly_retried(
+    tmp_path: Path,
+) -> None:
+    plan = _plan()
+    calls = {"host": 0, "writeback": 0, "spend": 0}
+
+    def host(_request: dict[str, object]) -> dict[str, object]:
+        calls["host"] += 1
+        if calls["host"] == 1:
+            raise PermissionError("host denied")
+        return _host_result(plan)
+
+    common = {
+        "host_runner": host,
+        "project": tmp_path,
+        "runtime_root": tmp_path / "runtime",
+        "goal_id": "fixture-goal",
+        "timeout_seconds": 5,
+        "execute": True,
+        "task_validator": _passing_validator,
+        "writeback": lambda _result: calls.__setitem__(
+            "writeback", calls["writeback"] + 1
+        )
+        or {"ok": True, "appended": True},
+        "spend": lambda: calls.__setitem__("spend", calls["spend"] + 1)
+        or {"ok": True, "appended": True},
+        "scheduler": lambda _spend: {"completed": True, "acknowledged": True},
+    }
+    failed = run_loopx_turn_once(plan, **common)
+    replayed = run_loopx_turn_once(plan, **common)
+    recovered = run_loopx_turn_once(plan, retry_failed=True, **common)
+
+    assert failed["result_kind"] == "host_failure"
+    assert failed["receipt"]["failed_phase"] == "host_execute"
+    assert failed["reason"] == "PermissionError"
+    assert replayed["replayed"] is True
+    assert recovered["status"] == "committed"
+    assert calls == {"host": 2, "writeback": 1, "spend": 1}
+
+
+def test_permission_denial_during_spend_preserves_writeback_and_resumes(
+    tmp_path: Path,
+) -> None:
+    plan = _plan()
+    calls = {"host": 0, "writeback": 0, "spend": 0}
+
+    def host(_request: dict[str, object]) -> dict[str, object]:
+        calls["host"] += 1
+        return _host_result(plan)
+
+    def writeback(_result: dict[str, object]) -> dict[str, object]:
+        calls["writeback"] += 1
+        return {"ok": True, "appended": True}
+
+    def denied_spend() -> dict[str, object]:
+        calls["spend"] += 1
+        raise PermissionError("quota ledger denied")
+
+    common = {
+        "host_runner": host,
+        "project": tmp_path,
+        "runtime_root": tmp_path / "runtime",
+        "goal_id": "fixture-goal",
+        "timeout_seconds": 5,
+        "execute": True,
+        "task_validator": _passing_validator,
+        "writeback": writeback,
+        "scheduler": lambda _spend: {"completed": True, "acknowledged": True},
+    }
+    with pytest.raises(PermissionError):
+        run_loopx_turn_once(plan, spend=denied_spend, **common)
+
+    assert _journal(tmp_path / "runtime")["completed_phases"] == [
+        "host_execute",
+        "typed_result",
+        "validation",
+        "durable_writeback",
+    ]
+    recovered = run_loopx_turn_once(
+        plan,
+        spend=lambda: calls.__setitem__("spend", calls["spend"] + 1)
+        or {"ok": True, "appended": True},
+        **common,
+    )
+
+    assert recovered["status"] == "committed"
+    assert calls == {"host": 1, "writeback": 1, "spend": 2}
+
+
+def test_budget_rejection_is_typed_and_retry_does_not_repeat_writeback(
+    tmp_path: Path,
+) -> None:
+    plan = _plan()
+    calls = {"host": 0, "writeback": 0, "spend": 0}
+
+    def host(_request: dict[str, object]) -> dict[str, object]:
+        calls["host"] += 1
+        return _host_result(plan)
+
+    def writeback(_result: dict[str, object]) -> dict[str, object]:
+        calls["writeback"] += 1
+        return {"ok": True, "appended": True}
+
+    def reject_budget() -> dict[str, object]:
+        calls["spend"] += 1
+        return {
+            "ok": False,
+            "appended": False,
+            "reason": "quota budget rejected",
+        }
+
+    common = {
+        "host_runner": host,
+        "project": tmp_path,
+        "runtime_root": tmp_path / "runtime",
+        "goal_id": "fixture-goal",
+        "timeout_seconds": 5,
+        "execute": True,
+        "task_validator": _passing_validator,
+        "writeback": writeback,
+        "scheduler": lambda _spend: {"completed": True, "acknowledged": True},
+    }
+    failed = run_loopx_turn_once(plan, spend=reject_budget, **common)
+
+    # Preserve the current M7.1 characterization. M7.2 must replace this split
+    # with one canonical typed settlement result rather than changing it here.
+    assert failed["result_kind"] == "validated_progress"
+    assert failed["receipt"]["result_kind"] == "quota_spend_failed"
+    assert failed["receipt"]["failed_phase"] == "quota_spend"
+    assert failed["effects"]["state_written"] is True
+    assert failed["effects"]["quota_spent"] is False
+
+    recovered = run_loopx_turn_once(
+        plan,
+        spend=lambda: calls.__setitem__("spend", calls["spend"] + 1)
+        or {"ok": True, "appended": True},
+        retry_failed=True,
+        **common,
+    )
+
+    assert recovered["status"] == "committed"
+    assert calls == {"host": 1, "writeback": 1, "spend": 2}
+
+
 def test_run_once_fails_closed_without_independent_task_validator(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- formalize cancellation, permission-denial, and budget-rejection settlement fixtures as five durable turn-closeout cases
- characterize the default Codex App selection-drift seam where a completed Todo cannot settle after the frontier advances
- replan M7 around one typed settlement algebra with Codex App and isolated turn-driver adapters, while keeping scheduler mutation as a host handoff

This PR intentionally preserves runtime behavior. M7.2 owns the typed plan/receipt replacement and deletion of the corresponding manual settlement truths.

## Validation

- 113 focused tests passed
- Ruff passed on changed Python tests
- configured strict mypy passed (15 source files)
- LoopX premerge passed: 4 direct checks, 4 catalog canaries, 8 risk-profile smokes, 1 public/private boundary scan
- change-quality receipt: `cqr_2a098efb31bb6e4b9f8b`
- no failures, warnings, skips, or manual holds
