### PR TITLE
fix(scheduler): project fallback automation id and create missing heartbeat automation

### DIFF
--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -66,6 +66,31 @@ SCHEDULER_BASE_IDENTITY_KEYS = (
     "heartbeat_recommendation.recommended_mode",
     "interaction_contract.mode",
 )
+
+
+def build_projected_codex_app_automation_id(
+    *,
+    goal_id: Any,
+    agent_id: Any,
+) -> str:
+    """Build a deterministic Codex App automation id when none is installed yet.
+
+    The fallback bridge needs a stable automation id to create the first
+    heartbeat automation for a goal/agent pair. The id is derived from the
+    same identity keys used by the scheduler so a later run can resolve it
+    back to the installed automation without guessing.
+    """
+
+    safe_goal_id = str(goal_id or "").strip()
+    safe_agent_id = str(agent_id or "").strip()
+    raw = (
+        f"loopx-{safe_goal_id}-{safe_agent_id}"
+        if safe_agent_id
+        else f"loopx-{safe_goal_id}"
+    )
+    projected = re.sub(r"[^A-Za-z0-9._:-]", "-", raw)
+    projected = re.sub(r"-+", "-", projected).strip("-")
+    return projected[:128] or "loopx-fallback"
 SCHEDULER_FRONTIER_IDENTITY_KEYS = (
     "selected_todo.todo_id",
     "selected_todo.action_kind",
@@ -350,22 +375,21 @@ def build_codex_app_scheduler_fallback_hint(
     bound scheduler ACK. It directly edits the Codex App automation store,
     bypassing the app API, so it is projected only when the host tool is
     unavailable or failed and ``apply_needed=true`` - never as the routine path.
+    When no automation is installed yet, a deterministic automation id is
+    projected so the fallback bridge can create the first heartbeat automation.
     """
 
     safe_goal_id = str(goal_id or "").strip()
     safe_agent_id = str(agent_id or "").strip()
     safe_automation_id = str(automation_id or "").strip()
     safe_turn_instance_id = str(turn_instance_id or "").strip() or "${LOOPX_TURN:?}"
+    projected_automation_id = False
     if not FALLBACK_AUTOMATION_ID_PATTERN.match(safe_automation_id):
-        return {
-            "schema_version": CODEX_APP_SCHEDULER_FALLBACK_HINT_SCHEMA_VERSION,
-            "available": False,
-            "reason": (
-                "automation_id_unresolved: no unique matching Codex App heartbeat "
-                "automation for this goal/agent; do not guess an automation id"
-            ),
-            "action": "surface_pasteable_heartbeat_gate",
-        }
+        safe_automation_id = build_projected_codex_app_automation_id(
+            goal_id=safe_goal_id,
+            agent_id=safe_agent_id,
+        )
+        projected_automation_id = True
     cli_args = [
         "loopx-apply-rrule",
         "--goal-id",
@@ -396,6 +420,21 @@ def build_codex_app_scheduler_fallback_hint(
             "SQLite automation store (codex-dev.db) and TOML, which bypasses the "
             "app API - use only as a bounded fallback, never as the routine path; "
             "run the bound ack_hint after it succeeds"
+            + (
+                "; automation_id_projected: no installed heartbeat automation "
+                "matched this goal/agent, so loopx-apply-rrule will create it "
+                "before applying the rrule"
+                if projected_automation_id
+                else ""
+            )
+        ),
+        **(
+            {
+                "automation_id_projected": True,
+                "action": "create_then_apply_rrule_via_fallback",
+            }
+            if projected_automation_id
+            else {}
         ),
     }
 

--- a/scripts/codex_app_apply_rrule.py
+++ b/scripts/codex_app_apply_rrule.py
@@ -6,8 +6,9 @@ Fallback host bridge for hosts where the Codex App does not expose
 
 1. reads ``loopx quota should-run`` and its ``scheduler_hint.codex_app``;
 2. when ``stateful_backoff.apply_needed=true`` and ``recommended_rrule`` is
-   present, backs up the Codex App automation SQLite database, updates both
-   the automation TOML and the ``automations`` row to the recommended RRULE;
+   present, creates the automation TOML and ``automations`` row when they are
+   missing, backs up the Codex App automation SQLite database, and updates
+   both stores to the recommended RRULE;
 3. runs the bound ``ack_hint.cli_args`` so LoopX persists the reset token and
    progression index.
 
@@ -30,6 +31,250 @@ from typing import Any
 
 def _now_ms() -> int:
     return int(time.time() * 1000)
+
+
+def _load_registry_goal(registry: Path, goal_id: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(registry.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    goals = payload.get("goals") if isinstance(payload, dict) else None
+    if not isinstance(goals, list):
+        return {}
+    for goal in goals:
+        if isinstance(goal, dict) and str(goal.get("id") or "") == goal_id:
+            return goal
+    return {}
+
+
+def _heartbeat_task_body(
+    *,
+    loopx: str,
+    registry: Path,
+    goal_id: str,
+    agent_id: str,
+) -> str:
+    command = [
+        loopx,
+        "--format",
+        "json",
+        "--registry",
+        str(registry),
+        "heartbeat-prompt",
+        "--thin",
+        "--goal-id",
+        goal_id,
+        "--agent-id",
+        agent_id,
+        "--codex-app",
+    ]
+    completed = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise SystemExit(
+            f"loopx heartbeat-prompt failed ({completed.returncode}): "
+            f"{completed.stderr[-500:]}"
+        )
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"loopx heartbeat-prompt returned invalid JSON: {exc}") from exc
+    body = payload.get("task_body") if isinstance(payload, dict) else None
+    if not isinstance(body, str) or not body.strip():
+        raise SystemExit("loopx heartbeat-prompt returned no task_body")
+    if '"""' in body:
+        raise SystemExit("loopx heartbeat-prompt task_body contains triple quotes")
+    return body
+
+
+def _write_automation_toml(
+    path: Path,
+    *,
+    automation_id: str,
+    name: str,
+    prompt: str,
+    rrule: str,
+    thread_id: str,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = (
+        "version = 1\n"
+        f'id = "{automation_id}"\n'
+        'kind = "heartbeat"\n'
+        f'name = "{name}"\n'
+        f'prompt = """{prompt}"""\n'
+        'status = "ACTIVE"\n'
+        f'rrule = "{rrule}"\n'
+        f'target_thread_id = "{thread_id}"\n'
+        f"created_at = {_now_ms()}\n"
+        f"updated_at = {_now_ms()}\n"
+    )
+    path.write_text(text, encoding="utf-8")
+
+
+def _sqlite_row_exists(db_path: Path, automation_id: str) -> bool:
+    if not db_path.exists():
+        return False
+    connection = sqlite3.connect(str(db_path))
+    try:
+        try:
+            row = connection.execute(
+                "SELECT 1 FROM automations WHERE id=?", (automation_id,)
+            ).fetchone()
+        except sqlite3.OperationalError:
+            return False
+    finally:
+        connection.close()
+    return row is not None
+
+
+def _ensure_sqlite_row(
+    db_path: Path,
+    *,
+    automation_id: str,
+    name: str,
+    prompt: str,
+    rrule: str,
+    cwd: str,
+    backup_path: Path | None,
+) -> None:
+    if backup_path is not None and db_path.exists():
+        connection = sqlite3.connect(str(db_path))
+        try:
+            connection.execute("PRAGMA busy_timeout=5000")
+            connection.backup(sqlite3.connect(str(backup_path)))
+        finally:
+            connection.close()
+    now = _now_ms()
+    connection = sqlite3.connect(str(db_path))
+    try:
+        connection.execute("PRAGMA busy_timeout=5000")
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS automations (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                prompt TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'ACTIVE',
+                next_run_at INTEGER,
+                last_run_at INTEGER,
+                cwds TEXT NOT NULL DEFAULT '[]',
+                rrule TEXT NOT NULL DEFAULT 'FREQ=HOURLY;INTERVAL=24;BYMINUTE=0',
+                model TEXT,
+                reasoning_effort TEXT,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                target_type TEXT,
+                project_id TEXT
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO automations (
+                id, name, prompt, status, next_run_at, last_run_at,
+                cwds, rrule, model, reasoning_effort, created_at,
+                updated_at, target_type, project_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                name=excluded.name,
+                prompt=excluded.prompt,
+                status=excluded.status,
+                next_run_at=excluded.next_run_at,
+                last_run_at=excluded.last_run_at,
+                cwds=excluded.cwds,
+                rrule=excluded.rrule,
+                updated_at=excluded.updated_at
+            """,
+            (
+                automation_id,
+                name,
+                prompt,
+                "ACTIVE",
+                now + 30_000,
+                now,
+                json.dumps([cwd]) if cwd else "[]",
+                rrule,
+                "",
+                "",
+                now,
+                now,
+                "",
+                "",
+            ),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def _ensure_automation(
+    *,
+    loopx: str,
+    registry: Path,
+    automations_root: Path,
+    db_path: Path,
+    automation_id: str,
+    goal_id: str,
+    agent_id: str,
+    rrule: str,
+    backup_path: Path | None,
+) -> bool:
+    toml_path = automations_root / automation_id / "automation.toml"
+    if toml_path.exists() and _sqlite_row_exists(db_path, automation_id):
+        return False
+    goal = _load_registry_goal(registry, goal_id)
+    thread_id = ""
+    bindings = (goal.get("coordination") or {}).get("thread_agent_bindings") or []
+    if isinstance(bindings, list):
+        matches = [
+            binding
+            for binding in bindings
+            if isinstance(binding, dict)
+            and str(binding.get("agent_id") or "") == agent_id
+        ]
+        if len(matches) == 1:
+            thread_id = str(matches[0].get("thread_id") or "")
+    cwd = str(goal.get("repo") or "")
+    name = f"{goal_id} LoopX"
+    if toml_path.exists():
+        text = toml_path.read_text(encoding="utf-8")
+        match = re.search(r'prompt = """(.*?)"""', text, re.DOTALL)
+        prompt = match.group(1) if match else _heartbeat_task_body(
+            loopx=loopx,
+            registry=registry,
+            goal_id=goal_id,
+            agent_id=agent_id,
+        )
+    else:
+        prompt = _heartbeat_task_body(
+            loopx=loopx,
+            registry=registry,
+            goal_id=goal_id,
+            agent_id=agent_id,
+        )
+        _write_automation_toml(
+            toml_path,
+            automation_id=automation_id,
+            name=name,
+            prompt=prompt,
+            rrule=rrule,
+            thread_id=thread_id,
+        )
+    _ensure_sqlite_row(
+        db_path,
+        automation_id=automation_id,
+        name=name,
+        prompt=prompt,
+        rrule=rrule,
+        cwd=cwd,
+        backup_path=backup_path,
+    )
+    return True
 
 
 def _load_scheduler_hint(
@@ -196,6 +441,8 @@ def main(argv: list[str] | None = None) -> int:
     ack_hint = codex_app.get("ack_hint", {})
     ack_args = ack_hint.get("cli_args") if isinstance(ack_hint, dict) else None
     toml_path = args.automations_root / args.automation_id / "automation.toml"
+    toml_missing = not toml_path.exists()
+    sqlite_missing = not _sqlite_row_exists(args.db_path, args.automation_id)
 
     if not apply_needed:
         print(
@@ -227,15 +474,35 @@ def main(argv: list[str] | None = None) -> int:
     print(f"backup={backup_path or 'none (dry-run)'}")
     print(f"ack_args={ack_args}")
     if args.dry_run:
+        if toml_missing or sqlite_missing:
+            print(
+                "dry-run: would create missing automation "
+                f"{args.automation_id} (toml={not toml_missing}, "
+                f"sqlite={not sqlite_missing})"
+            )
         print("dry-run: no writes performed")
         return 0
 
+    created = False
+    if toml_missing or sqlite_missing:
+        created = _ensure_automation(
+            loopx=args.loopx,
+            registry=args.registry,
+            automations_root=args.automations_root,
+            db_path=args.db_path,
+            automation_id=args.automation_id,
+            goal_id=args.goal_id,
+            agent_id=args.agent_id,
+            rrule=rrule,
+            backup_path=backup_path,
+        )
+        print(f"created missing automation: {args.automation_id}")
     _update_toml(toml_path, rrule)
     _update_sqlite(
         args.db_path,
         automation_id=args.automation_id,
         rrule=rrule,
-        backup_path=backup_path,
+        backup_path=None if created else backup_path,
     )
     _run_ack(args.loopx, ack_args)
     print(f"applied {rrule} and ACKed")

--- a/tests/control_plane/test_scheduler_fallback_hint.py
+++ b/tests/control_plane/test_scheduler_fallback_hint.py
@@ -111,14 +111,17 @@ def test_apply_needed_projects_fallback_hint_when_automation_id_resolved() -> No
     assert codex_app["failure_hint"]["cli_args"][0] == "quota"
 
 
-def test_apply_needed_without_automation_id_emits_gate_not_guess() -> None:
+def test_apply_needed_without_automation_id_projects_deterministic_fallback() -> None:
     hint = _hint(_active_decision(), automation_id=None)
     fallback = hint["codex_app"]["fallback_hint"]
-    assert fallback["available"] is False
-    assert fallback["reason"].startswith("automation_id_unresolved")
-    assert "do not guess an automation id" in fallback["reason"]
-    assert fallback["action"] == "surface_pasteable_heartbeat_gate"
-    assert "cli_args" not in fallback
+    assert fallback["available"] is True
+    assert fallback["automation_id_projected"] is True
+    assert fallback["action"] == "create_then_apply_rrule_via_fallback"
+    assert fallback["args"]["automation_id"] == (
+        "loopx-fallback-hint-goal-codex-fixture"
+    )
+    assert "--automation-id" in fallback["cli_args"]
+    assert "automation_id_projected" in fallback["reason"]
 
 
 def test_settled_cadence_omits_fallback_hint() -> None:

--- a/tests/test_codex_app_apply_rrule.py
+++ b/tests/test_codex_app_apply_rrule.py
@@ -237,3 +237,95 @@ def test_update_toml_and_sqlite_helpers(tmp_path: Path) -> None:
     finally:
         connection.close()
     assert row == ("FREQ=MINUTELY;INTERVAL=10",)
+
+
+def test_apply_creates_missing_automation_toml_and_sqlite(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    automations_root = tmp_path / "automations"
+    db_path = tmp_path / "codex-dev.db"
+    registry_path = tmp_path / "registry.json"
+    sqlite3.connect(str(db_path)).close()
+    registry_path.write_text(
+        json.dumps(
+            {
+                "goals": [
+                    {
+                        "id": "goal",
+                        "repo": "/tmp/workspace",
+                        "coordination": {
+                            "thread_agent_bindings": [
+                                {
+                                    "agent_id": "agent",
+                                    "thread_id": "thread-1",
+                                }
+                            ]
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        if "should-run" in command:
+            return _FakeCompleted(_hint_payload(apply_needed=True))
+        if "heartbeat-prompt" in command:
+            return _FakeCompleted(
+                {
+                    "ok": True,
+                    "task_body": (
+                        "Advance `goal` from active state. "
+                        "Agent: `agent`."
+                    ),
+                }
+            )
+        calls.append(command)
+        return _FakeCompleted({"ok": True})
+
+    monkeypatch.setattr("scripts.codex_app_apply_rrule.subprocess.run", fake_run)
+
+    code = main(
+        [
+            "--automations-root",
+            str(automations_root),
+            "--db-path",
+            str(db_path),
+            "--registry",
+            str(registry_path),
+            "--goal-id",
+            "goal",
+            "--agent-id",
+            "agent",
+            "--automation-id",
+            "loopx-goal-agent",
+            "--loopx",
+            "loopx",
+        ]
+    )
+
+    assert code == 0
+    toml_path = automations_root / "loopx-goal-agent" / "automation.toml"
+    assert toml_path.exists()
+    toml_text = toml_path.read_text(encoding="utf-8")
+    assert 'rrule = "FREQ=MINUTELY;INTERVAL=5"' in toml_text
+    assert 'target_thread_id = "thread-1"' in toml_text
+    assert 'prompt = """Advance `goal` from active state.' in toml_text
+
+    connection = sqlite3.connect(str(db_path))
+    try:
+        row = connection.execute(
+            "SELECT id, rrule, prompt, cwds FROM automations "
+            "WHERE id='loopx-goal-agent'"
+        ).fetchone()
+    finally:
+        connection.close()
+    assert row is not None
+    assert row[1] == "FREQ=MINUTELY;INTERVAL=5"
+    assert "Advance `goal`" in row[2]
+    assert "/tmp/workspace" in row[3]
+    assert any("scheduler-ack-current" in call for call in calls)
+    assert list(tmp_path.glob("codex-dev.db.bak-*"))


### PR DESCRIPTION
## Problem

When a goal/agent has no installed Codex App heartbeat automation, quota should-run returns fallback_hint available=false with reason automation_id_unresolved. The agent then surfaces a pasteable gate instead of running loopx-apply-rrule, so the first heartbeat automation never gets created automatically.

## Fix

- scheduler_hint now projects a deterministic automation id from goal_id + agent_id when no installed automation matches.
- codex_app_apply_rrule now creates the missing automation.toml and SQLite row before applying the recommended rrule, using heartbeat-prompt task_body, registry thread binding, and repo cwd.

## Validation

- Updated scheduler fallback tests.
- Added test for creating a missing automation end-to-end.
- Ran 28 focused pytest cases: passed.
- loopx canary premerge --tier quick: passed.