### PR TITLE
docs: define the Managed Semantic Control Plane strategy

### DIFF
--- a/docs/product/roadmaps/saas-opportunity-assessment.md
+++ b/docs/product/roadmaps/saas-opportunity-assessment.md
@@ -1,164 +1,302 @@
 # SaaS Opportunity Assessment
 
 Status: assessment target. This note is a strategic evaluation, not a
-commitment to build. It asks which parts of LoopX could support a hosted,
-recurring-revenue product without weakening the local-first control-plane
-contract that LoopX is built on.
+commitment to build. It asks how LoopX can support a hosted,
+recurring-revenue product without weakening the local-first and
+provider-neutral control-plane contract that LoopX is built on.
+
+## Commercial Thesis
+
+The most coherent commercial position for LoopX is:
+
+> Keep the semantic state contracts for long-running agents open and
+> local-first. Sell the reliable operation of those contracts as a Managed
+> Semantic Control Plane.
+
+The open layer gives agents and operators portable goal, authority, todo,
+evidence, acceptance, quota, handoff, recovery, and replan state. The paid
+layer makes that state reliable across a team: continuously available,
+collaborative, observable, recoverable, governed, and supported.
+
+This places LoopX near the intersection of two publicly commercialized
+adjacent patterns. Letta packages persistent, stateful agents as a hosted
+service and meters active agents and execution. Mastra packages an open agent
+framework with hosted operations, retention, team collaboration, and
+enterprise governance.
+LoopX should not copy either product boundary. Its differentiated surface is
+the provider-neutral semantic control layer above heterogeneous agent
+runtimes: complete state management, planning and supervision, evidence-backed
+recovery, and human authority that survive across runs and agents.
+
+That is a positioning hypothesis, not a revenue claim. It still has to be
+validated by repeat production use and willingness to pay.
 
 ## The Core Tension
 
-LoopX's value proposition is a local-first control plane: durable goal state,
-evidence, quota, and handoffs that the operator owns outright. A naive SaaS
-move — "we host your agent state on our servers" — destroys the exact property
-that makes the product trustworthy.
+LoopX's value proposition is a local-first control plane whose durable state
+the operator can own, inspect, export, and recover. A naive SaaS move — "we
+host your agent state on our servers" — weakens the exact property that makes
+the product trustworthy.
 
-So the SaaS question is not "can LoopX be hosted?" It is:
+The SaaS question is therefore not "can LoopX be hosted?" It is:
 
-> Which layers become *more* valuable when they live in the cloud, and which
-> layers must stay local by design?
+> Which control-plane responsibilities become more valuable when somebody
+> operates them continuously, and which authority and data boundaries must
+> remain portable by design?
 
-Anything that requires collaboration, durable cross-device access, or a
-shared source of truth benefits from a hosted layer. Anything that is the
-operator's ground truth — local goal state, private workspace content,
-credential-adjacent material — stays local.
+Collaboration, cross-device access, durable retention, shared governance,
+managed recovery, and operational support benefit from a hosted or BYOC
+service. The semantic contracts, export path, local execution option, and
+customer authority over private workspace content should remain open.
+
+The paid product sells operation, reliability, and organizational control. It
+must not sell users back access to their own state format.
+
+## Open And Paid Product Boundary
+
+| Layer | Community and local-first contract | Managed product value |
+| --- | --- | --- |
+| Semantic state | Open schemas and transitions for goals, todos, gates, decisions, evidence, acceptance, quota, handoff, recovery, and replan | Highly available state service, conflict handling, backup, restore, migration, and managed upgrades |
+| Execution | Provider-neutral adapters for Codex, Claude Code, Cursor, shell agents, and custom workers | Fleet registration, health, policy-controlled wake, supervisor scheduling, recovery, and operator routing |
+| Observation | Local projections, CLI status, export, and self-hostable dashboard surfaces | Shared workspaces, long retention, cross-agent timelines, evaluation, replay, alerts, and review queues |
+| Governance | Inspectable local authority, boundary, and approval contracts | Multi-tenant isolation, RBAC, SSO, audit, quotas, data residency, signed exports, and policy administration |
+| Delivery | Documentation and a usable self-host path | BYOC or managed deployment, SLA, migration, integration, incident response, and support |
+
+Portability is part of the product contract. A customer should be able to
+export semantic state, retain durable identities and evidence lineage, and
+return to a local or self-hosted control plane without reconstructing the
+meaning of its work from proprietary logs.
 
 ## Viability Test
 
-A hosted offering is worth building only if it passes all three:
+A managed offering is worth building only if it passes all four tests:
 
-1. **Continuous use**: operators return to it daily, not once per install.
-2. **Cloud-improved**: collaboration, sharing, or durability make the hosted
-   version strictly better than files on one machine.
-3. **Natural expansion**: revenue grows with seats, managed agents, retention,
-   or integrations — not with one-off features.
+1. **Continuous use**: operators and agent teams return to it throughout the
+   working week, not once per install.
+2. **Managed advantage**: collaboration, availability, recovery, retention, or
+   governance make the operated version materially better than files on one
+   machine.
+3. **Natural expansion**: revenue grows with workspaces, active managed agents,
+   retention, supervisor work, or enterprise controls rather than one-off
+   features.
+4. **Control-plane proof**: customers can measure less manual coordination,
+   faster recovery, fewer invalid continuations, or lower review and audit
+   cost.
 
