### PR TITLE
feat(turn): expose read-only journal inspection

### DIFF
--- a/docs/reference/effect-interpreter-packet.md
+++ b/docs/reference/effect-interpreter-packet.md
@@ -44,6 +44,31 @@ Interpretation therefore grants no authority to execute or retry a Turn,
 schedule work, write state, or spend quota. In particular, failed-journal
 recovery with `retry_failed=True` remains owned by the Turn executor.
 
+The public read-only consumer is:
+
+```bash
+loopx turn inspect-journal \
+  --goal-id <goal-id> \
+  --agent-id <agent-id> \
+  --turn-key <sha256:64-hex-digest> \
+  --format json
+```
+
+It resolves only the canonical journal location. There is no arbitrary
+`--journal-path` input. The command validates selectors, takes the existing
+journal lock, schema-checks the stored JSON, and returns the versioned
+`loopx_turn_journal_inspection_v0` projection. That projection allowlists only
+the replay decision, journal status, replay legality, identity-match booleans,
+ordered phase-prefix result, completed phase ids, tombstone retention, typed
+violation ids, and the explicit effect-free marker `effects: []`.
+
+JSON and Markdown render the same projection. They do not expose raw journal,
+plan, host-result, or receipt bodies; request context; capabilities;
+recommended actions; credentials; evidence; or resolved local paths. A
+successfully interpreted `replay_blocked` journal exits zero because replay
+legality is diagnostic data. Invalid selectors, missing journals, malformed
+JSON, and unsupported schemas exit non-zero.
+
 ## Canonical Example
 
 ### 1. Effect Request

--- a/docs/reference/protocols/loopx-turn-v0.md
+++ b/docs/reference/protocols/loopx-turn-v0.md
@@ -231,6 +231,33 @@ One driver tick has exactly these ordered phases:
 The driver may stop after any phase. A stop must return a typed result and must
 not silently continue with a different execution mode.
 
+### Read-Only Journal Inspection
+
+Maintainers can inspect one existing fenced journal without entering the live
+Turn lifecycle:
+
+```bash
+loopx turn inspect-journal \
+  --goal-id <goal-id> \
+  --agent-id <agent-id> \
+  --turn-key <sha256:64-hex-digest> \
+  --format markdown
+```
+
+The command resolves the canonical runtime journal path, reads it under the
+existing journal lock, and projects `interpret_turn_journal` into
+`loopx_turn_journal_inspection_v0`. It branches before status collection,
+quota construction, scheduler context, planning, host invocation, settlement,
+spend, or state writeback. Its `effects` field is therefore always an empty
+list.
+
+Exit zero means that inspection completed, including when `decision` is
+`replay_blocked`. A non-zero exit means the command could not inspect the
+requested journal because a selector, file, JSON document, or schema was
+invalid. This surface is diagnostic evidence only: it grants no authority to
+resume, retry, settle, schedule, spend, or write, and it is never an execution
+gate. Settlement replay enforcement remains owned by the Turn executor.
+
 ### User-Gate Quiet Wait
 
 When the user owns the next step and the agent lane has no executable work, the

