### PR TITLE
Guard accountable benchmark closeout with Todo validation

### DIFF
--- a/examples/control_plane/completion-validation-accountability-smoke.py
+++ b/examples/control_plane/completion-validation-accountability-smoke.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Keep accountable refresh and quota spend behind Todo validation authority."""
+
+from __future__ import annotations
+
+import json
+import shlex
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.quota.slot_accounting import (
+    build_quota_slot_preview_for_decision,
+)
+from loopx.control_plane.todos.active_state_todo_parser import (
+    parse_active_state_todos,
+)
+from loopx.state_refresh import refresh_state_run
+from loopx.todos import add_goal_todo, complete_goal_todo
+
+GOAL_ID = "completion-validation-accountability"
+AGENT_ID = "codex-author"
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path]:
+    project = root / "project"
+    project.mkdir()
+    state = project / "ACTIVE_GOAL_STATE.md"
+    state.write_text(
+        "\n".join(
+            [
+                "---",
+                f"goal_id: {GOAL_ID}",
+                "status: active",
+                "updated_at: 2026-08-15T00:00:00+00:00",
+                "---",
+                "",
+                "## Agent Todo",
+                "",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    runtime = root / "runtime"
+    registry = root / "registry.global.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "benchmark_runner",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": state.name,
+                        "adapter": {"kind": "accountability_smoke_v0"},
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": [AGENT_ID],
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return registry, runtime, state
+
+
+def agent_summary(state: Path) -> dict:
+    return parse_active_state_todos(
+        state.read_text(encoding="utf-8"),
+        item_limit=None,
+    )["agent_todos"]
+
+
+def quota_preview(
+    *,
+    runtime: Path,
+    summary: dict,
+    todo_id: str,
+) -> dict:
+    selected = next(item for item in summary["items"] if item["todo_id"] == todo_id)
+    before = {
+        "ok": True,
+        "goal_id": GOAL_ID,
+        "should_run": True,
+        "state": "eligible",
+        "effective_action": "normal_run",
+        "normal_delivery_allowed": True,
+        "selected_todo": selected,
+        "workspace_repair_allowed": False,
+        "safe_bypass_allowed": False,
+        "recovery_delivery_allowed": False,
+        "self_repair_allowed": False,
+        "capability_repair_allowed": False,
+        "quota": {
+            "compute": 1.0,
+            "window_hours": 24,
+            "slot_minutes": 1,
+            "allowed_slots": 10,
+            "spent_slots": 0,
+        },
+    }
+    after = {**before, "quota": {**before["quota"], "spent_slots": 1}}
+    return build_quota_slot_preview_for_decision(
+        {
+            "runtime_root": str(runtime),
+            "attention_queue": {
+                "items": [{"goal_id": GOAL_ID, "agent_todos": summary}]
+            },
+        },
+        goal_id=GOAL_ID,
+        before=before,
+        after_decision=lambda _status: after,
+        quota_status_builder=lambda goal, **_kwargs: goal["quota"],
+        self_repair_spend_actions=frozenset(),
+        agent_id=AGENT_ID,
+        todo_id=todo_id,
+    )
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(
+        prefix="loopx-completion-validation-accountability-"
+    ) as tmp:
+        root = Path(tmp)
+        registry, runtime, state = write_fixture(root)
+        independent_result = root / "controller-result.complete"
+        validation_command = (
+            f"{shlex.quote(sys.executable)} -c "
+            + shlex.quote(
+                "from pathlib import Path; import sys; "
+                f"sys.exit(0 if Path({str(independent_result)!r}).is_file() else 1)"
+            )
+        )
+        added = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text="Close out one independently verified benchmark result.",
+            task_class="advancement_task",
+            action_kind="benchmark_result_closeout",
+            claimed_by=AGENT_ID,
+            validation_command=validation_command,
+            validation_label="independent runner result complete",
+        )
+        todo_id = str(added["todo_id"])
+
+        open_summary = agent_summary(state)
+        projected = next(
+            item for item in open_summary["items"] if item["todo_id"] == todo_id
+        )
+        assert projected["completion_validation_required"] is True, projected
+        serialized_projection = json.dumps(open_summary)
+        assert str(independent_result) not in serialized_projection
+        assert "validation_command" not in serialized_projection
+        assert "validation_label" not in serialized_projection
+
+        try:
+            refresh_state_run(
+                registry_path=registry,
+                runtime_root_override=str(runtime),
+                goal_id=GOAL_ID,
+                project=None,
+                state_file=None,
+                classification="provisional_benchmark_reward",
+                recommended_action="wait for the independent runner result",
+                delivery_batch_scale="implementation",
+                delivery_outcome="outcome_progress",
+                agent_id=AGENT_ID,
+                progress_scope="agent_lane",
+                dry_run=False,
+                sync_global=False,
+            )
+        except ValueError as exc:
+            assert "completion validation" in str(exc), exc
+        else:
+            raise AssertionError("provisional reward became accountable")
+        assert not (runtime / "goals" / GOAL_ID / "runs" / "index.jsonl").exists()
+
+        blocked_spend = quota_preview(
+            runtime=runtime,
+            summary=open_summary,
+            todo_id=todo_id,
+        )
+        assert blocked_spend["ok"] is False, blocked_spend
+        assert "completion validation" in blocked_spend["reason"], blocked_spend
+
+        blocked_completion = complete_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=todo_id,
+            agent_id=AGENT_ID,
+            evidence="provisional agent-side verifier result",
+        )
+        assert blocked_completion["validation_blocked_completion"] is True
+
+        independent_result.write_text("complete\n", encoding="utf-8")
+        completed = complete_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=todo_id,
+            agent_id=AGENT_ID,
+            evidence="independent runner result complete",
+            no_followup=True,
+        )
+        assert completed["ok"] is True, completed
+        assert completed["changed"] is True, completed
+
+        done_summary = agent_summary(state)
+        durable = next(
+            item for item in done_summary["items"] if item["todo_id"] == todo_id
+        )
+        assert durable["status"] == "done", durable
+        assert durable["completion_validation_required"] is True, durable
+
+        refreshed = refresh_state_run(
+            registry_path=registry,
+            runtime_root_override=str(runtime),
+            goal_id=GOAL_ID,
+            project=None,
+            state_file=None,
+            classification="independent_benchmark_reward_validated",
+            recommended_action="inspect the next bounded benchmark action",
+            delivery_batch_scale="implementation",
+            delivery_outcome="outcome_progress",
+            agent_id=AGENT_ID,
+            progress_scope="agent_lane",
+            agent_vision_packet={
+                "state": "active",
+                "vision_summary": "Independent runner result is authoritative.",
+            },
+            dry_run=False,
+            sync_global=False,
+        )
+        assert refreshed["appended"] is True, refreshed
+
+        allowed_spend = quota_preview(
+            runtime=runtime,
+            summary=done_summary,
+            todo_id=todo_id,
+        )
+        assert allowed_spend["ok"] is True, allowed_spend
+
+    print("completion-validation-accountability-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/control_plane/goals/vision_checkpoint.py
+++ b/loopx/control_plane/goals/vision_checkpoint.py
@@ -1,0 +1,92 @@
+"""Agent-vision checkpoint contract for accountable state refreshes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...feedback import validate_public_safe_text
+
+VISION_CHECKPOINT_SCHEMA_VERSION = "vision_checkpoint_v0"
+VISION_CHECKPOINT_MATERIAL_OUTCOMES = {
+    "outcome_gap",
+    "outcome_progress",
+    "primary_goal_outcome",
+}
+VISION_UNCHANGED_REASON_LIMIT = 240
+
+
+def normalize_vision_unchanged_reason(value: str | None) -> str:
+    """Normalize and validate a vision closeout reason before state mutation."""
+
+    unchanged = " ".join(str(value or "").strip().split())
+    if not unchanged:
+        return ""
+    validate_public_safe_text("vision_unchanged_reason", unchanged)
+    if len(unchanged) > VISION_UNCHANGED_REASON_LIMIT:
+        raise ValueError(
+            "vision_unchanged_reason exceeds "
+            f"{VISION_UNCHANGED_REASON_LIMIT} chars"
+        )
+    return unchanged
+
+
+def build_vision_checkpoint(
+    *,
+    agent_id: str | None,
+    agent_vision: dict[str, Any] | None,
+    existing_agent_vision: dict[str, Any] | None,
+    vision_unchanged_reason: str | None,
+    delivery_outcome: str | None,
+    active_state_next_action_update: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Return the explicit vision closeout decision for this refresh run."""
+
+    triggers: list[dict[str, Any]] = []
+    if delivery_outcome in VISION_CHECKPOINT_MATERIAL_OUTCOMES:
+        triggers.append(
+            {
+                "kind": "material_delivery_outcome",
+                "delivery_outcome": delivery_outcome,
+            }
+        )
+    if active_state_next_action_update and active_state_next_action_update.get(
+        "would_update"
+    ):
+        triggers.append({"kind": "durable_next_action_update"})
+
+    unchanged = normalize_vision_unchanged_reason(vision_unchanged_reason)
+    required = bool(triggers or unchanged)
+    if agent_vision:
+        decision = "patched"
+        satisfied = True
+    elif unchanged and existing_agent_vision:
+        decision = "unchanged_with_reason"
+        satisfied = True
+    elif unchanged or required:
+        decision = "missing_required"
+        satisfied = False
+    else:
+        decision = "not_required"
+        satisfied = True
+
+    checkpoint: dict[str, Any] = {
+        "schema_version": VISION_CHECKPOINT_SCHEMA_VERSION,
+        "agent_id": agent_id,
+        "required": required,
+        "satisfied": satisfied,
+        "decision": decision,
+        "triggers": triggers,
+    }
+    if agent_vision:
+        checkpoint["agent_vision_state"] = agent_vision.get("state")
+    if unchanged and existing_agent_vision:
+        checkpoint["unchanged_reason"] = unchanged
+        checkpoint["agent_vision_state"] = existing_agent_vision.get("state")
+    elif unchanged:
+        checkpoint["missing_baseline"] = True
+        checkpoint["rejected_unchanged_reason"] = unchanged
+    if not satisfied:
+        checkpoint["required_resolution"] = ["write_vision_patch"]
+        if not checkpoint.get("missing_baseline"):
+            checkpoint["required_resolution"].append("record_unchanged_reason")
+    return checkpoint

--- a/loopx/control_plane/quota/settlement_validation.py
+++ b/loopx/control_plane/quota/settlement_validation.py
@@ -1,0 +1,64 @@
+"""Todo validation authority checks for quota settlement."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..todos.completion_validation_projection import (
+    pending_completion_validation_todo,
+)
+from ..todos.contract import normalize_todo_id
+
+
+def completion_validation_spend_error(
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+    todo_id: str | None,
+    agent_id: str | None,
+    selected_todo: dict[str, Any] | None,
+) -> str | None:
+    """Explain why one requested settlement still lacks validation authority."""
+
+    normalized_todo_id = normalize_todo_id(todo_id)
+    if not normalized_todo_id:
+        return None
+    summaries: list[dict[str, Any]] = []
+    if (
+        selected_todo
+        and normalize_todo_id(selected_todo.get("todo_id")) == normalized_todo_id
+    ):
+        summaries.append({"items": [selected_todo]})
+    queue = status_payload.get("attention_queue")
+    queue_items = queue.get("items") if isinstance(queue, dict) else []
+    queue_item = next(
+        (
+            item
+            for item in queue_items if isinstance(queue_items, list)
+            if isinstance(item, dict) and item.get("goal_id") == goal_id
+        ),
+        {},
+    )
+    project_asset = (
+        queue_item.get("project_asset")
+        if isinstance(queue_item.get("project_asset"), dict)
+        else {}
+    )
+    for owner in (queue_item, project_asset):
+        summary = owner.get("agent_todos")
+        if isinstance(summary, dict):
+            summaries.append(summary)
+    if any(
+        pending_completion_validation_todo(
+            summary,
+            todo_id=normalized_todo_id,
+            agent_id=agent_id,
+        )
+        is not None
+        for summary in summaries
+    ):
+        return (
+            "quota spend is blocked until controller-declared completion "
+            f"validation durably completes todo {normalized_todo_id}"
+        )
+    return None

