### PR TITLE
fix(task-lease): release verified lease when completion commits

### DIFF
--- a/loopx/control_plane/work_items/task_lease.py
+++ b/loopx/control_plane/work_items/task_lease.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import fnmatch
 import json
 import re
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -100,6 +100,16 @@ def task_lease_path(*, runtime_root: Path, goal_id: str, todo_id: str) -> Path:
 
 def task_lease_lock_path(*, runtime_root: Path, goal_id: str) -> Path:
     return task_lease_dir(runtime_root=runtime_root, goal_id=goal_id) / ".task-leases"
+
+
+class _VerifiedTaskLeaseFence(dict):
+    """Key-verified fence payload with its release hook held out-of-band.
+
+    The hook lives on the instance attribute, never inside the mapping, so
+    the payload stays JSON-serializable for every consumer at all times.
+    """
+
+    release_hook: Callable[[], None] | None = None
 
 
 @contextmanager
@@ -210,14 +220,54 @@ def hold_task_lease_mutation_fence(
                 },
             )
         assert_expected_version(lease, expected_version)
-        yield {
-            "schema_version": TASK_LEASE_SCHEMA_VERSION,
-            "required": True,
-            "active": True,
-            "owner": normalized_actor,
-            "version": lease.get("version"),
-            "execution_instance_verified": True,
-        }
+        fence = _VerifiedTaskLeaseFence(
+            {
+                "schema_version": TASK_LEASE_SCHEMA_VERSION,
+                "required": True,
+                "active": True,
+                "owner": normalized_actor,
+                "version": lease.get("version"),
+                "execution_instance_verified": True,
+            }
+        )
+        fence.release_hook = lambda: remove_lease(lease_path)
+        yield fence
+
+
+def release_verified_task_lease_fence(
+    fence: dict[str, Any] | None,
+    *,
+    committed: bool,
+) -> None:
+    """Release the lease behind a key-verified fence once its write committed.
+
+    Must run while the hold_task_lease_mutation_fence context is still open so
+    the per-goal lease lock it acquired is still held; the lease therefore
+    cannot have been renewed, transferred, or re-acquired since the fence
+    verified the owner and idempotency key. The release reuses the CLI release
+    semantics (the lease file is removed; no new lifecycle state).
+
+    The private release hook rides on the fence object's attribute, not inside
+    the payload mapping, and is disarmed here on every call. Only a committed,
+    key-verified fence releases the lease; non-verified fences carry no hook
+    and are never touched. A release failure never unwinds the committed
+    lifecycle write: it is surfaced additively as fence["released"] = False
+    and the lease file is left for an explicit `loopx task-lease release` or
+    TTL expiry.
+    """
+
+    hook = getattr(fence, "release_hook", None)
+    if hook is None or not isinstance(fence, dict):
+        return
+    fence.release_hook = None  # type: ignore[attr-defined]
+    if not committed or fence.get("execution_instance_verified") is not True:
+        return
+    try:
+        hook()
+    except OSError:
+        fence["released"] = False
+        return
+    fence["released"] = True
 
 
 def runtime_root_from_registry(registry_path: Path, runtime_root_override: str | None) -> Path:

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -105,7 +105,10 @@ from .control_plane.todos.write_policy import (
     require_user_todo_task_class,
     resolve_user_gate_global_gate_update,
 )
-from .control_plane.work_items.task_lease import hold_task_lease_mutation_fence
+from .control_plane.work_items.task_lease import (
+    hold_task_lease_mutation_fence,
+    release_verified_task_lease_fence,
+)
 
 
 ARCHIVE_COMPLETED_DEFAULT_MAX_ACTIVE_DONE = max(0, MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE - 2)
