### PR TITLE
ci(python): restore full-package lint coverage

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -48,10 +48,7 @@ jobs:
         run: >-
           python -m ruff check
           tests
-          loopx/canary
-          loopx/control_plane
-          loopx/domain_packs
-          loopx/presentation
+          loopx
 
       - name: Type-check kernel contracts
         run: python -m mypy

--- a/loopx/benchmark.py
+++ b/loopx/benchmark.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+# This module is the legacy public benchmark facade. The imports below keep
+# established ``loopx.benchmark`` call sites compatible while implementations
+# move into benchmark_core and benchmark_adapters.
+# ruff: noqa: F401
+
 import importlib.util
 import json
 import os

--- a/loopx/benchmark_adapters/agentissue.py
+++ b/loopx/benchmark_adapters/agentissue.py
@@ -1168,8 +1168,7 @@ def materialize_agentissue_codex_cli_runner_run_gate(
 
     workflow_check = json.loads(workflow_path.read_text(encoding="utf-8"))
     execution_gate = json.loads(gate_path.read_text(encoding="utf-8"))
-    handoff = json.loads(handoff_path.read_text(encoding="utf-8"))
-
+    json.loads(handoff_path.read_text(encoding="utf-8"))
     gate_items = [
         {
             "id": "selected_tag_and_image_locked",

--- a/loopx/benchmark_adapters/agents_last_exam.py
+++ b/loopx/benchmark_adapters/agents_last_exam.py
@@ -1277,8 +1277,6 @@ def _agents_last_exam_codex_mcp_config_probe(
     }
 
 def _agents_last_exam_fake_cua_server():
-    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-    import threading
 
     class Handler(BaseHTTPRequestHandler):
         def do_POST(self) -> None:  # noqa: N802

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -36,8 +36,8 @@ from .skillsbench_acp_failure_policy import (
 )
 from .skillsbench_signals import build_skillsbench_solution_quality_signals
 from .skillsbench_result_discovery import (
-    SKILLSBENCH_RESULT_DISCOVERY_SCHEMA_VERSION,
-    discover_skillsbench_benchflow_result_json,
+    SKILLSBENCH_RESULT_DISCOVERY_SCHEMA_VERSION as SKILLSBENCH_RESULT_DISCOVERY_SCHEMA_VERSION,
+    discover_skillsbench_benchflow_result_json as discover_skillsbench_benchflow_result_json,
 )
 from .skillsbench_typed_repair import (
     compact_skillsbench_typed_repair_counters,

--- a/loopx/capabilities/auto_research/core.py
+++ b/loopx/capabilities/auto_research/core.py
@@ -9,3 +9,11 @@ from .kernel import (
     lightweight_hypothesis,
     run_lightweight_auto_research,
 )
+
+__all__ = [
+    "LIGHTWEIGHT_AUTO_RESEARCH_EVIDENCE_SCHEMA_VERSION",
+    "LIGHTWEIGHT_AUTO_RESEARCH_HYPOTHESIS_SCHEMA_VERSION",
+    "LIGHTWEIGHT_AUTO_RESEARCH_RESULT_SCHEMA_VERSION",
+    "lightweight_hypothesis",
+    "run_lightweight_auto_research",
+]

--- a/loopx/capabilities/auto_research/human_view.py
+++ b/loopx/capabilities/auto_research/human_view.py
@@ -368,7 +368,7 @@ def _render_worker_turn(payload: dict[str, object]) -> str:
         f"- holdout_metric: `{payload.get('holdout_metric')}`",
         f"- appended_count: `{append.get('appended_count')}`",
         f"- live_evidence_written: `{live_evidence.get('written')}`",
-        f"- public_boundary: raw_logs=`False`, private_artifacts=`False`, paths=`local-only`",
+        "- public_boundary: raw_logs=`False`, private_artifacts=`False`, paths=`local-only`",
     ]
     return "\n".join(lines) + "\n"
 

--- a/loopx/capabilities/auto_research/preset.py
+++ b/loopx/capabilities/auto_research/preset.py
@@ -6,16 +6,16 @@ from collections.abc import Iterable
 from .defaults import AUTO_RESEARCH_DEFAULT_GOAL_ID
 from .role_profiles import (
     AUTO_RESEARCH_DEFAULT_LANES,
-    AUTO_RESEARCH_REQUIRED_HOLDOUT_IMPROVEMENTS,
+    AUTO_RESEARCH_REQUIRED_HOLDOUT_IMPROVEMENTS as AUTO_RESEARCH_REQUIRED_HOLDOUT_IMPROVEMENTS,
     AUTO_RESEARCH_REQUIRED_SKILL,
     AUTO_RESEARCH_ROLE_PROFILE_SCHEMA_VERSION,
     AUTO_RESEARCH_WORKER_SKILL_SOURCE,
     auto_research_role_id,
-    auto_research_role_id_for_action,
+    auto_research_role_id_for_action as auto_research_role_id_for_action,
     auto_research_role_profile,
-    auto_research_seed_action_for_role,
-    auto_research_seed_title,
-    auto_research_successor_specs_for_action,
+    auto_research_seed_action_for_role as auto_research_seed_action_for_role,
+    auto_research_seed_title as auto_research_seed_title,
+    auto_research_successor_specs_for_action as auto_research_successor_specs_for_action,
     knn_demo_visible_first_steps,
 )
 from ...control_plane.agents.multi_agent.recipe import (

--- a/loopx/capabilities/auto_research/research_state.py
+++ b/loopx/capabilities/auto_research/research_state.py
@@ -19,7 +19,6 @@ from .evidence_packet import (
     RESEARCH_EVIDENCE_EVENT_SCHEMA_VERSION,
     RESEARCH_HYPOTHESIS_SCHEMA_VERSION,
     _compact_public_text,
-    _compact_public_text_list,
     _compact_public_token,
     _derive_hypothesis_status,
     _finite_float,

--- a/loopx/capabilities/explore/harness_runtime.py
+++ b/loopx/capabilities/explore/harness_runtime.py
@@ -25,7 +25,6 @@ from .harness_checkpoint import (
 )
 from .router_state import (
     advance_epoch,
-    family_routing_terms,
     initial_router_state,
     observe_epoch,
 )

--- a/loopx/claude_goal_mode/scripts/goalmode_cmd.py
+++ b/loopx/claude_goal_mode/scripts/goalmode_cmd.py
@@ -230,7 +230,7 @@ def main():
     print(f"  todo_id : {tid}")
     print(f"  scope   : {proj}")
     print(f"  task    : {task}")
-    print(f"  wrote   : .claude/loop.md  (the per-tick protocol)")
+    print("  wrote   : .claude/loop.md  (the per-tick protocol)")
     print()
     print("START WORKING — run native `/loop`  (Claude self-paces)  or  `/loop 10m`  (fixed cadence).")
     print("Each /loop tick runs: should_run -> claim_task -> ONE bounded verified segment -> complete_task.")

--- a/loopx/cli_commands/benchmark_run_ledger.py
+++ b/loopx/cli_commands/benchmark_run_ledger.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import sys
 from collections.abc import Callable
 from pathlib import Path

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -14,7 +14,6 @@ from ..control_plane.quota.heartbeat_receipt import (
     fail_heartbeat_receipt,
     find_heartbeat_receipt,
     heartbeat_receipt_view,
-    upgrade_identityless_heartbeat_receipt,
 )
 from ..control_plane.quota.live_decision import build_live_quota_should_run_decision
 from ..control_plane.quota.monitor_poll import find_quota_monitor_poll_turn

--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -27,7 +27,10 @@ from ..presentation.renderers.status_markdown import render_status_markdown
 from ..quota import build_quota_should_run
 from ..review_packet import build_review_packet, render_review_packet_markdown
 from ..status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, collect_status
-from .status_registration import default_public_scan_root, register_status_commands
+from .status_registration import (
+    default_public_scan_root as default_public_scan_root,
+    register_status_commands as register_status_commands,
+)
 
 PrintPayload = Callable[
     [dict[str, object], str, Callable[[dict[str, object]], str]],

--- a/loopx/state_migration.py
+++ b/loopx/state_migration.py
@@ -2,14 +2,12 @@ from __future__ import annotations
 
 import copy
 import json
-import os
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from .global_registry import write_json
-from .paths import DEFAULT_RUNTIME_ROOT
 from .registry import registry_goals
 
 

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -36,12 +36,12 @@ from .control_plane.agents.multi_agent.visible_wake_scheduler import (
     resolve_initial_wake_plan,
 )
 from .visible_multi_agent_tmux import (
-    PANE_A2A_INPUT_READY_TIMEOUT_SECONDS,
-    PANE_A2A_WAKEUP_PROMPT,
-    PANE_A2A_WAKEUP_SCHEMA_VERSION,
+    PANE_A2A_INPUT_READY_TIMEOUT_SECONDS as PANE_A2A_INPUT_READY_TIMEOUT_SECONDS,
+    PANE_A2A_WAKEUP_PROMPT as PANE_A2A_WAKEUP_PROMPT,
+    PANE_A2A_WAKEUP_SCHEMA_VERSION as PANE_A2A_WAKEUP_SCHEMA_VERSION,
     TMUX_LANE_ID_OPTION,
-    build_pane_a2a_wakeup_prompt,
-    wake_visible_multi_agent_panes,
+    build_pane_a2a_wakeup_prompt as build_pane_a2a_wakeup_prompt,
+    wake_visible_multi_agent_panes as wake_visible_multi_agent_panes,
 )
 
 


### PR DESCRIPTION
## Summary
- restore a zero-error Ruff baseline across the complete `loopx` package
- preserve compatibility facades with explicit re-export declarations
- remove genuine dead imports and no-op formatting issues
- expand Python CI linting from four selected subpackages to all product modules

## Validation
- `python -m ruff check tests loopx` — passed
- `python -m mypy` — passed (16 configured source files)
- focused pytest — 46 passed
- AgentIssue validation gate, benchmark claim review, and Auto Research thin-preset smokes — passed
- changed Python compile and public/private boundary scan — passed
- full pytest with CI coverage flags exceeded the 10-minute local Windows budget without a final result; GitHub CI remains authoritative

## Premerge holds
`loopx canary premerge --from-git-diff` selected 18 checks: direct diff checks, changed-file compilation, public boundary, and 12 smokes passed. Six aggregate failures reduce to three underlying smokes that fail identically on an untouched `origin/main` worktree: extension entrypoint discovery, current monitor/replan assertion drift, and Windows symlink privilege. Benchmark-sensitive paths retain the required maintainer review hold. No benchmark scoring, task semantics, runner behavior, permission boundary, or public evidence policy changes are intended.