### PR TITLE
fix(todo): fence completion by task lease

### DIFF
--- a/docs/product/roadmaps/frontstage-channel-lease-roadmap.md
+++ b/docs/product/roadmaps/frontstage-channel-lease-roadmap.md
@@ -230,7 +230,14 @@ review action over an independent handoff, optionally excluding the author.
 
 The current implementation is local and file-backed, with per-goal locking,
 renewal, transfer, release, registered-owner validation, and stale-owner
-invalidation. A later server can own the same schema and coordination surface.
+invalidation. A concrete same-agent/multi-process completion race established
+the first lifecycle adoption case: while a lease is effective, `todo complete`
+must present the acquire idempotency key and holds the lease lock through Todo
+and successor writeback. The key fences execution instances that share one
+registered `agent_id`; an optional expected version adds an explicit CAS. A
+completed Todo is terminal-idempotent, so a stale replay cannot append a second
+successor after the canonical completion commits. A later server can own the
+same schema and coordination surface.
 Conflicts should be detected by `(goal_id, todo_id)` plus overlapping
 write-scope checks: another agent may claim a different todo in the same goal,
 but a second pending claim on the same todo must fail closed, renew, or
@@ -240,9 +247,10 @@ explicitly transfer ownership.
 
 P1:
 
-- Keep the shipped optional `task_lease_v0` runtime and conflict smoke stable.
-  Adopt it in a host execution path only after a concrete concurrent-write bad
-  case demonstrates value; do not silently turn it into a default quota gate.
+- Keep the shipped optional `task_lease_v0` runtime, lifecycle fence, and
+  conflict smoke stable. The proven same-agent completion race justifies
+  fencing `todo complete` when a lease is active; do not turn lease acquisition
+  into a default quota gate.
 - Treat the shipped React `/frontstage` route as the baseline
   `goal_channel_projection_v0` reader. Future work should polish visual
   acceptance, operator onboarding, and local fixture realism while preserving

--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -602,12 +602,31 @@ If it carried `blocks_agent` / `unblocks_todo_id`, the replacement inherits
 those unblock fields too. Use `--next-claimed-by <agent-id>` to make a handoff
 explicit.
 
-`todo complete` and `todo supersede` are intentionally idempotent for repeated
-heartbeats: if the old todo is already complete and the next todo already
-exists with the same metadata, the command returns `changed=false` and does not
-duplicate the next checkbox. `todo archive-completed` is only a hygiene command:
+`todo complete` is terminal-idempotent for repeated heartbeats: once the source
+todo is complete, a later completion returns `changed=false` and cannot append
+or relink a different successor. Correct a completed route with an explicit
+follow-up todo or lifecycle command instead of replaying `complete` with new
+arguments. `todo supersede` keeps its own idempotent successor insertion.
+`todo archive-completed` is only a hygiene command:
 it moves already-completed active todos into `Completed Work Archive`; it does
 not mark open todos as done.
+
+When an open todo has an effective hard task lease, completion must prove the
+execution instance, not only the shared agent identity:
+
+```bash
+loopx todo complete \
+  --goal-id <goal-id> \
+  --todo-id <todo_id> \
+  --claimed-by <agent-id> \
+  --task-lease-idempotency-key <acquire-key> \
+  --task-lease-expected-version <lease-version> \
+  --evidence "<public-safe evidence>"
+```
+
+The version check is optional; the idempotency key is required while the lease
+is active. A missing or mismatched key fails before Todo or successor state is
+written, including when two host processes intentionally share one `agent_id`.
 
 ## Parsed Schema
 

--- a/docs/reference/protocols/host-integration-surface-v0.md
+++ b/docs/reference/protocols/host-integration-surface-v0.md
@@ -216,7 +216,7 @@ the host lacks authority. A host adapter may expose these write classes:
 
 | Write Class | CLI Baseline | Required Guards |
 | --- | --- | --- |
-| Todo claim and lifecycle | `loopx todo claim/update/complete` | registered agent id, active-state file lock, task class, optional successor handoff with `blocks_agent` / `unblocks_todo_id` |
+| Todo claim and lifecycle | `loopx todo claim/update/complete` | registered agent id, active-state file lock, task class, active task-lease execution key when present, optional successor handoff with `blocks_agent` / `unblocks_todo_id` |
 | User/agent todo creation | `loopx todo add --role user --task-class user_gate\|user_action` / `--role agent` | public-safe text, concrete actor, duplicate detection |
 | Gate decision | `loopx operator-gate --decision approve|reject|defer` | explicit controller/user decision, dry-run preview before write |
 | Human reward | `loopx reward ... --dry-run` then explicit write | run-bound judgment, public-safe reason, no score impersonation |
@@ -293,7 +293,15 @@ quota, capability, write-scope, or workspace guards:
 
 ```bash
 loopx task-lease acquire --goal-id <goal-id> --todo-id <todo_id> --owner <agent-id> --idempotency-key <turn-key> --write-scope <scope>
+loopx todo complete --goal-id <goal-id> --todo-id <todo_id> --claimed-by <agent-id> --task-lease-idempotency-key <turn-key> --evidence "<public-safe evidence>"
 ```
