### PR TITLE
refactor(replan): bind evidence-log to the novelty policy

### DIFF
--- a/docs/development/testing-and-quality.md
+++ b/docs/development/testing-and-quality.md
@@ -287,11 +287,39 @@ nonzero unless every real provider call passes. See
 [Model behavior qualification v0](../reference/protocols/model-behavior-qualification-v0.md)
 for the actor and promotion contract.
 
+Replan evidence preflight has a separate function-tool qualification because a
+no-tool JSON decision cannot prove that the model would perform a shell read.
+It gives the live model the shipped thin Codex App heartbeat task body and one
+ordinary `exec_command` function tool. The bounded host loop returns the
+production `quota should-run` fixture only after the model requests that command
+and passes only when the model subsequently calls the exact evidence-log
+command projected by `required_reads[0]`:
+
+```bash
+python3 scripts/qualify-doubao-replan-evidence-tool-live.py \
+  --qualification-id <public-safe-run-id>
+```
+
+The model does not receive a testing-only decision schema, required-read index,
+or expected command. Clock and a small set of workspace reads are supported so
+the model can follow the normal heartbeat preflight. No shell command is
+executed, the loop stops at the matching evidence-log intent, and the receipt
+retains only action kinds and command digests. Fake transports validate the
+tool protocol and negative cases; only a real provider run qualifies behavior.
+
 真实 Doubao 调用是低频本地/手动门，不进入普通 CI。`ARK_API_KEY` 只通过进程环境
 注入；packet、prompt、原始响应、凭证和对话都不能成为仓库证据，只保留有界 receipt
 与 mismatch code。fake transport 只能验证 adapter 的序列化、脱敏与 fail-closed，不能
 作为 Doubao 行为通过证据。真实入口缺少密钥时直接失败，且任一真实调用不通过都会以
 非零状态退出。
+
+replan evidence preflight 另有一条 function-tool 行为资格门，因为 no-tool JSON 决策
+不能证明模型真的会发起 shell read。真实模型只看到正式的 thin Codex App heartbeat
+task body 和普通 `exec_command` tool；它先自行请求生产 `quota should-run`，宿主再回送
+正式 fixture，随后只有模型实际调用 `required_reads[0]` 投影的精确 evidence-log 命令
+才算通过。模型看不到测试专用 decision schema、required-read index 或预期命令。
+clock 与少量 workspace read 允许正常 preflight；宿主不执行任何 shell 命令，在匹配
+evidence-log 意图时立即停止，只在 receipt 中保留 action kind 与 command digest。
 
 The regular live suite is
 `actual_default_model_behavior_portfolio_v0`: fifteen one-arm scenarios, two

--- a/docs/reference/protocols/agent-scoped-evidence-ledger-v0.md
+++ b/docs/reference/protocols/agent-scoped-evidence-ledger-v0.md
@@ -19,10 +19,10 @@ jobs:
 | `loopx status` | Projects current state, todo index, attention queues, agent lanes, run history, and event summaries. | It answers "what is true now", not "what sequence should this agent review before replanning". |
 | `loopx review-packet` | Packages status and attention items for review or handoff. | It is packet-shaped, not a general scoped event ledger. |
 | `loopx history` | Reads compact run history and run indexes. | It is run-centric and not equivalent to rollout events. |
-| `loopx quota should-run --agent-id ...` | Decides whether a specific agent lane should act. | It can route work by agent, but does not expose a standard per-agent evidence read. |
+| `loopx quota should-run --agent-id ...` | Decides whether a specific agent lane should act and materializes the evidence source requested by `replan_novelty_policy`. | A standalone required-read hint has insufficient prompt salience and is not a replan control mechanism. |
 
-The missing surface is a public-safe, bounded, agent-scoped ledger that an agent
-can read before replanning.
+The resulting surface is a public-safe, bounded, agent-scoped ledger that an
+agent can read before replanning.
 
 ## Ownership Boundary
 
@@ -31,35 +31,34 @@ can read before replanning.
 | Event sources | Durable append-only events, compact run records, ids, timestamps, and public-safe refs. | Prompt-ready planning summaries or cross-agent privacy policy. |
 | Status and review packets | Current projections, attention queues, frontier summaries, and operator packets. | Raw chronological replay or write authority. |
 | Quota | Lane routing, spend policy, scheduler hints, and required read hints. | Reconstructing history itself or storing replan rationale. |
-| Agent-scoped evidence ledger | Thin chronological rows for the current agent plus compressed frontier for other agents. | Canonical writes, raw logs, raw trajectories, private documents, or full other-agent traces. |
-| Acting agent | Reads its scoped ledger before replan or handoff and cites the digest in writeback. | Inferring hidden context from another agent's private lane. |
+| Agent-scoped evidence ledger | Thin chronological rows for the current agent plus compressed frontier for other agents. | Replan selection policy, repair-delta validation, canonical writes, raw logs, raw trajectories, private documents, or full other-agent traces. |
+| Replan novelty policy | Makes evidence preflight and uncovered-direction selection prompt-visible. | Reimplementing blocker fingerprints, successor validation, or terminal-closure truth. |
+| Repair delta | Validates the durable replan writeback, including repeated-blocker rejection and coverage-backed `exploration_exhausted`. | Reconstructing the evidence ledger. |
+| Acting agent | Executes projected required reads, selects an uncovered direction, and submits the resulting repair delta. | Treating a read receipt alone as progress or inferring hidden context from another agent's private lane. |
 
 ## Read Model Shape
 
-The first implementation should return JSON and may render Markdown later:
+The CLI payload uses the shipped `agent_scoped_evidence_log_v0` schema (the
+protocol name describes the ledger concept rather than a second wire schema):
 
 ```json
 {
-  "schema_version": "agent_scoped_evidence_ledger_v0",
+  "schema_version": "agent_scoped_evidence_log_v0",
   "goal_id": "example-goal",
   "agent_id": "codex-evidence-peer",
-  "generated_at": "2026-07-05T00:00:00Z",
-  "source": {
-    "rollout_event_log": true,
-    "run_history": true,
-    "todo_projection": true
-  },
-  "scope": {
-    "current_agent_detail": true,
-    "other_agent_detail": "compressed_frontier"
-  },
-  "filters": {
-    "todo_id": null,
-    "event_kind": null,
-    "since": null,
-    "limit": 30
-  },
-  "events": [
+  "mode": "thin",
+  "todo_id": null,
+  "since": null,
+  "event_kinds": [],
+  "limit": 30,
+  "matched_count": 1,
+  "ledger_count": 1,
+  "truncated": false,
+  "source_refs": [
+    "rollout_event_log.public_safe_view",
+    "compact_run_history.public_refs"
+  ],
+  "ledger": [
     {
       "event_id": "evt_123",
       "recorded_at": "2026-07-05T00:00:00Z",
@@ -69,30 +68,27 @@ The first implementation should return JSON and may render Markdown later:
       "todo_id": "todo_123",
       "classification": "implementation_batch",
       "status": "open",
-      "summary": "P0 implementation frontier was split into a design contract and a CLI read model.",
-      "evidence_refs": ["docs/reference/protocols/agent-scoped-evidence-ledger-v0.md"],
-      "boundary": {
-        "raw_logs_recorded": false,
-        "raw_trajectory_recorded": false,
-        "credential_values_recorded": false,
-        "absolute_paths_recorded": false
+      "summary": "P0 implementation frontier was split into a design contract and a CLI read model."
+    }
+  ],
+  "other_agent_frontier": {
+    "schema_version": "other_agent_frontier_v0",
+    "policy": "goal_frontier_only",
+    "item_count": 1,
+    "items": [
+      {
+        "agent_id": "codex-main-control",
+        "source": "run_history",
+        "classification": "validated_progress"
       }
-    }
-  ],
-  "other_agent_frontier": [
-    {
-      "agent_id": "codex-main-control",
-      "vision_summary": "Owns the currently claimed runtime validation slice.",
-      "top_todo": "Validate the next control-plane PR batch.",
-      "handoff_state": "no_handoff_required",
-      "latest_material_at": "2026-07-05T00:00:00Z"
-    }
-  ],
-  "reader_hints": {
-    "required_before": ["autonomous_replan", "successor_replan", "handoff"],
-    "next_required_reads": [
-      "loopx evidence-log --goal-id example-goal --agent-id codex-evidence-peer --thin --limit 30"
     ]
+  },
+  "boundary": {
+    "raw_logs_recorded": false,
+    "raw_trajectory_recorded": false,
+    "credential_values_recorded": false,
+    "absolute_paths_recorded": false,
+    "other_agent_event_stream_expanded": false
   }
 }
 ```
