### PR TITLE
test(replan): execute evidence-log behavior through real LoopX

### DIFF
--- a/docs/development/testing-and-quality.md
+++ b/docs/development/testing-and-quality.md
@@ -289,11 +289,12 @@ for the actor and promotion contract.
 
 Replan evidence preflight has a separate function-tool qualification because a
 no-tool JSON decision cannot prove that the model would perform a shell read.
-It gives the live model the shipped thin Codex App heartbeat task body and one
-ordinary `exec_command` function tool. The bounded host loop returns the
-production `quota should-run` fixture only after the model requests that command
-and passes only when the model subsequently calls the exact evidence-log
-command projected by `required_reads[0]`:
+It creates a hermetic public-safe Goal, gives the live model the shipped thin
+Codex App heartbeat task body and one ordinary `exec_command` function tool,
+and runs the model's accepted quota and evidence commands through the real
+LoopX CLI. The bounded host loop passes only when the real `quota should-run`
+result projects one evidence-log read and the model subsequently selects and
+successfully executes that exact command:
 
 ```bash
 python3 scripts/qualify-doubao-replan-evidence-tool-live.py \
@@ -301,11 +302,13 @@ python3 scripts/qualify-doubao-replan-evidence-tool-live.py \
 ```
 
 The model does not receive a testing-only decision schema, required-read index,
-or expected command. Clock and a small set of workspace reads are supported so
-the model can follow the normal heartbeat preflight. No shell command is
-executed, the loop stops at the matching evidence-log intent, and the receipt
-retains only action kinds and command digests. Fake transports validate the
-tool protocol and negative cases; only a real provider run qualifies behavior.
+expected command, or prebuilt quota packet. Clock and a small set of workspace
+reads are supported so the model can follow the normal heartbeat preflight.
+Commands are parsed into a strict allowlist without invoking a shell; quota may
+write only its normal receipt inside the temporary fixture, and no external or
+repository write is allowed. The receipt retains only action kinds and command
+digests. Fake transports validate the tool protocol, real CLI execution seam,
+and negative cases; only a real provider run qualifies model behavior.
 
 真实 Doubao 调用是低频本地/手动门，不进入普通 CI。`ARK_API_KEY` 只通过进程环境
 注入；packet、prompt、原始响应、凭证和对话都不能成为仓库证据，只保留有界 receipt
@@ -314,12 +317,14 @@ tool protocol and negative cases; only a real provider run qualifies behavior.
 非零状态退出。
 
 replan evidence preflight 另有一条 function-tool 行为资格门，因为 no-tool JSON 决策
-不能证明模型真的会发起 shell read。真实模型只看到正式的 thin Codex App heartbeat
-task body 和普通 `exec_command` tool；它先自行请求生产 `quota should-run`，宿主再回送
-正式 fixture，随后只有模型实际调用 `required_reads[0]` 投影的精确 evidence-log 命令
-才算通过。模型看不到测试专用 decision schema、required-read index 或预期命令。
-clock 与少量 workspace read 允许正常 preflight；宿主不执行任何 shell 命令，在匹配
-evidence-log 意图时立即停止，只在 receipt 中保留 action kind 与 command digest。
+不能证明模型真的会发起 shell read。资格门创建一个隔离、public-safe 的临时 Goal；
+真实模型只看到正式的 thin Codex App heartbeat task body 和普通 `exec_command` tool。
+模型选中的 quota 与 evidence 命令会经过严格 allowlist 后进入真实 LoopX CLI；只有真实
+`quota should-run` 投影出一条 required read，且模型随后选中并成功执行该精确
+evidence-log 命令才算通过。模型看不到测试专用 decision schema、required-read index、
+预期命令或预制 quota packet。clock 与少量 workspace read 允许正常 preflight；
+不调用 shell，quota 的正常 receipt 只写入临时 fixture，仓库与外部系统均不写入，最终
+receipt 只保留 action kind 与 command digest。
 
 The regular live suite is
 `actual_default_model_behavior_portfolio_v0`: fifteen one-arm scenarios, two

--- a/docs/reference/protocols/agent-scoped-evidence-ledger-v0.md
+++ b/docs/reference/protocols/agent-scoped-evidence-ledger-v0.md
@@ -184,12 +184,15 @@ as an unused packet field.
 
 The live behavior qualification tests that causal handoff through an actual
 function-tool conversation rather than a testing-only output field. A Doubao
