### PR TITLE
fix(control-plane): completed-todo chain replan must fire without a vision baseline

### DIFF
--- a/loopx/control_plane/goals/goal_frontier/outcome_continuity.py
+++ b/loopx/control_plane/goals/goal_frontier/outcome_continuity.py
@@ -410,9 +410,10 @@ def acceptance_gaps_from_todo_completion_checkpoint(
 ) -> list[dict[str, Any]]:
     """Require a checkpoint after a bounded chain of scoped completions."""
 
-    if not isinstance(agent_vision, dict):
-        return []
-    if goal_vision_state_is_closed(str(agent_vision.get("state") or "")):
+    vision_present = isinstance(agent_vision, dict)
+    if vision_present and goal_vision_state_is_closed(
+        str(agent_vision.get("state") or "")
+    ):
         return []
     if not agent_id:
         return []
@@ -445,7 +446,7 @@ def acceptance_gaps_from_todo_completion_checkpoint(
         isinstance(checkpoint, dict)
         and checkpoint_generated_at is not None
         and checkpoint_generated_at >= completed_at
-        and _checkpoint_covers_completed_todo(agent_vision, checkpoint)
+        and _checkpoint_covers_completed_todo(agent_vision or {}, checkpoint)
     ):
         return []
 
@@ -453,7 +454,7 @@ def acceptance_gaps_from_todo_completion_checkpoint(
         checkpoint_generated_at
         if isinstance(checkpoint, dict)
         and checkpoint_generated_at is not None
-        and _checkpoint_covers_completed_todo(agent_vision, checkpoint)
+        and _checkpoint_covers_completed_todo(agent_vision or {}, checkpoint)
         else None
     )
     uncheckpointed_items = [
@@ -467,7 +468,7 @@ def acceptance_gaps_from_todo_completion_checkpoint(
     if len(uncheckpointed_items) < threshold:
         return []
 
-    patch = _dict_field(agent_vision, "vision_patch")
+    patch = _dict_field(agent_vision, "vision_patch") if vision_present else {}
     return [
         {
             "kind": VISION_OUTCOME_CHECKPOINT_REQUIRED_TRIGGER,
@@ -479,7 +480,13 @@ def acceptance_gaps_from_todo_completion_checkpoint(
             ),
             "acceptance_summary": (
                 _compact_text(patch.get("acceptance_summary"), limit=420)
-                or "Name the active final-outcome claim and its authoritative evidence."
+                or (
+                    "Write a bounded agent vision patch, then name the active "
+                    "final-outcome claim and its authoritative evidence."
+                    if not vision_present
+                    else "Name the active final-outcome claim and its "
+                    "authoritative evidence."
+                )
             ),
             "advancement_policy": patch.get("advancement_policy"),
             "completed_todo_id": latest_item.get("todo_id"),

--- a/tests/control_plane/test_goal_vision_succession.py
+++ b/tests/control_plane/test_goal_vision_succession.py
@@ -317,6 +317,32 @@ def test_completed_todo_chain_requires_a_later_outcome_checkpoint(
         assert gaps[0]["completed_todo_threshold"] == 5
 
 
+def test_completed_todo_chain_without_vision_baseline_still_requires_checkpoint() -> None:
+    summary = {
+        "recent_completed_advancement_items": [
+            {
+                "todo_id": f"todo_completed_no_vision_{index}",
+                "claimed_by": AGENT_ID,
+                "completed_at": f"2026-07-12T00:02:0{index}Z",
+            }
+            for index in range(5)
+        ]
+    }
+
+    gaps = acceptance_gaps_from_todo_completion_checkpoint(
+        None,
+        None,
+        agent_todo_summary=summary,
+        agent_id=AGENT_ID,
+    )
+
+    assert len(gaps) == 1
+    assert gaps[0]["kind"] == "vision_outcome_checkpoint_required"
+    assert gaps[0]["completed_todo_count"] == 5
+    assert gaps[0]["completed_todo_threshold"] == 5
+    assert "Write a bounded agent vision patch" in gaps[0]["acceptance_summary"]
+
+
 @pytest.mark.parametrize(
     ("advancement_policy", "repair_delta_kinds", "expects_gap"),
     [


### PR DESCRIPTION
## Summary

`acceptance_gaps_from_todo_completion_checkpoint` early-returned `[]` whenever the agent had no persisted per-agent vision baseline. Any agent that completed work while its vision baseline was missing (for example because refresh-state recorded `vision_checkpoint_missing`/`missing_baseline`) silently disabled the completed-chain replan: 5+ completed advancement todos no longer required a checkpoint, and the goal could keep accepting `validated_progress` + spend forever while the only visible gap (`vision_checkpoint_missing`) did not force replan while any open todo remained.

This PR removes that silent disable: the completed-chain checkpoint now counts uncheckpointed completions even without a vision baseline, and the emitted gap explicitly asks the agent to write a bounded vision patch. The chain threshold (5) and all existing checkpoint semantics are unchanged.

## Validation

- New test: `test_completed_todo_chain_without_vision_baseline_still_requires_checkpoint`
- `test_goal_vision_succession.py`, `test_goal_frontier_replan_rules.py`, `test_goal_vision_blocked_successor.py`, `test_monitor_replan_agent_scope.py`, `test_goal_terminal_no_followup.py` — 116 passed
- `heartbeat-quota-flow-smoke`, `quota-replan-decision-plane-smoke`, `autonomous-replan-obligation-readmodel-smoke`, `autonomous-replan-obligation-smoke` — ok
- `ruff check --select F` on changed files — passed

No private state, credentials, local paths, or benchmark evidence included.