--- a/loopx/control_plane/quota/slot_accounting.py
+++ b/loopx/control_plane/quota/slot_accounting.py
@@ -33,6 +33,7 @@ from .settlement import (
     settlement_result_payload,
 )
 from .settlement_workspace_causality import completed_todo_workspace_causality
+from .settlement_validation import completion_validation_spend_error
 from .spend_sources import DEFAULT_SLOT_SPEND_SOURCE, VALID_SLOT_SPEND_SOURCES
 
 QUOTA_SLOT_SPENT_CLASSIFICATION = "quota_slot_spent"
@@ -45,10 +46,18 @@ QuotaStatusBuilder = Callable[..., dict[str, Any]]
 def _todo_binding_error(
     *,
     source: str,
+    status_payload: dict[str, Any],
+    goal_id: str,
     before: dict[str, Any],
     requested_todo_id: str | None,
+    agent_id: str | None,
     settlement_identity: SettlementIdentity | None = None,
 ) -> str | None:
+    selected = (
+        before.get("selected_todo")
+        if isinstance(before.get("selected_todo"), dict)
+        else {}
+    )
     if settlement_identity is not None:
         if requested_todo_id != settlement_identity.todo_id:
             return (
@@ -56,8 +65,13 @@ def _todo_binding_error(
                 f"expected {settlement_identity.todo_id} but received "
                 f"{requested_todo_id or 'missing'}"
             )
-        return None
-    selected = before.get("selected_todo") if isinstance(before.get("selected_todo"), dict) else {}
+        return completion_validation_spend_error(
+            status_payload,
+            goal_id=goal_id,
+            todo_id=requested_todo_id,
+            agent_id=agent_id,
+            selected_todo=selected,
+        )
     selected_todo_id = normalize_todo_id(selected.get("todo_id"))
     if requested_todo_id and selected_todo_id and requested_todo_id != selected_todo_id:
         return (
@@ -75,7 +89,13 @@ def _todo_binding_error(
             f"quota spend requires --todo-id {selected_todo_id} for heartbeat "
             "delivery so the accounted turn is bound to the selected todo"
         )
-    return None
+    return completion_validation_spend_error(
+        status_payload,
+        goal_id=goal_id,
+        todo_id=requested_todo_id,
+        agent_id=agent_id,
+        selected_todo=selected,
+    )
 
 
 def _resolve_preview_settlement(
@@ -369,8 +389,11 @@ def build_quota_slot_preview_for_decision(
         }
     binding_error = _todo_binding_error(
         source=source,
+        status_payload=status_payload,
+        goal_id=safe_goal_id,
         before=before,
         requested_todo_id=normalized_todo_id,
+        agent_id=safe_requested_agent_id,
         settlement_identity=settlement_identity,
     )
     if binding_error:

--- a/loopx/control_plane/todos/completion_validation_accountability.py
+++ b/loopx/control_plane/todos/completion_validation_accountability.py
@@ -1,0 +1,27 @@
+"""Accountable refresh fence for controller-validated Todos."""
+
+from __future__ import annotations
+
+from .active_state_todo_parser import parse_active_state_todos
+from .completion_validation_projection import pending_completion_validation_todo
+
+
+def require_accountable_completion_validation(
+    state_text: str,
+    *,
+    todo_id: str | None,
+    agent_id: str | None,
+) -> None:
+    """Reject accountable evidence while its exact validation Todo is open."""
+
+    summary = parse_active_state_todos(state_text, item_limit=None).get("agent_todos")
+    pending = pending_completion_validation_todo(
+        summary,
+        todo_id=todo_id,
+        agent_id=agent_id,
+    )
+    if pending is not None:
+        raise ValueError(
+            "accountable refresh is blocked until controller-declared completion "
+            f"validation durably completes todo {pending.get('todo_id')}"
+        )

--- a/loopx/control_plane/todos/completion_validation_projection.py
+++ b/loopx/control_plane/todos/completion_validation_projection.py
@@ -1,0 +1,57 @@
+"""Public-safe projection for controller-declared Todo completion validation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .contract import (
+    TODO_STATUS_DONE,
+    normalize_todo_claimed_by,
+    normalize_todo_id,
+)
+
+
+def project_completion_validation_authority(item: dict[str, Any]) -> dict[str, Any]:
+    """Replace private validation execution details with one authority marker."""
+
+    projected = dict(item)
+    required = bool(str(projected.pop("validation_command", "") or "").strip())
+    projected.pop("validation_label", None)
+    projected.pop("validation_timeout_seconds", None)
+    if required:
+        projected["completion_validation_required"] = True
+    return projected
+
+
+def pending_completion_validation_todo(
+    todo_summary: dict[str, Any] | None,
+    *,
+    todo_id: str | None = None,
+    agent_id: str | None = None,
+) -> dict[str, Any] | None:
+    """Return a projected open Todo whose controller validation is required."""
+
+    if not isinstance(todo_summary, dict):
+        return None
+    expected_todo_id = normalize_todo_id(todo_id)
+    expected_agent_id = normalize_todo_claimed_by(agent_id)
+    items = todo_summary.get("items")
+    for item in items if isinstance(items, list) else []:
+        if not isinstance(item, dict):
+            continue
+        item_todo_id = normalize_todo_id(item.get("todo_id"))
+        if expected_todo_id and item_todo_id != expected_todo_id:
+            continue
+        item_agent_id = normalize_todo_claimed_by(item.get("claimed_by"))
+        if (
+            expected_agent_id
+            and item_agent_id
+            and item_agent_id != expected_agent_id
+        ):
+            continue
+        if item.get("completion_validation_required") is not True:
+            continue
+        if item.get("done") is True or item.get("status") == TODO_STATUS_DONE:
+            continue
+        return item
+    return None

--- a/loopx/control_plane/todos/todo_summary.py
+++ b/loopx/control_plane/todos/todo_summary.py
@@ -43,6 +43,7 @@ from .contract import (
     normalize_todo_task_class,
     todo_done_for_status,
 )
+from .completion_validation_projection import project_completion_validation_authority
 from .handoff_gate import build_todo_handoff_gate_states
 from .handoff_note import attach_todo_handoff_note
 from .projection import (
@@ -331,7 +332,7 @@ def structured_todo_item(
         index=index,
         text=text,
     )
-    normalized = dict(item)
+    normalized = project_completion_validation_authority(item)
     normalized.update(
         {
             "schema_version": TODO_ITEM_SCHEMA_VERSION,
@@ -497,6 +498,7 @@ def compact_todo_item(item: dict[str, Any]) -> dict[str, Any]:
         "completed_at",
         "updated_at",
         "superseded_by",
+        "completion_validation_required",
     ):
         if item.get(key) is not None:
             compact[key] = item.get(key)

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -62,6 +62,10 @@ from .history import (
 from .control_plane.runtime.local_state_write_correctness import build_local_state_write_correctness_dry_run_packet
 from .paths import resolve_runtime_root
 from .control_plane.goals.goal_vision import normalize_goal_vision_update
+from .control_plane.goals.vision_checkpoint import (
+    build_vision_checkpoint,
+    normalize_vision_unchanged_reason,
+)
 from .control_plane.goals.goal_frontier import latest_agent_vision_from_runs
 from .registry import registry_goals, resolve_state_file
 from .runtime import validate_goal_id_path_segment
@@ -74,6 +78,9 @@ from .control_plane.todos.contract import (
     normalize_todo_claimed_by,
 )
 from .control_plane.todos.active_state_todo_parser import parse_active_state_todos
+from .control_plane.todos.completion_validation_accountability import (
+    require_accountable_completion_validation,
+)
 
 DEFAULT_REFRESH_CLASSIFICATION = "state_refreshed"
 DEFAULT_REFRESH_ACTION = "inspect refreshed active goal state and continue the next bounded progress segment"
@@ -89,13 +96,6 @@ BULLET_PREFIX_RE = re.compile(r"^(?:[-*]\s+|\d+[.)]\s+)")
 CHECKBOX_PREFIX_RE = re.compile(r"^\[(?P<mark>[ xX])\]\s+")
 ACTIVE_STATE_NEXT_ACTION_UPDATE_SCHEMA_VERSION = "active_state_next_action_update_v0"
 REPAIR_NOOP_SCHEMA_VERSION = "repair_noop_v0"
-VISION_CHECKPOINT_SCHEMA_VERSION = "vision_checkpoint_v0"
-VISION_CHECKPOINT_MATERIAL_OUTCOMES = {
-    "outcome_gap",
-    "outcome_progress",
-    "primary_goal_outcome",
-}
-VISION_UNCHANGED_REASON_LIMIT = 240
 
 
 def now_local() -> str:
@@ -201,85 +201,6 @@ def _noop_classification_for(classification: str) -> str:
     if "repair" in normalized and "replan" not in normalized:
         return "repair_noop"
     return "replan_noop"
-
-
-def build_vision_checkpoint(
-    *,
-    agent_id: str | None,
-    agent_vision: dict[str, Any] | None,
-    existing_agent_vision: dict[str, Any] | None,
-    vision_unchanged_reason: str | None,
-    delivery_outcome: str | None,
-    active_state_next_action_update: dict[str, Any] | None,
-) -> dict[str, Any]:
-    """Return the explicit vision closeout decision for this refresh run."""
-
-    triggers: list[dict[str, Any]] = []
-    if delivery_outcome in VISION_CHECKPOINT_MATERIAL_OUTCOMES:
-        triggers.append(
-            {
-                "kind": "material_delivery_outcome",
-                "delivery_outcome": delivery_outcome,
-            }
-        )
-    if active_state_next_action_update and active_state_next_action_update.get("would_update"):
-        triggers.append({"kind": "durable_next_action_update"})
-
-    unchanged = normalize_vision_unchanged_reason(vision_unchanged_reason)
-
-    required = bool(triggers or unchanged)
-    if agent_vision:
-        decision = "patched"
-        satisfied = True
-    elif unchanged and existing_agent_vision:
-        decision = "unchanged_with_reason"
-        satisfied = True
-    elif unchanged:
-        decision = "missing_required"
-        satisfied = False
-    elif required:
-        decision = "missing_required"
-        satisfied = False
-    else:
-        decision = "not_required"
-        satisfied = True
-
-    checkpoint: dict[str, Any] = {
-        "schema_version": VISION_CHECKPOINT_SCHEMA_VERSION,
-        "agent_id": agent_id,
-        "required": required,
-        "satisfied": satisfied,
-        "decision": decision,
-        "triggers": triggers,
-    }
-    if agent_vision:
-        checkpoint["agent_vision_state"] = agent_vision.get("state")
-    if unchanged and existing_agent_vision:
-        checkpoint["unchanged_reason"] = unchanged
-        checkpoint["agent_vision_state"] = existing_agent_vision.get("state")
-    elif unchanged:
-        checkpoint["missing_baseline"] = True
-        checkpoint["rejected_unchanged_reason"] = unchanged
-    if not satisfied:
-        checkpoint["required_resolution"] = ["write_vision_patch"]
-        if not checkpoint.get("missing_baseline"):
-            checkpoint["required_resolution"].append("record_unchanged_reason")
-    return checkpoint
-
-
-def normalize_vision_unchanged_reason(value: str | None) -> str:
-    """Normalize and validate a vision closeout reason before state mutation."""
-
-    unchanged = " ".join(str(value or "").strip().split())
-    if not unchanged:
-        return ""
-    validate_public_safe_text("vision_unchanged_reason", unchanged)
-    if len(unchanged) > VISION_UNCHANGED_REASON_LIMIT:
-        raise ValueError(
-            "vision_unchanged_reason exceeds "
-            f"{VISION_UNCHANGED_REASON_LIMIT} chars"
-        )
-    return unchanged
 
 
 def next_action_section_bounds(lines: list[str]) -> tuple[int, int] | None:
@@ -1052,6 +973,12 @@ def refresh_state_run(
         raise FileNotFoundError(f"state file does not exist: {resolved_state_file}")
     state_text = resolved_state_file.read_text(encoding="utf-8")
     expected_write_state_text = state_text
+    if normalized_delivery_outcome in ACCOUNTABLE_DELIVERY_OUTCOMES:
+        require_accountable_completion_validation(
+            state_text,
+            todo_id=(settlement_identity.todo_id if settlement_identity else None),
+            agent_id=normalized_agent_id or None,
+        )
     normalized_next_action = normalize_next_action_text(next_action) if next_action else None
     registered_agents = registered_agents_for_goal(registry_goal)
     known_agents = {agent for agent in registered_agents if agent}


### PR DESCRIPTION
## Motivation and failure mode

A validation-gated benchmark closeout has three distinct milestones:

1. an agent produces provisional local evidence;
2. the declared independent validation completes; and
3. LoopX records accountable progress and settles quota.

Before this change, the existing Todo validation gate protected milestone 2, but `refresh-state` and quota settlement were separate write paths. That meant provisional evidence from milestone 1 could be promoted to an accountable outcome at milestone 3 before the independent validation had completed. A later matching result would not repair that authority and ordering error; a failure or mismatch would leave evidence that had already been counted.

This is a generic control-plane invariant, not a runner-specific workaround. Fixing only one benchmark adapter would leave every other validation-gated Todo exposed to the same refresh and quota paths.

## Invariant

For any Todo that declares completion validation, accountable refresh and quota settlement must fail closed until completion is durable through the existing validation gate. Public projection exposes only the boolean marker `completion_validation_required`; the command, label, timeout, credentials, and local paths remain private.

## What changed

- Project controller-declared Todo validation as a public-safe authority marker while keeping its private configuration out of projection.
- Reject accountable `refresh-state` evidence while the bound validation Todo is still open.
- Reject quota settlement for the same Todo until its validation-gated completion is durable.
- Move the existing vision-checkpoint rules into their goals bounded context so the hot refresh module shrinks instead of accumulating more control-plane logic.
- Add a focused end-to-end smoke covering provisional evidence rejection, completion rejection, independent-result acceptance, and post-validation refresh/spend.

## Compatibility and non-goals

Existing Todos without completion validation keep their current behavior. This change does not alter benchmark scoring, task semantics, runner commands, or case selection, and it does not launch jobs, upload artifacts, or submit results.

## Validation

- `73 passed` across Todo completion validation, quota slot accounting, state refresh projections/replan, and CLI output-budget tests.
- `completion-validation-accountability-smoke.py`: passed.
- `quota-spend-workspace-causality-smoke.py`: passed.
- control-plane maintainability ratchet: passed with no new debt or exceptions.
- Ruff checks for new modules/smoke and fatal checks for touched legacy modules: passed.
- Public/private boundary scan: clean across all 8 changed files.
- Standard premerge canary: direct checks passed; 17/18 selected checks passed. The sole failure, `monitor-scheduler-contract-smoke.py`, reproduces unchanged on exact `origin/main` (`38719201`) and is unrelated to this diff.

The canary gate remains red because of the reproduced default-branch failure, so this PR is intentionally draft and must not self-merge.
