### PR TITLE
fix(control-plane): execute quota-projected actions through real model tools

### DIFF
--- a/docs/development/control-plane-course/10-autonomous-agent-quality-gates.md
+++ b/docs/development/control-plane-course/10-autonomous-agent-quality-gates.md
@@ -475,7 +475,9 @@ guided_transaction = {
 `loopx/control_plane/testing/actual_default_model_behavior_portfolio.py::_scenario_contract`：
 
 ```python
-if spec.actor_kind in {"turn", "turn_tool", "replan_tool"}:
+if spec.actor_kind in {
+    "turn", "turn_tool", "replan_tool", "scoped_gate_tool"
+}:
     build_model_behavior_actor_request(
         packet,
         semantic_contract_required=False,

--- a/docs/development/control-plane-course/10-autonomous-agent-quality-gates.md
+++ b/docs/development/control-plane-course/10-autonomous-agent-quality-gates.md
@@ -232,6 +232,14 @@ candidate checkout 的正式 packet builder
 todo、peer routing、same-agent continuation、final human gate、healthy continuation 和
 projection repair；每个场景重复两次，所有重复都要通过。
 
+这些场景不应一律只做 packet interpretation。当结论是“agent 必须真的调用工具”时，
+portfolio 使用 scenario-owned 的 hermetic actor：selected Todo 执行目标 read，replan 执行
+evidence-log read，scoped gate 在呈现非阻塞 notice 后执行 successor，capability bridge
+则执行 quota 投影的 repair Todo 写入并由 host 读回。第四种场景里，等待或更新
+monitor fallback、或在 quota 后重新读取 workspace，都必须失败。四个 actor 只共享已证明的 tool decoding 和隔离 CLI 机制；
+各自的 Goal fixture、合法动作状态机和 semantic oracle 保持独立，不引入通用 scenario
+runner。
+
 双臂只在两类问题中合理：
 
 1. 临时验证一个敏感改动是否与明确 baseline 语义等价；
@@ -476,7 +484,8 @@ guided_transaction = {
 
 ```python
 if spec.actor_kind in {
-    "turn", "turn_tool", "replan_tool", "scoped_gate_tool"
+    "turn", "turn_tool", "replan_tool", "scoped_gate_tool",
+    "capability_repair_tool"
 }:
     build_model_behavior_actor_request(
         packet,

--- a/docs/development/control-plane-course/10-autonomous-agent-quality-gates.md
+++ b/docs/development/control-plane-course/10-autonomous-agent-quality-gates.md
@@ -475,11 +475,15 @@ guided_transaction = {
 `loopx/control_plane/testing/actual_default_model_behavior_portfolio.py::_scenario_contract`：
 
 ```python
-if spec.actor_kind == "turn":
-    action_signature = dict(packet.get("action_signature") or {})
-    if action_signature.get("matches") is not True:
-        raise ValueError("turn scenario action signature parity is not verified")
-    build_model_behavior_actor_request(packet, semantic_contract_required=True, ...)
+if spec.actor_kind in {"turn", "turn_tool", "replan_tool"}:
+    build_model_behavior_actor_request(
+        packet,
+        semantic_contract_required=False,
+        ...,
+    )
+    contract = _turn_expected_contract(source_packet)
+    if _turn_expected_contract(packet) != contract:
+        raise ValueError("actor packet diverges from source action contract")
 else:
     if spec.phase == "entry":
         _validate_actual_default_projection(packet)

--- a/docs/development/testing-and-quality.md
+++ b/docs/development/testing-and-quality.md
@@ -343,8 +343,10 @@ The regular live suite is
 `actual_default_model_behavior_portfolio_v0`: fifteen one-arm scenarios and two
 attempts each. Its selected-Todo case starts from a production thin heartbeat,
 executes real quota, and requires the model to perform the selected Todo's
-read-only target action. The other turn cases remain bounded packet-interpretation
-checks. Nine core scenarios check normal
+read-only target action. Its required-vision replan case independently builds a
+hermetic missing-vision state, executes real quota, and requires the model to
+perform the exact projected evidence-log read. The other turn cases remain
+bounded packet-interpretation checks. Nine core scenarios check normal
 onboarding, agent identity and goal selection, selected todo, peer identity
 routing, same-agent continuation, final human gate, healthy continuation, and
 projection repair. Three composition scenarios check vision/monitor/peer replan
@@ -361,7 +363,7 @@ remaining live turn actor cases consume the default CLI hot-path
 `quota should-run` projection used by Codex App automation and return
 runtime-facing decisions rather than echoing the testing-only nine-field
 semantic contract. The suite has 30 bounded scenario attempts and, after
-accounting for the selected-Todo tool loop, at most 40 provider turns.
+accounting for both tool loops, at most 50 provider turns.
 Exact scheduler, vision, writeback, and warning fields stay in deterministic
 action-signature coverage; pair mode keeps TurnEnvelope semantic extraction for
 explicit packet differentials or outcome claims.
@@ -377,12 +379,14 @@ clean/noisy 场景保持不变，同时要求 blocking gate 与 non-blocking not
 work 与 required vision replan 仍然可区分。每个
 场景都有在 CLI projection 前推导的独立确定性 source oracle，所有重复都必须通过；
 actor 硬错误不自动重试。selected-Todo 场景从正式 thin heartbeat 开始，执行真实 quota，
-并要求模型实际读取 selected Todo 指向的目标；其他 turn 场景仍直接读取 Codex App
+并要求模型实际读取 selected Todo 指向的目标；required-vision replan 场景独立构造
+缺失 vision 的 hermetic 状态，执行真实 quota，并要求模型实际读取投影出的精确
+evidence-log；其他 turn 场景仍直接读取 Codex App
 automation 使用的默认 CLI hot-path `quota should-run` projection 并返回运行时决策，
 因此属于 packet interpretation，而不是工具行为证明。scheduler、vision、writeback 与
 warning 的精确字段继续由 action-signature 确定性覆盖；pair 中的 TurnEnvelope 只用于
-明确的 packet 差分或结果提升声明。全套仍是 30 个有界 scenario attempt；考虑
-selected-Todo 每次最多 6 个 provider turn，最坏上限为 40 个 provider turn。
+明确的 packet 差分或结果提升声明。全套仍是 30 个有界 scenario attempt；考虑两个
+工具场景各自每次最多 6 个 provider turn，最坏上限为 50 个 provider turn。
 
 For onboarding packets, the suite uses the shipped guided packet builder and
 redacts only local absolute path surfaces before provider transport. The

--- a/docs/development/testing-and-quality.md
+++ b/docs/development/testing-and-quality.md
@@ -339,6 +339,18 @@ evidence-log 命令才算通过。模型看不到测试专用 decision schema、
 不调用 shell，quota 的正常 receipt 只写入临时 fixture，仓库与外部系统均不写入，最终
 receipt 只保留 action kind 与 command digest。
 
+The scoped-gate successor composition case is also a real tool loop. Its
+hermetic Goal contains an unrelated open user gate and a deferred successor
+whose prerequisite is complete. After real quota selects the successor, the
+model must surface the user action as a non-blocking assistant notice and read
+the exact successor target. Waiting after the notice, omitting it, or reading
+the gated decoy fails.
+
+```bash
+python3 scripts/qualify-doubao-scoped-gate-successor-tool-live.py \
+  --qualification-id <public-safe-run-id>
+```
+
 The regular live suite is
 `actual_default_model_behavior_portfolio_v0`: fifteen one-arm scenarios and two
 attempts each. Its selected-Todo case starts from a production thin heartbeat,
@@ -363,7 +375,7 @@ remaining live turn actor cases consume the default CLI hot-path
 `quota should-run` projection used by Codex App automation and return
 runtime-facing decisions rather than echoing the testing-only nine-field
 semantic contract. The suite has 30 bounded scenario attempts and, after
-accounting for both tool loops, at most 50 provider turns.
+accounting for all three tool loops, at most 60 provider turns.
 Exact scheduler, vision, writeback, and warning fields stay in deterministic
 action-signature coverage; pair mode keeps TurnEnvelope semantic extraction for
 explicit packet differentials or outcome claims.
@@ -383,10 +395,12 @@ actor 硬错误不自动重试。selected-Todo 场景从正式 thin heartbeat �
 缺失 vision 的 hermetic 状态，执行真实 quota，并要求模型实际读取投影出的精确
 evidence-log；其他 turn 场景仍直接读取 Codex App
 automation 使用的默认 CLI hot-path `quota should-run` projection 并返回运行时决策，
-因此属于 packet interpretation，而不是工具行为证明。scheduler、vision、writeback 与
+scoped-gate successor 场景也从 hermetic Goal 与正式 heartbeat 开始：真实 quota 必须
+同时投影非阻塞 user notice 和 ready deferred successor，模型随后既要呈现提醒，也要
+实际执行被选中的 successor；其他 turn 场景仍属于 packet interpretation。scheduler、vision、writeback 与
 warning 的精确字段继续由 action-signature 确定性覆盖；pair 中的 TurnEnvelope 只用于
-明确的 packet 差分或结果提升声明。全套仍是 30 个有界 scenario attempt；考虑两个
-工具场景各自每次最多 6 个 provider turn，最坏上限为 50 个 provider turn。
+明确的 packet 差分或结果提升声明。全套仍是 30 个有界 scenario attempt；考虑三个
+工具场景各自每次最多 6 个 provider turn，最坏上限为 60 个 provider turn。
 
 For onboarding packets, the suite uses the shipped guided packet builder and
 redacts only local absolute path surfaces before provider transport. The

--- a/docs/development/testing-and-quality.md
+++ b/docs/development/testing-and-quality.md
@@ -259,15 +259,17 @@ continues after a healthy onboarding transition, or repairs a known projection
 gap. The composition group also checks decisions where several individually
 reasonable signals conflict: a monitor lane says wait while a vision contract
 requires replan; a user notice remains open while an independent successor must
-run; or capability-blocked advancement yields to monitor-schedule repair. Keep
+run; or capability-blocked advancement requires an agent-owned capability-
+bridge repair before any monitor fallback. Keep
 schema validity, cold-path restoration, exact field presence, and the underlying
 state transition table in deterministic tests.
 
 它适合验证模型是否识别 selected todo、尊重人类门禁、在健康 onboarding transition
 后继续、或识别已知 projection gap。组合场景还会验证多个单独看来都合理、合在一起
 却存在优先级冲突的信号：monitor lane 要求等待但 vision 合同要求 replan；user notice
-仍打开但独立 successor 必须运行；advancement 被 capability 阻塞时应转而修复 monitor
-schedule。schema、冷路径恢复、精确字段存在性和底层状态转移表仍由确定性测试负责。
+仍打开但独立 successor 必须运行；advancement 被 capability 阻塞时，agent 必须先
+执行 capability-bridge repair，不能退回 monitor wait。schema、冷路径恢复、精确字段
+存在性和底层状态转移表仍由确定性测试负责。
 
 Live Doubao calls are a low-frequency local/manual gate, not ordinary CI.
 `ARK_API_KEY` is injected only through the process environment. Packets,
@@ -351,6 +353,24 @@ python3 scripts/qualify-doubao-scoped-gate-successor-tool-live.py \
   --qualification-id <public-safe-run-id>
 ```
 
+Capability-bridge repair is the fourth real tool loop. Its hermetic Goal has a
+capability-blocked advancement Todo and an incomplete monitor fallback. Real
+quota must project `capability_bridge_repair`. The actor sends the shipped task
+body inside the same heartbeat trigger envelope, including its trigger time,
+that the Codex App model normally receives. The default CLI projection keeps
+`interaction_contract` in the action-first prefix rather than after diagnostic
+lanes; the model must then execute the
+projected `todo add --target-capability ... --unblocks-todo-id ...` action, and
+the host reads the new repair Todo back before passing. Waiting on or updating
+the monitor, repairing before quota, or materializing the wrong capability
+fails. Bounded workspace inspection remains available before quota; any
+workspace read after quota is classified as backtracking and fails immediately.
+
+```bash
+python3 scripts/qualify-doubao-capability-monitor-repair-tool-live.py \
+  --qualification-id <public-safe-run-id>
+```
+
 The regular live suite is
 `actual_default_model_behavior_portfolio_v0`: fifteen one-arm scenarios and two
 attempts each. Its selected-Todo case starts from a production thin heartbeat,
@@ -363,7 +383,7 @@ onboarding, agent identity and goal selection, selected todo, peer identity
 routing, same-agent continuation, final human gate, healthy continuation, and
 projection repair. Three composition scenarios check vision/monitor/peer replan
 precedence, non-blocking user notice plus ready-successor execution, and
-capability fallback into monitor-schedule repair. Three compaction scenarios
+capability-bridge repair before monitor fallback. Three compaction scenarios
 check the JSON budget and source-derived semantic parity, then repeat clean
 selected-work and blocking-gate contracts under over-budget omitted diagnostics.
 Four contrast groups require the clean/noisy cases to remain invariant while
@@ -375,7 +395,7 @@ remaining live turn actor cases consume the default CLI hot-path
 `quota should-run` projection used by Codex App automation and return
 runtime-facing decisions rather than echoing the testing-only nine-field
 semantic contract. The suite has 30 bounded scenario attempts and, after
-accounting for all three tool loops, at most 60 provider turns.
+accounting for all four tool loops, at most 70 provider turns.
 Exact scheduler, vision, writeback, and warning fields stay in deterministic
 action-signature coverage; pair mode keeps TurnEnvelope semantic extraction for
 explicit packet differentials or outcome claims.
@@ -384,8 +404,8 @@ explicit packet differentials or outcome claims.
 场景，每个重复 2 次。9 个核心场景覆盖正常接入、agent 身份与
 goal 选择、selected todo、peer 身份路由、same-agent 续接、最终 human gate、健康继续
 和 projection repair；3 个组合场景覆盖 vision/monitor/peer replan 优先级、非阻塞
-user notice 与 ready successor 并存，以及 capability fallback 转入 monitor schedule
-修复；3 个 compaction 场景覆盖 JSON 预算与 source-derived 语义一致，并分别让正常
+user notice 与 ready successor 并存，以及 capability-bridge repair 必须先于 monitor
+fallback；3 个 compaction 场景覆盖 JSON 预算与 source-derived 语义一致，并分别让正常
 selected work 和阻塞 gate 在超预算省略诊断下重复运行。4 个 contrast group 要求
 clean/noisy 场景保持不变，同时要求 blocking gate 与 non-blocking notice、selected
 work 与 required vision replan 仍然可区分。每个
@@ -397,10 +417,12 @@ evidence-log；其他 turn 场景仍直接读取 Codex App
 automation 使用的默认 CLI hot-path `quota should-run` projection 并返回运行时决策，
 scoped-gate successor 场景也从 hermetic Goal 与正式 heartbeat 开始：真实 quota 必须
 同时投影非阻塞 user notice 和 ready deferred successor，模型随后既要呈现提醒，也要
-实际执行被选中的 successor；其他 turn 场景仍属于 packet interpretation。scheduler、vision、writeback 与
+实际执行被选中的 successor；capability repair 场景则要求模型执行 quota 投影的
+repair Todo 写入，host 再读回新 Todo，而非等待 monitor fallback。其他 turn 场景仍属于
+packet interpretation。scheduler、vision、writeback 与
 warning 的精确字段继续由 action-signature 确定性覆盖；pair 中的 TurnEnvelope 只用于
-明确的 packet 差分或结果提升声明。全套仍是 30 个有界 scenario attempt；考虑三个
-工具场景各自每次最多 6 个 provider turn，最坏上限为 60 个 provider turn。
+明确的 packet 差分或结果提升声明。全套仍是 30 个有界 scenario attempt；考虑四个
+真实工具场景各自每次最多 6 个 provider turn，最坏上限为 70 个 provider turn。
 
 For onboarding packets, the suite uses the shipped guided packet builder and
 redacts only local absolute path surfaces before provider transport. The

--- a/docs/development/testing-and-quality.md
+++ b/docs/development/testing-and-quality.md
@@ -310,6 +310,19 @@ repository write is allowed. The receipt retains only action kinds and command
 digests. Fake transports validate the tool protocol, real CLI execution seam,
 and negative cases; only a real provider run qualifies model behavior.
 
+The selected-Todo scenario has its own focused real-action entrypoint for
+changes to quota selection, heartbeat instructions, or the shared tool seam:
+
+```bash
+python3 scripts/qualify-doubao-selected-todo-tool-live.py \
+  --qualification-id <public-safe-run-id>
+```
+
+It starts from the same production heartbeat contract, executes real quota,
+and passes only after the model reads the target named by the selected Todo.
+Reading the target before quota, choosing a deferred decoy, describing the
+action without calling the tool, or issuing an unallowlisted command fails.
+
 真实 Doubao 调用是低频本地/手动门，不进入普通 CI。`ARK_API_KEY` 只通过进程环境
 注入；packet、prompt、原始响应、凭证和对话都不能成为仓库证据，只保留有界 receipt
 与 mismatch code。fake transport 只能验证 adapter 的序列化、脱敏与 fail-closed，不能
@@ -327,8 +340,11 @@ evidence-log 命令才算通过。模型看不到测试专用 decision schema、
 receipt 只保留 action kind 与 command digest。
 
 The regular live suite is
-`actual_default_model_behavior_portfolio_v0`: fifteen one-arm scenarios, two
-attempts each, and at most 30 provider calls. Nine core scenarios check normal
+`actual_default_model_behavior_portfolio_v0`: fifteen one-arm scenarios and two
+attempts each. Its selected-Todo case starts from a production thin heartbeat,
+executes real quota, and requires the model to perform the selected Todo's
+read-only target action. The other turn cases remain bounded packet-interpretation
+checks. Nine core scenarios check normal
 onboarding, agent identity and goal selection, selected todo, peer identity
 routing, same-agent continuation, final human gate, healthy continuation, and
 projection repair. Three composition scenarios check vision/monitor/peer replan
@@ -341,16 +357,17 @@ blocking gate versus non-blocking notice and selected work versus required
 vision replan remain distinguishable. Each
 scenario has an independent deterministic source oracle derived before CLI
 projection; every repeat must pass and hard actor errors are not retried. The
-live turn actor consumes the default CLI hot-path
-`quota should-run` projection used by Codex App automation and returns
+remaining live turn actor cases consume the default CLI hot-path
+`quota should-run` projection used by Codex App automation and return
 runtime-facing decisions rather than echoing the testing-only nine-field
-semantic contract.
+semantic contract. The suite has 30 bounded scenario attempts and, after
+accounting for the selected-Todo tool loop, at most 40 provider turns.
 Exact scheduler, vision, writeback, and warning fields stay in deterministic
 action-signature coverage; pair mode keeps TurnEnvelope semantic extraction for
 explicit packet differentials or outcome claims.
 
 常规 live suite 是 `actual_default_model_behavior_portfolio_v0`：15 个 one-arm
-场景，每个重复 2 次，最多 30 次模型调用。9 个核心场景覆盖正常接入、agent 身份与
+场景，每个重复 2 次。9 个核心场景覆盖正常接入、agent 身份与
 goal 选择、selected todo、peer 身份路由、same-agent 续接、最终 human gate、健康继续
 和 projection repair；3 个组合场景覆盖 vision/monitor/peer replan 优先级、非阻塞
 user notice 与 ready successor 并存，以及 capability fallback 转入 monitor schedule
@@ -359,10 +376,13 @@ selected work 和阻塞 gate 在超预算省略诊断下重复运行。4 个 con
 clean/noisy 场景保持不变，同时要求 blocking gate 与 non-blocking notice、selected
 work 与 required vision replan 仍然可区分。每个
 场景都有在 CLI projection 前推导的独立确定性 source oracle，所有重复都必须通过；
-actor 硬错误不自动重试。live turn actor 直接读取 Codex App automation 使用的默认 CLI hot-path
-`quota should-run` projection 并返回运行时决策，不再回显测试专用的九字段 semantic
-contract。scheduler、vision、writeback 与 warning 的精确字段继续由 action-signature
-确定性覆盖；pair 中的 TurnEnvelope 只用于明确的 packet 差分或结果提升声明。
+actor 硬错误不自动重试。selected-Todo 场景从正式 thin heartbeat 开始，执行真实 quota，
+并要求模型实际读取 selected Todo 指向的目标；其他 turn 场景仍直接读取 Codex App
+automation 使用的默认 CLI hot-path `quota should-run` projection 并返回运行时决策，
+因此属于 packet interpretation，而不是工具行为证明。scheduler、vision、writeback 与
+warning 的精确字段继续由 action-signature 确定性覆盖；pair 中的 TurnEnvelope 只用于
+明确的 packet 差分或结果提升声明。全套仍是 30 个有界 scenario attempt；考虑
+selected-Todo 每次最多 6 个 provider turn，最坏上限为 40 个 provider turn。
 
 For onboarding packets, the suite uses the shipped guided packet builder and
 redacts only local absolute path surfaces before provider transport. The

--- a/docs/reference/protocols/model-behavior-qualification-v0.md
+++ b/docs/reference/protocols/model-behavior-qualification-v0.md
@@ -246,16 +246,20 @@ stochastic output.
 ## Actual-Default Scenario Portfolio
 
 `actual_default_model_behavior_portfolio_v0` is the regular low-frequency live
-suite. Its turn scenarios feed the live actor the same default full
-`quota should-run` packet consumed by Codex App automation. Onboarding scenarios
-use the shipped guided-onboarding packet. The suite does not introduce a third
-model protocol or retain a retired product arm. Its fixed catalog covers nine
-core decisions:
+suite. Its selected-Todo scenario starts from the shipped thin Codex App
+heartbeat task, lets the model call the real `quota should-run` CLI, and then
+requires a real read-only action against the selected Todo target. The other
+turn scenarios still feed the live actor the same default full quota packet
+consumed by Codex App automation, because their current proof is packet
+interpretation rather than tool execution. Onboarding scenarios use the shipped
+guided-onboarding packet. The suite does not introduce a third model protocol or
+retain a retired product arm. Its fixed catalog covers nine core decisions:
 
 1. the normal guided onboarding packet selects `connect_if_needed`;
 2. an unresolved agent identity selects `select_agent_identity`;
 3. multiple goals select `select_goal` before any mutation;
-4. the default quota packet preserves the exact selected todo;
+4. real quota selects the exact Todo and the model executes its bounded target
+   action instead of merely repeating its id;
 5. the selected peer identity matches the todo claim in the model-facing route;
 6. `same_agent_non_delivery` keeps the successor with the completing peer;
 7. a final human gate selects `ask_user` and forbids normal delivery;
@@ -294,20 +298,32 @@ hard behavior dimensions. Contrast expectations are derived from source
 contracts before projection or provider spend.
 
 Every scenario declares its own deterministic source oracle and runs exactly
-twice. The oracle validates exact packet fields before provider spend. The live
-turn actor then reads the default full `quota should-run` packet directly and
-must preserve the runtime-facing decision, selected todo, user gate, execution
-obligation, delivery boundary, quiet-wait rule, and ordered action kinds. It is
-not asked to echo the testing-only nine-field semantic contract. Exact
+twice. The oracle validates exact source semantics before provider spend. The
+selected-Todo scenario then proves the complete state-to-action path: hermetic
+Goal state, production heartbeat prompt, real quota output, model-selected tool
+action, real readback, and a bounded semantic receipt. The remaining live turn
+actor cases read the default full quota packet directly and must preserve the
+runtime-facing decision, selected todo, user gate, execution obligation,
+delivery boundary, quiet-wait rule, and ordered action kinds. They are not asked
+to echo the testing-only nine-field semantic contract, but they also must not be
+described as tool-behavior proof. Exact
 scheduler, vision, writeback, and warning projections remain deterministic
 action-signature tests; explicit pair/corpus mode retains TurnEnvelope and
 semantic-contract extraction when a packet differential is the thing under
 test. All attempts must align. Actor or transport errors are not retried
-automatically; the portfolio fails closed and stops further calls. The maximum
-regular run is therefore 30 provider calls. Generic full-versus-candidate pair
-mode remains available only
+automatically; the portfolio fails closed and stops further calls. The catalog
+still has 30 bounded scenario attempts. Because each selected-Todo attempt may
+need up to six provider turns, the maximum regular run is 40 provider turns.
+Generic full-versus-candidate pair mode remains available only
 for temporary sensitive differentials or explicit stable-versus-candidate
 outcome claims, not as a permanent regular-behavior baseline.
+
+The selected-Todo and replan evidence-log gates share only proven mechanics:
+ordinary exec-tool decoding, bounded LoopX argv extraction, and isolated CLI
+execution. Their Goal fixtures, legal action state machines, and semantic
+oracles remain scenario-owned. This keeps a second real call site from copying
+transport plumbing without turning unrelated behavior into a parameter-heavy
+generic runner.
 
 The complete catalog is preflighted before the first provider call. Schema,
 public-safety, action-signature, actual-default, and scenario-oracle failures

--- a/docs/reference/protocols/model-behavior-qualification-v0.md
+++ b/docs/reference/protocols/model-behavior-qualification-v0.md
@@ -246,11 +246,14 @@ stochastic output.
 ## Actual-Default Scenario Portfolio
 
 `actual_default_model_behavior_portfolio_v0` is the regular low-frequency live
-suite. Its selected-Todo and required-vision replan scenarios start from the
+suite. Its selected-Todo, required-vision replan, and scoped-gate successor
+scenarios start from the
 shipped thin Codex App heartbeat task and let the model call the real
 `quota should-run` CLI. The first requires a real read-only action against the
 selected Todo target; the second requires the exact agent-scoped evidence-log
-read projected by a hermetic missing-vision replan state. The other turn
+read projected by a hermetic missing-vision replan state; the third requires a
+post-quota non-blocking user notice followed by the exact ready-successor
+action. The other turn
 scenarios still feed the live actor the same default full quota packet consumed
 by Codex App automation, because their current proof is packet interpretation
 rather than tool execution. Onboarding scenarios use the shipped guided-
@@ -316,15 +319,16 @@ semantic-contract extraction when a packet differential is the thing under
 test. All attempts must align. Actor or transport errors are not retried
 automatically; the portfolio fails closed and stops further calls. The catalog
 still has 30 bounded scenario attempts. Because each selected-Todo attempt may
-need up to six provider turns, the maximum regular run is 40 provider turns.
+need up to six provider turns, the maximum regular run is 60 provider turns.
 Generic full-versus-candidate pair mode remains available only
 for temporary sensitive differentials or explicit stable-versus-candidate
 outcome claims, not as a permanent regular-behavior baseline.
 
-The selected-Todo and replan evidence-log gates share only proven mechanics:
+The selected-Todo, replan evidence-log, and scoped-gate successor gates share
+only proven mechanics:
 ordinary exec-tool decoding, bounded LoopX argv extraction, and isolated CLI
 execution. Their Goal fixtures, legal action state machines, and semantic
-oracles remain scenario-owned. This keeps a second real call site from copying
+oracles remain scenario-owned. This keeps three real call sites from copying
 transport plumbing without turning unrelated behavior into a parameter-heavy
 generic runner.
 

--- a/docs/reference/protocols/model-behavior-qualification-v0.md
+++ b/docs/reference/protocols/model-behavior-qualification-v0.md
@@ -246,13 +246,15 @@ stochastic output.
 ## Actual-Default Scenario Portfolio
 
 `actual_default_model_behavior_portfolio_v0` is the regular low-frequency live
-suite. Its selected-Todo scenario starts from the shipped thin Codex App
-heartbeat task, lets the model call the real `quota should-run` CLI, and then
-requires a real read-only action against the selected Todo target. The other
-turn scenarios still feed the live actor the same default full quota packet
-consumed by Codex App automation, because their current proof is packet
-interpretation rather than tool execution. Onboarding scenarios use the shipped
-guided-onboarding packet. The suite does not introduce a third model protocol or
+suite. Its selected-Todo and required-vision replan scenarios start from the
+shipped thin Codex App heartbeat task and let the model call the real
+`quota should-run` CLI. The first requires a real read-only action against the
+selected Todo target; the second requires the exact agent-scoped evidence-log
+read projected by a hermetic missing-vision replan state. The other turn
+scenarios still feed the live actor the same default full quota packet consumed
+by Codex App automation, because their current proof is packet interpretation
+rather than tool execution. Onboarding scenarios use the shipped guided-
+onboarding packet. The suite does not introduce a third model protocol or
 retain a retired product arm. Its fixed catalog covers nine core decisions:
 
 1. the normal guided onboarding packet selects `connect_if_needed`;
@@ -272,7 +274,8 @@ snapshots; each packet is generated through the production quota, interaction,
 and scheduler paths and deliberately contains competing signals:
 
 10. a monitor lane and peer-owned advancement both look non-runnable, but a
-    missing required per-agent vision still selects autonomous replan;
+    missing required per-agent vision still selects autonomous replan and the
+    model executes the projected evidence-log read before choosing a delta;
 11. an open user notice coexists with a ready deferred successor, so the model
     must surface the notice and execute the successor replan rather than treat
     every `user_action_required` value as a blocking gate;

--- a/docs/reference/protocols/model-behavior-qualification-v0.md
+++ b/docs/reference/protocols/model-behavior-qualification-v0.md
@@ -246,14 +246,18 @@ stochastic output.
 ## Actual-Default Scenario Portfolio
 
 `actual_default_model_behavior_portfolio_v0` is the regular low-frequency live
-suite. Its selected-Todo, required-vision replan, and scoped-gate successor
-scenarios start from the
-shipped thin Codex App heartbeat task and let the model call the real
-`quota should-run` CLI. The first requires a real read-only action against the
+suite. Its selected-Todo, required-vision replan, scoped-gate successor, and
+capability-bridge repair scenarios start from the shipped thin Codex App
+heartbeat task and let the model call the real `quota should-run` CLI. The
+capability scenario also wraps that task body in the trigger envelope carrying
+the heartbeat time, matching the Codex App input that makes `LOOPX_TURN`
+reusable. The first requires a real read-only action against the
 selected Todo target; the second requires the exact agent-scoped evidence-log
 read projected by a hermetic missing-vision replan state; the third requires a
 post-quota non-blocking user notice followed by the exact ready-successor
-action. The other turn
+action. The fourth requires the quota-projected agent-owned capability-repair
+Todo to be created and read back before the incomplete monitor fallback can
+delay work; any post-quota workspace read fails as action backtracking. The other turn
 scenarios still feed the live actor the same default full quota packet consumed
 by Codex App automation, because their current proof is packet interpretation
 rather than tool execution. Onboarding scenarios use the shipped guided-
@@ -283,8 +287,9 @@ and scheduler paths and deliberately contains competing signals:
     must surface the notice and execute the successor replan rather than treat
     every `user_action_required` value as a blocking gate;
 12. unavailable capability blocks the visible advancement, while an incomplete
-    monitor schedule remains repairable, so the selected and primary action is
-    monitor-schedule repair rather than wait or the blocked task.
+    monitor schedule remains as a fallback, so the agent must execute the
+    quota-projected capability-repair Todo rather than wait on or update the
+    monitor or attempt the blocked task.
 
 Three compaction scenarios exercise the actual default CLI projection:
 
@@ -305,9 +310,10 @@ contracts before projection or provider spend.
 
 Every scenario declares its own deterministic source oracle and runs exactly
 twice. The oracle validates exact source semantics before provider spend. The
-selected-Todo scenario then proves the complete state-to-action path: hermetic
-Goal state, production heartbeat prompt, real quota output, model-selected tool
-action, real readback, and a bounded semantic receipt. The remaining live turn
+four real-tool scenarios then prove their complete state-to-action paths:
+hermetic Goal state, production heartbeat prompt, real quota output, model-
+selected tool action, real readback, and a bounded semantic receipt. The
+remaining live turn
 actor cases read the default full quota packet directly and must preserve the
 runtime-facing decision, selected todo, user gate, execution obligation,
 delivery boundary, quiet-wait rule, and ordered action kinds. They are not asked
@@ -318,17 +324,18 @@ action-signature tests; explicit pair/corpus mode retains TurnEnvelope and
 semantic-contract extraction when a packet differential is the thing under
 test. All attempts must align. Actor or transport errors are not retried
 automatically; the portfolio fails closed and stops further calls. The catalog
-still has 30 bounded scenario attempts. Because each selected-Todo attempt may
-need up to six provider turns, the maximum regular run is 60 provider turns.
+still has 30 bounded scenario attempts. Because each of the four real-tool
+scenario attempts may need up to six provider turns, the maximum regular run
+is 70 provider turns.
 Generic full-versus-candidate pair mode remains available only
 for temporary sensitive differentials or explicit stable-versus-candidate
 outcome claims, not as a permanent regular-behavior baseline.
 
-The selected-Todo, replan evidence-log, and scoped-gate successor gates share
-only proven mechanics:
+The selected-Todo, replan evidence-log, scoped-gate successor, and capability-
+bridge repair gates share only proven mechanics:
 ordinary exec-tool decoding, bounded LoopX argv extraction, and isolated CLI
 execution. Their Goal fixtures, legal action state machines, and semantic
-oracles remain scenario-owned. This keeps three real call sites from copying
+oracles remain scenario-owned. This keeps four real call sites from copying
 transport plumbing without turning unrelated behavior into a parameter-heavy
 generic runner.
 

--- a/examples/control_plane/monitor-scheduler-contract-smoke.py
+++ b/examples/control_plane/monitor-scheduler-contract-smoke.py
@@ -806,7 +806,11 @@ def assert_capability_repair_precedes_monitor_schedule_repair() -> None:
     assert guard["heartbeat_recommendation"]["recommended_mode"] == "repair_capability_bridge", guard
     assert guard["execution_obligation"]["contract"] == "capability_gate", guard
     primary_action = guard["interaction_contract"]["agent_channel"]["primary_action"]
-    assert "repair or materialize the missing bridge capability" in primary_action, guard
+    assert primary_action.startswith(
+        "execute interaction_contract.cli_channel.next_cli_actions[0]"
+    ), guard
+    assert "do not backtrack" in primary_action, guard
+    assert "monitor fallback" in primary_action, guard
     assert guard["scheduler_hint"]["cadence_class"] == "active_work", guard
 
 

--- a/loopx/control_plane/heartbeat/task_body.py
+++ b/loopx/control_plane/heartbeat/task_body.py
@@ -644,7 +644,7 @@ def render_thin_heartbeat_task_body(
 {RUNTIME_EXECUTION_ROUTING_RULE}
 {scope_sentence}
 
-Inspect state/status/repo.
+Run quota; execute `interaction_contract` next—no detours.
 `LOOPX_TURN=<current_time_iso>`; reuse.
 {pr_review_pre_quota_instruction}{quota_guard_instruction}.
 {HEARTBEAT_NOTIFICATION_RULE_SHORT}

--- a/loopx/control_plane/quota/cli_projection.py
+++ b/loopx/control_plane/quota/cli_projection.py
@@ -610,6 +610,22 @@ def _promote_runtime_capability_reentry(
     return promoted
 
 
+def _promote_interaction_contract(payload: dict[str, Any]) -> dict[str, Any]:
+    interaction = payload.get("interaction_contract")
+    if not isinstance(interaction, dict):
+        return payload
+    promoted = {
+        key: payload[key]
+        for key in (*_RUNTIME_CAPABILITY_PREFIX_FIELDS, "runtime_capability_reentry")
+        if key in payload
+    }
+    promoted["interaction_contract"] = interaction
+    promoted.update(
+        (key, value) for key, value in payload.items() if key not in promoted
+    )
+    return promoted
+
+
 def compact_quota_should_run_cli_payload(
     payload: dict[str, Any],
     *,
@@ -683,4 +699,6 @@ def compact_quota_should_run_cli_payload(
             compact = dict(compact)
             compact["goal_route_hint"] = _compact_goal_route_hint(goal_route_hint)
         compact = _compact_shadowed_action_projections(compact)
-    return _promote_runtime_capability_reentry(compact)
+    return _promote_interaction_contract(
+        _promote_runtime_capability_reentry(compact)
+    )

--- a/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
+++ b/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
@@ -51,6 +51,15 @@ ACTUAL_DEFAULT_MODEL_BEHAVIOR_HOT_PATH_JSON_BUDGET = 40_000
 ACTUAL_DEFAULT_MODEL_BEHAVIOR_CONTRAST_SCHEMA_VERSION = (
     "actual_default_model_behavior_contrast_v0"
 )
+_TOOL_ACTOR_KINDS = frozenset(
+    {
+        "turn_tool",
+        "replan_tool",
+        "scoped_gate_tool",
+        "capability_repair_tool",
+    }
+)
+_TURN_ACTOR_KINDS = frozenset({"turn", *_TOOL_ACTOR_KINDS})
 
 
 @dataclass(frozen=True)
@@ -263,8 +272,7 @@ def actual_default_model_behavior_scenario_catalog() -> dict[str, Any]:
                 "composition_dimensions": list(spec.composition_dimensions),
                 "packet_view": (
                     "production_heartbeat_tool_loop"
-                    if spec.actor_kind
-                    in {"turn_tool", "replan_tool", "scoped_gate_tool"}
+                    if spec.actor_kind in _TOOL_ACTOR_KINDS
                     else (
                         "quota_should_run_default"
                         if spec.actor_kind == "turn"
@@ -750,13 +758,7 @@ def _scenario_contract(
     source_packet: Mapping[str, Any],
     actor_packet: Mapping[str, Any],
 ) -> dict[str, Any]:
-    if spec.actor_kind in {
-        "turn",
-        "turn_tool",
-        "replan_tool",
-        "scoped_gate_tool",
-        "capability_repair_tool",
-    }:
+    if spec.actor_kind in _TURN_ACTOR_KINDS:
         build_model_behavior_actor_request(
             actor_packet,
             qualification_id=f"portfolio-preflight-{spec.scenario_id}",
@@ -1006,13 +1008,7 @@ def _receipt_alignment(
     receipt: Mapping[str, Any],
     expected: Mapping[str, Any],
 ) -> tuple[bool, list[str]]:
-    if spec.actor_kind in {
-        "turn",
-        "turn_tool",
-        "replan_tool",
-        "scoped_gate_tool",
-        "capability_repair_tool",
-    }:
+    if spec.actor_kind in _TURN_ACTOR_KINDS:
         fields = tuple(expected)
         mismatches = [
             f"source_mismatch:{field}"
@@ -1272,6 +1268,9 @@ def run_actual_default_model_behavior_portfolio(
         result["status"] == "failed" for result in contrast_results
     )
     skip_count = sum(result["status"] == "not_run" for result in results)
+    tool_enabled_scenario_count = sum(
+        spec.actor_kind in _TOOL_ACTOR_KINDS for spec in _SCENARIOS
+    )
     return {
         "schema_version": ACTUAL_DEFAULT_MODEL_BEHAVIOR_PORTFOLIO_SCHEMA_VERSION,
         "qualification_id": qualification_id,
@@ -1293,9 +1292,10 @@ def run_actual_default_model_behavior_portfolio(
         "contrasts": contrast_results,
         "boundary": {
             "tools_enabled": True,
-            "tool_enabled_scenario_count": 3,
+            "tool_enabled_scenario_count": tool_enabled_scenario_count,
             "packet_interpretation_scenario_count": (
-                ACTUAL_DEFAULT_MODEL_BEHAVIOR_SCENARIO_COUNT - 3
+                ACTUAL_DEFAULT_MODEL_BEHAVIOR_SCENARIO_COUNT
+                - tool_enabled_scenario_count
             ),
             "raw_packets_persisted": False,
             "raw_model_responses_persisted": False,

--- a/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
+++ b/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
@@ -126,7 +126,7 @@ _SCENARIOS = (
     ),
     _ScenarioSpec(
         "turn_scoped_gate_successor_replan",
-        "turn",
+        "scoped_gate_tool",
         None,
         "execute",
         "control_plane_composition",
@@ -263,7 +263,8 @@ def actual_default_model_behavior_scenario_catalog() -> dict[str, Any]:
                 "composition_dimensions": list(spec.composition_dimensions),
                 "packet_view": (
                     "production_heartbeat_tool_loop"
-                    if spec.actor_kind in {"turn_tool", "replan_tool"}
+                    if spec.actor_kind
+                    in {"turn_tool", "replan_tool", "scoped_gate_tool"}
                     else (
                         "quota_should_run_default"
                         if spec.actor_kind == "turn"
@@ -749,7 +750,12 @@ def _scenario_contract(
     source_packet: Mapping[str, Any],
     actor_packet: Mapping[str, Any],
 ) -> dict[str, Any]:
-    if spec.actor_kind in {"turn", "turn_tool", "replan_tool"}:
+    if spec.actor_kind in {
+        "turn",
+        "turn_tool",
+        "replan_tool",
+        "scoped_gate_tool",
+    }:
         build_model_behavior_actor_request(
             actor_packet,
             qualification_id=f"portfolio-preflight-{spec.scenario_id}",
@@ -999,7 +1005,12 @@ def _receipt_alignment(
     receipt: Mapping[str, Any],
     expected: Mapping[str, Any],
 ) -> tuple[bool, list[str]]:
-    if spec.actor_kind in {"turn", "turn_tool", "replan_tool"}:
+    if spec.actor_kind in {
+        "turn",
+        "turn_tool",
+        "replan_tool",
+        "scoped_gate_tool",
+    }:
         fields = tuple(expected)
         mismatches = [
             f"source_mismatch:{field}"
@@ -1027,6 +1038,7 @@ def _scenario_result(
     onboarding_actor: OnboardingModelBehaviorActor,
     selected_todo_actor: Callable[[str], Mapping[str, Any]],
     replan_evidence_actor: Callable[[str], Mapping[str, Any]],
+    scoped_gate_successor_actor: Callable[[str], Mapping[str, Any]],
 ) -> tuple[dict[str, Any], bool, list[dict[str, Any]]]:
     receipt_digests: list[str] = []
     observed_routes: list[str] = []
@@ -1045,6 +1057,13 @@ def _scenario_result(
                 observed_route = str(receipt.get("decision") or "")
             elif spec.actor_kind == "replan_tool":
                 receipt = dict(replan_evidence_actor(run_id))
+                if receipt.get("qualification_passed") is not True:
+                    failure_codes.append(
+                        str(receipt.get("failure_code") or "tool_behavior_failed")
+                    )
+                observed_route = str(receipt.get("decision") or "")
+            elif spec.actor_kind == "scoped_gate_tool":
+                receipt = dict(scoped_gate_successor_actor(run_id))
                 if receipt.get("qualification_passed") is not True:
                     failure_codes.append(
                         str(receipt.get("failure_code") or "tool_behavior_failed")
@@ -1158,6 +1177,7 @@ def run_actual_default_model_behavior_portfolio(
     onboarding_actor: OnboardingModelBehaviorActor,
     selected_todo_actor: Callable[[str], Mapping[str, Any]],
     replan_evidence_actor: Callable[[str], Mapping[str, Any]],
+    scoped_gate_successor_actor: Callable[[str], Mapping[str, Any]],
 ) -> dict[str, Any]:
     """Run the fixed low-frequency one-arm portfolio with bounded receipts."""
     expected_ids = {spec.scenario_id for spec in _SCENARIOS}
@@ -1217,6 +1237,7 @@ def run_actual_default_model_behavior_portfolio(
             onboarding_actor=onboarding_actor,
             selected_todo_actor=selected_todo_actor,
             replan_evidence_actor=replan_evidence_actor,
+            scoped_gate_successor_actor=scoped_gate_successor_actor,
         )
         actor_call_count += int(result["repeats_completed"])
         if actor_error:
@@ -1260,9 +1281,9 @@ def run_actual_default_model_behavior_portfolio(
         "contrasts": contrast_results,
         "boundary": {
             "tools_enabled": True,
-            "tool_enabled_scenario_count": 2,
+            "tool_enabled_scenario_count": 3,
             "packet_interpretation_scenario_count": (
-                ACTUAL_DEFAULT_MODEL_BEHAVIOR_SCENARIO_COUNT - 2
+                ACTUAL_DEFAULT_MODEL_BEHAVIOR_SCENARIO_COUNT - 3
             ),
             "raw_packets_persisted": False,
             "raw_model_responses_persisted": False,

--- a/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
+++ b/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from copy import deepcopy
 from dataclasses import dataclass
 from hashlib import sha256
@@ -32,6 +32,10 @@ from .onboarding_model_behavior_qualification import (
     build_onboarding_model_behavior_actor_request,
     build_onboarding_postcondition_observation,
     run_onboarding_model_behavior_phase,
+)
+from .selected_todo_tool_behavior import (
+    SELECTED_TODO_TOOL_FIXTURE_ACTION_TEXT,
+    SELECTED_TODO_TOOL_FIXTURE_TODO_ID,
 )
 
 ACTUAL_DEFAULT_MODEL_BEHAVIOR_PORTFOLIO_SCHEMA_VERSION = (
@@ -90,7 +94,7 @@ _SCENARIOS = (
     ),
     _ScenarioSpec(
         "turn_selected_todo",
-        "turn",
+        "turn_tool",
         None,
         "execute",
     ),
@@ -258,9 +262,13 @@ def actual_default_model_behavior_scenario_catalog() -> dict[str, Any]:
                 "scenario_family": spec.scenario_family,
                 "composition_dimensions": list(spec.composition_dimensions),
                 "packet_view": (
-                    "quota_should_run_default"
-                    if spec.actor_kind == "turn"
-                    else "guided_onboarding_default"
+                    "production_heartbeat_tool_loop"
+                    if spec.actor_kind == "turn_tool"
+                    else (
+                        "quota_should_run_default"
+                        if spec.actor_kind == "turn"
+                        else "guided_onboarding_default"
+                    )
                 ),
                 "repeat_policy": {
                     "attempts": ACTUAL_DEFAULT_MODEL_BEHAVIOR_REPEAT_ATTEMPTS,
@@ -442,6 +450,20 @@ def _turn_scenario_source(
     return payload
 
 
+def _selected_todo_scenario_source() -> dict[str, Any]:
+    payload = _turn_scenario_source(human_gate=False)
+    payload["selected_todo"] = {
+        **dict(payload["selected_todo"]),
+        "text": SELECTED_TODO_TOOL_FIXTURE_ACTION_TEXT,
+    }
+    payload["recommended_action"] = SELECTED_TODO_TOOL_FIXTURE_ACTION_TEXT
+    payload["interaction_contract"] = build_interaction_contract(
+        payload,
+        available_capabilities=["shell", "filesystem_read"],
+    )
+    return payload
+
+
 def build_quota_hot_path_compaction_regression_source() -> dict[str, Any]:
     """Build a coherent over-budget turn whose cold diagnostics are removable."""
 
@@ -586,7 +608,7 @@ def _build_actual_default_model_behavior_scenario_sources(
     packets = _entry_scenario_packets(root)
     packets.update(
         {
-            "turn_selected_todo": _turn_scenario_source(human_gate=False),
+            "turn_selected_todo": _selected_todo_scenario_source(),
             "turn_peer_agent_identity": _turn_scenario_source(
                 human_gate=False,
                 agent_id="codex-portfolio-reviewer",
@@ -727,7 +749,7 @@ def _scenario_contract(
     source_packet: Mapping[str, Any],
     actor_packet: Mapping[str, Any],
 ) -> dict[str, Any]:
-    if spec.actor_kind == "turn":
+    if spec.actor_kind in {"turn", "turn_tool"}:
         build_model_behavior_actor_request(
             actor_packet,
             qualification_id=f"portfolio-preflight-{spec.scenario_id}",
@@ -784,6 +806,16 @@ def _scenario_contract(
         "selected_todo_id"
     ):
         raise ValueError("selected-todo scenario requires selected work")
+    if spec.scenario_id == "turn_selected_todo" and (
+        contract.get("selected_todo_id") != SELECTED_TODO_TOOL_FIXTURE_TODO_ID
+        or source_packet.get("recommended_action")
+        != SELECTED_TODO_TOOL_FIXTURE_ACTION_TEXT
+        or dict(source_packet.get("selected_todo") or {}).get("text")
+        != SELECTED_TODO_TOOL_FIXTURE_ACTION_TEXT
+    ):
+        raise ValueError(
+            "selected-todo source must match the real-action fixture contract"
+        )
     if spec.scenario_id in {
         "turn_peer_agent_identity",
         "turn_same_agent_continuation",
@@ -967,7 +999,7 @@ def _receipt_alignment(
     receipt: Mapping[str, Any],
     expected: Mapping[str, Any],
 ) -> tuple[bool, list[str]]:
-    if spec.actor_kind == "turn":
+    if spec.actor_kind in {"turn", "turn_tool"}:
         fields = tuple(expected)
         mismatches = [
             f"source_mismatch:{field}"
@@ -993,6 +1025,7 @@ def _scenario_result(
     qualification_id: str,
     turn_actor: ModelBehaviorActor,
     onboarding_actor: OnboardingModelBehaviorActor,
+    selected_todo_actor: Callable[[str], Mapping[str, Any]],
 ) -> tuple[dict[str, Any], bool, list[dict[str, Any]]]:
     receipt_digests: list[str] = []
     observed_routes: list[str] = []
@@ -1002,7 +1035,14 @@ def _scenario_result(
     for repeat_index in range(ACTUAL_DEFAULT_MODEL_BEHAVIOR_REPEAT_ATTEMPTS):
         run_id = f"{qualification_id}:{spec.scenario_id}:r{repeat_index + 1}"
         try:
-            if spec.actor_kind == "turn":
+            if spec.actor_kind == "turn_tool":
+                receipt = dict(selected_todo_actor(run_id))
+                if receipt.get("qualification_passed") is not True:
+                    failure_codes.append(
+                        str(receipt.get("failure_code") or "tool_behavior_failed")
+                    )
+                observed_route = str(receipt.get("decision") or "")
+            elif spec.actor_kind == "turn":
                 receipt = run_model_behavior_qualification_arm(
                     packet,
                     qualification_id=run_id,
@@ -1108,6 +1148,7 @@ def run_actual_default_model_behavior_portfolio(
     qualification_id: str,
     turn_actor: ModelBehaviorActor,
     onboarding_actor: OnboardingModelBehaviorActor,
+    selected_todo_actor: Callable[[str], Mapping[str, Any]],
 ) -> dict[str, Any]:
     """Run the fixed low-frequency one-arm portfolio with bounded receipts."""
     expected_ids = {spec.scenario_id for spec in _SCENARIOS}
@@ -1165,6 +1206,7 @@ def run_actual_default_model_behavior_portfolio(
             qualification_id=qualification_id,
             turn_actor=turn_actor,
             onboarding_actor=onboarding_actor,
+            selected_todo_actor=selected_todo_actor,
         )
         actor_call_count += int(result["repeats_completed"])
         if actor_error:
@@ -1207,7 +1249,11 @@ def run_actual_default_model_behavior_portfolio(
         "scenarios": results,
         "contrasts": contrast_results,
         "boundary": {
-            "tools_enabled": False,
+            "tools_enabled": True,
+            "tool_enabled_scenario_count": 1,
+            "packet_interpretation_scenario_count": (
+                ACTUAL_DEFAULT_MODEL_BEHAVIOR_SCENARIO_COUNT - 1
+            ),
             "raw_packets_persisted": False,
             "raw_model_responses_persisted": False,
             "automatic_retries": False,

--- a/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
+++ b/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
@@ -134,7 +134,7 @@ _SCENARIOS = (
     ),
     _ScenarioSpec(
         "turn_capability_monitor_repair",
-        "turn",
+        "capability_repair_tool",
         None,
         "execute",
         "control_plane_composition",
@@ -755,6 +755,7 @@ def _scenario_contract(
         "turn_tool",
         "replan_tool",
         "scoped_gate_tool",
+        "capability_repair_tool",
     }:
         build_model_behavior_actor_request(
             actor_packet,
@@ -930,7 +931,7 @@ def _scenario_contract(
             raise ValueError(
                 "capability bridge repair must name the missing capability"
             )
-        if "repair or materialize the missing bridge capability" not in str(
+        if "next_cli_actions[0]" not in str(
             action.get("primary_action")
         ):
             raise ValueError(
@@ -1010,6 +1011,7 @@ def _receipt_alignment(
         "turn_tool",
         "replan_tool",
         "scoped_gate_tool",
+        "capability_repair_tool",
     }:
         fields = tuple(expected)
         mismatches = [
@@ -1039,6 +1041,7 @@ def _scenario_result(
     selected_todo_actor: Callable[[str], Mapping[str, Any]],
     replan_evidence_actor: Callable[[str], Mapping[str, Any]],
     scoped_gate_successor_actor: Callable[[str], Mapping[str, Any]],
+    capability_monitor_repair_actor: Callable[[str], Mapping[str, Any]],
 ) -> tuple[dict[str, Any], bool, list[dict[str, Any]]]:
     receipt_digests: list[str] = []
     observed_routes: list[str] = []
@@ -1064,6 +1067,13 @@ def _scenario_result(
                 observed_route = str(receipt.get("decision") or "")
             elif spec.actor_kind == "scoped_gate_tool":
                 receipt = dict(scoped_gate_successor_actor(run_id))
+                if receipt.get("qualification_passed") is not True:
+                    failure_codes.append(
+                        str(receipt.get("failure_code") or "tool_behavior_failed")
+                    )
+                observed_route = str(receipt.get("decision") or "")
+            elif spec.actor_kind == "capability_repair_tool":
+                receipt = dict(capability_monitor_repair_actor(run_id))
                 if receipt.get("qualification_passed") is not True:
                     failure_codes.append(
                         str(receipt.get("failure_code") or "tool_behavior_failed")
@@ -1178,6 +1188,7 @@ def run_actual_default_model_behavior_portfolio(
     selected_todo_actor: Callable[[str], Mapping[str, Any]],
     replan_evidence_actor: Callable[[str], Mapping[str, Any]],
     scoped_gate_successor_actor: Callable[[str], Mapping[str, Any]],
+    capability_monitor_repair_actor: Callable[[str], Mapping[str, Any]],
 ) -> dict[str, Any]:
     """Run the fixed low-frequency one-arm portfolio with bounded receipts."""
     expected_ids = {spec.scenario_id for spec in _SCENARIOS}
@@ -1238,6 +1249,7 @@ def run_actual_default_model_behavior_portfolio(
             selected_todo_actor=selected_todo_actor,
             replan_evidence_actor=replan_evidence_actor,
             scoped_gate_successor_actor=scoped_gate_successor_actor,
+            capability_monitor_repair_actor=capability_monitor_repair_actor,
         )
         actor_call_count += int(result["repeats_completed"])
         if actor_error:

--- a/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
+++ b/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
@@ -118,7 +118,7 @@ _SCENARIOS = (
     ),
     _ScenarioSpec(
         "turn_required_vision_replan",
-        "turn",
+        "replan_tool",
         None,
         "execute",
         "control_plane_composition",
@@ -263,7 +263,7 @@ def actual_default_model_behavior_scenario_catalog() -> dict[str, Any]:
                 "composition_dimensions": list(spec.composition_dimensions),
                 "packet_view": (
                     "production_heartbeat_tool_loop"
-                    if spec.actor_kind == "turn_tool"
+                    if spec.actor_kind in {"turn_tool", "replan_tool"}
                     else (
                         "quota_should_run_default"
                         if spec.actor_kind == "turn"
@@ -749,7 +749,7 @@ def _scenario_contract(
     source_packet: Mapping[str, Any],
     actor_packet: Mapping[str, Any],
 ) -> dict[str, Any]:
-    if spec.actor_kind in {"turn", "turn_tool"}:
+    if spec.actor_kind in {"turn", "turn_tool", "replan_tool"}:
         build_model_behavior_actor_request(
             actor_packet,
             qualification_id=f"portfolio-preflight-{spec.scenario_id}",
@@ -999,7 +999,7 @@ def _receipt_alignment(
     receipt: Mapping[str, Any],
     expected: Mapping[str, Any],
 ) -> tuple[bool, list[str]]:
-    if spec.actor_kind in {"turn", "turn_tool"}:
+    if spec.actor_kind in {"turn", "turn_tool", "replan_tool"}:
         fields = tuple(expected)
         mismatches = [
             f"source_mismatch:{field}"
@@ -1026,6 +1026,7 @@ def _scenario_result(
     turn_actor: ModelBehaviorActor,
     onboarding_actor: OnboardingModelBehaviorActor,
     selected_todo_actor: Callable[[str], Mapping[str, Any]],
+    replan_evidence_actor: Callable[[str], Mapping[str, Any]],
 ) -> tuple[dict[str, Any], bool, list[dict[str, Any]]]:
     receipt_digests: list[str] = []
     observed_routes: list[str] = []
@@ -1037,6 +1038,13 @@ def _scenario_result(
         try:
             if spec.actor_kind == "turn_tool":
                 receipt = dict(selected_todo_actor(run_id))
+                if receipt.get("qualification_passed") is not True:
+                    failure_codes.append(
+                        str(receipt.get("failure_code") or "tool_behavior_failed")
+                    )
+                observed_route = str(receipt.get("decision") or "")
+            elif spec.actor_kind == "replan_tool":
+                receipt = dict(replan_evidence_actor(run_id))
                 if receipt.get("qualification_passed") is not True:
                     failure_codes.append(
                         str(receipt.get("failure_code") or "tool_behavior_failed")
@@ -1149,6 +1157,7 @@ def run_actual_default_model_behavior_portfolio(
     turn_actor: ModelBehaviorActor,
     onboarding_actor: OnboardingModelBehaviorActor,
     selected_todo_actor: Callable[[str], Mapping[str, Any]],
+    replan_evidence_actor: Callable[[str], Mapping[str, Any]],
 ) -> dict[str, Any]:
     """Run the fixed low-frequency one-arm portfolio with bounded receipts."""
     expected_ids = {spec.scenario_id for spec in _SCENARIOS}
@@ -1207,6 +1216,7 @@ def run_actual_default_model_behavior_portfolio(
             turn_actor=turn_actor,
             onboarding_actor=onboarding_actor,
             selected_todo_actor=selected_todo_actor,
+            replan_evidence_actor=replan_evidence_actor,
         )
         actor_call_count += int(result["repeats_completed"])
         if actor_error:
@@ -1250,9 +1260,9 @@ def run_actual_default_model_behavior_portfolio(
         "contrasts": contrast_results,
         "boundary": {
             "tools_enabled": True,
-            "tool_enabled_scenario_count": 1,
+            "tool_enabled_scenario_count": 2,
             "packet_interpretation_scenario_count": (
-                ACTUAL_DEFAULT_MODEL_BEHAVIOR_SCENARIO_COUNT - 1
+                ACTUAL_DEFAULT_MODEL_BEHAVIOR_SCENARIO_COUNT - 2
             ),
             "raw_packets_persisted": False,
             "raw_model_responses_persisted": False,

--- a/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
+++ b/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
@@ -1,0 +1,512 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from collections.abc import Mapping
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+
+from ...heartbeat_prompt import build_heartbeat_prompt
+from ..quota.turn_envelope import quota_action_signature_document
+from .doubao_model_behavior_actor import (
+    ARK_API_KEY_ENV,
+    DOUBAO_2_1_PRO_MODEL,
+    DOUBAO_MODEL_ENV,
+    DoubaoActorTransport,
+    _direct_ark_transport,
+)
+from .model_tool_behavior import (
+    DoubaoExecToolClient,
+    argument_value,
+    digest_text,
+    execute_loopx_cli,
+    loopx_command_tokens,
+)
+from .selected_todo_tool_behavior import (
+    SELECTED_TODO_TOOL_FIXTURE_AGENT_ID,
+    SELECTED_TODO_TOOL_FIXTURE_GOAL_ID,
+    _classify_tool_command,
+    _execute_workspace_read,
+    _SelectedTodoToolFixture,
+)
+
+CAPABILITY_MONITOR_REPAIR_TOOL_BEHAVIOR_RECEIPT_SCHEMA_VERSION = (
+    "capability_monitor_repair_tool_behavior_receipt_v0"
+)
+CAPABILITY_MONITOR_REPAIR_TOOL_BEHAVIOR_MAX_CALLS = 6
+
+CAPABILITY_REPAIR_BLOCKED_TODO_ID = "todo_portfolio_private_read"
+CAPABILITY_REPAIR_MONITOR_TODO_ID = "todo_portfolio_monitor_schedule"
+CAPABILITY_REPAIR_TARGET_CAPABILITY = "private_read"
+CAPABILITY_REPAIR_TRIGGER_TIME = "2026-08-12T00:00:00+08:00"
+
+
+def _heartbeat_trigger_message(task_body: str) -> str:
+    return (
+        "<heartbeat>\n"
+        "  <automation_id>loopx</automation_id>\n"
+        f"  <current_time_iso>{CAPABILITY_REPAIR_TRIGGER_TIME}</current_time_iso>\n"
+        "  <instructions>\n"
+        f"{task_body}\n"
+        "  </instructions>\n"
+        "</heartbeat>"
+    )
+
+
+def _build_capability_repair_fixture(root: Path) -> _SelectedTodoToolFixture:
+    source_root = Path(__file__).resolve().parents[3]
+    project_root = root / "project"
+    runtime_root = root / "runtime"
+    fixture_home = root / "home"
+    state_relative = (
+        Path(".codex")
+        / "goals"
+        / SELECTED_TODO_TOOL_FIXTURE_GOAL_ID
+        / "ACTIVE_GOAL_STATE.md"
+    )
+    state_path = project_root / state_relative
+    local_registry_path = project_root / ".loopx" / "registry.json"
+    global_registry_path = (
+        fixture_home / ".codex" / "loopx" / "registry.global.json"
+    )
+    unused_target = project_root / "fixture" / "unused.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    unused_target.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "init", "-q"],
+        cwd=project_root,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    state_path.write_text(
+        "---\n"
+        "status: active\n"
+        "owner_mode: goal\n"
+        'objective: "Repair the missing capability bridge before delivery."\n'
+        "updated_at: 2026-08-12T00:00:00+08:00\n"
+        "---\n\n"
+        "# Capability Repair Live Fixture\n\n"
+        "## Objective\n\n"
+        "Repair the missing capability bridge before delivery.\n\n"
+        "## Next Action\n\n"
+        "- Repair or materialize the missing capability bridge.\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P0] Repair the release monitor schedule.\n"
+        "  <!-- loopx:todo "
+        f"todo_id={CAPABILITY_REPAIR_MONITOR_TODO_ID} status=open "
+        "task_class=continuous_monitor action_kind=monitor "
+        f"claimed_by={SELECTED_TODO_TOOL_FIXTURE_AGENT_ID} priority=P0 "
+        "target_key=portfolio-release-monitor -->\n"
+        "- [ ] [P1] Read a private source before implementation.\n"
+        "  <!-- loopx:todo "
+        f"todo_id={CAPABILITY_REPAIR_BLOCKED_TODO_ID} status=open "
+        "task_class=advancement_task action_kind=read_private_source "
+        f"claimed_by={SELECTED_TODO_TOOL_FIXTURE_AGENT_ID} priority=P1 "
+        f"required_capabilities={CAPABILITY_REPAIR_TARGET_CAPABILITY} -->\n",
+        encoding="utf-8",
+    )
+    registry = {
+        "schema_version": "0.1",
+        "updated_at": "2026-08-12T00:00:00+08:00",
+        "common_runtime_root": str(runtime_root),
+        "goals": [
+            {
+                "id": SELECTED_TODO_TOOL_FIXTURE_GOAL_ID,
+                "domain": "capability-repair-live-fixture",
+                "status": "active",
+                "repo": str(project_root),
+                "state_file": str(state_relative),
+                "adapter": {
+                    "kind": "fixture_connected_delivery_v0",
+                    "status": "connected-delivery",
+                },
+                "coordination": {
+                    "registered_agents": [SELECTED_TODO_TOOL_FIXTURE_AGENT_ID],
+                    "agent_model": "peer_v1",
+                },
+                "authority_sources": [],
+                "quota": {
+                    "compute": 1.0,
+                    "window_hours": 24,
+                    "allowed_slots": 5,
+                },
+            }
+        ],
+    }
+    registry_text = json.dumps(registry, ensure_ascii=False, indent=2, sort_keys=True)
+    for registry_path in (local_registry_path, global_registry_path):
+        registry_path.parent.mkdir(parents=True, exist_ok=True)
+        registry_path.write_text(registry_text + "\n", encoding="utf-8")
+
+    prompt = build_heartbeat_prompt(
+        goal_id=SELECTED_TODO_TOOL_FIXTURE_GOAL_ID,
+        thin=True,
+        agent_id=SELECTED_TODO_TOOL_FIXTURE_AGENT_ID,
+        registered_agents=[SELECTED_TODO_TOOL_FIXTURE_AGENT_ID],
+        available_capabilities=[
+            "shell",
+            "filesystem_read",
+            "filesystem_write",
+            "network",
+        ],
+        runtime_profile="codex_app_heartbeat",
+    )
+    quota_guard_command = str(prompt["quota_guard_command"])
+    if quota_guard_command not in str(prompt["task_body"]):
+        raise ValueError("heartbeat fixture must contain its production quota guard")
+    return _SelectedTodoToolFixture(
+        task_body=str(prompt["task_body"]),
+        quota_guard_command=quota_guard_command,
+        project_root=project_root,
+        runtime_root=runtime_root,
+        global_registry_path=global_registry_path,
+        source_root=source_root,
+        selected_target=unused_target,
+    )
+
+
+def _is_capability_repair_command(command: str) -> bool:
+    tokens = loopx_command_tokens(command)
+    if not tokens:
+        return False
+    try:
+        todo_index = tokens.index("todo")
+    except ValueError:
+        return False
+    return bool(
+        tokens[todo_index : todo_index + 2] == ["todo", "add"]
+        and argument_value(tokens, "--goal-id")
+        == SELECTED_TODO_TOOL_FIXTURE_GOAL_ID
+        and argument_value(tokens, "--role") == "agent"
+        and argument_value(tokens, "--task-class") == "advancement_task"
+        and argument_value(tokens, "--action-kind") == "materialize_capability"
+        and argument_value(tokens, "--target-capability")
+        == CAPABILITY_REPAIR_TARGET_CAPABILITY
+        and argument_value(tokens, "--claimed-by")
+        == SELECTED_TODO_TOOL_FIXTURE_AGENT_ID
+        and argument_value(tokens, "--unblocks-todo-id")
+        == CAPABILITY_REPAIR_BLOCKED_TODO_ID
+        and bool(argument_value(tokens, "--text"))
+    )
+
+
+def _is_monitor_fallback_command(command: str) -> bool:
+    tokens = loopx_command_tokens(command)
+    if not tokens:
+        return False
+    return any(
+        tokens[index : index + 2]
+        in (["quota", "monitor-poll"], ["todo", "update"])
+        and CAPABILITY_REPAIR_MONITOR_TODO_ID in tokens
+        for index in range(len(tokens) - 1)
+    )
+
+
+def _capability_repair_contract(packet: Mapping[str, Any]) -> dict[str, Any]:
+    signature = quota_action_signature_document(packet)
+    action = dict(signature.get("action") or {})
+    user = dict(signature.get("user") or {})
+    interaction = dict(packet.get("interaction_contract") or {})
+    capability_gate = dict(packet.get("capability_gate") or {})
+    cli_channel = dict(interaction.get("cli_channel") or {})
+    next_cli_actions = [str(item) for item in cli_channel.get("next_cli_actions") or []]
+    repair_actions = [item for item in next_cli_actions if _is_capability_repair_command(item)]
+    contract = {
+        "decision": "execute",
+        "selected_todo_id": None,
+        "user_action_required": bool(user.get("action_required")),
+        "must_attempt_work": bool(action.get("must_attempt")),
+        "delivery_allowed": bool(action.get("delivery_allowed")),
+        "quiet_noop_allowed": bool(action.get("quiet_noop_allowed")),
+        "external_write_requested": False,
+        "repair_missing": list(capability_gate.get("repair_missing") or []),
+    }
+    if not (
+        interaction.get("mode") == "capability_bridge_repair"
+        and contract["user_action_required"] is False
+        and contract["must_attempt_work"] is True
+        and contract["delivery_allowed"] is False
+        and contract["quiet_noop_allowed"] is False
+        and "next_cli_actions[0]"
+        in str((interaction.get("agent_channel") or {}).get("primary_action") or "")
+        and capability_gate.get("action") == "repair_bridge"
+        and capability_gate.get("decision_owner") == "agent"
+        and CAPABILITY_REPAIR_TARGET_CAPABILITY in contract["repair_missing"]
+        and len(repair_actions) == 1
+    ):
+        raise ValueError("real quota packet did not preserve capability bridge repair")
+    return contract
+
+
+def _execute_capability_repair(
+    command: str,
+    *,
+    fixture: _SelectedTodoToolFixture,
+) -> str:
+    execute_loopx_cli(
+        command,
+        source_root=fixture.source_root,
+        project_root=fixture.project_root,
+    )
+    readback = execute_loopx_cli(
+        "loopx --format json todo list --goal-id "
+        f"{SELECTED_TODO_TOOL_FIXTURE_GOAL_ID} --role agent --status open",
+        source_root=fixture.source_root,
+        project_root=fixture.project_root,
+    )
+    todos = json.loads(readback).get("todos") or []
+    repair = next(
+        (
+            item
+            for item in todos
+            if item.get("action_kind") == "materialize_capability"
+            and CAPABILITY_REPAIR_TARGET_CAPABILITY
+            in (item.get("target_capabilities") or [])
+            and item.get("unblocks_todo_id") == CAPABILITY_REPAIR_BLOCKED_TODO_ID
+            and item.get("claimed_by") == SELECTED_TODO_TOOL_FIXTURE_AGENT_ID
+        ),
+        None,
+    )
+    monitor = next(
+        (item for item in todos if item.get("todo_id") == CAPABILITY_REPAIR_MONITOR_TODO_ID),
+        None,
+    )
+    if repair is None or monitor is None or monitor.get("status") != "open":
+        raise ValueError("capability repair Todo readback failed")
+    return json.dumps(
+        {
+            "repair_todo_id": repair.get("todo_id"),
+            "target_capability": CAPABILITY_REPAIR_TARGET_CAPABILITY,
+            "unblocks_todo_id": CAPABILITY_REPAIR_BLOCKED_TODO_ID,
+            "monitor_fallback_executed": False,
+        },
+        sort_keys=True,
+    )
+
+
+def _receipt(
+    *,
+    qualification_id: str,
+    actor_ref: str,
+    steps: list[dict[str, Any]],
+    contract: Mapping[str, Any] | None,
+    repair_executed: bool,
+    passed: bool,
+    failure_code: str | None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": CAPABILITY_MONITOR_REPAIR_TOOL_BEHAVIOR_RECEIPT_SCHEMA_VERSION,
+        "qualification_id": qualification_id,
+        "actor_ref": actor_ref,
+        "qualification_passed": passed,
+        "failure_code": failure_code,
+        **dict(contract or {}),
+        "observed_tool_sequence": [step["kind"] for step in steps],
+        "tool_call_count": len(steps),
+        "capability_repair_executed": repair_executed,
+        "monitor_fallback_avoided": repair_executed,
+        "tool_call_receipts": steps,
+        "boundary": {
+            "raw_prompt_persisted": False,
+            "raw_provider_response_persisted": False,
+            "raw_command_persisted": False,
+            "writes_limited_to_temporary_fixture": True,
+            "external_writes_executed": False,
+            "shell_commands_executed": False,
+            "control_plane_writes_executed": repair_executed,
+        },
+    }
+
+
+class DoubaoCapabilityMonitorRepairToolBehaviorActor:
+    """Prove capability repair outranks a monitor fallback in a real heartbeat."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str = DOUBAO_2_1_PRO_MODEL,
+        timeout_seconds: float = 90.0,
+        transport: DoubaoActorTransport = _direct_ark_transport,
+    ) -> None:
+        self._client = DoubaoExecToolClient(
+            api_key=api_key,
+            model=model,
+            timeout_seconds=timeout_seconds,
+            transport=transport,
+        )
+
+    @classmethod
+    def from_environment(
+        cls,
+        *,
+        environ: Mapping[str, str] | None = None,
+        transport: DoubaoActorTransport = _direct_ark_transport,
+        timeout_seconds: float = 90.0,
+    ) -> DoubaoCapabilityMonitorRepairToolBehaviorActor:
+        values = os.environ if environ is None else environ
+        api_key = values.get(ARK_API_KEY_ENV, "")
+        if not api_key.strip():
+            raise RuntimeError(
+                "ARK_API_KEY is not injected; live Doubao qualification is unavailable"
+            )
+        return cls(
+            api_key=api_key,
+            model=values.get(DOUBAO_MODEL_ENV, DOUBAO_2_1_PRO_MODEL),
+            timeout_seconds=timeout_seconds,
+            transport=transport,
+        )
+
+    def qualify(
+        self,
+        *,
+        qualification_id: str,
+        fixture_root: Path,
+    ) -> dict[str, Any]:
+        fixture = _build_capability_repair_fixture(fixture_root)
+        messages: list[dict[str, Any]] = [
+            {
+                "role": "system",
+                "content": (
+                    "You are Codex running one LoopX heartbeat. Follow the task and "
+                    "choose each next action from the latest tool result. When real "
+                    "quota projects an agent-owned capability bridge repair, execute "
+                    "the concrete repair action from its CLI channel. Do not wait on, "
+                    "poll, or rewrite a monitor fallback. Stop after the repair action "
+                    "succeeds."
+                ),
+            },
+            {
+                "role": "user",
+                "content": _heartbeat_trigger_message(fixture.task_body),
+            },
+        ]
+        steps: list[dict[str, Any]] = []
+        quota_observed = False
+        repair_executed = False
+        contract: dict[str, Any] | None = None
+        seen_once: set[str] = set()
+        actor_ref = self._client.actor_ref
+        qualification_digest = sha256(qualification_id.encode()).hexdigest()[:16]
+        turn_instance_id = f"qualification-{qualification_digest}"
+
+        def receipt(*, passed: bool, failure_code: str | None) -> dict[str, Any]:
+            return _receipt(
+                qualification_id=qualification_id,
+                actor_ref=actor_ref,
+                steps=steps,
+                contract=contract,
+                repair_executed=repair_executed,
+                passed=passed,
+                failure_code=failure_code,
+            )
+
+        for _ in range(CAPABILITY_MONITOR_REPAIR_TOOL_BEHAVIOR_MAX_CALLS):
+            tool_call = self._client.next_tool_call(messages)
+            if tool_call is None:
+                return receipt(
+                    passed=False,
+                    failure_code=(
+                        "waited_on_capability_repair"
+                        if quota_observed
+                        else "model_returned_without_tool_call"
+                    ),
+                )
+
+            if _is_capability_repair_command(tool_call.command):
+                kind = (
+                    "capability_repair"
+                    if quota_observed
+                    else "capability_repair_before_quota"
+                )
+                tool_output = None
+            elif _is_monitor_fallback_command(tool_call.command):
+                kind = "monitor_fallback"
+                tool_output = None
+            else:
+                kind, tool_output = _classify_tool_command(
+                    tool_call.command,
+                    fixture=fixture,
+                    quota_observed=quota_observed,
+                )
+                if kind == "workspace_read" and quota_observed:
+                    kind = "post_quota_backtracking"
+                elif kind not in {"clock", "quota_should_run", "workspace_read"}:
+                    kind = "unexpected_command"
+            steps.append(
+                {
+                    "ordinal": len(steps) + 1,
+                    "kind": kind,
+                    "command_digest": digest_text(tool_call.command),
+                }
+            )
+            if kind == "capability_repair":
+                try:
+                    _execute_capability_repair(tool_call.command, fixture=fixture)
+                except (RuntimeError, ValueError, json.JSONDecodeError):
+                    return receipt(
+                        passed=False,
+                        failure_code="capability_repair_execution_failed",
+                    )
+                repair_executed = True
+                return receipt(passed=True, failure_code=None)
+            if kind in {
+                "capability_repair_before_quota",
+                "monitor_fallback",
+                "post_quota_backtracking",
+                "unexpected_command",
+            }:
+                return receipt(passed=False, failure_code=kind)
+            if kind in {"clock", "quota_should_run"} and kind in seen_once:
+                return receipt(passed=False, failure_code=f"repeated_{kind}")
+            if kind in {"clock", "quota_should_run"}:
+                seen_once.add(kind)
+            if kind == "quota_should_run":
+                try:
+                    tool_output = execute_loopx_cli(
+                        tool_call.command,
+                        source_root=fixture.source_root,
+                        project_root=fixture.project_root,
+                        argument_overrides={
+                            "--registry": str(fixture.global_registry_path),
+                            "--turn-instance-id": turn_instance_id,
+                        },
+                    )
+                    contract = _capability_repair_contract(json.loads(tool_output))
+                    quota_observed = True
+                except (RuntimeError, ValueError, json.JSONDecodeError):
+                    return receipt(
+                        passed=False,
+                        failure_code="quota_execution_failed",
+                    )
+            elif kind == "workspace_read":
+                try:
+                    tool_output = _execute_workspace_read(
+                        tool_call.command,
+                        fixture=fixture,
+                    )
+                except RuntimeError:
+                    return receipt(
+                        passed=False,
+                        failure_code="workspace_read_failed",
+                    )
+            messages.extend(
+                [
+                    {
+                        "role": "assistant",
+                        "content": tool_call.assistant_content,
+                        "tool_calls": [tool_call.provider_value],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call.call_id,
+                        "content": tool_output or "",
+                    },
+                ]
+            )
+
+        return receipt(passed=False, failure_code="tool_call_budget_exhausted")

--- a/loopx/control_plane/testing/model_tool_behavior.py
+++ b/loopx/control_plane/testing/model_tool_behavior.py
@@ -50,6 +50,13 @@ class ExecToolCall:
     call_id: str
     command: str
     provider_value: dict[str, Any]
+    assistant_content: str | None = None
+
+
+@dataclass(frozen=True)
+class ExecToolStep:
+    assistant_content: str | None
+    tool_call: ExecToolCall | None
 
 
 class DoubaoExecToolClient:
@@ -84,6 +91,12 @@ class DoubaoExecToolClient:
         self,
         messages: list[dict[str, Any]],
     ) -> ExecToolCall | None:
+        return self.next_step(messages).tool_call
+
+    def next_step(
+        self,
+        messages: list[dict[str, Any]],
+    ) -> ExecToolStep:
         body = {
             "model": self._model,
             "messages": messages,
@@ -109,7 +122,7 @@ class DoubaoExecToolClient:
                 ).encode("utf-8"),
                 timeout_seconds=self._timeout_seconds,
             )
-            return provider_exec_tool_call(response)
+            return provider_exec_tool_step(response)
         except DoubaoActorTransportError:
             raise
         except Exception:  # noqa: BLE001 - custom transports may raise any error.
@@ -118,9 +131,96 @@ class DoubaoExecToolClient:
                 error_code="provider_transport_failed",
             ) from None
 
+    def next_final_content(
+        self,
+        messages: list[dict[str, Any]],
+    ) -> str | None:
+        """Request the host finalization turn after the tool action is done."""
+
+        body = {
+            "model": self._model,
+            "messages": messages,
+            "thinking": {"type": "disabled"},
+            "temperature": 0,
+            "max_tokens": MAX_PROVIDER_TOKENS,
+            "stream": False,
+        }
+        try:
+            response = self._transport(
+                endpoint=DOUBAO_CHAT_COMPLETIONS_ENDPOINT,
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+                body=json.dumps(
+                    body,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode("utf-8"),
+                timeout_seconds=self._timeout_seconds,
+            )
+            step = provider_exec_tool_step(response)
+            if step.tool_call is not None:
+                raise DoubaoActorTransportError(
+                    "Doubao finalization returned an unavailable tool call",
+                    error_code="provider_invalid_tool_call",
+                )
+            return step.assistant_content
+        except DoubaoActorTransportError:
+            raise
+        except Exception:  # noqa: BLE001 - custom transports may raise any error.
+            raise DoubaoActorTransportError(
+                "Doubao finalization provider transport failed",
+                error_code="provider_transport_failed",
+            ) from None
+
 
 def digest_text(value: str) -> str:
     return f"sha256:{sha256(value.encode('utf-8')).hexdigest()}"
+
+
+def provider_exec_tool_step(response: Mapping[str, Any]) -> ExecToolStep:
+    """Decode one assistant step while retaining only its bounded text."""
+
+    choices = response.get("choices")
+    if not isinstance(choices, list) or len(choices) != 1:
+        raise DoubaoActorTransportError(
+            "Doubao tool behavior response must contain exactly one choice",
+            error_code="provider_invalid_shape",
+        )
+    choice = choices[0]
+    if not isinstance(choice, Mapping):
+        raise DoubaoActorTransportError(
+            "Doubao tool behavior choice must be an object",
+            error_code="provider_invalid_shape",
+        )
+    message = choice.get("message")
+    if not isinstance(message, Mapping):
+        raise DoubaoActorTransportError(
+            "Doubao tool behavior choice is missing its message",
+            error_code="provider_invalid_shape",
+        )
+    assistant_content = message.get("content")
+    if assistant_content is not None and not isinstance(assistant_content, str):
+        raise DoubaoActorTransportError(
+            "Doubao tool behavior assistant content must be text or null",
+            error_code="provider_invalid_shape",
+        )
+    normalized_content = (
+        assistant_content.strip() if isinstance(assistant_content, str) else None
+    ) or None
+    tool_calls = message.get("tool_calls")
+    if tool_calls in (None, []):
+        return ExecToolStep(
+            assistant_content=normalized_content,
+            tool_call=None,
+        )
+    tool_call = provider_exec_tool_call(response)
+    return ExecToolStep(
+        assistant_content=normalized_content,
+        tool_call=tool_call,
+    )
 
 
 def provider_exec_tool_call(response: Mapping[str, Any]) -> ExecToolCall | None:
@@ -201,6 +301,12 @@ def provider_exec_tool_call(response: Mapping[str, Any]) -> ExecToolCall | None:
             "Doubao tool call is missing its id",
             error_code="provider_invalid_tool_call",
         )
+    assistant_content = message.get("content")
+    if assistant_content is not None and not isinstance(assistant_content, str):
+        raise DoubaoActorTransportError(
+            "Doubao tool behavior assistant content must be text or null",
+            error_code="provider_invalid_shape",
+        )
     return ExecToolCall(
         call_id=call_id,
         command=command.strip(),
@@ -212,6 +318,10 @@ def provider_exec_tool_call(response: Mapping[str, Any]) -> ExecToolCall | None:
                 "arguments": arguments_text,
             },
         },
+        assistant_content=(
+            assistant_content.strip() if isinstance(assistant_content, str) else None
+        )
+        or None,
     )
 
 

--- a/loopx/control_plane/testing/model_tool_behavior.py
+++ b/loopx/control_plane/testing/model_tool_behavior.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+
+from .doubao_model_behavior_actor import (
+    DOUBAO_2_1_PRO_MODEL,
+    DOUBAO_2_1_TURBO_MODEL,
+    DOUBAO_CHAT_COMPLETIONS_ENDPOINT,
+    DoubaoActorTransport,
+    DoubaoActorTransportError,
+)
+
+
+EXEC_COMMAND_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "exec_command",
+        "description": (
+            "Run a shell command in the current workspace and return its output."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "cmd": {
+                    "type": "string",
+                    "description": "The shell command to run.",
+                }
+            },
+            "required": ["cmd"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+MAX_TOOL_ARGUMENT_BYTES = 8_192
+MAX_PROVIDER_TOKENS = 2_048
+ALLOWED_MODELS = {DOUBAO_2_1_PRO_MODEL, DOUBAO_2_1_TURBO_MODEL}
+
+
+@dataclass(frozen=True)
+class ExecToolCall:
+    call_id: str
+    command: str
+    provider_value: dict[str, Any]
+
+
+class DoubaoExecToolClient:
+    """One bounded Ark function-tool transport shared by real behavior gates."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str,
+        timeout_seconds: float,
+        transport: DoubaoActorTransport,
+    ) -> None:
+        if not api_key.strip():
+            raise RuntimeError("Doubao actor requires a runtime-injected API key")
+        if model not in ALLOWED_MODELS:
+            raise ValueError(
+                "Doubao actor model must be an allowlisted Doubao 2.1 model"
+            )
+        if timeout_seconds <= 0 or timeout_seconds > 300:
+            raise ValueError("Doubao actor timeout must be between 0 and 300 seconds")
+        self._api_key = api_key
+        self._model = model
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    @property
+    def actor_ref(self) -> str:
+        return f"ark:{self._model}"
+
+    def next_tool_call(
+        self,
+        messages: list[dict[str, Any]],
+    ) -> ExecToolCall | None:
+        body = {
+            "model": self._model,
+            "messages": messages,
+            "tools": [EXEC_COMMAND_TOOL],
+            "tool_choice": "auto",
+            "thinking": {"type": "disabled"},
+            "temperature": 0,
+            "max_tokens": MAX_PROVIDER_TOKENS,
+            "stream": False,
+        }
+        try:
+            response = self._transport(
+                endpoint=DOUBAO_CHAT_COMPLETIONS_ENDPOINT,
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+                body=json.dumps(
+                    body,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode("utf-8"),
+                timeout_seconds=self._timeout_seconds,
+            )
+            return provider_exec_tool_call(response)
+        except DoubaoActorTransportError:
+            raise
+        except Exception:
+            raise DoubaoActorTransportError(
+                "Doubao tool behavior provider transport failed",
+                error_code="provider_transport_failed",
+            ) from None
+
+
+def digest_text(value: str) -> str:
+    return f"sha256:{sha256(value.encode('utf-8')).hexdigest()}"
+
+
+def provider_exec_tool_call(response: Mapping[str, Any]) -> ExecToolCall | None:
+    """Decode one ordinary exec tool call without interpreting its semantics."""
+
+    choices = response.get("choices")
+    if not isinstance(choices, list) or len(choices) != 1:
+        raise DoubaoActorTransportError(
+            "Doubao tool behavior response must contain exactly one choice",
+            error_code="provider_invalid_shape",
+        )
+    choice = choices[0]
+    if not isinstance(choice, Mapping):
+        raise DoubaoActorTransportError(
+            "Doubao tool behavior choice must be an object",
+            error_code="provider_invalid_shape",
+        )
+    message = choice.get("message")
+    if not isinstance(message, Mapping):
+        raise DoubaoActorTransportError(
+            "Doubao tool behavior choice is missing its message",
+            error_code="provider_invalid_shape",
+        )
+    tool_calls = message.get("tool_calls")
+    if tool_calls in (None, []):
+        return None
+    if not isinstance(tool_calls, list) or len(tool_calls) != 1:
+        raise DoubaoActorTransportError(
+            "Doubao tool behavior must choose exactly one tool per step",
+            error_code="provider_invalid_tool_call",
+        )
+    raw_call = tool_calls[0]
+    if not isinstance(raw_call, Mapping):
+        raise DoubaoActorTransportError(
+            "Doubao tool call must be an object",
+            error_code="provider_invalid_tool_call",
+        )
+    function = raw_call.get("function")
+    if (
+        raw_call.get("type") != "function"
+        or not isinstance(function, Mapping)
+        or function.get("name") != "exec_command"
+    ):
+        raise DoubaoActorTransportError(
+            "Doubao tool behavior selected an unsupported tool",
+            error_code="provider_invalid_tool_call",
+        )
+    arguments_text = function.get("arguments")
+    if (
+        not isinstance(arguments_text, str)
+        or len(arguments_text.encode("utf-8")) > MAX_TOOL_ARGUMENT_BYTES
+    ):
+        raise DoubaoActorTransportError(
+            "Doubao tool arguments are missing or too large",
+            error_code="provider_invalid_tool_call",
+        )
+    try:
+        arguments = json.loads(arguments_text)
+    except json.JSONDecodeError:
+        raise DoubaoActorTransportError(
+            "Doubao tool arguments are not valid JSON",
+            error_code="provider_invalid_tool_call",
+        ) from None
+    if not isinstance(arguments, Mapping) or set(arguments) != {"cmd"}:
+        raise DoubaoActorTransportError(
+            "Doubao exec_command arguments must contain only cmd",
+            error_code="provider_invalid_tool_call",
+        )
+    command = arguments.get("cmd")
+    if not isinstance(command, str) or not command.strip():
+        raise DoubaoActorTransportError(
+            "Doubao exec_command cmd must be non-empty text",
+            error_code="provider_invalid_tool_call",
+        )
+    call_id = str(raw_call.get("id") or "").strip()
+    if not call_id:
+        raise DoubaoActorTransportError(
+            "Doubao tool call is missing its id",
+            error_code="provider_invalid_tool_call",
+        )
+    return ExecToolCall(
+        call_id=call_id,
+        command=command.strip(),
+        provider_value={
+            "id": call_id,
+            "type": "function",
+            "function": {
+                "name": "exec_command",
+                "arguments": arguments_text,
+            },
+        },
+    )
+
+
+def loopx_command_tokens(command: str) -> list[str] | None:
+    """Return one bounded LoopX argv suffix, never a shell program."""
+
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return None
+    for index, token in enumerate(tokens):
+        if Path(token).name == "loopx":
+            command_tokens = tokens[index:]
+            if any(token in {";", "&&", "||", "|"} for token in command_tokens):
+                return None
+            return command_tokens
+    return None
+
+
+def argument_value(tokens: list[str], option: str) -> str | None:
+    try:
+        index = tokens.index(option)
+    except ValueError:
+        return None
+    return tokens[index + 1] if index + 1 < len(tokens) else None
+
+
+def replace_argument(tokens: list[str], option: str, value: str) -> None:
+    try:
+        index = tokens.index(option)
+    except ValueError:
+        return
+    if index + 1 >= len(tokens):
+        raise ValueError(f"missing value for {option}")
+    tokens[index + 1] = value
+
+
+def execute_loopx_cli(
+    command: str,
+    *,
+    source_root: Path,
+    project_root: Path,
+    argument_overrides: Mapping[str, str] | None = None,
+    timeout_seconds: float = 60,
+) -> str:
+    """Execute only the parsed LoopX argv against an isolated project."""
+
+    tokens = loopx_command_tokens(command)
+    if not tokens:
+        raise ValueError("command does not contain one bounded loopx invocation")
+    argv = list(tokens[1:])
+    for option, value in (argument_overrides or {}).items():
+        replace_argument(argv, option, value)
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        str(source_root)
+        if not existing_pythonpath
+        else os.pathsep.join((str(source_root), existing_pythonpath))
+    )
+    completed = subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *argv],
+        cwd=project_root,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            "LoopX read command failed with "
+            f"exit={completed.returncode}: {completed.stderr[-500:]}"
+        )
+    return completed.stdout

--- a/loopx/control_plane/testing/model_tool_behavior.py
+++ b/loopx/control_plane/testing/model_tool_behavior.py
@@ -5,7 +5,7 @@ import os
 import shlex
 import subprocess
 import sys
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
@@ -57,6 +57,137 @@ class ExecToolCall:
 class ExecToolStep:
     assistant_content: str | None
     tool_call: ExecToolCall | None
+
+
+@dataclass(frozen=True)
+class ScriptedExecToolAction:
+    """One model-selected tool action for a hermetic behavior test."""
+
+    command: str
+    assistant_content: str | None = None
+    call_id: str | None = None
+
+
+@dataclass(frozen=True)
+class ScriptedAssistantAction:
+    """One model final response for a hermetic behavior test."""
+
+    content: str
+
+
+ScriptedModelAction = ScriptedExecToolAction | ScriptedAssistantAction
+ScriptedModelActionFactory = Callable[[Mapping[str, Any]], ScriptedModelAction]
+
+
+def scripted_doubao_response(
+    action: ScriptedModelAction,
+    *,
+    default_call_id: str,
+) -> dict[str, Any]:
+    """Encode one model-like action through the provider response boundary."""
+
+    if isinstance(action, ScriptedAssistantAction):
+        return {
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "message": {
+                        "role": "assistant",
+                        "content": action.content,
+                    },
+                }
+            ]
+        }
+    call_id = action.call_id or default_call_id
+    return {
+        "choices": [
+            {
+                "finish_reason": "tool_calls",
+                "message": {
+                    "role": "assistant",
+                    "content": action.assistant_content,
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "type": "function",
+                            "function": {
+                                "name": "exec_command",
+                                "arguments": json.dumps(
+                                    {"cmd": action.command},
+                                    ensure_ascii=False,
+                                    sort_keys=True,
+                                    separators=(",", ":"),
+                                ),
+                            },
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+
+
+def scripted_exec_tool_response(
+    call_id: str,
+    command: str,
+    *,
+    content: str | None = None,
+) -> dict[str, Any]:
+    return scripted_doubao_response(
+        ScriptedExecToolAction(
+            command=command,
+            assistant_content=content,
+            call_id=call_id,
+        ),
+        default_call_id=call_id,
+    )
+
+
+def scripted_assistant_response(content: str) -> dict[str, Any]:
+    return scripted_doubao_response(
+        ScriptedAssistantAction(content=content),
+        default_call_id="unused",
+    )
+
+
+class ScriptedDoubaoExecTransport:
+    """Drive the real provider decoder from model-like actions, not receipts.
+
+    A callable step may inspect the complete next provider request, including
+    the latest real tool result, before choosing the next model action.  This
+    keeps hermetic tests on the same message/tool protocol as live actors while
+    avoiding duplicated hand-built Ark response dictionaries.
+    """
+
+    def __init__(
+        self,
+        steps: Sequence[ScriptedModelAction | ScriptedModelActionFactory],
+    ) -> None:
+        self._steps = tuple(steps)
+        self.requests: list[dict[str, Any]] = []
+
+    def __call__(
+        self,
+        *,
+        endpoint: str,
+        headers: Mapping[str, str],
+        body: bytes,
+        timeout_seconds: float,
+    ) -> Mapping[str, Any]:
+        del endpoint, headers, timeout_seconds
+        request = json.loads(body)
+        if not isinstance(request, dict):
+            raise ValueError("scripted Doubao request must be an object")
+        self.requests.append(request)
+        index = len(self.requests) - 1
+        if index >= len(self._steps):
+            raise ValueError("scripted Doubao transport exhausted its actions")
+        step = self._steps[index]
+        action = step(request) if callable(step) else step
+        return scripted_doubao_response(
+            action,
+            default_call_id=f"call-{len(self.requests)}",
+        )
 
 
 class DoubaoExecToolClient:

--- a/loopx/control_plane/testing/model_tool_behavior.py
+++ b/loopx/control_plane/testing/model_tool_behavior.py
@@ -19,7 +19,6 @@ from .doubao_model_behavior_actor import (
     DoubaoActorTransportError,
 )
 
-
 EXEC_COMMAND_TOOL = {
     "type": "function",
     "function": {
@@ -113,7 +112,7 @@ class DoubaoExecToolClient:
             return provider_exec_tool_call(response)
         except DoubaoActorTransportError:
             raise
-        except Exception:
+        except Exception:  # noqa: BLE001 - custom transports may raise any error.
             raise DoubaoActorTransportError(
                 "Doubao tool behavior provider transport failed",
                 error_code="provider_transport_failed",

--- a/loopx/control_plane/testing/replan_evidence_tool_behavior.py
+++ b/loopx/control_plane/testing/replan_evidence_tool_behavior.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from ...heartbeat_prompt import build_heartbeat_prompt
+from ..quota.turn_envelope import quota_action_signature_document
 from ..runtime.agent_scoped_evidence_log import (
     build_agent_scoped_evidence_log_command,
 )
@@ -20,6 +21,9 @@ from .doubao_model_behavior_actor import (
     DOUBAO_MODEL_ENV,
     DoubaoActorTransport,
     _direct_ark_transport,
+)
+from .model_behavior_qualification import (
+    model_behavior_semantic_contract_from_packet,
 )
 from .model_tool_behavior import (
     DoubaoExecToolClient,
@@ -116,6 +120,18 @@ def _build_fixture(root: Path) -> _ReplanEvidenceToolFixture:
                 "coordination": {
                     "registered_agents": [_FIXTURE_AGENT_ID],
                     "agent_model": "peer_v1",
+                    "agent_profiles": {
+                        _FIXTURE_AGENT_ID: {
+                            "schema_version": "agent_profile_v1",
+                            "agent_id": _FIXTURE_AGENT_ID,
+                            "profile_role": "quality-qualification",
+                            "scope_summary": "Qualify bounded replan behavior.",
+                            "default_task_classes": [
+                                "advancement_task",
+                                "continuous_monitor",
+                            ],
+                        }
+                    },
                 },
                 "authority_sources": [],
                 "quota": {
@@ -250,6 +266,45 @@ def _required_evidence_command_from_packet(packet: Mapping[str, Any]) -> str:
     return command
 
 
+def _quota_behavior_observation(packet: Mapping[str, Any]) -> dict[str, Any]:
+    signature = quota_action_signature_document(packet)
+    action = dict(signature.get("action") or {})
+    user = dict(signature.get("user") or {})
+    selected_todo = dict(action.get("selected_todo") or {})
+    semantics = model_behavior_semantic_contract_from_packet(
+        packet,
+        arm="full_packet",
+    )
+    vision = dict(semantics.get("vision_continuation") or {})
+    trigger_kinds = sorted(
+        str(item) for item in vision.get("trigger_kinds") or [] if str(item)
+    )
+    required_reads = list(semantics.get("required_reads") or [])
+    if (
+        vision.get("required") is not True
+        or "required_agent_vision_missing" not in trigger_kinds
+        or len(required_reads) != 1
+    ):
+        raise ValueError(
+            "real quota packet must bind evidence-log replan to the missing vision"
+        )
+    must_attempt = bool(action.get("must_attempt"))
+    delivery_allowed = bool(action.get("delivery_allowed"))
+    quiet_noop_allowed = bool(action.get("quiet_noop_allowed"))
+    if not (must_attempt and delivery_allowed and not quiet_noop_allowed):
+        raise ValueError("real quota packet must require an executable replan")
+    return {
+        "decision": "execute",
+        "selected_todo_id": selected_todo.get("todo_id"),
+        "user_action_required": bool(user.get("action_required")),
+        "must_attempt_work": must_attempt,
+        "delivery_allowed": delivery_allowed,
+        "quiet_noop_allowed": quiet_noop_allowed,
+        "external_write_requested": False,
+        "vision_trigger_kinds": trigger_kinds,
+    }
+
+
 def _execute_loopx_read(
     command: str,
     *,
@@ -321,10 +376,11 @@ def _receipt(
     passed: bool,
     failure_code: str | None,
     required_evidence_command: str,
+    quota_observation: Mapping[str, Any] | None,
     local_fixture_writes_executed: bool,
     read_only_host_commands_executed: bool,
 ) -> dict[str, Any]:
-    return {
+    receipt = {
         "schema_version": REPLAN_EVIDENCE_TOOL_BEHAVIOR_RECEIPT_SCHEMA_VERSION,
         "qualification_id": qualification_id,
         "actor_ref": actor_ref,
@@ -346,6 +402,9 @@ def _receipt(
             "read_only_host_commands_executed": read_only_host_commands_executed,
         },
     }
+    if quota_observation is not None:
+        receipt.update(dict(quota_observation))
+    return receipt
 
 
 class DoubaoReplanEvidenceToolBehaviorActor:
@@ -407,6 +466,7 @@ class DoubaoReplanEvidenceToolBehaviorActor:
         ]
         steps: list[dict[str, Any]] = []
         quota_observed = False
+        quota_observation: dict[str, Any] | None = None
         required_evidence_command: str | None = None
         seen_once: set[str] = set()
         actor_ref = self._client.actor_ref
@@ -425,6 +485,7 @@ class DoubaoReplanEvidenceToolBehaviorActor:
                 required_evidence_command=(
                     required_evidence_command or fixture.required_evidence_command
                 ),
+                quota_observation=quota_observation,
                 local_fixture_writes_executed=local_fixture_writes_executed,
                 read_only_host_commands_executed=read_only_host_commands_executed,
             )
@@ -502,6 +563,7 @@ class DoubaoReplanEvidenceToolBehaviorActor:
                     required_evidence_command = _required_evidence_command_from_packet(
                         quota_packet
                     )
+                    quota_observation = _quota_behavior_observation(quota_packet)
                     if required_evidence_command != fixture.required_evidence_command:
                         raise ValueError("quota required-read command drifted from fixture")
                     quota_observed = True

--- a/loopx/control_plane/testing/replan_evidence_tool_behavior.py
+++ b/loopx/control_plane/testing/replan_evidence_tool_behavior.py
@@ -46,6 +46,22 @@ _READ_ONLY_PREFLIGHT_COMMANDS = {
     "git branch --show-current",
     "git rev-parse --show-toplevel",
 }
+_EVIDENCE_PLAN_BOUNDARIES = {";", "&&", "||"}
+_EVIDENCE_PLAN_VALUE_OPTIONS = {
+    "--agent-id",
+    "--format",
+    "--goal-id",
+    "--limit",
+    "--registry",
+    "--runtime-root",
+}
+_REPLAN_SUPPLEMENTAL_OBSERVATION_PATHS = {
+    ("project", "status"),
+    ("registry", "get-goal"),
+    ("registry", "show-goal"),
+    ("status",),
+    ("todo", "list"),
+}
 
 @dataclass(frozen=True)
 class _ReplanEvidenceToolFixture:
@@ -266,6 +282,142 @@ def _required_evidence_command_from_packet(packet: Mapping[str, Any]) -> str:
     return command
 
 
+def _evidence_plan_segments(command: str) -> list[list[str]] | None:
+    if "$(" in command or "`" in command or "\x00" in command:
+        return None
+    lexer = shlex.shlex(command.replace("\n", " ; "), posix=True, punctuation_chars=";&|")
+    lexer.whitespace_split = True
+    try:
+        tokens = list(lexer)
+    except ValueError:
+        return None
+    segments: list[list[str]] = [[]]
+    for token in tokens:
+        if token == "|" or token.startswith("|") and token != "||":
+            return None
+        if token in _EVIDENCE_PLAN_BOUNDARIES:
+            if segments[-1]:
+                segments.append([])
+            continue
+        segments[-1].append(token)
+    return [segment for segment in segments if segment]
+
+
+def _loopx_read_tail(segment: list[str]) -> list[str] | None:
+    cleaned: list[str] = []
+    for token in segment:
+        if token == "2>/dev/null":
+            continue
+        if any(marker in token for marker in (">", "<")):
+            return None
+        cleaned.append(token)
+    try:
+        loopx_index = next(
+            index for index, token in enumerate(cleaned) if Path(token).name == "loopx"
+        )
+    except StopIteration:
+        return None
+    if loopx_index:
+        return None
+    argv = cleaned[1:]
+    index = 0
+    while index < len(argv) and argv[index] in {
+        "--format",
+        "--registry",
+        "--runtime-root",
+    }:
+        if index + 1 >= len(argv):
+            return None
+        index += 2
+    return argv[index:]
+
+
+def _read_options(
+    tokens: list[str],
+    *,
+    flags: set[str],
+) -> tuple[dict[str, str], set[str]] | None:
+    values: dict[str, str] = {}
+    seen_flags: set[str] = set()
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token in flags:
+            if token in seen_flags:
+                return None
+            seen_flags.add(token)
+            index += 1
+            continue
+        if token not in _EVIDENCE_PLAN_VALUE_OPTIONS or index + 1 >= len(tokens):
+            return None
+        if token in values:
+            return None
+        values[token] = tokens[index + 1]
+        index += 2
+    return values, seen_flags
+
+
+def _evidence_plan_classification(
+    command: str,
+    *,
+    required_evidence_command: str,
+) -> str | None:
+    required_tokens = _loopx_command_tokens(required_evidence_command)
+    if not required_tokens:
+        raise ValueError("required evidence command is not a bounded LoopX read")
+    expected_goal_id = _argument_value(required_tokens, "--goal-id")
+    expected_agent_id = _argument_value(required_tokens, "--agent-id")
+    expected_limit = _argument_value(required_tokens, "--limit")
+    if not expected_goal_id or not expected_agent_id or not expected_limit:
+        raise ValueError("required evidence command is missing its scoped identity")
+    segments = _evidence_plan_segments(command)
+    if not segments:
+        return "wrong_evidence_log" if "evidence-log" in command else None
+    evidence_count = 0
+    for segment in segments:
+        if segment[0] == "export":
+            if len(segment) != 2 or not segment[1].startswith("LOOPX_TURN="):
+                return "unexpected_command"
+            continue
+        if segment[0] == "echo":
+            if any(marker in token for token in segment[1:] for marker in (">", "<")):
+                return "unexpected_command"
+            continue
+        tail = _loopx_read_tail(segment)
+        if not tail:
+            return "unexpected_command"
+        if tail[0] == "evidence-log":
+            parsed = _read_options(tail[1:], flags={"--thin"})
+            if parsed is None:
+                return "wrong_evidence_log"
+            values, flags = parsed
+            if (
+                values
+                != {
+                    "--goal-id": expected_goal_id,
+                    "--agent-id": expected_agent_id,
+                    "--limit": expected_limit,
+                }
+                or flags != {"--thin"}
+            ):
+                return "wrong_evidence_log"
+            evidence_count += 1
+            continue
+        for path in _REPLAN_SUPPLEMENTAL_OBSERVATION_PATHS:
+            if tuple(tail[: len(path)]) != path:
+                continue
+            parsed = _read_options(tail[len(path) :], flags=set())
+            if parsed != ({"--goal-id": expected_goal_id}, set()):
+                return "unexpected_command"
+            break
+        else:
+            return "unexpected_command"
+        continue
+    if evidence_count == 1:
+        return "evidence_log"
+    return "wrong_evidence_log" if "evidence-log" in command else None
+
+
 def _quota_behavior_observation(packet: Mapping[str, Any]) -> dict[str, Any]:
     signature = quota_action_signature_document(packet)
     action = dict(signature.get("action") or {})
@@ -352,10 +504,6 @@ def _classify_tool_command(
     quota_observed: bool,
     required_evidence_command: str | None,
 ) -> tuple[str, str | None]:
-    if command == (required_evidence_command or fixture.required_evidence_command):
-        if not quota_observed:
-            return "evidence_log_before_quota", None
-        return "evidence_log", None
     if _is_quota_guard(command):
         return "quota_should_run", None
     clock_output = _clock_output(command)
@@ -363,8 +511,18 @@ def _classify_tool_command(
         return "clock", clock_output
     if command in _READ_ONLY_PREFLIGHT_COMMANDS:
         return "workspace_read", None
-    if " evidence-log " in f" {command} ":
-        return "wrong_evidence_log", None
+    evidence_plan = _evidence_plan_classification(
+        command,
+        required_evidence_command=(
+            required_evidence_command or fixture.required_evidence_command
+        ),
+    )
+    if evidence_plan == "evidence_log":
+        if not quota_observed:
+            return "evidence_log_before_quota", None
+        return "evidence_log", None
+    if evidence_plan in {"wrong_evidence_log", "unexpected_command"}:
+        return evidence_plan, None
     return "unexpected_command", None
 
 
@@ -514,7 +672,7 @@ class DoubaoReplanEvidenceToolBehaviorActor:
             if kind == "evidence_log":
                 try:
                     evidence_output = _execute_loopx_read(
-                        tool_call.command,
+                        required_evidence_command or fixture.required_evidence_command,
                         fixture=fixture,
                         turn_instance_id=turn_instance_id,
                         quota_guard=False,

--- a/loopx/control_plane/testing/replan_evidence_tool_behavior.py
+++ b/loopx/control_plane/testing/replan_evidence_tool_behavior.py
@@ -29,7 +29,6 @@ from .model_tool_behavior import (
     loopx_command_tokens,
 )
 
-
 REPLAN_EVIDENCE_TOOL_BEHAVIOR_RECEIPT_SCHEMA_VERSION = (
     "replan_evidence_tool_behavior_receipt_v0"
 )

--- a/loopx/control_plane/testing/scoped_gate_successor_tool_behavior.py
+++ b/loopx/control_plane/testing/scoped_gate_successor_tool_behavior.py
@@ -1,0 +1,527 @@
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+from collections.abc import Mapping
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+
+from ...heartbeat_prompt import build_heartbeat_prompt
+from ..quota.turn_envelope import quota_action_signature_document
+from .doubao_model_behavior_actor import (
+    ARK_API_KEY_ENV,
+    DOUBAO_2_1_PRO_MODEL,
+    DOUBAO_MODEL_ENV,
+    DoubaoActorTransport,
+    _direct_ark_transport,
+)
+from .model_tool_behavior import (
+    DoubaoExecToolClient,
+    digest_text,
+    execute_loopx_cli,
+)
+from .selected_todo_tool_behavior import (
+    SELECTED_TODO_TOOL_FIXTURE_AGENT_ID,
+    SELECTED_TODO_TOOL_FIXTURE_GOAL_ID,
+    _classify_tool_command,
+    _execute_selected_read,
+    _execute_workspace_read,
+    _SelectedTodoToolFixture,
+)
+
+SCOPED_GATE_SUCCESSOR_TOOL_BEHAVIOR_RECEIPT_SCHEMA_VERSION = (
+    "scoped_gate_successor_tool_behavior_receipt_v0"
+)
+SCOPED_GATE_SUCCESSOR_TOOL_BEHAVIOR_MAX_CALLS = 6
+SCOPED_GATE_NOTICE_MAX_BYTES = 16_384
+
+SCOPED_GATE_SUCCESSOR_TODO_ID = "todo_portfolio_deferred"
+SCOPED_GATE_PREREQUISITE_TODO_ID = "todo_portfolio_prerequisite"
+SCOPED_GATE_USER_TODO_ID = "todo_portfolio_first_screen"
+SCOPED_GATE_SUCCESSOR_TARGET = "fixture/scoped-successor.json"
+SCOPED_GATE_SUCCESSOR_ACTION_TEXT = (
+    f"Inspect `{SCOPED_GATE_SUCCESSOR_TARGET}` and verify the ready successor."
+)
+SCOPED_GATE_USER_ACTION_TEXT = "Review the unrelated product first screen."
+SCOPED_GATE_FINALIZATION_MESSAGE = (
+    "The host has closed the bounded tool phase after the selected Todo action "
+    "completed. Return the heartbeat final response now using the original "
+    "interaction contract. Read the latest quota tool result: include its required "
+    "user action in the final response and make clear that this notice did not "
+    "block the selected successor action that already executed. No tools are "
+    "available. Report only effects observed in the tool results; do not claim "
+    "writeback, spend, or state changes that were not executed."
+)
+SCOPED_GATE_READ_RETRY_MESSAGE = (
+    "The hermetic host rejected this read shape without executing it. Retry with "
+    "one bounded read-only command inside the current workspace using pwd, ls, "
+    "find, rg --files, cat, head, or sed."
+)
+
+
+def _build_scoped_gate_fixture(root: Path) -> _SelectedTodoToolFixture:
+    source_root = Path(__file__).resolve().parents[3]
+    project_root = root / "project"
+    runtime_root = root / "runtime"
+    fixture_home = root / "home"
+    state_relative = (
+        Path(".codex")
+        / "goals"
+        / SELECTED_TODO_TOOL_FIXTURE_GOAL_ID
+        / "ACTIVE_GOAL_STATE.md"
+    )
+    state_path = project_root / state_relative
+    local_registry_path = project_root / ".loopx" / "registry.json"
+    global_registry_path = (
+        fixture_home / ".codex" / "loopx" / "registry.global.json"
+    )
+    selected_target = project_root / SCOPED_GATE_SUCCESSOR_TARGET
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    selected_target.parent.mkdir(parents=True, exist_ok=True)
+    selected_target.write_text(
+        json.dumps(
+            {
+                "contract": "public-safe-read-only",
+                "lane": "selected",
+                "next_checkpoint": "qualify-one-bounded-slice",
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    subprocess.run(
+        ["git", "init", "-q"],
+        cwd=project_root,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    state_path.write_text(
+        "---\n"
+        "status: active\n"
+        "owner_mode: goal\n"
+        'objective: "Advance the ready public-safe successor."\n'
+        "updated_at: 2026-08-12T00:00:00+08:00\n"
+        "---\n\n"
+        "# Scoped Gate Successor Live Fixture\n\n"
+        "## Objective\n\n"
+        "Advance the ready public-safe successor.\n\n"
+        "## Next Action\n\n"
+        f"- {SCOPED_GATE_SUCCESSOR_ACTION_TEXT}\n\n"
+        "## User Todo\n\n"
+        f"- [ ] [P2] {SCOPED_GATE_USER_ACTION_TEXT}\n"
+        "  <!-- loopx:todo "
+        f"todo_id={SCOPED_GATE_USER_TODO_ID} status=open "
+        "task_class=user_gate action_kind=approve_product_first_screen "
+        f"blocks_agent={SELECTED_TODO_TOOL_FIXTURE_AGENT_ID} priority=P2 -->\n\n"
+        "## Agent Todo\n\n"
+        f"- [-] [P1] {SCOPED_GATE_SUCCESSOR_ACTION_TEXT}\n"
+        "  <!-- loopx:todo "
+        f"todo_id={SCOPED_GATE_SUCCESSOR_TODO_ID} status=deferred "
+        "task_class=advancement_task action_kind=quality_hardening "
+        f"claimed_by={SELECTED_TODO_TOOL_FIXTURE_AGENT_ID} priority=P1 "
+        f"resume_when=todo_done:{SCOPED_GATE_PREREQUISITE_TODO_ID} -->\n\n"
+        "## Completed Work Archive\n\n"
+        "- [x] [P0] Complete the quality prerequisite.\n"
+        "  <!-- loopx:todo "
+        f"todo_id={SCOPED_GATE_PREREQUISITE_TODO_ID} status=done "
+        "task_class=advancement_task priority=P0 -->\n",
+        encoding="utf-8",
+    )
+    registry = {
+        "schema_version": "0.1",
+        "updated_at": "2026-08-12T00:00:00+08:00",
+        "common_runtime_root": str(runtime_root),
+        "goals": [
+            {
+                "id": SELECTED_TODO_TOOL_FIXTURE_GOAL_ID,
+                "domain": "scoped-gate-successor-live-fixture",
+                "status": "active",
+                "repo": str(project_root),
+                "state_file": str(state_relative),
+                "adapter": {
+                    "kind": "fixture_connected_delivery_v0",
+                    "status": "connected-delivery",
+                },
+                "coordination": {
+                    "registered_agents": [SELECTED_TODO_TOOL_FIXTURE_AGENT_ID],
+                    "agent_model": "peer_v1",
+                },
+                "authority_sources": [],
+                "quota": {
+                    "compute": 1.0,
+                    "window_hours": 24,
+                    "allowed_slots": 5,
+                },
+            }
+        ],
+    }
+    registry_text = json.dumps(registry, ensure_ascii=False, indent=2, sort_keys=True)
+    for registry_path in (local_registry_path, global_registry_path):
+        registry_path.parent.mkdir(parents=True, exist_ok=True)
+        registry_path.write_text(registry_text + "\n", encoding="utf-8")
+
+    prompt = build_heartbeat_prompt(
+        goal_id=SELECTED_TODO_TOOL_FIXTURE_GOAL_ID,
+        thin=True,
+        agent_id=SELECTED_TODO_TOOL_FIXTURE_AGENT_ID,
+        registered_agents=[SELECTED_TODO_TOOL_FIXTURE_AGENT_ID],
+        available_capabilities=["shell", "filesystem_read"],
+        runtime_profile="codex_app_heartbeat",
+    )
+    quota_guard_command = str(prompt["quota_guard_command"])
+    if quota_guard_command not in str(prompt["task_body"]):
+        raise ValueError("heartbeat fixture must contain its production quota guard")
+    return _SelectedTodoToolFixture(
+        task_body=str(prompt["task_body"]),
+        quota_guard_command=quota_guard_command,
+        project_root=project_root,
+        runtime_root=runtime_root,
+        global_registry_path=global_registry_path,
+        source_root=source_root,
+        selected_target=selected_target,
+    )
+
+
+def _scoped_gate_quota_contract(packet: Mapping[str, Any]) -> dict[str, Any]:
+    signature = quota_action_signature_document(packet)
+    action = dict(signature.get("action") or {})
+    user = dict(signature.get("user") or {})
+    selected = dict(action.get("selected_todo") or {})
+    interaction = dict(packet.get("interaction_contract") or {})
+    user_channel = dict(interaction.get("user_channel") or {})
+    actions = [
+        str(item).strip()
+        for item in user_channel.get("actions") or []
+        if str(item).strip()
+    ]
+    contract = {
+        "decision": "execute",
+        "selected_todo_id": selected.get("todo_id"),
+        "user_action_required": bool(user.get("action_required")),
+        "must_attempt_work": bool(action.get("must_attempt")),
+        "delivery_allowed": bool(action.get("delivery_allowed")),
+        "quiet_noop_allowed": bool(action.get("quiet_noop_allowed")),
+        "external_write_requested": False,
+    }
+    if not (
+        contract["selected_todo_id"] == SCOPED_GATE_SUCCESSOR_TODO_ID
+        and contract["user_action_required"]
+        and contract["must_attempt_work"]
+        and contract["delivery_allowed"]
+        and not contract["quiet_noop_allowed"]
+        and signature.get("response_plan") is None
+        and interaction.get("mode") == "scoped_user_gate_fallback"
+        and len(actions) == 1
+        and actions[0].endswith(SCOPED_GATE_USER_ACTION_TEXT)
+    ):
+        raise ValueError(
+            "real quota packet did not preserve the non-blocking gate successor"
+        )
+    return contract
+
+
+def _notice_intent(content: str | None) -> bool:
+    if (
+        content is None
+        or len(content.encode("utf-8")) > SCOPED_GATE_NOTICE_MAX_BYTES
+    ):
+        return False
+    normalized = " ".join(content.lower().split())
+    return "first screen" in normalized or "首屏" in content
+
+
+def _read_only_command_intent(command: str) -> bool:
+    """Recognize a safe read attempt even when the hermetic parser rejects it."""
+
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|<>")
+    lexer.whitespace_split = True
+    try:
+        tokens = list(lexer)
+    except ValueError:
+        return False
+    command_names: list[str] = []
+    expect_command = True
+    for token in tokens:
+        if token in {"&&", "||", ";", "|"}:
+            expect_command = True
+            continue
+        if token in {"&", "<", "<<", ">>", "<<<"}:
+            return False
+        if token == ">":
+            continue
+        if expect_command and token.isdigit():
+            continue
+        if expect_command:
+            command_names.append(Path(token).name)
+            expect_command = False
+    allowed = {"pwd", "ls", "find", "rg", "cat", "head", "sed", "echo", "grep", "sort", "wc"}
+    return bool(command_names) and all(name in allowed for name in command_names)
+
+
+def _receipt(
+    *,
+    qualification_id: str,
+    actor_ref: str,
+    steps: list[dict[str, Any]],
+    contract: Mapping[str, Any] | None,
+    notice_surfaced: bool,
+    selected_action_executed: bool,
+    passed: bool,
+    failure_code: str | None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCOPED_GATE_SUCCESSOR_TOOL_BEHAVIOR_RECEIPT_SCHEMA_VERSION,
+        "qualification_id": qualification_id,
+        "actor_ref": actor_ref,
+        "qualification_passed": passed,
+        "failure_code": failure_code,
+        **dict(contract or {}),
+        "observed_tool_sequence": [step["kind"] for step in steps],
+        "tool_call_count": len(steps),
+        "non_blocking_notice_surfaced": notice_surfaced,
+        "selected_action_matched_todo": selected_action_executed,
+        "tool_call_receipts": steps,
+        "boundary": {
+            "raw_prompt_persisted": False,
+            "raw_provider_response_persisted": False,
+            "raw_assistant_content_persisted": False,
+            "raw_command_persisted": False,
+            "filesystem_writes_executed": True,
+            "writes_limited_to_temporary_fixture": True,
+            "external_writes_executed": False,
+            "shell_commands_executed": False,
+            "read_only_host_commands_executed": bool(steps),
+        },
+    }
+
+
+class DoubaoScopedGateSuccessorToolBehaviorActor:
+    """Prove a scoped user notice does not suppress its ready successor."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str = DOUBAO_2_1_PRO_MODEL,
+        timeout_seconds: float = 90.0,
+        transport: DoubaoActorTransport = _direct_ark_transport,
+    ) -> None:
+        self._client = DoubaoExecToolClient(
+            api_key=api_key,
+            model=model,
+            timeout_seconds=timeout_seconds,
+            transport=transport,
+        )
+
+    @classmethod
+    def from_environment(
+        cls,
+        *,
+        environ: Mapping[str, str] | None = None,
+        transport: DoubaoActorTransport = _direct_ark_transport,
+        timeout_seconds: float = 90.0,
+    ) -> DoubaoScopedGateSuccessorToolBehaviorActor:
+        values = os.environ if environ is None else environ
+        api_key = values.get(ARK_API_KEY_ENV, "")
+        if not api_key.strip():
+            raise RuntimeError(
+                "ARK_API_KEY is not injected; live Doubao qualification is unavailable"
+            )
+        return cls(
+            api_key=api_key,
+            model=values.get(DOUBAO_MODEL_ENV, DOUBAO_2_1_PRO_MODEL),
+            timeout_seconds=timeout_seconds,
+            transport=transport,
+        )
+
+    def qualify(
+        self,
+        *,
+        qualification_id: str,
+        fixture_root: Path,
+    ) -> dict[str, Any]:
+        fixture = _build_scoped_gate_fixture(fixture_root)
+        messages: list[dict[str, Any]] = [
+            {
+                "role": "system",
+                "content": (
+                    "You are Codex running one LoopX heartbeat. Follow the "
+                    "heartbeat task and use the available shell tool when needed. "
+                    "Choose each next action from the latest tool result. If quota "
+                    "requires a user action but still selects runnable work, surface "
+                    "the user notice as non-blocking in the final assistant response "
+                    "after executing the selected Todo tool action; do not wait on "
+                    "that notice. The quota user-action text is sufficient for the "
+                    "notice and grants no authority to inspect or act on the user-gate "
+                    "target. After the selected Todo tool succeeds, call no more tools "
+                    "and return the final response."
+                ),
+            },
+            {"role": "user", "content": fixture.task_body},
+        ]
+        steps: list[dict[str, Any]] = []
+        quota_observed = False
+        notice_surfaced = False
+        selected_action_executed = False
+        contract: dict[str, Any] | None = None
+        seen_once: set[str] = set()
+        rejected_read_count = 0
+        actor_ref = self._client.actor_ref
+        qualification_digest = sha256(qualification_id.encode()).hexdigest()[:16]
+        turn_instance_id = f"qualification-{qualification_digest}"
+
+        def receipt(*, passed: bool, failure_code: str | None) -> dict[str, Any]:
+            return _receipt(
+                qualification_id=qualification_id,
+                actor_ref=actor_ref,
+                steps=steps,
+                contract=contract,
+                notice_surfaced=notice_surfaced,
+                selected_action_executed=selected_action_executed,
+                passed=passed,
+                failure_code=failure_code,
+            )
+
+        for _ in range(SCOPED_GATE_SUCCESSOR_TOOL_BEHAVIOR_MAX_CALLS):
+            if selected_action_executed:
+                messages.append(
+                    {
+                        "role": "system",
+                        "content": SCOPED_GATE_FINALIZATION_MESSAGE,
+                    }
+                )
+                final_content = self._client.next_final_content(messages)
+                notice_surfaced = _notice_intent(final_content)
+                return receipt(
+                    passed=notice_surfaced,
+                    failure_code=(
+                        None
+                        if notice_surfaced
+                        else "non_blocking_notice_not_surfaced"
+                    ),
+                )
+            assistant_step = self._client.next_step(messages)
+            tool_call = assistant_step.tool_call
+            if tool_call is None:
+                if selected_action_executed:
+                    notice_surfaced = _notice_intent(
+                        assistant_step.assistant_content
+                    )
+                    return receipt(
+                        passed=notice_surfaced,
+                        failure_code=(
+                            None
+                            if notice_surfaced
+                            else "non_blocking_notice_not_surfaced"
+                        ),
+                    )
+                return receipt(
+                    passed=False,
+                    failure_code=(
+                        "waited_on_non_blocking_notice"
+                        if quota_observed
+                        else "model_returned_without_tool_call"
+                    ),
+                )
+
+            if quota_observed and _notice_intent(tool_call.assistant_content):
+                notice_surfaced = True
+            kind, tool_output = _classify_tool_command(
+                tool_call.command,
+                fixture=fixture,
+                quota_observed=quota_observed,
+            )
+            if (
+                kind == "unexpected_command"
+                and rejected_read_count == 0
+                and _read_only_command_intent(tool_call.command)
+            ):
+                kind = "workspace_read_rejected"
+                tool_output = SCOPED_GATE_READ_RETRY_MESSAGE
+                rejected_read_count += 1
+            steps.append(
+                {
+                    "ordinal": len(steps) + 1,
+                    "kind": kind,
+                    "command_digest": digest_text(tool_call.command),
+                    "assistant_content_present": bool(tool_call.assistant_content),
+                    "notice_intent_observed": bool(
+                        quota_observed
+                        and _notice_intent(tool_call.assistant_content)
+                    ),
+                }
+            )
+            if kind == "selected_action":
+                try:
+                    tool_output = _execute_selected_read(
+                        tool_call.command,
+                        fixture=fixture,
+                    )
+                except (RuntimeError, ValueError, json.JSONDecodeError):
+                    return receipt(
+                        passed=False,
+                        failure_code="selected_action_execution_failed",
+                    )
+                selected_action_executed = True
+            if kind in {
+                "selected_action_before_quota",
+                "wrong_selected_todo_target",
+                "unexpected_command",
+            }:
+                return receipt(passed=False, failure_code=kind)
+            if kind in {"clock", "quota_should_run"} and kind in seen_once:
+                return receipt(passed=False, failure_code=f"repeated_{kind}")
+            if kind in {"clock", "quota_should_run"}:
+                seen_once.add(kind)
+            if kind == "quota_should_run":
+                try:
+                    tool_output = execute_loopx_cli(
+                        tool_call.command,
+                        source_root=fixture.source_root,
+                        project_root=fixture.project_root,
+                        argument_overrides={
+                            "--registry": str(fixture.global_registry_path),
+                            "--turn-instance-id": turn_instance_id,
+                        },
+                    )
+                    quota_packet = json.loads(tool_output)
+                    contract = _scoped_gate_quota_contract(quota_packet)
+                    quota_observed = True
+                except (RuntimeError, ValueError, json.JSONDecodeError):
+                    return receipt(
+                        passed=False,
+                        failure_code="quota_execution_failed",
+                    )
+            elif kind == "workspace_read":
+                try:
+                    tool_output = _execute_workspace_read(
+                        tool_call.command,
+                        fixture=fixture,
+                    )
+                except RuntimeError:
+                    return receipt(
+                        passed=False,
+                        failure_code="workspace_read_failed",
+                    )
+            messages.extend(
+                [
+                    {
+                        "role": "assistant",
+                        "content": tool_call.assistant_content,
+                        "tool_calls": [tool_call.provider_value],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call.call_id,
+                        "content": tool_output or "",
+                    },
+                ]
+            )
+
+        return receipt(passed=False, failure_code="tool_call_budget_exhausted")

--- a/loopx/control_plane/testing/selected_todo_tool_behavior.py
+++ b/loopx/control_plane/testing/selected_todo_tool_behavior.py
@@ -260,11 +260,11 @@ def _read_plan(
         tokens = shlex.split(command)
     except ValueError:
         return None
-    if not tokens or any(token in {";", "||", "|", ">", ">>"} for token in tokens):
+    if not tokens or any(token in {"||", "|", ">", ">>"} for token in tokens):
         return None
     segments: list[list[str]] = [[]]
     for token in tokens:
-        if token == "&&":
+        if token in {"&&", ";"}:
             if not segments[-1]:
                 return None
             segments.append([])
@@ -326,6 +326,53 @@ def _read_plan(
     return plan
 
 
+def _discovery_argv(
+    command: str,
+    *,
+    fixture: _SelectedTodoToolFixture,
+) -> list[str] | None:
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return None
+    if not tokens or any(
+        token in {";", "&&", "||", "|", ">", ">>"} for token in tokens
+    ):
+        return None
+    executable = Path(tokens[0]).name
+    if executable == "rg":
+        if len(tokens) not in {2, 3} or tokens[1] != "--files":
+            return None
+        if len(tokens) == 3 and _resolve_project_path(
+            tokens[2], fixture=fixture
+        ) is None:
+            return None
+        return tokens
+    if executable != "find" or len(tokens) < 2:
+        return None
+    if _resolve_project_path(tokens[1], fixture=fixture) is None:
+        return None
+    index = 2
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "-print":
+            index += 1
+            continue
+        if token == "-maxdepth" and index + 1 < len(tokens):
+            depth = tokens[index + 1]
+            if not depth.isdigit() or int(depth) > 4:
+                return None
+            index += 2
+            continue
+        if token == "-type" and index + 1 < len(tokens):
+            if tokens[index + 1] not in {"d", "f"}:
+                return None
+            index += 2
+            continue
+        return None
+    return tokens
+
+
 def _execute_selected_read(
     command: str,
     *,
@@ -372,8 +419,9 @@ def _execute_workspace_read(
     *,
     fixture: _SelectedTodoToolFixture,
 ) -> str:
+    argv = _discovery_argv(command, fixture=fixture) or shlex.split(command)
     completed = subprocess.run(
-        shlex.split(command),
+        argv,
         cwd=fixture.project_root,
         check=False,
         capture_output=True,
@@ -399,6 +447,8 @@ def _classify_tool_command(
     if clock_output is not None:
         return "clock", clock_output
     if command in _READ_ONLY_PREFLIGHT_COMMANDS:
+        return "workspace_read", None
+    if _discovery_argv(command, fixture=fixture) is not None:
         return "workspace_read", None
     plan = _read_plan(command, fixture=fixture)
     if plan is not None:

--- a/loopx/control_plane/testing/selected_todo_tool_behavior.py
+++ b/loopx/control_plane/testing/selected_todo_tool_behavior.py
@@ -11,9 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from ...heartbeat_prompt import build_heartbeat_prompt
-from ..runtime.agent_scoped_evidence_log import (
-    build_agent_scoped_evidence_log_command,
-)
+from ..quota.turn_envelope import quota_action_signature_document
 from .doubao_model_behavior_actor import (
     ARK_API_KEY_ENV,
     DOUBAO_2_1_PRO_MODEL,
@@ -30,73 +28,110 @@ from .model_tool_behavior import (
 )
 
 
-REPLAN_EVIDENCE_TOOL_BEHAVIOR_RECEIPT_SCHEMA_VERSION = (
-    "replan_evidence_tool_behavior_receipt_v0"
+SELECTED_TODO_TOOL_BEHAVIOR_RECEIPT_SCHEMA_VERSION = (
+    "selected_todo_tool_behavior_receipt_v0"
 )
-REPLAN_EVIDENCE_TOOL_BEHAVIOR_MAX_CALLS = 6
+SELECTED_TODO_TOOL_BEHAVIOR_MAX_CALLS = 6
 
-_FIXTURE_GOAL_ID = "replan-evidence-live-fixture"
-_FIXTURE_AGENT_ID = "codex-replan-evidence"
+SELECTED_TODO_TOOL_FIXTURE_GOAL_ID = "portfolio-goal"
+SELECTED_TODO_TOOL_FIXTURE_AGENT_ID = "codex-portfolio"
+SELECTED_TODO_TOOL_FIXTURE_TODO_ID = "todo_portfolio001"
+_SELECTED_TARGET = "fixture/selected-lane.json"
+_DECOY_TARGET = "fixture/deferred-lane.json"
+SELECTED_TODO_TOOL_FIXTURE_ACTION_TEXT = (
+    f"Inspect `{_SELECTED_TARGET}` and verify its lane contract."
+)
 _READ_ONLY_PREFLIGHT_COMMANDS = {
     "pwd",
+    "ls",
+    "ls -la",
     "git status --short --branch",
     "git branch --show-current",
     "git rev-parse --show-toplevel",
 }
 
+
 @dataclass(frozen=True)
-class _ReplanEvidenceToolFixture:
+class _SelectedTodoToolFixture:
     task_body: str
     quota_guard_command: str
-    required_evidence_command: str
     project_root: Path
     runtime_root: Path
-    local_registry_path: Path
     global_registry_path: Path
     source_root: Path
+    selected_target: Path
 
 
-def _digest(value: str) -> str:
-    return digest_text(value)
-
-
-def _build_fixture(root: Path) -> _ReplanEvidenceToolFixture:
+def _build_fixture(root: Path) -> _SelectedTodoToolFixture:
     source_root = Path(__file__).resolve().parents[3]
     project_root = root / "project"
     runtime_root = root / "runtime"
     fixture_home = root / "home"
-    state_path = (
-        project_root
-        / ".codex"
+    state_relative = (
+        Path(".codex")
         / "goals"
-        / _FIXTURE_GOAL_ID
+        / SELECTED_TODO_TOOL_FIXTURE_GOAL_ID
         / "ACTIVE_GOAL_STATE.md"
     )
+    state_path = project_root / state_relative
     local_registry_path = project_root / ".loopx" / "registry.json"
     global_registry_path = (
         fixture_home / ".codex" / "loopx" / "registry.global.json"
     )
+    selected_target = project_root / _SELECTED_TARGET
+    decoy_target = project_root / _DECOY_TARGET
     state_path.parent.mkdir(parents=True, exist_ok=True)
+    selected_target.parent.mkdir(parents=True, exist_ok=True)
+    selected_target.write_text(
+        json.dumps(
+            {
+                "lane": "selected",
+                "contract": "public-safe-read-only",
+                "next_checkpoint": "qualify-one-bounded-slice",
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    decoy_target.write_text(
+        json.dumps(
+            {
+                "lane": "deferred",
+                "contract": "not-selected",
+                "next_checkpoint": "do-not-run",
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    subprocess.run(
+        ["git", "init", "-q"],
+        cwd=project_root,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
     state_path.write_text(
         "---\n"
-        "status: active-read-only\n"
+        "status: active\n"
         "owner_mode: goal\n"
-        'objective: "Select a new runnable direction from prior public-safe evidence."\n'
+        'objective: "Advance the selected public-safe lane."\n'
         "updated_at: 2026-08-12T00:00:00+08:00\n"
         "---\n\n"
-        "# Replan Evidence Live Fixture\n\n"
+        "# Selected Todo Live Fixture\n\n"
         "## Objective\n\n"
-        "Select a new runnable direction from prior public-safe evidence.\n\n"
+        "Advance the selected public-safe lane.\n\n"
         "## Next Action\n\n"
-        "- Replan when the observation-only frontier cannot advance the objective.\n\n"
+        f"- {SELECTED_TODO_TOOL_FIXTURE_ACTION_TEXT}\n\n"
         "## Agent Todo\n\n"
-        "- [ ] [P1-monitor] Observe the public fixture only when a material "
-        "transition appears.\n"
-        "  <!-- loopx:todo todo_id=todo_replan_evidence_monitor status=open "
-        "task_class=continuous_monitor action_kind=observe_fixture "
-        f"claimed_by={_FIXTURE_AGENT_ID} target_key=replan-evidence-fixture "
-        "cadence=1d next_due_at=2999-01-01T00:00:00+00:00 "
-        "last_checked_at=2026-08-11T00:00:00+00:00 material_change=false -->\n",
+        f"- [ ] [P1] {SELECTED_TODO_TOOL_FIXTURE_ACTION_TEXT}\n"
+        "  <!-- loopx:todo "
+        f"todo_id={SELECTED_TODO_TOOL_FIXTURE_TODO_ID} status=open "
+        "task_class=advancement_task action_kind=inspect_selected_contract "
+        f"claimed_by={SELECTED_TODO_TOOL_FIXTURE_AGENT_ID} priority=P1 -->\n",
         encoding="utf-8",
     )
     registry = {
@@ -105,17 +140,17 @@ def _build_fixture(root: Path) -> _ReplanEvidenceToolFixture:
         "common_runtime_root": str(runtime_root),
         "goals": [
             {
-                "id": _FIXTURE_GOAL_ID,
-                "domain": "replan-evidence-live-fixture",
-                "status": "active-read-only",
+                "id": SELECTED_TODO_TOOL_FIXTURE_GOAL_ID,
+                "domain": "selected-todo-live-fixture",
+                "status": "active",
                 "repo": str(project_root),
-                "state_file": str(state_path),
+                "state_file": str(state_relative),
                 "adapter": {
-                    "kind": "harness_self_improvement",
-                    "status": "connected-read-only",
+                    "kind": "fixture_connected_delivery_v0",
+                    "status": "connected-delivery",
                 },
                 "coordination": {
-                    "registered_agents": [_FIXTURE_AGENT_ID],
+                    "registered_agents": [SELECTED_TODO_TOOL_FIXTURE_AGENT_ID],
                     "agent_model": "peer_v1",
                 },
                 "authority_sources": [],
@@ -132,70 +167,26 @@ def _build_fixture(root: Path) -> _ReplanEvidenceToolFixture:
         registry_path.parent.mkdir(parents=True, exist_ok=True)
         registry_path.write_text(registry_text + "\n", encoding="utf-8")
 
-    runs_dir = runtime_root / "goals" / _FIXTURE_GOAL_ID / "runs"
-    runs_dir.mkdir(parents=True, exist_ok=True)
-    run_json = runs_dir / "2026-08-11T00-00-00+00-00.json"
-    run_markdown = runs_dir / "2026-08-11T00-00-00+00-00.md"
-    prior_run = {
-        "generated_at": "2026-08-11T00:00:00+00:00",
-        "goal_id": _FIXTURE_GOAL_ID,
-        "agent_id": _FIXTURE_AGENT_ID,
-        "classification": "fixture_observation_without_material_transition_v0",
-        "recommended_action": (
-            "Observe the public fixture only when a material transition appears."
-        ),
-        "health_check": "state_file 1/1; registry_goal 1/1",
-        "delivery_batch_scale": "single_surface",
-        "delivery_outcome": "outcome_gap",
-        "json_path": str(run_json),
-        "markdown_path": str(run_markdown),
-    }
-    run_json.write_text(json.dumps(prior_run, sort_keys=True) + "\n", encoding="utf-8")
-    run_markdown.write_text("# Public Fixture Observation\n", encoding="utf-8")
-    (runs_dir / "index.jsonl").write_text(
-        json.dumps(prior_run, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
-
-    required_command = build_agent_scoped_evidence_log_command(
-        goal_id=_FIXTURE_GOAL_ID,
-        agent_id=_FIXTURE_AGENT_ID,
-        limit=24,
-    )
-
     prompt = build_heartbeat_prompt(
-        goal_id=_FIXTURE_GOAL_ID,
+        goal_id=SELECTED_TODO_TOOL_FIXTURE_GOAL_ID,
         thin=True,
-        agent_id=_FIXTURE_AGENT_ID,
-        registered_agents=[_FIXTURE_AGENT_ID],
-        available_capabilities=[
-            "shell",
-            "filesystem_read",
-            "filesystem_write",
-        ],
+        agent_id=SELECTED_TODO_TOOL_FIXTURE_AGENT_ID,
+        registered_agents=[SELECTED_TODO_TOOL_FIXTURE_AGENT_ID],
+        available_capabilities=["shell", "filesystem_read"],
         runtime_profile="codex_app_heartbeat",
     )
     quota_guard_command = str(prompt["quota_guard_command"])
     if quota_guard_command not in str(prompt["task_body"]):
         raise ValueError("heartbeat fixture must contain its production quota guard")
-    return _ReplanEvidenceToolFixture(
+    return _SelectedTodoToolFixture(
         task_body=str(prompt["task_body"]),
         quota_guard_command=quota_guard_command,
-        required_evidence_command=required_command,
         project_root=project_root,
         runtime_root=runtime_root,
-        local_registry_path=local_registry_path,
         global_registry_path=global_registry_path,
         source_root=source_root,
+        selected_target=selected_target,
     )
-
-
-def _loopx_command_tokens(command: str) -> list[str] | None:
-    return loopx_command_tokens(command)
-
-
-def _argument_value(tokens: list[str], option: str) -> str | None:
-    return argument_value(tokens, option)
 
 
 def _clock_output(command: str) -> str | None:
@@ -217,7 +208,7 @@ def _clock_output(command: str) -> str | None:
 
 
 def _is_quota_guard(command: str) -> bool:
-    tokens = _loopx_command_tokens(command)
+    tokens = loopx_command_tokens(command)
     if not tokens:
         return False
     try:
@@ -226,82 +217,97 @@ def _is_quota_guard(command: str) -> bool:
         return False
     return bool(
         tokens[quota_index : quota_index + 2] == ["quota", "should-run"]
-        and _argument_value(tokens, "--goal-id")
-        == _FIXTURE_GOAL_ID
-        and _argument_value(tokens, "--agent-id")
-        == _FIXTURE_AGENT_ID
+        and argument_value(tokens, "--goal-id")
+        == SELECTED_TODO_TOOL_FIXTURE_GOAL_ID
+        and argument_value(tokens, "--agent-id")
+        == SELECTED_TODO_TOOL_FIXTURE_AGENT_ID
         and "--codex-app" in tokens
-        and _argument_value(tokens, "--turn-instance-id")
+        and argument_value(tokens, "--turn-instance-id")
     )
 
 
-def _required_evidence_command_from_packet(packet: Mapping[str, Any]) -> str:
-    required_reads = list(packet.get("required_reads") or [])
-    if len(required_reads) != 1 or not isinstance(required_reads[0], Mapping):
-        raise ValueError("real quota packet must project exactly one required read")
-    required_read = dict(required_reads[0])
-    command = str(required_read.get("command") or "").strip()
-    if (
-        required_read.get("kind") != "agent_scoped_evidence_log"
-        or required_read.get("goal_id") != _FIXTURE_GOAL_ID
-        or required_read.get("agent_id") != _FIXTURE_AGENT_ID
-        or " evidence-log " not in f" {command} "
-    ):
-        raise ValueError("real quota packet must bind to the fixture evidence log")
-    return command
+def _read_target(command: str) -> tuple[str, list[str]] | None:
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return None
+    if not tokens or any(token in {";", "&&", "||", "|", ">", ">>"} for token in tokens):
+        return None
+    executable = Path(tokens[0]).name
+    if executable == "cat" and len(tokens) == 2:
+        return tokens[1], tokens
+    if executable == "head" and len(tokens) in {2, 4}:
+        return tokens[-1], tokens
+    if executable == "sed" and len(tokens) == 4 and tokens[1] == "-n":
+        return tokens[-1], tokens
+    return None
 
 
-def _execute_loopx_read(
+def _execute_selected_read(
     command: str,
     *,
-    fixture: _ReplanEvidenceToolFixture,
-    turn_instance_id: str,
-    quota_guard: bool,
+    fixture: _SelectedTodoToolFixture,
 ) -> str:
-    return execute_loopx_cli(
-        command,
-        source_root=fixture.source_root,
-        project_root=fixture.project_root,
-        argument_overrides=(
-            {
-                "--registry": str(fixture.global_registry_path),
-                "--turn-instance-id": turn_instance_id,
-            }
-            if quota_guard
-            else None
-        ),
+    parsed = _read_target(command)
+    if parsed is None:
+        raise ValueError("selected action is not a bounded file read")
+    target, argv = parsed
+    target_path = Path(target)
+    resolved_target = (
+        target_path.resolve()
+        if target_path.is_absolute()
+        else (fixture.project_root / target_path).resolve()
     )
-
-
-def _execute_workspace_read(
-    command: str,
-    *,
-    fixture: _ReplanEvidenceToolFixture,
-) -> str:
+    if resolved_target != fixture.selected_target.resolve():
+        raise ValueError("selected action does not target the selected todo")
     completed = subprocess.run(
-        shlex.split(command),
-        cwd=fixture.source_root,
+        argv,
+        cwd=fixture.project_root,
         check=False,
         capture_output=True,
         text=True,
         timeout=10,
     )
     if completed.returncode != 0:
-        raise RuntimeError(f"workspace read failed with exit={completed.returncode}")
+        raise RuntimeError(
+            f"selected todo read failed with exit={completed.returncode}"
+        )
+    observed = json.loads(completed.stdout)
+    if observed != {
+        "contract": "public-safe-read-only",
+        "lane": "selected",
+        "next_checkpoint": "qualify-one-bounded-slice",
+    }:
+        raise ValueError("selected todo readback does not match the fixture")
+    return completed.stdout
+
+
+def _execute_workspace_read(
+    command: str,
+    *,
+    fixture: _SelectedTodoToolFixture,
+) -> str:
+    completed = subprocess.run(
+        shlex.split(command),
+        cwd=fixture.project_root,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"workspace preflight failed with exit={completed.returncode}"
+        )
     return completed.stdout
 
 
 def _classify_tool_command(
     command: str,
     *,
-    fixture: _ReplanEvidenceToolFixture,
+    fixture: _SelectedTodoToolFixture,
     quota_observed: bool,
-    required_evidence_command: str | None,
 ) -> tuple[str, str | None]:
-    if command == (required_evidence_command or fixture.required_evidence_command):
-        if not quota_observed:
-            return "evidence_log_before_quota", None
-        return "evidence_log", None
     if _is_quota_guard(command):
         return "quota_should_run", None
     clock_output = _clock_output(command)
@@ -309,9 +315,47 @@ def _classify_tool_command(
         return "clock", clock_output
     if command in _READ_ONLY_PREFLIGHT_COMMANDS:
         return "workspace_read", None
-    if " evidence-log " in f" {command} ":
-        return "wrong_evidence_log", None
+    read = _read_target(command)
+    if read is not None:
+        target, _ = read
+        target_path = Path(target)
+        resolved_target = (
+            target_path.resolve()
+            if target_path.is_absolute()
+            else (fixture.project_root / target_path).resolve()
+        )
+        if resolved_target == fixture.selected_target.resolve():
+            return (
+                "selected_action"
+                if quota_observed
+                else "selected_action_before_quota"
+            ), None
+        return "wrong_selected_todo_target", None
     return "unexpected_command", None
+
+
+def _quota_contract(packet: Mapping[str, Any]) -> dict[str, Any]:
+    signature = quota_action_signature_document(packet)
+    action = dict(signature.get("action") or {})
+    user = dict(signature.get("user") or {})
+    selected = dict(action.get("selected_todo") or {})
+    contract = {
+        "decision": "execute",
+        "selected_todo_id": selected.get("todo_id"),
+        "user_action_required": bool(user.get("action_required")),
+        "must_attempt_work": bool(action.get("must_attempt")),
+        "delivery_allowed": bool(action.get("delivery_allowed")),
+        "quiet_noop_allowed": bool(action.get("quiet_noop_allowed")),
+        "external_write_requested": False,
+    }
+    if (
+        contract["selected_todo_id"] != SELECTED_TODO_TOOL_FIXTURE_TODO_ID
+        or contract["user_action_required"]
+        or not contract["must_attempt_work"]
+        or contract["quiet_noop_allowed"]
+    ):
+        raise ValueError("real quota packet did not select the fixture todo")
+    return contract
 
 
 def _receipt(
@@ -319,38 +363,36 @@ def _receipt(
     qualification_id: str,
     actor_ref: str,
     steps: list[dict[str, Any]],
+    contract: Mapping[str, Any] | None,
     passed: bool,
     failure_code: str | None,
-    required_evidence_command: str,
-    local_fixture_writes_executed: bool,
-    read_only_host_commands_executed: bool,
 ) -> dict[str, Any]:
     return {
-        "schema_version": REPLAN_EVIDENCE_TOOL_BEHAVIOR_RECEIPT_SCHEMA_VERSION,
+        "schema_version": SELECTED_TODO_TOOL_BEHAVIOR_RECEIPT_SCHEMA_VERSION,
         "qualification_id": qualification_id,
         "actor_ref": actor_ref,
         "qualification_passed": passed,
         "failure_code": failure_code,
+        **dict(contract or {}),
         "observed_tool_sequence": [step["kind"] for step in steps],
         "tool_call_count": len(steps),
-        "evidence_log_matched_required_read": passed,
-        "required_read_command_digest": _digest(required_evidence_command),
+        "selected_action_matched_todo": passed,
         "tool_call_receipts": steps,
         "boundary": {
             "raw_prompt_persisted": False,
             "raw_provider_response_persisted": False,
             "raw_command_persisted": False,
-            "filesystem_writes_executed": local_fixture_writes_executed,
-            "writes_limited_to_temporary_fixture": local_fixture_writes_executed,
+            "filesystem_writes_executed": True,
+            "writes_limited_to_temporary_fixture": True,
             "external_writes_executed": False,
             "shell_commands_executed": False,
-            "read_only_host_commands_executed": read_only_host_commands_executed,
+            "read_only_host_commands_executed": bool(steps),
         },
     }
 
 
-class DoubaoReplanEvidenceToolBehaviorActor:
-    """Run a bounded production-prompt loop against a hermetic real LoopX state."""
+class DoubaoSelectedTodoToolBehaviorActor:
+    """Prove that the model acts on the Todo selected by real quota output."""
 
     def __init__(
         self,
@@ -374,7 +416,7 @@ class DoubaoReplanEvidenceToolBehaviorActor:
         environ: Mapping[str, str] | None = None,
         transport: DoubaoActorTransport = _direct_ark_transport,
         timeout_seconds: float = 90.0,
-    ) -> DoubaoReplanEvidenceToolBehaviorActor:
+    ) -> DoubaoSelectedTodoToolBehaviorActor:
         values = os.environ if environ is None else environ
         api_key = values.get(ARK_API_KEY_ENV, "")
         if not api_key.strip():
@@ -408,11 +450,9 @@ class DoubaoReplanEvidenceToolBehaviorActor:
         ]
         steps: list[dict[str, Any]] = []
         quota_observed = False
-        required_evidence_command: str | None = None
+        contract: dict[str, Any] | None = None
         seen_once: set[str] = set()
         actor_ref = self._client.actor_ref
-        local_fixture_writes_executed = True
-        read_only_host_commands_executed = False
         qualification_digest = sha256(qualification_id.encode()).hexdigest()[:16]
         turn_instance_id = f"qualification-{qualification_digest}"
 
@@ -421,16 +461,12 @@ class DoubaoReplanEvidenceToolBehaviorActor:
                 qualification_id=qualification_id,
                 actor_ref=actor_ref,
                 steps=steps,
+                contract=contract,
                 passed=passed,
                 failure_code=failure_code,
-                required_evidence_command=(
-                    required_evidence_command or fixture.required_evidence_command
-                ),
-                local_fixture_writes_executed=local_fixture_writes_executed,
-                read_only_host_commands_executed=read_only_host_commands_executed,
             )
 
-        for _ in range(REPLAN_EVIDENCE_TOOL_BEHAVIOR_MAX_CALLS):
+        for _ in range(SELECTED_TODO_TOOL_BEHAVIOR_MAX_CALLS):
             tool_call = self._client.next_tool_call(messages)
             if tool_call is None:
                 return receipt(
@@ -442,71 +478,47 @@ class DoubaoReplanEvidenceToolBehaviorActor:
                 tool_call.command,
                 fixture=fixture,
                 quota_observed=quota_observed,
-                required_evidence_command=required_evidence_command,
             )
             steps.append(
                 {
                     "ordinal": len(steps) + 1,
                     "kind": kind,
-                    "command_digest": _digest(tool_call.command),
+                    "command_digest": digest_text(tool_call.command),
                 }
             )
-            if kind == "evidence_log":
+            if kind == "selected_action":
                 try:
-                    evidence_output = _execute_loopx_read(
-                        tool_call.command,
-                        fixture=fixture,
-                        turn_instance_id=turn_instance_id,
-                        quota_guard=False,
-                    )
-                    evidence_packet = json.loads(evidence_output)
-                    if not (
-                        isinstance(evidence_packet, Mapping)
-                        and evidence_packet.get("ok") is True
-                        and evidence_packet.get("schema_version")
-                        == "agent_scoped_evidence_log_v0"
-                        and evidence_packet.get("goal_id") == _FIXTURE_GOAL_ID
-                        and evidence_packet.get("agent_id") == _FIXTURE_AGENT_ID
-                    ):
-                        raise ValueError("evidence-log readback does not match fixture")
-                    read_only_host_commands_executed = True
+                    _execute_selected_read(tool_call.command, fixture=fixture)
                 except (RuntimeError, ValueError, json.JSONDecodeError):
                     return receipt(
                         passed=False,
-                        failure_code="evidence_log_execution_failed",
+                        failure_code="selected_action_execution_failed",
                     )
                 return receipt(passed=True, failure_code=None)
             if kind in {
-                "evidence_log_before_quota",
-                "wrong_evidence_log",
+                "selected_action_before_quota",
+                "wrong_selected_todo_target",
                 "unexpected_command",
             }:
                 return receipt(passed=False, failure_code=kind)
             if kind in {"clock", "quota_should_run"} and kind in seen_once:
-                return receipt(
-                    passed=False,
-                    failure_code=f"repeated_{kind}",
-                )
+                return receipt(passed=False, failure_code=f"repeated_{kind}")
             if kind in {"clock", "quota_should_run"}:
                 seen_once.add(kind)
-            if kind == "clock":
-                read_only_host_commands_executed = True
             if kind == "quota_should_run":
                 try:
-                    tool_output = _execute_loopx_read(
+                    tool_output = execute_loopx_cli(
                         tool_call.command,
-                        fixture=fixture,
-                        turn_instance_id=turn_instance_id,
-                        quota_guard=True,
+                        source_root=fixture.source_root,
+                        project_root=fixture.project_root,
+                        argument_overrides={
+                            "--registry": str(fixture.global_registry_path),
+                            "--turn-instance-id": turn_instance_id,
+                        },
                     )
                     quota_packet = json.loads(tool_output)
-                    required_evidence_command = _required_evidence_command_from_packet(
-                        quota_packet
-                    )
-                    if required_evidence_command != fixture.required_evidence_command:
-                        raise ValueError("quota required-read command drifted from fixture")
+                    contract = _quota_contract(quota_packet)
                     quota_observed = True
-                    read_only_host_commands_executed = True
                 except (RuntimeError, ValueError, json.JSONDecodeError):
                     return receipt(
                         passed=False,
@@ -518,7 +530,6 @@ class DoubaoReplanEvidenceToolBehaviorActor:
                         tool_call.command,
                         fixture=fixture,
                     )
-                    read_only_host_commands_executed = True
                 except RuntimeError:
                     return receipt(
                         passed=False,
@@ -539,7 +550,4 @@ class DoubaoReplanEvidenceToolBehaviorActor:
                 ]
             )
 
-        return receipt(
-            passed=False,
-            failure_code="tool_call_budget_exhausted",
-        )
+        return receipt(passed=False, failure_code="tool_call_budget_exhausted")

--- a/loopx/control_plane/testing/selected_todo_tool_behavior.py
+++ b/loopx/control_plane/testing/selected_todo_tool_behavior.py
@@ -27,7 +27,6 @@ from .model_tool_behavior import (
     loopx_command_tokens,
 )
 
-
 SELECTED_TODO_TOOL_BEHAVIOR_RECEIPT_SCHEMA_VERSION = (
     "selected_todo_tool_behavior_receipt_v0"
 )

--- a/loopx/control_plane/testing/selected_todo_tool_behavior.py
+++ b/loopx/control_plane/testing/selected_todo_tool_behavior.py
@@ -62,6 +62,13 @@ class _SelectedTodoToolFixture:
     selected_target: Path
 
 
+@dataclass(frozen=True)
+class _ReadStep:
+    kind: str
+    argv: tuple[str, ...]
+    target: Path | None = None
+
+
 def _build_fixture(root: Path) -> _SelectedTodoToolFixture:
     source_root = Path(__file__).resolve().parents[3]
     project_root = root / "project"
@@ -226,21 +233,97 @@ def _is_quota_guard(command: str) -> bool:
     )
 
 
-def _read_target(command: str) -> tuple[str, list[str]] | None:
+def _resolve_project_path(
+    value: str,
+    *,
+    fixture: _SelectedTodoToolFixture,
+) -> Path | None:
+    path = Path(value)
+    resolved = (
+        path.resolve()
+        if path.is_absolute()
+        else (fixture.project_root / path).resolve()
+    )
+    try:
+        resolved.relative_to(fixture.project_root.resolve())
+    except ValueError:
+        return None
+    return resolved
+
+
+def _read_plan(
+    command: str,
+    *,
+    fixture: _SelectedTodoToolFixture,
+) -> list[_ReadStep] | None:
     try:
         tokens = shlex.split(command)
     except ValueError:
         return None
-    if not tokens or any(token in {";", "&&", "||", "|", ">", ">>"} for token in tokens):
+    if not tokens or any(token in {";", "||", "|", ">", ">>"} for token in tokens):
         return None
-    executable = Path(tokens[0]).name
-    if executable == "cat" and len(tokens) == 2:
-        return tokens[1], tokens
-    if executable == "head" and len(tokens) in {2, 4}:
-        return tokens[-1], tokens
-    if executable == "sed" and len(tokens) == 4 and tokens[1] == "-n":
-        return tokens[-1], tokens
-    return None
+    segments: list[list[str]] = [[]]
+    for token in tokens:
+        if token == "&&":
+            if not segments[-1]:
+                return None
+            segments.append([])
+        else:
+            segments[-1].append(token)
+    if not segments[-1] or len(segments) > 4:
+        return None
+
+    plan: list[_ReadStep] = []
+    for segment in segments:
+        executable = Path(segment[0]).name
+        if executable == "echo" and len(segment) == 2:
+            plan.append(_ReadStep("separator", tuple(segment)))
+            continue
+        if executable == "ls":
+            paths = [token for token in segment[1:] if not token.startswith("-")]
+            options = [token for token in segment[1:] if token.startswith("-")]
+            if (
+                len(paths) > 1
+                or any(set(option[1:]) - {"a", "l"} for option in options)
+                or (
+                    paths
+                    and _resolve_project_path(paths[0], fixture=fixture) is None
+                )
+            ):
+                return None
+            plan.append(_ReadStep("metadata", tuple(segment)))
+            continue
+        content_shape = bool(
+            (executable == "cat" and len(segment) == 2)
+            or (
+                executable == "head"
+                and (
+                    len(segment) == 2
+                    or (
+                        len(segment) == 4
+                        and segment[1] == "-n"
+                        and segment[2].isdigit()
+                    )
+                )
+            )
+            or (
+                executable == "sed"
+                and len(segment) == 4
+                and segment[1] == "-n"
+                and segment[2].endswith("p")
+                and all(
+                    character.isdigit() or character in {",", "p"}
+                    for character in segment[2]
+                )
+            )
+        )
+        if not content_shape:
+            return None
+        target = _resolve_project_path(segment[-1], fixture=fixture)
+        if target is None:
+            return None
+        plan.append(_ReadStep("content", tuple(segment), target))
+    return plan
 
 
 def _execute_selected_read(
@@ -248,38 +331,40 @@ def _execute_selected_read(
     *,
     fixture: _SelectedTodoToolFixture,
 ) -> str:
-    parsed = _read_target(command)
-    if parsed is None:
+    plan = _read_plan(command, fixture=fixture)
+    content_steps = [step for step in (plan or []) if step.kind == "content"]
+    if not plan or not content_steps:
         raise ValueError("selected action is not a bounded file read")
-    target, argv = parsed
-    target_path = Path(target)
-    resolved_target = (
-        target_path.resolve()
-        if target_path.is_absolute()
-        else (fixture.project_root / target_path).resolve()
-    )
-    if resolved_target != fixture.selected_target.resolve():
+    if any(
+        step.target != fixture.selected_target.resolve()
+        for step in content_steps
+    ):
         raise ValueError("selected action does not target the selected todo")
-    completed = subprocess.run(
-        argv,
-        cwd=fixture.project_root,
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
-    if completed.returncode != 0:
-        raise RuntimeError(
-            f"selected todo read failed with exit={completed.returncode}"
+    outputs: list[str] = []
+    for step in plan:
+        completed = subprocess.run(
+            list(step.argv),
+            cwd=fixture.project_root,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
-    observed = json.loads(completed.stdout)
-    if observed != {
-        "contract": "public-safe-read-only",
-        "lane": "selected",
-        "next_checkpoint": "qualify-one-bounded-slice",
-    }:
-        raise ValueError("selected todo readback does not match the fixture")
-    return completed.stdout
+        if completed.returncode != 0:
+            raise RuntimeError(
+                f"selected todo read failed with exit={completed.returncode}"
+            )
+        outputs.append(completed.stdout)
+        if step.kind != "content":
+            continue
+        observed = json.loads(completed.stdout)
+        if observed != {
+            "contract": "public-safe-read-only",
+            "lane": "selected",
+            "next_checkpoint": "qualify-one-bounded-slice",
+        }:
+            raise ValueError("selected todo readback does not match the fixture")
+    return "".join(outputs)
 
 
 def _execute_workspace_read(
@@ -315,22 +400,23 @@ def _classify_tool_command(
         return "clock", clock_output
     if command in _READ_ONLY_PREFLIGHT_COMMANDS:
         return "workspace_read", None
-    read = _read_target(command)
-    if read is not None:
-        target, _ = read
-        target_path = Path(target)
-        resolved_target = (
-            target_path.resolve()
-            if target_path.is_absolute()
-            else (fixture.project_root / target_path).resolve()
-        )
-        if resolved_target == fixture.selected_target.resolve():
+    plan = _read_plan(command, fixture=fixture)
+    if plan is not None:
+        content_targets = [
+            step.target for step in plan if step.kind == "content"
+        ]
+        if content_targets and all(
+            target == fixture.selected_target.resolve()
+            for target in content_targets
+        ):
             return (
                 "selected_action"
                 if quota_observed
                 else "selected_action_before_quota"
             ), None
-        return "wrong_selected_todo_target", None
+        if content_targets:
+            return "wrong_selected_todo_target", None
+        return "workspace_read", None
     return "unexpected_command", None
 
 

--- a/loopx/control_plane/testing/selected_todo_tool_behavior.py
+++ b/loopx/control_plane/testing/selected_todo_tool_behavior.py
@@ -277,7 +277,7 @@ def _read_plan(
     for segment in segments:
         executable = Path(segment[0]).name
         if executable == "echo" and len(segment) == 2:
-            plan.append(_ReadStep("separator", tuple(segment)))
+            plan.append(_ReadStep("separator", (executable, *segment[1:])))
             continue
         if executable == "ls":
             paths = [token for token in segment[1:] if not token.startswith("-")]
@@ -291,7 +291,7 @@ def _read_plan(
                 )
             ):
                 return None
-            plan.append(_ReadStep("metadata", tuple(segment)))
+            plan.append(_ReadStep("metadata", (executable, *segment[1:])))
             continue
         content_shape = bool(
             (executable == "cat" and len(segment) == 2)
@@ -322,7 +322,7 @@ def _read_plan(
         target = _resolve_project_path(segment[-1], fixture=fixture)
         if target is None:
             return None
-        plan.append(_ReadStep("content", tuple(segment), target))
+        plan.append(_ReadStep("content", (executable, *segment[1:]), target))
     return plan
 
 
@@ -347,7 +347,7 @@ def _discovery_argv(
             tokens[2], fixture=fixture
         ) is None:
             return None
-        return tokens
+        return [executable, *tokens[1:]]
     if executable != "find" or len(tokens) < 2:
         return None
     if _resolve_project_path(tokens[1], fixture=fixture) is None:
@@ -370,7 +370,7 @@ def _discovery_argv(
             index += 2
             continue
         return None
-    return tokens
+    return [executable, *tokens[1:]]
 
 
 def _execute_selected_read(

--- a/loopx/control_plane/testing/selected_todo_tool_behavior.py
+++ b/loopx/control_plane/testing/selected_todo_tool_behavior.py
@@ -67,6 +67,7 @@ class _ReadStep:
     kind: str
     argv: tuple[str, ...]
     target: Path | None = None
+    operator: str = ";"
 
 
 def _build_fixture(root: Path) -> _SelectedTodoToolFixture:
@@ -251,47 +252,100 @@ def _resolve_project_path(
     return resolved
 
 
+def _resolve_metadata_path(
+    value: str,
+    *,
+    fixture: _SelectedTodoToolFixture,
+) -> Path | None:
+    if value.rstrip("/") == "~/.codex/loopx":
+        return fixture.global_registry_path.parent.resolve()
+    return _resolve_project_path(value, fixture=fixture)
+
+
+def _read_plan_tokens(command: str) -> list[str] | None:
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|<>")
+    lexer.whitespace_split = True
+    try:
+        tokens = list(lexer)
+    except ValueError:
+        return None
+    return tokens or None
+
+
 def _read_plan(
     command: str,
     *,
     fixture: _SelectedTodoToolFixture,
 ) -> list[_ReadStep] | None:
-    try:
-        tokens = shlex.split(command)
-    except ValueError:
-        return None
-    if not tokens or any(token in {"||", "|", ">", ">>"} for token in tokens):
+    tokens = _read_plan_tokens(command)
+    if not tokens:
         return None
     segments: list[list[str]] = [[]]
+    operators = [";"]
     for token in tokens:
-        if token in {"&&", ";"}:
+        if token in {"&&", "||", ";"}:
             if not segments[-1]:
                 return None
             segments.append([])
+            operators.append(token)
+        elif token in {"&", "|", "<", "<<", ">>", "<<<"}:
+            return None
         else:
             segments[-1].append(token)
-    if not segments[-1] or len(segments) > 4:
+    if not segments[-1] or len(segments) > 8:
         return None
 
     plan: list[_ReadStep] = []
-    for segment in segments:
+    for operator, raw_segment in zip(operators, segments, strict=True):
+        segment = list(raw_segment)
+        if len(segment) >= 3 and segment[-3:] == ["2", ">", "/dev/null"]:
+            segment = segment[:-3]
+        if not segment or any(
+            token in {"&", "|", "<", ">", "<<", ">>", "<<<"}
+            for token in segment
+        ):
+            return None
         executable = Path(segment[0]).name
+        if executable == "pwd" and len(segment) == 1:
+            plan.append(_ReadStep("metadata", (executable,), operator=operator))
+            continue
         if executable == "echo" and len(segment) == 2:
-            plan.append(_ReadStep("separator", (executable, *segment[1:])))
+            plan.append(
+                _ReadStep(
+                    "separator",
+                    (executable, *segment[1:]),
+                    operator=operator,
+                )
+            )
             continue
         if executable == "ls":
             paths = [token for token in segment[1:] if not token.startswith("-")]
             options = [token for token in segment[1:] if token.startswith("-")]
+            resolved_path = (
+                _resolve_metadata_path(paths[0], fixture=fixture)
+                if paths
+                else None
+            )
             if (
                 len(paths) > 1
                 or any(set(option[1:]) - {"a", "l"} for option in options)
-                or (
-                    paths
-                    and _resolve_project_path(paths[0], fixture=fixture) is None
-                )
+                or (paths and resolved_path is None)
             ):
                 return None
-            plan.append(_ReadStep("metadata", (executable, *segment[1:])))
+            argv = [executable, *options]
+            if resolved_path is not None:
+                argv.append(str(resolved_path))
+            plan.append(_ReadStep("metadata", tuple(argv), operator=operator))
+            continue
+        discovery_argv = _discovery_tokens(segment, fixture=fixture)
+        if discovery_argv is not None:
+            plan.append(
+                _ReadStep(
+                    "metadata",
+                    tuple(discovery_argv),
+                    operator=operator,
+                )
+            )
             continue
         content_shape = bool(
             (executable == "cat" and len(segment) == 2)
@@ -322,22 +376,23 @@ def _read_plan(
         target = _resolve_project_path(segment[-1], fixture=fixture)
         if target is None:
             return None
-        plan.append(_ReadStep("content", (executable, *segment[1:]), target))
+        plan.append(
+            _ReadStep(
+                "content",
+                (executable, *segment[1:-1], str(target)),
+                target,
+                operator,
+            )
+        )
     return plan
 
 
-def _discovery_argv(
-    command: str,
+def _discovery_tokens(
+    tokens: list[str],
     *,
     fixture: _SelectedTodoToolFixture,
 ) -> list[str] | None:
-    try:
-        tokens = shlex.split(command)
-    except ValueError:
-        return None
-    if not tokens or any(
-        token in {";", "&&", "||", "|", ">", ">>"} for token in tokens
-    ):
+    if not tokens:
         return None
     executable = Path(tokens[0]).name
     if executable == "rg":
@@ -350,9 +405,11 @@ def _discovery_argv(
         return [executable, *tokens[1:]]
     if executable != "find" or len(tokens) < 2:
         return None
-    if _resolve_project_path(tokens[1], fixture=fixture) is None:
+    root = _resolve_metadata_path(tokens[1], fixture=fixture)
+    if root is None:
         return None
     index = 2
+    has_maxdepth = False
     while index < len(tokens):
         token = tokens[index]
         if token == "-print":
@@ -362,6 +419,7 @@ def _discovery_argv(
             depth = tokens[index + 1]
             if not depth.isdigit() or int(depth) > 4:
                 return None
+            has_maxdepth = True
             index += 2
             continue
         if token == "-type" and index + 1 < len(tokens):
@@ -369,8 +427,36 @@ def _discovery_argv(
                 return None
             index += 2
             continue
+        if token == "-name" and index + 1 < len(tokens):
+            pattern = tokens[index + 1]
+            if (
+                not pattern
+                or len(pattern.encode("utf-8")) > 128
+                or "/" in pattern
+                or pattern.startswith("-")
+            ):
+                return None
+            index += 2
+            continue
         return None
-    return [executable, *tokens[1:]]
+    argv = [executable, str(root), *tokens[2:]]
+    if not has_maxdepth:
+        argv[2:2] = ["-maxdepth", "4"]
+    return argv
+
+
+def _discovery_argv(
+    command: str,
+    *,
+    fixture: _SelectedTodoToolFixture,
+) -> list[str] | None:
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return None
+    if any(token in {";", "&&", "||", "|", ">", ">>"} for token in tokens):
+        return None
+    return _discovery_tokens(tokens, fixture=fixture)
 
 
 def _execute_selected_read(
@@ -387,8 +473,28 @@ def _execute_selected_read(
         for step in content_steps
     ):
         raise ValueError("selected action does not target the selected todo")
+    output, executed_content = _execute_read_plan(plan, fixture=fixture)
+    if executed_content != len(content_steps):
+        raise ValueError("selected todo content read was skipped")
+    return output
+
+
+def _execute_read_plan(
+    plan: list[_ReadStep],
+    *,
+    fixture: _SelectedTodoToolFixture,
+) -> tuple[str, int]:
     outputs: list[str] = []
+    status = 0
+    executed_content = 0
     for step in plan:
+        should_run = bool(
+            step.operator == ";"
+            or (step.operator == "&&" and status == 0)
+            or (step.operator == "||" and status != 0)
+        )
+        if not should_run:
+            continue
         completed = subprocess.run(
             list(step.argv),
             cwd=fixture.project_root,
@@ -397,13 +503,11 @@ def _execute_selected_read(
             text=True,
             timeout=10,
         )
-        if completed.returncode != 0:
-            raise RuntimeError(
-                f"selected todo read failed with exit={completed.returncode}"
-            )
+        status = completed.returncode
         outputs.append(completed.stdout)
-        if step.kind != "content":
+        if step.kind != "content" or status != 0:
             continue
+        executed_content += 1
         observed = json.loads(completed.stdout)
         if observed != {
             "contract": "public-safe-read-only",
@@ -411,7 +515,9 @@ def _execute_selected_read(
             "next_checkpoint": "qualify-one-bounded-slice",
         }:
             raise ValueError("selected todo readback does not match the fixture")
-    return "".join(outputs)
+    if status != 0:
+        raise RuntimeError(f"bounded read plan failed with exit={status}")
+    return "".join(outputs), executed_content
 
 
 def _execute_workspace_read(
@@ -419,6 +525,10 @@ def _execute_workspace_read(
     *,
     fixture: _SelectedTodoToolFixture,
 ) -> str:
+    plan = _read_plan(command, fixture=fixture)
+    if plan is not None:
+        output, _ = _execute_read_plan(plan, fixture=fixture)
+        return output
     argv = _discovery_argv(command, fixture=fixture) or shlex.split(command)
     completed = subprocess.run(
         argv,

--- a/loopx/control_plane/testing/selected_todo_tool_behavior.py
+++ b/loopx/control_plane/testing/selected_todo_tool_behavior.py
@@ -67,6 +67,7 @@ class _ReadStep:
     argv: tuple[str, ...]
     target: Path | None = None
     operator: str = ";"
+    line_limit: int | None = None
 
 
 def _build_fixture(root: Path) -> _SelectedTodoToolFixture:
@@ -256,9 +257,91 @@ def _resolve_metadata_path(
     *,
     fixture: _SelectedTodoToolFixture,
 ) -> Path | None:
-    if value.rstrip("/") == "~/.codex/loopx":
-        return fixture.global_registry_path.parent.resolve()
+    runtime_marker = "~/.codex/loopx"
+    normalized = value.rstrip("/")
+    if normalized == runtime_marker or normalized.startswith(runtime_marker + "/"):
+        suffix = normalized[len(runtime_marker) :].lstrip("/")
+        runtime_root = fixture.global_registry_path.parent.resolve()
+        resolved = (runtime_root / suffix).resolve()
+        try:
+            resolved.relative_to(runtime_root)
+        except ValueError:
+            return None
+        return resolved
     return _resolve_project_path(value, fixture=fixture)
+
+
+def _is_fixture_metadata_target(
+    target: Path | None,
+    *,
+    fixture: _SelectedTodoToolFixture,
+) -> bool:
+    if target is None:
+        return False
+    allowed = {
+        (fixture.project_root / ".loopx" / "registry.json").resolve(),
+        (
+            fixture.project_root
+            / ".codex"
+            / "goals"
+            / SELECTED_TODO_TOOL_FIXTURE_GOAL_ID
+            / "ACTIVE_GOAL_STATE.md"
+        ).resolve(),
+    }
+    return target.resolve() in allowed
+
+
+def _metadata_pipeline_step(
+    segment: list[str],
+    *,
+    fixture: _SelectedTodoToolFixture,
+    operator: str,
+) -> _ReadStep | None:
+    if segment.count("|") != 1:
+        return None
+    pipe_index = segment.index("|")
+    left = segment[:pipe_index]
+    right = segment[pipe_index + 1 :]
+    if len(left) >= 3 and left[-3:] == ["2", ">", "/dev/null"]:
+        left = left[:-3]
+    if len(right) == 2 and Path(right[0]).name == "head":
+        limit_token = right[1]
+        if not limit_token.startswith("-") or not limit_token[1:].isdigit():
+            return None
+        limit = int(limit_token[1:])
+    elif (
+        len(right) == 3
+        and Path(right[0]).name == "head"
+        and right[1] == "-n"
+        and right[2].isdigit()
+    ):
+        limit = int(right[2])
+    else:
+        return None
+    if limit < 1 or limit > 200:
+        return None
+    discovery_argv = _discovery_tokens(left, fixture=fixture)
+    if discovery_argv is not None:
+        return _ReadStep(
+            "metadata",
+            tuple(discovery_argv),
+            operator=operator,
+            line_limit=limit,
+        )
+    if len(left) != 2 or Path(left[0]).name != "cat":
+        return None
+    target = _resolve_metadata_path(left[1], fixture=fixture)
+    allowed_registries = {
+        fixture.global_registry_path.resolve(),
+        (fixture.project_root / ".loopx" / "registry.json").resolve(),
+    }
+    if target not in allowed_registries:
+        return None
+    return _ReadStep(
+        "metadata",
+        ("head", "-n", str(limit), str(target)),
+        operator=operator,
+    )
 
 
 def _read_plan_tokens(command: str) -> list[str] | None:
@@ -287,7 +370,9 @@ def _read_plan(
                 return None
             segments.append([])
             operators.append(token)
-        elif token in {"&", "|", "<", "<<", ">>", "<<<"}:
+        elif token == "|":
+            segments[-1].append(token)
+        elif token in {"&", "<", "<<", ">>", "<<<"}:
             return None
         else:
             segments[-1].append(token)
@@ -297,6 +382,16 @@ def _read_plan(
     plan: list[_ReadStep] = []
     for operator, raw_segment in zip(operators, segments, strict=True):
         segment = list(raw_segment)
+        if "|" in segment:
+            pipeline_step = _metadata_pipeline_step(
+                segment,
+                fixture=fixture,
+                operator=operator,
+            )
+            if pipeline_step is None:
+                return None
+            plan.append(pipeline_step)
+            continue
         if len(segment) >= 3 and segment[-3:] == ["2", ">", "/dev/null"]:
             segment = segment[:-3]
         if not segment or any(
@@ -437,6 +532,21 @@ def _discovery_tokens(
                 return None
             index += 2
             continue
+        if (
+            token == "-not"
+            and index + 2 < len(tokens)
+            and tokens[index + 1] == "-path"
+        ):
+            pattern = tokens[index + 2]
+            if (
+                not pattern
+                or len(pattern.encode("utf-8")) > 128
+                or Path(pattern).is_absolute()
+                or ".." in Path(pattern).parts
+            ):
+                return None
+            index += 3
+            continue
         return None
     argv = [executable, str(root), *tokens[2:]]
     if not has_maxdepth:
@@ -465,15 +575,21 @@ def _execute_selected_read(
 ) -> str:
     plan = _read_plan(command, fixture=fixture)
     content_steps = [step for step in (plan or []) if step.kind == "content"]
-    if not plan or not content_steps:
+    selected_steps = [
+        step
+        for step in content_steps
+        if step.target == fixture.selected_target.resolve()
+    ]
+    if not plan or not selected_steps:
         raise ValueError("selected action is not a bounded file read")
     if any(
         step.target != fixture.selected_target.resolve()
+        and not _is_fixture_metadata_target(step.target, fixture=fixture)
         for step in content_steps
     ):
         raise ValueError("selected action does not target the selected todo")
     output, executed_content = _execute_read_plan(plan, fixture=fixture)
-    if executed_content != len(content_steps):
+    if executed_content != len(selected_steps):
         raise ValueError("selected todo content read was skipped")
     return output
 
@@ -503,11 +619,20 @@ def _execute_read_plan(
             timeout=10,
         )
         status = completed.returncode
-        outputs.append(completed.stdout)
-        if step.kind != "content" or status != 0:
+        step_output = completed.stdout
+        if step.line_limit is not None:
+            step_output = "".join(
+                step_output.splitlines(keepends=True)[: step.line_limit]
+            )
+        outputs.append(step_output)
+        if (
+            step.kind != "content"
+            or status != 0
+            or step.target != fixture.selected_target.resolve()
+        ):
             continue
         executed_content += 1
-        observed = json.loads(completed.stdout)
+        observed = json.loads(step_output)
         if observed != {
             "contract": "public-safe-read-only",
             "lane": "selected",
@@ -564,8 +689,10 @@ def _classify_tool_command(
         content_targets = [
             step.target for step in plan if step.kind == "content"
         ]
-        if content_targets and all(
-            target == fixture.selected_target.resolve()
+        selected_target = fixture.selected_target.resolve()
+        if selected_target in content_targets and all(
+            target == selected_target
+            or _is_fixture_metadata_target(target, fixture=fixture)
             for target in content_targets
         ):
             return (
@@ -573,6 +700,11 @@ def _classify_tool_command(
                 if quota_observed
                 else "selected_action_before_quota"
             ), None
+        if content_targets and all(
+            _is_fixture_metadata_target(target, fixture=fixture)
+            for target in content_targets
+        ):
+            return "workspace_read", None
         if content_targets:
             return "wrong_selected_todo_target", None
         return "workspace_read", None

--- a/loopx/control_plane/testing/selected_todo_tool_behavior.py
+++ b/loopx/control_plane/testing/selected_todo_tool_behavior.py
@@ -257,9 +257,33 @@ def _resolve_metadata_path(
     *,
     fixture: _SelectedTodoToolFixture,
 ) -> Path | None:
-    runtime_marker = "~/.codex/loopx"
     normalized = value.rstrip("/")
-    if normalized == runtime_marker or normalized.startswith(runtime_marker + "/"):
+    candidate = Path(normalized)
+    if candidate.is_absolute():
+        resolved = candidate.resolve()
+        fixture_roots = (
+            fixture.project_root.resolve(),
+            fixture.runtime_root.resolve(),
+            fixture.global_registry_path.parents[2].resolve(),
+        )
+        if any(
+            resolved == root or root in resolved.parents for root in fixture_roots
+        ):
+            return resolved
+        return None
+    runtime_marker = next(
+        (
+            marker
+            for marker in (
+                "~/.codex/loopx",
+                "$HOME/.codex/loopx",
+                "${HOME}/.codex/loopx",
+            )
+            if normalized == marker or normalized.startswith(marker + "/")
+        ),
+        None,
+    )
+    if runtime_marker is not None:
         suffix = normalized[len(runtime_marker) :].lstrip("/")
         runtime_root = fixture.global_registry_path.parent.resolve()
         resolved = (runtime_root / suffix).resolve()
@@ -297,13 +321,23 @@ def _metadata_pipeline_step(
     fixture: _SelectedTodoToolFixture,
     operator: str,
 ) -> _ReadStep | None:
-    if segment.count("|") != 1:
+    pipe_indices = [index for index, token in enumerate(segment) if token == "|"]
+    if len(pipe_indices) not in {1, 2}:
         return None
-    pipe_index = segment.index("|")
-    left = segment[:pipe_index]
-    right = segment[pipe_index + 1 :]
+    left = segment[: pipe_indices[0]]
+    right = segment[pipe_indices[-1] + 1 :]
     if len(left) >= 3 and left[-3:] == ["2", ">", "/dev/null"]:
         left = left[:-3]
+    if len(pipe_indices) == 2:
+        middle = segment[pipe_indices[0] + 1 : pipe_indices[1]]
+        if len(middle) >= 3 and middle[-3:] == ["2", ">", "/dev/null"]:
+            middle = middle[:-3]
+        if not (
+            len(middle) == 3
+            and Path(middle[0]).name in {"python", "python3"}
+            and middle[1:] == ["-m", "json.tool"]
+        ):
+            return None
     if len(right) == 2 and Path(right[0]).name == "head":
         limit_token = right[1]
         if not limit_token.startswith("-") or not limit_token[1:].isdigit():
@@ -345,7 +379,8 @@ def _metadata_pipeline_step(
 
 
 def _read_plan_tokens(command: str) -> list[str] | None:
-    lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|<>")
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|<>\n")
+    lexer.whitespace = " \t\r"
     lexer.whitespace_split = True
     try:
         tokens = list(lexer)
@@ -365,11 +400,11 @@ def _read_plan(
     segments: list[list[str]] = [[]]
     operators = [";"]
     for token in tokens:
-        if token in {"&&", "||", ";"}:
+        if token in {"&&", "||", ";", "\n"}:
             if not segments[-1]:
                 return None
             segments.append([])
-            operators.append(token)
+            operators.append(";" if token == "\n" else token)
         elif token == "|":
             segments[-1].append(token)
         elif token in {"&", "<", "<<", ">>", "<<<"}:
@@ -400,6 +435,20 @@ def _read_plan(
         ):
             return None
         executable = Path(segment[0]).name
+        if (
+            executable == "export"
+            and len(segment) == 2
+            and segment[1].startswith("LOOPX_TURN=")
+            and len(segment[1]) <= 160
+        ):
+            plan.append(_ReadStep("metadata", ("true",), operator=operator))
+            continue
+        if executable == "cd" and len(segment) == 2:
+            target = _resolve_metadata_path(segment[1], fixture=fixture)
+            if target != fixture.project_root.resolve():
+                return None
+            plan.append(_ReadStep("metadata", ("true",), operator=operator))
+            continue
         if executable == "pwd" and len(segment) == 1:
             plan.append(_ReadStep("metadata", (executable,), operator=operator))
             continue

--- a/loopx/control_plane/work_items/primary_action.py
+++ b/loopx/control_plane/work_items/primary_action.py
@@ -289,7 +289,11 @@ def resolve_canonical_primary_action(payload: dict[str, Any], *, mode: str) -> s
     if mode == "outcome_floor_recovery":
         return "produce the required outcome-floor evidence artifact or write the concrete blocker"
     if mode == "capability_bridge_repair":
-        return "repair or materialize the missing bridge capability, rewrite the todo, or write a compact blocker"
+        return (
+            "execute interaction_contract.cli_channel.next_cli_actions[0] to "
+            "materialize the missing capability; do not backtrack to generic "
+            "inspection or a monitor fallback"
+        )
     if mode == "agent_workspace_repair":
         return "create or switch to an independent worktree/branch, then rerun quota guard before file edits"
     if mode == "automation_prompt_upgrade":

--- a/scripts/qualify-doubao-capability-monitor-repair-tool-live.py
+++ b/scripts/qualify-doubao-capability-monitor-repair-tool-live.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+repo_root_text = str(REPO_ROOT)
+if sys.path[0] != repo_root_text:
+    sys.path.insert(0, repo_root_text)
+
+from loopx.control_plane.testing.capability_monitor_repair_tool_behavior import (
+    DoubaoCapabilityMonitorRepairToolBehaviorActor,
+)
+from loopx.control_plane.testing.release_commit_qualification import (
+    collect_release_source_identity,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the capability-monitor repair tool behavior against the real "
+            "Ark Doubao API and print only its bounded receipt."
+        )
+    )
+    parser.add_argument("--qualification-id", required=True)
+    parser.add_argument("--timeout-seconds", type=float, default=90.0)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    source = collect_release_source_identity(args.repo_root)
+    if source["git_dirty"]:
+        raise RuntimeError(
+            "live Doubao qualification requires a clean candidate checkout"
+        )
+    actor = DoubaoCapabilityMonitorRepairToolBehaviorActor.from_environment(
+        timeout_seconds=args.timeout_seconds
+    )
+    with TemporaryDirectory(prefix="loopx-capability-repair-live-") as temp_dir:
+        result = actor.qualify(
+            qualification_id=args.qualification_id,
+            fixture_root=Path(temp_dir),
+        )
+    result["source"] = source
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True, indent=2))
+    return 0 if result["qualification_passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qualify-doubao-model-behavior-live.py
+++ b/scripts/qualify-doubao-model-behavior-live.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from hashlib import sha256
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -24,6 +25,9 @@ from loopx.control_plane.testing.doubao_model_behavior_actor import (  # noqa: E
 )
 from loopx.control_plane.testing.release_commit_qualification import (  # noqa: E402
     collect_release_source_identity,
+)
+from loopx.control_plane.testing.selected_todo_tool_behavior import (  # noqa: E402
+    DoubaoSelectedTodoToolBehaviorActor,
 )
 
 
@@ -53,9 +57,21 @@ def main() -> int:
     onboarding_actor = DoubaoOnboardingModelBehaviorActor.from_environment(
         timeout_seconds=args.timeout_seconds
     )
+    selected_todo_actor = DoubaoSelectedTodoToolBehaviorActor.from_environment(
+        timeout_seconds=args.timeout_seconds
+    )
     with TemporaryDirectory(prefix="loopx-doubao-live-") as temp_dir:
+        temp_root = Path(temp_dir)
+
+        def qualify_selected_todo(run_id: str) -> dict[str, object]:
+            run_digest = sha256(run_id.encode("utf-8")).hexdigest()[:16]
+            return selected_todo_actor.qualify(
+                qualification_id=run_id,
+                fixture_root=temp_root / "selected-todo" / run_digest,
+            )
+
         sources, packets = build_actual_default_model_behavior_scenario_inputs(
-            Path(temp_dir)
+            temp_root / "portfolio"
         )
         result = run_actual_default_model_behavior_portfolio(
             packets,
@@ -63,6 +79,7 @@ def main() -> int:
             qualification_id=args.qualification_id,
             turn_actor=turn_actor,
             onboarding_actor=onboarding_actor,
+            selected_todo_actor=qualify_selected_todo,
         )
     result["source"] = source
     print(json.dumps(result, ensure_ascii=False, sort_keys=True, indent=2))

--- a/scripts/qualify-doubao-model-behavior-live.py
+++ b/scripts/qualify-doubao-model-behavior-live.py
@@ -14,21 +14,24 @@ if sys.path[0] != repo_root_text:
     sys.path.insert(0, repo_root_text)
 
 # The candidate checkout must win over any installed LoopX package.
-from loopx.control_plane.testing.actual_default_model_behavior_portfolio import (  # noqa: E402
+from loopx.control_plane.testing.actual_default_model_behavior_portfolio import (
     build_actual_default_model_behavior_scenario_inputs,
     run_actual_default_model_behavior_portfolio,
 )
-from loopx.control_plane.testing.doubao_model_behavior_actor import (  # noqa: E402
+from loopx.control_plane.testing.doubao_model_behavior_actor import (
     DoubaoModelBehaviorActor,
     DoubaoOnboardingModelBehaviorActor,
 )
-from loopx.control_plane.testing.release_commit_qualification import (  # noqa: E402
+from loopx.control_plane.testing.release_commit_qualification import (
     collect_release_source_identity,
 )
-from loopx.control_plane.testing.replan_evidence_tool_behavior import (  # noqa: E402
+from loopx.control_plane.testing.replan_evidence_tool_behavior import (
     DoubaoReplanEvidenceToolBehaviorActor,
 )
-from loopx.control_plane.testing.selected_todo_tool_behavior import (  # noqa: E402
+from loopx.control_plane.testing.scoped_gate_successor_tool_behavior import (
+    DoubaoScopedGateSuccessorToolBehaviorActor,
+)
+from loopx.control_plane.testing.selected_todo_tool_behavior import (
     DoubaoSelectedTodoToolBehaviorActor,
 )
 
@@ -65,6 +68,11 @@ def main() -> int:
     replan_evidence_actor = DoubaoReplanEvidenceToolBehaviorActor.from_environment(
         timeout_seconds=args.timeout_seconds
     )
+    scoped_gate_successor_actor = (
+        DoubaoScopedGateSuccessorToolBehaviorActor.from_environment(
+            timeout_seconds=args.timeout_seconds
+        )
+    )
     with TemporaryDirectory(prefix="loopx-doubao-live-") as temp_dir:
         temp_root = Path(temp_dir)
 
@@ -82,6 +90,13 @@ def main() -> int:
                 fixture_root=temp_root / "replan-evidence" / run_digest,
             )
 
+        def qualify_scoped_gate_successor(run_id: str) -> dict[str, object]:
+            run_digest = sha256(run_id.encode("utf-8")).hexdigest()[:16]
+            return scoped_gate_successor_actor.qualify(
+                qualification_id=run_id,
+                fixture_root=temp_root / "scoped-gate-successor" / run_digest,
+            )
+
         sources, packets = build_actual_default_model_behavior_scenario_inputs(
             temp_root / "portfolio"
         )
@@ -93,6 +108,7 @@ def main() -> int:
             onboarding_actor=onboarding_actor,
             selected_todo_actor=qualify_selected_todo,
             replan_evidence_actor=qualify_replan_evidence,
+            scoped_gate_successor_actor=qualify_scoped_gate_successor,
         )
     result["source"] = source
     print(json.dumps(result, ensure_ascii=False, sort_keys=True, indent=2))

--- a/scripts/qualify-doubao-model-behavior-live.py
+++ b/scripts/qualify-doubao-model-behavior-live.py
@@ -25,6 +25,9 @@ from loopx.control_plane.testing.doubao_model_behavior_actor import (  # noqa: E
 from loopx.control_plane.testing.release_commit_qualification import (  # noqa: E402
     collect_release_source_identity,
 )
+from loopx.control_plane.testing.replan_evidence_tool_behavior import (  # noqa: E402
+    DoubaoReplanEvidenceToolBehaviorActor,
+)
 from loopx.control_plane.testing.selected_todo_tool_behavior import (  # noqa: E402
     DoubaoSelectedTodoToolBehaviorActor,
 )
@@ -59,6 +62,9 @@ def main() -> int:
     selected_todo_actor = DoubaoSelectedTodoToolBehaviorActor.from_environment(
         timeout_seconds=args.timeout_seconds
     )
+    replan_evidence_actor = DoubaoReplanEvidenceToolBehaviorActor.from_environment(
+        timeout_seconds=args.timeout_seconds
+    )
     with TemporaryDirectory(prefix="loopx-doubao-live-") as temp_dir:
         temp_root = Path(temp_dir)
 
@@ -67,6 +73,13 @@ def main() -> int:
             return selected_todo_actor.qualify(
                 qualification_id=run_id,
                 fixture_root=temp_root / "selected-todo" / run_digest,
+            )
+
+        def qualify_replan_evidence(run_id: str) -> dict[str, object]:
+            run_digest = sha256(run_id.encode("utf-8")).hexdigest()[:16]
+            return replan_evidence_actor.qualify(
+                qualification_id=run_id,
+                fixture_root=temp_root / "replan-evidence" / run_digest,
             )
 
         sources, packets = build_actual_default_model_behavior_scenario_inputs(
@@ -79,6 +92,7 @@ def main() -> int:
             turn_actor=turn_actor,
             onboarding_actor=onboarding_actor,
             selected_todo_actor=qualify_selected_todo,
+            replan_evidence_actor=qualify_replan_evidence,
         )
     result["source"] = source
     print(json.dumps(result, ensure_ascii=False, sort_keys=True, indent=2))

--- a/scripts/qualify-doubao-model-behavior-live.py
+++ b/scripts/qualify-doubao-model-behavior-live.py
@@ -18,6 +18,9 @@ from loopx.control_plane.testing.actual_default_model_behavior_portfolio import 
     build_actual_default_model_behavior_scenario_inputs,
     run_actual_default_model_behavior_portfolio,
 )
+from loopx.control_plane.testing.capability_monitor_repair_tool_behavior import (
+    DoubaoCapabilityMonitorRepairToolBehaviorActor,
+)
 from loopx.control_plane.testing.doubao_model_behavior_actor import (
     DoubaoModelBehaviorActor,
     DoubaoOnboardingModelBehaviorActor,
@@ -73,6 +76,11 @@ def main() -> int:
             timeout_seconds=args.timeout_seconds
         )
     )
+    capability_monitor_repair_actor = (
+        DoubaoCapabilityMonitorRepairToolBehaviorActor.from_environment(
+            timeout_seconds=args.timeout_seconds
+        )
+    )
     with TemporaryDirectory(prefix="loopx-doubao-live-") as temp_dir:
         temp_root = Path(temp_dir)
 
@@ -97,6 +105,13 @@ def main() -> int:
                 fixture_root=temp_root / "scoped-gate-successor" / run_digest,
             )
 
+        def qualify_capability_monitor_repair(run_id: str) -> dict[str, object]:
+            run_digest = sha256(run_id.encode("utf-8")).hexdigest()[:16]
+            return capability_monitor_repair_actor.qualify(
+                qualification_id=run_id,
+                fixture_root=temp_root / "capability-monitor-repair" / run_digest,
+            )
+
         sources, packets = build_actual_default_model_behavior_scenario_inputs(
             temp_root / "portfolio"
         )
@@ -109,6 +124,7 @@ def main() -> int:
             selected_todo_actor=qualify_selected_todo,
             replan_evidence_actor=qualify_replan_evidence,
             scoped_gate_successor_actor=qualify_scoped_gate_successor,
+            capability_monitor_repair_actor=qualify_capability_monitor_repair,
         )
     result["source"] = source
     print(json.dumps(result, ensure_ascii=False, sort_keys=True, indent=2))

--- a/scripts/qualify-doubao-model-behavior-live.py
+++ b/scripts/qualify-doubao-model-behavior-live.py
@@ -8,7 +8,6 @@ from hashlib import sha256
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 repo_root_text = str(REPO_ROOT)
 if sys.path[0] != repo_root_text:

--- a/scripts/qualify-doubao-scoped-gate-successor-tool-live.py
+++ b/scripts/qualify-doubao-scoped-gate-successor-tool-live.py
@@ -15,8 +15,8 @@ if sys.path[0] != repo_root_text:
 from loopx.control_plane.testing.release_commit_qualification import (
     collect_release_source_identity,
 )
-from loopx.control_plane.testing.selected_todo_tool_behavior import (
-    DoubaoSelectedTodoToolBehaviorActor,
+from loopx.control_plane.testing.scoped_gate_successor_tool_behavior import (
+    DoubaoScopedGateSuccessorToolBehaviorActor,
 )
 
 
@@ -24,8 +24,8 @@ def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
             "Run one production-heartbeat Doubao function-tool loop against "
-            "a hermetic real LoopX goal and verify that the model executes the "
-            "Todo selected by real quota output."
+            "a hermetic scoped user gate and verify that the model surfaces "
+            "the notice without suppressing the ready successor action."
         )
     )
     parser.add_argument("--qualification-id", required=True)
@@ -41,10 +41,12 @@ def main() -> int:
         raise RuntimeError(
             "live Doubao qualification requires a clean candidate checkout"
         )
-    actor = DoubaoSelectedTodoToolBehaviorActor.from_environment(
+    actor = DoubaoScopedGateSuccessorToolBehaviorActor.from_environment(
         timeout_seconds=args.timeout_seconds
     )
-    with TemporaryDirectory(prefix="loopx-doubao-selected-todo-tool-") as temp_dir:
+    with TemporaryDirectory(
+        prefix="loopx-doubao-scoped-gate-successor-tool-"
+    ) as temp_dir:
         result = actor.qualify(
             qualification_id=args.qualification_id,
             fixture_root=Path(temp_dir),

--- a/scripts/qualify-doubao-selected-todo-tool-live.py
+++ b/scripts/qualify-doubao-selected-todo-tool-live.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+repo_root_text = str(REPO_ROOT)
+if sys.path[0] != repo_root_text:
+    sys.path.insert(0, repo_root_text)
+
+from loopx.control_plane.testing.release_commit_qualification import (  # noqa: E402
+    collect_release_source_identity,
+)
+from loopx.control_plane.testing.selected_todo_tool_behavior import (  # noqa: E402
+    DoubaoSelectedTodoToolBehaviorActor,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run one production-heartbeat Doubao function-tool loop against "
+            "a hermetic real LoopX goal and verify that the model executes the "
+            "Todo selected by real quota output."
+        )
+    )
+    parser.add_argument("--qualification-id", required=True)
+    parser.add_argument("--timeout-seconds", type=float, default=90.0)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    source = collect_release_source_identity(args.repo_root)
+    if source["git_dirty"]:
+        raise RuntimeError(
+            "live Doubao qualification requires a clean candidate checkout"
+        )
+    actor = DoubaoSelectedTodoToolBehaviorActor.from_environment(
+        timeout_seconds=args.timeout_seconds
+    )
+    with TemporaryDirectory(prefix="loopx-doubao-selected-todo-tool-") as temp_dir:
+        result = actor.qualify(
+            qualification_id=args.qualification_id,
+            fixture_root=Path(temp_dir),
+        )
+    result["source"] = source
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True, indent=2))
+    return 0 if result["qualification_passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qualify-doubao-selected-todo-tool-live.py
+++ b/scripts/qualify-doubao-selected-todo-tool-live.py
@@ -7,7 +7,6 @@ import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 repo_root_text = str(REPO_ROOT)
 if sys.path[0] != repo_root_text:

--- a/tests/control_plane/test_actual_default_model_behavior_portfolio.py
+++ b/tests/control_plane/test_actual_default_model_behavior_portfolio.py
@@ -385,6 +385,23 @@ def _selected_todo_actor(_: str) -> dict[str, Any]:
     }
 
 
+def _replan_evidence_actor(_: str) -> dict[str, Any]:
+    return {
+        "schema_version": "replan_evidence_tool_behavior_receipt_v0",
+        "qualification_passed": True,
+        "failure_code": None,
+        "decision": "execute",
+        "selected_todo_id": None,
+        "user_action_required": False,
+        "must_attempt_work": True,
+        "delivery_allowed": True,
+        "quiet_noop_allowed": False,
+        "external_write_requested": False,
+        "evidence_log_matched_required_read": True,
+        "vision_trigger_kinds": ["required_agent_vision_missing"],
+    }
+
+
 def test_live_packet_builder_uses_production_blocking_gate_plan(tmp_path: Path) -> None:
     sources, packets = build_actual_default_model_behavior_scenario_inputs(tmp_path)
 
@@ -599,6 +616,7 @@ def test_portfolio_oracle_catches_wrong_selected_todo(tmp_path: Path) -> None:
         turn_actor=_turn_actor,
         onboarding_actor=_onboarding_actor,
         selected_todo_actor=wrong_selected_todo_actor,
+        replan_evidence_actor=_replan_evidence_actor,
     )
 
     selected = next(
@@ -637,6 +655,7 @@ def test_portfolio_source_oracle_rejects_mutated_compact_user_action(
             turn_actor=turn_actor,
             onboarding_actor=_onboarding_actor,
             selected_todo_actor=_selected_todo_actor,
+            replan_evidence_actor=_replan_evidence_actor,
         )
 
     assert calls == 0
@@ -660,6 +679,7 @@ def test_portfolio_rejects_mutated_blocking_gate_response_plan(tmp_path: Path) -
             turn_actor=_turn_actor,
             onboarding_actor=_onboarding_actor,
             selected_todo_actor=_selected_todo_actor,
+            replan_evidence_actor=_replan_evidence_actor,
         )
 
 
@@ -683,6 +703,7 @@ def test_portfolio_oracle_rejects_silent_wait_for_user_gate(tmp_path: Path) -> N
         turn_actor=silent_wait_actor,
         onboarding_actor=_onboarding_actor,
         selected_todo_actor=_selected_todo_actor,
+        replan_evidence_actor=_replan_evidence_actor,
     )
 
     gate = next(
@@ -707,7 +728,7 @@ def test_catalog_declares_independent_bounded_repeat_policy() -> None:
         scenario["packet_view"]
         == (
             "production_heartbeat_tool_loop"
-            if scenario["actor_kind"] == "turn_tool"
+            if scenario["actor_kind"] in {"turn_tool", "replan_tool"}
             else (
                 "quota_should_run_default"
                 if scenario["actor_kind"] == "turn"
@@ -775,6 +796,7 @@ def test_portfolio_preflights_every_scenario_before_actor_spend(tmp_path: Path) 
             turn_actor=turn_actor,
             onboarding_actor=onboarding_actor,
             selected_todo_actor=_selected_todo_actor,
+            replan_evidence_actor=_replan_evidence_actor,
         )
 
     assert calls == 0
@@ -801,6 +823,7 @@ def test_portfolio_aborts_on_authentication_failure_with_bounded_receipt(
         turn_actor=turn_actor,
         onboarding_actor=_onboarding_actor,
         selected_todo_actor=_selected_todo_actor,
+        replan_evidence_actor=_replan_evidence_actor,
     )
 
     assert calls == 1
@@ -840,6 +863,7 @@ def test_portfolio_preflight_rejects_wrong_same_agent_route(tmp_path: Path) -> N
             turn_actor=turn_actor,
             onboarding_actor=_onboarding_actor,
             selected_todo_actor=_selected_todo_actor,
+            replan_evidence_actor=_replan_evidence_actor,
         )
 
     assert calls == 0
@@ -864,6 +888,7 @@ def test_portfolio_turn_actor_reads_actual_default_packet_without_semantic_echo(
         turn_actor=turn_actor,
         onboarding_actor=_onboarding_actor,
         selected_todo_actor=_selected_todo_actor,
+        replan_evidence_actor=_replan_evidence_actor,
     )
 
     assert result["qualification_passed"] is True
@@ -914,6 +939,7 @@ def test_portfolio_selected_todo_uses_real_action_actor_when_supplied(
         turn_actor=_turn_actor,
         onboarding_actor=_onboarding_actor,
         selected_todo_actor=selected_todo_actor,
+        replan_evidence_actor=_replan_evidence_actor,
     )
 
     assert result["qualification_passed"] is True
@@ -922,8 +948,35 @@ def test_portfolio_selected_todo_uses_real_action_actor_when_supplied(
         "actual-default-portfolio-real-selected-action:turn_selected_todo:r2",
     ]
     assert result["boundary"]["tools_enabled"] is True
-    assert result["boundary"]["tool_enabled_scenario_count"] == 1
-    assert result["boundary"]["packet_interpretation_scenario_count"] == 14
+    assert result["boundary"]["tool_enabled_scenario_count"] == 2
+    assert result["boundary"]["packet_interpretation_scenario_count"] == 13
+
+
+def test_portfolio_required_vision_replan_uses_real_action_actor_when_supplied(
+    tmp_path: Path,
+) -> None:
+    replan_calls: list[str] = []
+
+    def replan_evidence_actor(run_id: str) -> Mapping[str, Any]:
+        replan_calls.append(run_id)
+        return _replan_evidence_actor(run_id)
+
+    sources, packets = _scenario_inputs(tmp_path)
+    result = run_actual_default_model_behavior_portfolio(
+        packets,
+        scenario_sources=sources,
+        qualification_id="actual-default-portfolio-real-replan-evidence",
+        turn_actor=_turn_actor,
+        onboarding_actor=_onboarding_actor,
+        selected_todo_actor=_selected_todo_actor,
+        replan_evidence_actor=replan_evidence_actor,
+    )
+
+    assert result["qualification_passed"] is True
+    assert replan_calls == [
+        "actual-default-portfolio-real-replan-evidence:turn_required_vision_replan:r1",
+        "actual-default-portfolio-real-replan-evidence:turn_required_vision_replan:r2",
+    ]
 
 
 def test_portfolio_preflight_rejects_invalid_contrast_before_actor_spend(
@@ -956,6 +1009,7 @@ def test_portfolio_preflight_rejects_invalid_contrast_before_actor_spend(
             turn_actor=turn_actor,
             onboarding_actor=_onboarding_actor,
             selected_todo_actor=_selected_todo_actor,
+            replan_evidence_actor=_replan_evidence_actor,
         )
 
     assert calls == 0
@@ -986,6 +1040,7 @@ def test_portfolio_contrast_rejects_noisy_gate_semantic_collapse(
         turn_actor=collapsed_actor,
         onboarding_actor=_onboarding_actor,
         selected_todo_actor=_selected_todo_actor,
+        replan_evidence_actor=_replan_evidence_actor,
     )
 
     contrast = next(
@@ -1004,26 +1059,21 @@ def test_portfolio_contrast_rejects_noisy_gate_semantic_collapse(
 def test_portfolio_oracle_rejects_quiet_wait_for_required_vision_replan(
     tmp_path: Path,
 ) -> None:
-    def quiet_wait_actor(request: Mapping[str, Any]) -> dict[str, Any]:
-        result = _turn_actor(request)
-        semantics = result["decision"]["semantic_contract"]
-        vision = semantics["vision_continuation"]
-        if "required_agent_vision_missing" in vision.get("trigger_kinds", []):
-            result["decision"] = {
-                **result["decision"],
-                "decision": "wait",
-                "intended_action_kinds": ["wait"],
-            }
-        return result
+    def quiet_wait_actor(run_id: str) -> dict[str, Any]:
+        return {
+            **_replan_evidence_actor(run_id),
+            "decision": "wait",
+        }
 
     sources, packets = _scenario_inputs(tmp_path)
     result = run_actual_default_model_behavior_portfolio(
         packets,
         scenario_sources=sources,
         qualification_id="actual-default-portfolio-required-vision-wait",
-        turn_actor=quiet_wait_actor,
+        turn_actor=_turn_actor,
         onboarding_actor=_onboarding_actor,
         selected_todo_actor=_selected_todo_actor,
+        replan_evidence_actor=quiet_wait_actor,
     )
 
     scenario = next(
@@ -1060,6 +1110,7 @@ def test_portfolio_oracle_rejects_waiting_on_hot_path_compaction_refs(
         turn_actor=waiting_actor,
         onboarding_actor=_onboarding_actor,
         selected_todo_actor=_selected_todo_actor,
+        replan_evidence_actor=_replan_evidence_actor,
     )
 
     scenario = next(
@@ -1098,6 +1149,7 @@ def test_portfolio_oracle_rejects_treating_non_blocking_notice_as_gate(
         turn_actor=blocking_actor,
         onboarding_actor=_onboarding_actor,
         selected_todo_actor=_selected_todo_actor,
+        replan_evidence_actor=_replan_evidence_actor,
     )
 
     scenario = next(
@@ -1134,6 +1186,7 @@ def test_portfolio_oracle_rejects_waiting_on_capability_monitor_repair(
         turn_actor=waiting_actor,
         onboarding_actor=_onboarding_actor,
         selected_todo_actor=_selected_todo_actor,
+        replan_evidence_actor=_replan_evidence_actor,
     )
 
     scenario = next(

--- a/tests/control_plane/test_actual_default_model_behavior_portfolio.py
+++ b/tests/control_plane/test_actual_default_model_behavior_portfolio.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 import json
+import re
+import shlex
 from collections.abc import Mapping
 from copy import deepcopy
+from hashlib import sha256
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-from loopx.bootstrap_command_pack import build_start_goal_guided_packet
 from loopx.control_plane.quota.cli_projection import (
     compact_quota_should_run_cli_payload,
 )
@@ -25,6 +27,15 @@ from loopx.control_plane.testing.actual_default_model_behavior_portfolio import 
 from loopx.control_plane.testing.doubao_model_behavior_actor import (
     DoubaoActorTransportError,
 )
+from loopx.control_plane.testing.capability_monitor_repair_tool_behavior import (
+    DoubaoCapabilityMonitorRepairToolBehaviorActor,
+    _build_capability_repair_fixture,
+)
+from loopx.control_plane.testing.model_tool_behavior import (
+    ScriptedAssistantAction,
+    ScriptedDoubaoExecTransport,
+    ScriptedExecToolAction,
+)
 from loopx.control_plane.testing.model_behavior_qualification import (
     FULL_QUOTA_DECISION_PACKET_SCHEMA_VERSION,
     MODEL_BEHAVIOR_ACTOR_RESULT_SCHEMA_VERSION,
@@ -34,261 +45,27 @@ from loopx.control_plane.testing.model_behavior_qualification import (
 from loopx.control_plane.testing.onboarding_model_behavior_qualification import (
     ONBOARDING_MODEL_BEHAVIOR_DECISION_SCHEMA_VERSION,
     ONBOARDING_MODEL_BEHAVIOR_RESULT_SCHEMA_VERSION,
-    build_onboarding_postcondition_observation,
     onboarding_entry_semantic_contract,
     onboarding_postcondition_semantic_contract,
 )
+from loopx.control_plane.testing.replan_evidence_tool_behavior import (
+    DoubaoReplanEvidenceToolBehaviorActor,
+    _build_fixture as _build_replan_fixture,
+)
+from loopx.control_plane.testing.scoped_gate_successor_tool_behavior import (
+    DoubaoScopedGateSuccessorToolBehaviorActor,
+    _build_scoped_gate_fixture,
+)
 from loopx.control_plane.testing.selected_todo_tool_behavior import (
     SELECTED_TODO_TOOL_FIXTURE_ACTION_TEXT,
+    DoubaoSelectedTodoToolBehaviorActor,
+    _build_fixture as _build_selected_fixture,
 )
-
-GOAL_ID = "portfolio-goal"
-AGENT_ID = "codex-portfolio"
-
-
-def _write_project(root: Path) -> tuple[Path, Path]:
-    project = root / "project"
-    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
-    state_file.parent.mkdir(parents=True)
-    state_file.write_text("# Active Goal State\n", encoding="utf-8")
-    registry_path = project / ".loopx" / "registry.json"
-    registry_path.parent.mkdir(parents=True)
-    registry_path.write_text(
-        json.dumps(
-            {
-                "schema_version": "0.1",
-                "goals": [
-                    {
-                        "id": GOAL_ID,
-                        "status": "active",
-                        "repo": str(project),
-                        "state_file": str(state_file.relative_to(project)),
-                        "coordination": {
-                            "agent_model": "peer_v1",
-                            "registered_agents": [AGENT_ID],
-                        },
-                    }
-                ],
-            },
-            indent=2,
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-    return project, registry_path
-
-
-def _guided_packet(
-    project: Path,
-    *,
-    goal_id: str | None,
-    agent_id: str | None,
-) -> dict[str, Any]:
-    return build_start_goal_guided_packet(
-        project=project,
-        goal_id=goal_id,
-        agent_id=agent_id,
-        cli_bin="loopx",
-        host_surface="codex-app",
-        goal_text="Establish one public-safe quality contract.",
-        available_capabilities=["network"],
-        include_command_pack_detail=False,
-    )
-
-
-def _entry_packets(tmp_path: Path) -> dict[str, dict[str, Any]]:
-    project, registry_path = _write_project(tmp_path)
-    connect = _guided_packet(project, goal_id=GOAL_ID, agent_id=AGENT_ID)
-
-    registry = json.loads(registry_path.read_text(encoding="utf-8"))
-    registry["goals"][0]["coordination"]["registered_agents"].append(
-        "codex-portfolio-reviewer"
-    )
-    registry_path.write_text(json.dumps(registry, indent=2) + "\n", encoding="utf-8")
-    identity = _guided_packet(project, goal_id=GOAL_ID, agent_id=None)
-
-    second_goal = "portfolio-second-goal"
-    second_state = project / ".codex" / "goals" / second_goal / "ACTIVE_GOAL_STATE.md"
-    second_state.parent.mkdir(parents=True)
-    second_state.write_text("# Second Active Goal State\n", encoding="utf-8")
-    registry["goals"].append(
-        {
-            "id": second_goal,
-            "status": "active",
-            "repo": str(project),
-            "state_file": str(second_state.relative_to(project)),
-            "coordination": {
-                "agent_model": "peer_v1",
-                "registered_agents": ["codex-portfolio-second"],
-            },
-        }
-    )
-    registry_path.write_text(json.dumps(registry, indent=2) + "\n", encoding="utf-8")
-    goal_selection = _guided_packet(project, goal_id=None, agent_id=None)
-    return {
-        "onboarding_connect_default": connect,
-        "onboarding_agent_identity_gate": identity,
-        "onboarding_goal_selection_gate": goal_selection,
-    }
-
-
-def _turn_source(
-    *,
-    human_gate: bool,
-    agent_id: str = AGENT_ID,
-    continuation_policy: str | None = None,
-) -> dict[str, Any]:
-    selected_todo = None
-    if not human_gate:
-        selected_todo = {
-            "todo_id": "todo_portfolio001",
-            "status": "open",
-            "task_class": "advancement_task",
-            "claimed_by": agent_id,
-            "text": "Implement one bounded public-safe slice.",
-        }
-        if continuation_policy:
-            selected_todo["continuation_policy"] = continuation_policy
-    return {
-        "ok": True,
-        "mode": "should-run",
-        "goal_id": GOAL_ID,
-        "decision": "skip" if human_gate else "run",
-        "should_run": not human_gate,
-        "effective_action": "operator_gate" if human_gate else "normal_run",
-        "state": "operator_gate" if human_gate else "eligible",
-        "action_required": human_gate,
-        "open_count": 1 if human_gate else 0,
-        "recommended_action": (
-            "Approve the bounded public release."
-            if human_gate
-            else "Implement one bounded public-safe slice."
-        ),
-        "selected_todo": selected_todo,
-        "agent_identity": {"agent_id": agent_id},
-        "interaction_contract": {
-            "schema_version": "loopx_interaction_contract_v0",
-            "mode": "user_gate" if human_gate else "bounded_delivery",
-            **(
-                {
-                    "response_plan": {
-                        "schema_version": "interaction_response_plan_v0",
-                        "kind": "surface_user_gate",
-                        "decision": "ask_user",
-                        "action_sequence": ["notify", "wait"],
-                        "silent_wait_allowed": False,
-                    }
-                }
-                if human_gate
-                else {}
-            ),
-            "user_channel": {
-                "action_required": human_gate,
-                "notify": "NOTIFY" if human_gate else "DONT_NOTIFY",
-                "actions": ["Approve the bounded public release."]
-                if human_gate
-                else [],
-            },
-            "agent_channel": {
-                "must_attempt": not human_gate,
-                "delivery_allowed": not human_gate,
-                "quiet_noop_allowed": False,
-                "primary_action": (
-                    "Wait for release approval."
-                    if human_gate
-                    else "Implement one bounded public-safe slice."
-                ),
-            },
-            "cli_channel": {
-                "next_cli_actions": [],
-                "spend_allowed_now": False,
-                "spend_after_validation": not human_gate,
-                "spend_policy": (
-                    "no spend while user gate is open"
-                    if human_gate
-                    else "spend after validated writeback"
-                ),
-            },
-        },
-        "goal_boundary": {
-            "write_scope": ["loopx/**", "tests/**"],
-            "guards": ["stop before external writes"],
-        },
-    }
-
 
 def _scenario_inputs(
     tmp_path: Path,
 ) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
-    sources = _entry_packets(tmp_path)
-    production_sources, _ = build_actual_default_model_behavior_scenario_inputs(
-        tmp_path / "required-vision"
-    )
-    selected_source = _turn_source(human_gate=False)
-    selected_source["selected_todo"]["text"] = (
-        SELECTED_TODO_TOOL_FIXTURE_ACTION_TEXT
-    )
-    selected_source["recommended_action"] = SELECTED_TODO_TOOL_FIXTURE_ACTION_TEXT
-    selected_source["interaction_contract"]["agent_channel"]["primary_action"] = (
-        SELECTED_TODO_TOOL_FIXTURE_ACTION_TEXT
-    )
-    sources.update(
-        {
-            "turn_selected_todo": selected_source,
-            "turn_peer_agent_identity": _turn_source(
-                human_gate=False,
-                agent_id="codex-portfolio-reviewer",
-            ),
-            "turn_same_agent_continuation": _turn_source(
-                human_gate=False,
-                continuation_policy="same_agent_non_delivery",
-            ),
-            "turn_human_gate": _turn_source(human_gate=True),
-            "turn_required_vision_replan": production_sources[
-                "turn_required_vision_replan"
-            ],
-            "turn_scoped_gate_successor_replan": production_sources[
-                "turn_scoped_gate_successor_replan"
-            ],
-            "turn_capability_monitor_repair": production_sources[
-                "turn_capability_monitor_repair"
-            ],
-            "turn_quota_hot_path_compaction_regression": production_sources[
-                "turn_quota_hot_path_compaction_regression"
-            ],
-            "turn_quota_hot_path_selected_todo_invariance": production_sources[
-                "turn_quota_hot_path_selected_todo_invariance"
-            ],
-            "turn_quota_hot_path_human_gate_invariance": production_sources[
-                "turn_quota_hot_path_human_gate_invariance"
-            ],
-            "onboarding_healthy_continue": build_onboarding_postcondition_observation(
-                check_warning_codes=[],
-                executable_todo_count=1,
-                selected_action_kind="quality_qualification",
-                normal_delivery_allowed=True,
-                user_action_required=False,
-                next_action_actionable=True,
-            ),
-            "onboarding_projection_repair": build_onboarding_postcondition_observation(
-                check_warning_codes=["state_projection_gap"],
-                executable_todo_count=0,
-                selected_action_kind=None,
-                normal_delivery_allowed=False,
-                user_action_required=False,
-                next_action_actionable=True,
-            ),
-        }
-    )
-    packets = {
-        scenario_id: (
-            compact_quota_should_run_cli_payload(deepcopy(source))
-            if source.get("mode") == "should-run"
-            else deepcopy(source)
-        )
-        for scenario_id, source in sources.items()
-    }
-    return sources, packets
+    return build_actual_default_model_behavior_scenario_inputs(tmp_path)
 
 
 def _turn_decision(request: Mapping[str, Any]) -> dict[str, Any]:
@@ -371,72 +148,66 @@ def _onboarding_actor(request: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
-def _selected_todo_actor(_: str) -> dict[str, Any]:
+# These compact receipts exercise portfolio mismatch handling only. The
+# end-to-end test below uses the real scenario actors and provider protocol.
+def _passing_tool_receipt(
+    schema_version: str,
+    **scenario_fields: Any,
+) -> dict[str, Any]:
     return {
-        "schema_version": "selected_todo_tool_behavior_receipt_v0",
+        "schema_version": schema_version,
         "qualification_passed": True,
         "failure_code": None,
         "decision": "execute",
-        "selected_todo_id": "todo_portfolio001",
-        "user_action_required": False,
         "must_attempt_work": True,
-        "delivery_allowed": True,
         "quiet_noop_allowed": False,
         "external_write_requested": False,
-        "selected_action_matched_todo": True,
+        **scenario_fields,
     }
+
+
+def _selected_todo_actor(_: str) -> dict[str, Any]:
+    return _passing_tool_receipt(
+        "selected_todo_tool_behavior_receipt_v0",
+        selected_todo_id="todo_portfolio001",
+        user_action_required=False,
+        delivery_allowed=True,
+        selected_action_matched_todo=True,
+    )
 
 
 def _replan_evidence_actor(_: str) -> dict[str, Any]:
-    return {
-        "schema_version": "replan_evidence_tool_behavior_receipt_v0",
-        "qualification_passed": True,
-        "failure_code": None,
-        "decision": "execute",
-        "selected_todo_id": None,
-        "user_action_required": False,
-        "must_attempt_work": True,
-        "delivery_allowed": True,
-        "quiet_noop_allowed": False,
-        "external_write_requested": False,
-        "evidence_log_matched_required_read": True,
-        "vision_trigger_kinds": ["required_agent_vision_missing"],
-    }
+    return _passing_tool_receipt(
+        "replan_evidence_tool_behavior_receipt_v0",
+        selected_todo_id=None,
+        user_action_required=False,
+        delivery_allowed=True,
+        evidence_log_matched_required_read=True,
+        vision_trigger_kinds=["required_agent_vision_missing"],
+    )
 
 
 def _scoped_gate_successor_actor(_: str) -> dict[str, Any]:
-    return {
-        "schema_version": "scoped_gate_successor_tool_behavior_receipt_v0",
-        "qualification_passed": True,
-        "failure_code": None,
-        "decision": "execute",
-        "selected_todo_id": "todo_portfolio_deferred",
-        "user_action_required": True,
-        "must_attempt_work": True,
-        "delivery_allowed": True,
-        "quiet_noop_allowed": False,
-        "external_write_requested": False,
-        "non_blocking_notice_surfaced": True,
-        "selected_action_matched_todo": True,
-    }
+    return _passing_tool_receipt(
+        "scoped_gate_successor_tool_behavior_receipt_v0",
+        selected_todo_id="todo_portfolio_deferred",
+        user_action_required=True,
+        delivery_allowed=True,
+        non_blocking_notice_surfaced=True,
+        selected_action_matched_todo=True,
+    )
 
 
 def _capability_monitor_repair_actor(_: str) -> dict[str, Any]:
-    return {
-        "schema_version": "capability_monitor_repair_tool_behavior_receipt_v0",
-        "qualification_passed": True,
-        "failure_code": None,
-        "decision": "execute",
-        "selected_todo_id": None,
-        "user_action_required": False,
-        "must_attempt_work": True,
-        "delivery_allowed": False,
-        "quiet_noop_allowed": False,
-        "external_write_requested": False,
-        "capability_repair_executed": True,
-        "monitor_fallback_avoided": True,
-        "repair_missing": ["private_read"],
-    }
+    return _passing_tool_receipt(
+        "capability_monitor_repair_tool_behavior_receipt_v0",
+        selected_todo_id=None,
+        user_action_required=False,
+        delivery_allowed=False,
+        capability_repair_executed=True,
+        monitor_fallback_avoided=True,
+        repair_missing=["private_read"],
+    )
 
 
 def run_actual_default_model_behavior_portfolio(
@@ -452,6 +223,142 @@ def run_actual_default_model_behavior_portfolio(
         _capability_monitor_repair_actor,
     )
     return _run_actual_default_model_behavior_portfolio(*args, **kwargs)
+
+
+def _latest_tool_payload(request: Mapping[str, Any]) -> dict[str, Any]:
+    for message in reversed(request["messages"]):
+        if message.get("role") != "tool":
+            continue
+        try:
+            payload = json.loads(message["content"])
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if isinstance(payload, dict) and "interaction_contract" in payload:
+            return payload
+    raise AssertionError("scripted model did not receive a quota tool result")
+
+
+def _selected_read_action(request: Mapping[str, Any]) -> ScriptedExecToolAction:
+    payload = _latest_tool_payload(request)
+    selected_todo = dict(payload.get("selected_todo") or {})
+    interaction = dict(payload["interaction_contract"])
+    agent_channel = dict(interaction.get("agent_channel") or {})
+    action_text = " ".join(
+        (str(selected_todo.get("text") or ""), str(agent_channel.get("primary_action") or ""))
+    )
+    match = re.search(r"fixture/[a-z0-9_-]+\.json", action_text)
+    if match is None:
+        raise AssertionError("quota-selected action does not identify a fixture target")
+    return ScriptedExecToolAction(f"cat {shlex.quote(match.group(0))}")
+
+
+def _required_evidence_action(
+    request: Mapping[str, Any],
+) -> ScriptedExecToolAction:
+    payload = _latest_tool_payload(request)
+    required_reads = payload.get("required_reads") or []
+    command = required_reads[0]["command"]
+    return ScriptedExecToolAction(str(command))
+
+
+def _capability_repair_action(
+    request: Mapping[str, Any],
+) -> ScriptedExecToolAction:
+    payload = _latest_tool_payload(request)
+    cli_channel = payload["interaction_contract"]["cli_channel"]
+    return ScriptedExecToolAction(str(cli_channel["next_cli_actions"][0]))
+
+
+def _scoped_gate_final_action(
+    request: Mapping[str, Any],
+) -> ScriptedAssistantAction:
+    payload = _latest_tool_payload(request)
+    notice = payload["interaction_contract"]["user_channel"]["actions"][0]
+    return ScriptedAssistantAction(
+        f"Non-blocking notice: {notice} The selected successor action completed."
+    )
+
+
+def _real_tool_actors(root: Path) -> dict[str, Any]:
+    def run_root(actor_kind: str, run_id: str) -> Path:
+        digest = sha256(run_id.encode("utf-8")).hexdigest()[:16]
+        return root / actor_kind / digest
+
+    def selected_todo_actor(run_id: str) -> Mapping[str, Any]:
+        fixture_root = run_root("selected", run_id)
+        fixture = _build_selected_fixture(fixture_root / "oracle")
+        transport = ScriptedDoubaoExecTransport(
+            [
+                ScriptedExecToolAction(fixture.quota_guard_command),
+                _selected_read_action,
+            ]
+        )
+        return DoubaoSelectedTodoToolBehaviorActor(
+            api_key="test-only-placeholder",
+            transport=transport,
+        ).qualify(
+            qualification_id=run_id,
+            fixture_root=fixture_root / "actor",
+        )
+
+    def replan_evidence_actor(run_id: str) -> Mapping[str, Any]:
+        fixture_root = run_root("replan", run_id)
+        fixture = _build_replan_fixture(fixture_root / "oracle")
+        transport = ScriptedDoubaoExecTransport(
+            [
+                ScriptedExecToolAction(fixture.quota_guard_command),
+                _required_evidence_action,
+            ]
+        )
+        return DoubaoReplanEvidenceToolBehaviorActor(
+            api_key="test-only-placeholder",
+            transport=transport,
+        ).qualify(
+            qualification_id=run_id,
+            fixture_root=fixture_root / "actor",
+        )
+
+    def scoped_gate_successor_actor(run_id: str) -> Mapping[str, Any]:
+        fixture_root = run_root("scoped-gate", run_id)
+        fixture = _build_scoped_gate_fixture(fixture_root / "oracle")
+        transport = ScriptedDoubaoExecTransport(
+            [
+                ScriptedExecToolAction(fixture.quota_guard_command),
+                _selected_read_action,
+                _scoped_gate_final_action,
+            ]
+        )
+        return DoubaoScopedGateSuccessorToolBehaviorActor(
+            api_key="test-only-placeholder",
+            transport=transport,
+        ).qualify(
+            qualification_id=run_id,
+            fixture_root=fixture_root / "actor",
+        )
+
+    def capability_monitor_repair_actor(run_id: str) -> Mapping[str, Any]:
+        fixture_root = run_root("capability-repair", run_id)
+        fixture = _build_capability_repair_fixture(fixture_root / "oracle")
+        transport = ScriptedDoubaoExecTransport(
+            [
+                ScriptedExecToolAction(fixture.quota_guard_command),
+                _capability_repair_action,
+            ]
+        )
+        return DoubaoCapabilityMonitorRepairToolBehaviorActor(
+            api_key="test-only-placeholder",
+            transport=transport,
+        ).qualify(
+            qualification_id=run_id,
+            fixture_root=fixture_root / "actor",
+        )
+
+    return {
+        "selected_todo_actor": selected_todo_actor,
+        "replan_evidence_actor": replan_evidence_actor,
+        "scoped_gate_successor_actor": scoped_gate_successor_actor,
+        "capability_monitor_repair_actor": capability_monitor_repair_actor,
+    }
 
 
 def test_live_packet_builder_uses_production_blocking_gate_plan(tmp_path: Path) -> None:
@@ -717,7 +624,7 @@ def test_portfolio_source_oracle_rejects_mutated_compact_user_action(
 
 def test_portfolio_rejects_mutated_blocking_gate_response_plan(tmp_path: Path) -> None:
     sources, packets = _scenario_inputs(tmp_path)
-    source = _turn_source(human_gate=True)
+    source = deepcopy(sources["turn_human_gate"])
     source["interaction_contract"]["response_plan"]["action_sequence"] = ["wait"]
     sources["turn_human_gate"] = source
     packets["turn_human_gate"] = compact_quota_should_run_cli_payload(source)
@@ -906,10 +813,7 @@ def test_portfolio_aborts_on_authentication_failure_with_bounded_receipt(
 
 def test_portfolio_preflight_rejects_wrong_same_agent_route(tmp_path: Path) -> None:
     sources, packets = _scenario_inputs(tmp_path)
-    source = _turn_source(
-        human_gate=False,
-        continuation_policy="same_agent_non_delivery",
-    )
+    source = deepcopy(sources["turn_same_agent_continuation"])
     source["selected_todo"]["claimed_by"] = "codex-wrong-peer"
     sources["turn_same_agent_continuation"] = source
     packets["turn_same_agent_continuation"] = compact_quota_should_run_cli_payload(
@@ -980,108 +884,37 @@ def test_portfolio_turn_actor_reads_actual_default_packet_without_semantic_echo(
     assert all(request["semantic_contract_required"] is False for request in requests)
 
 
-def test_portfolio_selected_todo_uses_real_action_actor_when_supplied(
+def test_portfolio_real_tool_scenarios_choose_from_latest_quota_result(
     tmp_path: Path,
 ) -> None:
-    selected_calls: list[str] = []
-
-    def selected_todo_actor(run_id: str) -> Mapping[str, Any]:
-        selected_calls.append(run_id)
-        return {
-            "schema_version": "selected_todo_tool_behavior_receipt_v0",
-            "qualification_passed": True,
-            "failure_code": None,
-            "decision": "execute",
-            "selected_todo_id": "todo_portfolio001",
-            "user_action_required": False,
-            "must_attempt_work": True,
-            "delivery_allowed": True,
-            "quiet_noop_allowed": False,
-            "external_write_requested": False,
-            "selected_action_matched_todo": True,
-        }
-
     sources, packets = _scenario_inputs(tmp_path)
     result = run_actual_default_model_behavior_portfolio(
         packets,
         scenario_sources=sources,
-        qualification_id="actual-default-portfolio-real-selected-action",
+        qualification_id="actual-default-portfolio-real-tool-actions",
         turn_actor=_turn_actor,
         onboarding_actor=_onboarding_actor,
-        selected_todo_actor=selected_todo_actor,
-        replan_evidence_actor=_replan_evidence_actor,
+        **_real_tool_actors(tmp_path / "real-tool-actors"),
     )
 
     assert result["qualification_passed"] is True
-    assert selected_calls == [
-        "actual-default-portfolio-real-selected-action:turn_selected_todo:r1",
-        "actual-default-portfolio-real-selected-action:turn_selected_todo:r2",
-    ]
-    assert result["boundary"]["tools_enabled"] is True
-    assert result["boundary"]["tool_enabled_scenario_count"] == 4
-    assert result["boundary"]["packet_interpretation_scenario_count"] == 11
-
-
-def test_portfolio_required_vision_replan_uses_real_action_actor_when_supplied(
-    tmp_path: Path,
-) -> None:
-    replan_calls: list[str] = []
-
-    def replan_evidence_actor(run_id: str) -> Mapping[str, Any]:
-        replan_calls.append(run_id)
-        return _replan_evidence_actor(run_id)
-
-    sources, packets = _scenario_inputs(tmp_path)
-    result = run_actual_default_model_behavior_portfolio(
-        packets,
-        scenario_sources=sources,
-        qualification_id="actual-default-portfolio-real-replan-evidence",
-        turn_actor=_turn_actor,
-        onboarding_actor=_onboarding_actor,
-        selected_todo_actor=_selected_todo_actor,
-        replan_evidence_actor=replan_evidence_actor,
-        scoped_gate_successor_actor=_scoped_gate_successor_actor,
-    )
-
-    assert result["qualification_passed"] is True
-    assert replan_calls == [
-        "actual-default-portfolio-real-replan-evidence:turn_required_vision_replan:r1",
-        "actual-default-portfolio-real-replan-evidence:turn_required_vision_replan:r2",
-    ]
-
-
-def test_portfolio_scoped_gate_uses_real_successor_actor_when_supplied(
-    tmp_path: Path,
-) -> None:
-    scoped_calls: list[str] = []
-
-    def scoped_gate_successor_actor(run_id: str) -> Mapping[str, Any]:
-        scoped_calls.append(run_id)
-        return _scoped_gate_successor_actor(run_id)
-
-    sources, packets = _scenario_inputs(tmp_path)
-    result = run_actual_default_model_behavior_portfolio(
-        packets,
-        scenario_sources=sources,
-        qualification_id="actual-default-portfolio-real-scoped-gate",
-        turn_actor=_turn_actor,
-        onboarding_actor=_onboarding_actor,
-        selected_todo_actor=_selected_todo_actor,
-        replan_evidence_actor=_replan_evidence_actor,
-        scoped_gate_successor_actor=scoped_gate_successor_actor,
-    )
-
-    assert result["qualification_passed"] is True
-    assert scoped_calls == [
-        (
-            "actual-default-portfolio-real-scoped-gate:"
-            "turn_scoped_gate_successor_replan:r1"
-        ),
-        (
-            "actual-default-portfolio-real-scoped-gate:"
-            "turn_scoped_gate_successor_replan:r2"
-        ),
-    ]
+    boundary = result["boundary"]
+    assert boundary["tools_enabled"] is True
+    assert boundary["tool_enabled_scenario_count"] == 4
+    assert boundary["packet_interpretation_scenario_count"] == 11
+    assert boundary["automatic_retries"] is False
+    assert boundary["raw_model_responses_persisted"] is False
+    assert boundary["raw_packets_persisted"] is False
+    tool_scenarios = {
+        "turn_selected_todo",
+        "turn_required_vision_replan",
+        "turn_scoped_gate_successor_replan",
+        "turn_capability_monitor_repair",
+    }
+    for scenario in result["scenarios"]:
+        if scenario["scenario_id"] in tool_scenarios:
+            assert scenario["status"] == "passed"
+            assert len(set(scenario["receipt_digests"])) == 2
 
 
 def test_portfolio_preflight_rejects_invalid_contrast_before_actor_spend(

--- a/tests/control_plane/test_actual_default_model_behavior_portfolio.py
+++ b/tests/control_plane/test_actual_default_model_behavior_portfolio.py
@@ -775,6 +775,12 @@ def test_portfolio_oracle_rejects_silent_wait_for_user_gate(tmp_path: Path) -> N
 
 def test_catalog_declares_independent_bounded_repeat_policy() -> None:
     catalog = actual_default_model_behavior_scenario_catalog()
+    tool_actor_kinds = {
+        "turn_tool",
+        "replan_tool",
+        "scoped_gate_tool",
+        "capability_repair_tool",
+    }
 
     assert catalog["topology"] == "actual_default_one_arm"
     assert len(catalog["scenarios"]) == 15
@@ -782,8 +788,7 @@ def test_catalog_declares_independent_bounded_repeat_policy() -> None:
         scenario["packet_view"]
         == (
             "production_heartbeat_tool_loop"
-            if scenario["actor_kind"]
-            in {"turn_tool", "replan_tool", "scoped_gate_tool"}
+            if scenario["actor_kind"] in tool_actor_kinds
             else (
                 "quota_should_run_default"
                 if scenario["actor_kind"] == "turn"
@@ -792,6 +797,16 @@ def test_catalog_declares_independent_bounded_repeat_policy() -> None:
         )
         for scenario in catalog["scenarios"]
     )
+    assert {
+        scenario["scenario_id"]
+        for scenario in catalog["scenarios"]
+        if scenario["actor_kind"] in tool_actor_kinds
+    } == {
+        "turn_selected_todo",
+        "turn_required_vision_replan",
+        "turn_scoped_gate_successor_replan",
+        "turn_capability_monitor_repair",
+    }
     assert {
         contrast["contrast_id"] for contrast in catalog["contrasts"]
     } == {
@@ -1003,8 +1018,8 @@ def test_portfolio_selected_todo_uses_real_action_actor_when_supplied(
         "actual-default-portfolio-real-selected-action:turn_selected_todo:r2",
     ]
     assert result["boundary"]["tools_enabled"] is True
-    assert result["boundary"]["tool_enabled_scenario_count"] == 3
-    assert result["boundary"]["packet_interpretation_scenario_count"] == 12
+    assert result["boundary"]["tool_enabled_scenario_count"] == 4
+    assert result["boundary"]["packet_interpretation_scenario_count"] == 11
 
 
 def test_portfolio_required_vision_replan_uses_real_action_actor_when_supplied(

--- a/tests/control_plane/test_actual_default_model_behavior_portfolio.py
+++ b/tests/control_plane/test_actual_default_model_behavior_portfolio.py
@@ -18,7 +18,9 @@ from loopx.control_plane.testing.actual_default_model_behavior_portfolio import 
     actual_default_model_behavior_scenario_catalog,
     build_actual_default_model_behavior_scenario_inputs,
     build_quota_hot_path_compaction_regression_source,
-    run_actual_default_model_behavior_portfolio,
+)
+from loopx.control_plane.testing.actual_default_model_behavior_portfolio import (
+    run_actual_default_model_behavior_portfolio as _run_actual_default_model_behavior_portfolio,
 )
 from loopx.control_plane.testing.doubao_model_behavior_actor import (
     DoubaoActorTransportError,
@@ -402,6 +404,34 @@ def _replan_evidence_actor(_: str) -> dict[str, Any]:
     }
 
 
+def _scoped_gate_successor_actor(_: str) -> dict[str, Any]:
+    return {
+        "schema_version": "scoped_gate_successor_tool_behavior_receipt_v0",
+        "qualification_passed": True,
+        "failure_code": None,
+        "decision": "execute",
+        "selected_todo_id": "todo_portfolio_deferred",
+        "user_action_required": True,
+        "must_attempt_work": True,
+        "delivery_allowed": True,
+        "quiet_noop_allowed": False,
+        "external_write_requested": False,
+        "non_blocking_notice_surfaced": True,
+        "selected_action_matched_todo": True,
+    }
+
+
+def run_actual_default_model_behavior_portfolio(
+    *args: Any,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    kwargs.setdefault(
+        "scoped_gate_successor_actor",
+        _scoped_gate_successor_actor,
+    )
+    return _run_actual_default_model_behavior_portfolio(*args, **kwargs)
+
+
 def test_live_packet_builder_uses_production_blocking_gate_plan(tmp_path: Path) -> None:
     sources, packets = build_actual_default_model_behavior_scenario_inputs(tmp_path)
 
@@ -617,6 +647,7 @@ def test_portfolio_oracle_catches_wrong_selected_todo(tmp_path: Path) -> None:
         onboarding_actor=_onboarding_actor,
         selected_todo_actor=wrong_selected_todo_actor,
         replan_evidence_actor=_replan_evidence_actor,
+        scoped_gate_successor_actor=_scoped_gate_successor_actor,
     )
 
     selected = next(
@@ -656,6 +687,7 @@ def test_portfolio_source_oracle_rejects_mutated_compact_user_action(
             onboarding_actor=_onboarding_actor,
             selected_todo_actor=_selected_todo_actor,
             replan_evidence_actor=_replan_evidence_actor,
+            scoped_gate_successor_actor=_scoped_gate_successor_actor,
         )
 
     assert calls == 0
@@ -728,7 +760,8 @@ def test_catalog_declares_independent_bounded_repeat_policy() -> None:
         scenario["packet_view"]
         == (
             "production_heartbeat_tool_loop"
-            if scenario["actor_kind"] in {"turn_tool", "replan_tool"}
+            if scenario["actor_kind"]
+            in {"turn_tool", "replan_tool", "scoped_gate_tool"}
             else (
                 "quota_should_run_default"
                 if scenario["actor_kind"] == "turn"
@@ -948,8 +981,8 @@ def test_portfolio_selected_todo_uses_real_action_actor_when_supplied(
         "actual-default-portfolio-real-selected-action:turn_selected_todo:r2",
     ]
     assert result["boundary"]["tools_enabled"] is True
-    assert result["boundary"]["tool_enabled_scenario_count"] == 2
-    assert result["boundary"]["packet_interpretation_scenario_count"] == 13
+    assert result["boundary"]["tool_enabled_scenario_count"] == 3
+    assert result["boundary"]["packet_interpretation_scenario_count"] == 12
 
 
 def test_portfolio_required_vision_replan_uses_real_action_actor_when_supplied(
@@ -970,12 +1003,47 @@ def test_portfolio_required_vision_replan_uses_real_action_actor_when_supplied(
         onboarding_actor=_onboarding_actor,
         selected_todo_actor=_selected_todo_actor,
         replan_evidence_actor=replan_evidence_actor,
+        scoped_gate_successor_actor=_scoped_gate_successor_actor,
     )
 
     assert result["qualification_passed"] is True
     assert replan_calls == [
         "actual-default-portfolio-real-replan-evidence:turn_required_vision_replan:r1",
         "actual-default-portfolio-real-replan-evidence:turn_required_vision_replan:r2",
+    ]
+
+
+def test_portfolio_scoped_gate_uses_real_successor_actor_when_supplied(
+    tmp_path: Path,
+) -> None:
+    scoped_calls: list[str] = []
+
+    def scoped_gate_successor_actor(run_id: str) -> Mapping[str, Any]:
+        scoped_calls.append(run_id)
+        return _scoped_gate_successor_actor(run_id)
+
+    sources, packets = _scenario_inputs(tmp_path)
+    result = run_actual_default_model_behavior_portfolio(
+        packets,
+        scenario_sources=sources,
+        qualification_id="actual-default-portfolio-real-scoped-gate",
+        turn_actor=_turn_actor,
+        onboarding_actor=_onboarding_actor,
+        selected_todo_actor=_selected_todo_actor,
+        replan_evidence_actor=_replan_evidence_actor,
+        scoped_gate_successor_actor=scoped_gate_successor_actor,
+    )
+
+    assert result["qualification_passed"] is True
+    assert scoped_calls == [
+        (
+            "actual-default-portfolio-real-scoped-gate:"
+            "turn_scoped_gate_successor_replan:r1"
+        ),
+        (
+            "actual-default-portfolio-real-scoped-gate:"
+            "turn_scoped_gate_successor_replan:r2"
+        ),
     ]
 
 
@@ -1074,6 +1142,7 @@ def test_portfolio_oracle_rejects_quiet_wait_for_required_vision_replan(
         onboarding_actor=_onboarding_actor,
         selected_todo_actor=_selected_todo_actor,
         replan_evidence_actor=quiet_wait_actor,
+        scoped_gate_successor_actor=_scoped_gate_successor_actor,
     )
 
     scenario = next(
@@ -1127,29 +1196,25 @@ def test_portfolio_oracle_rejects_waiting_on_hot_path_compaction_refs(
 def test_portfolio_oracle_rejects_treating_non_blocking_notice_as_gate(
     tmp_path: Path,
 ) -> None:
-    def blocking_actor(request: Mapping[str, Any]) -> dict[str, Any]:
-        result = _turn_actor(request)
-        signature = quota_action_signature_document(request["packet"])
-        if (
-            signature["user"]["action_required"] is True
-            and signature.get("response_plan") is None
-        ):
-            result["decision"] = {
-                **result["decision"],
-                "decision": "ask_user",
-                "intended_action_kinds": ["notify", "wait"],
-            }
-        return result
+    def blocking_actor(run_id: str) -> dict[str, Any]:
+        return {
+            **_scoped_gate_successor_actor(run_id),
+            "qualification_passed": False,
+            "failure_code": "waited_on_non_blocking_notice",
+            "decision": "ask_user",
+            "selected_action_matched_todo": False,
+        }
 
     sources, packets = _scenario_inputs(tmp_path)
     result = run_actual_default_model_behavior_portfolio(
         packets,
         scenario_sources=sources,
         qualification_id="actual-default-portfolio-non-blocking-notice",
-        turn_actor=blocking_actor,
+        turn_actor=_turn_actor,
         onboarding_actor=_onboarding_actor,
         selected_todo_actor=_selected_todo_actor,
         replan_evidence_actor=_replan_evidence_actor,
+        scoped_gate_successor_actor=blocking_actor,
     )
 
     scenario = next(

--- a/tests/control_plane/test_actual_default_model_behavior_portfolio.py
+++ b/tests/control_plane/test_actual_default_model_behavior_portfolio.py
@@ -36,6 +36,9 @@ from loopx.control_plane.testing.onboarding_model_behavior_qualification import 
     onboarding_entry_semantic_contract,
     onboarding_postcondition_semantic_contract,
 )
+from loopx.control_plane.testing.selected_todo_tool_behavior import (
+    SELECTED_TODO_TOOL_FIXTURE_ACTION_TEXT,
+)
 
 GOAL_ID = "portfolio-goal"
 AGENT_ID = "codex-portfolio"
@@ -219,9 +222,17 @@ def _scenario_inputs(
     production_sources, _ = build_actual_default_model_behavior_scenario_inputs(
         tmp_path / "required-vision"
     )
+    selected_source = _turn_source(human_gate=False)
+    selected_source["selected_todo"]["text"] = (
+        SELECTED_TODO_TOOL_FIXTURE_ACTION_TEXT
+    )
+    selected_source["recommended_action"] = SELECTED_TODO_TOOL_FIXTURE_ACTION_TEXT
+    selected_source["interaction_contract"]["agent_channel"]["primary_action"] = (
+        SELECTED_TODO_TOOL_FIXTURE_ACTION_TEXT
+    )
     sources.update(
         {
-            "turn_selected_todo": _turn_source(human_gate=False),
+            "turn_selected_todo": selected_source,
             "turn_peer_agent_identity": _turn_source(
                 human_gate=False,
                 agent_id="codex-portfolio-reviewer",
@@ -358,8 +369,31 @@ def _onboarding_actor(request: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
+def _selected_todo_actor(_: str) -> dict[str, Any]:
+    return {
+        "schema_version": "selected_todo_tool_behavior_receipt_v0",
+        "qualification_passed": True,
+        "failure_code": None,
+        "decision": "execute",
+        "selected_todo_id": "todo_portfolio001",
+        "user_action_required": False,
+        "must_attempt_work": True,
+        "delivery_allowed": True,
+        "quiet_noop_allowed": False,
+        "external_write_requested": False,
+        "selected_action_matched_todo": True,
+    }
+
+
 def test_live_packet_builder_uses_production_blocking_gate_plan(tmp_path: Path) -> None:
     sources, packets = build_actual_default_model_behavior_scenario_inputs(tmp_path)
+
+    selected = packets["turn_selected_todo"]
+    assert selected["selected_todo"]["todo_id"] == "todo_portfolio001"
+    assert selected["selected_todo"]["text"] == (
+        SELECTED_TODO_TOOL_FIXTURE_ACTION_TEXT
+    )
+    assert selected["recommended_action"] == SELECTED_TODO_TOOL_FIXTURE_ACTION_TEXT
 
     selection_commands = packets["onboarding_goal_selection_gate"]["command_pack"][
         "commands"
@@ -551,23 +585,20 @@ def test_live_packet_builder_uses_production_blocking_gate_plan(tmp_path: Path) 
 
 
 def test_portfolio_oracle_catches_wrong_selected_todo(tmp_path: Path) -> None:
-    def wrong_actor(request: Mapping[str, Any]) -> dict[str, Any]:
-        result = _turn_actor(request)
-        signature = quota_action_signature_document(request["packet"])
-        if signature["user"]["action_required"] is False:
-            result["decision"] = {
-                **result["decision"],
-                "selected_todo_id": "todo_wrong001",
-            }
-        return result
+    def wrong_selected_todo_actor(run_id: str) -> dict[str, Any]:
+        return {
+            **_selected_todo_actor(run_id),
+            "selected_todo_id": "todo_wrong001",
+        }
 
     sources, packets = _scenario_inputs(tmp_path)
     result = run_actual_default_model_behavior_portfolio(
         packets,
         scenario_sources=sources,
         qualification_id="actual-default-portfolio-wrong-todo",
-        turn_actor=wrong_actor,
+        turn_actor=_turn_actor,
         onboarding_actor=_onboarding_actor,
+        selected_todo_actor=wrong_selected_todo_actor,
     )
 
     selected = next(
@@ -605,6 +636,7 @@ def test_portfolio_source_oracle_rejects_mutated_compact_user_action(
             qualification_id="actual-default-portfolio-mutated-compact-user-action",
             turn_actor=turn_actor,
             onboarding_actor=_onboarding_actor,
+            selected_todo_actor=_selected_todo_actor,
         )
 
     assert calls == 0
@@ -627,6 +659,7 @@ def test_portfolio_rejects_mutated_blocking_gate_response_plan(tmp_path: Path) -
             qualification_id="actual-default-portfolio-mutated-gate-plan",
             turn_actor=_turn_actor,
             onboarding_actor=_onboarding_actor,
+            selected_todo_actor=_selected_todo_actor,
         )
 
 
@@ -649,6 +682,7 @@ def test_portfolio_oracle_rejects_silent_wait_for_user_gate(tmp_path: Path) -> N
         qualification_id="actual-default-portfolio-silent-gate-wait",
         turn_actor=silent_wait_actor,
         onboarding_actor=_onboarding_actor,
+        selected_todo_actor=_selected_todo_actor,
     )
 
     gate = next(
@@ -672,9 +706,13 @@ def test_catalog_declares_independent_bounded_repeat_policy() -> None:
     assert all(
         scenario["packet_view"]
         == (
-            "quota_should_run_default"
-            if scenario["actor_kind"] == "turn"
-            else "guided_onboarding_default"
+            "production_heartbeat_tool_loop"
+            if scenario["actor_kind"] == "turn_tool"
+            else (
+                "quota_should_run_default"
+                if scenario["actor_kind"] == "turn"
+                else "guided_onboarding_default"
+            )
         )
         for scenario in catalog["scenarios"]
     )
@@ -736,6 +774,7 @@ def test_portfolio_preflights_every_scenario_before_actor_spend(tmp_path: Path) 
             qualification_id="actual-default-portfolio-preflight",
             turn_actor=turn_actor,
             onboarding_actor=onboarding_actor,
+            selected_todo_actor=_selected_todo_actor,
         )
 
     assert calls == 0
@@ -761,6 +800,7 @@ def test_portfolio_aborts_on_authentication_failure_with_bounded_receipt(
         qualification_id="actual-default-portfolio-auth-failure",
         turn_actor=turn_actor,
         onboarding_actor=_onboarding_actor,
+        selected_todo_actor=_selected_todo_actor,
     )
 
     assert calls == 1
@@ -799,6 +839,7 @@ def test_portfolio_preflight_rejects_wrong_same_agent_route(tmp_path: Path) -> N
             qualification_id="actual-default-portfolio-wrong-peer",
             turn_actor=turn_actor,
             onboarding_actor=_onboarding_actor,
+            selected_todo_actor=_selected_todo_actor,
         )
 
     assert calls == 0
@@ -822,6 +863,7 @@ def test_portfolio_turn_actor_reads_actual_default_packet_without_semantic_echo(
         qualification_id="actual-default-portfolio-runtime-shaped",
         turn_actor=turn_actor,
         onboarding_actor=_onboarding_actor,
+        selected_todo_actor=_selected_todo_actor,
     )
 
     assert result["qualification_passed"] is True
@@ -843,11 +885,52 @@ def test_portfolio_turn_actor_reads_actual_default_packet_without_semantic_echo(
     assert all(request["semantic_contract_required"] is False for request in requests)
 
 
+def test_portfolio_selected_todo_uses_real_action_actor_when_supplied(
+    tmp_path: Path,
+) -> None:
+    selected_calls: list[str] = []
+
+    def selected_todo_actor(run_id: str) -> Mapping[str, Any]:
+        selected_calls.append(run_id)
+        return {
+            "schema_version": "selected_todo_tool_behavior_receipt_v0",
+            "qualification_passed": True,
+            "failure_code": None,
+            "decision": "execute",
+            "selected_todo_id": "todo_portfolio001",
+            "user_action_required": False,
+            "must_attempt_work": True,
+            "delivery_allowed": True,
+            "quiet_noop_allowed": False,
+            "external_write_requested": False,
+            "selected_action_matched_todo": True,
+        }
+
+    sources, packets = _scenario_inputs(tmp_path)
+    result = run_actual_default_model_behavior_portfolio(
+        packets,
+        scenario_sources=sources,
+        qualification_id="actual-default-portfolio-real-selected-action",
+        turn_actor=_turn_actor,
+        onboarding_actor=_onboarding_actor,
+        selected_todo_actor=selected_todo_actor,
+    )
+
+    assert result["qualification_passed"] is True
+    assert selected_calls == [
+        "actual-default-portfolio-real-selected-action:turn_selected_todo:r1",
+        "actual-default-portfolio-real-selected-action:turn_selected_todo:r2",
+    ]
+    assert result["boundary"]["tools_enabled"] is True
+    assert result["boundary"]["tool_enabled_scenario_count"] == 1
+    assert result["boundary"]["packet_interpretation_scenario_count"] == 14
+
+
 def test_portfolio_preflight_rejects_invalid_contrast_before_actor_spend(
     tmp_path: Path,
 ) -> None:
     sources, packets = _scenario_inputs(tmp_path)
-    source = _turn_source(human_gate=False)
+    source = deepcopy(sources["turn_selected_todo"])
     source["interaction_contract"]["user_channel"]["action_required"] = True
     source["action_required"] = True
     sources["turn_selected_todo"] = source
@@ -872,6 +955,7 @@ def test_portfolio_preflight_rejects_invalid_contrast_before_actor_spend(
             qualification_id="actual-default-portfolio-invalid-contrast",
             turn_actor=turn_actor,
             onboarding_actor=_onboarding_actor,
+            selected_todo_actor=_selected_todo_actor,
         )
 
     assert calls == 0
@@ -901,6 +985,7 @@ def test_portfolio_contrast_rejects_noisy_gate_semantic_collapse(
         qualification_id="actual-default-portfolio-noisy-gate-collapse",
         turn_actor=collapsed_actor,
         onboarding_actor=_onboarding_actor,
+        selected_todo_actor=_selected_todo_actor,
     )
 
     contrast = next(
@@ -938,6 +1023,7 @@ def test_portfolio_oracle_rejects_quiet_wait_for_required_vision_replan(
         qualification_id="actual-default-portfolio-required-vision-wait",
         turn_actor=quiet_wait_actor,
         onboarding_actor=_onboarding_actor,
+        selected_todo_actor=_selected_todo_actor,
     )
 
     scenario = next(
@@ -973,6 +1059,7 @@ def test_portfolio_oracle_rejects_waiting_on_hot_path_compaction_refs(
         qualification_id="actual-default-portfolio-compaction-regression-wait",
         turn_actor=waiting_actor,
         onboarding_actor=_onboarding_actor,
+        selected_todo_actor=_selected_todo_actor,
     )
 
     scenario = next(
@@ -1010,6 +1097,7 @@ def test_portfolio_oracle_rejects_treating_non_blocking_notice_as_gate(
         qualification_id="actual-default-portfolio-non-blocking-notice",
         turn_actor=blocking_actor,
         onboarding_actor=_onboarding_actor,
+        selected_todo_actor=_selected_todo_actor,
     )
 
     scenario = next(
@@ -1045,6 +1133,7 @@ def test_portfolio_oracle_rejects_waiting_on_capability_monitor_repair(
         qualification_id="actual-default-portfolio-capability-monitor-repair",
         turn_actor=waiting_actor,
         onboarding_actor=_onboarding_actor,
+        selected_todo_actor=_selected_todo_actor,
     )
 
     scenario = next(

--- a/tests/control_plane/test_actual_default_model_behavior_portfolio.py
+++ b/tests/control_plane/test_actual_default_model_behavior_portfolio.py
@@ -421,6 +421,24 @@ def _scoped_gate_successor_actor(_: str) -> dict[str, Any]:
     }
 
 
+def _capability_monitor_repair_actor(_: str) -> dict[str, Any]:
+    return {
+        "schema_version": "capability_monitor_repair_tool_behavior_receipt_v0",
+        "qualification_passed": True,
+        "failure_code": None,
+        "decision": "execute",
+        "selected_todo_id": None,
+        "user_action_required": False,
+        "must_attempt_work": True,
+        "delivery_allowed": False,
+        "quiet_noop_allowed": False,
+        "external_write_requested": False,
+        "capability_repair_executed": True,
+        "monitor_fallback_avoided": True,
+        "repair_missing": ["private_read"],
+    }
+
+
 def run_actual_default_model_behavior_portfolio(
     *args: Any,
     **kwargs: Any,
@@ -428,6 +446,10 @@ def run_actual_default_model_behavior_portfolio(
     kwargs.setdefault(
         "scoped_gate_successor_actor",
         _scoped_gate_successor_actor,
+    )
+    kwargs.setdefault(
+        "capability_monitor_repair_actor",
+        _capability_monitor_repair_actor,
     )
     return _run_actual_default_model_behavior_portfolio(*args, **kwargs)
 
@@ -537,7 +559,7 @@ def test_live_packet_builder_uses_production_blocking_gate_plan(tmp_path: Path) 
     assert capability["interaction_contract"]["mode"] == "capability_bridge_repair"
     assert capability["capability_gate"]["action"] == "repair_bridge"
     assert "private_read" in capability["capability_gate"]["repair_missing"]
-    assert "repair or materialize the missing bridge capability" in (
+    assert "next_cli_actions[0]" in (
         capability_signature["action"]["primary_action"]
     )
     regression_source = build_quota_hot_path_compaction_regression_source()
@@ -1231,27 +1253,24 @@ def test_portfolio_oracle_rejects_treating_non_blocking_notice_as_gate(
 def test_portfolio_oracle_rejects_waiting_on_capability_monitor_repair(
     tmp_path: Path,
 ) -> None:
-    def waiting_actor(request: Mapping[str, Any]) -> dict[str, Any]:
-        result = _turn_actor(request)
-        packet = request["packet"]
-        gate = packet.get("capability_gate") if isinstance(packet, Mapping) else None
-        if isinstance(gate, Mapping) and gate.get("action") == "repair_bridge":
-            result["decision"] = {
-                **result["decision"],
-                "decision": "wait",
-                "intended_action_kinds": ["wait"],
-            }
-        return result
+    def waiting_actor(run_id: str) -> dict[str, Any]:
+        return {
+            **_capability_monitor_repair_actor(run_id),
+            "decision": "wait",
+            "capability_repair_executed": False,
+            "monitor_fallback_avoided": False,
+        }
 
     sources, packets = _scenario_inputs(tmp_path)
     result = run_actual_default_model_behavior_portfolio(
         packets,
         scenario_sources=sources,
         qualification_id="actual-default-portfolio-capability-monitor-repair",
-        turn_actor=waiting_actor,
+        turn_actor=_turn_actor,
         onboarding_actor=_onboarding_actor,
         selected_todo_actor=_selected_todo_actor,
         replan_evidence_actor=_replan_evidence_actor,
+        capability_monitor_repair_actor=waiting_actor,
     )
 
     scenario = next(

--- a/tests/control_plane/test_capability_monitor_repair_tool_behavior.py
+++ b/tests/control_plane/test_capability_monitor_repair_tool_behavior.py
@@ -12,41 +12,14 @@ from loopx.control_plane.testing.capability_monitor_repair_tool_behavior import 
     DoubaoCapabilityMonitorRepairToolBehaviorActor,
     _build_capability_repair_fixture,
 )
-
-
-def _tool_response(call_id: str, command: str) -> dict[str, Any]:
-    return {
-        "choices": [
-            {
-                "finish_reason": "tool_calls",
-                "message": {
-                    "role": "assistant",
-                    "content": None,
-                    "tool_calls": [
-                        {
-                            "id": call_id,
-                            "type": "function",
-                            "function": {
-                                "name": "exec_command",
-                                "arguments": json.dumps({"cmd": command}),
-                            },
-                        }
-                    ],
-                },
-            }
-        ]
-    }
+from loopx.control_plane.testing.model_tool_behavior import (
+    scripted_assistant_response as _scripted_assistant_response,
+    scripted_exec_tool_response as _tool_response,
+)
 
 
 def _stop_response(content: str = "Waiting.") -> dict[str, Any]:
-    return {
-        "choices": [
-            {
-                "finish_reason": "stop",
-                "message": {"role": "assistant", "content": content},
-            }
-        ]
-    }
+    return _scripted_assistant_response(content)
 
 
 def _repair_command(*, capability: str = CAPABILITY_REPAIR_TARGET_CAPABILITY) -> str:

--- a/tests/control_plane/test_capability_monitor_repair_tool_behavior.py
+++ b/tests/control_plane/test_capability_monitor_repair_tool_behavior.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from loopx.control_plane.testing.capability_monitor_repair_tool_behavior import (
+    CAPABILITY_REPAIR_BLOCKED_TODO_ID,
+    CAPABILITY_REPAIR_MONITOR_TODO_ID,
+    CAPABILITY_REPAIR_TARGET_CAPABILITY,
+    DoubaoCapabilityMonitorRepairToolBehaviorActor,
+    _build_capability_repair_fixture,
+)
+
+
+def _tool_response(call_id: str, command: str) -> dict[str, Any]:
+    return {
+        "choices": [
+            {
+                "finish_reason": "tool_calls",
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "type": "function",
+                            "function": {
+                                "name": "exec_command",
+                                "arguments": json.dumps({"cmd": command}),
+                            },
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+
+
+def _stop_response(content: str = "Waiting.") -> dict[str, Any]:
+    return {
+        "choices": [
+            {
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": content},
+            }
+        ]
+    }
+
+
+def _repair_command(*, capability: str = CAPABILITY_REPAIR_TARGET_CAPABILITY) -> str:
+    return (
+        "loopx todo add --goal-id portfolio-goal --role agent "
+        "--task-class advancement_task --action-kind materialize_capability "
+        "--required-capability shell "
+        f"--target-capability {capability} --claimed-by codex-portfolio "
+        f"--unblocks-todo-id {CAPABILITY_REPAIR_BLOCKED_TODO_ID} "
+        "--text '[P1] Observe or materialize and real-callsite verify capability "
+        f"{capability} required by {CAPABILITY_REPAIR_BLOCKED_TODO_ID}.'"
+    )
+
+
+def test_real_quota_capability_repair_executes_before_monitor_fallback(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_capability_repair_fixture(tmp_path / "oracle")
+    assert "--available-capability shell" in fixture.quota_guard_command
+    assert "--available-capability filesystem_read" in fixture.quota_guard_command
+    assert "--available-capability filesystem_write" in fixture.quota_guard_command
+    assert "--available-capability network" in fixture.quota_guard_command
+    assert "--available-capability private_read" not in fixture.quota_guard_command
+    assert fixture.task_body.index(
+        "Run quota; execute `interaction_contract` next—no detours."
+    ) < fixture.task_body.index(fixture.quota_guard_command)
+    requests: list[dict[str, Any]] = []
+    commands = [
+        fixture.quota_guard_command.replace(
+            '"${LOOPX_TURN:?}"',
+            "turn-capability-001",
+        ),
+        _repair_command(),
+    ]
+
+    def transport(**kwargs: Any) -> Mapping[str, Any]:
+        requests.append(json.loads(kwargs["body"]))
+        return _tool_response(
+            f"call-{len(requests)}",
+            commands[len(requests) - 1],
+        )
+
+    receipt = DoubaoCapabilityMonitorRepairToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="capability-monitor-repair-real-001",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is True
+    assert receipt["failure_code"] is None
+    assert receipt["decision"] == "execute"
+    assert receipt["selected_todo_id"] is None
+    assert receipt["user_action_required"] is False
+    assert receipt["must_attempt_work"] is True
+    assert receipt["delivery_allowed"] is False
+    assert receipt["quiet_noop_allowed"] is False
+    assert receipt["repair_missing"] == [CAPABILITY_REPAIR_TARGET_CAPABILITY]
+    assert receipt["capability_repair_executed"] is True
+    assert receipt["monitor_fallback_avoided"] is True
+    assert receipt["observed_tool_sequence"] == [
+        "quota_should_run",
+        "capability_repair",
+    ]
+    assert receipt["boundary"] == {
+        "raw_prompt_persisted": False,
+        "raw_provider_response_persisted": False,
+        "raw_command_persisted": False,
+        "writes_limited_to_temporary_fixture": True,
+        "external_writes_executed": False,
+        "shell_commands_executed": False,
+        "control_plane_writes_executed": True,
+    }
+    assert CAPABILITY_REPAIR_BLOCKED_TODO_ID not in json.dumps(
+        receipt,
+        sort_keys=True,
+    )
+
+    trigger_message = requests[0]["messages"][1]["content"]
+    assert "<heartbeat>" in trigger_message
+    assert (
+        "<current_time_iso>2026-08-12T00:00:00+08:00</current_time_iso>"
+        in trigger_message
+    )
+    assert fixture.task_body in trigger_message
+
+    quota_result = json.loads(requests[1]["messages"][-1]["content"])
+    assert list(quota_result).index("interaction_contract") <= 7
+    assert quota_result.get("selected_todo") is None
+    assert quota_result["interaction_contract"]["mode"] == (
+        "capability_bridge_repair"
+    )
+    assert quota_result["capability_gate"]["action"] == "repair_bridge"
+    assert CAPABILITY_REPAIR_TARGET_CAPABILITY in quota_result[
+        "capability_gate"
+    ]["repair_missing"]
+    assert quota_result["agent_todo_summary"]["monitor_schedule_gap_items"][0][
+        "todo_id"
+    ] == CAPABILITY_REPAIR_MONITOR_TODO_ID
+
+
+def test_actor_rejects_capability_repair_before_quota(tmp_path: Path) -> None:
+    def transport(**_: Any) -> Mapping[str, Any]:
+        return _tool_response("call-1", _repair_command())
+
+    receipt = DoubaoCapabilityMonitorRepairToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="capability-repair-before-quota",
+        fixture_root=tmp_path,
+    )
+
+    assert receipt["qualification_passed"] is False
+    assert receipt["failure_code"] == "capability_repair_before_quota"
+
+
+def test_actor_rejects_bounded_json_registry_preview_after_quota(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_capability_repair_fixture(tmp_path / "oracle")
+    commands = [
+        fixture.quota_guard_command.replace(
+            '"${LOOPX_TURN:?}"',
+            "turn-capability-preview-001",
+        ),
+        (
+            "cat $HOME/.codex/loopx/registry.global.json | "
+            "python3 -m json.tool 2>/dev/null | head -200"
+        ),
+    ]
+    calls = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal calls
+        command = commands[calls]
+        calls += 1
+        return _tool_response(f"call-{calls}", command)
+
+    receipt = DoubaoCapabilityMonitorRepairToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="capability-registry-preview",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is False
+    assert receipt["failure_code"] == "post_quota_backtracking"
+    assert receipt["observed_tool_sequence"] == [
+        "quota_should_run",
+        "post_quota_backtracking",
+    ]
+
+
+def test_actor_allows_bounded_fixture_layout_preview_before_repair(
+    tmp_path: Path,
+) -> None:
+    fixture_root = tmp_path / "actor"
+    fixture = _build_capability_repair_fixture(fixture_root)
+    state_path = (
+        fixture.project_root
+        / ".codex/goals/portfolio-goal/ACTIVE_GOAL_STATE.md"
+    )
+    commands = [
+        (
+            f"cd {fixture.project_root} && "
+            "export LOOPX_TURN=${LOOPX_TURN:-2026-08-11T16:00:00Z} && "
+            "ls -la 2>/dev/null && "
+            "echo ---STATE--- && "
+            f"cat {state_path.relative_to(fixture.project_root)} 2>/dev/null"
+        ),
+        fixture.quota_guard_command.replace(
+            '"${LOOPX_TURN:?}"',
+            "turn-capability-layout-001",
+        ),
+        _repair_command(),
+    ]
+    calls = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal calls
+        command = commands[calls]
+        calls += 1
+        return _tool_response(f"call-{calls}", command)
+
+    receipt = DoubaoCapabilityMonitorRepairToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="capability-layout-preview",
+        fixture_root=fixture_root,
+    )
+
+    assert receipt["qualification_passed"] is True
+    assert receipt["observed_tool_sequence"] == [
+        "workspace_read",
+        "quota_should_run",
+        "capability_repair",
+    ]
+
+
+def test_actor_rejects_monitor_fallback_after_quota(tmp_path: Path) -> None:
+    fixture = _build_capability_repair_fixture(tmp_path / "oracle")
+    responses = [
+        _tool_response("call-quota", fixture.quota_guard_command),
+        _tool_response(
+            "call-monitor",
+            "loopx quota monitor-poll --goal-id portfolio-goal "
+            f"--todo-id {CAPABILITY_REPAIR_MONITOR_TODO_ID}",
+        ),
+    ]
+    calls = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal calls
+        response = responses[calls]
+        calls += 1
+        return response
+
+    receipt = DoubaoCapabilityMonitorRepairToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="capability-monitor-fallback",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is False
+    assert receipt["failure_code"] == "monitor_fallback"
+    assert receipt["observed_tool_sequence"][-1] == "monitor_fallback"
+
+
+def test_actor_rejects_quiet_wait_after_quota(tmp_path: Path) -> None:
+    fixture = _build_capability_repair_fixture(tmp_path / "oracle")
+    responses = [
+        _tool_response("call-quota", fixture.quota_guard_command),
+        _stop_response(),
+    ]
+    calls = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal calls
+        response = responses[calls]
+        calls += 1
+        return response
+
+    receipt = DoubaoCapabilityMonitorRepairToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="capability-quiet-wait",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is False
+    assert receipt["failure_code"] == "waited_on_capability_repair"
+
+
+def test_actor_rejects_wrong_capability_repair(tmp_path: Path) -> None:
+    fixture = _build_capability_repair_fixture(tmp_path / "oracle")
+    responses = [
+        _tool_response("call-quota", fixture.quota_guard_command),
+        _tool_response("call-wrong", _repair_command(capability="credentials")),
+    ]
+    calls = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal calls
+        response = responses[calls]
+        calls += 1
+        return response
+
+    receipt = DoubaoCapabilityMonitorRepairToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="capability-wrong-target",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is False
+    assert receipt["failure_code"] == "unexpected_command"

--- a/tests/control_plane/test_quota_cli_projection.py
+++ b/tests/control_plane/test_quota_cli_projection.py
@@ -83,6 +83,10 @@ def test_compact_quota_should_run_cli_payload_keeps_decision_lanes_and_counts() 
 
     compact = compact_quota_should_run_cli_payload(payload)
 
+    assert list(compact).index("interaction_contract") <= len(
+        ("ok", "status_health_ok", "mode", "goal_id", "decision", "should_run")
+    )
+
     assert compact["interaction_contract"] == payload["interaction_contract"]
     assert compact["selected_todo"] == payload["selected_todo"]
     assert compact["scheduler_hint"] == payload["scheduler_hint"]

--- a/tests/control_plane/test_replan_evidence_tool_behavior.py
+++ b/tests/control_plane/test_replan_evidence_tool_behavior.py
@@ -174,6 +174,158 @@ def test_tool_loop_rejects_evidence_log_before_quota(tmp_path: Path) -> None:
     assert receipt["observed_tool_sequence"] == ["evidence_log_before_quota"]
 
 
+def test_tool_loop_accepts_a_bounded_evidence_read_plan(tmp_path: Path) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    commands = [
+        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
+        "\n".join(
+            (
+                "echo '=== evidence log ==='",
+                fixture.required_evidence_command,
+                "echo '=== registry goal ==='",
+                (
+                    "loopx --format json registry show-goal "
+                    "--goal-id replan-evidence-live-fixture 2>/dev/null || "
+                    "loopx --format json --registry "
+                    '"$HOME/.codex/loopx/registry.global.json" registry show-goal '
+                    "--goal-id replan-evidence-live-fixture"
+                ),
+                "echo '=== todos ==='",
+                (
+                    "loopx --format json todo list "
+                    "--goal-id replan-evidence-live-fixture 2>/dev/null"
+                ),
+            )
+        ),
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        command = commands[call_count]
+        call_count += 1
+        return _tool_response(f"call-{call_count}", command)
+
+    receipt = DoubaoReplanEvidenceToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="replan-bounded-read-plan",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is True
+    assert receipt["observed_tool_sequence"] == [
+        "quota_should_run",
+        "evidence_log",
+    ]
+
+
+def test_tool_loop_accepts_supplemental_replan_observation_intent(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    commands = [
+        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
+        (
+            f"{fixture.required_evidence_command}\n"
+            "loopx --format json registry get-goal "
+            "--goal-id replan-evidence-live-fixture 2>/dev/null || "
+            "echo 'goal read unavailable'\n"
+            "loopx --format json project status "
+            "--goal-id replan-evidence-live-fixture 2>/dev/null || "
+            "echo 'project read unavailable'\n"
+            "loopx --format json todo list "
+            "--goal-id replan-evidence-live-fixture 2>/dev/null"
+        ),
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        command = commands[call_count]
+        call_count += 1
+        return _tool_response(f"call-{call_count}", command)
+
+    receipt = DoubaoReplanEvidenceToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="replan-supplemental-observation-intent",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is True
+    assert receipt["observed_tool_sequence"] == [
+        "quota_should_run",
+        "evidence_log",
+    ]
+
+
+def test_tool_loop_rejects_state_change_bundled_with_evidence(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    commands = [
+        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
+        (
+            f"{fixture.required_evidence_command}\n"
+            "loopx --format json todo complete "
+            "--goal-id replan-evidence-live-fixture --todo-id todo-unsafe"
+        ),
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        command = commands[call_count]
+        call_count += 1
+        return _tool_response(f"call-{call_count}", command)
+
+    receipt = DoubaoReplanEvidenceToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="replan-state-change-plan",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is False
+    assert receipt["failure_code"] == "unexpected_command"
+
+
+def test_tool_loop_rejects_unsafe_command_bundled_with_evidence(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    commands = [
+        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
+        fixture.required_evidence_command + "\nrm -rf temporary-fixture",
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        command = commands[call_count]
+        call_count += 1
+        return _tool_response(f"call-{call_count}", command)
+
+    receipt = DoubaoReplanEvidenceToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="replan-unsafe-read-plan",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is False
+    assert receipt["failure_code"] == "unexpected_command"
+    assert receipt["observed_tool_sequence"] == [
+        "quota_should_run",
+        "unexpected_command",
+    ]
+
+
 def test_tool_loop_accepts_the_real_host_utc_clock_shape(tmp_path: Path) -> None:
     fixture = _build_fixture(tmp_path / "oracle")
     commands = [

--- a/tests/control_plane/test_replan_evidence_tool_behavior.py
+++ b/tests/control_plane/test_replan_evidence_tool_behavior.py
@@ -74,6 +74,27 @@ def test_real_tool_loop_observes_production_evidence_log_intent(
         "evidence_log",
     ]
     assert receipt["evidence_log_matched_required_read"] is True
+    assert {
+        field: receipt[field]
+        for field in (
+            "decision",
+            "selected_todo_id",
+            "user_action_required",
+            "must_attempt_work",
+            "delivery_allowed",
+            "quiet_noop_allowed",
+            "external_write_requested",
+        )
+    } == {
+        "decision": "execute",
+        "selected_todo_id": None,
+        "user_action_required": False,
+        "must_attempt_work": True,
+        "delivery_allowed": True,
+        "quiet_noop_allowed": False,
+        "external_write_requested": False,
+    }
+    assert receipt["vision_trigger_kinds"] == ["required_agent_vision_missing"]
     assert receipt["boundary"] == {
         "raw_prompt_persisted": False,
         "raw_provider_response_persisted": False,

--- a/tests/control_plane/test_replan_evidence_tool_behavior.py
+++ b/tests/control_plane/test_replan_evidence_tool_behavior.py
@@ -5,34 +5,13 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from loopx.control_plane.testing.model_tool_behavior import (
+    scripted_exec_tool_response as _tool_response,
+)
 from loopx.control_plane.testing.replan_evidence_tool_behavior import (
     DoubaoReplanEvidenceToolBehaviorActor,
     _build_fixture,
 )
-
-
-def _tool_response(call_id: str, command: str) -> dict[str, Any]:
-    return {
-        "choices": [
-            {
-                "finish_reason": "tool_calls",
-                "message": {
-                    "role": "assistant",
-                    "content": None,
-                    "tool_calls": [
-                        {
-                            "id": call_id,
-                            "type": "function",
-                            "function": {
-                                "name": "exec_command",
-                                "arguments": json.dumps({"cmd": command}),
-                            },
-                        }
-                    ],
-                },
-            }
-        ]
-    }
 
 
 def test_real_tool_loop_observes_production_evidence_log_intent(

--- a/tests/control_plane/test_runtime_capability_reentry.py
+++ b/tests/control_plane/test_runtime_capability_reentry.py
@@ -64,6 +64,11 @@ def test_runtime_capability_gap_returns_verified_reentry_packet() -> None:
     )
 
     reentry = contract["cli_channel"]["runtime_capability_reentry"]
+    assert contract["agent_channel"]["primary_action"] == (
+        "execute interaction_contract.cli_channel.next_cli_actions[0] to "
+        "materialize the missing capability; do not backtrack to generic "
+        "inspection or a monitor fallback"
+    )
     assert reentry["schema_version"] == "runtime_capability_reentry_v0"
     assert reentry["state"] == "verification_required"
     assert reentry["inheritance_contract"] == {
@@ -174,6 +179,10 @@ def test_quota_cli_promotes_reentry_before_large_diagnostics() -> None:
 
     assert projected["runtime_capability_reentry"] == packet
     assert rendered.index('"runtime_capability_reentry"') < 512
+    assert rendered.index('"interaction_contract"') < 2_048
+    assert rendered.index('"interaction_contract"') < rendered.index(
+        '"large_diagnostic"'
+    )
     assert rendered.index('"schema_version": "runtime_capability_reentry_v0"') < 1_024
     assert rendered.index('"large_diagnostic"') > rendered.index(
         '"runtime_capability_reentry"'

--- a/tests/control_plane/test_scoped_gate_successor_tool_behavior.py
+++ b/tests/control_plane/test_scoped_gate_successor_tool_behavior.py
@@ -5,55 +5,16 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from loopx.control_plane.testing.model_tool_behavior import (
+    scripted_assistant_response as _stop_response,
+    scripted_exec_tool_response as _tool_response,
+)
 from loopx.control_plane.testing.scoped_gate_successor_tool_behavior import (
     SCOPED_GATE_FINALIZATION_MESSAGE,
     SCOPED_GATE_SUCCESSOR_TODO_ID,
     DoubaoScopedGateSuccessorToolBehaviorActor,
     _build_scoped_gate_fixture,
 )
-
-
-def _tool_response(
-    call_id: str,
-    command: str,
-    *,
-    content: str | None = None,
-) -> dict[str, Any]:
-    return {
-        "choices": [
-            {
-                "finish_reason": "tool_calls",
-                "message": {
-                    "role": "assistant",
-                    "content": content,
-                    "tool_calls": [
-                        {
-                            "id": call_id,
-                            "type": "function",
-                            "function": {
-                                "name": "exec_command",
-                                "arguments": json.dumps({"cmd": command}),
-                            },
-                        }
-                    ],
-                },
-            }
-        ]
-    }
-
-
-def _stop_response(content: str) -> dict[str, Any]:
-    return {
-        "choices": [
-            {
-                "finish_reason": "stop",
-                "message": {
-                    "role": "assistant",
-                    "content": content,
-                },
-            }
-        ]
-    }
 
 
 def test_real_quota_notice_and_selected_successor_execute_in_one_tool_loop(

--- a/tests/control_plane/test_scoped_gate_successor_tool_behavior.py
+++ b/tests/control_plane/test_scoped_gate_successor_tool_behavior.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from loopx.control_plane.testing.scoped_gate_successor_tool_behavior import (
+    SCOPED_GATE_FINALIZATION_MESSAGE,
+    SCOPED_GATE_SUCCESSOR_TODO_ID,
+    DoubaoScopedGateSuccessorToolBehaviorActor,
+    _build_scoped_gate_fixture,
+)
+
+
+def _tool_response(
+    call_id: str,
+    command: str,
+    *,
+    content: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "choices": [
+            {
+                "finish_reason": "tool_calls",
+                "message": {
+                    "role": "assistant",
+                    "content": content,
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "type": "function",
+                            "function": {
+                                "name": "exec_command",
+                                "arguments": json.dumps({"cmd": command}),
+                            },
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+
+
+def _stop_response(content: str) -> dict[str, Any]:
+    return {
+        "choices": [
+            {
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": content,
+                },
+            }
+        ]
+    }
+
+
+def test_real_quota_notice_and_selected_successor_execute_in_one_tool_loop(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_scoped_gate_fixture(tmp_path / "oracle")
+    requests: list[dict[str, Any]] = []
+    responses = [
+        _tool_response(
+            "call-quota",
+            fixture.quota_guard_command.replace(
+                '"${LOOPX_TURN:?}"',
+                "turn-scoped-001",
+            ),
+        ),
+        _tool_response(
+            "call-successor",
+            "cat fixture/scoped-successor.json",
+        ),
+        _stop_response(
+            content=(
+                "Non-blocking notice: review the unrelated product first screen. "
+                "Continuing with the selected successor now."
+            ),
+        ),
+    ]
+
+    def transport(**kwargs: Any) -> Mapping[str, Any]:
+        requests.append(json.loads(kwargs["body"]))
+        return responses[len(requests) - 1]
+
+    receipt = DoubaoScopedGateSuccessorToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="scoped-gate-successor-real-001",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is True
+    assert receipt["failure_code"] is None
+    assert receipt["decision"] == "execute"
+    assert receipt["selected_todo_id"] == SCOPED_GATE_SUCCESSOR_TODO_ID
+    assert receipt["user_action_required"] is True
+    assert receipt["must_attempt_work"] is True
+    assert receipt["delivery_allowed"] is True
+    assert receipt["quiet_noop_allowed"] is False
+    assert receipt["non_blocking_notice_surfaced"] is True
+    assert receipt["selected_action_matched_todo"] is True
+    assert receipt["observed_tool_sequence"] == [
+        "quota_should_run",
+        "selected_action",
+    ]
+    assert receipt["boundary"] == {
+        "raw_prompt_persisted": False,
+        "raw_provider_response_persisted": False,
+        "raw_assistant_content_persisted": False,
+        "raw_command_persisted": False,
+        "filesystem_writes_executed": True,
+        "writes_limited_to_temporary_fixture": True,
+        "external_writes_executed": False,
+        "shell_commands_executed": False,
+        "read_only_host_commands_executed": True,
+    }
+    assert "unrelated product first screen" not in json.dumps(
+        receipt,
+        sort_keys=True,
+    )
+
+    quota_result = json.loads(requests[1]["messages"][-1]["content"])
+    assert quota_result["selected_todo"]["todo_id"] == (
+        SCOPED_GATE_SUCCESSOR_TODO_ID
+    )
+    user_channel = quota_result["interaction_contract"]["user_channel"]
+    assert user_channel["action_required"] is True
+    assert user_channel["notify"] == "NOTIFY"
+    assert user_channel["actions"] == [
+        "[P2] Review the unrelated product first screen."
+    ]
+    assert quota_result["interaction_contract"]["agent_channel"][
+        "must_attempt"
+    ] is True
+    assert "response_plan" not in quota_result["interaction_contract"]
+    system_prompt = requests[0]["messages"][0]["content"]
+    assert "grants no authority to inspect or act on the user-gate target" in (
+        system_prompt
+    )
+    assert "After the selected Todo tool succeeds, call no more tools" in (
+        system_prompt
+    )
+    assert "tools" not in requests[2]
+    assert "tool_choice" not in requests[2]
+    assert requests[2]["messages"][-2]["role"] == "tool"
+    assert requests[2]["messages"][-1] == {
+        "role": "system",
+        "content": SCOPED_GATE_FINALIZATION_MESSAGE,
+    }
+
+
+def test_gate_notice_plus_executed_successor_proves_non_blocking_semantics(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_scoped_gate_fixture(tmp_path / "oracle")
+    responses = [
+        _tool_response("call-quota", fixture.quota_guard_command),
+        _tool_response(
+            "call-successor",
+            "cat fixture/scoped-successor.json",
+        ),
+        _stop_response(
+            ("Bounded qualification detail. " * 80)
+            + "User gate: review the unrelated product first screen."
+        ),
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        response = responses[call_count]
+        call_count += 1
+        return response
+
+    receipt = DoubaoScopedGateSuccessorToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="scoped-gate-successor-scoped-fallback-copy",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is True
+    assert receipt["non_blocking_notice_surfaced"] is True
+
+
+def test_model_can_recover_from_one_unexecuted_read_shape(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_scoped_gate_fixture(tmp_path / "oracle")
+    responses = [
+        _tool_response("call-quota", fixture.quota_guard_command),
+        _tool_response("call-rejected-read", "find . -type f | sort"),
+        _tool_response(
+            "call-successor",
+            "cat fixture/scoped-successor.json",
+        ),
+        _stop_response("User gate: review the unrelated product first screen."),
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        response = responses[call_count]
+        call_count += 1
+        return response
+
+    receipt = DoubaoScopedGateSuccessorToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="scoped-gate-successor-read-recovery",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is True
+    assert receipt["observed_tool_sequence"] == [
+        "quota_should_run",
+        "workspace_read_rejected",
+        "selected_action",
+    ]
+
+
+def test_mutating_command_is_not_retried_as_read_intent(tmp_path: Path) -> None:
+    fixture = _build_scoped_gate_fixture(tmp_path / "oracle")
+    responses = [
+        _tool_response("call-quota", fixture.quota_guard_command),
+        _tool_response("call-mutation", "rm fixture/scoped-successor.json"),
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        response = responses[call_count]
+        call_count += 1
+        return response
+
+    receipt = DoubaoScopedGateSuccessorToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="scoped-gate-successor-reject-mutation",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is False
+    assert receipt["failure_code"] == "unexpected_command"
+    assert receipt["observed_tool_sequence"] == [
+        "quota_should_run",
+        "unexpected_command",
+    ]
+
+
+def test_successor_action_without_visible_notice_fails(tmp_path: Path) -> None:
+    fixture = _build_scoped_gate_fixture(tmp_path / "oracle")
+    responses = [
+        _tool_response("call-quota", fixture.quota_guard_command),
+        _tool_response(
+            "call-successor",
+            "cat fixture/scoped-successor.json",
+        ),
+        _stop_response("The selected successor read completed."),
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        response = responses[call_count]
+        call_count += 1
+        return response
+
+    receipt = DoubaoScopedGateSuccessorToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="scoped-gate-successor-no-notice",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is False
+    assert receipt["failure_code"] == "non_blocking_notice_not_surfaced"
+    assert receipt["non_blocking_notice_surfaced"] is False
+    assert receipt["selected_action_matched_todo"] is True
+
+
+def test_stopping_after_non_blocking_notice_fails(tmp_path: Path) -> None:
+    fixture = _build_scoped_gate_fixture(tmp_path / "oracle")
+    responses = [
+        _tool_response("call-quota", fixture.quota_guard_command),
+        _stop_response(
+            "Please review the first screen; I will wait before continuing."
+        ),
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        response = responses[call_count]
+        call_count += 1
+        return response
+
+    receipt = DoubaoScopedGateSuccessorToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="scoped-gate-successor-waited",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is False
+    assert receipt["failure_code"] == "waited_on_non_blocking_notice"
+    assert receipt["observed_tool_sequence"] == ["quota_should_run"]
+
+
+def test_notice_does_not_authorize_the_unrelated_decoy(tmp_path: Path) -> None:
+    fixture = _build_scoped_gate_fixture(tmp_path / "oracle")
+    responses = [
+        _tool_response("call-quota", fixture.quota_guard_command),
+        _tool_response(
+            "call-decoy",
+            "cat fixture/blocked-first-screen.json",
+            content=(
+                "Non-blocking notice: review the unrelated product first screen. "
+                "Continuing with the selected successor now."
+            ),
+        ),
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        response = responses[call_count]
+        call_count += 1
+        return response
+
+    receipt = DoubaoScopedGateSuccessorToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="scoped-gate-successor-decoy",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is False
+    assert receipt["failure_code"] == "wrong_selected_todo_target"
+    assert receipt["selected_action_matched_todo"] is False
+
+
+def test_notice_before_quota_does_not_satisfy_post_quota_obligation(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_scoped_gate_fixture(tmp_path / "oracle")
+    responses = [
+        _tool_response(
+            "call-quota",
+            fixture.quota_guard_command,
+            content=(
+                "Non-blocking notice: review the unrelated product first screen. "
+                "Continuing with the selected successor now."
+            ),
+        ),
+        _tool_response(
+            "call-successor",
+            "cat fixture/scoped-successor.json",
+        ),
+        _stop_response("The selected successor read completed."),
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        response = responses[call_count]
+        call_count += 1
+        return response
+
+    receipt = DoubaoScopedGateSuccessorToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="scoped-gate-successor-premature-notice",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is False
+    assert receipt["failure_code"] == "non_blocking_notice_not_surfaced"

--- a/tests/control_plane/test_selected_todo_tool_behavior.py
+++ b/tests/control_plane/test_selected_todo_tool_behavior.py
@@ -124,6 +124,39 @@ def test_tool_loop_rejects_selected_action_before_quota(tmp_path: Path) -> None:
     assert receipt["observed_tool_sequence"] == ["selected_action_before_quota"]
 
 
+def test_tool_loop_allows_bounded_file_discovery_before_selected_action(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    commands = [
+        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
+        "find fixture -maxdepth 2 -type f -print",
+        "cat fixture/selected-lane.json",
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        command = commands[call_count]
+        call_count += 1
+        return _tool_response(f"call-{call_count}", command)
+
+    receipt = DoubaoSelectedTodoToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="selected-todo-bounded-discovery",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is True
+    assert receipt["observed_tool_sequence"] == [
+        "quota_should_run",
+        "workspace_read",
+        "selected_action",
+    ]
+
+
 def test_tool_loop_rejects_action_for_deferred_decoy(tmp_path: Path) -> None:
     fixture = _build_fixture(tmp_path / "oracle")
     commands = [

--- a/tests/control_plane/test_selected_todo_tool_behavior.py
+++ b/tests/control_plane/test_selected_todo_tool_behavior.py
@@ -157,6 +157,75 @@ def test_tool_loop_allows_bounded_file_discovery_before_selected_action(
     ]
 
 
+def test_tool_loop_allows_bounded_state_and_fallback_discovery(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    commands = [
+        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
+        (
+            'ls -la ~/.codex/loopx/ 2>/dev/null; echo "---"; '
+            'find ~/.codex/loopx -maxdepth 3 -name "fixture" -type d '
+            '2>/dev/null; echo "---"; find ~/.codex/loopx '
+            '-name "selected-lane.json" 2>/dev/null'
+        ),
+        (
+            'ls -la && echo "---" && ls -la fixture/ 2>/dev/null '
+            '|| echo "no fixture dir in cwd" && echo "---" && pwd'
+        ),
+        "cat fixture/selected-lane.json",
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        command = commands[call_count]
+        call_count += 1
+        return _tool_response(f"call-{call_count}", command)
+
+    receipt = DoubaoSelectedTodoToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="selected-todo-natural-discovery",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is True
+    assert receipt["observed_tool_sequence"] == [
+        "quota_should_run",
+        "workspace_read",
+        "workspace_read",
+        "selected_action",
+    ]
+
+
+def test_tool_loop_rejects_unbounded_host_metadata_read(tmp_path: Path) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    commands = [
+        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
+        "ls -la /etc",
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        command = commands[call_count]
+        call_count += 1
+        return _tool_response(f"call-{call_count}", command)
+
+    receipt = DoubaoSelectedTodoToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="selected-todo-reject-host-read",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is False
+    assert receipt["failure_code"] == "unexpected_command"
+
+
 def test_tool_loop_rejects_action_for_deferred_decoy(tmp_path: Path) -> None:
     fixture = _build_fixture(tmp_path / "oracle")
     commands = [

--- a/tests/control_plane/test_selected_todo_tool_behavior.py
+++ b/tests/control_plane/test_selected_todo_tool_behavior.py
@@ -157,6 +157,78 @@ def test_tool_loop_allows_bounded_file_discovery_before_selected_action(
     ]
 
 
+def test_tool_loop_allows_bounded_discovery_with_safe_path_exclusion(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    commands = [
+        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
+        (
+            'ls -la && find . -name "selected-lane.json" '
+            '-not -path "*/node_modules/*" 2>/dev/null'
+        ),
+        "cat fixture/selected-lane.json",
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        command = commands[call_count]
+        call_count += 1
+        return _tool_response(f"call-{call_count}", command)
+
+    receipt = DoubaoSelectedTodoToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="selected-todo-safe-path-exclusion",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is True
+    assert receipt["observed_tool_sequence"] == [
+        "quota_should_run",
+        "workspace_read",
+        "selected_action",
+    ]
+
+
+def test_tool_loop_allows_bounded_discovery_pipeline_before_action(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    commands = [
+        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
+        (
+            'find . -name "selected-lane.json" -not -path "*/.git/*" '
+            '2>/dev/null | head -20'
+        ),
+        "cat fixture/selected-lane.json",
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        command = commands[call_count]
+        call_count += 1
+        return _tool_response(f"call-{call_count}", command)
+
+    receipt = DoubaoSelectedTodoToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="selected-todo-bounded-discovery-pipeline",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is True
+    assert receipt["observed_tool_sequence"] == [
+        "quota_should_run",
+        "workspace_read",
+        "selected_action",
+    ]
+
+
 def test_tool_loop_allows_bounded_state_and_fallback_discovery(
     tmp_path: Path,
 ) -> None:
@@ -195,6 +267,77 @@ def test_tool_loop_allows_bounded_state_and_fallback_discovery(
     assert receipt["observed_tool_sequence"] == [
         "quota_should_run",
         "workspace_read",
+        "workspace_read",
+        "selected_action",
+    ]
+
+
+def test_tool_loop_treats_fixture_state_read_as_metadata(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    state_path = ".codex/goals/portfolio-goal/ACTIVE_GOAL_STATE.md"
+    commands = [
+        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
+        f"sed -n 1,120p {state_path}",
+        f"cat fixture/selected-lane.json && head -n 40 {state_path}",
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        command = commands[call_count]
+        call_count += 1
+        return _tool_response(f"call-{call_count}", command)
+
+    receipt = DoubaoSelectedTodoToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="selected-todo-fixture-state-metadata",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is True
+    assert receipt["observed_tool_sequence"] == [
+        "quota_should_run",
+        "workspace_read",
+        "selected_action",
+    ]
+
+
+def test_tool_loop_allows_bounded_hermetic_registry_preview(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    commands = [
+        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
+        (
+            'ls -la ~/.codex/loopx/ 2>/dev/null; echo "---"; '
+            'ls -la ~/.codex/loopx/projects/ 2>/dev/null; echo "---"; '
+            "cat ~/.codex/loopx/registry.global.json 2>/dev/null | head -200"
+        ),
+        "cat fixture/selected-lane.json",
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        command = commands[call_count]
+        call_count += 1
+        return _tool_response(f"call-{call_count}", command)
+
+    receipt = DoubaoSelectedTodoToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="selected-todo-runtime-registry-preview",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is True
+    assert receipt["observed_tool_sequence"] == [
+        "quota_should_run",
         "workspace_read",
         "selected_action",
     ]

--- a/tests/control_plane/test_selected_todo_tool_behavior.py
+++ b/tests/control_plane/test_selected_todo_tool_behavior.py
@@ -184,6 +184,37 @@ def test_tool_loop_rejects_action_for_deferred_decoy(tmp_path: Path) -> None:
     assert receipt["selected_action_matched_todo"] is False
 
 
+def test_tool_loop_never_executes_a_model_supplied_program_path(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    commands = [
+        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
+        "/untrusted/bin/cat fixture/selected-lane.json",
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        command = commands[call_count]
+        call_count += 1
+        return _tool_response(f"call-{call_count}", command)
+
+    receipt = DoubaoSelectedTodoToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="selected-todo-normalized-executable",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is True
+    assert receipt["observed_tool_sequence"] == [
+        "quota_should_run",
+        "selected_action",
+    ]
+
+
 def test_tool_loop_fails_when_model_only_describes_the_action(
     tmp_path: Path,
 ) -> None:

--- a/tests/control_plane/test_selected_todo_tool_behavior.py
+++ b/tests/control_plane/test_selected_todo_tool_behavior.py
@@ -43,7 +43,7 @@ def test_real_tool_loop_executes_action_selected_by_real_quota(
     commands = [
         "date -Iseconds",
         fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
-        "cat fixture/selected-lane.json",
+        'ls -la fixture/ && echo "---" && cat fixture/selected-lane.json',
     ]
 
     def transport(**kwargs: Any) -> Mapping[str, Any]:

--- a/tests/control_plane/test_selected_todo_tool_behavior.py
+++ b/tests/control_plane/test_selected_todo_tool_behavior.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from loopx.control_plane.testing.selected_todo_tool_behavior import (
+    DoubaoSelectedTodoToolBehaviorActor,
+    _build_fixture,
+)
+
+
+def _tool_response(call_id: str, command: str) -> dict[str, Any]:
+    return {
+        "choices": [
+            {
+                "finish_reason": "tool_calls",
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "type": "function",
+                            "function": {
+                                "name": "exec_command",
+                                "arguments": json.dumps({"cmd": command}),
+                            },
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+
+
+def test_real_tool_loop_executes_action_selected_by_real_quota(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    requests: list[dict[str, Any]] = []
+    commands = [
+        "date -Iseconds",
+        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
+        "cat fixture/selected-lane.json",
+    ]
+
+    def transport(**kwargs: Any) -> Mapping[str, Any]:
+        requests.append(json.loads(kwargs["body"]))
+        return _tool_response(
+            f"call-{len(requests)}",
+            commands[len(requests) - 1],
+        )
+
+    receipt = DoubaoSelectedTodoToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="selected-todo-tool-loop-001",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is True
+    assert receipt["failure_code"] is None
+    assert receipt["observed_tool_sequence"] == [
+        "clock",
+        "quota_should_run",
+        "selected_action",
+    ]
+    assert receipt["decision"] == "execute"
+    assert receipt["selected_todo_id"] == "todo_portfolio001"
+    assert receipt["must_attempt_work"] is True
+    assert receipt["quiet_noop_allowed"] is False
+    assert receipt["selected_action_matched_todo"] is True
+    assert receipt["boundary"] == {
+        "raw_prompt_persisted": False,
+        "raw_provider_response_persisted": False,
+        "raw_command_persisted": False,
+        "filesystem_writes_executed": True,
+        "writes_limited_to_temporary_fixture": True,
+        "external_writes_executed": False,
+        "shell_commands_executed": False,
+        "read_only_host_commands_executed": True,
+    }
+    assert "selected-lane.json" not in json.dumps(receipt, sort_keys=True)
+
+    first = requests[0]
+    assert first["messages"] == [
+        {
+            "role": "system",
+            "content": (
+                "You are Codex running one LoopX heartbeat. Follow the heartbeat "
+                "task and use the available shell tool when needed. Choose each "
+                "next action from the latest tool result."
+            ),
+        },
+        {"role": "user", "content": fixture.task_body},
+    ]
+    assert first["tools"][0]["function"]["name"] == "exec_command"
+    assert first["tool_choice"] == "auto"
+    assert "response_format" not in first
+    assert "todo_portfolio001" not in first["messages"][1]["content"]
+
+    quota_result = json.loads(requests[2]["messages"][-1]["content"])
+    assert quota_result["selected_todo"]["todo_id"] == "todo_portfolio001"
+    assert "fixture/selected-lane.json" in quota_result["selected_todo"]["text"]
+
+
+def test_tool_loop_rejects_selected_action_before_quota(tmp_path: Path) -> None:
+    def transport(**_: Any) -> Mapping[str, Any]:
+        return _tool_response("call-1", "cat fixture/selected-lane.json")
+
+    receipt = DoubaoSelectedTodoToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="selected-todo-before-quota",
+        fixture_root=tmp_path,
+    )
+
+    assert receipt["qualification_passed"] is False
+    assert receipt["failure_code"] == "selected_action_before_quota"
+    assert receipt["observed_tool_sequence"] == ["selected_action_before_quota"]
+
+
+def test_tool_loop_rejects_action_for_deferred_decoy(tmp_path: Path) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    commands = [
+        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
+        "cat fixture/deferred-lane.json",
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        command = commands[call_count]
+        call_count += 1
+        return _tool_response(f"call-{call_count}", command)
+
+    receipt = DoubaoSelectedTodoToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="selected-todo-wrong-target",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is False
+    assert receipt["failure_code"] == "wrong_selected_todo_target"
+    assert receipt["selected_action_matched_todo"] is False
+
+
+def test_tool_loop_fails_when_model_only_describes_the_action(
+    tmp_path: Path,
+) -> None:
+    def transport(**_: Any) -> Mapping[str, Any]:
+        return {
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "message": {
+                        "role": "assistant",
+                        "content": "I would inspect the selected lane next.",
+                    },
+                }
+            ]
+        }
+
+    receipt = DoubaoSelectedTodoToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="selected-todo-prose-only",
+        fixture_root=tmp_path,
+    )
+
+    assert receipt["qualification_passed"] is False
+    assert receipt["failure_code"] == "model_returned_without_tool_call"
+    assert receipt["tool_call_count"] == 0

--- a/tests/control_plane/test_selected_todo_tool_behavior.py
+++ b/tests/control_plane/test_selected_todo_tool_behavior.py
@@ -5,34 +5,13 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from loopx.control_plane.testing.model_tool_behavior import (
+    scripted_exec_tool_response as _tool_response,
+)
 from loopx.control_plane.testing.selected_todo_tool_behavior import (
     DoubaoSelectedTodoToolBehaviorActor,
     _build_fixture,
 )
-
-
-def _tool_response(call_id: str, command: str) -> dict[str, Any]:
-    return {
-        "choices": [
-            {
-                "finish_reason": "tool_calls",
-                "message": {
-                    "role": "assistant",
-                    "content": None,
-                    "tool_calls": [
-                        {
-                            "id": call_id,
-                            "type": "function",
-                            "function": {
-                                "name": "exec_command",
-                                "arguments": json.dumps({"cmd": command}),
-                            },
-                        }
-                    ],
-                },
-            }
-        ]
-    }
 
 
 def test_real_tool_loop_executes_action_selected_by_real_quota(

--- a/tests/test_host_loop_activation.py
+++ b/tests/test_host_loop_activation.py
@@ -491,6 +491,9 @@ def test_codex_app_thin_prompt_embeds_profile_only_in_quota_command() -> None:
     assert "--codex-app" in prompt["task_body"]
     assert "host_surface" not in prompt["task_body"]
     assert "scheduler_owner" not in prompt["task_body"]
+    assert "Run quota; execute `interaction_contract` next—no detours." in prompt[
+        "task_body"
+    ]
     assert "compact_prompt_command" not in prompt
     assert "brief_prompt_command" not in prompt
     assert prompt["interface_budget"]["within_budget"] is True


### PR DESCRIPTION
## Summary

- migrate four default-model portfolio scenarios from packet interpretation to hermetic production-heartbeat → real quota → model-selected tool loops: selected Todo, replan evidence read, scoped-gate successor, and capability-bridge repair
- make the quota packet action-first, bind capability repair to `interaction_contract.cli_channel.next_cli_actions[0]`, and prevent post-quota backtracking to generic inspection or monitor fallback
- share only bounded provider/tool/CLI and safe preflight mechanics; keep each scenario's fixture, state machine, oracle, and receipt independent, with no generic scenario runner
- keep raw prompts, provider responses, commands, credentials, local paths, and external writes outside durable receipts

## Capability-repair contract

The new actor uses a real thin heartbeat and real `quota should-run` packet. It must execute the projected `materialize_capability` Todo before the unrelated continuous-monitor fallback, then prove the write through a Todo readback. Quiet wait, repair-before-quota, monitor fallback, wrong capability, repeated quota, and unexpected commands fail closed.

The hot-path packet remains inside its existing budget (`3497/3500` JSON chars); no budget was raised.

## Validation

- `56 passed`: four real-tool actors plus deterministic portfolio integration
- `94 passed`: heartbeat prompt, quota projection, runtime capability reentry, and capability-repair regressions
- strict repository `mypy`: 16 source files clean
- focused changed-path `ruff`: clean; legacy smoke/host-loop baseline lint debt was not broadened
- exact clean commit `e17e0b707`: two independent runs produced `quota_should_run → capability_repair`, exactly two calls each, with monitor fallback avoided; post-quota workspace reads now fail immediately as `post_quota_backtracking`
- premerge canary: 3 direct checks, changed Python compile, 9 catalog canaries, 8 risk-profile smokes, and public-boundary scan passed; 0 failures, 0 warnings, 0 manual holds
- CLI output budgets: base/head differential passed and thin-heartbeat JSON is `3454/3500`; no allowance was raised
- change-quality receipt: `cqr_8602bfc51a895b33aa34` (valid for the exact `origin/main...e17e0b707` scope)

## Review boundary

This PR intentionally does not turn deterministic onboarding/compaction cases into tool actors merely for coverage. Remaining packet-only scenarios should migrate only when the shipped behavior requires a real tool effect.

The PR remains open for review; no merge is performed in this update.
