### PR TITLE
docs(product): position LoopX as the layer on top of agent harnesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **The open, provider-neutral, stateful control plane for long-running agents.**
 
-<sub>Keep objectives, gates, todos, evidence, quota, and handoffs stable while Codex, Claude Code, Cursor, or your own runtime executes bounded turns.</sub>
+<sub>LoopX runs on top of Codex App, Claude Code, Cursor, dsh, or your own agent harness, providing long-horizon state, semantic decisions, governance, recovery, and human-agent collaboration — objectives, gates, todos, evidence, quota, and handoffs stay stable while the harness executes bounded turns.</sub>
 
 <a href="https://trendshift.io/repositories/102379?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-102379"><img src="https://trendshift.io/api/badge/repositories/102379" alt="huangruiteng/loopx on Trendshift" width="220" height="48"></a>
 
@@ -21,9 +21,12 @@
 ---
 
 Open and provider-neutral, LoopX is a lightweight state kernel and local-first
-control plane for loop engineering. It keeps long-running work reviewable,
-restartable, and easier to hand off across turns, tools, and agents without
-replacing the runtime that performs the work.
+control plane for loop engineering. It runs on top of different agent harnesses
+— Codex App, Codex CLI, Claude Code, Cursor, dsh, or your own runner — rather
+than replacing them. LoopX provides the long-horizon state, semantic decisions
+about what happens next, governance, recovery, and human-agent collaboration
+that keep long-running work reviewable, restartable, and easier to hand off
+across turns, tools, and agents.
 
 **Loop engineering for long-running AI agents and peer agent teams.**
 
@@ -283,7 +286,10 @@ loopx doctor
 
 ## Capabilities
 
-LoopX folds its control-plane mechanics into five questions:
+LoopX folds its control-plane mechanics into five questions. Each question
+delivers one product promise on top of any agent harness: objective →
+long-horizon state; next → semantic decisions; human judgment →
+human-agent collaboration; evidence → recovery; continuation → governance.
 
 | Question | What LoopX keeps visible |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **The open, provider-neutral, stateful control plane for long-running agents.**
 
-<sub>LoopX runs on top of Codex App, Claude Code, Cursor, dsh, or your own agent harness, providing long-horizon state, semantic decisions, governance, recovery, and human-agent collaboration — objectives, gates, todos, evidence, quota, and handoffs stay stable while the harness executes bounded turns.</sub>
+<sub>Runs on top of any agent harness — Codex App, Claude Code, Cursor, dsh, or your own — providing long-horizon state, semantic decisions, governance, recovery, and human-agent collaboration. Objectives, gates, todos, evidence, quota, and handoffs stay stable while the harness executes bounded turns.</sub>
 
 <a href="https://trendshift.io/repositories/102379?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-102379"><img src="https://trendshift.io/api/badge/repositories/102379" alt="huangruiteng/loopx on Trendshift" width="220" height="48"></a>
 
@@ -22,11 +22,10 @@
 
 Open and provider-neutral, LoopX is a lightweight state kernel and local-first
 control plane for loop engineering. It runs on top of different agent harnesses
-— Codex App, Codex CLI, Claude Code, Cursor, dsh, or your own runner — rather
-than replacing them. LoopX provides the long-horizon state, semantic decisions
-about what happens next, governance, recovery, and human-agent collaboration
-that keep long-running work reviewable, restartable, and easier to hand off
-across turns, tools, and agents.
+rather than replacing them, providing the long-horizon state, semantic
+decisions about what happens next, governance, recovery, and human-agent
+collaboration that keep long-running work reviewable, restartable, and easier
+to hand off across turns, tools, and agents.
 
 **Loop engineering for long-running AI agents and peer agent teams.**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 
 **面向长程 Agent 的开放、有状态、Provider-neutral 控制面。**
 
-<sub>LoopX 运行在 Codex App、Claude Code、Cursor、dsh 或自有 agent harness 之上，提供长程状态、语义决策、治理、恢复与人机协同；目标、gate、todo、证据、quota 和交接跨轮次保持稳定，有界执行仍由 harness 负责。</sub>
+<sub>LoopX 运行在任何 agent harness 之上，提供长程状态、语义决策、治理、恢复与人机协同；目标、gate、todo、证据、quota 和交接跨轮次保持稳定，有界执行仍由 harness 负责。</sub>
 
 <a href="https://trendshift.io/repositories/102379?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-102379"><img src="https://trendshift.io/api/badge/repositories/102379" alt="huangruiteng/loopx 在 Trendshift 的趋势排名" width="220" height="48"></a>
 
@@ -21,10 +21,9 @@
 ---
 
 LoopX 是开放且 Provider-neutral 的轻量 state kernel，也是 local-first
