### PR TITLE
fix(goal): preserve terminal settlement order

### DIFF
--- a/loopx/control_plane/heartbeat/rules.py
+++ b/loopx/control_plane/heartbeat/rules.py
@@ -1,7 +1,5 @@
 """Heartbeat prompt rule constants inside the heartbeat bounded context."""
 
-from __future__ import annotations
-
 
 DEFAULT_MATERIAL_QUEUE_RULE = "Do not consume the learning material queue unless the user explicitly asks."
 DEFAULT_PERMISSION_RULE = "Do not ask for permissions when the current Codex session is already trusted."
@@ -56,7 +54,7 @@ HOST_LOOP_QUOTA_DISPATCH_RULE = (
     "Run quota; execute `interaction_contract` next—no detours."
 )
 HOST_LOOP_TODO_CLOSEOUT_RULE = (
-    "Nontrivial done -> successor todo or explicit no-follow-up."
+    "Done -> successor todo; final -> refresh/spend before no-follow-up completion."
 )
 CODEX_NATIVE_GOAL_UNCHANGED_WAIT_RULE = (
     "\n\nNative Codex `/goal` owns blocked state. Recheck quota at the "

--- a/tests/test_visible_goal_terminal_settlement.py
+++ b/tests/test_visible_goal_terminal_settlement.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from loopx.heartbeat_prompt import build_heartbeat_prompt
+
+
+def test_visible_goal_keeps_final_todo_nonterminal_until_spend() -> None:
+    payload = build_heartbeat_prompt(
+        goal_id="terminal-settlement-fixture",
+        thin=True,
+        runtime_profile="codex_app_ssh_goal",
+    )
+    task_body = " ".join(payload["task_body"].split())
+
+    terminal_rule = (
+        "Done -> successor todo; final -> refresh/spend before no-follow-up "
+        "completion."
+    )
+    refresh = "refresh the accountable progress record before spending"
+    spend = "Then spend exactly once against that refresh"
+
+    assert task_body.index(terminal_rule) < task_body.index(refresh)
+    assert task_body.index(refresh) < task_body.index(spend)
+    assert payload["interface_budget"]["within_budget"] is True


### PR DESCRIPTION
## What changed

- make the visible Goal prompt order final settlement explicitly: accountable
  refresh and spend happen before no-follow-up completion;
- add a focused regression test for the ordering and the existing compact-prompt
  character budget;
- keep the rule shorter than the previous generic closeout sentence.

## Why

Final Todo completion can derive `terminal_no_followup`, whose quota contract
correctly forbids further spend. The prior prompt mentioned a no-follow-up rationale
before the refresh/spend sequence, so an agent could terminalize the Goal first and
strand an otherwise validated settlement.

This change makes the legal order explicit without weakening the terminal guard or
adding a new quota exception.

## Validation

- `python -m pytest tests/test_visible_goal_terminal_settlement.py tests/test_host_loop_activation.py -q` — 78 passed
- `ruff check loopx/control_plane/heartbeat/rules.py tests/test_visible_goal_terminal_settlement.py` — passed
- visible Goal prompt remains within budget (`2495 <= 2800` budget characters)
- `loopx canary premerge --from-git-diff` — 12 selected control-plane/canary checks passed; no failures or manual holds
