### PR TITLE
feat(decision-context): settle reviewed evidence cursors

### DIFF
--- a/docs/capabilities/decision-context/README.md
+++ b/docs/capabilities/decision-context/README.md
@@ -33,15 +33,19 @@ flowchart LR
     READ["Bounded scan + exact read<br/>freshness · revision · conflicts"]
     EVIDENCE["Evidence packet<br/>accepted · rejected · stale · conflicting"]
     PROPOSAL["Decision proposal<br/>recommendation · alternatives · stop list"]
-    CORE["LoopX lifecycle<br/>todo · gate · event · outcome"]
+    REVIEW["Review settlement<br/>approve · reject · defer · no change"]
+    CORE["LoopX lifecycle<br/>todo · user gate · event"]
+    OUTCOME["Outcome receipt<br/>later observed result"]
     MEMORY["Reward Memory<br/>reviewed reusable experience"]
 
     SOURCES --> READ
     RECALL --> READ
     READ --> EVIDENCE
     EVIDENCE --> PROPOSAL
-    PROPOSAL --> CORE
-    CORE -. "verified outcome only" .-> MEMORY
+    PROPOSAL --> REVIEW
+    REVIEW --> CORE
+    CORE --> OUTCOME
+    OUTCOME -. "verified outcome only" .-> MEMORY
 ```
 
 ## What It Owns
@@ -56,10 +60,14 @@ Decision Context owns the decision-quality layer:
    rejected, or conflicting claims.
 4. **Decision proposals** keep recommendations, alternatives, next actions,
    and stop lists separate from evidence.
-5. **Outcome receipts** link an accepted decision to observed outcomes and
-   invalidated assumptions.
-6. **Cursor commit** advances private source cursors only after the complete
-   packet chain and lifecycle writeback have been validated.
+5. **Review receipts** record owner `approve`, `reject`, or `defer` through the
+   existing user gate, or one explicit semantic `no_change` result without a
+   gate.
+6. **Cursor commit** advances private source cursors after the review settlement
+   and lifecycle writeback have been validated. It does not wait for a future
+   real-world outcome.
+7. **Outcome receipts** later link an accepted decision to observed outcomes
+   and invalidated assumptions.
 
 ## What It Does Not Own
 
@@ -84,18 +92,21 @@ the caller must label the conclusion as partial or exact-read the missing
 authority through another path. Fail-open must not masquerade as complete
 context coverage.
 
-## Three Auditable Outputs
+## Four Auditable Outputs
 
 | Output | Answers | Typical contents |
 |---|---|---|
 | `decision_evidence_packet_v0` | What should the decision trust now? | Changed facts, accepted recall, stale/rejected claims, conflicts, revisions, provider health |
 | `decision_proposal_v0` | What should happen next? | Objective scores, recommendation, alternatives, actions, stop list |
+| `decision_review_receipt_v0` | What did the owner decide about the proposal? | Approve/reject/defer gate evidence, or an explicit quiet no-change settlement |
 | `decision_outcome_receipt_v0` | What happened after the decision? | Accepted decision, transitions, outcomes, invalidated assumptions, review time |
 
 The evidence packet is intended to be deterministic and auditable. The
-proposal is explicitly advisory. The outcome receipt is append-only evidence;
-only a verified outcome may later become a Reward Memory candidate, and that
-candidate still follows Reward Memory review and activation.
+proposal is explicitly advisory. The review receipt settles whether the source
+material has been consumed; it is not proof of a future outcome. The outcome
+receipt is append-only evidence; only a verified outcome may later become a
+Reward Memory candidate, and that candidate still follows Reward Memory review
+and activation.
 
 ## Typical Uses
 
@@ -149,9 +160,49 @@ loopx decision-context prepare-evidence \
   --format json
 ```
 
-`prepare-evidence` is deliberately read only. Semantic rebase, proposal,
-validated LoopX writeback, and cursor commit remain separate acceptance
-boundaries.
+`prepare-evidence` is deliberately read only. A domain adapter can provide a
+strict semantic rebase and persist an unapplied private checkpoint:
+
+```bash
+loopx decision-context prepare-review \
+  --goal-id <goal-id> \
+  --agent-id <agent-id> \
+  --profile <ignored-private-profile.json> \
+  --decision-id <stable-decision-id> \
+  --rebase-json <ignored-private-rebase.json> \
+  --pending-settlement <ignored-private-pending.json> \
+  --execute \
+  --format json
+```
+
+After a proposal is decided through an existing `user_gate`, settle it with
+the exact gate event. The gate must use
+`decision_scope=direction:action:<proposal-packet-ref>`:
+
+```bash
+loopx decision-context settle-review \
+  --goal-id <goal-id> \
+  --agent-id <agent-id> \
+  --profile <ignored-private-profile.json> \
+  --cursor-state <ignored-private-cursors.json> \
+  --pending-settlement <ignored-private-pending.json> \
+  --event-log <ignored-private-rollout-events.jsonl> \
+  --proposal-json <public-safe-proposal.json> \
+  --source-event-id <exact-user-gate-event-id> \
+  --actor-ref <owner-ref> \
+  --reason-code <reason-code> \
+  --summary <compact-public-safe-summary> \
+  --execute \
+  --format json
+```
+
+For an explicit semantic `no_change`, omit `--proposal-json` and
+`--source-event-id`; no user gate is created. Preview by omitting `--execute`.
+These commands write only the caller-selected private pending/cursor state and
+the existing local rollout event log. They grant no trading, external action,
+or other irreversible authority. Removing the private profile disables the
+route; removing the pending checkpoint abandons an unsettled review without
+changing active cursors.
 
 ## Relationship To Other Capabilities
 
@@ -166,8 +217,8 @@ boundaries.
 
 The public capability currently ships its packet contracts, default-off
 activation profile, provider-neutral source contract, bounded evidence
-assembly, public-safe projections, validated outcome feedback, and private
-cursor-commit boundary.
+assembly, public-safe projections, owner-gated or quiet review settlement,
+private cursor commit, and later validated outcome feedback.
 
 It is still marked **experimental**. A production integration must provide its
 own private source adapters, profile, authority policy, proposal logic, and

--- a/docs/capabilities/decision-context/README.zh-CN.md
+++ b/docs/capabilities/decision-context/README.zh-CN.md
@@ -31,15 +31,19 @@ flowchart LR
     READ["有界扫描 + exact read<br/>freshness · revision · conflict"]
     EVIDENCE["Evidence packet<br/>采纳 · 拒绝 · 过期 · 冲突"]
     PROPOSAL["Decision proposal<br/>建议 · 备选 · stop list"]
-    CORE["LoopX lifecycle<br/>todo · gate · event · outcome"]
+    REVIEW["Review settlement<br/>approve · reject · defer · no change"]
+    CORE["LoopX lifecycle<br/>todo · user gate · event"]
+    OUTCOME["Outcome receipt<br/>后续真实结果"]
     MEMORY["Reward Memory<br/>经评审的可复用经验"]
 
     SOURCES --> READ
     RECALL --> READ
     READ --> EVIDENCE
     EVIDENCE --> PROPOSAL
-    PROPOSAL --> CORE
-    CORE -. "仅 verified outcome" .-> MEMORY
+    PROPOSAL --> REVIEW
+    REVIEW --> CORE
+    CORE --> OUTCOME
+    OUTCOME -. "仅 verified outcome" .-> MEMORY
 ```
 
 ## 它负责什么
@@ -51,9 +55,11 @@ Decision Context 负责“决策质量层”：
 3. **证据 rebase**：提升当前事实，并明确记录过期、拒绝或冲突的 claim。
 4. **决策建议**：把 recommendation、alternatives、next actions 和 stop list
    与事实证据分开。
-5. **结果回执**：把接受的决策与真实结果、失效假设关联起来。
-6. **cursor commit**：只有完整 packet 链和 lifecycle writeback 验证通过后，
-   才推进私有信源 cursor。
+5. **评审回执**：复用现有 user gate 记录 owner 的 `approve`、`reject`、`defer`，
+   或者在没有实质变化时记录一条无需 gate 的语义 `no_change`。
+6. **cursor commit**：review settlement 与 lifecycle writeback 验证通过后推进
+   私有信源 cursor，不等待未来的真实结果。
+7. **结果回执**：在后续把接受的决策与真实结果、失效假设关联起来。
 
 ## 它不负责什么
 
@@ -74,17 +80,19 @@ exact-read 完整度和未覆盖的 P0 source 投影为公开安全的回执。`
 不阻断安全的 LoopX lifecycle，但调用方必须显式标记结论为部分覆盖，或者先通过
 其他 authority 路径补齐 exact read；不能把 fail-open 误写成“所有关键上下文已检查”。
 
-## 三类可审计产物
+## 四类可审计产物
 
 | 产物 | 回答的问题 | 典型内容 |
 |---|---|---|
 | `decision_evidence_packet_v0` | 这次决策现在应该相信什么？ | changed facts、采纳的召回、过期/拒绝 claim、冲突、revision、provider health |
 | `decision_proposal_v0` | 下一步建议做什么？ | objective score、推荐决策、备选方案、行动、stop list |
+| `decision_review_receipt_v0` | Owner 如何处理这次建议？ | approve/reject/defer 的 gate 证据，或显式 quiet no-change settlement |
 | `decision_outcome_receipt_v0` | 决策之后实际发生了什么？ | 接受的决策、状态迁移、真实结果、失效假设、复核时间 |
 
-Evidence packet 尽量确定性和可审计；proposal 明确只是建议；outcome receipt
-是追加式证据。只有经过验证的 outcome 才可能生成 Reward Memory candidate，
-而 candidate 仍需走 Reward Memory 自己的 review 和 activation。
+Evidence packet 尽量确定性和可审计；proposal 明确只是建议；review receipt
+只结算“这批材料是否已经处理”，不是未来 outcome 的证明。Outcome receipt 是
+追加式证据。只有经过验证的 outcome 才可能生成 Reward Memory candidate，而
+candidate 仍需走 Reward Memory 自己的 review 和 activation。
 
 ## 典型场景
 
@@ -134,8 +142,46 @@ loopx decision-context prepare-evidence \
   --format json
 ```
 
-`prepare-evidence` 刻意保持只读。语义 rebase、proposal、经验证的 LoopX
-writeback 和 cursor commit 是彼此独立的验收边界。
+`prepare-evidence` 刻意保持只读。领域 adapter 可以提交严格的语义 rebase，并把
+尚未应用的 cursor proposal 写入私有 pending checkpoint：
+
+```bash
+loopx decision-context prepare-review \
+  --goal-id <goal-id> \
+  --agent-id <agent-id> \
+  --profile <ignored-private-profile.json> \
+  --decision-id <stable-decision-id> \
+  --rebase-json <ignored-private-rebase.json> \
+  --pending-settlement <ignored-private-pending.json> \
+  --execute \
+  --format json
+```
+
+Proposal 经现有 `user_gate` 决定后，用精确 gate event 结算；该 gate 必须使用
+`decision_scope=direction:action:<proposal-packet-ref>`：
+
+```bash
+loopx decision-context settle-review \
+  --goal-id <goal-id> \
+  --agent-id <agent-id> \
+  --profile <ignored-private-profile.json> \
+  --cursor-state <ignored-private-cursors.json> \
+  --pending-settlement <ignored-private-pending.json> \
+  --event-log <ignored-private-rollout-events.jsonl> \
+  --proposal-json <public-safe-proposal.json> \
+  --source-event-id <exact-user-gate-event-id> \
+  --actor-ref <owner-ref> \
+  --reason-code <reason-code> \
+  --summary <compact-public-safe-summary> \
+  --execute \
+  --format json
+```
+
+显式语义 `no_change` 不传 `--proposal-json` 和 `--source-event-id`，也不会创建
+user gate。去掉 `--execute` 即为预览。这些命令只写调用方指定的私有 pending/
+cursor 状态和现有本地 rollout event log，不授予交易、外部动作或其他不可逆权限。
+移除私有 profile 即关闭入口；删除尚未结算的 pending checkpoint 不会改变 active
+cursor。
 
 ## 与其他能力的关系
 
@@ -150,7 +196,8 @@ writeback 和 cursor commit 是彼此独立的验收边界。
 
 公开能力已经具备 packet 契约、默认关闭的 activation profile、
 provider-neutral source contract、有界 evidence assembly、公开安全投影、
-经验证的 outcome feedback 和私有 cursor commit 边界。
+owner-gated 或 quiet review settlement、私有 cursor commit，以及后续经验证的
+outcome feedback。
 
 它目前仍标记为 **experimental**。生产接入方需要提供自己的私有 source adapter、
 profile、authority policy、proposal logic 和经过验证的 lifecycle writeback。

--- a/docs/reference/protocols/decision-context-architecture-v0.md
+++ b/docs/reference/protocols/decision-context-architecture-v0.md
@@ -50,13 +50,14 @@ Reward Memory asks what reusable experience was learned in the past. Decision
 Context asks which facts should be trusted for the current decision.
 
 - Reward Memory follows candidate → review → activate → apply/retire.
-- Decision Context follows recall → exact read → rebase → propose → outcome.
+- Decision Context follows recall → exact read → rebase → propose → review
+  settlement → cursor commit → later outcome observation.
 - Reward Memory may be one optional input to Decision Context.
 - A verified Decision Context outcome may create a Reward Memory candidate, but
   the candidate still follows Reward Memory review and activation.
 - Neither capability creates action authority.
 
-## Three packets
+## Four packets
 
 ### `decision_evidence_packet_v0`
 
@@ -71,6 +72,18 @@ a health receipt and fails open to authority sources.
 The advisory reasoning layer contains objective scores, a recommended decision,
 alternatives, next actions, and a stop list. It references the stable evidence
 packet fingerprint and requires authority confirmation. It is not Core truth.
+
+### `decision_review_receipt_v0`
+
+The settlement layer records one of four dispositions:
+
+- `approve`, `reject`, and `defer` exact-read an existing `user_gate` event whose
+  scope is `direction:action:<proposal-packet-ref>`;
+- `no_change` requires an explicit semantic rebase receipt and creates no gate.
+
+The receipt proves that the evidence batch was reviewed or found immaterial. It
+allows private source cursors to advance after validated lifecycle writeback,
+but it is not an observed outcome and creates no action authority.
 
 ### `decision_outcome_receipt_v0`
 
@@ -118,7 +131,9 @@ flowchart LR
     RECALL["ContextProvider<br/>advisory recall"]
     EVIDENCE["Decision evidence packet"]
     AGENT["Agent proposal"]
-    OUTCOME["Outcome receipt"]
+    REVIEW["Review receipt<br/>gate or semantic no change"]
+    CURSOR["Private cursor commit"]
+    OUTCOME["Later outcome receipt"]
 
     THIN --> REG
     REG --> SOURCE
@@ -126,7 +141,9 @@ flowchart LR
     RECEIPT --> EVIDENCE
     RECALL --> EVIDENCE
     EVIDENCE --> AGENT
-    AGENT --> OUTCOME
+    AGENT --> REVIEW
+    REVIEW --> CURSOR
+    REVIEW --> OUTCOME
 ```
 
 This lets the steady-state automation prompt become generic: wake the goal,
