### PR TITLE
Surface per-goal token, cost, and duration in the personal workspace

### DIFF
--- a/apps/presentation/dashboard/src/features/personal-workspace/channel-header.tsx
+++ b/apps/presentation/dashboard/src/features/personal-workspace/channel-header.tsx
@@ -1,6 +1,7 @@
 import { Bot, ChevronDown, Menu, RefreshCw } from "lucide-react";
 
 import type { WorkspaceAgentOption, WorkspaceGoal, WorkspaceGoalTab } from "./personal-workspace-model";
+import { goalUsageLabel } from "./personal-workspace-model";
 
 export function ChannelHeader({
   agents,
@@ -29,7 +30,7 @@ export function ChannelHeader({
       <div className="personal-channel-title">
         <h1>{selectedGoal?.title ?? "LoopX 管家"}</h1>
         <p>{selectedGoal
-          ? `${selectedGoal.agentLabel ?? selectedGoal.agentId} · ${selectedGoal.state} · ${selectedGoal.nextSentence}`
+          ? `${selectedGoal.agentLabel ?? selectedGoal.agentId} · ${selectedGoal.state}${goalUsageLabel(selectedGoal.usage) ? ` · ${goalUsageLabel(selectedGoal.usage)}` : ""} · ${selectedGoal.nextSentence}`
           : "跨 Goal 的个人工作入口"}</p>
       </div>
       {selectedGoal ? <nav aria-label="Goal 视图" className="personal-goal-tabs">{(["chat", "tasks", "files"] as const).map((tab) => <button aria-current={selectedGoalTab === tab ? "page" : undefined} key={tab} onClick={() => onSelectGoalTab(tab)} type="button">{tab === "chat" ? "Chat" : tab === "tasks" ? "Tasks" : "Files"}</button>)}</nav> : null}

--- a/apps/presentation/dashboard/src/features/personal-workspace/context-drawer.tsx
+++ b/apps/presentation/dashboard/src/features/personal-workspace/context-drawer.tsx
@@ -25,7 +25,7 @@ import type {
   WorkspaceDrawerSelection,
   WorkspaceTodo,
 } from "./personal-workspace-model";
-import { attentionAgeLabel } from "./personal-workspace-model";
+import { attentionAgeLabel, formatCostUsd, formatDurationMs, formatTokenCount, hasGoalUsage } from "./personal-workspace-model";
 
 const focusableSelector = [
   "a[href]",
@@ -245,7 +245,18 @@ export function ContextDrawer({ agents, callbacks, onClose, selection }: {
 
         {selection.kind === "goal" ? (
           <>
-            <section className="personal-detail-card"><small>{selection.item.state}</small><h3>{selection.item.title}</h3><p>{selection.item.agentSentence}</p></section>
+            <section className="personal-detail-card">
+              <small>{selection.item.state}</small>
+              <h3>{selection.item.title}</h3>
+              <p>{selection.item.agentSentence}</p>
+              {hasGoalUsage(selection.item.usage) ? (
+                <dl>
+                  <div><dt>Tokens 24h / 7d</dt><dd>{formatTokenCount(selection.item.usage.tokens24h)} / {formatTokenCount(selection.item.usage.tokens7d)}</dd></div>
+                  <div><dt>成本 24h / 7d</dt><dd>{formatCostUsd(selection.item.usage.costUsd24h)} / {formatCostUsd(selection.item.usage.costUsd7d)}</dd></div>
+                  <div><dt>运行时长 24h / 7d</dt><dd>{formatDurationMs(selection.item.usage.durationMs24h)} / {formatDurationMs(selection.item.usage.durationMs7d)}</dd></div>
+                </dl>
+              ) : null}
+            </section>
             <div className="personal-drawer-action-grid">
               <button className="personal-secondary-action" onClick={() => callbacks.onRequestScheduleConfig?.("heartbeat", selection.item.goalId)} type="button"><Radio size={16} />设置 Heartbeat</button>
               <button className="personal-secondary-action" onClick={() => callbacks.onRequestScheduleConfig?.("monitor", selection.item.goalId)} type="button"><CalendarClock size={16} />添加定时检查</button>

--- a/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-model.ts
+++ b/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-model.ts
@@ -24,6 +24,15 @@ export type WorkspaceTodo = WorkspaceAgentTodo & {
   ownerLabel?: string | null;
 };
 
+export type WorkspaceGoalUsage = {
+  costUsd7d: number;
+  costUsd24h: number;
+  durationMs7d: number;
+  durationMs24h: number;
+  tokens7d: number;
+  tokens24h: number;
+};
+
 export type WorkspaceGoal = {
   agentId: string;
   agentLabel?: string;
@@ -36,6 +45,7 @@ export type WorkspaceGoal = {
   nextSentence: string;
   state: WorkspaceGoalState;
   title: string;
+  usage?: WorkspaceGoalUsage | null;
 };
 
 export type WorkspaceAttention = {
@@ -275,4 +285,34 @@ export function attentionAgeLabel(updatedAt?: string | null): string | null {
   const days = Math.floor(diff / 86_400_000);
   if (days >= 1) return `${days} 天`;
   return `${Math.floor(diff / 3_600_000)} 小时`;
+}
+
+export function formatTokenCount(value?: number | null): string {
+  const n = value ?? 0;
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+export function formatCostUsd(value?: number | null): string {
+  return `$${(value ?? 0).toFixed(2)}`;
+}
+
+export function formatDurationMs(value?: number | null): string {
+  const ms = value ?? 0;
+  if (ms >= 3_600_000) return `${(ms / 3_600_000).toFixed(1)}h`;
+  if (ms >= 60_000) return `${(ms / 60_000).toFixed(1)}m`;
+  if (ms >= 1_000) return `${Math.round(ms / 1_000)}s`;
+  return `${ms}ms`;
+}
+
+/** True only when a goal has actually reported usage; zeros mean ingestion has not landed yet. */
+export function hasGoalUsage(usage?: WorkspaceGoalUsage | null): usage is WorkspaceGoalUsage {
+  return Boolean(usage && (usage.tokens24h + usage.tokens7d + usage.costUsd24h + usage.costUsd7d + usage.durationMs24h + usage.durationMs7d) > 0);
+}
+
+/** Compact header chip, e.g. "7d 45.6k tokens · $0.42"; null when nothing reported. */
+export function goalUsageLabel(usage?: WorkspaceGoalUsage | null): string | null {
+  if (!hasGoalUsage(usage)) return null;
+  return `7d ${formatTokenCount(usage.tokens7d)} tokens · ${formatCostUsd(usage.costUsd7d)}`;
 }

--- a/apps/presentation/dashboard/src/views/dashboard-page.tsx
+++ b/apps/presentation/dashboard/src/views/dashboard-page.tsx
@@ -5060,6 +5060,7 @@ function answerPersonalManagerQuestion(
 
 function buildPersonalHomeModel(payload: StatusPayload, rows: GoalDirectoryRow[]): PersonalHomeModel {
   const rowById = new Map(rows.map((row) => [row.goal.id, row]));
+  const usageById = shareUsageById(payload.usage_summary);
   const agentRows = buildAgentManagementRows(rows, payload.todo_index, payload.agent_management_projection);
   const allUserTodos = payload.attention_queue.items.flatMap((item, sourceOrder) => {
     const blocking = ["user_or_controller", "controller"].includes(item.waiting_on);
@@ -5124,6 +5125,17 @@ function buildPersonalHomeModel(payload: StatusPayload, rows: GoalDirectoryRow[]
       runEvidence: personalRunEvidence(payload, row),
       state,
       title: personalGoalTitle(goal.id),
+      usage: (() => {
+        const goalUsage = usageById.get(goal.id);
+        return goalUsage ? {
+          costUsd24h: goalUsage.cost_usd_24h,
+          costUsd7d: goalUsage.cost_usd_7d,
+          durationMs24h: goalUsage.duration_ms_24h,
+          durationMs7d: goalUsage.duration_ms_7d,
+          tokens24h: goalUsage.input_tokens_24h + goalUsage.output_tokens_24h,
+          tokens7d: goalUsage.input_tokens_7d + goalUsage.output_tokens_7d,
+        } : null;
+      })(),
     }];
   });
   return {


### PR DESCRIPTION
Wires the `usage_summary` per-goal aggregate from #3117 into the personal Agent workspace merged in #3149.

- Goal channel header shows a compact 7d tokens/cost chip next to the state; the goal detail drawer lists 24h/7d tokens, cost, and duration.
- Follows the #3117 pending-ingestion rule: when a goal has not reported usage, nothing renders instead of misleading zeros.
- Validated: `tsc --noEmit`, personal-workspace contract test, and the browser acceptance smoke (16/16 PASS, observations empty).