### PR TITLE
feat(todos): gate claim/lease authority behind per-goal handoff mode

### DIFF
--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -89,6 +89,7 @@ from .cli_commands import (
     handle_starter_command,
     handle_summary_all_command,
     handle_support_control_command,
+    handle_handoff_mode_command,
     handle_task_lease_command,
     handle_todo_command,
     handle_version_command,
@@ -125,6 +126,7 @@ from .cli_commands import (
     register_status_commands,
     register_summary_all_command,
     register_support_control_commands,
+    register_handoff_mode_command,
     register_task_lease_command,
     register_todo_command,
     register_version_command,
@@ -285,6 +287,7 @@ def build_parser() -> LoopXArgumentParser:
     register_explore_commands(sub, add_subcommand_format)
     register_todo_command(sub, add_subcommand_format)
     register_task_lease_command(sub, add_subcommand_format)
+    register_handoff_mode_command(sub, add_subcommand_format)
     register_quota_command(sub)
 
     return parser
@@ -771,6 +774,15 @@ def main(argv: list[str] | None = None) -> int:
     )
     if task_lease_result is not None:
         return task_lease_result
+
+    handoff_mode_result = handle_handoff_mode_command(
+        args,
+        registry_path=registry_path,
+        output_format=output_format,
+        print_payload=print_payload,
+    )
+    if handoff_mode_result is not None:
+        return handoff_mode_result
 
     if args.command == "quota":
         return handle_quota_command(

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -94,6 +94,7 @@ from .first_run_report import (
 from .dreaming import handle_dreaming_command, register_dreaming_commands
 from .evidence_log import handle_evidence_log_command, register_evidence_log_command
 from .explore import handle_explore_command, register_explore_commands
+from .handoff_mode import handle_handoff_mode_command, register_handoff_mode_command
 from .history import handle_history_command, register_history_command
 from .goal_channel import handle_goal_channel_command, register_goal_channel_commands
 from .lark_inbox import (
@@ -235,6 +236,7 @@ __all__ = [
     "handle_dreaming_command",
     "handle_evidence_log_command",
     "handle_explore_command",
+    "handle_handoff_mode_command",
     "handle_history_command",
     "handle_goal_channel_command",
     "build_lark_issue_fix_reviewer_provider_hooks",
@@ -295,6 +297,7 @@ __all__ = [
     "register_dreaming_commands",
     "register_evidence_log_command",
     "register_explore_commands",
+    "register_handoff_mode_command",
     "register_history_command",
     "register_goal_channel_commands",
     "register_lark_inbox_commands",

--- a/loopx/cli_commands/handoff_mode.py
+++ b/loopx/cli_commands/handoff_mode.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+from ..control_plane.todos.handoff_mode import (
+    HANDOFF_MODE_VALUES,
+    HandoffModeError,
+    set_goal_handoff_mode,
+    show_goal_handoff_mode,
+)
+from ..file_lock import LockAcquireTimeoutError
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+
+
+def render_handoff_mode_markdown(payload: dict[str, object]) -> str:
+    lines = [
+        "# LoopX Goal Handoff Mode",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- action: `{payload.get('action')}`",
+        f"- goal_id: `{payload.get('goal_id')}`",
+    ]
+    if payload.get("handoff_mode"):
+        lines.append(f"- handoff_mode: `{payload.get('handoff_mode')}`")
+    if payload.get("previous_mode"):
+        lines.append(f"- previous_mode: `{payload.get('previous_mode')}`")
+    if payload.get("source"):
+        lines.append(f"- source: `{payload.get('source')}`")
+    if "changed" in payload:
+        lines.append(f"- changed: `{payload.get('changed')}`")
+    if payload.get("error"):
+        lines.append(f"- error: {payload.get('error')}")
+    if payload.get("error_code"):
+        lines.append(f"- error_code: `{payload.get('error_code')}`")
+    claimed = payload.get("claimed_todos")
+    if isinstance(claimed, list) and claimed:
+        lines.append("- claimed open todos:")
+        for item in claimed:
+            if isinstance(item, dict):
+                lines.append(
+                    f"  - `{item.get('todo_id')}` claimed_by=`{item.get('claimed_by')}`"
+                )
+    leases = payload.get("active_leases")
+    if isinstance(leases, list) and leases:
+        lines.append("- time-active leases:")
+        for item in leases:
+            if isinstance(item, dict):
+                lines.append(
+                    f"  - `{item.get('todo_id')}` owner=`{item.get('owner')}` "
+                    f"expires_at=`{item.get('expires_at')}`"
+                )
+    return "\n".join(lines)
+
+
+def register_handoff_mode_command(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    parser = subparsers.add_parser(
+        "handoff-mode",
+        help=(
+            "Show or set the per-goal handoff_mode front-matter field that "
+            "selects which ownership authority governs todo handoffs."
+        ),
+    )
+    add_subcommand_format(parser)
+    parser.add_argument(
+        "handoff_mode_command",
+        choices=["show", "set"],
+        help=(
+            "Use show to read the effective mode (absent front-matter means "
+            "legacy) or set to change it. Setting requires a quiescent goal: "
+            "no open todo with claimed_by and no time-active task lease."
+        ),
+    )
+    parser.add_argument("--goal-id", required=True, help="Goal id whose active state carries the mode.")
+    parser.add_argument(
+        "--mode",
+        choices=list(HANDOFF_MODE_VALUES),
+        help=(
+            "For set, the target mode: legacy keeps today's dual soft-claim + "
+            "hard-lease behavior, soft_claim rejects lease acquire/renew/"
+            "transfer, hard_lease requires the actor to hold the todo's lease "
+            "for ownership changes and makes the completion fence mandatory."
+        ),
+    )
+    parser.add_argument("--project", help="Project root. Defaults to the registry goal repo.")
+    parser.add_argument("--state-file", help="Active goal state path. Defaults to the registry goal state_file.")
+
+
+def handle_handoff_mode_command(
+    args: argparse.Namespace,
+    *,
+    registry_path: Path,
+    output_format: Callable[..., str],
+    print_payload: PrintPayload,
+) -> int | None:
+    if args.command != "handoff-mode":
+        return None
+    path_args = {
+        "project": Path(args.project).expanduser() if args.project else None,
+        "state_file": Path(args.state_file).expanduser() if args.state_file else None,
+    }
+    try:
+        if args.handoff_mode_command == "show":
+            if args.mode:
+                raise ValueError("handoff-mode show does not accept --mode")
+            payload = show_goal_handoff_mode(
+                registry_path=registry_path,
+                goal_id=args.goal_id,
+                **path_args,
+            )
+        else:
+            if not args.mode:
+                raise ValueError("handoff-mode set requires --mode")
+            payload = set_goal_handoff_mode(
+                registry_path=registry_path,
+                goal_id=args.goal_id,
+                mode=args.mode,
+                **path_args,
+            )
+    except HandoffModeError as exc:
+        payload = {
+            "ok": False,
+            "schema_version": "goal_handoff_mode_v0",
+            "action": getattr(args, "handoff_mode_command", None),
+            "goal_id": args.goal_id,
+            "error": str(exc),
+            "error_code": exc.code,
+            **exc.payload,
+        }
+    except LockAcquireTimeoutError as exc:
+        payload = {
+            "ok": False,
+            "schema_version": "goal_handoff_mode_v0",
+            "action": getattr(args, "handoff_mode_command", None),
+            "goal_id": args.goal_id,
+            "error": str(exc),
+            **exc.to_payload(),
+        }
+    except Exception as exc:
+        payload = {
+            "ok": False,
+            "schema_version": "goal_handoff_mode_v0",
+            "action": getattr(args, "handoff_mode_command", None),
+            "goal_id": args.goal_id,
+            "error": str(exc),
+            "error_code": exc.__class__.__name__,
+        }
+    print_payload(payload, output_format(args), render_handoff_mode_markdown)
+    return 0 if payload.get("ok") else 1

--- a/loopx/cli_commands/task_lease.py
+++ b/loopx/cli_commands/task_lease.py
@@ -177,6 +177,9 @@ def handle_task_lease_command(
                     },
                 }
                 if isinstance(failure_details, dict):
+                    task_lease_payload = failure_details.get("task_lease_payload")
+                    if isinstance(task_lease_payload, dict):
+                        payload.update(task_lease_payload)
                     if failure_details.get("conflicts") is not None:
                         payload["conflicts"] = failure_details["conflicts"]
                     if failure_details.get("lease") is not None:
@@ -250,6 +253,7 @@ def handle_task_lease_command(
                 owner=args.owner,
                 idempotency_key=args.idempotency_key,
                 expected_version=args.expected_version,
+                registry_path=registry_path,
             )
         else:
             unsupported = [

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -10,6 +10,7 @@ from ..control_plane.quota.settlement import (
     resolve_heartbeat_settlement_identity,
     settlement_result_payload,
 )
+from ..control_plane.todos.handoff_mode import HandoffModeError
 from ..control_plane.todos.markdown import render_todo_markdown
 from ..control_plane.work_items.task_lease import TaskLeaseError
 from ..file_lock import lock_timeout_error_fields
@@ -815,7 +816,7 @@ def handle_todo_command(
             "error": str(exc),
             **lock_timeout_error_fields(exc),
         }
-        if isinstance(exc, TaskLeaseError):
+        if isinstance(exc, (TaskLeaseError, HandoffModeError)):
             payload["error_code"] = exc.code
             payload.update(exc.payload)
     append_todo_rollout_event(

--- a/loopx/control_plane/todos/completion_fence.py
+++ b/loopx/control_plane/todos/completion_fence.py
@@ -11,12 +11,20 @@ def completed_todo_replay(
     goal_id: str,
     todo_id: str,
     completion_turn_key: str | None,
+    handoff_mode: str,
     mutation_authority: dict[str, Any],
     state_file: str,
     project: str | None,
     dry_run: bool,
 ) -> dict[str, Any] | None:
-    """Return the terminal-idempotent receipt for an already completed Todo."""
+    """Return local terminal-replay response-shape parity for a completed Todo.
+
+    ``handoff_mode`` is the currently resolved goal mode, not a persisted copy
+    of the original completion result. This local replay therefore is not a
+    durable operation receipt and must not be presented as Stage 2 proof.
+    Original effect markers such as a lease fence or handoff-gate override are
+    intentionally absent because this branch performs neither effect.
+    """
 
     if str(todo.get("status") or "") != TODO_STATUS_DONE:
         return None
@@ -34,6 +42,7 @@ def completed_todo_replay(
         "goal_id": goal_id,
         "todo_id": todo_id,
         "status": TODO_STATUS_DONE,
+        "handoff_mode": handoff_mode,
         "mutation_authority": mutation_authority,
         "state_file": state_file,
         "project": project,

--- a/loopx/control_plane/todos/handoff_mode.py
+++ b/loopx/control_plane/todos/handoff_mode.py
@@ -11,8 +11,11 @@ The goal's ACTIVE_GOAL_STATE.md YAML front-matter may declare ``handoff_mode``:
   for cleanup and observability of legacy leftovers.
 * ``hard_lease``: ownership changes on an existing todo require the acting
   agent to hold that todo's time-active task lease, and the completion fence
-  becomes mandatory. The delegated ``coordination.todo_lifecycle_authority``
-  override is the one audited door through the gate.
+  becomes mandatory for both user-role and agent-role todos. An exact linked
+  user-gate decision-scope override changes lifecycle actor attribution only;
+  it does not bypass the fence. The delegated
+  ``coordination.todo_lifecycle_authority`` override is the one audited door
+  through the gate.
 
 The mode lives in the front-matter (not the registry) because the markdown
 file is the artifact that travels across endpoints; lease JSON and registry

--- a/loopx/control_plane/todos/handoff_mode.py
+++ b/loopx/control_plane/todos/handoff_mode.py
@@ -12,8 +12,8 @@ The goal's ACTIVE_GOAL_STATE.md YAML front-matter may declare ``handoff_mode``:
 * ``hard_lease``: ownership changes on an existing todo require the acting
   agent to hold that todo's time-active task lease, and the completion fence
   becomes mandatory for both user-role and agent-role todos. An exact linked
-  user-gate decision-scope override changes lifecycle actor attribution only;
-  it does not bypass the fence. The delegated
+  user-gate decision-scope override authorizes only the exact linked decision
+  transition; it does not bypass the completion fence. The delegated
   ``coordination.todo_lifecycle_authority`` override is the one audited door
   through the gate.
 

--- a/loopx/control_plane/todos/handoff_mode.py
+++ b/loopx/control_plane/todos/handoff_mode.py
@@ -293,13 +293,29 @@ def set_goal_handoff_mode(
     )
     with exclusive_file_lock(resolved_state_file, operation="handoff_mode_set"):
         original = resolved_state_file.read_text(encoding="utf-8")
-        previous = goal_handoff_mode(original)
+        previous_raw = parse_state_frontmatter(original).get(
+            HANDOFF_MODE_FRONTMATTER_KEY
+        )
+        try:
+            previous = normalize_handoff_mode(previous_raw)
+        except HandoffModeError as exc:
+            previous = str(previous_raw or "").strip()
+            previous_mode_fields = {
+                "previous_mode": previous,
+                "previous_mode_valid": False,
+                "previous_mode_error_code": exc.code,
+            }
+        else:
+            previous_mode_fields = {
+                "previous_mode": previous,
+                "previous_mode_valid": True,
+            }
         payload = {
             "ok": True,
             "schema_version": HANDOFF_MODE_SCHEMA_VERSION,
             "action": "set",
             "goal_id": goal_id,
-            "previous_mode": previous,
+            **previous_mode_fields,
             "handoff_mode": requested,
             "state_file": str(resolved_state_file),
         }
@@ -325,7 +341,7 @@ def set_goal_handoff_mode(
                     payload={
                         "goal_id": goal_id,
                         "requested_mode": requested,
-                        "previous_mode": previous,
+                        **previous_mode_fields,
                         "claimed_todos": claimed,
                         "active_leases": leases,
                     },

--- a/loopx/control_plane/todos/handoff_mode.py
+++ b/loopx/control_plane/todos/handoff_mode.py
@@ -22,6 +22,14 @@ file is the artifact that travels across endpoints; lease JSON and registry
 are host-local. Pre-NoKV the file syncs last-writer-wins, so two hosts can
 briefly disagree about the mode; that window is documented, not engineered
 around here.
+
+The v0 transition scan is materialized-state only: it reads open claims from
+the locked ``ACTIVE_GOAL_STATE.md`` text plus time-active local lease files. It
+does not merge the event projection, so a claim that exists only in the event
+log can be missed. A successful switch is therefore not a proof that every
+projection is quiescent. The selected mode's typed per-write gate remains the
+safety boundary for later governed ownership and completion mutations,
+including event-projected completion.
 """
 
 from __future__ import annotations
@@ -49,7 +57,9 @@ DELEGATED_AUTHORITY_MODE = "delegated_orchestration_override"
 class HandoffModeError(ValueError):
     """Typed handoff-mode failure; mirrors TaskLeaseError's code/payload shape."""
 
-    def __init__(self, message: str, *, code: str, payload: dict[str, Any] | None = None) -> None:
+    def __init__(
+        self, message: str, *, code: str, payload: dict[str, Any] | None = None
+    ) -> None:
         super().__init__(message)
         self.code = code
         self.payload = payload or {}
@@ -216,6 +226,14 @@ def _quiescence_offenders(
     goal_id: str,
     state_text: str,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Return blockers visible to the v0 materialized-state scan.
+
+    Event-projection overlays are intentionally outside this pre-NoKV scan.
+    Callers must not interpret an empty result as an authority-wide safety
+    guarantee; later governed writes still cross the selected handoff-mode
+    gate.
+    """
+
     from ..work_items.task_lease import (
         lease_is_active,
         read_lease,
@@ -269,11 +287,14 @@ def set_goal_handoff_mode(
 ) -> dict[str, Any]:
     """Set the goal handoff mode; requires a quiescent goal for transitions.
 
-    Quiescence means no open todo carries a claimed_by owner and no
-    time-active lease file exists under the goal. Transitions on a
-    non-quiescent goal refuse with a typed offender list; there is no force
-    override in v0. Hand-editing the front-matter bypasses this check and is
-    out of contract.
+    In v0, quiescence means no open todo materialized in the locked active-state
+    Markdown carries a claimed_by owner and no time-active lease file exists
+    under the goal. The scan does not overlay event-only todos, so success is a
+    pre-NoKV migration check rather than an authority-wide safety guarantee;
+    every later governed ownership or completion write still crosses the
+    selected mode's typed gate. Visible non-quiescence refuses with a typed
+    offender list and there is no force override. Hand-editing the front-matter
+    bypasses this check and is out of contract.
     """
 
     from ...file_lock import exclusive_file_lock
@@ -352,11 +373,16 @@ def set_goal_handoff_mode(
             lines = original.splitlines()
             open_index, close_index = _frontmatter_bounds(lines)
             for index in range(open_index, close_index):
-                if lines[index].split(":", 1)[0].strip() == HANDOFF_MODE_FRONTMATTER_KEY:
+                if (
+                    lines[index].split(":", 1)[0].strip()
+                    == HANDOFF_MODE_FRONTMATTER_KEY
+                ):
                     lines[index] = f"{HANDOFF_MODE_FRONTMATTER_KEY}: {requested}"
                     break
             else:
-                lines.insert(close_index, f"{HANDOFF_MODE_FRONTMATTER_KEY}: {requested}")
+                lines.insert(
+                    close_index, f"{HANDOFF_MODE_FRONTMATTER_KEY}: {requested}"
+                )
             new_text = "\n".join(lines) + ("\n" if original.endswith("\n") else "")
             resolved_state_file.write_text(new_text, encoding="utf-8")
     payload["changed"] = True

--- a/loopx/control_plane/todos/handoff_mode.py
+++ b/loopx/control_plane/todos/handoff_mode.py
@@ -1,0 +1,344 @@
+"""Per-goal handoff mode: which ownership authority governs todo handoffs.
+
+The goal's ACTIVE_GOAL_STATE.md YAML front-matter may declare ``handoff_mode``:
+
+* absent / ``legacy`` (default): today's dual soft-claim + hard-lease
+  behavior, byte-for-byte. The known soft-claim/hard-lease split brain stays
+  open in this mode by design; it is surfaced additively, never silently
+  repaired.
+* ``soft_claim``: the markdown claim is the only ownership record. Task-lease
+  acquire/renew/transfer are typed-rejected; release and inspect stay allowed
+  for cleanup and observability of legacy leftovers.
+* ``hard_lease``: ownership changes on an existing todo require the acting
+  agent to hold that todo's time-active task lease, and the completion fence
+  becomes mandatory. The delegated ``coordination.todo_lifecycle_authority``
+  override is the one audited door through the gate.
+
+The mode lives in the front-matter (not the registry) because the markdown
+file is the artifact that travels across endpoints; lease JSON and registry
+are host-local. Pre-NoKV the file syncs last-writer-wins, so two hosts can
+briefly disagree about the mode; that window is documented, not engineered
+around here.
+"""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from pathlib import Path
+from typing import Any
+
+from ..goals.active_state_metadata import parse_state_frontmatter
+from .contract import normalize_todo_claimed_by
+
+HANDOFF_MODE_SCHEMA_VERSION = "goal_handoff_mode_v0"
+HANDOFF_MODE_FRONTMATTER_KEY = "handoff_mode"
+HANDOFF_MODE_LEGACY = "legacy"
+HANDOFF_MODE_SOFT_CLAIM = "soft_claim"
+HANDOFF_MODE_HARD_LEASE = "hard_lease"
+HANDOFF_MODE_VALUES = (
+    HANDOFF_MODE_LEGACY,
+    HANDOFF_MODE_SOFT_CLAIM,
+    HANDOFF_MODE_HARD_LEASE,
+)
+DELEGATED_AUTHORITY_MODE = "delegated_orchestration_override"
+
+
+class HandoffModeError(ValueError):
+    """Typed handoff-mode failure; mirrors TaskLeaseError's code/payload shape."""
+
+    def __init__(self, message: str, *, code: str, payload: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.payload = payload or {}
+
+
+def normalize_handoff_mode(value: Any) -> str:
+    candidate = str(value or "").strip()
+    if not candidate:
+        return HANDOFF_MODE_LEGACY
+    if candidate not in HANDOFF_MODE_VALUES:
+        raise HandoffModeError(
+            f"unsupported handoff_mode {candidate!r}; expected one of: "
+            + ", ".join(HANDOFF_MODE_VALUES),
+            code="invalid_handoff_mode",
+            payload={"handoff_mode": candidate, "supported": list(HANDOFF_MODE_VALUES)},
+        )
+    return candidate
+
+
+def goal_handoff_mode(state_text: str) -> str:
+    """Read the goal handoff mode from active-state text; absent means legacy."""
+
+    front_matter = parse_state_frontmatter(state_text)
+    return normalize_handoff_mode(front_matter.get(HANDOFF_MODE_FRONTMATTER_KEY))
+
+
+def _resolve_state(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    project: Path | None = None,
+    state_file: Path | None = None,
+) -> tuple[Path | None, Path]:
+    from ...todos import resolve_todo_state_path
+
+    return resolve_todo_state_path(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        project=project,
+        state_file=state_file,
+    )
+
+
+def goal_handoff_mode_for_goal(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    project: Path | None = None,
+    state_file: Path | None = None,
+) -> str:
+    _project, resolved_state_file = _resolve_state(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        project=project,
+        state_file=state_file,
+    )
+    return goal_handoff_mode(resolved_state_file.read_text(encoding="utf-8"))
+
+
+def enter_todo_ownership_handoff_gate(
+    stack: ExitStack,
+    *,
+    state_text: str,
+    registry_path: Path,
+    goal_id: str,
+    todo_id: str,
+    mutation_authority: dict[str, Any],
+    actor_agent_id: str | None,
+    ownership_mutation: bool,
+) -> dict[str, Any]:
+    """Gate one claimed_by mutation on an existing todo behind the goal mode.
+
+    Returns additive payload fields (always ``handoff_mode``; plus the door
+    marker or the held holder-gate receipt in hard_lease mode). In hard_lease
+    mode the per-goal lease lock is entered on ``stack`` so it stays held
+    through the markdown commit, matching the completion fence's
+    state-lock-then-lease-lock order.
+    """
+
+    mode = goal_handoff_mode(state_text)
+    extras: dict[str, Any] = {"handoff_mode": mode}
+    if not ownership_mutation or mode != HANDOFF_MODE_HARD_LEASE:
+        return extras
+    if mutation_authority.get("mode") == DELEGATED_AUTHORITY_MODE:
+        extras["handoff_gate_overridden"] = True
+        return extras
+    from ..work_items.task_lease import hold_handoff_lease_holder_gate
+
+    extras["task_lease_holder_gate"] = stack.enter_context(
+        hold_handoff_lease_holder_gate(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            todo_id=todo_id,
+            actor_agent_id=actor_agent_id,
+        )
+    )
+    return extras
+
+
+def resolve_todo_completion_handoff(
+    *,
+    state_text: str,
+    mutation_authority: dict[str, Any],
+) -> dict[str, Any]:
+    """Resolve mode plus the delegated-authority door for one todo completion."""
+
+    mode = goal_handoff_mode(state_text)
+    extras: dict[str, Any] = {"handoff_mode": mode}
+    if (
+        mode == HANDOFF_MODE_HARD_LEASE
+        and mutation_authority.get("mode") == DELEGATED_AUTHORITY_MODE
+    ):
+        extras["handoff_gate_overridden"] = True
+    return extras
+
+
+def show_goal_handoff_mode(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    project: Path | None = None,
+    state_file: Path | None = None,
+) -> dict[str, Any]:
+    _project, resolved_state_file = _resolve_state(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        project=project,
+        state_file=state_file,
+    )
+    front_matter = parse_state_frontmatter(
+        resolved_state_file.read_text(encoding="utf-8")
+    )
+    raw = front_matter.get(HANDOFF_MODE_FRONTMATTER_KEY)
+    return {
+        "ok": True,
+        "schema_version": HANDOFF_MODE_SCHEMA_VERSION,
+        "action": "show",
+        "goal_id": goal_id,
+        "handoff_mode": normalize_handoff_mode(raw),
+        "source": "frontmatter" if str(raw or "").strip() else "default",
+        "state_file": str(resolved_state_file),
+    }
+
+
+def _frontmatter_bounds(lines: list[str]) -> tuple[int, int]:
+    if not lines or lines[0].strip() != "---":
+        raise HandoffModeError(
+            "active state file has no YAML front-matter; add one before setting "
+            "handoff_mode",
+            code="state_frontmatter_missing",
+        )
+    for index in range(1, len(lines)):
+        if lines[index].strip() == "---":
+            return 1, index
+    raise HandoffModeError(
+        "active state front-matter is not terminated by ---",
+        code="state_frontmatter_missing",
+    )
+
+
+def _quiescence_offenders(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    state_text: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    from ..work_items.task_lease import (
+        lease_is_active,
+        read_lease,
+        runtime_root_from_registry,
+        task_lease_dir,
+    )
+    from .active_state_todo_parser import parse_active_state_todos
+
+    claimed: list[dict[str, Any]] = []
+    todos = parse_active_state_todos(state_text, item_limit=None)
+    for role in ("user_todos", "agent_todos"):
+        summary = todos.get(role)
+        items = summary.get("items") if isinstance(summary, dict) else []
+        for item in items or []:
+            if not isinstance(item, dict) or item.get("done") is True:
+                continue
+            owner = normalize_todo_claimed_by(item.get("claimed_by"))
+            if owner:
+                claimed.append(
+                    {
+                        "todo_id": item.get("todo_id"),
+                        "claimed_by": owner,
+                        "status": item.get("status"),
+                    }
+                )
+    leases: list[dict[str, Any]] = []
+    runtime_root = runtime_root_from_registry(registry_path, None)
+    lease_dir = task_lease_dir(runtime_root=runtime_root, goal_id=goal_id)
+    if lease_dir.exists():
+        for path in sorted(lease_dir.glob("todo_*.json")):
+            lease = read_lease(path)
+            if lease_is_active(lease):
+                leases.append(
+                    {
+                        "todo_id": lease.get("todo_id"),
+                        "owner": lease.get("owner"),
+                        "expires_at": lease.get("expires_at"),
+                        "lease_path": str(path),
+                    }
+                )
+    return claimed, leases
+
+
+def set_goal_handoff_mode(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    mode: str,
+    project: Path | None = None,
+    state_file: Path | None = None,
+) -> dict[str, Any]:
+    """Set the goal handoff mode; requires a quiescent goal for transitions.
+
+    Quiescence means no open todo carries a claimed_by owner and no
+    time-active lease file exists under the goal. Transitions on a
+    non-quiescent goal refuse with a typed offender list; there is no force
+    override in v0. Hand-editing the front-matter bypasses this check and is
+    out of contract.
+    """
+
+    from ...file_lock import exclusive_file_lock
+    from ..work_items.task_lease import (
+        runtime_root_from_registry,
+        task_lease_lock_path,
+    )
+
+    requested = normalize_handoff_mode(mode)
+    if not str(mode or "").strip():
+        raise HandoffModeError(
+            "handoff-mode set requires an explicit --mode value",
+            code="invalid_handoff_mode",
+        )
+    _project, resolved_state_file = _resolve_state(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        project=project,
+        state_file=state_file,
+    )
+    with exclusive_file_lock(resolved_state_file, operation="handoff_mode_set"):
+        original = resolved_state_file.read_text(encoding="utf-8")
+        previous = goal_handoff_mode(original)
+        payload = {
+            "ok": True,
+            "schema_version": HANDOFF_MODE_SCHEMA_VERSION,
+            "action": "set",
+            "goal_id": goal_id,
+            "previous_mode": previous,
+            "handoff_mode": requested,
+            "state_file": str(resolved_state_file),
+        }
+        if previous == requested:
+            payload["changed"] = False
+            return payload
+        lease_lock = task_lease_lock_path(
+            runtime_root=runtime_root_from_registry(registry_path, None),
+            goal_id=goal_id,
+        )
+        with exclusive_file_lock(lease_lock, operation="handoff_mode_set"):
+            claimed, leases = _quiescence_offenders(
+                registry_path=registry_path,
+                goal_id=goal_id,
+                state_text=original,
+            )
+            if claimed or leases:
+                raise HandoffModeError(
+                    "handoff_mode can only change while the goal is quiescent: "
+                    f"{len(claimed)} claimed open todo(s), "
+                    f"{len(leases)} time-active lease(s)",
+                    code="handoff_mode_not_quiescent",
+                    payload={
+                        "goal_id": goal_id,
+                        "requested_mode": requested,
+                        "previous_mode": previous,
+                        "claimed_todos": claimed,
+                        "active_leases": leases,
+                    },
+                )
+            lines = original.splitlines()
+            open_index, close_index = _frontmatter_bounds(lines)
+            for index in range(open_index, close_index):
+                if lines[index].split(":", 1)[0].strip() == HANDOFF_MODE_FRONTMATTER_KEY:
+                    lines[index] = f"{HANDOFF_MODE_FRONTMATTER_KEY}: {requested}"
+                    break
+            else:
+                lines.insert(close_index, f"{HANDOFF_MODE_FRONTMATTER_KEY}: {requested}")
+            new_text = "\n".join(lines) + ("\n" if original.endswith("\n") else "")
+            resolved_state_file.write_text(new_text, encoding="utf-8")
+    payload["changed"] = True
+    return payload

--- a/loopx/control_plane/todos/handoff_mode.py
+++ b/loopx/control_plane/todos/handoff_mode.py
@@ -159,6 +159,61 @@ def enter_todo_ownership_handoff_gate(
     return extras
 
 
+def enter_added_todo_ownership_handoff_gate(
+    stack: ExitStack,
+    *,
+    lines: list[str],
+    state_text: str,
+    registry_path: Path,
+    goal_id: str,
+    role: str,
+    text: str,
+    claimed_by: str | None,
+    actor_agent_id: str | None,
+) -> dict[str, Any]:
+    """Gate the ``todo add`` path when it would reassign an existing todo.
+
+    ``todo add`` matches an open todo by text and upserts its metadata, so a
+    ``claimed_by`` argument on that branch changes the claim of a todo that
+    may already hold a lease. Creating a todo stays ungated in every mode: a
+    todo id that does not exist yet cannot hold one. Re-adding a todo with the
+    claim it already carries is not an ownership change and is not gated.
+
+    The delegated-authority door is not offered here. Reassignment under a
+    ``coordination.todo_lifecycle_authority`` grant goes through
+    ``todo update --claimed-by``, which is the verb that owns that action.
+    """
+
+    from ...todos import matching_todo_block  # loopx.todos, deferred: import cycle
+    from .active_state_editing import section_bounds
+
+    bounds = section_bounds(lines, role)
+    existing = (
+        matching_todo_block(
+            lines, bounds[0], bounds[1], text, role=role, source_section=bounds[2]
+        )
+        if bounds
+        else None
+    )
+    requested = normalize_todo_claimed_by(claimed_by) if claimed_by else None
+    current = normalize_todo_claimed_by(existing.get("claimed_by")) if existing else None
+    return enter_todo_ownership_handoff_gate(
+        stack,
+        state_text=state_text,
+        registry_path=registry_path,
+        goal_id=goal_id,
+        todo_id=str(existing.get("todo_id") or "") if existing else "",
+        mutation_authority={},
+        actor_agent_id=actor_agent_id,
+        ownership_mutation=(
+            role == "agent"
+            and existing is not None
+            and requested is not None
+            and requested != current
+        ),
+    )
+
+
 def resolve_todo_completion_handoff(
     *,
     state_text: str,

--- a/loopx/control_plane/todos/list_projection.py
+++ b/loopx/control_plane/todos/list_projection.py
@@ -84,6 +84,42 @@ def _compact_item(value: Any) -> Any:
     return compact
 
 
+def todo_item_relations(item: dict[str, Any]) -> dict[str, Any]:
+    """Project the stable relationship fields for one todo list item."""
+
+    relations: dict[str, Any] = {}
+    for key in (
+        "claimed_by",
+        "bound_agent",
+        "goal_bound",
+        "blocks_agent",
+        "excluded_agents",
+        "global_gate",
+        "unblocks_todo_id",
+        "successor_todo_ids",
+        "superseded_by",
+        "resume_when",
+        "resume_condition",
+        "resume_ready",
+        "decision_scope",
+        "required_decision_scopes",
+        "required_write_scopes",
+        "required_capabilities",
+        "target_capabilities",
+        "task_class",
+        "action_kind",
+        "continuation_policy",
+        "target_key",
+        "cadence",
+        "next_due_at",
+        "expires_at",
+    ):
+        value = item.get(key)
+        if value is not None and value != []:
+            relations[key] = value
+    return relations
+
+
 def compact_agent_lane_todo_summary(
     summary: dict[str, Any],
     *,

--- a/loopx/control_plane/work_items/task_lease.py
+++ b/loopx/control_plane/work_items/task_lease.py
@@ -24,7 +24,13 @@ from ..todos.contract import (
     normalize_todo_excluded_agents,
     normalize_todo_id,
 )
-
+from ..todos.handoff_mode import (
+    HANDOFF_MODE_HARD_LEASE,
+    HANDOFF_MODE_LEGACY,
+    HANDOFF_MODE_SOFT_CLAIM,
+    HandoffModeError,
+    goal_handoff_mode_for_goal,
+)
 
 TASK_LEASE_SCHEMA_VERSION = "task_lease_v0"
 DEFAULT_TASK_LEASE_TTL_SECONDS = 45 * 60
@@ -112,6 +118,138 @@ class _VerifiedTaskLeaseFence(dict):
     release_hook: Callable[[], None] | None = None
 
 
+def goal_handoff_mode_for_lease(registry_path: Path, goal_id: str) -> str:
+    """Resolve the goal handoff mode for lease verbs.
+
+    An invalid ``handoff_mode`` value is re-typed as a TaskLeaseError. A goal
+    or state file that cannot be resolved falls back to legacy: each lease
+    verb's own todo-projection checks already own that failure surface.
+    """
+
+    try:
+        return goal_handoff_mode_for_goal(registry_path=registry_path, goal_id=goal_id)
+    except HandoffModeError as exc:
+        raise TaskLeaseError(str(exc), code=exc.code, payload=exc.payload) from exc
+    except (OSError, ValueError):
+        return HANDOFF_MODE_LEGACY
+
+
+def _require_lease_mutation_allowed_by_handoff_mode(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    todo_id: str,
+    action: str,
+) -> str:
+    handoff_mode = goal_handoff_mode_for_lease(registry_path, goal_id)
+    if handoff_mode == HANDOFF_MODE_SOFT_CLAIM:
+        raise TaskLeaseError(
+            f"goal handoff mode 'soft_claim' forbids task lease {action}; "
+            "release and inspect remain available for legacy leftovers",
+            code="handoff_mode_forbids_lease",
+            payload={
+                "goal_id": goal_id,
+                "todo_id": todo_id,
+                "action": action,
+                "handoff_mode": handoff_mode,
+            },
+        )
+    return handoff_mode
+
+
+def _optional_handoff_mode(registry_path: Path | None, goal_id: str) -> str | None:
+    if registry_path is None:
+        return None
+    try:
+        return goal_handoff_mode_for_lease(registry_path, goal_id)
+    except (TaskLeaseError, OSError, ValueError):
+        return None
+
+
+@contextmanager
+def hold_handoff_lease_holder_gate(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    todo_id: str,
+    actor_agent_id: str | None,
+) -> Iterator[dict[str, Any]]:
+    """Hold the per-goal lease lock while proving the actor owns the lease.
+
+    hard_lease handoff mode only: an ownership mutation (claim, claimed_by
+    update, clear) on an existing todo requires the acting agent to hold that
+    todo's time-active lease. Identity is compared with
+    normalize_todo_claimed_by on both sides. Callers must already hold the
+    markdown state lock; this guard then takes the per-goal lease lock, the
+    same markdown-lock-then-lease-lock order used by the completion fence,
+    and the caller keeps it held until the markdown write commits.
+    """
+
+    normalized_goal_id = normalize_goal_id(goal_id)
+    normalized_todo_id = normalize_lease_todo_id(todo_id)
+    actor = normalize_todo_claimed_by(actor_agent_id)
+    runtime_root = runtime_root_from_registry(registry_path, None)
+    lease_path = task_lease_path(
+        runtime_root=runtime_root,
+        goal_id=normalized_goal_id,
+        todo_id=normalized_todo_id,
+    )
+    base_payload: dict[str, Any] = {
+        "goal_id": normalized_goal_id,
+        "todo_id": normalized_todo_id,
+        "handoff_mode": HANDOFF_MODE_HARD_LEASE,
+        "lease_path": str(lease_path),
+    }
+    if not actor:
+        raise TaskLeaseError(
+            "hard_lease handoff mode requires an attributed actor for "
+            "ownership changes; provide --agent-id",
+            code="handoff_mode_requires_lease",
+            payload={**base_payload, "reason": "missing_actor"},
+        )
+    lock_target = task_lease_lock_path(
+        runtime_root=runtime_root,
+        goal_id=normalized_goal_id,
+    )
+    with exclusive_file_lock(
+        lock_target,
+        agent_id=actor,
+        operation="handoff_lease_holder_gate",
+    ):
+        lease = read_lease(lease_path)
+        if not lease_is_active(lease):
+            raise TaskLeaseError(
+                "hard_lease handoff mode requires a time-active task lease "
+                "before ownership of an existing todo can change; acquire one "
+                "with `loopx task-lease acquire`",
+                code="handoff_mode_requires_lease",
+                payload={**base_payload, "reason": "no_active_lease"},
+            )
+        assert lease is not None
+        owner = normalize_todo_claimed_by(lease.get("owner"))
+        if owner != actor:
+            raise TaskLeaseError(
+                f"hard_lease handoff mode: actor {actor!r} does not own the "
+                f"time-active task lease held by {owner!r}",
+                code="handoff_mode_requires_lease",
+                payload={
+                    **base_payload,
+                    "reason": "lease_owner_mismatch",
+                    "actor_agent_id": actor,
+                    "lease_owner": owner,
+                    "lease_version": lease.get("version"),
+                    "expires_at": lease.get("expires_at"),
+                },
+            )
+        yield {
+            "schema_version": TASK_LEASE_SCHEMA_VERSION,
+            "checked": True,
+            "active": True,
+            "owner": owner,
+            "version": lease.get("version"),
+        }
+
+
 @contextmanager
 def hold_task_lease_mutation_fence(
     *,
@@ -123,14 +261,22 @@ def hold_task_lease_mutation_fence(
     idempotency_key: str | None,
     expected_version: int | None = None,
     require_active_when_key_supplied: bool = True,
+    handoff: dict[str, Any] | None = None,
 ) -> Iterator[dict[str, Any]]:
     """Hold the per-goal lease lock while one todo lifecycle write commits.
 
-    Task leases are optional. Once an effective lease exists, however, the
-    lifecycle writer must prove that it is the execution instance that acquired
-    the lease. The idempotency key is the execution-instance fence; agent ids
-    alone are insufficient because multiple host processes may share one peer
-    identity.
+    Task leases are optional in legacy and soft_claim handoff modes. Once an
+    effective lease exists, however, the lifecycle writer must prove that it
+    is the execution instance that acquired the lease. The idempotency key is
+    the execution-instance fence; agent ids alone are insufficient because
+    multiple host processes may share one peer identity.
+
+    ``handoff`` carries the resolved goal handoff mode plus the delegated
+    authority door marker. In hard_lease mode (without the door) the fence is
+    mandatory: no effective lease is a typed error instead of a silent
+    ``{"required": False}``, and a time-active lease whose owner constraint is
+    no longer effective (the legacy self-disarm state) fails loudly instead of
+    letting a keyless completion through.
     """
 
     normalized_goal_id = normalize_goal_id(goal_id)
@@ -150,13 +296,18 @@ def hold_task_lease_mutation_fence(
         runtime_root=runtime_root,
         goal_id=normalized_goal_id,
     )
+    handoff = handoff or {}
+    handoff_mode = str(handoff.get("handoff_mode") or HANDOFF_MODE_LEGACY)
+    handoff_gate_overridden = handoff.get("handoff_gate_overridden") is True
     with exclusive_file_lock(
         lock_target,
         agent_id=actor_agent_id,
         operation="task_lease_mutation_fence",
     ):
         lease = read_lease(lease_path)
-        active = lease_is_active(lease)
+        time_active = lease_is_active(lease)
+        active = time_active
+        constraint: dict[str, Any] | None = None
         if active and lease:
             constraint = task_lease_owner_constraint(
                 todo,
@@ -169,6 +320,36 @@ def hold_task_lease_mutation_fence(
             active = constraint.get("effective") is True
 
         if not active:
+            if handoff_mode == HANDOFF_MODE_HARD_LEASE and not handoff_gate_overridden:
+                if time_active and lease:
+                    raise TaskLeaseError(
+                        "hard_lease handoff mode found a time-active lease "
+                        "diverged from the todo projection; refusing keyless "
+                        "completion. Repair ownership (release or transfer the "
+                        "lease, or restore claimed_by) before completing.",
+                        code="handoff_mode_lease_claim_divergence",
+                        payload={
+                            "goal_id": normalized_goal_id,
+                            "todo_id": normalized_todo_id,
+                            "handoff_mode": handoff_mode,
+                            "lease_owner": lease.get("owner"),
+                            "lease_version": lease.get("version"),
+                            "constraint": constraint,
+                            "lease_path": str(lease_path),
+                        },
+                    )
+                raise TaskLeaseError(
+                    "hard_lease handoff mode requires an effective task lease "
+                    "to complete this todo; acquire one with "
+                    "`loopx task-lease acquire`",
+                    code="handoff_mode_requires_lease",
+                    payload={
+                        "goal_id": normalized_goal_id,
+                        "todo_id": normalized_todo_id,
+                        "handoff_mode": handoff_mode,
+                        "lease_path": str(lease_path),
+                    },
+                )
             if (
                 require_active_when_key_supplied
                 and (requested_key is not None or expected_version is not None)
@@ -649,6 +830,12 @@ def acquire_task_lease(
         agent_id=owner,
         operation="task_lease_acquire",
     ):
+        handoff_mode = _require_lease_mutation_allowed_by_handoff_mode(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            todo_id=todo_id,
+            action="acquire",
+        )
         todo = require_task_lease_owner_allowed(
             registry_path=registry_path,
             goal_id=goal_id,
@@ -697,6 +884,7 @@ def acquire_task_lease(
                     "idempotent": True,
                     "lease": existing,
                     "lease_path": str(lease_path),
+                    "handoff_mode": handoff_mode,
                 }
             raise TaskLeaseError(
                 "todo already has an active lease",
@@ -741,6 +929,7 @@ def acquire_task_lease(
             "idempotent": False,
             "lease": lease,
             "lease_path": str(lease_path),
+            "handoff_mode": handoff_mode,
         }
 
 
@@ -768,6 +957,12 @@ def renew_task_lease(
         agent_id=owner,
         operation="task_lease_renew",
     ):
+        handoff_mode = _require_lease_mutation_allowed_by_handoff_mode(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            todo_id=todo_id,
+            action="renew",
+        )
         require_task_lease_owner_allowed(
             registry_path=registry_path,
             goal_id=goal_id,
@@ -792,6 +987,7 @@ def renew_task_lease(
             "renewed": True,
             "lease": lease,
             "lease_path": str(lease_path),
+            "handoff_mode": handoff_mode,
         }
 
 
@@ -823,6 +1019,12 @@ def transfer_task_lease(
         agent_id=owner,
         operation="task_lease_transfer",
     ):
+        handoff_mode = _require_lease_mutation_allowed_by_handoff_mode(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            todo_id=todo_id,
+            action="transfer",
+        )
         require_registered_task_lease_owner(
             registry_path=registry_path,
             goal_id=goal_id,
@@ -855,6 +1057,7 @@ def transfer_task_lease(
             "transferred": True,
             "lease": lease,
             "lease_path": str(lease_path),
+            "handoff_mode": handoff_mode,
         }
 
 
@@ -866,11 +1069,16 @@ def release_task_lease(
     owner: str,
     idempotency_key: str,
     expected_version: int | None = None,
+    registry_path: Path | None = None,
 ) -> dict[str, Any]:
     goal_id = normalize_goal_id(goal_id)
     todo_id = normalize_lease_todo_id(todo_id)
     owner = normalize_owner(owner)
     idempotency_key = normalize_idempotency_key(idempotency_key)
+    # Release stays allowed in every handoff mode (cleanup of legacy
+    # leftovers); the mode is reported additively when resolvable.
+    handoff_mode = _optional_handoff_mode(registry_path, goal_id)
+    handoff_extra = {"handoff_mode": handoff_mode} if handoff_mode else {}
     lock_target = task_lease_lock_path(runtime_root=runtime_root, goal_id=goal_id)
     lease_path = task_lease_path(runtime_root=runtime_root, goal_id=goal_id, todo_id=todo_id)
     at = now_utc()
@@ -889,6 +1097,7 @@ def release_task_lease(
                 "released": False,
                 "missing": True,
                 "lease_path": str(lease_path),
+                **handoff_extra,
             }
         if lease_is_active(lease, at=at) and (
             lease.get("owner") != owner or lease.get("idempotency_key") != idempotency_key
@@ -906,6 +1115,7 @@ def release_task_lease(
             "released": True,
             "lease": released_lease,
             "lease_path": str(lease_path),
+            **handoff_extra,
         }
 
 
@@ -945,6 +1155,7 @@ def inspect_task_lease(
                 active = False
             else:
                 executor_constraint = None
+    handoff_mode = _optional_handoff_mode(registry_path, goal_id)
     return {
         "ok": True,
         "schema_version": TASK_LEASE_SCHEMA_VERSION,
@@ -954,5 +1165,6 @@ def inspect_task_lease(
         "active": active,
         "lease": lease,
         "lease_path": str(lease_path),
+        **({"handoff_mode": handoff_mode} if handoff_mode else {}),
         **({"executor_constraint": executor_constraint} if executor_constraint else {}),
     }

--- a/loopx/control_plane/work_items/task_lease_settlement.py
+++ b/loopx/control_plane/work_items/task_lease_settlement.py
@@ -57,16 +57,18 @@ def _typed_failure(
     step_kind: SettlementStepKind,
     reason: str,
     code: str | None = None,
+    task_lease_payload: dict[str, Any] | None = None,
 ) -> SettlementResult[Any]:
+    details: dict[str, Any] = {}
+    if code:
+        details["task_lease_error_code"] = code
+    if task_lease_payload:
+        details["task_lease_payload"] = dict(task_lease_payload)
     return SettlementResult.failed(
         kind=kind,
         step_kind=step_kind,
         reason=reason,
-        details=(
-            {"task_lease_error_code": code}
-            if code
-            else None
-        ),
+        details=details or None,
     )
 
 
@@ -319,6 +321,7 @@ def _map_task_lease_error(exc: TaskLeaseError) -> SettlementResult[dict[str, Any
         step_kind=SettlementStepKind.DURABLE_WRITEBACK,
         reason=str(exc),
         code=exc.code,
+        task_lease_payload=exc.payload,
     )
 
 

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -107,6 +107,7 @@ from .control_plane.todos.write_policy import (
     resolve_user_gate_global_gate_update,
 )
 from .control_plane.todos.handoff_mode import (
+    enter_added_todo_ownership_handoff_gate,
     enter_todo_ownership_handoff_gate,
     resolve_todo_completion_handoff,
 )
@@ -889,7 +890,7 @@ def add_goal_todo(
         resolved_state_file,
         agent_id=agent_id or claimed_by,
         operation="todo_add",
-    ):
+    ), ExitStack() as handoff_gate_stack:
         original = resolved_state_file.read_text(encoding="utf-8")
         lines = original.splitlines()
         updated_at = now_local()
@@ -991,6 +992,17 @@ def add_goal_todo(
             resume_when=normalized_resume_when,
             monitor_metadata=normalized_monitor_metadata,
         )
+        handoff_gate = enter_added_todo_ownership_handoff_gate(
+            handoff_gate_stack,
+            lines=lines,
+            state_text=original,
+            registry_path=registry_path,
+            goal_id=goal_id,
+            role=role,
+            text=todo_text,
+            claimed_by=effective_claimed_by,
+            actor_agent_id=effective_agent_id or effective_claimed_by,
+        )
         add_result = add_todo_to_lines(
             lines,
             role=role,
@@ -1074,6 +1086,7 @@ def add_goal_todo(
         "state_file": str(resolved_state_file),
         "project": str(resolved_project) if resolved_project else None,
         "updated_at": updated_at if changed else None,
+        **handoff_gate,
     }
     return _attach_todo_write_correctness_dry_run_packet(
         payload,

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -1622,11 +1622,13 @@ def complete_goal_todo(
             decision_outcome=effective_decision_outcome,
             decision_target=decision_target,
         )
+        completion_handoff = resolve_todo_completion_handoff(state_text=original, mutation_authority=mutation_authority)
         terminal_replay = completed_todo_replay(
             todo=completion_todo,
             goal_id=goal_id,
             todo_id=todo_id,
             completion_turn_key=completion_turn_key,
+            handoff_mode=completion_handoff["handoff_mode"],
             mutation_authority=mutation_authority,
             state_file=str(resolved_state_file),
             project=str(resolved_project) if resolved_project else None,
@@ -1634,7 +1636,6 @@ def complete_goal_todo(
         )
         if terminal_replay:
             return terminal_replay
-        completion_handoff = resolve_todo_completion_handoff(state_text=original, mutation_authority=mutation_authority)
         task_lease_fence = lease_fence_stack.enter_context(
             hold_task_lease_mutation_fence(
                 registry_path=registry_path,

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -105,6 +105,10 @@ from .control_plane.todos.write_policy import (
     require_user_todo_task_class,
     resolve_user_gate_global_gate_update,
 )
+from .control_plane.todos.handoff_mode import (
+    enter_todo_ownership_handoff_gate,
+    resolve_todo_completion_handoff,
+)
 from .control_plane.work_items.task_lease import (
     hold_task_lease_mutation_fence,
     release_verified_task_lease_fence,
@@ -1195,7 +1199,7 @@ def update_goal_todo(
         resolved_state_file,
         agent_id=agent_id or claimed_by,
         operation="todo_update",
-    ):
+    ), ExitStack() as handoff_gate_stack:
         original = resolved_state_file.read_text(encoding="utf-8")
         lines = original.splitlines()
         updated_at = now_local()
@@ -1274,6 +1278,16 @@ def update_goal_todo(
             authority_action=None if claim_only else authority_action,
             authority_reason=authority_reason,
             requested_claimed_by=effective_claimed_by,
+        )
+        handoff_gate = enter_todo_ownership_handoff_gate(
+            handoff_gate_stack,
+            state_text=original,
+            registry_path=registry_path,
+            goal_id=goal_id,
+            todo_id=str(authority_todo.get("todo_id") or todo_id),
+            mutation_authority=mutation_authority,
+            actor_agent_id=effective_agent_id or effective_claimed_by,
+            ownership_mutation=(claimed_by is not None or clear_claim) and target_role == "agent",
         )
         target_task_class = task_class or str(existing_block.get("task_class") or "")
         if target_role == "user" and claimed_by:
@@ -1478,6 +1492,7 @@ def update_goal_todo(
         "goal_id": goal_id,
         "agent_id": effective_agent_id,
         "mutation_authority": mutation_authority,
+        **handoff_gate,
         **update_result,
         "state_file": str(resolved_state_file),
         "project": str(resolved_project) if resolved_project else None,
@@ -1619,6 +1634,7 @@ def complete_goal_todo(
         )
         if terminal_replay:
             return terminal_replay
+        completion_handoff = resolve_todo_completion_handoff(state_text=original, mutation_authority=mutation_authority)
         task_lease_fence = lease_fence_stack.enter_context(
             hold_task_lease_mutation_fence(
                 registry_path=registry_path,
@@ -1634,6 +1650,7 @@ def complete_goal_todo(
                     task_lease_idempotency_key is not None
                     or task_lease_expected_version is not None
                 ),
+                handoff=completion_handoff,
             )
         )
         normalized_successor_todo_ids = normalize_todo_id_list(successor_todo_ids)
@@ -1721,6 +1738,7 @@ def complete_goal_todo(
                 event_result["linked_successor_id"] = completion_policy.linked_successor_id
                 event_result["mutation_authority"] = mutation_authority
                 event_result["task_lease_fence"] = task_lease_fence
+                event_result.update(completion_handoff)
                 release_verified_task_lease_fence(
                     task_lease_fence,
                     committed=bool(event_result.get("changed")) and not dry_run,
@@ -1851,6 +1869,7 @@ def complete_goal_todo(
         "linked_successor_id": completion_policy.linked_successor_id,
         "mutation_authority": mutation_authority,
         "task_lease_fence": task_lease_fence,
+        **completion_handoff,
         "state_file": str(resolved_state_file),
         "project": str(resolved_project) if resolved_project else None,
         "updated_at": updated_at if changed else None,

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -84,6 +84,7 @@ from .control_plane.todos.line_update import (
 from .control_plane.todos.list_projection import (
     compact_agent_lane_todo_summary,
     compact_todo_projection_overlay,
+    todo_item_relations,
     todo_list_projection_contract,
 )
 from .control_plane.todos import monitor_metadata as todo_monitor_metadata
@@ -264,40 +265,6 @@ def filtered_todo_summary(
         )
         or empty_todo_summary(role=role)
     )
-
-
-def todo_item_relations(item: dict[str, Any]) -> dict[str, Any]:
-    relations: dict[str, Any] = {}
-    for key in (
-        "claimed_by",
-        "bound_agent",
-        "goal_bound",
-        "blocks_agent",
-        "excluded_agents",
-        "global_gate",
-        "unblocks_todo_id",
-        "successor_todo_ids",
-        "superseded_by",
-        "resume_when",
-        "resume_condition",
-        "resume_ready",
-        "decision_scope",
-        "required_decision_scopes",
-        "required_write_scopes",
-        "required_capabilities",
-        "target_capabilities",
-        "task_class",
-        "action_kind",
-        "continuation_policy",
-        "target_key",
-        "cadence",
-        "next_due_at",
-        "expires_at",
-    ):
-        value = item.get(key)
-        if value is not None and value != []:
-            relations[key] = value
-    return relations
 
 
 def _summary_items(fields: dict[str, Any], role: str) -> list[dict[str, Any]]:

--- a/tests/control_plane/test_goal_handoff_mode.py
+++ b/tests/control_plane/test_goal_handoff_mode.py
@@ -192,6 +192,22 @@ def test_goal_handoff_mode_rejects_unknown_value_loudly() -> None:
     assert error.value.code == "invalid_handoff_mode"
 
 
+def test_invalid_goal_handoff_mode_runtime_read_fails_closed_without_mutation(
+    tmp_path: Path,
+) -> None:
+    registry, state = _write_workspace(tmp_path)
+    todo = _add_todo(registry)
+    _set_frontmatter_mode(state, "banana")
+    before = state.read_bytes()
+
+    with pytest.raises(HandoffModeError) as error:
+        _claim(registry, todo["todo_id"], AGENT_A)
+
+    assert error.value.code == "invalid_handoff_mode"
+    assert error.value.payload["handoff_mode"] == "banana"
+    assert state.read_bytes() == before
+
+
 def test_goal_handoff_mode_without_frontmatter_is_legacy() -> None:
     assert goal_handoff_mode("## Agent Todo\n") == HANDOFF_MODE_LEGACY
 

--- a/tests/control_plane/test_goal_handoff_mode.py
+++ b/tests/control_plane/test_goal_handoff_mode.py
@@ -1,0 +1,780 @@
+"""Per-goal handoff-mode gate over the soft-claim / hard-lease split brain.
+
+Modes (goal front-matter ``handoff_mode``):
+
+* absent / ``legacy``: today's dual behavior, byte-for-byte. The split-brain
+  hole stays open BY DESIGN; the legacy tests below are characterization pins
+  that document it, not aspirations.
+* ``soft_claim``: markdown claim is the only ownership record; task-lease
+  acquire/renew/transfer are typed-rejected, release/inspect stay allowed.
+* ``hard_lease``: ownership changes on an existing todo require the actor to
+  hold that todo's time-active lease; completion fence is mandatory and the
+  legacy self-disarm state becomes a loud typed error. The delegated
+  ``todo_lifecycle_authority`` override is the one audited door through the
+  gate.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import ExitStack
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from loopx.control_plane.todos.handoff_mode import (
+    HANDOFF_MODE_HARD_LEASE,
+    HANDOFF_MODE_LEGACY,
+    HANDOFF_MODE_SOFT_CLAIM,
+    HandoffModeError,
+    goal_handoff_mode,
+)
+from loopx.control_plane.work_items import task_lease
+from loopx.control_plane.work_items.task_lease import (
+    TaskLeaseError,
+    acquire_task_lease,
+    build_lease,
+    hold_handoff_lease_holder_gate,
+    inspect_task_lease,
+    release_task_lease,
+    renew_task_lease,
+    task_lease_path,
+    transfer_task_lease,
+    write_lease,
+)
+from loopx.status import parse_active_state_todos
+from loopx.todos import add_goal_todo, complete_goal_todo, update_goal_todo
+
+GOAL_ID = "handoff-mode-gate"
+AGENT_A = "agent-a"
+AGENT_B = "agent-b"
+ORCHESTRATOR = "agent-orchestrator"
+
+
+def _write_workspace(
+    tmp_path: Path,
+    *,
+    handoff_mode: str | None = None,
+    lifecycle_authority: list[dict[str, Any]] | None = None,
+) -> tuple[Path, Path]:
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    state = repo / "ACTIVE_GOAL_STATE.md"
+    front_matter = [
+        "---",
+        f"goal_id: {GOAL_ID}",
+        "updated_at: 2026-08-01T00:00:00+00:00",
+    ]
+    if handoff_mode is not None:
+        front_matter.append(f"handoff_mode: {handoff_mode}")
+    front_matter.append("---")
+    state.write_text(
+        "\n".join([*front_matter, "", "## Agent Todo", ""]) + "\n",
+        encoding="utf-8",
+    )
+    coordination: dict[str, Any] = {
+        "agent_model": "peer_v1",
+        "registered_agents": [AGENT_A, AGENT_B, ORCHESTRATOR],
+    }
+    if lifecycle_authority is not None:
+        coordination["todo_lifecycle_authority"] = lifecycle_authority
+    registry = tmp_path / "registry.global.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "common_runtime_root": str(tmp_path / "runtime"),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "harness_self_improvement",
+                        "status": "active",
+                        "repo": str(repo),
+                        "state_file": state.name,
+                        "adapter": {"kind": "harness_self_improvement"},
+                        "coordination": coordination,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return registry, state
+
+
+def _set_frontmatter_mode(state: Path, mode: str) -> None:
+    """Hand-edit the front-matter mode (simulates the out-of-contract path)."""
+
+    lines = state.read_text(encoding="utf-8").splitlines()
+    close = next(i for i in range(1, len(lines)) if lines[i].strip() == "---")
+    for index in range(1, close):
+        if lines[index].split(":", 1)[0].strip() == "handoff_mode":
+            lines[index] = f"handoff_mode: {mode}"
+            break
+    else:
+        lines.insert(close, f"handoff_mode: {mode}")
+    state.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _add_todo(registry: Path, *, claimed_by: str | None = None) -> dict[str, Any]:
+    return add_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="agent",
+        text="Deliver one bounded control-plane change.",
+        task_class="advancement_task",
+        claimed_by=claimed_by,
+    )
+
+
+def _agent_todo(state: Path, todo_id: str) -> dict[str, Any]:
+    todos = parse_active_state_todos(state.read_text(encoding="utf-8"))
+    return next(
+        item
+        for item in todos["agent_todos"]["items"]
+        if item["todo_id"] == todo_id
+    )
+
+
+def _acquire(
+    registry: Path,
+    tmp_path: Path,
+    todo_id: str,
+    *,
+    owner: str,
+    key: str = "turn-lease-1",
+    ttl_seconds: int = 600,
+) -> dict[str, Any]:
+    return acquire_task_lease(
+        registry_path=registry,
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        owner=owner,
+        idempotency_key=key,
+        ttl_seconds=ttl_seconds,
+    )
+
+
+def _claim(registry: Path, todo_id: str, agent: str, **kwargs: Any) -> dict[str, Any]:
+    return update_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        claimed_by=agent,
+        agent_id=agent,
+        claim_only=True,
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mode reader
+# ---------------------------------------------------------------------------
+
+
+def test_goal_handoff_mode_defaults_to_legacy_when_absent() -> None:
+    text = "---\ngoal_id: g\n---\n\n## Agent Todo\n"
+    assert goal_handoff_mode(text) == HANDOFF_MODE_LEGACY
+
+
+def test_goal_handoff_mode_reads_explicit_values() -> None:
+    for mode in (HANDOFF_MODE_LEGACY, HANDOFF_MODE_SOFT_CLAIM, HANDOFF_MODE_HARD_LEASE):
+        text = f"---\ngoal_id: g\nhandoff_mode: {mode}\n---\n"
+        assert goal_handoff_mode(text) == mode
+
+
+def test_goal_handoff_mode_rejects_unknown_value_loudly() -> None:
+    with pytest.raises(HandoffModeError) as error:
+        goal_handoff_mode("---\ngoal_id: g\nhandoff_mode: banana\n---\n")
+
+    assert error.value.code == "invalid_handoff_mode"
+
+
+def test_goal_handoff_mode_without_frontmatter_is_legacy() -> None:
+    assert goal_handoff_mode("## Agent Todo\n") == HANDOFF_MODE_LEGACY
+
+
+# ---------------------------------------------------------------------------
+# (a) Legacy characterization pins: the split-brain hole stays open, loudly.
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_pin_claim_over_foreign_active_lease_silently_succeeds(
+    tmp_path: Path,
+) -> None:
+    """S1 pin: soft claim never reads the lease store, so two owners coexist."""
+
+    registry, state = _write_workspace(tmp_path)
+    todo = _add_todo(registry)
+    _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+
+    result = _claim(registry, todo["todo_id"], AGENT_B)
+
+    assert result["ok"] is True
+    assert result["handoff_mode"] == HANDOFF_MODE_LEGACY
+    assert _agent_todo(state, todo["todo_id"])["claimed_by"] == AGENT_B
+    lease_file = task_lease_path(
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+    )
+    lease = json.loads(lease_file.read_text(encoding="utf-8"))
+    assert lease["owner"] == AGENT_A
+    assert lease["status"] == "active"
+
+
+def test_legacy_pin_foreign_claim_makes_lease_renew_fail_typed(
+    tmp_path: Path,
+) -> None:
+    registry, _state = _write_workspace(tmp_path)
+    todo = _add_todo(registry)
+    _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+    _claim(registry, todo["todo_id"], AGENT_B)
+
+    with pytest.raises(TaskLeaseError) as error:
+        renew_task_lease(
+            registry_path=registry,
+            runtime_root=tmp_path / "runtime",
+            goal_id=GOAL_ID,
+            todo_id=todo["todo_id"],
+            owner=AGENT_A,
+            idempotency_key="turn-lease-1",
+        )
+
+    assert error.value.code == "owner_conflicts_with_claim"
+
+
+def test_legacy_pin_fence_self_disarms_and_claimant_completes_keyless(
+    tmp_path: Path,
+) -> None:
+    """The completion fence disarms itself in the split-brain state: the
+    markdown claimant completes WITHOUT any lease credentials while the
+    foreign lease sits on disk status=active."""
+
+    registry, _state = _write_workspace(tmp_path)
+    todo = _add_todo(registry)
+    _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+    _claim(registry, todo["todo_id"], AGENT_B)
+
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        agent_id=AGENT_B,
+        evidence="done without lease credentials",
+    )
+
+    assert result["ok"] is True
+    assert result["task_lease_fence"] == {
+        "schema_version": "task_lease_v0",
+        "required": False,
+        "active": False,
+    }
+    assert result["handoff_mode"] == HANDOFF_MODE_LEGACY
+    lease_file = task_lease_path(
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+    )
+    assert json.loads(lease_file.read_text(encoding="utf-8"))["status"] == "active"
+
+
+def test_legacy_pin_lease_holder_cannot_complete_after_foreign_claim(
+    tmp_path: Path,
+) -> None:
+    registry, _state = _write_workspace(tmp_path)
+    todo = _add_todo(registry)
+    _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+    _claim(registry, todo["todo_id"], AGENT_B)
+
+    with pytest.raises(ValueError, match="cannot complete"):
+        complete_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=todo["todo_id"],
+            agent_id=AGENT_A,
+            task_lease_idempotency_key="turn-lease-1",
+        )
+
+
+def test_legacy_lease_verbs_report_handoff_mode(tmp_path: Path) -> None:
+    registry, _state = _write_workspace(tmp_path)
+    todo = _add_todo(registry)
+
+    acquired = _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+    assert acquired["handoff_mode"] == HANDOFF_MODE_LEGACY
+
+    inspected = inspect_task_lease(
+        registry_path=registry,
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+    )
+    assert inspected["handoff_mode"] == HANDOFF_MODE_LEGACY
+
+
+# ---------------------------------------------------------------------------
+# (b) soft_claim: markdown claim only; lease mutations typed-rejected.
+# ---------------------------------------------------------------------------
+
+
+def test_soft_claim_rejects_lease_acquire(tmp_path: Path) -> None:
+    registry, _state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_SOFT_CLAIM)
+    todo = _add_todo(registry)
+
+    with pytest.raises(TaskLeaseError) as error:
+        _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+
+    assert error.value.code == "handoff_mode_forbids_lease"
+    assert error.value.payload["handoff_mode"] == HANDOFF_MODE_SOFT_CLAIM
+
+
+def test_soft_claim_rejects_renew_and_transfer_of_legacy_leftover(
+    tmp_path: Path,
+) -> None:
+    registry, state = _write_workspace(tmp_path)
+    todo = _add_todo(registry)
+    _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+    _set_frontmatter_mode(state, HANDOFF_MODE_SOFT_CLAIM)
+
+    with pytest.raises(TaskLeaseError) as renew_error:
+        renew_task_lease(
+            registry_path=registry,
+            runtime_root=tmp_path / "runtime",
+            goal_id=GOAL_ID,
+            todo_id=todo["todo_id"],
+            owner=AGENT_A,
+            idempotency_key="turn-lease-1",
+        )
+    assert renew_error.value.code == "handoff_mode_forbids_lease"
+
+    with pytest.raises(TaskLeaseError) as transfer_error:
+        transfer_task_lease(
+            registry_path=registry,
+            runtime_root=tmp_path / "runtime",
+            goal_id=GOAL_ID,
+            todo_id=todo["todo_id"],
+            owner=AGENT_A,
+            idempotency_key="turn-lease-1",
+            new_owner=AGENT_B,
+            new_idempotency_key="turn-lease-2",
+        )
+    assert transfer_error.value.code == "handoff_mode_forbids_lease"
+
+
+def test_soft_claim_allows_release_and_inspect_of_legacy_leftover(
+    tmp_path: Path,
+) -> None:
+    registry, state = _write_workspace(tmp_path)
+    todo = _add_todo(registry)
+    _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+    _set_frontmatter_mode(state, HANDOFF_MODE_SOFT_CLAIM)
+
+    inspected = inspect_task_lease(
+        registry_path=registry,
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+    )
+    assert inspected["ok"] is True
+    assert inspected["handoff_mode"] == HANDOFF_MODE_SOFT_CLAIM
+
+    released = release_task_lease(
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        owner=AGENT_A,
+        idempotency_key="turn-lease-1",
+        registry_path=registry,
+    )
+    assert released["ok"] is True
+    assert released["released"] is True
+
+
+def test_soft_claim_todo_verbs_behave_like_legacy(tmp_path: Path) -> None:
+    registry, state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_SOFT_CLAIM)
+    todo = _add_todo(registry)
+
+    claim = _claim(registry, todo["todo_id"], AGENT_B)
+    assert claim["ok"] is True
+    assert claim["handoff_mode"] == HANDOFF_MODE_SOFT_CLAIM
+    assert _agent_todo(state, todo["todo_id"])["claimed_by"] == AGENT_B
+
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        agent_id=AGENT_B,
+        evidence="soft mode keyless completion",
+    )
+    assert result["ok"] is True
+    assert result["handoff_mode"] == HANDOFF_MODE_SOFT_CLAIM
+    assert result["task_lease_fence"]["required"] is False
+
+
+# ---------------------------------------------------------------------------
+# (c) hard_lease: ownership mutations require the actor to hold the lease.
+# ---------------------------------------------------------------------------
+
+
+def test_hard_lease_claim_without_lease_is_typed_rejected(tmp_path: Path) -> None:
+    registry, state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry)
+    before = state.read_text(encoding="utf-8")
+
+    with pytest.raises(TaskLeaseError) as error:
+        _claim(registry, todo["todo_id"], AGENT_B)
+
+    assert error.value.code == "handoff_mode_requires_lease"
+    assert error.value.payload["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
+    assert state.read_text(encoding="utf-8") == before
+
+
+def test_hard_lease_claim_by_non_owner_is_typed_rejected(tmp_path: Path) -> None:
+    registry, state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry)
+    _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+    before = state.read_text(encoding="utf-8")
+
+    with pytest.raises(TaskLeaseError) as error:
+        _claim(registry, todo["todo_id"], AGENT_B)
+
+    assert error.value.code == "handoff_mode_requires_lease"
+    assert error.value.payload["lease_owner"] == AGENT_A
+    assert state.read_text(encoding="utf-8") == before
+
+
+def test_hard_lease_holder_claim_succeeds(tmp_path: Path) -> None:
+    registry, state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry)
+    _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+
+    result = _claim(registry, todo["todo_id"], AGENT_A)
+
+    assert result["ok"] is True
+    assert result["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
+    assert _agent_todo(state, todo["todo_id"])["claimed_by"] == AGENT_A
+
+
+def test_hard_lease_expired_lease_does_not_authorize_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, _state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry)
+    _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A, ttl_seconds=60)
+    real_now = task_lease.now_utc()
+    monkeypatch.setattr(task_lease, "now_utc", lambda: real_now + timedelta(hours=2))
+
+    with pytest.raises(TaskLeaseError) as error:
+        _claim(registry, todo["todo_id"], AGENT_A)
+
+    assert error.value.code == "handoff_mode_requires_lease"
+
+
+def test_hard_lease_clear_claim_requires_lease(tmp_path: Path) -> None:
+    registry, state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+
+    with pytest.raises(TaskLeaseError) as error:
+        update_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=todo["todo_id"],
+            agent_id=AGENT_A,
+            clear_claim=True,
+        )
+    assert error.value.code == "handoff_mode_requires_lease"
+
+    _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+    result = update_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        agent_id=AGENT_A,
+        clear_claim=True,
+    )
+    assert result["ok"] is True
+    assert not _agent_todo(state, todo["todo_id"]).get("claimed_by")
+
+
+def test_hard_lease_claimed_by_update_requires_lease(tmp_path: Path) -> None:
+    registry, _state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+
+    with pytest.raises(TaskLeaseError) as error:
+        update_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=todo["todo_id"],
+            claimed_by=AGENT_A,
+            agent_id=AGENT_A,
+            note="keep ownership, add note",
+        )
+
+    assert error.value.code == "handoff_mode_requires_lease"
+
+
+def test_hard_lease_non_ownership_update_needs_no_lease(tmp_path: Path) -> None:
+    registry, _state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry)
+
+    result = update_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        agent_id=AGENT_B,
+        note="metadata-only update",
+    )
+
+    assert result["ok"] is True
+    assert result["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
+
+
+def test_hard_lease_creation_time_assignment_stays_allowed(tmp_path: Path) -> None:
+    """A fresh todo id can never hold a lease; add --claimed-by is a
+    deliberate boundary that stays open in hard_lease mode."""
+
+    registry, state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+
+    assert todo["ok"] is True
+    assert _agent_todo(state, todo["todo_id"])["claimed_by"] == AGENT_A
+
+
+def test_hard_lease_completion_successor_assignment_stays_allowed(
+    tmp_path: Path,
+) -> None:
+    registry, state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+    _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        agent_id=AGENT_A,
+        task_lease_idempotency_key="turn-lease-1",
+        evidence="done with verified lease key",
+        next_agent_todo="Follow-up slice for the peer lane.",
+        next_claimed_by=AGENT_B,
+    )
+
+    assert result["ok"] is True
+    successor_id = result["next_todos"][0]["todo_id"]
+    assert _agent_todo(state, successor_id)["claimed_by"] == AGENT_B
+
+
+def test_hard_lease_completion_without_lease_is_typed_rejected(
+    tmp_path: Path,
+) -> None:
+    registry, _state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+
+    with pytest.raises(TaskLeaseError) as error:
+        complete_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=todo["todo_id"],
+            agent_id=AGENT_A,
+            evidence="no lease exists",
+        )
+
+    assert error.value.code == "handoff_mode_requires_lease"
+    assert error.value.payload["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
+
+
+def test_hard_lease_completion_with_verified_key_succeeds(tmp_path: Path) -> None:
+    registry, _state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+    _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        agent_id=AGENT_A,
+        task_lease_idempotency_key="turn-lease-1",
+        evidence="done with verified lease key",
+    )
+
+    assert result["ok"] is True
+    assert result["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
+    assert result["task_lease_fence"]["required"] is True
+    assert result["task_lease_fence"]["execution_instance_verified"] is True
+
+
+def test_hard_lease_self_disarm_state_becomes_loud_typed_error(
+    tmp_path: Path,
+) -> None:
+    """Legacy remnants or manual edits can leave claimed_by diverged from a
+    time-active lease. In hard_lease mode that must fail loudly instead of
+    silently completing keyless."""
+
+    registry, state = _write_workspace(tmp_path)
+    todo = _add_todo(registry)
+    _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+    _claim(registry, todo["todo_id"], AGENT_B)
+    _set_frontmatter_mode(state, HANDOFF_MODE_HARD_LEASE)
+
+    with pytest.raises(TaskLeaseError) as error:
+        complete_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=todo["todo_id"],
+            agent_id=AGENT_B,
+            evidence="split-brain keyless completion attempt",
+        )
+
+    assert error.value.code == "handoff_mode_lease_claim_divergence"
+    assert error.value.payload["lease_owner"] == AGENT_A
+
+
+# ---------------------------------------------------------------------------
+# (d) the door: delegated todo_lifecycle_authority passes the hard gate.
+# ---------------------------------------------------------------------------
+
+
+def _orchestrator_grant() -> list[dict[str, Any]]:
+    return [
+        {
+            "agent_id": ORCHESTRATOR,
+            "actions": ["reassign", "update", "complete"],
+            "requires_reason": True,
+        }
+    ]
+
+
+def test_hard_lease_delegated_reassign_passes_gate_with_marker(
+    tmp_path: Path,
+) -> None:
+    registry, state = _write_workspace(
+        tmp_path,
+        handoff_mode=HANDOFF_MODE_HARD_LEASE,
+        lifecycle_authority=_orchestrator_grant(),
+    )
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+
+    result = update_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        claimed_by=AGENT_B,
+        agent_id=ORCHESTRATOR,
+        authority_reason="peer lane is stalled; reassigning",
+    )
+
+    assert result["ok"] is True
+    assert result["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
+    assert result["handoff_gate_overridden"] is True
+    assert result["mutation_authority"]["mode"] == "delegated_orchestration_override"
+    assert (
+        result["mutation_authority"]["authority_reason"]
+        == "peer lane is stalled; reassigning"
+    )
+    assert _agent_todo(state, todo["todo_id"])["claimed_by"] == AGENT_B
+
+
+def test_hard_lease_delegated_complete_passes_gate_with_marker(
+    tmp_path: Path,
+) -> None:
+    registry, _state = _write_workspace(
+        tmp_path,
+        handoff_mode=HANDOFF_MODE_HARD_LEASE,
+        lifecycle_authority=_orchestrator_grant(),
+    )
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        agent_id=ORCHESTRATOR,
+        authority_reason="closing stalled item for the goal owner",
+        evidence="delegated completion",
+    )
+
+    assert result["ok"] is True
+    assert result["handoff_gate_overridden"] is True
+    assert result["task_lease_fence"]["required"] is False
+
+
+def test_hard_lease_gate_has_no_untyped_bypass_without_grant(
+    tmp_path: Path,
+) -> None:
+    registry, _state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+
+    with pytest.raises(ValueError):
+        update_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=todo["todo_id"],
+            claimed_by=AGENT_B,
+            agent_id=ORCHESTRATOR,
+            authority_reason="no grant exists for this actor",
+        )
+
+
+# ---------------------------------------------------------------------------
+# (f) identity normalization on both sides of the holder check.
+# ---------------------------------------------------------------------------
+
+
+def test_hard_lease_holder_check_normalizes_both_sides(tmp_path: Path) -> None:
+    registry, state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry)
+    _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+
+    result = update_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        claimed_by=" Agent-A ",
+        agent_id="AGENT-A",
+        claim_only=True,
+    )
+
+    assert result["ok"] is True
+    assert _agent_todo(state, todo["todo_id"])["claimed_by"] == AGENT_A
+
+
+def test_holder_gate_normalizes_lease_owner_case_variants(tmp_path: Path) -> None:
+    registry, _state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry)
+    lease_file = task_lease_path(
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+    )
+    now = task_lease.now_utc()
+    write_lease(
+        lease_file,
+        build_lease(
+            goal_id=GOAL_ID,
+            todo_id=todo["todo_id"],
+            owner="Agent-A",
+            idempotency_key="turn-lease-1",
+            write_scopes=[],
+            acquire_ttl_seconds=600,
+            version=1,
+            acquired_at=task_lease.isoformat(now),
+            updated_at=task_lease.isoformat(now),
+            expires_at=task_lease.isoformat(now + timedelta(seconds=600)),
+        ),
+    )
+
+    with ExitStack() as stack:
+        gate = stack.enter_context(
+            hold_handoff_lease_holder_gate(
+                registry_path=registry,
+                goal_id=GOAL_ID,
+                todo_id=todo["todo_id"],
+                actor_agent_id=" agent-a ",
+            )
+        )
+        assert gate["active"] is True
+        assert gate["owner"] == AGENT_A

--- a/tests/control_plane/test_goal_handoff_mode.py
+++ b/tests/control_plane/test_goal_handoff_mode.py
@@ -51,6 +51,7 @@ GOAL_ID = "handoff-mode-gate"
 AGENT_A = "agent-a"
 AGENT_B = "agent-b"
 ORCHESTRATOR = "agent-orchestrator"
+DECISION_SCOPE = "direction:action:approve_handoff"
 
 
 def _write_workspace(
@@ -135,6 +136,40 @@ def _agent_todo(state: Path, todo_id: str) -> dict[str, Any]:
         for item in todos["agent_todos"]["items"]
         if item["todo_id"] == todo_id
     )
+
+
+def _user_todo(state: Path, todo_id: str) -> dict[str, Any]:
+    todos = parse_active_state_todos(state.read_text(encoding="utf-8"))
+    return next(
+        item
+        for item in todos["user_todos"]["items"]
+        if item["todo_id"] == todo_id
+    )
+
+
+def _add_exact_user_gate_pair(
+    registry: Path,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    target = add_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="agent",
+        text="Continue after the exact owner decision.",
+        task_class="advancement_task",
+        claimed_by=AGENT_A,
+        required_decision_scopes=[DECISION_SCOPE],
+    )
+    gate = add_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="user",
+        text="Approve the exact handoff decision.",
+        task_class="user_gate",
+        blocks_agent=AGENT_A,
+        decision_scope=DECISION_SCOPE,
+        unblocks_todo_id=target["todo_id"],
+    )
+    return target, gate
 
 
 def _acquire(
@@ -621,6 +656,131 @@ def test_hard_lease_completion_with_verified_key_succeeds(tmp_path: Path) -> Non
     assert result["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
     assert result["task_lease_fence"]["required"] is True
     assert result["task_lease_fence"]["execution_instance_verified"] is True
+
+
+def test_hard_lease_exact_user_gate_completion_without_lease_is_typed_rejected(
+    tmp_path: Path,
+) -> None:
+    registry, state = _write_workspace(
+        tmp_path,
+        handoff_mode=HANDOFF_MODE_HARD_LEASE,
+    )
+    _target, gate = _add_exact_user_gate_pair(registry)
+    before = state.read_text(encoding="utf-8")
+
+    with pytest.raises(TaskLeaseError) as error:
+        complete_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=gate["todo_id"],
+            role="user",
+            decision_outcome="approve",
+            agent_id=AGENT_A,
+            evidence="exact owner decision without a task lease",
+        )
+
+    assert error.value.code == "handoff_mode_requires_lease"
+    assert error.value.payload["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
+    assert state.read_text(encoding="utf-8") == before
+
+
+def test_hard_lease_exact_user_gate_completion_uses_fence_and_releases_lease(
+    tmp_path: Path,
+) -> None:
+    registry, state = _write_workspace(
+        tmp_path,
+        handoff_mode=HANDOFF_MODE_HARD_LEASE,
+    )
+    target, gate = _add_exact_user_gate_pair(registry)
+    _acquire(registry, tmp_path, gate["todo_id"], owner=AGENT_A)
+    lease_file = task_lease_path(
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=gate["todo_id"],
+    )
+
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=gate["todo_id"],
+        role="user",
+        decision_outcome="approve",
+        agent_id=AGENT_A,
+        task_lease_idempotency_key="turn-lease-1",
+        task_lease_expected_version=1,
+        evidence="lease holder approved the exact decision scope",
+    )
+
+    assert result["ok"] is True
+    assert result["mutation_authority"]["mode"] == (
+        "exact_user_gate_decision_scope_override"
+    )
+    assert "handoff_gate_overridden" not in result
+    assert result["task_lease_fence"] == {
+        "schema_version": "task_lease_v0",
+        "required": True,
+        "active": True,
+        "owner": AGENT_A,
+        "version": 1,
+        "execution_instance_verified": True,
+        "released": True,
+    }
+    assert not lease_file.exists()
+    assert _user_todo(state, gate["todo_id"])["status"] == "done"
+    target_after = _agent_todo(state, target["todo_id"])
+    assert target_after["status"] == "open"
+    assert not target_after.get("required_decision_scopes")
+    assert result["decision_scope_resolution"]["state"] == "resolved"
+    assert result["decision_scope_resolution"][
+        "remaining_required_decision_scopes"
+    ] == []
+
+
+@pytest.mark.parametrize(
+    ("lease_owner", "actor_agent_id", "completion_key"),
+    [
+        (AGENT_A, AGENT_A, "wrong-turn-key"),
+        (AGENT_B, AGENT_A, "turn-lease-1"),
+    ],
+    ids=("wrong-key", "foreign-holder"),
+)
+def test_hard_lease_exact_user_gate_rejects_invalid_lease_fence_without_state_change(
+    tmp_path: Path,
+    lease_owner: str,
+    actor_agent_id: str,
+    completion_key: str,
+) -> None:
+    registry, state = _write_workspace(
+        tmp_path,
+        handoff_mode=HANDOFF_MODE_HARD_LEASE,
+    )
+    _target, gate = _add_exact_user_gate_pair(registry)
+    _acquire(registry, tmp_path, gate["todo_id"], owner=lease_owner)
+    lease_file = task_lease_path(
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=gate["todo_id"],
+    )
+    before = state.read_text(encoding="utf-8")
+
+    with pytest.raises(TaskLeaseError) as error:
+        complete_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=gate["todo_id"],
+            role="user",
+            decision_outcome="approve",
+            agent_id=actor_agent_id,
+            task_lease_idempotency_key=completion_key,
+            task_lease_expected_version=1,
+            evidence="invalid execution instance must not consume the gate",
+        )
+
+    assert error.value.code == "lease_cas_mismatch"
+    assert state.read_text(encoding="utf-8") == before
+    persisted_lease = json.loads(lease_file.read_text(encoding="utf-8"))
+    assert persisted_lease["status"] == "active"
+    assert persisted_lease["owner"] == lease_owner
 
 
 def test_hard_lease_self_disarm_state_becomes_loud_typed_error(

--- a/tests/control_plane/test_goal_handoff_mode.py
+++ b/tests/control_plane/test_goal_handoff_mode.py
@@ -30,6 +30,7 @@ from loopx.control_plane.todos.handoff_mode import (
     HANDOFF_MODE_SOFT_CLAIM,
     HandoffModeError,
     goal_handoff_mode,
+    set_goal_handoff_mode,
 )
 from loopx.control_plane.work_items import task_lease
 from loopx.control_plane.work_items.task_lease import (
@@ -44,8 +45,18 @@ from loopx.control_plane.work_items.task_lease import (
     transfer_task_lease,
     write_lease,
 )
+from loopx.event_sourced_state import (
+    TODO_ADDED,
+    AppendOnlyStateEventStore,
+    make_state_event,
+)
 from loopx.status import parse_active_state_todos
-from loopx.todos import add_goal_todo, complete_goal_todo, update_goal_todo
+from loopx.todos import (
+    add_goal_todo,
+    complete_goal_todo,
+    list_goal_todos,
+    update_goal_todo,
+)
 
 GOAL_ID = "handoff-mode-gate"
 AGENT_A = "agent-a"
@@ -132,9 +143,7 @@ def _add_todo(registry: Path, *, claimed_by: str | None = None) -> dict[str, Any
 def _agent_todo(state: Path, todo_id: str) -> dict[str, Any]:
     todos = parse_active_state_todos(state.read_text(encoding="utf-8"))
     return next(
-        item
-        for item in todos["agent_todos"]["items"]
-        if item["todo_id"] == todo_id
+        item for item in todos["agent_todos"]["items"] if item["todo_id"] == todo_id
     )
 
 
@@ -245,6 +254,86 @@ def test_invalid_goal_handoff_mode_runtime_read_fails_closed_without_mutation(
 
 def test_goal_handoff_mode_without_frontmatter_is_legacy() -> None:
     assert goal_handoff_mode("## Agent Todo\n") == HANDOFF_MODE_LEGACY
+
+
+def test_event_only_claim_is_not_a_v0_quiescence_offender_but_hard_gate_blocks_write(
+    tmp_path: Path,
+) -> None:
+    """The v0 switch scan is materialized-state only, not a safety proof.
+
+    An event-only claim is visible through the real todo projection but absent
+    from ACTIVE_GOAL_STATE.md, so the transition scan does not see it.  After
+    the switch, the normal event writeback path must still cross the hard-lease
+    completion gate and leave both persisted surfaces unchanged on rejection.
+    """
+
+    registry, state = _write_workspace(tmp_path)
+    event_log = state.with_name("events.jsonl")
+    todo_id = "todo_event_only_claimed"
+    store = AppendOnlyStateEventStore(event_log)
+    store.append(
+        make_state_event(
+            event_id="evt-event-only-claimed",
+            goal_id=GOAL_ID,
+            event_type=TODO_ADDED,
+            refs={"todo_id": todo_id},
+            payload={
+                "role": "agent",
+                "title": "Complete the event-only claimed task.",
+                "task_class": "advancement_task",
+                "claimed_by": AGENT_A,
+            },
+            recorded_at="2026-08-01T00:01:00+00:00",
+            producer="handoff-mode-event-only-characterization",
+        )
+    )
+
+    assert todo_id not in state.read_text(encoding="utf-8")
+    projected = list_goal_todos(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+    )
+    assert projected["source"] == "event_projection_with_markdown_overlay"
+    assert todo_id in projected["projection_overlay"]["event_only_todo_ids"]
+    assert projected["todo"]["status"] == "open"
+    assert projected["todo"]["claimed_by"] == AGENT_A
+
+    event_log_before_switch = event_log.read_text(encoding="utf-8")
+    switched = set_goal_handoff_mode(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        mode=HANDOFF_MODE_HARD_LEASE,
+    )
+    assert switched["changed"] is True
+    assert switched["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
+    assert switched["previous_mode"] == HANDOFF_MODE_LEGACY
+    assert event_log.read_text(encoding="utf-8") == event_log_before_switch
+
+    state_after_switch = state.read_text(encoding="utf-8")
+    event_log_after_switch = event_log.read_text(encoding="utf-8")
+    with pytest.raises(TaskLeaseError) as error:
+        complete_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=todo_id,
+            claimed_by=AGENT_A,
+            agent_id=AGENT_A,
+            evidence="event-only completion still needs the post-switch lease gate",
+            no_followup=True,
+        )
+
+    assert error.value.code == "handoff_mode_requires_lease"
+    assert error.value.payload["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
+    assert state.read_text(encoding="utf-8") == state_after_switch
+    assert event_log.read_text(encoding="utf-8") == event_log_after_switch
+    projected_after = list_goal_todos(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+    )
+    assert projected_after["todo"]["status"] == "open"
+    assert projected_after["todo"]["claimed_by"] == AGENT_A
 
 
 # ---------------------------------------------------------------------------

--- a/tests/control_plane/test_goal_handoff_mode.py
+++ b/tests/control_plane/test_goal_handoff_mode.py
@@ -598,6 +598,98 @@ def test_hard_lease_holder_claim_succeeds(tmp_path: Path) -> None:
     assert _agent_todo(state, todo["todo_id"])["claimed_by"] == AGENT_A
 
 
+def test_hard_lease_holder_can_handoff_claim_and_peer_can_finish(
+    tmp_path: Path,
+) -> None:
+    registry, state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+    acquired_by_a = _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+    lease_file = task_lease_path(
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+    )
+
+    handed_off = update_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        claimed_by=AGENT_B,
+        agent_id=AGENT_A,
+    )
+
+    assert handed_off["ok"] is True
+    assert handed_off["mutation_authority"]["actor_agent_id"] == AGENT_A
+    assert handed_off["task_lease_holder_gate"]["owner"] == AGENT_A
+    assert _agent_todo(state, todo["todo_id"])["claimed_by"] == AGENT_B
+    lease_held_by_a = json.loads(lease_file.read_text(encoding="utf-8"))
+    assert lease_held_by_a["owner"] == AGENT_A
+    assert lease_held_by_a["status"] == "active"
+
+    state_during_handoff = state.read_text(encoding="utf-8")
+    with pytest.raises(TaskLeaseError) as claim_error:
+        update_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=todo["todo_id"],
+            agent_id=AGENT_B,
+            clear_claim=True,
+        )
+    assert claim_error.value.code == "handoff_mode_requires_lease"
+    assert claim_error.value.payload["actor_agent_id"] == AGENT_B
+    assert claim_error.value.payload["lease_owner"] == AGENT_A
+    assert state.read_text(encoding="utf-8") == state_during_handoff
+    assert json.loads(lease_file.read_text(encoding="utf-8")) == lease_held_by_a
+
+    with pytest.raises(TaskLeaseError) as completion_error:
+        complete_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=todo["todo_id"],
+            agent_id=AGENT_B,
+            evidence="peer cannot complete before acquiring the hard lease",
+        )
+    assert completion_error.value.code == "handoff_mode_lease_claim_divergence"
+    assert completion_error.value.payload["lease_owner"] == AGENT_A
+    assert state.read_text(encoding="utf-8") == state_during_handoff
+    assert json.loads(lease_file.read_text(encoding="utf-8")) == lease_held_by_a
+
+    released_by_a = release_task_lease(
+        registry_path=registry,
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        owner=AGENT_A,
+        idempotency_key="turn-lease-1",
+        expected_version=acquired_by_a["lease"]["version"],
+    )
+    assert released_by_a["released"] is True
+    assert not lease_file.exists()
+
+    acquired_by_b = _acquire(
+        registry,
+        tmp_path,
+        todo["todo_id"],
+        owner=AGENT_B,
+        key="turn-lease-2",
+    )
+    completed_by_b = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        agent_id=AGENT_B,
+        task_lease_idempotency_key="turn-lease-2",
+        task_lease_expected_version=acquired_by_b["lease"]["version"],
+        evidence="peer completed after acquiring the hard lease",
+    )
+
+    assert completed_by_b["ok"] is True
+    assert completed_by_b["task_lease_fence"]["execution_instance_verified"] is True
+    assert completed_by_b["task_lease_fence"]["released"] is True
+    assert _agent_todo(state, todo["todo_id"])["status"] == "done"
+    assert not lease_file.exists()
+
+
 def test_hard_lease_expired_lease_does_not_authorize_claim(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/control_plane/test_goal_handoff_mode.py
+++ b/tests/control_plane/test_goal_handoff_mode.py
@@ -554,6 +554,124 @@ def test_soft_claim_todo_verbs_behave_like_legacy(tmp_path: Path) -> None:
     assert result["task_lease_fence"]["required"] is False
 
 
+@pytest.mark.parametrize(
+    ("configured_mode", "expected_mode"),
+    [
+        (None, HANDOFF_MODE_LEGACY),
+        (HANDOFF_MODE_SOFT_CLAIM, HANDOFF_MODE_SOFT_CLAIM),
+    ],
+)
+def test_local_terminal_replay_matches_completion_response_shape_without_lease(
+    tmp_path: Path,
+    configured_mode: str | None,
+    expected_mode: str,
+) -> None:
+    registry, state = _write_workspace(tmp_path, handoff_mode=configured_mode)
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+    turn_key = "turn-terminal-response-parity"
+
+    completed = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        agent_id=AGENT_A,
+        evidence="complete the lease-free handoff-mode case",
+        completion_turn_key=turn_key,
+        no_followup=True,
+    )
+    completed_state = state.read_text(encoding="utf-8")
+    replayed = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        agent_id=AGENT_A,
+        evidence="retry the same local completion turn",
+        completion_turn_key=turn_key,
+        no_followup=True,
+    )
+
+    assert completed["handoff_mode"] == expected_mode
+    assert replayed["handoff_mode"] == expected_mode
+    assert replayed["completed"] is True
+    assert replayed["changed"] is False
+    assert replayed["idempotent_replay"] is True
+    assert state.read_text(encoding="utf-8") == completed_state
+
+
+def test_local_terminal_replay_reports_current_mode_not_original_result_proof(
+    tmp_path: Path,
+) -> None:
+    """Replay parity reads current goal mode; it is not an original receipt."""
+
+    registry, state = _write_workspace(tmp_path)
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+    turn_key = "turn-current-mode-parity"
+
+    completed = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        agent_id=AGENT_A,
+        evidence="complete before a legal quiescent mode transition",
+        completion_turn_key=turn_key,
+        no_followup=True,
+    )
+    assert completed["handoff_mode"] == HANDOFF_MODE_LEGACY
+    changed_mode = set_goal_handoff_mode(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        mode=HANDOFF_MODE_SOFT_CLAIM,
+    )
+    assert changed_mode["changed"] is True
+    mode_changed_state = state.read_text(encoding="utf-8")
+
+    replayed = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        agent_id=AGENT_A,
+        evidence="retry after the goal mode changed",
+        completion_turn_key=turn_key,
+        no_followup=True,
+    )
+
+    assert replayed["handoff_mode"] == HANDOFF_MODE_SOFT_CLAIM
+    assert replayed["changed"] is False
+    assert replayed["idempotent_replay"] is True
+    assert state.read_text(encoding="utf-8") == mode_changed_state
+
+
+def test_local_terminal_replay_fails_closed_on_current_invalid_mode(
+    tmp_path: Path,
+) -> None:
+    registry, state = _write_workspace(tmp_path)
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+    turn_key = "turn-invalid-mode-replay"
+    complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        agent_id=AGENT_A,
+        completion_turn_key=turn_key,
+        no_followup=True,
+    )
+    _set_frontmatter_mode(state, "banana")
+    invalid_state = state.read_text(encoding="utf-8")
+
+    with pytest.raises(HandoffModeError) as error:
+        complete_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=todo["todo_id"],
+            agent_id=AGENT_A,
+            completion_turn_key=turn_key,
+            no_followup=True,
+        )
+
+    assert error.value.code == "invalid_handoff_mode"
+    assert state.read_text(encoding="utf-8") == invalid_state
+
+
 # ---------------------------------------------------------------------------
 # (c) hard_lease: ownership mutations require the actor to hold the lease.
 # ---------------------------------------------------------------------------
@@ -962,8 +1080,72 @@ def test_hard_lease_exact_user_gate_rejects_invalid_lease_fence_without_state_ch
     persisted_lease = json.loads(lease_file.read_text(encoding="utf-8"))
     assert persisted_lease["status"] == "active"
     assert persisted_lease["owner"] == lease_owner
+def test_hard_lease_local_terminal_replay_keeps_response_shape_after_release(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same-turn local replay does not re-enter lease authority or mutate state."""
 
+    registry, state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+    lease_key = "turn-hard-lease-instance"
+    turn_key = "turn-hard-lease-completion"
+    _acquire(
+        registry,
+        tmp_path,
+        todo["todo_id"],
+        owner=AGENT_A,
+        key=lease_key,
+    )
 
+    completed = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        agent_id=AGENT_A,
+        task_lease_idempotency_key=lease_key,
+        completion_turn_key=turn_key,
+        evidence="complete under the held hard lease",
+        no_followup=True,
+    )
+    lease_file = task_lease_path(
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+    )
+    assert completed["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
+    assert completed["task_lease_fence"]["released"] is True
+    assert not lease_file.exists()
+    completed_state = state.read_text(encoding="utf-8")
+
+    def unexpected_lease_effect(*_args: Any, **_kwargs: Any) -> None:
+        pytest.fail("terminal replay must not re-enter the task-lease effect path")
+
+    monkeypatch.setattr(
+        "loopx.todos.hold_task_lease_mutation_fence",
+        unexpected_lease_effect,
+    )
+    monkeypatch.setattr(
+        "loopx.todos.release_verified_task_lease_fence",
+        unexpected_lease_effect,
+    )
+    replayed = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        agent_id=AGENT_A,
+        task_lease_idempotency_key=lease_key,
+        completion_turn_key=turn_key,
+        evidence="retry the same completion after lease release",
+        no_followup=True,
+    )
+
+    assert replayed["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
+    assert replayed["completed"] is True
+    assert replayed["changed"] is False
+    assert replayed["idempotent_replay"] is True
+    assert state.read_text(encoding="utf-8") == completed_state
+    assert not lease_file.exists()
 def test_hard_lease_self_disarm_state_becomes_loud_typed_error(
     tmp_path: Path,
 ) -> None:
@@ -1057,6 +1239,51 @@ def test_hard_lease_delegated_complete_passes_gate_with_marker(
     assert result["ok"] is True
     assert result["handoff_gate_overridden"] is True
     assert result["task_lease_fence"]["required"] is False
+
+
+def test_delegated_terminal_replay_parity_excludes_original_gate_effect_marker(
+    tmp_path: Path,
+) -> None:
+    """Current mode is replayable; an original gate override effect is not."""
+
+    registry, state = _write_workspace(
+        tmp_path,
+        handoff_mode=HANDOFF_MODE_HARD_LEASE,
+        lifecycle_authority=_orchestrator_grant(),
+    )
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+    turn_key = "turn-delegated-terminal-replay"
+    completed = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        agent_id=ORCHESTRATOR,
+        authority_reason="close the item through delegated authority",
+        completion_turn_key=turn_key,
+        no_followup=True,
+    )
+    completed_state = state.read_text(encoding="utf-8")
+
+    replayed = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        agent_id=ORCHESTRATOR,
+        authority_reason="retry the delegated completion turn",
+        completion_turn_key=turn_key,
+        no_followup=True,
+    )
+
+    assert completed["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
+    assert completed["handoff_gate_overridden"] is True
+    assert replayed["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
+    assert replayed["mutation_authority"]["mode"] == (
+        "delegated_orchestration_override"
+    )
+    assert "handoff_gate_overridden" not in replayed
+    assert replayed["changed"] is False
+    assert replayed["idempotent_replay"] is True
+    assert state.read_text(encoding="utf-8") == completed_state
 
 
 def test_hard_lease_gate_has_no_untyped_bypass_without_grant(

--- a/tests/control_plane/test_goal_handoff_mode.py
+++ b/tests/control_plane/test_goal_handoff_mode.py
@@ -808,6 +808,103 @@ def test_hard_lease_holder_can_handoff_claim_and_peer_can_finish(
     assert not lease_file.exists()
 
 
+def test_hard_lease_blocks_todo_add_reassigning_a_leased_todo(tmp_path: Path) -> None:
+    registry, state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+    _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+    lease_file = task_lease_path(
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+    )
+    state_before = state.read_text(encoding="utf-8")
+    lease_before = json.loads(lease_file.read_text(encoding="utf-8"))
+
+    with pytest.raises(TaskLeaseError) as add_error:
+        _add_todo(registry, claimed_by=AGENT_B)
+
+    assert add_error.value.code == "handoff_mode_requires_lease"
+    assert add_error.value.payload["actor_agent_id"] == AGENT_B
+    assert add_error.value.payload["lease_owner"] == AGENT_A
+    assert state.read_text(encoding="utf-8") == state_before
+    assert json.loads(lease_file.read_text(encoding="utf-8")) == lease_before
+
+
+def test_hard_lease_allows_todo_add_creating_a_claimed_todo(tmp_path: Path) -> None:
+    registry, state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+
+    created = add_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="agent",
+        text="Draft the follow-up migration note.",
+        task_class="advancement_task",
+        claimed_by=AGENT_A,
+    )
+
+    assert created["ok"] is True
+    assert created["added"] is True
+    assert created["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
+    assert "task_lease_holder_gate" not in created
+    assert _agent_todo(state, created["todo_id"])["claimed_by"] == AGENT_A
+
+
+def test_hard_lease_allows_todo_add_repeating_the_existing_claim(tmp_path: Path) -> None:
+    registry, state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+    _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+
+    repeated = _add_todo(registry, claimed_by=AGENT_A)
+
+    assert repeated["ok"] is True
+    assert repeated["already_exists"] is True
+    assert repeated["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
+    assert "task_lease_holder_gate" not in repeated
+    assert _agent_todo(state, todo["todo_id"])["claimed_by"] == AGENT_A
+
+
+def test_hard_lease_lease_holder_may_reassign_through_todo_add(tmp_path: Path) -> None:
+    registry, state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+    _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+
+    handed_off = add_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="agent",
+        text="Deliver one bounded control-plane change.",
+        task_class="advancement_task",
+        claimed_by=AGENT_B,
+        agent_id=AGENT_A,
+    )
+
+    assert handed_off["ok"] is True
+    assert handed_off["already_exists"] is True
+    assert handed_off["task_lease_holder_gate"]["owner"] == AGENT_A
+    assert _agent_todo(state, todo["todo_id"])["claimed_by"] == AGENT_B
+
+
+def test_legacy_pin_todo_add_reassigns_a_leased_todo(tmp_path: Path) -> None:
+    """Characterizes today's behavior: the add path is ungated in legacy mode."""
+
+    registry, state = _write_workspace(tmp_path)
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+    _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+    lease_file = task_lease_path(
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+    )
+
+    reassigned = _add_todo(registry, claimed_by=AGENT_B)
+
+    assert reassigned["ok"] is True
+    assert reassigned["already_exists"] is True
+    assert reassigned["handoff_mode"] == HANDOFF_MODE_LEGACY
+    assert _agent_todo(state, todo["todo_id"])["claimed_by"] == AGENT_B
+    assert json.loads(lease_file.read_text(encoding="utf-8"))["owner"] == AGENT_A
+
+
 def test_hard_lease_expired_lease_does_not_authorize_claim(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/control_plane/test_goal_handoff_mode_cli.py
+++ b/tests/control_plane/test_goal_handoff_mode_cli.py
@@ -99,6 +99,18 @@ def _add_todo(registry: Path, *, claimed_by: str | None = None) -> dict[str, Any
     )
 
 
+def _set_frontmatter_mode(state: Path, mode: str) -> None:
+    lines = state.read_text(encoding="utf-8").splitlines()
+    close = next(i for i in range(1, len(lines)) if lines[i].strip() == "---")
+    for index in range(1, close):
+        if lines[index].split(":", 1)[0].strip() == "handoff_mode":
+            lines[index] = f"handoff_mode: {mode}"
+            break
+    else:
+        lines.insert(close, f"handoff_mode: {mode}")
+    state.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
 # ---------------------------------------------------------------------------
 # (e) mode switch CLI: show / set with quiescence enforcement.
 # ---------------------------------------------------------------------------
@@ -118,6 +130,54 @@ def test_handoff_mode_show_defaults_to_legacy(
     assert payload["ok"] is True
     assert payload["handoff_mode"] == HANDOFF_MODE_LEGACY
     assert payload["source"] == "default"
+
+
+def test_handoff_mode_show_rejects_invalid_frontmatter_without_mutation(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    registry, state = _write_workspace(tmp_path, handoff_mode="banana")
+    before = state.read_bytes()
+
+    exit_code, payload = _run_cli(
+        capsys, registry, "handoff-mode", "show", "--goal-id", GOAL_ID
+    )
+
+    assert exit_code == 1
+    assert payload["ok"] is False
+    assert payload["error_code"] == "invalid_handoff_mode"
+    assert payload["handoff_mode"] == "banana"
+    assert state.read_bytes() == before
+
+
+def test_handoff_mode_set_repairs_invalid_frontmatter_on_quiescent_goal(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    registry, state = _write_workspace(tmp_path, handoff_mode="banana")
+    before = state.read_bytes()
+
+    exit_code, payload = _run_cli(
+        capsys,
+        registry,
+        "handoff-mode",
+        "set",
+        "--goal-id",
+        GOAL_ID,
+        "--mode",
+        HANDOFF_MODE_HARD_LEASE,
+    )
+
+    assert exit_code == 0
+    assert payload["ok"] is True
+    assert payload["changed"] is True
+    assert payload["previous_mode"] == "banana"
+    assert payload["previous_mode_valid"] is False
+    assert payload["previous_mode_error_code"] == "invalid_handoff_mode"
+    assert payload["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
+    assert state.read_bytes() == before.replace(
+        b"handoff_mode: banana", b"handoff_mode: hard_lease"
+    )
 
 
 def test_handoff_mode_set_on_quiescent_goal_updates_frontmatter(
@@ -154,6 +214,37 @@ def test_handoff_mode_set_on_quiescent_goal_updates_frontmatter(
     assert show_payload["source"] == "frontmatter"
 
 
+def test_handoff_mode_set_invalid_previous_mode_still_refuses_claimed_todo(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    registry, state = _write_workspace(tmp_path)
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+    _set_frontmatter_mode(state, "banana")
+    before = state.read_bytes()
+
+    exit_code, payload = _run_cli(
+        capsys,
+        registry,
+        "handoff-mode",
+        "set",
+        "--goal-id",
+        GOAL_ID,
+        "--mode",
+        HANDOFF_MODE_SOFT_CLAIM,
+    )
+
+    assert exit_code == 1
+    assert payload["error_code"] == "handoff_mode_not_quiescent"
+    assert payload["previous_mode"] == "banana"
+    assert payload["previous_mode_valid"] is False
+    assert payload["previous_mode_error_code"] == "invalid_handoff_mode"
+    assert [item["todo_id"] for item in payload["claimed_todos"]] == [
+        todo["todo_id"]
+    ]
+    assert state.read_bytes() == before
+
+
 def test_handoff_mode_set_refused_when_open_claimed_todo_exists(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -180,6 +271,46 @@ def test_handoff_mode_set_refused_when_open_claimed_todo_exists(
     assert [item["todo_id"] for item in claimed] == [todo["todo_id"]]
     assert claimed[0]["claimed_by"] == AGENT_A
     assert state.read_text(encoding="utf-8") == before
+
+
+def test_handoff_mode_set_invalid_previous_mode_still_refuses_active_lease(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    registry, state = _write_workspace(tmp_path)
+    todo = _add_todo(registry)
+    acquire_task_lease(
+        registry_path=registry,
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        owner=AGENT_A,
+        idempotency_key="turn-invalid-mode-lease",
+        ttl_seconds=600,
+    )
+    _set_frontmatter_mode(state, "banana")
+    before = state.read_bytes()
+
+    exit_code, payload = _run_cli(
+        capsys,
+        registry,
+        "handoff-mode",
+        "set",
+        "--goal-id",
+        GOAL_ID,
+        "--mode",
+        HANDOFF_MODE_HARD_LEASE,
+    )
+
+    assert exit_code == 1
+    assert payload["error_code"] == "handoff_mode_not_quiescent"
+    assert payload["previous_mode"] == "banana"
+    assert payload["previous_mode_valid"] is False
+    assert payload["previous_mode_error_code"] == "invalid_handoff_mode"
+    assert [item["todo_id"] for item in payload["active_leases"]] == [
+        todo["todo_id"]
+    ]
+    assert state.read_bytes() == before
 
 
 def test_handoff_mode_set_refused_when_time_active_lease_exists(

--- a/tests/control_plane/test_goal_handoff_mode_cli.py
+++ b/tests/control_plane/test_goal_handoff_mode_cli.py
@@ -1,0 +1,329 @@
+"""CLI surface for the per-goal handoff mode: show/set plus error-code mapping.
+
+``loopx handoff-mode show|set`` reads and writes the ``handoff_mode`` key in
+the goal's ACTIVE_GOAL_STATE.md YAML front-matter. Setting requires quiescence
+(no open claimed todo, no time-active lease) and refuses with a typed offender
+list otherwise; there is no --force in v0. Gate rejections raised by todo and
+task-lease verbs must surface their typed error codes through the existing
+CLI error_code mapping.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from loopx.cli import main as cli_main
+from loopx.control_plane.todos.handoff_mode import (
+    HANDOFF_MODE_HARD_LEASE,
+    HANDOFF_MODE_LEGACY,
+    HANDOFF_MODE_SOFT_CLAIM,
+)
+from loopx.control_plane.work_items.task_lease import acquire_task_lease
+from loopx.todos import add_goal_todo, update_goal_todo
+
+GOAL_ID = "handoff-mode-cli"
+AGENT_A = "agent-a"
+AGENT_B = "agent-b"
+
+
+def _write_workspace(
+    tmp_path: Path,
+    *,
+    handoff_mode: str | None = None,
+) -> tuple[Path, Path]:
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    state = repo / "ACTIVE_GOAL_STATE.md"
+    front_matter = [
+        "---",
+        f"goal_id: {GOAL_ID}",
+        "updated_at: 2026-08-01T00:00:00+00:00",
+    ]
+    if handoff_mode is not None:
+        front_matter.append(f"handoff_mode: {handoff_mode}")
+    front_matter.append("---")
+    state.write_text(
+        "\n".join([*front_matter, "", "## Agent Todo", ""]) + "\n",
+        encoding="utf-8",
+    )
+    registry = tmp_path / "registry.global.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "common_runtime_root": str(tmp_path / "runtime"),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "harness_self_improvement",
+                        "status": "active",
+                        "repo": str(repo),
+                        "state_file": state.name,
+                        "adapter": {"kind": "harness_self_improvement"},
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": [AGENT_A, AGENT_B],
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return registry, state
+
+
+def _run_cli(
+    capsys: pytest.CaptureFixture[str],
+    registry: Path,
+    *argv: str,
+) -> tuple[int, dict[str, Any]]:
+    exit_code = cli_main(
+        ["--registry", str(registry), "--format", "json", *argv]
+    )
+    captured = capsys.readouterr()
+    return exit_code, json.loads(captured.out)
+
+
+def _add_todo(registry: Path, *, claimed_by: str | None = None) -> dict[str, Any]:
+    return add_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="agent",
+        text="Deliver one bounded control-plane change.",
+        task_class="advancement_task",
+        claimed_by=claimed_by,
+    )
+
+
+# ---------------------------------------------------------------------------
+# (e) mode switch CLI: show / set with quiescence enforcement.
+# ---------------------------------------------------------------------------
+
+
+def test_handoff_mode_show_defaults_to_legacy(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    registry, _state = _write_workspace(tmp_path)
+
+    exit_code, payload = _run_cli(
+        capsys, registry, "handoff-mode", "show", "--goal-id", GOAL_ID
+    )
+
+    assert exit_code == 0
+    assert payload["ok"] is True
+    assert payload["handoff_mode"] == HANDOFF_MODE_LEGACY
+    assert payload["source"] == "default"
+
+
+def test_handoff_mode_set_on_quiescent_goal_updates_frontmatter(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    registry, state = _write_workspace(tmp_path)
+
+    exit_code, payload = _run_cli(
+        capsys,
+        registry,
+        "handoff-mode",
+        "set",
+        "--goal-id",
+        GOAL_ID,
+        "--mode",
+        HANDOFF_MODE_HARD_LEASE,
+    )
+
+    assert exit_code == 0
+    assert payload["ok"] is True
+    assert payload["changed"] is True
+    assert payload["previous_mode"] == HANDOFF_MODE_LEGACY
+    assert payload["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
+    text = state.read_text(encoding="utf-8")
+    assert "handoff_mode: hard_lease" in text.split("---")[1]
+    assert f"goal_id: {GOAL_ID}" in text
+
+    show_code, show_payload = _run_cli(
+        capsys, registry, "handoff-mode", "show", "--goal-id", GOAL_ID
+    )
+    assert show_code == 0
+    assert show_payload["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
+    assert show_payload["source"] == "frontmatter"
+
+
+def test_handoff_mode_set_refused_when_open_claimed_todo_exists(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    registry, state = _write_workspace(tmp_path)
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+    before = state.read_text(encoding="utf-8")
+
+    exit_code, payload = _run_cli(
+        capsys,
+        registry,
+        "handoff-mode",
+        "set",
+        "--goal-id",
+        GOAL_ID,
+        "--mode",
+        HANDOFF_MODE_SOFT_CLAIM,
+    )
+
+    assert exit_code == 1
+    assert payload["ok"] is False
+    assert payload["error_code"] == "handoff_mode_not_quiescent"
+    claimed = payload["claimed_todos"]
+    assert [item["todo_id"] for item in claimed] == [todo["todo_id"]]
+    assert claimed[0]["claimed_by"] == AGENT_A
+    assert state.read_text(encoding="utf-8") == before
+
+
+def test_handoff_mode_set_refused_when_time_active_lease_exists(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    registry, _state = _write_workspace(tmp_path)
+    todo = _add_todo(registry)
+    acquire_task_lease(
+        registry_path=registry,
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        owner=AGENT_A,
+        idempotency_key="turn-lease-1",
+        ttl_seconds=600,
+    )
+
+    exit_code, payload = _run_cli(
+        capsys,
+        registry,
+        "handoff-mode",
+        "set",
+        "--goal-id",
+        GOAL_ID,
+        "--mode",
+        HANDOFF_MODE_HARD_LEASE,
+    )
+
+    assert exit_code == 1
+    assert payload["error_code"] == "handoff_mode_not_quiescent"
+    leases = payload["active_leases"]
+    assert [item["todo_id"] for item in leases] == [todo["todo_id"]]
+    assert leases[0]["owner"] == AGENT_A
+
+
+def test_handoff_mode_set_allowed_after_goal_becomes_quiescent(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    registry, _state = _write_workspace(tmp_path)
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+    update_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        agent_id=AGENT_A,
+        clear_claim=True,
+    )
+
+    exit_code, payload = _run_cli(
+        capsys,
+        registry,
+        "handoff-mode",
+        "set",
+        "--goal-id",
+        GOAL_ID,
+        "--mode",
+        HANDOFF_MODE_SOFT_CLAIM,
+    )
+
+    assert exit_code == 0
+    assert payload["ok"] is True
+    assert payload["handoff_mode"] == HANDOFF_MODE_SOFT_CLAIM
+
+
+def test_handoff_mode_set_same_value_is_idempotent(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    registry, _state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_SOFT_CLAIM)
+
+    exit_code, payload = _run_cli(
+        capsys,
+        registry,
+        "handoff-mode",
+        "set",
+        "--goal-id",
+        GOAL_ID,
+        "--mode",
+        HANDOFF_MODE_SOFT_CLAIM,
+    )
+
+    assert exit_code == 0
+    assert payload["ok"] is True
+    assert payload["changed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Typed error-code mapping through the existing CLI surfaces.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_todo_claim_in_hard_mode_maps_typed_error_code(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    registry, _state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry)
+
+    exit_code, payload = _run_cli(
+        capsys,
+        registry,
+        "todo",
+        "claim",
+        "--goal-id",
+        GOAL_ID,
+        "--todo-id",
+        todo["todo_id"],
+        "--claimed-by",
+        AGENT_B,
+        "--agent-id",
+        AGENT_B,
+    )
+
+    assert exit_code == 1
+    assert payload["ok"] is False
+    assert payload["error_code"] == "handoff_mode_requires_lease"
+    assert payload["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
+
+
+def test_cli_task_lease_acquire_in_soft_mode_maps_typed_error_code(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    registry, _state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_SOFT_CLAIM)
+    todo = _add_todo(registry)
+
+    exit_code, payload = _run_cli(
+        capsys,
+        registry,
+        "task-lease",
+        "acquire",
+        "--goal-id",
+        GOAL_ID,
+        "--todo-id",
+        todo["todo_id"],
+        "--owner",
+        AGENT_A,
+        "--idempotency-key",
+        "turn-lease-1",
+    )
+
+    assert exit_code == 1
+    assert payload["ok"] is False
+    assert payload["error_code"] == "handoff_mode_forbids_lease"
+    assert payload["handoff_mode"] == HANDOFF_MODE_SOFT_CLAIM


### PR DESCRIPTION
按已合入的 RFC 附录 B（#3042）实现 per-goal 交接模式门禁。附录 B 是本 PR 的验收依据。

## 问题

领任务的两本账可以各说各话：一个 agent 拿到某个 todo 的硬租约，另一个 agent 之后仍能软认领同一个 todo，两边都成功。分叉之后软认领方全胜——后来的软认领让先前的活租约直接失效，完成栅栏在这种矛盾状态下自动失效让软认领方不带钥匙就能完成，持约人反而因为授权先看软认领而完不成。

修法不是让两本账互相同步，而是让每个 goal 声明一种交接模式，用门禁挡住用错方式领任务的一端。

## 三种模式

`handoff_mode` 写在 goal 状态文件的 YAML 头部。字段放在这里而不是 registry，因为状态文件是会跨端流转的那个文件，租约 JSON 和 registry 都是单机的。

**不填或 `legacy`（默认）**：与今天完全一样，两种领法都开放。

**`soft_claim`**：只用软认领。`task-lease acquire/renew/transfer` 被拒绝（`handoff_mode_forbids_lease`）；`release` 与 `inspect` 保留，用于清理和查看遗留租约。

**`hard_lease`**：改动**已有** todo 的认领关系必须持有它的活租约（`handoff_mode_requires_lease`），完成必须带钥匙，矛盾态不再自动失效而是响亮报错（`handoff_mode_lease_claim_divergence`）。创建工作时顺手指定认领人仍然放行，因为那个 todo id 还不存在，不可能持有租约。

切换模式要求静止：goal 内还有未完成的认领或活租约时拒绝切换并列出阻挡者（`handoff_mode_not_quiescent`），v0 不提供强制切换。`hard_lease` 保留一扇门：既有的委托授权（`coordination.todo_lifecycle_authority`，附说明理由）可以不持租约改认领，结果里带 `handoff_gate_overridden` 标记，可审计。不新增任何绕过开关。

新增 `loopx handoff-mode show|set` 两个子命令。

## 三件必须说清楚的事

**一、合并这个 PR 不会给任何现存 goal 止血。** 默认是 legacy，所有现存 goal 都是 legacy，分叉的口子在这些 goal 上依然全开。这是有意保留的默认值，不是疏漏——它让存量行为零变化。真正的止血发生在有 goal 实际切到 `hard_lease` 或 `soft_claim` 的那一刻。附录 B 的第一条配套约定要求实现 PR 明说这一点。

**二、`hard_lease` 下人工决策 gate 的完成也需要租约。** 完成栅栏对所有 todo 强制生效，user 角色的 gate todo 不例外；而 user gate 自己的决策域覆写不会打开委托授权那扇门。这意味着在 hard 模式下，完成一个人工决策 gate 需要有 agent 先取得租约并交接钥匙。这忠实于附录 B 的文本（"完成必须带钥匙"，没有角色例外），但它是一个当时没有单独讨论过的运维后果，请确认是否仍然接受。租约在 user todo 上是可获取的，所以不存在死锁；不接受的话可以把 user 角色显式豁免。

**三、静止态检查是"已落盘状态"级别的，不是全投影级别的。** 它读锁内的状态文件正文加本机活租约文件，不合并事件投影，所以只存在于事件日志里的认领会被漏掉。切换成功因此不构成"每一份投影都静止"的证明。附录 B 第五条读起来像一个绝对保证，实际实现是这个范围。真正的安全边界是每次写入时的门禁，它在切换之后照常拦截——测试里钉了这个组合。

## 关于 `todo add`

`todo add` 会按文本匹配已存在的开放 todo 并更新它的元数据，所以 `--claimed-by` 在那条分支上改的是一个已经存在、可能已经持有租约的 todo 的认领人。这条路既不过生命周期授权也不过门禁，在 hard 模式下正好绕开了这个模式要守的规则，而且落到一个比 legacy 更糟的状态：持约人被授权挡住、新认领人被矛盾态挡住、goal 又因为不静止而无法切回模式。

本 PR 把这条分支接进同一个门禁、同样的锁序、同样的类型化拒绝。创建 todo 在所有模式下仍然放行；用已经持有的认领人重复 add 不算认领变更，也不拦。委托授权那扇门在这条路上不开——带授权的改派走 `todo update --claimed-by`，那才是这个动作对应的动词。

## 验证

- 新增两个测试文件共 60 个用例（48 + 12）：legacy 行为的 characterization 钉子（含分叉洞本身）、soft/hard 两种模式的门禁、委托授权门、身份归一化、静止态切换、CLI 错误码映射，以及 `todo add` 这条路的五个用例（外部租约拦截、创建放行、重复 add 放行、持约人可改派、legacy 行为钉死）。
- `tests/control_plane` 与 `tests/canary` 全量 1179 通过 0 失败。
- `tests/cli_commands`、`tests/architecture`、CLI 诊断、entrypoint、turn driver 共 147 通过。
- 真实 CLI 驱动过全部行为：非法模式值的修复、hard 模式下非持约人被拒、持约人成功、完成路径、非静止时切换被拒与静止后切换成功、以及 `todo add` 绕过被拦且 legacy 下行为不变。
- `loopx/todos.py` 2140 行，未改动模块预算上限（2142）。ruff 干净。

## 已知边界

- 跨端窗口：共享模式之前，模式跟着状态文件同步（后写者胜），两端可能短暂看到不同的值。门禁会收敛，但消除不了这个窗口。
- 手工编辑状态文件头部可以绕过静止态检查，这属于契约之外。
- legacy 模式下的分叉洞按设计保留，已由 characterization 用例钉住。
