### PR TITLE
feat(control-plane): gate public Git history windows

### DIFF
--- a/docs/capabilities/public-git-history-window/README.md
+++ b/docs/capabilities/public-git-history-window/README.md
@@ -1,0 +1,118 @@
+# Public Git history window
+
+`public_git_history_window` is an opt-in LoopX capability for callers that
+publish public Git history. It evaluates a typed effect before commit, push,
+merge, tag, or release execution and returns an `allow`, `defer`, or `reject`
+receipt. Deferred work remains local until the configured window ends.
+
+The capability does not cover ordinary PR collaboration. Comments, reviews,
+labels, reviewer requests, and metadata remain available. PR creation is also
+outside the history window when the head is already remote and the caller does
+not perform an implicit push.
+
+## Enable it for a goal
+
+Keep the real timezone and window values in an ignored, untracked file below
+the goal repository's `.loopx/config/` directory:
+
+```json
+{
+  "schema_version": "public_git_history_window_config_v0",
+  "timezone": "Region/City",
+  "blocked_windows": [
+    {
+      "window_id": "working-window",
+      "start": "09:00",
+      "end": "17:00"
+    }
+  ],
+  "public_repositories_only": true,
+  "collaboration_writes_allowed": true
+}
+```
+
+Preview and then apply the goal pointer:
+
+```bash
+loopx configure-goal \
+  --goal-id <goal-id> \
+  --public-git-history-window-config .loopx/config/public-history-window.json
+
+loopx configure-goal \
+  --goal-id <goal-id> \
+  --public-git-history-window-config .loopx/config/public-history-window.json \
+  --execute
+```
+
+The registry stores only the ignored file pointer. Quota and status projections
+report that the capability is active without returning its private window
+values.
+
+## Evaluate an effect
+
+Every public history caller supplies a stable effect id, the action, repository
+visibility and identity, and the execution timestamp:
+
+```bash
+loopx --format json public-git-history-window evaluate \
+  --goal-id <goal-id> \
+  --effect-id <stable-effect-id> \
+  --action push \
+  --repository-visibility public \
+  --repository-identity <provider/repository>
+```
+
+For push, merge, tag, and release, callers must also provide a verified JSON
+list of newly outgoing commits. An empty list is accepted only after a real
+comparison against the target remote ref proves that the effect publishes no
+new commit:
+
+```json
+[
+  {
+    "sha": "<commit-sha>",
+    "author_at": "2026-01-01T08:30:00+00:00",
+    "committer_at": "2026-01-01T08:30:00+00:00"
+  }
+]
+```
+
+This prevents a commit created during a blocked window from being silently
+published later. LoopX rejects that effect and asks the caller to recreate the
+unpublished commit outside the window; it never falsifies author or committer
+timestamps.
+
+## Decision rules
+
+- Window start is inclusive and window end is exclusive.
+- Windows may cross midnight.
+- Unknown repository visibility fails closed for history writes.
+- Private repositories are outside a public-only policy.
+- Auto-merge enablement is rejected because execution time would not be
+  rechecked; the host must evaluate `pr_merge` when the merge actually runs.
+- A repeated request with the same effect identity and inputs produces the same
+  receipt identity.
+- `pr_create` receipts require `head_already_remote` and `no_implicit_push`.
+
+## Disable it
+
+Preview and apply removal of the goal pointer:
+
+```bash
+loopx configure-goal --goal-id <goal-id> \
+  --clear-public-git-history-window-config
+
+loopx configure-goal --goal-id <goal-id> \
+  --clear-public-git-history-window-config --execute
+```
+
+## Enforcement boundary
+
+This version defines the provider-neutral decision and receipt contract plus a
+real CLI entrypoint. A host or capability that can write public Git history
+must call the evaluator before execution and obey non-allow receipts. Raw Git
+commands that bypass the evaluator are not intercepted by this version.
+
+中文摘要：该能力只约束公开仓库的历史写入，不约束 PR 评论、review、标签和
+reviewer 等协作操作；真实时区和禁运时段只保存在项目本地的 ignored 配置中，
+不会进入公开仓库或 quota 投影。

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -6,13 +6,13 @@ from typing import Any
 
 from ..extensions.runtime import extension_catalog_entries
 from .issue_fix.workflow_plan import build_issue_fix_pr_lifecycle_command
+from .public_git_history_window.catalog import PUBLIC_GIT_HISTORY_WINDOW_CAPABILITY
 from .registry import CapabilityRegistry
 
 CAPABILITY_CATALOG_SCHEMA_VERSION = "loopx_capability_catalog_v0"
 CAPABILITY_DETAIL_SCHEMA_VERSION = "loopx_capability_detail_v0"
-
-
 BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
