### PR TITLE
feat(scripts): add Codex App RRULE apply fallback tool

### DIFF
--- a/scripts/codex_app_apply_rrule.py
+++ b/scripts/codex_app_apply_rrule.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Apply a LoopX scheduler-hint RRULE to the Codex App automation store.
+
+Fallback host bridge for hosts where the Codex App does not expose
+``automation_update``. The script:
+
+1. reads ``loopx quota should-run`` and its ``scheduler_hint.codex_app``;
+2. when ``stateful_backoff.apply_needed=true`` and ``recommended_rrule`` is
+   present, backs up the Codex App automation SQLite database, updates both
+   the automation TOML and the ``automations`` row to the recommended RRULE;
+3. runs the bound ``ack_hint.cli_args`` so LoopX persists the reset token and
+   progression index.
+
+The script is public-safe: it carries no credentials and all host paths can be
+overridden for tests or alternate installations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _load_scheduler_hint(
+    *,
+    loopx: str,
+    registry: Path,
+    goal_id: str,
+    agent_id: str,
+    turn_instance_id: str,
+    capabilities: list[str],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    command = [
+        loopx,
+        "--format",
+        "json",
+        "--registry",
+        str(registry),
+        "quota",
+        "should-run",
+        "--goal-id",
+        goal_id,
+        "--agent-id",
+        agent_id,
+        "--codex-app",
+        "--turn-instance-id",
+        turn_instance_id,
+    ]
+    for capability in capabilities:
+        command.extend(["--available-capability", capability])
+    completed = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise SystemExit(
+            f"loopx should-run failed ({completed.returncode}): "
+            f"{completed.stderr[-500:]}"
+        )
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"loopx should-run returned invalid JSON: {exc}") from exc
+    hint = payload.get("scheduler_hint", {})
+    codex_app = hint.get("codex_app", {})
+    if not isinstance(codex_app, dict):
+        codex_app = {}
+    stateful = codex_app.get("stateful_backoff", {})
+    if not isinstance(stateful, dict):
+        stateful = {}
+    return codex_app, stateful
+
+
+def _update_toml(toml_path: Path, rrule: str) -> None:
+    text = toml_path.read_text(encoding="utf-8")
+    pattern = re.compile(r'^rrule\s*=\s*".*?"', re.MULTILINE)
+    if not pattern.search(text):
+        raise SystemExit(f"automation TOML has no rrule field: {toml_path}")
+    toml_path.write_text(
+        pattern.sub(f'rrule = "{rrule}"', text),
+        encoding="utf-8",
+    )
+
+
+def _update_sqlite(
+    db_path: Path,
+    *,
+    automation_id: str,
+    rrule: str,
+    backup_path: Path | None,
+) -> None:
+    if backup_path is not None:
+        if not db_path.exists():
+            raise SystemExit(f"automation SQLite does not exist: {db_path}")
+        connection = sqlite3.connect(str(db_path))
+        try:
+            connection.execute("PRAGMA busy_timeout=5000")
+            connection.backup(sqlite3.connect(str(backup_path)))
+        finally:
+            connection.close()
+    connection = sqlite3.connect(str(db_path))
+    try:
+        connection.execute("PRAGMA busy_timeout=5000")
+        cursor = connection.execute(
+            "UPDATE automations SET rrule=?, updated_at=? WHERE id=?",
+            (rrule, _now_ms(), automation_id),
+        )
+        connection.commit()
+        if cursor.rowcount != 1:
+            raise SystemExit(
+                f"automation row not found or not updated in {db_path}: "
+                f"{automation_id}"
+            )
+    finally:
+        connection.close()
+
+
+def _run_ack(loopx: str, ack_args: list[str]) -> None:
+    completed = subprocess.run(
+        [loopx, *ack_args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise SystemExit(
+            f"loopx scheduler ACK failed ({completed.returncode}): "
+            f"{completed.stderr[-500:]}"
+        )
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Apply the LoopX scheduler-hint RRULE to the Codex App automation "
+            "store (TOML + SQLite) and run the bound ACK."
+        )
+    )
+    parser.add_argument("--goal-id", default="loopx-meta")
+    parser.add_argument("--agent-id", default="codex-side-bypass")
+    parser.add_argument(
+        "--registry",
+        type=Path,
+        default=Path.home() / ".codex/loopx/registry.global.json",
+    )
+    parser.add_argument("--automation-id", default="loopx")
+    parser.add_argument(
+        "--automations-root",
+        type=Path,
+        default=Path.home() / ".codex/automations",
+    )
+    parser.add_argument(
+        "--db-path",
+        type=Path,
+        default=Path.home() / ".codex/sqlite/codex-dev.db",
+    )
+    parser.add_argument("--loopx", default="loopx")
+    parser.add_argument(
+        "--capability",
+        action="append",
+        default=["network", "external_evidence_poll"],
+    )
+    parser.add_argument(
+        "--turn-instance-id",
+        default=f"apply-rrule-{_now_ms()}",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    codex_app, stateful = _load_scheduler_hint(
+        loopx=args.loopx,
+        registry=args.registry,
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        turn_instance_id=args.turn_instance_id,
+        capabilities=args.capability,
+    )
+    apply_needed = stateful.get("apply_needed") is True
+    rrule = codex_app.get("recommended_rrule") or stateful.get("current_rrule")
+    ack_hint = codex_app.get("ack_hint", {})
+    ack_args = ack_hint.get("cli_args") if isinstance(ack_hint, dict) else None
+    toml_path = args.automations_root / args.automation_id / "automation.toml"
+
+    if not apply_needed:
+        print(
+            f"no apply needed (apply_needed=false); rrule={rrule or 'unknown'}; "
+            f"ack_needed={stateful.get('ack_needed') is True}"
+        )
+        if (
+            stateful.get("ack_needed") is True
+            and isinstance(ack_args, list)
+            and not args.dry_run
+        ):
+            _run_ack(args.loopx, ack_args)
+        return 0
+    if not rrule:
+        raise SystemExit(
+            "apply_needed=true but no recommended_rrule/current_rrule was projected"
+        )
+    if not isinstance(ack_args, list):
+        raise SystemExit("apply_needed=true but no ack_hint.cli_args was projected")
+
+    backup_path = (
+        Path(str(args.db_path) + f".bak-{time.strftime('%Y%m%dT%H%M%S')}")
+        if not args.dry_run
+        else None
+    )
+    print(f"apply rrule={rrule}")
+    print(f"toml={toml_path}")
+    print(f"db={args.db_path}")
+    print(f"backup={backup_path or 'none (dry-run)'}")
+    print(f"ack_args={ack_args}")
+    if args.dry_run:
+        print("dry-run: no writes performed")
+        return 0
+
+    _update_toml(toml_path, rrule)
+    _update_sqlite(
+        args.db_path,
+        automation_id=args.automation_id,
+        rrule=rrule,
+        backup_path=backup_path,
+    )
+    _run_ack(args.loopx, ack_args)
+    print(f"applied {rrule} and ACKed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_codex_app_apply_rrule.py
+++ b/tests/test_codex_app_apply_rrule.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from scripts.codex_app_apply_rrule import (
+    _now_ms,
+    _update_sqlite,
+    _update_toml,
+    main,
+)
+
+
+def _write_toml(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        'version = 1\nid = "loopx"\nkind = "heartbeat"\n'
+        'status = "ACTIVE"\nrrule = "FREQ=MINUTELY;INTERVAL=3"\n',
+        encoding="utf-8",
+    )
+
+
+def _write_db(path: Path, *, rrule: str = "FREQ=MINUTELY;INTERVAL=3") -> None:
+    connection = sqlite3.connect(str(path))
+    try:
+        connection.execute(
+            "CREATE TABLE automations ("
+            "id TEXT PRIMARY KEY, name TEXT, prompt TEXT, status TEXT, "
+            "next_run_at INTEGER, last_run_at INTEGER, cwds TEXT, rrule TEXT, "
+            "model TEXT, reasoning_effort TEXT, created_at INTEGER, "
+            "updated_at INTEGER, target_type TEXT, project_id TEXT)"
+        )
+        connection.execute(
+            "INSERT INTO automations (id, name, prompt, status, cwds, rrule, "
+            "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "loopx",
+                "LoopX 旁路",
+                "advance loopx-meta",
+                "ACTIVE",
+                "[]",
+                rrule,
+                _now_ms(),
+                _now_ms(),
+            ),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def _hint_payload(*, apply_needed: bool, ack_needed: bool = False) -> dict:
+    return {
+        "ok": True,
+        "scheduler_hint": {
+            "codex_app": {
+                "recommended_rrule": (
+                    "FREQ=MINUTELY;INTERVAL=5" if apply_needed else None
+                ),
+                "stateful_backoff": {
+                    "apply_needed": apply_needed,
+                    "ack_needed": ack_needed,
+                    "current_rrule": "FREQ=MINUTELY;INTERVAL=3",
+                },
+                "ack_hint": (
+                    {
+                        "cli_args": [
+                            "quota",
+                            "scheduler-ack-current",
+                            "--goal-id",
+                            "loopx-meta",
+                            "--applied-rrule",
+                            "FREQ=MINUTELY;INTERVAL=5",
+                            "--host-match-observed",
+                            "--execute",
+                        ]
+                    }
+                    if apply_needed or ack_needed
+                    else None
+                ),
+            }
+        },
+    }
+
+
+class _FakeCompleted:
+    def __init__(self, payload: dict) -> None:
+        self.returncode = 0
+        self.stdout = json.dumps(payload)
+        self.stderr = ""
+
+
+def test_apply_updates_toml_db_and_runs_ack(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    toml_path = tmp_path / "automations/loopx/automation.toml"
+    db_path = tmp_path / "codex-dev.db"
+    _write_toml(toml_path)
+    _write_db(db_path)
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        if "should-run" in command:
+            return _FakeCompleted(_hint_payload(apply_needed=True))
+        calls.append(command)
+        return _FakeCompleted({"ok": True})
+
+    monkeypatch.setattr("scripts.codex_app_apply_rrule.subprocess.run", fake_run)
+
+    code = main(
+        [
+            "--automations-root",
+            str(tmp_path / "automations"),
+            "--db-path",
+            str(db_path),
+            "--loopx",
+            "loopx",
+        ]
+    )
+
+    assert code == 0
+    assert 'rrule = "FREQ=MINUTELY;INTERVAL=5"' in toml_path.read_text(
+        encoding="utf-8"
+    )
+    connection = sqlite3.connect(str(db_path))
+    try:
+        row = connection.execute(
+            "SELECT rrule FROM automations WHERE id='loopx'"
+        ).fetchone()
+    finally:
+        connection.close()
+    assert row == ("FREQ=MINUTELY;INTERVAL=5",)
+    assert calls and calls[0][0] == "loopx"
+    assert any("scheduler-ack-current" in call for call in calls)
+    backups = list(tmp_path.glob("codex-dev.db.bak-*"))
+    assert len(backups) == 1
+
+
+def test_dry_run_writes_nothing(tmp_path: Path, monkeypatch) -> None:
+    toml_path = tmp_path / "automations/loopx/automation.toml"
+    db_path = tmp_path / "codex-dev.db"
+    _write_toml(toml_path)
+    _write_db(db_path)
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return _FakeCompleted(_hint_payload(apply_needed=True))
+
+    monkeypatch.setattr("scripts.codex_app_apply_rrule.subprocess.run", fake_run)
+
+    code = main(
+        [
+            "--automations-root",
+            str(tmp_path / "automations"),
+            "--db-path",
+            str(db_path),
+            "--loopx",
+            "loopx",
+            "--dry-run",
+        ]
+    )
+
+    assert code == 0
+    assert 'rrule = "FREQ=MINUTELY;INTERVAL=3"' in toml_path.read_text(
+        encoding="utf-8"
+    )
+    connection = sqlite3.connect(str(db_path))
+    try:
+        row = connection.execute(
+            "SELECT rrule FROM automations WHERE id='loopx'"
+        ).fetchone()
+    finally:
+        connection.close()
+    assert row == ("FREQ=MINUTELY;INTERVAL=3",)
+    assert not list(tmp_path.glob("codex-dev.db.bak-*"))
+    assert all("scheduler-ack-current" not in call for call in calls)
+
+
+def test_no_apply_needed_is_quiet_noop(tmp_path: Path, monkeypatch) -> None:
+    toml_path = tmp_path / "automations/loopx/automation.toml"
+    db_path = tmp_path / "codex-dev.db"
+    _write_toml(toml_path)
+    _write_db(db_path)
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return _FakeCompleted(_hint_payload(apply_needed=False, ack_needed=True))
+
+    monkeypatch.setattr("scripts.codex_app_apply_rrule.subprocess.run", fake_run)
+
+    code = main(
+        [
+            "--automations-root",
+            str(tmp_path / "automations"),
+            "--db-path",
+            str(db_path),
+            "--loopx",
+            "loopx",
+        ]
+    )
+
+    assert code == 0
+    assert 'rrule = "FREQ=MINUTELY;INTERVAL=3"' in toml_path.read_text(
+        encoding="utf-8"
+    )
+    assert not list(tmp_path.glob("codex-dev.db.bak-*"))
+    assert any("scheduler-ack-current" in call for call in calls)
+
+
+def test_update_toml_and_sqlite_helpers(tmp_path: Path) -> None:
+    toml_path = tmp_path / "automation.toml"
+    db_path = tmp_path / "store.db"
+    _write_toml(toml_path)
+    _write_db(db_path)
+
+    _update_toml(toml_path, "FREQ=MINUTELY;INTERVAL=10")
+    _update_sqlite(
+        db_path,
+        automation_id="loopx",
+        rrule="FREQ=MINUTELY;INTERVAL=10",
+        backup_path=tmp_path / "store.db.bak",
+    )
+
+    assert 'rrule = "FREQ=MINUTELY;INTERVAL=10"' in toml_path.read_text(
+        encoding="utf-8"
+    )
+    assert (tmp_path / "store.db.bak").exists()
+    connection = sqlite3.connect(str(db_path))
+    try:
+        row = connection.execute(
+            "SELECT rrule FROM automations WHERE id='loopx'"
+        ).fetchone()
+    finally:
+        connection.close()
+    assert row == ("FREQ=MINUTELY;INTERVAL=10",)


### PR DESCRIPTION
## Summary

Adds a reusable fallback host bridge that applies LoopX's Codex App scheduler
hint RRULE to the local automation store when `automation_update` is not
available.

## Motivation

LoopX heartbeats project `scheduler_hint.codex_app.stateful_backoff` with
`apply_needed` / `recommended_rrule` / `ack_hint.cli_args`. On hosts without
the Codex App `automation_update` tool, there was no first-class way to apply
the RRULE; operators had to edit `~/.codex/automations/<id>/automation.toml`
and the `~/.codex/sqlite/codex-dev.db` `automations` row by hand and then run
the ACK manually.

## What Changed

- New `scripts/codex_app_apply_rrule.py`:
  - reads `loopx quota should-run` and extracts `scheduler_hint.codex_app`;
  - when `apply_needed=true` and `recommended_rrule` is present, backs up the
    automation SQLite (`.backup`), updates the automation TOML `rrule` and the
    `automations` row, then runs the bound `ack_hint.cli_args`;
  - when `apply_needed=false` but `ack_needed=true`, runs the ACK without a
    host update;
  - supports `--dry-run` and overridable paths/goal/agent for tests and
    alternate installations; no credentials or private material are handled.
- New `tests/test_codex_app_apply_rrule.py`: covers apply (TOML + DB + ACK +
  backup), dry-run no-write, no-apply ACK-only, and helper-level updates.

## Validation

- `tests/test_codex_app_apply_rrule.py`: 4 passed.
- `ruff check` clean on both files.
- `git diff --check` clean.

## Notes

This is a host-specific fallback bridge, not a substitute for
`automation_update`; it is scoped to the Codex App automation store and should
be invoked only with the RRULE projected by LoopX.
