### PR TITLE
fix(launcher): reject shell metacharacters in worker commands

### DIFF
--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -302,7 +302,7 @@ def main() -> int:
                     "agent_id": "codex-side-bypass",
                     "role_id": "planner",
                     "scope": "plan one state-backed handoff",
-                    "worker_turn_command": "printf 'turn streamed\\n'",
+                    "worker_turn_command": "printf turn-streamed",
                 }
             ],
         }
@@ -505,7 +505,7 @@ def main() -> int:
                     "LOOPX_GOAL_ID": "loopx-meta",
                     "LOOPX_AGENT_ID": "codex-side-bypass",
                     "LOOPX_ROLE_ID": "planner",
-                    "LOOPX_PANE_WORKER_TURN": "printf 'worker turn streamed\\n'",
+                    "LOOPX_PANE_WORKER_TURN": "printf worker-turn-streamed",
                 },
                 check=True,
                 capture_output=True,
@@ -532,7 +532,7 @@ def main() -> int:
             assert "round 1/2" not in tick.stdout and "round 2/2" not in tick.stdout, tick.stdout
             assert "quota should-run" in tick.stdout, tick.stdout
             assert "--format markdown" in tick.stdout, tick.stdout
-            assert "worker turn streamed" in tick.stdout, tick.stdout
+            assert "worker-turn-streamed" in tick.stdout, tick.stdout
             status_artifact = (
                 workspace
                 / ".local"

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -46,6 +47,29 @@ from .visible_multi_agent_tmux import (
 
 def _q(value: object) -> str:
     return shlex.quote(str(value))
+
+
+_WORKER_COMMAND_RE = re.compile(r"^[A-Za-z0-9_./:+-]+(?: [A-Za-z0-9_./:+-]+)*$")
+
+
+def validate_worker_command(command: str, *, field: str) -> str:
+    """Return a worker command that is safe to pass through a shell env var.
+
+    The command is executed by the pane worker through a shell, so it must be
+    a plain executable plus space-separated safe arguments: no quotes, command
+    substitution, pipes, redirects, or other shell metacharacters.
+    """
+
+    if command is None:
+        return ""
+    text = str(command or "").strip()
+    if not text:
+        return ""
+    if not _WORKER_COMMAND_RE.match(text):
+        raise ValueError(
+            f"{field} contains unsafe shell metacharacters: {text!r}"
+        )
+    return text
 
 
 AUTO_WAKE_LOOP_SCHEMA_VERSION = "multi_agent_auto_wake_loop_v0"
@@ -457,8 +481,14 @@ def build_visible_multi_agent_payload_from_spec(
         )
         skill_profile = _role_skill_profile(raw_role.get("skill"))
         reasoning_effort = str(raw_role.get("reasoning_effort") or default_reasoning_effort)
-        worker_turn_command = str(raw_role.get("worker_turn_command") or "").strip()
-        worker_loop_command = str(raw_role.get("worker_loop_command") or "").strip()
+        worker_turn_command = validate_worker_command(
+            raw_role.get("worker_turn_command"),
+            field="worker_turn_command",
+        )
+        worker_loop_command = validate_worker_command(
+            raw_role.get("worker_loop_command"),
+            field="worker_loop_command",
+        )
         output_language = str(
             raw_role.get("output_language")
             or (

--- a/tests/test_worker_command_validation.py
+++ b/tests/test_worker_command_validation.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+
+from loopx.visible_multi_agent_launcher import (
+    build_visible_multi_agent_payload_from_spec,
+    validate_worker_command,
+)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        None,
+        "",
+        "loopx turn run-once",
+        "python3 worker.py --flag 1",
+        "printf turn-streamed",
+        "/usr/bin/env python3",
+    ],
+)
+def test_validate_worker_command_accepts_safe_commands(command: str | None) -> None:
+    assert validate_worker_command(command, field="worker_turn_command") == (
+        command if command is not None else ""
+    )
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "evil; id",
+        "evil | cat",
+        "evil > /tmp/pwned",
+        "evil $(id)",
+        "`id`",
+        "printf 'x'",
+        "a\nb",
+        "a&b",
+        "a${x}",
+        "a b'c",
+    ],
+)
+def test_validate_worker_command_rejects_unsafe_commands(command: str) -> None:
+    with pytest.raises(ValueError, match="unsafe shell metacharacters"):
+        validate_worker_command(command, field="worker_turn_command")
+
+
+def test_spec_builder_rejects_unsafe_worker_command() -> None:
+    spec = {
+        "goal_id": "loopx-meta",
+        "roles": [
+            {
+                "agent_id": "codex-side-bypass",
+                "worker_turn_command": "evil; id",
+            }
+        ],
+    }
+
+    with pytest.raises(ValueError, match="unsafe shell metacharacters"):
+        build_visible_multi_agent_payload_from_spec(spec)


### PR DESCRIPTION
## What

`visible_multi_agent_launcher` propagated role JSON `worker_turn_command` / `worker_loop_command` into environment variables that the pane worker executes through a shell. Untrusted role data could inject commands (RCE, and privilege escalation when the launcher runs with elevated privileges).

## Change

- New `validate_worker_command()`: commands must be a plain executable plus space-separated safe arguments (token charset `[A-Za-z0-9_./:+-]`). Quotes, command substitution, pipes, redirects, newlines, and other shell metacharacters are rejected before export.
- Applied at the role-spec parse site; optional fields remain optional.
- Launcher smoke updated to use a safe `printf` command (no shell quoting).

## Validation

- `tests/test_worker_command_validation.py`: 17 tests (safe command matrix, unsafe matrix incl. newline/quotes/substitution, spec-builder rejection) - all pass.
- `examples/visible-multi-agent-launcher-smoke.py`: passes.
- `py_compile` clean.

Addresses GHSA-c42j-vw98-9jqm (details kept private pending coordinated disclosure).