### PR TITLE
fix(control-plane): make fine execution use coherent decision slices

### DIFF
--- a/docs/development/control-plane-course/10-autonomous-agent-quality-gates.md
+++ b/docs/development/control-plane-course/10-autonomous-agent-quality-gates.md
@@ -235,8 +235,10 @@ projection repair；每个场景重复两次，所有重复都要通过。
 这些场景不应一律只做 packet interpretation。当结论是“agent 必须真的调用工具”时，
 portfolio 使用 scenario-owned 的 hermetic actor：selected Todo 执行目标 read，replan 执行
 evidence-log read，scoped gate 在呈现非阻塞 notice 后执行 successor，capability bridge
-则执行 quota 投影的 repair Todo 写入并由 host 读回。第四种场景里，等待或更新
-monitor fallback、或在 quota 后重新读取 workspace，都必须失败。四个 actor 只共享已证明的 tool decoding 和隔离 CLI 机制；
+则先执行原 blocked Todo 的真实任务侧 callsite，再在同一 heartbeat 执行 quota 投影的
+re-entry 命令；只有 quota 重新选中原 Todo，且没有 repair Todo、turn settlement 或
+durable capability grant，才算通过。第四种场景里，等待或更新 monitor fallback、在
+quota 前绕过 gate、验证前 re-entry、或读取错误目标，都必须失败。四个 actor 只共享已证明的 tool decoding 和隔离 CLI 机制；
 各自的 Goal fixture、合法动作状态机和 semantic oracle 保持独立，不引入通用 scenario
 runner。
 

--- a/docs/development/testing-and-quality.md
+++ b/docs/development/testing-and-quality.md
@@ -353,18 +353,20 @@ python3 scripts/qualify-doubao-scoped-gate-successor-tool-live.py \
   --qualification-id <public-safe-run-id>
 ```
 
-Capability-bridge repair is the fourth real tool loop. Its hermetic Goal has a
-capability-blocked advancement Todo and an incomplete monitor fallback. Real
+Capability-bridge re-entry is the fourth real tool loop. Its hermetic Goal has
+a capability-blocked advancement Todo and an incomplete monitor fallback. Real
 quota must project `capability_bridge_repair`. The actor sends the shipped task
 body inside the same heartbeat trigger envelope, including its trigger time,
 that the Codex App model normally receives. The default CLI projection keeps
 `interaction_contract` in the action-first prefix rather than after diagnostic
-lanes; the model must then execute the
-projected `todo add --target-capability ... --unblocks-todo-id ...` action, and
-the host reads the new repair Todo back before passing. Waiting on or updating
-the monitor, repairing before quota, or materializing the wrong capability
-fails. Bounded workspace inspection remains available before quota; any
-workspace read after quota is classified as backtracking and fails immediately.
+lanes. The model must verify the capability with the blocked Todo's real
+task-facing read, then execute the projected quota re-entry command in the same
+heartbeat; quota must select the original Todo without a repair Todo, turn
+settlement, or durable capability grant. Waiting on or updating the monitor,
+reading the callsite before quota, re-entering before successful verification,
+or reading a different target fails. Bounded workspace inspection remains
+available before quota; unrelated workspace reads after quota are classified as
+backtracking and fail immediately.
 
 ```bash
 python3 scripts/qualify-doubao-capability-monitor-repair-tool-live.py \
@@ -404,7 +406,7 @@ explicit packet differentials or outcome claims.
 场景，每个重复 2 次。9 个核心场景覆盖正常接入、agent 身份与
 goal 选择、selected todo、peer 身份路由、same-agent 续接、最终 human gate、健康继续
 和 projection repair；3 个组合场景覆盖 vision/monitor/peer replan 优先级、非阻塞
-user notice 与 ready successor 并存，以及 capability-bridge repair 必须先于 monitor
+user notice 与 ready successor 并存，以及 capability-bridge re-entry 必须先于 monitor
 fallback；3 个 compaction 场景覆盖 JSON 预算与 source-derived 语义一致，并分别让正常
 selected work 和阻塞 gate 在超预算省略诊断下重复运行。4 个 contrast group 要求
 clean/noisy 场景保持不变，同时要求 blocking gate 与 non-blocking notice、selected
@@ -417,8 +419,10 @@ evidence-log；其他 turn 场景仍直接读取 Codex App
 automation 使用的默认 CLI hot-path `quota should-run` projection 并返回运行时决策，
 scoped-gate successor 场景也从 hermetic Goal 与正式 heartbeat 开始：真实 quota 必须
 同时投影非阻塞 user notice 和 ready deferred successor，模型随后既要呈现提醒，也要
-实际执行被选中的 successor；capability repair 场景则要求模型执行 quota 投影的
-repair Todo 写入，host 再读回新 Todo，而非等待 monitor fallback。其他 turn 场景仍属于
+实际执行被选中的 successor；capability re-entry 场景则要求模型先执行原 blocked Todo
+的真实任务侧 read，再在同一 heartbeat 执行 quota 投影的 re-entry 命令；quota 必须重新
+选中原 Todo，且全程不创建 repair Todo、不结算 turn、也不写 durable capability grant。
+其他 turn 场景仍属于
 packet interpretation。scheduler、vision、writeback 与
 warning 的精确字段继续由 action-signature 确定性覆盖；pair 中的 TurnEnvelope 只用于
 明确的 packet 差分或结果提升声明。全套仍是 30 个有界 scenario attempt；考虑四个

--- a/docs/reference/protocols/model-behavior-qualification-v0.md
+++ b/docs/reference/protocols/model-behavior-qualification-v0.md
@@ -255,9 +255,11 @@ reusable. The first requires a real read-only action against the
 selected Todo target; the second requires the exact agent-scoped evidence-log
 read projected by a hermetic missing-vision replan state; the third requires a
 post-quota non-blocking user notice followed by the exact ready-successor
-action. The fourth requires the quota-projected agent-owned capability-repair
-Todo to be created and read back before the incomplete monitor fallback can
-delay work; any post-quota workspace read fails as action backtracking. The other turn
+action. The fourth requires a real task-facing call against the blocked Todo,
+followed by the quota-projected capability re-entry command in the same
+heartbeat. Quota must then select the original Todo without a repair Todo, turn
+settlement, or durable capability grant; an unrelated post-quota workspace read
+fails as action backtracking. The other turn
 scenarios still feed the live actor the same default full quota packet consumed
 by Codex App automation, because their current proof is packet interpretation
 rather than tool execution. Onboarding scenarios use the shipped guided-
@@ -287,9 +289,10 @@ and scheduler paths and deliberately contains competing signals:
     must surface the notice and execute the successor replan rather than treat
     every `user_action_required` value as a blocking gate;
 12. unavailable capability blocks the visible advancement, while an incomplete
-    monitor schedule remains as a fallback, so the agent must execute the
-    quota-projected capability-repair Todo rather than wait on or update the
-    monitor or attempt the blocked task.
+    monitor schedule remains as a fallback, so the agent must verify the
+    capability at the blocked Todo's real callsite and re-enter quota in the
+    same heartbeat rather than create a repair Todo, wait on or update the
+    monitor, or claim an unverified capability.
 
 Three compaction scenarios exercise the actual default CLI projection:
 

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -1457,6 +1457,19 @@ def build_start_goal_guided_packet(
         "writes_now": False,
         "spends_quota_now": False,
         "command_cwd_source": "#/project",
+        **(
+            {
+                "checkpoint_policy": {
+                    "task_frontier": "agent_advancement_todos_only",
+                    "protocol_step_todo_projection": "forbidden",
+                    "protocol_step_advancement_checkpoint": False,
+                    "protocol_step_turn_settlement": False,
+                    "settlement": "once_after_task_facing_slice",
+                }
+            }
+            if fine_grained
+            else {}
+        ),
         "ordered_steps": [
             {
                 "id": "inspect_connection",

--- a/loopx/cli_commands/start_goal.py
+++ b/loopx/cli_commands/start_goal.py
@@ -95,8 +95,8 @@ def register_start_goal_command(subparsers: argparse._SubParsersAction) -> None:
         "--fine-grained",
         action="store_true",
         help=(
-            "Persist fine-grained execution for this goal: one small checkpoint "
-            "todo per turn, followed by evidence-driven replanning."
+            "Persist fine-grained planning for this goal: small verifiable checkpoint "
+            "Todos executed in coherent evidence-driven turn slices."
         ),
     )
     goal_input_group = start_goal_parser.add_mutually_exclusive_group(required=True)

--- a/loopx/control_plane/goals/goal_frontier/__init__.py
+++ b/loopx/control_plane/goals/goal_frontier/__init__.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from ....execution_profile import execution_profile_is_fine_grained
 from ...agents.agent_scope import (
     agent_scope_blocking_handoff_gates,
     agent_scope_count_advancement_items,
@@ -1338,10 +1337,6 @@ def derive_goal_frontier_replan_obligation_from_summaries(
             ),
         )
     if replan_rule.rule is GoalFrontierReplanRule.VISION_ACCEPTANCE_GAP:
-        fine_checkpoint_replan = any(
-            gap.get("replan_cadence") == "fine_grained_after_each_todo"
-            for gap in compact_acceptance_gaps
-        )
         return build_autonomous_replan_obligation_payload(
             schema_version=AUTONOMOUS_REPLAN_OBLIGATION_SCHEMA_VERSION,
             agent_id=agent_id,
@@ -1371,14 +1366,7 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                 for gap in compact_acceptance_gaps[:3]
             ],
             guidance_actions=[
-                *(
-                    [
-                        "read_latest_completed_todo_evidence",
-                        "retain_replace_or_split_successor",
-                    ]
-                    if fine_checkpoint_replan
-                    else ["create_successor"]
-                ),
+                "create_successor",
                 "update_agent_vision",
                 "record_evidence_gap",
                 "record_no_followup",
@@ -1389,11 +1377,7 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                     "role": "agent",
                     "priority": "P0",
                     "text": (
-                        "run a bounded fine-grained checkpoint replan: read the latest "
-                        "completion evidence, then retain, replace, or split the next "
-                        "runnable advancement todo, or record no-follow-up"
-                        if fine_checkpoint_replan
-                        else "run a bounded vision-gap replan: create the next runnable "
+                        "run a bounded vision-gap replan: create the next runnable "
                         "advancement todo or record an explicit no-follow-up rationale"
                     ),
                 }
@@ -1403,11 +1387,7 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                 "production actions, or owner-only decisions"
             ),
             recommended_action=(
-                "run the existing bounded replan path before successor execution: "
-                "read latest completion evidence, then retain, replace, or split the "
-                "successor and write a frontier delta, or record no-follow-up"
-                if fine_checkpoint_replan
-                else "run a bounded vision-gap replan before another quiet poll: create "
+                "run a bounded vision-gap replan before another quiet poll: create "
                 "successor work, update the agent vision, record evidence gap, or "
                 "record no-follow-up"
             ),
@@ -1705,13 +1685,7 @@ def build_goal_frontier_projection_context_from_status(
             latest_vision_checkpoint,
             agent_todo_summary=agent_todo_summary,
             agent_id=agent_id,
-            completed_todo_threshold=(
-                1
-                if execution_profile_is_fine_grained(
-                    (project_asset or {}).get("execution_profile")
-                )
-                else COMPLETED_TODO_CHAIN_REPLAN_THRESHOLD
-            ),
+            completed_todo_threshold=COMPLETED_TODO_CHAIN_REPLAN_THRESHOLD,
         )
     )
     if _terminal_no_followup_resolves_vision_checkpoint(

--- a/loopx/control_plane/goals/goal_frontier/outcome_continuity.py
+++ b/loopx/control_plane/goals/goal_frontier/outcome_continuity.py
@@ -506,10 +506,5 @@ def acceptance_gaps_from_todo_completion_checkpoint(
                 else None
             ),
             "required_path_outcomes": ["continue", "no_change", "replan"],
-            **(
-                {"replan_cadence": "fine_grained_after_each_todo"}
-                if threshold == 1
-                else {}
-            ),
         }
     ]

