### PR TITLE
feat(effect): add read-only Turn journal interpretation lens

### DIFF
--- a/docs/reference/effect-interpreter-packet.md
+++ b/docs/reference/effect-interpreter-packet.md
@@ -26,6 +26,24 @@ decision or turn-settlement logic; they give refactor and test code one
 stable abstraction for reading the effect program shape across packet
 families.
 
+## Turn Journal Lens
+
+`interpret_turn_journal` reads an existing fenced Turn journal and returns an
+`EffectTurn`. It compares goal, agent owner, and Turn-key identity across the
+journal, stored plan, typed settlement identity, host result, and receipt. It
+also validates that completed phases are an ordered transaction prefix and
+exposes retained `committed`, `stopped`, and `failed` journal tombstones.
+
+`request.context.replay_legal` is the replay-legality signal. Identity,
+phase-order, and terminal-status failures appear together as stable typed
+violation values in `request.context.violations`; semantic mismatches return a
+blocked observation instead of raising an exception.
+
+`EffectObservation.should_run` remains false and `EffectNext` remains empty.
+Interpretation therefore grants no authority to execute or retry a Turn,
+schedule work, write state, or spend quota. In particular, failed-journal
+recovery with `retry_failed=True` remains owned by the Turn executor.
+
 ## Canonical Example
 
 ### 1. Effect Request

