### PR TITLE
fix(replan): settle all typed semantic exits

### DIFF
--- a/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
+++ b/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.md
@@ -576,6 +576,15 @@ knowledge. Todo, monitor, capability, scheduler, and gate state machines keep
 their domain transition invariants. They do not move behind a shared protocol
 merely because their packets have similar fields.
 
+The replan semantic-exit repair in #3208 is an explicit non-candidate:
+`refresh-state` already re-derives the current obligation and records a typed
+semantic ACK, while the defect was an extra goal-frontier settlement condition
+that ignored valid non-successor ACKs when acceptance gaps remained. This is a
+domain-local reducer/ACK invariant, not a second multi-step executor. Keep it in
+the replan/goal-frontier owner. Revisit Effect Program migration only when a
+second real runtime scenario—such as a quota/status read ACK with the same
+plan/receipt lifecycle—can replace duplicate orchestration across two adapters.
+
 The earlier R5-R9 list is therefore not an implementation queue:
 
 - the shared `EffectInterpreter` protocol is deferred to M7.3;

--- a/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.zh-CN.md
+++ b/docs/architecture/rfcs/agent-loop-effect-interpreter-v0.zh-CN.md
@@ -377,6 +377,8 @@ M7.3：在两个 M7.2 adapter 都消费经过验证的 plan/receipt 语义后，
 
 M7.4：只有在移除重复知识时，才一次扩展一个有界状态族。Todo、monitor、capability、scheduler 和 gate 状态机保留自己的 domain transition invariants。它们不能仅仅因为 packet 字段相似就移到共享 protocol 后面。
 
+#3208 的 replan semantic-exit 修复明确不是候选：`refresh-state` 已经会重新推导当前 obligation 并记录 typed semantic ACK，实际缺陷是 goal-frontier 中一个额外的 settlement 条件在 acceptance gaps 仍存在时忽略了合法的 non-successor ACK。这是 domain-local reducer/ACK invariant，不是第二个 multi-step executor，应继续由 replan/goal-frontier owner 持有。只有第二个真实 runtime 场景（例如具有相同 plan/receipt lifecycle 的 quota/status read ACK）出现，并且能在两个 adapter 间删除重复编排时，才重新评估 Effect Program 迁移。
+
 因此，之前的 R5-R9 列表不是实施队列：
 
 - 共享 `EffectInterpreter` protocol 推迟到 M7.3；

--- a/docs/reference/protocols/agent-scoped-evidence-ledger-v0.md
+++ b/docs/reference/protocols/agent-scoped-evidence-ledger-v0.md
@@ -186,6 +186,11 @@ The agent should then write back one of:
 - coverage-backed `exploration_exhausted` or `no_followup`; or
 - for a vision-derived duty, a fresh evidence-linked vision path outcome.
 
+An accepted typed semantic ACK settles the corresponding projected obligation
+even when the source acceptance gap remains visible. Terminal coverage inputs
+fail at the CLI boundary when their required coverage scope is missing;
+`exploration_exhausted` additionally requires explicit coverage completion.
+
 Every successful diagnostic `loopx evidence-log` execution appends an
 `evidence_log_read` rollout event and returns an
 `evidence_log_read_receipt_v0`. The receipt carries the goal id, agent id,

--- a/docs/reference/protocols/goal-vision-replan-contract-v0.md
+++ b/docs/reference/protocols/goal-vision-replan-contract-v0.md
@@ -84,7 +84,9 @@ For machine-generated or multi-field patches, the same command also accepts
 both pass through the same budget validation. When a vision-derived replan duty
 is open, a valid packet counts only when it carries a fresh evidence-linked path
 outcome accepted by the shared semantic write gate. An invalid, over-budget, or
-pathless packet fails instead of recording a partial closure.
+pathless packet fails instead of recording a partial closure. A matching typed
+semantic ACK settles the vision-derived duty even while the original acceptance
+gap remains visible in the source projection.
 
 Inline vision writes require `--agent-id`. JSON packets must also resolve to
 the same `agent_id` as the refresh run. This keeps `research-executor`,

--- a/examples/control_plane/goal-frontier-replan-rules-smoke.py
+++ b/examples/control_plane/goal-frontier-replan-rules-smoke.py
@@ -54,16 +54,24 @@ def advancement(todo_id: str, claimed_by: str, *, index: int) -> dict:
     )
 
 
-def monitor() -> dict:
+def monitor(
+    *,
+    cadence: str | None = "15m",
+    next_due_at: str | None = "2999-01-01T00:00:00+00:00",
+) -> dict:
+    schedule = {}
+    if cadence is not None:
+        schedule["cadence"] = cadence
+    if next_due_at is not None:
+        schedule["next_due_at"] = next_due_at
     return quota_todo_item(
         todo_id="todo_monitor",
         text="[P1] Monitor a material transition.",
         claimed_by=CURRENT_AGENT,
         task_class="continuous_monitor",
         action_kind="monitor",
-        cadence="15m",
-        next_due_at="2999-01-01T00:00:00+00:00",
         target_key="goal-frontier-rule-smoke",
+        **schedule,
     )
 
 
