### PR TITLE
fix(goal): prevent ambiguous quota spend retries

### DIFF
--- a/docs/heartbeat-automation-prompt.md
+++ b/docs/heartbeat-automation-prompt.md
@@ -485,6 +485,9 @@ If the result says should_run=true:
 
    loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id <GOAL_ID> --todo-id <SELECTED_TODO_ID> --slots 1 --source heartbeat --execute
 
+   Run it exactly once as rendered; no pipe/filter/retry. If spend output is
+   ambiguous, verify with read-only quota status; never rerun.
+
    If the automation reserves a coarser fixed interval, set `--slots` to the
    number of scheduler minutes consumed by that completed turn.
 
@@ -615,9 +618,10 @@ critic / next action; for non-trivial feature slices, create a successor todo
 or write a compact no-follow-up rationale; append one accountable
 `refresh-state --delivery-outcome outcome_progress`, then exactly one
 `loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id <GOAL_ID> --todo-id <SELECTED_TODO_ID> --slots 1 --source heartbeat --execute`
-event for the completed turn. Only an optional state-only refresh belongs after
-spend. Use `--slots 1` for minute-based heartbeats; for coarser intervals,
-spend the scheduler minutes consumed by that turn.
+event for the completed turn; run it as rendered, without pipes or filters,
+and never rerun it. Only an optional state-only refresh belongs after spend.
+Use `--slots 1` for minute-based heartbeats; for coarser intervals, spend the
+scheduler minutes consumed by that turn.
 ```
 
 ## Agent Checklist

--- a/docs/heartbeat-automation-prompt.md
+++ b/docs/heartbeat-automation-prompt.md
@@ -483,7 +483,7 @@ If the result says should_run=true:
    A plain state-only refresh is quota-neutral and cannot replace it. Then, for
    a minute-based heartbeat, spend one slot:
 
-   loopx --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id <GOAL_ID> --todo-id <SELECTED_TODO_ID> --slots 1 --source heartbeat --execute
+   loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id <GOAL_ID> --todo-id <SELECTED_TODO_ID> --slots 1 --source heartbeat --execute
 
    If the automation reserves a coarser fixed interval, set `--slots` to the
    number of scheduler minutes consumed by that completed turn.
@@ -614,7 +614,7 @@ boundary is already clear. Validate it, write back changed files / validation /
 critic / next action; for non-trivial feature slices, create a successor todo
 or write a compact no-follow-up rationale; append one accountable
 `refresh-state --delivery-outcome outcome_progress`, then exactly one
-`loopx --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id <GOAL_ID> --todo-id <SELECTED_TODO_ID> --slots 1 --source heartbeat --execute`
+`loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id <GOAL_ID> --todo-id <SELECTED_TODO_ID> --slots 1 --source heartbeat --execute`
 event for the completed turn. Only an optional state-only refresh belongs after
 spend. Use `--slots 1` for minute-based heartbeats; for coarser intervals,
 spend the scheduler minutes consumed by that turn.

--- a/docs/operations/new-project-codex-prompt.md
+++ b/docs/operations/new-project-codex-prompt.md
@@ -241,10 +241,11 @@ loopx new-project-prompt \
    三个 placeholder 都必须替换为本轮实际验证过的值；不要把较小或仅准备性的
    turn 默认、拔高成 `multi_surface` / `outcome_progress`。
    这是 `spend-slot` 将消费的因果记录；普通 state-only refresh 不能替代它。
-   然后只 append 一次 quota spend：
+   然后原样（不加管道或过滤）append 一次 quota spend；输出为空或不明确时用只读
+   quota status 核对，不能重跑：
 
    ```bash
