### PR TITLE
docs(rfc): record handoff-mode decision and correct lease authority claim

### DIFF
--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
@@ -238,10 +238,12 @@ One provider key stores one goal's v0 aggregate. The illustrative shape is:
 
 The schema contains no raw todo body, transcript, credential, absolute path,
 or raw evidence. It contains only the facts needed to adjudicate the command
-slice and recover its proof. As in current LoopX, a claimed todo remains `open`:
-`claimed_by` carries soft ownership and the lease/fence carries execution
-authority, without inventing a `claimed` lifecycle status that local mode does
-not have.
+slice and recover its proof. As in current LoopX, a claimed todo remains `open`,
+without inventing a `claimed` lifecycle status that local mode does not have.
+In the target contract, `claimed_by` carries soft ownership and the lease/fence
+carries execution authority; the current implementation does not honor this
+yet: when the two records diverge, the markdown claimant wins on the write
+path. See Appendix B.
 
 Each eligibility revision or digest is scoped to the snapshot referenced by the
 target todo: authorization covers only that todo's actor scope, dependency
@@ -632,3 +634,83 @@ live NoKV restart/recovery. Passing
 claim that the complete P0 acceptance gate above passes. Historical latency or
 fault results are informative only; they are not a durability, recovery, HA,
 or production qualification claim.
+
+## Appendix B: Handoff-Mode Decision Record (2026-08-10)
+
+This appendix writes down a direction already agreed during the PR #2787
+review, as part of the implementation prerequisite. It changes documentation
+only; no runtime behavior changes.
+
+### Why
+
+Live CLI verification reproduced a fact: the two claim records can disagree.
+One agent acquires a hard lease on a todo; another agent can still soft-claim
+the same todo afterwards, and both succeed. What happens after the divergence
+matters more:
+
+- The later soft claim invalidates the earlier active lease outright: the
+  holder's renew and re-acquire are rejected;
+- The completion fence disarms itself in exactly this conflicted state: the
+  soft claimant completes without any key;
+- The lease holder cannot complete at all: authorization checks the soft
+  claim first, so the lease credentials are never even evaluated.
+
+In short, once the two records diverge today, the soft claimant wins
+everywhere; the lease does not carry execution authority on its own. The
+sentence in section 4 ("the lease/fence carries execution authority")
+describes the target contract; the body text has been corrected in this
+revision.
+
+### Decision
+
+Do not synchronize the two records against each other. Instead, each goal
+declares a handoff mode (`handoff_mode`) that separates the two ways of
+taking work. The field lives in the goal state file's front matter for now,
+traveling with the file across endpoints; once shared mode ships, the shared
+authority owns it. Three values:
+
+- absent or `legacy`: exactly today's behavior, both paths open. The
+  divergence hole remains in this mode; that is a deliberate default, not an
+  oversight.
+- `soft_claim`: this goal uses soft claims only. acquire/renew/transfer are
+  rejected; release and inspect remain available to clean up and view
+  leftover leases.
+- `hard_lease`: changing the claim on an existing todo requires holding its
+  active lease; completion requires the key; the self-disarm-on-conflict
+  behavior becomes a loud error. Assigning a claimant at todo creation stays
+  allowed: a fresh todo cannot have a lease yet.
+
+Companion rules:
+
+1. Default is `legacy`; existing goals see zero behavior change. The hole
+   stays open there, and the implementation PR must say so plainly.
+2. Field placement as above; the registry and lease files are per-host, only
+   the goal state file travels across endpoints.
+3. Cross-endpoint window: the mode propagates by file sync, so two endpoints
+   can briefly see different values. Today this can only converge, not be
+   eliminated; state it honestly. Shared mode closes it.
+4. `hard_lease` keeps one door: the existing delegated authority
+   (todo_lifecycle_authority, with a stated reason) may change claims
+   without holding the lease, with an explicit, auditable override marker in
+   the result. No new bypass switches.
+5. Switching modes requires quiescence: refuse while the goal still has open
+   claims or active leases, and list what blocks it. No forced switch in v0.
+
+### Relation to Staged Delivery
+
+Mapped to the five-stage plan from the #2787 review: the characterization
+stage first records today's actual behavior (including the three divergence
+facts above) as fixtures; the gate itself is an explicitly declared behavior
+change, landing as its own PR before the file provider shadow so divergent
+data does not pollute the shadow parity baseline; once local canonical
+promotion folds claim and lease into one ledger, this class of divergence
+becomes structurally impossible and the gate is absorbed. The read-surface
+and hygiene fixes (status showing real leases; releasing the verified lease
+on completion) touch no decision semantics and were submitted ahead of this
+record.
+
+The characterization stage's negative cases extend the original list: a soft
+claim overriding an active lease; the completion fence disarming in the
+conflicted state; authorization running before the lease fence; claim-change
+entry points not yet gated; the window between the lease acquire's projection
+read and the state-file lock.

