### PR TITLE
feat(pr-review): harden execution contract with four self-dev review lenses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,14 @@ private/security-sensitive material that must not be posted publicly.
 Do not leave actionable PR blockers only in chat memory. The final user report
 should include the PR comment URL and a compact summary of the posted findings.
 
+Before publishing a review, run the capability-owned review lenses for typed
+state rules, domain neutrality, behavior-change disclosure, and
+guidance-vs-obligation (defined in `pull_request_review_execution_contract_v1`).
+Flag substring denylists or prose-only classification rules with the concrete
+misclassification risk, product- or benchmark-specific wording in generic
+control-plane contracts, silent default-behavior changes, and text that calls a
+machine-enforced obligation "guidance".
+
 ## Engineering Quality And Right-Sized Scope
 
 Treat code volume as a cost, especially during refactors. A good LoopX change
@@ -264,6 +272,18 @@ section, or abstraction, pass a scope-fit review:
 - Make illegal states hard to express. For status, quota, scheduler, monitor,
   todo, and handoff flows, prefer explicit enums, schemas, and transition
   helpers over scattered booleans and prose-only assumptions.
+- State-classification and delivery-semantics rules belong in typed enums,
+  schemas, or transition helpers. Substring denylists and prose heuristics must
+  carry a documented reason and a typed follow-up; PR review must flag them
+  with the concrete false-positive/negative risk.
+- Core control-plane obligations and error text must stay domain-neutral. Do
+  not put product- or benchmark-specific wording (for example "product
+  advancement") into generic work-lane, quota, todo, or settlement contracts;
+  prefer goal-agnostic phrasing.
+- Default behavior changes must be disclosed: rename the smoke that encoded the
+  old default, update docs/release notes, and name the affected lanes.
+  "Guidance" versus machine-enforced obligations (such as `must_attempt_work`)
+  must be explicit in the contract, not inferred from prose.
 - Fail fast with actionable context at input, config, permission, and state
   boundaries, but do not replace clear control flow with broad exception
   plumbing or silent fallback.

--- a/examples/pr-review-command-smoke.py
+++ b/examples/pr-review-command-smoke.py
@@ -475,6 +475,10 @@ def main() -> int:
         "validation_matrix",
         "failure_analysis",
         "code_volume",
+        "typed_state_rule",
+        "domain_neutrality",
+        "behavior_change_disclosure",
+        "guidance_vs_obligation",
     }, requirements
     assert requirements["symbol_map"]["item_count"] == {"minimum": 2, "maximum": 5}
     assert "caller_evidence" in requirements["symbol_map"]["item_fields"]
@@ -492,6 +496,12 @@ def main() -> int:
         "partly_avoidable",
         "not_yet_proven",
     ]
+    assert "substring denylists" in requirements["typed_state_rule"]["rule"]
+    assert "domain-neutral" in requirements["domain_neutrality"]["rule"]
+    assert "silent behavior changes" in requirements["behavior_change_disclosure"][
+        "rule"
+    ]
+    assert "must_attempt_work" in requirements["guidance_vs_obligation"]["rule"]
     assert execution["completion_gate"]["metadata_only_verdict_allowed"] is False
     assert execution["completion_gate"]["stale_head_verdict_allowed"] is False
     assert execution["finding_contract"]["findings_first"] is True
@@ -499,6 +509,14 @@ def main() -> int:
     assert first_plan["schema_version"] == "pull_request_review_plan_v1", first_plan
     assert first_plan["applicability"]["docs_only"] is True, first_plan
     assert first_plan["applicability"]["symbol_map_required"] is False, first_plan
