### PR TITLE
feat(content-ops): add layout template library

### DIFF
--- a/docs/capabilities/content-ops/README.md
+++ b/docs/capabilities/content-ops/README.md
@@ -20,6 +20,13 @@ the order of the `--item-json` inputs; windows live in item approval and deliver
 intent records. See
 [`content_ops_queue_projection_v0`](../../reference/protocols/content-ops-queue-v0.md).
 
+The built-in layout template library moves reusable presentation rules out of
+writing skills. `template-list` and `template-show` expose four generic visual
+systems; `layout-plan` records typed page roles before
+rendering; `layout-check` rejects sparse, overcrowded, overflowing, colliding,
+or role-incomplete page sets. See
+[`content_ops_layout_plan_v0`](../../reference/protocols/content-ops-layout-v0.md).
+
 ## Implemented Surface
 
 | Layer | Current path |
@@ -28,6 +35,7 @@ intent records. See
 | CLI entry | `loopx content-ops ...` |
 | Protocol docs | `docs/reference/protocols/content-ops-surface-v0.md` |
 | Queue projection | `docs/reference/protocols/content-ops-queue-v0.md` |
+| Layout contract | `docs/reference/protocols/content-ops-layout-v0.md` |
 | Smoke | `examples/content-ops-*-smoke.py` |
 
 ## Safe Defaults
@@ -40,6 +48,7 @@ intent records. See
 - Revising approved content invalidates the approval and any delivery intent.
 - Provider delivery and readback receipts must match the approved revision and
   digest; the lifecycle helper performs no external write.
+- Layout acceptance never implies content approval or publishing authority.
 
 ## Connector-First Ops Pattern
 

--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -76,6 +76,7 @@ scanning a chronological list.
 - [`x_public_channel_ops_v0`](x-public-channel-ops-v0.md): X public channel operations v0
 - [`content_ops_item_v0`](content-ops-item-lifecycle-v0.md): provider-neutral content item lifecycle v0
 - [`content_ops_queue_projection_v0`](content-ops-queue-v0.md): read-only managed content queue projection v0
+- [`content_ops_layout_plan_v0`](content-ops-layout-v0.md): typed content layout plan, template library, and acceptance check v0
 
 ## Quality, Review, And Release
 

--- a/docs/reference/protocols/content-ops-layout-v0.md
+++ b/docs/reference/protocols/content-ops-layout-v0.md
@@ -1,0 +1,109 @@
+# Content-Ops Layout v0
+
+`content_ops_layout_*_v0` makes content presentation a reviewable LoopX
+contract. It separates three owners:
+
+- LoopX core owns built-in templates, typed page roles, deterministic
+  compactness thresholds, and acceptance results.
+- A writing or platform adapter owns the copy, page selection, narrative
+  structure, author voice, and rendering.
+- A renderer owns pixels and emits a compact measurement packet; LoopX does not
+  add an image-processing dependency or ingest draft bodies.
+
+This is a machine-enforced acceptance check, not optional prose guidance.
+
+## Template library
+
+```bash
+loopx content-ops template-list --format json
+loopx content-ops template-show \
+  --template-id light-serif-longform \
+  --format json
+```
+
+The built-in `content_ops_layout_template_catalog_v0` currently includes:
+
+- `light-serif-longform` for dense analytical storytelling;
+- `monochrome-editorial` for high-contrast technical commentary;
+- `product-brief` for problem/mechanism/boundary summaries;
+- `control-plane-hybrid` for prose plus state, gate, and evidence artifacts.
+
+Templates define canvas size, safe area, density limits, page archetypes, and
+portable style tokens. They do not contain project names, private paths, draft
+bodies, or provider credentials.
+
+## Typed plan
+
+Build a plan before rendering:
+
+```bash
+loopx content-ops layout-plan \
+  --item-id plugin-scaling-note \
+  --template-id light-serif-longform \
+  --page p01:cover:source-system \
+  --page p02:argument:source-system \
+  --page p03:evidence:source-system \
+  --page p04:closing:creator-system \
+  --required-role cover \
+  --required-role argument \
+  --required-role evidence \
+  --required-role closing \
+  --closing-role closing \
+  --generated-at 2026-08-15T12:00:00+08:00 \
+  --format json
+```
+
+Roles are typed as `cover`, `argument`, `mechanism`, `evidence`, `boundary`,
+`closing`, or `cta`. Project-specific narrative obligations—such as ending in
+the creator's voice or bridging from one named subject to another—remain in the
+writing adapter or item-local review plan. LoopX does not universalize them or
+infer them from prose substrings.
+
+## Renderer measurement
+
+The renderer emits `content_ops_layout_measurement_v0`:
+
+```json
+{
+  "schema_version": "content_ops_layout_measurement_v0",
+  "plan_id": "layout:plugin-scaling-note:light-serif-longform",
+  "template_id": "light-serif-longform",
+  "pages": [
+    {
+      "page_id": "p01",
+      "asset_ref": "images/p01.jpg",
+      "canvas": {"width": 1440, "height": 1920},
+      "meaningful_content_bounds": {"top": 154, "bottom": 1364},
+      "checks": {
+        "overflow": false,
+        "collision": false,
+        "single_character_line": false
+      }
+    }
+  ]
+}
+```
+
+`asset_ref` must be a relative public-safe reference. Meaningful bounds exclude
+decorative rules, page numbers, and footers so they cannot make a sparse page
+look full.
+
+## Acceptance
+
+```bash
+loopx content-ops layout-check \
+  --plan-json layout-plan.json \
+  --measurement-json layout-measurement.json \
+  --format json
+```
+
+`content_ops_layout_check_packet_v0` returns `pass` only when:
+
+- measured page ids exactly match the plan;
+- all required roles are present and the last page has the planned closing role;
+- canvas and density satisfy the selected template and role;
+- overflow, collision, and single-character-line checks are explicitly false;
+- every renderer safety check is explicitly satisfied.
+
+The packet always keeps `autopublish_allowed=false`. Layout acceptance never
+grants provider access, publishing authority, or approval for the content body.