@@ -108,10 +116,21 @@ def main() -> None:
     assert own_frontier["selected_todo"]["todo_id"] == "todo_current"
     assert own_frontier["goal_frontier_projection"]["replan_required"] is False
 
-    monitor_only = quota([monitor()], include_vision=False)
-    assert monitor_only["decision"] == "autonomous_replan_required", monitor_only
-    trigger = monitor_only["autonomous_replan_obligation"]["triggers"][0]
-    assert trigger["kind"] == "frontier_exhausted_monitor_lane", trigger
+    future_monitor = quota([monitor()], include_vision=False)
+    assert future_monitor["decision"] == "skip", future_monitor
+    assert future_monitor["effective_action"] == "monitor_quiet_skip", future_monitor
+    assert future_monitor["goal_frontier_projection"]["replan_required"] is False
+
+    unscheduled_monitor = quota(
+        [monitor(cadence=None, next_due_at=None)],
+        include_vision=False,
+    )
+    assert unscheduled_monitor["decision"] == "run", unscheduled_monitor
+    assert unscheduled_monitor["selected_todo"]["todo_id"] == "todo_monitor"
+    assert unscheduled_monitor["work_lane_contract"]["obligation"] == (
+        "repair_monitor_schedule_metadata"
+    )
+    assert unscheduled_monitor["goal_frontier_projection"]["replan_required"] is False
     print("goal-frontier-replan-rules-smoke ok")
 
 

--- a/loopx/cli_commands/project_lifecycle.py
+++ b/loopx/cli_commands/project_lifecycle.py
@@ -176,6 +176,22 @@ def _inline_progress_observation(
         return None
     if not fields["result_class"]:
         raise ValueError("typed progress observation requires --progress-result-class")
+    if fields["result_class"] in {
+        ProgressResultClass.EXPLORATION_EXHAUSTED.value,
+        ProgressResultClass.NO_FOLLOWUP.value,
+    } and not fields["coverage_scope_id"]:
+        raise ValueError(
+            f"--progress-result-class {fields['result_class']} requires "
+            "--progress-coverage-scope-id"
+        )
+    if (
+        fields["result_class"] == ProgressResultClass.EXPLORATION_EXHAUSTED.value
+        and fields["coverage_complete"] is not True
+    ):
+        raise ValueError(
+            "--progress-result-class exploration_exhausted requires "
+            "--progress-coverage-complete"
+        )
     return {
         "schema_version": "typed_progress_observation_v0",
         **{key: value for key, value in fields.items() if value is not None},

--- a/loopx/control_plane/goals/goal_frontier/__init__.py
+++ b/loopx/control_plane/goals/goal_frontier/__init__.py
@@ -1655,7 +1655,6 @@ def build_goal_frontier_projection_context_from_status(
             obligation_ack,
             replan_obligation,
         )
-        and (not acceptance_gaps or replan_transition_ack is not None)
     ):
         replan_obligation = None
         replan_scope = autonomous_replan_scope_decision(
@@ -1693,7 +1692,6 @@ def build_goal_frontier_projection_context_from_status(
             frontier_obligation_ack,
             frontier_replan_obligation,
         )
-        and (not acceptance_gaps or frontier_transition_ack is not None)
     ):
         frontier_replan_obligation = None
         replan_transition_ack = frontier_transition_ack

--- a/loopx/control_plane/testing/replan_semantic_action_behavior.py
+++ b/loopx/control_plane/testing/replan_semantic_action_behavior.py
@@ -60,6 +60,7 @@ class _ReplanSemanticActionFixture:
     frontier_target: Path
     work_source_target: Path
     composition_experiment_ref: str | None = None
+    frontier_exhausted: bool = False
 
 
 @dataclass
@@ -78,6 +79,7 @@ class _QualificationState:
     work_source_read: bool = False
     created_successor_id: str | None = None
     successor_reentry_observation: dict[str, Any] | None = None
+    semantic_reentry_observation: dict[str, Any] | None = None
 
 
 def _digest(value: str) -> str:
@@ -88,6 +90,7 @@ def _build_fixture(
     root: Path,
     *,
     composition_frontier: bool = False,
+    exhausted_frontier: bool = False,
 ) -> _ReplanSemanticActionFixture:
     source_root = Path(__file__).resolve().parents[3]
     project_root = root / "project"
@@ -136,15 +139,19 @@ def _build_fixture(
                         "evidence_id": "evidence-existing",
                     }
                 ],
