### PR TITLE
feat(first-run): add local feedback receipt and public issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/first_run.yml
+++ b/.github/ISSUE_TEMPLATE/first_run.yml
@@ -1,0 +1,71 @@
+name: First run
+description: Optional public feedback after installing and running LoopX for the first time.
+title: "First run: [OS] / [host]"
+labels: ["first-run", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for trying LoopX. This issue is optional and public. Do not paste logs,
+        absolute paths, credentials, internal project names, or goal contents.
+  - type: input
+    id: version
+    attributes:
+      label: LoopX version
+      description: Output of `loopx --version`, if available.
+      placeholder: "0.4.4"
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - WSL
+        - Other
+  - type: dropdown
+    id: host
+    attributes:
+      label: Host surface
+      options:
+        - Codex App
+        - Codex CLI
+        - Claude Code
+        - OpenCode
+        - TraeX
+        - Pi
+        - Gemini CLI
+        - Cursor
+        - Shell or custom runner
+        - Other
+  - type: checkboxes
+    id: steps
+    attributes:
+      label: Completed steps
+      options:
+        - label: Install
+        - label: loopx doctor
+        - label: connect
+        - label: Create a goal or todo
+        - label: Complete a writeback
+        - label: Resume across sessions
+  - type: input
+    id: task_type
+    attributes:
+      label: Task type (optional)
+      description: One short generic label such as research, coding, ops, or a personal project.
+      placeholder: "research"
+  - type: checkboxes
+    id: boundaries
+    attributes:
+      label: Public/private boundary
+      options:
+        - label: This issue does not contain logs, paths, credentials, internal project names, or goal contents.
+          required: true
+  - type: checkboxes
+    id: citation
+    attributes:
+      label: Usage evidence
+      options:
+        - label: I allow maintainers to cite this issue as an anonymous first-run adoption sample.

--- a/.github/ISSUE_TEMPLATE/usage_story.yml
+++ b/.github/ISSUE_TEMPLATE/usage_story.yml
@@ -1,0 +1,60 @@
+name: Usage story
+description: Optional public report from users who ran LoopX over time, not just once.
+title: "Usage story: [duration] / [task type]"
+labels: ["usage-story", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing a longer-run LoopX story. This issue is optional and public.
+        Do not paste logs, absolute paths, credentials, internal project names, or goal contents.
+  - type: dropdown
+    id: duration
+    attributes:
+      label: How long did the loop run?
+      options:
+        - Several hours
+        - Several days
+        - Several weeks
+        - More than a month
+  - type: checkboxes
+    id: capabilities
+    attributes:
+      label: What did the run exercise?
+      options:
+        - label: Resume after crash or reboot
+        - label: Resume after model or runtime switch
+        - label: Multiple agents or parallel lanes
+        - label: Human gates and approval
+        - label: Quota / budget control
+        - label: Handoff across sessions
+  - type: input
+    id: scale
+    attributes:
+      label: Approximate scale (optional)
+      description: Wall-clock duration, number of goals, or number of turns.
+      placeholder: "5 days / 3 goals"
+  - type: textarea
+    id: blockers
+    attributes:
+      label: What broke, and how did you recover? (optional)
+      description: Public-safe failure mode only; no logs or private details.
+      placeholder: "Lost a session after a reboot; resumed from the saved state and completed the goal."
+  - type: textarea
+    id: outcome
+    attributes:
+      label: What did LoopX help you finish? (optional)
+      description: One public-safe outcome sentence.
+  - type: checkboxes
+    id: boundaries
+    attributes:
+      label: Public/private boundary
+      options:
+        - label: This issue does not contain logs, paths, credentials, internal project names, or goal contents.
+          required: true
+  - type: checkboxes
+    id: citation
+    attributes:
+      label: Usage evidence
+      options:
+        - label: I allow maintainers to cite this issue as an anonymous usage-story sample.

--- a/README.md
+++ b/README.md
@@ -250,6 +250,18 @@ loopx refresh-state         # what should the next turn see?
 loopx quota spend-slot      # account for a completed, validated slice
 ```
 
+### First-Run Feedback
+
+If LoopX works for you, a one-minute public issue helps us learn what a real
+first run looks like. It is optional, contains no telemetry, and should not
+include logs, paths, credentials, internal project names, or goal contents:
+
+- [First-run feedback](https://github.com/huangruiteng/loopx/issues/new?template=first_run.yml)
+- [Usage story for longer runs](https://github.com/huangruiteng/loopx/issues/new?template=usage_story.yml)
+
+`loopx first-run-report` prints the same prefilled link locally without
+sending anything.
+
 A successful connection has:
 
 - `loopx doctor` passing;

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -229,6 +229,16 @@ loopx refresh-state         # 下一轮应该看到什么？
 loopx quota spend-slot      # 为完成并验证的 slice 记账
 ```
 
+### 首次运行反馈
+
+如果 LoopX 帮你跑通了第一个任务，欢迎用一分钟提交一条公开反馈（可选，无任何
+遥测；不要粘贴日志、路径、凭据、内部项目名或 goal 内容）：
+
+- [首次运行反馈](https://github.com/huangruiteng/loopx/issues/new?template=first_run.yml)
+- [长程使用案例](https://github.com/huangruiteng/loopx/issues/new?template=usage_story.yml)
+
+`loopx first-run-report` 会在本地打印同样的预填链接，不会发送任何数据。
+
 成功连接后应该满足：
 
 - `loopx doctor` 通过；

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -68,6 +68,7 @@ from .cli_commands import (
     handle_evidence_log_command,
     handle_extension_command,
     handle_explore_command,
+    handle_first_run_report_command,
     handle_goal_channel_command,
     handle_history_command,
     handle_lark_inbox_command,
@@ -104,6 +105,7 @@ from .cli_commands import (
     register_extension_commands,
     register_explore_commands,
     register_goal_channel_commands,
+    register_first_run_report_command,
     register_history_command,
     register_lark_inbox_commands,
     build_lark_issue_fix_reviewer_provider_hooks,
@@ -214,6 +216,8 @@ def build_parser() -> LoopXArgumentParser:
 
     register_doctor_command(sub)
 
+    register_first_run_report_command(sub)
+
     register_worker_bridge_commands(sub, add_subcommand_format)
 
     register_support_control_commands(sub, add_subcommand_format)
@@ -321,6 +325,7 @@ def main(argv: list[str] | None = None) -> int:
             "codex-cli-visible-session-proof",
             "demo",
             "doctor",
+            "first-run-report",
             "new-project-prompt",
             "start-goal",
             "slash-commands",
@@ -367,6 +372,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "doctor":
         return handle_doctor_command(args, print_payload)
+
+    if args.command == "first-run-report":
+        return handle_first_run_report_command(args, print_payload)
 
     worker_bridge_result = handle_worker_bridge_command(
         args,

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -87,6 +87,10 @@ from .canary import handle_canary_command, register_canary_commands
 from .capability import handle_capability_command, register_capability_commands
 from .extension import handle_extension_command, register_extension_commands
 from .doctor import handle_doctor_command, register_doctor_command
+from .first_run_report import (
+    handle_first_run_report_command,
+    register_first_run_report_command,
+)
 from .dreaming import handle_dreaming_command, register_dreaming_commands
 from .evidence_log import handle_evidence_log_command, register_evidence_log_command
 from .explore import handle_explore_command, register_explore_commands
@@ -227,6 +231,7 @@ __all__ = [
     "handle_diagnose_command",
     "handle_demo_command",
     "handle_doctor_command",
+    "handle_first_run_report_command",
     "handle_dreaming_command",
     "handle_evidence_log_command",
     "handle_explore_command",
@@ -286,6 +291,7 @@ __all__ = [
     "register_capability_commands",
     "register_extension_commands",
     "register_doctor_command",
+    "register_first_run_report_command",
     "register_dreaming_commands",
     "register_evidence_log_command",
     "register_explore_commands",

--- a/loopx/cli_commands/first_run_report.py
+++ b/loopx/cli_commands/first_run_report.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from datetime import datetime, timezone
+import platform
+import sys
+from urllib.parse import urlencode
+
+from .. import __version__
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+
+FIRST_RUN_ISSUE_URL = "https://github.com/huangruiteng/loopx/issues/new"
+FIRST_RUN_ISSUE_TEMPLATE = "first_run.yml"
+
+
+def _issue_url(title: str) -> str:
+    query = urlencode({"template": FIRST_RUN_ISSUE_TEMPLATE, "title": title})
+    return f"{FIRST_RUN_ISSUE_URL}?{query}"
+
+
+def collect_first_run_report() -> dict[str, object]:
+    os_label = f"{platform.system()} {platform.release()}".strip()
+    title = f"First run: LoopX {__version__} on {os_label} ({platform.machine()})"
+    return {
+        "schema_version": "first_run_report_v0",
+        "loopx_version": __version__,
+        "os": os_label,
+        "arch": platform.machine(),
+        "python": sys.version.split()[0],
+        "reported_at": datetime.now(timezone.utc).isoformat(),
+        "issue_url": _issue_url(title),
+        "sent": False,
+    }
+
+
+def render_first_run_report_markdown(payload: dict[str, object]) -> str:
+    lines = [
+        "LoopX first-run report (local only, nothing was sent)",
+        "",
+        f"- LoopX: {payload['loopx_version']}",
+        f"- OS: {payload['os']}",
+        f"- Arch: {payload['arch']}",
+        f"- Python: {payload['python']}",
+        f"- Generated: {payload['reported_at']}",
+        "",
+        "Create an optional public feedback issue:",
+        str(payload["issue_url"]),
+    ]
+    return "\n".join(lines)
+
+
+def register_first_run_report_command(
+    subparsers: argparse._SubParsersAction,
+) -> argparse.ArgumentParser:
+    return subparsers.add_parser(
+        "first-run-report",
+        help="Print a local first-run receipt and an optional public feedback issue link.",
+    )
+
+
+def handle_first_run_report_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    payload = collect_first_run_report()
+    print_payload(payload, args.format, render_first_run_report_markdown)
+    return 0

--- a/loopx/control_plane/testing/cli_output_budget.py
+++ b/loopx/control_plane/testing/cli_output_budget.py
@@ -538,6 +538,12 @@ CLI_OUTPUT_COMMAND_CLASSIFICATIONS: tuple[CliOutputCommandClassification, ...] =
         rationale="installation diagnostic invoked on demand, not a recurring decision payload",
     ),
     CliOutputCommandClassification(
+        command_id="first-run-report",
+        qualification="explicit_cold_path_exception",
+        surface_id=None,
+        rationale="explicit local feedback receipt invoked on demand and sends nothing",
+    ),
+    CliOutputCommandClassification(
         command_id="slash-commands",
         qualification="explicit_cold_path_exception",
         surface_id=None,

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -27,6 +27,10 @@ COMMAND_GROUPS: list[dict[str, object]] = [
                 "purpose": "Check install, PATH, release snapshot, skills, and import health.",
             },
             {
+                "command": "loopx first-run-report",
+                "purpose": "Print a local first-run receipt and an optional public feedback issue link.",
+            },
+            {
                 "command": "loopx slash-commands --install",
                 "purpose": "Refresh host slash-command prompt and skill files.",
             },

--- a/man/loopx.1
+++ b/man/loopx.1
@@ -32,6 +32,9 @@ Start or continue one concrete long\-running goal through the agent.
 \fBloopx doctor\fR
 Check install, PATH, release snapshot, skills, and import health.
 .TP
+\fBloopx first\-run\-report\fR
+Print a local first\-run receipt and an optional public feedback issue link.
+.TP
 \fBloopx slash\-commands \-\-install\fR
 Refresh host slash\-command prompt and skill files.
 .TP

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -854,10 +854,12 @@ $skill_line
 $slash_line
 $claude_line
 $opencode_line
+- first-run feedback (optional): https://github.com/huangruiteng/loopx/issues/new?template=first_run.yml
 
 Current shell can use it with:
   export PATH="$bin_dir:\$PATH"
   export MANPATH="$man_root:\${MANPATH:-}"
   loopx doctor
+  loopx first-run-report
   man loopx
 EOF


### PR DESCRIPTION
Implements the approved first-run feedback design: a local-only receipt command plus optional public GitHub issue forms, with zero default telemetry.

## Changed surfaces
- New `loopx first-run-report` CLI command (local receipt + prefilled first-run issue URL; sends nothing)
- New `.github/ISSUE_TEMPLATE/first_run.yml` and `usage_story.yml` forms with public/private boundary checkboxes
- Install success hint in `scripts/install-local.sh`
- `loopx commands` catalog, manpage, and CLI output budget classification
- README + README.zh-CN first-run feedback sections

## Checks run
- `python3 -m loopx.cli first-run-report` (markdown and JSON) passed
- `examples/cli-help-manpage-smoke.py` passed with Python 3.12 + LOOPX_PYTHON
- `pytest tests/control_plane/test_cli_output_budget.py tests/control_plane/test_cli_output_differential.py`: 27 passed
- `ruff check` on changed Python files passed
- `git diff --check` clean

## Failures/skips
- Full `mypy` run not clean due to pre-existing repository-wide baseline errors unrelated to this diff; the new module has no mypy findings.
- No telemetry or network path added; smoke verifies zero-send local output.