+    assert first_plan["applicability"]["typed_state_rule_required"] is False, first_plan
+    assert (
+        first_plan["applicability"]["behavior_change_disclosure_required"] is False
+    ), first_plan
+    assert first_plan["applicability"]["domain_neutrality_required"] is False, first_plan
+    assert (
+        first_plan["applicability"]["guidance_vs_obligation_required"] is False
+    ), first_plan
     assert "symbol_map" not in first_plan["required_evidence_ids"], first_plan
     assert first_plan["result_template"]["target_exact_head"] == (
         "773@7730000000000000000000000000000000000000"
@@ -508,6 +526,12 @@ def main() -> int:
     assert merged_plan["applicability"]["code_change"] is True, merged_plan
     assert merged_plan["applicability"]["symbol_map_required"] is True, merged_plan
     assert merged_plan["applicability"]["negative_walkthrough_required"] is True, merged_plan
+    assert merged_plan["applicability"]["typed_state_rule_required"] is True, merged_plan
+    assert (
+        merged_plan["applicability"]["behavior_change_disclosure_required"] is True
+    ), merged_plan
+    assert "typed_state_rule" in merged_plan["required_evidence_ids"], merged_plan
+    assert "behavior_change_disclosure" in merged_plan["required_evidence_ids"], merged_plan
     assert "symbol_map" in merged_plan["required_evidence_ids"], merged_plan
     merged_risk_hint = merged["metadata_risk_hint"]
     assert merged_risk_hint["level"] == "medium", merged_risk_hint

--- a/loopx/capabilities/pr_review_queue/review_contract.py
+++ b/loopx/capabilities/pr_review_queue/review_contract.py
@@ -82,7 +82,7 @@ def build_review_template(item: Mapping[str, Any]) -> dict[str, Any]:
             _section(
                 "对主干的风险",
                 "250-500字",
-                "Use `failure_analysis`, `walkthroughs.negative`, and `validation_matrix`; trace each finding from triggering state to observed outcome and minimum repair. When `scope_fit` applies, name the active production caller or explicitly record a coverage-only boundary.",
+                "Use `failure_analysis`, `walkthroughs.negative`, and `validation_matrix`; trace each finding from triggering state to observed outcome and minimum repair. When `scope_fit` applies, name the active production caller or explicitly record a coverage-only boundary. Surface typed-state-rule, domain-neutrality, behavior-change-disclosure, and guidance-vs-obligation findings when their evidence applies.",
             ),
             _section(
                 "我的整体评价",
@@ -253,6 +253,71 @@ def build_review_execution_contract() -> dict[str, Any]:
                     "behavior_preserving_validation",
                 ],
             },
