### PR TITLE
feat(materials): read per-entry material cap from catalog constraints

### DIFF
--- a/loopx/capabilities/material_lifecycle/_validation.py
+++ b/loopx/capabilities/material_lifecycle/_validation.py
@@ -91,6 +91,37 @@ def positive_int(value: Any, *, field: str) -> int:
     return normalized
 
 
+DEFAULT_MAX_MATERIALS_PER_ENTRY = 3
+
+
+def material_catalog_entry_limit(
+    *,
+    explicit: int | None,
+    catalog: Mapping[str, Any] | None,
+) -> int:
+    """Resolve the per-entry material cap from an explicit override or catalog.
+
+    The catalog contract reads
+    ``rankings.ranked_entries.constraints.max_materials_per_entry``. When a
+    catalog is supplied but no explicit override is, that constraint is
+    required so builders never silently fall back to a stale default.
+    """
+    if explicit is not None:
+        return positive_int(explicit, field="max_materials_per_entry")
+    if catalog is None:
+        return DEFAULT_MAX_MATERIALS_PER_ENTRY
+    try:
+        constraint = catalog["rankings"]["ranked_entries"]["constraints"][
+            "max_materials_per_entry"
+        ]
+    except (KeyError, TypeError) as exc:
+        raise ValueError(
+            "catalog must define rankings.ranked_entries.constraints."
+            "max_materials_per_entry when max_materials_per_entry is not provided"
+        ) from exc
+    return positive_int(constraint, field="catalog.max_materials_per_entry")
+
+
 def token_list(
     values: Sequence[Any] | None,
     *,

--- a/loopx/capabilities/material_lifecycle/readable_projection.py
+++ b/loopx/capabilities/material_lifecycle/readable_projection.py
@@ -12,6 +12,7 @@ from ._validation import (
     check_record_keys,
     compact_token,
     iso_timestamp,
+    material_catalog_entry_limit,
     packet_ref,
     positive_int,
 )
@@ -344,18 +345,24 @@ def build_material_readable_projection(
     expected_material_refs: Sequence[str],
     canonical_item_count: int,
     top_window_size: int = 30,
-    max_materials_per_entry: int = 3,
+    max_materials_per_entry: int | None = None,
+    catalog: Mapping[str, Any] | None = None,
     document_title: str = "Current Material Priorities",
     intro_lines: Sequence[str] | None = None,
     footer_lines: Sequence[str] | None = None,
     labels: Mapping[str, Any] | None = None,
 ) -> tuple[bytes, dict[str, Any]]:
-    """Render a local-readable view and a content-free public-safe receipt."""
+    """Render a local-readable view and a content-free public-safe receipt.
+
+    When ``max_materials_per_entry`` is omitted, the cap is read from
+    ``catalog["rankings"]["ranked_entries"]["constraints"]``; without a catalog
+    it falls back to the default of 3.
+    """
 
     window_size = positive_int(top_window_size, field="top_window_size")
-    entry_limit = positive_int(
-        max_materials_per_entry,
-        field="max_materials_per_entry",
+    entry_limit = material_catalog_entry_limit(
+        explicit=max_materials_per_entry,
+        catalog=catalog,
     )
     item_count = positive_int(canonical_item_count, field="canonical_item_count")
     if isinstance(expected_material_refs, (str, bytes)) or not isinstance(

--- a/loopx/capabilities/material_lifecycle/rebuild.py
+++ b/loopx/capabilities/material_lifecycle/rebuild.py
@@ -11,6 +11,7 @@ from ._validation import (
     compact_text,
     compact_token,
     iso_timestamp,
+    material_catalog_entry_limit,
     packet_ref,
     positive_int,
     token_list,
@@ -289,15 +290,21 @@ def build_material_ranked_entry_rebuild_plan(
     observed_at: str,
     source_entries: Sequence[Mapping[str, Any]],
     rebuilt_entries: Sequence[Mapping[str, Any]],
-    max_materials_per_entry: int = 3,
+    max_materials_per_entry: int | None = None,
+    catalog: Mapping[str, Any] | None = None,
     top_window_size: int = 30,
     protected_rank_anchors: Sequence[Mapping[str, Any]] | None = None,
 ) -> dict[str, Any]:
-    """Validate a lossless structural rebuild without applying store changes."""
+    """Validate a lossless structural rebuild without applying store changes.
 
-    entry_limit = positive_int(
-        max_materials_per_entry,
-        field="max_materials_per_entry",
+    When ``max_materials_per_entry`` is omitted, the cap is read from
+    ``catalog["rankings"]["ranked_entries"]["constraints"]``; without a catalog
+    it falls back to the default of 3.
+    """
+
+    entry_limit = material_catalog_entry_limit(
+        explicit=max_materials_per_entry,
+        catalog=catalog,
     )
     window_size = positive_int(top_window_size, field="top_window_size")
     normalized_source, source_by_ref, source_material_refs = (

--- a/tests/capabilities/test_material_lifecycle_contracts.py
+++ b/tests/capabilities/test_material_lifecycle_contracts.py
@@ -702,3 +702,121 @@ def test_ranked_entry_rebuild_apply_receipt_requires_rollback() -> None:
             material_ref_count=89,
             top_window_size=30,
         )
+
+
+def catalog_with_entry_limit(limit: int) -> dict[str, object]:
+    return {
+        "rankings": {
+            "ranked_entries": {
+                "constraints": {"max_materials_per_entry": limit},
+            }
+        }
+    }
+
+
+def test_ranked_entry_rebuild_reads_entry_limit_from_catalog() -> None:
+    plan = build_material_ranked_entry_rebuild_plan(
+        goal_id="goal:material-example",
+        plan_id="plan:catalog-limit",
+        inventory_ref=str(inventory_packet()["inventory_ref"]),
+        source_revision="revision:42",
+        observed_at=OBSERVED_AT,
+        source_entries=[
+            {
+                "entry_ref": "entry:source",
+                "rank": 1,
+                "material_refs": [
+                    "material:a",
+                    "material:b",
+                    "material:c",
+                    "material:d",
+                ],
+            }
+        ],
+        rebuilt_entries=[
+            {
+                "source_entry_ref": "entry:source",
+                "target_rank": 1,
+                "material_refs": [
+                    "material:a",
+                    "material:b",
+                    "material:c",
+                    "material:d",
+                ],
+                "reason_code": "preserve_entry",
+            }
+        ],
+        top_window_size=1,
+        catalog=catalog_with_entry_limit(4),
+    )
+
+    assert plan["constraints"]["max_materials_per_entry"] == 4
+    assert plan["verification"]["entry_budget_verified"] is True
+
+
+def test_ranked_entry_rebuild_explicit_limit_overrides_catalog() -> None:
+    source_entries = [
+        {
+            "entry_ref": "entry:source",
+            "rank": 1,
+            "material_refs": [
+                "material:a",
+                "material:b",
+                "material:c",
+                "material:d",
+            ],
+        }
+    ]
+    with pytest.raises(ValueError, match="at most 3"):
+        build_material_ranked_entry_rebuild_plan(
+            goal_id="goal:material-example",
+            plan_id="plan:explicit-override",
+            inventory_ref=str(inventory_packet()["inventory_ref"]),
+            source_revision="revision:42",
+            observed_at=OBSERVED_AT,
+            source_entries=source_entries,
+            rebuilt_entries=[
+                {
+                    "source_entry_ref": "entry:source",
+                    "target_rank": 1,
+                    "material_refs": [
+                        "material:a",
+                        "material:b",
+                        "material:c",
+                        "material:d",
+                    ],
+                    "reason_code": "preserve_entry",
+                }
+            ],
+            top_window_size=1,
+            max_materials_per_entry=3,
+            catalog=catalog_with_entry_limit(5),
+        )
+
+
+def test_ranked_entry_rebuild_requires_catalog_constraint_when_no_override() -> None:
+    with pytest.raises(ValueError, match="max_materials_per_entry"):
+        build_material_ranked_entry_rebuild_plan(
+            goal_id="goal:material-example",
+            plan_id="plan:missing-constraint",
+            inventory_ref=str(inventory_packet()["inventory_ref"]),
+            source_revision="revision:42",
+            observed_at=OBSERVED_AT,
+            source_entries=[
+                {
+                    "entry_ref": "entry:source",
+                    "rank": 1,
+                    "material_refs": ["material:a"],
+                }
+            ],
+            rebuilt_entries=[
+                {
+                    "source_entry_ref": "entry:source",
+                    "target_rank": 1,
+                    "material_refs": ["material:a"],
+                    "reason_code": "preserve_entry",
+                }
+            ],
+            top_window_size=1,
+            catalog={"rankings": {"ranked_entries": {"constraints": {}}}},
+        )

--- a/tests/capabilities/test_material_readable_projection.py
+++ b/tests/capabilities/test_material_readable_projection.py
@@ -185,3 +185,62 @@ def test_readable_projection_rejects_invalid_counts_lines_and_rank_gaps() -> Non
             canonical_item_count=2,
             top_window_size=1,
         )
+
+
+def catalog_with_entry_limit(limit: int) -> dict[str, object]:
+    return {
+        "rankings": {
+            "ranked_entries": {
+                "constraints": {"max_materials_per_entry": limit},
+            }
+        }
+    }
+
+
+def test_readable_projection_reads_entry_limit_from_catalog() -> None:
+    projection, receipt = build_material_readable_projection(
+        goal_id="goal:materials",
+        projection_id="projection:catalog-limit",
+        authority_revision="revision:42",
+        observed_at=OBSERVED_AT,
+        entries=[entry(1, ["m1", "m2", "m3", "m4"])],
+        expected_material_refs=["m1", "m2", "m3", "m4"],
+        canonical_item_count=4,
+        top_window_size=1,
+        catalog=catalog_with_entry_limit(4),
+    )
+
+    rendered = projection.decode("utf-8")
+    assert "Material m4" in rendered
+    assert receipt["constraints"]["max_materials_per_entry"] == 4
+
+
+def test_readable_projection_explicit_limit_overrides_catalog() -> None:
+    with pytest.raises(ValueError, match="between 1 and 3"):
+        build_material_readable_projection(
+            goal_id="goal:materials",
+            projection_id="projection:explicit-override",
+            authority_revision="revision:42",
+            observed_at=OBSERVED_AT,
+            entries=[entry(1, ["m1", "m2", "m3", "m4"])],
+            expected_material_refs=["m1", "m2", "m3", "m4"],
+            canonical_item_count=4,
+            top_window_size=1,
+            max_materials_per_entry=3,
+            catalog=catalog_with_entry_limit(5),
+        )
+
+
+def test_readable_projection_requires_catalog_constraint_when_no_override() -> None:
+    with pytest.raises(ValueError, match="max_materials_per_entry"):
+        build_material_readable_projection(
+            goal_id="goal:materials",
+            projection_id="projection:missing-constraint",
+            authority_revision="revision:42",
+            observed_at=OBSERVED_AT,
+            entries=[entry(1, ["m1"])],
+            expected_material_refs=["m1"],
+            canonical_item_count=1,
+            top_window_size=1,
+            catalog={"rankings": {"ranked_entries": {"constraints": {}}}},
+        )


### PR DESCRIPTION
## Summary

`build_material_ranked_entry_rebuild_plan` and `build_material_readable_projection`
now read the per-entry material cap directly from the material catalog when the
caller does not pass an explicit override:

- New optional `catalog` parameter on both builders.
- `max_materials_per_entry` becomes an optional override (`int | None = None`);
  when omitted, the cap is resolved from
  `catalog["rankings"]["ranked_entries"]["constraints"]["max_materials_per_entry"]`.
- Without a catalog, the existing default of 3 is preserved, so current callers
  are unaffected.
- Supplying a catalog without the constraint now fails fast instead of silently
  falling back to a stale default.

## Validation

- Material lifecycle capability tests: 72 passed, including 6 new tests covering
  catalog resolution, explicit-override precedence, and missing-constraint
  failure for both builders.
- `loopx canary premerge --from-git-diff`: passed (diff hygiene plus py_compile
  on all changed files; surface: python).
- `git diff --check`: clean.

## Self-merge

Narrow, single-purpose, backward-compatible contract change with focused public
smokes; no benchmark, permission, evidence-policy, or private-boundary impact.
Maintainer-authorized self-merge.
