### PR TITLE
feat(content-ops): add read-only queue-status projection

### DIFF
--- a/docs/capabilities/content-ops/README.md
+++ b/docs/capabilities/content-ops/README.md
@@ -14,6 +14,12 @@ delivery receipts, exact readback, and supersession without copying draft bodies
 or provider credentials into LoopX state. See
 [`content_ops_item_v0`](../../reference/protocols/content-ops-item-lifecycle-v0.md).
 
+`loopx content-ops queue-status` projects caller-owned item files into one
+read-only managed queue surface with state counts and a next action. Priority is
+the order of the `--item-json` inputs; windows live in item approval and delivery
+intent records. See
+[`content_ops_queue_projection_v0`](../../reference/protocols/content-ops-queue-v0.md).
+
 ## Implemented Surface
 
 | Layer | Current path |
@@ -21,6 +27,7 @@ or provider credentials into LoopX state. See
 | Capability module | `loopx/capabilities/content_ops/` |
 | CLI entry | `loopx content-ops ...` |
 | Protocol docs | `docs/reference/protocols/content-ops-surface-v0.md` |
+| Queue projection | `docs/reference/protocols/content-ops-queue-v0.md` |
 | Smoke | `examples/content-ops-*-smoke.py` |
 
 ## Safe Defaults

--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -74,6 +74,7 @@ scanning a chronological list.
 - [`value_connector_plan_v0`](value-connector-plan-v0.md): Value connector plan v0
 - [`x_public_channel_ops_v0`](x-public-channel-ops-v0.md): X public channel operations v0
 - [`content_ops_item_v0`](content-ops-item-lifecycle-v0.md): provider-neutral content item lifecycle v0
+- [`content_ops_queue_projection_v0`](content-ops-queue-v0.md): read-only managed content queue projection v0
 
 ## Quality, Review, And Release
 

--- a/docs/reference/protocols/content-ops-queue-v0.md
+++ b/docs/reference/protocols/content-ops-queue-v0.md
@@ -1,0 +1,40 @@
+# content_ops_queue_projection_v0
+
+Status: read-only managed queue projection v0.
+
+`content_ops_queue_projection_v0` is the queue surface for caller-owned
+`content_ops_item_v0` records. It is not a publisher and never stores draft
+bodies. The order of the input item files is the priority order.
+
+## Boundary
+
+The projection derives from validated item records only:
+
+- stable `item_id`, `item_kind`, channel, state, revision, and opaque
+  `content_ref`;
+- state counts and terminal count;
+- the first actionable non-terminal item as `next_action`;
+- no draft bodies, credentials, browser state, media, private source maps, or
+  local paths.
+
+## CLI
+
+Project a caller-owned queue:
+
+```bash
+loopx content-ops queue-status \
+  --item-json items/launch-post-v1.json \
+  --item-json items/community-recap-v1.json \
+  --queue-id loopx-x-operations \
+  --generated-at 2026-08-10T02:00:00+08:00 \
+  --format json
+```
+
+The command reports `external_reads_performed=false`,
+`external_writes_performed=false`, and `autopublish_allowed=false`.
+
+## Truth Contract
+
+`queue-status` is a read-only projection. Approval, delivery, and readback must
+still go through the item lifecycle and exact owner-authorization records; the
+queue surface itself has no publish authority.

