### PR TITLE
fix(turn): project durable completion continuation in built-in CLI provider

### DIFF
--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
@@ -577,6 +577,14 @@ only the `load` / `compare_and_put` provider. This prerequisite does not create
 a generic storage abstraction over registry, run history, quota, scheduler, or
 evidence; those ledgers retain the owners defined in Section 3.
 
+Durable completion continuation read-back
+(`durable_completion.py`: `read_persisted_todo_record` /
+`project_durable_completion_outcome`) is a provider read point: it re-reads
+the persisted lifecycle record (Markdown first, event projection fallback)
+after the completion write and before settlement. Once a remote provider
+becomes canonical, this seam flips to provider-first without changing the
+typed outcome contract below.
+
 ### P0: contract and deterministic proof
 
 - this ownership matrix and explicit shared-mode boundary;
@@ -593,6 +601,10 @@ evidence; those ledgers retain the owners defined in Section 3.
 
 - lease renewal, explicit release, expired-lease reclaim, and stale-fence
   writeback rejection, all required before production shared mode;
+- durable completion continuation projection
+  (`successor | no_followup | active_goal`) with fail-closed contradiction
+  rules (`no_followup` + successors, dangling declared successor), reproduced
+  by the provider with identical semantics;
 - atomic `complete_todo_with_successor` and accepted evidence pointers;
 - transfer and restricted delegated assignment;
 - delivery/wake integration through Agent IM;

--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
@@ -503,6 +503,13 @@ gate/dependency ref、claim/lease field 与按 privacy class 标注的 opaque po
 history、quota、scheduler 或 evidence 的通用存储抽象，这些账继续遵守第 3 节的 owner
 边界。
 
+完成续接（continuation）的持久化读回
+（`durable_completion.py`：`read_persisted_todo_record` /
+`project_durable_completion_outcome`）是一个 provider read point：它在完成写入之后、
+settlement 之前重新读取已落盘的 lifecycle record（Markdown 优先，event projection
+兜底）。一旦远端 provider 成为 canonical，这个 seam 翻转为 provider-first，且不改变
+下述 typed outcome 合同。
+
 ### P0：合同与 deterministic proof
 
 - 本 ownership matrix 与显式 shared-mode boundary；
@@ -518,6 +525,10 @@ history、quota、scheduler 或 evidence 的通用存储抽象，这些账继续
 
 - Lease renewal、显式 release、过期 lease reclaim 与 stale-fence writeback rejection；
   production shared mode 前必须完成这些能力；
+- durable completion continuation projection
+  （`successor | no_followup | active_goal`），带 fail-closed 矛盾规则
+  （`no_followup` + successors、悬挂的 declared successor），并由 provider 以相同
+  语义复现；
 - atomic `complete_todo_with_successor` 与 accepted evidence pointer；
 - transfer 与受限 delegated assignment；
 - 经 Agent IM 的 delivery/wake integration；

--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -13,6 +13,10 @@ from ..control_plane.quota.turn_envelope import build_turn_envelope
 from ..control_plane.runtime.status_projection_cache import (
     resolve_status_projection_cache_runtime_root,
 )
+from ..control_plane.todos.durable_completion import (
+    project_durable_completion_outcome,
+    read_persisted_todo_record,
+)
 from ..control_plane.scheduler.execution_context import (
     scheduler_execution_context_for_turn,
 )
@@ -523,6 +527,38 @@ def handle_turn_command(
                     project=None,
                     dry_run=False,
                 )
