### PR TITLE
fix(control-plane): harden monitor and repeated-stall replans

### DIFF
--- a/examples/control_plane/todo-lifecycle-cli-smoke.py
+++ b/examples/control_plane/todo-lifecycle-cli-smoke.py
@@ -69,6 +69,8 @@ def assert_peer_monitor_no_followup() -> None:
             "1d",
             "--next-due-at",
             "2026-07-11T00:00:00Z",
+            "--expires-at",
+            "2026-07-12T00:00:00Z",
         )
         side_monitor_id = side_monitor_added["todo_id"]
         monitor_update_bypass = run_cli_error(
@@ -144,6 +146,8 @@ def assert_peer_monitor_no_followup() -> None:
             "1d",
             "--next-due-at",
             "2026-07-11T00:00:00Z",
+            "--expires-at",
+            "2026-07-12T00:00:00Z",
         )
         write_monitor_completed = run_cli(
             registry_path,

--- a/loopx/capabilities/issue_fix/pr_monitor_materialization.py
+++ b/loopx/capabilities/issue_fix/pr_monitor_materialization.py
@@ -158,6 +158,7 @@ def materialize_issue_fix_grouped_monitors(
                 "0" if material_change else str(previous_no_change + 1)
             ),
             "material_change": "true" if material_change else "false",
+            "watch_only": "true",
         }
         reason = (
             f"Issue-fix PR lifecycle bucket {group['state_bucket']} contains "

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -361,6 +361,15 @@ def register_todo_command(
         ),
     )
     todo_parser.add_argument(
+        "--watch-only",
+        action="store_true",
+        help=(
+            "For agent continuous_monitor add/update, declare an intentionally "
+            "unbounded liveness watch. Watch-only monitors remain schedulable but "
+            "do not drive autonomous replan or block goal convergence."
+        ),
+    )
+    todo_parser.add_argument(
         "--clear-claim",
         action="store_true",
         help="For todo update, remove the soft claimed_by owner from the todo.",
@@ -498,6 +507,7 @@ def handle_todo_command(
                     "cadence": args.cadence,
                     "next_due_at": args.next_due_at,
                     "expires_at": args.expires_at,
+                    "watch_only": "true" if args.watch_only else None,
                 },
                 **_todo_path_args(args),
                 dry_run=bool(args.dry_run),
@@ -563,6 +573,7 @@ def handle_todo_command(
                     "cadence": args.cadence,
                     "next_due_at": args.next_due_at,
                     "expires_at": args.expires_at,
+                    "watch_only": "true" if args.watch_only else None,
                 },
                 clear_claim=bool(args.clear_claim),
                 **_todo_path_args(args),

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -50,6 +50,7 @@ TODO_OPTION_FIELDS = (
     ("--cadence", "cadence"),
     ("--next-due-at", "next_due_at"),
     ("--expires-at", "expires_at"),
+    ("--watch-only", "watch_only"),
     ("--clear-claim", "clear_claim"),
     ("--no-follow-up", "no_follow_up"),
     ("--next-agent-todo", "next_agent_todo"),
@@ -80,7 +81,7 @@ _TODO_UPDATE_MUTABLE_FIELDS = (
     "blocks_agent", "clear_blocks_agent", "excluded_agents", "clear_excluded_agents",
     "global_gate", "clear_global_gate", "unblocks_todo_id", "successor_todo_ids",
     "resume_when", "clear_resume_when", "no_follow_up", "monitor_target_key",
-    "cadence", "next_due_at", "expires_at", "clear_claim",
+    "cadence", "next_due_at", "expires_at", "watch_only", "clear_claim",
 )
 
 _TODO_UPDATE_UNSUPPORTED_FIELDS = (

--- a/loopx/control_plane/goals/goal_frontier/__init__.py
+++ b/loopx/control_plane/goals/goal_frontier/__init__.py
@@ -11,6 +11,8 @@ from ...agents.agent_scope import (
 )
 from ...agents.profile import agent_profile_requires_vision
 from ...agents.runtime_model import peer_work_key, select_peer_for_work
+from ...runtime.time import parse_timestamp
+from ...todos.projection import todo_item_is_watch_only_monitor
 from ...work_items.autonomous_replan_ack import (
     autonomous_replan_ack_matches_agent,
     autonomous_replan_ack_matches_frontier,
@@ -45,6 +47,7 @@ from .semantic_history import (
     latest_agent_vision_from_status_payload,
     latest_autonomous_replan_ack_from_status_payload,
     latest_missing_vision_checkpoint_from_status_payload,
+    latest_replan_ack_feedback_from_status_payload,
 )
 from .terminal import (
     GOAL_TERMINAL_SOURCE_COMPLETENESS_SCHEMA_VERSION,  # noqa: F401
@@ -853,6 +856,20 @@ def _summary_task_counts(summary: dict[str, Any] | None) -> dict[str, int]:
         return {"open": open_count, "advancement": 0, "monitor": 0, "monitor_due": 0}
     executable = summary.get("executable_backlog_items")
     monitor_open = summary.get("monitor_open_items")
+    watch_only_count = (
+        len(
+            [
+                item
+                for item in monitor_open
+                if isinstance(item, dict)
+                and _todo_item_is_actionable_open(item)
+                and todo_item_is_watch_only_monitor(item)
+            ]
+        )
+        if isinstance(monitor_open, list)
+        else safe_non_negative_int(summary.get("watch_only_monitor_count"))
+    )
+    open_count = max(0, open_count - watch_only_count)
     advancement_count = (
         _count_advancement_items(executable)
         if isinstance(executable, list)
@@ -874,6 +891,7 @@ def _summary_task_counts(summary: dict[str, Any] | None) -> dict[str, int]:
                 if isinstance(item, dict)
                 and _todo_item_is_actionable_open(item)
                 and _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
+                and not todo_item_is_watch_only_monitor(item)
             ]
         )
         if isinstance(monitor_open, list)
@@ -883,7 +901,11 @@ def _summary_task_counts(summary: dict[str, Any] | None) -> dict[str, int]:
         "open": open_count,
         "advancement": advancement_count,
         "monitor": monitor_count,
-        "monitor_due": safe_non_negative_int(summary.get("monitor_due_count")),
+        "monitor_due": max(
+            0,
+            safe_non_negative_int(summary.get("monitor_due_count"))
+            - safe_non_negative_int(summary.get("watch_only_monitor_due_count")),
+        ),
     }
 
 
@@ -905,6 +927,8 @@ def _monitor_no_change_streak_trigger(
         if not _todo_item_is_actionable_open(item):
             continue
         if _todo_task_class(item) != TODO_TASK_CLASS_MONITOR:
+            continue
+        if todo_item_is_watch_only_monitor(item):
             continue
         claimed_by = agent_scope_item_claimed_by(item)
         if agent_id and claimed_by != agent_id:
@@ -1679,6 +1703,17 @@ def build_goal_frontier_projection_context_from_status(
         agent_id=agent_id,
         neutral_classifications=neutral_replan_ack_classifications,
     )
+    latest_replan_ack_feedback = latest_replan_ack_feedback_from_status_payload(
+        status_payload,
+        goal_id=goal_id,
+        agent_id=agent_id,
+    )
+    ack_time = parse_timestamp((latest_agent_replan_ack or {}).get("generated_at"))
+    feedback_time = parse_timestamp(
+        (latest_replan_ack_feedback or {}).get("generated_at")
+    )
+    if ack_time is not None and feedback_time is not None and ack_time >= feedback_time:
+        latest_replan_ack_feedback = None
     latest_agent_vision = latest_agent_vision_from_status_payload(
         status_payload,
         goal_id=goal_id,
@@ -1822,6 +1857,21 @@ def build_goal_frontier_projection_context_from_status(
             registered_agent_ids=registered_agent_ids,
         )
 
+    if replan_obligation and latest_replan_ack_feedback:
+        replan_obligation = dict(replan_obligation)
+        replan_obligation["replan_ack_feedback"] = latest_replan_ack_feedback
+        claims = latest_replan_ack_feedback.get("rejected_claims") or []
+        first_claim = next(
+            (item for item in claims if isinstance(item, dict)),
+            None,
+        )
+        if first_claim:
+            replan_obligation["recommended_action"] = (
+                "previous replan ACK was rejected: "
+                f"{first_claim.get('kind')}: {first_claim.get('reason')}; "
+                + str(replan_obligation.get("recommended_action") or "replan again")
+            )
+
     goal_frontier_projection = build_goal_frontier_projection_from_summaries(
         goal_id=goal_id,
         agent_id=agent_id,
@@ -1856,6 +1906,9 @@ def compact_replan_obligation(replan_obligation: dict[str, Any]) -> dict[str, An
         compact["agent_todo_writeback_required"] = True
     if replan_obligation.get("frontier_identity"):
         compact["frontier_identity"] = replan_obligation.get("frontier_identity")
+    if isinstance(replan_obligation.get("replan_ack_feedback"), dict):
+        compact["replan_ack_feedback"] = replan_obligation["replan_ack_feedback"]
+        compact["recommended_action"] = replan_obligation.get("recommended_action")
     return compact
 
 

--- a/loopx/control_plane/goals/goal_frontier/semantic_history.py
+++ b/loopx/control_plane/goals/goal_frontier/semantic_history.py
@@ -297,3 +297,34 @@ def latest_autonomous_replan_ack_from_status_payload(
         latest_runs,
         neutral_classifications=neutral_classifications,
     )
+
+
+def latest_replan_ack_feedback_from_status_payload(
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+    agent_id: str | None,
+) -> dict[str, Any] | None:
+    """Return the newest rejected replan ACK reason for one agent lane."""
+
+    semantic_history_present, context = _semantic_agent_context_for_goal(
+        status_payload,
+        goal_id=goal_id,
+        agent_id=agent_id,
+    )
+    if semantic_history_present:
+        run = (
+            context.get("latest_replan_ack_feedback_run")
+            if isinstance(context, dict)
+            else None
+        )
+        candidates = [run] if isinstance(run, dict) else []
+    else:
+        candidates = _latest_runs_for_goal(status_payload, goal_id=goal_id)
+    for run in candidates:
+        if not _run_agent_id_matches(run, agent_id=agent_id):
+            continue
+        feedback = run.get("replan_ack_feedback")
+        if isinstance(feedback, dict):
+            return feedback
+    return None

--- a/loopx/control_plane/goals/goal_frontier/terminal.py
+++ b/loopx/control_plane/goals/goal_frontier/terminal.py
@@ -6,7 +6,6 @@ GOAL_TERMINAL_STATE_SCHEMA_VERSION = "goal_terminal_state_v0"
 GOAL_TERMINAL_SOURCE_COMPLETENESS_SCHEMA_VERSION = "goal_terminal_source_completeness_v0"
 VISION_CHECKPOINT_NO_FOLLOWUP_RESOLUTION = "record_no_followup"
 
-
 def _strict_zero(value: Any) -> bool:
     return type(value) is int and value == 0
 
@@ -31,17 +30,18 @@ def _terminal_todo_source_state(
     total = summary.get("total_count")
     done = summary.get("done_count")
     deferred = summary.get("deferred_count")
+    watch_only = summary.get("watch_only_monitor_count", 0)
     if not (
         type(total) is int
         and total >= 0
         and type(done) is int
-        and done == total
-        and _strict_zero(summary.get("open_count"))
+        and type(watch_only) is int
+        and watch_only >= 0
+        and done + watch_only == total
+        and _strict_zero(summary.get("convergence_open_count", summary.get("open_count")))
         and _strict_zero(deferred)
-        and _strict_zero(summary.get("monitor_due_count"))
-        and _strict_zero(summary.get("monitor_schedule_gap_count"))
         and isinstance(summary.get("monitor_open_items"), list)
-        and not summary.get("monitor_open_items")
+        and len(summary.get("monitor_open_items")) == watch_only
     ):
         return "invalid", False
     intent = summary.get("closure_intent")

--- a/loopx/control_plane/runtime/run_compaction.py
+++ b/loopx/control_plane/runtime/run_compaction.py
@@ -225,6 +225,34 @@ def compact_quota_monitor_target(run: dict[str, Any]) -> dict[str, Any] | None:
     return compact or None
 
 
+def compact_replan_ack_feedback(run: dict[str, Any]) -> dict[str, Any] | None:
+    noop = run.get("autonomous_replan_noop")
+    ack = run.get("autonomous_replan_ack")
+    delta = ack.get("delta_contract") if isinstance(ack, dict) else None
+    rejected = delta.get("rejected_claims") if isinstance(delta, dict) else None
+    if not isinstance(noop, dict) or not isinstance(rejected, list) or not rejected:
+        return None
+    claims = [
+        {
+            "kind": str(item.get("kind") or "").strip(),
+            "reason": str(item.get("reason") or "").strip(),
+        }
+        for item in rejected[:5]
+        if isinstance(item, dict)
+        and str(item.get("kind") or "").strip()
+        and str(item.get("reason") or "").strip()
+    ]
+    if not claims:
+        return None
+    return {
+        "schema_version": "replan_ack_feedback_v0",
+        "generated_at": run.get("generated_at"),
+        "agent_id": run.get("agent_id"),
+        "classification": noop.get("classification"),
+        "rejected_claims": claims,
+    }
+
+
 def compact_run_base(
     run: dict[str, Any],
     *,
@@ -269,6 +297,10 @@ def compact_run_base(
     replan_ack = compact_autonomous_replan_ack(run)
     if replan_ack:
         compact["autonomous_replan_ack"] = replan_ack
+
+    replan_feedback = compact_replan_ack_feedback(run)
+    if replan_feedback:
+        compact["replan_ack_feedback"] = replan_feedback
 
     resume_contract = compact_operator_gate_resume_contract(run.get("operator_gate_resume_contract"))
     if resume_contract:

--- a/loopx/control_plane/runtime/run_context_retention.py
+++ b/loopx/control_plane/runtime/run_context_retention.py
@@ -9,6 +9,7 @@ SEMANTIC_CONTEXT_RUN_FIELDS = (
     "latest_vision_checkpoint_run",
     "latest_outcome_vision_checkpoint_run",
     "latest_autonomous_replan_ack_run",
+    "latest_replan_ack_feedback_run",
     "latest_material_milestone_run",
 )
 SEMANTIC_CONTEXT_RUN_PAYLOAD_FIELDS = {
@@ -32,6 +33,11 @@ SEMANTIC_CONTEXT_RUN_PAYLOAD_FIELDS = {
         "generated_at",
         "agent_id",
         "autonomous_replan_ack",
+    ),
+    "latest_replan_ack_feedback_run": (
+        "generated_at",
+        "agent_id",
+        "replan_ack_feedback",
     ),
     "latest_material_milestone_run": (
         "generated_at",
@@ -146,6 +152,11 @@ def goal_semantic_history_from_runs(
             run.get("autonomous_replan_ack"), dict
         ):
             context["latest_autonomous_replan_ack_run"] = run
+
+        if "latest_replan_ack_feedback_run" not in context and isinstance(
+            run.get("replan_ack_feedback"), dict
+        ):
+            context["latest_replan_ack_feedback_run"] = run
 
         if (
             "latest_material_milestone_run" not in context

--- a/loopx/control_plane/scheduler/monitor_poll_writeback.py
+++ b/loopx/control_plane/scheduler/monitor_poll_writeback.py
@@ -269,6 +269,7 @@ def write_monitor_poll_todo_state(
         role="agent",
         reason=reason_summary,
         monitor_metadata=monitor_metadata,
+        enforce_monitor_boundedness=False,
         agent_id=agent_id,
         dry_run=not execute,
     )

--- a/loopx/control_plane/todos/contract.py
+++ b/loopx/control_plane/todos/contract.py
@@ -49,7 +49,16 @@ TODO_MONITOR_METADATA_FIELDS = (
     "consecutive_no_change",
     "material_change",
     "max_no_change_before_replan",
+    "watch_only",
 )
+
+
+def normalize_todo_watch_only(value: Any) -> bool | None:
+    if value is True or str(value or "").strip().lower() == "true":
+        return True
+    if value is False or str(value or "").strip().lower() == "false":
+        return False
+    return None
 
 TODO_TASK_CLASS_ADVANCEMENT = "advancement_task"
 TODO_TASK_CLASS_MONITOR = "continuous_monitor"
@@ -1212,6 +1221,7 @@ def format_todo_metadata_line(
     consecutive_no_change: str | None = None,
     material_change: str | None = None,
     max_no_change_before_replan: str | None = None,
+    watch_only: str | None = None,
     note: str | None = None,
     evidence: str | None = None,
     completion_turn_key: str | None = None,

--- a/loopx/control_plane/todos/line_update.py
+++ b/loopx/control_plane/todos/line_update.py
@@ -357,4 +357,5 @@ def apply_todo_update_to_lines(
         "cadence": effective_metadata.get("cadence"),
         "next_due_at": effective_metadata.get("next_due_at"),
         "expires_at": effective_metadata.get("expires_at"),
+        "watch_only": effective_metadata.get("watch_only"),
     }

--- a/loopx/control_plane/todos/list_projection.py
+++ b/loopx/control_plane/todos/list_projection.py
@@ -57,6 +57,7 @@ _ITEM_FIELDS = (
     "cadence",
     "next_due_at",
     "expires_at",
+    "watch_only",
 )
 
 

--- a/loopx/control_plane/todos/monitor_metadata.py
+++ b/loopx/control_plane/todos/monitor_metadata.py
@@ -4,7 +4,11 @@ import re
 from typing import Any
 
 from ..runtime.time import parse_timestamp
-from .contract import TODO_MONITOR_METADATA_FIELDS
+from .contract import (
+    TODO_MONITOR_METADATA_FIELDS,
+    TODO_TASK_CLASS_MONITOR,
+    normalize_todo_watch_only,
+)
 
 
 MONITOR_CADENCE_PATTERN = re.compile(
@@ -37,7 +41,32 @@ def normalize_monitor_metadata(metadata: dict[str, Any] | None) -> dict[str, str
             raise ValueError("--consecutive-no-change must be an integer") from exc
     if "material_change" in normalized and normalized["material_change"] not in {"true", "false"}:
         raise ValueError("--material-change metadata must be true or false")
+    if "watch_only" in normalized and normalize_todo_watch_only(
+        normalized["watch_only"]
+    ) is None:
+        raise ValueError("--watch-only metadata must be true or false")
     return normalized
+
+
+def require_continuous_monitor_boundedness(
+    *,
+    task_class: str | None,
+    resume_when: str | None,
+    monitor_metadata: dict[str, Any] | None,
+) -> None:
+    if task_class != TODO_TASK_CLASS_MONITOR:
+        return
+    metadata = monitor_metadata or {}
+    if (
+        str(metadata.get("expires_at") or "").strip()
+        or str(resume_when or "").strip()
+        or normalize_todo_watch_only(metadata.get("watch_only")) is True
+    ):
+        return
+    raise ValueError(
+        "continuous_monitor requires one of: --expires-at, --resume-when, "
+        "or --watch-only"
+    )
 
 
 def require_monitor_metadata_scope(

--- a/loopx/control_plane/todos/projection.py
+++ b/loopx/control_plane/todos/projection.py
@@ -23,6 +23,7 @@ from .contract import (
     normalize_removed_todo_continuation_policy,
     normalize_todo_id,
     normalize_todo_status,
+    normalize_todo_watch_only,
 )
 
 
@@ -33,6 +34,13 @@ TODO_PRIORITY_PREFIX_PATTERN = re.compile(
     re.IGNORECASE,
 )
 TODO_PRIORITY_LABEL_PATTERN = re.compile(r"\bP([0-4])\b", re.IGNORECASE)
+
+
+def todo_item_is_watch_only_monitor(item: dict[str, Any]) -> bool:
+    return bool(
+        todo_item_task_class(item) == TODO_TASK_CLASS_MONITOR
+        and normalize_todo_watch_only(item.get("watch_only")) is True
+    )
 
 
 def todo_priority_parts(text: str) -> tuple[str | None, str]:

--- a/loopx/control_plane/todos/quota_summary.py
+++ b/loopx/control_plane/todos/quota_summary.py
@@ -31,6 +31,7 @@ from .handoff_gate import build_todo_handoff_gate_lanes
 from .projection import (
     todo_item_is_actionable_open,
     todo_item_is_due_monitor,
+    todo_item_is_watch_only_monitor,
     todo_item_task_class,
     todo_projection_sort_key,
     todo_summary_monitor_schedule_gap_items,
@@ -91,6 +92,7 @@ QUOTA_PAYLOAD_ITEM_FIELDS = (
     "cadence",
     "next_due_at",
     "expires_at",
+    "watch_only",
     "last_checked_at",
     "result_hash",
     "consecutive_no_change",
@@ -227,16 +229,25 @@ def _terminal_closure_proof_is_valid(
         and displayed_items_cover_source
         and all(
             isinstance(item, dict)
-            and item.get("status") == "done"
-            and item.get("done") is True
+            and (
+                (item.get("status") == "done" and item.get("done") is True)
+                or (
+                    todo_item_is_watch_only_monitor(item)
+                )
+            )
             and item.get("route_continuation_replan_required") is not True
             for item in items
         )
-        and value.get("monitor_open_items") == []
+        and all(
+            isinstance(item, dict)
+            and todo_item_is_watch_only_monitor(item)
+            for item in (value.get("monitor_open_items") or [])
+        )
         and value.get("deferred_items") == []
         and value.get("deferred_resume_candidates") == []
-        and _strict_non_negative_int(value.get("monitor_due_count")) == 0
-        and _strict_non_negative_int(value.get("monitor_schedule_gap_count")) == 0
+        and _strict_non_negative_int(
+            value.get("convergence_open_count", value.get("open_count"))
+        ) == 0
         and _strict_non_negative_int(value.get("completed_without_successor_count", 0)) == 0
         and _strict_non_negative_int(value.get("route_continuation_replan_count", 0)) == 0
         and isinstance(proof, dict)
@@ -244,8 +255,12 @@ def _terminal_closure_proof_is_valid(
         and proof.get("role") == source_proof.get("role")
         and proof.get("source_section") == value.get("source_section")
         and proof.get("item_count") == total_count
-        and proof.get("all_todos_done") is True
-        and _strict_non_negative_int(proof.get("monitor_open_count")) == 0
+        and (
+            proof.get("all_todos_done") is True
+            or proof.get("all_convergent_todos_done") is True
+        )
+        and _strict_non_negative_int(proof.get("monitor_open_count"))
+        == _strict_non_negative_int(proof.get("watch_only_monitor_count", 0))
         and _strict_non_negative_int(proof.get("successor_gap_count")) == 0
         and _strict_non_negative_int(proof.get("route_replan_count")) == 0
         and _strict_non_negative_int(proof.get("no_followup_count")) is not None
@@ -521,6 +536,12 @@ def summarize_user_todos_for_quota(
         "backlog_items": lanes.display_open_items[:TODO_BACKLOG_ITEM_LIMIT],
         "executable_backlog_items": lanes.executable_items[:TODO_BACKLOG_ITEM_LIMIT],
     }
+    if value.get("watch_only_monitor_count"):
+        summary["watch_only_monitor_count"] = value["watch_only_monitor_count"]
+        summary["watch_only_monitor_due_count"] = value.get(
+            "watch_only_monitor_due_count", 0
+        )
+        summary["convergence_open_count"] = value.get("convergence_open_count")
     if recent_completed_advancement_items:
         summary["recent_completed_advancement_items"] = recent_completed_advancement_items
     if blocker_items:

--- a/loopx/control_plane/todos/summary_item.py
+++ b/loopx/control_plane/todos/summary_item.py
@@ -58,6 +58,7 @@ TODO_SUMMARY_COMPACT_FIELDS = (
     "cadence",
     "next_due_at",
     "expires_at",
+    "watch_only",
     "last_checked_at",
     "result_hash",
     "consecutive_no_change",

--- a/loopx/control_plane/todos/todo_summary.py
+++ b/loopx/control_plane/todos/todo_summary.py
@@ -48,6 +48,7 @@ from .projection import (
     todo_item_is_actionable_open as projection_todo_item_is_actionable_open,
     todo_item_is_deferred as projection_todo_item_is_deferred,
     todo_item_is_due_monitor as projection_todo_item_is_due_monitor,
+    todo_item_is_watch_only_monitor as projection_todo_item_is_watch_only_monitor,
     todo_item_missing_monitor_schedule as projection_todo_item_missing_monitor_schedule,
     todo_item_task_class as projection_todo_item_task_class,
     todo_item_next_due_at as projection_todo_item_next_due_at,
@@ -472,6 +473,7 @@ def compact_todo_item(item: dict[str, Any]) -> dict[str, Any]:
         "cadence",
         "next_due_at",
         "expires_at",
+        "watch_only",
         "last_checked_at",
         "result_hash",
         "consecutive_no_change",
@@ -1257,6 +1259,25 @@ def compact_todo_group(
         item.get("route_continuation_replan_required") is True
         for item in [*items, *handoff_gates]
     )
+    watch_only_monitor_items = [
+        item
+        for item in lanes.monitor_items
+        if projection_todo_item_is_watch_only_monitor(item)
+    ]
+    watch_only_ids = {
+        normalize_todo_id(item.get("todo_id"))
+        for item in watch_only_monitor_items
+    }
+    watch_only_monitor_due_items = [
+        item
+        for item in lanes.monitor_due_items
+        if normalize_todo_id(item.get("todo_id")) in watch_only_ids
+    ]
+    convergent_open_items = [
+        item
+        for item in lanes.open_items
+        if normalize_todo_id(item.get("todo_id")) not in watch_only_ids
+    ]
     summary = {
         "schema_version": "todo_summary_v0",
         "source_section": source_section,
@@ -1327,6 +1348,10 @@ def compact_todo_group(
         ][:MAX_DEFERRED_TODO_VISIBILITY_ITEMS],
         "items": lanes.budgeted_items if item_limit is None else lanes.budgeted_items[:item_limit],
     }
+    if watch_only_monitor_items:
+        summary["watch_only_monitor_count"] = len(watch_only_monitor_items)
+        summary["watch_only_monitor_due_count"] = len(watch_only_monitor_due_items)
+        summary["convergence_open_count"] = len(convergent_open_items)
     if recent_completed_advancement_items:
         summary["recent_completed_advancement_items"] = recent_completed_advancement_items
     if include_task_orchestration_authority:
@@ -1339,7 +1364,7 @@ def compact_todo_group(
         summary["blocker_items"] = [
             compact_todo_item(item) for item in lanes.blocker_items
         ]
-    if not lanes.open_items and not lanes.deferred_items:
+    if not convergent_open_items and not lanes.deferred_items:
         summary["source_proof"] = {
             "schema_version": TODO_SOURCE_PROOF_SCHEMA_VERSION,
             "role": role,
@@ -1348,8 +1373,8 @@ def compact_todo_group(
         }
     if (
         source_valid
-        and len(lanes.done_items) == len(items)
-        and not lanes.monitor_items
+        and len(lanes.done_items) + len(watch_only_monitor_items) == len(items)
+        and not convergent_open_items
         and not successor_gap_items
         and not route_replan_required
     ):
@@ -1358,13 +1383,20 @@ def compact_todo_group(
             "role": role,
             "source_section": source_section,
             "item_count": len(items),
-            "all_todos_done": True,
-            "monitor_open_count": 0,
+            "all_todos_done": not watch_only_monitor_items,
+            "monitor_open_count": len(watch_only_monitor_items),
             "successor_gap_count": 0,
             "route_replan_count": 0,
             "no_followup_count": len(no_followup_items),
             "derived": True,
         }
+        if watch_only_monitor_items:
+            summary["terminal_closure_proof"].update(
+                {
+                    "all_convergent_todos_done": True,
+                    "watch_only_monitor_count": len(watch_only_monitor_items),
+                }
+            )
     if no_followup_items:
         summary["closure_intent"] = {
             "schema_version": TODO_CLOSURE_INTENT_SCHEMA_VERSION,

--- a/loopx/control_plane/work_items/autonomous_replan_ack.py
+++ b/loopx/control_plane/work_items/autonomous_replan_ack.py
@@ -65,6 +65,33 @@ def compact_autonomous_replan_ack(run: dict[str, Any] | None) -> dict[str, Any] 
         )
     if watch_evidence:
         compact_delta["auto_evidence"] = watch_evidence
+    stall_evidence = next(
+        (
+            item
+            for item in (delta_contract.get("auto_evidence") or [])
+            if isinstance(item, dict)
+            and item.get("kind") == "blocker"
+            and str(item.get("stall_fingerprint") or "").strip()
+        ),
+        None,
+    )
+    if stall_evidence:
+        compact_delta.setdefault("auto_evidence", []).append(
+            {
+                key: stall_evidence[key]
+                for key in (
+                    "kind",
+                    "todo_ids",
+                    "stall_fingerprint",
+                    "selected_todo_id",
+                    "blocker_todo_id",
+                    "evidence_hash",
+                    "runnable_todo_ids",
+                    "direction_signatures",
+                )
+                if key in stall_evidence
+            }
+        )
     result = {
         "schema_version": ack.get("schema_version"),
         "recorded": True,

--- a/loopx/control_plane/work_items/repair_delta.py
+++ b/loopx/control_plane/work_items/repair_delta.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import json
 from collections.abc import Iterable
 from datetime import datetime
 from typing import Any, cast
@@ -22,6 +24,7 @@ from ..todos.projection import (
     todo_item_expires_at,
     todo_item_is_actionable_open,
     todo_item_is_expired_monitor,
+    todo_item_is_watch_only_monitor,
     todo_item_next_due_at,
     todo_item_task_class,
 )
@@ -41,7 +44,9 @@ REPAIR_DELTA_KIND_CHOICES = (
     "goal_boundary_projection",
     "no_followup",
     "watch_lane_continuation",
+    "exploration_exhausted",
 )
+REPAIR_DELTA_CONTRACT_SCHEMA_VERSION = "repair_delta_contract_v0"
 
 FRONTIER_REPLAN_ACK_DELTA_KINDS = frozenset(
     {
@@ -52,6 +57,7 @@ FRONTIER_REPLAN_ACK_DELTA_KINDS = frozenset(
         "runnable_todo_set",
         "successor_or_supersede",
         "watch_lane_continuation",
+        "exploration_exhausted",
     }
 )
 
@@ -67,6 +73,7 @@ ACCOUNTABLE_REPLAN_DELTA_KINDS = frozenset(
         "no_followup",
         "runnable_todo_set",
         "successor_or_supersede",
+        "exploration_exhausted",
     }
 )
 
@@ -122,6 +129,170 @@ def _todo_is_done(item: dict[str, Any]) -> bool:
     )
 
 
+def _todo_is_open_or_blocked(item: dict[str, Any]) -> bool:
+    return normalize_todo_status(item.get("status")) in {"open", "blocked"}
+
+
+def _stable_digest(value: Any) -> str:
+    normalized = " ".join(str(value or "").split()).lower()
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+
+
+def _todo_direction_signature(item: dict[str, Any]) -> str:
+    return _stable_digest(
+        json.dumps(
+            {
+                "action_kind": str(item.get("action_kind") or "").strip(),
+                "target_key": str(item.get("target_key") or "").strip(),
+                "task_domain": str(item.get("task_domain") or "").strip(),
+                "text": str(item.get("title") or item.get("text") or "").strip(),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )
+
+
+def _stall_snapshot(
+    *,
+    selected_todo_id: str | None,
+    blockers: list[dict[str, Any]],
+    runnable: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    if not blockers:
+        return None
+    normalized_selected_todo_id = normalize_todo_id(selected_todo_id)
+    causal_blockers = [
+        item
+        for item in blockers
+        if normalize_todo_id(item.get("todo_id")) == normalized_selected_todo_id
+        or normalize_todo_id(item.get("unblocks_todo_id"))
+        == normalized_selected_todo_id
+    ]
+    blocker = min(
+        causal_blockers or blockers,
+        key=lambda item: normalize_todo_id(item.get("todo_id")) or "~",
+    )
+    blocker_text = str(
+        blocker.get("reason")
+        or blocker.get("note")
+        or blocker.get("title")
+        or blocker.get("text")
+        or ""
+    ).strip()
+    evidence_hash = str(blocker.get("result_hash") or "").strip() or _stable_digest(
+        blocker.get("evidence") or blocker_text
+    )
+    fingerprint = _stable_digest(
+        json.dumps(
+            {
+                "selected_todo_id": normalized_selected_todo_id or "",
+                "blocker_todo_id": normalize_todo_id(blocker.get("todo_id")) or "",
+                "blocker_text": " ".join(blocker_text.split()).lower(),
+                "evidence_hash": evidence_hash,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )
+    return {
+        "stall_fingerprint": fingerprint,
+        "selected_todo_id": normalized_selected_todo_id,
+        "blocker_todo_id": normalize_todo_id(blocker.get("todo_id")),
+        "evidence_hash": evidence_hash,
+        "runnable_todo_ids": [
+            todo_id
+            for item in runnable
+            if (todo_id := normalize_todo_id(item.get("todo_id")))
+        ],
+        "direction_signatures": sorted(
+            {_todo_direction_signature(item) for item in runnable}
+        ),
+    }
+
+
+def _prior_stall_snapshot(
+    runs: list[dict[str, Any]] | None,
+    *,
+    agent_id: str | None,
+    fingerprint: str,
+) -> dict[str, Any] | None:
+    for run in (runs or [])[:20]:
+        if agent_id and str(run.get("agent_id") or "").strip() != agent_id:
+            continue
+        ack = run.get("autonomous_replan_ack")
+        delta = ack.get("delta_contract") if isinstance(ack, dict) else None
+        if not isinstance(delta, dict):
+            continue
+        for item in delta.get("auto_evidence") or []:
+            if not isinstance(item, dict) or item.get("kind") != "blocker":
+                continue
+            if item.get("stall_fingerprint") == fingerprint:
+                return item
+    return None
+
+
+def _stall_replan_context(
+    *,
+    scoped: list[dict[str, Any]],
+    selected_todo_id: str | None,
+    newest_first_runs: list[dict[str, Any]] | None,
+    agent_id: str | None,
+) -> tuple[
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    dict[str, Any] | None,
+    dict[str, Any] | None,
+    list[str],
+]:
+    runnable_items = [
+        item
+        for item in scoped
+        if todo_item_is_actionable_open(item)
+        and todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+    ]
+    blocker_items = [
+        item
+        for item in scoped
+        if _todo_is_open_or_blocked(item)
+        and todo_item_task_class(item) == TODO_TASK_CLASS_BLOCKER
+    ]
+    stall_snapshot = _stall_snapshot(
+        selected_todo_id=selected_todo_id,
+        blockers=blocker_items,
+        runnable=runnable_items,
+    )
+    prior_stall = (
+        _prior_stall_snapshot(
+            newest_first_runs,
+            agent_id=agent_id,
+            fingerprint=str(stall_snapshot.get("stall_fingerprint") or ""),
+        )
+        if stall_snapshot
+        else None
+    )
+    if not prior_stall:
+        return runnable_items, blocker_items, stall_snapshot, None, []
+    previous_ids = {str(item) for item in prior_stall.get("runnable_todo_ids") or []}
+    previous_signatures = {
+        str(item) for item in prior_stall.get("direction_signatures") or []
+    }
+    new_direction_ids = [
+        todo_id
+        for item in runnable_items
+        if (todo_id := normalize_todo_id(item.get("todo_id")))
+        and todo_id not in previous_ids
+        and _todo_direction_signature(item) not in previous_signatures
+    ]
+    return (
+        runnable_items,
+        blocker_items,
+        stall_snapshot,
+        prior_stall,
+        new_direction_ids,
+    )
+
+
 def _bounded_watch_todo_ids(
     items: list[dict[str, Any]],
     *,
@@ -130,7 +301,8 @@ def _bounded_watch_todo_ids(
     todo_ids: list[str] = []
     for item in items:
         if not (
-            todo_item_is_actionable_open(item)
+            normalize_todo_status(item.get("status")) == "open"
+            and not _todo_is_done(item)
             and todo_item_task_class(item) == TODO_TASK_CLASS_MONITOR
             and str(item.get("target_key") or "").strip()
             and monitor_cadence_delta(item.get("cadence")) is not None
@@ -150,6 +322,8 @@ def _bounded_watch_todo_ids(
             continue
         resume_when = normalize_todo_resume_when(item.get("resume_when"))
         if resume_when and item.get("resume_ready") is True:
+            continue
+        if todo_item_is_watch_only_monitor(item):
             continue
         if expires_at is None and not resume_when:
             continue
@@ -271,6 +445,8 @@ def validate_repair_delta_claims(
     next_action_changed: bool,
     vision_patch_written: bool,
     observed_at: datetime | None = None,
+    selected_todo_id: str | None = None,
+    newest_first_runs: list[dict[str, Any]] | None = None,
 ) -> tuple[list[str], list[dict[str, Any]], list[dict[str, str]]]:
     projected_items: Any = (
         agent_todo_summary.get("items")
@@ -301,10 +477,22 @@ def validate_repair_delta_claims(
     blocker_ids = [
         todo_id
         for item in scoped
-        if todo_item_is_actionable_open(item)
+        if _todo_is_open_or_blocked(item)
         and todo_item_task_class(item) == TODO_TASK_CLASS_BLOCKER
         and (todo_id := normalize_todo_id(item.get("todo_id")))
     ]
+    (
+        runnable_items,
+        blocker_items,
+        stall_snapshot,
+        prior_stall,
+        new_direction_ids,
+    ) = _stall_replan_context(
+        scoped=scoped,
+        selected_todo_id=selected_todo_id,
+        newest_first_runs=newest_first_runs,
+        agent_id=normalized_agent_id,
+    )
     bounded_watch_ids = _bounded_watch_todo_ids(
         scoped,
         observed_at=observed_at or now_utc(),
@@ -328,11 +516,37 @@ def validate_repair_delta_claims(
             accepted.append(kind)
             continue
         if kind == "runnable_todo_set":
-            todo_ids = runnable_ids
-            reason = "no scoped open advancement todo exists"
+            todo_ids = new_direction_ids if prior_stall else runnable_ids
+            reason = (
+                "repeated stall requires a new runnable todo with a different direction"
+                if prior_stall
+                else "no scoped open advancement todo exists"
+            )
         elif kind == "blocker":
-            todo_ids = blocker_ids
-            reason = "no scoped open blocker todo exists"
+            todo_ids = [] if prior_stall else blocker_ids
+            reason = (
+                "repeated stall fingerprint cannot close replan; create a new "
+                "runnable direction or record exploration_exhausted with coverage evidence"
+                if prior_stall
+                else "no scoped open blocker todo exists"
+            )
+        elif kind == "exploration_exhausted":
+            exhausted = [
+                item
+                for item in blocker_items
+                if str(item.get("action_kind") or "").strip()
+                == "exploration_exhausted"
+                and str(item.get("evidence") or "").strip()
+            ]
+            todo_ids = [
+                todo_id
+                for item in exhausted
+                if (todo_id := normalize_todo_id(item.get("todo_id")))
+            ]
+            reason = (
+                "exploration_exhausted requires a scoped blocker todo with "
+                "action_kind=exploration_exhausted and coverage evidence"
+            )
         elif kind == "watch_lane_continuation":
             todo_ids = bounded_watch_ids
             reason = (
@@ -340,14 +554,24 @@ def validate_repair_delta_claims(
                 if advancement_policy == "repeat_until_closed"
                 else (
                     "no scoped monitor has a valid target, cadence, next due, "
-                    "and unexpired expiry or unresolved resume condition"
+                    "and unexpired expiry or unresolved resume condition; "
+                    "watch_only monitors are liveness-only and cannot close replan"
                 )
             )
             if advancement_policy == "repeat_until_closed":
                 todo_ids = []
         elif kind == "successor_or_supersede":
-            todo_ids = successor_transition_ids
-            reason = "no completed todo links a scoped open advancement successor"
+            todo_ids = (
+                successor_transition_ids
+                if not prior_stall
+                or any(todo_id in new_direction_ids for todo_id in successor_transition_ids)
+                else []
+            )
+            reason = (
+                "repeated stall requires a newly linked successor with a different direction"
+                if prior_stall
+                else "no completed todo links a scoped open advancement successor"
+            )
         elif kind == "no_followup":
             todo_ids = no_followup_ids
             reason = (
@@ -378,6 +602,92 @@ def validate_repair_delta_claims(
                     "todo_ids": todo_ids,
                 }
             )
+            if kind == "blocker" and stall_snapshot:
+                evidence[-1].update(stall_snapshot)
+            if kind == "runnable_todo_set" and prior_stall:
+                evidence[-1]["resolves_stall_fingerprint"] = prior_stall.get(
+                    "stall_fingerprint"
+                )
         else:
             rejected.append({"kind": kind, "reason": reason})
     return accepted, evidence, rejected
+
+
+def build_repair_delta_contract(
+    *,
+    requested_delta_kinds: list[str],
+    active_state_next_action_update: dict[str, Any] | None,
+    agent_vision: dict[str, Any] | None,
+    existing_agent_vision: dict[str, Any] | None,
+    agent_todo_summary: dict[str, Any] | None,
+    agent_id: str | None,
+    dry_run: bool,
+    selected_todo_id: str | None = None,
+    newest_first_runs: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build the machine-validated replan delta at the work-item boundary."""
+
+    update = active_state_next_action_update or {}
+    effective_vision = agent_vision or existing_agent_vision or {}
+    vision_patch = (
+        effective_vision.get("vision_patch")
+        if isinstance(effective_vision.get("vision_patch"), dict)
+        else {}
+    )
+    delta_kinds, evidence, rejected_claims = validate_repair_delta_claims(
+        requested_delta_kinds,
+        agent_todo_summary=agent_todo_summary,
+        agent_id=agent_id,
+        advancement_policy=str(vision_patch.get("advancement_policy") or "").strip(),
+        next_action_changed=bool(update.get("would_update")),
+        vision_patch_written=agent_vision is not None,
+        selected_todo_id=selected_todo_id,
+        newest_first_runs=newest_first_runs,
+    )
+    if update.get("updated") is True:
+        if "active_state_next_action" not in delta_kinds:
+            delta_kinds.append("active_state_next_action")
+        evidence.append(
+            {
+                "kind": "active_state_next_action",
+                "source": "refresh_state_next_action_update",
+                "updated": True,
+            }
+        )
+    elif update.get("would_update") is True:
+        evidence.append(
+            {
+                "kind": "active_state_next_action",
+                "source": "refresh_state_next_action_update",
+                "would_update": True,
+                "dry_run": bool(dry_run),
+            }
+        )
+    if agent_vision:
+        if "goal_vision_patch" not in delta_kinds:
+            delta_kinds.append("goal_vision_patch")
+        evidence.append(
+            {
+                "kind": "goal_vision_patch",
+                "source": "refresh_state_agent_vision",
+                "state": agent_vision.get("state"),
+                "agent_id": agent_vision.get("agent_id"),
+                "budget_status": (
+                    agent_vision.get("vision_budget", {}).get("status")
+                    if isinstance(agent_vision.get("vision_budget"), dict)
+                    else None
+                ),
+            }
+        )
+
+    contract = {
+        "schema_version": REPAIR_DELTA_CONTRACT_SCHEMA_VERSION,
+        "required": True,
+        "delta_present": repair_delta_kinds_have_frontier_delta(delta_kinds),
+        "delta_kinds": delta_kinds,
+        "auto_evidence": evidence,
+        "accepted_without_delta": False,
+    }
+    if rejected_claims:
+        contract["rejected_claims"] = rejected_claims
+    return contract

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -26,11 +26,11 @@ from .control_plane.quota.settlement import (
     settlement_result_payload,
 )
 from .control_plane.work_items.repair_delta import (
+    REPAIR_DELTA_CONTRACT_SCHEMA_VERSION as REPAIR_DELTA_CONTRACT_SCHEMA_VERSION,
     REPAIR_DELTA_KIND_CHOICES as REPAIR_DELTA_KIND_CHOICES,
+    build_repair_delta_contract,
     normalize_repair_delta_kinds,
     repair_delta_kinds_have_accountable_progress,
-    repair_delta_kinds_have_frontier_delta,
-    validate_repair_delta_claims,
 )
 from .control_plane.work_items.autonomous_replan_ack import (
     latest_monitor_replan_frontier_identity,
@@ -60,7 +60,6 @@ from .control_plane.goals.goal_frontier import latest_agent_vision_from_runs
 from .registry import registry_goals, resolve_state_file
 from .runtime import validate_goal_id_path_segment
 from .state_projection import state_projection_gap_warning
-from .control_plane.todos.active_state_todo_parser import parse_active_state_todos
 from .control_plane.todos.contract import (
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_BLOCKER,
@@ -68,6 +67,7 @@ from .control_plane.todos.contract import (
     TODO_TASK_CLASS_USER_GATE,
     normalize_todo_claimed_by,
 )
+from .control_plane.todos.active_state_todo_parser import parse_active_state_todos
 
 DEFAULT_REFRESH_CLASSIFICATION = "state_refreshed"
 DEFAULT_REFRESH_ACTION = "inspect refreshed active goal state and continue the next bounded progress segment"
@@ -82,7 +82,6 @@ RECOMMENDED_ACTION_SECTION_LINE_LIMIT = 16
 BULLET_PREFIX_RE = re.compile(r"^(?:[-*]\s+|\d+[.)]\s+)")
 CHECKBOX_PREFIX_RE = re.compile(r"^\[(?P<mark>[ xX])\]\s+")
 ACTIVE_STATE_NEXT_ACTION_UPDATE_SCHEMA_VERSION = "active_state_next_action_update_v0"
-REPAIR_DELTA_CONTRACT_SCHEMA_VERSION = "repair_delta_contract_v0"
 REPAIR_NOOP_SCHEMA_VERSION = "repair_noop_v0"
 VISION_CHECKPOINT_SCHEMA_VERSION = "vision_checkpoint_v0"
 VISION_CHECKPOINT_MATERIAL_OUTCOMES = {
@@ -196,85 +195,6 @@ def _noop_classification_for(classification: str) -> str:
     if "repair" in normalized and "replan" not in normalized:
         return "repair_noop"
     return "replan_noop"
-
-
-def build_repair_delta_contract(
-    *,
-    requested_delta_kinds: list[str],
-    active_state_next_action_update: dict[str, Any] | None,
-    agent_vision: dict[str, Any] | None,
-    existing_agent_vision: dict[str, Any] | None,
-    state_text: str,
-    agent_id: str | None,
-    dry_run: bool,
-) -> dict[str, Any]:
-    update = active_state_next_action_update or {}
-    todo_fields = parse_active_state_todos(state_text, item_limit=None)
-    effective_vision = agent_vision or existing_agent_vision or {}
-    vision_patch = (
-        effective_vision.get("vision_patch")
-        if isinstance(effective_vision.get("vision_patch"), dict)
-        else {}
-    )
-    delta_kinds, evidence, rejected_claims = validate_repair_delta_claims(
-        requested_delta_kinds,
-        agent_todo_summary=(
-            todo_fields.get("agent_todos")
-            if isinstance(todo_fields.get("agent_todos"), dict)
-            else None
-        ),
-        agent_id=agent_id,
-        advancement_policy=str(vision_patch.get("advancement_policy") or "").strip(),
-        next_action_changed=bool(update.get("would_update")),
-        vision_patch_written=agent_vision is not None,
-    )
-    if update.get("updated") is True:
-        if "active_state_next_action" not in delta_kinds:
-            delta_kinds.append("active_state_next_action")
-        evidence.append(
-            {
-                "kind": "active_state_next_action",
-                "source": "refresh_state_next_action_update",
-                "updated": True,
-            }
-        )
-    elif update.get("would_update") is True:
-        evidence.append(
-            {
-                "kind": "active_state_next_action",
-                "source": "refresh_state_next_action_update",
-                "would_update": True,
-                "dry_run": bool(dry_run),
-            }
-        )
-    if agent_vision:
-        if "goal_vision_patch" not in delta_kinds:
-            delta_kinds.append("goal_vision_patch")
-        evidence.append(
-            {
-                "kind": "goal_vision_patch",
-                "source": "refresh_state_agent_vision",
-                "state": agent_vision.get("state"),
-                "agent_id": agent_vision.get("agent_id"),
-                "budget_status": (
-                    agent_vision.get("vision_budget", {}).get("status")
-                    if isinstance(agent_vision.get("vision_budget"), dict)
-                    else None
-                ),
-            }
-        )
-
-    contract = {
-        "schema_version": REPAIR_DELTA_CONTRACT_SCHEMA_VERSION,
-        "required": True,
-        "delta_present": repair_delta_kinds_have_frontier_delta(delta_kinds),
-        "delta_kinds": delta_kinds,
-        "auto_evidence": evidence,
-        "accepted_without_delta": False,
-    }
-    if rejected_claims:
-        contract["rejected_claims"] = rejected_claims
-    return contract
 
 
 def build_vision_checkpoint(
@@ -1216,9 +1136,15 @@ def refresh_state_run(
             active_state_next_action_update=active_state_next_action_update,
             agent_vision=agent_vision,
             existing_agent_vision=existing_agent_vision,
-            state_text=state_text,
+            agent_todo_summary=parse_active_state_todos(
+                state_text, item_limit=None
+            ).get("agent_todos"),
             agent_id=normalized_agent_id or None,
             dry_run=dry_run,
+            selected_todo_id=(
+                settlement_identity.todo_id if settlement_identity else None
+            ),
+            newest_first_runs=newest_first_runs,
         )
         validated_repair_delta_kinds = list(
             repair_delta_contract.get("delta_kinds") or []

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -21,7 +21,6 @@ from .control_plane.todos.contract import (
     TODO_STATUS_DEFERRED,
     TODO_STATUS_DONE,
     TODO_STATUS_OPEN,
-    TODO_TASK_CLASS_MONITOR,
     TODO_TASK_CLASS_USER_GATE,
     build_todo_id,
     format_todo_metadata_line,
@@ -86,7 +85,7 @@ from .control_plane.todos.list_projection import (
     compact_todo_projection_overlay,
     todo_list_projection_contract,
 )
-from .control_plane.todos.monitor_metadata import require_monitor_metadata_scope
+from .control_plane.todos import monitor_metadata as todo_monitor_metadata
 from .control_plane.todos.mutation_authority import authorize_todo_lifecycle_mutation, todo_update_authority_action
 from .control_plane.todos.todo_summary import compact_todo_group, normalize_todo_text
 from .control_plane.todos.succession_warning import build_open_parent_successor_advisory
@@ -647,7 +646,7 @@ def add_todo_to_lines(
     if status and not normalized_status:
         raise ValueError("todo status must be one of: open, done, blocked, deferred")
     normalized_resume_when = require_supported_todo_resume_when(resume_when)
-    normalized_monitor_metadata = require_monitor_metadata_scope(
+    normalized_monitor_metadata = todo_monitor_metadata.require_monitor_metadata_scope(
         monitor_metadata=monitor_metadata,
         role=role,
         task_class=task_class,
@@ -844,6 +843,7 @@ def add_todo_to_lines(
         "cadence": effective_metadata.get("cadence"),
         "next_due_at": effective_metadata.get("next_due_at"),
         "expires_at": effective_metadata.get("expires_at"),
+        "watch_only": effective_metadata.get("watch_only"),
         "evidence": effective_metadata.get("evidence") or evidence,
         "updated_at": effective_metadata.get("updated_at") or updated_at,
     }
@@ -1015,17 +1015,17 @@ def add_goal_todo(
         if unblocks_todo_id and not normalized_unblocks_todo_id:
             raise ValueError("unblocks_todo_id must use the public token shape todo_<letters-digits-underscore-hyphen>")
         normalized_resume_when = require_supported_todo_resume_when(resume_when)
-        if task_class == TODO_TASK_CLASS_MONITOR and normalized_resume_when:
-            raise ValueError(
-                "continuous_monitor todos cannot use resume_when; use target_key, "
-                "cadence, and next_due_at so the monitor can observe the transition"
-            )
         if normalized_status == TODO_STATUS_DEFERRED and not normalized_resume_when:
             raise ValueError("deferred todo add requires --resume-when with a supported condition")
-        normalized_monitor_metadata = require_monitor_metadata_scope(
+        normalized_monitor_metadata = todo_monitor_metadata.require_monitor_metadata_scope(
             monitor_metadata=monitor_metadata,
             role=role,
             task_class=task_class,
+        )
+        todo_monitor_metadata.require_continuous_monitor_boundedness(
+            task_class=task_class,
+            resume_when=normalized_resume_when,
+            monitor_metadata=normalized_monitor_metadata,
         )
         add_result = add_todo_to_lines(
             lines,
@@ -1104,6 +1104,7 @@ def add_goal_todo(
         "cadence": add_result.get("cadence"),
         "next_due_at": add_result.get("next_due_at"),
         "expires_at": add_result.get("expires_at"),
+        "watch_only": add_result.get("watch_only"),
         "state_file": str(resolved_state_file),
         "project": str(resolved_project) if resolved_project else None,
         "updated_at": updated_at if changed else None,
@@ -1170,6 +1171,7 @@ def update_goal_todo(
     clear_resume_when: bool = False,
     no_followup: bool | None = None,
     monitor_metadata: dict[str, Any] | None = None,
+    enforce_monitor_boundedness: bool = True,
     clear_claim: bool = False,
     claim_only: bool = False,
     project: Path | None = None,
@@ -1399,26 +1401,28 @@ def update_goal_todo(
             else normalized_resume_when
             or normalize_supported_todo_resume_when(existing_block.get("resume_when"))
         )
-        if target_task_class == TODO_TASK_CLASS_MONITOR and normalized_resume_when:
-            raise ValueError(
-                "continuous_monitor todos cannot use resume_when; use target_key, "
-                "cadence, and next_due_at so the monitor can observe the transition"
-            )
-        if (
-            task_class == TODO_TASK_CLASS_MONITOR
-            and effective_resume_when
-            and not clear_resume_when
-        ):
-            raise ValueError(
-                "moving a todo to continuous_monitor requires --clear-resume-when"
-            )
         if target_status == TODO_STATUS_DEFERRED and not effective_resume_when:
             raise ValueError("transition to deferred requires --resume-when with a supported condition")
-        normalized_monitor_metadata = require_monitor_metadata_scope(
+        normalized_monitor_metadata = todo_monitor_metadata.require_monitor_metadata_scope(
             monitor_metadata=monitor_metadata,
             role=target_role,
             task_class=target_task_class,
         )
+        effective_monitor_metadata = {
+            key: existing_block.get(key)
+            for key in (
+                "expires_at",
+                "watch_only",
+            )
+            if existing_block.get(key) is not None
+        }
+        effective_monitor_metadata.update(normalized_monitor_metadata)
+        if enforce_monitor_boundedness:
+            todo_monitor_metadata.require_continuous_monitor_boundedness(
+                task_class=target_task_class,
+                resume_when=effective_resume_when,
+                monitor_metadata=effective_monitor_metadata,
+            )
         update_result = apply_todo_update_to_lines(
             lines,
             todo_id=todo_id,

--- a/tests/control_plane/test_goal_terminal_no_followup.py
+++ b/tests/control_plane/test_goal_terminal_no_followup.py
@@ -197,6 +197,25 @@ def test_agent_only_no_followup_closes_explicit_empty_user_source() -> None:
     assert goal_frontier_is_terminal_no_followup(projection=projection) is True
 
 
+def test_watch_only_monitor_does_not_block_terminal_convergence() -> None:
+    state_text = """\
+## User Todo / Owner Review Reading Queue
+
+## Agent Todo
+
+- [x] [P0] Complete the bounded delivery.
+  <!-- loopx:todo todo_id=todo_delivery status=done task_class=advancement_task no_followup=true evidence=validated -->
+- [ ] [P2] Observe public release liveness.
+  <!-- loopx:todo todo_id=todo_liveness status=open task_class=continuous_monitor action_kind=monitor target_key=release cadence=1h next_due_at=2026-08-12T00%3A00%3A00Z watch_only=true -->
+"""
+
+    projection = _terminal_projection(state_text)
+
+    assert projection["normalized_progress"]["agent_open_count"] == 0
+    assert projection["normalized_progress"]["agent_monitor_open_count"] == 0
+    assert goal_frontier_is_terminal_no_followup(projection=projection) is True
+
+
 def test_agent_only_no_followup_fails_closed_when_user_source_is_missing() -> None:
     state_text = """\
 ## Agent Todo

--- a/tests/control_plane/test_monitor_followthrough_contract.py
+++ b/tests/control_plane/test_monitor_followthrough_contract.py
@@ -6,6 +6,7 @@ import pytest
 
 from loopx.control_plane.scheduler.monitor_poll_writeback import (
     resolve_monitor_todo_item,
+    write_monitor_poll_todo_state,
 )
 from loopx.control_plane.scheduler.monitor_todo import (
     monitor_todo_is_actionable_open,
@@ -66,6 +67,7 @@ def _add_monitor(
             "target_key": target_key,
             "cadence": "1h",
             "next_due_at": next_due_at,
+            "watch_only": "true",
         },
     )
 
@@ -92,36 +94,36 @@ def test_exact_todo_id_precedes_ambiguous_target_key(tmp_path: Path) -> None:
     assert first["todo_id"] != second["todo_id"]
 
 
-def test_monitor_resume_when_is_rejected_without_legacy_bypass(
+def test_monitor_resume_when_is_a_supported_bounded_policy(
     tmp_path: Path,
 ) -> None:
     registry, _runtime, _state = _write_fixture(tmp_path)
 
-    with pytest.raises(ValueError, match="continuous_monitor todos cannot use resume_when"):
-        add_goal_todo(
-            registry_path=registry,
-            goal_id=GOAL_ID,
-            role="agent",
-            text="Poll a merge target.",
-            task_class="continuous_monitor",
-            claimed_by=AGENT_ID,
-            resume_when="pr_merged:owner/repo#42",
-            monitor_metadata={"target_key": "public-pr:42", "cadence": "1h"},
-        )
+    bounded = add_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="agent",
+        text="Poll a merge target.",
+        task_class="continuous_monitor",
+        claimed_by=AGENT_ID,
+        resume_when="pr_merged:owner/repo#42",
+        monitor_metadata={"target_key": "public-pr:42", "cadence": "1h"},
+    )
+    assert bounded["resume_when"] == "pr_merged:owner/repo#42"
 
     monitor = _add_monitor(
         registry,
         text="Poll a legacy merge target.",
         target_key="legacy-pr:42",
     )
-    with pytest.raises(ValueError, match="continuous_monitor todos cannot use resume_when"):
-        update_goal_todo(
-            registry_path=registry,
-            goal_id=GOAL_ID,
-            todo_id=monitor["todo_id"],
-            agent_id=AGENT_ID,
-            resume_when="pr_merged:owner/repo#42",
-        )
+    updated = update_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=monitor["todo_id"],
+        agent_id=AGENT_ID,
+        resume_when="pr_merged:owner/repo#42",
+    )
+    assert updated["resume_when"] == "pr_merged:owner/repo#42"
 
     assert monitor_todo_is_actionable_open(
         {
@@ -131,6 +133,31 @@ def test_monitor_resume_when_is_rejected_without_legacy_bypass(
             "resume_ready": False,
         }
     ) is False
+
+
+def test_runtime_writeback_can_read_legacy_unbounded_monitor(tmp_path: Path) -> None:
+    registry, _runtime, state = _write_fixture(tmp_path)
+    state.write_text(
+        state.read_text(encoding="utf-8")
+        + "\n- [ ] [P2] Legacy public monitor.\n"
+        + "  <!-- loopx:todo todo_id=todo_legacy_monitor status=open "
+        + "task_class=continuous_monitor claimed_by=codex-quality-qualification "
+        + "target_key=legacy-public cadence=1h -->\n",
+        encoding="utf-8",
+    )
+
+    result = write_monitor_poll_todo_state(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        generated_at="2026-08-11T00:00:00Z",
+        execute=False,
+        todo_id="todo_legacy_monitor",
+        result_hash="unchanged",
+        agent_id=AGENT_ID,
+    )
+
+    assert result is not None
+    assert result["todo_update"]["changed"] is True
 
 
 def test_material_poll_reloads_status_and_projects_declared_successor(

--- a/tests/control_plane/test_monitor_replan_agent_scope.py
+++ b/tests/control_plane/test_monitor_replan_agent_scope.py
@@ -151,6 +151,106 @@ def test_peer_advancement_does_not_suppress_current_monitor_streak_replan() -> N
     }
 
 
+def test_watch_only_monitor_streak_does_not_create_replan_obligation() -> None:
+    monitor = quota_todo_item(
+        todo_id="todo_watch_only_monitor",
+        index=1,
+        title="Observe public release liveness.",
+        task_class="continuous_monitor",
+        claimed_by=AGENT_ID,
+        target_key="github-pr-123",
+        consecutive_no_change="50",
+        cadence="30m",
+        next_due_at="2099-01-01T00:00:00+00:00",
+        watch_only="true",
+    )
+    payload = quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        recommended_action="Observe liveness quietly.",
+        agent_todos=quota_todo_summary([monitor]),
+        coordination={
+            "agent_model": "peer_v1",
+            "registered_agents": [AGENT_ID],
+        },
+    )
+
+    guard = build_quota_should_run(
+        payload,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        scheduler_execution_context=(
+            GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT
+        ),
+    )
+
+    assert guard["decision"] != "autonomous_replan_required"
+    assert guard.get("autonomous_replan_obligation") is None
+    assert guard["goal_frontier_projection"]["monitor_only_lanes"]["present"] is False
+
+
+def test_rejected_replan_ack_reason_is_visible_in_quota_feedback() -> None:
+    monitor = quota_todo_item(
+        todo_id="todo_stalled_monitor",
+        index=1,
+        title="Watch bounded qualification evidence.",
+        task_class="continuous_monitor",
+        claimed_by=AGENT_ID,
+        target_key="qualification",
+        consecutive_no_change="5",
+        cadence="30m",
+        next_due_at="2099-01-01T00:00:00+00:00",
+        expires_at="2099-01-02T00:00:00+00:00",
+    )
+    payload = quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        recommended_action="Replan the stalled qualification lane.",
+        agent_todos=quota_todo_summary([monitor]),
+        coordination={
+            "agent_model": "peer_v1",
+            "registered_agents": [AGENT_ID],
+        },
+        latest_runs=[
+            {
+                "generated_at": "2026-08-11T00:00:00Z",
+                "agent_id": AGENT_ID,
+                "classification": "replan_noop",
+                "replan_ack_feedback": {
+                    "schema_version": "replan_ack_feedback_v0",
+                    "generated_at": "2026-08-11T00:00:00Z",
+                    "agent_id": AGENT_ID,
+                    "classification": "replan_noop",
+                    "rejected_claims": [
+                        {
+                            "kind": "watch_lane_continuation",
+                            "reason": "monitor is missing expires_at or resume_when",
+                        }
+                    ],
+                },
+            }
+        ],
+    )
+
+    guard = build_quota_should_run(
+        payload,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        scheduler_execution_context=(
+            GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT
+        ),
+    )
+
+    obligation = guard["autonomous_replan_obligation"]
+    assert obligation["replan_ack_feedback"]["rejected_claims"][0]["kind"] == (
+        "watch_lane_continuation"
+    )
+    assert "previous replan ACK was rejected" in obligation["recommended_action"]
+    assert guard["heartbeat_recommendation"]["replan_obligation"][
+        "replan_ack_feedback"
+    ] == obligation["replan_ack_feedback"]
+
+
 def test_current_agent_advancement_still_preempts_monitor_streak_replan() -> None:
     guard = _guard(current_agent_advancement=True)
 

--- a/tests/control_plane/test_repair_delta_claims.py
+++ b/tests/control_plane/test_repair_delta_claims.py
@@ -16,6 +16,8 @@ def _validate(
     items: tuple[dict, ...],
     advancement_policy: str = "as_needed",
     summary: dict | None = None,
+    selected_todo_id: str | None = None,
+    newest_first_runs: list[dict] | None = None,
 ) -> tuple[list[str], list[dict], list[dict]]:
     return validate_repair_delta_claims(
         [kind],
@@ -25,7 +27,23 @@ def _validate(
         next_action_changed=False,
         vision_patch_written=False,
         observed_at=datetime(2026, 8, 1, tzinfo=timezone.utc),
+        selected_todo_id=selected_todo_id,
+        newest_first_runs=newest_first_runs,
     )
+
+
+def _blocker_ack(evidence: dict) -> dict:
+    return {
+        "agent_id": "quality-agent",
+        "autonomous_replan_ack": {
+            "recorded": True,
+            "delta_contract": {
+                "delta_present": True,
+                "delta_kinds": ["blocker"],
+                "auto_evidence": [evidence],
+            },
+        },
+    }
 
 
 def test_watch_only_replan_delta_is_not_accountable_progress() -> None:
@@ -135,7 +153,29 @@ def test_watch_claim_requires_bounded_schedule() -> None:
 
     assert accepted == []
     assert evidence == []
-    assert "expiry or unresolved resume condition" in rejected[0]["reason"]
+    assert "watch_only monitors are liveness-only" in rejected[0]["reason"]
+
+
+def test_watch_only_monitor_cannot_ack_replan() -> None:
+    accepted, evidence, rejected = _validate(
+        "watch_lane_continuation",
+        items=(
+            {
+                "todo_id": "todo_watch_only123",
+                "status": "open",
+                "task_class": "continuous_monitor",
+                "claimed_by": "quality-agent",
+                "target_key": "review",
+                "cadence": "30m",
+                "next_due_at": "2026-08-01T13:00:00Z",
+                "watch_only": "true",
+            },
+        ),
+    )
+
+    assert accepted == []
+    assert evidence == []
+    assert "liveness-only" in rejected[0]["reason"]
 
 
 def test_watch_claim_requires_non_repeating_vision_and_records_evidence() -> None:
@@ -224,6 +264,29 @@ def test_watch_claim_rejects_satisfied_resume_condition() -> None:
     assert rejected
 
 
+def test_watch_claim_accepts_unresolved_resume_condition() -> None:
+    accepted, evidence, rejected = _validate(
+        "watch_lane_continuation",
+        items=(
+            {
+                "todo_id": "todo_resume_bound123",
+                "status": "open",
+                "task_class": "continuous_monitor",
+                "claimed_by": "quality-agent",
+                "target_key": "review",
+                "cadence": "30m",
+                "next_due_at": "2026-08-01T13:00:00Z",
+                "resume_when": "todo_done:todo_dependency123",
+                "resume_ready": False,
+            },
+        ),
+    )
+
+    assert accepted == ["watch_lane_continuation"]
+    assert evidence[0]["todo_ids"] == ["todo_resume_bound123"]
+    assert rejected == []
+
+
 def test_successor_claim_requires_real_scoped_transition() -> None:
     source = {
         "todo_id": "todo_source123456",
@@ -256,6 +319,139 @@ def test_successor_claim_requires_real_scoped_transition() -> None:
 
     assert accepted == ["successor_or_supersede"]
     assert evidence[0]["todo_ids"] == [source["todo_id"], successor["todo_id"]]
+    assert rejected == []
+
+
+def test_repeated_blocker_fingerprint_is_rejected() -> None:
+    blocker = {
+        "todo_id": "todo_blocker1234",
+        "status": "open",
+        "task_class": "blocker",
+        "claimed_by": "quality-agent",
+        "reason": "same dependency is still unavailable",
+        "evidence": "probe-result-v1",
+    }
+    accepted, evidence, rejected = _validate(
+        "blocker",
+        items=(blocker,),
+        selected_todo_id="todo_selected123",
+    )
+    assert accepted == ["blocker"]
+    assert rejected == []
+    assert evidence[0]["stall_fingerprint"]
+
+    accepted, _, rejected = _validate(
+        "blocker",
+        items=(blocker,),
+        selected_todo_id="todo_selected123",
+        newest_first_runs=[_blocker_ack(evidence[0])],
+    )
+    assert accepted == []
+    assert "repeated stall fingerprint" in rejected[0]["reason"]
+
+
+def test_stall_fingerprint_prefers_the_selected_todo_causal_blocker() -> None:
+    unrelated = {
+        "todo_id": "todo_aaa_unrelated",
+        "status": "blocked",
+        "task_class": "blocker",
+        "claimed_by": "quality-agent",
+        "reason": "unrelated dependency remains unavailable",
+        "evidence": "unrelated-probe",
+    }
+    selected = {
+        "todo_id": "todo_selected123",
+        "status": "blocked",
+        "task_class": "blocker",
+        "claimed_by": "quality-agent",
+        "reason": "selected dependency remains unavailable",
+        "evidence": "selected-probe",
+    }
+    accepted, evidence, rejected = _validate(
+        "blocker",
+        items=(unrelated, selected),
+        selected_todo_id=selected["todo_id"],
+    )
+
+    assert accepted == ["blocker"]
+    assert rejected == []
+    assert evidence[0]["blocker_todo_id"] == selected["todo_id"]
+
+
+def test_repeated_stall_requires_a_new_runnable_direction() -> None:
+    blocker = {
+        "todo_id": "todo_blocker1234",
+        "status": "open",
+        "task_class": "blocker",
+        "claimed_by": "quality-agent",
+        "reason": "same dependency is still unavailable",
+        "evidence": "probe-result-v1",
+    }
+    old_direction = {
+        "todo_id": "todo_old_direction",
+        "status": "open",
+        "task_class": "advancement_task",
+        "claimed_by": "quality-agent",
+        "action_kind": "probe",
+        "text": "Retry the same dependency probe.",
+    }
+    _, evidence, _ = _validate(
+        "blocker",
+        items=(blocker, old_direction),
+        selected_todo_id="todo_selected123",
+    )
+    previous = _blocker_ack(evidence[0])
+
+    accepted, _, rejected = _validate(
+        "runnable_todo_set",
+        items=(blocker, old_direction),
+        selected_todo_id="todo_selected123",
+        newest_first_runs=[previous],
+    )
+    assert accepted == []
+    assert "different direction" in rejected[0]["reason"]
+
+    new_direction = {
+        "todo_id": "todo_new_direction",
+        "status": "open",
+        "task_class": "advancement_task",
+        "claimed_by": "quality-agent",
+        "action_kind": "local_fallback",
+        "text": "Validate a local fallback path.",
+    }
+    accepted, evidence, rejected = _validate(
+        "runnable_todo_set",
+        items=(blocker, old_direction, new_direction),
+        selected_todo_id="todo_selected123",
+        newest_first_runs=[previous],
+    )
+    assert accepted == ["runnable_todo_set"]
+    assert evidence[0]["todo_ids"] == ["todo_new_direction"]
+    assert rejected == []
+
+
+def test_exploration_exhausted_requires_coverage_evidence() -> None:
+    blocker = {
+        "todo_id": "todo_exhausted123",
+        "status": "open",
+        "task_class": "blocker",
+        "claimed_by": "quality-agent",
+        "action_kind": "exploration_exhausted",
+        "reason": "all public fallback routes exhausted",
+    }
+    accepted, _, rejected = _validate(
+        "exploration_exhausted",
+        items=(blocker,),
+    )
+    assert accepted == []
+    assert "coverage evidence" in rejected[0]["reason"]
+
+    blocker["evidence"] = "coverage: routes-a-b-c"
+    accepted, _, rejected = _validate(
+        "exploration_exhausted",
+        items=(blocker,),
+    )
+    assert accepted == ["exploration_exhausted"]
     assert rejected == []
 
 

--- a/tests/control_plane/test_run_context_retention.py
+++ b/tests/control_plane/test_run_context_retention.py
@@ -11,6 +11,7 @@ from loopx.control_plane.runtime.run_context_retention import (
 from loopx.control_plane.status.agent_lane_projection import (
     compact_agent_lane_status_payload_for_display,
 )
+from loopx.status import compact_run
 
 AGENT_ID = "quality-agent"
 OTHER_AGENT_ID = "other-agent"
@@ -121,6 +122,37 @@ def test_semantic_history_uses_independent_agent_slots() -> None:
         _agent_context(semantic_history, OTHER_AGENT_ID)["latest_agent_vision_run"]
         is runs[5]
     )
+
+
+def test_rejected_replan_feedback_survives_compaction_and_semantic_history() -> None:
+    run = _run(
+        "2026-08-09T00:06:00Z",
+        classification="replan_noop",
+        autonomous_replan_noop={
+            "classification": "replan_noop",
+            "requested_classification": "successor_replan_recorded",
+        },
+        autonomous_replan_ack={
+            "recorded": False,
+            "delta_contract": {
+                "rejected_claims": [
+                    {
+                        "kind": "watch_lane_continuation",
+                        "reason": "monitor is missing expires_at, resume_when, or watch_only",
+                    }
+                ]
+            },
+        },
+    )
+
+    compacted = compact_run(run)
+    history = goal_semantic_history_from_runs([compacted])
+    context = _agent_context(history, AGENT_ID)
+
+    assert compacted["replan_ack_feedback"]["rejected_claims"][0]["kind"] == (
+        "watch_lane_continuation"
+    )
+    assert context["latest_replan_ack_feedback_run"] is compacted
 
 
 def test_retirement_prevents_stale_vision_selection() -> None:

--- a/tests/control_plane/test_todo_mutation_authority.py
+++ b/tests/control_plane/test_todo_mutation_authority.py
@@ -130,6 +130,84 @@ def _add_agent_todo(
     )
 
 
+def test_continuous_monitor_requires_explicit_boundedness(tmp_path: Path) -> None:
+    registry, state = _write_fixture(tmp_path, multi_agent=False)
+    common = {
+        "registry_path": registry,
+        "goal_id": GOAL_ID,
+        "role": "agent",
+        "text": "Watch one public dependency.",
+        "task_class": "continuous_monitor",
+        "action_kind": "monitor",
+        "claimed_by": AUTHOR_AGENT,
+        "monitor_metadata": {
+            "target_key": "public-dependency",
+            "cadence": "30m",
+            "next_due_at": "2026-08-12T00:00:00Z",
+        },
+    }
+
+    with pytest.raises(ValueError, match="requires one of: --expires-at"):
+        add_goal_todo(**common)
+
+    result = add_goal_todo(
+        **{
+            **common,
+            "monitor_metadata": {
+                **common["monitor_metadata"],
+                "watch_only": "true",
+            },
+        }
+    )
+    item = _agent_todo(state, str(result["todo_id"]))
+    assert item["watch_only"] == "true"
+
+
+def test_update_to_continuous_monitor_requires_explicit_boundedness(
+    tmp_path: Path,
+) -> None:
+    registry, state = _write_fixture(tmp_path, multi_agent=False)
+    todo = _add_agent_todo(registry)
+    before = state.read_text(encoding="utf-8")
+
+    with pytest.raises(ValueError, match="requires one of: --expires-at"):
+        update_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=str(todo["todo_id"]),
+            agent_id=AUTHOR_AGENT,
+            task_class="continuous_monitor",
+            monitor_metadata={
+                "target_key": "public-dependency",
+                "cadence": "30m",
+                "next_due_at": "2026-08-12T00:00:00Z",
+            },
+        )
+
+    assert state.read_text(encoding="utf-8") == before
+
+
+def test_continuous_monitor_accepts_resume_condition_bound(tmp_path: Path) -> None:
+    registry, state = _write_fixture(tmp_path, multi_agent=False)
+    result = add_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="agent",
+        text="Watch until the prerequisite PR merges.",
+        task_class="continuous_monitor",
+        action_kind="monitor",
+        claimed_by=AUTHOR_AGENT,
+        resume_when="pr_merged:#3083",
+        monitor_metadata={
+            "target_key": "pr-3083",
+            "cadence": "30m",
+            "next_due_at": "2026-08-12T00:00:00Z",
+        },
+    )
+    item = _agent_todo(state, str(result["todo_id"]))
+    assert item["resume_when"] == "pr_merged:#3083"
+
+
 def test_multi_agent_update_requires_actor_and_is_atomic(tmp_path: Path) -> None:
     registry, state = _write_fixture(tmp_path)
     todo = _add_agent_todo(registry)
@@ -1175,7 +1253,11 @@ def test_monitor_writeback_propagates_multi_agent_actor(tmp_path: Path) -> None:
         text="Poll one public monitor target.",
         task_class="continuous_monitor",
         claimed_by=AUTHOR_AGENT,
-        monitor_metadata={"target_key": "public-pr:42", "cadence": "15m"},
+        monitor_metadata={
+            "target_key": "public-pr:42",
+            "cadence": "15m",
+            "watch_only": "true",
+        },
     )
 
     result = write_monitor_poll_todo_state(


### PR DESCRIPTION
## Summary

- require every `continuous_monitor` to declare `expires_at`, `resume_when`, or explicit `watch_only`
- keep `watch_only` as a schedulable liveness lane while excluding it from autonomous replan and goal convergence
- retain rejected replan ACK reasons through compact history and surface them in quota/heartbeat guidance
- fingerprint selected-Todo causal blockers and reject repeated blocker ACKs unless a genuinely new runnable direction or evidence-backed `exploration_exhausted` closure appears
- move repair-delta contract assembly into its work-item bounded context and keep hot-path/maintainability budgets intact

## Validation

- `157 passed` focused impacted pytest suite
- `python -m mypy` — passed (16 strict targets)
- `ruff check --select F` on all changed Python files — passed
- autonomous replan, read-model, Todo lifecycle, monitor policy/writeback smokes — passed
- hot-path interface budget and control-plane maintainability ratchet — passed
- `loopx canary premerge --from-git-diff --goal-id loopx-meta --tier standard` — 18/18 selected checks passed, 0 failures, 0 warnings, 0 manual holds
- public/private boundary scan — clean across all 28 changed files
- exact-scope change-quality receipt: `cqr_8a3f39ae22c1a4360ab6` (valid)

## Scope and risk

- no scheduler ownership change and no new executor
- legacy unbounded monitors remain readable by runtime poll writeback, but authoring/update fails closed until an explicit lifecycle policy is supplied
- no private state, internal links, credentials, local paths, generated logs, or benchmark evidence included
- no required validation skipped; no manual hold

Closes #3083.
Closes #3084.
