### PR TITLE
docs(rfc): record ABPM derivation background in goal artifact lifecycle RFC

### DIFF
--- a/docs/architecture/rfcs/README.md
+++ b/docs/architecture/rfcs/README.md
@@ -13,7 +13,7 @@ defined by the implementation and stable reference contracts.
 - [Goal Channel collaboration v0](goal-channel-collaboration-v0.md): bind one external collaboration channel to one LoopX goal while preserving LoopX as the source of truth.
 - [Goal Channel 协作模型 v0](goal-channel-collaboration-v0.zh-CN.md): 将一个外部协作通道绑定到一个 LoopX goal，同时保持 LoopX 作为事实源。
 - [Shared-goal online authority and pluggable coordination provider v0](shared-goal-authority-state-provider-v0.md): a claim-only contract proof for target-scoped conflicts over one canonical coordination aggregate, atomic original-receipt replay, and per-layer persistence ownership, with NoKV as an unpromoted provider candidate ([中文版](shared-goal-authority-state-provider-v0.zh-CN.md), [validation boundary](shared-goal-authority-state-provider-v0-evidence.zh-CN.md)).
-- [Goal artifact lifecycle projection v0](goal-artifact-lifecycle-projection-v0.md): treat a goal as a business artifact with derived milestones, blocking guards, and legal next transitions, projected read-only for operators and global views ([中文版](goal-artifact-lifecycle-projection-v0.zh-CN.md)).
+- [Goal artifact lifecycle projection v0](goal-artifact-lifecycle-projection-v0.md): derived from artifact-centric business process management (ABPM / GSM milestone-guard semantics); treat a goal as a business artifact with derived milestones, blocking guards, and legal next transitions, projected read-only for operators and global views ([中文版](goal-artifact-lifecycle-projection-v0.zh-CN.md)).
 
 RFCs must not contain internal conversations, private links, local filesystem
 paths, credentials, raw transcripts, or non-public organizational context.

--- a/docs/architecture/rfcs/goal-artifact-lifecycle-projection-v0.md
+++ b/docs/architecture/rfcs/goal-artifact-lifecycle-projection-v0.md
@@ -13,6 +13,26 @@
 
 ---
 
+## Background: Derived From Artifact-Centric Business Process Management
+
+This RFC is derived from **artifact-based business process management (ABPM)**,
+the artifact-centric line of process research that models work around business
+artifacts rather than flowcharts. In ABPM, a business artifact is an entity
+with identity and an explicit lifecycle; **guard conditions** gate each state
+transition, and **milestones** are the externally meaningful progress points a
+case can reach. The Guard-Stage-Milestone (GSM) model is the best-known form of
+this semantics.
+
+LoopX already follows part of that philosophy: goals, todos, gates, evidence,
+leases, and run history are typed, and several bounded contexts (content items,
+benchmark cases, observable artifact handles) already have artifact-like
+lifecycles. What is missing is the artifact lens at the goal layer itself.
+
+This RFC adopts only the artifact-lifecycle vocabulary (milestone / guard /
+next-transition) as a read-only projection for goals. It deliberately does not
+adopt process engines, flowcharts, or a unified lifecycle abstraction; those
+are non-goals in Section 2.
+
 ## 0. An Example to Help Everyone Understand
 
 An operator opens the dashboard for a long-running benchmark-qualification

--- a/docs/architecture/rfcs/goal-artifact-lifecycle-projection-v0.zh-CN.md
+++ b/docs/architecture/rfcs/goal-artifact-lifecycle-projection-v0.zh-CN.md
@@ -9,6 +9,14 @@
 
 ---
 
+## 背景：由 Artifact-Centric 业务流程管理（ABPM）衍生
+
+本 RFC 由 **artifact-based business process management（ABPM）** 衍生而来。ABPM 是流程研究里以工件为中心的路线：把工作建模为“业务工件”而不是流程图。在 ABPM 中，业务工件是带身份和显式生命周期的实体；**guard condition（守卫条件）** 决定每个状态迁移是否合法，**milestone（里程碑）** 是 case 可以到达的、对外有意义的进度点。Guard-Stage-Milestone（GSM）是这个语义最著名的形态。
+
+LoopX 已经部分遵循这套哲学：goal、todo、gate、evidence、lease、run history 都是 typed 的，多个 bounded context（content item、benchmark case、observable artifact handle）已经有了类似工件生命周期。缺的是 **goal 这一层本身**的工件视角。
+
+本 RFC 只借用 artifact-lifecycle 的词汇（milestone / guard / next-transition），把它作为 goal 的只读投影。明确不采用流程引擎、流程图或统一生命周期抽象——这些是第 2 节里的非目标。
+
 ## 0. 一个帮助理解的例子
 
 运维打开一个长跑 benchmark 认证 goal 的 dashboard。这个 goal 已经跑了几周。页面上有 todo 数量、quota 状态、reason codes、最近一次 run 的 classification。但没有一个能回答运维真正关心的三个问题：


### PR DESCRIPTION
## What

Adds the derivation background to the Goal Artifact Lifecycle Projection RFC (EN + zh-CN mirrors): the proposal comes from **artifact-based business process management (ABPM)**, specifically the Guard-Stage-Milestone milestone-guard semantics, and adopts only the artifact-lifecycle vocabulary as a read-only goal projection while process engines and lifecycle unification stay explicit non-goals. The RFC index entry now names the derivation.

## Validation

- `python3 examples/docs-governance-smoke.py`: passed
- `loopx check` on the three changed files: public boundary clean
- `git diff --check`: clean