### PR TITLE
fix(replan): preserve postdelivery watch frontier

### DIFF
--- a/loopx/control_plane/goals/goal_frontier/__init__.py
+++ b/loopx/control_plane/goals/goal_frontier/__init__.py
@@ -304,6 +304,18 @@ def _watch_lane_ack_covers_dead_monitor_repeat(
     }
     if not evidence_todo_ids:
         return False
+    vision_todo_ids = {
+        str(todo_id).strip()
+        for gap in acceptance_gaps
+        for todo_id in (gap.get("vision_todo_ids") or [])
+        if str(todo_id or "").strip()
+    }
+    if (
+        len(evidence_todo_ids) != 1
+        or not vision_todo_ids
+        or not evidence_todo_ids.issubset(vision_todo_ids)
+    ):
+        return False
     summary = agent_todo_summary if isinstance(agent_todo_summary, dict) else {}
     exact_watch_items_by_id: dict[str, dict[str, Any]] = {}
     for lane in (

--- a/loopx/control_plane/work_items/autonomous_replan_ack.py
+++ b/loopx/control_plane/work_items/autonomous_replan_ack.py
@@ -18,6 +18,24 @@ def autonomous_replan_ack_recorded(run: dict[str, Any]) -> bool:
     return delta_contract.get("delta_present") is True
 
 
+def watch_lane_continuation_todo_ids(
+    delta_contract: dict[str, Any] | None,
+) -> list[str]:
+    """Return the exact Todo evidence carried by a validated watch delta."""
+
+    if not isinstance(delta_contract, dict):
+        return []
+    todo_ids: list[str] = []
+    for item in delta_contract.get("auto_evidence") or []:
+        if not isinstance(item, dict) or item.get("kind") != "watch_lane_continuation":
+            continue
+        for raw_todo_id in item.get("todo_ids") or []:
+            todo_id = str(raw_todo_id or "").strip()
+            if todo_id and todo_id not in todo_ids:
+                todo_ids.append(todo_id)
+    return todo_ids
+
+
 def compact_autonomous_replan_ack(run: dict[str, Any] | None) -> dict[str, Any] | None:
     if not isinstance(run, dict) or not autonomous_replan_ack_recorded(run):
         return None
@@ -37,21 +55,14 @@ def compact_autonomous_replan_ack(run: dict[str, Any] | None) -> dict[str, Any] 
         ],
     }
     watch_evidence: list[dict[str, Any]] = []
