### PR TITLE
feat(packages): add loopx-repo-health provider for public repo-health snapshots

### DIFF
--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -1,0 +1,44 @@
+name: Package Smoke
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/package-smoke.yml"
+      - "packages/loopx-repo-health/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/package-smoke.yml"
+      - "packages/loopx-repo-health/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: package-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  repo-health:
+    name: loopx-repo-health
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Compile package modules
+        run: >-
+          python -m py_compile
+          packages/loopx-repo-health/src/loopx_repo_health/*.py
+
+      - name: Run offline contract smoke
+        run: >-
+          python
+          packages/loopx-repo-health/smoke/repo_health_snapshot_smoke.py

--- a/packages/loopx-repo-health/CONTRACT.md
+++ b/packages/loopx-repo-health/CONTRACT.md
@@ -1,0 +1,35 @@
+# Repo-Health Provider Contract
+
+`repo_health_snapshot_v0` is a provider-neutral, public-safe snapshot of GitHub
+repository health. The provider collects typed observations from the GitHub
+REST API and freezes them into one document; consumers (monthly reports,
+community-funnel monitors, content material) render or aggregate the snapshot
+but do not reinterpret missing metrics as zero.
+
+## Ownership
+
+| Surface | Owner | Responsibility |
+| --- | --- | --- |
+| Contract | `loopx-repo-health` extension | Schema, frozen metric ids, boundary rules |
+| Observation | GitHub REST collector | Public evidence with typed values or `null` |
+| Rendering | `loopx-repo-health` | Deterministic markdown projection |
+| Revision | Human owner | Approval before metric semantics change |
+
+## Rules
+
+- All metric values are non-negative integers or `null`; a failed collection is
+  represented as a warning plus `null`, never a fabricated number.
+- `latency.pr_merge_*` and `latency.first_response_*` are bounded samples; the
+  evidence `warnings` list names the sample size.
+- `traffic_14d` requires repository access; unavailable surfaces become zero
+  counts with a warning, so consumers can distinguish "no traffic" from
+  "no access".
+- Credentials are never part of the request or response packet; authentication
+  comes from the process environment only.
+- The provider rejects a request with a mismatched `schema_version` before
+  doing any network work.
+
+## Evidence
+
+Each snapshot carries `evidence.sources`, `evidence.rate_limit_remaining`, and
+`evidence.warnings` so downstream reports can audit freshness and sampling.

--- a/packages/loopx-repo-health/README.md
+++ b/packages/loopx-repo-health/README.md
@@ -1,0 +1,58 @@
+# loopx-repo-health
+
+Public-safe GitHub repo-health snapshot provider for LoopX. It collects a
+bounded set of public repository metrics from the GitHub REST API and emits a
+frozen `repo_health_snapshot_v0` document that can feed monthly reports,
+community-funnel monitoring, and content material.
+
+## Metrics
+
+- Counts: stars, forks, watchers, open issues, releases, contributors, sampled
+  PR total, sampled commented-issue total.
+- Traffic (14-day window): views and clones (requires repository access).
+- Latency: PR merge p25/p75 and first-human-response p25/p75, computed from a
+  bounded recent sample.
+- Recent star timeline: weekly buckets from the newest stargazer pages.
+
+Every metric comes from public repository data. The provider never accepts or
+emits raw trajectories, benchmark evidence, credentials, or private links.
+
+## Auth and boundaries
+
+- Read `GH_TOKEN` or `GITHUB_TOKEN` from the environment; the request packet
+  never carries credentials.
+- Unauthenticated requests still work for most endpoints, but GitHub now
+  requires authentication for the stargazers list, so a token is recommended.
+- Rate limits are GitHub's; the collector reports `rate_limit_remaining` in
+  evidence and fails fast with an explicit error instead of guessing.
+- Latency metrics are samples, not full-history percentiles; the snapshot
+  records the sample size in `evidence.warnings`.
+
+## Usage
+
+Managed extension invocation (stdin request → stdout response):
+
+```bash
+python3 -m pip install .
+loopx extension install --manifest extension.toml --execute --format json
+loopx extension run loopx-repo-health --input-json examples/request.json --execute --format json
+```
+
+Direct CLI:
+
+```bash
+loopx-repo-health --doctor
+loopx-repo-health snapshot --owner huangruiteng --repo loopx --format json
+loopx-repo-health snapshot --owner huangruiteng --repo loopx --format md
+```
+
+`schemas/request.schema.json` and `schemas/response.schema.json` are the
+versioned wire contracts. The provider validates its output against
+`repo_health_snapshot_v0` before returning it.
+
+## Validation
+
+```bash
+python3 smoke/repo_health_snapshot_smoke.py            # offline contract smoke
+python3 smoke/repo_health_snapshot_smoke.py --live owner repo   # optional live check
+```

--- a/packages/loopx-repo-health/examples/request.json
+++ b/packages/loopx-repo-health/examples/request.json
@@ -1,0 +1,5 @@
+{
+  "owner": "huangruiteng",
+  "repo": "loopx",
+  "schema_version": "loopx_repo_health_request_v0"
+}

--- a/packages/loopx-repo-health/extension.toml
+++ b/packages/loopx-repo-health/extension.toml
@@ -1,0 +1,12 @@
+schema_version = "loopx_extension_manifest_v0"
+id = "loopx-repo-health"
+version = "0.1.0"
+requires_loopx_api = ">=1,<2"
+permissions = []
+
+[runtime]
+protocol = "loopx_repo_health_extension_v0"
+entrypoint = "loopx-repo-health"
+doctor_args = ["--doctor"]
+required_permissions = []
+timeout_seconds = 30

--- a/packages/loopx-repo-health/pyproject.toml
+++ b/packages/loopx-repo-health/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=69"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "loopx-repo-health"
+version = "0.1.0"
+description = "Public-safe GitHub repo-health snapshot provider for LoopX"
+readme = "README.md"
+requires-python = ">=3.11"
+
+[project.scripts]
+loopx-repo-health = "loopx_repo_health.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/packages/loopx-repo-health/schemas/request.schema.json
+++ b/packages/loopx-repo-health/schemas/request.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "owner": {
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9_.-]+$",
+      "type": "string"
+    },
+    "repo": {
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9_.-]+$",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "loopx_repo_health_request_v0"
+    }
+  },
+  "required": [
+    "schema_version",
+    "owner",
+    "repo"
+  ],
+  "type": "object"
+}

--- a/packages/loopx-repo-health/schemas/response.schema.json
+++ b/packages/loopx-repo-health/schemas/response.schema.json
@@ -1,0 +1,285 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "oneOf": [
+    {
+      "properties": {
+        "error": false,
+        "ok": {
+          "const": true
+        }
+      },
+      "required": [
+        "request_schema_version",
+        "result"
+      ]
+    },
+    {
+      "properties": {
+        "ok": {
+          "const": false
+        },
+        "request_schema_version": false,
+        "result": false
+      },
+      "required": [
+        "error"
+      ]
+    }
+  ],
+  "properties": {
+    "doctor": {
+      "const": "ok",
+      "type": "string"
+    },
+    "error": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "extension_id": {
+      "const": "loopx-repo-health"
+    },
+    "ok": {
+      "type": "boolean"
+    },
+    "request_schema_version": {
+      "const": "loopx_repo_health_request_v0"
+    },
+    "result": {
+      "additionalProperties": false,
+      "properties": {
+        "captured_at": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "counts": {
+          "additionalProperties": false,
+          "properties": {
+            "contributors": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "forks": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "issues_total": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "open_issues": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "prs_total": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "releases": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "stars": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "watchers": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "stars",
+            "forks",
+            "watchers",
+            "open_issues",
+            "releases",
+            "contributors",
+            "prs_total",
+            "issues_total"
+          ],
+          "type": "object"
+        },
+        "evidence": {
+          "type": "object"
+        },
+        "latency": {
+          "properties": {
+            "first_response_p25_min": {
+              "anyOf": [
+                {
+                  "minimum": 0,
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "first_response_p75_min": {
+              "anyOf": [
+                {
+                  "minimum": 0,
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "pr_merge_p25_min": {
+              "anyOf": [
+                {
+                  "minimum": 0,
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "pr_merge_p75_min": {
+              "anyOf": [
+                {
+                  "minimum": 0,
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "pr_merge_p25_min",
+            "pr_merge_p75_min",
+            "first_response_p25_min",
+            "first_response_p75_min"
+          ],
+          "type": "object"
+        },
+        "repo": {
+          "properties": {
+            "created_at": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "license": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "owner": {
+              "type": "string"
+            },
+            "pushed_at": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "owner",
+            "name",
+            "license",
+            "created_at",
+            "pushed_at"
+          ],
+          "type": "object"
+        },
+        "schema_version": {
+          "const": "repo_health_snapshot_v0"
+        },
+        "star_timeline_weekly": {
+          "items": {
+            "properties": {
+              "stars": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "week": {
+                "pattern": "^[0-9]{4}-W[0-9]{2}$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "week",
+              "stars"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "traffic_14d": {
+          "properties": {
+            "clones": {
+              "properties": {
+                "count": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "uniques": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "count",
+                "uniques"
+              ],
+              "type": "object"
+            },
+            "views": {
+              "properties": {
+                "count": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "uniques": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "count",
+                "uniques"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "views",
+            "clones"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "schema_version",
+        "captured_at",
+        "repo",
+        "counts",
+        "traffic_14d",
+        "latency",
+        "star_timeline_weekly"
+      ],
+      "type": "object"
+    },
+    "schema_version": {
+      "const": "loopx_repo_health_response_v0"
+    }
+  },
+  "required": [
+    "ok",
+    "schema_version",
+    "extension_id"
+  ],
+  "type": "object"
+}

--- a/packages/loopx-repo-health/smoke/repo_health_snapshot_smoke.py
+++ b/packages/loopx-repo-health/smoke/repo_health_snapshot_smoke.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Offline contract smoke for loopx-repo-health.
+
+Run without network: python3 smoke/repo_health_snapshot_smoke.py
+Optional live check (requires GH_TOKEN for stargazers/traffic):
+python3 smoke/repo_health_snapshot_smoke.py --live owner repo
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from loopx_repo_health.contract import SNAPSHOT_SCHEMA_VERSION, validate_snapshot
+from loopx_repo_health.render import render_markdown
+
+
+def _fixture() -> dict:
+    return {
+        "schema_version": SNAPSHOT_SCHEMA_VERSION,
+        "captured_at": "2026-08-17T00:00:00+00:00",
+        "repo": {
+            "owner": "huangruiteng",
+            "name": "loopx",
+            "license": "Apache-2.0",
+            "created_at": "2026-05-31T14:58:56Z",
+            "pushed_at": "2026-08-16T17:44:43Z",
+        },
+        "counts": {
+            "stars": 4804,
+            "forks": 417,
+            "watchers": 14,
+            "open_issues": 29,
+            "releases": 1,
+            "contributors": 39,
+            "prs_total": 200,
+            "issues_total": 76,
+        },
+        "traffic_14d": {
+            "views": {"count": 88117, "uniques": 27496},
+            "clones": {"count": 29250, "uniques": 4602},
+        },
+        "latency": {
+            "pr_merge_p25_min": 12.0,
+            "pr_merge_p75_min": 1440.0,
+            "first_response_p25_min": 30.0,
+            "first_response_p75_min": 720.0,
+        },
+        "star_timeline_weekly": [{"week": "2026-W33", "stars": 197}],
+        "evidence": {
+            "sources": ["github-rest"],
+            "rate_limit_remaining": 4900,
+            "warnings": [],
+        },
+    }
+
+
+def _run_offline() -> int:
+    fixture = _fixture()
+    violations = validate_snapshot(fixture)
+    if violations:
+        print(f"FAIL: fixture should be valid: {violations}", file=sys.stderr)
+        return 1
+
+    broken = copy.deepcopy(fixture)
+    broken["counts"]["stars"] = -1
+    if validate_snapshot(broken) == []:
+        print("FAIL: negative stars accepted", file=sys.stderr)
+        return 1
+
+    broken = copy.deepcopy(fixture)
+    broken["schema_version"] = "repo_health_snapshot_v1"
+    if validate_snapshot(broken) == []:
+        print("FAIL: mismatched schema_version accepted", file=sys.stderr)
+        return 1
+
+    broken = copy.deepcopy(fixture)
+    broken["traffic_14d"]["views"] = {"count": -1, "uniques": 0}
+    if validate_snapshot(broken) == []:
+        print("FAIL: negative traffic accepted", file=sys.stderr)
+        return 1
+
+    md = render_markdown(fixture)
+    if "Repo Health: huangruiteng/loopx" not in md or "| stars | 4804 |" not in md:
+        print("FAIL: markdown projection missing expected rows", file=sys.stderr)
+        return 1
+
+    print("ok: offline contract smoke passed")
+    return 0
+
+
+def _run_live(owner: str, repo: str) -> int:
+    from loopx_repo_health.github import GitHubRepoHealthCollector
+
+    snapshot = GitHubRepoHealthCollector(owner, repo).collect().to_dict()
+    violations = validate_snapshot(snapshot)
+    if violations:
+        print(f"FAIL: live snapshot invalid: {violations}", file=sys.stderr)
+        return 1
+    print(f"ok: live snapshot for {owner}/{repo} passed contract validation")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--live", nargs=2, metavar=("OWNER", "REPO"))
+    args = parser.parse_args()
+    if args.live:
+        return _run_live(*args.live)
+    return _run_offline()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/loopx-repo-health/src/loopx_repo_health/__init__.py
+++ b/packages/loopx-repo-health/src/loopx_repo_health/__init__.py
@@ -1,0 +1,5 @@
+__all__ = ["__version__", "SNAPSHOT_SCHEMA_VERSION", "validate_snapshot"]
+
+__version__ = "0.1.0"
+
+from .contract import SNAPSHOT_SCHEMA_VERSION, validate_snapshot  # noqa: E402

--- a/packages/loopx-repo-health/src/loopx_repo_health/cli.py
+++ b/packages/loopx-repo-health/src/loopx_repo_health/cli.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+from typing import Any
+
+from .contract import SNAPSHOT_SCHEMA_VERSION, validate_snapshot
+from .github import GitHubRepoHealthCollector
+from .render import render_markdown
+
+
+EXTENSION_ID = "loopx-repo-health"
+REQUEST_SCHEMA_VERSION = "loopx_repo_health_request_v0"
+RESPONSE_SCHEMA_VERSION = "loopx_repo_health_response_v0"
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog=EXTENSION_ID)
+    parser.add_argument("--doctor", action="store_true", help="run the managed-runtime health check")
+    sub = parser.add_subparsers(dest="command")
+    snap = sub.add_parser("snapshot", help="collect a repo-health snapshot")
+    snap.add_argument("--owner", required=True)
+    snap.add_argument("--repo", required=True)
+    snap.add_argument("--format", choices=("json", "md"), default="json")
+    return parser
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    json.dump(payload, sys.stdout, sort_keys=True, ensure_ascii=False)
+    sys.stdout.write("\n")
+
+
+def _doctor() -> int:
+    _emit(
+        {
+            "ok": True,
+            "schema_version": RESPONSE_SCHEMA_VERSION,
+            "extension_id": EXTENSION_ID,
+            "doctor": "ok",
+        }
+    )
+    return 0
+
+
+def _run_request(payload: dict[str, Any]) -> int:
+    if not isinstance(payload, dict):
+        raise ValueError("extension input must be a JSON object")
+    if payload.get("schema_version") != REQUEST_SCHEMA_VERSION:
+        raise ValueError(f"extension input must use {REQUEST_SCHEMA_VERSION}")
+    owner = payload.get("owner")
+    repo = payload.get("repo")
+    if not isinstance(owner, str) or not owner.strip():
+        raise ValueError("request requires non-empty string `owner`")
+    if not isinstance(repo, str) or not repo.strip():
+        raise ValueError("request requires non-empty string `repo`")
+    snapshot = GitHubRepoHealthCollector(owner.strip(), repo.strip()).collect().to_dict()
+    violations = validate_snapshot(snapshot)
+    if violations:
+        raise ValueError(f"snapshot contract violated: {violations}")
+    _emit(
+        {
+            "ok": True,
+            "schema_version": RESPONSE_SCHEMA_VERSION,
+            "extension_id": EXTENSION_ID,
+            "request_schema_version": REQUEST_SCHEMA_VERSION,
+            "result": snapshot,
+        }
+    )
+    return 0
+
+
+def _snapshot_command(args: argparse.Namespace) -> int:
+    snapshot = GitHubRepoHealthCollector(args.owner, args.repo).collect().to_dict()
+    violations = validate_snapshot(snapshot)
+    if violations:
+        _emit({"ok": False, "error": f"snapshot contract violated: {violations}"})
+        return 1
+    if args.format == "md":
+        sys.stdout.write(render_markdown(snapshot))
+    else:
+        _emit(snapshot)
+    return 0
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.doctor:
+        return _doctor()
+    try:
+        if args.command == "snapshot":
+            return _snapshot_command(args)
+        payload = json.load(sys.stdin)
+        return _run_request(payload)
+    except (json.JSONDecodeError, OSError, ValueError, KeyError) as exc:
+        _emit(
+            {
+                "ok": False,
+                "schema_version": RESPONSE_SCHEMA_VERSION,
+                "extension_id": EXTENSION_ID,
+                "error": str(exc),
+            }
+        )
+        return 1
+
+
+def main() -> int:
+    return run()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/loopx-repo-health/src/loopx_repo_health/contract.py
+++ b/packages/loopx-repo-health/src/loopx_repo_health/contract.py
@@ -1,0 +1,77 @@
+"""Public-safe repo-health snapshot contract.
+
+The snapshot only contains public repository metrics. It never accepts or
+emits raw trajectories, benchmark evidence, credentials, or private links.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+SNAPSHOT_SCHEMA_VERSION = "repo_health_snapshot_v0"
+
+
+@dataclass
+class RepoHealthSnapshot:
+    captured_at: str
+    repo: dict[str, Any]
+    counts: dict[str, int]
+    traffic_14d: dict[str, dict[str, int]]
+    latency: dict[str, float | None]
+    star_timeline_weekly: list[dict[str, Any]]
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": SNAPSHOT_SCHEMA_VERSION,
+            "captured_at": self.captured_at,
+            "repo": self.repo,
+            "counts": self.counts,
+            "traffic_14d": self.traffic_14d,
+            "latency": self.latency,
+            "star_timeline_weekly": self.star_timeline_weekly,
+            "evidence": self.evidence,
+        }
+
+
+def validate_snapshot(payload: dict[str, Any]) -> list[str]:
+    """Return a list of contract violations (empty when the payload is valid)."""
+
+    violations: list[str] = []
+    if payload.get("schema_version") != SNAPSHOT_SCHEMA_VERSION:
+        violations.append(f"schema_version must be {SNAPSHOT_SCHEMA_VERSION}")
+    for key in ("captured_at", "repo", "counts", "traffic_14d", "latency", "star_timeline_weekly"):
+        if key not in payload:
+            violations.append(f"missing required field {key}")
+    counts = payload.get("counts")
+    if not isinstance(counts, dict):
+        violations.append("counts must be an object")
+    else:
+        for metric in (
+            "stars",
+            "forks",
+            "watchers",
+            "open_issues",
+            "releases",
+            "contributors",
+            "prs_total",
+            "issues_total",
+        ):
+            if not isinstance(counts.get(metric), int) or counts[metric] < 0:
+                violations.append(f"counts.{metric} must be a non-negative integer")
+    traffic = payload.get("traffic_14d")
+    if isinstance(traffic, dict):
+        for surface in ("views", "clones"):
+            item = traffic.get(surface)
+            if not isinstance(item, dict) or not all(
+                isinstance(item.get(k), int) and item[k] >= 0 for k in ("count", "uniques")
+            ):
+                violations.append(f"traffic_14d.{surface} must have non-negative count/uniques")
+    else:
+        violations.append("traffic_14d must be an object")
+    latency = payload.get("latency")
+    if not isinstance(latency, dict):
+        violations.append("latency must be an object")
+    return violations

--- a/packages/loopx-repo-health/src/loopx_repo_health/github.py
+++ b/packages/loopx-repo-health/src/loopx_repo_health/github.py
@@ -1,0 +1,312 @@
+"""Bounded GitHub REST collector for public repo-health metrics.
+
+Uses only the Python standard library. Authentication is read from the
+environment (`GH_TOKEN` or `GITHUB_TOKEN`); the request packet never carries
+credentials.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from statistics import quantiles
+from typing import Any
+
+from .contract import RepoHealthSnapshot, SNAPSHOT_SCHEMA_VERSION
+
+
+API_BASE = "https://api.github.com"
+USER_AGENT = "loopx-repo-health/0.1.0"
+REQUEST_TIMEOUT_SECONDS = 15
+_LINK_LAST_PAGE = re.compile(r'[?&]page=(\d+)>;\s*rel="last"')
+
+
+class GitHubError(RuntimeError):
+    pass
+
+
+def _token() -> str | None:
+    return os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+
+
+def _headers() -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": USER_AGENT,
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    token = _token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _request_json(
+    path: str,
+    *,
+    params: dict[str, str] | None = None,
+    accept: str | None = None,
+) -> tuple[Any, dict[str, str]]:
+    url = f"{API_BASE}{path}"
+    if params:
+        url = f"{url}?{urllib.parse.urlencode(params)}"
+    req = urllib.request.Request(url, headers=_headers())
+    if accept:
+        req.add_header("Accept", accept)
+    try:
+        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as resp:
+            headers = {k.lower(): v for k, v in resp.headers.items()}
+            body = resp.read().decode("utf-8")
+            return (json.loads(body) if body else None, headers)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:300]
+        raise GitHubError(f"GET {path} failed with {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise GitHubError(f"GET {path} unreachable: {exc.reason}") from exc
+
+
+def _last_page(headers: dict[str, str]) -> int | None:
+    link = headers.get("link", "")
+    match = _LINK_LAST_PAGE.search(link)
+    return int(match.group(1)) if match else None
+
+
+def _rate_limit_remaining(headers: dict[str, str]) -> int | None:
+    raw = headers.get("x-ratelimit-remaining")
+    return int(raw) if raw is not None else None
+
+
+def _iso(value: str | None) -> str | None:
+    return value if value else None
+
+
+def _minutes_between(start: str | None, end: str | None) -> float | None:
+    if not start or not end:
+        return None
+    try:
+        s = datetime.fromisoformat(start.replace("Z", "+00:00"))
+        e = datetime.fromisoformat(end.replace("Z", "+00:00"))
+        return max(0.0, (e - s).total_seconds() / 60.0)
+    except ValueError:
+        return None
+
+
+def _percentiles(values: list[float], p25: float = 0.25, p75: float = 0.75) -> tuple[float | None, float | None]:
+    if not values:
+        return (None, None)
+    if len(values) < 5:
+        return (round(values[0], 1), round(values[-1], 1))
+    q = quantiles(sorted(values), n=4, method="inclusive")
+    return (round(q[0], 1), round(q[2], 1))
+
+
+class GitHubRepoHealthCollector:
+    def __init__(self, owner: str, repo: str) -> None:
+        self.owner = owner
+        self.repo = repo
+        self.warnings: list[str] = []
+        self._rate_limit_remaining: int | None = None
+
+    def collect(self) -> RepoHealthSnapshot:
+        captured_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        repo_meta, headers = _request_json(f"/repos/{self.owner}/{self.repo}")
+        self._rate_limit_remaining = _rate_limit_remaining(headers)
+        repo = {
+            "owner": self.owner,
+            "name": self.repo,
+            "license": (repo_meta.get("license") or {}).get("spdx_id"),
+            "created_at": _iso(repo_meta.get("created_at")),
+            "pushed_at": _iso(repo_meta.get("pushed_at")),
+        }
+        counts = {
+            "stars": int(repo_meta["stargazers_count"]),
+            "forks": int(repo_meta["forks_count"]),
+            "watchers": int(repo_meta.get("subscribers_count", 0)),
+            "open_issues": int(repo_meta["open_issues_count"]),
+            "releases": self._count_releases(),
+            "contributors": self._count_contributors(),
+            "prs_total": 0,
+            "issues_total": 0,
+        }
+        traffic_14d = self._collect_traffic()
+        latency = self._collect_latency(counts)
+        star_timeline_weekly = self._collect_star_timeline_weekly()
+        evidence = {
+            "sources": ["github-rest"],
+            "rate_limit_remaining": self._rate_limit_remaining,
+            "warnings": self.warnings,
+        }
+        return RepoHealthSnapshot(
+            captured_at=captured_at,
+            repo=repo,
+            counts=counts,
+            traffic_14d=traffic_14d,
+            latency=latency,
+            star_timeline_weekly=star_timeline_weekly,
+            evidence=evidence,
+        )
+
+    def _count_releases(self) -> int:
+        _, headers = _request_json(
+            f"/repos/{self.owner}/{self.repo}/releases",
+            params={"per_page": "1"},
+        )
+        last = _last_page(headers)
+        return last or 0
+
+    def _count_contributors(self) -> int:
+        _, headers = _request_json(
+            f"/repos/{self.owner}/{self.repo}/contributors",
+            params={"per_page": "1", "anon": "true"},
+        )
+        return _last_page(headers) or 0
+
+    def _collect_traffic(self) -> dict[str, dict[str, int]]:
+        result: dict[str, dict[str, int]] = {}
+        for surface in ("views", "clones"):
+            try:
+                payload, _ = _request_json(f"/repos/{self.owner}/{self.repo}/traffic/{surface}")
+                result[surface] = {"count": int(payload.get("count", 0)), "uniques": int(payload.get("uniques", 0))}
+            except GitHubError as exc:
+                result[surface] = {"count": 0, "uniques": 0}
+                self.warnings.append(f"traffic/{surface} unavailable: {exc}")
+        return result
+
+    def _closed_pull_requests(self, limit: int = 200) -> list[dict[str, Any]]:
+        pulls: list[dict[str, Any]] = []
+        page = 1
+        while len(pulls) < limit and page <= 5:
+            batch, headers = _request_json(
+                f"/repos/{self.owner}/{self.repo}/pulls",
+                params={"state": "closed", "per_page": "100", "page": str(page), "sort": "updated", "direction": "desc"},
+            )
+            pulls.extend(batch or [])
+            self._rate_limit_remaining = _rate_limit_remaining(headers)
+            if len(batch or []) < 100:
+                break
+            page += 1
+        return pulls[:limit]
+
+    def _issues_with_comments(self, limit: int = 100) -> list[dict[str, Any]]:
+        issues: list[dict[str, Any]] = []
+        page = 1
+        while len(issues) < limit and page <= 3:
+            batch, headers = _request_json(
+                f"/repos/{self.owner}/{self.repo}/issues",
+                params={"state": "all", "per_page": "100", "page": str(page), "sort": "created", "direction": "desc"},
+            )
+            self._rate_limit_remaining = _rate_limit_remaining(headers)
+            for issue in batch or []:
+                if "pull_request" in issue:
+                    continue
+                if int(issue.get("comments", 0)) > 0:
+                    issues.append(issue)
+            if len(batch or []) < 100:
+                break
+            page += 1
+        return issues[:limit]
+
+    def _first_comment_minutes(self, number: int, created_at: str | None) -> float | None:
+        try:
+            events, _ = _request_json(
+                f"/repos/{self.owner}/{self.repo}/issues/{number}/timeline",
+                accept="application/vnd.github+json",
+            )
+        except GitHubError:
+            return None
+        human_times = [
+            event.get("created_at")
+            for event in events or []
+            if event.get("event") == "commented"
+            and not ((event.get("actor") or {}).get("login") or "").endswith("[bot]")
+            and event.get("created_at")
+        ]
+        if not human_times:
+            return None
+        return _minutes_between(created_at, min(human_times))
+
+    def _collect_latency(self, counts: dict[str, int]) -> dict[str, float | None]:
+        pulls = self._closed_pull_requests()
+        counts["prs_total"] = len(pulls)
+        merge_latencies = [
+            minutes
+            for minutes in (_minutes_between(p.get("created_at"), p.get("merged_at")) for p in pulls)
+            if minutes is not None
+        ]
+        p25, p75 = _percentiles(merge_latencies)
+        if len(pulls) >= 100:
+            self.warnings.append(f"pr merge latency sampled from latest {len(pulls)} closed PRs")
+
+        issues = self._issues_with_comments()
+        counts["issues_total"] = len(issues)
+        first_response_minutes: list[float] = []
+        sampled = issues[:30]
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            future_to_issue = {
+                pool.submit(self._first_comment_minutes, i["number"], i.get("created_at")): i for i in sampled
+            }
+            for future in as_completed(future_to_issue):
+                minutes = future.result()
+                if minutes is not None:
+                    first_response_minutes.append(minutes)
+        fr_p25, fr_p75 = _percentiles(first_response_minutes)
+        if sampled:
+            self.warnings.append(
+                f"first-response latency sampled from {len(first_response_minutes)}/{len(sampled)} newest commented issues"
+            )
+        else:
+            self.warnings.append("no commented issues found; first-response latency unavailable")
+        return {
+            "pr_merge_p25_min": p25,
+            "pr_merge_p75_min": p75,
+            "first_response_p25_min": fr_p25,
+            "first_response_p75_min": fr_p75,
+        }
+
+    def _collect_star_timeline_weekly(self) -> list[dict[str, Any]]:
+        """Weekly star buckets from the authenticated stargazers feed.
+
+        The stargazers feed is oldest-first, so this collector reads the last
+        pages (newest stars) for a bounded recent-window trend.
+        """
+
+        stars: list[str] = []
+        try:
+            _, headers = _request_json(
+                f"/repos/{self.owner}/{self.repo}/stargazers",
+                params={"per_page": "100", "page": "1"},
+                accept="application/vnd.github.star+json",
+            )
+        except GitHubError as exc:
+            self.warnings.append(f"star timeline unavailable: {exc}")
+            return []
+        self._rate_limit_remaining = _rate_limit_remaining(headers)
+        last = _last_page(headers)
+        pages = [1] if not last or last <= 1 else [last, last - 1, last - 2]
+        for page in pages:
+            batch, headers = _request_json(
+                f"/repos/{self.owner}/{self.repo}/stargazers",
+                params={"per_page": "100", "page": str(page)},
+                accept="application/vnd.github.star+json",
+            )
+            self._rate_limit_remaining = _rate_limit_remaining(headers)
+            stars.extend(item["starred_at"] for item in batch or [])
+        if not stars:
+            self.warnings.append("star timeline unavailable (stargazers endpoint requires auth)")
+            return []
+        buckets: dict[str, int] = {}
+        for raw in stars:
+            try:
+                iso = datetime.fromisoformat(raw.replace("Z", "+00:00")).isocalendar()
+            except ValueError:
+                continue
+            week = f"{iso.year}-W{iso.week:02d}"
+            buckets[week] = buckets.get(week, 0) + 1
+        return [{"week": week, "stars": count} for week, count in sorted(buckets.items())]

--- a/packages/loopx-repo-health/src/loopx_repo_health/render.py
+++ b/packages/loopx-repo-health/src/loopx_repo_health/render.py
@@ -1,0 +1,76 @@
+"""Compact markdown rendering for a repo-health snapshot."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _fmt_minutes(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    if value < 60:
+        return f"{value:.0f} min"
+    return f"{value / 60:.1f} h"
+
+
+def render_markdown(snapshot: dict[str, Any]) -> str:
+    counts = snapshot["counts"]
+    traffic = snapshot["traffic_14d"]
+    latency = snapshot["latency"]
+    repo = snapshot["repo"]
+    lines = [
+        f"# Repo Health: {repo['owner']}/{repo['name']}",
+        "",
+        f"- captured_at: {snapshot['captured_at']}",
+        f"- license: {repo.get('license') or 'n/a'}",
+        f"- pushed_at: {repo.get('pushed_at') or 'n/a'}",
+        "",
+        "## Counts",
+        "",
+        "| metric | value |",
+        "| --- | --- |",
+    ]
+    for key in (
+        "stars",
+        "forks",
+        "watchers",
+        "open_issues",
+        "releases",
+        "contributors",
+        "prs_total",
+        "issues_total",
+    ):
+        lines.append(f"| {key} | {counts.get(key, 0)} |")
+    lines += [
+        "",
+        "## Traffic (14d)",
+        "",
+        "| surface | count | uniques |",
+        "| --- | --- | --- |",
+    ]
+    for surface in ("views", "clones"):
+        item = traffic.get(surface, {})
+        lines.append(f"| {surface} | {item.get('count', 0)} | {item.get('uniques', 0)} |")
+    lines += [
+        "",
+        "## Latency",
+        "",
+        "| metric | value |",
+        "| --- | --- |",
+        f"| PR merge p25 | {_fmt_minutes(latency.get('pr_merge_p25_min'))} |",
+        f"| PR merge p75 | {_fmt_minutes(latency.get('pr_merge_p75_min'))} |",
+        f"| first response p25 | {_fmt_minutes(latency.get('first_response_p25_min'))} |",
+        f"| first response p75 | {_fmt_minutes(latency.get('first_response_p75_min'))} |",
+        "",
+        "## Recent star timeline (weekly)",
+        "",
+        "| week | stars |",
+        "| --- | --- |",
+    ]
+    for row in snapshot.get("star_timeline_weekly", []):
+        lines.append(f"| {row['week']} | {row['stars']} |")
+    warnings = (snapshot.get("evidence") or {}).get("warnings") or []
+    if warnings:
+        lines += ["", "## Warnings", ""]
+        lines += [f"- {w}" for w in warnings]
+    return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary
New independently packaged LoopX extension provider: `packages/loopx-repo-health`.

It collects a bounded set of public GitHub repo-health metrics from the GitHub REST API and emits a frozen `repo_health_snapshot_v0` document for monthly reports, community-funnel monitoring, and public content material.

## What is included
- `repo_health_snapshot_v0` contract + validation (`contract.py`)
- Bounded GitHub REST collector: counts, 14d views/clones, PR merge p25/p75, first-human-response p25/p75, recent weekly star timeline (`github.py`)
- Managed extension protocol (stdin request → stdout response), `--doctor`, and `snapshot --format json|md` CLI
- Versioned request/response JSON schemas, README, CONTRACT.md
- Offline contract smoke + optional live smoke

## Validation
- `python3 smoke/repo_health_snapshot_smoke.py` → offline contract smoke passed
- Live snapshot on `huangruiteng/loopx` with token: traffic 88,117 views / 29,250 clones; PR merge p25/p75 6.5/187.2 min; first response p25/p75 18.4/295.9 min; contract validation passed
- JSON schemas parse; package compiles

## Boundary
- Public-safe only: no raw trajectories, benchmark evidence, credentials, or private links
- Auth via `GH_TOKEN`/`GITHUB_TOKEN` env only; credentials never in packets
- Latency and star timeline are bounded samples with explicit warnings