### PR TITLE
docs(book): colocate MkDocs configs

### DIFF
--- a/.github/workflows/frontstage-pages.yml
+++ b/.github/workflows/frontstage-pages.yml
@@ -13,8 +13,8 @@ on:
       - "apps/presentation/site/**"
       - "docs/**"
       - "mkdocs.yaml"
-      - "mkdocs.book.zh.yaml"
-      - "mkdocs.book.en.yaml"
+      - "docs/book/mkdocs.zh.yaml"
+      - "docs/book/mkdocs.en.yaml"
       - "docs/showcases/**"
       - "docs/assets/long-running-loop-openviking-trajectory.png"
       - "docs/assets/long-running-loop-ml-experiment-trajectory.png"
@@ -38,8 +38,8 @@ on:
       - "apps/presentation/site/**"
       - "docs/**"
       - "mkdocs.yaml"
-      - "mkdocs.book.zh.yaml"
-      - "mkdocs.book.en.yaml"
+      - "docs/book/mkdocs.zh.yaml"
+      - "docs/book/mkdocs.en.yaml"
       - "docs/showcases/**"
       - "docs/assets/long-running-loop-openviking-trajectory.png"
       - "docs/assets/long-running-loop-ml-experiment-trajectory.png"
@@ -206,10 +206,10 @@ jobs:
         run: mkdocs build --strict --site-dir output/frontstage-pages/site/docs
 
       - name: Build Chinese Developer Book
-        run: mkdocs build --strict --config-file mkdocs.book.zh.yaml --site-dir output/frontstage-pages/site/docs/book
+        run: mkdocs build --strict --config-file docs/book/mkdocs.zh.yaml --site-dir ../../output/frontstage-pages/site/docs/book
 
       - name: Build English Developer Book
-        run: mkdocs build --strict --config-file mkdocs.book.en.yaml --site-dir output/frontstage-pages/site/docs/book/en
+        run: mkdocs build --strict --config-file docs/book/mkdocs.en.yaml --site-dir ../../output/frontstage-pages/site/docs/book/en
 
       - name: Validate rendered Developer Book
         run: python3 examples/dev-book-publication-smoke.py --site-dir output/frontstage-pages/site/docs/book

--- a/docs/book/mkdocs.en.yaml
+++ b/docs/book/mkdocs.en.yaml
@@ -1,9 +1,9 @@
-INHERIT: mkdocs.yaml
+INHERIT: ../../mkdocs.yaml
 
 site_name: LoopX · Developer Book
 site_url: https://huangruiteng.github.io/loopx/docs/book/en/
-docs_dir: docs/book/en
-site_dir: output/docs-book-en
+docs_dir: en
+site_dir: ../../output/docs-book-en
 edit_uri: edit/main/docs/book/en/
 
 theme:

--- a/docs/book/mkdocs.zh.yaml
+++ b/docs/book/mkdocs.zh.yaml
@@ -1,9 +1,9 @@
-INHERIT: mkdocs.yaml
+INHERIT: ../../mkdocs.yaml
 
 site_name: LoopX · Developer Book
 site_url: https://huangruiteng.github.io/loopx/docs/book/
-docs_dir: docs/book
-site_dir: output/docs-book-zh
+docs_dir: .
+site_dir: ../../output/docs-book-zh
 edit_uri: edit/main/docs/book/
 
 exclude_docs: |

--- a/examples/dev-book-publication-smoke.py
+++ b/examples/dev-book-publication-smoke.py
@@ -12,8 +12,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 BOOK = REPO_ROOT / "docs" / "book"
 CONTROL_PLANE_COURSE = REPO_ROOT / "docs" / "development" / "control-plane-course"
 MKDOCS = REPO_ROOT / "mkdocs.yaml"
-MKDOCS_ZH = REPO_ROOT / "mkdocs.book.zh.yaml"
-MKDOCS_EN = REPO_ROOT / "mkdocs.book.en.yaml"
+MKDOCS_ZH = BOOK / "mkdocs.zh.yaml"
+MKDOCS_EN = BOOK / "mkdocs.en.yaml"
 BRAND_STYLES = REPO_ROOT / "docs" / "stylesheets" / "loopx.css"
 HOMEPAGE = REPO_ROOT / "apps" / "presentation" / "site" / "src" / "App.tsx"
 
