### PR TITLE
fix(task-lease): preserve legacy error codes and conflict payloads in typed CLI

### DIFF
--- a/loopx/cli_commands/task_lease.py
+++ b/loopx/cli_commands/task_lease.py
@@ -143,12 +143,19 @@ def handle_task_lease_command(
                 todo_id=args.todo_id,
             )
             if result.failure is not None:
+                failure_details = result.failure.details
+                original_code = (
+                    str(failure_details.get("task_lease_error_code"))
+                    if isinstance(failure_details, dict)
+                    and failure_details.get("task_lease_error_code")
+                    else result.failure.kind.value
+                )
                 payload = {
                     "ok": False,
                     "schema_version": "task_lease_v0",
                     "action": "acquire",
                     "error": str(result.failure.reason),
-                    "error_code": result.failure.kind.value,
+                    "error_code": original_code,
                     "lease_path": str(lease_path),
                     "settlement": {
                         "effect_id": (
@@ -165,9 +172,15 @@ def handle_task_lease_command(
                         "failure": {
                             "step": result.failure.step_kind.value,
                             "kind": result.failure.kind.value,
+                            "code": original_code,
                         },
                     },
                 }
+                if isinstance(failure_details, dict):
+                    if failure_details.get("conflicts") is not None:
+                        payload["conflicts"] = failure_details["conflicts"]
+                    if failure_details.get("lease") is not None:
+                        payload["lease"] = failure_details["lease"]
             else:
                 lease = result.value if isinstance(result.value, dict) else {}
                 idempotent = any(

--- a/loopx/control_plane/effect_program.py
+++ b/loopx/control_plane/effect_program.py
@@ -139,13 +139,17 @@ class SettlementFailure:
     kind: SettlementFailureKind
     step_kind: SettlementStepKind
     reason: str
+    details: Mapping[str, Any] | None = None
 
-    def as_dict(self) -> dict[str, str]:
-        return {
+    def as_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
             "kind": self.kind.value,
             "step_kind": self.step_kind.value,
             "reason": self.reason,
         }
+        if self.details:
+            result["details"] = dict(self.details)
+        return result
 
 
 T = TypeVar("T")
@@ -175,6 +179,7 @@ class SettlementResult(Generic[T]):
         step_kind: SettlementStepKind,
         reason: str,
         receipts: tuple[SettlementReceipt, ...] = (),
+        details: Mapping[str, Any] | None = None,
     ) -> SettlementResult[T]:
         return cls(
             value=None,
@@ -183,6 +188,7 @@ class SettlementResult(Generic[T]):
                 kind=kind,
                 step_kind=step_kind,
                 reason=reason,
+                details=details,
             ),
         )
 

--- a/loopx/control_plane/work_items/task_lease_settlement.py
+++ b/loopx/control_plane/work_items/task_lease_settlement.py
@@ -51,6 +51,25 @@ def _now_utc() -> datetime:
     return datetime.now(tz=timezone.utc)
 
 
+def _typed_failure(
+    *,
+    kind: SettlementFailureKind,
+    step_kind: SettlementStepKind,
+    reason: str,
+    code: str | None = None,
+) -> SettlementResult[Any]:
+    return SettlementResult.failed(
+        kind=kind,
+        step_kind=step_kind,
+        reason=reason,
+        details=(
+            {"task_lease_error_code": code}
+            if code
+            else None
+        ),
+    )
+
+
 
 def _settlement_identity(
     *,
@@ -146,14 +165,39 @@ def resolve_task_lease_validation(
     """
     try:
         normalized_goal_id = normalize_goal_id(goal_id)
-        normalized_owner = normalize_owner(owner)
-        normalized_todo_id = normalize_lease_todo_id(todo_id)
-        normalized_key = normalize_idempotency_key(idempotency_key)
     except ValueError as exc:
-        return SettlementResult.failed(
+        return _typed_failure(
             kind=SettlementFailureKind.INVALID_IDENTITY,
             step_kind=SettlementStepKind.VALIDATION,
             reason=str(exc),
+            code="invalid_goal_id",
+        )
+    try:
+        normalized_owner = normalize_owner(owner)
+    except ValueError as exc:
+        return _typed_failure(
+            kind=SettlementFailureKind.INVALID_IDENTITY,
+            step_kind=SettlementStepKind.VALIDATION,
+            reason=str(exc),
+            code="invalid_owner",
+        )
+    try:
+        normalized_todo_id = normalize_lease_todo_id(todo_id)
+    except ValueError as exc:
+        return _typed_failure(
+            kind=SettlementFailureKind.INVALID_IDENTITY,
+            step_kind=SettlementStepKind.VALIDATION,
+            reason=str(exc),
+            code="invalid_todo_id",
+        )
+    try:
+        normalized_key = normalize_idempotency_key(idempotency_key)
+    except ValueError as exc:
+        return _typed_failure(
+            kind=SettlementFailureKind.INVALID_IDENTITY,
+            step_kind=SettlementStepKind.VALIDATION,
+            reason=str(exc),
+            code="invalid_idempotency_key",
         )
 
     identity = SettlementIdentity(
@@ -172,10 +216,11 @@ def resolve_task_lease_validation(
             owner=normalized_owner,
         )
     except ValueError as exc:
-        return SettlementResult.failed(
+        return _typed_failure(
             kind=SettlementFailureKind.PERMISSION_DENIED,
             step_kind=SettlementStepKind.VALIDATION,
             reason=str(exc),
+            code=getattr(exc, "code", None),
         )
 
     # --- existing active lease check ---
@@ -205,6 +250,11 @@ def resolve_task_lease_validation(
             kind=SettlementFailureKind.WRITEBACK_REJECTED,
             step_kind=SettlementStepKind.VALIDATION,
             reason="todo already has an active lease with a different owner or key",
+            details={
+                "task_lease_error_code": "todo_lease_conflict",
+                "lease": existing,
+                "lease_path": str(lease_path),
+            },
         )
 
     # --- write-scope conflict check ---
@@ -223,6 +273,10 @@ def resolve_task_lease_validation(
                 kind=SettlementFailureKind.WRITEBACK_REJECTED,
                 step_kind=SettlementStepKind.VALIDATION,
                 reason=f"write scopes overlap {len(conflicts)} active lease(s)",
+                details={
+                    "task_lease_error_code": "write_scope_conflict",
+                    "conflicts": conflicts,
+                },
             )
 
     return SettlementResult.pure(
@@ -260,10 +314,11 @@ def _map_task_lease_error(exc: TaskLeaseError) -> SettlementResult[dict[str, Any
         kind = SettlementFailureKind.PERMISSION_DENIED
     else:
         kind = SettlementFailureKind.WRITEBACK_REJECTED
-    return SettlementResult.failed(
+    return _typed_failure(
         kind=kind,
         step_kind=SettlementStepKind.DURABLE_WRITEBACK,
         reason=str(exc),
+        code=exc.code,
     )
 
 

--- a/tests/control_plane/test_task_lease_cli_settlement.py
+++ b/tests/control_plane/test_task_lease_cli_settlement.py
@@ -101,10 +101,12 @@ def test_cli_acquire_typed_failure_payload(monkeypatch) -> None:
         kind=SettlementFailureKind.INVALID_IDENTITY,
         step_kind=SettlementStepKind.DURABLE_WRITEBACK,
         reason="idempotency key was reused with different acquire parameters",
+        details={"task_lease_error_code": "idempotency_key_reuse"},
     )
     payload = _run_acquire(monkeypatch, result)
     assert payload["ok"] is False
-    assert payload["error_code"] == "invalid_identity"
+    assert payload["error_code"] == "idempotency_key_reuse"
     assert payload["settlement"]["failure"]["step"] == "durable_writeback"
     assert payload["settlement"]["failure"]["kind"] == "invalid_identity"
+    assert payload["settlement"]["failure"]["code"] == "idempotency_key_reuse"
     assert "idempotency" in payload["error"]


### PR DESCRIPTION
## Summary

Follow-up to #3091: routing `loopx task-lease acquire` through the typed settlement adapter changed `error_code` from task-lease-specific codes (`write_scope_conflict`, `todo_lease_conflict`, `idempotency_key_reuse`, …) to generic typed kinds, breaking `examples/control_plane/task-lease-runtime-smoke.py` (Full Public shard-3 regression on main 111f7ff).

Changes:
- `SettlementFailure` gains an optional `details` mapping (default `None`) so adapters can carry provider-specific codes without changing shared quota/Turn semantics.
- `resolve_task_lease_validation` attaches original task-lease codes for normalization, permission, lease-conflict, and write-scope-conflict failures; conflict and lease details are surfaced again in the CLI payload.
- CLI keeps `error_code` parity (original code when present, typed kind as fallback) and adds `settlement.failure.code`.
- Tests updated for idempotency-key reuse with the original code.

## Validation

- `examples/control_plane/task-lease-runtime-smoke.py`: ok (the exact CI-failing smoke).
- `test_task_lease_cli_settlement` + `test_task_lease` + effect-program conformance/fault-replay/incident-replay: 82 passed.
- `git diff --check` clean; public-boundary scan clean (3 files).
- Note: full `canary premerge` shows 1 pre-existing local timeout (`refresh-state-write-correctness-smoke.py` needs ~5.5 min locally vs the 120 s canary cap; unchanged by this PR and passing under CI limits).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] Test update