### PR TITLE
feat(stride): add read-only shadow stride observation (M1)

### DIFF
--- a/loopx/control_plane/runtime/stride_observation.py
+++ b/loopx/control_plane/runtime/stride_observation.py
@@ -1,0 +1,144 @@
+"""Read-only hierarchical stride observation (RFC #3204, M1 shadow slice).
+
+This module derives a provider-neutral ``hierarchical_stride_observation_v0``
+projection from existing public-safe run receipts. It is observation only:
+it never changes Todo selection, scheduler cadence, quota spend,
+notification, gates, or execution behavior (``shadow_only`` is always true).
+Fields that cannot be derived from existing receipts stay ``unknown`` rather
+than being guessed from prose or command names.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+STRIDE_OBSERVATION_SCHEMA_VERSION = "hierarchical_stride_observation_v0"
+STRIDE_EVALUATION_SCHEMA_VERSION = "hierarchical_stride_evaluation_v0"
+EVIDENCE_FRESH_WINDOW_HOURS = 6
+AUTHORITY_CHANGE_MARKERS = ("replan", "vision", "gate")
+
+
+def _compact_text(value: Any, *, limit: int = 180) -> str:
+    return " ".join(str(value or "").strip().split())[:limit]
+
+
+def read_run_index(runtime_root: Path, goal_id: str) -> list[dict[str, Any]]:
+    """Read one goal's durable public run index (best effort, tolerant)."""
+
+    index_path = runtime_root / "goals" / goal_id / "runs" / "index.jsonl"
+    if not index_path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in index_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(row, dict):
+            rows.append(row)
+    return rows
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    text = _compact_text(value, limit=80)
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def build_stride_observation(
+    runtime_root: Path,
+    *,
+    goal_id: str,
+    agent_id: str,
+) -> dict[str, Any]:
+    """Project a shadow-only stride observation from existing run receipts."""
+
+    runs = read_run_index(runtime_root, goal_id)
+    agent_runs = [
+        run
+        for run in runs
+        if _compact_text(run.get("agent_id")) == agent_id
+    ]
+    generated_at = datetime.now(UTC)
+    fresh_cutoff = generated_at - timedelta(hours=EVIDENCE_FRESH_WINDOW_HOURS)
+    latest_run = agent_runs[-1] if agent_runs else None
+    latest_generated_at = _parse_timestamp(
+        (latest_run or {}).get("generated_at")
+    )
+    evidence_fresh = (
+        latest_generated_at is not None
+        and latest_generated_at >= fresh_cutoff
+    )
+
+    authority_change_index: int | None = None
+    for index, run in enumerate(agent_runs):
+        classification = _compact_text(run.get("classification"), limit=240)
+        lowered = classification.lower()
+        if any(marker in lowered for marker in AUTHORITY_CHANGE_MARKERS):
+            authority_change_index = index
+    bounded_slices_since_change = (
+        len(agent_runs) - authority_change_index - 1
+        if authority_change_index is not None
+        else len(agent_runs)
+    )
+
+    material_slices = sum(
+        1
+        for run in agent_runs
+        if _compact_text(run.get("delivery_outcome")) == "outcome_progress"
+    )
+    latest_outcome = (
+        _compact_text((latest_run or {}).get("delivery_outcome"), limit=60)
+        or "none"
+    )
+
+    mismatch_signals: list[str] = []
+    if agent_runs and not evidence_fresh:
+        mismatch_signals.append("settlement_lag")
+
+    return {
+        "schema_version": STRIDE_OBSERVATION_SCHEMA_VERSION,
+        "lineage": {
+            "goal_id": _compact_text(goal_id),
+            "agent_id": _compact_text(agent_id),
+            "source_run_count": len(agent_runs),
+        },
+        "delivery": {
+            "material_slices": material_slices,
+            "latest_outcome": latest_outcome,
+            "evidence_fresh": evidence_fresh,
+        },
+        "authority": {
+            "bounded_slices_since_change": bounded_slices_since_change,
+            "segment_disposition": "unknown",
+        },
+        "effect": {
+            "unknown": True,
+        },
+        "mismatch_signals": mismatch_signals,
+        "shadow_only": True,
+    }
+
+
+def evaluate_stride_observation(observation: dict[str, Any]) -> dict[str, Any]:
+    """Offline evaluator: report derived mismatch signals, recommend nothing."""
+
+    signals = list(observation.get("mismatch_signals") or [])
+    return {
+        "schema_version": STRIDE_EVALUATION_SCHEMA_VERSION,
+        "signals": signals,
+        "recommendations": [],
+        "shadow_only": True,
+    }

