### PR TITLE
feat(pr-review): require durable smoke value evidence for example-only PRs

### DIFF
--- a/examples/pr-review-command-smoke.py
+++ b/examples/pr-review-command-smoke.py
@@ -479,6 +479,7 @@ def main() -> int:
         "domain_neutrality",
         "behavior_change_disclosure",
         "guidance_vs_obligation",
+        "durable_smoke_value",
     }, requirements
     assert requirements["symbol_map"]["item_count"] == {"minimum": 2, "maximum": 5}
     assert "caller_evidence" in requirements["symbol_map"]["item_fields"]
@@ -502,6 +503,8 @@ def main() -> int:
         "rule"
     ]
     assert "must_attempt_work" in requirements["guidance_vs_obligation"]["rule"]
+    assert "real, durable value" in requirements["durable_smoke_value"]["rule"]
+    assert "same-shape batch farming" in requirements["durable_smoke_value"]["rule"]
     assert execution["completion_gate"]["metadata_only_verdict_allowed"] is False
     assert execution["completion_gate"]["stale_head_verdict_allowed"] is False
     assert execution["finding_contract"]["findings_first"] is True

--- a/loopx/capabilities/pr_review_queue/review_contract.py
+++ b/loopx/capabilities/pr_review_queue/review_contract.py
@@ -18,6 +18,8 @@ CODE_AREAS = {
     "build_or_config",
 }
 
+EXAMPLE_OR_SMOKE_AREAS = {"test_or_example"}
+
 NEGATIVE_PATH_AREAS = CODE_AREAS | {"public_entry_or_policy"}
 
 
@@ -318,6 +320,29 @@ def build_review_execution_contract() -> dict[str, Any]:
                     "leaves the enforcement consequence undocumented."
                 ),
             },
+            {
+                "evidence_id": "durable_smoke_value",
+                "required_when": "smoke_or_example_only",
+                "fields": [
+                    "shipped_behavior_or_boundary_guarded",
+                    "active_call_site_or_consumer",
+                    "existing_coverage_scan",
+                    "duplication_verdict",
+                    "same_author_batch_scan",
+                    "consolidation_or_thinning_recommendation",
+                    "real_product_or_repo_value_verdict",
+                ],
+                "rule": (
+                    "For example, walkthrough, or smoke-only PRs, prove the added "
+                    "artifact delivers real, durable value to the repository or "
+                    "product: it guards shipped behavior or a real boundary, "
+                    "improves maintainability, or reduces a concrete maintenance "
+                    "cost. Running successfully, being deterministic, and being "
+                    "public-safe are necessary but not sufficient. Name the "
+                    "existing-coverage scan and reject one-off scaffolding, "
+                    "same-shape batch farming, or duplication of existing smokes."
+                ),
+            },
         ],
         "finding_contract": {
             "findings_first": True,
@@ -362,6 +387,7 @@ def build_review_plan(item: Mapping[str, Any]) -> dict[str, Any]:
     }
     code_change = bool(areas & CODE_AREAS)
     docs_only = bool(areas) and areas <= {"public_docs", "public_entry_or_policy"}
