### PR TITLE
fix(quota): preserve completed-chain evidence window

### DIFF
--- a/loopx/control_plane/goals/goal_frontier/outcome_continuity.py
+++ b/loopx/control_plane/goals/goal_frontier/outcome_continuity.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from ...agents.agent_scope import agent_scope_item_claimed_by
 from ...work_items.repair_delta import repair_delta_kinds_have_frontier_delta
+from ..goal_vision_policy import COMPLETED_TODO_CHAIN_REPLAN_THRESHOLD
 from ..goal_vision_state import goal_vision_state_is_closed
 
 VISION_OUTCOME_CHECKPOINT_REQUIRED_TRIGGER = "vision_outcome_checkpoint_required"
@@ -22,9 +23,6 @@ REPEAT_VISION_REPLAN_SATISFYING_DELTA_KINDS = (
     "runnable_todo_set",
     "successor_or_supersede",
 )
-COMPLETED_TODO_CHAIN_REPLAN_THRESHOLD = 5
-
-
 def _compact_text(value: Any, *, limit: int) -> str | None:
     text = " ".join(str(value or "").strip().split())
     return text[:limit] if text else None

--- a/loopx/control_plane/goals/goal_vision_policy.py
+++ b/loopx/control_plane/goals/goal_vision_policy.py
@@ -13,6 +13,10 @@ GOAL_VISION_ADVANCEMENT_POLICY_CHOICES = tuple(
     policy.value for policy in GoalVisionAdvancementPolicy
 )
 
+# A completed advancement chain gets one outcome-continuity checkpoint at this
+# cadence. Agent-facing projections must preserve at least the same window.
+COMPLETED_TODO_CHAIN_REPLAN_THRESHOLD = 5
+
 
 def normalize_goal_vision_advancement_policy(value: Any) -> str:
     candidate = str(value or "").strip().lower().replace("-", "_")

--- a/loopx/control_plane/todos/quota_summary.py
+++ b/loopx/control_plane/todos/quota_summary.py
@@ -10,6 +10,7 @@ from ..agents.agent_scope import (
     agent_scope_item_claimed_by,
 )
 from ..agents.capability_gate import missing_required_capabilities
+from ..goals.goal_vision_policy import COMPLETED_TODO_CHAIN_REPLAN_THRESHOLD
 from ..runtime.time import now_utc
 from .claim_visibility import (
     build_agent_claim_scoped_open_items,
@@ -123,7 +124,7 @@ QUOTA_PAYLOAD_LANE_LIMITS = {
     "current_agent_claimed_advancement_items": QUOTA_PAYLOAD_VISIBILITY_LANE_LIMIT,
     "current_agent_claimed_monitor_items": QUOTA_PAYLOAD_VISIBILITY_LANE_LIMIT,
     "current_agent_blocker_items": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
-    "recent_completed_advancement_items": 3,
+    "recent_completed_advancement_items": COMPLETED_TODO_CHAIN_REPLAN_THRESHOLD,
     "claimed_by_others_items": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
     "other_agent_scoped_items": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
     "other_agent_bound_user_action_items": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,

--- a/tests/control_plane/test_goal_vision_succession.py
+++ b/tests/control_plane/test_goal_vision_succession.py
@@ -595,6 +595,8 @@ def test_recent_completed_advancement_projection_is_agent_scoped() -> None:
         "todo_current_completed_7",
         "todo_current_completed_6",
         "todo_current_completed_5",
+        "todo_current_completed_4",
+        "todo_current_completed_3",
     ]
     gaps = acceptance_gaps_from_todo_completion_checkpoint(
         _outcome_vision(


### PR DESCRIPTION
## Summary

- expose five recent completed advancement Todos in the quota hot-path payload, matching the five-completion outcome checkpoint cadence
- single-source the completed-chain threshold in goal-vision policy so decision logic and agent-facing evidence cannot drift
- retain the existing larger raw summary/cold-path bound and avoid widening unrelated diagnostic lanes

## Why five

Three hides two of the causal records required to explain a five-completion replan. Five is the minimum complete evidence window. Values above five add recurring payload cost without changing the checkpoint decision, so this PR deliberately does not choose seven, eight, or the full raw lane.

## Validation

- 237 focused quota/goal-vision/projection/scheduler tests passed
- Ruff 0.15.7 passed on all four changed Python paths
- repository strict mypy passed for all 16 configured files
- absolute CLI output budget and 97-row base/head differential passed with zero review signals
- premerge: 4 direct checks plus 17 risk-selected checks passed; no failures, warnings, or manual holds
- exact change-quality receipt: `cqr_36b9eee9c9af70f5fb84`