### PR TITLE
refactor(turn): absorb fenced journal recovery into TypeScript

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -181,20 +181,11 @@ jobs:
           assert readiness["status"] == "ready", readiness
           assert readiness["semantic_probe"] == "passed", readiness
           with TemporaryDirectory() as temporary_directory:
-              effect_id = identity.effect_id
+              effect_id = journal_identity.effect_id
               writable_journal = {
-                  "schema_version": "loopx_turn_journal_v0",
-                  "goal_id": "fixture-goal",
-                  "turn_key": turn_key,
+                  **journal,
                   "status": "in_progress",
-                  "completed_phases": ["host_execute"],
-                  "plan": {
-                      "transaction": {
-                          "settlement_plan": {
-                              "identity": {"effect_id": effect_id}
-                          }
-                      }
-                  },
+                  "completed_phases": [],
               }
               committed = write_turn_journal(
                   str(Path(temporary_directory) / "turn.json"),

--- a/loopx/control_plane/turn_driver/executor.py
+++ b/loopx/control_plane/turn_driver/executor.py
@@ -1065,7 +1065,10 @@ def _ensure_turn_settlement_plan(
         host=str(host_fields.get("kind") or "generic-cli"),
         execution_mode=str(host_fields.get("execution_mode") or "isolated-headless"),
         session_action=str(host_fields.get("session_action") or "resume"),
-        turn_instance_id=transaction_plan.get("turn_instance_id"),
+        turn_instance_id=(
+            transaction_plan.get("turn_instance_id")
+            or transaction_plan.get("turn_key")
+        ),
     )
     settlement_plan = built.get("settlement_plan")
     if isinstance(settlement_plan, Mapping):
@@ -1091,7 +1094,6 @@ def _typed_settlement_stage(
     transaction_plan = (
         plan.get("transaction") if isinstance(plan.get("transaction"), Mapping) else {}
     )
-    _ensure_turn_settlement_plan(plan, transaction_plan)
 
     terminal_closeout_required = False
     completion_intent_error: str | None = None
@@ -1312,6 +1314,10 @@ def run_loopx_turn_once(
             "executable": "built-in",
             "kind": str(planned_host.get("kind") or "codex-cli"),
         }
+    transaction_plan = (
+        plan.get("transaction") if isinstance(plan.get("transaction"), dict) else {}
+    )
+    _ensure_turn_settlement_plan(plan, transaction_plan)
     request = build_loopx_turn_host_request(plan)
     empty_effects = {
         "host_invoked": False,

--- a/loopx/control_plane/turn_driver/turn_journal.ts
+++ b/loopx/control_plane/turn_driver/turn_journal.ts
@@ -94,8 +94,8 @@ export type TurnJournalEffect = EffectTurn<
   "replay_legal" | "replay_blocked"
 >;
 
-const transactionPhases = Object.freeze([...transactionContract.phases]);
-const supportedJournalStatuses = new Set([
+export const transactionPhases = Object.freeze([...transactionContract.phases]);
+export const supportedJournalStatuses: ReadonlySet<string> = new Set([
   "in_progress",
   "scheduler_action_required",
   "committed",

--- a/loopx/control_plane/turn_driver/turn_journal_effects.ts
+++ b/loopx/control_plane/turn_driver/turn_journal_effects.ts
@@ -4,6 +4,10 @@ import { isAbsolute } from "node:path";
 
 import type { JsonObject } from "../effect_program.ts";
 import {
+  SETTLEMENT_STEP_KINDS,
+  settlementIdentityFromPlan,
+} from "../effect_program.ts";
+import {
   EffectRuntimeConflictError,
   EffectRuntimeRequestError,
 } from "../effect_runtime_errors.ts";
@@ -12,6 +16,28 @@ import {
   withFileMutationLock,
 } from "../effect_runtime_io.ts";
 import { requireNonEmptyString as requiredString } from "../runtime_decode.ts";
+import {
+  interpretTurnJournalEffect,
+  supportedJournalStatuses,
+  transactionPhases,
+} from "./turn_journal.ts";
+
+const terminalStatuses = new Set(["committed", "stopped"]);
+const preparedStepKinds: ReadonlySet<string> = new Set(
+  SETTLEMENT_STEP_KINDS.filter((kind) => kind !== "validation"),
+);
+const statusTransitions: Readonly<Record<string, ReadonlySet<string>>> = {
+  in_progress: new Set([
+    "in_progress",
+    "failed",
+    "stopped",
+    "scheduler_action_required",
+    "committed",
+  ]),
+  failed: new Set(["failed", "in_progress"]),
+  scheduler_action_required: new Set(["scheduler_action_required", "committed"]),
+};
+const legalPhaseAdvances = new Set(["0->2", "2->3", "3->4", "4->5", "5->7"]);
 
 function asObject(value: unknown): JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -22,12 +48,8 @@ function asObject(value: unknown): JsonObject {
 function journalEffectId(journal: JsonObject): string | null {
   const plan = asObject(journal.plan);
   const transaction = asObject(plan.transaction);
-  const settlement = asObject(transaction.settlement_plan);
-  const identity = asObject(settlement.identity);
-  const effectId = typeof identity.effect_id === "string"
-    ? identity.effect_id.trim()
-    : "";
-  return effectId || null;
+  const parsed = settlementIdentityFromPlan(transaction);
+  return parsed.failure === null ? parsed.value.effect_id : null;
 }
 
 function sha256(value: string): string {
@@ -48,6 +70,178 @@ function operationId(journal: JsonObject): string {
   return `sha256:${sha256(JSON.stringify(stableValue(journal)))}`;
 }
 
+function journalWithoutRecoveryAudit(journal: JsonObject): JsonObject {
+  const projected = { ...journal };
+  delete projected.recovery_audit;
+  return projected;
+}
+
+interface JournalState {
+  status: string;
+  completedPhases: string[];
+  effectId: string;
+  failedPhase: string | null;
+}
+
+function conflict(message: string, code = "journal_transition_conflict"): never {
+  throw new EffectRuntimeConflictError(message, code);
+}
+
+function samePrefix(left: readonly string[], right: readonly string[]): boolean {
+  return left.length <= right.length && left.every((phase, index) => phase === right[index]);
+}
+
+function requireValidPreparedAttempt(
+  journal: JsonObject,
+  state: Pick<JournalState, "status" | "completedPhases" | "effectId">,
+): void {
+  if (journal.effect_attempts === undefined) return;
+  const attempts = asObject(journal.effect_attempts);
+  if (Object.keys(attempts).length !== 1) {
+    conflict("Turn journal must carry at most one prepared effect");
+  }
+  const [stepKind, rawAttempt] = Object.entries(attempts)[0] ?? [];
+  if (!stepKind || !preparedStepKinds.has(stepKind)) {
+    conflict("Turn journal carries an unsupported prepared effect step");
+  }
+  const attempt = asObject(rawAttempt);
+  const effectRef = `${state.effectId}#${stepKind}`;
+  if (attempt.status !== "prepared" || attempt.effect_ref !== effectRef) {
+    conflict("Turn journal prepared effect does not match settlement identity");
+  }
+  const phaseIndex = stepKind === "terminal_closeout"
+    ? transactionPhases.indexOf("scheduler_apply")
+    : transactionPhases.indexOf(stepKind);
+  if (
+    phaseIndex < 0 ||
+    state.completedPhases.length !== phaseIndex ||
+    !samePrefix(state.completedPhases, transactionPhases)
+  ) {
+    conflict("Turn journal prepared effect is not the next settlement step");
+  }
+  if (!["in_progress", "failed"].includes(state.status)) {
+    conflict("Turn journal terminal state cannot retain a prepared effect");
+  }
+}
+
+function requireJournalState(journal: JsonObject): JournalState {
+  if (journal.schema_version !== "loopx_turn_journal_v0") {
+    throw new EffectRuntimeRequestError(
+      "Turn journal has an unsupported schema",
+      "journal_snapshot_invalid",
+    );
+  }
+  const plan = asObject(journal.plan);
+  const envelope = asObject(plan.turn_envelope);
+  const goalId = typeof journal.goal_id === "string" ? journal.goal_id : "";
+  const agentId = typeof envelope.agent_id === "string" ? envelope.agent_id : "";
+  const turnKey = typeof journal.turn_key === "string" ? journal.turn_key : "";
+  const effect = interpretTurnJournalEffect({
+    schema_version: "loopx_turn_journal_interpretation_request_v0",
+    journal,
+    goal_id: goalId,
+    agent_id: agentId,
+    turn_key: turnKey,
+  });
+  const context = effect.request.context;
+  const effectId = journalEffectId(journal);
+  if (!context.journal_consistent || !effectId) {
+    throw new EffectRuntimeRequestError(
+      `Turn journal snapshot is inconsistent: ${context.violations.join(", ")}`,
+      "journal_snapshot_invalid",
+    );
+  }
+  if (journal.recovery_audit !== undefined && context.last_recovery === null) {
+    throw new EffectRuntimeRequestError(
+      "Turn journal carries a malformed recovery audit",
+      "journal_snapshot_invalid",
+    );
+  }
+  const status = context.journal_status;
+  const completedPhases = [...context.completed_phases];
+  if (!supportedJournalStatuses.has(status)) {
+    throw new EffectRuntimeRequestError(
+      "Turn journal status is unsupported",
+      "journal_snapshot_invalid",
+    );
+  }
+  const receipt = asObject(journal.receipt);
+  const failedPhase = typeof receipt.failed_phase === "string"
+    ? receipt.failed_phase
+    : null;
+  if (status === "committed" && completedPhases.length !== transactionPhases.length) {
+    conflict("Committed Turn journal must contain the complete transaction prefix");
+  }
+  if (status === "stopped" && completedPhases.length !== 3) {
+    conflict("Stopped Turn journal must end after validation");
+  }
+  if (status === "scheduler_action_required" && completedPhases.length !== 5) {
+    conflict("Scheduler-pending Turn journal must end after quota spend");
+  }
+  if (status === "in_progress" && completedPhases.length > 5) {
+    conflict("In-progress Turn journal cannot claim scheduler completion");
+  }
+  if (status === "failed") {
+    const nextPhase = transactionPhases[completedPhases.length] ?? null;
+    const terminalCloseoutFailure =
+      failedPhase === "terminal_closeout" && completedPhases.length === 5;
+    if (!failedPhase || (failedPhase !== nextPhase && !terminalCloseoutFailure)) {
+      conflict("Failed Turn journal must name the next uncompleted phase");
+    }
+  }
+  const state = { status, completedPhases, effectId, failedPhase };
+  requireValidPreparedAttempt(journal, state);
+  return state;
+}
+
+function requireJournalTransition(
+  existing: JsonObject,
+  incoming: JsonObject,
+  previous: JournalState,
+  next: JournalState,
+): void {
+  if (operationId(asObject(existing.plan)) !== operationId(asObject(incoming.plan))) {
+    conflict("Turn journal transaction plan is immutable", "journal_plan_conflict");
+  }
+  if (terminalStatuses.has(previous.status)) {
+    const auditOnly =
+      previous.status === next.status &&
+      operationId(journalWithoutRecoveryAudit(existing)) ===
+        operationId(journalWithoutRecoveryAudit(incoming));
+    if (auditOnly) return;
+    conflict("Terminal Turn journal tombstones are immutable");
+  }
+  if (!statusTransitions[previous.status]?.has(next.status)) {
+    conflict(`Illegal Turn journal status transition ${previous.status}->${next.status}`);
+  }
+  if (
+    previous.status === next.status &&
+    ["failed", "scheduler_action_required"].includes(previous.status) &&
+    operationId(journalWithoutRecoveryAudit(existing)) !==
+      operationId(journalWithoutRecoveryAudit(incoming))
+  ) {
+    conflict("Settled Turn journal state only permits recovery-audit completion");
+  }
+  const validationRetryRewind =
+    previous.status === "failed" &&
+    next.status === "in_progress" &&
+    previous.failedPhase === "validation" &&
+    samePrefix(next.completedPhases, previous.completedPhases);
+  if (
+    !samePrefix(previous.completedPhases, next.completedPhases) &&
+    !validationRetryRewind
+  ) {
+    conflict("Turn journal completed phases cannot regress or fork");
+  }
+  const phaseAdvance = `${previous.completedPhases.length}->${next.completedPhases.length}`;
+  if (
+    next.completedPhases.length > previous.completedPhases.length &&
+    !legalPhaseAdvances.has(phaseAdvance)
+  ) {
+    conflict("Turn journal transition cannot skip transaction checkpoints");
+  }
+}
+
 export async function commitTurnJournal(
   params: JsonObject,
 ): Promise<JsonObject> {
@@ -56,38 +250,26 @@ export async function commitTurnJournal(
     throw new EffectRuntimeRequestError("Turn journal path must be absolute");
   }
   const journal = asObject(params.journal);
-  if (journal.schema_version !== "loopx_turn_journal_v0") {
-    throw new EffectRuntimeRequestError(
-      "Turn journal has an unsupported schema",
-    );
-  }
+  const incomingState = requireJournalState(journal);
   const expectedEffectId = typeof params.expected_effect_id === "string"
     ? params.expected_effect_id.trim()
     : "";
-  const incomingEffectId = journalEffectId(journal);
+  const incomingEffectId = incomingState.effectId;
   if (expectedEffectId && incomingEffectId !== expectedEffectId) {
     throw new EffectRuntimeRequestError(
       "Turn journal does not carry the expected settlement effect",
     );
   }
-  const expectedPreviousSha256 = params.expected_previous_sha256;
-  if (expectedPreviousSha256 !== null && typeof expectedPreviousSha256 !== "string") {
-    throw new EffectRuntimeRequestError(
-      "expected_previous_sha256 must be a string or null",
-    );
-  }
   const incomingOperationId = operationId(journal);
   return await withFileMutationLock(path, async () => {
     let existing: JsonObject | null = null;
-    let existingSha256: string | null = null;
     try {
       const encoded = await readFile(path, "utf8");
-      existingSha256 = sha256(encoded);
       existing = asObject(JSON.parse(encoded));
-      const existingEffectId = journalEffectId(existing);
+      const existingState = requireJournalState(existing);
+      const existingEffectId = existingState.effectId;
       if (
         existingEffectId &&
-        incomingEffectId &&
         existingEffectId !== incomingEffectId
       ) {
         throw new EffectRuntimeConflictError(
@@ -104,14 +286,15 @@ export async function commitTurnJournal(
           operation_id: incomingOperationId,
         };
       }
+      requireJournalTransition(existing, journal, existingState, incomingState);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
     }
-    if (existingSha256 !== expectedPreviousSha256) {
-      throw new EffectRuntimeConflictError(
-        "Turn journal compare-and-swap precondition failed",
-        "compare_and_swap_conflict",
-      );
+    if (existing === null && (
+      incomingState.status !== "in_progress" ||
+      incomingState.completedPhases.length !== 0
+    )) {
+      conflict("A new Turn journal must begin in progress with no completed phases");
     }
     await atomicWriteJson(path, journal);
     return {

--- a/loopx/control_plane/turn_driver/turn_journal_runtime.py
+++ b/loopx/control_plane/turn_driver/turn_journal_runtime.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-import hashlib
-from pathlib import Path
 from typing import Any
 
 from ..effect_runtime import effect_runtime_result
@@ -161,15 +159,7 @@ def write_turn_journal(
     *,
     expected_effect_id: str | None = None,
 ) -> dict[str, object]:
-    """Atomically checkpoint a Turn journal in the TS Effect runtime."""
-
-    journal_path = Path(path)
-    try:
-        expected_previous_sha256: str | None = hashlib.sha256(
-            journal_path.read_bytes()
-        ).hexdigest()
-    except FileNotFoundError:
-        expected_previous_sha256 = None
+    """Commit a Turn-journal transition through the TS semantic owner."""
 
     payload = effect_runtime_result(
         "turn_journal.write",
@@ -177,7 +167,6 @@ def write_turn_journal(
             "path": path,
             "journal": dict(journal),
             "expected_effect_id": expected_effect_id,
-            "expected_previous_sha256": expected_previous_sha256,
         },
         retry_safe=True,
     )

--- a/tests/control_plane/test_effect_runtime_integration.py
+++ b/tests/control_plane/test_effect_runtime_integration.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 import shutil
@@ -16,24 +15,45 @@ import pytest
 from loopx.control_plane import effect_runtime
 
 
+_TURN_KEY = "sha256:" + "a" * 64
+_TODO_ID = "todo_fixture0001"
+
+
+def _effect_id(label: str) -> str:
+    return f"fixture-goal:fixture-agent:{_TODO_ID}:{label}"
+
+
 def _journal(effect_id: str) -> dict[str, object]:
+    goal_id, agent_id, todo_id, turn_instance_id = effect_id.split(":", 3)
     return {
         "schema_version": "loopx_turn_journal_v0",
-        "goal_id": "fixture-goal",
-        "turn_key": "sha256:" + "a" * 64,
+        "goal_id": goal_id,
+        "turn_key": _TURN_KEY,
         "status": "in_progress",
-        "completed_phases": ["host_execute"],
+        "completed_phases": [],
         "plan": {
-            "transaction": {"settlement_plan": {"identity": {"effect_id": effect_id}}}
+            "turn_envelope": {
+                "goal_id": goal_id,
+                "agent_id": agent_id,
+                "action": {"selected_todo": {"todo_id": todo_id}},
+            },
+            "transaction": {
+                "turn_key": _TURN_KEY,
+                "turn_instance_id": turn_instance_id,
+                "settlement_plan": {
+                    "schema_version": "quota_settlement_plan_v1",
+                    "identity": {
+                        "schema_version": "quota_settlement_identity_v0",
+                        "effect_id": effect_id,
+                        "goal_id": goal_id,
+                        "agent_id": agent_id,
+                        "todo_id": todo_id,
+                        "turn_instance_id": turn_instance_id,
+                    },
+                },
+            },
         },
     }
-
-
-def _digest(path: Path) -> str | None:
-    try:
-        return hashlib.sha256(path.read_bytes()).hexdigest()
-    except FileNotFoundError:
-        return None
 
 
 def _raw_runtime_response(
@@ -90,7 +110,6 @@ def test_managed_runtime_is_reused_and_restart_safe_for_typed_write(
             "path": str(journal_path),
             "journal": payload,
             "expected_effect_id": effect_id,
-            "expected_previous_sha256": None,
         },
     )
     assert committed["appended"] is True
@@ -113,7 +132,6 @@ def test_managed_runtime_is_reused_and_restart_safe_for_typed_write(
             "path": str(journal_path),
             "journal": payload,
             "expected_effect_id": effect_id,
-            "expected_previous_sha256": _digest(journal_path),
         },
     )
     assert replayed["appended"] is False
@@ -176,14 +194,15 @@ def test_typed_write_rejects_cross_effect_overwrite(
     monkeypatch.setattr(effect_runtime, "_runtime_dir", lambda: runtime_dir)
     monkeypatch.setenv("LOOPX_EFFECT_RUNTIME_IDLE_MS", "1000")
     journal_path = tmp_path / "turn.json"
-    first = _journal("effect-one")
+    first_effect_id = _effect_id("effect-one")
+    second_effect_id = _effect_id("effect-two")
+    first = _journal(first_effect_id)
     effect_runtime.effect_runtime_result(
         "turn_journal.write",
         {
             "path": str(journal_path),
             "journal": first,
-            "expected_effect_id": "effect-one",
-            "expected_previous_sha256": None,
+            "expected_effect_id": first_effect_id,
         },
     )
 
@@ -192,9 +211,8 @@ def test_typed_write_rejects_cross_effect_overwrite(
             "turn_journal.write",
             {
                 "path": str(journal_path),
-                "journal": _journal("effect-two"),
-                "expected_effect_id": "effect-two",
-                "expected_previous_sha256": _digest(journal_path),
+                "journal": _journal(second_effect_id),
+                "expected_effect_id": second_effect_id,
             },
         )
     except effect_runtime.EffectRuntimeConflict as exc:
@@ -212,7 +230,7 @@ def test_typed_write_rejects_cross_effect_overwrite(
     )
 
 
-def test_typed_write_serializes_same_effect_checkpoints_with_cas(
+def test_typed_write_serializes_conflicting_transitions_without_caller_cas(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -228,12 +246,30 @@ def test_typed_write_serializes_same_effect_checkpoints_with_cas(
             "path": str(journal_path),
             "journal": initial,
             "expected_effect_id": effect_id,
-            "expected_previous_sha256": None,
         },
     )
-    expected_previous_sha256 = _digest(journal_path)
-    first = {**initial, "status": "committed"}
-    second = {**initial, "status": "failed"}
+    advanced = {
+        **initial,
+        "completed_phases": ["host_execute", "typed_result"],
+    }
+    effect_runtime.effect_runtime_result(
+        "turn_journal.write",
+        {
+            "path": str(journal_path),
+            "journal": advanced,
+            "expected_effect_id": effect_id,
+        },
+    )
+    first = {
+        **advanced,
+        "status": "stopped",
+        "completed_phases": ["host_execute", "typed_result", "validation"],
+    }
+    second = {
+        **advanced,
+        "status": "failed",
+        "receipt": {"turn_key": _TURN_KEY, "failed_phase": "validation"},
+    }
 
     def commit(payload: dict[str, object]) -> dict[str, object] | RuntimeError:
         try:
@@ -243,7 +279,6 @@ def test_typed_write_serializes_same_effect_checkpoints_with_cas(
                     "path": str(journal_path),
                     "journal": payload,
                     "expected_effect_id": effect_id,
-                    "expected_previous_sha256": expected_previous_sha256,
                 },
             )
         except RuntimeError as exc:
@@ -256,8 +291,7 @@ def test_typed_write_serializes_same_effect_checkpoints_with_cas(
     failure = next(outcome for outcome in outcomes if isinstance(outcome, RuntimeError))
     assert isinstance(failure, effect_runtime.EffectRuntimeConflict)
     assert failure.error_kind == "conflict"
-    assert failure.diagnostic_code == "compare_and_swap_conflict"
-    assert "compare-and-swap precondition failed" in str(failure)
+    assert failure.diagnostic_code == "journal_transition_conflict"
     assert json.loads(journal_path.read_text(encoding="utf-8")) in (first, second)
     success = next(outcome for outcome in outcomes if isinstance(outcome, dict))
     assert success["appended"] is True
@@ -282,17 +316,18 @@ def test_successive_same_effect_checkpoints_receive_distinct_operation_ids(
             "path": str(journal_path),
             "journal": initial,
             "expected_effect_id": effect_id,
-            "expected_previous_sha256": None,
         },
     )
-    successor = {**initial, "status": "committed"}
+    successor = {
+        **initial,
+        "completed_phases": ["host_execute", "typed_result"],
+    }
     second = effect_runtime.effect_runtime_result(
         "turn_journal.write",
         {
             "path": str(journal_path),
             "journal": successor,
             "expected_effect_id": effect_id,
-            "expected_previous_sha256": _digest(journal_path),
         },
     )
 
@@ -323,7 +358,6 @@ def test_retry_safe_typed_write_recovers_after_unexpected_runtime_exit(
             "path": str(journal_path),
             "journal": payload,
             "expected_effect_id": effect_id,
-            "expected_previous_sha256": None,
         },
         retry_safe=True,
     )
@@ -659,9 +693,8 @@ def test_corrupt_persisted_journal_maps_to_bounded_internal_failure(
             "turn_journal.write",
             {
                 "path": str(journal_path),
-                "journal": _journal("effect-one"),
-                "expected_effect_id": "effect-one",
-                "expected_previous_sha256": _digest(journal_path),
+                "journal": _journal(_effect_id("effect-one")),
+                "expected_effect_id": _effect_id("effect-one"),
             },
         )
 

--- a/tests/control_plane_ts/turn_journal_effects.test.ts
+++ b/tests/control_plane_ts/turn_journal_effects.test.ts
@@ -6,68 +6,222 @@ import test from "node:test";
 
 import { commitTurnJournal } from "../../loopx/control_plane/turn_driver/turn_journal_effects.ts";
 
-function journal(status: string): Record<string, unknown> {
+const turnKey = `sha256:${"a".repeat(64)}`;
+const todoId = "todo_fixture0001";
+const phases = [
+  "host_execute",
+  "typed_result",
+  "validation",
+  "durable_writeback",
+  "quota_spend",
+  "scheduler_apply",
+  "scheduler_ack",
+] as const;
+
+function effectId(agentId = "fixture-agent"): string {
+  return `fixture-goal:${agentId}:${todoId}:${turnKey}`;
+}
+
+function journal(
+  status = "in_progress",
+  completedPhases: readonly string[] = [],
+  agentId = "fixture-agent",
+): Record<string, unknown> {
   return {
     schema_version: "loopx_turn_journal_v0",
     goal_id: "fixture-goal",
-    turn_key: `sha256:${"a".repeat(64)}`,
+    turn_key: turnKey,
     status,
-    completed_phases: ["host_execute"],
+    completed_phases: [...completedPhases],
     plan: {
+      turn_envelope: {
+        goal_id: "fixture-goal",
+        agent_id: agentId,
+        action: { selected_todo: { todo_id: todoId } },
+      },
       transaction: {
-        settlement_plan: { identity: { effect_id: "fixture-effect" } },
+        turn_key: turnKey,
+        settlement_plan: {
+          schema_version: "quota_settlement_plan_v1",
+          identity: {
+            schema_version: "quota_settlement_identity_v0",
+            effect_id: effectId(agentId),
+            goal_id: "fixture-goal",
+            agent_id: agentId,
+            todo_id: todoId,
+            turn_instance_id: turnKey,
+          },
+        },
       },
     },
   };
 }
 
-test("journal checkpoint retry is idempotent and operation-scoped", async () => {
+async function withJournalPath(
+  run: (path: string) => Promise<void>,
+): Promise<void> {
   const directory = await mkdtemp(join(tmpdir(), "loopx-ts-journal-"));
-  const path = join(directory, "turn.json");
   try {
-    const first = await commitTurnJournal({
-      path,
-      journal: journal("in_progress"),
-      expected_effect_id: "fixture-effect",
-      expected_previous_sha256: null,
-    });
-    const replay = await commitTurnJournal({
-      path,
-      journal: journal("in_progress"),
-      expected_effect_id: "fixture-effect",
-      expected_previous_sha256: null,
-    });
+    await run(join(directory, "turn.json"));
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+async function commit(path: string, snapshot: Record<string, unknown>) {
+  return await commitTurnJournal({
+    path,
+    journal: snapshot,
+    expected_effect_id: effectId(),
+  });
+}
+
+test("journal checkpoint retry is idempotent and operation-scoped", async () => {
+  await withJournalPath(async (path) => {
+    const snapshot = journal();
+    const first = await commit(path, snapshot);
+    const replay = await commit(path, snapshot);
+
     assert.equal(first.appended, true);
     assert.equal(first.replayed, false);
     assert.equal(replay.appended, false);
     assert.equal(replay.replayed, true);
     assert.equal(first.operation_id, replay.operation_id);
-  } finally {
-    await rm(directory, { recursive: true, force: true });
-  }
+  });
 });
 
-test("journal checkpoint rejects a stale compare-and-swap precondition", async () => {
-  const directory = await mkdtemp(join(tmpdir(), "loopx-ts-journal-"));
-  const path = join(directory, "turn.json");
-  try {
-    await commitTurnJournal({
-      path,
-      journal: journal("in_progress"),
-      expected_effect_id: "fixture-effect",
-      expected_previous_sha256: null,
-    });
+test("TS journal owner accepts the complete monotonic transaction", async () => {
+  await withJournalPath(async (path) => {
+    await commit(path, journal());
+    await commit(path, journal("in_progress", phases.slice(0, 2)));
+    await commit(path, journal("in_progress", phases.slice(0, 3)));
+
+    const preparedWriteback = journal("in_progress", phases.slice(0, 3));
+    preparedWriteback.effect_attempts = {
+      durable_writeback: {
+        status: "prepared",
+        effect_ref: `${effectId()}#durable_writeback`,
+      },
+    };
+    await commit(path, preparedWriteback);
+    await commit(path, journal("in_progress", phases.slice(0, 4)));
+
+    const preparedSpend = journal("in_progress", phases.slice(0, 4));
+    preparedSpend.effect_attempts = {
+      quota_spend: {
+        status: "prepared",
+        effect_ref: `${effectId()}#quota_spend`,
+      },
+    };
+    await commit(path, preparedSpend);
+    await commit(path, journal("in_progress", phases.slice(0, 5)));
+    await commit(path, journal("scheduler_action_required", phases.slice(0, 5)));
+    await commit(path, journal("committed", phases));
+
+    assert.equal(JSON.parse(await readFile(path, "utf8")).status, "committed");
+  });
+});
+
+test("new journals cannot appear after side effects", async () => {
+  await withJournalPath(async (path) => {
     await assert.rejects(
-      commitTurnJournal({
-        path,
-        journal: journal("committed"),
-        expected_effect_id: "fixture-effect",
-        expected_previous_sha256: null,
-      }),
-      /compare-and-swap precondition failed/,
+      commit(path, journal("in_progress", phases.slice(0, 3))),
+      /must begin in progress with no completed phases/,
     );
-    assert.equal(JSON.parse(await readFile(path, "utf8")).status, "in_progress");
-  } finally {
-    await rm(directory, { recursive: true, force: true });
-  }
+  });
+});
+
+test("completed phases cannot regress", async () => {
+  await withJournalPath(async (path) => {
+    await commit(path, journal());
+    await commit(path, journal("in_progress", phases.slice(0, 2)));
+    await commit(path, journal("in_progress", phases.slice(0, 3)));
+    await assert.rejects(
+      commit(path, journal("in_progress", phases.slice(0, 2))),
+      /completed phases cannot regress or fork/,
+    );
+  });
+});
+
+test("completed phases cannot skip transaction checkpoints", async () => {
+  await withJournalPath(async (path) => {
+    await commit(path, journal());
+    await assert.rejects(
+      commit(path, journal("committed", phases)),
+      /cannot skip transaction checkpoints/,
+    );
+  });
+});
+
+test("failed validation may explicitly rewind for host reinvocation", async () => {
+  await withJournalPath(async (path) => {
+    await commit(path, journal());
+    const failed = journal("failed", phases.slice(0, 2));
+    failed.receipt = { turn_key: turnKey, failed_phase: "validation" };
+    await commit(path, failed);
+    await commit(path, journal("in_progress", []));
+
+    assert.deepEqual(JSON.parse(await readFile(path, "utf8")).completed_phases, []);
+  });
+});
+
+test("terminal journal tombstones are immutable", async () => {
+  await withJournalPath(async (path) => {
+    await commit(path, journal());
+    await commit(path, journal("in_progress", phases.slice(0, 2)));
+    await commit(path, journal("in_progress", phases.slice(0, 3)));
+    await commit(path, journal("in_progress", phases.slice(0, 4)));
+    await commit(path, journal("in_progress", phases.slice(0, 5)));
+    await commit(path, journal("committed", phases));
+    const changed = journal("committed", phases);
+    changed.reason = "late mutation";
+    await assert.rejects(commit(path, changed), /tombstones are immutable/);
+  });
+});
+
+test("transaction plans are immutable within one effect", async () => {
+  await withJournalPath(async (path) => {
+    await commit(path, journal());
+    const changed = journal("in_progress", phases.slice(0, 2));
+    const plan = changed.plan as Record<string, unknown>;
+    plan.host = { kind: "changed-after-start" };
+    await assert.rejects(commit(path, changed), /transaction plan is immutable/);
+  });
+});
+
+test("cross-effect overwrite remains fail-closed", async () => {
+  await withJournalPath(async (path) => {
+    await commit(path, journal());
+    await assert.rejects(
+      commitTurnJournal({ path, journal: journal("in_progress", [], "other-agent") }),
+      /belongs to another settlement effect/,
+    );
+  });
+});
+
+test("prepared effects must use the settlement identity", async () => {
+  await withJournalPath(async (path) => {
+    const invalid = journal();
+    invalid.effect_attempts = {
+      durable_writeback: {
+        status: "prepared",
+        effect_ref: "another-effect#durable_writeback",
+      },
+    };
+    await assert.rejects(
+      commit(path, invalid),
+      /prepared effect does not match settlement identity/,
+    );
+  });
+});
+
+test("failed snapshots must name the next uncompleted phase", async () => {
+  await withJournalPath(async (path) => {
+    const invalid = journal("failed", phases.slice(0, 4));
+    invalid.receipt = { turn_key: turnKey, failed_phase: "validation" };
+    await assert.rejects(
+      commit(path, invalid),
+      /must name the next uncompleted phase/,
+    );
+  });
 });

--- a/tests/test_loopx_turn_executor.py
+++ b/tests/test_loopx_turn_executor.py
@@ -137,9 +137,18 @@ def test_task_validation_stage_reads_result_kind_through_effect_turn(
     result = _host_result(plan, kind="wait")
     journal = {
         "schema_version": LOOPX_TURN_JOURNAL_SCHEMA_VERSION,
+        "goal_id": "fixture-goal",
+        "turn_key": plan["transaction"]["turn_key"],
         "status": "in_progress",
         "completed_phases": list(TRANSACTION_PHASES[:2]),
+        "plan": plan,
     }
+    journal_path = tmp_path / "journal.json"
+    turn_executor._write_journal(
+        journal_path,
+        {**journal, "completed_phases": []},
+    )
+    turn_executor._write_journal(journal_path, journal)
 
     completed, payload = _task_validation_stage(
         plan,
@@ -147,7 +156,7 @@ def test_task_validation_stage_reads_result_kind_through_effect_turn(
         task_validator=None,
         completed_phases=list(TRANSACTION_PHASES[:2]),
         journal=journal,
-        journal_path=tmp_path / "journal.json",
+        journal_path=journal_path,
         effects={},
     )
 


### PR DESCRIPTION
## Summary

- make the TypeScript effect runtime the single semantic owner of Turn-journal snapshot and transition validation under the mutation lock;
- preserve the original contribution's valuable partial-execution, retry, prepared-effect recovery, settlement-identity fencing, and terminal tombstone behavior;
- reject cross-effect writes, plan mutation, phase regression/fork/skip, malformed prepared effects, and illegal terminal mutation;
- remove the duplicate Python pre-read/hash CAS authority and materialize the canonical settlement plan before the first checkpoint;
- keep journal recovery host-local and outside NoKV/shared-goal authority; scheduler apply/ACK remains outside settlement.

## Design evolution

The original Python-heavy implementation was valuable as a fault model, but the control plane has since moved state-machine and effect authority into TypeScript. This PR was therefore refined in place as a replacement-first implementation rather than reviving a parallel Python runtime. The final scope is 8 cohesive files (`+498/-133`) instead of the prior 38-file surface.

## Validation

- TypeScript typecheck: passed;
- TypeScript control-plane tests: 281 passed;
- focused Python effect-runtime / Turn-executor tests: 62 passed on the final head; wider implementation validation covered 169 relevant Python tests;
- release-artifacts smoke and canonical journal write probe: passed;
- `loopx canary premerge --from-git-diff`: 18/18 selected checks passed, 0 failures, 0 manual holds, public/private boundary clean, `self_merge_allowed=true`;
- GitHub DCO, dependency review, release build, pytest, Windows PowerShell, and SonarCloud checks: passed.

## Attribution

The final product and test commits retain `Co-authored-by: AetherX-Technologies <icybreeze9th@gmail.com>` so the fencing and recovery design contribution remains directly attributed to @AetherX-Technologies.
