### PR TITLE
feat(task-lease): route CLI acquire through typed settlement (GH-C82)

### DIFF
--- a/loopx/cli_commands/task_lease.py
+++ b/loopx/cli_commands/task_lease.py
@@ -6,12 +6,15 @@ from pathlib import Path
 
 from ..control_plane.work_items.task_lease import (
     TaskLeaseError,
-    acquire_task_lease,
     inspect_task_lease,
     release_task_lease,
     renew_task_lease,
     runtime_root_from_registry,
+    task_lease_path,
     transfer_task_lease,
+)
+from ..control_plane.work_items.task_lease_settlement import (
+    execute_task_lease_settlement,
 )
 from ..file_lock import LockAcquireTimeoutError
 from ..presentation.markdown import append_operator_action_markdown
@@ -122,17 +125,76 @@ def handle_task_lease_command(
             raise ValueError("task-lease action requires --idempotency-key")
         runtime_root = runtime_root_from_registry(registry_path, runtime_root_arg)
         if args.task_lease_command == "acquire":
-            payload = acquire_task_lease(
+            result = execute_task_lease_settlement(
                 registry_path=registry_path,
                 runtime_root=runtime_root,
                 goal_id=args.goal_id,
-                todo_id=args.todo_id,
                 owner=args.owner,
+                todo_id=args.todo_id,
                 idempotency_key=args.idempotency_key,
-                ttl_seconds=args.ttl_seconds,
                 write_scopes=args.write_scopes,
+                ttl_seconds=args.ttl_seconds,
                 expected_version=args.expected_version,
+                acquire=True,
             )
+            lease_path = task_lease_path(
+                runtime_root=runtime_root,
+                goal_id=args.goal_id,
+                todo_id=args.todo_id,
+            )
+            if result.failure is not None:
+                payload = {
+                    "ok": False,
+                    "schema_version": "task_lease_v0",
+                    "action": "acquire",
+                    "error": str(result.failure.reason),
+                    "error_code": result.failure.kind.value,
+                    "lease_path": str(lease_path),
+                    "settlement": {
+                        "effect_id": (
+                            result.receipts[-1].effect_id if result.receipts else None
+                        ),
+                        "receipts": [
+                            {
+                                "step": receipt.step_kind.value,
+                                "status": receipt.status,
+                                "effect_id": receipt.effect_id,
+                            }
+                            for receipt in result.receipts
+                        ],
+                        "failure": {
+                            "step": result.failure.step_kind.value,
+                            "kind": result.failure.kind.value,
+                        },
+                    },
+                }
+            else:
+                lease = result.value if isinstance(result.value, dict) else {}
+                idempotent = any(
+                    receipt.status == "idempotent" for receipt in result.receipts
+                )
+                payload = {
+                    "ok": True,
+                    "schema_version": "task_lease_v0",
+                    "action": "acquire",
+                    "acquired": not idempotent,
+                    "idempotent": idempotent,
+                    "lease": lease,
+                    "lease_path": str(lease_path),
+                    "settlement": {
+                        "effect_id": (
+                            result.receipts[-1].effect_id if result.receipts else None
+                        ),
+                        "receipts": [
+                            {
+                                "step": receipt.step_kind.value,
+                                "status": receipt.status,
+                                "effect_id": receipt.effect_id,
+                            }
+                            for receipt in result.receipts
+                        ],
+                    },
+                }
         elif args.task_lease_command == "renew":
             if args.write_scopes:
                 raise ValueError("task-lease renew does not accept --write-scope")

--- a/loopx/control_plane/work_items/task_lease_settlement.py
+++ b/loopx/control_plane/work_items/task_lease_settlement.py
@@ -11,7 +11,7 @@ orchestration as a typed settlement chain.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -25,8 +25,9 @@ from loopx.control_plane.effect_program import (
     SettlementStepKind,
 )
 from loopx.control_plane.work_items.task_lease import (
+    TaskLeaseError,
+    acquire_task_lease,
     active_conflicts,
-    build_lease,
     lease_is_active,
     normalize_goal_id,
     normalize_idempotency_key,
@@ -36,7 +37,6 @@ from loopx.control_plane.work_items.task_lease import (
     read_lease,
     require_task_lease_owner_allowed,
     task_lease_path,
-    write_lease,
 )
 
 __all__ = [
@@ -50,9 +50,6 @@ __all__ = [
 def _now_utc() -> datetime:
     return datetime.now(tz=timezone.utc)
 
-
-def _isoformat(value: datetime) -> str:
-    return value.isoformat()
 
 
 def _settlement_identity(
@@ -241,15 +238,51 @@ def resolve_task_lease_validation(
     )
 
 
+def _map_task_lease_error(exc: TaskLeaseError) -> SettlementResult[dict[str, Any]]:
+    """Map a ``TaskLeaseError`` raised by ``acquire_task_lease`` onto a typed failure."""
+    code = exc.code
+    if code in (
+        "invalid_goal_id",
+        "invalid_todo_id",
+        "invalid_owner",
+        "invalid_idempotency_key",
+        "invalid_ttl",
+        "idempotency_key_reuse",
+    ):
+        kind = SettlementFailureKind.INVALID_IDENTITY
+    elif code in (
+        "owner_not_registered",
+        "todo_not_found",
+        "todo_not_open",
+        "owner_excluded_from_todo",
+        "owner_conflicts_with_claim",
+    ):
+        kind = SettlementFailureKind.PERMISSION_DENIED
+    else:
+        kind = SettlementFailureKind.WRITEBACK_REJECTED
+    return SettlementResult.failed(
+        kind=kind,
+        step_kind=SettlementStepKind.DURABLE_WRITEBACK,
+        reason=str(exc),
+    )
+
+
 def commit_task_lease_acquire(
     identity: SettlementIdentity,
     *,
+    registry_path: Path,
     runtime_root: Path,
     write_scopes: list[str] | None = None,
     ttl_seconds: int | None = None,
+    expected_version: int | None = None,
     acquire: bool = True,
 ) -> SettlementResult[dict[str, Any]]:
-    """Commit the task-lease file, producing a typed acquire receipt.
+    """Commit the task-lease file via ``acquire_task_lease``, producing a typed receipt.
+
+    Routes through the owning module's ``acquire_task_lease`` so that the
+    per-goal ``exclusive_file_lock``, ``expected_version`` CAS, idempotency-key
+    parameter matching, and write-scope/ttl consistency checks are enforced
+    atomically — the same path every other caller takes.
 
     When *acquire* is ``False`` the step is skipped (no-op receipt).  That
     path is used by the semantic oracle to test failure short-circuiting.
@@ -260,44 +293,29 @@ def commit_task_lease_acquire(
             step_kind=SettlementStepKind.DURABLE_WRITEBACK,
             reason="task lease acquire rejected by settlement oracle",
         )
-    normalized_scopes = sorted(set(write_scopes or []))
-    normalized_ttl = normalize_ttl_seconds(ttl_seconds)
-    lease_path = task_lease_path(
-        runtime_root=runtime_root,
-        goal_id=identity.goal_id,
-        todo_id=identity.todo_id,
-    )
-    at = _now_utc()
-    updated_at = _isoformat(at)
-    expires_at = _isoformat(at + timedelta(seconds=normalized_ttl))
-    lease = build_lease(
-        goal_id=identity.goal_id,
-        todo_id=identity.todo_id,
-        owner=identity.agent_id,
-        idempotency_key=identity.turn_instance_id,
-        write_scopes=normalized_scopes,
-        acquire_ttl_seconds=normalized_ttl,
-        version=1,
-        acquired_at=updated_at,
-        updated_at=updated_at,
-        expires_at=expires_at,
-    )
     try:
-        write_lease(lease_path, lease)
-    except OSError as exc:
-        return SettlementResult.failed(
-            kind=SettlementFailureKind.WRITEBACK_REJECTED,
-            step_kind=SettlementStepKind.DURABLE_WRITEBACK,
-            reason=str(exc),
+        result = acquire_task_lease(
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+            goal_id=identity.goal_id,
+            todo_id=identity.todo_id,
+            owner=identity.agent_id,
+            idempotency_key=identity.turn_instance_id,
+            ttl_seconds=ttl_seconds,
+            write_scopes=write_scopes,
+            expected_version=expected_version,
         )
+    except TaskLeaseError as exc:
+        return _map_task_lease_error(exc)
+    lease_path = str(result.get("lease_path", ""))
     return SettlementResult.pure(
-        lease,
+        result["lease"],
         receipts=(
             SettlementReceipt(
                 step_kind=SettlementStepKind.DURABLE_WRITEBACK,
-                status="committed",
+                status="committed" if result.get("acquired") else "idempotent",
                 effect_id=identity.effect_id,
-                source_ref=str(lease_path),
+                source_ref=lease_path,
             ),
         ),
     )
@@ -313,6 +331,7 @@ def execute_task_lease_settlement(
     idempotency_key: str,
     write_scopes: list[str] | None = None,
     ttl_seconds: int | None = None,
+    expected_version: int | None = None,
     acquire: bool = True,
 ) -> SettlementResult[dict[str, Any]]:
     """Bind validation → acquire for the task-lease settlement adapter.
@@ -334,9 +353,11 @@ def execute_task_lease_settlement(
         .bind(
             lambda identity: commit_task_lease_acquire(
                 identity,
+                registry_path=registry_path,
                 runtime_root=runtime_root,
                 write_scopes=write_scopes,
                 ttl_seconds=ttl_seconds,
+                expected_version=expected_version,
                 acquire=acquire,
             )
         )

--- a/loopx/control_plane/work_items/task_lease_settlement.py
+++ b/loopx/control_plane/work_items/task_lease_settlement.py
@@ -1,0 +1,343 @@
+"""Task-lease adapter for the shared typed settlement algebra.
+
+Wraps the existing task_lease acquire path with typed identity, receipt,
+and failure semantics so it participates in the same conformance, fault/replay,
+and incident-replay coverage as the quota and Turn adapters.
+
+Pure decision logic (owner eligibility, conflict detection, lease persistence)
+remains in the owning ``task_lease`` module.  This adapter only models the
+orchestration as a typed settlement chain.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from loopx.control_plane.effect_program import (
+    SettlementFailureKind,
+    SettlementIdentity,
+    SettlementPlan,
+    SettlementReceipt,
+    SettlementResult,
+    SettlementStep,
+    SettlementStepKind,
+)
+from loopx.control_plane.work_items.task_lease import (
+    active_conflicts,
+    build_lease,
+    lease_is_active,
+    normalize_goal_id,
+    normalize_idempotency_key,
+    normalize_lease_todo_id,
+    normalize_owner,
+    normalize_ttl_seconds,
+    read_lease,
+    require_task_lease_owner_allowed,
+    task_lease_path,
+    write_lease,
+)
+
+__all__ = [
+    "build_task_lease_settlement_plan",
+    "commit_task_lease_acquire",
+    "execute_task_lease_settlement",
+    "resolve_task_lease_validation",
+]
+
+
+def _now_utc() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _isoformat(value: datetime) -> str:
+    return value.isoformat()
+
+
+def _settlement_identity(
+    *,
+    goal_id: str,
+    owner: str,
+    todo_id: str,
+    idempotency_key: str,
+) -> SettlementIdentity:
+    return SettlementIdentity(
+        goal_id=normalize_goal_id(goal_id),
+        agent_id=normalize_owner(owner),
+        todo_id=normalize_lease_todo_id(todo_id),
+        turn_instance_id=normalize_idempotency_key(idempotency_key),
+    )
+
+
+def build_task_lease_settlement_plan(
+    *,
+    goal_id: str,
+    owner: str,
+    todo_id: str,
+    idempotency_key: str,
+    write_scopes: list[str] | None = None,
+    ttl_seconds: int | None = None,
+) -> SettlementPlan:
+    """Build a typed settlement plan for a task-lease acquire.
+
+    The plan uses two ordered steps: validation (identity + eligibility +
+    no-conflicts check) and acquire (committed file write). The scheduler
+    is deliberately left outside the settlement boundary.
+    """
+    identity = _settlement_identity(
+        goal_id=goal_id,
+        owner=owner,
+        todo_id=todo_id,
+        idempotency_key=idempotency_key,
+    )
+    normalized_scopes = sorted(set(write_scopes or []))
+    normalized_ttl = normalize_ttl_seconds(ttl_seconds)
+    effect_ref = "$.identity.effect_id"
+    return SettlementPlan(
+        identity=identity,
+        steps=(
+            SettlementStep(
+                kind=SettlementStepKind.VALIDATION,
+                owner="agent",
+                precondition=(
+                    "owner is registered and eligible for this todo; "
+                    "no active lease with different owner/key exists; "
+                    "no write-scope conflict with another active lease"
+                ),
+                idempotency_key_ref=effect_ref,
+                expected_receipt="task_lease_validation_receipt",
+            ),
+            SettlementStep(
+                kind=SettlementStepKind.DURABLE_WRITEBACK,
+                owner="agent",
+                precondition=(
+                    "validation succeeded; lease file can be committed"
+                ),
+                idempotency_key_ref=effect_ref,
+                expected_receipt="task_lease_acquire_receipt",
+                command_template=(
+                    f"loopx task-lease acquire --goal-id {identity.goal_id}"
+                    f" --todo-id {identity.todo_id}"
+                    f" --owner {identity.agent_id}"
+                    f" --ttl {normalized_ttl}"
+                    + (
+                        "".join(f" --write-scope {s}" for s in normalized_scopes)
+                        if normalized_scopes
+                        else ""
+                    )
+                ),
+            ),
+        ),
+    )
+
+
+def resolve_task_lease_validation(
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    goal_id: str,
+    owner: str,
+    todo_id: str,
+    idempotency_key: str,
+    write_scopes: list[str] | None = None,
+) -> SettlementResult[SettlementIdentity]:
+    """Validate task-lease acquire preconditions.
+
+    Returns a typed result: either a pure identity with a validation receipt,
+    or a typed failure that short-circuits the acquire step.
+    """
+    try:
+        normalized_goal_id = normalize_goal_id(goal_id)
+        normalized_owner = normalize_owner(owner)
+        normalized_todo_id = normalize_lease_todo_id(todo_id)
+        normalized_key = normalize_idempotency_key(idempotency_key)
+    except ValueError as exc:
+        return SettlementResult.failed(
+            kind=SettlementFailureKind.INVALID_IDENTITY,
+            step_kind=SettlementStepKind.VALIDATION,
+            reason=str(exc),
+        )
+
+    identity = SettlementIdentity(
+        goal_id=normalized_goal_id,
+        agent_id=normalized_owner,
+        todo_id=normalized_todo_id,
+        turn_instance_id=normalized_key,
+    )
+
+    # --- owner eligibility (pure decision, owned by task_lease module) ---
+    try:
+        require_task_lease_owner_allowed(
+            registry_path=registry_path,
+            goal_id=normalized_goal_id,
+            todo_id=normalized_todo_id,
+            owner=normalized_owner,
+        )
+    except ValueError as exc:
+        return SettlementResult.failed(
+            kind=SettlementFailureKind.PERMISSION_DENIED,
+            step_kind=SettlementStepKind.VALIDATION,
+            reason=str(exc),
+        )
+
+    # --- existing active lease check ---
+    lease_path = task_lease_path(
+        runtime_root=runtime_root,
+        goal_id=normalized_goal_id,
+        todo_id=normalized_todo_id,
+    )
+    existing = read_lease(lease_path)
+    if existing is not None and lease_is_active(existing):
+        existing_owner = str(existing.get("owner") or "")
+        existing_key = str(existing.get("idempotency_key") or "")
+        if existing_owner == normalized_owner and existing_key == normalized_key:
+            # Same owner + key — would be idempotent; surface as already-settled
+            return SettlementResult.pure(
+                identity,
+                receipts=(
+                    SettlementReceipt(
+                        step_kind=SettlementStepKind.VALIDATION,
+                        status="idempotent",
+                        effect_id=identity.effect_id,
+                        source_ref=str(lease_path),
+                    ),
+                ),
+            )
+        return SettlementResult.failed(
+            kind=SettlementFailureKind.WRITEBACK_REJECTED,
+            step_kind=SettlementStepKind.VALIDATION,
+            reason="todo already has an active lease with a different owner or key",
+        )
+
+    # --- write-scope conflict check ---
+    normalized_scopes = sorted(set(write_scopes or []))
+    if normalized_scopes:
+        conflicts = active_conflicts(
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+            goal_id=normalized_goal_id,
+            todo_id=normalized_todo_id,
+            write_scopes=normalized_scopes,
+            at=_now_utc(),
+        )
+        if conflicts:
+            return SettlementResult.failed(
+                kind=SettlementFailureKind.WRITEBACK_REJECTED,
+                step_kind=SettlementStepKind.VALIDATION,
+                reason=f"write scopes overlap {len(conflicts)} active lease(s)",
+            )
+
+    return SettlementResult.pure(
+        identity,
+        receipts=(
+            SettlementReceipt(
+                step_kind=SettlementStepKind.VALIDATION,
+                status="committed",
+                effect_id=identity.effect_id,
+                source_ref=str(lease_path),
+            ),
+        ),
+    )
+
+
+def commit_task_lease_acquire(
+    identity: SettlementIdentity,
+    *,
+    runtime_root: Path,
+    write_scopes: list[str] | None = None,
+    ttl_seconds: int | None = None,
+    acquire: bool = True,
+) -> SettlementResult[dict[str, Any]]:
+    """Commit the task-lease file, producing a typed acquire receipt.
+
+    When *acquire* is ``False`` the step is skipped (no-op receipt).  That
+    path is used by the semantic oracle to test failure short-circuiting.
+    """
+    if not acquire:
+        return SettlementResult.failed(
+            kind=SettlementFailureKind.WRITEBACK_REJECTED,
+            step_kind=SettlementStepKind.DURABLE_WRITEBACK,
+            reason="task lease acquire rejected by settlement oracle",
+        )
+    normalized_scopes = sorted(set(write_scopes or []))
+    normalized_ttl = normalize_ttl_seconds(ttl_seconds)
+    lease_path = task_lease_path(
+        runtime_root=runtime_root,
+        goal_id=identity.goal_id,
+        todo_id=identity.todo_id,
+    )
+    at = _now_utc()
+    updated_at = _isoformat(at)
+    expires_at = _isoformat(at + timedelta(seconds=normalized_ttl))
+    lease = build_lease(
+        goal_id=identity.goal_id,
+        todo_id=identity.todo_id,
+        owner=identity.agent_id,
+        idempotency_key=identity.turn_instance_id,
+        write_scopes=normalized_scopes,
+        acquire_ttl_seconds=normalized_ttl,
+        version=1,
+        acquired_at=updated_at,
+        updated_at=updated_at,
+        expires_at=expires_at,
+    )
+    try:
+        write_lease(lease_path, lease)
+    except OSError as exc:
+        return SettlementResult.failed(
+            kind=SettlementFailureKind.WRITEBACK_REJECTED,
+            step_kind=SettlementStepKind.DURABLE_WRITEBACK,
+            reason=str(exc),
+        )
+    return SettlementResult.pure(
+        lease,
+        receipts=(
+            SettlementReceipt(
+                step_kind=SettlementStepKind.DURABLE_WRITEBACK,
+                status="committed",
+                effect_id=identity.effect_id,
+                source_ref=str(lease_path),
+            ),
+        ),
+    )
+
+
+def execute_task_lease_settlement(
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    goal_id: str,
+    owner: str,
+    todo_id: str,
+    idempotency_key: str,
+    write_scopes: list[str] | None = None,
+    ttl_seconds: int | None = None,
+    acquire: bool = True,
+) -> SettlementResult[dict[str, Any]]:
+    """Bind validation → acquire for the task-lease settlement adapter.
+
+    Pure decision logic (owner eligibility, conflict detection) lives in the
+    owning ``task_lease`` module.  This function only orchestrates the typed
+    settlement chain.
+    """
+    return (
+        resolve_task_lease_validation(
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+            goal_id=goal_id,
+            owner=owner,
+            todo_id=todo_id,
+            idempotency_key=idempotency_key,
+            write_scopes=write_scopes,
+        )
+        .bind(
+            lambda identity: commit_task_lease_acquire(
+                identity,
+                runtime_root=runtime_root,
+                write_scopes=write_scopes,
+                ttl_seconds=ttl_seconds,
+                acquire=acquire,
+            )
+        )
+    )

--- a/tests/control_plane/test_effect_program_adapter_conformance.py
+++ b/tests/control_plane/test_effect_program_adapter_conformance.py
@@ -5,6 +5,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -27,6 +28,11 @@ from loopx.control_plane.turn_driver.settlement import (
 from loopx.control_plane.turn_driver.transaction import (
     TRANSACTION_PHASES,
     build_loopx_turn_transaction_plan,
+)
+from loopx.control_plane.work_items.task_lease_settlement import (
+    build_task_lease_settlement_plan,
+    commit_task_lease_acquire,
+    resolve_task_lease_validation,
 )
 from loopx.rollout_event_log import rollout_event_log_path
 
@@ -262,6 +268,118 @@ def _run_turn_adapter(_runtime_root: Path, scenario: str) -> AdapterObservation:
     return AdapterObservation(result, tuple(calls), settlement_plan)
 
 
+# ── Task-lease adapter ────────────────────────────────────────────────
+TASK_LEASE_GOAL_ID = "task-lease-goal"
+TASK_LEASE_AGENT_ID = "task-lease-agent"
+TASK_LEASE_TODO_ID = "todo_lease_conformance"
+TASK_LEASE_IDEMPOTENCY_KEY = "task-lease-conformance-key"
+
+
+def _write_task_lease_registry(registry_path: Path) -> None:
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "goals": [
+                    {
+                        "id": TASK_LEASE_GOAL_ID,
+                        "status": "active",
+                        "repo": str(registry_path.parent),
+                        "state_file": "ACTIVE_GOAL_STATE.md",
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": [TASK_LEASE_AGENT_ID],
+                        },
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _run_task_lease_adapter(runtime_root: Path, scenario: str) -> AdapterObservation:
+    registry_path = runtime_root / "registry.json"
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    _write_task_lease_registry(registry_path)
+
+    idempotency_key = (
+        "invalid key with spaces!"
+        if scenario == "invalid_identity"
+        else TASK_LEASE_IDEMPOTENCY_KEY
+    )
+
+    # Build the plan with a valid idempotency key so construction does not crash.
+    # The invalid idempotency key is only injected at settlement execution time.
+    plan = build_task_lease_settlement_plan(
+        goal_id=TASK_LEASE_GOAL_ID,
+        owner=TASK_LEASE_AGENT_ID,
+        todo_id=TASK_LEASE_TODO_ID,
+        idempotency_key=TASK_LEASE_IDEMPOTENCY_KEY,
+        write_scopes=["docs/**"],
+        ttl_seconds=600,
+    ).as_dict()
+
+    acquire = scenario != "writeback_failure"
+
+    calls: list[SettlementStepKind] = []
+
+    def observed_validation(
+        registry_path: Path,
+        runtime_root: Path,
+        goal_id: str,
+        owner: str,
+        todo_id: str,
+        idempotency_key: str,
+        write_scopes: list[str] | None = None,
+    ) -> SettlementResult[SettlementIdentity]:
+        result = resolve_task_lease_validation(
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+            goal_id=goal_id,
+            owner=owner,
+            todo_id=todo_id,
+            idempotency_key=idempotency_key,
+            write_scopes=write_scopes,
+        )
+        return result
+
+    def observed_acquire(
+        identity: SettlementIdentity,
+    ) -> SettlementResult[dict[str, Any]]:
+        calls.append(SettlementStepKind.DURABLE_WRITEBACK)
+        return commit_task_lease_acquire(
+            identity,
+            runtime_root=runtime_root,
+            write_scopes=["docs/**"],
+            ttl_seconds=600,
+            acquire=acquire,
+        )
+
+    with (
+        patch(
+            "loopx.control_plane.work_items.task_lease_settlement.require_task_lease_owner_allowed",
+            return_value={"status": "open", "claimed_by": TASK_LEASE_AGENT_ID},
+        ),
+        patch(
+            "loopx.control_plane.work_items.task_lease_settlement.active_conflicts",
+            return_value=[],
+        ),
+    ):
+        result = observed_validation(
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+            goal_id=TASK_LEASE_GOAL_ID,
+            owner=TASK_LEASE_AGENT_ID,
+            todo_id=TASK_LEASE_TODO_ID,
+            idempotency_key=idempotency_key,
+            write_scopes=["docs/**"],
+        ).bind(observed_acquire)
+
+    return AdapterObservation(result, tuple(calls), plan)
+
+
 ADAPTERS = (
     AdapterSpec(
         name="quota",
@@ -294,6 +412,16 @@ ADAPTERS = (
             SettlementStepKind.DURABLE_WRITEBACK,
             SettlementStepKind.QUOTA_SPEND,
         ),
+        calls_before_writeback_failure=(SettlementStepKind.DURABLE_WRITEBACK,),
+    ),
+    AdapterSpec(
+        name="task_lease",
+        run=_run_task_lease_adapter,
+        success_receipts=(
+            SettlementStepKind.VALIDATION,
+            SettlementStepKind.DURABLE_WRITEBACK,
+        ),
+        success_calls=(SettlementStepKind.DURABLE_WRITEBACK,),
         calls_before_writeback_failure=(SettlementStepKind.DURABLE_WRITEBACK,),
     ),
 )

--- a/tests/control_plane/test_effect_program_adapter_conformance.py
+++ b/tests/control_plane/test_effect_program_adapter_conformance.py
@@ -351,6 +351,7 @@ def _run_task_lease_adapter(runtime_root: Path, scenario: str) -> AdapterObserva
         calls.append(SettlementStepKind.DURABLE_WRITEBACK)
         return commit_task_lease_acquire(
             identity,
+            registry_path=registry_path,
             runtime_root=runtime_root,
             write_scopes=["docs/**"],
             ttl_seconds=600,
@@ -364,6 +365,14 @@ def _run_task_lease_adapter(runtime_root: Path, scenario: str) -> AdapterObserva
         ),
         patch(
             "loopx.control_plane.work_items.task_lease_settlement.active_conflicts",
+            return_value=[],
+        ),
+        patch(
+            "loopx.control_plane.work_items.task_lease.require_task_lease_owner_allowed",
+            return_value={"status": "open", "claimed_by": TASK_LEASE_AGENT_ID},
+        ),
+        patch(
+            "loopx.control_plane.work_items.task_lease.active_conflicts",
             return_value=[],
         ),
     ):

--- a/tests/control_plane/test_effect_program_fault_replay_matrix.py
+++ b/tests/control_plane/test_effect_program_fault_replay_matrix.py
@@ -509,6 +509,80 @@ def test_task_lease_acquire_failure_short_circuits(
     assert SettlementStepKind.DURABLE_WRITEBACK not in receipt_kinds
 
 
+def test_task_lease_same_key_different_params_rejected(
+    tmp_path: Path,
+) -> None:
+    """Same idempotency key with different write_scopes or ttl must be rejected.
+
+    This is the regression test for the maintainer-requested idempotency-key
+    parameter-matching check inside ``acquire_task_lease``.  The adapter must
+    route through the real acquire path so the check is enforced atomically
+    under the per-goal exclusive_file_lock.
+    """
+    registry_path = tmp_path / "registry.json"
+    _write_task_lease_fault_registry(registry_path)
+    runtime_root = tmp_path / "runtime"
+
+    common = dict(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        goal_id=TASK_LEASE_FAULT_GOAL,
+        owner=TASK_LEASE_FAULT_AGENT,
+        todo_id=TASK_LEASE_FAULT_TODO,
+        idempotency_key=TASK_LEASE_FAULT_KEY,
+    )
+
+    with (
+        patch(
+            "loopx.control_plane.work_items.task_lease_settlement.require_task_lease_owner_allowed",
+            return_value={"status": "open", "claimed_by": TASK_LEASE_FAULT_AGENT},
+        ),
+        patch(
+            "loopx.control_plane.work_items.task_lease_settlement.active_conflicts",
+            return_value=[],
+        ),
+        patch(
+            "loopx.control_plane.work_items.task_lease.require_task_lease_owner_allowed",
+            return_value={"status": "open", "claimed_by": TASK_LEASE_FAULT_AGENT},
+        ),
+        patch(
+            "loopx.control_plane.work_items.task_lease.active_conflicts",
+            return_value=[],
+        ),
+    ):
+        # First acquire succeeds with docs/** scopes and 600s ttl
+        first = execute_task_lease_settlement(
+            **common,
+            write_scopes=["docs/**"],
+            ttl_seconds=600,
+            acquire=True,
+        )
+        assert first.failure is None
+
+        # Same key, different write_scopes — must be rejected
+        second = execute_task_lease_settlement(
+            **common,
+            write_scopes=["src/**"],
+            ttl_seconds=600,
+            acquire=True,
+        )
+        assert second.failure is not None
+        assert second.failure.step_kind is SettlementStepKind.DURABLE_WRITEBACK
+        assert second.failure.kind is SettlementFailureKind.INVALID_IDENTITY
+        assert "idempotency" in str(second.failure.reason).lower()
+
+        # Same key, different ttl — must be rejected
+        third = execute_task_lease_settlement(
+            **common,
+            write_scopes=["docs/**"],
+            ttl_seconds=300,
+            acquire=True,
+        )
+        assert third.failure is not None
+        assert third.failure.step_kind is SettlementStepKind.DURABLE_WRITEBACK
+        assert "idempotency" in str(third.failure.reason).lower()
+
+
 def test_task_lease_effect_id_consistency(
     tmp_path: Path,
 ) -> None:

--- a/tests/control_plane/test_effect_program_fault_replay_matrix.py
+++ b/tests/control_plane/test_effect_program_fault_replay_matrix.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping, Sequence
+from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -313,3 +316,210 @@ def test_failure_short_circuits_every_later_effect(
         < EXPECTED_SETTLEMENT_PHASES.index(reject_at)
         for step_kind in committed_steps
     )
+
+
+# ── Task-lease fault/replay scenarios ──────────────────────────────────
+
+from loopx.control_plane.work_items.task_lease_settlement import (  # noqa: E402
+    execute_task_lease_settlement,
+)
+
+TASK_LEASE_FAULT_GOAL = "task-lease-fault-goal"
+TASK_LEASE_FAULT_AGENT = "task-lease-fault-agent"
+TASK_LEASE_FAULT_TODO = "todo_lease_fault"
+TASK_LEASE_FAULT_KEY = "fault-key-1"
+
+
+def _write_task_lease_fault_registry(registry_path: Path) -> None:
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "goals": [
+                    {
+                        "id": TASK_LEASE_FAULT_GOAL,
+                        "status": "active",
+                        "repo": str(registry_path.parent),
+                        "state_file": "ACTIVE_GOAL_STATE.md",
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": [TASK_LEASE_FAULT_AGENT],
+                        },
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize(
+    ("acquire_first", "expected_second_effect_calls"),
+    [
+        (True, []),  # second call is idempotent — no duplicate effect
+    ],
+    ids=("idempotent-replay",),
+)
+def test_task_lease_acquire_idempotent_replay(
+    acquire_first: bool,
+    expected_second_effect_calls: list[SettlementStepKind],
+    tmp_path: Path,
+) -> None:
+    """Same identity + same params must not produce a duplicate side effect."""
+
+    registry_path = tmp_path / "registry.json"
+    _write_task_lease_fault_registry(registry_path)
+    runtime_root = tmp_path / "runtime"
+
+    common = dict(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        goal_id=TASK_LEASE_FAULT_GOAL,
+        owner=TASK_LEASE_FAULT_AGENT,
+        todo_id=TASK_LEASE_FAULT_TODO,
+        idempotency_key=TASK_LEASE_FAULT_KEY,
+        write_scopes=["docs/**"],
+        ttl_seconds=600,
+    )
+
+    with (
+        patch(
+            "loopx.control_plane.work_items.task_lease_settlement.require_task_lease_owner_allowed",
+            return_value={"status": "open", "claimed_by": TASK_LEASE_FAULT_AGENT},
+        ),
+        patch(
+            "loopx.control_plane.work_items.task_lease_settlement.active_conflicts",
+            return_value=[],
+        ),
+    ):
+        first = execute_task_lease_settlement(**common, acquire=acquire_first)
+        second = execute_task_lease_settlement(**common, acquire=True)
+
+    assert first.failure is None
+    assert second.failure is None
+    assert first.value is not None
+    assert second.value is not None
+
+    first_effect_id = first.receipts[0].effect_id
+    second_effect_id = second.receipts[0].effect_id
+    assert first_effect_id == second_effect_id
+
+    # The second call should discover the existing lease and return idempotent
+    second_statuses = {r.status for r in second.receipts}
+    assert "idempotent" in second_statuses
+
+
+def test_task_lease_validation_fails_before_acquire(
+    tmp_path: Path,
+) -> None:
+    """Invalid idempotency key must fail at validation with zero effects."""
+    registry_path = tmp_path / "registry.json"
+    _write_task_lease_fault_registry(registry_path)
+    runtime_root = tmp_path / "runtime"
+
+    with (
+        patch(
+            "loopx.control_plane.work_items.task_lease_settlement.require_task_lease_owner_allowed",
+            return_value={"status": "open", "claimed_by": TASK_LEASE_FAULT_AGENT},
+        ),
+        patch(
+            "loopx.control_plane.work_items.task_lease_settlement.active_conflicts",
+            return_value=[],
+        ),
+    ):
+        result = execute_task_lease_settlement(
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+            goal_id=TASK_LEASE_FAULT_GOAL,
+            owner=TASK_LEASE_FAULT_AGENT,
+            todo_id=TASK_LEASE_FAULT_TODO,
+            idempotency_key="bad key!",
+            write_scopes=["docs/**"],
+            ttl_seconds=600,
+            acquire=True,
+        )
+
+    assert result.failure is not None
+    assert result.failure.step_kind is SettlementStepKind.VALIDATION
+    assert result.failure.kind is SettlementFailureKind.INVALID_IDENTITY
+    assert result.receipts == ()
+
+
+def test_task_lease_acquire_failure_short_circuits(
+    tmp_path: Path,
+) -> None:
+    """When acquire is rejected, the result must carry failure at DURABLE_WRITEBACK."""
+    registry_path = tmp_path / "registry.json"
+    _write_task_lease_fault_registry(registry_path)
+    runtime_root = tmp_path / "runtime"
+
+    with (
+        patch(
+            "loopx.control_plane.work_items.task_lease_settlement.require_task_lease_owner_allowed",
+            return_value={"status": "open", "claimed_by": TASK_LEASE_FAULT_AGENT},
+        ),
+        patch(
+            "loopx.control_plane.work_items.task_lease_settlement.active_conflicts",
+            return_value=[],
+        ),
+    ):
+        result = execute_task_lease_settlement(
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+            goal_id=TASK_LEASE_FAULT_GOAL,
+            owner=TASK_LEASE_FAULT_AGENT,
+            todo_id=TASK_LEASE_FAULT_TODO,
+            idempotency_key=TASK_LEASE_FAULT_KEY,
+            write_scopes=["docs/**"],
+            ttl_seconds=600,
+            acquire=False,
+        )
+
+    assert result.failure is not None
+    assert result.failure.step_kind is SettlementStepKind.DURABLE_WRITEBACK
+    assert result.failure.kind is SettlementFailureKind.WRITEBACK_REJECTED
+    # Receipts should only contain validation (not acquire)
+    receipt_kinds = {r.step_kind for r in result.receipts}
+    assert SettlementStepKind.DURABLE_WRITEBACK not in receipt_kinds
+
+
+def test_task_lease_effect_id_consistency(
+    tmp_path: Path,
+) -> None:
+    """All receipts within one settlement run must share a single effect_id."""
+    registry_path = tmp_path / "registry.json"
+    _write_task_lease_fault_registry(registry_path)
+    runtime_root = tmp_path / "runtime"
+
+    with (
+        patch(
+            "loopx.control_plane.work_items.task_lease_settlement.require_task_lease_owner_allowed",
+            return_value={"status": "open", "claimed_by": TASK_LEASE_FAULT_AGENT},
+        ),
+        patch(
+            "loopx.control_plane.work_items.task_lease_settlement.active_conflicts",
+            return_value=[],
+        ),
+    ):
+        result = execute_task_lease_settlement(
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+            goal_id=TASK_LEASE_FAULT_GOAL,
+            owner=TASK_LEASE_FAULT_AGENT,
+            todo_id=TASK_LEASE_FAULT_TODO,
+            idempotency_key=TASK_LEASE_FAULT_KEY,
+            write_scopes=["docs/**"],
+            ttl_seconds=600,
+            acquire=True,
+        )
+
+    assert result.failure is None
+    effect_ids = {receipt.effect_id for receipt in result.receipts}
+    assert len(effect_ids) == 1
+    expected_effect_id = (
+        f"{TASK_LEASE_FAULT_GOAL}:{TASK_LEASE_FAULT_AGENT}"
+        f":{TASK_LEASE_FAULT_TODO}:{TASK_LEASE_FAULT_KEY}"
+    )
+    assert effect_ids == {expected_effect_id}

--- a/tests/control_plane/test_effect_program_fault_replay_matrix.py
+++ b/tests/control_plane/test_effect_program_fault_replay_matrix.py
@@ -393,6 +393,14 @@ def test_task_lease_acquire_idempotent_replay(
             "loopx.control_plane.work_items.task_lease_settlement.active_conflicts",
             return_value=[],
         ),
+        patch(
+            "loopx.control_plane.work_items.task_lease.require_task_lease_owner_allowed",
+            return_value={"status": "open", "claimed_by": TASK_LEASE_FAULT_AGENT},
+        ),
+        patch(
+            "loopx.control_plane.work_items.task_lease.active_conflicts",
+            return_value=[],
+        ),
     ):
         first = execute_task_lease_settlement(**common, acquire=acquire_first)
         second = execute_task_lease_settlement(**common, acquire=True)
@@ -426,6 +434,14 @@ def test_task_lease_validation_fails_before_acquire(
         ),
         patch(
             "loopx.control_plane.work_items.task_lease_settlement.active_conflicts",
+            return_value=[],
+        ),
+        patch(
+            "loopx.control_plane.work_items.task_lease.require_task_lease_owner_allowed",
+            return_value={"status": "open", "claimed_by": TASK_LEASE_FAULT_AGENT},
+        ),
+        patch(
+            "loopx.control_plane.work_items.task_lease.active_conflicts",
             return_value=[],
         ),
     ):
@@ -464,6 +480,14 @@ def test_task_lease_acquire_failure_short_circuits(
             "loopx.control_plane.work_items.task_lease_settlement.active_conflicts",
             return_value=[],
         ),
+        patch(
+            "loopx.control_plane.work_items.task_lease.require_task_lease_owner_allowed",
+            return_value={"status": "open", "claimed_by": TASK_LEASE_FAULT_AGENT},
+        ),
+        patch(
+            "loopx.control_plane.work_items.task_lease.active_conflicts",
+            return_value=[],
+        ),
     ):
         result = execute_task_lease_settlement(
             registry_path=registry_path,
@@ -500,6 +524,14 @@ def test_task_lease_effect_id_consistency(
         ),
         patch(
             "loopx.control_plane.work_items.task_lease_settlement.active_conflicts",
+            return_value=[],
+        ),
+        patch(
+            "loopx.control_plane.work_items.task_lease.require_task_lease_owner_allowed",
+            return_value={"status": "open", "claimed_by": TASK_LEASE_FAULT_AGENT},
+        ),
+        patch(
+            "loopx.control_plane.work_items.task_lease.active_conflicts",
             return_value=[],
         ),
     ):

--- a/tests/control_plane/test_effect_program_incident_replay.py
+++ b/tests/control_plane/test_effect_program_incident_replay.py
@@ -4,6 +4,7 @@ import json
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -21,6 +22,9 @@ from loopx.control_plane.turn_driver.settlement import (
 from loopx.control_plane.turn_driver.transaction import (
     TRANSACTION_PHASES,
     build_loopx_turn_transaction_plan,
+)
+from loopx.control_plane.work_items.task_lease_settlement import (
+    execute_task_lease_settlement,
 )
 from loopx.rollout_event_log import rollout_event_log_path
 
@@ -205,6 +209,69 @@ def _replay_quota(case: Mapping[str, Any], runtime_root: Path) -> dict[str, Any]
     return _observe(result, effect_calls=[], checkpoint_steps=[])
 
 
+def _replay_task_lease(
+    case: Mapping[str, Any],
+    runtime_root: Path,
+) -> dict[str, Any]:
+    case_input = case["input"]
+    assert isinstance(case_input, Mapping)
+    registry_path = runtime_root / "registry.json"
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "status": "active",
+                        "repo": str(registry_path.parent),
+                        "state_file": "ACTIVE_GOAL_STATE.md",
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": [AGENT_ID],
+                        },
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    idempotency_key = str(case_input.get("idempotency_key") or TURN_ID)
+    acquire = bool(case_input.get("acquire", True))
+    effect_calls: list[SettlementStepKind] = []
+    checkpoint_steps: list[SettlementStepKind] = []
+
+    with (
+        patch(
+            "loopx.control_plane.work_items.task_lease_settlement.require_task_lease_owner_allowed",
+            return_value={"status": "open", "claimed_by": AGENT_ID},
+        ),
+        patch(
+            "loopx.control_plane.work_items.task_lease_settlement.active_conflicts",
+            return_value=[],
+        ),
+    ):
+        result = execute_task_lease_settlement(
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+            goal_id=GOAL_ID,
+            owner=AGENT_ID,
+            todo_id=TODO_ID,
+            idempotency_key=idempotency_key,
+            write_scopes=["docs/**"],
+            ttl_seconds=600,
+            acquire=acquire,
+        )
+
+    return _observe(
+        result,
+        effect_calls=effect_calls,
+        checkpoint_steps=checkpoint_steps,
+    )
+
+
 def test_incident_replay_corpus_is_small_and_public_safe() -> None:
     corpus = _load_corpus()
 
@@ -236,6 +303,8 @@ def test_generalized_incidents_replay_against_real_adapters(
         observed = _replay_turn_driver(case)
     elif case["adapter"] == "quota":
         observed = _replay_quota(case, tmp_path / str(case["case_id"]))
+    elif case["adapter"] == "task_lease":
+        observed = _replay_task_lease(case, tmp_path / str(case["case_id"]))
     else:
         pytest.fail(f"unsupported incident replay adapter: {case['adapter']}")
 

--- a/tests/control_plane/test_effect_program_incident_replay.py
+++ b/tests/control_plane/test_effect_program_incident_replay.py
@@ -252,6 +252,14 @@ def _replay_task_lease(
             "loopx.control_plane.work_items.task_lease_settlement.active_conflicts",
             return_value=[],
         ),
+        patch(
+            "loopx.control_plane.work_items.task_lease.require_task_lease_owner_allowed",
+            return_value={"status": "open", "claimed_by": AGENT_ID},
+        ),
+        patch(
+            "loopx.control_plane.work_items.task_lease.active_conflicts",
+            return_value=[],
+        ),
     ):
         result = execute_task_lease_settlement(
             registry_path=registry_path,

--- a/tests/control_plane/test_task_lease_cli_settlement.py
+++ b/tests/control_plane/test_task_lease_cli_settlement.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from loopx.cli import build_parser
+from loopx.cli_commands.task_lease import handle_task_lease_command
+from loopx.control_plane.effect_program import (
+    SettlementFailureKind,
+    SettlementReceipt,
+    SettlementResult,
+    SettlementStepKind,
+)
+
+
+def _run_acquire(
+    monkeypatch,
+    result: SettlementResult[dict],
+) -> dict:
+    captured: list[dict] = []
+    import loopx.cli_commands.task_lease as task_lease_cli
+
+    monkeypatch.setattr(
+        task_lease_cli,
+        "execute_task_lease_settlement",
+        lambda **kwargs: result,
+    )
+    args = build_parser().parse_args(
+        [
+            "task-lease",
+            "acquire",
+            "--goal-id",
+            "cli-settlement-goal",
+            "--todo-id",
+            "todo_cli_settlement",
+            "--owner",
+            "codex-cli-agent",
+            "--idempotency-key",
+            "cli-settlement-key",
+            "--ttl-seconds",
+            "300",
+        ]
+    )
+    handle_task_lease_command(
+        args,
+        registry_path=Path("/tmp/registry.json"),
+        runtime_root_arg=None,
+        output_format=lambda _args: "json",
+        print_payload=lambda payload, _fmt, _render: captured.append(payload),
+    )
+    return captured[0]
+
+
+def test_cli_acquire_routes_through_typed_settlement(monkeypatch) -> None:
+    lease = {
+        "goal_id": "cli-settlement-goal",
+        "todo_id": "todo_cli_settlement",
+        "owner": "codex-cli-agent",
+        "version": 1,
+    }
+    result = SettlementResult.pure(
+        lease,
+        receipts=(
+            SettlementReceipt(
+                step_kind=SettlementStepKind.DURABLE_WRITEBACK,
+                status="committed",
+                effect_id="goal:agent:todo:key",
+                source_ref="lease-path",
+            ),
+        ),
+    )
+    payload = _run_acquire(monkeypatch, result)
+    assert payload["ok"] is True
+    assert payload["action"] == "acquire"
+    assert payload["acquired"] is True
+    assert payload["lease"]["version"] == 1
+    assert payload["settlement"]["effect_id"] == "goal:agent:todo:key"
+    assert payload["settlement"]["receipts"][0]["status"] == "committed"
+
+
+def test_cli_acquire_idempotent_replay_payload(monkeypatch) -> None:
+    lease = {"todo_id": "todo_cli_settlement", "owner": "codex-cli-agent"}
+    result = SettlementResult.pure(
+        lease,
+        receipts=(
+            SettlementReceipt(
+                step_kind=SettlementStepKind.DURABLE_WRITEBACK,
+                status="idempotent",
+                effect_id="goal:agent:todo:key",
+                source_ref="lease-path",
+            ),
+        ),
+    )
+    payload = _run_acquire(monkeypatch, result)
+    assert payload["ok"] is True
+    assert payload["acquired"] is False
+    assert payload["idempotent"] is True
+
+
+def test_cli_acquire_typed_failure_payload(monkeypatch) -> None:
+    result = SettlementResult.failed(
+        kind=SettlementFailureKind.INVALID_IDENTITY,
+        step_kind=SettlementStepKind.DURABLE_WRITEBACK,
+        reason="idempotency key was reused with different acquire parameters",
+    )
+    payload = _run_acquire(monkeypatch, result)
+    assert payload["ok"] is False
+    assert payload["error_code"] == "invalid_identity"
+    assert payload["settlement"]["failure"]["step"] == "durable_writeback"
+    assert payload["settlement"]["failure"]["kind"] == "invalid_identity"
+    assert "idempotency" in payload["error"]

--- a/tests/fixtures/control_plane/effect_program_incident_replay_v0.json
+++ b/tests/fixtures/control_plane/effect_program_incident_replay_v0.json
@@ -127,6 +127,49 @@
         ],
         "receipt_identity_count": 1
       }
+    },
+    {
+      "case_id": "task-lease-validation-failure-short-circuits",
+      "adapter": "task_lease",
+      "incident_class": "invalid_identity",
+      "invariant_id": "INV-FAILURE-SHORT-CIRCUIT",
+      "rationale": "An invalid idempotency key must fail validation before any acquire effect writes to disk.",
+      "input": {
+        "idempotency_key": "bad key!",
+        "acquire": true
+      },
+      "expected": {
+        "status": "failure",
+        "failure_kind": "invalid_identity",
+        "failure_step": "validation",
+        "effect_calls": [],
+        "checkpoint_steps": [],
+        "receipt_steps": [],
+        "receipt_identity_count": 0
+      }
+    },
+    {
+      "case_id": "task-lease-acquire-preserves-one-effect-identity",
+      "adapter": "task_lease",
+      "incident_class": "effect_identity_tracking",
+      "invariant_id": "INV-ONE-EFFECT-IDENTITY",
+      "rationale": "A successful task-lease acquire must produce validation and acquire receipts that share a single effect identity.",
+      "input": {
+        "idempotency_key": "replay-turn",
+        "acquire": true
+      },
+      "expected": {
+        "status": "success",
+        "failure_kind": null,
+        "failure_step": null,
+        "effect_calls": [],
+        "checkpoint_steps": [],
+        "receipt_steps": [
+          "validation",
+          "durable_writeback"
+        ],
+        "receipt_identity_count": 1
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Combined PR: #3081 (GH-C82 typed settlement adapter, 3 commits) + a wiring commit that gives the adapter its first **active production call site**.

- `loopx task-lease acquire` now routes through `execute_task_lease_settlement` instead of calling `acquire_task_lease` directly; the owning lock/CAS/idempotency path is unchanged (the adapter wraps it).
- CLI output is additive: `ok/action/acquired/idempotent/lease/lease_path/error` keys are preserved; new `settlement` block carries `effect_id`, `receipts`, and typed `failure.kind/step`.
- Idempotent replay stays a success with `idempotent: true`; same-key/different-params maps to `invalid_identity`; permission and writeback failures map to typed kinds.
- Added CLI-level tests for success, idempotent replay, and typed failure payloads.

## Validation

- New tests + existing `test_task_lease.py`: 25 passed.
- Adapter conformance/fault-replay/incident-replay + CLI argument diagnostics: 140 passed.
- `loopx canary premerge --from-git-diff --git-diff-base origin/main`: 0 failures / 0 warnings.
- `git diff --check` clean.

## Issue Or Task

- Closes # (supersedes #3081's scope-fit evidence gap; #3081 itself remains open on the contributor fork)
- Contributor task ID: GH-C82

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] Test update