### PR TITLE
feat(benchmark): bind provider env to installed Goal profiles

### DIFF
--- a/benchmark/deepswe/README.md
+++ b/benchmark/deepswe/README.md
@@ -115,7 +115,10 @@ Prepare the latter two with
 `benchmark_toolkit.native_codex_profile.install_native_codex_profile`. Do not copy
 `SKILL.md` files into a runner image. Generate the first input with
 `render_native_codex_goal_prompt`, build app-server's environment with
-`native_codex_profile_environment`, and set
+`native_codex_app_server_environment(profile, provider_env_key=..., base_env=...)`,
+then separately exclude that key from agent shell and tool processes. The
+credential-free `native_codex_profile_environment` remains the default for CLI
+and preflight work. Set
 `NativeGoalConfig.required_skill_ids=profile.required_skill_ids`. The runtime then
 uses `skills/list` before thread creation and fails before model work unless Codex
 actually discovers the installed skill set. A filesystem check alone is not

--- a/benchmark/native_codex_goal.py
+++ b/benchmark/native_codex_goal.py
@@ -35,6 +35,7 @@ from loopx.capabilities.benchmark_toolkit.native_codex_profile import (
     compact_native_codex_profile_receipt,
     inspect_native_codex_profile,
     install_native_codex_profile,
+    native_codex_app_server_environment,
     native_codex_profile_environment,
     render_native_codex_goal_prompt,
 )
@@ -57,6 +58,7 @@ __all__ = [
     "compact_native_goal_receipt",
     "inspect_native_codex_profile",
     "install_native_codex_profile",
+    "native_codex_app_server_environment",
     "native_codex_profile_environment",
     "observe_native_goal_event",
     "probe_native_goal_process",

--- a/benchmark/tests/test_native_codex_profile.py
+++ b/benchmark/tests/test_native_codex_profile.py
@@ -13,6 +13,8 @@ from loopx.capabilities.benchmark_toolkit.native_codex_profile import (
     compact_native_codex_profile_receipt,
     inspect_native_codex_profile,
     install_native_codex_profile,
+    native_codex_app_server_environment,
+    native_codex_profile_environment,
     render_native_codex_goal_prompt,
 )
 
@@ -80,6 +82,54 @@ def test_compact_profile_receipt_excludes_local_paths() -> None:
     assert receipt["source_clean"] is True
     assert receipt["skill_readback_ready"] is True
     assert "/private" not in rendered
+
+
+def test_app_server_environment_explicitly_admits_only_provider_value(
+    tmp_path: Path,
+) -> None:
+    profile = _fake_profile(tmp_path)
+    base_env = {
+        "PATH": "/usr/bin:/bin",
+        "CODEX_GOAL_API_KEY": "provider-value",
+        "UNRELATED_PRIVATE_VALUE": "must-not-pass",
+    }
+    original_base_env = dict(base_env)
+
+    profile_env = native_codex_profile_environment(profile, base_env=base_env)
+    app_server_env = native_codex_app_server_environment(
+        profile,
+        provider_env_key="CODEX_GOAL_API_KEY",
+        base_env=base_env,
+    )
+
+    assert "CODEX_GOAL_API_KEY" not in profile_env
+    assert "UNRELATED_PRIVATE_VALUE" not in profile_env
+    assert app_server_env["CODEX_GOAL_API_KEY"] == "provider-value"
+    assert "UNRELATED_PRIVATE_VALUE" not in app_server_env
+    assert app_server_env["CODEX_HOME"] == str(profile.codex_home)
+    assert base_env == original_base_env
+
+
+def test_app_server_environment_rejects_invalid_or_missing_provider_key(
+    tmp_path: Path,
+) -> None:
+    profile = _fake_profile(tmp_path)
+
+    with pytest.raises(ValueError, match="provider_env_key"):
+        native_codex_app_server_environment(
+            profile,
+            provider_env_key="invalid-key",
+            base_env={"invalid-key": "value"},
+        )
+    with pytest.raises(
+        NativeCodexProfileError,
+        match="provider_environment_value_missing:CODEX_GOAL_API_KEY",
+    ):
+        native_codex_app_server_environment(
+            profile,
+            provider_env_key="CODEX_GOAL_API_KEY",
+            base_env={"PATH": "/usr/bin:/bin"},
+        )
 
 
 def test_installed_cli_renders_and_rebinds_the_real_goal_prompt(tmp_path: Path) -> None:

--- a/examples/benchmark-native-goal-installed-profile-smoke.py
+++ b/examples/benchmark-native-goal-installed-profile-smoke.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -27,6 +28,7 @@ from loopx.capabilities.benchmark_toolkit.native_codex_profile import (
     compact_native_codex_profile_receipt,
     inspect_native_codex_profile,
     install_native_codex_profile,
+    native_codex_app_server_environment,
     native_codex_profile_environment,
     render_native_codex_goal_prompt,
 )
@@ -83,6 +85,35 @@ def main() -> int:
             require_clean_source=not args.allow_dirty_source,
         )
         profile_receipt = compact_native_codex_profile_receipt(profile)
