### PR TITLE
fix(release): sync derived capability and manpage surfaces

### DIFF
--- a/examples/capability-extension-registry-smoke.py
+++ b/examples/capability-extension-registry-smoke.py
@@ -57,6 +57,7 @@ next_real_step = "Keep explicit enablement bounded."
 
     baseline = run_cli(runtime_root, "capability", "list")
     assert [item["id"] for item in baseline["capabilities"]] == [
+        "benchmark-toolkit",
         "integration-branch-reconcile",
         "change-quality-qualification",
         "pull-request-review",

--- a/man/loopx.1
+++ b/man/loopx.1
@@ -1,4 +1,4 @@
-.TH LOOPX 1 "" "LoopX 0.4.7" "User Commands"
+.TH LOOPX 1 "" "LoopX 0.4.8" "User Commands"
 .SH NAME
 loopx \- control-plane helper for long-running agent work
 .SH SYNOPSIS


### PR DESCRIPTION
## Summary

- update the exact built-in capability registry expectation for the shipped `benchmark-toolkit` capability
- regenerate the checked-in man page so its version matches package version `0.4.8`

This repairs the two deterministic failures in the current main Full Public Smokes run without changing runtime behavior.

## Validation

- `examples/capability-extension-registry-smoke.py`
- `examples/cli-help-manpage-smoke.py`
- `examples/cli-version-command-modularization-smoke.py`
- `examples/release/release-version-contract-smoke.py`
- `examples/repository-hygiene-smoke.py`
- `loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard` (passed; 0 manual holds, 1 catalog canary, 8 risk-profile smokes, public-boundary scan)

Failing baseline: https://github.com/huangruiteng/loopx/actions/runs/31933173321