### PR TITLE
docs(capabilities): add implementation code map

### DIFF
--- a/docs/capabilities/README.md
+++ b/docs/capabilities/README.md
@@ -5,6 +5,12 @@ bounded, verifiable caller outcome from LoopX state. It owns the domain policy,
 normalizes provider observations, validates the result, and proposes a typed
 transition to the Kernel.
 
+Contributors can move from these product contracts to their implementation,
+registry, and validation through the
+[capability code map](https://github.com/huangruiteng/loopx/tree/main/loopx/capabilities).
+That code tree is a navigation surface, not evidence that a capability is
+registered or enabled.
+
 That makes it different from the surrounding boundaries:
 
 - the [Kernel](../architecture.md#runtime-responsibility-model) owns durable

--- a/loopx/capabilities/README.md
+++ b/loopx/capabilities/README.md
@@ -1,0 +1,45 @@
+# Capability Implementations
+
+This directory contains capability-owned implementation code and supporting
+modules. It is a contributor code boundary, not the shipped capability catalog:
+a package existing here does not by itself register or enable a capability.
+
+Use the runtime readback as the source of truth for the installed release:
+
+```bash
+loopx capability list --format json
+loopx capability show <capability-id> --format json
+```
+
+`show` reports the capability's commands, write boundaries, implemented
+protocol modules, canonical documentation, and durable validation. Follow
+those returned module and document paths instead of maintaining a second
+package-to-document index in this README.
+
+## Contributor Navigation
+
+- Start with the [product capability guide](../../docs/capabilities/README.md)
+  when choosing a capability by caller outcome.
+- Read [`catalog.py`](catalog.py) for built-in registration metadata and
+  [`registry.py`](registry.py) for registry behavior.
+- Treat packages such as shared context or provider helpers as supporting
+  modules unless `loopx capability list` reports a registered capability.
+- Use the capability's returned `docs`, `implemented_protocols`, and `smokes`
+  fields to move between its contract, implementation, and validation.
+
+Optional providers and their lifecycle belong to the
+[extension boundary](../../docs/reference/extensions.md). Installing or
+discovering an extension does not grant Kernel authority or turn an
+implementation directory into a registered capability.
+
+## Adding Or Moving Capability Code
+
+Name capabilities after caller outcomes. Keep domain policy and typed
+transition proposals in the owning capability, provider observations behind
+the provider boundary, and durable goal, todo, gate, quota, recovery, and
+scheduling truth in the Kernel.
+
+Do not add a new capability path until it has a real entrypoint, catalog
+registration, canonical documentation, and focused validation. Update the
+catalog metadata when any of those paths move; the CLI readback and existing
+catalog validation should remain the maintained cross-reference.


### PR DESCRIPTION
## Summary

- add a contributor-facing landing page for `loopx/capabilities/`
- route contributors to the canonical product capability guide, runtime catalog, implementation modules, and validation
- add the reverse link from the product capability index without duplicating a package-to-document table

## Product and architecture judgment

The capability documentation now explains the user-facing outcome boundary, but contributors entering through the implementation tree had no landing page. This closes that navigation gap while preserving three distinct authorities: CLI/catalog readback for shipped registration, `docs/capabilities/` for product contracts, and `loopx/capabilities/` for implementation ownership. Per-capability link-only READMEs are deliberately not added because they would duplicate catalog metadata and drift as modules or documents move.

This is documentation-only. It changes no capability registration, provider lifecycle, Kernel authority, permissions, or runtime behavior.

## Validation

- `python3 examples/docs-governance-smoke.py`
- `loopx canary premerge --from-git-diff`
  - standard tier passed
  - 14 selected checks passed
  - public-boundary scan passed
  - no failures, warnings, skips, or manual holds
- `git diff --check origin/main...HEAD`

## Boundary review

- no credentials, private state, raw evidence, generated logs, internal links, or local paths are included
- no runtime, benchmark, permission, installation, or public evidence-policy surface changes