--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
@@ -212,8 +212,9 @@ owner，新 host 或 extension 也可以新增本地 artifact，而无需修改�
 
 该 schema 不包含 raw todo body、transcript、credential、绝对路径或 raw evidence。
 它只包含裁决这一命令切片与恢复其凭证所需的事实。与现有 LoopX 一致，claim 后
-todo 仍为 `open`；soft ownership 由 `claimed_by` 表示，执行权由 lease/fence 表示，
-不会引入一个本地状态机不存在的 `claimed` status。
+todo 仍为 `open`，不会引入一个本地状态机不存在的 `claimed` status。在目标合同里，
+soft ownership 由 `claimed_by` 表示，执行权由 lease/fence 表示；当前实现尚未做到
+这一点：两本账分叉时，软认领方在写路径上实际胜出，详见附录 B。
 
 这里的 eligibility revision/digest 都是目标 todo 所引用的快照：authorization 只覆盖
 该 todo 的 actor scope，dependency 只覆盖它的传递依赖闭包，gate 只覆盖实际约束
@@ -553,3 +554,60 @@ stale-fence writeback、production authorization-projection publisher、保留 r
 `python3 examples/nokv-shadow-provider/probes.py contract` 通过并不表示上面的完整 P0
 验收门通过。历史 latency 或 fault 结果只具有参考意义，不构成 durability、recovery、
 HA 或 production qualification 声明。
