### PR TITLE
docs(rfc): add goal artifact lifecycle projection v0

### DIFF
--- a/docs/architecture/rfcs/README.md
+++ b/docs/architecture/rfcs/README.md
@@ -13,6 +13,7 @@ defined by the implementation and stable reference contracts.
 - [Goal Channel collaboration v0](goal-channel-collaboration-v0.md): bind one external collaboration channel to one LoopX goal while preserving LoopX as the source of truth.
 - [Goal Channel 协作模型 v0](goal-channel-collaboration-v0.zh-CN.md): 将一个外部协作通道绑定到一个 LoopX goal，同时保持 LoopX 作为事实源。
 - [Shared-goal online authority and pluggable coordination provider v0](shared-goal-authority-state-provider-v0.md): a claim-only contract proof for target-scoped conflicts over one canonical coordination aggregate, atomic original-receipt replay, and per-layer persistence ownership, with NoKV as an unpromoted provider candidate ([中文版](shared-goal-authority-state-provider-v0.zh-CN.md), [validation boundary](shared-goal-authority-state-provider-v0-evidence.zh-CN.md)).
+- [Goal artifact lifecycle projection v0](goal-artifact-lifecycle-projection-v0.md): treat a goal as a business artifact with derived milestones, blocking guards, and legal next transitions, projected read-only for operators and global views ([中文版](goal-artifact-lifecycle-projection-v0.zh-CN.md)).
 
 RFCs must not contain internal conversations, private links, local filesystem
 paths, credentials, raw transcripts, or non-public organizational context.

