### PR TITLE
Fix live model command paths before v0.4.8 release

### DIFF
--- a/loopx/control_plane/testing/replan_semantic_action_behavior.py
+++ b/loopx/control_plane/testing/replan_semantic_action_behavior.py
@@ -74,6 +74,7 @@ class _QualificationState:
     semantic_delta: dict[str, Any] | None = None
     seen_quota: bool = False
     seen_clock: bool = False
+    seen_refresh_state_help: bool = False
     read_only_host_commands_executed: bool = False
     frontier_context_read: bool = False
     work_source_read: bool = False
@@ -174,10 +175,7 @@ def _build_fixture(
         else (
             f"Read `{_FIXTURE_FRONTIER_FILE}`, inspect the selected uncovered "
             "entry's `source_ref`, then persist the typed result through "
-            "refresh-state. If replan creates a successor Todo, bind the current "
-            "replan obligation in that same Todo add; when the command returns "
-            "host_action=end_current_heartbeat, end this heartbeat and do not "
-            "execute the successor until the next heartbeat."
+            "refresh-state."
         )
     )
     fixture_agent_todo = (
@@ -670,6 +668,37 @@ def _bounded_workspace_read_plan(
     return bounded_workspace_read_plan(command, fixture=fixture)
 
 
+def _bounded_refresh_state_help_limit(command: str) -> int | None:
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|<>\n")
+    lexer.whitespace = " \t\r"
+    lexer.whitespace_split = True
+    try:
+        tokens = list(lexer)
+    except ValueError:
+        return None
+    if len(tokens) < 3 or Path(tokens[0]).name != "loopx":
+        return None
+    if tokens[1:3] != ["refresh-state", "--help"]:
+        return None
+    remainder = tokens[3:]
+    if remainder[:3] == ["2", ">&", "1"]:
+        remainder = remainder[3:]
+    if not remainder:
+        return 200
+    if remainder[:2] != ["|", "head"]:
+        return None
+    if len(remainder) == 3 and remainder[2].startswith("-"):
+        limit_text = remainder[2][1:]
+    elif len(remainder) == 4 and remainder[2] == "-n":
+        limit_text = remainder[3]
+    else:
+        return None
+    if not limit_text.isdigit():
+        return None
+    limit = int(limit_text)
+    return limit if 1 <= limit <= 200 else None
+
+
 def _execute_workspace_read(
     command: str,
     *,
@@ -837,6 +866,24 @@ def _handle_workspace_read(command: str, state: _QualificationState) -> str:
     state.work_source_read = state.work_source_read or read_work_source
     state.read_only_host_commands_executed = True
     return output
+
+
+def _handle_refresh_state_help(
+    state: _QualificationState,
+    *,
+    line_limit: int,
+) -> str:
+    _require_observed_frontier(state, prefix="refresh_state_help")
+    if state.seen_refresh_state_help:
+        raise ValueError("repeated_refresh_state_help")
+    output = execute_loopx_cli(
+        "loopx refresh-state --help",
+        source_root=state.fixture.source_root,
+        project_root=state.fixture.project_root,
+    )
+    state.seen_refresh_state_help = True
+    state.read_only_host_commands_executed = True
+    return "\n".join(output.splitlines()[:line_limit]) + "\n"
 
 
 def _expected_obligation_id(state: _QualificationState) -> str:
@@ -1007,6 +1054,12 @@ def _dispatch_behavior_command(
         return _handle_clock_command(clock_output, state), "clock", False
     if _bounded_workspace_read_plan(command, fixture=state.fixture) is not None:
         return _handle_workspace_read(command, state), "workspace_read", False
+    if (help_limit := _bounded_refresh_state_help_limit(command)) is not None:
+        return (
+            _handle_refresh_state_help(state, line_limit=help_limit),
+            "refresh_state_help",
+            False,
+        )
     if _is_replan_successor_create(command):
         return _handle_successor_command(command, state), "replan_successor_create", True
     if (observation := _progress_observation_from_command(command)) is not None:
@@ -1020,6 +1073,28 @@ def _dispatch_behavior_command(
     raise ValueError("unexpected_command")
 
 
+def _behavior_command_kind(
+    command: str,
+    state: _QualificationState,
+) -> str:
+    """Classify a proposed command before its handler can fail."""
+
+    if _is_quota_guard(command):
+        return "quota_should_run"
+    if _clock_output(command) is not None:
+        return "clock"
+    if _bounded_workspace_read_plan(command, fixture=state.fixture) is not None:
+        return "workspace_read"
+    if _bounded_refresh_state_help_limit(command) is not None:
+        return "refresh_state_help"
+    if _is_replan_successor_create(command):
+        return "replan_successor_create"
+    tokens = loopx_command_tokens(command) or []
+    if "refresh-state" in tokens:
+        return "semantic_replan_writeback"
+    return "unexpected_command"
+
+
 _EXPECTED_BEHAVIOR_FAILURES = frozenset(
     {
         "repeated_quota_should_run",
@@ -1028,6 +1103,10 @@ _EXPECTED_BEHAVIOR_FAILURES = frozenset(
         "semantic_action_before_frontier_read",
         "semantic_action_before_work_source_read",
         "semantic_action_misses_uncovered_frontier",
+        "refresh_state_help_before_quota",
+        "refresh_state_help_before_frontier_read",
+        "refresh_state_help_before_work_source_read",
+        "repeated_refresh_state_help",
         "successor_create_before_quota",
         "successor_create_before_frontier_read",
         "successor_create_before_work_source_read",
@@ -1098,12 +1177,13 @@ def _run_qualification_loop(
                 passed=False,
                 failure_code="model_returned_without_semantic_action",
             )
-        kind = "unexpected_command"
+        kind = _behavior_command_kind(tool_call.command, state)
         try:
-            output, kind, completed = _dispatch_behavior_command(
+            output, dispatched_kind, completed = _dispatch_behavior_command(
                 tool_call.command,
                 state,
             )
+            kind = dispatched_kind
         except (RuntimeError, ValueError, json.JSONDecodeError) as exc:
             _record_tool_step(state, kind=kind, command=tool_call.command)
             return _qualification_receipt(
@@ -1194,7 +1274,16 @@ class DoubaoReplanSemanticActionBehaviorActor:
                     "root; relative paths in the active-state action resolve there. "
                     "Treat the quota packet as the control-plane authority. Complete "
                     "one bounded in-scope action and persist its result through the "
-                    "real LoopX CLI."
+                    "real LoopX CLI. After quota, `cat` only the exact path named "
+                    "in active_state_next_action, then `cat` only the source_ref "
+                    "returned by that target, and fill and execute "
+                    "interaction_contract.cli_channel.next_cli_actions[0]. Do not "
+                    "use ls, find, rg, or paged help. If refresh-state syntax is "
+                    "still unclear, run exactly `loopx refresh-state --help` once, "
+                    "then execute the projected typed writeback. This scenario has "
+                    "a direct refresh-state outcome: execute exactly one loopx "
+                    "refresh-state command; do not create a Todo, chain commands, "
+                    "or combine actions."
                 ),
             },
             {"role": "user", "content": fixture.task_body},

--- a/loopx/control_plane/testing/selected_todo_tool_behavior.py
+++ b/loopx/control_plane/testing/selected_todo_tool_behavior.py
@@ -38,7 +38,8 @@ SELECTED_TODO_TOOL_FIXTURE_TODO_ID = "todo_portfolio001"
 _SELECTED_TARGET = "fixture/selected-lane.json"
 _DECOY_TARGET = "fixture/deferred-lane.json"
 SELECTED_TODO_TOOL_FIXTURE_ACTION_TEXT = (
-    f"Inspect `{_SELECTED_TARGET}` and verify its lane contract."
+    f"Read only `{_SELECTED_TARGET}`; use its self-contained JSON to verify "
+    "the selected lane contract."
 )
 _READ_ONLY_PREFLIGHT_COMMANDS = {
     "pwd",
@@ -369,11 +370,19 @@ def _metadata_pipeline_step(
         fixture.global_registry_path.resolve(),
         (fixture.project_root / ".loopx" / "registry.json").resolve(),
     }
-    if target not in allowed_registries:
+    if target in allowed_registries:
+        return BoundedWorkspaceReadStep(
+            "metadata",
+            ("head", "-n", str(limit), str(target)),
+            operator=operator,
+        )
+    content_target = _resolve_project_path(left[1], fixture=fixture)
+    if content_target is None:
         return None
     return BoundedWorkspaceReadStep(
-        "metadata",
-        ("head", "-n", str(limit), str(target)),
+        "content",
+        ("head", "-n", str(limit), str(content_target)),
+        target=content_target,
         operator=operator,
     )
 
@@ -581,12 +590,20 @@ def _discovery_tokens(
                 return None
             index += 2
             continue
-        if (
+        path_pattern_index: int | None = None
+        next_index: int | None = None
+        if token == "-path" and index + 1 < len(tokens):
+            path_pattern_index = index + 1
+            next_index = index + 2
+        elif (
             token == "-not"
             and index + 2 < len(tokens)
             and tokens[index + 1] == "-path"
         ):
-            pattern = tokens[index + 2]
+            path_pattern_index = index + 2
+            next_index = index + 3
+        if path_pattern_index is not None and next_index is not None:
+            pattern = tokens[path_pattern_index]
             if (
                 not pattern
                 or len(pattern.encode("utf-8")) > 128
@@ -594,7 +611,7 @@ def _discovery_tokens(
                 or ".." in Path(pattern).parts
             ):
                 return None
-            index += 3
+            index = next_index
             continue
         return None
     argv = [executable, str(root), *tokens[2:]]
@@ -869,7 +886,13 @@ class DoubaoSelectedTodoToolBehaviorActor:
                 "content": (
                     "You are Codex running one LoopX heartbeat. Follow the "
                     "heartbeat task and use the available shell tool when needed. "
-                    "Choose each next action from the latest tool result."
+                    "The shell working directory is the connected goal project "
+                    "root; resolve relative paths from the selected Todo there. "
+                    "Choose each next action from the latest tool result. After "
+                    "quota, execute the exact action in selected_todo.text directly. "
+                    "When it names one file, read only that file; do not discover, "
+                    "compare, or inspect other targets. After that selected Todo "
+                    "tool succeeds, call no more tools."
                 ),
             },
             {"role": "user", "content": fixture.task_body},

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -943,14 +943,16 @@ def interaction_next_cli_actions(
         typed_progress_args = (
             "--progress-result-class "
             "<advanced|blocked|exploration_exhausted|no_followup> "
-            "<typed-progress-identifiers-and-evidence>"
+            "--progress-surface-id <surface-id> "
+            "--progress-hypothesis-id <hypothesis-id> "
+            "--progress-probe-kind <probe-kind> "
+            "--progress-evidence-id <evidence-id>"
         )
         refresh_command = (
-            f"loopx refresh-state --goal-id {goal_id} "
+            f"loopx --format json refresh-state --goal-id {goal_id} "
             "--progress-scope agent_lane "
             "--classification bounded_replan_progress "
-            f"{typed_progress_args} "
-            "--delivery-batch-scale <scale> --delivery-outcome <outcome>"
+            f"{typed_progress_args}"
             f"{settlement_args}{scoped_cli_args}"
         )
         return [

--- a/tests/control_plane/test_monitor_replan_agent_scope.py
+++ b/tests/control_plane/test_monitor_replan_agent_scope.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import shlex
+
+from loopx.cli import build_parser
 from loopx.cli_commands.status import attach_agent_lane_next_actions
 from loopx.control_plane.agents.agent_lane_recommendation import (
     scope_status_item_to_agent_lane,
@@ -645,7 +648,28 @@ def test_nonblocking_user_action_does_not_suppress_empty_frontier_replan() -> No
     assert contract["user_channel"]["non_blocking"] is True, contract
     assert contract["agent_channel"]["must_attempt"] is True, contract
     cli_actions = contract["cli_channel"]["next_cli_actions"]
-    assert any("refresh-state" in action for action in cli_actions), cli_actions
+    refresh_action = next(action for action in cli_actions if "refresh-state" in action)
+    assert "--progress-surface-id <surface-id>" in refresh_action
+    assert "--progress-hypothesis-id <hypothesis-id>" in refresh_action
+    assert "--progress-probe-kind <probe-kind>" in refresh_action
+    assert "--progress-evidence-id <evidence-id>" in refresh_action
+    assert "typed-progress-identifiers-and-evidence" not in refresh_action
+    assert refresh_action.startswith("loopx --format json refresh-state ")
+    assert "--delivery-batch-scale" not in refresh_action
+    assert "--delivery-outcome" not in refresh_action
+    rendered_action = (
+        refresh_action.replace(
+            "<advanced|blocked|exploration_exhausted|no_followup>",
+            "advanced",
+        )
+        .replace("<surface-id>", "surface-new")
+        .replace("<hypothesis-id>", "hypothesis-new")
+        .replace("<probe-kind>", "probe-new")
+        .replace("<evidence-id>", "evidence-new")
+    )
+    parsed = build_parser().parse_args(shlex.split(rendered_action)[1:])
+    assert parsed.command == "refresh-state"
+    assert parsed.progress_result_class == "advanced"
     assert not any("todo add" in action for action in cli_actions), cli_actions
 
 

--- a/tests/control_plane/test_replan_semantic_action_behavior.py
+++ b/tests/control_plane/test_replan_semantic_action_behavior.py
@@ -4,9 +4,11 @@ import json
 import shlex
 from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 
 import pytest
 
+import loopx.control_plane.testing.replan_semantic_action_behavior as replan_behavior
 from loopx.control_plane.testing.model_tool_behavior import (
     ScriptedAssistantAction,
     ScriptedDoubaoExecTransport,
@@ -156,8 +158,19 @@ def test_real_tool_loop_chooses_and_persists_semantic_replan_action(
         "read_only_host_commands_executed": True,
     }
 
+    system_prompt = transport.requests[0]["messages"][0]["content"]
+    assert "`cat` only the exact path named in active_state_next_action" in system_prompt
+    assert "`cat` only the source_ref returned by that target" in system_prompt
+    assert "interaction_contract.cli_channel.next_cli_actions[0]" in system_prompt
+    assert "Do not use ls, find, rg, or paged help" in system_prompt
+    assert "exactly `loopx refresh-state --help` once" in system_prompt
+    assert "execute the projected typed writeback" in system_prompt
+    assert "execute exactly one loopx refresh-state command" in system_prompt
+    assert "do not create a Todo, chain commands, or combine actions" in system_prompt
+
     quota_packet = json.loads(transport.requests[2]["messages"][-1]["content"])
     assert quota_packet.get("required_reads") in (None, [])
+    assert "successor Todo" not in quota_packet["active_state_next_action"]
     assert quota_packet["autonomous_replan_obligation"]["replan_context"][
         "delivery_receipt"
     ]["status"] == "delivered"
@@ -188,6 +201,130 @@ def test_real_tool_loop_chooses_and_persists_semantic_replan_action(
         "surface-permission-config"
     )
     assert latest["autonomous_replan_ack"]["semantic_delta"]["accepted"] is True
+
+
+def test_semantic_cli_execution_failure_retains_command_kind(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    transport = ScriptedDoubaoExecTransport(
+        [
+            ScriptedExecToolAction(command=fixture.quota_guard_command),
+            ScriptedExecToolAction(command="cat replan-frontier.json"),
+            ScriptedExecToolAction(command="cat fixture/permission-config.json"),
+            _semantic_action,
+        ]
+    )
+    original_execute = replan_behavior._execute_loopx
+
+    def fail_semantic_writeback(command: str, **kwargs: Any) -> str:
+        if "refresh-state" in command:
+            raise RuntimeError("synthetic CLI execution failure")
+        return original_execute(command, **kwargs)
+
+    monkeypatch.setattr(replan_behavior, "_execute_loopx", fail_semantic_writeback)
+    receipt = DoubaoReplanSemanticActionBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="replan-semantic-action-cli-failure",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is False
+    assert receipt["failure_code"] == "semantic_replan_writeback_execution_failed"
+    assert receipt["observed_tool_sequence"][-1] == "semantic_replan_writeback"
+
+
+def test_real_tool_loop_allows_bounded_refresh_state_help(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    transport = ScriptedDoubaoExecTransport(
+        [
+            ScriptedExecToolAction(command=fixture.quota_guard_command),
+            ScriptedExecToolAction(command="cat replan-frontier.json"),
+            ScriptedExecToolAction(command="cat fixture/permission-config.json"),
+            ScriptedExecToolAction(
+                command="loopx refresh-state --help 2>&1 | head -60"
+            ),
+            _semantic_action,
+        ]
+    )
+    receipt = DoubaoReplanSemanticActionBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="replan-bounded-refresh-state-help",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is True, receipt
+    assert receipt["observed_tool_sequence"] == [
+        "quota_should_run",
+        "workspace_read",
+        "workspace_read",
+        "refresh_state_help",
+        "semantic_replan_writeback",
+    ]
+    assert receipt["semantic_action_accepted"] is True
+
+
+def test_real_tool_loop_preserves_projected_targets_through_content_pipelines(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    transport = ScriptedDoubaoExecTransport(
+        [
+            ScriptedExecToolAction(command=fixture.quota_guard_command),
+            ScriptedExecToolAction(
+                command="cat replan-frontier.json 2>/dev/null | head -200"
+            ),
+            ScriptedExecToolAction(
+                command="cat fixture/permission-config.json | head -200"
+            ),
+            _semantic_action,
+        ]
+    )
+    receipt = DoubaoReplanSemanticActionBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="replan-bounded-content-pipelines",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is True, receipt
+    assert receipt["observed_tool_sequence"] == [
+        "quota_should_run",
+        "workspace_read",
+        "workspace_read",
+        "semantic_replan_writeback",
+    ]
+    assert receipt["semantic_action_accepted"] is True
+
+
+def test_refresh_state_help_requires_projected_frontier_reads(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    transport = ScriptedDoubaoExecTransport(
+        [
+            ScriptedExecToolAction(command=fixture.quota_guard_command),
+            ScriptedExecToolAction(command="loopx refresh-state --help"),
+        ]
+    )
+    receipt = DoubaoReplanSemanticActionBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="replan-help-before-frontier",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is False
+    assert receipt["failure_code"] == "refresh_state_help_before_frontier_read"
 
 
 def test_model_exits_after_replan_confirms_goal_coverage_is_exhausted(

--- a/tests/control_plane/test_selected_todo_tool_behavior.py
+++ b/tests/control_plane/test_selected_todo_tool_behavior.py
@@ -70,8 +70,14 @@ def test_real_tool_loop_executes_action_selected_by_real_quota(
             "role": "system",
             "content": (
                 "You are Codex running one LoopX heartbeat. Follow the heartbeat "
-                "task and use the available shell tool when needed. Choose each "
-                "next action from the latest tool result."
+                "task and use the available shell tool when needed. The shell "
+                "working directory is the connected goal project root; resolve "
+                "relative paths from the selected Todo there. Choose each next "
+                "action from the latest tool result. After quota, execute the exact "
+                "action in selected_todo.text directly. When it names one file, "
+                "read only that file; do not discover, compare, or inspect other "
+                "targets. After that selected Todo tool succeeds, call no more "
+                "tools."
             ),
         },
         {"role": "user", "content": fixture.task_body},
@@ -172,6 +178,68 @@ def test_tool_loop_allows_bounded_discovery_with_safe_path_exclusion(
     ]
 
 
+def test_tool_loop_allows_bounded_discovery_with_positive_path_filter(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    commands = [
+        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
+        (
+            'ls -la && find . -name "selected-lane.json" '
+            '-path "*/fixture/*" 2>/dev/null'
+        ),
+        "cat fixture/selected-lane.json",
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        command = commands[call_count]
+        call_count += 1
+        return _tool_response(f"call-{call_count}", command)
+
+    receipt = DoubaoSelectedTodoToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="selected-todo-positive-path-filter",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is True
+    assert receipt["observed_tool_sequence"] == [
+        "quota_should_run",
+        "workspace_read",
+        "selected_action",
+    ]
+
+
+def test_tool_loop_rejects_absolute_positive_path_filter(tmp_path: Path) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    commands = [
+        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
+        'find . -path "/etc/*"',
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        command = commands[call_count]
+        call_count += 1
+        return _tool_response(f"call-{call_count}", command)
+
+    receipt = DoubaoSelectedTodoToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="selected-todo-reject-absolute-path-filter",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is False
+    assert receipt["failure_code"] == "unexpected_command"
+
+
 def test_tool_loop_allows_bounded_discovery_pipeline_before_action(
     tmp_path: Path,
 ) -> None:
@@ -204,6 +272,37 @@ def test_tool_loop_allows_bounded_discovery_pipeline_before_action(
     assert receipt["observed_tool_sequence"] == [
         "quota_should_run",
         "workspace_read",
+        "selected_action",
+    ]
+
+
+def test_tool_loop_allows_bounded_selected_content_pipeline(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_fixture(tmp_path / "oracle")
+    commands = [
+        fixture.quota_guard_command.replace('"${LOOPX_TURN:?}"', "turn-001"),
+        "cat fixture/selected-lane.json 2>/dev/null | head -200",
+    ]
+    call_count = 0
+
+    def transport(**_: Any) -> Mapping[str, Any]:
+        nonlocal call_count
+        command = commands[call_count]
+        call_count += 1
+        return _tool_response(f"call-{call_count}", command)
+
+    receipt = DoubaoSelectedTodoToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify(
+        qualification_id="selected-todo-bounded-content-pipeline",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is True
+    assert receipt["observed_tool_sequence"] == [
+        "quota_should_run",
         "selected_action",
     ]
 


### PR DESCRIPTION
## Summary

- make the autonomous-replan interaction command directly executable by projecting the exact typed progress flags, requesting JSON output, and removing ambiguous delivery placeholders;
- admit only bounded project-local read shapes observed on the live path, including safe positive `find -path` filters and bounded `cat ... | head` content reads, while retaining absolute/traversal and unrelated-target rejection;
- make selected-Todo and replan live actors state their project-root/path contract explicitly, and preserve the selected target as the causal anchor;
- keep qualification failures attributable to the command kind even when the underlying CLI handler raises.

## Product and architecture judgment

Motivation: the v0.4.8 actual-default release gate exposed cases where the control-plane projection was semantically correct but not directly executable by the model: typed flag names were hidden behind a placeholder, JSON output was omitted, and a live actor did not state its working-directory contract.

The change fixes the owning seams rather than weakening the oracle. Generic interaction projection now names the real CLI contract; the live actors continue to reject broad host reads, unrelated Todo targets, untyped writebacks, and semantic no-ops. Existing users should see more reliable autonomous replan and selected-Todo execution. The main risk is agent-facing command/prompt drift; parser-backed tests, negative boundary cases, and the repeated real-model portfolio cover that surface.

No new capability, provider, permission, scoring rule, benchmark task semantic, or external write path is introduced.

## Validation

- `61 passed` across the selected-Todo, semantic-replan, agent-scope, and actual-default portfolio test files;
- Ruff: passed;
- mypy: passed (`16 source files`);
- risk-based premerge canary: passed (`17/17`, failures `0`, manual holds `0`);
- real Ark/Doubao actual-default portfolio on the exact commit: `16/16` scenarios, `32/32` actor calls, `4/4` contrasts, failures `0`, skips `0`, automatic retries `0`;
- focused real selected-Todo and semantic-replan tool qualifications: passed.

## Boundary

Raw model responses, prompts, commands, credentials, temporary fixture paths, and local diagnostic artifacts are not persisted or included. The branch contains only six product/test paths.
