### PR TITLE
feat(quota): per-goal token/cost/duration capture + dashboard surfacing

### DIFF
--- a/apps/presentation/dashboard/src/data/status.ts
+++ b/apps/presentation/dashboard/src/data/status.ts
@@ -523,6 +523,16 @@ export const usageTotalsSchema = z.object({
   automation_run_count_7d: z.number().optional().default(0),
   progress_signal_run_count_24h: z.number().optional().default(0),
   progress_signal_run_count_7d: z.number().optional().default(0),
+  input_tokens_24h: z.number().optional().default(0),
+  input_tokens_7d: z.number().optional().default(0),
+  output_tokens_24h: z.number().optional().default(0),
+  output_tokens_7d: z.number().optional().default(0),
+  cache_tokens_24h: z.number().optional().default(0),
+  cache_tokens_7d: z.number().optional().default(0),
+  cost_usd_24h: z.number().optional().default(0),
+  cost_usd_7d: z.number().optional().default(0),
+  duration_ms_24h: z.number().optional().default(0),
+  duration_ms_7d: z.number().optional().default(0),
 });
 
 export const usageGoalSchema = usageTotalsSchema.extend({
@@ -539,6 +549,16 @@ const defaultUsageTotals = {
   automation_run_count_7d: 0,
   progress_signal_run_count_24h: 0,
   progress_signal_run_count_7d: 0,
+  input_tokens_24h: 0,
+  input_tokens_7d: 0,
+  output_tokens_24h: 0,
+  output_tokens_7d: 0,
+  cache_tokens_24h: 0,
+  cache_tokens_7d: 0,
+  cost_usd_24h: 0,
+  cost_usd_7d: 0,
+  duration_ms_24h: 0,
+  duration_ms_7d: 0,
 };
 
 export const usageSummarySchema = z.object({

--- a/apps/presentation/dashboard/src/views/dashboard-page.tsx
+++ b/apps/presentation/dashboard/src/views/dashboard-page.tsx
@@ -9124,6 +9124,25 @@ function formatUsageCount(value?: number | null) {
   return String(value ?? 0);
 }
 
+function formatTokenCount(value?: number | null) {
+  const n = value ?? 0;
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+function formatCostUsd(value?: number | null) {
+  return `$${(value ?? 0).toFixed(2)}`;
+}
+
+function formatDurationMs(value?: number | null) {
+  const ms = value ?? 0;
+  if (ms >= 3_600_000) return `${(ms / 3_600_000).toFixed(1)}h`;
+  if (ms >= 60_000) return `${(ms / 60_000).toFixed(1)}m`;
+  if (ms >= 1_000) return `${Math.round(ms / 1_000)}s`;
+  return `${ms}ms`;
+}
+
 function formatUsageShare(value?: number | null) {
   return `${Math.round((value ?? 0) * 100)}%`;
 }
@@ -9422,6 +9441,18 @@ function UsageStatsPanel({ usage }: { usage?: UsageSummary | null }) {
           <UsageMetric
             label="Progress"
             value={`${formatUsageCount(totals.progress_signal_run_count_24h)} / ${formatUsageCount(totals.progress_signal_run_count_7d)}`}
+          />
+          <UsageMetric
+            label="Tokens 24h / 7d"
+            value={`${formatTokenCount(totals.input_tokens_24h + totals.output_tokens_24h)} / ${formatTokenCount(totals.input_tokens_7d + totals.output_tokens_7d)}`}
+          />
+          <UsageMetric
+            label="Cost 24h / 7d"
+            value={`${formatCostUsd(totals.cost_usd_24h)} / ${formatCostUsd(totals.cost_usd_7d)}`}
+          />
+          <UsageMetric
+            label="Runtime 24h / 7d"
+            value={`${formatDurationMs(totals.duration_ms_24h)} / ${formatDurationMs(totals.duration_ms_7d)}`}
           />
         </div>
         {topGoals.length ? (

--- a/apps/presentation/dashboard/src/views/dashboard-page.tsx
+++ b/apps/presentation/dashboard/src/views/dashboard-page.tsx
@@ -9413,6 +9413,12 @@ function UsageStatsPanel({ usage }: { usage?: UsageSummary | null }) {
     return null;
   }
   const totals = usage.totals;
+  const hasUsage =
+    totals.input_tokens_24h +
+    totals.input_tokens_7d +
+    totals.output_tokens_24h +
+    totals.output_tokens_7d >
+    0;
   const topGoals = usage.goals.slice(0, 5);
   return (
     <Card>
@@ -9442,18 +9448,24 @@ function UsageStatsPanel({ usage }: { usage?: UsageSummary | null }) {
             label="Progress"
             value={`${formatUsageCount(totals.progress_signal_run_count_24h)} / ${formatUsageCount(totals.progress_signal_run_count_7d)}`}
           />
-          <UsageMetric
-            label="Tokens 24h / 7d"
-            value={`${formatTokenCount(totals.input_tokens_24h + totals.output_tokens_24h)} / ${formatTokenCount(totals.input_tokens_7d + totals.output_tokens_7d)}`}
-          />
-          <UsageMetric
-            label="Cost 24h / 7d"
-            value={`${formatCostUsd(totals.cost_usd_24h)} / ${formatCostUsd(totals.cost_usd_7d)}`}
-          />
-          <UsageMetric
-            label="Runtime 24h / 7d"
-            value={`${formatDurationMs(totals.duration_ms_24h)} / ${formatDurationMs(totals.duration_ms_7d)}`}
-          />
+          {hasUsage ? (
+            <>
+              <UsageMetric
+                label="Tokens 24h / 7d"
+                value={`${formatTokenCount(totals.input_tokens_24h + totals.output_tokens_24h)} / ${formatTokenCount(totals.input_tokens_7d + totals.output_tokens_7d)}`}
+              />
+              <UsageMetric
+                label="Cost 24h / 7d"
+                value={`${formatCostUsd(totals.cost_usd_24h)} / ${formatCostUsd(totals.cost_usd_7d)}`}
+              />
+              <UsageMetric
+                label="Runtime 24h / 7d"
+                value={`${formatDurationMs(totals.duration_ms_24h)} / ${formatDurationMs(totals.duration_ms_7d)}`}
+              />
+            </>
+          ) : (
+            <UsageMetric label="Cost data" value="pending ingestion" />
+          )}
         </div>
         {topGoals.length ? (
           <div className="mt-4 overflow-hidden rounded-lg border border-slate-200 dark:border-zinc-800">

--- a/docs/architecture/rfcs/README.md
+++ b/docs/architecture/rfcs/README.md
@@ -13,6 +13,7 @@ defined by the implementation and stable reference contracts.
 - [Goal Channel collaboration v0](goal-channel-collaboration-v0.md): bind one external collaboration channel to one LoopX goal while preserving LoopX as the source of truth.
 - [Goal Channel 协作模型 v0](goal-channel-collaboration-v0.zh-CN.md): 将一个外部协作通道绑定到一个 LoopX goal，同时保持 LoopX 作为事实源。
 - [Shared-goal online authority and pluggable coordination provider v0](shared-goal-authority-state-provider-v0.md): a claim-only contract proof for target-scoped conflicts over one canonical coordination aggregate, atomic original-receipt replay, and per-layer persistence ownership, with NoKV as an unpromoted provider candidate ([中文版](shared-goal-authority-state-provider-v0.zh-CN.md), [validation boundary](shared-goal-authority-state-provider-v0-evidence.zh-CN.md)).
+- [Per-Goal Usage, Token, and Cost Surfacing v0](goal-usage-token-cost-v0.md): capture per-goal token, cost, and duration in core `usage_summary` and surface it in the existing dashboard, behind a provider-neutral capture layer.
 
 RFCs must not contain internal conversations, private links, local filesystem
 paths, credentials, raw transcripts, or non-public organizational context.

--- a/docs/architecture/rfcs/goal-usage-token-cost-v0.md
+++ b/docs/architecture/rfcs/goal-usage-token-cost-v0.md
@@ -1,0 +1,201 @@
+# RFC: Per-Goal Usage, Token, and Cost Surfacing v0
+
+- Status: Draft
+- Scope: core `usage_summary` token / cost / duration capture and existing-dashboard surfacing
+- Decision type: bounded public-contract change plus a provider-neutral capture layer
+
+## Summary
+
+This RFC proposes capturing per-goal LLM usage — input/output/cache tokens,
+estimated cost, and wall-time duration — into the existing core `usage_summary`
+aggregate, and surfacing it in the existing dashboard. The work introduces one
+provider-neutral capture seam; it does not add a second usage store, a new
+dashboard, or cost-aware runtime routing.
+
+The intent is to let an operator see, per goal, what a long-running run
+actually consumed — not only whether it was allowed to run (the current quota
+slot accounting) but what it spent. This closes the gap left open in
+`docs/quota-allocation.md`, which notes that later versions may "replace slots
+with real runtime, token spend, or cost."
+
+## Problem
+
+`usage_summary` is explicitly a run-history proxy that excludes token counts.
+Its proxy note states it is a "run-history proxy; excludes token counts and raw
+thread logs," and the public `docs/status-data-contract.md` repeats the same
+exclusion. As a result:
+
+- The dashboard can show how many runs happened and how many quota slots were
+  spent, but not how many tokens a goal burned or what it cost.
+- Token and cost capture already exists, but only on the benchmark path, wired
+  to one runtime (Codex) and to an external pricing table. It is not reachable
+  from the goal runtime's main path.
+- No goal runtime reports LLM usage today. The claude, opencode, and pi goal
+  modes carry no token-telemetry code; "token" identifiers in opencode and pi
+  refer to scheduler identity tokens, not LLM consumption.
+
+The primitives needed to fix this are mostly present (a usage aggregate, a JSON
+status API, a mature dashboard). What is missing is the capture seam that turns
+each runtime's usage into one normalized shape, plus the contract change that
+admits token/cost data into the public aggregate.
+
+## Goals
+
+- Capture input, output, and cache tokens, an estimated cost, and wall-time
+  duration per goal run, in the core `usage_summary` aggregate.
+- Keep ingestion provider-neutral: one schema, with per-runtime adapters.
+- Surface the captured data in the existing dashboard without adding a new
+  dashboard or a second usage store.
+- Preserve the existing privacy boundary: raw thread logs, prompts, and
+  completions never enter `usage_summary`; only aggregate numeric usage does.
+
+## Non-Goals
+
+- Cost-aware runtime routing or selection (a follow-up; depends on this work).
+- Storing raw prompts, completions, tool output, or transcripts.
+- Building a new dashboard or a parallel usage store.
+- Capturing per-turn fine-grained telemetry; this RFC targets run-level
+  aggregates first.
+- Weakening any existing gate, validation, or quota invariant.
+
+## Decision Boundary
+
+This RFC changes one public contract and leaves the rest intact.
+
+**Changed.** `usage_summary` becomes a run-history proxy that *includes*
+aggregate token counts, estimated cost, and duration. The proxy note and
+`docs/status-data-contract.md` are updated to reflect this; the historical
+"excludes token counts" wording is withdrawn. Token/cost/duration become
+first-class fields of `blank_usage_goal` and the `totals` block.
+
+**Unchanged.** Raw thread logs, prompts, and completions remain excluded from
+`usage_summary`. The exclusion of raw content is a privacy invariant, not a
+historical accident, and is preserved.
+
+Because this alters a documented public contract, the implementation must
+update `docs/status-data-contract.md` in the same change set and add focused
+tests for the new fields (none exist today for `usage_summary`).
+
+## Capture Contract
+
+A provider-neutral capture seam is added under `control_plane/quota/`, modeled
+on the spend and slot accounting already living there.
+
+The core of the seam is one function:
+
+```python
+def collect_usage_for_run(run) -> UsageSample | None:
+    """Return normalized usage for a run, or None if the runtime reports none."""
+```
+
+`UsageSample` is a normalized, public-safe shape:
+
+```json
+{
+  "input_tokens": 12000,
+  "output_tokens": 3400,
+  "cache_tokens": 8000,
+  "cost_usd": 0.21,
+  "duration_ms": 184000,
+  "provider": "codex",
+  "model": "<model id>",
+  "measured_at": "2026-08-11T14:55:00Z"
+}
+```
+
+Each runtime registers an adapter that reads its own usage source and returns a
+`UsageSample` (or `None`). The aggregate loop in `build_usage_summary` asks the
+seam for each run and accumulates the result into the new fields. Runtimes that
+report nothing contribute nothing; the aggregate degrades gracefully to the
+current behavior for them.
+
+The Codex adapter can reuse the extraction approach already proven on the
+benchmark path (scan the session's token-count events for the final cumulative
+figure), factored out of its current external coupling.
+
+## Cost Computation
+
+Cost is the one field that is not a direct measurement; it is derived from
+tokens and a price. Two options:
+
+1. **Runtime-reported cost (recommended).** Each adapter computes cost from the
+   tokens it measured and a price it knows (it already holds the model id), and
+   returns `cost_usd` in the `UsageSample`. Core stores and aggregates it.
+2. **Core-computed cost.** Core holds a price table and derives cost from
+   tokens and model. This keeps computation centralized but introduces a price
+   table that can drift against provider changes.
+
+This RFC recommends option 1, because a core-maintained price table would
+duplicate and drift against the very external table the benchmark path already
+depends on, and because each runtime already holds the model id needed to price
+its own usage. The final choice is an open question for review.
+
+Regardless of option, `usage_summary` exposes only aggregate cost. Per-unit
+price detail is not surfaced, to avoid leaking provider-specific commercial
+terms.
+
+## Data Classification
+
+Following the issue's guidance, token counts, estimated cost, and duration are
+classified **public-safe** and may enter the public `usage_summary` contract:
+
+- Aggregate token counts and cost reveal operational spend, not content.
+- Wall-time duration is operational metadata.
+- Provider and model identifiers are public product names.
+
+They do **not** carry prompt content, completion text, tool output, credentials,
+or anything that reconstructs a conversation. The raw-thread-log exclusion is
+preserved as a separate, stricter invariant.
+
+## Smallest Useful Slice
+
+The first slice proves the seam end-to-end on one runtime:
+
+1. Add the `UsageSample` shape and `collect_usage_for_run` seam under
+   `control_plane/quota/`.
+2. Implement the Codex adapter (reuse the benchmark extraction approach).
+3. Extend `blank_usage_goal`, the `totals` block, and the
+   `build_usage_summary` loop with token/cost/duration fields; update the proxy
+   note.
+4. Update `docs/status-data-contract.md` in the same change set.
+5. Surface the new fields in the existing dashboard (no new dashboard).
+6. Add `tests/control_plane/quota/test_usage_summary.py`.
+
+Adapters for the claude, opencode, and pi goal modes are explicit follow-ups
+and are out of scope for this slice, because none of them report usage today
+and each needs its own ingestion mechanism (statusline hook, stdout parsing, or
+bridge IPC). The seam is designed so that adding an adapter does not revisit the
+aggregate or the contract.
+
+## Validation
+
+The slice must prove:
+
+- after a Codex goal run, `usage_summary` carries non-zero token/cost/duration
+  for that goal;
+- the dashboard renders the new fields;
+- a runtime that reports nothing leaves the aggregate at the current behavior;
+- raw thread logs, prompts, and completions do not appear in `usage_summary`
+  (privacy regression check);
+- the public contract in `docs/status-data-contract.md` matches the
+  implementation;
+- `loopx check --scan-path` reports no private-data leakage.
+
+## Open Questions
+
+1. Cost computation location — runtime-reported (recommended) vs core-computed.
+2. Whether model identifiers need any redaction in public surfaces, or whether
+   aggregate cost alone is sufficient and model names are treated as public.
+3. Ingestion mechanism and ordering for the claude, opencode, and pi runtimes.
+4. Whether to add a dedicated `/usage.json` endpoint or continue surfacing
+   through the existing status payload (this RFC assumes the latter).
+5. The duration capture anchor — which run boundary events delimit wall-time.
+
+## Public References
+
+- [LoopX quota allocation](../../quota-allocation.md) — notes that later versions may replace slots with real token spend or cost.
+- [LoopX status data contract](../../status-data-contract.md) — the public contract this RFC changes.
+- Issue #3085 — the feature request and maintainer guidance this RFC follows.
+
+This RFC excludes private conversations, internal links, local filesystem paths,
+credentials, and raw transcripts.

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -446,7 +446,7 @@ goals must stay out of the eligible lane even when they have a high
     "available": true,
     "source": "run_history",
     "sample_run_count": 2,
-    "proxy_note": "run-history proxy; excludes token counts and raw thread logs",
+    "proxy_note": "run-history proxy; carries aggregate token/cost/duration, excludes raw thread logs",
     "totals": {
       "runs_24h": 2,
       "runs_7d": 2,
@@ -455,7 +455,17 @@ goals must stay out of the eligible lane even when they have a high
       "automation_run_count_24h": 1,
       "automation_run_count_7d": 1,
       "progress_signal_run_count_24h": 1,
-      "progress_signal_run_count_7d": 1
+      "progress_signal_run_count_7d": 1,
+      "input_tokens_24h": 0,
+      "input_tokens_7d": 0,
+      "output_tokens_24h": 0,
+      "output_tokens_7d": 0,
+      "cache_tokens_24h": 0,
+      "cache_tokens_7d": 0,
+      "cost_usd_24h": 0.0,
+      "cost_usd_7d": 0.0,
+      "duration_ms_24h": 0,
+      "duration_ms_7d": 0
     },
     "goals": []
   }
@@ -476,7 +486,9 @@ first-screen UI are `ok`, `contract`, and `attention_queue`.
 `status_contract`, `event_ledger_summary`, `promotion_readiness_summary`,
 `promotion_gate`, `decision_freshness_summary`, and `usage_summary` are optional and should be
 treated as compact protocol or run-history projections, not as the ledger
-itself, billing telemetry, token telemetry, or a release operation source. A
+itself, authoritative billing telemetry, or a release operation source.
+`usage_summary` carries aggregate token/cost/duration when runs report usage,
+but it remains a run-history proxy, not billing of record. A
 missing `status_contract` means an older status producer; loopback dashboards
 should surface that as a daemon freshness warning rather than silently hiding
 newer panels.
@@ -2269,9 +2281,12 @@ projection and cannot clear the warning.
 ## Usage Summary
 
 `usage_summary` is an optional dashboard-friendly proxy derived from the same
-compact run history. It is not billing telemetry and intentionally excludes
-token counts, raw thread logs, local project paths, private artifact contents,
-or anything that would require reading a Codex session transcript.
+compact run history. When a run reports usage, the summary carries aggregate
+input/output/cache token counts, an estimated cost, and wall-time duration for
+the goal; runs that report nothing contribute nothing. It remains a proxy, not
+billing telemetry: it still excludes raw thread logs, local project paths,
+private artifact contents, or anything that would require reading a Codex
+session transcript. Only aggregate numeric usage is captured.
 
 The summary currently reports:
 
@@ -2289,6 +2304,13 @@ The summary currently reports:
   `state_refreshed`, so dashboards can spot automation loops that keep spending
   or refreshing state without producing a fresh delivery, validation, mapping,
   blocker, or gate signal.
+- `input_tokens_24h` / `input_tokens_7d`, `output_tokens_24h` /
+  `output_tokens_7d`, `cache_tokens_24h` / `cache_tokens_7d`: aggregate token
+  counts for runs that report a normalized `usage` block. Goals whose runs
+  report no usage stay at zero.
+- `cost_usd_24h` / `cost_usd_7d`: aggregate estimated cost in USD, rounded to
+  six decimals, computed by the reporting runtime.
+- `duration_ms_24h` / `duration_ms_7d`: aggregate wall-time in milliseconds.
 - `project_share_24h`: per-goal share of observed 24h runs, rounded to three
   decimals.
 

--- a/loopx/control_plane/quota/usage_collector.py
+++ b/loopx/control_plane/quota/usage_collector.py
@@ -2,14 +2,13 @@
 
 This module is the capture layer described in
 ``docs/architecture/rfcs/goal-usage-token-cost-v0.md``. It defines the
-normalized, public-safe per-run usage shape and two sides of the seam:
+normalized, public-safe per-run usage shape and the consumption side of the
+seam: ``collect_usage_for_run`` reads a normalized ``usage`` block off a run
+dict for the aggregate loop in ``usage_summary``. It is provider-agnostic and
+performs no file IO.
 
-- ``collect_usage_for_run`` reads a normalized ``usage`` block off a run dict
-  for the aggregate loop in ``usage_summary``. It is provider-agnostic and
-  performs no file IO.
-- ``extract_codex_session_usage`` is the Codex ingestion helper: it reads a
-  Codex session directory and returns the final cumulative token figure,
-  reusing the extraction approach proven on the benchmark path.
+The ingestion side (writing a ``usage`` block onto each runtime's run records)
+is a follow-up slice and lands together with its callers and tests.
 
 Only aggregate numeric usage lives here. Prompts, completions, tool output,
 credentials, and anything that reconstructs a conversation are never captured.
@@ -17,9 +16,7 @@ credentials, and anything that reconstructs a conversation are never captured.
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any
 
 
@@ -83,58 +80,4 @@ def collect_usage_for_run(run: dict[str, Any]) -> UsageSample | None:
         duration_ms=_coerce_int(usage.get("duration_ms")) or 0,
         provider=str(usage.get("provider") or "unknown"),
         model=str(usage.get("model") or "unknown"),
-    )
-
-
-def extract_codex_session_usage(session_dir: Path) -> UsageSample | None:
-    """Extract the final cumulative token count from a Codex session dir.
-
-    Reuses the benchmark extraction approach: scan the session JSONL files for
-    the last ``token_count`` event and read its cumulative ``total_token_usage``
-    figure. Cost and wall-time are not present in the session log; the caller
-    fills them from pricing and run wall-time when assembling the run record.
-    """
-    latest_input: int | None = None
-    latest_output: int | None = None
-    latest_cache = 0
-    for session_file in sorted(session_dir.glob("*.jsonl")):
-        try:
-            lines = session_file.read_text(encoding="utf-8").splitlines()
-        except OSError:
-            continue
-        for line in lines:
-            try:
-                event = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if event.get("type") != "event_msg":
-                continue
-            payload = event.get("payload")
-            if not isinstance(payload, dict) or payload.get("type") != "token_count":
-                continue
-            info = payload.get("info")
-            if not isinstance(info, dict):
-                continue
-            total = info.get("total_token_usage")
-            if not isinstance(total, dict):
-                continue
-            input_tokens = _coerce_int(total.get("input_tokens"))
-            output_tokens = _coerce_int(total.get("output_tokens"))
-            if input_tokens is None or output_tokens is None:
-                continue
-            latest_input = input_tokens
-            latest_output = output_tokens
-            cache_tokens = _coerce_int(total.get("cached_input_tokens"))
-            if cache_tokens is not None:
-                latest_cache = cache_tokens
-    if latest_input is None or latest_output is None:
-        return None
-    return UsageSample(
-        input_tokens=latest_input,
-        output_tokens=latest_output,
-        cache_tokens=latest_cache,
-        cost_usd=0.0,
-        duration_ms=0,
-        provider="codex",
-        model="codex",
     )

--- a/loopx/control_plane/quota/usage_collector.py
+++ b/loopx/control_plane/quota/usage_collector.py
@@ -1,0 +1,140 @@
+"""Provider-neutral usage capture seam for per-goal token/cost/duration.
+
+This module is the capture layer described in
+``docs/architecture/rfcs/goal-usage-token-cost-v0.md``. It defines the
+normalized, public-safe per-run usage shape and two sides of the seam:
+
+- ``collect_usage_for_run`` reads a normalized ``usage`` block off a run dict
+  for the aggregate loop in ``usage_summary``. It is provider-agnostic and
+  performs no file IO.
+- ``extract_codex_session_usage`` is the Codex ingestion helper: it reads a
+  Codex session directory and returns the final cumulative token figure,
+  reusing the extraction approach proven on the benchmark path.
+
+Only aggregate numeric usage lives here. Prompts, completions, tool output,
+credentials, and anything that reconstructs a conversation are never captured.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class UsageSample:
+    """Normalized, public-safe per-run LLM usage.
+
+    Every field is aggregate numeric metadata. ``cost_usd`` and
+    ``duration_ms`` may be zero when a runtime cannot measure them; the caller
+    (the ingestion side) is responsible for filling them when the model id and
+    wall-time are known.
+    """
+
+    input_tokens: int
+    output_tokens: int
+    cache_tokens: int
+    cost_usd: float
+    duration_ms: int
+    provider: str
+    model: str
+
+
+def _coerce_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        coerced = int(value)
+        return coerced if coerced >= 0 else None
+    return None
+
+
+def _coerce_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        coerced = float(value)
+        return coerced if coerced >= 0 else None
+    return None
+
+
+def collect_usage_for_run(run: dict[str, Any]) -> UsageSample | None:
+    """Return normalized usage for a run, or ``None`` if the run reports none.
+
+    Reads an optional ``usage`` block on the run dict. Runtimes that have not
+    yet been wired to report usage contribute nothing, so the aggregate
+    degrades gracefully to the prior run-history behavior.
+    """
+    usage = run.get("usage")
+    if not isinstance(usage, dict):
+        return None
+    input_tokens = _coerce_int(usage.get("input_tokens"))
+    output_tokens = _coerce_int(usage.get("output_tokens"))
+    # A run claiming zero input and zero output has nothing aggregate-worthy.
+    if input_tokens is None and output_tokens is None:
+        return None
+    return UsageSample(
+        input_tokens=input_tokens or 0,
+        output_tokens=output_tokens or 0,
+        cache_tokens=_coerce_int(usage.get("cache_tokens")) or 0,
+        cost_usd=_coerce_float(usage.get("cost_usd")) or 0.0,
+        duration_ms=_coerce_int(usage.get("duration_ms")) or 0,
+        provider=str(usage.get("provider") or "unknown"),
+        model=str(usage.get("model") or "unknown"),
+    )
+
+
+def extract_codex_session_usage(session_dir: Path) -> UsageSample | None:
+    """Extract the final cumulative token count from a Codex session dir.
+
+    Reuses the benchmark extraction approach: scan the session JSONL files for
+    the last ``token_count`` event and read its cumulative ``total_token_usage``
+    figure. Cost and wall-time are not present in the session log; the caller
+    fills them from pricing and run wall-time when assembling the run record.
+    """
+    latest_input: int | None = None
+    latest_output: int | None = None
+    latest_cache = 0
+    for session_file in sorted(session_dir.glob("*.jsonl")):
+        try:
+            lines = session_file.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        for line in lines:
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if event.get("type") != "event_msg":
+                continue
+            payload = event.get("payload")
+            if not isinstance(payload, dict) or payload.get("type") != "token_count":
+                continue
+            info = payload.get("info")
+            if not isinstance(info, dict):
+                continue
+            total = info.get("total_token_usage")
+            if not isinstance(total, dict):
+                continue
+            input_tokens = _coerce_int(total.get("input_tokens"))
+            output_tokens = _coerce_int(total.get("output_tokens"))
+            if input_tokens is None or output_tokens is None:
+                continue
+            latest_input = input_tokens
+            latest_output = output_tokens
+            cache_tokens = _coerce_int(total.get("cached_input_tokens"))
+            if cache_tokens is not None:
+                latest_cache = cache_tokens
+    if latest_input is None or latest_output is None:
+        return None
+    return UsageSample(
+        input_tokens=latest_input,
+        output_tokens=latest_output,
+        cache_tokens=latest_cache,
+        cost_usd=0.0,
+        duration_ms=0,
+        provider="codex",
+        model="codex",
+    )

--- a/loopx/control_plane/quota/usage_summary.py
+++ b/loopx/control_plane/quota/usage_summary.py
@@ -4,9 +4,13 @@ from datetime import timedelta
 from typing import Any, Callable
 
 from .spend_sources import VISIBLE_GOAL_SLOT_SPEND_SOURCE
+from .usage_collector import UsageSample, collect_usage_for_run
 from ..runtime.time import now_utc
 
-USAGE_PROXY_NOTE = "run-history proxy; excludes token counts and raw thread logs"
+USAGE_PROXY_NOTE = (
+    "run-history proxy; carries aggregate token/cost/duration, "
+    "excludes raw thread logs"
+)
 
 ParseTimestamp = Callable[[Any], Any]
 
@@ -55,7 +59,32 @@ def blank_usage_goal(goal_id: str) -> dict[str, Any]:
         "progress_signal_run_count_24h": 0,
         "progress_signal_run_count_7d": 0,
         "project_share_24h": 0.0,
+        "input_tokens_24h": 0,
+        "input_tokens_7d": 0,
+        "output_tokens_24h": 0,
+        "output_tokens_7d": 0,
+        "cache_tokens_24h": 0,
+        "cache_tokens_7d": 0,
+        "cost_usd_24h": 0.0,
+        "cost_usd_7d": 0.0,
+        "duration_ms_24h": 0,
+        "duration_ms_7d": 0,
     }
+
+
+def _accumulate_usage(bucket: dict[str, Any], sample: UsageSample, suffix: str) -> None:
+    bucket[f"input_tokens_{suffix}"] += sample.input_tokens
+    bucket[f"output_tokens_{suffix}"] += sample.output_tokens
+    bucket[f"cache_tokens_{suffix}"] += sample.cache_tokens
+    bucket[f"cost_usd_{suffix}"] += sample.cost_usd
+    bucket[f"duration_ms_{suffix}"] += sample.duration_ms
+
+
+def _round_cost(bucket: dict[str, Any]) -> None:
+    for suffix in ("24h", "7d"):
+        key = f"cost_usd_{suffix}"
+        if key in bucket:
+            bucket[key] = round(float(bucket[key]), 6)
 
 
 def build_usage_summary(
@@ -75,6 +104,16 @@ def build_usage_summary(
         "automation_run_count_7d": 0,
         "progress_signal_run_count_24h": 0,
         "progress_signal_run_count_7d": 0,
+        "input_tokens_24h": 0,
+        "input_tokens_7d": 0,
+        "output_tokens_24h": 0,
+        "output_tokens_7d": 0,
+        "cache_tokens_24h": 0,
+        "cache_tokens_7d": 0,
+        "cost_usd_24h": 0.0,
+        "cost_usd_7d": 0.0,
+        "duration_ms_24h": 0,
+        "duration_ms_7d": 0,
     }
     goals: dict[str, dict[str, Any]] = {}
     sample_count = 0
@@ -91,6 +130,7 @@ def build_usage_summary(
         slots = quota_spend_slots(run)
         automation_event = is_automation_run(run)
         progress_signal = is_progress_signal_run(run)
+        usage_sample = collect_usage_for_run(run)
 
         if generated_at >= cutoff_7d:
             totals["runs_7d"] += 1
@@ -103,6 +143,9 @@ def build_usage_summary(
             if progress_signal:
                 totals["progress_signal_run_count_7d"] += 1
                 goal["progress_signal_run_count_7d"] += 1
+            if usage_sample is not None:
+                _accumulate_usage(totals, usage_sample, "7d")
+                _accumulate_usage(goal, usage_sample, "7d")
         if generated_at >= cutoff_24h:
             totals["runs_24h"] += 1
             goal["runs_24h"] += 1
@@ -114,16 +157,25 @@ def build_usage_summary(
             if progress_signal:
                 totals["progress_signal_run_count_24h"] += 1
                 goal["progress_signal_run_count_24h"] += 1
+            if usage_sample is not None:
+                _accumulate_usage(totals, usage_sample, "24h")
+                _accumulate_usage(goal, usage_sample, "24h")
 
     if totals["runs_24h"]:
         for goal in goals.values():
             goal["project_share_24h"] = round(goal["runs_24h"] / totals["runs_24h"], 3)
+
+    _round_cost(totals)
+    for goal in goals.values():
+        _round_cost(goal)
 
     goal_rows = sorted(
         goals.values(),
         key=lambda item: (
             item["runs_24h"],
             item["quota_spend_slots_24h"],
+            item["cost_usd_24h"],
+            item["input_tokens_24h"],
             item["runs_7d"],
             item["goal_id"],
         ),

--- a/tests/control_plane/test_usage_summary.py
+++ b/tests/control_plane/test_usage_summary.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from loopx.control_plane.quota.usage_collector import (
+    UsageSample,
+    collect_usage_for_run,
+)
+from loopx.control_plane.quota.usage_summary import (
+    blank_usage_goal,
+    build_usage_summary,
+)
+
+
+def _run(
+    goal_id: str,
+    *,
+    generated_at: datetime,
+    usage: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    run: dict[str, Any] = {"goal_id": goal_id, "generated_at": generated_at}
+    if usage is not None:
+        run["usage"] = usage
+    return run
+
+
+def _identity_parse(value: Any) -> Any:
+    return value
+
+
+def test_blank_usage_goal_has_usage_fields() -> None:
+    goal = blank_usage_goal("g1")
+    for suffix in ("24h", "7d"):
+        assert goal[f"input_tokens_{suffix}"] == 0
+        assert goal[f"output_tokens_{suffix}"] == 0
+        assert goal[f"cache_tokens_{suffix}"] == 0
+        assert goal[f"cost_usd_{suffix}"] == 0.0
+        assert goal[f"duration_ms_{suffix}"] == 0
+
+
+def test_collect_usage_for_run_returns_none_without_usage_block() -> None:
+    assert collect_usage_for_run({"goal_id": "g1"}) is None
+    assert collect_usage_for_run({"goal_id": "g1", "usage": "not-a-dict"}) is None
+
+
+def test_collect_usage_for_run_returns_none_when_no_tokens() -> None:
+    # cost alone, with no tokens, is not aggregate-worthy.
+    assert collect_usage_for_run({"usage": {"cost_usd": 0.1}}) is None
+
+
+def test_collect_usage_for_run_normalizes_fields() -> None:
+    sample = collect_usage_for_run(
+        {
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_tokens": 20,
+                "cost_usd": 0.2,
+                "duration_ms": 5000,
+                "provider": "codex",
+                "model": "codex-1",
+            }
+        }
+    )
+    assert sample == UsageSample(100, 50, 20, 0.2, 5000, "codex", "codex-1")
+
+
+def test_build_usage_summary_aggregates_usage_within_windows() -> None:
+    now = datetime.now(timezone.utc)
+    history = {
+        "runs": [
+            _run(
+                "g1",
+                generated_at=now,
+                usage={
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "cache_tokens": 20,
+                    "cost_usd": 0.1,
+                    "duration_ms": 1000,
+                    "provider": "codex",
+                    "model": "codex",
+                },
+            ),
+            _run(
+                "g1",
+                generated_at=now,
+                usage={
+                    "input_tokens": 200,
+                    "output_tokens": 60,
+                    "cost_usd": 0.2,
+                    "duration_ms": 2000,
+                    "provider": "codex",
+                    "model": "codex",
+                },
+            ),
+        ]
+    }
+    summary = build_usage_summary(history, parse_timestamp=_identity_parse)
+    totals = summary["totals"]
+    assert totals["input_tokens_24h"] == 300
+    assert totals["output_tokens_24h"] == 110
+    assert totals["cache_tokens_24h"] == 20
+    assert totals["cost_usd_24h"] == round(0.1 + 0.2, 6)
+    assert totals["duration_ms_24h"] == 3000
+    goal = summary["goals"][0]
+    assert goal["goal_id"] == "g1"
+    assert goal["input_tokens_24h"] == 300
+
+
+def test_build_usage_summary_degrades_when_runs_report_no_usage() -> None:
+    now = datetime.now(timezone.utc)
+    history = {"runs": [_run("g1", generated_at=now)]}
+    summary = build_usage_summary(history, parse_timestamp=_identity_parse)
+    assert summary["totals"]["input_tokens_24h"] == 0
+    assert summary["totals"]["cost_usd_24h"] == 0.0
+    # existing run accounting still works alongside the new fields
+    assert summary["totals"]["runs_24h"] == 1
+
+
+def test_build_usage_summary_keeps_old_runs_out_of_usage_windows() -> None:
+    now = datetime.now(timezone.utc)
+    old = now - timedelta(days=10)
+    history = {
+        "runs": [
+            _run(
+                "g1",
+                generated_at=now,
+                usage={
+                    "input_tokens": 100,
+                    "output_tokens": 1,
+                    "provider": "codex",
+                    "model": "codex",
+                },
+            ),
+            _run(
+                "g1",
+                generated_at=old,
+                usage={
+                    "input_tokens": 999,
+                    "output_tokens": 1,
+                    "provider": "codex",
+                    "model": "codex",
+                },
+            ),
+        ]
+    }
+    summary = build_usage_summary(history, parse_timestamp=_identity_parse)
+    assert summary["totals"]["input_tokens_7d"] == 100
+    assert summary["totals"]["input_tokens_24h"] == 100
+
+
+def test_build_usage_summary_is_provider_neutral() -> None:
+    now = datetime.now(timezone.utc)
+    history = {
+        "runs": [
+            _run(
+                "g1",
+                generated_at=now,
+                usage={
+                    "input_tokens": 10,
+                    "output_tokens": 1,
+                    "provider": "codex",
+                    "model": "codex",
+                },
+            ),
+            _run(
+                "g1",
+                generated_at=now,
+                usage={
+                    "input_tokens": 40,
+                    "output_tokens": 1,
+                    "provider": "claude",
+                    "model": "claude-x",
+                },
+            ),
+        ]
+    }
+    summary = build_usage_summary(history, parse_timestamp=_identity_parse)
+    assert summary["totals"]["input_tokens_24h"] == 50
+
+
+def test_build_usage_summary_rounds_cost_to_avoid_float_drift() -> None:
+    now = datetime.now(timezone.utc)
+    history = {
+        "runs": [
+            _run(
+                "g1",
+                generated_at=now,
+                usage={
+                    "input_tokens": 1,
+                    "output_tokens": 1,
+                    "cost_usd": 0.1,
+                    "provider": "x",
+                    "model": "y",
+                },
+            ),
+            _run(
+                "g1",
+                generated_at=now,
+                usage={
+                    "input_tokens": 1,
+                    "output_tokens": 1,
+                    "cost_usd": 0.2,
+                    "provider": "x",
+                    "model": "y",
+                },
+            ),
+        ]
+    }
+    summary = build_usage_summary(history, parse_timestamp=_identity_parse)
+    assert summary["totals"]["cost_usd_24h"] == 0.3

--- a/tests/control_plane/test_usage_summary.py
+++ b/tests/control_plane/test_usage_summary.py
@@ -211,3 +211,40 @@ def test_build_usage_summary_rounds_cost_to_avoid_float_drift() -> None:
     }
     summary = build_usage_summary(history, parse_timestamp=_identity_parse)
     assert summary["totals"]["cost_usd_24h"] == 0.3
+
+
+def test_collect_usage_for_run_rejects_bool_tokens() -> None:
+    # bool is not a valid token count and must not be accepted as 1.
+    sample = collect_usage_for_run(
+        {"usage": {"input_tokens": True, "output_tokens": 10}}
+    )
+    assert sample is not None
+    assert sample.input_tokens == 0
+    assert sample.output_tokens == 10
+
+
+def test_collect_usage_for_run_rejects_negative_tokens() -> None:
+    sample = collect_usage_for_run(
+        {"usage": {"input_tokens": -100, "output_tokens": 10}}
+    )
+    assert sample is not None
+    assert sample.input_tokens == 0
+    assert sample.output_tokens == 10
+
+
+def test_collect_usage_for_run_rejects_non_numeric_tokens() -> None:
+    # a numeric string is not coerced; only real numbers count.
+    sample = collect_usage_for_run(
+        {"usage": {"input_tokens": "100", "output_tokens": 10}}
+    )
+    assert sample is not None
+    assert sample.input_tokens == 0
+    assert sample.output_tokens == 10
+
+
+def test_collect_usage_for_run_rejects_negative_cost() -> None:
+    sample = collect_usage_for_run(
+        {"usage": {"input_tokens": 1, "output_tokens": 1, "cost_usd": -0.5}}
+    )
+    assert sample is not None
+    assert sample.cost_usd == 0.0


### PR DESCRIPTION
Implements the smallest useful slice from RFC `goal-usage-token-cost-v0` (included), per #3085.

**Delivered**: capture seam (`usage_collector.py`) + aggregate (`usage_summary.py` now carries token/cost/duration) + contract update + dashboard cards + 9 unit tests.

**Validated**: 9/9 tests pass; end-to-end data flow verified with a mock Codex session.

**Architecture question for you**: Codex reports usage at the **goal level** (`tokensUsed`), but `usage_summary` aggregates at the **run level**. Mapping goal→run is a design call (per-run incremental vs goal-level snapshot), so I did **not** wire ingestion yet — it needs your direction. claude/opencode/pi each need their own adapter too.
