### PR TITLE
fix(heartbeat): qualify DONT_NOTIFY as output-only and project agent_must_attempt mirror

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1443,7 +1443,10 @@ is projected by a future `quota should-run`, not by the ack response.
 The payload also includes `execution_obligation`, which is the compatibility
 entry point for older workers deciding whether a quiet no-op is allowed.
 `heartbeat_recommendation.notify` is only a user-facing notification policy. It
-must not be interpreted as an execution gate. If
+must not be interpreted as an execution gate. `heartbeat_recommendation.
+agent_must_attempt` mirrors `execution_obligation.must_attempt_work` as a
+single-field shortcut so thin heartbeat prompts can key work obligation off
+one boolean instead of parsing notify semantics. If
 `execution_obligation.kind=external_evidence_observation_required`, ordinary
 delivery is still blocked, but the worker must perform one read-only
 observation or write a compact missing-handle blocker before it may stop. If

--- a/loopx/control_plane/heartbeat/rules.py
+++ b/loopx/control_plane/heartbeat/rules.py
@@ -13,11 +13,10 @@ USER_TODO_FINAL_MESSAGE_RULE = (
     "the projection internally and stay quiet."
 )
 HEARTBEAT_NOTIFICATION_RULE_SHORT = (
-    "`user_channel.notify` controls OUTPUT only: NOTIFY=向用户输出具体动作/问题; "
-    "DONT_NOTIFY=quiet output（不打扰用户），不代表无需工作。"
-    "Execution obligation is separate: `execution_obligation.must_attempt_work=true` "
-    "-> run the bounded slice and write back even under DONT_NOTIFY; "
-    "quiet no-op requires `must_attempt_work=false` and DONT_NOTIFY. "
+    "`user_channel.notify` controls OUTPUT only: NOTIFY=向用户输出动作; "
+    "DONT_NOTIFY=安静输出。执行义务看 `heartbeat_recommendation.agent_must_attempt`/"
+    "`execution_obligation.must_attempt_work`：true 时必须执行 bounded slice 并写回，"
+    "quiet no-op 仅当 false。"
     "Due/peer gate != prompt; missing NOTIFY action->"
     "具体user todo未投影，需修复LoopX状态投影."
 )

--- a/loopx/control_plane/heartbeat/rules.py
+++ b/loopx/control_plane/heartbeat/rules.py
@@ -13,7 +13,11 @@ USER_TODO_FINAL_MESSAGE_RULE = (
     "the projection internally and stay quiet."
 )
 HEARTBEAT_NOTIFICATION_RULE_SHORT = (
-    "`user_channel.notify`: NOTIFY=Chinese action; DONT_NOTIFY=quiet. "
+    "`user_channel.notify` controls OUTPUT only: NOTIFY=向用户输出具体动作/问题; "
+    "DONT_NOTIFY=quiet output（不打扰用户），不代表无需工作。"
+    "Execution obligation is separate: `execution_obligation.must_attempt_work=true` "
+    "-> run the bounded slice and write back even under DONT_NOTIFY; "
+    "quiet no-op requires `must_attempt_work=false` and DONT_NOTIFY. "
     "Due/peer gate != prompt; missing NOTIFY action->"
     "具体user todo未投影，需修复LoopX状态投影."
 )

--- a/loopx/control_plane/quota/should_run_packet.py
+++ b/loopx/control_plane/quota/should_run_packet.py
@@ -810,6 +810,18 @@ def _build_quota_should_run_payload(
     route: _QuotaDecisionRoute,
 ) -> dict[str, Any]:
     agent_scope_action = _agent_scope_frontier_action(route.effective_action)