-   loopx --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id <STABLE_GOAL_ID> --slots 1 --source adapter --execute
+   loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id <STABLE_GOAL_ID> --slots 1 --source adapter --execute
    ```
 
    如果 dashboard 或 controller 在 spend 后仍需状态更新，再运行第 8 步不带

--- a/examples/control_plane/heartbeat-prompt-smoke.py
+++ b/examples/control_plane/heartbeat-prompt-smoke.py
@@ -311,7 +311,7 @@ def main() -> int:
         '--turn-instance-id "${LOOPX_TURN:?}"'
     ), payload
     assert payload["quota_spend_command"] == (
-        'loopx --registry "$HOME/.codex/loopx/registry.global.json" '
+        'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" '
         "quota spend-slot --goal-id public-heartbeat-goal --slots 1 --source heartbeat --execute"
     ), payload
     assert compact_payload["compact"] is True, compact_payload
@@ -484,8 +484,9 @@ def main() -> int:
         "loopx todo add --goal-id public-heartbeat-goal --role user --task-class user_gate|user_action",
         "owner todos and `--role agent` for agent todos, not prose",
         "Done->successor first; final->refresh->spend->no-follow-up",
-        'loopx --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id public-heartbeat-goal --slots 1 --source heartbeat --execute',
-        "Account actual validated class/scale/outcome",
+        'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id public-heartbeat-goal --slots 1 --source heartbeat --execute',
+        "Account actual class/scale/outcome",
+        "once unpiped; never retry",
         "Optional state-only post-spend",
         "No spend for quiet skips",
     ):
@@ -630,9 +631,7 @@ def main() -> int:
     )
     brief_task = normalized(str(brief_payload["task_body"]))
     for phrase in (
-        "Brief installed LoopX heartbeat",
-        "Thin dispatcher",
-        "Thin dispatcher; detail",
+        "Brief LoopX heartbeat; detail",
         "loopx heartbeat-prompt --compact --goal-id public-heartbeat-goal --active-state /tmp/public-heartbeat-goal/ACTIVE_GOAL_STATE.md",
         "Guard/retry; `LOOPX_TURN=<current_time_iso>`",
         'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota should-run --goal-id public-heartbeat-goal',
@@ -655,8 +654,9 @@ def main() -> int:
         "bounded segment/batch",
         "validate/writeback/todos",
         "Progress(actual,no upgrade)",
+        "Spend once; no pipe/retry",
         "Post-spend state",
-        'loopx --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id public-heartbeat-goal --slots 1 --source heartbeat --execute',
+        'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id public-heartbeat-goal --slots 1 --source heartbeat --execute',
         "No spend for quiet skips",
     ):
         assert phrase in brief_task, phrase
@@ -826,7 +826,7 @@ def main() -> int:
         "loopx todo add --goal-id <GOAL_ID> --role user --task-class user_action",
         "Use `--role agent` for project-agent follow-up work",
         "docs/project-agent-todo-contract.md",
-        'loopx --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id <GOAL_ID> --todo-id <SELECTED_TODO_ID> --slots 1 --source heartbeat --execute',
+        'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id <GOAL_ID> --todo-id <SELECTED_TODO_ID> --slots 1 --source heartbeat --execute',
         "loopx refresh-state --goal-id <GOAL_ID>",
         "--classification <PUBLIC_SAFE_PROGRESS_CLASSIFICATION>",
         "--delivery-batch-scale <ACTUAL_DELIVERY_BATCH_SCALE>",
@@ -932,7 +932,7 @@ def main() -> int:
         "loopx todo add --goal-id public-heartbeat-goal --role user --task-class user_gate",
         "loopx todo add --goal-id public-heartbeat-goal --role user --task-class user_action",
         "docs/project-agent-todo-contract.md",
-        'loopx --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id public-heartbeat-goal --slots 1 --source heartbeat --execute',
+        'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id public-heartbeat-goal --slots 1 --source heartbeat --execute',
         "loopx refresh-state --goal-id public-heartbeat-goal",
         "--classification <PUBLIC_SAFE_PROGRESS_CLASSIFICATION>",
         "--delivery-batch-scale <ACTUAL_DELIVERY_BATCH_SCALE>",
@@ -985,7 +985,7 @@ def main() -> int:
             "Public-safe repo publication is not an operator gate by itself",
             "Run the smallest useful validation",
             "loopx refresh-state --goal-id <GOAL_ID>",
-            'loopx --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id <GOAL_ID> --todo-id <SELECTED_TODO_ID> --slots 1 --source heartbeat --execute',
+            'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id <GOAL_ID> --todo-id <SELECTED_TODO_ID> --slots 1 --source heartbeat --execute',
             "If the dashboard or controller needs a state-only update after spend",
             "Return a compact final report",
         ),

--- a/examples/control_plane/heartbeat-prompt-smoke.py
+++ b/examples/control_plane/heartbeat-prompt-smoke.py
@@ -833,6 +833,7 @@ def main() -> int:
         "--delivery-outcome <ACTUAL_DELIVERY_OUTCOME>",
         "Never default or upgrade smaller/preparatory work",
         "append exactly one",
+        "If spend output is ambiguous, verify with read-only quota status; never rerun.",
         "Do not append spend for quiet should_run=false skips, preflight failures, pure dry-run previews, or duplicate accounting attempts",
         "safe_bypass_allowed=true and you actually completed a bounded safe-bypass step",
         "safe_bypass_kind=outcome_floor_recovery",

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -786,7 +786,7 @@ def main() -> int:
             '--turn-instance-id "${LOOPX_TURN:?}"'
         ), payload
         assert payload["quota_spend_command"] == (
-            'loopx --registry "$HOME/.codex/loopx/registry.global.json" '
+            'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" '
             "quota spend-slot --goal-id installer-smoke-goal --slots 1 --source heartbeat --execute"
         ), payload
         assert payload["thin"] is True, payload

--- a/examples/project/project-prompt-smoke.py
+++ b/examples/project/project-prompt-smoke.py
@@ -69,8 +69,9 @@ SPEND_MUST_HAVE = (
     "`multi_surface` / `outcome_progress`",
     "accountable delivery",
     "普通 state-only refresh 不能替代它",
-    "然后只 append 一次 quota spend",
-    'loopx --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id',
+    "然后原样（不加管道或过滤）append 一次 quota spend",
+    "不能重跑",
+    'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota spend-slot --goal-id',
     "--source adapter --execute",
     "在 spend 后仍需状态更新",
     "不要在 spend 后追加另一个 accountable progress refresh",
@@ -169,7 +170,7 @@ def main() -> int:
         "--runtime-profile outer_controller"
     ), payload
     assert payload["quota_spend_command"] == (
-        'loopx --registry "$HOME/.codex/loopx/registry.global.json" '
+        'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" '
         "quota spend-slot --goal-id new-project-main-control --slots 1 --source adapter --execute"
     ), payload
     assert payload["progress_refresh_command"] == (

--- a/loopx/control_plane/heartbeat/task_body.py
+++ b/loopx/control_plane/heartbeat/task_body.py
@@ -552,21 +552,21 @@ for `user_channel.notify=NOTIFY`, otherwise wait.{host_wait_rule}
 
 `should_run=true`: take highest-priority unblocked in-scope todo; honor
 claims/leases and blocker-push/recovery obligations. Before dependencies, persist changed
-scope/acceptance/non-goal evidence and next todo. One bounded segment stays in this
-same Goal: a segment is progress, not a new Goal boundary. Reuse this activation
-across phases/revisions until terminal; do not create a successor host Goal merely to
-continue. Validate/write public-safe evidence, critic, and next action.
+scope/acceptance/non-goal evidence and next todo. Keep work bounded: a segment is
+progress, not a new Goal boundary. Reuse this Goal until terminal; do not create a
+successor host Goal merely to continue.
+Validate/write public-safe evidence, critic, and next action.
 {HOST_LOOP_TODO_CLOSEOUT_RULE}
 
 Use actual classification/scale/outcome only; never default or upgrade them to
 `multi_surface` / `outcome_progress`; refresh the accountable progress record
 before spending: `{progress_refresh_state_command}`. Then spend exactly once
 against that refresh; no pipe/retry: `{quota_spend_command}`.
+Rerun the same guard read-only. Complete {completion_subject} only on
+`should_run=false` + terminal no-follow-up; otherwise obey its next action.
 
 No spend: gate/wait/dry-run/preflight failure/no-op/duplicate. Stop: private/company
 material, credentials, destructive git, unauthorized production, or repo rules.
-Complete {completion_subject} only on LoopX terminal success with no follow-up; else
-keep the gate or next action explicit.
 
 {policy_tail}"""
 def render_ark_managed_agent_goal_task_body(

--- a/loopx/control_plane/heartbeat/task_body.py
+++ b/loopx/control_plane/heartbeat/task_body.py
@@ -226,6 +226,9 @@ If the result says `should_run=true`:
    {quota_spend_command}
    ```
 
