### PR TITLE
fix(turn): fail closed and upgrade legacy plans missing typed settlement

### DIFF
--- a/loopx/control_plane/turn_driver/executor.py
+++ b/loopx/control_plane/turn_driver/executor.py
@@ -26,6 +26,7 @@ from .transaction import (
     LOOPX_TURN_RESULT_SCHEMA_VERSION,
     TRANSACTION_PHASES,
     LoopXTurnResultKind,
+    build_loopx_turn_transaction_plan,
     validate_loopx_turn_receipt,
 )
 
@@ -977,6 +978,53 @@ def _completion_writeback_outcome(
     return outcome
 
 
+def _ensure_turn_settlement_plan(
+    plan: Mapping[str, Any],
+    transaction_plan: dict[str, Any],
+) -> None:
+    """Upgrade a legacy transaction plan with a typed settlement plan.
+
+    Turn plans produced by older LoopX releases (for example plans read from a
+    scored-workspace image) do not carry ``settlement_plan``. Rebuild it from
+    the plan's own ``turn_envelope`` lineage so the typed closeout can bind
+    validation -> writeback -> spend instead of failing every legacy run.
+    """
+
+    if isinstance(transaction_plan.get("settlement_plan"), Mapping):
+        return
+    envelope = plan.get("turn_envelope")
+    if not isinstance(envelope, Mapping):
+        return
+    action = envelope.get("action")
+    if not isinstance(action, Mapping):
+        return
+    selected_todo = action.get("selected_todo")
+    if not isinstance(selected_todo, Mapping):
+        return
+    lineage = {
+        "goal_id": str(envelope.get("goal_id") or ""),
+        "agent_id": str(envelope.get("agent_id") or ""),
+        "todo_id": str(selected_todo.get("todo_id") or ""),
+    }
+    if not all(lineage.values()):
+        return
+    host = plan.get("host")
+    host_fields = host if isinstance(host, Mapping) else {}
+    built = build_loopx_turn_transaction_plan(
+        planned=True,
+        lineage=lineage,
+        host=str(host_fields.get("kind") or "generic-cli"),
+        execution_mode=str(
+            host_fields.get("execution_mode") or "isolated-headless"
+        ),
+        session_action=str(host_fields.get("session_action") or "resume"),
+        turn_instance_id=transaction_plan.get("turn_instance_id"),
+    )
+    settlement_plan = built.get("settlement_plan")
+    if isinstance(settlement_plan, Mapping):
+        transaction_plan["settlement_plan"] = settlement_plan
+
+
 def _typed_settlement_stage(
     plan: Mapping[str, Any],
     result: dict[str, Any],
@@ -995,6 +1043,7 @@ def _typed_settlement_stage(
         if isinstance(plan.get("transaction"), Mapping)
         else {}
     )
+    _ensure_turn_settlement_plan(plan, transaction_plan)
 
     def writeback_effect() -> Mapping[str, Any]:
         if result.get("result_kind") == LoopXTurnResultKind.VALIDATED_COMPLETION.value:

--- a/loopx/control_plane/turn_driver/settlement.py
+++ b/loopx/control_plane/turn_driver/settlement.py
@@ -41,6 +41,40 @@ def _effect_id(transaction_plan: Mapping[str, Any]) -> str:
     return effect_id
 
 
+def _settlement_effect_id(
+    transaction_plan: Mapping[str, Any],
+) -> SettlementResult[str]:
+    """Resolve the typed effect id, failing closed instead of raising.
+
+    Legacy or journaled Turn plans created before the typed settlement binding
+    may have no ``settlement_plan``. The turn driver must surface that as a
+    typed validation failure rather than crash with ``ValueError``.
+    """
+
+    settlement_plan = transaction_plan.get("settlement_plan")
+    if not isinstance(settlement_plan, Mapping):
+        return SettlementResult.failed(
+            kind=SettlementFailureKind.RECEIPT_MISSING,
+            step_kind=SettlementStepKind.VALIDATION,
+            reason="Turn transaction has no typed settlement plan",
+        )
+    identity = settlement_plan.get("identity")
+    if not isinstance(identity, Mapping):
+        return SettlementResult.failed(
+            kind=SettlementFailureKind.INVALID_IDENTITY,
+            step_kind=SettlementStepKind.VALIDATION,
+            reason="Turn settlement plan has no identity",
+        )
+    effect_id = str(identity.get("effect_id") or "").strip()
+    if not effect_id:
+        return SettlementResult.failed(
+            kind=SettlementFailureKind.INVALID_IDENTITY,
+            step_kind=SettlementStepKind.VALIDATION,
+            reason="Turn settlement plan has no effect id",
+        )
+    return SettlementResult.pure(effect_id)
+
+
 def _receipt(
     *,
     effect_id: str,
@@ -194,7 +228,11 @@ def execute_turn_driver_settlement(
 ) -> SettlementResult[TurnSettlementState]:
     """Bind validation -> writeback -> spend for the isolated Turn adapter."""
 
-    effect_id = _effect_id(transaction_plan)
+    effect_result = _settlement_effect_id(transaction_plan)
+    if effect_result.failure is not None:
+        return effect_result
+    effect_id = effect_result.value
+    assert effect_id is not None
     result = _seed_result(
         transaction_plan,
         transaction_phases=transaction_phases,

--- a/tests/test_loopx_turn_executor.py
+++ b/tests/test_loopx_turn_executor.py
@@ -145,6 +145,39 @@ def test_typed_settlement_fails_closed_when_journal_receipt_payload_is_missing()
     assert calls == {"writeback": 0, "spend": 0, "checkpoint": 0}
 
 
+def test_typed_settlement_fails_closed_when_plan_has_no_settlement_plan() -> None:
+    transaction = _plan()["transaction"]
+    assert isinstance(transaction, dict)
+    legacy = {
+        key: value
+        for key, value in transaction.items()
+        if key != "settlement_plan"
+    }
+    calls = {"writeback": 0, "spend": 0, "checkpoint": 0}
+
+    result = execute_turn_driver_settlement(
+        legacy,
+        transaction_phases=TRANSACTION_PHASES,
+        completed_phases=TRANSACTION_PHASES[:3],
+        writeback_payload=None,
+        quota_spend_payload=None,
+        writeback=lambda: calls.__setitem__("writeback", calls["writeback"] + 1)
+        or {"ok": True, "appended": True},
+        spend=lambda: calls.__setitem__("spend", calls["spend"] + 1)
+        or {"ok": True, "appended": True},
+        checkpoint=lambda _kind, _payload, _phases: calls.__setitem__(
+            "checkpoint", calls["checkpoint"] + 1
+        ),
+    )
+
+    assert result.failure is not None
+    assert result.failure.kind.value == "receipt_missing"
+    assert result.failure.step_kind.value == "validation"
+    assert "typed settlement plan" in result.failure.reason
+    assert result.receipts == ()
+    assert calls == {"writeback": 0, "spend": 0, "checkpoint": 0}
+
+
 def _host_argv(result_path: Path, count_path: Path) -> list[str]:
     script = """
 import json
@@ -327,6 +360,47 @@ def test_run_once_commits_once_and_replays_without_duplicate_effects(tmp_path: P
     assert replay["replayed"] is True
     assert not any(replay["effects"].values())
     assert count_path.read_text(encoding="utf-8") == "1"
+    assert calls == {"writeback": 1, "spend": 1, "scheduler": 1}
+
+
+def test_run_once_legacy_plan_without_settlement_plan_is_upgraded(
+    tmp_path: Path,
+) -> None:
+    plan = _plan()
+    transaction = plan["transaction"]
+    assert isinstance(transaction, dict)
+    transaction.pop("settlement_plan", None)
+    result_path = tmp_path / "result.json"
+    result_path.write_text(json.dumps(_host_result(plan)), encoding="utf-8")
+    count_path = tmp_path / "host-count"
+    calls = {"writeback": 0, "spend": 0, "scheduler": 0}
+    writeback, spend, scheduler = _callbacks(calls)
+
+    committed = run_loopx_turn_once(
+        plan,
+        host_argv=_host_argv(result_path, count_path),
+        project=tmp_path,
+        runtime_root=tmp_path / "runtime",
+        goal_id="fixture-goal",
+        timeout_seconds=5,
+        execute=True,
+        task_validator=_passing_validator,
+        writeback=writeback,
+        spend=spend,
+        scheduler=scheduler,
+    )
+
+    assert committed["ok"] is True
+    assert committed["status"] == "committed"
+    assert committed["receipt"]["status"] == "committed"
+    assert committed["settlement_result"]["ok"] is True
+    assert (
+        [
+            receipt["step_kind"]
+            for receipt in committed["settlement_result"]["receipts"]
+        ]
+        == ["validation", "durable_writeback", "quota_spend"]
+    )
     assert calls == {"writeback": 1, "spend": 1, "scheduler": 1}
 
 


### PR DESCRIPTION
## Summary

Fixes the Full Public Smokes regression on main where
`examples/skillsbench-loopx-turn-agent-cli-smoke.py` crashed with
`ValueError: Turn transaction has no typed settlement plan`.

## Root Cause

Turn plans produced by older LoopX releases (for example plans read from a
scored-workspace image) do not carry `transaction.settlement_plan`. After the
typed settlement binding landed, `turn_driver/settlement._effect_id` raised
`ValueError` for those legacy plans, crashing `run_loopx_turn_once` instead of
returning a typed receipt.

## What Changed

- `loopx/control_plane/turn_driver/settlement.py`:
  `execute_turn_driver_settlement` now resolves the typed effect id through a
  new `_settlement_effect_id` helper that returns a typed
  `SettlementResult.failed(...)` (`receipt_missing` / `invalid_identity`,
  step `validation`) instead of raising `ValueError`.
- `loopx/control_plane/turn_driver/executor.py`: `_typed_settlement_stage`
  upgrades legacy transaction plans by synthesizing `settlement_plan` from the
  plan's own `turn_envelope` lineage (goal/agent/todo) and host fields, so
  legacy and workspace-provided plans can still commit through the typed
  closeout.
- Tests: added unit coverage for the fail-closed path (plan without
  `settlement_plan` returns a typed failure and never invokes callbacks) and an
  end-to-end test proving a legacy plan is upgraded and commits exactly once.

## Validation

- `tests/test_loopx_turn_executor.py` + `tests/test_loopx_turn_driver.py`:
  69 passed.
- `ruff check` clean on touched modules.
- `git diff --check` clean.

## Notes

The typed fail-closed path remains as defense in depth: if lineage cannot be
reconstructed, the turn now returns `validation_failed` with a public-safe
reason instead of crashing.
