### PR TITLE
fix(goal): bind no-follow-up ACKs to lifecycle truth

### DIFF
--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -358,6 +358,13 @@ the agent should do one of two things:
   / `--reason` / `--evidence`, explaining why the feature is truly finished
   and does not need rollout, audit, docs, or product-path proof.
 
+This succession decision is durable Todo state. A later progress observation,
+vision ACK, coverage-exhausted result, or rewritten rationale cannot substitute
+for it. If the Todo is already complete without either branch, use the supported
+same-turn `todo complete --no-follow-up` recovery when its completion identity
+is still current; otherwise add/link a real successor. Do not create a user
+gate merely to silence a succession warning.
+
 This keeps the active checklist honest without making LoopX a heavyweight
 project-management state machine.
 

--- a/docs/reference/protocols/goal-vision-replan-contract-v0.md
+++ b/docs/reference/protocols/goal-vision-replan-contract-v0.md
@@ -279,6 +279,15 @@ state persists across turns until evidence proves the requested end state. It
 prevents a role from declaring success merely because it consumed the currently
 selected todo, recorded a checkpoint, or observed that another lane is quiet.
 
+A typed progress observation with `result_class=no_followup` is coverage
+evidence, not Todo lifecycle settlement. A writeback may use its
+`coverage_backed_no_followup` outcome only when the same packet closes the
+agent vision with `state=no_followup` and records `path_delta.outcome=stop`.
+If a completed advancement Todo still lacks a successor, the agent must first
+settle that Todo through `loopx todo complete --no-follow-up` (or add/link a
+successor). A semantic ACK cannot replace this durable continuation, and the
+repair path must not invent a human gate without a real external authority.
+
 The audit also exposes a compact deterministic `vision_gap_judge_v0`
 instruction packet for the agent. It borrows the strict done-judge stance used
 by autonomous goal loops without calling an LLM: the agent is told to compare

--- a/loopx/control_plane/goals/goal_frontier/__init__.py
+++ b/loopx/control_plane/goals/goal_frontier/__init__.py
@@ -12,6 +12,10 @@ from ...agents.profile import agent_profile_requires_vision
 from ...agents.runtime_model import peer_work_key, select_peer_for_work
 from ...runtime.time import parse_timestamp
 from ...todos.projection import todo_item_is_watch_only_monitor
