### PR TITLE
fix(todos): preserve completion_turn_key in event-sourced projection

### DIFF
--- a/loopx/event_sourced_state.py
+++ b/loopx/event_sourced_state.py
@@ -821,6 +821,7 @@ def _update_todo_from_event(todo: dict[str, Any], event: dict[str, Any]) -> None
             "completed_at",
             "updated_at",
             "no_followup",
+            "completion_turn_key",
         ):
             if payload.get(key) is not None:
                 todo[key] = compact_text(payload[key])
@@ -948,6 +949,7 @@ def render_todo_markdown(item: dict[str, Any]) -> list[str]:
         reason=item.get("reason"),
         completed_at=item.get("completed_at"),
         updated_at=item.get("updated_at"),
+        completion_turn_key=item.get("completion_turn_key"),
     )
     if metadata:
         lines.append(metadata)

--- a/tests/control_plane/test_event_sourced_completion_turn_key.py
+++ b/tests/control_plane/test_event_sourced_completion_turn_key.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import pytest
+
+from loopx.control_plane.todos.completion_fence import completed_todo_replay
+from loopx.event_sourced_state import (
+    TODO_ADDED,
+    TODO_COMPLETED,
+    build_state_projection,
+    make_state_event,
+    render_todo_markdown,
+)
+
+GOAL_ID = "fixture-event-goal"
+TODO_ID = "todo_fixture_event_0001"
+TURN_A = "turn-a"
+TURN_B = "turn-b"
+
+
+def _added_event() -> dict:
+    return make_state_event(
+        event_id="added-1",
+        goal_id=GOAL_ID,
+        event_type=TODO_ADDED,
+        refs={"todo_id": TODO_ID},
+        payload={
+            "role": "agent",
+            "text": "fixture event todo",
+            "priority": "P2",
+            "claimed_by": "codex-side-bypass",
+        },
+        recorded_at="2026-08-15T00:00:00Z",
+        producer="loopx.todo.add",
+    )
+
+
+def _completed_event(*, turn_key: str) -> dict:
+    return make_state_event(
+        event_id="completed-1",
+        goal_id=GOAL_ID,
+        event_type=TODO_COMPLETED,
+        refs={"todo_id": TODO_ID},
+        payload={
+            "completed_at": "2026-08-15T00:01:00Z",
+            "updated_at": "2026-08-15T00:01:00Z",
+            "evidence": "fixture done",
+            "no_followup": "true",
+            "completion_turn_key": turn_key,
+        },
+        recorded_at="2026-08-15T00:01:00Z",
+        producer="loopx.todo.complete",
+        actor_agent_id="codex-side-bypass",
+    )
+
+
+def _projected_todo() -> dict:
+    projection = build_state_projection(
+        [_added_event(), _completed_event(turn_key=TURN_A)],
+        goal_id=GOAL_ID,
+    )
+    items = projection["agent_todos"]["items"]
+    assert len(items) == 1
+    return items[0]
+
+
+def _replay(todo: dict, *, turn_key: str) -> dict:
+    result = completed_todo_replay(
+        todo=todo,
+        goal_id=GOAL_ID,
+        todo_id=TODO_ID,
+        completion_turn_key=turn_key,
+        handoff_mode="goal",
+        mutation_authority={"agent_id": "codex-side-bypass"},
+        state_file="ACTIVE_GOAL_STATE.md",
+        project=None,
+        dry_run=False,
+    )
+    assert result is not None
+    return result
+
+
+def test_event_projection_preserves_completion_turn_key() -> None:
+    todo = _projected_todo()
+    assert todo["status"] == "done"
+    assert todo["completion_turn_key"] == TURN_A
+
+
+def test_same_turn_replay_is_idempotent_after_event_projection() -> None:
+    todo = _projected_todo()
+    receipt = _replay(todo, turn_key=TURN_A)
+    assert receipt["idempotent_replay"] is True
+    assert receipt["changed"] is False
+    assert receipt["completed"] is True
+
+
+def test_different_turn_replay_fails_closed_after_event_projection() -> None:
+    todo = _projected_todo()
+    with pytest.raises(ValueError, match="different completion_turn_key"):
+        _replay(todo, turn_key=TURN_B)
+
+
+def test_event_projection_markdown_renders_completion_turn_key() -> None:
+    todo = _projected_todo()
+    rendered = "\n".join(render_todo_markdown(todo))
+    assert f"completion_turn_key={TURN_A}" in rendered


### PR DESCRIPTION
## Summary

- Keep `completion_turn_key` in the event-sourced `TODO_COMPLETED` projection and render it in the generated Markdown todo metadata.
- Same-key replay after event-log projection now returns an idempotent receipt; a different key still fails closed.
- Focused regression tests cover the projection, the replay fence, and the rendered metadata line.

## Issue Or Task

- Closes #3196

## Validation

- `python -m pytest -q tests/control_plane/test_event_sourced_completion_turn_key.py` — 4 passed
- Related control-plane tests: `tests/control_plane/test_todo_list_agent_lane_projection.py` + `tests/control_plane/test_todo_mutation_authority.py` — 44 passed
- `python -m py_compile` on changed files passes; the 3 ruff findings on `event_sourced_state.py` are pre-existing on `main` (verified against HEAD) and untouched by this diff.

## Type of Change

- [x] Bug fix
- [x] Test update

## Boundary Checklist

- [x] No credentials, private state, local paths, or raw evidence included.