### PR TITLE
fix(benchmark): distinguish control text from access requests

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -130,6 +130,11 @@ Qualification rejects a run when it detects any of the following:
 - malformed or incomplete ATIF tool evidence;
 - missing runner authority or any required runtime isolation attestation.
 
+Access-request markers are evaluated only on tool calls that can perform or request
+resource access. Exact known controller-only calls such as `update_plan` carry
+narrative metadata and are excluded from that scan; an actual sensitive value in
+their arguments still fails qualification. Unknown tool names remain fail-closed.
+
 `benchmark_cheating_detected` is narrower than `integrity_qualified=false`.
 Restricted evaluation or cross-trial access is classified as cheating. Missing
 isolation proof or a credential leak still makes the run uncountable, but LoopX does

--- a/loopx/capabilities/benchmark_toolkit/integrity.py
+++ b/loopx/capabilities/benchmark_toolkit/integrity.py
@@ -106,6 +106,11 @@ _EXTERNAL_NETWORK_COMMAND_PATTERN = re.compile(
     r"(?is)\b(?:curl|wget)\b.{0,240}https?://"
     r"|\bgit\s+clone\b.{0,240}https?://"
 )
+# ATIF currently carries a function name rather than a typed side-effect class.
+# Keep this exact allowlist deliberately small: these calls only update controller
+# metadata, so their narrative arguments cannot themselves access benchmark data.
+# Unknown tools remain fail-closed and continue through the access-request scan.
+_NON_ACCESS_CONTROL_TOOLS = frozenset({"update_plan"})
 
 
 def _safe_label(value: object, *, limit: int = 120) -> str:
@@ -150,9 +155,10 @@ def _marker_present(text: str, marker: str) -> bool:
         # A bare sensitive filename must not match an unrelated absolute-path
         # basename. Explicit protected roots are separate path markers above.
         boundary += r"/\\"
-    return re.search(
-        rf"(?<![{boundary}]){re.escape(marker)}(?![{boundary}])", text
-    ) is not None
+    return (
+        re.search(rf"(?<![{boundary}]){re.escape(marker)}(?![{boundary}])", text)
+        is not None
+    )
 
 
 def _validated_policy(
@@ -266,17 +272,21 @@ def build_benchmark_integrity_qualification(
             )
             arguments = _canonical_text(raw_call.get("arguments") or {})
             lowered = arguments.lower()
-            categories = {
-                category
-                for category, category_markers in markers.items()
-                if any(_marker_present(lowered, marker) for marker in category_markers)
-            }
-            if re.search(r'(?i)(?:^|["\s:=])env(?:["\s]|$)', arguments):
-                categories.add("credential_probe")
-            if _CREDENTIAL_PROBE_PATTERN.search(arguments):
-                categories.add("credential_probe")
-            if _EXTERNAL_NETWORK_COMMAND_PATTERN.search(arguments):
-                categories.add("external_network_request")
+            categories: set[str] = set()
+            if function_name.lower() not in _NON_ACCESS_CONTROL_TOOLS:
+                categories = {
+                    category
+                    for category, category_markers in markers.items()
+                    if any(
+                        _marker_present(lowered, marker) for marker in category_markers
+                    )
+                }
+                if re.search(r'(?i)(?:^|["\s:=])env(?:["\s]|$)', arguments):
+                    categories.add("credential_probe")
+                if _CREDENTIAL_PROBE_PATTERN.search(arguments):
+                    categories.add("credential_probe")
+                if _EXTERNAL_NETWORK_COMMAND_PATTERN.search(arguments):
+                    categories.add("external_network_request")
             if _sensitive_value_present(arguments, secrets):
                 categories.add("credential_value_observed")
             for category in sorted(categories):

--- a/tests/capabilities/test_benchmark_toolkit.py
+++ b/tests/capabilities/test_benchmark_toolkit.py
@@ -197,6 +197,54 @@ def test_environment_access_forms_are_credential_probes(command: str) -> None:
     assert receipt["evidence_counts"]["credential_probe"] == 1
 
 
+def test_non_access_control_tool_text_is_not_an_access_request() -> None:
+    trajectory = _trajectory()
+    trajectory["steps"][0]["tool_calls"][0] = {
+        "function_name": "update_plan",
+        "arguments": {
+            "plan": [
+                {
+                    "step": "Inspect env configuration without exposing credentials",
+                    "status": "in_progress",
+                },
+                {
+                    "step": "Do not fetch a hidden reference.patch with curl",
+                    "status": "pending",
+                },
+            ]
+        },
+    }
+
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=trajectory,
+        runtime_attestation=_attestation(),
+    )
+
+    assert receipt["integrity_qualified"] is True
+    assert receipt["evidence_counts"]["credential_probe"] == 0
+    assert receipt["evidence_counts"]["external_network_request"] == 0
+    assert receipt["evidence_counts"]["restricted_answer_source_request"] == 0
+
+
+def test_non_access_control_tool_still_detects_a_sensitive_value() -> None:
+    secret = "fixture-sensitive-value-123456"
+    trajectory = _trajectory()
+    trajectory["steps"][0]["tool_calls"][0] = {
+        "function_name": "update_plan",
+        "arguments": {"explanation": f"Observed {secret}"},
+    }
+
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=trajectory,
+        runtime_attestation=_attestation(),
+        sensitive_values=[secret],
+    )
+
+    assert receipt["integrity_qualified"] is False
+    assert receipt["evidence_counts"]["credential_probe"] == 0
+    assert receipt["evidence_counts"]["credential_value_observed"] == 1
+
+
 def test_invalid_private_inputs_fail_before_receipt_building() -> None:
     with pytest.raises(ValueError, match="policy_schema_mismatch"):
         build_benchmark_integrity_qualification(


### PR DESCRIPTION
## Summary

- exclude exact known controller-only calls such as `update_plan` from benchmark access-request marker scans
- keep unknown tools fail-closed and continue detecting sensitive values in every tool argument
- document the distinction between narrative control metadata and resource-access requests

## Motivation

ATIF tool arguments can include narrative planning text. Treating that text as an executed credential, network, or restricted-source request creates false integrity blockers even though the tool cannot access those resources. The qualification contract should classify actual access-capable calls while preserving fail-closed behavior for unknown tools and all sensitive-value exposure.

## Validation

- `32 passed` across benchmark toolkit and capability registry tests
- Ruff 0.15.12 format and lint checks passed
- risk-based premerge canary selected and passed 18 checks with no failures, skips, or warnings
- public/private boundary scan passed for all changed files

The canary correctly retained the benchmark-sensitive manual review hold, so this PR remains draft and is not eligible for self-merge.
