### PR TITLE
fix(pr-review): stop passing statusCheckRollup to gh pr list

### DIFF
--- a/loopx/pr_review.py
+++ b/loopx/pr_review.py
@@ -112,6 +112,49 @@ def _run_gh_json(args: list[str], *, cwd: Path | None = None) -> Any:
     return json.loads(proc.stdout or "null")
 
 
+def _attach_status_check_rollup(
+    row: dict[str, Any],
+    *,
+    repository: str | None,
+    cwd: Path | None = None,
+) -> None:
+    """Attach check-run status for one exact PR head.
+
+    ``gh pr list`` does not support ``statusCheckRollup`` in its ``--json``
+    field set, so the queue scan fetches check runs by exact ``headRefOid``
+    through the commits check-runs API instead. A failed lookup leaves the
+    rollup absent; the risk hint then reports that no rollup was available.
+    """
+
+    head_oid = str(row.get("headRefOid") or "").strip()
+    if not head_oid or not repository:
+        return
+    try:
+        runs = _run_gh_json(
+            [
+                "api",
+                f"repos/{repository}/commits/{head_oid}/check-runs",
+                "--paginate",
+                "-q",
+                ".check_runs",
+            ],
+            cwd=cwd,
+        )
+    except Exception:
+        return
+    if not isinstance(runs, list):
+        return
+    row["statusCheckRollup"] = [
+        {
+            "name": str(item.get("name") or item.get("context") or ""),
+            "status": str(item.get("status") or ""),
+            "conclusion": str(item.get("conclusion") or ""),
+        }
+        for item in runs
+        if isinstance(item, dict)
+    ]
+
+
 def resolve_current_github_repository(*, cwd: Path | None = None) -> str | None:
     try:
         payload = _run_gh_json(["repo", "view", "--json", "nameWithOwner"], cwd=cwd)
@@ -193,6 +236,7 @@ def scan_github_pull_requests(
     since: str | None = None,
 ) -> dict[str, Any]:
     repo_args = ["--repo", repo] if repo else []
+    api_repository = repo or resolve_current_github_repository(cwd=cwd)
     normalized_state = normalize_pr_state_filter(state_filter)
     search_args: list[str] = []
     search_date = _github_search_date(since)
@@ -219,7 +263,6 @@ def scan_github_pull_requests(
         "changedFiles",
         "additions",
         "deletions",
-        "statusCheckRollup",
     ]
     fetch_limit = max(1, limit)
     if since:
@@ -268,6 +311,11 @@ def scan_github_pull_requests(
                 continue
             if number:
                 seen_numbers.add(number)
+            _attach_status_check_rollup(
+                row,
+                repository=api_repository,
+                cwd=cwd,
+            )
             detailed.append(row)
         state_scans.append(
             {

--- a/tests/test_pr_review_github_scan.py
+++ b/tests/test_pr_review_github_scan.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import loopx.pr_review as pr_review_module
+
+
+HEAD_1 = "a" * 40
+HEAD_2 = "b" * 40
+
+
+def _rows() -> list[dict[str, object]]:
+    return [
+        {
+            "number": 1,
+            "title": "one",
+            "state": "OPEN",
+            "headRefOid": HEAD_1,
+            "updatedAt": "2026-08-12T00:00:00Z",
+        },
+        {
+            "number": 2,
+            "title": "two",
+            "state": "OPEN",
+            "headRefOid": HEAD_2,
+            "updatedAt": "2026-08-12T00:00:00Z",
+        },
+    ]
+
+
+def _fake_run_gh_json(args: list[str], *, cwd: Path | None = None):
+    if args[0] == "pr" and args[1] == "list":
+        return _rows()
+    if args[0] == "api" and args[1].endswith("/check-runs"):
+        if args[1].endswith(f"{HEAD_2}/check-runs"):
+            return [
+                {"name": "build", "status": "IN_PROGRESS", "conclusion": ""},
+            ]
+        return [
+            {"name": "pytest", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"name": "lint", "status": "COMPLETED", "conclusion": "FAILURE"},
+        ]
+    return {}
+
+
+def test_pr_list_json_excludes_status_check_rollup(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake(args: list[str], *, cwd: Path | None = None):
+        calls.append(args)
+        return _fake_run_gh_json(args, cwd=cwd)
+
+    monkeypatch.setattr(pr_review_module, "_run_gh_json", fake)
+    scan = pr_review_module.scan_github_pull_requests(
+        repo="huangruiteng/loopx",
+        limit=10,
+        state_filter="open",
+    )
+
+    list_call = next(
+        args for args in calls if args[0] == "pr" and args[1] == "list"
+    )
+    json_fields = list_call[list_call.index("--json") + 1].split(",")
+    assert "statusCheckRollup" not in json_fields
+
+    rows = scan["pull_requests"]
+    assert len(rows) == 2
+    assert rows[0]["statusCheckRollup"] == [
+        {"name": "pytest", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        {"name": "lint", "status": "COMPLETED", "conclusion": "FAILURE"},
+    ]
+    assert rows[1]["statusCheckRollup"] == [
+        {"name": "build", "status": "IN_PROGRESS", "conclusion": ""},
+    ]
+    api_calls = [args for args in calls if args[0] == "api"]
+    assert any(
+        args[1] == f"repos/huangruiteng/loopx/commits/{HEAD_1}/check-runs"
+        for args in api_calls
+    )
+    assert any(
+        args[1] == f"repos/huangruiteng/loopx/commits/{HEAD_2}/check-runs"
+        for args in api_calls
+    )
+
+
+def test_pr_list_failed_check_lookup_leaves_rollup_absent(monkeypatch) -> None:
+    def fake(args: list[str], *, cwd: Path | None = None):
+        if args[0] == "pr" and args[1] == "list":
+            return _rows()
+        raise RuntimeError("api unavailable")
+
+    monkeypatch.setattr(pr_review_module, "_run_gh_json", fake)
+    scan = pr_review_module.scan_github_pull_requests(
+        repo="huangruiteng/loopx",
+        limit=10,
+        state_filter="open",
+    )
+    rows = scan["pull_requests"]
+    assert all("statusCheckRollup" not in row for row in rows)


### PR DESCRIPTION
## What

`loopx pr-review` failed before scanning because `statusCheckRollup` was included in the `gh pr list --json` field set, which the CLI does not support for list (only `gh pr view`).

Fix:
- Remove `statusCheckRollup` from the list fields.
- Fetch check runs per exact `headRefOid` via `gh api repos/<owner>/<repo>/commits/<head>/check-runs` and attach the same rollup shape consumed by the metadata risk hints.
- A failed lookup leaves the rollup absent (risk hint reports no rollup) instead of failing the whole scan.

## Validation

- `pytest tests/test_pr_review_github_scan.py`: 2 passed (field exclusion, rollup attachment by exact head, failed-lookup tolerance)
- `python3 examples/pr-review-command-smoke.py`: passed
- Live `loopx pr-review --repo huangruiteng/loopx --state open --limit 3`: succeeds and attaches checks (e.g., PRs with failing checks now report them)
- `loopx check` on changed files: public boundary clean
- `git diff --check`: clean