### PR TITLE
fix(quota): preserve turn settlement across replans

### DIFF
--- a/loopx/control_plane/quota/settlement.py
+++ b/loopx/control_plane/quota/settlement.py
@@ -47,6 +47,7 @@ __all__ = [
     "find_settlement_spend_run",
     "find_settlement_step_event",
     "find_settlement_writeback",
+    "infer_persisted_heartbeat_settlement_identity",
     "require_settlement_spend",
     "require_settlement_todo_completion",
     "require_settlement_writeback",
@@ -55,6 +56,14 @@ __all__ = [
     "settlement_result_payload",
     "settlement_step_command",
 ]
+
+
+def _identity_mismatch(reason: str) -> SettlementResult[SettlementIdentity]:
+    return SettlementResult.failed(
+        kind=SettlementFailureKind.IDENTITY_MISMATCH,
+        step_kind=SettlementStepKind.VALIDATION,
+        reason=reason,
+    )
 
 
 def resolve_heartbeat_settlement_identity(
@@ -160,6 +169,92 @@ def _run_index_records(runtime_root: Path, goal_id: str) -> list[dict[str, Any]]
         if isinstance(record, dict):
             records.append(record)
     return records
+
+
+def infer_persisted_heartbeat_settlement_identity(
+    runtime_root: Path,
+    *,
+    goal_id: str,
+    agent_id: str | None,
+    todo_id: str | None,
+) -> SettlementResult[SettlementIdentity] | None:
+    """Recover the latest typed heartbeat identity when a caller omits its turn id.
+
+    This is a compatibility recovery seam, not a second source of truth. It
+    considers only the newest same-agent accountable writeback or spend, and
+    then revalidates that candidate against the original heartbeat guard.
+    Unrelated Todo lineages and legacy untyped runs fall back to the existing
+    frontier binding rules.
+    """
+
+    normalized_agent_id = normalize_todo_claimed_by(agent_id)
+    normalized_todo_id = normalize_todo_id(todo_id)
+    if not normalized_agent_id or not normalized_todo_id:
+        return None
+
+    candidate: dict[str, Any] | None = None
+    for run in reversed(_run_index_records(runtime_root, goal_id)):
+        run_agent_id = normalize_todo_claimed_by(run.get("agent_id"))
+        if run_agent_id and run_agent_id != normalized_agent_id:
+            continue
+        classification = str(run.get("classification") or "").strip()
+        delivery_outcome = normalize_delivery_outcome(run.get("delivery_outcome"))
+        if classification == "quota_slot_voided":
+            continue
+        if classification == "quota_scheduler_ack":
+            continue
+        if classification == "quota_monitor_poll" and run.get("material_change") is not True:
+            continue
+        if (
+            classification == "state_refreshed"
+            and delivery_outcome not in ACCOUNTABLE_DELIVERY_OUTCOMES
+        ):
+            continue
+        if (
+            classification == "quota_slot_spent"
+            or delivery_outcome in ACCOUNTABLE_DELIVERY_OUTCOMES
+        ):
+            candidate = run
+        break
+
+    if candidate is None:
+        return None
+    candidate_todo_id = normalize_todo_id(candidate.get("todo_id"))
+    if candidate_todo_id != normalized_todo_id:
+        return None
+    candidate_turn_id = str(candidate.get("turn_instance_id") or "").strip()
+    if not candidate_turn_id:
+        return None
+
+    identity = SettlementIdentity(
+        goal_id=goal_id,
+        agent_id=normalized_agent_id,
+        todo_id=normalized_todo_id,
+        turn_instance_id=candidate_turn_id,
+    )
+    persisted_value = candidate.get("settlement_identity")
+    persisted = persisted_value if isinstance(persisted_value, Mapping) else {}
+    for field, expected in (
+        ("goal_id", identity.goal_id),
+        ("agent_id", identity.agent_id),
+        ("todo_id", identity.todo_id),
+        ("turn_instance_id", identity.turn_instance_id),
+        ("effect_id", identity.effect_id),
+    ):
+        actual = str(persisted.get(field) or "").strip()
+        if actual and actual != expected:
+            return _identity_mismatch(
+                "persisted settlement identity mismatch: "
+                f"{field} is {actual} but expected {expected}"
+            )
+
+    return resolve_heartbeat_settlement_identity(
+        runtime_root,
+        goal_id=goal_id,
+        agent_id=normalized_agent_id,
+        todo_id=normalized_todo_id,
+        turn_instance_id=candidate_turn_id,
+    )
 
 
 def find_settlement_writeback(

--- a/loopx/control_plane/quota/slot_accounting.py
+++ b/loopx/control_plane/quota/slot_accounting.py
@@ -26,6 +26,7 @@ from ..work_items.delivery_outcome import (
 )
 from .settlement import (
     SettlementIdentity,
+    infer_persisted_heartbeat_settlement_identity,
     require_settlement_writeback,
     resolve_heartbeat_settlement_identity,
     settlement_result_payload,
@@ -73,6 +74,57 @@ def _todo_binding_error(
             "delivery so the accounted turn is bound to the selected todo"
         )
     return None
+
+
+def _resolve_preview_settlement(
+    *,
+    raw_runtime_root: Any,
+    source: str,
+    goal_id: str,
+    agent_id: str | None,
+    todo_id: str | None,
+    turn_instance_id: str | None,
+) -> dict[str, Any]:
+    if turn_instance_id and source != DEFAULT_SLOT_SPEND_SOURCE:
+        return {"reason": "turn-scoped settlement is valid only for heartbeat spend"}
+    if turn_instance_id and not raw_runtime_root:
+        return {"reason": "status payload does not include runtime_root"}
+    if source != DEFAULT_SLOT_SPEND_SOURCE or not raw_runtime_root:
+        return {}
+
+    runtime_root = Path(str(raw_runtime_root)).expanduser()
+    result = (
+        resolve_heartbeat_settlement_identity(
+            runtime_root,
+            goal_id=goal_id,
+            agent_id=agent_id,
+            todo_id=todo_id,
+            turn_instance_id=turn_instance_id,
+        )
+        if turn_instance_id
+        else infer_persisted_heartbeat_settlement_identity(
+            runtime_root,
+            goal_id=goal_id,
+            agent_id=agent_id,
+            todo_id=todo_id,
+        )
+    )
+    if result is None:
+        return {}
+    identity = result.value if result.failure is None else None
+    if identity is not None:
+        result = result.bind(
+            lambda resolved: require_settlement_writeback(
+                runtime_root,
+                resolved,
+            )
+        )
+    return {
+        "identity": identity,
+        "result": result,
+        "delivery_run": result.value if result.failure is None else None,
+        "reason": result.failure.reason if result.failure is not None else None,
+    }
 
 
 def _now_local() -> str:
@@ -234,71 +286,36 @@ def build_quota_slot_preview_for_decision(
     settlement_identity = None
     settlement_result = None
     delivery_completion_run = None
-    if turn_instance_id:
-        if source != DEFAULT_SLOT_SPEND_SOURCE:
-            return {
-                "ok": False,
-                "mode": "spend-slot",
-                "dry_run": True,
-                "goal_id": safe_goal_id,
-                "slots": safe_slots,
-                "agent_id": safe_requested_agent_id,
-                "appended": False,
-                "registry_mutated": False,
-                "reason": "turn-scoped settlement is valid only for heartbeat spend",
-                "before": before,
-                "after": None,
-            }
-        if not raw_runtime_root:
-            return {
-                "ok": False,
-                "mode": "spend-slot",
-                "dry_run": True,
-                "goal_id": safe_goal_id,
-                "slots": safe_slots,
-                "agent_id": safe_requested_agent_id,
-                "appended": False,
-                "registry_mutated": False,
-                "reason": "status payload does not include runtime_root",
-                "before": before,
-                "after": None,
-            }
-        runtime_root = Path(str(raw_runtime_root)).expanduser()
-        settlement_result = resolve_heartbeat_settlement_identity(
-            runtime_root,
-            goal_id=safe_goal_id,
-            agent_id=safe_requested_agent_id,
-            todo_id=normalized_todo_id,
-            turn_instance_id=turn_instance_id,
-        )
-        if settlement_result.failure is None:
-            settlement_identity = settlement_result.value
-        if settlement_identity is not None:
-            settlement_result = settlement_result.bind(
-                lambda identity: require_settlement_writeback(
-                    runtime_root,
-                    identity,
-                )
-            )
-            if settlement_result.failure is None:
-                delivery_completion_run = settlement_result.value
-        if settlement_result.failure is not None:
-            return {
-                "ok": False,
-                "mode": "spend-slot",
-                "dry_run": True,
-                "goal_id": safe_goal_id,
-                "slots": safe_slots,
-                "agent_id": safe_requested_agent_id,
-                "appended": False,
-                "registry_mutated": False,
-                "reason": settlement_result.failure.reason,
-                "settlement_result": settlement_result_payload(
-                    settlement_result
-                ),
-                "before": before,
-                "after": None,
-            }
+    settlement = _resolve_preview_settlement(
+        raw_runtime_root=raw_runtime_root,
+        source=source,
+        goal_id=safe_goal_id,
+        agent_id=safe_requested_agent_id,
+        todo_id=normalized_todo_id,
+        turn_instance_id=turn_instance_id,
+    )
+    settlement_identity = settlement.get("identity")
+    settlement_result = settlement.get("result")
+    delivery_completion_run = settlement.get("delivery_run")
+    if settlement.get("reason"):
+        return {
+            "ok": False,
+            "mode": "spend-slot",
+            "dry_run": True,
+            "goal_id": safe_goal_id,
+            "slots": safe_slots,
+            "agent_id": safe_requested_agent_id,
+            "appended": False,
+            "registry_mutated": False,
+            "reason": settlement["reason"],
+            "settlement_result": (
+                settlement_result_payload(settlement_result)
+                if settlement_result is not None
+                else None
+            ),
+            "before": before,
+            "after": None,
+        }
     binding_error = _todo_binding_error(
         source=source,
         before=before,

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -38,6 +38,7 @@ from .control_plane.quota.scheduler_ack import (
 )
 from .control_plane.quota.settlement import (
     find_settlement_spend_run,
+    infer_persisted_heartbeat_settlement_identity,
     require_settlement_spend,
     require_settlement_writeback,
     resolve_heartbeat_settlement_identity,
@@ -1054,6 +1055,33 @@ def spend_quota_slot(
             "reason": "turn-scoped settlement is valid only for heartbeat spend",
         }
     raw_runtime_root = status_payload.get("runtime_root")
+    if (
+        not turn_instance_id
+        and source == DEFAULT_SLOT_SPEND_SOURCE
+        and raw_runtime_root
+    ):
+        inferred_result = infer_persisted_heartbeat_settlement_identity(
+            Path(str(raw_runtime_root)).expanduser(),
+            goal_id=safe_goal_id,
+            agent_id=agent_id,
+            todo_id=todo_id,
+        )
+        if inferred_result is not None:
+            if inferred_result.failure is not None or inferred_result.value is None:
+                return {
+                    "ok": False,
+                    "mode": "spend-slot",
+                    "dry_run": not execute,
+                    "appended": False,
+                    "goal_id": safe_goal_id,
+                    "reason": (
+                        inferred_result.failure.reason
+                        if inferred_result.failure is not None
+                        else "persisted heartbeat settlement has no identity"
+                    ),
+                    "settlement_result": settlement_result_payload(inferred_result),
+                }
+            turn_instance_id = inferred_result.value.turn_instance_id
     if turn_instance_id and raw_runtime_root:
         runtime_root = Path(str(raw_runtime_root)).expanduser()
         guard_result = resolve_heartbeat_settlement_identity(

--- a/tests/control_plane/test_quota_slot_accounting.py
+++ b/tests/control_plane/test_quota_slot_accounting.py
@@ -10,6 +10,7 @@ from loopx.control_plane.quota.slot_accounting import (
     build_quota_slot_preview_for_decision,
     build_quota_slot_spend_event,
 )
+from loopx.quota import spend_quota_slot
 from loopx.rollout_event_log import rollout_event_log_path
 
 GOAL_ID = "quota-slot-accounting-fixture"
@@ -477,6 +478,89 @@ def _normal_run_status(runtime: Path) -> dict[str, Any]:
     }
 
 
+def _write_typed_settlement_fixture(
+    runtime: Path,
+    *,
+    todo_id: str,
+    turn_instance_id: str,
+    include_spend: bool = False,
+) -> str:
+    effect_id = f"{GOAL_ID}:{AGENT_A}:{todo_id}:{turn_instance_id}"
+    identity = {
+        "effect_id": effect_id,
+        "goal_id": GOAL_ID,
+        "agent_id": AGENT_A,
+        "todo_id": todo_id,
+        "turn_instance_id": turn_instance_id,
+    }
+    records = [
+        {
+            **_run(
+                "2026-01-01T00:01:00+00:00",
+                classification="validated_progress",
+                delivery_outcome="outcome_progress",
+                agent_id=AGENT_A,
+            ),
+            "todo_id": todo_id,
+            "turn_instance_id": turn_instance_id,
+            "settlement_identity": identity,
+        }
+    ]
+    if include_spend:
+        records.append(
+            {
+                **_spent("2026-01-01T00:02:00+00:00", agent_id=AGENT_A),
+                "todo_id": todo_id,
+                "turn_instance_id": turn_instance_id,
+                "settlement_identity": identity,
+            }
+        )
+    _write_run_index(runtime, records)
+
+    events = [
+        {
+            "schema_version": "loopx_rollout_event_v0",
+            "event_id": "event-guard",
+            "event_kind": "quota_should_run",
+            "goal_id": GOAL_ID,
+            "agent_id": AGENT_A,
+            "run_id": turn_instance_id,
+            "details": {
+                "todo_id": todo_id,
+                "settlement_effect_id": effect_id,
+            },
+        },
+        {
+            "schema_version": "loopx_rollout_event_v0",
+            "event_id": "event-writeback",
+            "event_kind": "refresh_state",
+            "goal_id": GOAL_ID,
+            "agent_id": AGENT_A,
+            "run_id": turn_instance_id,
+            "details": {"settlement_effect_id": effect_id},
+        },
+    ]
+    if include_spend:
+        events.append(
+            {
+                "schema_version": "loopx_rollout_event_v0",
+                "event_id": "event-spend",
+                "event_kind": "quota_spend",
+                "goal_id": GOAL_ID,
+                "agent_id": AGENT_A,
+                "run_id": turn_instance_id,
+                "details": {"settlement_effect_id": effect_id},
+            }
+        )
+    rollout_path = rollout_event_log_path(runtime, GOAL_ID)
+    rollout_path.parent.mkdir(parents=True, exist_ok=True)
+    rollout_path.write_text(
+        "".join(json.dumps(event) + "\n" for event in events),
+        encoding="utf-8",
+    )
+    return effect_id
+
+
 def test_heartbeat_spend_requires_todo_binding(tmp_path: Path) -> None:
     runtime = tmp_path / "runtime"
     before = _normal_run_before(todo_id="todo_selected_binding")
@@ -522,19 +606,16 @@ def test_heartbeat_spend_rejects_mismatched_todo_binding(tmp_path: Path) -> None
     assert "binding mismatch" in preview["reason"]
 
 
-def test_heartbeat_spend_reselection_strands_completed_todo_settlement(
+def test_heartbeat_spend_recovers_completed_todo_identity_after_reselection(
     tmp_path: Path,
 ) -> None:
     runtime = tmp_path / "runtime"
-    _write_run_index(
+    original_todo_id = "todo_completed_delivery"
+    turn_instance_id = "turn-completed-delivery"
+    effect_id = _write_typed_settlement_fixture(
         runtime,
-        [
-            _run(
-                "2026-01-01T00:01:00+00:00",
-                classification="validated_progress",
-                delivery_outcome="outcome_progress",
-            )
-        ],
+        todo_id=original_todo_id,
+        turn_instance_id=turn_instance_id,
     )
     before = _normal_run_before(todo_id="todo_new_successor")
 
@@ -548,28 +629,23 @@ def test_heartbeat_spend_reselection_strands_completed_todo_settlement(
         },
         quota_status_builder=lambda goal, **_: goal["quota"],
         self_repair_spend_actions=frozenset(),
-        agent_id=None,
-        todo_id="todo_completed_delivery",
+        agent_id=AGENT_A,
+        todo_id=original_todo_id,
         source="heartbeat",
     )
 
-    # M7.1 characterizes the current split-brain: an accountable delivery is
-    # present, but spend rebinds against a fresh selection instead of the
-    # original turn identity. M7.2 replaces this behavior.
-    assert preview["ok"] is False
-    assert "selected todo is todo_new_successor" in preview["reason"]
-    assert "--todo-id is todo_completed_delivery" in preview["reason"]
+    assert preview["ok"] is True, preview
+    assert preview["delivery_completion_spend"] is True
+    assert preview["turn_instance_id"] == turn_instance_id
+    assert preview["settlement_identity"]["effect_id"] == effect_id
 
 
-def test_turn_scoped_spend_keeps_original_todo_across_successor_reselection(
+def test_implicit_heartbeat_identity_fails_closed_on_persisted_effect_drift(
     tmp_path: Path,
 ) -> None:
     runtime = tmp_path / "runtime"
     original_todo_id = "todo_completed_delivery"
     turn_instance_id = "turn-completed-delivery"
-    effect_id = (
-        f"{GOAL_ID}:{AGENT_A}:{original_todo_id}:{turn_instance_id}"
-    )
     _write_run_index(
         runtime,
         [
@@ -582,46 +658,67 @@ def test_turn_scoped_spend_keeps_original_todo_across_successor_reselection(
                 ),
                 "todo_id": original_todo_id,
                 "turn_instance_id": turn_instance_id,
-                "settlement_identity": {
-                    "effect_id": effect_id,
-                    "goal_id": GOAL_ID,
-                    "agent_id": AGENT_A,
-                    "todo_id": original_todo_id,
-                    "turn_instance_id": turn_instance_id,
-                },
+                "settlement_identity": {"effect_id": "drifted-effect-id"},
             }
         ],
     )
-    rollout_path = rollout_event_log_path(runtime, GOAL_ID)
-    rollout_path.parent.mkdir(parents=True, exist_ok=True)
-    rollout_path.write_text(
-        "".join(
-            json.dumps(event) + "\n"
-            for event in (
-                {
-                    "schema_version": "loopx_rollout_event_v0",
-                    "event_id": "event-guard",
-                    "event_kind": "quota_should_run",
-                    "goal_id": GOAL_ID,
-                    "agent_id": AGENT_A,
-                    "run_id": turn_instance_id,
-                    "details": {
-                        "todo_id": original_todo_id,
-                        "settlement_effect_id": effect_id,
-                    },
-                },
-                {
-                    "schema_version": "loopx_rollout_event_v0",
-                    "event_id": "event-writeback",
-                    "event_kind": "refresh_state",
-                    "goal_id": GOAL_ID,
-                    "agent_id": AGENT_A,
-                    "run_id": turn_instance_id,
-                    "details": {"settlement_effect_id": effect_id},
-                },
-            )
-        ),
-        encoding="utf-8",
+    before = _normal_run_before(todo_id="todo_new_successor")
+
+    preview = build_quota_slot_preview_for_decision(
+        _normal_run_status(runtime),
+        goal_id=GOAL_ID,
+        before=before,
+        after_decision=lambda _: before,
+        quota_status_builder=lambda goal, **_: goal["quota"],
+        self_repair_spend_actions=frozenset(),
+        agent_id=AGENT_A,
+        todo_id=original_todo_id,
+        source="heartbeat",
+    )
+
+    assert preview["ok"] is False
+    assert "persisted settlement identity mismatch" in preview["reason"]
+    assert preview["settlement_result"]["failure"]["kind"] == "identity_mismatch"
+
+
+def test_implicit_heartbeat_spend_replays_exactly_once_after_frontier_moves(
+    tmp_path: Path,
+) -> None:
+    runtime = tmp_path / "runtime"
+    original_todo_id = "todo_completed_delivery"
+    turn_instance_id = "turn-completed-delivery"
+    _write_typed_settlement_fixture(
+        runtime,
+        todo_id=original_todo_id,
+        turn_instance_id=turn_instance_id,
+        include_spend=True,
+    )
+
+    replay = spend_quota_slot(
+        {"runtime_root": str(runtime)},
+        goal_id=GOAL_ID,
+        execute=True,
+        source="heartbeat",
+        agent_id=AGENT_A,
+        todo_id=original_todo_id,
+    )
+
+    assert replay["ok"] is True, replay
+    assert replay["appended"] is False
+    assert replay["idempotent_replay"] is True
+    assert replay["turn_instance_id"] == turn_instance_id
+
+
+def test_turn_scoped_spend_keeps_original_todo_across_successor_reselection(
+    tmp_path: Path,
+) -> None:
+    runtime = tmp_path / "runtime"
+    original_todo_id = "todo_completed_delivery"
+    turn_instance_id = "turn-completed-delivery"
+    effect_id = _write_typed_settlement_fixture(
+        runtime,
+        todo_id=original_todo_id,
+        turn_instance_id=turn_instance_id,
     )
     before = _normal_run_before(todo_id="todo_new_successor")
 


### PR DESCRIPTION
## Summary

- recover the latest persisted heartbeat settlement identity when a legacy closeout omits its turn id
- revalidate the recovered identity against the original guard and accountable writeback before spending
- preserve fail-closed identity drift and exactly-once spend replay after Todo completion advances the frontier

## Motivation and design

Completing the selected Todo can replan the goal onto a successor before quota closeout. The legacy fallback then compared the completed Todo with the new frontier and stranded an otherwise validated delivery. This change treats the persisted `(goal, agent, todo, turn)` identity as the settlement truth and reuses the existing typed guard, writeback, and spend receipt chain. Unrelated Todo lineages and untyped legacy records continue through the existing frontier rules.

The recovery seam remains quota-owned and does not move scheduler handoff inside settlement or introduce a second executor.

## Validation

- 259 focused quota, Effect Program, Turn, and heartbeat tests passed
- ruff passed on all four changed Python files
- repository mypy configuration passed
- changed runtime modules compiled successfully
- premerge canary passed: 17/17 selected checks, no manual holds, self-merge allowed
- change-quality receipt `cqr_91080ecfb2a515bbae6a` is valid for the committed diff

## Boundary scan

Only quota runtime code and durable control-plane tests are included. No private state, local paths, credentials, raw logs, internal links, or generated lockfiles are part of the PR.
