### PR TITLE
fix(ci): unblock frontstage Pages queue and guard star history freshness

### DIFF
--- a/.github/workflows/frontstage-pages.yml
+++ b/.github/workflows/frontstage-pages.yml
@@ -61,11 +61,15 @@ permissions:
 
 concurrency:
   group: frontstage-pages
-  cancel-in-progress: false
+  # A stalled Pages deployment previously occupied this group for two days and
+  # starved every later run (all queued runs were cancelled). Pages deploys are
+  # quick and idempotent, so a newer run may safely supersede a stale one.
+  cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
@@ -167,6 +171,25 @@ jobs:
             --expected-count "$(cat "$RUNNER_TEMP/loopx-stargazers-count")" \
             --output output/frontstage-pages/site/site-assets/star-history.svg
 
+      - name: Verify star history freshness
+        if: github.event_name != 'pull_request'
+        run: |
+          python3 - <<'PY'
+          import datetime as dt
+          from pathlib import Path
+
+          svg_path = Path(
+              "output/frontstage-pages/site/site-assets/star-history.svg"
+          )
+          svg = svg_path.read_text(encoding="utf-8")
+          today = dt.datetime.now(dt.timezone.utc).date()
+          expected = f"updated {today:%b} {today.day}, {today.year}"
+          if expected not in svg:
+              raise SystemExit(
+                  f"stale star history: expected {expected!r} in generated SVG"
+              )
+          PY
+
       - name: Build documentation site
         run: mkdocs build --strict --site-dir output/frontstage-pages/site/docs
 
@@ -195,6 +218,7 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary

- A stalled `deploy` job occupied the `frontstage-pages` concurrency group since 2026-08-09T18:52Z (deployment created with `latestStatus: null`, job never completed). Every later run in the group was cancelled by GitHub concurrency, and the newest schedule run stayed `pending` with no jobs, so the deployed `star-history.svg` stopped updating at 2026-08-09.
- `concurrency.cancel-in-progress: true` lets a newer run supersede a stale one instead of starving the group.
- `timeout-minutes` on `build` (40) and `deploy` (15) makes a hung job fail visibly rather than blocking forever.
- A new `Verify star history freshness` step fails the build if the generated SVG does not carry today's UTC date, so "Star History didn't update" is caught at generation time.

## Validation

- YAML parses (`cancel-in-progress: true`, build 40 / deploy 15).
- `git diff --check` clean.
- Freshness check logic verified locally: `render-star-history.py` output contains `updated Aug 11, 2026` (UTC today) and the guard passes.
- Operational remediation already applied: stuck runs 31330105609 and 31470438022 cancelled; a fresh `workflow_dispatch` (31488222507) is running normally (build in progress) instead of queuing.

## Issue Or Task

- Closes # (root-cause fix for stale GitHub star history)
- Contributor task ID: n/a

## Validation

- [x] YAML parse + diff check
- [x] Freshness guard local pass
- [ ] CI Frontstage Pages (on merge; dispatch validation run in progress)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Test update