### PR TITLE
fix(smoke): drop stale status replan-obligation shim reference

### DIFF
--- a/examples/control_plane/event-sourced-status-read-path-smoke.py
+++ b/examples/control_plane/event-sourced-status-read-path-smoke.py
@@ -104,7 +104,6 @@ def direct_active_state_todo_fields(goal: dict, *, runtime_root: Path | None = N
         parse_issue_meta_surface=status_module.parse_issue_meta_surface,
         backlog_hygiene_warning=status_module.backlog_hygiene_warning,
         completed_todo_archive_warning=status_module.completed_todo_archive_warning,
-        autonomous_replan_obligation=status_module.autonomous_replan_obligation,
         state_projection_gap_warning=status_module.state_projection_gap_warning,
     )
 


### PR DESCRIPTION
## Summary

Fixes the main@9908ef67 `Full Public Smokes` failure in `event-sourced-status-read-path-smoke.py`:

- #3161 (`7f67d51c6`) removed `loopx.status.autonomous_replan_obligation` in favor of `build_autonomous_replan_obligation`, but the smoke's `direct_active_state_todo_fields` still passed the removed attribute as a keyword.
- The read model (`loopx/control_plane/todos/active_state_todos.py`) no longer accepts that parameter, so the smoke raised `AttributeError: module 'loopx.status' has no attribute 'autonomous_replan_obligation'`.

## Change

- Remove the stale `autonomous_replan_obligation=status_module.autonomous_replan_obligation` keyword from `examples/control_plane/event-sourced-status-read-path-smoke.py`.

## Validation

- `python3 examples/control_plane/event-sourced-status-read-path-smoke.py` → `event-sourced-status-read-path-smoke ok`
- `python3 -m py_compile examples/control_plane/event-sourced-status-read-path-smoke.py`
- `git diff --check` clean
- Focused pytest `tests/control_plane/test_progress_observation.py tests/control_plane/test_replan_host_context_projection.py` → 9 passed