--- a/docs/architecture/rfcs/goal-artifact-lifecycle-projection-v0.md
+++ b/docs/architecture/rfcs/goal-artifact-lifecycle-projection-v0.md
@@ -1,0 +1,160 @@
+# RFC: Goal Artifact Lifecycle Projection (milestone / guard / next-transition) v0
+
+- Status: Draft, under maintainer review
+- Proposed by: LoopX maintainers
+- Date: 2026-08-12
+- Scope: a read-only, goal-level lifecycle projection derived from existing
+  typed state, with a global aggregation view as a later slice; no runtime
+  state-machine change, no process engine
+- Source baseline: LoopX `ef5a8acb1`
+- Language note: the
+  [Chinese version](./goal-artifact-lifecycle-projection-v0.zh-CN.md) and this
+  English version are semantic mirrors. A difference between them is a defect.
+
+---
+
+## 0. An Example to Help Everyone Understand
+
+An operator opens the dashboard for a long-running benchmark-qualification
+goal. The goal has been running for weeks. The dashboard shows todo counts,
+quota state, reason codes, and the latest run classification. None of these
+answers the three questions the operator actually has:
+
+- **Where is this goal in its lifecycle?** (is it still starting, actively
+  qualifying, waiting for owner decisions, or closing?)
+- **Which milestones has it reached?** (environment ready, baseline pass,
+  release-candidate evidence collected)
+- **Which guard blocks the next step, and who owns it?** (the baseline was
+  reached, but "owner approves baseline" is still open and no other transition
+  is legal)
+
+The operator has to reconstruct these answers from scattered todo status,
+gate lists, evidence keys, and run-history classifications. LoopX already
+models every piece below the goal as typed state; the goal itself is the least
+typed layer that operators look at.
+
+## 1. What This RFC Chooses
+
+This RFC proposes one derived, read-only projection,
+`goal_artifact_lifecycle_projection_v0`, that treats a goal as a business
+artifact with a lifecycle:
+
+```text
+goal_id
+lifecycle_phase            (derived, not a new stored state)
+milestones[]               (id, label, reached, reached_evidence_refs[])
+guards[]                   (id, kind, blocked, owner, decision_scope,
+                            evidence_required)
+next_transitions[]         (target_phase, precondition, reason_codes[])
+```
+
+The projection is **derived only** from state LoopX already owns:
+
+- registry goal fields and active-state todos (task class, status, action kind,
+  claimed owner);
+- user gates and decision scopes (`blocks_agent`, `resume_when`,
+  `required_decision_scope`, and `validation_command` once that field ships);
+- evidence and run history (compact evidence refs, delivery outcome, material
+  milestone runs, classification);
+- goal frontier and work-lane reason codes (what the control plane says is the
+  next legal action).
+
+Milestone reachability starts from declared acceptance markers where the goal
+records them, and falls back to evidence-derived markers (a bounded
+`primary_goal_outcome` or `compact_evidence` run with a material batch scale).
+Guards are open owner decisions or unmet evidence preconditions. Next
+transitions come from the existing frontier/lane derivation, not from a new
+state machine.
+
+## 2. Non-Goals
+
+- No BPMN/process engine, workflow DSL, or flowchart execution.
+- No unification of the bounded lifecycles that already exist (todo, monitor,
+  content item, benchmark case, PR, observable artifact handle each keep their
+  own legal transitions).
+- No milestone-based enforcement yet: this RFC does not change what "done"
+  means or add a new gate.
+- No new stored goal state: `lifecycle_phase` and milestones are projections,
+  not authoritative fields.
+
+## 3. Short-Term Applications (next 1-2 releases)
+
+1. One module, `loopx/control_plane/goals/artifact_lifecycle.py`, that derives
+   the projection from a status/goal payload (pure function, no file reads).
+2. A focused fixture smoke proving derivation on a synthetic goal: declared
+   milestones, evidence-reached milestones, an open owner gate as a blocking
+   guard, and a legal next transition from the work lane.
+3. First consumer: goal detail in status markdown and the dashboard
+   (`goal_artifact_lifecycle_projection_v0` alongside `goal_channel_projection_v0`),
+   so an operator can answer the three questions from the example.
+4. Public-safe boundary stays identical to existing projections: no raw logs,
+   evidence bodies, credentials, or local paths.
+
+## 4. Mid-Term Applications (2-4 releases)
+
+1. **Global goal board**: aggregate the per-goal projection across goals into
+   one cross-goal view (which goals reached which milestones, which guards
+   block how many goals, what is the next transition per goal). This is the
+   natural home in the existing `/loopx-global-*` family and the operator
+   dashboard.
+2. **Periodic report digest**: milestone and guard deltas become report rows
+   ("milestone reached", "guard opened/closed") instead of free-text run
+   summaries.
+3. **Replan novelty substrate**: "covered milestones / attempted transitions"
+   becomes a structured input for replan novelty, replacing part of the
+   evidence-log string scan with a typed covered-state query.
+4. **Verified-completion guard surface**: when `validation_command` ships, it
+   plugs into `guards[]` as an evidence requirement, giving the completion
+   path one place to explain why a transition is blocked.
+
+## 5. Long-Term Applications (after real callers exist)
+
+Each of these is gated by an active production call site and must pass
+scope-fit review before implementation:
+
+1. **Milestone-based closeout semantics**: if a caller needs enforceable
+   completion, define "goal done" as all declared milestones reached with
+   evidence, rather than todo completion plus no-follow-up.
+2. **Case-ownership views**: use claims, leases, and guard owners to answer
+   "who owns this case and which guard blocks it" for multi-agent goals.
+3. **Artifact history as covered-state ledger**: expose a typed
+   "covered states" query over run history and rollout events, only if a
+   second consumer besides replan needs it.
+
+## 6. Alternatives Considered
+
+- **Unify all bounded lifecycles into one artifact abstraction**: rejected.
+  The bounded contexts have different legal transitions and would merge
+  duplicate knowledge (AGENTS.md duplicate-knowledge gate).
+- **Add a workflow/process engine**: rejected. LoopX's value is typed state
+  and evidence gates, not orchestration.
+- **Formalize evidence history only**: accepted as a substrate, not a
+  standalone line; it is folded into the milestone derivation.
+- **Status quo**: rejected; the goal layer remains the least typed layer
+  operators see.
+
+## 7. Smallest Useful Implementation Slice
+
+One pure derivation module plus one fixture smoke and one readout in status
+markdown. No runtime behavior changes, no new stored fields, no quota or
+settlement impact. The slice proves the vocabulary before any consumer or
+enforcement is built.
+
+## 8. Validation Criteria
+
+- Fixture smoke asserts milestone/guard/next-transition derivation from a
+  synthetic goal payload, including negative cases (unreached milestone,
+  blocking guard with no legal transition).
+- The projection stays public-safe: no raw evidence bodies, credentials,
+  local paths, or private payloads.
+- `examples/docs-governance-smoke.py` and `loopx check` on the new files pass.
+- No existing status/quota/settlement smoke changes.
+
+## 9. Open Questions
+
+- Milestone declaration: should milestones come from declared goal acceptance
+  fields first, or from evidence-derived markers first?
+- Should `lifecycle_phase` be constrained to a fixed enum (e.g.
+  `starting / qualifying / waiting_owner / closing / closed`) or left as a
+  derived label?
+- When should milestone semantics become enforceable, if ever?

