### PR TITLE
fix(control-plane): align replan watch-ack smoke and restore quota CLI size budget

### DIFF
--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import Any
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -31,6 +32,9 @@ GOAL_ID = "replan-decision-plane-fixture"
 PRIMARY_AGENT = "codex-main-control"
 SIDE_AGENT = "codex-side-bypass"
 FUTURE_DUE_AT = "2999-01-01T00:00:00+00:00"
+FUTURE_EXPIRY_AT = "2999-12-31T00:00:00+00:00"
+WATCH_FRONTIER_ID = "fixture-monitor-target"
+WATCH_TODO_ID = "todo_monitor_wait"
 APP_SCHEDULER_CONTEXT = scheduler_execution_context_for_runtime_profile(
     "codex_app_heartbeat"
 )
@@ -54,12 +58,13 @@ SIDE_AGENT_REPLAN_OBLIGATION = {
 
 SIDE_AGENT_DEAD_MONITOR_REPLAN_OBLIGATION = {
     **GLOBAL_REPLAN_OBLIGATION,
+    "frontier_identity": WATCH_FRONTIER_ID,
     "triggers": [
         {
             "kind": "dead_monitor_repeat",
             "source": "run_history",
             "agent_id": SIDE_AGENT,
-            "monitor_target_id": "fixture-monitor-target",
+            "monitor_target_id": WATCH_FRONTIER_ID,
         }
     ],
 }
@@ -69,6 +74,7 @@ def monitor_item(
     *,
     cadence: str | None = "15m",
     next_due_at: str | None = FUTURE_DUE_AT,
+    expires_at: str | None = None,
 ) -> dict:
     item = {
         "index": 1,
@@ -86,6 +92,8 @@ def monitor_item(
         item["cadence"] = cadence
     if next_due_at is not None:
         item["next_due_at"] = next_due_at
+    if expires_at is not None:
+        item["expires_at"] = expires_at
     return item
 
 
@@ -300,7 +308,7 @@ def peer_status_payload(
     return payload
 
 
-def agent_vision_gap_run() -> dict:
+def agent_vision_gap_run(*, vision_todo_ids: list[str] | None = None) -> dict:
     return {
         "classification": "state_refreshed",
         "generated_at": "2026-07-04T00:00:00+00:00",
@@ -314,7 +322,9 @@ def agent_vision_gap_run() -> dict:
                 "acceptance_summary": "Show the next runnable auto-research frontier without owner prompting.",
                 "replan_trigger_summary": "Auto-research evidence is still synthetic and needs a next-round live validation todo.",
             },
-            "todo_delta": [],
+            "todo_delta": [
+                f"activate:{todo_id}" for todo_id in (vision_todo_ids or [])
+            ],
             "vision_budget": {
                 "schema_version": "goal_vision_budget_v0",
                 "status": "ok",
@@ -362,8 +372,10 @@ def agent_vision_acceptance_only_run(
 def watch_lane_continuation_ack_run(
     *,
     delta_kinds: list[str] | None = None,
+    frontier_identity: str | None = None,
+    watch_todo_ids: list[str] | None = None,
 ) -> dict:
-    return {
+    run: dict[str, Any] = {
         "classification": "monitor_poll_autonomous_replan_recorded_v0",
         "agent_id": SIDE_AGENT,
         "progress_scope": "agent_lane",
@@ -378,6 +390,16 @@ def watch_lane_continuation_ack_run(
             },
         },
     }
+    if frontier_identity:
+        run["autonomous_replan_ack"]["frontier_identity"] = frontier_identity
+    if watch_todo_ids:
+        run["autonomous_replan_ack"]["delta_contract"]["auto_evidence"] = [
+            {
+                "kind": "watch_lane_continuation",
+                "todo_ids": watch_todo_ids,
+            }
+        ]
+    return run
 
 
 def unchanged_heartbeat_monitor_runs() -> list[dict]:
@@ -1658,12 +1680,15 @@ def assert_explicit_as_needed_vision_gap_uses_watch_lane_continuation_ack() -> N
 def assert_as_needed_watch_ack_covers_repeated_heartbeat_receipts() -> None:
     latest_runs = [
         *unchanged_heartbeat_monitor_runs(),
-        watch_lane_continuation_ack_run(),
-        agent_vision_gap_run(),
+        watch_lane_continuation_ack_run(
+            frontier_identity=WATCH_FRONTIER_ID,
+            watch_todo_ids=[WATCH_TODO_ID],
+        ),
+        agent_vision_gap_run(vision_todo_ids=[WATCH_TODO_ID]),
     ]
     guard = build_quota_should_run(
         status_payload(
-            [monitor_item()],
+            [monitor_item(expires_at=FUTURE_EXPIRY_AT)],
             replan_obligation=SIDE_AGENT_DEAD_MONITOR_REPLAN_OBLIGATION,
             latest_runs=latest_runs,
         ),
@@ -1677,7 +1702,12 @@ def assert_as_needed_watch_ack_covers_repeated_heartbeat_receipts() -> None:
 
     due_guard = build_quota_should_run(
         status_payload(
-            [monitor_item(next_due_at="2000-01-01T00:00:00+00:00")],
+            [
+                monitor_item(
+                    next_due_at="2000-01-01T00:00:00+00:00",
+                    expires_at=FUTURE_EXPIRY_AT,
+                )
+            ],
             replan_obligation=SIDE_AGENT_DEAD_MONITOR_REPLAN_OBLIGATION,
             latest_runs=latest_runs,
         ),
@@ -1688,6 +1718,36 @@ def assert_as_needed_watch_ack_covers_repeated_heartbeat_receipts() -> None:
     assert due_guard["effective_action"] == "normal_run", due_guard
     assert due_guard["work_lane_contract"]["obligation"] == "attempt_due_monitor", due_guard
     assert due_guard.get("autonomous_replan_obligation") is None, due_guard
+
+
+def assert_as_needed_watch_ack_requires_exact_causal_identity() -> None:
+    cases = (
+        watch_lane_continuation_ack_run(),
+        watch_lane_continuation_ack_run(
+            frontier_identity="unrelated-frontier",
+            watch_todo_ids=[WATCH_TODO_ID],
+        ),
+        watch_lane_continuation_ack_run(
+            frontier_identity=WATCH_FRONTIER_ID,
+            watch_todo_ids=["todo_unrelated_watch"],
+        ),
+    )
+    for ack_run in cases:
+        guard = build_quota_should_run(
+            status_payload(
+                [monitor_item(expires_at=FUTURE_EXPIRY_AT)],
+                replan_obligation=SIDE_AGENT_DEAD_MONITOR_REPLAN_OBLIGATION,
+                latest_runs=[
+                    *unchanged_heartbeat_monitor_runs(),
+                    ack_run,
+                    agent_vision_gap_run(vision_todo_ids=[WATCH_TODO_ID]),
+                ],
+            ),
+            goal_id=GOAL_ID,
+            agent_id=SIDE_AGENT,
+        )
+        assert guard["decision"] == "autonomous_replan_required", guard
+        assert guard["goal_frontier_projection"]["replan_required"] is True, guard
 
 
 def assert_repeat_vision_keeps_repeated_heartbeat_replan() -> None:
@@ -1765,6 +1825,7 @@ def main() -> None:
     assert_projected_replan_ack_is_agent_scoped()
     assert_explicit_as_needed_vision_gap_uses_watch_lane_continuation_ack()
     assert_as_needed_watch_ack_covers_repeated_heartbeat_receipts()
+    assert_as_needed_watch_ack_requires_exact_causal_identity()
     assert_repeat_vision_keeps_repeated_heartbeat_replan()
     assert_blocking_handoff_gate_beats_derived_monitor_replan()
     print("quota-replan-decision-plane-smoke ok")

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -10,7 +10,6 @@ from ..control_plane.quota.cli_projection import (
     compact_quota_should_run_cli_payload,
 )
 from ..control_plane.quota.error_codes import quota_error_code
-from ..control_plane.quota.effect_program import SettlementIdentity
 from ..control_plane.quota.heartbeat_receipt import (
     fail_heartbeat_receipt,
     find_heartbeat_receipt,
@@ -26,6 +25,8 @@ from ..control_plane.quota.settlement_cli import (
     attach_spend_settlement_result,
     quota_rollout_details,
     quota_rollout_todo_id,
+    render_existing_heartbeat_receipt_payload,
+    reconcile_existing_heartbeat_receipt_for_turn,
 )
 from ..control_plane.quota.spend_sources import (
     DEFAULT_SLOT_SPEND_SOURCE,
@@ -595,78 +596,6 @@ def _quota_renderer(
     }.get(command, render_quota_markdown)
 
 
-def _reconcile_existing_heartbeat_receipt(
-    payload: dict[str, object],
-    args: argparse.Namespace,
-    *,
-    runtime_root: Path,
-    turn_instance_id: str,
-    existing: dict[str, object],
-) -> tuple[dict[str, object], str, bool, str]:
-    """Bind an identity-less same-turn receipt without changing a bound receipt."""
-
-    receipt = existing
-    receipt_status = "replayed"
-    receipt_appended = False
-    rollout_todo_id = quota_rollout_todo_id(payload, args)
-    if rollout_todo_id:
-        existing_details_value = receipt.get("details")
-        existing_details = (
-            existing_details_value
-            if isinstance(existing_details_value, Mapping)
-            else {}
-        )
-        existing_todo_id = str(existing_details.get("todo_id") or "").strip()
-        existing_effect_id = str(
-            existing_details.get("settlement_effect_id") or ""
-        ).strip()
-        expected_effect_id = SettlementIdentity(
-            goal_id=args.goal_id,
-            agent_id=args.agent_id,
-            todo_id=rollout_todo_id,
-            turn_instance_id=turn_instance_id,
-        ).effect_id
-        if existing_todo_id and existing_effect_id:
-            if (
-                existing_todo_id != rollout_todo_id
-                or existing_effect_id != expected_effect_id
-            ):
-                raise ValueError(
-                    "heartbeat receipt settlement identity conflicts with the "
-                    "current selected Todo"
-                )
-        else:
-            rollout_details = quota_rollout_details(
-                payload,
-                args,
-                todo_id=rollout_todo_id,
-            )
-            receipt, upgraded = upgrade_identityless_heartbeat_receipt(
-                runtime_root,
-                goal_id=args.goal_id,
-                agent_id=args.agent_id,
-                turn_instance_id=turn_instance_id,
-                todo_id=rollout_todo_id,
-                settlement_effect_id=expected_effect_id,
-                status=str(
-                    payload.get("effective_action")
-                    or payload.get("decision")
-                    or "should-run"
-                ),
-                summary=f"heartbeat quota receipt upgraded for turn={turn_instance_id}",
-                details=rollout_details,
-            )
-            if upgraded:
-                receipt_status = "upgraded"
-                receipt_appended = True
-    details_value = receipt.get("details")
-    details: Mapping[str, object] = (
-        details_value if isinstance(details_value, Mapping) else {}
-    )
-    stall_observation = str(details.get("stall_observation") or "not_applicable")
-    return receipt, receipt_status, receipt_appended, stall_observation
-
-
 def handle_quota_command(
     args: argparse.Namespace,
     *,
@@ -725,14 +654,14 @@ def handle_quota_command(
                         heartbeat_receipt_existing_status,
                         heartbeat_receipt_existing_appended,
                         heartbeat_stall_observation,
-                    ) = _reconcile_existing_heartbeat_receipt(
+                        heartbeat_receipt_ready,
+                    ) = reconcile_existing_heartbeat_receipt_for_turn(
                         payload,
                         args,
                         runtime_root=runtime_root,
                         turn_instance_id=heartbeat_turn_id,
                         existing=heartbeat_receipt_existing,
                     )
-                    heartbeat_receipt_ready = True
                 else:
                     existing_stall = find_quota_monitor_poll_turn(
                         runtime_root,
@@ -944,19 +873,13 @@ def handle_quota_command(
                     ),
                 )
             elif heartbeat_receipt_existing:
-                payload["heartbeat_receipt"] = heartbeat_receipt_view(
-                    heartbeat_receipt_existing,
+                render_existing_heartbeat_receipt_payload(
+                    payload,
+                    receipt=heartbeat_receipt_existing,
                     turn_instance_id=heartbeat_turn_id,
                     status=heartbeat_receipt_existing_status,
+                    appended=heartbeat_receipt_existing_appended,
                 )
-                payload["rollout_event"] = {
-                    "schema_version": heartbeat_receipt_existing.get("schema_version"),
-                    "event_id": heartbeat_receipt_existing.get("event_id"),
-                    "event_kind": heartbeat_receipt_existing.get("event_kind"),
-                    "recorded_at": heartbeat_receipt_existing.get("recorded_at"),
-                    "status": heartbeat_receipt_existing.get("status"),
-                    "appended": heartbeat_receipt_existing_appended,
-                }
             else:
                 rollout_details.update(
                     {

--- a/loopx/control_plane/quota/settlement_cli.py
+++ b/loopx/control_plane/quota/settlement_cli.py
@@ -7,12 +7,136 @@ from collections.abc import Mapping
 from pathlib import Path
 
 from ..todos.contract import normalize_todo_id
+from .effect_program import SettlementIdentity
+from .heartbeat_receipt import (
+    heartbeat_receipt_view,
+    upgrade_identityless_heartbeat_receipt,
+)
 from .settlement import (
     require_settlement_spend,
     require_settlement_writeback,
     resolve_heartbeat_settlement_identity,
     settlement_result_payload,
 )
+
+
+def reconcile_existing_heartbeat_receipt(
+    payload: dict[str, object],
+    args: argparse.Namespace,
+    *,
+    runtime_root: Path,
+    turn_instance_id: str,
+    existing: dict[str, object],
+) -> tuple[dict[str, object], str, bool, str]:
+    """Bind an identity-less same-turn receipt without changing a bound receipt."""
+
+    receipt = existing
+    receipt_status = "replayed"
+    receipt_appended = False
+    rollout_todo_id = quota_rollout_todo_id(payload, args)
+    if rollout_todo_id:
+        existing_details_value = receipt.get("details")
+        existing_details = (
+            existing_details_value
+            if isinstance(existing_details_value, Mapping)
+            else {}
+        )
+        existing_todo_id = str(existing_details.get("todo_id") or "").strip()
+        existing_effect_id = str(
+            existing_details.get("settlement_effect_id") or ""
+        ).strip()
+        expected_effect_id = SettlementIdentity(
+            goal_id=args.goal_id,
+            agent_id=args.agent_id,
+            todo_id=rollout_todo_id,
+            turn_instance_id=turn_instance_id,
+        ).effect_id
+        if existing_todo_id and existing_effect_id:
+            if (
+                existing_todo_id != rollout_todo_id
+                or existing_effect_id != expected_effect_id
+            ):
+                raise ValueError(
+                    "heartbeat receipt settlement identity conflicts with the "
+                    "current selected Todo"
+                )
+        else:
+            rollout_details = quota_rollout_details(
+                payload,
+                args,
+                todo_id=rollout_todo_id,
+            )
+            receipt, upgraded = upgrade_identityless_heartbeat_receipt(
+                runtime_root,
+                goal_id=args.goal_id,
+                agent_id=args.agent_id,
+                turn_instance_id=turn_instance_id,
+                todo_id=rollout_todo_id,
+                settlement_effect_id=expected_effect_id,
+                status=str(
+                    payload.get("effective_action")
+                    or payload.get("decision")
+                    or "should-run"
+                ),
+                summary=f"heartbeat quota receipt upgraded for turn={turn_instance_id}",
+                details=rollout_details,
+            )
+            if upgraded:
+                receipt_status = "upgraded"
+                receipt_appended = True
+    details_value = receipt.get("details")
+    details: Mapping[str, object] = (
+        details_value if isinstance(details_value, Mapping) else {}
+    )
+    stall_observation = str(details.get("stall_observation") or "not_applicable")
+    return receipt, receipt_status, receipt_appended, stall_observation
+
+
+def reconcile_existing_heartbeat_receipt_for_turn(
+    payload: dict[str, object],
+    args: argparse.Namespace,
+    *,
+    runtime_root: Path,
+    turn_instance_id: str,
+    existing: dict[str, object],
+) -> tuple[dict[str, object], str, bool, str, bool]:
+    """Reconcile an existing receipt and report whether the turn is receipt-ready."""
+
+    receipt, status, appended, stall_observation = (
+        reconcile_existing_heartbeat_receipt(
+            payload,
+            args,
+            runtime_root=runtime_root,
+            turn_instance_id=turn_instance_id,
+            existing=existing,
+        )
+    )
+    return receipt, status, appended, stall_observation, True
+
+
+def render_existing_heartbeat_receipt_payload(
+    payload: dict[str, object],
+    *,
+    receipt: dict[str, object],
+    turn_instance_id: str,
+    status: str,
+    appended: bool,
+) -> None:
+    """Render the committed existing heartbeat receipt into a quota payload."""
+
+    payload["heartbeat_receipt"] = heartbeat_receipt_view(
+        receipt,
+        turn_instance_id=turn_instance_id,
+        status=status,
+    )
+    payload["rollout_event"] = {
+        "schema_version": receipt.get("schema_version"),
+        "event_id": receipt.get("event_id"),
+        "event_kind": receipt.get("event_kind"),
+        "recorded_at": receipt.get("recorded_at"),
+        "status": receipt.get("status"),
+        "appended": appended,
+    }
 
 
 def quota_rollout_todo_id(


### PR DESCRIPTION
## Why

After #3037/#3038 (watch ACK causal binding) and #3034 (identity-less
heartbeat receipt upgrades) merged, main's Full Public Smokes exposed two
regressions that PR pytest did not cover:

- `quota-replan-decision-plane-smoke` still built watch ACKs and dead-monitor
  obligations under the old semantics (no `frontier_identity`, no exact watch
  Todo evidence, no `vision_todo_ids`, no monitor `expires_at`), so the
  as-needed watch ACK no longer suppresses `dead_monitor_repeat` and the
  fixture expects `skip` but got `autonomous_replan_required`;
- `loopx/cli_commands/quota.py` grew to 1076 lines, above the 1000-line
  command-owner budget enforced by
  `cli-command-module-size-ownership-command-modularization-smoke`.

## What changed

- Aligned `quota-replan-decision-plane-smoke` fixtures with the shipped causal
  watch-ACK contract: the dead-monitor obligation carries `frontier_identity`,
  the watch ACK carries `frontier_identity` + `auto_evidence` with the exact
  watch Todo, the vision gap carries `vision_todo_ids`, and the monitored Todo
  has a bounded unexpired `expires_at`.
- Extracted the heartbeat-receipt reconciliation and rendering helpers from
  `loopx/cli_commands/quota.py` into the existing CLI-helper home
  `loopx/control_plane/quota/settlement_cli.py` (where
  `quota_rollout_todo_id` / `quota_rollout_details` already live), restoring
  the module-size budget.

## Validation

- `python3 examples/control_plane/quota-replan-decision-plane-smoke.py` passes.
- `python3 examples/control_plane/peer-agent-runtime-v1-smoke.py` passes.
- `python3 examples/cli-command-module-size-ownership-command-modularization-smoke.py`
  passes (`quota.py` 999 lines).
- 205 focused pytest (quota settlement CLI/receipt/slot accounting + goal
  vision blocked-successor/succession + CLI diagnostics) pass.
- `py_compile` and `git diff --check` clean; public/private boundary scan clean.

No runtime behavior change beyond moving helpers to their bounded module; no
benchmark scoring, permission, or external-service surface touched.
