### PR TITLE
refactor(control-plane): type stable core packet producers

### DIFF
--- a/loopx/control_plane/quota/decision_summary.py
+++ b/loopx/control_plane/quota/decision_summary.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TypedDict
 
 from ...state_projection import actions_are_projection_aligned
 from ..goals.contract_health import project_contract_health_for_goal
@@ -26,7 +26,26 @@ def quota_plan_items(plan: dict[str, Any]) -> list[dict[str, Any]]:
     return items
 
 
-def compact_quota_decision(decision: dict[str, Any]) -> dict[str, Any]:
+class QuotaDecisionPacket(TypedDict):
+    should_run: bool
+    normal_delivery_allowed: bool
+    recovery_delivery_allowed: bool
+    effective_action: str | None
+    self_repair_allowed: bool
+    capability_repair_allowed: bool
+    workspace_repair_allowed: bool
+    state: str
+    safe_bypass_allowed: bool
+    safe_bypass_kind: str | None
+    blocked_action_scope: str | None
+    compute: float | None
+    window_hours: int | None
+    slot_minutes: int | None
+    spent_slots: int | None
+    allowed_slots: int | None
+
+
+def compact_quota_decision(decision: dict[str, Any]) -> QuotaDecisionPacket:
     quota = decision.get("quota") if isinstance(decision.get("quota"), dict) else {}
     return {
         "should_run": bool(decision.get("should_run")),

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import shlex
+import typing
 from collections.abc import Mapping
 from typing import Any
 
@@ -46,6 +47,19 @@ INTERACTION_CONTRACT_SCHEMA_VERSION = "loopx_interaction_contract_v0"
 INTERACTION_RESPONSE_PLAN_SCHEMA_VERSION = "interaction_response_plan_v0"
 PROTOCOL_ACTION_PACKET_SCHEMA_VERSION = "protocol_action_packet_v0"
 PROTOCOL_ACTION_PACKET_LLM_POLICY = "no_api"
+
+
+class _InteractionContractRequired(typing.TypedDict):
+    schema_version: str
+    mode: str
+    user_channel: dict[str, Any]
+    agent_channel: dict[str, Any]
+    cli_channel: dict[str, Any]
+
+
+class InteractionContractPacket(_InteractionContractRequired, total=False):
+    response_plan: dict[str, Any]
+    fallback_policy: dict[str, Any]
 
 
 def _blocked_successor_wait_observation_required(payload: dict[str, Any]) -> bool:
@@ -1337,7 +1351,7 @@ def build_interaction_contract(
     scheduler_execution_context: (
         Mapping[str, Any] | SchedulerExecutionContextResolution | None
     ) = None,
-) -> dict[str, Any]:
+) -> InteractionContractPacket:
     execution_obligation = (
         payload.get("execution_obligation")
         if isinstance(payload.get("execution_obligation"), dict)
@@ -1397,7 +1411,7 @@ def build_interaction_contract(
         delivery_allowed=delivery_allowed,
         quiet_noop_allowed=quiet_noop_allowed,
     )
-    contract = {
+    contract: dict[str, Any] = {
         "schema_version": INTERACTION_CONTRACT_SCHEMA_VERSION,
         "mode": mode,
         "user_channel": user_channel,
@@ -1424,4 +1438,4 @@ def build_interaction_contract(
     _attach_interaction_vision_wait_state(contract, payload)
     if _interaction_fallback_policy_required(payload, mode=mode):
         contract["fallback_policy"] = {"do_not_cancel_on_block": True}
-    return contract
+    return typing.cast(InteractionContractPacket, contract)

--- a/tests/control_plane/test_core_packet_contracts.py
+++ b/tests/control_plane/test_core_packet_contracts.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, get_type_hints
+
+from loopx.control_plane.quota.decision_summary import (
+    QuotaDecisionPacket,
+    compact_quota_decision,
+)
+from loopx.control_plane.work_items.interaction_contract import (
+    InteractionContractPacket,
+    build_interaction_contract,
+)
+
+
+def _shape_ok(packet: Mapping[str, Any], contract: Any) -> bool:
+    annotations = set(get_type_hints(contract))
+    required = set(getattr(contract, "__required_keys__", frozenset()))
+    return required <= set(packet) and set(packet) <= annotations
+
+
+def test_quota_decision_packet_accepts_representative_packet() -> None:
+    packet = compact_quota_decision(
+        {
+            "goal_id": "loopx-meta",
+            "decision": "run",
+            "should_run": True,
+            "effective_action": "normal_run",
+            "normal_delivery_allowed": True,
+            "recovery_delivery_allowed": False,
+            "self_repair_allowed": False,
+            "capability_repair_allowed": False,
+            "workspace_repair_allowed": False,
+            "state": "normal",
+            "safe_bypass_allowed": False,
+            "safe_bypass_kind": None,
+            "blocked_action_scope": None,
+            "quota": {
+                "compute": 1.0,
+                "window_hours": 24,
+                "slot_minutes": 1,
+                "spent_slots": 3,
+                "allowed_slots": 10,
+            },
+            "reason": "runnable work",
+        }
+    )
+
+    assert _shape_ok(packet, QuotaDecisionPacket)
+    assert packet["safe_bypass_kind"] is None
+    assert packet["blocked_action_scope"] is None
+
+
+def test_interaction_contract_packet_accepts_representative_packet() -> None:
+    packet = build_interaction_contract(
+        {
+            "goal_id": "loopx-meta",
+            "effective_action": "normal_run",
+            "agent_identity": {"agent_id": "codex-quality-qualification"},
+            "heartbeat_recommendation": {"recommended_mode": "bounded_delivery"},
+        }
+    )
+
+    assert _shape_ok(packet, InteractionContractPacket)
+
+
+def test_packet_contracts_reject_unknown_keys() -> None:
+    assert not _shape_ok({"unknown": True}, QuotaDecisionPacket)
+    assert not _shape_ok({"unknown": True}, InteractionContractPacket)
+
+
+def test_packet_contracts_reject_missing_required_keys() -> None:
+    quota_packet = compact_quota_decision({})
+    interaction_packet = build_interaction_contract({})
+
+    quota_without_should_run = dict(quota_packet)
+    interaction_without_mode = dict(interaction_packet)
+    quota_without_should_run.pop("should_run")
+    interaction_without_mode.pop("mode")
+
+    assert not _shape_ok(quota_without_should_run, QuotaDecisionPacket)
+    assert not _shape_ok(interaction_without_mode, InteractionContractPacket)
+
+
+def test_contract_required_keys_match_producer_invariants() -> None:
+    assert QuotaDecisionPacket.__optional_keys__ == frozenset()
+    assert QuotaDecisionPacket.__required_keys__ == frozenset(
+        {
+            "should_run",
+            "normal_delivery_allowed",
+            "recovery_delivery_allowed",
+            "effective_action",
+            "self_repair_allowed",
+            "capability_repair_allowed",
+            "workspace_repair_allowed",
+            "state",
+            "safe_bypass_allowed",
+            "safe_bypass_kind",
+            "blocked_action_scope",
+            "compute",
+            "window_hours",
+            "slot_minutes",
+            "spent_slots",
+            "allowed_slots",
+        }
+    )
+    assert InteractionContractPacket.__required_keys__ == frozenset(
+        {"schema_version", "mode", "user_channel", "agent_channel", "cli_channel"}
+    )
+    assert InteractionContractPacket.__optional_keys__ == frozenset(
+        {"response_plan", "fallback_policy"}
+    )


### PR DESCRIPTION
## Summary

- add required-key `QuotaDecisionPacket` and `InteractionContractPacket` contracts beside their existing producers
- wire `compact_quota_decision()` and `build_interaction_contract()` to those stable return types without changing runtime payloads
- validate real producer packets, reject unknown keys, reject missing required keys, and assert the exact required/optional key sets
- preserve nullable quota values such as `safe_bypass_kind`, `blocked_action_scope`, and quota counters in the type surface

## Scope refinement

This replaces #2891 on current `main`. The older PR also typed `compact_todo_summary_item()`, but exact-head review showed that value is a mutable intermediate: downstream capability and routing callers add fields after compaction and continue to treat it as `dict[str, Any]`. Advertising it as a closed TypedDict would be a false contract hidden by the current mypy file allowlist. This replacement deliberately leaves that seam untyped until an immutable final Todo packet boundary exists.

The two retained packets are stable producer outputs. `QuotaDecisionPacket` has only required keys because the compact producer always emits them; `InteractionContractPacket` has five required top-level keys and only the two conditionally emitted top-level keys as optional. Internal interaction construction remains a mutable dict and is cast once at the final return boundary.

## Validation

- `84 passed`: core packet, quota decision/projection, scheduler acknowledgement, monitor projection, and interaction arbitration/workspace tests
- repository-declared mypy: passed (16 source files)
- changed test Ruff: passed; production base/head differential introduces zero new Ruff findings
- changed Python compile and diff checks: passed
- exact-scope quality receipt: `cqr_78cd2e08e281cb6971cf`, valid, 0 blockers
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: passed, 17 selected checks, 0 failures, 0 warnings, 0 manual holds, self-merge allowed

No private state, internal links, raw evidence, credentials, local paths, generated logs, or benchmark artifacts are included.
