### PR TITLE
feat(turn): bind typed settlement runtime

### DIFF
--- a/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
+++ b/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
@@ -213,6 +213,11 @@ their authority boundaries differ. A generic `Kleisli`, middleware stack,
 executor registry, or general `Effect` monad remains premature until shared
 execution ownership, not just similar packet fields, is proven.
 
+The shared settlement algebra is owned by the core `effect_program` module.
+Quota supplies the Codex App/CLI plan builder and compatibility re-exports;
+each runtime adapter composes the core algebra instead of inheriting a domain
+program or moving its execution authority into a generic base class.
+
 ### Handler Is Data, Not a Callable
 
 Runtime middleware receives a `handler` callable and decides whether to call

--- a/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.zh-CN.md
+++ b/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.zh-CN.md
@@ -175,6 +175,8 @@ A => F[C]
 
 runtime 合同有两个一等调用方。默认 Codex App 路径通过跨 agent/host 边界的 data-encoded CLI effects 结算普通 LoopX turn。隔离 turn driver 通过 in-process callbacks 执行同一 settlement 形状。它们应共享 plan、receipt、effect identity 和 failure algebra，但不需要共享同一个 executor，因为它们的 authority boundary 不同。在共享执行所有权被证明之前，通用 `Kleisli`、middleware stack、executor registry 或通用 `Effect` monad 仍为时过早。
 
+共享 settlement algebra 由核心 `effect_program` 模块拥有。Quota 只提供 Codex App/CLI plan builder 与兼容 re-export；各 runtime adapter 组合核心 algebra，而不是继承领域 program，也不会把自己的执行权上移到通用基类。
+
 ### Handler 是数据，不是 Callable
 
 Runtime middleware 接收一个 `handler` callable，并决定是否调用、调用一次、重试、fallback 或短路。LoopX 无法跨 context 和 session 边界接收 model 或 host callable。相反，interpreter 在 packet 中返回 `next_effect`：CLI actions、scheduler ACK 和 failure hint。host 或下一个自动化 turn 调用这个 data-encoded handler。

