### PR TITLE
fix(smoke): raise compact scheduler-hint budget above shipped fallback_hint size

### DIFF
--- a/examples/control_plane/quota-scheduler-hint-compaction-smoke.py
+++ b/examples/control_plane/quota-scheduler-hint-compaction-smoke.py
@@ -316,9 +316,12 @@ def assert_compact_scheduler(name: str, source_payload: dict) -> None:
     assert "automation_update" in reset_detail["codex_app_apply"], (name, detailed)
     assert len(reset_detail["profile_signature"]) == 12, (name, detailed)
     assert json_size(compact) < json_size(detailed), (name, json_size(compact), json_size(detailed))
-    # #3058 added the required codex_app.fallback_hint to the compact hot path;
-    # keep the budget tight but above the shipped-contract size.
-    assert json_size(compact) <= 3_900, (name, json_size(compact))
+    # #3053-era scheduler-ack/failure route_binding and #3058's required
+    # codex_app.fallback_hint grew the shipped compact hot path. Measured at
+    # ec37e88f: active-work=4523, human-gate=4692, cli-default=5784 (local).
+    # Keep the budget tight but above the shipped-contract size with a small
+    # margin for runner path variance.
+    assert json_size(compact) <= 6_200, (name, json_size(compact))
 
 
 def run_should_run_cli(


### PR DESCRIPTION
## Summary

`examples/control_plane/quota-scheduler-hint-compaction-smoke.py` guards the compact `scheduler_hint` hot-path size at 3900 chars. The shipped contract has since grown beyond that budget with two required fields:

- scheduler-ack/failure `route_binding` (#3053-era workspace-causality runtime)
- `codex_app.fallback_hint` (#3058, required in the compact hot path)

Measured at head `ec37e88f`: active-work=4523, human-gate=4692, cli-default=5784 (local). The Full Public Smokes shard-2 has been failing on this assertion since those fields shipped.

## Change

Raise the characterization budget to 6200, still tight above the shipped-contract size, and document the measured drivers so future growth stays attributable. Single assertion + comment; no runtime behavior change.

## Validation

- `quota-scheduler-hint-compaction-smoke.py` passes at the fix head (active-work/human-gate/cli-default all within 6200)
- `tests/control_plane/test_cli_output_budget.py`: 15 passed
- scheduler fallback/backoff/execution-context/ack-binding/heartbeat-prompt tests: 189 passed (1 environmental local failure in `test_scheduler_ack_current_host_binding.py` due to `python -m loopx.cli` module resolution from the temp venv; identical on pristine head, unrelated to this diff)
- CLI output base/head differential: ok (97/97, no review signals)
- `loopx canary premerge --from-git-diff`: 5/5 catalog checks + public boundary passed
- CI: pytest pass, dependency-review pass