### PR TITLE
feat(todos): per-todo validation timeout overrides the 20s default

### DIFF
--- a/loopx/canary/module_metric_baseline.json
+++ b/loopx/canary/module_metric_baseline.json
@@ -103,7 +103,7 @@
     "loopx/todos.py": {
       "any_count": 48,
       "dict_any_count": 0,
-      "lines": 2165
+      "lines": 2190
     },
     "loopx/worker_bridge.py": {
       "any_count": 28,

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -219,6 +219,16 @@ def register_todo_command(
         "--validation-label",
         help="Optional public-safe label for the validation receipt.",
     )
+    todo_parser.add_argument(
+        "--validation-timeout-seconds",
+        type=int,
+        help=(
+            "Per-todo timeout for the caller-approved validation command. "
+            "Only meaningful with --validation-command on `todo add`; must be "
+            "1-29 so a timed-out validation still produces a typed receipt "
+            "inside the 30s outer subprocess budget. Defaults to 20."
+        ),
+    )
     todo_parser.add_argument("--reason", help="Public-safe reason for blocked/deferred/supersede transitions.")
     todo_parser.add_argument(
         "--authority-reason",
@@ -618,6 +628,7 @@ def handle_todo_command(
                 resume_when=args.resume_when,
                 validation_command=args.validation_command,
                 validation_label=args.validation_label,
+                validation_timeout_seconds=args.validation_timeout_seconds,
                 monitor_metadata={
                     "target_key": args.monitor_target_key,
                     "cadence": args.cadence,

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -48,6 +48,7 @@ TODO_OPTION_FIELDS = (
     ("--resume-when", "resume_when"),
     ("--validation-command", "validation_command"),
     ("--validation-label", "validation_label"),
+    ("--validation-timeout-seconds", "validation_timeout_seconds"),
     ("--clear-resume-when", "clear_resume_when"),
     ("--target-key", "monitor_target_key"),
     ("--cadence", "cadence"),

--- a/loopx/control_plane/todos/completion_validation.py
+++ b/loopx/control_plane/todos/completion_validation.py
@@ -16,6 +16,9 @@ from .contract import TODO_STATUS_DONE
 # Kept safely under the 30s outer CLI/MCP subprocess budget so a timed-out
 # validation still produces a typed receipt before the outer call is killed.
 _COMPLETION_VALIDATION_TIMEOUT_SECONDS = 20
+# Per-todo overrides (declared on `todo add`) must also stay under that outer
+# budget for the same reason; the writer-side range check enforces this.
+COMPLETION_VALIDATION_TIMEOUT_MAX_SECONDS = 29
 
 
 def _resolve_goal_repo_workspace(registry_path: Path, goal_id: str) -> Path | None:
@@ -31,28 +34,40 @@ def _resolve_goal_repo_workspace(registry_path: Path, goal_id: str) -> Path | No
 
 def _read_declared_validation(
     *, state_file: Path, todo_id: str, role: str | None
-) -> tuple[str | None, str | None, bool]:
+) -> tuple[str | None, str | None, int | None, bool]:
     """Pre-read a todo's declared validation command without the mutation lock.
 
-    Returns ``(validation_command, validation_label, already_completed)`` from
-    the markdown state file, or ``(None, None, False)`` when the todo is not
-    materialized in markdown. Read-only; safe to call before acquiring the
-    state-file lock so a slow validation command does not block concurrent todo
-    operations on the same goal (the MUTATION lock deadline is 5s).
-    ``validation_command`` is set only at ``todo add`` and has no update path,
-    so the value cannot drift between this pre-read and the in-lock commit.
+    Returns ``(validation_command, validation_label, validation_timeout_seconds,
+    already_completed)`` from the markdown state file, or ``(None, None, None,
+    False)`` when the todo is not materialized in markdown. Read-only; safe to
+    call before acquiring the state-file lock so a slow validation command does
+    not block concurrent todo operations on the same goal (the MUTATION lock
+    deadline is 5s). ``validation_command`` and ``validation_timeout_seconds``
+    are set only at ``todo add`` and have no update path, so the values cannot
+    drift between this pre-read and the in-lock commit. A stored timeout that
+    fails to parse as an int falls back to ``None`` (the default), matching the
+    writer-side range check that guarantees a well-formed value.
     """
     try:
         lines = state_file.read_text(encoding="utf-8").splitlines()
     except FileNotFoundError:
-        return None, None, False
+        return None, None, None, False
     match = find_todo_block(lines, todo_id=todo_id, role=role)
     if not match:
-        return None, None, False
+        return None, None, None, False
     _role, _section, _start, _end, block = match
+    try:
+        timeout_seconds: int | None = (
+            int(block["validation_timeout_seconds"])
+            if block.get("validation_timeout_seconds")
+            else None
+        )
+    except (TypeError, ValueError):
+        timeout_seconds = None
     return (
         block.get("validation_command") or None,
         block.get("validation_label") or None,
+        timeout_seconds,
         block.get("status") == TODO_STATUS_DONE,
     )
 
@@ -61,20 +76,28 @@ def _run_declared_completion_validation(
     *,
     validation_command: str | None,
     validation_label: str | None,
+    validation_timeout_seconds: int | None,
     registry_path: Path,
     goal_id: str,
 ) -> dict[str, Any] | None:
     """Run a todo's declared caller-approved validation command.
 
     Returns ``None`` when no ``validation_command`` is declared (the unchanged
-    fast path). Otherwise always returns a privacy-safe receipt whose
-    ``passed`` is True only when the command ran and exited zero; setup
-    failures (no repository workspace), timeouts, missing executables, and
-    malformed commands are all reported as ``passed=False`` receipts rather
-    than raised, so completion can surface a typed failure without committing.
+    fast path). ``validation_timeout_seconds`` overrides the module default
+    when declared on ``todo add``; ``None`` keeps the default. Otherwise always
+    returns a privacy-safe receipt whose ``passed`` is True only when the
+    command ran and exited zero; setup failures (no repository workspace),
+    timeouts, missing executables, and malformed commands are all reported as
+    ``passed=False`` receipts rather than raised, so completion can surface a
+    typed failure without committing.
     """
     if not validation_command:
         return None
+    timeout_seconds = (
+        validation_timeout_seconds
+        if validation_timeout_seconds is not None
+        else _COMPLETION_VALIDATION_TIMEOUT_SECONDS
+    )
     label = validation_label or "todo completion validation"
     workspace = _resolve_goal_repo_workspace(registry_path, goal_id)
     if workspace is None:
@@ -97,7 +120,7 @@ def _run_declared_completion_validation(
             workspace,
             validation_command=str(validation_command),
             validation_label=label,
-            timeout_seconds=_COMPLETION_VALIDATION_TIMEOUT_SECONDS,
+            timeout_seconds=timeout_seconds,
         )
     except subprocess.TimeoutExpired:
         return {
@@ -107,8 +130,7 @@ def _run_declared_completion_validation(
             "passed": False,
             "status": "timeout",
             "summary": (
-                f"validation command timed out after "
-                f"{_COMPLETION_VALIDATION_TIMEOUT_SECONDS}s"
+                f"validation command timed out after {timeout_seconds}s"
             ),
             "stdout_captured": False,
             "stderr_captured": False,
@@ -160,13 +182,17 @@ def run_completion_validation_gate(
     call before acquiring the mutation lock so a multi-second validation command
     does not block concurrent todo operations on the same goal.
     """
-    validation_command, validation_label, already_completed = _read_declared_validation(
-        state_file=state_file, todo_id=todo_id, role=role
-    )
+    (
+        validation_command,
+        validation_label,
+        validation_timeout_seconds,
+        already_completed,
+    ) = _read_declared_validation(state_file=state_file, todo_id=todo_id, role=role)
     completion_validation = (
         _run_declared_completion_validation(
             validation_command=validation_command,
             validation_label=validation_label,
+            validation_timeout_seconds=validation_timeout_seconds,
             registry_path=registry_path,
             goal_id=goal_id,
         )

--- a/loopx/control_plane/todos/contract.py
+++ b/loopx/control_plane/todos/contract.py
@@ -1138,6 +1138,7 @@ _TODO_METADATA_FIELD_SCHEMA = (
             "completion_turn_key",
             "validation_command",
             "validation_label",
+            "validation_timeout_seconds",
         )
     ),
     _TodoMetadataField(
@@ -1276,6 +1277,7 @@ def format_todo_metadata_line(
     completion_turn_key: str | None = None,
     validation_command: str | None = None,
     validation_label: str | None = None,
+    validation_timeout_seconds: str | None = None,
     reason: str | None = None,
     completed_at: str | None = None,
     updated_at: str | None = None,

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -73,6 +73,7 @@ from .control_plane.todos.completion_policy import (
 )
 from .control_plane.todos.completion_fence import completed_todo_replay
 from .control_plane.todos.completion_validation import (
+    COMPLETION_VALIDATION_TIMEOUT_MAX_SECONDS,
     run_completion_validation_gate,
 )
 from .control_plane.todos.event_writeback import (
@@ -576,10 +577,27 @@ def add_todo_to_lines(
     resume_when: str | None = None,
     validation_command: str | None = None,
     validation_label: str | None = None,
+    validation_timeout_seconds: int | None = None,
     monitor_metadata: dict[str, Any] | None = None,
     evidence: str | None = None,
     updated_at: str | None = None,
 ) -> dict[str, Any]:
+    if validation_timeout_seconds is not None:
+        if not validation_command:
+            raise ValueError(
+                "--validation-timeout-seconds requires --validation-command"
+            )
+        if not (
+            1
+            <= validation_timeout_seconds
+            <= COMPLETION_VALIDATION_TIMEOUT_MAX_SECONDS
+        ):
+            raise ValueError(
+                "--validation-timeout-seconds must be between 1 and "
+                f"{COMPLETION_VALIDATION_TIMEOUT_MAX_SECONDS} (the outer "
+                "CLI/MCP subprocess budget is 30s, and a timed-out "
+                "validation must still produce a typed receipt)"
+            )
     if role == "agent" and blocks_agent:
         raise ValueError(
             "blocks_agent is only valid for user gates; use excluded_agents for "
@@ -657,6 +675,11 @@ def add_todo_to_lines(
             resume_when=normalized_resume_when,
             validation_command=validation_command,
             validation_label=validation_label,
+            validation_timeout_seconds=(
+                str(validation_timeout_seconds)
+                if validation_timeout_seconds is not None
+                else None
+            ),
             **normalized_monitor_metadata,
             evidence=evidence,
             updated_at=updated_at,
@@ -845,6 +868,7 @@ def add_goal_todo(
     resume_when: str | None = None,
     validation_command: str | None = None,
     validation_label: str | None = None,
+    validation_timeout_seconds: int | None = None,
     monitor_metadata: dict[str, Any] | None = None,
     project: Path | None = None,
     state_file: Path | None = None,
@@ -1045,6 +1069,7 @@ def add_goal_todo(
             resume_when=normalized_resume_when,
             validation_command=validation_command,
             validation_label=validation_label,
+            validation_timeout_seconds=validation_timeout_seconds,
             monitor_metadata=normalized_monitor_metadata,
             updated_at=updated_at,
         )

--- a/tests/control_plane/test_todo_completion_validation.py
+++ b/tests/control_plane/test_todo_completion_validation.py
@@ -78,6 +78,7 @@ def _add_todo(
     *,
     validation_command: str | None = None,
     validation_label: str | None = None,
+    validation_timeout_seconds: int | None = None,
 ) -> dict:
     return add_goal_todo(
         registry_path=registry,
@@ -88,6 +89,7 @@ def _add_todo(
         claimed_by=AGENT,
         validation_command=validation_command,
         validation_label=validation_label,
+        validation_timeout_seconds=validation_timeout_seconds,
     )
 
 
@@ -275,3 +277,44 @@ def test_terminal_replay_short_circuits_before_validation(
     # Replay short-circuits before the validation gate; the command is not re-run.
     assert calls["count"] == 1
     assert replay["ok"] is True
+
+
+def test_per_todo_validation_timeout_overrides_default(tmp_path: Path) -> None:
+    registry, state = _write_fixture(tmp_path)
+    # A 1s per-todo timeout cuts the sleeping command off long before the 20s
+    # module default, and the typed receipt reports the declared value.
+    todo = _add_todo(
+        registry,
+        validation_command=_SLEEP_COMMAND,
+        validation_timeout_seconds=1,
+    )
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=str(todo["todo_id"]),
+        agent_id=AGENT,
+        evidence="claim of completion",
+    )
+    assert result["ok"] is False
+    assert result["validation_blocked_completion"] is True
+    receipt = result["validation"]
+    assert receipt["passed"] is False
+    assert receipt["status"] == "timeout"
+    assert "timed out after 1s" in receipt["summary"]
+    assert _agent_todo(state, str(todo["todo_id"]))["status"] == "open"
+
+
+def test_validation_timeout_out_of_range_rejected(tmp_path: Path) -> None:
+    registry, _state = _write_fixture(tmp_path)
+    with pytest.raises(ValueError, match="1 and 29"):
+        _add_todo(
+            registry,
+            validation_command=_PASS_COMMAND,
+            validation_timeout_seconds=30,
+        )
+
+
+def test_validation_timeout_requires_validation_command(tmp_path: Path) -> None:
+    registry, _state = _write_fixture(tmp_path)
+    with pytest.raises(ValueError, match="requires --validation-command"):
+        _add_todo(registry, validation_timeout_seconds=5)


### PR DESCRIPTION
## Summary

Lands the second P2 flagged in the #3142 review: the completion-validation gate ran every declared `validation_command` with a fixed 20s module constant, so tests could only exercise the timeout path by monkeypatching the constant.

- `todo add` accepts an optional `--validation-timeout-seconds` alongside `--validation-command`. Range-checked to **1–29** at the writer side: a timed-out validation must still produce a typed receipt before the outer CLI/MCP subprocess budget (30s) kills the call. Declaring a timeout without a command is rejected.
- The value persists in the todo metadata block and flows through `_read_declared_validation` into `run_completion_validation_gate`, replacing the constant in both the runner call and the timeout receipt summary (`"timed out after Ns"` now reports the declared value).
- Unchanged elsewhere: todos without the field keep the 20s default, the no-command fast path is untouched, and the receipt still captures no stdout/stderr/local paths.

## Verification

- `pytest tests/control_plane/test_todo_completion_validation.py` — 10 passed (3 new: declared 1s timeout cuts off a sleeping command and reports `after 1s`; out-of-range 30 rejected; timeout-without-command rejected). The override test needs no monkeypatch — the declared value itself drives the timeout.
- all todo-related suites (14 files) — 152 passed
- `pytest tests/canary/` (incl. maintainability ratchet) — 20 passed; `loopx/todos.py` baseline bumped 2165 → 2190 (honest bump for the new flag plumbing)
- `mypy` — the 4 pre-existing `loopx/todos.py` errors are identical to main; the new plumbing adds none

Refs #3142 (second P2 follow-up; the first, the module extraction, landed in #3209).