+   If spend output is ambiguous, verify with read-only quota status; never
+   rerun.
+
    Do not append spend for quiet `should_run=false` skips, preflight failures,
    pure dry-run previews, or duplicate accounting attempts. If
    `should_run=false` but `safe_bypass_allowed=true` and you actually completed

--- a/loopx/control_plane/heartbeat/task_body.py
+++ b/loopx/control_plane/heartbeat/task_body.py
@@ -220,7 +220,7 @@ If the result says `should_run=true`:
    ```
 
    Spend consumes this causal record; plain state-only refresh cannot replace
-   it. Then spend once:
+   it. Run spend once as rendered; no pipe/filter/retry:
 
    ```bash
    {quota_spend_command}
@@ -271,7 +271,7 @@ def render_brief_heartbeat_task_body(
     )
     return f"""Advance `{goal_id}` using `{active_state}`.
 
-Brief installed LoopX heartbeat. Thin dispatcher; detail:
+Brief LoopX heartbeat; detail:
 `{compact_prompt_command}`.
 {scope_block}
 
@@ -303,7 +303,7 @@ If `should_run=true`: fetch compact; use `status --limit 3` and
 ranker/cross-domain evidence recovery or blocker writeback;
 validate/writeback/todos; {HOST_LOOP_TODO_CLOSEOUT_COMPACT_RULE} Progress(actual,no upgrade):
 `{progress_refresh_state_command}`
-Spend:
+Spend once; no pipe/retry:
 `{quota_spend_command}`
 Post-spend state:
 `{refresh_state_command}`
@@ -408,8 +408,8 @@ If `should_run=true`:
    use `{cli_bin} todo add --goal-id {goal_id} --role user --task-class user_gate|user_action`
    for owner todos and `--role agent` for agent todos, not prose.
    {HOST_LOOP_TODO_CLOSEOUT_COMPACT_RULE}
-9. Account actual validated class/scale/outcome; never default/upgrade. Then
-   refresh and spend:
+9. Account actual class/scale/outcome; no defaults. Refresh; spend once
+   unpiped; never retry:
 
 ```bash
 {progress_refresh_state_command}
@@ -544,13 +544,13 @@ def _render_goal_task_body(
 
 {RUNTIME_EXECUTION_ROUTING_RULE}
 
-At each continuation inspect LoopX state/status/repo. {prequota_block}{HOST_LOOP_QUOTA_DISPATCH_RULE}
+Each continuation inspect state/status/repo. {prequota_block}{HOST_LOOP_QUOTA_DISPATCH_RULE}
 Guard: `{quota_guard_command}`.
 
-`should_run=false`: no delivery/spend; surface a concrete Chinese action/gate only
+`should_run=false`: no delivery/spend; surface concrete Chinese action/gate only
 for `user_channel.notify=NOTIFY`, otherwise wait.{host_wait_rule}
 
-`should_run=true`: take the highest-priority in-scope unblocked agent todo; honor
+`should_run=true`: take highest-priority unblocked in-scope todo; honor
 claims/leases and blocker-push/recovery obligations. Before dependencies, persist changed
 scope/acceptance/non-goal evidence and next todo. One bounded segment stays in this
 same Goal: a segment is progress, not a new Goal boundary. Reuse this activation
@@ -559,14 +559,13 @@ continue. Validate/write public-safe evidence, critic, and next action.
 {HOST_LOOP_TODO_CLOSEOUT_RULE}
 
 Use actual classification/scale/outcome only; never default or upgrade them to
-`multi_surface` / `outcome_progress`; refresh the accountable progress record before
-spending:
-`{progress_refresh_state_command}`. Then spend exactly once against that refresh:
-`{quota_spend_command}`.
+`multi_surface` / `outcome_progress`; refresh the accountable progress record
+before spending: `{progress_refresh_state_command}`. Then spend exactly once
+against that refresh; no pipe/retry: `{quota_spend_command}`.
 
 No spend: gate/wait/dry-run/preflight failure/no-op/duplicate. Stop: private/company
 material, credentials, destructive git, unauthorized production, or repo rules.
-Complete this {completion_subject} only on LoopX terminal success with no follow-up; else
+Complete {completion_subject} only on LoopX terminal success with no follow-up; else
 keep the gate or next action explicit.
 
 {policy_tail}"""

