### PR TITLE
chore(release): bump version to 0.4.6

### DIFF
--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.5"
+__version__ = "0.4.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.4.5"
+version = "0.4.6"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## What

Bump `pyproject.toml` and `loopx/__init__.py` to 0.4.6 ahead of the v0.4.6 release.

## Validation

- `scripts/release_artifacts.py expected-tag` -> `v0.4.6`
- `tests/test_doctor_install_freshness.py`: 8 passed
- Release body validated with `examples/release/release-readiness-doc-smoke.py --expect-no-optional-capability-changes` (v0.4.6 has no optional capability/host surface changes)