--- a/loopx/control_plane/goals/start_contract.py
+++ b/loopx/control_plane/goals/start_contract.py
@@ -139,8 +139,10 @@ def build_goal_start_contract(
         contract["turn_mode"] = "fine_grained"
         contract["fine_grained"] = {
             "todo_granularity": "small_checkpoint",
-            "turn_boundary": "one_todo_per_turn",
-            "replan": "after_each_todo",
+            "turn_work_budget": "coherent_slice",
+            "turn_boundary": "settle_after_coherent_slice",
+            "replan": "direction_change_or_bounded_chain",
+            "checkpoint_accounting": "advancement_only",
         }
         planner = contract["planner"]
         planner["fine_grained_plan_horizon"] = (
@@ -177,11 +179,14 @@ def build_goal_start_prompt(
     )
     fine_rule = (
         "\n8. Fine-grained mode: the current Todo must be one small verifiable checkpoint. "
-        "If it is too broad, split it before work. Complete only that Todo this turn; "
-        "after validation, durable writeback, accountable refresh, and spend, end the "
-        "turn. The next heartbeat must use the existing replan obligation/ACK path to "
-        "read fresh evidence and retain, replace, or split the successor; do not execute "
-        "a prewritten successor in the same turn."
+        "If it is too broad, split it before work. A coherent decision slice may complete "
+        "one or more causally related Agent advancement Todos in the same turn: after each "
+        "completion inspect its fresh evidence before creating or claiming the next Todo, "
+        "and settle only once after the slice. Use the existing replan obligation/ACK path "
+        "when evidence changes direction or the bounded-chain review becomes due; never "
+        "prewrite a long runnable chain. Protocol/setup and capability re-entry steps stay "
+        "inline in the guided transaction, are not Todos, and do not count as advancement "
+        "checkpoints or turn settlement."
         if fine_grained
         else ""
     )

--- a/loopx/control_plane/heartbeat/builder.py
+++ b/loopx/control_plane/heartbeat/builder.py
@@ -68,12 +68,15 @@ from ...project_prompt import (
 )
 
 FINE_GRAINED_TURN_RULE = (
-    "Fine-grained turn contract: the selected Todo must be one small verifiable "
-    "checkpoint; if it is broader, split/replan before delivery. Complete only that "
-    "Todo in this turn. After validation, durable Todo evidence/writeback, accountable "
-    "refresh, and one spend, end the turn without claiming or executing a successor. "
-    "On the next continuation, read the fresh completion evidence and satisfy the "
-    "existing replan obligation/ACK by retaining, replacing, or splitting the successor."
+    "Fine-grained planning contract: each Todo must be one small verifiable checkpoint; "
+    "if broader, split before delivery. The turn budget is one coherent decision slice "
+    "and may complete one or more causally related Agent advancement Todos. After each "
+    "completion inspect fresh evidence before creating or claiming a successor; continue "
+    "only while the direction remains unchanged. Validate and durably complete each Todo, "
+    "then perform accountable refresh and spend to settle the turn once after the slice. "
+    "A direction change or bounded-chain review must use the existing replan obligation/"
+    "ACK path before further delivery. Protocol/setup and capability re-entry steps are "
+    "inline non-advancement work: never create Todos or settle a turn for them alone."
 )
 
 

--- a/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
+++ b/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
@@ -933,7 +933,7 @@ def _scenario_contract(
             raise ValueError(
                 "capability bridge repair must name the missing capability"
             )
-        if "real task-facing callsite" not in str(action.get("primary_action")):
+        if "verification_target.instruction" not in str(action.get("primary_action")):
             raise ValueError(
                 "primary action must direct the agent to verify the bridge inline"
             )

--- a/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
+++ b/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
@@ -933,11 +933,9 @@ def _scenario_contract(
             raise ValueError(
                 "capability bridge repair must name the missing capability"
             )
-        if "next_cli_actions[0]" not in str(
-            action.get("primary_action")
-        ):
+        if "real task-facing callsite" not in str(action.get("primary_action")):
             raise ValueError(
-                "primary action must direct the agent to repair the bridge"
+                "primary action must direct the agent to verify the bridge inline"
             )
     compaction_selected_todos = {
         "turn_quota_hot_path_compaction_regression": "todo_c0ffee123456",

--- a/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
+++ b/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
@@ -933,7 +933,7 @@ def _scenario_contract(
             raise ValueError(
                 "capability bridge repair must name the missing capability"
             )
-        if "verification_target.instruction" not in str(action.get("primary_action")):
+        if "next_cli_actions[0]" not in str(action.get("primary_action")):
             raise ValueError(
                 "primary action must direct the agent to verify the bridge inline"
             )

--- a/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
+++ b/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
@@ -933,7 +933,7 @@ def _scenario_contract(
             raise ValueError(
                 "capability bridge repair must name the missing capability"
             )
-        if "next_task_action.instruction" not in str(action.get("primary_action")):
+        if "next_task_action.operation" not in str(action.get("primary_action")):
             raise ValueError(
                 "primary action must direct the agent to verify the bridge inline"
             )

--- a/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
+++ b/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
@@ -933,7 +933,7 @@ def _scenario_contract(
             raise ValueError(
                 "capability bridge repair must name the missing capability"
             )
-        if "next_cli_actions[0]" not in str(action.get("primary_action")):
+        if "next_task_action.instruction" not in str(action.get("primary_action")):
             raise ValueError(
                 "primary action must direct the agent to verify the bridge inline"
             )

--- a/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
+++ b/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
@@ -251,6 +251,10 @@ def _redacted_command_shape(
         "mentions_fixture_dir": "fixture/" in command,
         "mentions_selected_target": str(fixture.selected_target.name) in command,
         "multiline": "\n" in command,
+        "has_pipe": "|" in command,
+        "has_stderr_redirect": "2>" in command,
+        "has_conditional": "&&" in command or "||" in command,
+        "has_option_terminator": " -- " in command,
     }
 
 

--- a/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
+++ b/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
@@ -222,6 +222,12 @@ def _capability_repair_contract(packet: Mapping[str, Any]) -> dict[str, Any]:
     next_cli_actions = [str(item) for item in cli_channel.get("next_cli_actions") or []]
     reentry = dict(cli_channel.get("runtime_capability_reentry") or {})
     verification = dict(reentry.get("verification_contract") or {})
+    candidates = [
+        item for item in reentry.get("candidates") or [] if isinstance(item, Mapping)
+    ]
+    target = (
+        dict(candidates[0].get("verification_target") or {}) if candidates else {}
+    )
     reentry_actions = [
         item for item in next_cli_actions if _is_capability_reentry_command(item)
     ]
@@ -248,6 +254,8 @@ def _capability_repair_contract(packet: Mapping[str, Any]) -> dict[str, Any]:
         and CAPABILITY_REPAIR_TARGET_CAPABILITY in contract["repair_missing"]
         and verification.get("advancement_checkpoint") is False
         and verification.get("settles_turn") is False
+        and target.get("todo_id") == CAPABILITY_REPAIR_BLOCKED_TODO_ID
+        and "fixture/private-source.json" in str(target.get("instruction") or "")
         and len(reentry_actions) == 1
         and all("todo add" not in action for action in next_cli_actions)
     ):

--- a/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
+++ b/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
@@ -33,7 +33,7 @@ from .selected_todo_tool_behavior import (
 )
 
 CAPABILITY_MONITOR_REPAIR_TOOL_BEHAVIOR_RECEIPT_SCHEMA_VERSION = (
-    "capability_monitor_repair_tool_behavior_receipt_v0"
+    "capability_monitor_repair_tool_behavior_receipt_v1"
 )
 CAPABILITY_MONITOR_REPAIR_TOOL_BEHAVIOR_MAX_CALLS = 6
 
@@ -71,9 +71,21 @@ def _build_capability_repair_fixture(root: Path) -> _SelectedTodoToolFixture:
     global_registry_path = (
         fixture_home / ".codex" / "loopx" / "registry.global.json"
     )
-    unused_target = project_root / "fixture" / "unused.json"
+    selected_target = project_root / "fixture" / "private-source.json"
     state_path.parent.mkdir(parents=True, exist_ok=True)
-    unused_target.parent.mkdir(parents=True, exist_ok=True)
+    selected_target.parent.mkdir(parents=True, exist_ok=True)
+    selected_target.write_text(
+        json.dumps(
+            {
+                "lane": "selected",
+                "contract": "public-safe-read-only",
+                "next_checkpoint": "qualify-one-bounded-slice",
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
     subprocess.run(
         ["git", "init", "-q"],
         cwd=project_root,
@@ -101,7 +113,7 @@ def _build_capability_repair_fixture(root: Path) -> _SelectedTodoToolFixture:
         "task_class=continuous_monitor action_kind=monitor "
         f"claimed_by={SELECTED_TODO_TOOL_FIXTURE_AGENT_ID} priority=P0 "
         "target_key=portfolio-release-monitor -->\n"
-        "- [ ] [P1] Read a private source before implementation.\n"
+        "- [ ] [P1] Read fixture/private-source.json before implementation.\n"
         "  <!-- loopx:todo "
         f"todo_id={CAPABILITY_REPAIR_BLOCKED_TODO_ID} status=open "
         "task_class=advancement_task action_kind=read_private_source "
@@ -165,32 +177,26 @@ def _build_capability_repair_fixture(root: Path) -> _SelectedTodoToolFixture:
         runtime_root=runtime_root,
         global_registry_path=global_registry_path,
         source_root=source_root,
-        selected_target=unused_target,
+        selected_target=selected_target,
     )
 
 
-def _is_capability_repair_command(command: str) -> bool:
+def _is_capability_reentry_command(command: str) -> bool:
     tokens = loopx_command_tokens(command)
     if not tokens:
         return False
-    try:
-        todo_index = tokens.index("todo")
-    except ValueError:
-        return False
     return bool(
-        tokens[todo_index : todo_index + 2] == ["todo", "add"]
+        any(
+            tokens[index : index + 2] == ["quota", "should-run"]
+            for index in range(len(tokens) - 1)
+        )
         and argument_value(tokens, "--goal-id")
         == SELECTED_TODO_TOOL_FIXTURE_GOAL_ID
-        and argument_value(tokens, "--role") == "agent"
-        and argument_value(tokens, "--task-class") == "advancement_task"
-        and argument_value(tokens, "--action-kind") == "materialize_capability"
-        and argument_value(tokens, "--target-capability")
-        == CAPABILITY_REPAIR_TARGET_CAPABILITY
-        and argument_value(tokens, "--claimed-by")
-        == SELECTED_TODO_TOOL_FIXTURE_AGENT_ID
-        and argument_value(tokens, "--unblocks-todo-id")
-        == CAPABILITY_REPAIR_BLOCKED_TODO_ID
-        and bool(argument_value(tokens, "--text"))
+        and any(
+            tokens[index : index + 2]
+            == ["--available-capability", CAPABILITY_REPAIR_TARGET_CAPABILITY]
+            for index in range(len(tokens) - 1)
+        )
     )
 
 
@@ -214,7 +220,11 @@ def _capability_repair_contract(packet: Mapping[str, Any]) -> dict[str, Any]:
     capability_gate = dict(packet.get("capability_gate") or {})
     cli_channel = dict(interaction.get("cli_channel") or {})
     next_cli_actions = [str(item) for item in cli_channel.get("next_cli_actions") or []]
-    repair_actions = [item for item in next_cli_actions if _is_capability_repair_command(item)]
+    reentry = dict(cli_channel.get("runtime_capability_reentry") or {})
+    verification = dict(reentry.get("verification_contract") or {})
+    reentry_actions = [
+        item for item in next_cli_actions if _is_capability_reentry_command(item)
+    ]
     contract = {
         "decision": "execute",
         "selected_todo_id": None,
@@ -231,61 +241,55 @@ def _capability_repair_contract(packet: Mapping[str, Any]) -> dict[str, Any]:
         and contract["must_attempt_work"] is True
         and contract["delivery_allowed"] is False
         and contract["quiet_noop_allowed"] is False
-        and "next_cli_actions[0]"
+        and "real task-facing callsite"
         in str((interaction.get("agent_channel") or {}).get("primary_action") or "")
         and capability_gate.get("action") == "repair_bridge"
         and capability_gate.get("decision_owner") == "agent"
         and CAPABILITY_REPAIR_TARGET_CAPABILITY in contract["repair_missing"]
-        and len(repair_actions) == 1
+        and verification.get("advancement_checkpoint") is False
+        and verification.get("settles_turn") is False
+        and len(reentry_actions) == 1
+        and all("todo add" not in action for action in next_cli_actions)
     ):
         raise ValueError("real quota packet did not preserve capability bridge repair")
     return contract
 
 
-def _execute_capability_repair(
+def _execute_capability_callsite(
     command: str,
     *,
     fixture: _SelectedTodoToolFixture,
 ) -> str:
-    execute_loopx_cli(
+    kind, _ = _classify_tool_command(
         command,
-        source_root=fixture.source_root,
-        project_root=fixture.project_root,
+        fixture=fixture,
+        quota_observed=True,
     )
-    readback = execute_loopx_cli(
-        "loopx --format json todo list --goal-id "
-        f"{SELECTED_TODO_TOOL_FIXTURE_GOAL_ID} --role agent --status open",
-        source_root=fixture.source_root,
-        project_root=fixture.project_root,
-    )
-    todos = json.loads(readback).get("todos") or []
-    repair = next(
-        (
-            item
-            for item in todos
-            if item.get("action_kind") == "materialize_capability"
-            and CAPABILITY_REPAIR_TARGET_CAPABILITY
-            in (item.get("target_capabilities") or [])
-            and item.get("unblocks_todo_id") == CAPABILITY_REPAIR_BLOCKED_TODO_ID
-            and item.get("claimed_by") == SELECTED_TODO_TOOL_FIXTURE_AGENT_ID
-        ),
-        None,
-    )
-    monitor = next(
-        (item for item in todos if item.get("todo_id") == CAPABILITY_REPAIR_MONITOR_TODO_ID),
-        None,
-    )
-    if repair is None or monitor is None or monitor.get("status") != "open":
-        raise ValueError("capability repair Todo readback failed")
-    return json.dumps(
-        {
-            "repair_todo_id": repair.get("todo_id"),
-            "target_capability": CAPABILITY_REPAIR_TARGET_CAPABILITY,
-            "unblocks_todo_id": CAPABILITY_REPAIR_BLOCKED_TODO_ID,
-            "monitor_fallback_executed": False,
-        },
-        sort_keys=True,
-    )
+    if kind != "selected_action":
+        raise ValueError("capability verification was not the blocked Todo callsite")
+    return _execute_workspace_read(command, fixture=fixture)
+
+
+def _capability_reentry_contract(packet: Mapping[str, Any]) -> dict[str, Any]:
+    signature = quota_action_signature_document(packet)
+    action = dict(signature.get("action") or {})
+    selected = dict(action.get("selected_todo") or {})
+    interaction = dict(packet.get("interaction_contract") or {})
+    capability_gate = dict(packet.get("capability_gate") or {})
+    if not (
+        selected.get("todo_id") == CAPABILITY_REPAIR_BLOCKED_TODO_ID
+        and action.get("must_attempt") is True
+        and action.get("delivery_allowed") is True
+        and interaction.get("mode") == "bounded_delivery"
+        and capability_gate.get("action") == "run"
+        and not capability_gate.get("repair_missing")
+        and "runtime_capability_reentry" not in packet
+    ):
+        raise ValueError("verified capability did not re-enter the blocked Todo")
+    return {
+        "blocked_todo_reentered": True,
+        "same_turn_delivery_allowed": True,
+    }
 
 
 def _receipt(
@@ -294,7 +298,8 @@ def _receipt(
     actor_ref: str,
     steps: list[dict[str, Any]],
     contract: Mapping[str, Any] | None,
-    repair_executed: bool,
+    callsite_verified: bool,
+    reentry_completed: bool,
     passed: bool,
     failure_code: str | None,
 ) -> dict[str, Any]:
@@ -307,8 +312,9 @@ def _receipt(
         **dict(contract or {}),
         "observed_tool_sequence": [step["kind"] for step in steps],
         "tool_call_count": len(steps),
-        "capability_repair_executed": repair_executed,
-        "monitor_fallback_avoided": repair_executed,
+        "capability_callsite_verified": callsite_verified,
+        "same_turn_quota_reentry_completed": reentry_completed,
+        "monitor_fallback_avoided": reentry_completed,
         "tool_call_receipts": steps,
         "boundary": {
             "raw_prompt_persisted": False,
@@ -317,13 +323,15 @@ def _receipt(
             "writes_limited_to_temporary_fixture": True,
             "external_writes_executed": False,
             "shell_commands_executed": False,
-            "control_plane_writes_executed": repair_executed,
+            "task_facing_reads_executed": callsite_verified,
+            "control_plane_writes_executed": False,
+            "advancement_checkpoints_written": False,
         },
     }
 
 
 class DoubaoCapabilityMonitorRepairToolBehaviorActor:
-    """Prove capability repair outranks a monitor fallback in a real heartbeat."""
+    """Prove inline capability re-entry outranks a monitor fallback."""
 
     def __init__(
         self,
@@ -374,10 +382,11 @@ class DoubaoCapabilityMonitorRepairToolBehaviorActor:
                 "content": (
                     "You are Codex running one LoopX heartbeat. Follow the task and "
                     "choose each next action from the latest tool result. When real "
-                    "quota projects an agent-owned capability bridge repair, execute "
-                    "the concrete repair action from its CLI channel. Do not wait on, "
-                    "poll, or rewrite a monitor fallback. Stop after the repair action "
-                    "succeeds."
+                    "quota projects an agent-owned capability bridge repair, verify it "
+                    "with the blocked Todo's real task-facing callsite. After success, "
+                    "run the projected quota re-entry command in this same heartbeat. "
+                    "Do not create a repair Todo, wait on, poll, or rewrite a monitor "
+                    "fallback. Stop when quota makes the blocked Todo runnable."
                 ),
             },
             {
@@ -387,7 +396,8 @@ class DoubaoCapabilityMonitorRepairToolBehaviorActor:
         ]
         steps: list[dict[str, Any]] = []
         quota_observed = False
-        repair_executed = False
+        callsite_verified = False
+        reentry_completed = False
         contract: dict[str, Any] | None = None
         seen_once: set[str] = set()
         actor_ref = self._client.actor_ref
@@ -400,7 +410,8 @@ class DoubaoCapabilityMonitorRepairToolBehaviorActor:
                 actor_ref=actor_ref,
                 steps=steps,
                 contract=contract,
-                repair_executed=repair_executed,
+                callsite_verified=callsite_verified,
+                reentry_completed=reentry_completed,
                 passed=passed,
                 failure_code=failure_code,
             )
@@ -411,17 +422,17 @@ class DoubaoCapabilityMonitorRepairToolBehaviorActor:
                 return receipt(
                     passed=False,
                     failure_code=(
-                        "waited_on_capability_repair"
+                        "waited_on_capability_reentry"
                         if quota_observed
                         else "model_returned_without_tool_call"
                     ),
                 )
 
-            if _is_capability_repair_command(tool_call.command):
+            if _is_capability_reentry_command(tool_call.command):
                 kind = (
-                    "capability_repair"
-                    if quota_observed
-                    else "capability_repair_before_quota"
+                    "quota_reentry"
+                    if quota_observed and callsite_verified
+                    else "quota_reentry_before_callsite"
                 )
                 tool_output = None
             elif _is_monitor_fallback_command(tool_call.command):
@@ -433,9 +444,19 @@ class DoubaoCapabilityMonitorRepairToolBehaviorActor:
                     fixture=fixture,
                     quota_observed=quota_observed,
                 )
-                if kind == "workspace_read" and quota_observed:
+                if kind in {"selected_action", "selected_action_before_quota"}:
+                    kind = (
+                        "capability_callsite"
+                        if quota_observed
+                        else "capability_callsite_before_quota"
+                    )
+                elif kind == "workspace_read" and quota_observed:
                     kind = "post_quota_backtracking"
-                elif kind not in {"clock", "quota_should_run", "workspace_read"}:
+                elif kind not in {
+                    "clock",
+                    "quota_should_run",
+                    "workspace_read",
+                }:
                     kind = "unexpected_command"
             steps.append(
                 {
@@ -444,18 +465,21 @@ class DoubaoCapabilityMonitorRepairToolBehaviorActor:
                     "command_digest": digest_text(tool_call.command),
                 }
             )
-            if kind == "capability_repair":
+            if kind == "capability_callsite":
                 try:
-                    _execute_capability_repair(tool_call.command, fixture=fixture)
+                    tool_output = _execute_capability_callsite(
+                        tool_call.command,
+                        fixture=fixture,
+                    )
                 except (RuntimeError, ValueError, json.JSONDecodeError):
                     return receipt(
                         passed=False,
-                        failure_code="capability_repair_execution_failed",
+                        failure_code="capability_callsite_execution_failed",
                     )
-                repair_executed = True
-                return receipt(passed=True, failure_code=None)
+                callsite_verified = True
             if kind in {
-                "capability_repair_before_quota",
+                "capability_callsite_before_quota",
+                "quota_reentry_before_callsite",
                 "monitor_fallback",
                 "post_quota_backtracking",
                 "unexpected_command",
@@ -482,6 +506,26 @@ class DoubaoCapabilityMonitorRepairToolBehaviorActor:
                     return receipt(
                         passed=False,
                         failure_code="quota_execution_failed",
+                    )
+            elif kind == "quota_reentry":
+                try:
+                    tool_output = execute_loopx_cli(
+                        tool_call.command,
+                        source_root=fixture.source_root,
+                        project_root=fixture.project_root,
+                        argument_overrides={
+                            "--registry": str(fixture.global_registry_path),
+                            "--turn-instance-id": turn_instance_id,
+                        },
+                    )
+                    reentry = _capability_reentry_contract(json.loads(tool_output))
+                    contract = {**dict(contract or {}), **reentry}
+                    reentry_completed = True
+                    return receipt(passed=True, failure_code=None)
+                except (RuntimeError, ValueError, json.JSONDecodeError):
+                    return receipt(
+                        passed=False,
+                        failure_code="quota_reentry_failed",
                     )
             elif kind == "workspace_read":
                 try:

--- a/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
+++ b/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
@@ -225,11 +225,23 @@ def _redacted_command_shape(
     except ValueError:
         tokens = []
     executable = Path(tokens[0]).name if tokens else ""
+    family = (
+        "content_read"
+        if executable in {"cat", "head", "sed", "jq", "python", "python3"}
+        else "discovery"
+        if executable in {"find", "grep", "rg"}
+        else "metadata"
+        if executable in {"ls", "pwd", "stat", "test"}
+        else "control_plane"
+        if executable == "loopx"
+        else "shell_wrapper"
+        if executable in {"bash", "sh", "zsh"}
+        else "other"
+    )
     return {
         "parseable": bool(tokens),
         "token_count_bucket": min(len(tokens), 8),
-        "read_executable": executable in {"cat", "head", "sed", "jq", "python", "python3"},
-        "shell_wrapper": executable in {"bash", "sh", "zsh"},
+        "command_family": family,
         "mentions_fixture_dir": "fixture/" in command,
         "mentions_selected_target": str(fixture.selected_target.name) in command,
         "multiline": "\n" in command,
@@ -420,8 +432,11 @@ class DoubaoCapabilityMonitorRepairToolBehaviorActor:
                 "role": "system",
                 "content": (
                     "You are Codex running one LoopX heartbeat. Follow the task and "
-                    "choose each next action from the latest tool result. When real "
-                    "quota projects an agent-owned capability bridge repair, verify it "
+                    "choose each next action from the latest tool result. "
+                    "The exec tool's current workspace is the goal project root, so "
+                    "project-relative task paths are directly addressable. "
+                    "When real quota projects an agent-owned capability bridge repair, "
+                    "verify it "
                     "by executing agent_channel.next_task_action.instruction with the "
                     "appropriate task-facing tool; do not run that instruction as CLI "
                     "text or inspect state/workspace again. After success, run "

--- a/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
+++ b/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
@@ -247,7 +247,7 @@ def _capability_repair_contract(packet: Mapping[str, Any]) -> dict[str, Any]:
         and contract["must_attempt_work"] is True
         and contract["delivery_allowed"] is False
         and contract["quiet_noop_allowed"] is False
-        and "real task-facing callsite"
+        and "next_cli_actions[0]"
         in str((interaction.get("agent_channel") or {}).get("primary_action") or "")
         and capability_gate.get("action") == "repair_bridge"
         and capability_gate.get("decision_owner") == "agent"
@@ -256,6 +256,8 @@ def _capability_repair_contract(packet: Mapping[str, Any]) -> dict[str, Any]:
         and verification.get("settles_turn") is False
         and target.get("todo_id") == CAPABILITY_REPAIR_BLOCKED_TODO_ID
         and "fixture/private-source.json" in str(target.get("instruction") or "")
+        and next_cli_actions
+        and str(target.get("instruction") or "") in next_cli_actions[0]
         and len(reentry_actions) == 1
         and all("todo add" not in action for action in next_cli_actions)
     ):
@@ -391,8 +393,10 @@ class DoubaoCapabilityMonitorRepairToolBehaviorActor:
                     "You are Codex running one LoopX heartbeat. Follow the task and "
                     "choose each next action from the latest tool result. When real "
                     "quota projects an agent-owned capability bridge repair, verify it "
-                    "with the blocked Todo's real task-facing callsite. After success, "
-                    "run the projected quota re-entry command in this same heartbeat. "
+                    "by directly executing next_cli_actions[0]; it already contains the "
+                    "blocked Todo's task-facing instruction, so do not inspect state or "
+                    "workspace again. After success, run the projected quota re-entry "
+                    "command in this same heartbeat. "
                     "Do not create a repair Todo, wait on, poll, or rewrite a monitor "
                     "fallback. Stop when quota makes the blocked Todo runnable."
                 ),

--- a/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
+++ b/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
@@ -337,7 +337,7 @@ def _capability_repair_contract(packet: Mapping[str, Any]) -> dict[str, Any]:
         and contract["must_attempt_work"] is True
         and contract["delivery_allowed"] is False
         and contract["quiet_noop_allowed"] is False
-        and "next_task_action.instruction"
+        and "next_task_action.operation"
         in str((interaction.get("agent_channel") or {}).get("primary_action") or "")
         and capability_gate.get("action") == "repair_bridge"
         and capability_gate.get("decision_owner") == "agent"
@@ -348,8 +348,12 @@ def _capability_repair_contract(packet: Mapping[str, Any]) -> dict[str, Any]:
         and "fixture/private-source.json" in str(target.get("instruction") or "")
         and next_task_action.get("kind") == "capability_verification"
         and next_task_action.get("todo_id") == target.get("todo_id")
+        and next_task_action.get("operation") == "read_private_source"
         and next_task_action.get("instruction") == target.get("instruction")
         and next_task_action.get("target_ref") == "fixture/private-source.json"
+        and next_task_action.get("preflight_allowed") is False
+        and next_task_action.get("advancement_checkpoint") is False
+        and next_task_action.get("settles_turn") is False
         and next_task_action.get("continuation_cli_action_index") == 0
         and len(reentry_actions) == 1
         and all("todo add" not in action for action in next_cli_actions)
@@ -489,10 +493,11 @@ class DoubaoCapabilityMonitorRepairToolBehaviorActor:
                     "project-relative task paths are directly addressable. "
                     "When real quota projects an agent-owned capability bridge repair, "
                     "verify it "
-                    "by executing agent_channel.next_task_action.instruction with the "
-                    "appropriate task-facing tool against its exact target_ref; do not "
-                    "run that instruction as CLI text, probe target existence, or "
-                    "inspect state/workspace again. After success, run "
+                    "by executing agent_channel.next_task_action.operation once with "
+                    "the appropriate task-facing tool against its exact target_ref. "
+                    "This exec-only qualification maps read_private_source to the "
+                    "single command `cat <target_ref>`. Do not probe target existence "
+                    "or inspect state/workspace again. After success, run "
                     "cli_channel.next_cli_actions[0] in this same heartbeat. "
                     "Do not create a repair Todo, wait on, poll, or rewrite a monitor "
                     "fallback. Stop when quota makes the blocked Todo runnable."

--- a/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
+++ b/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import subprocess
 from collections.abc import Mapping
 from hashlib import sha256
@@ -210,6 +211,29 @@ def _is_monitor_fallback_command(command: str) -> bool:
         and CAPABILITY_REPAIR_MONITOR_TODO_ID in tokens
         for index in range(len(tokens) - 1)
     )
+
+
+def _redacted_command_shape(
+    command: str,
+    *,
+    fixture: _SelectedTodoToolFixture,
+) -> dict[str, Any]:
+    """Describe a rejected live action without retaining provider-selected text."""
+
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = []
+    executable = Path(tokens[0]).name if tokens else ""
+    return {
+        "parseable": bool(tokens),
+        "token_count_bucket": min(len(tokens), 8),
+        "read_executable": executable in {"cat", "head", "sed", "jq", "python", "python3"},
+        "shell_wrapper": executable in {"bash", "sh", "zsh"},
+        "mentions_fixture_dir": "fixture/" in command,
+        "mentions_selected_target": str(fixture.selected_target.name) in command,
+        "multiline": "\n" in command,
+    }
 
 
 def _capability_repair_contract(packet: Mapping[str, Any]) -> dict[str, Any]:
@@ -475,13 +499,17 @@ class DoubaoCapabilityMonitorRepairToolBehaviorActor:
                     "workspace_read",
                 }:
                     kind = "unexpected_command"
-            steps.append(
-                {
-                    "ordinal": len(steps) + 1,
-                    "kind": kind,
-                    "command_digest": digest_text(tool_call.command),
-                }
-            )
+            step = {
+                "ordinal": len(steps) + 1,
+                "kind": kind,
+                "command_digest": digest_text(tool_call.command),
+            }
+            if kind == "unexpected_command":
+                step["redacted_command_shape"] = _redacted_command_shape(
+                    tool_call.command,
+                    fixture=fixture,
+                )
+            steps.append(step)
             if kind == "capability_callsite":
                 try:
                     tool_output = _execute_capability_callsite(

--- a/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
+++ b/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
@@ -243,6 +243,11 @@ def _redacted_command_shape(
         "parseable": bool(tokens),
         "token_count_bucket": min(len(tokens), 8),
         "command_family": family,
+        "content_read_operation": (
+            executable
+            if family == "content_read"
+            else None
+        ),
         "mentions_fixture_dir": "fixture/" in command,
         "mentions_selected_target": str(fixture.selected_target.name) in command,
         "multiline": "\n" in command,

--- a/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
+++ b/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
@@ -226,6 +226,18 @@ def _redacted_command_shape(
     except ValueError:
         tokens = []
     executable = Path(tokens[0]).name if tokens else ""
+    target_index = next(
+        (
+            index
+            for index, token in enumerate(tokens)
+            if str(fixture.selected_target.name) in token
+        ),
+        -1,
+    )
+    redirect_index = next(
+        (index for index, token in enumerate(tokens) if "2>" in token),
+        -1,
+    )
     family = (
         "content_read"
         if executable in {"cat", "head", "sed", "jq", "python", "python3"}
@@ -255,6 +267,18 @@ def _redacted_command_shape(
         "has_stderr_redirect": "2>" in command,
         "has_conditional": "&&" in command or "||" in command,
         "has_option_terminator": " -- " in command,
+        "cat_option_count_bucket": (
+            min(
+                sum(1 for token in tokens[1:] if token.startswith("-")),
+                3,
+            )
+            if executable == "cat"
+            else 0
+        ),
+        "redirect_precedes_target": (
+            redirect_index >= 0 and target_index >= 0 and redirect_index < target_index
+        ),
+        "has_pwd_expansion": "$(pwd)" in command or "$PWD" in command,
     }
 
 

--- a/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
+++ b/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
@@ -519,7 +519,7 @@ class DoubaoCapabilityMonitorRepairToolBehaviorActor:
                 "kind": kind,
                 "command_digest": digest_text(tool_call.command),
             }
-            if kind == "unexpected_command":
+            if kind in {"unexpected_command", "post_quota_backtracking"}:
                 step["redacted_command_shape"] = _redacted_command_shape(
                     tool_call.command,
                     fixture=fixture,

--- a/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
+++ b/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
@@ -119,6 +119,7 @@ def _build_capability_repair_fixture(root: Path) -> _SelectedTodoToolFixture:
         f"todo_id={CAPABILITY_REPAIR_BLOCKED_TODO_ID} status=open "
         "task_class=advancement_task action_kind=read_private_source "
         f"claimed_by={SELECTED_TODO_TOOL_FIXTURE_AGENT_ID} priority=P1 "
+        "target_key=fixture/private-source.json "
         f"required_capabilities={CAPABILITY_REPAIR_TARGET_CAPABILITY} -->\n",
         encoding="utf-8",
     )
@@ -298,6 +299,7 @@ def _capability_repair_contract(packet: Mapping[str, Any]) -> dict[str, Any]:
         and next_task_action.get("kind") == "capability_verification"
         and next_task_action.get("todo_id") == target.get("todo_id")
         and next_task_action.get("instruction") == target.get("instruction")
+        and next_task_action.get("target_ref") == "fixture/private-source.json"
         and next_task_action.get("continuation_cli_action_index") == 0
         and len(reentry_actions) == 1
         and all("todo add" not in action for action in next_cli_actions)
@@ -438,8 +440,9 @@ class DoubaoCapabilityMonitorRepairToolBehaviorActor:
                     "When real quota projects an agent-owned capability bridge repair, "
                     "verify it "
                     "by executing agent_channel.next_task_action.instruction with the "
-                    "appropriate task-facing tool; do not run that instruction as CLI "
-                    "text or inspect state/workspace again. After success, run "
+                    "appropriate task-facing tool against its exact target_ref; do not "
+                    "run that instruction as CLI text, probe target existence, or "
+                    "inspect state/workspace again. After success, run "
                     "cli_channel.next_cli_actions[0] in this same heartbeat. "
                     "Do not create a repair Todo, wait on, poll, or rewrite a monitor "
                     "fallback. Stop when quota makes the blocked Todo runnable."

--- a/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
+++ b/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
@@ -219,6 +219,9 @@ def _capability_repair_contract(packet: Mapping[str, Any]) -> dict[str, Any]:
     interaction = dict(packet.get("interaction_contract") or {})
     capability_gate = dict(packet.get("capability_gate") or {})
     cli_channel = dict(interaction.get("cli_channel") or {})
+    next_task_action = dict(
+        (interaction.get("agent_channel") or {}).get("next_task_action") or {}
+    )
     next_cli_actions = [str(item) for item in cli_channel.get("next_cli_actions") or []]
     reentry = dict(cli_channel.get("runtime_capability_reentry") or {})
     verification = dict(reentry.get("verification_contract") or {})
@@ -247,7 +250,7 @@ def _capability_repair_contract(packet: Mapping[str, Any]) -> dict[str, Any]:
         and contract["must_attempt_work"] is True
         and contract["delivery_allowed"] is False
         and contract["quiet_noop_allowed"] is False
-        and "next_cli_actions[0]"
+        and "next_task_action.instruction"
         in str((interaction.get("agent_channel") or {}).get("primary_action") or "")
         and capability_gate.get("action") == "repair_bridge"
         and capability_gate.get("decision_owner") == "agent"
@@ -256,8 +259,10 @@ def _capability_repair_contract(packet: Mapping[str, Any]) -> dict[str, Any]:
         and verification.get("settles_turn") is False
         and target.get("todo_id") == CAPABILITY_REPAIR_BLOCKED_TODO_ID
         and "fixture/private-source.json" in str(target.get("instruction") or "")
-        and next_cli_actions
-        and str(target.get("instruction") or "") in next_cli_actions[0]
+        and next_task_action.get("kind") == "capability_verification"
+        and next_task_action.get("todo_id") == target.get("todo_id")
+        and next_task_action.get("instruction") == target.get("instruction")
+        and next_task_action.get("continuation_cli_action_index") == 0
         and len(reentry_actions) == 1
         and all("todo add" not in action for action in next_cli_actions)
     ):
@@ -393,10 +398,10 @@ class DoubaoCapabilityMonitorRepairToolBehaviorActor:
                     "You are Codex running one LoopX heartbeat. Follow the task and "
                     "choose each next action from the latest tool result. When real "
                     "quota projects an agent-owned capability bridge repair, verify it "
-                    "by directly executing next_cli_actions[0]; it already contains the "
-                    "blocked Todo's task-facing instruction, so do not inspect state or "
-                    "workspace again. After success, run the projected quota re-entry "
-                    "command in this same heartbeat. "
+                    "by executing agent_channel.next_task_action.instruction with the "
+                    "appropriate task-facing tool; do not run that instruction as CLI "
+                    "text or inspect state/workspace again. After success, run "
+                    "cli_channel.next_cli_actions[0] in this same heartbeat. "
                     "Do not create a repair Todo, wait on, poll, or rewrite a monitor "
                     "fallback. Stop when quota makes the blocked Todo runnable."
                 ),

--- a/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
+++ b/loopx/control_plane/testing/capability_monitor_repair_tool_behavior.py
@@ -238,6 +238,19 @@ def _redacted_command_shape(
         (index for index, token in enumerate(tokens) if "2>" in token),
         -1,
     )
+    fallback_operation = None
+    for operator in ("||", "&&"):
+        if operator not in tokens:
+            continue
+        index = tokens.index(operator) + 1
+        if index < len(tokens):
+            candidate = Path(tokens[index]).name
+            fallback_operation = (
+                candidate
+                if candidate in {"exit", "return", "false", "echo", "printf", "cat"}
+                else "other"
+            )
+        break
     family = (
         "content_read"
         if executable in {"cat", "head", "sed", "jq", "python", "python3"}
@@ -263,9 +276,13 @@ def _redacted_command_shape(
         "mentions_fixture_dir": "fixture/" in command,
         "mentions_selected_target": str(fixture.selected_target.name) in command,
         "multiline": "\n" in command,
-        "has_pipe": "|" in command,
+        "has_pipe": "|" in tokens,
         "has_stderr_redirect": "2>" in command,
         "has_conditional": "&&" in command or "||" in command,
+        "conditional_kind": (
+            "or" if "||" in tokens else "and" if "&&" in tokens else None
+        ),
+        "fallback_operation": fallback_operation,
         "has_option_terminator": " -- " in command,
         "cat_option_count_bucket": (
             min(

--- a/loopx/control_plane/todos/write_hint.py
+++ b/loopx/control_plane/todos/write_hint.py
@@ -34,13 +34,6 @@ def build_capability_resolution_writeback_actions(
     bindings = capability_gate.get("resolution_bindings")
     if not isinstance(bindings, list):
         return []
-    targeted_capabilities = {
-        str(capability)
-        for candidate in capability_gate.get("runnable_candidates") or []
-        if isinstance(candidate, dict)
-        for capability in candidate.get("target_capabilities") or []
-        if str(capability).strip()
-    }
     actions: list[str] = []
     agent = agent_id or "<registered-agent>"
     for binding in bindings:
@@ -63,19 +56,6 @@ def build_capability_resolution_writeback_actions(
                 f"loopx todo add --goal-id {goal_id} --role user "
                 "--task-class user_gate --action-kind provide_capability "
                 f"--target-capability {capability} --blocks-agent {agent} "
-                f"--unblocks-todo-id {todo_id} --text '{text}'"
-            )
-        elif owner == "agent" and capability not in targeted_capabilities:
-            text = (
-                f"[{priority}] Observe or materialize and real-callsite verify "
-                f"capability {capability} required by {todo_id}."
-            )
-            claimed_arg = f" --claimed-by {agent_id}" if agent_id else ""
-            actions.append(
-                f"loopx todo add --goal-id {goal_id} --role agent "
-                "--task-class advancement_task --action-kind materialize_capability "
-                "--required-capability shell "
-                f"--target-capability {capability}{claimed_arg} "
                 f"--unblocks-todo-id {todo_id} --text '{text}'"
             )
         if len(actions) >= limit:

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -668,14 +668,15 @@ def interaction_next_cli_actions(
             available_capabilities=available_capabilities,
             scheduler_execution_context=scheduler_execution_context,
         )
-    if capability_reentry is not None:
-        capability_resolution_actions.extend(
-            (
-                "after real-callsite verification of "
-                f"{candidate['capability']}: {candidate['command']}"
-            )
+    capability_reentry_actions = (
+        [
+            "after real-callsite verification of "
+            f"{candidate['capability']}: {candidate['command']}"
             for candidate in capability_reentry["candidates"]
-        )
+        ]
+        if capability_reentry is not None
+        else []
+    )
     if mode == "terminal_no_followup":
         return ["no quota spend until explicit goal resume or newly projected work"]
     if mode == "agent_monitor_only":
@@ -876,10 +877,15 @@ def interaction_next_cli_actions(
             ),
         ])
         return actions
+    if mode == "capability_bridge_repair":
+        return capability_reentry_actions or [
+            "perform the projected real task-facing capability check, then rerun "
+            "quota in this same turn"
+        ]
+    capability_resolution_actions.extend(capability_reentry_actions)
     if mode in {
         "bounded_delivery",
         "outcome_floor_recovery",
-        "capability_bridge_repair",
         "control_plane_self_repair",
         "boundary_projection_repair",
         "scoped_user_gate_fallback",
@@ -951,6 +957,11 @@ def _interaction_spend_policy(
         return "no spend for moving agent work into an independent worktree"
     if mode == "automation_prompt_upgrade":
         return "no spend until the host update is acknowledged and quota reruns"
+    if mode == "capability_bridge_repair":
+        return (
+            "no spend or advancement checkpoint for capability verification; rerun "
+            "quota in the same turn"
+        )
     if mode == "autonomous_replan":
         return (
             "spend only after accountable replan delta; no spend for "
@@ -1047,7 +1058,6 @@ def _interaction_spend_after_validation(mode: str) -> bool:
     return mode in {
         "bounded_delivery",
         "outcome_floor_recovery",
-        "capability_bridge_repair",
         "autonomous_replan",
         "control_plane_self_repair",
         "boundary_projection_repair",

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -1139,6 +1139,8 @@ def _build_interaction_agent_channel(
             "instruction": target["instruction"],
             "continuation_cli_action_index": 0,
         }
+        if target.get("target_ref"):
+            channel["next_task_action"]["target_ref"] = target["target_ref"]
     if _blocked_successor_wait_observation_required(payload):
         channel["primary_action"] = (
             "record one no-spend blocked-successor wait observation, rerun quota, "

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -1160,7 +1160,11 @@ def _build_interaction_agent_channel(
             "capability": candidate["capability"],
             "todo_id": target["todo_id"],
             "action_kind": target["action_kind"],
+            "operation": target["action_kind"],
             "instruction": target["instruction"],
+            "preflight_allowed": False,
+            "advancement_checkpoint": False,
+            "settles_turn": False,
             "continuation_cli_action_index": 0,
         }
         if target.get("target_ref"):

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -668,15 +668,19 @@ def interaction_next_cli_actions(
             available_capabilities=available_capabilities,
             scheduler_execution_context=scheduler_execution_context,
         )
-    capability_reentry_actions = (
-        [
-            "after real-callsite verification of "
-            f"{candidate['capability']}: {candidate['command']}"
-            for candidate in capability_reentry["candidates"]
-        ]
-        if capability_reentry is not None
-        else []
-    )
+    capability_reentry_actions: list[str] = []
+    if capability_reentry is not None:
+        for candidate in capability_reentry["candidates"]:
+            target = candidate["verification_target"]
+            capability_reentry_actions.extend(
+                [
+                    "first verify "
+                    f"{candidate['capability']} at Todo {target['todo_id']} by "
+                    f"executing its task-facing instruction: {target['instruction']}",
+                    "only after that real-callsite succeeds, rerun quota in this "
+                    f"same turn: {candidate['command']}",
+                ]
+            )
     if mode == "terminal_no_followup":
         return ["no quota spend until explicit goal resume or newly projected work"]
     if mode == "agent_monitor_only":

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -668,19 +668,11 @@ def interaction_next_cli_actions(
             available_capabilities=available_capabilities,
             scheduler_execution_context=scheduler_execution_context,
         )
-    capability_reentry_actions: list[str] = []
-    if capability_reentry is not None:
-        for candidate in capability_reentry["candidates"]:
-            target = candidate["verification_target"]
-            capability_reentry_actions.extend(
-                [
-                    "first verify "
-                    f"{candidate['capability']} at Todo {target['todo_id']} by "
-                    f"executing its task-facing instruction: {target['instruction']}",
-                    "only after that real-callsite succeeds, rerun quota in this "
-                    f"same turn: {candidate['command']}",
-                ]
-            )
+    capability_reentry_actions = (
+        [str(candidate["command"]) for candidate in capability_reentry["candidates"]]
+        if capability_reentry is not None
+        else []
+    )
     if mode == "terminal_no_followup":
         return ["no quota spend until explicit goal resume or newly projected work"]
     if mode == "agent_monitor_only":
@@ -1128,6 +1120,7 @@ def _build_interaction_agent_channel(
     must_attempt: bool,
     delivery_allowed: bool,
     quiet_noop_allowed: bool,
+    capability_reentry: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     channel: dict[str, Any] = {
         "must_attempt": must_attempt,
@@ -1135,6 +1128,17 @@ def _build_interaction_agent_channel(
         "quiet_noop_allowed": quiet_noop_allowed,
     }
     channel.update(build_primary_action_projection(payload, mode=mode))
+    if capability_reentry is not None:
+        candidate = capability_reentry["candidates"][0]
+        target = candidate["verification_target"]
+        channel["next_task_action"] = {
+            "kind": "capability_verification",
+            "capability": candidate["capability"],
+            "todo_id": target["todo_id"],
+            "action_kind": target["action_kind"],
+            "instruction": target["instruction"],
+            "continuation_cli_action_index": 0,
+        }
     if _blocked_successor_wait_observation_required(payload):
         channel["primary_action"] = (
             "record one no-spend blocked-successor wait observation, rerun quota, "
@@ -1211,12 +1215,14 @@ def _build_interaction_cli_channel(
     scheduler_execution_context: (
         Mapping[str, Any] | SchedulerExecutionContextResolution | None
     ) = None,
+    capability_reentry: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    capability_reentry = build_runtime_capability_reentry_packet(
-        payload,
-        available_capabilities=available_capabilities,
-        scheduler_execution_context=scheduler_execution_context,
-    )
+    if capability_reentry is None:
+        capability_reentry = build_runtime_capability_reentry_packet(
+            payload,
+            available_capabilities=available_capabilities,
+            scheduler_execution_context=scheduler_execution_context,
+        )
     settlement_plan = _codex_app_settlement_plan(
         payload,
         available_capabilities=available_capabilities,
@@ -1406,6 +1412,11 @@ def build_interaction_contract(
     )
     spend_after_validation = _interaction_spend_after_validation(mode)
     required_reads = _interaction_required_reads(payload)
+    capability_reentry = build_runtime_capability_reentry_packet(
+        payload,
+        available_capabilities=available_capabilities,
+        scheduler_execution_context=scheduler_execution_context,
+    )
 
     user_channel = _build_interaction_user_channel(
         payload,
@@ -1424,6 +1435,7 @@ def build_interaction_contract(
         must_attempt=must_attempt,
         delivery_allowed=delivery_allowed,
         quiet_noop_allowed=quiet_noop_allowed,
+        capability_reentry=capability_reentry,
     )
     contract: dict[str, Any] = {
         "schema_version": INTERACTION_CONTRACT_SCHEMA_VERSION,
@@ -1438,6 +1450,7 @@ def build_interaction_contract(
             spend_after_validation=spend_after_validation,
             available_capabilities=available_capabilities,
             scheduler_execution_context=scheduler_execution_context,
+            capability_reentry=capability_reentry,
         ),
     }
     response_plan = _build_interaction_response_plan(

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -587,6 +587,56 @@ def _quota_spend_action(
     )
 
 
+def _terminal_cli_actions(
+    *,
+    mode: str,
+    goal_id: str,
+    scoped_cli_args: str,
+    payload: dict[str, Any],
+    settlement_plan: Mapping[str, Any] | None,
+    capability_resolution_actions: list[str],
+    capability_reentry_actions: list[str],
+) -> list[str]:
+    if mode == "capability_bridge_repair":
+        return capability_reentry_actions or [
+            "perform the projected real task-facing capability check, then rerun "
+            "quota in this same turn"
+        ]
+    resolution_actions = [
+        *capability_resolution_actions,
+        *capability_reentry_actions,
+    ]
+    if mode in {
+        "bounded_delivery",
+        "outcome_floor_recovery",
+        "control_plane_self_repair",
+        "boundary_projection_repair",
+        "scoped_user_gate_fallback",
+        "bounded_delivery_with_user_notice",
+    }:
+        typed_writeback = settlement_step_command(
+            settlement_plan,
+            SettlementStepKind.DURABLE_WRITEBACK,
+        )
+        return [
+            *resolution_actions,
+            typed_writeback
+            or f"loopx refresh-state --goal-id {goal_id} --classification <validated_progress>{scoped_cli_args}",
+            _quota_spend_action(
+                goal_id,
+                scoped_cli_args=scoped_cli_args,
+                payload=payload,
+                settlement_plan=settlement_plan,
+            ),
+        ]
+    if mode in {"user_gate", "user_todo_blocker_push", "user_action_required"}:
+        return [
+            *resolution_actions,
+            "no quota spend for blocker-push/gate-notification",
+        ]
+    return ["no quota spend without validated transition/blocker writeback"]
+
+
 def interaction_next_cli_actions(
     payload: dict[str, Any],
     *,
@@ -873,41 +923,15 @@ def interaction_next_cli_actions(
             ),
         ])
         return actions
-    if mode == "capability_bridge_repair":
-        return capability_reentry_actions or [
-            "perform the projected real task-facing capability check, then rerun "
-            "quota in this same turn"
-        ]
-    capability_resolution_actions.extend(capability_reentry_actions)
-    if mode in {
-        "bounded_delivery",
-        "outcome_floor_recovery",
-        "control_plane_self_repair",
-        "boundary_projection_repair",
-        "scoped_user_gate_fallback",
-        "bounded_delivery_with_user_notice",
-    }:
-        typed_writeback = settlement_step_command(
-            settlement_plan,
-            SettlementStepKind.DURABLE_WRITEBACK,
-        )
-        return [
-            *capability_resolution_actions,
-            typed_writeback
-            or f"loopx refresh-state --goal-id {goal_id} --classification <validated_progress>{scoped_cli_args}",
-            _quota_spend_action(
-                goal_id,
-                scoped_cli_args=scoped_cli_args,
-                payload=payload,
-                settlement_plan=settlement_plan,
-            ),
-        ]
-    if mode in {"user_gate", "user_todo_blocker_push", "user_action_required"}:
-        return [
-            *capability_resolution_actions,
-            "no quota spend for blocker-push/gate-notification",
-        ]
-    return ["no quota spend without validated transition/blocker writeback"]
+    return _terminal_cli_actions(
+        mode=mode,
+        goal_id=goal_id,
+        scoped_cli_args=scoped_cli_args,
+        payload=payload,
+        settlement_plan=settlement_plan,
+        capability_resolution_actions=capability_resolution_actions,
+        capability_reentry_actions=capability_reentry_actions,
+    )
 
 
 def _interaction_required_reads(payload: dict[str, Any]) -> list[dict[str, Any]]:

--- a/loopx/control_plane/work_items/primary_action.py
+++ b/loopx/control_plane/work_items/primary_action.py
@@ -291,8 +291,9 @@ def resolve_canonical_primary_action(payload: dict[str, Any], *, mode: str) -> s
     if mode == "capability_bridge_repair":
         return (
             "execute interaction_contract.agent_channel.next_task_action.instruction "
-            "with its real task-facing tool, not as CLI text and without another "
-            "workspace/state preflight; on success execute cli_channel."
+            "with its real task-facing tool and exact target_ref when projected, not "
+            "as CLI text and without another workspace/state preflight; on success "
+            "execute cli_channel."
             "next_cli_actions[0] in the same turn and continue only when quota allows"
         )
     if mode == "agent_workspace_repair":

--- a/loopx/control_plane/work_items/primary_action.py
+++ b/loopx/control_plane/work_items/primary_action.py
@@ -290,9 +290,10 @@ def resolve_canonical_primary_action(payload: dict[str, Any], *, mode: str) -> s
         return "produce the required outcome-floor evidence artifact or write the concrete blocker"
     if mode == "capability_bridge_repair":
         return (
-            "perform one real task-facing callsite check for the blocked Todo; on "
-            "success rerun quota with the observed capability in this same turn and "
-            "continue only when quota allows"
+            "execute runtime_capability_reentry.candidates[0].verification_target."
+            "instruction at the blocked Todo's real task-facing callsite; on success "
+            "rerun quota with the observed capability in this same turn and continue "
+            "only when quota allows"
         )
     if mode == "agent_workspace_repair":
         return "create or switch to an independent worktree/branch, then rerun quota guard before file edits"

--- a/loopx/control_plane/work_items/primary_action.py
+++ b/loopx/control_plane/work_items/primary_action.py
@@ -290,9 +290,9 @@ def resolve_canonical_primary_action(payload: dict[str, Any], *, mode: str) -> s
         return "produce the required outcome-floor evidence artifact or write the concrete blocker"
     if mode == "capability_bridge_repair":
         return (
-            "execute interaction_contract.cli_channel.next_cli_actions[0] to "
-            "materialize the missing capability; do not backtrack to generic "
-            "inspection or a monitor fallback"
+            "perform one real task-facing callsite check for the blocked Todo; on "
+            "success rerun quota with the observed capability in this same turn and "
+            "continue only when quota allows"
         )
     if mode == "agent_workspace_repair":
         return "create or switch to an independent worktree/branch, then rerun quota guard before file edits"

--- a/loopx/control_plane/work_items/primary_action.py
+++ b/loopx/control_plane/work_items/primary_action.py
@@ -290,10 +290,10 @@ def resolve_canonical_primary_action(payload: dict[str, Any], *, mode: str) -> s
         return "produce the required outcome-floor evidence artifact or write the concrete blocker"
     if mode == "capability_bridge_repair":
         return (
-            "execute runtime_capability_reentry.candidates[0].verification_target."
-            "instruction at the blocked Todo's real task-facing callsite; on success "
-            "rerun quota with the observed capability in this same turn and continue "
-            "only when quota allows"
+            "execute interaction_contract.cli_channel.next_cli_actions[0], derived "
+            "from runtime_capability_reentry.candidates[0].verification_target."
+            "instruction, without another workspace/state preflight; then follow the "
+            "same-turn quota reentry action and continue only when quota allows"
         )
     if mode == "agent_workspace_repair":
         return "create or switch to an independent worktree/branch, then rerun quota guard before file edits"

--- a/loopx/control_plane/work_items/primary_action.py
+++ b/loopx/control_plane/work_items/primary_action.py
@@ -290,9 +290,10 @@ def resolve_canonical_primary_action(payload: dict[str, Any], *, mode: str) -> s
         return "produce the required outcome-floor evidence artifact or write the concrete blocker"
     if mode == "capability_bridge_repair":
         return (
-            "execute interaction_contract.agent_channel.next_task_action.instruction "
-            "with its real task-facing tool and exact target_ref when projected, not "
-            "as CLI text and without another workspace/state preflight; on success "
+            "execute interaction_contract.agent_channel.next_task_action.operation "
+            "once with its real task-facing tool and exact target_ref when projected; "
+            "preflight_allowed is false, and the instruction is context rather than "
+            "CLI text; on success "
             "execute cli_channel."
             "next_cli_actions[0] in the same turn and continue only when quota allows"
         )

--- a/loopx/control_plane/work_items/primary_action.py
+++ b/loopx/control_plane/work_items/primary_action.py
@@ -290,10 +290,10 @@ def resolve_canonical_primary_action(payload: dict[str, Any], *, mode: str) -> s
         return "produce the required outcome-floor evidence artifact or write the concrete blocker"
     if mode == "capability_bridge_repair":
         return (
-            "execute interaction_contract.cli_channel.next_cli_actions[0], derived "
-            "from runtime_capability_reentry.candidates[0].verification_target."
-            "instruction, without another workspace/state preflight; then follow the "
-            "same-turn quota reentry action and continue only when quota allows"
+            "execute interaction_contract.agent_channel.next_task_action.instruction "
+            "with its real task-facing tool, not as CLI text and without another "
+            "workspace/state preflight; on success execute cli_channel."
+            "next_cli_actions[0] in the same turn and continue only when quota allows"
         )
     if mode == "agent_workspace_repair":
         return "create or switch to an independent worktree/branch, then rerun quota guard before file edits"

--- a/loopx/control_plane/work_items/runtime_capability_reentry.py
+++ b/loopx/control_plane/work_items/runtime_capability_reentry.py
@@ -44,11 +44,15 @@ def _verification_target_for_capability(
         instruction = str(candidate.get("text") or "").strip()
         if not instruction:
             continue
-        return {
+        target = {
             "todo_id": todo_id,
             "action_kind": str(candidate.get("action_kind") or "unspecified"),
             "instruction": instruction,
         }
+        target_ref = str(candidate.get("target_key") or "").strip()
+        if target_ref:
+            target["target_ref"] = target_ref
+        return target
     return None
 
 

--- a/loopx/control_plane/work_items/runtime_capability_reentry.py
+++ b/loopx/control_plane/work_items/runtime_capability_reentry.py
@@ -93,6 +93,14 @@ def build_runtime_capability_reentry_packet(
         "state": "verification_required",
         "source": "quota_should_run.capability_gate.repair_missing",
         "candidates": reentry_candidates,
+        "verification_contract": {
+            "scope": "real_task_facing_callsite_for_blocked_todo",
+            "ordinary_delivery_allowed": False,
+            "advancement_checkpoint": False,
+            "settles_turn": False,
+            "on_success": "rerun_quota_in_same_turn_then_continue_if_allowed",
+            "on_failure": "record_exact_blocker_without_capability_flag",
+        },
         "inheritance_contract": {
             "source_invocation": "verified quota should-run reentry",
             "propagates_to": [

--- a/loopx/control_plane/work_items/runtime_capability_reentry.py
+++ b/loopx/control_plane/work_items/runtime_capability_reentry.py
@@ -14,6 +14,44 @@ from ..scheduler.execution_context import (
 RUNTIME_CAPABILITY_REENTRY_SCHEMA_VERSION = "runtime_capability_reentry_v0"
 
 
+def _verification_target_for_capability(
+    capability_gate: Mapping[str, Any],
+    capability: str,
+) -> dict[str, Any] | None:
+    blocked_ids = {
+        str(todo_id)
+        for binding in capability_gate.get("resolution_bindings") or []
+        if isinstance(binding, Mapping)
+        and binding.get("owner") == "agent"
+        and binding.get("capability") == capability
+        for todo_id in (
+            binding.get("blocked_todo_ids")
+            or [binding.get("primary_blocked_todo_id")]
+        )
+        if str(todo_id or "").strip()
+    }
+    for candidate in capability_gate.get("blocked_candidates") or []:
+        if not isinstance(candidate, Mapping):
+            continue
+        todo_id = str(candidate.get("todo_id") or "").strip()
+        if todo_id not in blocked_ids:
+            continue
+        required = runtime_capabilities_for_cli_projection(
+            candidate.get("required_capabilities")
+        )
+        if capability not in required:
+            continue
+        instruction = str(candidate.get("text") or "").strip()
+        if not instruction:
+            continue
+        return {
+            "todo_id": todo_id,
+            "action_kind": str(candidate.get("action_kind") or "unspecified"),
+            "instruction": instruction,
+        }
+    return None
+
+
 def build_runtime_capability_reentry_packet(
     payload: Mapping[str, Any],
     *,
@@ -74,6 +112,12 @@ def build_runtime_capability_reentry_packet(
 
     reentry_candidates = []
     for capability in candidates:
+        verification_target = _verification_target_for_capability(
+            capability_gate,
+            capability,
+        )
+        if verification_target is None:
+            continue
         cli_args = [
             *base_args,
             "--available-capability",
@@ -84,10 +128,12 @@ def build_runtime_capability_reentry_packet(
             {
                 "capability": capability,
                 "verification_required": "successful_real_callsite_observation",
-                "cli_args": cli_args,
+                "verification_target": verification_target,
                 "command": shlex.join(cli_args),
             }
         )
+    if not reentry_candidates:
+        return None
     return {
         "schema_version": RUNTIME_CAPABILITY_REENTRY_SCHEMA_VERSION,
         "state": "verification_required",

--- a/loopx/execution_profile.py
+++ b/loopx/execution_profile.py
@@ -40,6 +40,10 @@ TURN_GRANULARITY_CHOICES = (
     TURN_GRANULARITY_STANDARD,
     TURN_GRANULARITY_FINE,
 )
+FINE_GRAINED_SMALL_SCALE_STREAK_THRESHOLD = 5
+FINE_GRAINED_PLANNING_GRANULARITY = "fine_checkpoint"
+FINE_GRAINED_TURN_WORK_BUDGET = "coherent_slice"
+FINE_GRAINED_CHECKPOINT_ACCOUNTING = "advancement_only"
 
 _LABEL_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,79}$")
 
@@ -68,6 +72,18 @@ def _positive_int(value: Any, fallback: int) -> int:
     except (TypeError, ValueError):
         return fallback
     return parsed if parsed > 0 else fallback
+
+
+def _apply_fine_grained_contract(profile: dict[str, Any]) -> None:
+    profile["turn_granularity"] = TURN_GRANULARITY_FINE
+    profile["planning_granularity"] = FINE_GRAINED_PLANNING_GRANULARITY
+    profile["turn_work_budget"] = FINE_GRAINED_TURN_WORK_BUDGET
+    profile["checkpoint_accounting"] = FINE_GRAINED_CHECKPOINT_ACCOUNTING
+    profile["minimum_scale"] = "single_surface"
+    profile["degradation_policy"] = {
+        "small_scale_streak_threshold": FINE_GRAINED_SMALL_SCALE_STREAK_THRESHOLD,
+        "on_degradation": "review_direction_after_bounded_chain",
+    }
 
 
 def build_execution_profile(
@@ -109,12 +125,7 @@ def build_execution_profile(
     if turn_granularity is not None:
         normalized_turn_granularity = normalize_turn_granularity(turn_granularity)
         if normalized_turn_granularity == TURN_GRANULARITY_FINE:
-            profile["turn_granularity"] = TURN_GRANULARITY_FINE
-            profile["minimum_scale"] = "single_surface"
-            profile["degradation_policy"] = {
-                "small_scale_streak_threshold": 1,
-                "on_degradation": "replan_after_checkpoint",
-            }
+            _apply_fine_grained_contract(profile)
     return profile
 
 
@@ -175,11 +186,7 @@ def compact_execution_profile(value: Any) -> dict[str, Any]:
     floor["if_unavailable"] = _label(raw_floor.get("if_unavailable"), str(floor["if_unavailable"]))
     profile["outcome_floor"] = floor
     if execution_profile_is_fine_grained(profile):
-        profile["minimum_scale"] = "single_surface"
-        profile["degradation_policy"] = {
-            "small_scale_streak_threshold": 1,
-            "on_degradation": "replan_after_checkpoint",
-        }
+        _apply_fine_grained_contract(profile)
     return profile
 
 
@@ -210,16 +217,14 @@ def execution_profile_with_turn_granularity(
     normalized = compact_execution_profile(profile)
     mode = normalize_turn_granularity(turn_granularity)
     if mode == TURN_GRANULARITY_FINE:
-        normalized["turn_granularity"] = TURN_GRANULARITY_FINE
-        normalized["minimum_scale"] = "single_surface"
-        normalized["degradation_policy"] = {
-            "small_scale_streak_threshold": 1,
-            "on_degradation": "replan_after_checkpoint",
-        }
+        _apply_fine_grained_contract(normalized)
         return normalized
     was_fine = execution_profile_is_fine_grained(normalized)
     normalized.pop("turn_granularity", None)
     if was_fine:
+        normalized.pop("planning_granularity", None)
+        normalized.pop("turn_work_budget", None)
+        normalized.pop("checkpoint_accounting", None)
         normalized["minimum_scale"] = DEFAULT_EXECUTION_PROFILE["minimum_scale"]
         normalized["degradation_policy"] = dict(
             DEFAULT_EXECUTION_PROFILE["degradation_policy"]
@@ -265,7 +270,8 @@ def execution_profile_summary(profile: dict[str, Any] | None) -> str:
             f"surface:{','.join(surface_hints)}"
         )
     turn_suffix = (
-        " turn_granularity=fine"
+        " turn_granularity=fine planning_granularity=fine_checkpoint "
+        "turn_work_budget=coherent_slice checkpoint_accounting=advancement_only"
         if execution_profile_is_fine_grained(normalized)
         else ""
     )

--- a/loopx/long_task_cadence.py
+++ b/loopx/long_task_cadence.py
@@ -152,10 +152,12 @@ def build_long_task_cadence_hint(
             else "keep"
         )
         reason = (
-            "fine_checkpoint_complete"
+            "fine_direction_review_due"
             if recommendation == "replan"
             else "repeated_surface_only"
             if recommendation == "widen"
+            else "fine_checkpoint_within_slice"
+            if fine_grained
             else _reason_from_granularity(granularity)
         )
         return {

--- a/tests/control_plane/test_actual_default_model_behavior_portfolio.py
+++ b/tests/control_plane/test_actual_default_model_behavior_portfolio.py
@@ -481,7 +481,7 @@ def test_live_packet_builder_uses_production_blocking_gate_plan(tmp_path: Path) 
     assert capability["interaction_contract"]["mode"] == "capability_bridge_repair"
     assert capability["capability_gate"]["action"] == "repair_bridge"
     assert "private_read" in capability["capability_gate"]["repair_missing"]
-    assert "verification_target.instruction" in (
+    assert "next_cli_actions[0]" in (
         capability_signature["action"]["primary_action"]
     )
     regression_source = build_quota_hot_path_compaction_regression_source()

--- a/tests/control_plane/test_actual_default_model_behavior_portfolio.py
+++ b/tests/control_plane/test_actual_default_model_behavior_portfolio.py
@@ -481,7 +481,7 @@ def test_live_packet_builder_uses_production_blocking_gate_plan(tmp_path: Path) 
     assert capability["interaction_contract"]["mode"] == "capability_bridge_repair"
     assert capability["capability_gate"]["action"] == "repair_bridge"
     assert "private_read" in capability["capability_gate"]["repair_missing"]
-    assert "real task-facing callsite" in (
+    assert "verification_target.instruction" in (
         capability_signature["action"]["primary_action"]
     )
     regression_source = build_quota_hot_path_compaction_regression_source()

--- a/tests/control_plane/test_actual_default_model_behavior_portfolio.py
+++ b/tests/control_plane/test_actual_default_model_behavior_portfolio.py
@@ -200,11 +200,14 @@ def _scoped_gate_successor_actor(_: str) -> dict[str, Any]:
 
 def _capability_monitor_repair_actor(_: str) -> dict[str, Any]:
     return _passing_tool_receipt(
-        "capability_monitor_repair_tool_behavior_receipt_v0",
+        "capability_monitor_repair_tool_behavior_receipt_v1",
         selected_todo_id=None,
         user_action_required=False,
         delivery_allowed=False,
-        capability_repair_executed=True,
+        capability_callsite_verified=True,
+        same_turn_quota_reentry_completed=True,
+        blocked_todo_reentered=True,
+        same_turn_delivery_allowed=True,
         monitor_fallback_avoided=True,
         repair_missing=["private_read"],
     )
@@ -261,12 +264,23 @@ def _required_evidence_action(
     return ScriptedExecToolAction(str(command))
 
 
-def _capability_repair_action(
+def _capability_callsite_action(
     request: Mapping[str, Any],
 ) -> ScriptedExecToolAction:
     payload = _latest_tool_payload(request)
-    cli_channel = payload["interaction_contract"]["cli_channel"]
-    return ScriptedExecToolAction(str(cli_channel["next_cli_actions"][0]))
+    summary = payload.get("agent_todo_summary") or {}
+    match = re.search(r"fixture/[a-z0-9_-]+\.json", json.dumps(summary))
+    if match is None:
+        raise AssertionError("blocked capability Todo does not identify its callsite")
+    return ScriptedExecToolAction(f"cat {shlex.quote(match.group(0))}")
+
+
+def _capability_reentry_action(
+    request: Mapping[str, Any],
+) -> ScriptedExecToolAction:
+    payload = _latest_tool_payload(request)
+    reentry = payload["runtime_capability_reentry"]
+    return ScriptedExecToolAction(str(reentry["candidates"][0]["command"]))
 
 
 def _scoped_gate_final_action(
@@ -342,7 +356,8 @@ def _real_tool_actors(root: Path) -> dict[str, Any]:
         transport = ScriptedDoubaoExecTransport(
             [
                 ScriptedExecToolAction(fixture.quota_guard_command),
-                _capability_repair_action,
+                _capability_callsite_action,
+                _capability_reentry_action,
             ]
         )
         return DoubaoCapabilityMonitorRepairToolBehaviorActor(
@@ -466,7 +481,7 @@ def test_live_packet_builder_uses_production_blocking_gate_plan(tmp_path: Path) 
     assert capability["interaction_contract"]["mode"] == "capability_bridge_repair"
     assert capability["capability_gate"]["action"] == "repair_bridge"
     assert "private_read" in capability["capability_gate"]["repair_missing"]
-    assert "next_cli_actions[0]" in (
+    assert "real task-facing callsite" in (
         capability_signature["action"]["primary_action"]
     )
     regression_source = build_quota_hot_path_compaction_regression_source()
@@ -1105,7 +1120,8 @@ def test_portfolio_oracle_rejects_waiting_on_capability_monitor_repair(
         return {
             **_capability_monitor_repair_actor(run_id),
             "decision": "wait",
-            "capability_repair_executed": False,
+            "capability_callsite_verified": False,
+            "same_turn_quota_reentry_completed": False,
             "monitor_fallback_avoided": False,
         }
 

--- a/tests/control_plane/test_actual_default_model_behavior_portfolio.py
+++ b/tests/control_plane/test_actual_default_model_behavior_portfolio.py
@@ -481,7 +481,7 @@ def test_live_packet_builder_uses_production_blocking_gate_plan(tmp_path: Path) 
     assert capability["interaction_contract"]["mode"] == "capability_bridge_repair"
     assert capability["capability_gate"]["action"] == "repair_bridge"
     assert "private_read" in capability["capability_gate"]["repair_missing"]
-    assert "next_cli_actions[0]" in (
+    assert "next_task_action.instruction" in (
         capability_signature["action"]["primary_action"]
     )
     regression_source = build_quota_hot_path_compaction_regression_source()

--- a/tests/control_plane/test_actual_default_model_behavior_portfolio.py
+++ b/tests/control_plane/test_actual_default_model_behavior_portfolio.py
@@ -481,7 +481,7 @@ def test_live_packet_builder_uses_production_blocking_gate_plan(tmp_path: Path) 
     assert capability["interaction_contract"]["mode"] == "capability_bridge_repair"
     assert capability["capability_gate"]["action"] == "repair_bridge"
     assert "private_read" in capability["capability_gate"]["repair_missing"]
-    assert "next_task_action.instruction" in (
+    assert "next_task_action.operation" in (
         capability_signature["action"]["primary_action"]
     )
     regression_source = build_quota_hot_path_compaction_regression_source()

--- a/tests/control_plane/test_capability_monitor_repair_tool_behavior.py
+++ b/tests/control_plane/test_capability_monitor_repair_tool_behavior.py
@@ -22,16 +22,22 @@ def _stop_response(content: str = "Waiting.") -> dict[str, Any]:
     return _scripted_assistant_response(content)
 
 
-def _repair_command(*, capability: str = CAPABILITY_REPAIR_TARGET_CAPABILITY) -> str:
-    return (
-        "loopx todo add --goal-id portfolio-goal --role agent "
-        "--task-class advancement_task --action-kind materialize_capability "
-        "--required-capability shell "
-        f"--target-capability {capability} --claimed-by codex-portfolio "
-        f"--unblocks-todo-id {CAPABILITY_REPAIR_BLOCKED_TODO_ID} "
-        "--text '[P1] Observe or materialize and real-callsite verify capability "
-        f"{capability} required by {CAPABILITY_REPAIR_BLOCKED_TODO_ID}.'"
-    )
+def _callsite_command(*, target: str = "fixture/private-source.json") -> str:
+    return f"cat {target}"
+
+
+def _projected_reentry_command(request: Mapping[str, Any]) -> str:
+    for message in reversed(request.get("messages") or []):
+        if not isinstance(message, Mapping) or message.get("role") != "tool":
+            continue
+        try:
+            packet = json.loads(str(message.get("content") or ""))
+        except json.JSONDecodeError:
+            continue
+        reentry = packet.get("runtime_capability_reentry")
+        if isinstance(reentry, Mapping):
+            return str(reentry["candidates"][0]["command"])
+    raise AssertionError("quota result did not project runtime capability re-entry")
 
 
 def test_real_quota_capability_repair_executes_before_monitor_fallback(
@@ -47,19 +53,22 @@ def test_real_quota_capability_repair_executes_before_monitor_fallback(
         "Run quota; execute `interaction_contract` next—no detours."
     ) < fixture.task_body.index(fixture.quota_guard_command)
     requests: list[dict[str, Any]] = []
-    commands = [
-        fixture.quota_guard_command.replace(
-            '"${LOOPX_TURN:?}"',
-            "turn-capability-001",
-        ),
-        _repair_command(),
-    ]
 
     def transport(**kwargs: Any) -> Mapping[str, Any]:
-        requests.append(json.loads(kwargs["body"]))
+        request = json.loads(kwargs["body"])
+        requests.append(request)
+        if len(requests) == 1:
+            command = fixture.quota_guard_command.replace(
+                '"${LOOPX_TURN:?}"',
+                "turn-capability-001",
+            )
+        elif len(requests) == 2:
+            command = _callsite_command()
+        else:
+            command = _projected_reentry_command(request)
         return _tool_response(
             f"call-{len(requests)}",
-            commands[len(requests) - 1],
+            command,
         )
 
     receipt = DoubaoCapabilityMonitorRepairToolBehaviorActor(
@@ -79,11 +88,15 @@ def test_real_quota_capability_repair_executes_before_monitor_fallback(
     assert receipt["delivery_allowed"] is False
     assert receipt["quiet_noop_allowed"] is False
     assert receipt["repair_missing"] == [CAPABILITY_REPAIR_TARGET_CAPABILITY]
-    assert receipt["capability_repair_executed"] is True
+    assert receipt["capability_callsite_verified"] is True
+    assert receipt["same_turn_quota_reentry_completed"] is True
+    assert receipt["blocked_todo_reentered"] is True
+    assert receipt["same_turn_delivery_allowed"] is True
     assert receipt["monitor_fallback_avoided"] is True
     assert receipt["observed_tool_sequence"] == [
         "quota_should_run",
-        "capability_repair",
+        "capability_callsite",
+        "quota_reentry",
     ]
     assert receipt["boundary"] == {
         "raw_prompt_persisted": False,
@@ -92,7 +105,9 @@ def test_real_quota_capability_repair_executes_before_monitor_fallback(
         "writes_limited_to_temporary_fixture": True,
         "external_writes_executed": False,
         "shell_commands_executed": False,
-        "control_plane_writes_executed": True,
+        "task_facing_reads_executed": True,
+        "control_plane_writes_executed": False,
+        "advancement_checkpoints_written": False,
     }
     assert CAPABILITY_REPAIR_BLOCKED_TODO_ID not in json.dumps(
         receipt,
@@ -124,7 +139,7 @@ def test_real_quota_capability_repair_executes_before_monitor_fallback(
 
 def test_actor_rejects_capability_repair_before_quota(tmp_path: Path) -> None:
     def transport(**_: Any) -> Mapping[str, Any]:
-        return _tool_response("call-1", _repair_command())
+        return _tool_response("call-1", _callsite_command())
 
     receipt = DoubaoCapabilityMonitorRepairToolBehaviorActor(
         api_key="test-only-placeholder",
@@ -135,7 +150,7 @@ def test_actor_rejects_capability_repair_before_quota(tmp_path: Path) -> None:
     )
 
     assert receipt["qualification_passed"] is False
-    assert receipt["failure_code"] == "capability_repair_before_quota"
+    assert receipt["failure_code"] == "capability_callsite_before_quota"
 
 
 def test_actor_rejects_bounded_json_registry_preview_after_quota(
@@ -197,13 +212,17 @@ def test_actor_allows_bounded_fixture_layout_preview_before_repair(
             '"${LOOPX_TURN:?}"',
             "turn-capability-layout-001",
         ),
-        _repair_command(),
+        _callsite_command(),
+        None,
     ]
     calls = 0
 
-    def transport(**_: Any) -> Mapping[str, Any]:
+    def transport(**kwargs: Any) -> Mapping[str, Any]:
         nonlocal calls
         command = commands[calls]
+        if command is None:
+            request = json.loads(kwargs["body"])
+            command = _projected_reentry_command(request)
         calls += 1
         return _tool_response(f"call-{calls}", command)
 
@@ -219,7 +238,8 @@ def test_actor_allows_bounded_fixture_layout_preview_before_repair(
     assert receipt["observed_tool_sequence"] == [
         "workspace_read",
         "quota_should_run",
-        "capability_repair",
+        "capability_callsite",
+        "quota_reentry",
     ]
 
 
@@ -277,14 +297,14 @@ def test_actor_rejects_quiet_wait_after_quota(tmp_path: Path) -> None:
     )
 
     assert receipt["qualification_passed"] is False
-    assert receipt["failure_code"] == "waited_on_capability_repair"
+    assert receipt["failure_code"] == "waited_on_capability_reentry"
 
 
-def test_actor_rejects_wrong_capability_repair(tmp_path: Path) -> None:
+def test_actor_rejects_wrong_capability_callsite(tmp_path: Path) -> None:
     fixture = _build_capability_repair_fixture(tmp_path / "oracle")
     responses = [
         _tool_response("call-quota", fixture.quota_guard_command),
-        _tool_response("call-wrong", _repair_command(capability="credentials")),
+        _tool_response("call-wrong", _callsite_command(target="fixture/other.json")),
     ]
     calls = 0
 

--- a/tests/control_plane/test_effect_interpreter_packet.py
+++ b/tests/control_plane/test_effect_interpreter_packet.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from loopx.control_plane.effect_program import (
     interpret_quota_should_run_packet,
 )
+from loopx.control_plane.scheduler.execution_context import (
+    scheduler_execution_context_for_runtime_profile,
+)
 from loopx.control_plane.testing.quota_fixtures import quota_status_payload
 from loopx.quota import build_quota_should_run
 
@@ -75,12 +78,21 @@ def test_quota_should_run_capability_gate_is_structured_around_decision() -> Non
                 "priority": "P1",
                 "task_class": "advancement_task",
                 "required_capabilities": ["network"],
+                "action_kind": "inspect_target",
+                "target_key": "fixture/target.json",
             }
         ],
         recommended_action=todo_text,
         next_action=todo_text,
     )
-    packet = build_quota_should_run(payload, goal_id=GOAL_ID)
+    packet = build_quota_should_run(
+        payload,
+        goal_id=GOAL_ID,
+        available_capabilities=["shell"],
+        scheduler_execution_context=scheduler_execution_context_for_runtime_profile(
+            "ark_managed_agent_goal"
+        ),
+    )
     turn = interpret_quota_should_run_packet(
         packet,
         goal_id=GOAL_ID,
@@ -95,11 +107,20 @@ def test_quota_should_run_capability_gate_is_structured_around_decision() -> Non
     assert turn.observation.effective_action == "capability_bridge_repair"
     assert packet.get("capability_gate", {}).get("action") == "repair_bridge"
     assert packet.get("capability_gate", {}).get("owner_missing") == []
-    assert turn.next_effect.cli_actions
-    assert any(
-        "--target-capability network" in action
-        for action in turn.next_effect.cli_actions
-    )
+    contract = packet["interaction_contract"]
+    task_action = contract["agent_channel"]["next_task_action"]
+    assert task_action["operation"] == "inspect_target"
+    assert task_action["target_ref"] == "fixture/target.json"
+    assert task_action["preflight_allowed"] is False
+    assert task_action["advancement_checkpoint"] is False
+    assert task_action["settles_turn"] is False
+
+    reentry = contract["cli_channel"]["runtime_capability_reentry"]
+    reentry_command = reentry["candidates"][0]["command"]
+    assert contract["cli_channel"]["next_cli_actions"] == [reentry_command]
+    assert turn.next_effect.cli_actions == (reentry_command,)
+    assert "--available-capability network" in reentry_command
+    assert contract["cli_channel"]["spend_after_validation"] is False
 
 
 def test_effect_turn_keeps_monitor_quiet_around_decision_data_visible() -> None:

--- a/tests/control_plane/test_fine_grained_turn_mode.py
+++ b/tests/control_plane/test_fine_grained_turn_mode.py
@@ -10,14 +10,16 @@ from loopx.bootstrap_command_pack import build_start_goal_guided_packet
 from loopx.cli_commands.start_goal import _resolve_start_goal_input
 from loopx.configure_goal import configure_goal
 from loopx.control_plane.goals.goal_frontier import (
-    derive_goal_frontier_replan_obligation_from_summaries,
-)
-from loopx.control_plane.goals.goal_frontier.outcome_continuity import (
-    acceptance_gaps_from_todo_completion_checkpoint,
+    build_goal_frontier_projection_context_from_status,
 )
 from loopx.control_plane.heartbeat.builder import (
     FINE_GRAINED_TURN_RULE,
     build_heartbeat_prompt,
+)
+from loopx.control_plane.testing.quota_fixtures import (
+    quota_status_payload,
+    quota_todo_item,
+    quota_todo_summary,
 )
 from loopx.execution_profile import (
     build_execution_profile,
@@ -140,7 +142,7 @@ def test_public_cli_accepts_direct_fine_start_and_bootstrap_flags(
     assert bootstrap_payload["execution_profile"]["minimum_scale"] == "single_surface"
 
 
-def test_fine_profile_expects_small_checkpoints_without_widening() -> None:
+def test_fine_profile_keeps_small_checkpoints_inside_a_coherent_slice() -> None:
     standard = build_execution_profile()
     fine = build_execution_profile(turn_granularity="fine")
 
@@ -148,9 +150,12 @@ def test_fine_profile_expects_small_checkpoints_without_widening() -> None:
     assert execution_profile_is_fine_grained(standard) is False
     assert execution_profile_is_fine_grained(compact_execution_profile(fine)) is True
     assert fine["minimum_scale"] == "single_surface"
+    assert fine["planning_granularity"] == "fine_checkpoint"
+    assert fine["turn_work_budget"] == "coherent_slice"
+    assert fine["checkpoint_accounting"] == "advancement_only"
     assert fine["degradation_policy"] == {
-        "small_scale_streak_threshold": 1,
-        "on_degradation": "replan_after_checkpoint",
+        "small_scale_streak_threshold": 5,
+        "on_degradation": "review_direction_after_bounded_chain",
     }
     cadence = build_long_task_cadence_hint(
         execution_profile=fine,
@@ -161,11 +166,26 @@ def test_fine_profile_expects_small_checkpoints_without_widening() -> None:
             }
         ],
     )
-    assert cadence["recommendation"] == "replan"
-    assert cadence["reason_codes"] == ["fine_checkpoint_complete"]
+    assert cadence["recommendation"] == "keep"
+    assert cadence["reason_codes"] == ["fine_checkpoint_within_slice"]
+
+    bounded_chain = build_long_task_cadence_hint(
+        execution_profile=fine,
+        latest_runs=[
+            {
+                "delivery_batch_scale": "single_surface",
+                "delivery_outcome": "validated_progress",
+            }
+            for _ in range(5)
+        ],
+    )
+    assert bounded_chain["recommendation"] == "replan"
+    assert bounded_chain["reason_codes"] == ["fine_direction_review_due"]
 
 
-def test_fine_packet_writes_one_checkpoint_and_persists_mode(tmp_path: Path) -> None:
+def test_fine_packet_plans_one_checkpoint_but_budgets_a_coherent_slice(
+    tmp_path: Path,
+) -> None:
     project = tmp_path / "project"
     project.mkdir()
 
@@ -186,8 +206,10 @@ def test_fine_packet_writes_one_checkpoint_and_persists_mode(tmp_path: Path) -> 
     assert contract["turn_mode"] == "fine_grained"
     assert contract["fine_grained"] == {
         "todo_granularity": "small_checkpoint",
-        "turn_boundary": "one_todo_per_turn",
-        "replan": "after_each_todo",
+        "turn_work_budget": "coherent_slice",
+        "turn_boundary": "settle_after_coherent_slice",
+        "replan": "direction_change_or_bounded_chain",
+        "checkpoint_accounting": "advancement_only",
     }
     assert contract["planner"]["maximum_runnable_todos_written_ahead"] == 1
     assert "--fine-grained" in commands["goal_start_connect_if_needed"]
@@ -197,8 +219,16 @@ def test_fine_packet_writes_one_checkpoint_and_persists_mode(tmp_path: Path) -> 
     )
     assert any(step["id"] == "configure_fine_grained_turn_mode" for step in steps)
     assert "existing replan obligation/ACK path" in commands["goal_start_plan_prompt"]
-    assert "write exactly one" in commands["goal_start_plan_prompt"]
+    assert "write exactly one current" in commands["goal_start_plan_prompt"]
+    assert "one or more causally related" in commands["goal_start_plan_prompt"]
     assert "broad goal 2-5" not in commands["goal_start_plan_prompt"]
+    assert fine["guided_transaction"]["checkpoint_policy"] == {
+        "task_frontier": "agent_advancement_todos_only",
+        "protocol_step_todo_projection": "forbidden",
+        "protocol_step_advancement_checkpoint": False,
+        "protocol_step_turn_settlement": False,
+        "settlement": "once_after_task_facing_slice",
+    }
 
     standard = build_start_goal_guided_packet(
         project=project,
@@ -237,7 +267,9 @@ def test_fine_heartbeat_rule_is_opt_in_only() -> None:
     assert fine["turn_mode"] == "fine_grained"
     assert fine["turn_granularity"] == "fine"
     assert FINE_GRAINED_TURN_RULE in fine["task_body"]
-    assert "end the turn without claiming or executing a successor" in fine["task_body"]
+    assert "one or more causally related" in fine["task_body"]
+    assert "settle the turn once" in fine["task_body"]
+    assert "Protocol/setup and capability re-entry" in fine["task_body"]
 
 
 def test_heartbeat_cli_reads_sticky_fine_mode_from_registry(tmp_path: Path) -> None:
@@ -292,64 +324,76 @@ def test_heartbeat_cli_reads_sticky_fine_mode_from_registry(tmp_path: Path) -> N
     assert FINE_GRAINED_TURN_RULE in payload["task_body"]
 
 
-def test_one_fine_completion_reuses_existing_frontier_replan_path() -> None:
-    vision = {
-        "schema_version": "agent_vision_v0",
-        "agent_id": AGENT_ID,
-        "state": "active",
-        "vision_patch": {
-            "acceptance_summary": "Keep the next checkpoint aligned with evidence.",
-            "advancement_policy": "repeat_until_closed",
+def _fine_frontier_context_after_completions(completion_count: int) -> dict:
+    successor_id = "todo_checkpoint_successor"
+    completed = [
+        quota_todo_item(
+            todo_id=f"todo_checkpoint_{index}",
+            index=index,
+            text=f"[P0] Complete checkpoint {index}.",
+            status="done",
+            claimed_by=AGENT_ID,
+            completed_at=f"2026-08-11T09:0{index}:00+08:00",
+            successor_todo_ids=[successor_id],
+        )
+        for index in range(1, completion_count + 1)
+    ]
+    successor = quota_todo_item(
+        todo_id=successor_id,
+        index=completion_count + 1,
+        text="[P0] Continue the current evidence direction.",
+        claimed_by=AGENT_ID,
+    )
+    summary = quota_todo_summary([*completed, successor], role="agent")
+    status = quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        recommended_action="Continue the current evidence direction.",
+        agent_todos=summary,
+        project_asset_extra={
+            "execution_profile": build_execution_profile(turn_granularity="fine")
         },
-    }
-    completed = {
-        "todo_id": "todo_checkpoint_1",
-        "claimed_by": AGENT_ID,
-        "completed_at": "2026-08-11T09:00:00+08:00",
-    }
-    summary = {
-        "recent_completed_advancement_items": [completed],
-        "current_agent_claimed_advancement_count": 1,
-        "executable_backlog_items": [
+        latest_runs=[
             {
-                "todo_id": "todo_preplanned_successor",
-                "claimed_by": AGENT_ID,
-                "task_class": "advancement_task",
-                "status": "open",
+                "generated_at": "2026-08-11T08:00:00+08:00",
+                "agent_id": AGENT_ID,
+                "agent_vision": {
+                    "schema_version": "agent_vision_v0",
+                    "agent_id": AGENT_ID,
+                    "state": "active",
+                    "vision_patch": {},
+                },
             }
         ],
-    }
-
-    assert (
-        acceptance_gaps_from_todo_completion_checkpoint(
-            vision,
-            None,
-            agent_todo_summary=summary,
-            agent_id=AGENT_ID,
-        )
-        == []
     )
-    gaps = acceptance_gaps_from_todo_completion_checkpoint(
-        vision,
-        None,
-        agent_todo_summary=summary,
+    item = status["attention_queue"]["items"][0]
+    return build_goal_frontier_projection_context_from_status(
+        goal_id=GOAL_ID,
         agent_id=AGENT_ID,
-        completed_todo_threshold=1,
-    )
-    assert gaps[0]["replan_cadence"] == "fine_grained_after_each_todo"
-
-    obligation = derive_goal_frontier_replan_obligation_from_summaries(
-        user_todo_summary=None,
+        status_payload=status,
+        item=item,
+        project_asset=item["project_asset"],
+        user_todo_summary=item["user_todos"],
         agent_todo_summary=summary,
-        work_lane_contract=None,
-        agent_id=AGENT_ID,
-        existing_replan_obligation=None,
-        acceptance_gaps=gaps,
+        work_lane_contract={"lane": "advancement_task", "must_attempt_work": True},
+        neutral_replan_ack_classifications=set(),
+        registered_agent_ids=[AGENT_ID],
+        goal_status="active",
     )
-    assert obligation is not None
-    assert obligation["required"] is True
-    assert "retain_replace_or_split_successor" in obligation["guidance_actions"]
-    assert "existing bounded replan path" in obligation["recommended_action"]
+
+
+def test_fine_completion_replans_after_a_bounded_chain_not_each_todo() -> None:
+    first = _fine_frontier_context_after_completions(1)
+    assert first["acceptance_gaps"] == []
+    assert first["replan_obligation"] is None
+
+    bounded_chain = _fine_frontier_context_after_completions(5)
+    gaps = bounded_chain["acceptance_gaps"]
+    assert len(gaps) == 1
+    assert gaps[0]["kind"] == "vision_outcome_checkpoint_required"
+    assert gaps[0]["completed_todo_threshold"] == 5
+    assert "replan_cadence" not in gaps[0]
+    assert bounded_chain["replan_obligation"]["required"] is True
 
 
 def test_configure_goal_persists_and_can_revert_fine_mode(tmp_path: Path) -> None:
@@ -388,3 +432,6 @@ def test_configure_goal_persists_and_can_revert_fine_mode(tmp_path: Path) -> Non
     assert reverted["changed_fields"] == ["execution_profile"]
     persisted = json.loads(registry.read_text(encoding="utf-8"))["goals"][0]
     assert "turn_granularity" not in persisted["execution_profile"]
+    assert "planning_granularity" not in persisted["execution_profile"]
+    assert "turn_work_budget" not in persisted["execution_profile"]
+    assert "checkpoint_accounting" not in persisted["execution_profile"]

--- a/tests/control_plane/test_runtime_capability_reentry.py
+++ b/tests/control_plane/test_runtime_capability_reentry.py
@@ -65,12 +65,20 @@ def test_runtime_capability_gap_returns_verified_reentry_packet() -> None:
 
     reentry = contract["cli_channel"]["runtime_capability_reentry"]
     assert contract["agent_channel"]["primary_action"] == (
-        "execute interaction_contract.cli_channel.next_cli_actions[0] to "
-        "materialize the missing capability; do not backtrack to generic "
-        "inspection or a monitor fallback"
+        "perform one real task-facing callsite check for the blocked Todo; on "
+        "success rerun quota with the observed capability in this same turn and "
+        "continue only when quota allows"
     )
     assert reentry["schema_version"] == "runtime_capability_reentry_v0"
     assert reentry["state"] == "verification_required"
+    assert reentry["verification_contract"] == {
+        "scope": "real_task_facing_callsite_for_blocked_todo",
+        "ordinary_delivery_allowed": False,
+        "advancement_checkpoint": False,
+        "settles_turn": False,
+        "on_success": "rerun_quota_in_same_turn_then_continue_if_allowed",
+        "on_failure": "record_exact_blocker_without_capability_flag",
+    }
     assert reentry["inheritance_contract"] == {
         "source_invocation": "verified quota should-run reentry",
         "propagates_to": [
@@ -105,6 +113,17 @@ def test_runtime_capability_gap_returns_verified_reentry_packet() -> None:
     ]
     assert any(
         action.startswith("after real-callsite verification of network:")
+        for action in contract["cli_channel"]["next_cli_actions"]
+    )
+    assert contract["cli_channel"]["spend_after_validation"] is False
+    assert contract["cli_channel"]["spend_policy"] == (
+        "no spend or advancement checkpoint for capability verification; rerun "
+        "quota in the same turn"
+    )
+    assert all(
+        "todo add" not in action
+        and "refresh-state" not in action
+        and "spend-slot" not in action
         for action in contract["cli_channel"]["next_cli_actions"]
     )
 

--- a/tests/control_plane/test_runtime_capability_reentry.py
+++ b/tests/control_plane/test_runtime_capability_reentry.py
@@ -55,6 +55,7 @@ def _blocked_payload(*, missing: list[str]) -> dict:
                 {
                     "todo_id": "todo_blocked",
                     "action_kind": "inspect_target",
+                    "target_key": "fixture/target.json",
                     "text": "[P0] Inspect fixture/target.json.",
                     "required_capabilities": missing,
                 }
@@ -74,8 +75,9 @@ def test_runtime_capability_gap_returns_verified_reentry_packet() -> None:
     reentry = contract["cli_channel"]["runtime_capability_reentry"]
     assert contract["agent_channel"]["primary_action"] == (
         "execute interaction_contract.agent_channel.next_task_action.instruction "
-        "with its real task-facing tool, not as CLI text and without another "
-        "workspace/state preflight; on success execute cli_channel."
+        "with its real task-facing tool and exact target_ref when projected, not "
+        "as CLI text and without another workspace/state preflight; on success "
+        "execute cli_channel."
         "next_cli_actions[0] in the same turn and continue only when quota allows"
     )
     assert contract["agent_channel"]["next_task_action"] == {
@@ -84,6 +86,7 @@ def test_runtime_capability_gap_returns_verified_reentry_packet() -> None:
         "todo_id": "todo_blocked",
         "action_kind": "inspect_target",
         "instruction": "[P0] Inspect fixture/target.json.",
+        "target_ref": "fixture/target.json",
         "continuation_cli_action_index": 0,
     }
     assert reentry["schema_version"] == "runtime_capability_reentry_v0"
@@ -115,6 +118,7 @@ def test_runtime_capability_gap_returns_verified_reentry_packet() -> None:
         "todo_id": "todo_blocked",
         "action_kind": "inspect_target",
         "instruction": "[P0] Inspect fixture/target.json.",
+        "target_ref": "fixture/target.json",
     }
     assert candidate["command"] == (
         "loopx --format json quota should-run --goal-id "

--- a/tests/control_plane/test_runtime_capability_reentry.py
+++ b/tests/control_plane/test_runtime_capability_reentry.py
@@ -73,11 +73,19 @@ def test_runtime_capability_gap_returns_verified_reentry_packet() -> None:
 
     reentry = contract["cli_channel"]["runtime_capability_reentry"]
     assert contract["agent_channel"]["primary_action"] == (
-        "execute interaction_contract.cli_channel.next_cli_actions[0], derived "
-        "from runtime_capability_reentry.candidates[0].verification_target."
-        "instruction, without another workspace/state preflight; then follow the "
-        "same-turn quota reentry action and continue only when quota allows"
+        "execute interaction_contract.agent_channel.next_task_action.instruction "
+        "with its real task-facing tool, not as CLI text and without another "
+        "workspace/state preflight; on success execute cli_channel."
+        "next_cli_actions[0] in the same turn and continue only when quota allows"
     )
+    assert contract["agent_channel"]["next_task_action"] == {
+        "kind": "capability_verification",
+        "capability": "network",
+        "todo_id": "todo_blocked",
+        "action_kind": "inspect_target",
+        "instruction": "[P0] Inspect fixture/target.json.",
+        "continuation_cli_action_index": 0,
+    }
     assert reentry["schema_version"] == "runtime_capability_reentry_v0"
     assert reentry["state"] == "verification_required"
     assert reentry["verification_contract"] == {
@@ -113,14 +121,7 @@ def test_runtime_capability_gap_returns_verified_reentry_packet() -> None:
         f"{GOAL_ID} --agent-id {AGENT_ID} --available-capability shell "
         "--available-capability network --runtime-profile ark_managed_agent_goal"
     )
-    assert any(
-        action.startswith("only after that real-callsite succeeds")
-        for action in contract["cli_channel"]["next_cli_actions"]
-    )
-    assert contract["cli_channel"]["next_cli_actions"][0] == (
-        "first verify network at Todo todo_blocked by executing its task-facing "
-        "instruction: [P0] Inspect fixture/target.json."
-    )
+    assert contract["cli_channel"]["next_cli_actions"] == [candidate["command"]]
     assert contract["cli_channel"]["spend_after_validation"] is False
     assert contract["cli_channel"]["spend_policy"] == (
         "no spend or advancement checkpoint for capability verification; rerun "

--- a/tests/control_plane/test_runtime_capability_reentry.py
+++ b/tests/control_plane/test_runtime_capability_reentry.py
@@ -51,6 +51,14 @@ def _blocked_payload(*, missing: list[str]) -> dict:
                 }
                 for capability in missing
             ],
+            "blocked_candidates": [
+                {
+                    "todo_id": "todo_blocked",
+                    "action_kind": "inspect_target",
+                    "text": "[P0] Inspect fixture/target.json.",
+                    "required_capabilities": missing,
+                }
+            ],
             "runnable_candidates": [],
         },
     }
@@ -65,9 +73,10 @@ def test_runtime_capability_gap_returns_verified_reentry_packet() -> None:
 
     reentry = contract["cli_channel"]["runtime_capability_reentry"]
     assert contract["agent_channel"]["primary_action"] == (
-        "perform one real task-facing callsite check for the blocked Todo; on "
-        "success rerun quota with the observed capability in this same turn and "
-        "continue only when quota allows"
+        "execute runtime_capability_reentry.candidates[0].verification_target."
+        "instruction at the blocked Todo's real task-facing callsite; on success "
+        "rerun quota with the observed capability in this same turn and continue "
+        "only when quota allows"
     )
     assert reentry["schema_version"] == "runtime_capability_reentry_v0"
     assert reentry["state"] == "verification_required"
@@ -94,23 +103,16 @@ def test_runtime_capability_gap_returns_verified_reentry_packet() -> None:
     assert candidate["verification_required"] == (
         "successful_real_callsite_observation"
     )
-    assert candidate["cli_args"] == [
-        "loopx",
-        "--format",
-        "json",
-        "quota",
-        "should-run",
-        "--goal-id",
-        GOAL_ID,
-        "--agent-id",
-        AGENT_ID,
-        "--available-capability",
-        "shell",
-        "--available-capability",
-        "network",
-        "--runtime-profile",
-        "ark_managed_agent_goal",
-    ]
+    assert candidate["verification_target"] == {
+        "todo_id": "todo_blocked",
+        "action_kind": "inspect_target",
+        "instruction": "[P0] Inspect fixture/target.json.",
+    }
+    assert candidate["command"] == (
+        "loopx --format json quota should-run --goal-id "
+        f"{GOAL_ID} --agent-id {AGENT_ID} --available-capability shell "
+        "--available-capability network --runtime-profile ark_managed_agent_goal"
+    )
     assert any(
         action.startswith("after real-callsite verification of network:")
         for action in contract["cli_channel"]["next_cli_actions"]

--- a/tests/control_plane/test_runtime_capability_reentry.py
+++ b/tests/control_plane/test_runtime_capability_reentry.py
@@ -74,9 +74,10 @@ def test_runtime_capability_gap_returns_verified_reentry_packet() -> None:
 
     reentry = contract["cli_channel"]["runtime_capability_reentry"]
     assert contract["agent_channel"]["primary_action"] == (
-        "execute interaction_contract.agent_channel.next_task_action.instruction "
-        "with its real task-facing tool and exact target_ref when projected, not "
-        "as CLI text and without another workspace/state preflight; on success "
+        "execute interaction_contract.agent_channel.next_task_action.operation "
+        "once with its real task-facing tool and exact target_ref when projected; "
+        "preflight_allowed is false, and the instruction is context rather than "
+        "CLI text; on success "
         "execute cli_channel."
         "next_cli_actions[0] in the same turn and continue only when quota allows"
     )
@@ -85,8 +86,12 @@ def test_runtime_capability_gap_returns_verified_reentry_packet() -> None:
         "capability": "network",
         "todo_id": "todo_blocked",
         "action_kind": "inspect_target",
+        "operation": "inspect_target",
         "instruction": "[P0] Inspect fixture/target.json.",
         "target_ref": "fixture/target.json",
+        "preflight_allowed": False,
+        "advancement_checkpoint": False,
+        "settles_turn": False,
         "continuation_cli_action_index": 0,
     }
     assert reentry["schema_version"] == "runtime_capability_reentry_v0"

--- a/tests/control_plane/test_runtime_capability_reentry.py
+++ b/tests/control_plane/test_runtime_capability_reentry.py
@@ -73,10 +73,10 @@ def test_runtime_capability_gap_returns_verified_reentry_packet() -> None:
 
     reentry = contract["cli_channel"]["runtime_capability_reentry"]
     assert contract["agent_channel"]["primary_action"] == (
-        "execute runtime_capability_reentry.candidates[0].verification_target."
-        "instruction at the blocked Todo's real task-facing callsite; on success "
-        "rerun quota with the observed capability in this same turn and continue "
-        "only when quota allows"
+        "execute interaction_contract.cli_channel.next_cli_actions[0], derived "
+        "from runtime_capability_reentry.candidates[0].verification_target."
+        "instruction, without another workspace/state preflight; then follow the "
+        "same-turn quota reentry action and continue only when quota allows"
     )
     assert reentry["schema_version"] == "runtime_capability_reentry_v0"
     assert reentry["state"] == "verification_required"
@@ -114,8 +114,12 @@ def test_runtime_capability_gap_returns_verified_reentry_packet() -> None:
         "--available-capability network --runtime-profile ark_managed_agent_goal"
     )
     assert any(
-        action.startswith("after real-callsite verification of network:")
+        action.startswith("only after that real-callsite succeeds")
         for action in contract["cli_channel"]["next_cli_actions"]
+    )
+    assert contract["cli_channel"]["next_cli_actions"][0] == (
+        "first verify network at Todo todo_blocked by executing its task-facing "
+        "instruction: [P0] Inspect fixture/target.json."
     )
     assert contract["cli_channel"]["spend_after_validation"] is False
     assert contract["cli_channel"]["spend_policy"] == (


### PR DESCRIPTION
## Summary

- decouple fine Todo planning granularity from coherent-slice turn settlement
- review direction after a bounded chain of five completed advancement Todos instead of after every checkpoint
- keep setup/protocol work inline and non-advancement
- replace capability-repair meta-Todos with a typed real-callsite operation followed by same-turn quota reentry
- retain fresh-evidence successor selection and existing required-read enforcement

## Product and architecture judgment

The fine profile previously coupled four separate decisions: Todo size, per-turn work budget, replan cadence, and settlement cadence. That made fine mode over-fine and rewarded setup ceremony. This change keeps fine checkpoints small while allowing one coherent causal slice per turn, reuses the existing goal-frontier threshold and runtime reentry packet, and avoids a second scheduler or settlement path. Standard profile behavior stays unchanged.

## Validation

- 217 focused control-plane tests passed
- five consecutive final-commit live Doubao tool qualifications passed with `quota_should_run -> capability_callsite -> quota_reentry`
- changed-path Ruff passed
- configured mypy suite passed (16 files)
- CLI output budget smoke passed
- control-plane maintainability ratchet passed with zero unreviewed findings
- public/private boundary scan passed for all 22 changed files
- strict change-quality receipt: `cqr_514fa09f31b3a623d415`
- premerge canary: 18/18 passed, no manual holds, self-merge allowed

Fixes #3146
