### PR TITLE
feat(lark): track inbox reaction lifecycle

### DIFF
--- a/docs/capabilities/lark-event-inbox.md
+++ b/docs/capabilities/lark-event-inbox.md
@@ -8,6 +8,7 @@ Lark event stream
   -> host-managed collector
   -> .loopx/inbox/<channel>/*.json
   -> loopx lark-inbox drain
+  -> loopx lark-inbox processing (optional reaction lifecycle)
   -> domain agent writes a todo, vision correction, artifact update, or rationale
   -> direct bot question: loopx lark-inbox reply (optional, configured sender only)
   -> loopx lark-inbox ack --message-id ... --execute
@@ -103,7 +104,8 @@ bot profile to the same local-private chat:
     "sender_identity": "bot",
     "bot_display_name": "Project Review Bot",
     "chat_id": "oc_<local-private-chat-id>",
-    "received_reaction_emoji": "Get"
+    "received_reaction_emoji": "Get",
+    "processing_reaction_emoji": "OnIt"
   }
 }
 ```
@@ -115,6 +117,22 @@ a direct mention, direct question, or verified reply to the configured bot.
 The reaction is a best-effort receipt: provider failure increments compact
 failure accounting but does not discard the inbox event or grant execution
 authority. Ordinary group conversation does not receive the reaction.
+
+`reply.processing_reaction_emoji` is optional and requires a distinct
+`received_reaction_emoji`. When both are configured, the host should run
+`lark-inbox processing` immediately before interpreting an actionable item.
+LoopX first adds the processing reaction and then removes the received
+reaction. A verified source-thread reply removes any remaining lifecycle
+reaction. If the provider cannot delete a reaction, the operation fails with a
+retryable cleanup status instead of claiming completion.
+
+Reaction ids are stored only in an owner-private receipt ledger under the
+configured inbox. Each message transition is serialized with a private
+per-message lock. LoopX deletes only reaction ids returned by writes made
+through the configured bot profile; it never deletes another participant's
+reaction by emoji type. The receipt ledger is fail-closed: malformed state is
+not ignored, and a provider reaction that cannot be recorded is rolled back
+best-effort.
 
 The reply path never uses the machine default profile. Before any send it
 verifies that the named profile resolves to the expected bot and that the bot
@@ -234,6 +252,18 @@ loopx lark-inbox drain \
   --project . \
   --config .loopx/config/lark/event-inbox.json
 
+loopx lark-inbox processing \
+  --project . \
+  --config .loopx/config/lark/event-inbox.json \
+  --message-id om_xxx
+
+# Execute only after reviewing the preview.
+loopx lark-inbox processing \
+  --project . \
+  --config .loopx/config/lark/event-inbox.json \
+  --message-id om_xxx \
+  --execute
+
 loopx lark-inbox ack \
   --project . \
   --config .loopx/config/lark/event-inbox.json \
@@ -244,6 +274,9 @@ loopx lark-inbox ack \
 Drain is read-only and returns bounded local-private message content. A message
 must be acknowledged only after its effect is written back. Duplicate event
 files collapse by `message_id`; repeated acknowledgement is idempotent.
+`processing` is also idempotent: retries reuse the recorded processing
+reaction and finish any pending received-reaction cleanup without creating
+another processing reaction.
 
 Urgency classification stays local: explicit `@` mentions of the configured
 bot/LoopX, bounded question signals on addressed events, and provider-verified
@@ -273,7 +306,20 @@ loopx lark-inbox reply \
 
 The command uses an idempotency key derived from the source message and reply
 text, sends with `--reply-in-thread`, and reads the created message back through
-the same configured profile. Ordinary chatter remains a no-reply path;
+the same configured profile. Lifecycle reactions are removed only after that
+readback succeeds. A sent reply whose reaction cleanup fails returns
+`sent_verified_cleanup_pending`; retry `lark-inbox reaction-complete` before
+acknowledging the source:
+
+```bash
+loopx lark-inbox reaction-complete \
+  --project . \
+  --config .loopx/config/lark/event-inbox.json \
+  --message-id om_xxx \
+  --execute
+```
+
+Ordinary chatter remains a no-reply path;
 enabling this capability does not grant reviewer-notification or other
 outbound authority.
 

--- a/examples/lark-event-collector-lifecycle-smoke.py
+++ b/examples/lark-event-collector-lifecycle-smoke.py
@@ -27,6 +27,9 @@ from loopx.extensions.lark.event_collector_runtime import (  # noqa: E402
 from loopx.extensions.lark.event_inbox import (  # noqa: E402
     project_lark_event_inbox_urgency,
 )
+from loopx.extensions.lark.inbox_reactions import (  # noqa: E402
+    lark_inbox_reaction_receipts,
+)
 from loopx.cli_commands.lark_inbox import (  # noqa: E402
     _collector_permissions,
 )
@@ -74,6 +77,7 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-collector-") as raw:
                     "bot_display_name": "Project Review Bot",
                     "chat_id": "oc_private_fixture_chat",
                     "received_reaction_emoji": "Get",
+                    "processing_reaction_emoji": "OnIt",
                 },
             }
         ),
@@ -274,12 +278,14 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-collector-") as raw:
             )
         invalid_inbox["reply"]["enabled"] = True
         invalid_inbox["reply"].pop("received_reaction_emoji")
+        invalid_inbox["reply"].pop("processing_reaction_emoji")
         inbox_config.write_text(json.dumps(invalid_inbox), encoding="utf-8")
         assert _collector_permissions(
             project=project,
             config_path=collector_config,
         ) == (LARK_COLLECTOR_PERMISSION,)
         invalid_inbox["reply"]["received_reaction_emoji"] = "Get"
+        invalid_inbox["reply"]["processing_reaction_emoji"] = "OnIt"
         inbox_config.write_text(json.dumps(invalid_inbox), encoding="utf-8")
 
         messages = {
@@ -456,6 +462,15 @@ else:
         assert runtime_result["received_reaction_count"] == 1, runtime_result
         assert runtime_result["received_reaction_failure_count"] == 1, runtime_result
         assert runtime_result["external_writes_performed"] is True, runtime_result
+        assert lark_inbox_reaction_receipts(
+            inbox=project / ".loopx" / "inbox" / "team-feedback",
+            message_id="om_runtime_reply",
+        ) == {
+            "received": {
+                "reaction_id": "reaction_runtime",
+                "emoji_type": "Get",
+            }
+        }
         runtime_urgency = project_lark_event_inbox_urgency(
             project=project,
             config_path=inbox_config,

--- a/loopx/cli_commands/lark_inbox.py
+++ b/loopx/cli_commands/lark_inbox.py
@@ -22,6 +22,10 @@ from ..extensions.lark.event_inbox import (
     project_lark_event_inbox_urgency,
 )
 from ..extensions.lark.inbox_reply import reply_lark_event_inbox
+from ..extensions.lark.inbox_reactions import (
+    complete_lark_event_inbox_reactions,
+    mark_lark_event_inbox_processing,
+)
 from ..extensions.lark.reviewer_notification import (
     lark_reviewer_notification_sink,
 )
@@ -113,6 +117,29 @@ def register_lark_inbox_commands(
     reply.add_argument("--message-id", required=True)
     reply.add_argument("--text", required=True)
     reply.add_argument("--execute", action="store_true")
+    processing = sub.add_parser(
+        "processing",
+        help=(
+            "Mark one captured message as actively processing and replace its "
+            "received reaction when configured."
+        ),
+    )
+    add_subcommand_format(processing)
+    processing.add_argument("--project")
+    processing.add_argument("--config")
+    processing.add_argument("--goal-id")
+    processing.add_argument("--message-id", required=True)
+    processing.add_argument("--execute", action="store_true")
+    reaction_complete = sub.add_parser(
+        "reaction-complete",
+        help="Remove bot-owned lifecycle reactions for one captured message.",
+    )
+    add_subcommand_format(reaction_complete)
+    reaction_complete.add_argument("--project")
+    reaction_complete.add_argument("--config")
+    reaction_complete.add_argument("--goal-id")
+    reaction_complete.add_argument("--message-id", required=True)
+    reaction_complete.add_argument("--execute", action="store_true")
     ingest = sub.add_parser(
         "ingest",
         help=(
@@ -176,7 +203,7 @@ def _required_extension_permissions(command: str) -> tuple[str, ...]:
         return (LARK_INBOX_READ_PERMISSION,)
     if command in {"ack", "ingest"}:
         return (LARK_INBOX_WRITE_PERMISSION,)
-    if command == "reply":
+    if command in {"reply", "processing", "reaction-complete"}:
         return (LARK_REPLY_PERMISSION,)
     return (LARK_COLLECTOR_PERMISSION,)
 
@@ -289,7 +316,14 @@ def handle_lark_inbox_command(
         return None
     activation: dict[str, object] | None = None
     try:
-        inbox_commands = {"drain", "ack", "reply", "ingest"}
+        inbox_commands = {
+            "drain",
+            "ack",
+            "reply",
+            "processing",
+            "reaction-complete",
+            "ingest",
+        }
         project: Path | None = None
         config_path: str | None = None
         if args.lark_inbox_command in inbox_commands:
@@ -335,6 +369,20 @@ def handle_lark_inbox_command(
                 config_path=config_path,
                 message_id=args.message_id,
                 text=args.text,
+                execute=args.execute,
+            )
+        elif args.lark_inbox_command == "processing":
+            payload = mark_lark_event_inbox_processing(
+                project=project,
+                config_path=config_path,
+                message_id=args.message_id,
+                execute=args.execute,
+            )
+        elif args.lark_inbox_command == "reaction-complete":
+            payload = complete_lark_event_inbox_reactions(
+                project=project,
+                config_path=config_path,
+                message_id=args.message_id,
                 execute=args.execute,
             )
         elif args.lark_inbox_command == "ingest":

--- a/loopx/extensions/lark/event_collector_runtime.py
+++ b/loopx/extensions/lark/event_collector_runtime.py
@@ -19,6 +19,10 @@ from .event_inbox import (
     _event_attention_kind,
     ingest_lark_event_inbox,
 )
+from .inbox_reactions import (
+    lark_inbox_reaction_lock,
+    record_lark_inbox_reaction,
+)
 
 
 APP_ID_PATTERN = re.compile(r"cli_[A-Za-z0-9_-]+")
@@ -235,17 +239,17 @@ def lark_event_requires_reply_context_lookup(
     return direct_attention not in {"direct_question", "direct_mention"}
 
 
-def add_lark_event_received_reaction(
+def _create_lark_event_received_reaction(
     event: Mapping[str, Any],
     *,
     runner: CommandRunner,
     command_prefix: Sequence[str],
     profile: str,
     emoji_type: str,
-) -> bool:
+) -> str | None:
     message_id = str(event.get("message_id") or "").strip()
     if not MESSAGE_ID_PATTERN.fullmatch(message_id) or not emoji_type:
-        return False
+        return None
     payload = _run_json(
         runner,
         [
@@ -269,11 +273,60 @@ def add_lark_event_received_reaction(
         ],
         timeout_seconds=5,
     )
-    return bool(
-        isinstance(payload, Mapping)
-        and payload.get("ok") is True
-        and _find_string_by_key(payload, {"reaction_id"})
+    if not isinstance(payload, Mapping) or payload.get("ok") is not True:
+        return None
+    return _find_string_by_key(payload, {"reaction_id"})
+
+
+def add_lark_event_received_reaction(
+    event: Mapping[str, Any],
+    *,
+    runner: CommandRunner,
+    command_prefix: Sequence[str],
+    profile: str,
+    emoji_type: str,
+) -> bool:
+    return (
+        _create_lark_event_received_reaction(
+            event,
+            runner=runner,
+            command_prefix=command_prefix,
+            profile=profile,
+            emoji_type=emoji_type,
+        )
+        is not None
     )
+
+
+def _delete_lark_event_reaction(
+    *,
+    runner: CommandRunner,
+    command_prefix: Sequence[str],
+    profile: str,
+    message_id: str,
+    reaction_id: str,
+) -> bool:
+    payload = _run_json(
+        runner,
+        [
+            *command_prefix,
+            "--profile",
+            profile,
+            "im",
+            "reactions",
+            "delete",
+            "--message-id",
+            message_id,
+            "--reaction-id",
+            reaction_id,
+            "--as",
+            "bot",
+            "--format",
+            "json",
+        ],
+        timeout_seconds=5,
+    )
+    return bool(isinstance(payload, Mapping) and payload.get("ok") is True)
 
 
 def run_lark_event_collector(
@@ -359,37 +412,73 @@ def run_lark_event_collector(
                         "reply_to_bot": False,
                     }
                 )
-            result = ingest_lark_event_inbox(
-                project=config["project"],
-                config_path=config["event_inbox_config_ref"],
-                events=[{"schema_version": "lark_event_inbox_event_v0", **enriched}],
-                execute=True,
-            )
-            if int(result.get("accepted_count") or 0) == 0:
+            message_id = str(enriched.get("message_id") or "")
+            if not MESSAGE_ID_PATTERN.fullmatch(message_id):
                 continue
-            captured_count += 1
-            verified_count += int(enriched.get("reply_context_verified") is True)
-            reply_to_bot_count += int(enriched.get("reply_to_bot") is True)
-            attention_kind = _event_attention_kind(
-                enriched,
-                bot_display_name=str(
-                    config["inbox"]["reply"].get("bot_display_name") or ""
-                ),
-                capture_scope="configured_chat_all",
-            )
-            received_reaction_emoji = str(
-                config["inbox"]["reply"].get("received_reaction_emoji") or ""
-            )
-            if attention_kind is not None and received_reaction_emoji:
-                reaction_added = add_lark_event_received_reaction(
-                    enriched,
-                    runner=runner,
-                    command_prefix=command_prefix,
-                    profile=str(config["profile"]),
-                    emoji_type=received_reaction_emoji,
+            with lark_inbox_reaction_lock(
+                inbox=config["inbox"]["inbox_path"],
+                message_id=message_id,
+            ):
+                result = ingest_lark_event_inbox(
+                    project=config["project"],
+                    config_path=config["event_inbox_config_ref"],
+                    events=[
+                        {
+                            "schema_version": "lark_event_inbox_event_v0",
+                            **enriched,
+                        }
+                    ],
+                    execute=True,
                 )
-                received_reaction_count += int(reaction_added)
-                received_reaction_failure_count += int(not reaction_added)
+                if int(result.get("accepted_count") or 0) == 0:
+                    continue
+                captured_count += 1
+                verified_count += int(
+                    enriched.get("reply_context_verified") is True
+                )
+                reply_to_bot_count += int(enriched.get("reply_to_bot") is True)
+                attention_kind = _event_attention_kind(
+                    enriched,
+                    bot_display_name=str(
+                        config["inbox"]["reply"].get("bot_display_name")
+                        or ""
+                    ),
+                    capture_scope="configured_chat_all",
+                )
+                received_reaction_emoji = str(
+                    config["inbox"]["reply"].get("received_reaction_emoji")
+                    or ""
+                )
+                if attention_kind is not None and received_reaction_emoji:
+                    reaction_id = _create_lark_event_received_reaction(
+                        enriched,
+                        runner=runner,
+                        command_prefix=command_prefix,
+                        profile=str(config["profile"]),
+                        emoji_type=received_reaction_emoji,
+                    )
+                    if reaction_id:
+                        try:
+                            record_lark_inbox_reaction(
+                                inbox=config["inbox"]["inbox_path"],
+                                message_id=message_id,
+                                phase="received",
+                                reaction_id=reaction_id,
+                                emoji_type=received_reaction_emoji,
+                            )
+                        except (OSError, ValueError):
+                            _delete_lark_event_reaction(
+                                runner=runner,
+                                command_prefix=command_prefix,
+                                profile=str(config["profile"]),
+                                message_id=message_id,
+                                reaction_id=reaction_id,
+                            )
+                            reaction_id = None
+                    received_reaction_count += int(reaction_id is not None)
+                    received_reaction_failure_count += int(
+                        reaction_id is None
+                    )
         returncode = process.wait()
     finally:
         if process.poll() is None:

--- a/loopx/extensions/lark/event_inbox.py
+++ b/loopx/extensions/lark/event_inbox.py
@@ -95,15 +95,29 @@ def load_lark_event_inbox_config(
     received_reaction_emoji = str(
         reply_payload.get("received_reaction_emoji") or ""
     ).strip()
-    if received_reaction_emoji and not REACTION_EMOJI_PATTERN.fullmatch(
-        received_reaction_emoji
+    processing_reaction_emoji = str(
+        reply_payload.get("processing_reaction_emoji") or ""
+    ).strip()
+    for field, emoji_type in (
+        ("received_reaction_emoji", received_reaction_emoji),
+        ("processing_reaction_emoji", processing_reaction_emoji),
+    ):
+        if emoji_type and not REACTION_EMOJI_PATTERN.fullmatch(emoji_type):
+            raise ValueError(f"lark inbox {field} must be a valid emoji type")
+        if emoji_type and not reply_enabled:
+            raise ValueError(f"lark inbox {field} requires enabled reply")
+    if processing_reaction_emoji and not received_reaction_emoji:
+        raise ValueError(
+            "lark inbox processing_reaction_emoji requires "
+            "received_reaction_emoji"
+        )
+    if (
+        processing_reaction_emoji
+        and processing_reaction_emoji == received_reaction_emoji
     ):
         raise ValueError(
-            "lark inbox received_reaction_emoji must be a valid emoji type"
-        )
-    if received_reaction_emoji and not reply_enabled:
-        raise ValueError(
-            "lark inbox received_reaction_emoji requires enabled reply"
+            "lark inbox processing_reaction_emoji must differ from "
+            "received_reaction_emoji"
         )
     if reply_enabled and (
         capture_scope != "configured_chat_all"
@@ -130,6 +144,7 @@ def load_lark_event_inbox_config(
             "bot_display_name": bot_display_name,
             "chat_id": chat_id,
             "received_reaction_emoji": received_reaction_emoji,
+            "processing_reaction_emoji": processing_reaction_emoji,
         },
     }
 
@@ -359,8 +374,11 @@ def inspect_lark_event_inbox(
         "local_private_content_returned": bool(bounded),
         "external_reads_performed": False,
         "instruction": (
-            "Translate each actionable item into a todo, vision correction, PR update, "
-            "or no-follow-up rationale, then acknowledge its message_id."
+            "For an actionable item, first run `loopx lark-inbox processing` for "
+            "its message_id, then translate it into a todo, vision correction, PR "
+            "update, or no-follow-up rationale. Send and verify any required reply "
+            "before acknowledging the message_id. If no reply is required, run "
+            "`loopx lark-inbox reaction-complete` before acknowledging it."
         ),
     }
 

--- a/loopx/extensions/lark/inbox_reactions.py
+++ b/loopx/extensions/lark/inbox_reactions.py
@@ -1,0 +1,661 @@
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+import re
+import subprocess
+from collections.abc import Callable, Mapping
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator, Sequence
+
+from .event_inbox import (
+    MESSAGE_ID_PATTERN,
+    REACTION_EMOJI_PATTERN,
+    _event_from_file,
+    _load_processed,
+    load_lark_event_inbox_config,
+)
+from .private_json import write_private_json_atomic
+
+
+REACTION_RECEIPTS_SCHEMA_VERSION = "lark_event_inbox_reaction_receipts_v0"
+REACTION_PHASES = {"received", "processing"}
+REACTION_ID_PATTERN = re.compile(r"[A-Za-z0-9_-]{1,200}")
+CommandRunner = Callable[[Sequence[str]], Mapping[str, Any]]
+
+
+def _default_runner(args: Sequence[str]) -> Mapping[str, Any]:
+    result = subprocess.run(
+        list(args),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=10,
+    )
+    return {
+        "returncode": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+
+
+def _call(runner: CommandRunner, args: Sequence[str]) -> Mapping[str, Any]:
+    try:
+        return runner(args)
+    except (OSError, subprocess.SubprocessError):
+        return {"returncode": 1}
+
+
+def _json_object(value: Any) -> Mapping[str, Any]:
+    try:
+        payload = json.loads(str(value or ""))
+    except json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, Mapping) else {}
+
+
+def _find_string_by_key(value: object, key: str) -> str | None:
+    if isinstance(value, Mapping):
+        candidate = value.get(key)
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+        return next(
+            (
+                found
+                for child in value.values()
+                if (found := _find_string_by_key(child, key))
+            ),
+            None,
+        )
+    if isinstance(value, list):
+        return next(
+            (
+                found
+                for child in value
+                if (found := _find_string_by_key(child, key))
+            ),
+            None,
+        )
+    return None
+
+
+def _contains_string_by_key(value: object, key: str, expected: str) -> bool:
+    if isinstance(value, Mapping):
+        candidate = value.get(key)
+        if isinstance(candidate, str) and candidate.strip() == expected:
+            return True
+        return any(
+            _contains_string_by_key(child, key, expected)
+            for child in value.values()
+        )
+    if isinstance(value, list):
+        return any(
+            _contains_string_by_key(child, key, expected) for child in value
+        )
+    return False
+
+
+def _receipt_path(inbox: Path) -> Path:
+    return inbox / "reactions" / "receipts.json"
+
+
+def _lock_path(inbox: Path) -> Path:
+    return inbox / "reactions" / "receipts.lock"
+
+
+def _operation_lock_path(inbox: Path, message_id: str) -> Path:
+    bucket = hashlib.sha256(message_id.encode("utf-8")).hexdigest()[:2]
+    return inbox / "reactions" / f"operation-{bucket}.lock"
+
+
+@contextmanager
+def lark_inbox_reaction_lock(
+    *, inbox: Path, message_id: str
+) -> Iterator[None]:
+    normalized = str(message_id or "").strip()
+    if not MESSAGE_ID_PATTERN.fullmatch(normalized):
+        raise ValueError("reaction lock requires a valid Lark message id")
+    lock_path = _operation_lock_path(inbox, normalized)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+", encoding="utf-8") as lock:
+        os.fchmod(lock.fileno(), 0o600)
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+
+
+def _valid_receipt(value: object) -> dict[str, str] | None:
+    if not isinstance(value, Mapping):
+        return None
+    reaction_id = str(value.get("reaction_id") or "").strip()
+    emoji_type = str(value.get("emoji_type") or "").strip()
+    if not REACTION_ID_PATTERN.fullmatch(
+        reaction_id
+    ) or not REACTION_EMOJI_PATTERN.fullmatch(emoji_type):
+        return None
+    return {
+        "reaction_id": reaction_id,
+        "emoji_type": emoji_type,
+    }
+
+
+def _load_receipts(path: Path) -> dict[str, dict[str, dict[str, str]]]:
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("lark inbox reaction receipts are unreadable") from exc
+    if (
+        not isinstance(payload, Mapping)
+        or payload.get("schema_version") != REACTION_RECEIPTS_SCHEMA_VERSION
+    ):
+        raise ValueError("lark inbox reaction receipts schema is invalid")
+    raw_receipts = payload.get("receipts")
+    if not isinstance(raw_receipts, Mapping):
+        raise ValueError("lark inbox reaction receipts payload is invalid")
+    receipts: dict[str, dict[str, dict[str, str]]] = {}
+    for raw_message_id, raw_phases in raw_receipts.items():
+        message_id = str(raw_message_id)
+        if not MESSAGE_ID_PATTERN.fullmatch(message_id) or not isinstance(
+            raw_phases, Mapping
+        ):
+            raise ValueError("lark inbox reaction receipt entry is invalid")
+        phases = {
+            phase: receipt
+            for phase in REACTION_PHASES
+            if (receipt := _valid_receipt(raw_phases.get(phase))) is not None
+        }
+        if set(raw_phases) != set(phases):
+            raise ValueError("lark inbox reaction receipt phase is invalid")
+        if phases:
+            receipts[message_id] = phases
+    return receipts
+
+
+def lark_inbox_reaction_receipts(
+    *, inbox: Path, message_id: str
+) -> dict[str, dict[str, str]]:
+    normalized = str(message_id or "").strip()
+    if not MESSAGE_ID_PATTERN.fullmatch(normalized):
+        raise ValueError("reaction receipts require a valid Lark message id")
+    return dict(_load_receipts(_receipt_path(inbox)).get(normalized, {}))
+
+
+def _update_receipts(
+    *,
+    inbox: Path,
+    update: Callable[[dict[str, dict[str, dict[str, str]]]], None],
+) -> None:
+    lock_path = _lock_path(inbox)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+", encoding="utf-8") as lock:
+        os.fchmod(lock.fileno(), 0o600)
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        path = _receipt_path(inbox)
+        receipts = _load_receipts(path)
+        update(receipts)
+        write_private_json_atomic(
+            path,
+            {
+                "schema_version": REACTION_RECEIPTS_SCHEMA_VERSION,
+                "receipts": receipts,
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+        fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+
+
+def record_lark_inbox_reaction(
+    *,
+    inbox: Path,
+    message_id: str,
+    phase: str,
+    reaction_id: str,
+    emoji_type: str,
+) -> None:
+    normalized_message_id = str(message_id or "").strip()
+    normalized_phase = str(phase or "").strip()
+    normalized_reaction_id = str(reaction_id or "").strip()
+    normalized_emoji_type = str(emoji_type or "").strip()
+    if not MESSAGE_ID_PATTERN.fullmatch(normalized_message_id):
+        raise ValueError("reaction receipt requires a valid Lark message id")
+    if normalized_phase not in REACTION_PHASES:
+        raise ValueError("reaction receipt phase is invalid")
+    if not REACTION_ID_PATTERN.fullmatch(normalized_reaction_id):
+        raise ValueError("reaction receipt requires a valid reaction id")
+    if not REACTION_EMOJI_PATTERN.fullmatch(normalized_emoji_type):
+        raise ValueError("reaction receipt requires a valid emoji type")
+
+    def update(receipts: dict[str, dict[str, dict[str, str]]]) -> None:
+        phases = receipts.setdefault(normalized_message_id, {})
+        phases[normalized_phase] = {
+            "reaction_id": normalized_reaction_id,
+            "emoji_type": normalized_emoji_type,
+        }
+
+    _update_receipts(inbox=inbox, update=update)
+
+
+def clear_lark_inbox_reaction(
+    *,
+    inbox: Path,
+    message_id: str,
+    phase: str,
+    reaction_id: str,
+) -> None:
+    normalized_message_id = str(message_id or "").strip()
+    normalized_phase = str(phase or "").strip()
+    normalized_reaction_id = str(reaction_id or "").strip()
+    if not MESSAGE_ID_PATTERN.fullmatch(normalized_message_id):
+        raise ValueError("reaction receipt requires a valid Lark message id")
+    if normalized_phase not in REACTION_PHASES:
+        raise ValueError("reaction receipt phase is invalid")
+    if not REACTION_ID_PATTERN.fullmatch(normalized_reaction_id):
+        raise ValueError("reaction receipt requires a valid reaction id")
+
+    def update(receipts: dict[str, dict[str, dict[str, str]]]) -> None:
+        phases = receipts.get(normalized_message_id)
+        if not phases:
+            return
+        receipt = phases.get(normalized_phase)
+        if receipt and receipt.get("reaction_id") == normalized_reaction_id:
+            phases.pop(normalized_phase, None)
+        if not phases:
+            receipts.pop(normalized_message_id, None)
+
+    _update_receipts(inbox=inbox, update=update)
+
+
+def _create_reaction(
+    *,
+    runner: CommandRunner,
+    profile: str,
+    message_id: str,
+    emoji_type: str,
+) -> str | None:
+    result = _call(
+        runner,
+        [
+            "lark-cli",
+            "--profile",
+            profile,
+            "im",
+            "reactions",
+            "create",
+            "--message-id",
+            message_id,
+            "--data",
+            json.dumps(
+                {"reaction_type": {"emoji_type": emoji_type}},
+                separators=(",", ":"),
+            ),
+            "--as",
+            "bot",
+            "--format",
+            "json",
+        ],
+    )
+    if result.get("returncode") != 0:
+        return None
+    payload = _json_object(result.get("stdout"))
+    return (
+        _find_string_by_key(payload, "reaction_id")
+        if payload.get("ok") is True
+        else None
+    )
+
+
+def _delete_reaction(
+    *,
+    runner: CommandRunner,
+    profile: str,
+    message_id: str,
+    reaction_id: str,
+) -> bool:
+    result = _call(
+        runner,
+        [
+            "lark-cli",
+            "--profile",
+            profile,
+            "im",
+            "reactions",
+            "delete",
+            "--message-id",
+            message_id,
+            "--reaction-id",
+            reaction_id,
+            "--as",
+            "bot",
+            "--format",
+            "json",
+        ],
+    )
+    if (
+        result.get("returncode") == 0
+        and _json_object(result.get("stdout")).get("ok") is True
+    ):
+        return True
+    readback = _call(
+        runner,
+        [
+            "lark-cli",
+            "--profile",
+            profile,
+            "im",
+            "reactions",
+            "list",
+            "--message-id",
+            message_id,
+            "--page-all",
+            "--as",
+            "bot",
+            "--format",
+            "json",
+        ],
+    )
+    if readback.get("returncode") != 0:
+        return False
+    payload = _json_object(readback.get("stdout"))
+    return bool(
+        payload.get("ok") is True
+        and not _contains_string_by_key(payload, "reaction_id", reaction_id)
+    )
+
+
+def _captured_pending_message(
+    *, inbox: Path, message_id: str
+) -> bool:
+    if message_id in _load_processed(inbox / "processed.json"):
+        return False
+    return any(
+        event.get("message_id") == message_id
+        for path in (inbox.glob("*.json") if inbox.is_dir() else [])
+        if path.name != "processed.json"
+        if (event := _event_from_file(path)) is not None
+    )
+
+
+def _operation_result(
+    *,
+    operation: str,
+    status: str,
+    ok: bool,
+    execute: bool,
+    configured: bool,
+    created_count: int = 0,
+    deleted_count: int = 0,
+    pending_delete_count: int = 0,
+    blocker: str | None = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "ok": ok,
+        "schema_version": "lark_event_inbox_reaction_operation_v0",
+        "operation": operation,
+        "status": status,
+        "execute": execute,
+        "configured": configured,
+        "external_write_authority_asserted": execute,
+        "external_writes_performed": created_count + deleted_count > 0,
+        "created_count": created_count,
+        "deleted_count": deleted_count,
+        "pending_delete_count": pending_delete_count,
+        "private_sender_profile_captured": False,
+        "private_message_id_captured": False,
+        "private_reaction_id_captured": False,
+        "raw_provider_payload_captured": False,
+    }
+    if blocker:
+        result["blocker"] = blocker
+    return result
+
+
+def mark_lark_event_inbox_processing(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    message_id: str,
+    execute: bool = False,
+    runner: CommandRunner = _default_runner,
+) -> dict[str, Any]:
+    config = load_lark_event_inbox_config(project=project, config_path=config_path)
+    if not config["enabled"]:
+        raise ValueError("lark event inbox is not enabled")
+    normalized = str(message_id or "").strip()
+    if not MESSAGE_ID_PATTERN.fullmatch(normalized):
+        raise ValueError("processing requires a valid Lark message id")
+    inbox = config["inbox_path"]
+    with lark_inbox_reaction_lock(inbox=inbox, message_id=normalized):
+        if not _captured_pending_message(inbox=inbox, message_id=normalized):
+            raise ValueError("processing requires a captured pending inbox message")
+        return _mark_lark_event_inbox_processing_locked(
+            config=config,
+            message_id=normalized,
+            execute=execute,
+            runner=runner,
+        )
+
+
+def _mark_lark_event_inbox_processing_locked(
+    *,
+    config: Mapping[str, Any],
+    message_id: str,
+    execute: bool,
+    runner: CommandRunner,
+) -> dict[str, Any]:
+    inbox = config["inbox_path"]
+    normalized = message_id
+    reply = config["reply"]
+    processing_emoji = str(reply.get("processing_reaction_emoji") or "")
+    if not processing_emoji:
+        return _operation_result(
+            operation="processing",
+            status="not_configured",
+            ok=True,
+            execute=execute,
+            configured=False,
+        )
+    receipts = lark_inbox_reaction_receipts(
+        inbox=inbox,
+        message_id=normalized,
+    )
+    received = receipts.get("received")
+    processing = receipts.get("processing")
+    if not execute:
+        return _operation_result(
+            operation="processing",
+            status="preview_ready",
+            ok=True,
+            execute=False,
+            configured=True,
+            pending_delete_count=int(received is not None),
+        )
+
+    profile = str(reply["sender_profile"])
+    created_count = 0
+    if processing is None:
+        reaction_id = _create_reaction(
+            runner=runner,
+            profile=profile,
+            message_id=normalized,
+            emoji_type=processing_emoji,
+        )
+        if reaction_id is None:
+            return _operation_result(
+                operation="processing",
+                status="failed",
+                ok=False,
+                execute=True,
+                configured=True,
+                blocker="lark_inbox_processing_reaction_create_failed",
+            )
+        try:
+            record_lark_inbox_reaction(
+                inbox=inbox,
+                message_id=normalized,
+                phase="processing",
+                reaction_id=reaction_id,
+                emoji_type=processing_emoji,
+            )
+        except (OSError, ValueError):
+            _delete_reaction(
+                runner=runner,
+                profile=profile,
+                message_id=normalized,
+                reaction_id=reaction_id,
+            )
+            return _operation_result(
+                operation="processing",
+                status="failed",
+                ok=False,
+                execute=True,
+                configured=True,
+                created_count=1,
+                blocker="lark_inbox_processing_reaction_receipt_failed",
+            )
+        processing = {
+            "reaction_id": reaction_id,
+            "emoji_type": processing_emoji,
+        }
+        created_count = 1
+
+    deleted_count = 0
+    if received is not None:
+        if not _delete_reaction(
+            runner=runner,
+            profile=profile,
+            message_id=normalized,
+            reaction_id=received["reaction_id"],
+        ):
+            return _operation_result(
+                operation="processing",
+                status="cleanup_pending",
+                ok=False,
+                execute=True,
+                configured=True,
+                created_count=created_count,
+                pending_delete_count=1,
+                blocker="lark_inbox_received_reaction_delete_failed",
+            )
+        clear_lark_inbox_reaction(
+            inbox=inbox,
+            message_id=normalized,
+            phase="received",
+            reaction_id=received["reaction_id"],
+        )
+        deleted_count = 1
+    return _operation_result(
+        operation="processing",
+        status="processing",
+        ok=True,
+        execute=True,
+        configured=True,
+        created_count=created_count,
+        deleted_count=deleted_count,
+    )
+
+
+def complete_lark_event_inbox_reactions(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    message_id: str,
+    execute: bool = False,
+    runner: CommandRunner = _default_runner,
+) -> dict[str, Any]:
+    config = load_lark_event_inbox_config(project=project, config_path=config_path)
+    if not config["enabled"]:
+        raise ValueError("lark event inbox is not enabled")
+    normalized = str(message_id or "").strip()
+    if not MESSAGE_ID_PATTERN.fullmatch(normalized):
+        raise ValueError("reaction completion requires a valid Lark message id")
+    inbox = config["inbox_path"]
+    with lark_inbox_reaction_lock(inbox=inbox, message_id=normalized):
+        return _complete_lark_event_inbox_reactions_locked(
+            config=config,
+            message_id=normalized,
+            execute=execute,
+            runner=runner,
+        )
+
+
+def _complete_lark_event_inbox_reactions_locked(
+    *,
+    config: Mapping[str, Any],
+    message_id: str,
+    execute: bool,
+    runner: CommandRunner,
+) -> dict[str, Any]:
+    inbox = config["inbox_path"]
+    normalized = message_id
+    receipts = lark_inbox_reaction_receipts(
+        inbox=inbox,
+        message_id=normalized,
+    )
+    configured = bool(
+        config["reply"].get("received_reaction_emoji")
+        or config["reply"].get("processing_reaction_emoji")
+    )
+    if not receipts:
+        return _operation_result(
+            operation="complete",
+            status="already_complete",
+            ok=True,
+            execute=execute,
+            configured=configured,
+        )
+    if not execute:
+        return _operation_result(
+            operation="complete",
+            status="preview_ready",
+            ok=True,
+            execute=False,
+            configured=configured,
+            pending_delete_count=len(receipts),
+        )
+
+    profile = str(config["reply"]["sender_profile"])
+    deleted_count = 0
+    for phase in ("processing", "received"):
+        receipt = receipts.get(phase)
+        if receipt is None:
+            continue
+        if not _delete_reaction(
+            runner=runner,
+            profile=profile,
+            message_id=normalized,
+            reaction_id=receipt["reaction_id"],
+        ):
+            remaining = len(receipts) - deleted_count
+            return _operation_result(
+                operation="complete",
+                status="cleanup_pending",
+                ok=False,
+                execute=True,
+                configured=configured,
+                deleted_count=deleted_count,
+                pending_delete_count=remaining,
+                blocker="lark_inbox_reaction_delete_failed",
+            )
+        clear_lark_inbox_reaction(
+            inbox=inbox,
+            message_id=normalized,
+            phase=phase,
+            reaction_id=receipt["reaction_id"],
+        )
+        deleted_count += 1
+    return _operation_result(
+        operation="complete",
+        status="completed",
+        ok=True,
+        execute=True,
+        configured=configured,
+        deleted_count=deleted_count,
+    )

--- a/loopx/extensions/lark/inbox_reactions.py
+++ b/loopx/extensions/lark/inbox_reactions.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-import fcntl
 import hashlib
 import json
-import os
 import re
 import subprocess
 from collections.abc import Callable, Mapping
@@ -12,6 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterator, Sequence
 
+from ...file_lock import exclusive_file_lock
 from .event_inbox import (
     MESSAGE_ID_PATTERN,
     REACTION_EMOJI_PATTERN,
@@ -103,13 +102,9 @@ def _receipt_path(inbox: Path) -> Path:
     return inbox / "reactions" / "receipts.json"
 
 
-def _lock_path(inbox: Path) -> Path:
-    return inbox / "reactions" / "receipts.lock"
-
-
-def _operation_lock_path(inbox: Path, message_id: str) -> Path:
+def _operation_lock_target(inbox: Path, message_id: str) -> Path:
     bucket = hashlib.sha256(message_id.encode("utf-8")).hexdigest()[:2]
-    return inbox / "reactions" / f"operation-{bucket}.lock"
+    return inbox / "reactions" / f"operation-{bucket}"
 
 
 @contextmanager
@@ -119,15 +114,11 @@ def lark_inbox_reaction_lock(
     normalized = str(message_id or "").strip()
     if not MESSAGE_ID_PATTERN.fullmatch(normalized):
         raise ValueError("reaction lock requires a valid Lark message id")
-    lock_path = _operation_lock_path(inbox, normalized)
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with lock_path.open("a+", encoding="utf-8") as lock:
-        os.fchmod(lock.fileno(), 0o600)
-        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
-        try:
-            yield
-        finally:
-            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+    with exclusive_file_lock(
+        _operation_lock_target(inbox, normalized),
+        operation="lark_inbox_reaction_transition",
+    ):
+        yield
 
 
 def _valid_receipt(value: object) -> dict[str, str] | None:
@@ -193,12 +184,11 @@ def _update_receipts(
     inbox: Path,
     update: Callable[[dict[str, dict[str, dict[str, str]]]], None],
 ) -> None:
-    lock_path = _lock_path(inbox)
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with lock_path.open("a+", encoding="utf-8") as lock:
-        os.fchmod(lock.fileno(), 0o600)
-        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
-        path = _receipt_path(inbox)
+    path = _receipt_path(inbox)
+    with exclusive_file_lock(
+        path,
+        operation="lark_inbox_reaction_receipts",
+    ):
         receipts = _load_receipts(path)
         update(receipts)
         write_private_json_atomic(
@@ -209,7 +199,6 @@ def _update_receipts(
                 "updated_at": datetime.now(timezone.utc).isoformat(),
             },
         )
-        fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
 
 
 def record_lark_inbox_reaction(

--- a/loopx/extensions/lark/inbox_reply.py
+++ b/loopx/extensions/lark/inbox_reply.py
@@ -13,6 +13,7 @@ from .event_inbox import (
     _event_from_file,
     load_lark_event_inbox_config,
 )
+from .inbox_reactions import complete_lark_event_inbox_reactions
 
 
 CommandRunner = Callable[[Sequence[str]], Mapping[str, Any]]
@@ -187,6 +188,7 @@ def _result(
     write_performed: bool = False,
     readback_performed: bool = False,
     reply_verified: bool = False,
+    reaction_cleanup_verified: bool = False,
     blocker: str | None = None,
 ) -> dict[str, Any]:
     packet: dict[str, Any] = {
@@ -199,6 +201,7 @@ def _result(
         "external_write_performed": write_performed,
         "verification_performed": readback_performed,
         "reply_verified": reply_verified,
+        "reaction_cleanup_verified": reaction_cleanup_verified,
         "sender_identity_verified": identity_verified,
         "sender_chat_membership_verified": membership_verified,
         "private_sender_profile_captured": False,
@@ -385,9 +388,30 @@ def reply_lark_event_inbox(
             message=readback_message,
         )
     )
+    reaction_cleanup = (
+        complete_lark_event_inbox_reactions(
+            project=project,
+            config_path=config_path,
+            message_id=source_message_id,
+            execute=True,
+            runner=runner,
+        )
+        if verified
+        else None
+    )
+    reaction_cleanup_verified = bool(
+        reaction_cleanup is not None and reaction_cleanup.get("ok") is True
+    )
+    completed = bool(verified and reaction_cleanup_verified)
     return _result(
-        status="sent_verified" if verified else "sent_unverified",
-        ok=verified,
+        status=(
+            "sent_verified"
+            if completed
+            else "sent_verified_cleanup_pending"
+            if verified
+            else "sent_unverified"
+        ),
+        ok=completed,
         execute=True,
         receipt=receipt,
         identity_verified=True,
@@ -395,5 +419,12 @@ def reply_lark_event_inbox(
         write_performed=True,
         readback_performed=True,
         reply_verified=verified,
-        blocker=None if verified else "lark_inbox_reply_not_verified",
+        reaction_cleanup_verified=reaction_cleanup_verified,
+        blocker=(
+            None
+            if completed
+            else "lark_inbox_reply_reaction_cleanup_pending"
+            if verified
+            else "lark_inbox_reply_not_verified"
+        ),
     )

--- a/loopx/extensions/lark/provider.py
+++ b/loopx/extensions/lark/provider.py
@@ -20,6 +20,10 @@ REQUIRED_EXPORTS = {
         "project_lark_event_inbox_urgency",
     ),
     "loopx.extensions.lark.inbox_reply": ("reply_lark_event_inbox",),
+    "loopx.extensions.lark.inbox_reactions": (
+        "complete_lark_event_inbox_reactions",
+        "mark_lark_event_inbox_processing",
+    ),
     "loopx.extensions.lark.reviewer_notification": (
         "lark_reviewer_notification_sink",
     ),

--- a/tests/extensions/test_lark_inbox_reactions.py
+++ b/tests/extensions/test_lark_inbox_reactions.py
@@ -1,0 +1,522 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from loopx.extensions.lark.inbox_reactions import (
+    complete_lark_event_inbox_reactions,
+    lark_inbox_reaction_receipts,
+    mark_lark_event_inbox_processing,
+    record_lark_inbox_reaction,
+)
+from loopx.extensions.lark.event_inbox import load_lark_event_inbox_config
+from loopx.extensions.lark.inbox_reply import reply_lark_event_inbox
+
+
+def _fixture(tmp_path: Path, *, lifecycle: bool = True) -> tuple[Path, Path, Path]:
+    inbox = tmp_path / ".loopx" / "inbox" / "feedback"
+    inbox.mkdir(parents=True)
+    config = tmp_path / ".loopx" / "config" / "lark-inbox.json"
+    config.parent.mkdir(parents=True)
+    reply = {
+        "enabled": True,
+        "sender_profile": "project-review-bot",
+        "sender_identity": "bot",
+        "bot_display_name": "Project Review Bot",
+        "chat_id": "oc_project_review",
+    }
+    if lifecycle:
+        reply.update(
+            {
+                "received_reaction_emoji": "Get",
+                "processing_reaction_emoji": "OnIt",
+            }
+        )
+    config.write_text(
+        json.dumps(
+            {
+                "schema_version": "lark_event_inbox_config_v0",
+                "enabled": True,
+                "inbox_dir": ".loopx/inbox/feedback",
+                "capture_scope": "configured_chat_all",
+                "reply": reply,
+            }
+        ),
+        encoding="utf-8",
+    )
+    message_id = "om_reaction_fixture"
+    (inbox / f"{message_id}.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "lark_event_inbox_event_v0",
+                "event_id": "evt-reaction-fixture",
+                "message_id": message_id,
+                "create_time": "2026-08-11T00:00:00Z",
+                "content": "@Project Review Bot please handle this",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return config, inbox, tmp_path
+
+
+class ReactionRunner:
+    def __init__(
+        self,
+        *,
+        fail_delete: bool = False,
+        reaction_still_present: bool = True,
+    ) -> None:
+        self.calls: list[list[str]] = []
+        self.fail_delete = fail_delete
+        self.reaction_still_present = reaction_still_present
+
+    def __call__(self, args: Sequence[str]) -> dict[str, Any]:
+        call = list(args)
+        self.calls.append(call)
+        if "create" in call:
+            emoji_payload = json.loads(call[call.index("--data") + 1])
+            emoji_type = emoji_payload["reaction_type"]["emoji_type"]
+            return {
+                "returncode": 0,
+                "stdout": json.dumps(
+                    {
+                        "ok": True,
+                        "data": {"reaction_id": f"reaction_{emoji_type}"},
+                    }
+                ),
+                "stderr": "",
+            }
+        if "delete" in call:
+            return {
+                "returncode": int(self.fail_delete),
+                "stdout": json.dumps({"ok": not self.fail_delete}),
+                "stderr": "",
+            }
+        if "list" in call:
+            return {
+                "returncode": 0,
+                "stdout": json.dumps(
+                    {
+                        "ok": True,
+                        "data": {
+                            "items": (
+                                [{"reaction_id": "reaction_Get"}]
+                                if self.reaction_still_present
+                                else []
+                            )
+                        },
+                    }
+                ),
+                "stderr": "",
+            }
+        raise AssertionError(call)
+
+
+class ReplyRunner:
+    def __init__(
+        self,
+        *,
+        matching_readback: bool = True,
+        fail_reaction_delete: bool = False,
+    ) -> None:
+        self.calls: list[list[str]] = []
+        self.matching_readback = matching_readback
+        self.fail_reaction_delete = fail_reaction_delete
+
+    def __call__(self, args: Sequence[str]) -> dict[str, Any]:
+        call = list(args)
+        self.calls.append(call)
+        if call[3:6] == ["auth", "status", "--verify"]:
+            return {
+                "returncode": 0,
+                "stdout": json.dumps(
+                    {
+                        "identities": {
+                            "bot": {
+                                "available": True,
+                                "verified": True,
+                                "appName": "Project Review Bot",
+                            }
+                        }
+                    }
+                ),
+                "stderr": "",
+            }
+        if call[3:6] == ["im", "chats", "get"]:
+            return {"returncode": 0, "stdout": "{}", "stderr": ""}
+        if "+messages-reply" in call:
+            return {
+                "returncode": 0,
+                "stdout": json.dumps({"message_id": "om_reply_fixture"}),
+                "stderr": "",
+            }
+        if "+messages-mget" in call:
+            return {
+                "returncode": 0,
+                "stdout": json.dumps(
+                    {
+                        "items": [
+                            {
+                                "message_id": "om_reply_fixture",
+                                "content": (
+                                    "处理完成"
+                                    if self.matching_readback
+                                    else "provider returned different text"
+                                ),
+                            }
+                        ]
+                    },
+                    ensure_ascii=False,
+                ),
+                "stderr": "",
+            }
+        if "reactions" in call and "delete" in call:
+            return {
+                "returncode": int(self.fail_reaction_delete),
+                "stdout": json.dumps(
+                    {"ok": not self.fail_reaction_delete}
+                ),
+                "stderr": "",
+            }
+        if "reactions" in call and "list" in call:
+            return {
+                "returncode": 0,
+                "stdout": json.dumps(
+                    {
+                        "ok": True,
+                        "data": {
+                            "items": (
+                                [{"reaction_id": "reaction_OnIt"}]
+                                if self.fail_reaction_delete
+                                else []
+                            )
+                        },
+                    }
+                ),
+                "stderr": "",
+            }
+        raise AssertionError(call)
+
+
+def test_processing_replaces_received_reaction(tmp_path: Path) -> None:
+    config, inbox, project = _fixture(tmp_path)
+    record_lark_inbox_reaction(
+        inbox=inbox,
+        message_id="om_reaction_fixture",
+        phase="received",
+        reaction_id="reaction_Get",
+        emoji_type="Get",
+    )
+    runner = ReactionRunner()
+
+    result = mark_lark_event_inbox_processing(
+        project=project,
+        config_path=config,
+        message_id="om_reaction_fixture",
+        execute=True,
+        runner=runner,
+    )
+
+    assert result["ok"] is True
+    assert result["status"] == "processing"
+    assert result["created_count"] == 1
+    assert result["deleted_count"] == 1
+    assert ["create" in call for call in runner.calls] == [True, False]
+    assert runner.calls[1][runner.calls[1].index("--reaction-id") + 1] == (
+        "reaction_Get"
+    )
+    assert lark_inbox_reaction_receipts(
+        inbox=inbox,
+        message_id="om_reaction_fixture",
+    ) == {
+        "processing": {
+            "reaction_id": "reaction_OnIt",
+            "emoji_type": "OnIt",
+        }
+    }
+
+
+def test_processing_delete_failure_is_retryable(tmp_path: Path) -> None:
+    config, inbox, project = _fixture(tmp_path)
+    record_lark_inbox_reaction(
+        inbox=inbox,
+        message_id="om_reaction_fixture",
+        phase="received",
+        reaction_id="reaction_Get",
+        emoji_type="Get",
+    )
+    failed_runner = ReactionRunner(fail_delete=True)
+
+    failed = mark_lark_event_inbox_processing(
+        project=project,
+        config_path=config,
+        message_id="om_reaction_fixture",
+        execute=True,
+        runner=failed_runner,
+    )
+
+    assert failed["ok"] is False
+    assert failed["status"] == "cleanup_pending"
+    assert failed["blocker"] == "lark_inbox_received_reaction_delete_failed"
+    assert set(
+        lark_inbox_reaction_receipts(
+            inbox=inbox,
+            message_id="om_reaction_fixture",
+        )
+    ) == {"received", "processing"}
+
+    retry_runner = ReactionRunner()
+    retried = mark_lark_event_inbox_processing(
+        project=project,
+        config_path=config,
+        message_id="om_reaction_fixture",
+        execute=True,
+        runner=retry_runner,
+    )
+
+    assert retried["ok"] is True
+    assert retried["created_count"] == 0
+    assert len(retry_runner.calls) == 1
+    assert "delete" in retry_runner.calls[0]
+
+
+def test_delete_retry_accepts_already_absent_reaction(tmp_path: Path) -> None:
+    config, inbox, project = _fixture(tmp_path)
+    record_lark_inbox_reaction(
+        inbox=inbox,
+        message_id="om_reaction_fixture",
+        phase="received",
+        reaction_id="reaction_Get",
+        emoji_type="Get",
+    )
+    runner = ReactionRunner(
+        fail_delete=True,
+        reaction_still_present=False,
+    )
+
+    result = mark_lark_event_inbox_processing(
+        project=project,
+        config_path=config,
+        message_id="om_reaction_fixture",
+        execute=True,
+        runner=runner,
+    )
+
+    assert result["ok"] is True
+    assert result["status"] == "processing"
+    assert any("list" in call for call in runner.calls)
+    assert set(
+        lark_inbox_reaction_receipts(
+            inbox=inbox,
+            message_id="om_reaction_fixture",
+        )
+    ) == {"processing"}
+
+
+def test_completion_removes_only_recorded_bot_reactions(tmp_path: Path) -> None:
+    config, inbox, project = _fixture(tmp_path)
+    for phase, reaction_id, emoji_type in (
+        ("received", "reaction_Get", "Get"),
+        ("processing", "reaction_OnIt", "OnIt"),
+    ):
+        record_lark_inbox_reaction(
+            inbox=inbox,
+            message_id="om_reaction_fixture",
+            phase=phase,
+            reaction_id=reaction_id,
+            emoji_type=emoji_type,
+        )
+    runner = ReactionRunner()
+
+    result = complete_lark_event_inbox_reactions(
+        project=project,
+        config_path=config,
+        message_id="om_reaction_fixture",
+        execute=True,
+        runner=runner,
+    )
+
+    assert result["ok"] is True
+    assert result["status"] == "completed"
+    assert result["deleted_count"] == 2
+    assert all("delete" in call for call in runner.calls)
+    assert {
+        call[call.index("--reaction-id") + 1] for call in runner.calls
+    } == {"reaction_Get", "reaction_OnIt"}
+    assert (
+        lark_inbox_reaction_receipts(
+            inbox=inbox,
+            message_id="om_reaction_fixture",
+        )
+        == {}
+    )
+
+
+def test_lifecycle_is_quiet_when_not_configured(tmp_path: Path) -> None:
+    config, _, project = _fixture(tmp_path, lifecycle=False)
+    runner = ReactionRunner()
+
+    result = mark_lark_event_inbox_processing(
+        project=project,
+        config_path=config,
+        message_id="om_reaction_fixture",
+        execute=True,
+        runner=runner,
+    )
+
+    assert result["ok"] is True
+    assert result["status"] == "not_configured"
+    assert result["external_writes_performed"] is False
+    assert runner.calls == []
+
+
+def test_verified_reply_removes_processing_reaction(tmp_path: Path) -> None:
+    config, inbox, project = _fixture(tmp_path)
+    record_lark_inbox_reaction(
+        inbox=inbox,
+        message_id="om_reaction_fixture",
+        phase="processing",
+        reaction_id="reaction_OnIt",
+        emoji_type="OnIt",
+    )
+    runner = ReplyRunner()
+
+    result = reply_lark_event_inbox(
+        project=project,
+        config_path=config,
+        message_id="om_reaction_fixture",
+        text="处理完成",
+        execute=True,
+        runner=runner,
+    )
+
+    assert result["ok"] is True
+    assert result["status"] == "sent_verified"
+    assert result["reply_verified"] is True
+    assert result["reaction_cleanup_verified"] is True
+    delete_call = next(call for call in runner.calls if "delete" in call)
+    assert delete_call[delete_call.index("--reaction-id") + 1] == (
+        "reaction_OnIt"
+    )
+    assert (
+        lark_inbox_reaction_receipts(
+            inbox=inbox,
+            message_id="om_reaction_fixture",
+        )
+        == {}
+    )
+
+
+def test_unverified_reply_preserves_processing_reaction(tmp_path: Path) -> None:
+    config, inbox, project = _fixture(tmp_path)
+    record_lark_inbox_reaction(
+        inbox=inbox,
+        message_id="om_reaction_fixture",
+        phase="processing",
+        reaction_id="reaction_OnIt",
+        emoji_type="OnIt",
+    )
+    runner = ReplyRunner(matching_readback=False)
+
+    result = reply_lark_event_inbox(
+        project=project,
+        config_path=config,
+        message_id="om_reaction_fixture",
+        text="处理完成",
+        execute=True,
+        runner=runner,
+    )
+
+    assert result["ok"] is False
+    assert result["status"] == "sent_unverified"
+    assert result["reply_verified"] is False
+    assert result["reaction_cleanup_verified"] is False
+    assert not any("delete" in call for call in runner.calls)
+    assert "processing" in lark_inbox_reaction_receipts(
+        inbox=inbox,
+        message_id="om_reaction_fixture",
+    )
+
+
+def test_verified_reply_reports_retryable_cleanup_failure(
+    tmp_path: Path,
+) -> None:
+    config, inbox, project = _fixture(tmp_path)
+    record_lark_inbox_reaction(
+        inbox=inbox,
+        message_id="om_reaction_fixture",
+        phase="processing",
+        reaction_id="reaction_OnIt",
+        emoji_type="OnIt",
+    )
+    runner = ReplyRunner(fail_reaction_delete=True)
+
+    result = reply_lark_event_inbox(
+        project=project,
+        config_path=config,
+        message_id="om_reaction_fixture",
+        text="处理完成",
+        execute=True,
+        runner=runner,
+    )
+
+    assert result["ok"] is False
+    assert result["status"] == "sent_verified_cleanup_pending"
+    assert result["reply_verified"] is True
+    assert result["reaction_cleanup_verified"] is False
+    assert result["blocker"] == "lark_inbox_reply_reaction_cleanup_pending"
+    assert "processing" in lark_inbox_reaction_receipts(
+        inbox=inbox,
+        message_id="om_reaction_fixture",
+    )
+
+
+def test_processing_config_requires_distinct_received_reaction(
+    tmp_path: Path,
+) -> None:
+    config, _, project = _fixture(tmp_path)
+    payload = json.loads(config.read_text(encoding="utf-8"))
+    payload["reply"]["processing_reaction_emoji"] = "Get"
+    config.write_text(json.dumps(payload), encoding="utf-8")
+
+    try:
+        load_lark_event_inbox_config(project=project, config_path=config)
+    except ValueError as exc:
+        assert "must differ" in str(exc)
+    else:
+        raise AssertionError("equal lifecycle reactions must fail closed")
+
+    payload["reply"].pop("received_reaction_emoji")
+    payload["reply"]["processing_reaction_emoji"] = "OnIt"
+    config.write_text(json.dumps(payload), encoding="utf-8")
+    try:
+        load_lark_event_inbox_config(project=project, config_path=config)
+    except ValueError as exc:
+        assert "requires received_reaction_emoji" in str(exc)
+    else:
+        raise AssertionError("processing without received must fail closed")
+
+
+def test_malformed_receipt_ledger_fails_closed(tmp_path: Path) -> None:
+    config, inbox, project = _fixture(tmp_path)
+    receipt_path = inbox / "reactions" / "receipts.json"
+    receipt_path.parent.mkdir(parents=True)
+    receipt_path.write_text("{not-json", encoding="utf-8")
+    runner = ReactionRunner()
+
+    try:
+        complete_lark_event_inbox_reactions(
+            project=project,
+            config_path=config,
+            message_id="om_reaction_fixture",
+            execute=True,
+            runner=runner,
+        )
+    except ValueError as exc:
+        assert "unreadable" in str(exc)
+    else:
+        raise AssertionError("malformed reaction receipts must fail closed")
+    assert runner.calls == []

--- a/tests/extensions/test_lark_inbox_reactions.py
+++ b/tests/extensions/test_lark_inbox_reactions.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import sys
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
@@ -520,3 +523,47 @@ def test_malformed_receipt_ledger_fails_closed(tmp_path: Path) -> None:
     else:
         raise AssertionError("malformed reaction receipts must fail closed")
     assert runner.calls == []
+
+
+def test_reaction_module_uses_cross_platform_lock_fallback(
+    tmp_path: Path,
+) -> None:
+    script = """
+import builtins
+import tempfile
+from pathlib import Path
+
+original_import = builtins.__import__
+
+def without_fcntl(name, *args, **kwargs):
+    if name == "fcntl":
+        raise ImportError("simulated non-POSIX platform")
+    return original_import(name, *args, **kwargs)
+
+builtins.__import__ = without_fcntl
+from loopx.extensions.lark.inbox_reactions import lark_inbox_reaction_lock
+
+with tempfile.TemporaryDirectory() as raw:
+    inbox = Path(raw) / ".loopx" / "inbox" / "feedback"
+    with lark_inbox_reaction_lock(
+        inbox=inbox,
+        message_id="om_cross_platform_fixture",
+    ):
+        pass
+print("cross-platform reaction lock: ok")
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "PYTHONPATH": str(Path(__file__).resolve().parents[2]),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == "cross-platform reaction lock: ok"


### PR DESCRIPTION
## Summary

- add an opt-in `Get -> OnIt -> removed` reaction lifecycle for actionable Lark inbox messages
- persist only bot-owned reaction ids in a project-private receipt ledger and serialize transitions per message
- expose idempotent `lark-inbox processing` and `reaction-complete` commands
- clean up lifecycle reactions only after source-thread reply readback succeeds
- preserve the existing single received-reaction behavior when `processing_reaction_emoji` is not configured

## Safety and compatibility

- ordinary group conversation still receives no reaction
- reaction cleanup deletes only ids returned by the configured bot's own writes
- malformed receipts fail closed; provider cleanup failures remain retryable
- no chat ids, profiles, credentials, local paths, or raw provider payloads are added to public state
- all new external writes remain behind `lark.reply.send`

## Validation

- `pytest -q tests/extensions/test_lark_inbox_reactions.py` — 10 passed
- `python examples/lark-event-collector-lifecycle-smoke.py` — passed
- `python examples/lark-event-inbox-smoke.py` — passed
- `python examples/lark-extension-activation-smoke.py` — passed
- `mypy loopx/extensions/lark/inbox_reactions.py` — passed
- `ruff check` on changed Python surfaces — passed
- `loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard` — 13/13 checks passed, no warnings or manual holds
