### PR TITLE
fix(refresh-state): contain --state-file override to the project root

### DIFF
--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -478,15 +478,31 @@ def resolve_goal_state(
     if project is None and goal and goal.get("repo"):
         project = Path(str(goal.get("repo"))).expanduser()
 
+    registered_state_file = (
+        resolve_state_file(project, goal.get("state_file"))
+        if project and goal and goal.get("state_file")
+        else None
+    )
     state_file = state_file_override.expanduser() if state_file_override else None
     if state_file is None and goal:
-        state_file = resolve_state_file(project, goal.get("state_file")) if project else None
+        state_file = registered_state_file
     if state_file is None:
         raise ValueError("state file is required when the goal is not resolvable from registry")
     if not state_file.is_absolute():
         if project is None:
             raise ValueError("relative state file requires --project or registry repo")
         state_file = project / state_file
+    state_file = state_file.resolve()
+    if state_file_override is not None:
+        if project is None:
+            raise ValueError("--state-file override requires --project or a registry goal with repo")
+        registered_resolved = (
+            registered_state_file.resolve() if registered_state_file is not None else None
+        )
+        if state_file != registered_resolved and not state_file.is_relative_to(project):
+            raise ValueError(
+                f"--state-file {state_file} escapes project root {project}"
+            )
     return goal, project, state_file
 
 

--- a/tests/test_state_file_containment.py
+++ b/tests/test_state_file_containment.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from loopx.state_refresh import resolve_goal_state
+
+
+def _registry(project: Path) -> dict[str, object]:
+    return {
+        "goals": [
+            {
+                "id": "loopx-meta",
+                "repo": str(project),
+                "state_file": ".local/goals/loopx-meta/ACTIVE_GOAL_STATE.md",
+            }
+        ]
+    }
+
+
+def test_override_inside_project_is_allowed(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    state_file = project / ".local" / "goals" / "loopx-meta" / "ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text("## Next Action\n", encoding="utf-8")
+
+    goal, resolved_project, resolved = resolve_goal_state(
+        registry=_registry(project),
+        goal_id="loopx-meta",
+        project_override=project,
+        state_file_override=state_file,
+    )
+
+    assert goal is not None
+    assert resolved_project == project.resolve()
+    assert resolved == state_file.resolve()
+
+
+def test_override_equal_to_registered_state_file_is_allowed(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    state_file = project / ".local" / "goals" / "loopx-meta" / "ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text("## Next Action\n", encoding="utf-8")
+
+    _, _, resolved = resolve_goal_state(
+        registry=_registry(project),
+        goal_id="loopx-meta",
+        project_override=project,
+        state_file_override=state_file,
+    )
+
+    assert resolved == state_file.resolve()
+
+
+def test_override_outside_project_is_rejected(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    outside = tmp_path / "outside.md"
+    outside.write_text("## Next Action\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="escapes project root"):
+        resolve_goal_state(
+            registry=_registry(project),
+            goal_id="loopx-meta",
+            project_override=project,
+            state_file_override=outside,
+        )
+
+
+def test_relative_override_escaping_project_is_rejected(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+
+    with pytest.raises(ValueError, match="escapes project root"):
+        resolve_goal_state(
+            registry=_registry(project),
+            goal_id="loopx-meta",
+            project_override=project,
+            state_file_override=Path("../outside.md"),
+        )


### PR DESCRIPTION
## What

`loopx refresh-state --state-file <path> --next-action <text>` rewrote the `## Next Action` section of an arbitrary caller-supplied path with no containment check, allowing attacker-controlled text to be written into any file the invoking user can write.

## Change

- `resolve_goal_state` now resolves the override and requires it to stay inside the project root, or to equal the goal's registered state file.
- Escaping overrides (absolute outside paths, or relative `..` escapes) fail closed with a clear `ValueError` before any write.

## Validation

- `tests/test_state_file_containment.py`: 4 tests (in-project allowed, registered-state allowed, outside rejected, relative escape rejected) - all pass.
- Regression: `test_project_lifecycle_goal_channel.py`, `test_m6_quality_gates.py`, `test_goal_vision_succession.py`, `test_goal_outcome_continuity_characterization.py` all pass (45 tests).
- `py_compile` clean.

Addresses GHSA-2225-fc9v-43cv (details kept private pending coordinated disclosure).