-的 Loop Engineering 控制面。它运行在 Codex App、Codex CLI、Claude Code、
-Cursor、dsh 或自有 runner 等不同 agent harness 之上，而不是替代它们：
-LoopX 提供长程状态、语义决策、治理、恢复与人机协同，让跨轮次、跨工具、
-跨 agent 的工作可审阅、可恢复、可接力。
+的 Loop Engineering 控制面。它运行在不同 agent harness 之上，而不是替代
+它们：LoopX 提供长程状态、语义决策、治理、恢复与人机协同，让跨轮次、
+跨工具、跨 agent 的工作可审阅、可恢复、可接力。
 
 > 让 Loop 持续向前，让关键判断留在人手里。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 
 **面向长程 Agent 的开放、有状态、Provider-neutral 控制面。**
 
-<sub>Codex、Claude Code、Cursor 或自有 runtime 负责一次次有界执行；LoopX 让目标、gate、todo、证据、quota 和交接跨轮次保持稳定。</sub>
+<sub>LoopX 运行在 Codex App、Claude Code、Cursor、dsh 或自有 agent harness 之上，提供长程状态、语义决策、治理、恢复与人机协同；目标、gate、todo、证据、quota 和交接跨轮次保持稳定，有界执行仍由 harness 负责。</sub>
 
 <a href="https://trendshift.io/repositories/102379?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-102379"><img src="https://trendshift.io/api/badge/repositories/102379" alt="huangruiteng/loopx 在 Trendshift 的趋势排名" width="220" height="48"></a>
 
@@ -21,8 +21,10 @@
 ---
 
 LoopX 是开放且 Provider-neutral 的轻量 state kernel，也是 local-first
-的 Loop Engineering 控制面。它不替代真正执行任务的 agent runtime，而是让
-跨轮次、跨工具、跨 agent 的工作可审阅、可恢复、可接力。
+的 Loop Engineering 控制面。它运行在 Codex App、Codex CLI、Claude Code、
+Cursor、dsh 或自有 runner 等不同 agent harness 之上，而不是替代它们：
+LoopX 提供长程状态、语义决策、治理、恢复与人机协同，让跨轮次、跨工具、
+跨 agent 的工作可审阅、可恢复、可接力。
 
 > 让 Loop 持续向前，让关键判断留在人手里。
 
@@ -257,7 +259,9 @@ loopx doctor
 
 ## 能力
 
-LoopX 把控制面归结为五个用户可以直接行动的问题：
+LoopX 把控制面归结为五个用户可以直接行动的问题。每个问题对应一个产品
+承诺：目标 → 长程状态；下一步 → 语义决策；人类判断 → 人机协同；
+证据 → 恢复；能否继续 → 治理。
 
 | 问题 | LoopX 保持可见的状态 |
 | --- | --- |

--- a/apps/presentation/site/src/App.tsx
+++ b/apps/presentation/site/src/App.tsx
@@ -76,7 +76,7 @@ const content = {
       thirdPrefix: "You keep the ",
       thirdAccent: "judgment",
     },