+
+The acquire key is an execution-instance fence. A lifecycle writer cannot rely
+on `agent_id` alone because multiple host processes may share one registered
+peer identity. While an effective lease exists, `todo complete` holds the lease
+lock through canonical state writeback and rejects a missing, stale, or
+mismatched key before creating successors. Hosts may also pass
+`--task-lease-expected-version` for an explicit version CAS.
 
 If the host adapter is unavailable, the user or automation can run those
 commands and preserve the same state transitions. If a host offers an operation

--- a/loopx/claude_goal_mode/mcp/loopx_mcp.py
+++ b/loopx/claude_goal_mode/mcp/loopx_mcp.py
@@ -127,7 +127,13 @@ def claim_task(todo_id: str, agent_id: str) -> str:
 
 
 @mcp.tool()
-def complete_task(todo_id: str, agent_id: str, evidence: str, next_agent_todo: str = "") -> str:
+def complete_task(
+    todo_id: str,
+    agent_id: str,
+    evidence: str,
+    next_agent_todo: str = "",
+    task_lease_idempotency_key: str = "",
+) -> str:
     """Complete a todo (with evidence), then spend one quota slot.
 
     Mirrors the Codex heartbeat contract: spend exactly once AFTER validated
@@ -136,6 +142,8 @@ def complete_task(todo_id: str, agent_id: str, evidence: str, next_agent_todo: s
     gid, _ = _ctx()
     args = ["todo", "complete", "--goal-id", gid, "--todo-id", todo_id,
             "--claimed-by", agent_id, "--evidence", evidence]
+    if task_lease_idempotency_key:
+        args += ["--task-lease-idempotency-key", task_lease_idempotency_key]
     if next_agent_todo:
         # Don't hard-code a next claimer. With --next-agent-todo and no
         # --next-claimed-by, LoopX assigns the new todo using its own completion

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -10,21 +10,22 @@ from ..control_plane.quota.settlement import (
     resolve_heartbeat_settlement_identity,
     settlement_result_payload,
 )
+from ..control_plane.todos.markdown import render_todo_markdown
+from ..control_plane.work_items.task_lease import TaskLeaseError
+from ..file_lock import lock_timeout_error_fields
 from ..history import load_registry
 from ..paths import resolve_runtime_root
+from ..todo_followups import capture_followup_todos
 from ..todo_suggestion_prompt import (
     ALLOWED_TODO_SUGGESTION_SOURCES,
     ALLOWED_TODO_SUGGESTION_TRIGGERS,
     build_todo_suggestion_prompt_packet,
     render_todo_suggestion_prompt_markdown,
 )
-from ..todo_followups import capture_followup_todos
-from ..control_plane.todos.markdown import render_todo_markdown
-from ..file_lock import lock_timeout_error_fields
 from ..todos import (
     ARCHIVE_COMPLETED_DEFAULT_MAX_ACTIVE_DONE,
-    archive_completed_todos,
     add_goal_todo,
+    archive_completed_todos,
     complete_goal_todo,
     list_goal_todos,
     supersede_goal_todo,
@@ -46,7 +47,6 @@ from .todo_argument_validation import (
     validate_todo_update_options,
 )
 from .todo_event import RolloutEventAppender, append_todo_rollout_event
-
 
 PrintPayload = Callable[
     [dict[str, object], str, Callable[[dict[str, object]], str]],
@@ -252,6 +252,21 @@ def register_todo_command(
             "the assignment target, not the lifecycle actor; multi-agent lifecycle "
             "commands still require --agent-id. User todos use --bound-agent or "
             "--goal-bound instead."
+        ),
+    )
+    todo_parser.add_argument(
+        "--task-lease-idempotency-key",
+        help=(
+            "For todo complete, prove the execution instance that owns an active "
+            "hard task lease. Required when that todo has an effective lease."
+        ),
+    )
+    todo_parser.add_argument(
+        "--task-lease-expected-version",
+        type=int,
+        help=(
+            "For todo complete, optionally CAS the active hard task lease version. "
+            "Requires --task-lease-idempotency-key."
         ),
     )
     todo_parser.add_argument(
@@ -582,6 +597,8 @@ def handle_todo_command(
                 decision_outcome=args.decision_outcome,
                 evidence=args.evidence,
                 completion_turn_key=completion_turn_key,
+                task_lease_idempotency_key=args.task_lease_idempotency_key,
+                task_lease_expected_version=args.task_lease_expected_version,
                 note=args.note,
                 no_followup=bool(args.no_follow_up),
                 successor_todo_ids=args.successor_todo_ids,
@@ -689,6 +706,9 @@ def handle_todo_command(
             "error": str(exc),
             **lock_timeout_error_fields(exc),
         }
+        if isinstance(exc, TaskLeaseError):
+            payload["error_code"] = exc.code
+            payload.update(exc.payload)
     append_todo_rollout_event(
         payload,
         args=args,

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -5,7 +5,6 @@ from collections.abc import Iterable
 
 from ..control_plane.todos.contract import TODO_CONTINUATION_POLICY_VALUES
 
-
 TODO_OPTION_FIELDS = (
     ("--role", "role"),
     ("--text", "text"),
@@ -33,6 +32,8 @@ TODO_OPTION_FIELDS = (
     ("--required-decision-scope", "required_decision_scopes"),
     ("--decision-outcome", "decision_outcome"),
     ("--claimed-by", "claimed_by"),
+    ("--task-lease-idempotency-key", "task_lease_idempotency_key"),
+    ("--task-lease-expected-version", "task_lease_expected_version"),
     ("--bound-agent", "bound_agent"),
     ("--goal-bound", "goal_bound"),
     ("--blocks-agent", "blocks_agent"),
@@ -330,6 +331,10 @@ def validate_todo_complete_options(args: argparse.Namespace) -> None:
         raise ValueError("todo complete does not update --explore-result-node-ref; use todo update first")
     if args.claimed_by and args.clear_claim:
         raise ValueError("todo complete accepts either --claimed-by or --clear-claim, not both")
+    if args.task_lease_expected_version is not None and not args.task_lease_idempotency_key:
+        raise ValueError(
+            "--task-lease-expected-version requires --task-lease-idempotency-key"
+        )
     if any(getattr(args, field) for field in ("task_repository", "bound_agent", "goal_bound", "blocks_agent", "clear_blocks_agent", "excluded_agents", "clear_excluded_agents", "global_gate", "clear_global_gate", "unblocks_todo_id", "resume_when")):
         raise ValueError("todo complete does not update current todo routing metadata; use todo update first")
     if any(getattr(args, field) for field in ("monitor_target_key", "cadence", "next_due_at", "expires_at")):
@@ -447,6 +452,17 @@ def validate_shared_todo_options(args: argparse.Namespace) -> None:
     if getattr(args, "turn_instance_id", None) and args.todo_command != "complete":
         raise ValueError(
             "--turn-instance-id is supported only by todo complete settlement"
+        )
+    if (
+        args.todo_command != "complete"
+        and (
+            args.task_lease_idempotency_key
+            or args.task_lease_expected_version is not None
+        )
+    ):
+        raise ValueError(
+            "--task-lease-idempotency-key and --task-lease-expected-version "
+            "are supported only by todo complete"
         )
     if args.capability_binding_ref and args.todo_command != "add":
         raise ValueError(

--- a/loopx/control_plane/todos/completion_fence.py
+++ b/loopx/control_plane/todos/completion_fence.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .contract import TODO_STATUS_DONE
+
+
+def completed_todo_replay(
+    *,
+    todo: dict[str, Any],
+    goal_id: str,
+    todo_id: str,
+    completion_turn_key: str | None,
+    mutation_authority: dict[str, Any],
+    state_file: str,
+    project: str | None,
+    dry_run: bool,
+) -> dict[str, Any] | None:
+    """Return the terminal-idempotent receipt for an already completed Todo."""
+
+    if str(todo.get("status") or "") != TODO_STATUS_DONE:
+        return None
+    existing_turn_key = str(todo.get("completion_turn_key") or "")
+    if completion_turn_key and completion_turn_key != existing_turn_key:
+        raise ValueError(
+            "todo is already completed under a different completion_turn_key"
+        )
+    return {
+        "ok": True,
+        "dry_run": dry_run,
+        "completed": True,
+        "idempotent_replay": True,
+        "changed": False,
+        "goal_id": goal_id,
+        "todo_id": todo_id,
+        "status": TODO_STATUS_DONE,
+        "mutation_authority": mutation_authority,
+        "state_file": state_file,
+        "project": project,
+    }

--- a/loopx/control_plane/todos/event_writeback.py
+++ b/loopx/control_plane/todos/event_writeback.py
@@ -335,6 +335,26 @@ def complete_event_projected_goal_todo(
     effective_claimed_by = claimed_by or normalize_todo_claimed_by(item.get("claimed_by"))
     store = AppendOnlyStateEventStore(Path(context["event_log_path"]))
     already_done = todo_done_for_status(str(item.get("status") or TODO_STATUS_OPEN))
+    if already_done:
+        return {
+            "ok": True,
+            "dry_run": dry_run,
+            "completed": True,
+            "idempotent_replay": True,
+            "changed": False,
+            "goal_id": goal_id,
+            "role": role,
+            "section": TODO_SECTION_HEADINGS[role],
+            "todo": item.get("text") or item.get("title"),
+            "todo_id": todo_id,
+            "status": TODO_STATUS_DONE,
+            "status_changed": False,
+            "next_todos": [],
+            "state_file": str(context.get("state_file") or ""),
+            "project": str(context.get("project") or "") or None,
+            "updated_at": None,
+            "source": "event_log",
+        }
     next_unblocks_todo_id = todo_id if next_agent_todo else None
     next_user_bound_agent = effective_claimed_by
     if next_user_todo and len(registered_agents) > 1:

--- a/loopx/control_plane/todos/line_update.py
+++ b/loopx/control_plane/todos/line_update.py
@@ -14,6 +14,7 @@ from .contract import (
     TODO_STATUS_DONE,
     TODO_STATUS_OPEN,
     TodoContinuationPolicy,
+    merge_todo_id_lists,
     metadata_line_for_todo_block,
     normalize_explore_result_node_refs,
     normalize_required_capabilities,
@@ -59,6 +60,45 @@ def upsert_todo_metadata(
         insert_at -= 1
     lines.insert(insert_at, metadata_line)
     return True
+
+
+def link_generated_successor_todo_ids(
+    lines: list[str],
+    *,
+    update_result: dict[str, Any],
+    role: str | None,
+    successor_todo_ids: list[str],
+) -> bool:
+    merged_successor_ids = merge_todo_id_lists(
+        update_result.get("successor_todo_ids"),
+        successor_todo_ids,
+    )
+    if merged_successor_ids == normalize_todo_id_list(
+        update_result.get("successor_todo_ids")
+    ):
+        return False
+    block_match = find_todo_block(
+        lines,
+        todo_id=str(update_result.get("todo_id") or ""),
+        role=role,
+    )
+    if not block_match:
+        return False
+    _resolved_role, _section, _start, _end, block = block_match
+    metadata_updated = upsert_todo_metadata(
+        lines,
+        block,
+        metadata_line_for_todo_block(
+            block,
+            {"successor_todo_ids": merged_successor_ids},
+        ),
+    )
+    update_result["successor_todo_ids"] = merged_successor_ids
+    update_result["metadata_updated"] = bool(
+        update_result.get("metadata_updated") or metadata_updated
+    )
+    update_result["changed"] = bool(update_result.get("changed") or metadata_updated)
+    return metadata_updated
 
 
 def apply_todo_update_to_lines(

--- a/loopx/control_plane/work_items/task_lease.py
+++ b/loopx/control_plane/work_items/task_lease.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 import fnmatch
 import json
 import re
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-from ...agent_registry import registered_agent_ids_from_registry, require_registered_agent_id
+from ...agent_registry import (
+    registered_agent_ids_from_registry,
+    require_registered_agent_id,
+)
 from ...file_lock import exclusive_file_lock
 from ...history import load_registry
 from ...paths import resolve_runtime_root
@@ -95,6 +100,124 @@ def task_lease_path(*, runtime_root: Path, goal_id: str, todo_id: str) -> Path:
 
 def task_lease_lock_path(*, runtime_root: Path, goal_id: str) -> Path:
     return task_lease_dir(runtime_root=runtime_root, goal_id=goal_id) / ".task-leases"
+
+
+@contextmanager
+def hold_task_lease_mutation_fence(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    todo_id: str,
+    todo: dict[str, Any],
+    actor_agent_id: str | None,
+    idempotency_key: str | None,
+    expected_version: int | None = None,
+    require_active_when_key_supplied: bool = True,
+) -> Iterator[dict[str, Any]]:
+    """Hold the per-goal lease lock while one todo lifecycle write commits.
+
+    Task leases are optional. Once an effective lease exists, however, the
+    lifecycle writer must prove that it is the execution instance that acquired
+    the lease. The idempotency key is the execution-instance fence; agent ids
+    alone are insufficient because multiple host processes may share one peer
+    identity.
+    """
+
+    normalized_goal_id = normalize_goal_id(goal_id)
+    normalized_todo_id = normalize_lease_todo_id(todo_id)
+    requested_key = (
+        normalize_idempotency_key(idempotency_key)
+        if idempotency_key is not None
+        else None
+    )
+    runtime_root = runtime_root_from_registry(registry_path, None)
+    lease_path = task_lease_path(
+        runtime_root=runtime_root,
+        goal_id=normalized_goal_id,
+        todo_id=normalized_todo_id,
+    )
+    lock_target = task_lease_lock_path(
+        runtime_root=runtime_root,
+        goal_id=normalized_goal_id,
+    )
+    with exclusive_file_lock(
+        lock_target,
+        agent_id=actor_agent_id,
+        operation="task_lease_mutation_fence",
+    ):
+        lease = read_lease(lease_path)
+        active = lease_is_active(lease)
+        if active and lease:
+            constraint = task_lease_owner_constraint(
+                todo,
+                owner=lease.get("owner"),
+                registered_agents=registered_agent_ids_from_registry(
+                    registry_path,
+                    normalized_goal_id,
+                ),
+            )
+            active = constraint.get("effective") is True
+
+        if not active:
+            if (
+                require_active_when_key_supplied
+                and (requested_key is not None or expected_version is not None)
+            ):
+                raise TaskLeaseError(
+                    "task lease fence was supplied but no effective lease is active",
+                    code="lease_not_active",
+                    payload={
+                        "goal_id": normalized_goal_id,
+                        "todo_id": normalized_todo_id,
+                        "lease_path": str(lease_path),
+                    },
+                )
+            yield {
+                "schema_version": TASK_LEASE_SCHEMA_VERSION,
+                "required": False,
+                "active": False,
+            }
+            return
+
+        assert lease is not None
+        if requested_key is None:
+            raise TaskLeaseError(
+                "todo has an active task lease; lifecycle mutation requires its idempotency key",
+                code="lease_fence_required",
+                payload={
+                    "goal_id": normalized_goal_id,
+                    "todo_id": normalized_todo_id,
+                    "lease_owner": lease.get("owner"),
+                    "lease_version": lease.get("version"),
+                    "lease_path": str(lease_path),
+                },
+            )
+        normalized_actor = normalize_todo_claimed_by(actor_agent_id)
+        if (
+            lease.get("owner") != normalized_actor
+            or lease.get("idempotency_key") != requested_key
+        ):
+            raise TaskLeaseError(
+                "task lease owner or execution-instance key mismatch",
+                code="lease_cas_mismatch",
+                payload={
+                    "goal_id": normalized_goal_id,
+                    "todo_id": normalized_todo_id,
+                    "lease_owner": lease.get("owner"),
+                    "lease_version": lease.get("version"),
+                    "actor_agent_id": normalized_actor,
+                    "lease_path": str(lease_path),
+                },
+            )
+        assert_expected_version(lease, expected_version)
+        yield {
+            "schema_version": TASK_LEASE_SCHEMA_VERSION,
+            "required": True,
+            "active": True,
+            "owner": normalized_actor,
+            "version": lease.get("version"),
+            "execution_instance_verified": True,
+        }
 
 
 def runtime_root_from_registry(registry_path: Path, runtime_root_override: str | None) -> Path:

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -1718,6 +1718,7 @@ def complete_goal_todo(
                 )
                 event_result["linked_successor_id"] = completion_policy.linked_successor_id
                 event_result["mutation_authority"] = mutation_authority
+                event_result["task_lease_fence"] = task_lease_fence
                 return event_result
         update_result = apply_todo_update_to_lines(
             lines,

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import ExitStack
 from pathlib import Path
 from typing import Any
 
@@ -70,12 +71,14 @@ from .control_plane.todos.completion_policy import (
     linked_successor_from_todo,
     resolve_completion_policy,
 )
+from .control_plane.todos.completion_fence import completed_todo_replay
 from .control_plane.todos.event_writeback import (
     complete_event_projected_goal_todo,
     event_projection_todo_context,
 )
 from .control_plane.todos.line_update import (
     apply_todo_update_to_lines,
+    link_generated_successor_todo_ids,
     upsert_todo_metadata,
 )
 from .control_plane.todos.list_projection import (
@@ -102,6 +105,7 @@ from .control_plane.todos.write_policy import (
     require_user_todo_task_class,
     resolve_user_gate_global_gate_update,
 )
+from .control_plane.work_items.task_lease import hold_task_lease_mutation_fence
 
 
 ARCHIVE_COMPLETED_DEFAULT_MAX_ACTIVE_DONE = max(0, MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE - 2)
@@ -588,38 +592,6 @@ def matching_todo_block(
         if normalize_todo_text(str(block.get("text") or "")) == expected:
             return block
     return None
-
-
-def link_generated_successor_todo_ids(
-    lines: list[str],
-    *,
-    update_result: dict[str, Any],
-    role: str | None,
-    successor_todo_ids: list[str],
-) -> bool:
-    merged_successor_ids = merge_todo_id_lists(
-        update_result.get("successor_todo_ids"),
-        successor_todo_ids,
-    )
-    if merged_successor_ids == normalize_todo_id_list(update_result.get("successor_todo_ids")):
-        return False
-    block_match = find_todo_block(
-        lines,
-        todo_id=str(update_result.get("todo_id") or ""),
-        role=role,
-    )
-    if not block_match:
-        return False
-    _resolved_role, _section, _start, _end, block = block_match
-    metadata_updated = upsert_todo_metadata(
-        lines,
-        block,
-        metadata_line_for_todo_block(block, {"successor_todo_ids": merged_successor_ids}),
-    )
-    update_result["successor_todo_ids"] = merged_successor_ids
-    update_result["metadata_updated"] = bool(update_result.get("metadata_updated") or metadata_updated)
-    update_result["changed"] = bool(update_result.get("changed") or metadata_updated)
-    return metadata_updated
 
 
 def add_todo_to_lines(
@@ -1534,6 +1506,8 @@ def complete_goal_todo(
     decision_outcome: str | None = None,
     evidence: str | None = None,
     completion_turn_key: str | None = None,
+    task_lease_idempotency_key: str | None = None,
+    task_lease_expected_version: int | None = None,
     note: str | None = None,
     no_followup: bool = False,
     successor_todo_ids: list[str] | None = None,
@@ -1573,7 +1547,7 @@ def complete_goal_todo(
         resolved_state_file,
         agent_id=agent_id or claimed_by,
         operation="todo_complete",
-    ):
+    ), ExitStack() as lease_fence_stack:
         original = resolved_state_file.read_text(encoding="utf-8")
         lines = original.splitlines()
         updated_at = now_local()
@@ -1631,28 +1605,35 @@ def complete_goal_todo(
             decision_outcome=effective_decision_outcome,
             decision_target=decision_target,
         )
-        existing_completion_turn_key = str(
-            completion_todo.get("completion_turn_key") or ""
+        terminal_replay = completed_todo_replay(
+            todo=completion_todo,
+            goal_id=goal_id,
+            todo_id=todo_id,
+            completion_turn_key=completion_turn_key,
+            mutation_authority=mutation_authority,
+            state_file=str(resolved_state_file),
+            project=str(resolved_project) if resolved_project else None,
+            dry_run=dry_run,
         )
-        if completion_match and str(completion_todo.get("status") or "") == TODO_STATUS_DONE:
-            if completion_turn_key and completion_turn_key == existing_completion_turn_key:
-                return {
-                    "ok": True,
-                    "dry_run": dry_run,
-                    "completed": True,
-                    "idempotent_replay": True,
-                    "changed": False,
-                    "goal_id": goal_id,
-                    "todo_id": todo_id,
-                    "status": TODO_STATUS_DONE,
-                    "mutation_authority": mutation_authority,
-                    "state_file": str(resolved_state_file),
-                    "project": str(resolved_project) if resolved_project else None,
-                }
-            if completion_turn_key:
-                raise ValueError(
-                    "todo is already completed under a different completion_turn_key"
-                )
+        if terminal_replay:
+            return terminal_replay
+        task_lease_fence = lease_fence_stack.enter_context(
+            hold_task_lease_mutation_fence(
+                registry_path=registry_path,
+                goal_id=goal_id,
+                todo_id=todo_id,
+                todo=completion_todo,
+                actor_agent_id=agent_id or claimed_by,
+                idempotency_key=(
+                    task_lease_idempotency_key or completion_turn_key
+                ),
+                expected_version=task_lease_expected_version,
+                require_active_when_key_supplied=(
+                    task_lease_idempotency_key is not None
+                    or task_lease_expected_version is not None
+                ),
+            )
+        )
         normalized_successor_todo_ids = normalize_todo_id_list(successor_todo_ids)
         if successor_todo_ids and not normalized_successor_todo_ids:
             raise ValueError("successor_todo_ids must contain public todo_<letters-digits-underscore-hyphen> tokens")
@@ -1858,6 +1839,7 @@ def complete_goal_todo(
         "next_todos": next_results,
         "linked_successor_id": completion_policy.linked_successor_id,
         "mutation_authority": mutation_authority,
+        "task_lease_fence": task_lease_fence,
         "state_file": str(resolved_state_file),
         "project": str(resolved_project) if resolved_project else None,
         "updated_at": updated_at if changed else None,

--- a/tests/control_plane/test_todo_mutation_authority.py
+++ b/tests/control_plane/test_todo_mutation_authority.py
@@ -5,16 +5,20 @@ from pathlib import Path
 
 import pytest
 
-from loopx.control_plane.todos.event_writeback import (
-    complete_event_projected_goal_todo,
-)
 from loopx.control_plane.scheduler.monitor_poll_writeback import (
     write_monitor_poll_todo_state,
 )
+from loopx.control_plane.todos.event_writeback import (
+    complete_event_projected_goal_todo,
+)
+from loopx.control_plane.work_items.task_lease import (
+    TaskLeaseError,
+    acquire_task_lease,
+)
 from loopx.event_sourced_state import (
-    AppendOnlyStateEventStore,
     TODO_ADDED,
     TODO_UPDATED,
+    AppendOnlyStateEventStore,
     StateEventError,
     backfill_todo_events_from_markdown,
     build_state_projection,
@@ -27,7 +31,6 @@ from loopx.todos import (
     supersede_goal_todo,
     update_goal_todo,
 )
-
 
 GOAL_ID = "todo-mutation-authority"
 AUTHOR_AGENT = "codex-author"
@@ -75,6 +78,7 @@ def _write_fixture(
     registry.write_text(
         json.dumps(
             {
+                "common_runtime_root": str(tmp_path / "runtime"),
                 "goals": [
                     {
                         "id": GOAL_ID,
@@ -268,6 +272,86 @@ def test_capability_binding_follows_generated_agent_successor(tmp_path: Path) ->
     )
 
 
+def test_active_task_lease_fences_same_agent_completion_instance(
+    tmp_path: Path,
+) -> None:
+    registry, state = _write_fixture(tmp_path, multi_agent=False)
+    todo = _add_agent_todo(registry)
+    lease_key = "turn-owner-instance"
+    acquire_task_lease(
+        registry_path=registry,
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        owner=AUTHOR_AGENT,
+        idempotency_key=lease_key,
+        ttl_seconds=600,
+    )
+    before = state.read_text(encoding="utf-8")
+
+    with pytest.raises(TaskLeaseError) as missing_fence:
+        complete_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=todo["todo_id"],
+            claimed_by=AUTHOR_AGENT,
+            evidence="stale execution instance",
+            next_agent_todo="Create a stale successor.",
+        )
+    assert missing_fence.value.code == "lease_fence_required"
+    assert state.read_text(encoding="utf-8") == before
+
+    with pytest.raises(TaskLeaseError) as mismatched_fence:
+        complete_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=todo["todo_id"],
+            claimed_by=AUTHOR_AGENT,
+            task_lease_idempotency_key="other-instance",
+            evidence="wrong execution instance",
+        )
+    assert mismatched_fence.value.code == "lease_cas_mismatch"
+    assert state.read_text(encoding="utf-8") == before
+
+    completed = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        claimed_by=AUTHOR_AGENT,
+        task_lease_idempotency_key=lease_key,
+        task_lease_expected_version=1,
+        evidence="lease owner validated the result",
+        next_agent_todo="Create the canonical successor.",
+    )
+    assert completed["task_lease_fence"] == {
+        "schema_version": "task_lease_v0",
+        "required": True,
+        "active": True,
+        "owner": AUTHOR_AGENT,
+        "version": 1,
+        "execution_instance_verified": True,
+    }
+
+    replayed = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        claimed_by=AUTHOR_AGENT,
+        evidence="late result from another execution instance",
+        next_agent_todo="Create a duplicate stale successor.",
+    )
+    assert replayed["idempotent_replay"] is True
+    assert replayed["changed"] is False
+    agent_todos = parse_active_state_todos(state.read_text(encoding="utf-8"))[
+        "agent_todos"
+    ]["items"]
+    todo_titles = [
+        str(item.get("title") or item.get("text") or "") for item in agent_todos
+    ]
+    assert todo_titles.count("Create the canonical successor.") == 1
+    assert "Create a duplicate stale successor." not in todo_titles
+
+
 def test_capability_binding_cannot_be_rebound_by_duplicate_add(tmp_path: Path) -> None:
     registry, state = _write_fixture(tmp_path)
     add_goal_todo(
@@ -360,6 +444,45 @@ def test_capability_binding_follows_event_projected_successor(tmp_path: Path) ->
     assert successor["capability_binding_ref"] == (
         "issue-fix:feasibility-a1b2c3d4"
     )
+
+    event_count = len(AppendOnlyStateEventStore(event_log).load())
+    completed_parent = next(
+        item
+        for item in replayed["agent_todos"]["items"]
+        if item["todo_id"] == parent["todo_id"]
+    )
+    duplicate = complete_event_projected_goal_todo(
+        goal_id=GOAL_ID,
+        context={
+            "item": completed_parent,
+            "role": "agent",
+            "event_log_path": event_log,
+            "fields": {"agent_todos": replayed["agent_todos"]},
+        },
+        evidence="late stale completion",
+        note=None,
+        no_followup=False,
+        successor_todo_ids=[],
+        claimed_by=AUTHOR_AGENT,
+        clear_claim=False,
+        next_agent_todo="Create a duplicate event successor.",
+        next_user_todo=None,
+        next_user_task_class="user_gate",
+        next_claimed_by=AUTHOR_AGENT,
+        next_task_class="advancement_task",
+        next_action_kind="issue_fix_reviewer_request",
+        next_task_repository=None,
+        next_required_capabilities=None,
+        next_continuation_policy="same_agent_non_delivery",
+        self_merged=False,
+        next_excluded_agents=[],
+        registered_agents=[AUTHOR_AGENT],
+        updated_at="2026-07-18T00:02:00+00:00",
+        dry_run=False,
+    )
+    assert duplicate["idempotent_replay"] is True
+    assert duplicate["changed"] is False
+    assert len(AppendOnlyStateEventStore(event_log).load()) == event_count
 
 
 def test_task_domain_survives_markdown_event_projection() -> None:

--- a/tests/control_plane/test_todo_mutation_authority.py
+++ b/tests/control_plane/test_todo_mutation_authority.py
@@ -352,6 +352,61 @@ def test_active_task_lease_fences_same_agent_completion_instance(
     assert "Create a duplicate stale successor." not in todo_titles
 
 
+def test_event_projected_completion_reports_task_lease_fence(
+    tmp_path: Path,
+) -> None:
+    registry, state = _write_fixture(tmp_path, multi_agent=False)
+    event_log = state.with_name("events.jsonl")
+    store = AppendOnlyStateEventStore(event_log)
+    todo_id = "todo_event_lease"
+    store.append(
+        make_state_event(
+            event_id="evt-event-lease-parent",
+            goal_id=GOAL_ID,
+            event_type=TODO_ADDED,
+            refs={"todo_id": todo_id},
+            payload={
+                "role": "agent",
+                "title": "Complete the event-projected leased task.",
+                "task_class": "advancement_task",
+                "claimed_by": AUTHOR_AGENT,
+            },
+            recorded_at="2026-07-18T00:00:00+00:00",
+        )
+    )
+    lease_key = "event-projection-instance"
+    acquire_task_lease(
+        registry_path=registry,
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        owner=AUTHOR_AGENT,
+        idempotency_key=lease_key,
+        ttl_seconds=600,
+    )
+
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        claimed_by=AUTHOR_AGENT,
+        task_lease_idempotency_key=lease_key,
+        task_lease_expected_version=1,
+        evidence="event-projected lease owner validated the result",
+        no_followup=True,
+    )
+
+    assert result["source"] == "event_log"
+    assert result["task_lease_fence"] == {
+        "schema_version": "task_lease_v0",
+        "required": True,
+        "active": True,
+        "owner": AUTHOR_AGENT,
+        "version": 1,
+        "execution_instance_verified": True,
+    }
+
+
 def test_capability_binding_cannot_be_rebound_by_duplicate_add(tmp_path: Path) -> None:
     registry, state = _write_fixture(tmp_path)
     add_goal_todo(

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -638,6 +638,10 @@ def test_todo_update_validation_accepts_a_mutable_field() -> None:
             "todo complete does not update --continuation-policy; use todo update first",
         ),
         (
+            ["--todo-id", "todo_example", "--task-lease-expected-version", "2"],
+            "--task-lease-expected-version requires --task-lease-idempotency-key",
+        ),
+        (
             ["--todo-id", "todo_example", "--next-user-todo", "Approve."],
             "--next-user-todo requires explicit --next-user-task-class "
             "user_action|user_gate",
@@ -656,6 +660,46 @@ def test_todo_complete_validation_preserves_exact_diagnostics(
         validate_todo_complete_options(args)
 
     assert str(exc_info.value) == expected
+
+
+def test_todo_complete_preserves_typed_task_lease_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def reject_stale_instance(**_kwargs: object) -> dict[str, object]:
+        raise todo_command.TaskLeaseError(
+            "todo has an active task lease",
+            code="lease_fence_required",
+            payload={"lease_version": 3},
+        )
+
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(todo_command, "complete_goal_todo", reject_stale_instance)
+    args = build_parser().parse_args(
+        [
+            "todo",
+            "complete",
+            "--goal-id",
+            "example-goal",
+            "--todo-id",
+            "todo_example",
+            "--claimed-by",
+            "codex-example",
+        ]
+    )
+
+    exit_code = todo_command.handle_todo_command(
+        args,
+        registry_path=tmp_path / "registry.json",
+        runtime_root_arg=None,
+        print_payload=lambda payload, *_args: captured.update(payload),
+        append_cli_rollout_event=lambda *_args, **_kwargs: {},
+        format_name="json",
+    )
+
+    assert exit_code == 1
+    assert captured["error_code"] == "lease_fence_required"
+    assert captured["lease_version"] == 3
 
 
 def test_todo_complete_validation_accepts_no_follow_up_with_evidence() -> None:


### PR DESCRIPTION
Replaces #2909 on top of the current `main` without rewriting the old branch.

## Summary

- require an active task-lease owner to prove its execution-instance key before Todo completion can mutate state;
- hold the per-goal lease lock across completion writeback so transfer/release cannot race the lifecycle write;
- preserve terminal replay idempotency and prevent stale attempts from creating duplicate successors;
- expose the same typed lease-fence receipt for Markdown and event-projected Todo completion;
- document and thread the fence through CLI and MCP completion entry points.

## Validation

- `python -m pytest -q tests/control_plane/test_todo_mutation_authority.py tests/control_plane/test_task_lease.py tests/test_cli_argument_diagnostics.py` — 133 passed;
- `python -m mypy` — passed;
- changed-surface Ruff base/head differential — 32 findings on base, 30 on head, zero new; the added completion-fence module is clean;
- `python -m loopx.cli --format json canary premerge --from-git-diff --goal-id loopx-meta --tier standard --no-progress` — passed: 4 direct checks and 18 selected catalog/risk/boundary checks, zero failures or manual holds;
- public/private boundary scan — clean across all 13 changed files;
- change-quality receipt `cqr_34515b4567e1bb390b2e` — valid for exact scope fingerprint `34515b4567e1bb390b2e96625d9bff3b29f3f473e42cca364c417ad3239b5648`.

## Scope and risk

This is a Todo/task-lease lifecycle consistency change. It does not alter benchmark scoring, permissions, release behavior, or external service calls. Local runtime state, credentials, raw logs, and private material are excluded.
