### PR TITLE
refactor(skill): make start packet the LoopX behavior authority

### DIFF
--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -427,7 +427,8 @@ def main() -> int:
         loopx_command_skill = codex_home / "skills" / "loopx" / "SKILL.md"
         loopx_command_skill_text = loopx_command_skill.read_text(encoding="utf-8")
         assert "surface=codex-skills" in loopx_command_skill_text, loopx_command_skill_text
-        assert "`ark-managed-agent` for Ark Managed Agent" in loopx_command_skill_text
+        assert "Identify the exact current host surface" in loopx_command_skill_text
+        assert "`goal_start_contract` as authoritative" in loopx_command_skill_text
         loopx_openai_metadata = loopx_command_skill.parent / "agents" / "openai.yaml"
         loopx_openai_metadata_text = loopx_openai_metadata.read_text(encoding="utf-8")
         assert 'display_name: "LoopX"' in loopx_openai_metadata_text, loopx_openai_metadata_text

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -687,6 +687,10 @@ def _goal_start_contract(
 ) -> dict[str, Any]:
     return {
         "schema_version": GOAL_START_SCHEMA_VERSION,
+        "behavior_authority": (
+            "ordered_steps + goal_start_contract; skill passes raw arguments after host "
+            "detection, executes packet"
+        ),
         "slash_syntax": "/loopx <goal text>",
         "goal_text": goal_text,
         "selected_capability_route": selected_capability_route,
@@ -725,26 +729,24 @@ def _goal_start_contract(
             "default_task_class": "advancement_task",
             "required_fields": ["priority", "text", "task_class", "action_kind"],
             "public_safe_only": True,
-            "budget_policy": (
-                "For clear bounded problems, planning should sharpen action selection "
-                "rather than crowd out task work; prefer the minimum sufficient ordered "
-                "todo plan over fixed-count filler."
-            ),
+            "budget_policy": "minimum sufficient plan; no fixed-count filler",
         },
         "priority_ordering": {
             "bucket_order": ["P0", "P1", "P2"],
             "same_priority_tie_breaker": "planner_order_then_todo_write_order",
-            "prompt_constraint": (
-                "Sort planned todos by priority bucket and relative rank before writing. "
-                "For multiple P0/P1/P2 items, earlier items are higher rank; preserve that "
-                "exact order when running todo add commands."
-            ),
-            "storage_contract": (
-                "LoopX status/quota already use todo index as the same-priority tie-breaker, "
-                "so host integrations must write todos in planner order instead of adding "
-                "a separate rank field."
-            ),
+            "prompt_constraint": "priority then exact write order",
+            "storage_contract": "Todo index is same-priority rank; no extra field",
         },
+        "execution_invariants": (
+            "identity: fresh public-safe agent after verified/active; explicit takeover; "
+            "bind/readback before Todo; no peer inference; unknown: "
+            "loopx agent-onboard --list-agent-types | route: selected_capability_route only; "
+            "never infer from text/URLs; #/activation+#/stop_conditions; review/pasteable "
+            "gates | Todo/writeback: Agent advancement_task; User owner/private; business Todo "
+            "before work; current evidence + next Todo; refresh/quota; chat not durable | "
+            "returned typed quota_guard; one bounded validation+writeback or exact blocker; "
+            "optional need/preview/explicit apply"
+        ),
         "activation": {
             "after_write": ["refresh-state", "host_loop_activation", "quota should-run"],
             "host_loop_required_after_todo_writeback": True,
@@ -766,10 +768,7 @@ def _goal_start_contract(
                 "Do not claim autonomous setup complete from registry/quota identity alone. "
                 "If the host cannot mutate its loop surface, report the exact pasteable gate."
             ),
-            "low_cost_recheck_policy": (
-                "Only recompute onboarding/activation when activation is missing, unknown, stale, "
-                "or the agent type changed; normal ticks should read quota/status/state directly."
-            ),
+            "low_cost_recheck_policy": "missing/unknown/stale/type-changed only",
             "begin_automation_when_quota_allows": True,
             "spend_quota_after_writeback": True,
         },
@@ -792,14 +791,9 @@ def _goal_start_contract(
                     "issue_fix_pr_lifecycle_template"
                 ],
                 "writeback": (
-                    "persist source-qualified candidate preflight; only proceed enters "
-                    "feasibility and writes its successor; otherwise reuse, disposition, or close; "
-                    "private repro material, issue body/comment reads, external comments, PR creation, "
-                    "merge, publish, destructive git, and production actions stay explicit gates; "
-                    "after PR creation, use active external-review-request authority to call "
-                    "reviewer-request, verify the formal request or its permission-only reviewer "
-                    "comment fallback, then use one monitor per PR state bucket, never per PR; "
-                    "actions/messages stay one-shot; domain-state stays compact"
+                    "persist candidate preflight; only proceed enters feasibility and writes "
+                    "its successor; keep private/external/publish/destructive/production gates; "
+                    "after PR creation verify reviewer-request, then monitor one PR state bucket"
                 ),
             }
         },
