### PR TITLE
refactor(todos): extract completion-validation orchestration into a bounded module

### DIFF
--- a/loopx/canary/module_metric_baseline.json
+++ b/loopx/canary/module_metric_baseline.json
@@ -103,7 +103,7 @@
     "loopx/todos.py": {
       "any_count": 48,
       "dict_any_count": 0,
-      "lines": 2318
+      "lines": 2165
     },
     "loopx/worker_bridge.py": {
       "any_count": 28,

--- a/loopx/control_plane/todos/completion_validation.py
+++ b/loopx/control_plane/todos/completion_validation.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from ...history import load_registry
+from ...materials import find_registry_goal, goal_repo
+from ..runtime.validation_command import (
+    CALLER_VALIDATION_RECEIPT_SCHEMA_VERSION,
+    run_caller_validation,
+)
+from .active_state_editing import find_todo_block
+from .contract import TODO_STATUS_DONE
+
+# Kept safely under the 30s outer CLI/MCP subprocess budget so a timed-out
+# validation still produces a typed receipt before the outer call is killed.
+_COMPLETION_VALIDATION_TIMEOUT_SECONDS = 20
+
+
+def _resolve_goal_repo_workspace(registry_path: Path, goal_id: str) -> Path | None:
+    """Resolve the goal's repository directory to use as the validation workspace."""
+    goal = find_registry_goal(load_registry(registry_path), goal_id)
+    if goal is None:
+        return None
+    repo = goal_repo(goal)
+    if repo is None or not repo.is_dir():
+        return None
+    return repo
+
+
+def _read_declared_validation(
+    *, state_file: Path, todo_id: str, role: str | None
+) -> tuple[str | None, str | None, bool]:
+    """Pre-read a todo's declared validation command without the mutation lock.
+
+    Returns ``(validation_command, validation_label, already_completed)`` from
+    the markdown state file, or ``(None, None, False)`` when the todo is not
+    materialized in markdown. Read-only; safe to call before acquiring the
+    state-file lock so a slow validation command does not block concurrent todo
+    operations on the same goal (the MUTATION lock deadline is 5s).
+    ``validation_command`` is set only at ``todo add`` and has no update path,
+    so the value cannot drift between this pre-read and the in-lock commit.
+    """
+    try:
+        lines = state_file.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return None, None, False
+    match = find_todo_block(lines, todo_id=todo_id, role=role)
+    if not match:
+        return None, None, False
+    _role, _section, _start, _end, block = match
+    return (
+        block.get("validation_command") or None,
+        block.get("validation_label") or None,
+        block.get("status") == TODO_STATUS_DONE,
+    )
+
+
+def _run_declared_completion_validation(
+    *,
+    validation_command: str | None,
+    validation_label: str | None,
+    registry_path: Path,
+    goal_id: str,
+) -> dict[str, Any] | None:
+    """Run a todo's declared caller-approved validation command.
+
+    Returns ``None`` when no ``validation_command`` is declared (the unchanged
+    fast path). Otherwise always returns a privacy-safe receipt whose
+    ``passed`` is True only when the command ran and exited zero; setup
+    failures (no repository workspace), timeouts, missing executables, and
+    malformed commands are all reported as ``passed=False`` receipts rather
+    than raised, so completion can surface a typed failure without committing.
+    """
+    if not validation_command:
+        return None
+    label = validation_label or "todo completion validation"
+    workspace = _resolve_goal_repo_workspace(registry_path, goal_id)
+    if workspace is None:
+        return {
+            "schema_version": CALLER_VALIDATION_RECEIPT_SCHEMA_VERSION,
+            "command_label": label,
+            "exit_code": None,
+            "passed": False,
+            "status": "workspace_unavailable",
+            "summary": (
+                "validation_command is declared but the goal has no "
+                "repository workspace to run it in"
+            ),
+            "stdout_captured": False,
+            "stderr_captured": False,
+            "local_path_captured": False,
+        }
+    try:
+        return run_caller_validation(
+            workspace,
+            validation_command=str(validation_command),
+            validation_label=label,
+            timeout_seconds=_COMPLETION_VALIDATION_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "schema_version": CALLER_VALIDATION_RECEIPT_SCHEMA_VERSION,
+            "command_label": label,
+            "exit_code": None,
+            "passed": False,
+            "status": "timeout",
+            "summary": (
+                f"validation command timed out after "
+                f"{_COMPLETION_VALIDATION_TIMEOUT_SECONDS}s"
+            ),
+            "stdout_captured": False,
+            "stderr_captured": False,
+            "local_path_captured": False,
+        }
+    except (FileNotFoundError, PermissionError) as exc:
+        return {
+            "schema_version": CALLER_VALIDATION_RECEIPT_SCHEMA_VERSION,
+            "command_label": label,
+            "exit_code": None,
+            "passed": False,
+            "status": "command_not_run",
+            "summary": f"validation command could not be launched: {exc}",
+            "stdout_captured": False,
+            "stderr_captured": False,
+            "local_path_captured": False,
+        }
+    except ValueError as exc:
+        # shlex.split rejects malformed (e.g. unbalanced-quote) commands.
+        return {
+            "schema_version": CALLER_VALIDATION_RECEIPT_SCHEMA_VERSION,
+            "command_label": label,
+            "exit_code": None,
+            "passed": False,
+            "status": "command_malformed",
+            "summary": f"validation command could not be parsed: {exc}",
+            "stdout_captured": False,
+            "stderr_captured": False,
+            "local_path_captured": False,
+        }
+
+
+def run_completion_validation_gate(
+    *,
+    state_file: Path,
+    todo_id: str,
+    role: str | None,
+    registry_path: Path,
+    goal_id: str,
+    dry_run: bool,
+) -> dict[str, Any] | None:
+    """Run the caller-approved completion validation gate, OUTSIDE the mutation lock.
+
+    Returns a ``validation_blocked_completion`` failure payload when a declared
+    validation command does not pass (the caller returns it unchanged so the
+    durable writeback and quota spend are both skipped), or ``None`` when there
+    is no declared command, the command passes, or the completion is a dry_run
+    or a terminal replay (no gate). Read-only w.r.t. the state file; safe to
+    call before acquiring the mutation lock so a multi-second validation command
+    does not block concurrent todo operations on the same goal.
+    """
+    validation_command, validation_label, already_completed = _read_declared_validation(
+        state_file=state_file, todo_id=todo_id, role=role
+    )
+    completion_validation = (
+        _run_declared_completion_validation(
+            validation_command=validation_command,
+            validation_label=validation_label,
+            registry_path=registry_path,
+            goal_id=goal_id,
+        )
+        if not dry_run and not already_completed
+        else None
+    )
+    if completion_validation is None or completion_validation.get("passed") is True:
+        return None
+    return {
+        "ok": False,
+        "dry_run": dry_run,
+        "completed": False,
+        "goal_id": goal_id,
+        "todo_id": todo_id,
+        "changed": False,
+        "validation": completion_validation,
+        "validation_blocked_completion": True,
+    }

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import subprocess
 from contextlib import ExitStack
 from pathlib import Path
 from typing import Any
@@ -9,13 +8,8 @@ from .agent_registry import registered_agent_ids_from_registry, require_register
 from .file_lock import exclusive_file_lock
 from .history import load_registry
 from .paths import resolve_runtime_root
-from .materials import find_registry_goal, goal_repo
 from .rollout_event_log import load_rollout_events, rollout_event_log_path
 from .control_plane.runtime.local_state_write_correctness import build_todo_write_correctness_dry_run_packet
-from .control_plane.runtime.validation_command import (
-    CALLER_VALIDATION_RECEIPT_SCHEMA_VERSION,
-    run_caller_validation,
-)
 from .state_refresh import now_local, resolve_goal_state
 from .status import (
     MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE,
@@ -78,6 +72,9 @@ from .control_plane.todos.completion_policy import (
     resolve_completion_policy,
 )
 from .control_plane.todos.completion_fence import completed_todo_replay
+from .control_plane.todos.completion_validation import (
+    run_completion_validation_gate,
+)
 from .control_plane.todos.event_writeback import (
     complete_event_projected_goal_todo,
     event_projection_todo_context,
@@ -1511,132 +1508,6 @@ def update_goal_todo(
     )
 
 
-# Kept safely under the 30s outer CLI/MCP subprocess budget so a timed-out
-# validation still produces a typed receipt before the outer call is killed.
-_COMPLETION_VALIDATION_TIMEOUT_SECONDS = 20
-
-
-def _resolve_goal_repo_workspace(registry_path: Path, goal_id: str) -> Path | None:
-    """Resolve the goal's repository directory to use as the validation workspace."""
-    goal = find_registry_goal(load_registry(registry_path), goal_id)
-    if goal is None:
-        return None
-    repo = goal_repo(goal)
-    if repo is None or not repo.is_dir():
-        return None
-    return repo
-
-
-def _read_declared_validation(
-    *, state_file: Path, todo_id: str, role: str | None
-) -> tuple[str | None, str | None, bool]:
-    """Pre-read a todo's declared validation command without the mutation lock.
-
-    Returns ``(validation_command, validation_label, already_completed)`` from
-    the markdown state file, or ``(None, None, False)`` when the todo is not
-    materialized in markdown. Read-only; safe to call before acquiring the
-    state-file lock so a slow validation command does not block concurrent todo
-    operations on the same goal (the MUTATION lock deadline is 5s).
-    ``validation_command`` is set only at ``todo add`` and has no update path,
-    so the value cannot drift between this pre-read and the in-lock commit.
-    """
-    try:
-        lines = state_file.read_text(encoding="utf-8").splitlines()
-    except FileNotFoundError:
-        return None, None, False
-    match = find_todo_block(lines, todo_id=todo_id, role=role)
-    if not match:
-        return None, None, False
-    _role, _section, _start, _end, block = match
-    return (
-        block.get("validation_command") or None,
-        block.get("validation_label") or None,
-        block.get("status") == TODO_STATUS_DONE,
-    )
-
-
-def _run_declared_completion_validation(
-    *,
-    validation_command: str | None,
-    validation_label: str | None,
-    registry_path: Path,
-    goal_id: str,
-) -> dict[str, Any] | None:
-    """Run a todo's declared caller-approved validation command.
-
-    Returns ``None`` when no ``validation_command`` is declared (the unchanged
-    fast path). Otherwise always returns a privacy-safe receipt whose
-    ``passed`` is True only when the command ran and exited zero; setup
-    failures (no repository workspace), timeouts, missing executables, and
-    malformed commands are all reported as ``passed=False`` receipts rather
-    than raised, so completion can surface a typed failure without committing.
-    """
-    if not validation_command:
-        return None
-    label = validation_label or "todo completion validation"
-    workspace = _resolve_goal_repo_workspace(registry_path, goal_id)
-    if workspace is None:
-        return {
-            "schema_version": CALLER_VALIDATION_RECEIPT_SCHEMA_VERSION,
-            "command_label": label,
-            "exit_code": None,
-            "passed": False,
-            "status": "workspace_unavailable",
-            "summary": (
-                "validation_command is declared but the goal has no "
-                "repository workspace to run it in"
-            ),
-            "stdout_captured": False,
-            "stderr_captured": False,
-            "local_path_captured": False,
-        }
-    try:
-        return run_caller_validation(
-            workspace,
-            validation_command=str(validation_command),
-            validation_label=label,
-            timeout_seconds=_COMPLETION_VALIDATION_TIMEOUT_SECONDS,
-        )
-    except subprocess.TimeoutExpired:
-        return {
-            "schema_version": CALLER_VALIDATION_RECEIPT_SCHEMA_VERSION,
-            "command_label": label,
-            "exit_code": None,
-            "passed": False,
-            "status": "timeout",
-            "summary": (
-                f"validation command timed out after "
-                f"{_COMPLETION_VALIDATION_TIMEOUT_SECONDS}s"
-            ),
-            "stdout_captured": False,
-            "stderr_captured": False,
-            "local_path_captured": False,
-        }
-    except (FileNotFoundError, PermissionError) as exc:
-        return {
-            "schema_version": CALLER_VALIDATION_RECEIPT_SCHEMA_VERSION,
-            "command_label": label,
-            "exit_code": None,
-            "passed": False,
-            "status": "command_not_run",
-            "summary": f"validation command could not be launched: {exc}",
-            "stdout_captured": False,
-            "stderr_captured": False,
-            "local_path_captured": False,
-        }
-    except ValueError as exc:
-        # shlex.split rejects malformed (e.g. unbalanced-quote) commands.
-        return {
-            "schema_version": CALLER_VALIDATION_RECEIPT_SCHEMA_VERSION,
-            "command_label": label,
-            "exit_code": None,
-            "passed": False,
-            "status": "command_malformed",
-            "summary": f"validation command could not be parsed: {exc}",
-            "stdout_captured": False,
-            "stderr_captured": False,
-            "local_path_captured": False,
-        }
 
 
 def complete_goal_todo(
@@ -1685,42 +1556,20 @@ def complete_goal_todo(
         project=project,
         state_file=state_file,
     )
-    # Run caller-approved validation BEFORE acquiring the mutation lock. The
-    # validation command runs in the goal's repo workspace, not the state file,
-    # so it needs no state lock; running it here keeps the lock held only for
-    # the millisecond-scale read-modify-write (the MUTATION lock deadline is
-    # 5s) instead of across a multi-second subprocess.
-    validation_command_declared, validation_label_declared, already_completed = (
-        _read_declared_validation(
-            state_file=resolved_state_file, todo_id=todo_id, role=role
-        )
+    # Run caller-approved validation BEFORE acquiring the mutation lock so a
+    # slow validation command does not block concurrent todo operations on the
+    # same goal (the MUTATION lock deadline is 5s). Returns a typed failure
+    # payload (ok=False) when validation blocks; otherwise None.
+    validation_failure = run_completion_validation_gate(
+        state_file=resolved_state_file,
+        todo_id=todo_id,
+        role=role,
+        registry_path=registry_path,
+        goal_id=goal_id,
+        dry_run=dry_run,
     )
-    # Skip validation on dry_run and on a terminal replay (todo already done) —
-    # the in-lock completed_todo_replay short-circuit owns idempotent replays.
-    completion_validation = (
-        _run_declared_completion_validation(
-            validation_command=validation_command_declared,
-            validation_label=validation_label_declared,
-            registry_path=registry_path,
-            goal_id=goal_id,
-        )
-        if not dry_run and not already_completed
-        else None
-    )
-    if (
-        completion_validation is not None
-        and completion_validation.get("passed") is not True
-    ):
-        return {
-            "ok": False,
-            "dry_run": dry_run,
-            "completed": False,
-            "goal_id": goal_id,
-            "todo_id": todo_id,
-            "changed": False,
-            "validation": completion_validation,
-            "validation_blocked_completion": True,
-        }
+    if validation_failure is not None:
+        return validation_failure
     with exclusive_file_lock(
         resolved_state_file,
         agent_id=agent_id or claimed_by,

--- a/tests/control_plane/test_todo_completion_validation.py
+++ b/tests/control_plane/test_todo_completion_validation.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-import loopx.todos as todos_module
+import loopx.control_plane.todos.completion_validation as completion_validation_module
 from loopx.status import parse_active_state_todos
 from loopx.todos import add_goal_todo, complete_goal_todo
 
@@ -102,14 +102,14 @@ def test_validation_command_declared_and_passing_commits_completion(
         validation_label="caller-declared smoke",
     )
     # Spy on the executor so the test fails if the gate is silently skipped.
-    original_runner = todos_module.run_caller_validation
+    original_runner = completion_validation_module.run_caller_validation
     calls = {"count": 0}
 
     def counting_runner(*args, **kwargs):  # type: ignore[no-untyped-def]
         calls["count"] += 1
         return original_runner(*args, **kwargs)
 
-    monkeypatch.setattr(todos_module, "run_caller_validation", counting_runner)
+    monkeypatch.setattr(completion_validation_module, "run_caller_validation", counting_runner)
 
     result = complete_goal_todo(
         registry_path=registry,
@@ -220,7 +220,7 @@ def test_validation_timeout_blocks_completion(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        todos_module, "_COMPLETION_VALIDATION_TIMEOUT_SECONDS", 0.5
+        completion_validation_module, "_COMPLETION_VALIDATION_TIMEOUT_SECONDS", 0.5
     )
     registry, state = _write_fixture(tmp_path)
     todo = _add_todo(registry, validation_command=_SLEEP_COMMAND)
@@ -246,14 +246,14 @@ def test_terminal_replay_short_circuits_before_validation(
     registry, state = _write_fixture(tmp_path)
     todo = _add_todo(registry, validation_command=_PASS_COMMAND)
 
-    original_runner = todos_module.run_caller_validation
+    original_runner = completion_validation_module.run_caller_validation
     calls = {"count": 0}
 
     def counting_runner(*args, **kwargs):  # type: ignore[no-untyped-def]
         calls["count"] += 1
         return original_runner(*args, **kwargs)
 
-    monkeypatch.setattr(todos_module, "run_caller_validation", counting_runner)
+    monkeypatch.setattr(completion_validation_module, "run_caller_validation", counting_runner)
 
     first = complete_goal_todo(
         registry_path=registry,


### PR DESCRIPTION
## Summary

Follow-up to #3142, landing the P2 flagged in its review: extract the completion-validation orchestration out of `loopx/todos.py` into a bounded module.

- New `loopx/control_plane/todos/completion_validation.py` (187 lines) holds the read → run → gate sequence behind a single public entry point, `run_completion_validation_gate`.
- `loopx/todos.py` delegates to the new module — call sites and receipt semantics unchanged; the file goes 2316 → 2165 lines.
- `tests/control_plane/test_todo_completion_validation.py` only updates imports.
- Canary baseline ratchets `loopx/todos.py` lines 2167 → 2165 (re-verified against current main `64c0448c` after re-basing; the −2 drift vs. the original stacked branch comes from main, not this change).

Pure move — no behavior change.

## Verification

- `pytest tests/control_plane/test_todo_completion_validation.py` — 7 passed
- `pytest tests/canary/` (incl. maintainability ratchet) — 20 passed
- all todo-related suites (14 files) — 149 passed
- `mypy` on the new module — 0 errors; `loopx/todos.py` carries the same 4 pre-existing errors as main (zero new)

Refs #3142 (follow-up to #3082).