-These tests are applied to each candidate below.
+The fourth test matters most. A dashboard with no measurable effect on long
+running work is an interface feature, not a durable SaaS business.
 
-## Candidate Directions, Ranked
+## Product Ladder
+
+The following directions are not four independent SaaS products. They are an
+adoption and expansion ladder toward one Managed Semantic Control Plane.
 
 ### 1. AgentOps Observation And Governance Cloud
 
-The strongest candidate: a "Datadog / Langfuse for agent loops" focused on
-goals, evidence, and quota rather than on LLM traces.
+The strongest entry wedge is a "Datadog / Langfuse for agent loops" focused on
+goals, authority, evidence, recovery, and quota rather than only LLM traces.
 
 The control plane already produces the raw material: goal state, run history,
-evidence events, quota decisions, and handoff records. A hosted observation
-layer turns this into a shared team surface:
+evidence events, quota decisions, handoff records, and public-safe projections.
+A hosted observation layer turns it into a shared team surface:
 
-- a cross-member goal board: who is running which agents, on what objectives;
-- quota and budget views that map spend to goals rather than to API calls;
+- a cross-member goal board showing who is running which agents and why;
+- quota and budget views that map spend to goals rather than only API calls;
 - gate and approval queues routed through Lark or equivalent channels;
-- evidence drill-downs that survive a machine wipe or an operator switch.
+- recovery and handoff timelines that survive a machine loss or operator
+  switch;
+- evidence and evaluation drill-downs that explain what changed and whether a
+  continuation was valid.
 
-Why it fits: observation is consumed continuously, is useless without
-collaboration at team scale, and revenue scales with seats and managed agents.
-The dashboard frontend already exists (`apps/presentation/dashboard`), and the
-status data contract (`docs/status-data-contract.md`) is a public projection
-surface that a hosted read model can consume without ever touching private
-state.
+This wedge is read-mostly and can consume the public status data contract
+without owning private workspace content. It proves daily use and team
+collaboration before LoopX assumes authority over production control state.
 
-Pricing sketch: free tier for a single operator with short retention; team
-tier priced per seat plus per managed agent; governance features (approval
-routing, retention, export) gated to the team tier.
+### 2. Evidence And Review Service
 
-### 2. Evidence And Review SaaS
+The next expansion layer adds immutable evidence retention, replay,
+review-ready handoff reports, evaluation history, and periodic explanations of
+what agents did and why.
 
-A narrower, compliance-adjacent product: immutable evidence retention,
-review-ready handoff reports, and periodic "what did the agents do and why"
-summaries.
+Observation sells to the team operating agents today. Evidence and review sell
+to the organization that must justify agent decisions later. As agents enter
+production workflows, "show me the evidence" becomes an admission requirement.
 
-This is the same product as direction 1 sold under a different contract.
-Observation sells to the team that runs agents today; evidence and review
-sells to the organization that must justify agent decisions to stakeholders
-later. As agents enter production workflows, "show me the evidence" moves
-from a nice-to-have to an admission requirement.
+The event-sourced state model and existing evidence and handoff projections
+make this possible without a new agent runtime. The trust bar is higher:
+retained evidence must have explicit lineage, append-only semantics, deletion
+policy, and signed or otherwise verifiable exports.
 
-The event-sourced state model and the existing evidence/handoff projection
-make this realistic without new runtime machinery. The limiting factor is
-trust: customers must believe retained evidence is complete and unmodified,
-which pushes toward append-only storage and signed exports.
+### 3. Managed Semantic Control Plane, Preferably BYOC First
 
-### 3. Hosted Control Plane, Preferably BYOC
+The product destination is not observation alone. It is an operated control
+plane that keeps complete semantic execution state coherent while local or
+third-party runtimes perform bounded work.
 
-The foundations note `server-client-product-shape.md` already names the
-medium-term shape: the server owns durable goal state, event history, and
-governed planning lanes. That architecture carries a quiet proof that SaaS
-plumbing is natural here:
+The foundations note `server-client-product-shape.md` already names the medium
+term shape: the server owns durable goal state, event history, and governed
+planning lanes. The same architecture supports:
 
-- quota and spend policy already exist per goal;
-- writes are idempotent and events are append-only;
-- the public/private boundary classifier is a first-class runtime concept.
+- idempotent and conflict-aware writes to authoritative state;
+- supervisor scheduling, stalled-loop detection, recovery, handoff, and replan;
+- policy-controlled promotion from advisory proposals to executable work;
+- cross-runtime identity, claim, quota, evidence, and acceptance continuity;
+- operator-visible control over every transition that spends authority.
 
-Those are exactly the mechanisms a multi-tenant control plane needs. The
-risk is not technical fit; it is operational gravity. Hosting the authoritative
-state for a customer's production agent loops makes LoopX part of their
-critical path, with matching SLA burden.
+The supervisor is not a hidden autonomous manager. It may schedule, observe,
+recover, and propose within recorded policy; it does not acquire human
+authority merely because it is hosted.
 
-The lower-risk entry is BYOC: the control plane runs in the customer's cloud
-account, and LoopX sells the console, upgrades, and support. This preserves
-the local-first promise — the customer still owns the state — while creating a
-recurring-revenue surface. Full multi-tenant hosting is a later decision, not
-a prerequisite.
+The lower-risk enterprise entry is BYOC. The control plane runs in the
+customer's cloud account while LoopX sells the console, managed upgrades,
+governance, recovery operations, and support. Full multi-tenant hosting can
+follow when isolation, deletion, backup, and on-call contracts are proven.
 
