### PR TITLE
docs(governance): appoint Lark subsystem maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Repository governance files remain owned by the lead maintainer.
+/.github/CODEOWNERS @huangruiteng
+/GOVERNANCE.md @huangruiteng
+/MAINTAINERS.md @huangruiteng
+
+# Lark integration review routing.
+/loopx/extensions/lark/** @huangruiteng @steven-kid
+/loopx/cli_commands/lark_*.py @huangruiteng @steven-kid
+/docs/capabilities/lark-*.md @huangruiteng @steven-kid
+/docs/integrations/lark-*.md @huangruiteng @steven-kid
+/examples/lark-* @huangruiteng @steven-kid
+/examples/lark_extension_test_support.py @huangruiteng @steven-kid
+/examples/control_plane/lark-* @huangruiteng @steven-kid
+/tests/extensions/test_lark_*.py @huangruiteng @steven-kid

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,9 +147,11 @@ See the [LoopX Turn protocol](docs/reference/protocols/loopx-turn-v0.md) and the
 
 Repository roles and decision authority are defined in
 [GOVERNANCE.md](GOVERNANCE.md). Creator and contributor attribution is recorded
-in [AUTHORS.md](AUTHORS.md) and the public Git history. Contribution does not
-automatically grant merge or release authority, and an agent or automation
-identity is not a human maintainer.
+in [AUTHORS.md](AUTHORS.md), while path-scoped maintenance and preferred review
+assignments are recorded in [MAINTAINERS.md](MAINTAINERS.md). The public Git
+history records individual contributions. Contribution does not automatically
+grant merge or release authority, and an agent or automation identity is not a
+human maintainer.
 
 When naming or packaging a fork, integration, or hosted service, follow the
 project's [name and marks guidance](TRADEMARKS.md).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -15,6 +15,10 @@ maintainer appointments, security-sensitive handling, and changes to this
 governance model. That tie-break role should be revisited when the active
 maintainer group grows.
 
+Path-scoped subsystem appointments and preferred review assignments are
+recorded in [MAINTAINERS.md](MAINTAINERS.md). A subsystem appointment does not
+by itself grant repository-wide maintainer authority.
+
 ## Repository Developers With Write Access
 
 The following developers have, or have been invited to accept, GitHub's
@@ -27,9 +31,11 @@ as a maintainer or grant release, security, or governance authority.
 | [`@wujc12`](https://github.com/wujc12) | Write | Active |
 | [`@ZaynJarvis`](https://github.com/ZaynJarvis) | Write | Active |
 | [`@Hoey041`](https://github.com/Hoey041) | Write | Active |
-| [`@maxliux5`](https://github.com/maxliux5) | Write | Invitation pending |
-| [`@JackyCSer`](https://github.com/JackyCSer) | Write | Invitation pending |
-| [`@steven-kid`](https://github.com/steven-kid) | Write | Invitation pending |
+| [`@maxliux5`](https://github.com/maxliux5) | Write | Active |
+| [`@JackyCSer`](https://github.com/JackyCSer) | Write | Active |
+| [`@steven-kid`](https://github.com/steven-kid) | Write | Active |
+| [`@liubf21`](https://github.com/liubf21) | Write | Invitation pending |
+| [`@wchwawa`](https://github.com/wchwawa) | Write | Invitation pending |
 
 GitHub's repository settings are the operational source of truth for access.
 This public snapshot should be updated through a pull request when a write-role

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,69 @@
+# LoopX Subsystem Maintainers
+
+This document records path-scoped subsystem maintenance and preferred review
+assignments. Repository-wide roles, release authority, and final governance
+decisions remain defined by [GOVERNANCE.md](GOVERNANCE.md). GitHub repository
+settings remain the operational source of truth for access.
+
+A subsystem maintainer is accountable for review quality and contract
+coherence inside a named surface. The appointment does not grant authority
+over unrelated subsystems, releases, security handling, repository settings,
+or admin-bypass merges.
+
+## Lark Integration
+
+| Role | Account | Scope |
+| --- | --- | --- |
+| Subsystem maintainer | [`@steven-kid`](https://github.com/steven-kid) | Bundled Lark extension, its direct CLI delegates, Lark capability and integration documentation, and focused Lark validation |
+| Lead maintainer and fallback reviewer | [`@huangruiteng`](https://github.com/huangruiteng) | Repository governance, cross-subsystem decisions, and review of changes authored by the subsystem maintainer |
+
+The Lark integration maintainer is expected to:
+
+- provide the first substantive response and design review for Lark pull
+  requests;
+- keep extension implementation, direct CLI delegates, public documentation,
+  and focused validation consistent;
+- protect authority, readback, owner-private receipt, retry, idempotency, and
+  cross-platform boundaries;
+- submit approval or change-request reviews on pull requests authored by other
+  contributors; and
+- escalate changes that alter shared extension lifecycle, status, quota, todo,
+  release, security, or repository-governance contracts.
+
+The appointment does not authorize the subsystem maintainer to approve their
+own pull requests. A non-author reviewer must still approve those changes under
+the repository rules. Merge, release, security, repository-settings, and
+admin-bypass authority remain governed by `GOVERNANCE.md` and the lead
+maintainer.
+
+The matching paths are recorded in [`.github/CODEOWNERS`](.github/CODEOWNERS).
+That file provides automatic review routing. This appointment does not make
+code-owner approval a branch-protection requirement. After at least three, and
+normally five, completed cross-author exact-head review cycles, the lead
+maintainer may separately decide whether to propose required code-owner review.
+
+## Shared Host Integration Seams
+
+`@steven-kid` is a preferred reviewer, not the sole code owner, for the shared
+host integration seams currently centered on:
+
+- `loopx/host_loop_activation.py`;
+- `loopx/host_mode_planner.py`;
+- `loopx/cli_commands/host_mode_plan.py`; and
+- `docs/integrations/runtime-connector-catalog.md`.
+
+Host integration spans Codex, Claude Code, OpenCode, DeepSeek Harness, and
+other runtime providers. Provider-specific implementation remains with the
+relevant contributors and repository maintainers, while shared status, quota,
+todo, scheduler, and Turn contracts remain outside the Lark appointment. These
+host paths are therefore not assigned to `@steven-kid` in `CODEOWNERS` at this
+stage.
+
+## Changing An Appointment
+
+Adding, expanding, narrowing, or retiring a subsystem appointment requires a
+public pull request that updates this document and any matching `CODEOWNERS`
+routes. Contribution count alone is not sufficient evidence. The decision
+should consider sustained technical judgment, cross-author review quality,
+boundary discipline, responsiveness, and whether the proposed path scope is
+cohesive.


### PR DESCRIPTION
## Summary

- appoint `@steven-kid` as the path-scoped Lark integration subsystem maintainer
- add `CODEOWNERS` routes for the bundled Lark extension, direct CLI delegates, Lark docs, examples, and focused tests
- keep shared host integration as a preferred-review assignment rather than broad code ownership
- document that the appointment grants no release, security, repository-settings, unrelated control-plane, or admin-bypass authority
- refresh the public write-access snapshot from current GitHub collaborators and pending invitations

## Review and enforcement boundary

This PR does not change the `main` ruleset. CODEOWNERS provides automatic review routing only; code-owner approval remains optional. The lead maintainer remains a code owner on every appointed path and reviews changes authored by the subsystem maintainer. Any future move to required code-owner review needs a separate owner decision after cross-author review evidence exists.

## Validation

- `python3 examples/docs-governance-smoke.py` — passed
- `loopx check --scan-path .github/CODEOWNERS --scan-path MAINTAINERS.md --scan-path GOVERNANCE.md --scan-path CONTRIBUTING.md` — 0 errors; public-boundary scan clean for all four files
- `git diff --cached --check` — passed before commit
- every Lark CODEOWNERS pattern matches at least one tracked path; the extension route covers 32 files

## Scope and exclusions

No runtime, release, security, GitHub ruleset, benchmark, or permission-setting behavior changes. Unrelated untracked files in the primary worktree were not copied or staged. The two existing local LoopX state-projection warnings reported by `loopx check` are outside this public governance diff.
