### PR TITLE
fix(control-plane): bind replan reads by obligation identity

### DIFF
--- a/loopx/control_plane/testing/replan_evidence_tool_behavior.py
+++ b/loopx/control_plane/testing/replan_evidence_tool_behavior.py
@@ -52,6 +52,7 @@ _EVIDENCE_PLAN_VALUE_OPTIONS = {
     "--format",
     "--goal-id",
     "--limit",
+    "--required-read-id",
     "--registry",
     "--runtime-root",
 }
@@ -272,10 +273,17 @@ def _required_evidence_command_from_packet(packet: Mapping[str, Any]) -> str:
         raise ValueError("real quota packet must project exactly one required read")
     required_read = dict(required_reads[0])
     command = str(required_read.get("command") or "").strip()
+    required_read_id = str(required_read.get("required_read_id") or "").strip()
     if (
         required_read.get("kind") != "agent_scoped_evidence_log"
         or required_read.get("goal_id") != _FIXTURE_GOAL_ID
         or required_read.get("agent_id") != _FIXTURE_AGENT_ID
+        or not required_read_id
+        or _argument_value(
+            _loopx_command_tokens(command) or [],
+            "--required-read-id",
+        )
+        != required_read_id
         or " evidence-log " not in f" {command} "
     ):
         raise ValueError("real quota packet must bind to the fixture evidence log")