--- a/examples/content-ops-queue-status-smoke.py
+++ b/examples/content-ops-queue-status-smoke.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Smoke-test the content-ops queue-status projection CLI."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.content_ops.item_lifecycle import (  # noqa: E402
+    apply_content_ops_item_event,
+    build_content_ops_item,
+)
+
+
+PRIVATE_PATTERNS = [
+    re.compile(r"/Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"/private/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._-]+"),
+]
+
+
+def _review_ready() -> dict[str, Any]:
+    item = build_content_ops_item(
+        item_id="community-recap-v1",
+        item_kind="post",
+        channel="x",
+        content_digest="sha256:" + "b" * 64,
+        content_ref="draft:community-recap-v1",
+        source_refs=["source:github-loopx-public-recap"],
+        created_at="2026-08-10T02:00:00+08:00",
+    )
+    return apply_content_ops_item_event(
+        item,
+        {
+            "event_id": "review:community-recap-v1",
+            "action": "submit_review",
+            "expected_state": item["state"],
+            "expected_revision": item["revision"],
+            "occurred_at": "2026-08-10T02:05:00+08:00",
+            "payload": {},
+        },
+    )["item"]
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        item_path = Path(tmp) / "item.json"
+        item_path.write_text(
+            json.dumps(_review_ready(), ensure_ascii=True),
+            encoding="utf-8",
+        )
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "--format",
+                "json",
+                "content-ops",
+                "queue-status",
+                "--item-json",
+                str(item_path),
+                "--queue-id",
+                "loopx-x-operations",
+                "--generated-at",
+                "2026-08-10T02:10:00+08:00",
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True, payload
+    assert payload["projection"]["queue_id"] == "loopx-x-operations", payload
+    assert payload["projection"]["counts"] == {"review_ready": 1}, payload
+    assert payload["projection"]["next_action"]["item_id"] == "community-recap-v1"
+    assert payload["external_reads_performed"] is False, payload
+    assert payload["external_writes_performed"] is False, payload
+    assert payload["autopublish_allowed"] is False, payload
+
+    text = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    for pattern in PRIVATE_PATTERNS:
+        if pattern.search(text):
+            raise AssertionError(f"payload matched private pattern {pattern.pattern!r}")
+
+    print("content-ops-queue-status-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/canary/module_metric_baseline.json
+++ b/loopx/canary/module_metric_baseline.json
@@ -23,7 +23,7 @@
     "loopx/capabilities/catalog.py": {
       "any_count": 8,
       "dict_any_count": 0,
-      "lines": 1863
+      "lines": 1892
     },
     "loopx/capabilities/content_ops/surface.py": {
       "any_count": 40,

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -1374,6 +1374,21 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "purpose": "Merge public source packets and private owner gates into a control-plane surface.",
                 "write_boundary": "local packet aggregation only",
             },
+            {
+                "command": "loopx content-ops item-create --item-id <id> --item-kind <kind> --channel <channel> --content-digest <sha256> --content-ref <ref> --created-at <iso> --format json",
+                "purpose": "Create one provider-neutral content item without draft bodies.",
+                "write_boundary": "local item packet only; no external write",
+            },
+            {
+                "command": "loopx content-ops item-transition --item-json <item.json> --event-json <event.json> --format json",
+                "purpose": "Apply one content item lifecycle event and emit a compact receipt.",
+                "write_boundary": "local item transition only; no external write",
+            },
+            {
+                "command": "loopx content-ops queue-status --item-json <item.json> --format json",
+                "purpose": "Project caller-owned content items into one read-only managed queue surface.",
+                "write_boundary": "local queue projection only; no external read or write",
+            },
         ],
         "implemented_protocols": [
             {
@@ -1406,6 +1421,16 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "module": "loopx.capabilities.content_ops.social_browser_x",
                 "doc": "docs/capabilities/content-ops/README.md",
             },
+            {
+                "schema_version": "content_ops_item_v0",
+                "module": "loopx.capabilities.content_ops.item_lifecycle",
+                "doc": "docs/reference/protocols/content-ops-item-lifecycle-v0.md",
+            },
+            {
+                "schema_version": "content_ops_queue_projection_v0",
+                "module": "loopx.capabilities.content_ops.item_lifecycle",
+                "doc": "docs/reference/protocols/content-ops-queue-v0.md",
+            },
         ],
         "smokes": [
             "python3 examples/content-ops-exploration-plan-smoke.py",
@@ -1413,15 +1438,19 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
             "python3 examples/content-ops-private-connector-gate-smoke.py",
             "python3 examples/content-ops-chatview-report-smoke.py",
             "python3 examples/content-ops-packet-aggregation-smoke.py",
+            "python3 examples/content-ops-queue-status-smoke.py",
         ],
         "docs": [
             "docs/capabilities/content-ops/README.md",
             "docs/reference/protocols/content-ops-surface-v0.md",
+            "docs/reference/protocols/content-ops-item-lifecycle-v0.md",
+            "docs/reference/protocols/content-ops-queue-v0.md",
         ],
         "boundaries": [
             "Private connectors enter as owner gates or compact approved counts first.",
             "Raw chats, transcripts, auth material, logs, and local paths are not copied into public packets.",
             "Publish remains blocked until an explicit user decision.",
+            "Queue projection is read-only and never stores draft bodies or provider credentials.",
         ],
         "next_real_step": (
             "Turn the aggregated surface into a small review/feed UI where a user "

--- a/loopx/capabilities/content_ops/cli.py
+++ b/loopx/capabilities/content_ops/cli.py
@@ -14,7 +14,9 @@ from ..issue_fix.content_ops_cli import (
 from .item_lifecycle import (
     apply_content_ops_item_event,
     build_content_ops_item_packet,
+    build_content_ops_queue_status_packet,
     render_content_ops_item_packet_markdown,
+    render_content_ops_queue_status_markdown,
 )
 from .surface import (
     build_content_ops_chatview_report_packet,
@@ -388,6 +390,33 @@ def register_content_ops_commands(
         required=True,
         help="Path to a content item event JSON object.",
     )
+    queue_parser = content_ops_sub.add_parser(
+        "queue-status",
+        help=(
+            "Project caller-owned content_ops_item_v0 files into one read-only "
+            "managed queue surface."
+        ),
+    )
+    add_subcommand_format(queue_parser)
+    queue_parser.add_argument(
+        "--item-json",
+        action="append",
+        required=True,
+        help=(
+            "Path to content_ops_item_v0 JSON; repeat in priority order. "
+            "Use '-' to read one item from stdin."
+        ),
+    )
+    queue_parser.add_argument(
+        "--queue-id",
+        default="content_ops_managed_queue",
+        help="Stable queue id for the projection.",
+    )
+    queue_parser.add_argument(
+        "--generated-at",
+        default="2026-08-10T00:00:00Z",
+        help="Public-safe generated_at timestamp for the queue projection.",
+    )
 
 
 def handle_content_ops_command(
@@ -489,13 +518,23 @@ def handle_content_ops_command(
                 _load_json_object(args.event_json),
             )
             renderer = render_content_ops_item_packet_markdown
+        elif args.content_ops_command == "queue-status":
+            payload = build_content_ops_queue_status_packet(
+                items=[
+                    _load_json_object(path) for path in args.item_json
+                ],
+                queue_id=args.queue_id,
+                generated_at=args.generated_at,
+            )
+            renderer = render_content_ops_queue_status_markdown
         else:
             raise ValueError(
                 "content-ops requires `preview`, `exploration-plan`, "
                 "`issue-fix-intake`, `issue-fix-metadata-preview`, "
                 "`observe-public-handle`, `project-private-connector-gate`, "
                 "`aggregate-packets`, `project-chatview-report`, or "
-                "`walkthrough-artifact`, `item-create`, or `item-transition`"
+                "`walkthrough-artifact`, `item-create`, `item-transition`, "
+                "or `queue-status`"
             )
     except Exception as exc:
         payload = {

--- a/loopx/capabilities/content_ops/item_lifecycle.py
+++ b/loopx/capabilities/content_ops/item_lifecycle.py
@@ -15,6 +15,8 @@ from .schemas import (
     CONTENT_OPS_ITEM_SCHEMA_VERSION,
     CONTENT_OPS_ITEM_TRANSITION_PACKET_SCHEMA_VERSION,
     CONTENT_OPS_ITEM_TRANSITION_RECEIPT_SCHEMA_VERSION,
+    CONTENT_OPS_QUEUE_PROJECTION_SCHEMA_VERSION,
+    CONTENT_OPS_QUEUE_STATUS_PACKET_SCHEMA_VERSION,
 )
 
 ALLOWED_ITEM_KINDS = {"article", "post", "profile_update", "reply", "repost"}
@@ -734,6 +736,110 @@ def project_content_ops_item(item: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
+def build_content_ops_queue_projection(
+    *,
+    items: Sequence[Mapping[str, Any]],
+    queue_id: str = "content_ops_managed_queue",
+    generated_at: str = "2026-08-10T00:00:00Z",
+) -> dict[str, Any]:
+    """Project caller-owned content items into one managed queue surface."""
+
+    queue_token = _token(queue_id, "queue_id")
+    timestamp = _timestamp(generated_at, "generated_at")
+    if not items:
+        raise ValueError("content queue requires at least one item")
+    normalized = [_require_item(item) for item in items]
+    item_projections = [project_content_ops_item(item) for item in normalized]
+
+    counts: dict[str, int] = {}
+    terminal_count = 0
+    for projection in item_projections:
+        state = str(projection["state"])
+        counts[state] = counts.get(state, 0) + 1
+        if projection["terminal"]:
+            terminal_count += 1
+
+    actionable = [
+        {
+            "priority_index": index,
+            "item_id": projection["item_id"],
+            "item_kind": projection["item_kind"],
+            "channel": projection["channel"],
+            "state": projection["state"],
+            "revision": projection["revision"],
+            "next_actions": projection["next_actions"],
+        }
+        for index, projection in enumerate(item_projections, start=1)
+        if not projection["terminal"]
+    ]
+    next_action = None
+    if actionable:
+        first = actionable[0]
+        next_action = {
+            "item_id": first["item_id"],
+            "state": first["state"],
+            "priority_index": first["priority_index"],
+            "next_actions": first["next_actions"],
+        }
+
+    return {
+        "schema_version": CONTENT_OPS_QUEUE_PROJECTION_SCHEMA_VERSION,
+        "queue_id": queue_token,
+        "generated_at": timestamp,
+        "item_count": len(item_projections),
+        "counts": counts,
+        "terminal_count": terminal_count,
+        "items": [
+            {
+                "priority_index": index,
+                "item_id": projection["item_id"],
+                "item_kind": projection["item_kind"],
+                "channel": projection["channel"],
+                "state": projection["state"],
+                "revision": projection["revision"],
+                "content_ref": normalized[index - 1]["content_ref"],
+                "terminal": projection["terminal"],
+                "published_url": projection["published_url"],
+                "next_actions": projection["next_actions"],
+            }
+            for index, projection in enumerate(item_projections, start=1)
+        ],
+        "next_action": next_action,
+        "truth_contract": {
+            "projection_is_writable": False,
+            "external_effect_authority": "none",
+            "autopublish_allowed": False,
+        },
+    }
+
+
+def build_content_ops_queue_status_packet(
+    *,
+    items: Sequence[Mapping[str, Any]],
+    queue_id: str = "content_ops_managed_queue",
+    generated_at: str = "2026-08-10T00:00:00Z",
+) -> dict[str, Any]:
+    """Build a read-only queue status packet without draft bodies."""
+
+    projection = build_content_ops_queue_projection(
+        items=items,
+        queue_id=queue_id,
+        generated_at=generated_at,
+    )
+    return {
+        "ok": True,
+        "schema_version": CONTENT_OPS_QUEUE_STATUS_PACKET_SCHEMA_VERSION,
+        "queue_id": projection["queue_id"],
+        "generated_at": projection["generated_at"],
+        "item_count": projection["item_count"],
+        "projection": projection,
+        "external_reads_performed": False,
+        "external_writes_performed": False,
+        "private_source_bodies_read": False,
+        "autopublish_allowed": False,
+    }
+
+
 def build_content_ops_item_packet(**kwargs: Any) -> dict[str, Any]:
     item = build_content_ops_item(**kwargs)
     return {
@@ -840,4 +946,55 @@ def render_content_ops_item_packet_markdown(packet: Mapping[str, Any]) -> str:
                 f"- transition: `{receipt.get('from_state')} -> {receipt.get('to_state')}`",
             ]
         )
+    return "\n".join(lines) + "\n"
+
+
+def render_content_ops_queue_status_markdown(packet: Mapping[str, Any]) -> str:
+    if not packet.get("ok"):
+        return f"# LoopX Content-Ops Queue\n\n- error: `{packet.get('error')}`\n"
+    projection = (
+        packet.get("projection")
+        if isinstance(packet.get("projection"), Mapping)
+        else {}
+    )
+    counts = projection.get("counts") if isinstance(projection.get("counts"), Mapping) else {}
+    next_action = (
+        projection.get("next_action")
+        if isinstance(projection.get("next_action"), Mapping)
+        else None
+    )
+    lines = [
+        "# LoopX Content-Ops Queue",
+        "",
+        f"- queue_id: `{projection.get('queue_id')}`",
+        f"- item_count: `{projection.get('item_count')}`",
+        f"- terminal_count: `{projection.get('terminal_count')}`",
+        f"- counts: `{counts}`",
+        f"- external_writes_performed: `{packet.get('external_writes_performed')}`",
+    ]
+    if next_action:
+        lines.extend(
+            [
+                "",
+                "## Next Action",
+                "",
+                f"- item_id: `{next_action.get('item_id')}`",
+                f"- state: `{next_action.get('state')}`",
+                f"- priority_index: `{next_action.get('priority_index')}`",
+                f"- next_actions: `{next_action.get('next_actions')}`",
+            ]
+        )
+    items = projection.get("items")
+    if isinstance(items, Sequence) and not isinstance(items, (str, bytes)):
+        lines.extend(["", "## Queue Items", ""])
+        for item in items:
+            if not isinstance(item, Mapping):
+                continue
+            lines.append(
+                f"- `{item.get('priority_index')}` "
+                f"`{item.get('item_id')}` "
+                f"state=`{item.get('state')}` "
+                f"kind=`{item.get('item_kind')}` "
+                f"rev=`{item.get('revision')}`"
+            )
     return "\n".join(lines) + "\n"

--- a/loopx/capabilities/content_ops/schemas.py
+++ b/loopx/capabilities/content_ops/schemas.py
@@ -34,6 +34,8 @@ CONTENT_OPS_ITEM_TRANSITION_RECEIPT_SCHEMA_VERSION = (
     "content_ops_item_transition_receipt_v0"
 )
 CONTENT_OPS_ITEM_PROJECTION_SCHEMA_VERSION = "content_ops_item_projection_v0"
+CONTENT_OPS_QUEUE_PROJECTION_SCHEMA_VERSION = "content_ops_queue_projection_v0"
+CONTENT_OPS_QUEUE_STATUS_PACKET_SCHEMA_VERSION = "content_ops_queue_status_packet_v0"
 CONTENT_OPS_EXPLORATION_PLAN_PACKET_SCHEMA_VERSION = (
     "content_ops_exploration_plan_packet_v0"
 )

--- a/tests/test_content_ops_queue_status.py
+++ b/tests/test_content_ops_queue_status.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from loopx.capabilities.content_ops.item_lifecycle import (
+    apply_content_ops_item_event,
+    build_content_ops_item,
+    build_content_ops_queue_status_packet,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DIGEST = "sha256:" + "a" * 64
+
+
+def _item(item_id: str, item_kind: str = "post") -> dict[str, object]:
+    return build_content_ops_item(
+        item_id=item_id,
+        item_kind=item_kind,
+        channel="x",
+        content_digest=DIGEST,
+        content_ref=f"draft:{item_id}",
+        source_refs=["source:public-feed"],
+        created_at="2026-08-10T02:00:00+08:00",
+    )
+
+
+def _review_ready(item: dict[str, object]) -> dict[str, object]:
+    return apply_content_ops_item_event(
+        item,
+        {
+            "event_id": f"review:{item['item_id']}",
+            "action": "submit_review",
+            "expected_state": item["state"],
+            "expected_revision": item["revision"],
+            "occurred_at": "2026-08-10T02:05:00+08:00",
+            "payload": {},
+        },
+    )["item"]
+
+
+def _draft(item: dict[str, object]) -> dict[str, object]:
+    return apply_content_ops_item_event(
+        item,
+        {
+            "event_id": f"draft:{item['item_id']}",
+            "action": "revise",
+            "expected_state": item["state"],
+            "expected_revision": item["revision"],
+            "occurred_at": "2026-08-10T02:04:00+08:00",
+            "payload": {
+                "content_digest": item["content_digest"],
+                "content_ref": item["content_ref"],
+            },
+        },
+    )["item"]
+
+
+def test_queue_projection_orders_actionable_items_and_counts_states() -> None:
+    review = _review_ready(_item("community-recap-v1"))
+    draft = _draft(_item("runta-post-v1"))
+    packet = build_content_ops_queue_status_packet(
+        items=[review, draft],
+        queue_id="x-test-queue",
+        generated_at="2026-08-10T02:10:00+08:00",
+    )
+
+    projection = packet["projection"]
+    assert projection["queue_id"] == "x-test-queue"
+    assert projection["item_count"] == 2
+    assert projection["counts"] == {"review_ready": 1, "draft": 1}
+    assert projection["terminal_count"] == 0
+    assert projection["next_action"]["item_id"] == "community-recap-v1"
+    assert projection["items"][0]["priority_index"] == 1
+    assert projection["items"][1]["priority_index"] == 2
+    assert packet["external_reads_performed"] is False
+    assert packet["external_writes_performed"] is False
+    assert packet["autopublish_allowed"] is False
+
+
+def test_queue_projection_is_idle_when_all_items_are_terminal() -> None:
+    item = apply_content_ops_item_event(
+        _item("old-post-v1"),
+        {
+            "event_id": "skip:old-post-v1",
+            "action": "skip",
+            "expected_state": "captured",
+            "expected_revision": 1,
+            "occurred_at": "2026-08-10T02:05:00+08:00",
+            "payload": {"reason": "Superseded by a newer draft."},
+        },
+    )["item"]
+
+    projection = build_content_ops_queue_status_packet(
+        items=[item],
+        queue_id="x-test-queue",
+        generated_at="2026-08-10T02:10:00+08:00",
+    )["projection"]
+
+    assert projection["terminal_count"] == 1
+    assert projection["next_action"] is None
+
+
+def test_queue_projection_rejects_unknown_item_fields() -> None:
+    item = dict(_item("bad-item-v1"))
+    item["draft_body"] = "must stay outside LoopX state"
+
+    with pytest.raises(ValueError, match="unsupported fields"):
+        build_content_ops_queue_status_packet(
+            items=[item],
+            queue_id="x-test-queue",
+            generated_at="2026-08-10T02:10:00+08:00",
+        )
+
+
+def test_queue_status_cli_projects_items_without_external_effects(
+    tmp_path: Path,
+) -> None:
+    item = _review_ready(_item("community-recap-v1"))
+    item_path = tmp_path / "item.json"
+    item_path.write_text(json.dumps(item), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "content-ops",
+            "queue-status",
+            "--item-json",
+            str(item_path),
+            "--queue-id",
+            "x-test-queue",
+            "--generated-at",
+            "2026-08-10T02:10:00+08:00",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["projection"]["next_action"]["item_id"] == "community-recap-v1"
+    assert payload["external_writes_performed"] is False


### PR DESCRIPTION
## What

Adds `loopx content-ops queue-status` so caller-owned `content_ops_item_v0` files can be projected into one read-only managed queue surface.

## Why

The item lifecycle already exists, but operations lanes were falling back to ad hoc markdown boards. This gives the capability its own queue projection: input order is priority, item state drives the next action, and approval/delivery windows stay in the item lifecycle.

## Surface

- `queue-status` CLI: repeatable `--item-json`, optional `--queue-id`, `--generated-at`
- `content_ops_queue_projection_v0` with state counts, terminal count, item rows, and `next_action`
- protocol doc `docs/reference/protocols/content-ops-queue-v0.md`
- catalog entries for `item-create`, `item-transition`, and `queue-status`
- unit tests + focused CLI smoke

## Safety

- read-only projection, `external_reads_performed=false`, `external_writes_performed=false`, `autopublish_allowed=false`
- no draft bodies, credentials, browser state, media, or local paths
- validation reuses the existing strict item lifecycle

## Validation

- `pytest tests/test_content_ops_queue_status.py tests/test_content_ops_item_lifecycle.py` -> 11 passed
- `pytest tests/canary/test_maintainability_ratchet.py tests/control_plane/test_m6_quality_gates.py` -> passed
- `python examples/content-ops-queue-status-smoke.py` -> ok
- `loopx check --scan-path docs/capabilities/content-ops --scan-path docs/reference/protocols/content-ops-queue-v0.md --scan-path examples/content-ops-queue-status-smoke.py` -> 0 errors/warnings
- `ruff` clean on changed files
- `git diff --check` clean

`module_metric_baseline.json` updates the `catalog.py` line ceiling from 1863 to 1892 so the stable built-in capability registry can keep the new item lifecycle and queue-status catalog entries without unreviewed ratchet debt.
