### PR TITLE
feat(control-plane): cover frontier-derived replan obligations with novelty guidance

### DIFF
--- a/loopx/control_plane/testing/cli_output_budget.py
+++ b/loopx/control_plane/testing/cli_output_budget.py
@@ -216,7 +216,7 @@ CLI_OUTPUT_BUDGET_SPECS: tuple[CliOutputBudgetSpec, ...] = (
             "multi_agent": {"json": 480, "markdown": 72},
         },
         scale_axis="todo_count",
-        max_json_growth_chars_per_unit=360,
+        max_json_growth_chars_per_unit=520,
     ),
     CliOutputBudgetSpec(
         surface_id="review_packet_handoff_only",

--- a/loopx/control_plane/work_items/autonomous_replan_obligation.py
+++ b/loopx/control_plane/work_items/autonomous_replan_obligation.py
@@ -588,26 +588,22 @@ def build_autonomous_replan_obligation(
             "run a bounded autonomous replan for the exact blocked successor: "
             "promote one safe in-scope evidence-backed successor when available; "
             "otherwise record a no-spend wait continuation for this frontier"
-            + REPLAN_NOVELTY_GUIDANCE
         )
     elif dead_monitor_evidence:
         recommended_action = (
             "resolve a dead monitor loop: record watch-lane continuation with expiry, "
             "a concrete blocker, todo supersede, or successor runnable todo before "
             "another quiet monitor poll"
-            + REPLAN_NOVELTY_GUIDANCE
         )
     elif any(item.get("kind") in {"periodic_review", "periodic_review_due"} for item in evidence):
         recommended_action = (
             "run a bounded autonomous periodic review: keep, split, add, retire, or ask for "
             "a decision; then update todos and select the next validated slice"
-            + REPLAN_NOVELTY_GUIDANCE
         )
     else:
         recommended_action = (
             "run an autonomous replan after two consecutive stalled turns before another "
             "monitor-only or repeated action consumes the eligible turn"
-            + REPLAN_NOVELTY_GUIDANCE
         )
 
     extra_fields: dict[str, Any] = {}
@@ -706,7 +702,10 @@ def build_autonomous_replan_obligation_payload(
     agent_id: str | None = None,
     include_agent_id: bool = False,
     extra_fields: dict[str, Any] | None = None,
+    include_novelty_guidance: bool = True,
 ) -> dict[str, Any]:
+    if include_novelty_guidance:
+        recommended_action = recommended_action + REPLAN_NOVELTY_GUIDANCE
     payload: dict[str, Any] = {
         "schema_version": schema_version,
         "required": True,
@@ -717,6 +716,16 @@ def build_autonomous_replan_obligation_payload(
         "todo_actions": todo_actions,
         "stop_condition": stop_condition,
         "recommended_action": recommended_action,
+    }
+    payload["replan_novelty_policy"] = {
+        "schema_version": REPLAN_NOVELTY_POLICY_SCHEMA_VERSION,
+        "review_evidence_log": True,
+        "prefer_unattempted_direction": True,
+        "repeated_blocker_restatement_rejected": False,
+        "no_new_direction_closure": [
+            "exploration_exhausted_with_coverage_evidence",
+            "explicit_terminal_blocker_or_no_followup",
+        ],
     }
     if include_agent_id or agent_id is not None:
         payload["agent_id"] = agent_id

--- a/tests/control_plane/test_replan_novelty_policy.py
+++ b/tests/control_plane/test_replan_novelty_policy.py
@@ -4,6 +4,9 @@ from loopx.control_plane.goals.goal_frontier import (
     align_autonomous_replan_guidance_with_acceptance_policy,
     compact_replan_obligation,
 )
+from loopx.control_plane.work_items.autonomous_replan_obligation import (
+    build_autonomous_replan_obligation_payload,
+)
 from loopx.status import (
     DEAD_MONITOR_REPEAT_THRESHOLD,
     build_autonomous_replan_obligation,
@@ -125,3 +128,49 @@ def test_compact_replan_obligation_preserves_novelty_policy() -> None:
     )
     compact = compact_replan_obligation(obligation)
     assert compact["replan_novelty_policy"] == obligation["replan_novelty_policy"]
+
+
+def test_payload_builder_defaults_to_novelty_guidance_and_policy() -> None:
+    payload = build_autonomous_replan_obligation_payload(
+        schema_version="autonomous_replan_obligation_v0",
+        stall_threshold=1,
+        trigger_count=1,
+        triggers=[],
+        guidance_actions=["create_successor"],
+        todo_actions=[],
+        stop_condition="stop on owner-only authority",
+        recommended_action="run a bounded frontier replan",
+    )
+
+    assert "evidence log" in payload["recommended_action"]
+    assert "prefer a direction not already covered" in payload["recommended_action"]
+    policy = payload["replan_novelty_policy"]
+    assert policy["review_evidence_log"] is True
+    assert policy["repeated_blocker_restatement_rejected"] is False
+
+
+def test_payload_builder_extra_fields_override_novelty_policy() -> None:
+    payload = build_autonomous_replan_obligation_payload(
+        schema_version="autonomous_replan_obligation_v0",
+        stall_threshold=1,
+        trigger_count=1,
+        triggers=[],
+        guidance_actions=[],
+        todo_actions=[],
+        stop_condition="stop on owner-only authority",
+        recommended_action="run a bounded replan",
+        extra_fields={
+            "replan_novelty_policy": {
+                "schema_version": "replan_novelty_policy_v0",
+                "review_evidence_log": True,
+                "prefer_unattempted_direction": True,
+                "repeated_blocker_restatement_rejected": True,
+                "no_new_direction_closure": ["watch_lane_expiry"],
+            }
+        },
+    )
+
+    assert payload["replan_novelty_policy"]["repeated_blocker_restatement_rejected"]
+    assert payload["replan_novelty_policy"]["no_new_direction_closure"] == [
+        "watch_lane_expiry"
+    ]


### PR DESCRIPTION
## Summary

Follow-up to #3100. The first PR attached the replan novelty guidance (review the agent-scoped evidence log, prefer an untried direction, don't restate the same blocker, close only with coverage-backed `exploration_exhausted`) and the compact `replan_novelty_policy` field to the run-history stall obligation builder.

This PR moves that behavior into `build_autonomous_replan_obligation_payload` so **every** replan obligation gets the same guidance and policy by default, including the goal-frontier derived paths that were previously missed:

- `vision_acceptance_gap` (standard and fine-grained checkpoint replan)
- `todo_succession_gap`
- `long_todo_chain`
- `monitor_no_change_streak`
- `monitor_frontier_exhausted`

The run-history stall builder keeps its trigger-specific policy override (e.g. `watch_lane_expiry` for dead monitors, `repeated_blocker_restatement_rejected=true` for repeated stalls); callers can also opt out via `include_novelty_guidance=False`.

`diagnose` output now carries the larger obligation text per goal, so its explicit output-growth budget is raised from 360 to 520 chars/unit (the ratchet measured 457 chars/unit on the growth fixture).

## Validation

- `tests/control_plane/test_replan_novelty_policy.py` — 7 focused tests (payload-builder default + override included)
- impacted control-plane pytest files — 88 passed
- `test_cli_output_budget.py` — 15 passed
- `autonomous-replan-obligation-smoke`, `autonomous-replan-obligation-readmodel-smoke`, `quota-replan-decision-plane-smoke`, `heartbeat-quota-flow-smoke`, `review-packet-cli-smoke` — ok
- `ruff check --select F` on all changed files — passed

No private state, credentials, local paths, or benchmark evidence included.