+from ...todos.succession_warning import (
+    TODO_SUCCESSION_WARNING_REASON_CODE,
+    todo_succession_gap_items,
+)
 from ...work_items.autonomous_replan_ack import (
     autonomous_replan_ack_matches_agent,
     autonomous_replan_ack_matches_frontier,
@@ -75,7 +79,7 @@ LONG_TODO_CHAIN_TRIGGER = "long_todo_chain"
 VISION_ACCEPTANCE_GAP_TRIGGER = "vision_acceptance_gap"
 VISION_SUCCESSOR_GAP_TRIGGER = "vision_successor_required"
 VISION_PROFILE_MISSING_TRIGGER = "required_agent_vision_missing"
-TODO_SUCCESSION_GAP_TRIGGER = "completed_advancement_without_successor"
+TODO_SUCCESSION_GAP_TRIGGER = TODO_SUCCESSION_WARNING_REASON_CODE
 TODO_TASK_CLASS_ADVANCEMENT = "advancement_task"
 TODO_TASK_CLASS_MONITOR = "continuous_monitor"
 LONG_TODO_CHAIN_ADVANCEMENT_THRESHOLD = 15
@@ -982,35 +986,6 @@ def _ready_deferred_successor_count(
     )
 
 
-def _succession_gap_items(
-    agent_todo_summary: dict[str, Any] | None,
-    *,
-    agent_id: str | None,
-) -> list[dict[str, Any]]:
-    if not isinstance(agent_todo_summary, dict):
-        return []
-    warning = (
-        agent_todo_summary.get("todo_succession_warning")
-        if isinstance(agent_todo_summary.get("todo_succession_warning"), dict)
-        else {}
-    )
-    source_items = (
-        warning.get("items")
-        if isinstance(warning.get("items"), list)
-        else agent_todo_summary.get("completed_without_successor_items")
-        if isinstance(agent_todo_summary.get("completed_without_successor_items"), list)
-        else []
-    )
-    items = [item for item in source_items if isinstance(item, dict)]
-    if not agent_id:
-        return items
-    return [
-        item
-        for item in items
-        if agent_scope_item_claimed_by_agent_or_unclaimed(item, agent_id=agent_id)
-    ]
-
-
 def _replan_evidence_acknowledged(
     items: list[dict[str, Any]],
     latest_replan_ack: dict[str, Any] | None,
@@ -1049,6 +1024,14 @@ def _succession_gap_acknowledged(
 ) -> bool:
     """Return true when a valid replan ack postdates the newest succession gap."""
 
+    semantic_delta = (
+        latest_replan_ack.get("semantic_delta")
+        if isinstance(latest_replan_ack, dict)
+        and isinstance(latest_replan_ack.get("semantic_delta"), dict)
+        else {}
+    )
+    if "new_runnable_successor" not in set(semantic_delta.get("outcomes") or []):
+        return False
     return _replan_evidence_acknowledged(
         gap_items,
         latest_replan_ack,
@@ -1138,7 +1121,7 @@ def derive_goal_frontier_replan_obligation_from_summaries(
         == outcome_continuity.VISION_OUTCOME_CHECKPOINT_REQUIRED_TRIGGER
         for item in compact_acceptance_gaps
     )
-    succession_gap_items = _succession_gap_items(
+    succession_gap_items = todo_succession_gap_items(
         agent_todo_summary,
         agent_id=agent_id,
     )
@@ -1236,8 +1219,9 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                     "priority": "P0",
                     "text": (
                         "run a bounded successor replan: create or link the next "
-                        "runnable advancement todo, or record an explicit "
-                        "no-follow-up rationale"
+                        "runnable advancement Todo, or settle the completed Todo "
+                        "through loopx todo complete --no-follow-up; do not invent "
+                        "a user gate"
                     ),
                 }
             ],
@@ -1246,9 +1230,13 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                 "credentials, destructive git, production actions, or owner-only decisions"
             ),
             recommended_action=(
-                "run a bounded successor replan before another quiet poll: add/link "
-                "the next advancement todo, or record explicit no-follow-up"
+                "before another quiet poll, add/link the next advancement Todo or "
+                "settle the completed Todo through loopx todo complete "
+                "--no-follow-up; do not invent a user gate"
             ),
+            extra_fields={
+                "satisfying_semantic_outcomes": ["new_runnable_successor"],
+            },
         )
     if replan_rule.rule is GoalFrontierReplanRule.VISION_ACCEPTANCE_GAP:
         return build_autonomous_replan_obligation_payload(
@@ -1613,6 +1601,12 @@ def build_goal_frontier_projection_context_from_status(
             if gap.get("kind")
             != outcome_continuity.VISION_CHECKPOINT_MISSING_TRIGGER
         ]
+    todo_succession_gap_open = bool(
+        todo_succession_gap_items(
+            agent_todo_summary,
+            agent_id=agent_id,
+        )
+    )
     replan_obligation = align_autonomous_replan_guidance_with_acceptance_policy(
         replan_obligation,
         acceptance_gaps=source_acceptance_gaps,
@@ -1650,6 +1644,7 @@ def build_goal_frontier_projection_context_from_status(
             obligation_ack,
             replan_obligation=replan_obligation,
             acceptance_gaps=source_acceptance_gaps,
+            todo_succession_gap_open=todo_succession_gap_open,
         )
         and autonomous_replan_ack_matches_frontier(
             obligation_ack,
@@ -1687,6 +1682,7 @@ def build_goal_frontier_projection_context_from_status(
             frontier_obligation_ack,
             replan_obligation=frontier_replan_obligation,
             acceptance_gaps=source_acceptance_gaps,
+            todo_succession_gap_open=todo_succession_gap_open,
         )
         and autonomous_replan_ack_matches_frontier(
             frontier_obligation_ack,

--- a/loopx/control_plane/goals/goal_frontier/ack_policy.py
+++ b/loopx/control_plane/goals/goal_frontier/ack_policy.py
@@ -30,6 +30,7 @@ def autonomous_replan_ack_satisfies_obligation(
     *,
     replan_obligation: dict[str, Any] | None,
     acceptance_gaps: list[dict[str, Any]] | None,
+    todo_succession_gap_open: bool = False,
 ) -> bool:
     """Reject ACKs that miss the obligation's typed semantic outcome."""
 
@@ -54,6 +55,8 @@ def autonomous_replan_ack_satisfies_obligation(
         if str(item or "").strip()
     }
     required = set(required_semantic_outcomes(replan_obligation or {}))
+    if todo_succession_gap_open:
+        outcomes.intersection_update({"new_runnable_successor"})
     return bool(outcomes & required)
 
 

--- a/loopx/control_plane/todos/succession_warning.py
+++ b/loopx/control_plane/todos/succession_warning.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from ..agents.agent_scope import agent_scope_item_claimed_by_agent_or_unclaimed
 from .contract import (
     TODO_STATUS_OPEN,
     normalize_required_write_scopes,
@@ -14,6 +15,7 @@ from .contract import (
 
 
 TODO_SUCCESSION_WARNING_SCHEMA_VERSION = "todo_succession_warning_v0"
+TODO_SUCCESSION_WARNING_REASON_CODE = "completed_advancement_without_successor"
 TODO_PARENT_SUCCESSOR_ADVISORY_SCHEMA_VERSION = "todo_parent_successor_advisory_v0"
 
 
@@ -160,13 +162,16 @@ def build_todo_succession_warning_lanes(
         ),
         "reason_code": warning.get(
             "reason_code",
-            "completed_advancement_without_successor",
+            TODO_SUCCESSION_WARNING_REASON_CODE,
         ),
         "count": count,
         "items": items,
         "recommended_action": warning.get(
             "recommended_action",
-            "record no_followup=true or add/link a successor todo",
+            (
+                "run loopx todo complete --no-follow-up for the completed Todo, "
+                "or add/link a successor Todo; do not invent a user gate"
+            ),
         ),
     }
     return {
@@ -174,3 +179,36 @@ def build_todo_succession_warning_lanes(
         "completed_without_successor_items": items,
         "todo_succession_warning": payload,
     }
+
+
+def todo_succession_gap_items(
+    summary: dict[str, Any] | None,
+    *,
+    agent_id: str | None,
+) -> list[dict[str, Any]]:
+    """Return current typed succession gaps owned by this agent lane."""
+
+    if not isinstance(summary, dict):
+        return []
+    warning = (
+        summary.get("todo_succession_warning")
+        if isinstance(summary.get("todo_succession_warning"), dict)
+        else {}
+    )
+    if warning and warning.get("reason_code") != TODO_SUCCESSION_WARNING_REASON_CODE:
+        return []
+    source_items = (
+        warning.get("items")
+        if isinstance(warning.get("items"), list)
+        else summary.get("completed_without_successor_items")
+        if isinstance(summary.get("completed_without_successor_items"), list)
+        else []
+    )
+    items = [item for item in source_items if isinstance(item, dict)]
+    if not agent_id:
+        return items
+    return [
+        item
+        for item in items
+        if agent_scope_item_claimed_by_agent_or_unclaimed(item, agent_id=agent_id)
+    ]

--- a/loopx/control_plane/todos/todo_summary.py
+++ b/loopx/control_plane/todos/todo_summary.py
@@ -60,6 +60,10 @@ from .projection import (
     todo_priority_rank as projection_todo_priority_rank,
     todo_projection_sort_key as projection_todo_projection_sort_key,
 )
+from .succession_warning import (
+    TODO_SUCCESSION_WARNING_REASON_CODE,
+    TODO_SUCCESSION_WARNING_SCHEMA_VERSION,
+)
 from ..work_items.project_asset import build_project_asset_todo_summary
 from .user_gate import open_user_gate_todo_items
 
@@ -75,7 +79,6 @@ MAX_COMPLETED_SUCCESSION_WARNING_ITEMS = 5
 MAX_RECENT_COMPLETED_ADVANCEMENT_ITEMS = MAX_TODO_VISIBILITY_LANE_ITEMS
 
 TODO_ITEM_SCHEMA_VERSION = "todo_item_v0"
-TODO_SUCCESSION_WARNING_SCHEMA_VERSION = "todo_succession_warning_v0"
 TODO_SOURCE_PROOF_SCHEMA_VERSION = "todo_source_proof_v0"
 TODO_CLOSURE_INTENT_SCHEMA_VERSION = "todo_closure_intent_v0"
 TODO_TERMINAL_CLOSURE_PROOF_SCHEMA_VERSION = "todo_terminal_closure_proof_v0"
@@ -1434,12 +1437,13 @@ def compact_todo_group(
         summary["completed_without_successor_items"] = compact_gap_items
         summary["todo_succession_warning"] = {
             "schema_version": TODO_SUCCESSION_WARNING_SCHEMA_VERSION,
-            "reason_code": "completed_advancement_without_successor",
+            "reason_code": TODO_SUCCESSION_WARNING_REASON_CODE,
             "count": len(successor_gap_items),
             "items": compact_gap_items,
             "recommended_action": (
-                "record no_followup=true on completed tracked work, "
-                "or add/link a successor todo before closing the slice"
+                "run loopx todo complete --no-follow-up for the completed Todo, "
+                "or add/link a successor Todo before closing the slice; do not "
+                "invent a user gate"
             ),
         }
     if lanes.active_next_action_items:

--- a/loopx/control_plane/work_items/progress_observation.py
+++ b/loopx/control_plane/work_items/progress_observation.py
@@ -8,6 +8,7 @@ from collections.abc import Iterable, Mapping
 from enum import StrEnum
 from typing import Any
 
+from ..goals.goal_vision_state import normalize_goal_vision_state
 from ..todos.contract import (
     normalize_todo_task_domain,
     replan_successor_semantic_binding,
@@ -384,6 +385,25 @@ def semantic_delta_from_writeback(
     )
     outcomes = list(observation_delta.get("delta_kinds") or [])
 
+    no_followup_consistency_error: str | None = None
+    if "coverage_backed_no_followup" in outcomes:
+        vision_state = ""
+        path_outcome = ""
+        if isinstance(agent_vision, Mapping):
+            vision_state = normalize_goal_vision_state(agent_vision.get("state"))
+            path_delta = (
+                agent_vision.get("path_delta")
+                if isinstance(agent_vision.get("path_delta"), Mapping)
+                else {}
+            )
+            path_outcome = str(path_delta.get("outcome") or "").strip()
+        if vision_state != "no_followup" or path_outcome != "stop":
+            outcomes.remove("coverage_backed_no_followup")
+            no_followup_consistency_error = (
+                "coverage-backed no-follow-up requires agent_vision.state="
+                "no_followup and path_delta.outcome=stop"
+            )
+
     if isinstance(agent_vision, Mapping):
         patch = (
             agent_vision.get("vision_patch")
@@ -411,6 +431,8 @@ def semantic_delta_from_writeback(
 
     required = required_semantic_outcomes(obligation)
     satisfying = [outcome for outcome in outcomes if outcome in required]
+    if no_followup_consistency_error:
+        satisfying = []
     return {
         "schema_version": "replan_semantic_delta_v0",
         "accepted": bool(satisfying),
@@ -424,7 +446,14 @@ def semantic_delta_from_writeback(
         "reason": (
             "writeback changes an outcome accepted by this obligation source"
             if satisfying
+            else no_followup_consistency_error
+            if no_followup_consistency_error
             else "writeback does not satisfy this obligation's typed outcomes"
+        ),
+        **(
+            {"reason_code": "no_followup_vision_path_inconsistent"}
+            if no_followup_consistency_error
+            else {}
         ),
     }
 

--- a/loopx/control_plane/work_items/semantic_replan_writeback.py
+++ b/loopx/control_plane/work_items/semantic_replan_writeback.py
@@ -11,6 +11,7 @@ from ..status.autonomous_replan_projection import (
     autonomous_replan_obligation_from_runs,
 )
 from ..todos.active_state_todo_parser import parse_active_state_todos
+from ..todos.succession_warning import todo_succession_gap_items
 from .progress_observation import semantic_delta_from_writeback
 from .work_lane_context import build_work_lane_context_contract
 
@@ -132,11 +133,28 @@ def qualify_replan_writeback(
         completion_turn_key=completion_turn_key,
     ):
         return None, None
-    return obligation, semantic_delta_from_writeback(
+    semantic_delta = semantic_delta_from_writeback(
         obligation=obligation,
         progress_observation=progress_observation,
         agent_vision=agent_vision,
     )
+    if (
+        "coverage_backed_no_followup"
+        in set(semantic_delta.get("outcomes") or [])
+        and todo_succession_gap_items(agent_todos, agent_id=safe_agent_id)
+    ):
+        semantic_delta = {
+            **semantic_delta,
+            "accepted": False,
+            "satisfying_outcomes": [],
+            "reason_code": "todo_no_followup_settlement_required",
+            "reason": (
+                "coverage-backed no-follow-up cannot replace Todo lifecycle "
+                "settlement; first run loopx todo complete with --no-follow-up "
+                "for the completed Todo, then write the terminal vision/path"
+            ),
+        }
+    return obligation, semantic_delta
 
 
 def enforce_open_replan_writeback(
@@ -168,6 +186,8 @@ def enforce_open_replan_writeback(
         return None
     if isinstance(semantic_delta, dict) and semantic_delta.get("accepted") is True:
         return semantic_delta
+    if isinstance(semantic_delta, dict) and semantic_delta.get("reason_code"):
+        raise ValueError(str(semantic_delta.get("reason") or "invalid replan writeback"))
     raise ValueError(
         "an open autonomous replan obligation requires a typed semantic delta; "
         "this writeback does not change an accepted surface, hypothesis, probe "

--- a/tests/control_plane/test_goal_terminal_no_followup.py
+++ b/tests/control_plane/test_goal_terminal_no_followup.py
@@ -363,3 +363,49 @@ def test_no_followup_does_not_hide_open_vision_acceptance() -> None:
     assert decision["goal_frontier_projection"]["acceptance_gaps"][0]["kind"] == (
         "vision_acceptance_gap"
     )
+
+
+def test_structured_terminal_settlement_ignores_stale_next_action_repair() -> None:
+    parsed = _closed_todo_sources()
+    status = quota_status_payload(
+        goal_id="goal-terminal-test",
+        status="active",
+        recommended_action="Stop; the bounded goal is complete.",
+        active_state_next_action="Inspect an obsolete frontier.",
+        user_todos=parsed["user_todos"],
+        agent_todos=parsed["agent_todos"],
+        latest_runs=[
+            {
+                "classification": "bounded_terminal_closeout",
+                "generated_at": "2026-08-13T12:00:00+08:00",
+                "agent_vision": {
+                    "schema_version": "goal_vision_replan_contract_v0",
+                    "state": "no_followup",
+                    "vision_patch": {
+                        "acceptance_summary": "The bounded goal is complete."
+                    },
+                    "path_delta": {
+                        "outcome": "stop",
+                        "evidence_refs": ["evidence:terminal-coverage"],
+                    },
+                },
+            }
+        ],
+        item_extra={
+            "state_projection_gap": {
+                "schema_version": "state_projection_gap_v0",
+                "kind": "state_projection_gap",
+                "requires_todo_expansion": True,
+                "agent_open_count": 0,
+                "user_open_count": 0,
+                "target_roles": ["agent"],
+            }
+        },
+    )
+
+    decision = build_quota_should_run(status, goal_id="goal-terminal-test")
+
+    assert decision["decision"] == "skip"
+    assert decision["effective_action"] == "terminal_no_followup"
+    assert decision["goal_frontier_projection"]["acceptance_gaps"] == []
+    assert "state_projection_gap_repair" not in decision

--- a/tests/control_plane/test_progress_observation.py
+++ b/tests/control_plane/test_progress_observation.py
@@ -6,6 +6,7 @@ from loopx.control_plane.work_items.progress_observation import (
     build_replan_action_packet,
     build_replan_context,
     normalize_progress_observation,
+    semantic_delta_from_writeback,
     semantic_progress_delta,
     typed_progress_repeat_trigger,
 )
@@ -237,6 +238,60 @@ def test_no_followup_ignores_coverage_complete_churn() -> None:
         semantic_progress_delta(coverage_flag_only, baseline=baseline)["accepted"]
         is False
     )
+
+
+@pytest.mark.parametrize(
+    "agent_vision",
+    [
+        None,
+        {"state": "active", "path_delta": {"outcome": "continue"}},
+        {
+            "state": "active",
+            "vision_patch": {"acceptance_summary": "Keep exploring."},
+            "path_delta": {
+                "outcome": "continue",
+                "evidence_refs": ["evidence-open-path"],
+            },
+        },
+        {"state": "no_followup", "path_delta": {"outcome": "continue"}},
+        {"state": "active", "path_delta": {"outcome": "stop"}},
+    ],
+)
+def test_no_followup_writeback_requires_terminal_vision_and_path(
+    agent_vision: dict[str, object] | None,
+) -> None:
+    delta = semantic_delta_from_writeback(
+        obligation={
+            "obligation_id": "replan-terminal-consistency",
+            "satisfying_semantic_outcomes": ["coverage_backed_no_followup"],
+        },
+        progress_observation=_observation(
+            result_class="no_followup",
+            coverage_scope_id="scope-public-entrypoints",
+        ),
+        agent_vision=agent_vision,
+    )
+
+    assert delta["accepted"] is False
+    assert delta["reason_code"] == "no_followup_vision_path_inconsistent"
+    assert "coverage_backed_no_followup" not in delta["outcomes"]
+
+
+def test_no_followup_writeback_accepts_consistent_terminal_vision_and_path() -> None:
+    delta = semantic_delta_from_writeback(
+        obligation={
+            "obligation_id": "replan-terminal-consistency",
+            "satisfying_semantic_outcomes": ["coverage_backed_no_followup"],
+        },
+        progress_observation=_observation(
+            result_class="no_followup",
+            coverage_scope_id="scope-public-entrypoints",
+        ),
+        agent_vision={"state": "no_followup", "path_delta": {"outcome": "stop"}},
+    )
+
+    assert delta["accepted"] is True
+    assert delta["satisfying_outcomes"] == ["coverage_backed_no_followup"]
 
 
 def test_host_projects_evidence_context_and_minimal_action_packet() -> None:

--- a/tests/control_plane/test_refresh_state_replan_gate.py
+++ b/tests/control_plane/test_refresh_state_replan_gate.py
@@ -65,6 +65,26 @@ def _completed_advancement_chain_state() -> str:
     return "\n".join(lines) + "\n"
 
 
+def _completed_advancement_without_successor_state() -> str:
+    return f"""\
+## Agent Todo
+
+- [x] [P0] Completed a bounded advancement slice.
+  <!-- loopx:todo todo_id=todo_unsettled_completion status=done task_class=advancement_task claimed_by={AGENT_ID} no_followup=false completion_continuation=active_goal completion_turn_key=turn-unsettled completed_at=2026-08-13T11%3A30%3A00%2B08%3A00 -->
+"""
+
+
+def _terminal_no_followup_vision() -> dict:
+    return {
+        "state": "no_followup",
+        "vision_patch": {"acceptance_summary": "The bounded goal is complete."},
+        "path_delta": {
+            "outcome": "stop",
+            "evidence_refs": ["evidence:terminal-coverage"],
+        },
+    }
+
+
 def _durable_runs(count: int) -> list[dict]:
     return [
         {
@@ -466,7 +486,7 @@ def test_rotated_vision_obligation_accepts_fresh_evidence_linked_path() -> None:
 
 
 @pytest.mark.parametrize(
-    ("progress_observation", "expected_outcome"),
+    ("progress_observation", "agent_vision", "expected_outcome"),
     [
         (
             {
@@ -475,6 +495,7 @@ def test_rotated_vision_obligation_accepts_fresh_evidence_linked_path() -> None:
                 "blocker_id": "blocker-current-path",
                 "evidence_ids": ["evidence-current-blocker"],
             },
+            None,
             "new_concrete_blocker",
         ),
         (
@@ -485,6 +506,7 @@ def test_rotated_vision_obligation_accepts_fresh_evidence_linked_path() -> None:
                 "coverage_complete": True,
                 "evidence_ids": ["evidence-current-coverage"],
             },
+            None,
             "coverage_backed_exploration_exhausted",
         ),
         (
@@ -494,12 +516,14 @@ def test_rotated_vision_obligation_accepts_fresh_evidence_linked_path() -> None:
                 "coverage_scope_id": "coverage-current-goal",
                 "evidence_ids": ["evidence-current-coverage"],
             },
+            _terminal_no_followup_vision(),
             "coverage_backed_no_followup",
         ),
     ],
 )
 def test_rotated_vision_obligation_accepts_terminal_progress(
     progress_observation: dict,
+    agent_vision: dict | None,
     expected_outcome: str,
 ) -> None:
     runs = _rotated_vision_runs()
@@ -510,10 +534,65 @@ def test_rotated_vision_obligation_accepts_terminal_progress(
         agent_id=AGENT_ID,
         goal_id=GOAL_ID,
         progress_observation=progress_observation,
+        agent_vision=agent_vision,
     )
 
     assert semantic_delta is not None
     assert semantic_delta["satisfying_outcomes"] == [expected_outcome]
+
+
+def test_semantic_no_followup_cannot_replace_todo_lifecycle_settlement() -> None:
+    with pytest.raises(ValueError, match="first run loopx todo complete"):
+        enforce_open_replan_writeback(
+            newest_first_runs=[],
+            state_text=_completed_advancement_without_successor_state(),
+            agent_id=AGENT_ID,
+            goal_id=GOAL_ID,
+            progress_observation={
+                "schema_version": "typed_progress_observation_v0",
+                "result_class": "no_followup",
+                "coverage_scope_id": "coverage-current-goal",
+                "evidence_ids": ["evidence-current-coverage"],
+            },
+            agent_vision=_terminal_no_followup_vision(),
+        )
+
+
+def test_persisted_semantic_no_followup_ack_cannot_retire_todo_gap() -> None:
+    state_text = _completed_advancement_without_successor_state()
+    obligation_id = _current_obligation_id([], state_text=state_text)
+    semantic_ack = {
+        "classification": "bounded_replan_terminal",
+        "generated_at": "2026-08-13T12:00:00+08:00",
+        "agent_id": AGENT_ID,
+        "autonomous_replan_ack": {
+            "schema_version": "autonomous_replan_ack_v0",
+            "recorded": True,
+            "source": "refresh_state_semantic_delta",
+            "semantic_delta": {
+                "schema_version": "replan_semantic_delta_v0",
+                "accepted": True,
+                "outcomes": ["coverage_backed_no_followup"],
+                "satisfying_outcomes": ["coverage_backed_no_followup"],
+                "required_any_of": ["coverage_backed_no_followup"],
+                "obligation_id": obligation_id,
+            },
+        },
+    }
+
+    remaining, _ = qualify_replan_writeback(
+        newest_first_runs=[semantic_ack],
+        state_text=state_text,
+        agent_id=AGENT_ID,
+        goal_id=GOAL_ID,
+    )
+
+    assert remaining is not None
+    assert remaining["triggers"][0]["kind"] == (
+        "completed_advancement_without_successor"
+    )
+    assert "loopx todo complete --no-follow-up" in remaining["recommended_action"]
+    assert "do not invent a user gate" in remaining["recommended_action"]
 
 
 @pytest.mark.parametrize(

--- a/tests/control_plane/test_replan_novelty_policy.py
+++ b/tests/control_plane/test_replan_novelty_policy.py
@@ -244,6 +244,42 @@ def test_semantic_ack_is_bound_to_the_exact_rotated_obligation() -> None:
     ) is True
 
 
+def test_semantic_terminal_ack_cannot_close_an_open_todo_succession_gap() -> None:
+    obligation = _obligation(
+        [{"kind": "completed_advancement_without_successor", "todo_id": "todo-1"}]
+    )
+    no_followup_ack = {
+        "recorded": True,
+        "semantic_delta": {
+            "schema_version": "replan_semantic_delta_v0",
+            "accepted": True,
+            "obligation_id": obligation["obligation_id"],
+            "outcomes": ["coverage_backed_no_followup"],
+        },
+    }
+
+    assert autonomous_replan_ack_satisfies_obligation(
+        no_followup_ack,
+        replan_obligation=obligation,
+        acceptance_gaps=[],
+        todo_succession_gap_open=True,
+    ) is False
+
+    successor_ack = {
+        **no_followup_ack,
+        "semantic_delta": {
+            **no_followup_ack["semantic_delta"],
+            "outcomes": ["new_runnable_successor"],
+        },
+    }
+    assert autonomous_replan_ack_satisfies_obligation(
+        successor_ack,
+        replan_obligation=obligation,
+        acceptance_gaps=[],
+        todo_succession_gap_open=True,
+    ) is True
+
+
 def test_policy_normalization_precedes_deterministic_peer_scope_selection() -> None:
     obligation = _obligation([{"kind": "periodic_review_due", "source": "fixture"}])
     registered_agents = ["codex-primary", "codex-reviewer"]
@@ -262,5 +298,4 @@ def test_policy_normalization_precedes_deterministic_peer_scope_selection() -> N
 
     assert len(selected) == 1
     assert selected <= set(registered_agents)
-
 


### PR DESCRIPTION
## Summary

- Reject coverage-backed no-follow-up when the same writeback keeps the vision open or the path continuing.
- Keep Todo succession authoritative: a semantic ACK cannot retire a completed-without-successor gap; only a typed runnable successor or durable Todo no-follow-up settlement can resolve it.
- Point repair guidance to `loopx todo complete --no-follow-up` and explicitly reject synthetic user gates.
- Consolidate the typed Todo succession reason/filter so write and read paths consume the same current gap truth.

## Why this is separate from #3261

#3261 makes Todo completion continuation explicit and provides the narrow same-Turn recovery seam. This PR closes the cross-contract gap where progress/vision ACK state could still claim terminality without that durable Todo settlement.

## Validation

- 199 model-behavior and focused goal-frontier tests passed.
- 162 broader goal-frontier/quota tests passed (covered within the 199-test run plus a prior focused pass).
- 59 direct regression tests passed after final refinement.
- Ruff passed on changed Python and tests.
- Control-plane maintainability ratchet passed.
- `loopx canary premerge --from-git-diff`: 18/18 selected checks passed, no manual holds.
- Public/private boundary scan passed.

Closes #3264.