--- a/examples/content-ops-layout-library-smoke.py
+++ b/examples/content-ops-layout-library-smoke.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Smoke-test the content-ops layout template and acceptance contract."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.content_ops.layout import check_layout_packet  # noqa: E402
+
+
+def _run(*args: str, check: bool = True) -> dict[str, Any]:
+    result = subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "--format", "json", *args],
+        cwd=REPO_ROOT,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return json.loads(result.stdout)
+
+
+def _measurement(*, sparse_page: str | None = None) -> dict[str, Any]:
+    pages = []
+    for index in range(1, 6):
+        page_id = f"p{index:02d}"
+        bottom = 1364 if page_id != sparse_page else 700
+        pages.append(
+            {
+                "page_id": page_id,
+                "asset_ref": f"images/{page_id}.jpg",
+                "canvas": {"width": 1440, "height": 1920},
+                "meaningful_content_bounds": {"top": 154, "bottom": bottom},
+                "checks": {
+                    "overflow": False,
+                    "collision": False,
+                    "single_character_line": False,
+                },
+            }
+        )
+    return {
+        "schema_version": "content_ops_layout_measurement_v0",
+        "plan_id": "layout:dsh-plugin-scaling:light-serif-longform",
+        "template_id": "light-serif-longform",
+        "pages": pages,
+    }
+
+
+def main() -> int:
+    catalog = _run("content-ops", "template-list")
+    assert catalog["ok"] is True, catalog
+    assert catalog["template_count"] == 4, catalog
+    assert {
+        "light-serif-longform",
+        "monochrome-editorial",
+        "product-brief",
+        "control-plane-hybrid",
+    } == {template["template_id"] for template in catalog["templates"]}
+
+    template = _run(
+        "content-ops",
+        "template-show",
+        "--template-id",
+        "light-serif-longform",
+    )
+    assert template["template"]["canvas"] == {"width": 1440, "height": 1920}
+    assert template["template"]["density"]["default_min"] == 0.66
+
+    plan_packet = _run(
+        "content-ops",
+        "layout-plan",
+        "--item-id",
+        "dsh-plugin-scaling",
+        "--template-id",
+        "light-serif-longform",
+        "--page",
+        "p01:cover:dsh",
+        "--page",
+        "p02:argument:dsh",
+        "--page",
+        "p03:mechanism:dsh",
+        "--page",
+        "p04:evidence:dsh",
+        "--page",
+        "p05:closing:loopx",
+        "--required-role",
+        "cover",
+        "--required-role",
+        "argument",
+        "--required-role",
+        "evidence",
+        "--required-role",
+        "closing",
+        "--closing-role",
+        "closing",
+        "--generated-at",
+        "2026-08-15T12:00:00+08:00",
+    )
+    assert plan_packet["ok"] is True, plan_packet
+    assert plan_packet["plan"]["pages"][-1] == {
+        "page_id": "p05",
+        "role": "closing",
+        "subject_id": "loopx",
+    }
+
+    with tempfile.TemporaryDirectory() as tmp:
+        plan_path = Path(tmp) / "plan.json"
+        measurement_path = Path(tmp) / "measurement.json"
+        plan_path.write_text(json.dumps(plan_packet), encoding="utf-8")
+        measurement_path.write_text(json.dumps(_measurement()), encoding="utf-8")
+        accepted = _run(
+            "content-ops",
+            "layout-check",
+            "--plan-json",
+            str(plan_path),
+            "--measurement-json",
+            str(measurement_path),
+        )
+    assert accepted["ok"] is True, accepted
+    assert accepted["status"] == "pass", accepted
+    assert accepted["autopublish_allowed"] is False, accepted
+
+    sparse = _measurement(sparse_page="p02")
+    rejected = check_layout_packet(plan_packet, sparse)
+    assert rejected["status"] == "revise", rejected
+    codes = {failure["code"] for failure in rejected["failures"]}
+    assert "content_too_sparse" in codes, rejected
+
+    wrong_plan = _measurement()
+    wrong_plan["plan_id"] = "layout:another-item:light-serif-longform"
+    mismatched = check_layout_packet(plan_packet, wrong_plan)
+    assert mismatched["status"] == "revise", mismatched
+    assert "plan_id_mismatch" in {
+        failure["code"] for failure in mismatched["failures"]
+    }, mismatched
+
+    unsafe = _measurement()
+    unsafe["pages"][0]["asset_ref"] = "file:private-page.jpg"
+    try:
+        check_layout_packet(plan_packet, unsafe)
+    except ValueError as exc:
+        assert "public-safe relative reference" in str(exc)
+    else:
+        raise AssertionError("absolute asset_ref was accepted")
+
+    print("content-ops-layout-library-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/content-ops-layout-library-smoke.py
+++ b/examples/content-ops-layout-library-smoke.py
@@ -76,6 +76,16 @@ def main() -> int:
     assert template["template"]["canvas"] == {"width": 1440, "height": 1920}
     assert template["template"]["density"]["default_min"] == 0.66
 
+    missing_template = _run(
+        "content-ops",
+        "template-show",
+        "--template-id",
+        "missing-template",
+        check=False,
+    )
+    assert missing_template["ok"] is False, missing_template
+    assert "unknown content-ops layout template" in missing_template["error"]
+
     plan_packet = _run(
         "content-ops",
         "layout-plan",

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -1252,6 +1252,21 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "purpose": "Project caller-owned content items into one read-only managed queue surface.",
                 "write_boundary": "local queue projection only; no external read or write",
             },
+            {
+                "command": "loopx content-ops template-list --format json",
+                "purpose": "List the built-in public-safe content layout template library.",
+                "write_boundary": "packaged template read only; no external read or write",
+            },
+            {
+                "command": "loopx content-ops layout-plan --item-id <id> --template-id <id> --page <page:role:subject> --generated-at <iso> --format json",
+                "purpose": "Record typed page roles and a closing obligation before rendering.",
+                "write_boundary": "local plan packet only; no draft body or external write",
+            },
+            {
+                "command": "loopx content-ops layout-check --plan-json <plan.json> --measurement-json <measurement.json> --format json",
+                "purpose": "Enforce template density, visual safety, required page roles, and the final-page role.",
+                "write_boundary": "local deterministic check only; never grants publish authority",
+            },
         ],
         "implemented_protocols": [
             {
@@ -1294,6 +1309,16 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "module": "loopx.capabilities.content_ops.item_lifecycle",
                 "doc": "docs/reference/protocols/content-ops-queue-v0.md",
             },
+            {
+                "schema_version": "content_ops_layout_plan_v0",
+                "module": "loopx.capabilities.content_ops.layout",
+                "doc": "docs/reference/protocols/content-ops-layout-v0.md",
+            },
+            {
+                "schema_version": "content_ops_layout_check_packet_v0",
+                "module": "loopx.capabilities.content_ops.layout",
+                "doc": "docs/reference/protocols/content-ops-layout-v0.md",
+            },
         ],
         "smokes": [
             "python3 examples/content-ops-exploration-plan-smoke.py",
@@ -1302,18 +1327,22 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
             "python3 examples/content-ops-chatview-report-smoke.py",
             "python3 examples/content-ops-packet-aggregation-smoke.py",
             "python3 examples/content-ops-queue-status-smoke.py",
+            "python3 examples/content-ops-layout-library-smoke.py",
         ],
         "docs": [
             "docs/capabilities/content-ops/README.md",
             "docs/reference/protocols/content-ops-surface-v0.md",
             "docs/reference/protocols/content-ops-item-lifecycle-v0.md",
             "docs/reference/protocols/content-ops-queue-v0.md",
+            "docs/reference/protocols/content-ops-layout-v0.md",
         ],
         "boundaries": [
             "Private connectors enter as owner gates or compact approved counts first.",
             "Raw chats, transcripts, auth material, logs, and local paths are not copied into public packets.",
             "Publish remains blocked until an explicit user decision.",
             "Queue projection is read-only and never stores draft bodies or provider credentials.",
+            "Layout checks consume relative asset references and compact measurements, never draft bodies or local absolute paths.",
+            "Layout acceptance is deterministic and never implies creator approval or publishing authority.",
         ],
         "next_real_step": (
             "Turn the aggregated surface into a small review/feed UI where a user "

--- a/loopx/capabilities/content_ops/cli.py
+++ b/loopx/capabilities/content_ops/cli.py
@@ -18,6 +18,13 @@ from .item_lifecycle import (
     render_content_ops_item_packet_markdown,
     render_content_ops_queue_status_markdown,
 )
+from .layout import (
+    build_layout_plan_packet,
+    build_layout_template_catalog_packet,
+    build_layout_template_packet,
+    check_layout_packet,
+    render_layout_packet_markdown,
+)
 from .surface import (
     build_content_ops_chatview_report_packet,
     build_content_ops_exploration_plan_packet,
@@ -61,6 +68,19 @@ def _parse_path_counts(values: list[str]) -> dict[str, int]:
         path, raw_count = value.split("=", 1)
         counts[path.strip()] = int(raw_count.strip())
     return counts
+
+
+def _parse_layout_pages(page_values: list[str]) -> list[dict[str, object]]:
+    pages: list[dict[str, object]] = []
+    for value in page_values:
+        parts = value.split(":", 2)
+        if len(parts) != 3 or not all(part.strip() for part in parts):
+            raise ValueError("--page must use PAGE_ID:ROLE:SUBJECT_ID")
+        page_id, role, subject_id = (part.strip() for part in parts)
+        pages.append(
+            {"page_id": page_id, "role": role, "subject_id": subject_id}
+        )
+    return pages
 
 
 def register_content_ops_commands(
@@ -417,6 +437,57 @@ def register_content_ops_commands(
         default="2026-08-10T00:00:00Z",
         help="Public-safe generated_at timestamp for the queue projection.",
     )
+    template_list_parser = content_ops_sub.add_parser(
+        "template-list",
+        help="List the built-in public-safe content layout template library.",
+    )
+    add_subcommand_format(template_list_parser)
+    template_show_parser = content_ops_sub.add_parser(
+        "template-show",
+        help="Show one built-in content layout template and its acceptance rules.",
+    )
+    add_subcommand_format(template_show_parser)
+    template_show_parser.add_argument("--template-id", required=True)
+    layout_plan_parser = content_ops_sub.add_parser(
+        "layout-plan",
+        help="Build a typed page-role plan before rendering content assets.",
+    )
+    add_subcommand_format(layout_plan_parser)
+    layout_plan_parser.add_argument("--item-id", required=True)
+    layout_plan_parser.add_argument("--template-id", required=True)
+    layout_plan_parser.add_argument(
+        "--page",
+        action="append",
+        required=True,
+        help="Planned page as PAGE_ID:ROLE:SUBJECT_ID; repeat in reading order.",
+    )
+    layout_plan_parser.add_argument(
+        "--required-role",
+        action="append",
+        default=[],
+        help="Required typed role; repeat to override the template defaults.",
+    )
+    layout_plan_parser.add_argument(
+        "--closing-role",
+        default=None,
+        help="Required role for the final page; defaults to the template rule.",
+    )
+    layout_plan_parser.add_argument("--generated-at", required=True)
+    layout_check_parser = content_ops_sub.add_parser(
+        "layout-check",
+        help="Check rendered-page measurements against a typed layout plan.",
+    )
+    add_subcommand_format(layout_check_parser)
+    layout_check_parser.add_argument(
+        "--plan-json",
+        required=True,
+        help="Path to content_ops_layout_plan_v0 or its packet wrapper.",
+    )
+    layout_check_parser.add_argument(
+        "--measurement-json",
+        required=True,
+        help="Path to provider-produced content_ops_layout_measurement_v0.",
+    )
 
 
 def handle_content_ops_command(
@@ -527,6 +598,28 @@ def handle_content_ops_command(
                 generated_at=args.generated_at,
             )
             renderer = render_content_ops_queue_status_markdown
+        elif args.content_ops_command == "template-list":
+            payload = build_layout_template_catalog_packet()
+            renderer = render_layout_packet_markdown
+        elif args.content_ops_command == "template-show":
+            payload = build_layout_template_packet(args.template_id)
+            renderer = render_layout_packet_markdown
+        elif args.content_ops_command == "layout-plan":
+            payload = build_layout_plan_packet(
+                item_id=args.item_id,
+                template_id=args.template_id,
+                pages=_parse_layout_pages(args.page),
+                required_roles=args.required_role,
+                closing_role=args.closing_role,
+                generated_at=args.generated_at,
+            )
+            renderer = render_layout_packet_markdown
+        elif args.content_ops_command == "layout-check":
+            payload = check_layout_packet(
+                _load_json_object(args.plan_json),
+                _load_json_object(args.measurement_json),
+            )
+            renderer = render_layout_packet_markdown
         else:
             raise ValueError(
                 "content-ops requires `preview`, `exploration-plan`, "
@@ -534,7 +627,8 @@ def handle_content_ops_command(
                 "`observe-public-handle`, `project-private-connector-gate`, "
                 "`aggregate-packets`, `project-chatview-report`, or "
                 "`walkthrough-artifact`, `item-create`, `item-transition`, "
-                "or `queue-status`"
+                "`queue-status`, `template-list`, `template-show`, "
+                "`layout-plan`, or `layout-check`"
             )
     except Exception as exc:
         payload = {

--- a/loopx/capabilities/content_ops/cli.py
+++ b/loopx/capabilities/content_ops/cli.py
@@ -636,6 +636,14 @@ def handle_content_ops_command(
             "mode": "content-ops",
             "error": str(exc),
         }
-        renderer = render_content_ops_private_connector_gate_markdown
+        if args.content_ops_command in {
+            "template-list",
+            "template-show",
+            "layout-plan",
+            "layout-check",
+        }:
+            renderer = render_layout_packet_markdown
+        else:
+            renderer = render_content_ops_private_connector_gate_markdown
     print_payload(payload, output_format(args), renderer)
     return 0 if payload.get("ok") else 1

--- a/loopx/capabilities/content_ops/layout.py
+++ b/loopx/capabilities/content_ops/layout.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from enum import Enum
+from importlib.resources import files
+from pathlib import PurePosixPath
+from typing import Any
+
+
+class PageRole(str, Enum):
+    COVER = "cover"
+    ARGUMENT = "argument"
+    MECHANISM = "mechanism"
+    EVIDENCE = "evidence"
+    BOUNDARY = "boundary"
+    CLOSING = "closing"
+    CTA = "cta"
+
+
+_TEMPLATE_RESOURCE = "templates/layout-catalog-v0.json"
+
+
+def _catalog() -> dict[str, Any]:
+    payload = json.loads(
+        files("loopx.capabilities.content_ops")
+        .joinpath(_TEMPLATE_RESOURCE)
+        .read_text(encoding="utf-8")
+    )
+    if payload.get("schema_version") != "content_ops_layout_template_catalog_v0":
+        raise ValueError("layout template catalog has an unsupported schema_version")
+    templates = payload.get("templates")
+    if not isinstance(templates, list) or not templates:
+        raise ValueError("layout template catalog must contain templates")
+    return payload
+
+
+def _template(template_id: str) -> dict[str, Any]:
+    for template in _catalog()["templates"]:
+        if template.get("template_id") == template_id:
+            return dict(template)
+    raise ValueError(f"unknown content-ops layout template: {template_id}")
+
+
+def build_layout_template_catalog_packet() -> dict[str, object]:
+    catalog = _catalog()
+    return {
+        "ok": True,
+        "schema_version": "content_ops_layout_template_catalog_packet_v0",
+        "templates": [
+            {
+                "template_id": template["template_id"],
+                "title": template["title"],
+                "intent": template["intent"],
+                "canvas": template["canvas"],
+                "page_archetypes": template["page_archetypes"],
+            }
+            for template in catalog["templates"]
+        ],
+        "template_count": len(catalog["templates"]),
+        "external_reads_performed": False,
+        "external_writes_performed": False,
+    }
+
+
+def build_layout_template_packet(template_id: str) -> dict[str, object]:
+    return {
+        "ok": True,
+        "schema_version": "content_ops_layout_template_packet_v0",
+        "template": _template(template_id),
+        "external_reads_performed": False,
+        "external_writes_performed": False,
+    }
+
+
+def _normalize_role(value: object) -> str:
+    try:
+        return PageRole(str(value)).value
+    except ValueError as exc:
+        allowed = ", ".join(role.value for role in PageRole)
+        raise ValueError(f"unsupported page role {value!r}; choose one of: {allowed}") from exc
+
+
+def build_layout_plan_packet(
+    *,
+    item_id: str,
+    template_id: str,
+    pages: Iterable[Mapping[str, object]],
+    required_roles: Iterable[str] = (),
+    closing_role: str | None = None,
+    generated_at: str,
+) -> dict[str, object]:
+    template = _template(template_id)
+    normalized_pages: list[dict[str, object]] = []
+    page_ids: set[str] = set()
+    for index, raw_page in enumerate(pages, start=1):
+        page_id = str(raw_page.get("page_id") or f"p{index:02d}").strip()
+        subject_id = str(raw_page.get("subject_id") or "").strip()
+        if not page_id or page_id in page_ids:
+            raise ValueError("layout plan page_id values must be non-empty and unique")
+        if not subject_id:
+            raise ValueError(f"layout plan page {page_id} requires subject_id")
+        page_ids.add(page_id)
+        role = _normalize_role(raw_page.get("role"))
+        normalized_page: dict[str, object] = {
+            "page_id": page_id,
+            "role": role,
+            "subject_id": subject_id,
+        }
+        normalized_pages.append(normalized_page)
+    if not normalized_pages:
+        raise ValueError("layout plan requires at least one page")
+
+    roles = [_normalize_role(role) for role in required_roles]
+    if not roles:
+        roles = list(template["default_required_roles"])
+    normalized_closing_role = _normalize_role(
+        closing_role or template["default_closing_role"]
+    )
+
+    return {
+        "ok": True,
+        "schema_version": "content_ops_layout_plan_packet_v0",
+        "plan": {
+            "schema_version": "content_ops_layout_plan_v0",
+            "plan_id": f"layout:{item_id}:{template_id}",
+            "item_id": item_id,
+            "template_id": template_id,
+            "generated_at": generated_at,
+            "required_roles": roles,
+            "closing_role": normalized_closing_role,
+            "pages": normalized_pages,
+        },
+        "external_reads_performed": False,
+        "external_writes_performed": False,
+    }
+
+
+def _safe_asset_ref(value: object) -> str:
+    asset_ref = str(value or "").strip()
+    path = PurePosixPath(asset_ref)
+    if (
+        not asset_ref
+        or path.is_absolute()
+        or ".." in path.parts
+        or "\\" in asset_ref
+        or asset_ref.startswith("file:")
+    ):
+        raise ValueError("asset_ref must be a public-safe relative reference")
+    return asset_ref
+
+
+def _density_limits(template: Mapping[str, Any], role: str) -> tuple[float, float]:
+    role_limits = template["density"].get("role_overrides", {}).get(role, {})
+    minimum = float(role_limits.get("min", template["density"]["default_min"]))
+    maximum = float(role_limits.get("max", template["density"]["default_max"]))
+    return minimum, maximum
+
+
+def _measurement_pages(measurement: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:
+    if measurement.get("schema_version") != "content_ops_layout_measurement_v0":
+        raise ValueError("measurement must use content_ops_layout_measurement_v0")
+    pages = measurement.get("pages")
+    if not isinstance(pages, list):
+        raise ValueError("measurement pages must be a list")
+    result: dict[str, Mapping[str, Any]] = {}
+    for page in pages:
+        if not isinstance(page, Mapping):
+            raise ValueError("each measurement page must be an object")
+        page_id = str(page.get("page_id") or "").strip()
+        if not page_id or page_id in result:
+            raise ValueError("measurement page_id values must be non-empty and unique")
+        result[page_id] = page
+    return result
+
+
+def check_layout_packet(
+    plan_packet_or_plan: Mapping[str, Any],
+    measurement: Mapping[str, Any],
+) -> dict[str, object]:
+    plan = plan_packet_or_plan.get("plan", plan_packet_or_plan)
+    if not isinstance(plan, Mapping) or plan.get("schema_version") != "content_ops_layout_plan_v0":
+        raise ValueError("plan must use content_ops_layout_plan_v0")
+    template_id = str(plan.get("template_id") or "")
+    template = _template(template_id)
+    measured_by_id = _measurement_pages(measurement)
+    planned_pages = plan.get("pages")
+    if not isinstance(planned_pages, list) or not planned_pages:
+        raise ValueError("plan pages must be a non-empty list")
+
+    failures: list[dict[str, str]] = []
+    page_results: list[dict[str, object]] = []
+    if measurement.get("plan_id") != plan.get("plan_id"):
+        failures.append(
+            {
+                "code": "plan_id_mismatch",
+                "message": "measurement plan_id must match the layout plan",
+            }
+        )
+    if measurement.get("template_id") != template_id:
+        failures.append(
+            {
+                "code": "template_id_mismatch",
+                "message": "measurement template_id must match the layout plan",
+            }
+        )
+    expected_ids = [str(page["page_id"]) for page in planned_pages]
+    if len(expected_ids) != len(set(expected_ids)):
+        raise ValueError("plan page_id values must be unique")
+    if set(expected_ids) != set(measured_by_id):
+        failures.append(
+            {
+                "code": "page_set_mismatch",
+                "message": "measurement page ids must exactly match the layout plan",
+            }
+        )
+
+    roles = [_normalize_role(page["role"]) for page in planned_pages]
+    required_roles = [
+        _normalize_role(required_role) for required_role in plan.get("required_roles", [])
+    ]
+    for required_role in required_roles:
+        if required_role not in roles:
+            failures.append(
+                {
+                    "code": "required_role_missing",
+                    "message": f"required page role is missing: {required_role}",
+                }
+            )
+    closing_role = _normalize_role(plan.get("closing_role"))
+    if roles[-1] != closing_role:
+        failures.append(
+            {
+                "code": "closing_role_mismatch",
+                "message": f"last page must use closing role {closing_role}",
+            }
+        )
+
+    target_canvas = template["canvas"]
+    safe_area = template["safe_area"]
+    for planned_page in planned_pages:
+        page_id = str(planned_page["page_id"])
+        role = str(planned_page["role"])
+        measured = measured_by_id.get(page_id)
+        page_failures: list[dict[str, str]] = []
+        density: float | None = None
+        asset_ref: str | None = None
+        if measured is None:
+            page_failures.append(
+                {"code": "measurement_missing", "message": "page measurement is missing"}
+            )
+        else:
+            asset_ref = _safe_asset_ref(measured.get("asset_ref"))
+            canvas = measured.get("canvas")
+            bounds = measured.get("meaningful_content_bounds")
+            checks = measured.get("checks")
+            if not isinstance(canvas, Mapping) or not isinstance(bounds, Mapping):
+                raise ValueError(f"measurement page {page_id} requires canvas and bounds")
+            if not isinstance(checks, Mapping):
+                raise ValueError(f"measurement page {page_id} requires checks")
+            width = int(canvas.get("width", 0))
+            height = int(canvas.get("height", 0))
+            if width != target_canvas["width"] or height != target_canvas["height"]:
+                page_failures.append(
+                    {
+                        "code": "canvas_mismatch",
+                        "message": (
+                            f"canvas must be {target_canvas['width']}x"
+                            f"{target_canvas['height']}"
+                        ),
+                    }
+                )
+            top = int(bounds.get("top", -1))
+            bottom = int(bounds.get("bottom", -1))
+            if top < 0 or bottom <= top or bottom > height:
+                page_failures.append(
+                    {"code": "invalid_content_bounds", "message": "content bounds are invalid"}
+                )
+            elif height > 0:
+                usable_height = height * (
+                    1.0 - float(safe_area["top_ratio"]) - float(safe_area["bottom_ratio"])
+                )
+                density = round((bottom - top) / usable_height, 3)
+                minimum, maximum = _density_limits(template, role)
+                if density < minimum:
+                    page_failures.append(
+                        {
+                            "code": "content_too_sparse",
+                            "message": f"density {density:.3f} is below {minimum:.3f}; tighten the page",
+                        }
+                    )
+                if density > maximum:
+                    page_failures.append(
+                        {
+                            "code": "content_too_dense",
+                            "message": f"density {density:.3f} exceeds {maximum:.3f}; split or reduce content",
+                        }
+                    )
+            for check_name, code in (
+                ("overflow", "content_overflow"),
+                ("collision", "content_collision"),
+                ("single_character_line", "single_character_line"),
+            ):
+                if checks.get(check_name) is not False:
+                    page_failures.append(
+                        {"code": code, "message": f"{check_name} must be explicitly false"}
+                    )
+        page_results.append(
+            {
+                "page_id": page_id,
+                "asset_ref": asset_ref,
+                "role": role,
+                "density": density,
+                "status": "pass" if not page_failures else "revise",
+                "failures": page_failures,
+            }
+        )
+        failures.extend(
+            {"code": failure["code"], "message": f"{page_id}: {failure['message']}"}
+            for failure in page_failures
+        )
+
+    return {
+        "ok": not failures,
+        "schema_version": "content_ops_layout_check_packet_v0",
+        "status": "pass" if not failures else "revise",
+        "plan_id": plan.get("plan_id"),
+        "template_id": template_id,
+        "page_results": page_results,
+        "failures": failures,
+        "next_action": (
+            "layout_acceptance_complete"
+            if not failures
+            else "revise_failed_pages_and_rerun_layout_check"
+        ),
+        "external_reads_performed": False,
+        "external_writes_performed": False,
+        "autopublish_allowed": False,
+    }
+
+
+def render_layout_packet_markdown(packet: Mapping[str, object]) -> str:
+    if not packet.get("ok") and "error" in packet:
+        return f"# Content-Ops Layout\n\nError: {packet['error']}\n"
+    if packet.get("schema_version") == "content_ops_layout_template_catalog_packet_v0":
+        lines = ["# Content-Ops Layout Templates", ""]
+        for template in packet["templates"]:  # type: ignore[union-attr]
+            lines.append(f"- `{template['template_id']}` — {template['title']}")
+        return "\n".join(lines) + "\n"
+    if packet.get("schema_version") == "content_ops_layout_template_packet_v0":
+        template = packet["template"]  # type: ignore[assignment]
+        return (
+            "# Content-Ops Layout Template\n\n"
+            f"- id: `{template['template_id']}`\n"
+            f"- title: {template['title']}\n"
+            f"- intent: {template['intent']}\n"
+        )
+    if packet.get("schema_version") == "content_ops_layout_plan_packet_v0":
+        plan = packet["plan"]  # type: ignore[assignment]
+        return (
+            "# Content-Ops Layout Plan\n\n"
+            f"- plan: `{plan['plan_id']}`\n"
+            f"- template: `{plan['template_id']}`\n"
+            f"- pages: {len(plan['pages'])}\n"
+            f"- closing role: `{plan['closing_role']}`\n"
+        )
+    lines = [
+        "# Content-Ops Layout Check",
+        "",
+        f"- status: `{packet.get('status')}`",
+        f"- next action: `{packet.get('next_action')}`",
+    ]
+    for failure in packet.get("failures", []):  # type: ignore[union-attr]
+        lines.append(f"- `{failure['code']}`: {failure['message']}")
+    return "\n".join(lines) + "\n"

--- a/loopx/capabilities/content_ops/templates/layout-catalog-v0.json
+++ b/loopx/capabilities/content_ops/templates/layout-catalog-v0.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": "content_ops_layout_template_catalog_v0",
+  "templates": [
+    {
+      "template_id": "light-serif-longform",
+      "title": "Light serif longform",
+      "intent": "Dense analytical stories with a calm editorial rhythm and one argument per page.",
+      "canvas": {"width": 1440, "height": 1920},
+      "safe_area": {"top_ratio": 0.08, "bottom_ratio": 0.08},
+      "density": {
+        "default_min": 0.66,
+        "default_max": 0.94,
+        "role_overrides": {
+          "cover": {"min": 0.48, "max": 0.82},
+          "closing": {"min": 0.56, "max": 0.88}
+        }
+      },
+      "default_required_roles": ["cover", "argument", "evidence"],
+      "default_closing_role": "closing",
+      "page_archetypes": ["editorial-cover", "argument-stack", "evidence-notes", "mechanism-flow", "synthesis-close"],
+      "style_tokens": {
+        "background": "#F4F0E7",
+        "text": "#171717",
+        "muted": "#5D5A54",
+        "accent": "#B14B35",
+        "heading_family": "serif",
+        "body_family": "sans-serif",
+        "decoration": "rules-and-indexes"
+      }
+    },
+    {
+      "template_id": "monochrome-editorial",
+      "title": "Monochrome editorial",
+      "intent": "High-contrast technical commentary with restrained diagrams and evidence labels.",
+      "canvas": {"width": 1440, "height": 1800},
+      "safe_area": {"top_ratio": 0.07, "bottom_ratio": 0.07},
+      "density": {"default_min": 0.62, "default_max": 0.93, "role_overrides": {"cover": {"min": 0.44, "max": 0.80}}},
+      "default_required_roles": ["cover", "argument", "evidence"],
+      "default_closing_role": "closing",
+      "page_archetypes": ["type-cover", "numbered-argument", "source-ledger", "comparison-grid", "closing-statement"],
+      "style_tokens": {"background": "#F8F8F5", "text": "#111111", "muted": "#666666", "accent": "#111111", "heading_family": "sans-serif", "body_family": "sans-serif", "decoration": "hairlines-and-numerals"}
+    },
+    {
+      "template_id": "product-brief",
+      "title": "Product brief",
+      "intent": "Compact product reasoning with explicit problem, mechanism, boundary, and takeaway blocks.",
+      "canvas": {"width": 1440, "height": 1800},
+      "safe_area": {"top_ratio": 0.07, "bottom_ratio": 0.07},
+      "density": {"default_min": 0.60, "default_max": 0.91, "role_overrides": {"cover": {"min": 0.42, "max": 0.78}, "boundary": {"min": 0.52, "max": 0.88}}},
+      "default_required_roles": ["cover", "mechanism", "boundary"],
+      "default_closing_role": "closing",
+      "page_archetypes": ["product-cover", "problem-mechanism", "three-part-brief", "boundary-box", "decision-close"],
+      "style_tokens": {"background": "#F5F3ED", "text": "#181818", "muted": "#60605A", "accent": "#D4633A", "heading_family": "sans-serif", "body_family": "sans-serif", "decoration": "flat-blocks"}
+    },
+    {
+      "template_id": "control-plane-hybrid",
+      "title": "Control-plane hybrid",
+      "intent": "Technical narratives that combine prose, state transitions, gates, and executable-looking artifacts.",
+      "canvas": {"width": 1440, "height": 1800},
+      "safe_area": {"top_ratio": 0.07, "bottom_ratio": 0.07},
+      "density": {"default_min": 0.64, "default_max": 0.93, "role_overrides": {"cover": {"min": 0.45, "max": 0.80}, "mechanism": {"min": 0.58, "max": 0.90}}},
+      "default_required_roles": ["cover", "mechanism", "evidence", "boundary"],
+      "default_closing_role": "closing",
+      "page_archetypes": ["system-cover", "state-lanes", "effect-program", "evidence-ledger", "operator-close"],
+      "style_tokens": {"background": "#111418", "text": "#F4F0E8", "muted": "#9DA4AB", "accent": "#F08A5D", "heading_family": "sans-serif", "body_family": "sans-serif", "decoration": "state-lines-and-code"}
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ include = ["loopx*"]
 
 [tool.setuptools.package-data]
 "loopx.capabilities.auto_research" = ["worker_skill/SKILL.md"]
+"loopx.capabilities.content_ops" = ["templates/*.json"]
 "loopx.extensions.lark" = ["extension.toml"]
 "loopx.extensions.openviking_periodic_report" = ["extension.toml"]
 "loopx.extensions.openviking_semantic_preference" = ["extension.toml"]


### PR DESCRIPTION
## Summary

- add a built-in `content-ops` layout template library with four provider-neutral visual systems;
- add `template-list`, `template-show`, `layout-plan`, and `layout-check` commands;
- check canvas, meaningful-content density, required/final page roles, renderer safety flags, packet identity, and public-safe relative asset references;
- document the protocol, package the template catalog, and add a focused public smoke.

Project-specific author voice and narrative bridges intentionally stay in writing adapters or item-local review plans. The generic LoopX contract does not infer them from prose or impose them on every creator workflow.

## Changed surfaces

- `loopx.capabilities.content_ops.layout`
- content-ops CLI and capability catalog
- packaged layout template catalog
- public protocol and capability docs
- focused layout-library smoke

## Validation

- `loopx canary premerge --from-git-diff --tier standard`: passed
  - 17 selected checks executed
  - 0 failures, 0 warnings, 0 manual holds
- changed Python compilation: passed
- focused content-ops and catalog smokes: passed
- Ruff: passed
- wheel build/readback: template catalog and layout module included
- public/private boundary scan: clean across all 9 changed files

## Authority boundary

- no external reads or writes;
- no draft bodies, provider credentials, raw logs, or local paths in packets;
- layout acceptance keeps `autopublish_allowed=false` and grants no publish authority.

Ready for maintainer review; not self-merged.