@@ -1719,6 +1722,10 @@ def complete_goal_todo(
                 event_result["linked_successor_id"] = completion_policy.linked_successor_id
                 event_result["mutation_authority"] = mutation_authority
                 event_result["task_lease_fence"] = task_lease_fence
+                release_verified_task_lease_fence(
+                    task_lease_fence,
+                    committed=bool(event_result.get("changed")) and not dry_run,
+                )
                 return event_result
         update_result = apply_todo_update_to_lines(
             lines,
@@ -1830,6 +1837,10 @@ def complete_goal_todo(
             new_text = replace_updated_at(new_text, updated_at)
         if changed and not dry_run:
             resolved_state_file.write_text(new_text, encoding="utf-8")
+        release_verified_task_lease_fence(
+            task_lease_fence,
+            committed=changed and not dry_run,
+        )
     result = {
         "ok": True,
         "dry_run": dry_run,

--- a/tests/control_plane/test_todo_mutation_authority.py
+++ b/tests/control_plane/test_todo_mutation_authority.py
@@ -11,12 +11,15 @@ from loopx.control_plane.scheduler.monitor_poll_writeback import (
 from loopx.control_plane.todos.event_writeback import (
     complete_event_projected_goal_todo,
 )
+import loopx.control_plane.work_items.task_lease as task_lease_module
 from loopx.control_plane.work_items.task_lease import (
     TaskLeaseError,
     acquire_task_lease,
+    release_task_lease,
 )
 from loopx.event_sourced_state import (
     TODO_ADDED,
+    TODO_DEFERRED,
     TODO_UPDATED,
     AppendOnlyStateEventStore,
     StateEventError,
@@ -95,6 +98,10 @@ def _write_fixture(
         encoding="utf-8",
     )
     return registry, state
+
+
+def _lease_path(tmp_path: Path, todo_id: str) -> Path:
+    return tmp_path / "runtime" / "goals" / GOAL_ID / "task-leases" / f"{todo_id}.json"
 
 
 def _agent_todo(state: Path, todo_id: str) -> dict:
@@ -330,7 +337,9 @@ def test_active_task_lease_fences_same_agent_completion_instance(
         "owner": AUTHOR_AGENT,
         "version": 1,
         "execution_instance_verified": True,
+        "released": True,
     }
+    assert not _lease_path(tmp_path, todo["todo_id"]).exists()
 
     replayed = complete_goal_todo(
         registry_path=registry,
@@ -404,7 +413,424 @@ def test_event_projected_completion_reports_task_lease_fence(
         "owner": AUTHOR_AGENT,
         "version": 1,
         "execution_instance_verified": True,
+        "released": True,
     }
+    assert not _lease_path(tmp_path, todo_id).exists()
+
+
+def test_unfenced_completion_leaves_no_lease_artifacts(tmp_path: Path) -> None:
+    registry, _state = _write_fixture(tmp_path, multi_agent=False)
+    todo = _add_agent_todo(registry)
+
+    completed = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        claimed_by=AUTHOR_AGENT,
+        evidence="no lease was ever taken",
+        no_followup=True,
+    )
+
+    assert completed["ok"] is True
+    assert completed["task_lease_fence"] == {
+        "schema_version": "task_lease_v0",
+        "required": False,
+        "active": False,
+    }
+    lease_dir = _lease_path(tmp_path, todo["todo_id"]).parent
+    assert list(lease_dir.glob("todo_*.json")) == []
+
+
+def test_divergent_claim_completion_leaves_foreign_lease_untouched(
+    tmp_path: Path,
+) -> None:
+    registry, _state = _write_fixture(tmp_path)
+    todo = _add_agent_todo(registry, claimed_by=None)
+    acquire_task_lease(
+        registry_path=registry,
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        owner=AUTHOR_AGENT,
+        idempotency_key="author-instance",
+        ttl_seconds=600,
+    )
+    update_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        claimed_by=REVIEW_AGENT,
+        agent_id=REVIEW_AGENT,
+        claim_only=True,
+    )
+    lease_path = _lease_path(tmp_path, todo["todo_id"])
+    lease_before = lease_path.read_text(encoding="utf-8")
+
+    completed = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        claimed_by=REVIEW_AGENT,
+        agent_id=REVIEW_AGENT,
+        evidence="split-brain claimer completed without the lease key",
+        no_followup=True,
+    )
+
+    assert completed["ok"] is True
+    assert completed["task_lease_fence"] == {
+        "schema_version": "task_lease_v0",
+        "required": False,
+        "active": False,
+    }
+    assert lease_path.read_text(encoding="utf-8") == lease_before
+    assert json.loads(lease_before)["owner"] == AUTHOR_AGENT
+
+
+def test_dry_run_completion_does_not_release_lease(tmp_path: Path) -> None:
+    registry, state = _write_fixture(tmp_path, multi_agent=False)
+    todo = _add_agent_todo(registry)
+    lease_key = "dry-run-instance"
+    acquire_task_lease(
+        registry_path=registry,
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        owner=AUTHOR_AGENT,
+        idempotency_key=lease_key,
+        ttl_seconds=600,
+    )
+    before = state.read_text(encoding="utf-8")
+
+    completed = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        claimed_by=AUTHOR_AGENT,
+        task_lease_idempotency_key=lease_key,
+        evidence="dry run must not touch the lease",
+        no_followup=True,
+        dry_run=True,
+    )
+
+    assert completed["dry_run"] is True
+    assert completed["task_lease_fence"]["execution_instance_verified"] is True
+    assert "released" not in completed["task_lease_fence"]
+    lease_path = _lease_path(tmp_path, todo["todo_id"])
+    assert json.loads(lease_path.read_text(encoding="utf-8"))["status"] == "active"
+    assert state.read_text(encoding="utf-8") == before
+
+
+def test_release_failure_after_commit_keeps_completion_ok(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, _state = _write_fixture(tmp_path, multi_agent=False)
+    todo = _add_agent_todo(registry)
+    lease_key = "release-failure-instance"
+    acquire_task_lease(
+        registry_path=registry,
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        owner=AUTHOR_AGENT,
+        idempotency_key=lease_key,
+        ttl_seconds=600,
+    )
+
+    def _fail_remove(path: Path) -> None:
+        raise OSError("simulated unlink failure")
+
+    monkeypatch.setattr(task_lease_module, "remove_lease", _fail_remove)
+    completed = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        claimed_by=AUTHOR_AGENT,
+        task_lease_idempotency_key=lease_key,
+        evidence="completion must survive a failed lease release",
+        no_followup=True,
+    )
+
+    assert completed["ok"] is True
+    assert completed["completed"] is True
+    assert completed["task_lease_fence"]["execution_instance_verified"] is True
+    assert completed["task_lease_fence"]["released"] is False
+    lease_path = _lease_path(tmp_path, todo["todo_id"])
+    assert json.loads(lease_path.read_text(encoding="utf-8"))["status"] == "active"
+
+
+def test_reopened_todo_completes_unfenced_after_lease_release(
+    tmp_path: Path,
+) -> None:
+    """Pin the accepted reopen-window divergence of release-on-completion.
+
+    Before leases were released on completion, the leftover lease file
+    resurrected as the execution-instance fence if a done todo was manually
+    reopened inside the lease TTL, so a second completion without the key
+    was rejected with lease_fence_required. With the lease released at the
+    first committed completion, the reopened todo completes unfenced. This
+    matches the end state of the disciplined baseline flow (complete followed
+    by an explicit `loopx task-lease release`); no production path reopens
+    done todos.
+    """
+
+    registry, _state = _write_fixture(tmp_path, multi_agent=False)
+    todo = _add_agent_todo(registry)
+    lease_key = "reopen-window-instance"
+    acquire_task_lease(
+        registry_path=registry,
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        owner=AUTHOR_AGENT,
+        idempotency_key=lease_key,
+        ttl_seconds=600,
+    )
+
+    completed = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        claimed_by=AUTHOR_AGENT,
+        task_lease_idempotency_key=lease_key,
+        evidence="first completion releases the verified lease",
+        no_followup=True,
+    )
+    assert completed["task_lease_fence"]["released"] is True
+    assert not _lease_path(tmp_path, todo["todo_id"]).exists()
+
+    reopened = update_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        claimed_by=AUTHOR_AGENT,
+        status="open",
+        note="manual reopen inside the old lease TTL",
+    )
+    assert reopened["ok"] is True
+
+    recompleted = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        claimed_by=AUTHOR_AGENT,
+        evidence="reopened todo completes without a lease fence",
+        no_followup=True,
+    )
+    assert recompleted["ok"] is True
+    assert recompleted["task_lease_fence"] == {
+        "schema_version": "task_lease_v0",
+        "required": False,
+        "active": False,
+    }
+
+
+def test_cli_release_after_auto_release_reports_missing(tmp_path: Path) -> None:
+    """A post-completion `loopx task-lease release` now sees no lease file.
+
+    Baseline removed the then-stale lease and reported released=True; after
+    release-on-completion the same call reports released=False, missing=True
+    with ok=True (the pre-existing double-release shape).
+    """
+
+    registry, _state = _write_fixture(tmp_path, multi_agent=False)
+    todo = _add_agent_todo(registry)
+    lease_key = "double-release-instance"
+    acquire_task_lease(
+        registry_path=registry,
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        owner=AUTHOR_AGENT,
+        idempotency_key=lease_key,
+        ttl_seconds=600,
+    )
+    complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        claimed_by=AUTHOR_AGENT,
+        task_lease_idempotency_key=lease_key,
+        evidence="completion already released the lease",
+        no_followup=True,
+    )
+
+    released = release_task_lease(
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        owner=AUTHOR_AGENT,
+        idempotency_key=lease_key,
+    )
+
+    assert released["ok"] is True
+    assert released["released"] is False
+    assert released["missing"] is True
+
+
+def test_exception_after_verified_fence_leaves_lease_intact(
+    tmp_path: Path,
+) -> None:
+    registry, state = _write_fixture(tmp_path, multi_agent=False)
+    todo = _add_agent_todo(registry)
+    lease_key = "post-fence-failure-instance"
+    acquire_task_lease(
+        registry_path=registry,
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        owner=AUTHOR_AGENT,
+        idempotency_key=lease_key,
+        ttl_seconds=600,
+    )
+    lease_path = _lease_path(tmp_path, todo["todo_id"])
+    lease_before = lease_path.read_text(encoding="utf-8")
+    state_before = state.read_text(encoding="utf-8")
+
+    with pytest.raises(ValueError, match="successor_todo_ids"):
+        complete_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=todo["todo_id"],
+            claimed_by=AUTHOR_AGENT,
+            task_lease_idempotency_key=lease_key,
+            successor_todo_ids=["!!not-a-todo-id!!"],
+            evidence="fails after the fence verified",
+            no_followup=True,
+        )
+
+    assert lease_path.read_text(encoding="utf-8") == lease_before
+    assert json.loads(lease_before)["status"] == "active"
+    assert state.read_text(encoding="utf-8") == state_before
+
+
+def test_event_projected_dry_run_completion_does_not_release_lease(
+    tmp_path: Path,
+) -> None:
+    registry, state = _write_fixture(tmp_path, multi_agent=False)
+    event_log = state.with_name("events.jsonl")
+    store = AppendOnlyStateEventStore(event_log)
+    todo_id = "todo_event_dry_run_lease"
+    store.append(
+        make_state_event(
+            event_id="evt-event-dry-run-lease",
+            goal_id=GOAL_ID,
+            event_type=TODO_ADDED,
+            refs={"todo_id": todo_id},
+            payload={
+                "role": "agent",
+                "title": "Dry-run the event-projected leased task.",
+                "task_class": "advancement_task",
+                "claimed_by": AUTHOR_AGENT,
+            },
+            recorded_at="2026-07-18T00:00:00+00:00",
+        )
+    )
+    lease_key = "event-dry-run-instance"
+    acquire_task_lease(
+        registry_path=registry,
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        owner=AUTHOR_AGENT,
+        idempotency_key=lease_key,
+        ttl_seconds=600,
+    )
+    log_before = event_log.read_text(encoding="utf-8")
+
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        claimed_by=AUTHOR_AGENT,
+        task_lease_idempotency_key=lease_key,
+        evidence="event-projected dry run must not touch the lease",
+        no_followup=True,
+        dry_run=True,
+    )
+
+    assert result["source"] == "event_log"
+    assert result["dry_run"] is True
+    assert result["task_lease_fence"]["execution_instance_verified"] is True
+    assert "released" not in result["task_lease_fence"]
+    lease_path = _lease_path(tmp_path, todo_id)
+    assert json.loads(lease_path.read_text(encoding="utf-8"))["status"] == "active"
+    assert event_log.read_text(encoding="utf-8") == log_before
+
+
+def test_event_projected_terminal_replay_does_not_release_lease(
+    tmp_path: Path,
+) -> None:
+    """Terminal event-projected replay never releases a leftover lease.
+
+    A verified fence cannot coexist with the already-done writeback branch:
+    the owner constraint self-disarms any fence over a non-open todo. The
+    reachable shape is a lease acquired while the todo was open, the todo
+    then deferred, and a completion without the key: the fence reports
+    inactive, the writeback replays with changed=False, and the stale lease
+    file is left exactly as it was.
+    """
+
+    registry, state = _write_fixture(tmp_path, multi_agent=False)
+    event_log = state.with_name("events.jsonl")
+    store = AppendOnlyStateEventStore(event_log)
+    todo_id = "todo_event_deferred_lease"
+    store.append(
+        make_state_event(
+            event_id="evt-event-deferred-parent",
+            goal_id=GOAL_ID,
+            event_type=TODO_ADDED,
+            refs={"todo_id": todo_id},
+            payload={
+                "role": "agent",
+                "title": "Terminal event-projected leased task.",
+                "task_class": "advancement_task",
+                "claimed_by": AUTHOR_AGENT,
+            },
+            recorded_at="2026-07-18T00:00:00+00:00",
+        )
+    )
+    lease_key = "event-deferred-instance"
+    acquire_task_lease(
+        registry_path=registry,
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        owner=AUTHOR_AGENT,
+        idempotency_key=lease_key,
+        ttl_seconds=600,
+    )
+    store.append(
+        make_state_event(
+            event_id="evt-event-deferred-terminal",
+            goal_id=GOAL_ID,
+            event_type=TODO_DEFERRED,
+            refs={"todo_id": todo_id},
+            payload={"reason": "deferred after the lease was acquired"},
+            recorded_at="2026-07-18T00:01:00+00:00",
+        )
+    )
+    lease_path = _lease_path(tmp_path, todo_id)
+    lease_before = lease_path.read_text(encoding="utf-8")
+
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        claimed_by=AUTHOR_AGENT,
+        evidence="terminal event-projected todo replays without a write",
+        no_followup=True,
+    )
+
+    assert result["changed"] is False
+    assert result["idempotent_replay"] is True
+    assert result["task_lease_fence"] == {
+        "schema_version": "task_lease_v0",
+        "required": False,
+        "active": False,
+    }
+    assert lease_path.read_text(encoding="utf-8") == lease_before
+    assert json.loads(lease_before)["status"] == "active"
 
 
 def test_capability_binding_cannot_be_rebound_by_duplicate_add(tmp_path: Path) -> None:


