### PR TITLE
chore(license): adopt Apache-2.0 for LoopX open core

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,3 +40,4 @@
 - [ ] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
 - [ ] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
 - [ ] I kept the change scoped to the linked issue/task.
+- [ ] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,40 @@
+name: DCO
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  signoff:
+    name: Sign-off
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out pull-request history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Require a DCO trailer on every commit
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          missing=0
+          while IFS= read -r commit; do
+            if ! git show -s --format=%B "${commit}" |
+              grep -Eq '^Signed-off-by: [^<]+ <[^<>[:space:]]+@[^<>[:space:]]+>$'; then
+              echo "::error::Commit ${commit} is missing a valid Signed-off-by trailer."
+              missing=1
+            fi
+          done < <(git rev-list --reverse "${BASE_SHA}..${HEAD_SHA}")
+
+          if [[ "${missing}" -ne 0 ]]; then
+            echo "Add the DCO certification with: git commit --amend -s"
+            exit 1
+          fi

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -29,10 +29,15 @@ in [GOVERNANCE.md](GOVERNANCE.md), not by authorship volume.
 
 ## Attribution And License
 
-LoopX is distributed under the [MIT License](LICENSE), with copyright held by
-LoopX contributors for their respective contributions. This attribution file
-does not transfer copyright, require copyright assignment, or alter the
-license.
+LoopX's unified open source core is distributed under the
+[Apache License 2.0](LICENSE) beginning with `v0.4.8`, with copyright held by
+LoopX contributors for their respective contributions. Releases through
+`v0.4.7` retain their original MIT terms, whose license text and copyright
+notice are preserved in [LICENSE-MIT](LICENSE-MIT). See the
+[licensing policy](docs/project/licensing.md) for the transition boundary.
+
+This attribution file does not transfer copyright, require copyright
+assignment, or alter either license.
 
 Corrections to creator or contributor attribution are welcome as a pull
 request with public evidence.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,37 @@ Choose focused smokes and broader canaries by change risk; do not run every
 public smoke or a live model call for every patch. The quality guide explains
 the CI, local/manual, and release-only boundaries.
 
