### PR TITLE
fix(test): include scope_fit evidence in pr-review contract test

### DIFF
--- a/tests/capabilities/test_pr_review_contract.py
+++ b/tests/capabilities/test_pr_review_contract.py
@@ -41,6 +41,7 @@ def test_execution_contract_owns_deep_review_requirements() -> None:
         "problem_context",
         "architecture_flow",
         "changed_line_classification",
+        "scope_fit",
         "symbol_map",
         "walkthroughs",
         "validation_matrix",
@@ -70,8 +71,10 @@ def test_runtime_plan_requires_symbol_map_and_negative_walkthrough() -> None:
     }
     assert plan["applicability"]["code_change"] is True
     assert plan["applicability"]["symbol_map_required"] is True
+    assert plan["applicability"]["scope_fit_required"] is True
     assert plan["applicability"]["negative_walkthrough_required"] is True
     assert "symbol_map" in plan["required_evidence_ids"]
+    assert "scope_fit" in plan["required_evidence_ids"]
     assert set(plan["result_template"]["evidence"]) == set(
         plan["required_evidence_ids"]
     )
@@ -90,7 +93,9 @@ def test_docs_plan_does_not_invent_code_symbols() -> None:
 
     assert plan["applicability"]["docs_only"] is True
     assert plan["applicability"]["symbol_map_required"] is False
+    assert plan["applicability"]["scope_fit_required"] is False
     assert "symbol_map" not in plan["required_evidence_ids"]
+    assert "scope_fit" not in plan["required_evidence_ids"]
     concrete = next(
         section for section in template["sections"] if section["label"] == "具体改动"
     )


### PR DESCRIPTION
## Summary

#3090 added the `scope_fit` evidence requirement to the pr-review execution contract but missed the exact-set assertion in `tests/capabilities/test_pr_review_contract.py`, which broke Python Tests on main (0cb8ef4: 1 failed / 2731 passed).

Changes (single test file):
- add `scope_fit` to the expected evidence-requirement set;
- assert `scope_fit_required` true for code-change plans and false for docs-only plans;
- assert `scope_fit` membership in code-change `required_evidence_ids` and absence in docs-only plans.

## Validation

- `tests/capabilities/test_pr_review_contract.py`: 3 passed.
- `examples/pr-review-command-smoke.py`: ok.
- `git diff --check` clean.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] Test update