### PR TITLE
fix: unblock the first /loopx run on a fresh project

### DIFF
--- a/loopx/agent_onboarding.py
+++ b/loopx/agent_onboarding.py
@@ -339,7 +339,7 @@ def build_agent_onboarding_packet(
     resolved_project = str(inspection["project"])
     resolved_goal_id = str(inspection["goal_id"])
     registry_path = Path(str(inspection["registry"]))
-    registry = read_json(registry_path)
+    registry = read_json(registry_path) if registry_path.exists() else {}
     goal = next(
         (
             item

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -1492,9 +1492,9 @@ def build_start_goal_guided_packet(
                     "--project . "
                     "--role agent "
                     + (
-                        f"--agent-id {shell_arg(str(command_pack.get('agent_id') or ''))} "
+                        f"--claimed-by {shell_arg(str(command_pack.get('agent_id') or ''))} "
                         if command_pack.get("agent_id")
-                        else "--agent-id <agent-id> "
+                        else "--claimed-by <agent-id> "
                     )
                     + "--task-class advancement_task --action-kind <action_kind> "
                     "[--target-key <target_key>] --text '<[P0/P1/P2] ...>'"

--- a/tests/control_plane/test_start_goal_compact_projection.py
+++ b/tests/control_plane/test_start_goal_compact_projection.py
@@ -20,7 +20,11 @@ from loopx.capabilities.issue_fix.candidate_preflight import (
     build_issue_fix_candidate_preflight_packet,
     candidate_preflight_input_contract,
 )
-from loopx.cli import main as cli_main
+from loopx.cli import build_parser, main as cli_main
+from loopx.cli_commands.todo_argument_validation import (
+    validate_shared_todo_options,
+    validate_todo_add_options,
+)
 
 GOAL_ID = "guided-projection-goal"
 AGENT_ID = "codex-guided-projection"
@@ -707,7 +711,7 @@ def test_start_goal_reuses_bound_thread_agent_and_scopes_commands(tmp_path: Path
     assert "bind_thread_identity" not in {
         step["id"] for step in payload["guided_transaction"]["ordered_steps"]
     }
-    assert f"--agent-id {AGENT_ID}" in payload["guided_transaction"]["ordered_steps"][3]["command_template"]
+    assert f"--claimed-by {AGENT_ID}" in payload["guided_transaction"]["ordered_steps"][3]["command_template"]
 
     explicit_override = build_start_goal_guided_packet(
         project=project,
@@ -1335,3 +1339,45 @@ def test_codex_ide_plugin_uses_visible_goal_and_preserves_compact_parity(
     assert legacy["command_pack"]["host_loop_activation"]["host_surface"] == (
         "codex_ide_visible_goal_mode"
     )
+
+
+def _runnable_todo_add_argv(command_template: str) -> list[str]:
+    """Drop the documented optional span so the template can be parsed as argv."""
+    tokens = shlex.split(command_template)
+    assert tokens[0] == "loopx"
+    argv: list[str] = []
+    inside_optional = False
+    for token in tokens[1:]:
+        if inside_optional:
+            inside_optional = not token.endswith("]")
+            continue
+        if token.startswith("["):
+            inside_optional = not token.endswith("]")
+            continue
+        argv.append(token)
+    return argv
+
+
+@pytest.mark.parametrize("agent_id", [AGENT_ID, None])
+def test_guided_write_ordered_todos_template_is_accepted_by_todo_add(
+    tmp_path: Path,
+    agent_id: str | None,
+) -> None:
+    project = _write_connected_project(tmp_path)
+    payload = build_start_goal_guided_packet(
+        project=project,
+        goal_id=GOAL_ID,
+        agent_id=agent_id,
+        cli_bin="loopx",
+        host_surface="codex-app",
+        goal_text=GOAL_TEXT,
+        available_capabilities=["network"],
+    )
+    template = next(
+        step["command_template"]
+        for step in payload["guided_transaction"]["ordered_steps"]
+        if step["id"] == "write_ordered_todos"
+    )
+    args = build_parser().parse_args(_runnable_todo_add_argv(template))
+    validate_shared_todo_options(args)
+    validate_todo_add_options(args)

--- a/tests/test_agent_onboarding_unconnected_project.py
+++ b/tests/test_agent_onboarding_unconnected_project.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from loopx.agent_onboarding import build_agent_onboarding_packet
+
+
+@pytest.mark.parametrize("agent_type", ["claude-code", "codex-app"])
+def test_agent_onboard_serves_a_packet_before_the_project_registry_exists(
+    tmp_path: Path,
+    agent_type: str,
+) -> None:
+    """First-run onboarding must answer, not raise, when .loopx/registry.json is absent."""
+    project = tmp_path / "fresh-project"
+    project.mkdir()
+
+    packet = build_agent_onboarding_packet(project=project, agent_type=agent_type)
+
+    assert packet["ok"] is True
+    assert packet["agent_type"] == agent_type
+    assert not (project / ".loopx" / "registry.json").exists()


### PR DESCRIPTION
## Summary

- `fix(start-goal)`: the guided `write_ordered_todos` template emitted
  `todo add --role agent --agent-id <agent-id>`, which `validate_todo_add_options`
  unconditionally rejects. Following the packet LoopX itself emits therefore failed
  at the first business write, before host-loop activation. Switched to
  `--claimed-by`, matching every sibling `todo add` template.
- `fix(onboarding)`: `build_agent_onboarding_packet` read `.loopx/registry.json`
  unguarded, so `agent-onboard` exited with a raw `FileNotFoundError` traceback on a
  project that is not connected yet — the primary onboarding case. Treat a missing
  registry as an empty one, matching `agent_registry.load_goal_from_registry`.

Three source lines total; the rest is regression coverage.

## Issue Or Task

- Closes #3092
- Contributor task ID: n/a

## Validation

- [x] `python3 -m py_compile loopx/*.py`
- [x] `loopx check --scan-path loopx/ --scan-path tests/ --scan-path examples/ --scan-path docs/` — public boundary scan clean, 2201 files
- [x] Other:
  - `python -m ruff check tests loopx/canary loopx/control_plane loopx/domain_packs loopx/presentation` — all checks passed
  - `python -m mypy` — success, no issues
  - `python examples/control_plane/cli-output-budget-regression-smoke.py` — ok
  - `loopx canary premerge --from-git-diff` — 2/2 catalog canaries passed, 0 failures, 0 manual holds
  - `python -m pytest -q` — full suite run serially on this branch and on `69d9100e`; identical failure sets. 12 pre-existing failures (`test_host_loop_activation.py` traex cases, `test_fine_grained_turn_mode.py`) reproduce unchanged on clean `main` in this environment, plus one flaky subprocess-timeout case that passes when run on its own. No regression attributable to this change.
  - Both new tests were verified to fail on `main` and pass on this branch.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] Test update

## LoopX Area

- [x] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [ ] Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
- [ ] Capability or extension (providers, adapters, skills)
- [ ] Public docs or presentation surface (README, protocols, dashboard)
- [ ] Build, packaging, installer, or CI
- [ ] Host or runtime integration

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.

## Notes On The Regression Test

The new `write_ordered_todos` test does not assert a string. It feeds the emitted
template through `build_parser()` and the real `validate_shared_todo_options` /
`validate_todo_add_options`, covering both the resolved-agent and placeholder
branches. That keeps the generated packet tied to the CLI contract it names rather
than to a snapshot, so this class of drift fails loudly next time.

One existing assertion in `test_start_goal_reuses_bound_thread_agent_and_scopes_commands`
pinned the old `--agent-id` spelling and was updated; its intent (the write-back
command is scoped to the bound lane agent) is preserved by `--claimed-by`.

Happy to split this into two PRs or adjust the approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