@@ -102,22 +98,24 @@ in a prompt, and stable enough for quota/replan tests.
 
 ## CLI Contract
 
-The first public CLI can be read-only:
+The public CLI is read-only:
 
 ```bash
-loopx evidence-log --goal-id <goal-id> --agent-id <agent-id> --thin --limit 30
+loopx --format json evidence-log --goal-id <goal-id> --agent-id <agent-id> --thin --limit 30
 ```
 
 Supported filters:
 
 | Option | Meaning |
 | --- | --- |
-| `--todo-id <todo-id>` | Return rows tied to one todo plus goal-level rows that block it. |
+| `--todo-id <todo-id>` | Filter rollout events by exact todo id and compact runs by bounded todo mention. |
 | `--since <iso8601>` | Return rows recorded after a timestamp. |
 | `--event-kind <kind>` | Filter rollout event kinds such as `todo_update`, `quota_should_run`, or `validation`. |
-| `--include-other-agent-frontier` | Include compressed other-agent frontier rows. This should be on by default for replan packets, but not expand other-agent detail. |
 | `--limit <n>` | Bound rows after filtering. Default should be small enough for an agent prompt. |
-| `--format json` | Emit the schema above. Markdown can be a later convenience view. |
+| `--history-limit <n>` | Bound compact run-history rows scanned before filtering. |
+| `--rollout-limit <n>` | Bound rollout-event rows scanned from the tail before filtering. |
+| `--thin` | Select the only current public-safe mode; accepted explicitly for readable generated commands. |
+| global `--format json\|markdown` | Select JSON or the compact Markdown rendering. |
 
 The command must fail closed on missing `goal_id` or `agent_id`. A vague
 surface value such as `codex` should not silently fall into `other-agent`
@@ -126,22 +124,20 @@ separate host surface such as `codex-app`, `codex-cli`, `opencode`, or `claude-c
 
 ## Scoping Rules
 
-The current agent gets detailed rows when any of these are true:
+The current implementation returns detailed rows under these deterministic
+rules:
 
 - the event has `agent_id` equal to the requested agent id;
-- the event references a todo claimed by that agent;
-- the event references an unclaimed todo currently selected for that agent lane;
-- the event is a gate, blocker, validation, or state projection that directly
-  changes that agent's next action;
-- the event records a handoff to or from that agent.
-
-Goal-level rows may appear only when they change route, acceptance, global gate,
-active next action, or replan obligation.
+- when `--todo-id` is present, the event has that exact todo id;
+- compact run-history rows have the requested agent id and, when filtered by
+  todo, mention that todo in one of the bounded run fields;
+- `--since` and normalized `--event-kind` filters are applied before the final
+  newest-first limit.
 
 Other agents should not be shown row by row by default. They should be compressed
-into `other_agent_frontier` with bounded `vision_summary`, `top_todo`,
-`handoff_state`, and latest material timestamp. This lets an agent understand the
-shared direction without inheriting another lane's private scratchpad.
+into `other_agent_frontier` from the latest compact run-history row per agent,
+with a maximum of three rows. This lets an agent understand the shared direction
+without inheriting another lane's private scratchpad.
 
 ## Replan Integration
 
@@ -153,13 +149,24 @@ contract should include required reads:
   "effective_action": "autonomous_replan",
   "required_reads": [
     {
-      "kind": "agent_scoped_evidence_ledger",
-      "command": "loopx evidence-log --goal-id loopx-meta --agent-id codex-evidence-peer --thin --limit 30",
+      "kind": "agent_scoped_evidence_log",
+      "command": "loopx --format json evidence-log --goal-id loopx-meta --agent-id codex-evidence-peer --thin --limit 24",
       "reason": "Read this agent's own material chronology before writing a replan delta."
     }
   ]
 }
 ```
+
+The control-plane responsibilities are deliberately split and causally bound:
+
+- `replan_novelty_policy` is the baseline: it names
+  `agent_scoped_evidence_log` as its evidence source and makes uncovered-
+  direction selection visible in the primary recommended action;
+- quota materializes that requested source as `required_reads[0]`, which carries
+  the exact command. A generic replan without the novelty policy does not
+  recreate the old standalone hint;
+- `repair_delta` remains the only writeback truth for repeated blockers,
+  successor novelty, and coverage-backed exhaustion.
 
 The agent should then write back one of:
 
@@ -169,8 +176,20 @@ The agent should then write back one of:
 - a no-follow-up rationale when the ledger proves the lane is intentionally
   closed.
 
-An acknowledgement without reading the ledger or writing a bounded delta should
-not clear the replan obligation.
+LoopX cannot infer from an acknowledgement alone that a shell read happened.
+Accordingly, the evidence-log read is not a second settlement mechanism: the
+obligation clears only through a valid bounded repair delta, while the
+prompt-visible novelty policy prevents the preflight command from being buried
+as an unused packet field.
+
+The live behavior qualification tests that causal handoff through an actual
+function-tool conversation rather than a testing-only output field. A Doubao
+actor receives the shipped Codex App heartbeat body, chooses the quota command,
+receives the production replan packet, and must then call the exact evidence-log
+command from that packet. Prose such as "read the log next", a generic read
+action, a command for another agent, or an evidence-log call made before quota
+does not pass. The harness stops before executing the evidence command and
+stores only bounded command digests.
 
 ## Privacy Boundary
 
@@ -187,19 +206,15 @@ Rows may contain compact ids, relative public artifact refs, redacted summaries,
 omission notes, and private source counts. If a source is private, the row should
 say that only a compact pointer or count was recorded.
 
-## Rollout Plan
+## Current Implementation Status
 
-1. Add this public contract and keep it separate from runtime changes.
-2. Implement a read-only builder over rollout events with agent-id, todo-id,
-   kind, since, and limit filters.
-3. Merge compact run-history references into the same row shape without changing
-   existing `loopx history` semantics.
-4. Add other-agent frontier compression from todo/vision/handoff projections.
-5. Wire `required_reads` into quota, status, review packets, and autonomous
-   replan writeback.
-6. Add focused smokes for agent filtering, other-agent compression, privacy
-   redaction, and replan required-read stability.
-7. Expose discoverability in docs and help text once the CLI path is stable.
+The read-only CLI, rollout-event/run-history merge, bounded other-agent
+frontier, policy-owned quota/review-packet required reads, and public boundary
+smokes are implemented. Todo and material projections remain separate current-
+state surfaces; they are not copied into this chronological ledger. Replan
+novelty selection is owned by `replan_novelty_policy`, while durable acceptance
+is owned by the repair-delta control path rather than expanded inside the ledger
+builder.
 
 ## Acceptance
 
@@ -213,6 +228,9 @@ A change satisfies this contract only when:
   prompts;
 - replan-capable quota/status payloads can point agents to the required ledger
   read;
+- the live function-tool qualification proves that the default model selects
+  that exact read from a production heartbeat/quota exchange rather than merely
+  echoing a test field;
 - the existing status, history, review-packet, and rollout-event-log surfaces
   keep their current responsibilities; and
 - public tests prove the privacy boundary without committing private state,

--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -46,6 +46,11 @@ GLOBAL_REPLAN_OBLIGATION = {
     "stall_threshold": 2,
     "trigger_count": 1,
     "triggers": [{"kind": "periodic_review_due", "source": "fixture"}],
+    "replan_novelty_policy": {
+        "schema_version": "replan_novelty_policy_v0",
+        "evidence_source": "agent_scoped_evidence_log",
+        "writeback": "repair_delta",
+    },
     "stop_condition": "stop after one bounded replan slice writes back a concrete frontier delta",
 }
 
@@ -569,8 +574,14 @@ def assert_replan_beats_monitor_quiet_skip() -> None:
     assert "evidence-log" in required_reads[0]["command"], required_reads
     assert " --agent-id codex-side-bypass " in f" {required_reads[0]['command']} ", required_reads
     assert "--todo-id" not in required_reads[0]["command"], required_reads
