### PR TITLE
fix(control-plane): reject equivalent terminal coverage

### DIFF
--- a/loopx/control_plane/work_items/progress_observation.py
+++ b/loopx/control_plane/work_items/progress_observation.py
@@ -243,6 +243,24 @@ def typed_progress_repeat_trigger(
     }
 
 
+def _has_new_terminal_coverage(
+    current: Mapping[str, Any],
+    prior: Mapping[str, Any] | None,
+) -> bool:
+    """Compare terminal coverage semantics without treating proof churn as novelty."""
+
+    if prior is None:
+        return True
+    result_class = current["result_class"]
+    if result_class != prior.get("result_class"):
+        return True
+    if current.get("coverage_scope_id") != prior.get("coverage_scope_id"):
+        return True
+    if result_class == ProgressResultClass.EXPLORATION_EXHAUSTED.value:
+        return current.get("coverage_complete") != prior.get("coverage_complete")
+    return False
+
+
 def semantic_progress_delta(
     observation: Mapping[str, Any] | None,
     *,
@@ -284,10 +302,15 @@ def semantic_progress_delta(
             current.get("coverage_complete") is True
             and current.get("coverage_scope_id")
             and current.get("evidence_ids")
+            and _has_new_terminal_coverage(current, prior)
         ):
             delta_kinds.append("coverage_backed_exploration_exhausted")
     elif result_class == ProgressResultClass.NO_FOLLOWUP.value:
-        if current.get("coverage_scope_id") and current.get("evidence_ids"):
+        if (
+            current.get("coverage_scope_id")
+            and current.get("evidence_ids")
+            and _has_new_terminal_coverage(current, prior)
+        ):
             delta_kinds.append("coverage_backed_no_followup")
     return {
         "schema_version": "replan_semantic_delta_v0",

--- a/tests/control_plane/test_progress_observation.py
+++ b/tests/control_plane/test_progress_observation.py
@@ -137,6 +137,64 @@ def test_exhaustion_requires_coverage_proof() -> None:
     assert semantic_progress_delta(complete, baseline=None)["delta_kinds"] == [
         "coverage_backed_exploration_exhausted"
     ]
+    assert semantic_progress_delta(complete, baseline=incomplete)["delta_kinds"] == [
+        "coverage_backed_exploration_exhausted"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("result_class", "terminal_fields", "delta_kind"),
+    [
+        (
+            "exploration_exhausted",
+            {"coverage_complete": True},
+            "coverage_backed_exploration_exhausted",
+        ),
+        (
+            "no_followup",
+            {},
+            "coverage_backed_no_followup",
+        ),
+    ],
+)
+def test_terminal_coverage_requires_a_semantically_new_scope(
+    result_class: str,
+    terminal_fields: dict[str, object],
+    delta_kind: str,
+) -> None:
+    baseline = normalize_progress_observation(
+        _observation(
+            result_class=result_class,
+            coverage_scope_id="scope-public-entrypoints",
+            **terminal_fields,
+        )
+    )
+    repeated = normalize_progress_observation(dict(baseline))
+    evidence_only = normalize_progress_observation(
+        _observation(
+            result_class=result_class,
+            coverage_scope_id="scope-public-entrypoints",
+            evidence_ids=["evidence-new-output"],
+            **terminal_fields,
+        )
+    )
+    new_scope = normalize_progress_observation(
+        _observation(
+            result_class=result_class,
+            coverage_scope_id="scope-public-cli",
+            **terminal_fields,
+        )
+    )
+
+    assert baseline["fingerprint"] == repeated["fingerprint"]
+    assert baseline["fingerprint"] != evidence_only["fingerprint"]
+    assert semantic_progress_delta(repeated, baseline=baseline)["accepted"] is False
+    assert (
+        semantic_progress_delta(evidence_only, baseline=baseline)["accepted"] is False
+    )
+    assert semantic_progress_delta(new_scope, baseline=baseline)["delta_kinds"] == [
+        delta_kind
+    ]
 
 
 def test_host_projects_evidence_context_and_minimal_action_packet() -> None:

--- a/tests/control_plane/test_progress_observation.py
+++ b/tests/control_plane/test_progress_observation.py
@@ -197,6 +197,48 @@ def test_terminal_coverage_requires_a_semantically_new_scope(
     ]
 
 
+def test_terminal_result_class_change_is_a_semantic_delta() -> None:
+    baseline = normalize_progress_observation(
+        _observation(
+            result_class="exploration_exhausted",
+            coverage_scope_id="scope-public-entrypoints",
+            coverage_complete=True,
+        )
+    )
+    no_followup = normalize_progress_observation(
+        _observation(
+            result_class="no_followup",
+            coverage_scope_id="scope-public-entrypoints",
+        )
+    )
+
+    assert semantic_progress_delta(no_followup, baseline=baseline)["delta_kinds"] == [
+        "coverage_backed_no_followup"
+    ]
+
+
+def test_no_followup_ignores_coverage_complete_churn() -> None:
+    baseline = normalize_progress_observation(
+        _observation(
+            result_class="no_followup",
+            coverage_scope_id="scope-public-entrypoints",
+            coverage_complete=False,
+        )
+    )
+    coverage_flag_only = normalize_progress_observation(
+        _observation(
+            result_class="no_followup",
+            coverage_scope_id="scope-public-entrypoints",
+            coverage_complete=True,
+        )
+    )
+
+    assert (
+        semantic_progress_delta(coverage_flag_only, baseline=baseline)["accepted"]
+        is False
+    )
+
+
 def test_host_projects_evidence_context_and_minimal_action_packet() -> None:
     runs = [
         _run("2026-08-13T01:01:00Z", _observation()),


### PR DESCRIPTION
## Summary

- compare terminal coverage by its typed semantic identity instead of the full observation fingerprint
- reject repeated or evidence-only `exploration_exhausted` / `no_followup` observations
- preserve valid progress for a new coverage scope, a changed terminal result class, and incomplete-to-complete exhaustion

Evidence IDs remain required proof, but rotating them no longer makes equivalent terminal coverage novel. The observation schema and returned delta contract are unchanged.

## Issue Or Task

- Closes #3191
- Contributor task ID: GH-C91

## Validation

- [x] `.venv/bin/python -m py_compile loopx/control_plane/work_items/progress_observation.py tests/control_plane/test_progress_observation.py`
- [x] `.venv/bin/python -m pytest -q tests/control_plane/test_progress_observation.py tests/control_plane/test_replan_host_context_projection.py tests/control_plane/test_replan_semantic_action_behavior.py tests/control_plane/test_replan_novelty_policy.py` — 34 passed
- [x] `.venv/bin/python examples/control_plane/quota-replan-decision-plane-smoke.py`
- [x] `loopx check` over both changed paths plus `docs/status-data-contract.md`, `docs/reference/protocols/agent-scoped-evidence-ledger-v0.md`, and `CONTRIBUTOR_TASKS.md` — 0 errors; only expected missing local registry warnings
- [x] `loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard` — 4 direct checks and 9 selected canaries/smokes passed; 0 failures, skips, or manual holds
- [x] `git diff --check origin/main...HEAD`
- [ ] GitHub Python Tests — fork workflow is awaiting maintainer approval; this supplies the repository-wide pinned ruff, mypy, pytest, and coverage gate

The focused mutation guards prove that exact repeats and evidence-only churn are rejected; a genuinely new scope, a changed typed terminal outcome, and incomplete-to-complete exhaustion remain valid; and `coverage_complete` churn is ignored for `no_followup`. A standalone local ruff/mypy bootstrap was not counted because its isolated tool download did not complete; it changed no tracked files, and the required pinned versions remain covered by GitHub Python Tests.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] Test update

## LoopX Area

- [x] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [ ] Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
- [ ] Capability or extension (providers, adapters, skills)
- [ ] Public docs or presentation surface (README, protocols, dashboard)
- [ ] Build, packaging, installer, or CI
- [ ] Host or runtime integration

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
