### PR TITLE
feat(benchmark): isolate native Codex workers from the host

### DIFF
--- a/benchmark/deepswe/README.md
+++ b/benchmark/deepswe/README.md
@@ -75,9 +75,35 @@ python benchmark/deepswe/run_native_codex_goal.py \
 ```
 
 Use `--preflight-only` to verify initialize, thread creation, and Goal
-attachment without starting a model turn. A benchmark adapter can reuse the
-same runtime directly while keeping its environment bridge active in another
-task:
+attachment without starting a model turn. On Linux, the same runnable can opt
+into the toolkit's host-filesystem boundary:
+
+```bash
+python benchmark/deepswe/run_native_codex_goal.py \
+  --cwd <task-worktree> \
+  --objective-file <objective.txt> \
+  --task-file <task.txt> \
+  --isolate \
+  --isolation-work-dir <runner-created-per-run-dir> \
+  --private-root <controller-private-root> \
+  --profile-root <per-run-installed-profile>
+```
+
+Isolation is explicit; the default invocation is unchanged. The work directory
+must be outside the private root and task workspace. The optional profile is a
+writable process input, so create it per run or restore it from a pinned snapshot
+rather than sharing it across trials. Use a deterministic per-run work directory:
+if the worker is killed before normal cleanup, the next identical invocation
+repairs stale workspace-alias references before launch and restores host paths on
+exit.
+
+When task-local LoopX control state exists, both `.loopx/registry.json` and
+`.loopx/runtime/registry.global.json` must exist. Neither file means there is no
+control state to relocate; only one file is treated as incomplete state and fails
+closed.
+
+A benchmark adapter can reuse the same runtime directly while keeping its
+environment bridge active in another task:
 
 ```python
 from loopx.capabilities.benchmark_toolkit.native_codex_goal import (

--- a/benchmark/deepswe/run_native_codex_goal.py
+++ b/benchmark/deepswe/run_native_codex_goal.py
@@ -19,6 +19,14 @@ from loopx.capabilities.benchmark_toolkit.native_codex_goal import (
     probe_native_goal_process,
     run_native_goal_process_until_terminal,
 )
+from loopx.capabilities.benchmark_toolkit.native_codex_isolation import (
+    NativeCodexIsolationEnvelope,
+    NativeCodexLoopXStateRebase,
+    build_native_codex_isolation_envelope,
+    rebase_native_codex_loopx_workspace_state,
+)
+
+_APP_SERVER_ARGS = ("app-server", "--listen", "stdio://", "--enable", "goals")
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -46,6 +54,23 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--response-timeout-seconds", type=float, default=30)
     parser.add_argument("--goal-timeout-seconds", type=float, default=21_600)
     parser.add_argument(
+        "--isolate",
+        action="store_true",
+        help="Run app-server in the benchmark-toolkit native isolation envelope",
+    )
+    parser.add_argument(
+        "--isolation-work-dir",
+        help="Runner-created per-run directory shared with the isolated worker",
+    )
+    parser.add_argument(
+        "--private-root",
+        help="Controller-private root that must stay absent inside isolation",
+    )
+    parser.add_argument(
+        "--profile-root",
+        help="Optional per-run formal LoopX profile exposed inside isolation",
+    )
+    parser.add_argument(
         "--preflight-only",
         action="store_true",
         help="Prove initialize/thread/Goal attachment without starting a model turn",
@@ -53,33 +78,108 @@ def _parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _rebase_count(value: NativeCodexLoopXStateRebase | None) -> int:
+    return value.replacement_count if value is not None else 0
+
+
 def main(argv: Sequence[str] | None = None) -> int:
-    args = _parser().parse_args(argv)
-    config = NativeGoalConfig(
-        cwd=args.cwd,
-        objective=Path(args.objective_file).read_text(encoding="utf-8").strip(),
-        task_instruction=Path(args.task_file).read_text(encoding="utf-8").strip(),
-        model=args.model,
-        effort=args.effort,
-        token_budget=args.token_budget,
+    parser = _parser()
+    args = parser.parse_args(argv)
+    isolation_paths = (
+        args.isolation_work_dir,
+        args.private_root,
+        args.profile_root,
     )
-    if args.preflight_only:
-        turn = probe_native_goal_process(
-            config,
-            codex_bin=args.codex_bin,
-            response_timeout_sec=args.response_timeout_seconds,
+    if args.isolate and not all(isolation_paths[:2]):
+        parser.error("--isolate requires --isolation-work-dir and --private-root")
+    if not args.isolate and any(isolation_paths):
+        parser.error("isolation path arguments require --isolate")
+
+    workspace_source = Path(args.cwd)
+    envelope: NativeCodexIsolationEnvelope | None = None
+    recovered: NativeCodexLoopXStateRebase | None = None
+    rebased: NativeCodexLoopXStateRebase | None = None
+    restored: NativeCodexLoopXStateRebase | None = None
+    restore_required = False
+    process_command: Sequence[str] | None = None
+    process_cwd: str | None = None
+    runtime_cwd = args.cwd
+    if args.isolate:
+        envelope = build_native_codex_isolation_envelope(
+            executable=args.codex_bin,
+            process_args=_APP_SERVER_ARGS,
+            work_dir=Path(args.isolation_work_dir),
+            private_root=Path(args.private_root),
+            workspace_source=workspace_source,
+            profile_root=Path(args.profile_root) if args.profile_root else None,
         )
-        mode = "goal_attachment_preflight"
-    else:
-        turn = run_native_goal_process_until_terminal(
-            config,
-            codex_bin=args.codex_bin,
-            response_timeout_sec=args.response_timeout_seconds,
-            goal_timeout_sec=args.goal_timeout_seconds,
+        if envelope.workspace_alias is None:
+            raise RuntimeError("native isolation did not create a workspace alias")
+        runtime_cwd = str(envelope.workspace_alias)
+        process_command = envelope.process_command
+        process_cwd = str(envelope.work_dir)
+
+    try:
+        if envelope is not None and envelope.workspace_alias is not None:
+            # A prior SIGKILL may have prevented the normal finally block.
+            # Recover the deterministic alias before preparing this run.
+            recovered = rebase_native_codex_loopx_workspace_state(
+                workspace_source,
+                source_root=envelope.workspace_alias,
+                target_root=workspace_source,
+            )
+            rebased = rebase_native_codex_loopx_workspace_state(
+                workspace_source,
+                source_root=workspace_source,
+                target_root=envelope.workspace_alias,
+            )
+            restore_required = True
+        config = NativeGoalConfig(
+            cwd=runtime_cwd,
+            objective=Path(args.objective_file).read_text(encoding="utf-8").strip(),
+            task_instruction=Path(args.task_file).read_text(encoding="utf-8").strip(),
+            model=args.model,
+            effort=args.effort,
+            token_budget=args.token_budget,
         )
-        mode = "goal_until_terminal"
+        if args.preflight_only:
+            turn = probe_native_goal_process(
+                config,
+                codex_bin=args.codex_bin,
+                process_command=process_command,
+                process_cwd=process_cwd,
+                response_timeout_sec=args.response_timeout_seconds,
+            )
+            mode = "goal_attachment_preflight"
+        else:
+            turn = run_native_goal_process_until_terminal(
+                config,
+                codex_bin=args.codex_bin,
+                process_command=process_command,
+                process_cwd=process_cwd,
+                response_timeout_sec=args.response_timeout_seconds,
+                goal_timeout_sec=args.goal_timeout_seconds,
+            )
+            mode = "goal_until_terminal"
+    finally:
+        if restore_required and envelope is not None:
+            assert envelope.workspace_alias is not None
+            restored = rebase_native_codex_loopx_workspace_state(
+                workspace_source,
+                source_root=envelope.workspace_alias,
+                target_root=workspace_source,
+            )
     receipt = compact_native_goal_receipt(turn)
     receipt["execution_mode"] = mode
+    receipt["native_isolation"] = {
+        "enabled": envelope is not None,
+        "workspace_alias_used": bool(envelope and envelope.workspace_alias),
+        "profile_bound": bool(envelope and envelope.profile_root),
+        "control_state_found": bool(rebased and rebased.control_state_found),
+        "recovered_replacement_count": _rebase_count(recovered),
+        "prelaunch_replacement_count": _rebase_count(rebased),
+        "restored_replacement_count": _rebase_count(restored),
+    }
     print(json.dumps(receipt, indent=2, sort_keys=True))
     return 0
 

--- a/benchmark/tests/test_native_codex_goal.py
+++ b/benchmark/tests/test_native_codex_goal.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import pytest
 
+from benchmark.deepswe import run_native_codex_goal as runnable_goal
 from benchmark.native_codex_goal import (
     NativeGoalConfig,
     NativeGoalProtocolError,
@@ -21,6 +22,9 @@ from benchmark.native_codex_goal import (
     run_native_goal_process_until_terminal,
     run_native_goal_until_terminal,
     start_native_goal_turn,
+)
+from loopx.capabilities.benchmark_toolkit.native_codex_isolation import (
+    NativeCodexIsolationEnvelope,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -555,3 +559,114 @@ def test_runnable_example_connects_to_stdio_app_server(tmp_path: Path) -> None:
     assert receipt["goal_status"] == "active"
     assert receipt["turn_id_present"] is False
     assert str(tmp_path) not in completed.stdout
+
+
+def test_runnable_example_isolation_recovers_and_restores_loopx_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    private_root = tmp_path / "controller-private"
+    workspace = private_root / "task-workspace"
+    workspace.mkdir(parents=True)
+    work_dir = tmp_path / "run-work"
+    work_dir.mkdir()
+    profile_root = tmp_path / "installed-profile"
+    profile_root.mkdir()
+    alias = work_dir / "host-visible"
+    alias.mkdir()
+    objective = tmp_path / "objective.txt"
+    task = tmp_path / "task.txt"
+    objective.write_text("Finish the task.\n", encoding="utf-8")
+    task.write_text("Implement the requested behavior.\n", encoding="utf-8")
+
+    project_registry = workspace / ".loopx/registry.json"
+    global_registry = workspace / ".loopx/runtime/registry.global.json"
+    global_registry.parent.mkdir(parents=True)
+    for registry in (project_registry, global_registry):
+        registry.write_text(
+            json.dumps({"workspace": str(alias)}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    def fake_envelope(**kwargs: Any) -> NativeCodexIsolationEnvelope:
+        assert kwargs["workspace_source"] == workspace
+        assert kwargs["private_root"] == private_root
+        assert kwargs["profile_root"] == profile_root
+        return NativeCodexIsolationEnvelope(
+            process_command=("isolated-codex", "app-server"),
+            work_dir=work_dir,
+            workspace_alias=alias,
+            profile_root=profile_root,
+        )
+
+    observed: dict[str, Any] = {}
+
+    def fake_probe(config: NativeGoalConfig, **kwargs: Any) -> object:
+        observed["config"] = config
+        observed["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(
+        runnable_goal,
+        "build_native_codex_isolation_envelope",
+        fake_envelope,
+    )
+    monkeypatch.setattr(runnable_goal, "probe_native_goal_process", fake_probe)
+    monkeypatch.setattr(
+        runnable_goal,
+        "compact_native_goal_receipt",
+        lambda _: {"goal_status": "active", "turn_id_present": False},
+    )
+
+    assert (
+        runnable_goal.main(
+            [
+                "--cwd",
+                str(workspace),
+                "--objective-file",
+                str(objective),
+                "--task-file",
+                str(task),
+                "--codex-bin",
+                "codex",
+                "--isolate",
+                "--isolation-work-dir",
+                str(work_dir),
+                "--private-root",
+                str(private_root),
+                "--profile-root",
+                str(profile_root),
+                "--preflight-only",
+            ]
+        )
+        == 0
+    )
+
+    config = observed["config"]
+    assert isinstance(config, NativeGoalConfig)
+    assert config.cwd == str(alias)
+    assert observed["kwargs"] == {
+        "codex_bin": "codex",
+        "process_command": ("isolated-codex", "app-server"),
+        "process_cwd": str(work_dir),
+        "response_timeout_sec": 30,
+    }
+    for registry in (project_registry, global_registry):
+        assert json.loads(registry.read_text(encoding="utf-8")) == {
+            "workspace": str(workspace)
+        }
+
+    output = capsys.readouterr().out
+    receipt = json.loads(output)
+    assert receipt["native_isolation"] == {
+        "control_state_found": True,
+        "enabled": True,
+        "prelaunch_replacement_count": 2,
+        "profile_bound": True,
+        "recovered_replacement_count": 2,
+        "restored_replacement_count": 2,
+        "workspace_alias_used": True,
+    }
+    assert str(workspace) not in output
+    assert str(alias) not in output

--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -60,6 +60,14 @@ It validates every candidate before writing, updates files atomically, rejects
 symlinked control-state paths, and leaves task files, model output, trajectories,
 verifier evidence, and arbitrary workspace prose untouched. This keeps formally
 installed LoopX state readable after the temporary `host-visible` alias disappears.
+The two canonical registries form one consistency boundary: both absent means no
+control state, while only one present fails closed. If an abrupt process kill skips
+the reverse rewrite, a subsequent launch using the same deterministic work
+directory first recovers stale alias references.
+
+The profile bind is writable because Codex and an installed LoopX release may need
+runtime state. It must therefore be a per-run profile or a runner-restored pinned
+snapshot, never ambient state shared across trials.
 
 This is a filesystem/process envelope, not a complete benchmark sandbox. It grants
 no model credential, task-command bridge, shell-network policy, evaluator denial,
@@ -73,7 +81,11 @@ The runnable source example is
 Its `--preflight-only` mode proves a live Codex initialize/thread/Goal attachment
 without invoking a model. Full mode starts one turn and waits for a correlated
 terminal event, then keeps draining Codex-owned continuation turns until the Goal
-leaves `active`. The same total timeout covers the full Goal lifecycle.
+leaves `active`. The same total timeout covers the full Goal lifecycle. Add
+`--isolate`, `--isolation-work-dir`, and `--private-root` to make this envelope the
+real process path; `--profile-root` adds the optional per-run formal profile. The
+launcher performs recovery, pre-launch rebase, and `finally` restoration around
+both preflight and full Goal modes.
 
 ### Formal installed profile and skill discovery
 

--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -11,9 +11,41 @@ Benchmark adapters that use the Codex app-server Goal API should import
 `loopx.capabilities.benchmark_toolkit.native_codex_goal`. The module provides the
 real stdio JSON-RPC process transport, the ordered Goal transaction, terminal event
 correlation, Goal-status polling across automatic continuation turns, and a
-public-safe receipt. A runner supplies its own isolated process command,
-environment, sandbox policy, task bridge, and timeout; it should not copy the
-Goal state machine.
+public-safe receipt. A runner supplies its environment, sandbox policy, task bridge,
+and timeout; it should not copy the Goal state machine.
+
+On Linux, a host-side runner may use `native_codex_isolation` to build the isolated
+process command. Its synthetic root contains a read-only system runtime, fresh
+`/proc`, `/run`, and `/tmp`, runner-created work children, one explicitly selected
+task workspace at the returned `host-visible` alias, and an optional formal LoopX
+profile at its verified absolute path. The surrounding host root, original task
+path, ambient host `/tmp`, nested host mounts, symlinked work children, and
+`/proc/1/root` escape path are absent. The helper requires unprivileged user, mount,
+and PID namespaces plus `pivot_root` and fails closed when its roots overlap.
+
+```python
+from loopx.capabilities.benchmark_toolkit.native_codex_isolation import (
+    build_native_codex_isolation_envelope,
+)
+
+envelope = build_native_codex_isolation_envelope(
+    executable="codex",
+    process_args=["app-server", "--listen", "stdio://", "--enable", "goals"],
+    work_dir=runner_work_dir,
+    private_root=controller_private_root,
+    workspace_source=task_workspace,
+    profile_root=profile.root,
+)
+# Pass envelope.process_command to probe_native_goal_process or
+# run_native_goal_process_until_terminal, and use envelope.workspace_alias as cwd.
+```
+
+This is a filesystem/process envelope, not a complete benchmark sandbox. It grants
+no model credential, task-command bridge, shell-network policy, evaluator denial,
+cross-trial denial, verifier ordering, upload, submission, or scoring authority.
+The runner must still attest those boundaries independently. Platforms without the
+required Linux namespace primitives must use an equivalent runner-owned isolation
+boundary instead of silently falling back to the ambient host.
 
 The runnable source example is
 [`benchmark/deepswe/run_native_codex_goal.py`](../../../benchmark/deepswe/run_native_codex_goal.py).

--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -26,6 +26,7 @@ and PID namespaces plus `pivot_root` and fails closed when its roots overlap.
 ```python
 from loopx.capabilities.benchmark_toolkit.native_codex_isolation import (
     build_native_codex_isolation_envelope,
+    rebase_native_codex_loopx_workspace_state,
 )
 
 envelope = build_native_codex_isolation_envelope(
@@ -36,9 +37,29 @@ envelope = build_native_codex_isolation_envelope(
     workspace_source=task_workspace,
     profile_root=profile.root,
 )
+# If the selected workspace already contains LoopX control state, relocate its
+# generated path references before launch and restore them after termination.
+rebase_native_codex_loopx_workspace_state(
+    task_workspace,
+    source_root=task_workspace,
+    target_root=envelope.workspace_alias,
+)
 # Pass envelope.process_command to probe_native_goal_process or
 # run_native_goal_process_until_terminal, and use envelope.workspace_alias as cwd.
+# In a finally block after the process terminates:
+rebase_native_codex_loopx_workspace_state(
+    task_workspace,
+    source_root=envelope.workspace_alias,
+    target_root=task_workspace,
+)
 ```
+
+The relocation helper is deliberately narrow: it rewrites only LoopX registries
+and generated run-history JSON, JSONL, and Markdown under the selected workspace.
+It validates every candidate before writing, updates files atomically, rejects
+symlinked control-state paths, and leaves task files, model output, trajectories,
+verifier evidence, and arbitrary workspace prose untouched. This keeps formally
+installed LoopX state readable after the temporary `host-visible` alias disappears.
 
 This is a filesystem/process envelope, not a complete benchmark sandbox. It grants
 no model credential, task-command bridge, shell-network policy, evaluator denial,

--- a/loopx/capabilities/benchmark_toolkit/__init__.py
+++ b/loopx/capabilities/benchmark_toolkit/__init__.py
@@ -38,7 +38,9 @@ from .native_codex_goal import (
 from .native_codex_isolation import (
     NativeCodexIsolationEnvelope,
     NativeCodexIsolationError,
+    NativeCodexLoopXStateRebase,
     build_native_codex_isolation_envelope,
+    rebase_native_codex_loopx_workspace_state,
 )
 from .native_codex_profile import (
     NATIVE_CODEX_GOAL_PROMPT_SCHEMA_VERSION,
@@ -83,6 +85,7 @@ __all__ = [
     "NativeCodexGoalPrompt",
     "NativeCodexIsolationEnvelope",
     "NativeCodexIsolationError",
+    "NativeCodexLoopXStateRebase",
     "NativeCodexProfile",
     "NativeCodexProfileError",
     "NativeGoalConfig",
@@ -111,6 +114,7 @@ __all__ = [
     "native_codex_profile_environment",
     "observe_native_goal_event",
     "probe_native_goal_process",
+    "rebase_native_codex_loopx_workspace_state",
     "refresh_native_goal_status",
     "render_native_codex_goal_prompt",
     "run_native_goal_process",

--- a/loopx/capabilities/benchmark_toolkit/__init__.py
+++ b/loopx/capabilities/benchmark_toolkit/__init__.py
@@ -35,6 +35,11 @@ from .native_codex_goal import (
     start_native_goal_turn,
     wait_native_goal_turn,
 )
+from .native_codex_isolation import (
+    NativeCodexIsolationEnvelope,
+    NativeCodexIsolationError,
+    build_native_codex_isolation_envelope,
+)
 from .native_codex_profile import (
     NATIVE_CODEX_GOAL_PROMPT_SCHEMA_VERSION,
     NATIVE_CODEX_PROFILE_REQUIRED_SKILL_IDS,
@@ -76,6 +81,8 @@ __all__ = [
     "RUN_PERMISSION_POLICY_SCHEMA_VERSION",
     "RUN_PERMISSION_QUOTA_PROJECTION_SCHEMA_VERSION",
     "NativeCodexGoalPrompt",
+    "NativeCodexIsolationEnvelope",
+    "NativeCodexIsolationError",
     "NativeCodexProfile",
     "NativeCodexProfileError",
     "NativeGoalConfig",
@@ -88,6 +95,7 @@ __all__ = [
     "attach_native_goal",
     "build_benchmark_candidate_source_boundary",
     "build_benchmark_integrity_qualification",
+    "build_native_codex_isolation_envelope",
     "build_run_permission_policy",
     "classify_benchmark_artifact_path",
     "classify_benchmark_candidate_source_path",

--- a/loopx/capabilities/benchmark_toolkit/native_codex_isolation.py
+++ b/loopx/capabilities/benchmark_toolkit/native_codex_isolation.py
@@ -305,17 +305,19 @@ def rebase_native_codex_loopx_workspace_state(
 
     Call once before launch from the host path to the alias, then once after
     process termination from the alias back to the host path.  All candidate
-    files are parsed before any replacement is committed.
+    files are parsed before any replacement is committed.  The source must
+    exist; the pre-launch target may be a planned alias that the envelope will
+    materialize immediately afterwards.
     """
 
     try:
         resolved_storage = storage_root.resolve(strict=True)
         resolved_source = source_root.resolve(strict=True)
-        resolved_target = target_root.resolve(strict=True)
     except OSError as exc:
         raise NativeCodexIsolationError(
             "native_codex_loopx_state_rebase_root_missing"
         ) from exc
+    resolved_target = target_root.expanduser().resolve(strict=False)
     if not resolved_storage.is_dir():
         raise NativeCodexIsolationError(
             "native_codex_loopx_state_rebase_storage_not_directory"

--- a/loopx/capabilities/benchmark_toolkit/native_codex_isolation.py
+++ b/loopx/capabilities/benchmark_toolkit/native_codex_isolation.py
@@ -9,11 +9,15 @@ installed LoopX profile.
 
 from __future__ import annotations
 
+import json
 import os
+import re
 import shutil
+import tempfile
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 
 class NativeCodexIsolationError(RuntimeError):
@@ -28,6 +32,15 @@ class NativeCodexIsolationEnvelope:
     work_dir: Path
     workspace_alias: Path | None
     profile_root: Path | None
+
+
+@dataclass(frozen=True)
+class NativeCodexLoopXStateRebase:
+    """Result of relocating LoopX-owned paths across a workspace alias."""
+
+    control_state_found: bool
+    rewritten_files: tuple[Path, ...]
+    replacement_count: int
 
 
 _ISOLATION_SCRIPT = r"""
@@ -165,6 +178,192 @@ def _paths_overlap(left: Path, right: Path) -> bool:
     return left == right or left in right.parents or right in left.parents
 
 
+def _replace_path_prefix(value: Any, source: str, target: str) -> tuple[Any, int]:
+    if isinstance(value, str):
+        if value == source:
+            return target, 1
+        prefix = f"{source}{os.sep}"
+        if value.startswith(prefix):
+            return f"{target}{value[len(source) :]}", 1
+        return value, 0
+    if isinstance(value, list):
+        replaced: list[Any] = []
+        count = 0
+        for item in value:
+            next_item, item_count = _replace_path_prefix(item, source, target)
+            replaced.append(next_item)
+            count += item_count
+        return replaced, count
+    if isinstance(value, dict):
+        replaced_dict: dict[Any, Any] = {}
+        count = 0
+        for key, item in value.items():
+            next_item, item_count = _replace_path_prefix(item, source, target)
+            replaced_dict[key] = next_item
+            count += item_count
+        return replaced_dict, count
+    return value, 0
+
+
+def _generated_runtime_files(storage_root: Path) -> tuple[Path, ...]:
+    goals_root = storage_root / ".loopx/runtime/goals"
+    if not goals_root.exists():
+        return ()
+    if goals_root.is_symlink() or not goals_root.is_dir():
+        raise NativeCodexIsolationError("native_codex_loopx_goals_root_not_directory")
+
+    files: list[Path] = []
+    for goal_dir in sorted(goals_root.iterdir()):
+        if goal_dir.is_symlink():
+            raise NativeCodexIsolationError("native_codex_loopx_goal_dir_symlinked")
+        if not goal_dir.is_dir():
+            continue
+        runs_dir = goal_dir / "runs"
+        if not runs_dir.exists():
+            continue
+        if runs_dir.is_symlink() or not runs_dir.is_dir():
+            raise NativeCodexIsolationError("native_codex_loopx_runs_dir_not_directory")
+        for path in sorted(runs_dir.iterdir()):
+            if path.is_symlink():
+                raise NativeCodexIsolationError(
+                    "native_codex_loopx_run_artifact_symlinked"
+                )
+            if path.is_file() and path.suffix in {".json", ".jsonl", ".md"}:
+                files.append(path)
+    return tuple(files)
+
+
+def _rewrite_json_text(text: str, source: str, target: str) -> tuple[str, int]:
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise NativeCodexIsolationError(
+            "native_codex_loopx_state_invalid_json"
+        ) from exc
+    rewritten, count = _replace_path_prefix(payload, source, target)
+    return json.dumps(rewritten, ensure_ascii=False, indent=2) + "\n", count
+
+
+def _rewrite_jsonl_text(text: str, source: str, target: str) -> tuple[str, int]:
+    rewritten_lines: list[str] = []
+    count = 0
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise NativeCodexIsolationError(
+                "native_codex_loopx_state_invalid_jsonl"
+            ) from exc
+        rewritten, line_count = _replace_path_prefix(payload, source, target)
+        rewritten_lines.append(json.dumps(rewritten, ensure_ascii=False))
+        count += line_count
+    suffix = "\n" if rewritten_lines else ""
+    return "\n".join(rewritten_lines) + suffix, count
+
+
+def _rewrite_markdown_text(text: str, source: str, target: str) -> tuple[str, int]:
+    # Generated Markdown embeds paths inside backticks or after punctuation.
+    # Refuse identifier-adjacent matches so prose such as ``prefix-/path`` is
+    # not silently rewritten.
+    pattern = re.compile(
+        rf"(?<![0-9A-Za-z_.-]){re.escape(source)}(?=$|[/\s`'\"\[\](){{}}:,])"
+    )
+    return pattern.subn(lambda _: target, text)
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary_path = Path(temporary)
+    try:
+        os.fchmod(descriptor, path.stat().st_mode & 0o777)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        temporary_path.replace(path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def rebase_native_codex_loopx_workspace_state(
+    storage_root: Path,
+    *,
+    source_root: Path,
+    target_root: Path,
+) -> NativeCodexLoopXStateRebase:
+    """Relocate LoopX-owned state across an isolated workspace alias.
+
+    Native Codex sees ``workspace_source`` through a temporary path.  LoopX
+    registries and generated run-history artifacts may persist that path while
+    the process is alive.  This bounded rewrite keeps those artifacts readable
+    after the alias disappears without touching task files, model output, raw
+    trajectories, verifier evidence, or arbitrary workspace prose.
+
+    Call once before launch from the host path to the alias, then once after
+    process termination from the alias back to the host path.  All candidate
+    files are parsed before any replacement is committed.
+    """
+
+    try:
+        resolved_storage = storage_root.resolve(strict=True)
+        resolved_source = source_root.resolve(strict=True)
+        resolved_target = target_root.resolve(strict=True)
+    except OSError as exc:
+        raise NativeCodexIsolationError(
+            "native_codex_loopx_state_rebase_root_missing"
+        ) from exc
+    if not resolved_storage.is_dir():
+        raise NativeCodexIsolationError(
+            "native_codex_loopx_state_rebase_storage_not_directory"
+        )
+    if resolved_source == resolved_target:
+        raise NativeCodexIsolationError(
+            "native_codex_loopx_state_rebase_roots_identical"
+        )
+
+    registry_paths = (
+        resolved_storage / ".loopx/registry.json",
+        resolved_storage / ".loopx/runtime/registry.global.json",
+    )
+    existing_registries = tuple(path for path in registry_paths if path.is_file())
+    if not existing_registries:
+        return NativeCodexLoopXStateRebase(False, (), 0)
+    if len(existing_registries) != len(registry_paths):
+        raise NativeCodexIsolationError("native_codex_loopx_registry_incomplete")
+    if any(path.is_symlink() for path in registry_paths):
+        raise NativeCodexIsolationError("native_codex_loopx_registry_symlinked")
+
+    source = str(resolved_source)
+    target = str(resolved_target)
+    candidates = (*registry_paths, *_generated_runtime_files(resolved_storage))
+    pending: list[tuple[Path, str, int]] = []
+    replacement_count = 0
+    for path in candidates:
+        text = path.read_text(encoding="utf-8")
+        if path.suffix == ".json":
+            rewritten, count = _rewrite_json_text(text, source, target)
+        elif path.suffix == ".jsonl":
+            rewritten, count = _rewrite_jsonl_text(text, source, target)
+        else:
+            rewritten, count = _rewrite_markdown_text(text, source, target)
+        if count:
+            pending.append((path, rewritten, count))
+            replacement_count += count
+
+    for path, rewritten, _ in pending:
+        _atomic_write_text(path, rewritten)
+
+    return NativeCodexLoopXStateRebase(
+        control_state_found=True,
+        rewritten_files=tuple(path for path, _, _ in pending),
+        replacement_count=replacement_count,
+    )
+
+
 def build_native_codex_isolation_envelope(
     *,
     executable: str,
@@ -295,5 +494,7 @@ def build_native_codex_isolation_envelope(
 __all__ = [
     "NativeCodexIsolationEnvelope",
     "NativeCodexIsolationError",
+    "NativeCodexLoopXStateRebase",
     "build_native_codex_isolation_envelope",
+    "rebase_native_codex_loopx_workspace_state",
 ]

--- a/loopx/capabilities/benchmark_toolkit/native_codex_isolation.py
+++ b/loopx/capabilities/benchmark_toolkit/native_codex_isolation.py
@@ -1,0 +1,299 @@
+"""Linux allowlist envelope for host-side native Codex benchmark workers.
+
+The benchmark runner still owns task provisioning, command bridging, network
+policy, evaluator ordering, and scoring.  This module only builds the process
+boundary that keeps a host-side ``codex app-server`` away from the ambient host
+filesystem while re-exposing one task workspace and, optionally, one formally
+installed LoopX profile.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class NativeCodexIsolationError(RuntimeError):
+    """The requested native Codex process boundary is not safe to build."""
+
+
+@dataclass(frozen=True)
+class NativeCodexIsolationEnvelope:
+    """Resolved process command and task-visible paths for one isolated run."""
+
+    process_command: tuple[str, ...]
+    work_dir: Path
+    workspace_alias: Path | None
+    profile_root: Path | None
+
+
+_ISOLATION_SCRIPT = r"""
+private_root=$1
+workspace_source=$2
+work_dir=$3
+profile_root=$4
+executable=$5
+setpriv_bin=$6
+shift 6
+
+mount --make-rprivate /
+sandbox_root="$work_dir/.sandbox-root"
+mkdir -p "$sandbox_root"
+mount -t tmpfs -o mode=0755,nodev,nosuid tmpfs "$sandbox_root"
+
+# Keep only the host system runtime required to execute Codex.  Plain bind
+# mounts intentionally omit any nested host mounts, and every system directory
+# is remounted read-only inside this mount namespace.
+for system_dir in usr bin sbin lib lib64; do
+    if [ -d "/$system_dir" ]; then
+        mkdir -p "$sandbox_root/$system_dir"
+        mount --bind "/$system_dir" "$sandbox_root/$system_dir"
+        mount -o remount,bind,ro "$sandbox_root/$system_dir"
+    fi
+done
+
+mkdir -p "$sandbox_root/etc" "$sandbox_root/etc/ssl" "$sandbox_root/dev"
+mkdir -p "$sandbox_root/proc" "$sandbox_root/run" "$sandbox_root/tmp"
+chmod 1777 "$sandbox_root/tmp"
+for etc_file in hosts nsswitch.conf passwd group resolv.conf localtime; do
+    if [ -e "/etc/$etc_file" ]; then
+        touch "$sandbox_root/etc/$etc_file"
+        mount --bind "/etc/$etc_file" "$sandbox_root/etc/$etc_file"
+        mount -o remount,bind,ro "$sandbox_root/etc/$etc_file"
+    fi
+done
+if [ -d /etc/ssl ]; then
+    mount --bind /etc/ssl "$sandbox_root/etc/ssl"
+    mount -o remount,bind,ro "$sandbox_root/etc/ssl"
+fi
+ln -s /proc/mounts "$sandbox_root/etc/mtab"
+for device in null zero full random urandom tty; do
+    if [ -e "/dev/$device" ]; then
+        touch "$sandbox_root/dev/$device"
+        mount --bind "/dev/$device" "$sandbox_root/dev/$device"
+    fi
+done
+ln -s /proc/self/fd "$sandbox_root/dev/fd"
+ln -s /proc/self/fd/0 "$sandbox_root/dev/stdin"
+ln -s /proc/self/fd/1 "$sandbox_root/dev/stdout"
+ln -s /proc/self/fd/2 "$sandbox_root/dev/stderr"
+mount -t proc -o nosuid,nodev,noexec proc "$sandbox_root/proc"
+
+# Share only runner-created children of the per-run work directory.  Refuse
+# symlinks and special files so a prepared work directory cannot widen the
+# allowlist before pivot_root.
+mkdir -p "$sandbox_root$work_dir"
+for shared_path in "$work_dir"/* "$work_dir"/.[!.]* "$work_dir"/..?*; do
+    [ -e "$shared_path" ] || continue
+    [ "$shared_path" = "$sandbox_root" ] && continue
+    [ ! -L "$shared_path" ] || exit 64
+    target="$sandbox_root$shared_path"
+    if [ -d "$shared_path" ]; then
+        mkdir -p "$target"
+    elif [ -f "$shared_path" ]; then
+        mkdir -p "$(dirname "$target")"
+        touch "$target"
+    else
+        exit 64
+    fi
+    mount --bind "$shared_path" "$target"
+done
+
+if [ -n "$workspace_source" ]; then
+    workspace_alias="$sandbox_root$work_dir/host-visible"
+    mkdir -p "$workspace_alias"
+    mount --bind "$workspace_source" "$workspace_alias"
+fi
+if [ -n "$profile_root" ]; then
+    mkdir -p "$sandbox_root$profile_root"
+    mount --bind "$profile_root" "$sandbox_root$profile_root"
+fi
+
+# A test launcher or alternate Codex binary may live outside the shared system
+# runtime, work directory, or formal profile.  Re-expose only the resolved file.
+bind_executable=1
+case "$executable" in
+    /usr/*|/bin/*|/sbin/*|/lib/*|/lib64/*|"$work_dir"/*) bind_executable=0 ;;
+esac
+if [ -n "$profile_root" ]; then
+    case "$executable" in
+        "$profile_root"/*) bind_executable=0 ;;
+    esac
+fi
+if [ "$bind_executable" = 1 ]; then
+    mkdir -p "$sandbox_root$(dirname "$executable")"
+    touch "$sandbox_root$executable"
+    mount --bind "$executable" "$sandbox_root$executable"
+    mount -o remount,bind,ro "$sandbox_root$executable"
+fi
+
+mkdir -p "$sandbox_root/.old-root"
+cd "$sandbox_root"
+pivot_root . .old-root
+umount -l /.old-root
+rmdir /.old-root
+cd "$work_dir"
+
+# The denied root and source spelling stay absent.  The caller uses only the
+# case-local alias returned by NativeCodexIsolationEnvelope.
+[ ! -e "$private_root" ]
+[ -z "$workspace_source" ] || [ ! -e "$workspace_source" ]
+
+# Capabilities exist only inside the fresh user namespace so Codex can install
+# its nested workspace/network sandbox.  They cannot reach the host namespace.
+exec "$setpriv_bin" --no-new-privs "$executable" "$@"
+"""
+
+
+def _resolve_executable(value: str, *, error: str) -> Path:
+    resolved = shutil.which(value) if not os.path.isabs(value) else value
+    if not resolved:
+        raise NativeCodexIsolationError(error)
+    try:
+        path = Path(resolved).resolve(strict=True)
+    except OSError as exc:
+        raise NativeCodexIsolationError(error) from exc
+    if not path.is_file() or not os.access(path, os.X_OK):
+        raise NativeCodexIsolationError(error)
+    return path
+
+
+def _paths_overlap(left: Path, right: Path) -> bool:
+    return left == right or left in right.parents or right in left.parents
+
+
+def build_native_codex_isolation_envelope(
+    *,
+    executable: str,
+    process_args: Sequence[str],
+    work_dir: Path,
+    private_root: Path,
+    workspace_source: Path | None = None,
+    profile_root: Path | None = None,
+) -> NativeCodexIsolationEnvelope:
+    """Build a fail-closed Linux namespace command for native Codex.
+
+    ``private_root`` is absent after ``pivot_root``.  ``workspace_source`` is
+    available only as ``work_dir / "host-visible"``.  ``profile_root`` retains
+    its absolute spelling so a formally installed CLI, Codex home, and skill
+    tree can use their verified paths without exposing the surrounding host.
+    """
+
+    unshare = _resolve_executable("unshare", error="native_codex_unshare_missing")
+    setpriv = _resolve_executable("setpriv", error="native_codex_setpriv_missing")
+    shell = _resolve_executable("sh", error="native_codex_shell_missing")
+    resolved_executable = _resolve_executable(
+        executable, error="native_codex_executable_missing"
+    )
+    if isinstance(process_args, (str, bytes)):
+        raise TypeError("process_args must be a sequence of arguments")
+    try:
+        resolved_work_dir = work_dir.resolve(strict=True)
+        resolved_private_root = private_root.resolve(strict=True)
+    except OSError as exc:
+        raise NativeCodexIsolationError("native_codex_isolation_root_missing") from exc
+    if not resolved_work_dir.is_dir() or not resolved_private_root.is_dir():
+        raise NativeCodexIsolationError("native_codex_isolation_root_not_directory")
+    if _paths_overlap(resolved_work_dir, resolved_private_root):
+        raise NativeCodexIsolationError("native_codex_work_dir_overlaps_private_root")
+    if resolved_executable == resolved_private_root or (
+        resolved_private_root in resolved_executable.parents
+    ):
+        raise NativeCodexIsolationError("native_codex_executable_inside_private_root")
+
+    workspace_alias: Path | None = None
+    workspace_raw = ""
+    if workspace_source is not None:
+        try:
+            resolved_workspace = workspace_source.resolve(strict=True)
+        except OSError as exc:
+            raise NativeCodexIsolationError(
+                "native_codex_workspace_source_missing"
+            ) from exc
+        if not resolved_workspace.is_dir():
+            raise NativeCodexIsolationError(
+                "native_codex_workspace_source_not_directory"
+            )
+        if _paths_overlap(resolved_workspace, resolved_work_dir):
+            raise NativeCodexIsolationError(
+                "native_codex_workspace_source_overlaps_work_dir"
+            )
+        if resolved_workspace == resolved_private_root or (
+            resolved_workspace in resolved_private_root.parents
+        ):
+            raise NativeCodexIsolationError(
+                "native_codex_workspace_source_exposes_private_root"
+            )
+        if resolved_executable == resolved_workspace or (
+            resolved_workspace in resolved_executable.parents
+        ):
+            raise NativeCodexIsolationError(
+                "native_codex_executable_inside_workspace_source"
+            )
+        workspace_raw = str(resolved_workspace)
+        workspace_alias = resolved_work_dir / "host-visible"
+        workspace_alias.mkdir(parents=True, exist_ok=True)
+
+    resolved_profile: Path | None = None
+    profile_raw = ""
+    if profile_root is not None:
+        try:
+            resolved_profile = profile_root.resolve(strict=True)
+        except OSError as exc:
+            raise NativeCodexIsolationError(
+                "native_codex_profile_root_missing"
+            ) from exc
+        if not resolved_profile.is_dir():
+            raise NativeCodexIsolationError("native_codex_profile_root_not_directory")
+        if _paths_overlap(resolved_profile, resolved_private_root):
+            raise NativeCodexIsolationError(
+                "native_codex_profile_root_overlaps_private_root"
+            )
+        if _paths_overlap(resolved_profile, resolved_work_dir):
+            raise NativeCodexIsolationError(
+                "native_codex_profile_root_overlaps_work_dir"
+            )
+        if workspace_source is not None and _paths_overlap(
+            resolved_profile, Path(workspace_raw)
+        ):
+            raise NativeCodexIsolationError(
+                "native_codex_profile_root_overlaps_workspace_source"
+            )
+        profile_raw = str(resolved_profile)
+
+    command = (
+        str(unshare),
+        "--user",
+        "--map-root-user",
+        "--mount",
+        "--pid",
+        "--fork",
+        "--mount-proc",
+        str(shell),
+        "-ceu",
+        _ISOLATION_SCRIPT,
+        "sh",
+        str(resolved_private_root),
+        workspace_raw,
+        str(resolved_work_dir),
+        profile_raw,
+        str(resolved_executable),
+        str(setpriv),
+        *(str(value) for value in process_args),
+    )
+    return NativeCodexIsolationEnvelope(
+        process_command=command,
+        work_dir=resolved_work_dir,
+        workspace_alias=workspace_alias,
+        profile_root=resolved_profile,
+    )
+
+
+__all__ = [
+    "NativeCodexIsolationEnvelope",
+    "NativeCodexIsolationError",
+    "build_native_codex_isolation_envelope",
+]

--- a/loopx/capabilities/benchmark_toolkit/native_codex_isolation.py
+++ b/loopx/capabilities/benchmark_toolkit/native_codex_isolation.py
@@ -383,12 +383,6 @@ def build_native_codex_isolation_envelope(
     tree can use their verified paths without exposing the surrounding host.
     """
 
-    unshare = _resolve_executable("unshare", error="native_codex_unshare_missing")
-    setpriv = _resolve_executable("setpriv", error="native_codex_setpriv_missing")
-    shell = _resolve_executable("sh", error="native_codex_shell_missing")
-    resolved_executable = _resolve_executable(
-        executable, error="native_codex_executable_missing"
-    )
     if isinstance(process_args, (str, bytes)):
         raise TypeError("process_args must be a sequence of arguments")
     try:
@@ -400,13 +394,9 @@ def build_native_codex_isolation_envelope(
         raise NativeCodexIsolationError("native_codex_isolation_root_not_directory")
     if _paths_overlap(resolved_work_dir, resolved_private_root):
         raise NativeCodexIsolationError("native_codex_work_dir_overlaps_private_root")
-    if resolved_executable == resolved_private_root or (
-        resolved_private_root in resolved_executable.parents
-    ):
-        raise NativeCodexIsolationError("native_codex_executable_inside_private_root")
-
     workspace_alias: Path | None = None
     workspace_raw = ""
+    resolved_workspace: Path | None = None
     if workspace_source is not None:
         try:
             resolved_workspace = workspace_source.resolve(strict=True)
@@ -425,18 +415,14 @@ def build_native_codex_isolation_envelope(
         if resolved_workspace == resolved_private_root or (
             resolved_workspace in resolved_private_root.parents
         ):
+            # A selected workspace may intentionally be a narrow child of the
+            # denied private root.  The reverse direction is unsafe because it
+            # would re-expose the private root through an ancestor bind.
             raise NativeCodexIsolationError(
                 "native_codex_workspace_source_exposes_private_root"
             )
-        if resolved_executable == resolved_workspace or (
-            resolved_workspace in resolved_executable.parents
-        ):
-            raise NativeCodexIsolationError(
-                "native_codex_executable_inside_workspace_source"
-            )
         workspace_raw = str(resolved_workspace)
         workspace_alias = resolved_work_dir / "host-visible"
-        workspace_alias.mkdir(parents=True, exist_ok=True)
 
     resolved_profile: Path | None = None
     profile_raw = ""
@@ -464,6 +450,28 @@ def build_native_codex_isolation_envelope(
                 "native_codex_profile_root_overlaps_workspace_source"
             )
         profile_raw = str(resolved_profile)
+
+    # Root policy is pure input validation and must fail deterministically even
+    # on hosts that do not provide the Linux namespace tools used at launch.
+    unshare = _resolve_executable("unshare", error="native_codex_unshare_missing")
+    setpriv = _resolve_executable("setpriv", error="native_codex_setpriv_missing")
+    shell = _resolve_executable("sh", error="native_codex_shell_missing")
+    resolved_executable = _resolve_executable(
+        executable, error="native_codex_executable_missing"
+    )
+    if resolved_executable == resolved_private_root or (
+        resolved_private_root in resolved_executable.parents
+    ):
+        raise NativeCodexIsolationError("native_codex_executable_inside_private_root")
+    if resolved_workspace is not None and (
+        resolved_executable == resolved_workspace
+        or resolved_workspace in resolved_executable.parents
+    ):
+        raise NativeCodexIsolationError(
+            "native_codex_executable_inside_workspace_source"
+        )
+    if workspace_alias is not None:
+        workspace_alias.mkdir(parents=True, exist_ok=True)
 
     command = (
         str(unshare),

--- a/tests/capabilities/test_native_codex_isolation.py
+++ b/tests/capabilities/test_native_codex_isolation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import shutil
 import subprocess
 import textwrap
@@ -11,6 +12,7 @@ import pytest
 from loopx.capabilities.benchmark_toolkit.native_codex_isolation import (
     NativeCodexIsolationError,
     build_native_codex_isolation_envelope,
+    rebase_native_codex_loopx_workspace_state,
 )
 
 
@@ -71,6 +73,154 @@ def test_native_codex_isolation_rejects_overlapping_authority_roots(
             work_dir=work_dir,
             private_root=private_root,
             workspace_source=controller_root,
+        )
+
+
+def test_native_codex_loopx_state_rebase_round_trips_generated_control_state(
+    tmp_path: Path,
+) -> None:
+    visible = tmp_path / "visible"
+    alias = tmp_path / "run-work" / "host-visible"
+    alias.mkdir(parents=True)
+    project_registry = visible / ".loopx/registry.json"
+    global_registry = visible / ".loopx/runtime/registry.global.json"
+    global_registry.parent.mkdir(parents=True)
+    registry_payload = {
+        "common_runtime_root": str(visible / ".loopx/runtime"),
+        "unrelated": f"prefix-{visible}-must-not-change",
+        "goals": [{"id": "goal-1", "repo": str(visible)}],
+    }
+    for path in (project_registry, global_registry):
+        path.write_text(
+            json.dumps(registry_payload, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    runs_dir = visible / ".loopx/runtime/goals/goal-1/runs"
+    runs_dir.mkdir(parents=True)
+    run_json = runs_dir / "run.json"
+    run_markdown = runs_dir / "run.md"
+    index_path = runs_dir / "index.jsonl"
+    run_json.write_text(
+        json.dumps(
+            {
+                "state": {"path": str(visible / ".codex/goals/goal-1/state.md")},
+                "unrelated": f"prefix-{visible}-must-not-change",
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    run_markdown.write_text(
+        f"- state_file: `{visible}/.codex/goals/goal-1/state.md`\n"
+        f"- unrelated: `prefix-{visible}-must-not-change`\n",
+        encoding="utf-8",
+    )
+    index_path.write_text(
+        json.dumps(
+            {
+                "json_path": str(run_json),
+                "markdown_path": str(run_markdown),
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    originals = {
+        path: path.read_text(encoding="utf-8")
+        for path in (
+            project_registry,
+            global_registry,
+            run_json,
+            run_markdown,
+            index_path,
+        )
+    }
+
+    rebased = rebase_native_codex_loopx_workspace_state(
+        visible,
+        source_root=visible,
+        target_root=alias,
+    )
+
+    assert rebased.control_state_found is True
+    assert rebased.replacement_count == 8
+    assert set(rebased.rewritten_files) == set(originals)
+    for path in originals:
+        text = path.read_text(encoding="utf-8")
+        assert str(alias) in text
+    for path in (project_registry, global_registry, run_json, run_markdown):
+        assert f"prefix-{visible}-must-not-change" in path.read_text(encoding="utf-8")
+
+    restored = rebase_native_codex_loopx_workspace_state(
+        visible,
+        source_root=alias,
+        target_root=visible,
+    )
+
+    assert restored.control_state_found is True
+    assert restored.replacement_count == rebased.replacement_count
+    for path, original in originals.items():
+        assert path.read_text(encoding="utf-8") == original
+
+
+def test_native_codex_loopx_state_rebase_validates_all_files_before_writing(
+    tmp_path: Path,
+) -> None:
+    visible = tmp_path / "visible"
+    alias = tmp_path / "alias"
+    alias.mkdir()
+    project_registry = visible / ".loopx/registry.json"
+    global_registry = visible / ".loopx/runtime/registry.global.json"
+    global_registry.parent.mkdir(parents=True)
+    registry_text = (
+        json.dumps(
+            {"common_runtime_root": str(visible / ".loopx/runtime")},
+            indent=2,
+        )
+        + "\n"
+    )
+    project_registry.write_text(registry_text, encoding="utf-8")
+    global_registry.write_text(registry_text, encoding="utf-8")
+    runs_dir = visible / ".loopx/runtime/goals/goal-1/runs"
+    runs_dir.mkdir(parents=True)
+    (runs_dir / "index.jsonl").write_text("not-json\n", encoding="utf-8")
+
+    with pytest.raises(
+        NativeCodexIsolationError,
+        match="native_codex_loopx_state_invalid_jsonl",
+    ):
+        rebase_native_codex_loopx_workspace_state(
+            visible,
+            source_root=visible,
+            target_root=alias,
+        )
+
+    assert project_registry.read_text(encoding="utf-8") == registry_text
+    assert global_registry.read_text(encoding="utf-8") == registry_text
+
+
+def test_native_codex_loopx_state_rebase_requires_complete_registry_pair(
+    tmp_path: Path,
+) -> None:
+    visible = tmp_path / "visible"
+    alias = tmp_path / "alias"
+    alias.mkdir()
+    project_registry = visible / ".loopx/registry.json"
+    project_registry.parent.mkdir(parents=True)
+    project_registry.write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(
+        NativeCodexIsolationError,
+        match="native_codex_loopx_registry_incomplete",
+    ):
+        rebase_native_codex_loopx_workspace_state(
+            visible,
+            source_root=visible,
+            target_root=alias,
         )
 
 

--- a/tests/capabilities/test_native_codex_isolation.py
+++ b/tests/capabilities/test_native_codex_isolation.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import textwrap
+from functools import cache
+from pathlib import Path
+
+import pytest
+
+from loopx.capabilities.benchmark_toolkit.native_codex_isolation import (
+    NativeCodexIsolationError,
+    build_native_codex_isolation_envelope,
+)
+
+
+@cache
+def _namespace_mounts_supported() -> bool:
+    unshare = shutil.which("unshare")
+    if not unshare:
+        return False
+    probe = subprocess.run(
+        [
+            unshare,
+            "--user",
+            "--map-root-user",
+            "--mount",
+            "--pid",
+            "--fork",
+            "sh",
+            "-c",
+            "mount --make-rprivate / && mount -t tmpfs tmpfs /tmp && umount /tmp",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return probe.returncode == 0
+
+
+def test_native_codex_isolation_rejects_overlapping_authority_roots(
+    tmp_path: Path,
+) -> None:
+    controller_root = tmp_path / "controller"
+    private_root = controller_root / "private"
+    private_root.mkdir(parents=True)
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    profile_root = private_root / "profile"
+    profile_root.mkdir()
+
+    with pytest.raises(
+        NativeCodexIsolationError,
+        match="native_codex_profile_root_overlaps_private_root",
+    ):
+        build_native_codex_isolation_envelope(
+            executable="sh",
+            process_args=["-c", "true"],
+            work_dir=work_dir,
+            private_root=private_root,
+            profile_root=profile_root,
+        )
+
+    with pytest.raises(
+        NativeCodexIsolationError,
+        match="native_codex_workspace_source_exposes_private_root",
+    ):
+        build_native_codex_isolation_envelope(
+            executable="sh",
+            process_args=["-c", "true"],
+            work_dir=work_dir,
+            private_root=private_root,
+            workspace_source=controller_root,
+        )
+
+
+@pytest.mark.skipif(
+    not _namespace_mounts_supported(),
+    reason="unprivileged user/mount namespaces are unavailable",
+)
+def test_native_codex_isolation_exposes_only_workspace_profile_and_work_children(
+    tmp_path: Path,
+) -> None:
+    private_root = tmp_path / "controller-private"
+    workspace = private_root / "task-workspace"
+    workspace.mkdir(parents=True)
+    (private_root / "hidden-answer.txt").write_text("denied", encoding="utf-8")
+    (workspace / "task-marker.txt").write_text("visible", encoding="utf-8")
+    profile_root = tmp_path / "installed-profile"
+    profile_root.mkdir()
+    (profile_root / "profile-marker.txt").write_text("installed", encoding="utf-8")
+    work_dir = tmp_path / "run-work"
+    work_dir.mkdir()
+    (work_dir / "runner-marker.txt").write_text("runner", encoding="utf-8")
+    host_sentinel = tmp_path / "host-only-sentinel.txt"
+    host_sentinel.write_text("host", encoding="utf-8")
+
+    probe = textwrap.dedent(
+        """
+        set -eu
+        private_root=$1
+        workspace_source=$2
+        workspace_alias=$3
+        profile_root=$4
+        work_dir=$5
+        host_sentinel=$6
+        test ! -e "$private_root"
+        test ! -e "$workspace_source"
+        test -f "$workspace_alias/task-marker.txt"
+        test -f "$profile_root/profile-marker.txt"
+        test -f "$work_dir/runner-marker.txt"
+        test ! -e "$host_sentinel"
+        test ! -e "/proc/1/root$host_sentinel"
+        touch "$workspace_alias/workspace-write"
+        touch "$profile_root/profile-write"
+        ! touch /usr/native-codex-isolation-must-be-read-only 2>/dev/null
+        printf 'isolated\n'
+        """
+    )
+    envelope = build_native_codex_isolation_envelope(
+        executable="sh",
+        process_args=[
+            "-ceu",
+            probe,
+            "sh",
+            str(private_root),
+            str(workspace),
+            str(work_dir / "host-visible"),
+            str(profile_root),
+            str(work_dir),
+            str(host_sentinel),
+        ],
+        work_dir=work_dir,
+        private_root=private_root,
+        workspace_source=workspace,
+        profile_root=profile_root,
+    )
+
+    completed = subprocess.run(
+        envelope.process_command,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout == "isolated\n"
+    assert envelope.workspace_alias == work_dir / "host-visible"
+    assert (workspace / "workspace-write").is_file()
+    assert (profile_root / "profile-write").is_file()
+    assert not Path("/usr/native-codex-isolation-must-be-read-only").exists()
+
+
+@pytest.mark.skipif(
+    not _namespace_mounts_supported(),
+    reason="unprivileged user/mount namespaces are unavailable",
+)
+def test_native_codex_isolation_rejects_symlinked_work_children(
+    tmp_path: Path,
+) -> None:
+    private_root = tmp_path / "controller-private"
+    private_root.mkdir()
+    work_dir = tmp_path / "run-work"
+    work_dir.mkdir()
+    (work_dir / "escape-link").symlink_to(private_root, target_is_directory=True)
+    envelope = build_native_codex_isolation_envelope(
+        executable="sh",
+        process_args=["-c", "exit 99"],
+        work_dir=work_dir,
+        private_root=private_root,
+    )
+
+    completed = subprocess.run(
+        envelope.process_command,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 64

--- a/tests/capabilities/test_native_codex_isolation.py
+++ b/tests/capabilities/test_native_codex_isolation.py
@@ -81,7 +81,7 @@ def test_native_codex_loopx_state_rebase_round_trips_generated_control_state(
 ) -> None:
     visible = tmp_path / "visible"
     alias = tmp_path / "run-work" / "host-visible"
-    alias.mkdir(parents=True)
+    alias.parent.mkdir(parents=True)
     project_registry = visible / ".loopx/registry.json"
     global_registry = visible / ".loopx/runtime/registry.global.json"
     global_registry.parent.mkdir(parents=True)
@@ -149,12 +149,16 @@ def test_native_codex_loopx_state_rebase_round_trips_generated_control_state(
     assert rebased.control_state_found is True
     assert rebased.replacement_count == 8
     assert set(rebased.rewritten_files) == set(originals)
+    assert not alias.exists()
     for path in originals:
         text = path.read_text(encoding="utf-8")
         assert str(alias) in text
     for path in (project_registry, global_registry, run_json, run_markdown):
         assert f"prefix-{visible}-must-not-change" in path.read_text(encoding="utf-8")
 
+    # The isolation envelope materializes the planned alias between the two
+    # calls; the pre-launch relocation must not require it prematurely.
+    alias.mkdir()
     restored = rebase_native_codex_loopx_workspace_state(
         visible,
         source_root=alias,


### PR DESCRIPTION
## What changed

- add a built-in Linux namespace envelope for host-side native Codex benchmark workers;
- expose only a read-only system runtime, fresh process/runtime/temp filesystems, runner-created work children, one selected task workspace, and one optional formal LoopX profile;
- reject overlapping authority roots, symlinked work children, missing namespace tools, and unsafe executable placement without ambient-host fallback;
- add a bounded path-relocation helper for LoopX registries and generated run history when the selected workspace is mounted through a temporary alias;
- wire the envelope into `benchmark/deepswe/run_native_codex_goal.py --isolate` as an opt-in real process path;
- recover stale alias references on the next deterministic run, restore host paths in `finally`, and emit only compact path-free lifecycle counts;
- document the registry-pair invariant and require per-run or snapshot-restored writable profiles.

## Why

The native Goal runtime and formal installed profile prove the app-server transaction, CLI, and skills, but they do not by themselves prevent a host-side worker from inheriting the ambient host filesystem. Benchmark adapters otherwise need to duplicate a delicate `pivot_root` command or risk producing a treatment that is not permission-comparable with its baseline.

A second lifecycle issue appears when that workspace is deliberately exposed at a temporary alias: LoopX can persist absolute registry or run-history references while the process is alive, and those references become unreadable after the alias disappears. The helper now owns both the normal round trip and next-run recovery after an abrupt worker exit.

This change gives adapters provider-neutral process-boundary and LoopX-state-relocation contracts while leaving task bridges, model credentials, shell-network policy, evaluator denial, verifier ordering, uploads, submissions, and scoring with the runner. Isolation remains opt-in; existing invocations do not change behavior.

## Validation

- focused native Goal and isolation suite — 23 passed;
- Ruff check and format, Python compilation, diff hygiene, and mypy 1.19.1 — passed;
- `loopx canary premerge --from-git-diff` — all 18 selected checks passed and the seven-file public/private boundary scan was clean;
- active-callsite regression proves isolated process command/cwd propagation, prior-crash recovery, prelaunch aliasing, final host-path restoration, and path-free receipts;
- existing real Linux namespace tests retain workspace/profile allowlisting, host and `/proc/1/root` denial, read-only system paths, and symlink fail-closed coverage.

## Review findings addressed

- production callsite: implemented through the runnable Goal adapter's explicit `--isolate` path;
- platform portability: root-policy validation now precedes namespace-tool resolution;
- abrupt termination: the next launch using the same deterministic work directory repairs stale aliases;
- registry/profile semantics: the paired-registry invariant and per-run writable-profile responsibility are explicit;
- intentional workspace nesting: documented in code while unsafe ancestor exposure remains rejected.

## Holds and merge decision

The risk gate reports the expected `benchmark_sensitive` manual-review hold. This is an opt-in benchmark helper/runtime change: it does not launch jobs or change scoring, task semantics, verifier behavior, permission policy, uploads, or submissions. Maintainer authorization is recorded for self-review and admin-bypass merge after the refreshed required checks pass.