--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -362,6 +362,10 @@ def handle_turn_command(
                 boundary = payload.get("boundary")
                 if isinstance(boundary, dict):
                     boundary.pop("opaque_session_handle_omitted", None)
+            else:
+                transaction = payload.get("transaction")
+                if isinstance(transaction, dict):
+                    transaction.pop("settlement_plan", None)
         elif args.turn_command == "run-once":
             if args.resume_turn_key:
                 if args.turn_instance_id:

--- a/loopx/control_plane/effect_program.py
+++ b/loopx/control_plane/effect_program.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any
+from enum import StrEnum
+from typing import Any, Generic, TypeVar, cast
+
+
+# Keep the established wire ids while moving their implementation to the
+# core-owned algebra shared by quota and Turn adapters.
+SETTLEMENT_IDENTITY_SCHEMA_VERSION = "quota_settlement_identity_v0"
+SETTLEMENT_PLAN_SCHEMA_VERSION = "quota_settlement_plan_v0"
+SETTLEMENT_RECEIPT_SCHEMA_VERSION = "quota_settlement_receipt_v0"
 
 
 @dataclass(frozen=True)
@@ -64,6 +72,184 @@ class EffectStep:
 class EffectProgram:
     steps: tuple[EffectStep, ...] = ()
     execution_mode: str | None = None
+
+
+class SettlementStepKind(StrEnum):
+    VALIDATION = "validation"
+    TODO_COMPLETION = "todo_completion"
+    DURABLE_WRITEBACK = "durable_writeback"
+    QUOTA_SPEND = "quota_spend"
+
+
+class SettlementFailureKind(StrEnum):
+    INVALID_IDENTITY = "invalid_identity"
+    RECEIPT_MISSING = "receipt_missing"
+    IDENTITY_MISMATCH = "identity_mismatch"
+    WRITEBACK_MISSING = "writeback_missing"
+    WRITEBACK_REJECTED = "writeback_rejected"
+    QUOTA_SPEND_REJECTED = "quota_spend_rejected"
+    CANCELLED = "cancelled"
+    PERMISSION_DENIED = "permission_denied"
+    BUDGET_REJECTED = "budget_rejected"
+
+
+@dataclass(frozen=True, slots=True)
+class SettlementIdentity:
+    goal_id: str
+    agent_id: str
+    todo_id: str
+    turn_instance_id: str
+
+    @property
+    def effect_id(self) -> str:
+        return f"{self.goal_id}:{self.agent_id}:{self.todo_id}:{self.turn_instance_id}"
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "schema_version": SETTLEMENT_IDENTITY_SCHEMA_VERSION,
+            "effect_id": self.effect_id,
+            "goal_id": self.goal_id,
+            "agent_id": self.agent_id,
+            "todo_id": self.todo_id,
+            "turn_instance_id": self.turn_instance_id,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SettlementReceipt:
+    step_kind: SettlementStepKind
+    status: str
+    effect_id: str
+    source_ref: str | None = None
+
+    def as_dict(self) -> dict[str, str]:
+        receipt = {
+            "schema_version": SETTLEMENT_RECEIPT_SCHEMA_VERSION,
+            "step_kind": self.step_kind.value,
+            "status": self.status,
+            "effect_id": self.effect_id,
+        }
+        if self.source_ref:
+            receipt["source_ref"] = self.source_ref
+        return receipt
+
+
+@dataclass(frozen=True, slots=True)
+class SettlementFailure:
+    kind: SettlementFailureKind
+    step_kind: SettlementStepKind
+    reason: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "kind": self.kind.value,
+            "step_kind": self.step_kind.value,
+            "reason": self.reason,
+        }
+
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+
+@dataclass(frozen=True, slots=True)
+class SettlementResult(Generic[T]):
+    value: T | None
+    receipts: tuple[SettlementReceipt, ...] = ()
+    failure: SettlementFailure | None = None
+
+    @classmethod
+    def pure(
+        cls,
+        value: T,
+        *,
+        receipts: tuple[SettlementReceipt, ...] = (),
+    ) -> SettlementResult[T]:
+        return cls(value=value, receipts=receipts)
+
+    @classmethod
+    def failed(
+        cls,
+        *,
+        kind: SettlementFailureKind,
+        step_kind: SettlementStepKind,
+        reason: str,
+        receipts: tuple[SettlementReceipt, ...] = (),
+    ) -> SettlementResult[T]:
+        return cls(
+            value=None,
+            receipts=receipts,
+            failure=SettlementFailure(
+                kind=kind,
+                step_kind=step_kind,
+                reason=reason,
+            ),
+        )
+
+    def bind(self, step: Callable[[T], SettlementResult[U]]) -> SettlementResult[U]:
+        if self.failure is not None:
+            return SettlementResult(
+                value=None,
+                receipts=self.receipts,
+                failure=self.failure,
+            )
+        next_result = step(cast(T, self.value))
+        return SettlementResult(
+            value=next_result.value,
+            receipts=(*self.receipts, *next_result.receipts),
+            failure=next_result.failure,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SettlementStep:
+    kind: SettlementStepKind
+    owner: str
+    precondition: str
+    idempotency_key_ref: str
+    expected_receipt: str
+    command_template: str | None = None
+    conditional: bool = False
+
+    def as_dict(self) -> dict[str, Any]:
+        step: dict[str, Any] = {
+            "kind": self.kind.value,
+            "owner": self.owner,
+            "precondition": self.precondition,
+            "idempotency_key_ref": self.idempotency_key_ref,
+            "expected_receipt": self.expected_receipt,
+        }
+        if self.command_template:
+            step["command_template"] = self.command_template
+        if self.conditional:
+            step["conditional"] = True
+        return step
+
+
+@dataclass(frozen=True, slots=True)
+class SettlementPlan:
+    identity: SettlementIdentity
+    steps: tuple[SettlementStep, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": SETTLEMENT_PLAN_SCHEMA_VERSION,
+            "identity": self.identity.as_dict(),
+            "ordered_steps": [step.as_dict() for step in self.steps],
+            "host_handoff": {
+                "owner": "host",
+                "kind": "scheduler_handoff",
+                "inside_agent_settlement": False,
+            },
+        }
+
+
+def settlement_result_payload(result: SettlementResult[Any]) -> dict[str, Any]:
+    return {
+        "ok": result.failure is None,
+        "receipts": [receipt.as_dict() for receipt in result.receipts],
+        "failure": result.failure.as_dict() if result.failure else None,
+    }
 
 
 def _mapping(value: Any) -> Mapping[str, Any]:

--- a/loopx/control_plane/quota/effect_program.py
+++ b/loopx/control_plane/quota/effect_program.py
@@ -1,184 +1,41 @@
 from __future__ import annotations
 
 import shlex
-from collections.abc import Callable, Mapping
-from dataclasses import dataclass
-from enum import StrEnum
-from typing import Any, Generic, TypeVar, cast
+from collections.abc import Mapping
+from typing import Any
 
-SETTLEMENT_IDENTITY_SCHEMA_VERSION = "quota_settlement_identity_v0"
-SETTLEMENT_PLAN_SCHEMA_VERSION = "quota_settlement_plan_v0"
-SETTLEMENT_RECEIPT_SCHEMA_VERSION = "quota_settlement_receipt_v0"
+from ..effect_program import (
+    SETTLEMENT_IDENTITY_SCHEMA_VERSION,
+    SETTLEMENT_PLAN_SCHEMA_VERSION,
+    SETTLEMENT_RECEIPT_SCHEMA_VERSION,
+    SettlementFailure,
+    SettlementFailureKind,
+    SettlementIdentity,
+    SettlementPlan,
+    SettlementReceipt,
+    SettlementResult,
+    SettlementStep,
+    SettlementStepKind,
+    settlement_result_payload,
+)
 
-
-class SettlementStepKind(StrEnum):
-    VALIDATION = "validation"
-    TODO_COMPLETION = "todo_completion"
-    DURABLE_WRITEBACK = "durable_writeback"
-    QUOTA_SPEND = "quota_spend"
-
-
-class SettlementFailureKind(StrEnum):
-    INVALID_IDENTITY = "invalid_identity"
-    RECEIPT_MISSING = "receipt_missing"
-    IDENTITY_MISMATCH = "identity_mismatch"
-    WRITEBACK_MISSING = "writeback_missing"
-    WRITEBACK_REJECTED = "writeback_rejected"
-    QUOTA_SPEND_REJECTED = "quota_spend_rejected"
-    CANCELLED = "cancelled"
-    PERMISSION_DENIED = "permission_denied"
-    BUDGET_REJECTED = "budget_rejected"
-
-
-@dataclass(frozen=True, slots=True)
-class SettlementIdentity:
-    goal_id: str
-    agent_id: str
-    todo_id: str
-    turn_instance_id: str
-
-    @property
-    def effect_id(self) -> str:
-        return f"{self.goal_id}:{self.agent_id}:{self.todo_id}:{self.turn_instance_id}"
-
-    def as_dict(self) -> dict[str, str]:
-        return {
-            "schema_version": SETTLEMENT_IDENTITY_SCHEMA_VERSION,
-            "effect_id": self.effect_id,
-            "goal_id": self.goal_id,
-            "agent_id": self.agent_id,
-            "todo_id": self.todo_id,
-            "turn_instance_id": self.turn_instance_id,
-        }
-
-
-@dataclass(frozen=True, slots=True)
-class SettlementReceipt:
-    step_kind: SettlementStepKind
-    status: str
-    effect_id: str
-    source_ref: str | None = None
-
-    def as_dict(self) -> dict[str, str]:
-        receipt = {
-            "schema_version": SETTLEMENT_RECEIPT_SCHEMA_VERSION,
-            "step_kind": self.step_kind.value,
-            "status": self.status,
-            "effect_id": self.effect_id,
-        }
-        if self.source_ref:
-            receipt["source_ref"] = self.source_ref
-        return receipt
-
-
-@dataclass(frozen=True, slots=True)
-class SettlementFailure:
-    kind: SettlementFailureKind
-    step_kind: SettlementStepKind
-    reason: str
-
-    def as_dict(self) -> dict[str, str]:
-        return {
-            "kind": self.kind.value,
-            "step_kind": self.step_kind.value,
-            "reason": self.reason,
-        }
-
-
-T = TypeVar("T")
-U = TypeVar("U")
-
-
-@dataclass(frozen=True, slots=True)
-class SettlementResult(Generic[T]):
-    value: T | None
-    receipts: tuple[SettlementReceipt, ...] = ()
-    failure: SettlementFailure | None = None
-
-    @classmethod
-    def pure(
-        cls,
-        value: T,
-        *,
-        receipts: tuple[SettlementReceipt, ...] = (),
-    ) -> SettlementResult[T]:
-        return cls(value=value, receipts=receipts)
-
-    @classmethod
-    def failed(
-        cls,
-        *,
-        kind: SettlementFailureKind,
-        step_kind: SettlementStepKind,
-        reason: str,
-        receipts: tuple[SettlementReceipt, ...] = (),
-    ) -> SettlementResult[T]:
-        return cls(
-            value=None,
-            receipts=receipts,
-            failure=SettlementFailure(
-                kind=kind,
-                step_kind=step_kind,
-                reason=reason,
-            ),
-        )
-
-    def bind(self, step: Callable[[T], SettlementResult[U]]) -> SettlementResult[U]:
-        if self.failure is not None:
-            return SettlementResult(
-                value=None,
-                receipts=self.receipts,
-                failure=self.failure,
-            )
-        next_result = step(cast(T, self.value))
-        return SettlementResult(
-            value=next_result.value,
-            receipts=(*self.receipts, *next_result.receipts),
-            failure=next_result.failure,
-        )
-
-
-@dataclass(frozen=True, slots=True)
-class SettlementStep:
-    kind: SettlementStepKind
-    owner: str
-    precondition: str
-    idempotency_key_ref: str
-    expected_receipt: str
-    command_template: str | None = None
-    conditional: bool = False
-
-    def as_dict(self) -> dict[str, Any]:
-        step: dict[str, Any] = {
-            "kind": self.kind.value,
-            "owner": self.owner,
-            "precondition": self.precondition,
-            "idempotency_key_ref": self.idempotency_key_ref,
-            "expected_receipt": self.expected_receipt,
-        }
-        if self.command_template:
-            step["command_template"] = self.command_template
-        if self.conditional:
-            step["conditional"] = True
-        return step
-
-
-@dataclass(frozen=True, slots=True)
-class SettlementPlan:
-    identity: SettlementIdentity
-    steps: tuple[SettlementStep, ...]
-
-    def as_dict(self) -> dict[str, Any]:
-        return {
-            "schema_version": SETTLEMENT_PLAN_SCHEMA_VERSION,
-            "identity": self.identity.as_dict(),
-            "ordered_steps": [step.as_dict() for step in self.steps],
-            "host_handoff": {
-                "owner": "host",
-                "kind": "scheduler_handoff",
-                "inside_agent_settlement": False,
-            },
-        }
+__all__ = [
+    "SETTLEMENT_IDENTITY_SCHEMA_VERSION",
+    "SETTLEMENT_PLAN_SCHEMA_VERSION",
+    "SETTLEMENT_RECEIPT_SCHEMA_VERSION",
+    "SettlementFailure",
+    "SettlementFailureKind",
+    "SettlementIdentity",
+    "SettlementPlan",
+    "SettlementReceipt",
+    "SettlementResult",
+    "SettlementStep",
+    "SettlementStepKind",
+    "build_codex_app_settlement_plan",
+    "settlement_binding_args",
+    "settlement_result_payload",
+    "settlement_step_command",
+]
 
 
 def _quoted_turn_ref(turn_instance_id_ref: str) -> str:
@@ -290,11 +147,3 @@ def settlement_binding_args(plan: Mapping[str, Any] | None) -> str:
         f" --todo-id {shlex.quote(todo_id)}"
         f" --turn-instance-id {_quoted_turn_ref(turn_instance_id)}"
     )
