### PR TITLE
fix(codex-app): isolate fallback receipt identity

### DIFF
--- a/docs/heartbeat-automation-prompt.md
+++ b/docs/heartbeat-automation-prompt.md
@@ -546,7 +546,10 @@ If `automation_update` is unavailable in the session and
 `fallback_hint.cli_args` (`loopx-apply-rrule`) once instead. It backs up
 `codex-dev.db`, syncs the automation TOML and SQLite row, and runs the bound
 ACK; direct SQLite edits bypass the app API, so this is a bounded fallback and
-never the routine path. When the automation id could not be resolved,
+never the routine path. The bridge treats the provided turn id as its parent
+and derives a stable child receipt id for the internal quota query, so it does
+not reuse the already-settled heartbeat receipt. When the automation id could
+not be resolved,
 `fallback_hint.available=false` and the pasteable heartbeat gate is the correct
 stop - never guess an automation id.
 

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -179,6 +179,9 @@ def main() -> int:
         stale_loopx = bin_dir / "loopx"
         stale_loopx.write_text("#!/usr/bin/env bash\nexit 99\n", encoding="utf-8")
         stale_loopx.chmod(0o755)
+        stale_fallback = bin_dir / "loopx-apply-rrule"
+        stale_fallback.write_text("#!/usr/bin/env bash\nexit 98\n", encoding="utf-8")
+        stale_fallback.chmod(0o755)
         stale_canary_target = root / "stale-canary-target"
         stale_canary_target.mkdir()
         (bin_dir / "loopx-canary").symlink_to(stale_canary_target)
@@ -226,6 +229,10 @@ def main() -> int:
         assert "non-blocking" in install.stderr, install.stderr
         assert "examples/canary/canary-promotion-readiness-smoke.py" in install.stderr, install.stderr
         assert f"- executable: {bin_dir / 'loopx'}" in install.stdout, install.stdout
+        assert (
+            f"- Codex App fallback executable: {bin_dir / 'loopx-apply-rrule'}"
+            in install.stdout
+        ), install.stdout
         assert "- release: " in install.stdout, install.stdout
         assert f"- canary executable: {bin_dir / 'loopx-canary'}" in install.stdout, install.stdout
         assert "- executable compatibility: none" in install.stdout, install.stdout
@@ -255,11 +262,25 @@ def main() -> int:
 
         wrapper = bin_dir / "loopx"
         assert wrapper.is_symlink(), wrapper
+        fallback_wrapper = bin_dir / "loopx-apply-rrule"
+        assert fallback_wrapper.is_symlink(), fallback_wrapper
         assert not (bin_dir / "goal-harness").exists()
         assert (bin_dir / "goal-harness.legacy-disabled").is_symlink()
         assert wrapper.resolve() != REPO_ROOT / "scripts" / "loopx", wrapper.resolve()
         assert wrapper.resolve().name == "loopx", wrapper.resolve()
         release_root = wrapper.resolve().parents[1]
