### PR TITLE
fix(serve-status): validate goal_id to block path traversal in reward routes

### DIFF
--- a/loopx/feedback.py
+++ b/loopx/feedback.py
@@ -11,6 +11,23 @@ from .paths import resolve_runtime_root
 from .registry import registry_goals, resolve_state_file
 
 
+GOAL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+
+def validate_goal_id(goal_id: str) -> str:
+    """Return a goal id that is safe to use as a single path segment.
+
+    Rejects empty ids, path separators, ``..``, and shell metacharacters so a
+    caller-supplied goal id cannot escape the runtime goals directory.
+    """
+
+    if not GOAL_ID_RE.match(goal_id):
+        raise ValueError(
+            f"invalid goal_id {goal_id!r}: must match {GOAL_ID_RE.pattern}"
+        )
+    return goal_id
+
+
 REWARD_VALUES = {"positive", "negative", "mixed", "neutral"}
 LESSON_KINDS = {
     "route",
@@ -378,6 +395,7 @@ def append_human_reward(
     state_file_override: Path | None = None,
     write_active_state_summary: bool = False,
 ) -> dict[str, Any]:
+    validate_goal_id(goal_id)
     registry = load_registry(registry_path)
     runtime_root = resolve_runtime_root(registry, runtime_root_override)
     index_path = runtime_root / "goals" / goal_id / "runs" / "index.jsonl"

--- a/loopx/status_server.py
+++ b/loopx/status_server.py
@@ -15,7 +15,7 @@ from .extensions.presentation import (
     read_extension_projection,
 )
 from .extensions.runtime import default_extension_state_file
-from .feedback import append_human_reward, compact_reward
+from .feedback import append_human_reward, compact_reward, validate_goal_id
 from .history import load_registry
 from .materials import read_review_material
 from .paths import resolve_runtime_root
@@ -178,6 +178,7 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
             raise ValueError(f"unknown reward field(s): {', '.join(unknown)}")
 
         goal_id = str(body.get("goal_id") or "").strip()
+        validate_goal_id(goal_id)
         decision = str(body.get("decision") or "").strip()
         reward_value = str(body.get("reward") or "").strip()
         reason_summary = str(body.get("reason_summary") or "").strip()
@@ -351,6 +352,7 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
         if unknown:
             raise ValueError(f"unknown configure-goal field(s): {', '.join(unknown)}")
         goal_id = str(body.get("goal_id") or "").strip()
+        validate_goal_id(goal_id)
         if not goal_id:
             raise ValueError("goal_id is required")
         allowed_domains = body.get("allowed_domains")

--- a/tests/test_feedback_goal_id_validation.py
+++ b/tests/test_feedback_goal_id_validation.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import http.client
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from loopx.feedback import append_human_reward, validate_goal_id
+from loopx.status_server import (
+    StatusHTTPServer,
+    StatusRequestHandler,
+)
+
+
+@pytest.mark.parametrize(
+    "goal_id",
+    ["loopx-meta", "example.goal_1", "goal-42", "ABC_xyz"],
+)
+def test_validate_goal_id_accepts_safe_ids(goal_id: str) -> None:
+    assert validate_goal_id(goal_id) == goal_id
+
+
+@pytest.mark.parametrize(
+    "goal_id",
+    ["", "../evil", "a/b", "a\\b", "..", "a b", "a;b", "a|b", "a$b"],
+)
+def test_validate_goal_id_rejects_unsafe_ids(goal_id: str) -> None:
+    with pytest.raises(ValueError, match="invalid goal_id"):
+        validate_goal_id(goal_id)
+
+
+def test_append_human_reward_rejects_traversal_before_any_io(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="invalid goal_id"):
+        append_human_reward(
+            registry_path=tmp_path / "missing-registry.json",
+            runtime_root_override=None,
+            goal_id="../../etc/passwd",
+            run_generated_at=None,
+            reward={"decision": "positive", "reason_summary": "x"},
+            dry_run=True,
+        )
+
+
+def _start_server() -> tuple[StatusHTTPServer, threading.Thread]:
+    server = StatusHTTPServer(("127.0.0.1", 0), StatusRequestHandler)
+    server.verbose = False
+    server.registry_path = Path("/nonexistent")
+    server.runtime_root_override = None
+    server.scan_roots = []
+    server.limit = 10
+    server.status_path = "/status.json"
+    server.reward_dry_run_path = "/reward/dry-run"
+    server.reward_append_path = "/reward/append"
+    server.reward_write_enabled = False
+    server.configure_goal_dry_run_path = "/configure-goal/dry-run"
+    server.configure_goal_apply_path = "/configure-goal/apply"
+    server.control_plane_write_enabled = False
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+def _post(
+    port: int,
+    path: str,
+    body: dict[str, object],
+) -> http.client.HTTPResponse:
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    conn.request(
+        "POST",
+        path,
+        body=json.dumps(body),
+        headers={"Content-Type": "application/json"},
+    )
+    return conn.getresponse()
+
+
+def test_reward_dry_run_rejects_traversal_goal_id() -> None:
+    server, thread = _start_server()
+    try:
+        response = _post(
+            server.server_address[1],
+            "/reward/dry-run",
+            {
+                "goal_id": "../../etc/passwd",
+                "run_generated_at": "2026-08-12T00:00:00Z",
+                "decision": "positive",
+                "reward": "good",
+                "reason_summary": "works",
+            },
+        )
+        payload = json.loads(response.read().decode("utf-8"))
+        assert response.status == 400
+        assert payload["ok"] is False
+        assert "invalid goal_id" in payload["error"]
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+def test_configure_goal_dry_run_rejects_traversal_goal_id() -> None:
+    server, thread = _start_server()
+    try:
+        response = _post(
+            server.server_address[1],
+            "/configure-goal/dry-run",
+            {"goal_id": "..%2F..%2Fetc"},
+        )
+        payload = json.loads(response.read().decode("utf-8"))
+        assert response.status == 400
+        assert "invalid goal_id" in payload["error"]
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)


### PR DESCRIPTION
## What

`append_human_reward` built the run-index path directly from a caller-supplied `goal_id` (`runtime_root/goals/{goal_id}/runs/index.jsonl`) with no validation. An unauthenticated `serve-status` request could therefore read arbitrary files or append to arbitrary existing JSONL files.

## Change

- New `validate_goal_id()` in `loopx/feedback.py`: rejects empty ids, path separators, `..`, and shell metacharacters (single-path-segment token).
- `append_human_reward` validates first, before any filesystem access.
- `serve-status` reward and configure-goal request parsers validate `goal_id` as defense in depth; invalid ids fail closed with HTTP 400.

## Validation

- `tests/test_feedback_goal_id_validation.py`: 16 tests (safe/rejected id matrix, append rejection before I/O, reward + configure-goal HTTP 400 integration) - all pass.
- `tests/capabilities/test_reward_memory_ingestion.py` + `tests/test_trajectory_hygiene.py` pass (no regression).
- `py_compile` clean.

Addresses GHSA-hfmf-6xvq-9jw6 (details kept private pending coordinated disclosure).