### PR TITLE
fix(quota): raise monitor no-change replan streak default from 2 to 5

### DIFF
--- a/examples/control_plane/monitor-poll-writeback-smoke.py
+++ b/examples/control_plane/monitor-poll-writeback-smoke.py
@@ -435,7 +435,7 @@ def assert_interleaved_monitor_stalls_replan_blocked_benchmark() -> None:
         obligation = quota["autonomous_replan_obligation"]
         assert obligation["triggers"][0]["kind"] == "monitor_no_change_streak", obligation
         assert obligation["triggers"][0]["run_count"] == 28, obligation
-        assert obligation["dead_monitor_detector"]["threshold"] == 2, obligation
+        assert obligation["dead_monitor_detector"]["threshold"] == 5, obligation
 
 
 def assert_stalled_monitor_does_not_preempt_runnable_advancement() -> None:

--- a/loopx/control_plane/goals/goal_frontier/__init__.py
+++ b/loopx/control_plane/goals/goal_frontier/__init__.py
@@ -16,6 +16,7 @@ from ...work_items.autonomous_replan_ack import (
 )
 from ...work_items.autonomous_replan_obligation import (
     AUTONOMOUS_REPLAN_STALL_THRESHOLD,
+    MONITOR_NO_CHANGE_STREAK_THRESHOLD,
     build_autonomous_replan_obligation_payload,
 )
 from ...work_items.repair_delta import repair_delta_kinds_have_frontier_delta
