### PR TITLE
fix(smokes): align benchmark doc smoke with retired GH-C40 board row

### DIFF
--- a/examples/benchmark-developer-workflow-doc-smoke.py
+++ b/examples/benchmark-developer-workflow-doc-smoke.py
@@ -154,9 +154,10 @@ def main() -> int:
     require(
         tasks,
         [
-            "GH-C40",
-            "bounded benchmark lifecycle/read-model seams",
-            "raw logs, task text, verifier output, or host paths",
+            "Benchmark boundary",
+            "Shared lifecycle, readiness, ledger, and reducer contracts are the public seam;",
+            "Terminal-Bench, ALE, and EdgeBench now sit on the same seams as SkillsBench",
+            "raw task text, logs, trajectories, verifier tails, credentials, uploads, or local paths",
         ],
         source=TASKS,
     )


### PR DESCRIPTION
## Why

`examples/benchmark-developer-workflow-doc-smoke.py` still required the retired
`GH-C40` row and its old wording ("bounded benchmark lifecycle/read-model
seams", "raw logs, task text, verifier output, or host paths") in
`CONTRIBUTOR_TASKS.md`. PR #3027 retired that row because Terminal-Bench, ALE,
and EdgeBench now use the shared lifecycle/read-model/reducer seams, so the
post-merge Full Public Smokes run on `main` failed at
`benchmark-developer-workflow-doc-smoke` (run 31328752422).

## What changed

The smoke now asserts the current public task-board truth:

- the `Benchmark boundary` row exists;
- "Shared lifecycle, readiness, ledger, and reducer contracts are the public
  seam;";
- "Terminal-Bench, ALE, and EdgeBench now sit on the same seams as SkillsBench";
- the boundary wording for excluded material ("raw task text, logs,
  trajectories, verifier tails, credentials, uploads, or local paths").

No benchmark adapter, scoring, runner, or evidence behavior is touched.

## Validation

- `python3 examples/benchmark-developer-workflow-doc-smoke.py` passes at head.
- `python3 -m py_compile examples/benchmark-developer-workflow-doc-smoke.py` passes.
- `git diff --check` clean.
- `canary premerge --tier standard` direct + selected checks: 0 failures; the
  only gate is the benchmark-sensitive manual hold, which requires a maintainer
  merge decision.
