### PR TITLE
feat(pr-review): require scope-fit evidence for production surface changes

### DIFF
--- a/examples/pr-review-command-smoke.py
+++ b/examples/pr-review-command-smoke.py
@@ -82,6 +82,7 @@ def main() -> int:
         "Motivation Causal Chain",
         "Implementation Execution Chain",
         "Code Volume And Simplification Review",
+        "Scope-Fit And Active Call-Site Gate",
     ):
         assert duplicated_contract_heading not in skill_source, duplicated_contract_heading
 
@@ -229,6 +230,47 @@ def main() -> int:
     assert main_risk["post_merge_review"] is False, main_risk
     assert main_risk["potential_regressions"], main_risk
     assert main_risk["bug_risks"], main_risk
+    contract = payload.get("agent_response_contract", {}).get(
+        "review_execution_contract", {}
+    )
+    scope_fit_reqs = [
+        req
+        for req in contract.get("evidence_requirements", [])
+        if req.get("evidence_id") == "scope_fit"
+    ]
+    assert scope_fit_reqs, "scope_fit evidence requirement missing from contract"
+    assert scope_fit_reqs[0]["required_when"] == "code_change", scope_fit_reqs
+    code_pr = next(
+        (
+            p
+            for p in payload.get("pull_requests", [])
+            if p.get("review_plan", {}).get("applicability", {}).get("code_change")
+        ),
+        None,
+    )
+    assert code_pr is not None, "fixture must include a code-change PR"
+    assert "scope_fit" in code_pr["review_plan"]["required_evidence_ids"], code_pr[
+        "review_plan"
+    ]
+    assert (
+        code_pr["review_plan"]["applicability"]["scope_fit_required"] is True
+    ), code_pr["review_plan"]
+    docs_pr = next(
+        (
+            p
+            for p in payload.get("pull_requests", [])
+            if not p.get("review_plan", {}).get("applicability", {}).get("code_change")
+        ),
+        None,
+    )
+    assert docs_pr is not None, "fixture must include a docs-only PR"
+    assert docs_pr["review_plan"]["applicability"]["scope_fit_required"] is False
+    risk_section = next(
+        section
+        for section in template["sections"]
+        if section["label"] == "对主干的风险"
+    )
+    assert "scope_fit" in risk_section["agent_instruction"], risk_section
 
     default_payload = json.loads(
         run_cli("--format", "json", "pr-review", "--fixture", str(FIXTURE)).stdout
@@ -427,6 +469,7 @@ def main() -> int:
         "problem_context",
         "architecture_flow",
         "changed_line_classification",
+        "scope_fit",
         "symbol_map",
         "walkthroughs",
         "validation_matrix",

--- a/loopx/capabilities/pr_review_queue/review_contract.py
+++ b/loopx/capabilities/pr_review_queue/review_contract.py
@@ -82,7 +82,7 @@ def build_review_template(item: Mapping[str, Any]) -> dict[str, Any]:
             _section(
                 "对主干的风险",
                 "250-500字",
-                "Use `failure_analysis`, `walkthroughs.negative`, and `validation_matrix`; trace each finding from triggering state to observed outcome and minimum repair.",
+                "Use `failure_analysis`, `walkthroughs.negative`, and `validation_matrix`; trace each finding from triggering state to observed outcome and minimum repair. When `scope_fit` applies, name the active production caller or explicitly record a coverage-only boundary.",
             ),
             _section(
                 "我的整体评价",
@@ -145,6 +145,26 @@ def build_review_execution_contract() -> dict[str, Any]:
                 ],
                 "fields": ["files", "additions", "deletions", "behavior_role"],
                 "rule": "Classify the exact base..head diff before judging code volume.",
+            },
+            {
+                "evidence_id": "scope_fit",
+                "required_when": "code_change",
+                "fields": [
+                    "shipped_behavior",
+                    "active_call_sites",
+                    "caller_path_or_none",
+                    "coverage_only_declared",
+                    "scope_fit_verdict",
+                ],
+                "rule": (
+                    "For every added or moved production module, adapter, CLI "
+                    "command, or control-plane contract, verify a shipped "
+                    "behavior and at least one active production call site in "
+                    "the reviewed branch. Test-only coverage of an unused "
+                    "module is not a shipped behavior; name the gap and treat "
+                    "it as blocking unless an explicit, owner-accepted "
+                    "coverage-only boundary is recorded."
+                ),
             },
             {
                 "evidence_id": "symbol_map",
@@ -288,6 +308,7 @@ def build_review_plan(item: Mapping[str, Any]) -> dict[str, Any]:
     ]
     if code_change:
         required_evidence.insert(3, "symbol_map")
+        required_evidence.append("scope_fit")
     number = item.get("number")
     head_oid = str(item.get("head_oid") or "").strip()
     target_key = f"{number}@{head_oid}" if number and head_oid else None
@@ -305,6 +326,7 @@ def build_review_plan(item: Mapping[str, Any]) -> dict[str, Any]:
             "code_change": code_change,
             "docs_only": docs_only,
             "symbol_map_required": code_change,
+            "scope_fit_required": code_change,
             "negative_walkthrough_required": bool(areas & NEGATIVE_PATH_AREAS),
         },
         "required_evidence_ids": required_evidence,


### PR DESCRIPTION
## Summary

The scope-fit / active-call-site gate belongs in the `pr-review` capability contract, not the host skill (the skill is line-bounded at 180 and must stay a thin adapter). This PR moves the gate into the CLI packet:

- `loopx/capabilities/pr_review_queue/review_contract.py`:
  - adds a required evidence id `scope_fit` (`required_when: code_change`) with fields `shipped_behavior`, `active_call_sites`, `caller_path_or_none`, `coverage_only_declared`, `scope_fit_verdict`, and the rule that test-only coverage of an unused module is not a shipped behavior;
  - code-change review plans now include `scope_fit` in `required_evidence_ids` and set `applicability.scope_fit_required=true`;
  - the `对主干的风险` template instruction tells reviewers to name the active production caller or record an explicit coverage-only boundary.
- `examples/pr-review-command-smoke.py`:
  - forbids the scope-fit heading from being duplicated into the skill file;
  - asserts the contract carries `scope_fit`;
  - asserts code-change plans require it while docs-only plans do not.

## Validation

- `examples/pr-review-command-smoke.py`: ok (local, Python 3.12).
- `loopx canary premerge --from-git-diff --git-diff-base origin/main`: 0 failures / 0 warnings, including `pr-review-command-smoke` and public-boundary scan on both changed files.
- `git diff --check` clean.

## Issue Or Task

- Closes # (n/a)
- Contributor task ID: n/a

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] Test update