### PR TITLE
fix(replan): route exact bound successors before replan

### DIFF
--- a/examples/control_plane/heartbeat-quota-flow-smoke.py
+++ b/examples/control_plane/heartbeat-quota-flow-smoke.py
@@ -27,24 +27,32 @@ EXPECTED_NEXT_ACTION = (
 
 
 def run_cli(root: Path, *args: str, registry_path: Path, runtime: Path) -> dict:
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "loopx.cli",
-            "--registry",
-            str(registry_path),
-            "--runtime-root",
-            str(runtime),
-            "--format",
-            "json",
-            *args,
-        ],
-        cwd=REPO_ROOT,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    command = [
+        sys.executable,
+        "-m",
+        "loopx.cli",
+        "--registry",
+        str(registry_path),
+        "--runtime-root",
+        str(runtime),
+        "--format",
+        "json",
+        *args,
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise AssertionError(
+            "LoopX CLI failed during heartbeat smoke\n"
+            f"stdout:\n{exc.stdout}\n"
+            f"stderr:\n{exc.stderr}"
+        ) from exc
     return json.loads(result.stdout)
 
 
@@ -816,7 +824,7 @@ def main() -> int:
         assert interaction["agent_channel"]["quiet_noop_allowed"] is False, interaction
         assert interaction["cli_channel"]["spend_after_validation"] is True, interaction
         assert "accountable replan delta" in interaction["cli_channel"]["spend_policy"], interaction
-        assert "surface_only" in " ".join(interaction["cli_channel"]["next_cli_actions"]), interaction
+        assert "surface_only" in interaction["cli_channel"]["spend_policy"], interaction
 
         refresh = run_cli(
             root,

--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -627,8 +627,11 @@ def assert_replan_beats_monitor_quiet_skip() -> None:
     assert "goal_frontier_projection: replan_required=True" in markdown, markdown
     assert "deferred_ready=0 acceptance_gaps=0" in markdown, markdown
     assert "autonomous_replan_decision: decision=autonomous_replan_required" in markdown, markdown
-    assert "replan_action_packet:" in markdown, markdown
-    assert "required_outcome=semantic_delta" in markdown, markdown
+    assert (
+        "interaction_agent_action: select one bounded next slice; prefer "
+        "replan_action_packet.writeback_contract.successor_command"
+        in markdown
+    ), markdown
     repeat_guard = build_quota_should_run(payload, goal_id=GOAL_ID, agent_id=SIDE_AGENT)
     assert repeat_guard["replan_action_packet"] == action_packet, repeat_guard
 
@@ -776,10 +779,14 @@ def assert_replan_preserves_current_agent_runnable_frontier() -> None:
     assert lane_action["selected_by"] == "current_agent_claimed_todo", guard
     assert lane_action["preserves_goal_next_action"] is True, guard
     primary_action = guard["interaction_contract"]["agent_channel"]["primary_action"]
-    assert "typed semantic outcome" in primary_action, guard
-    assert "host-projected coverage ledger" in primary_action, guard
+    assert "select one bounded next slice" in primary_action, guard
+    assert "replan_action_packet.writeback_contract.successor_command" in (
+        primary_action
+    ), guard
     cli_actions = guard["interaction_contract"]["cli_channel"]["next_cli_actions"]
-    assert "typed semantic outcome" in cli_actions[0], guard
+    assert cli_actions[0] == (
+        "execute replan_action_packet.writeback_contract.successor_command"
+    ), guard
     frontier = guard["goal_frontier_projection"]["remaining_advancement_frontier"]
     assert frontier["current_agent_claimed_advancement_count"] == 1, guard
     assert guard["goal_route_hint"]["current_agent_next_action"]["todo_id"] == (

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -497,6 +497,9 @@ def handle_quota_command(
                             host_observation_resolver=resolve_codex_app_automation_rrule,
                             scheduler_execution_context=scheduler_context,
                             operator_inbox_urgency_projector=operator_inbox_urgency_projector,
+                            bounded_research_frontier_projector=(
+                                project_live_explore_composition_frontier
+                            ),
                         )
                         cache_metadata = None
                         heartbeat_stall_observation = (
@@ -537,6 +540,9 @@ def handle_quota_command(
                 next_claimed_by=args.next_claimed_by,
                 scheduler_execution_context=scheduler_context,
                 operator_inbox_urgency_projector=operator_inbox_urgency_projector,
+                bounded_research_frontier_projector=(
+                    project_live_explore_composition_frontier
+                ),
                 status_reloader=lambda: collect_status(
                     registry_path=registry_path,
                     runtime_root_override=runtime_root_arg,

--- a/loopx/control_plane/goals/goal_frontier/__init__.py
+++ b/loopx/control_plane/goals/goal_frontier/__init__.py
@@ -1417,6 +1417,7 @@ def build_goal_frontier_projection_context_from_status(
     agent_todo_summary: dict[str, Any] | None,
     work_lane_contract: dict[str, Any] | None,
     neutral_replan_ack_classifications: set[str],
+    agent_todo_source_items: list[dict[str, Any]] | None = None,
     registered_agent_ids: list[str] | None = None,
     goal_status: str | None = None,
     agent_profile: dict[str, Any] | None = None,
@@ -1542,6 +1543,7 @@ def build_goal_frontier_projection_context_from_status(
         agent_todo_summary,
         agent_id=agent_id,
         replan_obligation=replan_obligation,
+        agent_todo_items=agent_todo_source_items,
     )
     obligation_ack = replan_transition_ack or effective_replan_ack
     if (
@@ -1576,6 +1578,7 @@ def build_goal_frontier_projection_context_from_status(
         agent_todo_summary,
         agent_id=agent_id,
         replan_obligation=frontier_replan_obligation,
+        agent_todo_items=agent_todo_source_items,
     )
     frontier_obligation_ack = frontier_transition_ack or effective_replan_ack
     if (

--- a/loopx/control_plane/goals/goal_frontier/ack_policy.py
+++ b/loopx/control_plane/goals/goal_frontier/ack_policy.py
@@ -120,10 +120,16 @@ def replan_successor_transition_ack(
             "successor"
         ),
     }
-    return {
+    ack = {
         "schema_version": "autonomous_replan_ack_v0",
         "recorded": True,
         "source": "todo_replan_successor_transition",
         "generated_at": successor.get("updated_at"),
         "semantic_delta": semantic_delta,
     }
+    frontier_identity = str(
+        (replan_obligation or {}).get("frontier_identity") or ""
+    ).strip()
+    if frontier_identity:
+        ack["frontier_identity"] = frontier_identity
+    return ack

--- a/loopx/control_plane/goals/goal_frontier/ack_policy.py
+++ b/loopx/control_plane/goals/goal_frontier/ack_policy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any
 
 from ...todos.contract import (
@@ -7,8 +8,8 @@ from ...todos.contract import (
     normalize_todo_claimed_by,
     normalize_todo_id,
     normalize_todo_replan_obligation_id,
-    normalize_todo_status,
 )
+from ...todos.projection import todo_item_is_actionable_open, todo_item_task_class
 from ...work_items.progress_observation import required_semantic_outcomes
 
 
@@ -60,6 +61,7 @@ def replan_successor_transition_ack(
     *,
     agent_id: str | None,
     replan_obligation: dict[str, Any] | None,
+    agent_todo_items: Iterable[dict[str, Any]] | None = None,
 ) -> dict[str, Any] | None:
     """Project an exact runnable-successor Todo as the replan receipt.
 
@@ -74,19 +76,24 @@ def replan_successor_transition_ack(
     safe_agent_id = normalize_todo_claimed_by(agent_id)
     if not obligation_id or not safe_agent_id:
         return None
-    executable_items = (
-        agent_todo_summary.get("first_executable_items")
-        if isinstance(agent_todo_summary, dict)
-        and isinstance(agent_todo_summary.get("first_executable_items"), list)
-        else []
-    )
+    if agent_todo_items is None:
+        source_items = (
+            agent_todo_summary.get("first_executable_items")
+            if isinstance(agent_todo_summary, dict)
+            and isinstance(agent_todo_summary.get("first_executable_items"), list)
+            else []
+        )
+    else:
+        source_items = [
+            item for item in agent_todo_items if isinstance(item, dict)
+        ]
     successor = next(
         (
             item
-            for item in executable_items
+            for item in source_items
             if isinstance(item, dict)
-            and normalize_todo_status(item.get("status")) == "open"
-            and item.get("task_class") == TODO_TASK_CLASS_ADVANCEMENT
+            and todo_item_is_actionable_open(item)
+            and todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
             and normalize_todo_claimed_by(item.get("claimed_by"))
             == safe_agent_id
             and normalize_todo_replan_obligation_id(

--- a/loopx/control_plane/quota/should_run_prepare.py
+++ b/loopx/control_plane/quota/should_run_prepare.py
@@ -575,6 +575,7 @@ def _prepare_quota_should_run_item(
         project_asset=project_asset,
         user_todo_summary=user_todo_summary,
         agent_todo_summary=agent_todo_summary,
+        agent_todo_source_items=agent_todo_source_items,
         work_lane_contract=work_lane_contract,
         neutral_replan_ack_classifications=AUTONOMOUS_REPLAN_ACK_NEUTRAL_CLASSIFICATIONS,
         registered_agent_ids=registered_agent_ids,

--- a/loopx/control_plane/testing/replan_semantic_action_behavior.py
+++ b/loopx/control_plane/testing/replan_semantic_action_behavior.py
@@ -77,6 +77,7 @@ class _QualificationState:
     frontier_context_read: bool = False
     work_source_read: bool = False
     created_successor_id: str | None = None
+    successor_reentry_observation: dict[str, Any] | None = None
 
 
 def _digest(value: str) -> str:
@@ -508,6 +509,52 @@ def _quota_behavior_observation(packet: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
+def _successor_reentry_observation(
+    packet: Mapping[str, Any],
+    *,
+    successor_todo_id: str,
+    composition_experiment_ref: str | None,
+) -> dict[str, Any]:
+    selected_todo = packet.get("selected_todo")
+    if not isinstance(selected_todo, Mapping):
+        raise ValueError("successor_reentry_selected_todo_missing")
+    if str(selected_todo.get("todo_id") or "") != successor_todo_id:
+        raise ValueError("successor_reentry_selected_todo_mismatch")
+    if packet.get("decision") == "autonomous_replan_required" or isinstance(
+        packet.get("autonomous_replan_obligation"), Mapping
+    ):
+        raise ValueError("successor_reentry_replan_not_closed")
+
+    observation: dict[str, Any] = {
+        "decision": packet.get("decision"),
+        "effective_action": packet.get("effective_action"),
+        "selected_todo_id": successor_todo_id,
+        "replan_closed": True,
+    }
+    if composition_experiment_ref:
+        frontier = packet.get("bounded_research_frontier")
+        gaps = (
+            frontier.get("gaps")
+            if isinstance(frontier, Mapping)
+            and isinstance(frontier.get("gaps"), list)
+            else []
+        )
+        gap = next(
+            (
+                item
+                for item in gaps
+                if isinstance(item, Mapping)
+                and item.get("experiment_node_ref") == composition_experiment_ref
+            ),
+            None,
+        )
+        if not isinstance(gap, Mapping) or gap.get("status") != "scheduled":
+            raise ValueError("successor_reentry_composition_not_scheduled")
+        observation["composition_experiment_ref"] = composition_experiment_ref
+        observation["composition_status"] = "scheduled"
+    return observation
+
+
 def _execute_loopx(
     command: str,
     *,
@@ -633,7 +680,7 @@ def _qualification_receipt(
     passed: bool,
     failure_code: str | None,
 ) -> dict[str, Any]:
-    return _receipt(
+    receipt = _receipt(
         qualification_id=qualification_id,
         actor_ref=actor_ref,
         steps=state.steps,
@@ -644,6 +691,9 @@ def _qualification_receipt(
         local_fixture_writes_executed=True,
         read_only_host_commands_executed=state.read_only_host_commands_executed,
     )
+    if state.successor_reentry_observation is not None:
+        receipt["successor_reentry"] = state.successor_reentry_observation
+    return receipt
 
 
 def _record_tool_step(
@@ -769,6 +819,20 @@ def _handle_successor_command(command: str, state: _QualificationState) -> str:
         "accepted": True,
         "satisfying_outcomes": ["new_runnable_successor"],
     }
+    reentry_output = _execute_loopx(
+        state.fixture.quota_guard_command,
+        fixture=state.fixture,
+        turn_instance_id=f"{state.turn_instance_id}-successor",
+    )
+    reentry_packet = json.loads(reentry_output)
+    if not isinstance(reentry_packet, dict):
+        raise ValueError("successor_reentry_quota_invalid")
+    state.successor_reentry_observation = _successor_reentry_observation(
+        reentry_packet,
+        successor_todo_id=state.created_successor_id,
+        composition_experiment_ref=state.fixture.composition_experiment_ref,
+    )
+    state.read_only_host_commands_executed = True
     return output
 
 
@@ -848,6 +912,11 @@ _EXPECTED_BEHAVIOR_FAILURES = frozenset(
         "repeated_successor_create",
         "successor_create_failed",
         "successor_transition_missing",
+        "successor_reentry_quota_invalid",
+        "successor_reentry_selected_todo_missing",
+        "successor_reentry_selected_todo_mismatch",
+        "successor_reentry_replan_not_closed",
+        "successor_reentry_composition_not_scheduled",
         "quota_obligation_missing",
         "non_semantic_replan_action",
         "semantic_writeback_failed",

--- a/loopx/control_plane/testing/replan_semantic_action_behavior.py
+++ b/loopx/control_plane/testing/replan_semantic_action_behavior.py
@@ -247,11 +247,20 @@ def _build_fixture(
                 "evidence_ids": ["evidence-existing"],
             },
         }
-        prior_runs.append(run)
         safe_timestamp = generated_at.replace(":", "-")
-        (runs_dir / f"{safe_timestamp}.json").write_text(
+        json_path = runs_dir / f"{safe_timestamp}.json"
+        markdown_path = runs_dir / f"{safe_timestamp}.md"
+        json_path.write_text(
             json.dumps(run, sort_keys=True) + "\n",
             encoding="utf-8",
+        )
+        markdown_path.write_text("# Bounded fixture probe\n", encoding="utf-8")
+        prior_runs.append(
+            {
+                **run,
+                "json_path": str(json_path),
+                "markdown_path": str(markdown_path),
+            }
         )
     (runs_dir / "index.jsonl").write_text(
         "".join(json.dumps(run, sort_keys=True) + "\n" for run in prior_runs),
@@ -524,6 +533,11 @@ def _successor_reentry_observation(
         packet.get("autonomous_replan_obligation"), Mapping
     ):
         raise ValueError("successor_reentry_replan_not_closed")
+    if not (
+        packet.get("decision") == "run"
+        and packet.get("effective_action") == "normal_run"
+    ):
+        raise ValueError("successor_reentry_not_runnable")
 
     observation: dict[str, Any] = {
         "decision": packet.get("decision"),
@@ -916,6 +930,7 @@ _EXPECTED_BEHAVIOR_FAILURES = frozenset(
         "successor_reentry_selected_todo_missing",
         "successor_reentry_selected_todo_mismatch",
         "successor_reentry_replan_not_closed",
+        "successor_reentry_not_runnable",
         "successor_reentry_composition_not_scheduled",
         "quota_obligation_missing",
         "non_semantic_replan_action",

--- a/loopx/control_plane/todos/summary_item.py
+++ b/loopx/control_plane/todos/summary_item.py
@@ -11,6 +11,7 @@ from .contract import (
     normalize_todo_excluded_agents,
     normalize_todo_id,
     normalize_todo_required_decision_scopes,
+    normalize_todo_replan_obligation_id,
     normalize_todo_resume_when,
     normalize_todo_task_domain,
     normalize_todo_task_repository,
@@ -54,6 +55,7 @@ TODO_SUMMARY_COMPACT_FIELDS = (
     "resume_ready",
     "no_followup",
     "successor_todo_ids",
+    "replan_obligation_id",
     "target_key",
     "cadence",
     "next_due_at",
@@ -161,6 +163,13 @@ def compact_todo_summary_item(
         compact["removed_continuation_policy"] = removed_continuation_policy
     else:
         compact.pop("removed_continuation_policy", None)
+    replan_obligation_id = normalize_todo_replan_obligation_id(
+        compact.get("replan_obligation_id")
+    )
+    if replan_obligation_id:
+        compact["replan_obligation_id"] = replan_obligation_id
+    else:
+        compact.pop("replan_obligation_id", None)
     compact["task_class"] = todo_item_task_class(compact)
     if (
         compact["task_class"] == "advancement_task"

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -941,17 +941,38 @@ def record_quota_monitor_poll(
     turn_instance_id: str | None = None,
     scheduler_execution_context: Mapping[str, Any] | SchedulerExecutionContextResolution | None = None,
     operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
+    bounded_research_frontier_projector: (
+        Callable[..., Mapping[str, Any] | None] | None
+    ) = None,
     status_reloader: Callable[[], dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     safe_goal_id = _validate_goal_id_path_segment(str(goal_id or ""))
+
     def should_run(current_status: dict[str, Any]) -> dict[str, Any]:
-        return build_quota_should_run(current_status,
+        decision_status = current_status
+        if bounded_research_frontier_projector is not None:
+            raw_runtime_root = current_status.get("runtime_root")
+            if raw_runtime_root:
+                frontier = bounded_research_frontier_projector(
+                    runtime_root=Path(str(raw_runtime_root)).expanduser(),
+                    goal_id=safe_goal_id,
+                    agent_id=agent_id,
+                    status_payload=current_status,
+                )
+                if isinstance(frontier, Mapping):
+                    decision_status = {
+                        **current_status,
+                        "bounded_research_frontier": dict(frontier),
+                    }
+        return build_quota_should_run(
+            decision_status,
             goal_id=safe_goal_id,
             agent_id=agent_id,
             available_capabilities=available_capabilities,
             scheduler_execution_context=scheduler_execution_context,
             operator_inbox_urgency_projector=operator_inbox_urgency_projector,
         )
+
     before = should_run(status_payload)
     return record_quota_monitor_poll_for_decision(
         before,

--- a/tests/control_plane/test_goal_frontier_replan_rules.py
+++ b/tests/control_plane/test_goal_frontier_replan_rules.py
@@ -7,12 +7,16 @@ import pytest
 from loopx.control_plane.goals.goal_frontier import (
     derive_goal_frontier_replan_obligation_from_summaries,
 )
+from loopx.control_plane.goals.goal_frontier.ack_policy import (
+    replan_successor_transition_ack,
+)
 from loopx.control_plane.goals.goal_frontier.replan_rules import (
     GOAL_FRONTIER_REPLAN_RULE_ORDER,
     GoalFrontierReplanFacts,
     GoalFrontierReplanRule,
     select_goal_frontier_replan_rule,
 )
+from loopx.control_plane.todos.summary_item import compact_todo_summary_item
 
 
 @pytest.mark.parametrize(
@@ -194,3 +198,76 @@ def test_current_agent_advancement_satisfies_scoped_vision_frontier() -> None:
     )
 
     assert obligation is None
+
+
+def test_exact_replan_successor_uses_authoritative_todo_source() -> None:
+    obligation_id = "replan-0123456789abcdef"
+    successor = compact_todo_summary_item(
+        {
+            "todo_id": "todo_0123456789ab",
+            "text": "Run the selected bounded experiment.",
+            "status": "open",
+            "task_class": "advancement_task",
+            "claimed_by": "current-agent",
+            "replan_obligation_id": obligation_id,
+        }
+    )
+    unrelated_display_items = [
+        _advancement(f"todo_{index:012x}", "current-agent") for index in range(3)
+    ]
+
+    ack = replan_successor_transition_ack(
+        {"first_executable_items": unrelated_display_items},
+        agent_id="current-agent",
+        replan_obligation={
+            "obligation_id": obligation_id,
+            "satisfying_semantic_outcomes": ["new_runnable_successor"],
+        },
+        agent_todo_items=[*unrelated_display_items, successor],
+    )
+
+    assert successor["replan_obligation_id"] == obligation_id
+    assert ack is not None
+    assert ack["semantic_delta"]["successor_todo_id"] == successor["todo_id"]
+    assert ack["semantic_delta"]["outcomes"] == ["new_runnable_successor"]
+
+
+def test_unrelated_actionable_todo_cannot_close_replan() -> None:
+    obligation_id = "replan-0123456789abcdef"
+
+    ack = replan_successor_transition_ack(
+        {"first_executable_items": []},
+        agent_id="current-agent",
+        replan_obligation={
+            "obligation_id": obligation_id,
+            "satisfying_semantic_outcomes": ["new_runnable_successor"],
+        },
+        agent_todo_items=[
+            {
+                **_advancement("todo_0123456789ab", "current-agent"),
+                "replan_obligation_id": "replan-fedcba9876543210",
+            }
+        ],
+    )
+
+    assert ack is None
+
+
+def test_empty_authoritative_todo_source_does_not_use_stale_display_item() -> None:
+    obligation_id = "replan-0123456789abcdef"
+    stale_display_item = {
+        **_advancement("todo_0123456789ab", "current-agent"),
+        "replan_obligation_id": obligation_id,
+    }
+
+    ack = replan_successor_transition_ack(
+        {"first_executable_items": [stale_display_item]},
+        agent_id="current-agent",
+        replan_obligation={
+            "obligation_id": obligation_id,
+            "satisfying_semantic_outcomes": ["new_runnable_successor"],
+        },
+        agent_todo_items=[],
+    )
+
+    assert ack is None

--- a/tests/control_plane/test_goal_frontier_replan_rules.py
+++ b/tests/control_plane/test_goal_frontier_replan_rules.py
@@ -202,6 +202,7 @@ def test_current_agent_advancement_satisfies_scoped_vision_frontier() -> None:
 
 def test_exact_replan_successor_uses_authoritative_todo_source() -> None:
     obligation_id = "replan-0123456789abcdef"
+    frontier_identity = "progress:abcdef0123456789"
     successor = compact_todo_summary_item(
         {
             "todo_id": "todo_0123456789ab",
@@ -221,6 +222,7 @@ def test_exact_replan_successor_uses_authoritative_todo_source() -> None:
         agent_id="current-agent",
         replan_obligation={
             "obligation_id": obligation_id,
+            "frontier_identity": frontier_identity,
             "satisfying_semantic_outcomes": ["new_runnable_successor"],
         },
         agent_todo_items=[*unrelated_display_items, successor],
@@ -228,6 +230,7 @@ def test_exact_replan_successor_uses_authoritative_todo_source() -> None:
 
     assert successor["replan_obligation_id"] == obligation_id
     assert ack is not None
+    assert ack["frontier_identity"] == frontier_identity
     assert ack["semantic_delta"]["successor_todo_id"] == successor["todo_id"]
     assert ack["semantic_delta"]["outcomes"] == ["new_runnable_successor"]
 

--- a/tests/control_plane/test_replan_semantic_action_behavior.py
+++ b/tests/control_plane/test_replan_semantic_action_behavior.py
@@ -187,6 +187,15 @@ def test_real_tool_loop_selects_composition_gap_and_creates_bound_successor(
         "replan_successor_create",
     ]
     assert receipt["selected_semantic_outcomes"] == ["new_runnable_successor"]
+    successor_reentry = receipt["successor_reentry"]
+    assert successor_reentry["selected_todo_id"].startswith("todo_")
+    assert successor_reentry["decision"] == "run"
+    assert successor_reentry["effective_action"] == "normal_run"
+    assert successor_reentry["replan_closed"] is True
+    assert successor_reentry["composition_experiment_ref"] == (
+        "experiment-permission-composition"
+    )
+    assert successor_reentry["composition_status"] == "scheduled"
 
     quota_packet = json.loads(transport.requests[1]["messages"][-1]["content"])
     selected_gap = quota_packet["bounded_research_frontier"]["selected_gap"]

--- a/tests/control_plane/test_replan_semantic_action_behavior.py
+++ b/tests/control_plane/test_replan_semantic_action_behavior.py
@@ -359,6 +359,10 @@ def test_model_can_create_and_bind_a_real_runnable_successor(tmp_path: Path) -> 
         "replan_successor_create",
     ]
     assert receipt["selected_semantic_outcomes"] == ["new_runnable_successor"]
+    successor_reentry = receipt["successor_reentry"]
+    assert successor_reentry["decision"] == "run"
+    assert successor_reentry["effective_action"] == "normal_run"
+    assert successor_reentry["replan_closed"] is True
 
 
 def test_stale_successor_obligation_is_rejected_before_todo_mutation(


### PR DESCRIPTION
## Summary

- preserve `replan_obligation_id` through canonical Todo summary compaction
- close an exact current-agent successor transition without weakening frontier matching by carrying the obligation's typed `frontier_identity` into the synthetic ACK
- prove that the next heartbeat selects the bound successor in a real runnable lane, including a scheduled composition experiment
- preserve the live bounded-research frontier across heartbeat and explicit monitor-poll writeback
- repair the two stale quota/heartbeat smokes against the current structured interaction contract

Fixes #3175.

## Validation

- Ruff focused lint: passed
- repository-declared Mypy: passed (`Success: no issues found in 16 source files`)
- 162 focused replan/quota/vision/refresh/fine-grained/monitor/composition tests: passed
- `heartbeat-quota-flow-smoke.py`: passed
- `quota-replan-decision-plane-smoke.py`: passed
- public/private boundary scan of all 11 changed files: passed
- change-quality receipt: `cqr_f4d37332e6416adb114f` (valid exact scope, 0 risks)
- premerge gate: passed, 18 selected checks, 0 failures, 0 manual holds, `self_merge_allowed=true`

## Review correction

The review finding about the missing frontier identity was correct. The earlier validation comment incorrectly treated partial pytest output as a completed run. The current result above was collected only after the pytest process exited successfully. The fix propagates the typed identity; it does not bypass or relax `autonomous_replan_ack_matches_frontier`.