@@ -821,19 +815,19 @@ def _goal_start_prompt(*, goal_text: str | None, goal_id: str, agent_id: str | N
         else "Goal text: use the text after `/loopx`; if it is empty, handle bare `/loopx` instead."
     )
     agent_clause = f" Use agent id `{agent_id}` for quota/claim commands." if agent_id else ""
-    return f"""Plan before writing todos for `/loopx <goal text>`.
+    return f"""Plan; returned `ordered_steps` + `goal_start_contract` are authoritative.
 
 {goal_clause}
 Goal id: {goal_id}.{agent_clause}
 
-Planning rules:
-1. Choose the planning profile: broad or fuzzy product direction uses 2-5 public-safe todos; clear bounded problems use a planner-sized ordered todo plan with enough steps to make the approach explicit.
-2. Before substantive work, plan then write concise todos; avoid management-only filler.
-3. Every new todo starts with `[P0]`, `[P1]`, or `[P2]`; include at least one `[P0]` unless the first useful step is blocked by a user gate.
-4. If several todos share the same priority, their listed order is their relative priority. Preserve that exact order when writing them.
-5. Prefer executable Agent Todo items with `task_class=advancement_task`; use User Todo only for concrete owner decisions or private-material gates.
-6. After writing todos, run `loopx refresh-state --goal-id {goal_id}`, activate the host loop if it is missing, unknown, or stale (Codex App automation, Codex CLI `/goal <task_body>`, Claude Code `/loop`, OpenCode bridge, or a custom host-loop gate), then run its typed `quota_guard` and begin the first allowed bounded segment.
-7. Enter issue-fix only when `selected_capability_route.capability_id=issue-fix`; never infer it from goal text or URLs. Run workflow-plan and feasibility before implementation, write only the admitted successor or no-follow-up, preserve private/external/destructive gates, verify reviewer requests, and reconcile PR lifecycle one PR per message.
+Rules:
+1. Identity: use verified binding/active contract; a stable unbound host gets a fresh public-safe agent. Existing lanes require explicit takeover plus bind/readback before Todo; never infer peers from Todo/worktree/arguments. Unknown host: `loopx agent-onboard --list-agent-types`.
+2. Capability: only `selected_capability_route`; run entry/admission and its later `capability show`; never infer from text/URLs. Capability state owns facts; generic Todos schedule.
+3. Todos: broad goal 2-5 public-safe items, bounded goal minimum sufficient plan; `[P0]`/`[P1]`/`[P2]`, no `--priority`, preserve order, prefer Agent `advancement_task`, User Todo only for owner/private gates. Write one business Todo before work.
+4. Writeback: current Todo evidence + next executable Todo, then `loopx refresh-state --goal-id {goal_id}` and quota readback. Chat/model summaries are not durable state.
+5. Host loop: after Todo write, activate missing/unknown/stale/type-changed Codex App heartbeat automation, CLI/TraeX `/goal`, Claude `/loop`, OpenCode bridge, Ark one-shot, or custom gate. Else surface the exact pasteable gate; never claim autonomy.
+6. Run the returned typed `quota_guard`; finish one bounded segment with validation + LoopX writeback or an exact blocker. Setup/planning/claim is not delivery.
+7. Optional features: need, preview, explicit apply. Respect private data, credentials, destructive git, production authority, and review rules.
 """
 
 

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -122,10 +122,9 @@ def _loopx_start_goal_arguments_instruction(
         "unchanged as one value to "
         f'`{cli_bin} start-goal --guided --project . --slash-command-arguments='
         f'"<complete visible $ARGUMENTS>" --host-surface {selected_host}`. '
-        "The CLI, not the model, owns parsing the optional leading typed "
-        "`--capability-route issue-fix` switch and preserving the remaining goal "
-        "text. Never split and recompose the switch. Never infer a route from "
-        "issue/PR wording or URLs."
+        "The CLI, not the model, owns parsing supported leading switches and "
+        "preserving the remaining goal text. Never split or recompose the "
+        "arguments, and never infer a route from issue/PR wording or URLs."
     )
     if host_surface is None:
         instruction += (
@@ -144,21 +143,15 @@ def _command_prompt_specs(*, cli_bin: str, include_legacy_aliases: bool) -> list
             "argument_hint": "[--capability-route issue-fix] [task text]",
             "instructions": [
                 "Visible command arguments: `$ARGUMENTS`.",
-                "Before start-goal, identify the exact current host: use `codex-app` for the desktop app with automation tools, `codex-app-ssh` for the desktop app over SSH without automation tools, `codex-ide-plugin` only for the IDE plugin, `codex-cli-tui` for the terminal TUI, `opencode` for OpenCode, `traex-cli` for the TraeX terminal TUI, `pi` for Pi, `gemini-cli` for the Gemini CLI, `cursor-agent` for the Cursor agent CLI, or `ark-managed-agent` for Ark Managed Agent.",
+                "Identify the exact current host surface (codex-app, codex-app-ssh, codex-ide-plugin, codex-cli-tui, opencode, traex-cli, pi, gemini-cli, cursor-agent, or ark-managed-agent).",
                 _loopx_start_goal_arguments_instruction(
                     cli_bin=cli_bin,
                     host_surface=None,
                 ),
-                f"Treat the returned `ordered_steps` as a required transaction. On first connection, run its bootstrap command and resolve the returned agent-identity gate before planning; a stable unbound host thread is a new session and defaults to fresh registration. Then plan and execute at least one business `{cli_bin} todo add` derived from `$ARGUMENTS` before substantive task work. Encode priority in the todo text such as `[P0]`; `{cli_bin} todo add` has no `--priority` flag. Do not continue until LoopX status shows that business Agent Todo.",
-                f"If `selected_capability_route` is present, run its entry and admission commands before substantive implementation, and treat `{cli_bin} capability show <capability-id> --format json` as the authoritative later-transition command surface. Use capability-owned commands for listed external transitions instead of substituting provider CLIs. Keep capability facts in capability-owned state; generic Todos remain scheduling records.",
-                f"Before dependent work, persist material scope, acceptance, or non-goal changes in current Todo evidence and the next executable Todo; then run `{cli_bin} refresh-state` and verify quota readback. Chat/model summaries are not durable state.",
-                f"If that packet exposes a goal-selection gate, rerun one exact choice before any mutation. Resolve agent identity in this order: reuse the packet's verified thread binding; otherwise reuse the exact agent id already named by this host task's active LoopX interaction contract or heartbeat; otherwise treat a stable unbound host thread as a new session and follow the packet's fresh-registration default. Select an existing registered lane only for explicit takeover, then complete the returned bind/readback step. Codex App `start-goal` automatically reads its stable ambient thread id when available. Never treat a new Todo, worktree, or argument-bearing invocation as a new peer by itself, and never infer identity from registry order. When no stable thread id is available, fresh registration requires explicit new-peer/session intent and `--new-peer`. Preview `{cli_bin} register-agent --goal-id <selected-goal-id> --agent-id <new-agent-id> --require-new`, then apply with `--execute` and continue only when the result reports `ok=true`, `changed=true`, `written=true`, successful global sync, and verified registration readback. Rerun start-goal with the verified `--agent-id` before todo writeback.",
-                f"If arguments are empty and the host task already identifies an active LoopX goal, run its exact CLI `interaction_contract` or quota command first; do not call `start-goal` or bootstrap another goal. Only when no active goal contract is present, inspect `{cli_bin} bootstrap-command-pack --project .`, `{cli_bin} status`, and `{cli_bin} slash-commands` before changing files.",
-                f"Use `{cli_bin} agent-onboard --list-agent-types` when the host runtime is unclear; pass an exact type such as `codex-app`, `codex-app-ssh`, `codex-ide-plugin`, `codex-cli`, `claude-code`, `opencode`, `traex-cli`, `pi`, or `ark-managed-agent`, never ambiguous `codex`.",
-                f"Do not configure optional features during first-run. Only when the task needs bounded child agents or Explore, inspect `{cli_bin} configure-goal --goal-id <resolved-goal-id>` and its `configuration_catalog`; preview before explicit apply and never auto-enable a feature merely because it exists.",
-                "When project work is started, plan ordered P0/P1/P2 todos, write them through LoopX todo state, refresh state, activate the host loop if missing/stale, run quota, and complete one bounded delivery segment through validation plus LoopX writeback or an exact blocker; do not return merely after setup, planning, or claim.",
-                "Host loop activation means Codex App heartbeat automation; Codex App over SSH, the Codex IDE plugin, or CLI visible `/goal <task_body>`; Claude Code native `/loop`; OpenCode `loopx_goal_activate`; TraeX visible `/goal <task_body>`; Ark Managed Agent one-shot Goal submission; or a custom host-loop gate from `loopx agent-onboard`.",
-                "If this session cannot mutate the host loop surface, surface the exact pasteable gate instead of saying LoopX is autonomously connected.",
+                "Treat the returned `ordered_steps` and `goal_start_contract` as authoritative. Follow their identity, capability-route, Todo, writeback, host-loop, quota, and stop/gate rules before substantive work; do not reconstruct those rules from skill memory.",
+                "If the packet exposes a goal-selection gate, rerun one exact choice before any mutation.",
+                f"If arguments are empty and the host already identifies an active LoopX goal, follow its exact CLI `interaction_contract` or quota command first; otherwise inspect `{cli_bin} status` and `{cli_bin} bootstrap-command-pack --project .` before changing files.",
+                "If this session cannot mutate the host loop surface, surface the exact pasteable gate instead of claiming autonomous setup.",
             ],
         },
         {

--- a/tests/control_plane/test_start_goal_compact_projection.py
+++ b/tests/control_plane/test_start_goal_compact_projection.py
@@ -190,6 +190,51 @@ def test_default_projection_preserves_host_actions_and_json_anchors(
         _resolve_pointer(projection, ref["json_pointer"])
 
 
+def test_goal_start_packet_is_parity_complete_behavior_authority(
+    tmp_path: Path,
+) -> None:
+    project = _write_connected_project(tmp_path)
+    payload = _build(project, include_detail=False)
+
+    contract = payload["command_pack"]["goal_start_contract"]
+    assert "ordered_steps + goal_start_contract" in contract["behavior_authority"]
+    assert "passes raw arguments" in contract["behavior_authority"]
+
+    invariants = contract["execution_invariants"]
+    for marker in (
+        "fresh public-safe agent",
+        "explicit takeover",
+        "bind/readback before Todo",
+        "loopx agent-onboard --list-agent-types",
+        "selected_capability_route",
+        "never infer from text/URLs",
+        "#/activation",
+        "#/stop_conditions",
+        "Agent advancement_task",
+        "business Todo before work",
+        "current evidence + next Todo",
+        "chat not durable",
+        "returned typed quota_guard",
+        "one bounded validation+writeback",
+        "exact blocker",
+        "explicit apply",
+    ):
+        assert marker in invariants
+
+    prompt = payload["command_pack"]["commands"]["goal_start_plan_prompt"]
+    for required_text in (
+        "stable unbound host gets a fresh public-safe agent",
+        "selected_capability_route",
+        "no `--priority`",
+        "current Todo evidence + next executable Todo",
+        "Chat/model summaries are not durable state",
+        "Codex App heartbeat automation",
+        "returned typed `quota_guard`",
+        "surface the exact pasteable gate",
+    ):
+        assert required_text in prompt
+
+
 def test_issue_fix_goal_projects_capability_guard_without_todo_fields(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_slash_command_install.py
+++ b/tests/test_slash_command_install.py
@@ -45,20 +45,17 @@ def test_host_materialization_installs_generated_loopx_entry_skill(
         "status": "created",
     }
     assert 'name: "loopx"' in skill_text
-    assert "`ark-managed-agent` for Ark Managed Agent" in skill_text
-    assert "Ark Managed Agent one-shot Goal submission" in skill_text
+    assert "ark-managed-agent" in skill_text
     assert "--slash-command-arguments" in skill_text
     assert "The CLI, not the model, owns parsing" in skill_text
-    assert "Never split and recompose the switch" in skill_text
-    assert "Never infer a route from issue/PR wording or URLs" in skill_text
-    assert "run its exact CLI `interaction_contract` or quota command first" in skill_text
-    assert "do not call `start-goal` or bootstrap another goal" in skill_text
-    assert "reuse the packet's verified thread binding" in skill_text
-    assert "already named by this host task's active LoopX interaction contract" in skill_text
-    assert "treat a stable unbound host thread as a new session" in skill_text
-    assert "Select an existing registered lane only for explicit takeover" in skill_text
-    assert "Never treat a new Todo, worktree, or argument-bearing invocation as a new peer" in skill_text
-    assert "When no stable thread id is available" in skill_text
+    assert "Never split or recompose" in skill_text
+    assert "never infer a route from issue/PR wording or URLs" in skill_text
+    assert "`ordered_steps` and `goal_start_contract` as authoritative" in skill_text
+    assert "surface the exact pasteable gate" in skill_text
+    assert "follow its exact CLI `interaction_contract` or quota command first" in skill_text
+    assert "reuse the packet's verified thread binding" not in skill_text
+    assert "capability show <capability-id> --format json" not in skill_text
+    assert "Chat/model summaries are not durable state" not in skill_text
     assert materialize_loopx_entry_skill(
         skills_dir=skills_dir,
         execute=True,
@@ -82,18 +79,11 @@ def test_host_materialization_can_bind_exact_managed_agent_surface(
     assert "--host-surface <exact-current-host>" not in skill_text
     assert "--slash-command-arguments" in skill_text
     assert "The CLI, not the model, owns parsing" in skill_text
-    assert "before substantive task work" in skill_text
-    assert "has no `--priority` flag" in skill_text
-    assert "Before dependent work, persist material scope" in skill_text
-    assert "current Todo evidence and the next executable Todo" in skill_text
-    assert "Chat/model summaries are not durable state" in skill_text
-    assert "run its entry and admission commands" in skill_text
-    assert "capability show <capability-id> --format json" in skill_text
-    assert "instead of substituting provider CLIs" in skill_text
-    assert "generic Todos remain scheduling records" in skill_text
-    assert "Never infer a route" in skill_text
-    assert "run its exact CLI `interaction_contract` or quota command first" in skill_text
-    assert "Only when no active goal contract is present" in skill_text
+    assert "`ordered_steps` and `goal_start_contract` as authoritative" in skill_text
+    assert "never infer a route" in skill_text
+    assert "follow its exact CLI `interaction_contract` or quota command first" in skill_text
+    assert "current Todo evidence and the next executable Todo" not in skill_text
+    assert "generic Todos remain scheduling records" not in skill_text
 
 
 def test_host_materialization_rejects_unknown_fixed_surface(tmp_path: Path) -> None:
@@ -123,16 +113,13 @@ def test_codex_install_upgrades_managed_loopx_facade(tmp_path: Path) -> None:
     skill_text = skill.read_text(encoding="utf-8")
     assert "Treat this as the LoopX `/loopx` explicit LoopX command skill." in skill_text
     assert "--host-surface <exact-current-host>" in skill_text
-    assert "`codex-ide-plugin` only for the IDE plugin" in skill_text
-    assert "`ark-managed-agent` for Ark Managed Agent" in skill_text
-    assert (
-        "Codex App over SSH, the Codex IDE plugin, or CLI visible "
-        "`/goal <task_body>`"
-    ) in skill_text
+    assert "Identify the exact current host surface" in skill_text
+    assert "ark-managed-agent" in skill_text
+    assert "`ordered_steps` and `goal_start_contract` as authoritative" in skill_text
     assert "use `codex-ide` for the IDE" not in skill_text
-    assert "do not return merely after setup, planning, or claim" in skill_text
-    assert "run its exact CLI `interaction_contract` or quota command first" in skill_text
-    assert "Only when no active goal contract is present" in skill_text
+    assert "surface the exact pasteable gate" in skill_text
+    assert "follow its exact CLI `interaction_contract` or quota command first" in skill_text
+    assert "do not return merely after setup, planning, or claim" not in skill_text
     metadata_text = metadata.read_text(encoding="utf-8")
     assert 'display_name: "LoopX"' in metadata_text
     assert 'display_name: "LoopX /loopx"' not in metadata_text


### PR DESCRIPTION
## Summary

- make `ordered_steps` plus `goal_start_contract` the behavior authority for generated `/loopx`
- keep the installed skill as a thin host-detection, lossless-argument-transport, and packet-execution facade
- add parity coverage for identity, capability routing, Todo/writeback, host-loop activation, quota, and stop/gate invariants
- preserve existing standard-mode contract keys and stay within current CLI output budgets

This is PR1 from #3066. It intentionally does not add the optional fine-grained mode planned for PR2.

## Product and architecture judgment

The regression in #3064 came from moving lifecycle prose out of the generated skill before the CLI packet carried equivalent authority. This change fixes the ownership seam: lifecycle truth now belongs to the typed control packet, while the skill transports input and executes that packet. Installed users keep standard behavior without maintaining two copies of the protocol. The main compatibility risk is packet growth or omitted invariants; the base/head budget smoke and parity test cover both.

## Validation

- `162 passed` across packet, actual-default behavior, ordered-step, host-loop, and install tests
- `examples/install-local-smoke.py` passed
- `examples/control_plane/cli-output-budget-regression-smoke.py` passed, including base/head differential budgets
- `ruff` passed on all changed paths
- repository `mypy` config passed (`16 source files`)
- public/private boundary scan passed for all five changed paths
- exact change-quality receipt passed: `cqr_abed75e4c24cd7ecc844`
- standard premerge canary passed: 5/5 catalog checks plus public-boundary check; no skips or manual holds

The install smoke took 116.2 seconds on this host, so the final premerge invocation used a 180-second per-check timeout after the default 120-second run timed out. The smoke itself passed unchanged; no repository timeout or output budget was raised.

## Scope hygiene

One cohesive commit contains two product modules, two semantic test modules, and one durable install smoke. No local goal state, credentials, raw logs, private links, generated lockfile, or unrelated worktree artifacts are included.

## Merge plan

Self-review now; hold merge until the owner-approved weekend window.