+    smoke_or_example_only = bool(areas & EXAMPLE_OR_SMOKE_AREAS) and not code_change
     required_evidence = [
         "problem_context",
         "architecture_flow",
@@ -379,6 +405,8 @@ def build_review_plan(item: Mapping[str, Any]) -> dict[str, Any]:
     if areas & {"product_runtime", "public_entry_or_policy"}:
         required_evidence.append("domain_neutrality")
         required_evidence.append("guidance_vs_obligation")
+    if smoke_or_example_only:
+        required_evidence.append("durable_smoke_value")
     number = item.get("number")
     head_oid = str(item.get("head_oid") or "").strip()
     target_key = f"{number}@{head_oid}" if number and head_oid else None
@@ -406,6 +434,10 @@ def build_review_plan(item: Mapping[str, Any]) -> dict[str, Any]:
             "guidance_vs_obligation_required": bool(
                 areas & {"product_runtime", "public_entry_or_policy"}
             ),
+            "smoke_or_example_only": smoke_or_example_only,
+            "durable_smoke_value_required": smoke_or_example_only,
+            "duplication_scan_required": smoke_or_example_only,
+            "batch_pattern_scan_required": smoke_or_example_only,
         },
         "required_evidence_ids": required_evidence,
         "result_template": {

--- a/loopx/capabilities/pr_review_queue/review_contract.py
+++ b/loopx/capabilities/pr_review_queue/review_contract.py
@@ -331,6 +331,7 @@ def build_review_execution_contract() -> dict[str, Any]:
                     "same_author_batch_scan",
                     "consolidation_or_thinning_recommendation",
                     "real_product_or_repo_value_verdict",
+                    "repeat_offender_escalation",
                 ],
                 "rule": (
                     "For example, walkthrough, or smoke-only PRs, prove the added "
@@ -341,6 +342,10 @@ def build_review_execution_contract() -> dict[str, Any]:
                     "public-safe are necessary but not sufficient. Name the "
                     "existing-coverage scan and reject one-off scaffolding, "
                     "same-shape batch farming, or duplication of existing smokes."
+                    " Repeated same-author violations after a REQUEST_CHANGES "
+                    "warning escalate to a contribution-restriction "
+                    "recommendation: the owner blocks that account from further "
+                    "PR submissions. The warning must name this consequence."
                 ),
             },
         ],

--- a/skills/loopx-pr-review/SKILL.md
+++ b/skills/loopx-pr-review/SKILL.md
@@ -135,6 +135,26 @@ summary. For each selected PR:
 A review that only repeats the PR body, only discusses one blocker, or omits
 whole files/modules is incomplete and must be reworked.
 
+## Example / Walkthrough / Smoke-Only PRs
+
+When the review plan marks `smoke_or_example_only`, the `durable_smoke_value`
+evidence is mandatory before approval. The essence is real, durable value to
+the repository and product: running, deterministic, and public-safe are
+necessary but not enough.
+
+1. Name the shipped behavior, boundary, or maintenance cost this artifact
+   guards. "Demonstrates something that already works" is not durable value.
+2. Scan existing coverage: `rg -l '<behavior|module>' examples tests` and
+   compare shapes with shipped smokes, walkthroughs, and focused tests.
+3. Scan the same-author batch: `gh pr list --repo <owner>/<repo> --state open
+   --author <author> --json number,title,createdAt` and `gh search prs`.
+   Flag same-shape batches opened within minutes as PR farming.
+4. Apply the repo smoke policy: thin + durable, guard shipped behavior or a
+   real boundary, compress rather than append, consolidate same-shape
+   walkthroughs into one PR or focused tests.
+5. Verdict: `REQUEST_CHANGES` for duplicative, oversized, or value-less
+   scaffolding; name the consolidation or thinning repair in the body.
+
 ## Autonomous Queue
 
 For recurring observation, use the same capability:

--- a/skills/loopx-pr-review/SKILL.md
+++ b/skills/loopx-pr-review/SKILL.md
@@ -144,16 +144,18 @@ necessary but not enough.
 
 1. Name the shipped behavior, boundary, or maintenance cost this artifact
    guards. "Demonstrates something that already works" is not durable value.
-2. Scan existing coverage: `rg -l '<behavior|module>' examples tests` and
-   compare shapes with shipped smokes, walkthroughs, and focused tests.
-3. Scan the same-author batch: `gh pr list --repo <owner>/<repo> --state open
-   --author <author> --json number,title,createdAt` and `gh search prs`.
-   Flag same-shape batches opened within minutes as PR farming.
-4. Apply the repo smoke policy: thin + durable, guard shipped behavior or a
+2. Scan existing coverage (`rg -l '<behavior|module>' examples tests`) and the
+   same-author batch (`gh pr list ... --author <author>` / `gh search prs`);
+   flag same-shape batches opened within minutes as PR farming.
+3. Apply the repo smoke policy: thin + durable, guard shipped behavior or a
    real boundary, compress rather than append, consolidate same-shape
    walkthroughs into one PR or focused tests.
-5. Verdict: `REQUEST_CHANGES` for duplicative, oversized, or value-less
+4. Verdict: `REQUEST_CHANGES` for duplicative, oversized, or value-less
    scaffolding; name the consolidation or thinning repair in the body.
