### PR TITLE
docs: add PR/issue area label taxonomy and template guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Report reproducible incorrect or unexpected LoopX behavior.
 title: "[Bug]: "
-labels: ["bug"]
+labels: ["bug", "triage"]
 body:
   - type: markdown
     attributes:
@@ -51,6 +51,22 @@ body:
         - Custom or external worker
         - Not host-specific
         - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: LoopX area
+      description: Which public product area does this bug affect? Maintainers use this to apply the matching area label.
+      options:
+        - Control plane (goals, todos, quota, scheduler, registry, runtime)
+        - Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
+        - Capability or extension (providers, adapters, skills)
+        - Public docs or presentation surface (README, protocols, dashboard)
+        - Build, packaging, installer, or CI
+        - Host or runtime integration
+        - Not sure
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Propose a concrete LoopX product or documentation improvement.
 title: "[Feature]: "
-labels: ["enhancement"]
+labels: ["enhancement", "triage"]
 body:
   - type: markdown
     attributes:
@@ -58,16 +58,16 @@ body:
   - type: dropdown
     id: area
     attributes:
-      label: Product area
+      label: LoopX area
+      description: Which public product area does this request target? Maintainers use this to apply the matching area label.
       options:
-        - Goal, todo, and gate lifecycle
-        - Quota, scheduler, and heartbeat
-        - Issue-fix or another domain capability
-        - Host and runtime integration
-        - Dashboard and operator surfaces
-        - Extensions and external integrations
-        - Documentation and onboarding
-        - Other
+        - Control plane (goals, todos, quota, scheduler, registry, runtime)
+        - Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
+        - Capability or extension (providers, adapters, skills)
+        - Public docs or presentation surface (README, protocols, dashboard)
+        - Build, packaging, installer, or CI
+        - Host or runtime integration
+        - Not sure
     validations:
       required: true
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,28 @@
 - [ ] `loopx check --scan-root .`
 - [ ] Other:
 
+## Type of Change
+
+<!-- Mark the applicable options. -->
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Refactoring (no functional changes)
+- [ ] Documentation update
+- [ ] Test update
+
+## LoopX Area
+
+<!-- Mark the primary area. Maintainers apply the matching GitHub label. -->
+
+- [ ] Control plane (goals, todos, quota, scheduler, registry, runtime)
+- [ ] Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
+- [ ] Capability or extension (providers, adapters, skills)
+- [ ] Public docs or presentation surface (README, protocols, dashboard)
+- [ ] Build, packaging, installer, or CI
+- [ ] Host or runtime integration
+
 ## Boundary Checklist
 
 - [ ] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -19,5 +19,9 @@ goals.
 - [Integration guide](../integration.md)
 - [Status data contract](../status-data-contract.md)
 
+## Maintainer And Triage
+
+- [PR and issue labels](pr-issue-labels.md)
+
 Runtime-specific adapters belong under
 [`docs/integrations/`](../integrations/README.md).

--- a/docs/operations/pr-issue-labels.md
+++ b/docs/operations/pr-issue-labels.md
@@ -1,0 +1,56 @@
+# PR And Issue Labels
+
+LoopX uses GitHub labels so maintainers, contributors, and agent monitors can
+filter, route, and aggregate issues and pull requests by lifecycle and product
+area.
+
+## Lifecycle Labels
+
+These labels describe the item lifecycle and are applied by issue templates or
+maintainer triage:
+
+| Label | Applied by | Meaning |
+| --- | --- | --- |
+| `bug` | Bug report template | Reproducible incorrect or unexpected behavior. |
+| `enhancement` | Feature request template | Concrete product or documentation improvement. |
+| `triage` | Issue templates | Needs maintainer triage or routing before work starts. |
+| `duplicate` / `question` / `invalid` / `wontfix` | Maintainer triage | Standard GitHub lifecycle states. |
+| `good first issue` / `help wanted` | Maintainer triage | Contributor onboarding signals. |
+| `workflow-audit` | Contributor task board | Public or synthetic agent workflows for LoopX audit. |
+
+## Area Labels
+
+Area labels describe the public product surface a change touches. Issue
+templates ask contributors to select an area, and pull request templates ask
+for a self-tagged primary area; maintainers apply the matching label:
+
+| Label | Public surface |
+| --- | --- |
+| `control-plane` | Goals, todos, quota, scheduler, registry, runtime, state, and gate lifecycle. |
+| `benchmark-boundary` | Benchmark adapters, runners, verifiers, scoring, leaderboards, and public benchmark evidence. |
+| `capability-extension` | Capability, extension, provider, adapter, or skill contracts. |
+| `public-docs` | README, protocol docs, frontstage, dashboard, and first-screen presentation surfaces. |
+| `build-or-ci` | Build, packaging, installer, CI workflows, and release pipelines. |
+
+Anything not clearly covered by an area label keeps only its lifecycle label.
+
+## Triage Policy
+
+1. Issue templates auto-apply `triage` plus `bug` or `enhancement`.
+2. Maintainers (or an approved bot) move triaged items forward: route to an
+   area label, mark `duplicate`/`question`/`invalid`/`wontfix`, or link a
+   contributor task.
+3. Pull requests self-tag a primary area in the template. Reviewers verify the
+   area matches the diff and correct the label when it does not.
+4. Agent monitors (PR review queue, issue intake) may read area labels as
+   routing hints, but labels never grant review, merge, or write authority.
+
+## Staged Auto-Classification
+
+Today labels are human-selected through templates and triage. The next stage
+may add a rule-based classifier that suggests area labels from title, changed
+files, and review areas, followed by an offline model for long-tail cases.
+This staged path follows the classification practice used by the OpenViking
+feedback observability design: start with deterministic rules as an
+enhancement, then move to a model, then stabilize the taxonomy. Until then,
+labels are guidance, not an automated contract.


### PR DESCRIPTION
## Summary

Adds a public PR/issue label taxonomy for the LoopX repository so issues and
pull requests can be filtered, routed, and aggregated by product area, and so
issue templates stop referencing labels that do not exist.

## What Changed

- Created repository labels: `triage`, `control-plane`, `benchmark-boundary`,
  `public-docs`, `capability-extension`, `build-or-ci`.
- Bug report and feature request templates now auto-apply `triage` alongside
  `bug` / `enhancement`, and ask contributors to select the LoopX area so
  maintainers can apply the matching area label.
- Pull request template now asks contributors to self-tag a Type of Change and
  a primary LoopX area, matching the same taxonomy.
- Added `docs/operations/pr-issue-labels.md` documenting the lifecycle and
  area labels, the triage policy, and the staged rule-based auto-classification
  plan (following the OpenViking feedback-observability classification
  practice: deterministic rules first, offline model later).

## Validation

- Issue template YAML parses cleanly (`yaml.safe_load` for all templates).
- `git diff --check` clean.
- Public/private boundary scan clean (no local paths, credentials, or internal
  material).
- Labels created and read back via `gh label list`.

## Notes

Labels are guidance for routing and aggregation; they grant no review, merge,
or write authority. Auto-applied labels are limited to what GitHub issue forms
support (fixed template labels); area labels are applied by maintainers after
the contributor's area selection.
