### PR TITLE
fix(turn): resume preserved sessions on failed-turn retry

### DIFF
--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import argparse
 import json
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from pathlib import Path
+from typing import Any
 
 from ..capabilities.explore.composition_frontier import (
     project_live_explore_composition_frontier,
@@ -744,8 +745,11 @@ def handle_turn_command(
                 }
 
             host_runner = None
+            session_binding_resolver = None
             if args.host == "codex-cli":
-                def run_built_in_host(request: dict[str, object]) -> dict[str, object]:
+                def run_built_in_host(
+                    request: Mapping[str, Any],
+                ) -> dict[str, Any]:
                     return run_codex_cli_host(
                         request,
                         runtime_root=runtime_root,
@@ -758,10 +762,18 @@ def handle_turn_command(
 
                 host_runner = run_built_in_host
 
+                def resolve_built_in_session_binding(
+                    turn_envelope: Mapping[str, Any],
+                ) -> dict[str, str] | None:
+                    return codex_cli_session_binding(runtime_root, turn_envelope)
+
+                session_binding_resolver = resolve_built_in_session_binding
+
             payload = run_loopx_turn_once(
                 payload,
                 host_argv=raw_argv,
                 host_runner=host_runner,
+                session_binding_resolver=session_binding_resolver,
                 project=project,
                 runtime_root=runtime_root,
                 goal_id=args.goal_id,

--- a/loopx/control_plane/turn_driver/codex_cli.py
+++ b/loopx/control_plane/turn_driver/codex_cli.py
@@ -143,8 +143,11 @@ def _store_codex_cli_session(
     )
     temporary = Path(temporary_name)
     try:
-        os.fchmod(descriptor, 0o600)
-        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+        if hasattr(os, "fchmod"):
+            os.fchmod(descriptor, 0o600)
+        handle = os.fdopen(descriptor, "w", encoding="utf-8")
+        descriptor = -1
+        with handle:
             json.dump(
                 {
                     "schema_version": CODEX_CLI_SESSION_SCHEMA_VERSION,
@@ -161,6 +164,8 @@ def _store_codex_cli_session(
         os.replace(temporary, path)
         path.chmod(0o600)
     finally:
+        if descriptor >= 0:
+            os.close(descriptor)
         temporary.unlink(missing_ok=True)
 
 
@@ -480,7 +485,10 @@ def run_codex_cli_host(
                     lineage=lineage,
                     session_id=observed_session[0],
                 )
-            raise BuiltInHostError("codex_cli_timeout")
+            raise BuiltInHostError(
+                "codex_cli_timeout",
+                recovery_kind=("resume_session" if observed_session else None),
+            )
         category = failure_categories[0] if failure_categories else "exit_nonzero"
         if returncode != 0 and category in SESSION_INVALIDATING_FAILURE_CATEGORIES:
             _discard_codex_cli_session(runtime_root, lineage=lineage)

--- a/loopx/control_plane/turn_driver/driver.py
+++ b/loopx/control_plane/turn_driver/driver.py
@@ -193,6 +193,45 @@ def _session_plan(
     }, None
 
 
+def reconcile_failed_turn_session_request(
+    request: Mapping[str, Any],
+    *,
+    session_binding: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Re-authorize a journaled host request against one current binding."""
+
+    envelope = _mapping(request.get("turn_envelope"))
+    selected_todo = selected_turn_todo(envelope)
+    lineage = _turn_lineage(envelope, selected_todo=selected_todo)
+    session, session_error = _session_plan(
+        route=LoopXTurnRoute.READY_FOR_HOST,
+        lineage=lineage,
+        session_binding=session_binding,
+    )
+    if session_error:
+        raise ValueError(f"failed-Turn recovery {session_error}")
+    if session.get("action") != "resume":
+        raise ValueError(
+            "failed-Turn recovery requires a compatible persisted session binding"
+        )
+
+    planned_session = _mapping(request.get("session"))
+    planned_action = str(planned_session.get("action") or "")
+    if planned_action not in {"start_new", "resume"}:
+        raise ValueError(
+            "failed-Turn recovery requires a start_new or resume session action"
+        )
+    if planned_action == "resume":
+        return dict(request)
+    return {
+        **request,
+        "session": {
+            **session,
+            "binding_status": "failed_turn_recovery",
+        },
+    }
+
+
 def _child_host_operations(
     envelope: Mapping[str, Any],
     *,

--- a/loopx/control_plane/turn_driver/executor.py
+++ b/loopx/control_plane/turn_driver/executor.py
@@ -24,7 +24,7 @@ from ..effect_program import (
 from ..goals.goal_vision import normalize_goal_vision_packet
 from ..work_items.delivery_batch_scale import require_delivery_batch_scale
 from ..work_items.delivery_outcome import require_delivery_outcome
-from .driver import selected_turn_todo
+from .driver import reconcile_failed_turn_session_request, selected_turn_todo
 from .settlement import (
     completion_writeback_outcome,
     execute_turn_driver_settlement,
@@ -49,6 +49,8 @@ HOST_ARG_MAX_COUNT = 32
 HOST_ARG_MAX_CHARS = 1_024
 HOST_AGENT_VISION_JSON_MAX_CHARS = 3_200
 HOST_PATH_DELTA_MODES = {"", "unchanged", "material_replan"}
+HOST_RECOVERY_SCHEMA_VERSION = "loopx_turn_host_recovery_v0"
+HOST_RECOVERY_KINDS = {"resume_session"}
 HOST_RESULT_TEXT_LIMITS = (
     ("classification", 120),
     ("recommended_action", 1_200),
@@ -91,6 +93,10 @@ TerminalCloseout = Callable[[dict[str, Any]], dict[str, Any]]
 Spend = Callable[[], dict[str, Any]]
 Scheduler = Callable[[dict[str, Any]], dict[str, Any]]
 HostRunner = Callable[[Mapping[str, Any]], dict[str, Any]]
+SessionBindingResolver = Callable[
+    [Mapping[str, Any]],
+    Mapping[str, Any] | None,
+]
 TaskValidator = Callable[
     [Mapping[str, Any], Mapping[str, Any]],
     Mapping[str, Any],
@@ -100,9 +106,12 @@ TaskValidator = Callable[
 class BuiltInHostError(RuntimeError):
     """A public-safe built-in host failure classification."""
 
-    def __init__(self, reason: str) -> None:
+    def __init__(self, reason: str, *, recovery_kind: str | None = None) -> None:
+        if recovery_kind is not None and recovery_kind not in HOST_RECOVERY_KINDS:
+            raise ValueError("unsupported built-in host recovery kind")
         super().__init__(reason)
         self.reason = reason
+        self.recovery_kind = recovery_kind
 
 
 def _normalize_argv(value: Sequence[str], *, label: str) -> list[str]:
@@ -769,7 +778,16 @@ def _run_host_runner(
     try:
         value = runner(request)
     except BuiltInHostError as exc:
-        return {"ok": False, "reason": exc.reason, "returncode": None}
+        return {
+            "ok": False,
+            "reason": exc.reason,
+            "returncode": None,
+            **(
+                {"recovery_kind": exc.recovery_kind}
+                if exc.recovery_kind is not None
+                else {}
+            ),
+        }
     except Exception as exc:  # noqa: BLE001 - host adapters fail closed at boundary
         return {"ok": False, "reason": type(exc).__name__, "returncode": None}
     if not isinstance(value, dict):
@@ -840,6 +858,37 @@ def _execution_payload(
     }
 
 
+def _reconcile_failed_turn_retry_request(
+    request: Mapping[str, Any],
+    journal: Mapping[str, Any],
+    *,
+    session_binding_resolver: SessionBindingResolver | None,
+) -> dict[str, Any]:
+    recovery = _mapping(journal.get("host_recovery"))
+    if not recovery:
+        return dict(request)
+    if recovery.get("schema_version") != HOST_RECOVERY_SCHEMA_VERSION:
+        raise ValueError("failed-Turn host recovery has an unsupported schema")
+    if recovery.get("kind") not in HOST_RECOVERY_KINDS:
+        raise ValueError("failed-Turn host recovery has an unsupported kind")
+    receipt = _mapping(journal.get("receipt"))
+    if receipt.get("failed_phase") != "host_execute":
+        raise ValueError("failed-Turn session recovery requires a host execution failure")
+    if session_binding_resolver is None:
+        raise ValueError("failed-Turn session recovery has no binding resolver")
+    envelope = _mapping(request.get("turn_envelope"))
+    try:
+        session_binding = session_binding_resolver(envelope)
+    except Exception:  # noqa: BLE001 - provider boundary fails closed
+        raise ValueError(
+            "failed-Turn recovery session binding could not be resolved"
+        ) from None
+    return reconcile_failed_turn_session_request(
+        request,
+        session_binding=session_binding,
+    )
+
+
 def _host_result_stage(
     plan: Mapping[str, Any],
     request: Mapping[str, Any],
@@ -886,6 +935,14 @@ def _host_result_stage(
                 completed_phases=[],
                 result_kind=LoopXTurnResultKind.HOST_FAILURE.value,
             )
+            recovery_kind = host_observation.get("recovery_kind")
+            if recovery_kind is not None:
+                journal["host_recovery"] = {
+                    "schema_version": HOST_RECOVERY_SCHEMA_VERSION,
+                    "kind": recovery_kind,
+                }
+            else:
+                journal.pop("host_recovery", None)
             _write_journal(journal_path, journal)
             return (
                 None,
@@ -1320,6 +1377,7 @@ def run_loopx_turn_once(
     *,
     host_argv: Sequence[str] | None = None,
     host_runner: HostRunner | None = None,
+    session_binding_resolver: SessionBindingResolver | None = None,
     project: Path,
     runtime_root: Path,
     goal_id: str,
@@ -1388,6 +1446,11 @@ def run_loopx_turn_once(
                 effects=empty_effects,
             )
         if journal and journal.get("status") == "failed":
+            request = _reconcile_failed_turn_retry_request(
+                request,
+                journal,
+                session_binding_resolver=session_binding_resolver,
+            )
             receipt = journal.get("receipt") if isinstance(journal.get("receipt"), dict) else {}
             if receipt.get("failed_phase") == "validation":
                 if journal.get("validation_stage") != "task_postcondition":
@@ -1402,6 +1465,7 @@ def run_loopx_turn_once(
                 journal.pop("validation_stage", None)
             journal.pop("reason", None)
             journal.pop("receipt", None)
+            journal.pop("host_recovery", None)
             journal["status"] = "in_progress"
             _write_journal(journal_path, journal)
         if journal is None:

--- a/tests/test_loopx_turn_driver.py
+++ b/tests/test_loopx_turn_driver.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import io
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -21,6 +22,7 @@ from loopx.control_plane.turn_driver import (
     run_loopx_turn_once,
 )
 from loopx.control_plane.turn_driver.codex_cli import _store_codex_cli_session
+from loopx.control_plane.turn_driver.executor import BuiltInHostError
 from loopx.control_plane.quota.live_decision import bind_scheduler_followup_cli_routes
 from loopx.todos import complete_goal_todo
 
@@ -352,6 +354,30 @@ def test_codex_session_binding_uses_adaptive_primary_todo(
         tmp_path,
         lineage=lineage,
         session_id="session-primary",
+    )
+
+    assert codex_cli_session_binding(tmp_path, envelope) == {
+        "schema_version": LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION,
+        **lineage,
+    }
+
+
+def test_codex_session_store_falls_back_when_fchmod_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delattr(os, "fchmod", raising=False)
+    envelope = _envelope()
+    lineage = {
+        "goal_id": "fixture-goal",
+        "agent_id": "codex-fixture",
+        "todo_id": "todo_fixture0001",
+    }
+
+    _store_codex_cli_session(
+        tmp_path,
+        lineage=lineage,
+        session_id="session-without-fchmod",
     )
 
     assert codex_cli_session_binding(tmp_path, envelope) == {
@@ -1880,3 +1906,102 @@ def test_turn_run_once_cli_uses_built_in_codex_host_and_typed_writeback(
     assert "Run one revised public fixture check" in state
     if result_kind != "validated_progress":
         assert f"LoopX%20Turn%20{result_kind}" in state
+
+
+def test_turn_run_once_cli_resumes_session_from_recoverable_failed_turn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project, runtime, registry = _write_live_fixture(tmp_path)
+    session_available = False
+    session_actions: list[str] = []
+
+    def fake_session_binding(
+        _runtime_root: Path,
+        _turn_envelope: dict[str, object],
+    ) -> dict[str, str] | None:
+        if not session_available:
+            return None
+        return {
+            "schema_version": LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION,
+            "goal_id": "loopx-turn-fixture",
+            "agent_id": "codex-fixture",
+            "todo_id": "todo_fixture0001",
+        }
+
+    def fake_codex_host(
+        request: dict[str, object],
+        **_kwargs: object,
+    ) -> dict[str, object]:
+        nonlocal session_available
+        session = request["session"]
+        assert isinstance(session, dict)
+        session_actions.append(str(session["action"]))
+        if len(session_actions) == 1:
+            session_available = True
+            raise BuiltInHostError(
+                "codex_cli_timeout",
+                recovery_kind="resume_session",
+            )
+        return {
+            "schema_version": "loopx_turn_result_v0",
+            "turn_key": request["turn_key"],
+            "result_kind": "wait",
+            "completed_phases": ["host_execute", "typed_result"],
+        }
+
+    monkeypatch.setattr(
+        "loopx.cli_commands.turn.codex_cli_session_binding",
+        fake_session_binding,
+    )
+    monkeypatch.setattr(
+        "loopx.cli_commands.turn.run_codex_cli_host",
+        fake_codex_host,
+    )
+    argv = [
+        "--registry",
+        str(registry),
+        "--runtime-root",
+        str(runtime),
+        "--format",
+        "json",
+        "turn",
+        "run-once",
+        "--goal-id",
+        "loopx-turn-fixture",
+        "--agent-id",
+        "codex-fixture",
+        "--host",
+        "codex-cli",
+        "--project",
+        str(project),
+        "--scan-root",
+        str(project),
+        "--no-global-sync",
+        "--execute",
+    ]
+
+    failed_output = io.StringIO()
+    with contextlib.redirect_stdout(failed_output):
+        failed_exit_code = cli_main(argv)
+    failed = json.loads(failed_output.getvalue())
+
+    recovered_output = io.StringIO()
+    with contextlib.redirect_stdout(recovered_output):
+        recovered_exit_code = cli_main(
+            [
+                *argv[:-1],
+                "--resume-turn-key",
+                failed["resume_turn_key"],
+                "--retry-failed-turn",
+                "--execute",
+            ]
+        )
+    recovered = json.loads(recovered_output.getvalue())
+
+    assert failed_exit_code == 1
+    assert failed["reason"] == "codex_cli_timeout"
+    assert recovered_exit_code == 0, recovered
+    assert recovered["status"] == "stopped"
+    assert recovered["quota_slot_spend_count"] == 0
+    assert session_actions == ["start_new", "resume"]

--- a/tests/test_loopx_turn_executor.py
+++ b/tests/test_loopx_turn_executor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 
 import pytest
@@ -50,6 +51,17 @@ def _plan() -> dict[str, object]:
             "compaction": {"within_budget": True},
         },
         host="generic-cli",
+        execution_mode="isolated-headless",
+    )
+
+
+def _codex_plan() -> dict[str, object]:
+    plan = _plan()
+    envelope = plan["turn_envelope"]
+    assert isinstance(envelope, dict)
+    return build_loopx_turn_plan(
+        envelope,
+        host="codex-cli",
         execution_mode="isolated-headless",
     )
 
@@ -339,6 +351,100 @@ def test_run_once_explicitly_retries_failed_host_without_duplicate_effects(tmp_p
     assert replayed["replayed"] is True
     assert recovered["status"] == "committed"
     assert calls == {"host": 2, "writeback": 1, "spend": 1, "scheduler": 1}
+
+
+def test_run_once_resumes_session_observed_by_recoverable_failed_turn(
+    tmp_path: Path,
+) -> None:
+    plan = _codex_plan()
+    calls = {"host": 0, "writeback": 0, "spend": 0, "scheduler": 0}
+    session_actions: list[str] = []
+    writeback, spend, scheduler = _callbacks(calls)
+
+    def host(request: dict[str, object]) -> dict[str, object]:
+        calls["host"] += 1
+        session = request["session"]
+        assert isinstance(session, dict)
+        session_actions.append(str(session["action"]))
+        if calls["host"] == 1:
+            raise BuiltInHostError(
+                "codex_cli_timeout",
+                recovery_kind="resume_session",
+            )
+        return _host_result(plan)
+
+    def session_binding(
+        _turn_envelope: Mapping[str, object],
+    ) -> dict[str, object]:
+        return {
+            "schema_version": "loopx_turn_session_binding_v0",
+            "goal_id": "fixture-goal",
+            "agent_id": "codex-fixture",
+            "todo_id": "todo_fixture0001",
+        }
+
+    common = {
+        "host_runner": host,
+        "session_binding_resolver": session_binding,
+        "project": tmp_path,
+        "runtime_root": tmp_path / "runtime",
+        "goal_id": "fixture-goal",
+        "timeout_seconds": 5,
+        "execute": True,
+        "task_validator": _passing_validator,
+        "writeback": writeback,
+        "spend": spend,
+        "scheduler": scheduler,
+    }
+
+    failed = run_loopx_turn_once(plan, **common)
+    recovered = run_loopx_turn_once(plan, retry_failed=True, **common)
+
+    assert failed["reason"] == "codex_cli_timeout"
+    assert recovered["status"] == "committed"
+    assert session_actions == ["start_new", "resume"]
+    assert calls == {"host": 2, "writeback": 1, "spend": 1, "scheduler": 1}
+
+
+def test_run_once_recoverable_failed_turn_rejects_session_identity_drift(
+    tmp_path: Path,
+) -> None:
+    plan = _codex_plan()
+    calls = {"host": 0, "writeback": 0, "spend": 0, "scheduler": 0}
+    writeback, spend, scheduler = _callbacks(calls)
+
+    def host(_request: dict[str, object]) -> dict[str, object]:
+        calls["host"] += 1
+        raise BuiltInHostError(
+            "codex_cli_timeout",
+            recovery_kind="resume_session",
+        )
+
+    common = {
+        "host_runner": host,
+        "session_binding_resolver": lambda _turn_envelope: {
+            "schema_version": "loopx_turn_session_binding_v0",
+            "goal_id": "fixture-goal",
+            "agent_id": "codex-fixture",
+            "todo_id": "todo_from_another_turn",
+        },
+        "project": tmp_path,
+        "runtime_root": tmp_path / "runtime",
+        "goal_id": "fixture-goal",
+        "timeout_seconds": 5,
+        "execute": True,
+        "task_validator": _passing_validator,
+        "writeback": writeback,
+        "spend": spend,
+        "scheduler": scheduler,
+    }
+
+    failed = run_loopx_turn_once(plan, **common)
+    with pytest.raises(ValueError, match="session binding does not match"):
+        run_loopx_turn_once(plan, retry_failed=True, **common)
+
+    assert failed["reason"] == "codex_cli_timeout"
+    assert calls == {"host": 1, "writeback": 0, "spend": 0, "scheduler": 0}
 
 
 def test_run_once_commits_once_and_replays_without_duplicate_effects(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- mark Codex CLI timeouts as resumable only after an opaque session has been observed and preserved
- reconcile eligible failed-Turn retries from the journaled `start_new` request to `resume`
- validate the current Goal/Agent/Todo session binding before retrying the Host
- keep identity drift fail-closed without additional Host execution or durable side effects
- support atomic session persistence on platforms where `os.fchmod` is unavailable

## Root cause

When a Codex CLI Turn timed out, LoopX preserved the observed session binding.

However, `--resume-turn-key --retry-failed-turn` reloaded the original journaled plan, where the session action was still `start_new`. The Codex adapter then detected the preserved binding as session drift and rejected the retry before invoking the Host.

As a result, a recoverable timeout could not actually resume the preserved session.

## Behavior change

Failed-Turn reconciliation is now enabled only when all of the following are true:

- the caller explicitly requests `retry_failed`
- the failure occurred during `host_execute`
- the Host recorded typed `resume_session` recovery metadata
- a fresh session binding exists
- its Goal, Agent, and Todo identities match the failed Turn

When these conditions hold, the retry request is changed from `start_new` to `resume`.

Missing or mismatched bindings fail before another Host invocation.

## Measured results

| Recovery invariant | Before | After |
| --- | ---: | ---: |
| Eligible timeout recovery succeeds | 0/1 | 1/1 |
| Preserved session is resumed | 0/1 | 1/1 |
| Host action sequence | `start_new` only | `start_new → resume` |
| Retry Host calls on identity drift | 0 | 0 |
| Duplicate durable writebacks | 0 | 0 |
| Duplicate quota charges | 0 | 0 |
| Persistence without `os.fchmod` | 0/1 | 1/1 |

The successful recovery path performs exactly one retry Host invocation, one successful durable writeback, one quota spend, and one scheduler transition.

## Safety and scope

- timeouts that occur before a session is observed are not marked resumable
- ordinary non-recovery session-drift validation remains unchanged
- recovery metadata is typed and limited to the `host_execute` phase
- Goal/Agent/Todo identity drift remains fail-closed
- no benchmark scoring, task semantics, permission boundary, or submission behavior changes
- no raw sessions, trajectories, logs, credentials, or private state are added

## Validation

- `python -m pytest -q tests/test_loopx_turn_executor.py tests/test_loopx_turn_driver.py`
  - `80 passed`
- Ruff checks passed
- LoopX public-boundary checks passed
- `git diff --check` passed

Implements GH-C92.

Closes #3228