### PR TITLE
fix(quota): upgrade identityless heartbeat receipts

### DIFF
--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -10,6 +10,7 @@ from ..control_plane.quota.cli_projection import (
     compact_quota_should_run_cli_payload,
 )
 from ..control_plane.quota.error_codes import quota_error_code
+from ..control_plane.quota.effect_program import SettlementIdentity
 from ..control_plane.quota.heartbeat_receipt import (
     fail_heartbeat_receipt,
     find_heartbeat_receipt,
@@ -619,9 +620,12 @@ def _reconcile_existing_heartbeat_receipt(
         existing_effect_id = str(
             existing_details.get("settlement_effect_id") or ""
         ).strip()
-        expected_effect_id = (
-            f"{args.goal_id}:{args.agent_id}:{rollout_todo_id}:{turn_instance_id}"
-        )
+        expected_effect_id = SettlementIdentity(
+            goal_id=args.goal_id,
+            agent_id=args.agent_id,
+            todo_id=rollout_todo_id,
+            turn_instance_id=turn_instance_id,
+        ).effect_id
         if existing_todo_id and existing_effect_id:
             if (
                 existing_todo_id != rollout_todo_id

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -14,6 +14,7 @@ from ..control_plane.quota.heartbeat_receipt import (
     fail_heartbeat_receipt,
     find_heartbeat_receipt,
     heartbeat_receipt_view,
+    upgrade_identityless_heartbeat_receipt,
 )
 from ..control_plane.quota.live_decision import build_live_quota_should_run_decision
 from ..control_plane.quota.monitor_poll import find_quota_monitor_poll_turn
@@ -593,6 +594,75 @@ def _quota_renderer(
     }.get(command, render_quota_markdown)
 
 
+def _reconcile_existing_heartbeat_receipt(
+    payload: dict[str, object],
+    args: argparse.Namespace,
+    *,
+    runtime_root: Path,
+    turn_instance_id: str,
+    existing: dict[str, object],
+) -> tuple[dict[str, object], str, bool, str]:
+    """Bind an identity-less same-turn receipt without changing a bound receipt."""
+
+    receipt = existing
+    receipt_status = "replayed"
+    receipt_appended = False
+    rollout_todo_id = quota_rollout_todo_id(payload, args)
+    if rollout_todo_id:
+        existing_details_value = receipt.get("details")
+        existing_details = (
+            existing_details_value
+            if isinstance(existing_details_value, Mapping)
+            else {}
+        )
+        existing_todo_id = str(existing_details.get("todo_id") or "").strip()
+        existing_effect_id = str(
+            existing_details.get("settlement_effect_id") or ""
+        ).strip()
+        expected_effect_id = (
+            f"{args.goal_id}:{args.agent_id}:{rollout_todo_id}:{turn_instance_id}"
+        )
+        if existing_todo_id and existing_effect_id:
+            if (
+                existing_todo_id != rollout_todo_id
+                or existing_effect_id != expected_effect_id
+            ):
+                raise ValueError(
+                    "heartbeat receipt settlement identity conflicts with the "
+                    "current selected Todo"
+                )
+        else:
+            rollout_details = quota_rollout_details(
+                payload,
+                args,
+                todo_id=rollout_todo_id,
+            )
+            receipt, upgraded = upgrade_identityless_heartbeat_receipt(
+                runtime_root,
+                goal_id=args.goal_id,
+                agent_id=args.agent_id,
+                turn_instance_id=turn_instance_id,
+                todo_id=rollout_todo_id,
+                settlement_effect_id=expected_effect_id,
+                status=str(
+                    payload.get("effective_action")
+                    or payload.get("decision")
+                    or "should-run"
+                ),
+                summary=f"heartbeat quota receipt upgraded for turn={turn_instance_id}",
+                details=rollout_details,
+            )
+            if upgraded:
+                receipt_status = "upgraded"
+                receipt_appended = True
+    details_value = receipt.get("details")
+    details: Mapping[str, object] = (
+        details_value if isinstance(details_value, Mapping) else {}
+    )
+    stall_observation = str(details.get("stall_observation") or "not_applicable")
+    return receipt, receipt_status, receipt_appended, stall_observation
+
+
 def handle_quota_command(
     args: argparse.Namespace,
     *,
@@ -603,6 +673,8 @@ def handle_quota_command(
 ) -> int:
     heartbeat_turn_id: str | None = None
     heartbeat_receipt_existing: dict[str, object] | None = None
+    heartbeat_receipt_existing_status = "replayed"
+    heartbeat_receipt_existing_appended = False
     heartbeat_receipt_ready = False
     heartbeat_stall_observation = "not_evaluated"
     detail_sections: frozenset[str] = frozenset()
@@ -644,13 +716,17 @@ def handle_quota_command(
                     turn_instance_id=heartbeat_turn_id,
                 )
                 if heartbeat_receipt_existing:
-                    details = (
-                        heartbeat_receipt_existing.get("details")
-                        if isinstance(heartbeat_receipt_existing.get("details"), Mapping)
-                        else {}
-                    )
-                    heartbeat_stall_observation = str(
-                        details.get("stall_observation") or "not_applicable"
+                    (
+                        heartbeat_receipt_existing,
+                        heartbeat_receipt_existing_status,
+                        heartbeat_receipt_existing_appended,
+                        heartbeat_stall_observation,
+                    ) = _reconcile_existing_heartbeat_receipt(
+                        payload,
+                        args,
+                        runtime_root=runtime_root,
+                        turn_instance_id=heartbeat_turn_id,
+                        existing=heartbeat_receipt_existing,
                     )
                     heartbeat_receipt_ready = True
                 else:
@@ -867,7 +943,7 @@ def handle_quota_command(
                 payload["heartbeat_receipt"] = heartbeat_receipt_view(
                     heartbeat_receipt_existing,
                     turn_instance_id=heartbeat_turn_id,
-                    status="replayed",
+                    status=heartbeat_receipt_existing_status,
                 )
                 payload["rollout_event"] = {
                     "schema_version": heartbeat_receipt_existing.get("schema_version"),
@@ -875,7 +951,7 @@ def handle_quota_command(
                     "event_kind": heartbeat_receipt_existing.get("event_kind"),
                     "recorded_at": heartbeat_receipt_existing.get("recorded_at"),
                     "status": heartbeat_receipt_existing.get("status"),
-                    "appended": False,
+                    "appended": heartbeat_receipt_existing_appended,
                 }
             else:
                 rollout_details.update(
@@ -917,9 +993,10 @@ def handle_quota_command(
                     turn_instance_id=heartbeat_turn_id,
                 )
                 if receipt:
-                    rollout_event = (
-                        payload.get("rollout_event")
-                        if isinstance(payload.get("rollout_event"), Mapping)
+                    rollout_event_value = payload.get("rollout_event")
+                    rollout_event: Mapping[str, object] = (
+                        rollout_event_value
+                        if isinstance(rollout_event_value, Mapping)
                         else {}
                     )
                     payload["heartbeat_receipt"] = heartbeat_receipt_view(

--- a/loopx/control_plane/quota/heartbeat_receipt.py
+++ b/loopx/control_plane/quota/heartbeat_receipt.py
@@ -1,12 +1,80 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
 from pathlib import Path
 
-from ...rollout_event_log import load_rollout_events, rollout_event_log_path
+from ...file_lock import exclusive_file_lock
+from ...rollout_event_log import (
+    ROLLOUT_EVENT_SCHEMA_VERSION,
+    build_rollout_event,
+    load_rollout_events,
+    rollout_event_log_path,
+)
 from .effect_program import SETTLEMENT_IDENTITY_SCHEMA_VERSION
 
 HEARTBEAT_RECEIPT_SCHEMA_VERSION = "heartbeat_quota_receipt_v0"
+
+
+def _heartbeat_receipt_events(
+    events: list[dict[str, object]],
+    *,
+    goal_id: str,
+    agent_id: str,
+    turn_instance_id: str,
+) -> list[dict[str, object]]:
+    return [
+        event
+        for event in events
+        if event.get("event_kind") == "quota_should_run"
+        and str(event.get("goal_id") or "") == goal_id
+        and str(event.get("agent_id") or "") == agent_id
+        and str(event.get("run_id") or "") == turn_instance_id
+    ]
+
+
+def _receipt_settlement_identity(
+    event: Mapping[str, object],
+) -> tuple[str, str] | None:
+    details_value = event.get("details")
+    details: Mapping[str, object] = (
+        details_value if isinstance(details_value, Mapping) else {}
+    )
+    todo_id = str(details.get("todo_id") or "").strip()
+    effect_id = str(details.get("settlement_effect_id") or "").strip()
+    if effect_id and not todo_id:
+        raise ValueError(
+            "heartbeat receipt has an effect identity without a Todo; refuse to "
+            "infer or upgrade it"
+        )
+    if not todo_id:
+        return None
+    if not effect_id:
+        goal_id = str(event.get("goal_id") or "").strip()
+        agent_id = str(event.get("agent_id") or "").strip()
+        turn_instance_id = str(event.get("run_id") or "").strip()
+        effect_id = f"{goal_id}:{agent_id}:{todo_id}:{turn_instance_id}"
+    return todo_id, effect_id
+
+
+def _effective_heartbeat_receipt(
+    events: list[dict[str, object]],
+) -> dict[str, object] | None:
+    if not events:
+        return None
+    identities: dict[tuple[str, str], dict[str, object]] = {}
+    for event in events:
+        identity = _receipt_settlement_identity(event)
+        if identity is not None:
+            identities[identity] = event
+    if len(identities) > 1:
+        raise ValueError(
+            "heartbeat receipt has conflicting settlement identities for the "
+            "same goal, agent, and turn"
+        )
+    if identities:
+        return next(iter(identities.values()))
+    return events[-1]
 
 
 def find_heartbeat_receipt(
@@ -17,15 +85,117 @@ def find_heartbeat_receipt(
     turn_instance_id: str,
 ) -> dict[str, object] | None:
     events = load_rollout_events(rollout_event_log_path(runtime_root, goal_id))
-    for event in reversed(events):
-        if (
-            event.get("event_kind") == "quota_should_run"
-            and str(event.get("goal_id") or "") == goal_id
-            and str(event.get("agent_id") or "") == agent_id
-            and str(event.get("run_id") or "") == turn_instance_id
-        ):
-            return event
-    return None
+    return _effective_heartbeat_receipt(
+        _heartbeat_receipt_events(
+            events,
+            goal_id=goal_id,
+            agent_id=agent_id,
+            turn_instance_id=turn_instance_id,
+        )
+    )
+
+
+def upgrade_identityless_heartbeat_receipt(
+    runtime_root: Path,
+    *,
+    goal_id: str,
+    agent_id: str,
+    turn_instance_id: str,
+    todo_id: str,
+    settlement_effect_id: str,
+    status: str,
+    summary: str,
+    details: Mapping[str, object],
+) -> tuple[dict[str, object], bool]:
+    """Append one settlement-bound receipt after an identity-less same-turn guard.
+
+    The correction is append-only and serialized with the rollout log lock. A
+    matching correction replays, a legacy Todo-only receipt gains its derived
+    effect id, and effect-only or conflicting identities fail closed.
+    """
+
+    normalized_todo_id = str(todo_id).strip()
+    normalized_effect_id = str(settlement_effect_id).strip()
+    expected_effect_id = (
+        f"{goal_id}:{agent_id}:{normalized_todo_id}:{turn_instance_id}"
+    )
+    if not normalized_todo_id or normalized_effect_id != expected_effect_id:
+        raise ValueError(
+            "heartbeat receipt upgrade requires the deterministic selected Todo "
+            "settlement identity"
+        )
+
+    log_path = rollout_event_log_path(runtime_root, goal_id)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with exclusive_file_lock(log_path):
+        try:
+            lines = log_path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            lines = []
+        events: list[dict[str, object]] = []
+        for line in lines:
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if (
+                isinstance(parsed, dict)
+                and parsed.get("schema_version") == ROLLOUT_EVENT_SCHEMA_VERSION
+            ):
+                events.append(parsed)
+        matching = _heartbeat_receipt_events(
+            events,
+            goal_id=goal_id,
+            agent_id=agent_id,
+            turn_instance_id=turn_instance_id,
+        )
+        effective = _effective_heartbeat_receipt(matching)
+        if effective is None:
+            raise ValueError(
+                "identity-less heartbeat receipt is missing; rerun the original guard"
+            )
+        existing_identity = _receipt_settlement_identity(effective)
+        expected_identity = (normalized_todo_id, normalized_effect_id)
+        if existing_identity is not None:
+            if existing_identity != expected_identity:
+                raise ValueError(
+                    "heartbeat receipt settlement identity conflicts with the "
+                    "current selected Todo"
+                )
+            existing_details_value = effective.get("details")
+            existing_details = (
+                existing_details_value
+                if isinstance(existing_details_value, Mapping)
+                else {}
+            )
+            if str(existing_details.get("settlement_effect_id") or "").strip():
+                return effective, False
+
+        corrected_details = dict(details)
+        corrected_details.update(
+            {
+                "turn_instance_id": turn_instance_id,
+                "todo_id": normalized_todo_id,
+                "settlement_effect_id": normalized_effect_id,
+                "settlement_receipt_revision": "identity_upgrade",
+            }
+        )
+        source_event_id = str(effective.get("event_id") or "").strip() or None
+        corrected = build_rollout_event(
+            goal_id=goal_id,
+            event_kind="quota_should_run",
+            agent_id=agent_id,
+            todo_id=normalized_todo_id,
+            run_id=turn_instance_id,
+            status=status,
+            summary=summary,
+            source_event_id=source_event_id,
+            caused_by=source_event_id,
+            details=corrected_details,
+        )
+        with log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(corrected, sort_keys=True, ensure_ascii=False) + "\n")
+        return corrected, True
 
 
 def heartbeat_receipt_view(

--- a/loopx/control_plane/quota/heartbeat_receipt.py
+++ b/loopx/control_plane/quota/heartbeat_receipt.py
@@ -11,7 +11,7 @@ from ...rollout_event_log import (
     load_rollout_events,
     rollout_event_log_path,
 )
-from .effect_program import SETTLEMENT_IDENTITY_SCHEMA_VERSION
+from .effect_program import SETTLEMENT_IDENTITY_SCHEMA_VERSION, SettlementIdentity
 
 HEARTBEAT_RECEIPT_SCHEMA_VERSION = "heartbeat_quota_receipt_v0"
 
@@ -53,7 +53,12 @@ def _receipt_settlement_identity(
         goal_id = str(event.get("goal_id") or "").strip()
         agent_id = str(event.get("agent_id") or "").strip()
         turn_instance_id = str(event.get("run_id") or "").strip()
-        effect_id = f"{goal_id}:{agent_id}:{todo_id}:{turn_instance_id}"
+        effect_id = SettlementIdentity(
+            goal_id=goal_id,
+            agent_id=agent_id,
+            todo_id=todo_id,
+            turn_instance_id=turn_instance_id,
+        ).effect_id
     return todo_id, effect_id
 
 
@@ -116,9 +121,12 @@ def upgrade_identityless_heartbeat_receipt(
 
     normalized_todo_id = str(todo_id).strip()
     normalized_effect_id = str(settlement_effect_id).strip()
-    expected_effect_id = (
-        f"{goal_id}:{agent_id}:{normalized_todo_id}:{turn_instance_id}"
-    )
+    expected_effect_id = SettlementIdentity(
+        goal_id=goal_id,
+        agent_id=agent_id,
+        todo_id=normalized_todo_id,
+        turn_instance_id=turn_instance_id,
+    ).effect_id
     if not normalized_todo_id or normalized_effect_id != expected_effect_id:
         raise ValueError(
             "heartbeat receipt upgrade requires the deterministic selected Todo "

--- a/loopx/control_plane/quota/settlement.py
+++ b/loopx/control_plane/quota/settlement.py
@@ -93,12 +93,15 @@ def resolve_heartbeat_settlement_identity(
                 "turn_instance_id"
             ),
         )
-    receipt_event = find_heartbeat_receipt(
-        runtime_root,
-        goal_id=goal_id,
-        agent_id=normalized_agent_id,
-        turn_instance_id=normalized_turn_id,
-    )
+    try:
+        receipt_event = find_heartbeat_receipt(
+            runtime_root,
+            goal_id=goal_id,
+            agent_id=normalized_agent_id,
+            turn_instance_id=normalized_turn_id,
+        )
+    except ValueError as exc:
+        return _identity_mismatch(str(exc))
     if receipt_event is None:
         return SettlementResult.failed(
             kind=SettlementFailureKind.RECEIPT_MISSING,

--- a/tests/control_plane/test_heartbeat_receipt.py
+++ b/tests/control_plane/test_heartbeat_receipt.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from loopx.control_plane.quota.heartbeat_receipt import (
+    find_heartbeat_receipt,
+    upgrade_identityless_heartbeat_receipt,
+)
+from loopx.rollout_event_log import (
+    append_rollout_event,
+    build_rollout_event,
+    load_rollout_events,
+    rollout_event_log_path,
+)
+
+GOAL_ID = "heartbeat-receipt-fixture"
+AGENT_ID = "codex-heartbeat-receipt"
+TURN_ID = "turn-heartbeat-receipt-1"
+TODO_ID = "todo_heartbeat_receipt"
+EFFECT_ID = f"{GOAL_ID}:{AGENT_ID}:{TODO_ID}:{TURN_ID}"
+
+
+def _append_receipt(
+    runtime_root: Path,
+    *,
+    todo_id: str = "",
+    effect_id: str = "",
+) -> dict[str, object]:
+    details: dict[str, object] = {"stall_observation": "not_applicable"}
+    if todo_id:
+        details["todo_id"] = todo_id
+    if effect_id:
+        details["settlement_effect_id"] = effect_id
+    event = build_rollout_event(
+        goal_id=GOAL_ID,
+        event_kind="quota_should_run",
+        agent_id=AGENT_ID,
+        todo_id=todo_id or None,
+        run_id=TURN_ID,
+        status="normal_run",
+        summary="heartbeat receipt fixture",
+        details=details,
+    )
+    return append_rollout_event(
+        rollout_event_log_path(runtime_root, GOAL_ID),
+        event,
+    )
+
+
+def _upgrade(runtime_root: Path, *, todo_id: str = TODO_ID) -> tuple[dict[str, object], bool]:
+    effect_id = f"{GOAL_ID}:{AGENT_ID}:{todo_id}:{TURN_ID}"
+    return upgrade_identityless_heartbeat_receipt(
+        runtime_root,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        turn_instance_id=TURN_ID,
+        todo_id=todo_id,
+        settlement_effect_id=effect_id,
+        status="normal_run",
+        summary="heartbeat receipt upgraded",
+        details={"stall_observation": "not_applicable", "todo_id": todo_id},
+    )
+
+
+def test_identityless_receipt_upgrade_is_append_only_and_idempotent(
+    tmp_path: Path,
+) -> None:
+    original = _append_receipt(tmp_path)
+
+    corrected, appended = _upgrade(tmp_path)
+    replay, replay_appended = _upgrade(tmp_path)
+
+    assert appended is True
+    assert replay_appended is False
+    assert corrected["event_id"] != original["event_id"]
+    assert replay["event_id"] == corrected["event_id"]
+    assert corrected["causality"]["source_event_id"] == original["event_id"]
+    assert corrected["causality"]["caused_by"] == original["event_id"]
+    assert corrected["details"]["todo_id"] == TODO_ID
+    assert corrected["details"]["settlement_effect_id"] == EFFECT_ID
+    assert corrected["details"]["settlement_receipt_revision"] == "identity_upgrade"
+    assert len(load_rollout_events(rollout_event_log_path(tmp_path, GOAL_ID))) == 2
+
+
+def test_identityless_receipt_upgrade_rejects_conflicting_selected_todo(
+    tmp_path: Path,
+) -> None:
+    _append_receipt(tmp_path)
+    _upgrade(tmp_path)
+
+    with pytest.raises(ValueError, match="conflicts with the current selected Todo"):
+        _upgrade(tmp_path, todo_id="todo_conflicting")
+
+    assert len(load_rollout_events(rollout_event_log_path(tmp_path, GOAL_ID))) == 2
+
+
+def test_concurrent_identityless_receipt_upgrades_append_one_correction(
+    tmp_path: Path,
+) -> None:
+    _append_receipt(tmp_path)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(lambda _: _upgrade(tmp_path), range(16)))
+
+    assert sum(1 for _, appended in results if appended) == 1
+    assert {event["event_id"] for event, _ in results} == {
+        results[0][0]["event_id"]
+    }
+    assert len(load_rollout_events(rollout_event_log_path(tmp_path, GOAL_ID))) == 2
+
+
+def test_legacy_todo_only_receipt_upgrades_derived_effect_identity(
+    tmp_path: Path,
+) -> None:
+    original = _append_receipt(tmp_path, todo_id=TODO_ID)
+
+    corrected, appended = _upgrade(tmp_path)
+
+    assert appended is True
+    assert corrected["event_id"] != original["event_id"]
+    assert corrected["details"]["settlement_effect_id"] == EFFECT_ID
+    assert len(load_rollout_events(rollout_event_log_path(tmp_path, GOAL_ID))) == 2
+
+
+def test_effect_without_todo_identity_fails_closed(tmp_path: Path) -> None:
+    _append_receipt(tmp_path, effect_id=EFFECT_ID)
+
+    with pytest.raises(ValueError, match="effect identity without a Todo"):
+        find_heartbeat_receipt(
+            tmp_path,
+            goal_id=GOAL_ID,
+            agent_id=AGENT_ID,
+            turn_instance_id=TURN_ID,
+        )
+    with pytest.raises(ValueError, match="effect identity without a Todo"):
+        _upgrade(tmp_path)
+
+    assert len(load_rollout_events(rollout_event_log_path(tmp_path, GOAL_ID))) == 1
+
+
+def test_effective_receipt_does_not_downgrade_after_identity_correction(
+    tmp_path: Path,
+) -> None:
+    _append_receipt(tmp_path)
+    corrected, _ = _upgrade(tmp_path)
+    _append_receipt(tmp_path)
+
+    effective = find_heartbeat_receipt(
+        tmp_path,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        turn_instance_id=TURN_ID,
+    )
+
+    assert effective is not None
+    assert effective["event_id"] == corrected["event_id"]

--- a/tests/control_plane/test_quota_settlement.py
+++ b/tests/control_plane/test_quota_settlement.py
@@ -277,3 +277,21 @@ def test_guard_receipt_rejects_different_effect_identity(tmp_path: Path) -> None
     assert result.failure is not None
     assert result.failure.kind is SettlementFailureKind.IDENTITY_MISMATCH
     assert "different-effect" in result.failure.reason
+
+
+def test_guard_receipt_returns_typed_failure_for_effect_without_todo(
+    tmp_path: Path,
+) -> None:
+    _append_guard_receipt(tmp_path, todo_id="", effect_id="effect-without-todo")
+
+    result = resolve_heartbeat_settlement_identity(
+        tmp_path,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        todo_id=TODO_ID,
+        turn_instance_id=TURN_ID,
+    )
+
+    assert result.failure is not None
+    assert result.failure.kind is SettlementFailureKind.IDENTITY_MISMATCH
+    assert "effect identity without a Todo" in result.failure.reason

--- a/tests/control_plane/test_quota_settlement_cli.py
+++ b/tests/control_plane/test_quota_settlement_cli.py
@@ -13,13 +13,22 @@ TODO_ID = "todo_fixture_settlement"
 TURN_ID = "turn-settlement-cli-1"
 
 
-def _write_fixture(root: Path) -> tuple[Path, Path, Path]:
+def _write_fixture(
+    root: Path,
+    *,
+    required_capability: str | None = None,
+) -> tuple[Path, Path, Path]:
     project = root / "project"
     runtime = root / "runtime"
     state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
     state_path = project / state_file
     registry_path = project / ".loopx" / "registry.json"
     state_path.parent.mkdir(parents=True, exist_ok=True)
+    capability_metadata = (
+        f" required_capabilities={required_capability}"
+        if required_capability
+        else ""
+    )
     state_path.write_text(
         "---\n"
         "status: active-read-only\n"
@@ -35,7 +44,8 @@ def _write_fixture(root: Path) -> tuple[Path, Path, Path]:
         "## Agent Todo\n\n"
         "- [ ] [P1] Validate and settle the selected delivery.\n"
         f"  <!-- loopx:todo todo_id={TODO_ID} status=open "
-        "task_class=advancement_task action_kind=validate -->\n",
+        "task_class=advancement_task action_kind=validate"
+        f"{capability_metadata} -->\n",
         encoding="utf-8",
     )
     registry_path.parent.mkdir(parents=True, exist_ok=True)
@@ -123,6 +133,21 @@ def _classification_count(runtime: Path, classification: str) -> int:
         1
         for line in index_path.read_text(encoding="utf-8").splitlines()
         if json.loads(line).get("classification") == classification
+    )
+
+
+def _heartbeat_receipt_count(runtime: Path, turn_instance_id: str) -> int:
+    log_path = runtime / "goals" / GOAL_ID / "rollout-event-log.jsonl"
+    if not log_path.exists():
+        return 0
+    return sum(
+        1
+        for line in log_path.read_text(encoding="utf-8").splitlines()
+        if (
+            (event := json.loads(line)).get("event_kind") == "quota_should_run"
+            and event.get("run_id") == turn_instance_id
+            and event.get("agent_id") == AGENT_ID
+        )
     )
 
 
@@ -275,3 +300,145 @@ def test_standard_codex_app_settlement_is_receipted_and_idempotent(
     assert replay["idempotent_replay"] is True
     assert replay["appended"] is False
     assert _spend_run_count(runtime) == 1
+
+
+def test_same_turn_identityless_guard_upgrades_and_settles_full_chain(
+    tmp_path: Path,
+) -> None:
+    project, runtime, registry_path = _write_fixture(
+        tmp_path,
+        required_capability="network",
+    )
+    binding = (
+        "--agent-id",
+        AGENT_ID,
+        "--todo-id",
+        TODO_ID,
+        "--turn-instance-id",
+        TURN_ID,
+    )
+    guard_args = (
+        "quota",
+        "should-run",
+        "--codex-app",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--turn-instance-id",
+        TURN_ID,
+        "--scan-path",
+        str(project),
+    )
+
+    first_rc, first = _run_cli(registry_path, runtime, *guard_args)
+    upgraded_rc, upgraded = _run_cli(
+        registry_path,
+        runtime,
+        *guard_args,
+        "--available-capability",
+        "network",
+    )
+    replay_rc, replay = _run_cli(
+        registry_path,
+        runtime,
+        *guard_args,
+        "--available-capability",
+        "network",
+    )
+
+    assert first_rc == 0, first
+    assert "settlement_identity" not in first["heartbeat_receipt"]
+    assert upgraded_rc == 0, upgraded
+    assert upgraded["heartbeat_receipt"]["status"] == "upgraded"
+    identity = upgraded["heartbeat_receipt"]["settlement_identity"]
+    assert identity["todo_id"] == TODO_ID
+    assert identity["effect_id"] == f"{GOAL_ID}:{AGENT_ID}:{TODO_ID}:{TURN_ID}"
+    assert replay_rc == 0, replay
+    assert replay["heartbeat_receipt"]["status"] == "replayed"
+    assert replay["heartbeat_receipt"]["event_id"] == upgraded["heartbeat_receipt"]["event_id"]
+    assert _heartbeat_receipt_count(runtime, TURN_ID) == 2
+
+    complete_rc, complete = _run_cli(
+        registry_path,
+        runtime,
+        "todo",
+        "complete",
+        "--goal-id",
+        GOAL_ID,
+        *binding,
+        "--claimed-by",
+        AGENT_ID,
+        "--evidence",
+        "identity upgrade delivery validated",
+        "--next-agent-todo",
+        "Continue after the identity upgrade delivery.",
+        "--next-claimed-by",
+        AGENT_ID,
+        "--next-action-kind",
+        "implement",
+    )
+    assert complete_rc == 0, complete
+    successor_id = complete["next_todos"][0]["todo_id"]
+    assert successor_id != TODO_ID
+
+    refresh_rc, refresh = _run_cli(
+        registry_path,
+        runtime,
+        "refresh-state",
+        "--goal-id",
+        GOAL_ID,
+        "--classification",
+        "identity_upgrade_validated",
+        "--delivery-batch-scale",
+        "single_surface",
+        "--delivery-outcome",
+        "outcome_progress",
+        *binding,
+        "--no-global-sync",
+        "--suppress-external-sinks",
+    )
+    assert refresh_rc == 0, refresh
+
+    successor_guard_rc, successor_guard = _run_cli(
+        registry_path,
+        runtime,
+        "quota",
+        "should-run",
+        "--codex-app",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--available-capability",
+        "network",
+        "--scan-path",
+        str(project),
+    )
+    assert successor_guard_rc == 0, successor_guard
+    assert successor_guard["selected_todo"]["todo_id"] == successor_id
+
+    spend_args = (
+        "quota",
+        "spend-slot",
+        "--goal-id",
+        GOAL_ID,
+        "--slots",
+        "1",
+        "--source",
+        "heartbeat",
+        "--execute",
+        *binding,
+        "--scan-path",
+        str(project),
+    )
+    spend_rc, spend = _run_cli(registry_path, runtime, *spend_args)
+    spend_replay_rc, spend_replay = _run_cli(registry_path, runtime, *spend_args)
+
+    assert spend_rc == 0, spend
+    assert spend["settlement_result"]["ok"] is True
+    assert spend_replay_rc == 0, spend_replay
+    assert spend_replay["idempotent_replay"] is True
+    assert spend_replay["appended"] is False
+    assert _spend_run_count(runtime) == 1
+    assert _heartbeat_receipt_count(runtime, TURN_ID) == 2


### PR DESCRIPTION
## Summary

- append exactly one correction when a repeated heartbeat guard gains a selected Todo in the same turn
- preserve legacy Todo-only receipts while rejecting effect-only or conflicting settlement identities
- return malformed receipt identity as a typed settlement failure
- cover append-only replay, concurrent retry, legacy compatibility, and the complete guard-to-spend CLI chain

## Validation

- 111 focused quota, settlement, effect-program, CLI projection, and vision tests
- repository fast-lane Ruff and configured mypy checks
- CLI output-budget regression, public-boundary scan, `py_compile`, and diff hygiene
- premerge: 4 direct checks, 9 catalog canaries, and 8 risk-profile checks; 0 failures, warnings, or manual holds
- change-quality receipt: `cqr_5a78d87c59a022cdc585`

## Risk and boundaries

- reuses the existing rollout event log, lock, deterministic settlement identity, and typed failure algebra
- correction is append-only and idempotent under concurrent retry
- no scheduler, permission, scoring, benchmark, or public/private evidence-policy changes
