### PR TITLE
feat(explore): project explicit composition frontier

### DIFF
--- a/docs/architecture/rfcs/research-exploration-control-plane-v0.md
+++ b/docs/architecture/rfcs/research-exploration-control-plane-v0.md
@@ -407,6 +407,52 @@ The packet selects at most one obligation for one agent turn. Status and
 drill-down commands may expose a separately bounded list and total counts. No
 hot path should enumerate every candidate pair or copy full evidence bodies.
 
+### 8.4 Bounded Autonomous Model Selection (Deferred)
+
+Eligibility and ranking are different decisions. The control plane proves that
+a candidate is legal, still pending, scoped to the current goal and agent, and
+within evidence, capability, authority, and projection budgets. It must not
+present a structural ordering as a success probability. A single eligible gap
+may be projected directly. When several gaps are eligible, a later
+implementation should deliver at most three public-safe typed candidate cards
+and let the model choose which one is most valuable to execute first.
+
+Each bounded candidate card should include at least:
+
+- experiment identity and normalized input node identities;
+- `interaction_kind` and typed closure basis;
+- each input's terminal result class and compact evidence abstract;
+- proposed probe family, capability readiness, cost class, and prior joint
+  attempt count;
+- the current obligation id and allowed outcomes.
+
+The model optimizes expected research value rather than a self-reported success
+probability. The first version should compare ordinal typed dimensions for
+breakthrough plausibility, information gain, falsifiability, execution cost,
+duplicate risk, and capability readiness. It must not publish or consume
+apparently precise numeric probabilities before calibration evidence exists.
+Model confidence is routing metadata only; it cannot create a finding, close a
+composition gap, or upgrade goal-acceptance truth.
+
+The model must return a bounded `composition_selection_v0` receipt containing
+at least the current obligation id, an experiment ref from the delivered
+candidate set, typed selection reasons, a confidence bucket, and bounded typed
+reasons for rejected alternatives. The semantic write gate must verify that:
+
+1. the obligation identity is still current;
+2. the selected experiment belongs to the candidate set actually delivered in
+   this turn;
+3. the candidate remains eligible and has no active bound successor;
+4. the successor binds both the obligation and experiment identities;
+5. the selection receipt is never treated as experiment-outcome evidence.
+
+Deterministic ordering may be used only as an explicit, observable weak-model
+fallback. It must not silently claim to have chosen the most promising
+candidate. M4 should first use real model-tool behavior and repeated live shadow
+to prove that a model can read candidate cards, select a legal candidate, and
+produce a meaningful experiment or justified dismissal. This RFC does not
+require M2 to implement the selection protocol.
+
 ## 9. Composition Gap Lifecycle
 
 The derived gap has a causal lifecycle even though its truth is computed from
@@ -728,6 +774,9 @@ events. Qualification should compare:
   direction;
 - composition-candidate precision: eligible gaps that lead to a meaningful
   experiment or justified dismissal;
+- autonomous-selection yield: meaningful experiments or justified dismissals
+  from model selections relative to the declared deterministic fallback;
+- out-of-set/invalid selection rate and time from selection to semantic outcome;
 - duplicate experiment rate;
 - false-obligation rate;
 - protocol/tooling share of total calls;
@@ -751,9 +800,9 @@ control-plane failures.
 |---|---|---|---|
 | M0 | RFC, current-state inventory, and explicit ownership decision | Maintainer review; no runtime behavior | Draft |
 | M1 | Characterization fixtures plus typed research observation and closure contract in Explore | Deterministic normalization, privacy, compatibility, and negative tests | Not started |