+    execution_obligation = _execution_obligation(
+        should_run=route.should_run,
+        effective_action=route.effective_action,
+        heartbeat_recommendation=route.heartbeat_recommendation,
+        work_lane_contract=route.payload_work_lane_contract,
+        external_evidence_observation=route.external_evidence_observation,
+    )
+    # Single-field mirror so heartbeat prompts can stay thin: agents key work
+    # obligation off this boolean instead of parsing notify semantics.
+    route.heartbeat_recommendation["agent_must_attempt"] = bool(
+        execution_obligation.get("must_attempt_work")
+    )
     payload = {
         **_standing_decision_authority_payload_from_status_item(
             prepared.item,
@@ -904,13 +916,7 @@ def _build_quota_should_run_payload(
         ),
         "handoff_readiness": prepared.item.get("handoff_readiness"),
         "heartbeat_recommendation": route.heartbeat_recommendation,
-        "execution_obligation": _execution_obligation(
-            should_run=route.should_run,
-            effective_action=route.effective_action,
-            heartbeat_recommendation=route.heartbeat_recommendation,
-            work_lane_contract=route.payload_work_lane_contract,
-            external_evidence_observation=route.external_evidence_observation,
-        ),
+        "execution_obligation": execution_obligation,
         "goal_boundary": prepared.goal_boundary,
         "goal_frontier_projection": prepared.goal_frontier_projection,
         "plan_summary": prepared.plan.get("summary"),

--- a/tests/control_plane/test_heartbeat_notification_rule.py
+++ b/tests/control_plane/test_heartbeat_notification_rule.py
@@ -1,0 +1,52 @@
+"""Regression tests for the heartbeat notify/execution-obligation wording.
+
+The short notification rule used to read "DONT_NOTIFY=quiet", which agents can
+misread as "do nothing". The rule must qualify DONT_NOTIFY as an output-level
+signal only and keep `execution_obligation.must_attempt_work` as the authority
+for whether a bounded slice must run.
+"""
+
+from __future__ import annotations
+
+from loopx.control_plane.heartbeat.rules import HEARTBEAT_NOTIFICATION_RULE_SHORT
+from loopx.control_plane.heartbeat.task_body import (
+    render_brief_heartbeat_task_body,
+    render_thin_heartbeat_task_body,
+)
+
+
+def test_short_rule_qualifies_dont_notify_as_output_only() -> None:
+    rule = HEARTBEAT_NOTIFICATION_RULE_SHORT
+    assert "DONT_NOTIFY" in rule
+    assert "OUTPUT only" in rule
+    # The old ambiguous mapping must be gone.
+    assert "DONT_NOTIFY=quiet." not in rule
+    assert "execution_obligation.must_attempt_work=true" in rule
+    assert "must_attempt_work=false" in rule
+
+
+def test_rendered_task_bodies_keep_execution_obligation_authority() -> None:
+    kwargs = dict(
+        goal_id="fixture-goal",
+        active_state="active",
+        cli_preflight="",
+        pr_review_pre_quota_command="",
+        quota_guard_command="loopx quota should-run",
+        quota_spend_command="",
+        refresh_state_command="",
+        progress_refresh_state_command="",
+        material_queue_rule="",
+        permission_rule="",
+        cli_bin="loopx",
+        agent_scope_instruction="",
+        expanded_prompt_command="",
+        compact_prompt_command="",
+        brief_prompt_command="",
+        thin_prompt_command="",
+    )
+    for renderer in (render_thin_heartbeat_task_body, render_brief_heartbeat_task_body):
+        body = renderer(**kwargs)
+        assert "execution_obligation.must_attempt_work" in body
+        assert "OUTPUT only" in body
+        # A bare "DONT_NOTIFY=quiet" no-op mapping must never appear in the prompt.
+        assert "DONT_NOTIFY=quiet." not in body

--- a/tests/control_plane/test_heartbeat_notification_rule.py
+++ b/tests/control_plane/test_heartbeat_notification_rule.py
@@ -13,6 +13,19 @@ from loopx.control_plane.heartbeat.task_body import (
     render_brief_heartbeat_task_body,
     render_thin_heartbeat_task_body,
 )
+from loopx.control_plane.scheduler.execution_context import (
+    GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT,
+)
+from loopx.control_plane.testing.quota_fixtures import (
+    quota_status_payload,
+    quota_todo_item,
+    quota_todo_summary,
+)
+from loopx.quota import build_quota_should_run
+
+
+GOAL_ID = "heartbeat-notify-obligation-fixture"
+AGENT_ID = "codex-notify-agent"
 
 
 def test_short_rule_qualifies_dont_notify_as_output_only() -> None:
@@ -21,8 +34,8 @@ def test_short_rule_qualifies_dont_notify_as_output_only() -> None:
     assert "OUTPUT only" in rule
     # The old ambiguous mapping must be gone.
     assert "DONT_NOTIFY=quiet." not in rule
-    assert "execution_obligation.must_attempt_work=true" in rule
-    assert "must_attempt_work=false" in rule
+    assert "heartbeat_recommendation.agent_must_attempt" in rule
+    assert "execution_obligation.must_attempt_work" in rule
 
 
 def test_rendered_task_bodies_keep_execution_obligation_authority() -> None:
@@ -46,7 +59,61 @@ def test_rendered_task_bodies_keep_execution_obligation_authority() -> None:
     )
     for renderer in (render_thin_heartbeat_task_body, render_brief_heartbeat_task_body):
         body = renderer(**kwargs)
+        assert "agent_must_attempt" in body
         assert "execution_obligation.must_attempt_work" in body
         assert "OUTPUT only" in body
         # A bare "DONT_NOTIFY=quiet" no-op mapping must never appear in the prompt.
         assert "DONT_NOTIFY=quiet." not in body
+
+
+def test_heartbeat_recommendation_mirrors_execution_obligation_in_replan() -> None:
+    obligation = {
+        "schema_version": "autonomous_replan_obligation_v0",
+        "required": True,
+        "stall_threshold": 2,
+        "trigger_count": 1,
+        "triggers": [
+            {
+                "kind": "periodic_review_due",
+                "source": "run_history",
+                "agent_id": AGENT_ID,
+            }
+        ],
+        "stop_condition": (
+            "stop after one bounded replan slice writes back a concrete frontier delta"
+        ),
+    }
+    payload = quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        recommended_action="Advance the current lane.",
+        agent_todos=quota_todo_summary(
+            [
+                quota_todo_item(
+                    todo_id="todo_advance",
+                    index=1,
+                    title="Advance the current lane.",
+                    task_class="advancement_task",
+                    claimed_by=AGENT_ID,
+                )
+            ]
+        ),
+        coordination={
+            "agent_model": "peer_v1",
+            "registered_agents": [AGENT_ID],
+        },
+        project_asset_extra={"autonomous_replan_obligation": obligation},
+    )
+    guard = build_quota_should_run(
+        payload,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        scheduler_execution_context=GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT,
+    )
+    assert guard["decision"] == "autonomous_replan_required"
+    heartbeat = guard["heartbeat_recommendation"]
+    obligation = guard["execution_obligation"]
+    assert heartbeat.get("agent_must_attempt") is True
+    assert heartbeat["agent_must_attempt"] is bool(
+        obligation.get("must_attempt_work")
+    )


