### PR TITLE
fix(ci): restore frontstage Pages build

### DIFF
--- a/.github/workflows/frontstage-pages.yml
+++ b/.github/workflows/frontstage-pages.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Validate public showcase catalog
         run: python3 examples/showcase-catalog-smoke.py
 
-- name: Validate README star history
+      - name: Validate README star history
         run: python3 examples/readme-star-history-smoke.py
 
       - name: Validate Developer Book publication

--- a/docs/guides/minimal-custom-runtime-example.md
+++ b/docs/guides/minimal-custom-runtime-example.md
@@ -85,4 +85,4 @@ shell, Grok Build, or other cooperative hosts.
 - [Custom agent runner integration](custom-agent-runner-integration.md)
 - [Runtime connector catalog](../integrations/runtime-connector-catalog.md)
 - [Host integration surface v0](../reference/protocols/host-integration-surface-v0.md)
-- [LoopX Turn fake-host walkthrough smoke](../../examples/loopx-turn-fake-host-walkthrough-smoke.py)
+- [LoopX Turn fake-host walkthrough smoke](https://github.com/huangruiteng/loopx/blob/main/examples/loopx-turn-fake-host-walkthrough-smoke.py)

--- a/docs/guides/minimal-custom-runtime-example.zh-CN.md
+++ b/docs/guides/minimal-custom-runtime-example.zh-CN.md
@@ -80,4 +80,4 @@ python3 examples/loopx-turn-fake-host-walkthrough-smoke.py
 - [Custom agent runner integration](custom-agent-runner-integration.md)
 - [Runtime connector catalog](../integrations/runtime-connector-catalog.md)
 - [Host integration surface v0](../reference/protocols/host-integration-surface-v0.md)
-- [LoopX Turn fake-host walkthrough smoke](../../examples/loopx-turn-fake-host-walkthrough-smoke.py)
+- [LoopX Turn fake-host walkthrough smoke](https://github.com/huangruiteng/loopx/blob/main/examples/loopx-turn-fake-host-walkthrough-smoke.py)


### PR DESCRIPTION
Restores the frontstage-pages workflow so the public docs and Developer Book pipeline can run again on main.

- Restore YAML indentation for the README star history step so the workflow can start.
- Link the fake-host walkthrough smoke in both custom-runtime guides to a GitHub blob so `mkdocs build --strict` no longer aborts on unresolved documentation links.
- Verified locally with `yaml.safe_load`, `mkdocs build --strict`, `frontstage-pages-workflow-smoke.py`, `docs-governance-smoke.py`, and `dev-book-publication-smoke.py`.