@@ -136,7 +153,7 @@ and goal configuration.
 
 ## Invariants
 
-1. Every packet is goal-scoped, public-safe, structured, and fingerprinted.
+1. Every public packet is goal-scoped, public-safe, structured, and fingerprinted.
 2. Evidence and proposal remain separate.
 3. Providers never create authority.
 4. Raw provider payloads, raw chat, tool output, and credentials never enter a
@@ -146,13 +163,15 @@ and goal configuration.
 6. Proposals remain advisory; transitions use existing todo, gate, quota, and
    writeback.
 7. Provider failure is fail-open and does not block the Core lifecycle.
-8. Verified outcomes are recorded before any Reward Memory distillation.
+8. Review settlement, not a future outcome, is the cursor-commit boundary.
+9. `no_change` requires explicit semantic proof and does not create a user gate.
+10. Verified outcomes are recorded before any Reward Memory distillation.
 
 ## Delivery stages
 
 ### P0: contract
 
-Define the three packets, stable fingerprints, public-safe field allowlists,
+Define the four packets, stable fingerprints, public-safe field allowlists,
 the provider-neutral incremental source contract, focused tests, and this
 boundary document. Do not wire a concrete provider, CLI, or Core writeback.
 
@@ -186,11 +205,19 @@ semantic rebase: changed-source cursors remain at `preserve`, so merely scanning
 or reading a source can never mark it absorbed. Sources marked `on_demand` are
 excluded from automatic collection and require explicit source selection.
 
-Private cursor commit remains a separate acceptance boundary. The host API
+Private cursor commit remains a separate acceptance boundary. A review may
+cross agent turns, so `prepare-review --execute` stores one private pending
+settlement containing the public-safe assembly plus private cursor proposals;
+it never mutates active cursor state. `settle-review` then exact-reads either a
+matching existing user-gate event or the assembly's explicit semantic
+`no_change` proof, appends a validation event, and performs cursor CAS.
+
+The host API
 `commit_profile_decision_cursors(...)` now performs that boundary explicitly:
 
-- it verifies the assembly, evidence, proposal, outcome, and cursor-checkpoint
-  packet chain;
+- it verifies the assembly, evidence, review, and cursor-checkpoint packet
+  chain, plus the proposal for gated dispositions;
+- it supports the previous proposal/outcome chain as a compatibility read path;
 - it exact-reads an existing LoopX rollout event whose `decision_id` and
   artifact refs bind the same packet chain;
 - it rejects a changed private profile or a cursor value that no longer matches
@@ -199,9 +226,11 @@ Private cursor commit remains a separate acceptance boundary. The host API
   readback verification;
 - it returns only opaque cursor refs in a public-safe commit receipt.
 
-Scanning, evidence preparation, and proposal construction still perform no
-cursor write. A missing or generic boolean "writeback succeeded" assertion is
-not sufficient to commit.
+Scanning, evidence preparation, proposal construction, and pending-settlement
+creation still perform no active cursor write. A missing or generic boolean
+"writeback succeeded" assertion is not sufficient to commit. An approved
+decision's real-world outcome remains a later append-only observation and does
+not block marking already reviewed source material as consumed.
 
 Private hosts may bind a provider instance at runtime through
 `source_provider_overrides`. The provider id must already be declared by the
@@ -215,9 +244,13 @@ cursor.
 
 ### P1: first dogfood
 
-Use one private, redacted decision-assistant scenario. Write an outcome receipt
-through existing event/run history. Measure decision changes, observed
-outcomes, and invalidated assumptions rather than retrieval volume.
+Use one private, redacted decision-assistant scenario. Let a domain adapter map
+new facts to stable private theses; send only material proposals through the
+existing user gate and keep explicit semantic no-change runs quiet. Settle the
+source cursor after approve/reject/defer/no-change, then write later outcomes
+through existing event/run history. Measure decision changes, rejected stale
+evidence, reading saved, observed outcomes, and invalidated assumptions rather
+than retrieval volume.
 
 ### P2: cross-domain validation and Core promotion gate
 

--- a/docs/reference/protocols/decision-context-architecture-v0.zh-CN.md
+++ b/docs/reference/protocols/decision-context-architecture-v0.zh-CN.md
@@ -61,13 +61,13 @@ goal owner 可以显式选择场景、provider 和 agent lane。
 | | Reward Memory | Decision Context |
 |---|---|---|
 | 核心问题 | 过去学到了什么可复用经验？ | 此刻决策需要相信哪些事实？ |
-| 生命周期 | candidate → review → activate → apply/retire | recall → exact read → rebase → propose → outcome |
+| 生命周期 | candidate → review → activate → apply/retire | recall → exact read → rebase → propose → review settlement → cursor commit → 后续 outcome |
 | 主要对象 | policy、preference、procedural experience | fact、judgment、assumption、conflict、decision、outcome |
 | 写入条件 | 经过验证和 authority review | 决策与结果作为可审计记录追加 |
 | 动作权限 | 不创造 authority | 不创造 authority |
 | 连接方式 | 可作为 Decision Context 的可选经验来源 | verified outcome 可产生 Reward Memory candidate |
 
-## 三层 packet
+## 四层 packet
 
 ### `decision_evidence_packet_v0`
 
@@ -96,6 +96,17 @@ goal owner 可以显式选择场景、provider 和 agent lane。
 
 proposal 必须引用 evidence packet 的稳定指纹，并显式标记
 `authority_confirmation_required=true`。它不能写成 Core truth。
+
+### `decision_review_receipt_v0`
+
+结算层记录四种 disposition：
+
+- `approve`、`reject`、`defer` 必须精确回读现有 `user_gate` event，且 gate scope
+  必须是 `direction:action:<proposal-packet-ref>`；
+- `no_change` 必须有显式 semantic rebase 证明，不创建 gate。
+
+该 receipt 只证明“这批证据已评审或没有实质影响”，允许在 lifecycle writeback
+验证后推进私有 source cursor；它不是 outcome，也不创造动作权限。
 
 ### `decision_outcome_receipt_v0`
 
@@ -146,7 +157,9 @@ flowchart LR
     RECALL["ContextProvider<br/>advisory recall"]
     EVIDENCE["Decision evidence packet"]
     AGENT["Agent proposal"]
-    OUTCOME["Outcome receipt"]
+    REVIEW["Review receipt<br/>gate 或 semantic no change"]
+    CURSOR["私有 cursor commit"]
+    OUTCOME["后续 outcome receipt"]
 
     THIN --> REG
     REG --> SOURCE
@@ -154,7 +167,9 @@ flowchart LR
     RECEIPT --> EVIDENCE
     RECALL --> EVIDENCE
     EVIDENCE --> AGENT
