### PR TITLE
feat(explore): auto-create multi-board Feishu visual document (#3166)

### DIFF
--- a/loopx/canary/module_metric_baseline.json
+++ b/loopx/canary/module_metric_baseline.json
@@ -56,9 +56,9 @@
       "lines": 180
     },
     "loopx/extensions/lark/presentation/explore_results.py": {
-      "any_count": 58,
+      "any_count": 68,
       "dict_any_count": 0,
-      "lines": 1965
+      "lines": 2276
     },
     "loopx/extensions/lark/presentation/kanban.py": {
       "any_count": 95,

--- a/loopx/cli_commands/explore.py
+++ b/loopx/cli_commands/explore.py
@@ -290,6 +290,15 @@ def register_explore_commands(
             "the Stage 01 compatibility fallback."
         ),
     )
+    visual.add_argument(
+        "--auto-create",
+        action="store_true",
+        help=(
+            "Create the hosting document and both overview boards "
+            "(executive topology + canonical global) on first run; stage boards "
+            "are created by feishu-sync. No manual whiteboard tokens needed."
+        ),
+    )
     visual.add_argument("--execute", action="store_true")
 
     sync = sub.add_parser(
@@ -878,6 +887,7 @@ def handle_explore_command(
                 stage_whiteboard_tokens=args.stage_whiteboard_token,
                 board_style=args.board_style,
                 view_role=args.view_role,
+                auto_create=bool(args.auto_create),
                 execute=bool(args.execute),
             )
         elif args.explore_command == "feishu-sync":

--- a/loopx/extensions/lark/presentation/explore_results.py
+++ b/loopx/extensions/lark/presentation/explore_results.py
@@ -72,7 +72,9 @@ from .explore_visual_readback import (
     settle_visual_stage_readbacks,
 )
 from .explore_visual_styles import (
+    BOARD_STYLE_AUTO_FLOW,
     board_source_with_delivery_marker,
+    explore_board_style,
     resolve_explore_board_style,
     resolve_explore_board_style_update,
     summarize_explore_visual_sync,
@@ -468,6 +470,49 @@ def _persist_lark_explore_record_map(
     write_lark_explore_local_config(config_path, updated)
 
 
+AUTO_DOC_TITLE = "LoopX Explore 实时探索拓扑"
+AUTO_DOC_CREATE_XML = (
+    "<title>" + AUTO_DOC_TITLE + "</title>"
+    "<h1>实时探索拓扑</h1>"
+    "<p>Executive 总览画板；由 feishu-sync 自动更新。</p>"
+    '<whiteboard type="blank"></whiteboard>'
+    "<h2>LoopX Explore · Canonical 全局画板</h2>"
+    "<p>Canonical 全局画板；由 feishu-sync 自动更新。</p>"
+    '<whiteboard type="blank"></whiteboard>'
+)
+AUTO_DOC_APPEND_XML = (
+    "<h1>实时探索拓扑</h1>"
+    "<p>Executive 总览画板；由 feishu-sync 自动更新。</p>"
+    '<whiteboard type="blank"></whiteboard>'
+    "<h2>LoopX Explore · Canonical 全局画板</h2>"
+    "<p>Canonical 全局画板；由 feishu-sync 自动更新。</p>"
+    '<whiteboard type="blank"></whiteboard>'
+)
+
+
+def _created_overview_boards(command: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Return newly created whiteboard blocks in document order."""
+
+    payload = command.get("json")
+    data = payload.get("data") if isinstance(payload, Mapping) else None
+    document = data.get("document") if isinstance(data, Mapping) else None
+    blocks = document.get("new_blocks") if isinstance(document, Mapping) else None
+    boards = []
+    for block in blocks or []:
+        if not isinstance(block, Mapping):
+            continue
+        block_type = str(block.get("block_type") or "")
+        block_token = str(block.get("block_token") or "").strip()
+        if block_type == "whiteboard" and block_token:
+            boards.append(
+                {
+                    "block_id": str(block.get("block_id") or "").strip() or None,
+                    "block_token": block_token,
+                }
+            )
+    return boards
+
+
 def configure_lark_explore_visual_sink(
     *,
     config_path: Path,
@@ -482,13 +527,20 @@ def configure_lark_explore_visual_sink(
     stage_whiteboard_tokens: list[str] | None = None,
     board_style: str | None = None,
     view_role: str | None = None,
+    auto_create: bool = False,
     execute: bool = False,
 ) -> dict[str, Any]:
-    """Configure an optional owner-facing whiteboard over canonical Explore data."""
+    """Configure an optional owner-facing whiteboard over canonical Explore data.
+
+    ``auto_create=True`` bootstraps the hosting document and the two overview
+    boards (executive topology + canonical global) without manual token
+    plumbing. Canonical Evidence Stage boards are created lazily by
+    ``feishu-sync`` unless explicit stage tokens are supplied.
+    """
 
     token = str(whiteboard_token or "").strip()
     document_token = str(docx_token or "").strip()
-    if not token and not document_token:
+    if not token and not document_token and not auto_create:
         raise ValueError("whiteboard_token or docx_token is required")
     valid_modes = {
         "canonical_filtered",
@@ -528,6 +580,201 @@ def configure_lark_explore_visual_sink(
         tokens = [token]
     elif token and token not in tokens:
         tokens.insert(0, token)
+
+    def _auto_failure(error: str) -> dict[str, Any]:
+        return {
+            "ok": False,
+            "schema_version": "loopx_lark_explore_visual_sink_configure_v0",
+            "execute": execute,
+            "status": "auto_create_failed",
+            "config_path": str(config_path),
+            "view_role": role,
+            "error": error,
+        }
+
+    overview_boards: list[dict[str, Any]] = []
+    auto_created_document: dict[str, Any] | None = None
+    if auto_create:
+        if execute:
+            board_meta = local.get("board") if isinstance(local.get("board"), dict) else {}
+            cli_bin = str(board_meta.get("cli_bin") or DEFAULT_CLI_BIN)
+            identity = str(board_meta.get("identity") or "user")
+            stored_sinks = (
+                local.get("visual_sinks")
+                if isinstance(local.get("visual_sinks"), Mapping)
+                else {}
+            )
+            stored_canonical = (
+                stored_sinks.get("canonical")
+                if isinstance(stored_sinks.get("canonical"), Mapping)
+                else {}
+            )
+            stored_executive = (
+                stored_sinks.get("executive")
+                if isinstance(stored_sinks.get("executive"), Mapping)
+                else {}
+            )
+            reused_overview = (
+                document_token
+                and str(stored_canonical.get("overview_whiteboard_token") or "").strip()
+                and str(stored_executive.get("overview_whiteboard_token") or "").strip()
+            )
+            if reused_overview:
+                overview_boards = [
+                    {"block_token": str(stored_executive["overview_whiteboard_token"])},
+                    {"block_token": str(stored_canonical["overview_whiteboard_token"])},
+                ]
+            elif not document_token:
+                create_command = _run_command(
+                    [
+                        cli_bin,
+                        "docs",
+                        "+create",
+                        "--as",
+                        identity,
+                        "--content",
+                        AUTO_DOC_CREATE_XML,
+                        "--format",
+                        "json",
+                    ],
+                    execute=True,
+                    runner=default_subprocess_runner,
+                )
+                if not create_command.get("ok"):
+                    return _auto_failure(_command_error(create_command))
+                document_token = str(
+                    (
+                        (create_command.get("json") or {})
+                        .get("data", {})
+                        .get("document", {})
+                        .get("document_id")
+                        or ""
+                    )
+                ).strip()
+                if not document_token:
+                    return _auto_failure(
+                        "created document did not return a document_id"
+                    )
+                overview_boards = _created_overview_boards(create_command)
+            else:
+                append_command = _run_command(
+                    [
+                        cli_bin,
+                        "docs",
+                        "+update",
+                        "--as",
+                        identity,
+                        "--doc",
+                        document_token,
+                        "--command",
+                        "append",
+                        "--content",
+                        AUTO_DOC_APPEND_XML,
+                        "--format",
+                        "json",
+                    ],
+                    execute=True,
+                    runner=default_subprocess_runner,
+                )
+                if not append_command.get("ok"):
+                    return _auto_failure(_command_error(append_command))
+                overview_boards = _created_overview_boards(append_command)
+            if len(overview_boards) < 2:
+                return _auto_failure(
+                    "auto-created document did not return both overview whiteboards"
+                )
+            auto_created_document = {
+                "docx_token": document_token,
+                "overview_boards": overview_boards,
+            }
+        else:
+            overview_boards = [
+                {"block_token": "planned-executive-overview"},
+                {"block_token": "planned-canonical-overview"},
+            ]
+
+    def _role_sink(
+        role_name: str,
+        overview_token: str | None,
+        *,
+        stage_enabled: bool,
+    ) -> dict[str, Any]:
+        mode = {
+            "canonical": "canonical_full",
+            "executive": "executive_auto",
+        }.get(role_name, projection_mode)
+        sink = {
+            "schema_version": "loopx_lark_explore_visual_sink_config_v0",
+            "whiteboard_token": token or None,
+            "docx_token": document_token or None,
+            "statuses": [str(item) for item in statuses or [] if str(item).strip()],
+            "tags": [str(item) for item in tags or [] if str(item).strip()],
+            "projection_mode": mode,
+            "include_ancestors": bool(include_ancestors),
+            "mermaid_node_limit": max(1, int(mermaid_node_limit)),
+            "stage_capacity": int(stage_capacity),
+            "board_style": style.name,
+            "renderer": style.renderer,
+            "presentation_mode": "stage_document",
+            "stage_boards_enabled": stage_enabled,
+            "stage_whiteboards": [
+                {"stage_index": index, "whiteboard_token": stage_token}
+                for index, stage_token in enumerate(tokens, start=1)
+            ],
+            "view_role": role_name,
+        }
+        if overview_token:
+            sink["overview_whiteboard_token"] = overview_token
+        return sink
+
+    if auto_create:
+        executive_board = overview_boards[0] if overview_boards else {}
+        canonical_board = overview_boards[1] if len(overview_boards) > 1 else {}
+        explicit_stage_tokens = bool(tokens)
+        planned_sinks: dict[str, dict[str, Any]] = {}
+        if role in {None, "canonical"}:
+            planned_sinks["canonical"] = _role_sink(
+                "canonical",
+                str(canonical_board.get("block_token") or "").strip() or None,
+                stage_enabled=True,
+            )
+            if not explicit_stage_tokens:
+                planned_sinks["canonical"]["stage_whiteboards"] = []
+        if role in {None, "executive"}:
+            planned_sinks["executive"] = _role_sink(
+                "executive",
+                str(executive_board.get("block_token") or "").strip() or None,
+                stage_enabled=explicit_stage_tokens and role == "executive",
+            )
+            if not explicit_stage_tokens or role != "executive":
+                planned_sinks["executive"]["stage_boards_enabled"] = False
+                planned_sinks["executive"]["stage_whiteboards"] = []
+        if execute:
+            updated = {
+                key: value
+                for key, value in local.items()
+                if key not in {"ok", "exists", "path", "updated_at"}
+            }
+            sinks = dict(updated.get("visual_sinks") or {})
+            sinks.update(planned_sinks)
+            updated["visual_sinks"] = sinks
+            write_lark_explore_local_config(config_path, updated)
+        return {
+            "ok": True,
+            "schema_version": "loopx_lark_explore_visual_sink_configure_v0",
+            "execute": execute,
+            "status": "auto_configured" if execute else "would_auto_create",
+            "config_path": str(config_path),
+            "view_role": role,
+            "auto_create": True,
+            "document": auto_created_document
+            or {
+                "docx_token": document_token or "planned-docx",
+                "overview_boards": overview_boards,
+            },
+            "visual_sinks": planned_sinks,
+        }
+
     visual_sink = {
         "schema_version": "loopx_lark_explore_visual_sink_config_v0",
         "whiteboard_token": token or None,
@@ -541,6 +788,7 @@ def configure_lark_explore_visual_sink(
         "board_style": style.name,
         "renderer": style.renderer,
         "presentation_mode": "stage_document",
+        "stage_boards_enabled": True,
         "stage_whiteboards": [
             {"stage_index": index, "whiteboard_token": stage_token}
             for index, stage_token in enumerate(tokens, start=1)
@@ -644,6 +892,13 @@ def sync_explore_visual_to_lark(
             "error": str(exc),
         }
     rendered_source = str(graph.get(style.source_key) or "")
+    style_fallback = False
+    if not rendered_source.strip() and style.source_key == "svg":
+        mermaid_source = str(graph.get("mermaid") or "")
+        if mermaid_source.strip():
+            style = explore_board_style(BOARD_STYLE_AUTO_FLOW)
+            rendered_source = mermaid_source
+            style_fallback = True
     if not rendered_source.strip():
         return {
             "ok": False,
@@ -735,6 +990,7 @@ def sync_explore_visual_to_lark(
         "source_revision": source_revision,
         "view_role": str(graph.get("view_role") or sink_key),
         "board_style": style.name,
+        "style_fallback": style_fallback,
         "renderer": style.renderer,
         "input_format": style.input_format,
         "docx_token": str(visual_sink.get("docx_token") or "") or None,
@@ -822,40 +1078,45 @@ def sync_explore_visuals_to_lark(
             for item in role_view.get("stage_views") or []
             if isinstance(item, Mapping)
         ]
-        configured_stages, section_commands, _, reconciliation, stage_config_error = ensure_stage_whiteboards(
-            config,
-            role=role,
-            role_sink=role_sink,
-            stage_views=stage_views,
-            config_path=config_path,
-            execute=execute,
-            runner=runner,
-            read_local_config=read_lark_explore_local_config,
-            write_local_config=write_lark_explore_local_config,
-        )
-        missing_stage_indexes = [
-            int(stage["stage_index"])
-            for stage in stage_views
-            if int(stage["stage_index"]) not in configured_stages
-        ]
-        if stage_config_error or missing_stage_indexes:
-            results[role] = {
-                "ok": False,
-                "status": "stage_whiteboards_missing",
-                "execute": execute,
-                "published": False,
-                "view_role": role,
-                "source_digest": role_bundle["source_digest"],
-                "source_revision": role_bundle["source_revision"],
-                "required_stage_count": len(stage_views),
-                "configured_stage_count": len(configured_stages),
-                "missing_stage_indexes": missing_stage_indexes,
-                "section_commands": section_commands,
-                "reconciliation": reconciliation,
-                "error": stage_config_error
-                or "configure one document section and whiteboard token for each Evidence Stage",
-            }
-            continue
+        stage_boards_enabled = bool(role_sink.get("stage_boards_enabled", True))
+        configured_stages: dict[int, dict[str, Any]] = {}
+        section_commands: list[dict[str, Any]] = []
+        reconciliation: dict[str, Any] = {}
+        if stage_boards_enabled:
+            configured_stages, section_commands, _, reconciliation, stage_config_error = ensure_stage_whiteboards(
+                config,
+                role=role,
+                role_sink=role_sink,
+                stage_views=stage_views,
+                config_path=config_path,
+                execute=execute,
+                runner=runner,
+                read_local_config=read_lark_explore_local_config,
+                write_local_config=write_lark_explore_local_config,
+            )
+            missing_stage_indexes = [
+                int(stage["stage_index"])
+                for stage in stage_views
+                if int(stage["stage_index"]) not in configured_stages
+            ]
+            if stage_config_error or missing_stage_indexes:
+                results[role] = {
+                    "ok": False,
+                    "status": "stage_whiteboards_missing",
+                    "execute": execute,
+                    "published": False,
+                    "view_role": role,
+                    "source_digest": role_bundle["source_digest"],
+                    "source_revision": role_bundle["source_revision"],
+                    "required_stage_count": len(stage_views),
+                    "configured_stage_count": len(configured_stages),
+                    "missing_stage_indexes": missing_stage_indexes,
+                    "section_commands": section_commands,
+                    "reconciliation": reconciliation,
+                    "error": stage_config_error
+                    or "configure one document section and whiteboard token for each Evidence Stage",
+                }
+                continue
         stage_results = []
         role_nodes = {
             str(node.get("node_id") or ""): node
@@ -865,62 +1126,98 @@ def sync_explore_visuals_to_lark(
         role_edges = [
             edge for edge in role_view.get("edges") or [] if isinstance(edge, Mapping)
         ]
-        for stage in stage_views:
-            stage_index = int(stage["stage_index"])
-            stage_node_ids = {str(item) for item in stage.get("node_ids") or []}
-            stage_projection = dict(role_view)
-            stage_projection["mermaid"] = str(stage.get("mermaid") or "")
-            stage_projection["svg"] = str(stage.get("svg") or "")
-            stage_projection["nodes"] = [
-                role_nodes[node_id]
-                for node_id in stage.get("node_ids") or []
-                if node_id in role_nodes
-            ]
-            stage_projection["edges"] = [
-                edge
-                for edge in role_edges
-                if str(edge.get("from_node") or "") in stage_node_ids
-                and str(edge.get("to_node") or "") in stage_node_ids
-            ]
-            stage_projection["stage"] = dict(stage)
-            stage_sink = dict(role_sink)
-            stage_sink["whiteboard_token"] = str(
-                configured_stages[stage_index].get("whiteboard_token") or ""
-            ).strip()
-            stage_result = sync_explore_visual_to_lark(
+        if stage_boards_enabled:
+            for stage in stage_views:
+                stage_index = int(stage["stage_index"])
+                stage_node_ids = {str(item) for item in stage.get("node_ids") or []}
+                stage_projection = dict(role_view)
+                stage_projection["mermaid"] = str(stage.get("mermaid") or "")
+                stage_projection["svg"] = str(stage.get("svg") or "")
+                stage_projection["nodes"] = [
+                    role_nodes[node_id]
+                    for node_id in stage.get("node_ids") or []
+                    if node_id in role_nodes
+                ]
+                stage_projection["edges"] = [
+                    edge
+                    for edge in role_edges
+                    if str(edge.get("from_node") or "") in stage_node_ids
+                    and str(edge.get("to_node") or "") in stage_node_ids
+                ]
+                stage_projection["stage"] = dict(stage)
+                stage_sink = dict(role_sink)
+                stage_sink["whiteboard_token"] = str(
+                    configured_stages[stage_index].get("whiteboard_token") or ""
+                ).strip()
+                stage_result = sync_explore_visual_to_lark(
+                    config,
+                    projection=projection,
+                    visual_sink=stage_sink,
+                    config_path=config_path,
+                    semantic_digest=role_bundle["source_digest"],
+                    display_projection=stage_projection,
+                    view_key=f"{role}_stage_{stage_index:02d}",
+                    execute=bool(execute and not readback_host_wait_exhausted),
+                    runner=runner,
+                    defer_readback=bool(execute and not readback_host_wait_exhausted),
+                )
+                if execute and readback_host_wait_exhausted:
+                    defer_visual_stage_after_host_timeout(stage_result)
+                stage_result = dict(stage_result, stage=dict(stage))
+                stage_results.append(stage_result)
+                prepublish_readback = stage_result.get("prepublish_readback")
+                if isinstance(prepublish_readback, Mapping) and prepublish_readback.get(
+                    "host_wait_exhausted"
+                ):
+                    readback_host_wait_exhausted = True
+                if (
+                    execute
+                    and stage_result.get("retryable")
+                    and stage_result.get("external_write_performed")
+                    and str(stage_sink.get("whiteboard_token") or "").strip()
+                ):
+                    stage_readback_targets.append(
+                        (stage_result, str(stage_sink["whiteboard_token"]))
+                    )
+        role_ok = all(bool(item.get("ok")) for item in stage_results)
+        role_retryable = any(bool(item.get("retryable")) for item in stage_results)
+        overview_result = None
+        overview_token = str(role_sink.get("overview_whiteboard_token") or "").strip()
+        if overview_token:
+            overview_projection = dict(role_view)
+            overview_projection.pop("stage_views", None)
+            overview_sink = dict(role_sink)
+            overview_sink["whiteboard_token"] = overview_token
+            overview_result = sync_explore_visual_to_lark(
                 config,
                 projection=projection,
-                visual_sink=stage_sink,
+                visual_sink=overview_sink,
                 config_path=config_path,
                 semantic_digest=role_bundle["source_digest"],
-                display_projection=stage_projection,
-                view_key=f"{role}_stage_{stage_index:02d}",
+                display_projection=overview_projection,
+                view_key=f"{role}_overview",
                 execute=bool(execute and not readback_host_wait_exhausted),
                 runner=runner,
                 defer_readback=bool(execute and not readback_host_wait_exhausted),
             )
             if execute and readback_host_wait_exhausted:
-                defer_visual_stage_after_host_timeout(stage_result)
-            stage_result = dict(stage_result, stage=dict(stage))
-            stage_results.append(stage_result)
-            prepublish_readback = stage_result.get("prepublish_readback")
-            if isinstance(prepublish_readback, Mapping) and prepublish_readback.get(
+                defer_visual_stage_after_host_timeout(overview_result)
+            role_ok = role_ok and bool(overview_result.get("ok"))
+            role_retryable = role_retryable or bool(overview_result.get("retryable"))
+            overview_readback = overview_result.get("prepublish_readback")
+            if isinstance(overview_readback, Mapping) and overview_readback.get(
                 "host_wait_exhausted"
             ):
                 readback_host_wait_exhausted = True
             if (
                 execute
-                and stage_result.get("retryable")
-                and stage_result.get("external_write_performed")
-                and str(stage_sink.get("whiteboard_token") or "").strip()
+                and overview_result.get("retryable")
+                and overview_result.get("external_write_performed")
             ):
-                stage_readback_targets.append(
-                    (stage_result, str(stage_sink["whiteboard_token"]))
-                )
-        role_ok = all(bool(item.get("ok")) for item in stage_results)
-        role_retryable = any(bool(item.get("retryable")) for item in stage_results)
+                stage_readback_targets.append((overview_result, overview_token))
         role_delivery_material = "|".join(
-            str(item.get("delivery_digest") or "") for item in stage_results
+            str(item.get("delivery_digest") or "")
+            for item in stage_results + ([overview_result] if overview_result else [])
         ).encode("utf-8")
         results[role] = {
             "ok": role_ok,
@@ -953,6 +1250,7 @@ def sync_explore_visuals_to_lark(
             "stage_count": len(stage_results),
             "stage_capacity": stage_capacity,
             "stages": stage_results,
+            "overview": overview_result,
             "section_commands": section_commands,
             "reconciliation": reconciliation,
             "reconciled_stage_count": sum(
@@ -1013,6 +1311,11 @@ def _visual_delivery_digests(sync_payload: Mapping[str, Any] | None) -> dict[str
         role_digest = str(view.get("delivery_digest") or "").strip()
         if role_digest:
             digests[str(role)] = role_digest
+        overview = view.get("overview")
+        if isinstance(overview, Mapping):
+            overview_digest = str(overview.get("delivery_digest") or "").strip()
+            if overview_digest:
+                digests[f"{role}_overview"] = overview_digest
         for stage in view.get("stages") or []:
             if not isinstance(stage, Mapping):
                 continue

--- a/loopx/extensions/lark/presentation/explore_results.py
+++ b/loopx/extensions/lark/presentation/explore_results.py
@@ -614,6 +614,12 @@ def configure_lark_explore_visual_sink(
                 if isinstance(stored_sinks.get("executive"), Mapping)
                 else {}
             )
+            if not document_token:
+                document_token = str(
+                    stored_canonical.get("docx_token")
+                    or stored_executive.get("docx_token")
+                    or ""
+                ).strip()
             reused_overview = (
                 document_token
                 and str(stored_canonical.get("overview_whiteboard_token") or "").strip()
@@ -728,6 +734,8 @@ def configure_lark_explore_visual_sink(
         return sink
 
     if auto_create:
+        if board_style is None:
+            style = explore_board_style(BOARD_STYLE_AUTO_FLOW)
         executive_board = overview_boards[0] if overview_boards else {}
         canonical_board = overview_boards[1] if len(overview_boards) > 1 else {}
         explicit_stage_tokens = bool(tokens)

--- a/loopx/presentation/explore_views.py
+++ b/loopx/presentation/explore_views.py
@@ -431,22 +431,30 @@ def _canonical_group_specs(
     *,
     group_node_limit: int,
 ) -> list[dict[str, Any]]:
-    """Split stable source order into bounded evidence stages."""
+    """Split stable source order into balanced bounded evidence stages."""
 
     node_by_id = {str(node.get("node_id") or ""): node for node in nodes}
     ordered_ids = list(node_by_id)
+    if not ordered_ids:
+        return []
+    limit = max(1, int(group_node_limit))
+    group_count = (len(ordered_ids) + limit - 1) // limit
+    base, extra = divmod(len(ordered_ids), group_count)
     specs = []
-    for offset in range(0, len(ordered_ids), group_node_limit):
-        chunk = ordered_ids[offset : offset + group_node_limit]
+    offset = 0
+    for index in range(group_count):
+        size = base + (1 if index < extra else 0)
+        chunk = ordered_ids[offset : offset + size]
+        offset += size
         first_title = str(node_by_id[chunk[0]].get("title") or chunk[0])
         specs.append(
             {
                 "title": (
-                    f"Evidence stage {offset // group_node_limit + 1:02d} · "
+                    f"Evidence stage {index + 1:02d} · "
                     f"{first_title}"
                 ),
                 "node_ids": chunk,
-                "order": offset,
+                "order": offset - size,
             }
         )
     return specs

--- a/tests/test_explore_presentation_views.py
+++ b/tests/test_explore_presentation_views.py
@@ -1051,7 +1051,6 @@ def test_visual_sync_single_sink_lane_style_falls_back_to_mermaid(
 def test_visual_sync_publishes_overview_board_without_stages(tmp_path) -> None:
     projection = _complex_projection()
     config = LarkExploreConfig(base_token="PUBLIC_FIXTURE_BASE")
-    bundle = build_explore_presentation_bundle(projection)
 
     synced = sync_explore_visuals_to_lark(
         config,

--- a/tests/test_explore_presentation_views.py
+++ b/tests/test_explore_presentation_views.py
@@ -944,6 +944,8 @@ def test_visual_configuration_auto_create_plans_without_writes(tmp_path) -> None
     assert planned["visual_sinks"]["canonical"]["overview_whiteboard_token"] == (
         "planned-canonical-overview"
     )
+    assert planned["visual_sinks"]["canonical"]["board_style"] == "auto_flow"
+    assert planned["visual_sinks"]["canonical"]["renderer"] == "mermaid"
     assert planned["visual_sinks"]["executive"]["overview_whiteboard_token"] == (
         "planned-executive-overview"
     )
@@ -951,6 +953,68 @@ def test_visual_configuration_auto_create_plans_without_writes(tmp_path) -> None
     stored = read_lark_explore_local_config(config_path)
     assert not stored.get("visual_sinks")
     assert not stored.get("visual_sink")
+
+
+def test_visual_configuration_auto_create_reuses_existing_document(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "lark-explore.json"
+    write_lark_explore_local_config(
+        config_path,
+        {
+            "board": {
+                "base_token": "PUBLIC_FIXTURE_BASE",
+                "tables": {"nodes": "tblN", "edges": "tblE", "findings": "tblF"},
+            },
+            "visual_sinks": {
+                "canonical": {
+                    "docx_token": "doc_existing",
+                    "overview_whiteboard_token": "wb_canonical_overview",
+                    "view_role": "canonical",
+                    "projection_mode": "canonical_full",
+                    "board_style": "auto_flow",
+                    "renderer": "mermaid",
+                    "stage_boards_enabled": True,
+                    "stage_capacity": 14,
+                },
+                "executive": {
+                    "docx_token": "doc_existing",
+                    "overview_whiteboard_token": "wb_executive_overview",
+                    "view_role": "executive",
+                    "projection_mode": "executive_auto",
+                    "board_style": "auto_flow",
+                    "renderer": "mermaid",
+                    "stage_boards_enabled": False,
+                    "stage_capacity": 14,
+                },
+            },
+        },
+    )
+    calls: list[list[str]] = []
+
+    def fail_runner(command, *_args, **_kwargs):
+        calls.append(command)
+        return {"ok": False, "returncode": 1, "stderr": "should not be invoked"}
+
+    monkeypatch.setattr(
+        "loopx.extensions.lark.presentation.explore_results._run_command",
+        fail_runner,
+    )
+
+    result = configure_lark_explore_visual_sink(
+        config_path=config_path,
+        auto_create=True,
+        execute=True,
+    )
+
+    assert result["status"] == "auto_configured"
+    assert result["document"]["docx_token"] == "doc_existing"
+    assert calls == []
+    stored = read_lark_explore_local_config(config_path)
+    assert stored["visual_sinks"]["canonical"]["overview_whiteboard_token"] == (
+        "wb_canonical_overview"
+    )
 
 
 def test_visual_sync_single_sink_lane_style_falls_back_to_mermaid(

--- a/tests/test_explore_presentation_views.py
+++ b/tests/test_explore_presentation_views.py
@@ -9,6 +9,7 @@ import pytest
 from loopx.presentation.explore_views import (
     PRESENTATION_MODE_CANONICAL_ONLY,
     PRESENTATION_MODE_DUAL_VIEW,
+    _canonical_group_specs,
     _display_width,
     build_explore_presentation_bundle,
     explore_source_digest,
@@ -909,6 +910,107 @@ def test_visual_delivery_digest_changes_when_only_rendered_mermaid_changes(
     assert first["source_digest"] == changed["source_digest"]
     assert first["delivery_digest"] != changed["delivery_digest"]
     assert first["command"]["command"] != changed["command"]["command"]
+
+
+def test_canonical_group_specs_balances_stage_tail() -> None:
+    nodes = [{"node_id": f"n{i:02d}", "title": f"N{i}"} for i in range(29)]
+
+    specs = _canonical_group_specs(nodes, group_node_limit=12)
+
+    sizes = [len(spec["node_ids"]) for spec in specs]
+    assert sizes == [10, 10, 9]
+    assert [spec["order"] for spec in specs] == [0, 10, 20]
+    assert [spec["title"] for spec in specs][0].startswith("Evidence stage 01 · ")
+
+
+def test_visual_configuration_auto_create_plans_without_writes(tmp_path) -> None:
+    config_path = tmp_path / "lark-explore.json"
+    write_lark_explore_local_config(
+        config_path,
+        {
+            "board": {
+                "base_token": "PUBLIC_FIXTURE_BASE",
+                "tables": {"nodes": "tblN", "edges": "tblE", "findings": "tblF"},
+            }
+        },
+    )
+
+    planned = configure_lark_explore_visual_sink(
+        config_path=config_path,
+        auto_create=True,
+    )
+
+    assert planned["status"] == "would_auto_create"
+    assert planned["visual_sinks"]["canonical"]["overview_whiteboard_token"] == (
+        "planned-canonical-overview"
+    )
+    assert planned["visual_sinks"]["executive"]["overview_whiteboard_token"] == (
+        "planned-executive-overview"
+    )
+    assert planned["visual_sinks"]["executive"]["stage_boards_enabled"] is False
+    stored = read_lark_explore_local_config(config_path)
+    assert not stored.get("visual_sinks")
+    assert not stored.get("visual_sink")
+
+
+def test_visual_sync_single_sink_lane_style_falls_back_to_mermaid(
+    tmp_path,
+) -> None:
+    projection = _complex_projection()
+    config = LarkExploreConfig(base_token="PUBLIC_FIXTURE_BASE")
+    bundle = build_explore_presentation_bundle(projection)
+    display = dict(bundle["executive"])
+    display.pop("svg", None)
+    display["mermaid"] = display.get("mermaid") or "flowchart TB\n a[\"A\"]"
+
+    result = sync_explore_visual_to_lark(
+        config,
+        projection=projection,
+        visual_sink={
+            "whiteboard_token": "wb_lane_fixture",
+            "view_role": "executive",
+            "board_style": "semantic_lane_columns",
+        },
+        config_path=tmp_path / "lark-explore.json",
+        semantic_digest=bundle["source_digest"],
+        display_projection=display,
+        view_key="executive",
+    )
+
+    assert result["ok"] is True
+    assert result["style_fallback"] is True
+    assert result["board_style"] == "auto_flow"
+    assert result["renderer"] == "mermaid"
+    assert result["input_format"] == "mermaid"
+
+
+def test_visual_sync_publishes_overview_board_without_stages(tmp_path) -> None:
+    projection = _complex_projection()
+    config = LarkExploreConfig(base_token="PUBLIC_FIXTURE_BASE")
+    bundle = build_explore_presentation_bundle(projection)
+
+    synced = sync_explore_visuals_to_lark(
+        config,
+        projection=projection,
+        visual_sinks={
+            "executive": {
+                "whiteboard_token": "wb_executive_fixture",
+                "view_role": "executive",
+                "overview_whiteboard_token": "wb_executive_overview",
+                "stage_boards_enabled": False,
+                "stage_capacity": 14,
+            }
+        },
+        config_path=tmp_path / "lark-explore.json",
+    )
+
+    view = synced["views"]["executive"]
+    assert view["stage_count"] == 0
+    assert view["overview"]["ok"] is True
+    assert view["overview"]["view_role"] == "executive"
+    assert view["overview"]["command"]["command"].startswith(
+        "lark-cli whiteboard +update --as user --whiteboard-token wb_executive_overview"
+    )
 
 
 def test_legacy_grid_renderer_config_fails_with_migration_message(tmp_path) -> None:


### PR DESCRIPTION
Closes #3166

## Summary

`loopx explore feishu-visual-configure` now supports `--auto-create`: it creates
the hosting document and both overview boards (executive topology + canonical
global), registers canonical + executive sinks, and lets `feishu-sync` lazily
create one canonical board per Evidence Stage. No manual doc/whiteboard token
plumbing is required.

## Root cause

- `feishu-setup` only provisioned the Base tables; no document or visual sink
  was created.
- `feishu-visual-configure` required a pre-existing docx/whiteboard token, and
  the single-sink path could not publish per-stage boards.
- `feishu-sync` rendered stage documents with the configured style; when the
  projection only carried Mermaid (no SVG), the style expectation mismatched
  and the board could not be published.
- Stage splitting was uneven and tail-heavy, unlike a balanced multi-stage
  visual document.

## Changes

- `explore feishu-visual-configure --auto-create [--execute]` bootstraps the
  docx + two overview boards and is idempotent: an existing document and
  overview tokens are reused without re-running create/append commands.
- Auto-created sinks default to `board_style=auto_flow` (Mermaid).
- `feishu-sync` publishes the per-role overview board when configured and uses
  `stage_boards_enabled` to control canonical stage boards (executive stage
  boards stay off by default); the overview digest is included in the delivery
  digest.
- Mermaid fallback when the projection has no SVG source.
- Balanced canonical stage splitting (29 nodes -> 10/10/9 under a 12-node group
  limit).
- Maintainability baseline refresh for the lark explore presentation module
  (grandfathered size; follow-up: split into bounded modules).

## Validation

- `pytest -q tests/test_explore_presentation_views.py tests/canary/test_maintainability_ratchet.py`: 51 passed.
- `py_compile` on changed modules and `git diff --check` are clean.
- `loopx canary premerge --from-git-diff`: merge gate passed,
  `self_merge_allowed=true`.
- End-to-end on a real goal: document published with executive overview board,
  canonical global board, and 14 canonical stage boards, each stage carrying a
  full node/edge graph, with readback verified.
