### PR TITLE
fix(control-plane): require explicit peer coordination

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -387,6 +387,15 @@ When `spawn_policy.mode=multi_subagent`, status exposes
 This makes the selected execution mode visible to dashboards and heartbeat
 dispatchers instead of relying on prompt text.
 
+`spawn_policy` governs ephemeral child capacity only. Registering multiple
+durable peers does not auto-elect a coordinator and does not project their
+claimed lanes to another peer. Hosts that can activate durable peer runtimes
+must separately opt in with
+`loopx configure-goal --goal-id <goal> --peer-task-coordinator <registered-agent>`
+and report `--available-capability peer_agent_activation` at quota time. Clear
+the selection with `--clear-peer-task-coordinator`; neither setting widens Todo
+ownership or repository authority.
+
 These fields are a public contract, not a runtime lock manager. The current
 lightweight runtime surface uses todo `claimed_by` as a soft owner written under
 the active-state CLI lock. Claim ids must be listed in

--- a/docs/integrations/codex-subagent-orchestration.md
+++ b/docs/integrations/codex-subagent-orchestration.md
@@ -213,7 +213,11 @@ or non-resumable lane is projected under `blocked_peer_lanes`; if no peer lane
 can run, the bundle has `execution_state=blocked`,
 `terminal_outcome=blocked`, and `retry_policy=material_peer_state_change_only`.
 That blocked diagnostic does not replace the coordinator's own runnable lane or
-re-arm an activation obligation on every heartbeat.
+re-arm an activation obligation on every heartbeat. If the coordinator also
+has no in-scope runnable fallback, the final interaction mode is
+`peer_coordination_blocked`: schedulers return the bundle to its owner and stop
+the recurring heartbeat until peer capability/readiness, coordinator
+configuration, or the coordinator's own work frontier materially changes.
 
 Disable registered-peer coordination without changing peer registration or
 child-worker policy:

--- a/docs/integrations/codex-subagent-orchestration.md
+++ b/docs/integrations/codex-subagent-orchestration.md
@@ -176,14 +176,58 @@ loopx configure-goal \
 
 `multi_subagent` remains the compatibility name for host child-worker capacity
 and permission policy. It does not ask the user to select a run mode or agent
-hierarchy. With host child capability, `quota should-run` projects adaptive
-`task_orchestration_contract_v2`; without it, the registered-peer compatibility
-path remains `task_orchestration_contract_v1`. Dormant registered agents and
-closed, blocked, or deferred todos are not coordinator candidates.
+hierarchy. With observed host child capability, `quota should-run` may project
+adaptive `task_orchestration_contract_v2`. Without that capability, it does not
+fall back to coordinating registered peers: registration grants Todo ownership,
+not cross-agent scheduling authority.
 
 Use `--multi-subagent-feature off` to disable worker spawning. The low-level
 `--orchestration-mode` and `--spawn-allowed` flags remain available for host
 integrations.
+
+## Explicit Registered-Peer Coordination
+
+Registered peers are independent by default. LoopX never hashes the peer set or
+open Todo bundle to auto-elect a coordinator. A host that can really activate
+or resume durable peer runtimes may select one coordinator explicitly:
+
+```bash
+loopx configure-goal \
+  --goal-id example-peer-task-goal \
+  --peer-task-coordinator codex-alpha \
+  --execute
+```
+
+The selected coordinator must then report the observed host capability on each
+eligible turn:
+
+```bash
+loopx quota should-run \
+  --goal-id example-peer-task-goal \
+  --agent-id codex-alpha \
+  --available-capability peer_agent_activation
+```
+
+The contract includes only peer lanes that are currently actionable. A dormant
+or non-resumable lane is projected under `blocked_peer_lanes`; if no peer lane
+can run, the bundle has `execution_state=blocked`,
+`terminal_outcome=blocked`, and `retry_policy=material_peer_state_change_only`.
+That blocked diagnostic does not replace the coordinator's own runnable lane or
+re-arm an activation obligation on every heartbeat.
+
+Disable registered-peer coordination without changing peer registration or
+child-worker policy:
+
+```bash
+loopx configure-goal \
+  --goal-id example-peer-task-goal \
+  --clear-peer-task-coordinator \
+  --execute
+```
+
+This opt-in grants neither cross-owner Todo mutation nor broader repository,
+publication, credential, or production authority. Read it back with
+`loopx configure-goal --goal-id example-peer-task-goal` before relying on it.
 
 ## Run History And Observation
 

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -845,6 +845,10 @@ Item fields:
   hot-path readers do not need to scan the detailed todo sections. The richer
   top-level `user_todos`, `agent_todos`, and `quota` fields remain available
   for detailed views.
+- `goal_boundary.peer_task_coordination`: optional quota-only coordination
+  authority. It appears only when the registry explicitly selects a
+  `coordinator_agent_id`. Registered peers are otherwise independent; child
+  spawn policy never implies registered-peer coordination authority.
 - Current routing authority: consumers should choose the current owner, gate,
   waiting party, and next action from `attention_queue.items` and its
   `project_asset`. `run_history.latest_runs` is an evidence and drill-down

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -848,7 +848,10 @@ Item fields:
 - `goal_boundary.peer_task_coordination`: optional quota-only coordination
   authority. It appears only when the registry explicitly selects a
   `coordinator_agent_id`. Registered peers are otherwise independent; child
-  spawn policy never implies registered-peer coordination authority.
+  spawn policy never implies registered-peer coordination authority. A blocked
+  explicit bundle never displaces the coordinator's own runnable Todo; with no
+  local fallback it projects `interaction_contract.mode=peer_coordination_blocked`
+  so schedulers stop until a material coordination input changes.
 - Current routing authority: consumers should choose the current owner, gate,
   waiting party, and next action from `attention_queue.items` and its
   `project_asset`. `run_history.latest_runs` is an evidence and drill-down

--- a/examples/control_plane/task-orchestration-smoke.py
+++ b/examples/control_plane/task-orchestration-smoke.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 import sys
 from pathlib import Path
 
@@ -210,6 +211,20 @@ def adaptive_payload() -> dict:
     }
 
 
