### PR TITLE
fix(docs): restore capability-aware frontstage builds

### DIFF
--- a/.github/workflows/frontstage-pages.yml
+++ b/.github/workflows/frontstage-pages.yml
@@ -109,7 +109,9 @@ jobs:
           cache: pip
 
       - name: Install docs dependencies
-        run: python -m pip install --disable-pip-version-check -r docs/requirements-docs.txt
+        run: |
+          python -m pip install --disable-pip-version-check -r docs/requirements-docs.txt
+          python -m pip install --disable-pip-version-check -e .
 
       - name: Validate public showcase catalog
         run: python3 examples/showcase-catalog-smoke.py

--- a/docs/book/mkdocs.en.yaml
+++ b/docs/book/mkdocs.en.yaml
@@ -6,6 +6,12 @@ docs_dir: en
 site_dir: ../../output/docs-book-en
 edit_uri: edit/main/docs/book/en/
 
+# Capability pages belong to the root docs site. Keep this inherited config on
+# the Developer Book's own source tree.
+plugins:
+  - search
+hooks: []
+
 theme:
   name: material
   language: en

--- a/docs/book/mkdocs.zh.yaml
+++ b/docs/book/mkdocs.zh.yaml
@@ -9,6 +9,12 @@ edit_uri: edit/main/docs/book/
 exclude_docs: |
   en/**
 
+# Capability pages belong to the root docs site. Keep this inherited config on
+# the Developer Book's own source tree.
+plugins:
+  - search
+hooks: []
+
 theme:
   name: material
   language: zh


### PR DESCRIPTION
## Summary

- Install the current LoopX checkout before capability-aware MkDocs hooks run.
- Keep root capability-generation hooks scoped out of Developer Book builds.
- Restore the writer-to-reader conformance introduced by #3265 without weakening strict docs validation.

## Validation

- Root MkDocs strict build.
- Chinese and English Developer Book strict builds.
- `python examples/dev-book-publication-smoke.py --site-dir <combined-site>/docs/book`.
- `loopx canary premerge --from-git-diff`: 11/11 selected checks passed, no manual holds.
- Public/private boundary scan passed.

This fixes the Frontstage Pages regression first observed while qualifying #3261.