### PR DESCRIPTION
## 问题

一个 todo 走完最守规矩的硬租约流程——领取、拿到租约、带着钥匙完成——之后，它的租约记录还留在磁盘上，状态写着 active、到期时间还在未来。也就是说：每一次规范的租约式完成，都会留下一张"看起来还活着"的租约，挂在一个已经完成的 todo 上，直到有人手动 release 或者等它自然过期。账清了，凭证没销。

## 这个 PR 做了什么

完成动作真正落账之后，把刚刚验证过钥匙的那张租约顺手销掉（复用现有 release 的语义，不发明新的生命周期状态）。边界收得很窄：

- 只有"钥匙验证通过 + 完成确实落账"才销；预览（dry-run）不销；
- 分叉态（软认领与持约人不一致、栅栏自我失效的那种状态）碰都不碰别人的租约；
- 销账失败不连累已经完成的事实：完成照常成功，结果里如实标 released=false，租约文件留给手动清理；
- 进程在"落账之后、销账之前"死掉的窗口存在且已声明：那种情况下与今天完全一样，等手动 release 或过期。

两个刻意接受、已用测试钉死、需要 reviewer 知情裁决的行为涟漪：

1. **重开窗口**：今天如果有人手动把已完成的 todo 改回 open（这个操作本来就没有守卫），残留的旧租约会"复活"成完成栅栏，挡住第二次无钥匙完成。租约销掉之后，这道意外形成的挡板消失了，重开的 todo 可以无栅栏完成。终态与"完成后规范地手动 release"完全一致，生产路径也没有任何地方会重开已完成的 todo，但这是一个真实差异，明确写在这里。
2. **完成后再手动 release**：以前会删掉那张已经陈旧的文件并报 released=true，现在报 released=false、missing=true（ok 仍为 true）——即本来就有的重复销账语义。