--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -22,10 +22,12 @@ from ..control_plane.scheduler.execution_context import (
 )
 from ..control_plane.turn_driver import (
     LOOPX_TURN_EXECUTION_SCHEMA_VERSION,
+    LOOPX_TURN_JOURNAL_INSPECTION_SCHEMA_VERSION,
     LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION,
     build_loopx_turn_command_validator,
     build_loopx_turn_plan,
     codex_cli_session_binding,
+    inspect_loopx_turn_journal,
     load_loopx_turn_plan_from_journal,
     run_codex_cli_host,
     run_loopx_turn_once,
@@ -55,9 +57,18 @@ def register_turn_commands(
 ) -> None:
     parser = subparsers.add_parser(
         "turn",
-        help="Plan or run one governed external-host turn from a live LoopX decision.",
+        help="Plan, run, or inspect one governed external-host Turn.",
     )
     command_sub = parser.add_subparsers(dest="turn_command", required=True)
+    inspect_journal = command_sub.add_parser(
+        "inspect-journal",
+        help="Inspect one canonical fenced Turn journal without executing effects.",
+    )
+    add_subcommand_format(inspect_journal)
+    inspect_journal.add_argument("--goal-id", required=True)
+    inspect_journal.add_argument("--agent-id", required=True)
+    inspect_journal.add_argument("--turn-key", required=True)
+
     plan = command_sub.add_parser(
         "plan",
         help="Build one typed read-only host decision without launching or writing.",
@@ -277,6 +288,45 @@ def _render_loopx_turn_execution_markdown(payload: dict[str, object]) -> str:
     )
 
 
+def _render_loopx_turn_journal_inspection_markdown(
+    payload: dict[str, object],
+) -> str:
+    if not payload.get("ok"):
+        error = payload.get("error") or "Turn journal inspection failed"
+        return f"LoopX Turn journal inspection failed: {error}"
+    completed_phases = payload.get("completed_phases")
+    violations = payload.get("violations")
+    return "\n".join(
+        [
+            "# LoopX Turn Journal Inspection",
+            f"- decision: {payload.get('decision')}",
+            f"- journal_status: {payload.get('journal_status')}",
+            f"- replay_legal: {payload.get('replay_legal')}",
+            f"- goal_matches: {payload.get('goal_matches')}",
+            f"- owner_matches: {payload.get('owner_matches')}",
+            f"- turn_key_matches: {payload.get('turn_key_matches')}",
+            (
+                "- phases_form_ordered_prefix: "
+                f"{payload.get('phases_form_ordered_prefix')}"
+            ),
+            "- completed_phases: "
+            + (
+                ", ".join(str(value) for value in completed_phases)
+                if isinstance(completed_phases, list) and completed_phases
+                else "none"
+            ),
+            f"- tombstone_retained: {payload.get('tombstone_retained')}",
+            "- violations: "
+            + (
+                ", ".join(str(value) for value in violations)
+                if isinstance(violations, list) and violations
+                else "none"
+            ),
+            "- effects: none",
+        ]
+    )
+
+
 def handle_turn_command(
     args: argparse.Namespace,
     *,
@@ -287,6 +337,31 @@ def handle_turn_command(
 ) -> int | None:
     if args.command != "turn":
         return None
+    if args.turn_command == "inspect-journal":
+        try:
+            runtime_root = resolve_status_projection_cache_runtime_root(
+                registry_path=registry_path,
+                runtime_root_override=runtime_root_arg,
+            )
+            payload = inspect_loopx_turn_journal(
+                runtime_root,
+                goal_id=args.goal_id,
+                agent_id=args.agent_id,
+                turn_key=args.turn_key,
+            )
+        except Exception as exc:  # noqa: BLE001 - typed CLI failure boundary
+            payload = {
+                "ok": False,
+                "schema_version": LOOPX_TURN_JOURNAL_INSPECTION_SCHEMA_VERSION,
+                "error": str(exc),
+                "effects": [],
+            }
+        print_payload(
+            payload,
+            output_format(args),
+            _render_loopx_turn_journal_inspection_markdown,
+        )
+        return 0 if payload.get("ok") else 1
     try:
         scan_roots = [Path(item).expanduser() for item in args.scan_path]
         if not scan_roots:

--- a/loopx/control_plane/turn_driver/__init__.py
+++ b/loopx/control_plane/turn_driver/__init__.py
@@ -16,9 +16,11 @@ from .driver import (
 )
 from .executor import (
     LOOPX_TURN_HOST_REQUEST_SCHEMA_VERSION,
+    LOOPX_TURN_JOURNAL_INSPECTION_SCHEMA_VERSION,
     LOOPX_TURN_TASK_VALIDATION_SCHEMA_VERSION,
     build_loopx_turn_command_validator,
     build_loopx_turn_host_request,
+    inspect_loopx_turn_journal,
     load_loopx_turn_plan_from_journal,
     normalize_host_argv,
     run_loopx_turn_once,
@@ -49,6 +51,7 @@ __all__ = [
     "CODEX_CLI_SESSION_SCHEMA_VERSION",
     "LOOPX_TURN_EXECUTION_SCHEMA_VERSION",
     "LOOPX_TURN_HOST_REQUEST_SCHEMA_VERSION",
+    "LOOPX_TURN_JOURNAL_INSPECTION_SCHEMA_VERSION",
     "LOOPX_TURN_RESULT_SCHEMA_VERSION",
     "LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION",
     "LOOPX_TURN_TASK_VALIDATION_SCHEMA_VERSION",
@@ -68,6 +71,7 @@ __all__ = [
     "codex_cli_session_id_from_jsonl",
     "decide_loop_disposition",
     "load_codex_cli_session",
+    "inspect_loopx_turn_journal",
     "load_loopx_turn_plan_from_journal",
     "loopx_turn_execution_committed",
     "loopx_turn_execution_has_durable_effects",

--- a/loopx/control_plane/turn_driver/executor.py
+++ b/loopx/control_plane/turn_driver/executor.py
@@ -12,9 +12,11 @@ from pathlib import Path
 from typing import Any
 
 from ...authority import validate_public_safe_text
-from ...file_lock import exclusive_file_lock
+from ...file_lock import LockAcquireTimeoutError, exclusive_file_lock
+from ...runtime import validate_goal_id_path_segment
 from ..effect_program import (
     SettlementStepKind,
+    interpret_turn_journal,
     interpret_turn_result_packet,
     settlement_result_payload,
 )
@@ -34,6 +36,7 @@ from .transaction import (
 )
 
 LOOPX_TURN_HOST_REQUEST_SCHEMA_VERSION = "loopx_turn_host_request_v0"
+LOOPX_TURN_JOURNAL_INSPECTION_SCHEMA_VERSION = "loopx_turn_journal_inspection_v0"
 LOOPX_TURN_JOURNAL_SCHEMA_VERSION = "loopx_turn_journal_v0"
 LOOPX_TURN_TASK_VALIDATION_SCHEMA_VERSION = "loopx_turn_task_validation_v0"
 HOST_RESULT_MAX_BYTES = 12_000
@@ -565,6 +568,59 @@ def _load_journal(path: Path) -> dict[str, Any] | None:
     if not isinstance(value, dict) or value.get("schema_version") != LOOPX_TURN_JOURNAL_SCHEMA_VERSION:
         raise ValueError("LoopX Turn journal has an unsupported schema")
     return value
+
+
+def inspect_loopx_turn_journal(
+    runtime_root: Path,
+    *,
+    goal_id: str,
+    agent_id: str,
+    turn_key: str,
+) -> dict[str, object]:
+    """Inspect one canonical Turn journal without granting execution authority."""
+
+    safe_goal_id = validate_goal_id_path_segment(goal_id)
+    if not agent_id or agent_id != agent_id.strip():
+        raise ValueError("agent_id must be a non-empty exact identity")
+    path = turn_journal_path(
+        runtime_root,
+        goal_id=safe_goal_id,
+        turn_key=turn_key,
+    )
+    try:
+        with exclusive_file_lock(path):
+            journal = _load_journal(path)
+    except json.JSONDecodeError:
+        raise ValueError("LoopX Turn journal contains malformed JSON") from None
+    except LockAcquireTimeoutError:
+        raise
+    except OSError:
+        raise ValueError("LoopX Turn journal could not be read") from None
+    if journal is None:
+        raise ValueError("LoopX Turn journal does not exist")
+
+    turn = interpret_turn_journal(
+        journal,
+        goal_id=safe_goal_id,
+        agent_id=agent_id,
+        turn_key=turn_key,
+    )
+    context = turn.request.context
+    return {
+        "ok": True,
+        "schema_version": LOOPX_TURN_JOURNAL_INSPECTION_SCHEMA_VERSION,
+        "decision": turn.observation.decision,
+        "journal_status": context["journal_status"],
+        "replay_legal": context["replay_legal"],
+        "goal_matches": context["goal_matches"],
+        "owner_matches": context["owner_matches"],
+        "turn_key_matches": context["turn_key_matches"],
+        "phases_form_ordered_prefix": context["phases_form_ordered_prefix"],
+        "completed_phases": list(context["completed_phases"]),
+        "tombstone_retained": context["tombstone_retained"],
+        "violations": list(context["violations"]),
+        "effects": [],
+    }
 
 
 def _journal_committed_effect_id(journal: Mapping[str, Any]) -> str | None:

--- a/tests/test_loopx_turn_journal_inspection.py
+++ b/tests/test_loopx_turn_journal_inspection.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from loopx.cli import main as cli_main
+from loopx.cli_commands import turn as turn_command
+from loopx.control_plane.turn_driver import executor
+
+
+TURN_KEY = "sha256:" + "a" * 64
+COMPLETED_PHASES = [
+    "host_execute",
+    "typed_result",
+    "validation",
+    "durable_writeback",
+    "quota_spend",
+    "scheduler_apply",
+    "scheduler_ack",
+]
+
+
+def _journal(*, status: str = "committed") -> dict[str, Any]:
+    return {
+        "schema_version": "loopx_turn_journal_v0",
+        "goal_id": "fixture-goal",
+        "turn_key": TURN_KEY,
+        "status": status,
+        "completed_phases": list(COMPLETED_PHASES),
+        "plan": {
+            "turn_envelope": {
+                "goal_id": "fixture-goal",
+                "agent_id": "fixture-agent",
+            },
+            "transaction": {
+                "turn_key": TURN_KEY,
+                "settlement_plan": {
+                    "identity": {
+                        "goal_id": "fixture-goal",
+                        "agent_id": "fixture-agent",
+                    }
+                },
+            },
+        },
+        "host_result": {"turn_key": TURN_KEY, "private_detail": "do-not-expose"},
+        "receipt": {"turn_key": TURN_KEY, "body": "do-not-expose"},
+    }
+
+
+def _write_journal(runtime_root: Path, journal: dict[str, Any]) -> Path:
+    path = runtime_root / "goals" / "fixture-goal" / "turns" / f"{'a' * 64}.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(journal, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def _run_inspection_cli(
+    tmp_path: Path,
+    *,
+    output_format: str,
+    goal_id: str = "fixture-goal",
+    agent_id: str = "fixture-agent",
+    turn_key: str = TURN_KEY,
+) -> tuple[int, str]:
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(
+            [
+                "--registry",
+                str(tmp_path / "registry.json"),
+                "--runtime-root",
+                str(tmp_path),
+                "turn",
+                "inspect-journal",
+                "--goal-id",
+                goal_id,
+                "--agent-id",
+                agent_id,
+                "--turn-key",
+                turn_key,
+                "--format",
+                output_format,
+            ]
+        )
+    return exit_code, output.getvalue()
+
+
+def test_existing_run_once_markdown_renderer_remains_intact() -> None:
+    rendered = turn_command._render_loopx_turn_execution_markdown(
+        {
+            "status": "committed",
+            "result_kind": "validated_progress",
+            "validation": {"status": "passed", "recovery_kind": None},
+            "receipt": {"next_phase": None},
+            "effects": {
+                "host_invoked": True,
+                "state_written": True,
+                "quota_spent": True,
+            },
+        }
+    )
+
+    assert rendered.startswith("# LoopX Turn Run Once\n")
+    assert "- validation: passed" in rendered
+    assert "- quota_spent: True" in rendered
+
+
+def test_inspection_returns_versioned_allowlisted_projection_without_mutation(
+    tmp_path: Path,
+) -> None:
+    journal_path = _write_journal(tmp_path, _journal())
+    before_bytes = journal_path.read_bytes()
+    before_entries = {
+        path.relative_to(tmp_path)
+        for path in tmp_path.rglob("*")
+        if not path.name.endswith(".lock")
+    }
+
+    result = executor.inspect_loopx_turn_journal(
+        tmp_path,
+        goal_id="fixture-goal",
+        agent_id="fixture-agent",
+        turn_key=TURN_KEY,
+    )
+
+    after_entries = {
+        path.relative_to(tmp_path)
+        for path in tmp_path.rglob("*")
+        if not path.name.endswith(".lock")
+    }
+    assert result == {
+        "ok": True,
+        "schema_version": "loopx_turn_journal_inspection_v0",
+        "decision": "replay_legal",
+        "journal_status": "committed",
+        "replay_legal": True,
+        "goal_matches": True,
+        "owner_matches": True,
+        "turn_key_matches": True,
+        "phases_form_ordered_prefix": True,
+        "completed_phases": COMPLETED_PHASES,
+        "tombstone_retained": True,
+        "violations": [],
+        "effects": [],
+    }
+    assert journal_path.read_bytes() == before_bytes
+    assert after_entries == before_entries
+    assert "do-not-expose" not in json.dumps(result)
+
+
+def test_inspection_reports_blocked_journal_as_successful_read(tmp_path: Path) -> None:
+    journal = _journal(status="in_progress")
+    journal["completed_phases"] = ["typed_result"]
+    _write_journal(tmp_path, journal)
+
+    result = executor.inspect_loopx_turn_journal(
+        tmp_path,
+        goal_id="fixture-goal",
+        agent_id="fixture-agent",
+        turn_key=TURN_KEY,
+    )
+
+    assert result["ok"] is True
+    assert result["decision"] == "replay_blocked"
+    assert result["replay_legal"] is False
+    assert result["violations"] == [
+        "completed_phases_not_ordered_prefix",
+        "journal_not_terminal",
+    ]
+    assert result["effects"] == []
+
+
+def test_inspection_rejects_goal_path_traversal_before_lock_or_file_access(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_access(*args: object, **kwargs: object) -> None:
+        raise AssertionError("filesystem access must not occur")
+
+    monkeypatch.setattr(executor, "exclusive_file_lock", unexpected_access)
+    monkeypatch.setattr(executor, "_load_journal", unexpected_access)
+
+    with pytest.raises(ValueError, match="single path segment"):
+        executor.inspect_loopx_turn_journal(
+            tmp_path,
+            goal_id="../outside",
+            agent_id="fixture-agent",
+            turn_key=TURN_KEY,
+        )
+
+
+@pytest.mark.parametrize("agent_id", ["", " fixture-agent "])
+def test_inspection_rejects_invalid_agent_identity_before_file_access(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    agent_id: str,
+) -> None:
+    def unexpected_access(*args: object, **kwargs: object) -> None:
+        raise AssertionError("filesystem access must not occur")
+
+    monkeypatch.setattr(executor, "exclusive_file_lock", unexpected_access)
+    monkeypatch.setattr(executor, "_load_journal", unexpected_access)
+
+    with pytest.raises(ValueError, match="non-empty exact identity"):
+        executor.inspect_loopx_turn_journal(
+            tmp_path,
+            goal_id="fixture-goal",
+            agent_id=agent_id,
+            turn_key=TURN_KEY,
+        )
+
+
+def test_inspect_journal_cli_branches_before_live_or_write_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_journal(tmp_path, _journal())
+
+    def unexpected_call(*args: object, **kwargs: object) -> None:
+        raise AssertionError("inspect-journal reached a live or write path")
+
+    for name in (
+        "build_lark_operator_inbox_urgency_projector",
+        "collect_status",
+        "scheduler_execution_context_for_turn",
+        "build_live_quota_should_run_decision",
+        "build_loopx_turn_plan",
+        "run_codex_cli_host",
+        "run_loopx_turn_once",
+        "spend_quota_slot",
+        "refresh_state_run",
+        "complete_goal_todo",
+        "update_goal_todo",
+    ):
+        monkeypatch.setattr(turn_command, name, unexpected_call)
+    monkeypatch.setattr(executor, "execute_turn_driver_settlement", unexpected_call)
+    monkeypatch.setattr(executor, "_write_journal", unexpected_call)
+
+    exit_code, raw_output = _run_inspection_cli(tmp_path, output_format="json")
+
+    payload = json.loads(raw_output)
+    assert exit_code == 0
+    assert payload["schema_version"] == "loopx_turn_journal_inspection_v0"
+    assert payload["decision"] == "replay_legal"
+    assert payload["effects"] == []
+
+
+def test_inspect_journal_cli_json_and_markdown_share_allowlisted_projection(
+    tmp_path: Path,
+) -> None:
+    _write_journal(tmp_path, _journal())
+
+    json_exit, json_output = _run_inspection_cli(tmp_path, output_format="json")
+    markdown_exit, markdown_output = _run_inspection_cli(
+        tmp_path,
+        output_format="markdown",
+    )
+
+    payload = json.loads(json_output)
+    assert json_exit == 0
+    assert markdown_exit == 0
+    assert set(payload) == {
+        "ok",
+        "schema_version",
+        "decision",
+        "journal_status",
+        "replay_legal",
+        "goal_matches",
+        "owner_matches",
+        "turn_key_matches",
+        "phases_form_ordered_prefix",
+        "completed_phases",
+        "tombstone_retained",
+        "violations",
+        "effects",
+    }
+    assert markdown_output == (
+        "# LoopX Turn Journal Inspection\n"
+        "- decision: replay_legal\n"
+        "- journal_status: committed\n"
+        "- replay_legal: True\n"
+        "- goal_matches: True\n"
+        "- owner_matches: True\n"
+        "- turn_key_matches: True\n"
+        "- phases_form_ordered_prefix: True\n"
+        f"- completed_phases: {', '.join(COMPLETED_PHASES)}\n"
+        "- tombstone_retained: True\n"
+        "- violations: none\n"
+        "- effects: none\n"
+    )
+    assert "do-not-expose" not in json_output
+    assert "do-not-expose" not in markdown_output
+
+
+def test_inspect_journal_cli_returns_zero_for_identity_mismatch(tmp_path: Path) -> None:
+    _write_journal(tmp_path, _journal())
+
+    exit_code, raw_output = _run_inspection_cli(
+        tmp_path,
+        output_format="json",
+        agent_id="other-agent",
+    )
+
+    payload = json.loads(raw_output)
+    assert exit_code == 0
+    assert payload["decision"] == "replay_blocked"
+    assert payload["owner_matches"] is False
+    assert payload["violations"] == ["owner_mismatch"]
+
+
+@pytest.mark.parametrize(
+    ("journal_text", "error_fragment"),
+    (
+        (None, "journal does not exist"),
+        ("{not-json", "contains malformed JSON"),
+        ('{"schema_version": "future_turn_journal_v1"}', "unsupported schema"),
+    ),
+)
+def test_inspect_journal_cli_returns_nonzero_when_inspection_cannot_complete(
+    tmp_path: Path,
+    journal_text: str | None,
+    error_fragment: str,
+) -> None:
+    if journal_text is not None:
+        path = _write_journal(tmp_path, _journal())
+        path.write_text(journal_text, encoding="utf-8")
+
+    exit_code, raw_output = _run_inspection_cli(tmp_path, output_format="json")
+
+    payload = json.loads(raw_output)
+    assert exit_code == 1
+    assert payload["ok"] is False
+    assert payload["schema_version"] == "loopx_turn_journal_inspection_v0"
+    assert error_fragment in payload["error"]
+    assert payload["effects"] == []
+
+
+def test_inspect_journal_cli_does_not_expose_path_on_read_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    journal_path = _write_journal(tmp_path, _journal())
+
+    def denied_read(path: Path) -> None:
+        raise OSError(13, "permission denied", str(path))
+
+    monkeypatch.setattr(executor, "_load_journal", denied_read)
+
+    exit_code, raw_output = _run_inspection_cli(tmp_path, output_format="json")
+
+    payload = json.loads(raw_output)
+    assert exit_code == 1
+    assert payload["error"] == "LoopX Turn journal could not be read"
+    assert str(journal_path) not in raw_output


### PR DESCRIPTION
## Summary

- Add `loopx turn inspect-journal` for inspecting an existing canonical fenced Turn journal without entering planning, execution, settlement, quota, scheduler, or writeback paths.
- Add the versioned, allowlisted `loopx_turn_journal_inspection_v0` projection with matching JSON and Markdown output.
- Treat `replay_blocked` as a successful inspection, reject invalid selectors before filesystem access, and prevent raw journal data or local paths from entering output.
- Add focused boundary tests and update the canonical Effect Program and LoopX Turn protocol documentation.

## Issue Or Task

- Closes #3197
- Contributor task ID: `turn / effect program`

## Validation

- [ ] `python3 -m py_compile loopx/*.py`
- [ ] `loopx check --scan-root .`
- [x] Other:
  - `python -m pytest -q tests/test_loopx_turn_journal_inspection.py tests/control_plane/test_effect_turn_turn_journal.py tests/test_loopx_turn_executor.py tests/test_loopx_turn_transaction.py tests/test_loopx_turn_driver.py tests/test_loopx_turn_settlement_parity.py -k "not test_codex_session_binding_uses_adaptive_primary_todo"` — 118 passed, 1 deselected
  - `python examples/loopx-turn-fake-host-walkthrough-smoke.py`
  - Targeted `python -m ruff check` and `python -m compileall -q` on changed Python files
  - `python -m loopx.cli check` on the changed runtime, test, and documentation paths
  - `git diff --check`
  - The deselected test is an existing Windows-only baseline failure caused by unavailable `os.fchmod`; it was reproduced before this change.

## Type of Change

<!-- Mark the applicable options. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [x] Test update

## LoopX Area

<!-- Mark the primary area. Maintainers apply the matching GitHub label. -->

- [x] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [ ] Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
- [ ] Capability or extension (providers, adapters, skills)
- [ ] Public docs or presentation surface (README, protocols, dashboard)
- [ ] Build, packaging, installer, or CI
- [ ] Host or runtime integration

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.