### PR TITLE
build(pypi): publish canonical project links

### DIFF
--- a/examples/release-artifacts-smoke.py
+++ b/examples/release-artifacts-smoke.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import tomllib
 from pathlib import Path
 
 
@@ -52,6 +53,17 @@ def main() -> int:
     assert identity.name == "loopx", identity
     assert run("expected-tag").stdout.strip() == identity.tag
     assert run("validate-tag", identity.tag).returncode == 0
+
+    project_metadata = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))[
+        "project"
+    ]
+    assert project_metadata["urls"] == {
+        "Homepage": "https://huangruiteng.github.io/loopx/",
+        "Documentation": "https://huangruiteng.github.io/loopx/docs/",
+        "Repository": "https://github.com/huangruiteng/loopx",
+        "Issues": "https://github.com/huangruiteng/loopx/issues",
+        "Changelog": "https://github.com/huangruiteng/loopx/releases",
+    }
 
     invalid_tag = run("validate-tag", "v999.0.0")
     assert invalid_tag.returncode == 2, invalid_tag

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,13 @@ license-files = ["LICENSE", "NOTICE", "LICENSE-MIT"]
 authors = [{ name = "LoopX contributors" }]
 dependencies = []
 
+[project.urls]
+Homepage = "https://huangruiteng.github.io/loopx/"
+Documentation = "https://huangruiteng.github.io/loopx/docs/"
+Repository = "https://github.com/huangruiteng/loopx"
+Issues = "https://github.com/huangruiteng/loopx/issues"
+Changelog = "https://github.com/huangruiteng/loopx/releases"
+
 [project.optional-dependencies]
 deepseek-harness = [
   "deepseek-harness-sdk>=0.1.0rc5",


### PR DESCRIPTION
## Summary

- add canonical Homepage, Documentation, Repository, Issues, and Changelog links to the `loopx` package metadata
- ratchet those links in the durable release artifact smoke so the first PyPI project page cannot silently lose its authority links

## Validation

- `python examples/release-artifacts-smoke.py`
- built `loopx-0.4.8` wheel and sdist with the pinned release toolchain
- `twine check` passed for both distributions
- installed the wheel without dependencies in a fresh Python 3.11 environment; `loopx --version` returned `loopx 0.4.8`
- read the built wheel metadata back and confirmed all five `Project-URL` entries
- `loopx canary premerge --from-git-diff --tier standard`: passed 10 selected checks plus diff/compile checks
- public/private boundary scan: clean for both changed files

## Scope and boundary

- no runtime behavior, dependency, release trigger, token, credential, or publishing permission change
- no local/private state, generated distributions, logs, or build artifacts included
- PyPI publishing remains fail-closed behind the existing `PYPI_PUBLISH_ENABLED` variable and Trusted Publisher setup

## Merge decision

The change is a small, single-purpose package metadata correction with a focused durable smoke. The premerge gate reports no manual holds and allows self-merge after required GitHub checks pass.