+        assert fallback_wrapper.resolve() == (
+            release_root / "scripts" / "loopx-apply-rrule"
+        ), fallback_wrapper.resolve()
+        fallback_help = subprocess.run(
+            [str(fallback_wrapper), "--help"],
+            cwd=root,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert "outer host turn identity" in fallback_help.stdout, fallback_help.stdout
         release_python = release_root / ".loopx-python"
         assert release_python.read_text(encoding="utf-8").strip() == sys.executable
         assert (release_root / "loopx" / "cli.py").is_file(), release_root

--- a/scripts/codex_app_apply_rrule.py
+++ b/scripts/codex_app_apply_rrule.py
@@ -19,6 +19,7 @@ overridden for tests or alternate installations.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import re
 import sqlite3
@@ -28,9 +29,47 @@ import time
 from pathlib import Path
 from typing import Any
 
+from loopx.turn_identity import normalize_turn_instance_id
+
+
+_FAILURE_OUTPUT_LIMIT = 2_000
+
 
 def _now_ms() -> int:
     return int(time.time() * 1000)
+
+
+def _bounded_failure_output(value: str) -> str:
+    output = value.strip()
+    if len(output) <= _FAILURE_OUTPUT_LIMIT:
+        return output
+    half = (_FAILURE_OUTPUT_LIMIT - len(" ... ")) // 2
+    return f"{output[:half]} ... {output[-half:]}"
+
+
+def _subprocess_failure_detail(completed: subprocess.CompletedProcess[str]) -> str:
+    details = []
+    for label, value in (
+        ("stdout", completed.stdout),
+        ("stderr", completed.stderr),
+    ):
+        bounded = _bounded_failure_output(value or "")
+        if bounded:
+            details.append(f"{label}={bounded}")
+    return "; ".join(details) or "no diagnostic output"
+
+
+def _scheduler_hint_turn_instance_id(parent_turn_instance_id: str) -> str:
+    """Derive one replay-safe child receipt identity for the fallback query."""
+
+    try:
+        normalized = normalize_turn_instance_id(parent_turn_instance_id)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    if not normalized:
+        raise SystemExit("--turn-instance-id must not be empty")
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:24]
+    return f"apply-rrule:{digest}"
 
 
 def _load_registry_goal(registry: Path, goal_id: str) -> dict[str, Any]:
