### PR TITLE
fix(auto-research): emit argv-safe visible worker-turn hooks

### DIFF
--- a/examples/auto-research-visible-worker-hook-smoke.py
+++ b/examples/auto-research-visible-worker-hook-smoke.py
@@ -22,6 +22,7 @@ from loopx.capabilities.auto_research.demo_supervisor import (  # noqa: E402
 from loopx.capabilities.auto_research.user_contract import (  # noqa: E402
     build_auto_research_preset_context,
 )
+from loopx.visible_multi_agent_launcher import validate_worker_command  # noqa: E402
 
 
 GOAL_ID = "loopx-auto-research-visible-worker-hook-smoke"
@@ -47,14 +48,20 @@ def assert_public_safe(payload: Any) -> None:
 
 
 def assert_worker_turn_command_shape() -> None:
-    command = build_visible_worker_turn_command(objective=QUESTION)
-    assert '"$LOOPX_PANE_LOOPX" --format json auto-research worker-turn' in command
-    assert '--goal-id "$LOOPX_GOAL_ID"' in command
-    assert '--agent-id "$LOOPX_AGENT_ID"' in command
-    assert '--lane-count "${LOOPX_VISIBLE_LANE_COUNT:-1}"' in command
+    command = build_visible_worker_turn_command(
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        lane_count=1,
+    )
+    assert validate_worker_command(command, field="worker_turn_command") == command
+    assert command.startswith("loopx --format json auto-research worker-turn")
+    assert f"--goal-id {GOAL_ID}" in command
+    assert f"--agent-id {AGENT_ID}" in command
+    assert "--lane-count 1" in command
     assert "--visible-lanes-accepted" in command
     assert "--complete-selected-todo" in command
     assert "--execute" in command
+    assert "$" not in command
     assert_public_safe(command)
 
 
@@ -77,6 +84,7 @@ def assert_supervisor_can_configure_worker_turn() -> None:
         assert lane["pane_local_a2a"]["status_check_only"] is True, lane
         assert lane["pane_local_a2a"]["counts_as_research_round"] is False, lane
         assert "LOOPX_PANE_WORKER_TURN" in lane["visible_launch_command"], lane
+        assert "export LOOPX_PANE_WORKER_TURN='" in lane["visible_launch_command"], lane
         assert "auto-research worker-turn" in lane["visible_launch_command"], lane
         assert "--visible-lanes-accepted" in lane["visible_launch_command"], lane
         assert "--complete-selected-todo" in lane["visible_launch_command"], lane

--- a/loopx/capabilities/auto_research/demo_supervisor.py
+++ b/loopx/capabilities/auto_research/demo_supervisor.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-import shlex
 from collections.abc import Iterable
 from typing import Any
 
 from .defaults import (
     AUTO_RESEARCH_DEFAULT_GOAL_ID,
-    AUTO_RESEARCH_DEFAULT_OBJECTIVE,
     build_auto_research_layer_contract,
 )
 from .preset import (
@@ -23,19 +21,43 @@ from ...visible_multi_agent_launcher import build_visible_multi_agent_payload_fr
 AUTO_RESEARCH_DEMO_SUPERVISOR_SCHEMA_VERSION = "auto_research_demo_supervisor_plan_v0"
 
 
-def build_visible_worker_turn_command(*, objective: object | None = None) -> str:
-    """Return a pane-local worker-turn hook that still obeys visible evidence gates."""
+def build_visible_worker_turn_command(
+    *,
+    goal_id: str = AUTO_RESEARCH_DEFAULT_GOAL_ID,
+    agent_id: str,
+    lane_count: int = 1,
+) -> str:
+    """Return a pane-local worker-turn hook that still obeys visible evidence gates.
 
-    clean_objective = str(objective or AUTO_RESEARCH_DEFAULT_OBJECTIVE).strip()
-    return (
-        '"$LOOPX_PANE_LOOPX" --format json auto-research worker-turn '
-        '--goal-id "$LOOPX_GOAL_ID" '
-        '--agent-id "$LOOPX_AGENT_ID" '
-        f"--objective {shlex.quote(clean_objective)} "
-        '--lane-count "${LOOPX_VISIBLE_LANE_COUNT:-1}" '
-        "--visible-lanes-accepted "
-        "--complete-selected-todo "
-        "--execute"
+    The hook is exported through ``LOOPX_PANE_WORKER_TURN`` and executed by the
+    pane shell, so it must be a plain argv-style command without shell
+    metacharacters. Goal, agent, and lane values are baked in as literal safe
+    tokens; the open question lives in the role profile/preset context rather
+    than in the hook.
+    """
+
+    clean_goal = str(goal_id or AUTO_RESEARCH_DEFAULT_GOAL_ID).strip()
+    clean_agent = str(agent_id or "").strip()
+    if not clean_agent:
+        raise ValueError("build_visible_worker_turn_command requires agent_id")
+    count = max(1, int(lane_count or 1))
+    return " ".join(
+        [
+            "loopx",
+            "--format",
+            "json",
+            "auto-research",
+            "worker-turn",
+            "--goal-id",
+            clean_goal,
+            "--agent-id",
+            clean_agent,
+            "--lane-count",
+            str(count),
+            "--visible-lanes-accepted",
+            "--complete-selected-todo",
+            "--execute",
+        ]
     )
 
 
@@ -62,11 +84,7 @@ def build_auto_research_demo_supervisor_plan(
 
     goal = str(goal_id).strip() or AUTO_RESEARCH_DEFAULT_GOAL_ID
     lanes = auto_research_lane_specs(agent_specs)
-    worker_turn_command = (
-        build_visible_worker_turn_command(objective=open_question)
-        if configure_visible_worker_turn
-        else ""
-    )
+    worker_turn_configured = bool(configure_visible_worker_turn)
     roles = [
         build_auto_research_preset_role(
             lane=lane,
@@ -78,9 +96,13 @@ def build_auto_research_demo_supervisor_plan(
         )
         for lane in lanes
     ]
-    if worker_turn_command:
+    if worker_turn_configured:
         for role in roles:
-            role["worker_turn_command"] = worker_turn_command
+            role["worker_turn_command"] = build_visible_worker_turn_command(
+                goal_id=goal,
+                agent_id=str(role.get("agent_id") or "").strip(),
+                lane_count=len(lanes),
+            )
             role_profile = role.get("role_profile")
             if isinstance(role_profile, dict):
                 role_profile["visible_worker_turn_configured"] = True
@@ -133,7 +155,7 @@ def build_auto_research_demo_supervisor_plan(
                     "todo_evidence_status_protocol",
                 ],
                 "worker_turn_owner": "generic_multi_agent_kernel",
-                "visible_worker_turn_configured": bool(worker_turn_command),
+                "visible_worker_turn_configured": worker_turn_configured,
                 "output_language": output_language,
                 "presentation_layers_in_kernel": False,
             },

--- a/tests/test_worker_command_validation.py
+++ b/tests/test_worker_command_validation.py
@@ -58,3 +58,30 @@ def test_spec_builder_rejects_unsafe_worker_command() -> None:
 
     with pytest.raises(ValueError, match="unsafe shell metacharacters"):
         build_visible_multi_agent_payload_from_spec(spec)
+
+
+def test_auto_research_supervisor_visible_worker_turn_hook_is_safe() -> None:
+    from loopx.capabilities.auto_research.demo_supervisor import (
+        build_auto_research_demo_supervisor_plan,
+        build_visible_worker_turn_command,
+    )
+    from loopx.capabilities.auto_research.user_contract import (
+        build_auto_research_preset_context,
+    )
+
+    command = build_visible_worker_turn_command(
+        goal_id="loopx-auto-research-safe-hook",
+        agent_id="auto-research-observer",
+        lane_count=1,
+    )
+    assert validate_worker_command(command, field="worker_turn_command") == command
+
+    payload = build_auto_research_demo_supervisor_plan(
+        goal_id="loopx-auto-research-safe-hook",
+        open_question="如何提升 KNN 精确近邻检索速度？",
+        preset_context=build_auto_research_preset_context("knn-demo"),
+        configure_visible_worker_turn=True,
+    )
+    assert payload["auto_research"]["visible_worker_turn_configured"] is True
+    for lane in payload["lanes"]:
+        assert lane["pane_local_a2a"]["worker_turn_configured"] is True


### PR DESCRIPTION
## Summary

Fixes the main `Full Public Smokes` regression introduced by #3139 (launcher worker-command hardening). `build_visible_worker_turn_command` still generated a shell-style hook:

```
"$LOOPX_PANE_LOOPX" --format json auto-research worker-turn --goal-id "$LOOPX_GOAL_ID" --agent-id "$LOOPX_AGENT_ID" --objective '...' --lane-count "${LOOPX_VISIBLE_LANE_COUNT:-1}" ...
```

`validate_worker_command` rejects that shape because the hook is exported through `LOOPX_PANE_WORKER_TURN` and executed by the pane shell, so shell metacharacters are unsafe.

## Change

- `loopx/capabilities/auto_research/demo_supervisor.py`: build the hook as literal argv tokens (`loopx --format json auto-research worker-turn --goal-id <id> --agent-id <id> --lane-count <n> --visible-lanes-accepted --complete-selected-todo --execute`). Goal, agent, and lane values are baked in per role; the open question stays in the role profile/preset context instead of the shell hook.
- `examples/auto-research-visible-worker-hook-smoke.py`: assert the safe shape, including a `validate_worker_command` roundtrip and the single-quoted env export.
- `tests/test_worker_command_validation.py`: regression test that the supervisor plan builds only validator-safe worker hooks.

## Validation

- `pytest tests/test_worker_command_validation.py` → 18 passed
- `python examples/auto-research-visible-worker-hook-smoke.py` → ok
- `python examples/auto-research-demo-supervisor-smoke.py` → ok
- `python examples/generic-multi-agent-spec-contract-smoke.py` → ok
- `py_compile` on changed files and `git diff --check` pass

## Boundaries

- No runtime behavior, quota, scheduler, or scoring change; no private state, credentials, local paths, or raw logs.