### PR TITLE
fix(quota): replan turns notify instead of DONT_NOTIFY to prevent quiet no-op misreading

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1447,6 +1447,9 @@ must not be interpreted as an execution gate. `heartbeat_recommendation.
 agent_must_attempt` mirrors `execution_obligation.must_attempt_work` as a
 single-field shortcut so thin heartbeat prompts can key work obligation off
 one boolean instead of parsing notify semantics. If
+`autonomous_replan_required`, `heartbeat_recommendation.notify` is `NOTIFY`:
+replan turns are machine execution contracts and must not be projected as
+`DONT_NOTIFY`, which agents can misread as permission for a quiet no-op. If
 `execution_obligation.kind=external_evidence_observation_required`, ordinary
 delivery is still blocked, but the worker must perform one read-only
 observation or write a compact missing-handle blocker before it may stop. If

--- a/loopx/control_plane/goals/goal_frontier/__init__.py
+++ b/loopx/control_plane/goals/goal_frontier/__init__.py
@@ -1892,7 +1892,7 @@ def build_autonomous_replan_recommendation(
 ) -> dict[str, Any]:
     return {
         "recommended_mode": AUTONOMOUS_REPLAN_REQUIRED_MODE,
-        "notify": "DONT_NOTIFY",
+        "notify": "NOTIFY",
         "replan_obligation": compact_replan_obligation(replan_obligation),
         "spend_policy": (
             "append exactly one heartbeat spend only after executing the selected "
@@ -1901,7 +1901,9 @@ def build_autonomous_replan_recommendation(
         "reason": reason
         or (
             "status exposes an autonomous replan obligation; advance the goal-level "
-            "planning-trigger slice before monitor-only or agent-scope wait classification"
+            "planning-trigger slice before monitor-only or agent-scope wait "
+            "classification; replan turns always notify because DONT_NOTIFY would "
+            "mislead agents into a quiet no-op"
         ),
     }
 

--- a/tests/control_plane/test_heartbeat_notification_rule.py
+++ b/tests/control_plane/test_heartbeat_notification_rule.py
@@ -113,6 +113,11 @@ def test_heartbeat_recommendation_mirrors_execution_obligation_in_replan() -> No
     assert guard["decision"] == "autonomous_replan_required"
     heartbeat = guard["heartbeat_recommendation"]
     obligation = guard["execution_obligation"]
+    assert heartbeat.get("notify") == "NOTIFY"
+    user_channel = (
+        (guard.get("interaction_contract") or {}).get("user_channel") or {}
+    )
+    assert user_channel.get("notify") == "NOTIFY"
     assert heartbeat.get("agent_must_attempt") is True
     assert heartbeat["agent_must_attempt"] is bool(
         obligation.get("must_attempt_work")

--- a/tests/control_plane/test_heartbeat_recommendation_rules.py
+++ b/tests/control_plane/test_heartbeat_recommendation_rules.py
@@ -109,7 +109,7 @@ def test_required_replan_preempts_waiting_user_todo() -> None:
     )
 
     assert recommendation["recommended_mode"] == "autonomous_replan_required"
-    assert recommendation["notify"] == "DONT_NOTIFY"
+    assert recommendation["notify"] == "NOTIFY"
     assert recommendation["replan_obligation"]["trigger_count"] == 1
 
 


### PR DESCRIPTION
## Summary

Autonomous replan turns must never project `DONT_NOTIFY`. The heartbeat prompt and the quota packet already separate user notification from execution obligation (#3152), but a replan turn still carried `notify=DONT_NOTIFY`; agents can anchor on that and exit with a quiet no-op instead of executing the mandatory replan slice (no required read, no ACK, no direction change), leaving the obligation open forever.

## Changes

- `loopx/control_plane/goals/goal_frontier/__init__.py`: `build_autonomous_replan_recommendation` now emits `notify=NOTIFY` (with a reason explaining why), so both `heartbeat_recommendation.notify` and `interaction_contract.user_channel.notify` (which derives from it) flip to `NOTIFY` for every replan turn.
- `docs/status-data-contract.md`: documents that `autonomous_replan_required` uses `NOTIFY`.
- Tests: replan recommendation asserts `NOTIFY`; the packet-level regression asserts `heartbeat_recommendation.notify`, `user_channel.notify`, and `agent_must_attempt` are all consistent in replan mode.

## Validation

- `loopx canary premerge --from-git-diff --goal-id loopx-meta --tier standard`: passed with a valid change-quality receipt.
- Pytest: 43 heartbeat/goal-frontier/quota projection tests passed.
- `ruff check --select F` on changed Python files: passed.