@@ -149,6 +149,8 @@ def main() -> int:
     args = parser.parse_args()
 
     assert not (BOOK / "labs").exists(), "Dev Book publication must not include Labs"
+    assert not (REPO_ROOT / "mkdocs.book.zh.yaml").exists()
+    assert not (REPO_ROOT / "mkdocs.book.en.yaml").exists()
 
     mkdocs = read(MKDOCS)
     assert "book/chapters/" not in mkdocs
@@ -163,14 +165,16 @@ def main() -> int:
     zh_config = read(MKDOCS_ZH)
     en_config = read(MKDOCS_EN)
     for config in (zh_config, en_config):
-        assert "INHERIT: mkdocs.yaml" in config
+        assert "INHERIT: ../../mkdocs.yaml" in config
         assert config.index("scheme: slate") < config.index("scheme: default")
         assert "navigation.sections" in config
         assert "navigation.expand" not in config
-    assert "docs_dir: docs/book" in zh_config
+    assert "docs_dir: ." in zh_config
+    assert "site_dir: ../../output/docs-book-zh" in zh_config
     assert "language: zh" in zh_config
     assert "en/**" in zh_config
-    assert "docs_dir: docs/book/en" in en_config
+    assert "docs_dir: en" in en_config
+    assert "site_dir: ../../output/docs-book-en" in en_config
     assert "language: en" in en_config
     assert "中文:" not in en_config
 

--- a/examples/frontstage-pages-workflow-smoke.py
+++ b/examples/frontstage-pages-workflow-smoke.py
@@ -106,8 +106,8 @@ def main() -> int:
         "npm run smoke:frontstage-share-bundle",
         "npm run export:frontstage-share -- --base /loopx/ --out-dir ../../../output/frontstage-pages",
         "mkdocs build --strict --site-dir output/frontstage-pages/site/docs",
-        "mkdocs build --strict --config-file mkdocs.book.zh.yaml --site-dir output/frontstage-pages/site/docs/book",
-        "mkdocs build --strict --config-file mkdocs.book.en.yaml --site-dir output/frontstage-pages/site/docs/book/en",
+        "mkdocs build --strict --config-file docs/book/mkdocs.zh.yaml --site-dir ../../output/frontstage-pages/site/docs/book",
+        "mkdocs build --strict --config-file docs/book/mkdocs.en.yaml --site-dir ../../output/frontstage-pages/site/docs/book/en",
         "actions/configure-pages@v6",
         "enablement: true",
         "actions/upload-pages-artifact@v5",
@@ -133,8 +133,8 @@ def main() -> int:
         assert_absent(text, forbidden)
 
     for path in [
-        "mkdocs.book.zh.yaml",
-        "mkdocs.book.en.yaml",
+        "docs/book/mkdocs.zh.yaml",
+        "docs/book/mkdocs.en.yaml",
         "examples/dev-book-publication-smoke.py",
     ]:
         assert_pr_and_push_trigger(trigger_text, path)


### PR DESCRIPTION
## Summary

- move the Chinese and English Developer Book MkDocs configs from the repository root into `docs/book/`
- update inherited config, docs, default output, workflow trigger, and workflow build paths for config-relative resolution
- update durable publication and Pages workflow smokes to protect the localized layout

## Behavior and compatibility

The public Developer Book URLs and rendered content do not change. Maintainer build commands now use `docs/book/mkdocs.zh.yaml` and `docs/book/mkdocs.en.yaml`. Because MkDocs resolves both config fields and relative `--site-dir` overrides from the child config directory, the Pages workflow uses `../../output/...` to preserve the existing artifact layout.

## Validation

- strict main docs build
- strict Chinese and English Developer Book builds using their default output paths
- strict main/Chinese/English rebuild into the exact Pages artifact layout
- `python3 examples/dev-book-publication-smoke.py`
- `python3 examples/dev-book-publication-smoke.py --site-dir output/frontstage-validation/site/docs/book`
- `python3 examples/frontstage-pages-workflow-smoke.py`
- `loopx check` over all changed public paths
- `loopx canary premerge --from-git-diff --tier standard --no-progress`
- `git diff --check`

The standard pre-merge gate passed 11 selected catalog and risk-profile checks, Python compile checks, diff hygiene, and the public-boundary scan with no failures, warnings, or manual holds.