@@ -838,7 +839,7 @@ def _monitor_no_change_streak_trigger(
         if agent_id and claimed_by != agent_id:
             continue
         no_change_count = safe_non_negative_int(item.get("consecutive_no_change"))
-        if no_change_count < AUTONOMOUS_REPLAN_STALL_THRESHOLD:
+        if no_change_count < MONITOR_NO_CHANGE_STREAK_THRESHOLD:
             continue
         target_key = str(
             item.get("target_key") or item.get("todo_id") or "monitor"
@@ -861,7 +862,7 @@ def _monitor_no_change_streak_trigger(
         "todo_id": monitor.get("todo_id"),
         "monitor_target_id": target_key,
         "run_count": no_change_count,
-        "threshold": AUTONOMOUS_REPLAN_STALL_THRESHOLD,
+        "threshold": MONITOR_NO_CHANGE_STREAK_THRESHOLD,
         "agent_id": agent_id,
     }
 
@@ -1403,7 +1404,7 @@ def derive_goal_frontier_replan_obligation_from_summaries(
             schema_version=AUTONOMOUS_REPLAN_OBLIGATION_SCHEMA_VERSION,
             agent_id=agent_id,
             include_agent_id=True,
-            stall_threshold=AUTONOMOUS_REPLAN_STALL_THRESHOLD,
+            stall_threshold=MONITOR_NO_CHANGE_STREAK_THRESHOLD,
             trigger_count=1,
             triggers=[monitor_no_change_trigger],
             guidance_actions=[

--- a/loopx/control_plane/goals/goal_frontier/__init__.py
+++ b/loopx/control_plane/goals/goal_frontier/__init__.py
@@ -15,7 +15,6 @@ from ...work_items.autonomous_replan_ack import (
     autonomous_replan_ack_matches_frontier,
 )
 from ...work_items.autonomous_replan_obligation import (
-    AUTONOMOUS_REPLAN_STALL_THRESHOLD,
     MONITOR_NO_CHANGE_STREAK_THRESHOLD,
     build_autonomous_replan_obligation_payload,
 )

--- a/loopx/control_plane/work_items/autonomous_replan_obligation.py
+++ b/loopx/control_plane/work_items/autonomous_replan_obligation.py
@@ -24,6 +24,11 @@ SectionEntries = Callable[[list[str]], list[str]]
 
 MAX_AUTONOMOUS_REPLAN_TRIGGERS = 3
 AUTONOMOUS_REPLAN_STALL_THRESHOLD = 2
+# Unchanged-poll streak before a monitor-only lane is forced to replan. Kept
+# deliberately above the 2-turn run-history stall threshold: quiet monitors
+# legitimately wait several cadence cycles for external evidence, and forcing
+# replan after two unchanged polls creates churn for slow external sources.
+MONITOR_NO_CHANGE_STREAK_THRESHOLD = 5
 AUTONOMOUS_REPLAN_TRIGGER_PATTERNS = (
     (
         "periodic_review",
@@ -458,7 +463,7 @@ def build_autonomous_replan_obligation(
     if not evidence:
         monitor_evidence = _monitor_no_change_evidence(
             agent_todos,
-            threshold=autonomous_replan_stall_threshold,
+            threshold=MONITOR_NO_CHANGE_STREAK_THRESHOLD,
             schema_version=dead_monitor_repeat_schema_version,
         )
         if monitor_evidence:

--- a/tests/control_plane/test_monitor_replan_agent_scope.py
+++ b/tests/control_plane/test_monitor_replan_agent_scope.py
@@ -35,7 +35,7 @@ def _guard(
             task_class="continuous_monitor",
             claimed_by=AGENT_ID,
             target_key="github-pr-123",
-            consecutive_no_change="2",
+            consecutive_no_change="5",
             cadence="30m",
             next_due_at="2099-01-01T00:00:00+00:00",
         ),
@@ -71,7 +71,7 @@ def _guard(
                 task_class="continuous_monitor",
                 claimed_by=AGENT_ID,
                 target_key="github-pr-456",
-                consecutive_no_change="2",
+                consecutive_no_change="5",
                 cadence="1h",
                 next_due_at="2099-01-01T00:00:00+00:00",
             ),
@@ -138,8 +138,8 @@ def test_peer_advancement_does_not_suppress_current_monitor_streak_replan() -> N
     trigger = obligation["triggers"][0]
     assert trigger["kind"] == "monitor_no_change_streak"
     assert trigger["todo_id"] == "todo_stalled_monitor"
-    assert trigger["run_count"] == 2
-    assert trigger["threshold"] == 2
+    assert trigger["run_count"] == 5
+    assert trigger["threshold"] == 5
 
     frontier = guard["goal_frontier_projection"]
     assert frontier["monitor_only_lanes"]["present"] is True
@@ -169,13 +169,13 @@ def test_interleaved_monitors_keep_independent_no_change_streaks() -> None:
         "kind": "monitor_no_change_streak",
         "section": "agent_todo_summary.monitor_open_items",
         "text": (
-            "monitor github-pr-456 recorded 2 consecutive unchanged polls "
+            "monitor github-pr-456 recorded 5 consecutive unchanged polls "
             "without selectable advancement"
         ),
         "todo_id": "todo_unchanged_twice",
         "monitor_target_id": "github-pr-456",
-        "run_count": 2,
-        "threshold": 2,
+        "run_count": 5,
+        "threshold": 5,
         "agent_id": AGENT_ID,
     }
     assert [
@@ -370,7 +370,7 @@ def _combined_user_frontier_guard(*, user_task_class: str) -> dict:
         task_class="continuous_monitor",
         claimed_by=AGENT_ID,
         target_key="github-pr-123",
-        consecutive_no_change="2",
+        consecutive_no_change="5",
         cadence="30m",
         next_due_at="2099-01-01T00:00:00+00:00",
     )
@@ -424,7 +424,7 @@ def _combined_user_frontier_guard(*, user_task_class: str) -> dict:
                         ),
                         "advancement_policy": "repeat_until_closed",
                         "replan_trigger_summary": (
-                            "Replan after two unchanged monitor observations."
+                            "Replan after five unchanged monitor observations."
                         ),
                     },
                 },


### PR DESCRIPTION
## Summary

Raise the default `monitor_no_change_streak` replan threshold from 2 to 5
consecutive unchanged polls, so quiet monitor-only lanes are not forced into
autonomous replan after one or two empty cadence cycles.

## Motivation

The previous default shared the run-history `AUTONOMOUS_REPLAN_STALL_THRESHOLD`
(2), which is appropriate for "two turns without material progress" but too
aggressive for monitors that legitimately wait several cadence cycles for
external evidence (for example, a 3-minute PR queue monitor or a 6-hour issue
intake monitor). Two unchanged polls can happen before the monitor is even
due, producing replan churn and spurious todo/vision writebacks.

## What Changed

- Added `MONITOR_NO_CHANGE_STREAK_THRESHOLD = 5` in
  `loopx/control_plane/work_items/autonomous_replan_obligation.py`, decoupled
  from the run-history 2-turn stall threshold.
- Both monitor streak paths now use the new constant: the goal-frontier
  `_monitor_no_change_streak_trigger` and the fallback
  `_monitor_no_change_evidence` builder.
- Updated monitor-streak fixtures from `2` to `5` in
  `tests/control_plane/test_monitor_replan_agent_scope.py` and the
  `dead_monitor_detector.threshold` assertion in the
  `monitor-poll-writeback-smoke.py` example.

## Validation

- 73 focused tests pass (monitor replan agent scope, goal frontier replan
  rules, goal vision blocked successor, heartbeat recommendation rules), plus
  45 monitor/frontier followthrough and CLI projection tests.
- `examples/control_plane/monitor-poll-writeback-smoke.py` passes.
- `git diff --check` clean.

## Notes

The run-history "2 stalls -> replan" contract is intentionally unchanged; only
the monitor unchanged-poll streak default is raised. A monitor still triggers
replan at the threshold when the agent has no runnable advancement, and the
existing resolutions (expiry, blocker, supersede, successor) are unchanged.
