### PR TITLE
feat(control-plane): add replan novelty guidance and evidence-log read policy

### DIFF
--- a/loopx/control_plane/goals/goal_frontier/__init__.py
+++ b/loopx/control_plane/goals/goal_frontier/__init__.py
@@ -19,6 +19,7 @@ from ...work_items.autonomous_replan_ack import (
 )
 from ...work_items.autonomous_replan_obligation import (
     MONITOR_NO_CHANGE_STREAK_THRESHOLD,
+    REPLAN_NOVELTY_GUIDANCE,
     build_autonomous_replan_obligation_payload,
 )
 from ...work_items.repair_delta import (
@@ -222,6 +223,7 @@ def align_autonomous_replan_guidance_with_acceptance_policy(
         "create or claim one safe in-scope runnable advancement todo, or record "
         "an explicit successor/supersede transition; watch-lane continuation "
         "alone does not satisfy a repeat-until-closed vision"
+        + REPLAN_NOVELTY_GUIDANCE
     )
     aligned["satisfying_repair_delta_kinds"] = list(
         REPEAT_VISION_REPLAN_SATISFYING_DELTA_KINDS
@@ -1906,6 +1908,8 @@ def compact_replan_obligation(replan_obligation: dict[str, Any]) -> dict[str, An
         compact["agent_todo_writeback_required"] = True
     if replan_obligation.get("frontier_identity"):
         compact["frontier_identity"] = replan_obligation.get("frontier_identity")
+    if isinstance(replan_obligation.get("replan_novelty_policy"), dict):
+        compact["replan_novelty_policy"] = replan_obligation["replan_novelty_policy"]
     if isinstance(replan_obligation.get("replan_ack_feedback"), dict):
         compact["replan_ack_feedback"] = replan_obligation["replan_ack_feedback"]
         compact["recommended_action"] = replan_obligation.get("recommended_action")

--- a/loopx/control_plane/quota/should_run_packet.py
+++ b/loopx/control_plane/quota/should_run_packet.py
@@ -1121,7 +1121,8 @@ def _quota_required_reads(decision: dict[str, Any]) -> list[dict[str, Any]]:
         agent_id=quota_decision_agent_id(decision),
         reason=(
             "read recent public-safe evidence across this agent lane before "
-            "replan; if local evidence is thin, use bounded public-safe search"
+            "replan; avoid repeating already-covered directions; use bounded "
+            "public-safe search when local evidence is thin"
         ),
     )
     return [read] if read else []

--- a/loopx/control_plane/work_items/autonomous_replan_obligation.py
+++ b/loopx/control_plane/work_items/autonomous_replan_obligation.py
@@ -24,6 +24,22 @@ SectionEntries = Callable[[list[str]], list[str]]
 
 MAX_AUTONOMOUS_REPLAN_TRIGGERS = 3
 AUTONOMOUS_REPLAN_STALL_THRESHOLD = 2
+REPLAN_NOVELTY_POLICY_SCHEMA_VERSION = "replan_novelty_policy_v0"
+# Generic agent-facing guidance appended to every autonomous replan
+# recommended_action. It is deliberately surface-neutral: it tells the agent
+# to consult its own evidence ledger, prefer an untried direction, and only
+# close on an explicit coverage-backed terminal state instead of restating an
+# already-tried action or blocker.
+REPLAN_NOVELTY_GUIDANCE = (
+    " Review the agent-scoped evidence log first (required_reads carries the "
+    "exact `loopx evidence-log` command), then keep proposing new approaches: "
+    "prefer a direction not already covered by recent runs, such as a new "
+    "surface, method, parameter combination, validation command, or hypothesis. "
+    "Do not repeat an already-tried action or restate the same blocker. If no "
+    "new direction remains, list which surfaces and combinations are already "
+    "covered and record an explicit exploration_exhausted blocker with that "
+    "coverage evidence."
+)
 # Unchanged-poll streak before a monitor-only lane is forced to replan. Kept
 # deliberately above the 2-turn run-history stall threshold: quiet monitors
 # legitimately wait several cadence cycles for external evidence, and forcing
@@ -572,22 +588,26 @@ def build_autonomous_replan_obligation(
             "run a bounded autonomous replan for the exact blocked successor: "
             "promote one safe in-scope evidence-backed successor when available; "
             "otherwise record a no-spend wait continuation for this frontier"
+            + REPLAN_NOVELTY_GUIDANCE
         )
     elif dead_monitor_evidence:
         recommended_action = (
             "resolve a dead monitor loop: record watch-lane continuation with expiry, "
             "a concrete blocker, todo supersede, or successor runnable todo before "
             "another quiet monitor poll"
+            + REPLAN_NOVELTY_GUIDANCE
         )
     elif any(item.get("kind") in {"periodic_review", "periodic_review_due"} for item in evidence):
         recommended_action = (
             "run a bounded autonomous periodic review: keep, split, add, retire, or ask for "
             "a decision; then update todos and select the next validated slice"
+            + REPLAN_NOVELTY_GUIDANCE
         )
     else:
         recommended_action = (
             "run an autonomous replan after two consecutive stalled turns before another "
             "monitor-only or repeated action consumes the eligible turn"
+            + REPLAN_NOVELTY_GUIDANCE
         )
 
     extra_fields: dict[str, Any] = {}
@@ -608,6 +628,29 @@ def build_autonomous_replan_obligation(
         extra_fields["frontier_identity"] = dead_monitor_evidence.get(
             "monitor_target_id"
         )
+    repeated_stall = bool(
+        blocked_successor_evidence
+        or dead_monitor_evidence
+        or any(
+            item.get("kind")
+            in {"run_history_no_progress_repeat", "no_progress_streak", "repeated_action_loop"}
+            for item in evidence
+        )
+    )
+    extra_fields["replan_novelty_policy"] = {
+        "schema_version": REPLAN_NOVELTY_POLICY_SCHEMA_VERSION,
+        "review_evidence_log": True,
+        "prefer_unattempted_direction": True,
+        "repeated_blocker_restatement_rejected": repeated_stall,
+        "no_new_direction_closure": (
+            ["watch_lane_expiry", "exploration_exhausted_with_coverage_evidence"]
+            if dead_monitor_evidence
+            else [
+                "exploration_exhausted_with_coverage_evidence",
+                "explicit_terminal_blocker_or_no_followup",
+            ]
+        ),
+    }
 
     result = build_autonomous_replan_obligation_payload(
         schema_version=autonomous_replan_schema_version,

--- a/tests/control_plane/test_replan_novelty_policy.py
+++ b/tests/control_plane/test_replan_novelty_policy.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from loopx.control_plane.goals.goal_frontier import (
+    align_autonomous_replan_guidance_with_acceptance_policy,
+    compact_replan_obligation,
+)
+from loopx.status import (
+    DEAD_MONITOR_REPEAT_THRESHOLD,
+    build_autonomous_replan_obligation,
+)
+
+
+def _obligation(evidence: list[dict[str, object]]) -> dict:
+    obligation = build_autonomous_replan_obligation(evidence, agent_todos=None)
+    assert obligation is not None, obligation
+    return obligation
+
+
+def test_generic_stall_obligation_carries_novelty_guidance() -> None:
+    obligation = _obligation(
+        [
+            {
+                "kind": "run_history_no_progress_repeat",
+                "section": "run_history",
+                "text": "two stalled turns repeated the same action",
+            }
+        ]
+    )
+
+    policy = obligation["replan_novelty_policy"]
+    assert policy["schema_version"] == "replan_novelty_policy_v0"
+    assert policy["review_evidence_log"] is True
+    assert policy["prefer_unattempted_direction"] is True
+    assert policy["repeated_blocker_restatement_rejected"] is True
+    assert "exploration_exhausted_with_coverage_evidence" in policy[
+        "no_new_direction_closure"
+    ]
+
+    action = obligation["recommended_action"]
+    assert "evidence log" in action
+    assert "not already covered" in action
+    assert "Do not repeat an already-tried action" in action
+    assert "exploration_exhausted" in action
+
+
+def test_dead_monitor_obligation_policy_adds_watch_expiry_closure() -> None:
+    obligation = _obligation(
+        [
+            {
+                "kind": "dead_monitor_repeat",
+                "monitor_target_id": "stable-monitor-target",
+                "run_count": DEAD_MONITOR_REPEAT_THRESHOLD,
+                "threshold": DEAD_MONITOR_REPEAT_THRESHOLD,
+            }
+        ]
+    )
+
+    policy = obligation["replan_novelty_policy"]
+    assert policy["repeated_blocker_restatement_rejected"] is True
+    assert policy["no_new_direction_closure"] == [
+        "watch_lane_expiry",
+        "exploration_exhausted_with_coverage_evidence",
+    ]
+    action = obligation["recommended_action"]
+    assert "resolve a dead monitor loop" in action
+    assert "evidence log" in action
+
+
+def test_periodic_review_obligation_policy_is_not_repeated_stall() -> None:
+    obligation = _obligation(
+        [
+            {
+                "kind": "periodic_review_due",
+                "section": "run_history",
+                "text": "periodic review threshold reached",
+            }
+        ]
+    )
+
+    policy = obligation["replan_novelty_policy"]
+    assert policy["repeated_blocker_restatement_rejected"] is False
+    assert policy["review_evidence_log"] is True
+    action = obligation["recommended_action"]
+    assert "bounded autonomous periodic review" in action
+    assert "evidence log" in action
+
+
+def test_aligned_repeat_until_closed_guidance_keeps_novelty_hint() -> None:
+    obligation = _obligation(
+        [
+            {
+                "kind": "blocked_successor_no_progress_repeat",
+                "section": "run_history",
+                "text": "exact blocked successor waits repeated",
+                "frontier_identity": "stable-frontier",
+            }
+        ]
+    )
+    aligned = align_autonomous_replan_guidance_with_acceptance_policy(
+        obligation,
+        acceptance_gaps=[
+            {
+                "kind": "vision_acceptance_gap",
+                "advancement_policy": "repeat_until_closed",
+            }
+        ],
+    )
+    assert aligned is not None
+    assert "watch-lane continuation alone does not satisfy" in aligned[
+        "recommended_action"
+    ]
+    assert "evidence log" in aligned["recommended_action"]
+    assert aligned["replan_novelty_policy"]["repeated_blocker_restatement_rejected"]
+
+
+def test_compact_replan_obligation_preserves_novelty_policy() -> None:
+    obligation = _obligation(
+        [
+            {
+                "kind": "run_history_no_progress_repeat",
+                "section": "run_history",
+                "text": "two stalled turns repeated the same action",
+            }
+        ]
+    )
+    compact = compact_replan_obligation(obligation)
+    assert compact["replan_novelty_policy"] == obligation["replan_novelty_policy"]


### PR DESCRIPTION
## Summary

Long-running exploration goals can burn repeated turns on already-covered directions. The existing replan packet already carries an `agent_scoped_evidence_log` required read, but it lives outside the primary `recommended_action` text, so agents rarely act on it.

This PR makes the replan contract explicit on both layers:

1. **Prompt layer** — every autonomous replan `recommended_action` (generic stall, blocked successor, dead monitor, periodic review, and the repeat-until-closed aligned variant) now appends generic novelty guidance: review the agent-scoped evidence log first, prefer an untried direction (surface / method / parameter / validation command / hypothesis), do not restate an already-tried action or blocker, and if no new direction remains, list covered evidence and record an explicit `exploration_exhausted` blocker.
2. **Structured layer (minimal)** — the obligation payload now carries a compact `replan_novelty_policy` field (`review_evidence_log`, `prefer_unattempted_direction`, `repeated_blocker_restatement_rejected`, `no_new_direction_closure`), and `compact_replan_obligation` preserves it so it survives status compaction. The quota required-read reason is aligned to the same novelty wording.

No enforcement or validation behavior changes: the existing stall-fingerprint / new-direction / `exploration_exhausted` machinery stays untouched.

## Validation

- `tests/control_plane/test_replan_novelty_policy.py` — 5 new focused tests
- `pytest tests/control_plane` — 1031 passed; 2 failures are pre-existing environment issues (`scripts/loopx` resolves Python 3.9, LoopX requires 3.11+), unrelated to this diff
- `examples/autonomous-replan-obligation-smoke.py`, `examples/control_plane/autonomous-replan-obligation-readmodel-smoke.py`, `examples/control_plane/quota-replan-decision-plane-smoke.py` — ok
- `ruff check --select F` on all changed files — passed

## Scope

No private state, credentials, local paths, or benchmark evidence included.