--- a/docs/superpowers/plans/2026-08-14-interpret-turn-journal.md
+++ b/docs/superpowers/plans/2026-08-14-interpret-turn-journal.md
@@ -1,0 +1,415 @@
+# Turn Journal Interpretation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a read-only `interpret_turn_journal` Effect Program lens that returns structured replay legality, identity mismatch, tombstone, and phase-order information.
+
+**Architecture:** Keep the public lens in `loopx.control_plane.effect_program` beside the existing quota and Turn-result interpreters. Move the canonical Turn phase sequence into that core Effect Program module and retain `turn_driver.transaction.TRANSACTION_PHASES` as an alias, so interpretation and execution share one exact ordering rule without a circular import or duplicated tuple. Project typed violations into `EffectRequest.context`; never call executor, journal I/O, scheduling, or quota code.
+
+**Tech Stack:** Python 3.12, frozen dataclasses, `StrEnum`, pytest, Markdown reference documentation.
+
+## Global Constraints
+
+- The API is `interpret_turn_journal(journal, *, goal_id=None, agent_id=None, turn_key=None, capabilities=()) -> EffectTurn`.
+- Semantic mismatches return `EffectTurn` with `decision="replay_blocked"`; they do not raise.
+- `EffectObservation.should_run` is always `False`; `request.context["replay_legal"]` is the legality signal.
+- The lens performs no journal I/O, mutation, execution, scheduling, model call, or quota spending.
+- Existing journal and Turn wire schemas remain unchanged.
+- Terminal replay tombstones are exactly `committed`, `stopped`, and `failed`; failed recovery with `retry_failed=True` remains executor-owned.
+- Classification uses typed fields and exact equality, not substring heuristics.
+
+---
+
+### Task 1: Establish The Legal Replay Lens And Canonical Phase Source
+
+**Files:**
+- Create: `tests/control_plane/test_effect_turn_turn_journal.py`
+- Modify: `loopx/control_plane/effect_program.py`
+- Modify: `loopx/control_plane/turn_driver/transaction.py`
+
+**Interfaces:**
+- Consumes: existing `EffectRequest`, `EffectInterpretation`, `EffectObservation`, `EffectNext`, and `EffectTurn` dataclasses.
+- Produces: `TurnTransactionPhase`, `TURN_TRANSACTION_PHASES`, and `interpret_turn_journal(...) -> EffectTurn`; preserves `turn_driver.transaction.TRANSACTION_PHASES` as the same tuple.
+
+- [ ] **Step 1: Write the failing legal-journal test**
+
+```python
+from copy import deepcopy
+
+from loopx.control_plane.effect_program import EffectNext, interpret_turn_journal
+
+
+def _journal(*, status: str = "committed") -> dict[str, object]:
+    turn_key = "sha256:fixture-turn"
+    return {
+        "schema_version": "loopx_turn_journal_v0",
+        "goal_id": "fixture-goal",
+        "turn_key": turn_key,
+        "status": status,
+        "completed_phases": [
+            "host_execute",
+            "typed_result",
+            "validation",
+            "durable_writeback",
+            "quota_spend",
+            "scheduler_apply",
+            "scheduler_ack",
+        ],
+        "plan": {
+            "turn_envelope": {
+                "goal_id": "fixture-goal",
+                "agent_id": "fixture-agent",
+            },
+            "transaction": {
+                "turn_key": turn_key,
+                "settlement_plan": {
+                    "identity": {
+                        "goal_id": "fixture-goal",
+                        "agent_id": "fixture-agent",
+                    }
+                },
+            },
+        },
+        "host_result": {"turn_key": turn_key},
+        "receipt": {"turn_key": turn_key},
+    }
+
+
+def test_turn_journal_reports_legal_replay_without_mutating_input() -> None:
+    journal = _journal()
+    before = deepcopy(journal)
+
+    turn = interpret_turn_journal(
+        journal,
+        goal_id="fixture-goal",
+        agent_id="fixture-agent",
+        turn_key="sha256:fixture-turn",
+        capabilities=["filesystem_read"],
+    )
+
+    assert turn.request.kind == "turn_journal"
+    assert turn.request.source == "turn_journal"
+    assert turn.request.context == {
+        "replay_legal": True,
+        "goal_matches": True,
+        "owner_matches": True,
+        "turn_key_matches": True,
+        "phases_form_ordered_prefix": True,
+        "journal_status": "committed",
+        "tombstone_retained": True,
+        "completed_phases": (
+            "host_execute",
+            "typed_result",
+            "validation",
+            "durable_writeback",
+            "quota_spend",
+            "scheduler_apply",
+            "scheduler_ack",
+        ),
+        "violations": (),
+    }
+    assert turn.observation.decision == "replay_legal"
+    assert turn.observation.should_run is False
+    assert turn.next_effect == EffectNext()
+    assert journal == before
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run: `python -m pytest -q tests/control_plane/test_effect_turn_turn_journal.py::test_turn_journal_reports_legal_replay_without_mutating_input`
+
+Expected: collection fails because `interpret_turn_journal` does not exist.
+
+- [ ] **Step 3: Add the canonical phase enum and minimal legal lens**
+
+In `effect_program.py`, define the canonical phases and implement the public signature:
+
+```python
+class TurnTransactionPhase(StrEnum):
+    HOST_EXECUTE = "host_execute"
+    TYPED_RESULT = "typed_result"
+    VALIDATION = "validation"
+    DURABLE_WRITEBACK = "durable_writeback"
+    QUOTA_SPEND = "quota_spend"
+    SCHEDULER_APPLY = "scheduler_apply"
+    SCHEDULER_ACK = "scheduler_ack"
+
+
+TURN_TRANSACTION_PHASES = tuple(phase.value for phase in TurnTransactionPhase)
+
+
+def interpret_turn_journal(
+    journal: Mapping[str, Any],
+    *,
+    goal_id: str | None = None,
+    agent_id: str | None = None,
+    turn_key: str | None = None,
+    capabilities: Sequence[str] = (),
+) -> EffectTurn:
+    plan = _mapping(journal.get("plan"))
+    envelope = _mapping(plan.get("turn_envelope"))
+    transaction = _mapping(plan.get("transaction"))
+    settlement = _mapping(transaction.get("settlement_plan"))
+    identity = _mapping(settlement.get("identity"))
+    completed = tuple(str(value) for value in journal.get("completed_phases", []))
+    context = {
+        "replay_legal": True,
+        "goal_matches": True,
+        "owner_matches": True,
+        "turn_key_matches": True,
+        "phases_form_ordered_prefix": completed
+        == TURN_TRANSACTION_PHASES[: len(completed)],
+        "journal_status": str(journal.get("status") or ""),
+        "tombstone_retained": journal.get("status")
+        in {"committed", "stopped", "failed"},
+        "completed_phases": completed,
+        "violations": (),
+    }
+    return EffectTurn(
+        request=EffectRequest(
+            kind="turn_journal",
+            source="turn_journal",
+            goal_id=goal_id,
+            agent_id=agent_id,
+            capabilities=tuple(capabilities),
+            context=context,
+        ),
+        interpretation=EffectInterpretation(
+            route="turn_journal_replay",
+            obligation="observe_fenced_replay",
+            interaction_mode="read_only",
+        ),
+        observation=EffectObservation(
+            decision="replay_legal",
+            should_run=False,
+            effective_action="observe_replay",
+            recommended_action="Retain the terminal Turn journal tombstone.",
+            protocol_summary="Turn journal replay is legal and effect-free.",
+        ),
+        next_effect=EffectNext(),
+    )
+```
+
+In `turn_driver/transaction.py`, import `TURN_TRANSACTION_PHASES` and keep compatibility:
+
+```python
+TRANSACTION_PHASES = TURN_TRANSACTION_PHASES
+```
+
+- [ ] **Step 4: Run legal-lens and transaction regression tests**
+
+Run: `python -m pytest -q tests/control_plane/test_effect_turn_turn_journal.py tests/test_loopx_turn_transaction.py`
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit the legal lens seam**
+
+```bash
+git add -- tests/control_plane/test_effect_turn_turn_journal.py loopx/control_plane/effect_program.py loopx/control_plane/turn_driver/transaction.py
+git commit -m "feat(effect): interpret legal turn journal replay"
+```
+
+### Task 2: Return Typed Violations For Illegal And Tombstone States
+
+**Files:**
+- Modify: `tests/control_plane/test_effect_turn_turn_journal.py`
+- Modify: `loopx/control_plane/effect_program.py`
+
+**Interfaces:**
+- Consumes: `TURN_TRANSACTION_PHASES` and `interpret_turn_journal` from Task 1.
+- Produces: `TurnJournalViolation(StrEnum)` and complete structured replay results in `EffectRequest.context`.
+
+- [ ] **Step 1: Add failing identity, phase, terminal, and malformed tests**
+
+Add tests that mutate only controlled fixture fields and assert literal outcomes:
+
+```python
+def test_turn_journal_accumulates_identity_and_phase_violations() -> None:
+    journal = _journal()
+    journal["goal_id"] = "other-goal"
+    journal["turn_key"] = "sha256:other-turn"
+    journal["completed_phases"] = ["host_execute", "validation"]
+    identity = journal["plan"]["transaction"]["settlement_plan"]["identity"]
+    identity["agent_id"] = "other-agent"
+
+    turn = interpret_turn_journal(
+        journal,
+        goal_id="fixture-goal",
+        agent_id="fixture-agent",
+        turn_key="sha256:fixture-turn",
+    )
+
+    assert turn.request.context["replay_legal"] is False
+    assert turn.request.context["goal_matches"] is False
+    assert turn.request.context["owner_matches"] is False
+    assert turn.request.context["turn_key_matches"] is False
+    assert turn.request.context["phases_form_ordered_prefix"] is False
+    assert turn.request.context["violations"] == (
+        "goal_mismatch",
+        "owner_mismatch",
+        "turn_key_mismatch",
+        "completed_phases_not_ordered_prefix",
+    )
+    assert turn.observation.decision == "replay_blocked"
+    assert turn.observation.should_run is False
+
+
+@pytest.mark.parametrize("status", ["committed", "stopped", "failed"])
+def test_turn_journal_retains_terminal_tombstones(status: str) -> None:
+    turn = interpret_turn_journal(
+        _journal(status=status),
+        goal_id="fixture-goal",
+        agent_id="fixture-agent",
+        turn_key="sha256:fixture-turn",
+    )
+    assert turn.request.context["tombstone_retained"] is True
+    assert turn.request.context["journal_status"] == status
+    assert turn.request.context["replay_legal"] is True
+
+
+def test_turn_journal_blocks_non_terminal_and_malformed_trace() -> None:
+    journal = {"status": "in_progress", "completed_phases": "host_execute"}
+    turn = interpret_turn_journal(journal)
+    assert turn.request.context["replay_legal"] is False
+    assert turn.request.context["tombstone_retained"] is False
+    assert turn.request.context["violations"] == (
+        "goal_identity_missing",
+        "owner_identity_missing",
+        "turn_key_identity_missing",
+        "completed_phases_invalid",
+        "journal_not_terminal",
+    )
+```
+
+- [ ] **Step 2: Run the new tests and verify RED**
+
+Run: `python -m pytest -q tests/control_plane/test_effect_turn_turn_journal.py`
+
+Expected: tests fail because Task 1 does not yet compare trace identity or classify blocked replay.
+
+- [ ] **Step 3: Implement exact identity comparison and typed violations**
+
+Add the enum and helpers in `effect_program.py`:
+
+```python
+class TurnJournalViolation(StrEnum):
+    GOAL_IDENTITY_MISSING = "goal_identity_missing"
+    GOAL_MISMATCH = "goal_mismatch"
+    OWNER_IDENTITY_MISSING = "owner_identity_missing"
+    OWNER_MISMATCH = "owner_mismatch"
+    TURN_KEY_IDENTITY_MISSING = "turn_key_identity_missing"
+    TURN_KEY_MISMATCH = "turn_key_mismatch"
+    COMPLETED_PHASES_INVALID = "completed_phases_invalid"
+    COMPLETED_PHASES_NOT_ORDERED_PREFIX = "completed_phases_not_ordered_prefix"
+    JOURNAL_NOT_TERMINAL = "journal_not_terminal"
+    JOURNAL_STATUS_UNSUPPORTED = "journal_status_unsupported"
+
+
+def _present_strings(*values: Any) -> tuple[str, ...]:
+    return tuple(value for item in values if (value := str(item or "").strip()))
+
+
+def _values_match(values: tuple[str, ...]) -> bool:
+    return bool(values) and len(set(values)) == 1
+```
+
+Update `interpret_turn_journal` to:
+
+1. require journal/envelope/settlement goal, envelope/settlement owner, and journal/transaction Turn key;
+2. append the explicit expectation to each comparison when supplied;
+3. compare optional host-result and receipt Turn keys only when present;
+4. distinguish non-list phases from list values that are not the canonical prefix;
+5. classify `in_progress` and `scheduler_action_required` as known non-terminal state, with unknown values classified as unsupported;
+6. set legality from an empty violation list;
+7. emit `replay_blocked`, `block_replay`, and domain-neutral readback when any violation exists.
+
+The final legality calculation is:
+
+```python
+replay_legal = not violations
+context["violations"] = tuple(violation.value for violation in violations)
+```
+
+- [ ] **Step 4: Run focused tests and existing Effect Program regressions**
+
+Run: `python -m pytest -q tests/control_plane/test_effect_turn_turn_journal.py tests/control_plane/test_effect_interpreter_packet.py tests/control_plane/test_effect_turn_turn_result.py tests/test_loopx_turn_transaction.py tests/test_loopx_turn_executor.py`
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit structured violation behavior**
+
+```bash
+git add -- tests/control_plane/test_effect_turn_turn_journal.py loopx/control_plane/effect_program.py
+git commit -m "feat(effect): report blocked turn journal replay"
+```
+
+### Task 3: Document And Validate The Read-Only Contract
+
+**Files:**
+- Modify: `docs/reference/effect-interpreter-packet.md`
+- Track: `docs/superpowers/plans/2026-08-14-interpret-turn-journal.md`
+
+**Interfaces:**
+- Consumes: final `interpret_turn_journal` behavior from Tasks 1 and 2.
+- Produces: public guidance describing identity, tombstone, replay, and no-authority semantics.
+
+- [ ] **Step 1: Update the reference documentation**
+
+Add a `Turn Journal Lens` section that states:
+
+```markdown
+## Turn Journal Lens
+
+`interpret_turn_journal` reads an existing fenced Turn journal and returns an
+`EffectTurn`. It compares goal, agent owner, and Turn-key identity across the
+journal trace; validates that completed phases are an ordered transaction
+prefix; and exposes retained terminal tombstones.
+
+`request.context.replay_legal` is the legality signal. `should_run` remains
+false and `next_effect` remains empty: interpretation grants no permission to
+execute, retry, schedule, write state, or spend quota. Semantic mismatches are
+returned as typed violation values instead of exceptions.
+```
+
+- [ ] **Step 2: Run formatting and focused validation**
+
+Run:
+
+```powershell
+python -m pytest -q tests/control_plane/test_effect_turn_turn_journal.py tests/control_plane/test_effect_interpreter_packet.py tests/control_plane/test_effect_turn_turn_result.py tests/test_loopx_turn_transaction.py tests/test_loopx_turn_executor.py
+python examples/loopx-turn-fake-host-walkthrough-smoke.py
+loopx check --scan-path docs/reference/effect-interpreter-packet.md --scan-path CONTRIBUTOR_TASKS.md
+loopx canary premerge --from-git-diff --git-diff-base upstream/main
+git diff --check upstream/main...HEAD
+```
+
+Expected: every command exits zero. If the canary reports an explicit skip, record the skip and its reason rather than claiming that surface was tested.
+
+- [ ] **Step 3: Run the public/private boundary scan**
+
+Run:
+
+```powershell
+git diff --name-only upstream/main...HEAD
+git diff upstream/main...HEAD | Select-String -Pattern 'credential|secret|private state|raw log|trajectory|verifier output|[A-Z]:\\|file://|localhost' -CaseSensitive:$false
+```
+
+Expected: only the scoped product, test, reference, spec, and plan files appear; no credential, private-state, raw-evidence, local-path, or internal-link content is present.
+
+- [ ] **Step 4: Commit documentation and plan**
+
+```bash
+git add -- docs/reference/effect-interpreter-packet.md docs/superpowers/plans/2026-08-14-interpret-turn-journal.md
+git commit -m "docs(effect): explain turn journal replay lens"
+```
+
+- [ ] **Step 5: Verify the final branch state**
+
+Run:
+
+```powershell
+git status --short --branch
+git log --oneline upstream/main..HEAD
+```
+
+Expected: the worktree is clean and the scoped commits are listed.

--- a/docs/superpowers/specs/2026-08-14-interpret-turn-journal-design.md
+++ b/docs/superpowers/specs/2026-08-14-interpret-turn-journal-design.md
@@ -1,0 +1,186 @@
+# Read-Only Turn Journal Interpretation Design
+
+## Goal
+
+Add a read-only `interpret_turn_journal` lens that maps an existing fenced
+LoopX Turn journal onto `EffectTurn`. The lens reports whether effect-free
+replay is legal, explains identity and phase-order violations as structured
+data, and preserves terminal journal tombstones without executing or mutating
+anything.
+
+## Scope
+
+The change will:
+
+- add `interpret_turn_journal` to
+  `loopx.control_plane.effect_program`;
+- compare goal, owner, and Turn-key identity across the journal trace;
+- verify that `completed_phases` is an ordered prefix of
+  `TRANSACTION_PHASES`;
+- expose terminal `committed`, `stopped`, and `failed` journal state as a
+  retained tombstone;
+- distinguish `replay_legal` from `replay_blocked` without authorizing
+  execution;
+- add focused semantic tests and update the Effect Interpreter Packet
+  reference.
+
+The change will not add a journal loader, executor, scheduler path, write
+operation, schema migration, model call, quota spend, or second settlement
+ledger.
+
+## Ownership And Placement
+
+- Capability outcome: read an existing Turn journal as an Effect Program
+  observation.
+- Capability owner: the existing Turn / Effect Program contract.
+- Provider: built into LoopX core; no extension provider is involved.
+- Implementation home: `loopx/control_plane/effect_program.py`, beside
+  `interpret_quota_should_run_packet` and `interpret_turn_result_packet`.
+
+The nearest existing owner is sufficient because this is another packet lens
+over an already shipped Turn contract. A new capability package, journal
+adapter, or interpreter protocol would add structure without a separate caller
+contract.
+
+## Public API
+
+```python
+def interpret_turn_journal(
+    journal: Mapping[str, Any],
+    *,
+    goal_id: str | None = None,
+    agent_id: str | None = None,
+    turn_key: str | None = None,
+    capabilities: Sequence[str] = (),
+) -> EffectTurn:
+    ...
+```
+
+The supplied identity arguments are expectations, not authority grants. The
+function reads the supplied mapping and returns an `EffectTurn`; it does not
+open a path, acquire a lock, write a journal, or invoke replay.
+
+## Identity And Phase Interpretation
+
+The lens reads identity from the existing trace locations:
+
+- journal: `goal_id` and `turn_key`;
+- stored plan envelope: `goal_id` and `agent_id`;
+- transaction plan: `turn_key`;
+- typed settlement identity: `goal_id` and `agent_id`;
+- host result and receipt: any present `turn_key`.
+
+All present values for one identity dimension must agree with each other and
+with the corresponding explicit expectation when one is supplied. Missing
+required journal, envelope, transaction, or settlement identity is reported as
+structured invalid identity rather than raising an exception. Optional host
+result and receipt fields are compared only when present because an
+in-progress trace may not have reached those stages.
+
+`completed_phases` is valid only when it is a list whose string values equal
+the same-length prefix of `TRANSACTION_PHASES`. An empty list is a valid
+ordered prefix, but it does not make an in-progress journal eligible for
+effect-free replay.
+
+## Replay And Tombstone Semantics
+
+An effect-free replay is legal when:
+
+1. goal, owner, and Turn-key identity match;
+2. completed phases form an ordered transaction prefix; and
+3. the journal has a terminal status currently treated as a replay tombstone:
+   `committed`, `stopped`, or `failed`.
+
+This describes the existing default replay boundary. It does not authorize a
+`retry_failed=True` recovery, which remains executor-owned and may perform
+effects.
+
+The input journal is never modified. Terminal status is projected as
+`tombstone_retained=True` with its original `journal_status`; no tombstone is
+created, deleted, or rewritten. Non-terminal state is visible but has
+`replay_legal=False` and `tombstone_retained=False`.
+
+## EffectTurn Mapping
+
+`EffectRequest`:
+
+- `kind="turn_journal"`;
+- `source="turn_journal"`;
+- expected `goal_id`, `agent_id`, and capabilities remain visible;
+- `context` contains:
+  - `replay_legal`;
+  - `goal_matches`;
+  - `owner_matches`;
+  - `turn_key_matches`;
+  - `phases_form_ordered_prefix`;
+  - `journal_status`;
+  - `tombstone_retained`;
+  - normalized `completed_phases`;
+  - an ordered tuple of typed violation values.
+
+`EffectInterpretation`:
+
+- `route="turn_journal_replay"`;
+- `obligation="observe_fenced_replay"`;
+- `interaction_mode="read_only"`.
+
+`EffectObservation`:
+
+- `decision` is `replay_legal` or `replay_blocked`;
+- `should_run` is always `False`, so the lens cannot be mistaken for
+  execution permission;
+- `effective_action` is `observe_replay` or `block_replay`;
+- `recommended_action` gives a compact, domain-neutral readback;
+- `protocol_summary` summarizes legality without embedding raw journal data.
+
+`EffectNext` is empty. The structured `request.context["replay_legal"]` field,
+not `should_run`, is the replay-legality signal.
+
+## Structured Violations
+
+Implementation will define a typed `StrEnum` for stable violation values and
+project their string values into `EffectRequest.context`. The initial values
+cover:
+
+- `goal_identity_missing`;
+- `goal_mismatch`;
+- `owner_identity_missing`;
+- `owner_mismatch`;
+- `turn_key_identity_missing`;
+- `turn_key_mismatch`;
+- `completed_phases_invalid`;
+- `completed_phases_not_ordered_prefix`;
+- `journal_not_terminal`;
+- `journal_status_unsupported`.
+
+Violations are accumulated in deterministic order so one trace can expose all
+independent problems in a single read. Classification is based on typed fields
+and exact equality, not substring heuristics.
+
+## Error Handling And Compatibility
+
+Semantic mismatches return `EffectTurn` with `decision="replay_blocked"`.
+They do not raise. The function accepts any `Mapping`; malformed nested values
+are treated as missing or invalid structured fields.
+
+Existing `EffectTurn` dataclasses and existing interpreter behavior remain
+unchanged. No journal or Turn wire schema changes. Callers that do not use the
+new lens observe no behavior change.
+
+## Testing
+
+Focused tests will derive expectations from the Turn transaction contract and
+cover:
+
+1. a terminal journal with matching trace identity and ordered phases;
+2. owner, goal, and Turn-key mismatches accumulated as structured violations;
+3. a non-prefix phase sequence blocked even when the journal is terminal;
+4. retained `committed`, `stopped`, and `failed` tombstone status;
+5. a non-terminal journal that remains observable but not replay-legal;
+6. malformed or missing identity fields returning a blocked result rather
+   than raising;
+7. input immutability and empty `EffectNext` fields.
+
+Validation will include focused pytest coverage, the existing fake-host Turn
+walkthrough, the documented `loopx check` scans, and the repository's
+risk-based premerge canary for the final diff.

--- a/loopx/control_plane/effect_program.py
+++ b/loopx/control_plane/effect_program.py
@@ -288,27 +288,33 @@ def _mapping(value: Any) -> Mapping[str, Any]:
     return value if isinstance(value, Mapping) else {}
 
 
-def _present_strings(*values: Any) -> tuple[str, ...]:
-    return tuple(
-        normalized
-        for item in values
-        if (normalized := str(item or "").strip())
-    )
+def _valid_identity_value(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
 
 
 def _identity_state(
     required_values: Sequence[Any],
     *,
-    optional_values: Sequence[Any] = (),
+    optional_values: Sequence[tuple[bool, Any]] = (),
     expected: str | None = None,
 ) -> tuple[bool, bool]:
-    required = _present_strings(*required_values)
-    complete = len(required) == len(required_values)
-    observed = (
-        *required,
-        *_present_strings(*optional_values),
-        *_present_strings(expected),
+    required_complete = all(
+        _valid_identity_value(value) for value in required_values
     )
+    optional_complete = all(
+        not present or _valid_identity_value(value)
+        for present, value in optional_values
+    )
+    expected_complete = expected is None or _valid_identity_value(expected)
+    complete = required_complete and optional_complete and expected_complete
+    observed = [value for value in required_values if _valid_identity_value(value)]
+    observed.extend(
+        value
+        for present, value in optional_values
+        if present and _valid_identity_value(value)
+    )
+    if expected is not None and _valid_identity_value(expected):
+        observed.append(expected)
     return complete, complete and len(set(observed)) == 1
 
 
@@ -458,7 +464,10 @@ def interpret_turn_journal(
     )
     turn_key_complete, turn_key_matches = _identity_state(
         (journal.get("turn_key"), transaction.get("turn_key")),
-        optional_values=(host_result.get("turn_key"), receipt.get("turn_key")),
+        optional_values=(
+            ("turn_key" in host_result, host_result.get("turn_key")),
+            ("turn_key" in receipt, receipt.get("turn_key")),
+        ),
         expected=turn_key,
     )
 

--- a/loopx/control_plane/effect_program.py
+++ b/loopx/control_plane/effect_program.py
@@ -87,6 +87,19 @@ class TurnTransactionPhase(StrEnum):
 TURN_TRANSACTION_PHASES = tuple(phase.value for phase in TurnTransactionPhase)
 
 
+class TurnJournalViolation(StrEnum):
+    GOAL_IDENTITY_MISSING = "goal_identity_missing"
+    GOAL_MISMATCH = "goal_mismatch"
+    OWNER_IDENTITY_MISSING = "owner_identity_missing"
+    OWNER_MISMATCH = "owner_mismatch"
+    TURN_KEY_IDENTITY_MISSING = "turn_key_identity_missing"
+    TURN_KEY_MISMATCH = "turn_key_mismatch"
+    COMPLETED_PHASES_INVALID = "completed_phases_invalid"
+    COMPLETED_PHASES_NOT_ORDERED_PREFIX = "completed_phases_not_ordered_prefix"
+    JOURNAL_NOT_TERMINAL = "journal_not_terminal"
+    JOURNAL_STATUS_UNSUPPORTED = "journal_status_unsupported"
+
+
 class SettlementStepKind(StrEnum):
     VALIDATION = "validation"
     TODO_COMPLETION = "todo_completion"
@@ -275,6 +288,30 @@ def _mapping(value: Any) -> Mapping[str, Any]:
     return value if isinstance(value, Mapping) else {}
 
 
+def _present_strings(*values: Any) -> tuple[str, ...]:
+    return tuple(
+        normalized
+        for item in values
+        if (normalized := str(item or "").strip())
+    )
+
+
+def _identity_state(
+    required_values: Sequence[Any],
+    *,
+    optional_values: Sequence[Any] = (),
+    expected: str | None = None,
+) -> tuple[bool, bool]:
+    required = _present_strings(*required_values)
+    complete = len(required) == len(required_values)
+    observed = (
+        *required,
+        *_present_strings(*optional_values),
+        *_present_strings(expected),
+    )
+    return complete, complete and len(set(observed)) == 1
+
+
 def effect_program_from_ordered_steps(
     ordered_steps: Sequence[Mapping[str, Any]],
     *,
@@ -399,24 +436,79 @@ def interpret_turn_journal(
 ) -> EffectTurn:
     """Read one fenced Turn journal through the canonical effect slots."""
 
-    completed_phases = tuple(
-        str(phase) for phase in journal.get("completed_phases", [])
+    plan = _mapping(journal.get("plan"))
+    envelope = _mapping(plan.get("turn_envelope"))
+    transaction = _mapping(plan.get("transaction"))
+    settlement = _mapping(transaction.get("settlement_plan"))
+    identity = _mapping(settlement.get("identity"))
+    host_result = _mapping(journal.get("host_result"))
+    receipt = _mapping(journal.get("receipt"))
+
+    goal_complete, goal_matches = _identity_state(
+        (
+            journal.get("goal_id"),
+            envelope.get("goal_id"),
+            identity.get("goal_id"),
+        ),
+        expected=goal_id,
     )
+    owner_complete, owner_matches = _identity_state(
+        (envelope.get("agent_id"), identity.get("agent_id")),
+        expected=agent_id,
+    )
+    turn_key_complete, turn_key_matches = _identity_state(
+        (journal.get("turn_key"), transaction.get("turn_key")),
+        optional_values=(host_result.get("turn_key"), receipt.get("turn_key")),
+        expected=turn_key,
+    )
+
+    violations: list[TurnJournalViolation] = []
+    if not goal_complete:
+        violations.append(TurnJournalViolation.GOAL_IDENTITY_MISSING)
+    elif not goal_matches:
+        violations.append(TurnJournalViolation.GOAL_MISMATCH)
+    if not owner_complete:
+        violations.append(TurnJournalViolation.OWNER_IDENTITY_MISSING)
+    elif not owner_matches:
+        violations.append(TurnJournalViolation.OWNER_MISMATCH)
+    if not turn_key_complete:
+        violations.append(TurnJournalViolation.TURN_KEY_IDENTITY_MISSING)
+    elif not turn_key_matches:
+        violations.append(TurnJournalViolation.TURN_KEY_MISMATCH)
+
+    raw_completed_phases = journal.get("completed_phases")
+    if isinstance(raw_completed_phases, list):
+        completed_phases = tuple(str(phase) for phase in raw_completed_phases)
+        phases_form_ordered_prefix = completed_phases == TURN_TRANSACTION_PHASES[
+            : len(completed_phases)
+        ]
+        if not phases_form_ordered_prefix:
+            violations.append(
+                TurnJournalViolation.COMPLETED_PHASES_NOT_ORDERED_PREFIX
+            )
+    else:
+        completed_phases = ()
+        phases_form_ordered_prefix = False
+        violations.append(TurnJournalViolation.COMPLETED_PHASES_INVALID)
+
     journal_status = str(journal.get("status") or "")
-    phases_form_ordered_prefix = completed_phases == TURN_TRANSACTION_PHASES[
-        : len(completed_phases)
-    ]
+    tombstone_retained = journal_status in {"committed", "stopped", "failed"}
+    if journal_status in {"in_progress", "scheduler_action_required"}:
+        violations.append(TurnJournalViolation.JOURNAL_NOT_TERMINAL)
+    elif not tombstone_retained:
+        violations.append(TurnJournalViolation.JOURNAL_STATUS_UNSUPPORTED)
+
+    replay_legal = not violations
     context = {
-        "replay_legal": True,
-        "goal_matches": True,
-        "owner_matches": True,
-        "turn_key_matches": True,
+        "replay_legal": replay_legal,
+        "goal_matches": goal_matches,
+        "owner_matches": owner_matches,
+        "turn_key_matches": turn_key_matches,
         "phases_form_ordered_prefix": phases_form_ordered_prefix,
         "journal_status": journal_status,
-        "tombstone_retained": journal_status
-        in {"committed", "stopped", "failed"},
+        "tombstone_retained": tombstone_retained,
         "completed_phases": completed_phases,
-        "violations": (),
+        "violations": tuple(violation.value for violation in violations),
     }
     return EffectTurn(
         request=EffectRequest(
@@ -433,11 +525,22 @@ def interpret_turn_journal(
             interaction_mode="read_only",
         ),
         observation=EffectObservation(
-            decision="replay_legal",
+            decision="replay_legal" if replay_legal else "replay_blocked",
             should_run=False,
-            effective_action="observe_replay",
-            recommended_action="Retain the terminal Turn journal tombstone.",
-            protocol_summary="Turn journal replay is legal and effect-free.",
+            effective_action=("observe_replay" if replay_legal else "block_replay"),
+            recommended_action=(
+                "Retain the terminal Turn journal tombstone."
+                if replay_legal
+                else "Inspect the structured Turn journal violations before replay."
+            ),
+            protocol_summary=(
+                "Turn journal replay is legal and effect-free."
+                if replay_legal
+                else (
+                    "Turn journal replay is blocked by "
+                    f"{len(violations)} structured violation(s)."
+                )
+            ),
         ),
         next_effect=EffectNext(),
     )

--- a/loopx/control_plane/effect_program.py
+++ b/loopx/control_plane/effect_program.py
@@ -74,6 +74,19 @@ class EffectProgram:
     execution_mode: str | None = None
 
 
+class TurnTransactionPhase(StrEnum):
+    HOST_EXECUTE = "host_execute"
+    TYPED_RESULT = "typed_result"
+    VALIDATION = "validation"
+    DURABLE_WRITEBACK = "durable_writeback"
+    QUOTA_SPEND = "quota_spend"
+    SCHEDULER_APPLY = "scheduler_apply"
+    SCHEDULER_ACK = "scheduler_ack"
+
+
+TURN_TRANSACTION_PHASES = tuple(phase.value for phase in TurnTransactionPhase)
+
+
 class SettlementStepKind(StrEnum):
     VALIDATION = "validation"
     TODO_COMPLETION = "todo_completion"
@@ -373,6 +386,60 @@ def interpret_quota_should_run_packet(
         interpretation=interpretation,
         observation=observation,
         next_effect=next_effect,
+    )
+
+
+def interpret_turn_journal(
+    journal: Mapping[str, Any],
+    *,
+    goal_id: str | None = None,
+    agent_id: str | None = None,
+    turn_key: str | None = None,
+    capabilities: Sequence[str] = (),
+) -> EffectTurn:
+    """Read one fenced Turn journal through the canonical effect slots."""
+
+    completed_phases = tuple(
+        str(phase) for phase in journal.get("completed_phases", [])
+    )
+    journal_status = str(journal.get("status") or "")
+    phases_form_ordered_prefix = completed_phases == TURN_TRANSACTION_PHASES[
+        : len(completed_phases)
+    ]
+    context = {
+        "replay_legal": True,
+        "goal_matches": True,
+        "owner_matches": True,
+        "turn_key_matches": True,
+        "phases_form_ordered_prefix": phases_form_ordered_prefix,
+        "journal_status": journal_status,
+        "tombstone_retained": journal_status
+        in {"committed", "stopped", "failed"},
+        "completed_phases": completed_phases,
+        "violations": (),
+    }
+    return EffectTurn(
+        request=EffectRequest(
+            kind="turn_journal",
+            source="turn_journal",
+            goal_id=goal_id,
+            agent_id=agent_id,
+            capabilities=tuple(capabilities),
+            context=context,
+        ),
+        interpretation=EffectInterpretation(
+            route="turn_journal_replay",
+            obligation="observe_fenced_replay",
+            interaction_mode="read_only",
+        ),
+        observation=EffectObservation(
+            decision="replay_legal",
+            should_run=False,
+            effective_action="observe_replay",
+            recommended_action="Retain the terminal Turn journal tombstone.",
+            protocol_summary="Turn journal replay is legal and effect-free.",
+        ),
+        next_effect=EffectNext(),
     )
 
 

--- a/loopx/control_plane/turn_driver/transaction.py
+++ b/loopx/control_plane/turn_driver/transaction.py
@@ -14,6 +14,7 @@ from ..effect_program import (
     SettlementPlan,
     SettlementStep,
     SettlementStepKind,
+    TURN_TRANSACTION_PHASES,
 )
 
 LOOPX_TURN_TRANSACTION_PLAN_SCHEMA_VERSION = "loopx_turn_transaction_plan_v0"
@@ -21,15 +22,7 @@ LOOPX_TURN_RESULT_SCHEMA_VERSION = "loopx_turn_result_v0"
 LOOPX_TURN_RECEIPT_SCHEMA_VERSION = "loopx_turn_receipt_v0"
 LOOPX_TURN_RECEIPT_VALIDATION_SCHEMA_VERSION = "loopx_turn_receipt_validation_v0"
 LOOPX_TURN_EXECUTION_SCHEMA_VERSION = "loopx_turn_execution_v0"
-TRANSACTION_PHASES = (
-    "host_execute",
-    "typed_result",
-    "validation",
-    "durable_writeback",
-    "quota_spend",
-    "scheduler_apply",
-    "scheduler_ack",
-)
+TRANSACTION_PHASES = TURN_TRANSACTION_PHASES
 
 
 class LoopXTurnResultKind(str, Enum):

--- a/tests/control_plane/test_effect_turn_turn_journal.py
+++ b/tests/control_plane/test_effect_turn_turn_journal.py
@@ -5,7 +5,12 @@ from typing import Any
 
 import pytest
 
-from loopx.control_plane.effect_program import EffectNext, interpret_turn_journal
+from loopx.control_plane.effect_program import (
+    TURN_TRANSACTION_PHASES,
+    EffectNext,
+    interpret_turn_journal,
+)
+from loopx.control_plane.turn_driver.transaction import TRANSACTION_PHASES
 
 
 def _journal(*, status: str = "committed") -> dict[str, Any]:
@@ -170,3 +175,64 @@ def test_turn_journal_blocks_unknown_status_as_unsupported() -> None:
     assert turn.request.context["replay_legal"] is False
     assert turn.request.context["tombstone_retained"] is False
     assert turn.request.context["violations"] == ("journal_status_unsupported",)
+
+
+def test_turn_journal_compares_identity_strings_exactly() -> None:
+    journal = _journal()
+    journal["goal_id"] = " fixture-goal "
+
+    turn = interpret_turn_journal(
+        journal,
+        goal_id="fixture-goal",
+        agent_id="fixture-agent",
+        turn_key="sha256:fixture-turn",
+    )
+
+    assert turn.request.context["replay_legal"] is False
+    assert turn.request.context["goal_matches"] is False
+    assert turn.request.context["violations"] == ("goal_mismatch",)
+
+
+def test_turn_journal_blocks_present_malformed_identity_fields() -> None:
+    journal = _journal()
+    journal["plan"]["turn_envelope"]["agent_id"] = 7
+    journal["host_result"]["turn_key"] = ""
+    journal["receipt"]["turn_key"] = object()
+
+    turn = interpret_turn_journal(
+        journal,
+        goal_id="fixture-goal",
+        agent_id="fixture-agent",
+        turn_key="sha256:fixture-turn",
+    )
+
+    assert turn.request.context["replay_legal"] is False
+    assert turn.request.context["owner_matches"] is False
+    assert turn.request.context["turn_key_matches"] is False
+    assert turn.request.context["violations"] == (
+        "owner_identity_missing",
+        "turn_key_identity_missing",
+    )
+
+
+def test_turn_journal_blocks_explicit_empty_identity_expectations() -> None:
+    turn = interpret_turn_journal(
+        _journal(),
+        goal_id="",
+        agent_id="",
+        turn_key="",
+    )
+
+    assert turn.request.context["replay_legal"] is False
+    assert turn.request.context["goal_matches"] is False
+    assert turn.request.context["owner_matches"] is False
+    assert turn.request.context["turn_key_matches"] is False
+    assert turn.request.context["violations"] == (
+        "goal_identity_missing",
+        "owner_identity_missing",
+        "turn_key_identity_missing",
+    )
+
+
+def test_turn_transaction_keeps_the_canonical_phase_tuple_alias() -> None:
+    assert TRANSACTION_PHASES is TURN_TRANSACTION_PHASES

--- a/tests/control_plane/test_effect_turn_turn_journal.py
+++ b/tests/control_plane/test_effect_turn_turn_journal.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any
 
+import pytest
+
 from loopx.control_plane.effect_program import EffectNext, interpret_turn_journal
 
 
@@ -86,3 +88,85 @@ def test_turn_journal_reports_legal_replay_without_mutating_input() -> None:
     assert turn.observation.effective_action == "observe_replay"
     assert turn.next_effect == EffectNext()
     assert journal == before
+
+
+def test_turn_journal_accumulates_identity_and_phase_violations() -> None:
+    journal = _journal()
+    journal["goal_id"] = "other-goal"
+    journal["turn_key"] = "sha256:other-turn"
+    journal["completed_phases"] = ["host_execute", "validation"]
+    identity = journal["plan"]["transaction"]["settlement_plan"]["identity"]
+    identity["agent_id"] = "other-agent"
+
+    turn = interpret_turn_journal(
+        journal,
+        goal_id="fixture-goal",
+        agent_id="fixture-agent",
+        turn_key="sha256:fixture-turn",
+    )
+
+    assert turn.request.context["replay_legal"] is False
+    assert turn.request.context["goal_matches"] is False
+    assert turn.request.context["owner_matches"] is False
+    assert turn.request.context["turn_key_matches"] is False
+    assert turn.request.context["phases_form_ordered_prefix"] is False
+    assert turn.request.context["violations"] == (
+        "goal_mismatch",
+        "owner_mismatch",
+        "turn_key_mismatch",
+        "completed_phases_not_ordered_prefix",
+    )
+    assert turn.observation.decision == "replay_blocked"
+    assert turn.observation.should_run is False
+    assert turn.observation.effective_action == "block_replay"
+    assert turn.next_effect == EffectNext()
+
+
+@pytest.mark.parametrize("status", ["committed", "stopped", "failed"])
+def test_turn_journal_retains_terminal_tombstones(status: str) -> None:
+    turn = interpret_turn_journal(
+        _journal(status=status),
+        goal_id="fixture-goal",
+        agent_id="fixture-agent",
+        turn_key="sha256:fixture-turn",
+    )
+
+    assert turn.request.context["tombstone_retained"] is True
+    assert turn.request.context["journal_status"] == status
+    assert turn.request.context["replay_legal"] is True
+
+
+def test_turn_journal_blocks_non_terminal_and_malformed_trace() -> None:
+    journal = {"status": "in_progress", "completed_phases": "host_execute"}
+
+    turn = interpret_turn_journal(journal)
+
+    assert turn.request.context["replay_legal"] is False
+    assert turn.request.context["goal_matches"] is False
+    assert turn.request.context["owner_matches"] is False
+    assert turn.request.context["turn_key_matches"] is False
+    assert turn.request.context["phases_form_ordered_prefix"] is False
+    assert turn.request.context["tombstone_retained"] is False
+    assert turn.request.context["completed_phases"] == ()
+    assert turn.request.context["violations"] == (
+        "goal_identity_missing",
+        "owner_identity_missing",
+        "turn_key_identity_missing",
+        "completed_phases_invalid",
+        "journal_not_terminal",
+    )
+    assert turn.observation.decision == "replay_blocked"
+    assert turn.observation.should_run is False
+
+
+def test_turn_journal_blocks_unknown_status_as_unsupported() -> None:
+    turn = interpret_turn_journal(
+        _journal(status="retired"),
+        goal_id="fixture-goal",
+        agent_id="fixture-agent",
+        turn_key="sha256:fixture-turn",
+    )
+
+    assert turn.request.context["replay_legal"] is False
+    assert turn.request.context["tombstone_retained"] is False
+    assert turn.request.context["violations"] == ("journal_status_unsupported",)

--- a/tests/control_plane/test_effect_turn_turn_journal.py
+++ b/tests/control_plane/test_effect_turn_turn_journal.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from loopx.control_plane.effect_program import EffectNext, interpret_turn_journal
+
+
+def _journal(*, status: str = "committed") -> dict[str, Any]:
+    turn_key = "sha256:fixture-turn"
+    return {
+        "schema_version": "loopx_turn_journal_v0",
+        "goal_id": "fixture-goal",
+        "turn_key": turn_key,
+        "status": status,
+        "completed_phases": [
+            "host_execute",
+            "typed_result",
+            "validation",
+            "durable_writeback",
+            "quota_spend",
+            "scheduler_apply",
+            "scheduler_ack",
+        ],
+        "plan": {
+            "turn_envelope": {
+                "goal_id": "fixture-goal",
+                "agent_id": "fixture-agent",
+            },
+            "transaction": {
+                "turn_key": turn_key,
+                "settlement_plan": {
+                    "identity": {
+                        "goal_id": "fixture-goal",
+                        "agent_id": "fixture-agent",
+                    }
+                },
+            },
+        },
+        "host_result": {"turn_key": turn_key},
+        "receipt": {"turn_key": turn_key},
+    }
+
+
+def test_turn_journal_reports_legal_replay_without_mutating_input() -> None:
+    journal = _journal()
+    before = deepcopy(journal)
+
+    turn = interpret_turn_journal(
+        journal,
+        goal_id="fixture-goal",
+        agent_id="fixture-agent",
+        turn_key="sha256:fixture-turn",
+        capabilities=["filesystem_read"],
+    )
+
+    assert turn.request.kind == "turn_journal"
+    assert turn.request.source == "turn_journal"
+    assert turn.request.goal_id == "fixture-goal"
+    assert turn.request.agent_id == "fixture-agent"
+    assert turn.request.capabilities == ("filesystem_read",)
+    assert turn.request.context == {
+        "replay_legal": True,
+        "goal_matches": True,
+        "owner_matches": True,
+        "turn_key_matches": True,
+        "phases_form_ordered_prefix": True,
+        "journal_status": "committed",
+        "tombstone_retained": True,
+        "completed_phases": (
+            "host_execute",
+            "typed_result",
+            "validation",
+            "durable_writeback",
+            "quota_spend",
+            "scheduler_apply",
+            "scheduler_ack",
+        ),
+        "violations": (),
+    }
+    assert turn.interpretation.route == "turn_journal_replay"
+    assert turn.interpretation.obligation == "observe_fenced_replay"
+    assert turn.interpretation.interaction_mode == "read_only"
+    assert turn.observation.decision == "replay_legal"
+    assert turn.observation.should_run is False
+    assert turn.observation.effective_action == "observe_replay"
+    assert turn.next_effect == EffectNext()
+    assert journal == before


### PR DESCRIPTION
## Summary

- Add a read-only `interpret_turn_journal` lens that projects fenced Turn journals into the existing `EffectTurn` model.
- Return structured replay legality and violations for exact goal, owner, Turn-key, terminal-status, and transaction phase-order checks.
- Preserve `committed`, `stopped`, and `failed` journal tombstones without executing replay, writing state, scheduling work, or spending quota.
- Share one typed Turn transaction phase sequence between journal interpretation and transaction validation.
- Add focused semantic tests and update the Effect Interpreter Packet reference.

## Issue Or Task

- Closes #3172
- Contributor task ID: GH-C84

## Validation

- [ ] `python3 -m py_compile loopx/*.py`
- [ ] `loopx check --scan-root .`
- [x] Other: Focused and regression tests — 59 passed
  - `python -m pytest -q tests/control_plane/test_effect_turn_turn_journal.py tests/control_plane/test_effect_interpreter_packet.py tests/control_plane/test_effect_turn_turn_result.py tests/test_loopx_turn_transaction.py tests/test_loopx_turn_executor.py`
- [x] Other: Targeted Ruff check passed
  - `python -m ruff check loopx/control_plane/effect_program.py loopx/control_plane/turn_driver/transaction.py tests/control_plane/test_effect_turn_turn_journal.py`
- [x] Other: Targeted Python compilation passed
  - `python -m py_compile loopx/control_plane/effect_program.py loopx/control_plane/turn_driver/transaction.py tests/control_plane/test_effect_turn_turn_journal.py`
- [x] Other: Fake-host walkthrough smoke passed
  - `python examples/loopx-turn-fake-host-walkthrough-smoke.py`
- [x] Other: Issue-scoped LoopX checks passed with two environment-only warnings
  - `loopx check --scan-path docs/reference/effect-interpreter-packet.md --scan-path CONTRIBUTOR_TASKS.md`


## Type of Change

<!-- Mark the applicable options. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes)
- [x] Documentation update
- [x] Test update

## LoopX Area

<!-- Mark the primary area. Maintainers apply the matching GitHub label. -->

- [x] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [ ] Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
- [ ] Capability or extension (providers, adapters, skills)
- [ ] Public docs or presentation surface (README, protocols, dashboard)
- [ ] Build, packaging, installer, or CI
- [ ] Host or runtime integration

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.