+                # Project the continuation the Todo lifecycle durably recorded,
+                # never a host-normalized continuation. Contradictory or
+                # dangling durable state fails closed before any further
+                # writeback so the typed settlement sees the truthful outcome.
+                state_file = completion.get("state_file")
+                if not isinstance(state_file, str) or not state_file:
+                    return {
+                        "ok": False,
+                        "appended": False,
+                        "reason": (
+                            "validated completion lifecycle did not report its "
+                            "durable Todo state file"
+                        ),
+                    }
+                try:
+                    durable_todo, existing_todo_ids = read_persisted_todo_record(
+                        Path(state_file),
+                        todo_id=todo_id,
+                        registry_path=registry_path,
+                        goal_id=args.goal_id,
+                    )
+                    completion_outcome = project_durable_completion_outcome(
+                        todo=durable_todo,
+                        expected_todo_id=todo_id,
+                        existing_todo_ids=existing_todo_ids,
+                    )
+                except ValueError as exc:
+                    return {
+                        "ok": False,
+                        "appended": False,
+                        "reason": f"durable completion projection failed: {exc}",
+                    }
                 refresh = writeback(
                     result,
                     completion_todo_id=todo_id,
@@ -536,10 +572,7 @@ def handle_turn_command(
                         refresh.get("appended")
                     ),
                     "classification": refresh.get("classification"),
-                    "completion": {
-                        "todo_id": completion.get("todo_id"),
-                        "continuation": "active_goal",
-                    },
+                    "completion": completion_outcome,
                 }
 
             def current_status() -> dict[str, object]:

