### PR TITLE
release: bump version to 0.4.5

### DIFF
--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.4"
+__version__ = "0.4.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.4.4"
+version = "0.4.5"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump for the v0.4.5 security-hardening release. Release notes validated by `release-readiness-doc-smoke` (6 surfaces) and `release-version-contract-smoke`.