### PR TITLE
feat(scheduler): project typed loopx-apply-rrule fallback_hint in codex_app scheduler hint

### DIFF
--- a/docs/heartbeat-automation-prompt.md
+++ b/docs/heartbeat-automation-prompt.md
@@ -541,12 +541,24 @@ hint directly, otherwise do nothing. For the uniquely matched current heartbeat,
 `quota should-run` reconciles the installed RRULE with the ACK ledger; a
 `host_observation.status=drift_detected` result reopens `apply_needed`:
 
+If `automation_update` is unavailable in the session and
+`scheduler_hint.codex_app.fallback_hint.available=true`, run the bound
+`fallback_hint.cli_args` (`loopx-apply-rrule`) once instead. It backs up
+`codex-dev.db`, syncs the automation TOML and SQLite row, and runs the bound
+ACK; direct SQLite edits bypass the app API, so this is a bounded fallback and
+never the routine path. When the automation id could not be resolved,
+`fallback_hint.available=false` and the pasteable heartbeat gate is the correct
+stop - never guess an automation id.
+
 ```text
 Create a heartbeat automation starting at 3 minutes for the current thread;
 then apply `quota should-run.scheduler_hint`: update RRULE only when
 `apply_needed=true`, trying once per hint and turn; ack with the provided
 `ack_hint.cli_args` only after the host update succeeds, or run the provided
-`failure_hint.cli_args` once if that update fails or times out.
+`failure_hint.cli_args` once if that update fails or times out. If
+`automation_update` is unavailable and `fallback_hint.available=true`, run the
+provided `fallback_hint.cli_args` once instead; if it is unavailable, surface
+the pasteable heartbeat gate.
 
 Task:
 Advance <GOAL_ID> using <ACTIVE_GOAL_STATE_PATH>. Before any delivery work,

--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -861,6 +861,13 @@ when `codex_app.stateful_backoff.apply_needed=true`; if the desired RRULE is
 already applied, it is omitted so the agent does not call a host tool again.
 If that match still needs a reset-token/identity binding,
 `stateful_backoff.ack_needed=true` and the bound ack runs without a host update.
+When an apply is required but `automation_update` is unavailable in the
+session, `codex_app.fallback_hint` carries the bounded `loopx-apply-rrule`
+command for the resolved automation (backup `codex-dev.db`, sync TOML+SQLite,
+run the bound ACK). Direct SQLite edits bypass the app API, so the fallback is
+projected only for this gap and never as the routine path; an unresolved
+automation id projects `available=false` and requires the pasteable heartbeat
+gate instead of guessing.
 After a successful host RRULE update, the agent records that fact with
 `loopx` plus `codex_app.ack_hint.cli_args`; current payloads use
 `quota scheduler-ack-current` to re-read the latest scheduler hint before LoopX

--- a/loopx/control_plane/heartbeat/rules.py
+++ b/loopx/control_plane/heartbeat/rules.py
@@ -23,16 +23,20 @@ HEARTBEAT_VISION_WRITEBACK_RULE_SHORT = (
 )
 SCHEDULER_HINT_APPLICATION_RULE = (
     "`scheduler_hint` no-spend. host_action=pause_or_delete_current_heartbeat -> "
-    "automation_update stop once, verify, end; else apply_needed -> RRULE then "
-    "ack/failure_hint; ack_needed -> ack."
+    "automation_update stop once, verify, end; else apply_needed -> RRULE via "
+    "automation_update; if automation_update is unavailable or fails, execute "
+    "fallback_hint.cli_args (loopx-apply-rrule; direct SQLite write bypasses the "
+    "app API - fallback only), then ack; further failure -> failure_hint; "
+    "ack_needed -> ack."
 )
 SCHEDULER_HINT_COMPACT_RULE = (
     "host_action=pause_or_delete_current_heartbeat: automation_update stop; "
-    "else RRULE apply/ack/fail. No spend."
+    "else RRULE apply via automation_update, fallback_hint when unavailable, "
+    "then ack/fail. No spend."
 )
 SCHEDULER_HINT_THIN_RULE = (
     "host_action=pause_or_delete_current_heartbeat->automation_update stop(no-spend); "
-    "else RRULE/ack/fail."
+    "else RRULE via automation_update, fallback_hint when unavailable, then ack/fail."
 )
 RUNTIME_CAPABILITY_PROJECTION_THIN_RULE = (
     "Observed capabilities -> `--available-capability`; never user gates."

--- a/loopx/control_plane/heartbeat/rules.py
+++ b/loopx/control_plane/heartbeat/rules.py
@@ -24,9 +24,8 @@ HEARTBEAT_VISION_WRITEBACK_RULE_SHORT = (
 SCHEDULER_HINT_APPLICATION_RULE = (
     "`scheduler_hint` no-spend. host_action=pause_or_delete_current_heartbeat -> "
     "automation_update stop once, verify, end; else apply_needed -> RRULE via "
-    "automation_update; if automation_update is unavailable or fails, execute "
-    "fallback_hint.cli_args (loopx-apply-rrule; direct SQLite write bypasses the "
-    "app API - fallback only), then ack; further failure -> failure_hint; "
+    "automation_update; unavailable -> fallback_hint.cli_args (SQLite/app API "
+    "bypass - fallback only), then ack; further failure -> failure_hint; "
     "ack_needed -> ack."
 )
 SCHEDULER_HINT_COMPACT_RULE = (
@@ -36,7 +35,7 @@ SCHEDULER_HINT_COMPACT_RULE = (
 )
 SCHEDULER_HINT_THIN_RULE = (
     "host_action=pause_or_delete_current_heartbeat->automation_update stop(no-spend); "
-    "else RRULE via automation_update, fallback_hint when unavailable, then ack/fail."
+    "else RRULE/fallback_hint/ack/fail."
 )
 RUNTIME_CAPABILITY_PROJECTION_THIN_RULE = (
     "Observed capabilities -> `--available-capability`; never user gates."

--- a/loopx/control_plane/quota/live_decision.py
+++ b/loopx/control_plane/quota/live_decision.py
@@ -29,12 +29,30 @@ def bind_scheduler_followup_cli_routes(
     codex_app = scheduler_hint.get("codex_app")
     if not isinstance(codex_app, dict):
         return
-    for hint_name in ("ack_hint", "failure_hint"):
+    for hint_name in ("ack_hint", "failure_hint", "fallback_hint"):
         followup_hint = codex_app.get(hint_name)
         if not isinstance(followup_hint, dict):
             continue
         cli_args = followup_hint.get("cli_args")
-        if not isinstance(cli_args, list) or not cli_args or cli_args[0] == "--registry":
+        if not isinstance(cli_args, list) or not cli_args:
+            continue
+        if hint_name == "fallback_hint":
+            if cli_args[0] != "loopx-apply-rrule" or "--registry" in cli_args:
+                continue
+            followup_hint["cli_args"] = [
+                cli_args[0],
+                "--registry",
+                str(registry_path.expanduser().resolve()),
+                *cli_args[1:],
+            ]
+            followup_hint["route_binding"] = {
+                "schema_version": "codex_app_scheduler_fallback_route_v0",
+                "source": source,
+                "registry_bound": True,
+                "runtime_root_bound": False,
+            }
+            continue
+        if cli_args[0] == "--registry":
             continue
         followup_hint["cli_args"] = [
             "--registry",
@@ -79,6 +97,7 @@ def build_live_quota_should_run_decision(
         and resolved_context.context.codex_app_applicable
     )
     observed_rrule = str(codex_app_current_rrule or "").strip()
+    observed_automation_id = ""
     if (
         codex_app_applicable
         and not observed_rrule
@@ -87,6 +106,7 @@ def build_live_quota_should_run_decision(
         observation = host_observation_resolver(goal_id=goal_id, agent_id=agent_id)
         if observation.get("available") is True:
             observed_rrule = str(observation.get("rrule") or "")
+            observed_automation_id = str(observation.get("automation_id") or "").strip()
     payload = build_quota_should_run(
         status_payload,
         goal_id=goal_id,
@@ -94,6 +114,7 @@ def build_live_quota_should_run_decision(
         available_capabilities=available_capabilities,
         include_scheduler_detail=include_scheduler_detail,
         codex_app_current_rrule=observed_rrule,
+        codex_app_automation_id=observed_automation_id or None,
         scheduler_execution_context=resolved_context,
         operator_inbox_urgency_projector=operator_inbox_urgency_projector,
     )

--- a/loopx/control_plane/quota/should_run.py
+++ b/loopx/control_plane/quota/should_run.py
@@ -52,6 +52,7 @@ def build_quota_paused_should_run_payload(
     goal_health_ok: bool,
     include_scheduler_detail: bool,
     codex_app_current_rrule: Any,
+    codex_app_automation_id: Any = None,
     resolved_scheduler_context: SchedulerExecutionContextResolution,
 ) -> dict[str, Any]:
     """Project one canonical paused contract with no contradicting lane authority.
@@ -127,6 +128,7 @@ def build_quota_paused_should_run_payload(
         include_detail=include_scheduler_detail,
         available_capabilities=None,
         codex_app_current_rrule=codex_app_current_rrule,
+        codex_app_automation_id=codex_app_automation_id,
         scheduler_execution_context=resolved_scheduler_context,
     )
     payload["protocol_action_packet"] = build_protocol_action_packet(payload)
@@ -141,6 +143,7 @@ def build_quota_should_run(
     available_capabilities: Any = None,
     include_scheduler_detail: bool = False,
     codex_app_current_rrule: Any = None,
+    codex_app_automation_id: Any = None,
     scheduler_execution_context: (
         Mapping[str, Any] | SchedulerExecutionContextResolution | None
     ) = None,
@@ -187,6 +190,7 @@ def build_quota_should_run(
                 goal_health_ok=goal_health_ok,
                 include_scheduler_detail=include_scheduler_detail,
                 codex_app_current_rrule=codex_app_current_rrule,
+                codex_app_automation_id=codex_app_automation_id,
                 resolved_scheduler_context=resolved_scheduler_context,
             )
         prepared = _prepare_quota_should_run_item(
@@ -196,6 +200,7 @@ def build_quota_should_run(
             available_capabilities=available_capabilities,
             include_scheduler_detail=include_scheduler_detail,
             codex_app_current_rrule=codex_app_current_rrule,
+            codex_app_automation_id=codex_app_automation_id,
             resolved_scheduler_context=resolved_scheduler_context,
             operator_inbox_urgency_projector=operator_inbox_urgency_projector,
             registry_goal=registry_goal,

--- a/loopx/control_plane/quota/should_run_packet.py
+++ b/loopx/control_plane/quota/should_run_packet.py
@@ -139,6 +139,7 @@ def _compact_autonomous_candidate_context(
 def _scheduler_hint(
     payload: dict[str, Any], *, include_detail: bool = False,
     codex_app_scheduler_state: dict[str, Any] | None = None, available_capabilities: Any = None, codex_app_current_rrule: Any = None,
+    codex_app_automation_id: Any = None,
     scheduler_execution_context: Mapping[str, Any] | SchedulerExecutionContextResolution | None = None,
 ) -> dict[str, Any]:
     return build_scheduler_hint(
@@ -148,6 +149,7 @@ def _scheduler_hint(
         include_detail=include_detail,
         codex_app_scheduler_state=codex_app_scheduler_state,
         available_capabilities=available_capabilities, codex_app_current_rrule=codex_app_current_rrule,
+        codex_app_automation_id=codex_app_automation_id,
         scheduler_execution_context=scheduler_execution_context,
     )
 
@@ -1094,6 +1096,7 @@ def _build_quota_should_run_payload(
             else None
         ),
         codex_app_current_rrule=prepared.codex_app_current_rrule,
+        codex_app_automation_id=prepared.codex_app_automation_id,
         scheduler_execution_context=prepared.resolved_scheduler_context,
     )
     finalize_user_gate_notification_cooldown(

--- a/loopx/control_plane/quota/should_run_prepare.py
+++ b/loopx/control_plane/quota/should_run_prepare.py
@@ -130,6 +130,7 @@ class _QuotaDecisionPreparation:
     boundary_projection_repair: dict[str, Any] | None
     include_scheduler_detail: bool
     codex_app_current_rrule: Any
+    codex_app_automation_id: Any
     resolved_scheduler_context: SchedulerExecutionContextResolution
 
 def _same_todo_identity(left: dict[str, Any], right: dict[str, Any]) -> bool:
@@ -347,6 +348,7 @@ def _prepare_quota_should_run_item(
     available_capabilities: Any,
     include_scheduler_detail: bool,
     codex_app_current_rrule: Any,
+    codex_app_automation_id: Any = None,
     resolved_scheduler_context: SchedulerExecutionContextResolution,
     operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None,
     registry_goal: dict[str, Any],
@@ -660,5 +662,6 @@ def _prepare_quota_should_run_item(
         boundary_projection_repair=boundary_projection_repair,
         include_scheduler_detail=include_scheduler_detail,
         codex_app_current_rrule=codex_app_current_rrule,
+        codex_app_automation_id=codex_app_automation_id,
         resolved_scheduler_context=resolved_scheduler_context,
     )

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from collections.abc import Collection, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -51,9 +52,13 @@ SCHEDULER_HINT_DETAIL_SCHEMA_VERSION = "scheduler_hint_detail_v0"
 CODEX_APP_STATEFUL_BACKOFF_SCHEMA_VERSION = "codex_app_stateful_backoff_v0"
 CODEX_APP_SCHEDULER_ACK_HINT_SCHEMA_VERSION = "codex_app_scheduler_ack_hint_v0"
 CODEX_APP_SCHEDULER_FAILURE_HINT_SCHEMA_VERSION = "codex_app_scheduler_failure_hint_v0"
+CODEX_APP_SCHEDULER_FALLBACK_HINT_SCHEMA_VERSION = (
+    "codex_app_scheduler_fallback_hint_v0"
+)
 USER_GATE_NOTIFICATION_COOLDOWN_SCHEMA_VERSION = "user_gate_notification_cooldown_v0"
 CODEX_APP_MAX_INTERVAL_MINUTES = 60
 DEFAULT_ACK_CAPABILITIES = {"shell", "filesystem_read", "filesystem_write"}
+FALLBACK_AUTOMATION_ID_PATTERN = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
 SCHEDULER_BASE_IDENTITY_KEYS = (
     "goal_id",
     "agent_identity.agent_id",
@@ -331,6 +336,70 @@ def build_codex_app_scheduler_failure_hint(
     }
 
 
+def build_codex_app_scheduler_fallback_hint(
+    *,
+    goal_id: Any,
+    agent_id: Any,
+    automation_id: Any,
+    turn_instance_id: Any = "${LOOPX_TURN:?}",
+) -> dict[str, Any]:
+    """Project the bounded SQLite/TOML RRULE fallback for automation_update gaps.
+
+    The fallback is a standalone host bridge (``loopx-apply-rrule``) that backs
+    up ``codex-dev.db``, syncs the automation TOML and SQLite row, and runs the
+    bound scheduler ACK. It directly edits the Codex App automation store,
+    bypassing the app API, so it is projected only when the host tool is
+    unavailable or failed and ``apply_needed=true`` - never as the routine path.
+    """
+
+    safe_goal_id = str(goal_id or "").strip()
+    safe_agent_id = str(agent_id or "").strip()
+    safe_automation_id = str(automation_id or "").strip()
+    safe_turn_instance_id = str(turn_instance_id or "").strip() or "${LOOPX_TURN:?}"
+    if not FALLBACK_AUTOMATION_ID_PATTERN.match(safe_automation_id):
+        return {
+            "schema_version": CODEX_APP_SCHEDULER_FALLBACK_HINT_SCHEMA_VERSION,
+            "available": False,
+            "reason": (
+                "automation_id_unresolved: no unique matching Codex App heartbeat "
+                "automation for this goal/agent; do not guess an automation id"
+            ),
+            "action": "surface_pasteable_heartbeat_gate",
+        }
+    cli_args = [
+        "loopx-apply-rrule",
+        "--goal-id",
+        safe_goal_id,
+        "--agent-id",
+        safe_agent_id,
+        "--automation-id",
+        safe_automation_id,
+        "--turn-instance-id",
+        safe_turn_instance_id,
+    ]
+    return {
+        "schema_version": CODEX_APP_SCHEDULER_FALLBACK_HINT_SCHEMA_VERSION,
+        "available": True,
+        "command": "loopx-apply-rrule",
+        "after": "automation_update_unavailable_or_failed",
+        "cli_args": cli_args,
+        "args": {
+            "goal_id": safe_goal_id,
+            "agent_id": safe_agent_id,
+            "automation_id": safe_automation_id,
+            "turn_instance_id": safe_turn_instance_id,
+        },
+        "no_spend": True,
+        "reason": (
+            "fallback only when automation_update is unavailable or failed and "
+            "apply_needed=true; loopx-apply-rrule directly updates the Codex App "
+            "SQLite automation store (codex-dev.db) and TOML, which bypasses the "
+            "app API - use only as a bounded fallback, never as the routine path; "
+            "run the bound ack_hint after it succeeds"
+        ),
+    }
+
+
 @dataclass(frozen=True)
 class _SchedulerHintBuilder:
     payload: dict[str, Any]
@@ -340,6 +409,7 @@ class _SchedulerHintBuilder:
     scheduler_ack_capabilities: Any
     codex_app_scheduler_state: dict[str, Any] | None
     codex_app_current_rrule: Any
+    codex_app_automation_id: Any
     include_detail: bool
 
     def _identity_value(self, path: str) -> Any:
@@ -655,6 +725,11 @@ class _SchedulerHintBuilder:
                     observed_host_rrule=effective_host_rrule,
                     available_capabilities=self.scheduler_ack_capabilities,
                 )
+                codex_app["fallback_hint"] = build_codex_app_scheduler_fallback_hint(
+                    goal_id=goal_id,
+                    agent_id=agent_id,
+                    automation_id=self.codex_app_automation_id,
+                )
         if ack_needed and goal_id and agent_id:
             codex_app["ack_hint"] = build_codex_app_scheduler_ack_hint(
                 goal_id=goal_id,
@@ -783,6 +858,7 @@ def build_scheduler_hint(
     codex_app_scheduler_state: dict[str, Any] | None = None,
     available_capabilities: Any = None,
     codex_app_current_rrule: Any = None,
+    codex_app_automation_id: Any = None,
     scheduler_execution_context: (
         Mapping[str, Any] | SchedulerExecutionContextResolution | None
     ) = None,
@@ -950,6 +1026,7 @@ def build_scheduler_hint(
         scheduler_ack_capabilities=scheduler_ack_capabilities,
         codex_app_scheduler_state=codex_app_scheduler_state,
         codex_app_current_rrule=codex_app_current_rrule,
+        codex_app_automation_id=codex_app_automation_id,
         include_detail=include_detail,
     )
     if arbitration.disposition == SchedulerDisposition.AGENT_MONITOR_ONLY_WAIT:

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -790,6 +790,7 @@ def build_quota_should_run(
     available_capabilities: Any = None,
     include_scheduler_detail: bool = False,
     codex_app_current_rrule: Any = None,
+    codex_app_automation_id: Any = None,
     scheduler_execution_context: (
         Mapping[str, Any] | SchedulerExecutionContextResolution | None
     ) = None,
@@ -806,6 +807,7 @@ def build_quota_should_run(
         available_capabilities=available_capabilities,
         include_scheduler_detail=include_scheduler_detail,
         codex_app_current_rrule=codex_app_current_rrule,
+        codex_app_automation_id=codex_app_automation_id,
         scheduler_execution_context=scheduler_execution_context,
         operator_inbox_urgency_projector=operator_inbox_urgency_projector,
     )

--- a/loopx/upgrade.py
+++ b/loopx/upgrade.py
@@ -344,6 +344,7 @@ def resolve_codex_app_automation_rrule(
     return {
         "available": True,
         "rrule": entry["rrule"],
+        "automation_id": str(entry.get("automation_id") or "").strip(),
         "source": "codex_app_automation_manifest",
     }
 

--- a/tests/control_plane/test_scheduler_fallback_hint.py
+++ b/tests/control_plane/test_scheduler_fallback_hint.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from loopx.control_plane.heartbeat.rules import (
+    SCHEDULER_HINT_APPLICATION_RULE,
+    SCHEDULER_HINT_COMPACT_RULE,
+    SCHEDULER_HINT_THIN_RULE,
+)
+from loopx.control_plane.quota.live_decision import (
+    bind_scheduler_followup_cli_routes,
+)
+from loopx.control_plane.scheduler.ack import build_codex_app_scheduler_ack_event
+from loopx.control_plane.scheduler.execution_context import (
+    scheduler_execution_context_for_runtime_profile,
+)
+from loopx.control_plane.scheduler.scheduler_hint import build_scheduler_hint
+from loopx.upgrade import resolve_codex_app_automation_rrule
+
+
+GOAL_ID = "fallback-hint-goal"
+AGENT_ID = "codex-fixture"
+APP_CONTEXT = scheduler_execution_context_for_runtime_profile("codex_app_heartbeat")
+
+
+def _active_decision() -> dict:
+    return {
+        "goal_id": GOAL_ID,
+        "agent_identity": {"agent_id": AGENT_ID},
+        "should_run": True,
+        "effective_action": "normal_run",
+        "recommended_action": "run the next bounded segment",
+        "heartbeat_recommendation": {
+            "recommended_mode": "steering_audit_then_one_step",
+            "notify": "DONT_NOTIFY",
+        },
+        "execution_obligation": {
+            "must_attempt_work": True,
+            "kind": "work_lane_contract",
+            "contract_obligation": "advance_one_bounded_segment",
+        },
+        "interaction_contract": {
+            "schema_version": "loopx_interaction_contract_v0",
+            "mode": "bounded_delivery",
+            "user_channel": {"action_required": False, "notify": "DONT_NOTIFY"},
+            "agent_channel": {
+                "must_attempt": True,
+                "delivery_allowed": True,
+                "quiet_noop_allowed": False,
+            },
+        },
+        "automation_liveness": {
+            "keep_active": True,
+            "automation_action": "execute_bounded_work",
+            "spend_policy": "spend once only after validated writeback",
+        },
+        "capability_gate": {
+            "action": "run",
+            "available": ["shell", "filesystem_read", "filesystem_write"],
+        },
+    }
+
+
+def _hint(
+    decision: dict,
+    *,
+    scheduler_state: dict | None = None,
+    host_rrule: str | None = None,
+    automation_id: str | None = None,
+) -> dict:
+    return build_scheduler_hint(
+        decision,
+        codex_app_scheduler_state=scheduler_state,
+        codex_app_current_rrule=host_rrule,
+        codex_app_automation_id=automation_id,
+        scheduler_execution_context=APP_CONTEXT,
+    )
+
+
+def _ack_state(hint: dict, *, applied_rrule: str, generated_at: datetime) -> dict:
+    event = build_codex_app_scheduler_ack_event(
+        {"goal_id": GOAL_ID, "scheduler_hint": hint},
+        agent_id=AGENT_ID,
+        applied_rrule=applied_rrule,
+        generated_at=generated_at.isoformat(),
+    )
+    return event["scheduler_ack_event"]["scheduler_state"]
+
+
+def test_apply_needed_projects_fallback_hint_when_automation_id_resolved() -> None:
+    hint = _hint(_active_decision(), automation_id="loopx")
+    codex_app = hint["codex_app"]
+    assert codex_app["stateful_backoff"]["apply_needed"] is True
+
+    fallback = codex_app["fallback_hint"]
+    assert fallback["available"] is True
+    assert fallback["schema_version"] == "codex_app_scheduler_fallback_hint_v0"
+    assert fallback["command"] == "loopx-apply-rrule"
+    assert fallback["cli_args"][0] == "loopx-apply-rrule"
+    assert "--goal-id" in fallback["cli_args"]
+    assert GOAL_ID in fallback["cli_args"]
+    assert "--agent-id" in fallback["cli_args"]
+    assert AGENT_ID in fallback["cli_args"]
+    assert "--automation-id" in fallback["cli_args"]
+    assert "loopx" in fallback["cli_args"]
+    assert "--turn-instance-id" in fallback["cli_args"]
+    assert "${LOOPX_TURN:?}" in fallback["cli_args"]
+    assert "bypasses" in fallback["reason"]
+    assert "never as the routine path" in fallback["reason"]
+    assert codex_app["failure_hint"]["cli_args"][0] == "quota"
+
+
+def test_apply_needed_without_automation_id_emits_gate_not_guess() -> None:
+    hint = _hint(_active_decision(), automation_id=None)
+    fallback = hint["codex_app"]["fallback_hint"]
+    assert fallback["available"] is False
+    assert fallback["reason"].startswith("automation_id_unresolved")
+    assert "do not guess an automation id" in fallback["reason"]
+    assert fallback["action"] == "surface_pasteable_heartbeat_gate"
+    assert "cli_args" not in fallback
+
+
+def test_settled_cadence_omits_fallback_hint() -> None:
+    now = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    first = _hint(_active_decision(), automation_id="loopx")
+    applied_rrule = first["codex_app"]["recommended_rrule"]
+    settled = _ack_state(first, applied_rrule=applied_rrule, generated_at=now)
+
+    second = _hint(
+        _active_decision(),
+        scheduler_state=settled,
+        host_rrule=applied_rrule,
+        automation_id="loopx",
+    )
+    assert second["codex_app"]["stateful_backoff"]["apply_needed"] is False
+    assert "fallback_hint" not in second["codex_app"]
+
+
+def test_fallback_hint_cli_route_binds_registry(tmp_path: Path) -> None:
+    payload = {
+        "scheduler_hint": {
+            "codex_app": {
+                "fallback_hint": {
+                    "cli_args": [
+                        "loopx-apply-rrule",
+                        "--goal-id",
+                        GOAL_ID,
+                        "--agent-id",
+                        AGENT_ID,
+                        "--automation-id",
+                        "loopx",
+                        "--turn-instance-id",
+                        "${LOOPX_TURN:?}",
+                    ],
+                }
+            }
+        }
+    }
+    registry_path = tmp_path / "registry.json"
+    bind_scheduler_followup_cli_routes(
+        payload,
+        registry_path=registry_path,
+        runtime_root=tmp_path / "runtime",
+    )
+    fallback = payload["scheduler_hint"]["codex_app"]["fallback_hint"]
+    assert fallback["cli_args"][:3] == [
+        "loopx-apply-rrule",
+        "--registry",
+        str(registry_path.resolve()),
+    ]
+    assert fallback["route_binding"]["schema_version"] == (
+        "codex_app_scheduler_fallback_route_v0"
+    )
+    assert fallback["route_binding"]["registry_bound"] is True
+    assert fallback["route_binding"]["runtime_root_bound"] is False
+
+
+def test_heartbeat_scheduler_rules_name_the_fallback(tmp_path: Path) -> None:
+    for rule in (
+        SCHEDULER_HINT_APPLICATION_RULE,
+        SCHEDULER_HINT_COMPACT_RULE,
+        SCHEDULER_HINT_THIN_RULE,
+    ):
+        assert "fallback_hint" in rule
+    assert "SQLite" in SCHEDULER_HINT_APPLICATION_RULE
+    assert "app API" in SCHEDULER_HINT_APPLICATION_RULE
+
+
+def test_resolve_codex_app_automation_rrule_returns_automation_id(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("CODEX_THREAD_ID", raising=False)
+    automation_path = tmp_path / "automations" / "fixture" / "automation.toml"
+    automation_path.parent.mkdir(parents=True, exist_ok=True)
+    automation_path.write_text(
+        "\n".join(
+            [
+                "version = 1",
+                'id = "fixture"',
+                'kind = "heartbeat"',
+                'name = "Fallback fixture"',
+                (
+                    'prompt = "Advance `fallback-hint-goal` from active state. '
+                    'Agent: `codex-fixture`."'
+                ),
+                'status = "ACTIVE"',
+                'rrule = "FREQ=MINUTELY;INTERVAL=3"',
+                'target_thread_id = "fixture-thread"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = resolve_codex_app_automation_rrule(
+        goal_id="fallback-hint-goal",
+        agent_id="codex-fixture",
+        root=tmp_path,
+    )
+    assert result["available"] is True
+    assert result["automation_id"] == "fixture"


### PR DESCRIPTION
## What

When `scheduler_hint.codex_app.stateful_backoff.apply_needed=true` and the host observation resolves exactly one Codex App heartbeat automation id, quota now projects a typed `fallback_hint` whose `cli_args` run `loopx-apply-rrule` (backup `codex-dev.db`, sync TOML + SQLite row, run the bound ACK). When the automation id cannot be resolved, `fallback_hint.available=false` with `action=surface_pasteable_heartbeat_gate` - never a guessed id.

Heartbeat prompt rules (application/compact/thin) and docs now name the fallback path and the API-bypass constraint so the direct SQLite store edit is used only when `automation_update` is unavailable or failed, never as the routine path.

## Changes

- `scheduler_hint.codex_app` gains `fallback_hint` (schema `codex_app_scheduler_fallback_hint_v0`)
- `resolve_codex_app_automation_rrule` returns `automation_id` so the hint can bind the exact automation
- `bind_scheduler_followup_cli_routes` binds `--registry` into the fallback command route
- Heartbeat prompt rules and heartbeat/quota docs updated
- Focused tests: 6 new cases (resolved id, unresolved gate, settled omission, CLI route binding, prompt rules, automation-id resolution)

## Validation

- New focused tests: 6 passed
- Related scheduler/heartbeat/apply-rrule suite: 55 passed
- Broader quota/upgrade/heartbeat suite: 176 passed; 10 pre-existing TraeX env failures (scripts/loopx Python 3.9 wrapper) unrelated to this diff
- Canary premerge: 18/18 checks passed (catalog 9, risk profiles 8, public boundary 1), direct checks passed, boundary scan clean