--- a/loopx/project_prompt.py
+++ b/loopx/project_prompt.py
@@ -123,7 +123,7 @@ def render_quota_spend_command(
     agent_arg = f" --agent-id {shell_arg(agent_id)}" if agent_id else ""
     capability_args = render_available_capability_args(available_capabilities)
     return (
-        f"{shell_arg(cli_bin)} "
+        f"{shell_arg(cli_bin)} --format json "
         f"--registry {SHARED_GLOBAL_REGISTRY} "
         "quota spend-slot "
         f"--goal-id {shell_arg(goal_id)} "
@@ -758,8 +758,10 @@ setup-only turn. The configured thin loop spends only after a later validated
 delivery writeback. If I explicitly asked you to do delivery in this same turn
 and you completed a validated delivery segment, replace all three placeholders
 with this turn's actual validated classification, batch scale, and outcome.
-Never default or upgrade them to `multi_surface` / `outcome_progress`. Then write
-one accountable progress refresh and spend exactly once against that record:
+Never default or upgrade them to `multi_surface` / `outcome_progress`. Run the
+rendered commands without pipes or filters: write one accountable progress
+refresh, then spend exactly once. If spend output is ambiguous, use read-only
+quota status; never rerun it:
 
 ```bash
 {progress_refresh_command}
@@ -971,7 +973,8 @@ def render_prompt_text(
 ```
 
    这是 `spend-slot` 将消费的因果记录；普通 state-only refresh 不能替代它。
-   然后只 append 一次 quota spend：
+   然后原样（不加管道或过滤）append 一次 quota spend；输出为空或不明确时用只读
+   quota status 核对，不能重跑：
 
 ```bash
 {quota_spend_command}

--- a/tests/test_ark_managed_agent_host.py
+++ b/tests/test_ark_managed_agent_host.py
@@ -74,7 +74,7 @@ def test_goal_prompt_is_one_transport_independent_activation() -> None:
     assert "invoke LoopX Turn" in normalized
     assert "a segment is progress, not a new Goal boundary" in normalized
     assert (
-        "Reuse this activation across phases/revisions until terminal"
+        "Reuse this Goal until terminal"
     ) in normalized
     assert "do not create a successor host Goal merely to continue" in normalized
     assert (
@@ -82,7 +82,7 @@ def test_goal_prompt_is_one_transport_independent_activation() -> None:
         "lifecycle/registry and `loopx-self-repair` for runtime/projection drift."
         in normalized
     )
-    assert "take the highest-priority in-scope unblocked agent todo" in normalized
+    assert "take highest-priority unblocked in-scope todo" in normalized
     assert "claims/leases and blocker-push/recovery obligations" in normalized
     assert (
         "Before dependencies, persist changed scope/acceptance/non-goal evidence "

--- a/tests/test_host_loop_activation.py
+++ b/tests/test_host_loop_activation.py
@@ -301,10 +301,12 @@ def test_goal_hosts_attribute_spend_to_current_progress_refresh(
     assert "--delivery-batch-scale multi_surface" not in refresh_command
     assert "--delivery-outcome outcome_progress" not in refresh_command
     normalized_task_body = " ".join(task_body.split())
+    assert payload["quota_spend_command"].startswith("loopx --format json ")
     assert (
         "never default or upgrade them to `multi_surface` / `outcome_progress`"
         in normalized_task_body
     )
+    assert "no pipe/retry" in normalized_task_body
 
 
 @pytest.mark.parametrize(

--- a/tests/test_visible_goal_terminal_settlement.py
+++ b/tests/test_visible_goal_terminal_settlement.py
@@ -17,7 +17,14 @@ def test_visible_goal_keeps_final_todo_nonterminal_until_spend() -> None:
     )
     refresh = "refresh the accountable progress record before spending"
     spend = "Then spend exactly once against that refresh"
+    readback = "Rerun the same guard read-only"
+    terminal_readback = (
+        "Complete visible Goal only on `should_run=false` + terminal "
+        "no-follow-up"
+    )
 
     assert task_body.index(terminal_rule) < task_body.index(refresh)
     assert task_body.index(refresh) < task_body.index(spend)
+    assert task_body.index(spend) < task_body.index(readback)
+    assert terminal_readback in task_body
     assert payload["interface_budget"]["within_budget"] is True


### PR DESCRIPTION
## What changed

- render generated `quota spend-slot` commands with JSON output across Goal and heartbeat prompts
- tell agents to execute the rendered spend command once without pipes or output filters
- direct ambiguous-output recovery to a read-only quota status check instead of retrying the mutation
- require visible Goal hosts to rerun the read-only guard after spend and complete only on an explicit terminal no-follow-up decision
- keep compact and brief prompt variants inside their existing interface budgets
- align the public prompt documentation and durable smokes with the generated command

## Why

A quota spend can succeed even when an added shell filter hides its Markdown output. An agent may interpret the empty output as a failed command and run the mutation again, producing duplicate accounting. Machine-readable output plus an explicit no-pipe/no-retry contract closes that ambiguity.

Spend success is also not proof that the Goal is terminal: the refreshed state may still project runnable follow-up or repair work. A mandatory read-only guard after spend prevents the host Goal from reporting completion while LoopX still requires another action.

## Validation

- `scripts/loopx canary premerge --from-git-diff --format json` — 18/18 selected checks passed, including install/update, quota/work-lane, benchmark-ledger, CLI-budget, and public-boundary coverage; 0 failures, warnings, or manual holds
- focused Goal host lifecycle tests — 78 passed
- `python examples/control_plane/heartbeat-prompt-smoke.py`
- `python examples/project/project-prompt-smoke.py`
- `git diff --check`