-### 4. Domain Packs With Marketplace Revenue
+### 4. Domain Packs And Marketplace Revenue
 
-Domain capability packs
-(`docs/product/domain-capability-packs.md`) are a monetization layer,
-not a standalone SaaS. Sold individually, they are one-time purchases.
-Attached to a hosted platform with a marketplace take rate, they become
-recurring. This direction depends on direction 1 or 3 existing first; it
-cannot lead.
+Domain capability packs (`docs/product/domain-capability-packs.md`) are an
+expansion layer rather than the core business. They can add opinionated
+evaluation, review, or operational workflows while the Kernel remains generic.
+
+Packs may support marketplace or enterprise integration revenue after the team
+or managed control plane exists. They should not lead the SaaS strategy, and
+commercial packaging must not move domain-specific authority into the generic
+Kernel.
+
+## Metering And Packaging
+
+The primary billing unit should follow managed control-plane value, not model
+token resale.
+
+| Value surface | Candidate unit | Why it expands |
+| --- | --- | --- |
+| Team control plane | workspace plus collaborator seats | More teams and operators share the same governed state |
+| Agent continuity | monthly active managed agent or active governed goal | More long-running workers rely on identity, state, quota, and recovery |
+| Evidence operations | retained event/evidence volume and retention window | Longer-lived and regulated workflows need more durable history |
+| Managed supervision | policy-controlled wake, recovery, replay, or evaluation executions | Customers pay for operated continuation rather than raw model calls |
+| Enterprise delivery | deployment environment plus governance and support tier | BYOC, SSO, RBAC, audit, residency, SLA, and migration create organizational value |
+
+A plausible package ladder is:
+
+- **Community**: local-first Kernel, protocols, CLI, exports, and self-hostable
+  projections.
+- **Team Cloud**: shared workspaces, short-to-medium retention, approvals,
+  alerts, and collaborative review.
+- **Managed Control Plane**: durable semantic state, supervisor scheduling,
+  recovery, replay, evaluation, and higher retention.
+- **Enterprise / BYOC**: private deployment, governance, audit, residency,
+  migration, SLA, and dedicated support.
+
+This is a packaging model, not a published price list. Before choosing prices,
+LoopX needs usage distributions for active agents, event volume, retention,
+supervisor executions, and support cost. It should not charge for both an agent
+and its goals as duplicate activity; cohort data should decide which unit best
+tracks customer value, and dormant registered identities should remain free.
 
 ## What Should Not Be SaaS
 
-- **Execution hosting** ("we run your agents"): it competes with frontier
-  model vendors on compute margins and contradicts the architectural rule
-  that the control plane does not own domain behavior.
-- **Hosted CLI state as the product**: nobody pays to move local files to
-  someone else's disk. The cloud layer must add collaboration or governance
-  value, not just relocate state.
+- **A closed semantic state format**: goals, evidence, authority, and handoff
+  must stay inspectable and exportable. Lock-in should come from operating
+  quality, not state captivity.
+- **Generic execution hosting as the core product**: LoopX may orchestrate
+  external runtimes and operate bounded supervisor work, but reselling model
+  tokens and sandboxes would compete on compute margins and blur the rule that
+  the control plane does not own domain behavior.
+- **Hosted CLI files as the product**: nobody pays merely to move local files
+  to somebody else's disk. The managed layer must add collaboration,
+  reliability, recovery, or governance.
+- **Cloud authority by default**: hosted infrastructure does not grant
+  permission to read private workspaces, approve gates, publish, or perform
+  production writes.
 
 ## Honest Constraints
 
+- **Adoption and proof gap**: public long-running demonstrations establish
+  technical feasibility, not recurring team demand. The SaaS case requires
+  external production workloads with retention, recovery, and collaboration
+  needs.
 - **Cold start**: an observation cloud needs enough teams running LoopX loops
