### PR TITLE
refactor(control-plane): share typed settlement receipt-chain driver

### DIFF
--- a/loopx/control_plane/quota/settlement.py
+++ b/loopx/control_plane/quota/settlement.py
@@ -33,6 +33,7 @@ from .heartbeat_receipt import find_heartbeat_receipt
 from .settlement_workspace_causality import (
     delivery_workspace_causality_from_event_details,
 )
+from ..settlement_driver import effect_ids_match, settlement_receipt
 
 __all__ = [
     "SETTLEMENT_IDENTITY_SCHEMA_VERSION",
@@ -155,7 +156,7 @@ def resolve_heartbeat_settlement_identity(
         turn_instance_id=normalized_turn_id,
     )
     receipt_effect_id = str(details.get("settlement_effect_id") or "").strip()
-    if receipt_effect_id and receipt_effect_id != identity.effect_id:
+    if not effect_ids_match(receipt_effect_id, identity.effect_id):
         return SettlementResult.failed(
             kind=SettlementFailureKind.IDENTITY_MISMATCH,
             step_kind=SettlementStepKind.VALIDATION,
@@ -169,10 +170,9 @@ def resolve_heartbeat_settlement_identity(
     return SettlementResult.pure(
         identity,
         receipts=(
-            SettlementReceipt(
+            settlement_receipt(
+                identity,
                 step_kind=SettlementStepKind.VALIDATION,
-                status="committed",
-                effect_id=identity.effect_id,
                 source_ref=f"rollout_event:{event_id}" if event_id else None,
             ),
         ),
@@ -348,10 +348,9 @@ def require_settlement_todo_completion(
     return SettlementResult.pure(
         receipt_event,
         receipts=(
-            SettlementReceipt(
+            settlement_receipt(
+                identity,
                 step_kind=SettlementStepKind.TODO_COMPLETION,
-                status="committed",
-                effect_id=identity.effect_id,
                 source_ref=f"rollout_event:{event_id}" if event_id else None,
             ),
         ),
@@ -381,10 +380,9 @@ def require_settlement_writeback(
     return SettlementResult.pure(
         run,
         receipts=(
-            SettlementReceipt(
+            settlement_receipt(
+                identity,
                 step_kind=SettlementStepKind.DURABLE_WRITEBACK,
-                status="committed",
-                effect_id=identity.effect_id,
                 source_ref=f"rollout_event:{event_id}" if event_id else None,
             ),
         ),
@@ -428,10 +426,9 @@ def require_settlement_spend(
     return SettlementResult.pure(
         run,
         receipts=(
-            SettlementReceipt(
+            settlement_receipt(
+                identity,
                 step_kind=SettlementStepKind.QUOTA_SPEND,
-                status="committed",
-                effect_id=identity.effect_id,
                 source_ref=f"rollout_event:{event_id}" if event_id else None,
             ),
         ),

--- a/loopx/control_plane/settlement_driver.py
+++ b/loopx/control_plane/settlement_driver.py
@@ -1,0 +1,291 @@
+"""Core-owned typed settlement receipt-chain driver.
+
+Quota and Turn adapters both settle a typed plan under one identity: validation
+first, then writeback, then spend, replaying committed receipts for the same
+effect id with every failure typed by step.  This module owns that shared
+receipt-chain semantics; adapters keep their provenance reads, effect bindings,
+and domain policy (scheduler, Todo lifecycle, spend accounting, vision).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+from .effect_program import (
+    SettlementFailureKind,
+    SettlementIdentity,
+    SettlementReceipt,
+    SettlementResult,
+    SettlementStepKind,
+)
+
+
+SettlementPayload = Mapping[str, Any]
+SettlementEffect = Callable[[], Mapping[str, Any]]
+SettlementCheckpoint = Callable[
+    [SettlementStepKind, Mapping[str, Any], tuple[str, ...]],
+    None,
+]
+
+DEFAULT_MISSING_FAILURE_KINDS: Mapping[SettlementStepKind, SettlementFailureKind] = {
+    SettlementStepKind.DURABLE_WRITEBACK: SettlementFailureKind.RECEIPT_MISSING,
+}
+MISSING_PAYLOAD_REASONS: Mapping[SettlementStepKind, str] = {
+    SettlementStepKind.DURABLE_WRITEBACK: (
+        "Turn journal is missing its committed writeback payload"
+    ),
+    SettlementStepKind.QUOTA_SPEND: (
+        "Turn journal is missing its committed quota spend payload"
+    ),
+}
+
+
+def effect_ids_match(
+    committed_effect_id: str | None,
+    expected_effect_id: str,
+) -> bool:
+    """Return whether committed receipts prove the expected effect id."""
+
+    return not committed_effect_id or committed_effect_id == expected_effect_id
+
+
+def settlement_receipt(
+    identity: SettlementIdentity,
+    *,
+    step_kind: SettlementStepKind,
+    source_ref: str | None = None,
+) -> SettlementReceipt:
+    """Build one committed receipt for a settlement identity and step."""
+
+    return SettlementReceipt(
+        step_kind=step_kind,
+        status="committed",
+        effect_id=identity.effect_id,
+        source_ref=source_ref,
+    )
+
+
+def settlement_identity_from_plan(
+    transaction_plan: Mapping[str, Any],
+) -> SettlementResult[SettlementIdentity]:
+    """Resolve the complete typed settlement identity from a transaction plan."""
+
+    settlement_plan = transaction_plan.get("settlement_plan")
+    if not isinstance(settlement_plan, Mapping):
+        return SettlementResult.failed(
+            kind=SettlementFailureKind.RECEIPT_MISSING,
+            step_kind=SettlementStepKind.VALIDATION,
+            reason="Turn transaction has no typed settlement plan",
+        )
+    identity = settlement_plan.get("identity")
+    if not isinstance(identity, Mapping):
+        return SettlementResult.failed(
+            kind=SettlementFailureKind.INVALID_IDENTITY,
+            step_kind=SettlementStepKind.VALIDATION,
+            reason="Turn settlement plan has no identity",
+        )
+    required = (
+        "goal_id",
+        "agent_id",
+        "todo_id",
+        "turn_instance_id",
+    )
+    if any(not str(identity.get(field) or "").strip() for field in required):
+        return SettlementResult.failed(
+            kind=SettlementFailureKind.INVALID_IDENTITY,
+            step_kind=SettlementStepKind.VALIDATION,
+            reason="Turn settlement plan has an incomplete identity",
+        )
+    built = SettlementIdentity(
+        goal_id=str(identity["goal_id"]),
+        agent_id=str(identity["agent_id"]),
+        todo_id=str(identity["todo_id"]),
+        turn_instance_id=str(identity["turn_instance_id"]),
+    )
+    effect_id = str(identity.get("effect_id") or "").strip()
+    if not effect_id:
+        return SettlementResult.failed(
+            kind=SettlementFailureKind.INVALID_IDENTITY,
+            step_kind=SettlementStepKind.VALIDATION,
+            reason="Turn settlement plan has no effect id",
+        )
+    if effect_id and effect_id != built.effect_id:
+        return SettlementResult.failed(
+            kind=SettlementFailureKind.INVALID_IDENTITY,
+            step_kind=SettlementStepKind.VALIDATION,
+            reason="Turn settlement plan effect id does not match its identity",
+        )
+    return SettlementResult.pure(
+        built,
+    )
+
+
+def require_matching_effect_id(
+    committed_effect_id: str | None,
+    expected_effect_id: str,
+) -> SettlementResult[str]:
+    """Fail closed when committed receipts belong to another effect id."""
+
+    if not effect_ids_match(committed_effect_id, expected_effect_id):
+        return SettlementResult.failed(
+            kind=SettlementFailureKind.IDENTITY_MISMATCH,
+            step_kind=SettlementStepKind.VALIDATION,
+            reason=(
+                "Turn journal belongs to another settlement effect: journal "
+                f"effect is {committed_effect_id} but plan effect is "
+                f"{expected_effect_id}"
+            ),
+        )
+    return SettlementResult.pure(expected_effect_id)
+
+
+def is_committed_payload(value: Mapping[str, Any] | None) -> bool:
+    """Return whether a step payload durably committed its effect."""
+
+    return bool(
+        isinstance(value, Mapping)
+        and value.get("ok") is True
+        and value.get("appended") is True
+    )
+
+
+def seed_committed_steps(
+    identity: SettlementIdentity,
+    *,
+    ordered_steps: Sequence[SettlementStepKind],
+    committed_payloads: Mapping[SettlementStepKind, Mapping[str, Any] | None],
+    completed_phases: Sequence[str] | None = None,
+    transaction_phases: Sequence[str] | None = None,
+    require_validation: bool = True,
+    missing_failure_kinds: Mapping[SettlementStepKind, SettlementFailureKind]
+    | None = None,
+    source_ref_prefix: str = "turn_journal",
+) -> SettlementResult[dict[SettlementStepKind, Mapping[str, Any]]]:
+    """Seed committed receipts in plan order from durable step payloads."""
+
+    if completed_phases is not None and transaction_phases is not None:
+        phases = tuple(str(phase) for phase in completed_phases)
+        if phases != tuple(transaction_phases)[: len(phases)]:
+            return SettlementResult.failed(
+                kind=SettlementFailureKind.RECEIPT_MISSING,
+                step_kind=SettlementStepKind.VALIDATION,
+                reason="Turn journal phases are not an ordered transaction prefix",
+            )
+        if require_validation and "validation" not in phases:
+            return SettlementResult.failed(
+                kind=SettlementFailureKind.RECEIPT_MISSING,
+                step_kind=SettlementStepKind.VALIDATION,
+                reason="Turn settlement requires a committed validation receipt",
+            )
+    missing_kinds = dict(DEFAULT_MISSING_FAILURE_KINDS)
+    if missing_failure_kinds:
+        missing_kinds.update(missing_failure_kinds)
+    receipts: list[SettlementReceipt] = []
+    committed: dict[SettlementStepKind, Mapping[str, Any]] = {}
+    for step_kind in ordered_steps:
+        if step_kind is SettlementStepKind.VALIDATION and require_validation:
+            if completed_phases is not None and "validation" not in completed_phases:
+                return SettlementResult.failed(
+                    kind=SettlementFailureKind.RECEIPT_MISSING,
+                    step_kind=step_kind,
+                    reason="Turn settlement requires a committed validation receipt",
+                    receipts=tuple(receipts),
+                )
+            receipts.append(
+                settlement_receipt(
+                    identity,
+                    step_kind=step_kind,
+                    source_ref=(
+                        f"{source_ref_prefix}:{identity.effect_id}#{step_kind.value}"
+                    ),
+                )
+            )
+            committed[step_kind] = {}
+            continue
+        if completed_phases is not None:
+            committed_flag = step_kind.value in completed_phases
+        else:
+            committed_flag = True
+        if not committed_flag:
+            # Pending step: not yet committed; the caller may run its effect.
+            continue
+        payload = committed_payloads.get(step_kind)
+        if payload is None:
+            return SettlementResult.failed(
+                kind=missing_kinds.get(step_kind, SettlementFailureKind.RECEIPT_MISSING),
+                step_kind=step_kind,
+                reason=MISSING_PAYLOAD_REASONS.get(
+                    step_kind,
+                    f"Turn journal is missing its committed {step_kind.value} payload",
+                ),
+                receipts=tuple(receipts),
+            )
+        if not is_committed_payload(payload):
+            return SettlementResult.failed(
+                kind=missing_kinds.get(step_kind, SettlementFailureKind.RECEIPT_MISSING),
+                step_kind=step_kind,
+                reason=MISSING_PAYLOAD_REASONS.get(
+                    step_kind,
+                    f"Turn journal is missing its committed {step_kind.value} payload",
+                ),
+                receipts=tuple(receipts),
+            )
+        receipts.append(
+            settlement_receipt(
+                identity,
+                step_kind=step_kind,
+                source_ref=f"{source_ref_prefix}:{identity.effect_id}#{step_kind.value}",
+            )
+        )
+        committed[step_kind] = payload
+    return SettlementResult.pure(committed, receipts=tuple(receipts))
+
+
+def _callback_failure_kind(
+    step_kind: SettlementStepKind,
+    reason: str,
+) -> SettlementFailureKind:
+    if step_kind is SettlementStepKind.DURABLE_WRITEBACK:
+        return SettlementFailureKind.WRITEBACK_REJECTED
+    if "budget" in reason.casefold():
+        return SettlementFailureKind.BUDGET_REJECTED
+    return SettlementFailureKind.QUOTA_SPEND_REJECTED
+
+
+def commit_step_effect(
+    identity: SettlementIdentity,
+    *,
+    step_kind: SettlementStepKind,
+    transaction_phases: Sequence[str],
+    effect: SettlementEffect,
+    checkpoint: SettlementCheckpoint,
+    source_ref_prefix: str = "turn_journal",
+) -> SettlementResult[Mapping[str, Any]]:
+    """Run one step effect and record its committed receipt."""
+
+    payload = dict(effect())
+    if not is_committed_payload(payload):
+        reason = str(
+            payload.get("error")
+            or payload.get("reason")
+            or f"{step_kind.value} callback rejected the settlement"
+        )
+        return SettlementResult.failed(
+            kind=_callback_failure_kind(step_kind, reason),
+            step_kind=step_kind,
+            reason=reason,
+        )
+    phase_index = tuple(transaction_phases).index(step_kind.value)
+    completed_phases = tuple(transaction_phases)[: phase_index + 1]
+    checkpoint(step_kind, payload, completed_phases)
+    return SettlementResult.pure(
+        payload,
+        receipts=(
+            settlement_receipt(
+                identity,
+                step_kind=step_kind,
+                source_ref=f"{source_ref_prefix}:{identity.effect_id}#{step_kind.value}",
+            ),
+        ),
+    )

--- a/loopx/control_plane/turn_driver/settlement.py
+++ b/loopx/control_plane/turn_driver/settlement.py
@@ -1,4 +1,4 @@
-"""Turn-driver adapter for the shared typed settlement algebra."""
+"""Turn-driver adapter for the shared typed settlement receipt-chain driver."""
 
 from __future__ import annotations
 
@@ -7,10 +7,14 @@ from dataclasses import dataclass
 from typing import Any
 
 from ..effect_program import (
-    SettlementFailureKind,
-    SettlementReceipt,
     SettlementResult,
     SettlementStepKind,
+)
+from ..settlement_driver import (
+    commit_step_effect,
+    require_matching_effect_id,
+    seed_committed_steps,
+    settlement_identity_from_plan,
 )
 
 
@@ -28,191 +32,11 @@ class TurnSettlementState:
     quota_spend: Mapping[str, Any] | None = None
 
 
-def _effect_id(transaction_plan: Mapping[str, Any]) -> str:
-    settlement_plan = transaction_plan.get("settlement_plan")
-    if not isinstance(settlement_plan, Mapping):
-        raise ValueError("Turn transaction has no typed settlement plan")
-    identity = settlement_plan.get("identity")
-    if not isinstance(identity, Mapping):
-        raise ValueError("Turn settlement plan has no identity")
-    effect_id = str(identity.get("effect_id") or "").strip()
-    if not effect_id:
-        raise ValueError("Turn settlement plan has no effect id")
-    return effect_id
-
-
-def _settlement_effect_id(
-    transaction_plan: Mapping[str, Any],
-) -> SettlementResult[str]:
-    """Resolve the typed effect id, failing closed instead of raising.
-
-    Legacy or journaled Turn plans created before the typed settlement binding
-    may have no ``settlement_plan``. The turn driver must surface that as a
-    typed validation failure rather than crash with ``ValueError``.
-    """
-
-    settlement_plan = transaction_plan.get("settlement_plan")
-    if not isinstance(settlement_plan, Mapping):
-        return SettlementResult.failed(
-            kind=SettlementFailureKind.RECEIPT_MISSING,
-            step_kind=SettlementStepKind.VALIDATION,
-            reason="Turn transaction has no typed settlement plan",
-        )
-    identity = settlement_plan.get("identity")
-    if not isinstance(identity, Mapping):
-        return SettlementResult.failed(
-            kind=SettlementFailureKind.INVALID_IDENTITY,
-            step_kind=SettlementStepKind.VALIDATION,
-            reason="Turn settlement plan has no identity",
-        )
-    effect_id = str(identity.get("effect_id") or "").strip()
-    if not effect_id:
-        return SettlementResult.failed(
-            kind=SettlementFailureKind.INVALID_IDENTITY,
-            step_kind=SettlementStepKind.VALIDATION,
-            reason="Turn settlement plan has no effect id",
-        )
-    return SettlementResult.pure(effect_id)
-
-
-def _receipt(
-    *,
-    effect_id: str,
-    step_kind: SettlementStepKind,
-) -> SettlementReceipt:
-    return SettlementReceipt(
-        step_kind=step_kind,
-        status="committed",
-        effect_id=effect_id,
-        source_ref=f"turn_journal:{effect_id}#{step_kind.value}",
-    )
-
-
-def _committed_payload(value: Mapping[str, Any] | None) -> bool:
-    return bool(
-        isinstance(value, Mapping)
-        and value.get("ok") is True
-        and value.get("appended") is True
-    )
-
-
-def _seed_result(
-    transaction_plan: Mapping[str, Any],
-    *,
-    transaction_phases: tuple[str, ...],
-    completed_phases: Sequence[str],
-    writeback_payload: Mapping[str, Any] | None,
-    quota_spend_payload: Mapping[str, Any] | None,
-) -> SettlementResult[TurnSettlementState]:
-    effect_id = _effect_id(transaction_plan)
-    phases = tuple(str(phase) for phase in completed_phases)
-    if phases != transaction_phases[: len(phases)]:
-        return SettlementResult.failed(
-            kind=SettlementFailureKind.RECEIPT_MISSING,
-            step_kind=SettlementStepKind.VALIDATION,
-            reason="Turn journal phases are not an ordered transaction prefix",
-        )
-    if "validation" not in phases:
-        return SettlementResult.failed(
-            kind=SettlementFailureKind.RECEIPT_MISSING,
-            step_kind=SettlementStepKind.VALIDATION,
-            reason="Turn settlement requires a committed validation receipt",
-        )
-
-    receipts = [
-        _receipt(
-            effect_id=effect_id,
-            step_kind=SettlementStepKind.VALIDATION,
-        )
-    ]
-    if "durable_writeback" in phases:
-        if not _committed_payload(writeback_payload):
-            return SettlementResult.failed(
-                kind=SettlementFailureKind.RECEIPT_MISSING,
-                step_kind=SettlementStepKind.DURABLE_WRITEBACK,
-                reason="Turn journal is missing its committed writeback payload",
-                receipts=tuple(receipts),
-            )
-        receipts.append(
-            _receipt(
-                effect_id=effect_id,
-                step_kind=SettlementStepKind.DURABLE_WRITEBACK,
-            )
-        )
-    if "quota_spend" in phases:
-        if not _committed_payload(quota_spend_payload):
-            return SettlementResult.failed(
-                kind=SettlementFailureKind.RECEIPT_MISSING,
-                step_kind=SettlementStepKind.QUOTA_SPEND,
-                reason="Turn journal is missing its committed quota spend payload",
-                receipts=tuple(receipts),
-            )
-        receipts.append(
-            _receipt(
-                effect_id=effect_id,
-                step_kind=SettlementStepKind.QUOTA_SPEND,
-            )
-        )
-    return SettlementResult.pure(
-        TurnSettlementState(
-            completed_phases=phases,
-            writeback=writeback_payload,
-            quota_spend=quota_spend_payload,
-        ),
-        receipts=tuple(receipts),
-    )
-
-
-def _callback_failure_kind(
-    step_kind: SettlementStepKind,
-    reason: str,
-) -> SettlementFailureKind:
-    if step_kind is SettlementStepKind.DURABLE_WRITEBACK:
-        return SettlementFailureKind.WRITEBACK_REJECTED
-    if "budget" in reason.casefold():
-        return SettlementFailureKind.BUDGET_REJECTED
-    return SettlementFailureKind.QUOTA_SPEND_REJECTED
-
-
-def _commit_effect(
-    state: TurnSettlementState,
-    *,
-    effect_id: str,
-    step_kind: SettlementStepKind,
-    transaction_phases: tuple[str, ...],
-    effect: TurnEffect,
-    checkpoint: TurnSettlementCheckpoint,
-) -> SettlementResult[TurnSettlementState]:
-    payload = dict(effect())
-    if not _committed_payload(payload):
-        reason = str(
-            payload.get("error")
-            or payload.get("reason")
-            or f"{step_kind.value} callback rejected the settlement"
-        )
-        return SettlementResult.failed(
-            kind=_callback_failure_kind(step_kind, reason),
-            step_kind=step_kind,
-            reason=reason,
-        )
-    phase_index = transaction_phases.index(step_kind.value)
-    completed_phases = transaction_phases[: phase_index + 1]
-    next_state = TurnSettlementState(
-        completed_phases=completed_phases,
-        writeback=(
-            payload
-            if step_kind is SettlementStepKind.DURABLE_WRITEBACK
-            else state.writeback
-        ),
-        quota_spend=(
-            payload if step_kind is SettlementStepKind.QUOTA_SPEND else state.quota_spend
-        ),
-    )
-    checkpoint(step_kind, payload, completed_phases)
-    return SettlementResult.pure(
-        next_state,
-        receipts=(_receipt(effect_id=effect_id, step_kind=step_kind),),
-    )
+SETTLEMENT_STEPS = (
+    SettlementStepKind.VALIDATION,
+    SettlementStepKind.DURABLE_WRITEBACK,
+    SettlementStepKind.QUOTA_SPEND,
+)
 
 
 def execute_turn_driver_settlement(
@@ -239,47 +63,90 @@ def execute_turn_driver_settlement(
     unchanged.
     """
 
-    effect_result = _settlement_effect_id(transaction_plan)
-    if effect_result.failure is not None:
-        return effect_result
-    effect_id = effect_result.value
-    assert effect_id is not None
-    if committed_effect_id and committed_effect_id != effect_id:
+    identity_result = settlement_identity_from_plan(transaction_plan)
+    if identity_result.failure is not None:
+        return identity_result
+    identity = identity_result.value
+    assert identity is not None
+    matched = require_matching_effect_id(committed_effect_id, identity.effect_id)
+    if matched.failure is not None:
         return SettlementResult.failed(
-            kind=SettlementFailureKind.IDENTITY_MISMATCH,
-            step_kind=SettlementStepKind.VALIDATION,
-            reason=(
-                "Turn journal belongs to another settlement effect: journal "
-                f"effect is {committed_effect_id} but plan effect is {effect_id}"
-            ),
+            kind=matched.failure.kind,
+            step_kind=matched.failure.step_kind,
+            reason=matched.failure.reason,
         )
-    result = _seed_result(
-        transaction_plan,
+    phases = tuple(str(phase) for phase in completed_phases)
+    committed_payloads: dict[SettlementStepKind, Mapping[str, Any] | None] = {
+        SettlementStepKind.VALIDATION: {},
+        SettlementStepKind.DURABLE_WRITEBACK: writeback_payload,
+        SettlementStepKind.QUOTA_SPEND: quota_spend_payload,
+    }
+    seeded = seed_committed_steps(
+        identity,
+        ordered_steps=SETTLEMENT_STEPS,
+        committed_payloads=committed_payloads,
+        completed_phases=phases,
         transaction_phases=transaction_phases,
-        completed_phases=completed_phases,
-        writeback_payload=writeback_payload,
-        quota_spend_payload=quota_spend_payload,
+        require_validation=True,
+        source_ref_prefix="turn_journal",
     )
-    if "durable_writeback" not in completed_phases:
-        result = result.bind(
-            lambda state: _commit_effect(
-                state,
-                effect_id=effect_id,
-                step_kind=SettlementStepKind.DURABLE_WRITEBACK,
-                transaction_phases=transaction_phases,
-                effect=writeback,
-                checkpoint=checkpoint,
-            )
+    if seeded.failure is not None:
+        return SettlementResult.failed(
+            kind=seeded.failure.kind,
+            step_kind=seeded.failure.step_kind,
+            reason=seeded.failure.reason,
+            receipts=seeded.receipts,
         )
-    if "quota_spend" not in completed_phases:
-        result = result.bind(
-            lambda state: _commit_effect(
-                state,
-                effect_id=effect_id,
-                step_kind=SettlementStepKind.QUOTA_SPEND,
-                transaction_phases=transaction_phases,
-                effect=spend,
-                checkpoint=checkpoint,
-            )
+    state = TurnSettlementState(
+        completed_phases=phases,
+        writeback=writeback_payload,
+        quota_spend=quota_spend_payload,
+    )
+    receipts = list(seeded.receipts)
+    if "durable_writeback" not in phases:
+        step_result = commit_step_effect(
+            identity,
+            step_kind=SettlementStepKind.DURABLE_WRITEBACK,
+            transaction_phases=transaction_phases,
+            effect=writeback,
+            checkpoint=checkpoint,
         )
-    return result
+        if step_result.failure is not None:
+            return SettlementResult.failed(
+                kind=step_result.failure.kind,
+                step_kind=step_result.failure.step_kind,
+                reason=step_result.failure.reason,
+                receipts=tuple(receipts),
+            )
+        receipts.extend(step_result.receipts)
+        phase_index = transaction_phases.index(
+            SettlementStepKind.DURABLE_WRITEBACK.value
+        )
+        state = TurnSettlementState(
+            completed_phases=tuple(transaction_phases[: phase_index + 1]),
+            writeback=step_result.value,
+            quota_spend=state.quota_spend,
+        )
+    if "quota_spend" not in phases:
+        step_result = commit_step_effect(
+            identity,
+            step_kind=SettlementStepKind.QUOTA_SPEND,
+            transaction_phases=transaction_phases,
+            effect=spend,
+            checkpoint=checkpoint,
+        )
+        if step_result.failure is not None:
+            return SettlementResult.failed(
+                kind=step_result.failure.kind,
+                step_kind=step_result.failure.step_kind,
+                reason=step_result.failure.reason,
+                receipts=tuple(receipts),
+            )
+        receipts.extend(step_result.receipts)
+        phase_index = transaction_phases.index(SettlementStepKind.QUOTA_SPEND.value)
+        state = TurnSettlementState(
+            completed_phases=tuple(transaction_phases[: phase_index + 1]),
+            writeback=state.writeback,
+            quota_spend=step_result.value,
+        )
+    return SettlementResult.pure(state, receipts=tuple(receipts))

--- a/tests/control_plane/test_settlement_driver.py
+++ b/tests/control_plane/test_settlement_driver.py
@@ -1,0 +1,315 @@
+"""Focused tests for the core-owned typed settlement receipt-chain driver.
+
+The driver is the shared seam behind the quota adapter's validator chain and
+the Turn adapter's effect executor.  Expectations are derived from the typed
+settlement contract (RFC M7.1) and the existing parity behavior of both
+adapters, not from implementation output.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from loopx.control_plane.effect_program import (
+    SettlementFailureKind,
+    SettlementIdentity,
+    SettlementStepKind,
+)
+from loopx.control_plane.settlement_driver import (
+    commit_step_effect,
+    effect_ids_match,
+    require_matching_effect_id,
+    seed_committed_steps,
+    settlement_identity_from_plan,
+    settlement_receipt,
+)
+
+
+IDENTITY = SettlementIdentity(
+    goal_id="fixture-goal",
+    agent_id="fixture-agent",
+    todo_id="todo_fixture0001",
+    turn_instance_id="fixture-turn",
+)
+
+SETTLEMENT_STEPS = (
+    SettlementStepKind.VALIDATION,
+    SettlementStepKind.DURABLE_WRITEBACK,
+    SettlementStepKind.QUOTA_SPEND,
+)
+
+TRANSACTION_PHASES = (
+    "host_execute",
+    "typed_result",
+    "validation",
+    "durable_writeback",
+    "quota_spend",
+    "scheduler_apply",
+    "scheduler_ack",
+)
+
+COMMITTED_PAYLOAD: dict[str, Any] = {"ok": True, "appended": True}
+
+
+def _plan() -> dict[str, Any]:
+    return {
+        "transaction": {
+            "turn_key": "sha256:fixture-turn",
+            "settlement_plan": {
+                "identity": {
+                    "effect_id": IDENTITY.effect_id,
+                    "goal_id": IDENTITY.goal_id,
+                    "agent_id": IDENTITY.agent_id,
+                    "todo_id": IDENTITY.todo_id,
+                    "turn_instance_id": IDENTITY.turn_instance_id,
+                }
+            },
+        }
+    }
+
+
+def _committed_payloads(
+    *,
+    writeback: bool = False,
+    spend: bool = False,
+) -> dict[SettlementStepKind, dict[str, Any] | None]:
+    return {
+        SettlementStepKind.VALIDATION: {},
+        SettlementStepKind.DURABLE_WRITEBACK: (
+            dict(COMMITTED_PAYLOAD) if writeback else None
+        ),
+        SettlementStepKind.QUOTA_SPEND: dict(COMMITTED_PAYLOAD) if spend else None,
+    }
+
+
+def test_effect_ids_match_allows_missing_and_equal_provenance() -> None:
+    assert effect_ids_match(None, IDENTITY.effect_id) is True
+    assert effect_ids_match(IDENTITY.effect_id, IDENTITY.effect_id) is True
+    assert effect_ids_match("other-effect", IDENTITY.effect_id) is False
+
+
+def test_settlement_receipt_is_committed_under_the_identity() -> None:
+    receipt = settlement_receipt(
+        IDENTITY,
+        step_kind=SettlementStepKind.VALIDATION,
+        source_ref="rollout_event:abc",
+    )
+    assert receipt.step_kind is SettlementStepKind.VALIDATION
+    assert receipt.status == "committed"
+    assert receipt.effect_id == IDENTITY.effect_id
+    assert receipt.source_ref == "rollout_event:abc"
+
+
+def test_settlement_identity_from_plan_fails_closed_on_incomplete_identity() -> None:
+    plan = {"transaction": {"settlement_plan": {"identity": {"effect_id": "e"}}}}
+    result = settlement_identity_from_plan(plan["transaction"])
+    assert result.failure is not None
+    assert result.failure.kind is SettlementFailureKind.INVALID_IDENTITY
+    assert result.failure.step_kind is SettlementStepKind.VALIDATION
+    assert "incomplete identity" in result.failure.reason
+
+
+@pytest.mark.parametrize(
+    ("plan", "kind", "step", "reason_part"),
+    [
+        (
+            {"transaction": {}},
+            SettlementFailureKind.RECEIPT_MISSING,
+            SettlementStepKind.VALIDATION,
+            "no typed settlement plan",
+        ),
+        (
+            {"transaction": {"settlement_plan": {}}},
+            SettlementFailureKind.INVALID_IDENTITY,
+            SettlementStepKind.VALIDATION,
+            "has no identity",
+        ),
+        (
+            {"transaction": {"settlement_plan": {"identity": {}}}},
+            SettlementFailureKind.INVALID_IDENTITY,
+            SettlementStepKind.VALIDATION,
+            "incomplete identity",
+        ),
+    ],
+)
+def test_settlement_identity_from_plan_fails_closed(
+    plan: dict[str, Any],
+    kind: SettlementFailureKind,
+    step: SettlementStepKind,
+    reason_part: str,
+) -> None:
+    result = settlement_identity_from_plan(plan["transaction"])
+    assert result.failure is not None
+    assert result.failure.kind is kind
+    assert result.failure.step_kind is step
+    assert reason_part in result.failure.reason
+
+
+def test_settlement_identity_from_plan_rejects_effect_id_mismatch() -> None:
+    plan = _plan()
+    plan["transaction"]["settlement_plan"]["identity"]["effect_id"] = "other"
+    result = settlement_identity_from_plan(plan["transaction"])
+    assert result.failure is not None
+    assert result.failure.kind is SettlementFailureKind.INVALID_IDENTITY
+    assert "does not match its identity" in result.failure.reason
+
+
+def test_require_matching_effect_id_fails_closed_on_mismatch() -> None:
+    ok = require_matching_effect_id(None, IDENTITY.effect_id)
+    assert ok.failure is None
+    matched = require_matching_effect_id(IDENTITY.effect_id, IDENTITY.effect_id)
+    assert matched.failure is None
+    mismatch = require_matching_effect_id("other-effect", IDENTITY.effect_id)
+    assert mismatch.failure is not None
+    assert mismatch.failure.kind is SettlementFailureKind.IDENTITY_MISMATCH
+    assert mismatch.failure.step_kind is SettlementStepKind.VALIDATION
+    assert "other-effect" in mismatch.failure.reason
+    assert IDENTITY.effect_id in mismatch.failure.reason
+
+
+def test_seed_committed_steps_emits_ordered_receipts_for_committed_phases() -> None:
+    result = seed_committed_steps(
+        IDENTITY,
+        ordered_steps=SETTLEMENT_STEPS,
+        committed_payloads=_committed_payloads(writeback=True, spend=True),
+        completed_phases=TRANSACTION_PHASES[:5],
+        transaction_phases=TRANSACTION_PHASES,
+        require_validation=True,
+    )
+    assert result.failure is None
+    assert [r.step_kind for r in result.receipts] == [
+        SettlementStepKind.VALIDATION,
+        SettlementStepKind.DURABLE_WRITEBACK,
+        SettlementStepKind.QUOTA_SPEND,
+    ]
+    assert all(r.effect_id == IDENTITY.effect_id for r in result.receipts)
+    assert set(result.value) == set(SETTLEMENT_STEPS)
+
+
+def test_seed_committed_steps_skips_pending_steps_when_phases_are_given() -> None:
+    result = seed_committed_steps(
+        IDENTITY,
+        ordered_steps=SETTLEMENT_STEPS,
+        committed_payloads=_committed_payloads(),
+        completed_phases=TRANSACTION_PHASES[:3],
+        transaction_phases=TRANSACTION_PHASES,
+        require_validation=True,
+    )
+    assert result.failure is None
+    assert [r.step_kind for r in result.receipts] == [
+        SettlementStepKind.VALIDATION
+    ]
+    assert set(result.value) == {SettlementStepKind.VALIDATION}
+
+
+def test_seed_committed_steps_fails_on_missing_committed_writeback_payload() -> None:
+    result = seed_committed_steps(
+        IDENTITY,
+        ordered_steps=SETTLEMENT_STEPS,
+        committed_payloads=_committed_payloads(),
+        completed_phases=TRANSACTION_PHASES[:4],
+        transaction_phases=TRANSACTION_PHASES,
+        require_validation=True,
+    )
+    assert result.failure is not None
+    assert result.failure.kind is SettlementFailureKind.RECEIPT_MISSING
+    assert result.failure.step_kind is SettlementStepKind.DURABLE_WRITEBACK
+    assert result.failure.reason == (
+        "Turn journal is missing its committed writeback payload"
+    )
+    assert [r.step_kind for r in result.receipts] == [
+        SettlementStepKind.VALIDATION
+    ]
+
+
+def test_seed_committed_steps_rejects_non_prefix_phases() -> None:
+    result = seed_committed_steps(
+        IDENTITY,
+        ordered_steps=SETTLEMENT_STEPS,
+        committed_payloads=_committed_payloads(writeback=True),
+        completed_phases=["host_execute", "validation"],
+        transaction_phases=TRANSACTION_PHASES,
+        require_validation=True,
+    )
+    assert result.failure is not None
+    assert result.failure.kind is SettlementFailureKind.RECEIPT_MISSING
+    assert result.failure.step_kind is SettlementStepKind.VALIDATION
+    assert "ordered transaction prefix" in result.failure.reason
+
+
+def test_seed_committed_steps_validator_mode_fails_on_missing_step() -> None:
+    result = seed_committed_steps(
+        IDENTITY,
+        ordered_steps=SETTLEMENT_STEPS,
+        committed_payloads=_committed_payloads(writeback=True),
+        completed_phases=None,
+        require_validation=True,
+    )
+    assert result.failure is not None
+    assert result.failure.step_kind is SettlementStepKind.QUOTA_SPEND
+    assert result.failure.kind is SettlementFailureKind.RECEIPT_MISSING
+
+
+def test_commit_step_effect_records_receipt_and_checkpoint() -> None:
+    checkpoints: list[tuple[SettlementStepKind, Any, tuple[str, ...]]] = []
+
+    def checkpoint(
+        step_kind: SettlementStepKind,
+        payload: Any,
+        phases: tuple[str, ...],
+    ) -> None:
+        checkpoints.append((step_kind, payload, phases))
+
+    result = commit_step_effect(
+        IDENTITY,
+        step_kind=SettlementStepKind.DURABLE_WRITEBACK,
+        transaction_phases=TRANSACTION_PHASES,
+        effect=lambda: dict(COMMITTED_PAYLOAD),
+        checkpoint=checkpoint,
+    )
+    assert result.failure is None
+    assert result.value == COMMITTED_PAYLOAD
+    assert [r.step_kind for r in result.receipts] == [
+        SettlementStepKind.DURABLE_WRITEBACK
+    ]
+    assert checkpoints == [
+        (
+            SettlementStepKind.DURABLE_WRITEBACK,
+            COMMITTED_PAYLOAD,
+            ("host_execute", "typed_result", "validation", "durable_writeback"),
+        )
+    ]
+
+
+def test_commit_step_effect_maps_callback_failure_kinds() -> None:
+    writeback = commit_step_effect(
+        IDENTITY,
+        step_kind=SettlementStepKind.DURABLE_WRITEBACK,
+        transaction_phases=TRANSACTION_PHASES,
+        effect=lambda: {"ok": False, "reason": "writeback rejected"},
+        checkpoint=lambda *_args: None,
+    )
+    assert writeback.failure is not None
+    assert writeback.failure.kind is SettlementFailureKind.WRITEBACK_REJECTED
+
+    budget = commit_step_effect(
+        IDENTITY,
+        step_kind=SettlementStepKind.QUOTA_SPEND,
+        transaction_phases=TRANSACTION_PHASES,
+        effect=lambda: {"ok": False, "reason": "compute budget exhausted"},
+        checkpoint=lambda *_args: None,
+    )
+    assert budget.failure is not None
+    assert budget.failure.kind is SettlementFailureKind.BUDGET_REJECTED
+
+    rejected = commit_step_effect(
+        IDENTITY,
+        step_kind=SettlementStepKind.QUOTA_SPEND,
+        transaction_phases=TRANSACTION_PHASES,
+        effect=lambda: {"ok": False, "reason": "spend rejected"},
+        checkpoint=lambda *_args: None,
+    )
+    assert rejected.failure is not None
+    assert rejected.failure.kind is SettlementFailureKind.QUOTA_SPEND_REJECTED


### PR DESCRIPTION
## What

Extracts a core-owned `loopx/control_plane/settlement_driver.py` owning the typed settlement receipt-chain semantics that the quota adapter and the isolated Turn adapter each re-implemented:

- `settlement_identity_from_plan` — resolve the complete typed identity/effect id from a transaction plan, failing closed on missing/contradictory identity;
- `require_matching_effect_id` — the `IDENTITY_MISMATCH` cross-check (same rule as #3193), with `None` provenance as the opt-in seam;
- `seed_committed_steps` — ordered committed-receipt seeding from durable step payloads, with per-step missing-failure kinds and exact preserved messages;
- `commit_step_effect` — run one step effect, validate the committed payload, checkpoint phases, and record the receipt;
- `settlement_receipt` / `effect_ids_match` / `is_committed_payload` — shared factories/predicates.

The Turn adapter (`turn_driver/settlement.py`) now delegates identity resolution, seeding, and step effects to the driver while keeping its public `execute_turn_driver_settlement` signature; the quota adapter (`quota/settlement.py`) reuses the shared receipt factory and effect-id predicate. Domain policy stays outside the driver: scheduler apply/ACK, Todo lifecycle reducers, spend accounting, and vision/replan qualification remain in their bounded contexts.

## Validation

- `tests/control_plane/test_settlement_driver.py` (new, 15 tests) pins the shared contract: identity resolution, mismatch cross-check, ordered seeding, validator vs effect mode, failure-kind mapping.
- Existing suites unchanged and green at exact head: turn transaction/executor/driver, quota settlement/should-run parity/CLI projection/slot accounting, adapter conformance, incident replay, fault replay matrix, state-refresh projections — 214 focused tests pass locally.
- Ruff within the repo pin (`0.15.4`) and `py_compile` pass on all changed files.
- No behavior change: the diff is a behavior-preserving extraction; the committed-effect cross-check activates only when a caller supplies provenance (already wired by #3193's executor change).