### PR DESCRIPTION
## Summary

Fix a heartbeat instruction-following trap: the short heartbeat notification rule said `DONT_NOTIFY=quiet`, which agents can misread as "do nothing". When the quota packet also projects `user_channel.notify=DONT_NOTIFY` in `autonomous_replan_required` mode, the agent exits the turn with a minimal writeback and never executes the mandatory replan slice (no required evidence-log read, no replan ACK, no direction change) — a deadlock where every heartbeat repeats the same obligation.

## Changes

- `loopx/control_plane/quota/should_run_packet.py`: the quota packet now projects `heartbeat_recommendation.agent_must_attempt`, a single boolean mirror of `execution_obligation.must_attempt_work`, computed from the same `_execution_obligation` builder (single source of truth).
- `loopx/control_plane/heartbeat/rules.py`: the short notification rule is now unambiguous — `user_channel.notify` controls output only, and execution obligation is keyed off `heartbeat_recommendation.agent_must_attempt` / `execution_obligation.must_attempt_work` (`true` = run a bounded slice and write back even under `DONT_NOTIFY`; quiet no-op only when `false`).
- `docs/status-data-contract.md`: documents the new mirror field and the notify-vs-execution separation.
- `tests/control_plane/test_heartbeat_notification_rule.py`: regression tests that (1) the short rule and rendered thin/brief task bodies never contain the bare `DONT_NOTIFY=quiet` no-op mapping, (2) they reference the machine fields, and (3) `heartbeat_recommendation.agent_must_attempt` mirrors `execution_obligation.must_attempt_work` in an `autonomous_replan_required` packet.

## Validation

- `loopx canary premerge --from-git-diff --goal-id loopx-meta --tier standard`: passed with a valid change-quality receipt.
- Pytest: 57 heartbeat/quota projection tests passed.
- `ruff check --select F` on changed Python files: passed.

## Product note

Keeping the heartbeat prompt thin was a deliberate goal: instead of adding a long prose explanation, the CLI now carries a machine-readable `agent_must_attempt` boolean that thin prompts can reference in one line.