-  to have something to observe. The realistic loop is: free CLI adoption
-  grows the base, then a cloud tier converts the teams that emerge. Expect a
-  long horizon before the SaaS layer is self-sustaining.
-- **Brand tension**: local-first and SaaS pull in opposite directions. Done
-  well this is differentiation ("your state stays yours; the collaboration
-  layer is hosted"). Done carelessly it reads as a bait-and-switch.
-- **Maintenance surface**: hosted products carry on-call, data retention, and
-  customer-support obligations that a single-maintainer OSS project does not
-  currently have. The first paid tier should be deliberately narrow.
+  to have something to observe. Free CLI adoption can grow the base, but a
+  hosted tier may take a long time to become self-sustaining.
+- **Brand tension**: local-first and SaaS can pull in opposite directions.
+  Portability, self-hosting, explicit opt-in, and a narrow managed boundary
+  have to remain product behavior rather than marketing language.
+- **Trust and security surface**: retained evidence and authority state create
+  stronger isolation, deletion, backup, incident-response, and compliance
+  obligations than an OSS CLI.
+- **Operational capacity**: hosted products carry on-call, upgrade, migration,
+  and customer-support obligations that a small maintainer team does not
+  currently have. The first paid tier should remain deliberately narrow.
+- **Unproven unit economics**: supervisor execution, retention, and support can
+  erase margin if pricing follows raw activity without a value-aligned cap or
+  tier.
+
+## Proof Gates Before Significant SaaS Build-Out
+
+Before taking authoritative customer state onto a managed service, LoopX
+should be able to show:
+
+1. several independent teams using the control plane recurrently across
+   multi-week goals;
+2. measured reductions in manual context reconstruction, invalid continuation,
+   recovery time, or review effort;
+3. design partners willing to pay for collaboration, retention, governance, or
+   managed recovery rather than for generic support alone;
+4. verified export, restore, deletion, tenancy, backup, and public/private
+   boundary behavior;
+5. a usage model showing that retention, supervisor work, and support can
+   sustain acceptable gross margin.
+
+These gates separate technical optionality from realized commercial value.
 
 ## Suggested Path
 
-Phase 0 — opt-in observation relay: a `loopx cloud sync` command that pushes
-public-safe status projections to a hosted dashboard. Free for individuals,
-short retention. This is the smallest possible wedge: `status_server` and the
-dashboard already exist, so the new surface is an account system and a hosted
-read model.
+Phase 0 — instrument the local product and validate the billable objects.
+Measure active agents and goals, event and evidence volume, recovery actions,
+review frequency, and operator attention without collecting private content by
+default.
 
-Phase 1 — team tier: shared goal boards, Lark-routed approvals, and quota
-budgets across seats. Priced per seat plus per managed agent.
+Phase 1 — opt-in observation relay. Add a `loopx cloud sync` path that pushes
+public-safe status projections to a hosted dashboard. Keep it free or narrowly
+metered for individuals with short retention.
 
-Phase 2 — evidence and review tier: long retention, signed evidence exports,
-review-ready summaries. Sold to organizations rather than teams.
+Phase 2 — team and evidence tier. Add shared goal boards, approval routing,
+quota budgets, longer retention, replay, signed exports, and review-ready
+summaries. Validate recurring willingness to pay with design partners.
 
-Phase 3 — BYOC hosted control plane and domain-pack marketplace revenue.
+Phase 3 — Managed Semantic Control Plane, BYOC first. Operate durable state,
+supervisor scheduling, recovery, and governed replanning inside the customer's
+environment, with managed upgrades and support.
 
-Each phase is independently shippable and each funds the next; no phase
-requires betting on the full multi-tenant end state.
+Phase 4 — multi-tenant control plane and domain marketplace, only after
+isolation, support load, and unit economics are proven.
+
+Each phase is independently shippable and creates evidence for the next. No
+phase requires betting the open-source project on the full hosted end state.
+
+## Market Reference Points
+
+- [Letta pricing](https://www.letta.com/pricing) demonstrates active-agent,
+  execution, team, and enterprise metering around persistent agent state.
+- [Mastra pricing](https://mastra.ai/pricing) demonstrates usage, retention,
+  team, and enterprise packaging around an open agent development platform.
+
+These references show that buyers can understand hosted state, operations, and
+governance as paid surfaces. They do not prove demand for LoopX's distinct
+semantic control-plane contract.
 
 ## Relation To Existing Docs
 
 - `../foundations/server-client-product-shape.md` names the durable
-  control-plane server role this assessment builds on.
-- `../surfaces/README.md` and the frontstage notes cover the public
-  presentation surfaces that a hosted dashboard would extend.
-- `../domain-capability-packs.md` defines the pack boundary that direction 4
-  monetizes.
+  control-plane server, client, and executor roles this assessment monetizes.
+- `../surfaces/README.md` and the frontstage notes cover the public presentation
+  surfaces that a hosted workspace would extend.
+- `../domain-capability-packs.md` defines the pack boundary that marketplace or
+  enterprise integrations may monetize.
+- `../../reference/protocols/event-sourced-state-contract-v0.md` and the
+  decision, goal, evidence, quota, and handoff contracts define the portable
+  semantic state that must not become proprietary lock-in.
 
-This note intentionally avoids pricing commitments, launch dates, and
-capacity promises. It is a map of where SaaS revenue could plausibly live,
-to be revisited when the CLI adoption funnel justifies a hosted tier.
+This note intentionally avoids pricing commitments, launch dates, and capacity
+promises. It defines where recurring value can plausibly live and what evidence
+must exist before LoopX treats that option as a business.

--- a/docs/product/roadmaps/saas-opportunity-assessment.zh-CN.md
+++ b/docs/product/roadmaps/saas-opportunity-assessment.zh-CN.md
@@ -1,95 +1,177 @@
 # SaaS 机会评估
 
-状态：评估目标。本文是战略评估，不是建设承诺。它讨论 LoopX 的哪些部分可以支撑一个托管、订阅制产品，同时不削弱 LoopX 赖以成立的 local-first 控制面契约。
+状态：评估目标。本文是战略评估，不是建设承诺。它讨论 LoopX 如何支撑托管、订阅制产品，同时不削弱 LoopX 赖以成立的 local-first、provider-neutral 控制面契约。
+
+## 商业判断
+
+LoopX 最连贯的商业位置是：
+
+> 开源并保持 local-first 的长程 Agent 语义状态契约；收费提供稳定运行这些契约的 Managed Semantic Control Plane。
+
+开源层提供可迁移的 goal、authority、todo、evidence、acceptance、quota、handoff、recovery 和 replan 状态。付费层让这些状态在团队环境中持续可用：可协作、可观测、可恢复、可治理，并有人为其稳定性负责。
+
+这个位置接近两种已经公开商业化的相邻模式。Letta 将持久、有状态的 Agent 包装成托管服务，按 active agent 与执行量计费；Mastra 在开源 Agent 框架之上销售托管运行、留存、团队协作和企业治理。LoopX 不需要复制二者的产品边界。它的差异化位置是跨异构 Agent runtime 的 provider-neutral 语义控制层：完备的状态管理、规划与监督，基于证据的恢复，以及能够跨 run、跨 Agent 继承的人类 authority。
+
+这是产品定位假设，不是收入结论。它仍然需要持续生产使用和付费意愿验证。
 
 ## 核心张力
 
-LoopX 的价值主张是 local-first 控制面：goal 状态、evidence、quota 和 handoff 都由 operator 完全自持。一个天真的 SaaS 做法——“我们替你在服务器上托管 agent 状态”——会摧毁让产品可信的那个属性。
+LoopX 的价值主张是 local-first 控制面：operator 可以拥有、检查、导出和恢复 durable state。一个天真的 SaaS 做法——“我们替你在服务器上托管 Agent 状态”——会削弱让产品可信的那个属性。
 
-所以 SaaS 问题不是“LoopX 能否被托管”，而是：
+因此，SaaS 问题不是“LoopX 能否被托管”，而是：
 
-> 哪些层放到云上会变得*更有价值*，哪些层必须按设计留在本地？
+> 哪些控制面职责由专门服务持续运行后更有价值；哪些 authority 与数据边界必须按设计保持可迁移？
 
-需要协作、跨设备持久访问或共享事实源的东西，适合托管层；作为 operator 事实源的任何东西——本地 goal 状态、私有工作区内容、与凭据相邻的材料——都留在本地。
+协作、跨设备访问、长期留存、共享治理、托管恢复和运维支持适合 hosted 或 BYOC 服务。语义状态契约、导出路径、本地执行选项，以及客户对私有工作区内容的 authority 应当保持开放。
+
+付费产品卖的是运行、可靠性和组织控制，不能把用户自己的状态格式锁住后再卖回访问权。
+
+## 开源层与付费层边界
+
+| 层次 | Community 与 local-first 契约 | Managed 产品价值 |
+| --- | --- | --- |
+| 语义状态 | goal、todo、gate、decision、evidence、acceptance、quota、handoff、recovery、replan 的开放 schema 与 transition | 高可用状态服务、冲突处理、备份恢复、迁移和托管升级 |
+| 执行 | Codex、Claude Code、Cursor、shell agent 与自定义 worker 的 provider-neutral adapter | Agent fleet 注册、health、策略约束的 wake、Supervisor 调度、恢复和 operator 路由 |
+| 观测 | 本地 projection、CLI status、导出与可自托管 dashboard surface | 共享 workspace、长期留存、跨 Agent timeline、评测、回放、告警和 review queue |
+| 治理 | 可检查的本地 authority、boundary 与 approval contract | 多租户隔离、RBAC、SSO、审计、配额、数据驻留、签名导出和策略管理 |
+| 交付 | 文档与可用的 self-host 路径 | BYOC 或 managed deployment、SLA、迁移、集成、incident response 和支持 |
+
+可迁移性是产品契约的一部分。客户应当能够导出语义状态，保留 durable identity 与 evidence lineage，并回到本地或 self-hosted 控制面，而不需要从私有日志中重新推断工作的含义。
 
 ## 可行性测试
 
-托管产品只有在通过以下全部三条时才值得建设：
+Managed 产品只有在通过以下全部四条时才值得建设：
 
-1. **持续使用**：operator 每天回来使用，而不是装一次就完。
-2. **云化提升**：协作、共享或持久性让托管版本严格优于“单机文件”。
-3. **自然扩张**：收入随席位、托管 agent、留存或集成增长，而不是靠一次性功能。
+1. **持续使用**：operator 与 Agent team 在一周工作过程中持续使用，而不是装一次就结束。
+2. **托管优势**：协作、可用性、恢复、留存或治理让托管版本显著优于单机文件。
+3. **自然扩张**：收入随 workspace、active managed agent、留存、Supervisor work 或企业控制扩张，而不是依赖一次性 feature。
+4. **控制面效果**：客户可以测量人工协调减少、恢复加快、非法 continuation 下降，或 review 与 audit 成本下降。
 
-下面每个候选方向都用这三条测试衡量。
+第四条最重要。无法改善长程工作的 dashboard 只是一个界面 feature，不是可持续的 SaaS 生意。
 
-## 候选方向（按优先级排序）
+## 产品阶梯
+
+下面不是四个独立 SaaS，而是一条走向 Managed Semantic Control Plane 的采用与扩张路径。
 
 ### 1. AgentOps 观测与治理云
 
-最强候选：面向 goals、evidence、quota 的“Agent loops 版 Datadog / Langfuse”，而不是面向 LLM trace。
+最强的进入楔子，是面向 goal、authority、evidence、recovery、quota 的“Agent loop 版 Datadog / Langfuse”，而不只看 LLM trace。
 
-控制面已经产出原材料：goal 状态、run history、evidence 事件、quota 决策和 handoff 记录。托管观测层把它变成团队共享面：
+控制面已经产出原材料：goal 状态、run history、evidence 事件、quota 决策、handoff 记录和 public-safe projection。托管观测层把它们变成团队共享面：
 
-- 跨成员 goal board：谁在跑哪些 agent、针对什么目标；
-- quota 与预算视图：把花费映射到 goal 而不是 API 调用；
+- 跨成员 goal board：谁在跑哪些 Agent，为什么运行；
+- quota 与预算视图：把花费映射到 goal，而不只映射到 API 调用；
 - 通过 Lark 或等价渠道路由的 gate 与审批队列；
-- 在机器损坏或 operator 交接后仍然存活的 evidence 下钻。
+- 在机器损坏或 operator 切换后仍然存在的 recovery 与 handoff timeline；
+- 解释发生了什么、continuation 是否合法的 evidence 与 eval 下钻。
 
-为什么契合：观测是持续消费的；没有团队规模的协作它就毫无价值；收入随席位和托管 agent 扩展。dashboard 前端已存在（`apps/presentation/dashboard`），status data contract（`docs/status-data-contract.md`）是公开投影面，托管读模型可以消费它而完全不触碰私有状态。
+这个楔子以读为主，可以消费 public status data contract，而不持有私有 workspace 内容。它先证明日常使用和团队协作，再让 LoopX 承担生产控制状态的 authority。
 
-定价草图：单 operator 免费档 + 短留存；团队档按席位加托管 agent 计费；治理功能（审批路由、留存、导出）放在团队档。
+### 2. Evidence 与 Review 服务
 
-### 2. Evidence 与 Review SaaS
+下一层增加不可变 evidence 留存、回放、review-ready handoff 报告、评测历史，以及周期性的“Agent 做了什么、为什么”说明。
 
-更窄、偏合规的产品：不可变 evidence 留存、review-ready handoff 报告，以及周期性的“agent 做了什么、为什么”摘要。
+观测卖给今天就在运行 Agent 的团队；evidence 与 review 卖给未来需要解释 Agent 决策的组织。当 Agent 进入生产工作流，“给我看 evidence”会成为准入要求。
 
-这是方向 1 换个契约卖：观测卖给今天就在跑 agent 的团队；evidence 与 review 卖给未来需要向 stakeholders 解释 agent 决策的组织。当 agent 进入生产工作流，“给我看 evidence”会从锦上添花变成准入要求。
+事件溯源状态模型以及现有 evidence、handoff projection 使这层无需新增 Agent runtime 即可落地。它的信任门槛更高：留存 evidence 必须具备明确 lineage、append-only 语义、删除策略，以及签名或其他可验证导出。
 
-事件溯源状态模型和现有 evidence/handoff 投影让它无需新运行时机制即可落地。限制因素是信任：客户必须相信留存 evidence 完整且未被修改，这推动 append-only 存储和签名导出。
+### 3. Managed Semantic Control Plane（优先 BYOC）
 
-### 3. 托管控制面（优先 BYOC）
+产品终局不只是观测，而是一个持续运行的控制面：本地或第三方 runtime 执行 bounded work，Managed Semantic Control Plane 维护完备且一致的 semantic execution state。
 
-基础文档 `server-client-product-shape.md` 已经点名中期形态：服务器持有 durable goal 状态、事件历史和 governed planning lanes。该架构已经隐含 SaaS 管道在这里是自然的：
+基础文档 `server-client-product-shape.md` 已经点名中期形态：服务器持有 durable goal state、event history 和 governed planning lane。同一套架构可以支撑：
 
-- per-goal quota 与花费策略已存在；
-- 写入幂等、事件 append-only；
-- public/private 边界分类器是一等运行时概念。
+- 对权威状态进行幂等、可识别冲突的写入；
+- Supervisor 调度、stalled-loop 检测、恢复、handoff 和 replan；
+- 从 advisory proposal 到 executable work 的 policy-controlled promotion；
+- 跨 runtime 的 identity、claim、quota、evidence 与 acceptance 连续性；
+- operator 对每一次 authority 消耗 transition 的可见控制。
 
-这些正是多租户控制面需要的机制。风险不在技术契合，而在运营重力：托管客户生产 agent loop 的权威状态，会让 LoopX 进入客户关键路径，并承担相应的 SLA 负担。
+Supervisor 不是隐藏的自治管理者。它可以在已记录策略内调度、观察、恢复和提出 proposal，但不会因为被托管就自动取得人类 authority。
 
-更低风险的入口是 BYOC：控制面跑在客户自己的云账号里，LoopX 卖 console、升级和支持。这保留了 local-first 承诺——客户仍然拥有状态——同时创造订阅收入面。完整多租户托管是后续决策，不是前提。
+更低风险的企业入口是 BYOC：控制面运行在客户自己的云账号里，LoopX 销售 console、managed upgrade、治理、恢复运维和支持。完整多租户托管应当在隔离、删除、备份与 on-call 契约得到证明后再进入。
 
 ### 4. Domain Packs 与 Marketplace 收入
 
-Domain capability packs（`docs/product/domain-capability-packs.md`）是变现层，不是独立 SaaS。单独卖是一次性购买；挂到带 marketplace 抽成的托管平台上才变成订阅。这个方向依赖方向 1 或 3 先存在，不能作为起点。
+Domain capability packs（`docs/product/domain-capability-packs.md`）是扩张层，不是核心生意。它可以增加有领域倾向的评测、review 或运维 workflow，同时保持 Kernel 通用。
+
+当 team tier 或 managed control plane 已经存在后，pack 可以产生 marketplace 或企业集成收入。它不应当领先 SaaS 战略，商业包装也不能把领域 authority 搬进通用 Kernel。
+
+## 计费单位与产品分层
+
+主要计费单位应当跟随 managed control-plane value，而不是转售模型 token。
+
+| 价值面 | 候选计费单位 | 扩张逻辑 |
+| --- | --- | --- |
+| 团队控制面 | workspace + collaborator seat | 更多团队与 operator 共享同一份 governed state |
+| Agent 连续性 | 月 active managed agent 或 active governed goal | 更多长程 worker 依赖 identity、state、quota 与 recovery |
+| Evidence 运维 | retained event/evidence volume + retention window | 更长周期或强监管 workflow 需要更持久的历史 |
+| Managed supervision | 策略约束的 wake、recovery、replay 或 eval execution | 客户为持续运行的 continuation 付费，而不是为原始模型调用付费 |
+| 企业交付 | deployment environment + 治理与支持档位 | BYOC、SSO、RBAC、audit、residency、SLA 与迁移形成组织价值 |
+
+一个可行的产品阶梯是：
+
+- **Community**：local-first Kernel、protocol、CLI、export 和可自托管 projection；
+- **Team Cloud**：共享 workspace、中短期留存、审批、告警和协作 review；
+- **Managed Control Plane**：durable semantic state、Supervisor 调度、恢复、回放、评测和更长留存；
+- **Enterprise / BYOC**：私有部署、治理、审计、数据驻留、迁移、SLA 和专属支持。
+
+这是 packaging model，不是公开价格表。定价前需要先获得 active agent、event volume、retention、Supervisor execution 和支持成本的真实分布。Agent 与其 goal 不能作为同一活动被重复计费；应当用 cohort 数据选择更贴近客户价值的主单位，未活跃的注册 identity 保持免费。
 
 ## 什么不该做成 SaaS
 
-- **执行托管**（“我们替你跑 agent”）：会在算力毛利上和前沿模型厂商竞争，且违背“控制面不拥有 domain 行为”的架构原则。
-- **托管 CLI 状态作为产品**：没人会花钱把本地文件搬到别人的磁盘上。云层必须增加协作或治理价值，而不只是迁移状态。
+- **封闭的语义状态格式**：goal、evidence、authority 和 handoff 必须保持可检查、可导出。产品粘性应来自运行质量，而不是状态绑架。
+- **把通用执行托管当核心产品**：LoopX 可以编排外部 runtime，也可以运行 bounded Supervisor work；但转售模型 token 与 sandbox 会让项目在算力毛利上竞争，并模糊“控制面不拥有 domain 行为”的边界。
+- **把托管 CLI 文件当产品**：没人会为把本地文件搬到别人的磁盘付费。Managed 层必须增加协作、可靠性、恢复或治理价值。
+- **默认获得云端 authority**：托管基础设施不会自动授予读取私有 workspace、通过 gate、发布或执行生产写入的权限。
 
 ## 诚实的约束
 
-- **冷启动**：观测云需要足够多跑 LoopX loop 的团队才有东西可观测。现实的路径是：免费 CLI 采用扩大基数，云档再转化涌现出的团队。SaaS 层实现自给自足之前，预期需要很长的周期。
-- **品牌张力**：local-first 与 SaaS 拉扯方向相反。做得好是差异化（“你的状态还是你的；协作层托管”）；做得草率就会被解读为 bait-and-switch。
-- **维护面**：托管产品带来 on-call、数据留存和客户支持义务，这是单维护者 OSS 项目目前没有的。第一个付费档应当刻意收窄。
+- **采用与证据缺口**：公开长程 demo 能证明技术可行性，不能证明团队的 recurring demand。SaaS 需要外部生产 workload 对留存、恢复和协作的持续需求。
+- **冷启动**：观测云需要足够多运行 LoopX loop 的团队才有东西可观测。免费 CLI 可以扩大基数，但 hosted tier 达成自给自足可能需要很长时间。
+- **品牌张力**：local-first 与 SaaS 可能方向相反。可迁移、self-host、明确 opt-in 和收窄的 managed boundary 必须是产品行为，不能只停留在营销表述。
+- **信任与安全面**：托管 evidence 与 authority state，会带来比 OSS CLI 更强的隔离、删除、备份、incident response 和合规责任。
+- **运营能力**：托管产品包含 on-call、升级、迁移和客户支持义务，当前小型维护团队并不具备完整能力。第一个付费档应当刻意收窄。
+- **单位经济性未验证**：如果计费只跟随原始活动量，Supervisor execution、留存和支持可能吞掉毛利，需要与价值对齐的分档或上限。
+
+## 大规模建设前的证据门槛
+
+在 Managed 服务接管客户权威状态之前，LoopX 至少应当证明：
+
+1. 多个独立团队持续在数周级 goal 上使用控制面；
+2. 人工上下文重建、非法 continuation、恢复时间或 review 工作量出现可测下降；
+3. design partner 愿意为协作、留存、治理或 managed recovery 付费，而不只是购买通用支持；
+4. export、restore、deletion、tenancy、backup 与 public/private boundary 行为得到验证；
+5. 使用模型能够证明 retention、Supervisor work 与支持成本可以维持可接受毛利。
+
+这些门槛将技术期权与已经兑现的商业价值分开。
 
 ## 建议路径
 
-Phase 0 —— opt-in 观测中继：一个 `loopx cloud sync` 命令，把 public-safe status 投影推到托管 dashboard。个人免费、短留存。这是最小的楔子：`status_server` 和 dashboard 已存在，新增面只有账号系统和托管读模型。
+Phase 0 —— 为本地产品补充度量，验证可计费对象。在默认不收集私有内容的前提下，统计 active agent / goal、event / evidence volume、recovery action、review frequency 和 operator attention。
 
-Phase 1 —— 团队档：共享 goal board、Lark 路由审批、跨席位 quota 预算。按席位加托管 agent 计费。
+Phase 1 —— opt-in 观测中继。增加 `loopx cloud sync` 路径，把 public-safe status projection 推到托管 dashboard。个人档免费或窄计费，保持短留存。
 
-Phase 2 —— evidence 与 review 档：长留存、签名 evidence 导出、review-ready 摘要。卖给组织而不是团队。
+Phase 2 —— team 与 evidence tier。增加共享 goal board、审批路由、quota budget、更长留存、回放、签名导出和 review-ready summary，并用 design partner 验证 recurring willingness to pay。
 
-Phase 3 —— BYOC 托管控制面与 domain-pack marketplace 收入。
+Phase 3 —— Managed Semantic Control Plane，优先 BYOC。在客户环境中运行 durable state、Supervisor 调度、恢复和 governed replan，同时提供 managed upgrade 与支持。
 
-每个阶段可独立交付，各自为下一阶段提供资金；任何阶段都不需要押注完整多租户终态。
+Phase 4 —— 完整多租户控制面与 domain marketplace。只在隔离、支持负担和单位经济性得到证明后进入。
+
+每个阶段都可以独立交付，并为下一阶段产生证据；任何阶段都不需要让开源项目提前押注完整 hosted 终态。
+
+## 市场参照
+
+- [Letta pricing](https://www.letta.com/pricing) 展示了围绕 persistent agent state，按 active agent、执行、team 和 enterprise 能力计费的方式。
+- [Mastra pricing](https://mastra.ai/pricing) 展示了开源 Agent 开发平台如何按 usage、retention、team 和 enterprise 能力分层。
+
+这些参照说明客户能够理解托管状态、运维和治理的付费价值，但不能直接证明 LoopX 独特的 semantic control-plane contract 已经存在市场需求。
 
 ## 与现有文档的关系
 
-- `../foundations/server-client-product-shape.md` 命名了本评估依赖的 durable 控制面服务器角色。
-- `../surfaces/README.md` 与 frontstage 笔记覆盖托管 dashboard 会扩展的公开展示面。
-- `../domain-capability-packs.md` 定义了方向 4 变现的 pack 边界。
+- `../foundations/server-client-product-shape.md` 定义了本评估要商业化的 durable control-plane server、client 与 executor 角色。
+- `../surfaces/README.md` 与 frontstage 笔记覆盖 hosted workspace 将扩展的 public presentation surface。
+- `../domain-capability-packs.md` 定义了 marketplace 或企业集成可能商业化的 pack 边界。
+- `../../reference/protocols/event-sourced-state-contract-v0.md` 以及 decision、goal、evidence、quota、handoff contract 定义了不能变成私有锁定的 portable semantic state。
 
-本文刻意不给出定价承诺、发布日期和容量承诺。它是 SaaS 收入可能落在哪里的地图，在 CLI 采用漏斗足以支撑托管档时再重新审视。
+本文刻意不给出定价承诺、发布日期和容量承诺。它定义 recurring value 可能落在哪里，以及 LoopX 在把这项技术期权视作生意之前还需要哪些证据。


### PR DESCRIPTION
## Summary

- reframe the SaaS opportunity around one commercial thesis: keep LoopX's semantic state contracts open and local-first, and sell their reliable operation as a Managed Semantic Control Plane
- replace four competing SaaS candidates with an adoption ladder from observation and evidence to BYOC-managed control and enterprise delivery
- define the community/paid boundary, candidate billing units, packaging tiers, non-goals, and proof gates before significant SaaS build-out
- keep the English and Chinese strategy documents aligned

## Why

The previous assessment identified several plausible hosted surfaces, but it left the long-term control-plane product as the third candidate and did not explain how open-source state contracts connect to recurring revenue. This change makes the commercial boundary explicit while preserving portability, human authority, and the local-first contract.

## Impact

This is a documentation-only strategy change. It does not commit LoopX to launch dates, prices, capacity, telemetry collection, a cloud service, or any runtime behavior. It gives future product work a clearer test for what belongs in Community, Team Cloud, Managed Control Plane, and Enterprise/BYOC tiers.

## Validation

- `git diff --check`
- both external pricing reference links returned HTTP 200
- all referenced local documents exist
- `mkdocs build --strict --site-dir /private/tmp/loopx-saas-docs-site`
- public/private and credential-marker scan on both changed files returned no findings

## Scope boundary

Only the two public SaaS assessment documents are included. Existing unrelated files and local/private state were excluded.