+## License And DCO Sign-Off
+
+LoopX's unified open source core is licensed under the
+[Apache License 2.0](LICENSE). Unless you explicitly state otherwise before
+submission, contributions accepted into this repository are submitted under
+Apache-2.0 without additional terms or conditions. LoopX does not require a
+copyright assignment or contributor license agreement.
+
+Every pull-request commit must certify the
+[Developer Certificate of Origin 1.1](DCO) by including a sign-off trailer:
+
+```text
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+Create that trailer with Git's `-s` option:
+
+```bash
+git commit -s -m "feat: describe the change"
+```
+
+The name and email must identify the person making the certification and must
+be information you are permitted to publish in the permanent Git history. If a
+commit is missing the trailer, amend it with `git commit --amend -s` or use an
+interactive rebase to sign the affected commits, then update the pull-request
+branch. The `DCO` pull-request check rejects unsigned commits.
+
+Releases through `v0.4.7` remain under their original MIT terms. See the
+[licensing and v0.4.8 transition policy](docs/project/licensing.md) for the
+historical notice, patent-grant boundary, and open-core scope.
+
 ## Experimental Features
 
 Use `loopx/experiments/<experiment-id>/` for an opt-in prototype that does not

--- a/DCO
+++ b/DCO
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,202 @@
-MIT License
 
-Copyright (c) 2026 LoopX contributors
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+   1. Definitions.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 LoopX contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,6 @@
+LoopX
+Copyright 2026 LoopX contributors
+
+LoopX releases through v0.4.7 were distributed under the MIT License.
+The historical MIT license text and copyright notice are retained in
+LICENSE-MIT.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <a href="https://trendshift.io/repositories/102379?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-102379"><img src="https://trendshift.io/api/badge/repositories/102379" alt="huangruiteng/loopx on Trendshift" width="220" height="48"></a>
 
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) [![Release](https://img.shields.io/github/v/release/huangruiteng/loopx?display_name=tag)](https://github.com/huangruiteng/loopx/releases/latest) [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/XmGgQyCFZd) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](pyproject.toml) [![Local first](https://img.shields.io/badge/control--plane-local--first-brightgreen.svg)](docs/public-private-boundary.md) [![Loop Agents](https://img.shields.io/badge/status-loop%20agents%20active-brightgreen.svg)](docs/product/release-readiness.md)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE) [![Release](https://img.shields.io/github/v/release/huangruiteng/loopx?display_name=tag)](https://github.com/huangruiteng/loopx/releases/latest) [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/XmGgQyCFZd) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](pyproject.toml) [![Local first](https://img.shields.io/badge/control--plane-local--first-brightgreen.svg)](docs/public-private-boundary.md) [![Loop Agents](https://img.shields.io/badge/status-loop%20agents%20active-brightgreen.svg)](docs/product/release-readiness.md)
 
 [Public website](https://huangruiteng.github.io/loopx/) · [Docs](https://huangruiteng.github.io/loopx/docs/) · [Developer Book](https://huangruiteng.github.io/loopx/docs/book/) · [Try LoopX](#try-loopx) · [See real loops](#evidence) · [How it works](#why-loopx) · [User manual](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [简体中文](README.zh-CN.md)
 
@@ -600,6 +600,10 @@ surface.
 
 ## License
 
-MIT. See [LICENSE](LICENSE).
+Apache License 2.0 beginning with `v0.4.8`. See [LICENSE](LICENSE) and
+[NOTICE](NOTICE). Releases through `v0.4.7` remain under their original MIT
+terms; the historical text and notice are preserved in
+[LICENSE-MIT](LICENSE-MIT). The [licensing policy](docs/project/licensing.md)
+explains the version, contribution, patent-grant, and open-core boundaries.
 
 [osai-verify: eb42dd9cf910399988f0]: #

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@
 
 <a href="https://trendshift.io/repositories/102379?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-102379"><img src="https://trendshift.io/api/badge/repositories/102379" alt="huangruiteng/loopx 在 Trendshift 的趋势排名" width="220" height="48"></a>
 
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) [![Release](https://img.shields.io/github/v/release/huangruiteng/loopx?display_name=tag)](https://github.com/huangruiteng/loopx/releases/latest) [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/XmGgQyCFZd) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](pyproject.toml) [![Local first](https://img.shields.io/badge/control--plane-local--first-brightgreen.svg)](docs/public-private-boundary.md) [![Loop Agents](https://img.shields.io/badge/status-loop%20agents%20active-brightgreen.svg)](docs/product/release-readiness.md)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE) [![Release](https://img.shields.io/github/v/release/huangruiteng/loopx?display_name=tag)](https://github.com/huangruiteng/loopx/releases/latest) [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/XmGgQyCFZd) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](pyproject.toml) [![Local first](https://img.shields.io/badge/control--plane-local--first-brightgreen.svg)](docs/public-private-boundary.md) [![Loop Agents](https://img.shields.io/badge/status-loop%20agents%20active-brightgreen.svg)](docs/product/release-readiness.md)
 
 [产品首页](https://huangruiteng.github.io/loopx/) · [文档](https://huangruiteng.github.io/loopx/docs/) · [开发者手册](https://huangruiteng.github.io/loopx/docs/book/) · [试用 LoopX](#试用-loopx) · [查看真实 Loop](#证据) · [理解工作原理](#为什么需要-loopx) · [用户手册](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [English](README.md)
 
@@ -541,4 +541,7 @@ Loop 的 terminal acceptance、补足独立采用与 outcome evidence，并打�
 
 ## License
 
-MIT，见 [LICENSE](LICENSE)。
+从 `v0.4.8` 起采用 Apache License 2.0，见 [LICENSE](LICENSE) 与
+[NOTICE](NOTICE)。`v0.4.7` 及更早版本永久保留原 MIT 许可；历史许可证全文与
+notice 保存在 [LICENSE-MIT](LICENSE-MIT)。[许可证政策](docs/project/licensing.md)
+说明版本、贡献、专利授权与 open-core 边界。

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -36,16 +36,18 @@ Please do not use the LoopX name or marks:
 - in a confusingly similar logo or visual identity that obscures who operates
   or maintains the offering.
 
-Forks may retain the notices required by the MIT License and may accurately
-state their relationship to LoopX. A materially modified distribution should
-use its own primary name and make the lack of official project endorsement
-clear.
+Forks must retain the notices required by the applicable software license and
+may accurately state their relationship to LoopX. A materially modified
+distribution should use its own primary name and make the lack of official
+project endorsement clear.
 
 ## Copyright License And Project Identity
 
-The [MIT License](LICENSE) grants copyright permissions for the code and
-documentation. It does not grant permission to misrepresent the source of a
-distribution or imply project endorsement.
+The [Apache License 2.0](LICENSE) grants copyright and patent permissions for
+the code and documentation subject to its terms. Historical MIT terms are
+preserved in [LICENSE-MIT](LICENSE-MIT). Neither software license grants
+permission to misrepresent the source of a distribution or imply project
+endorsement.
 
 For a proposed use that may look official, open a GitHub issue before launch.
 Do not put credentials, private evidence, or embargoed security details in that

--- a/apps/presentation/dashboard/package-lock.json
+++ b/apps/presentation/dashboard/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@loopx/dashboard",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.0",
         "@tanstack/react-query": "^5.101.0",

--- a/apps/presentation/dashboard/package.json
+++ b/apps/presentation/dashboard/package.json
@@ -2,6 +2,7 @@
   "name": "@loopx/dashboard",
   "private": true,
   "version": "0.1.0",
+  "license": "Apache-2.0",
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && vite build",

--- a/apps/presentation/site/package-lock.json
+++ b/apps/presentation/site/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@loopx/public-site",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "lucide-react": "^1.17.0",
         "react": "^19.2.6",

--- a/apps/presentation/site/package.json
+++ b/apps/presentation/site/package.json
@@ -2,6 +2,7 @@
   "name": "@loopx/public-site",
   "private": true,
   "version": "0.1.0",
+  "license": "Apache-2.0",
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && vite build",

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,6 +70,7 @@ a longer onboarding path.
 - [Contributor tasks](../CONTRIBUTOR_TASKS.md)
 - [Governance](../GOVERNANCE.md)
 - [Authors and contributors](../AUTHORS.md)
+- [Licensing and the v0.4.8 transition](project/licensing.md)
 - [Project history](project/history.md)
 - [Name and marks](../TRADEMARKS.md)
 

--- a/docs/product/release-note-template.md
+++ b/docs/product/release-note-template.md
@@ -110,6 +110,15 @@ made.>
 detail with direct PR links. Repeat the persisted-state migration decision
 explicitly.>
 
+## Licensing
+
+<Include this group when the release changes licensing. For `v0.4.8`, state
+that the unified open source core moves to Apache-2.0, releases through
+`v0.4.7` remain MIT, the historical notice is retained, Apache-2.0 continues
+to permit commercial use, and the explicit patent framework supports future
+enterprise and ecosystem collaboration without manufacturing retroactive
+patent grants from historical MIT contributors. Link `docs/project/licensing.md`.>
+
 <!--
 Include this section only when the tag range contains eligible contributors
 other than @huangruiteng. Keep founder stewardship out of this community-only
@@ -208,6 +217,14 @@ loopx doctor
 ### 文档与兼容性
 
 <中文摘要与 PR 链接。>
+
+### 许可证
+
+<当版本改变许可证时镜像英文 Licensing。`v0.4.8` 必须明确：统一开源 core
+切换为 Apache-2.0；`v0.4.7` 及更早版本永久保持 MIT；保留历史 notice；
+Apache-2.0 不限制商业使用；显式专利框架服务于未来企业与生态协作，但不会让
+历史 MIT 贡献凭空产生追溯性的完整 Apache 专利授权。链接
+`docs/project/licensing.md`。>
 
 <!-- 英文存在 Community Contributors 时，保留同一人员、PR 和贡献范围。 -->
 

--- a/docs/project/licensing.md
+++ b/docs/project/licensing.md
@@ -1,0 +1,64 @@
+# LoopX Licensing
+
+LoopX uses the Apache License 2.0 as the primary license for its unified open
+source core beginning with `v0.4.8`. The complete current license is in
+[`LICENSE`](../../LICENSE), and the attribution notices distributed with the
+project are in [`NOTICE`](../../NOTICE).
+
+## Version Boundary
+
+- Releases and tags through `v0.4.7` remain permanently available under the
+  MIT License that governed those releases.
+- Beginning with `v0.4.8`, the unified LoopX open source core is distributed
+  under Apache-2.0.
+- The previous MIT license text and its copyright notice are preserved
+  verbatim in [`LICENSE-MIT`](../../LICENSE-MIT). They continue to document
+  and govern the rights already granted for historical MIT releases and
+  portions first distributed under those terms.
+
+Changing the license of a current distribution does not revoke or narrow the
+permissions already granted for an earlier release. Users may continue to use
+an older LoopX release under its original MIT terms.
+
+## Why Apache-2.0
+
+Apache-2.0 keeps the core permissive for commercial and non-commercial use
+while adding an explicit patent-license framework for covered contributions.
+That clearer framework is useful when model providers, infrastructure teams,
+and large enterprises adopt or contribute to LoopX as shared long-horizon
+agent infrastructure. The change is intended to make ecosystem collaboration
+easier, not to restrict commercial use.
+
+The transition does not manufacture a retroactive Apache patent grant from
+people who contributed solely under MIT terms. The patent-governance value of
+Apache-2.0 accumulates primarily through code distributed in the new release
+line and through future contributions submitted under the Apache-2.0 and DCO
+terms. Historical copyright and attribution records remain intact.
+
+## Contributions After The Transition
+
+Unless a contributor explicitly states otherwise before submission, future
+contributions accepted into LoopX are submitted under Apache-2.0, as described
+by section 5 of that license. Each commit in a pull request must also carry a
+Developer Certificate of Origin 1.1 sign-off. See
+[`CONTRIBUTING.md`](../../CONTRIBUTING.md) and [`DCO`](../../DCO) for the exact
+workflow and certification.
+
+No contributor license agreement or copyright assignment is introduced by
+this transition. Copyright remains with contributors for their respective
+contributions.
+
+## Open Core And Commercial Boundaries
+
+This repository's unified open source core is Apache-2.0. A separately
+delivered Managed Control Plane, enterprise-only modules, hosted operations,
+or implementation and support services may use separate commercial terms when
+they are not part of this repository's Apache-2.0 core distribution.
+
+Apache-2.0 itself permits commercial use, modification, and distribution
+subject to its terms. The separate project-name and logo guidance in
+[`TRADEMARKS.md`](../../TRADEMARKS.md) still applies; the software license does
+not create endorsement or trademark rights.
+
+This document explains the project's public licensing policy and is not legal
+advice.

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.7"
+__version__ = "0.4.8"

--- a/packages/loopx-finance-value-discovery/pyproject.toml
+++ b/packages/loopx-finance-value-discovery/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.4.0"
 description = "Public-safe finance value-discovery extension for LoopX."
 readme = "README.md"
 requires-python = ">=3.11"
+license = "Apache-2.0"
 dependencies = ["loopx>=0.4.0"]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.4.7"
+version = "0.4.8"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ version = "0.4.7"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"
-license = "MIT"
-license-files = ["LICENSE"]
+license = "Apache-2.0"
+license-files = ["LICENSE", "NOTICE", "LICENSE-MIT"]
 authors = [{ name = "LoopX contributors" }]
 dependencies = []
 

--- a/tests/test_license_metadata.py
+++ b/tests/test_license_metadata.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APACHE_2_LICENSE_SHA256 = (
+    "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30"
+)
+
+
+def _project_metadata(path: str) -> dict[str, object]:
+    data = tomllib.loads((ROOT / path).read_text(encoding="utf-8"))
+    project = data.get("project")
+    assert isinstance(project, dict)
+    return project
+
+
+def test_root_license_is_canonical_apache_2_with_historical_notices() -> None:
+    license_bytes = (ROOT / "LICENSE").read_bytes()
+    assert hashlib.sha256(license_bytes).hexdigest() == APACHE_2_LICENSE_SHA256
+
+    historical_mit = (ROOT / "LICENSE-MIT").read_text(encoding="utf-8")
+    notice = (ROOT / "NOTICE").read_text(encoding="utf-8")
+    assert historical_mit.startswith("MIT License\n\nCopyright (c) 2026 LoopX contributors")
+    assert "releases through v0.4.7 were distributed under the MIT License" in notice
+
+
+def test_python_distributions_declare_apache_2() -> None:
+    root_project = _project_metadata("pyproject.toml")
+    assert root_project["license"] == "Apache-2.0"
+    assert set(root_project["license-files"]) == {"LICENSE", "NOTICE", "LICENSE-MIT"}
+
+    extension_project = _project_metadata(
+        "packages/loopx-finance-value-discovery/pyproject.toml"
+    )
+    assert extension_project["license"] == "Apache-2.0"
+
+
+def test_npm_workspace_metadata_declares_apache_2() -> None:
+    for package_dir in ("apps/presentation/site", "apps/presentation/dashboard"):
+        manifest = json.loads((ROOT / package_dir / "package.json").read_text())
+        lock = json.loads((ROOT / package_dir / "package-lock.json").read_text())
+        assert manifest["license"] == "Apache-2.0"
+        assert lock["packages"][""]["license"] == "Apache-2.0"
+
+
+def test_public_docs_state_the_versioned_transition() -> None:
+    licensing = (ROOT / "docs/project/licensing.md").read_text(encoding="utf-8")
+    contributing = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+    assert "beginning with `v0.4.8`" in licensing
+    assert "through `v0.4.7`" in licensing
+    assert "git commit -s" in contributing
+    assert (ROOT / "DCO").read_text(encoding="utf-8").startswith(
+        "Developer Certificate of Origin\nVersion 1.1"
+    )

--- a/tests/test_license_metadata.py
+++ b/tests/test_license_metadata.py
@@ -31,6 +31,8 @@ def test_root_license_is_canonical_apache_2_with_historical_notices() -> None:
 
 def test_python_distributions_declare_apache_2() -> None:
     root_project = _project_metadata("pyproject.toml")
+    assert root_project["version"] == "0.4.8"
+    assert '__version__ = "0.4.8"' in (ROOT / "loopx/__init__.py").read_text()
     assert root_project["license"] == "Apache-2.0"
     assert set(root_project["license-files"]) == {"LICENSE", "NOTICE", "LICENSE-MIT"}
 


### PR DESCRIPTION
## Summary

- adopt Apache License 2.0 as the primary license for LoopX's unified open-source core beginning with `v0.4.8`;
- preserve the complete historical MIT license and copyright notice for releases through `v0.4.7`, and ship both `NOTICE` and `LICENSE-MIT` in Python artifacts;
- align Python and private npm workspace license metadata, contributor documentation, README badges, trademarks guidance, and the release-note contract;
- require a Developer Certificate of Origin 1.1 sign-off on every pull-request commit through a small first-party GitHub Actions check.

## Licensing boundary

Apache-2.0 remains permissive for commercial use while adding an explicit patent-license framework for covered contributions. The change is intended to support future enterprise and ecosystem collaboration, not to restrict commercial use.

Existing releases and tags through `v0.4.7` remain permanently available under MIT. The transition does not manufacture a retroactive Apache patent grant from historical contributors who submitted solely under MIT terms; the patent-governance value accumulates through the new release line and future Apache-2.0/DCO contributions.

The repository's open-source core is Apache-2.0. Separately delivered managed control-plane products, enterprise-only modules, hosted operations, and services may continue to use separate commercial terms when they are not part of this repository's Apache distribution.

## Validation

- `pytest -q tests/test_license_metadata.py` — 4 passed
- `python -m mypy` — passed
- `python examples/release-artifacts-smoke.py` — passed
- `uv build` — built `loopx-0.4.8` wheel and sdist; readback confirmed `License-Expression: Apache-2.0` and bundled `LICENSE`, `NOTICE`, and `LICENSE-MIT`
- canonical Apache-2.0 text diffed cleanly against the Apache Software Foundation copy
- DCO positive/negative commit-message fixtures — passed
- `loopx check` public/private scan — passed
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` — passed
- `git diff --check` — passed
- LoopX change-quality receipt `cqr_fa53c432f87e6eaddfad` — valid for the exact 22-file diff

## Review notes

- No runtime control-plane behavior changes.
- The version bump to `0.4.8` is intentional: it prevents an artifact identified as `0.4.7` from carrying the new license metadata and makes the published transition boundary mechanically consistent.
- Historical tags and previously published artifacts are unchanged.
