### PR TITLE
docs(policy): tighten public change-request boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,26 @@ references. If such context was already pushed, stop normal delivery, run
 LoopX self-repair, clean the current public heads, and record any remaining
 PR-ref or cached-view cleanup as an explicit user/support gate.
 
+Treat every surface of a public change request as public content, including its
+title, description, source branch, commit subjects and bodies, reviews,
+comments, check annotations, changed-path names, screenshots, and linked
+artifacts. Before pushing, opening, reviewing, or updating one, scan the exact
+candidate diff and the metadata that will be published for private platform or
+benchmark codenames, organization or person identities, private hosts and
+repositories, internal links, credentials, and local operating context. A name
+being present in an ignored local artifact or private upstream does not grant
+permission to repeat it on a public surface.
+
+Generalize private implementation provenance into provider-neutral product or
+host language. Keep exact private term mappings and denylists only in ignored
+owner-local state; public policy, fixtures, and cleanup descriptions must state
+the reusable boundary without reproducing the private terms. If private context
+has already reached a public change request, immediately sanitize every mutable
+surface without quoting the term in the cleanup change. Record immutable paths,
+commit history, provider caches, or third-party copies as an explicit
+owner/support cleanup gate rather than pretending that a metadata edit erased
+them.
+
 ## PR Review Comments
 
 When the user asks the agent to review a GitHub PR, treat PR feedback as a


### PR DESCRIPTION
## Summary

- Treat every public change-request surface as public content, including review metadata and changed-path names.
- Require an exact diff and publication-metadata scan before push, open, review, or update operations.
- Keep private term mappings in ignored owner-local state and publish only provider-neutral language.
- Define immediate cleanup for mutable remote metadata and an explicit support gate for immutable history or caches.

## Why

The existing boundary covered committed content and mentioned change-request descriptions, but it did not enumerate the wider publication surface. Private provenance can also escape through branch names, commit messages, reviews, comments, check annotations, filenames, screenshots, and links. This makes the boundary explicit and gives already-published material a fail-closed cleanup path.

## Validation

- `git diff --check`: passed.
- `loopx check --scan-path AGENTS.md`: public boundary clean; only unrelated global-state warnings.
- `loopx canary premerge --from-git-diff`: passed, 9/9 selected checks.
- Candidate diff and PR metadata draft scanned for private hosts, identities, codenames, credentials, local paths, and raw operating artifacts: clean.

This is a policy-only change. It does not change runtime, benchmark, scoring, permission, or submission behavior. Because it changes the public evidence policy, it is intentionally left for separate review rather than self-merged.
