### PR TITLE
docs(capabilities): clarify outcome and extension paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,10 +285,28 @@ loopx doctor
 
 ## Capabilities
 
-LoopX folds its control-plane mechanics into five questions. Each question
-delivers one product promise on top of any agent harness: objective →
-long-horizon state; next → semantic decisions; human judgment →
-human-agent collaboration; evidence → recovery; continuation → governance.
+LoopX keeps the architecture explicit so the same governed outcome can survive
+a change of agent harness or external provider. The terms describe different
+boundaries rather than interchangeable kinds of plugin:
+
+| Boundary | Meaning | Go deeper |
+| --- | --- | --- |
+| **Kernel** | Owns durable goal, todo, gate, evidence, quota, recovery, and scheduling truth. | [Architecture](docs/architecture.md) |
+| **Capability** | Defines a stable, provider-neutral contract for producing one bounded, verifiable caller outcome from LoopX state. | [Capability catalog](docs/capabilities/README.md) |
+| **Provider** | Calls an external system or local implementation and returns bounded observations, effect results, and readback. | [Provider responsibilities](docs/reference/extensions.md#runtime-responsibilities) |
+| **Extension** | Packages and operates an optional provider through explicit install, readiness, enable, upgrade, disable, and rollback lifecycle. | [Extension lifecycle](docs/reference/extensions.md#runtime-lifecycle) |
+
+Host declarations such as `--available-capability shell` describe observed
+execution support. They are runtime capacities in this product map, not product
+capabilities and not permission grants. The effective capability still applies
+its own policy and authority checks before proposing a transition.
+
+### Core Control-Plane Promises
+
+The Kernel folds its mechanics into five questions. Each question delivers one
+product promise on top of any agent harness: objective → long-horizon state;
+next → semantic decisions; human judgment → human-agent collaboration;
+evidence → recovery; continuation → governance.
 
 | Question | What LoopX keeps visible |
 | --- | --- |
@@ -315,6 +333,28 @@ The shipped primitives include lifetime goals, concrete user gates, audited safe
 fallbacks, peer todo ownership, quota and steering, compact run history,
 evidence-backed handoff, a read-first management surface, project-level value
 signals, and public/private boundary checks.
+
+### Product Capability Paths
+
+Capabilities turn those generic primitives into outcome-owned work lanes. Start
+from the outcome, then inspect the current registered implementation and its
+write boundary:
+
+| You need to... | Capability | Start with |
+| --- | --- | --- |
+| Turn a public issue into a reviewable, evidence-backed change | [Issue Fix](docs/capabilities/issue-fix/README.md) | `loopx capability show issue-fix --format json` |
+| Qualify the exact final diff before delivery | [Change Quality](docs/capabilities/change-quality/README.md) | `loopx capability show change-quality-qualification --format json` |
+| Preserve a changing stack of already reviewed branches | [Integration Branch](docs/capabilities/integration-branch/README.md) | `loopx capability show integration-branch-reconcile --format json` |
+| Explore uncertain research without losing hypotheses and findings | [Explore](docs/capabilities/explore/README.md) | `loopx capability show explore --format json` |
+| Rebase decisions on current evidence and verified outcomes | [Decision Context](docs/capabilities/decision-context/README.md) | `loopx capability show decision-context --format json` |
+| Produce scheduled or progress-triggered reports with receipts | [Periodic Report](docs/capabilities/periodic-report/README.md) | `loopx capability show periodic-report --format json` |
+
+Run `loopx capability list --format json` for the authoritative catalog in the
+installed release. A capability detail reports its user value, maturity,
+provider readiness, entry commands, write boundaries, protocols, and durable
+validation. Browse the [human-readable capability index](docs/capabilities/README.md)
+to choose by outcome; use [Extensions and Capabilities](docs/reference/extensions.md)
+when installing or building a provider.
 
 ### Runtime Responsibilities
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -258,7 +258,23 @@ loopx doctor
 
 ## 能力
 
-LoopX 把控制面归结为五个用户可以直接行动的问题。每个问题对应一个产品
+LoopX 显式保留架构边界，使同一个受治理结果在更换 Agent harness 或外部 Provider
+后仍然成立。以下术语描述的是不同边界，而不是几种可以互换的插件：
+
+| 边界 | 含义 | 深入阅读 |
+| --- | --- | --- |
+| **Kernel** | 持有持久化 goal、todo、gate、evidence、quota、恢复和调度事实。 | [核心架构](docs/architecture.md) |
+| **Capability** | 定义稳定、provider-neutral 的合同，从 LoopX 状态交付一个有界、可验证的调用者结果。 | [Capability 目录](docs/capabilities/README.md) |
+| **Provider** | 调用外部系统或本地实现，返回有界 observation、effect result 和 readback。 | [Provider 运行责任](docs/reference/extensions.md#runtime-responsibilities) |
+| **Extension** | 通过显式安装、readiness、启用、升级、停用和回滚生命周期交付可选 Provider。 | [Extension 生命周期](docs/reference/extensions.md#runtime-lifecycle) |
+
+`--available-capability shell` 等 host 声明描述的是已观测到的执行支持；在这张
+产品图里属于 runtime capacity，不是产品 Capability，也不授予权限。真正执行前，
+Capability 仍须应用自己的 policy 和 authority check，再提出 typed transition。
+
+### 控制面核心承诺
+
+Kernel 把控制面归结为五个用户可以直接行动的问题。每个问题对应一个产品
 承诺：目标 → 长程状态；下一步 → 语义决策；人类判断 → 人机协同；
 证据 → 恢复；能否继续 → 治理。
 
@@ -286,6 +302,25 @@ LoopX 把控制面归结为五个用户可以直接行动的问题。每个问�
 这些能力共同提供 lifetime goal、具体 user gate、经过审计的安全侧路、平级 todo
 ownership、quota 与 steering、紧凑 run history、证据化 handoff、read-first 管理面、
 项目级价值信号和 public/private boundary check。
+
+### 产品 Capability 路径
+
+Capability 把上述通用原语组成 outcome-owned 工作泳道。先按结果选择，再检查当前
+已注册实现及其写入边界：
+
+| 你需要…… | Capability | 从这里开始 |
+| --- | --- | --- |
+| 把公开 issue 推进为可审查、有证据的变更 | [Issue Fix](docs/capabilities/issue-fix/README.zh-CN.md) | `loopx capability show issue-fix --format json` |
+| 在交付前对精确 final diff 做质量验收 | [Change Quality](docs/capabilities/change-quality/README.md) | `loopx capability show change-quality-qualification --format json` |
+| 维护由多个已审查分支组成、持续变化的集成栈 | [Integration Branch](docs/capabilities/integration-branch/README.md) | `loopx capability show integration-branch-reconcile --format json` |
+| 在不丢失假设和发现的前提下探索不确定研究问题 | [Explore](docs/capabilities/explore/README.zh-CN.md) | `loopx capability show explore --format json` |
+| 基于当前证据和已验证结果重新建立决策上下文 | [Decision Context](docs/capabilities/decision-context/README.zh-CN.md) | `loopx capability show decision-context --format json` |
+| 生成带 receipt 的定时或进展触发报告 | [Periodic Report](docs/capabilities/periodic-report/README.md) | `loopx capability show periodic-report --format json` |
+
+运行 `loopx capability list --format json`，读取当前安装版本的权威目录。Capability
+详情包含用户价值、成熟度、Provider readiness、入口命令、写入边界、协议和持久
+验证。可从[人类可读 Capability 索引](docs/capabilities/README.md)按结果选择；安装或
+开发 Provider 时，再进入[Extension 与 Capability](docs/reference/extensions.md)。
 
 ### 四种运行责任
 

--- a/docs/capabilities/README.md
+++ b/docs/capabilities/README.md
@@ -1,56 +1,102 @@
 # LoopX Product Capabilities
 
-This directory groups LoopX product capabilities by real usage path. Keep kernel
-control-plane code generic; put scenario-specific protocols, implementation
-modules, CLI entrypoints, and smokes under the capability they serve.
+A LoopX capability is a stable, provider-neutral contract for producing one
+bounded, verifiable caller outcome from LoopX state. It owns the domain policy,
+normalizes provider observations, validates the result, and proposes a typed
+transition to the Kernel.
 
-## Capabilities Add Domain Lanes, Not Kernel Columns
+That makes it different from the surrounding boundaries:
 
-An operator surface may render LoopX as an agent-native Kanban. In that view,
-the Kernel supplies generic lifecycle operators such as claim, gate, monitor,
-complete, supersede, quota, and writeback. A capability may add a domain lane
-that interprets provider observations, but it must not create a parallel todo
-or scheduling authority.
+- the [Kernel](../architecture.md#runtime-responsibility-model) owns durable
+  goal, todo, gate, quota, recovery, and scheduling truth;
+- a provider performs a bounded external or local operation and returns
+  readback;
+- an [extension](../reference/extensions.md) packages and operates an optional
+  provider without acquiring Kernel authority;
+- host declarations such as `shell` and `network` describe runtime capacity,
+  not a product capability or a permission grant.
+
+## Inspect What This Release Can Do
+
+The runtime registry is authoritative. Directories and documentation do not
+become shipped capabilities merely by existing:
+
+```bash
+loopx capability list --format json
+loopx capability show issue-fix --format json
+```
+
+`list` reports registered capability and provider readiness. `show` adds the
+user value, maturity, entry commands, explicit write boundary, implemented
+protocols, and durable validation for one capability. Use that readback before
+enabling an advanced path or optional provider.
+
+## Choose By Outcome
+
+The selected documents below explain human usage paths behind registered
+capabilities. The CLI remains the source for the complete catalog and for exact
+availability and maturity in the installed release.
+
+### Engineering Delivery
+
+| You need to... | Capability path |
+| --- | --- |
+| Turn public issue and PR signals into a focused, reviewable fix with validation evidence | [issue-fix](issue-fix/README.md) capability ([中文](issue-fix/README.zh-CN.md)) |
+| Qualify the exact final diff through bounded review, safe repair, and strict receipts | [Change Quality](change-quality/README.md) |
+| Detect source-head drift and safely rebuild a local stack of already reviewed branches | [Integration Branch](integration-branch/README.md) |
+
+### Research And Decision Continuity
+
+| You need to... | Capability path |
+| --- | --- |
+| Preserve questions, hypotheses, experiments, findings, and composition frontiers across a long exploration | [Explore](explore/README.md) ([中文版](explore/README.zh-CN.md)) |
+| Separate current evidence, advisory proposals, and verified outcomes before making a decision | [Decision Context](decision-context/README.md) ([中文](decision-context/README.zh-CN.md)) |
+| Recall a settled autonomous turn without manufacturing a new user prompt | [Agent Turn Recall](agent-turn-recall/README.md) |
+| Add optional, provider-neutral preference recall without making memory the state authority | [Semantic Preference](semantic-preference/README.md) |
+
+### Operations And Projection
+
+| You need to... | Capability path |
+| --- | --- |
+| Compose scheduled or progress-triggered reports with source, archive, delivery, and settlement receipts | [Periodic Report](periodic-report/README.md) |
+| Turn public/private content signals into reviewable source, angle, draft, feedback, and publish-gate packets | [Content Operations](content-ops/README.md) |
+| Inventory, archive, migrate, and rerank a material store without losing raw source authority | [Material Lifecycle](material-lifecycle/README.md) ([中文](material-lifecycle/README.zh-CN.md)) |
+| Inspect compatibility routes for public-safe external-value intake while callers migrate to outcome-owned capabilities | [Value Connectors](value-connectors/README.md) |
+
+## From Capability To Provider
+
+The execution and control paths deliberately run in opposite directions:
+
+```text
+Agent -> Capability -> Provider -> external system
+Provider readback -> Capability transition proposal -> Kernel
+```
+
+Start from the caller outcome, not from an extension name. A built-in provider
+may already implement the capability. When an optional implementation is
+needed, inspect its declared permissions and readiness, then use the explicit
+install, doctor, enable, disable, upgrade, and rollback lifecycle documented in
+[Extensions and Capabilities](../reference/extensions.md). Installing an
+extension does not grant new authority.
+
+## Architecture Rule: Domain Lanes, Not Kernel Columns
+
+An operator surface may render LoopX as an agent-native Kanban. The Kernel
+supplies generic lifecycle operators such as claim, gate, monitor, complete,
+supersede, quota, and writeback. A capability may add a domain lane that
+interprets provider observations, but it must not create parallel todo or
+scheduling authority.
 
 For example, Issue Fix can project
-`feasibility -> patch -> checks -> review -> merge`, while an experiment pack
+`feasibility -> patch -> checks -> review -> merge`, while an experiment path
 can project `hypothesis -> execute -> evaluate -> promote/retire`. These labels
-are derived from capability-owned domain state and accepted Kernel transitions.
-They are not new core lifecycle statuses. If a domain stage changes permission,
+come from capability-owned domain state and accepted Kernel transitions; they
+are not new core lifecycle statuses. If a domain stage changes permission,
 claim eligibility, quota, a user gate, or terminal closure, the capability must
 propose a typed transition through the existing Kernel contract.
 
-Current capability paths:
-
-- [integration-branch](integration-branch/README.md): detect when a reviewed
-  feature or fix branch has moved, then preview or safely rebuild one local
-  integration branch from exact current source heads.
-- [decision-context](decision-context/README.md)
-  ([中文](decision-context/README.zh-CN.md),
-  [architecture](../reference/protocols/decision-context-architecture-v0.md)):
-  separate current evidence, advisory proposals, and verified outcomes through
-  default-off provider-neutral packet and incremental source contracts.
-- [material-lifecycle](material-lifecycle/README.md)
-  ([中文](material-lifecycle/README.zh-CN.md),
-  [architecture](../reference/protocols/material-lifecycle-architecture-v0.md)):
-  preserve raw source authority while inventorying, archiving, migrating, and
-  applying bounded material reranks.
-- [periodic-report](periodic-report/README.md): evaluate cadence and material
-  progress triggers, then compose deterministic provider-neutral report runs
-  with source, artifact, archive, and delivery receipts.
-- [issue-fix](issue-fix/README.md) ([中文](issue-fix/README.zh-CN.md)): turn
-  public GitHub issue/PR signals into focused fixes, explainable reviewer
-  routes, authority-gated PRs, and monitored lifecycle outcomes.
-- [content-ops](content-ops/README.md): collect public/private content signals
-  into reviewable source, angle, draft, feedback, and publish-gate packets.
-- [value-connectors](value-connectors/README.md): install and run public-safe
-  external-value connector starters, beginning with body-free GitHub public
-  channel metadata probes, plus gated candidate profiles such as X/browser
-  social work and finance market snapshots.
-- [explore](explore/README.md)（[中文版](explore/README.zh-CN.md)）: record long-running exploration results as a
-  compact topology (nodes, edges, findings) and project them into a
-  Feishu/Lark Base result board and result card.
-
-Do not add a capability path until there is at least one real CLI entrypoint and
-one smoke test. Future ideas belong in product planning docs until they have
-executable evidence.
+Keep Kernel control-plane code generic. Put scenario-specific protocols,
+implementation modules, CLI entrypoints, and smokes under the capability they
+serve. Do not add a capability path until there is at least one real CLI
+entrypoint and one durable smoke. Future ideas belong in product planning docs
+until they have executable evidence.

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -7,6 +7,8 @@ Current groups:
 
 - [Reference contracts](contracts/README.md)
 - [Protocol contracts](protocols/README.md)
+- [Extensions and capabilities](extensions.md): outcome contracts, provider
+  registration, extension packaging, readiness, and lifecycle boundaries.
 - [Project skill delivery](project-skill-delivery.md): release-owned,
   project-local skill discovery and managed-copy lifecycle.
 


### PR DESCRIPTION
## Summary

- keep LoopX architecture-first while defining Kernel, Capability, Provider, and Extension as distinct linked boundaries
- add outcome-first routes from the README to six representative registered capabilities and their authoritative `capability show` readbacks
- turn the capability index into a user-facing outcome map, while retaining the domain-lane and Kernel-authority rules for contributors
- add the missing Extensions and Capabilities entry to the reference index

The Hero and opening navigation are unchanged. This is a documentation and information-architecture change only; it does not add a runtime registry, alter capability state, or grant provider authority.

## Validation

- `loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard --format json --no-progress`: passed; 13 selected checks, 0 failures, 0 warnings, no manual holds
- `python3 examples/issue-fix-capability-guide-smoke.py`: passed
- `python3 examples/capability-extension-placement-doc-smoke.py`: passed
- `python3 examples/docs-governance-smoke.py`: passed
- `python3 examples/public_entry/readme-demo-surface-smoke.py`: passed
- six documented `loopx capability show <id> --format json` readbacks: passed
- public/private boundary scan: 4 changed public files, 0 hits
- `git diff --check`: passed

Full MkDocs rendering was not run because the system Python environment does not provide the optional `mkdocs` module. Repository-owned documentation and public-entry smokes passed.

## Public boundary

Only public documentation is included. The PR excludes local state, credentials, private links, raw benchmark material, generated logs, and unrelated primary-worktree artifacts.