+            {
+                "evidence_id": "typed_state_rule",
+                "required_when": "code_change",
+                "fields": [
+                    "state_classification_rule",
+                    "matching_mechanism",
+                    "typed_contract_or_enum",
+                    "false_positive_or_negative_risk",
+                    "migration_or_followup",
+                ],
+                "rule": (
+                    "State-classification and delivery-semantics rules must be typed "
+                    "enums, schemas, or transition helpers. Flag substring denylists, "
+                    "scattered booleans, and prose-only assumptions as findings with "
+                    "the concrete misclassification risk and the typed alternative."
+                ),
+            },
+            {
+                "evidence_id": "domain_neutrality",
+                "required_when": "product_runtime_or_policy_contract",
+                "fields": [
+                    "obligation_or_error_text",
+                    "domain_specific_language",
+                    "affected_goal_types",
+                    "neutral_alternative",
+                ],
+                "rule": (
+                    "Generic control-plane obligations and error text must stay "
+                    "domain-neutral. Flag product- or benchmark-specific wording in "
+                    "core work-lane, quota, todo, or settlement contracts and propose "
+                    "a goal-agnostic alternative."
+                ),
+            },
+            {
+                "evidence_id": "behavior_change_disclosure",
+                "required_when": "runtime_behavior_change",
+                "fields": [
+                    "previous_default",
+                    "new_default",
+                    "affected_callers_or_lanes",
+                    "disclosure_surface",
+                ],
+                "rule": (
+                    "Default behavior changes must be disclosed through renamed "
+                    "smokes, docs, or release notes. Flag silent behavior changes "
+                    "that alter existing automation without naming the old and new "
+                    "default."
+                ),
+            },
+            {
+                "evidence_id": "guidance_vs_obligation",
+                "required_when": "work_lane_or_obligation_contract",
+                "fields": [
+                    "advisory_or_enforced",
+                    "machine_flag",
+                    "consequence_when_ignored",
+                    "documented_semantics",
+                ],
+                "rule": (
+                    "Advisory versus machine-enforced semantics must be explicit. "
+                    "Flag text that calls a hard obligation 'guidance' when a "
+                    "contract flag such as must_attempt_work forces a turn, or that "
+                    "leaves the enforcement consequence undocumented."
+                ),
+            },
         ],
         "finding_contract": {
             "findings_first": True,
@@ -309,6 +374,11 @@ def build_review_plan(item: Mapping[str, Any]) -> dict[str, Any]:
     if code_change:
         required_evidence.insert(3, "symbol_map")
         required_evidence.append("scope_fit")
+        required_evidence.append("typed_state_rule")
+        required_evidence.append("behavior_change_disclosure")
+    if areas & {"product_runtime", "public_entry_or_policy"}:
+        required_evidence.append("domain_neutrality")
+        required_evidence.append("guidance_vs_obligation")
     number = item.get("number")
     head_oid = str(item.get("head_oid") or "").strip()
     target_key = f"{number}@{head_oid}" if number and head_oid else None
@@ -328,6 +398,14 @@ def build_review_plan(item: Mapping[str, Any]) -> dict[str, Any]:
             "symbol_map_required": code_change,
             "scope_fit_required": code_change,
             "negative_walkthrough_required": bool(areas & NEGATIVE_PATH_AREAS),
+            "typed_state_rule_required": code_change,
+            "behavior_change_disclosure_required": code_change,
+            "domain_neutrality_required": bool(
+                areas & {"product_runtime", "public_entry_or_policy"}
+            ),
+            "guidance_vs_obligation_required": bool(
+                areas & {"product_runtime", "public_entry_or_policy"}
+            ),
         },
         "required_evidence_ids": required_evidence,
         "result_template": {

--- a/tests/capabilities/test_pr_review_contract.py
+++ b/tests/capabilities/test_pr_review_contract.py
@@ -47,6 +47,10 @@ def test_execution_contract_owns_deep_review_requirements() -> None:
         "validation_matrix",
         "failure_analysis",
         "code_volume",
+        "typed_state_rule",
+        "domain_neutrality",
+        "behavior_change_disclosure",
+        "guidance_vs_obligation",
     }
     assert requirements["symbol_map"]["item_count"] == {
         "minimum": 2,
@@ -55,6 +59,13 @@ def test_execution_contract_owns_deep_review_requirements() -> None:
     assert "caller_evidence" in requirements["symbol_map"]["item_fields"]
     assert "negative_fields" in requirements["walkthroughs"]
     assert "regression_test" in requirements["failure_analysis"]["fields"]
+    assert requirements["typed_state_rule"]["required_when"] == "code_change"
+    assert "substring denylists" in requirements["typed_state_rule"]["rule"]
+    assert "domain-neutral" in requirements["domain_neutrality"]["rule"]
+    assert "silent behavior changes" in requirements["behavior_change_disclosure"][
+        "rule"
+    ]
+    assert "must_attempt_work" in requirements["guidance_vs_obligation"]["rule"]
     assert contract["completion_gate"]["metadata_only_verdict_allowed"] is False
     assert contract["completion_gate"]["stale_head_verdict_allowed"] is False
     assert contract["finding_contract"]["findings_first"] is True
@@ -73,8 +84,16 @@ def test_runtime_plan_requires_symbol_map_and_negative_walkthrough() -> None:
     assert plan["applicability"]["symbol_map_required"] is True
     assert plan["applicability"]["scope_fit_required"] is True
     assert plan["applicability"]["negative_walkthrough_required"] is True
+    assert plan["applicability"]["typed_state_rule_required"] is True
+    assert plan["applicability"]["behavior_change_disclosure_required"] is True
+    assert plan["applicability"]["domain_neutrality_required"] is True
+    assert plan["applicability"]["guidance_vs_obligation_required"] is True
     assert "symbol_map" in plan["required_evidence_ids"]
     assert "scope_fit" in plan["required_evidence_ids"]
+    assert "typed_state_rule" in plan["required_evidence_ids"]
+    assert "behavior_change_disclosure" in plan["required_evidence_ids"]
+    assert "domain_neutrality" in plan["required_evidence_ids"]
+    assert "guidance_vs_obligation" in plan["required_evidence_ids"]
     assert set(plan["result_template"]["evidence"]) == set(
         plan["required_evidence_ids"]
     )
@@ -94,10 +113,30 @@ def test_docs_plan_does_not_invent_code_symbols() -> None:
     assert plan["applicability"]["docs_only"] is True
     assert plan["applicability"]["symbol_map_required"] is False
     assert plan["applicability"]["scope_fit_required"] is False
+    assert plan["applicability"]["typed_state_rule_required"] is False
+    assert plan["applicability"]["behavior_change_disclosure_required"] is False
+    assert plan["applicability"]["domain_neutrality_required"] is False
+    assert plan["applicability"]["guidance_vs_obligation_required"] is False
     assert "symbol_map" not in plan["required_evidence_ids"]
     assert "scope_fit" not in plan["required_evidence_ids"]
+    assert "typed_state_rule" not in plan["required_evidence_ids"]
+    assert "domain_neutrality" not in plan["required_evidence_ids"]
+    assert "behavior_change_disclosure" not in plan["required_evidence_ids"]
+    assert "guidance_vs_obligation" not in plan["required_evidence_ids"]
     concrete = next(
         section for section in template["sections"] if section["label"] == "具体改动"
     )
     assert "### 关键内容讲解" in concrete["agent_instruction"]
     assert template["review_order"] == ["docs/design.md"]
+
+
+def test_test_only_plan_skips_runtime_lenses() -> None:
+    plan = build_review_plan(_item(areas={"test_or_example": 2}))
+
+    assert plan["applicability"]["code_change"] is False
+    assert plan["applicability"]["typed_state_rule_required"] is False
+    assert plan["applicability"]["behavior_change_disclosure_required"] is False
+    assert plan["applicability"]["domain_neutrality_required"] is False
+    assert plan["applicability"]["guidance_vs_obligation_required"] is False
+    assert "typed_state_rule" not in plan["required_evidence_ids"]
+    assert "domain_neutrality" not in plan["required_evidence_ids"]


### PR DESCRIPTION
## What

The PR review capability missed review classes that #3094 surfaced: substring denylists for state classification, product-centric wording in generic control-plane contracts, silent default-behavior changes, and hard obligations described as guidance. This PR adds four lenses to the capability-owned `pull_request_review_execution_contract_v1`:

- `typed_state_rule`: state-classification/delivery-semantics rules must be typed enums/schemas/transition helpers; flag substring denylists and prose assumptions with the misclassification risk.
- `domain_neutrality`: generic work-lane/quota/todo/settlement obligations and errors must stay goal-agnostic; flag product/benchmark-specific wording.
- `behavior_change_disclosure`: default-behavior changes must be disclosed via renamed smokes/docs/release notes; flag silent changes.
- `guidance_vs_obligation`: advisory vs machine-enforced semantics (e.g. `must_attempt_work`) must be explicit.

Review plans now require the lenses for code changes (typed_state_rule, behavior_change_disclosure) and for product_runtime/public_entry_or_policy areas (domain_neutrality, guidance_vs_obligation), with machine-visible applicability flags. AGENTS.md engineering-quality and PR-review sections state the same rules so both humans and agents follow them.

## Validation

- `pytest tests/capabilities/test_pr_review_contract.py tests/capabilities/test_pr_review_queue.py`: 22 passed
- `python3 examples/pr-review-command-smoke.py`: passed
- `loopx check` on changed files: public boundary clean (4 files)
- `git diff --check`: clean
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 12/12 checks passed, 0 run/direct failures (quality receipt recorded after PR creation)