### PR TITLE
feat(quota): add typed Codex App settlement

### DIFF
--- a/loopx/cli_commands/project_lifecycle.py
+++ b/loopx/cli_commands/project_lifecycle.py
@@ -15,6 +15,11 @@ from ..control_plane.agents.capability_gate import (
 from ..control_plane.goals.goal_vision_policy import (
     GOAL_VISION_ADVANCEMENT_POLICY_CHOICES,
 )
+from ..control_plane.quota.settlement import (
+    require_settlement_writeback,
+    resolve_heartbeat_settlement_identity,
+    settlement_result_payload,
+)
 from ..control_plane.work_items.delivery_batch_scale import (
     DELIVERY_BATCH_SCALE_INPUT_CHOICES,
 )
@@ -212,6 +217,20 @@ def register_project_lifecycle_commands(
             "Local git worktree that produced this accountable delivery. Use when "
             "refresh-state must run from a separate registry checkout; the local "
             "path is validated but is not persisted."
+        ),
+    )
+    refresh_state_parser.add_argument(
+        "--todo-id",
+        help=(
+            "Selected Todo from the original turn-scoped quota guard. Requires "
+            "--turn-instance-id and an accountable delivery outcome."
+        ),
+    )
+    refresh_state_parser.add_argument(
+        "--turn-instance-id",
+        help=(
+            "Stable quota guard turn id for settlement writeback. Reuse the same "
+            "value on retries."
         ),
     )
     refresh_state_parser.add_argument(
@@ -537,6 +556,8 @@ def handle_project_lifecycle_command(
                     if args.delivery_workspace_path
                     else None
                 ),
+                todo_id=getattr(args, "todo_id", None),
+                turn_instance_id=getattr(args, "turn_instance_id", None),
                 agent_id=args.agent_id,
                 agent_lane=args.agent_lane,
                 progress_scope=args.progress_scope,
@@ -567,14 +588,34 @@ def handle_project_lifecycle_command(
         payload["external_sink_delivery_authorized"] = not bool(
             args.suppress_external_sinks
         )
-        if payload.get("ok") and payload.get("appended") and not payload.get("dry_run"):
+        material_refresh_ready = bool(
+            payload.get("ok")
+            and (
+                payload.get("appended")
+                or payload.get("idempotent_replay")
+            )
+            and not payload.get("dry_run")
+        )
+        settlement_receipt_repair = bool(
+            payload.get("ok")
+            and payload.get("receipt_repair_required")
+            and getattr(args, "turn_instance_id", None)
+            and getattr(args, "todo_id", None)
+        )
+        if material_refresh_ready or settlement_receipt_repair:
             append_cli_rollout_event(
                 payload,
                 registry_path=registry_path,
                 runtime_root_arg=args.runtime_root,
                 event_kind="refresh_state",
                 agent_id=args.agent_id,
-                status="appended",
+                todo_id=getattr(args, "todo_id", None),
+                run_id=getattr(args, "turn_instance_id", None),
+                status=(
+                    "receipt_repaired"
+                    if settlement_receipt_repair
+                    else "appended"
+                ),
                 summary=(
                     "refresh-state appended compact control-plane state with "
                     f"classification={payload.get('classification')}"
@@ -590,8 +631,52 @@ def handle_project_lifecycle_command(
                         isinstance(payload.get("global_sync"), dict)
                         and payload["global_sync"].get("wrote")
                     ),
+                    "settlement_effect_id": (
+                        payload.get("settlement_identity", {}).get("effect_id")
+                        if isinstance(payload.get("settlement_identity"), dict)
+                        else None
+                    ),
                 },
+                idempotency_fields=(
+                    ["goal_id", "event_kind", "agent_id", "todo_id", "run_id"]
+                    if getattr(args, "turn_instance_id", None)
+                    else None
+                ),
             )
+            if getattr(args, "turn_instance_id", None) and getattr(
+                args,
+                "todo_id",
+                None,
+            ):
+                runtime_root = resolve_runtime_root(
+                    load_registry(registry_path),
+                    args.runtime_root,
+                )
+                settlement_result = resolve_heartbeat_settlement_identity(
+                    runtime_root,
+                    goal_id=args.goal_id,
+                    agent_id=args.agent_id,
+                    todo_id=getattr(args, "todo_id", None),
+                    turn_instance_id=getattr(args, "turn_instance_id", None),
+                ).bind(
+                    lambda identity: require_settlement_writeback(
+                        runtime_root,
+                        identity,
+                    )
+                )
+                payload["settlement_result"] = settlement_result_payload(
+                    settlement_result
+                )
+                if settlement_result.failure is not None:
+                    payload["ok"] = False
+                    payload["receipt_repair_required"] = True
+                    payload["error"] = settlement_result.failure.reason
+                elif settlement_receipt_repair:
+                    payload["receipt_repair_required"] = False
+                    payload["receipt_repaired"] = True
+            if not material_refresh_ready:
+                print_payload(payload, fmt, render_state_refresh_markdown)
+                return 0 if payload.get("ok") else 1
             graph_sync = sync_explore_graph_after_material_refresh(
                 registry_path=registry_path,
                 goal_id=args.goal_id,

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -20,6 +20,12 @@ from ..control_plane.quota.monitor_poll import find_quota_monitor_poll_turn
 from ..control_plane.quota.scheduler_ack import (
     record_quota_scheduler_failure_for_decision,
 )
+from ..control_plane.quota.settlement import (
+    require_settlement_spend,
+    require_settlement_writeback,
+    resolve_heartbeat_settlement_identity,
+    settlement_result_payload,
+)
 from ..control_plane.quota.spend_sources import (
     DEFAULT_SLOT_SPEND_SOURCE,
     VALID_SLOT_SPEND_SOURCES,
@@ -35,6 +41,7 @@ from ..control_plane.scheduler.execution_context import (
     SchedulerRuntimeProfile,
     scheduler_execution_context_for_runtime_profile,
 )
+from ..control_plane.todos.contract import normalize_todo_id
 from ..file_lock import lock_timeout_error_fields
 from ..presentation.renderers.quota_event_markdown import (
     render_quota_monitor_poll_markdown,
@@ -279,9 +286,9 @@ def register_quota_command(subparsers: argparse._SubParsersAction) -> None:
     quota_parser.add_argument(
         "--turn-instance-id",
         help=(
-            "Stable heartbeat trigger id for `quota should-run`. The command "
-            "persists one idempotent receipt and, for a quiet no-progress "
-            "decision, its stall observation. Reuse the same id on retries."
+            "Stable heartbeat settlement id for `quota should-run` and "
+            "`quota spend-slot`. The guard persists one idempotent receipt; "
+            "reuse the same id through writeback, spend, and retries."
         ),
     )
     quota_parser.add_argument("--slots", type=int, default=1, help="Slots to account for `quota spend-slot`.")
@@ -398,11 +405,14 @@ def _prepare_quota_command_context(
     heartbeat_turn_id = normalize_turn_instance_id(
         getattr(args, "turn_instance_id", None)
     )
-    if heartbeat_turn_id and command != "should-run":
-        raise ValueError("--turn-instance-id is only valid with `quota should-run`")
+    if heartbeat_turn_id and command not in {"should-run", "spend-slot"}:
+        raise ValueError(
+            "--turn-instance-id is only valid with `quota should-run` or "
+            "`quota spend-slot`"
+        )
     if heartbeat_turn_id and not args.agent_id:
-        raise ValueError("turn-scoped `quota should-run` requires --agent-id")
-    if heartbeat_turn_id and bool(args.dry_run):
+        raise ValueError("turn-scoped quota settlement requires --agent-id")
+    if heartbeat_turn_id and command == "should-run" and bool(args.dry_run):
         raise ValueError("turn-scoped `quota should-run` cannot use --dry-run")
 
     scan_roots = [Path(item).expanduser() for item in args.scan_path]
@@ -583,6 +593,100 @@ def _quota_renderer(
         "spend-slot": render_quota_slot_preview_markdown,
         "void-slot": render_quota_slot_preview_markdown,
     }.get(command, render_quota_markdown)
+
+
+def _quota_rollout_todo_id(
+    payload: Mapping[str, object],
+    args: argparse.Namespace,
+) -> str | None:
+    selected_todo = (
+        payload.get("selected_todo")
+        if isinstance(payload.get("selected_todo"), Mapping)
+        else {}
+    )
+    return (
+        normalize_todo_id(payload.get("todo_id"))
+        or normalize_todo_id(selected_todo.get("todo_id"))
+        or normalize_todo_id(args.todo_id)
+    )
+
+
+def _quota_rollout_details(
+    payload: Mapping[str, object],
+    args: argparse.Namespace,
+    *,
+    todo_id: str | None,
+) -> dict[str, object]:
+    successor_todo_ids = (
+        payload.get("successor_todo_ids")
+        if isinstance(payload.get("successor_todo_ids"), list)
+        else []
+    )
+    return {
+        "command": "quota",
+        "quota_command": args.quota_command,
+        "ok": bool(payload.get("ok")),
+        "should_run": bool(payload.get("should_run")),
+        "appended": bool(payload.get("appended")),
+        "slots": payload.get("slots") or "",
+        "source": payload.get("source") or "",
+        "todo_id": todo_id or "",
+        "target_key": payload.get("target_key") or "",
+        "successor_todo_ids": ",".join(
+            str(successor_id)
+            for successor_id in successor_todo_ids
+            if str(successor_id).strip()
+        ),
+        "applied_rrule": payload.get("applied_rrule") or "",
+        "settlement_effect_id": (
+            payload.get("settlement_identity", {}).get("effect_id")
+            if isinstance(payload.get("settlement_identity"), Mapping)
+            else ""
+        ),
+    }
+
+
+def _attach_spend_settlement_result(
+    payload: dict[str, object],
+    *,
+    runtime_root: Path,
+    goal_id: str,
+    agent_id: str | None,
+    todo_id: str | None,
+    turn_instance_id: str,
+) -> None:
+    guard_result = resolve_heartbeat_settlement_identity(
+        runtime_root,
+        goal_id=goal_id,
+        agent_id=agent_id,
+        todo_id=todo_id,
+        turn_instance_id=turn_instance_id,
+    )
+    identity = guard_result.value
+    if identity is None:
+        settlement_result = guard_result
+    else:
+        settlement_result = guard_result.bind(
+            lambda resolved: require_settlement_writeback(
+                runtime_root,
+                resolved,
+            )
+        ).bind(
+            lambda _writeback: require_settlement_spend(
+                runtime_root,
+                identity,
+            )
+        )
+    payload["settlement_result"] = settlement_result_payload(
+        settlement_result
+    )
+    if settlement_result.failure is not None:
+        payload["ok"] = False
+        payload["receipt_repair_required"] = True
+        payload["reason"] = settlement_result.failure.reason
+    elif payload.get("receipt_repair_required"):
+        payload["receipt_repair_required"] = False
+        payload["receipt_repaired"] = True
 
 
 def handle_quota_command(
@@ -801,6 +905,7 @@ def handle_quota_command(
                 available_capabilities=args.available_capabilities,
                 operator_inbox_urgency_projector=operator_inbox_urgency_projector,
                 todo_id=args.todo_id,
+                turn_instance_id=heartbeat_turn_id,
             )
         elif args.quota_command == "void-slot":
             payload = void_quota_slot(
@@ -826,30 +931,21 @@ def handle_quota_command(
         )
     should_log_quota = args.quota_command in QUOTA_EVENT_KINDS and (
         args.quota_command == "should-run"
-        or (payload.get("ok") and bool(payload.get("appended")))
+        or (
+            payload.get("ok")
+            and (
+                bool(payload.get("appended"))
+                or bool(payload.get("receipt_repair_required"))
+            )
+        )
     )
     if should_log_quota:
-        rollout_details = {
-            "command": "quota",
-            "quota_command": args.quota_command,
-            "ok": bool(payload.get("ok")),
-            "should_run": bool(payload.get("should_run")),
-            "appended": bool(payload.get("appended")),
-            "slots": payload.get("slots") or "",
-            "source": payload.get("source") or "",
-            "todo_id": payload.get("todo_id") or "",
-            "target_key": payload.get("target_key") or "",
-            "successor_todo_ids": ",".join(
-                str(todo_id)
-                for todo_id in (
-                    payload.get("successor_todo_ids")
-                    if isinstance(payload.get("successor_todo_ids"), list)
-                    else []
-                )
-                if str(todo_id).strip()
-            ),
-            "applied_rrule": payload.get("applied_rrule") or "",
-        }
+        rollout_todo_id = _quota_rollout_todo_id(payload, args)
+        rollout_details = _quota_rollout_details(
+            payload,
+            args,
+            todo_id=rollout_todo_id,
+        )
         if heartbeat_turn_id and args.quota_command == "should-run":
             if not heartbeat_receipt_ready:
                 prior_reason = str(payload.get("reason") or "").strip()
@@ -882,6 +978,12 @@ def handle_quota_command(
                     {
                         "turn_instance_id": heartbeat_turn_id,
                         "stall_observation": heartbeat_stall_observation,
+                        "settlement_effect_id": (
+                            f"{args.goal_id}:{args.agent_id}:{rollout_todo_id}:"
+                            f"{heartbeat_turn_id}"
+                            if rollout_todo_id
+                            else ""
+                        ),
                     }
                 )
                 append_cli_rollout_event(
@@ -938,6 +1040,12 @@ def handle_quota_command(
                 runtime_root_arg=runtime_root_arg,
                 event_kind=QUOTA_EVENT_KINDS[args.quota_command],
                 agent_id=args.agent_id,
+                todo_id=rollout_todo_id,
+                run_id=(
+                    heartbeat_turn_id
+                    if args.quota_command == "spend-slot"
+                    else None
+                ),
                 status=str(
                     payload.get("effective_action")
                     or payload.get("decision")
@@ -952,6 +1060,15 @@ def handle_quota_command(
                 details=rollout_details,
                 allow_failed=args.quota_command == "should-run",
             )
+            if args.quota_command == "spend-slot" and heartbeat_turn_id:
+                _attach_spend_settlement_result(
+                    payload,
+                    runtime_root=runtime_root,
+                    goal_id=args.goal_id,
+                    agent_id=args.agent_id,
+                    todo_id=rollout_todo_id,
+                    turn_instance_id=heartbeat_turn_id,
+                )
     if bool(getattr(args, "turn_envelope", False)):
         payload = build_turn_envelope(
             payload,

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -5,6 +5,13 @@ from collections.abc import Callable
 from pathlib import Path
 
 from ..control_plane.todos.contract import TODO_CONTINUATION_POLICY_VALUES
+from ..control_plane.quota.settlement import (
+    require_settlement_todo_completion,
+    resolve_heartbeat_settlement_identity,
+    settlement_result_payload,
+)
+from ..history import load_registry
+from ..paths import resolve_runtime_root
 from ..todo_suggestion_prompt import (
     ALLOWED_TODO_SUGGESTION_SOURCES,
     ALLOWED_TODO_SUGGESTION_TRIGGERS,
@@ -94,6 +101,13 @@ def register_todo_command(
         help="For capture-followups, append one public-safe agent follow-up todo. Repeat up to the requested batch.",
     )
     todo_parser.add_argument("--todo-id", help="Structured todo id from status/quota, such as todo_ab12cd34ef56.")
+    todo_parser.add_argument(
+        "--turn-instance-id",
+        help=(
+            "For todo complete, bind the lifecycle receipt to the original "
+            "turn-scoped quota guard and reuse it on retries."
+        ),
+    )
     todo_parser.add_argument("--status", choices=["open", "done", "blocked", "deferred"], help="For todo add/update, set the lifecycle status.")
     todo_parser.add_argument("--note", help="Public-safe note to attach to a lifecycle transition.")
     todo_parser.add_argument("--evidence", help="Public-safe evidence pointer or short result for complete/update.")
@@ -541,6 +555,25 @@ def handle_todo_command(
             )
         elif args.todo_command == "complete":
             validate_todo_complete_options(args)
+            settlement_result = None
+            completion_turn_key = None
+            if getattr(args, "turn_instance_id", None):
+                runtime_root = resolve_runtime_root(
+                    load_registry(registry_path),
+                    runtime_root_arg,
+                )
+                settlement_result = resolve_heartbeat_settlement_identity(
+                    runtime_root,
+                    goal_id=args.goal_id,
+                    agent_id=args.agent_id,
+                    todo_id=args.todo_id,
+                    turn_instance_id=getattr(args, "turn_instance_id", None),
+                )
+                if settlement_result.failure is not None:
+                    raise ValueError(settlement_result.failure.reason)
+                if settlement_result.value is None:
+                    raise ValueError("turn-scoped Todo completion has no identity")
+                completion_turn_key = settlement_result.value.effect_id
             payload = complete_goal_todo(
                 registry_path=registry_path,
                 goal_id=args.goal_id,
@@ -548,6 +581,7 @@ def handle_todo_command(
                 role=args.role,
                 decision_outcome=args.decision_outcome,
                 evidence=args.evidence,
+                completion_turn_key=completion_turn_key,
                 note=args.note,
                 no_followup=bool(args.no_follow_up),
                 successor_todo_ids=args.successor_todo_ids,
@@ -569,6 +603,11 @@ def handle_todo_command(
                 **_todo_path_args(args),
                 dry_run=bool(args.dry_run),
             )
+            if settlement_result is not None and settlement_result.value is not None:
+                payload["settlement_identity"] = settlement_result.value.as_dict()
+                payload["settlement_result"] = settlement_result_payload(
+                    settlement_result
+                )
         elif args.todo_command == "supersede":
             validate_todo_supersede_options(args)
             payload = supersede_goal_todo(
@@ -657,6 +696,40 @@ def handle_todo_command(
         runtime_root_arg=runtime_root_arg,
         append_cli_rollout_event=append_cli_rollout_event,
     )
+    if (
+        args.todo_command == "complete"
+        and getattr(args, "turn_instance_id", None)
+        and payload.get("ok")
+        and not payload.get("dry_run")
+    ):
+        runtime_root = resolve_runtime_root(
+            load_registry(registry_path),
+            runtime_root_arg,
+        )
+        guard_result = resolve_heartbeat_settlement_identity(
+            runtime_root,
+            goal_id=args.goal_id,
+            agent_id=args.agent_id,
+            todo_id=args.todo_id,
+            turn_instance_id=getattr(args, "turn_instance_id", None),
+        )
+        identity = guard_result.value
+        if identity is None:
+            settlement_result = guard_result
+        else:
+            settlement_result = guard_result.bind(
+                lambda resolved: require_settlement_todo_completion(
+                    runtime_root,
+                    resolved,
+                )
+            )
+        payload["settlement_result"] = settlement_result_payload(
+            settlement_result
+        )
+        if settlement_result.failure is not None:
+            payload["ok"] = False
+            payload["receipt_repair_required"] = True
+            payload["error"] = settlement_result.failure.reason
     print_payload(
         payload,
         format_name or str(getattr(args, "format", None) or "markdown"),

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -11,6 +11,7 @@ TODO_OPTION_FIELDS = (
     ("--text", "text"),
     ("--follow-up", "followups"),
     ("--todo-id", "todo_id"),
+    ("--turn-instance-id", "turn_instance_id"),
     ("--status", "status"),
     ("--note", "note"),
     ("--evidence", "evidence"),
@@ -443,6 +444,10 @@ def validate_shared_todo_options(args: argparse.Namespace) -> None:
         "complete",
         "supersede",
     }
+    if getattr(args, "turn_instance_id", None) and args.todo_command != "complete":
+        raise ValueError(
+            "--turn-instance-id is supported only by todo complete settlement"
+        )
     if args.capability_binding_ref and args.todo_command != "add":
         raise ValueError(
             "--capability-binding-ref is immutable and supported only by todo add"

--- a/loopx/cli_commands/todo_event.py
+++ b/loopx/cli_commands/todo_event.py
@@ -26,7 +26,12 @@ def append_todo_rollout_event(
     runtime_root_arg: str | None,
     append_cli_rollout_event: RolloutEventAppender,
 ) -> None:
-    if not payload.get("ok") or payload.get("dry_run"):
+    turn_instance_id = getattr(args, "turn_instance_id", None)
+    if (
+        not payload.get("ok")
+        or payload.get("dry_run")
+        or (payload.get("idempotent_replay") and not turn_instance_id)
+    ):
         return
     append_cli_rollout_event(
         payload,
@@ -35,6 +40,7 @@ def append_todo_rollout_event(
         event_kind=TODO_EVENT_KINDS.get(args.todo_command, "todo_update"),
         agent_id=args.agent_id or args.claimed_by,
         todo_id=args.todo_id or str(payload.get("todo_id") or "").strip() or None,
+        run_id=turn_instance_id,
         status=str(payload.get("status") or args.todo_command or "").strip(),
         summary=(
             f"todo {args.todo_command} recorded for "
@@ -48,7 +54,17 @@ def append_todo_rollout_event(
             "added": bool(payload.get("added")),
             "already_exists": bool(payload.get("already_exists")),
             "mutation_authority": payload.get("mutation_authority"),
+            "settlement_effect_id": (
+                payload.get("settlement_identity", {}).get("effect_id")
+                if isinstance(payload.get("settlement_identity"), dict)
+                else None
+            ),
         },
+        idempotency_fields=(
+            ["goal_id", "event_kind", "agent_id", "todo_id", "run_id"]
+            if turn_instance_id
+            else None
+        ),
     )
     capability_gap_status = str(
         getattr(args, "capability_gap_status", None) or ""

--- a/loopx/control_plane/quota/effect_program.py
+++ b/loopx/control_plane/quota/effect_program.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import shlex
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Generic, TypeVar, cast
+
+SETTLEMENT_IDENTITY_SCHEMA_VERSION = "quota_settlement_identity_v0"
+SETTLEMENT_PLAN_SCHEMA_VERSION = "quota_settlement_plan_v0"
+SETTLEMENT_RECEIPT_SCHEMA_VERSION = "quota_settlement_receipt_v0"
+
+
+class SettlementStepKind(StrEnum):
+    VALIDATION = "validation"
+    TODO_COMPLETION = "todo_completion"
+    DURABLE_WRITEBACK = "durable_writeback"
+    QUOTA_SPEND = "quota_spend"
+
+
+class SettlementFailureKind(StrEnum):
+    INVALID_IDENTITY = "invalid_identity"
+    RECEIPT_MISSING = "receipt_missing"
+    IDENTITY_MISMATCH = "identity_mismatch"
+    WRITEBACK_MISSING = "writeback_missing"
+    CANCELLED = "cancelled"
+    PERMISSION_DENIED = "permission_denied"
+    BUDGET_REJECTED = "budget_rejected"
+
+
+@dataclass(frozen=True, slots=True)
+class SettlementIdentity:
+    goal_id: str
+    agent_id: str
+    todo_id: str
+    turn_instance_id: str
+
+    @property
+    def effect_id(self) -> str:
+        return f"{self.goal_id}:{self.agent_id}:{self.todo_id}:{self.turn_instance_id}"
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "schema_version": SETTLEMENT_IDENTITY_SCHEMA_VERSION,
+            "effect_id": self.effect_id,
+            "goal_id": self.goal_id,
+            "agent_id": self.agent_id,
+            "todo_id": self.todo_id,
+            "turn_instance_id": self.turn_instance_id,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SettlementReceipt:
+    step_kind: SettlementStepKind
+    status: str
+    effect_id: str
+    source_ref: str | None = None
+
+    def as_dict(self) -> dict[str, str]:
+        receipt = {
+            "schema_version": SETTLEMENT_RECEIPT_SCHEMA_VERSION,
+            "step_kind": self.step_kind.value,
+            "status": self.status,
+            "effect_id": self.effect_id,
+        }
+        if self.source_ref:
+            receipt["source_ref"] = self.source_ref
+        return receipt
+
+
+@dataclass(frozen=True, slots=True)
+class SettlementFailure:
+    kind: SettlementFailureKind
+    step_kind: SettlementStepKind
+    reason: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "kind": self.kind.value,
+            "step_kind": self.step_kind.value,
+            "reason": self.reason,
+        }
+
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+
+@dataclass(frozen=True, slots=True)
+class SettlementResult(Generic[T]):
+    value: T | None
+    receipts: tuple[SettlementReceipt, ...] = ()
+    failure: SettlementFailure | None = None
+
+    @classmethod
+    def pure(
+        cls,
+        value: T,
+        *,
+        receipts: tuple[SettlementReceipt, ...] = (),
+    ) -> SettlementResult[T]:
+        return cls(value=value, receipts=receipts)
+
+    @classmethod
+    def failed(
+        cls,
+        *,
+        kind: SettlementFailureKind,
+        step_kind: SettlementStepKind,
+        reason: str,
+        receipts: tuple[SettlementReceipt, ...] = (),
+    ) -> SettlementResult[T]:
+        return cls(
+            value=None,
+            receipts=receipts,
+            failure=SettlementFailure(
+                kind=kind,
+                step_kind=step_kind,
+                reason=reason,
+            ),
+        )
+
+    def bind(self, step: Callable[[T], SettlementResult[U]]) -> SettlementResult[U]:
+        if self.failure is not None:
+            return SettlementResult(
+                value=None,
+                receipts=self.receipts,
+                failure=self.failure,
+            )
+        next_result = step(cast(T, self.value))
+        return SettlementResult(
+            value=next_result.value,
+            receipts=(*self.receipts, *next_result.receipts),
+            failure=next_result.failure,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SettlementStep:
+    kind: SettlementStepKind
+    owner: str
+    precondition: str
+    idempotency_key_ref: str
+    expected_receipt: str
+    command_template: str | None = None
+    conditional: bool = False
+
+    def as_dict(self) -> dict[str, Any]:
+        step: dict[str, Any] = {
+            "kind": self.kind.value,
+            "owner": self.owner,
+            "precondition": self.precondition,
+            "idempotency_key_ref": self.idempotency_key_ref,
+            "expected_receipt": self.expected_receipt,
+        }
+        if self.command_template:
+            step["command_template"] = self.command_template
+        if self.conditional:
+            step["conditional"] = True
+        return step
+
+
+@dataclass(frozen=True, slots=True)
+class SettlementPlan:
+    identity: SettlementIdentity
+    steps: tuple[SettlementStep, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": SETTLEMENT_PLAN_SCHEMA_VERSION,
+            "identity": self.identity.as_dict(),
+            "ordered_steps": [step.as_dict() for step in self.steps],
+            "host_handoff": {
+                "owner": "host",
+                "kind": "scheduler_handoff",
+                "inside_agent_settlement": False,
+            },
+        }
+
+
+def _quoted_turn_ref(turn_instance_id_ref: str) -> str:
+    if turn_instance_id_ref == "${LOOPX_TURN:?}":
+        return '"${LOOPX_TURN:?}"'
+    return shlex.quote(turn_instance_id_ref)
+
+
+def build_codex_app_settlement_plan(
+    *,
+    goal_id: str,
+    agent_id: str,
+    todo_id: str,
+    scoped_cli_args: str,
+    lifecycle_actor_args: str,
+    turn_instance_id_ref: str = "${LOOPX_TURN:?}",
+) -> SettlementPlan:
+    identity = SettlementIdentity(
+        goal_id=goal_id,
+        agent_id=agent_id,
+        todo_id=todo_id,
+        turn_instance_id=turn_instance_id_ref,
+    )
+    quoted_turn = _quoted_turn_ref(turn_instance_id_ref)
+    todo_arg = f" --todo-id {shlex.quote(todo_id)}"
+    turn_arg = f" --turn-instance-id {quoted_turn}"
+    completion = (
+        f"loopx todo complete --goal-id {shlex.quote(goal_id)}{todo_arg}"
+        f"{lifecycle_actor_args}{turn_arg} --evidence '<validated evidence>'"
+        " [--successor-todo-id <todo_id> | --no-follow-up]"
+    )
+    writeback = (
+        f"loopx refresh-state --goal-id {shlex.quote(goal_id)} "
+        "--classification <validated_progress> --delivery-batch-scale <scale> "
+        f"--delivery-outcome <outcome>{todo_arg}{turn_arg}{scoped_cli_args}"
+    )
+    spend = (
+        f"loopx quota spend-slot --goal-id {shlex.quote(goal_id)} --slots 1 "
+        f"--source heartbeat --execute{todo_arg}{turn_arg}{scoped_cli_args}"
+    )
+    effect_ref = "$.identity.effect_id"
+    return SettlementPlan(
+        identity=identity,
+        steps=(
+            SettlementStep(
+                kind=SettlementStepKind.VALIDATION,
+                owner="agent",
+                precondition="delivery result is independently validated",
+                idempotency_key_ref=effect_ref,
+                expected_receipt="validation_receipt",
+            ),
+            SettlementStep(
+                kind=SettlementStepKind.TODO_COMPLETION,
+                owner="agent",
+                precondition="validated result closes the selected Todo",
+                idempotency_key_ref=effect_ref,
+                expected_receipt="todo_completion_receipt",
+                command_template=completion,
+                conditional=True,
+            ),
+            SettlementStep(
+                kind=SettlementStepKind.DURABLE_WRITEBACK,
+                owner="agent",
+                precondition="validation succeeded",
+                idempotency_key_ref=effect_ref,
+                expected_receipt="durable_writeback_receipt",
+                command_template=writeback,
+            ),
+            SettlementStep(
+                kind=SettlementStepKind.QUOTA_SPEND,
+                owner="agent",
+                precondition="matching durable writeback receipt exists",
+                idempotency_key_ref=effect_ref,
+                expected_receipt="quota_spend_receipt",
+                command_template=spend,
+            ),
+        ),
+    )
+
+
+def settlement_step_command(
+    plan: Mapping[str, Any] | None,
+    kind: SettlementStepKind,
+) -> str | None:
+    if not isinstance(plan, Mapping):
+        return None
+    steps = plan.get("ordered_steps")
+    if not isinstance(steps, list):
+        return None
+    for step in steps:
+        if not isinstance(step, Mapping) or step.get("kind") != kind.value:
+            continue
+        command = str(step.get("command_template") or "").strip()
+        return command or None
+    return None
+
+
+def settlement_binding_args(plan: Mapping[str, Any] | None) -> str:
+    if not isinstance(plan, Mapping):
+        return ""
+    identity = plan.get("identity")
+    if not isinstance(identity, Mapping):
+        return ""
+    todo_id = str(identity.get("todo_id") or "").strip()
+    turn_instance_id = str(identity.get("turn_instance_id") or "").strip()
+    if not todo_id or not turn_instance_id:
+        return ""
+    return (
+        f" --todo-id {shlex.quote(todo_id)}"
+        f" --turn-instance-id {_quoted_turn_ref(turn_instance_id)}"
+    )

--- a/loopx/control_plane/quota/heartbeat_receipt.py
+++ b/loopx/control_plane/quota/heartbeat_receipt.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from pathlib import Path
 
 from ...rollout_event_log import load_rollout_events, rollout_event_log_path
+from .effect_program import SETTLEMENT_IDENTITY_SCHEMA_VERSION
 
 HEARTBEAT_RECEIPT_SCHEMA_VERSION = "heartbeat_quota_receipt_v0"
 
@@ -33,8 +34,11 @@ def heartbeat_receipt_view(
     turn_instance_id: str,
     status: str,
 ) -> dict[str, object]:
-    details = event.get("details") if isinstance(event.get("details"), Mapping) else {}
-    return {
+    details_value = event.get("details")
+    details: Mapping[str, object] = (
+        details_value if isinstance(details_value, Mapping) else {}
+    )
+    receipt: dict[str, object] = {
         "schema_version": HEARTBEAT_RECEIPT_SCHEMA_VERSION,
         "turn_instance_id": turn_instance_id,
         "status": status,
@@ -42,6 +46,18 @@ def heartbeat_receipt_view(
         "event_id": event.get("event_id"),
         "recorded_at": event.get("recorded_at"),
     }
+    todo_id = str(details.get("todo_id") or "").strip()
+    effect_id = str(details.get("settlement_effect_id") or "").strip()
+    if todo_id and effect_id:
+        receipt["settlement_identity"] = {
+            "schema_version": SETTLEMENT_IDENTITY_SCHEMA_VERSION,
+            "effect_id": effect_id,
+            "goal_id": event.get("goal_id"),
+            "agent_id": event.get("agent_id"),
+            "todo_id": todo_id,
+            "turn_instance_id": turn_instance_id,
+        }
+    return receipt
 
 
 def fail_heartbeat_receipt(

--- a/loopx/control_plane/quota/settlement.py
+++ b/loopx/control_plane/quota/settlement.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from ...rollout_event_log import load_rollout_events, rollout_event_log_path
+from ...turn_identity import normalize_turn_instance_id
+from ..todos.contract import normalize_todo_claimed_by, normalize_todo_id
+from ..work_items.delivery_outcome import (
+    ACCOUNTABLE_DELIVERY_OUTCOMES,
+    normalize_delivery_outcome,
+)
+from .effect_program import (
+    SETTLEMENT_IDENTITY_SCHEMA_VERSION,
+    SETTLEMENT_PLAN_SCHEMA_VERSION,
+    SETTLEMENT_RECEIPT_SCHEMA_VERSION,
+    SettlementFailure,
+    SettlementFailureKind,
+    SettlementIdentity,
+    SettlementPlan,
+    SettlementReceipt,
+    SettlementResult,
+    SettlementStep,
+    SettlementStepKind,
+    build_codex_app_settlement_plan,
+    settlement_binding_args,
+    settlement_step_command,
+)
+from .heartbeat_receipt import find_heartbeat_receipt
+
+__all__ = [
+    "SETTLEMENT_IDENTITY_SCHEMA_VERSION",
+    "SETTLEMENT_PLAN_SCHEMA_VERSION",
+    "SETTLEMENT_RECEIPT_SCHEMA_VERSION",
+    "SettlementFailure",
+    "SettlementFailureKind",
+    "SettlementIdentity",
+    "SettlementPlan",
+    "SettlementReceipt",
+    "SettlementResult",
+    "SettlementStep",
+    "SettlementStepKind",
+    "build_codex_app_settlement_plan",
+    "find_settlement_spend_run",
+    "find_settlement_step_event",
+    "find_settlement_writeback",
+    "require_settlement_spend",
+    "require_settlement_todo_completion",
+    "require_settlement_writeback",
+    "resolve_heartbeat_settlement_identity",
+    "settlement_binding_args",
+    "settlement_result_payload",
+    "settlement_step_command",
+]
+
+
+def resolve_heartbeat_settlement_identity(
+    runtime_root: Path,
+    *,
+    goal_id: str,
+    agent_id: str | None,
+    todo_id: str | None,
+    turn_instance_id: str | None,
+) -> SettlementResult[SettlementIdentity]:
+    normalized_agent_id = normalize_todo_claimed_by(agent_id)
+    normalized_todo_id = normalize_todo_id(todo_id)
+    try:
+        normalized_turn_id = normalize_turn_instance_id(turn_instance_id)
+    except ValueError as exc:
+        return SettlementResult.failed(
+            kind=SettlementFailureKind.INVALID_IDENTITY,
+            step_kind=SettlementStepKind.VALIDATION,
+            reason=str(exc),
+        )
+    if not normalized_agent_id or not normalized_todo_id or not normalized_turn_id:
+        return SettlementResult.failed(
+            kind=SettlementFailureKind.INVALID_IDENTITY,
+            step_kind=SettlementStepKind.VALIDATION,
+            reason=(
+                "turn-scoped settlement requires agent_id, todo_id, and "
+                "turn_instance_id"
+            ),
+        )
+    receipt_event = find_heartbeat_receipt(
+        runtime_root,
+        goal_id=goal_id,
+        agent_id=normalized_agent_id,
+        turn_instance_id=normalized_turn_id,
+    )
+    if receipt_event is None:
+        return SettlementResult.failed(
+            kind=SettlementFailureKind.RECEIPT_MISSING,
+            step_kind=SettlementStepKind.VALIDATION,
+            reason=(
+                "matching quota should-run heartbeat receipt is missing; rerun the "
+                "guard with the same turn_instance_id"
+            ),
+        )
+    details_value = receipt_event.get("details")
+    details = details_value if isinstance(details_value, Mapping) else {}
+    receipt_todo_id = normalize_todo_id(details.get("todo_id"))
+    if receipt_todo_id != normalized_todo_id:
+        return SettlementResult.failed(
+            kind=SettlementFailureKind.IDENTITY_MISMATCH,
+            step_kind=SettlementStepKind.VALIDATION,
+            reason=(
+                "settlement Todo does not match the original quota guard: "
+                f"receipt todo is {receipt_todo_id or 'missing'} but requested "
+                f"todo is {normalized_todo_id}"
+            ),
+        )
+    identity = SettlementIdentity(
+        goal_id=goal_id,
+        agent_id=normalized_agent_id,
+        todo_id=normalized_todo_id,
+        turn_instance_id=normalized_turn_id,
+    )
+    receipt_effect_id = str(details.get("settlement_effect_id") or "").strip()
+    if receipt_effect_id and receipt_effect_id != identity.effect_id:
+        return SettlementResult.failed(
+            kind=SettlementFailureKind.IDENTITY_MISMATCH,
+            step_kind=SettlementStepKind.VALIDATION,
+            reason=(
+                "settlement effect does not match the original quota guard: "
+                f"receipt effect is {receipt_effect_id} but expected "
+                f"{identity.effect_id}"
+            ),
+        )
+    event_id = str(receipt_event.get("event_id") or "").strip() or None
+    return SettlementResult.pure(
+        identity,
+        receipts=(
+            SettlementReceipt(
+                step_kind=SettlementStepKind.VALIDATION,
+                status="committed",
+                effect_id=identity.effect_id,
+                source_ref=f"rollout_event:{event_id}" if event_id else None,
+            ),
+        ),
+    )
+
+
+def _run_index_records(runtime_root: Path, goal_id: str) -> list[dict[str, Any]]:
+    index_path = runtime_root / "goals" / goal_id / "runs" / "index.jsonl"
+    if not index_path.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    try:
+        lines = index_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    for line in lines:
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(record, dict):
+            records.append(record)
+    return records
+
+
+def find_settlement_writeback(
+    runtime_root: Path,
+    identity: SettlementIdentity,
+) -> dict[str, Any] | None:
+    for run in reversed(_run_index_records(runtime_root, identity.goal_id)):
+        if str(run.get("turn_instance_id") or "") != identity.turn_instance_id:
+            continue
+        if normalize_todo_id(run.get("todo_id")) != identity.todo_id:
+            continue
+        run_agent_id = normalize_todo_claimed_by(run.get("agent_id"))
+        if run_agent_id != identity.agent_id:
+            continue
+        if (
+            normalize_delivery_outcome(run.get("delivery_outcome"))
+            not in ACCOUNTABLE_DELIVERY_OUTCOMES
+        ):
+            continue
+        return run
+    return None
+
+
+def find_settlement_step_event(
+    runtime_root: Path,
+    identity: SettlementIdentity,
+    *,
+    event_kind: str,
+) -> dict[str, Any] | None:
+    events = load_rollout_events(rollout_event_log_path(runtime_root, identity.goal_id))
+    for event in reversed(events):
+        if event.get("event_kind") != event_kind:
+            continue
+        if str(event.get("goal_id") or "") != identity.goal_id:
+            continue
+        if str(event.get("agent_id") or "") != identity.agent_id:
+            continue
+        if str(event.get("run_id") or "") != identity.turn_instance_id:
+            continue
+        details_value = event.get("details")
+        details = details_value if isinstance(details_value, Mapping) else {}
+        if str(details.get("settlement_effect_id") or "") != identity.effect_id:
+            continue
+        return event
+    return None
+
+
+def require_settlement_todo_completion(
+    runtime_root: Path,
+    identity: SettlementIdentity,
+) -> SettlementResult[dict[str, Any]]:
+    receipt_event = find_settlement_step_event(
+        runtime_root,
+        identity,
+        event_kind="todo_complete",
+    )
+    if receipt_event is None:
+        return SettlementResult.failed(
+            kind=SettlementFailureKind.RECEIPT_MISSING,
+            step_kind=SettlementStepKind.TODO_COMPLETION,
+            reason="matching Todo completion receipt is missing",
+        )
+    event_id = str(receipt_event.get("event_id") or "").strip()
+    return SettlementResult.pure(
+        receipt_event,
+        receipts=(
+            SettlementReceipt(
+                step_kind=SettlementStepKind.TODO_COMPLETION,
+                status="committed",
+                effect_id=identity.effect_id,
+                source_ref=f"rollout_event:{event_id}" if event_id else None,
+            ),
+        ),
+    )
+
+
+def require_settlement_writeback(
+    runtime_root: Path,
+    identity: SettlementIdentity,
+) -> SettlementResult[dict[str, Any]]:
+    run = find_settlement_writeback(runtime_root, identity)
+    receipt_event = find_settlement_step_event(
+        runtime_root,
+        identity,
+        event_kind="refresh_state",
+    )
+    if run is None or receipt_event is None:
+        return SettlementResult.failed(
+            kind=SettlementFailureKind.WRITEBACK_MISSING,
+            step_kind=SettlementStepKind.DURABLE_WRITEBACK,
+            reason=(
+                "matching accountable refresh-state receipt is missing for the "
+                "original settlement identity"
+            ),
+        )
+    event_id = str(receipt_event.get("event_id") or "").strip()
+    return SettlementResult.pure(
+        run,
+        receipts=(
+            SettlementReceipt(
+                step_kind=SettlementStepKind.DURABLE_WRITEBACK,
+                status="committed",
+                effect_id=identity.effect_id,
+                source_ref=f"rollout_event:{event_id}" if event_id else None,
+            ),
+        ),
+    )
+
+
+def find_settlement_spend_run(
+    runtime_root: Path,
+    identity: SettlementIdentity,
+) -> dict[str, Any] | None:
+    for run in reversed(_run_index_records(runtime_root, identity.goal_id)):
+        if str(run.get("classification") or "") != "quota_slot_spent":
+            continue
+        if str(run.get("turn_instance_id") or "") != identity.turn_instance_id:
+            continue
+        if normalize_todo_id(run.get("todo_id")) != identity.todo_id:
+            continue
+        if normalize_todo_claimed_by(run.get("agent_id")) != identity.agent_id:
+            continue
+        return run
+    return None
+
+
+def require_settlement_spend(
+    runtime_root: Path,
+    identity: SettlementIdentity,
+) -> SettlementResult[dict[str, Any]]:
+    run = find_settlement_spend_run(runtime_root, identity)
+    receipt_event = find_settlement_step_event(
+        runtime_root,
+        identity,
+        event_kind="quota_spend",
+    )
+    if run is None or receipt_event is None:
+        return SettlementResult.failed(
+            kind=SettlementFailureKind.RECEIPT_MISSING,
+            step_kind=SettlementStepKind.QUOTA_SPEND,
+            reason="matching quota spend receipt is missing",
+        )
+    event_id = str(receipt_event.get("event_id") or "").strip()
+    return SettlementResult.pure(
+        run,
+        receipts=(
+            SettlementReceipt(
+                step_kind=SettlementStepKind.QUOTA_SPEND,
+                status="committed",
+                effect_id=identity.effect_id,
+                source_ref=f"rollout_event:{event_id}" if event_id else None,
+            ),
+        ),
+    )
+
+
+def settlement_result_payload(result: SettlementResult[Any]) -> dict[str, Any]:
+    return {
+        "ok": result.failure is None,
+        "receipts": [receipt.as_dict() for receipt in result.receipts],
+        "failure": result.failure.as_dict() if result.failure else None,
+    }

--- a/loopx/control_plane/quota/slot_accounting.py
+++ b/loopx/control_plane/quota/slot_accounting.py
@@ -24,6 +24,12 @@ from ..work_items.delivery_outcome import (
     ACCOUNTABLE_DELIVERY_OUTCOMES,
     normalize_delivery_outcome,
 )
+from .settlement import (
+    SettlementIdentity,
+    require_settlement_writeback,
+    resolve_heartbeat_settlement_identity,
+    settlement_result_payload,
+)
 
 
 QUOTA_SLOT_SPENT_CLASSIFICATION = "quota_slot_spent"
@@ -38,7 +44,16 @@ def _todo_binding_error(
     source: str,
     before: dict[str, Any],
     requested_todo_id: str | None,
+    settlement_identity: SettlementIdentity | None = None,
 ) -> str | None:
+    if settlement_identity is not None:
+        if requested_todo_id != settlement_identity.todo_id:
+            return (
+                "quota spend Todo does not match the original settlement identity: "
+                f"expected {settlement_identity.todo_id} but received "
+                f"{requested_todo_id or 'missing'}"
+            )
+        return None
     selected = before.get("selected_todo") if isinstance(before.get("selected_todo"), dict) else {}
     selected_todo_id = normalize_todo_id(selected.get("todo_id"))
     if requested_todo_id and selected_todo_id and requested_todo_id != selected_todo_id:
@@ -208,16 +223,87 @@ def build_quota_slot_preview_for_decision(
     agent_id: str | None = None,
     workspace_path: Path | None = None,
     todo_id: str | None = None,
+    turn_instance_id: str | None = None,
     source: str = DEFAULT_SLOT_SPEND_SOURCE,
 ) -> dict[str, Any]:
     safe_goal_id = _validate_goal_id_path_segment(str(goal_id or ""))
     safe_slots = max(1, _int_number(slots, default=1))
     safe_requested_agent_id = normalize_todo_claimed_by(agent_id)
     normalized_todo_id = normalize_todo_id(todo_id) if todo_id else None
+    raw_runtime_root = status_payload.get("runtime_root")
+    settlement_identity = None
+    settlement_result = None
+    delivery_completion_run = None
+    if turn_instance_id:
+        if source != DEFAULT_SLOT_SPEND_SOURCE:
+            return {
+                "ok": False,
+                "mode": "spend-slot",
+                "dry_run": True,
+                "goal_id": safe_goal_id,
+                "slots": safe_slots,
+                "agent_id": safe_requested_agent_id,
+                "appended": False,
+                "registry_mutated": False,
+                "reason": "turn-scoped settlement is valid only for heartbeat spend",
+                "before": before,
+                "after": None,
+            }
+        if not raw_runtime_root:
+            return {
+                "ok": False,
+                "mode": "spend-slot",
+                "dry_run": True,
+                "goal_id": safe_goal_id,
+                "slots": safe_slots,
+                "agent_id": safe_requested_agent_id,
+                "appended": False,
+                "registry_mutated": False,
+                "reason": "status payload does not include runtime_root",
+                "before": before,
+                "after": None,
+            }
+        runtime_root = Path(str(raw_runtime_root)).expanduser()
+        settlement_result = resolve_heartbeat_settlement_identity(
+            runtime_root,
+            goal_id=safe_goal_id,
+            agent_id=safe_requested_agent_id,
+            todo_id=normalized_todo_id,
+            turn_instance_id=turn_instance_id,
+        )
+        if settlement_result.failure is None:
+            settlement_identity = settlement_result.value
+        if settlement_identity is not None:
+            settlement_result = settlement_result.bind(
+                lambda identity: require_settlement_writeback(
+                    runtime_root,
+                    identity,
+                )
+            )
+            if settlement_result.failure is None:
+                delivery_completion_run = settlement_result.value
+        if settlement_result.failure is not None:
+            return {
+                "ok": False,
+                "mode": "spend-slot",
+                "dry_run": True,
+                "goal_id": safe_goal_id,
+                "slots": safe_slots,
+                "agent_id": safe_requested_agent_id,
+                "appended": False,
+                "registry_mutated": False,
+                "reason": settlement_result.failure.reason,
+                "settlement_result": settlement_result_payload(
+                    settlement_result
+                ),
+                "before": before,
+                "after": None,
+            }
     binding_error = _todo_binding_error(
         source=source,
         before=before,
         requested_todo_id=normalized_todo_id,
+        settlement_identity=settlement_identity,
     )
     if binding_error:
         return {
@@ -246,8 +332,7 @@ def build_quota_slot_preview_for_decision(
         before.get("effective_action") == "capability_bridge_repair"
         and before.get("capability_repair_allowed") is True
     )
-    raw_runtime_root = status_payload.get("runtime_root")
-    delivery_completion_run = (
+    delivery_completion_run = delivery_completion_run or (
         _latest_unspent_accountable_delivery_run(
             Path(str(raw_runtime_root)).expanduser(),
             safe_goal_id,
@@ -343,7 +428,8 @@ def build_quota_slot_preview_for_decision(
         delivery_completion_run is not None
         and before.get("ok")
         and (
-            not before.get("should_run")
+            settlement_identity is not None
+            or not before.get("should_run")
             or before.get("effective_action") == "external_evidence_observe"
             or (
                 before.get("effective_action") == "agent_workspace_repair"
@@ -436,6 +522,21 @@ def build_quota_slot_preview_for_decision(
             "so the visible total can stay flat if an older spend expires."
         ),
         "todo_id": normalized_todo_id,
+        "turn_instance_id": (
+            settlement_identity.turn_instance_id
+            if settlement_identity is not None
+            else None
+        ),
+        "settlement_identity": (
+            settlement_identity.as_dict()
+            if settlement_identity is not None
+            else None
+        ),
+        "settlement_result": (
+            settlement_result_payload(settlement_result)
+            if settlement_result is not None
+            else None
+        ),
         "safe_bypass_spend": safe_bypass_spend,
         "self_repair_spend": self_repair_spend,
         "capability_repair_spend": capability_repair_spend,
@@ -497,6 +598,7 @@ def build_quota_slot_spend_event(
         and not self_repair_spend
         and not capability_repair_spend
         and before_compact["workspace_repair_allowed"] is not True
+        and not delivery_completion_spend
     )
     safe_bypass_spend = bool(preview.get("safe_bypass_spend")) and (
         (
@@ -553,6 +655,8 @@ def build_quota_slot_spend_event(
             "event_type": QUOTA_SLOT_SPENT_CLASSIFICATION,
             "source": safe_source,
             "todo_id": preview.get("todo_id"),
+            "turn_instance_id": preview.get("turn_instance_id"),
+            "settlement_identity": preview.get("settlement_identity"),
             "slots": slots,
             "reason_summary": (
                 f"{slots} automatic agent slot(s) completed under an eligible quota guard"
@@ -591,6 +695,10 @@ def build_quota_slot_spend_event(
     if safe_agent_id:
         record["agent_id"] = safe_agent_id
         record["quota_event"]["agent_id"] = safe_agent_id
+    if preview.get("turn_instance_id"):
+        record["turn_instance_id"] = preview["turn_instance_id"]
+        record["todo_id"] = preview.get("todo_id")
+        record["settlement_identity"] = preview.get("settlement_identity")
     return record
 
 
@@ -861,6 +969,9 @@ def record_quota_slot_spend_from_preview(
     }
     if record.get("agent_id"):
         index_record["agent_id"] = record["agent_id"]
+    for field in ("turn_instance_id", "todo_id", "settlement_identity"):
+        if record.get(field):
+            index_record[field] = record[field]
 
     payload = {
         **preview,

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -11,6 +11,12 @@ from ..agents.agent_scope_frontier import (
 from ..agents.capability_gate import runtime_capabilities_for_cli_projection
 from ..goals.goal_frontier import AUTONOMOUS_REPLAN_REQUIRED_MODE
 from ..goals.goal_vision_wait import exact_blocked_successor_wait_state
+from ..quota.settlement import (
+    SettlementStepKind,
+    build_codex_app_settlement_plan,
+    settlement_binding_args,
+    settlement_step_command,
+)
 from ..scheduler.execution_context import (
     SchedulerExecutionContextResolution,
     SchedulerRuntimeProfile,
@@ -40,21 +46,6 @@ INTERACTION_CONTRACT_SCHEMA_VERSION = "loopx_interaction_contract_v0"
 INTERACTION_RESPONSE_PLAN_SCHEMA_VERSION = "interaction_response_plan_v0"
 PROTOCOL_ACTION_PACKET_SCHEMA_VERSION = "protocol_action_packet_v0"
 PROTOCOL_ACTION_PACKET_LLM_POLICY = "no_api"
-
-
-def _heartbeat_spend_command(
-    goal_id: str,
-    *,
-    scoped_cli_args: str,
-    payload: dict[str, Any],
-) -> str:
-    selected = payload.get("selected_todo") if isinstance(payload.get("selected_todo"), dict) else {}
-    todo_id = normalize_todo_id(selected.get("todo_id"))
-    todo_arg = f" --todo-id {todo_id}" if todo_id else ""
-    return (
-        f"loopx quota spend-slot --goal-id {goal_id} --slots 1 "
-        f"--source heartbeat --execute{todo_arg}{scoped_cli_args}"
-    )
 
 
 def _blocked_successor_wait_observation_required(payload: dict[str, Any]) -> bool:
@@ -513,6 +504,75 @@ def _scoped_cli_args(
     return f" --agent-id {agent_id}{capability_args}"
 
 
+def _codex_app_settlement_plan(
+    payload: dict[str, Any],
+    *,
+    available_capabilities: Any,
+    scheduler_execution_context: (
+        Mapping[str, Any] | SchedulerExecutionContextResolution | None
+    ),
+) -> dict[str, Any] | None:
+    if (
+        scheduler_runtime_profile_for_execution_context(
+            scheduler_execution_context
+        )
+        is not SchedulerRuntimeProfile.CODEX_APP_HEARTBEAT
+    ):
+        return None
+    agent_identity = (
+        payload.get("agent_identity")
+        if isinstance(payload.get("agent_identity"), dict)
+        else {}
+    )
+    selected_todo = (
+        payload.get("selected_todo")
+        if isinstance(payload.get("selected_todo"), dict)
+        else {}
+    )
+    goal_id = str(payload.get("goal_id") or "").strip()
+    agent_id = str(agent_identity.get("agent_id") or "").strip()
+    todo_id = normalize_todo_id(selected_todo.get("todo_id"))
+    if not goal_id or not agent_id or not todo_id:
+        return None
+    scoped_cli_args = _scoped_cli_args(
+        agent_identity,
+        available_capabilities=available_capabilities,
+    )
+    return build_codex_app_settlement_plan(
+        goal_id=goal_id,
+        agent_id=agent_id,
+        todo_id=todo_id,
+        scoped_cli_args=scoped_cli_args,
+        lifecycle_actor_args=f" --agent-id {shlex.quote(agent_id)}",
+    ).as_dict()
+
+
+def _quota_spend_action(
+    goal_id: str,
+    *,
+    scoped_cli_args: str,
+    payload: dict[str, Any],
+    settlement_plan: Mapping[str, Any] | None,
+) -> str:
+    typed_command = settlement_step_command(
+        settlement_plan,
+        SettlementStepKind.QUOTA_SPEND,
+    )
+    if typed_command:
+        return typed_command
+    selected = (
+        payload.get("selected_todo")
+        if isinstance(payload.get("selected_todo"), dict)
+        else {}
+    )
+    todo_id = normalize_todo_id(selected.get("todo_id"))
+    todo_arg = f" --todo-id {todo_id}" if todo_id else ""
+    return (
+        f"loopx quota spend-slot --goal-id {goal_id} --slots 1 "
+        f"--source heartbeat --execute{todo_arg}{scoped_cli_args}"
+    )
+
+
 def interaction_next_cli_actions(
     payload: dict[str, Any],
     *,
@@ -522,6 +582,7 @@ def interaction_next_cli_actions(
         Mapping[str, Any] | SchedulerExecutionContextResolution | None
     ) = None,
     capability_reentry: dict[str, Any] | None = None,
+    settlement_plan: Mapping[str, Any] | None = None,
 ) -> list[str]:
     goal_id = str(payload.get("goal_id") or "<GOAL_ID>")
     agent_identity = (
@@ -538,6 +599,13 @@ def interaction_next_cli_actions(
         if agent_identity.get("agent_id")
         else ""
     )
+    if settlement_plan is None:
+        settlement_plan = _codex_app_settlement_plan(
+            payload,
+            available_capabilities=available_capabilities,
+            scheduler_execution_context=scheduler_execution_context,
+        )
+    settlement_args = settlement_binding_args(settlement_plan)
     try:
         scheduler_args = render_scheduler_execution_args(
             scheduler_execution_context=scheduler_execution_context,
@@ -662,8 +730,13 @@ def interaction_next_cli_actions(
             return [
                 f"loopx todo complete --goal-id {goal_id} --todo-id {monitor_todo_id}{lifecycle_actor_args} --evidence '<validated gate evidence>'",
                 f"loopx todo update --goal-id {goal_id} --todo-id {gated_todo_id}{lifecycle_actor_args} --note '<public-safe gate repair reason>'",
-                f"loopx refresh-state --goal-id {goal_id} --classification standing_monitor_gate_repair_recorded --delivery-batch-scale single_surface --delivery-outcome outcome_progress{scoped_cli_args}",
-                _heartbeat_spend_command(goal_id, scoped_cli_args=scoped_cli_args, payload=payload),
+                f"loopx refresh-state --goal-id {goal_id} --classification standing_monitor_gate_repair_recorded --delivery-batch-scale single_surface --delivery-outcome outcome_progress{settlement_args}{scoped_cli_args}",
+                _quota_spend_action(
+                    goal_id,
+                    scoped_cli_args=scoped_cli_args,
+                    payload=payload,
+                    settlement_plan=settlement_plan,
+                ),
             ]
         route_candidates = (
             agent_scope_frontier.get("route_continuation_replan_candidates")
@@ -673,8 +746,13 @@ def interaction_next_cli_actions(
         if route_candidates:
             return [
                 f"loopx todo add --goal-id {goal_id} --role agent --text '<public-safe route continuation advancement todo>'",
-                f"loopx refresh-state --goal-id {goal_id} --classification route_continuation_replan_recorded --delivery-batch-scale single_surface --delivery-outcome outcome_progress{scoped_cli_args}",
-                _heartbeat_spend_command(goal_id, scoped_cli_args=scoped_cli_args, payload=payload),
+                f"loopx refresh-state --goal-id {goal_id} --classification route_continuation_replan_recorded --delivery-batch-scale single_surface --delivery-outcome outcome_progress{settlement_args}{scoped_cli_args}",
+                _quota_spend_action(
+                    goal_id,
+                    scoped_cli_args=scoped_cli_args,
+                    payload=payload,
+                    settlement_plan=settlement_plan,
+                ),
             ]
         candidates = (
             agent_scope_frontier.get("deferred_resume_candidates")
@@ -689,8 +767,13 @@ def interaction_next_cli_actions(
             f"{lifecycle_actor_args} --status open --clear-resume-when "
             "--note '<public-safe successor replan reason>'"
             ),
-            f"loopx refresh-state --goal-id {goal_id} --classification successor_replan_recorded --delivery-batch-scale single_surface --delivery-outcome outcome_progress{scoped_cli_args}",
-            _heartbeat_spend_command(goal_id, scoped_cli_args=scoped_cli_args, payload=payload),
+            f"loopx refresh-state --goal-id {goal_id} --classification successor_replan_recorded --delivery-batch-scale single_surface --delivery-outcome outcome_progress{settlement_args}{scoped_cli_args}",
+            _quota_spend_action(
+                goal_id,
+                scoped_cli_args=scoped_cli_args,
+                payload=payload,
+                settlement_plan=settlement_plan,
+            ),
         ]
     if (
         mode == AgentScopeFrontierAction.AGENT_SCOPE_WAIT.value
@@ -709,7 +792,12 @@ def interaction_next_cli_actions(
         return [
             "read approved controller/job/marker/writeback surfaces only",
             f"loopx refresh-state --goal-id {goal_id} --classification <compact_blocker_or_transition>{scoped_cli_args}",
-            _heartbeat_spend_command(goal_id, scoped_cli_args=scoped_cli_args, payload=payload),
+            _quota_spend_action(
+                goal_id,
+                scoped_cli_args=scoped_cli_args,
+                payload=payload,
+                settlement_plan=settlement_plan,
+            ),
         ]
     if mode == "agent_workspace_repair":
         return [
@@ -755,11 +843,11 @@ def interaction_next_cli_actions(
             else "<delta_kind>"
         )
         actions.extend([
-            f"loopx refresh-state --goal-id {goal_id} --classification autonomous_replan_recorded --autonomous-replan-recorded --repair-delta-kind {delta_kind} --delivery-batch-scale <scale> --delivery-outcome <outcome>{scoped_cli_args}",
+            f"loopx refresh-state --goal-id {goal_id} --classification autonomous_replan_recorded --autonomous-replan-recorded --repair-delta-kind {delta_kind} --delivery-batch-scale <scale> --delivery-outcome <outcome>{settlement_args}{scoped_cli_args}",
             (
                 "if the replan writeback records an accountable delta such as "
                 "outcome_progress or primary_goal_outcome, run "
-                f"{_heartbeat_spend_command(goal_id, scoped_cli_args=scoped_cli_args, payload=payload)}; "
+                f"{_quota_spend_action(goal_id, scoped_cli_args=scoped_cli_args, payload=payload, settlement_plan=settlement_plan)}; "
                 "otherwise do not spend for surface_only watch-lane continuation/no-followup"
             ),
         ])
@@ -773,10 +861,20 @@ def interaction_next_cli_actions(
         "scoped_user_gate_fallback",
         "bounded_delivery_with_user_notice",
     }:
+        typed_writeback = settlement_step_command(
+            settlement_plan,
+            SettlementStepKind.DURABLE_WRITEBACK,
+        )
         return [
             *capability_resolution_actions,
-            f"loopx refresh-state --goal-id {goal_id} --classification <validated_progress>{scoped_cli_args}",
-            _heartbeat_spend_command(goal_id, scoped_cli_args=scoped_cli_args, payload=payload),
+            typed_writeback
+            or f"loopx refresh-state --goal-id {goal_id} --classification <validated_progress>{scoped_cli_args}",
+            _quota_spend_action(
+                goal_id,
+                scoped_cli_args=scoped_cli_args,
+                payload=payload,
+                settlement_plan=settlement_plan,
+            ),
         ]
     if mode in {"user_gate", "user_todo_blocker_push", "user_action_required"}:
         return [
@@ -1081,6 +1179,11 @@ def _build_interaction_cli_channel(
         available_capabilities=available_capabilities,
         scheduler_execution_context=scheduler_execution_context,
     )
+    settlement_plan = _codex_app_settlement_plan(
+        payload,
+        available_capabilities=available_capabilities,
+        scheduler_execution_context=scheduler_execution_context,
+    )
     channel = {
         "next_cli_actions": interaction_next_cli_actions(
             payload,
@@ -1088,6 +1191,7 @@ def _build_interaction_cli_channel(
             available_capabilities=available_capabilities,
             scheduler_execution_context=scheduler_execution_context,
             capability_reentry=capability_reentry,
+            settlement_plan=settlement_plan,
         ),
         "spend_allowed_now": False,
         "spend_after_validation": spend_after_validation,
@@ -1098,6 +1202,8 @@ def _build_interaction_cli_channel(
             spend_after_validation=spend_after_validation,
         ),
     }
+    if settlement_plan is not None and spend_after_validation:
+        channel["settlement_plan"] = settlement_plan
     if capability_reentry is not None:
         channel["runtime_capability_reentry"] = capability_reentry
     selected_todo = (

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -789,14 +789,24 @@ def interaction_next_cli_actions(
             typed_quota_guard,
         ]
     if mode == "external_evidence_observation":
+        spend_action = _quota_spend_action(
+            goal_id,
+            scoped_cli_args=scoped_cli_args,
+            payload=payload,
+            settlement_plan=settlement_plan,
+        )
         return [
             "read approved controller/job/marker/writeback surfaces only",
-            f"loopx refresh-state --goal-id {goal_id} --classification <compact_blocker_or_transition>{scoped_cli_args}",
-            _quota_spend_action(
-                goal_id,
-                scoped_cli_args=scoped_cli_args,
-                payload=payload,
-                settlement_plan=settlement_plan,
+            (
+                "on a substantive transition or blocker only: "
+                f"loopx refresh-state --goal-id {goal_id} "
+                "--classification <compact_blocker_or_transition> "
+                "--delivery-batch-scale <scale> --delivery-outcome <outcome>"
+                f"{settlement_args}{scoped_cli_args}"
+            ),
+            (
+                "after that accountable writeback receipt only: "
+                f"{spend_action}; otherwise do not spend for unchanged observation"
             ),
         ]
     if mode == "agent_workspace_repair":

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -36,6 +36,13 @@ from .control_plane.quota.scheduler_ack import (
     QUOTA_SCHEDULER_ACK_CLASSIFICATION,
     record_quota_scheduler_ack_for_decision,
 )
+from .control_plane.quota.settlement import (
+    find_settlement_spend_run,
+    require_settlement_spend,
+    require_settlement_writeback,
+    resolve_heartbeat_settlement_identity,
+    settlement_result_payload,
+)
 from .control_plane.quota.slot_accounting import (
     QUOTA_SLOT_SPENT_CLASSIFICATION,
     QUOTA_SLOT_VOIDED_CLASSIFICATION,
@@ -813,6 +820,7 @@ def build_quota_slot_preview(
     available_capabilities: Any = None,
     operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
     todo_id: str | None = None,
+    turn_instance_id: str | None = None,
     source: str = DEFAULT_SLOT_SPEND_SOURCE,
 ) -> dict[str, Any]:
     safe_goal_id = str(goal_id or "").strip()
@@ -838,6 +846,7 @@ def build_quota_slot_preview(
         quota_status_builder=quota_status,
         self_repair_spend_actions=SELF_REPAIR_SPEND_ACTIONS,
         todo_id=todo_id,
+        turn_instance_id=turn_instance_id,
         source=source,
     )
 
@@ -1032,8 +1041,85 @@ def spend_quota_slot(
     available_capabilities: Any = None,
     operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
     todo_id: str | None = None,
+    turn_instance_id: str | None = None,
 ) -> dict[str, Any]:
     safe_goal_id = _validate_goal_id_path_segment(str(goal_id or ""))
+    if turn_instance_id and source != DEFAULT_SLOT_SPEND_SOURCE:
+        return {
+            "ok": False,
+            "mode": "spend-slot",
+            "dry_run": not execute,
+            "appended": False,
+            "goal_id": safe_goal_id,
+            "reason": "turn-scoped settlement is valid only for heartbeat spend",
+        }
+    raw_runtime_root = status_payload.get("runtime_root")
+    if turn_instance_id and raw_runtime_root:
+        runtime_root = Path(str(raw_runtime_root)).expanduser()
+        guard_result = resolve_heartbeat_settlement_identity(
+            runtime_root,
+            goal_id=safe_goal_id,
+            agent_id=agent_id,
+            todo_id=todo_id,
+            turn_instance_id=turn_instance_id,
+        )
+        if guard_result.failure is not None or guard_result.value is None:
+            return {
+                "ok": False,
+                "mode": "spend-slot",
+                "dry_run": not execute,
+                "appended": False,
+                "goal_id": safe_goal_id,
+                "reason": (
+                    guard_result.failure.reason
+                    if guard_result.failure is not None
+                    else "turn-scoped spend has no settlement identity"
+                ),
+                "settlement_result": settlement_result_payload(guard_result),
+            }
+        identity = guard_result.value
+        spent_result = guard_result.bind(
+            lambda resolved: require_settlement_writeback(
+                runtime_root,
+                resolved,
+            )
+        ).bind(
+            lambda _writeback: require_settlement_spend(
+                runtime_root,
+                identity,
+            )
+        )
+        if spent_result.failure is None:
+            return {
+                "ok": True,
+                "mode": "spend-slot",
+                "dry_run": not execute,
+                "appended": False,
+                "idempotent_replay": True,
+                "goal_id": safe_goal_id,
+                "agent_id": identity.agent_id,
+                "todo_id": identity.todo_id,
+                "turn_instance_id": identity.turn_instance_id,
+                "settlement_identity": identity.as_dict(),
+                "settlement_result": settlement_result_payload(spent_result),
+                "reason": "quota spend receipt replayed for the same settlement identity",
+            }
+        prior_spend_run = find_settlement_spend_run(runtime_root, identity)
+        if prior_spend_run is not None:
+            return {
+                "ok": True,
+                "mode": "spend-slot",
+                "dry_run": not execute,
+                "appended": False,
+                "receipt_repair_required": bool(execute),
+                "goal_id": safe_goal_id,
+                "agent_id": identity.agent_id,
+                "todo_id": identity.todo_id,
+                "turn_instance_id": identity.turn_instance_id,
+                "settlement_identity": identity.as_dict(),
+                "settlement_result": settlement_result_payload(spent_result),
+                "reason": "quota spend run exists; repair its missing settlement receipt",
+            }
     preview = build_quota_slot_preview(
         status_payload,
         goal_id=safe_goal_id,
@@ -1043,6 +1129,7 @@ def spend_quota_slot(
         available_capabilities=available_capabilities,
         operator_inbox_urgency_projector=operator_inbox_urgency_projector,
         todo_id=todo_id,
+        turn_instance_id=turn_instance_id,
         source=source,
     )
     if not preview.get("ok"):

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -17,6 +17,13 @@ from .control_plane.work_items.delivery_outcome import (
     require_delivery_outcome,
 )
 from .control_plane.agents.workspace_guard import capture_delivery_workspace
+from .control_plane.quota.settlement import (
+    SettlementIdentity,
+    find_settlement_writeback,
+    require_settlement_writeback,
+    resolve_heartbeat_settlement_identity,
+    settlement_result_payload,
+)
 from .control_plane.work_items.repair_delta import (
     REPAIR_DELTA_KIND_CHOICES as REPAIR_DELTA_KIND_CHOICES,
     normalize_repair_delta_kinds,
@@ -583,6 +590,7 @@ def build_state_refresh_record(
     agent_vision: dict[str, Any] | None = None,
     vision_checkpoint: dict[str, Any] | None = None,
     delivery_workspace: dict[str, Any] | None = None,
+    settlement_identity: SettlementIdentity | None = None,
 ) -> dict[str, Any]:
     frontmatter = parse_frontmatter(state_text)
     next_action = extract_section_lines(state_text, "Next Action")
@@ -627,6 +635,10 @@ def build_state_refresh_record(
         record["delivery_outcome"] = delivery_outcome
     if delivery_workspace:
         record["delivery_workspace"] = delivery_workspace
+    if settlement_identity:
+        record["settlement_identity"] = settlement_identity.as_dict()
+        record["turn_instance_id"] = settlement_identity.turn_instance_id
+        record["todo_id"] = settlement_identity.todo_id
     if autonomous_replan_recorded:
         record["autonomous_replan_ack"] = {
             "schema_version": "autonomous_replan_ack_v0",
@@ -684,7 +696,14 @@ def _build_state_refresh_output_projections(
         },
         "runtime_projection_route": record["runtime_projection_route"],
     })
-    for field in ("delivery_batch_scale", "delivery_outcome", "delivery_workspace"):
+    for field in (
+        "delivery_batch_scale",
+        "delivery_outcome",
+        "delivery_workspace",
+        "settlement_identity",
+        "turn_instance_id",
+        "todo_id",
+    ):
         if field in record:
             index_record[field] = record[field]
 
@@ -933,6 +952,8 @@ def refresh_state_run(
     delivery_batch_scale: str | None = None,
     delivery_outcome: str | None = None,
     delivery_workspace_path: Path | None = None,
+    todo_id: str | None = None,
+    turn_instance_id: str | None = None,
     agent_id: str | None = None,
     agent_lane: str | None = None,
     progress_scope: str | None = None,
@@ -970,6 +991,80 @@ def refresh_state_run(
     normalized_repair_delta_kinds = normalize_repair_delta_kinds(repair_delta_kinds)
     registry = load_registry(registry_path)
     runtime_root = resolve_runtime_root(registry, runtime_root_override)
+    settlement_identity = None
+    settlement_result = None
+    if todo_id or turn_instance_id:
+        if normalized_delivery_outcome not in ACCOUNTABLE_DELIVERY_OUTCOMES:
+            raise ValueError(
+                "turn-scoped refresh-state requires an accountable --delivery-outcome"
+            )
+        settlement_result = resolve_heartbeat_settlement_identity(
+            runtime_root,
+            goal_id=safe_goal_id,
+            agent_id=normalized_agent_id or None,
+            todo_id=todo_id,
+            turn_instance_id=turn_instance_id,
+        )
+        if settlement_result.failure is not None:
+            raise ValueError(settlement_result.failure.reason)
+        settlement_identity = settlement_result.value
+        if settlement_identity is None:
+            raise ValueError("turn-scoped refresh-state has no settlement identity")
+        if not dry_run:
+            prior_writeback = require_settlement_writeback(
+                runtime_root,
+                settlement_identity,
+            )
+            if prior_writeback.failure is None and prior_writeback.value is not None:
+                return {
+                    "ok": True,
+                    "dry_run": False,
+                    "appended": False,
+                    "idempotent_replay": True,
+                    "registry": str(registry_path),
+                    "runtime_root": str(runtime_root),
+                    "goal_id": safe_goal_id,
+                    "classification": prior_writeback.value.get("classification"),
+                    "delivery_batch_scale": prior_writeback.value.get(
+                        "delivery_batch_scale"
+                    ),
+                    "delivery_outcome": prior_writeback.value.get(
+                        "delivery_outcome"
+                    ),
+                    "settlement_identity": settlement_identity.as_dict(),
+                    "settlement_result": settlement_result_payload(
+                        settlement_result.bind(
+                            lambda _identity: prior_writeback
+                        )
+                    ),
+                }
+            prior_writeback_run = find_settlement_writeback(
+                runtime_root,
+                settlement_identity,
+            )
+            if prior_writeback_run is not None:
+                return {
+                    "ok": True,
+                    "dry_run": False,
+                    "appended": False,
+                    "receipt_repair_required": True,
+                    "registry": str(registry_path),
+                    "runtime_root": str(runtime_root),
+                    "goal_id": safe_goal_id,
+                    "classification": prior_writeback_run.get("classification"),
+                    "delivery_batch_scale": prior_writeback_run.get(
+                        "delivery_batch_scale"
+                    ),
+                    "delivery_outcome": prior_writeback_run.get(
+                        "delivery_outcome"
+                    ),
+                    "settlement_identity": settlement_identity.as_dict(),
+                    "settlement_result": settlement_result_payload(
+                        settlement_result.bind(
+                            lambda _identity: prior_writeback
+                        )
+                    ),
+                }
     runtime_projection_route = resolve_runtime_projection_route(
         registry_path=registry_path,
         goal_id=safe_goal_id,
@@ -1195,6 +1290,7 @@ def refresh_state_run(
         agent_vision=agent_vision,
         vision_checkpoint=vision_checkpoint,
         delivery_workspace=delivery_workspace,
+        settlement_identity=settlement_identity,
     )
     if autonomous_replan_recorded:
         if "autonomous_replan_ack" not in record:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ files = [
   "loopx/benchmarks/read_models/benchmark_run_execution_contract.py",
   "loopx/benchmarks/read_models/benchmark_run_failure.py",
   "loopx/control_plane/__init__.py",
+  "loopx/control_plane/quota/effect_program.py",
   "loopx/control_plane/quota/states.py",
   "loopx/control_plane/runtime/active_user_assisted_pilot.py",
   "loopx/control_plane/runtime/event_store_migration_bridge.py",

--- a/tests/control_plane/test_quota_settlement.py
+++ b/tests/control_plane/test_quota_settlement.py
@@ -194,6 +194,32 @@ def test_standard_codex_app_actions_use_typed_settlement_before_turn_driver() ->
         assert '--turn-instance-id "${LOOPX_TURN:?}"' in command
 
 
+def test_codex_app_external_observation_settles_only_substantive_writeback() -> None:
+    todo_id = "todo_external_observation"
+    actions = interaction_next_cli_actions(
+        {
+            "goal_id": GOAL_ID,
+            "agent_identity": {"agent_id": AGENT_ID},
+            "selected_todo": {"todo_id": todo_id},
+        },
+        mode="external_evidence_observation",
+        scheduler_execution_context=scheduler_execution_context_for_runtime_profile(
+            SchedulerRuntimeProfile.CODEX_APP_HEARTBEAT
+        ),
+    )
+
+    assert len(actions) == 3
+    assert actions[0].startswith("read approved")
+    assert actions[1].startswith("on a substantive transition or blocker only:")
+    assert "--delivery-outcome <outcome>" in actions[1]
+    assert f"--todo-id {todo_id}" in actions[1]
+    assert '--turn-instance-id "${LOOPX_TURN:?}"' in actions[1]
+    assert actions[2].startswith("after that accountable writeback receipt only:")
+    assert f"--todo-id {todo_id}" in actions[2]
+    assert '--turn-instance-id "${LOOPX_TURN:?}"' in actions[2]
+    assert "otherwise do not spend for unchanged observation" in actions[2]
+
+
 def test_guard_receipt_resolves_stable_settlement_identity(tmp_path: Path) -> None:
     _append_guard_receipt(tmp_path)
 

--- a/tests/control_plane/test_quota_settlement.py
+++ b/tests/control_plane/test_quota_settlement.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from loopx.control_plane.quota.settlement import (
+    SettlementFailureKind,
+    SettlementReceipt,
+    SettlementResult,
+    SettlementStepKind,
+    build_codex_app_settlement_plan,
+    resolve_heartbeat_settlement_identity,
+    settlement_step_command,
+)
+from loopx.control_plane.scheduler.execution_context import (
+    SchedulerRuntimeProfile,
+    scheduler_execution_context_for_runtime_profile,
+)
+from loopx.control_plane.work_items.interaction_contract import (
+    interaction_next_cli_actions,
+)
+from loopx.rollout_event_log import rollout_event_log_path
+
+GOAL_ID = "settlement-goal"
+AGENT_ID = "codex-settlement"
+TODO_ID = "todo_settlement"
+TURN_ID = "turn-settlement-1"
+
+
+def _receipt(step: SettlementStepKind, marker: str) -> SettlementReceipt:
+    return SettlementReceipt(
+        step_kind=step,
+        status="committed",
+        effect_id="effect-1",
+        source_ref=marker,
+    )
+
+
+def _append_guard_receipt(
+    runtime_root: Path,
+    *,
+    todo_id: str = TODO_ID,
+    effect_id: str | None = None,
+) -> None:
+    path = rollout_event_log_path(runtime_root, GOAL_ID)
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "loopx_rollout_event_v0",
+                "event_id": "event-guard",
+                "event_kind": "quota_should_run",
+                "goal_id": GOAL_ID,
+                "agent_id": AGENT_ID,
+                "run_id": TURN_ID,
+                "details": {
+                    "todo_id": todo_id,
+                    **(
+                        {"settlement_effect_id": effect_id}
+                        if effect_id is not None
+                        else {}
+                    ),
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_settlement_result_satisfies_left_and_right_identity() -> None:
+    def writeback(value: int) -> SettlementResult[int]:
+        return SettlementResult.pure(
+            value + 1,
+            receipts=(_receipt(SettlementStepKind.DURABLE_WRITEBACK, "writeback"),),
+        )
+
+    assert SettlementResult.pure(2).bind(writeback) == writeback(2)
+    result = writeback(2)
+    assert result.bind(SettlementResult.pure) == result
+
+
+def test_settlement_result_satisfies_associativity_and_preserves_order() -> None:
+    def writeback(value: int) -> SettlementResult[int]:
+        return SettlementResult.pure(
+            value + 1,
+            receipts=(_receipt(SettlementStepKind.DURABLE_WRITEBACK, "writeback"),),
+        )
+
+    def spend(value: int) -> SettlementResult[str]:
+        return SettlementResult.pure(
+            str(value),
+            receipts=(_receipt(SettlementStepKind.QUOTA_SPEND, "spend"),),
+        )
+
+    initial = SettlementResult.pure(1)
+    left = initial.bind(writeback).bind(spend)
+    right = initial.bind(lambda value: writeback(value).bind(spend))
+
+    assert left == right
+    assert [receipt.step_kind for receipt in left.receipts] == [
+        SettlementStepKind.DURABLE_WRITEBACK,
+        SettlementStepKind.QUOTA_SPEND,
+    ]
+    assert (
+        initial.bind(spend).bind(lambda value: writeback(int(value))).receipts
+        != left.receipts
+    )
+
+
+@pytest.mark.parametrize(
+    "failure_kind",
+    [
+        SettlementFailureKind.CANCELLED,
+        SettlementFailureKind.PERMISSION_DENIED,
+        SettlementFailureKind.BUDGET_REJECTED,
+    ],
+)
+def test_settlement_result_short_circuits_without_erasing_failure(
+    failure_kind: SettlementFailureKind,
+) -> None:
+    failed: SettlementResult[int] = SettlementResult.failed(
+        kind=failure_kind,
+        step_kind=SettlementStepKind.DURABLE_WRITEBACK,
+        reason="writeback denied",
+        receipts=(_receipt(SettlementStepKind.VALIDATION, "validation"),),
+    )
+    called = False
+
+    def spend(_value: int) -> SettlementResult[str]:
+        nonlocal called
+        called = True
+        return SettlementResult.pure("spent")
+
+    result = failed.bind(spend)
+
+    assert called is False
+    assert result.failure == failed.failure
+    assert result.failure is not None
+    assert result.failure.kind is failure_kind
+    assert result.receipts == failed.receipts
+
+
+def test_codex_app_plan_projects_one_identity_across_settlement_steps() -> None:
+    plan = build_codex_app_settlement_plan(
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        todo_id=TODO_ID,
+        scoped_cli_args=f" --agent-id {AGENT_ID}",
+        lifecycle_actor_args=f" --agent-id {AGENT_ID}",
+    ).as_dict()
+
+    assert plan["identity"]["todo_id"] == TODO_ID
+    assert plan["identity"]["turn_instance_id"] == "${LOOPX_TURN:?}"
+    assert [step["kind"] for step in plan["ordered_steps"]] == [
+        "validation",
+        "todo_completion",
+        "durable_writeback",
+        "quota_spend",
+    ]
+    for kind in (
+        SettlementStepKind.TODO_COMPLETION,
+        SettlementStepKind.DURABLE_WRITEBACK,
+        SettlementStepKind.QUOTA_SPEND,
+    ):
+        command = settlement_step_command(plan, kind)
+        assert command is not None
+        assert f"--todo-id {TODO_ID}" in command
+        assert '--turn-instance-id "${LOOPX_TURN:?}"' in command
+    assert plan["host_handoff"]["inside_agent_settlement"] is False
+
+
+def test_standard_codex_app_actions_use_typed_settlement_before_turn_driver() -> None:
+    todo_id = "todo_123456789abc"
+    actions = interaction_next_cli_actions(
+        {
+            "goal_id": GOAL_ID,
+            "agent_identity": {"agent_id": AGENT_ID},
+            "selected_todo": {"todo_id": todo_id},
+        },
+        mode="bounded_delivery",
+        scheduler_execution_context=scheduler_execution_context_for_runtime_profile(
+            SchedulerRuntimeProfile.CODEX_APP_HEARTBEAT
+        ),
+    )
+
+    assert len(actions) == 2
+    assert actions[0].startswith("loopx refresh-state")
+    assert actions[1].startswith("loopx quota spend-slot")
+    for command in actions:
+        assert f"--todo-id {todo_id}" in command
+        assert '--turn-instance-id "${LOOPX_TURN:?}"' in command
+
+
+def test_guard_receipt_resolves_stable_settlement_identity(tmp_path: Path) -> None:
+    _append_guard_receipt(tmp_path)
+
+    result = resolve_heartbeat_settlement_identity(
+        tmp_path,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        todo_id=TODO_ID,
+        turn_instance_id=TURN_ID,
+    )
+
+    assert result.failure is None
+    assert result.value is not None
+    assert result.value.effect_id == (f"{GOAL_ID}:{AGENT_ID}:{TODO_ID}:{TURN_ID}")
+    assert result.receipts[0].step_kind is SettlementStepKind.VALIDATION
+
+
+def test_guard_receipt_rejects_different_todo(tmp_path: Path) -> None:
+    _append_guard_receipt(tmp_path, todo_id="todo_original")
+
+    result = resolve_heartbeat_settlement_identity(
+        tmp_path,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        todo_id="todo_successor",
+        turn_instance_id=TURN_ID,
+    )
+
+    assert result.failure is not None
+    assert result.failure.kind is SettlementFailureKind.IDENTITY_MISMATCH
+    assert result.failure.step_kind is SettlementStepKind.VALIDATION
+
+
+def test_guard_receipt_rejects_different_effect_identity(tmp_path: Path) -> None:
+    _append_guard_receipt(tmp_path, effect_id="different-effect")
+
+    result = resolve_heartbeat_settlement_identity(
+        tmp_path,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        todo_id=TODO_ID,
+        turn_instance_id=TURN_ID,
+    )
+
+    assert result.failure is not None
+    assert result.failure.kind is SettlementFailureKind.IDENTITY_MISMATCH
+    assert "different-effect" in result.failure.reason

--- a/tests/control_plane/test_quota_settlement_cli.py
+++ b/tests/control_plane/test_quota_settlement_cli.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GOAL_ID = "settlement-cli-fixture"
+AGENT_ID = "codex-settlement-cli"
+TODO_ID = "todo_fixture_settlement"
+TURN_ID = "turn-settlement-cli-1"
+
+
+def _write_fixture(root: Path) -> tuple[Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_path = project / state_file
+    registry_path = project / ".loopx" / "registry.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        "---\n"
+        "status: active-read-only\n"
+        "owner_mode: goal\n"
+        'objective: "Settle one standard Codex App delivery."\n'
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Settlement CLI Fixture\n\n"
+        "## Objective\n\n"
+        "Settle one standard Codex App delivery.\n\n"
+        "## Next Action\n\n"
+        "- Validate and settle the selected delivery.\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P1] Validate and settle the selected delivery.\n"
+        f"  <!-- loopx:todo todo_id={TODO_ID} status=open "
+        "task_class=advancement_task action_kind=validate -->\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "settlement-cli-fixture",
+                        "status": "active-read-only",
+                        "repo": str(project),
+                        "state_file": state_file,
+                        "adapter": {
+                            "kind": "read_only_project_map_v0",
+                            "status": "connected-read-only",
+                        },
+                        "coordination": {
+                            "registered_agents": [AGENT_ID],
+                            "agent_model": "peer_v1",
+                        },
+                        "authority_sources": [],
+                        "quota": {
+                            "compute": 1.0,
+                            "window_hours": 24,
+                            "allowed_slots": 2,
+                        },
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return project, runtime, registry_path
+
+
+def _run_cli(
+    registry_path: Path,
+    runtime: Path,
+    *args: str,
+) -> tuple[int, dict[str, Any]]:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime),
+            "--format",
+            "json",
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode, json.loads(result.stdout)
+
+
+def _spend_run_count(runtime: Path) -> int:
+    index_path = runtime / "goals" / GOAL_ID / "runs" / "index.jsonl"
+    if not index_path.exists():
+        return 0
+    return sum(
+        1
+        for line in index_path.read_text(encoding="utf-8").splitlines()
+        if json.loads(line).get("classification") == "quota_slot_spent"
+    )
+
+
+def _classification_count(runtime: Path, classification: str) -> int:
+    index_path = runtime / "goals" / GOAL_ID / "runs" / "index.jsonl"
+    if not index_path.exists():
+        return 0
+    return sum(
+        1
+        for line in index_path.read_text(encoding="utf-8").splitlines()
+        if json.loads(line).get("classification") == classification
+    )
+
+
+def test_standard_codex_app_settlement_is_receipted_and_idempotent(
+    tmp_path: Path,
+) -> None:
+    project, runtime, registry_path = _write_fixture(tmp_path)
+    binding = (
+        "--agent-id",
+        AGENT_ID,
+        "--todo-id",
+        TODO_ID,
+        "--turn-instance-id",
+        TURN_ID,
+    )
+
+    guard_rc, guard = _run_cli(
+        registry_path,
+        runtime,
+        "quota",
+        "should-run",
+        "--codex-app",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--turn-instance-id",
+        TURN_ID,
+        "--scan-path",
+        str(project),
+    )
+
+    assert guard_rc == 0, guard
+    identity = guard["heartbeat_receipt"]["settlement_identity"]
+    assert identity["todo_id"] == TODO_ID
+    assert identity["effect_id"] == (f"{GOAL_ID}:{AGENT_ID}:{TODO_ID}:{TURN_ID}")
+
+    complete_args = (
+        "todo",
+        "complete",
+        "--goal-id",
+        GOAL_ID,
+        *binding,
+        "--claimed-by",
+        AGENT_ID,
+        "--evidence",
+        "original delivery validated",
+        "--next-agent-todo",
+        "Continue the explicit successor delivery.",
+        "--next-claimed-by",
+        AGENT_ID,
+        "--next-action-kind",
+        "implement",
+    )
+    complete_rc, complete = _run_cli(
+        registry_path,
+        runtime,
+        *complete_args,
+    )
+
+    assert complete_rc == 0, complete
+    assert complete["settlement_result"]["ok"] is True
+    assert [
+        receipt["step_kind"] for receipt in complete["settlement_result"]["receipts"]
+    ] == ["validation", "todo_completion"]
+    successor_id = complete["next_todos"][0]["todo_id"]
+    assert successor_id != TODO_ID
+    complete_replay_rc, complete_replay = _run_cli(
+        registry_path,
+        runtime,
+        *complete_args,
+    )
+    assert complete_replay_rc == 0, complete_replay
+    assert complete_replay["idempotent_replay"] is True
+    assert complete_replay["settlement_result"]["ok"] is True
+
+    refresh_args = (
+        "refresh-state",
+        "--goal-id",
+        GOAL_ID,
+        "--classification",
+        "validated_progress",
+        "--delivery-batch-scale",
+        "single_surface",
+        "--delivery-outcome",
+        "outcome_progress",
+        *binding,
+        "--no-global-sync",
+        "--suppress-external-sinks",
+    )
+    refresh_rc, refresh = _run_cli(
+        registry_path,
+        runtime,
+        *refresh_args,
+    )
+
+    assert refresh_rc == 0, refresh
+    assert refresh["settlement_result"]["ok"] is True
+    assert [
+        receipt["step_kind"] for receipt in refresh["settlement_result"]["receipts"]
+    ] == ["validation", "durable_writeback"]
+    refresh_replay_rc, refresh_replay = _run_cli(
+        registry_path,
+        runtime,
+        *refresh_args,
+    )
+    assert refresh_replay_rc == 0, refresh_replay
+    assert refresh_replay["idempotent_replay"] is True
+    assert _classification_count(runtime, "validated_progress") == 1
+
+    fresh_guard_rc, fresh_guard = _run_cli(
+        registry_path,
+        runtime,
+        "quota",
+        "should-run",
+        "--codex-app",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--scan-path",
+        str(project),
+    )
+    assert fresh_guard_rc == 0, fresh_guard
+    assert fresh_guard["selected_todo"]["todo_id"] == successor_id
+
+    spend_args = (
+        "quota",
+        "spend-slot",
+        "--goal-id",
+        GOAL_ID,
+        "--slots",
+        "1",
+        "--source",
+        "heartbeat",
+        "--execute",
+        *binding,
+        "--scan-path",
+        str(project),
+    )
+    spend_rc, spend = _run_cli(registry_path, runtime, *spend_args)
+    replay_rc, replay = _run_cli(registry_path, runtime, *spend_args)
+
+    assert spend_rc == 0, spend
+    assert spend["settlement_result"]["ok"] is True
+    assert [
+        receipt["step_kind"] for receipt in spend["settlement_result"]["receipts"]
+    ] == ["validation", "durable_writeback", "quota_spend"]
+    assert replay_rc == 0, replay
+    assert replay["idempotent_replay"] is True
+    assert replay["appended"] is False
+    assert _spend_run_count(runtime) == 1

--- a/tests/control_plane/test_quota_slot_accounting.py
+++ b/tests/control_plane/test_quota_slot_accounting.py
@@ -10,6 +10,7 @@ from loopx.control_plane.quota.slot_accounting import (
     build_quota_slot_preview_for_decision,
     build_quota_slot_spend_event,
 )
+from loopx.rollout_event_log import rollout_event_log_path
 
 GOAL_ID = "quota-slot-accounting-fixture"
 AGENT_A = "codex-monitor-a"
@@ -558,6 +559,96 @@ def test_heartbeat_spend_reselection_strands_completed_todo_settlement(
     assert preview["ok"] is False
     assert "selected todo is todo_new_successor" in preview["reason"]
     assert "--todo-id is todo_completed_delivery" in preview["reason"]
+
+
+def test_turn_scoped_spend_keeps_original_todo_across_successor_reselection(
+    tmp_path: Path,
+) -> None:
+    runtime = tmp_path / "runtime"
+    original_todo_id = "todo_completed_delivery"
+    turn_instance_id = "turn-completed-delivery"
+    effect_id = (
+        f"{GOAL_ID}:{AGENT_A}:{original_todo_id}:{turn_instance_id}"
+    )
+    _write_run_index(
+        runtime,
+        [
+            {
+                **_run(
+                    "2026-01-01T00:01:00+00:00",
+                    classification="validated_progress",
+                    delivery_outcome="outcome_progress",
+                    agent_id=AGENT_A,
+                ),
+                "todo_id": original_todo_id,
+                "turn_instance_id": turn_instance_id,
+                "settlement_identity": {
+                    "effect_id": effect_id,
+                    "goal_id": GOAL_ID,
+                    "agent_id": AGENT_A,
+                    "todo_id": original_todo_id,
+                    "turn_instance_id": turn_instance_id,
+                },
+            }
+        ],
+    )
+    rollout_path = rollout_event_log_path(runtime, GOAL_ID)
+    rollout_path.parent.mkdir(parents=True, exist_ok=True)
+    rollout_path.write_text(
+        "".join(
+            json.dumps(event) + "\n"
+            for event in (
+                {
+                    "schema_version": "loopx_rollout_event_v0",
+                    "event_id": "event-guard",
+                    "event_kind": "quota_should_run",
+                    "goal_id": GOAL_ID,
+                    "agent_id": AGENT_A,
+                    "run_id": turn_instance_id,
+                    "details": {
+                        "todo_id": original_todo_id,
+                        "settlement_effect_id": effect_id,
+                    },
+                },
+                {
+                    "schema_version": "loopx_rollout_event_v0",
+                    "event_id": "event-writeback",
+                    "event_kind": "refresh_state",
+                    "goal_id": GOAL_ID,
+                    "agent_id": AGENT_A,
+                    "run_id": turn_instance_id,
+                    "details": {"settlement_effect_id": effect_id},
+                },
+            )
+        ),
+        encoding="utf-8",
+    )
+    before = _normal_run_before(todo_id="todo_new_successor")
+
+    preview = build_quota_slot_preview_for_decision(
+        _normal_run_status(runtime),
+        goal_id=GOAL_ID,
+        before=before,
+        after_decision=lambda _: {
+            **before,
+            "quota": {**before["quota"], "spent_slots": 1},
+        },
+        quota_status_builder=lambda goal, **_: goal["quota"],
+        self_repair_spend_actions=frozenset(),
+        agent_id=AGENT_A,
+        todo_id=original_todo_id,
+        turn_instance_id=turn_instance_id,
+        source="heartbeat",
+    )
+
+    assert preview["ok"] is True
+    assert preview["delivery_completion_spend"] is True
+    assert preview["todo_id"] == original_todo_id
+    assert preview["settlement_identity"]["effect_id"] == effect_id
+    assert [
+        receipt["step_kind"]
+        for receipt in preview["settlement_result"]["receipts"]
+    ] == ["validation", "durable_writeback"]
 
 
 def test_heartbeat_spend_records_matching_todo_binding(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- introduce a typed settlement program for the standard Codex App path with stable goal/agent/Todo/turn identity
- bind validation, optional Todo completion, durable writeback, and quota spend through receipt-checked flat-map semantics
- preserve scheduler authority as host handoff and keep the turn-driver adapter out of this batch
- keep external-evidence observation no-spend when unchanged; bind substantive transition/blocker writeback to the same settlement identity
- add exact-once replay, causal successor protection, structured failure modes, law tests, and a real CLI lifecycle test

## Validation

- 337 focused control-plane tests passed
- strict mypy passed for 16 source files
- Ruff 0.15.7 passed on every changed path
- interaction, external-evidence, heartbeat quota, and Todo lifecycle production smokes passed
- premerge canary: 17/17 selected checks passed; no failures, skips, or manual holds
- change-quality receipt: cqr_bd9d1048e3acba9112cf
- public/private boundary scan passed