### PR TITLE
chore(release): bump version to 0.4.7

### DIFF
--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.6"
+__version__ = "0.4.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.4.6"
+version = "0.4.7"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## What

Bump `pyproject.toml` and `loopx/__init__.py` to 0.4.7 ahead of the v0.4.7 release.

## Validation

- `scripts/release_artifacts.py expected-tag` -> `v0.4.7`
- `tests/test_doctor_install_freshness.py`: 8 passed
- `examples/release/release-version-contract-smoke.py`: passed
- Release body validated with `examples/release/release-readiness-doc-smoke.py` (surfaces: validation-command, opencode-goal-loops, deepseek-harness-turn-connector, per-goal-handoff-modes, explore-feishu-visual-auto-create)
- `git diff --check` clean