### PR TITLE
test(pr-program): add snapshot walkthrough smoke

### DIFF
--- a/examples/fixtures/pr-program-snapshot-baseline.public.json
+++ b/examples/fixtures/pr-program-snapshot-baseline.public.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": "loopx_pr_program_snapshot_v0",
+  "program_id": "example-runtime-reliability",
+  "generated_at": "2026-08-11T00:00:00Z",
+  "result_completeness": {
+    "complete": true,
+    "scope": {
+      "repositories": ["example/runtime"],
+      "states": ["open"],
+      "authors": [],
+      "time_window": {"since": null, "until": null}
+    }
+  },
+  "requirements": [
+    {
+      "id": "runtime-controls",
+      "title": "Expose runtime controls",
+      "priority": "P0",
+      "coverage": "partial"
+    }
+  ],
+  "change_requests": [
+    {
+      "ref": "example/runtime#42",
+      "title": "feat(runtime): expose control status",
+      "state": "open",
+      "draft": true,
+      "target_branch": "main",
+      "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "updated_at": "2026-08-11T00:00:00Z",
+      "checks": "pending",
+      "review": "pending",
+      "work_item": "action_required",
+      "theme": "runtime controls",
+      "priority": "P0",
+      "requirement_ids": ["runtime-controls"],
+      "depends_on": [],
+      "supersedes": [],
+      "description_digest": "sha256:example-description-42",
+      "review_digest": "sha256:example-review-42"
+    }
+  ]
+}

--- a/examples/fixtures/pr-program-snapshot-current.public.json
+++ b/examples/fixtures/pr-program-snapshot-current.public.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": "loopx_pr_program_snapshot_v0",
+  "program_id": "example-runtime-reliability",
+  "generated_at": "2026-08-11T01:00:00Z",
+  "result_completeness": {
+    "complete": true,
+    "scope": {
+      "repositories": ["example/runtime"],
+      "states": ["open"],
+      "authors": [],
+      "time_window": {"since": null, "until": null}
+    }
+  },
+  "requirements": [
+    {
+      "id": "runtime-controls",
+      "title": "Expose runtime controls",
+      "priority": "P0",
+      "coverage": "partial"
+    }
+  ],
+  "change_requests": [
+    {
+      "ref": "example/runtime#42",
+      "title": "feat(runtime): expose control status",
+      "state": "open",
+      "draft": false,
+      "target_branch": "main",
+      "head_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "updated_at": "2026-08-11T01:00:00Z",
+      "checks": "passed",
+      "review": "approved",
+      "work_item": "passed",
+      "theme": "runtime controls",
+      "priority": "P0",
+      "requirement_ids": ["runtime-controls"],
+      "depends_on": [],
+      "supersedes": [],
+      "description_digest": "sha256:example-description-42",
+      "review_digest": "sha256:example-review-42"
+    }
+  ]
+}

--- a/examples/pr-program-snapshot-walkthrough-smoke.py
+++ b/examples/pr-program-snapshot-walkthrough-smoke.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Smoke-test public PR-program snapshot reconciliation."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "skills" / "loopx-pr-program" / "scripts" / "diff_snapshot.py"
+FIXTURES = REPO_ROOT / "examples" / "fixtures"
+BASELINE = FIXTURES / "pr-program-snapshot-baseline.public.json"
+CURRENT = FIXTURES / "pr-program-snapshot-current.public.json"
+
+
+def load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def diff(previous: Path, current: Path) -> dict[str, Any]:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--previous", str(previous), "--current", str(current)],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    return json.loads(result.stdout)
+
+
+def assert_public_safe(payload: dict[str, Any]) -> None:
+    text = json.dumps(payload, sort_keys=True)
+    for forbidden in (
+        "/Users/",
+        "/private/",
+        "Bearer ",
+        "api_key",
+        "review_body",
+        "provider_payload",
+    ):
+        assert forbidden not in text, forbidden
+
+
+def main() -> int:
+    baseline = load(BASELINE)
+    current = load(CURRENT)
+    assert baseline["program_id"] == current["program_id"]
+    assert_public_safe(baseline)
+    assert_public_safe(current)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root = Path(temp_dir)
+        baseline_path = root / "baseline.json"
+        current_path = root / "current.json"
+        write(baseline_path, baseline)
+        write(current_path, current)
+
+        delta = diff(baseline_path, current_path)
+        assert delta["program_id"] == "example-runtime-reliability", delta
+        assert delta["baseline_advance_allowed"] is True, delta
+        assert delta["scope_matches_previous"] is True, delta
+        assert delta["changed"] == [
+            {
+                "ref": "example/runtime#42",
+                "changed_fields": [
+                    "draft",
+                    "head_sha",
+                    "checks",
+                    "review",
+                    "work_item",
+                ],
+                "before": {
+                    "draft": True,
+                    "head_sha": "a" * 40,
+                    "checks": "pending",
+                    "review": "pending",
+                    "work_item": "action_required",
+                },
+                "after": {
+                    "draft": False,
+                    "head_sha": "b" * 40,
+                    "checks": "passed",
+                    "review": "approved",
+                    "work_item": "passed",
+                },
+            }
+        ], delta
+        assert_public_safe(delta)
+
+        incomplete = json.loads(json.dumps(current))
+        incomplete["result_completeness"]["complete"] = False
+        incomplete["change_requests"][0]["checks"] = "unknown"
+        incomplete["change_requests"][0]["review"] = "unknown"
+        incomplete["change_requests"][0]["work_item"] = "unknown"
+        incomplete_path = root / "incomplete.json"
+        write(incomplete_path, incomplete)
+        incomplete_delta = diff(baseline_path, incomplete_path)
+        assert incomplete_delta["baseline_advance_allowed"] is False, incomplete_delta
+        assert incomplete_delta["baseline_block_reason"] == "incomplete_result", incomplete_delta
+        assert incomplete_delta["result_hash"] is None, incomplete_delta
+
+        mismatched = json.loads(json.dumps(current))
+        mismatched["result_completeness"]["scope"]["repositories"] = ["example/other"]
+        mismatched_path = root / "scope-mismatch.json"
+        write(mismatched_path, mismatched)
+        mismatch_delta = diff(baseline_path, mismatched_path)
+        assert mismatch_delta["baseline_advance_allowed"] is False, mismatch_delta
+        assert mismatch_delta["baseline_block_reason"] == "scope_mismatch", mismatch_delta
+        assert mismatch_delta["result_hash"] is None, mismatch_delta
+
+    print("pr-program-snapshot-walkthrough-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add public synthetic baseline/current PR-program snapshots and a script-level walkthrough smoke.
- Prove stable program identity plus material head, checks, review, and work-item transitions.
- Keep incomplete and scope-mismatched observations fail-closed, with no provider payloads, review bodies, credentials, local paths, or merge authority.

## Test plan
- [x] `python3 examples/pr-program-snapshot-walkthrough-smoke.py`
- [x] `uv run --no-project --with "pytest>=8,<9" python -m pytest -q tests/test_pr_program_snapshot_diff.py`
- [x] `loopx check --scan-path examples/pr-program-snapshot-walkthrough-smoke.py --scan-path examples/fixtures/pr-program-snapshot-baseline.public.json --scan-path examples/fixtures/pr-program-snapshot-current.public.json --scan-path skills/loopx-pr-program --scan-path CONTRIBUTOR_TASKS.md`
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)