+    PUBLIC_GIT_HISTORY_WINDOW_CAPABILITY,
     {
         "id": "integration-branch-reconcile",
         "origin": "builtin",

--- a/loopx/capabilities/public_git_history_window/__init__.py
+++ b/loopx/capabilities/public_git_history_window/__init__.py
@@ -1,0 +1,25 @@
+"""Goal-scoped public Git history write windows."""
+
+from .effect_program import (
+    PublicRepositoryAction,
+    build_public_git_history_effect_request,
+    evaluate_public_git_history_effect,
+    is_public_git_history_action,
+)
+from .policy import (
+    PUBLIC_GIT_HISTORY_WINDOW_CONFIG_SCHEMA_VERSION,
+    load_public_git_history_window_config,
+    public_git_history_window_goal_policy,
+    public_git_history_window_goal_policy_summary,
+)
+
+__all__ = [
+    "PUBLIC_GIT_HISTORY_WINDOW_CONFIG_SCHEMA_VERSION",
+    "PublicRepositoryAction",
+    "build_public_git_history_effect_request",
+    "evaluate_public_git_history_effect",
+    "is_public_git_history_action",
+    "load_public_git_history_window_config",
+    "public_git_history_window_goal_policy",
+    "public_git_history_window_goal_policy_summary",
+]

--- a/loopx/capabilities/public_git_history_window/catalog.py
+++ b/loopx/capabilities/public_git_history_window/catalog.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any
+
+PUBLIC_GIT_HISTORY_WINDOW_CAPABILITY: dict[str, Any] = {
+    "id": "public_git_history_window",
+    "origin": "builtin",
+    "visibility": "public",
+    "provider_id": "loopx-core",
+    "title": "Public Git history write window",
+    "status": "active-preview",
+    "default_enabled": False,
+    "real_world_anchor": (
+        "goal-scoped publication windows for public repository history"
+    ),
+    "user_value": (
+        "Preserve local progress while deferring public commit, push, merge, tag, "
+        "and release effects during configured local-time windows."
+    ),
+    "entry_command": (
+        "loopx public-git-history-window evaluate --goal-id <goal-id> "
+        "--effect-id <stable-effect-id> --action <history-action> "
+        "--repository-visibility <public|private|unknown> "
+        "--repository-identity <provider/repository> --format json"
+    ),
+    "commands": [
+        {
+            "command": (
+                "loopx configure-goal --goal-id <goal-id> "
+                "--public-git-history-window-config "
+                ".loopx/config/<policy>.json [--execute]"
+            ),
+            "purpose": "Preview or register one ignored goal-local policy pointer.",
+            "write_boundary": (
+                "registry pointer only; private window values remain in ignored "
+                "goal-local configuration"
+            ),
+        },
+        {
+            "command": (
+                "loopx public-git-history-window evaluate --goal-id <goal-id> "
+                "--effect-id <stable-effect-id> --action <action> "
+                "--repository-visibility <public|private|unknown> "
+                "--repository-identity <provider/repository> --format json"
+            ),
+            "purpose": (
+                "Return a typed allow, defer, or reject decision and receipt before "
+                "a repository effect executes."
+            ),
+            "write_boundary": "read-only evaluation; no git or remote write",
+        },
+    ],
+    "implemented_protocols": [
+        {
+            "schema_version": "public_git_history_window_config_v0",
+            "module": "loopx.capabilities.public_git_history_window.policy",
+            "doc": "docs/capabilities/public-git-history-window/README.md",
+        },
+        {
+            "schema_version": "public_git_history_window_decision_v0",
+            "module": "loopx.capabilities.public_git_history_window.effect_program",
+            "doc": "docs/capabilities/public-git-history-window/README.md",
+        },
+        {
+            "schema_version": "public_git_history_window_receipt_v0",
+            "module": "loopx.capabilities.public_git_history_window.effect_program",
+            "doc": "docs/capabilities/public-git-history-window/README.md",
+        },
+    ],
+    "smokes": [
+        "python -m pytest tests/capabilities/test_public_git_history_window.py -q"
+    ],
+    "docs": ["docs/capabilities/public-git-history-window/README.md"],
+    "boundaries": [
+        "The capability owns public history effects only; PR comments, reviews, labels, reviewer requests, and metadata remain available.",
+        "PR creation is allowed only when the head already exists remotely and the caller performs no implicit push.",
+        "Unknown repository visibility fails closed; private repositories are outside a public-only policy.",
+        "Auto-merge enablement is rejected because it cannot guarantee an execution-time policy recheck.",
+        "Outgoing unpublished commits are checked for blocked author and committer timestamps; timestamps are never rewritten.",
+        "The evaluator is the provider-neutral contract. Raw git callers that bypass it are not intercepted by v0.",
+    ],
+    "next_real_step": (
+        "Bind the evaluator to each shipped commit, push, merge, tag, and release "
+        "caller before claiming host-level enforcement."
+    ),
+}

--- a/loopx/capabilities/public_git_history_window/cli.py
+++ b/loopx/capabilities/public_git_history_window/cli.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Callable, Mapping
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from ...registry import read_json, registry_goals
+from .effect_program import (
+    PublicRepositoryAction,
+    build_public_git_history_effect_request,
+    evaluate_public_git_history_effect,
+)
+from .policy import (
+    load_public_git_history_window_config,
+    public_git_history_window_goal_policy,
+)
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+FormatSelector = Callable[..., str]
+AddFormat = Callable[[argparse.ArgumentParser], None]
+
+
+def register_public_git_history_window_commands(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: AddFormat,
+) -> None:
+    parser = subparsers.add_parser(
+        "public-git-history-window",
+        help="Evaluate goal-scoped time windows before public Git history writes.",
+    )
+    commands = parser.add_subparsers(
+        dest="public_git_history_window_command",
+        required=True,
+    )
+    evaluate = commands.add_parser(
+        "evaluate",
+        help="Return an allow, defer, or reject receipt for one repository effect.",
+    )
+    add_subcommand_format(evaluate)
+    evaluate.add_argument("--goal-id", required=True)
+    evaluate.add_argument("--effect-id", required=True)
+    evaluate.add_argument(
+        "--action",
+        choices=[action.value for action in PublicRepositoryAction],
+        required=True,
+    )
+    evaluate.add_argument(
+        "--repository-visibility",
+        choices=["public", "private", "unknown"],
+        default="unknown",
+    )
+    evaluate.add_argument("--repository-identity", required=True)
+    evaluate.add_argument(
+        "--observed-at",
+        help="Offset-aware ISO timestamp. Defaults to the host's current local time.",
+    )
+    evaluate.add_argument(
+        "--outgoing-commits-json",
+        type=Path,
+        help=(
+            "JSON list of newly outgoing commits with sha, author_at, and "
+            "committer_at. Required for push, PR merge, tag, and release; use an "
+            "empty list only after comparing the target remote ref."
+        ),
+    )
+
+
+def _goal(registry_path: Path, goal_id: str) -> dict[str, Any]:
+    payload = read_json(registry_path)
+    goal = next(
+        (item for item in registry_goals(payload) if str(item.get("id")) == goal_id),
+        None,
+    )
+    if goal is None:
+        raise ValueError(f"goal id not found in registry: {goal_id}")
+    return goal
+
+
+def _outgoing_commits(path: Path | None) -> list[Mapping[str, Any]]:
+    if path is None:
+        return []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("outgoing commits JSON is unavailable") from exc
+    if not isinstance(payload, list) or not all(
+        isinstance(item, Mapping) for item in payload
+    ):
+        raise ValueError("outgoing commits JSON must be a list of objects")
+    return payload
+
+
+def render_public_git_history_window_markdown(
+    payload: dict[str, object],
+) -> str:
+    lines = [
+        "# Public Git History Window",
+        "",
+        f"- ok: `{str(payload.get('ok')).lower()}`",
+        f"- goal_id: `{payload.get('goal_id')}`",
+        f"- action: `{payload.get('action')}`",
+        f"- disposition: `{payload.get('disposition') or payload.get('status')}`",
+        f"- reason_code: `{payload.get('reason_code')}`",
+    ]
+    if payload.get("defer_until"):
+        lines.append(f"- defer_until: `{payload.get('defer_until')}`")
+    if payload.get("required_action"):
+        lines.append(f"- required_action: {payload.get('required_action')}")
+    receipt = payload.get("receipt")
+    if isinstance(receipt, Mapping):
+        lines.append(f"- receipt_id: `{receipt.get('receipt_id')}`")
+    if payload.get("error"):
+        lines.append(f"- error: {payload.get('error')}")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def handle_public_git_history_window_command(
+    args: argparse.Namespace,
+    *,
+    registry_path: Path,
+    output_format: FormatSelector,
+    print_payload: PrintPayload,
+) -> int | None:
+    if args.command != "public-git-history-window":
+        return None
+    try:
+        if args.public_git_history_window_command != "evaluate":
+            raise ValueError("public-git-history-window requires evaluate")
+        goal = _goal(registry_path, str(args.goal_id))
+        goal_policy = public_git_history_window_goal_policy(goal)
+        if not goal_policy["enabled"]:
+            policy = {
+                "schema_version": goal_policy["schema_version"],
+                "enabled": False,
+                "public_repositories_only": True,
+                "collaboration_writes_allowed": True,
+                "blocked_windows": [],
+            }
+        else:
+            config_path = str(goal_policy.get("config_path") or "")
+            if not config_path:
+                raise ValueError(
+                    "enabled public Git history window has no config pointer"
+                )
+            policy = load_public_git_history_window_config(
+                project=Path(str(goal.get("repo") or "")),
+                config_path=config_path,
+            )
+        request = build_public_git_history_effect_request(
+            effect_id=str(args.effect_id),
+            goal_id=str(args.goal_id),
+            action=str(args.action),
+            repository_visibility=str(args.repository_visibility),
+            repository_identity=str(args.repository_identity),
+            observed_at=(
+                str(args.observed_at)
+                if args.observed_at
+                else datetime.now().astimezone().isoformat()
+            ),
+            outgoing_commits=_outgoing_commits(args.outgoing_commits_json),
+            outgoing_commits_verified=args.outgoing_commits_json is not None,
+        )
+        payload = evaluate_public_git_history_effect(request, policy=policy)
+    except (OSError, TypeError, ValueError) as exc:
+        payload = {
+            "ok": False,
+            "schema_version": "public_git_history_window_error_v0",
+            "goal_id": str(args.goal_id),
+            "status": "error",
+            "error": str(exc),
+        }
+    print_payload(
+        payload,
+        output_format(args),
+        render_public_git_history_window_markdown,
+    )
+    if payload.get("disposition") == "allow":
+        return 0
+    return 3 if payload.get("disposition") in {"defer", "reject"} else 1

--- a/loopx/capabilities/public_git_history_window/effect_program.py
+++ b/loopx/capabilities/public_git_history_window/effect_program.py
@@ -1,0 +1,419 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from datetime import date, datetime, time, timedelta
+from enum import StrEnum
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from ...control_plane.effect_program import EffectRequest
+
+PUBLIC_GIT_HISTORY_WINDOW_DECISION_SCHEMA_VERSION = (
+    "public_git_history_window_decision_v0"
+)
+PUBLIC_GIT_HISTORY_WINDOW_RECEIPT_SCHEMA_VERSION = (
+    "public_git_history_window_receipt_v0"
+)
+
+
+class PublicRepositoryAction(StrEnum):
+    COMMIT = "commit"
+    AMEND = "amend"
+    REBASE = "rebase"
+    CHERRY_PICK = "cherry_pick"
+    REVERT = "revert"
+    MERGE_COMMIT = "merge_commit"
+    PUSH = "push"
+    PR_MERGE = "pr_merge"
+    AUTO_MERGE_ENABLE = "auto_merge_enable"
+    TAG = "tag"
+    RELEASE = "release"
+    PR_CREATE = "pr_create"
+    PR_COMMENT = "pr_comment"
+    PR_REVIEW = "pr_review"
+    PR_METADATA = "pr_metadata"
+    REQUEST_REVIEWER = "request_reviewer"
+    LABEL = "label"
+
+
+PUBLIC_GIT_HISTORY_ACTIONS = frozenset(
+    {
+        PublicRepositoryAction.COMMIT,
+        PublicRepositoryAction.AMEND,
+        PublicRepositoryAction.REBASE,
+        PublicRepositoryAction.CHERRY_PICK,
+        PublicRepositoryAction.REVERT,
+        PublicRepositoryAction.MERGE_COMMIT,
+        PublicRepositoryAction.PUSH,
+        PublicRepositoryAction.PR_MERGE,
+        PublicRepositoryAction.AUTO_MERGE_ENABLE,
+        PublicRepositoryAction.TAG,
+        PublicRepositoryAction.RELEASE,
+    }
+)
+PUBLIC_GIT_PUBLICATION_ACTIONS = frozenset(
+    {
+        PublicRepositoryAction.PUSH,
+        PublicRepositoryAction.PR_MERGE,
+        PublicRepositoryAction.TAG,
+        PublicRepositoryAction.RELEASE,
+    }
+)
+
+
+def is_public_git_history_action(action: PublicRepositoryAction | str) -> bool:
+    try:
+        normalized = PublicRepositoryAction(str(action))
+    except ValueError:
+        return False
+    return normalized in PUBLIC_GIT_HISTORY_ACTIONS
+
+
+def _aware_datetime(value: object, *, label: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        text = str(value or "").strip()
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        try:
+            parsed = datetime.fromisoformat(text)
+        except ValueError as exc:
+            raise ValueError(f"{label} must be an ISO timestamp") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError(f"{label} must include a UTC offset")
+    return parsed
+
+
+def _clock(value: str) -> time:
+    hour, minute = (int(part) for part in value.split(":"))
+    return time(hour=hour, minute=minute)
+
+
+def _window_contains(local: datetime, window: Mapping[str, Any]) -> bool:
+    start = _clock(str(window["start"]))
+    end = _clock(str(window["end"]))
+    current = local.timetz().replace(tzinfo=None)
+    if start < end:
+        return start <= current < end
+    return current >= start or current < end
+
+
+def _window_resume_at(local: datetime, window: Mapping[str, Any]) -> datetime:
+    start = _clock(str(window["start"]))
+    end = _clock(str(window["end"]))
+    current = local.timetz().replace(tzinfo=None)
+    resume_date: date
+    if start < end:
+        resume_date = local.date()
+    elif current >= start:
+        resume_date = local.date() + timedelta(days=1)
+    else:
+        resume_date = local.date()
+    return datetime.combine(resume_date, end, tzinfo=local.tzinfo)
+
+
+def _blocked_window(
+    observed_at: datetime,
+    policy: Mapping[str, Any],
+) -> tuple[Mapping[str, Any], datetime] | None:
+    local = observed_at.astimezone(ZoneInfo(str(policy["timezone"])))
+    for window in policy.get("blocked_windows") or []:
+        if isinstance(window, Mapping) and _window_contains(local, window):
+            return window, _window_resume_at(local, window)
+    return None
+
+
+def _receipt_id(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:20]
+
+
+def _policy_fingerprint(policy: Mapping[str, Any]) -> str:
+    public_contract = {
+        "schema_version": policy.get("schema_version"),
+        "enabled": policy.get("enabled") is True,
+        "timezone": policy.get("timezone"),
+        "blocked_windows": policy.get("blocked_windows") or [],
+        "public_repositories_only": policy.get("public_repositories_only")
+        is not False,
+        "collaboration_writes_allowed": policy.get(
+            "collaboration_writes_allowed"
+        )
+        is True,
+    }
+    return _receipt_id(public_contract)
+
+
+def build_public_git_history_effect_request(
+    *,
+    effect_id: str,
+    goal_id: str,
+    action: PublicRepositoryAction | str,
+    repository_visibility: str,
+    repository_identity: str,
+    observed_at: datetime | str,
+    outgoing_commits: Sequence[Mapping[str, Any]] = (),
+    outgoing_commits_verified: bool = False,
+    source: str = "agent_or_host",
+) -> EffectRequest:
+    effect_id = str(effect_id or "").strip()
+    if not effect_id:
+        raise ValueError("effect_id must be present")
+    normalized_action = PublicRepositoryAction(str(action))
+    visibility = str(repository_visibility or "").strip().lower()
+    if visibility not in {"public", "private", "unknown"}:
+        raise ValueError("repository_visibility must be public, private, or unknown")
+    identity = str(repository_identity or "").strip()
+    if not identity:
+        raise ValueError("repository_identity must be present")
+    observed = _aware_datetime(observed_at, label="observed_at")
+    return EffectRequest(
+        kind=f"public_repository.{normalized_action.value}",
+        source=source,
+        goal_id=goal_id,
+        capabilities=("public_git_history_window",),
+        context={
+            "effect_id": effect_id,
+            "action": normalized_action.value,
+            "repository_visibility": visibility,
+            "repository_identity": identity,
+            "observed_at": observed.isoformat(),
+            "outgoing_commits": [dict(item) for item in outgoing_commits],
+            "outgoing_commits_verified": outgoing_commits_verified is True,
+        },
+    )
+
+
+def _decision(
+    *,
+    request: EffectRequest,
+    action: PublicRepositoryAction,
+    disposition: str,
+    reason_code: str,
+    observed_at: datetime,
+    policy: Mapping[str, Any],
+    defer_until: datetime | None = None,
+    blocked_window_id: str | None = None,
+    violating_commits: Sequence[Mapping[str, Any]] = (),
+    required_guards: Sequence[str] = (),
+    required_action: str | None = None,
+) -> dict[str, Any]:
+    receipt_core: dict[str, Any] = {
+        "schema_version": PUBLIC_GIT_HISTORY_WINDOW_RECEIPT_SCHEMA_VERSION,
+        "effect_id": str(request.context.get("effect_id") or ""),
+        "goal_id": request.goal_id,
+        "action": action.value,
+        "disposition": disposition,
+        "reason_code": reason_code,
+        "observed_at": observed_at.isoformat(),
+        "repository_identity": str(
+            request.context.get("repository_identity") or ""
+        ),
+        "policy_fingerprint": _policy_fingerprint(policy),
+    }
+    if defer_until is not None:
+        receipt_core["defer_until"] = defer_until.isoformat()
+    if blocked_window_id:
+        receipt_core["blocked_window_id"] = blocked_window_id
+    receipt = dict(receipt_core)
+    receipt["receipt_id"] = _receipt_id(receipt_core)
+    payload: dict[str, Any] = {
+        "ok": disposition == "allow",
+        "schema_version": PUBLIC_GIT_HISTORY_WINDOW_DECISION_SCHEMA_VERSION,
+        "goal_id": request.goal_id,
+        "effect_id": receipt_core["effect_id"],
+        "action": action.value,
+        "history_write": action in PUBLIC_GIT_HISTORY_ACTIONS,
+        "collaboration_write": action not in PUBLIC_GIT_HISTORY_ACTIONS,
+        "disposition": disposition,
+        "reason_code": reason_code,
+        "repository_visibility": request.context.get("repository_visibility"),
+        "observed_at": observed_at.isoformat(),
+        "policy": {
+            "schema_version": policy.get("schema_version"),
+            "enabled": policy.get("enabled") is True,
+            "public_repositories_only": policy.get("public_repositories_only")
+            is not False,
+            "collaboration_writes_allowed": policy.get(
+                "collaboration_writes_allowed"
+            )
+            is True,
+            "fingerprint": receipt_core["policy_fingerprint"],
+        },
+        "required_guards": list(required_guards),
+        "receipt": receipt,
+    }
+    if defer_until is not None:
+        payload["defer_until"] = defer_until.isoformat()
+    if blocked_window_id:
+        payload["blocked_window_id"] = blocked_window_id
+    if violating_commits:
+        payload["violating_commits"] = [dict(item) for item in violating_commits]
+    if required_action:
+        payload["required_action"] = required_action
+    return payload
+
+
+def _violating_outgoing_commits(
+    commits: object,
+    *,
+    policy: Mapping[str, Any],
+) -> list[dict[str, str]]:
+    if commits is None:
+        return []
+    if not isinstance(commits, Sequence) or isinstance(commits, (str, bytes)):
+        raise TypeError("outgoing_commits must be a list")
+    violating: list[dict[str, str]] = []
+    for index, raw in enumerate(commits):
+        if not isinstance(raw, Mapping):
+            raise TypeError(f"outgoing_commits[{index}] must be an object")
+        sha = str(raw.get("sha") or "").strip()
+        if not sha:
+            raise ValueError(f"outgoing_commits[{index}].sha must be present")
+        for field in ("author_at", "committer_at"):
+            timestamp = _aware_datetime(
+                raw.get(field), label=f"outgoing_commits[{index}].{field}"
+            )
+            blocked = _blocked_window(timestamp, policy)
+            if blocked is not None:
+                window, _resume = blocked
+                violating.append(
+                    {
+                        "sha": sha,
+                        "field": field,
+                        "timestamp": timestamp.isoformat(),
+                        "blocked_window_id": str(window["window_id"]),
+                    }
+                )
+    return violating
+
+
+def evaluate_public_git_history_effect(
+    request: EffectRequest,
+    *,
+    policy: Mapping[str, Any],
+) -> dict[str, Any]:
+    action = PublicRepositoryAction(str(request.context.get("action") or ""))
+    observed_at = _aware_datetime(
+        request.context.get("observed_at"), label="request observed_at"
+    )
+
+    if action not in PUBLIC_GIT_HISTORY_ACTIONS:
+        guards = (
+            ("head_already_remote", "no_implicit_push")
+            if action is PublicRepositoryAction.PR_CREATE
+            else ()
+        )
+        return _decision(
+            request=request,
+            action=action,
+            disposition="allow",
+            reason_code="collaboration_write_outside_capability",
+            observed_at=observed_at,
+            policy=policy,
+            required_guards=guards,
+        )
+    if policy.get("enabled") is not True:
+        return _decision(
+            request=request,
+            action=action,
+            disposition="allow",
+            reason_code="capability_disabled",
+            observed_at=observed_at,
+            policy=policy,
+        )
+
+    visibility = str(request.context.get("repository_visibility") or "unknown")
+    if policy.get("public_repositories_only") is not False:
+        if visibility == "private":
+            return _decision(
+                request=request,
+                action=action,
+                disposition="allow",
+                reason_code="private_repository_outside_policy",
+                observed_at=observed_at,
+                policy=policy,
+            )
+        if visibility != "public":
+            return _decision(
+                request=request,
+                action=action,
+                disposition="reject",
+                reason_code="repository_visibility_unknown",
+                observed_at=observed_at,
+                policy=policy,
+                required_action="resolve repository visibility before history write",
+            )
+
+    if action is PublicRepositoryAction.AUTO_MERGE_ENABLE:
+        return _decision(
+            request=request,
+            action=action,
+            disposition="reject",
+            reason_code="execution_time_not_rechecked",
+            observed_at=observed_at,
+            policy=policy,
+            required_action=(
+                "keep auto-merge disabled and evaluate pr_merge at execution time"
+            ),
+        )
+
+    violations = _violating_outgoing_commits(
+        request.context.get("outgoing_commits"),
+        policy=policy,
+    )
+    if violations:
+        return _decision(
+            request=request,
+            action=action,
+            disposition="reject",
+            reason_code="outgoing_commit_timestamp_in_blocked_window",
+            observed_at=observed_at,
+            policy=policy,
+            violating_commits=violations,
+            required_action="recreate the unpublished commit outside the blocked window",
+        )
+
+    blocked = _blocked_window(observed_at, policy)
+    if blocked is not None:
+        window, resume = blocked
+        return _decision(
+            request=request,
+            action=action,
+            disposition="defer",
+            reason_code="blocked_window_active",
+            observed_at=observed_at,
+            policy=policy,
+            defer_until=resume,
+            blocked_window_id=str(window["window_id"]),
+            required_action="preserve local work and retry this exact effect after defer_until",
+        )
+
+    if (
+        action in PUBLIC_GIT_PUBLICATION_ACTIONS
+        and request.context.get("outgoing_commits_verified") is not True
+    ):
+        return _decision(
+            request=request,
+            action=action,
+            disposition="reject",
+            reason_code="outgoing_commit_inventory_unverified",
+            observed_at=observed_at,
+            policy=policy,
+            required_action=(
+                "compare against the target remote ref and provide the complete "
+                "newly outgoing commit inventory"
+            ),
+        )
+
+    return _decision(
+        request=request,
+        action=action,
+        disposition="allow",
+        reason_code="outside_blocked_window",
+        observed_at=observed_at,
+        policy=policy,
+    )

--- a/loopx/capabilities/public_git_history_window/policy.py
+++ b/loopx/capabilities/public_git_history_window/policy.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+PUBLIC_GIT_HISTORY_WINDOW_CONFIG_SCHEMA_VERSION = (
+    "public_git_history_window_config_v0"
+)
+PUBLIC_GIT_HISTORY_WINDOW_POLICY_SCHEMA_VERSION = (
+    "public_git_history_window_policy_v0"
+)
+
+_CONFIG_FIELDS = {
+    "schema_version",
+    "timezone",
+    "blocked_windows",
+    "public_repositories_only",
+    "collaboration_writes_allowed",
+}
+_WINDOW_FIELDS = {"window_id", "start", "end"}
+_TIME_RE = re.compile(r"^(?:[01]\d|2[0-3]):[0-5]\d$")
+
+
+def _strict_mapping(
+    value: object,
+    *,
+    label: str,
+    allowed: set[str],
+) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{label} must be an object")
+    unknown = sorted(str(key) for key in value if str(key) not in allowed)
+    if unknown:
+        raise ValueError(f"{label} has unsupported fields: {', '.join(unknown)}")
+    return value
+
+
+def _time(value: object, *, label: str) -> str:
+    text = str(value or "").strip()
+    if not _TIME_RE.fullmatch(text):
+        raise ValueError(f"{label} must use 24-hour HH:MM")
+    return text
+
+
+def normalize_public_git_history_window_config(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    raw = _strict_mapping(payload, label="config", allowed=_CONFIG_FIELDS)
+    if raw.get("schema_version") != PUBLIC_GIT_HISTORY_WINDOW_CONFIG_SCHEMA_VERSION:
+        raise ValueError(
+            "config schema_version must be "
+            f"{PUBLIC_GIT_HISTORY_WINDOW_CONFIG_SCHEMA_VERSION}"
+        )
+    timezone = str(raw.get("timezone") or "").strip()
+    if not timezone:
+        raise ValueError("config timezone must be present")
+    try:
+        ZoneInfo(timezone)
+    except ZoneInfoNotFoundError as exc:
+        raise ValueError("config timezone is unavailable") from exc
+
+    windows_value = raw.get("blocked_windows")
+    if not isinstance(windows_value, list) or not windows_value:
+        raise ValueError("config blocked_windows must be a non-empty list")
+    windows: list[dict[str, str]] = []
+    window_ids: set[str] = set()
+    for index, value in enumerate(windows_value):
+        window = _strict_mapping(
+            value,
+            label=f"blocked_windows[{index}]",
+            allowed=_WINDOW_FIELDS,
+        )
+        window_id = str(window.get("window_id") or "").strip()
+        if not re.fullmatch(r"[a-z][a-z0-9_-]{0,63}", window_id):
+            raise ValueError(
+                f"blocked_windows[{index}].window_id must be a public-safe token"
+            )
+        if window_id in window_ids:
+            raise ValueError(f"duplicate blocked window id: {window_id}")
+        start = _time(window.get("start"), label=f"blocked_windows[{index}].start")
+        end = _time(window.get("end"), label=f"blocked_windows[{index}].end")
+        if start == end:
+            raise ValueError("blocked window start and end must differ")
+        window_ids.add(window_id)
+        windows.append({"window_id": window_id, "start": start, "end": end})
+
+    public_only = raw.get("public_repositories_only", True)
+    collaboration_allowed = raw.get("collaboration_writes_allowed", True)
+    if not isinstance(public_only, bool):
+        raise TypeError("config public_repositories_only must be a boolean")
+    if collaboration_allowed is not True:
+        raise ValueError(
+            "config collaboration_writes_allowed must be true; collaboration writes "
+            "are outside this capability"
+        )
+    return {
+        "schema_version": PUBLIC_GIT_HISTORY_WINDOW_POLICY_SCHEMA_VERSION,
+        "enabled": True,
+        "timezone": timezone,
+        "blocked_windows": windows,
+        "public_repositories_only": public_only,
+        "collaboration_writes_allowed": True,
+    }
+
+
+def public_git_history_window_goal_policy(goal: Mapping[str, Any]) -> dict[str, Any]:
+    control_plane_value = goal.get("control_plane")
+    control_plane: Mapping[str, Any] = (
+        control_plane_value if isinstance(control_plane_value, Mapping) else {}
+    )
+    raw_value = control_plane.get("public_git_history_window")
+    raw: Mapping[str, Any] = raw_value if isinstance(raw_value, Mapping) else {}
+    return {
+        "schema_version": PUBLIC_GIT_HISTORY_WINDOW_POLICY_SCHEMA_VERSION,
+        "enabled": raw.get("enabled") is True,
+        "config_path": str(raw.get("config_path") or "").strip() or None,
+    }
+
+
+def public_git_history_window_goal_policy_summary(
+    goal: Mapping[str, Any],
+) -> dict[str, Any]:
+    policy = public_git_history_window_goal_policy(goal)
+    return {
+        "enabled": policy["enabled"],
+        "config_pointer_registered": bool(policy["config_path"]),
+    }
+
+
+def _require_ignored_untracked(project: Path, relative: Path) -> None:
+    tracked = subprocess.run(
+        ["git", "-C", str(project), "ls-files", "--error-unmatch", "--", str(relative)],
+        capture_output=True,
+        check=False,
+    )
+    ignored = subprocess.run(
+        ["git", "-C", str(project), "check-ignore", "--quiet", "--", str(relative)],
+        capture_output=True,
+        check=False,
+    )
+    if tracked.returncode == 0 or ignored.returncode != 0:
+        raise ValueError(
+            "public Git history window config must be ignored and untracked"
+        )
+
+
+def load_public_git_history_window_config(
+    *,
+    project: Path,
+    config_path: str,
+) -> dict[str, Any]:
+    root = project.expanduser().resolve()
+    if not root.is_dir():
+        raise ValueError("goal project directory does not exist")
+    path = (root / config_path).resolve()
+    try:
+        relative = path.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("public Git history window config escapes the goal project") from exc
+    if relative.parts[:2] != (".loopx", "config") or path.suffix != ".json":
+        raise ValueError(
+            "public Git history window config must be under .loopx/config/"
+        )
+    _require_ignored_untracked(root, relative)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("public Git history window config is unavailable") from exc
+    if not isinstance(payload, Mapping):
+        raise TypeError("public Git history window config must be an object")
+    return normalize_public_git_history_window_config(payload)

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -22,6 +22,10 @@ from .capabilities.integration_branch.cli import (
     handle_integration_branch_command,
     register_integration_branch_commands,
 )
+from .capabilities.public_git_history_window.cli import (
+    handle_public_git_history_window_command,
+    register_public_git_history_window_commands,
+)
 from .capabilities.decision_context.cli import (
     handle_decision_context_command,
     register_decision_context_commands,
@@ -232,6 +236,8 @@ def build_parser() -> LoopXArgumentParser:
 
     register_integration_branch_commands(sub, add_subcommand_format)
 
+    register_public_git_history_window_commands(sub, add_subcommand_format)
+
     register_content_ops_commands(sub, add_subcommand_format)
 
     register_decision_context_commands(sub, add_subcommand_format)
@@ -439,6 +445,15 @@ def main(argv: list[str] | None = None) -> int:
     )
     if integration_branch_result is not None:
         return integration_branch_result
+
+    public_git_history_window_result = handle_public_git_history_window_command(
+        args,
+        registry_path=registry_path,
+        output_format=output_format,
+        print_payload=print_payload,
+    )
+    if public_git_history_window_result is not None:
+        return public_git_history_window_result
 
     if args.command == "ml-experiment":
         return handle_ml_experiment_command(args, output_format=output_format, print_payload=print_payload)

--- a/loopx/cli_commands/registry_admin.py
+++ b/loopx/cli_commands/registry_admin.py
@@ -642,6 +642,12 @@ def handle_registry_admin_command(
                 clear_reward_memory_config=bool(
                     args.clear_reward_memory_config
                 ),
+                public_git_history_window_config=(
+                    args.public_git_history_window_config
+                ),
+                clear_public_git_history_window_config=bool(
+                    args.clear_public_git_history_window_config
+                ),
                 execute=bool(args.execute),
             )
             if payload.get("ok"):

--- a/loopx/cli_commands/registry_admin_configure.py
+++ b/loopx/cli_commands/registry_admin_configure.py
@@ -317,6 +317,18 @@ def register_configure_goal_command(subparsers: argparse._SubParsersAction) -> N
         help="Disable the Reward Memory experiment and clear its agent allowlist.",
     )
     configure_goal_parser.add_argument(
+        "--public-git-history-window-config",
+        help=(
+            "Register a repo-relative ignored public Git history window config "
+            "under .loopx/config/."
+        ),
+    )
+    configure_goal_parser.add_argument(
+        "--clear-public-git-history-window-config",
+        action="store_true",
+        help="Disable the public Git history window and clear its config pointer.",
+    )
+    configure_goal_parser.add_argument(
         "--execute",
         action="store_true",
         help="Write the registry. Without this flag, configure-goal is a dry-run preview.",

--- a/loopx/configuration_catalog.py
+++ b/loopx/configuration_catalog.py
@@ -56,6 +56,11 @@ def build_goal_configuration_catalog(
         if isinstance(feature_summary.get("reward_memory"), Mapping)
         else {}
     )
+    public_git_history_window = (
+        feature_summary.get("public_git_history_window")
+        if isinstance(feature_summary.get("public_git_history_window"), Mapping)
+        else {}
+    )
     change_quality = (
         feature_summary.get("change_quality_qualification")
         if isinstance(
@@ -333,6 +338,89 @@ def build_goal_configuration_catalog(
                     "url": (
                         "https://github.com/huangruiteng/loopx/blob/main/"
                         "docs/capabilities/change-quality/README.md"
+                    ),
+                },
+            },
+            {
+                "feature_id": "public_git_history_window",
+                "display_name": "Public Git history window",
+                "availability": "supported_opt_in",
+                "default": {"enabled": False},
+                "current": {
+                    "enabled": public_git_history_window.get("enabled") is True,
+                    "config_pointer_registered": public_git_history_window.get(
+                        "config_pointer_registered"
+                    )
+                    is True,
+                },
+                "required_inputs": {
+                    "ignored-history-window-config": (
+                        "Replace the placeholder with a repo-relative ignored JSON "
+                        "config under .loopx/config/."
+                    )
+                },
+                "consider_when": (
+                    "A goal must defer public repository history writes during "
+                    "configured local-time windows."
+                ),
+                "effect": (
+                    "Evaluates commit, push, merge, tag, and release effects before "
+                    "execution and returns an allow, defer, or reject receipt."
+                ),
+                "does_not": [
+                    "block PR comments, reviews, labels, reviewers, or metadata",
+                    "rewrite author or committer timestamps",
+                    "make an implicit push while creating a PR",
+                    "enforce policy on raw git callers that bypass the evaluator",
+                ],
+                "commands": {
+                    "preview_enable": _configure_command(
+                        goal_id,
+                        "--public-git-history-window-config",
+                        "<ignored-history-window-config>",
+                    ),
+                    "apply_enable": _configure_command(
+                        goal_id,
+                        "--public-git-history-window-config",
+                        "<ignored-history-window-config>",
+                        execute=True,
+                    ),
+                    "preview_disable": _configure_command(
+                        goal_id, "--clear-public-git-history-window-config"
+                    ),
+                    "apply_disable": _configure_command(
+                        goal_id,
+                        "--clear-public-git-history-window-config",
+                        execute=True,
+                    ),
+                    "verify": [
+                        inspect_command,
+                        shlex.join(
+                            [
+                                "loopx",
+                                "--format",
+                                "json",
+                                "public-git-history-window",
+                                "evaluate",
+                                "--goal-id",
+                                goal_id,
+                                "--effect-id",
+                                "<stable-effect-id>",
+                                "--action",
+                                "push",
+                                "--repository-visibility",
+                                "public",
+                                "--repository-identity",
+                                "<provider/repository>",
+                            ]
+                        ),
+                    ],
+                },
+                "documentation": {
+                    "path": "docs/capabilities/public-git-history-window/README.md",
+                    "url": (
+                        "https://github.com/huangruiteng/loopx/blob/main/"
+                        "docs/capabilities/public-git-history-window/README.md"
                     ),
                 },
             },

--- a/loopx/configure_goal.py
+++ b/loopx/configure_goal.py
@@ -18,6 +18,9 @@ from .capabilities.change_quality.policy import (
     CHANGE_QUALITY_POLICY_SCHEMA_VERSION,
     change_quality_goal_policy_summary,
 )
+from .capabilities.public_git_history_window.policy import (
+    public_git_history_window_goal_policy_summary,
+)
 from .control_plane import compact_control_plane_policy, control_plane_policy_summary
 from .configuration_catalog import build_goal_configuration_catalog
 from .explore_graph import compact_explore_graph_policy
@@ -230,6 +233,9 @@ def _settings_summary(goal: dict[str, Any]) -> dict[str, Any]:
         "lark_event_inbox": _lark_event_inbox_config_summary(goal),
         "lark_kanban_heartbeat_sync": _lark_kanban_heartbeat_config_summary(goal),
         "reward_memory": reward_memory_goal_policy_summary(goal),
+        "public_git_history_window": public_git_history_window_goal_policy_summary(
+            goal
+        ),
         "change_quality_qualification": change_quality_goal_policy_summary(goal),
         "explore_graph": compact_explore_graph_policy(goal.get("explore_graph")),
         "orchestration": orchestration,
@@ -444,6 +450,8 @@ def configure_goal(
     reward_memory_config: str | None = None,
     reward_memory_agents: list[str] | None = None,
     clear_reward_memory_config: bool = False,
+    public_git_history_window_config: str | None = None,
+    clear_public_git_history_window_config: bool = False,
     execute: bool = False,
 ) -> dict[str, Any]:
     if not registry_path.exists():
@@ -518,6 +526,14 @@ def configure_goal(
             "--clear-reward-memory-config cannot be combined with "
             "--reward-memory-config or --reward-memory-agent"
         )
+    if (
+        clear_public_git_history_window_config
+        and public_git_history_window_config
+    ):
+        raise ValueError(
+            "--clear-public-git-history-window-config cannot be combined with "
+            "--public-git-history-window-config"
+        )
     if waiting_on and waiting_on not in WAITING_ON_CHOICES:
         raise ValueError("--waiting-on must be one of: " + ", ".join(WAITING_ON_CHOICES))
     if multi_subagent_feature is not None and multi_subagent_feature not in MULTI_SUBAGENT_FEATURE_CHOICES:
@@ -564,6 +580,10 @@ def configure_goal(
     reward_memory_config = _local_private_config_path(
         reward_memory_config,
         label="reward memory experiment config",
+    )
+    public_git_history_window_config = _local_private_config_path(
+        public_git_history_window_config,
+        label="public Git history window config",
     )
 
     payload = read_json(registry_path)
@@ -811,6 +831,19 @@ def configure_goal(
                     reward_memory_config or current_reward_memory["config_path"]
                 ),
                 "enabled_agents": list(effective_reward_memory_agents),
+            }
+
+    if (
+        public_git_history_window_config is not None
+        or clear_public_git_history_window_config
+    ):
+        control_plane = _mutable_control_plane(goal)
+        if clear_public_git_history_window_config:
+            control_plane.pop("public_git_history_window", None)
+        else:
+            control_plane["public_git_history_window"] = {
+                "enabled": True,
+                "config_path": public_git_history_window_config,
             }
 
     if explore_graph_enabled is not None:
@@ -1096,6 +1129,9 @@ def configure_goal(
         "lark_event_inbox": _lark_event_inbox_config_summary(goal),
         "lark_kanban_heartbeat_sync": _lark_kanban_heartbeat_config_summary(goal),
         "reward_memory": reward_memory_goal_policy_summary(goal),
+        "public_git_history_window": public_git_history_window_goal_policy_summary(
+            goal
+        ),
         "change_quality_qualification": change_quality_goal_policy_summary(goal),
         "default": "off",
         "configuration_entry": "multi_subagent_feature",

--- a/loopx/control_plane/quota/goal_boundary.py
+++ b/loopx/control_plane/quota/goal_boundary.py
@@ -6,14 +6,13 @@ from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any
 
-from ..reward_memory import reward_memory_goal_policy
-
 from ...benchmark_core import compact_run_permission_policy_for_quota
 from ...boundary_authority import checkpointed_boundary_authority_summary
 from ...execution_profile import execution_profile_outcome_floor
 from ...explore_graph import compact_explore_graph_policy
 from ...orchestration import compact_orchestration_policy
 from ...repository_identity import resolve_project_identity
+from ..reward_memory import reward_memory_goal_policy
 from ..todos.contract import (
     normalize_required_capabilities,
     normalize_required_write_scopes,
@@ -277,6 +276,51 @@ def goal_boundary(
             registry_path=registry_path,
         )
     )
+    public_history_window = (
+        control_plane.get("public_git_history_window")
+        if isinstance(control_plane.get("public_git_history_window"), Mapping)
+        else {}
+    )
+    if public_history_window.get("enabled") is True:
+        evaluate_parts = ["loopx"]
+        if registry_path is not None:
+            evaluate_parts.extend(["--registry", str(registry_path.expanduser())])
+        evaluate_parts.extend(
+            [
+                "public-git-history-window",
+                "evaluate",
+                "--goal-id",
+                str(goal.get("id") or ""),
+                "--effect-id",
+                "<stable-effect-id>",
+                "--action",
+                "<history-action>",
+                "--repository-visibility",
+                "<public|private|unknown>",
+                "--repository-identity",
+                "<provider/repository>",
+            ]
+        )
+        boundary.setdefault("capabilities", {})[
+            "public_git_history_window"
+        ] = {
+            "enabled": True,
+            "config_pointer_registered": bool(
+                public_history_window.get("config_path")
+            ),
+            "collaboration_writes_excluded": [
+                "pr_comment",
+                "pr_review",
+                "pr_metadata",
+                "request_reviewer",
+                "label",
+            ],
+            "evaluate_command": shlex.join(evaluate_parts),
+            "policy": (
+                "evaluate before public commit, push, merge, tag, or release; "
+                "PR collaboration remains outside this capability"
+            ),
+        }
     reward_memory = reward_memory_goal_policy(goal)
     if reward_memory["enabled"] and (
         agent_id is None or agent_id in reward_memory["enabled_agents"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,8 @@ python_version = "3.11"
 strict = true
 files = [
   "loopx/claude_goal_baseline.py",
+  "loopx/capabilities/public_git_history_window/effect_program.py",
+  "loopx/capabilities/public_git_history_window/policy.py",
   "loopx/benchmarks/read_models/benchmark_run_execution_contract.py",
   "loopx/benchmarks/read_models/benchmark_run_failure.py",
   "loopx/control_plane/__init__.py",

--- a/skills/loopx-project/SKILL.md
+++ b/skills/loopx-project/SKILL.md
@@ -443,6 +443,17 @@ adapter status, allowed write scope, parent-approval scopes, guards, and stop
 condition. Treat it as the project-specific boundary contract so automation
 prompts can stay short instead of repeating long per-project protected-scope
 lists.
+If `goal_boundary.capabilities.public_git_history_window.enabled=true`, evaluate
+the projected command immediately before every public commit, amend, rebase,
+cherry-pick, revert, merge, push, tag, or release effect and obey `defer` or
+`reject`. PR comments, reviews, labels, reviewer requests, and metadata are not
+history effects. PR creation remains available only when its head is already
+remote and creation performs no implicit push. Never satisfy the policy by
+rewriting author or committer timestamps.
+For push, merge, tag, and release evaluation, enumerate every newly outgoing
+commit and pass its author and committer timestamps through
+`--outgoing-commits-json`; an empty list is valid only after a real comparison
+against the target remote ref proves that no commit will be newly published.
 When reading status or quota routing, use `attention_queue.items` and
 `project_asset` as current authority only when the item is project-asset-backed.
 If `project_asset` is absent or the source is legacy/raw fallback, do not infer

--- a/tests/capabilities/test_capability_extension_registry.py
+++ b/tests/capabilities/test_capability_extension_registry.py
@@ -23,6 +23,7 @@ from loopx.extensions.runtime import (
 )
 
 BUILTIN_IDS = [
+    "public_git_history_window",
     "integration-branch-reconcile",
     "change-quality-qualification",
     "pull-request-review",

--- a/tests/capabilities/test_public_git_history_window.py
+++ b/tests/capabilities/test_public_git_history_window.py
@@ -1,0 +1,447 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from loopx.capabilities.catalog import BUILTIN_CAPABILITIES
+from loopx.capabilities.public_git_history_window.effect_program import (
+    PublicRepositoryAction,
+    build_public_git_history_effect_request,
+    evaluate_public_git_history_effect,
+)
+from loopx.capabilities.public_git_history_window.policy import (
+    PUBLIC_GIT_HISTORY_WINDOW_POLICY_SCHEMA_VERSION,
+    normalize_public_git_history_window_config,
+    public_git_history_window_goal_policy,
+)
+from loopx.cli import main
+from loopx.configure_goal import configure_goal
+from loopx.control_plane.quota.goal_boundary import goal_boundary
+
+GOAL_ID = "public-history-window-fixture"
+
+
+def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=check,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _policy(*, start: str = "09:00", end: str = "17:00") -> dict[str, object]:
+    return normalize_public_git_history_window_config(
+        {
+            "schema_version": "public_git_history_window_config_v0",
+            "timezone": "UTC",
+            "blocked_windows": [
+                {"window_id": "fixture-window", "start": start, "end": end}
+            ],
+            "public_repositories_only": True,
+            "collaboration_writes_allowed": True,
+        }
+    )
+
+
+def _request(
+    *,
+    action: PublicRepositoryAction | str = PublicRepositoryAction.PUSH,
+    observed_at: str = "2026-01-05T12:00:00+00:00",
+    visibility: str = "public",
+    outgoing_commits: list[dict[str, str]] | None = None,
+):
+    return build_public_git_history_effect_request(
+        effect_id="effect-fixture-001",
+        goal_id=GOAL_ID,
+        action=action,
+        repository_visibility=visibility,
+        repository_identity="example/project",
+        observed_at=observed_at,
+        outgoing_commits=outgoing_commits or [],
+        outgoing_commits_verified=True,
+    )
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    (repo / ".gitignore").write_text(".loopx/config/\n", encoding="utf-8")
+    config_dir = repo / ".loopx" / "config"
+    config_dir.mkdir(parents=True)
+    config = config_dir / "public-history-window.json"
+    config.write_text(
+        json.dumps(
+            {
+                "schema_version": "public_git_history_window_config_v0",
+                "timezone": "UTC",
+                "blocked_windows": [
+                    {
+                        "window_id": "fixture-window",
+                        "start": "09:00",
+                        "end": "17:00",
+                    }
+                ],
+                "public_repositories_only": True,
+                "collaboration_writes_allowed": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    registry = tmp_path / "registry.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "repo": str(repo),
+                        "control_plane": {},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    return repo, registry, config
+
+
+@pytest.mark.parametrize(
+    ("observed_at", "disposition", "defer_until"),
+    [
+        ("2026-01-05T08:59:59+00:00", "allow", None),
+        ("2026-01-05T09:00:00+00:00", "defer", "2026-01-05T17:00:00+00:00"),
+        ("2026-01-05T16:59:59+00:00", "defer", "2026-01-05T17:00:00+00:00"),
+        ("2026-01-05T17:00:00+00:00", "allow", None),
+    ],
+)
+def test_window_start_is_inclusive_and_end_is_exclusive(
+    observed_at: str,
+    disposition: str,
+    defer_until: str | None,
+) -> None:
+    decision = evaluate_public_git_history_effect(
+        _request(observed_at=observed_at),
+        policy=_policy(),
+    )
+
+    assert decision["disposition"] == disposition
+    assert decision.get("defer_until") == defer_until
+
+
+@pytest.mark.parametrize(
+    ("observed_at", "disposition", "defer_until"),
+    [
+        ("2026-01-05T21:59:59+00:00", "allow", None),
+        ("2026-01-05T22:00:00+00:00", "defer", "2026-01-06T06:00:00+00:00"),
+        ("2026-01-06T05:59:59+00:00", "defer", "2026-01-06T06:00:00+00:00"),
+        ("2026-01-06T06:00:00+00:00", "allow", None),
+    ],
+)
+def test_cross_midnight_windows_have_the_correct_resume_day(
+    observed_at: str,
+    disposition: str,
+    defer_until: str | None,
+) -> None:
+    decision = evaluate_public_git_history_effect(
+        _request(observed_at=observed_at),
+        policy=_policy(start="22:00", end="06:00"),
+    )
+
+    assert decision["disposition"] == disposition
+    assert decision.get("defer_until") == defer_until
+
+
+@pytest.mark.parametrize(
+    "action",
+    [
+        PublicRepositoryAction.PR_COMMENT,
+        PublicRepositoryAction.PR_REVIEW,
+        PublicRepositoryAction.PR_METADATA,
+        PublicRepositoryAction.REQUEST_REVIEWER,
+        PublicRepositoryAction.LABEL,
+    ],
+)
+def test_pr_collaboration_writes_remain_available_during_a_window(
+    action: PublicRepositoryAction,
+) -> None:
+    decision = evaluate_public_git_history_effect(
+        _request(action=action),
+        policy=_policy(),
+    )
+
+    assert decision["disposition"] == "allow"
+    assert decision["reason_code"] == "collaboration_write_outside_capability"
+    assert decision["history_write"] is False
+
+
+def test_pr_create_requires_a_remote_head_and_no_implicit_push() -> None:
+    decision = evaluate_public_git_history_effect(
+        _request(action=PublicRepositoryAction.PR_CREATE),
+        policy=_policy(),
+    )
+
+    assert decision["disposition"] == "allow"
+    assert decision["required_guards"] == [
+        "head_already_remote",
+        "no_implicit_push",
+    ]
+
+
+def test_private_repository_is_outside_public_only_policy_and_unknown_fails_closed() -> None:
+    private = evaluate_public_git_history_effect(
+        _request(visibility="private"),
+        policy=_policy(),
+    )
+    unknown = evaluate_public_git_history_effect(
+        _request(visibility="unknown"),
+        policy=_policy(),
+    )
+
+    assert private["disposition"] == "allow"
+    assert private["reason_code"] == "private_repository_outside_policy"
+    assert unknown["disposition"] == "reject"
+    assert unknown["reason_code"] == "repository_visibility_unknown"
+
+
+def test_auto_merge_fails_closed_until_execution_time_can_be_rechecked() -> None:
+    decision = evaluate_public_git_history_effect(
+        _request(
+            action=PublicRepositoryAction.AUTO_MERGE_ENABLE,
+            observed_at="2026-01-05T18:00:00+00:00",
+        ),
+        policy=_policy(),
+    )
+
+    assert decision["disposition"] == "reject"
+    assert decision["reason_code"] == "execution_time_not_rechecked"
+    assert "evaluate pr_merge" in decision["required_action"]
+
+
+@pytest.mark.parametrize("field", ["author_at", "committer_at"])
+def test_later_push_rejects_an_outgoing_commit_created_in_the_window(field: str) -> None:
+    commit = {
+        "sha": "abc123",
+        "author_at": "2026-01-05T08:00:00+00:00",
+        "committer_at": "2026-01-05T08:00:00+00:00",
+    }
+    commit[field] = "2026-01-05T12:00:00+00:00"
+    decision = evaluate_public_git_history_effect(
+        _request(
+            observed_at="2026-01-05T18:00:00+00:00",
+            outgoing_commits=[commit],
+        ),
+        policy=_policy(),
+    )
+
+    assert decision["disposition"] == "reject"
+    assert decision["reason_code"] == "outgoing_commit_timestamp_in_blocked_window"
+    assert {item["field"] for item in decision["violating_commits"]} == {field}
+    assert "recreate" in decision["required_action"]
+
+
+def test_same_effect_and_inputs_produce_the_same_receipt_identity() -> None:
+    request = _request(observed_at="2026-01-05T18:00:00+00:00")
+
+    first = evaluate_public_git_history_effect(request, policy=_policy())
+    second = evaluate_public_git_history_effect(request, policy=_policy())
+
+    assert first["receipt"] == second["receipt"]
+
+
+def test_publication_rejects_an_unverified_empty_outgoing_commit_inventory() -> None:
+    request = build_public_git_history_effect_request(
+        effect_id="effect-unverified-inventory",
+        goal_id=GOAL_ID,
+        action=PublicRepositoryAction.PUSH,
+        repository_visibility="public",
+        repository_identity="example/project",
+        observed_at="2026-01-05T18:00:00+00:00",
+    )
+
+    decision = evaluate_public_git_history_effect(request, policy=_policy())
+
+    assert decision["disposition"] == "reject"
+    assert decision["reason_code"] == "outgoing_commit_inventory_unverified"
+    assert "target remote ref" in decision["required_action"]
+
+
+def test_policy_rejects_a_configuration_that_claims_to_block_collaboration() -> None:
+    with pytest.raises(ValueError, match="must be true"):
+        normalize_public_git_history_window_config(
+            {
+                "schema_version": "public_git_history_window_config_v0",
+                "timezone": "UTC",
+                "blocked_windows": [
+                    {"window_id": "fixture", "start": "09:00", "end": "17:00"}
+                ],
+                "public_repositories_only": True,
+                "collaboration_writes_allowed": False,
+            }
+        )
+
+
+def test_goal_configuration_defaults_off_then_registers_only_the_private_pointer(
+    tmp_path: Path,
+) -> None:
+    _repo, registry, _config = _fixture(tmp_path)
+    stored = json.loads(registry.read_text(encoding="utf-8"))["goals"][0]
+    assert public_git_history_window_goal_policy(stored) == {
+        "schema_version": PUBLIC_GIT_HISTORY_WINDOW_POLICY_SCHEMA_VERSION,
+        "enabled": False,
+        "config_path": None,
+    }
+
+    preview = configure_goal(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        public_git_history_window_config=(
+            ".loopx/config/public-history-window.json"
+        ),
+        execute=False,
+    )
+    assert preview["after"]["public_git_history_window"] == {
+        "enabled": True,
+        "config_pointer_registered": True,
+    }
+    assert "timezone" not in json.dumps(preview)
+    assert "09:00" not in json.dumps(preview)
+
+
+def test_goal_boundary_projects_guard_contract_without_private_window_values(
+    tmp_path: Path,
+) -> None:
+    repo, registry, _config = _fixture(tmp_path)
+    goal = json.loads(registry.read_text(encoding="utf-8"))["goals"][0]
+    goal["control_plane"] = {
+        "public_git_history_window": {
+            "enabled": True,
+            "config_path": ".loopx/config/public-history-window.json",
+        }
+    }
+
+    boundary = goal_boundary(goal, registry_path=registry)
+
+    assert boundary is not None
+    capability = boundary["capabilities"]["public_git_history_window"]
+    assert capability["enabled"] is True
+    assert capability["config_pointer_registered"] is True
+    assert "pr_comment" in capability["collaboration_writes_excluded"]
+    assert str(repo) not in json.dumps(capability)
+    assert "09:00" not in json.dumps(capability)
+
+
+def test_cli_loads_the_ignored_config_and_returns_a_defer_receipt(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _repo, registry, _config = _fixture(tmp_path)
+    configure_goal(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        public_git_history_window_config=(
+            ".loopx/config/public-history-window.json"
+        ),
+        execute=True,
+    )
+
+    code = main(
+        [
+            "--registry",
+            str(registry),
+            "--format",
+            "json",
+            "public-git-history-window",
+            "evaluate",
+            "--goal-id",
+            GOAL_ID,
+            "--effect-id",
+            "effect-cli-001",
+            "--action",
+            "push",
+            "--repository-visibility",
+            "public",
+            "--repository-identity",
+            "example/project",
+            "--observed-at",
+            "2026-01-05T12:00:00+00:00",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert code == 3
+    assert output["disposition"] == "defer"
+    assert output["receipt"]["effect_id"] == "effect-cli-001"
+
+
+def test_config_loader_rejects_a_tracked_policy_file(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo, registry, config = _fixture(tmp_path)
+    (repo / ".gitignore").write_text("", encoding="utf-8")
+    _git(repo, "add", str(config.relative_to(repo)))
+    configure_goal(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        public_git_history_window_config=(
+            ".loopx/config/public-history-window.json"
+        ),
+        execute=True,
+    )
+
+    code = main(
+        [
+            "--registry",
+            str(registry),
+            "--format",
+            "json",
+            "public-git-history-window",
+            "evaluate",
+            "--goal-id",
+            GOAL_ID,
+            "--effect-id",
+            "effect-cli-002",
+            "--action",
+            "push",
+            "--repository-visibility",
+            "public",
+            "--repository-identity",
+            "example/project",
+            "--observed-at",
+            "2026-01-05T18:00:00+00:00",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert code == 1
+    assert "ignored and untracked" in output["error"]
+
+
+def test_capability_catalog_declares_effect_and_enforcement_boundaries() -> None:
+    capability = next(
+        item
+        for item in BUILTIN_CAPABILITIES
+        if item["id"] == "public_git_history_window"
+    )
+
+    assert capability["provider_id"] == "loopx-core"
+    assert capability["default_enabled"] is False
+    assert {item["schema_version"] for item in capability["implemented_protocols"]} == {
+        "public_git_history_window_config_v0",
+        "public_git_history_window_decision_v0",
+        "public_git_history_window_receipt_v0",
+    }
+    assert any("Raw git callers" in value for value in capability["boundaries"])
+
+
+def test_loopx_project_skill_requires_the_goal_boundary_guard() -> None:
+    skill = Path("skills/loopx-project/SKILL.md").read_text(encoding="utf-8")
+
+    assert "goal_boundary.capabilities.public_git_history_window.enabled=true" in skill
+    assert "Never satisfy the policy by" in skill
+    assert "rewriting author or committer timestamps" in skill


### PR DESCRIPTION
## Summary

- add the opt-in `public_git_history_window` capability with typed allow/defer/reject receipts
- keep real timezone/window values in ignored goal-local config and project only a compact goal-boundary guard
- leave PR collaboration writes available, reject auto-merge without an execution-time recheck, and require verified outgoing-commit inventories for publication effects
- register the CLI/configuration/catalog surfaces and update the LoopX project skill to obey the projected guard

## Validation

- 189 focused pytest cases passed
- strict mypy passed (18 configured source files)
- scoped Ruff passed for the new package, tests, catalog, and touched quota boundary
- CLI output budget regression smoke passed
- maintainability ratchet passed after keeping dependency direction and catalog size flat
- premerge canary passed: 18 selected, 18 executed, 0 failures, 0 manual holds
- public/private boundary scan passed for all 17 changed files
- change-quality receipt: `cqr_6fd103420632faea7ad1`

## Boundary

- no real goal timezone or blocked-window value is committed
- no local goal state, receipts, logs, credentials, or private links are included
- raw Git callers that bypass the evaluator are not claimed as enforced in v0
- this runtime/publication-policy change requires independent review; auto-merge is intentionally not enabled
