### PR TITLE
feat(goal): add opt-in fine-grained turn mode

### DIFF
--- a/loopx/bootstrap.py
+++ b/loopx/bootstrap.py
@@ -658,6 +658,7 @@ def bootstrap_project(
     execution_surface_only_hints: list[str] | None = None,
     execution_surface_streak_threshold: int | None = None,
     execution_outcome_must_advance: list[str] | None = None,
+    execution_turn_granularity: str | None = None,
     onboarding_scan_enabled: bool = True,
     accept_onboarding_agent_todos: bool = False,
     begin_autonomous_advance: bool = False,
@@ -692,6 +693,7 @@ def bootstrap_project(
         surface_only_hints=execution_surface_only_hints,
         surface_streak_threshold=execution_surface_streak_threshold,
         outcome_must_advance=execution_outcome_must_advance,
+        turn_granularity=execution_turn_granularity,
     )
     onboarding_scan = (
         build_onboarding_scan(

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -14,6 +14,10 @@ from .capabilities.issue_fix.workflow_plan import (
     build_issue_fix_goal_command_templates,
 )
 from .control_plane.effect_program import effect_program_from_ordered_steps
+from .control_plane.goals.start_contract import (
+    build_goal_start_contract,
+    build_goal_start_prompt,
+)
 from .host_loop_activation import (
     agent_type_for_host_surface,
     build_host_loop_activation_packet,
@@ -35,7 +39,6 @@ from .thread_agent_binding import normalize_thread_id, resolve_thread_agent_bind
 
 SCHEMA_VERSION = "loopx_bootstrap_command_pack_v0"
 CANONICAL_SLASH_COMMAND = "/loopx"
-GOAL_START_SCHEMA_VERSION = "loopx_goal_start_command_v0"
 GUIDED_START_SCHEMA_VERSION = "loopx_start_goal_guided_v0"
 PACKET_SUMMARY_SCHEMA_VERSION = "loopx_start_goal_packet_summary_v0"
 PACKET_MEASUREMENT_SCHEMA_VERSION = "loopx_packet_duplication_measurement_v0"
@@ -195,6 +198,7 @@ def _start_goal_command(
     goal_text: str,
     available_capabilities: list[str] | None,
     capability_route: str | None,
+    fine_grained: bool,
     include_command_pack_detail: bool,
 ) -> str:
     return (
@@ -206,6 +210,7 @@ def _start_goal_command(
         + (" --new-peer" if new_peer else "")
         + f" --host-surface {shell_arg(host_surface)}"
         + render_available_capability_args(available_capabilities)
+        + (" --fine-grained" if fine_grained else "")
         + (
             f" --capability-route {shell_arg(capability_route)}"
             if capability_route
@@ -228,6 +233,7 @@ def _start_goal_detail_command(
     goal_text: str,
     available_capabilities: list[str] | None,
     capability_route: str | None,
+    fine_grained: bool,
 ) -> str:
     return _start_goal_command(
         project=project,
@@ -240,6 +246,7 @@ def _start_goal_detail_command(
         goal_text=goal_text,
         available_capabilities=available_capabilities,
         capability_route=capability_route,
+        fine_grained=fine_grained,
         include_command_pack_detail=True,
     )
 
@@ -295,6 +302,7 @@ def build_start_goal_host_surface_selection_packet(
     new_peer: bool = False,
     available_capabilities: list[str] | None = None,
     capability_route: str | None = None,
+    fine_grained: bool = False,
     include_command_pack_detail: bool = False,
 ) -> dict[str, Any]:
     """Fail closed when the caller has not identified the current Codex host."""
@@ -327,6 +335,7 @@ def build_start_goal_host_surface_selection_packet(
             + (" --new-peer" if new_peer else "")
             + f" --host-surface {shell_arg(host_surface)}"
             + render_available_capability_args(available_capabilities)
+            + (" --fine-grained" if fine_grained else "")
             + (
                 f" --capability-route {shell_arg(capability_route)}"
                 if capability_route
@@ -587,6 +596,7 @@ def _bootstrap_command(
     goal_id: str,
     cli_bin: str,
     dry_run: bool,
+    fine_grained: bool = False,
 ) -> str:
     lines = [
         f"cd {shell_arg(project)}",
@@ -597,6 +607,9 @@ def _bootstrap_command(
         f"  --adapter-status {shell_arg(DEFAULT_HANDOFF_ADAPTER_STATUS)} \\",
         "  --codex-app-heartbeat ask",
     ]
+    if fine_grained:
+        lines[-1] += " \\"
+        lines.append("  --fine-grained")
     if dry_run:
         lines[-1] += " \\"
         lines.append("  --dry-run")
@@ -613,6 +626,7 @@ def _goal_start_bootstrap_command(
     goal_id: str,
     goal_text: str | None,
     cli_bin: str,
+    fine_grained: bool,
 ) -> str:
     objective = goal_text or "<exact /loopx goal text>"
     lines = [
@@ -626,6 +640,9 @@ def _goal_start_bootstrap_command(
         "  --no-onboarding-scan \\",
         "  --codex-app-heartbeat ask",
     ]
+    if fine_grained:
+        lines[-1] += " \\"
+        lines.append("  --fine-grained")
     return "\n".join(lines)
 
 
@@ -677,159 +694,6 @@ def _selected_goal_capability_route(
     }
 
 
-def _goal_start_contract(
-    *,
-    goal_text: str | None,
-    selected_capability_route: dict[str, Any] | None,
-    connected: bool,
-    agent_type: str,
-    issue_fix_commands: dict[str, str],
-) -> dict[str, Any]:
-    return {
-        "schema_version": GOAL_START_SCHEMA_VERSION,
-        "behavior_authority": (
-            "ordered_steps + goal_start_contract; skill passes raw arguments after host "
-            "detection, executes packet"
-        ),
-        "slash_syntax": "/loopx <goal text>",
-        "goal_text": goal_text,
-        "selected_capability_route": selected_capability_route,
-        "explicit_invocation_confirms_project_local_state_writes": True,
-        "connect_if_needed": True,
-        "bootstrap_policy": "create project-local LoopX state only when no matching registry goal exists",
-        "planner": {
-            "required_before_todo_write": True,
-            "default_profile": "open_ended_product_direction",
-            "profile_selection": (
-                "Use open_ended_product_direction when the user's goal is a broad, "
-                "fuzzy product direction or new initiative. Use clear_bounded_problem "
-                "when the target is a concrete task with a clear success condition. "
-                "In both cases, let the model produce a real ordered plan before writes."
-            ),
-            "profiles": {
-                "open_ended_product_direction": {
-                    "suggested_items_min": 2,
-                    "suggested_items_max": 5,
-                    "intent": (
-                        "turn an ambiguous product direction into public-safe, ranked "
-                        "todo options before execution"
-                    ),
-                },
-                "clear_bounded_problem": {
-                    "item_count_policy": "planner_sized",
-                    "may_reuse_current_todo_when_it_already_represents_the_plan": True,
-                    "intent": (
-                        "make the approach explicit with enough concise ordered todos, "
-                        "without arbitrary caps or management-only filler"
-                    ),
-                },
-            },
-            "allowed_priorities": ["P0", "P1", "P2"],
-            "default_role": "agent",
-            "default_task_class": "advancement_task",
-            "required_fields": ["priority", "text", "task_class", "action_kind"],
-            "public_safe_only": True,
-            "budget_policy": "minimum sufficient plan; no fixed-count filler",
-        },
-        "priority_ordering": {
-            "bucket_order": ["P0", "P1", "P2"],
-            "same_priority_tie_breaker": "planner_order_then_todo_write_order",
-            "prompt_constraint": "priority then exact write order",
-            "storage_contract": "Todo index is same-priority rank; no extra field",
-        },
-        "execution_invariants": (
-            "identity: fresh public-safe agent after verified/active; explicit takeover; "
-            "bind/readback before Todo; no peer inference; unknown: "
-            "loopx agent-onboard --list-agent-types | route: selected_capability_route only; "
-            "never infer from text/URLs; #/activation+#/stop_conditions; review/pasteable "
-            "gates | Todo/writeback: Agent advancement_task; User owner/private; business Todo "
-            "before work; current evidence + next Todo; refresh/quota; chat not durable | "
-            "returned typed quota_guard; one bounded validation+writeback or exact blocker; "
-            "optional need/preview/explicit apply"
-        ),
-        "activation": {
-            "after_write": ["refresh-state", "host_loop_activation", "quota should-run"],
-            "host_loop_required_after_todo_writeback": True,
-            "agent_type": agent_type,
-            "agent_type_discovery": "loopx agent-onboard --list-agent-types",
-            "host_surfaces": {
-                "codex-app": "Codex App heartbeat automation",
-                "codex-cli": "visible Codex CLI `/goal <task_body>`",
-                "claude-code": "Claude Code native `/loop` after `/loopx <task>` arms LoopX",
-                "opencode": "OpenCode `loopx_goal_activate`",
-                "pi": "Pi `loopx_goal_activate`",
-                "gemini-cli": "agent-driven Gemini CLI loop; every turn enters through quota should-run",
-                "cursor-agent": "agent-driven cursor-agent loop; every turn enters through quota should-run",
-                "ark-managed-agent": "one-shot Goal",
-                "manual": "external scheduler or manual quota/status loop",
-                "other-agent": "custom host loop driver using the returned task body and quota guard",
-            },
-            "missing_host_loop_policy": (
-                "Do not claim autonomous setup complete from registry/quota identity alone. "
-                "If the host cannot mutate its loop surface, report the exact pasteable gate."
-            ),
-            "low_cost_recheck_policy": "missing/unknown/stale/type-changed only",
-            "begin_automation_when_quota_allows": True,
-            "spend_quota_after_writeback": True,
-        },
-        "domain_route_hints": {
-            "issue_fix_workflow": {
-                "when": (
-                    "selected_capability_route.capability_id is explicitly "
-                    "set to issue-fix"
-                ),
-                "preview_command": issue_fix_commands[
-                    "issue_fix_workflow_plan_template"
-                ],
-                "decision_command": issue_fix_commands[
-                    "issue_fix_feasibility_template"
-                ],
-                "post_pr_reviewer_request_command": issue_fix_commands[
-                    "issue_fix_reviewer_request_template"
-                ],
-                "post_pr_monitor_command": issue_fix_commands[
-                    "issue_fix_pr_lifecycle_template"
-                ],
-                "writeback": (
-                    "persist candidate preflight; only proceed enters feasibility and writes "
-                    "its successor; keep private/external/publish/destructive/production gates; "
-                    "after PR creation verify reviewer-request, then monitor one PR state bucket"
-                ),
-            }
-        },
-        "connected_at_preview_time": connected,
-        "stop_conditions": [
-            "private material requested before a public-safe todo can be written",
-            "credentials or secrets are required",
-            "destructive git or production operation would be needed",
-            "the host cannot execute shell/CLI/tool calls or persist LoopX state",
-            "the host cannot activate or expose the required host loop and no concrete pasteable gate can be shown",
-        ],
-    }
-
-
-def _goal_start_prompt(*, goal_text: str | None, goal_id: str, agent_id: str | None) -> str:
-    goal_clause = (
-        f"Goal text: {goal_text}"
-        if goal_text
-        else "Goal text: use the text after `/loopx`; if it is empty, handle bare `/loopx` instead."
-    )
-    agent_clause = f" Use agent id `{agent_id}` for quota/claim commands." if agent_id else ""
-    return f"""Plan; returned `ordered_steps` + `goal_start_contract` are authoritative.
-
-{goal_clause}
-Goal id: {goal_id}.{agent_clause}
-
-Rules:
-1. Identity: use verified binding/active contract; a stable unbound host gets a fresh public-safe agent. Existing lanes require explicit takeover plus bind/readback before Todo; never infer peers from Todo/worktree/arguments. Unknown host: `loopx agent-onboard --list-agent-types`.
-2. Capability: only `selected_capability_route`; run entry/admission and its later `capability show`; never infer from text/URLs. Capability state owns facts; generic Todos schedule.
-3. Todos: broad goal 2-5 public-safe items, bounded goal minimum sufficient plan; `[P0]`/`[P1]`/`[P2]`, no `--priority`, preserve order, prefer Agent `advancement_task`, User Todo only for owner/private gates. Write one business Todo before work.
-4. Writeback: current Todo evidence + next executable Todo, then `loopx refresh-state --goal-id {goal_id}` and quota readback. Chat/model summaries are not durable state.
-5. Host loop: after Todo write, activate missing/unknown/stale/type-changed Codex App heartbeat automation, CLI/TraeX `/goal`, Claude `/loop`, OpenCode bridge, Ark one-shot, or custom gate. Else surface the exact pasteable gate; never claim autonomy.
-6. Run the returned typed `quota_guard`; finish one bounded segment with validation + LoopX writeback or an exact blocker. Setup/planning/claim is not delivery.
-7. Optional features: need, preview, explicit apply. Respect private data, credentials, destructive git, production authority, and review rules.
-"""
-
 
 def build_loopx_bootstrap_command_pack(
     *,
@@ -843,6 +707,7 @@ def build_loopx_bootstrap_command_pack(
     new_peer: bool = False,
     available_capabilities: list[str] | None = None,
     capability_route: str | None = None,
+    fine_grained: bool = False,
     resolve_linked_worktree_alias: bool = True,
 ) -> dict[str, Any]:
     inspection = inspect_bootstrap_connection(
@@ -905,12 +770,14 @@ def build_loopx_bootstrap_command_pack(
         goal_id=resolved_goal_id,
         cli_bin=cli_bin,
         dry_run=True,
+        fine_grained=fine_grained,
     )
     bootstrap_after_confirmation_command = _bootstrap_command(
         project=resolved_project,
         goal_id=resolved_goal_id,
         cli_bin=cli_bin,
         dry_run=False,
+        fine_grained=fine_grained,
     )
     host_loop_activation = build_host_loop_activation_packet(
         agent_type=agent_type,
@@ -969,11 +836,13 @@ def build_loopx_bootstrap_command_pack(
         goal_id=resolved_goal_id,
         goal_text=normalized_goal_text,
         cli_bin=cli_bin,
+        fine_grained=fine_grained,
     )
-    goal_start_plan_prompt = _goal_start_prompt(
+    goal_start_plan_prompt = build_goal_start_prompt(
         goal_text=normalized_goal_text,
         goal_id=resolved_goal_id,
         agent_id=str(selected_agent_id) if selected_agent_id else None,
+        fine_grained=fine_grained,
     )
     slash_command_catalog = build_slash_command_catalog(cli_bin=cli_bin)
 
@@ -1037,6 +906,7 @@ def build_loopx_bootstrap_command_pack(
             + (" --new-peer" if new_peer else "")
             + f" --host-surface {shell_arg(host_surface)}"
             + render_available_capability_args(available_capabilities)
+            + (" --fine-grained" if fine_grained else "")
             + (
                 f" --capability-route {shell_arg(capability_route)}"
                 if capability_route
@@ -1061,7 +931,7 @@ def build_loopx_bootstrap_command_pack(
         "available_slash_commands": slash_command_catalog,
         "onboarding_hint": slash_command_catalog["onboarding"],
         "recommended_next_step": recommended_next_step,
-        "goal_start_contract": _goal_start_contract(
+        "goal_start_contract": build_goal_start_contract(
             goal_text=normalized_goal_text,
             selected_capability_route=_selected_goal_capability_route(
                 capability_route
@@ -1069,6 +939,7 @@ def build_loopx_bootstrap_command_pack(
             connected=connected,
             agent_type=agent_type,
             issue_fix_commands=issue_fix_hint_commands,
+            fine_grained=fine_grained,
         ),
         "commands": {
             "doctor": f"{shell_arg(cli_bin)} doctor",
@@ -1079,6 +950,18 @@ def build_loopx_bootstrap_command_pack(
             "bootstrap_dry_run_preview": bootstrap_preview_command,
             "bootstrap_after_user_confirmation": bootstrap_after_confirmation_command,
             "goal_start_connect_if_needed": goal_start_bootstrap_command,
+            **(
+                {
+                    "goal_start_configure_turn_granularity": _project_command(
+                        resolved_project,
+                        f"{shell_arg(cli_bin)} configure-goal --goal-id "
+                        f"{shell_arg(resolved_goal_id)} "
+                        "--execution-turn-granularity fine --execute",
+                    )
+                }
+                if fine_grained
+                else {}
+            ),
             "goal_start_plan_prompt": goal_start_plan_prompt,
             "goal_start_bind_thread": (
                 f"{shell_arg(cli_bin)} bind-agent-thread --goal-id {shell_arg(resolved_goal_id)} "
@@ -1170,6 +1053,7 @@ def _build_multi_goal_start_selection_packet(
     goal_text: str,
     available_capabilities: list[str] | None,
     capability_route: str | None,
+    fine_grained: bool,
     include_command_pack_detail: bool,
 ) -> dict[str, Any] | None:
     inspection = inspect_bootstrap_connection(
@@ -1209,6 +1093,7 @@ def _build_multi_goal_start_selection_packet(
             + (" --new-peer" if new_peer else "")
             + f" --host-surface {shell_arg(host_surface)}"
             + render_available_capability_args(available_capabilities)
+            + (" --fine-grained" if fine_grained else "")
             + (
                 f" --capability-route {shell_arg(capability_route)}"
                 if capability_route
@@ -1284,7 +1169,7 @@ def _build_multi_goal_start_selection_packet(
         "available_slash_commands": slash_command_catalog,
         "onboarding_hint": slash_command_catalog["onboarding"],
         "recommended_next_step": recommended_next_step,
-        "goal_start_contract": _goal_start_contract(
+        "goal_start_contract": build_goal_start_contract(
             goal_text=normalized_goal_text,
             selected_capability_route=_selected_goal_capability_route(
                 capability_route
@@ -1292,6 +1177,7 @@ def _build_multi_goal_start_selection_packet(
             connected=True,
             agent_type=agent_type_for_host_surface(host_surface),
             issue_fix_commands=issue_fix_commands,
+            fine_grained=fine_grained,
         ),
         "commands": {
             "doctor": f"{shell_arg(cli_bin)} doctor",
@@ -1368,6 +1254,7 @@ def _build_multi_goal_start_selection_packet(
         goal_text=normalized_goal_text,
         available_capabilities=available_capabilities,
         capability_route=capability_route,
+        fine_grained=fine_grained,
     )
     selected_command_pack = (
         command_pack
@@ -1434,6 +1321,7 @@ def build_start_goal_guided_packet(
     new_peer: bool = False,
     available_capabilities: list[str] | None = None,
     capability_route: str | None = None,
+    fine_grained: bool = False,
     include_command_pack_detail: bool = False,
 ) -> dict[str, Any]:
     if goal_id is None:
@@ -1447,6 +1335,7 @@ def build_start_goal_guided_packet(
             goal_text=goal_text,
             available_capabilities=available_capabilities,
             capability_route=capability_route,
+            fine_grained=fine_grained,
             include_command_pack_detail=include_command_pack_detail,
         )
         if selection_packet is not None:
@@ -1462,6 +1351,7 @@ def build_start_goal_guided_packet(
         goal_text=goal_text,
         available_capabilities=available_capabilities,
         capability_route=capability_route,
+        fine_grained=fine_grained,
         resolve_linked_worktree_alias=False,
     )
     commands = command_pack.get("commands")
@@ -1482,6 +1372,7 @@ def build_start_goal_guided_packet(
                 goal_text=str(command_pack.get("goal_text") or goal_text),
                 available_capabilities=available_capabilities,
                 capability_route=capability_route,
+                fine_grained=fine_grained,
                 include_command_pack_detail=False,
             )
 
@@ -1545,6 +1436,21 @@ def build_start_goal_guided_packet(
         if commands.get("goal_start_bind_thread")
         else []
     )
+    fine_mode_steps = (
+        [
+            {
+                "id": "configure_fine_grained_turn_mode",
+                "kind": "conditional_mutation",
+                "command": commands.get("goal_start_configure_turn_granularity"),
+                "purpose": (
+                    "persist fine turn granularity for new or already-connected goals "
+                    "before planning and heartbeat activation"
+                ),
+            }
+        ]
+        if fine_grained
+        else []
+    )
     guided_transaction = {
         "schema_version": GUIDED_START_SCHEMA_VERSION,
         "mode": "dry_run_preview",
@@ -1565,11 +1471,17 @@ def build_start_goal_guided_packet(
                 "purpose": "create or reuse project-local LoopX state only when no matching goal exists",
             },
             *bind_thread_steps,
+            *fine_mode_steps,
             {
                 "id": "plan_ranked_todos",
                 "kind": "model_checkpoint",
                 "prompt": commands.get("goal_start_plan_prompt"),
-                "purpose": "produce concise public-safe P0/P1/P2 todos before todo writeback",
+                "purpose": (
+                    "produce one public-safe, small, verifiable checkpoint Todo; keep "
+                    "later options as evidence-linked planning notes"
+                    if fine_grained
+                    else "produce concise public-safe P0/P1/P2 todos before todo writeback"
+                ),
             },
             {
                 "id": "write_ordered_todos",
@@ -1588,7 +1500,10 @@ def build_start_goal_guided_packet(
                     "[--target-key <target_key>] --text '<[P0/P1/P2] ...>'"
                 ),
                 "purpose": (
-                    "write todos in planner order; capability successors preserve "
+                    "write only the current checkpoint Todo; the existing replan path "
+                    "qualifies any successor after completion evidence"
+                    if fine_grained
+                    else "write todos in planner order; capability successors preserve "
                     "the admitted action_kind and target_key for later quota re-entry"
                 ),
             },
@@ -1708,6 +1623,7 @@ def build_start_goal_guided_packet(
         goal_text=str(command_pack.get("goal_text") or goal_text),
         available_capabilities=available_capabilities,
         capability_route=capability_route,
+        fine_grained=fine_grained,
     )
     selected_command_pack = (
         command_pack

--- a/loopx/cli_commands/bootstrap_connect.py
+++ b/loopx/cli_commands/bootstrap_connect.py
@@ -10,9 +10,6 @@ from ..bootstrap import (
     bootstrap_project,
     render_bootstrap_markdown,
 )
-from ..execution_profile import DEFAULT_EXECUTION_PROFILE
-
-
 PrintPayload = Callable[
     [dict[str, object], str, Callable[[dict[str, object]], str]],
     None,
@@ -65,8 +62,16 @@ def register_bootstrap_connect_command(subparsers: argparse._SubParsersAction) -
         help=argparse.SUPPRESS,
     )
     bootstrap_parser.add_argument(
+        "--fine-grained",
+        action="store_true",
+        help=(
+            "Persist one-small-checkpoint-per-turn execution with evidence-driven "
+            "replanning after each completed Todo."
+        ),
+    )
+    bootstrap_parser.add_argument(
         "--execution-minimum-scale",
-        default=str(DEFAULT_EXECUTION_PROFILE["minimum_scale"]),
+        default=None,
         help="Minimum delivery scale after repeated small follow-through.",
     )
     bootstrap_parser.add_argument(
@@ -78,7 +83,7 @@ def register_bootstrap_connect_command(subparsers: argparse._SubParsersAction) -
     bootstrap_parser.add_argument(
         "--execution-small-streak-threshold",
         type=int,
-        default=int(DEFAULT_EXECUTION_PROFILE["degradation_policy"]["small_scale_streak_threshold"]),
+        default=None,
         help="Repeated small-scale streak that triggers the delivery contract.",
     )
     bootstrap_parser.add_argument(
@@ -96,7 +101,7 @@ def register_bootstrap_connect_command(subparsers: argparse._SubParsersAction) -
     bootstrap_parser.add_argument(
         "--execution-surface-streak-threshold",
         type=int,
-        default=int(DEFAULT_EXECUTION_PROFILE["outcome_floor"]["surface_streak_threshold"]),
+        default=None,
         help="Surface-progress streak that triggers the outcome-floor contract.",
     )
     bootstrap_parser.add_argument(
@@ -209,6 +214,7 @@ def handle_bootstrap_connect_command(
             execution_surface_only_hints=args.execution_surface_only_hint or None,
             execution_surface_streak_threshold=args.execution_surface_streak_threshold,
             execution_outcome_must_advance=args.execution_outcome_must_advance or None,
+            execution_turn_granularity=("fine" if bool(args.fine_grained) else None),
             onboarding_scan_enabled=not bool(args.no_onboarding_scan),
             accept_onboarding_agent_todos=bool(args.accept_onboarding_agent_todos),
             begin_autonomous_advance=bool(args.begin_autonomous_advance),

--- a/loopx/cli_commands/registry_admin.py
+++ b/loopx/cli_commands/registry_admin.py
@@ -584,6 +584,7 @@ def handle_registry_admin_command(
                 runtime_root_override=args.runtime_root,
                 quota_compute=args.quota_compute,
                 quota_window_hours=args.quota_window_hours,
+                execution_turn_granularity=args.execution_turn_granularity,
                 self_repair_enabled=args.self_repair_enabled,
                 self_repair_health=args.self_repair_health,
                 self_repair_waiting_projection=args.self_repair_waiting_projection,

--- a/loopx/cli_commands/registry_admin_configure.py
+++ b/loopx/cli_commands/registry_admin_configure.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 
+from ..execution_profile import TURN_GRANULARITY_CHOICES
 from ..orchestration import EXPLORE_HARNESS_PROFILES
 from .registry_admin_peer import (
     register_peer_runtime_arguments,
@@ -24,6 +25,14 @@ def register_configure_goal_command(subparsers: argparse._SubParsersAction) -> N
     )
     configure_goal_parser.add_argument(
         "--goal-id", required=True, help="Goal id to configure."
+    )
+    configure_goal_parser.add_argument(
+        "--execution-turn-granularity",
+        choices=TURN_GRANULARITY_CHOICES,
+        help=(
+            "Set sticky goal turn granularity. fine runs one small checkpoint Todo "
+            "per turn and replans from fresh evidence before its successor."
+        ),
     )
     configure_goal_parser.add_argument(
         "--quota-compute",

--- a/loopx/cli_commands/start_goal.py
+++ b/loopx/cli_commands/start_goal.py
@@ -20,10 +20,12 @@ PrintPayload = Callable[
 ]
 
 _CAPABILITY_ROUTE_SWITCH = "--capability-route"
+_FINE_GRAINED_SWITCH = "--fine-grained"
 _CAPABILITY_ROUTE_PREFIX = re.compile(
     r"\A--capability-route(?:=(?P<equals>\S+)|\s+(?P<spaced>\S+))"
     r"(?P<remainder>[\s\S]*)\Z"
 )
+_FINE_GRAINED_PREFIX = re.compile(r"\A--fine-grained(?P<remainder>(?:\s[\s\S]*)?)\Z")
 
 
 def add_capability_route_argument(parser: argparse.ArgumentParser) -> None:
@@ -89,6 +91,14 @@ def register_start_goal_command(subparsers: argparse._SubParsersAction) -> None:
         help="Capability available in this host loop. Repeat for multiple capabilities.",
     )
     add_capability_route_argument(start_goal_parser)
+    start_goal_parser.add_argument(
+        "--fine-grained",
+        action="store_true",
+        help=(
+            "Persist fine-grained execution for this goal: one small checkpoint "
+            "todo per turn, followed by evidence-driven replanning."
+        ),
+    )
     goal_input_group = start_goal_parser.add_mutually_exclusive_group(required=True)
     goal_input_group.add_argument(
         "--goal-text",
@@ -98,7 +108,8 @@ def register_start_goal_command(subparsers: argparse._SubParsersAction) -> None:
         "--slash-command-arguments",
         help=(
             "Complete visible /loopx arguments. The CLI consumes only an optional "
-            "leading --capability-route switch and treats the remainder as goal text. "
+            "leading --fine-grained and --capability-route switches and treats the "
+            "remainder as goal text. "
             "Use --slash-command-arguments='<arguments>' when the value begins with --."
         ),
     )
@@ -112,40 +123,71 @@ def register_start_goal_command(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
-def _resolve_start_goal_input(args: argparse.Namespace) -> tuple[str, str | None]:
+def _resolve_start_goal_input(args: argparse.Namespace) -> tuple[str, str | None, bool]:
     raw_arguments = getattr(args, "slash_command_arguments", None)
     capability_route = getattr(args, "capability_route", None)
+    fine_grained = bool(getattr(args, "fine_grained", False))
     if raw_arguments is None:
-        return str(args.goal_text), capability_route
+        return str(args.goal_text), capability_route, fine_grained
     if capability_route is not None:
         raise ValueError(
             "--slash-command-arguments cannot be combined with --capability-route; "
             "the raw argument string already owns the optional route switch"
         )
+    if fine_grained:
+        raise ValueError(
+            "--slash-command-arguments cannot be combined with --fine-grained; "
+            "the raw argument string already owns leading switches"
+        )
 
     normalized = str(raw_arguments).strip()
     if not normalized:
         raise ValueError("--slash-command-arguments must contain goal text")
-    if not normalized.startswith(_CAPABILITY_ROUTE_SWITCH):
-        return normalized, None
-
-    match = _CAPABILITY_ROUTE_PREFIX.fullmatch(normalized)
-    if match is None:
-        raise ValueError(
-            "malformed leading --capability-route in --slash-command-arguments"
-        )
-    route = str(match.group("equals") or match.group("spaced") or "")
-    if route not in START_GOAL_CAPABILITY_ROUTES:
-        raise ValueError(
-            "unsupported --capability-route; expected one of: "
-            + ", ".join(START_GOAL_CAPABILITY_ROUTES)
-        )
-    goal_text = str(match.group("remainder") or "").strip()
+    route = None
+    parsed_fine_grained = False
+    last_switch = None
+    remainder = normalized
+    while True:
+        if remainder.startswith(_FINE_GRAINED_SWITCH):
+            match = _FINE_GRAINED_PREFIX.fullmatch(remainder)
+            if match is None:
+                raise ValueError(
+                    "malformed leading --fine-grained in --slash-command-arguments"
+                )
+            if parsed_fine_grained:
+                raise ValueError("duplicate leading --fine-grained switch")
+            parsed_fine_grained = True
+            last_switch = _FINE_GRAINED_SWITCH
+            remainder = str(match.group("remainder") or "").strip()
+            continue
+        if remainder.startswith(_CAPABILITY_ROUTE_SWITCH):
+            match = _CAPABILITY_ROUTE_PREFIX.fullmatch(remainder)
+            if match is None:
+                raise ValueError(
+                    "malformed leading --capability-route in --slash-command-arguments"
+                )
+            if route is not None:
+                raise ValueError("duplicate leading --capability-route switch")
+            route = str(match.group("equals") or match.group("spaced") or "")
+            last_switch = _CAPABILITY_ROUTE_SWITCH
+            if route not in START_GOAL_CAPABILITY_ROUTES:
+                raise ValueError(
+                    "unsupported --capability-route; expected one of: "
+                    + ", ".join(START_GOAL_CAPABILITY_ROUTES)
+                )
+            remainder = str(match.group("remainder") or "").strip()
+            continue
+        break
+    goal_text = remainder
     if not goal_text:
+        if last_switch == _CAPABILITY_ROUTE_SWITCH:
+            raise ValueError(
+                "--slash-command-arguments must contain goal text after --capability-route"
+            )
         raise ValueError(
-            "--slash-command-arguments must contain goal text after --capability-route"
+            "--slash-command-arguments must contain goal text after --fine-grained"
         )
-    return goal_text, route
+    return goal_text, route, parsed_fine_grained
 
 
 def handle_start_goal_command(
@@ -162,7 +204,7 @@ def handle_start_goal_command(
         print_payload(payload, args.format, render_start_goal_guided_markdown)
         return 2
     try:
-        goal_text, capability_route = _resolve_start_goal_input(args)
+        goal_text, capability_route, fine_grained = _resolve_start_goal_input(args)
     except ValueError as exc:
         payload = {
             "ok": False,
@@ -186,6 +228,7 @@ def handle_start_goal_command(
             goal_text=goal_text,
             available_capabilities=args.available_capabilities,
             capability_route=capability_route,
+            fine_grained=fine_grained,
             include_command_pack_detail=bool(args.include_command_pack_detail),
         )
         print_payload(payload, args.format, render_start_goal_guided_markdown)
@@ -201,6 +244,7 @@ def handle_start_goal_command(
         goal_text=goal_text,
         available_capabilities=args.available_capabilities,
         capability_route=capability_route,
+        fine_grained=fine_grained,
         include_command_pack_detail=bool(args.include_command_pack_detail),
     )
     print_payload(payload, args.format, render_start_goal_guided_markdown)

--- a/loopx/cli_commands/starter_bootstrap.py
+++ b/loopx/cli_commands/starter_bootstrap.py
@@ -105,6 +105,7 @@ def handle_loopx_bootstrap_command_pack_command(
         goal_text=args.goal_text,
         available_capabilities=args.available_capabilities,
         capability_route=args.capability_route,
+        fine_grained=bool(args.fine_grained),
     )
     if bool(getattr(args, "message_only", False)):
         print(str(payload.get("message") or ""))

--- a/loopx/cli_commands/starter_bootstrap_registration.py
+++ b/loopx/cli_commands/starter_bootstrap_registration.py
@@ -93,6 +93,11 @@ def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) 
     )
     add_capability_route_argument(bootstrap_command_pack_parser)
     bootstrap_command_pack_parser.add_argument(
+        "--fine-grained",
+        action="store_true",
+        help="Preview sticky one-checkpoint-per-turn goal execution.",
+    )
+    bootstrap_command_pack_parser.add_argument(
         "--goal-text",
         help=(
             "Optional text after /loopx. When present, preview the explicit goal-start flow: "

--- a/loopx/cli_commands/support_control.py
+++ b/loopx/cli_commands/support_control.py
@@ -7,9 +7,11 @@ from pathlib import Path
 
 from ..agent_registry import (
     agent_profile_from_registry,
+    load_goal_from_registry,
     registered_agent_ids_from_registry,
     require_registered_agent_id,
 )
+from ..execution_profile import execution_profile_turn_granularity
 from ..heartbeat_prompt import (
     build_heartbeat_prompt,
     build_heartbeat_prompt_error_payload,
@@ -516,6 +518,15 @@ def handle_support_control_command(
             if active_state_source.startswith("registry:"):
                 agent_registry_path = Path(active_state_source.removeprefix("registry:"))
             registered_agents = registered_agent_ids_from_registry(agent_registry_path, args.goal_id)
+            registry_goal = load_goal_from_registry(
+                agent_registry_path,
+                args.goal_id,
+            )
+            turn_granularity = execution_profile_turn_granularity(
+                registry_goal.get("execution_profile")
+                if isinstance(registry_goal, dict)
+                else None
+            )
             agent_profile = None
             if args.agent_id:
                 effective_agent_id = require_registered_agent_id(
@@ -575,6 +586,7 @@ def handle_support_control_command(
                     else None
                 ),
                 visible_goal_host=args.visible_goal_host,
+                turn_granularity=turn_granularity,
             )
         except Exception as exc:
             fallback_active_state = active_state

--- a/loopx/configure_goal.py
+++ b/loopx/configure_goal.py
@@ -38,6 +38,11 @@ from .control_plane.todos.contract import normalize_todo_claimed_by
 from .control_plane.todos.mutation_authority import (
     normalize_todo_lifecycle_authority,
 )
+from .execution_profile import (
+    compact_execution_profile,
+    execution_profile_with_turn_granularity,
+    normalize_turn_granularity,
+)
 from .control_plane.agents.legacy_migration import (
     completed_peer_agent_runtime_migration,
     legacy_agent_hierarchy_present,
@@ -219,6 +224,7 @@ def _settings_summary(goal: dict[str, Any]) -> dict[str, Any]:
         coordination.get("registered_agents")
     )
     summary = {
+        "execution_profile": compact_execution_profile(goal.get("execution_profile")),
         "quota": {
             "compute": quota.get("compute"),
             "window_hours": quota.get("window_hours"),
@@ -396,6 +402,7 @@ def configure_goal(
     goal_id: str,
     quota_compute: float | None = None,
     quota_window_hours: float | None = None,
+    execution_turn_granularity: str | None = None,
     self_repair_enabled: bool | None = None,
     self_repair_health: bool | None = None,
     self_repair_waiting_projection: bool | None = None,
@@ -448,6 +455,10 @@ def configure_goal(
 ) -> dict[str, Any]:
     if not registry_path.exists():
         raise FileNotFoundError(f"registry file does not exist: {registry_path}")
+    if execution_turn_granularity is not None:
+        execution_turn_granularity = normalize_turn_granularity(
+            execution_turn_granularity
+        )
     if clear_allowed_domains and allowed_domains:
         raise ValueError("--clear-allowed-domains cannot be combined with --allowed-domain")
     if clear_explore_harness_profile and explore_harness_profile:
@@ -668,6 +679,11 @@ def configure_goal(
 
     before_goal = deepcopy(goal)
     before = _settings_summary(before_goal)
+    if execution_turn_granularity is not None:
+        goal["execution_profile"] = execution_profile_with_turn_granularity(
+            goal.get("execution_profile"),
+            execution_turn_granularity,
+        )
     legacy_hierarchy_before = legacy_agent_hierarchy_present(before_goal)
     expected_migration_id = peer_agent_runtime_migration_id(goal_id, before_goal)
     completed_migration_before = completed_peer_agent_runtime_migration(before_goal)

--- a/loopx/control_plane/goals/goal_frontier/__init__.py
+++ b/loopx/control_plane/goals/goal_frontier/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from ....execution_profile import execution_profile_is_fine_grained
 from ...agents.agent_scope import (
     agent_scope_blocking_handoff_gates,
     agent_scope_count_advancement_items,
@@ -22,7 +23,10 @@ from ...work_items.repair_delta import (
     repair_delta_kinds_have_frontier_delta,
     validate_repair_delta_claims,
 )
-from ..goal_vision_policy import goal_vision_repeats_advancement_until_closed
+from ..goal_vision_policy import (
+    COMPLETED_TODO_CHAIN_REPLAN_THRESHOLD,
+    goal_vision_repeats_advancement_until_closed,
+)
 from ..goal_vision_state import (
     goal_vision_state_is_closed,
     goal_vision_state_requires_successor,
@@ -1362,6 +1366,10 @@ def derive_goal_frontier_replan_obligation_from_summaries(
             ),
         )
     if replan_rule.rule is GoalFrontierReplanRule.VISION_ACCEPTANCE_GAP:
+        fine_checkpoint_replan = any(
+            gap.get("replan_cadence") == "fine_grained_after_each_todo"
+            for gap in compact_acceptance_gaps
+        )
         return build_autonomous_replan_obligation_payload(
             schema_version=AUTONOMOUS_REPLAN_OBLIGATION_SCHEMA_VERSION,
             agent_id=agent_id,
@@ -1391,7 +1399,14 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                 for gap in compact_acceptance_gaps[:3]
             ],
             guidance_actions=[
-                "create_successor",
+                *(
+                    [
+                        "read_latest_completed_todo_evidence",
+                        "retain_replace_or_split_successor",
+                    ]
+                    if fine_checkpoint_replan
+                    else ["create_successor"]
+                ),
                 "update_agent_vision",
                 "record_evidence_gap",
                 "record_no_followup",
@@ -1402,7 +1417,11 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                     "role": "agent",
                     "priority": "P0",
                     "text": (
-                        "run a bounded vision-gap replan: create the next runnable "
+                        "run a bounded fine-grained checkpoint replan: read the latest "
+                        "completion evidence, then retain, replace, or split the next "
+                        "runnable advancement todo, or record no-follow-up"
+                        if fine_checkpoint_replan
+                        else "run a bounded vision-gap replan: create the next runnable "
                         "advancement todo or record an explicit no-follow-up rationale"
                     ),
                 }
@@ -1412,7 +1431,11 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                 "production actions, or owner-only decisions"
             ),
             recommended_action=(
-                "run a bounded vision-gap replan before another quiet poll: create "
+                "run the existing bounded replan path before successor execution: "
+                "read latest completion evidence, then retain, replace, or split the "
+                "successor and write a frontier delta, or record no-follow-up"
+                if fine_checkpoint_replan
+                else "run a bounded vision-gap replan before another quiet poll: create "
                 "successor work, update the agent vision, record evidence gap, or "
                 "record no-follow-up"
             ),
@@ -1696,6 +1719,13 @@ def build_goal_frontier_projection_context_from_status(
             latest_vision_checkpoint,
             agent_todo_summary=agent_todo_summary,
             agent_id=agent_id,
+            completed_todo_threshold=(
+                1
+                if execution_profile_is_fine_grained(
+                    (project_asset or {}).get("execution_profile")
+                )
+                else COMPLETED_TODO_CHAIN_REPLAN_THRESHOLD
+            ),
         )
     )
     if _terminal_no_followup_resolves_vision_checkpoint(

--- a/loopx/control_plane/goals/goal_frontier/outcome_continuity.py
+++ b/loopx/control_plane/goals/goal_frontier/outcome_continuity.py
@@ -406,6 +406,7 @@ def acceptance_gaps_from_todo_completion_checkpoint(
     *,
     agent_todo_summary: dict[str, Any] | None,
     agent_id: str | None,
+    completed_todo_threshold: int = COMPLETED_TODO_CHAIN_REPLAN_THRESHOLD,
 ) -> list[dict[str, Any]]:
     """Require a checkpoint after a bounded chain of scoped completions."""
 
@@ -462,7 +463,8 @@ def acceptance_gaps_from_todo_completion_checkpoint(
         or (_iso_timestamp(item.get("completed_at")) or 0.0)
         > qualified_checkpoint_at
     ]
-    if len(uncheckpointed_items) < COMPLETED_TODO_CHAIN_REPLAN_THRESHOLD:
+    threshold = max(1, int(completed_todo_threshold))
+    if len(uncheckpointed_items) < threshold:
         return []
 
     patch = _dict_field(agent_vision, "vision_patch")
@@ -483,11 +485,11 @@ def acceptance_gaps_from_todo_completion_checkpoint(
             "completed_todo_id": latest_item.get("todo_id"),
             "completed_at": latest_item.get("completed_at"),
             "completed_todo_count": len(uncheckpointed_items),
-            "completed_todo_threshold": COMPLETED_TODO_CHAIN_REPLAN_THRESHOLD,
+            "completed_todo_threshold": threshold,
             "completed_todo_ids": [
                 item.get("todo_id")
                 for item in uncheckpointed_items[
-                    :COMPLETED_TODO_CHAIN_REPLAN_THRESHOLD
+                    :threshold
                 ]
                 if item.get("todo_id")
             ],
@@ -497,5 +499,10 @@ def acceptance_gaps_from_todo_completion_checkpoint(
                 else None
             ),
             "required_path_outcomes": ["continue", "no_change", "replan"],
+            **(
+                {"replan_cadence": "fine_grained_after_each_todo"}
+                if threshold == 1
+                else {}
+            ),
         }
     ]

--- a/loopx/control_plane/goals/start_contract.py
+++ b/loopx/control_plane/goals/start_contract.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from typing import Any
+
+GOAL_START_SCHEMA_VERSION = "loopx_goal_start_command_v0"
+
+
+def build_goal_start_contract(
+    *,
+    goal_text: str | None,
+    selected_capability_route: dict[str, Any] | None,
+    connected: bool,
+    agent_type: str,
+    issue_fix_commands: dict[str, str],
+    fine_grained: bool,
+) -> dict[str, Any]:
+    contract = {
+        "schema_version": GOAL_START_SCHEMA_VERSION,
+        "behavior_authority": (
+            "ordered_steps + goal_start_contract; skill passes raw arguments after host "
+            "detection, executes packet"
+        ),
+        "slash_syntax": "/loopx <goal text>",
+        "goal_text": goal_text,
+        "selected_capability_route": selected_capability_route,
+        "explicit_invocation_confirms_project_local_state_writes": True,
+        "connect_if_needed": True,
+        "bootstrap_policy": "create project-local LoopX state only when no matching registry goal exists",
+        "planner": {
+            "required_before_todo_write": True,
+            "default_profile": "open_ended_product_direction",
+            "profile_selection": (
+                "Use open_ended_product_direction when the user's goal is a broad, "
+                "fuzzy product direction or new initiative. Use clear_bounded_problem "
+                "when the target is a concrete task with a clear success condition. "
+                "In both cases, let the model produce a real ordered plan before writes."
+            ),
+            "profiles": {
+                "open_ended_product_direction": {
+                    "suggested_items_min": 2,
+                    "suggested_items_max": 5,
+                    "intent": (
+                        "turn an ambiguous product direction into public-safe, ranked "
+                        "todo options before execution"
+                    ),
+                },
+                "clear_bounded_problem": {
+                    "item_count_policy": "planner_sized",
+                    "may_reuse_current_todo_when_it_already_represents_the_plan": True,
+                    "intent": (
+                        "make the approach explicit with enough concise ordered todos, "
+                        "without arbitrary caps or management-only filler"
+                    ),
+                },
+            },
+            "allowed_priorities": ["P0", "P1", "P2"],
+            "default_role": "agent",
+            "default_task_class": "advancement_task",
+            "required_fields": ["priority", "text", "task_class", "action_kind"],
+            "public_safe_only": True,
+            "budget_policy": "minimum sufficient plan; no fixed-count filler",
+        },
+        "priority_ordering": {
+            "bucket_order": ["P0", "P1", "P2"],
+            "same_priority_tie_breaker": "planner_order_then_todo_write_order",
+            "prompt_constraint": "priority then exact write order",
+            "storage_contract": "Todo index is same-priority rank; no extra field",
+        },
+        "execution_invariants": (
+            "identity: fresh public-safe agent after verified/active; explicit takeover; "
+            "bind/readback before Todo; no peer inference; unknown: "
+            "loopx agent-onboard --list-agent-types | route: selected_capability_route only; "
+            "never infer from text/URLs; #/activation+#/stop_conditions; review/pasteable "
+            "gates | Todo/writeback: Agent advancement_task; User owner/private; business Todo "
+            "before work; current evidence + next Todo; refresh/quota; chat not durable | "
+            "returned typed quota_guard; one bounded validation+writeback or exact blocker; "
+            "optional need/preview/explicit apply"
+        ),
+        "activation": {
+            "after_write": ["refresh-state", "host_loop_activation", "quota should-run"],
+            "host_loop_required_after_todo_writeback": True,
+            "agent_type": agent_type,
+            "agent_type_discovery": "loopx agent-onboard --list-agent-types",
+            "host_surfaces": {
+                "codex-app": "Codex App heartbeat automation",
+                "codex-cli": "visible Codex CLI `/goal <task_body>`",
+                "claude-code": "Claude Code native `/loop` after `/loopx <task>` arms LoopX",
+                "opencode": "OpenCode `loopx_goal_activate`",
+                "pi": "Pi `loopx_goal_activate`",
+                "gemini-cli": "agent-driven Gemini CLI loop; every turn enters through quota should-run",
+                "cursor-agent": "agent-driven cursor-agent loop; every turn enters through quota should-run",
+                "ark-managed-agent": "one-shot Goal",
+                "manual": "external scheduler or manual quota/status loop",
+                "other-agent": "custom host loop driver using the returned task body and quota guard",
+            },
+            "missing_host_loop_policy": (
+                "Do not claim autonomous setup complete from registry/quota identity alone. "
+                "If the host cannot mutate its loop surface, report the exact pasteable gate."
+            ),
+            "low_cost_recheck_policy": "missing/unknown/stale/type-changed only",
+            "begin_automation_when_quota_allows": True,
+            "spend_quota_after_writeback": True,
+        },
+        "domain_route_hints": {
+            "issue_fix_workflow": {
+                "when": (
+                    "selected_capability_route.capability_id is explicitly "
+                    "set to issue-fix"
+                ),
+                "preview_command": issue_fix_commands[
+                    "issue_fix_workflow_plan_template"
+                ],
+                "decision_command": issue_fix_commands[
+                    "issue_fix_feasibility_template"
+                ],
+                "post_pr_reviewer_request_command": issue_fix_commands[
+                    "issue_fix_reviewer_request_template"
+                ],
+                "post_pr_monitor_command": issue_fix_commands[
+                    "issue_fix_pr_lifecycle_template"
+                ],
+                "writeback": (
+                    "persist candidate preflight; only proceed enters feasibility and writes "
+                    "its successor; keep private/external/publish/destructive/production gates; "
+                    "after PR creation verify reviewer-request, then monitor one PR state bucket"
+                ),
+            }
+        },
+        "connected_at_preview_time": connected,
+        "stop_conditions": [
+            "private material requested before a public-safe todo can be written",
+            "credentials or secrets are required",
+            "destructive git or production operation would be needed",
+            "the host cannot execute shell/CLI/tool calls or persist LoopX state",
+            "the host cannot activate or expose the required host loop and no concrete pasteable gate can be shown",
+        ],
+    }
+    if fine_grained:
+        contract["turn_mode"] = "fine_grained"
+        contract["fine_grained"] = {
+            "todo_granularity": "small_checkpoint",
+            "turn_boundary": "one_todo_per_turn",
+            "replan": "after_each_todo",
+        }
+        planner = contract["planner"]
+        planner["fine_grained_plan_horizon"] = (
+            "write one current runnable checkpoint; keep later options as evidence-linked "
+            "planning notes until the existing replan path qualifies the successor"
+        )
+        planner["maximum_runnable_todos_written_ahead"] = 1
+    return contract
+
+
+def build_goal_start_prompt(
+    *,
+    goal_text: str | None,
+    goal_id: str,
+    agent_id: str | None,
+    fine_grained: bool,
+) -> str:
+    goal_clause = (
+        f"Goal text: {goal_text}"
+        if goal_text
+        else "Goal text: use the text after `/loopx`; if it is empty, handle bare `/loopx` instead."
+    )
+    agent_clause = f" Use agent id `{agent_id}` for quota/claim commands." if agent_id else ""
+    todo_rule = (
+        "plan the broader direction as evidence-linked notes, but write exactly one "
+        "current small, verifiable Agent advancement_task Todo; do not write a runnable "
+        "successor ahead. Use `[P0]`/`[P1]`/`[P2]`, no `--priority`; User Todo only "
+        "for owner/private gates"
+        if fine_grained
+        else "broad goal 2-5 public-safe items, bounded goal minimum sufficient plan; "
+        "`[P0]`/`[P1]`/`[P2]`, no `--priority`, preserve order, prefer Agent "
+        "`advancement_task`, User Todo only for owner/private gates. Write one business "
+        "Todo before work"
+    )
+    fine_rule = (
+        "\n8. Fine-grained mode: the current Todo must be one small verifiable checkpoint. "
+        "If it is too broad, split it before work. Complete only that Todo this turn; "
+        "after validation, durable writeback, accountable refresh, and spend, end the "
+        "turn. The next heartbeat must use the existing replan obligation/ACK path to "
+        "read fresh evidence and retain, replace, or split the successor; do not execute "
+        "a prewritten successor in the same turn."
+        if fine_grained
+        else ""
+    )
+    return f"""Plan; returned `ordered_steps` + `goal_start_contract` are authoritative.
+
+{goal_clause}
+Goal id: {goal_id}.{agent_clause}
+
+Rules:
+1. Identity: use verified binding/active contract; a stable unbound host gets a fresh public-safe agent. Existing lanes require explicit takeover plus bind/readback before Todo; never infer peers from Todo/worktree/arguments. Unknown host: `loopx agent-onboard --list-agent-types`.
+2. Capability: only `selected_capability_route`; run entry/admission and its later `capability show`; never infer from text/URLs. Capability state owns facts; generic Todos schedule.
+3. Todos: {todo_rule}.
+4. Writeback: current Todo evidence + next executable Todo, then `loopx refresh-state --goal-id {goal_id}` and quota readback. Chat/model summaries are not durable state.
+5. Host loop: after Todo write, activate missing/unknown/stale/type-changed Codex App heartbeat automation, CLI/TraeX `/goal`, Claude `/loop`, OpenCode bridge, Ark one-shot, or custom gate. Else surface the exact pasteable gate; never claim autonomy.
+6. Run the returned typed `quota_guard`; finish one bounded segment with validation + LoopX writeback or an exact blocker. Setup/planning/claim is not delivery.
+7. Optional features: need, preview, explicit apply. Respect private data, credentials, destructive git, production authority, and review rules.{fine_rule}
+"""

--- a/loopx/control_plane/handoff/delivery_contract.py
+++ b/loopx/control_plane/handoff/delivery_contract.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from ...execution_profile import (
     compact_execution_profile,
+    execution_profile_is_fine_grained,
     execution_profile_outcome_floor,
     execution_profile_threshold,
     outcome_floor_threshold,
@@ -51,7 +52,11 @@ def handoff_delivery_contract(item: dict[str, Any] | None) -> dict[str, Any] | N
     outcome_floor = execution_profile_outcome_floor(profile)
     outcome_threshold = outcome_floor_threshold(profile)
     outcome_gap_streak = readiness.get("post_handoff_outcome_gap_streak")
-    small_degraded = isinstance(streak, int) and streak >= threshold
+    small_degraded = (
+        not execution_profile_is_fine_grained(profile)
+        and isinstance(streak, int)
+        and streak >= threshold
+    )
     outcome_degraded = (
         isinstance(outcome_gap_streak, int)
         and outcome_gap_streak >= outcome_threshold

--- a/loopx/control_plane/heartbeat/builder.py
+++ b/loopx/control_plane/heartbeat/builder.py
@@ -8,6 +8,10 @@ from typing import Any
 
 from ...agent_registry import normalize_registered_agents
 from ...ark_managed_agent_host import build_ark_managed_agent_host_contract
+from ...execution_profile import (
+    TURN_GRANULARITY_FINE,
+    execution_profile_turn_granularity,
+)
 from ..agents.runtime_model import AgentRuntimeModel
 from ..quota.spend_sources import (
     DEFAULT_SLOT_SPEND_SOURCE,
@@ -63,6 +67,15 @@ from ...project_prompt import (
     render_refresh_state_command,
 )
 
+FINE_GRAINED_TURN_RULE = (
+    "Fine-grained turn contract: the selected Todo must be one small verifiable "
+    "checkpoint; if it is broader, split/replan before delivery. Complete only that "
+    "Todo in this turn. After validation, durable Todo evidence/writeback, accountable "
+    "refresh, and one spend, end the turn without claiming or executing a successor. "
+    "On the next continuation, read the fresh completion evidence and satisfy the "
+    "existing replan obligation/ACK by retaining, replacing, or splitting the successor."
+)
+
 
 def _select_task_body_renderer(
     *,
@@ -109,9 +122,14 @@ def build_heartbeat_prompt(
     runtime_profile: str | None = None,
     scheduler_execution_context: dict[str, Any] | None = None,
     visible_goal_host: str | None = None,
+    turn_granularity: str | None = None,
 ) -> dict[str, Any]:
     if not (full or compact or brief or thin):
         thin = True
+    normalized_turn_granularity = execution_profile_turn_granularity(
+        {"turn_granularity": turn_granularity} if turn_granularity is not None else None
+    )
+    fine_grained = normalized_turn_granularity == TURN_GRANULARITY_FINE
     if visible_goal_host not in {None, "traex-cli"}:
         raise ValueError(f"unsupported visible goal host: {visible_goal_host}")
     if visible_goal_host == "traex-cli" and (
@@ -309,6 +327,8 @@ def build_heartbeat_prompt(
         brief_prompt_command=brief_prompt_command,
         thin_prompt_command=thin_prompt_command,
     )
+    if fine_grained:
+        task_body = f"{task_body}\n\n{FINE_GRAINED_TURN_RULE}"
     if native_goal_host and len(task_body) > NATIVE_GOAL_HOST_MAX_CHARS:
         host_limit = (
             "Ark Managed Agent goal prompt"
@@ -384,6 +404,9 @@ def build_heartbeat_prompt(
         ),
         "task_body": task_body,
     }
+    if fine_grained:
+        payload["turn_granularity"] = TURN_GRANULARITY_FINE
+        payload["turn_mode"] = "fine_grained"
     payload["agent_model"] = AgentRuntimeModel.PEER_V1.value
     if thin:
         payload.pop("compact_prompt_command", None)

--- a/loopx/execution_profile.py
+++ b/loopx/execution_profile.py
@@ -34,6 +34,13 @@ DEFAULT_EXECUTION_PROFILE: dict[str, Any] = {
     },
 }
 
+TURN_GRANULARITY_STANDARD = "standard"
+TURN_GRANULARITY_FINE = "fine"
+TURN_GRANULARITY_CHOICES = (
+    TURN_GRANULARITY_STANDARD,
+    TURN_GRANULARITY_FINE,
+)
+
 _LABEL_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,79}$")
 
 
@@ -72,6 +79,7 @@ def build_execution_profile(
     surface_only_hints: list[str] | None = None,
     surface_streak_threshold: int | None = None,
     outcome_must_advance: list[str] | None = None,
+    turn_granularity: str | None = None,
 ) -> dict[str, Any]:
     profile = compact_execution_profile(None)
     if minimum_scale:
@@ -98,6 +106,15 @@ def build_execution_profile(
     if outcome_must_advance:
         floor["must_advance"] = _label_list(outcome_must_advance, list(floor["must_advance"]))
     profile["outcome_floor"] = floor
+    if turn_granularity is not None:
+        normalized_turn_granularity = normalize_turn_granularity(turn_granularity)
+        if normalized_turn_granularity == TURN_GRANULARITY_FINE:
+            profile["turn_granularity"] = TURN_GRANULARITY_FINE
+            profile["minimum_scale"] = "single_surface"
+            profile["degradation_policy"] = {
+                "small_scale_streak_threshold": 1,
+                "on_degradation": "replan_after_checkpoint",
+            }
     return profile
 
 
@@ -121,6 +138,11 @@ def compact_execution_profile(value: Any) -> dict[str, Any]:
     }
     if not isinstance(value, dict):
         return profile
+
+    if "turn_granularity" in value:
+        turn_granularity = normalize_turn_granularity(value.get("turn_granularity"))
+        if turn_granularity == TURN_GRANULARITY_FINE:
+            profile["turn_granularity"] = turn_granularity
 
     profile["cadence"] = _label(value.get("cadence"), str(profile["cadence"]))
     profile["minimum_scale"] = _label(value.get("minimum_scale"), str(profile["minimum_scale"]))
@@ -152,7 +174,57 @@ def compact_execution_profile(value: Any) -> dict[str, Any]:
     floor["avoid"] = _label_list(raw_floor.get("avoid"), list(floor["avoid"]))
     floor["if_unavailable"] = _label(raw_floor.get("if_unavailable"), str(floor["if_unavailable"]))
     profile["outcome_floor"] = floor
+    if execution_profile_is_fine_grained(profile):
+        profile["minimum_scale"] = "single_surface"
+        profile["degradation_policy"] = {
+            "small_scale_streak_threshold": 1,
+            "on_degradation": "replan_after_checkpoint",
+        }
     return profile
+
+
+def normalize_turn_granularity(value: Any) -> str:
+    candidate = str(value or TURN_GRANULARITY_STANDARD).strip().lower().replace("-", "_")
+    if candidate not in TURN_GRANULARITY_CHOICES:
+        raise ValueError(
+            "turn_granularity must be one of: "
+            + ", ".join(TURN_GRANULARITY_CHOICES)
+        )
+    return candidate
+
+
+def execution_profile_turn_granularity(profile: dict[str, Any] | None) -> str:
+    if not isinstance(profile, dict) or "turn_granularity" not in profile:
+        return TURN_GRANULARITY_STANDARD
+    return normalize_turn_granularity(profile.get("turn_granularity"))
+
+
+def execution_profile_is_fine_grained(profile: dict[str, Any] | None) -> bool:
+    return execution_profile_turn_granularity(profile) == TURN_GRANULARITY_FINE
+
+
+def execution_profile_with_turn_granularity(
+    profile: dict[str, Any] | None,
+    turn_granularity: str,
+) -> dict[str, Any]:
+    normalized = compact_execution_profile(profile)
+    mode = normalize_turn_granularity(turn_granularity)
+    if mode == TURN_GRANULARITY_FINE:
+        normalized["turn_granularity"] = TURN_GRANULARITY_FINE
+        normalized["minimum_scale"] = "single_surface"
+        normalized["degradation_policy"] = {
+            "small_scale_streak_threshold": 1,
+            "on_degradation": "replan_after_checkpoint",
+        }
+        return normalized
+    was_fine = execution_profile_is_fine_grained(normalized)
+    normalized.pop("turn_granularity", None)
+    if was_fine:
+        normalized["minimum_scale"] = DEFAULT_EXECUTION_PROFILE["minimum_scale"]
+        normalized["degradation_policy"] = dict(
+            DEFAULT_EXECUTION_PROFILE["degradation_policy"]
+        )
+    return normalized
 
 
 def execution_profile_threshold(profile: dict[str, Any] | None) -> int:
@@ -192,6 +264,11 @@ def execution_profile_summary(profile: dict[str, Any] | None) -> str:
             f"markers:{','.join(outcome_markers)},"
             f"surface:{','.join(surface_hints)}"
         )
+    turn_suffix = (
+        " turn_granularity=fine"
+        if execution_profile_is_fine_grained(normalized)
+        else ""
+    )
     return (
         f"cadence={normalized.get('cadence')} "
         f"minimum={normalized.get('minimum_scale')} "
@@ -199,4 +276,5 @@ def execution_profile_summary(profile: dict[str, Any] | None) -> str:
         f"spend_rule={normalized.get('spend_rule')} "
         f"small_streak_threshold={policy.get('small_scale_streak_threshold')}"
         f"{floor_suffix}"
+        f"{turn_suffix}"
     )

--- a/loopx/long_task_cadence.py
+++ b/loopx/long_task_cadence.py
@@ -9,7 +9,11 @@ from .control_plane.work_items.delivery_outcome import (
     normalize_delivery_outcome,
     normalize_delivery_turn_kind,
 )
-from .execution_profile import compact_execution_profile, execution_profile_threshold
+from .execution_profile import (
+    compact_execution_profile,
+    execution_profile_is_fine_grained,
+    execution_profile_threshold,
+)
 
 
 LONG_TASK_CADENCE_HINT_SCHEMA_VERSION = "cadence_hint_v0"
@@ -138,8 +142,22 @@ def build_long_task_cadence_hint(
 
     granularity = _progress_granularity(latest_run)
     if granularity in SMALL_PROGRESS_GRANULARITIES:
-        recommendation = "widen" if small_step_streak >= threshold else "keep"
-        reason = "repeated_surface_only" if recommendation == "widen" else _reason_from_granularity(granularity)
+        threshold_reached = small_step_streak >= threshold
+        fine_grained = execution_profile_is_fine_grained(profile)
+        recommendation = (
+            "replan"
+            if fine_grained and threshold_reached
+            else "widen"
+            if threshold_reached
+            else "keep"
+        )
+        reason = (
+            "fine_checkpoint_complete"
+            if recommendation == "replan"
+            else "repeated_surface_only"
+            if recommendation == "widen"
+            else _reason_from_granularity(granularity)
+        )
         return {
             "schema_version": LONG_TASK_CADENCE_HINT_SCHEMA_VERSION,
             "signal": "thin_progress",

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -140,7 +140,7 @@ def _command_prompt_specs(*, cli_bin: str, include_legacy_aliases: bool) -> list
             "command": "/loopx",
             "name": "loopx",
             "description": "Inspect LoopX state, or start concrete project work when arguments are provided.",
-            "argument_hint": "[--capability-route issue-fix] [task text]",
+            "argument_hint": "[--fine-grained] [--capability-route issue-fix] [task text]",
             "instructions": [
                 "Visible command arguments: `$ARGUMENTS`.",
                 "Identify the exact current host surface (codex-app, codex-app-ssh, codex-ide-plugin, codex-cli-tui, opencode, traex-cli, pi, gemini-cli, cursor-agent, or ark-managed-agent).",

--- a/tests/control_plane/test_fine_grained_turn_mode.py
+++ b/tests/control_plane/test_fine_grained_turn_mode.py
@@ -1,0 +1,390 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from argparse import Namespace
+from pathlib import Path
+
+from loopx.bootstrap_command_pack import build_start_goal_guided_packet
+from loopx.cli_commands.start_goal import _resolve_start_goal_input
+from loopx.configure_goal import configure_goal
+from loopx.control_plane.goals.goal_frontier import (
+    derive_goal_frontier_replan_obligation_from_summaries,
+)
+from loopx.control_plane.goals.goal_frontier.outcome_continuity import (
+    acceptance_gaps_from_todo_completion_checkpoint,
+)
+from loopx.control_plane.heartbeat.builder import (
+    FINE_GRAINED_TURN_RULE,
+    build_heartbeat_prompt,
+)
+from loopx.execution_profile import (
+    build_execution_profile,
+    compact_execution_profile,
+    execution_profile_is_fine_grained,
+)
+from loopx.long_task_cadence import build_long_task_cadence_hint
+
+GOAL_ID = "fine-grained-fixture"
+AGENT_ID = "codex-fine-agent"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _start_args(**overrides: object) -> Namespace:
+    values: dict[str, object] = {
+        "goal_text": None,
+        "slash_command_arguments": None,
+        "capability_route": None,
+        "fine_grained": False,
+    }
+    values.update(overrides)
+    return Namespace(**values)
+
+
+def test_leading_fine_grained_switch_is_lossless_and_composes_with_route() -> None:
+    assert _resolve_start_goal_input(
+        _start_args(goal_text="Direct fine goal.", fine_grained=True)
+    ) == ("Direct fine goal.", None, True)
+
+    goal_text, route, fine_grained = _resolve_start_goal_input(
+        _start_args(
+            slash_command_arguments=(
+                "--fine-grained --capability-route issue-fix "
+                "Investigate  two branches without recomposing this text."
+            )
+        )
+    )
+
+    assert fine_grained is True
+    assert route == "issue-fix"
+    assert goal_text == "Investigate  two branches without recomposing this text."
+
+    reverse = _resolve_start_goal_input(
+        _start_args(
+            slash_command_arguments=(
+                "--capability-route=issue-fix --fine-grained Keep exact goal text."
+            )
+        )
+    )
+    assert reverse == ("Keep exact goal text.", "issue-fix", True)
+
+
+def test_public_cli_accepts_direct_fine_start_and_bootstrap_flags(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    registry = tmp_path / "registry.json"
+    environment = {
+        **os.environ,
+        "PYTHONDONTWRITEBYTECODE": "1",
+    }
+
+    started = subprocess.run(
+        [
+            str(REPO_ROOT / "scripts" / "loopx"),
+            "--format",
+            "json",
+            "--registry",
+            str(registry),
+            "start-goal",
+            "--guided",
+            "--project",
+            str(project),
+            "--goal-id",
+            GOAL_ID,
+            "--host-surface",
+            "ark-managed-agent",
+            "--fine-grained",
+            "--goal-text",
+            "Deliver one checkpoint.",
+        ],
+        cwd=REPO_ROOT,
+        env=environment,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    start_payload = json.loads(started.stdout)
+    assert start_payload["command_pack"]["goal_start_contract"]["turn_mode"] == (
+        "fine_grained"
+    )
+
+    bootstrapped = subprocess.run(
+        [
+            str(REPO_ROOT / "scripts" / "loopx"),
+            "--format",
+            "json",
+            "--registry",
+            str(registry),
+            "bootstrap",
+            "--project",
+            str(project),
+            "--goal-id",
+            GOAL_ID,
+            "--objective",
+            "Deliver one checkpoint.",
+            "--fine-grained",
+            "--dry-run",
+            "--no-global-sync",
+        ],
+        cwd=REPO_ROOT,
+        env=environment,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    bootstrap_payload = json.loads(bootstrapped.stdout)
+    assert bootstrap_payload["execution_profile"]["turn_granularity"] == "fine"
+    assert bootstrap_payload["execution_profile"]["minimum_scale"] == "single_surface"
+
+
+def test_fine_profile_expects_small_checkpoints_without_widening() -> None:
+    standard = build_execution_profile()
+    fine = build_execution_profile(turn_granularity="fine")
+
+    assert "turn_granularity" not in standard
+    assert execution_profile_is_fine_grained(standard) is False
+    assert execution_profile_is_fine_grained(compact_execution_profile(fine)) is True
+    assert fine["minimum_scale"] == "single_surface"
+    assert fine["degradation_policy"] == {
+        "small_scale_streak_threshold": 1,
+        "on_degradation": "replan_after_checkpoint",
+    }
+    cadence = build_long_task_cadence_hint(
+        execution_profile=fine,
+        latest_runs=[
+            {
+                "delivery_batch_scale": "single_surface",
+                "delivery_outcome": "validated_progress",
+            }
+        ],
+    )
+    assert cadence["recommendation"] == "replan"
+    assert cadence["reason_codes"] == ["fine_checkpoint_complete"]
+
+
+def test_fine_packet_writes_one_checkpoint_and_persists_mode(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+
+    fine = build_start_goal_guided_packet(
+        project=project,
+        goal_id=GOAL_ID,
+        agent_id=None,
+        cli_bin="loopx",
+        host_surface="ark-managed-agent",
+        goal_text="Explore a branching integration safely.",
+        fine_grained=True,
+        include_command_pack_detail=True,
+    )
+    contract = fine["command_pack"]["goal_start_contract"]
+    commands = fine["command_pack"]["commands"]
+    steps = fine["guided_transaction"]["ordered_steps"]
+
+    assert contract["turn_mode"] == "fine_grained"
+    assert contract["fine_grained"] == {
+        "todo_granularity": "small_checkpoint",
+        "turn_boundary": "one_todo_per_turn",
+        "replan": "after_each_todo",
+    }
+    assert contract["planner"]["maximum_runnable_todos_written_ahead"] == 1
+    assert "--fine-grained" in commands["goal_start_connect_if_needed"]
+    assert (
+        "--execution-turn-granularity fine"
+        in commands["goal_start_configure_turn_granularity"]
+    )
+    assert any(step["id"] == "configure_fine_grained_turn_mode" for step in steps)
+    assert "existing replan obligation/ACK path" in commands["goal_start_plan_prompt"]
+    assert "write exactly one" in commands["goal_start_plan_prompt"]
+    assert "broad goal 2-5" not in commands["goal_start_plan_prompt"]
+
+    standard = build_start_goal_guided_packet(
+        project=project,
+        goal_id=GOAL_ID,
+        agent_id=None,
+        cli_bin="loopx",
+        host_surface="ark-managed-agent",
+        goal_text="Explore a branching integration safely.",
+        include_command_pack_detail=True,
+    )
+    standard_contract = standard["command_pack"]["goal_start_contract"]
+    assert "turn_mode" not in standard_contract
+    assert "fine_grained" not in standard_contract
+    assert "--fine-grained" not in standard["command_pack"]["canonical_cli_command"]
+    assert not any(
+        step["id"] == "configure_fine_grained_turn_mode"
+        for step in standard["guided_transaction"]["ordered_steps"]
+    )
+
+
+def test_fine_heartbeat_rule_is_opt_in_only() -> None:
+    standard = build_heartbeat_prompt(goal_id=GOAL_ID, thin=True)
+    explicit_standard = build_heartbeat_prompt(
+        goal_id=GOAL_ID,
+        thin=True,
+        turn_granularity="standard",
+    )
+    fine = build_heartbeat_prompt(
+        goal_id=GOAL_ID,
+        thin=True,
+        turn_granularity="fine",
+    )
+
+    assert standard == explicit_standard
+    assert FINE_GRAINED_TURN_RULE not in standard["task_body"]
+    assert fine["turn_mode"] == "fine_grained"
+    assert fine["turn_granularity"] == "fine"
+    assert FINE_GRAINED_TURN_RULE in fine["task_body"]
+    assert "end the turn without claiming or executing a successor" in fine["task_body"]
+
+
+def test_heartbeat_cli_reads_sticky_fine_mode_from_registry(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    state = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    state.parent.mkdir(parents=True)
+    state.write_text("# Active Goal State\n", encoding="utf-8")
+    registry = tmp_path / "registry.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": str(state.relative_to(project)),
+                        "execution_profile": build_execution_profile(
+                            turn_granularity="fine"
+                        ),
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            str(REPO_ROOT / "scripts" / "loopx"),
+            "--format",
+            "json",
+            "--registry",
+            str(registry),
+            "heartbeat-prompt",
+            "--thin",
+            "--goal-id",
+            GOAL_ID,
+        ],
+        cwd=REPO_ROOT,
+        env={
+            **os.environ,
+            "PYTHONDONTWRITEBYTECODE": "1",
+        },
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    payload = json.loads(completed.stdout)
+
+    assert payload["turn_mode"] == "fine_grained"
+    assert FINE_GRAINED_TURN_RULE in payload["task_body"]
+
+
+def test_one_fine_completion_reuses_existing_frontier_replan_path() -> None:
+    vision = {
+        "schema_version": "agent_vision_v0",
+        "agent_id": AGENT_ID,
+        "state": "active",
+        "vision_patch": {
+            "acceptance_summary": "Keep the next checkpoint aligned with evidence.",
+            "advancement_policy": "repeat_until_closed",
+        },
+    }
+    completed = {
+        "todo_id": "todo_checkpoint_1",
+        "claimed_by": AGENT_ID,
+        "completed_at": "2026-08-11T09:00:00+08:00",
+    }
+    summary = {
+        "recent_completed_advancement_items": [completed],
+        "current_agent_claimed_advancement_count": 1,
+        "executable_backlog_items": [
+            {
+                "todo_id": "todo_preplanned_successor",
+                "claimed_by": AGENT_ID,
+                "task_class": "advancement_task",
+                "status": "open",
+            }
+        ],
+    }
+
+    assert (
+        acceptance_gaps_from_todo_completion_checkpoint(
+            vision,
+            None,
+            agent_todo_summary=summary,
+            agent_id=AGENT_ID,
+        )
+        == []
+    )
+    gaps = acceptance_gaps_from_todo_completion_checkpoint(
+        vision,
+        None,
+        agent_todo_summary=summary,
+        agent_id=AGENT_ID,
+        completed_todo_threshold=1,
+    )
+    assert gaps[0]["replan_cadence"] == "fine_grained_after_each_todo"
+
+    obligation = derive_goal_frontier_replan_obligation_from_summaries(
+        user_todo_summary=None,
+        agent_todo_summary=summary,
+        work_lane_contract=None,
+        agent_id=AGENT_ID,
+        existing_replan_obligation=None,
+        acceptance_gaps=gaps,
+    )
+    assert obligation is not None
+    assert obligation["required"] is True
+    assert "retain_replace_or_split_successor" in obligation["guidance_actions"]
+    assert "existing bounded replan path" in obligation["recommended_action"]
+
+
+def test_configure_goal_persists_and_can_revert_fine_mode(tmp_path: Path) -> None:
+    registry = tmp_path / "registry.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "status": "active",
+                        "execution_profile": build_execution_profile(),
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    applied = configure_goal(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        execution_turn_granularity="fine",
+        execute=True,
+    )
+    assert applied["changed_fields"] == ["execution_profile"]
+    persisted = json.loads(registry.read_text(encoding="utf-8"))["goals"][0]
+    assert persisted["execution_profile"]["turn_granularity"] == "fine"
+
+    reverted = configure_goal(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        execution_turn_granularity="standard",
+        execute=True,
+    )
+    assert reverted["changed_fields"] == ["execution_profile"]
+    persisted = json.loads(registry.read_text(encoding="utf-8"))["goals"][0]
+    assert "turn_granularity" not in persisted["execution_profile"]


### PR DESCRIPTION
## Summary

- add an opt-in `--fine-grained` turn mode across `/loopx`, `start-goal`, and bootstrap/connect entrypoints, persisted through the execution profile
- constrain fine mode to one small, verifiable advancement Todo per turn
- after completion, reuse the existing vision checkpoint, autonomous replan obligation, and frontier-delta ACK path to read fresh evidence and retain, replace, or split the successor
- keep standard-mode contracts and prompts unchanged
- move the pure goal-start contract and prompt into the goals bounded context so the bootstrap command pack remains within its maintainability budget

## Why

This prevents an agent from treating one broad Todo as permission for a long, wandering single turn. Fine mode creates an explicit checkpoint boundary while preserving LoopX's existing replan and scheduler ownership.

## Validation

- full repository suite: 2687 passed, 2 skipped
- focused fine-turn, CLI, heartbeat, frontier, parity, and maintainability suite: 226 passed
- strict mypy validation passed for the changed source modules
- premerge risk selection: 17/17 checks passed
- change-quality receipt: `cqr_92617a9785e11106e655`
- public/private boundary scan passed

## Merge disposition

The owner authorized maintainer self-merge after exact-head checks and self-review. Install and validate the exact PR branch before merge; merge only if the PR head remains unchanged and no blocker appears.

Closes #3066
