### PR TITLE
fix(contract): keep `loopx check` running past unreadable files

### DIFF
--- a/loopx/contract.py
+++ b/loopx/contract.py
@@ -672,6 +672,8 @@ def iter_scan_files(scan_root: Path) -> list[Path]:
             path = (current_dir / file_name).resolve()
             if path.name.endswith(".local.json"):
                 continue
+            if not path.is_file():
+                continue
             if path.suffix in DEFAULT_SCAN_SUFFIXES:
                 files.append(path)
     return sorted(set(files + tracked_files))
@@ -684,6 +686,7 @@ def scan_public_boundary(
     allowed_hits: list[str] = []
     private_state_git_warnings: list[str] = []
     skipped_private_state_files: list[str] = []
+    unreadable_files: list[str] = []
     files: list[Path] = []
     file_roots: dict[Path, Path] = {}
     for scan_root in scan_roots:
@@ -711,6 +714,9 @@ def scan_public_boundary(
             text = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             continue
+        except OSError as exc:
+            unreadable_files.append(f"{rel_or_abs(path, root)}: {exc.strerror or exc}")
+            continue
         for line_no, line in enumerate(text.splitlines(), start=1):
             for name, pattern in LEAK_PATTERNS.items():
                 if pattern.search(line):
@@ -727,6 +733,7 @@ def scan_public_boundary(
         "files": len(files),
         "scanned_files": len(files) - len(skipped_private_state_files),
         "skipped_private_state_files": skipped_private_state_files,
+        "unreadable_files": unreadable_files,
         "allowed_hits": allowed_hits,
         "private_state_git_warnings": private_state_git_warnings,
         "policy": policy,
@@ -867,6 +874,9 @@ def check_contract(
             f"{len(boundary.get('allowed_hits') or [])} private_doc_url hits"
         )
     warnings.extend(str(item) for item in boundary.get("private_state_git_warnings") or [])
+    warnings.extend(
+        f"unreadable file skipped: {item}" for item in boundary.get("unreadable_files") or []
+    )
     error_views = contract_error_views(error_diagnostics)
     errors = error_views["errors"]
 

--- a/tests/test_contract_scan_unreadable_files.py
+++ b/tests/test_contract_scan_unreadable_files.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from loopx.contract import iter_scan_files, scan_public_boundary
+
+
+def test_iter_scan_files_skips_dangling_symlink(tmp_path: Path) -> None:
+    package = tmp_path / "pkg"
+    package.mkdir()
+    (package / "ok.md").write_text("hello\n", encoding="utf-8")
+    (package / "dangling.json").symlink_to("../missing-target.json")
+
+    scanned = iter_scan_files(tmp_path)
+
+    assert [path.name for path in scanned] == ["ok.md"]
+
+
+def test_scan_public_boundary_survives_dangling_symlink(tmp_path: Path) -> None:
+    package = tmp_path / "pkg"
+    package.mkdir()
+    (package / "ok.md").write_text("hello\n", encoding="utf-8")
+    (package / "dangling.json").symlink_to("../missing-target.json")
+
+    payload = scan_public_boundary([tmp_path])
+
+    assert payload["ok"] is True
+    assert payload["scanned_files"] == 1
+    assert payload["unreadable_files"] == []
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root reads mode 000 files")
+def test_scan_public_boundary_reports_unreadable_file(tmp_path: Path) -> None:
+    (tmp_path / "ok.md").write_text("hello\n", encoding="utf-8")
+    locked = tmp_path / "locked.md"
+    locked.write_text("hello\n", encoding="utf-8")
+    locked.chmod(0o000)
+    try:
+        payload = scan_public_boundary([tmp_path])
+    finally:
+        locked.chmod(0o644)
+
+    assert payload["ok"] is True
+    assert payload["unreadable_files"] == ["locked.md: Permission denied"]


### PR DESCRIPTION
Closes #3121.

## Behavior change

One dangling symlink in the scan tree used to abort the entire `loopx check` run: `errors=1, warnings=0, checks=0`. The registry, runtime-root, user-gate and run-history checks never ran, even though the broken link says nothing about the public/private boundary.

Two guards, matching the suggestion in the issue:

- `iter_scan_files` — the `os.walk` branch appended every suffix match without checking that the resolved path exists (`_tracked_scan_files` already did check). A dangling symlink resolves to a missing target, so `path.is_file()` is `False` and it is now skipped. Regular files are unaffected.
- `scan_public_boundary` — the read guarded only `UnicodeDecodeError`. It now also catches `OSError`, which covers `FileNotFoundError`, `PermissionError` and `IsADirectoryError`, including the TOCTOU case where a file disappears between the walk and the read.

Unreadable-but-existing files are no longer silent: they land in a new `unreadable_files` field on the scan payload, and `check_contract` surfaces each one as `unreadable file skipped: <path>: <reason>`. Paths go through `rel_or_abs`, so they are reported relative to the scan root rather than as absolute local paths — the smaller point raised at the end of the issue.

## Validation

New file `tests/test_contract_scan_unreadable_files.py`, 3 tests: dangling symlink is skipped by `iter_scan_files`; the scan completes and reports the remaining file; a mode-000 file is reported as unreadable instead of aborting (skipped when running as root).

- The 3 new tests fail on `main` (`FileNotFoundError` / `PermissionError`) and pass with the fix.
- `python -m pytest -q -n 4`: 2798 passed, 17 failed, 2 skipped. The same 17 fail on unpatched `main` (2795 passed) — pre-existing on `main` at 0e1aa64, in `test_gemini_cursor_host_surfaces`, `control_plane/test_replan_evidence_tool_behavior` and `control_plane/test_scheduler_ack_current_host_binding`, all unrelated to this change.
- `python -m ruff check tests loopx/canary loopx/control_plane loopx/domain_packs loopx/presentation`: clean, and clean on `loopx/contract.py`.

Real-world case behind the issue: a plugin cache holding ~30,000 symlinks from a `bun` store, some pointing at removed packages. One broken link was enough to make `loopx check` unusable at that scope.

Happy to adjust the shape — e.g. make `unreadable_files` a check line instead of a warning, or drop the `check_contract` surfacing entirely and keep only the two guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)