### PR TITLE
fix(refresh-state): reject maintenance writebacks while autonomous replan is due

### DIFF
--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -33,8 +33,15 @@ from .control_plane.work_items.repair_delta import (
     repair_delta_kinds_have_accountable_progress,
 )
 from .control_plane.work_items.autonomous_replan_ack import (
+    REPLAN_REQUIRED_READ_LIMIT,
     latest_monitor_replan_frontier_identity,
     watch_lane_continuation_todo_ids,
+)
+from .control_plane.runtime.agent_scoped_evidence_log import (
+    build_agent_scoped_evidence_log_command,
+)
+from .control_plane.status.autonomous_replan_projection import (
+    autonomous_replan_obligation_from_runs,
 )
 from .control_plane.runtime.shared_runtime_refresh_projection import (
     build_shared_runtime_projection,
@@ -876,6 +883,62 @@ def render_state_refresh_markdown(payload: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def reject_maintenance_writeback_during_open_replan(
+    *,
+    classification: str,
+    vision_unchanged_reason: str | None,
+    repair_delta_kinds: list[str] | None,
+    autonomous_replan_recorded: bool,
+    newest_first_runs: list[dict[str, Any]] | None,
+    state_text: str,
+    agent_id: str,
+    goal_id: str,
+) -> None:
+    """Reject no-progress writebacks while an autonomous replan is due.
+
+    The quota layer enforces replan evidence passively at projection time; this
+    is the write-time gate so a maintenance writeback cannot keep the obligation
+    open forever. ACK-form writebacks and writebacks that carry a repair delta or
+    a material classification are unaffected.
+    """
+
+    safe_agent_id = str(agent_id or "").strip()
+    if not safe_agent_id or autonomous_replan_recorded:
+        return
+    if repair_delta_kinds:
+        return
+    maintenance_writeback = (
+        str(classification or "").strip().lower() == "source_audit_progress"
+        or bool(vision_unchanged_reason)
+    )
+    if not maintenance_writeback:
+        return
+    agent_todos = parse_active_state_todos(state_text, item_limit=None).get(
+        "agent_todos"
+    )
+    obligation = autonomous_replan_obligation_from_runs(
+        newest_first_runs,
+        agent_todos=agent_todos,
+        agent_id=safe_agent_id,
+    )
+    if not obligation:
+        return
+    obligation_id = str(obligation.get("obligation_id") or "").strip()
+    read_command = build_agent_scoped_evidence_log_command(
+        goal_id=goal_id,
+        agent_id=safe_agent_id,
+        limit=REPLAN_REQUIRED_READ_LIMIT,
+        required_read_id=obligation_id or None,
+    )
+    raise ValueError(
+        "an open autonomous replan obligation requires a replan delta; "
+        "maintenance writebacks (source_audit_progress / unchanged) are rejected "
+        f"while it is open. Read `{read_command}` then write the ACK with "
+        "`loopx refresh-state --classification autonomous_replan_recorded "
+        "--autonomous-replan-recorded --repair-delta-kind <kind> ...`"
+    )
+
+
 def refresh_state_run(
     *,
     registry_path: Path,
@@ -1082,11 +1145,7 @@ def refresh_state_run(
     existing_agent_vision: dict[str, Any] | None = None
     autonomous_replan_frontier_identity: str | None = None
     newest_first_runs: list[dict[str, Any]] = []
-    if normalized_agent_id and (
-        agent_vision_packet is not None
-        or normalized_vision_unchanged_reason
-        or autonomous_replan_recorded
-    ):
+    if normalized_agent_id:
         existing_runs, _ = load_index(
             runtime_root / "goals" / safe_goal_id / "runs" / "index.jsonl"
         )
@@ -1103,6 +1162,16 @@ def refresh_state_run(
             goal_id=safe_goal_id,
             agent_id=normalized_agent_id,
         )
+    reject_maintenance_writeback_during_open_replan(
+        classification=classification,
+        vision_unchanged_reason=normalized_vision_unchanged_reason,
+        repair_delta_kinds=normalized_repair_delta_kinds,
+        autonomous_replan_recorded=autonomous_replan_recorded,
+        newest_first_runs=newest_first_runs,
+        state_text=state_text,
+        agent_id=normalized_agent_id,
+        goal_id=safe_goal_id,
+    )
     if agent_vision_packet is not None:
         agent_vision = normalize_goal_vision_update(
             agent_vision_packet,

--- a/tests/control_plane/test_refresh_state_replan_gate.py
+++ b/tests/control_plane/test_refresh_state_replan_gate.py
@@ -1,0 +1,163 @@
+"""Write-time gate: maintenance writebacks are rejected while replan is due."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from loopx.control_plane.status.autonomous_replan_projection import (
+    AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD,
+)
+from loopx.state_refresh import (
+    reject_maintenance_writeback_during_open_replan,
+    refresh_state_run,
+)
+
+
+GOAL_ID = "replan-gate-fixture"
+AGENT_ID = "codex-replan-gate-agent"
+STATE_TEXT = "# Active Goal State\n"
+
+
+def _durable_runs(count: int) -> list[dict]:
+    return [
+        {
+            "classification": "source_audit_progress",
+            "generated_at": f"2026-08-13T00:{index:02d}:00+00:00",
+            "agent_id": AGENT_ID,
+            "progress_scope": "agent_lane",
+            "delivery_outcome": "surface_only",
+        }
+        for index in reversed(range(count))
+    ]
+
+
+def _call_gate(
+    *,
+    runs: list[dict],
+    classification: str = "source_audit_progress",
+    vision_unchanged_reason: str | None = "无新攻击面，审计维持",
+    repair_delta_kinds: list[str] | None = None,
+    autonomous_replan_recorded: bool = False,
+) -> None:
+    reject_maintenance_writeback_during_open_replan(
+        classification=classification,
+        vision_unchanged_reason=vision_unchanged_reason,
+        repair_delta_kinds=repair_delta_kinds,
+        autonomous_replan_recorded=autonomous_replan_recorded,
+        newest_first_runs=runs,
+        state_text=STATE_TEXT,
+        agent_id=AGENT_ID,
+        goal_id=GOAL_ID,
+    )
+
+
+def test_maintenance_writeback_rejected_when_replan_due() -> None:
+    with pytest.raises(ValueError) as exc:
+        _call_gate(runs=_durable_runs(AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD))
+    message = str(exc.value)
+    assert "autonomous replan obligation" in message
+    assert "source_audit_progress" in message
+    assert "evidence-log" in message
+    assert "--autonomous-replan-recorded" in message
+
+
+def test_maintenance_writeback_rejected_even_without_unchanged_reason() -> None:
+    with pytest.raises(ValueError):
+        _call_gate(
+            runs=_durable_runs(AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD),
+            vision_unchanged_reason=None,
+        )
+
+
+def test_ack_writeback_allowed_under_open_obligation() -> None:
+    _call_gate(
+        runs=_durable_runs(AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD),
+        autonomous_replan_recorded=True,
+    )
+
+
+def test_repair_delta_writeback_allowed_under_open_obligation() -> None:
+    _call_gate(
+        runs=_durable_runs(AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD),
+        repair_delta_kinds=["runnable_todo_set"],
+    )
+
+
+def test_material_classification_allowed_under_open_obligation() -> None:
+    _call_gate(
+        runs=_durable_runs(AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD),
+        classification="validated_progress",
+        vision_unchanged_reason=None,
+    )
+
+
+def test_writeback_allowed_when_replan_not_due() -> None:
+    _call_gate(runs=_durable_runs(5))
+
+
+def test_refresh_state_run_rejects_maintenance_writeback(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    state = (
+        project
+        / ".codex"
+        / "goals"
+        / GOAL_ID
+        / "ACTIVE_GOAL_STATE.md"
+    )
+    state.parent.mkdir(parents=True)
+    state.write_text(STATE_TEXT, encoding="utf-8")
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": str(state.relative_to(project)),
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": [AGENT_ID],
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    runtime_root = tmp_path / "runtime"
+    runs_index = (
+        runtime_root
+        / "goals"
+        / GOAL_ID
+        / "runs"
+        / "index.jsonl"
+    )
+    runs_index.parent.mkdir(parents=True)
+    with runs_index.open("w", encoding="utf-8") as handle:
+        for run in _durable_runs(AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD):
+            handle.write(json.dumps(run) + "\n")
+
+    with pytest.raises(ValueError) as exc:
+        refresh_state_run(
+            registry_path=registry_path,
+            runtime_root_override=str(runtime_root),
+            goal_id=GOAL_ID,
+            project=project,
+            state_file=None,
+            classification="source_audit_progress",
+            recommended_action="Observe the fixture.",
+            delivery_batch_scale="single_surface",
+            delivery_outcome="surface_only",
+            agent_id=AGENT_ID,
+            vision_unchanged_reason="无新攻击面，审计维持",
+            dry_run=False,
+            sync_global=False,
+        )
+    message = str(exc.value)
+    assert "--autonomous-replan-recorded" in message
+    assert "evidence-log" in message


### PR DESCRIPTION
## Summary

Add the missing write-time half of replan evidence enforcement. Replan obligations are derived at quota projection time, and ACK receipts are validated there too, but `refresh-state` accepted maintenance writebacks (e.g. `source_audit_progress` + `vision-unchanged-reason`) while an autonomous replan was due — letting an agent keep the obligation open forever with fake "no new surface" progress.

## Changes

- `loopx/state_refresh.py`: before recording a writeback, derive the current autonomous replan obligation from run history (reusing `autonomous_replan_obligation_from_runs`). If a replan is due and the writeback is maintenance-form (classification `source_audit_progress` or an unchanged reason) with no repair delta and no ACK flag, reject it with a precise error that points at the required evidence-log read and the `--autonomous-replan-recorded` ACK command.
- Escape hatches preserved: ACK-form writebacks, writebacks carrying `repair_delta_kinds`, and material classifications are unaffected.
- `tests/control_plane/test_refresh_state_replan_gate.py`: unit matrix (reject maintenance under due obligation; allow ACK / repair-delta / material classification; allow when not due) plus an integration test through `refresh_state_run`.

## Validation

- `loopx canary premerge --from-git-diff --goal-id loopx-meta --tier standard`: passed with a valid change-quality receipt.
- Pytest: 7 new gate tests + 88 refresh-state/lifecycle/vision regression tests passed.
- `ruff check --select F` on changed Python files: passed.