-                "uncovered": [
-                    {
-                        "surface_id": _FIXTURE_NEW_SURFACE_ID,
-                        "hypothesis_id": _FIXTURE_NEW_HYPOTHESIS_ID,
-                        "probe_kind": _FIXTURE_NEW_PROBE_KIND,
-                        "evidence_id": _FIXTURE_NEW_EVIDENCE_ID,
-                        "source_ref": _FIXTURE_SOURCE_FILE,
-                    }
-                ],
+                "uncovered": (
+                    []
+                    if exhausted_frontier
+                    else [
+                        {
+                            "surface_id": _FIXTURE_NEW_SURFACE_ID,
+                            "hypothesis_id": _FIXTURE_NEW_HYPOTHESIS_ID,
+                            "probe_kind": _FIXTURE_NEW_PROBE_KIND,
+                            "evidence_id": _FIXTURE_NEW_EVIDENCE_ID,
+                            "source_ref": _FIXTURE_SOURCE_FILE,
+                        }
+                    ]
+                ),
             },
             ensure_ascii=False,
             indent=2,
@@ -153,30 +160,50 @@ def _build_fixture(
         + "\n",
         encoding="utf-8",
     )
+    fixture_objective = (
+        "Inspect the projected frontier and close the bounded goal when its "
+        "coverage is exhausted."
+        if exhausted_frontier
+        else "Inspect the projected frontier and select one uncovered surface."
+    )
+    fixture_next_action = (
+        f"Read `{_FIXTURE_FRONTIER_FILE}`. If no uncovered entries remain, "
+        "persist a coverage-backed exploration_exhausted result through "
+        "refresh-state."
+        if exhausted_frontier
+        else (
+            f"Read `{_FIXTURE_FRONTIER_FILE}`, inspect the selected uncovered "
+            "entry's `source_ref`, then persist the typed result through "
+            "refresh-state. If replan creates a successor Todo, bind the current "
+            "replan obligation in that same Todo add; when the command returns "
+            "host_action=end_current_heartbeat, end this heartbeat and do not "
+            "execute the successor until the next heartbeat."
+        )
+    )
+    fixture_agent_todo = (
+        "- [ ] [P1-monitor] Observe the bounded fixture until its frontier "
+        "changes.\n"
+        "  <!-- loopx:todo "
+        f"todo_id={_FIXTURE_WORK_ITEM_ID} status=open "
+        "task_class=continuous_monitor action_kind=observe_fixture "
+        f"claimed_by={_FIXTURE_AGENT_ID} "
+        "target_key=replan-semantic-fixture "
+        "cadence=1d next_due_at=2999-01-01T00%3A00%3A00Z -->\n"
+    )
     state_path.write_text(
         "---\n"
         "status: active\n"
         "owner_mode: goal\n"
-        'objective: "Inspect the projected frontier and select one uncovered surface."\n'
+        f'objective: "{fixture_objective}"\n'
         "updated_at: 2026-08-13T00:00:00+08:00\n"
         "---\n\n"
         "# Replan Semantic Action Fixture\n\n"
         "## Objective\n\n"
-        "Inspect the projected frontier and select one uncovered surface.\n\n"
+        f"{fixture_objective}\n\n"
         "## Next Action\n\n"
-        f"- Read `{_FIXTURE_FRONTIER_FILE}`, inspect the selected uncovered "
-        "entry's `source_ref`, then persist the typed result through "
-        "refresh-state. If replan creates a successor Todo, bind the current "
-        "replan obligation in that same Todo add; when the command returns "
-        "host_action=end_current_heartbeat, end this heartbeat and do not "
-        "execute the successor until the next heartbeat.\n\n"
+        f"- {fixture_next_action}\n\n"
         "## Agent Todo\n\n"
-        "- [ ] [P1-monitor] Observe the bounded fixture until its frontier changes.\n"
-        "  <!-- loopx:todo "
-        f"todo_id={_FIXTURE_WORK_ITEM_ID} status=open "
-        "task_class=continuous_monitor action_kind=observe_fixture "
-        f"claimed_by={_FIXTURE_AGENT_ID} target_key=replan-semantic-fixture "
-        "cadence=1d next_due_at=2999-01-01T00%3A00%3A00Z -->\n",
+        f"{fixture_agent_todo}",
         encoding="utf-8",
     )
     registry_goal: dict[str, Any] = {
@@ -377,6 +404,7 @@ def _build_fixture(
         composition_experiment_ref=(
             _FIXTURE_COMPOSITION_EXPERIMENT_ID if composition_frontier else None
         ),
+        frontier_exhausted=exhausted_frontier,
     )
 
 
@@ -569,6 +597,29 @@ def _successor_reentry_observation(
     return observation
 
 
+def _semantic_reentry_observation(
+    packet: Mapping[str, Any],
+    *,
+    obligation_id: str,
+) -> dict[str, Any]:
+    obligation = packet.get("autonomous_replan_obligation")
+    if (
+        isinstance(obligation, Mapping)
+        and obligation.get("obligation_id") == obligation_id
+    ):
+        raise ValueError("semantic_reentry_replan_not_closed")
+    if packet.get("decision") == "autonomous_replan_required":
+        raise ValueError("semantic_reentry_replan_not_closed")
+    if packet.get("decision") != "skip":
+        raise ValueError("semantic_reentry_did_not_exit")
+    return {
+        "decision": packet.get("decision"),
+        "effective_action": packet.get("effective_action"),
+        "replan_closed": True,
+        "exited": True,
+    }
+
+
 def _execute_loopx(
     command: str,
     *,
@@ -707,6 +758,8 @@ def _qualification_receipt(
     )
     if state.successor_reentry_observation is not None:
         receipt["successor_reentry"] = state.successor_reentry_observation
+    if state.semantic_reentry_observation is not None:
+        receipt["semantic_reentry"] = state.semantic_reentry_observation
     return receipt
 
 
@@ -774,12 +827,17 @@ def _expected_obligation_id(state: _QualificationState) -> str:
     return obligation_id
 
 
-def _require_observed_frontier(state: _QualificationState, *, prefix: str) -> None:
+def _require_observed_frontier(
+    state: _QualificationState,
+    *,
+    prefix: str,
+    work_source_required: bool = True,
+) -> None:
     if state.quota_packet is None:
         raise ValueError(f"{prefix}_before_quota")
     if not state.frontier_context_read:
         raise ValueError(f"{prefix}_before_frontier_read")
-    if not state.work_source_read:
+    if work_source_required and not state.work_source_read:
         raise ValueError(f"{prefix}_before_work_source_read")
 
 
@@ -855,16 +913,27 @@ def _handle_semantic_writeback(
     observation: Mapping[str, Any],
     state: _QualificationState,
 ) -> str:
-    _require_observed_frontier(state, prefix="semantic_action")
-    matches_observed_surface = bool(
-        observation.get("surface_id") == _FIXTURE_NEW_SURFACE_ID
-        and observation.get("hypothesis_id") == _FIXTURE_NEW_HYPOTHESIS_ID
-        and observation.get("probe_kind") == _FIXTURE_NEW_PROBE_KIND
-        and _FIXTURE_NEW_EVIDENCE_ID in set(observation.get("evidence_ids") or [])
-    )
-    if not matches_observed_surface:
-        raise ValueError("semantic_action_misses_uncovered_frontier")
     obligation_id = _expected_obligation_id(state)
+    result_class = str(observation.get("result_class") or "")
+    terminal_result = result_class in {
+        ProgressResultClass.BLOCKED.value,
+        ProgressResultClass.EXPLORATION_EXHAUSTED.value,
+        ProgressResultClass.NO_FOLLOWUP.value,
+    }
+    _require_observed_frontier(
+        state,
+        prefix="semantic_action",
+        work_source_required=not terminal_result,
+    )
+    if not terminal_result:
+        matches_observed_surface = bool(
+            observation.get("surface_id") == _FIXTURE_NEW_SURFACE_ID
+            and observation.get("hypothesis_id") == _FIXTURE_NEW_HYPOTHESIS_ID
+            and observation.get("probe_kind") == _FIXTURE_NEW_PROBE_KIND
+            and _FIXTURE_NEW_EVIDENCE_ID in set(observation.get("evidence_ids") or [])
+        )
+        if not matches_observed_surface:
+            raise ValueError("semantic_action_misses_uncovered_frontier")
     obligation = dict(
         (state.quota_packet or {}).get("autonomous_replan_obligation") or {}
     )
@@ -884,6 +953,23 @@ def _handle_semantic_writeback(
     decoded = json.loads(output)
     if not isinstance(decoded, dict) or decoded.get("ok") is not True:
         raise ValueError("semantic_writeback_failed")
+    if result_class in {
+        ProgressResultClass.EXPLORATION_EXHAUSTED.value,
+        ProgressResultClass.NO_FOLLOWUP.value,
+    }:
+        reentry_output = _execute_loopx(
+            state.fixture.quota_guard_command,
+            fixture=state.fixture,
+            turn_instance_id=f"{state.turn_instance_id}-semantic-reentry",
+        )
+        reentry_packet = json.loads(reentry_output)
+        if not isinstance(reentry_packet, dict):
+            raise ValueError("semantic_reentry_quota_invalid")
+        state.semantic_reentry_observation = _semantic_reentry_observation(
+            reentry_packet,
+            obligation_id=obligation_id,
+        )
+        state.read_only_host_commands_executed = True
     return output
 
 
@@ -935,6 +1021,9 @@ _EXPECTED_BEHAVIOR_FAILURES = frozenset(
         "quota_obligation_missing",
         "non_semantic_replan_action",
         "semantic_writeback_failed",
+        "semantic_reentry_quota_invalid",
+        "semantic_reentry_replan_not_closed",
+        "semantic_reentry_did_not_exit",
         "manual_evidence_read_is_not_replan",
         "unexpected_command",
     }
@@ -1063,10 +1152,12 @@ class DoubaoReplanSemanticActionBehaviorActor:
         qualification_id: str,
         fixture_root: Path,
         composition_frontier: bool = False,
+        exhausted_frontier: bool = False,
     ) -> dict[str, Any]:
         fixture = _build_fixture(
             fixture_root,
             composition_frontier=composition_frontier,
+            exhausted_frontier=exhausted_frontier,
         )
         messages: list[dict[str, Any]] = [
             {

--- a/loopx/control_plane/testing/replan_semantic_action_behavior.py
+++ b/loopx/control_plane/testing/replan_semantic_action_behavior.py
@@ -612,9 +612,33 @@ def _semantic_reentry_observation(
         raise ValueError("semantic_reentry_replan_not_closed")
     if packet.get("decision") != "skip":
         raise ValueError("semantic_reentry_did_not_exit")
+    frontier = packet.get("goal_frontier_projection")
+    normalized_progress = (
+        frontier.get("normalized_progress")
+        if isinstance(frontier, Mapping)
+        else None
+    )
+    monitor_lanes = (
+        frontier.get("monitor_only_lanes")
+        if isinstance(frontier, Mapping)
+        else None
+    )
+    future_monitor_wait = bool(
+        packet.get("effective_action") == "monitor_quiet_skip"
+        and isinstance(frontier, Mapping)
+        and frontier.get("replan_required") is False
+        and isinstance(monitor_lanes, Mapping)
+        and monitor_lanes.get("present") is True
+        and isinstance(normalized_progress, Mapping)
+        and int(normalized_progress.get("agent_monitor_open_count") or 0) > 0
+        and int(normalized_progress.get("agent_monitor_due_count") or 0) == 0
+    )
+    if not future_monitor_wait:
+        raise ValueError("semantic_reentry_not_future_monitor_wait")
     return {
         "decision": packet.get("decision"),
         "effective_action": packet.get("effective_action"),
+        "replan_rule": "future_monitor_wait",
         "replan_closed": True,
         "exited": True,
     }
@@ -1023,6 +1047,7 @@ _EXPECTED_BEHAVIOR_FAILURES = frozenset(
         "semantic_writeback_failed",
         "semantic_reentry_quota_invalid",
         "semantic_reentry_replan_not_closed",
+        "semantic_reentry_not_future_monitor_wait",
         "semantic_reentry_did_not_exit",
         "manual_evidence_read_is_not_replan",
         "unexpected_command",

--- a/tests/control_plane/test_goal_frontier_replan_rules.py
+++ b/tests/control_plane/test_goal_frontier_replan_rules.py
@@ -107,6 +107,24 @@ from loopx.control_plane.todos.summary_item import compact_todo_summary_item
             False,
         ),
         (
+            {
+                "monitor_only_lane": True,
+                "monitor_count": 1,
+                "future_monitor_schedule_present": True,
+            },
+            GoalFrontierReplanRule.FUTURE_MONITOR_WAIT,
+            False,
+        ),
+        (
+            {
+                "monitor_only_lane": True,
+                "monitor_count": 1,
+                "monitor_schedule_gap_count": 1,
+            },
+            GoalFrontierReplanRule.MONITOR_FRONTIER_EXHAUSTED,
+            True,
+        ),
+        (
             {"monitor_only_lane": True, "monitor_count": 1},
             GoalFrontierReplanRule.MONITOR_FRONTIER_EXHAUSTED,
             True,
@@ -335,6 +353,52 @@ def test_empty_authoritative_todo_source_does_not_use_stale_display_item() -> No
     )
 
     assert ack is None
+
+
+def test_terminal_ack_cannot_hide_invalid_monitor_schedule() -> None:
+    monitor = {
+        "todo_id": "todo_monitor_gap",
+        "status": "open",
+        "task_class": "continuous_monitor",
+        "claimed_by": "current-agent",
+        "target_key": "bounded-monitor",
+        "cadence": "1d",
+    }
+    terminal_ack = {
+        "schema_version": "autonomous_replan_ack_v0",
+        "recorded": True,
+        "generated_at": "2026-08-13T09:00:00+08:00",
+        "semantic_delta": {
+            "accepted": True,
+            "outcomes": ["coverage_backed_exploration_exhausted"],
+        },
+    }
+
+    obligation = derive_goal_frontier_replan_obligation_from_summaries(
+        user_todo_summary={"open_count": 0},
+        agent_todo_summary={
+            "open_count": 1,
+            "claimed_advancement_open_count": 0,
+            "current_agent_claimed_advancement_count": 0,
+            "unclaimed_priority_open_items": [],
+            "executable_backlog_items": [],
+            "claim_scope": {"other_agent_claimed_items": []},
+            "monitor_open_items": [monitor],
+            "monitor_due_count": 0,
+            "monitor_schedule_gap_count": 1,
+        },
+        work_lane_contract={
+            "lane": "continuous_monitor",
+            "must_attempt_work": False,
+        },
+        agent_id="current-agent",
+        existing_replan_obligation=None,
+        latest_replan_ack=terminal_ack,
+    )
+
+    assert obligation is not None
+    assert obligation["triggers"][0]["kind"] == "frontier_exhausted_monitor_lane"
+    assert obligation["triggers"][0]["future_monitor_schedule_present"] is False
 
 
 def _ack(generated_at: str, delta_kind: str = "goal_vision_patch") -> dict[str, object]:

--- a/tests/control_plane/test_refresh_state_replan_gate.py
+++ b/tests/control_plane/test_refresh_state_replan_gate.py
@@ -14,6 +14,9 @@ from loopx.state_refresh import (
     enforce_open_replan_writeback,
     refresh_state_run,
 )
+from loopx.control_plane.work_items.semantic_replan_writeback import (
+    qualify_replan_writeback,
+)
 
 GOAL_ID = "replan-gate-fixture"
 AGENT_ID = "codex-replan-gate-agent"
@@ -87,6 +90,21 @@ def _call_gate(
         goal_id=GOAL_ID,
         progress_observation=progress_observation,
     )
+
+
+def _current_obligation_id(
+    runs: list[dict],
+    *,
+    state_text: str = STATE_TEXT,
+) -> str:
+    obligation, _ = qualify_replan_writeback(
+        newest_first_runs=runs,
+        state_text=state_text,
+        agent_id=AGENT_ID,
+        goal_id=GOAL_ID,
+    )
+    assert obligation is not None
+    return str(obligation["obligation_id"])
 
 
 def test_maintenance_writeback_rejected_when_replan_due() -> None:
@@ -262,10 +280,6 @@ def test_rotated_vision_obligation_rejects_first_maintenance_writeback() -> None
 
 def test_rotated_vision_obligation_contains_all_three_acceptance_gaps() -> None:
     """The write gate sees quota's vision, checkpoint, and completed-chain truth."""
-
-    from loopx.control_plane.work_items.semantic_replan_writeback import (
-        qualify_replan_writeback,
-    )
 
     obligation, semantic_delta = qualify_replan_writeback(
         newest_first_runs=_rotated_vision_runs(),
@@ -449,3 +463,104 @@ def test_rotated_vision_obligation_accepts_fresh_evidence_linked_path() -> None:
     assert semantic_delta["satisfying_outcomes"] == [
         "fresh_vision_path_outcome"
     ]
+
+
+@pytest.mark.parametrize(
+    ("progress_observation", "expected_outcome"),
+    [
+        (
+            {
+                "schema_version": "typed_progress_observation_v0",
+                "result_class": "blocked",
+                "blocker_id": "blocker-current-path",
+                "evidence_ids": ["evidence-current-blocker"],
+            },
+            "new_concrete_blocker",
+        ),
+        (
+            {
+                "schema_version": "typed_progress_observation_v0",
+                "result_class": "exploration_exhausted",
+                "coverage_scope_id": "coverage-current-goal",
+                "coverage_complete": True,
+                "evidence_ids": ["evidence-current-coverage"],
+            },
+            "coverage_backed_exploration_exhausted",
+        ),
+        (
+            {
+                "schema_version": "typed_progress_observation_v0",
+                "result_class": "no_followup",
+                "coverage_scope_id": "coverage-current-goal",
+                "evidence_ids": ["evidence-current-coverage"],
+            },
+            "coverage_backed_no_followup",
+        ),
+    ],
+)
+def test_rotated_vision_obligation_accepts_terminal_progress(
+    progress_observation: dict,
+    expected_outcome: str,
+) -> None:
+    runs = _rotated_vision_runs()
+    state_text = _completed_advancement_chain_state()
+    semantic_delta = enforce_open_replan_writeback(
+        newest_first_runs=runs,
+        state_text=state_text,
+        agent_id=AGENT_ID,
+        goal_id=GOAL_ID,
+        progress_observation=progress_observation,
+    )
+
+    assert semantic_delta is not None
+    assert semantic_delta["satisfying_outcomes"] == [expected_outcome]
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        "fresh_vision_path_outcome",
+        "new_concrete_blocker",
+        "coverage_backed_exploration_exhausted",
+        "coverage_backed_no_followup",
+    ],
+)
+def test_matching_non_successor_ack_clears_rotated_vision_obligation(
+    outcome: str,
+) -> None:
+    runs = _rotated_vision_runs()
+    state_text = _completed_advancement_chain_state()
+    obligation_id = _current_obligation_id(runs, state_text=state_text)
+    semantic_ack = {
+        "classification": "bounded_replan_progress",
+        "generated_at": "2026-08-13T12:00:00+08:00",
+        "agent_id": AGENT_ID,
+        "autonomous_replan_ack": {
+            "schema_version": "autonomous_replan_ack_v0",
+            "recorded": True,
+            "source": "refresh_state_semantic_delta",
+            "semantic_delta": {
+                "schema_version": "replan_semantic_delta_v0",
+                "accepted": True,
+                "outcomes": [outcome],
+                "satisfying_outcomes": [outcome],
+                "required_any_of": [
+                    "fresh_vision_path_outcome",
+                    "new_runnable_successor",
+                    "new_concrete_blocker",
+                    "coverage_backed_exploration_exhausted",
+                    "coverage_backed_no_followup",
+                ],
+                "obligation_id": obligation_id,
+            },
+        },
+    }
+
+    remaining, _ = qualify_replan_writeback(
+        newest_first_runs=[semantic_ack, *runs],
+        state_text=state_text,
+        agent_id=AGENT_ID,
+        goal_id=GOAL_ID,
+    )
+
+    assert remaining is None

--- a/tests/control_plane/test_replan_semantic_action_behavior.py
+++ b/tests/control_plane/test_replan_semantic_action_behavior.py
@@ -61,6 +61,32 @@ def _semantic_action(
     )
 
 
+def _exhausted_action(
+    request: Mapping[str, object],
+) -> ScriptedExecToolAction:
+    packet = _latest_quota_packet(request)
+    action = packet["replan_action_packet"]
+    assert isinstance(action, Mapping)
+    assert (
+        "coverage_backed_exploration_exhausted"
+        in action["uncovered_frontier"]["required_any_of"]
+    )
+    return ScriptedExecToolAction(
+        "loopx --format json --registry ignored --runtime-root ignored "
+        "refresh-state --goal-id replan-semantic-action-fixture "
+        "--agent-id codex-replan-semantic-action --progress-scope agent_lane "
+        "--classification bounded_replan_exhausted "
+        "--recommended-action bounded-goal-coverage-exhausted "
+        "--delivery-batch-scale single_surface "
+        "--delivery-outcome surface_only "
+        "--progress-result-class exploration_exhausted "
+        "--progress-coverage-scope-id coverage-fixture-all-surfaces "
+        "--progress-coverage-complete "
+        "--progress-evidence-id evidence-frontier-inventory "
+        "--no-global-sync --suppress-external-sinks"
+    )
+
+
 def _composition_successor_action(
     request: Mapping[str, object],
 ) -> ScriptedExecToolAction:
@@ -162,6 +188,94 @@ def test_real_tool_loop_chooses_and_persists_semantic_replan_action(
         "surface-permission-config"
     )
     assert latest["autonomous_replan_ack"]["semantic_delta"]["accepted"] is True
+
+
+def test_model_exits_after_replan_confirms_goal_coverage_is_exhausted(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_fixture(tmp_path / "oracle", exhausted_frontier=True)
+    transport = ScriptedDoubaoExecTransport(
+        [
+            ScriptedExecToolAction(command=fixture.quota_guard_command),
+            ScriptedExecToolAction(command="cat replan-frontier.json"),
+            _exhausted_action,
+        ]
+    )
+
+    receipt = DoubaoReplanSemanticActionBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="replan-exhausted-exit-001",
+        fixture_root=tmp_path / "actor",
+        exhausted_frontier=True,
+    )
+
+    assert receipt["qualification_passed"] is True, receipt
+    assert receipt["observed_tool_sequence"] == [
+        "quota_should_run",
+        "workspace_read",
+        "semantic_replan_writeback",
+    ]
+    assert receipt["selected_semantic_outcomes"] == [
+        "coverage_backed_exploration_exhausted"
+    ]
+    assert receipt["semantic_reentry"] == {
+        "decision": "skip",
+        "effective_action": "monitor_quiet_skip",
+        "replan_closed": True,
+        "exited": True,
+    }
+
+
+@pytest.mark.parametrize(
+    ("terminal_args", "expected_error"),
+    [
+        (
+            "--progress-result-class no_followup ",
+            "no_followup requires --progress-coverage-scope-id",
+        ),
+        (
+            "--progress-result-class exploration_exhausted ",
+            "exploration_exhausted requires --progress-coverage-scope-id",
+        ),
+        (
+            "--progress-result-class exploration_exhausted "
+            "--progress-coverage-scope-id coverage-fixture-all-surfaces ",
+            "exploration_exhausted requires --progress-coverage-complete",
+        ),
+    ],
+)
+def test_terminal_progress_cli_reports_missing_coverage_contract(
+    tmp_path: Path,
+    terminal_args: str,
+    expected_error: str,
+) -> None:
+    fixture = _build_fixture(tmp_path / "fixture", exhausted_frontier=True)
+    index_path = (
+        fixture.runtime_root
+        / "goals"
+        / "replan-semantic-action-fixture"
+        / "runs"
+        / "index.jsonl"
+    )
+    before = index_path.read_text(encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match=expected_error):
+        _execute_loopx(
+            "loopx --format json --registry ignored --runtime-root ignored "
+            "refresh-state --goal-id replan-semantic-action-fixture "
+            "--agent-id codex-replan-semantic-action "
+            "--progress-scope agent_lane "
+            "--classification bounded_replan_terminal "
+            f"{terminal_args}"
+            "--progress-evidence-id evidence-frontier-inventory "
+            "--no-global-sync --suppress-external-sinks",
+            fixture=fixture,
+            turn_instance_id="invalid-terminal-progress-turn",
+        )
+
+    assert index_path.read_text(encoding="utf-8") == before
 
 
 def test_real_tool_loop_selects_composition_gap_and_creates_bound_successor(

--- a/tests/control_plane/test_replan_semantic_action_behavior.py
+++ b/tests/control_plane/test_replan_semantic_action_behavior.py
@@ -223,6 +223,7 @@ def test_model_exits_after_replan_confirms_goal_coverage_is_exhausted(
     assert receipt["semantic_reentry"] == {
         "decision": "skip",
         "effective_action": "monitor_quiet_skip",
+        "replan_rule": "future_monitor_wait",
         "replan_closed": True,
         "exited": True,
     }


### PR DESCRIPTION
## Summary

- fix goal-frontier settlement so a matching typed semantic ACK can close the current obligation even while source acceptance gaps remain
- fail fast when `no_followup` or `exploration_exhausted` omits its coverage scope, and require explicit completion for exhausted coverage
- add a hermetic model-behavior case for exhausted goal -> replan -> semantic exhausted ACK -> quota re-entry -> clean exit
- record the Effect Program boundary in the RFC: this remains a domain-local reducer/ACK invariant until a second real quota/status read-ACK lifecycle can remove duplicate orchestration

The implementation deliberately does not add `--replan-obligation-id` to `refresh-state`: source tracing confirmed that caller-side binding was not the root cause of #3208. `refresh-state` already re-derives the current obligation, and the shared ACK policy matches the recorded semantic ACK to it.

Fixes #3208

## Integration with #3211

- #3211 was merged first, and this branch was rebased onto its merge commit `bdd2c4c68`
- the proposed broad historical terminal-ACK fallback was removed rather than carried through the rebase
- after a terminal semantic ACK settles the current obligation, #3211's current-state classifier owns the next step: due monitor execution, valid future monitor quiet wait, or a real repair/replan path
- the exhausted-goal behavior now proves quota re-entry reaches `future_monitor_wait` / `monitor_quiet_skip`
- rule and smoke coverage prove a missing monitor schedule remains visible as `repair_monitor_schedule_metadata`; a historical terminal ACK cannot hide it

## Validation

- targeted Ruff and Python compile: passed
- focused replan/quota/model-behavior suite: 117 passed
- combined rule/model subset: 31 passed
- control-plane maintainability ratchet: passed with 0 unreviewed debt and 0 regressions
- final `loopx canary premerge --from-git-diff`: 18/18 selected checks passed; 0 failures; 0 warnings; 0 manual holds

## Premerge coverage

- changed surfaces: refresh-state terminal input validation, goal-frontier reducer/ACK settlement, model behavior, ordered monitor-rule smoke, and public protocol/RFC docs
- direct checks: diff hygiene plus Python compile passed
- catalog canaries: 9/9 passed, including goal-frontier rules, heartbeat quota flow, CLI output budget, and maintainability
- risk-profile smokes: 8/8 passed
- public/private boundary: clean
- failures/skips: the first premerge run exposed one stale goal-frontier smoke that still expected a future-scheduled monitor to replan; the smoke was corrected to cover future quiet wait and missing-schedule repair, and the final full run passed; no checks skipped
- manual holds: none
- coverage rationale: unit coverage proves all four non-successor semantic outcomes settle an acceptance-gap obligation; the behavior test exercises the real CLI and quota re-entry after exhausted coverage; invalid terminal commands prove missing coverage fields fail before append; the combined monitor cases prevent a terminal ACK from masking schedule repair

This is ready for independent maintainer review after the refreshed GitHub checks complete because it changes runtime replan settlement semantics.