+def without_agent_work(state: dict, *, agent_id: str) -> dict:
+    result = deepcopy(state)
+    summary = result["attention_queue"]["items"][0]["agent_todos"]
+    for item in summary["items"]:
+        if item.get("claimed_by") == agent_id:
+            item["status"] = "done"
+            item["done"] = True
+    summary["open"] = sum(
+        item.get("status") == "open" for item in summary["items"]
+    )
+    summary["done"] = sum(item.get("done") is True for item in summary["items"])
+    return result
+
+
 def main() -> int:
     decisions = {
         agent_id: build_quota_should_run(
@@ -242,6 +257,52 @@ def main() -> int:
     assert blocked_decision["effective_action"] != "coordinate_task_bundle", (
         blocked_decision
     )
+    assert blocked_decision["interaction_contract"]["mode"] == "bounded_delivery", (
+        blocked_decision
+    )
+
+    blocked_without_fallback = without_agent_work(
+        payload(peer_task_coordinator=coordinator),
+        agent_id=coordinator,
+    )
+    blocked_turns = [
+        build_quota_should_run(
+            blocked_without_fallback,
+            goal_id=GOAL_ID,
+            agent_id=coordinator,
+            scheduler_execution_context=(
+                scheduler_execution_context_for_runtime_profile(
+                    SchedulerRuntimeProfile.CODEX_APP_HEARTBEAT
+                )
+            ),
+        )
+        for _ in range(2)
+    ]
+    for blocked_turn in blocked_turns:
+        assert blocked_turn["decision"] == "peer_coordination_blocked", blocked_turn
+        assert blocked_turn["should_run"] is False, blocked_turn
+        assert blocked_turn["interaction_contract"]["mode"] == (
+            "peer_coordination_blocked"
+        ), blocked_turn
+        assert blocked_turn["scheduler_hint"]["action"] == (
+            "return_to_owner_until_material_change"
+        ), blocked_turn
+        assert blocked_turn["scheduler_hint"]["codex_app"]["host_action"] == (
+            "pause_or_delete_current_heartbeat"
+        ), blocked_turn
+        assert blocked_turn["scheduler_hint"]["unchanged_poll"][
+            "local_scheduler"
+        ] == "stop", blocked_turn
+        assert blocked_turn["interaction_contract"]["cli_channel"][
+            "spend_after_validation"
+        ] is False, blocked_turn
+    assert [
+        turn["task_orchestration_contract"]["assignment_key"]
+        for turn in blocked_turns
+    ] == [
+        blocked_turns[0]["task_orchestration_contract"]["assignment_key"],
+        blocked_turns[0]["task_orchestration_contract"]["assignment_key"],
+    ], blocked_turns
 
     decision = build_quota_should_run(
         payload(peer_task_coordinator=coordinator),

--- a/examples/control_plane/task-orchestration-smoke.py
+++ b/examples/control_plane/task-orchestration-smoke.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Smoke deterministic task-scoped coordination among equal peers."""
+"""Smoke explicitly selected task-scoped coordination among equal peers."""
 
 from __future__ import annotations
 
@@ -20,7 +20,10 @@ from loopx.control_plane.turn_driver import (  # noqa: E402
     build_loopx_turn_host_request,
     build_loopx_turn_plan,
 )
-from loopx.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
+from loopx.quota import (  # noqa: E402
+    build_quota_should_run,
+    render_quota_should_run_markdown,
+)
 
 
 GOAL_ID = "task-orchestration-fixture"
@@ -28,7 +31,11 @@ PEERS = ["codex-alpha", "codex-beta", "codex-gamma"]
 DORMANT_PEER = "codex-dormant"
 
 
-def payload(*, reverse_agents: bool = False) -> dict:
+def payload(
+    *,
+    reverse_agents: bool = False,
+    peer_task_coordinator: str | None = None,
+) -> dict:
     registered_agents = [*PEERS, DORMANT_PEER]
     if reverse_agents:
         registered_agents = list(reversed(registered_agents))
@@ -36,6 +43,10 @@ def payload(*, reverse_agents: bool = False) -> dict:
         "agent_model": "peer_v1",
         "registered_agents": registered_agents,
     }
+    if peer_task_coordinator:
+        coordination["peer_task_coordination"] = {
+            "coordinator_agent_id": peer_task_coordinator,
+        }
     todos = [
         {
             "index": index,
@@ -101,6 +112,24 @@ def payload(*, reverse_agents: bool = False) -> dict:
         "ok": True,
         "attention_queue": {"items": [attention]},
         "run_history": {"goals": [goal]},
+        "agent_management_projection": {
+            "schema_version": "agent_management_projection_v0",
+            "agents": [
+                {
+                    "agent_id": agent_id,
+                    "state": "running",
+                    "last_activity_at": "2026-08-14T12:00:00Z",
+                }
+                for agent_id in PEERS
+            ]
+            + [
+                {
+                    "agent_id": DORMANT_PEER,
+                    "state": "waiting",
+                    "last_activity_at": None,
+                }
+            ],
+        },
     }
 
 
@@ -190,18 +219,41 @@ def main() -> int:
         )
         for agent_id in PEERS
     }
-    coordinators = [
-        agent_id
-        for agent_id, decision in decisions.items()
-        if "task_orchestration_contract" in decision
-    ]
-    assert len(coordinators) == 1, decisions
-    coordinator = coordinators[0]
-    decision = decisions[coordinator]
+    assert all(
+        "task_orchestration_contract" not in decision
+        for decision in decisions.values()
+    ), decisions
+    assert all(
+        decision["effective_action"] != "coordinate_task_bundle"
+        for decision in decisions.values()
+    ), decisions
+
+    coordinator = "codex-alpha"
+    blocked_decision = build_quota_should_run(
+        payload(peer_task_coordinator=coordinator),
+        goal_id=GOAL_ID,
+        agent_id=coordinator,
+    )
+    blocked_contract = blocked_decision["task_orchestration_contract"]
+    assert blocked_contract["execution_state"] == "blocked", blocked_contract
+    assert blocked_contract["eligible_peer_lanes"] == [], blocked_contract
+    assert len(blocked_contract["blocked_peer_lanes"]) == 2, blocked_contract
+    assert blocked_contract["terminal_outcome"] == "blocked", blocked_contract
+    assert blocked_decision["effective_action"] != "coordinate_task_bundle", (
+        blocked_decision
+    )
+
+    decision = build_quota_should_run(
+        payload(peer_task_coordinator=coordinator),
+        goal_id=GOAL_ID,
+        agent_id=coordinator,
+        available_capabilities=["peer_agent_activation"],
+    )
     contract = decision["task_orchestration_contract"]
     assert decision["effective_action"] == "coordinate_task_bundle", decision
     assert decision["interaction_contract"]["mode"] == "task_orchestration", decision
     assert contract["coordinator_agent_id"] == coordinator, contract
+    assert contract["execution_state"] == "ready", contract
     assert coordinator in PEERS and coordinator != DORMANT_PEER, contract
     assert contract["writeback_owner"] == "task_coordinator", contract
     assert "controller_agent_id" not in contract, contract
@@ -218,9 +270,10 @@ def main() -> int:
     assert "task_orchestration: mode=task_scoped_peer" in markdown, markdown
 
     reversed_decision = build_quota_should_run(
-        payload(reverse_agents=True),
+        payload(reverse_agents=True, peer_task_coordinator=coordinator),
         goal_id=GOAL_ID,
         agent_id=coordinator,
+        available_capabilities=["peer_agent_activation"],
     )
     assert reversed_decision["task_orchestration_contract"][
         "coordinator_agent_id"

--- a/examples/peer-agent-task-orchestration.registry.example.json
+++ b/examples/peer-agent-task-orchestration.registry.example.json
@@ -32,6 +32,9 @@
       },
       "coordination": {
         "agent_model": "peer_v1",
+        "peer_task_coordination": {
+          "coordinator_agent_id": "codex-alpha"
+        },
         "registered_agents": [
           "codex-alpha",
           "codex-beta",
@@ -50,7 +53,8 @@
       "next_probe": "python3 scripts/project-pre-tick.py --format json --save-run",
       "guards": [
         "registered agents are equal peers",
-        "open task participants determine the temporary coordinator",
+        "registered peers do not coordinate by default",
+        "the selected coordinator still requires observed peer_agent_activation capability",
         "repository-writing peers use independent worktrees",
         "executor exclusions cannot name the claimed peer",
         "task coordination cannot widen write or production authority"

--- a/examples/project/configure-goal-smoke.py
+++ b/examples/project/configure-goal-smoke.py
@@ -9,7 +9,6 @@ import sys
 import tempfile
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 GOAL_ID = "configure-goal-fixture"
 
@@ -208,6 +207,7 @@ def main() -> int:
         features = {item["feature_id"]: item for item in catalog["features"]}
         assert set(features) == {
             "multi_subagent",
+            "peer_task_coordination",
             "explore_graph",
             "explore_harness",
             "change_quality_qualification",
@@ -216,6 +216,13 @@ def main() -> int:
             "lark_kanban_heartbeat_sync",
         }
         assert features["multi_subagent"]["current"]["enabled"] is True
+        assert features["peer_task_coordination"]["current"] == {
+            "enabled": False,
+            "coordinator_agent_id": None,
+        }
+        assert "--peer-task-coordinator" in features[
+            "peer_task_coordination"
+        ]["commands"]["preview_enable"]
         assert features["explore_graph"]["current"]["enabled"] is False
         assert features["change_quality_qualification"]["current"] == {
             "enabled": False,
@@ -403,6 +410,67 @@ def main() -> int:
         assert authority["write_scope"] == ["docs/**"], authority
         assert authority["source"] == "operator_gate_resume_contract_v0:fixture", authority
         assert authority["decision_id"] == "gate-fixture-1", authority
+        peer_coordination_preview = payload(run_cli(
+            registry_path,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--peer-task-coordinator",
+            "codex-main-control",
+        ))
+        assert peer_coordination_preview["written"] is False, (
+            peer_coordination_preview
+        )
+        assert peer_coordination_preview["after"]["peer_task_coordination"] == {
+            "enabled": True,
+            "coordinator_agent_id": "codex-main-control",
+        }
+        peer_coordination_applied = payload(run_cli(
+            registry_path,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--peer-task-coordinator",
+            "codex-main-control",
+            "--execute",
+        ))
+        assert peer_coordination_applied["written"] is True, (
+            peer_coordination_applied
+        )
+        peer_goal = goal_from_registry(registry_path)
+        assert peer_goal["coordination"]["peer_task_coordination"] == {
+            "coordinator_agent_id": "codex-main-control",
+        }
+        assert goal_boundary(peer_goal)["peer_task_coordination"] == {
+            "enabled": True,
+            "coordinator_agent_id": "codex-main-control",
+        }
+        peer_coordination_cleared = payload(run_cli(
+            registry_path,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--clear-peer-task-coordinator",
+            "--execute",
+        ))
+        assert peer_coordination_cleared["written"] is True, (
+            peer_coordination_cleared
+        )
+        assert "peer_task_coordination" not in goal_from_registry(
+            registry_path
+        )["coordination"]
+        peer_coordination_restored = payload(run_cli(
+            registry_path,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--peer-task-coordinator",
+            "codex-main-control",
+            "--execute",
+        ))
+        assert peer_coordination_restored["written"] is True, (
+            peer_coordination_restored
+        )
         state_file = root / "project" / ".codex/goals/configure-goal-fixture/STATE.md"
         state_before_scope_migration = state_file.read_text(encoding="utf-8")
 
@@ -586,6 +654,9 @@ def main() -> int:
         assert "configured_agent_model" in agents_cleared["changed_fields"], agents_cleared
         assert "registered_agents" not in goal_from_registry(registry_path)["coordination"], agents_cleared
         assert "agent_model" not in goal_from_registry(registry_path)["coordination"], agents_cleared
+        assert "peer_task_coordination" not in goal_from_registry(
+            registry_path
+        )["coordination"], agents_cleared
 
         scope_cleared = payload(run_cli(
             registry_path,

--- a/loopx/cli_commands/registry_admin.py
+++ b/loopx/cli_commands/registry_admin.py
@@ -604,6 +604,10 @@ def handle_registry_admin_command(
                 lark_kanban_heartbeat_sync=args.lark_kanban_heartbeat_sync,
                 registered_agents=args.registered_agents,
                 clear_registered_agents=bool(args.clear_registered_agents),
+                peer_task_coordinator=args.peer_task_coordinator,
+                clear_peer_task_coordinator=bool(
+                    args.clear_peer_task_coordinator
+                ),
                 agent_profiles=agent_profiles,
                 clear_agent_profiles=args.clear_agent_profiles,
                 agent_work_modes=agent_work_modes or None,

--- a/loopx/cli_commands/registry_admin_configure.py
+++ b/loopx/cli_commands/registry_admin_configure.py
@@ -164,6 +164,18 @@ def register_configure_goal_command(subparsers: argparse._SubParsersAction) -> N
         help="Clear coordination.registered_agents.",
     )
     configure_goal_parser.add_argument(
+        "--peer-task-coordinator",
+        help=(
+            "Explicitly select one registered peer to coordinate peer-owned task "
+            "lanes. Registration alone never enables coordination."
+        ),
+    )
+    configure_goal_parser.add_argument(
+        "--clear-peer-task-coordinator",
+        action="store_true",
+        help="Disable registered-peer task coordination for this goal.",
+    )
+    configure_goal_parser.add_argument(
         "--agent-profile-json",
         dest="agent_profile_jsons",
         action="append",

--- a/loopx/configuration_catalog.py
+++ b/loopx/configuration_catalog.py
@@ -72,6 +72,11 @@ def build_goal_configuration_catalog(
         "--allowed-domain",
         "<bounded-domain>",
     )
+    peer_coordination = (
+        feature_summary.get("peer_task_coordination")
+        if isinstance(feature_summary.get("peer_task_coordination"), Mapping)
+        else {}
+    )
     graph_enable_args = ("--explore-graph-enabled",)
     harness_enable_args = (
         "--explore-harness-enabled",
@@ -142,6 +147,67 @@ def build_goal_configuration_catalog(
                             ["loopx", "quota", "should-run", "--goal-id", goal_id]
                         ),
                     ],
+                },
+                "documentation": {
+                    "path": "docs/integrations/codex-subagent-orchestration.md",
+                    "url": (
+                        "https://github.com/huangruiteng/loopx/blob/main/"
+                        "docs/integrations/codex-subagent-orchestration.md"
+                    ),
+                },
+            },
+            {
+                "feature_id": "peer_task_coordination",
+                "display_name": "Registered-peer task coordination",
+                "availability": "supported_explicit_opt_in",
+                "default": {"enabled": False},
+                "current": {
+                    "enabled": peer_coordination.get("enabled") is True,
+                    "coordinator_agent_id": peer_coordination.get(
+                        "coordinator_agent_id"
+                    ),
+                },
+                "required_inputs": {
+                    "registered-agent-id": (
+                        "Select one already registered peer explicitly; registration "
+                        "alone does not grant coordination authority."
+                    )
+                },
+                "consider_when": (
+                    "The host can activate or resume durable peer runtimes and one "
+                    "peer must coordinate an explicit task bundle."
+                ),
+                "effect": (
+                    "Projects peer-owned lanes only to the selected coordinator, "
+                    "subject to per-turn peer_agent_activation capability admission."
+                ),
+                "does_not": [
+                    "auto-elect a coordinator",
+                    "allow cross-owner todo mutation",
+                    "make dormant or non-resumable peer lanes executable",
+                ],
+                "commands": {
+                    "preview_enable": _configure_command(
+                        goal_id,
+                        "--peer-task-coordinator",
+                        "<registered-agent-id>",
+                    ),
+                    "apply_enable": _configure_command(
+                        goal_id,
+                        "--peer-task-coordinator",
+                        "<registered-agent-id>",
+                        execute=True,
+                    ),
+                    "preview_disable": _configure_command(
+                        goal_id,
+                        "--clear-peer-task-coordinator",
+                    ),
+                    "apply_disable": _configure_command(
+                        goal_id,
+                        "--clear-peer-task-coordinator",
+                        execute=True,
+                    ),
+                    "verify": [inspect_command],
                 },
                 "documentation": {
                     "path": "docs/integrations/codex-subagent-orchestration.md",

--- a/loopx/configure_goal.py
+++ b/loopx/configure_goal.py
@@ -26,6 +26,7 @@ from .orchestration import (
     EXPLORE_HARNESS_PROFILES,
     MULTI_SUBAGENT_ORCHESTRATION_MODE,
     compact_orchestration_policy,
+    compact_peer_task_coordination_policy,
     orchestration_policy_summary,
 )
 from .quota import goal_quota_config
@@ -243,6 +244,9 @@ def _settings_summary(goal: dict[str, Any]) -> dict[str, Any]:
         "write_scope": _clean_write_scope(coordination.get("write_scope") or []) or [],
         "checkpointed_boundary_authority": checkpointed_boundary_authority_summary(coordination),
         "registered_agents": registered_agents,
+        "peer_task_coordination": deepcopy(
+            compact_peer_task_coordination_policy(coordination)
+        ),
         "todo_lifecycle_authority": normalize_todo_lifecycle_authority(
             coordination.get("todo_lifecycle_authority"),
             registered_agents=registered_agents,
@@ -421,6 +425,8 @@ def configure_goal(
     explore_graph_enabled: bool | None = None,
     registered_agents: list[str] | None = None,
     clear_registered_agents: bool = False,
+    peer_task_coordinator: str | None = None,
+    clear_peer_task_coordinator: bool = False,
     agent_profiles: list[dict[str, Any]] | None = None,
     clear_agent_profiles: list[str] | None = None,
     agent_work_modes: dict[str, str] | None = None,
@@ -467,6 +473,11 @@ def configure_goal(
         )
     if clear_registered_agents and registered_agents:
         raise ValueError("--clear-registered-agents cannot be combined with --registered-agent")
+    if clear_peer_task_coordinator and peer_task_coordinator:
+        raise ValueError(
+            "--clear-peer-task-coordinator cannot be combined with "
+            "--peer-task-coordinator"
+        )
     if agent_model is not None:
         agent_model = str(agent_model).strip().lower()
         if agent_model not in AGENT_MODEL_CHOICES:
@@ -556,6 +567,12 @@ def configure_goal(
         if allowed_domains:
             raise ValueError("--multi-subagent-feature off cannot be combined with --allowed-domain")
     registered_agents = _clean_registered_agents(registered_agents)
+    if peer_task_coordinator is not None:
+        peer_task_coordinator = normalize_todo_claimed_by(peer_task_coordinator)
+        if not peer_task_coordinator:
+            raise ValueError(
+                "--peer-task-coordinator must be a public-safe registered agent id"
+            )
     reward_memory_agents = _clean_registered_agents(reward_memory_agents)
     clear_agent_profiles = _clean_registered_agents(clear_agent_profiles)
     clear_agent_work_modes = _clean_registered_agents(clear_agent_work_modes)
@@ -595,6 +612,14 @@ def configure_goal(
         if registered_agents is not None
         else normalize_registered_agents(existing_coordination.get("registered_agents"))
     )
+    if (
+        peer_task_coordinator is not None
+        and peer_task_coordinator not in effective_registered_agents
+    ):
+        raise ValueError(
+            "--peer-task-coordinator must name an agent already registered for "
+            f"this goal: {peer_task_coordinator}"
+        )
     existing_reward_memory = reward_memory_goal_policy(goal)
     effective_reward_memory_agents = (
         reward_memory_agents
@@ -709,6 +734,8 @@ def configure_goal(
     elif execute and legacy_hierarchy_before and not migration_completed_before and (
         agent_model is not None
         or registered_agents is not None
+        or peer_task_coordinator is not None
+        or clear_peer_task_coordinator
         or clear_registered_agents
     ):
         raise ValueError(
@@ -900,6 +927,8 @@ def configure_goal(
     if (
         clear_registered_agents
         or registered_agents is not None
+        or peer_task_coordinator is not None
+        or clear_peer_task_coordinator
         or normalized_agent_profiles
         or clear_agent_profiles
         or normalized_agent_work_modes
@@ -925,8 +954,22 @@ def configure_goal(
             coordination.pop("agent_work_modes", None)
             coordination.pop("supervisor", None)
             coordination.pop("todo_lifecycle_authority", None)
+            coordination.pop("peer_task_coordination", None)
         elif registered_agents is not None:
             coordination["registered_agents"] = registered_agents
+            current_peer_task_coordination = (
+                coordination.get("peer_task_coordination")
+                if isinstance(coordination.get("peer_task_coordination"), dict)
+                else {}
+            )
+            current_peer_coordinator = normalize_todo_claimed_by(
+                current_peer_task_coordination.get("coordinator_agent_id")
+            )
+            if (
+                current_peer_coordinator
+                and current_peer_coordinator not in registered_agents
+            ):
+                coordination.pop("peer_task_coordination", None)
             existing_profiles = (
                 coordination.get("agent_profiles")
                 if isinstance(coordination.get("agent_profiles"), dict)
@@ -976,6 +1019,13 @@ def configure_goal(
                 coordination.pop("todo_lifecycle_authority", None)
         if not clear_registered_agents:
             coordination["agent_model"] = effective_agent_model
+        if not clear_registered_agents:
+            if clear_peer_task_coordinator:
+                coordination.pop("peer_task_coordination", None)
+            elif peer_task_coordinator is not None:
+                coordination["peer_task_coordination"] = {
+                    "coordinator_agent_id": peer_task_coordinator,
+                }
         if not clear_registered_agents and (
             normalized_agent_profiles or clear_agent_profiles
         ):
@@ -1109,6 +1159,9 @@ def configure_goal(
             or {"enabled": False}
         ),
         "peer_supervisor": deepcopy(after.get("supervisor") or {"enabled": False}),
+        "peer_task_coordination": deepcopy(
+            after.get("peer_task_coordination") or {"enabled": False}
+        ),
         "lark_event_inbox": _lark_event_inbox_config_summary(goal),
         "lark_kanban_heartbeat_sync": _lark_kanban_heartbeat_config_summary(goal),
         "reward_memory": reward_memory_goal_policy_summary(goal),

--- a/loopx/control_plane/quota/decision_summary.py
+++ b/loopx/control_plane/quota/decision_summary.py
@@ -135,6 +135,8 @@ def refine_quota_recommended_action(
             or ""
         )
         if task_orchestration_contract
+        and str(task_orchestration_contract.get("execution_state") or "ready")
+        == "ready"
         else selected_action
     )
     if (
@@ -406,13 +408,24 @@ def _task_orchestration_effective_action(
 ) -> tuple[str, str]:
     if (
         contract
+        and str(contract.get("execution_state") or "ready") == "ready"
         and should_run
         and normal_delivery_allowed
         and effective_action == "normal_run"
     ):
+        if contract.get("mode") == "adaptive":
+            return (
+                "coordinate_task_bundle",
+                (
+                    "the task coordinator may use admitted child lanes before its "
+                    "own worker-lane delivery"
+                ),
+            )
         return (
             "coordinate_task_bundle",
-            "the deterministic task coordinator must activate or resume eligible "
-            "peer lanes before doing its own worker-lane delivery",
+            (
+                "the explicitly selected task coordinator must activate or resume "
+                "eligible peer lanes before doing its own worker-lane delivery"
+            ),
         )
     return effective_action, reason

--- a/loopx/control_plane/quota/goal_boundary.py
+++ b/loopx/control_plane/quota/goal_boundary.py
@@ -12,7 +12,10 @@ from ...benchmark_core import compact_run_permission_policy_for_quota
 from ...boundary_authority import checkpointed_boundary_authority_summary
 from ...execution_profile import execution_profile_outcome_floor
 from ...explore_graph import compact_explore_graph_policy
-from ...orchestration import compact_orchestration_policy
+from ...orchestration import (
+    compact_orchestration_policy,
+    compact_peer_task_coordination_policy,
+)
 from ...repository_identity import resolve_project_identity
 from ..todos.contract import (
     normalize_required_capabilities,
@@ -183,6 +186,9 @@ def _registry_boundary_projection(goal: Mapping[str, Any]) -> dict[str, Any]:
         boundary["requires_parent_approval"] = [
             str(value) for value in requires_approval if str(value).strip()
         ]
+    peer_task_coordination = compact_peer_task_coordination_policy(coordination)
+    if peer_task_coordination:
+        boundary["peer_task_coordination"] = peer_task_coordination
     guards = goal.get("guards") if isinstance(goal.get("guards"), list) else []
     if guards:
         boundary["guards"] = [str(value) for value in guards if str(value).strip()]

--- a/loopx/control_plane/quota/should_run_packet.py
+++ b/loopx/control_plane/quota/should_run_packet.py
@@ -59,6 +59,7 @@ from ..quota.stall_repair import (
 from ..quota.task_orchestration import (
     attach_task_orchestration_payload,
     payload_work_lane_contract as _payload_work_lane_contract,
+    task_orchestration_contract_is_actionable,
     task_goal_route_hint,
 )
 from ..scheduler.automation_liveness import build_automation_liveness
@@ -665,7 +666,9 @@ def _resolve_quota_should_run_route(
     if (
         not due_monitor_attempt
         and not prepared.inbox_reply_due
-        and not prepared.task_orchestration_contract
+        and not task_orchestration_contract_is_actionable(
+            prepared.task_orchestration_contract
+        )
         and not prepared.capability_monitor_fallback
     ):
         agent_lane_next_action = build_agent_lane_next_action(

--- a/loopx/control_plane/quota/should_run_packet.py
+++ b/loopx/control_plane/quota/should_run_packet.py
@@ -57,9 +57,11 @@ from ..quota.stall_repair import (
     standing_decision_authority_payload_from_status_item as _standing_decision_authority_payload_from_status_item,
 )
 from ..quota.task_orchestration import (
+    PEER_COORDINATION_BLOCKED_ACTION,
     attach_task_orchestration_payload,
     payload_work_lane_contract as _payload_work_lane_contract,
     task_orchestration_contract_is_actionable,
+    task_orchestration_requires_material_change_stop,
     task_goal_route_hint,
 )
 from ..scheduler.automation_liveness import build_automation_liveness
@@ -739,6 +741,27 @@ def _resolve_quota_should_run_route(
                 "spend_policy": agent_scope_frontier.get("spend_policy")
                 or "do not append quota spend while the current agent has no in-scope runnable candidate",
             }
+            if task_orchestration_requires_material_change_stop(
+                prepared.task_orchestration_contract,
+                effective_action=effective_action,
+            ):
+                effective_action = PEER_COORDINATION_BLOCKED_ACTION
+                reason = (
+                    "the explicitly selected peer task bundle is blocked and the "
+                    "coordinator has no in-scope runnable fallback; return control "
+                    "until peer capability, peer readiness, coordinator config, or "
+                    "the coordinator's own frontier changes"
+                )
+                selected_recommended_action = reason
+                heartbeat_recommendation = {
+                    **heartbeat_recommendation,
+                    "recommended_mode": PEER_COORDINATION_BLOCKED_ACTION,
+                    "notify": "DONT_NOTIFY",
+                    "reason": reason,
+                    "spend_policy": (
+                        "no quota spend while explicit peer coordination is blocked"
+                    ),
+                }
     state_action_projection_warning = build_state_action_projection_warning(
         item,
         agent_todo_summary=prepared.agent_todo_summary,
@@ -862,6 +885,8 @@ def _build_quota_should_run_payload(
             if prepared.automation_prompt_upgrade_required
             else agent_scope_action.value
             if agent_scope_action is not None
+            else PEER_COORDINATION_BLOCKED_ACTION
+            if route.effective_action == PEER_COORDINATION_BLOCKED_ACTION
             else "skip"
         ),
         "should_run": route.should_run,

--- a/loopx/control_plane/quota/should_run_prepare.py
+++ b/loopx/control_plane/quota/should_run_prepare.py
@@ -51,6 +51,7 @@ from ..quota.stall_repair import (
 from ..quota.task_orchestration import (
     apply_task_orchestration_contract,
     build_quota_work_lane_contract,
+    task_orchestration_contract_is_actionable,
 )
 from ..scheduler.execution_context import (
     SchedulerExecutionContextResolution,
@@ -337,6 +338,11 @@ def _build_agent_work_lane(
         user_todo_source_items=user_todo_source_items,
         available_capabilities=available_capabilities,
         parent_goal_id=goal_id,
+        agent_management_projection=(
+            status_payload.get("agent_management_projection")
+            if isinstance(status_payload.get("agent_management_projection"), dict)
+            else None
+        ),
     )
     return monitor_only, work_lane, task_orchestration
 
@@ -521,7 +527,7 @@ def _prepare_quota_should_run_item(
             monitor_item_limit=MONITOR_DUE_ITEM_LIMIT,
         )
     )
-    if task_orchestration_contract:
+    if task_orchestration_contract_is_actionable(task_orchestration_contract):
         capability_monitor_contract = capability_monitor_fallback = None
     work_lane_contract = capability_monitor_contract or work_lane_contract
     scoped_user_gate_fallback = _scoped_user_gate_fallback(

--- a/loopx/control_plane/quota/task_orchestration.py
+++ b/loopx/control_plane/quota/task_orchestration.py
@@ -22,6 +22,7 @@ AGENT_SCOPE_NON_EXECUTION_ACTIONS = {
     AgentScopeFrontierAction.REASSIGNMENT_REQUIRED.value,
 }
 PEER_AGENT_ACTIVATION_CAPABILITY = "peer_agent_activation"
+PEER_COORDINATION_BLOCKED_ACTION = "peer_coordination_blocked"
 
 
 def task_orchestration_contract_is_actionable(
@@ -30,6 +31,29 @@ def task_orchestration_contract_is_actionable(
     if not isinstance(contract, dict):
         return False
     return str(contract.get("execution_state") or "ready") == "ready"
+
+
+def task_orchestration_requires_material_change_stop(
+    contract: dict[str, Any] | None,
+    *,
+    effective_action: str,
+) -> bool:
+    """Stop an explicitly coordinated peer lane that has no local fallback.
+
+    A blocked peer bundle remains useful diagnostic state, but it is not a
+    runnable obligation.  The caller supplies the already-derived agent-scope
+    action so this rule only stops a coordinator after its own runnable
+    frontier has been exhausted.
+    """
+
+    if not isinstance(contract, dict):
+        return False
+    return bool(
+        contract.get("mode") == "task_scoped_peer"
+        and contract.get("execution_state") == "blocked"
+        and contract.get("retry_policy") == "material_peer_state_change_only"
+        and effective_action in AGENT_SCOPE_NON_EXECUTION_ACTIONS
+    )
 
 
 def build_quota_work_lane_contract(

--- a/loopx/control_plane/quota/task_orchestration.py
+++ b/loopx/control_plane/quota/task_orchestration.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from ..agents.agent_scope_frontier import AgentScopeFrontierAction
-from ..agents.runtime_model import peer_work_key, select_peer_for_work
+from ..agents.runtime_model import peer_work_key
 from ..todos.contract import (
     normalize_required_capabilities,
     normalize_todo_claimed_by,
@@ -16,12 +16,20 @@ from .task_orchestration_admission import (
     build_adaptive_task_orchestration_contract,
 )
 
-
 AGENT_SCOPE_NON_EXECUTION_ACTIONS = {
     AgentScopeFrontierAction.AGENT_SCOPE_EXHAUSTED.value,
     AgentScopeFrontierAction.AGENT_SCOPE_WAIT.value,
     AgentScopeFrontierAction.REASSIGNMENT_REQUIRED.value,
 }
+PEER_AGENT_ACTIVATION_CAPABILITY = "peer_agent_activation"
+
+
+def task_orchestration_contract_is_actionable(
+    contract: dict[str, Any] | None,
+) -> bool:
+    if not isinstance(contract, dict):
+        return False
+    return str(contract.get("execution_state") or "ready") == "ready"
 
 
 def build_quota_work_lane_contract(
@@ -91,6 +99,7 @@ def apply_task_orchestration_contract(
     user_todo_source_items: list[dict[str, Any]] | None = None,
     available_capabilities: Any = None,
     parent_goal_id: str | None = None,
+    agent_management_projection: dict[str, Any] | None = None,
 ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
     del agent_todo_summary
     contract = _task_orchestration_contract(
@@ -102,9 +111,12 @@ def apply_task_orchestration_contract(
         user_todo_source_items=user_todo_source_items,
         available_capabilities=available_capabilities,
         parent_goal_id=parent_goal_id,
+        agent_management_projection=agent_management_projection,
     )
     if not contract:
         return None, fallback_work_lane_contract
+    if not task_orchestration_contract_is_actionable(contract):
+        return contract, fallback_work_lane_contract
     return contract, _task_orchestration_work_lane_contract(contract)
 
 
@@ -113,6 +125,8 @@ def task_goal_route_hint(
     contract: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
     if not contract or not isinstance(goal_route_hint, dict):
+        return goal_route_hint
+    if not task_orchestration_contract_is_actionable(contract):
         return goal_route_hint
     lanes = contract.get("eligible_child_lanes")
     if not isinstance(lanes, list):
@@ -200,6 +214,7 @@ def _task_orchestration_contract(
     user_todo_source_items: list[dict[str, Any]] | None,
     available_capabilities: Any,
     parent_goal_id: str | None,
+    agent_management_projection: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
     if not isinstance(agent_identity, dict):
         return None
@@ -213,24 +228,35 @@ def _task_orchestration_contract(
         if isinstance(goal_boundary.get("orchestration"), dict)
         else {}
     )
+    available = normalize_required_capabilities(available_capabilities)
+    peer_coordination = (
+        goal_boundary.get("peer_task_coordination")
+        if isinstance(goal_boundary.get("peer_task_coordination"), dict)
+        else {}
+    )
+    configured_coordinator = normalize_todo_claimed_by(
+        peer_coordination.get("coordinator_agent_id")
+    )
+    if (
+        peer_coordination.get("enabled") is True
+        and configured_coordinator == agent_id
+    ):
+        peer_contract = _registered_peer_task_orchestration_contract(
+            agent_id=agent_id,
+            agent_identity=agent_identity,
+            raw_agent_todo_summary=raw_agent_todo_summary,
+            available_capabilities=available,
+            agent_management_projection=agent_management_projection,
+        )
+        if peer_contract:
+            return peer_contract
     if orchestration.get("mode") != "multi_subagent":
         return None
     if orchestration.get("spawn_allowed") is not True:
         return None
-    max_peers = orchestration.get("max_children")
-    if not isinstance(max_peers, int) or max_peers <= 0:
+    max_children = orchestration.get("max_children")
+    if not isinstance(max_children, int) or max_children <= 0:
         return None
-    available = normalize_required_capabilities(available_capabilities)
-    if _has_explicit_registered_peer_bundle(
-        agent_identity=agent_identity,
-        raw_agent_todo_summary=raw_agent_todo_summary,
-    ):
-        return _registered_peer_task_orchestration_contract(
-            agent_id=agent_id,
-            agent_identity=agent_identity,
-            raw_agent_todo_summary=raw_agent_todo_summary,
-            max_peers=max_peers,
-        )
     if SUBAGENT_SPAWN_CAPABILITY in available:
         return build_adaptive_task_orchestration_contract(
             agent_id=agent_id,
@@ -243,39 +269,9 @@ def _task_orchestration_contract(
             user_todo_source_items=user_todo_source_items,
             available_capabilities=available,
             parent_goal_id=parent_goal_id,
-            max_children=max_peers,
+            max_children=max_children,
         )
-    return _registered_peer_task_orchestration_contract(
-        agent_id=agent_id,
-        agent_identity=agent_identity,
-        raw_agent_todo_summary=raw_agent_todo_summary,
-        max_peers=max_peers,
-    )
-
-
-def _has_explicit_registered_peer_bundle(
-    *,
-    agent_identity: dict[str, Any],
-    raw_agent_todo_summary: dict[str, Any] | None,
-) -> bool:
-    registered_agents = set(agent_identity.get("registered_agents") or [])
-    source_items = (
-        raw_agent_todo_summary.get("items")
-        if isinstance(raw_agent_todo_summary, dict)
-        and isinstance(raw_agent_todo_summary.get("items"), list)
-        else []
-    )
-    claimed_agents = {
-        claimed_by
-        for item in source_items
-        if isinstance(item, dict)
-        and item.get("done") is not True
-        and str(item.get("status") or "open").strip().lower() == "open"
-        and str(item.get("task_class") or "") == "advancement_task"
-        for claimed_by in [normalize_todo_claimed_by(item.get("claimed_by"))]
-        if claimed_by in registered_agents
-    }
-    return len(claimed_agents) >= 2
+    return None
 
 
 def _registered_peer_task_orchestration_contract(
@@ -283,7 +279,8 @@ def _registered_peer_task_orchestration_contract(
     agent_id: str,
     agent_identity: dict[str, Any],
     raw_agent_todo_summary: dict[str, Any] | None,
-    max_peers: int,
+    available_capabilities: list[str],
+    agent_management_projection: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
     source_items = (
         raw_agent_todo_summary.get("items")
@@ -307,6 +304,7 @@ def _registered_peer_task_orchestration_contract(
             not peer_agent
             or peer_agent in seen_agents
             or peer_agent not in registered_agents
+            or peer_agent == agent_id
         ):
             continue
         candidate_lanes.append(
@@ -317,12 +315,13 @@ def _registered_peer_task_orchestration_contract(
                 "task_class": item.get("task_class"),
                 "action_kind": item.get("action_kind"),
                 "title": str(item.get("title") or item.get("text") or "").strip(),
+                "resume_when": item.get("resume_when"),
+                "resume_ready": item.get("resume_ready"),
             }
         )
         seen_agents.add(peer_agent)
     if not candidate_lanes:
         return None
-    candidate_agents = [lane["agent_id"] for lane in candidate_lanes]
     assignment_key = peer_work_key(
         {
             "mode": "task_scoped_peer",
@@ -336,32 +335,67 @@ def _registered_peer_task_orchestration_contract(
         },
         fallback="task_orchestration",
     )
-    coordinator = select_peer_for_work(
-        candidate_agents,
-        work_key=assignment_key,
-    )
-    if not coordinator or agent_id != coordinator:
-        return None
-    peer_lanes = [lane for lane in candidate_lanes if lane["agent_id"] != coordinator][
-        :max_peers
-    ]
-    if not peer_lanes:
-        return None
+    activation_available = PEER_AGENT_ACTIVATION_CAPABILITY in available_capabilities
+    peer_runtime_state = _peer_runtime_state_by_agent(agent_management_projection)
+    eligible_peer_lanes: list[dict[str, Any]] = []
+    blocked_peer_lanes: list[dict[str, Any]] = []
+    for lane in candidate_lanes:
+        reason_codes: list[str] = []
+        if not activation_available:
+            reason_codes.append("peer_agent_activation_unavailable")
+        peer_state = peer_runtime_state.get(str(lane["agent_id"]))
+        if not peer_state:
+            reason_codes.append("peer_liveness_unavailable")
+        elif peer_state.get("stale_claim_hint"):
+            reason_codes.append("peer_runtime_stale")
+        elif peer_state.get("state") not in {"running", "monitoring"}:
+            reason_codes.append("peer_runtime_not_active")
+        if lane.get("resume_when") and lane.get("resume_ready") is not True:
+            reason_codes.append("peer_lane_not_resume_ready")
+        if reason_codes:
+            blocked_peer_lanes.append({**lane, "reason_codes": reason_codes})
+        else:
+            eligible_peer_lanes.append(lane)
+    execution_state = "ready" if eligible_peer_lanes else "blocked"
     return {
         "schema_version": "task_orchestration_contract_v1",
         "mode": "task_scoped_peer",
-        "coordinator_agent_id": coordinator,
+        "coordinator_agent_id": agent_id,
         "assignment_key": assignment_key,
-        "activation_required": True,
-        "activation_allowed": True,
-        "max_peer_lanes": max_peers,
-        "eligible_peer_lanes": peer_lanes,
-        "blocked_peer_lanes": [],
+        "execution_state": execution_state,
+        "activation_required": bool(eligible_peer_lanes),
+        "activation_allowed": activation_available,
+        "required_capability": PEER_AGENT_ACTIVATION_CAPABILITY,
+        "eligible_peer_lanes": eligible_peer_lanes,
+        "blocked_peer_lanes": blocked_peer_lanes,
+        "retry_policy": "material_peer_state_change_only",
+        "terminal_outcome": "blocked" if execution_state == "blocked" else None,
         "writeback_owner": "task_coordinator",
         "coordinator_obligation": (
             "activate or resume eligible peer lanes, review returned evidence, "
             "then write accepted state/todos for this task bundle"
+            if eligible_peer_lanes
+            else "peer task bundle is blocked; do not retry until peer activation "
+            "capability or peer readiness changes"
         ),
+    }
+
+
+def _peer_runtime_state_by_agent(
+    projection: dict[str, Any] | None,
+) -> dict[str, dict[str, Any]]:
+    agents = (
+        projection.get("agents")
+        if isinstance(projection, dict)
+        and isinstance(projection.get("agents"), list)
+        else []
+    )
+    return {
+        agent_id: item
+        for item in agents
+        if isinstance(item, dict)
+        for agent_id in [normalize_todo_claimed_by(item.get("agent_id"))]
+        if agent_id
     }
 
 

--- a/loopx/control_plane/scheduler/arbitration.py
+++ b/loopx/control_plane/scheduler/arbitration.py
@@ -13,6 +13,7 @@ SCHEDULER_ARBITRATION_SCHEMA_VERSION = "scheduler_arbitration_v0"
 
 class SchedulerDisposition(str, Enum):
     TERMINAL_STOP = "terminal_stop"
+    PEER_COORDINATION_STOP = "peer_coordination_stop"
     AGENT_MONITOR_ONLY_WAIT = "agent_monitor_only_wait"
     ACTIVE_WORK = "active_work"
     AGENT_SCOPE_WAIT = "agent_scope_wait"
@@ -78,6 +79,8 @@ def _classify_disposition(
     agent_scope_modes = {str(value) for value in agent_scope_frontier_actions}
     if mode == "terminal_no_followup":
         return SchedulerDisposition.TERMINAL_STOP, mode
+    if mode == "peer_coordination_blocked":
+        return SchedulerDisposition.PEER_COORDINATION_STOP, mode
     if mode == "agent_monitor_only":
         return SchedulerDisposition.AGENT_MONITOR_ONLY_WAIT, mode
     if user_required and not must_attempt:
@@ -155,7 +158,11 @@ def build_scheduler_arbitration(
         errors.append("interaction_contract.delivery_without_attempt")
     if quiet_noop_allowed and (must_attempt or delivery_allowed or user_required):
         errors.append("interaction_contract.quiet_noop_conflicts_with_required_action")
-    if mode in {"terminal_no_followup", "agent_monitor_only"} and (
+    if mode in {
+        "terminal_no_followup",
+        "peer_coordination_blocked",
+        "agent_monitor_only",
+    } and (
         user_required or must_attempt or delivery_allowed or not quiet_noop_allowed
     ):
         errors.append("interaction_contract.terminal_conflicts_with_open_action")

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -148,6 +148,57 @@ def _scheduler_identity_keys(
     )
 
 
+def _build_scheduler_stop_hint(
+    *,
+    execution_context: SchedulerExecutionContextResolution,
+    action: str,
+    cadence_class: str,
+    reason_code: str,
+    reason: str,
+    spend_policy: str,
+    resume_trigger: str,
+    ssh_goal_runtime_action: str,
+    unchanged_spend_policy: str,
+) -> dict[str, Any]:
+    return apply_scheduler_execution_context(
+        {
+            "schema_version": SCHEDULER_HINT_SCHEMA_VERSION,
+            "source": "quota.should-run",
+            "action": action,
+            "cadence_class": cadence_class,
+            "reason_code": reason_code,
+            "reason": reason,
+            "spend_policy": spend_policy,
+            "codex_app": {
+                "apply": "pause_or_delete_current_heartbeat_if_possible",
+                "host_tool": "automation_update",
+                "host_action": "pause_or_delete_current_heartbeat",
+                "host_action_required": True,
+                "attempt_limit": 1,
+                "verify_host_result": True,
+                "ack_required": False,
+                "resume_trigger": resume_trigger,
+                "no_spend_for_host_action": True,
+            },
+            "unchanged_poll": {
+                "local_scheduler": "stop",
+                "codex_cli_tui": "exit",
+                CODEX_APP_SSH_GOAL_RUNTIME_KEY: ssh_goal_runtime_action,
+                "claude_code_loop": "stop",
+                "final_quota_replan_check_enabled": False,
+                "spend_policy": unchanged_spend_policy,
+            },
+            "unchanged_identity_keys": list(
+                _scheduler_identity_keys(
+                    cadence_class=cadence_class,
+                    execution_context=execution_context,
+                )
+            ),
+        },
+        execution_context,
+    )
+
+
 def _scheduler_progression_interval_elapsed(
     scheduler_state: Mapping[str, Any],
     *,
@@ -1016,45 +1067,43 @@ def build_scheduler_hint(
     )
 
     if arbitration.disposition == SchedulerDisposition.TERMINAL_STOP:
-        return apply_scheduler_execution_context(
-            {
-                "schema_version": SCHEDULER_HINT_SCHEMA_VERSION,
-                "source": "quota.should-run",
-                "action": "stop_until_explicit_resume",
-                "cadence_class": "terminal_no_followup",
-                "reason_code": arbitration.reason_code,
-                "reason": (
-                    "validated closure evidence derives no-follow-up and confirms no "
-                    "remaining frontier; recurring polling must stop until resume"
-                ),
-                "spend_policy": "no quota spend for terminal automation shutdown",
-                "codex_app": {
-                    "apply": "pause_or_delete_current_heartbeat_if_possible",
-                    "host_tool": "automation_update",
-                    "host_action": "pause_or_delete_current_heartbeat",
-                    "host_action_required": True,
-                    "attempt_limit": 1,
-                    "verify_host_result": True,
-                    "ack_required": False,
-                    "resume_trigger": "explicit goal resume or newly projected work",
-                    "no_spend_for_host_action": True,
-                },
-                "unchanged_poll": {
-                    "local_scheduler": "stop",
-                    "codex_cli_tui": "exit",
-                    CODEX_APP_SSH_GOAL_RUNTIME_KEY: "complete_host_goal",
-                    "claude_code_loop": "stop",
-                    "final_quota_replan_check_enabled": False,
-                    "spend_policy": "no quota spend for terminal loop stop",
-                },
-                "unchanged_identity_keys": list(
-                    _scheduler_identity_keys(
-                        cadence_class="terminal_no_followup",
-                        execution_context=execution_context,
-                    )
-                ),
-            },
-            execution_context,
+        return _build_scheduler_stop_hint(
+            execution_context=execution_context,
+            action="stop_until_explicit_resume",
+            cadence_class="terminal_no_followup",
+            reason_code=arbitration.reason_code,
+            reason=(
+                "validated closure evidence derives no-follow-up and confirms no "
+                "remaining frontier; recurring polling must stop until resume"
+            ),
+            spend_policy="no quota spend for terminal automation shutdown",
+            resume_trigger="explicit goal resume or newly projected work",
+            ssh_goal_runtime_action="complete_host_goal",
+            unchanged_spend_policy="no quota spend for terminal loop stop",
+        )
+
+    if arbitration.disposition == SchedulerDisposition.PEER_COORDINATION_STOP:
+        cadence_class = "peer_coordination_blocked"
+        return _build_scheduler_stop_hint(
+            execution_context=execution_context,
+            action="return_to_owner_until_material_change",
+            cadence_class=cadence_class,
+            reason_code=arbitration.reason_code,
+            reason=(
+                "explicit peer coordination has no executable peer lane or local "
+                "fallback; recurring polling must stop until its inputs change"
+            ),
+            spend_policy=(
+                "no quota spend while explicit peer coordination is blocked"
+            ),
+            resume_trigger=(
+                "peer activation capability, peer runtime readiness, coordinator "
+                "configuration, or newly projected local work"
+            ),
+            ssh_goal_runtime_action="return_to_owner",
+            unchanged_spend_policy=(
+                "no quota spend for blocked coordination stop"
+            ),
         )
 
     builder = _SchedulerHintBuilder(

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -438,6 +438,8 @@ def _interaction_mode(payload: dict[str, Any]) -> str:
         return "monitor_due"
     if effective_action == "terminal_no_followup" or state == "terminal_no_followup":
         return "terminal_no_followup"
+    if effective_action == "peer_coordination_blocked":
+        return effective_action
     if payload.get("scoped_user_gate_fallback"):
         return "scoped_user_gate_fallback"
     if _user_gate_notification_suppressed(payload):
@@ -1068,6 +1070,7 @@ def _interaction_quiet_noop_allowed(
         "blocked_wait",
         "user_gate_cooldown_wait",
         "terminal_no_followup",
+        "peer_coordination_blocked",
         "agent_monitor_only",
         "skip",
     }

--- a/loopx/orchestration.py
+++ b/loopx/orchestration.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import re
 from typing import Any
-
 
 DEFAULT_ORCHESTRATION_MODE = "default"
 MULTI_SUBAGENT_ORCHESTRATION_MODE = "multi_subagent"
@@ -81,6 +81,32 @@ def compact_orchestration_policy(spawn_policy: Any) -> dict[str, Any]:
     if isinstance(policy.get("explore_harness"), dict):
         compact["explore_harness"] = compact_explore_harness_policy(policy.get("explore_harness"))
     return compact
+
+
+def compact_peer_task_coordination_policy(coordination: Any) -> dict[str, Any] | None:
+    """Normalize the explicit registered-peer task coordinator selection.
+
+    Registered peer identity is not coordination authority.  The policy is
+    therefore fail-closed: only a non-empty ``coordinator_agent_id`` opts a
+    goal into peer task coordination.  Runtime capability admission remains a
+    separate, per-turn decision.
+    """
+
+    policy = coordination if isinstance(coordination, dict) else {}
+    peer_policy = (
+        policy.get("peer_task_coordination")
+        if isinstance(policy.get("peer_task_coordination"), dict)
+        else {}
+    )
+    coordinator_agent_id = str(
+        peer_policy.get("coordinator_agent_id") or ""
+    ).strip()
+    if not re.fullmatch(r"[a-z][a-z0-9_.:@-]{0,79}", coordinator_agent_id):
+        return None
+    return {
+        "enabled": True,
+        "coordinator_agent_id": coordinator_agent_id,
+    }
 
 
 def orchestration_policy_summary(policy: dict[str, Any] | None) -> str:

--- a/loopx/orchestration.py
+++ b/loopx/orchestration.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import re
 from typing import Any
+
+from .agent_registry import normalize_registered_agents
 
 DEFAULT_ORCHESTRATION_MODE = "default"
 MULTI_SUBAGENT_ORCHESTRATION_MODE = "multi_subagent"
@@ -98,14 +99,14 @@ def compact_peer_task_coordination_policy(coordination: Any) -> dict[str, Any] |
         if isinstance(policy.get("peer_task_coordination"), dict)
         else {}
     )
-    coordinator_agent_id = str(
-        peer_policy.get("coordinator_agent_id") or ""
-    ).strip()
-    if not re.fullmatch(r"[a-z][a-z0-9_.:@-]{0,79}", coordinator_agent_id):
+    coordinator_agent_ids = normalize_registered_agents(
+        [peer_policy.get("coordinator_agent_id")]
+    )
+    if not coordinator_agent_ids:
         return None
     return {
         "enabled": True,
-        "coordinator_agent_id": coordinator_agent_id,
+        "coordinator_agent_id": coordinator_agent_ids[0],
     }
 
 

--- a/loopx/status_server.py
+++ b/loopx/status_server.py
@@ -65,6 +65,8 @@ CONFIGURE_GOAL_REQUEST_FIELDS = {
     "clear_allowed_domains",
     "registered_agents",
     "clear_registered_agents",
+    "peer_task_coordinator",
+    "clear_peer_task_coordinator",
     "agent_profiles",
     "clear_agent_profiles",
     "agent_work_modes",
@@ -432,6 +434,10 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
             "clear_allowed_domains": bool(body.get("clear_allowed_domains", False)),
             "registered_agents": [str(item) for item in registered_agents] if registered_agents is not None else None,
             "clear_registered_agents": bool(body.get("clear_registered_agents", False)),
+            "peer_task_coordinator": body.get("peer_task_coordinator"),
+            "clear_peer_task_coordinator": bool(
+                body.get("clear_peer_task_coordinator", False)
+            ),
             "agent_profiles": agent_profiles,
             "clear_agent_profiles": (
                 [str(item) for item in clear_agent_profiles]
@@ -492,6 +498,10 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
             clear_allowed_domains=values["clear_allowed_domains"],
             registered_agents=values["registered_agents"],
             clear_registered_agents=values["clear_registered_agents"],
+            peer_task_coordinator=values["peer_task_coordinator"],
+            clear_peer_task_coordinator=values[
+                "clear_peer_task_coordinator"
+            ],
             agent_profiles=values["agent_profiles"],
             clear_agent_profiles=values["clear_agent_profiles"],
             agent_work_modes=values["agent_work_modes"],

--- a/tests/control_plane/test_goal_boundary_resolution.py
+++ b/tests/control_plane/test_goal_boundary_resolution.py
@@ -53,6 +53,37 @@ def test_goal_boundary_uses_registry_goal_for_scope_and_capability_projection() 
     ]
     assert boundary["requires_parent_approval"] == ["write", "publish"]
     assert boundary["guards"] == ["stay public"]
+    assert "peer_task_coordination" not in boundary
+
+
+def test_goal_boundary_projects_only_explicit_valid_peer_coordinator() -> None:
+    boundary = goal_boundary(
+        {
+            "coordination": {
+                "registered_agents": ["codex-alpha", "codex-beta"],
+                "peer_task_coordination": {
+                    "coordinator_agent_id": "codex-alpha",
+                },
+            },
+        }
+    )
+
+    assert boundary is not None
+    assert boundary["peer_task_coordination"] == {
+        "enabled": True,
+        "coordinator_agent_id": "codex-alpha",
+    }
+
+    invalid = goal_boundary(
+        {
+            "coordination": {
+                "peer_task_coordination": {
+                    "coordinator_agent_id": "../../private",
+                },
+            },
+        }
+    )
+    assert invalid is None
 
 
 def test_goal_boundary_projects_credential_free_repository_identity(

--- a/tests/control_plane/test_scheduler_interaction_arbitration.py
+++ b/tests/control_plane/test_scheduler_interaction_arbitration.py
@@ -159,6 +159,19 @@ def _payload(
             SchedulerDisposition.TERMINAL_STOP,
             "terminal_no_followup",
         ),
+        (
+            "peer-coordination-blocked",
+            _payload(
+                mode="peer_coordination_blocked",
+                should_run=False,
+                user_required=False,
+                must_attempt=False,
+                delivery_allowed=False,
+                quiet_noop_allowed=True,
+            ),
+            SchedulerDisposition.PEER_COORDINATION_STOP,
+            "peer_coordination_blocked",
+        ),
     ],
 )
 def test_interaction_contract_drives_scheduler(
@@ -309,6 +322,30 @@ def test_terminal_contract_with_open_action_fails_closed() -> None:
         "interaction_contract.terminal_conflicts_with_open_action"
         in hint["consistency_error"]["errors"]
     )
+
+
+def test_blocked_peer_coordination_returns_to_owner_without_polling() -> None:
+    payload = _payload(
+        mode="peer_coordination_blocked",
+        should_run=False,
+        user_required=False,
+        must_attempt=False,
+        delivery_allowed=False,
+        quiet_noop_allowed=True,
+    )
+
+    hint = _app_scheduler_hint(
+        payload,
+        agent_scope_frontier_actions=AGENT_SCOPE_ACTIONS,
+    )
+
+    assert hint["action"] == "return_to_owner_until_material_change"
+    assert hint["codex_app"]["host_action"] == (
+        "pause_or_delete_current_heartbeat"
+    )
+    assert hint["codex_app"]["host_action_required"] is True
+    assert hint["unchanged_poll"]["local_scheduler"] == "stop"
+    assert hint["unchanged_poll"]["final_quota_replan_check_enabled"] is False
 
 
 def test_structurally_invalid_contract_fails_closed() -> None:

--- a/tests/control_plane/test_task_orchestration_admission.py
+++ b/tests/control_plane/test_task_orchestration_admission.py
@@ -10,6 +10,20 @@ from loopx.control_plane.quota.task_orchestration import (
 AGENT_ID = "codex-main"
 
 
+def _peer_management(*agent_ids: str) -> dict[str, Any]:
+    return {
+        "schema_version": "agent_management_projection_v0",
+        "agents": [
+            {
+                "agent_id": agent_id,
+                "state": "running",
+                "last_activity_at": "2026-08-14T12:00:00Z",
+            }
+            for agent_id in agent_ids
+        ],
+    }
+
+
 def _todo(
     todo_id: str,
     *,
@@ -415,7 +429,7 @@ def test_admission_reports_ready_lanes_deferred_by_capacity() -> None:
     ]
 
 
-def test_explicit_registered_peer_bundle_precedes_ephemeral_host_capacity() -> None:
+def test_registered_peer_bundle_does_not_auto_elect_coordinator() -> None:
     peers = [AGENT_ID, "codex-peer-one", "codex-peer-two"]
     items = [
         {
@@ -425,7 +439,6 @@ def test_explicit_registered_peer_bundle_precedes_ephemeral_host_capacity() -> N
         for index, peer in enumerate(peers, start=1)
     ]
     summary = {"items": items}
-    contracts = []
     for agent_id in peers:
         contract, _work_lane = apply_task_orchestration_contract(
             fallback_work_lane_contract={"lane": "advancement_task"},
@@ -443,14 +456,131 @@ def test_explicit_registered_peer_bundle_precedes_ephemeral_host_capacity() -> N
             },
             agent_todo_summary=summary,
             raw_agent_todo_summary=summary,
-            available_capabilities=[],
+            available_capabilities=["subagent_spawn"],
         )
-        if contract:
-            contracts.append(contract)
+        assert contract is None
 
-    assert len(contracts) == 1
-    assert contracts[0]["schema_version"] == "task_orchestration_contract_v1"
-    assert contracts[0]["mode"] == "task_scoped_peer"
+
+def test_explicit_registered_peer_coordinator_requires_runtime_activation() -> None:
+    peers = [AGENT_ID, "codex-peer-one", "codex-peer-two"]
+    summary = {
+        "items": [
+            {**_todo("todo_primary"), "claimed_by": AGENT_ID},
+            {**_todo("todo_peer_one"), "claimed_by": "codex-peer-one"},
+            {**_todo("todo_peer_two"), "claimed_by": "codex-peer-two"},
+        ]
+    }
+
+    contract, work_lane = apply_task_orchestration_contract(
+        fallback_work_lane_contract={"lane": "advancement_task"},
+        goal_boundary={
+            "peer_task_coordination": {
+                "enabled": True,
+                "coordinator_agent_id": AGENT_ID,
+            },
+        },
+        agent_identity={
+            "agent_id": AGENT_ID,
+            "registered_agents": peers,
+        },
+        agent_todo_summary=summary,
+        raw_agent_todo_summary=summary,
+        available_capabilities=[],
+        agent_management_projection=_peer_management(
+            "codex-peer-one",
+            "codex-peer-two",
+        ),
+    )
+
+    assert contract is not None
+    assert contract["execution_state"] == "blocked"
+    assert contract["eligible_peer_lanes"] == []
+    assert [lane["reason_codes"] for lane in contract["blocked_peer_lanes"]] == [
+        ["peer_agent_activation_unavailable"],
+        ["peer_agent_activation_unavailable"],
+    ]
+    assert contract["terminal_outcome"] == "blocked"
+    assert contract["retry_policy"] == "material_peer_state_change_only"
+    assert work_lane == {"lane": "advancement_task"}
+
+
+def test_explicit_registered_peer_coordinator_projects_only_actionable_lanes() -> None:
+    peers = [AGENT_ID, "codex-peer-one", "codex-peer-two"]
+    summary = {
+        "items": [
+            {**_todo("todo_primary"), "claimed_by": AGENT_ID},
+            {**_todo("todo_peer_one"), "claimed_by": "codex-peer-one"},
+            {
+                **_todo("todo_peer_two", resume_ready=False),
+                "claimed_by": "codex-peer-two",
+            },
+        ]
+    }
+
+    contract, work_lane = apply_task_orchestration_contract(
+        fallback_work_lane_contract={"lane": "advancement_task"},
+        goal_boundary={
+            "peer_task_coordination": {
+                "enabled": True,
+                "coordinator_agent_id": AGENT_ID,
+            },
+        },
+        agent_identity={
+            "agent_id": AGENT_ID,
+            "registered_agents": peers,
+        },
+        agent_todo_summary=summary,
+        raw_agent_todo_summary=summary,
+        available_capabilities=["peer_agent_activation"],
+        agent_management_projection=_peer_management(
+            "codex-peer-one",
+            "codex-peer-two",
+        ),
+    )
+
+    assert contract is not None
+    assert contract["execution_state"] == "ready"
+    assert [lane["todo_id"] for lane in contract["eligible_peer_lanes"]] == [
+        "todo_peer_one"
+    ]
+    assert contract["blocked_peer_lanes"][0]["reason_codes"] == [
+        "peer_lane_not_resume_ready"
+    ]
+    assert work_lane["lane"] == "task_orchestration"
+
+
+def test_explicit_registered_peer_coordinator_blocks_unknown_peer_liveness() -> None:
+    peers = [AGENT_ID, "codex-peer-one"]
+    summary = {
+        "items": [
+            {**_todo("todo_primary"), "claimed_by": AGENT_ID},
+            {**_todo("todo_peer_one"), "claimed_by": "codex-peer-one"},
+        ]
+    }
+
+    contract, work_lane = apply_task_orchestration_contract(
+        fallback_work_lane_contract={"lane": "advancement_task"},
+        goal_boundary={
+            "peer_task_coordination": {
+                "enabled": True,
+                "coordinator_agent_id": AGENT_ID,
+            },
+        },
+        agent_identity={
+            "agent_id": AGENT_ID,
+            "registered_agents": peers,
+        },
+        agent_todo_summary=summary,
+        raw_agent_todo_summary=summary,
+        available_capabilities=["peer_agent_activation"],
+    )
+
+    assert contract is not None
+    assert contract["execution_state"] == "blocked"
+    assert contract["blocked_peer_lanes"][0]["reason_codes"] == [
+        "peer_liveness_unavailable"
+    ]
+    assert work_lane == {"lane": "advancement_task"}
 
 
 def test_claimed_primary_agent_coordinates_unclaimed_child_work() -> None:


### PR DESCRIPTION
## Summary

- keep registered peers independent by default; `multi_subagent` only authorizes ephemeral child workers
- add explicit `--peer-task-coordinator` configuration and require observed `peer_agent_activation` plus live/resumable peer state
- preserve the coordinator's own runnable Todo when peer coordination is blocked
- terminate a blocked peer-only loop with `peer_coordination_blocked` and return control until a material coordination input changes

Closes #3178.

## Validation

- control-plane regression: 1108 cases passed; the sole maintainability-budget failure was fixed without raising the budget, then the gate reran successfully
- focused pytest: 218 passed
- `examples/control_plane/task-orchestration-smoke.py`
- `examples/project/configure-goal-smoke.py`
- repository-configured strict mypy profile: 16 source files passed
- premerge canary: 18/18 passed, including public-boundary scan
- change-quality receipt: `cqr_f585f3bb12cc941f803e`

## Notes

- two consecutive blocked heartbeat packets retain the same assignment identity and both emit a host stop/return-to-owner action; they do not recreate a runnable coordination obligation
- the repository-wide Ruff scan still reports the pre-existing baseline; this PR adds no changed-surface syntax/F-level finding
- no private state, local paths, benchmark traces, credentials, or raw evidence are included