-
-
-def settlement_result_payload(result: SettlementResult[Any]) -> dict[str, Any]:
-    return {
-        "ok": result.failure is None,
-        "receipts": [receipt.as_dict() for receipt in result.receipts],
-        "failure": result.failure.as_dict() if result.failure else None,
-    }

--- a/loopx/control_plane/quota/effect_program.py
+++ b/loopx/control_plane/quota/effect_program.py
@@ -23,6 +23,8 @@ class SettlementFailureKind(StrEnum):
     RECEIPT_MISSING = "receipt_missing"
     IDENTITY_MISMATCH = "identity_mismatch"
     WRITEBACK_MISSING = "writeback_missing"
+    WRITEBACK_REJECTED = "writeback_rejected"
+    QUOTA_SPEND_REJECTED = "quota_spend_rejected"
     CANCELLED = "cancelled"
     PERMISSION_DENIED = "permission_denied"
     BUDGET_REJECTED = "budget_rejected"
@@ -288,3 +290,11 @@ def settlement_binding_args(plan: Mapping[str, Any] | None) -> str:
         f" --todo-id {shlex.quote(todo_id)}"
         f" --turn-instance-id {_quoted_turn_ref(turn_instance_id)}"
     )
+
+
+def settlement_result_payload(result: SettlementResult[Any]) -> dict[str, Any]:
+    return {
+        "ok": result.failure is None,
+        "receipts": [receipt.as_dict() for receipt in result.receipts],
+        "failure": result.failure.as_dict() if result.failure else None,
+    }

--- a/loopx/control_plane/quota/settlement.py
+++ b/loopx/control_plane/quota/settlement.py
@@ -26,6 +26,7 @@ from .effect_program import (
     SettlementStepKind,
     build_codex_app_settlement_plan,
     settlement_binding_args,
+    settlement_result_payload,
     settlement_step_command,
 )
 from .heartbeat_receipt import find_heartbeat_receipt
@@ -313,11 +314,3 @@ def require_settlement_spend(
             ),
         ),
     )
-
-
-def settlement_result_payload(result: SettlementResult[Any]) -> dict[str, Any]:
-    return {
-        "ok": result.failure is None,
-        "receipts": [receipt.as_dict() for receipt in result.receipts],
-        "failure": result.failure.as_dict() if result.failure else None,
-    }