--- a/tests/control_plane/test_stride_observation.py
+++ b/tests/control_plane/test_stride_observation.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from loopx.control_plane.runtime.stride_observation import (
+    STRIDE_EVALUATION_SCHEMA_VERSION,
+    STRIDE_OBSERVATION_SCHEMA_VERSION,
+    build_stride_observation,
+    evaluate_stride_observation,
+)
+
+GOAL_ID = "fixture-stride-goal"
+AGENT_ID = "codex-side-bypass"
+
+
+def _write_run_index(
+    runtime_root: Path,
+    rows: list[dict],
+) -> None:
+    index_path = (
+        runtime_root / "goals" / GOAL_ID / "runs" / "index.jsonl"
+    )
+    index_path.parent.mkdir(parents=True)
+    index_path.write_text(
+        "\n".join(json.dumps(row) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _run(
+    *,
+    classification: str,
+    outcome: str,
+    minutes_ago: int,
+) -> dict:
+    generated_at = (
+        datetime.now(UTC) - timedelta(minutes=minutes_ago)
+    ).isoformat()
+    return {
+        "generated_at": generated_at,
+        "goal_id": GOAL_ID,
+        "agent_id": AGENT_ID,
+        "classification": classification,
+        "delivery_outcome": outcome,
+    }
+
+
+def test_empty_runtime_is_fail_closed_observation(tmp_path: Path) -> None:
+    observation = build_stride_observation(
+        tmp_path,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+
+    assert observation["schema_version"] == STRIDE_OBSERVATION_SCHEMA_VERSION
+    assert observation["lineage"]["source_run_count"] == 0
+    assert observation["effect"]["unknown"] is True
+    assert observation["shadow_only"] is True
+    assert observation["delivery"]["evidence_fresh"] is False
+    assert observation["authority"]["segment_disposition"] == "unknown"
+
+
+def test_derives_delivery_and_authority_from_run_receipts(
+    tmp_path: Path,
+) -> None:
+    _write_run_index(
+        tmp_path,
+        [
+            _run(
+                classification="bounded_replan_progress",
+                outcome="outcome_progress",
+                minutes_ago=180,
+            ),
+            _run(
+                classification="exact_head_review_delivered_3206",
+                outcome="outcome_progress",
+                minutes_ago=60,
+            ),
+            _run(
+                classification="monitor_watch",
+                outcome="surface_only",
+                minutes_ago=1,
+            ),
+        ],
+    )
+
+    observation = build_stride_observation(
+        tmp_path,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+
+    assert observation["lineage"]["source_run_count"] == 3
+    assert observation["delivery"]["material_slices"] == 2
+    assert observation["delivery"]["latest_outcome"] == "surface_only"
+    assert observation["delivery"]["evidence_fresh"] is True
+    assert observation["authority"]["bounded_slices_since_change"] == 2
+    assert observation["effect"]["unknown"] is True
+    assert observation["mismatch_signals"] == []
+
+
+def test_stale_evidence_reports_settlement_lag_signal(tmp_path: Path) -> None:
+    _write_run_index(
+        tmp_path,
+        [
+            _run(
+                classification="monitor_watch",
+                outcome="surface_only",
+                minutes_ago=12 * 60,
+            )
+        ],
+    )
+
+    observation = build_stride_observation(
+        tmp_path,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+
+    assert observation["delivery"]["evidence_fresh"] is False
+    assert observation["mismatch_signals"] == ["settlement_lag"]
+
+    evaluation = evaluate_stride_observation(observation)
+    assert evaluation["schema_version"] == STRIDE_EVALUATION_SCHEMA_VERSION
+    assert evaluation["signals"] == ["settlement_lag"]
+    assert evaluation["recommendations"] == []
+    assert evaluation["shadow_only"] is True
+
+
+def test_other_agent_runs_are_not_attributed(tmp_path: Path) -> None:
+    _write_run_index(
+        tmp_path,
+        [
+            {
+                "generated_at": (
+                    datetime.now(UTC) - timedelta(minutes=5)
+                ).isoformat(),
+                "goal_id": GOAL_ID,
+                "agent_id": "codex-quality-qualification",
+                "classification": "exact_head_review_delivered_3206",
+                "delivery_outcome": "outcome_progress",
+            }
+        ],
+    )
+
+    observation = build_stride_observation(
+        tmp_path,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+
+    assert observation["lineage"]["source_run_count"] == 0


### PR DESCRIPTION
## Summary

- Add `loopx/control_plane/runtime/stride_observation.py`: a read-only, shadow-only projection that derives a provider-neutral `hierarchical_stride_observation_v0` from existing public-safe run receipts.
- Delivery layer: material slices, latest outcome, evidence freshness (6h window).
- Authority layer: bounded slices since the last replan/vision/gate run; segment disposition stays `unknown`.
- Effect layer: explicit `unknown: True` (fail-closed; host metrics absent).
- Offline evaluator reports only derivable mismatch signals (`settlement_lag`) and recommends nothing.
- 4 focused tests with public-safe fixtures.

## Issue Or Task

- Tracks #3203 (RFC #3204 M1 read-only observation; merged as `ae31e498`)

## Validation

- `python -m pytest -q tests/control_plane/test_stride_observation.py` — 4 passed
- `ruff check` clean on both files
- `python -m py_compile` passes

## Type of Change

- [x] New feature (read-only observation; no runtime behavior change)
- [x] Test update

## Boundary Checklist

- [x] No credentials, private state, local paths, or raw evidence included.