--- a/loopx/control_plane/todos/durable_completion.py
+++ b/loopx/control_plane/todos/durable_completion.py
@@ -1,0 +1,163 @@
+"""Project the durable completion continuation for the built-in Turn CLI provider.
+
+``loopx turn run-once`` completes the selected Todo through
+:func:`loopx.todos.complete_goal_todo` and must report the continuation the Todo
+lifecycle durably recorded (``successor``, ``no_followup``, or ``active_goal``)
+instead of normalizing every completion to ``active_goal``.
+
+Projection reads the persisted Todo lifecycle record only; it never trusts host
+result JSON and never creates successors from host text. Contradictory or
+dangling durable state fails closed so the typed settlement never sees a
+fabricated continuation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Collection
+from pathlib import Path
+from typing import Any, Mapping
+
+from .active_state_editing import (
+    TODO_SECTION_HEADINGS,
+    find_todo_block,
+    section_bounds,
+    todo_blocks,
+)
+from .contract import (
+    TODO_STATUS_DONE,
+    normalize_todo_id,
+    normalize_todo_id_list,
+    normalize_todo_no_followup,
+    normalize_todo_status,
+)
+from .event_writeback import event_projection_todo_context
+
+
+def read_persisted_todo_record(
+    state_file: Path,
+    *,
+    todo_id: str,
+    registry_path: Path | None = None,
+    goal_id: str | None = None,
+) -> tuple[dict[str, Any], set[str]]:
+    """Read one durable Todo record and the goal-state Todo id universe.
+
+    Returns the parsed Todo record for ``todo_id`` together with the set of
+    Todo ids present in the persisted goal state. Like
+    ``complete_goal_todo``, the record is looked up in the active Markdown
+    blocks first and falls back to the event projection for event-sourced
+    goals. Raises ``ValueError`` when the Todo cannot be located in the
+    durable lifecycle, so the caller can fail closed instead of projecting a
+    fabricated continuation.
+    """
+    lines = state_file.read_text(encoding="utf-8").splitlines()
+    block: dict[str, Any] | None = None
+    match = find_todo_block(lines, todo_id=todo_id)
+    if match is not None:
+        _role, _section, _start, _end, block = match
+    existing_todo_ids: set[str] = set()
+    for candidate_role in TODO_SECTION_HEADINGS:
+        bounds = section_bounds(lines, candidate_role)
+        if bounds is None:
+            continue
+        start, end, _heading = bounds
+        for item in todo_blocks(lines, start, end, role=candidate_role):
+            item_todo_id = normalize_todo_id(item.get("todo_id"))
+            if item_todo_id:
+                existing_todo_ids.add(item_todo_id)
+    if block is None and registry_path is not None and goal_id is not None:
+        context = event_projection_todo_context(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            state_path=state_file,
+            todo_id=todo_id,
+            role=None,
+        )
+        if context is not None:
+            block = dict(context["item"])
+            for candidate_role in ("user", "agent"):
+                summary = context["fields"].get(f"{candidate_role}_todos")
+                items = summary.get("items") if isinstance(summary, dict) else []
+                for item in items if isinstance(items, list) else []:
+                    if not isinstance(item, dict):
+                        continue
+                    item_todo_id = normalize_todo_id(item.get("todo_id"))
+                    if item_todo_id:
+                        existing_todo_ids.add(item_todo_id)
+    if block is None:
+        normalized_todo_id = normalize_todo_id(todo_id) or todo_id
+        raise ValueError(
+            f"durable completion todo_id {normalized_todo_id!r} was not found "
+            "in persisted Todo lifecycle state"
+        )
+    return block, existing_todo_ids
+
+
+def project_durable_completion_outcome(
+    *,
+    todo: Mapping[str, Any],
+    expected_todo_id: str,
+    existing_todo_ids: Collection[str] | None = None,
+) -> dict[str, Any]:
+    """Project the typed completion continuation recorded by the Todo lifecycle.
+
+    ``todo`` is the durable Todo record re-read from persisted lifecycle state
+    after ``complete_goal_todo``. The outcome is one of:
+
+    - ``successor`` when the Todo durably declares ``successor_todo_ids``;
+      every declared successor must exist in the goal state
+      (``existing_todo_ids``) or projection fails closed;
+    - ``no_followup`` when the Todo durably records ``no_followup``;
+    - ``active_goal`` otherwise.
+
+    Raises ``ValueError`` (fail closed) when the durable record contradicts
+    itself (both ``no_followup`` and successors), when a declared successor is
+    dangling, when the Todo id does not match ``expected_todo_id``, or when the
+    Todo is not durably done.
+    """
+    normalized_expected_todo_id = normalize_todo_id(expected_todo_id)
+    if not normalized_expected_todo_id:
+        raise ValueError("durable completion requires a public Todo id")
+    durable_todo_id = normalize_todo_id(todo.get("todo_id"))
+    if durable_todo_id != normalized_expected_todo_id:
+        raise ValueError(
+            "durable completion todo_id does not match the selected Todo"
+        )
+    if normalize_todo_status(todo.get("status")) != TODO_STATUS_DONE:
+        raise ValueError(
+            "durable completion requires the selected Todo to be durably done"
+        )
+    successor_todo_ids = normalize_todo_id_list(todo.get("successor_todo_ids"))
+    no_followup = normalize_todo_no_followup(todo.get("no_followup"))
+    if no_followup is True:
+        if successor_todo_ids:
+            raise ValueError(
+                "durable completion records both no_followup and "
+                "successor_todo_ids"
+            )
+        return {
+            "todo_id": normalized_expected_todo_id,
+            "continuation": "no_followup",
+        }
+    if successor_todo_ids:
+        if existing_todo_ids is not None:
+            existing = set(existing_todo_ids)
+            missing_todo_ids = [
+                successor_todo_id
+                for successor_todo_id in successor_todo_ids
+                if successor_todo_id not in existing
+            ]
+            if missing_todo_ids:
+                raise ValueError(
+                    "durable completion declares missing successor Todo ids: "
+                    + ", ".join(missing_todo_ids)
+                )
+        return {
+            "todo_id": normalized_expected_todo_id,
+            "continuation": "successor",
+            "successor_todo_ids": successor_todo_ids,
+        }
+    return {
+        "todo_id": normalized_expected_todo_id,
+        "continuation": "active_goal",
+    }

--- a/loopx/control_plane/turn_driver/executor.py
+++ b/loopx/control_plane/turn_driver/executor.py
@@ -1047,7 +1047,14 @@ def _typed_settlement_stage(
                 return {
                     "ok": False,
                     "appended": False,
-                    "reason": "todo lifecycle adapter returned an invalid completion outcome",
+                    "reason": str(
+                        callback_payload.get("reason")
+                        or callback_payload.get("error")
+                        or (
+                            "todo lifecycle adapter returned an invalid "
+                            "completion outcome"
+                        )
+                    ),
                 }
             return {
                 **callback_payload,

--- a/tests/control_plane/test_durable_completion_projection.py
+++ b/tests/control_plane/test_durable_completion_projection.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from loopx.control_plane.todos.durable_completion import (
+    project_durable_completion_outcome,
+    read_persisted_todo_record,
+)
+from loopx.event_sourced_state import (
+    TODO_ADDED,
+    TODO_COMPLETED,
+    AppendOnlyStateEventStore,
+    make_state_event,
+)
+
+TODO_DONE = {
+    "todo_id": "todo_fixture0001",
+    "status": "done",
+}
+
+
+def test_projects_active_goal_when_no_durable_continuation_recorded() -> None:
+    outcome = project_durable_completion_outcome(
+        todo=TODO_DONE,
+        expected_todo_id="todo_fixture0001",
+    )
+    assert outcome == {
+        "todo_id": "todo_fixture0001",
+        "continuation": "active_goal",
+    }
+
+
+def test_projects_declared_successor_continuation() -> None:
+    todo = {
+        **TODO_DONE,
+        "successor_todo_ids": ["todo_fixture0002", "todo_fixture0003"],
+    }
+    outcome = project_durable_completion_outcome(
+        todo=todo,
+        expected_todo_id="todo_fixture0001",
+        existing_todo_ids={"todo_fixture0001", "todo_fixture0002", "todo_fixture0003"},
+    )
+    assert outcome == {
+        "todo_id": "todo_fixture0001",
+        "continuation": "successor",
+        "successor_todo_ids": ["todo_fixture0002", "todo_fixture0003"],
+    }
+
+
+def test_projects_durable_no_followup_continuation() -> None:
+    outcome = project_durable_completion_outcome(
+        todo={**TODO_DONE, "no_followup": True},
+        expected_todo_id="todo_fixture0001",
+    )
+    assert outcome == {
+        "todo_id": "todo_fixture0001",
+        "continuation": "no_followup",
+    }
+
+
+def test_no_followup_without_existing_ids_needs_no_successor_verification() -> None:
+    outcome = project_durable_completion_outcome(
+        todo={**TODO_DONE, "no_followup": True},
+        expected_todo_id="todo_fixture0001",
+        existing_todo_ids=set(),
+    )
+    assert outcome["continuation"] == "no_followup"
+
+
+def test_fails_closed_on_no_followup_and_successor_contradiction() -> None:
+    todo = {
+        **TODO_DONE,
+        "no_followup": True,
+        "successor_todo_ids": ["todo_fixture0002"],
+    }
+    with pytest.raises(
+        ValueError,
+        match="both no_followup and successor_todo_ids",
+    ):
+        project_durable_completion_outcome(
+            todo=todo,
+            expected_todo_id="todo_fixture0001",
+            existing_todo_ids={"todo_fixture0002"},
+        )
+
+
+def test_fails_closed_on_dangling_declared_successor() -> None:
+    todo = {
+        **TODO_DONE,
+        "successor_todo_ids": ["todo_fixture0002", "todo_missing999"],
+    }
+    with pytest.raises(
+        ValueError,
+        match="declares missing successor Todo ids: todo_missing999",
+    ):
+        project_durable_completion_outcome(
+            todo=todo,
+            expected_todo_id="todo_fixture0001",
+            existing_todo_ids={"todo_fixture0001", "todo_fixture0002"},
+        )
+
+
+def test_fails_closed_when_durable_todo_id_mismatches_selected() -> None:
+    with pytest.raises(
+        ValueError,
+        match="does not match the selected Todo",
+    ):
+        project_durable_completion_outcome(
+            todo={**TODO_DONE, "todo_id": "todo_fixture0009"},
+            expected_todo_id="todo_fixture0001",
+        )
+
+
+def test_fails_closed_when_todo_is_not_durably_done() -> None:
+    with pytest.raises(
+        ValueError,
+        match="durably done",
+    ):
+        project_durable_completion_outcome(
+            todo={"todo_id": "todo_fixture0001", "status": "open"},
+            expected_todo_id="todo_fixture0001",
+        )
+
+
+def test_read_persisted_todo_record_projects_declared_successor(
+    tmp_path: Path,
+) -> None:
+    state_file = tmp_path / "ACTIVE_GOAL_STATE.md"
+    state_file.write_text(
+        "\n".join(
+            [
+                "---",
+                "status: active",
+                "updated_at: 2026-01-01T00:00:00+00:00",
+                "---",
+                "",
+                "# Fixture",
+                "",
+                "## Agent Todo",
+                "",
+                "- [x] Advance one public fixture.",
+                "  <!-- loopx:todo todo_id=todo_fixture0001 status=done task_class=advancement_task successor_todo_ids=todo_fixture0002 -->",
+                "- [ ] Continue the public fixture.",
+                "  <!-- loopx:todo todo_id=todo_fixture0002 status=open task_class=advancement_task -->",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    todo, existing_todo_ids = read_persisted_todo_record(
+        state_file,
+        todo_id="todo_fixture0001",
+    )
+    assert existing_todo_ids == {"todo_fixture0001", "todo_fixture0002"}
+    outcome = project_durable_completion_outcome(
+        todo=todo,
+        expected_todo_id="todo_fixture0001",
+        existing_todo_ids=existing_todo_ids,
+    )
+    assert outcome == {
+        "todo_id": "todo_fixture0001",
+        "continuation": "successor",
+        "successor_todo_ids": ["todo_fixture0002"],
+    }
+
+
+def test_read_persisted_todo_record_fails_closed_when_todo_is_missing(
+    tmp_path: Path,
+) -> None:
+    state_file = tmp_path / "ACTIVE_GOAL_STATE.md"
+    state_file.write_text(
+        "\n".join(
+            [
+                "---",
+                "status: active",
+                "---",
+                "",
+                "## Agent Todo",
+                "",
+                "- [x] Some other fixture.",
+                "  <!-- loopx:todo todo_id=todo_other0001 status=done -->",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(
+        ValueError,
+        match="was not found in persisted Todo lifecycle state",
+    ):
+        read_persisted_todo_record(
+            state_file,
+            todo_id="todo_fixture0001",
+        )
+
+
+def test_read_persisted_todo_record_falls_back_to_event_projection(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    state_file = repo / "ACTIVE_GOAL_STATE.md"
+    state_file.write_text(
+        "\n".join(
+            [
+                "---",
+                "status: active",
+                "updated_at: 2026-01-01T00:00:00+00:00",
+                "---",
+                "",
+                "# Fixture",
+                "",
+                "## Agent Todo",
+                "",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    # The event-sourced Todo lives only in the event log, mirroring the
+    # completion payload shape written by complete_event_projected_goal_todo.
+    goal_id = "fixture-goal"
+    events = [
+        make_state_event(
+            event_id="add-fixture-1",
+            goal_id=goal_id,
+            event_type=TODO_ADDED,
+            refs={"todo_id": "todo_fixture0001"},
+            payload={
+                "role": "agent",
+                "priority": "P0",
+                "title": "Advance one public fixture.",
+                "text": "Advance one public fixture.",
+                "planner_order": 1,
+                "task_class": "advancement_task",
+            },
+        ),
+        make_state_event(
+            event_id="complete-fixture-1",
+            goal_id=goal_id,
+            event_type=TODO_COMPLETED,
+            refs={"todo_id": "todo_fixture0001"},
+            payload={"no_followup": "true"},
+        ),
+    ]
+    AppendOnlyStateEventStore(repo / "events.jsonl").append_many(events)
+    registry = tmp_path / "registry.global.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "common_runtime_root": str(tmp_path / "runtime"),
+                "goals": [
+                    {
+                        "id": goal_id,
+                        "domain": "fixture",
+                        "status": "active",
+                        "repo": str(repo),
+                        "state_file": state_file.name,
+                        "adapter": {"kind": "fixture_v0"},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    todo, existing_todo_ids = read_persisted_todo_record(
+        state_file,
+        todo_id="todo_fixture0001",
+        registry_path=registry,
+        goal_id=goal_id,
+    )
+    assert existing_todo_ids == {"todo_fixture0001"}
+    outcome = project_durable_completion_outcome(
+        todo=todo,
+        expected_todo_id="todo_fixture0001",
+        existing_todo_ids=existing_todo_ids,
+    )
+    assert outcome == {
+        "todo_id": "todo_fixture0001",
+        "continuation": "no_followup",
+    }

--- a/tests/test_loopx_turn_driver.py
+++ b/tests/test_loopx_turn_driver.py
@@ -645,12 +645,29 @@ def test_scheduler_followup_binding_preserves_turn_lineage(
     assert ack_hint["route_binding"]["source"] == "loopx_turn_plan"
 
 
-def _write_live_fixture(root: Path) -> tuple[Path, Path, Path]:
+def _write_live_fixture(
+    root: Path,
+    *,
+    todo_metadata_extra: str = "",
+    extra_agent_todo_lines: tuple[str, ...] = (),
+) -> tuple[Path, Path, Path]:
     project = root / "project"
     runtime = root / "runtime"
     runtime.mkdir(parents=True)
     state = project / ".codex" / "goals" / "loopx-turn-fixture" / "ACTIVE_GOAL_STATE.md"
     state.parent.mkdir(parents=True)
+    agent_todo_lines = [
+        "- [ ] [P0] Advance one public fixture.",
+        "  <!-- loopx:todo todo_id=todo_fixture0001 status=open "
+        "task_class=advancement_task action_kind=fixture claimed_by=codex-fixture "
+        "priority=P0"
+        + (f" {todo_metadata_extra}" if todo_metadata_extra else "")
+        + " -->",
+        "",
+    ]
+    if extra_agent_todo_lines:
+        agent_todo_lines.extend(extra_agent_todo_lines)
+        agent_todo_lines.append("")
     state.write_text(
         "\n".join(
             [
@@ -663,9 +680,7 @@ def _write_live_fixture(root: Path) -> tuple[Path, Path, Path]:
                 "",
                 "## Agent Todo",
                 "",
-                "- [ ] [P0] Advance one public fixture.",
-                "  <!-- loopx:todo todo_id=todo_fixture0001 status=open task_class=advancement_task action_kind=fixture claimed_by=codex-fixture priority=P0 -->",
-                "",
+                *agent_todo_lines,
             ]
         ),
         encoding="utf-8",
@@ -1312,6 +1327,249 @@ raise SystemExit(0 if artifact.read_text(encoding="utf-8") == "completed" else 7
     assert replayed_exit_code == 0, replayed
     assert replayed["replayed"] is True
     assert not any(replayed["effects"].values())
+
+
+def _completion_host_and_validation_scripts() -> tuple[str, str]:
+    host_script = """
+import json
+import pathlib
+import sys
+request = json.load(sys.stdin)
+pathlib.Path("completion-artifact.txt").write_text("completed", encoding="utf-8")
+json.dump({
+    "schema_version": "loopx_turn_result_v0",
+    "turn_key": request["turn_key"],
+    "result_kind": "validated_completion",
+    "completed_phases": ["host_execute", "typed_result"],
+    "classification": "fixture_completion",
+    "recommended_action": "Refresh the active goal after completion.",
+    "next_action": "Select the next Todo from a fresh decision.",
+    "delivery_batch_scale": "implementation",
+    "delivery_outcome": "outcome_progress",
+    "vision_unchanged_reason": "The active goal may have further work.",
+    "summary": "One public fixture completed."
+}, sys.stdout)
+"""
+    validation_script = """
+import json
+import pathlib
+import sys
+json.load(sys.stdin)
+artifact = pathlib.Path("completion-artifact.txt")
+raise SystemExit(0 if artifact.read_text(encoding="utf-8") == "completed" else 7)
+"""
+    return host_script, validation_script
+
+
+def _turn_run_once_completion_argv(
+    project: Path,
+    runtime: Path,
+    registry: Path,
+    host_script: str,
+    validation_script: str,
+) -> list[str]:
+    return [
+        "--registry",
+        str(registry),
+        "--runtime-root",
+        str(runtime),
+        "--format",
+        "json",
+        "turn",
+        "run-once",
+        "--goal-id",
+        "loopx-turn-fixture",
+        "--agent-id",
+        "codex-fixture",
+        "--project",
+        str(project),
+        "--host-adapter-command-json",
+        json.dumps([sys.executable, "-c", host_script]),
+        "--validation-command-json",
+        json.dumps([sys.executable, "-c", validation_script]),
+        "--scan-root",
+        str(project),
+        "--no-global-sync",
+        "--execute",
+    ]
+
+
+def _turn_journal(runtime: Path) -> dict[str, object]:
+    journal_path = next(
+        (runtime / "goals" / "loopx-turn-fixture" / "turns").glob("*.json")
+    )
+    return json.loads(journal_path.read_text(encoding="utf-8"))
+
+
+def test_turn_run_once_cli_projects_declared_successor_continuation(
+    tmp_path: Path,
+) -> None:
+    project, runtime, registry = _write_live_fixture(
+        tmp_path,
+        todo_metadata_extra="successor_todo_ids=todo_fixture0002",
+        extra_agent_todo_lines=(
+            "- [ ] [P2] Continue the public fixture.",
+            "  <!-- loopx:todo todo_id=todo_fixture0002 status=open "
+            "task_class=advancement_task priority=P2 -->",
+        ),
+    )
+    host_project = tmp_path / "isolated-host-workspace"
+    host_project.mkdir()
+    host_script, validation_script = _completion_host_and_validation_scripts()
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(
+            _turn_run_once_completion_argv(
+                host_project,
+                runtime,
+                registry,
+                host_script,
+                validation_script,
+            )
+        )
+
+    payload = json.loads(output.getvalue())
+    assert exit_code == 0, payload
+    assert payload["status"] == "committed"
+    assert _turn_journal(runtime)["writeback"]["completion"] == {
+        "todo_id": "todo_fixture0001",
+        "continuation": "successor",
+        "successor_todo_ids": ["todo_fixture0002"],
+    }
+
+
+def test_turn_run_once_cli_projects_durable_no_followup_continuation(
+    tmp_path: Path,
+) -> None:
+    project, runtime, registry = _write_live_fixture(
+        tmp_path,
+        todo_metadata_extra="no_followup=true",
+    )
+    host_project = tmp_path / "isolated-host-workspace"
+    host_project.mkdir()
+    host_script, validation_script = _completion_host_and_validation_scripts()
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(
+            _turn_run_once_completion_argv(
+                host_project,
+                runtime,
+                registry,
+                host_script,
+                validation_script,
+            )
+        )
+
+    payload = json.loads(output.getvalue())
+    assert exit_code == 0, payload
+    assert payload["status"] == "committed"
+    assert _turn_journal(runtime)["writeback"]["completion"] == {
+        "todo_id": "todo_fixture0001",
+        "continuation": "no_followup",
+    }
+
+
+def test_turn_run_once_cli_fails_closed_on_dangling_declared_successor(
+    tmp_path: Path,
+) -> None:
+    project, runtime, registry = _write_live_fixture(
+        tmp_path,
+        todo_metadata_extra="successor_todo_ids=todo_missing999",
+    )
+    host_project = tmp_path / "isolated-host-workspace"
+    host_project.mkdir()
+    host_script, validation_script = _completion_host_and_validation_scripts()
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(
+            _turn_run_once_completion_argv(
+                host_project,
+                runtime,
+                registry,
+                host_script,
+                validation_script,
+            )
+        )
+
+    payload = json.loads(output.getvalue())
+    assert exit_code == 1, payload
+    assert payload["result_kind"] == "writeback_failed"
+    assert payload["receipt"]["failed_phase"] == "durable_writeback"
+    failure = payload["settlement_result"]["failure"]
+    assert failure["kind"] == "writeback_rejected"
+    assert "missing successor Todo ids: todo_missing999" in failure["reason"]
+    assert payload["effects"] == {
+        "host_invoked": True,
+        "state_written": False,
+        "quota_spent": False,
+        "scheduler_acknowledged": False,
+    }
+
+
+def test_turn_run_once_cli_replays_declared_successor_after_interruption(
+    tmp_path: Path,
+) -> None:
+    project, runtime, registry = _write_live_fixture(
+        tmp_path,
+        todo_metadata_extra="successor_todo_ids=todo_fixture0002",
+        extra_agent_todo_lines=(
+            "- [ ] [P2] Continue the public fixture.",
+            "  <!-- loopx:todo todo_id=todo_fixture0002 status=open "
+            "task_class=advancement_task priority=P2 -->",
+        ),
+    )
+    host_project = tmp_path / "isolated-host-workspace"
+    host_project.mkdir()
+    host_script, validation_script = _completion_host_and_validation_scripts()
+    argv = _turn_run_once_completion_argv(
+        host_project,
+        runtime,
+        registry,
+        host_script,
+        validation_script,
+    )
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(argv)
+    payload = json.loads(output.getvalue())
+    assert exit_code == 0, payload
+
+    journal_path = next(
+        (runtime / "goals" / "loopx-turn-fixture" / "turns").glob("*.json")
+    )
+    journal = json.loads(journal_path.read_text(encoding="utf-8"))
+    # Simulate a process interruption after the durable writeback committed but
+    # before quota spend settled: the retry must re-project the same durable
+    # continuation from the persisted Todo lifecycle, not a normalized one.
+    journal["status"] = "in_progress"
+    journal["completed_phases"] = [
+        "host_execute",
+        "typed_result",
+        "validation",
+        "durable_writeback",
+    ]
+    for key in ("receipt", "quota_spend", "settlement_result", "scheduler", "reason"):
+        journal.pop(key, None)
+    journal_path.write_text(json.dumps(journal), encoding="utf-8")
+
+    resumed_output = io.StringIO()
+    with contextlib.redirect_stdout(resumed_output):
+        resumed_exit_code = cli_main(
+            [
+                *argv[:-1],
+                "--resume-turn-key",
+                payload["resume_turn_key"],
+                "--execute",
+            ]
+        )
+    resumed = json.loads(resumed_output.getvalue())
+    assert resumed_exit_code == 0, resumed
+    assert resumed["status"] == "committed"
+    assert _turn_journal(runtime)["writeback"]["completion"] == {
+        "todo_id": "todo_fixture0001",
+        "continuation": "successor",
+        "successor_todo_ids": ["todo_fixture0002"],
+    }
 
 
 def test_turn_run_once_commits_independently_validated_progress(


### PR DESCRIPTION
Closes #3045

## Problem

`loopx turn run-once`'s built-in `completion_writeback` completed the selected Todo through `complete_goal_todo(...)` but always echoed `"continuation": "active_goal"` (`loopx/cli_commands/turn.py`). The governed Todo lifecycle already supports and validates `successor | active_goal | no_followup`, so the `successor`/`no_followup` outcomes were unreachable through the CLI completion path — a provider-state projection gap, confirmed by the maintainer in [#3045](https://github.com/huangruiteng/loopx/issues/3045#issuecomment-5289754594).

## Change (provider-only, additive)

- **Pure durable-outcome projector** — `loopx/control_plane/todos/durable_completion.py`:
  - `read_persisted_todo_record` re-reads the persisted Todo lifecycle record after `complete_goal_todo` (Markdown block first, event projection fallback for event-sourced goals), plus the goal-state Todo-id universe;
  - `project_durable_completion_outcome` maps the durable record to the typed outcome: `successor` only for declared successor ids that exist in the goal state, `no_followup` only when durably recorded, otherwise `active_goal`. Contradictory (`no_followup` + successors) or dangling (missing declared successor) state **fails closed** with `ValueError`.
- **CLI provider** — `completion_writeback` derives the continuation from the persisted record, never from host result JSON; projection failures return a fail-closed payload before the refresh writeback, so the turn settles `writeback_failed` with no quota spend.
- **Settlement seam** — `executor.py` now surfaces the provider's fail-closed reason in the typed settlement (`writeback_rejected`) instead of a generic string.

## Non-goals (kept)

- No new schema, Todo/event store, or scheduler; no successor creation from Host text.
- `completion_turn_key` replay fence (#3049) and settlement ordering preserved.
- Goal termination stays downstream: `decide_loop_disposition` still requires fresh terminal Goal frontier evidence for `no_followup` and declared-successor matching for `successor`.

## Validation

- New unit tests `tests/control_plane/test_durable_completion_projection.py` (11): three continuations, no_followup+successor contradiction, dangling successor, todo-id mismatch, not-durably-done, record read round-trip, event-projection fallback.
- New CLI end-to-end tests in `tests/test_loopx_turn_driver.py` (4): successor projection, no_followup projection, dangling fail-closed writeback (no spend), and idempotent re-projection after a simulated interruption between durable writeback and quota spend.
- Regression: 234 turn/todo tests pass; `ruff check` clean on changed files; `loopx check` public-boundary scan clean on the 5 changed paths.
- Note: repo-wide `mypy` is not clean on `main` (pre-existing); the new module has zero direct mypy errors and no new errors at changed lines.

Changed surfaces: `loopx/cli_commands/turn.py`, `loopx/control_plane/todos/durable_completion.py`, `loopx/control_plane/turn_driver/executor.py`, `tests/control_plane/test_durable_completion_projection.py`, `tests/test_loopx_turn_driver.py`.