--- a/loopx/control_plane/turn_driver/executor.py
+++ b/loopx/control_plane/turn_driver/executor.py
@@ -15,8 +15,13 @@ from ...authority import validate_public_safe_text
 from ...file_lock import exclusive_file_lock
 from ..effect_program import interpret_turn_result_packet
 from ..goals.goal_vision import normalize_goal_vision_packet
+from ..quota.effect_program import (
+    SettlementStepKind,
+    settlement_result_payload,
+)
 from ..work_items.delivery_batch_scale import require_delivery_batch_scale
 from ..work_items.delivery_outcome import require_delivery_outcome
+from .settlement import execute_turn_driver_settlement
 from .transaction import (
     LOOPX_TURN_RESULT_SCHEMA_VERSION,
     TRANSACTION_PHASES,
@@ -729,6 +734,11 @@ def _execution_payload(
         "scheduler": journal.get("scheduler"),
         "effects": dict(effects),
         "quota_slot_spend_count": 1 if quota_spent else 0,
+        **(
+            {"settlement_result": journal["settlement_result"]}
+            if isinstance(journal.get("settlement_result"), Mapping)
+            else {}
+        ),
         **({"reason": journal.get("reason")} if journal.get("reason") else {}),
     }
 
@@ -967,7 +977,7 @@ def _completion_writeback_outcome(
     return outcome
 
 
-def _transaction_closeout_stage(
+def _typed_settlement_stage(
     plan: Mapping[str, Any],
     result: dict[str, Any],
     *,
@@ -980,104 +990,111 @@ def _transaction_closeout_stage(
     spend: Spend,
     scheduler: Scheduler,
 ) -> dict[str, Any]:
-    if "durable_writeback" not in completed_phases:
+    transaction_plan = (
+        plan.get("transaction")
+        if isinstance(plan.get("transaction"), Mapping)
+        else {}
+    )
+
+    def writeback_effect() -> Mapping[str, Any]:
         if result.get("result_kind") == LoopXTurnResultKind.VALIDATED_COMPLETION.value:
             if completion_writeback is None:
                 raise ValueError("validated_completion requires a todo lifecycle adapter")
-            writeback_payload = completion_writeback(result)
+            callback_payload = completion_writeback(result)
             completion_outcome = _completion_writeback_outcome(
-                writeback_payload,
+                callback_payload,
                 plan=plan,
             )
             if completion_outcome is None:
-                writeback_payload = {
+                return {
                     "ok": False,
                     "appended": False,
                     "reason": "todo lifecycle adapter returned an invalid completion outcome",
                 }
-            else:
-                writeback_payload = {
-                    **writeback_payload,
-                    "completion": completion_outcome,
-                }
-        else:
-            writeback_payload = writeback(result)
-        if not writeback_payload.get("ok") or not writeback_payload.get("appended"):
-            failure = _host_failure(
-                plan,
-                kind=LoopXTurnResultKind.WRITEBACK_FAILED,
-                completed_phases=completed_phases,
-                failed_phase="durable_writeback",
-                reason=str(
-                    writeback_payload.get("error")
-                    or writeback_payload.get("reason")
-                    or "writeback failed"
-                ),
-            )
-            journal.update(
-                status="failed",
-                reason=failure["reason"],
-                receipt=failure["receipt"],
-            )
-            _write_journal(journal_path, journal)
-            return _execution_payload(
-                plan,
-                journal,
-                execute=True,
-                replayed=False,
-                effects=effects,
-            )
-        effects["state_written"] = True
-        completed_phases = list(TRANSACTION_PHASES[:4])
-        journal.update(
-            completed_phases=completed_phases,
-            writeback={
-                **_compact_callback(writeback_payload),
+            return {
+                **callback_payload,
+                "completion": completion_outcome,
+            }
+        return writeback(result)
+
+    def checkpoint(
+        step_kind: SettlementStepKind,
+        payload: Mapping[str, Any],
+        phases: tuple[str, ...],
+    ) -> None:
+        if step_kind is SettlementStepKind.DURABLE_WRITEBACK:
+            effects["state_written"] = True
+            journal["writeback"] = {
+                **_compact_callback(payload),
                 **(
-                    {"completion": writeback_payload["completion"]}
-                    if isinstance(writeback_payload.get("completion"), dict)
+                    {"completion": payload["completion"]}
+                    if isinstance(payload.get("completion"), dict)
                     else {}
                 ),
-            },
-        )
+            }
+        elif step_kind is SettlementStepKind.QUOTA_SPEND:
+            effects["quota_spent"] = True
+            journal["quota_spend"] = _compact_callback(payload)
+        journal["completed_phases"] = list(phases)
         _write_journal(journal_path, journal)
 
-    if "quota_spend" not in completed_phases:
-        spend_payload = spend()
-        if not spend_payload.get("ok") or not spend_payload.get("appended"):
-            failure = _host_failure(
-                plan,
-                kind=LoopXTurnResultKind.QUOTA_SPEND_FAILED,
-                completed_phases=completed_phases,
-                failed_phase="quota_spend",
-                reason=str(spend_payload.get("reason") or "quota spend failed"),
-            )
-            journal.update(
-                status="failed",
-                reason=failure["reason"],
-                receipt=failure["receipt"],
-            )
-            _write_journal(journal_path, journal)
-            return _execution_payload(
-                plan,
-                journal,
-                execute=True,
-                replayed=False,
-                effects=effects,
-            )
-        effects["quota_spent"] = True
-        completed_phases = list(TRANSACTION_PHASES[:5])
-        journal.update(
+    settlement_result = execute_turn_driver_settlement(
+        transaction_plan,
+        transaction_phases=TRANSACTION_PHASES,
+        completed_phases=completed_phases,
+        writeback_payload=(
+            journal.get("writeback")
+            if isinstance(journal.get("writeback"), Mapping)
+            else None
+        ),
+        quota_spend_payload=(
+            journal.get("quota_spend")
+            if isinstance(journal.get("quota_spend"), Mapping)
+            else None
+        ),
+        writeback=writeback_effect,
+        spend=spend,
+        checkpoint=checkpoint,
+    )
+    journal["settlement_result"] = settlement_result_payload(settlement_result)
+    if settlement_result.failure is not None:
+        failure_step = settlement_result.failure.step_kind
+        result_kind = (
+            LoopXTurnResultKind.VALIDATION_FAILED
+            if failure_step is SettlementStepKind.VALIDATION
+            else LoopXTurnResultKind.WRITEBACK_FAILED
+            if failure_step is SettlementStepKind.DURABLE_WRITEBACK
+            else LoopXTurnResultKind.QUOTA_SPEND_FAILED
+        )
+        completed_phases = list(journal.get("completed_phases") or completed_phases)
+        failure = _host_failure(
+            plan,
+            kind=result_kind,
             completed_phases=completed_phases,
-            quota_spend=_compact_callback(spend_payload),
+            failed_phase=failure_step.value,
+            reason=settlement_result.failure.reason,
+        )
+        journal.update(
+            status="failed",
+            result_kind=result_kind.value,
+            reason=failure["reason"],
+            receipt=failure["receipt"],
         )
         _write_journal(journal_path, journal)
-    else:
-        spend_payload = (
-            dict(journal["quota_spend"])
-            if isinstance(journal.get("quota_spend"), dict)
-            else {"ok": True, "appended": True}
+        return _execution_payload(
+            plan,
+            journal,
+            execute=True,
+            replayed=False,
+            effects=effects,
         )
+
+    settlement_state = settlement_result.value
+    if settlement_state is None or settlement_state.quota_spend is None:
+        raise ValueError("typed Turn settlement completed without a quota spend receipt")
+    completed_phases = list(settlement_state.completed_phases)
+    spend_payload = dict(settlement_state.quota_spend)
+    _write_journal(journal_path, journal)
 
     scheduler_payload = scheduler(spend_payload)
     journal["scheduler"] = scheduler_payload
@@ -1240,7 +1257,7 @@ def run_loopx_turn_once(
         if terminal is not None:
             return terminal
 
-        return _transaction_closeout_stage(
+        return _typed_settlement_stage(
             plan,
             result,
             completed_phases=completed_phases,

--- a/loopx/control_plane/turn_driver/executor.py
+++ b/loopx/control_plane/turn_driver/executor.py
@@ -13,12 +13,12 @@ from typing import Any
 
 from ...authority import validate_public_safe_text
 from ...file_lock import exclusive_file_lock
-from ..effect_program import interpret_turn_result_packet
-from ..goals.goal_vision import normalize_goal_vision_packet
-from ..quota.effect_program import (
+from ..effect_program import (
     SettlementStepKind,
+    interpret_turn_result_packet,
     settlement_result_payload,
 )
+from ..goals.goal_vision import normalize_goal_vision_packet
 from ..work_items.delivery_batch_scale import require_delivery_batch_scale
 from ..work_items.delivery_outcome import require_delivery_outcome
 from .settlement import execute_turn_driver_settlement

--- a/loopx/control_plane/turn_driver/settlement.py
+++ b/loopx/control_plane/turn_driver/settlement.py
@@ -1,0 +1,227 @@
+"""Turn-driver adapter for the shared typed settlement algebra."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from ..quota.effect_program import (
+    SettlementFailureKind,
+    SettlementReceipt,
+    SettlementResult,
+    SettlementStepKind,
+)
+
+
+TurnEffect = Callable[[], Mapping[str, Any]]
+TurnSettlementCheckpoint = Callable[
+    [SettlementStepKind, Mapping[str, Any], tuple[str, ...]],
+    None,
+]
+
+
+@dataclass(frozen=True, slots=True)
+class TurnSettlementState:
+    completed_phases: tuple[str, ...]
+    writeback: Mapping[str, Any] | None = None
+    quota_spend: Mapping[str, Any] | None = None
+
+
+def _effect_id(transaction_plan: Mapping[str, Any]) -> str:
+    settlement_plan = transaction_plan.get("settlement_plan")
+    if not isinstance(settlement_plan, Mapping):
+        raise ValueError("Turn transaction has no typed settlement plan")
+    identity = settlement_plan.get("identity")
+    if not isinstance(identity, Mapping):
+        raise ValueError("Turn settlement plan has no identity")
+    effect_id = str(identity.get("effect_id") or "").strip()
+    if not effect_id:
+        raise ValueError("Turn settlement plan has no effect id")
+    return effect_id
+
+
+def _receipt(
+    *,
+    effect_id: str,
+    step_kind: SettlementStepKind,
+) -> SettlementReceipt:
+    return SettlementReceipt(
+        step_kind=step_kind,
+        status="committed",
+        effect_id=effect_id,
+        source_ref=f"turn_journal:{effect_id}#{step_kind.value}",
+    )
+
+
+def _committed_payload(value: Mapping[str, Any] | None) -> bool:
+    return bool(
+        isinstance(value, Mapping)
+        and value.get("ok") is True
+        and value.get("appended") is True
+    )
+
+
+def _seed_result(
+    transaction_plan: Mapping[str, Any],
+    *,
+    transaction_phases: tuple[str, ...],
+    completed_phases: Sequence[str],
+    writeback_payload: Mapping[str, Any] | None,
+    quota_spend_payload: Mapping[str, Any] | None,
+) -> SettlementResult[TurnSettlementState]:
+    effect_id = _effect_id(transaction_plan)
+    phases = tuple(str(phase) for phase in completed_phases)
+    if phases != transaction_phases[: len(phases)]:
+        return SettlementResult.failed(
+            kind=SettlementFailureKind.RECEIPT_MISSING,
+            step_kind=SettlementStepKind.VALIDATION,
+            reason="Turn journal phases are not an ordered transaction prefix",
+        )
+    if "validation" not in phases:
+        return SettlementResult.failed(
+            kind=SettlementFailureKind.RECEIPT_MISSING,
+            step_kind=SettlementStepKind.VALIDATION,
+            reason="Turn settlement requires a committed validation receipt",
+        )
+
+    receipts = [
+        _receipt(
+            effect_id=effect_id,
+            step_kind=SettlementStepKind.VALIDATION,
+        )
+    ]
+    if "durable_writeback" in phases:
+        if not _committed_payload(writeback_payload):
+            return SettlementResult.failed(
+                kind=SettlementFailureKind.RECEIPT_MISSING,
+                step_kind=SettlementStepKind.DURABLE_WRITEBACK,
+                reason="Turn journal is missing its committed writeback payload",
+                receipts=tuple(receipts),
+            )
+        receipts.append(
+            _receipt(
+                effect_id=effect_id,
+                step_kind=SettlementStepKind.DURABLE_WRITEBACK,
+            )
+        )
+    if "quota_spend" in phases:
+        if not _committed_payload(quota_spend_payload):
+            return SettlementResult.failed(
+                kind=SettlementFailureKind.RECEIPT_MISSING,
+                step_kind=SettlementStepKind.QUOTA_SPEND,
+                reason="Turn journal is missing its committed quota spend payload",
+                receipts=tuple(receipts),
+            )
+        receipts.append(
+            _receipt(
+                effect_id=effect_id,
+                step_kind=SettlementStepKind.QUOTA_SPEND,
+            )
+        )
+    return SettlementResult.pure(
+        TurnSettlementState(
+            completed_phases=phases,
+            writeback=writeback_payload,
+            quota_spend=quota_spend_payload,
+        ),
+        receipts=tuple(receipts),
+    )
+
+
+def _callback_failure_kind(
+    step_kind: SettlementStepKind,
+    reason: str,
+) -> SettlementFailureKind:
+    if step_kind is SettlementStepKind.DURABLE_WRITEBACK:
+        return SettlementFailureKind.WRITEBACK_REJECTED
+    if "budget" in reason.casefold():
+        return SettlementFailureKind.BUDGET_REJECTED
+    return SettlementFailureKind.QUOTA_SPEND_REJECTED
+
+
+def _commit_effect(
+    state: TurnSettlementState,
+    *,
+    effect_id: str,
+    step_kind: SettlementStepKind,
+    transaction_phases: tuple[str, ...],
+    effect: TurnEffect,
+    checkpoint: TurnSettlementCheckpoint,
+) -> SettlementResult[TurnSettlementState]:
+    payload = dict(effect())
+    if not _committed_payload(payload):
+        reason = str(
+            payload.get("error")
+            or payload.get("reason")
+            or f"{step_kind.value} callback rejected the settlement"
+        )
+        return SettlementResult.failed(
+            kind=_callback_failure_kind(step_kind, reason),
+            step_kind=step_kind,
+            reason=reason,
+        )
+    phase_index = transaction_phases.index(step_kind.value)
+    completed_phases = transaction_phases[: phase_index + 1]
+    next_state = TurnSettlementState(
+        completed_phases=completed_phases,
+        writeback=(
+            payload
+            if step_kind is SettlementStepKind.DURABLE_WRITEBACK
+            else state.writeback
+        ),
+        quota_spend=(
+            payload if step_kind is SettlementStepKind.QUOTA_SPEND else state.quota_spend
+        ),
+    )
+    checkpoint(step_kind, payload, completed_phases)
+    return SettlementResult.pure(
+        next_state,
+        receipts=(_receipt(effect_id=effect_id, step_kind=step_kind),),
+    )
+
+
+def execute_turn_driver_settlement(
+    transaction_plan: Mapping[str, Any],
+    *,
+    transaction_phases: tuple[str, ...],
+    completed_phases: Sequence[str],
+    writeback_payload: Mapping[str, Any] | None,
+    quota_spend_payload: Mapping[str, Any] | None,
+    writeback: TurnEffect,
+    spend: TurnEffect,
+    checkpoint: TurnSettlementCheckpoint,
+) -> SettlementResult[TurnSettlementState]:
+    """Bind validation -> writeback -> spend for the isolated Turn adapter."""
+
+    effect_id = _effect_id(transaction_plan)
+    result = _seed_result(
+        transaction_plan,
+        transaction_phases=transaction_phases,
+        completed_phases=completed_phases,
+        writeback_payload=writeback_payload,
+        quota_spend_payload=quota_spend_payload,
+    )
+    if "durable_writeback" not in completed_phases:
+        result = result.bind(
+            lambda state: _commit_effect(
+                state,
+                effect_id=effect_id,
+                step_kind=SettlementStepKind.DURABLE_WRITEBACK,
+                transaction_phases=transaction_phases,
+                effect=writeback,
+                checkpoint=checkpoint,
+            )
+        )
+    if "quota_spend" not in completed_phases:
+        result = result.bind(
+            lambda state: _commit_effect(
+                state,
+                effect_id=effect_id,
+                step_kind=SettlementStepKind.QUOTA_SPEND,
+                transaction_phases=transaction_phases,
+                effect=spend,
+                checkpoint=checkpoint,
+            )
+        )
+    return result

--- a/loopx/control_plane/turn_driver/settlement.py
+++ b/loopx/control_plane/turn_driver/settlement.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
-from ..quota.effect_program import (
+from ..effect_program import (
     SettlementFailureKind,
     SettlementReceipt,
     SettlementResult,

--- a/loopx/control_plane/turn_driver/transaction.py
+++ b/loopx/control_plane/turn_driver/transaction.py
@@ -8,6 +8,12 @@ from enum import Enum
 from hashlib import sha256
 from typing import Any
 
+from ..quota.effect_program import (
+    SettlementIdentity,
+    SettlementPlan,
+    SettlementStep,
+    SettlementStepKind,
+)
 from ...turn_identity import normalize_turn_instance_id
 
 
@@ -148,6 +154,39 @@ def build_loopx_turn_transaction_plan(
     if normalized_instance_id is not None:
         identity["turn_instance_id"] = normalized_instance_id
     turn_key = _canonical_hash(identity)
+    settlement_identity = SettlementIdentity(
+        goal_id=str(lineage.get("goal_id") or ""),
+        agent_id=str(lineage.get("agent_id") or ""),
+        todo_id=str(lineage.get("todo_id") or ""),
+        turn_instance_id=normalized_instance_id or turn_key,
+    )
+    effect_ref = "$.identity.effect_id"
+    settlement_plan = SettlementPlan(
+        identity=settlement_identity,
+        steps=(
+            SettlementStep(
+                kind=SettlementStepKind.VALIDATION,
+                owner="turn_driver",
+                precondition="typed host result passed independent task validation",
+                idempotency_key_ref=effect_ref,
+                expected_receipt="validation_receipt",
+            ),
+            SettlementStep(
+                kind=SettlementStepKind.DURABLE_WRITEBACK,
+                owner="turn_driver_callback_adapter",
+                precondition="validation receipt exists",
+                idempotency_key_ref=effect_ref,
+                expected_receipt="durable_writeback_receipt",
+            ),
+            SettlementStep(
+                kind=SettlementStepKind.QUOTA_SPEND,
+                owner="turn_driver_callback_adapter",
+                precondition="matching durable writeback receipt exists",
+                idempotency_key_ref=effect_ref,
+                expected_receipt="quota_spend_receipt",
+            ),
+        ),
+    )
     plan = {
         "schema_version": LOOPX_TURN_TRANSACTION_PLAN_SCHEMA_VERSION,
         "status": "planned" if planned else "not_applicable",
@@ -160,6 +199,8 @@ def build_loopx_turn_transaction_plan(
             "next_phase": TRANSACTION_PHASES[0] if planned else None,
         },
     }
+    if planned:
+        plan["settlement_plan"] = settlement_plan.as_dict()
     if normalized_instance_id is not None:
         plan["turn_instance_id"] = normalized_instance_id
     return plan

--- a/loopx/control_plane/turn_driver/transaction.py
+++ b/loopx/control_plane/turn_driver/transaction.py
@@ -8,7 +8,7 @@ from enum import Enum
 from hashlib import sha256
 from typing import Any
 
-from ..quota.effect_program import (
+from ..effect_program import (
     SettlementIdentity,
     SettlementPlan,
     SettlementStep,

--- a/tests/control_plane/test_quota_settlement.py
+++ b/tests/control_plane/test_quota_settlement.py
@@ -5,11 +5,15 @@ from pathlib import Path
 
 import pytest
 
-from loopx.control_plane.quota.settlement import (
+from loopx.control_plane import effect_program as core_effect_program
+from loopx.control_plane.effect_program import (
     SettlementFailureKind,
     SettlementReceipt,
     SettlementResult,
     SettlementStepKind,
+)
+from loopx.control_plane.quota import effect_program as quota_effect_program
+from loopx.control_plane.quota.settlement import (
     build_codex_app_settlement_plan,
     resolve_heartbeat_settlement_identity,
     settlement_step_command,
@@ -36,6 +40,12 @@ def _receipt(step: SettlementStepKind, marker: str) -> SettlementReceipt:
         effect_id="effect-1",
         source_ref=marker,
     )
+
+
+def test_quota_reexports_the_core_settlement_algebra() -> None:
+    assert quota_effect_program.SettlementIdentity is core_effect_program.SettlementIdentity
+    assert quota_effect_program.SettlementPlan is core_effect_program.SettlementPlan
+    assert quota_effect_program.SettlementResult is core_effect_program.SettlementResult
 
 
 def _append_guard_receipt(

--- a/tests/test_loopx_turn_driver.py
+++ b/tests/test_loopx_turn_driver.py
@@ -938,6 +938,7 @@ def test_turn_cli_consumes_live_state_without_writes(
     assert exit_code == 0
     assert payload["route"]["kind"] == LoopXTurnRoute.READY_FOR_HOST.value
     assert payload["session"]["action"] == "start_new"
+    assert "settlement_plan" not in payload["transaction"]
     assert payload["turn_envelope"]["action_signature"]["matches"] is True
     assert payload["effects"]["state_written"] is False
     assert before == after

--- a/tests/test_loopx_turn_driver.py
+++ b/tests/test_loopx_turn_driver.py
@@ -95,6 +95,21 @@ def test_turn_plan_projects_ready_route_without_side_effects() -> None:
     ]
     assert payload["transaction"]["receipt_seed"]["status"] == "not_executed"
     assert payload["transaction"]["receipt_seed"]["next_phase"] == "host_execute"
+    settlement_plan = payload["transaction"]["settlement_plan"]
+    assert settlement_plan["identity"]["goal_id"] == "fixture-goal"
+    assert settlement_plan["identity"]["agent_id"] == "codex-fixture"
+    assert settlement_plan["identity"]["todo_id"] == "todo_fixture0001"
+    assert [step["kind"] for step in settlement_plan["ordered_steps"]] == [
+        "validation",
+        "durable_writeback",
+        "quota_spend",
+    ]
+    for step in settlement_plan["ordered_steps"]:
+        assert step["owner"]
+        assert step["precondition"]
+        assert step["idempotency_key_ref"] == "$.identity.effect_id"
+        assert step["expected_receipt"]
+    assert settlement_plan["host_handoff"]["inside_agent_settlement"] is False
     assert payload["turn_envelope"] == envelope
     assert payload["effects"] == {
         "host_invoked": False,
@@ -445,6 +460,14 @@ def test_turn_plan_transaction_key_is_stable_and_todo_scoped() -> None:
 
     assert first["transaction"]["turn_key"] == repeated["transaction"]["turn_key"]
     assert first["transaction"]["turn_key"] != changed["transaction"]["turn_key"]
+    assert (
+        first["transaction"]["settlement_plan"]["identity"]["effect_id"]
+        == repeated["transaction"]["settlement_plan"]["identity"]["effect_id"]
+    )
+    assert (
+        first["transaction"]["settlement_plan"]["identity"]["effect_id"]
+        != changed["transaction"]["settlement_plan"]["identity"]["effect_id"]
+    )
 
 
 def test_turn_plan_instance_id_distinguishes_new_turns_from_retries() -> None:

--- a/tests/test_loopx_turn_executor.py
+++ b/tests/test_loopx_turn_executor.py
@@ -17,6 +17,7 @@ from loopx.control_plane.turn_driver.executor import (
     BuiltInHostError,
     _task_validation_stage,
 )
+from loopx.control_plane.turn_driver.settlement import execute_turn_driver_settlement
 from loopx.control_plane.turn_driver.transaction import TRANSACTION_PHASES
 
 
@@ -115,6 +116,33 @@ def test_task_validation_stage_reads_result_kind_through_effect_turn(
     assert journal["status"] == "stopped"
     assert payload is not None
     assert payload["status"] == "stopped"
+
+
+def test_typed_settlement_fails_closed_when_journal_receipt_payload_is_missing() -> None:
+    transaction = _plan()["transaction"]
+    assert isinstance(transaction, dict)
+    calls = {"writeback": 0, "spend": 0, "checkpoint": 0}
+
+    result = execute_turn_driver_settlement(
+        transaction,
+        transaction_phases=TRANSACTION_PHASES,
+        completed_phases=TRANSACTION_PHASES[:4],
+        writeback_payload=None,
+        quota_spend_payload=None,
+        writeback=lambda: calls.__setitem__("writeback", calls["writeback"] + 1)
+        or {"ok": True, "appended": True},
+        spend=lambda: calls.__setitem__("spend", calls["spend"] + 1)
+        or {"ok": True, "appended": True},
+        checkpoint=lambda _kind, _payload, _phases: calls.__setitem__(
+            "checkpoint", calls["checkpoint"] + 1
+        ),
+    )
+
+    assert result.failure is not None
+    assert result.failure.kind.value == "receipt_missing"
+    assert result.failure.step_kind.value == "durable_writeback"
+    assert [receipt.step_kind.value for receipt in result.receipts] == ["validation"]
+    assert calls == {"writeback": 0, "spend": 0, "checkpoint": 0}
 
 
 def _host_argv(result_path: Path, count_path: Path) -> list[str]:
@@ -289,6 +317,10 @@ def test_run_once_commits_once_and_replays_without_duplicate_effects(tmp_path: P
     assert first["ok"] is True
     assert first["status"] == "committed"
     assert first["receipt"]["status"] == "committed"
+    assert [
+        receipt["step_kind"]
+        for receipt in first["settlement_result"]["receipts"]
+    ] == ["validation", "durable_writeback", "quota_spend"]
     assert first["effects"]["host_invoked"] is True
     assert first["effects"]["state_written"] is True
     assert first["effects"]["quota_spent"] is True
@@ -425,8 +457,10 @@ def test_invalid_completion_outcome_fails_closed_without_spending(
         or {"completed": True, "acknowledged": True},
     )
 
+    assert payload["result_kind"] == "writeback_failed"
     assert payload["receipt"]["result_kind"] == "writeback_failed"
     assert payload["receipt"]["failed_phase"] == "durable_writeback"
+    assert payload["settlement_result"]["failure"]["kind"] == "writeback_rejected"
     assert calls == {"completion": 1, "spend": 0, "scheduler": 0}
 
 
@@ -660,13 +694,18 @@ def test_cancellation_during_scheduler_preserves_settlement_and_resumes(
     with pytest.raises(KeyboardInterrupt):
         run_loopx_turn_once(plan, scheduler=cancelled_scheduler, **common)
 
-    assert _journal(tmp_path / "runtime")["completed_phases"] == [
+    interrupted_journal = _journal(tmp_path / "runtime")
+    assert interrupted_journal["completed_phases"] == [
         "host_execute",
         "typed_result",
         "validation",
         "durable_writeback",
         "quota_spend",
     ]
+    assert [
+        receipt["step_kind"]
+        for receipt in interrupted_journal["settlement_result"]["receipts"]
+    ] == ["validation", "durable_writeback", "quota_spend"]
 
     def healthy_scheduler(_spend: dict[str, object]) -> dict[str, object]:
         calls["scheduler"] += 1
@@ -802,11 +841,14 @@ def test_budget_rejection_is_typed_and_retry_does_not_repeat_writeback(
     }
     failed = run_loopx_turn_once(plan, spend=reject_budget, **common)
 
-    # Preserve the current M7.1 characterization. M7.2 must replace this split
-    # with one canonical typed settlement result rather than changing it here.
-    assert failed["result_kind"] == "validated_progress"
+    assert failed["result_kind"] == "quota_spend_failed"
     assert failed["receipt"]["result_kind"] == "quota_spend_failed"
     assert failed["receipt"]["failed_phase"] == "quota_spend"
+    assert failed["settlement_result"]["failure"]["kind"] == "budget_rejected"
+    assert [
+        receipt["step_kind"]
+        for receipt in failed["settlement_result"]["receipts"]
+    ] == ["validation", "durable_writeback"]
     assert failed["effects"]["state_written"] is True
     assert failed["effects"]["quota_spent"] is False
 


### PR DESCRIPTION
## Summary

- move the shared typed settlement algebra into `control_plane.effect_program`; quota keeps Codex App plan/CLI specialization and compatibility re-exports
- bind the same core `A -> Result[B]` receipt semantics into isolated LoopX Turn validation → writeback → spend
- replace the manual Turn closeout truth with one typed plan, stable effect identity, ordered receipts, replay repair, and fail-closed corruption handling
- keep scheduler apply/ACK outside settlement and keep quota/Turn executors local to their distinct authority boundaries

## Validation

- 129 focused tests passed across core settlement, quota/Codex App, Turn CLI, plan, executor, replay, and transaction
- Ruff 0.15.7 passed on the repository CI lint scope
- repository strict mypy passed for all 16 configured files; isolated core/Turn strict check passed for 3 files
- agent-facing CLI output budget passed with a 97-row base/head differential and zero review signals
- fake-host walkthrough, path-delta acceptance, and Codex CLI quickstart smokes passed
- public/private boundary scan: 12 changed files, zero hits
- premerge: 4 direct checks plus 16 risk-selected checks passed; no failures, skips, warnings, or manual holds
- exact change-quality receipt: `cqr_82603c4de5698eaa1059`

## Scope decision

There are now two real callers of the settlement algebra, so the types, bind laws, receipt serialization, failure vocabulary, and stable identity are core-owned. Their execution ownership is intentionally not shared: Codex App effects cross an agent/host CLI boundary, while Turn owns in-process callbacks and journal checkpoints. This PR therefore adds no shared executor, registry, middleware stack, inheritance hierarchy, or generic monad framework.