### PR TITLE
feat(lark): acknowledge inbox mentions immediately

### DIFF
--- a/docs/capabilities/lark-event-inbox.md
+++ b/docs/capabilities/lark-event-inbox.md
@@ -102,10 +102,19 @@ bot profile to the same local-private chat:
     "sender_profile": "project-review-bot",
     "sender_identity": "bot",
     "bot_display_name": "Project Review Bot",
-    "chat_id": "oc_<local-private-chat-id>"
+    "chat_id": "oc_<local-private-chat-id>",
+    "received_reaction_emoji": "Get"
   }
 }
 ```
+
+`reply.received_reaction_emoji` is optional and belongs to the same explicit
+sender boundary as source-thread replies. When configured, the collector adds
+that reaction only after an event is accepted into the inbox and classified as
+a direct mention, direct question, or verified reply to the configured bot.
+The reaction is a best-effort receipt: provider failure increments compact
+failure accounting but does not discard the inbox event or grant execution
+authority. Ordinary group conversation does not receive the reaction.
 
 The reply path never uses the machine default profile. Before any send it
 verifies that the named profile resolves to the expected bot and that the bot

--- a/examples/lark-event-collector-lifecycle-smoke.py
+++ b/examples/lark-event-collector-lifecycle-smoke.py
@@ -19,12 +19,20 @@ from loopx.extensions.lark.event_collector import (  # noqa: E402
     plan_lark_event_collector,
 )
 from loopx.extensions.lark.event_collector_runtime import (  # noqa: E402
+    add_lark_event_received_reaction,
     enrich_lark_event_reply_context,
     lark_event_requires_reply_context_lookup,
     run_lark_event_collector,
 )
 from loopx.extensions.lark.event_inbox import (  # noqa: E402
     project_lark_event_inbox_urgency,
+)
+from loopx.cli_commands.lark_inbox import (  # noqa: E402
+    _collector_permissions,
+)
+from loopx.extensions.lark import (  # noqa: E402
+    LARK_COLLECTOR_PERMISSION,
+    LARK_REPLY_PERMISSION,
 )
 
 
@@ -65,6 +73,7 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-collector-") as raw:
                     "sender_identity": "bot",
                     "bot_display_name": "Project Review Bot",
                     "chat_id": "oc_private_fixture_chat",
+                    "received_reaction_emoji": "Get",
                 },
             }
         ),
@@ -130,6 +139,13 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-collector-") as raw:
             config_path=collector_config,
             runtime_root=runtime_root,
         )
+        assert _collector_permissions(
+            project=project,
+            config_path=collector_config,
+        ) == (
+            LARK_COLLECTOR_PERMISSION,
+            LARK_REPLY_PERMISSION,
+        )
         assert plan["status"] == "install_ready", plan
         assert plan["thread_complete"] is True, plan
         assert plan["profile_bound"] is True, plan
@@ -192,6 +208,79 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-collector-") as raw:
             {"message_id": "om_plain_fixture", "content": "普通群聊消息"},
             bot_display_name="Project Review Bot",
         )
+        reaction_calls: list[list[str]] = []
+
+        def reaction_runner(
+            argv: list[str], **_: object
+        ) -> subprocess.CompletedProcess[str]:
+            reaction_calls.append(list(argv))
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                stdout=json.dumps(
+                    {
+                        "ok": True,
+                        "data": {"reaction_id": "reaction_fixture"},
+                    }
+                ),
+                stderr="",
+            )
+
+        assert add_lark_event_received_reaction(
+            direct_event,
+            runner=reaction_runner,
+            command_prefix=["lark-cli"],
+            profile="project-review-bot",
+            emoji_type="Get",
+        )
+        def timeout_runner(
+            argv: list[str], **_: object
+        ) -> subprocess.CompletedProcess[str]:
+            raise subprocess.TimeoutExpired(argv, 5)
+
+        assert not add_lark_event_received_reaction(
+            direct_event,
+            runner=timeout_runner,
+            command_prefix=["lark-cli"],
+            profile="project-review-bot",
+            emoji_type="Get",
+        )
+        assert reaction_calls[0][:3] == [
+            "lark-cli",
+            "--profile",
+            "project-review-bot",
+        ], reaction_calls
+        assert reaction_calls[0][3:6] == [
+            "im",
+            "reactions",
+            "create",
+        ], reaction_calls
+        assert json.loads(
+            reaction_calls[0][reaction_calls[0].index("--data") + 1]
+        ) == {"reaction_type": {"emoji_type": "Get"}}, reaction_calls
+        invalid_inbox = json.loads(inbox_config.read_text())
+        invalid_inbox["reply"]["enabled"] = False
+        inbox_config.write_text(json.dumps(invalid_inbox), encoding="utf-8")
+        try:
+            plan_lark_event_collector(
+                project=project,
+                config_path=collector_config,
+            )
+        except ValueError as exc:
+            assert "requires enabled reply" in str(exc), exc
+        else:
+            raise AssertionError(
+                "collector accepted received reaction with disabled reply"
+            )
+        invalid_inbox["reply"]["enabled"] = True
+        invalid_inbox["reply"].pop("received_reaction_emoji")
+        inbox_config.write_text(json.dumps(invalid_inbox), encoding="utf-8")
+        assert _collector_permissions(
+            project=project,
+            config_path=collector_config,
+        ) == (LARK_COLLECTOR_PERMISSION,)
+        invalid_inbox["reply"]["received_reaction_emoji"] = "Get"
+        inbox_config.write_text(json.dumps(invalid_inbox), encoding="utf-8")
 
         messages = {
             "om_reply_fixture": {
@@ -344,6 +433,11 @@ elif "whoami" in args:
 elif "+messages-mget" in args:
     message_id = args[args.index("--message-ids") + 1]
     print(json.dumps({"items": [messages[message_id]]}))
+elif "reactions" in args and "create" in args:
+    message_id = args[args.index("--message-id") + 1]
+    if message_id == "om_runtime_direct":
+        raise SystemExit(1)
+    print(json.dumps({"ok": True, "data": {"reaction_id": "reaction_runtime"}}))
 else:
     raise SystemExit(2)
 """,
@@ -359,6 +453,9 @@ else:
         assert runtime_result["captured_count"] == 3, runtime_result
         assert runtime_result["reply_context_verified_count"] == 2, runtime_result
         assert runtime_result["reply_to_bot_count"] == 1, runtime_result
+        assert runtime_result["received_reaction_count"] == 1, runtime_result
+        assert runtime_result["received_reaction_failure_count"] == 1, runtime_result
+        assert runtime_result["external_writes_performed"] is True, runtime_result
         runtime_urgency = project_lark_event_inbox_urgency(
             project=project,
             config_path=inbox_config,

--- a/loopx/cli_commands/lark_inbox.py
+++ b/loopx/cli_commands/lark_inbox.py
@@ -28,6 +28,7 @@ from ..extensions.lark.reviewer_notification import (
 from ..extensions.lark.event_collector import (
     inspect_lark_event_collector,
     install_lark_event_collector,
+    load_lark_event_collector_config,
     plan_lark_event_collector,
 )
 from ..extensions.lark.event_collector_runtime import run_lark_event_collector
@@ -180,6 +181,18 @@ def _required_extension_permissions(command: str) -> tuple[str, ...]:
     return (LARK_COLLECTOR_PERMISSION,)
 
 
+def _collector_permissions(
+    *, project: str | Path, config_path: str | Path
+) -> tuple[str, ...]:
+    config = load_lark_event_collector_config(
+        project=project,
+        config_path=config_path,
+    )
+    if config["inbox"]["reply"].get("received_reaction_emoji"):
+        return (LARK_COLLECTOR_PERMISSION, LARK_REPLY_PERMISSION)
+    return (LARK_COLLECTOR_PERMISSION,)
+
+
 def _resolve_lark_activation(
     command: str,
     *,
@@ -292,6 +305,17 @@ def handle_lark_inbox_command(
             args.lark_inbox_command,
             runtime_root_arg=runtime_root_arg,
         )
+        if args.lark_inbox_command.startswith("collector-"):
+            required_permissions = _collector_permissions(
+                project=args.project,
+                config_path=args.config,
+            )
+            if len(required_permissions) > 1:
+                activation = resolve_extension_activation(
+                    LARK_EXTENSION_ID,
+                    state_file=default_extension_state_file(runtime_root_arg),
+                    required_permissions=required_permissions,
+                )
         if args.lark_inbox_command == "drain":
             payload = inspect_lark_event_inbox(
                 project=project,

--- a/loopx/extensions/lark/event_collector_runtime.py
+++ b/loopx/extensions/lark/event_collector_runtime.py
@@ -26,14 +26,22 @@ CommandRunner = Callable[..., subprocess.CompletedProcess[str]]
 Sleeper = Callable[[float], None]
 
 
-def _run_json(runner: CommandRunner, argv: Sequence[str]) -> object:
-    result = runner(
-        list(argv),
-        capture_output=True,
-        text=True,
-        check=False,
-        timeout=30,
-    )
+def _run_json(
+    runner: CommandRunner,
+    argv: Sequence[str],
+    *,
+    timeout_seconds: float = 30,
+) -> object:
+    try:
+        result = runner(
+            list(argv),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired:
+        return {}
     if result.returncode != 0:
         return {}
     try:
@@ -227,6 +235,47 @@ def lark_event_requires_reply_context_lookup(
     return direct_attention not in {"direct_question", "direct_mention"}
 
 
+def add_lark_event_received_reaction(
+    event: Mapping[str, Any],
+    *,
+    runner: CommandRunner,
+    command_prefix: Sequence[str],
+    profile: str,
+    emoji_type: str,
+) -> bool:
+    message_id = str(event.get("message_id") or "").strip()
+    if not MESSAGE_ID_PATTERN.fullmatch(message_id) or not emoji_type:
+        return False
+    payload = _run_json(
+        runner,
+        [
+            *command_prefix,
+            "--profile",
+            profile,
+            "im",
+            "reactions",
+            "create",
+            "--message-id",
+            message_id,
+            "--data",
+            json.dumps(
+                {"reaction_type": {"emoji_type": emoji_type}},
+                separators=(",", ":"),
+            ),
+            "--as",
+            "bot",
+            "--format",
+            "json",
+        ],
+        timeout_seconds=5,
+    )
+    return bool(
+        isinstance(payload, Mapping)
+        and payload.get("ok") is True
+        and _find_string_by_key(payload, {"reaction_id"})
+    )
+
+
 def run_lark_event_collector(
     *,
     project: str | Path,
@@ -261,6 +310,8 @@ def run_lark_event_collector(
     captured_count = 0
     verified_count = 0
     reply_to_bot_count = 0
+    received_reaction_count = 0
+    received_reaction_failure_count = 0
     profile_app_id: str | None = None
     profile_identity_checked = False
     try:
@@ -319,6 +370,26 @@ def run_lark_event_collector(
             captured_count += 1
             verified_count += int(enriched.get("reply_context_verified") is True)
             reply_to_bot_count += int(enriched.get("reply_to_bot") is True)
+            attention_kind = _event_attention_kind(
+                enriched,
+                bot_display_name=str(
+                    config["inbox"]["reply"].get("bot_display_name") or ""
+                ),
+                capture_scope="configured_chat_all",
+            )
+            received_reaction_emoji = str(
+                config["inbox"]["reply"].get("received_reaction_emoji") or ""
+            )
+            if attention_kind is not None and received_reaction_emoji:
+                reaction_added = add_lark_event_received_reaction(
+                    enriched,
+                    runner=runner,
+                    command_prefix=command_prefix,
+                    profile=str(config["profile"]),
+                    emoji_type=received_reaction_emoji,
+                )
+                received_reaction_count += int(reaction_added)
+                received_reaction_failure_count += int(not reaction_added)
         returncode = process.wait()
     finally:
         if process.poll() is None:
@@ -337,6 +408,9 @@ def run_lark_event_collector(
         "captured_count": captured_count,
         "reply_context_verified_count": verified_count,
         "reply_to_bot_count": reply_to_bot_count,
+        "received_reaction_count": received_reaction_count,
+        "received_reaction_failure_count": received_reaction_failure_count,
+        "external_writes_performed": received_reaction_count > 0,
         "profile_identity_checked": profile_identity_checked,
         "profile_identity_verified": profile_app_id is not None,
         "private_content_returned": False,

--- a/loopx/extensions/lark/event_inbox.py
+++ b/loopx/extensions/lark/event_inbox.py
@@ -21,6 +21,7 @@ MESSAGE_ID_PATTERN = re.compile(r"om_[A-Za-z0-9_-]+")
 EVENT_ID_PATTERN = re.compile(r"[A-Za-z0-9:_-]{1,200}")
 SAFE_PROFILE_PATTERN = re.compile(r"[A-Za-z0-9._-]{1,100}")
 CHAT_ID_PATTERN = re.compile(r"oc_[A-Za-z0-9_-]+")
+REACTION_EMOJI_PATTERN = re.compile(r"[A-Za-z0-9_]{1,64}")
 LARK_OPERATOR_INBOX_SOURCE_CONTRACT = OperatorInboxSourceContract(
     config_schema_version=CONFIG_SCHEMA_VERSION,
     event_schema_version=EVENT_SCHEMA_VERSION,
@@ -91,6 +92,19 @@ def load_lark_event_inbox_config(
         str(reply_payload.get("bot_display_name") or "").split()
     )[:100]
     chat_id = str(reply_payload.get("chat_id") or "").strip()
+    received_reaction_emoji = str(
+        reply_payload.get("received_reaction_emoji") or ""
+    ).strip()
+    if received_reaction_emoji and not REACTION_EMOJI_PATTERN.fullmatch(
+        received_reaction_emoji
+    ):
+        raise ValueError(
+            "lark inbox received_reaction_emoji must be a valid emoji type"
+        )
+    if received_reaction_emoji and not reply_enabled:
+        raise ValueError(
+            "lark inbox received_reaction_emoji requires enabled reply"
+        )
     if reply_enabled and (
         capture_scope != "configured_chat_all"
         or not SAFE_PROFILE_PATTERN.fullmatch(sender_profile)
@@ -115,6 +129,7 @@ def load_lark_event_inbox_config(
             "sender_identity": sender_identity,
             "bot_display_name": bot_display_name,
             "chat_id": chat_id,
+            "received_reaction_emoji": received_reaction_emoji,
         },
     }
 


### PR DESCRIPTION
## Summary
- optionally add an immediate received reaction for actionable Lark inbox events
- keep the reaction inside the existing explicit reply sender boundary
- preserve inbox delivery when the reaction provider times out or fails
- require `lark.reply.send` only for collector configurations that enable the reaction

## Behavior
Set `reply.received_reaction_emoji` (for example `Get`) in the local-private inbox config. After an event is accepted into the inbox, direct mentions, direct questions, and provider-verified replies to the configured bot receive the reaction. Ordinary group conversation does not.

The reaction is best effort: failures are counted in the compact collector result and never discard the inbox event. Duplicate event delivery does not add another reaction because the inbox dedupe rejects the event before the reaction path.

## Validation
- `python examples/lark-event-collector-lifecycle-smoke.py`
- `python examples/lark-event-inbox-smoke.py`
- `python examples/control_plane/lark-inbox-priority-smoke.py`
- `python examples/lark-extension-activation-smoke.py`
- `ruff` and `compileall` on changed Python files
- `loopx check` public-boundary scan: 5 files, 0 errors, 0 warnings
- remote branch verified as one commit on current `main`, with exactly the five intended files

The broad premerge auto-selector was not used as evidence because the available full release overlay predates unrelated current-main files and therefore produced an inflated 619-file diff. The targeted extension-runtime set above covers the changed capability and permission boundary without attributing unrelated checks to this PR.