-    AGENT --> OUTCOME
+    AGENT --> REVIEW
+    REVIEW --> CURSOR
+    REVIEW --> OUTCOME
 ```
 
 这样 steady-state automation prompt 可以退化为通用唤醒：启动 goal、遵循 active
@@ -163,20 +178,22 @@ capability 与 goal 配置承担。
 
 ## 不变量
 
-1. 三类 packet 都是 goal-scoped、public-safe、稳定指纹化的结构化记录。
+1. 四类公开 packet 都是 goal-scoped、public-safe、稳定指纹化的结构化记录。
 2. evidence 与 proposal 分离，模型建议不能伪装成事实。
 3. provider 不创造 authority；provider payload、raw chat、tool output、credentials
    不进入 packet。
 4. recall 必须有界；accepted claim 必须保留 exact-read、revision 与 conflict receipt。
 5. proposal 只能建议，真实迁移继续经现有 todo、gate、quota 和 writeback。
 6. provider 不可用时 fail open，不阻断 Core lifecycle。
-7. verified outcome 先进入可审计 receipt，再决定是否提炼为 Reward Memory。
+7. cursor commit 的边界是 review settlement，而不是未来 outcome。
+8. `no_change` 必须有显式语义证明，且不创建 user gate。
+9. verified outcome 先进入可审计 receipt，再决定是否提炼为 Reward Memory。
 
 ## 分阶段交付
 
 ### P0：contract
 
-- 固化三类 packet、稳定指纹、公共安全字段白名单和 provider-neutral
+- 固化四类 packet、稳定指纹、公共安全字段白名单和 provider-neutral
   增量信源契约；
 - 建立能力边界文档与聚焦测试；
 - 不接具体 provider、CLI 或 control-plane writeback。
@@ -209,18 +226,28 @@ health、evidence 和 cursor checkpoint 记录。host API 通过领域 rebase ca
 `preserve`，避免把“扫描/读过”误记成“已吸收”。`on_demand` source 不进入自动
 扫描，只有显式选择后才会读取。
 
-私有 cursor commit 仍是独立验收边界。host API
+私有 cursor commit 仍是独立验收边界。Review 可能跨 Agent turn，所以
+`prepare-review --execute` 会保存一份私有 pending settlement：其中包含公开安全的
+assembly 和私有 cursor proposal，但绝不修改 active cursor。随后
+`settle-review` 精确回读匹配的既有 user-gate event，或核验 assembly 中显式的
+semantic `no_change`，追加 validation event，再执行 cursor CAS。
+
+host API
 `commit_profile_decision_cursors(...)` 现在显式执行这条边界：
 
-- 验证 assembly、evidence、proposal、outcome 与 cursor checkpoint 的完整引用链；
+- 验证 assembly、evidence、review 与 cursor checkpoint 的完整引用链；gated
+  disposition 还必须验证 proposal；
+- 保留原 proposal/outcome 链作为兼容读取路径；
 - 精确回读既有 LoopX rollout event，并校验其 `decision_id` 与 artifact refs
   绑定同一组 packet；
 - profile 已变化或当前 cursor 不再等于 assembly 快照时拒绝提交；
 - 通过文件锁、原子替换、fsync 与回读校验写入私有 cursor 文件；
 - public receipt 只包含不透明 cursor ref，不包含原始 cursor 或私有路径。
 
-source scan、evidence preparation 和 proposal 构建仍不会写 cursor；调用方只传
-一个“writeback 成功”的布尔值，不足以触发提交。
+source scan、evidence preparation、proposal 构建和 pending settlement 创建仍不会
+写 active cursor；调用方只传一个“writeback 成功”的布尔值，不足以触发提交。
+被 approve 的决策仍需在未来单独记录真实 outcome，但这不阻塞把已经评审的信源
+材料标记为已消费。
 
 私有宿主可以通过 `source_provider_overrides` 在运行时绑定 provider 实例。provider
 id 必须先由私有 goal profile 声明，实例身份也必须与声明一致。这样 MCP、收件箱、
@@ -231,9 +258,11 @@ provider 缺失或身份不匹配时 fail open，且不会推进 cursor。
 
 ### P1：首个 dogfood
 
-- 在一个私有、脱敏的决策助手场景生成 evidence/proposal；
-- 通过既有 event/run history 写入 outcome receipt；
-- 以“决策改变、真实结果、失效假设”而非召回条数验收。
+- 在一个私有、脱敏的决策助手场景，由领域 adapter 把新事实映射到稳定私有论点；
+- 只有实质 proposal 进入现有 user gate，显式 semantic no-change 保持 quiet；
+- approve/reject/defer/no-change 后结算 source cursor，后续再通过既有 event/run
+  history 写入 outcome receipt；
+- 以“判断修正、过时证据拒绝、人工阅读量下降、真实结果、失效假设”而非召回条数验收。
 
 ### P2：跨域验证与下沉门槛
 

--- a/examples/decision-context-contract-smoke.py
+++ b/examples/decision-context-contract-smoke.py
@@ -12,12 +12,13 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
-from loopx.capabilities.decision_context import (
+from loopx.capabilities.decision_context import (  # noqa: E402
     DecisionSourceSpec,
     build_decision_context_architecture_packet,
     build_decision_evidence_packet,
     build_decision_outcome_receipt,
     build_decision_proposal,
+    build_decision_review_receipt,
     build_decision_source_manifest,
 )
 
@@ -108,6 +109,36 @@ def main() -> int:
             "confidence": 0.8,
         },
     )
+    review_receipts = {
+        disposition: build_decision_review_receipt(
+            goal_id="goal:example",
+            decision_id="decision:priority",
+            evidence_packet_ref=str(evidence["packet_ref"]),
+            proposal_packet_ref=str(proposal["packet_ref"]),
+            gate_todo_id=f"todo:review:{disposition}",
+            source_event_id=f"event:review:{disposition}",
+            recorded_at=REVIEW_AT,
+            disposition=disposition,
+            actor_ref="owner:goal",
+            reason_code=f"owner_{disposition}",
+            summary=f"The owner recorded {disposition} through the existing gate.",
+        )
+        for disposition in ("approve", "reject", "defer")
+    }
+    review_receipts["no_change"] = build_decision_review_receipt(
+        goal_id="goal:example",
+        decision_id="decision:priority",
+        evidence_packet_ref=str(evidence["packet_ref"]),
+        recorded_at=REVIEW_AT,
+        disposition="no_change",
+        actor_ref="agent:decision-advisor",
+        reason_code="no_material_change",
+        summary="The source update does not alter the current decision.",
+    )
+    assert review_receipts["approve"]["outcome_observation_required"] is True
+    assert review_receipts["reject"]["outcome_observation_required"] is False
+    assert review_receipts["defer"]["outcome_observation_required"] is False
+    assert review_receipts["no_change"]["quiet_noop"] is True
     outcome = build_decision_outcome_receipt(
         goal_id="goal:example",
         decision_id="decision:priority",
@@ -142,6 +173,10 @@ def main() -> int:
                 "manifest_ref": manifest["manifest_ref"],
                 "evidence_ref": evidence["packet_ref"],
                 "proposal_ref": proposal["packet_ref"],
+                "review_refs": {
+                    disposition: receipt["packet_ref"]
+                    for disposition, receipt in sorted(review_receipts.items())
+                },
                 "outcome_ref": outcome["packet_ref"],
             },
             sort_keys=True,

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from ..extensions.runtime import extension_catalog_entries
+from .decision_context.catalog_entry import DECISION_CONTEXT_CATALOG_ENTRY
 from .issue_fix.workflow_plan import build_issue_fix_pr_lifecycle_command
 from .registry import CapabilityRegistry
 
@@ -544,145 +545,7 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
             "while keeping external PR/comment actions explicit."
         ),
     },
-    {
-        "id": "decision-context",
-        "origin": "builtin",
-        "visibility": "public",
-        "provider_id": "loopx-core",
-        "title": "Goal-scoped decision evidence and outcome contract",
-        "status": "experimental",
-        "default_enabled": False,
-        "real_world_anchor": (
-            "incremental authority rebase before long-running agent decisions"
-        ),
-        "user_value": (
-            "Separate current evidence, advisory proposals, and verified outcomes "
-            "while keeping source providers replaceable and Core authority unchanged."
-        ),
-        "entry_command": (
-            "loopx decision-context inspect-profile "
-            "--goal-id <goal-id> --agent-id <agent-id> --format json"
-        ),
-        "commands": [
-            {
-                "command": "loopx decision-context architecture --format json",
-                "purpose": "Render the default-off Stage-0 packet, source, provider, and lifecycle boundaries.",
-                "write_boundary": "stateless contract output only; no provider, source, goal state, or external write",
-            },
-            {
-                "command": (
-                    "loopx decision-context inspect-profile "
-                    "--goal-id <goal-id> --agent-id <agent-id> "
-                    "[--profile <private-local-profile>] --format json"
-                ),
-                "purpose": (
-                    "Resolve the default-off goal and agent route while projecting "
-                    "only public-safe provider availability."
-                ),
-                "write_boundary": (
-                    "reads an optional private local profile; never emits source "
-                    "locators, provider config, raw content, cursors, or credentials"
-                ),
-            },
-            {
-                "command": (
-                    "loopx decision-context source-manifest "
-                    "--goal-id <goal-id> --agent-id <agent-id> "
-                    "--profile <private-local-profile> --format json"
-                ),
-                "purpose": (
-                    "Project an enabled source profile into a public-safe manifest "
-                    "before any provider access."
-                ),
-                "write_boundary": (
-                    "read-only local projection; no provider access, cursor write, "
-                    "goal mutation, or external action"
-                ),
-            },
-            {
-                "command": (
-                    "loopx decision-context prepare-evidence "
-                    "--goal-id <goal-id> --agent-id <agent-id> "
-                    "--profile <private-local-profile> "
-                    "--decision-id <decision-id> "
-                    "[--cursor-state <private-cursor-json>] "
-                    "[--source-id <on-demand-source>] --format json"
-                ),
-                "purpose": (
-                    "Resolve enabled profile providers, run bounded scans and "
-                    "exact reads, and emit a public-safe evidence preparation "
-                    "packet for domain rebase."
-                ),
-                "write_boundary": (
-                    "read-only provider access; changed-source cursors remain "
-                    "preserved until semantic rebase and validated lifecycle "
-                    "writeback"
-                ),
-            },
-        ],
-        "implemented_protocols": [
-            {
-                "schema_version": "decision_context_architecture_v0",
-                "module": "loopx.capabilities.decision_context.architecture",
-                "doc": "docs/reference/protocols/decision-context-architecture-v0.md",
-            },
-            {
-                "schema_version": "decision_evidence_packet_v0",
-                "module": "loopx.capabilities.decision_context.packets",
-                "doc": "docs/reference/protocols/decision-context-architecture-v0.md",
-            },
-            {
-                "schema_version": "decision_proposal_v0",
-                "module": "loopx.capabilities.decision_context.packets",
-                "doc": "docs/reference/protocols/decision-context-architecture-v0.md",
-            },
-            {
-                "schema_version": "decision_outcome_receipt_v0",
-                "module": "loopx.capabilities.decision_context.packets",
-                "doc": "docs/reference/protocols/decision-context-architecture-v0.md",
-            },
-            {
-                "schema_version": "decision_source_manifest_v0",
-                "module": "loopx.capabilities.decision_context.sources",
-                "doc": "docs/reference/protocols/decision-context-architecture-v0.md",
-            },
-            {
-                "schema_version": "decision_source_scan_receipt_v0",
-                "module": "loopx.capabilities.decision_context.sources",
-                "doc": "docs/reference/protocols/decision-context-architecture-v0.md",
-            },
-            {
-                "schema_version": "decision_context_profile_v0",
-                "module": "loopx.capabilities.decision_context.profile",
-                "doc": "docs/reference/protocols/decision-context-architecture-v0.md",
-            },
-            {
-                "schema_version": "decision_context_activation_status_v0",
-                "module": "loopx.capabilities.decision_context.profile",
-                "doc": "docs/reference/protocols/decision-context-architecture-v0.md",
-            },
-            {
-                "schema_version": "decision_cursor_commit_receipt_v0",
-                "module": "loopx.capabilities.decision_context.cursor_commit",
-                "doc": "docs/reference/protocols/decision-context-architecture-v0.md",
-            },
-        ],
-        "smokes": ["python3 examples/decision-context-contract-smoke.py"],
-        "docs": [
-            "docs/reference/protocols/decision-context-architecture-v0.md",
-            "docs/reference/protocols/decision-context-architecture-v0.zh-CN.md",
-        ],
-        "boundaries": [
-            "The capability is default-off and cannot create action authority or mutate Core state.",
-            "Private source locators, cursors, raw content, provider payloads, tool output, and credentials stay outside public packets.",
-            "DecisionSourceProvider rebases current authority; ContextProvider supplies advisory recall only.",
-            "The built-in local-file adapter and prepare-evidence route are read-only; cursor commit requires packet-chain validation, exact lifecycle-event readback, private-state CAS, and atomic verified write.",
-        ],
-        "next_real_step": (
-            "Exercise the first private incremental source profile and produce "
-            "an outcome receipt that changes or stops a real decision."
-        ),
-    },
+    DECISION_CONTEXT_CATALOG_ENTRY,
     {
         "id": "project-skill-delivery",
         "origin": "builtin",

--- a/loopx/capabilities/decision_context/__init__.py
+++ b/loopx/capabilities/decision_context/__init__.py
@@ -27,9 +27,11 @@ from .packets import (
     DECISION_EVIDENCE_PACKET_SCHEMA_VERSION,
     DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION,
     DECISION_PROPOSAL_SCHEMA_VERSION,
+    DECISION_REVIEW_RECEIPT_SCHEMA_VERSION,
     build_decision_evidence_packet,
     build_decision_outcome_receipt,
     build_decision_proposal,
+    build_decision_review_receipt,
 )
 from .sources import (
     DECISION_SOURCE_MANIFEST_SCHEMA_VERSION,
@@ -53,9 +55,19 @@ from .cursor_commit import (
     DECISION_CURSOR_COMMIT_RECEIPT_SCHEMA_VERSION,
     commit_profile_decision_cursors,
 )
-from .private_state import load_private_decision_cursors
+from .private_state import (
+    DECISION_PENDING_SETTLEMENT_SCHEMA_VERSION,
+    load_private_decision_cursors,
+    load_private_pending_decision_settlement,
+    write_private_pending_decision_settlement,
+)
 from .runtime import (
     assemble_profile_decision_evidence,
+    decision_evidence_records_from_mapping,
+)
+from .review_settlement import (
+    DECISION_REVIEW_SETTLEMENT_SCHEMA_VERSION,
+    settle_profile_decision_review,
 )
 from .outcome_feedback import (
     DECISION_OUTCOME_FEEDBACK_SCHEMA_VERSION,
@@ -72,6 +84,9 @@ __all__ = [
     "DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION",
     "DECISION_OUTCOME_FEEDBACK_SCHEMA_VERSION",
     "DECISION_PROPOSAL_SCHEMA_VERSION",
+    "DECISION_REVIEW_RECEIPT_SCHEMA_VERSION",
+    "DECISION_PENDING_SETTLEMENT_SCHEMA_VERSION",
+    "DECISION_REVIEW_SETTLEMENT_SCHEMA_VERSION",
     "DECISION_CONTEXT_PROFILE_SCHEMA_VERSION",
     "DECISION_SOURCE_MANIFEST_SCHEMA_VERSION",
     "DECISION_SOURCE_SCAN_RECEIPT_SCHEMA_VERSION",
@@ -97,13 +112,18 @@ __all__ = [
     "build_decision_outcome_receipt",
     "build_decision_outcome_feedback",
     "build_decision_proposal",
+    "build_decision_review_receipt",
     "build_decision_source_item_refs",
     "build_decision_source_manifest",
     "build_decision_source_provider",
     "decision_source_provider_registered",
     "load_decision_context_profile",
     "load_private_decision_cursors",
+    "load_private_pending_decision_settlement",
     "normalize_decision_context_profile",
     "register_decision_source_provider",
     "resolve_decision_context_activation",
+    "decision_evidence_records_from_mapping",
+    "settle_profile_decision_review",
+    "write_private_pending_decision_settlement",
 ]

--- a/loopx/capabilities/decision_context/architecture.py
+++ b/loopx/capabilities/decision_context/architecture.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 from .assembler import (
     DECISION_CONTEXT_ASSEMBLY_SCHEMA_VERSION,
     DECISION_CURSOR_CHECKPOINT_SCHEMA_VERSION,
+    DECISION_SEMANTIC_REBASE_RECEIPT_SCHEMA_VERSION,
 )
 from .packets import (
     DECISION_EVIDENCE_PACKET_SCHEMA_VERSION,
     DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION,
     DECISION_PROPOSAL_SCHEMA_VERSION,
+    DECISION_REVIEW_RECEIPT_SCHEMA_VERSION,
 )
 from .cursor_commit import DECISION_CURSOR_COMMIT_RECEIPT_SCHEMA_VERSION
 from .sources import (
@@ -36,6 +38,7 @@ def build_decision_context_architecture_packet() -> dict[str, object]:
         "packet_schemas": [
             DECISION_EVIDENCE_PACKET_SCHEMA_VERSION,
             DECISION_PROPOSAL_SCHEMA_VERSION,
+            DECISION_REVIEW_RECEIPT_SCHEMA_VERSION,
             DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION,
         ],
         "source_schemas": [
@@ -44,6 +47,7 @@ def build_decision_context_architecture_packet() -> dict[str, object]:
         ],
         "assembly_schemas": [
             DECISION_CONTEXT_ASSEMBLY_SCHEMA_VERSION,
+            DECISION_SEMANTIC_REBASE_RECEIPT_SCHEMA_VERSION,
             DECISION_CURSOR_CHECKPOINT_SCHEMA_VERSION,
             DECISION_CURSOR_COMMIT_RECEIPT_SCHEMA_VERSION,
         ],
@@ -59,8 +63,9 @@ def build_decision_context_architecture_packet() -> dict[str, object]:
             "exact_read",
             "rebase",
             "propose",
-            "outcome",
+            "review_or_quiet_settlement",
             "commit_cursor",
+            "observe_outcome",
         ],
         "invariants": [
             "evidence_and_proposal_remain_separate",
@@ -70,6 +75,8 @@ def build_decision_context_architecture_packet() -> dict[str, object]:
             "cursor_commit_exact_reads_a_matching_lifecycle_event",
             "raw_provider_content_never_enters_public_packets",
             "proposals_require_existing_authority_confirmation",
+            "review_settlement_precedes_cursor_commit",
+            "outcome_observation_does_not_block_consumed_source_cursors",
             "verified_outcomes_precede_reward_memory_candidates",
         ],
         "next_stage": "private_incremental_source_profile_then_dogfood",

--- a/loopx/capabilities/decision_context/assembler.py
+++ b/loopx/capabilities/decision_context/assembler.py
@@ -29,6 +29,9 @@ from .sources import (
 DECISION_CONTEXT_ASSEMBLY_SCHEMA_VERSION = "decision_context_assembly_v0"
 DECISION_CURSOR_CHECKPOINT_SCHEMA_VERSION = "decision_cursor_checkpoint_v0"
 DECISION_SOURCE_COVERAGE_SCHEMA_VERSION = "decision_source_coverage_v0"
+DECISION_SEMANTIC_REBASE_RECEIPT_SCHEMA_VERSION = (
+    "decision_semantic_rebase_receipt_v0"
+)
 
 
 def _packet_ref(prefix: str, packet: Mapping[str, Any]) -> str:
@@ -96,6 +99,7 @@ class DecisionEvidenceRecords:
     recalled_claims: tuple[Mapping[str, Any], ...] = ()
     stale_or_rejected_claims: tuple[Mapping[str, Any], ...] = ()
     conflicts: tuple[Mapping[str, Any], ...] = ()
+    semantic_no_change: bool = False
 
 
 @dataclass(frozen=True)
@@ -472,6 +476,7 @@ def _checkpoint_disposition(
     collected: _CollectedSource,
     accounted_pairs: set[tuple[str, str]],
     conflict_refs: set[str],
+    semantic_no_change: bool,
 ) -> tuple[bool, str]:
     scan = collected.scan
     if scan.cursor_after is None:
@@ -486,6 +491,8 @@ def _checkpoint_disposition(
         return False, "exact_read_disabled"
     if collected.exact_read_failed or len(collected.exact_reads) != len(scan.items):
         return False, "exact_read_incomplete"
+    if semantic_no_change:
+        return True, "semantic_no_change"
 
     changed_refs = []
     for item in scan.items:
@@ -552,7 +559,8 @@ def assemble_decision_evidence(
     """Collect, rebase, and assemble one public-safe decision evidence packet.
 
     Cursor values are returned only as private proposals. A caller may persist
-    them after the decision ledger and outcome receipt have been validated.
+    them after a reviewed proposal or explicit semantic no-change result has
+    been written back and validated. Later outcome observation is separate.
     """
 
     assembly_time = _timestamp(observed_at, field_name="observed_at")
@@ -726,6 +734,19 @@ def assemble_decision_evidence(
     records = rebase(collection)
     if not isinstance(records, DecisionEvidenceRecords):
         raise TypeError("rebase must return DecisionEvidenceRecords")
+    if not isinstance(records.semantic_no_change, bool):
+        raise TypeError("semantic_no_change must be a boolean")
+    if records.semantic_no_change and any(
+        (
+            records.changed_facts,
+            records.recalled_claims,
+            records.stale_or_rejected_claims,
+            records.conflicts,
+        )
+    ):
+        raise ValueError(
+            "semantic_no_change cannot accompany material evidence records"
+        )
 
     verified_facts = _verified_changed_facts(
         facts=records.changed_facts,
@@ -755,6 +776,7 @@ def assemble_decision_evidence(
             collected=collected,
             accounted_pairs=accounted_pairs,
             conflict_refs=conflict_refs,
+            semantic_no_change=records.semantic_no_change,
         )
         if checkpoint_ready and collected.scan.cursor_after is not None:
             proposed_cursors[collected.source.source_id] = collected.scan.cursor_after
@@ -789,6 +811,25 @@ def assemble_decision_evidence(
         "source_coverage": _source_coverage(collected_sources),
         "context_retrieval_receipt": retrieval_receipt,
         "evidence_packet": evidence,
+        "semantic_rebase": {
+            "schema_version": DECISION_SEMANTIC_REBASE_RECEIPT_SCHEMA_VERSION,
+            "status": (
+                "no_material_change"
+                if records.semantic_no_change
+                else "material_change"
+                if any(
+                    (
+                        records.changed_facts,
+                        records.recalled_claims,
+                        records.stale_or_rejected_claims,
+                        records.conflicts,
+                    )
+                )
+                else "incomplete"
+            ),
+            "quiet_noop_allowed": records.semantic_no_change,
+            "raw_context_captured": False,
+        },
         "cursor_checkpoint": checkpoint,
         "provider_fail_open": True,
         "raw_context_captured": False,

--- a/loopx/capabilities/decision_context/catalog_entry.py
+++ b/loopx/capabilities/decision_context/catalog_entry.py
@@ -1,0 +1,195 @@
+"""Capability-owned catalog entry for Decision Context."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+DECISION_CONTEXT_CATALOG_ENTRY: dict[str, Any] = {
+    "id": "decision-context",
+    "origin": "builtin",
+    "visibility": "public",
+    "provider_id": "loopx-core",
+    "title": "Goal-scoped decision evidence, review, and outcome contract",
+    "status": "experimental",
+    "default_enabled": False,
+    "real_world_anchor": (
+        "incremental authority rebase before long-running agent decisions"
+    ),
+    "user_value": (
+        "Separate current evidence, advisory proposals, owner review, and "
+        "verified outcomes while keeping providers replaceable and Core "
+        "authority unchanged."
+    ),
+    "entry_command": (
+        "loopx decision-context inspect-profile "
+        "--goal-id <goal-id> --agent-id <agent-id> --format json"
+    ),
+    "commands": [
+        {
+            "command": "loopx decision-context architecture --format json",
+            "purpose": "Render the default-off packet, source, provider, and lifecycle boundaries.",
+            "write_boundary": "stateless contract output only; no provider, source, goal state, or external write",
+        },
+        {
+            "command": (
+                "loopx decision-context inspect-profile "
+                "--goal-id <goal-id> --agent-id <agent-id> "
+                "[--profile <private-local-profile>] --format json"
+            ),
+            "purpose": (
+                "Resolve the default-off goal and agent route while projecting "
+                "only public-safe provider availability."
+            ),
+            "write_boundary": (
+                "reads an optional private local profile; never emits source "
+                "locators, provider config, raw content, cursors, or credentials"
+            ),
+        },
+        {
+            "command": (
+                "loopx decision-context source-manifest "
+                "--goal-id <goal-id> --agent-id <agent-id> "
+                "--profile <private-local-profile> --format json"
+            ),
+            "purpose": (
+                "Project an enabled source profile into a public-safe manifest "
+                "before any provider access."
+            ),
+            "write_boundary": (
+                "read-only local projection; no provider access, cursor write, "
+                "goal mutation, or external action"
+            ),
+        },
+        {
+            "command": (
+                "loopx decision-context prepare-evidence "
+                "--goal-id <goal-id> --agent-id <agent-id> "
+                "--profile <private-local-profile> --decision-id <decision-id> "
+                "[--cursor-state <private-cursor-json>] "
+                "[--source-id <on-demand-source>] --format json"
+            ),
+            "purpose": (
+                "Run bounded scans and exact reads and emit a public-safe "
+                "evidence preparation packet for domain rebase."
+            ),
+            "write_boundary": (
+                "read-only provider access; changed-source cursors remain "
+                "preserved until semantic rebase and validated writeback"
+            ),
+        },
+        {
+            "command": (
+                "loopx decision-context prepare-review "
+                "--goal-id <goal-id> --agent-id <agent-id> "
+                "--profile <private-local-profile> --decision-id <decision-id> "
+                "--rebase-json <private-rebase> "
+                "--pending-settlement <private-pending> [--execute] --format json"
+            ),
+            "purpose": (
+                "Validate a domain semantic rebase and optionally persist an "
+                "unapplied private cross-turn settlement checkpoint."
+            ),
+            "write_boundary": (
+                "execute writes only the selected private pending checkpoint; "
+                "active cursors and Core state remain unchanged"
+            ),
+        },
+        {
+            "command": (
+                "loopx decision-context settle-review "
+                "--goal-id <goal-id> --agent-id <agent-id> "
+                "--profile <private-local-profile> --cursor-state <private-cursors> "
+                "--pending-settlement <private-pending> --event-log <event-log> "
+                "[--proposal-json <proposal> --source-event-id <gate-event>] "
+                "--actor-ref <actor> --reason-code <reason> --summary <summary> "
+                "[--execute] --format json"
+            ),
+            "purpose": (
+                "Settle approve, reject, defer, or explicit semantic no-change "
+                "and CAS-commit consumed-source cursors."
+            ),
+            "write_boundary": (
+                "execute appends one validated local rollout event and atomically "
+                "updates private cursors; no external action or authority change"
+            ),
+        },
+    ],
+    "implemented_protocols": [
+        {
+            "schema_version": schema_version,
+            "module": module,
+            "doc": "docs/reference/protocols/decision-context-architecture-v0.md",
+        }
+        for schema_version, module in (
+            (
+                "decision_context_architecture_v0",
+                "loopx.capabilities.decision_context.architecture",
+            ),
+            (
+                "decision_evidence_packet_v0",
+                "loopx.capabilities.decision_context.packets",
+            ),
+            (
+                "decision_proposal_v0",
+                "loopx.capabilities.decision_context.packets",
+            ),
+            (
+                "decision_review_receipt_v0",
+                "loopx.capabilities.decision_context.packets",
+            ),
+            (
+                "decision_outcome_receipt_v0",
+                "loopx.capabilities.decision_context.packets",
+            ),
+            (
+                "decision_source_manifest_v0",
+                "loopx.capabilities.decision_context.sources",
+            ),
+            (
+                "decision_source_scan_receipt_v0",
+                "loopx.capabilities.decision_context.sources",
+            ),
+            (
+                "decision_context_profile_v0",
+                "loopx.capabilities.decision_context.profile",
+            ),
+            (
+                "decision_context_activation_status_v0",
+                "loopx.capabilities.decision_context.profile",
+            ),
+            (
+                "decision_cursor_commit_receipt_v0",
+                "loopx.capabilities.decision_context.cursor_commit",
+            ),
+            (
+                "decision_semantic_rebase_receipt_v0",
+                "loopx.capabilities.decision_context.assembler",
+            ),
+            (
+                "decision_context_pending_settlement_v0",
+                "loopx.capabilities.decision_context.private_state",
+            ),
+            (
+                "decision_review_settlement_v0",
+                "loopx.capabilities.decision_context.review_settlement",
+            ),
+        )
+    ],
+    "smokes": ["python3 examples/decision-context-contract-smoke.py"],
+    "docs": [
+        "docs/reference/protocols/decision-context-architecture-v0.md",
+        "docs/reference/protocols/decision-context-architecture-v0.zh-CN.md",
+    ],
+    "boundaries": [
+        "The capability is default-off and cannot create action authority or mutate Core state.",
+        "Private locators, cursors, raw content, provider payloads, tool output, and credentials stay outside public packets.",
+        "DecisionSourceProvider rebases current authority; ContextProvider supplies advisory recall only.",
+        "Prepare-evidence is read-only; prepare-review writes only private unapplied state when explicitly executed.",
+        "Cursor commit requires a canonical review receipt, exact gate or semantic no-change proof, lifecycle-event readback, private-state CAS, and atomic verified write; future outcome observation is separate.",
+    ],
+    "next_real_step": (
+        "Exercise one private source profile through approve, reject, defer, and "
+        "quiet no-change settlement, then observe later outcomes."
+    ),
+}

--- a/loopx/capabilities/decision_context/cli.py
+++ b/loopx/capabilities/decision_context/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 from collections.abc import Callable, Collection
 from datetime import datetime, timezone
 from pathlib import Path
@@ -8,7 +9,15 @@ from pathlib import Path
 from .assembler import DecisionEvidenceRecords
 from .architecture import build_decision_context_architecture_packet
 from .profile import resolve_decision_context_activation
-from .runtime import assemble_profile_decision_evidence
+from .private_state import (
+    load_private_pending_decision_settlement,
+    write_private_pending_decision_settlement,
+)
+from .review_settlement import settle_profile_decision_review
+from .runtime import (
+    assemble_profile_decision_evidence,
+    decision_evidence_records_from_mapping,
+)
 from .sources import build_decision_source_manifest
 
 PrintPayload = Callable[
@@ -17,6 +26,16 @@ PrintPayload = Callable[
 ]
 FormatSelector = Callable[..., str]
 AddFormat = Callable[[argparse.ArgumentParser], None]
+
+
+def _load_json_mapping(path: str, *, label: str) -> dict[str, object]:
+    try:
+        payload = json.loads(Path(path).expanduser().read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{label} is unavailable") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} must be an object")
+    return payload
 
 
 def _collection_size(value: object) -> int:
@@ -121,6 +140,55 @@ def register_decision_context_commands(
         type=float,
         help="Optional bounded provider timeout override.",
     )
+    prepare_review = commands.add_parser(
+        "prepare-review",
+        help=(
+            "Validate a domain semantic rebase and optionally persist one private "
+            "pending settlement without applying active cursors."
+        ),
+    )
+    add_subcommand_format(prepare_review)
+    prepare_review.add_argument("--goal-id", required=True)
+    prepare_review.add_argument("--agent-id", required=True)
+    prepare_review.add_argument("--profile", required=True)
+    prepare_review.add_argument("--decision-id", required=True)
+    prepare_review.add_argument("--rebase-json", required=True)
+    prepare_review.add_argument("--pending-settlement", required=True)
+    prepare_review.add_argument("--cursor-state")
+    prepare_review.add_argument("--source-id", action="append")
+    prepare_review.add_argument("--observed-at")
+    prepare_review.add_argument("--before")
+    prepare_review.add_argument("--timeout-seconds", type=float)
+    prepare_review.add_argument(
+        "--execute",
+        action="store_true",
+        help="Write the private pending settlement; active cursors stay unchanged.",
+    )
+
+    settle_review = commands.add_parser(
+        "settle-review",
+        help=(
+            "Exact-read a user-gate event or semantic no-change result, append "
+            "validated writeback, and CAS-commit private cursors."
+        ),
+    )
+    add_subcommand_format(settle_review)
+    settle_review.add_argument("--goal-id", required=True)
+    settle_review.add_argument("--agent-id", required=True)
+    settle_review.add_argument("--profile", required=True)
+    settle_review.add_argument("--cursor-state", required=True)
+    settle_review.add_argument("--pending-settlement", required=True)
+    settle_review.add_argument("--event-log", required=True)
+    settle_review.add_argument("--proposal-json")
+    settle_review.add_argument("--source-event-id")
+    settle_review.add_argument("--actor-ref", required=True)
+    settle_review.add_argument("--reason-code", required=True)
+    settle_review.add_argument("--summary", required=True)
+    settle_review.add_argument(
+        "--execute",
+        action="store_true",
+        help="Append settlement evidence and apply the private cursor CAS.",
+    )
 
 
 def handle_decision_context_command(
@@ -133,10 +201,18 @@ def handle_decision_context_command(
         return None
     if args.decision_context_command == "architecture":
         payload = build_decision_context_architecture_packet()
-    elif args.decision_context_command == "prepare-evidence":
+    elif args.decision_context_command in {"prepare-evidence", "prepare-review"}:
         now = datetime.now(timezone.utc).isoformat()
         observed_at = str(getattr(args, "observed_at", None) or "").strip() or now
         before = str(getattr(args, "before", None) or "").strip() or observed_at
+        prepare_review = args.decision_context_command == "prepare-review"
+        records = (
+            decision_evidence_records_from_mapping(
+                _load_json_mapping(args.rebase_json, label="rebase JSON")
+            )
+            if prepare_review
+            else DecisionEvidenceRecords()
+        )
         activation, assembly = assemble_profile_decision_evidence(
             goal_id=args.goal_id,
             agent_id=args.agent_id,
@@ -154,16 +230,56 @@ def handle_decision_context_command(
                 if getattr(args, "source_id", None) is not None
                 else None
             ),
-            rebase=lambda _collection: DecisionEvidenceRecords(),
+            rebase=lambda _collection: records,
             timeout_seconds=getattr(args, "timeout_seconds", None),
         )
+        settlement_required = bool(
+            assembly is not None and assembly.proposed_cursors
+        )
+        pending_written = False
+        if prepare_review and settlement_required and bool(args.execute):
+            write_private_pending_decision_settlement(
+                Path(args.pending_settlement),
+                assembly,
+            )
+            pending_written = True
         payload = activation | {
             "assembly": assembly.public_packet() if assembly is not None else None,
-            "semantic_rebase_performed": False,
-            "validated_writeback_required": assembly is not None,
+            "semantic_rebase_performed": prepare_review,
+            "validated_writeback_required": (
+                settlement_required if prepare_review else assembly is not None
+            ),
             "cursor_commit_allowed": False,
             "cursor_state_mutated": False,
+            "pending_settlement_written": pending_written,
         }
+    elif args.decision_context_command == "settle-review":
+        assembly = load_private_pending_decision_settlement(
+            Path(args.pending_settlement)
+        )
+        proposal = (
+            _load_json_mapping(args.proposal_json, label="proposal JSON")
+            if str(args.proposal_json or "").strip()
+            else None
+        )
+        payload = settle_profile_decision_review(
+            goal_id=args.goal_id,
+            agent_id=args.agent_id,
+            profile_path=Path(args.profile),
+            cursor_path=Path(args.cursor_state),
+            assembly=assembly,
+            lifecycle_event_log_path=Path(args.event_log),
+            actor_ref=args.actor_ref,
+            reason_code=args.reason_code,
+            summary=args.summary,
+            proposal=proposal,
+            source_event_id=(
+                str(args.source_event_id).strip()
+                if args.source_event_id is not None
+                else None
+            ),
+            execute=bool(args.execute),
+        )
     elif args.decision_context_command in {"inspect-profile", "source-manifest"}:
         profile_value = str(getattr(args, "profile", None) or "").strip()
         status, profile = resolve_decision_context_activation(

--- a/loopx/capabilities/decision_context/cursor_commit.py
+++ b/loopx/capabilities/decision_context/cursor_commit.py
@@ -16,12 +16,15 @@ from ...rollout_event_log import (
 from .assembler import (
     DECISION_CONTEXT_ASSEMBLY_SCHEMA_VERSION,
     DECISION_CURSOR_CHECKPOINT_SCHEMA_VERSION,
+    DECISION_SEMANTIC_REBASE_RECEIPT_SCHEMA_VERSION,
     DecisionContextAssembly,
 )
 from .packets import (
     DECISION_EVIDENCE_PACKET_SCHEMA_VERSION,
     DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION,
     DECISION_PROPOSAL_SCHEMA_VERSION,
+    DECISION_REVIEW_RECEIPT_SCHEMA_VERSION,
+    build_decision_review_receipt,
 )
 from .private_state import (
     load_private_decision_cursors,
@@ -90,12 +93,9 @@ def _load_current_cursors(
     )
 
 
-def _validate_decision_packet_chain(
-    *,
+def _validate_assembly_evidence_checkpoint(
     assembly: DecisionContextAssembly,
-    proposal: Mapping[str, Any],
-    outcome_receipt: Mapping[str, Any],
-) -> tuple[str, str, str, Mapping[str, Any]]:
+) -> tuple[Mapping[str, Any], str, Mapping[str, Any]]:
     packet = assembly.public_packet()
     if packet.get("schema_version") != DECISION_CONTEXT_ASSEMBLY_SCHEMA_VERSION:
         raise ValueError("decision-context assembly schema is invalid")
@@ -134,6 +134,18 @@ def _validate_decision_packet_chain(
         or checkpoint.get("applied") is not False
     ):
         raise ValueError("decision-context cursor checkpoint is not committable")
+    return packet, evidence_ref, checkpoint
+
+
+def _validate_decision_packet_chain(
+    *,
+    assembly: DecisionContextAssembly,
+    proposal: Mapping[str, Any],
+    outcome_receipt: Mapping[str, Any],
+) -> tuple[str, str, str, Mapping[str, Any]]:
+    packet, evidence_ref, checkpoint = _validate_assembly_evidence_checkpoint(
+        assembly
+    )
 
     if proposal.get("schema_version") != DECISION_PROPOSAL_SCHEMA_VERSION:
         raise ValueError("decision-context proposal schema is invalid")
@@ -163,6 +175,140 @@ def _validate_decision_packet_chain(
     ):
         raise ValueError("decision-context outcome receipt does not match proposal")
     return evidence_ref, proposal_ref, outcome_ref, checkpoint
+
+
+def _validate_review_packet_chain(
+    *,
+    assembly: DecisionContextAssembly,
+    proposal: Mapping[str, Any] | None,
+    review_receipt: Mapping[str, Any],
+    event_log_path: Path,
+) -> tuple[str, str | None, str, Mapping[str, Any]]:
+    packet, evidence_ref, checkpoint = _validate_assembly_evidence_checkpoint(
+        assembly
+    )
+
+    if review_receipt.get("schema_version") != DECISION_REVIEW_RECEIPT_SCHEMA_VERSION:
+        raise ValueError("decision-context review receipt schema is invalid")
+    review_ref = _validated_packet_ref(
+        "decision-review",
+        review_receipt,
+        field="packet_ref",
+    )
+    try:
+        canonical_review = build_decision_review_receipt(
+            goal_id=review_receipt.get("goal_id"),
+            decision_id=review_receipt.get("decision_id"),
+            evidence_packet_ref=review_receipt.get("evidence_packet_ref"),
+            recorded_at=review_receipt.get("recorded_at"),
+            disposition=review_receipt.get("disposition"),
+            actor_ref=review_receipt.get("actor_ref"),
+            reason_code=review_receipt.get("reason_code"),
+            summary=review_receipt.get("summary"),
+            proposal_packet_ref=review_receipt.get("proposal_packet_ref"),
+            gate_todo_id=review_receipt.get("gate_todo_id"),
+            source_event_id=review_receipt.get("source_event_id"),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError("decision-context review receipt is invalid") from exc
+    if dict(review_receipt) != canonical_review:
+        raise ValueError("decision-context review receipt is not canonical")
+    if (
+        review_receipt.get("goal_id") != packet.get("goal_id")
+        or review_receipt.get("decision_id") != packet.get("decision_id")
+        or review_receipt.get("evidence_packet_ref") != evidence_ref
+    ):
+        raise ValueError("decision-context review receipt does not match evidence")
+
+    disposition = str(review_receipt.get("disposition") or "")
+    proposal_ref: str | None = None
+    if disposition == "no_change":
+        semantic_rebase = packet.get("semantic_rebase")
+        if (
+            not isinstance(semantic_rebase, Mapping)
+            or semantic_rebase.get("schema_version")
+            != DECISION_SEMANTIC_REBASE_RECEIPT_SCHEMA_VERSION
+            or semantic_rebase.get("status") != "no_material_change"
+            or semantic_rebase.get("quiet_noop_allowed") is not True
+            or proposal is not None
+        ):
+            raise ValueError(
+                "decision-context no_change settlement lacks semantic proof"
+            )
+    else:
+        if (
+            proposal is None
+            or proposal.get("schema_version") != DECISION_PROPOSAL_SCHEMA_VERSION
+        ):
+            raise ValueError("decision-context proposal schema is invalid")
+        proposal_ref = _validated_packet_ref(
+            "decision-proposal",
+            proposal,
+            field="packet_ref",
+        )
+        if (
+            proposal.get("goal_id") != packet.get("goal_id")
+            or proposal.get("decision_id") != packet.get("decision_id")
+            or proposal.get("evidence_packet_ref") != evidence_ref
+            or review_receipt.get("proposal_packet_ref") != proposal_ref
+        ):
+            raise ValueError("decision-context proposal does not match review")
+        source_event, resolved_disposition = resolve_decision_review_source_event(
+            event_log_path=event_log_path,
+            source_event_id=str(review_receipt.get("source_event_id") or ""),
+            proposal_packet_ref=proposal_ref,
+            gate_todo_id=str(review_receipt.get("gate_todo_id") or ""),
+        )
+        if resolved_disposition != disposition:
+            raise ValueError("decision-context gate disposition does not match review")
+        if source_event.get("recorded_at") != review_receipt.get("recorded_at"):
+            raise ValueError("decision-context review time does not match gate event")
+    return evidence_ref, proposal_ref, review_ref, checkpoint
+
+
+def resolve_decision_review_source_event(
+    *,
+    event_log_path: Path,
+    source_event_id: str,
+    proposal_packet_ref: str,
+    gate_todo_id: str | None = None,
+) -> tuple[Mapping[str, Any], str]:
+    """Exact-read one user-gate event and infer its review disposition."""
+
+    matches = [
+        event
+        for event in load_rollout_events(
+            event_log_path.expanduser(),
+            limit=_LIFECYCLE_WRITEBACK_READ_LIMIT,
+        )
+        if event.get("event_id") == source_event_id
+    ]
+    if len(matches) != 1:
+        raise ValueError("decision-context user-gate event was not found")
+    event = matches[0]
+    details = event.get("details")
+    expected_scope = f"direction:action:{proposal_packet_ref}"
+    if (
+        event.get("schema_version") != ROLLOUT_EVENT_SCHEMA_VERSION
+        or _event_id(event) != source_event_id
+        or not isinstance(details, Mapping)
+        or details.get("task_class") != "user_gate"
+        or details.get("decision_scope") != expected_scope
+        or (gate_todo_id and event.get("todo_id") != gate_todo_id)
+    ):
+        raise ValueError("decision-context user-gate event does not match proposal")
+
+    event_kind = event.get("event_kind")
+    status = event.get("status")
+    outcome = details.get("decision_outcome")
+    if event_kind == "todo_complete" and status == "done" and outcome in {
+        "approve",
+        "reject",
+    }:
+        return event, str(outcome)
+    if event_kind == "todo_update" and status == "deferred" and outcome is None:
+        return event, "defer"
+    raise ValueError("decision-context user-gate event has no review disposition")
 
 
 def _validate_lifecycle_writeback(
@@ -216,10 +362,11 @@ def commit_profile_decision_cursors(
     profile_path: Path,
     cursor_path: Path,
     assembly: DecisionContextAssembly,
-    proposal: Mapping[str, Any],
-    outcome_receipt: Mapping[str, Any],
     lifecycle_event_log_path: Path,
     lifecycle_event_id: str,
+    proposal: Mapping[str, Any] | None = None,
+    review_receipt: Mapping[str, Any] | None = None,
+    outcome_receipt: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """CAS-commit private cursors after exact-read lifecycle writeback validation."""
 
@@ -239,13 +386,32 @@ def commit_profile_decision_cursors(
     ):
         raise ValueError("decision-context profile changed since evidence assembly")
 
-    evidence_ref, proposal_ref, outcome_ref, checkpoint = (
-        _validate_decision_packet_chain(
+    review_ref: str | None = None
+    outcome_ref: str | None = None
+    if review_receipt is not None:
+        evidence_ref, proposal_ref, review_ref, checkpoint = (
+            _validate_review_packet_chain(
+                assembly=assembly,
+                proposal=proposal,
+                review_receipt=review_receipt,
+                event_log_path=lifecycle_event_log_path,
+            )
+        )
+        required_artifact_refs = {evidence_ref, review_ref}
+        if proposal_ref is not None:
+            required_artifact_refs.add(proposal_ref)
+    elif proposal is not None and outcome_receipt is not None:
+        evidence_ref, proposal_ref, outcome_ref, checkpoint = _validate_decision_packet_chain(
             assembly=assembly,
             proposal=proposal,
             outcome_receipt=outcome_receipt,
         )
-    )
+        required_artifact_refs = {evidence_ref, proposal_ref, outcome_ref}
+    else:
+        raise ValueError(
+            "decision-context cursor commit requires review_receipt or the "
+            "legacy proposal/outcome chain"
+        )
     packet = assembly.public_packet()
     if packet.get("goal_id") != goal_id:
         raise ValueError("decision-context assembly goal does not match profile")
@@ -255,7 +421,7 @@ def commit_profile_decision_cursors(
         event_id=lifecycle_event_id,
         goal_id=goal_id,
         decision_id=decision_id,
-        required_artifact_refs={evidence_ref, proposal_ref, outcome_ref},
+        required_artifact_refs=required_artifact_refs,
     )
 
     proposals = dict(assembly.proposed_cursors)
@@ -344,7 +510,13 @@ def commit_profile_decision_cursors(
         "checkpoint_ref": checkpoint["checkpoint_ref"],
         "evidence_packet_ref": evidence_ref,
         "proposal_packet_ref": proposal_ref,
+        "review_receipt_ref": review_ref,
         "outcome_receipt_ref": outcome_ref,
+        "settlement_disposition": (
+            review_receipt.get("disposition")
+            if review_receipt is not None
+            else "legacy_outcome_chain"
+        ),
         "lifecycle_event_id": event["event_id"],
         "status": "committed" if cursor_state_mutated else "replayed",
         "source_count": len(commit_rows),

--- a/loopx/capabilities/decision_context/packets.py
+++ b/loopx/capabilities/decision_context/packets.py
@@ -12,6 +12,7 @@ from typing import Any
 
 DECISION_EVIDENCE_PACKET_SCHEMA_VERSION = "decision_evidence_packet_v0"
 DECISION_PROPOSAL_SCHEMA_VERSION = "decision_proposal_v0"
+DECISION_REVIEW_RECEIPT_SCHEMA_VERSION = "decision_review_receipt_v0"
 DECISION_OUTCOME_RECEIPT_SCHEMA_VERSION = "decision_outcome_receipt_v0"
 
 DECISION_CONTEXT_CAPABILITY_ID = "decision_context"
@@ -20,6 +21,12 @@ DECISION_OUTCOME_VERIFICATION_STATUSES = {
     "verified",
     "refuted",
     "inconclusive",
+}
+DECISION_REVIEW_DISPOSITIONS = {
+    "approve",
+    "reject",
+    "defer",
+    "no_change",
 }
 
 _TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
@@ -446,6 +453,97 @@ def build_decision_proposal(
         "raw_context_captured": False,
     }
     packet["packet_ref"] = _packet_ref("decision-proposal", packet)
+    return packet
+
+
+def build_decision_review_receipt(
+    *,
+    goal_id: str,
+    decision_id: str,
+    evidence_packet_ref: str,
+    recorded_at: str,
+    disposition: str,
+    actor_ref: str,
+    reason_code: str,
+    summary: str,
+    proposal_packet_ref: str | None = None,
+    gate_todo_id: str | None = None,
+    source_event_id: str | None = None,
+) -> dict[str, Any]:
+    """Record one reviewed proposal or an explicit semantic no-change result.
+
+    Review settlement is deliberately separate from outcome observation. A
+    user may approve, reject, or defer a proposal before its real-world outcome
+    exists, while a semantic no-change result needs no user authority at all.
+    """
+
+    normalized_disposition = _compact_token(
+        disposition,
+        field="disposition",
+    )
+    if normalized_disposition not in DECISION_REVIEW_DISPOSITIONS:
+        raise ValueError(
+            "disposition must be approve, reject, defer, or no_change"
+        )
+    gated = normalized_disposition != "no_change"
+    gated_values = {
+        "proposal_packet_ref": proposal_packet_ref,
+        "gate_todo_id": gate_todo_id,
+        "source_event_id": source_event_id,
+    }
+    if gated:
+        missing = sorted(
+            field for field, value in gated_values.items() if value is None
+        )
+        if missing:
+            raise ValueError(
+                "gated review receipt is missing required fields: "
+                + ", ".join(missing)
+            )
+    elif any(value is not None for value in gated_values.values()):
+        raise ValueError(
+            "no_change review receipt must not reference a proposal or user gate"
+        )
+
+    packet: dict[str, Any] = {
+        "schema_version": DECISION_REVIEW_RECEIPT_SCHEMA_VERSION,
+        "goal_id": _compact_token(goal_id, field="goal_id"),
+        "decision_id": _compact_token(decision_id, field="decision_id"),
+        "evidence_packet_ref": _compact_token(
+            evidence_packet_ref,
+            field="evidence_packet_ref",
+        ),
+        "recorded_at": _iso_timestamp(recorded_at, field="recorded_at"),
+        "disposition": normalized_disposition,
+        "actor_ref": _compact_token(actor_ref, field="actor_ref"),
+        "reason_code": _compact_token(reason_code, field="reason_code"),
+        "summary": _compact_text(summary, field="summary"),
+        "proposal_packet_ref": (
+            _compact_token(proposal_packet_ref, field="proposal_packet_ref")
+            if proposal_packet_ref is not None
+            else None
+        ),
+        "gate_todo_id": (
+            _compact_token(gate_todo_id, field="gate_todo_id")
+            if gate_todo_id is not None
+            else None
+        ),
+        "source_event_id": (
+            _compact_token(source_event_id, field="source_event_id")
+            if source_event_id is not None
+            else None
+        ),
+        "visibility": "public_safe",
+        "capability": _capability_contract(packet_role="review_receipt"),
+        "authority_confirmation_required": gated,
+        "authority_confirmed": gated,
+        "quiet_noop": normalized_disposition == "no_change",
+        "outcome_observation_required": normalized_disposition == "approve",
+        "cursor_commit_allowed": True,
+        "external_writes_performed": False,
+        "raw_context_captured": False,
+    }
+    packet["packet_ref"] = _packet_ref("decision-review", packet)
     return packet
 
 

--- a/loopx/capabilities/decision_context/private_state.py
+++ b/loopx/capabilities/decision_context/private_state.py
@@ -9,7 +9,13 @@ import tempfile
 from collections.abc import Mapping
 from pathlib import Path
 
+from .assembler import DecisionContextAssembly
 from .profile import DecisionContextProfile
+
+
+DECISION_PENDING_SETTLEMENT_SCHEMA_VERSION = (
+    "decision_context_pending_settlement_v0"
+)
 
 
 def load_private_decision_cursors(
@@ -57,6 +63,99 @@ def write_private_decision_cursors_atomic(
     path: Path,
     cursors: Mapping[str, str],
 ) -> None:
+    _write_private_json_atomic(path, dict(sorted(cursors.items())))
+
+
+def write_private_pending_decision_settlement(
+    path: Path,
+    assembly: DecisionContextAssembly,
+) -> None:
+    """Persist unapplied cursor proposals for a cross-turn owner gate."""
+
+    _write_private_json_atomic(
+        path,
+        {
+            "schema_version": DECISION_PENDING_SETTLEMENT_SCHEMA_VERSION,
+            "assembly": assembly.public_packet(),
+            "proposed_cursors": dict(sorted(assembly.proposed_cursors.items())),
+            "expected_cursors": dict(sorted(assembly.expected_cursors.items())),
+            "profile_digest": assembly.profile_digest,
+            "runtime_bound_provider_ids": list(assembly.runtime_bound_provider_ids),
+            "active_cursor_state_mutated": False,
+        },
+    )
+
+
+def load_private_pending_decision_settlement(
+    path: Path,
+) -> DecisionContextAssembly:
+    """Reload a private pending settlement without exposing cursor values."""
+
+    try:
+        with path.expanduser().open(encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("decision-context pending settlement is unavailable") from exc
+    if not isinstance(payload, Mapping):
+        raise ValueError("decision-context pending settlement must be an object")
+    allowed = {
+        "schema_version",
+        "assembly",
+        "proposed_cursors",
+        "expected_cursors",
+        "profile_digest",
+        "runtime_bound_provider_ids",
+        "active_cursor_state_mutated",
+    }
+    if set(payload) != allowed:
+        raise ValueError("decision-context pending settlement fields are invalid")
+    if payload.get("schema_version") != DECISION_PENDING_SETTLEMENT_SCHEMA_VERSION:
+        raise ValueError("decision-context pending settlement schema is invalid")
+    if payload.get("active_cursor_state_mutated") is not False:
+        raise ValueError("decision-context pending settlement cannot apply cursors")
+    assembly = payload.get("assembly")
+    proposed = payload.get("proposed_cursors")
+    expected = payload.get("expected_cursors")
+    provider_ids = payload.get("runtime_bound_provider_ids")
+    profile_digest = payload.get("profile_digest")
+    if not isinstance(assembly, Mapping):
+        raise ValueError("decision-context pending assembly is invalid")
+    if not isinstance(proposed, Mapping) or any(
+        not isinstance(key, str)
+        or not isinstance(value, str)
+        or not key.strip()
+        or not value.strip()
+        for key, value in proposed.items()
+    ):
+        raise ValueError("decision-context pending cursor proposals are invalid")
+    if not isinstance(expected, Mapping) or any(
+        not isinstance(key, str)
+        or not key.strip()
+        or (value is not None and (not isinstance(value, str) or not value.strip()))
+        for key, value in expected.items()
+    ):
+        raise ValueError("decision-context pending expected cursors are invalid")
+    if (
+        isinstance(provider_ids, (str, bytes))
+        or not isinstance(provider_ids, list)
+        or any(not isinstance(value, str) or not value.strip() for value in provider_ids)
+    ):
+        raise ValueError("decision-context pending provider ids are invalid")
+    if not isinstance(profile_digest, str) or not profile_digest.strip():
+        raise ValueError("decision-context pending profile digest is invalid")
+    return DecisionContextAssembly(
+        packet=dict(assembly),
+        proposed_cursors={str(key): str(value) for key, value in proposed.items()},
+        expected_cursors={str(key): value for key, value in expected.items()},
+        profile_digest=profile_digest,
+        runtime_bound_provider_ids=tuple(sorted(set(provider_ids))),
+    )
+
+
+def _write_private_json_atomic(
+    path: Path,
+    payload: Mapping[str, object],
+) -> None:
     destination = path.expanduser()
     destination.parent.mkdir(parents=True, exist_ok=True)
     descriptor, temporary_name = tempfile.mkstemp(
@@ -68,7 +167,7 @@ def write_private_decision_cursors_atomic(
     try:
         with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
             json.dump(
-                dict(sorted(cursors.items())),
+                payload,
                 handle,
                 ensure_ascii=True,
                 sort_keys=True,

--- a/loopx/capabilities/decision_context/review_settlement.py
+++ b/loopx/capabilities/decision_context/review_settlement.py
@@ -1,0 +1,136 @@
+"""Owner-gated or quiet settlement for one Decision Context assembly."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from ...rollout_event_log import append_rollout_event, build_rollout_event
+from .assembler import DecisionContextAssembly
+from .cursor_commit import (
+    commit_profile_decision_cursors,
+    resolve_decision_review_source_event,
+)
+from .packets import build_decision_review_receipt
+
+
+DECISION_REVIEW_SETTLEMENT_SCHEMA_VERSION = "decision_review_settlement_v0"
+
+
+def settle_profile_decision_review(
+    *,
+    goal_id: str,
+    agent_id: str,
+    profile_path: Path,
+    cursor_path: Path,
+    assembly: DecisionContextAssembly,
+    lifecycle_event_log_path: Path,
+    actor_ref: str,
+    reason_code: str,
+    summary: str,
+    proposal: Mapping[str, Any] | None = None,
+    source_event_id: str | None = None,
+    execute: bool = False,
+) -> dict[str, Any]:
+    """Settle a reviewed proposal or an explicit semantic no-change result."""
+
+    packet = assembly.public_packet()
+    evidence = packet.get("evidence_packet")
+    if not isinstance(evidence, Mapping):
+        raise ValueError("decision-context assembly has no evidence packet")
+    evidence_ref = str(evidence.get("packet_ref") or "")
+    decision_id = str(packet.get("decision_id") or "")
+
+    gate_event: Mapping[str, Any] | None = None
+    proposal_ref: str | None = None
+    gate_todo_id: str | None = None
+    if source_event_id is not None:
+        if proposal is None:
+            raise ValueError("gated decision review requires a proposal")
+        proposal_ref = str(proposal.get("packet_ref") or "")
+        gate_event, disposition = resolve_decision_review_source_event(
+            event_log_path=lifecycle_event_log_path,
+            source_event_id=source_event_id,
+            proposal_packet_ref=proposal_ref,
+        )
+        gate_todo_id = str(gate_event.get("todo_id") or "")
+        recorded_at = str(gate_event.get("recorded_at") or "")
+    else:
+        if proposal is not None:
+            raise ValueError("proposal settlement requires a user-gate event")
+        disposition = "no_change"
+        recorded_at = str(packet.get("observed_at") or "")
+
+    review_receipt = build_decision_review_receipt(
+        goal_id=goal_id,
+        decision_id=decision_id,
+        evidence_packet_ref=evidence_ref,
+        recorded_at=recorded_at,
+        disposition=disposition,
+        actor_ref=actor_ref,
+        reason_code=reason_code,
+        summary=summary,
+        proposal_packet_ref=proposal_ref,
+        gate_todo_id=gate_todo_id,
+        source_event_id=source_event_id,
+    )
+    artifact_refs = [evidence_ref, str(review_receipt["packet_ref"])]
+    if proposal_ref is not None:
+        artifact_refs.append(proposal_ref)
+    lifecycle_event = build_rollout_event(
+        goal_id=goal_id,
+        event_kind="validation",
+        agent_id=agent_id,
+        todo_id=gate_todo_id,
+        decision_id=decision_id,
+        caused_by=source_event_id,
+        status="committed",
+        summary="Decision review settlement validated.",
+        artifact_refs=artifact_refs,
+        details={
+            "capability": "decision_context",
+            "disposition": disposition,
+            "quiet_noop": disposition == "no_change",
+        },
+        recorded_at=recorded_at,
+    )
+
+    result: dict[str, Any] = {
+        "ok": True,
+        "schema_version": DECISION_REVIEW_SETTLEMENT_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "decision_id": decision_id,
+        "disposition": disposition,
+        "review_receipt": review_receipt,
+        "lifecycle_event": {
+            "schema_version": lifecycle_event["schema_version"],
+            "event_id": lifecycle_event["event_id"],
+            "event_kind": lifecycle_event["event_kind"],
+            "status": lifecycle_event["status"],
+            "recorded_at": lifecycle_event["recorded_at"],
+        },
+        "executed": execute,
+        "quiet_noop": disposition == "no_change",
+        "external_writes_performed": False,
+        "raw_context_captured": False,
+        "private_paths_captured": False,
+    }
+    if not execute:
+        result["cursor_commit"] = None
+        return result
+
+    appended = append_rollout_event(lifecycle_event_log_path, lifecycle_event)
+    result["lifecycle_event"]["event_id"] = appended["event_id"]
+    result["cursor_commit"] = commit_profile_decision_cursors(
+        goal_id=goal_id,
+        agent_id=agent_id,
+        profile_path=profile_path,
+        cursor_path=cursor_path,
+        assembly=assembly,
+        proposal=proposal,
+        review_receipt=review_receipt,
+        lifecycle_event_log_path=lifecycle_event_log_path,
+        lifecycle_event_id=str(appended["event_id"]),
+    )
+    return result

--- a/loopx/capabilities/decision_context/runtime.py
+++ b/loopx/capabilities/decision_context/runtime.py
@@ -12,6 +12,7 @@ from ..context_providers.base import ContextProvider
 from .assembler import (
     DecisionContextAssembly,
     DecisionEvidenceRebaser,
+    DecisionEvidenceRecords,
     assemble_decision_evidence,
 )
 from .private_state import load_private_decision_cursors, private_file_digest
@@ -21,6 +22,49 @@ from .profile import (
 )
 from .providers import build_decision_source_provider
 from .sources import DecisionSourceProvider, DecisionSourceScan, DecisionSourceSpec
+
+
+_DECISION_EVIDENCE_RECORD_FIELDS = {
+    "changed_facts",
+    "recalled_claims",
+    "stale_or_rejected_claims",
+    "conflicts",
+    "semantic_no_change",
+}
+
+
+def decision_evidence_records_from_mapping(
+    value: Mapping[str, Any],
+) -> DecisionEvidenceRecords:
+    """Load a strict domain rebase result without trusting private raw content."""
+
+    if not isinstance(value, Mapping):
+        raise TypeError("decision evidence records must be an object")
+    unexpected = sorted(set(value) - _DECISION_EVIDENCE_RECORD_FIELDS)
+    if unexpected:
+        raise ValueError(
+            "decision evidence records contain unsupported fields: "
+            + ", ".join(unexpected)
+        )
+
+    def records(field: str) -> tuple[Mapping[str, Any], ...]:
+        raw = value.get(field, [])
+        if isinstance(raw, (str, bytes)) or not isinstance(raw, list):
+            raise TypeError(f"{field} must be a list of objects")
+        if any(not isinstance(item, Mapping) for item in raw):
+            raise TypeError(f"{field} must be a list of objects")
+        return tuple(dict(item) for item in raw)
+
+    semantic_no_change = value.get("semantic_no_change", False)
+    if not isinstance(semantic_no_change, bool):
+        raise TypeError("semantic_no_change must be a boolean")
+    return DecisionEvidenceRecords(
+        changed_facts=records("changed_facts"),
+        recalled_claims=records("recalled_claims"),
+        stale_or_rejected_claims=records("stale_or_rejected_claims"),
+        conflicts=records("conflicts"),
+        semantic_no_change=semantic_no_change,
+    )
 
 
 class _UnavailableContextProvider:
@@ -161,8 +205,9 @@ def assemble_profile_decision_evidence(
 
     The caller owns domain reasoning through ``rebase``. Raw exact reads and
     advisory recall stay in-process, while the returned public packet contains
-    only opaque refs and compact evidence. ``proposed_cursors`` remain private
-    and must not be persisted until the caller validates lifecycle writeback.
+    only opaque refs and compact evidence. ``proposed_cursors`` remain private;
+    a caller may keep them in the dedicated pending-settlement store, but must
+    not apply them to active cursor state before validated lifecycle writeback.
     """
 
     try:

--- a/loopx/cli_commands/todo_event.py
+++ b/loopx/cli_commands/todo_event.py
@@ -4,6 +4,8 @@ import argparse
 from collections.abc import Callable
 from pathlib import Path
 
+from ..control_plane.todos.contract import decision_scope_metadata_value
+
 
 RolloutEventAppender = Callable[..., dict[str, object]]
 
@@ -16,7 +18,6 @@ TODO_EVENT_KINDS = {
     "archive-completed": "todo_archive_completed",
     "capture-followups": "todo_capture_followups",
 }
-
 
 def append_todo_rollout_event(
     payload: dict[str, object],
@@ -50,6 +51,15 @@ def append_todo_rollout_event(
             "command": "todo",
             "todo_command": args.todo_command,
             "role": payload.get("role") or args.role or "",
+            "task_class": (
+                payload.get("task_class")
+                or getattr(args, "task_class", None)
+                or ""
+            ),
+            "decision_scope": decision_scope_metadata_value(
+                payload.get("decision_scope")
+            ),
+            "decision_outcome": payload.get("decision_outcome"),
             "changed": bool(payload.get("changed")),
             "added": bool(payload.get("added")),
             "already_exists": bool(payload.get("already_exists")),

--- a/tests/capabilities/test_decision_context_assembler.py
+++ b/tests/capabilities/test_decision_context_assembler.py
@@ -473,9 +473,11 @@ def test_architecture_projects_assembler_and_checkpoint_stage() -> None:
 
     assert packet["assembly_schemas"] == [
         "decision_context_assembly_v0",
+        "decision_semantic_rebase_receipt_v0",
         "decision_cursor_checkpoint_v0",
         "decision_cursor_commit_receipt_v0",
     ]
+    assert "decision_review_receipt_v0" in packet["packet_schemas"]
     assert (
         "incremental_cursors_advance_only_after_rebase_and_writeback"
         in packet["invariants"]

--- a/tests/capabilities/test_decision_context_packets.py
+++ b/tests/capabilities/test_decision_context_packets.py
@@ -6,6 +6,7 @@ from loopx.capabilities.decision_context import (
     build_decision_evidence_packet,
     build_decision_outcome_receipt,
     build_decision_proposal,
+    build_decision_review_receipt,
 )
 
 OBSERVED_AT = "2026-07-25T13:30:00+00:00"
@@ -301,6 +302,66 @@ def test_proposal_requires_at_least_one_objective_score() -> None:
                 "rationale": "A has evidence.",
                 "confidence": 0.7,
             },
+        )
+
+
+@pytest.mark.parametrize("disposition", ["approve", "reject", "defer"])
+def test_gated_review_receipt_binds_exact_proposal_and_gate(
+    disposition: str,
+) -> None:
+    evidence = evidence_packet()
+    proposal = proposal_packet(str(evidence["packet_ref"]))
+    receipt = build_decision_review_receipt(
+        goal_id="goal:decision-advisor",
+        decision_id="decision:20260725:priority",
+        evidence_packet_ref=str(evidence["packet_ref"]),
+        proposal_packet_ref=str(proposal["packet_ref"]),
+        gate_todo_id="todo:owner-review",
+        source_event_id="event:owner-review",
+        recorded_at=REVIEW_AT,
+        disposition=disposition,
+        actor_ref="owner:goal",
+        reason_code=f"owner_{disposition}",
+        summary=f"The owner recorded {disposition}.",
+    )
+
+    assert receipt["disposition"] == disposition
+    assert receipt["authority_confirmed"] is True
+    assert receipt["quiet_noop"] is False
+    assert receipt["outcome_observation_required"] is (disposition == "approve")
+
+
+def test_no_change_review_receipt_is_quiet_and_has_no_gate() -> None:
+    evidence = evidence_packet()
+    receipt = build_decision_review_receipt(
+        goal_id="goal:decision-advisor",
+        decision_id="decision:20260725:priority",
+        evidence_packet_ref=str(evidence["packet_ref"]),
+        recorded_at=REVIEW_AT,
+        disposition="no_change",
+        actor_ref="agent:decision-advisor",
+        reason_code="no_material_thesis_change",
+        summary="Changed source material does not alter the current decision.",
+    )
+
+    assert receipt["proposal_packet_ref"] is None
+    assert receipt["gate_todo_id"] is None
+    assert receipt["authority_confirmed"] is False
+    assert receipt["quiet_noop"] is True
+
+
+def test_no_change_review_receipt_rejects_user_gate_refs() -> None:
+    with pytest.raises(ValueError, match="must not reference"):
+        build_decision_review_receipt(
+            goal_id="goal:example",
+            decision_id="decision:example",
+            evidence_packet_ref="decision-evidence-example",
+            proposal_packet_ref="decision-proposal-example",
+            recorded_at=REVIEW_AT,
+            disposition="no_change",
+            actor_ref="agent:decision-advisor",
+            reason_code="no_material_change",
+            summary="No material change.",
         )
 
 

--- a/tests/capabilities/test_decision_context_profile.py
+++ b/tests/capabilities/test_decision_context_profile.py
@@ -339,4 +339,6 @@ def test_catalog_routes_to_default_off_profile_inspection() -> None:
     assert {
         "decision_context_profile_v0",
         "decision_context_activation_status_v0",
+        "decision_review_receipt_v0",
+        "decision_review_settlement_v0",
     } <= schema_versions

--- a/tests/capabilities/test_decision_context_runtime.py
+++ b/tests/capabilities/test_decision_context_runtime.py
@@ -13,6 +13,9 @@ from loopx.capabilities.decision_context import (
     build_decision_outcome_receipt,
     build_decision_proposal,
     commit_profile_decision_cursors,
+    load_private_pending_decision_settlement,
+    settle_profile_decision_review,
+    write_private_pending_decision_settlement,
 )
 from loopx.cli import main
 from loopx.rollout_event_log import append_rollout_event, build_rollout_event
@@ -143,6 +146,30 @@ def append_decision_writeback(
             proposal["packet_ref"],
             outcome["packet_ref"],
         ],
+        recorded_at=OBSERVED_AT,
+    )
+    return append_rollout_event(path, event)
+
+
+def append_review_gate_event(
+    path: Path,
+    proposal: dict[str, Any],
+    disposition: str,
+) -> dict[str, Any]:
+    deferred = disposition == "defer"
+    event = build_rollout_event(
+        goal_id="example-decision-goal",
+        event_kind="todo_update" if deferred else "todo_complete",
+        todo_id="todo:decision-review",
+        status="deferred" if deferred else "done",
+        summary="Owner review state changed.",
+        details={
+            "task_class": "user_gate",
+            "decision_scope": (
+                f"direction:action:{proposal['packet_ref']}"
+            ),
+            "decision_outcome": None if deferred else disposition,
+        },
         recorded_at=OBSERVED_AT,
     )
     return append_rollout_event(path, event)
@@ -725,3 +752,235 @@ def test_cursor_commit_rejects_writeback_without_full_packet_chain(
         )
 
     assert not cursors.exists()
+
+
+@pytest.mark.parametrize("disposition", ["approve", "reject", "defer"])
+def test_review_settlement_commits_consumed_cursor_without_future_outcome(
+    tmp_path: Path,
+    disposition: str,
+) -> None:
+    authority = tmp_path / "authority.md"
+    authority.write_text(PRIVATE_CONTENT, encoding="utf-8")
+    profile = write_profile(tmp_path / "profile.json", authority)
+    cursors = tmp_path / "cursors.json"
+    pending = tmp_path / "pending.json"
+    event_log = tmp_path / "rollout-events.jsonl"
+    _activation, assembly = assemble_profile_decision_evidence(
+        goal_id="example-decision-goal",
+        agent_id="example-agent",
+        profile_path=profile,
+        decision_id="decision:adoption",
+        observed_at=OBSERVED_AT,
+        before=BEFORE,
+        cursor_path=cursors,
+        rebase=semantic_rebase,
+    )
+    assert assembly is not None
+    proposal, _legacy_outcome = decision_chain(assembly)
+    write_private_pending_decision_settlement(pending, assembly)
+    reloaded = load_private_pending_decision_settlement(pending)
+    gate_event = append_review_gate_event(event_log, proposal, disposition)
+
+    result = settle_profile_decision_review(
+        goal_id="example-decision-goal",
+        agent_id="example-agent",
+        profile_path=profile,
+        cursor_path=cursors,
+        assembly=reloaded,
+        lifecycle_event_log_path=event_log,
+        actor_ref="owner:goal",
+        reason_code=f"owner_{disposition}",
+        summary=f"Owner recorded {disposition}.",
+        proposal=proposal,
+        source_event_id=str(gate_event["event_id"]),
+        execute=True,
+    )
+
+    assert result["disposition"] == disposition
+    assert result["review_receipt"]["outcome_observation_required"] is (
+        disposition == "approve"
+    )
+    assert result["cursor_commit"]["settlement_disposition"] == disposition
+    assert result["cursor_commit"]["outcome_receipt_ref"] is None
+    assert json.loads(cursors.read_text(encoding="utf-8")) == dict(
+        assembly.proposed_cursors
+    )
+
+
+def test_semantic_no_change_settlement_is_quiet_and_commits_cursor(
+    tmp_path: Path,
+) -> None:
+    authority = tmp_path / "authority.md"
+    authority.write_text(PRIVATE_CONTENT, encoding="utf-8")
+    profile = write_profile(tmp_path / "profile.json", authority)
+    cursors = tmp_path / "cursors.json"
+    event_log = tmp_path / "rollout-events.jsonl"
+    _activation, assembly = assemble_profile_decision_evidence(
+        goal_id="example-decision-goal",
+        agent_id="example-agent",
+        profile_path=profile,
+        decision_id="decision:adoption",
+        observed_at=OBSERVED_AT,
+        before=BEFORE,
+        cursor_path=cursors,
+        rebase=lambda _collection: DecisionEvidenceRecords(
+            semantic_no_change=True
+        ),
+    )
+    assert assembly is not None
+    assert assembly.public_packet()["semantic_rebase"]["status"] == (
+        "no_material_change"
+    )
+
+    result = settle_profile_decision_review(
+        goal_id="example-decision-goal",
+        agent_id="example-agent",
+        profile_path=profile,
+        cursor_path=cursors,
+        assembly=assembly,
+        lifecycle_event_log_path=event_log,
+        actor_ref="agent:decision-advisor",
+        reason_code="no_material_thesis_change",
+        summary="Changed material does not alter the current decision.",
+        execute=True,
+    )
+
+    assert result["disposition"] == "no_change"
+    assert result["quiet_noop"] is True
+    assert result["review_receipt"]["gate_todo_id"] is None
+    assert result["cursor_commit"]["settlement_disposition"] == "no_change"
+    assert json.loads(cursors.read_text(encoding="utf-8")) == dict(
+        assembly.proposed_cursors
+    )
+
+
+def test_review_settlement_rejects_gate_bound_to_another_proposal(
+    tmp_path: Path,
+) -> None:
+    authority = tmp_path / "authority.md"
+    authority.write_text(PRIVATE_CONTENT, encoding="utf-8")
+    profile = write_profile(tmp_path / "profile.json", authority)
+    cursors = tmp_path / "cursors.json"
+    event_log = tmp_path / "rollout-events.jsonl"
+    _activation, assembly = assemble_profile_decision_evidence(
+        goal_id="example-decision-goal",
+        agent_id="example-agent",
+        profile_path=profile,
+        decision_id="decision:adoption",
+        observed_at=OBSERVED_AT,
+        before=BEFORE,
+        cursor_path=cursors,
+        rebase=semantic_rebase,
+    )
+    assert assembly is not None
+    proposal, _legacy_outcome = decision_chain(assembly)
+    wrong = dict(proposal)
+    wrong["packet_ref"] = "decision-proposal-another"
+    gate_event = append_review_gate_event(event_log, wrong, "approve")
+
+    with pytest.raises(ValueError, match="does not match proposal"):
+        settle_profile_decision_review(
+            goal_id="example-decision-goal",
+            agent_id="example-agent",
+            profile_path=profile,
+            cursor_path=cursors,
+            assembly=assembly,
+            lifecycle_event_log_path=event_log,
+            actor_ref="owner:goal",
+            reason_code="owner_approve",
+            summary="Owner approved another proposal.",
+            proposal=proposal,
+            source_event_id=str(gate_event["event_id"]),
+            execute=True,
+        )
+
+    assert not cursors.exists()
+
+
+def test_prepare_and_settle_no_change_cli_crosses_turns_without_private_output(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    authority = tmp_path / "authority.md"
+    authority.write_text(PRIVATE_CONTENT, encoding="utf-8")
+    profile = write_profile(tmp_path / "profile.json", authority)
+    cursors = tmp_path / "cursors.json"
+    pending = tmp_path / "pending.json"
+    event_log = tmp_path / "rollout-events.jsonl"
+    rebase = tmp_path / "rebase.json"
+    rebase.write_text(
+        json.dumps({"semantic_no_change": True}),
+        encoding="utf-8",
+    )
+
+    assert main(
+        [
+            "--format",
+            "json",
+            "decision-context",
+            "prepare-review",
+            "--goal-id",
+            "example-decision-goal",
+            "--agent-id",
+            "example-agent",
+            "--profile",
+            str(profile),
+            "--decision-id",
+            "decision:adoption",
+            "--rebase-json",
+            str(rebase),
+            "--pending-settlement",
+            str(pending),
+            "--cursor-state",
+            str(cursors),
+            "--observed-at",
+            OBSERVED_AT,
+            "--before",
+            BEFORE,
+            "--execute",
+        ]
+    ) == 0
+    prepared = json.loads(capsys.readouterr().out)
+    assert prepared["pending_settlement_written"] is True
+    assert not cursors.exists()
+
+    assert main(
+        [
+            "--format",
+            "json",
+            "decision-context",
+            "settle-review",
+            "--goal-id",
+            "example-decision-goal",
+            "--agent-id",
+            "example-agent",
+            "--profile",
+            str(profile),
+            "--cursor-state",
+            str(cursors),
+            "--pending-settlement",
+            str(pending),
+            "--event-log",
+            str(event_log),
+            "--actor-ref",
+            "agent:decision-advisor",
+            "--reason-code",
+            "no_material_thesis_change",
+            "--summary",
+            "Changed material does not alter the current decision.",
+            "--execute",
+        ]
+    ) == 0
+    settled = json.loads(capsys.readouterr().out)
+    serialized = json.dumps(settled, sort_keys=True)
+    assert settled["disposition"] == "no_change"
+    assert settled["cursor_commit"]["readback_verified"] is True
+    for private_value in (
+        PRIVATE_CONTENT,
+        str(authority),
+        str(profile),
+        str(cursors),
+        str(pending),
+        str(event_log),
+    ):
+        assert private_value not in serialized

--- a/tests/control_plane/test_todo_decision_scope_cli_validation.py
+++ b/tests/control_plane/test_todo_decision_scope_cli_validation.py
@@ -10,6 +10,7 @@ from loopx.control_plane.testing.canary_harness import (
     run_json_cli_result,
     write_fixture_registry,
 )
+from loopx.rollout_event_log import load_rollout_events, rollout_event_log_path
 
 
 GOAL_ID = "decision-scope-cli-validation"
@@ -360,6 +361,20 @@ def test_todo_complete_cli_applies_explicit_user_gate_outcome(
     )
 
     assert completed["decision_outcome"] == decision_outcome
+    events = load_rollout_events(
+        rollout_event_log_path(tmp_path / "runtime", GOAL_ID)
+    )
+    completion_event = next(
+        event
+        for event in reversed(events)
+        if event.get("event_kind") == "todo_complete"
+        and event.get("todo_id") == gate["todo_id"]
+    )
+    assert completion_event["details"]["task_class"] == "user_gate"
+    assert completion_event["details"]["decision_scope"] == (
+        "private_read:project:restricted_material"
+    )
+    assert completion_event["details"]["decision_outcome"] == decision_outcome
     target_readback = run_json_cli(
         "todo",
         "list",


### PR DESCRIPTION
## Summary

- add a canonical decision_review_receipt_v0 for approve, reject, defer, and explicit semantic no-change settlement
- reuse existing user_gate events as review authority and keep later outcome observation separate from consumed-source cursor settlement
- persist cross-turn cursor proposals only in private unapplied state, then exact-read lifecycle evidence and CAS-commit active cursors
- expose public-safe todo gate scope/outcome fields without changing Core gate transitions or authority
- move the Decision Context catalog entry into its owning capability module to stay within the central catalog maintainability budget

## Boundaries

- no finance thesis, source body, provider payload, credential, private locator, or raw cursor enters public state
- no data provider, trading action, external write authority, new scheduler, or Core gate state machine is added
- no-change creates no user gate; approve, reject, and defer require an exact matching existing gate event
- later outcome receipts remain append-only observations and are still required for Reward Memory eligibility

## Validation

- Ruff and git diff checks passed
- Decision Context and adjacent Material Lifecycle/Todo tests: 94 passed
- Todo control-plane regression tests: 127 passed
- Decision Context contract smoke passed
- loopx canary premerge --from-git-diff --tier standard passed: 4 direct checks and 18 selected checks, 0 failures, 0 warnings, 0 manual holds
- public/private boundary scan passed for all 22 changed files with 0 hits

## Merge decision

Ready for maintainer review. This PR does not request or perform a merge.