@@ -77,7 +116,7 @@ def _heartbeat_task_body(
     if completed.returncode != 0:
         raise SystemExit(
             f"loopx heartbeat-prompt failed ({completed.returncode}): "
-            f"{completed.stderr[-500:]}"
+            f"{_subprocess_failure_detail(completed)}"
         )
     try:
         payload = json.loads(completed.stdout)
@@ -283,9 +322,10 @@ def _load_scheduler_hint(
     registry: Path,
     goal_id: str,
     agent_id: str,
-    turn_instance_id: str,
+    parent_turn_instance_id: str,
     capabilities: list[str],
 ) -> tuple[dict[str, Any], dict[str, Any]]:
+    turn_instance_id = _scheduler_hint_turn_instance_id(parent_turn_instance_id)
     command = [
         loopx,
         "--format",
@@ -313,7 +353,7 @@ def _load_scheduler_hint(
     if completed.returncode != 0:
         raise SystemExit(
             f"loopx should-run failed ({completed.returncode}): "
-            f"{completed.stderr[-500:]}"
+            f"{_subprocess_failure_detail(completed)}"
         )
     try:
         payload = json.loads(completed.stdout)
@@ -383,7 +423,7 @@ def _run_ack(loopx: str, ack_args: list[str]) -> None:
     if completed.returncode != 0:
         raise SystemExit(
             f"loopx scheduler ACK failed ({completed.returncode}): "
-            f"{completed.stderr[-500:]}"
+            f"{_subprocess_failure_detail(completed)}"
         )
 
 
@@ -421,6 +461,10 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--turn-instance-id",
         default=f"apply-rrule-{_now_ms()}",
+        help=(
+            "outer host turn identity; the bridge derives a stable child identity "
+            "for its internal quota query"
+        ),
     )
     parser.add_argument("--dry-run", action="store_true")
     return parser.parse_args(argv)
@@ -433,7 +477,7 @@ def main(argv: list[str] | None = None) -> int:
         registry=args.registry,
         goal_id=args.goal_id,
         agent_id=args.agent_id,
-        turn_instance_id=args.turn_instance_id,
+        parent_turn_instance_id=args.turn_instance_id,
         capabilities=args.capability,
     )
     apply_needed = stateful.get("apply_needed") is True

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -512,6 +512,11 @@ validate_release_candidate() {
     echo "loopx installer error: release candidate is missing an executable wrapper" >&2
     return 1
   fi
+  local fallback_wrapper="$candidate/scripts/loopx-apply-rrule"
+  if [[ ! -x "$fallback_wrapper" ]]; then
+    echo "loopx installer error: release candidate is missing the executable Codex App fallback wrapper" >&2
+    return 1
+  fi
 
   local doctor_json
   if ! doctor_json="$(PATH="$candidate/scripts:$PATH" "$candidate_wrapper" --format json doctor --deep)"; then
@@ -685,7 +690,7 @@ PYTHONPATH="$release_tmp" "${LOOPX_PYTHON:-python3}" \
     --source-root "$repo_root" \
     --installed-at "$installed_at"
 )
-chmod +x "$release_tmp/scripts/loopx"
+chmod +x "$release_tmp/scripts/loopx" "$release_tmp/scripts/loopx-apply-rrule"
 mv "$release_tmp" "$release_dir"
 release_tmp=""
 if ! validate_release_candidate "$release_dir"; then
@@ -697,6 +702,7 @@ if ! preflight_workflow_skills "$release_dir/skills" "$release_dir" "$bin_dir/lo
   exit 1
 fi
 install_symlink "$release_dir/scripts/loopx" "$bin_dir/loopx"
+install_symlink "$release_dir/scripts/loopx-apply-rrule" "$bin_dir/loopx-apply-rrule"
 verify_default_promotion
 
 canary_line="- canary executable: skipped"
@@ -842,6 +848,7 @@ fi
 cat <<EOF
 loopx installed locally
 - executable: $bin_dir/loopx
+- Codex App fallback executable: $bin_dir/loopx-apply-rrule
 - release: $release_dir
 - promotion mode: $promotion_mode
 - manual root: $man_root

--- a/scripts/loopx-apply-rrule
+++ b/scripts/loopx-apply-rrule
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_path="${BASH_SOURCE[0]}"
+while [[ -L "$script_path" ]]; do
+  script_dir="$(cd -P "$(dirname "$script_path")" && pwd)"
+  script_path="$(readlink "$script_path")"
+  if [[ "$script_path" != /* ]]; then
+    script_path="$script_dir/$script_path"
+  fi
+done
+script_dir="$(cd -P "$(dirname "$script_path")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+
+python_bin="${LOOPX_PYTHON:-}"
+if [[ -z "$python_bin" && -f "$repo_root/.loopx-python" ]]; then
+  IFS= read -r python_bin <"$repo_root/.loopx-python"
+fi
+if [[ -z "$python_bin" ]]; then
+  python_bin="python3"
+fi
+if ! command -v "$python_bin" >/dev/null 2>&1; then
+  echo "loopx runtime error: configured Python executable not found: $python_bin" >&2
+  echo "Set LOOPX_PYTHON to Python 3.11+ and reinstall LoopX." >&2
+  exit 2
+fi
+
+export PYTHONPATH="$repo_root${PYTHONPATH:+:$PYTHONPATH}"
+exec "$python_bin" "$repo_root/scripts/codex_app_apply_rrule.py" "$@"

--- a/tests/test_codex_app_apply_rrule.py
+++ b/tests/test_codex_app_apply_rrule.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import json
+import re
 import sqlite3
 from pathlib import Path
 
+import pytest
+
 from scripts.codex_app_apply_rrule import (
     _now_ms,
+    _scheduler_hint_turn_instance_id,
     _update_sqlite,
     _update_toml,
     main,
@@ -85,10 +89,90 @@ def _hint_payload(*, apply_needed: bool, ack_needed: bool = False) -> dict:
 
 
 class _FakeCompleted:
-    def __init__(self, payload: dict) -> None:
-        self.returncode = 0
-        self.stdout = json.dumps(payload)
-        self.stderr = ""
+    def __init__(
+        self,
+        payload: dict | None = None,
+        *,
+        returncode: int = 0,
+        stdout: str | None = None,
+        stderr: str = "",
+    ) -> None:
+        self.returncode = returncode
+        self.stdout = json.dumps(payload or {}) if stdout is None else stdout
+        self.stderr = stderr
+
+
+def test_scheduler_hint_uses_stable_child_turn_identity(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    parent_turn = "heartbeat-turn-3231"
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return _FakeCompleted(_hint_payload(apply_needed=False))
+
+    monkeypatch.setattr("scripts.codex_app_apply_rrule.subprocess.run", fake_run)
+
+    assert (
+        main(
+            [
+                "--automations-root",
+                str(tmp_path / "automations"),
+                "--db-path",
+                str(tmp_path / "codex-dev.db"),
+                "--loopx",
+                "loopx",
+                "--turn-instance-id",
+                parent_turn,
+            ]
+        )
+        == 0
+    )
+
+    child_turn = calls[0][calls[0].index("--turn-instance-id") + 1]
+    assert child_turn == _scheduler_hint_turn_instance_id(parent_turn)
+    assert child_turn == _scheduler_hint_turn_instance_id(parent_turn)
+    assert child_turn != parent_turn
+    assert len(child_turn) <= 128
+    assert re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._:-]*", child_turn)
+
+
+def test_should_run_failure_reports_structured_stdout(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    failure = {
+        "ok": False,
+        "error_code": "heartbeat_receipt_identity_conflict",
+        "reason": "heartbeat receipt settlement identity conflicts",
+    }
+
+    monkeypatch.setattr(
+        "scripts.codex_app_apply_rrule.subprocess.run",
+        lambda command, **kwargs: _FakeCompleted(failure, returncode=1),
+    )
+
+    with pytest.raises(SystemExit) as raised:
+        main(
+            [
+                "--automations-root",
+                str(tmp_path / "automations"),
+                "--db-path",
+                str(tmp_path / "codex-dev.db"),
+                "--loopx",
+                "loopx",
+                "--turn-instance-id",
+                "heartbeat-turn-3231",
+            ]
+        )
+
+    message = str(raised.value)
+    assert "loopx should-run failed (1)" in message
+    assert "stdout=" in message
+    assert "heartbeat_receipt_identity_conflict" in message
+    assert "heartbeat receipt settlement identity conflicts" in message
 
 
 def test_apply_updates_toml_db_and_runs_ack(


### PR DESCRIPTION
Fixes #3231.

## What changed

- Treat the fallback command's `--turn-instance-id` as the parent host turn and derive a stable, public-safe child receipt identity for its internal `quota should-run` query.
- Preserve bounded stdout and stderr diagnostics from failed LoopX subprocesses, so JSON quota errors are no longer rendered as an empty message.
- Ship `loopx-apply-rrule` as a release-owned executable and have `install-local.sh` atomically install/upgrade it with the main CLI.
- Document the parent/child receipt contract and add focused runtime and installer regressions.

## Root cause

The heartbeat guard had already settled the outer turn against its selected Todo. After delivery changed the selected Todo, the fallback bridge queried `quota should-run` with that same turn id, which correctly failed the receipt identity check. The quota CLI emitted the structured failure on stdout, while the bridge only displayed stderr. Because the bridge stopped before applying and ACKing the requested RRULE, the host remained on the tight cadence and repeatedly resurfaced the downstream gate.

The existing domain-local scheduler failure/cooldown reducer remains authoritative; this fix repairs the host bridge before that layer rather than introducing an Effect Program abstraction.

## Validation

Passed:

- `28 passed` — focused fallback, scheduler hint, and interaction arbitration pytest modules
- `examples/install-local-smoke.py`
- `examples/install-local-overwrite-smoke.py`
- `examples/codex-cli-packaged-install-smoke.py`
- `examples/release-wrapper-import-isolation-smoke.py`
- `examples/release-artifacts-smoke.py`
- `examples/release/local-install-promotion-boundary-smoke.py`
- `examples/control_plane/quota-scheduler-state-ack-smoke.py`
- Ruff, shell syntax, Python compile, and `git diff --check`
- Public/private boundary scan

Risk-based `loopx canary premerge --from-git-diff` executed 16 checks: 14 passed. Its two failures are bounded and independently classified:

- `install-local-smoke.py` hit the canary's 120-second per-check limit; the same full smoke passed standalone.
- `monitor-scheduler-contract-smoke.py` fails with the identical assertion on a detached clean `origin/main@221929602`, so it is an existing baseline drift outside this PR.

No private state, credentials, raw logs, local paths, or generated lockfiles are included.