+        provider_key = "LOOPX_BENCHMARK_PROVIDER_SENTINEL"
+        unrelated_key = "LOOPX_BENCHMARK_UNRELATED_SENTINEL"
+        sentinel_env = {
+            **os.environ,
+            provider_key: "provider-sentinel",
+            unrelated_key: "unrelated-sentinel",
+        }
+        default_profile_env = native_codex_profile_environment(
+            profile, base_env=sentinel_env
+        )
+        app_server_env = native_codex_app_server_environment(
+            profile,
+            provider_env_key=provider_key,
+            base_env=sentinel_env,
+        )
+        provider_environment_receipt = {
+            "default_environment_credential_free": provider_key
+            not in default_profile_env,
+            "declared_provider_value_admitted": app_server_env.get(provider_key)
+            == "provider-sentinel",
+            "unrelated_value_excluded": unrelated_key not in app_server_env,
+            "raw_values_recorded": False,
+        }
+        if not all(
+            value is True
+            for key, value in provider_environment_receipt.items()
+            if key != "raw_values_recorded"
+        ):
+            raise SystemExit("profile provider environment boundary failed")
         project = Path(raw) / "project"
         project.mkdir()
         registry = project / ".loopx" / "registry.json"
@@ -190,6 +221,7 @@ def main() -> int:
                 "profile": profile_receipt,
                 "goal_prompt": prompt_receipt,
                 "app_server": app_server_receipt,
+                "provider_environment": provider_environment_receipt,
                 "public_boundary": {
                     "local_paths_recorded": False,
                     "credentials_recorded": False,

--- a/examples/benchmark-native-goal-installed-profile-smoke.py
+++ b/examples/benchmark-native-goal-installed-profile-smoke.py
@@ -187,7 +187,7 @@ def main() -> int:
                     required_skill_ids=profile.required_skill_ids,
                 ),
                 codex_bin=codex_bin,
-                process_env=native_codex_profile_environment(profile),
+                process_env=app_server_env,
                 process_cwd=str(project),
                 response_timeout_sec=30,
             )

--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -34,7 +34,7 @@ skill files or importing an arbitrary checkout:
 from loopx.capabilities.benchmark_toolkit.native_codex_goal import NativeGoalConfig
 from loopx.capabilities.benchmark_toolkit.native_codex_profile import (
     install_native_codex_profile,
-    native_codex_profile_environment,
+    native_codex_app_server_environment,
     render_native_codex_goal_prompt,
 )
 
@@ -52,7 +52,11 @@ config = NativeGoalConfig(
     task_instruction=task_instruction,
     required_skill_ids=profile.required_skill_ids,
 )