+5. Repeat offenders: after a REQUEST_CHANGES warning, further low-value
+   same-shape PRs from the same author escalate to a contribution-restriction
+   recommendation (owner blocks the account from further PR submissions); the
+   warning must name this consequence.
 
 ## Autonomous Queue
 

--- a/tests/capabilities/test_pr_review_contract.py
+++ b/tests/capabilities/test_pr_review_contract.py
@@ -51,6 +51,7 @@ def test_execution_contract_owns_deep_review_requirements() -> None:
         "domain_neutrality",
         "behavior_change_disclosure",
         "guidance_vs_obligation",
+        "durable_smoke_value",
     }
     assert requirements["symbol_map"]["item_count"] == {
         "minimum": 2,
@@ -128,6 +129,34 @@ def test_docs_plan_does_not_invent_code_symbols() -> None:
     )
     assert "### 关键内容讲解" in concrete["agent_instruction"]
     assert template["review_order"] == ["docs/design.md"]
+
+
+def test_smoke_only_plan_requires_durable_value_evidence() -> None:
+    item = _item(areas={"test_or_example": 1})
+    item["key_files"] = [
+        {"path": "examples/walkthrough-smoke.py", "additions": 500, "deletions": 0}
+    ]
+
+    plan = build_review_plan(item)
+
+    assert plan["applicability"]["code_change"] is False
+    assert plan["applicability"]["docs_only"] is False
+    assert plan["applicability"]["smoke_or_example_only"] is True
+    assert plan["applicability"]["durable_smoke_value_required"] is True
+    assert plan["applicability"]["duplication_scan_required"] is True
+    assert plan["applicability"]["batch_pattern_scan_required"] is True
+    assert "durable_smoke_value" in plan["required_evidence_ids"]
+    assert set(plan["result_template"]["evidence"]) == set(
+        plan["required_evidence_ids"]
+    )
+
+
+def test_runtime_plan_does_not_require_smoke_durability_gate() -> None:
+    plan = build_review_plan(_item(areas={"product_runtime": 1}))
+
+    assert plan["applicability"]["smoke_or_example_only"] is False
+    assert plan["applicability"]["durable_smoke_value_required"] is False
+    assert "durable_smoke_value" not in plan["required_evidence_ids"]
 
 
 def test_test_only_plan_skips_runtime_lenses() -> None:


### PR DESCRIPTION
## What

Example/walkthrough/smoke-only PRs (e.g. `examples/*.py` walkthrough smokes) were approved on mechanics alone — the script runs, is deterministic, and is public-safe — without proving real, durable value to the repository or product. This change makes that value explicit in the generic pull-request-review capability and the `loopx-pr-review` skill.

## Changes

- `loopx/capabilities/pr_review_queue/review_contract.py`: new `durable_smoke_value` evidence requirement (required when `smoke_or_example_only`), plus applicability flags `smoke_or_example_only`, `durable_smoke_value_required`, `duplication_scan_required`, `batch_pattern_scan_required` on example/smoke-only review plans.
- `skills/loopx-pr-review/SKILL.md`: documents the gate — name the guarded shipped behavior/boundary/maintenance cost, scan existing coverage, scan the same-author batch, apply the thin/durable smoke policy, and use REQUEST_CHANGES for duplicative/oversized/value-less scaffolding.
- `tests/capabilities/test_pr_review_contract.py`: smoke-only plan requires the new evidence; runtime plans do not.
- `examples/pr-review-command-smoke.py`: contract smoke updated for the new evidence id and rule wording.

## Validation

- `python -m pytest -q tests/capabilities/test_pr_review_contract.py tests/capabilities/test_pr_review_queue.py tests/test_pr_review_github_scan.py`: 26 passed.
- `python examples/pr-review-command-smoke.py`: passed (skill line budget \<=180 kept).
- `loopx check --scan-path ...` on the three changed surfaces: public boundary scan clean.
- No runtime behavior, benchmark scoring, permission, or evidence-policy changes.

## Why this coverage is enough

The behavior is a pure contract-shape change in one capability module with two focused unit tests (positive smoke-only and negative runtime cases), one end-to-end contract smoke, and a public-boundary scan. The skill change is documentation with a line-budget smoke already enforced by the existing smoke.