-actor receives the shipped Codex App heartbeat body, chooses the quota command,
-receives the production replan packet, and must then call the exact evidence-log
-command from that packet. Prose such as "read the log next", a generic read
-action, a command for another agent, or an evidence-log call made before quota
-does not pass. The harness stops before executing the evidence command and
-stores only bounded command digests.
+actor receives the shipped Codex App heartbeat body and chooses the quota
+command against a hermetic public-safe Goal. The harness runs that command
+through the real LoopX CLI, returns its actual replan packet, and requires the
+actor to call the exact evidence-log command from that packet. The evidence
+command is also executed through the real read-only CLI and its goal/agent
+readback is checked before the run passes. Prose such as "read the log next", a
+generic read action, a command for another agent, or an evidence-log call made
+before quota does not pass. Only temporary fixture state may change, and the
+receipt stores bounded command digests rather than prompts, packets, or output.
 
 ## Privacy Boundary
 

--- a/examples/control_plane/cli-output-probe-runner.py
+++ b/examples/control_plane/cli-output-probe-runner.py
@@ -263,11 +263,12 @@ def main() -> int:
     if args.fixture_root.exists():
         shutil.rmtree(args.fixture_root)
     args.fixture_root.mkdir(parents=True)
-    rows = [
-        *_default_rows(probe, semantics, args.fixture_root),
-        *_variant_rows(probe, semantics, args.fixture_root),
-        *_blocking_gate_rows(probe, semantics, args.fixture_root),
-    ]
+    with probe._stable_budget_fixture_root(args.fixture_root) as stable_root:
+        rows = [
+            *_default_rows(probe, semantics, stable_root),
+            *_variant_rows(probe, semantics, stable_root),
+            *_blocking_gate_rows(probe, semantics, stable_root),
+        ]
     args.receipt.parent.mkdir(parents=True, exist_ok=True)
     args.receipt.write_text(
         json.dumps(

--- a/loopx/control_plane/testing/replan_evidence_tool_behavior.py
+++ b/loopx/control_plane/testing/replan_evidence_tool_behavior.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
-import contextlib
-import io
 import json
 import os
 import shlex
 import subprocess
+import sys
 from collections.abc import Mapping
 from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
 from typing import Any
 
-from ...cli import main as cli_main
 from ...heartbeat_prompt import build_heartbeat_prompt
 from ..runtime.agent_scoped_evidence_log import (
     build_agent_scoped_evidence_log_command,
@@ -396,16 +394,6 @@ def _replace_argument(tokens: list[str], option: str, value: str) -> None:
     tokens[index + 1] = value
 
 
-@contextlib.contextmanager
-def _working_directory(path: Path):
-    previous = Path.cwd()
-    os.chdir(path)
-    try:
-        yield
-    finally:
-        os.chdir(previous)
-
-
 def _execute_loopx_read(
     command: str,
     *,
@@ -420,16 +408,28 @@ def _execute_loopx_read(
     if quota_guard:
         _replace_argument(argv, "--registry", str(fixture.global_registry_path))
         _replace_argument(argv, "--turn-instance-id", turn_instance_id)
-    output = io.StringIO()
-    error = io.StringIO()
-    with _working_directory(fixture.project_root):
-        with contextlib.redirect_stdout(output), contextlib.redirect_stderr(error):
-            exit_code = cli_main(argv)
-    if exit_code != 0:
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        str(fixture.source_root)
+        if not existing_pythonpath
+        else os.pathsep.join((str(fixture.source_root), existing_pythonpath))
+    )
+    completed = subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *argv],
+        cwd=fixture.project_root,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if completed.returncode != 0:
         raise RuntimeError(
-            f"LoopX read command failed with exit={exit_code}: {error.getvalue()[-500:]}"
+            "LoopX read command failed with "
+            f"exit={completed.returncode}: {completed.stderr[-500:]}"
         )
-    return output.getvalue()
+    return completed.stdout
 
 
 def _execute_workspace_read(

--- a/loopx/control_plane/testing/replan_evidence_tool_behavior.py
+++ b/loopx/control_plane/testing/replan_evidence_tool_behavior.py
@@ -1,20 +1,21 @@
 from __future__ import annotations
 
+import contextlib
+import io
 import json
 import os
 import shlex
+import subprocess
 from collections.abc import Mapping
 from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
 from typing import Any
 
+from ...cli import main as cli_main
 from ...heartbeat_prompt import build_heartbeat_prompt
-from ..quota.turn_envelope import quota_action_signature_document
-from .actual_default_model_behavior_portfolio import (
-    ACTUAL_DEFAULT_MODEL_BEHAVIOR_FIXTURE_AGENT_ID,
-    ACTUAL_DEFAULT_MODEL_BEHAVIOR_FIXTURE_GOAL_ID,
-    build_actual_default_model_behavior_scenario_inputs,
+from ..runtime.agent_scoped_evidence_log import (
+    build_agent_scoped_evidence_log_command,
 )
 from .doubao_model_behavior_actor import (
     ARK_API_KEY_ENV,
@@ -36,11 +37,13 @@ REPLAN_EVIDENCE_TOOL_BEHAVIOR_MAX_CALLS = 6
 _ALLOWED_MODELS = {DOUBAO_2_1_PRO_MODEL, DOUBAO_2_1_TURBO_MODEL}
 _MAX_TOOL_ARGUMENT_BYTES = 8_192
 _MAX_PROVIDER_TOKENS = 2_048
-_READ_ONLY_PREFLIGHT_OUTPUTS = {
-    "pwd": "/workspace/loopx\n",
-    "git status --short --branch": "## codex/qualification...origin/main\n",
-    "git branch --show-current": "codex/qualification\n",
-    "git rev-parse --show-toplevel": "/workspace/loopx\n",
+_FIXTURE_GOAL_ID = "replan-evidence-live-fixture"
+_FIXTURE_AGENT_ID = "codex-replan-evidence"
+_READ_ONLY_PREFLIGHT_COMMANDS = {
+    "pwd",
+    "git status --short --branch",
+    "git branch --show-current",
+    "git rev-parse --show-toplevel",
 }
 
 _EXEC_COMMAND_TOOL = {
@@ -68,8 +71,13 @@ _EXEC_COMMAND_TOOL = {
 @dataclass(frozen=True)
 class _ReplanEvidenceToolFixture:
     task_body: str
-    quota_packet: dict[str, Any]
+    quota_guard_command: str
     required_evidence_command: str
+    project_root: Path
+    runtime_root: Path
+    local_registry_path: Path
+    global_registry_path: Path
+    source_root: Path
 
 
 @dataclass(frozen=True)
@@ -84,25 +92,113 @@ def _digest(value: str) -> str:
 
 
 def _build_fixture(root: Path) -> _ReplanEvidenceToolFixture:
-    _, packets = build_actual_default_model_behavior_scenario_inputs(root)
-    packet = dict(packets["turn_required_vision_replan"])
-    signature = quota_action_signature_document(packet)
-    required_reads = list(signature.get("required_reads") or [])
-    if len(required_reads) != 1 or not isinstance(required_reads[0], Mapping):
-        raise ValueError("replan fixture must project exactly one required read")
-    required_read = dict(required_reads[0])
-    required_command = str(required_read.get("command") or "").strip()
-    if (
-        required_read.get("kind") != "agent_scoped_evidence_log"
-        or " evidence-log " not in f" {required_command} "
-    ):
-        raise ValueError("replan fixture must bind to the agent evidence log")
+    source_root = Path(__file__).resolve().parents[3]
+    project_root = root / "project"
+    runtime_root = root / "runtime"
+    fixture_home = root / "home"
+    state_path = (
+        project_root
+        / ".codex"
+        / "goals"
+        / _FIXTURE_GOAL_ID
+        / "ACTIVE_GOAL_STATE.md"
+    )
+    local_registry_path = project_root / ".loopx" / "registry.json"
+    global_registry_path = (
+        fixture_home / ".codex" / "loopx" / "registry.global.json"
+    )
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        "---\n"
+        "status: active-read-only\n"
+        "owner_mode: goal\n"
+        'objective: "Select a new runnable direction from prior public-safe evidence."\n'
+        "updated_at: 2026-08-12T00:00:00+08:00\n"
+        "---\n\n"
+        "# Replan Evidence Live Fixture\n\n"
+        "## Objective\n\n"
+        "Select a new runnable direction from prior public-safe evidence.\n\n"
+        "## Next Action\n\n"
+        "- Replan when the observation-only frontier cannot advance the objective.\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P1-monitor] Observe the public fixture only when a material "
+        "transition appears.\n"
+        "  <!-- loopx:todo todo_id=todo_replan_evidence_monitor status=open "
+        "task_class=continuous_monitor action_kind=observe_fixture "
+        f"claimed_by={_FIXTURE_AGENT_ID} target_key=replan-evidence-fixture "
+        "cadence=1d next_due_at=2999-01-01T00:00:00+00:00 "
+        "last_checked_at=2026-08-11T00:00:00+00:00 material_change=false -->\n",
+        encoding="utf-8",
+    )
+    registry = {
+        "schema_version": "0.1",
+        "updated_at": "2026-08-12T00:00:00+08:00",
+        "common_runtime_root": str(runtime_root),
+        "goals": [
+            {
+                "id": _FIXTURE_GOAL_ID,
+                "domain": "replan-evidence-live-fixture",
+                "status": "active-read-only",
+                "repo": str(project_root),
+                "state_file": str(state_path),
+                "adapter": {
+                    "kind": "harness_self_improvement",
+                    "status": "connected-read-only",
+                },
+                "coordination": {
+                    "registered_agents": [_FIXTURE_AGENT_ID],
+                    "agent_model": "peer_v1",
+                },
+                "authority_sources": [],
+                "quota": {
+                    "compute": 1.0,
+                    "window_hours": 24,
+                    "allowed_slots": 5,
+                },
+            }
+        ],
+    }
+    registry_text = json.dumps(registry, ensure_ascii=False, indent=2, sort_keys=True)
+    for registry_path in (local_registry_path, global_registry_path):
+        registry_path.parent.mkdir(parents=True, exist_ok=True)
+        registry_path.write_text(registry_text + "\n", encoding="utf-8")
+
+    runs_dir = runtime_root / "goals" / _FIXTURE_GOAL_ID / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    run_json = runs_dir / "2026-08-11T00-00-00+00-00.json"
+    run_markdown = runs_dir / "2026-08-11T00-00-00+00-00.md"
+    prior_run = {
+        "generated_at": "2026-08-11T00:00:00+00:00",
+        "goal_id": _FIXTURE_GOAL_ID,
+        "agent_id": _FIXTURE_AGENT_ID,
+        "classification": "fixture_observation_without_material_transition_v0",
+        "recommended_action": (
+            "Observe the public fixture only when a material transition appears."
+        ),
+        "health_check": "state_file 1/1; registry_goal 1/1",
+        "delivery_batch_scale": "single_surface",
+        "delivery_outcome": "outcome_gap",
+        "json_path": str(run_json),
+        "markdown_path": str(run_markdown),
+    }
+    run_json.write_text(json.dumps(prior_run, sort_keys=True) + "\n", encoding="utf-8")
+    run_markdown.write_text("# Public Fixture Observation\n", encoding="utf-8")
+    (runs_dir / "index.jsonl").write_text(
+        json.dumps(prior_run, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    required_command = build_agent_scoped_evidence_log_command(
+        goal_id=_FIXTURE_GOAL_ID,
+        agent_id=_FIXTURE_AGENT_ID,
+        limit=24,
+    )
 
     prompt = build_heartbeat_prompt(
-        goal_id=ACTUAL_DEFAULT_MODEL_BEHAVIOR_FIXTURE_GOAL_ID,
+        goal_id=_FIXTURE_GOAL_ID,
         thin=True,
-        agent_id=ACTUAL_DEFAULT_MODEL_BEHAVIOR_FIXTURE_AGENT_ID,
-        registered_agents=[ACTUAL_DEFAULT_MODEL_BEHAVIOR_FIXTURE_AGENT_ID],
+        agent_id=_FIXTURE_AGENT_ID,
+        registered_agents=[_FIXTURE_AGENT_ID],
         available_capabilities=[
             "shell",
             "filesystem_read",
@@ -115,8 +211,13 @@ def _build_fixture(root: Path) -> _ReplanEvidenceToolFixture:
         raise ValueError("heartbeat fixture must contain its production quota guard")
     return _ReplanEvidenceToolFixture(
         task_body=str(prompt["task_body"]),
-        quota_packet=packet,
+        quota_guard_command=quota_guard_command,
         required_evidence_command=required_command,
+        project_root=project_root,
+        runtime_root=runtime_root,
+        local_registry_path=local_registry_path,
+        global_registry_path=global_registry_path,
+        source_root=source_root,
     )
 
 
@@ -261,12 +362,92 @@ def _is_quota_guard(command: str) -> bool:
     return bool(
         tokens[quota_index : quota_index + 2] == ["quota", "should-run"]
         and _argument_value(tokens, "--goal-id")
-        == ACTUAL_DEFAULT_MODEL_BEHAVIOR_FIXTURE_GOAL_ID
+        == _FIXTURE_GOAL_ID
         and _argument_value(tokens, "--agent-id")
-        == ACTUAL_DEFAULT_MODEL_BEHAVIOR_FIXTURE_AGENT_ID
+        == _FIXTURE_AGENT_ID
         and "--codex-app" in tokens
         and _argument_value(tokens, "--turn-instance-id")
     )
+
+
+def _required_evidence_command_from_packet(packet: Mapping[str, Any]) -> str:
+    required_reads = list(packet.get("required_reads") or [])
+    if len(required_reads) != 1 or not isinstance(required_reads[0], Mapping):
+        raise ValueError("real quota packet must project exactly one required read")
+    required_read = dict(required_reads[0])
+    command = str(required_read.get("command") or "").strip()
+    if (
+        required_read.get("kind") != "agent_scoped_evidence_log"
+        or required_read.get("goal_id") != _FIXTURE_GOAL_ID
+        or required_read.get("agent_id") != _FIXTURE_AGENT_ID
+        or " evidence-log " not in f" {command} "
+    ):
+        raise ValueError("real quota packet must bind to the fixture evidence log")
+    return command
+
+
+def _replace_argument(tokens: list[str], option: str, value: str) -> None:
+    try:
+        index = tokens.index(option)
+    except ValueError:
+        return
+    if index + 1 >= len(tokens):
+        raise ValueError(f"missing value for {option}")
+    tokens[index + 1] = value
+
+
+@contextlib.contextmanager
+def _working_directory(path: Path):
+    previous = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+def _execute_loopx_read(
+    command: str,
+    *,
+    fixture: _ReplanEvidenceToolFixture,
+    turn_instance_id: str,
+    quota_guard: bool,
+) -> str:
+    tokens = _loopx_command_tokens(command)
+    if not tokens:
+        raise ValueError("command does not contain one bounded loopx invocation")
+    argv = list(tokens[1:])
+    if quota_guard:
+        _replace_argument(argv, "--registry", str(fixture.global_registry_path))
+        _replace_argument(argv, "--turn-instance-id", turn_instance_id)
+    output = io.StringIO()
+    error = io.StringIO()
+    with _working_directory(fixture.project_root):
+        with contextlib.redirect_stdout(output), contextlib.redirect_stderr(error):
+            exit_code = cli_main(argv)
+    if exit_code != 0:
+        raise RuntimeError(
+            f"LoopX read command failed with exit={exit_code}: {error.getvalue()[-500:]}"
+        )
+    return output.getvalue()
+
+
+def _execute_workspace_read(
+    command: str,
+    *,
+    fixture: _ReplanEvidenceToolFixture,
+) -> str:
+    completed = subprocess.run(
+        shlex.split(command),
+        cwd=fixture.source_root,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(f"workspace read failed with exit={completed.returncode}")
+    return completed.stdout
 
 
 def _classify_tool_command(
@@ -274,26 +455,19 @@ def _classify_tool_command(
     *,
     fixture: _ReplanEvidenceToolFixture,
     quota_observed: bool,
+    required_evidence_command: str | None,
 ) -> tuple[str, str | None]:
-    if command == fixture.required_evidence_command:
+    if command == (required_evidence_command or fixture.required_evidence_command):
         if not quota_observed:
             return "evidence_log_before_quota", None
         return "evidence_log", None
     if _is_quota_guard(command):
-        return (
-            "quota_should_run",
-            json.dumps(
-                fixture.quota_packet,
-                ensure_ascii=False,
-                sort_keys=True,
-                separators=(",", ":"),
-            ),
-        )
+        return "quota_should_run", None
     clock_output = _clock_output(command)
     if clock_output is not None:
         return "clock", clock_output
-    if command in _READ_ONLY_PREFLIGHT_OUTPUTS:
-        return "workspace_read", _READ_ONLY_PREFLIGHT_OUTPUTS[command]
+    if command in _READ_ONLY_PREFLIGHT_COMMANDS:
+        return "workspace_read", None
     if " evidence-log " in f" {command} ":
         return "wrong_evidence_log", None
     return "unexpected_command", None
@@ -307,6 +481,8 @@ def _receipt(
     passed: bool,
     failure_code: str | None,
     required_evidence_command: str,
+    local_fixture_writes_executed: bool,
+    read_only_host_commands_executed: bool,
 ) -> dict[str, Any]:
     return {
         "schema_version": REPLAN_EVIDENCE_TOOL_BEHAVIOR_RECEIPT_SCHEMA_VERSION,
@@ -323,15 +499,17 @@ def _receipt(
             "raw_prompt_persisted": False,
             "raw_provider_response_persisted": False,
             "raw_command_persisted": False,
-            "filesystem_writes_executed": False,
+            "filesystem_writes_executed": local_fixture_writes_executed,
+            "writes_limited_to_temporary_fixture": local_fixture_writes_executed,
             "external_writes_executed": False,
             "shell_commands_executed": False,
+            "read_only_host_commands_executed": read_only_host_commands_executed,
         },
     }
 
 
 class DoubaoReplanEvidenceToolBehaviorActor:
-    """Run a bounded production-prompt function-tool loop without mutations."""
+    """Run a bounded production-prompt loop against a hermetic real LoopX state."""
 
     def __init__(
         self,
@@ -395,8 +573,27 @@ class DoubaoReplanEvidenceToolBehaviorActor:
         ]
         steps: list[dict[str, Any]] = []
         quota_observed = False
+        required_evidence_command: str | None = None
         seen_once: set[str] = set()
         actor_ref = f"ark:{self._model}"
+        local_fixture_writes_executed = True
+        read_only_host_commands_executed = False
+        qualification_digest = sha256(qualification_id.encode()).hexdigest()[:16]
+        turn_instance_id = f"qualification-{qualification_digest}"
+
+        def receipt(*, passed: bool, failure_code: str | None) -> dict[str, Any]:
+            return _receipt(
+                qualification_id=qualification_id,
+                actor_ref=actor_ref,
+                steps=steps,
+                passed=passed,
+                failure_code=failure_code,
+                required_evidence_command=(
+                    required_evidence_command or fixture.required_evidence_command
+                ),
+                local_fixture_writes_executed=local_fixture_writes_executed,
+                read_only_host_commands_executed=read_only_host_commands_executed,
+            )
 
         for _ in range(REPLAN_EVIDENCE_TOOL_BEHAVIOR_MAX_CALLS):
             body = {
@@ -433,19 +630,16 @@ class DoubaoReplanEvidenceToolBehaviorActor:
                     error_code="provider_transport_failed",
                 ) from None
             if tool_call is None:
-                return _receipt(
-                    qualification_id=qualification_id,
-                    actor_ref=actor_ref,
-                    steps=steps,
+                return receipt(
                     passed=False,
                     failure_code="model_returned_without_tool_call",
-                    required_evidence_command=fixture.required_evidence_command,
                 )
 
             kind, tool_output = _classify_tool_command(
                 tool_call.command,
                 fixture=fixture,
                 quota_observed=quota_observed,
+                required_evidence_command=required_evidence_command,
             )
             steps.append(
                 {
@@ -455,40 +649,78 @@ class DoubaoReplanEvidenceToolBehaviorActor:
                 }
             )
             if kind == "evidence_log":
-                return _receipt(
-                    qualification_id=qualification_id,
-                    actor_ref=actor_ref,
-                    steps=steps,
-                    passed=True,
-                    failure_code=None,
-                    required_evidence_command=fixture.required_evidence_command,
-                )
+                try:
+                    evidence_output = _execute_loopx_read(
+                        tool_call.command,
+                        fixture=fixture,
+                        turn_instance_id=turn_instance_id,
+                        quota_guard=False,
+                    )
+                    evidence_packet = json.loads(evidence_output)
+                    if not (
+                        isinstance(evidence_packet, Mapping)
+                        and evidence_packet.get("ok") is True
+                        and evidence_packet.get("schema_version")
+                        == "agent_scoped_evidence_log_v0"
+                        and evidence_packet.get("goal_id") == _FIXTURE_GOAL_ID
+                        and evidence_packet.get("agent_id") == _FIXTURE_AGENT_ID
+                    ):
+                        raise ValueError("evidence-log readback does not match fixture")
+                    read_only_host_commands_executed = True
+                except (RuntimeError, ValueError, json.JSONDecodeError):
+                    return receipt(
+                        passed=False,
+                        failure_code="evidence_log_execution_failed",
+                    )
+                return receipt(passed=True, failure_code=None)
             if kind in {
                 "evidence_log_before_quota",
                 "wrong_evidence_log",
                 "unexpected_command",
             }:
-                return _receipt(
-                    qualification_id=qualification_id,
-                    actor_ref=actor_ref,
-                    steps=steps,
-                    passed=False,
-                    failure_code=kind,
-                    required_evidence_command=fixture.required_evidence_command,
-                )
+                return receipt(passed=False, failure_code=kind)
             if kind in {"clock", "quota_should_run"} and kind in seen_once:
-                return _receipt(
-                    qualification_id=qualification_id,
-                    actor_ref=actor_ref,
-                    steps=steps,
+                return receipt(
                     passed=False,
                     failure_code=f"repeated_{kind}",
-                    required_evidence_command=fixture.required_evidence_command,
                 )
             if kind in {"clock", "quota_should_run"}:
                 seen_once.add(kind)
+            if kind == "clock":
+                read_only_host_commands_executed = True
             if kind == "quota_should_run":
-                quota_observed = True
+                try:
+                    tool_output = _execute_loopx_read(
+                        tool_call.command,
+                        fixture=fixture,
+                        turn_instance_id=turn_instance_id,
+                        quota_guard=True,
+                    )
+                    quota_packet = json.loads(tool_output)
+                    required_evidence_command = _required_evidence_command_from_packet(
+                        quota_packet
+                    )
+                    if required_evidence_command != fixture.required_evidence_command:
+                        raise ValueError("quota required-read command drifted from fixture")
+                    quota_observed = True
+                    read_only_host_commands_executed = True
+                except (RuntimeError, ValueError, json.JSONDecodeError):
+                    return receipt(
+                        passed=False,
+                        failure_code="quota_execution_failed",
+                    )
+            elif kind == "workspace_read":
+                try:
+                    tool_output = _execute_workspace_read(
+                        tool_call.command,
+                        fixture=fixture,
+                    )
+                    read_only_host_commands_executed = True
+                except RuntimeError:
+                    return receipt(
+                        passed=False,
+                        failure_code="workspace_read_failed",
+                    )
             messages.extend(
                 [
                     {
@@ -504,11 +736,7 @@ class DoubaoReplanEvidenceToolBehaviorActor:
                 ]
             )
 
-        return _receipt(
-            qualification_id=qualification_id,
-            actor_ref=actor_ref,
-            steps=steps,
+        return receipt(
             passed=False,
             failure_code="tool_call_budget_exhausted",
-            required_evidence_command=fixture.required_evidence_command,
         )

--- a/scripts/qualify-doubao-replan-evidence-tool-live.py
+++ b/scripts/qualify-doubao-replan-evidence-tool-live.py
@@ -24,8 +24,9 @@ from loopx.control_plane.testing.replan_evidence_tool_behavior import (  # noqa:
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
-            "Run one production-prompt Doubao function-tool loop and verify "
-            "that replan selects the projected evidence-log read."
+            "Run one production-prompt Doubao function-tool loop against a "
+            "hermetic real LoopX goal and verify that replan selects and "
+            "executes the projected evidence-log read."
         )
     )
     parser.add_argument("--qualification-id", required=True)

--- a/tests/control_plane/test_replan_evidence_tool_behavior.py
+++ b/tests/control_plane/test_replan_evidence_tool_behavior.py
@@ -42,14 +42,8 @@ def test_real_tool_loop_observes_production_evidence_log_intent(
     requests: list[dict[str, Any]] = []
     commands = [
         "date -Iseconds",
-        (
-            "export LOOPX_TURN=2026-08-12T00:00:00+08:00 && "
-            'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" '
-            "quota should-run --goal-id portfolio-goal --agent-id codex-portfolio "
-            "--available-capability shell --available-capability filesystem_read "
-            "--available-capability filesystem_write --codex-app "
-            '--turn-instance-id "${LOOPX_TURN:?}"'
-        ),
+        "export LOOPX_TURN=2026-08-12T00:00:00+08:00 && "
+        + fixture.quota_guard_command,
         fixture.required_evidence_command,
     ]
 
@@ -84,9 +78,11 @@ def test_real_tool_loop_observes_production_evidence_log_intent(
         "raw_prompt_persisted": False,
         "raw_provider_response_persisted": False,
         "raw_command_persisted": False,
-        "filesystem_writes_executed": False,
+        "filesystem_writes_executed": True,
+        "writes_limited_to_temporary_fixture": True,
         "external_writes_executed": False,
         "shell_commands_executed": False,
+        "read_only_host_commands_executed": True,
     }
     assert fixture.required_evidence_command not in json.dumps(receipt, sort_keys=True)
 
@@ -113,7 +109,29 @@ def test_real_tool_loop_observes_production_evidence_log_intent(
         "content": "2026-08-12T00:00:00+08:00\n",
     }
     quota_result = json.loads(requests[2]["messages"][-1]["content"])
-    assert quota_result == fixture.quota_packet
+    assert quota_result["decision"] == "autonomous_replan_required"
+    assert quota_result["effective_action"] == "autonomous_replan_required"
+    assert quota_result["required_reads"] == [
+        quota_result["interaction_contract"]["agent_channel"]["required_reads"][0]
+    ]
+    assert quota_result["required_reads"][0]["command"] == (
+        fixture.required_evidence_command
+    )
+    rollout_path = (
+        tmp_path
+        / "actor"
+        / "runtime"
+        / "goals"
+        / "replan-evidence-live-fixture"
+        / "rollout-event-log.jsonl"
+    )
+    rollout_events = [
+        json.loads(line)
+        for line in rollout_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert rollout_events[-1]["event_kind"] == "quota_should_run"
+    assert rollout_events[-1]["agent_id"] == "codex-replan-evidence"
 
 
 def test_tool_loop_rejects_evidence_log_before_quota(tmp_path: Path) -> None:
@@ -139,11 +157,7 @@ def test_tool_loop_accepts_the_real_host_utc_clock_shape(tmp_path: Path) -> None
     fixture = _build_fixture(tmp_path / "oracle")
     commands = [
         'date -u +"%Y-%m-%dT%H:%M:%SZ"',
-        (
-            "loopx quota should-run --goal-id portfolio-goal "
-            "--agent-id codex-portfolio --codex-app "
-            "--turn-instance-id turn-001"
-        ),
+        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
         fixture.required_evidence_command,
     ]
     requests: list[dict[str, Any]] = []
@@ -171,11 +185,7 @@ def test_tool_loop_allows_distinct_normal_workspace_preflight_reads(
     commands = [
         "pwd",
         "git status --short --branch",
-        (
-            "loopx quota should-run --goal-id portfolio-goal "
-            "--agent-id codex-portfolio --codex-app "
-            "--turn-instance-id turn-001"
-        ),
+        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
         fixture.required_evidence_command,
     ]
     call_count = 0
@@ -208,16 +218,14 @@ def test_tool_loop_rejects_generic_or_wrong_evidence_read(tmp_path: Path) -> Non
     responses = [
         _tool_response(
             "call-1",
-            (
-                "loopx quota should-run --goal-id portfolio-goal "
-                "--agent-id codex-portfolio --codex-app "
-                "--turn-instance-id turn-001"
+            fixture.quota_guard_command.replace(
+                '"${LOOPX_TURN:?}"', "turn-001"
             ),
         ),
         _tool_response(
             "call-2",
             (
-                "loopx --format json evidence-log --goal-id portfolio-goal "
+                "loopx --format json evidence-log --goal-id replan-evidence-live-fixture "
                 "--agent-id another-agent --thin --limit 24"
             ),
         ),


### PR DESCRIPTION
## Summary

This is a focused follow-up to #3105. It replaces the prebuilt quota-packet behavior fixture with a hermetic real LoopX goal and executes the product CLI selected by the model.

The qualified behavior is now:

1. create a public-safe temporary goal, registry, active state, monitor frontier, and prior run evidence;
2. give Doubao the shipped thin Codex App heartbeat task plus the normal command tool;
3. let the model select and run the real `quota should-run` command;
4. derive the exact evidence-log read target from that real quota response;
5. require the model to select the exact `evidence-log` read and execute it through the real CLI;
6. validate the returned schema, goal identity, agent identity, and bounded action receipt.

The harness uses a strict argv allowlist and an isolated `python -m loopx.cli` process boundary. It does not invoke a shell interpreter. Fake transports cover adapter/protocol negatives only; the live provider run is the model-behavior evidence.

The realistic temporary root also exposed an unrelated path-length dependency in the CLI differential budget fixture. This PR stabilizes the existing fixture root instead of increasing the 34,000-character budget.

## Validation

- live Doubao qualification passed on commit `b4788f452450d92bbc8ede13907b76f7212eb1c6`: `clock -> quota_should_run -> evidence_log`
- exact dynamic `required_reads[0]` digest matched the model-selected evidence-log command
- `6 passed` focused tool-behavior tests, including prose-only, premature read, wrong-agent read, and unexpected-command negatives
- `10 passed` replan novelty-policy tests
- `1049 passed` control-plane suite on the identical source tree `3cc747713d41d702b0328f3006d1ebf3610ffcee`
- CLI output budget regression smoke passed without a budget increase
- maintainability ratchet and the standard premerge plan checks passed
- public/private boundary scan passed for all changed paths
- `git diff --check` passed

## Scope

- no benchmark launch, scoring, permission, or scheduler behavior change
- no credentials, raw provider output, private state, local paths, or generated logs committed
- no auto-merge requested
