### PR TITLE
docs: promote Developer Book entries across public surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) [![Release](https://img.shields.io/github/v/release/huangruiteng/loopx?display_name=tag)](https://github.com/huangruiteng/loopx/releases/latest) [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/XmGgQyCFZd) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](pyproject.toml) [![Local first](https://img.shields.io/badge/control--plane-local--first-brightgreen.svg)](docs/public-private-boundary.md) [![Loop Agents](https://img.shields.io/badge/status-loop%20agents%20early-orange.svg)](docs/product/release-readiness.md)
 
-[Public website](https://huangruiteng.github.io/loopx/) · [Docs](https://huangruiteng.github.io/loopx/docs/) · [Try LoopX](#try-loopx) · [See real loops](#evidence) · [How it works](#why-loopx) · [User manual](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [简体中文](README.zh-CN.md)
+[Public website](https://huangruiteng.github.io/loopx/) · [Docs](https://huangruiteng.github.io/loopx/docs/) · [Developer Book](https://huangruiteng.github.io/loopx/docs/book/) · [Try LoopX](#try-loopx) · [See real loops](#evidence) · [How it works](#why-loopx) · [User manual](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [简体中文](README.zh-CN.md)
 
 **把会干活的 Agent，接成可管理、可复盘、可持续改进的数字员工。**
 
@@ -28,6 +28,12 @@ replacing the runtime that performs the work.
 **Loop engineering for long-running AI agents and peer agent teams.**
 
 > Keep the loop moving. Keep the judgment human.
+
+## Learn LoopX
+
+- **Developer Book** - the curated bilingual path from control-plane foundations to project onboarding and developer contributions. [中文版](https://huangruiteng.github.io/loopx/docs/book/) · [English](https://huangruiteng.github.io/loopx/docs/book/en/)
+- **Getting started** - install, connect a project, and run your first governed loop. [Guide](docs/guides/getting-started.md)
+- **Docs** - the full reference and operations site. [LoopX Docs](https://huangruiteng.github.io/loopx/docs/)
 
 <a id="how-it-works"></a>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,7 +12,7 @@
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) [![Release](https://img.shields.io/github/v/release/huangruiteng/loopx?display_name=tag)](https://github.com/huangruiteng/loopx/releases/latest) [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/XmGgQyCFZd) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](pyproject.toml) [![Local first](https://img.shields.io/badge/control--plane-local--first-brightgreen.svg)](docs/public-private-boundary.md) [![Loop Agents](https://img.shields.io/badge/status-loop%20agents%20early-orange.svg)](docs/product/release-readiness.md)
 
-[产品首页](https://huangruiteng.github.io/loopx/) · [文档](https://huangruiteng.github.io/loopx/docs/) · [试用 LoopX](#试用-loopx) · [查看真实 Loop](#证据) · [理解工作原理](#为什么需要-loopx) · [用户手册](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [English](README.md)
+[产品首页](https://huangruiteng.github.io/loopx/) · [文档](https://huangruiteng.github.io/loopx/docs/) · [开发者手册](https://huangruiteng.github.io/loopx/docs/book/) · [试用 LoopX](#试用-loopx) · [查看真实 Loop](#证据) · [理解工作原理](#为什么需要-loopx) · [用户手册](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [English](README.md)
 
 **把会干活的 Agent，接成可管理、可复盘、可持续改进的数字员工。**
 
@@ -25,6 +25,12 @@ LoopX 是开放且 Provider-neutral 的轻量 state kernel，也是 local-first
 跨轮次、跨工具、跨 agent 的工作可审阅、可恢复、可接力。
 
 > 让 Loop 持续向前，让关键判断留在人手里。
+
+## 学习 LoopX
+
+- **开发者手册** - 从控制面基础到项目接入和开发者贡献的双语学习路径。[简体中文](https://huangruiteng.github.io/loopx/docs/book/) · [English](https://huangruiteng.github.io/loopx/docs/book/en/)
+- **快速开始** - 安装、连接项目并运行第一个受治理的 Loop。[指南](docs/guides/getting-started.md)
+- **文档站** - 完整参考与运维文档。[LoopX Docs](https://huangruiteng.github.io/loopx/docs/)
 
 ## 为什么需要 LoopX
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -11,41 +11,46 @@ not need these documents to start LoopX.
 
 1. Read [Contributing](https://github.com/huangruiteng/loopx/blob/main/CONTRIBUTING.md) for repository boundaries and the
    pull-request checklist.
-2. Follow the [control-plane developer course](control-plane-course/README.md)
+2. Follow the [Developer Book](/loopx/docs/book/) for the curated external
+   learning path from control-plane foundations to project onboarding and
+   developer contributions.
+3. Follow the [control-plane developer course](control-plane-course/README.md)
    for a nine-lecture, code-led path through the real CLI, state machine, and
    layered quality gates.
-3. Read [Testing and quality](testing-and-quality.md) before changing agent-facing
+4. Read [Testing and quality](testing-and-quality.md) before changing agent-facing
    output, scheduler decisions, todo/gate semantics, onboarding, or release
    promotion.
-4. Use [What counts as a good smoke](good-smokes.md) before adding, retaining,
+5. Use [What counts as a good smoke](good-smokes.md) before adding, retaining,
    or consolidating a public smoke.
-5. Use [Architecture](../architecture.md) and the
+6. Use [Architecture](../architecture.md) and the
    [core control-plane graphs](../product/core-control-plane/README.md) to find
    the bounded context that owns the behavior.
-6. Check [Public/private boundaries](../public-private-boundary.md) before adding
+7. Check [Public/private boundaries](../public-private-boundary.md) before adding
    fixtures, examples, evidence, or provider-backed evaluation.
-7. Follow the [documentation layout policy](documentation-layout.md) before
+8. Follow the [documentation layout policy](documentation-layout.md) before
    adding or moving public documentation.
 
 1. 先阅读[贡献指南](https://github.com/huangruiteng/loopx/blob/main/CONTRIBUTING.md)，了解仓库边界和 PR 检查项。
-2. 按顺序学习[控制面开发者 9 讲](control-plane-course/README.md)，沿真实 CLI、
+2. 按顺序阅读[开发者手册](/loopx/docs/book/)，从控制面基础到项目接入和开发者贡献。
+3. 按顺序学习[控制面开发者 9 讲](control-plane-course/README.md)，沿真实 CLI、
    状态机、核心函数和分层质量门禁建立代码心智模型。
-3. 修改 agent-facing 输出、调度决策、todo/gate 语义、新用户接入或发布流程前，
+4. 修改 agent-facing 输出、调度决策、todo/gate 语义、新用户接入或发布流程前，
    阅读[测试与质量体系](testing-and-quality.md)。
-4. 新增、保留或合并公开 smoke 前，阅读
+5. 新增、保留或合并公开 smoke 前，阅读
    [什么是好的 Smoke](good-smokes.md)。
-5. 通过[架构文档](../architecture.md)和
+6. 通过[架构文档](../architecture.md)和
    [控制面核心图](../product/core-control-plane/README.md)定位真正拥有该行为的
    bounded context。
-6. 添加 fixture、示例、证据或模型测试前，检查
+7. 添加 fixture、示例、证据或模型测试前，检查
    [公开/私有边界](../public-private-boundary.md)。
-7. 新增或移动公开文档前，遵循
+8. 新增或移动公开文档前，遵循
    [文档布局规则](documentation-layout.md)。
 
 ## Core References / 核心参考
 
 | Area / 领域 | Reference / 文档 |
 | --- | --- |
+| Curated learning path / 开发者学习路径 | [Developer Book](/loopx/docs/book/) |
 | Control-plane code reading / 控制面代码领读 | [Nine-lecture developer course](control-plane-course/README.md) |
 | Quality layers and commands / 质量分层与命令 | [Testing and quality](testing-and-quality.md) |
 | Durable smoke design and cleanup / 稳定 Smoke 的设计与清理 | [What counts as a good smoke](good-smokes.md) |

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -10,6 +10,9 @@ If you are new to LoopX, start with the shorter
 surface to the host LoopX task entry, project connection, and one manual CLI
 quickstart. This page keeps the full operator and contributor detail.
 
+For the curated learning path, start with the
+[Developer Book](/loopx/docs/book/) before moving into the full guide.
+
 ## Codex App And Other Agent Setup
 
 If you already use Codex, Claude Code, Cursor, or another terminal agent, paste

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,10 @@ LoopX is the local control plane for long-running AI agent work. It keeps
 objectives, gates, todos, evidence, quota, and handoffs stable while Codex,
 Claude Code, OpenCode, Cursor, or a custom runner executes bounded turns.
 
+New to LoopX? Start with the
+[Developer Book](/loopx/docs/book/) for a curated bilingual path, or
+[Getting started](guides/getting-started.md) to run your first loop.
+
 ## Choose Your Path
 
 <div class="grid cards" markdown>


### PR DESCRIPTION
Make the Developer Book discoverable from the surfaces new users actually open first.

Changes:
- Add `Developer Book` / `开发者手册` to the README top navigation and a new `Learn LoopX` / `学习 LoopX` section above `Why LoopX`.
- Add a `New to LoopX? Start with the Developer Book` callout on the docs home page.
- Link the Developer Book from Getting Started and the developer guide start path and core reference table.

Validation:
- `python3 examples/dev-book-publication-smoke.py`
- `python3 examples/docs-governance-smoke.py`
- `python3 examples/frontstage-pages-workflow-smoke.py`
- `mkdocs build --strict`
- First-viewport preview approved by the owner.