@@ -368,6 +376,10 @@ def _evidence_plan_classification(
     expected_goal_id = _argument_value(required_tokens, "--goal-id")
     expected_agent_id = _argument_value(required_tokens, "--agent-id")
     expected_limit = _argument_value(required_tokens, "--limit")
+    expected_required_read_id = _argument_value(
+        required_tokens,
+        "--required-read-id",
+    )
     if not expected_goal_id or not expected_agent_id or not expected_limit:
         raise ValueError("required evidence command is missing its scoped identity")
     segments = _evidence_plan_segments(command)
@@ -391,15 +403,14 @@ def _evidence_plan_classification(
             if parsed is None:
                 return "wrong_evidence_log"
             values, flags = parsed
-            if (
-                values
-                != {
-                    "--goal-id": expected_goal_id,
-                    "--agent-id": expected_agent_id,
-                    "--limit": expected_limit,
-                }
-                or flags != {"--thin"}
-            ):
+            expected_values = {
+                "--goal-id": expected_goal_id,
+                "--agent-id": expected_agent_id,
+                "--limit": expected_limit,
+            }
+            if expected_required_read_id:
+                expected_values["--required-read-id"] = expected_required_read_id
+            if values != expected_values or flags != {"--thin"}:
                 return "wrong_evidence_log"
             evidence_count += 1
             continue
@@ -722,8 +733,6 @@ class DoubaoReplanEvidenceToolBehaviorActor:
                         quota_packet
                     )
                     quota_observation = _quota_behavior_observation(quota_packet)
-                    if required_evidence_command != fixture.required_evidence_command:
-                        raise ValueError("quota required-read command drifted from fixture")
                     quota_observed = True
                     read_only_host_commands_executed = True
                 except (RuntimeError, ValueError, json.JSONDecodeError):

--- a/loopx/control_plane/work_items/autonomous_replan_ack.py
+++ b/loopx/control_plane/work_items/autonomous_replan_ack.py
@@ -293,6 +293,27 @@ def _replan_requires_agent_evidence_log(
     ).strip() == "agent_scoped_evidence_log"
 
 
+def _ack_is_prior_watch_continuation_for_obligation(
+    ack: dict[str, Any],
+    obligation: dict[str, Any],
+) -> bool:
+    """Return whether a prior ACK is typed evidence for this exact watch frontier."""
+
+    ack_frontier = str(ack.get("frontier_identity") or "").strip()
+    obligation_frontier = str(obligation.get("frontier_identity") or "").strip()
+    if not ack_frontier or ack_frontier != obligation_frontier:
+        return False
+    delta_contract = ack.get("delta_contract")
+    if not isinstance(delta_contract, dict):
+        return False
+    delta_kinds = {
+        str(item or "").strip()
+        for item in delta_contract.get("delta_kinds") or []
+        if str(item or "").strip()
+    }
+    return "watch_lane_continuation" in delta_kinds
+
+
 def validate_replan_required_read_receipt(
     ack: dict[str, Any] | None,
     *,
@@ -317,11 +338,14 @@ def validate_replan_required_read_receipt(
         acked_at is not None
         and triggered_at is not None
         and acked_at < triggered_at
+        and _ack_is_prior_watch_continuation_for_obligation(
+            ack,
+            replan_obligation,
+        )
     ):
-        # A standing continuation ACK that predates this obligation instance is
-        # not a response to it; watch-lane/frontier continuation semantics
-        # decide applicability, and a fresh read cannot be required for a
-        # pre-existing ACK.
+        # Only typed watch continuation evidence for the same stable frontier
+        # may predate the obligation. Ordinary replan ACKs must still satisfy
+        # this obligation by identity even when projection clocks are reordered.
         return None
     required_read_id = str(replan_obligation.get("obligation_id") or "").strip()
     command = build_agent_scoped_evidence_log_command(
@@ -350,14 +374,17 @@ def validate_replan_required_read_receipt(
                 and read_window.get("limit") == REPLAN_REQUIRED_READ_LIMIT
                 and (
                     not required_read_id
-                    or str(receipt.get("required_read_id") or "")
-                    == required_read_id
+                    or str(receipt.get("required_read_id") or "") == required_read_id
                 )
                 and (
                     recorded_at := parse_timestamp(receipt.get("recorded_at"))
                 )
                 is not None
-                and (triggered_at is None or triggered_at <= recorded_at)
+                and (
+                    bool(required_read_id)
+                    or triggered_at is None
+                    or triggered_at <= recorded_at
+                )
                 and recorded_at <= acked_at
             ),
             None,

--- a/tests/control_plane/test_replan_evidence_tool_behavior.py
+++ b/tests/control_plane/test_replan_evidence_tool_behavior.py
@@ -6,6 +6,10 @@ from pathlib import Path
 from typing import Any
 
 from loopx.control_plane.testing.model_tool_behavior import (
+    ScriptedDoubaoExecTransport,
+    ScriptedExecToolAction,
+)
+from loopx.control_plane.testing.model_tool_behavior import (
     scripted_exec_tool_response as _tool_response,
 )
 from loopx.control_plane.testing.replan_evidence_tool_behavior import (
@@ -14,28 +18,54 @@ from loopx.control_plane.testing.replan_evidence_tool_behavior import (
 )
 
 
+def _latest_required_read_command(request: Mapping[str, Any]) -> str:
+    messages = request.get("messages")
+    if not isinstance(messages, list) or not messages:
+        raise AssertionError("model request must include the latest quota tool result")
+    latest = messages[-1]
+    if not isinstance(latest, Mapping) or latest.get("role") != "tool":
+        raise AssertionError(
+            "required read must be selected after the quota tool result"
+        )
+    packet = json.loads(str(latest.get("content") or ""))
+    required_reads = packet.get("required_reads") or []
+    if len(required_reads) != 1 or not isinstance(required_reads[0], Mapping):
+        raise AssertionError("quota must project exactly one required read")
+    command = str(required_reads[0].get("command") or "").strip()
+    required_read_id = str(required_reads[0].get("required_read_id") or "").strip()
+    if not command or not required_read_id:
+        raise AssertionError("required read must carry its obligation identity")
+    if f"--required-read-id {required_read_id}" not in command:
+        raise AssertionError("required read command must bind the obligation identity")
+    return command
+
+
+def _required_read_action(
+    request: Mapping[str, Any],
+    *,
+    suffix: str = "",
+) -> ScriptedExecToolAction:
+    return ScriptedExecToolAction(
+        command=_latest_required_read_command(request) + suffix,
+    )
+
+
 def test_real_tool_loop_observes_production_evidence_log_intent(
     tmp_path: Path,
 ) -> None:
     fixture = _build_fixture(tmp_path / "oracle")
-    requests: list[dict[str, Any]] = []
-    commands = [
-        "date -Iseconds",
-        "export LOOPX_TURN=2026-08-12T00:00:00+08:00 && "
-        + fixture.quota_guard_command,
-        fixture.required_evidence_command,
-    ]
-
-    def transport(
-        *,
-        endpoint: str,
-        headers: Mapping[str, str],
-        body: bytes,
-        timeout_seconds: float,
-    ) -> Mapping[str, Any]:
-        request = json.loads(body)
-        requests.append(request)
-        return _tool_response(f"call-{len(requests)}", commands[len(requests) - 1])
+    transport = ScriptedDoubaoExecTransport(
+        [
+            ScriptedExecToolAction(command="date -Iseconds"),
+            ScriptedExecToolAction(
+                command=(
+                    "export LOOPX_TURN=2026-08-12T00:00:00+08:00 && "
+                    + fixture.quota_guard_command
+                )
+            ),
+            _required_read_action,
+        ]
+    )
 
     actor = DoubaoReplanEvidenceToolBehaviorActor(
         api_key="test-only-placeholder",
@@ -46,7 +76,11 @@ def test_real_tool_loop_observes_production_evidence_log_intent(
         fixture_root=tmp_path / "actor",
     )
 
-    assert receipt["qualification_passed"] is True
+    assert receipt["qualification_passed"] is True, (
+        receipt["failure_code"],
+        receipt["observed_tool_sequence"],
+        receipt["tool_call_receipts"],
+    )
     assert receipt["observed_tool_sequence"] == [
         "clock",
         "quota_should_run",
@@ -86,6 +120,7 @@ def test_real_tool_loop_observes_production_evidence_log_intent(
     }
     assert fixture.required_evidence_command not in json.dumps(receipt, sort_keys=True)
 
+    requests = transport.requests
     first = requests[0]
     assert first["messages"] == [
         {
@@ -115,8 +150,9 @@ def test_real_tool_loop_observes_production_evidence_log_intent(
         quota_result["interaction_contract"]["agent_channel"]["required_reads"][0]
     ]
     assert quota_result["required_reads"][0]["command"] == (
-        fixture.required_evidence_command
+        _latest_required_read_command(requests[2])
     )
+    assert quota_result["required_reads"][0]["required_read_id"]
     rollout_path = (
         tmp_path
         / "actor"
@@ -130,8 +166,15 @@ def test_real_tool_loop_observes_production_evidence_log_intent(
         for line in rollout_path.read_text(encoding="utf-8").splitlines()
         if line.strip()
     ]
-    assert rollout_events[-1]["event_kind"] == "quota_should_run"
+    assert [event["event_kind"] for event in rollout_events[-2:]] == [
+        "quota_should_run",
+        "evidence_log_read",
+    ]
     assert rollout_events[-1]["agent_id"] == "codex-replan-evidence"
+    assert (
+        rollout_events[-1]["details"]["required_read_id"]
+        == (quota_result["required_reads"][0]["required_read_id"])
+    )
 
 
 def test_tool_loop_rejects_evidence_log_before_quota(tmp_path: Path) -> None:
@@ -155,35 +198,28 @@ def test_tool_loop_rejects_evidence_log_before_quota(tmp_path: Path) -> None:
 
 def test_tool_loop_accepts_a_bounded_evidence_read_plan(tmp_path: Path) -> None:
     fixture = _build_fixture(tmp_path / "oracle")
-    commands = [
-        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
-        "\n".join(
-            (
-                "echo '=== evidence log ==='",
-                fixture.required_evidence_command,
-                "echo '=== registry goal ==='",
-                (
-                    "loopx --format json registry show-goal "
-                    "--goal-id replan-evidence-live-fixture 2>/dev/null || "
-                    "loopx --format json --registry "
-                    '"$HOME/.codex/loopx/registry.global.json" registry show-goal '
-                    "--goal-id replan-evidence-live-fixture"
-                ),
-                "echo '=== todos ==='",
-                (
-                    "loopx --format json todo list "
-                    "--goal-id replan-evidence-live-fixture 2>/dev/null"
-                ),
-            )
-        ),
-    ]
-    call_count = 0
-
-    def transport(**_: Any) -> Mapping[str, Any]:
-        nonlocal call_count
-        command = commands[call_count]
-        call_count += 1
-        return _tool_response(f"call-{call_count}", command)
+    suffix = (
+        "\necho '=== registry goal ==='\n"
+        "loopx --format json registry show-goal "
+        "--goal-id replan-evidence-live-fixture 2>/dev/null || "
+        "loopx --format json --registry "
+        '"$HOME/.codex/loopx/registry.global.json" registry show-goal '
+        "--goal-id replan-evidence-live-fixture\n"
+        "echo '=== todos ==='\n"
+        "loopx --format json todo list "
+        "--goal-id replan-evidence-live-fixture 2>/dev/null"
+    )
+    transport = ScriptedDoubaoExecTransport(
+        [
+            ScriptedExecToolAction(
+                command=fixture.quota_guard_command.replace(
+                    '"${LOOPX_TURN:?}"',
+                    "turn-001",
+                )
+            ),
+            lambda request: _required_read_action(request, suffix=suffix),
+        ]
+    )
 
     receipt = DoubaoReplanEvidenceToolBehaviorActor(
         api_key="test-only-placeholder",
@@ -204,27 +240,28 @@ def test_tool_loop_accepts_supplemental_replan_observation_intent(
     tmp_path: Path,
 ) -> None:
     fixture = _build_fixture(tmp_path / "oracle")
-    commands = [
-        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
-        (
-            f"{fixture.required_evidence_command}\n"
-            "loopx --format json registry get-goal "
-            "--goal-id replan-evidence-live-fixture 2>/dev/null || "
-            "echo 'goal read unavailable'\n"
-            "loopx --format json project status "
-            "--goal-id replan-evidence-live-fixture 2>/dev/null || "
-            "echo 'project read unavailable'\n"
-            "loopx --format json todo list "
-            "--goal-id replan-evidence-live-fixture 2>/dev/null"
-        ),
-    ]
-    call_count = 0
-
-    def transport(**_: Any) -> Mapping[str, Any]:
-        nonlocal call_count
-        command = commands[call_count]
-        call_count += 1
-        return _tool_response(f"call-{call_count}", command)
+    suffix = (
+        "\n"
+        "loopx --format json registry get-goal "
+        "--goal-id replan-evidence-live-fixture 2>/dev/null || "
+        "echo 'goal read unavailable'\n"
+        "loopx --format json project status "
+        "--goal-id replan-evidence-live-fixture 2>/dev/null || "
+        "echo 'project read unavailable'\n"
+        "loopx --format json todo list "
+        "--goal-id replan-evidence-live-fixture 2>/dev/null"
+    )
+    transport = ScriptedDoubaoExecTransport(
+        [
+            ScriptedExecToolAction(
+                command=fixture.quota_guard_command.replace(
+                    '"${LOOPX_TURN:?}"',
+                    "turn-001",
+                )
+            ),
+            lambda request: _required_read_action(request, suffix=suffix),
+        ]
+    )
 
     receipt = DoubaoReplanEvidenceToolBehaviorActor(
         api_key="test-only-placeholder",
@@ -245,21 +282,22 @@ def test_tool_loop_rejects_state_change_bundled_with_evidence(
     tmp_path: Path,
 ) -> None:
     fixture = _build_fixture(tmp_path / "oracle")
-    commands = [
-        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
-        (
-            f"{fixture.required_evidence_command}\n"
-            "loopx --format json todo complete "
-            "--goal-id replan-evidence-live-fixture --todo-id todo-unsafe"
-        ),
-    ]
-    call_count = 0
-
-    def transport(**_: Any) -> Mapping[str, Any]:
-        nonlocal call_count
-        command = commands[call_count]
-        call_count += 1
-        return _tool_response(f"call-{call_count}", command)
+    suffix = (
+        "\n"
+        "loopx --format json todo complete "
+        "--goal-id replan-evidence-live-fixture --todo-id todo-unsafe"
+    )
+    transport = ScriptedDoubaoExecTransport(
+        [
+            ScriptedExecToolAction(
+                command=fixture.quota_guard_command.replace(
+                    '"${LOOPX_TURN:?}"',
+                    "turn-001",
+                )
+            ),
+            lambda request: _required_read_action(request, suffix=suffix),
+        ]
+    )
 
     receipt = DoubaoReplanEvidenceToolBehaviorActor(
         api_key="test-only-placeholder",
@@ -277,17 +315,20 @@ def test_tool_loop_rejects_unsafe_command_bundled_with_evidence(
     tmp_path: Path,
 ) -> None:
     fixture = _build_fixture(tmp_path / "oracle")
-    commands = [
-        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
-        fixture.required_evidence_command + "\nrm -rf temporary-fixture",
-    ]
-    call_count = 0
-
-    def transport(**_: Any) -> Mapping[str, Any]:
-        nonlocal call_count
-        command = commands[call_count]
-        call_count += 1
-        return _tool_response(f"call-{call_count}", command)
+    transport = ScriptedDoubaoExecTransport(
+        [
+            ScriptedExecToolAction(
+                command=fixture.quota_guard_command.replace(
+                    '"${LOOPX_TURN:?}"',
+                    "turn-001",
+                )
+            ),
+            lambda request: _required_read_action(
+                request,
+                suffix="\nrm -rf temporary-fixture",
+            ),
+        ]
+    )
 
     receipt = DoubaoReplanEvidenceToolBehaviorActor(
         api_key="test-only-placeholder",
@@ -307,16 +348,18 @@ def test_tool_loop_rejects_unsafe_command_bundled_with_evidence(
 
 def test_tool_loop_accepts_the_real_host_utc_clock_shape(tmp_path: Path) -> None:
     fixture = _build_fixture(tmp_path / "oracle")
-    commands = [
-        'date -u +"%Y-%m-%dT%H:%M:%SZ"',
-        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
-        fixture.required_evidence_command,
-    ]
-    requests: list[dict[str, Any]] = []
-
-    def transport(**kwargs: Any) -> Mapping[str, Any]:
-        requests.append(json.loads(kwargs["body"]))
-        return _tool_response(f"call-{len(requests)}", commands[len(requests) - 1])
+    transport = ScriptedDoubaoExecTransport(
+        [
+            ScriptedExecToolAction(command='date -u +"%Y-%m-%dT%H:%M:%SZ"'),
+            ScriptedExecToolAction(
+                command=fixture.quota_guard_command.replace(
+                    '"${LOOPX_TURN:?}"',
+                    "turn-001",
+                )
+            ),
+            _required_read_action,
+        ]
+    )
 
     receipt = DoubaoReplanEvidenceToolBehaviorActor(
         api_key="test-only-placeholder",
@@ -327,6 +370,7 @@ def test_tool_loop_accepts_the_real_host_utc_clock_shape(tmp_path: Path) -> None
     )
 
     assert receipt["qualification_passed"] is True
+    requests = transport.requests
     assert requests[1]["messages"][-1]["content"] == "2026-08-11T16:00:00Z\n"
 
 
@@ -334,19 +378,19 @@ def test_tool_loop_allows_distinct_normal_workspace_preflight_reads(
     tmp_path: Path,
 ) -> None:
     fixture = _build_fixture(tmp_path / "oracle")
-    commands = [
-        "pwd",
-        "git status --short --branch",
-        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
-        fixture.required_evidence_command,
-    ]
-    call_count = 0
-
-    def transport(**_: Any) -> Mapping[str, Any]:
-        nonlocal call_count
-        command = commands[call_count]
-        call_count += 1
-        return _tool_response(f"call-{call_count}", command)
+    transport = ScriptedDoubaoExecTransport(
+        [
+            ScriptedExecToolAction(command="pwd"),
+            ScriptedExecToolAction(command="git status --short --branch"),
+            ScriptedExecToolAction(
+                command=fixture.quota_guard_command.replace(
+                    '"${LOOPX_TURN:?}"',
+                    "turn-001",
+                )
+            ),
+            _required_read_action,
+        ]
+    )
 
     receipt = DoubaoReplanEvidenceToolBehaviorActor(
         api_key="test-only-placeholder",
@@ -370,9 +414,7 @@ def test_tool_loop_rejects_generic_or_wrong_evidence_read(tmp_path: Path) -> Non
     responses = [
         _tool_response(
             "call-1",
-            fixture.quota_guard_command.replace(
-                '"${LOOPX_TURN:?}"', "turn-001"
-            ),
+            fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
         ),
         _tool_response(
             "call-2",

--- a/tests/control_plane/test_replan_required_read_receipts.py
+++ b/tests/control_plane/test_replan_required_read_receipts.py
@@ -30,8 +30,13 @@ COMMAND = (
 )
 
 
-def _obligation(*, triggered_at: str = TRIGGERED_AT) -> dict[str, object]:
-    return {
+def _obligation(
+    *,
+    triggered_at: str = TRIGGERED_AT,
+    obligation_id: str | None = None,
+    frontier_identity: str | None = None,
+) -> dict[str, object]:
+    obligation: dict[str, object] = {
         "required": True,
         "triggers": [
             {
@@ -44,18 +49,31 @@ def _obligation(*, triggered_at: str = TRIGGERED_AT) -> dict[str, object]:
             "writeback": "repair_delta",
         },
     }
+    if obligation_id:
+        obligation["obligation_id"] = obligation_id
+    if frontier_identity:
+        obligation["frontier_identity"] = frontier_identity
+    return obligation
 
 
-def _ack() -> dict[str, object]:
-    return {
+def _ack(
+    *,
+    generated_at: str = ACKED_AT,
+    frontier_identity: str | None = None,
+    delta_kinds: list[str] | None = None,
+) -> dict[str, object]:
+    ack: dict[str, object] = {
         "recorded": True,
         "agent_id": AGENT_ID,
-        "generated_at": ACKED_AT,
+        "generated_at": generated_at,
         "delta_contract": {
             "delta_present": True,
-            "delta_kinds": ["runnable_todo_set"],
+            "delta_kinds": delta_kinds or ["runnable_todo_set"],
         },
     }
+    if frontier_identity:
+        ack["frontier_identity"] = frontier_identity
+    return ack
 
 
 def _receipt(
@@ -86,6 +104,8 @@ def _receipt(
     }
     if error:
         receipt["error"] = error
+    if required_read_id:
+        receipt["required_read_id"] = required_read_id
     return receipt
 
 
@@ -256,6 +276,85 @@ def test_receipt_must_match_the_projected_read_window() -> None:
     assert validation["required_read_satisfied"] is False
 
 
+def test_pre_trigger_ack_without_typed_continuation_is_rejected() -> None:
+    validation = validate_replan_required_read_receipt(
+        _ack(generated_at="2026-08-12T00:59:59Z"),
+        replan_obligation=_obligation(obligation_id="replan-current"),
+        receipts=[],
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+
+    assert validation is not None
+    assert validation["accepted"] is False
+    assert validation["rejected_claims"][0]["kind"] == ("required_read_not_executed")
+    assert "--required-read-id replan-current" in validation["required_read"]["command"]
+
+
+def test_pre_trigger_ack_accepts_matching_required_read_identity() -> None:
+    validation = validate_replan_required_read_receipt(
+        _ack(generated_at="2026-08-12T00:59:59Z"),
+        replan_obligation=_obligation(obligation_id="replan-current"),
+        receipts=[
+            _receipt(
+                "2026-08-12T00:59:58Z",
+                required_read_id="replan-current",
+            )
+        ],
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+
+    assert validation is not None
+    assert validation["accepted"] is True
+    assert validation["required_read_satisfied"] is True
+    assert validation["matched_receipt"]["required_read_id"] == "replan-current"
+
+
+def test_pre_trigger_ack_exempts_only_matching_typed_watch_continuation() -> None:
+    obligation = _obligation(
+        obligation_id="replan-current",
+        frontier_identity="frontier-stable",
+    )
+
+    matching_watch = validate_replan_required_read_receipt(
+        _ack(
+            generated_at="2026-08-12T00:59:59Z",
+            frontier_identity="frontier-stable",
+            delta_kinds=["watch_lane_continuation"],
+        ),
+        replan_obligation=obligation,
+        receipts=[],
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+    runnable_delta = validate_replan_required_read_receipt(
+        _ack(
+            generated_at="2026-08-12T00:59:59Z",
+            frontier_identity="frontier-stable",
+        ),
+        replan_obligation=obligation,
+        receipts=[],
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+    wrong_frontier = validate_replan_required_read_receipt(
+        _ack(
+            generated_at="2026-08-12T00:59:59Z",
+            frontier_identity="frontier-old",
+            delta_kinds=["watch_lane_continuation"],
+        ),
+        replan_obligation=obligation,
+        receipts=[],
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+
+    assert matching_watch is None
+    assert runnable_delta is not None and runnable_delta["accepted"] is False
+    assert wrong_frontier is not None and wrong_frontier["accepted"] is False
+
+
 def _quota_obligation() -> dict[str, object]:
     return build_autonomous_replan_obligation_payload(
         schema_version="autonomous_replan_obligation_v0",
@@ -279,6 +378,7 @@ def _quota_obligation() -> dict[str, object]:
 def _quota_payload(
     *,
     receipts: list[dict[str, object]] | None = None,
+    ack_generated_at: str = ACKED_AT,
 ) -> dict[str, object]:
     obligation = _quota_obligation()
     status_payload = quota_status_payload(
@@ -292,7 +392,7 @@ def _quota_payload(
         latest_runs=[
             {
                 "goal_id": GOAL_ID,
-                "generated_at": ACKED_AT,
+                "generated_at": ack_generated_at,
                 "agent_id": AGENT_ID,
                 "classification": "autonomous_replan_ack",
                 "autonomous_replan_ack": {
@@ -343,7 +443,6 @@ def test_quota_accepts_matching_obligation_receipt() -> None:
         "2026-08-12T01:05:00Z",
         required_read_id=str(obligation["obligation_id"]),
     )
-    receipt["required_read_id"] = obligation["obligation_id"]
     payload = _quota_payload(receipts=[receipt])
 
     assert payload.get("autonomous_replan_obligation") is None
@@ -358,10 +457,21 @@ def test_quota_accepts_failed_read_attempt_but_surfaces_warning() -> None:
         status="failed",
         error="registry unavailable",
     )
-    receipt["required_read_id"] = obligation["obligation_id"]
     payload = _quota_payload(receipts=[receipt])
 
     assert payload.get("autonomous_replan_obligation") is None
     feedback = payload["replan_ack_feedback"]
     assert feedback["accepted"] is True
     assert feedback["warnings"][0]["kind"] == "evidence_log_read_failed"
+
+
+def test_quota_rejects_pre_trigger_ack_and_reprojects_exact_required_read() -> None:
+    payload = _quota_payload(ack_generated_at="2026-08-12T00:59:59Z")
+
+    obligation = payload["autonomous_replan_obligation"]
+    feedback = payload["replan_ack_feedback"]
+    required_read = payload["required_reads"][0]
+    assert feedback["accepted"] is False
+    assert feedback["rejected_claims"][0]["kind"] == "required_read_not_executed"
+    assert required_read["required_read_id"] == obligation["obligation_id"]
+    assert required_read["command"] == feedback["required_read"]["command"]


### PR DESCRIPTION
## Summary

- bind replan required-read enforcement to the current obligation identity instead of timestamp ordering alone
- preserve the standing-watch compatibility case only for a typed `watch_lane_continuation` on the exact same frontier
- make the model behavior fixture select the current quota packet's exact evidence-log command and verify the durable `evidence_log_read` event

Fixes #3141.

## Behavior change

A pre-trigger ordinary replan ACK no longer bypasses required-read validation. It is rejected with `required_read_not_executed` unless an exact receipt carries the current `required_read_id`. The only pre-trigger exemption is an explicit watch-lane continuation whose frontier identity matches the current obligation.

This is a machine-enforced control-plane obligation, not guidance. Generic evidence-log reads without the projected `--required-read-id` do not satisfy it.

## Validation

- 85 focused replan, frontier, monitor, and behavior tests passed
- repository-declared mypy passed (16 configured source files)
- Ruff and changed-file `py_compile` passed
- `git diff --check origin/main...HEAD` passed
- risk-driven premerge passed: 15/15 selected checks, 0 failures, 0 manual holds
- exact-scope change-quality receipt: `cqr_cf09980a10102a9f6b37`

The first premerge invocation exposed a host entrypoint using system Python 3.9 (`tomllib` unavailable). The same E2E check and then the complete 15-check premerge suite passed through the repository's supported venv Python module entrypoint.

## Boundaries

- no benchmark-specific runtime rule or raw benchmark evidence
- no new capability, schema, executor, or speculative abstraction
- no private state, credentials, local paths, or generated rollout logs
