### PR TITLE
feat(canary): add repository-hygiene smoke and release-timeline ratchet

### DIFF
--- a/docs/development/testing-and-quality.md
+++ b/docs/development/testing-and-quality.md
@@ -113,6 +113,18 @@ Durable smoke 应保护已交付行为、可复用合同、公开/私有边界�
 贡献者检查项、语义 oracle 示例、公开安全 fixture 规则和合并流程见
 [什么是好的 Smoke](good-smokes.md)。
 
+The repository hygiene smoke is the thin baseline for LoopX's own public
+checkout: it asserts required tracked files, runs the canonical public/private
+boundary scan, and ratchets the release timeline to every published version
+tag.
+
+仓库卫生 smoke 是 LoopX 自身公共 checkout 的薄基线：断言必需跟踪文件存在，
+执行规范的公开/私有边界扫描，并把 release 时间线收紧到每个已发布版本 tag。
+
+```bash
+python3 examples/repository-hygiene-smoke.py
+```
+
 Run one focused smoke while developing, then let the canary planner select the
 smallest cross-surface set from the Git diff:
 

--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -361,6 +361,84 @@ path, and canary route rather than as a user-facing release baseline.
   Lark delivery are also hardened without making them first-run requirements
   ([#2200](https://github.com/huangruiteng/loopx/pull/2200)). No persisted-state
   migration is required; advanced capabilities remain explicitly activated.
+- `v0.2.7` on 2026-07-17: control-plane convergence and exact-release-evidence
+  release at the matching `v0.2.7` tag. Scheduler, quota, and todo decisions
+  share one agent/runtime/capability/ACK scope; monitors converge independently
+  without resetting one another; blocking user gates use one typed response
+  plan; and Reward Memory v1 ships project corpus configuration with bounded
+  Issue-Fix recall.
+- `v0.2.8` on 2026-07-19: typed Codex App automation contract and periodic
+  report control plane at the matching `v0.2.8` tag. Agent-scoped scheduler,
+  quota, todo, monitor, user-gate, and frontier decisions become typed runtime
+  contracts, and a provider-neutral periodic-report control plane ships for
+  scheduled or material-progress reports without granting external-write
+  authority.
+- `v0.2.9` on 2026-07-20: lane-isolated scheduling and OpenCode host support at
+  the matching `v0.2.9` tag. One agent lane can no longer consume or suppress
+  another lane's frontier, OpenCode becomes a first-class Turn-backed host, and
+  periodic reports gain a dense self-contained HTML presentation.
+- `v0.2.10` on 2026-07-20: in-session weekly report quick start at the matching
+  `v0.2.10` tag. A normal project session can request a local report without
+  profiles, RRULE, host Automation, providers, or external sinks; owner pause
+  stays authoritative for monitor-only quota work.
+- `v0.2.11` on 2026-07-20: packaged weekly report preset at the matching
+  `v0.2.11` tag. `loopx periodic-report inspect-profile --preset weekly`
+  exposes the built-in provider-neutral preset; it creates no schedule, invokes
+  no external sink, and grants no external-write authority.
+- `v0.2.12` on 2026-07-23: heartbeat receipt and review-quality release at the
+  matching `v0.2.12` tag. One quota receipt is persisted per heartbeat turn,
+  monitor/replan routing stays fresh, `loopx pr-review` gains a code-volume and
+  simplification lens, and adaptive multi-turn live-worker lifecycle phases
+  stay visible through compact run and ledger views.
+- `v0.2.13` on 2026-07-24: monitor follow-through release at the matching
+  `v0.2.13` tag. Material monitor writeback resolves the exact todo before
+  target-key fallback, exposes newly runnable successors immediately, and
+  returns a structured stale-projection warning instead of reporting a failed
+  write when only projection reload failed. Continuous-monitor todos may no
+  longer carry `resume_when`.
+- `v0.3.0` on 2026-07-30: capability and control-contract release at the
+  matching `v0.3.0` tag. LoopX promotes simplify-first change qualification,
+  provider-neutral decision context, governed material lifecycle workflows,
+  managed-project delivery, and Ark Managed Agent host support while ordering
+  quota rules and making recoverable Turn stages explicit.
+- `v0.4.0` on 2026-08-01: onboarding and turn-authority release at the matching
+  `v0.4.0` tag. Goal startup projects capability-owned admission routes,
+  replan acknowledgements require canonical agent-visible evidence, the default
+  `quota should-run` JSON stays inside a bounded model-facing budget, and the
+  README foregrounds two inspectable 200+ hour loop trajectories.
+- `v0.4.1` on 2026-08-04: durable work selection and Goal-host continuation
+  release at the matching `v0.4.1` tag. Capability-admitted Todo routes persist
+  across turns, Goal hosts wake on the earliest material frontier transition,
+  grouped Issue Fix PR monitors materialize explicitly, and default-off Agent
+  Turn Recall ships with agent/goal/project/Todo/authority scoping.
+- `v0.4.2` on 2026-08-06: host and workflow surface release at the matching
+  `v0.4.2` tag. Pi and TraeX become first-class host paths, adaptive child
+  admission enforces domain/capability/repository/write-scope readiness,
+  provider-neutral PR queue observation and PR program workflows ship, and
+  Issue Fix pins work to an approved base snapshot.
+- `v0.4.3` on 2026-08-08: effect-interpreter evolution release at the matching
+  `v0.4.3` tag. A second real `EffectTurn` interpreter consumes turn results,
+  data-encoded execution and an ordered effect program shape land, the runtime
+  plan is replacement-first, and a unified bilingual Dev Book adds an
+  independent Control-Plane Course chapter.
+- `v0.4.4` on 2026-08-09: M6 effect-program quality-gate completion at the
+  matching `v0.4.4` tag. Hot control-plane modules are bounded,
+  `EffectTurn`/`EffectProgram` are consumed by real runtime paths, and the M6
+  RFC is marked Complete with audit evidence.
+- `v0.4.5` on 2026-08-12: security-hardening and control-plane release at the
+  matching `v0.4.5` tag. LoopX fixes five privately reported security
+  advisories, adds caller-approved completion validation, ships a
+  durable-smoke review gate, and continues replan/evidence/settlement
+  hardening with community contributions across 16 contributors.
+- `v0.4.6` on 2026-08-13: replan and notification hardening release at the
+  matching `v0.4.6` tag. Replan closeout becomes semantic, quota/heartbeat
+  notification correctness is repaired, refresh-state writeback guards land,
+  and two architecture RFCs document the effect-program direction.
+- `v0.4.7` on 2026-08-15: governed-host continuation release at the matching
+  `v0.4.7` tag. OpenCode 1/2 goal loops stop interrupting on user messages or
+  task closeout, DeepSeek Harness connects through a managed Turn connector,
+  per-goal handoff mode gates claim/lease authority in state files, and Explore
+  can publish multiple Feishu visual boards in one automated step.
 
 When a new public release is promoted, add it here only after the matching tag,
 release note, stable ref, update path, and focused release canary agree.
@@ -377,6 +455,7 @@ python3 examples/fresh-clone-quickstart-smoke.py
 python3 examples/loopx-update-smoke.py
 python3 examples/release/release-version-contract-smoke.py
 python3 examples/release/release-readiness-doc-smoke.py
+python3 examples/repository-hygiene-smoke.py
 git diff --check
 loopx check --scan-path README.md --scan-path docs/ --scan-path examples/
 ```

--- a/examples/repository-hygiene-smoke.py
+++ b/examples/repository-hygiene-smoke.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Thin repository-hygiene smoke for LoopX's own public checkout."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.contract import scan_public_boundary  # noqa: E402
+
+
+REQUIRED_TRACKED_FILES = (
+    "LICENSE",
+    "CONTRIBUTING.md",
+)
+SECURITY_FILES = ("SECURITY.md", ".github/SECURITY.md")
+ISSUE_TEMPLATE_DIR = ".github/ISSUE_TEMPLATE/"
+PR_TEMPLATE = ".github/PULL_REQUEST_TEMPLATE.md"
+RELEASE_TIMELINE = REPO_ROOT / "docs" / "product" / "release-readiness.md"
+FIRST_PUBLIC_RELEASE = (0, 1, 3)
+VERSION_TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+
+
+def tracked_files() -> set[str]:
+    completed = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "ls-files", "-z"],
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            "repository-hygiene-smoke requires a git worktree: "
+            f"{completed.stderr.strip() or 'git ls-files failed'}"
+        )
+    return {line for line in completed.stdout.split("\0") if line}
+
+
+def validate_required_tracked_files(files: set[str]) -> None:
+    missing = [name for name in REQUIRED_TRACKED_FILES if name not in files]
+    if missing:
+        raise AssertionError(f"missing tracked repository-hygiene files: {sorted(missing)}")
+    if not any(name in files for name in SECURITY_FILES):
+        raise AssertionError(
+            "missing tracked security policy; expected one of "
+            + ", ".join(SECURITY_FILES)
+        )
+    if PR_TEMPLATE not in files:
+        raise AssertionError(f"missing tracked pull-request template: {PR_TEMPLATE}")
+    issue_templates = [
+        name
+        for name in files
+        if name.startswith(ISSUE_TEMPLATE_DIR)
+        and name != f"{ISSUE_TEMPLATE_DIR}config.yml"
+    ]
+    if not issue_templates:
+        raise AssertionError(f"missing tracked issue templates under {ISSUE_TEMPLATE_DIR}")
+
+
+def validate_public_private_boundary() -> None:
+    boundary = scan_public_boundary([REPO_ROOT], registry={})
+    hits = list(boundary.get("hits") or [])
+    if hits:
+        detail = "\n".join(hits)
+        raise AssertionError(f"public/private boundary violations:\n{detail}")
+    if not boundary.get("ok"):
+        raise AssertionError(
+            f"public/private boundary scan failed: {boundary.get('ok')}"
+        )
+
+
+def release_tags() -> list[str]:
+    completed = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "tag", "--list", "--sort=version:refname", "v*"],
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(f"cannot list git tags: {completed.stderr.strip()}")
+    tags: list[str] = []
+    for tag in completed.stdout.splitlines():
+        match = VERSION_TAG_RE.match(tag.strip())
+        if not match:
+            continue
+        version = tuple(int(part) for part in match.groups())
+        if version >= FIRST_PUBLIC_RELEASE:
+            tags.append(tag.strip())
+    return tags
+
+
+def validate_release_timeline() -> None:
+    if not RELEASE_TIMELINE.is_file():
+        raise AssertionError(f"missing release timeline: {RELEASE_TIMELINE.relative_to(REPO_ROOT)}")
+    timeline = RELEASE_TIMELINE.read_text(encoding="utf-8")
+    tags = release_tags()
+    if not tags:
+        if "on 20" not in timeline:
+            raise AssertionError("release timeline has no dated version entries")
+        return
+    missing = [tag for tag in tags if f"`{tag}`" not in timeline]
+    if missing:
+        raise AssertionError(
+            "release timeline is missing version entries: "
+            + ", ".join(missing)
+        )
+
+
+def main() -> int:
+    files = tracked_files()
+    validate_required_tracked_files(files)
+    validate_public_private_boundary()
+    validate_release_timeline()
+    print("repository-hygiene-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/canary/runner.py
+++ b/loopx/canary/runner.py
@@ -31,6 +31,9 @@ GIT_REQUIRED_SCRIPTS = {
     "control-plane-maintainability-ratchet-smoke.py": (
         "requires git ls-files so untracked local artifacts do not enter the report"
     ),
+    "repository-hygiene-smoke.py": (
+        "requires git ls-files and git tag to validate tracked hygiene files and release history"
+    ),
 }
 SERIAL_SMOKE_SCRIPTS = {
     "issue-fix-acceptance-loop-smoke.py": (


### PR DESCRIPTION
## What

Adds a thin repository-hygiene smoke to the existing canary/smoke suite:

- `examples/repository-hygiene-smoke.py` asserts required tracked files (LICENSE, CONTRIBUTING, SECURITY, issue/PR templates), runs the canonical `scan_public_boundary` scan, and ratchets `docs/product/release-readiness.md` to every published `v*` tag from `v0.1.3` onward.
- Registers the smoke as git-required in the canary runner so it skips gracefully outside a git worktree.
- Documents the smoke in the release compatibility gate and testing-and-quality docs.

## Release timeline backfill

The smoke would have failed immediately because the public release timeline stopped at `v0.2.6`. This PR backfills `v0.2.7` through `v0.4.7` from the corresponding GitHub release notes so every published tag has a repository-side registration.

## Validation

- `examples/repository-hygiene-smoke.py` passes in a clean worktree.
- Canary smoke-suite invocation for the new script passes.
- `ruff@0.15.4 check` on changed Python passes.
- `git diff --check` passes.