两个涟漪都做了基线 A/B：钉住新行为的测试在未改动基线上确实失败，证明钉的是真实差异而非空转。

## 为什么和 RFC 相关

RFC #2787 的方向是把状态和它的凭证放进同一本账、同一次提交。今天的现实是反着的：完成把状态记了账，凭证却原样留在另一本账里当孤儿。这些孤儿会直接污染后续阶段——Stage 2 的 shadow 对账要从现有记录构造输入，Stage 3 的迁移要以"现有投影可信"为前提，一地过期不作废的租约会让两者的基线都是脏的。先把"完成即销证"补上，是给后面的阶段一个干净的起点。它不改变任何"谁能领、谁能完成"的判断。

## 验证

- 新增/扩展 10 个用例：verified 完成后租约消失（markdown 与事件投影两条提交路径）、无租约完成零副作用、分叉态外来租约逐字节不动、dry-run（两条路径）不销、销账失败完成仍成功、栅栏验证后发生异常时租约完好、终态重放不销、以及上述两个涟漪各自的钉子。
- 焦点套件 59/59；tests/control_plane 全量 954 通过；相邻顶层套件 126/126；ruff 干净；模块行数 ratchet 绿（todos.py 2136/2142）。
- 不做的事：不动分叉态的判定语义（栅栏在矛盾态自我失效的行为原样保留，另行处理），不加任何新门禁。

@huangruiteng 
