### PR TITLE
docs: ground LoopX commercialization strategy in public evidence

### DIFF
--- a/docs/product/roadmaps/saas-opportunity-assessment.md
+++ b/docs/product/roadmaps/saas-opportunity-assessment.md
@@ -86,6 +86,129 @@ A managed offering is worth building only if it passes all four tests:
 The fourth test matters most. A dashboard with no measurable effect on long
 running work is an interface feature, not a durable SaaS business.
 
+## Commercial Comparables: Value Capture, Not Stars
+
+Public evidence checked on 2026-08-15 shows four different value-capture
+models, not four equivalent startups. GitHub stars establish distribution and
+category attention. They do not establish revenue, retention, gross margin, or
+enterprise willingness to pay.
+
+| Project | Public commercial evidence | Value-capture path | Current assessment | Lesson for LoopX |
+| --- | --- | --- | --- | --- |
+| Letta | The company [raised a $10M seed round in 2024](https://www.prnewswire.com/news-releases/berkeley-ai-research-lab-spinout-letta-raises-10m-seed-financing-led-by-felicis-to-build-ai-with-memory-302257004.html). Its current [API plan](https://docs.letta.com/pricing) charges a base subscription, active-agent usage, tool execution, and model usage; team and enterprise tiers add sharing, access control, SSO, and support. A [vendor case study](https://www.letta.com/case-studies/bilt/) reports more than one million agents in production at Bilt. | Hosted stateful agents, execution, collaboration, and enterprise control | Real pricing and production signals around persistent agent state. Public audited ARR is not available, and the Bilt evidence is vendor-reported. | Durable state can be a billable primitive when it is operated continuously and tied to production workloads. |
+| Mastra | Mastra [announced a $22M Series A and $35M total funding in April 2026](https://mastra.ai/blog/series-a). Its [pricing](https://mastra.ai/pricing) combines a $250/month team tier with metered observability, compute, memory, storage, retention, enterprise support, and a flat-fee self-hosted enterprise option. | Open framework plus hosted platform, operations, and enterprise deployment | The strongest public standalone platform signal in this comparison. Funding, named customer stories, and packaging are meaningful, but they are not disclosed revenue. | An open developer framework can expand into a managed operations surface if the paid layer owns reliability, retention, evaluation, and delivery. |
+| AgentScope | AgentScope is an Apache-2.0 project authored by the [Alibaba Tongyi Lab SysML team](https://github.com/agentscope-ai/agentscope/blob/main/pyproject.toml), not a separately disclosed startup. It deploys into Alibaba Cloud surfaces, while [AgentRun](https://www.alibabacloud.com/help/en/functioncompute/what-is-agentrun) sells serverless runtime, sandbox, model governance, observability, and cost management and explicitly integrates AgentScope. | Cloud consumption, ecosystem pull-through, and platform retention | Potentially high strategic value inside Alibaba Cloud, but no meaningful standalone AgentScope valuation or revenue unit is publicly separable. | A widely adopted OSS framework can create substantial platform value while most direct economic capture accrues to the surrounding cloud. |
+| CAMEL / Eigent | [CAMEL-AI](https://www.camel-ai.org/about) creates multi-agent research and category awareness. The related Eigent application [reports more than $250K revenue within three months of launch](https://www.eigent.ai/about), and lists [annual-plan equivalents of $19.90 and $99.99 per month plus enterprise deployment](https://www.eigent.ai/pricing). Its terms also allow a separate [commercial production license and professional services](https://www.eigent.ai/terms-of-use). | End-user application subscriptions, enterprise license, private deployment, and services | Early but concrete application monetization. The revenue number is company-reported, short-window, and not proof of durable recurring revenue. | Research and OSS attention can convert through an opinionated application, but the application layer has a different sales motion and margin structure from infrastructure. |
+
+Three conclusions follow.
+
+First, commercial value does not follow the star ranking. Mastra currently has
+the strongest public capital and packaged-platform signal; Letta has the
+clearest production case for stateful agents; AgentScope may create large
+embedded cloud value without becoming a standalone company; CAMEL converts
+research attention through a separate application product.
+
+Second, the recurring pattern is open distribution followed by a scarce paid
+surface: operated state, observability and deployment, cloud consumption, or a
+packaged domain application. Open source is compatible with revenue when the
+paid product removes operational and organizational burden rather than hiding
+the protocol.
+
+Third, LoopX's architectural position is an upper-layer combination of the
+first two patterns: Letta-like durable state plus Mastra-like managed
+operations, generalized across heterogeneous runtimes. The differentiated
+product is not a larger framework. It is the semantic control plane that keeps
+goal, authority, planning, supervision, evidence, recovery, and handoff
+coherent across agents and runs. The comparison validates the monetization
+shape; LoopX still has to validate repeat demand for this distinct layer.
+
+## Vertical Digital Employees And Digital Teams
+
+The application category is no longer hypothetical, but it is not yet a
+mature autonomous-labor market either.
+
+- BNY's [2025 annual report](https://www.bny.com/content/dam/bnymellon/documents/pdf/investor-relations/annual-report-2025.pdf)
+  reports 160 enterprise AI solutions in production and 134 "digital
+  employees," defined as multi-agent systems operating autonomously alongside
+  human colleagues. This is direct evidence that a regulated enterprise can
+  make the digital-employee concept an organizational unit rather than a demo.
+- Microsoft's [2025 Work Trend Index](https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/microsoft/final/en-us/microsoft-product-and-services/ai/pdf/executive-summary-work-trend-index-annual-report.pdf),
+  based on 31,000 workers in 31 countries, reports that 45% of leaders treat
+  expanding capacity with digital labor as a near-term priority and 46% say
+  their companies already use agents to automate workflows or processes. This
+  measures intent and self-reported adoption, not verified production ROI.
+- McKinsey's [2025 global survey](https://www.mckinsey.com/capabilities/quantumblack/our-insights/the-state-of-ai?lang=en)
+  is the useful counterweight: 23% report scaling an agentic system somewhere
+  and another 39% are experimenting, yet no individual function exceeds 10%
+  scaling and enterprise-wide EBIT impact remains uncommon. The gap is not
+  awareness; it is productionization and workflow redesign.
+- A field study of 5,179 customer-support workers found a [14% average
+  productivity increase](https://www.nber.org/papers/w31161) from generative AI
+  assistance. This validates task-level economics, especially for less
+  experienced workers, but it studied an assistant rather than an autonomous
+  digital employee.
+- AWS made [multi-agent collaboration generally available](https://aws.amazon.com/blogs/machine-learning/amazon-bedrock-announces-general-availability-of-multi-agent-collaboration/)
+  in 2025 and documents supervisor-led use across finance, retail, fraud,
+  support, healthcare, and agriculture. This proves that multi-agent
+  orchestration is becoming a platform primitive; vendor examples alone do
+  not prove that every workflow benefits from multiple agents.
+- Gartner's [failure forecast](https://www.gartner.com/en/newsroom/press-releases/2025-06-25-gartner-predicts-over-40-percent-of-agentic-ai-projects-will-be-canceled-by-end-of-2027)
+  predicts that more than 40% of agentic projects will be canceled by the end
+  of 2027 because of cost, unclear value, or weak risk controls. The same note
+  predicts agentic functions in 33% of enterprise applications by 2028. The
+  market can grow rapidly while undifferentiated projects fail rapidly.
+
+### The Product Unit
+
+A vertical digital employee should not mean "a prompt with a job title." It is
+a governed role contract with:
+
+- durable identity and a named human outcome owner;
+- bounded tools, data, authority, quota, and escalation policy;
+- explicit goals, plans, acceptance criteria, and service expectations;
+- evidence, decision, and action history that can be reviewed later;
+- recovery and handoff behavior when a run, model, machine, or operator
+  changes.
+
+A digital team is several such role contracts sharing goals and evidence while
+retaining distinct authority. It adds explicit claims and handoffs, team-level
+budgets and acceptance, and supervisor scheduling, recovery, and replanning.
+The supervisor coordinates recorded authority; it does not become a hidden
+executive.
+
+This definition maps directly to LoopX's semantic contracts. A domain pack can
+package role-specific tools, evaluation, review, and escalation. The open
+Kernel keeps the state and authority protocol portable. A paid Managed
+Semantic Control Plane keeps the employee or team continuously available,
+recoverable, observable, and governed.
+
+### Application Outlook And Wedge Order
+
+The ratings below are strategic inferences from the public evidence above,
+not market-size forecasts.
+
+| Workflow | Market readiness | LoopX fit | Why it can pay | Primary gate | Recommended LoopX position |
+| --- | --- | --- | --- | --- | --- |
+| Customer and employee service | High | Medium | High task volume, clear resolution, latency, deflection, and quality metrics | Real-time latency, safe escalation, and existing platform competition | Integrate as the long-running evidence, policy, and recovery layer rather than compete first as a contact-center runtime |
+| Software engineering, SRE, and IT operations | High | Very high | Work spans repositories, incidents, reviews, machines, and multiple days; failed continuation is expensive | Reliable acceptance, environment isolation, and human merge or production authority | First-party design-partner wedge for Team Cloud and Managed Control Plane |
+| Research, experimentation, and lab operations | Medium-high | Very high | Hypotheses, negative results, evidence lineage, quotas, and repeated experiments naturally require durable semantic state | Domain evaluation and connection to instruments, datasets, or compute | First-party wedge for research groups and technical startups; sell reproducibility, supervision, and recovery |
+| Finance, procurement, order-to-cash, and other back-office operations | Medium-high | High | Multi-system workflows have measurable cycle time, exception rate, and audit cost | ERP integration, permissions, privacy, and approval boundaries | BYOC design partners with narrow workflows and explicit human gates |
+| Legal, healthcare, and regulated professional work | Medium | High over time | High review and compliance cost make evidence and authority valuable | Liability, domain accuracy, data residency, and professional sign-off | Human-led digital team first; enter through governed review and evidence packs, not autonomous final decisions |
+| Cross-functional digital team | Early | Highest destination | Several specialized agents can own a persistent outcome instead of isolated tasks | Cross-role authority, conflict handling, shared acceptance, and accountable escalation | Long-term product destination after single-role recurrence and recovery are proven |
+
+The near-term sales message should therefore be **governed capacity for one
+valuable workflow**, not "replace a department with AI." The initial contract
+can combine a workspace or workflow fee, active managed employees, retained
+evidence, supervisor work, and enterprise delivery. Outcome-linked pricing may
+be added only where the outcome is attributable and auditable.
+
+The order also matters. Software, SRE, research, and technical operations are
+closest to LoopX's existing community and expose the exact long-horizon
+failures its control plane solves. Back-office and regulated workflows can
+produce higher contract values, but should follow through BYOC and domain
+partners after authority, evidence, deletion, and recovery behavior are
+proven. Digital teams are the expansion path, not the first SKU.
+
 ## Product Ladder
 
 The following directions are not four independent SaaS products. They are an
@@ -274,16 +397,23 @@ isolation, support load, and unit economics are proven.
 Each phase is independently shippable and creates evidence for the next. No
 phase requires betting the open-source project on the full hosted end state.
 
-## Market Reference Points
+## Evidence Boundary
 
-- [Letta pricing](https://www.letta.com/pricing) demonstrates active-agent,
-  execution, team, and enterprise metering around persistent agent state.
-- [Mastra pricing](https://mastra.ai/pricing) demonstrates usage, retention,
-  team, and enterprise packaging around an open agent development platform.
+The comparisons in this note intentionally separate different kinds of public
+evidence:
 
-These references show that buyers can understand hosted state, operations, and
-governance as paid surfaces. They do not prove demand for LoopX's distinct
-semantic control-plane contract.
+- financing validates investor conviction and operating runway, not product
+  retention or revenue;
+- a published price validates a monetization surface, not the number of paying
+  customers;
+- vendor case studies validate named deployments as reported by the vendor and
+  customer, not independently audited ROI;
+- enterprise surveys validate attention and stated adoption, not demand for
+  LoopX's distinct semantic control-plane contract.
+
+The evidence is strong enough to justify design-partner work and a measured
+commercial thesis. It is not strong enough to skip LoopX's own recurrence,
+outcome, willingness-to-pay, and unit-economics gates.
 
 ## Relation To Existing Docs
 

--- a/docs/product/roadmaps/saas-opportunity-assessment.md
+++ b/docs/product/roadmaps/saas-opportunity-assessment.md
@@ -1,22 +1,35 @@
-# SaaS Opportunity Assessment
+# Commercialization And SaaS Opportunity Assessment
 
 Status: assessment target. This note is a strategic evaluation, not a
-commitment to build. It asks how LoopX can support a hosted,
-recurring-revenue product without weakening the local-first and
-provider-neutral control-plane contract that LoopX is built on.
+commitment to build. It asks how LoopX can turn its control-plane technology
+into repeatable customer value through an enterprise harness, productized
+delivery, BYOC, managed operations, or SaaS without weakening the local-first
+and provider-neutral contract that LoopX is built on.
 
 ## Commercial Thesis
 
 The most coherent commercial position for LoopX is:
 
 > Keep the semantic state contracts for long-running agents open and
-> local-first. Sell the reliable operation of those contracts as a Managed
-> Semantic Control Plane.
+> local-first. Package them as a mature Enterprise Agent Harness, use
+> productized FDE delivery to put bounded vertical workflows into production,
+> and sell private deployment, licenses, managed operations, and support.
+> Expand repeated operational surfaces into a Managed Semantic Control Plane
+> and SaaS where the customer and market fit justify it.
 
 The open layer gives agents and operators portable goal, authority, todo,
 evidence, acceptance, quota, handoff, recovery, and replan state. The paid
-layer makes that state reliable across a team: continuously available,
-collaborative, observable, recoverable, governed, and supported.
+layer packages those contracts into a deployable product and makes the state
+reliable across a team: continuously available, collaborative, observable,
+recoverable, governed, and supported.
+
+The Managed Semantic Control Plane remains the durable commercial core, but it
+does not have to be the first SKU. A customer may first buy a working digital
+employee or team, a private deployment, integrations, acceptance evidence, and
+someone accountable for reaching production. The same delivery should run on
+one reusable Harness rather than on a customer-specific fork. Recurring cloud
+revenue becomes an expansion path after repeated value and operating demand
+exist.
 
 This places LoopX near the intersection of two publicly commercialized
 adjacent patterns. Letta packages persistent, stateful agents as a hosted
@@ -29,28 +42,35 @@ runtimes: complete state management, planning and supervision, evidence-backed
 recovery, and human authority that survive across runs and agents.
 
 That is a positioning hypothesis, not a revenue claim. It still has to be
-validated by repeat production use and willingness to pay.
+validated by repeat production use, delivery reuse, and willingness to pay.
 
 ## The Core Tension
 
 LoopX's value proposition is a local-first control plane whose durable state
 the operator can own, inspect, export, and recover. A naive SaaS move — "we
 host your agent state on our servers" — weakens the exact property that makes
-the product trustworthy.
+the product trustworthy. A naive delivery move — "we customize anything until
+the customer accepts it" — can turn the project into a low-reuse systems
+integration business.
 
-The SaaS question is therefore not "can LoopX be hosted?" It is:
+The commercialization question is therefore:
 
-> Which control-plane responsibilities become more valuable when somebody
-> operates them continuously, and which authority and data boundaries must
-> remain portable by design?
+> Which customer outcomes require direct delivery, which control-plane
+> responsibilities become more valuable when operated continuously, and which
+> authority, data, and product boundaries must remain portable and reusable by
+> design?
 
-Collaboration, cross-device access, durable retention, shared governance,
-managed recovery, and operational support benefit from a hosted or BYOC
-service. The semantic contracts, export path, local execution option, and
-customer authority over private workspace content should remain open.
+Discovery, integration, evaluation, and rollout may require an FDE working
+inside the customer workflow. Collaboration, durable retention, shared
+governance, managed recovery, and operational support benefit from a private,
+BYOC, or hosted service. The semantic contracts, export path, local execution
+option, and customer authority over private workspace content should remain
+open.
 
-The paid product sells operation, reliability, and organizational control. It
-must not sell users back access to their own state format.
+The paid product sells a production-ready Harness, delivered outcomes,
+operation, reliability, and organizational control. It must not sell users
+back access to their own state format or sell unbounded engineer time as the
+product.
 
 ## Open And Paid Product Boundary
 
@@ -60,7 +80,7 @@ must not sell users back access to their own state format.
 | Execution | Provider-neutral adapters for Codex, Claude Code, Cursor, shell agents, and custom workers | Fleet registration, health, policy-controlled wake, supervisor scheduling, recovery, and operator routing |
 | Observation | Local projections, CLI status, export, and self-hostable dashboard surfaces | Shared workspaces, long retention, cross-agent timelines, evaluation, replay, alerts, and review queues |
 | Governance | Inspectable local authority, boundary, and approval contracts | Multi-tenant isolation, RBAC, SSO, audit, quotas, data residency, signed exports, and policy administration |
-| Delivery | Documentation and a usable self-host path | BYOC or managed deployment, SLA, migration, integration, incident response, and support |
+| Delivery | Documentation, pack SDKs, reference workflows, and a usable self-host path | Enterprise Harness, productized FDE deployment, BYOC or managed operation, SLA, migration, integration, incident response, and support |
 
 Portability is part of the product contract. A customer should be able to
 export semantic state, retain durable identities and evidence lineage, and
@@ -69,22 +89,30 @@ meaning of its work from proprietary logs.
 
 ## Viability Test
 
-A managed offering is worth building only if it passes all four tests:
+A commercial offering is worth scaling only if it passes all six tests:
 
-1. **Continuous use**: operators and agent teams return to it throughout the
+1. **Outcome proof**: one bounded workflow reaches customer acceptance with a
+   measurable improvement in cycle time, quality, capacity, recovery, or
+   compliance cost.
+2. **Continuous use**: operators and agent teams return to it throughout the
    working week, not once per install.
-2. **Managed advantage**: collaboration, availability, recovery, retention, or
-   governance make the operated version materially better than files on one
-   machine.
-3. **Natural expansion**: revenue grows with workspaces, active managed agents,
-   retention, supervisor work, or enterprise controls rather than one-off
-   features.
-4. **Control-plane proof**: customers can measure less manual coordination,
+3. **Managed advantage**: integration, collaboration, availability, recovery,
+   retention, or governance make the product materially better than scripts
+   and files on one machine.
+4. **Delivery reuse**: customer work becomes adapters, packs, evals, or core
+   improvements that reduce effort on the next deployment; it does not create
+   a permanent customer fork.
+5. **Natural expansion**: revenue grows with licensed environments,
+   workspaces, active managed agents, retention, supervisor work, or enterprise
+   controls rather than only engineer-days.
+6. **Control-plane proof**: customers can measure less manual coordination,
    faster recovery, fewer invalid continuations, or lower review and audit
    cost.
 
-The fourth test matters most. A dashboard with no measurable effect on long
-running work is an interface feature, not a durable SaaS business.
+The first and fourth tests matter before the SaaS shape. A dashboard with no
+measurable effect is an interface feature; a successful deployment with no
+reusable asset is a services project. Neither is yet a durable software
+business.
 
 ## Commercial Comparables: Value Capture, Not Stars
 
@@ -121,6 +149,108 @@ product is not a larger framework. It is the semantic control plane that keeps
 goal, authority, planning, supervision, evidence, recovery, and handoff
 coherent across agents and runs. The comparison validates the monetization
 shape; LoopX still has to validate repeat demand for this distinct layer.
+
+## China Go-To-Market: Productized Delivery Before Pure SaaS
+
+"SaaS is hard in China" is too coarse to be a strategy. The market is real and
+growing: the China Academy of Information and Communications Technology's
+[2024 enterprise SaaS report](https://www.caict.ac.cn/kxyj/qwfb/ztbg/202408/P020240815374016912879.pdf)
+estimated a RMB 58.1 billion market in 2023, up 23.1%. The same report explains
+why a US-style horizontal public-cloud subscription is not the only practical
+entry: vendors increasingly add private or hybrid deployment and custom
+development for larger customers; subscription adoption remains uneven; and
+many providers still combine project fees with consulting, training, hardware,
+or other services.
+
+The report also names the trap. Heavy customization raises delivery cost,
+slows standard-product iteration, and prevents development effort from being
+amortized across customers. LoopX should therefore choose neither extreme:
+
+- do not wait for a low-touch horizontal SaaS dashboard to create value from a
+  still-emerging category;
+- do not become an unbounded custom-project company that happens to use LoopX;
+- use direct delivery to discover and prove valuable workflows, while one
+  versioned Harness, extension boundary, and evidence contract force the work
+  back into reusable product assets.
+
+Different customer segments should receive different commercial motions:
+
+| Segment | First offer | Delivery motion | Economic logic |
+| --- | --- | --- | --- |
+| AI-native startup or technical team | Enterprise Harness license plus support; optional Team Cloud | Self-serve or a short enablement sprint | The customer can integrate runtimes and values speed, portability, and multi-agent continuity; low delivery load can support recurring software revenue |
+| Research group or laboratory | Community edition, sponsored support, or a shared research Harness | Enablement and templates; FDE only for funded institutional workflows | Reproducibility and experiment supervision fit LoopX, but many groups cannot support enterprise sales and customization cost |
+| Mid-sized enterprise | Paid discovery and one bounded FDE deployment, followed by annual private or BYOC license | Outcome and acceptance milestones with explicit integrations and handover | The buyer can fund workflow change but wants direct proof before paying for an abstract platform |
+| Large or regulated enterprise | Enterprise Harness, FDE delivery, managed operations, governance, and SLA | Private/BYOC deployment with security, audit, and procurement work | Higher contract value can pay for integration and controls, but sales cycles and service burden are materially higher |
+| Overseas developer team | Team Cloud or Managed Control Plane with usage expansion | Product-led trial plus remote solution engineering | Public-cloud acceptance and software willingness to pay make the pure SaaS path more plausible |
+
+This is a sequencing decision, not a retreat from recurring revenue. The
+domestic entry is more likely to be license plus delivery plus annual managed
+operations. SaaS becomes appropriate for lower-friction teams, overseas
+customers, and the common operating surfaces discovered across deployments.
+
+### A Mature Harness Is The First Paid Product
+
+Mature agent harnesses show that customers pay for a complete working surface,
+not for a protocol diagram. OpenAI reports more than two million weekly Codex
+builders and sixfold growth in Business and Enterprise Codex users, while
+[metering team use by consumption](https://openai.com/index/codex-flexible-pricing-for-teams/).
+Anthropic packages Claude Code with [centralized billing, spend controls,
+usage analytics, managed tool and MCP policy, and a compliance API](https://www.anthropic.com/news/claude-code-on-team-and-enterprise),
+and [supports enterprise deployment through existing Bedrock or Vertex AI
+infrastructure](https://docs.anthropic.com/en/docs/claude-code/getting-started).
+These products do not validate LoopX demand, but they validate the buyer
+expectation: an enterprise harness includes installation, execution, policy,
+observability, administration, and support in one operable product.
+
+The first paid LoopX product should therefore be a **LoopX Enterprise Agent
+Harness**, not a collection of schemas and not another model or IDE. It should
+package:
+
+- a versioned Kernel and state service with local, private, and BYOC profiles;
+- supported adapters for mature runtimes such as Codex, Claude Code, Cursor,
+  shell agents, and customer workers;
+- supervisor scheduling, recovery, handoff, quota, and acceptance;
+- a local or private console for goals, evidence, review, replay, and fleet
+  health;
+- deployment automation, upgrades, backup and restore, policy defaults, and a
+  diagnostic support bundle;
+- a domain-pack boundary for tools, evals, role contracts, and customer-system
+  integrations without forking the Kernel.
+
+The customer buys a deployable system that can own one workflow through
+acceptance. The semantic control plane is the product spine inside it, rather
+than an infrastructure abstraction the buyer must assemble.
+
+### FDE As Product Discovery And Deployment
+
+FDE is useful when it closes the last mile between a capable Harness and a
+messy production workflow. OpenAI's current [FDE role](https://openai.com/careers/forward-deployed-engineer-%28fde%29-sf-san-francisco/)
+owns discovery, technical scoping, system design, build, rollout, measurable
+workflow impact, and codification of working patterns into reusable building
+blocks. Palantir's [2025 Form 10-K](https://www.sec.gov/Archives/edgar/data/1321655/000132165526000011/pltr-20251231.htm)
+reports $4.5 billion in revenue and 954 customers, showing that complex
+deployment and expansion can support a large software business; the same
+filing identifies high installation cost, long sales cycles, costly pilots,
+training, and ongoing service as material risks. The FDE is therefore part of
+the product feedback loop, not billable staff augmentation.
+
+A LoopX FDE engagement should have five bounded outputs:
+
+1. a workflow baseline, outcome owner, authority map, and paid scope;
+2. a production path built on the current Enterprise Harness and supported
+   extension points;
+3. an evaluation set, acceptance criteria, and before/after outcome evidence;
+4. deployment, operator training, runbook, rollback, and handover;
+5. at least one reusable pack, adapter, eval, playbook, or core improvement
+   that is generalized back into the product.
+
+The operating rules are strict: no indefinite free proof of concept, no
+customer-specific Kernel fork, no production write without customer authority,
+and no promise of outcome-based pricing until attribution is auditable. Track
+engineer-months to acceptance, reusable-versus-customer-only work, time to the
+second deployment of the same pack, license and managed revenue versus labor
+revenue, and renewal or expansion. If these do not improve across deployments,
+FDE is not creating a moat; it is hiding a services business.
 
 ## Vertical Digital Employees And Digital Teams
 
@@ -211,112 +341,95 @@ proven. Digital teams are the expansion path, not the first SKU.
 
 ## Product Ladder
 
-The following directions are not four independent SaaS products. They are an
-adoption and expansion ladder toward one Managed Semantic Control Plane.
+This is a product and revenue ladder, not five independent SaaS products. Each
+step should leave behind a reusable product and make the next step easier to
+sell.
 
-### 1. AgentOps Observation And Governance Cloud
+### 1. Enterprise Agent Harness
 
-The strongest entry wedge is a "Datadog / Langfuse for agent loops" focused on
-goals, authority, evidence, recovery, and quota rather than only LLM traces.
+The first sellable product is one versioned LoopX distribution that works in
+local, private, and BYOC profiles. It packages runtime adapters, semantic state,
+Supervisor behavior, recovery, acceptance, evaluation, deployment, upgrade,
+backup, diagnostics, and an operator console. The acceptance unit is one
+bounded workflow reaching production, not a successful installation.
 
-The control plane already produces the raw material: goal state, run history,
-evidence events, quota decisions, handoff records, and public-safe projections.
-A hosted observation layer turns it into a shared team surface:
+### 2. FDE-Led Design Partner Delivery
 
-- a cross-member goal board showing who is running which agents and why;
-- quota and budget views that map spend to goals rather than only API calls;
-- gate and approval queues routed through Lark or equivalent channels;
-- recovery and handoff timelines that survive a machine loss or operator
-  switch;
-- evidence and evaluation drill-downs that explain what changed and whether a
-  continuation was valid.
+Paid discovery and a bounded production engagement connect the Harness to one
+valuable customer workflow. The delivery includes integrations, evaluation,
+acceptance evidence, operating runbooks, rollback, and handover. FDE is not a
+standalone consulting SKU: every engagement must run on the supported Harness
+and produce reusable packs, adapters, evals, playbooks, or core improvements.
 
-This wedge is read-mostly and can consume the public status data contract
-without owning private workspace content. It proves daily use and team
-collaboration before LoopX assumes authority over production control state.
+### 3. Team Evidence And Governance Plane
 
-### 2. Evidence And Review Service
+Once one workflow is recurrent, LoopX can sell the organizational surface
+around it: a shared goal board, immutable evidence retention, replay,
+review-ready handoff reports, approval routing, quotas, evaluation history,
+RBAC, SSO, audit, and policy administration. It should begin as a private,
+BYOC, or read-mostly surface that consumes explicit projections instead of
+assuming access to private workspace content.
 
-The next expansion layer adds immutable evidence retention, replay,
-review-ready handoff reports, evaluation history, and periodic explanations of
-what agents did and why.
+### 4. Managed Semantic Control Plane
 
-Observation sells to the team operating agents today. Evidence and review sell
-to the organization that must justify agent decisions later. As agents enter
-production workflows, "show me the evidence" becomes an admission requirement.
+The durable destination is an operated control plane that keeps complete
+semantic execution state coherent while local or third-party runtimes perform
+bounded work. It provides authoritative, conflict-aware state; Supervisor
+scheduling; stalled-loop detection; recovery, handoff, and governed replan;
+and cross-runtime identity, claim, quota, evidence, and acceptance continuity.
 
-The event-sourced state model and existing evidence and handoff projections
-make this possible without a new agent runtime. The trust bar is higher:
-retained evidence must have explicit lineage, append-only semantics, deletion
-policy, and signed or otherwise verifiable exports.
+The Supervisor is not a hidden autonomous manager. Hosting does not grant it
+human authority. BYOC and managed private deployment are the lower-risk first
+forms; full multi-tenant hosting follows only after isolation, deletion,
+backup, support, and on-call economics are proven.
 
-### 3. Managed Semantic Control Plane, Preferably BYOC First
+### 5. Domain Packs And Partner Ecosystem
 
-The product destination is not observation alone. It is an operated control
-plane that keeps complete semantic execution state coherent while local or
-third-party runtimes perform bounded work.
-
-The foundations note `server-client-product-shape.md` already names the medium
-term shape: the server owns durable goal state, event history, and governed
-planning lanes. The same architecture supports:
-
-- idempotent and conflict-aware writes to authoritative state;
-- supervisor scheduling, stalled-loop detection, recovery, handoff, and replan;
-- policy-controlled promotion from advisory proposals to executable work;
-- cross-runtime identity, claim, quota, evidence, and acceptance continuity;
-- operator-visible control over every transition that spends authority.
-
-The supervisor is not a hidden autonomous manager. It may schedule, observe,
-recover, and propose within recorded policy; it does not acquire human
-authority merely because it is hosted.
-
-The lower-risk enterprise entry is BYOC. The control plane runs in the
-customer's cloud account while LoopX sells the console, managed upgrades,
-governance, recovery operations, and support. Full multi-tenant hosting can
-follow when isolation, deletion, backup, and on-call contracts are proven.
-
-### 4. Domain Packs And Marketplace Revenue
-
-Domain capability packs (`docs/product/domain-capability-packs.md`) are an
-expansion layer rather than the core business. They can add opinionated
-evaluation, review, or operational workflows while the Kernel remains generic.
-
-Packs may support marketplace or enterprise integration revenue after the team
-or managed control plane exists. They should not lead the SaaS strategy, and
-commercial packaging must not move domain-specific authority into the generic
+Domain capability packs (`docs/product/domain-capability-packs.md`) package
+tools, role contracts, evaluations, review rules, and integrations while the
+Kernel remains generic. LoopX or certified partners can deliver them. A
+marketplace is a later distribution and revenue surface, not the initial
+business, and domain-specific authority must remain outside the generic
 Kernel.
 
 ## Metering And Packaging
 
-The primary billing unit should follow managed control-plane value, not model
-token resale.
+Billing should follow delivered and managed value rather than token resale or
+unbounded engineer-days.
 
 | Value surface | Candidate unit | Why it expands |
 | --- | --- | --- |
+| Paid discovery and deployment | fixed scope, milestones, and acceptance | The customer pays to put one defined workflow into production, not for an indefinite proof of concept |
+| Harness license | annual environment or workspace license plus maintenance | The product remains useful after the FDE leaves and expands across workflows and teams |
+| FDE productionization | bounded integration and deployment fee | Last-mile work is funded while scope, handover, and reusable outputs stay explicit |
 | Team control plane | workspace plus collaborator seats | More teams and operators share the same governed state |
 | Agent continuity | monthly active managed agent or active governed goal | More long-running workers rely on identity, state, quota, and recovery |
 | Evidence operations | retained event/evidence volume and retention window | Longer-lived and regulated workflows need more durable history |
 | Managed supervision | policy-controlled wake, recovery, replay, or evaluation executions | Customers pay for operated continuation rather than raw model calls |
-| Enterprise delivery | deployment environment plus governance and support tier | BYOC, SSO, RBAC, audit, residency, SLA, and migration create organizational value |
+| Managed operations | deployment environment plus governance and support tier | BYOC, SSO, RBAC, audit, residency, SLA, migration, and incident response create organizational value |
 
 A plausible package ladder is:
 
 - **Community**: local-first Kernel, protocols, CLI, exports, and self-hostable
   projections.
-- **Team Cloud**: shared workspaces, short-to-medium retention, approvals,
-  alerts, and collaborative review.
-- **Managed Control Plane**: durable semantic state, supervisor scheduling,
-  recovery, replay, evaluation, and higher retention.
-- **Enterprise / BYOC**: private deployment, governance, audit, residency,
-  migration, SLA, and dedicated support.
+- **Enterprise Harness**: supported private distribution, runtime adapters,
+  console, deployment automation, upgrades, backup, diagnostics, and annual
+  maintenance.
+- **Design Partner Deployment**: paid, bounded FDE work with outcome,
+  acceptance, reuse, and handover gates.
+- **Managed / BYOC**: durable semantic state, Supervisor operation, recovery,
+  governance, audit, residency, migration, SLA, and support.
+- **Team Cloud**: shared workspaces, retention, approval, alert, and review for
+  lower-friction or overseas teams when multi-tenant economics are proven.
 
 This is a packaging model, not a published price list. Before choosing prices,
 LoopX needs usage distributions for active agents, event volume, retention,
-supervisor executions, and support cost. It should not charge for both an agent
-and its goals as duplicate activity; cohort data should decide which unit best
-tracks customer value, and dormant registered identities should remain free.
+Supervisor executions, delivery effort, and support cost. Contracts should
+distinguish software license, bounded delivery, and recurring managed
+operations. The licensed Harness must remain useful after delivery ends, and
+an agent and its goals should not be charged as duplicate activity.
 
-## What Should Not Be SaaS
+## What Should Not Become The Business
 
 - **A closed semantic state format**: goals, evidence, authority, and handoff
   must stay inspectable and exportable. Lock-in should come from operating
@@ -328,19 +441,32 @@ tracks customer value, and dormant registered identities should remain free.
 - **Hosted CLI files as the product**: nobody pays merely to move local files
   to somebody else's disk. The managed layer must add collaboration,
   reliability, recovery, or governance.
+- **Customer-specific Kernel forks or open-ended FDE staffing**: supported
+  extension points and bounded delivery must absorb customer variation. A
+  permanent fork or engineer-day dependency destroys reuse.
+- **Indefinite free proofs of concept**: discovery may be short, but production
+  work needs an owner, a paid scope, acceptance criteria, and a handover plan.
 - **Cloud authority by default**: hosted infrastructure does not grant
   permission to read private workspaces, approve gates, publish, or perform
   production writes.
+- **Department-replacement or unauditable outcome promises**: sell governed
+  capacity for a bounded workflow. Outcome-linked pricing requires a measurable
+  baseline and auditable attribution.
 
 ## Honest Constraints
 
 - **Adoption and proof gap**: public long-running demonstrations establish
-  technical feasibility, not recurring team demand. The SaaS case requires
-  external production workloads with retention, recovery, and collaboration
-  needs.
-- **Cold start**: an observation cloud needs enough teams running LoopX loops
-  to have something to observe. Free CLI adoption can grow the base, but a
-  hosted tier may take a long time to become self-sustaining.
+  technical feasibility, not recurring demand or customer outcomes. External
+  production workloads must establish both.
+- **Domestic procurement and collection**: private deployment, security review,
+  integration, procurement, and payment cycles can make revenue slower and
+  less repeatable than a public-cloud subscription suggests.
+- **FDE and services trap**: direct delivery can create the category, but it can
+  also consume founder attention, create customer concentration, and hide weak
+  software demand unless reuse and recurring software revenue improve.
+- **Cloud cold start**: a shared observation or control plane needs enough
+  recurrent teams and workflows to be useful. It should not be built merely to
+  create a SaaS-shaped SKU.
 - **Brand tension**: local-first and SaaS can pull in opposite directions.
   Portability, self-hosting, explicit opt-in, and a narrow managed boundary
   have to remain product behavior rather than marketing language.
@@ -348,54 +474,62 @@ tracks customer value, and dormant registered identities should remain free.
   stronger isolation, deletion, backup, incident-response, and compliance
   obligations than an OSS CLI.
 - **Operational capacity**: hosted products carry on-call, upgrade, migration,
-  and customer-support obligations that a small maintainer team does not
-  currently have. The first paid tier should remain deliberately narrow.
-- **Unproven unit economics**: supervisor execution, retention, and support can
-  erase margin if pricing follows raw activity without a value-aligned cap or
-  tier.
+  incident response, and customer-support obligations. FDE work adds delivery
+  staffing and partner-quality risk. The first paid scope should remain narrow.
+- **Unproven unit economics**: delivery labor, Supervisor execution, retention,
+  support, and long sales cycles can erase margin. Revenue quality must be
+  measured separately for license, delivery, and managed operations.
 
-## Proof Gates Before Significant SaaS Build-Out
+## Proof Gates Before Scaling Commercial Delivery Or SaaS
 
-Before taking authoritative customer state onto a managed service, LoopX
-should be able to show:
+Before scaling FDE headcount or taking authoritative customer state onto a
+managed service, LoopX should be able to show:
 
-1. several independent teams using the control plane recurrently across
-   multi-week goals;
-2. measured reductions in manual context reconstruction, invalid continuation,
-   recovery time, or review effort;
-3. design partners willing to pay for collaboration, retention, governance, or
-   managed recovery rather than for generic support alone;
-4. verified export, restore, deletion, tenancy, backup, and public/private
-   boundary behavior;
-5. a usage model showing that retention, supervisor work, and support can
-   sustain acceptable gross margin.
+1. multiple customers pay for bounded workflows with explicit outcome owners
+   and acceptance criteria;
+2. cycle time, quality, capacity, recovery, review, or compliance cost improves
+   against a recorded baseline;
+3. deployments use the same versioned Harness and supported extensions, and a
+   second deployment of the same pack requires materially less FDE effort;
+4. license, renewal, managed-operation, or expansion revenue remains after the
+   initial delivery rather than revenue tracking labor alone;
+5. independent teams use state, supervision, recovery, evidence, and handoff
+   recurrently across multi-week work;
+6. export, restore, deletion, tenancy, backup, and public/private boundary
+   behavior are verified before managed authority expands;
+7. delivery, retention, Supervisor work, support, sales cycle, and customer
+   concentration can sustain acceptable unit economics.
 
 These gates separate technical optionality from realized commercial value.
 
 ## Suggested Path
 
-Phase 0 — instrument the local product and validate the billable objects.
-Measure active agents and goals, event and evidence volume, recovery actions,
-review frequency, and operator attention without collecting private content by
-default.
+Phase 0 — instrument the local product and select two reference workflows.
+Record baselines, acceptance, active agents and goals, evidence volume,
+recovery, review effort, operator attention, and delivery effort without
+collecting private content by default.
 
-Phase 1 — opt-in observation relay. Add a `loopx cloud sync` path that pushes
-public-safe status projections to a hosted dashboard. Keep it free or narrowly
-metered for individuals with short retention.
+Phase 1 — package the Enterprise Agent Harness. Ship one supported distribution
+with private and BYOC profiles, runtime adapters, console, deployment and
+upgrade automation, backup and restore, diagnostics, and a paid discovery and
+acceptance template.
 
-Phase 2 — team and evidence tier. Add shared goal boards, approval routing,
-quota budgets, longer retention, replay, signed exports, and review-ready
-summaries. Validate recurring willingness to pay with design partners.
+Phase 2 — run a small number of paid design-partner deployments. Use bounded
+FDE engagements to reach production, measure outcomes, hand over operation,
+and record reusable versus customer-only work. Do not scale long free pilots.
 
-Phase 3 — Managed Semantic Control Plane, BYOC first. Operate durable state,
-supervisor scheduling, recovery, and governed replanning inside the customer's
-environment, with managed upgrades and support.
+Phase 3 — extract repeated work into domain packs and a Team Evidence And
+Governance Plane. Make the second deployment faster, enable partners, and add
+recurring license or managed-operation revenue around proven workflows.
 
-Phase 4 — multi-tenant control plane and domain marketplace, only after
-isolation, support load, and unit economics are proven.
+Phase 4 — operate the Managed Semantic Control Plane through BYOC or managed
+private deployments. Add multi-tenant Team Cloud for lower-friction and
+overseas customers only after isolation, support load, recurrence, and unit
+economics are proven.
 
 Each phase is independently shippable and creates evidence for the next. No
-phase requires betting the open-source project on the full hosted end state.
+phase requires betting the open-source project on the full hosted end state or
+turning the company into general-purpose systems integration.
 
 ## Evidence Boundary
 

--- a/docs/product/roadmaps/saas-opportunity-assessment.zh-CN.md
+++ b/docs/product/roadmaps/saas-opportunity-assessment.zh-CN.md
@@ -49,6 +49,67 @@ Managed 产品只有在通过以下全部四条时才值得建设：
 
 第四条最重要。无法改善长程工作的 dashboard 只是一个界面 feature，不是可持续的 SaaS 生意。
 
+## 商业对标：看价值捕获，不只看 Star
+
+截至 2026-08-15 的公开证据表明，这四个项目代表四种不同的价值捕获模式，并不是四家可直接横向比较的创业公司。GitHub Star 能证明分发和类别关注，不能证明收入、留存、毛利或企业付费意愿。
+
+| 项目 | 公开商业证据 | 价值捕获路径 | 当前判断 | 对 LoopX 的启示 |
+| --- | --- | --- | --- | --- |
+| Letta | 公司在 2024 年[完成 1000 万美元种子轮](https://www.prnewswire.com/news-releases/berkeley-ai-research-lab-spinout-letta-raises-10m-seed-financing-led-by-felicis-to-build-ai-with-memory-302257004.html)。当前 [API 方案](https://docs.letta.com/pricing)包含基础订阅、active agent、tool execution 与模型用量计费；team / enterprise 档增加共享、访问控制、SSO 和支持。[厂商案例](https://www.letta.com/case-studies/bilt/)称 Bilt 已运行超过 100 万个 Agent。 | 托管 stateful agent、执行、协作与企业控制 | Persistent agent state 已出现真实定价与生产信号；但没有公开审计 ARR，Bilt 数据来自厂商案例。 | Durable state 在被持续运行、并绑定生产 workload 后，可以成为计费 primitive。 |
+| Mastra | Mastra 于 2026 年 4 月[宣布 2200 万美元 A 轮、累计融资 3500 万美元](https://mastra.ai/blog/series-a)。其[定价](https://mastra.ai/pricing)包括 250 美元/月 team 档、观测/算力/memory/storage/retention 用量，以及按年收费的 self-hosted enterprise 方案。 | 开源框架 + 托管平台、运维与企业部署 | 这组对标中最强的独立平台商业信号。融资、客户案例与 packaging 有意义，但不等于已披露收入。 | 开源开发框架可以扩张到 Managed Operations，前提是付费层真正承担可靠性、留存、评测与交付。 |
+| AgentScope | AgentScope 是[阿里通义实验室 SysML 团队](https://github.com/agentscope-ai/agentscope/blob/main/pyproject.toml)维护的 Apache-2.0 项目，不是一家单独披露的创业公司。它可部署到阿里云体系；[AgentRun](https://www.alibabacloud.com/help/en/functioncompute/what-is-agentrun)销售 serverless runtime、sandbox、模型治理、观测和成本管理，并明确集成 AgentScope。 | 云消费、生态拉动与平台留存 | 在阿里云体系内可能有很高战略价值，但不存在有意义的独立 AgentScope 估值或收入单元。 | OSS 框架可以创造可观的平台价值，而直接经济回报主要被外围云平台捕获。 |
+| CAMEL / Eigent | [CAMEL-AI](https://www.camel-ai.org/about)建立多 Agent 研究与类别心智，关联产品 Eigent [自报上线不到三个月收入超过 25 万美元](https://www.eigent.ai/about)，并提供[年付折算 19.90 / 99.99 美元月费与 enterprise 部署](https://www.eigent.ai/pricing)；条款中还包含[商业生产许可与专业服务](https://www.eigent.ai/terms-of-use)。 | C 端/个人订阅、企业许可、私有化与服务 | 已有早期、具体的应用变现，但收入是公司自报的短窗口数据，不能证明稳定 recurring revenue。 | 研究与 OSS 热度可以通过有明确主张的应用转化，但它与基础设施的销售和毛利结构不同。 |
+
+由此可以得出三个结论。
+
+第一，商业价值并不按 Star 排名。Mastra 当前拥有最强的资本与平台 packaging 信号；Letta 拿出了最清楚的 stateful agent 生产案例；AgentScope 可能创造很大的云平台内嵌价值，却不必成为独立公司；CAMEL 则通过独立应用承接研究影响力。
+
+第二，反复出现的路径是“开源分发 + 稀缺付费面”：有人卖托管状态，有人卖观测与部署，有人拉动云消费，也有人销售垂域应用和私有化。开源并不妨碍收入，前提是付费产品消除真实的运行与组织负担，而不是把协议藏起来。
+
+第三，LoopX 的架构位置是前两种模式的上层组合：Letta 式 durable state + Mastra 式 managed operations，并把它泛化到异构 runtime。差异化产品不是一个功能更多的 Agent 框架，而是让 goal、authority、规划、监督、evidence、recovery 与 handoff 跨 Agent、跨 run 保持一致的语义控制面。这些对标验证了变现形态，但 LoopX 仍需要验证客户是否会为这一独立层持续付费。
+
+## 垂域数字员工与数字团队
+
+这个应用类别已经不再是假设，但也还没有成熟为“自治数字劳动力市场”。
+
+- BNY 在 [2025 年报](https://www.bny.com/content/dam/bnymellon/documents/pdf/investor-relations/annual-report-2025.pdf)中披露 160 个生产中的企业 AI 方案和 134 个“数字员工”，并将后者定义为与人类同事一起自主工作的 multi-agent system。这证明强监管企业已经可以把数字员工变成组织单元，而不只是 demo。
+- Microsoft 的 [2025 Work Trend Index](https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/microsoft/final/en-us/microsoft-product-and-services/ai/pdf/executive-summary-work-trend-index-annual-report.pdf)覆盖 31 个国家的 3.1 万名工作者：45% 的领导者把数字劳动力扩充团队容量视为近期重点，46% 称公司已用 Agent 自动化 workflow 或 process。这反映意愿与自报采用，不等于已验证的生产 ROI。
+- McKinsey [2025 全球调查](https://www.mckinsey.com/capabilities/quantumblack/our-insights/the-state-of-ai?lang=en)提供了必要的反面约束：23% 的受访者称公司已经在某处 scale agentic system，另有 39% 正在试验；但没有任何单一职能的 scale 比例超过 10%，企业级 EBIT 影响仍不普遍。缺口不在认知，而在生产化与 workflow 重构。
+- 一项覆盖 5179 名客服人员的实地研究发现，生成式 AI assistant 带来[平均 14% 的生产率提升](https://www.nber.org/papers/w31161)，对低经验员工提升更大。这验证了任务级经济价值，但研究对象是 assistant，不是自治数字员工。
+- AWS 在 2025 年将 [multi-agent collaboration 正式 GA](https://aws.amazon.com/blogs/machine-learning/amazon-bedrock-announces-general-availability-of-multi-agent-collaboration/)，并展示金融、零售、反欺诈、客服、医疗与农业中的 Supervisor 编排。这说明多 Agent 协作正在成为平台 primitive，但厂商案例不能证明所有 workflow 都需要多个 Agent。
+- Gartner 的[失败预测](https://www.gartner.com/en/newsroom/press-releases/2025-06-25-gartner-predicts-over-40-percent-of-agentic-ai-projects-will-be-canceled-by-end-of-2027)认为，到 2027 年底超过 40% 的 agentic 项目会因成本、价值不清或风险控制不足而取消；同一份判断又预测 2028 年 33% 的企业软件将包含 agentic 能力。市场快速增长与大量同质项目失败可以同时发生。
+
+### 产品单元是什么
+
+垂域数字员工不能只是“带职位名的 prompt”。它应当是一份 governed role contract，至少包含：
+
+- durable identity，以及一个明确的人类 outcome owner；
+- 有边界的 tool、data、authority、quota 与 escalation policy；
+- 明确的 goal、plan、acceptance criteria 与服务预期；
+- 可供事后 review 的 evidence、decision 与 action history；
+- run、模型、机器或 operator 变化后的 recovery 与 handoff 行为。
+
+数字团队则是多个这样的角色契约：共享 goal 与 evidence，但各自保留独立 authority；它进一步需要显式 claim / handoff、团队级 budget / acceptance，以及 Supervisor 的调度、恢复与 replan。Supervisor 只能协调已记录的 authority，不能成为隐藏的管理者。
+
+这一定义与 LoopX 的语义契约直接对应。Domain pack 可以包装领域工具、评测、review 和 escalation；开源 Kernel 保持 state 与 authority protocol 可迁移；付费 Managed Semantic Control Plane 负责让数字员工或数字团队持续在线、可恢复、可观测、可治理。
+
+### 应用前景与切入顺序
+
+下表是基于上述公开证据得出的战略判断，不是市场规模预测。
+
+| Workflow | 市场成熟度 | LoopX 适配度 | 付费逻辑 | 主要门槛 | 建议位置 |
+| --- | --- | --- | --- | --- | --- |
+| 客服与员工服务 | 高 | 中 | 任务量大，resolution、latency、deflection 与质量指标清楚 | 实时延迟、安全转人工、成熟平台竞争 | 作为长程 evidence、policy 与 recovery 层接入，不先做 contact-center runtime |
+| 软件工程、SRE 与 IT 运维 | 高 | 很高 | 工作跨 repo、incident、review、机器和多天周期，错误 continuation 代价高 | acceptance 可靠性、环境隔离、merge / 生产 authority | Team Cloud 与 Managed Control Plane 的第一批 design partner |
+| 科研、实验与实验室运营 | 中高 | 很高 | hypothesis、negative result、evidence lineage、quota 与重复实验天然需要 durable semantic state | 领域评测，以及对仪器、数据集或算力的连接 | 面向科研组和技术创业公司的首批场景，销售可复现、监督与恢复 |
+| 财务、采购、order-to-cash 等后台运营 | 中高 | 高 | 跨系统 workflow 有明确 cycle time、exception rate 与 audit cost | ERP 集成、权限、隐私和审批边界 | 通过 BYOC design partner，从有明确人类 gate 的窄 workflow 进入 |
+| 法律、医疗等强监管专业工作 | 中 | 长期高 | review 与合规成本高，evidence 和 authority 更值钱 | 责任、领域准确性、数据驻留与专业签字 | 先做 human-led 数字团队，以治理、review 和 evidence pack 进入，不让 Agent 自主做最终决定 |
+| 跨职能数字团队 | 早期 | 终局最高 | 多个专职 Agent 可以持续拥有一个 outcome，而不只完成孤立任务 | 跨角色 authority、冲突、共享 acceptance 与可问责 escalation | 单角色复用与恢复得到证明后的长期产品终局 |
+
+因此，近期销售话术应当是**为一个高价值 workflow 提供可治理的新增产能**，而不是“用 AI 替换一个部门”。初始合同可以组合 workspace / workflow 费用、active managed employee、evidence retention、Supervisor work 与 enterprise delivery；只有当结果可归因、可审计时，才适合增加 outcome-linked pricing。
+
+顺序同样重要。软件、SRE、科研与技术运营最接近 LoopX 当前社区，也最直接暴露控制面要解决的长程失败。后台与强监管 workflow 可能带来更高客单价，但应在 authority、evidence、deletion 与 recovery 得到证明后，通过 BYOC 和领域伙伴进入。数字团队是扩张路径，不是第一个 SKU。
+
 ## 产品阶梯
 
 下面不是四个独立 SaaS，而是一条走向 Managed Semantic Control Plane 的采用与扩张路径。
@@ -160,12 +221,11 @@ Phase 4 —— 完整多租户控制面与 domain marketplace。只在隔离、�
 
 每个阶段都可以独立交付，并为下一阶段产生证据；任何阶段都不需要让开源项目提前押注完整 hosted 终态。
 
-## 市场参照
+## 证据边界
 
-- [Letta pricing](https://www.letta.com/pricing) 展示了围绕 persistent agent state，按 active agent、执行、team 和 enterprise 能力计费的方式。
-- [Mastra pricing](https://mastra.ai/pricing) 展示了开源 Agent 开发平台如何按 usage、retention、team 和 enterprise 能力分层。
+本文刻意区分不同类型的公开证据：融资只能证明投资判断与 runway，不能证明留存或收入；公开价格只能证明存在变现面，不能证明付费客户数；厂商案例证明的是厂商与客户共同披露的部署，不是独立审计 ROI；企业调查证明关注和自报采用，不能证明客户已经需要 LoopX 独特的 semantic control-plane contract。
 
-这些参照说明客户能够理解托管状态、运维和治理的付费价值，但不能直接证明 LoopX 独特的 semantic control-plane contract 已经存在市场需求。
+现有证据足以支持 design partner 与有节制的商业假设，但不足以跳过 LoopX 自身对复用频率、业务结果、付费意愿和单位经济性的验证。
 
 ## 与现有文档的关系
 

--- a/docs/product/roadmaps/saas-opportunity-assessment.zh-CN.md
+++ b/docs/product/roadmaps/saas-opportunity-assessment.zh-CN.md
@@ -1,30 +1,32 @@
-# SaaS 机会评估
+# 商业化与 SaaS 机会评估
 
-状态：评估目标。本文是战略评估，不是建设承诺。它讨论 LoopX 如何支撑托管、订阅制产品，同时不削弱 LoopX 赖以成立的 local-first、provider-neutral 控制面契约。
+状态：评估目标。本文是战略评估，不是建设承诺。它讨论 LoopX 如何通过 Enterprise Harness、产品化交付、BYOC、托管运维或 SaaS，把控制面技术变成可重复的客户价值，同时不削弱 LoopX 赖以成立的 local-first、provider-neutral 契约。
 
 ## 商业判断
 
 LoopX 最连贯的商业位置是：
 
-> 开源并保持 local-first 的长程 Agent 语义状态契约；收费提供稳定运行这些契约的 Managed Semantic Control Plane。
+> 开源并保持 local-first 的长程 Agent 语义状态契约；把它们包装成成熟的 Enterprise Agent Harness；通过产品化 FDE 交付把有边界的垂域 workflow 推到生产；收费提供私有部署、软件许可、托管运维与支持；再把跨客户反复出现的运行面扩张为 Managed Semantic Control Plane 与 SaaS。
 
-开源层提供可迁移的 goal、authority、todo、evidence、acceptance、quota、handoff、recovery 和 replan 状态。付费层让这些状态在团队环境中持续可用：可协作、可观测、可恢复、可治理，并有人为其稳定性负责。
+开源层提供可迁移的 goal、authority、todo、evidence、acceptance、quota、handoff、recovery 和 replan 状态。付费层把这些契约包装成可部署产品，并让它们在团队环境中持续可用：可协作、可观测、可恢复、可治理，并有人为其稳定性负责。
+
+Managed Semantic Control Plane 仍然是长期商业复利的核心，但不必成为第一个 SKU。客户最初可能购买的是一个真正工作的数字员工或数字团队、私有部署、系统集成、验收证据，以及把方案推到生产的人。每次交付都必须运行在同一套可复用 Harness 上，而不是形成客户专属分叉。重复价值与持续运维需求出现后，云端 recurring revenue 才成为自然扩张。
 
 这个位置接近两种已经公开商业化的相邻模式。Letta 将持久、有状态的 Agent 包装成托管服务，按 active agent 与执行量计费；Mastra 在开源 Agent 框架之上销售托管运行、留存、团队协作和企业治理。LoopX 不需要复制二者的产品边界。它的差异化位置是跨异构 Agent runtime 的 provider-neutral 语义控制层：完备的状态管理、规划与监督，基于证据的恢复，以及能够跨 run、跨 Agent 继承的人类 authority。
 
-这是产品定位假设，不是收入结论。它仍然需要持续生产使用和付费意愿验证。
+这是产品定位假设，不是收入结论。它仍然需要重复生产使用、交付复用和付费意愿验证。
 
 ## 核心张力
 
-LoopX 的价值主张是 local-first 控制面：operator 可以拥有、检查、导出和恢复 durable state。一个天真的 SaaS 做法——“我们替你在服务器上托管 Agent 状态”——会削弱让产品可信的那个属性。
+LoopX 的价值主张是 local-first 控制面：operator 可以拥有、检查、导出和恢复 durable state。一个天真的 SaaS 做法——“我们替你在服务器上托管 Agent 状态”——会削弱让产品可信的那个属性；一个天真的交付做法——“客户要什么就一直定制到验收”——则会把项目变成低复用的系统集成生意。
 
-因此，SaaS 问题不是“LoopX 能否被托管”，而是：
+因此，商业化问题是：
 
-> 哪些控制面职责由专门服务持续运行后更有价值；哪些 authority 与数据边界必须按设计保持可迁移？
+> 哪些客户结果需要直接交付；哪些控制面职责由专门服务持续运行后更有价值；哪些 authority、数据与产品边界必须按设计保持可迁移、可复用？
 
-协作、跨设备访问、长期留存、共享治理、托管恢复和运维支持适合 hosted 或 BYOC 服务。语义状态契约、导出路径、本地执行选项，以及客户对私有工作区内容的 authority 应当保持开放。
+Discovery、集成、评测与上线可能需要 FDE 进入客户 workflow。协作、长期留存、共享治理、托管恢复和运维支持适合私有、BYOC 或 hosted 服务。语义状态契约、导出路径、本地执行选项，以及客户对私有工作区内容的 authority 应当保持开放。
 
-付费产品卖的是运行、可靠性和组织控制，不能把用户自己的状态格式锁住后再卖回访问权。
+付费产品卖的是生产就绪的 Harness、被交付的结果、运行、可靠性和组织控制；不能把用户自己的状态格式锁住后再卖回访问权，也不能把无限工程师工时伪装成产品。
 
 ## 开源层与付费层边界
 
@@ -34,20 +36,22 @@ LoopX 的价值主张是 local-first 控制面：operator 可以拥有、检查�
 | 执行 | Codex、Claude Code、Cursor、shell agent 与自定义 worker 的 provider-neutral adapter | Agent fleet 注册、health、策略约束的 wake、Supervisor 调度、恢复和 operator 路由 |
 | 观测 | 本地 projection、CLI status、导出与可自托管 dashboard surface | 共享 workspace、长期留存、跨 Agent timeline、评测、回放、告警和 review queue |
 | 治理 | 可检查的本地 authority、boundary 与 approval contract | 多租户隔离、RBAC、SSO、审计、配额、数据驻留、签名导出和策略管理 |
-| 交付 | 文档与可用的 self-host 路径 | BYOC 或 managed deployment、SLA、迁移、集成、incident response 和支持 |
+| 交付 | 文档、pack SDK、参考 workflow 与可用的 self-host 路径 | Enterprise Harness、产品化 FDE 部署、BYOC 或 managed operation、SLA、迁移、集成、incident response 和支持 |
 
 可迁移性是产品契约的一部分。客户应当能够导出语义状态，保留 durable identity 与 evidence lineage，并回到本地或 self-hosted 控制面，而不需要从私有日志中重新推断工作的含义。
 
 ## 可行性测试
 
-Managed 产品只有在通过以下全部四条时才值得建设：
+商业产品只有在通过以下全部六条时才值得规模化：
 
-1. **持续使用**：operator 与 Agent team 在一周工作过程中持续使用，而不是装一次就结束。
-2. **托管优势**：协作、可用性、恢复、留存或治理让托管版本显著优于单机文件。
-3. **自然扩张**：收入随 workspace、active managed agent、留存、Supervisor work 或企业控制扩张，而不是依赖一次性 feature。
-4. **控制面效果**：客户可以测量人工协调减少、恢复加快、非法 continuation 下降，或 review 与 audit 成本下降。
+1. **结果证明**：一个有边界的 workflow 达到客户验收，并在周期、质量、产能、恢复或合规成本上有可测改善。
+2. **持续使用**：operator 与 Agent team 在一周工作过程中持续使用，而不是装一次就结束。
+3. **托管优势**：集成、协作、可用性、恢复、留存或治理让产品显著优于单机脚本与文件。
+4. **交付复用**：客户工作沉淀为 adapter、pack、eval 或核心改进，降低下一次部署成本，而不是形成永久客户分叉。
+5. **自然扩张**：收入随授权环境、workspace、active managed agent、留存、Supervisor work 或企业控制扩张，而不只随工程师天数增长。
+6. **控制面效果**：客户可以测量人工协调减少、恢复加快、非法 continuation 下降，或 review 与 audit 成本下降。
 
-第四条最重要。无法改善长程工作的 dashboard 只是一个界面 feature，不是可持续的 SaaS 生意。
+结果证明与交付复用应当早于 SaaS 形态。无法改善长程工作的 dashboard 只是界面 feature；没有产生可复用资产的成功部署只是服务项目。两者都还不是耐久的软件生意。
 
 ## 商业对标：看价值捕获，不只看 Star
 
@@ -67,6 +71,57 @@ Managed 产品只有在通过以下全部四条时才值得建设：
 第二，反复出现的路径是“开源分发 + 稀缺付费面”：有人卖托管状态，有人卖观测与部署，有人拉动云消费，也有人销售垂域应用和私有化。开源并不妨碍收入，前提是付费产品消除真实的运行与组织负担，而不是把协议藏起来。
 
 第三，LoopX 的架构位置是前两种模式的上层组合：Letta 式 durable state + Mastra 式 managed operations，并把它泛化到异构 runtime。差异化产品不是一个功能更多的 Agent 框架，而是让 goal、authority、规划、监督、evidence、recovery 与 handoff 跨 Agent、跨 run 保持一致的语义控制面。这些对标验证了变现形态，但 LoopX 仍需要验证客户是否会为这一独立层持续付费。
+
+## 中国市场：先产品化交付，再验证纯 SaaS
+
+“SaaS 在国内难卖”太粗，不足以直接指导战略。中国信通院的[《企业级 SaaS 市场发展研究报告（2024 年）》](https://www.caict.ac.cn/kxyj/qwfb/ztbg/202408/P020240815374016912879.pdf)估算，2023 年国内 SaaS 市场规模为 581 亿元，同比增长 23.1%。市场是真实增长的；但同一报告也指出，大客户推动厂商增加私有化、混合部署和定制开发，订阅制采用仍不均衡，项目费、咨询、培训、硬件等收入并存。
+
+报告同时点出了反面：重定制会推高交付成本、拖慢标准产品迭代，并让研发投入无法跨客户摊销。因此 LoopX 不该选择两个极端：
+
+- 不等一个低接触、横向 SaaS dashboard 自动创造仍处在早期的类别需求；
+- 不成为“恰好使用 LoopX”的无限定制项目公司；
+- 用直接交付发现并证明高价值 workflow，同时以统一版本 Harness、扩展边界和 evidence contract，把客户工作强制沉淀成可复用产品资产。
+
+不同客户应当使用不同的商业动作：
+
+| 客户 | 首个产品 | 交付方式 | 经济逻辑 |
+| --- | --- | --- | --- |
+| AI-native 创业公司或技术团队 | Enterprise Harness 许可与支持；可选 Team Cloud | 自助接入或短期 enablement | 客户能自行集成 runtime，重视速度、可迁移和多 Agent 连续性；低交付负担可以形成软件 recurring revenue |
+| 科研组或实验室 | Community、赞助支持或共享科研 Harness | 模板与 enablement；只有有经费的机构 workflow 才做 FDE | 可复现、实验监督与恢复很适合 LoopX，但多数科研组承受不了企业销售和定制成本 |
+| 中型企业 | 付费 discovery + 一次有边界的 FDE 上线，之后转年度私有/BYOC 许可 | 明确 outcome、验收、集成与交接 | 客户愿意为 workflow 改造付费，但会先要求直接价值，而不是购买抽象平台 |
+| 大型或强监管企业 | Enterprise Harness、FDE、托管运维、治理与 SLA | 私有/BYOC，包含安全、审计和采购工作 | 高客单价可以覆盖集成与控制要求，但销售周期和服务负担明显更高 |
+| 海外开发者团队 | Team Cloud 或 Managed Control Plane | 产品试用 + 远程 solution engineering | 对公有云和软件订阅的接受度更高，纯 SaaS 路径更成立 |
+
+这是一种先后顺序，不是放弃 recurring revenue。国内的第一收入形态更可能是“软件许可 + 有边界交付 + 年度托管运维”；SaaS 更适合低摩擦团队、海外客户，以及多次交付后被证明共性的运行面。
+
+### 成熟 Harness 是第一个付费产品
+
+成熟 Agent harness 的公开实践说明，客户购买的是一套完整可运行的产品，而不是协议图。OpenAI 称 Codex 已有超过 200 万周活开发者，并通过[按用量计费](https://openai.com/index/codex-flexible-pricing-for-teams/)服务团队；Anthropic 为 Claude Code 打包了[统一账单、支出控制、用量分析、tool / MCP 策略和 Compliance API](https://www.anthropic.com/news/claude-code-on-team-and-enterprise)，也[支持通过现有 Bedrock 或 Vertex AI 基础设施做企业部署](https://docs.anthropic.com/en/docs/claude-code/getting-started)。这些数据不证明 LoopX 已经有需求，但证明了企业对 harness 的完整度预期：安装、执行、策略、观测、管理与支持必须组成一个可运维产品。
+
+LoopX 的第一个付费产品因此应当是 **LoopX Enterprise Agent Harness**，而不是一组 schema，也不是另一个模型或 IDE。它应当包含：
+
+- 有版本的 Kernel 与 state service，支持 local、private 与 BYOC profile；
+- Codex、Claude Code、Cursor、shell agent 与客户 worker 的受支持 adapter；
+- Supervisor 调度、恢复、handoff、quota 与 acceptance；
+- 面向 goal、evidence、review、replay 与 fleet health 的本地或私有 console；
+- 部署自动化、升级、备份恢复、默认 policy 与诊断支持包；
+- 承载 tool、eval、role contract 与客户系统集成的 domain-pack 边界，不分叉 Kernel。
+
+客户购买的是一套能把一个 workflow 推到验收的系统。Semantic Control Plane 是其中的产品脊柱，而不是留给客户自行拼装的基础设施抽象。
+
+### FDE 是产品发现与生产化机制
+
+FDE 的价值，是补齐成熟 Harness 与混乱生产 workflow 之间的最后一公里。OpenAI 当前的 [FDE 岗位](https://openai.com/careers/forward-deployed-engineer-%28fde%29-sf-san-francisco/)覆盖 discovery、技术定界、系统设计、开发、上线、workflow 效果衡量，以及把成功模式沉淀为工具、playbook 与可复用 building block。Palantir 的 [2025 Form 10-K](https://www.sec.gov/Archives/edgar/data/1321655/000132165526000011/pltr-20251231.htm)披露 45 亿美元收入与 954 家客户，说明复杂部署和持续扩张可以支撑大型软件生意；同一文件也把高安装成本、长销售周期、昂贵 pilot、培训与持续服务列为明确风险。因此 FDE 必须是产品反馈环，而不是按人天出售的 staff augmentation。
+
+一次 LoopX FDE 交付应当有五个有边界的产物：
+
+1. workflow baseline、明确的 outcome owner、authority map 与付费范围；
+2. 基于当前 Enterprise Harness 和受支持扩展点的生产路径；
+3. eval set、验收标准与前后效果证据；
+4. 部署、operator 培训、runbook、rollback 与交接；
+5. 至少一个回流产品的 pack、adapter、eval、playbook 或核心改进。
+
+规则必须严格：不做无限期免费 PoC，不做客户专属 Kernel 分叉，不在没有客户 authority 时执行生产写入，也不在结果归因不可审计时承诺 outcome pricing。持续跟踪到验收的工程师月数、可复用与客户专属工作的比例、同一 pack 第二次部署耗时、软件与托管收入相对人力收入的占比，以及续费与扩张。如果这些指标不随交付改善，FDE 不是在形成壁垒，而是在掩盖服务生意。
 
 ## 垂域数字员工与数字团队
 
@@ -112,114 +167,103 @@ Managed 产品只有在通过以下全部四条时才值得建设：
 
 ## 产品阶梯
 
-下面不是四个独立 SaaS，而是一条走向 Managed Semantic Control Plane 的采用与扩张路径。
+下面是产品与收入阶梯，不是五个独立 SaaS。每一步都必须留下可复用产品，并让下一步更容易出售。
 
-### 1. AgentOps 观测与治理云
+### 1. Enterprise Agent Harness
 
-最强的进入楔子，是面向 goal、authority、evidence、recovery、quota 的“Agent loop 版 Datadog / Langfuse”，而不只看 LLM trace。
+第一个可销售产品，是一套支持 local、private 与 BYOC profile 的统一版本 LoopX 发行物。它打包 runtime adapter、语义状态、Supervisor、恢复、验收、评测、部署升级、备份诊断与 operator console。验收单位是一个有边界 workflow 到达生产，而不是软件成功安装。
 
-控制面已经产出原材料：goal 状态、run history、evidence 事件、quota 决策、handoff 记录和 public-safe projection。托管观测层把它们变成团队共享面：
+### 2. FDE 驱动的 Design Partner 交付
 
-- 跨成员 goal board：谁在跑哪些 Agent，为什么运行；
-- quota 与预算视图：把花费映射到 goal，而不只映射到 API 调用；
-- 通过 Lark 或等价渠道路由的 gate 与审批队列；
-- 在机器损坏或 operator 切换后仍然存在的 recovery 与 handoff timeline；
-- 解释发生了什么、continuation 是否合法的 evidence 与 eval 下钻。
+付费 discovery 与有边界的生产交付，把 Harness 接入一个高价值客户 workflow。交付包括集成、评测、验收证据、运行手册、rollback 与交接。FDE 不是独立咨询 SKU：每个项目都必须运行在受支持 Harness 上，并沉淀 pack、adapter、eval、playbook 或核心改进。
 
-这个楔子以读为主，可以消费 public status data contract，而不持有私有 workspace 内容。它先证明日常使用和团队协作，再让 LoopX 承担生产控制状态的 authority。
+### 3. Team Evidence And Governance Plane
 
-### 2. Evidence 与 Review 服务
+当一个 workflow 开始反复运行后，LoopX 可以销售其组织控制面：共享 goal board、不可变 evidence 留存、回放、review-ready handoff、审批、quota、评测历史、RBAC、SSO、audit 与 policy administration。它应先采用 private、BYOC 或 read-mostly 形态，通过明确 projection 消费数据，而不是默认读取私有 workspace。
 
-下一层增加不可变 evidence 留存、回放、review-ready handoff 报告、评测历史，以及周期性的“Agent 做了什么、为什么”说明。
+### 4. Managed Semantic Control Plane
 
-观测卖给今天就在运行 Agent 的团队；evidence 与 review 卖给未来需要解释 Agent 决策的组织。当 Agent 进入生产工作流，“给我看 evidence”会成为准入要求。
+长期终局是一个持续运行的控制面：本地或第三方 runtime 执行 bounded work，Managed Semantic Control Plane 维护完备且一致的 semantic execution state。它负责权威且可识别冲突的状态、Supervisor 调度、stalled-loop 检测、恢复、handoff、governed replan，以及跨 runtime 的 identity、claim、quota、evidence 与 acceptance 连续性。
 
-事件溯源状态模型以及现有 evidence、handoff projection 使这层无需新增 Agent runtime 即可落地。它的信任门槛更高：留存 evidence 必须具备明确 lineage、append-only 语义、删除策略，以及签名或其他可验证导出。
+Supervisor 不是隐藏的自治管理者，托管不会自动赋予它人类 authority。BYOC 与 managed private 是风险更低的第一形态；完整多租户托管要等隔离、删除、备份、支持和 on-call 经济性得到证明。
 
-### 3. Managed Semantic Control Plane（优先 BYOC）
+### 5. Domain Packs 与伙伴生态
 
-产品终局不只是观测，而是一个持续运行的控制面：本地或第三方 runtime 执行 bounded work，Managed Semantic Control Plane 维护完备且一致的 semantic execution state。
-
-基础文档 `server-client-product-shape.md` 已经点名中期形态：服务器持有 durable goal state、event history 和 governed planning lane。同一套架构可以支撑：
-
-- 对权威状态进行幂等、可识别冲突的写入；
-- Supervisor 调度、stalled-loop 检测、恢复、handoff 和 replan；
-- 从 advisory proposal 到 executable work 的 policy-controlled promotion；
-- 跨 runtime 的 identity、claim、quota、evidence 与 acceptance 连续性；
-- operator 对每一次 authority 消耗 transition 的可见控制。
-
-Supervisor 不是隐藏的自治管理者。它可以在已记录策略内调度、观察、恢复和提出 proposal，但不会因为被托管就自动取得人类 authority。
-
-更低风险的企业入口是 BYOC：控制面运行在客户自己的云账号里，LoopX 销售 console、managed upgrade、治理、恢复运维和支持。完整多租户托管应当在隔离、删除、备份与 on-call 契约得到证明后再进入。
-
-### 4. Domain Packs 与 Marketplace 收入
-
-Domain capability packs（`docs/product/domain-capability-packs.md`）是扩张层，不是核心生意。它可以增加有领域倾向的评测、review 或运维 workflow，同时保持 Kernel 通用。
-
-当 team tier 或 managed control plane 已经存在后，pack 可以产生 marketplace 或企业集成收入。它不应当领先 SaaS 战略，商业包装也不能把领域 authority 搬进通用 Kernel。
+Domain capability packs（`docs/product/domain-capability-packs.md`）包装 tool、role contract、eval、review rule 与集成，同时保持 Kernel 通用。LoopX 或认证伙伴可以交付它们。Marketplace 是更晚的分发与收入面，不是第一门生意；领域 authority 仍然不能进入通用 Kernel。
 
 ## 计费单位与产品分层
 
-主要计费单位应当跟随 managed control-plane value，而不是转售模型 token。
+计费应当跟随被交付和被托管的价值，而不是转售模型 token 或无限工程师天数。
 
 | 价值面 | 候选计费单位 | 扩张逻辑 |
 | --- | --- | --- |
+| 付费 discovery 与部署 | 固定范围、milestone 与验收 | 客户为一个明确 workflow 到达生产付费，而不是为无限期 PoC 付费 |
+| Harness 许可 | 年度 environment / workspace 许可 + maintenance | FDE 离场后产品仍能独立运行，并跨 workflow 与团队扩张 |
+| FDE 生产化 | 有边界的集成与部署费 | 为最后一公里提供资金，同时明确 scope、交接与复用产物 |
 | 团队控制面 | workspace + collaborator seat | 更多团队与 operator 共享同一份 governed state |
 | Agent 连续性 | 月 active managed agent 或 active governed goal | 更多长程 worker 依赖 identity、state、quota 与 recovery |
 | Evidence 运维 | retained event/evidence volume + retention window | 更长周期或强监管 workflow 需要更持久的历史 |
 | Managed supervision | 策略约束的 wake、recovery、replay 或 eval execution | 客户为持续运行的 continuation 付费，而不是为原始模型调用付费 |
-| 企业交付 | deployment environment + 治理与支持档位 | BYOC、SSO、RBAC、audit、residency、SLA 与迁移形成组织价值 |
+| 托管运维 | deployment environment + 治理与支持档位 | BYOC、SSO、RBAC、audit、residency、SLA、迁移和 incident response 形成组织价值 |
 
 一个可行的产品阶梯是：
 
 - **Community**：local-first Kernel、protocol、CLI、export 和可自托管 projection；
-- **Team Cloud**：共享 workspace、中短期留存、审批、告警和协作 review；
-- **Managed Control Plane**：durable semantic state、Supervisor 调度、恢复、回放、评测和更长留存；
-- **Enterprise / BYOC**：私有部署、治理、审计、数据驻留、迁移、SLA 和专属支持。
+- **Enterprise Harness**：受支持的私有发行物、runtime adapter、console、部署自动化、升级、备份、诊断与年度维护；
+- **Design Partner Deployment**：带 outcome、验收、复用和交接门槛的付费 FDE；
+- **Managed / BYOC**：durable semantic state、Supervisor 运维、恢复、治理、审计、数据驻留、迁移、SLA 与支持；
+- **Team Cloud**：在多租户经济性得到证明后，面向低摩擦或海外团队提供共享 workspace、留存、审批、告警和 review。
 
-这是 packaging model，不是公开价格表。定价前需要先获得 active agent、event volume、retention、Supervisor execution 和支持成本的真实分布。Agent 与其 goal 不能作为同一活动被重复计费；应当用 cohort 数据选择更贴近客户价值的主单位，未活跃的注册 identity 保持免费。
+这是 packaging model，不是公开价格表。定价前需要先获得 active agent、event volume、retention、Supervisor execution、交付工作量和支持成本的真实分布。合同应当区分软件许可、有边界交付和 recurring managed operation。FDE 离场后 Harness 必须仍有独立价值；Agent 与其 goal 不能作为同一活动被重复计费。
 
-## 什么不该做成 SaaS
+## 什么不该成为生意
 
 - **封闭的语义状态格式**：goal、evidence、authority 和 handoff 必须保持可检查、可导出。产品粘性应来自运行质量，而不是状态绑架。
 - **把通用执行托管当核心产品**：LoopX 可以编排外部 runtime，也可以运行 bounded Supervisor work；但转售模型 token 与 sandbox 会让项目在算力毛利上竞争，并模糊“控制面不拥有 domain 行为”的边界。
 - **把托管 CLI 文件当产品**：没人会为把本地文件搬到别人的磁盘付费。Managed 层必须增加协作、可靠性、恢复或治理价值。
+- **客户专属 Kernel 分叉或无限 FDE 驻场**：客户差异必须进入受支持扩展点和有边界交付。永久分叉与工程师天数依赖会摧毁复用。
+- **无限期免费 PoC**：discovery 可以短，但生产工作必须有 owner、付费范围、验收标准和交接计划。
 - **默认获得云端 authority**：托管基础设施不会自动授予读取私有 workspace、通过 gate、发布或执行生产写入的权限。
+- **替代部门或不可审计的结果承诺**：销售的是一个有边界 workflow 的 governed capacity。Outcome-linked pricing 必须建立在可测 baseline 与可审计归因上。
 
 ## 诚实的约束
 
-- **采用与证据缺口**：公开长程 demo 能证明技术可行性，不能证明团队的 recurring demand。SaaS 需要外部生产 workload 对留存、恢复和协作的持续需求。
-- **冷启动**：观测云需要足够多运行 LoopX loop 的团队才有东西可观测。免费 CLI 可以扩大基数，但 hosted tier 达成自给自足可能需要很长时间。
+- **采用与证据缺口**：公开长程 demo 能证明技术可行性，不能证明 recurring demand 或客户结果。外部生产 workload 必须同时验证二者。
+- **国内采购与回款**：私有部署、安全评估、集成、采购与付款周期，可能让收入比公有云订阅更慢、更难复用。
+- **FDE 与服务陷阱**：直接交付可以创建类别，也会消耗创始人注意力、造成客户集中，并在复用和 recurring 软件收入不改善时掩盖弱产品需求。
+- **云端冷启动**：共享观测或控制面需要足够多反复运行的团队与 workflow。不能只为造出 SaaS 形态而建设。
 - **品牌张力**：local-first 与 SaaS 可能方向相反。可迁移、self-host、明确 opt-in 和收窄的 managed boundary 必须是产品行为，不能只停留在营销表述。
 - **信任与安全面**：托管 evidence 与 authority state，会带来比 OSS CLI 更强的隔离、删除、备份、incident response 和合规责任。
-- **运营能力**：托管产品包含 on-call、升级、迁移和客户支持义务，当前小型维护团队并不具备完整能力。第一个付费档应当刻意收窄。
-- **单位经济性未验证**：如果计费只跟随原始活动量，Supervisor execution、留存和支持可能吞掉毛利，需要与价值对齐的分档或上限。
+- **运营能力**：托管产品包含 on-call、升级、迁移、incident response 和客户支持；FDE 还增加交付人员与伙伴质量风险。第一个付费范围应当刻意收窄。
+- **单位经济性未验证**：交付人力、Supervisor execution、留存、支持和长销售周期都可能吞掉毛利。软件许可、交付与托管运维的收入质量必须分开衡量。
 
-## 大规模建设前的证据门槛
+## 规模化商业交付或 SaaS 前的证据门槛
 
-在 Managed 服务接管客户权威状态之前，LoopX 至少应当证明：
+在扩大 FDE 团队或让 Managed 服务接管客户权威状态之前，LoopX 至少应当证明：
 
-1. 多个独立团队持续在数周级 goal 上使用控制面；
-2. 人工上下文重建、非法 continuation、恢复时间或 review 工作量出现可测下降；
-3. design partner 愿意为协作、留存、治理或 managed recovery 付费，而不只是购买通用支持；
-4. export、restore、deletion、tenancy、backup 与 public/private boundary 行为得到验证；
-5. 使用模型能够证明 retention、Supervisor work 与支持成本可以维持可接受毛利。
+1. 多个客户为有明确 outcome owner 与验收标准的有边界 workflow 付费；
+2. 周期、质量、产能、恢复、review 或合规成本相对 baseline 有可测改善；
+3. 部署使用同一版本 Harness 与受支持扩展点，同一 pack 第二次部署明显减少 FDE 工作量；
+4. 初次交付后仍然存在许可、续费、托管运维或扩张收入，而不是收入只跟随人力；
+5. 独立团队在数周级工作中反复使用 state、supervision、recovery、evidence 与 handoff；
+6. Managed authority 扩张前，export、restore、deletion、tenancy、backup 与 public/private boundary 行为得到验证；
+7. 交付、留存、Supervisor work、支持、销售周期与客户集中度可以维持可接受的单位经济性。
 
 这些门槛将技术期权与已经兑现的商业价值分开。
 
 ## 建议路径
 
-Phase 0 —— 为本地产品补充度量，验证可计费对象。在默认不收集私有内容的前提下，统计 active agent / goal、event / evidence volume、recovery action、review frequency 和 operator attention。
+Phase 0 —— 为本地产品补充度量，并选择两个参考 workflow。在默认不收集私有内容的前提下，记录 baseline、验收、active agent / goal、event / evidence volume、recovery、review、operator attention 与交付工作量。
 
-Phase 1 —— opt-in 观测中继。增加 `loopx cloud sync` 路径，把 public-safe status projection 推到托管 dashboard。个人档免费或窄计费，保持短留存。
+Phase 1 —— 打包 Enterprise Agent Harness。交付统一受支持发行物、private / BYOC profile、runtime adapter、console、部署升级、备份恢复、诊断，以及付费 discovery 与验收模板。
 
-Phase 2 —— team 与 evidence tier。增加共享 goal board、审批路由、quota budget、更长留存、回放、签名导出和 review-ready summary，并用 design partner 验证 recurring willingness to pay。
+Phase 2 —— 只做少量付费 design partner。用有边界 FDE 推到生产、衡量结果、完成交接，并记录可复用与客户专属工作；不规模化长期免费 pilot。
 
-Phase 3 —— Managed Semantic Control Plane，优先 BYOC。在客户环境中运行 durable state、Supervisor 调度、恢复和 governed replan，同时提供 managed upgrade 与支持。
+Phase 3 —— 把重复工作抽成 domain pack 与 Team Evidence And Governance Plane。让第二次部署更快、让伙伴可交付，并围绕已证明的 workflow 增加 recurring license 或 managed-operation 收入。
 
-Phase 4 —— 完整多租户控制面与 domain marketplace。只在隔离、支持负担和单位经济性得到证明后进入。
+Phase 4 —— 通过 BYOC 或 managed private 运行 Managed Semantic Control Plane。只有隔离、支持负担、复用频率和单位经济性得到证明后，才为低摩擦和海外客户增加多租户 Team Cloud。
 
-每个阶段都可以独立交付，并为下一阶段产生证据；任何阶段都不需要让开源项目提前押注完整 hosted 终态。
+每个阶段都可以独立交付，并为下一阶段产生证据；任何阶段都不需要让开源项目提前押注完整 hosted 终态，也不需要把公司变成通用系统集成商。
 
 ## 证据边界
 


### PR DESCRIPTION
## Summary

- compare Letta, Mastra, AgentScope, and CAMEL/Eigent by public financing, pricing, production evidence, and value-capture model instead of GitHub stars
- assess vertical digital employees and teams as governed role contracts, then rank the first application wedges for LoopX
- replace a SaaS-first sequence with a China-aware commercial ladder: Enterprise Agent Harness, bounded FDE design-partner delivery, team evidence and governance, Managed Semantic Control Plane, and domain packs
- segment startup, research, mid-market, regulated-enterprise, and overseas motions; define pricing surfaces and safeguards against custom-project and staff-augmentation traps
- preserve explicit evidence boundaries and keep the English and Chinese strategy notes aligned

## Validation

- git diff --check and staged diff check
- python3 examples/docs-governance-smoke.py
- loopx check on both strategy notes (public boundary clean; two unrelated existing active-state warnings)
- candidate-file secret and private-marker scan
- official-source readback for CAICT, OpenAI, Anthropic, SEC, BNY, Microsoft, McKinsey, NBER, AWS, and Gartner; several bot-protected pages reject curl but were independently readable through web retrieval

## Scope and risk

- public documentation only; no runtime, protocol, published price, launch commitment, or first-screen change
- no local/private state, credentials, raw logs, internal links, or unrelated worktree artifacts included
- financing, company-reported cases, survey adoption, and strategic inference remain explicitly separated from audited revenue and LoopX-specific demand
- the recommendation does not assume pure SaaS or pure services: recurring software value must survive after FDE delivery and each deployment must improve reuse