### PR TITLE
fix(status-server): stop sending ACAO:* on unauthenticated read responses

### DIFF
--- a/loopx/status_server.py
+++ b/loopx/status_server.py
@@ -103,6 +103,25 @@ def is_loopback_origin(origin: str | None) -> bool:
     return parsed.scheme in {"http", "https"} and is_loopback_host(parsed.hostname or "")
 
 
+def cors_response_headers(origin: str | None) -> dict[str, str]:
+    """Return CORS headers for an unauthenticated response.
+
+    Only loopback browser origins may read responses cross-origin. A
+    non-loopback ``Origin`` gets no ``Access-Control-Allow-Origin`` header so
+    browsers block reads; non-browser clients (no ``Origin`` header) need no
+    CORS headers at all.
+    """
+
+    if not origin or not is_loopback_origin(origin):
+        return {}
+    return {
+        "Access-Control-Allow-Origin": origin,
+        "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type",
+        "Vary": "Origin",
+    }
+
+
 def reward_preview_id(payload: dict[str, Any]) -> str:
     stable = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(stable.encode("utf-8")).hexdigest()[:24]
@@ -146,17 +165,15 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
         self.send_header("Content-Type", "application/json; charset=utf-8")
         self.send_header("Content-Length", str(len(body)))
         self.send_header("Cache-Control", "no-store")
-        self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        for key, value in cors_response_headers(self.headers.get("Origin")).items():
+            self.send_header(key, value)
         self.end_headers()
         self.wfile.write(body)
 
     def do_OPTIONS(self) -> None:
         self.send_response(204)
-        self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        for key, value in cors_response_headers(self.headers.get("Origin")).items():
+            self.send_header(key, value)
         self.end_headers()
 
     def _read_json_body(self) -> dict[str, Any]:

--- a/tests/test_status_server_cors.py
+++ b/tests/test_status_server_cors.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import http.client
+import threading
+
+from loopx.status_server import (
+    StatusHTTPServer,
+    StatusRequestHandler,
+    cors_response_headers,
+)
+
+
+def test_cors_response_headers_loopback_origin_is_echoed() -> None:
+    headers = cors_response_headers("http://127.0.0.1:8123")
+
+    assert headers["Access-Control-Allow-Origin"] == "http://127.0.0.1:8123"
+    assert headers["Access-Control-Allow-Methods"] == "GET, POST, OPTIONS"
+    assert headers["Vary"] == "Origin"
+
+
+def test_cors_response_headers_localhost_origin_is_echoed() -> None:
+    headers = cors_response_headers("http://localhost:8123")
+
+    assert headers["Access-Control-Allow-Origin"] == "http://localhost:8123"
+
+
+def test_cors_response_headers_foreign_origin_is_rejected() -> None:
+    assert cors_response_headers("https://evil.example") == {}
+
+
+def test_cors_response_headers_missing_origin_needs_no_cors() -> None:
+    assert cors_response_headers(None) == {}
+
+
+def _start_server() -> tuple[StatusHTTPServer, threading.Thread]:
+    server = StatusHTTPServer(("127.0.0.1", 0), StatusRequestHandler)
+    server.verbose = False
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+def _get(port: int, *, origin: str | None) -> http.client.HTTPResponse:
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    headers = {"Origin": origin} if origin else {}
+    conn.request("GET", "/healthz", headers=headers)
+    return conn.getresponse()
+
+
+def test_healthz_without_origin_omits_acao() -> None:
+    server, thread = _start_server()
+    try:
+        response = _get(server.server_address[1], origin=None)
+        body = response.read()
+        assert response.status == 200
+        assert response.getheader("Access-Control-Allow-Origin") is None
+        assert b'"ok": true' in body
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+def test_healthz_with_foreign_origin_omits_acao() -> None:
+    server, thread = _start_server()
+    try:
+        response = _get(server.server_address[1], origin="https://evil.example")
+        response.read()
+        assert response.status == 200
+        assert response.getheader("Access-Control-Allow-Origin") is None
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+def test_healthz_with_loopback_origin_echoes_acao() -> None:
+    server, thread = _start_server()
+    try:
+        origin = f"http://127.0.0.1:{server.server_address[1]}"
+        response = _get(server.server_address[1], origin=origin)
+        response.read()
+        assert response.status == 200
+        assert response.getheader("Access-Control-Allow-Origin") == origin
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)


### PR DESCRIPTION
## What

`loopx serve-status` sent `Access-Control-Allow-Origin: *` on every JSON response, including unauthenticated read routes. While the server is running, any website the operator visits could `fetch()` control-plane state and private repo Markdown cross-origin without interaction.

## Change

- New `cors_response_headers(origin)`: only loopback browser origins are echoed; foreign origins and non-browser clients (no Origin header) receive no ACAO header, so browsers block cross-origin reads.
- `_send_json` and `do_OPTIONS` now use this helper instead of hardcoding `*`.
- Write endpoints keep their existing `is_loopback_origin` checks.

## Validation

- `tests/test_status_server_cors.py`: 7 new tests (unit: loopback echo, foreign reject, no-Origin; integration: /healthz without Origin, foreign Origin, loopback Origin) - all pass.
- `tests/test_status_server_extension_projection.py` passes.
- `py_compile` clean.

Addresses GHSA-vx2m-gpq4-8j5q and GHSA-p7c9-q3rc-f4f5 (details kept private pending coordinated disclosure).