-| M2 | Explicit-only composition candidate, canonical gap projection, and read-only status shadow | No pairwise inference; bounded packet; projection parity | Not started |
+| M2 | Explicit-only composition candidate, canonical gap projection, and read-only status shadow | No pairwise inference; bounded packet; projection parity | Partially implemented (#3173: explicit experiment projection and successor binding) |
 | M3 | Goal-frontier obligation, exact Todo/experiment lineage, and shared write-time gate | State/replay matrix and premerge canary pass | Not started |
-| M4 | Real model-tool behavior qualification and repeated live shadow | Model selects the bound semantic action; compact receipts only | Not started |
+| M4 | Bounded multi-candidate cards, `composition_selection_v0`, real model-tool behavior qualification, and repeated live shadow | Model autonomously selects a legal semantic action from the delivered candidate set; selection quality is no worse than the declared fallback; compact receipts only | Not started |
 | M5 | Shared-constraint candidate ranking in shadow mode | Precision and cost evidence; no automatic trigger | Not started |
 | M6 | Optional inferred trigger | Explicit maintainer decision and measured promotion thresholds | Deferred |
 | M7 | N-ary composition or concurrent scheduling | A real second-order caller and authority boundary exist | Deferred |
@@ -855,6 +904,7 @@ This is a living RFC, not an append-only diary.
 | Date | Decision |
 |---|---|
 | 2026-08-13 | Adopt Explore as the canonical research-topology owner; choose explicit-only composition candidates for v0; represent joint work as an experiment node; defer shared-constraint inference to shadow qualification. |
+| 2026-08-13 | Separate eligibility from ranking: the control plane owns a legal bounded candidate set, while the model autonomously prioritizes among multiple eligible candidates. A selection receipt proves a scheduling choice, not research truth. Defer the protocol to M4 rather than adding it to the #3173 runtime slice. |
 
 ## 20. Acceptance Criteria for the RFC
 

--- a/docs/architecture/rfcs/research-exploration-control-plane-v0.zh-CN.md
+++ b/docs/architecture/rfcs/research-exploration-control-plane-v0.zh-CN.md
@@ -375,6 +375,44 @@ control-plane packet 不应该如此。
 另一份有界 list 和 total count。任何 hot path 都不能枚举所有 candidate pair
 或复制完整 evidence body。
 
+### 8.4 有界的模型自主选择（延后实现）
+
+Eligibility 与 ranking 是两个不同的判断。控制面负责证明 candidate 合法、仍然
+pending、位于当前 goal/agent scope，并满足 evidence、capability、authority 与
+projection budget；它不应把结构排序伪装成“成功概率”。当只有一个 eligible gap
+时可以直接投影它。当同时存在多个 eligible gap 时，后续实现应向模型交付最多三
+张 public-safe、类型化 candidate card，让模型选择最值得先执行的一个。
+
+Candidate card 至少应有界地携带：
+
+- experiment 与 normalized input node identity；
+- `interaction_kind` 与 typed closure basis；
+- 每个 input 的 terminal result class 和 compact evidence abstract；
+- proposed probe family、capability readiness、cost class 与 prior joint-attempt count；
+- 当前 obligation id 与允许的 outcome。
+
+模型的选择目标是预期研究价值，而不是自报的成功率。第一版使用 ordinal、typed
+维度比较 breakthrough plausibility、information gain、falsifiability、execution
+cost、duplicate risk 与 capability readiness；在没有校准 evidence 前，不发布或
+消费表面精确的数值 probability。模型 confidence 只是 routing metadata，不能产生
+finding、关闭 composition gap 或升级 goal acceptance truth。
+
+模型必须返回有界的 `composition_selection_v0` receipt，至少包括当前 obligation
+id、从交付 candidate set 中选择的 experiment ref、typed selection reasons、
+confidence bucket，以及被放弃候选的有界 typed reason。Semantic write gate 必须
+验证：
+
+1. obligation identity 仍是当前义务；
+2. selected experiment 属于本轮实际交付的 candidate set；
+3. candidate 仍 eligible，且没有 active bound successor；
+4. successor 同时绑定 obligation 与 experiment identity；
+5. selection receipt 不被误当成 experiment outcome evidence。
+
+确定性排序只可作为显式配置、可观测的弱模型 fallback，不能静默宣称它选中了
+“最有希望”的 candidate。M4 应先用真实 model-tool behavior 与重复 live shadow
+证明模型能够读取 candidate cards、选择合法候选并产生 meaningful experiment 或
+justified dismissal；本 RFC 不要求 M2 实现该选择协议。
+
 ## 9. Composition gap 生命周期
 
 尽管 gap truth 从 durable Explore event 派生，它仍有因果生命周期：
@@ -674,6 +712,9 @@ test 已足够。不要为假想 caller 增加 distributed coordination abstract
 - 真正产生新 runnable direction 的 replan obligation 比例；
 - composition-candidate precision：eligible gap 中产生 meaningful experiment
   或 justified dismissal 的比例；
+- autonomous-selection yield：模型选择相对于显式 deterministic fallback 产生
+  meaningful experiment 或 justified dismissal 的比例；
+- out-of-set/invalid selection rate，以及 selection 后到 semantic outcome 的时间；
 - duplicate experiment rate；
 - false-obligation rate；
 - protocol/tooling call 占比；
@@ -696,9 +737,9 @@ rule，以及 model variance 与 control-plane failure 的分离。
 |---|---|---|---|
 | M0 | RFC、current-state inventory 与显式 ownership decision | Maintainer review；无 runtime behavior | Draft |
 | M1 | Characterization fixture，以及 Explore 中的 typed research observation 与 closure contract | Deterministic normalization、privacy、compatibility 与 negative test | 未开始 |
-| M2 | Explicit-only composition candidate、canonical gap projection 与 read-only status shadow | 不做 pairwise inference；packet 有界；projection parity | 未开始 |
+| M2 | Explicit-only composition candidate、canonical gap projection 与 read-only status shadow | 不做 pairwise inference；packet 有界；projection parity | 部分实现（#3173：显式 experiment 投影与 successor binding） |
 | M3 | Goal-frontier obligation、精确 Todo/experiment lineage 与共享 write-time gate | State/replay matrix 与 premerge canary 通过 | 未开始 |
-| M4 | 真实 model-tool behavior qualification 与重复 live shadow | 模型选择绑定的 semantic action；只保留 compact receipt | 未开始 |
+| M4 | 有界 multi-candidate card、`composition_selection_v0`、真实 model-tool behavior qualification 与重复 live shadow | 模型从交付 candidate set 中自主选择合法 semantic action；选择质量不劣于 declared fallback；只保留 compact receipt | 未开始 |
 | M5 | Shared-constraint candidate 在 shadow mode 中排序 | 有 precision/cost evidence；不自动触发 | 未开始 |
 | M6 | 可选 inferred trigger | 显式 maintainer decision 与量化 promotion threshold | 延后 |
 | M7 | N-ary composition 或并发调度 | 存在真实 second-order caller 与 authority boundary | 延后 |
@@ -793,6 +834,7 @@ evidence-backed terminal result。
 | 日期 | 决策 |
 |---|---|
 | 2026-08-13 | 采用 Explore 作为 canonical research-topology owner；v0 选择 explicit-only composition candidate；joint work 表示为 experiment node；shared-constraint inference 延后到 shadow qualification。 |
+| 2026-08-13 | 将 eligibility 与 ranking 分离：控制面拥有合法、有界 candidate set，模型在多个 eligible candidate 中自主择优；selection receipt 只证明调度选择，不构成 research truth。该协议延后到 M4，不进入 #3173 的首期 runtime。 |
 
 ## 20. RFC 验收标准
 

--- a/loopx/capabilities/explore/composition_frontier.py
+++ b/loopx/capabilities/explore/composition_frontier.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from ...control_plane.quota.goal_boundary import registry_goal_by_id
+from ...control_plane.todos.contract import (
+    TODO_TASK_CLASS_ADVANCEMENT,
+    normalize_explore_result_node_refs,
+    normalize_todo_claimed_by,
+)
+from ...control_plane.todos.projection import (
+    todo_item_is_actionable_open,
+    todo_item_task_class,
+)
+from ...orchestration import compact_orchestration_policy
+from .result_log import (
+    NODE_KIND_EXPERIMENT,
+    NODE_STATUS_DEAD_END,
+    NODE_STATUS_EXPLORING,
+    NODE_STATUS_OPEN,
+    NODE_STATUS_RESOLVED,
+    build_explore_result_projection,
+    explore_result_log_path,
+    load_explore_result_events_strict,
+)
+
+COMPOSITION_FRONTIER_SCHEMA_VERSION = "loopx_explore_composition_frontier_v0"
+COMPOSITION_GAP_SCHEMA_VERSION = "loopx_explore_composition_gap_v0"
+COMPOSITION_EDGE_TYPE = "depends_on"
+MAX_PROJECTED_GAPS = 3
+
+_CLOSED_INPUT_STATUSES = {
+    NODE_STATUS_RESOLVED,
+    NODE_STATUS_DEAD_END,
+}
+_OPEN_EXPERIMENT_STATUSES = {
+    NODE_STATUS_OPEN,
+    NODE_STATUS_EXPLORING,
+}
+
+
+def _digest(value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(value, sort_keys=True, ensure_ascii=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:16]
+
+
+def _todo_items(*sources: Any) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for source in sources:
+        if not isinstance(source, Mapping):
+            continue
+        for raw in source.get("items") or []:
+            if not isinstance(raw, Mapping):
+                continue
+            item = dict(raw)
+            identity = str(item.get("todo_id") or item.get("index") or "").strip()
+            if not identity:
+                identity = _digest(item)
+            if identity in seen:
+                continue
+            seen.add(identity)
+            items.append(item)
+    return items
+
+
+def _bound_experiment_refs(
+    todos: Sequence[Mapping[str, Any]],
+    *,
+    agent_id: str | None,
+) -> set[str]:
+    safe_agent_id = normalize_todo_claimed_by(agent_id)
+    refs: set[str] = set()
+    for todo in todos:
+        if not todo_item_is_actionable_open(dict(todo)):
+            continue
+        if todo_item_task_class(dict(todo)) != TODO_TASK_CLASS_ADVANCEMENT:
+            continue
+        claimed_by = normalize_todo_claimed_by(todo.get("claimed_by"))
+        if safe_agent_id and claimed_by != safe_agent_id:
+            continue
+        refs.update(normalize_explore_result_node_refs(todo.get("explore_result_node_refs")))
+    return refs
+
+
+def _evidence_backed(node: Mapping[str, Any]) -> bool:
+    return bool(node.get("evidence_refs") or int(node.get("finding_count") or 0) > 0)
+
+
+def build_explore_composition_frontier(
+    projection: Mapping[str, Any],
+    *,
+    todos: Sequence[Mapping[str, Any]] = (),
+    agent_id: str | None = None,
+    enabled: bool,
+) -> dict[str, Any]:
+    """Project explicit, evidence-backed composition experiments as bounded gaps.
+
+    A composition experiment is an existing open Explore ``experiment`` node
+    with at least two outgoing ``depends_on`` edges to closed, evidence-backed
+    input nodes.  The projection never infers arbitrary node pairs, so its
+    runtime and reviewer surface remain linear in the recorded graph.
+    """
+
+    goal_id = str(projection.get("goal_id") or "").strip()
+    base: dict[str, Any] = {
+        "schema_version": COMPOSITION_FRONTIER_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "enabled": bool(enabled),
+        "derivation": "explicit_experiment_dependencies",
+        "candidate_count": 0,
+        "pending_count": 0,
+        "scheduled_count": 0,
+        "gaps": [],
+        "selected_gap": None,
+    }
+    if not enabled:
+        base["state"] = "disabled"
+        base["reason"] = "explore_harness_opt_in_required"
+        return base
+
+    nodes = [node for node in projection.get("nodes") or [] if isinstance(node, Mapping)]
+    edges = [edge for edge in projection.get("edges") or [] if isinstance(edge, Mapping)]
+    nodes_by_id = {
+        str(node.get("node_id") or ""): node
+        for node in nodes
+        if str(node.get("node_id") or "")
+    }
+    inputs_by_experiment: dict[str, set[str]] = {}
+    for edge in edges:
+        if str(edge.get("edge_type") or "") != COMPOSITION_EDGE_TYPE:
+            continue
+        experiment_id = str(edge.get("from_node") or "")
+        input_id = str(edge.get("to_node") or "")
+        if experiment_id and input_id:
+            inputs_by_experiment.setdefault(experiment_id, set()).add(input_id)
+
+    bound_refs = _bound_experiment_refs(todos, agent_id=agent_id)
+    candidates: list[dict[str, Any]] = []
+    for experiment_id, input_ids in inputs_by_experiment.items():
+        experiment = nodes_by_id.get(experiment_id)
+        if not isinstance(experiment, Mapping):
+            continue
+        if str(experiment.get("node_kind") or "") != NODE_KIND_EXPERIMENT:
+            continue
+        if str(experiment.get("status") or "") not in _OPEN_EXPERIMENT_STATUSES:
+            continue
+        inputs = [nodes_by_id.get(input_id) for input_id in sorted(input_ids)]
+        if len(inputs) < 2 or any(not isinstance(node, Mapping) for node in inputs):
+            continue
+        if any(str(node.get("status") or "") not in _CLOSED_INPUT_STATUSES for node in inputs):
+            continue
+        if any(not _evidence_backed(node) for node in inputs):
+            continue
+        scheduled = experiment_id in bound_refs
+        input_refs = [str(node.get("node_id") or "") for node in inputs]
+        gap_identity = {
+            "goal_id": goal_id,
+            "experiment_node_ref": experiment_id,
+            "input_node_refs": input_refs,
+        }
+        candidates.append(
+            {
+                "schema_version": COMPOSITION_GAP_SCHEMA_VERSION,
+                "gap_id": "composition-" + _digest(gap_identity),
+                "experiment_node_ref": experiment_id,
+                "input_node_refs": input_refs,
+                "input_count": len(input_refs),
+                "title": str(experiment.get("title") or "")[:200],
+                "status": "scheduled" if scheduled else "pending",
+                "required_outcome": "joint_experiment_result",
+                "successor_summary": (
+                    "Run the bounded joint experiment: "
+                    + str(experiment.get("title") or experiment_id)
+                )[:240],
+                "successor_binding": {
+                    "explore_result_node_refs": [experiment_id],
+                },
+            }
+        )
+
+    candidates.sort(
+        key=lambda gap: (
+            gap["status"] != "pending",
+            -int(gap["input_count"]),
+            str(gap["gap_id"]),
+        )
+    )
+    pending = [gap for gap in candidates if gap["status"] == "pending"]
+    base.update(
+        {
+            "state": "pending" if pending else "satisfied",
+            "candidate_count": len(candidates),
+            "pending_count": len(pending),
+            "scheduled_count": len(candidates) - len(pending),
+            "gaps": candidates[:MAX_PROJECTED_GAPS],
+            "selected_gap": pending[0] if pending else None,
+        }
+    )
+    return base
+
+
+def project_live_explore_composition_frontier(
+    *,
+    runtime_root: Path,
+    goal_id: str,
+    agent_id: str | None,
+    status_payload: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    """Read the goal's Explore graph for one live quota decision.
+
+    The goal boundary remains the only opt-in authority.  Invalid logs fail
+    closed into a compact unavailable projection rather than breaking quota.
+    """
+
+    goal = registry_goal_by_id(status_payload).get(goal_id) or next(
+        (
+            candidate
+            for candidate in (
+                status_payload.get("run_history", {}).get("goals", [])
+                if isinstance(status_payload.get("run_history"), Mapping)
+                else []
+            )
+            if isinstance(candidate, Mapping)
+            and str(candidate.get("id") or "") == goal_id
+        ),
+        {},
+    )
+    orchestration = compact_orchestration_policy(goal.get("spawn_policy"))
+    harness = (
+        orchestration.get("explore_harness")
+        if isinstance(orchestration.get("explore_harness"), Mapping)
+        else {}
+    )
+    enabled = harness.get("enabled") is True
+    log_path = explore_result_log_path(runtime_root, goal_id)
+    if not enabled:
+        return None
+    try:
+        events = load_explore_result_events_strict(log_path, goal_id=goal_id)
+    except ValueError:
+        return {
+            "schema_version": COMPOSITION_FRONTIER_SCHEMA_VERSION,
+            "goal_id": goal_id,
+            "enabled": enabled,
+            "state": "unavailable",
+            "reason": "invalid_explore_result_log",
+            "candidate_count": 0,
+            "pending_count": 0,
+            "scheduled_count": 0,
+            "gaps": [],
+            "selected_gap": None,
+        }
+    projection = build_explore_result_projection(events, goal_id=goal_id)
+    item = next(
+        (
+            candidate
+            for candidate in (
+                status_payload.get("attention_queue", {}).get("items", [])
+                if isinstance(status_payload.get("attention_queue"), Mapping)
+                else []
+            )
+            if isinstance(candidate, Mapping)
+            and str(candidate.get("goal_id") or "") == goal_id
+        ),
+        {},
+    )
+    project_asset = (
+        item.get("project_asset")
+        if isinstance(item.get("project_asset"), Mapping)
+        else {}
+    )
+    item_todos = item.get("agent_todos") if isinstance(item.get("agent_todos"), Mapping) else {}
+    asset_todos = (
+        project_asset.get("agent_todos")
+        if isinstance(project_asset.get("agent_todos"), Mapping)
+        else {}
+    )
+    return build_explore_composition_frontier(
+        projection,
+        todos=_todo_items(item_todos, asset_todos),
+        agent_id=agent_id,
+        enabled=enabled,
+    )

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -5,6 +5,9 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
+from ..capabilities.explore.composition_frontier import (
+    project_live_explore_composition_frontier,
+)
 from ..control_plane.quota.cli_projection import (
     compact_quota_monitor_poll_cli_payload,
     compact_quota_should_run_cli_payload,
@@ -419,6 +422,9 @@ def handle_quota_command(
                 host_observation_resolver=resolve_codex_app_automation_rrule,
                 scheduler_execution_context=scheduler_context,
                 operator_inbox_urgency_projector=operator_inbox_urgency_projector,
+                bounded_research_frontier_projector=(
+                    project_live_explore_composition_frontier
+                ),
             )
             if heartbeat_turn_id:
                 heartbeat_receipt_existing = find_heartbeat_receipt(
@@ -463,6 +469,9 @@ def handle_quota_command(
                             turn_instance_id=heartbeat_turn_id,
                             scheduler_execution_context=scheduler_context,
                             operator_inbox_urgency_projector=operator_inbox_urgency_projector,
+                            bounded_research_frontier_projector=(
+                                project_live_explore_composition_frontier
+                            ),
                         )
                         if not poll.get("ok"):
                             raise RuntimeError(

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -17,7 +17,6 @@ from ..control_plane.quota.heartbeat_receipt import (
     fail_heartbeat_receipt,
     find_heartbeat_receipt,
     heartbeat_receipt_view,
-    upgrade_identityless_heartbeat_receipt,
 )
 from ..control_plane.quota.live_decision import build_live_quota_should_run_decision
 from ..control_plane.quota.monitor_poll import find_quota_monitor_poll_turn

--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -5,6 +5,9 @@ import json
 from collections.abc import Callable
 from pathlib import Path
 
+from ..capabilities.explore.composition_frontier import (
+    project_live_explore_composition_frontier,
+)
 from ..control_plane.quota.live_decision import build_live_quota_should_run_decision
 from ..control_plane.quota.turn_envelope import build_turn_envelope
 from ..control_plane.runtime.status_projection_cache import (
@@ -318,6 +321,9 @@ def handle_turn_command(
             route_source="loopx_turn_plan",
             scheduler_execution_context=scheduler_context,
             operator_inbox_urgency_projector=operator_inbox_urgency_projector,
+            bounded_research_frontier_projector=(
+                project_live_explore_composition_frontier
+            ),
         )
         resume_identity = {
             "goal_id": args.resume_goal_id,
@@ -577,6 +583,9 @@ def handle_turn_command(
                     route_source="loopx_turn_run_once",
                     scheduler_execution_context=turn_scheduler_context,
                     operator_inbox_urgency_projector=operator_inbox_urgency_projector,
+                    bounded_research_frontier_projector=(
+                        project_live_explore_composition_frontier
+                    ),
                 )
                 hint = latest.get("scheduler_hint") if isinstance(latest.get("scheduler_hint"), dict) else {}
                 phase = hint.get("execution_phase")

--- a/loopx/control_plane/quota/live_decision.py
+++ b/loopx/control_plane/quota/live_decision.py
@@ -12,6 +12,7 @@ from ..scheduler.execution_context import (
 
 
 HostObservationResolver = Callable[..., Mapping[str, Any]]
+BoundedResearchFrontierProjector = Callable[..., Mapping[str, Any] | None]
 
 
 def bind_scheduler_followup_cli_routes(
@@ -87,6 +88,7 @@ def build_live_quota_should_run_decision(
     route_source: str = "quota_cli_invocation",
     scheduler_execution_context: Mapping[str, Any] | SchedulerExecutionContextResolution | None = None,
     operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
+    bounded_research_frontier_projector: BoundedResearchFrontierProjector | None = None,
 ) -> dict[str, Any]:
     """Build one live CLI decision while keeping host observation injectable."""
 
@@ -107,8 +109,21 @@ def build_live_quota_should_run_decision(
         if observation.get("available") is True:
             observed_rrule = str(observation.get("rrule") or "")
             observed_automation_id = str(observation.get("automation_id") or "").strip()
+    decision_status_payload = status_payload
+    if bounded_research_frontier_projector is not None:
+        frontier = bounded_research_frontier_projector(
+            runtime_root=runtime_root,
+            goal_id=goal_id,
+            agent_id=agent_id,
+            status_payload=status_payload,
+        )
+        if isinstance(frontier, Mapping):
+            decision_status_payload = {
+                **status_payload,
+                "bounded_research_frontier": dict(frontier),
+            }
     payload = build_quota_should_run(
-        status_payload,
+        decision_status_payload,
         goal_id=goal_id,
         agent_id=agent_id,
         available_capabilities=available_capabilities,

--- a/loopx/control_plane/quota/should_run_packet.py
+++ b/loopx/control_plane/quota/should_run_packet.py
@@ -1070,6 +1070,17 @@ def _build_quota_should_run_payload(
         next_action_warning=route.next_action_warning,
         replan_obligation=prepared.replan_obligation,
     )
+    bounded_research_frontier = (
+        prepared.status_payload.get("bounded_research_frontier")
+        if isinstance(
+            prepared.status_payload.get("bounded_research_frontier"), dict
+        )
+        else None
+    )
+    _attach_truthy_fields(
+        payload,
+        bounded_research_frontier=bounded_research_frontier,
+    )
     _apply_agent_monitor_only_precedence(
         payload,
         monitor_only=prepared.agent_monitor_only,
@@ -1082,6 +1093,7 @@ def _build_quota_should_run_payload(
             agent_id=(
                 quota_decision_agent_id(payload) or prepared.requested_agent_id
             ),
+            bounded_research_frontier=bounded_research_frontier,
         )
     payload["automation_liveness"] = build_automation_liveness(payload)
     payload["interaction_contract"] = build_interaction_contract(

--- a/loopx/control_plane/quota/turn_envelope.py
+++ b/loopx/control_plane/quota/turn_envelope.py
@@ -297,6 +297,7 @@ def _replan_action_packet(payload: Mapping[str, Any]) -> dict[str, Any] | None:
             "uncovered_frontier",
             "required_outcome",
             "allowed_terminal",
+            "bounded_frontier",
         ),
     )
     return compact or None

--- a/loopx/control_plane/testing/replan_semantic_action_behavior.py
+++ b/loopx/control_plane/testing/replan_semantic_action_behavior.py
@@ -46,6 +46,7 @@ _FIXTURE_NEW_SURFACE_ID = "surface-permission-config"
 _FIXTURE_NEW_HYPOTHESIS_ID = "hypothesis-permission-default"
 _FIXTURE_NEW_PROBE_KIND = "static-contract-read"
 _FIXTURE_NEW_EVIDENCE_ID = "evidence-permission-config"
+_FIXTURE_COMPOSITION_EXPERIMENT_ID = "experiment-permission-composition"
 
 
 @dataclass(frozen=True)
@@ -58,6 +59,7 @@ class _ReplanSemanticActionFixture:
     source_root: Path
     frontier_target: Path
     work_source_target: Path
+    composition_experiment_ref: str | None = None
 
 
 @dataclass
@@ -81,7 +83,11 @@ def _digest(value: str) -> str:
     return digest_text(value)
 
 
-def _build_fixture(root: Path) -> _ReplanSemanticActionFixture:
+def _build_fixture(
+    root: Path,
+    *,
+    composition_frontier: bool = False,
+) -> _ReplanSemanticActionFixture:
     source_root = Path(__file__).resolve().parents[3]
     project_root = root / "project"
     runtime_root = root / "runtime"
@@ -172,43 +178,46 @@ def _build_fixture(root: Path) -> _ReplanSemanticActionFixture:
         "cadence=1d next_due_at=2999-01-01T00%3A00%3A00Z -->\n",
         encoding="utf-8",
     )
+    registry_goal: dict[str, Any] = {
+        "id": _FIXTURE_GOAL_ID,
+        "domain": "replan-semantic-action-fixture",
+        "status": "active",
+        "repo": str(project_root),
+        "state_file": str(state_relative),
+        "adapter": {
+            "kind": "fixture_connected_delivery_v0",
+            "status": "connected-delivery",
+        },
+        "coordination": {
+            "registered_agents": [_FIXTURE_AGENT_ID],
+            "agent_model": "peer_v1",
+            "agent_profiles": {
+                _FIXTURE_AGENT_ID: {
+                    "schema_version": "agent_profile_v1",
+                    "agent_id": _FIXTURE_AGENT_ID,
+                    "profile_role": "quality-qualification",
+                    "scope_summary": "Qualify one bounded semantic replan.",
+                    "default_task_classes": ["continuous_monitor"],
+                    "vision_requirement": "optional",
+                }
+            },
+        },
+        "authority_sources": [],
+        "quota": {
+            "compute": 1.0,
+            "window_hours": 24,
+            "allowed_slots": 5,
+        },
+    }
+    if composition_frontier:
+        registry_goal["spawn_policy"] = {
+            "explore_harness": {"enabled": True, "profile": "generic"}
+        }
     registry = {
         "schema_version": "0.1",
         "updated_at": "2026-08-13T00:00:00+08:00",
         "common_runtime_root": str(runtime_root),
-        "goals": [
-            {
-                "id": _FIXTURE_GOAL_ID,
-                "domain": "replan-semantic-action-fixture",
-                "status": "active",
-                "repo": str(project_root),
-                "state_file": str(state_relative),
-                "adapter": {
-                    "kind": "fixture_connected_delivery_v0",
-                    "status": "connected-delivery",
-                },
-                "coordination": {
-                    "registered_agents": [_FIXTURE_AGENT_ID],
-                    "agent_model": "peer_v1",
-                    "agent_profiles": {
-                        _FIXTURE_AGENT_ID: {
-                            "schema_version": "agent_profile_v1",
-                            "agent_id": _FIXTURE_AGENT_ID,
-                            "profile_role": "quality-qualification",
-                            "scope_summary": "Qualify one bounded semantic replan.",
-                            "default_task_classes": ["continuous_monitor"],
-                            "vision_requirement": "optional",
-                        }
-                    },
-                },
-                "authority_sources": [],
-                "quota": {
-                    "compute": 1.0,
-                    "window_hours": 24,
-                    "allowed_slots": 5,
-                },
-            }
-        ],
+        "goals": [registry_goal],
     }
     registry_text = json.dumps(registry, ensure_ascii=False, indent=2, sort_keys=True)
     for registry_path in (local_registry_path, global_registry_path):
@@ -248,6 +257,89 @@ def _build_fixture(root: Path) -> _ReplanSemanticActionFixture:
         encoding="utf-8",
     )
 
+    if composition_frontier:
+        explore_commands = (
+            (
+                "node",
+                "--node-id",
+                "surface-existing",
+                "--title",
+                "Existing closed surface",
+                "--kind",
+                "hypothesis",
+                "--status",
+                "resolved",
+                "--evidence-ref",
+                "evidence-existing",
+            ),
+            (
+                "node",
+                "--node-id",
+                _FIXTURE_NEW_SURFACE_ID,
+                "--title",
+                "Permission configuration surface",
+                "--kind",
+                "hypothesis",
+                "--status",
+                "dead_end",
+                "--evidence-ref",
+                _FIXTURE_NEW_EVIDENCE_ID,
+            ),
+            (
+                "node",
+                "--node-id",
+                _FIXTURE_COMPOSITION_EXPERIMENT_ID,
+                "--title",
+                "Jointly probe the existing and permission surfaces",
+                "--kind",
+                "experiment",
+                "--status",
+                "open",
+            ),
+            (
+                "edge",
+                "--from",
+                _FIXTURE_COMPOSITION_EXPERIMENT_ID,
+                "--to",
+                "surface-existing",
+                "--type",
+                "depends_on",
+            ),
+            (
+                "edge",
+                "--from",
+                _FIXTURE_COMPOSITION_EXPERIMENT_ID,
+                "--to",
+                _FIXTURE_NEW_SURFACE_ID,
+                "--type",
+                "depends_on",
+            ),
+        )
+        for explore_args in explore_commands:
+            execute_loopx_cli(
+                shlex.join(
+                    (
+                        "loopx",
+                        "--format",
+                        "json",
+                        "--registry",
+                        "fixture-registry",
+                        "--runtime-root",
+                        "fixture-runtime",
+                        "explore",
+                        *explore_args,
+                        "--goal-id",
+                        _FIXTURE_GOAL_ID,
+                    )
+                ),
+                source_root=source_root,
+                project_root=project_root,
+                argument_overrides={
+                    "--registry": str(global_registry_path),
+                    "--runtime-root": str(runtime_root),
+                },
+            )
+
     prompt = build_heartbeat_prompt(
         goal_id=_FIXTURE_GOAL_ID,
         thin=True,
@@ -272,6 +364,9 @@ def _build_fixture(root: Path) -> _ReplanSemanticActionFixture:
         source_root=source_root,
         frontier_target=frontier_target,
         work_source_target=source_target,
+        composition_experiment_ref=(
+            _FIXTURE_COMPOSITION_EXPERIMENT_ID if composition_frontier else None
+        ),
     )
 
 
@@ -635,6 +730,13 @@ def _handle_successor_command(command: str, state: _QualificationState) -> str:
     )
     if requested_obligation_id != expected_obligation_id:
         raise ValueError("successor_create_obligation_mismatch")
+    if state.fixture.composition_experiment_ref:
+        requested_experiment_ref = argument_value(
+            loopx_command_tokens(command) or [],
+            "--explore-result-node-ref",
+        )
+        if requested_experiment_ref != state.fixture.composition_experiment_ref:
+            raise ValueError("successor_create_composition_binding_mismatch")
     output = _execute_loopx(
         command,
         fixture=state.fixture,
@@ -742,6 +844,7 @@ _EXPECTED_BEHAVIOR_FAILURES = frozenset(
         "successor_create_before_frontier_read",
         "successor_create_before_work_source_read",
         "successor_create_obligation_mismatch",
+        "successor_create_composition_binding_mismatch",
         "repeated_successor_create",
         "successor_create_failed",
         "successor_transition_missing",
@@ -875,8 +978,12 @@ class DoubaoReplanSemanticActionBehaviorActor:
         *,
         qualification_id: str,
         fixture_root: Path,
+        composition_frontier: bool = False,
     ) -> dict[str, Any]:
-        fixture = _build_fixture(fixture_root)
+        fixture = _build_fixture(
+            fixture_root,
+            composition_frontier=composition_frontier,
+        )
         messages: list[dict[str, Any]] = [
             {
                 "role": "system",

--- a/loopx/control_plane/work_items/progress_observation.py
+++ b/loopx/control_plane/work_items/progress_observation.py
@@ -491,6 +491,7 @@ def build_replan_action_packet(
     *,
     goal_id: str | None = None,
     agent_id: str | None = None,
+    bounded_research_frontier: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     context = obligation.get("replan_context")
     if not isinstance(context, Mapping):
@@ -515,14 +516,36 @@ def build_replan_action_packet(
     successor_priority = str(todo_action.get("priority") or "P1").strip()
     if successor_priority not in {"P0", "P1", "P2", "P3", "P4"}:
         successor_priority = "P1"
+    selected_gap = (
+        bounded_research_frontier.get("selected_gap")
+        if isinstance(bounded_research_frontier, Mapping)
+        and isinstance(bounded_research_frontier.get("selected_gap"), Mapping)
+        else None
+    )
     successor_summary = str(
-        todo_action.get("text")
+        (selected_gap or {}).get("successor_summary")
+        or todo_action.get("text")
         or "Select one evidence-grounded bounded successor slice."
     ).strip()[:240]
     successor_text = shlex.quote(
         f"[{successor_priority}] {successor_summary}"
     )
-    return {
+    successor_binding = (
+        selected_gap.get("successor_binding")
+        if isinstance(selected_gap, Mapping)
+        and isinstance(selected_gap.get("successor_binding"), Mapping)
+        else {}
+    )
+    explore_result_node_refs = [
+        ref
+        for raw in successor_binding.get("explore_result_node_refs") or []
+        if (ref := _stable_id(raw, field="explore_result_node_ref"))
+    ][:3]
+    successor_ref_args = "".join(
+        f" --explore-result-node-ref {shlex.quote(ref)}"
+        for ref in explore_result_node_refs
+    )
+    packet = {
         "schema_version": REPLAN_ACTION_PACKET_SCHEMA_VERSION,
         "decision": "replan_required",
         "obligation_id": obligation.get("obligation_id"),
@@ -537,6 +560,7 @@ def build_replan_action_packet(
                 f"--claimed-by {safe_agent_id} "
                 "--replan-obligation-id "
                 f"{obligation.get('obligation_id')}"
+                f"{successor_ref_args}"
             ),
             "successor_host_action": "end_current_heartbeat",
         },
@@ -546,3 +570,16 @@ def build_replan_action_packet(
             ProgressResultClass.NO_FOLLOWUP.value,
         ],
     }
+    if isinstance(selected_gap, Mapping):
+        packet["bounded_frontier"] = {
+            key: selected_gap[key]
+            for key in (
+                "schema_version",
+                "gap_id",
+                "experiment_node_ref",
+                "input_node_refs",
+                "required_outcome",
+            )
+            if key in selected_gap
+        }
+    return packet

--- a/tests/capabilities/test_explore_composition_frontier.py
+++ b/tests/capabilities/test_explore_composition_frontier.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+
+from loopx.capabilities.explore.composition_frontier import (
+    build_explore_composition_frontier,
+    project_live_explore_composition_frontier,
+)
+from loopx.capabilities.explore.result_log import (
+    append_explore_result_events,
+    build_explore_edge_event,
+    build_explore_node_event,
+    build_explore_result_projection,
+    explore_result_log_path,
+)
+from loopx.control_plane.work_items.progress_observation import (
+    build_replan_action_packet,
+)
+
+GOAL_ID = "composition-frontier-fixture"
+AGENT_ID = "codex-composition-fixture"
+EXPERIMENT_ID = "experiment_joint_boundary"
+
+
+def _events() -> list[dict[str, object]]:
+    return [
+        build_explore_node_event(
+            goal_id=GOAL_ID,
+            node_id="surface_a",
+            title="Closed surface A",
+            node_kind="hypothesis",
+            status="resolved",
+            evidence_refs=["evidence-a"],
+        ),
+        build_explore_node_event(
+            goal_id=GOAL_ID,
+            node_id="surface_b",
+            title="Closed surface B",
+            node_kind="hypothesis",
+            status="dead_end",
+            evidence_refs=["evidence-b"],
+        ),
+        build_explore_node_event(
+            goal_id=GOAL_ID,
+            node_id=EXPERIMENT_ID,
+            title="Combine A and B at the shared boundary",
+            node_kind="experiment",
+            status="open",
+        ),
+        build_explore_edge_event(
+            goal_id=GOAL_ID,
+            from_node=EXPERIMENT_ID,
+            to_node="surface_a",
+            edge_type="depends_on",
+        ),
+        build_explore_edge_event(
+            goal_id=GOAL_ID,
+            from_node=EXPERIMENT_ID,
+            to_node="surface_b",
+            edge_type="depends_on",
+        ),
+    ]
+
+
+def _projection() -> dict[str, object]:
+    return build_explore_result_projection(_events(), goal_id=GOAL_ID)
+
+
+def test_explicit_joint_experiment_projects_one_bounded_gap() -> None:
+    frontier = build_explore_composition_frontier(
+        _projection(),
+        agent_id=AGENT_ID,
+        enabled=True,
+    )
+
+    assert frontier["state"] == "pending"
+    assert frontier["candidate_count"] == 1
+    assert frontier["pending_count"] == 1
+    assert frontier["scheduled_count"] == 0
+    assert frontier["selected_gap"] == frontier["gaps"][0]
+    assert frontier["selected_gap"]["experiment_node_ref"] == EXPERIMENT_ID
+    assert frontier["selected_gap"]["input_node_refs"] == [
+        "surface_a",
+        "surface_b",
+    ]
+
+
+def test_frontier_does_not_infer_pairs_and_exact_todo_binding_schedules_gap() -> None:
+    no_experiment = build_explore_composition_frontier(
+        build_explore_result_projection(_events()[:2], goal_id=GOAL_ID),
+        agent_id=AGENT_ID,
+        enabled=True,
+    )
+    assert no_experiment["candidate_count"] == 0
+    assert no_experiment["selected_gap"] is None
+
+    scheduled = build_explore_composition_frontier(
+        _projection(),
+        todos=[
+            {
+                "todo_id": "todo_joint",
+                "status": "claimed",
+                "done": False,
+                "task_class": "advancement_task",
+                "claimed_by": AGENT_ID,
+                "explore_result_node_refs": [EXPERIMENT_ID],
+            }
+        ],
+        agent_id=AGENT_ID,
+        enabled=True,
+    )
+    assert scheduled["state"] == "satisfied"
+    assert scheduled["pending_count"] == 0
+    assert scheduled["scheduled_count"] == 1
+    assert scheduled["selected_gap"] is None
+
+
+def test_live_projection_is_goal_opt_in_and_reads_only_public_explore_log(
+    tmp_path: Path,
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    append_explore_result_events(
+        explore_result_log_path(runtime_root, GOAL_ID),
+        _events(),
+        expected_goal_id=GOAL_ID,
+    )
+    status_payload = {
+        "run_history": {
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "spawn_policy": {
+                        "explore_harness": {"enabled": True, "profile": "generic"}
+                    },
+                }
+            ]
+        },
+        "attention_queue": {
+            "items": [
+                {
+                    "goal_id": GOAL_ID,
+                    "agent_todos": {"items": []},
+                    "project_asset": {"agent_todos": {"items": []}},
+                }
+            ]
+        },
+    }
+
+    frontier = project_live_explore_composition_frontier(
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        status_payload=status_payload,
+    )
+    assert frontier is not None
+    assert frontier["enabled"] is True
+    assert frontier["selected_gap"]["experiment_node_ref"] == EXPERIMENT_ID
+
+    status_payload["run_history"]["goals"][0]["spawn_policy"] = {}
+    disabled = project_live_explore_composition_frontier(
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        status_payload=status_payload,
+    )
+    assert disabled is None
+
+
+def test_replan_successor_binds_obligation_and_joint_experiment() -> None:
+    frontier = build_explore_composition_frontier(
+        _projection(),
+        agent_id=AGENT_ID,
+        enabled=True,
+    )
+    obligation = {
+        "obligation_id": "replan-composition-fixture",
+        "agent_id": AGENT_ID,
+        "replan_context": {
+            "uncovered_frontier": {"required_any_of": ["new_runnable_successor"]}
+        },
+        "todo_actions": [
+            {
+                "action": "add",
+                "role": "agent",
+                "priority": "P1",
+                "text": "Select a bounded successor.",
+            }
+        ],
+    }
+    packet = build_replan_action_packet(
+        obligation,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        bounded_research_frontier=frontier,
+    )
+
+    command = shlex.split(packet["writeback_contract"]["successor_command"])
+    assert command[0:3] == ["loopx", "todo", "add"]
+    assert command[command.index("--replan-obligation-id") + 1] == (
+        "replan-composition-fixture"
+    )
+    assert command[command.index("--explore-result-node-ref") + 1] == (
+        EXPERIMENT_ID
+    )
+    assert packet["bounded_frontier"]["required_outcome"] == (
+        "joint_experiment_result"
+    )

--- a/tests/control_plane/test_replan_semantic_action_behavior.py
+++ b/tests/control_plane/test_replan_semantic_action_behavior.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 from collections.abc import Mapping
 from pathlib import Path
 
@@ -58,6 +59,30 @@ def _semantic_action(
         "--progress-evidence-id evidence-permission-config "
         "--no-global-sync --suppress-external-sinks"
     )
+
+
+def _composition_successor_action(
+    request: Mapping[str, object],
+) -> ScriptedExecToolAction:
+    packet = _latest_quota_packet(request)
+    frontier = packet.get("bounded_research_frontier")
+    assert isinstance(frontier, Mapping)
+    selected_gap = frontier.get("selected_gap")
+    assert isinstance(selected_gap, Mapping)
+    assert selected_gap["required_outcome"] == "joint_experiment_result"
+    action = packet["replan_action_packet"]
+    assert isinstance(action, Mapping)
+    bounded = action.get("bounded_frontier")
+    assert isinstance(bounded, Mapping)
+    assert bounded["gap_id"] == selected_gap["gap_id"]
+    writeback = action.get("writeback_contract")
+    assert isinstance(writeback, Mapping)
+    command = str(writeback.get("successor_command") or "")
+    assert command
+    command_tokens = shlex.split(command)
+    assert command_tokens[0] == "loopx"
+    command_tokens[1:1] = ["--format", "json", "--registry", "ignored"]
+    return ScriptedExecToolAction(command=shlex.join(command_tokens))
 
 
 def test_real_tool_loop_chooses_and_persists_semantic_replan_action(
@@ -128,6 +153,49 @@ def test_real_tool_loop_chooses_and_persists_semantic_replan_action(
         "surface-permission-config"
     )
     assert latest["autonomous_replan_ack"]["semantic_delta"]["accepted"] is True
+
+
+def test_real_tool_loop_selects_composition_gap_and_creates_bound_successor(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_fixture(
+        tmp_path / "oracle",
+        composition_frontier=True,
+    )
+    transport = ScriptedDoubaoExecTransport(
+        [
+            ScriptedExecToolAction(command=fixture.quota_guard_command),
+            ScriptedExecToolAction(command="cat replan-frontier.json"),
+            ScriptedExecToolAction(command="cat fixture/permission-config.json"),
+            _composition_successor_action,
+        ]
+    )
+    receipt = DoubaoReplanSemanticActionBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="replan-composition-successor-001",
+        fixture_root=tmp_path / "actor",
+        composition_frontier=True,
+    )
+
+    assert receipt["qualification_passed"] is True, receipt
+    assert receipt["observed_tool_sequence"] == [
+        "quota_should_run",
+        "workspace_read",
+        "workspace_read",
+        "replan_successor_create",
+    ]
+    assert receipt["selected_semantic_outcomes"] == ["new_runnable_successor"]
+
+    quota_packet = json.loads(transport.requests[1]["messages"][-1]["content"])
+    selected_gap = quota_packet["bounded_research_frontier"]["selected_gap"]
+    assert selected_gap["experiment_node_ref"] == (
+        "experiment-permission-composition"
+    )
+    assert quota_packet["replan_action_packet"]["bounded_frontier"][
+        "experiment_node_ref"
+    ] == selected_gap["experiment_node_ref"]
 
 
 def test_action_outside_observed_frontier_is_rejected(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- derive a bounded composition frontier only from explicit open Explore experiment nodes with at least two evidence-backed closed dependencies
- project the selected experiment into live quota and bind it to an existing replan successor without creating a second authority ledger
- qualify the flow with a real quota-to-tool-to-Todo behavior actor and focused negative tests

## Scope

This first slice deliberately does not infer arbitrary node pairs and does not create a composition-only replan obligation. It reuses the existing Explore graph, Todo identity, and replan obligation. A follow-up can add canonical composition-triggered obligations only when quota and write-time gates share the same derivation.

## Validation

- 47 focused pytest cases passed across composition, semantic replan, live quota, progress observation, host context, and turn envelope
- focused Ruff and py_compile passed
- premerge selected 17 checks; 16 passed
- monitor-scheduler-contract-smoke failed identically on clean origin/main@v0.4.6, so it is recorded as a baseline failure rather than relaxed here
- loopx check: ok (9 checks, 0 errors; 2 unrelated existing projection warnings)
- public/private scan found no private paths, raw benchmark evidence, credentials, or internal links

## Manual hold

Do not merge until the candidate has been locally installed and exercised against one explicit composition experiment.