-    body: "An open, provider-neutral, stateful control plane for long-running agents—keeping authority, gates, todos, quota, evidence, recovery, and handoffs in one loop.",
+    body: "LoopX runs on top of Codex, Claude Code, Cursor, dsh, or your own agent harness — providing long-horizon state, semantic decisions, governance, recovery, and human-agent collaboration while authority, gates, todos, quota, and evidence stay in one loop.",
     copy: "Get started",
     setup: {
       eyebrow: "Set up LoopX",
@@ -177,7 +177,7 @@ const content = {
       thirdPrefix: "判断始终",
       thirdAccent: "由你掌握",
     },
-    body: "面向长程 Agent 的开放、有状态、Provider-neutral 控制面，把权限状态、Gate、Todo、Quota、Evidence、恢复与交接组织在同一闭环中。",
+    body: "LoopX 运行在 Codex、Claude Code、Cursor、dsh 或自有 harness 之上，提供长程状态、语义决策、治理、恢复与人机协同；权限、Gate、Todo、Quota 与 Evidence 仍集中在同一个控制闭环中。",
     copy: "开始使用",
     setup: {
       eyebrow: "设置 LoopX",

--- a/apps/presentation/site/src/App.tsx
+++ b/apps/presentation/site/src/App.tsx
@@ -76,7 +76,7 @@ const content = {
       thirdPrefix: "You keep the ",
       thirdAccent: "judgment",
     },
-    body: "LoopX runs on top of Codex, Claude Code, Cursor, dsh, or your own agent harness — providing long-horizon state, semantic decisions, governance, recovery, and human-agent collaboration while authority, gates, todos, quota, and evidence stay in one loop.",
+    body: "LoopX runs on top of any agent harness, providing long-horizon state, semantic decisions, governance, recovery, and human-agent collaboration while authority, gates, todos, quota, and evidence stay in one loop.",
     copy: "Get started",
     setup: {
       eyebrow: "Set up LoopX",
@@ -177,7 +177,7 @@ const content = {
       thirdPrefix: "判断始终",
       thirdAccent: "由你掌握",
     },
-    body: "LoopX 运行在 Codex、Claude Code、Cursor、dsh 或自有 harness 之上，提供长程状态、语义决策、治理、恢复与人机协同；权限、Gate、Todo、Quota 与 Evidence 仍集中在同一个控制闭环中。",
+    body: "LoopX 运行在任何 agent harness 之上，提供长程状态、语义决策、治理、恢复与人机协同；权限、Gate、Todo、Quota 与 Evidence 仍集中在同一个控制闭环中。",
     copy: "开始使用",
     setup: {
       eyebrow: "设置 LoopX",

--- a/docs/product/core-control-plane/README.md
+++ b/docs/product/core-control-plane/README.md
@@ -1,5 +1,10 @@
 # Core Control-Plane Graphs
 
+> Positioning: LoopX runs on top of different agent harnesses and provides
+> long-horizon state, semantic decisions, governance, recovery, and
+> human-agent collaboration; these graphs map the control-plane state behind
+> that promise. See the [product vision](../vision.md).
+
 This folder keeps the three product diagrams that should move together when
 LoopX learns a new long-running agent behavior:
 

--- a/docs/product/vision.md
+++ b/docs/product/vision.md
@@ -6,8 +6,7 @@ state drift, human gates, run evidence, handoffs, ownership, quota, and
 public/private boundaries. The larger product category is a dynamic goal
 control plane: a way to turn a static agent goal into long-running, reviewable
 state that stays understandable and recoverable across many turns. LoopX runs
-on top of different agent harnesses — Codex App, Codex CLI, Claude Code,
-Cursor, dsh, or your own runtime — and provides long-horizon state, semantic
+on top of different agent harnesses and provides long-horizon state, semantic
 decisions, governance, recovery, and human-agent collaboration without
 replacing the harness that executes the work.
 

--- a/docs/product/vision.md
+++ b/docs/product/vision.md
@@ -5,7 +5,11 @@ because engineering work exposes the hard control-plane problems quickly:
 state drift, human gates, run evidence, handoffs, ownership, quota, and
 public/private boundaries. The larger product category is a dynamic goal
 control plane: a way to turn a static agent goal into long-running, reviewable
-state that stays understandable and recoverable across many turns.
+state that stays understandable and recoverable across many turns. LoopX runs
+on top of different agent harnesses — Codex App, Codex CLI, Claude Code,
+Cursor, dsh, or your own runtime — and provides long-horizon state, semantic
+decisions, governance, recovery, and human-agent collaboration without
+replacing the harness that executes the work.
 
 The long-term product should help humans who do not want to inspect prompts,
 logs, or traces. The first customer is the maintainer/operator of a Loop Agent:
@@ -46,7 +50,11 @@ clear next improvement targets.
 
 **Dynamic goal control plane for long-running agents**
 
+**Runs on top of any agent harness — long-horizon state, semantic decisions, governance, recovery, and human-agent collaboration**
+
 **让多个 agent 昼夜接力，把人的判断留在控制面。**
+
+**运行在不同 agent harness 之上，为它们提供长程状态、语义决策、治理、恢复与人机协同。**
 
 LoopX 把目标、用户决策、agent todo、认领关系、scope、safe fallback、
 run history 和 quota 放进同一层状态：该等人的地方明确等人，不该空等的


### PR DESCRIPTION
## Summary

Adopt one consistent product definition across the repo's first-screen surfaces:
**LoopX runs on top of different agent harnesses (Codex App, Codex CLI, Claude
Code, Cursor, dsh, or your own runner) and provides long-horizon state,
semantic decisions, governance, recovery, and human-agent collaboration.**

- `README.md` / `README.zh-CN.md`: hero subtitle, intro paragraph, and a
  promise-mapping sentence above the five-question capabilities table.
- `docs/product/vision.md`: product vision paragraph and First-Screen Copy
  candidates.
- `docs/product/core-control-plane/README.md`: one-line positioning blockquote
  linking to the product vision.
- `apps/presentation/site/src/App.tsx`: English and Chinese frontstage hero
  body.

The existing control-plane mechanism language is preserved; the new definition
states where LoopX sits (above harnesses) and what it provides, while the
five-question table keeps the promise concrete.

## Validation

- `npm run build` passes for `apps/presentation/site` (tsc + vite).
- `examples/frontstage-pages-workflow-smoke.py` passes.
- `loopx check --scan-path` reports a clean public boundary for all five
  changed files.
- `git diff --check` clean; English and Chinese hero text verified in a local
  production build.

## Review Notes

- "agent harness" is used deliberately (rather than bare "harness") to avoid
  collision with the internal effect-interpreter usage of "harness" in the
  control-plane course docs.
- First-screen hero changes: rendered previews are shared with the requester
  outside this PR; please review the first viewport before merge.
