### PR TITLE
fix(explore): keep local projection provider-neutral

### DIFF
--- a/loopx/cli_commands/project_lifecycle.py
+++ b/loopx/cli_commands/project_lifecycle.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import argparse
-from importlib import import_module
 import json
 from collections.abc import Callable, Mapping
+from importlib import import_module
 from pathlib import Path
 
 from ..capabilities.explore.activation import (
@@ -25,28 +25,33 @@ from ..control_plane.work_items.delivery_batch_scale import (
 )
 from ..control_plane.work_items.delivery_outcome import DELIVERY_OUTCOME_CHOICES
 from ..control_plane.work_items.progress_observation import ProgressResultClass
-from ..extensions.runtime import (
-    default_extension_state_file,
-    resolve_extension_activation,
-)
 from ..extensions.lark.goal_channel_lifecycle import (
     goal_channel_gate_sync_failure,
     sync_human_gate_after_refresh,
 )
+from ..extensions.runtime import (
+    default_extension_state_file,
+    resolve_extension_activation,
+)
+from ..feedback import (
+    LESSON_KINDS,
+    append_human_reward,
+    compact_reward,
+    render_reward_markdown,
+)
 from ..history import load_registry
-from ..feedback import LESSON_KINDS, append_human_reward, compact_reward, render_reward_markdown
 from ..operator_gate import (
     DEFAULT_OPERATOR_GATE,
     OPERATOR_GATE_DECISIONS,
     record_operator_gate,
     render_operator_gate_markdown,
 )
+from ..paths import resolve_runtime_root
 from ..project_map import (
     DEFAULT_PROJECT_MAP_CLASSIFICATION,
     read_only_project_map_run,
     render_read_only_project_map_markdown,
 )
-from ..paths import resolve_runtime_root
 from ..state_refresh import (
     DEFAULT_REFRESH_ACTION,
     DEFAULT_REFRESH_CLASSIFICATION,
@@ -55,7 +60,6 @@ from ..state_refresh import (
     refresh_state_run,
     render_state_refresh_markdown,
 )
-
 
 PrintPayload = Callable[
     [dict[str, object], str, Callable[[dict[str, object]], str]],
@@ -92,17 +96,29 @@ def _lark_explore_graph_syncer(
     )
 
     def sync(**kwargs: object) -> Mapping[str, object]:
+        implementation = import_module(
+            "loopx.extensions.lark.presentation.explore_results"
+        )
+        preview_kwargs = dict(kwargs)
+        preview_kwargs["execute"] = False
+        preview = dict(
+            implementation.sync_issue_fix_explore_on_material_change(
+                **preview_kwargs
+            )
+        )
+        if preview.get("status") in {"not_applicable", "not_configured"}:
+            return preview
+
         provider = import_module("loopx.extensions.lark")
         activation = resolve_extension_activation(
             str(provider.LARK_EXTENSION_ID),
             state_file=default_extension_state_file(extension_runtime_root),
             required_permissions=(str(provider.LARK_PROJECTION_SINK_PERMISSION),),
         )
-        implementation = import_module(
-            "loopx.extensions.lark.presentation.explore_results"
-        )
-        result = dict(
-            implementation.sync_issue_fix_explore_on_material_change(**kwargs)
+        result = (
+            dict(implementation.sync_issue_fix_explore_on_material_change(**kwargs))
+            if kwargs.get("execute")
+            else preview
         )
         result["extension_activation"] = activation
         return result

--- a/tests/cli_commands/test_project_lifecycle_explore_graph.py
+++ b/tests/cli_commands/test_project_lifecycle_explore_graph.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from loopx.cli_commands import project_lifecycle
+
+
+@pytest.mark.parametrize("status", ["not_applicable", "not_configured"])
+def test_local_only_explore_projection_does_not_require_optional_extension(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    status: str,
+) -> None:
+    calls: list[bool] = []
+
+    def project(**kwargs: Any) -> dict[str, Any]:
+        calls.append(bool(kwargs["execute"]))
+        return {"ok": True, "status": status, "projection": {}}
+
+    implementation = SimpleNamespace(sync_issue_fix_explore_on_material_change=project)
+    monkeypatch.setattr(
+        project_lifecycle,
+        "import_module",
+        lambda name: implementation,
+    )
+    monkeypatch.setattr(
+        project_lifecycle,
+        "resolve_runtime_root",
+        lambda registry, runtime_root_arg: tmp_path,
+    )
+    monkeypatch.setattr(project_lifecycle, "load_registry", lambda path: {})
+
+    def unexpected_activation(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("local-only projection must not activate a sink provider")
+
+    monkeypatch.setattr(
+        project_lifecycle,
+        "resolve_extension_activation",
+        unexpected_activation,
+    )
+
+    sync = project_lifecycle._lark_explore_graph_syncer(
+        None,
+        registry_path=tmp_path / "registry.json",
+    )
+    result = sync(execute=True)
+
+    assert result["status"] == status
+    assert calls == [False]
+    assert "extension_activation" not in result
+
+
+def test_external_explore_projection_activates_provider_before_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    def project(**kwargs: Any) -> dict[str, Any]:
+        if kwargs["execute"]:
+            events.append("write")
+            return {"ok": True, "status": "synced", "projection": {}}
+        events.append("preview")
+        return {"ok": True, "status": "would_sync", "projection": {}}
+
+    implementation = SimpleNamespace(sync_issue_fix_explore_on_material_change=project)
+    provider = SimpleNamespace(
+        LARK_EXTENSION_ID="loopx-lark",
+        LARK_PROJECTION_SINK_PERMISSION="lark.projection_sink.use",
+    )
+
+    def import_fake(name: str) -> object:
+        if name == "loopx.extensions.lark.presentation.explore_results":
+            return implementation
+        if name == "loopx.extensions.lark":
+            return provider
+        raise AssertionError(name)
+
+    monkeypatch.setattr(project_lifecycle, "import_module", import_fake)
+    monkeypatch.setattr(
+        project_lifecycle,
+        "resolve_runtime_root",
+        lambda registry, runtime_root_arg: tmp_path,
+    )
+    monkeypatch.setattr(project_lifecycle, "load_registry", lambda path: {})
+
+    def activate(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        events.append("activate")
+        return {"status": "active"}
+
+    monkeypatch.setattr(
+        project_lifecycle,
+        "resolve_extension_activation",
+        activate,
+    )
+
+    sync = project_lifecycle._lark_explore_graph_syncer(
+        None,
+        registry_path=tmp_path / "registry.json",
+    )
+    result = sync(execute=True)
+
+    assert result["status"] == "synced"
+    assert result["extension_activation"] == {"status": "active"}
+    assert events == ["preview", "activate", "write"]


### PR DESCRIPTION
## What changed

- preflight Explore Graph material projection without activating an optional external sink provider
- return local-only `not_applicable` and `not_configured` outcomes directly
- preserve provider activation before every external write
- add focused ordering and boundary regression tests

## Why

Explore Graph is a core local capability, while external projection is optional. The refresh path previously resolved the optional provider before determining whether a sink was relevant. A missing provider could therefore turn a valid local-only refresh into a delivery failure.

## Impact

Enabled Explore Graph goals can refresh local state without installing an unrelated sink extension. Configured external delivery keeps the existing installation, permission, write, and readback gates.

## Validation

- `pytest -q tests/cli_commands` (61 passed)
- `python examples/issue-fix-explore-projection-smoke.py`
- `python examples/lark-explore-source-runtime-route-smoke.py`
- `python examples/lark-extension-activation-smoke.py`
- `loopx canary premerge --from-git-diff --tier standard --timeout-seconds 75` (5/5 catalog canaries passed)
- real refresh readback: local-only projection completed with no extension activation