-    for item in delta_contract.get("auto_evidence") or []:
-        if not isinstance(item, dict) or item.get("kind") != "watch_lane_continuation":
-            continue
-        todo_ids = [
-            str(todo_id).strip()
-            for todo_id in (item.get("todo_ids") or [])
-            if str(todo_id or "").strip()
-        ][:4]
-        if todo_ids:
-            watch_evidence.append(
-                {
-                    "kind": "watch_lane_continuation",
-                    "todo_ids": todo_ids,
-                }
-            )
+    todo_ids = watch_lane_continuation_todo_ids(delta_contract)[:4]
+    if todo_ids:
+        watch_evidence.append(
+            {
+                "kind": "watch_lane_continuation",
+                "todo_ids": todo_ids,
+            }
+        )
     if watch_evidence:
         compact_delta["auto_evidence"] = watch_evidence
     result = {
@@ -88,6 +99,7 @@ def latest_monitor_replan_frontier_identity(
     latest_runs: list[dict[str, Any]] | None,
     *,
     agent_id: str | None = None,
+    watch_todo_ids: list[str] | None = None,
 ) -> str | None:
     """Return the latest monitor identity that a durable replan ACK must bind."""
 
@@ -95,6 +107,7 @@ def latest_monitor_replan_frontier_identity(
         latest_runs,
         agent_id=agent_id,
         include_generic_watch=True,
+        watch_todo_ids=watch_todo_ids,
     )
 
 
@@ -103,8 +116,18 @@ def _latest_monitor_replan_frontier_identity(
     *,
     agent_id: str | None,
     include_generic_watch: bool,
+    watch_todo_ids: list[str] | None = None,
 ) -> str | None:
     normalized_agent_id = str(agent_id or "").strip()
+    normalized_watch_todo_ids = {
+        str(todo_id or "").strip()
+        for todo_id in (watch_todo_ids or [])
+        if str(todo_id or "").strip()
+    }
+    evidence_linked_watch = (
+        include_generic_watch and len(normalized_watch_todo_ids) == 1
+    )
+    intervening_material_runs = 0
     for run in latest_runs or []:
         if not isinstance(run, dict):
             continue
@@ -127,6 +150,14 @@ def _latest_monitor_replan_frontier_identity(
                 continue
         classification = str(run.get("classification") or "").strip()
         if classification != "quota_monitor_poll":
+            if evidence_linked_watch:
+                intervening_material_runs += 1
+                if (
+                    intervening_material_runs
+                    >= AUTONOMOUS_REPLAN_ACK_MATERIAL_RUN_WINDOW
+                ):
+                    return None
+                continue
             return None
         if target.get("monitor_mode") != (
             "blocked_successor_wait_without_material_transition"
@@ -139,6 +170,8 @@ def _latest_monitor_replan_frontier_identity(
                 continue
             target_identity = str(target.get("target_id") or "").strip()
             return target_identity or None
+        if intervening_material_runs:
+            return None
         frontier_identity = str(target.get("frontier_identity") or "").strip()
         return frontier_identity or None
     return None

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -33,6 +33,7 @@ from .control_plane.work_items.repair_delta import (
 )
 from .control_plane.work_items.autonomous_replan_ack import (
     latest_monitor_replan_frontier_identity,
+    watch_lane_continuation_todo_ids,
 )
 from .control_plane.runtime.shared_runtime_refresh_projection import (
     build_shared_runtime_projection,
@@ -1140,6 +1141,7 @@ def refresh_state_run(
     agent_vision: dict[str, Any] | None = None
     existing_agent_vision: dict[str, Any] | None = None
     autonomous_replan_frontier_identity: str | None = None
+    newest_first_runs: list[dict[str, Any]] = []
     if normalized_agent_id and (
         agent_vision_packet is not None
         or normalized_vision_unchanged_reason
@@ -1161,13 +1163,6 @@ def refresh_state_run(
             goal_id=safe_goal_id,
             agent_id=normalized_agent_id,
         )
-        if autonomous_replan_recorded:
-            autonomous_replan_frontier_identity = (
-                latest_monitor_replan_frontier_identity(
-                    newest_first_runs,
-                    agent_id=normalized_agent_id,
-                )
-            )
     if agent_vision_packet is not None:
         agent_vision = normalize_goal_vision_update(
             agent_vision_packet,
@@ -1236,6 +1231,16 @@ def refresh_state_run(
             )
         ):
             normalized_delivery_outcome = "outcome_gap"
+        if effective_autonomous_replan_recorded and normalized_agent_id:
+            autonomous_replan_frontier_identity = (
+                latest_monitor_replan_frontier_identity(
+                    newest_first_runs,
+                    agent_id=normalized_agent_id,
+                    watch_todo_ids=watch_lane_continuation_todo_ids(
+                        repair_delta_contract
+                    ),
+                )
+            )
     vision_checkpoint = build_vision_checkpoint(
         agent_id=normalized_agent_id or None,
         agent_vision=agent_vision,

--- a/tests/control_plane/test_goal_vision_blocked_successor.py
+++ b/tests/control_plane/test_goal_vision_blocked_successor.py
@@ -309,12 +309,27 @@ def _generic_watch_ack(*, frontier_identity: str) -> dict:
     }
 
 
+def _append_bounded_watch_todo(state_path, *, claimed_by: str) -> None:
+    state_path.write_text(
+        state_path.read_text(encoding="utf-8")
+        + "\n## Agent Todo\n\n"
+        + "- [ ] [P2] Keep the exact bounded watch active.\n"
+        + "  <!-- loopx:todo "
+        + f"todo_id={MONITOR_ID} status=open task_class=continuous_monitor "
+        + f"claimed_by={claimed_by} target_key=bounded-watch cadence=7d "
+        + "next_due_at=2099-01-01T00%3A00%3A00Z "
+        + "expires_at=2099-02-01T00%3A00%3A00Z -->\n",
+        encoding="utf-8",
+    )
+
+
 def _generic_watch_quota(
     *,
     ack: dict | None,
     advancement_policy: str = "as_needed",
     expires_at: str = "2099-02-01T00:00:00+00:00",
     target_id: str = "generic-watch-target",
+    extra_agent_items: list[dict] | None = None,
 ) -> dict:
     monitor = quota_todo_item(
         todo_id=MONITOR_ID,
@@ -336,7 +351,10 @@ def _generic_watch_quota(
             vision_todo_ids=[MONITOR_ID],
         ),
     ]
-    agent_todos = quota_todo_summary([monitor], role="agent")
+    agent_todos = quota_todo_summary(
+        [monitor, *(extra_agent_items or [])],
+        role="agent",
+    )
     payload = quota_status_payload(
         goal_id=GOAL_ID,
         status="active",
@@ -1018,6 +1036,35 @@ def test_dead_monitor_repeat_rejects_noncausal_watch_ack(
     assert obligation["triggers"][0]["kind"] == "dead_monitor_repeat"
 
 
+def test_dead_monitor_repeat_rejects_unrelated_bounded_watch_evidence() -> None:
+    unrelated_monitor_id = "todo_unrelated_bounded_monitor"
+    unrelated_monitor = quota_todo_item(
+        todo_id=unrelated_monitor_id,
+        index=2,
+        text="[P2] Monitor a different bounded frontier.",
+        task_class="continuous_monitor",
+        claimed_by=AGENT_ID,
+        target_key="unrelated-bounded-watch",
+        cadence="7d",
+        next_due_at="2099-01-01T00:00:00+00:00",
+        expires_at="2099-02-01T00:00:00+00:00",
+    )
+    ack = _generic_watch_ack(frontier_identity="generic-watch-target")
+    ack["autonomous_replan_ack"]["delta_contract"]["auto_evidence"][0][
+        "todo_ids"
+    ] = [unrelated_monitor_id]
+
+    guard = _generic_watch_quota(
+        ack=ack,
+        extra_agent_items=[unrelated_monitor],
+    )
+
+    assert guard["decision"] == "autonomous_replan_required"
+    assert guard["autonomous_replan_obligation"]["frontier_identity"] == (
+        "generic-watch-target"
+    )
+
+
 def test_wait_only_ack_does_not_clear_repeat_vision_blocked_successor() -> None:
     polls = _blocked_wait_polls()
     frontier_identity = polls[0]["monitor_target"]["frontier_identity"]
@@ -1185,6 +1232,46 @@ def test_refresh_ack_recovers_generic_dead_monitor_target_identity() -> None:
         agent_id=AGENT_ID,
     ) == "bounded-generic-target"
 
+    intermediary = {
+        "classification": "todo_completion",
+        "generated_at": "2026-07-16T00:02:30+00:00",
+        "agent_id": AGENT_ID,
+    }
+    assert (
+        latest_monitor_replan_frontier_identity(
+            [intermediary, *polls],
+            agent_id=AGENT_ID,
+        )
+        is None
+    )
+    assert latest_monitor_replan_frontier_identity(
+        [intermediary, *polls],
+        agent_id=AGENT_ID,
+        watch_todo_ids=[MONITOR_ID],
+    ) == "bounded-generic-target"
+    assert (
+        latest_monitor_replan_frontier_identity(
+            [intermediary, *polls],
+            agent_id=AGENT_ID,
+            watch_todo_ids=[MONITOR_ID, "todo_second_watch"],
+        )
+        is None
+    )
+    blocked_poll = deepcopy(polls[0])
+    blocked_poll["monitor_target"] = {
+        **blocked_poll["monitor_target"],
+        "monitor_mode": "blocked_successor_wait_without_material_transition",
+        "frontier_identity": "blocked-successor-frontier",
+    }
+    assert (
+        latest_monitor_replan_frontier_identity(
+            [intermediary, blocked_poll],
+            agent_id=AGENT_ID,
+            watch_todo_ids=[MONITOR_ID],
+        )
+        is None
+    )
+
     conflicting = _generic_quiet_polls(target_id="conflicting-generic-target")
     conflicting[0]["monitor_target"]["agent_id"] = PRIMARY_AGENT
     assert latest_monitor_replan_frontier_identity(
@@ -1201,10 +1288,12 @@ def test_refresh_ack_recovers_generic_dead_monitor_target_identity() -> None:
 
 
 def test_refresh_ack_recovers_only_the_current_agent_frontier(tmp_path) -> None:
-    registry_path, runtime_root, _ = write_cli_fixture(
+    registry_path, runtime_root, project = write_cli_fixture(
         tmp_path / "fixture",
         scoped_agents=True,
     )
+    state_path = project / ".codex" / "goals" / "half-speed" / "ACTIVE_GOAL_STATE.md"
+    _append_bounded_watch_todo(state_path, claimed_by=SCOPED_AGENT_ID)
     peer_agent_id = "codex-main-control"
     current_frontier = "current-agent-frontier"
     peer_frontier = "newer-peer-frontier"
@@ -1293,6 +1382,59 @@ def test_refresh_ack_recovers_only_the_current_agent_frontier(tmp_path) -> None:
     )
 
     assert payload["autonomous_replan_ack"]["frontier_identity"] == current_frontier
+
+
+def test_refresh_watch_ack_crosses_material_run_with_exact_todo_evidence(
+    tmp_path,
+) -> None:
+    registry_path, runtime_root, project = write_cli_fixture(
+        tmp_path / "fixture",
+        scoped_agents=True,
+    )
+    state_path = project / ".codex" / "goals" / "half-speed" / "ACTIVE_GOAL_STATE.md"
+    _append_bounded_watch_todo(state_path, claimed_by=SCOPED_AGENT_ID)
+    target_id = "postdelivery-watch-target"
+    poll = {
+        "goal_id": "half-speed",
+        "classification": "quota_monitor_poll",
+        "generated_at": "2099-01-01T00:02:00+00:00",
+        "agent_id": SCOPED_AGENT_ID,
+        "monitor_target": {
+            "monitor_mode": "monitor_quiet_until_material_transition",
+            "agent_id": SCOPED_AGENT_ID,
+            "target_id": target_id,
+        },
+    }
+    material_run = {
+        "goal_id": "half-speed",
+        "classification": "todo_completion",
+        "generated_at": "2099-01-01T00:03:00+00:00",
+        "agent_id": SCOPED_AGENT_ID,
+    }
+    index_path = runtime_root / "goals" / "half-speed" / "runs" / "index.jsonl"
+    with index_path.open("a", encoding="utf-8") as index_file:
+        for run in (poll, material_run):
+            index_file.write(json.dumps(run, ensure_ascii=False) + "\n")
+
+    payload = refresh_state_run(
+        registry_path=registry_path,
+        runtime_root_override=None,
+        goal_id="half-speed",
+        project=None,
+        state_file=None,
+        classification="postdelivery_watch_replan",
+        recommended_action="Keep the exact bounded watch active.",
+        agent_id=SCOPED_AGENT_ID,
+        autonomous_replan_recorded=True,
+        repair_delta_kinds=["watch_lane_continuation"],
+        dry_run=True,
+        sync_global=False,
+    )
+
+    ack = payload["autonomous_replan_ack"]
+    assert ack["recorded"] is True
+    assert ack["frontier_identity"] == target_id
+    assert ack["delta_contract"]["auto_evidence"][0]["todo_ids"] == [MONITOR_ID]
 
 
 def test_watch_only_replan_downgrades_accountable_delivery_outcome(tmp_path) -> None:


### PR DESCRIPTION
## Why

An evidence-linked bounded watch replan could lose its causal monitor identity when Todo completion, settlement, or status records appeared between the quiet monitor poll and `refresh-state`. The replan ACK then remained structurally valid but could not match the later `dead_monitor_repeat` obligation, so two unchanged heartbeats reopened the same gap.

## What changed

- extract exact watch Todo evidence once for ACK compaction and refresh binding;
- allow a bounded generic-watch identity lookup to cross intervening same-agent material records only when exactly one validated watch Todo is present;
- keep blocked-successor identity lookup fail-closed across material records;
- require the exact watch evidence to belong to the current vision Todo lineage before it can suppress a repeated acceptance gap;
- add positive replay coverage plus missing evidence, ambiguous evidence, unrelated watch, target drift, expiry, repeat-until-closed, peer attribution, and blocked-successor negatives.

## Validation

- 148 focused quota/vision/monitor/repair/heartbeat/settlement tests passed;
- Ruff 0.15.2 and repository-native mypy passed;
- CLI output-budget regression smoke and canary quality audit passed;
- exact public/private path scan and diff hygiene passed;
- strict change-quality receipt `cqr_fb7d7da51a2d92681ddc` is valid;
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 17/17 selected canaries passed, with zero warnings or manual holds.

No live model call was run because this is a deterministic control-plane replay and causality contract change.
