### PR TITLE
docs(rfc): TypeScript control-plane migration RFC (#3225)

### DIFF
--- a/docs/architecture/rfcs/README.md
+++ b/docs/architecture/rfcs/README.md
@@ -22,6 +22,8 @@ defined by the implementation and stable reference contracts.
 - [Goal artifact lifecycle projection v0](goal-artifact-lifecycle-projection-v0.md): derived from artifact-centric business process management (ABPM / GSM milestone-guard semantics); treat a goal as a business artifact with derived milestones, blocking guards, and legal next transitions, projected read-only for operators and global views ([中文版](goal-artifact-lifecycle-projection-v0.zh-CN.md)).
 - [Post-Outcome Memory Utility Attribution v0](post-outcome-memory-utility-attribution-v0.md): attribute bounded, evidence-tiered utility to recalled memory after verified outcomes, without turning retrieval, model judgment, or a global evaluator into authority.
 - [结果后记忆效用归因 v0](post-outcome-memory-utility-attribution-v0.zh-CN.md)：在可验证结果之后，对召回记忆做有界、分证据等级的效用归因，同时避免让召回、模型判断或全局评估器变成新的权限来源。
+- [TypeScript Control-Plane Migration v0](typescript-control-plane-migration-v0.md): contract-first, parity-gated, block-by-block migration from Python to TypeScript over the event store, parity-fixture layer, and CLI boundary; Python remains canonical during the transition.
+- [TypeScript 控制面迁移 v0](typescript-control-plane-migration-v0.zh-CN.md)：契约优先、parity 门禁、逐块迁移；基于事件存储、parity fixture 层与 CLI 边界从 Python 渐进迁移到 TypeScript，过渡期内 Python 保持权威实现。
 
 RFCs must not contain internal conversations, private links, local filesystem
 paths, credentials, raw transcripts, or non-public organizational context.

--- a/docs/architecture/rfcs/typescript-control-plane-migration-v0.md
+++ b/docs/architecture/rfcs/typescript-control-plane-migration-v0.md
@@ -1,0 +1,203 @@
+# RFC: TypeScript Control-Plane Migration Direction v0
+
+- Status: Draft, under maintainer review
+- Proposed by: LoopX maintainers
+- Date: 2026-08-15
+- Scope: an incremental, contract-first migration strategy for the LoopX
+  control-plane core from Python to TypeScript; parity-gated, block-by-block
+  replacement
+- Source baseline: `d1fe05932`
+- Tracking issue: [#3225](https://github.com/huangruiteng/loopx/issues/3225)
+- Language note: the
+  [Chinese version](./typescript-control-plane-migration-v0.zh-CN.md) and this
+  English version are semantic mirrors. A difference between them is a defect.
+
+---
+
+## 0. Example
+
+A host wants to embed LoopX decision-making without requiring a Python
+runtime. Today, the Pi extension
+(`loopx/pi_goal_mode/loopx-goal.ts`) already runs the quota decision by
+shelling out to the Python CLI
+(`loopx quota should-run --runtime-profile generic_cli`). The extension
+implements its goal loop in TypeScript; only the decision kernel is Python.
+
+The migration question is whether that split can grow into a full TypeScript
+control-plane core without a big-bang rewrite: Python and TypeScript calling
+each other, one surface at a time, with the user experience unchanged.
+
+This RFC answers yes, but not through in-process mutual calls. It proposes a
+contract-first "strangler" migration over three existing seams: the event
+store, the parity-fixture layer, and the CLI boundary.
+
+## 1. Problem
+
+- External projects are already porting the LoopX kernel to TypeScript; the
+  most complete sketch is
+  [Foreman PR #1](https://github.com/needware/foreman/pull/1).
+- The frontstage/dashboard surface is already TypeScript.
+- A shared runtime would simplify CLI distribution and host integration,
+  including an npm package.
+- The control-plane core is roughly 343k lines of Python, with more than
+  1,200 files under `tests/` and `examples/`. A one-pass rewrite is
+  high-risk, effectively un-reviewable, and would strand production behavior
+  behind a single cut-over.
+- The naive reading of "Python and TypeScript calling each other" —
+  in-process imports — is impractical: embedding CPython inside Node and
+  V8 inside Python both carry GIL/ABI/packaging costs, and Pyodide/WASM has
+  startup, single-thread, filesystem, and process limitations.
+
+The practical question is therefore: which boundary can carry a
+dual-language transition with parity guarantees and rollback?
+
+## 2. Decision
+
+Adopt a contract-first, parity-gated, block-by-block migration:
+
+1. Interop happens over a process boundary with JSON contracts
+   (stdio JSON-RPC/NDJSON), not in-process imports. Calls are coarse-grained —
+   a CLI command, a projection render, or a decision request — so per-call
+   latency is acceptable.
+2. The event store is the shared fact surface: append-only events with
+   versioned schemas (`loopx_state_event_v0`) form the only cross-language
+   state contract. Either language can build projections from the same event
+   stream.
+3. Read paths and projections migrate first (pure, side-effect-free), then
+   deterministic decision kernels (quota `should-run`, todo lifecycle
+   transitions, scheduler state transitions) validated by parity fixtures and
+   decision replay. The event store and write paths migrate last, through a
+   dual-read → dual-write → flip sequence with a bounded canary and a recorded
+   rollback plan.
+4. Python remains the canonical implementation during the transition. A block
+   flips only when its parity gate passes and its rollback plan is recorded.
+
+### 2.1 Interop options
+
+| Option | Verdict | Notes |
+| --- | --- | --- |
+| TS → Python subprocess | ✅ already in production | `pi_goal_mode` uses `execFile("loopx", ...)` with a 30s timeout; simplest and proven for coarse calls |
+| Python → TS subprocess | ✅ viable | `node dist/...` with JSON on stdin; same shape when a migrated kernel must be called from Python |
+| Long-lived sidecar (JSON-RPC over Unix socket) | ⚠️ optimize later | Amortizes startup for hot paths; requires lifecycle, version, and lock discipline |
+| Pyodide / WASM | ❌ not for production CLI | Startup in seconds, single-threaded, filesystem/process limits |
+| Rust core + PyO3/napi-rs dual bindings | ⚠️ separate project | True shared core with thin Python/TS bindings (like huggingface/tokenizers), but it is a Rust rewrite, not a TypeScript migration |
+
+## 3. Existing seams that make this viable
+
+The migration is not a leap into the unknown; three seams already exist in the
+repository:
+
+- `loopx/pi_goal_mode/loopx-goal.ts` and `pi-goal-loop-runtime.mjs`: a
+  production TypeScript surface that delegates quota decisions to the Python
+  CLI over a process boundary.
+- `loopx/control_plane/testing/quota_should_run_parity.py`: a compact,
+  stable parity surface for comparing old and new quota builders; the template
+  for every future parity fixture.
+- `loopx/control_plane/testing/decision_replay.py`: replays historical
+  payloads against a decision builder — the dual-implementation comparison
+  harness.
+- `loopx/control_plane/testing/cli_output_differential.py`: enforces CLI
+  output contracts and growth budgets.
+- `loopx/event_sourced_state.py`: append-only, schema-versioned event state
+  (`loopx_state_event_v0`).
+- `loopx/control_plane/runtime/event_store_migration_bridge.py`: already
+  models dual-read parity, bounded canaries, and rollback records for event
+  projection promotion.
+
+## 4. Migration phases
+
+### Phase 0 — Contract freeze
+
+Turn the candidate scope in #3225 into typed schemas and a parity-fixture
+inventory: append-only event state and idempotent writes; todo lifecycle
+(claim, lease, status, revision, completion validation); gates and decision
+scope; quota (`should-run`/spend) and scheduler/monitor contracts; the Turn
+envelope and transaction semantics; handoff and review-packet projection; CLI
+and status/quota JSON parity. No code migration happens in this phase.
+
+### Phase 1 — Read paths and projections
+
+Migrate status JSON, todo list projection, handoff review-packet projection,
+and frontstage rendering. These are pure functions with no side effects.
+TypeScript implements each surface; Python generates golden fixtures; a
+dual-read gate requires the TypeScript projection to match the Python head
+before it may serve.
+
+### Phase 2 — Deterministic decision kernels
+
+Migrate `quota should-run`, todo state transitions, and scheduler state
+transition rules. These are pure decisions with no I/O, so they are the
+natural parity candidates. `decision_replay` replays historical inputs
+through both implementations; a block flips only when outputs are identical
+field-by-field. After this phase, the Pi extension can drop its Python quota
+dependency.
+
+### Phase 3 — Event store and write paths
+
+TypeScript first reads the event store as a projection reader (dual-read),
+then dual-writes with idempotency checks, then flips the write path. The
+`event_store_migration_bridge` canary and rollback gates apply at each step.
+
+### Phase 4 — Distribution
+
+Publish an npm package and a pip shim (or both). A TypeScript CLI shim
+forwards unmigrated commands to Python, so the `loopx` user experience stays
+unchanged throughout.
+
+## 5. Interop contract
+
+- Every surface carries a versioned JSON schema (`..._v0`).
+- Requests/responses travel as NDJSON over stdio; the long-lived sidecar may
+  add content-length framing.
+- Errors use a machine-readable envelope (code + message), never raw
+  tracebacks.
+- Callers set timeouts, following the existing `LOOPX_CLI_TIMEOUT_MS` pattern.
+- Writes are idempotent: events carry stable ids and duplicate application is
+  a no-op.
+- No credentials, raw logs, or private paths cross the boundary.
+
+## 6. Validation
+
+- Parity fixtures per surface: the same input corpus produces identical
+  compact JSON output from both implementations.
+- Decision replay: historical payloads replay against both implementations.
+- Dual-read gate: TypeScript projection must match the Python head before it
+  serves traffic.
+- Bounded canary: a small canary goal set runs on the new path before flip.
+- Rollback record: the flip is flag-gated and the rollback plan is recorded
+  before the flip happens.
+- CLI output budgets remain enforced by `cli_output_differential`.
+
+## 7. Non-goals
+
+- No behavior change; Python remains canonical during the transition.
+- No in-process embedding (CPython inside Node, or V8 inside Python).
+- No Pyodide/WASM as the production runtime.
+- No fork-first migration; upstream-owned and contribution-friendly.
+- No one-pass rewrite of the full control-plane core.
+
+## 8. Open questions
+
+- Runtime choice: Node.js, Bun, or Deno?
+- Packaging/distribution: npm package, pip shim, or both?
+- Contributor ownership and review lane for the TypeScript track?
+- Hot-path budget: which surfaces justify a long-lived sidecar?
+- Should the eventual shared core be Rust with thin Python/TypeScript
+  bindings instead (a separate RFC)?
+
+## 9. Smallest useful implementation slice
+
+A TypeScript implementation of the `quota should-run` compact parity surface,
+run against the same fixture corpus as `quota_should_run_parity.py`, producing
+identical JSON. Optionally paired with one read-path probe: a TypeScript todo
+list/status projection rendering the same event fixtures as the Python
+projection. This validates the entire pipeline — contract, parity fixtures,
+dual implementation, and the process boundary — at near-zero production risk.
+
+## 10. Rollout and rollback
+
+Every block follows the same sequence: dual implementation → parity gate →
+dual-read (for read paths) → bounded canary → flip behind a flag → recorded
+rollback plan. Any parity mismatch blocks the flip. Rollback means flipping
+back and keeping both implementations until the block is re-qualified; no
+existing user state is migrated twice or left half-migrated.

--- a/docs/architecture/rfcs/typescript-control-plane-migration-v0.zh-CN.md
+++ b/docs/architecture/rfcs/typescript-control-plane-migration-v0.zh-CN.md
@@ -1,0 +1,172 @@
+# RFC：LoopX 控制面 TypeScript 渐进迁移方向 v0
+
+- Status: Draft，维护者评审中
+- Proposed by: LoopX maintainers
+- Date: 2026-08-15
+- Scope: LoopX 控制面核心从 Python 到 TypeScript 的增量迁移策略；
+  契约优先、parity 门禁、逐块替换
+- Source baseline: `d1fe05932`
+- Tracking issue: [#3225](https://github.com/huangruiteng/loopx/issues/3225)
+- Language note: 本中文版与
+  [英文版](./typescript-control-plane-migration-v0.md) 为语义镜像；
+  两者不一致视为缺陷。
+
+---
+
+## 0. 示例
+
+某个宿主希望在不需要 Python 运行时的情况下内嵌 LoopX 的决策能力。现在
+Pi 扩展（`loopx/pi_goal_mode/loopx-goal.ts`）已经通过子进程调用 Python CLI
+（`loopx quota should-run --runtime-profile generic_cli`）来完成 quota
+决策。扩展本身的 goal loop 用 TypeScript 实现，只有决策内核是 Python。
+
+迁移问题是：这个切分能否不经过一次性重写，逐步长成完整的 TypeScript
+控制面核心——Python 和 TypeScript 相互调用、一次迁移一块、用户体验不变。
+
+本 RFC 的结论是：可以，但不是靠进程内互调，而是基于三个已有接缝做
+契约优先的 strangler 迁移：事件存储、parity fixture 层、CLI 边界。
+
+## 1. 问题
+
+- 外部项目已经在把 LoopX 内核移植到 TypeScript，最完整的草图是
+  [Foreman PR #1](https://github.com/needware/foreman/pull/1)。
+- frontstage/dashboard 表面已经是 TypeScript。
+- 共享运行时能简化 CLI 分发与宿主集成，包括 npm 包。
+- 控制面核心约 34.3 万行 Python，`tests/` 与 `examples/` 下超过 1,200
+  个文件。一次性重写风险高、几乎不可评审，并且会把生产行为押在一次
+  切换上。
+- "Python 和 TypeScript 互相调"如果指进程内直接 import，不现实：
+  在 Node 里嵌入 CPython、在 Python 里嵌入 V8 都有 GIL/ABI/打包成本；
+  Pyodide/WASM 有启动、单线程、文件系统与进程能力的限制。
+
+因此真正的问题变成：哪条边界能承载"双语言渐进切换 + parity 保证 +
+可回滚"？
+
+## 2. 决策
+
+采用契约优先、parity 门禁、逐块迁移：
+
+1. 互调走进程边界 + JSON 契约（stdio JSON-RPC/NDJSON），不做进程内
+   import。调用粒度是粗粒度的——一条 CLI 命令、一次投影渲染、一个决策
+   请求——所以单次调用延迟可接受。
+2. 事件存储是双语言的共同事实面：append-only 事件带版本化 schema
+   （`loopx_state_event_v0`），两种语言都从同一事件流构建投影。
+3. 读路径与投影先迁（纯函数、无副作用），然后是确定性决策内核
+   （quota `should-run`、todo 生命周期迁移、scheduler 状态迁移），用
+   parity fixture 与决策回放校验；事件存储与写路径最后迁，走
+   dual-read → dual-write → flip 序列，带有限 canary 与已记录的
+   rollback 计划。
+4. 过渡期内 Python 仍是权威实现。一个块只有在 parity 门禁通过且
+   rollback 计划已记录之后才能翻转。
+
+### 2.1 互调方案对比
+
+| 方案 | 结论 | 说明 |
+| --- | --- | --- |
+| TS 子进程调 Python | ✅ 已在生产 | `pi_goal_mode` 用 `execFile("loopx", ...)`，30s 超时；粗粒度调用最简单、已被验证 |
+| Python 子进程调 TS | ✅ 可行 | `node dist/...` + stdin JSON；已迁移的内核被 Python 调用时同构 |
+| 长驻 sidecar（Unix socket 上 JSON-RPC） | ⚠️ 后续优化 | 摊薄启动开销，适合热路径；需要生命周期、版本与锁纪律 |
+| Pyodide / WASM | ❌ 不适合生产 CLI | 启动秒级、单线程、文件系统/进程受限 |
+| Rust 核心 + PyO3/napi-rs 双绑定 | ⚠️ 另一个项目 | 真正的共享核心 + Python/TS 薄绑定（类似 huggingface/tokenizers），但那是 Rust 重写，不是 TS 迁移 |
+
+## 3. 让该方案可行的现有接缝
+
+迁移不是从零赌一个方案，仓库里已有三个接缝：
+
+- `loopx/pi_goal_mode/loopx-goal.ts` 与 `pi-goal-loop-runtime.mjs`：
+  生产级 TypeScript 表面，通过进程边界把 quota 决策委托给 Python CLI。
+- `loopx/control_plane/testing/quota_should_run_parity.py`：用于新旧 quota
+  构建器对比的 compact 稳定表面；是未来所有 parity fixture 的模板。
+- `loopx/control_plane/testing/decision_replay.py`：用历史真实输入回放决策
+  构建器——即双实现对比的 harness。
+- `loopx/control_plane/testing/cli_output_differential.py`：约束 CLI 输出
+  契约与增长预算。
+- `loopx/event_sourced_state.py`：append-only、schema 版本化的事件状态
+  （`loopx_state_event_v0`）。
+- `loopx/control_plane/runtime/event_store_migration_bridge.py`：已建模
+  dual-read parity、有限 canary 与事件投影晋升的 rollback 记录。
+
+## 4. 迁移阶段
+
+### Phase 0 — 契约冻结
+
+把 #3225 的候选范围固化为类型化 schema 与 parity fixture 清单：
+append-only 事件状态与幂等写入；todo 生命周期（claim、lease、status、
+revision、完成校验）；gates 与决策范围；quota（`should-run`/spend）与
+scheduler/monitor 契约；Turn envelope 与事务语义；handoff 与 review-packet
+投影；CLI 与 status/quota JSON parity。本阶段不迁移任何代码。
+
+### Phase 1 — 读路径与投影
+
+迁移 status JSON、todo list projection、handoff review-packet projection 与
+frontstage 渲染。这些是纯函数、无副作用。TypeScript 实现每个表面，Python
+生成 golden fixture；dual-read 门禁要求 TS 投影与 Python 头一致后才能对外
+服务。
+
+### Phase 2 — 确定性决策内核
+
+迁移 `quota should-run`、todo 状态迁移与 scheduler 状态迁移规则。这些是
+无 IO 的纯决策，天然适合 parity 验证。`decision_replay` 把历史输入回放给
+两个实现；只有逐字段一致才允许翻转。此阶段完成后，Pi 扩展可以去掉对
+Python quota 的依赖。
+
+### Phase 3 — 事件存储与写路径
+
+TypeScript 先作为投影读取者（dual-read），再双写并做幂等校验，最后翻转
+写路径。每一步都套用 `event_store_migration_bridge` 的 canary 与 rollback
+门禁。
+
+### Phase 4 — 分发
+
+发布 npm 包与 pip shim（或二者之一）。TypeScript CLI shim 把未迁移命令
+转发给 Python，`loopx` 的用户体验全程不变。
+
+## 5. 互调契约
+
+- 每个表面带版本化 JSON schema（`..._v0`）。
+- 请求/响应以 NDJSON 走 stdio；长驻 sidecar 可加 content-length 帧。
+- 错误用机器可读信封（code + message），不传原始 traceback。
+- 调用方设置超时，沿用现有 `LOOPX_CLI_TIMEOUT_MS` 模式。
+- 写入幂等：事件带稳定 id，重复应用是 no-op。
+- 边界上不出现凭据、原始日志或私有路径。
+
+## 6. 验证
+
+- 每个表面的 parity fixture：同一输入语料在两个实现上产生完全相同的
+  compact JSON 输出。
+- 决策回放：历史输入回放两个实现。
+- Dual-read 门禁：TS 投影服务流量前必须与 Python 头一致。
+- 有限 canary：翻转前在一小组 canary goal 上运行新路径。
+- Rollback 记录：翻转由 flag 控制，翻转前记录回滚计划。
+- CLI 输出预算继续由 `cli_output_differential` 强制。
+
+## 7. 非目标
+
+- 不做行为变更；过渡期内 Python 仍是权威实现。
+- 不做进程内嵌入（Node 内嵌 CPython，或 Python 内嵌 V8）。
+- 不以 Pyodide/WASM 作为生产运行时。
+- 不做 fork-first 迁移；上游主导、欢迎贡献。
+- 不做控制面核心的一次性全量重写。
+
+## 8. 开放问题
+
+- 运行时选择：Node.js、Bun 还是 Deno？
+- 打包/分发：npm 包、pip shim，还是两者都要？
+- TypeScript 轨道的贡献者归属与评审通道？
+- 热路径预算：哪些表面值得引入长驻 sidecar？
+- 最终共享核心是否应改为 Rust + Python/TS 薄绑定（单独 RFC）？
+
+## 9. 最小可用实现切片
+
+用 TypeScript 实现 `quota should-run` 的 compact parity 表面，与
+`quota_should_run_parity.py` 使用同一 fixture 语料，输出完全一致的 JSON。
+可选配一个读路径探针：TypeScript 的 todo list/status 投影渲染与 Python
+投影相同的事件 fixtures。这能以接近零的生产风险验证整条管线——契约、
+parity fixtures、双实现与进程边界。
+
+## 10. 上线与回滚
+
+每个块都走同一序列：双实现 → parity 门禁 → dual-read（读路径）→ 有限
+canary → flag 控制翻转 → 记录回滚计划。任何 parity 不一致都会阻止翻转。
+回滚即翻回并保留双实现，直到该块重新通过验证；用户状态不会二次迁移，
+也不会留下半迁移状态。


### PR DESCRIPTION
## Summary

Adds a formal RFC for the TypeScript migration direction of the LoopX control-plane core, following up on issue #3225.

The RFC answers the core question — "is there a seamless gradual migration path, e.g. Python and TypeScript calling each other?" — with a concrete design:

- **No in-process mutual calls.** Interop runs over a process boundary with versioned JSON contracts (stdio JSON-RPC/NDJSON); coarse-grained CLI/projection/decision calls make per-call latency acceptable.
- **Contract-first strangler migration** in four phases: contract freeze → read paths/projections → deterministic decision kernels (quota should-run, todo lifecycle, scheduler transitions) → event store and write paths last.
- **Three existing seams** make this viable today: the production TS→Python CLI boundary in `pi_goal_mode`, the `quota_should_run_parity` fixture template, and the versioned event store plus `event_store_migration_bridge` dual-read/canary/rollback gates.
- Python remains canonical during the transition; every block flips only behind a parity gate + recorded rollback plan.

Includes English and Chinese semantic mirrors, plus an entry in the RFC index.

## Checklist

- [x] Public-safe scan (no internal paths, credentials, or private context)
- [x] RFC index updated
- [x] EN + zh-CN semantic mirrors
- [x] Tracks #3225

## Validation

Docs-only change; no runtime behavior touched. Files reviewed for the public/private boundary per repository policy.