-process_env = native_codex_profile_environment(profile)
+process_env = native_codex_app_server_environment(
+    profile,
+    provider_env_key=runner_provider_env_key,
+    base_env=runner_environment,
+)
 ```
 
 The profile installer redirects the release, executable, manual, home, and Codex
@@ -66,9 +70,13 @@ source by default, skill-tree digests, and `doctor --agent-type codex-app-ssh`.
 release-snapshot CLI, requires the `codex_app_ssh_goal` profile and interface budget,
 and proves that the returned body names that installed CLI. For an isolated case it
 also replaces the generic global-registry token with the explicit case registry.
-Use `native_codex_profile_environment` for app-server so the same profile supplies
-`HOME`, `CODEX_HOME`, and `PATH`. Setting `required_skill_ids` makes the native
-runtime call the real app-server `skills/list` surface before `thread/start`;
+Use `native_codex_app_server_environment` for app-server so the same profile
+supplies `HOME`, `CODEX_HOME`, and `PATH` while exactly one runner-declared model
+provider value is restored. The lower-level `native_codex_profile_environment`
+remains credential-free by default. The runner must still exclude the provider
+key from agent shell and tool environments; this helper grants no such tool
+access. Setting `required_skill_ids` makes the native runtime call the real
+app-server `skills/list` surface before `thread/start`;
 missing skills, discovery errors, or a wrong cwd fail before any model turn. The
 path-free profile, prompt, and Goal receipts can then prove all three inputs without
 publishing installation paths, prompt text, or skill bodies.

--- a/loopx/capabilities/benchmark_toolkit/__init__.py
+++ b/loopx/capabilities/benchmark_toolkit/__init__.py
@@ -46,6 +46,7 @@ from .native_codex_profile import (
     compact_native_codex_profile_receipt,
     inspect_native_codex_profile,
     install_native_codex_profile,
+    native_codex_app_server_environment,
     native_codex_profile_environment,
     render_native_codex_goal_prompt,
 )
@@ -98,6 +99,7 @@ __all__ = [
     "inspect_native_codex_profile",
     "install_native_codex_profile",
     "materialize_public_benchmark_artifacts",
+    "native_codex_app_server_environment",
     "native_codex_profile_environment",
     "observe_native_goal_event",
     "probe_native_goal_process",

--- a/loopx/capabilities/benchmark_toolkit/native_codex_profile.py
+++ b/loopx/capabilities/benchmark_toolkit/native_codex_profile.py
@@ -34,6 +34,7 @@ NATIVE_CODEX_PROFILE_REQUIRED_SKILL_IDS = (
 )
 _DEFAULT_GLOBAL_REGISTRY_TOKEN = "$HOME/.codex/loopx/registry.global.json"
 _SAFE_RELEASE_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*\Z")
+_SAFE_ENV_KEY = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
 _INSTALL_ENV_PASSTHROUGH = (
     "LANG",
     "LC_ALL",
@@ -228,6 +229,32 @@ def native_codex_profile_environment(
             "PATH": f"{profile.bin_dir}{os.pathsep}{inherited_path}",
         }
     )
+    return env
+
+
+def native_codex_app_server_environment(
+    profile: NativeCodexProfile,
+    *,
+    provider_env_key: str,
+    base_env: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Admit one runner-owned provider value into the formal profile environment.
+
+    The underlying profile environment remains credential-free by default. The
+    runner must name the provider key explicitly and separately deny that key to
+    agent shell or tool processes.
+    """
+
+    if not _SAFE_ENV_KEY.fullmatch(provider_env_key):
+        raise ValueError("provider_env_key must be a safe environment variable name")
+    source = os.environ if base_env is None else base_env
+    provider_value = source.get(provider_env_key)
+    if not isinstance(provider_value, str) or not provider_value.strip():
+        raise NativeCodexProfileError(
+            f"provider_environment_value_missing:{provider_env_key}"
+        )
+    env = native_codex_profile_environment(profile, base_env=base_env)
+    env[provider_env_key] = provider_value
     return env
 
 
@@ -587,6 +614,7 @@ __all__ = [
     "compact_native_codex_profile_receipt",
     "inspect_native_codex_profile",
     "install_native_codex_profile",
+    "native_codex_app_server_environment",
     "native_codex_profile_environment",
     "render_native_codex_goal_prompt",
 ]


### PR DESCRIPTION
## What changed

- add a typed `native_codex_app_server_environment()` helper that starts from the credential-free formal profile environment and explicitly admits one validated runner-owned provider key;
- keep unrelated ambient values excluded and fail closed when the declared provider value is missing;
- export the helper through the benchmark toolkit and compatibility facade;
- document the app-server versus agent-shell credential boundary;
- extend the formal-install smoke with credential-free-default, explicit-admission, and unrelated-value-exclusion checks.

## Why

A formally installed profile intentionally builds a minimal environment. An adapter that uses that environment directly for Codex app-server can accidentally drop the model provider value even when the runner admitted it. The failure occurs before model work and is easy to miss in a no-model Goal attachment preflight.

This change makes the required overlay explicit without weakening the default boundary. The runner still owns provider configuration and must separately exclude the declared key from agent shell and tool processes.

## Impact

Benchmark adapters can compose a real installed LoopX profile, discovered skills, installed CLI, and model transport without inheriting the full ambient environment. This does not change benchmark scoring, task semantics, permissions, upload/submission behavior, or launch any benchmark job.

## Validation

- 25 benchmark native Goal/profile tests passed.
- 59 benchmark toolkit, installer freshness, and slash-command tests passed.
- Real formal-install + Codex app-server no-model smoke passed, including six required LoopX skills and the provider environment boundary.
- Ruff, Python compile checks, and diff hygiene passed.
- Risk canary executed 18 selected checks with 0 failures and 0 warnings. It reported the standard manual-review hold for benchmark-sensitive paths; no technical check failed.
