### PR TITLE
fix(cli): extract quota settlement rollout helpers to restore module-size budget

### DIFF
--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -20,11 +20,10 @@ from ..control_plane.quota.monitor_poll import find_quota_monitor_poll_turn
 from ..control_plane.quota.scheduler_ack import (
     record_quota_scheduler_failure_for_decision,
 )
-from ..control_plane.quota.settlement import (
-    require_settlement_spend,
-    require_settlement_writeback,
-    resolve_heartbeat_settlement_identity,
-    settlement_result_payload,
+from ..control_plane.quota.settlement_cli import (
+    attach_spend_settlement_result,
+    quota_rollout_details,
+    quota_rollout_todo_id,
 )
 from ..control_plane.quota.spend_sources import (
     DEFAULT_SLOT_SPEND_SOURCE,
@@ -41,7 +40,6 @@ from ..control_plane.scheduler.execution_context import (
     SchedulerRuntimeProfile,
     scheduler_execution_context_for_runtime_profile,
 )
-from ..control_plane.todos.contract import normalize_todo_id
 from ..file_lock import lock_timeout_error_fields
 from ..presentation.renderers.quota_event_markdown import (
     render_quota_monitor_poll_markdown,
@@ -595,100 +593,6 @@ def _quota_renderer(
     }.get(command, render_quota_markdown)
 
 
-def _quota_rollout_todo_id(
-    payload: Mapping[str, object],
-    args: argparse.Namespace,
-) -> str | None:
-    selected_todo = (
-        payload.get("selected_todo")
-        if isinstance(payload.get("selected_todo"), Mapping)
-        else {}
-    )
-    return (
-        normalize_todo_id(payload.get("todo_id"))
-        or normalize_todo_id(selected_todo.get("todo_id"))
-        or normalize_todo_id(args.todo_id)
-    )
-
-
-def _quota_rollout_details(
-    payload: Mapping[str, object],
-    args: argparse.Namespace,
-    *,
-    todo_id: str | None,
-) -> dict[str, object]:
-    successor_todo_ids = (
-        payload.get("successor_todo_ids")
-        if isinstance(payload.get("successor_todo_ids"), list)
-        else []
-    )
-    return {
-        "command": "quota",
-        "quota_command": args.quota_command,
-        "ok": bool(payload.get("ok")),
-        "should_run": bool(payload.get("should_run")),
-        "appended": bool(payload.get("appended")),
-        "slots": payload.get("slots") or "",
-        "source": payload.get("source") or "",
-        "todo_id": todo_id or "",
-        "target_key": payload.get("target_key") or "",
-        "successor_todo_ids": ",".join(
-            str(successor_id)
-            for successor_id in successor_todo_ids
-            if str(successor_id).strip()
-        ),
-        "applied_rrule": payload.get("applied_rrule") or "",
-        "settlement_effect_id": (
-            payload.get("settlement_identity", {}).get("effect_id")
-            if isinstance(payload.get("settlement_identity"), Mapping)
-            else ""
-        ),
-    }
-
-
-def _attach_spend_settlement_result(
-    payload: dict[str, object],
-    *,
-    runtime_root: Path,
-    goal_id: str,
-    agent_id: str | None,
-    todo_id: str | None,
-    turn_instance_id: str,
-) -> None:
-    guard_result = resolve_heartbeat_settlement_identity(
-        runtime_root,
-        goal_id=goal_id,
-        agent_id=agent_id,
-        todo_id=todo_id,
-        turn_instance_id=turn_instance_id,
-    )
-    identity = guard_result.value
-    if identity is None:
-        settlement_result = guard_result
-    else:
-        settlement_result = guard_result.bind(
-            lambda resolved: require_settlement_writeback(
-                runtime_root,
-                resolved,
-            )
-        ).bind(
-            lambda _writeback: require_settlement_spend(
-                runtime_root,
-                identity,
-            )
-        )
-    payload["settlement_result"] = settlement_result_payload(
-        settlement_result
-    )
-    if settlement_result.failure is not None:
-        payload["ok"] = False
-        payload["receipt_repair_required"] = True
-        payload["reason"] = settlement_result.failure.reason
-    elif payload.get("receipt_repair_required"):
-        payload["receipt_repair_required"] = False
-        payload["receipt_repaired"] = True
-
-
 def handle_quota_command(
     args: argparse.Namespace,
     *,
@@ -940,8 +844,8 @@ def handle_quota_command(
         )
     )
     if should_log_quota:
-        rollout_todo_id = _quota_rollout_todo_id(payload, args)
-        rollout_details = _quota_rollout_details(
+        rollout_todo_id = quota_rollout_todo_id(payload, args)
+        rollout_details = quota_rollout_details(
             payload,
             args,
             todo_id=rollout_todo_id,
@@ -1061,7 +965,7 @@ def handle_quota_command(
                 allow_failed=args.quota_command == "should-run",
             )
             if args.quota_command == "spend-slot" and heartbeat_turn_id:
-                _attach_spend_settlement_result(
+                attach_spend_settlement_result(
                     payload,
                     runtime_root=runtime_root,
                     goal_id=args.goal_id,

--- a/loopx/control_plane/quota/settlement_cli.py
+++ b/loopx/control_plane/quota/settlement_cli.py
@@ -1,0 +1,109 @@
+"""CLI rollout helpers for heartbeat settlement identity and receipt wiring."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping
+from pathlib import Path
+
+from ..todos.contract import normalize_todo_id
+from .settlement import (
+    require_settlement_spend,
+    require_settlement_writeback,
+    resolve_heartbeat_settlement_identity,
+    settlement_result_payload,
+)
+
+
+def quota_rollout_todo_id(
+    payload: Mapping[str, object],
+    args: argparse.Namespace,
+) -> str | None:
+    selected_todo = (
+        payload.get("selected_todo")
+        if isinstance(payload.get("selected_todo"), Mapping)
+        else {}
+    )
+    return (
+        normalize_todo_id(payload.get("todo_id"))
+        or normalize_todo_id(selected_todo.get("todo_id"))
+        or normalize_todo_id(args.todo_id)
+    )
+
+
+def quota_rollout_details(
+    payload: Mapping[str, object],
+    args: argparse.Namespace,
+    *,
+    todo_id: str | None,
+) -> dict[str, object]:
+    successor_todo_ids = (
+        payload.get("successor_todo_ids")
+        if isinstance(payload.get("successor_todo_ids"), list)
+        else []
+    )
+    return {
+        "command": "quota",
+        "quota_command": args.quota_command,
+        "ok": bool(payload.get("ok")),
+        "should_run": bool(payload.get("should_run")),
+        "appended": bool(payload.get("appended")),
+        "slots": payload.get("slots") or "",
+        "source": payload.get("source") or "",
+        "todo_id": todo_id or "",
+        "target_key": payload.get("target_key") or "",
+        "successor_todo_ids": ",".join(
+            str(successor_id)
+            for successor_id in successor_todo_ids
+            if str(successor_id).strip()
+        ),
+        "applied_rrule": payload.get("applied_rrule") or "",
+        "settlement_effect_id": (
+            payload.get("settlement_identity", {}).get("effect_id")
+            if isinstance(payload.get("settlement_identity"), Mapping)
+            else ""
+        ),
+    }
+
+
+def attach_spend_settlement_result(
+    payload: dict[str, object],
+    *,
+    runtime_root: Path,
+    goal_id: str,
+    agent_id: str | None,
+    todo_id: str | None,
+    turn_instance_id: str,
+) -> None:
+    guard_result = resolve_heartbeat_settlement_identity(
+        runtime_root,
+        goal_id=goal_id,
+        agent_id=agent_id,
+        todo_id=todo_id,
+        turn_instance_id=turn_instance_id,
+    )
+    identity = guard_result.value
+    if identity is None:
+        settlement_result = guard_result
+    else:
+        settlement_result = guard_result.bind(
+            lambda resolved: require_settlement_writeback(
+                runtime_root,
+                resolved,
+            )
+        ).bind(
+            lambda _writeback: require_settlement_spend(
+                runtime_root,
+                identity,
+            )
+        )
+    payload["settlement_result"] = settlement_result_payload(
+        settlement_result
+    )
+    if settlement_result.failure is not None:
+        payload["ok"] = False
+        payload["receipt_repair_required"] = True
+        payload["reason"] = settlement_result.failure.reason
+    elif payload.get("receipt_repair_required"):
+        payload["receipt_repair_required"] = False
+        payload["receipt_repaired"] = True


### PR DESCRIPTION
## Summary

Restores the module-size public smoke on main by bringing
`loopx/cli_commands/quota.py` back under its 1000-line ownership budget
(1091 → 995 lines).

## What Changed

- Extracted the heartbeat settlement rollout helpers
  (`quota_rollout_todo_id`, `quota_rollout_details`,
  `attach_spend_settlement_result`) from
  `loopx/cli_commands/quota.py` into a cohesive owner module:
  `loopx/control_plane/quota/settlement_cli.py` (109 lines).
- `loopx/cli_commands/quota.py` now imports and calls those helpers;
  CLI behavior, command registration, rollout event fields, and settlement
  receipt repair semantics are unchanged.

## Validation

- `examples/cli-command-module-size-ownership-command-modularization-smoke.py`: ok
  (quota.py 995 ≤ 1000).
- `tests/control_plane/test_quota_settlement_cli.py`,
  `test_quota_settlement.py`, `test_quota_slot_accounting.py`,
  `test_cli_output_budget.py`: 51 passed.
- `ruff check` clean on both touched modules.
- `git diff --check` clean.

## Notes

The extracted module is a CLI rollout glue owner for heartbeat settlement
identity/receipt wiring; no runtime or public CLI contract changes.
