### PR TITLE
test(effect): add public incident replays

### DIFF
--- a/tests/control_plane/test_effect_program_incident_replay.py
+++ b/tests/control_plane/test_effect_program_incident_replay.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from loopx.control_plane.effect_program import (
+    SettlementResult,
+    SettlementStepKind,
+)
+from loopx.control_plane.quota.settlement import (
+    resolve_heartbeat_settlement_identity,
+)
+from loopx.control_plane.turn_driver.settlement import (
+    TurnSettlementState,
+    execute_turn_driver_settlement,
+)
+from loopx.control_plane.turn_driver.transaction import (
+    TRANSACTION_PHASES,
+    build_loopx_turn_transaction_plan,
+)
+from loopx.rollout_event_log import rollout_event_log_path
+
+GOAL_ID = "replay-goal"
+AGENT_ID = "replay-agent"
+TODO_ID = "todo_incident"
+TURN_ID = "replay-turn"
+FIXTURE = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "control_plane"
+    / "effect_program_incident_replay_v0.json"
+)
+ALLOWED_CASE_KEYS = {
+    "case_id",
+    "adapter",
+    "incident_class",
+    "invariant_id",
+    "rationale",
+    "input",
+    "expected",
+}
+REQUIRED_INVARIANTS = {
+    "INV-WRITEBACK-BEFORE-SPEND",
+    "INV-FAILURE-SHORT-CIRCUIT",
+    "INV-ONE-EFFECT-IDENTITY",
+    "INV-AT-MOST-ONCE-SETTLEMENT",
+}
+
+
+def _load_corpus() -> dict[str, Any]:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def _assert_public_case(value: Any, *, excluded_keys: set[str]) -> None:
+    if isinstance(value, Mapping):
+        assert not ({str(key).casefold() for key in value} & excluded_keys)
+        for nested in value.values():
+            _assert_public_case(nested, excluded_keys=excluded_keys)
+    elif isinstance(value, list):
+        for nested in value:
+            _assert_public_case(nested, excluded_keys=excluded_keys)
+    elif isinstance(value, str):
+        assert "://" not in value
+        assert not value.startswith("/")
+        assert "@" not in value
+
+
+def _effect_id(transaction_plan: Mapping[str, Any]) -> str:
+    settlement_plan = transaction_plan["settlement_plan"]
+    assert isinstance(settlement_plan, Mapping)
+    identity = settlement_plan["identity"]
+    assert isinstance(identity, Mapping)
+    return str(identity["effect_id"])
+
+
+def _committed_payload(
+    step_kind: SettlementStepKind,
+    *,
+    effect_id: str,
+) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "appended": True,
+        "effect_id": effect_id,
+        "step_kind": step_kind.value,
+    }
+
+
+def _observe(
+    result: SettlementResult[Any],
+    *,
+    effect_calls: list[SettlementStepKind],
+    checkpoint_steps: list[SettlementStepKind],
+) -> dict[str, Any]:
+    failure = result.failure
+    return {
+        "status": "failure" if failure else "success",
+        "failure_kind": failure.kind.value if failure else None,
+        "failure_step": failure.step_kind.value if failure else None,
+        "effect_calls": [step.value for step in effect_calls],
+        "checkpoint_steps": [step.value for step in checkpoint_steps],
+        "receipt_steps": [receipt.step_kind.value for receipt in result.receipts],
+        "receipt_identity_count": len(
+            {receipt.effect_id for receipt in result.receipts}
+        ),
+    }
+
+
+def _replay_turn_driver(case: Mapping[str, Any]) -> dict[str, Any]:
+    case_input = case["input"]
+    assert isinstance(case_input, Mapping)
+    transaction_plan = build_loopx_turn_transaction_plan(
+        planned=True,
+        lineage={
+            "goal_id": GOAL_ID,
+            "agent_id": AGENT_ID,
+            "todo_id": TODO_ID,
+        },
+        host="generic-cli",
+        execution_mode="isolated-headless",
+        session_action="resume",
+        turn_instance_id=TURN_ID,
+    )
+    effect_id = _effect_id(transaction_plan)
+    reject_at = (
+        SettlementStepKind(str(case_input["reject_at"]))
+        if case_input.get("reject_at")
+        else None
+    )
+    effect_calls: list[SettlementStepKind] = []
+    checkpoint_steps: list[SettlementStepKind] = []
+
+    def effect(step_kind: SettlementStepKind) -> Mapping[str, Any]:
+        effect_calls.append(step_kind)
+        if step_kind is reject_at:
+            return {
+                "ok": False,
+                "appended": False,
+                "reason": f"{step_kind.value} rejected by replay fixture",
+            }
+        return _committed_payload(step_kind, effect_id=effect_id)
+
+    result: SettlementResult[TurnSettlementState] = execute_turn_driver_settlement(
+        transaction_plan,
+        transaction_phases=TRANSACTION_PHASES,
+        completed_phases=tuple(case_input["completed_phases"]),
+        writeback_payload=(
+            _committed_payload(
+                SettlementStepKind.DURABLE_WRITEBACK,
+                effect_id=effect_id,
+            )
+            if case_input.get("writeback_committed")
+            else None
+        ),
+        quota_spend_payload=(
+            _committed_payload(SettlementStepKind.QUOTA_SPEND, effect_id=effect_id)
+            if case_input.get("spend_committed")
+            else None
+        ),
+        writeback=lambda: effect(SettlementStepKind.DURABLE_WRITEBACK),
+        spend=lambda: effect(SettlementStepKind.QUOTA_SPEND),
+        checkpoint=lambda step, _payload, _phases: checkpoint_steps.append(step),
+    )
+    return _observe(
+        result,
+        effect_calls=effect_calls,
+        checkpoint_steps=checkpoint_steps,
+    )
+
+
+def _replay_quota(case: Mapping[str, Any], runtime_root: Path) -> dict[str, Any]:
+    case_input = case["input"]
+    assert isinstance(case_input, Mapping)
+    event_path = rollout_event_log_path(runtime_root, GOAL_ID)
+    event_path.parent.mkdir(parents=True, exist_ok=True)
+    event_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "loopx_rollout_event_v0",
+                "event_id": "incident-replay-guard",
+                "event_kind": "quota_should_run",
+                "goal_id": GOAL_ID,
+                "agent_id": AGENT_ID,
+                "run_id": TURN_ID,
+                "details": {
+                    "todo_id": TODO_ID,
+                    "settlement_effect_id": case_input["guard_effect_id"],
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    result = resolve_heartbeat_settlement_identity(
+        runtime_root,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        todo_id=TODO_ID,
+        turn_instance_id=TURN_ID,
+    )
+    return _observe(result, effect_calls=[], checkpoint_steps=[])
+
+
+def test_incident_replay_corpus_is_small_and_public_safe() -> None:
+    corpus = _load_corpus()
+
+    assert corpus["schema_version"] == "effect_program_incident_replay_v0"
+    assert 3 <= len(corpus["cases"]) <= 6
+    assert len({case["case_id"] for case in corpus["cases"]}) == len(
+        corpus["cases"]
+    )
+    assert {case["invariant_id"] for case in corpus["cases"]} == REQUIRED_INVARIANTS
+    assert all(set(case) == ALLOWED_CASE_KEYS for case in corpus["cases"])
+    assert all(len(case["rationale"]) >= 60 for case in corpus["cases"])
+    excluded_keys = {
+        str(key).casefold() for key in corpus["public_boundary"]["excluded_fields"]
+    }
+    for case in corpus["cases"]:
+        _assert_public_case(case, excluded_keys=excluded_keys)
+
+
+@pytest.mark.parametrize(
+    "case",
+    _load_corpus()["cases"],
+    ids=lambda case: case["case_id"],
+)
+def test_generalized_incidents_replay_against_real_adapters(
+    case: Mapping[str, Any],
+    tmp_path: Path,
+) -> None:
+    if case["adapter"] == "turn_driver":
+        observed = _replay_turn_driver(case)
+    elif case["adapter"] == "quota":
+        observed = _replay_quota(case, tmp_path / str(case["case_id"]))
+    else:
+        pytest.fail(f"unsupported incident replay adapter: {case['adapter']}")
+
+    assert observed == case["expected"]

--- a/tests/fixtures/control_plane/effect_program_incident_replay_v0.json
+++ b/tests/fixtures/control_plane/effect_program_incident_replay_v0.json
@@ -1,0 +1,132 @@
+{
+  "schema_version": "effect_program_incident_replay_v0",
+  "public_boundary": {
+    "source_class": "generalized_regression_incidents",
+    "retained_fields": [
+      "adapter",
+      "phase_prefix",
+      "receipt_presence",
+      "failure_point",
+      "semantic_outcome"
+    ],
+    "excluded_fields": [
+      "raw_logs",
+      "trajectories",
+      "local_paths",
+      "private_links",
+      "people",
+      "incident_timeline"
+    ]
+  },
+  "cases": [
+    {
+      "case_id": "spend-claim-without-writeback-receipt",
+      "adapter": "turn_driver",
+      "incident_class": "partial_journal_replay",
+      "invariant_id": "INV-WRITEBACK-BEFORE-SPEND",
+      "rationale": "A persisted spend claim cannot establish settlement when the same identity has no committed writeback receipt.",
+      "input": {
+        "completed_phases": [
+          "host_execute",
+          "typed_result",
+          "validation",
+          "durable_writeback",
+          "quota_spend"
+        ],
+        "writeback_committed": false,
+        "spend_committed": true
+      },
+      "expected": {
+        "status": "failure",
+        "failure_kind": "receipt_missing",
+        "failure_step": "durable_writeback",
+        "effect_calls": [],
+        "checkpoint_steps": [],
+        "receipt_steps": [
+          "validation"
+        ],
+        "receipt_identity_count": 1
+      }
+    },
+    {
+      "case_id": "writeback-rejection-short-circuits-spend",
+      "adapter": "turn_driver",
+      "incident_class": "effect_failure",
+      "invariant_id": "INV-FAILURE-SHORT-CIRCUIT",
+      "rationale": "A rejected writeback remains the terminal failure and no quota spend effect may execute afterward.",
+      "input": {
+        "completed_phases": [
+          "host_execute",
+          "typed_result",
+          "validation"
+        ],
+        "writeback_committed": false,
+        "spend_committed": false,
+        "reject_at": "durable_writeback"
+      },
+      "expected": {
+        "status": "failure",
+        "failure_kind": "writeback_rejected",
+        "failure_step": "durable_writeback",
+        "effect_calls": [
+          "durable_writeback"
+        ],
+        "checkpoint_steps": [],
+        "receipt_steps": [
+          "validation"
+        ],
+        "receipt_identity_count": 1
+      }
+    },
+    {
+      "case_id": "guard-effect-identity-drift",
+      "adapter": "quota",
+      "incident_class": "identity_drift",
+      "invariant_id": "INV-ONE-EFFECT-IDENTITY",
+      "rationale": "A guard receipt bound to another effect identity fails validation before any settlement effect can run.",
+      "input": {
+        "guard_effect_id": "replay-goal:replay-agent:todo_incident:another-turn"
+      },
+      "expected": {
+        "status": "failure",
+        "failure_kind": "identity_mismatch",
+        "failure_step": "validation",
+        "effect_calls": [],
+        "checkpoint_steps": [],
+        "receipt_steps": [],
+        "receipt_identity_count": 0
+      }
+    },
+    {
+      "case_id": "committed-settlement-replay-is-idempotent",
+      "adapter": "turn_driver",
+      "incident_class": "duplicate_delivery_retry",
+      "invariant_id": "INV-AT-MOST-ONCE-SETTLEMENT",
+      "rationale": "Replaying a fully committed settlement reconstructs receipts without invoking writeback or spend again.",
+      "input": {
+        "completed_phases": [
+          "host_execute",
+          "typed_result",
+          "validation",
+          "durable_writeback",
+          "quota_spend"
+        ],
+        "writeback_committed": true,
+        "spend_committed": true
+      },
+      "expected": {
+        "status": "success",
+        "failure_kind": null,
+        "failure_step": null,
+        "effect_calls": [],
+        "checkpoint_steps": [],
+        "receipt_steps": [
+          "validation",
+          "durable_writeback",
+          "quota_spend"
+        ],
+        "receipt_identity_count": 1
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add a four-case public-safe incident replay corpus for settlement failures and retries
- replay the independent expected outcomes through the shipped quota and Turn adapters
- enforce a fixture boundary that rejects URLs, absolute paths, contact identifiers, and excluded evidence keys

## Product and architecture judgment

The missing evidence was a compact replay layer between synthetic fault matrices and private incident material. This change closes that gap without adding runtime code or a second settlement abstraction: one data fixture owns the reviewed semantic oracle, while one focused test invokes the existing adapter entry points. It covers writeback-before-spend, failure short-circuit, effect identity stability, and at-most-once replay. Scheduler ownership remains outside settlement and is unchanged.

## Validation

- 99 focused Effect Program, quota, receipt, scheduler, and adapter tests passed
- Ruff passed for the new test
- repository-configured mypy passed (16 source files)
- JSON parse, Python compilation, and diff hygiene passed
- LoopX public-boundary scan passed for both changed paths with zero errors or warnings
- premerge canary passed: three catalog canaries, zero failures, zero skips, zero manual holds
- change-quality receipt: `cqr_f8bb9363fdf68e3bb371` (exact fingerprint verified)

## Scope and risk

This is a validation-only change. It does not modify runtime behavior, scheduling, permissions, benchmark semantics, or public evidence policy. No raw logs, trajectories, private links, local paths, credentials, or generated evidence are included.
