### PR TITLE
feat(todos): auto-acquire completion key for hard_lease user gates

### DIFF
--- a/loopx/control_plane/work_items/task_lease.py
+++ b/loopx/control_plane/work_items/task_lease.py
@@ -19,6 +19,7 @@ from ...paths import resolve_runtime_root
 from ..runtime.time import now_utc as runtime_now_utc
 from ..runtime.time import parse_timestamp, utc_isoformat
 from ..todos.contract import (
+    TODO_TASK_CLASS_USER_GATE,
     normalize_required_write_scopes,
     normalize_todo_claimed_by,
     normalize_todo_excluded_agents,
@@ -276,7 +277,10 @@ def hold_task_lease_mutation_fence(
     mandatory: no effective lease is a typed error instead of a silent
     ``{"required": False}``, and a time-active lease whose owner constraint is
     no longer effective (the legacy self-disarm state) fails loudly instead of
-    letting a keyless completion through.
+    letting a keyless completion through. For a user-role ``user_gate``
+    completion that supplies no explicit lease credentials, the fence mints
+    the key itself under the same per-goal lease lock; an existing
+    time-active lease is never displaced.
     """
 
     normalized_goal_id = normalize_goal_id(goal_id)
@@ -299,6 +303,14 @@ def hold_task_lease_mutation_fence(
     handoff = handoff or {}
     handoff_mode = str(handoff.get("handoff_mode") or HANDOFF_MODE_LEGACY)
     handoff_gate_overridden = handoff.get("handoff_gate_overridden") is True
+    auto_acquire_lease = (
+        handoff_mode == HANDOFF_MODE_HARD_LEASE
+        and not handoff_gate_overridden
+        and not require_active_when_key_supplied
+        and str(todo.get("role") or "") == "user"
+        and str(todo.get("task_class") or "") == TODO_TASK_CLASS_USER_GATE
+    )
+    auto_acquired = False
     with exclusive_file_lock(
         lock_target,
         agent_id=actor_agent_id,
@@ -318,6 +330,77 @@ def hold_task_lease_mutation_fence(
                 ),
             )
             active = constraint.get("effective") is True
+
+        if (
+            auto_acquire_lease
+            and not active
+            and not (time_active and lease)
+        ):
+            # Mint the completion key under the same per-goal lease lock. A
+            # time-active lease is never displaced: if one exists but its
+            # owner constraint is no longer effective, the hard branch below
+            # keeps the loud divergence error.
+            normalized_actor = normalize_todo_claimed_by(actor_agent_id)
+            if not normalized_actor:
+                raise TaskLeaseError(
+                    "hard_lease handoff mode auto-acquire requires an "
+                    "attributed actor; provide --agent-id",
+                    code="handoff_mode_requires_lease",
+                    payload={
+                        "goal_id": normalized_goal_id,
+                        "todo_id": normalized_todo_id,
+                        "handoff_mode": handoff_mode,
+                        "lease_path": str(lease_path),
+                        "reason": "missing_actor",
+                    },
+                )
+            constraint = task_lease_owner_constraint(
+                todo,
+                owner=normalized_actor,
+                registered_agents=registered_agent_ids_from_registry(
+                    registry_path,
+                    normalized_goal_id,
+                ),
+            )
+            if constraint.get("effective") is not True:
+                raise TaskLeaseError(
+                    "hard_lease handoff mode auto-acquire rejected for "
+                    "the acting agent",
+                    code="handoff_mode_requires_lease",
+                    payload={
+                        "goal_id": normalized_goal_id,
+                        "todo_id": normalized_todo_id,
+                        "handoff_mode": handoff_mode,
+                        "lease_path": str(lease_path),
+                        "reason": str(
+                            constraint.get("reason") or "owner_not_allowed"
+                        ),
+                        "constraint": constraint,
+                    },
+                )
+            at = now_utc()
+            auto_key = requested_key or f"auto-{normalized_todo_id}"
+            updated_at = isoformat(at)
+            expires_at = isoformat(
+                at + timedelta(seconds=DEFAULT_TASK_LEASE_TTL_SECONDS)
+            )
+            lease = build_lease(
+                goal_id=normalized_goal_id,
+                todo_id=normalized_todo_id,
+                owner=normalized_actor,
+                idempotency_key=auto_key,
+                write_scopes=[],
+                acquire_ttl_seconds=DEFAULT_TASK_LEASE_TTL_SECONDS,
+                version=int((lease or {}).get("version") or 0) + 1,
+                acquired_at=updated_at,
+                updated_at=updated_at,
+                expires_at=expires_at,
+            )
+            write_lease(lease_path, lease)
+            requested_key = auto_key
+            auto_acquired = True
+            active = True
+            time_active = True
 
         if not active:
             if handoff_mode == HANDOFF_MODE_HARD_LEASE and not handoff_gate_overridden:
@@ -401,16 +484,17 @@ def hold_task_lease_mutation_fence(
                 },
             )
         assert_expected_version(lease, expected_version)
-        fence = _VerifiedTaskLeaseFence(
-            {
-                "schema_version": TASK_LEASE_SCHEMA_VERSION,
-                "required": True,
-                "active": True,
-                "owner": normalized_actor,
-                "version": lease.get("version"),
-                "execution_instance_verified": True,
-            }
-        )
+        fence_payload = {
+            "schema_version": TASK_LEASE_SCHEMA_VERSION,
+            "required": True,
+            "active": True,
+            "owner": normalized_actor,
+            "version": lease.get("version"),
+            "execution_instance_verified": True,
+        }
+        if auto_acquired:
+            fence_payload["auto_acquired"] = True
+        fence = _VerifiedTaskLeaseFence(fence_payload)
         fence.release_hook = lambda: remove_lease(lease_path)
         yield fence
 

--- a/tests/control_plane/test_goal_handoff_mode.py
+++ b/tests/control_plane/test_goal_handoff_mode.py
@@ -24,6 +24,9 @@ from typing import Any
 
 import pytest
 
+from loopx.control_plane.todos.contract import (
+    TODO_TASK_CLASS_USER_ACTION,
+)
 from loopx.control_plane.todos.handoff_mode import (
     HANDOFF_MODE_HARD_LEASE,
     HANDOFF_MODE_LEGACY,
@@ -1054,29 +1057,34 @@ def test_hard_lease_completion_with_verified_key_succeeds(tmp_path: Path) -> Non
     assert result["task_lease_fence"]["execution_instance_verified"] is True
 
 
-def test_hard_lease_exact_user_gate_completion_without_lease_is_typed_rejected(
+def test_hard_lease_non_gate_user_todo_completion_without_lease_is_typed_rejected(
     tmp_path: Path,
 ) -> None:
     registry, state = _write_workspace(
         tmp_path,
         handoff_mode=HANDOFF_MODE_HARD_LEASE,
     )
-    _target, gate = _add_exact_user_gate_pair(registry)
+    action = add_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="user",
+        text="Owner follow-up action.",
+        task_class=TODO_TASK_CLASS_USER_ACTION,
+        bound_agent=AGENT_A,
+    )
     before = state.read_text(encoding="utf-8")
 
     with pytest.raises(TaskLeaseError) as error:
         complete_goal_todo(
             registry_path=registry,
             goal_id=GOAL_ID,
-            todo_id=gate["todo_id"],
+            todo_id=action["todo_id"],
             role="user",
-            decision_outcome="approve",
             agent_id=AGENT_A,
-            evidence="exact owner decision without a task lease",
+            evidence="non-gate user todos must still cross the lease fence",
         )
 
     assert error.value.code == "handoff_mode_requires_lease"
-    assert error.value.payload["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
     assert state.read_text(encoding="utf-8") == before
 
 
@@ -1177,6 +1185,77 @@ def test_hard_lease_exact_user_gate_rejects_invalid_lease_fence_without_state_ch
     persisted_lease = json.loads(lease_file.read_text(encoding="utf-8"))
     assert persisted_lease["status"] == "active"
     assert persisted_lease["owner"] == lease_owner
+
+
+def test_hard_lease_user_gate_completion_auto_acquires_key(tmp_path: Path) -> None:
+    """A user-gate decision completes without caller-supplied lease credentials.
+
+    The completion fence mints the key under the per-goal lease lock, verifies
+    it, and releases it after the committed writeback - the human decision is
+    the authority, so the presenter never needs to hold a key across the wait.
+    """
+
+    registry, state = _write_workspace(
+        tmp_path,
+        handoff_mode=HANDOFF_MODE_HARD_LEASE,
+    )
+    target, gate = _add_exact_user_gate_pair(registry)
+    lease_file = task_lease_path(
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=gate["todo_id"],
+    )
+
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=gate["todo_id"],
+        role="user",
+        decision_outcome="approve",
+        agent_id=AGENT_A,
+        evidence="owner decision recorded under an auto-acquired completion key",
+    )
+
+    assert result["ok"] is True
+    assert result["task_lease_fence"]["auto_acquired"] is True
+    assert result["task_lease_fence"]["required"] is True
+    assert result["task_lease_fence"]["execution_instance_verified"] is True
+    assert result["task_lease_fence"]["released"] is True
+    assert not lease_file.exists()
+    assert _user_todo(state, gate["todo_id"])["status"] == "done"
+    target_after = _agent_todo(state, target["todo_id"])
+    assert target_after["status"] == "open"
+    assert not target_after.get("required_decision_scopes")
+
+
+def test_hard_lease_user_gate_auto_acquire_does_not_displace_existing_lease(
+    tmp_path: Path,
+) -> None:
+    """An active lease held by another agent is never displaced automatically."""
+
+    registry, state = _write_workspace(
+        tmp_path,
+        handoff_mode=HANDOFF_MODE_HARD_LEASE,
+    )
+    _target, gate = _add_exact_user_gate_pair(registry)
+    _acquire(registry, tmp_path, gate["todo_id"], owner=AGENT_B, key="turn-lease-b")
+    before = state.read_text(encoding="utf-8")
+
+    with pytest.raises(TaskLeaseError) as error:
+        complete_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=gate["todo_id"],
+            role="user",
+            decision_outcome="approve",
+            agent_id=AGENT_A,
+            evidence="agent A must not displace B's completion key",
+        )
+
+    assert error.value.code == "lease_fence_required"
+    assert state.read_text(encoding="utf-8") == before
+
+
 def test_hard_lease_local_terminal_replay_keeps_response_shape_after_release(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Small follow-up to #3164: in `hard_lease` mode, completing a user-role `user_gate` todo no longer requires the caller to pre-acquire and pass lease credentials. The completion fence mints the key itself under the existing per-goal lease lock at write time, verifies it, and releases it on commit. The "completion must be keyed" invariant is unchanged - the harness supplies the key at completion time instead of forcing the presenter to hold it across the human wait.

@wchwawa 这是 #3164 合并后的一个小 follow-up（完成时自动 acquire 钥匙），请 review。

## Behavior change (disclosed)

- `hard_lease` + `user_gate` + no explicit `task_lease_idempotency_key`/`task_lease_expected_version`: previously `handoff_mode_requires_lease`; now succeeds via auto-acquire (`task_lease_fence.auto_acquired: true`, released after commit).
- Unchanged: agent-role completions, non-gate user todos, explicit-credential paths, legacy/soft modes, the delegated-authority door, and never displacing an existing time-active lease.

## Implementation

- `hold_task_lease_mutation_fence` (`loopx/control_plane/work_items/task_lease.py`): when hard_lease + not overridden + todo is user/`user_gate` + no explicit credentials + no active lease, mint a lease under the same per-goal lease lock using the fence's idempotency key (or deterministic `auto-<todo_id>` fallback), validate owner eligibility via `task_lease_owner_constraint`, mark `auto_acquired`, and continue through the existing verified + release path.
- `loopx/todos.py` and `handoff_mode.py` untouched: module line budget and control-plane surface stay minimal.

## Validation

- 62 focused handoff-mode tests pass (auto-acquire success, non-displacement of an existing lease, non-gate user todo still rejected).
- m6 maintainability ratchet passes.
- `tests/control_plane`: 1183 passed; 2 environment-only subprocess failures (system Python 3.9 in `scripts/loopx`) reproduced identically on `origin/main`.
- ruff clean on changed files; `py_compile` + `git diff --check` clean.
- change-quality receipt `cqr_9cc5e7a653c8412cb9ea` valid.
- canary premerge: 16/17 passed; the single failure (`refresh-state-write-correctness-smoke.py`) reproduces on clean `origin/main` with system Python 3.9 (`str | None` needs 3.10+).