-    assert "across this agent lane" in required_reads[0]["reason"], required_reads
-    assert "public-safe search" in required_reads[0]["reason"], required_reads
+    assert "novelty policy evidence source" in required_reads[0]["reason"], required_reads
+    novelty_policy = guard["autonomous_replan_obligation"][
+        "replan_novelty_policy"
+    ]
+    assert (
+        novelty_policy.get("evidence_source") or novelty_policy.get("evidence")
+    ) == "agent_scoped_evidence_log", guard
+    assert novelty_policy["writeback"] == "repair_delta", guard
     assert guard["autonomous_replan_obligation"]["required_reads"] == required_reads, guard
     assert (
         guard["interaction_contract"]["agent_channel"]["required_reads"] == required_reads

--- a/loopx/control_plane/goals/goal_frontier/__init__.py
+++ b/loopx/control_plane/goals/goal_frontier/__init__.py
@@ -19,8 +19,9 @@ from ...work_items.autonomous_replan_ack import (
 )
 from ...work_items.autonomous_replan_obligation import (
     MONITOR_NO_CHANGE_STREAK_THRESHOLD,
-    REPLAN_NOVELTY_GUIDANCE,
     build_autonomous_replan_obligation_payload,
+    ensure_replan_novelty_policy,
+    with_replan_novelty_guidance,
 )
 from ...work_items.repair_delta import (
     repair_delta_kinds_have_frontier_delta,
@@ -218,12 +219,11 @@ def align_autonomous_replan_guidance_with_acceptance_policy(
         else action
         for action in (replan_obligation.get("todo_actions") or [])
     ]
-    aligned["recommended_action"] = (
+    aligned["recommended_action"] = with_replan_novelty_guidance(
         "run a bounded autonomous replan for the exact blocked successor: "
         "create or claim one safe in-scope runnable advancement todo, or record "
         "an explicit successor/supersede transition; watch-lane continuation "
         "alone does not satisfy a repeat-until-closed vision"
-        + REPLAN_NOVELTY_GUIDANCE
     )
     aligned["satisfying_repair_delta_kinds"] = list(
         REPEAT_VISION_REPLAN_SATISFYING_DELTA_KINDS
@@ -1691,6 +1691,8 @@ def build_goal_frontier_projection_context_from_status(
         project_asset,
         agent_id=agent_id,
     )
+    if replan_obligation:
+        replan_obligation = ensure_replan_novelty_policy(replan_obligation)
     replan_scope = autonomous_replan_scope_decision(
         replan_obligation,
         agent_id=agent_id,
@@ -1852,7 +1854,9 @@ def build_goal_frontier_projection_context_from_status(
         acceptance_gaps=acceptance_gaps,
     )
     if frontier_replan_obligation:
-        replan_obligation = frontier_replan_obligation
+        replan_obligation = ensure_replan_novelty_policy(
+            frontier_replan_obligation
+        )
         replan_scope = autonomous_replan_scope_decision(
             replan_obligation,
             agent_id=agent_id,
@@ -1909,7 +1913,11 @@ def compact_replan_obligation(replan_obligation: dict[str, Any]) -> dict[str, An
     if replan_obligation.get("frontier_identity"):
         compact["frontier_identity"] = replan_obligation.get("frontier_identity")
     if isinstance(replan_obligation.get("replan_novelty_policy"), dict):
-        compact["replan_novelty_policy"] = replan_obligation["replan_novelty_policy"]
+        # Keep hot quota/status packets on the two authoritative seams. The
+        # detailed selection hint remains available on the full obligation.
+        compact["replan_novelty_policy"] = {
+            "evidence": "agent_scoped_evidence_log",
+        }
     if isinstance(replan_obligation.get("replan_ack_feedback"), dict):
         compact["replan_ack_feedback"] = replan_obligation["replan_ack_feedback"]
         compact["recommended_action"] = replan_obligation.get("recommended_action")

--- a/loopx/control_plane/quota/should_run_packet.py
+++ b/loopx/control_plane/quota/should_run_packet.py
@@ -1109,20 +1109,30 @@ def _build_quota_should_run_payload(
 
 
 def _quota_required_reads(decision: dict[str, Any]) -> list[dict[str, Any]]:
-    effective_action = str(decision.get("effective_action") or "")
-    replan_required = effective_action in {
-        AUTONOMOUS_REPLAN_REQUIRED_MODE,
-        AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value,
-    } or isinstance(decision.get("autonomous_replan_obligation"), dict)
-    if not replan_required:
+    """Materialize only evidence reads requested by the novelty policy.
+
+    A generic replan action is not enough: that was the old, low-salience hint
+    path. The prompt-visible novelty policy is now the causal owner and the
+    required-read packet is its executable evidence provider.
+    """
+
+    obligation = decision.get("autonomous_replan_obligation")
+    if not isinstance(obligation, dict):
+        return []
+    policy = obligation.get("replan_novelty_policy")
+    if not isinstance(policy, dict):
+        return []
+    evidence_source = str(
+        policy.get("evidence_source") or policy.get("evidence") or ""
+    ).strip()
+    if evidence_source != "agent_scoped_evidence_log":
         return []
     read = build_agent_scoped_required_read(
         goal_id=str(decision.get("goal_id") or ""),
         agent_id=quota_decision_agent_id(decision),
         reason=(
-            "read recent public-safe evidence across this agent lane before "
-            "replan; avoid repeating already-covered directions; use bounded "
-            "public-safe search when local evidence is thin"
+            "novelty policy evidence source; execute before selecting the "
+            "replan repair delta"
         ),
     )
     return [read] if read else []

--- a/loopx/control_plane/runtime/agent_scoped_evidence_log.py
+++ b/loopx/control_plane/runtime/agent_scoped_evidence_log.py
@@ -1,27 +1,19 @@
 from __future__ import annotations
 
-import re
 import shlex
 from collections.abc import Iterable, Mapping
 from datetime import datetime
 from typing import Any
 
+from .public_safety import public_safe_compact_text
 from .time import parse_timestamp
 
 
 SCHEMA_VERSION = "agent_scoped_evidence_log_v0"
 REQUIRED_READ_SCHEMA_VERSION = "loopx_agent_required_read_v0"
 
-_AK_SK_PATTERN = re.compile(r"(?i)\b(?:ak|sk|access[_-]?key|secret[_-]?key)\b\s*[:=]\s*\S+")
-
-
 def _compact_text(value: Any, *, limit: int = 220) -> str | None:
-    text = " ".join(str(value or "").split())
-    if not text:
-        return None
-    if _AK_SK_PATTERN.search(text):
-        return None
-    return text[:limit]
+    return public_safe_compact_text(value, limit=limit)
 
 
 def _normalize_event_kind(value: str) -> str:

--- a/loopx/control_plane/runtime/public_safety.py
+++ b/loopx/control_plane/runtime/public_safety.py
@@ -12,6 +12,8 @@ LOCAL_PATH_SURFACE_PATTERN = re.compile(
 )
 SECRET_LIKE_SURFACE_PATTERN = re.compile(
     r"(?i)(?:\bbearer\s+[a-z0-9._~+/=-]{16,}|"
+    r"\b(?:access|secret)[_-]?key\s*[=:]\s*[^\s`'\"<>]+|"
+    r"\b(?:ak|sk)\s*[=:]\s*[^\s`'\"<>]+|"
     r"(?<![a-z0-9_])(?:ak|sk)[-_=:][a-z0-9_=-]{10,}|"
     r"\btoken\s*[=:]\s*[^\s`'\"<>]{12,})"
 )

--- a/loopx/control_plane/testing/replan_evidence_tool_behavior.py
+++ b/loopx/control_plane/testing/replan_evidence_tool_behavior.py
@@ -1,0 +1,514 @@
+from __future__ import annotations
+
+import json
+import os
+import shlex
+from collections.abc import Mapping
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+
+from ...heartbeat_prompt import build_heartbeat_prompt
+from ..quota.turn_envelope import quota_action_signature_document
+from .actual_default_model_behavior_portfolio import (
+    ACTUAL_DEFAULT_MODEL_BEHAVIOR_FIXTURE_AGENT_ID,
+    ACTUAL_DEFAULT_MODEL_BEHAVIOR_FIXTURE_GOAL_ID,
+    build_actual_default_model_behavior_scenario_inputs,
+)
+from .doubao_model_behavior_actor import (
+    ARK_API_KEY_ENV,
+    DOUBAO_2_1_PRO_MODEL,
+    DOUBAO_2_1_TURBO_MODEL,
+    DOUBAO_CHAT_COMPLETIONS_ENDPOINT,
+    DOUBAO_MODEL_ENV,
+    DoubaoActorTransport,
+    DoubaoActorTransportError,
+    _direct_ark_transport,
+)
+
+
+REPLAN_EVIDENCE_TOOL_BEHAVIOR_RECEIPT_SCHEMA_VERSION = (
+    "replan_evidence_tool_behavior_receipt_v0"
+)
+REPLAN_EVIDENCE_TOOL_BEHAVIOR_MAX_CALLS = 6
+
+_ALLOWED_MODELS = {DOUBAO_2_1_PRO_MODEL, DOUBAO_2_1_TURBO_MODEL}
+_MAX_TOOL_ARGUMENT_BYTES = 8_192
+_MAX_PROVIDER_TOKENS = 2_048
+_READ_ONLY_PREFLIGHT_OUTPUTS = {
+    "pwd": "/workspace/loopx\n",
+    "git status --short --branch": "## codex/qualification...origin/main\n",
+    "git branch --show-current": "codex/qualification\n",
+    "git rev-parse --show-toplevel": "/workspace/loopx\n",
+}
+
+_EXEC_COMMAND_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "exec_command",
+        "description": (
+            "Run a shell command in the current workspace and return its output."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "cmd": {
+                    "type": "string",
+                    "description": "The shell command to run.",
+                }
+            },
+            "required": ["cmd"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+@dataclass(frozen=True)
+class _ReplanEvidenceToolFixture:
+    task_body: str
+    quota_packet: dict[str, Any]
+    required_evidence_command: str
+
+
+@dataclass(frozen=True)
+class _ToolCall:
+    call_id: str
+    command: str
+    provider_value: dict[str, Any]
+
+
+def _digest(value: str) -> str:
+    return f"sha256:{sha256(value.encode('utf-8')).hexdigest()}"
+
+
+def _build_fixture(root: Path) -> _ReplanEvidenceToolFixture:
+    _, packets = build_actual_default_model_behavior_scenario_inputs(root)
+    packet = dict(packets["turn_required_vision_replan"])
+    signature = quota_action_signature_document(packet)
+    required_reads = list(signature.get("required_reads") or [])
+    if len(required_reads) != 1 or not isinstance(required_reads[0], Mapping):
+        raise ValueError("replan fixture must project exactly one required read")
+    required_read = dict(required_reads[0])
+    required_command = str(required_read.get("command") or "").strip()
+    if (
+        required_read.get("kind") != "agent_scoped_evidence_log"
+        or " evidence-log " not in f" {required_command} "
+    ):
+        raise ValueError("replan fixture must bind to the agent evidence log")
+
+    prompt = build_heartbeat_prompt(
+        goal_id=ACTUAL_DEFAULT_MODEL_BEHAVIOR_FIXTURE_GOAL_ID,
+        thin=True,
+        agent_id=ACTUAL_DEFAULT_MODEL_BEHAVIOR_FIXTURE_AGENT_ID,
+        registered_agents=[ACTUAL_DEFAULT_MODEL_BEHAVIOR_FIXTURE_AGENT_ID],
+        available_capabilities=[
+            "shell",
+            "filesystem_read",
+            "filesystem_write",
+        ],
+        runtime_profile="codex_app_heartbeat",
+    )
+    quota_guard_command = str(prompt["quota_guard_command"])
+    if quota_guard_command not in str(prompt["task_body"]):
+        raise ValueError("heartbeat fixture must contain its production quota guard")
+    return _ReplanEvidenceToolFixture(
+        task_body=str(prompt["task_body"]),
+        quota_packet=packet,
+        required_evidence_command=required_command,
+    )
+
+
+def _provider_tool_call(response: Mapping[str, Any]) -> _ToolCall | None:
+    choices = response.get("choices")
+    if not isinstance(choices, list) or len(choices) != 1:
+        raise DoubaoActorTransportError(
+            "Doubao tool behavior response must contain exactly one choice",
+            error_code="provider_invalid_shape",
+        )
+    choice = choices[0]
+    if not isinstance(choice, Mapping):
+        raise DoubaoActorTransportError(
+            "Doubao tool behavior choice must be an object",
+            error_code="provider_invalid_shape",
+        )
+    message = choice.get("message")
+    if not isinstance(message, Mapping):
+        raise DoubaoActorTransportError(
+            "Doubao tool behavior choice is missing its message",
+            error_code="provider_invalid_shape",
+        )
+    tool_calls = message.get("tool_calls")
+    if tool_calls in (None, []):
+        return None
+    if not isinstance(tool_calls, list) or len(tool_calls) != 1:
+        raise DoubaoActorTransportError(
+            "Doubao tool behavior must choose exactly one tool per step",
+            error_code="provider_invalid_tool_call",
+        )
+    raw_call = tool_calls[0]
+    if not isinstance(raw_call, Mapping):
+        raise DoubaoActorTransportError(
+            "Doubao tool call must be an object",
+            error_code="provider_invalid_tool_call",
+        )
+    function = raw_call.get("function")
+    if (
+        raw_call.get("type") != "function"
+        or not isinstance(function, Mapping)
+        or function.get("name") != "exec_command"
+    ):
+        raise DoubaoActorTransportError(
+            "Doubao tool behavior selected an unsupported tool",
+            error_code="provider_invalid_tool_call",
+        )
+    arguments_text = function.get("arguments")
+    if (
+        not isinstance(arguments_text, str)
+        or len(arguments_text.encode("utf-8")) > _MAX_TOOL_ARGUMENT_BYTES
+    ):
+        raise DoubaoActorTransportError(
+            "Doubao tool arguments are missing or too large",
+            error_code="provider_invalid_tool_call",
+        )
+    try:
+        arguments = json.loads(arguments_text)
+    except json.JSONDecodeError:
+        raise DoubaoActorTransportError(
+            "Doubao tool arguments are not valid JSON",
+            error_code="provider_invalid_tool_call",
+        ) from None
+    if not isinstance(arguments, Mapping) or set(arguments) != {"cmd"}:
+        raise DoubaoActorTransportError(
+            "Doubao exec_command arguments must contain only cmd",
+            error_code="provider_invalid_tool_call",
+        )
+    command = arguments.get("cmd")
+    if not isinstance(command, str) or not command.strip():
+        raise DoubaoActorTransportError(
+            "Doubao exec_command cmd must be non-empty text",
+            error_code="provider_invalid_tool_call",
+        )
+    call_id = str(raw_call.get("id") or "").strip()
+    if not call_id:
+        raise DoubaoActorTransportError(
+            "Doubao tool call is missing its id",
+            error_code="provider_invalid_tool_call",
+        )
+    return _ToolCall(
+        call_id=call_id,
+        command=command.strip(),
+        provider_value={
+            "id": call_id,
+            "type": "function",
+            "function": {
+                "name": "exec_command",
+                "arguments": arguments_text,
+            },
+        },
+    )
+
+
+def _loopx_command_tokens(command: str) -> list[str] | None:
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return None
+    for index, token in enumerate(tokens):
+        if Path(token).name == "loopx":
+            command_tokens = tokens[index:]
+            if any(token in {";", "&&", "||", "|"} for token in command_tokens):
+                return None
+            return command_tokens
+    return None
+
+
+def _argument_value(tokens: list[str], option: str) -> str | None:
+    try:
+        index = tokens.index(option)
+    except ValueError:
+        return None
+    return tokens[index + 1] if index + 1 < len(tokens) else None
+
+
+def _clock_output(command: str) -> str | None:
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return None
+    if not tokens or Path(tokens[0]).name != "date" or len(tokens) > 4:
+        return None
+    if any(
+        token in {";", "&&", "||", "|"}
+        or (index > 0 and not token.startswith(("-", "+")))
+        for index, token in enumerate(tokens)
+    ):
+        return None
+    if "-u" in tokens or "--utc" in tokens:
+        return "2026-08-11T16:00:00Z\n"
+    return "2026-08-12T00:00:00+08:00\n"
+
+
+def _is_quota_guard(command: str) -> bool:
+    tokens = _loopx_command_tokens(command)
+    if not tokens:
+        return False
+    try:
+        quota_index = tokens.index("quota")
+    except ValueError:
+        return False
+    return bool(
+        tokens[quota_index : quota_index + 2] == ["quota", "should-run"]
+        and _argument_value(tokens, "--goal-id")
+        == ACTUAL_DEFAULT_MODEL_BEHAVIOR_FIXTURE_GOAL_ID
+        and _argument_value(tokens, "--agent-id")
+        == ACTUAL_DEFAULT_MODEL_BEHAVIOR_FIXTURE_AGENT_ID
+        and "--codex-app" in tokens
+        and _argument_value(tokens, "--turn-instance-id")
+    )
+
+
+def _classify_tool_command(
+    command: str,
+    *,
+    fixture: _ReplanEvidenceToolFixture,
+    quota_observed: bool,
+) -> tuple[str, str | None]:
+    if command == fixture.required_evidence_command:
+        if not quota_observed:
+            return "evidence_log_before_quota", None
+        return "evidence_log", None
+    if _is_quota_guard(command):
+        return (
+            "quota_should_run",
+            json.dumps(
+                fixture.quota_packet,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        )
+    clock_output = _clock_output(command)
+    if clock_output is not None:
+        return "clock", clock_output
+    if command in _READ_ONLY_PREFLIGHT_OUTPUTS:
+        return "workspace_read", _READ_ONLY_PREFLIGHT_OUTPUTS[command]
+    if " evidence-log " in f" {command} ":
+        return "wrong_evidence_log", None
+    return "unexpected_command", None
+
+
+def _receipt(
+    *,
+    qualification_id: str,
+    actor_ref: str,
+    steps: list[dict[str, Any]],
+    passed: bool,
+    failure_code: str | None,
+    required_evidence_command: str,
+) -> dict[str, Any]:
+    return {
+        "schema_version": REPLAN_EVIDENCE_TOOL_BEHAVIOR_RECEIPT_SCHEMA_VERSION,
+        "qualification_id": qualification_id,
+        "actor_ref": actor_ref,
+        "qualification_passed": passed,
+        "failure_code": failure_code,
+        "observed_tool_sequence": [step["kind"] for step in steps],
+        "tool_call_count": len(steps),
+        "evidence_log_matched_required_read": passed,
+        "required_read_command_digest": _digest(required_evidence_command),
+        "tool_call_receipts": steps,
+        "boundary": {
+            "raw_prompt_persisted": False,
+            "raw_provider_response_persisted": False,
+            "raw_command_persisted": False,
+            "filesystem_writes_executed": False,
+            "external_writes_executed": False,
+            "shell_commands_executed": False,
+        },
+    }
+
+
+class DoubaoReplanEvidenceToolBehaviorActor:
+    """Run a bounded production-prompt function-tool loop without mutations."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str = DOUBAO_2_1_PRO_MODEL,
+        timeout_seconds: float = 90.0,
+        transport: DoubaoActorTransport = _direct_ark_transport,
+    ) -> None:
+        if not api_key.strip():
+            raise RuntimeError("Doubao actor requires a runtime-injected API key")
+        if model not in _ALLOWED_MODELS:
+            raise ValueError(
+                "Doubao actor model must be an allowlisted Doubao 2.1 model"
+            )
+        if timeout_seconds <= 0 or timeout_seconds > 300:
+            raise ValueError("Doubao actor timeout must be between 0 and 300 seconds")
+        self._api_key = api_key
+        self._model = model
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    @classmethod
+    def from_environment(
+        cls,
+        *,
+        environ: Mapping[str, str] | None = None,
+        transport: DoubaoActorTransport = _direct_ark_transport,
+        timeout_seconds: float = 90.0,
+    ) -> DoubaoReplanEvidenceToolBehaviorActor:
+        values = os.environ if environ is None else environ
+        api_key = values.get(ARK_API_KEY_ENV, "")
+        if not api_key.strip():
+            raise RuntimeError(
+                "ARK_API_KEY is not injected; live Doubao qualification is unavailable"
+            )
+        return cls(
+            api_key=api_key,
+            model=values.get(DOUBAO_MODEL_ENV, DOUBAO_2_1_PRO_MODEL),
+            timeout_seconds=timeout_seconds,
+            transport=transport,
+        )
+
+    def qualify(
+        self,
+        *,
+        qualification_id: str,
+        fixture_root: Path,
+    ) -> dict[str, Any]:
+        fixture = _build_fixture(fixture_root)
+        messages: list[dict[str, Any]] = [
+            {
+                "role": "system",
+                "content": (
+                    "You are Codex running one LoopX heartbeat. Follow the "
+                    "heartbeat task and use the available shell tool when needed. "
+                    "Choose each next action from the latest tool result."
+                ),
+            },
+            {"role": "user", "content": fixture.task_body},
+        ]
+        steps: list[dict[str, Any]] = []
+        quota_observed = False
+        seen_once: set[str] = set()
+        actor_ref = f"ark:{self._model}"
+
+        for _ in range(REPLAN_EVIDENCE_TOOL_BEHAVIOR_MAX_CALLS):
+            body = {
+                "model": self._model,
+                "messages": messages,
+                "tools": [_EXEC_COMMAND_TOOL],
+                "tool_choice": "auto",
+                "thinking": {"type": "disabled"},
+                "temperature": 0,
+                "max_tokens": _MAX_PROVIDER_TOKENS,
+                "stream": False,
+            }
+            try:
+                response = self._transport(
+                    endpoint=DOUBAO_CHAT_COMPLETIONS_ENDPOINT,
+                    headers={
+                        "Authorization": f"Bearer {self._api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    body=json.dumps(
+                        body,
+                        ensure_ascii=False,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ).encode("utf-8"),
+                    timeout_seconds=self._timeout_seconds,
+                )
+                tool_call = _provider_tool_call(response)
+            except DoubaoActorTransportError:
+                raise
+            except Exception:
+                raise DoubaoActorTransportError(
+                    "Doubao tool behavior provider transport failed",
+                    error_code="provider_transport_failed",
+                ) from None
+            if tool_call is None:
+                return _receipt(
+                    qualification_id=qualification_id,
+                    actor_ref=actor_ref,
+                    steps=steps,
+                    passed=False,
+                    failure_code="model_returned_without_tool_call",
+                    required_evidence_command=fixture.required_evidence_command,
+                )
+
+            kind, tool_output = _classify_tool_command(
+                tool_call.command,
+                fixture=fixture,
+                quota_observed=quota_observed,
+            )
+            steps.append(
+                {
+                    "ordinal": len(steps) + 1,
+                    "kind": kind,
+                    "command_digest": _digest(tool_call.command),
+                }
+            )
+            if kind == "evidence_log":
+                return _receipt(
+                    qualification_id=qualification_id,
+                    actor_ref=actor_ref,
+                    steps=steps,
+                    passed=True,
+                    failure_code=None,
+                    required_evidence_command=fixture.required_evidence_command,
+                )
+            if kind in {
+                "evidence_log_before_quota",
+                "wrong_evidence_log",
+                "unexpected_command",
+            }:
+                return _receipt(
+                    qualification_id=qualification_id,
+                    actor_ref=actor_ref,
+                    steps=steps,
+                    passed=False,
+                    failure_code=kind,
+                    required_evidence_command=fixture.required_evidence_command,
+                )
+            if kind in {"clock", "quota_should_run"} and kind in seen_once:
+                return _receipt(
+                    qualification_id=qualification_id,
+                    actor_ref=actor_ref,
+                    steps=steps,
+                    passed=False,
+                    failure_code=f"repeated_{kind}",
+                    required_evidence_command=fixture.required_evidence_command,
+                )
+            if kind in {"clock", "quota_should_run"}:
+                seen_once.add(kind)
+            if kind == "quota_should_run":
+                quota_observed = True
+            messages.extend(
+                [
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [tool_call.provider_value],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call.call_id,
+                        "content": tool_output or "",
+                    },
+                ]
+            )
+
+        return _receipt(
+            qualification_id=qualification_id,
+            actor_ref=actor_ref,
+            steps=steps,
+            passed=False,
+            failure_code="tool_call_budget_exhausted",
+            required_evidence_command=fixture.required_evidence_command,
+        )

--- a/loopx/control_plane/work_items/autonomous_replan_obligation.py
+++ b/loopx/control_plane/work_items/autonomous_replan_obligation.py
@@ -25,21 +25,48 @@ SectionEntries = Callable[[list[str]], list[str]]
 MAX_AUTONOMOUS_REPLAN_TRIGGERS = 3
 AUTONOMOUS_REPLAN_STALL_THRESHOLD = 2
 REPLAN_NOVELTY_POLICY_SCHEMA_VERSION = "replan_novelty_policy_v0"
-# Generic agent-facing guidance appended to every autonomous replan
-# recommended_action. It is deliberately surface-neutral: it tells the agent
-# to consult its own evidence ledger, prefer an untried direction, and only
-# close on an explicit coverage-backed terminal state instead of restating an
-# already-tried action or blocker.
+# Keep the effective rule prompt-visible. The novelty policy owns the evidence
+# source, quota binds that source to the executable required_reads projection,
+# and repair_delta remains the only writeback/enforcement truth.
 REPLAN_NOVELTY_GUIDANCE = (
-    " Review the agent-scoped evidence log first (required_reads carries the "
-    "exact `loopx evidence-log` command), then keep proposing new approaches: "
-    "prefer a direction not already covered by recent runs, such as a new "
-    "surface, method, parameter combination, validation command, or hypothesis. "
-    "Do not repeat an already-tried action or restate the same blocker. If no "
-    "new direction remains, list which surfaces and combinations are already "
-    "covered and record an explicit exploration_exhausted blocker with that "
-    "coverage evidence."
+    " Run required_reads[0] (evidence-log); choose an untried direction. "
+    "Reject repeats; exploration_exhausted needs coverage."
 )
+
+
+def build_replan_novelty_policy() -> dict[str, str]:
+    """Bind replan preflight to the existing repair-delta settlement truth."""
+
+    return {
+        "schema_version": REPLAN_NOVELTY_POLICY_SCHEMA_VERSION,
+        "evidence_source": "agent_scoped_evidence_log",
+        "writeback": "repair_delta",
+    }
+
+
+def with_replan_novelty_guidance(action: str) -> str:
+    """Make the policy visible once on every replan primary action."""
+
+    marker = "required_reads[0] (evidence-log)"
+    normalized = str(action or "").strip()
+    if marker in normalized:
+        return normalized
+    return normalized + REPLAN_NOVELTY_GUIDANCE
+
+
+def ensure_replan_novelty_policy(
+    obligation: dict[str, Any],
+) -> dict[str, Any]:
+    """Upgrade any legacy obligation onto the policy-owned evidence path."""
+
+    normalized = dict(obligation)
+    normalized["recommended_action"] = with_replan_novelty_guidance(
+        str(normalized.get("recommended_action") or "run a bounded autonomous replan")
+    )
+    normalized["replan_novelty_policy"] = build_replan_novelty_policy()
+    return normalized
+
+
 # Unchanged-poll streak before a monitor-only lane is forced to replan. Kept
 # deliberately above the 2-turn run-history stall threshold: quiet monitors
 # legitimately wait several cadence cycles for external evidence, and forcing
@@ -624,30 +651,6 @@ def build_autonomous_replan_obligation(
         extra_fields["frontier_identity"] = dead_monitor_evidence.get(
             "monitor_target_id"
         )
-    repeated_stall = bool(
-        blocked_successor_evidence
-        or dead_monitor_evidence
-        or any(
-            item.get("kind")
-            in {"run_history_no_progress_repeat", "no_progress_streak", "repeated_action_loop"}
-            for item in evidence
-        )
-    )
-    extra_fields["replan_novelty_policy"] = {
-        "schema_version": REPLAN_NOVELTY_POLICY_SCHEMA_VERSION,
-        "review_evidence_log": True,
-        "prefer_unattempted_direction": True,
-        "repeated_blocker_restatement_rejected": repeated_stall,
-        "no_new_direction_closure": (
-            ["watch_lane_expiry", "exploration_exhausted_with_coverage_evidence"]
-            if dead_monitor_evidence
-            else [
-                "exploration_exhausted_with_coverage_evidence",
-                "explicit_terminal_blocker_or_no_followup",
-            ]
-        ),
-    }
-
     result = build_autonomous_replan_obligation_payload(
         schema_version=autonomous_replan_schema_version,
         stall_threshold=(
@@ -702,10 +705,7 @@ def build_autonomous_replan_obligation_payload(
     agent_id: str | None = None,
     include_agent_id: bool = False,
     extra_fields: dict[str, Any] | None = None,
-    include_novelty_guidance: bool = True,
 ) -> dict[str, Any]:
-    if include_novelty_guidance:
-        recommended_action = recommended_action + REPLAN_NOVELTY_GUIDANCE
     payload: dict[str, Any] = {
         "schema_version": schema_version,
         "required": True,
@@ -717,21 +717,11 @@ def build_autonomous_replan_obligation_payload(
         "stop_condition": stop_condition,
         "recommended_action": recommended_action,
     }
-    payload["replan_novelty_policy"] = {
-        "schema_version": REPLAN_NOVELTY_POLICY_SCHEMA_VERSION,
-        "review_evidence_log": True,
-        "prefer_unattempted_direction": True,
-        "repeated_blocker_restatement_rejected": False,
-        "no_new_direction_closure": [
-            "exploration_exhausted_with_coverage_evidence",
-            "explicit_terminal_blocker_or_no_followup",
-        ],
-    }
     if include_agent_id or agent_id is not None:
         payload["agent_id"] = agent_id
     if extra_fields:
         payload.update(extra_fields)
-    return payload
+    return ensure_replan_novelty_policy(payload)
 
 
 def autonomous_replan_obligation_from_runs(

--- a/scripts/qualify-doubao-replan-evidence-tool-live.py
+++ b/scripts/qualify-doubao-replan-evidence-tool-live.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+repo_root_text = str(REPO_ROOT)
+if sys.path[0] != repo_root_text:
+    sys.path.insert(0, repo_root_text)
+
+from loopx.control_plane.testing.release_commit_qualification import (  # noqa: E402
+    collect_release_source_identity,
+)
+from loopx.control_plane.testing.replan_evidence_tool_behavior import (  # noqa: E402
+    DoubaoReplanEvidenceToolBehaviorActor,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run one production-prompt Doubao function-tool loop and verify "
+            "that replan selects the projected evidence-log read."
+        )
+    )
+    parser.add_argument("--qualification-id", required=True)
+    parser.add_argument("--timeout-seconds", type=float, default=90.0)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    source = collect_release_source_identity(args.repo_root)
+    if source["git_dirty"]:
+        raise RuntimeError(
+            "live Doubao qualification requires a clean candidate checkout"
+        )
+    actor = DoubaoReplanEvidenceToolBehaviorActor.from_environment(
+        timeout_seconds=args.timeout_seconds
+    )
+    with TemporaryDirectory(prefix="loopx-doubao-replan-tool-") as temp_dir:
+        result = actor.qualify(
+            qualification_id=args.qualification_id,
+            fixture_root=Path(temp_dir),
+        )
+    result["source"] = source
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True, indent=2))
+    return 0 if result["qualification_passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/control_plane/test_agent_scoped_evidence_log.py
+++ b/tests/control_plane/test_agent_scoped_evidence_log.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from loopx.control_plane.runtime.agent_scoped_evidence_log import (
+    build_agent_scoped_evidence_log,
+)
+
+
+@pytest.mark.parametrize(
+    "unsafe_summary",
+    [
+        "access_key=should-not-surface",
+        "secret-key:should-not-surface",
+        "sk=should-not-surface",
+        "/private/tmp/owner-only/evidence.json",
+    ],
+)
+def test_evidence_log_reuses_the_shared_public_safety_boundary(
+    unsafe_summary: str,
+) -> None:
+    payload = build_agent_scoped_evidence_log(
+        goal_id="public-goal",
+        agent_id="codex-agent",
+        rollout_events=[
+            {
+                "agent_id": "codex-agent",
+                "event_kind": "validation",
+                "recorded_at": "2026-08-12T00:00:00Z",
+                "summary": unsafe_summary,
+            }
+        ],
+        history_runs=[],
+    )
+
+    assert unsafe_summary not in json.dumps(payload)
+    assert payload["ledger"] == [
+        {
+            "source": "rollout_event_log",
+            "recorded_at": "2026-08-12T00:00:00Z",
+            "event_id": None,
+            "event_kind": "validation",
+            "agent_id": "codex-agent",
+        }
+    ]
+
+
+def test_evidence_log_keeps_safe_compact_prose() -> None:
+    payload = build_agent_scoped_evidence_log(
+        goal_id="public-goal",
+        agent_id="codex-agent",
+        rollout_events=[
+            {
+                "agent_id": "codex-agent",
+                "event_kind": "validation",
+                "recorded_at": "2026-08-12T00:00:00Z",
+                "summary": "authorization token label is safe as prose",
+            }
+        ],
+        history_runs=[],
+    )
+
+    assert payload["ledger"][0]["summary"] == (
+        "authorization token label is safe as prose"
+    )

--- a/tests/control_plane/test_replan_evidence_tool_behavior.py
+++ b/tests/control_plane/test_replan_evidence_tool_behavior.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from loopx.control_plane.testing.replan_evidence_tool_behavior import (
+    DoubaoReplanEvidenceToolBehaviorActor,
+    _build_fixture,
+)
+
+
+def _tool_response(call_id: str, command: str) -> dict[str, Any]:
+    return {
+        "choices": [
+            {
+                "finish_reason": "tool_calls",
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "type": "function",
+                            "function": {
+                                "name": "exec_command",
+                                "arguments": json.dumps({"cmd": command}),
+                            },
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+
+
+def test_real_tool_loop_observes_production_evidence_log_intent(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    requests: list[dict[str, Any]] = []
+    commands = [
+        "date -Iseconds",
+        (
+            "export LOOPX_TURN=2026-08-12T00:00:00+08:00 && "
+            'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" '
+            "quota should-run --goal-id portfolio-goal --agent-id codex-portfolio "
+            "--available-capability shell --available-capability filesystem_read "
+            "--available-capability filesystem_write --codex-app "
+            '--turn-instance-id "${LOOPX_TURN:?}"'
+        ),
+        fixture.required_evidence_command,
+    ]
+
+    def transport(
+        *,
+        endpoint: str,
+        headers: Mapping[str, str],
+        body: bytes,
+        timeout_seconds: float,
+    ) -> Mapping[str, Any]:
+        request = json.loads(body)
+        requests.append(request)
+        return _tool_response(f"call-{len(requests)}", commands[len(requests) - 1])
+
+    actor = DoubaoReplanEvidenceToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    )
+    receipt = actor.qualify(
+        qualification_id="replan-evidence-tool-loop-001",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is True
+    assert receipt["observed_tool_sequence"] == [
+        "clock",
+        "quota_should_run",
+        "evidence_log",
+    ]
+    assert receipt["evidence_log_matched_required_read"] is True
+    assert receipt["boundary"] == {
+        "raw_prompt_persisted": False,
+        "raw_provider_response_persisted": False,
+        "raw_command_persisted": False,
+        "filesystem_writes_executed": False,
+        "external_writes_executed": False,
+        "shell_commands_executed": False,
+    }
+    assert fixture.required_evidence_command not in json.dumps(receipt, sort_keys=True)
+
+    first = requests[0]
+    assert first["messages"] == [
+        {
+            "role": "system",
+            "content": (
+                "You are Codex running one LoopX heartbeat. Follow the heartbeat "
+                "task and use the available shell tool when needed. Choose each "
+                "next action from the latest tool result."
+            ),
+        },
+        {"role": "user", "content": fixture.task_body},
+    ]
+    assert first["tools"][0]["function"]["name"] == "exec_command"
+    assert first["tool_choice"] == "auto"
+    assert "response_format" not in first
+    assert "required_reads" not in first["messages"][1]["content"]
+
+    assert requests[1]["messages"][-1] == {
+        "role": "tool",
+        "tool_call_id": "call-1",
+        "content": "2026-08-12T00:00:00+08:00\n",
+    }
+    quota_result = json.loads(requests[2]["messages"][-1]["content"])
+    assert quota_result == fixture.quota_packet
+
+
+def test_tool_loop_rejects_evidence_log_before_quota(tmp_path: Path) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        return _tool_response("call-1", fixture.required_evidence_command)
+
+    receipt = DoubaoReplanEvidenceToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="replan-evidence-before-quota",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is False
+    assert receipt["failure_code"] == "evidence_log_before_quota"
+    assert receipt["observed_tool_sequence"] == ["evidence_log_before_quota"]
+
+
+def test_tool_loop_accepts_the_real_host_utc_clock_shape(tmp_path: Path) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    commands = [
+        'date -u +"%Y-%m-%dT%H:%M:%SZ"',
+        (
+            "loopx quota should-run --goal-id portfolio-goal "
+            "--agent-id codex-portfolio --codex-app "
+            "--turn-instance-id turn-001"
+        ),
+        fixture.required_evidence_command,
+    ]
+    requests: list[dict[str, Any]] = []
+
+    def transport(**kwargs: Any) -> Mapping[str, Any]:
+        requests.append(json.loads(kwargs["body"]))
+        return _tool_response(f"call-{len(requests)}", commands[len(requests) - 1])
+
+    receipt = DoubaoReplanEvidenceToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="replan-utc-clock",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is True
+    assert requests[1]["messages"][-1]["content"] == "2026-08-11T16:00:00Z\n"
+
+
+def test_tool_loop_allows_distinct_normal_workspace_preflight_reads(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    commands = [
+        "pwd",
+        "git status --short --branch",
+        (
+            "loopx quota should-run --goal-id portfolio-goal "
+            "--agent-id codex-portfolio --codex-app "
+            "--turn-instance-id turn-001"
+        ),
+        fixture.required_evidence_command,
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        command = commands[call_count]
+        call_count += 1
+        return _tool_response(f"call-{call_count}", command)
+
+    receipt = DoubaoReplanEvidenceToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="replan-workspace-preflight",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is True
+    assert receipt["observed_tool_sequence"] == [
+        "workspace_read",
+        "workspace_read",
+        "quota_should_run",
+        "evidence_log",
+    ]
+
+
+def test_tool_loop_rejects_generic_or_wrong_evidence_read(tmp_path: Path) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    responses = [
+        _tool_response(
+            "call-1",
+            (
+                "loopx quota should-run --goal-id portfolio-goal "
+                "--agent-id codex-portfolio --codex-app "
+                "--turn-instance-id turn-001"
+            ),
+        ),
+        _tool_response(
+            "call-2",
+            (
+                "loopx --format json evidence-log --goal-id portfolio-goal "
+                "--agent-id another-agent --thin --limit 24"
+            ),
+        ),
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        response = responses[call_count]
+        call_count += 1
+        return response
+
+    receipt = DoubaoReplanEvidenceToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="replan-wrong-evidence-read",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is False
+    assert receipt["failure_code"] == "wrong_evidence_log"
+    assert receipt["evidence_log_matched_required_read"] is False
+    assert fixture.required_evidence_command not in json.dumps(receipt, sort_keys=True)
+
+
+def test_tool_loop_fails_when_model_describes_instead_of_calling(
+    tmp_path: Path,
+) -> None:
+    def transport(**_: Any) -> Mapping[str, Any]:
+        return {
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "message": {
+                        "role": "assistant",
+                        "content": "I would inspect the evidence log next.",
+                    },
+                }
+            ]
+        }
+
+    receipt = DoubaoReplanEvidenceToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="replan-prose-only",
+        fixture_root=tmp_path,
+    )
+
+    assert receipt["qualification_passed"] is False
+    assert receipt["failure_code"] == "model_returned_without_tool_call"
+    assert receipt["tool_call_count"] == 0

--- a/tests/control_plane/test_replan_novelty_policy.py
+++ b/tests/control_plane/test_replan_novelty_policy.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from loopx.control_plane.goals.goal_frontier import (
     align_autonomous_replan_guidance_with_acceptance_policy,
+    autonomous_replan_scope_decision,
     compact_replan_obligation,
 )
 from loopx.control_plane.work_items.autonomous_replan_obligation import (
     build_autonomous_replan_obligation_payload,
 )
+from loopx.control_plane.quota.should_run_packet import _quota_required_reads
 from loopx.status import (
     DEAD_MONITOR_REPEAT_THRESHOLD,
     build_autonomous_replan_obligation,
@@ -32,21 +34,17 @@ def test_generic_stall_obligation_carries_novelty_guidance() -> None:
 
     policy = obligation["replan_novelty_policy"]
     assert policy["schema_version"] == "replan_novelty_policy_v0"
-    assert policy["review_evidence_log"] is True
-    assert policy["prefer_unattempted_direction"] is True
-    assert policy["repeated_blocker_restatement_rejected"] is True
-    assert "exploration_exhausted_with_coverage_evidence" in policy[
-        "no_new_direction_closure"
-    ]
+    assert policy["evidence_source"] == "agent_scoped_evidence_log"
+    assert policy["writeback"] == "repair_delta"
 
     action = obligation["recommended_action"]
-    assert "evidence log" in action
-    assert "not already covered" in action
-    assert "Do not repeat an already-tried action" in action
+    assert "required_reads[0] (evidence-log)" in action
+    assert "untried direction" in action
+    assert "Reject repeats" in action
     assert "exploration_exhausted" in action
 
 
-def test_dead_monitor_obligation_policy_adds_watch_expiry_closure() -> None:
+def test_dead_monitor_obligation_reuses_the_same_repair_delta_contract() -> None:
     obligation = _obligation(
         [
             {
@@ -59,17 +57,14 @@ def test_dead_monitor_obligation_policy_adds_watch_expiry_closure() -> None:
     )
 
     policy = obligation["replan_novelty_policy"]
-    assert policy["repeated_blocker_restatement_rejected"] is True
-    assert policy["no_new_direction_closure"] == [
-        "watch_lane_expiry",
-        "exploration_exhausted_with_coverage_evidence",
-    ]
+    assert policy["evidence_source"] == "agent_scoped_evidence_log"
+    assert policy["writeback"] == "repair_delta"
     action = obligation["recommended_action"]
     assert "resolve a dead monitor loop" in action
-    assert "evidence log" in action
+    assert "required_reads[0] (evidence-log)" in action
 
 
-def test_periodic_review_obligation_policy_is_not_repeated_stall() -> None:
+def test_periodic_review_obligation_reuses_the_same_preflight_contract() -> None:
     obligation = _obligation(
         [
             {
@@ -81,11 +76,10 @@ def test_periodic_review_obligation_policy_is_not_repeated_stall() -> None:
     )
 
     policy = obligation["replan_novelty_policy"]
-    assert policy["repeated_blocker_restatement_rejected"] is False
-    assert policy["review_evidence_log"] is True
+    assert policy["evidence_source"] == "agent_scoped_evidence_log"
     action = obligation["recommended_action"]
     assert "bounded autonomous periodic review" in action
-    assert "evidence log" in action
+    assert "required_reads[0] (evidence-log)" in action
 
 
 def test_aligned_repeat_until_closed_guidance_keeps_novelty_hint() -> None:
@@ -109,14 +103,15 @@ def test_aligned_repeat_until_closed_guidance_keeps_novelty_hint() -> None:
         ],
     )
     assert aligned is not None
-    assert "watch-lane continuation alone does not satisfy" in aligned[
-        "recommended_action"
-    ]
-    assert "evidence log" in aligned["recommended_action"]
-    assert aligned["replan_novelty_policy"]["repeated_blocker_restatement_rejected"]
+    assert (
+        "watch-lane continuation alone does not satisfy"
+        in aligned["recommended_action"]
+    )
+    assert "required_reads[0] (evidence-log)" in aligned["recommended_action"]
+    assert aligned["replan_novelty_policy"]["writeback"] == "repair_delta"
 
 
-def test_compact_replan_obligation_preserves_novelty_policy() -> None:
+def test_compact_replan_obligation_keeps_only_authoritative_seam_refs() -> None:
     obligation = _obligation(
         [
             {
@@ -127,7 +122,9 @@ def test_compact_replan_obligation_preserves_novelty_policy() -> None:
         ]
     )
     compact = compact_replan_obligation(obligation)
-    assert compact["replan_novelty_policy"] == obligation["replan_novelty_policy"]
+    assert compact["replan_novelty_policy"] == {
+        "evidence": "agent_scoped_evidence_log",
+    }
 
 
 def test_payload_builder_defaults_to_novelty_guidance_and_policy() -> None:
@@ -142,14 +139,14 @@ def test_payload_builder_defaults_to_novelty_guidance_and_policy() -> None:
         recommended_action="run a bounded frontier replan",
     )
 
-    assert "evidence log" in payload["recommended_action"]
-    assert "prefer a direction not already covered" in payload["recommended_action"]
+    assert "required_reads[0] (evidence-log)" in payload["recommended_action"]
+    assert "untried direction" in payload["recommended_action"]
     policy = payload["replan_novelty_policy"]
-    assert policy["review_evidence_log"] is True
-    assert policy["repeated_blocker_restatement_rejected"] is False
+    assert policy["evidence_source"] == "agent_scoped_evidence_log"
+    assert policy["writeback"] == "repair_delta"
 
 
-def test_payload_builder_extra_fields_override_novelty_policy() -> None:
+def test_payload_builder_normalizes_legacy_policy_extra_fields() -> None:
     payload = build_autonomous_replan_obligation_payload(
         schema_version="autonomous_replan_obligation_v0",
         stall_threshold=1,
@@ -170,7 +167,61 @@ def test_payload_builder_extra_fields_override_novelty_policy() -> None:
         },
     )
 
-    assert payload["replan_novelty_policy"]["repeated_blocker_restatement_rejected"]
-    assert payload["replan_novelty_policy"]["no_new_direction_closure"] == [
-        "watch_lane_expiry"
-    ]
+    assert payload["replan_novelty_policy"] == {
+        "schema_version": "replan_novelty_policy_v0",
+        "evidence_source": "agent_scoped_evidence_log",
+        "writeback": "repair_delta",
+    }
+
+
+def test_novelty_policy_materializes_the_evidence_log_provider() -> None:
+    reads = _quota_required_reads(
+        {
+            "goal_id": "replan-goal",
+            "agent_identity": {"agent_id": "codex-replan"},
+            "autonomous_replan_obligation": {
+                "replan_novelty_policy": {
+                    "evidence": "agent_scoped_evidence_log",
+                    "writeback": "repair_delta",
+                }
+            },
+        }
+    )
+
+    assert reads[0]["kind"] == "agent_scoped_evidence_log"
+    assert "evidence-log --goal-id replan-goal" in reads[0]["command"]
+    assert "--agent-id codex-replan" in reads[0]["command"]
+    assert "novelty policy evidence source" in reads[0]["reason"]
+
+
+def test_generic_replan_without_novelty_policy_does_not_restore_the_old_hint() -> None:
+    reads = _quota_required_reads(
+        {
+            "goal_id": "replan-goal",
+            "effective_action": "autonomous_replan",
+            "agent_identity": {"agent_id": "codex-replan"},
+            "autonomous_replan_obligation": {},
+        }
+    )
+
+    assert reads == []
+
+
+def test_policy_normalization_precedes_deterministic_peer_scope_selection() -> None:
+    obligation = _obligation([{"kind": "periodic_review_due", "source": "fixture"}])
+    registered_agents = ["codex-primary", "codex-reviewer"]
+
+    selected = {
+        scope["selected_peer_agent"]
+        for agent_id in registered_agents
+        if (
+            scope := autonomous_replan_scope_decision(
+                obligation,
+                agent_id=agent_id,
+                registered_agent_ids=registered_agents,
+            )
+        )["applies"]
+    }
+
+    assert len(selected) == 1
+    assert selected <= set(registered_agents)


### PR DESCRIPTION
## Summary

- make `replan_novelty_policy` the causal owner of evidence preflight and keep `repair_delta` as the only settlement truth
- normalize obligations before deterministic peer-owner selection so policy enrichment cannot drift the owner hash
- absorb #3101 frontier-derived coverage while removing its duplicate legacy policy truth and unused guidance switch
- reuse the shared public-safety boundary for the agent-scoped evidence ledger
- add a bounded Doubao function-tool qualification that uses the shipped Codex App heartbeat prompt and production quota packet, then passes only on the exact projected evidence-log call
- leave the existing no-tool model-behavior portfolio and its schema unchanged

## Validation

- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/pytest -q tests/control_plane` — 1049 passed on latest `origin/main`
- `python examples/control_plane/quota-replan-decision-plane-smoke.py` — passed
- clean rebased-candidate live Doubao qualification — `clock -> quota_should_run -> evidence_log`, exact required-read digest matched
- `loopx canary premerge --from-git-diff` — 18 selected checks passed (9 catalog, 8 risk-profile, 1 public-boundary), 0 failures, 0 manual holds
- Ruff, format, Python compile, and diff checks — passed

## Safety and scope

The live harness executes no shell or external writes, stops when the evidence-log intent is observed, and retains only bounded action kinds and command digests. Raw prompts, provider responses, commands, credentials, and conversations are not persisted. No benchmark semantics, scheduler authority, or quota spend behavior changes.