--- a/docs/architecture/rfcs/goal-artifact-lifecycle-projection-v0.zh-CN.md
+++ b/docs/architecture/rfcs/goal-artifact-lifecycle-projection-v0.zh-CN.md
@@ -1,0 +1,95 @@
+# RFC：Goal Artifact 生命周期投影（milestone / guard / next-transition）v0
+
+- 状态：Draft，maintainer 评审中
+- 提出方：LoopX maintainers
+- 日期：2026-08-12
+- 范围：一个只读的 goal 级生命周期投影，由现有 typed state 派生；全局聚合视图作为后续切片；不改变运行时状态机，不引入流程引擎
+- 基线：LoopX `ef5a8acb1`
+- 语言说明：[英文版](./goal-artifact-lifecycle-projection-v0.md)与本中文版互为语义镜像，差异视为缺陷。
+
+---
+
+## 0. 一个帮助理解的例子
+
+运维打开一个长跑 benchmark 认证 goal 的 dashboard。这个 goal 已经跑了几周。页面上有 todo 数量、quota 状态、reason codes、最近一次 run 的 classification。但没有一个能回答运维真正关心的三个问题：
+
+- **这个 goal 处于生命周期的哪个阶段？**（还在启动、正在认证、等待 owner 决策、还是收尾？）
+- **它达成了哪些 milestone？**（环境就绪、baseline 通过、release-candidate 证据收集完毕）
+- **哪个 guard 挡住了下一步，owner 是谁？**（baseline 已达成，但“owner 批准 baseline”仍未关闭，且没有其他合法迁移）
+
+运维只能从分散的 todo 状态、gate 列表、evidence key、run-history classification 里手动拼出答案。LoopX 已经把 goal 之下的每一层都建模成 typed state；goal 本身恰恰是 operator 最常看、却最缺少 typed 语义的一层。
+
+## 1. 本 RFC 的选择
+
+提出一个派生的只读投影 `goal_artifact_lifecycle_projection_v0`，把 goal 当作一个有生命周期的业务工件：
+
+```text
+goal_id
+lifecycle_phase            （派生，不是新增存储状态）
+milestones[]               （id, label, reached, reached_evidence_refs[]）
+guards[]                   （id, kind, blocked, owner, decision_scope,
+                             evidence_required）
+next_transitions[]         （target_phase, precondition, reason_codes[]）
+```
+
+投影**只从 LoopX 已拥有的状态派生**：
+
+- registry goal 字段与 active-state todo（task class、status、action kind、claimed owner）；
+- user gate 与 decision scope（`blocks_agent`、`resume_when`、`required_decision_scope`，以及未来上线的 `validation_command`）；
+- evidence 与 run history（compact evidence refs、delivery outcome、material milestone runs、classification）；
+- goal frontier 与 work-lane reason codes（控制面认定的下一步合法动作）。
+
+Milestone 的达成：优先取 goal 声明的 acceptance 标记；没有声明时回退到证据派生标记（带 material batch scale 的 bounded `primary_goal_outcome` 或 `compact_evidence` run）。Guard 是未关闭的 owner 决策或未满足的证据前置条件。Next transitions 复用现有 frontier/lane 推导，不新建状态机。
+
+## 2. 非目标
+
+- 不做 BPMN/流程引擎、workflow DSL 或流程图执行。
+- 不统一已有 bounded lifecycle（todo、monitor、content item、benchmark case、PR、observable artifact handle 各自保留合法迁移）。
+- 暂不引入 milestone 强制语义：本 RFC 不改变“done”的定义，也不新增 gate。
+- 不新增 goal 存储状态：`lifecycle_phase` 和 milestone 只是投影，不是权威字段。
+
+## 3. 短期应用（未来 1-2 个 release）
+
+1. 新增 `loopx/control_plane/goals/artifact_lifecycle.py`：从 status/goal payload 派生投影（纯函数，不读文件）。
+2. 一个 fixture smoke：用合成 goal 证明派生规则——声明的 milestone、evidence 达成的 milestone、未关闭的 owner gate 作为 blocking guard、来自 work lane 的合法 next transition。
+3. 第一个消费者：status markdown 与 dashboard 的 goal 详情（与 `goal_channel_projection_v0` 并列展示 `goal_artifact_lifecycle_projection_v0`），让运维能回答例子里的三个问题。
+4. 公开边界与现有投影一致：不含 raw logs、evidence body、credentials、本地路径。
+
+## 4. 中期应用（2-4 个 release）
+
+1. **全局 goal board**：把 per-goal 投影跨 goal 聚合——哪些 goal 达成哪些 milestone、哪些 guard 阻塞了多少 goal、每个 goal 的 next transition 是什么。这是现有 `/loopx-global-*` 家族和 operator dashboard 的自然落点。
+2. **Periodic report 摘要**：milestone 与 guard 的增量成为报告行（“milestone reached”“guard opened/closed”），替代自由文本 run 摘要。
+3. **Replan novelty 底座**：把“已覆盖 milestone / 已尝试迁移”变成结构化输入，替代部分 evidence-log 字符串扫描。
+4. **验证完成守卫面**：`validation_command` 上线后作为 `guards[]` 的 evidence requirement，让完成路径有一个统一的地方解释“为什么迁移被阻塞”。
+
+## 5. 长期应用（出现真实调用方之后）
+
+每一项都以 active production call site 为前提，通过 scope-fit review 后才实现：
+
+1. **Milestone-based closeout 语义**：如果有调用方需要强制的完成定义，把“goal done”定义为所有声明的 milestone 均达成且带 evidence，而不是“todo 完成 + no-followup”。
+2. **Case 所有权视图**：用 claim、lease、guard owner 回答多 agent goal 的“这个 case 归谁、哪个 guard 阻塞它”。
+3. **Artifact history 作为 covered-state ledger**：只有当第二个消费者出现时，才提供 typed “已覆盖状态”查询（基于 run history 与 rollout events）。
+
+## 6. 备选方案
+
+- **统一所有 bounded lifecycle 为一个 artifact 抽象**：拒绝。各 bounded context 的合法迁移不同，合并会产生重复知识（AGENTS.md duplicate-knowledge gate）。
+- **引入 workflow/流程引擎**：拒绝。LoopX 的价值是 typed state 与 evidence gate，不是编排。
+- **只形式化 evidence history**：接受为底座，不作为独立主线；并入 milestone 派生。
+- **维持现状**：拒绝；goal 层仍是 operator 看到的最缺 typed 语义的一层。
+
+## 7. 最小可用实现切片
+
+一个纯派生模块 + 一个 fixture smoke + status markdown 一处展示。不改运行时行为、不新增存储字段、不影响 quota 与 settlement。先证明词汇可用，再谈消费者或强制语义。
+
+## 8. 验证标准
+
+- Fixture smoke 断言合成 goal payload 的 milestone/guard/next-transition 派生，包含负例（未达成 milestone、blocking guard 且无合法迁移）。
+- 投影保持 public-safe：不含 raw evidence body、credentials、本地路径或私有 payload。
+- `examples/docs-governance-smoke.py` 与对新增文件的 `loopx check` 通过。
+- 现有 status/quota/settlement smoke 不变。
+
+## 9. 开放问题
+
+- Milestone 声明来源：优先用 goal 声明的 acceptance 字段，还是 evidence 派生标记？
+- `lifecycle_phase` 用固定枚举（如 `starting / qualifying / waiting_owner / closing / closed`）还是派生标签？
+- Milestone 语义何时、以及是否应该变成可执行的强制门？


### PR DESCRIPTION
## What

RFC for a read-only **goal artifact lifecycle projection** (`goal_artifact_lifecycle_projection_v0`): derive milestone / guard / next-transition for each goal from existing typed state (todos, gates/decision scopes, evidence, run history, frontier), then aggregate globally.

Applications by horizon:

- **Short-term**: pure derivation module + fixture smoke + goal detail readout in status/dashboard.
- **Mid-term**: global goal board, periodic report milestone/guard digest, replan novelty substrate, validation_command as a guard.
- **Long-term** (gated by real callers): milestone-based closeout semantics, case-ownership views, covered-state ledger.

Explicit non-goals: no process engine, no unification of bounded lifecycles, no enforcement/milestone gate yet, no new stored goal state.

## Validation

- `python3 examples/docs-governance-smoke.py`: passed
- `loopx check` on the three new/changed files: public boundary clean
- `git diff --check`: clean
- Bilingual mirror (EN + zh-CN) with RFC index entries