+
+## 附录 B：交接模式决策记录（2026-08-10）
+
+本附录把 PR #2787 评审中已同意的方向落成文字，作为实施前置条件的一部分。
+只改文档，不改任何运行时行为。
+
+### 起因
+
+用真实 CLI 验证时复现了一个事实：领任务的两本账可以各说各话。一个 agent 先拿到
+某个 todo 的硬租约，另一个 agent 之后仍能软认领同一个 todo，两边都成功。分叉之后
+的实际行为更关键：
+
+- 后来的软认领会让先前的活租约直接失效：持约人续租、重新领取都被拒绝；
+- 完成栅栏恰好在这种矛盾状态下自动失效：软认领方不带钥匙就能完成；
+- 持约人反而完不成：授权检查先看软认领，租约凭证根本轮不到被检查。
+
+也就是说，今天两本账一旦分叉，软认领方全胜，租约不单独构成执行权。第 4 节中
+"执行权由 lease/fence 表示"描述的是目标合同，正文已随本修订改口。
+
+### 决定
+
+不做两本账之间的互相同步，改为每个 goal 声明一种交接模式（`handoff_mode`），
+用模式把两种领法隔开。字段暂放在 goal 状态文件头部（front-matter），跟着文件
+跨端走；共享模式上线后由共享权威托管。三个取值：
+
+- 不填或 `legacy`：与今天完全一样，两种领法都开放。分叉的口子在此模式下仍然
+  存在；这是有意保留的默认值，不是疏漏。
+- `soft_claim`：该 goal 只用软认领。acquire/renew/transfer 被拒绝；release 与
+  inspect 保留，用于清理和查看遗留租约。
+- `hard_lease`：改动已有 todo 的认领关系必须持有它的活租约；完成必须带钥匙；
+  "矛盾态自动失效"改为响亮报错。新建 todo 时顺手指定认领人仍然允许——新 todo
+  不可能已有租约。
+
+配套约定：
+
+1. 默认 `legacy`，存量 goal 行为零变化；洞还在，实现 PR 必须明说。
+2. 字段落点如上；registry 与租约文件都是单机的，只有 goal 状态文件跨端。
+3. 跨端窗口：模式靠文件同步传播，两端可能短暂看到不同的值。现在只能收敛、
+   不能消灭，如实声明；共享模式才能关死。
+4. `hard_lease` 留一扇门：既有的委托授权（todo_lifecycle_authority，附说明
+   理由）可以不持租约改认领，结果里带明确的越门标记，可审计。不新增任何
+   绕过开关。
+5. 切换模式要求静止：goal 内仍有未完成的认领或活租约时拒绝切换，并列出
+   阻挡者。v0 不提供强制切换。
+
+### 与分阶段交付的关系
+
+对应 #2787 评审结论中的五阶段计划：先在 characterization 阶段把今天的真实行为
+（含上面三条分叉事实）做成用例入册；门禁本身是一次显式声明的行为变更，作为
+独立 PR 在 file provider shadow 之前落地，避免分叉数据污染 shadow 对账基线；
+本地 canonical promotion 把 claim 与 lease 收进同一本账后，这类分叉从结构上
+不再可能，门禁自然被吸收。读侧与卫生修复（status 显示真实租约、完成后销掉已
+验证的租约）不涉及判断语义，已先行提交。
+
+characterization 阶段的负向用例在原清单上补充：软认领盖掉活租约、完成栅栏在
+矛盾态失效、授权检查先于租约栅栏、尚未设防的认领变更入口、租约获取读取投影
+与状态文件锁之间的窗口。


### PR DESCRIPTION
## 这个 PR 做什么

把 #2787 评审里已经同意的方向写进 RFC：领任务的两套机制不做互相同步，改为每个 goal 声明一种交接模式（handoff_mode），用门禁挡住用错方式领任务的端。只改文档，不改任何运行时行为。

## 为什么现在写

验证前置重构时，用真实 CLI 复现了两本账分叉：硬租约在手，别人照样能软认领同一个 todo。分叉之后软认领方全胜：活租约被顶掉、完成栅栏自动失效、持约人反而完不成。RFC 正文里"执行权由 lease/fence 表示"这句和当前实现不符，这次一并改口：那是目标合同，不是现状。

门禁的实现是一次真实的行为变更。动工之前先把决定和边界白纸黑字定下来，评审有依据，后面的实现 PR 有验收线。

## 写了什么

- 第 4 节改口一句：执行权语义标注为目标合同，现状如实描述（分叉时软认领方在写路径上实际胜出）。
- 新增附录 B 决策记录：
  - 三种模式各自的含义：不填/legacy（与今天完全一样，口子有意保留）、soft_claim（只用软认领，租约动词拒绝，release/inspect 保留）、hard_lease（改认领必须持活租约，完成必须带钥匙，矛盾态响亮报错）；
  - 五条配套约定：默认 legacy 零变化且洞明说、字段放 goal 状态文件头部、跨端同步窗口如实声明、hard_lease 留一扇可审计的委托授权门、切换模式要求静止态；
  - 与五阶段计划的关系：先 characterization 入册今天的行为，门禁作为独立 PR 在 file provider shadow 之前落地，本地单一账本落地后门禁自然被吸收；
  - characterization 需要补充的负向用例清单。
- 中文为准，英文同步。

## 关联

- 读侧与卫生修复已先行：#3039（status 显示真实租约）、#3040（完成后销掉已验证的租约）。
- 门禁实现将作为独立 PR 提交，以本记录为验收依据。

@huangruiteng 
