### PR TITLE
feat(reward-memory): attribute post-outcome utility

### DIFF
--- a/docs/architecture/rfcs/post-outcome-memory-utility-attribution-v0.md
+++ b/docs/architecture/rfcs/post-outcome-memory-utility-attribution-v0.md
@@ -113,13 +113,13 @@ fields needed for replay and audit:
 
 ```json
 {
-  "schema": "memory_utility_observation_v0",
+  "schema_version": "memory_utility_observation_v0",
   "observation_id": "muo_<stable_digest>",
   "scope": {
     "agent_id": "agent_opaque",
     "project_id": "project_opaque",
     "corpus_id": "corpus_opaque",
-    "surface": "reward_memory"
+    "surface_id": "reward_memory"
   },
   "application_receipt_id": "rma_<opaque>",
   "memory_ref_digests": ["sha256:<digest>"],
@@ -132,7 +132,13 @@ fields needed for replay and audit:
   "confidence": 0.42,
   "reason_codes": ["multiple_memories_not_disambiguated"],
   "evidence_refs": ["evidence_opaque"],
-  "created_at": "2026-08-15T00:00:00Z"
+  "evaluator_ref": "evaluator_opaque",
+  "evaluation_version": "evaluation_v0",
+  "created_at": "2026-08-15T00:00:00Z",
+  "grants_new_action_authority": false,
+  "provider_write_performed": false,
+  "external_writes_performed": false,
+  "raw_content_captured": false
 }
 ```
 
@@ -170,6 +176,10 @@ Evidence strength is typed rather than inferred from prose:
 4. `evaluator_inference`: a model judgment over public-safe receipts and
    outcomes;
 5. `insufficient`: lineage exists but attribution does not.
+
+The three stronger bases require at least one opaque `evidence_ref` in the
+proposal; `insufficient` may have no evidence reference. An unknown label does
+not waive this provenance requirement.
 
 Model inference alone is weak evidence. It may be retained for calibration and
 review, but profiles MUST be able to prevent it from moving a strong rank

--- a/docs/architecture/rfcs/post-outcome-memory-utility-attribution-v0.zh-CN.md
+++ b/docs/architecture/rfcs/post-outcome-memory-utility-attribution-v0.zh-CN.md
@@ -82,13 +82,13 @@ LoopX 应在现有 `reward_memory` 能力中增加 provider-neutral 的结果后
 
 ```json
 {
-  "schema": "memory_utility_observation_v0",
+  "schema_version": "memory_utility_observation_v0",
   "observation_id": "muo_<stable_digest>",
   "scope": {
     "agent_id": "agent_opaque",
     "project_id": "project_opaque",
     "corpus_id": "corpus_opaque",
-    "surface": "reward_memory"
+    "surface_id": "reward_memory"
   },
   "application_receipt_id": "rma_<opaque>",
   "memory_ref_digests": ["sha256:<digest>"],
@@ -101,7 +101,13 @@ LoopX 应在现有 `reward_memory` 能力中增加 provider-neutral 的结果后
   "confidence": 0.42,
   "reason_codes": ["multiple_memories_not_disambiguated"],
   "evidence_refs": ["evidence_opaque"],
-  "created_at": "2026-08-15T00:00:00Z"
+  "evaluator_ref": "evaluator_opaque",
+  "evaluation_version": "evaluation_v0",
+  "created_at": "2026-08-15T00:00:00Z",
+  "grants_new_action_authority": false,
+  "provider_write_performed": false,
+  "external_writes_performed": false,
+  "raw_content_captured": false
 }
 ```
 
@@ -128,6 +134,9 @@ LoopX 应在现有 `reward_memory` 能力中增加 provider-neutral 的结果后
 3. `deterministic_effect`：能区分记忆贡献的 artifact、test 或 effect 证据；
 4. `evaluator_inference`：模型基于 public-safe receipt 与 outcome 作出的判断；
 5. `insufficient`：lineage 存在，但无法归因。
+
+前三类较强证据必须在 proposal 中至少带一个 opaque `evidence_ref`；
+`insufficient` 可以不带 evidence reference。即使 label 是 `unknown`，也不能绕过这条 provenance 要求。
 
 仅有模型推断属于弱证据。它可以留下来做校准与 review，但 profile 必须能禁止它移动一个已经由强证据建立的 rank prior。
 

--- a/examples/reward-memory-dogfood-smoke.py
+++ b/examples/reward-memory-dogfood-smoke.py
@@ -5,6 +5,7 @@ import sys
 import json
 import subprocess
 import tempfile
+from copy import deepcopy
 from pathlib import Path
 
 
@@ -22,6 +23,10 @@ from loopx.capabilities.reward_memory import (  # noqa: E402
     build_reward_memory_operator_control,
     review_reward_memory_candidate,
     run_reward_memory_evaluation,
+)
+from loopx.capabilities.reward_memory.dogfood import (  # noqa: E402
+    REWARD_MEMORY_DOGFOOD_BATCH_SCHEMA_VERSION,
+    REWARD_MEMORY_DOGFOOD_RECEIPT_SCHEMA_VERSION,
 )
 
 
@@ -97,22 +102,37 @@ def active_review() -> dict[str, object]:
     )
 
 
-def session(*, surface_id: str, status: str) -> RewardMemoryRecallSession:
+def session(
+    *,
+    surface_id: str,
+    status: str,
+    memory_refs: tuple[str, ...] = (),
+) -> RewardMemoryRecallSession:
     items: tuple[RewardMemoryRecallItem, ...] = ()
     if status == "completed":
-        items = (
+        selected_refs = memory_refs or (f"memory:{surface_id}",)
+        items = tuple(
             RewardMemoryRecallItem(
-                memory_ref=f"memory:{surface_id}",
-                candidate_ref=f"candidate:{surface_id}",
+                memory_ref=memory_ref,
+                candidate_ref=f"candidate:{surface_id}:{index}",
                 target_class="soft_preference",
                 content_summary="Transient fixture summary.",
-            ),
+            )
+            for index, memory_ref in enumerate(selected_refs)
         )
     return RewardMemoryRecallSession(
         public_packet={
             "corpus_id": "dogfood_preferences",
             "surface_id": surface_id,
             "mode": "function_boundary",
+            "query_kind": "business_recall",
+            "query_evidence": [
+                {
+                    "query_digest": "0123456789abcdef",
+                    "query_summary": "Scoped dogfood recall fixture.",
+                    "exact_query_exposed": False,
+                }
+            ],
             "status": status,
             "result_readback_verified": status == "completed",
         },
@@ -178,6 +198,8 @@ def observation(
         "module_outcome": {
             "artifact_ref": receipt["artifact_ref"],
             "outcome_verified": True,
+            "outcome_ref": f"outcome:{domain_id}",
+            "outcome_status": "completed",
             "summary": f"Verified bounded outcome for {domain_id}.",
         },
         "cost": {
@@ -199,6 +221,54 @@ def observation(
                 else None
             ),
         },
+    }
+
+
+def utility_attribution(
+    receipt: dict[str, object],
+    *,
+    outcome_ref: str,
+    memory_ref_digests: list[str] | None = None,
+    utility_label: str = "unknown",
+    attribution_level: str = "none",
+    evidence_basis: str = "insufficient",
+    evidence_refs: list[str] | None = None,
+) -> dict[str, object]:
+    scope = {
+        "agent_id": "agent:dogfood",
+        "project_id": "project:dogfood",
+        "corpus_id": receipt["corpus_id"],
+        "surface_id": receipt["surface_id"],
+    }
+    return {
+        "context": {
+            "scope": scope,
+            "retrieval_snapshot_ref": "snapshot:dogfood:stage3",
+            "policy_snapshot_ref": "policy:dogfood:v0",
+        },
+        "proposal": {
+            "scope": scope,
+            "application_id": receipt["application_id"],
+            "artifact_ref": receipt["artifact_ref"],
+            "outcome_ref": outcome_ref,
+            "outcome_status": "completed",
+            "retrieval_snapshot_ref": "snapshot:dogfood:stage3",
+            "policy_snapshot_ref": "policy:dogfood:v0",
+            "memory_ref_digests": memory_ref_digests or receipt["memory_ref_digests"],
+            "utility_label": utility_label,
+            "attribution_level": attribution_level,
+            "evidence_basis": evidence_basis,
+            "confidence": 0.95 if evidence_refs else 0.0,
+            "reason_codes": [
+                "attribution_evidence_missing"
+                if not evidence_refs
+                else "bounded_fixture_evidence"
+            ],
+            "evidence_refs": evidence_refs or [],
+            "evaluator_ref": "evaluator:dogfood:fixture",
+            "evaluation_version": "evaluation:dogfood:v0",
+        },
+        "created_at": "2026-08-16T00:00:00Z",
     }
 
 
@@ -227,7 +297,170 @@ def main() -> None:
             interventions=1,
         ),
     ]
+    observations[0]["utility_attribution"] = utility_attribution(
+        receipts[0],
+        outcome_ref=observations[0]["module_outcome"]["outcome_ref"],
+    )
+
+    malformed_baseline = build_reward_memory_dogfood_receipt(observations[1])
+    malformed_observation = deepcopy(observations[1])
+    malformed_observation["utility_attribution"] = utility_attribution(
+        receipts[1],
+        outcome_ref=observations[1]["module_outcome"]["outcome_ref"],
+    )
+    malformed_observation["utility_attribution"]["proposal"] = {
+        "utility_label": "helpful"
+    }
+    observations[1] = malformed_observation
     dogfood = [build_reward_memory_dogfood_receipt(item) for item in observations]
+    assert dogfood[0]["schema_version"] == REWARD_MEMORY_DOGFOOD_RECEIPT_SCHEMA_VERSION
+    assert dogfood[0]["application_outcome"] == "applied", dogfood[0]
+    assert dogfood[0]["application_disposition"] == "applied", dogfood[0]
+    assert dogfood[0]["utility_evaluation"] == {"status": "accepted"}, dogfood[0]
+    assert dogfood[0]["utility_observation"]["utility_label"] == "unknown", dogfood[0]
+    assert dogfood[0]["utility_observation"]["evidence_basis"] == "insufficient"
+
+    assert dogfood[1]["utility_evaluation"] == {
+        "status": "rejected",
+        "reason_code": "utility_attribution_rejected",
+    }, dogfood[1]
+    assert dogfood[1]["utility_observation"] is None, dogfood[1]
+    for key in (
+        "application_id",
+        "artifact_ref",
+        "corpus_id",
+        "surface_id",
+        "application_outcome",
+        "application_disposition",
+        "module_outcome",
+        "memory_ref_digests",
+        "verification",
+    ):
+        assert dogfood[1][key] == malformed_baseline[key], key
+    assert dogfood[1]["receipt_id"] == malformed_baseline["receipt_id"], dogfood[1]
+    assert "helpful" not in json.dumps(dogfood[1]), dogfood[1]
+    assert dogfood[2]["utility_evaluation"]["status"] == "not_requested"
+
+    for nested_key in (
+        "verification",
+        "module_outcome",
+        "utility_evaluation",
+        "utility_observation",
+        "cost",
+        "intervention",
+        "bot_feedback",
+    ):
+        tampered = deepcopy(dogfood[0])
+        tampered[nested_key]["raw_log"] = "private fixture output"
+        try:
+            build_reward_memory_dogfood_batch(
+                [tampered],
+                [],
+                evaluation=run_reward_memory_evaluation(),
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"unknown nested field was accepted: {nested_key}")
+
+    multi_memory_result = apply_reward_memory_recall(
+        {"candidate": "multi_memory"},
+        session(
+            surface_id="issue_fix.multi_memory",
+            status="completed",
+            memory_refs=("memory:multi-a", "memory:multi-b"),
+        ),
+        application_id="application:multi-memory",
+        artifact_ref="artifact:multi-memory",
+        apply_memory=lambda base, items: {
+            "outcome": "applied",
+            "output": {"candidate": "multi_memory"},
+            "memory_refs": [item.memory_ref for item in items],
+            "reasoning_summary": "The result uses both recalled memories; evidence isolates one contribution.",
+            "current_artifact_verified": True,
+        },
+    )["receipt"]
+    multi_observation = observation(
+        multi_memory_result,
+        family="issue_fix",
+        domain_id="issue_fix.multi_memory",
+        latency_ms=3,
+        interventions=0,
+    )
+    multi_observation["utility_attribution"] = utility_attribution(
+        multi_memory_result,
+        outcome_ref=multi_observation["module_outcome"]["outcome_ref"],
+        memory_ref_digests=[multi_memory_result["memory_ref_digests"][0]],
+        utility_label="helpful",
+        attribution_level="item",
+        evidence_basis="deterministic_effect",
+        evidence_refs=["test-result:multi-memory"],
+    )
+    multi_dogfood = build_reward_memory_dogfood_receipt(multi_observation)
+    assert multi_dogfood["utility_evaluation"] == {"status": "accepted"}, multi_dogfood
+    assert multi_dogfood["utility_observation"]["attribution_level"] == "item", (
+        multi_dogfood
+    )
+    assert build_reward_memory_dogfood_batch(
+        [multi_dogfood],
+        [],
+        evaluation=run_reward_memory_evaluation(),
+    )["receipts"][0]["utility"]["evaluation"] == {"status": "accepted"}
+
+    revised_utility_input = deepcopy(observations[0])
+    revised_utility_input["utility_attribution"]["proposal"]["evaluation_version"] = (
+        "evaluation:dogfood:v1"
+    )
+    revised_utility = build_reward_memory_dogfood_receipt(revised_utility_input)
+    assert revised_utility["receipt_id"] == dogfood[0]["receipt_id"]
+    assert (
+        revised_utility["utility_observation"]["observation_id"]
+        != dogfood[0]["utility_observation"]["observation_id"]
+    )
+    try:
+        build_reward_memory_dogfood_batch(
+            [dogfood[0], revised_utility],
+            [],
+            evaluation=run_reward_memory_evaluation(),
+        )
+    except ValueError as exc:
+        assert "double-count a receipt" in str(exc), exc
+    else:
+        raise AssertionError("one settlement was counted twice")
+
+    relabeled_settlement_input = deepcopy(observations[0])
+    relabeled_settlement_input["domain_family"] = "loopx"
+    relabeled_settlement_input["domain_id"] = "loopx.relabelled_settlement"
+    relabeled_settlement = build_reward_memory_dogfood_receipt(
+        relabeled_settlement_input
+    )
+    assert relabeled_settlement["receipt_id"] == dogfood[0]["receipt_id"]
+    try:
+        build_reward_memory_dogfood_batch(
+            [dogfood[0], relabeled_settlement],
+            [],
+            evaluation=run_reward_memory_evaluation(),
+        )
+    except ValueError as exc:
+        assert "double-count a receipt" in str(exc), exc
+    else:
+        raise AssertionError("domain relabeling double-counted one settlement")
+
+    revised_outcome_input = deepcopy(observations[0])
+    revised_outcome_input["module_outcome"]["outcome_status"] = "reconciled"
+    del revised_outcome_input["utility_attribution"]
+    revised_outcome = build_reward_memory_dogfood_receipt(revised_outcome_input)
+    assert revised_outcome["receipt_id"] != dogfood[0]["receipt_id"]
+    try:
+        build_reward_memory_dogfood_batch(
+            [dogfood[0], revised_outcome],
+            [],
+            evaluation=run_reward_memory_evaluation(),
+        )
+    except ValueError as exc:
+        assert "double-count an application settlement" in str(exc), exc
+    else:
+        raise AssertionError("one application settlement was counted twice")
 
     reviewed = active_review()
     edited = build_reward_memory_operator_control(
@@ -293,12 +526,20 @@ def main() -> None:
         [edited["receipt"], retired["receipt"]],
         evaluation=run_reward_memory_evaluation(),
     )
+    assert packet["schema_version"] == REWARD_MEMORY_DOGFOOD_BATCH_SCHEMA_VERSION
     assert packet["status"] == "ready_for_bounded_issue_fix_pilot", packet
-    assert packet["metrics"]["hit_count"] == 1, packet
-    assert packet["metrics"]["miss_count"] == 1, packet
-    assert packet["metrics"]["refute_count"] == 1, packet
+    assert packet["metrics"]["applied_count"] == 1, packet
+    assert packet["metrics"]["not_applied_count"] == 1, packet
+    assert packet["metrics"]["refuted_count"] == 1, packet
+    assert packet["metrics"]["utility_observation_count"] == 1, packet
+    assert packet["metrics"]["utility_unknown_count"] == 1, packet
+    assert packet["metrics"]["utility_rejected_count"] == 1, packet
+    assert packet["metrics"]["utility_not_requested_count"] == 1, packet
     assert packet["metrics"]["loopx_domain_count"] == 2, packet
     assert packet["metrics"]["intervention_count"] == 1, packet
+    assert packet["receipts"][0]["application"]["disposition"] == "applied"
+    assert packet["receipts"][0]["module_outcome"]["outcome_status"] == "completed"
+    assert packet["receipts"][0]["utility"]["observation"]["utility_label"] == "unknown"
     assert packet["boundaries"]["production_rollout_allowed"] is False, packet
     assert packet["boundaries"]["operator_write_performed"] is False, packet
 
@@ -309,6 +550,8 @@ def main() -> None:
     )
     assert held["status"] == "hold", held
     assert "two_loopx_domains_required" in held["reason_codes"], held
+    assert "application_disposition_missing:not_applied" in held["reason_codes"], held
+    assert "application_disposition_missing:refuted" in held["reason_codes"], held
     assert "operator_control_missing:retire" in held["reason_codes"], held
 
     with tempfile.TemporaryDirectory() as directory:
@@ -342,6 +585,10 @@ def main() -> None:
         )
         cli_packet = json.loads(completed.stdout)
         assert cli_packet["status"] == "ready_for_bounded_issue_fix_pilot"
+        assert (
+            cli_packet["schema_version"] == REWARD_MEMORY_DOGFOOD_BATCH_SCHEMA_VERSION
+        )
+        assert cli_packet["metrics"]["utility_unknown_count"] == 1
 
         control_input = Path(directory) / "control.json"
         control_input.write_text(

--- a/loopx/capabilities/reward_memory/README.md
+++ b/loopx/capabilities/reward_memory/README.md
@@ -451,7 +451,8 @@ loopx reward-memory route-check --case pr-3237 --format json
   write and exactly read back compact events inside a standing-policy boundary;
   it does not choose the event, corpus, or consumer module.
 - Stage 4: evaluation harness and release gate.
-- Stage 5: bounded cross-module dogfood and operator edit/retire controls.
+- Stage 5: bounded cross-module dogfood, optional post-outcome utility
+  attribution, and operator edit/retire controls.
 
 Later stages must extend this contract rather than collapsing these classes,
 duplicating existing context/provider capabilities, or turning provider
@@ -525,11 +526,11 @@ core contract invariants only, does not claim semantic uplift, and does not
 authorize production rollout. Stage 5 must use a corpus-owner-approved record,
 exact provider readback, and real module outcomes before making an uplift claim.
 
-## Stage 5 dogfood receipts and operator controls
+## Stage 5 dogfood receipts, utility attribution, and operator controls
 
 Stage 5 adds one thin evidence layer over the Stage 3 application receipt. It
 does not add a store, scheduler, semantic router, automatic recall path, or
-another evaluator. A caller supplies a compact real-module observation whose
+ranking behavior. A caller supplies a compact real-module observation whose
 artifact reference matches the application receipt:
 
 ```bash
@@ -537,21 +538,69 @@ loopx reward-memory dogfood-evaluate \
   --input compact-observations.json --format json
 ```
 
-`reward_memory_dogfood_receipt_v0` derives `hit`, `miss`, or `refute` from the
-existing application outcome instead of trusting a caller-provided label. A
-hit or refute is invalid unless the selected provider result was read back
-exactly and the current artifact was verified. The receipt retains only opaque
-or hashed memory references, a compact verified outcome summary, latency,
+`reward_memory_dogfood_receipt_v1` records `application_disposition` as
+`applied`, `not_applied`, or `refuted`. This is application coverage, not a
+causal utility judgment. An applied or refuted disposition is invalid unless
+the selected provider result was read back exactly and the current artifact
+was verified. The receipt retains the opaque digest `application_receipt_id`
+for the exact Stage 3 application receipt, plus only opaque or hashed memory
+references, a compact verified outcome reference and summary, latency,
 model-token and provider-call counts, intervention count, and optional compact
-bot feedback. It retains no raw provider content and grants no new action
-authority.
+bot feedback.
+It retains no raw provider content and grants no new action authority.
 
-`reward_memory_dogfood_batch_v0` becomes
+The former `reward_memory_dogfood_receipt_v0` used `hit`, `miss`, and `refute`
+for this same application-coverage distinction. In particular, its `hit`
+never established that a memory was `helpful`. The v1 receipt supersedes that
+ambiguous naming instead of silently changing the v0 contract.
+
+Post-outcome utility is a separate `memory_utility_observation_v0` with one of
+`helpful`, `harmful`, `neutral`, or `unknown`. The optional evaluator is
+default-off and proposal-only. LoopX validates its proposal against separately
+trusted agent, project, corpus, and surface scope; the verified outcome ref;
+and the retrieval and policy snapshot refs supplied by the execution boundary.
+Snapshot freshness is owned by the execution or provider adapter that supplies
+the trusted attribution context. When a compatible application receipt also
+carries snapshot refs, the validator cross-checks them exactly. A stale or
+mismatched evaluator echo is rejected. `applied` plus a successful outcome
+remains `unknown` without independent attribution evidence. When several
+memories are involved, attribution defaults to `set`; set-level credit is never
+copied to individual items.
+
+Evidence basis is typed rather than inferred from prose. `owner_correction`,
+`controlled_replay`, and `deterministic_effect` are stronger bases and require
+at least one opaque `evidence_ref` in the evaluator proposal, even when the
+label remains `unknown`. `evaluator_inference` is weaker and `insufficient` is
+lineage-only. Stage 1 preserves that typed distinction; the Stage 2 reducer
+owns precedence between weak and strong observations.
+
+The public observation contains only opaque references, canonical memory
+digests, typed reason codes, evaluator/version identity, and compact public-safe
+evidence. URLs, local paths, raw-content fields, and any proposal to grant
+action authority or perform a write are rejected. Provider adapters must digest
+exact private provider references before constructing this public contract. An
+absent, timed-out, or malformed evaluator fails open: the main result,
+application settlement, and dogfood readiness remain unchanged. The attribution
+subject, evidence, evaluator identity, and evaluation version produce a stable
+observation id for replay identity. A different judgment under the same key is
+a conflicting delivery, not additional support; a correction must cite new
+evidence or advance the evaluation version. Utility-attribution Stage 1 does not
+persist or reduce observations and therefore does not yet claim
+duplicate-delivery no-op behavior. The Stage 5 batch rejects duplicate
+`application_receipt_id` values and counts each application settlement once.
+The settlement `receipt_id` deliberately excludes evaluator status and
+`observation_id`; utility retries and new evidence use the observation identity
+instead. A new utility observation for the same settlement belongs in the later
+append-only utility ledger and must not duplicate disposition or cost metrics.
+
+`reward_memory_dogfood_batch_v1` becomes
 `ready_for_bounded_issue_fix_pilot` only when the Stage 4 gate still passes and
 the bounded batch contains at least one Issue Fix result, two distinct LoopX
-domain results, all three hit/miss/refute classes, and both operator controls.
-This is a trial-readiness statement. Semantic-uplift and production-rollout
-claims remain false.
+domain results, all three `applied`/`not_applied`/`refuted` application
+dispositions, and both operator controls. Utility observations do not affect
+this readiness decision. This is a trial-readiness statement; semantic uplift
+and production rollout remain false. The Stage 2 reducer and projection,
+ranking influence, and OpenViking writeback are outside this implementation.
 
 The edit/retire control is similarly narrow:
 

--- a/loopx/capabilities/reward_memory/README.zh-CN.md
+++ b/loopx/capabilities/reward_memory/README.zh-CN.md
@@ -380,7 +380,8 @@ loopx reward-memory route-check --case pr-3237 --format json
   application receipt。最简 ingest seam 复用 Stage 2/3 与声明 provider，把 standing-policy
   范围内的紧凑事件原子写入并精确读回；不自动选择事件、corpus 或模块。
 - Stage 4：evaluation harness 与 release gate。
-- Stage 5：受限的 cross-module dogfood，以及 operator edit/retire control。
+- Stage 5：受限的 cross-module dogfood、可选 post-outcome utility attribution，
+  以及 operator edit/retire control。
 
 后续阶段必须在这份合同上扩展，不能合并五类记忆、重复建设 context/provider 能力，也
 不能把 provider availability 变成 user gate。Stage 1 继续保持 stateless read model，
@@ -443,10 +444,10 @@ interruption 和 user gate 计数均为零，release gate 才能通过。
 contract invariant，不声明 semantic uplift，也不授权 production rollout。Stage 5 必须
 使用经 corpus owner 批准的 record、精确 provider readback 和真实模块结果，才能讨论收益。
 
-## Stage 5 dogfood receipt 与 operator control
+## Stage 5 dogfood receipt、utility attribution 与 operator control
 
 Stage 5 只在 Stage 3 application receipt 上增加一层薄的证据合同，不新增 store、scheduler、
-语义路由器、automatic recall 或第二套 evaluator。调用方传入紧凑的真实模块 observation，
+语义路由器、automatic recall 或 ranking behavior。调用方传入紧凑的真实模块 observation，
 其中 artifact reference 必须与 application receipt 一致：
 
 ```bash
@@ -454,16 +455,55 @@ loopx reward-memory dogfood-evaluate \
   --input compact-observations.json --format json
 ```
 
-`reward_memory_dogfood_receipt_v0` 根据已有 application outcome 推导 `hit`、`miss` 或
-`refute`，不接受调用方自行声明结果类型。`hit` 或 `refute` 必须同时满足精确 provider
-result readback 与 current-artifact verification。Receipt 只保留 opaque/hashed memory ref、
-紧凑的已验证结果摘要、latency、model token、provider call、intervention count，以及可选的
-紧凑 bot feedback；不保留 raw provider content，也不授予新的 action authority。
+`reward_memory_dogfood_receipt_v1` 用 `application_disposition` 记录 `applied`、
+`not_applied` 或 `refuted`。它表示 application coverage，不是因果 utility 判断。
+`applied` 或 `refuted` 必须同时满足精确 provider result readback 与 current-artifact
+verification。Receipt 保留精确 Stage 3 application receipt 的 opaque digest
+`application_receipt_id`，以及 opaque/hashed memory ref、紧凑的已验证 outcome ref 与摘要、
+latency、model token、provider call、intervention count，以及可选的紧凑 bot feedback；
+不保留 raw provider content，也不授予新的 action authority。
+
+旧的 `reward_memory_dogfood_receipt_v0` 曾用 `hit`、`miss`、`refute` 表示同一组
+application coverage；其中 `hit` 从未证明 memory 是 `helpful`。v1 通过替代这组有歧义的
+命名来修复合同，而不是悄悄改变 v0 语义。
+
+Post-outcome utility 使用独立的 `memory_utility_observation_v0`，标签只能是
+`helpful`、`harmful`、`neutral` 或 `unknown`。可选 evaluator 默认关闭，只能提出
+proposal。LoopX 会用独立可信的 agent、project、corpus、surface scope，已验证 outcome
+ref，以及执行边界提供的 retrieval/policy snapshot ref 校验 proposal。Snapshot freshness
+由提供可信 attribution context 的执行边界或 provider adapter 负责；如果兼容的 application
+receipt 也携带 snapshot ref，validator 会做精确交叉检查。过期或不匹配的 evaluator echo
+会被拒绝。没有独立 attribution evidence 时，即使 `applied` 且 outcome 成功也必须保持
+`unknown`。涉及多条 memory 时，attribution 默认是 `set`，不能把 set-level credit
+复制给单个 item。
+
+Evidence basis 必须类型化，不能从自然语言推断。`owner_correction`、
+`controlled_replay` 与 `deterministic_effect` 属于较强证据，evaluator proposal
+至少要带一个 opaque `evidence_ref`，即使 label 仍是 `unknown` 也不能省略。
+`evaluator_inference` 较弱，`insufficient` 只表示存在 lineage。Stage 1 保留这组类型差异；
+弱证据与强证据之间的 precedence 由 Stage 2 reducer 负责。
+
+公共 observation 只包含 opaque ref、canonical memory digest、类型化 reason code、
+evaluator/version identity 和紧凑的 public-safe evidence；URL、本地路径、raw-content
+字段，以及任何授予 action authority 或执行 write 的 proposal 都会被拒绝。Provider
+adapter 必须先把精确私有 provider ref 转成 digest，再构造这份公共合同。
+Evaluator 缺失、超时或输出畸形时 fail open：main result、application settlement 与
+dogfood readiness 都不改变。归因对象、证据、evaluator identity 与 evaluation version
+共同生成稳定 observation id，供 replay 对齐；同一键下出现不同判断属于冲突 delivery，
+不能算作额外 support，修正判断必须提供新 evidence 或提升 evaluation version。
+Utility-attribution Stage 1 不持久化也不归约 observation，因此尚不声明 duplicate
+delivery 是 no-op。Stage 5 batch 会拒绝重复的 `application_receipt_id`，每条 application
+settlement 只计数一次。Settlement `receipt_id` 会刻意排除 evaluator status 与
+`observation_id`，utility retry 和新 evidence 改用 observation identity 区分。同一
+settlement 的新 utility observation 应进入后续 append-only utility ledger，不能重复累计
+disposition 或 cost metric。
 
 只有 Stage 4 gate 仍然通过，并且受限 batch 同时包含至少一个 Issue Fix 结果、两个不同的
-LoopX domain 结果、hit/miss/refute 三类结果，以及 edit/retire 两类 operator control，
-`reward_memory_dogfood_batch_v0` 才会进入 `ready_for_bounded_issue_fix_pilot`。这只是
-试用就绪声明，semantic uplift 与 production rollout 仍然为 false。
+LoopX domain 结果、`applied`/`not_applied`/`refuted` 三类 application disposition，以及
+edit/retire 两类 operator control，`reward_memory_dogfood_batch_v1` 才会进入
+`ready_for_bounded_issue_fix_pilot`。Utility observation 不参与 readiness 判断。这只是
+试用就绪声明，semantic uplift 与 production rollout 仍然为 false；Stage 2 reducer 与
+projection、ranking influence，以及 OpenViking writeback 都不属于本次实现。
 
 Edit/retire control 同样保持克制：
 

--- a/loopx/capabilities/reward_memory/__init__.py
+++ b/loopx/capabilities/reward_memory/__init__.py
@@ -34,6 +34,12 @@ from .dogfood import (
     build_reward_memory_dogfood_receipt,
     build_reward_memory_operator_control,
 )
+from .memory_utility import (
+    MEMORY_UTILITY_OBSERVATION_SCHEMA_VERSION,
+    build_reward_memory_utility_observation,
+    reward_memory_application_receipt_id,
+    validate_reward_memory_utility_observation,
+)
 from .registry import (
     build_reward_memory_corpus_registry_packet,
     normalize_reward_memory_corpus,
@@ -57,6 +63,8 @@ __all__ = [
     "build_reward_memory_dogfood_batch",
     "build_reward_memory_dogfood_receipt",
     "build_reward_memory_operator_control",
+    "build_reward_memory_utility_observation",
+    "reward_memory_application_receipt_id",
     "build_reward_memory_route_packet",
     "build_reward_memory_recall_request",
     "execute_reward_memory_recall",
@@ -64,6 +72,7 @@ __all__ = [
     "normalize_reward_memory_provider_binding",
     "normalize_reward_memory_standing_policy",
     "normalize_reward_memory_corpus",
+    "MEMORY_UTILITY_OBSERVATION_SCHEMA_VERSION",
     "issue_fix_verified_contributor_candidate_fixture",
     "pr_3237_regression_observation",
     "reward_memory_health_case",
@@ -72,4 +81,5 @@ __all__ = [
     "run_reward_memory_automatic_ingest_hook",
     "run_reward_memory_automatic_recall_hook",
     "semantic_preference_inventory_to_reward_corpora",
+    "validate_reward_memory_utility_observation",
 ]

--- a/loopx/capabilities/reward_memory/catalog_entry.py
+++ b/loopx/capabilities/reward_memory/catalog_entry.py
@@ -23,7 +23,7 @@ REWARD_MEMORY_CATALOG_ENTRY: dict[str, Any] = {
             },
         ],
     },
-    "title": "Reward-memory candidate, recall, and application foundation",
+    "title": "Reward-memory candidate, recall, application, and utility-attribution foundation",
     "status": "active-preview",
     "real_world_anchor": (
         "typed feedback memory, provider-owned corpus health, and pilot/meta delegation"
@@ -67,8 +67,8 @@ REWARD_MEMORY_CATALOG_ENTRY: dict[str, Any] = {
         },
         {
             "command": "loopx reward-memory dogfood-evaluate --input <compact-observations.json> --format json",
-            "purpose": "Bind verified Issue Fix and LoopX module outcomes to compact hit, miss, refute, cost, intervention, and bot-feedback receipts after the Stage-4 gate.",
-            "write_boundary": "reads compact receipts only; no raw provider content, memory write, operator write, automatic recall, or external write",
+            "purpose": "Bind verified Issue Fix and LoopX module outcomes to compact application-disposition coverage, cost, intervention, bot-feedback, and optional post-outcome utility observations after the Stage-4 gate.",
+            "write_boundary": "utility attribution is default-off, proposal-only, and fail-open; this command reads compact receipts only and performs no ranking, authority, memory, operator, provider, or external write",
         },
         {
             "command": "loopx reward-memory operator-control --input <reviewed-record.json> --action edit --control-ref <ref> --reasoning-summary <summary> --edited-content-summary <summary> --format json",
@@ -165,12 +165,17 @@ REWARD_MEMORY_CATALOG_ENTRY: dict[str, Any] = {
             "doc": "loopx/capabilities/reward_memory/README.md",
         },
         {
-            "schema_version": "reward_memory_dogfood_receipt_v0",
+            "schema_version": "memory_utility_observation_v0",
+            "module": "loopx.capabilities.reward_memory.memory_utility",
+            "doc": "loopx/capabilities/reward_memory/README.md",
+        },
+        {
+            "schema_version": "reward_memory_dogfood_receipt_v1",
             "module": "loopx.capabilities.reward_memory.dogfood",
             "doc": "loopx/capabilities/reward_memory/README.md",
         },
         {
-            "schema_version": "reward_memory_dogfood_batch_v0",
+            "schema_version": "reward_memory_dogfood_batch_v1",
             "module": "loopx.capabilities.reward_memory.dogfood",
             "doc": "loopx/capabilities/reward_memory/README.md",
         },
@@ -209,8 +214,11 @@ REWARD_MEMORY_CATALOG_ENTRY: dict[str, Any] = {
         "Provider and application failures preserve the base output, emit compact receipts or setup hints, and never become user gates automatically.",
         "Private corpus summaries stay transient in-process; public packets retain opaque references and compact lineage only.",
         "Stage 4 proves bounded core-contract invariants only; its fixture pass does not claim semantic uplift or authorize production rollout.",
-        "Stage 5 receipts are derived from Stage-3 application receipts and verified module outcomes; hit or refute requires exact provider readback plus current-artifact verification.",
-        "Stage 5 trial readiness requires Issue Fix, two distinct LoopX domains, hit/miss/refute coverage, and authority-matched edit/retire controls; it still does not authorize production rollout.",
+        "Stage 5 keeps application disposition separate from post-outcome utility: applied, not_applied, and refuted describe coverage, while helpful, harmful, neutral, and unknown require an independently bound utility observation.",
+        "Applied plus a successful outcome remains unknown without independent attribution evidence; evaluator scope, outcome, retrieval snapshot, and policy snapshot must match trusted execution context, with receipt-carried snapshots cross-checked when present.",
+        "Utility attribution is default-off, proposal-only, and fail-open; absent or malformed evaluator output leaves the main result, application settlement, and trial readiness unchanged.",
+        "Stage 5 trial readiness requires Issue Fix, two distinct LoopX domains, applied/not_applied/refuted coverage, and authority-matched edit/retire controls; utility does not affect readiness or authorize ranking, lifecycle, provider, or external writes.",
+        "Utility-attribution Stage 1 provides stable observation identity only; idempotent reduction, utility projection, ranking influence, and OpenViking writeback remain later-stage work.",
     ],
     "next_real_step": (
         "Feed one corpus-owner-approved, exactly read-back record through the "

--- a/loopx/capabilities/reward_memory/dogfood.py
+++ b/loopx/capabilities/reward_memory/dogfood.py
@@ -14,19 +14,64 @@ from .candidate_review import (
     review_reward_memory_candidate,
 )
 from .evaluation import REWARD_MEMORY_EVALUATION_SCHEMA_VERSION
+from .memory_utility import (
+    build_reward_memory_utility_observation,
+    normalize_reward_memory_ref_digests,
+    reward_memory_application_receipt_id,
+    validate_reward_memory_utility_observation,
+)
 from .registry import normalize_reward_memory_corpus
 
 
-REWARD_MEMORY_DOGFOOD_RECEIPT_SCHEMA_VERSION = "reward_memory_dogfood_receipt_v0"
-REWARD_MEMORY_DOGFOOD_BATCH_SCHEMA_VERSION = "reward_memory_dogfood_batch_v0"
+REWARD_MEMORY_DOGFOOD_RECEIPT_SCHEMA_VERSION = "reward_memory_dogfood_receipt_v1"
+REWARD_MEMORY_DOGFOOD_BATCH_SCHEMA_VERSION = "reward_memory_dogfood_batch_v1"
 REWARD_MEMORY_OPERATOR_CONTROL_SCHEMA_VERSION = "reward_memory_operator_control_v0"
 
-DOGFOOD_OUTCOMES = {"hit", "miss", "refute"}
+APPLICATION_DISPOSITIONS = {"applied", "not_applied", "refuted"}
+UTILITY_EVALUATION_STATUSES = {"accepted", "rejected", "not_requested"}
 DOMAIN_FAMILIES = {"issue_fix", "loopx"}
 OPERATOR_ACTIONS = {"edit", "retire"}
 TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/#-]{0,199}$")
 MAX_RECEIPTS = 24
 MAX_OPERATOR_CONTROLS = 8
+
+_DOGFOOD_RECEIPT_FIELDS = frozenset(
+    {
+        "ok",
+        "schema_version",
+        "domain_family",
+        "domain_id",
+        "application_id",
+        "application_receipt_id",
+        "artifact_ref",
+        "corpus_id",
+        "surface_id",
+        "application_outcome",
+        "application_disposition",
+        "module_outcome",
+        "utility_evaluation",
+        "utility_observation",
+        "memory_ref_digests",
+        "verification",
+        "cost",
+        "intervention",
+        "bot_feedback",
+        "receipt_id",
+        "grants_new_action_authority",
+        "raw_content_captured",
+        "external_writes_performed",
+    }
+)
+_VERIFICATION_FIELDS = frozenset(
+    {"result_readback_verified", "current_artifact_verified"}
+)
+_MODULE_OUTCOME_FIELDS = frozenset(
+    {"verified", "outcome_ref", "outcome_status", "summary"}
+)
+_COST_FIELDS = frozenset({"latency_ms", "model_tokens", "provider_call_count"})
+_INTERVENTION_FIELDS = frozenset({"count", "summary"})
+_BOT_FEEDBACK_FIELDS = frozenset({"captured", "summary"})
+_UTILITY_ATTRIBUTION_FIELDS = frozenset({"context", "proposal", "created_at"})
 
 
 def _token(value: object, label: str) -> str:
@@ -57,6 +102,20 @@ def _counter(mapping: Mapping[str, Any], key: str) -> int:
     return value
 
 
+def _exact_fields(
+    mapping: Mapping[str, Any], expected: frozenset[str], label: str
+) -> None:
+    keys = set(mapping)
+    if any(not isinstance(key, str) for key in keys):
+        raise ValueError(f"{label} fields must be strings")
+    if keys != expected:
+        missing = sorted(expected - keys)
+        unknown = sorted(keys - expected)
+        raise ValueError(
+            f"{label} has invalid fields: missing={missing}, unknown={unknown}"
+        )
+
+
 def _digest(payload: Mapping[str, Any], *, prefix: str) -> str:
     value = hashlib.sha256(
         json.dumps(payload, sort_keys=True, ensure_ascii=False).encode("utf-8")
@@ -64,20 +123,35 @@ def _digest(payload: Mapping[str, Any], *, prefix: str) -> str:
     return f"{prefix}:{value}"
 
 
-def _dogfood_outcome(application_outcome: object) -> str:
+def _application_disposition(application_outcome: object) -> str:
     outcome = str(application_outcome or "").strip()
     if outcome == "applied":
-        return "hit"
+        return "applied"
     if outcome == "refuted":
-        return "refute"
+        return "refuted"
     if outcome in {
         "ignored",
         "failed",
         "not_available",
         "available_not_applied",
     }:
-        return "miss"
+        return "not_applied"
     raise ValueError("application receipt outcome is invalid")
+
+
+def _dogfood_receipt_identity(receipt: Mapping[str, Any]) -> dict[str, Any]:
+    # Utility delivery has its own observation_id. Keep this identity tied to the
+    # application settlement so evaluator absence, rejection, or revision cannot
+    # duplicate application disposition and cost metrics.
+    module_outcome = receipt["module_outcome"]
+    return {
+        "schema_version": receipt["schema_version"],
+        "application_receipt_id": receipt["application_receipt_id"],
+        "application_outcome": receipt["application_outcome"],
+        "application_disposition": receipt["application_disposition"],
+        "module_outcome_ref": module_outcome["outcome_ref"],
+        "module_outcome_status": module_outcome["outcome_status"],
+    }
 
 
 def build_reward_memory_dogfood_receipt(
@@ -105,9 +179,12 @@ def build_reward_memory_dogfood_receipt(
     ):
         raise ValueError("application_receipt must use the Stage-3 receipt schema")
     application_id = _token(application.get("application_id"), "application_id")
+    application_receipt_id = reward_memory_application_receipt_id(application)
     artifact_ref = _token(application.get("artifact_ref"), "artifact_ref")
+    corpus_id = _token(application.get("corpus_id"), "corpus_id")
     surface_id = _token(application.get("surface_id"), "surface_id")
-    outcome = _dogfood_outcome(application.get("outcome"))
+    application_outcome = str(application.get("outcome") or "").strip()
+    application_disposition = _application_disposition(application_outcome)
     readback_verified = _boolean(application, "result_readback_verified")
     current_verified = _boolean(application, "current_artifact_verified")
     if _boolean(application, "grants_new_action_authority"):
@@ -116,22 +193,17 @@ def build_reward_memory_dogfood_receipt(
         raise ValueError("application receipt cannot contain raw content")
     if _boolean(application, "external_writes_performed"):
         raise ValueError("application receipt cannot perform external writes")
-    if outcome in {"hit", "refute"} and not readback_verified:
-        raise ValueError("hit or refute requires exact provider result readback")
-    if outcome in {"hit", "refute"} and not current_verified:
-        raise ValueError("hit or refute requires current-artifact verification")
-    memory_ref_digests = application.get("memory_ref_digests")
-    if not isinstance(memory_ref_digests, Sequence) or isinstance(
-        memory_ref_digests, (str, bytes)
-    ):
-        raise ValueError("memory_ref_digests must be a list")
-    digests = sorted(
-        {_token(value, "memory_ref_digest") for value in memory_ref_digests}
+    if application_disposition in {"applied", "refuted"} and not readback_verified:
+        raise ValueError("applied or refuted requires exact provider result readback")
+    if application_disposition in {"applied", "refuted"} and not current_verified:
+        raise ValueError("applied or refuted requires current-artifact verification")
+    digests = normalize_reward_memory_ref_digests(
+        application.get("memory_ref_digests"),
+        "memory_ref_digests",
+        minimum=0,
     )
-    if len(digests) != len(memory_ref_digests):
-        raise ValueError("memory_ref_digests must not contain duplicates")
-    if outcome in {"hit", "refute"} and not digests:
-        raise ValueError("hit or refute requires attributed memory references")
+    if application_disposition in {"applied", "refuted"} and not digests:
+        raise ValueError("applied or refuted requires attributed memory references")
 
     module_outcome = observation.get("module_outcome")
     if not isinstance(module_outcome, Mapping):
@@ -144,9 +216,64 @@ def build_reward_memory_dogfood_receipt(
     outcome_verified = _boolean(module_outcome, "outcome_verified")
     if not outcome_verified:
         raise ValueError("dogfood requires a verified real module outcome")
+    outcome_ref = _token(
+        module_outcome.get("outcome_ref"), "module_outcome.outcome_ref"
+    )
+    outcome_status = _token(
+        module_outcome.get("outcome_status"), "module_outcome.outcome_status"
+    )
     outcome_summary = _compact(
         module_outcome.get("summary"), "module_outcome.summary", limit=360
     )
+
+    verified_outcome = {
+        "verified": True,
+        "outcome_ref": outcome_ref,
+        "artifact_ref": artifact_ref,
+        "outcome_status": outcome_status,
+    }
+    utility_observation: dict[str, Any] | None = None
+    if "utility_attribution" not in observation:
+        utility_evaluation = {
+            "status": "not_requested",
+            "reason_code": "utility_attribution_not_requested",
+        }
+    else:
+        try:
+            attribution = observation.get("utility_attribution")
+            if not isinstance(attribution, Mapping):
+                raise ValueError("utility_attribution must be an object")
+            _exact_fields(
+                attribution,
+                _UTILITY_ATTRIBUTION_FIELDS,
+                "utility_attribution",
+            )
+            attribution_context = attribution.get("context")
+            evaluator_proposal = attribution.get("proposal")
+            if not isinstance(attribution_context, Mapping):
+                raise ValueError("utility attribution context must be an object")
+            if not isinstance(evaluator_proposal, Mapping):
+                raise ValueError("utility attribution proposal must be an object")
+            built_observation = build_reward_memory_utility_observation(
+                application,
+                verified_outcome,
+                attribution_context,
+                evaluator_proposal,
+                created_at=attribution.get("created_at"),
+            )
+            utility_observation = validate_reward_memory_utility_observation(
+                built_observation,
+                application_receipt=application,
+                verified_outcome=verified_outcome,
+                attribution_context=attribution_context,
+            )
+        except ValueError:
+            utility_evaluation = {
+                "status": "rejected",
+                "reason_code": "utility_attribution_rejected",
+            }
+        else:
+            utility_evaluation = {"status": "accepted"}
 
     cost = observation.get("cost")
     if not isinstance(cost, Mapping):
@@ -178,28 +305,26 @@ def build_reward_memory_dogfood_receipt(
             bot_feedback.get("summary"), "bot_feedback.summary", limit=240
         )
 
-    identity = {
-        "domain_family": family,
-        "domain_id": domain_id,
-        "application_id": application_id,
-        "artifact_ref": artifact_ref,
-        "surface_id": surface_id,
-        "outcome": outcome,
-    }
-    return {
+    receipt = {
         "ok": True,
         "schema_version": REWARD_MEMORY_DOGFOOD_RECEIPT_SCHEMA_VERSION,
-        "receipt_id": _digest(identity, prefix="dogfood"),
         "domain_family": family,
         "domain_id": domain_id,
         "application_id": application_id,
+        "application_receipt_id": application_receipt_id,
         "artifact_ref": artifact_ref,
+        "corpus_id": corpus_id,
         "surface_id": surface_id,
-        "outcome": outcome,
+        "application_outcome": application_outcome,
+        "application_disposition": application_disposition,
         "module_outcome": {
             "verified": True,
+            "outcome_ref": outcome_ref,
+            "outcome_status": outcome_status,
             "summary": outcome_summary,
         },
+        "utility_evaluation": utility_evaluation,
+        "utility_observation": utility_observation,
         "memory_ref_digests": digests,
         "verification": {
             "result_readback_verified": readback_verified,
@@ -218,6 +343,10 @@ def build_reward_memory_dogfood_receipt(
         "raw_content_captured": False,
         "external_writes_performed": False,
     }
+    receipt["receipt_id"] = _digest(
+        _dogfood_receipt_identity(receipt), prefix="dogfood"
+    )
+    return receipt
 
 
 def _scope_matches(record: Mapping[str, Any], corpus: Mapping[str, Any]) -> bool:
@@ -409,50 +538,186 @@ def _validate_control_receipt(raw: object) -> dict[str, Any]:
 def _validate_dogfood_receipt(raw: object) -> dict[str, Any]:
     if not isinstance(raw, Mapping):
         raise ValueError("dogfood receipt must be an object")
+    _exact_fields(raw, _DOGFOOD_RECEIPT_FIELDS, "dogfood receipt")
     if raw.get("schema_version") != REWARD_MEMORY_DOGFOOD_RECEIPT_SCHEMA_VERSION:
         raise ValueError("dogfood receipt schema is invalid")
+    if _boolean(raw, "ok") is not True:
+        raise ValueError("dogfood receipt must be successful")
     family = str(raw.get("domain_family") or "").strip()
     domain_id = _token(raw.get("domain_id"), "domain_id")
     if family not in DOMAIN_FAMILIES or not domain_id.startswith(f"{family}."):
         raise ValueError("dogfood receipt domain is invalid")
-    outcome = str(raw.get("outcome") or "").strip()
-    if outcome not in DOGFOOD_OUTCOMES:
-        raise ValueError("dogfood receipt outcome is invalid")
-    for key in ("receipt_id", "application_id", "artifact_ref", "surface_id"):
+    application_outcome = str(raw.get("application_outcome") or "").strip()
+    application_disposition = str(raw.get("application_disposition") or "").strip()
+    if application_disposition not in APPLICATION_DISPOSITIONS:
+        raise ValueError("dogfood receipt application disposition is invalid")
+    if _application_disposition(application_outcome) != application_disposition:
+        raise ValueError("dogfood receipt application outcome is inconsistent")
+    for key in (
+        "receipt_id",
+        "application_id",
+        "application_receipt_id",
+        "artifact_ref",
+        "corpus_id",
+        "surface_id",
+    ):
         _token(raw.get(key), key)
     verification = raw.get("verification")
     if not isinstance(verification, Mapping):
         raise ValueError("dogfood receipt verification is invalid")
+    _exact_fields(verification, _VERIFICATION_FIELDS, "dogfood receipt verification")
     readback = _boolean(verification, "result_readback_verified")
     current = _boolean(verification, "current_artifact_verified")
-    if outcome in {"hit", "refute"} and not (readback and current):
-        raise ValueError("hit or refute receipt is not exactly verified")
+    normalized_verification = {
+        "result_readback_verified": readback,
+        "current_artifact_verified": current,
+    }
+    if application_disposition in {"applied", "refuted"} and not (readback and current):
+        raise ValueError("applied or refuted receipt is not exactly verified")
+    digests = normalize_reward_memory_ref_digests(
+        raw.get("memory_ref_digests"),
+        "dogfood receipt memory_ref_digests",
+        minimum=0,
+    )
+    if raw["memory_ref_digests"] != digests:
+        raise ValueError("dogfood receipt memory_ref_digests must be sorted")
+    if application_disposition in {"applied", "refuted"} and not digests:
+        raise ValueError("applied or refuted receipt requires memory references")
     module_outcome = raw.get("module_outcome")
-    if not isinstance(module_outcome, Mapping) or not _boolean(
-        module_outcome, "verified"
-    ):
+    if not isinstance(module_outcome, Mapping):
+        raise ValueError("dogfood module outcome is invalid")
+    _exact_fields(module_outcome, _MODULE_OUTCOME_FIELDS, "dogfood module outcome")
+    if not _boolean(module_outcome, "verified"):
         raise ValueError("dogfood module outcome is not verified")
-    _compact(module_outcome.get("summary"), "module_outcome.summary", limit=360)
+    outcome_ref = _token(
+        module_outcome.get("outcome_ref"), "module_outcome.outcome_ref"
+    )
+    outcome_status = _token(
+        module_outcome.get("outcome_status"), "module_outcome.outcome_status"
+    )
+    normalized_module_outcome = {
+        "verified": True,
+        "outcome_ref": outcome_ref,
+        "outcome_status": outcome_status,
+        "summary": _compact(
+            module_outcome.get("summary"), "module_outcome.summary", limit=360
+        ),
+    }
+
+    utility_evaluation = raw.get("utility_evaluation")
+    if not isinstance(utility_evaluation, Mapping):
+        raise ValueError("dogfood utility evaluation is invalid")
+    evaluation_status = str(utility_evaluation.get("status") or "").strip()
+    if evaluation_status not in UTILITY_EVALUATION_STATUSES:
+        raise ValueError("dogfood utility evaluation status is invalid")
+    utility_observation = raw.get("utility_observation")
+    if evaluation_status == "accepted":
+        if set(utility_evaluation) != {"status"}:
+            raise ValueError("accepted utility evaluation must not carry a reason")
+        normalized_utility = validate_reward_memory_utility_observation(
+            utility_observation
+        )
+        utility_scope = normalized_utility["scope"]
+        if (
+            utility_scope["corpus_id"] != raw["corpus_id"]
+            or utility_scope["surface_id"] != raw["surface_id"]
+        ):
+            raise ValueError("embedded utility observation scope does not match")
+        if normalized_utility["outcome_ref"] != outcome_ref:
+            raise ValueError("embedded utility observation outcome does not match")
+        if (
+            normalized_utility["application_receipt_id"]
+            != raw["application_receipt_id"]
+        ):
+            raise ValueError(
+                "embedded utility observation application receipt does not match"
+            )
+        if normalized_utility["attribution_level"] == "item":
+            if (
+                len(normalized_utility["memory_ref_digests"]) != 1
+                or normalized_utility["memory_ref_digests"][0] not in digests
+            ):
+                raise ValueError("embedded item utility memory digest is not applied")
+        elif normalized_utility["memory_ref_digests"] != digests:
+            raise ValueError("embedded utility observation memory digests do not match")
+        normalized_utility_evaluation = {"status": "accepted"}
+    else:
+        expected_reason = f"utility_attribution_{evaluation_status}"
+        if set(utility_evaluation) != {"status", "reason_code"} or (
+            utility_evaluation.get("reason_code") != expected_reason
+        ):
+            raise ValueError("dogfood utility evaluation reason is invalid")
+        if utility_observation is not None:
+            raise ValueError(
+                "unaccepted utility evaluation cannot carry an observation"
+            )
+        normalized_utility = None
+        normalized_utility_evaluation = {
+            "status": evaluation_status,
+            "reason_code": expected_reason,
+        }
+
+    if raw["receipt_id"] != _digest(_dogfood_receipt_identity(raw), prefix="dogfood"):
+        raise ValueError("dogfood receipt identity is invalid")
     cost = raw.get("cost")
     if not isinstance(cost, Mapping):
         raise ValueError("dogfood receipt cost is invalid")
-    for key in ("latency_ms", "model_tokens", "provider_call_count"):
-        _counter(cost, key)
+    _exact_fields(cost, _COST_FIELDS, "dogfood receipt cost")
+    normalized_cost = {
+        key: _counter(cost, key)
+        for key in ("latency_ms", "model_tokens", "provider_call_count")
+    }
     intervention = raw.get("intervention")
     if not isinstance(intervention, Mapping):
         raise ValueError("dogfood receipt intervention is invalid")
-    _counter(intervention, "count")
+    _exact_fields(intervention, _INTERVENTION_FIELDS, "dogfood receipt intervention")
+    intervention_count = _counter(intervention, "count")
+    intervention_summary = intervention.get("summary")
+    if intervention_count:
+        normalized_intervention_summary = _compact(
+            intervention_summary, "intervention.summary", limit=240
+        )
+    elif intervention_summary is not None:
+        raise ValueError("intervention.summary must be null when count is zero")
+    else:
+        normalized_intervention_summary = None
+    normalized_intervention = {
+        "count": intervention_count,
+        "summary": normalized_intervention_summary,
+    }
     feedback = raw.get("bot_feedback")
     if not isinstance(feedback, Mapping):
         raise ValueError("dogfood receipt bot_feedback is invalid")
-    _boolean(feedback, "captured")
+    _exact_fields(feedback, _BOT_FEEDBACK_FIELDS, "dogfood receipt bot_feedback")
+    feedback_captured = _boolean(feedback, "captured")
+    feedback_summary = feedback.get("summary")
+    if feedback_captured:
+        normalized_feedback_summary = _compact(
+            feedback_summary, "bot_feedback.summary", limit=240
+        )
+    elif feedback_summary is not None:
+        raise ValueError("bot_feedback.summary must be null when captured is false")
+    else:
+        normalized_feedback_summary = None
+    normalized_feedback = {
+        "captured": feedback_captured,
+        "summary": normalized_feedback_summary,
+    }
     if _boolean(raw, "grants_new_action_authority"):
         raise ValueError("dogfood receipt cannot grant action authority")
     if _boolean(raw, "raw_content_captured"):
         raise ValueError("dogfood receipt cannot contain raw content")
     if _boolean(raw, "external_writes_performed"):
         raise ValueError("dogfood receipt cannot perform external writes")
-    return dict(raw)
+    result = dict(raw)
+    result["verification"] = normalized_verification
+    result["module_outcome"] = normalized_module_outcome
+    result["utility_evaluation"] = normalized_utility_evaluation
+    result["cost"] = normalized_cost
+    result["intervention"] = normalized_intervention
+    result["bot_feedback"] = normalized_feedback
+    result["utility_observation"] = normalized_utility
+    return result
 
 
 def build_reward_memory_dogfood_batch(
@@ -476,6 +741,13 @@ def build_reward_memory_dogfood_batch(
     receipt_ids = [item["receipt_id"] for item in normalized_receipts]
     if len(receipt_ids) != len(set(receipt_ids)):
         raise ValueError("dogfood batch must not double-count a receipt")
+    application_receipt_ids = [
+        item["application_receipt_id"] for item in normalized_receipts
+    ]
+    if len(application_receipt_ids) != len(set(application_receipt_ids)):
+        raise ValueError(
+            "dogfood batch must not double-count an application settlement"
+        )
     control_refs = [item["control_ref"] for item in controls]
     if len(control_refs) != len(set(control_refs)):
         raise ValueError("dogfood batch must not double-count an operator control")
@@ -496,7 +768,9 @@ def build_reward_memory_dogfood_batch(
             if item["domain_family"] == "loopx"
         }
     )
-    outcomes = {item["outcome"] for item in normalized_receipts}
+    application_dispositions = {
+        item["application_disposition"] for item in normalized_receipts
+    }
     actions = {item["action"] for item in controls}
     reason_codes: list[str] = []
     if not gate_ready:
@@ -505,19 +779,43 @@ def build_reward_memory_dogfood_batch(
         reason_codes.append("issue_fix_outcome_missing")
     if len(loopx_domains) < 2:
         reason_codes.append("two_loopx_domains_required")
-    for outcome in sorted(DOGFOOD_OUTCOMES - outcomes):
-        reason_codes.append(f"outcome_missing:{outcome}")
+    for disposition in sorted(APPLICATION_DISPOSITIONS - application_dispositions):
+        reason_codes.append(f"application_disposition_missing:{disposition}")
     for action in sorted(OPERATOR_ACTIONS - actions):
         reason_codes.append(f"operator_control_missing:{action}")
 
+    utility_observations = [
+        item["utility_observation"]
+        for item in normalized_receipts
+        if item["utility_observation"] is not None
+    ]
+    disposition_metrics = {
+        f"{disposition}_count": sum(
+            item["application_disposition"] == disposition
+            for item in normalized_receipts
+        )
+        for disposition in sorted(APPLICATION_DISPOSITIONS)
+    }
+    utility_label_metrics = {
+        f"utility_{label}_count": sum(
+            item["utility_label"] == label for item in utility_observations
+        )
+        for label in ("helpful", "harmful", "neutral", "unknown")
+    }
     totals = {
         "receipt_count": len(normalized_receipts),
         "issue_fix_receipt_count": issue_fix_count,
         "loopx_domain_count": len(loopx_domains),
-        "hit_count": sum(item["outcome"] == "hit" for item in normalized_receipts),
-        "miss_count": sum(item["outcome"] == "miss" for item in normalized_receipts),
-        "refute_count": sum(
-            item["outcome"] == "refute" for item in normalized_receipts
+        **disposition_metrics,
+        "utility_observation_count": len(utility_observations),
+        **utility_label_metrics,
+        "utility_rejected_count": sum(
+            item["utility_evaluation"]["status"] == "rejected"
+            for item in normalized_receipts
+        ),
+        "utility_not_requested_count": sum(
+            item["utility_evaluation"]["status"] == "not_requested"
+            for item in normalized_receipts
         ),
         "latency_ms": sum(item["cost"]["latency_ms"] for item in normalized_receipts),
         "model_tokens": sum(
@@ -534,24 +832,34 @@ def build_reward_memory_dogfood_batch(
         ),
     }
     ready = not reason_codes
-    compact_receipts = [
-        {
-            key: item[key]
-            for key in (
-                "receipt_id",
-                "domain_family",
-                "domain_id",
-                "artifact_ref",
-                "surface_id",
-                "outcome",
-                "verification",
-                "cost",
-                "intervention",
-                "bot_feedback",
-            )
-        }
-        for item in normalized_receipts
-    ]
+    compact_receipts = []
+    for item in normalized_receipts:
+        compact_receipts.append(
+            {
+                "receipt_id": item["receipt_id"],
+                "domain_family": item["domain_family"],
+                "domain_id": item["domain_id"],
+                "application": {
+                    "application_id": item["application_id"],
+                    "application_receipt_id": item["application_receipt_id"],
+                    "artifact_ref": item["artifact_ref"],
+                    "corpus_id": item["corpus_id"],
+                    "surface_id": item["surface_id"],
+                    "outcome": item["application_outcome"],
+                    "disposition": item["application_disposition"],
+                    "memory_ref_digests": item["memory_ref_digests"],
+                    "verification": item["verification"],
+                },
+                "module_outcome": item["module_outcome"],
+                "utility": {
+                    "evaluation": item["utility_evaluation"],
+                    "observation": item["utility_observation"],
+                },
+                "cost": item["cost"],
+                "intervention": item["intervention"],
+                "bot_feedback": item["bot_feedback"],
+            }
+        )
     return {
         "ok": ready,
         "schema_version": REWARD_MEMORY_DOGFOOD_BATCH_SCHEMA_VERSION,
@@ -559,7 +867,7 @@ def build_reward_memory_dogfood_batch(
         "reason_codes": reason_codes,
         "stage4_gate_verified": gate_ready,
         "loopx_domains": loopx_domains,
-        "outcomes": sorted(outcomes),
+        "application_dispositions": sorted(application_dispositions),
         "operator_controls": sorted(actions),
         "metrics": totals,
         "receipts": compact_receipts,

--- a/loopx/capabilities/reward_memory/memory_utility.py
+++ b/loopx/capabilities/reward_memory/memory_utility.py
@@ -1,0 +1,740 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from collections.abc import Mapping
+from datetime import datetime
+from pathlib import PurePosixPath, PureWindowsPath
+from typing import Any
+
+from .application import (
+    APPLICATION_OUTCOMES,
+    RECALL_MODES,
+    RECALL_QUERY_KINDS,
+    REWARD_MEMORY_APPLICATION_RECEIPT_SCHEMA_VERSION,
+)
+
+
+MEMORY_UTILITY_OBSERVATION_SCHEMA_VERSION = "memory_utility_observation_v0"
+
+UTILITY_LABELS = frozenset({"helpful", "harmful", "neutral", "unknown"})
+ATTRIBUTION_LEVELS = frozenset({"item", "set", "none"})
+EVIDENCE_BASES = frozenset(
+    {
+        "owner_correction",
+        "controlled_replay",
+        "deterministic_effect",
+        "evaluator_inference",
+        "insufficient",
+    }
+)
+
+_EXISTING_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/#-]{0,199}$")
+_OPAQUE_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,199}$")
+_MEMORY_REF_DIGEST_RE = re.compile(r"^(?:[0-9a-f]{16}|sha256:[0-9a-f]{64})$")
+_MAX_MEMORY_DIGESTS = 16
+_MAX_REASON_CODES = 12
+_MAX_EVIDENCE_REFS = 16
+
+_APPLICATION_RECEIPT_REQUIRED_FIELDS = frozenset(
+    {
+        "schema_version",
+        "application_id",
+        "artifact_ref",
+        "corpus_id",
+        "surface_id",
+        "mode",
+        "query_kind",
+        "query_evidence",
+        "outcome",
+        "memory_ref_digests",
+        "reasoning_summary",
+        "current_artifact_verified",
+        "result_readback_verified",
+        "provider_call_count",
+        "model_reasoning_preserved",
+        "grants_new_action_authority",
+        "external_writes_performed",
+        "raw_content_captured",
+    }
+)
+_APPLICATION_RECEIPT_OPTIONAL_FIELDS = frozenset(
+    {"retrieval_snapshot_ref", "policy_snapshot_ref"}
+)
+_QUERY_EVIDENCE_FIELDS = frozenset(
+    {"query_digest", "query_summary", "exact_query_exposed"}
+)
+
+_VERIFIED_OUTCOME_FIELDS = frozenset(
+    {"verified", "outcome_ref", "artifact_ref", "outcome_status"}
+)
+_ATTRIBUTION_CONTEXT_FIELDS = frozenset(
+    {"scope", "retrieval_snapshot_ref", "policy_snapshot_ref"}
+)
+_SCOPE_FIELDS = frozenset({"agent_id", "project_id", "corpus_id", "surface_id"})
+_EVALUATOR_PROPOSAL_FIELDS = frozenset(
+    {
+        "scope",
+        "application_id",
+        "artifact_ref",
+        "outcome_ref",
+        "outcome_status",
+        "retrieval_snapshot_ref",
+        "policy_snapshot_ref",
+        "memory_ref_digests",
+        "utility_label",
+        "attribution_level",
+        "evidence_basis",
+        "confidence",
+        "reason_codes",
+        "evidence_refs",
+        "evaluator_ref",
+        "evaluation_version",
+    }
+)
+_OBSERVATION_FIELDS = frozenset(
+    {
+        "schema_version",
+        "observation_id",
+        "scope",
+        "application_receipt_id",
+        "memory_ref_digests",
+        "retrieval_snapshot_ref",
+        "policy_snapshot_ref",
+        "outcome_ref",
+        "utility_label",
+        "attribution_level",
+        "evidence_basis",
+        "confidence",
+        "reason_codes",
+        "evidence_refs",
+        "evaluator_ref",
+        "evaluation_version",
+        "created_at",
+        "grants_new_action_authority",
+        "provider_write_performed",
+        "external_writes_performed",
+        "raw_content_captured",
+    }
+)
+
+
+def _object(value: object, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be an object")
+    return value
+
+
+def _require_exact_fields(
+    value: Mapping[str, Any], expected: frozenset[str], label: str
+) -> None:
+    keys = set(value)
+    if any(not isinstance(key, str) for key in keys):
+        raise ValueError(f"{label} fields must be strings")
+    if keys == expected:
+        return
+    missing = sorted(expected - keys)
+    unknown = sorted(keys - expected)
+    raise ValueError(
+        f"{label} has invalid fields: missing={missing}, unknown={unknown}"
+    )
+
+
+def _existing_token(value: object, label: str) -> str:
+    result = str(value or "").strip()
+    if not _EXISTING_TOKEN_RE.fullmatch(result):
+        raise ValueError(f"{label} must be a compact public-safe token")
+    return result
+
+
+def _opaque_ref(value: object, label: str) -> str:
+    result = str(value or "").strip()
+    if (
+        not _OPAQUE_REF_RE.fullmatch(result)
+        or "://" in result
+        or PurePosixPath(result).is_absolute()
+        or PureWindowsPath(result).is_absolute()
+    ):
+        raise ValueError(f"{label} must be an opaque public-safe reference")
+    return result
+
+
+def _timestamp(value: object, label: str) -> str:
+    result = str(value or "").strip()
+    try:
+        parsed = datetime.fromisoformat(result.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{label} must be an ISO timestamp") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError(f"{label} must include a timezone")
+    return result
+
+
+def _false_boundary(value: Mapping[str, Any], key: str, label: str) -> bool:
+    if value.get(key) is not False:
+        raise ValueError(f"{label}.{key} must be false")
+    return False
+
+
+def _boolean(value: Mapping[str, Any], key: str, label: str) -> bool:
+    result = value.get(key)
+    if not isinstance(result, bool):
+        raise ValueError(f"{label}.{key} must be a boolean")
+    return result
+
+
+def _non_negative_integer(value: object, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{label} must be a non-negative integer")
+    return value
+
+
+def _compact_text(value: object, label: str, *, maximum: int) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{label} must be compact public-safe text")
+    result = value.strip()
+    if not result or len(result) > maximum or any(char in result for char in "\r\n"):
+        raise ValueError(f"{label} must be compact public-safe text")
+    return result
+
+
+def _confidence(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("confidence must be a finite number between 0 and 1")
+    result = float(value)
+    if not math.isfinite(result) or not 0.0 <= result <= 1.0:
+        raise ValueError("confidence must be a finite number between 0 and 1")
+    return result
+
+
+def _refs(
+    value: object,
+    label: str,
+    *,
+    maximum: int,
+    minimum: int = 0,
+) -> list[str]:
+    if not isinstance(value, list) or not minimum <= len(value) <= maximum:
+        raise ValueError(
+            f"{label} must be a list containing between {minimum} and "
+            f"{maximum} opaque references"
+        )
+    result = sorted(_opaque_ref(item, label) for item in value)
+    if len(set(result)) != len(result):
+        raise ValueError(f"{label} must not contain duplicates")
+    return result
+
+
+def normalize_reward_memory_ref_digests(
+    value: object,
+    label: str,
+    *,
+    minimum: int = 1,
+) -> list[str]:
+    result = _refs(
+        value,
+        label,
+        minimum=minimum,
+        maximum=_MAX_MEMORY_DIGESTS,
+    )
+    if any(not _MEMORY_REF_DIGEST_RE.fullmatch(item) for item in result):
+        raise ValueError(f"{label} must contain only canonical opaque memory digests")
+    return result
+
+
+def _scope(value: object, label: str) -> dict[str, str]:
+    raw = _object(value, label)
+    _require_exact_fields(raw, _SCOPE_FIELDS, label)
+    return {
+        key: _opaque_ref(raw.get(key), f"{label}.{key}")
+        for key in ("agent_id", "project_id", "corpus_id", "surface_id")
+    }
+
+
+def _canonical_digest(value: Mapping[str, Any], *, prefix: str) -> str:
+    try:
+        encoded = json.dumps(
+            dict(value),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise ValueError("application_receipt must be canonical JSON data") from exc
+    return f"{prefix}{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _validate_application_receipt_envelope(raw: Mapping[str, Any]) -> None:
+    keys = set(raw)
+    if any(not isinstance(key, str) for key in keys):
+        raise ValueError("application_receipt fields must be strings")
+    missing = sorted(_APPLICATION_RECEIPT_REQUIRED_FIELDS - keys)
+    unknown = sorted(
+        keys
+        - _APPLICATION_RECEIPT_REQUIRED_FIELDS
+        - _APPLICATION_RECEIPT_OPTIONAL_FIELDS
+    )
+    if missing or unknown:
+        raise ValueError(
+            "application_receipt has invalid fields: "
+            f"missing={missing}, unknown={unknown}"
+        )
+
+    mode = str(raw.get("mode") or "").strip()
+    if mode not in RECALL_MODES:
+        raise ValueError("application_receipt.mode is invalid")
+    query_kind = str(raw.get("query_kind") or "").strip()
+    if query_kind not in RECALL_QUERY_KINDS:
+        raise ValueError("application_receipt.query_kind is invalid")
+    query_evidence = raw.get("query_evidence")
+    if not isinstance(query_evidence, list) or len(query_evidence) > 3:
+        raise ValueError("application_receipt.query_evidence must be a bounded list")
+    for index, item in enumerate(query_evidence):
+        label = f"application_receipt.query_evidence[{index}]"
+        evidence = _object(item, label)
+        _require_exact_fields(evidence, _QUERY_EVIDENCE_FIELDS, label)
+        digest = str(evidence.get("query_digest") or "").strip()
+        if not re.fullmatch(r"[0-9a-f]{16}", digest):
+            raise ValueError(f"{label}.query_digest must be a canonical digest")
+        _compact_text(
+            evidence.get("query_summary"), f"{label}.query_summary", maximum=220
+        )
+        if evidence.get("exact_query_exposed") is not False:
+            raise ValueError(f"{label}.exact_query_exposed must be false")
+
+    _compact_text(
+        raw.get("reasoning_summary"),
+        "application_receipt.reasoning_summary",
+        maximum=500,
+    )
+    _boolean(raw, "current_artifact_verified", "application_receipt")
+    _boolean(raw, "result_readback_verified", "application_receipt")
+    if _boolean(raw, "model_reasoning_preserved", "application_receipt") is not True:
+        raise ValueError("application_receipt.model_reasoning_preserved must be true")
+    _non_negative_integer(
+        raw.get("provider_call_count"), "application_receipt.provider_call_count"
+    )
+
+
+def reward_memory_application_receipt_id(value: Mapping[str, Any]) -> str:
+    """Return the stable opaque id for one complete application receipt."""
+
+    _, receipt_id = _application_receipt(value, minimum_memory_digests=0)
+    return receipt_id
+
+
+def _application_receipt(
+    value: object,
+    *,
+    minimum_memory_digests: int = 1,
+) -> tuple[dict[str, Any], str]:
+    raw = _object(value, "application_receipt")
+    if raw.get("schema_version") != REWARD_MEMORY_APPLICATION_RECEIPT_SCHEMA_VERSION:
+        raise ValueError(
+            "application_receipt must use reward_memory_application_receipt_v0"
+        )
+    _validate_application_receipt_envelope(raw)
+    outcome = str(raw.get("outcome") or "").strip()
+    if outcome not in APPLICATION_OUTCOMES:
+        raise ValueError("application_receipt.outcome is invalid")
+    memory_ref_digests = normalize_reward_memory_ref_digests(
+        raw.get("memory_ref_digests"),
+        "application_receipt.memory_ref_digests",
+        minimum=minimum_memory_digests,
+    )
+    if memory_ref_digests != raw.get("memory_ref_digests"):
+        raise ValueError(
+            "application_receipt.memory_ref_digests must be sorted and canonical"
+        )
+    normalized: dict[str, Any] = {
+        "application_id": _existing_token(
+            raw.get("application_id"), "application_receipt.application_id"
+        ),
+        "artifact_ref": _existing_token(
+            raw.get("artifact_ref"), "application_receipt.artifact_ref"
+        ),
+        "corpus_id": _opaque_ref(raw.get("corpus_id"), "application_receipt.corpus_id"),
+        "surface_id": _opaque_ref(
+            raw.get("surface_id"), "application_receipt.surface_id"
+        ),
+        "outcome": outcome,
+        "memory_ref_digests": memory_ref_digests,
+        "grants_new_action_authority": _false_boundary(
+            raw, "grants_new_action_authority", "application_receipt"
+        ),
+        "external_writes_performed": _false_boundary(
+            raw, "external_writes_performed", "application_receipt"
+        ),
+        "raw_content_captured": _false_boundary(
+            raw, "raw_content_captured", "application_receipt"
+        ),
+    }
+    for key in ("retrieval_snapshot_ref", "policy_snapshot_ref"):
+        if key in raw:
+            normalized[key] = _opaque_ref(raw.get(key), f"application_receipt.{key}")
+    # Bind the complete v0 receipt rather than a hand-picked identity subset.
+    return normalized, _canonical_digest(raw, prefix="rma_")
+
+
+def _verified_outcome(value: object) -> dict[str, Any]:
+    raw = _object(value, "verified_outcome")
+    _require_exact_fields(raw, _VERIFIED_OUTCOME_FIELDS, "verified_outcome")
+    if raw.get("verified") is not True:
+        raise ValueError("verified_outcome.verified must be true")
+    return {
+        "verified": True,
+        "outcome_ref": _opaque_ref(
+            raw.get("outcome_ref"), "verified_outcome.outcome_ref"
+        ),
+        "artifact_ref": _existing_token(
+            raw.get("artifact_ref"), "verified_outcome.artifact_ref"
+        ),
+        "outcome_status": _opaque_ref(
+            raw.get("outcome_status"), "verified_outcome.outcome_status"
+        ),
+    }
+
+
+def _attribution_context(value: object) -> dict[str, Any]:
+    raw = _object(value, "attribution_context")
+    _require_exact_fields(raw, _ATTRIBUTION_CONTEXT_FIELDS, "attribution_context")
+    return {
+        "scope": _scope(raw.get("scope"), "attribution_context.scope"),
+        "retrieval_snapshot_ref": _opaque_ref(
+            raw.get("retrieval_snapshot_ref"),
+            "attribution_context.retrieval_snapshot_ref",
+        ),
+        "policy_snapshot_ref": _opaque_ref(
+            raw.get("policy_snapshot_ref"), "attribution_context.policy_snapshot_ref"
+        ),
+    }
+
+
+def _utility_fields(value: Mapping[str, Any]) -> dict[str, Any]:
+    utility_label = str(value.get("utility_label") or "").strip()
+    attribution_level = str(value.get("attribution_level") or "").strip()
+    evidence_basis = str(value.get("evidence_basis") or "").strip()
+    if utility_label not in UTILITY_LABELS:
+        raise ValueError("utility_label is invalid")
+    if attribution_level not in ATTRIBUTION_LEVELS:
+        raise ValueError("attribution_level is invalid")
+    if evidence_basis not in EVIDENCE_BASES:
+        raise ValueError("evidence_basis is invalid")
+
+    evidence_refs = _refs(
+        value.get("evidence_refs"),
+        "evidence_refs",
+        maximum=_MAX_EVIDENCE_REFS,
+    )
+    if evidence_basis == "insufficient" and utility_label != "unknown":
+        raise ValueError("insufficient evidence must produce unknown utility")
+    if (
+        evidence_basis
+        in {
+            "owner_correction",
+            "controlled_replay",
+            "deterministic_effect",
+        }
+        and not evidence_refs
+    ):
+        raise ValueError("strong evidence basis requires evidence_refs")
+    if attribution_level == "none" and utility_label != "unknown":
+        raise ValueError("none attribution must produce unknown utility")
+    if utility_label != "unknown" and not evidence_refs:
+        raise ValueError("non-unknown utility requires evidence_refs")
+
+    return {
+        "utility_label": utility_label,
+        "attribution_level": attribution_level,
+        "evidence_basis": evidence_basis,
+        "confidence": _confidence(value.get("confidence")),
+        "reason_codes": _refs(
+            value.get("reason_codes"), "reason_codes", maximum=_MAX_REASON_CODES
+        ),
+        "evidence_refs": evidence_refs,
+        "evaluator_ref": _opaque_ref(value.get("evaluator_ref"), "evaluator_ref"),
+        "evaluation_version": _opaque_ref(
+            value.get("evaluation_version"), "evaluation_version"
+        ),
+    }
+
+
+def _validate_attribution_subject(
+    memory_ref_digests: list[str],
+    *,
+    attribution_level: str,
+    application_memory_ref_digests: list[str],
+) -> None:
+    if attribution_level == "item":
+        if (
+            len(memory_ref_digests) != 1
+            or memory_ref_digests[0] not in application_memory_ref_digests
+        ):
+            raise ValueError(
+                "item attribution must bind exactly one digest from the application receipt"
+            )
+        return
+    if memory_ref_digests != application_memory_ref_digests:
+        raise ValueError(
+            "set or none attribution must bind the complete application memory set"
+        )
+
+
+def _validate_bindings(
+    application_receipt: Mapping[str, Any],
+    verified_outcome: Mapping[str, Any],
+    attribution_context: Mapping[str, Any],
+) -> None:
+    if verified_outcome["artifact_ref"] != application_receipt["artifact_ref"]:
+        raise ValueError(
+            "verified_outcome.artifact_ref must match the application receipt"
+        )
+    scope = attribution_context["scope"]
+    if scope["corpus_id"] != application_receipt["corpus_id"]:
+        raise ValueError(
+            "attribution_context.scope.corpus_id must match the application receipt"
+        )
+    if scope["surface_id"] != application_receipt["surface_id"]:
+        raise ValueError(
+            "attribution_context.scope.surface_id must match the application receipt"
+        )
+    for key in ("retrieval_snapshot_ref", "policy_snapshot_ref"):
+        expected = application_receipt.get(key)
+        if expected is not None and attribution_context[key] != expected:
+            raise ValueError(
+                f"attribution_context.{key} must match the application receipt"
+            )
+
+
+def _evaluator_proposal(
+    value: object,
+    *,
+    application_receipt: Mapping[str, Any],
+    verified_outcome: Mapping[str, Any],
+    attribution_context: Mapping[str, Any],
+) -> dict[str, Any]:
+    raw = _object(value, "evaluator_proposal")
+    _require_exact_fields(raw, _EVALUATOR_PROPOSAL_FIELDS, "evaluator_proposal")
+    proposal = {
+        "scope": _scope(raw.get("scope"), "evaluator_proposal.scope"),
+        "application_id": _existing_token(
+            raw.get("application_id"), "evaluator_proposal.application_id"
+        ),
+        "artifact_ref": _existing_token(
+            raw.get("artifact_ref"), "evaluator_proposal.artifact_ref"
+        ),
+        "outcome_ref": _opaque_ref(
+            raw.get("outcome_ref"), "evaluator_proposal.outcome_ref"
+        ),
+        "outcome_status": _opaque_ref(
+            raw.get("outcome_status"), "evaluator_proposal.outcome_status"
+        ),
+        "retrieval_snapshot_ref": _opaque_ref(
+            raw.get("retrieval_snapshot_ref"),
+            "evaluator_proposal.retrieval_snapshot_ref",
+        ),
+        "policy_snapshot_ref": _opaque_ref(
+            raw.get("policy_snapshot_ref"), "evaluator_proposal.policy_snapshot_ref"
+        ),
+        "memory_ref_digests": normalize_reward_memory_ref_digests(
+            raw.get("memory_ref_digests"),
+            "evaluator_proposal.memory_ref_digests",
+        ),
+    } | _utility_fields(raw)
+
+    expected_echoes = {
+        "scope": attribution_context["scope"],
+        "application_id": application_receipt["application_id"],
+        "artifact_ref": verified_outcome["artifact_ref"],
+        "outcome_ref": verified_outcome["outcome_ref"],
+        "outcome_status": verified_outcome["outcome_status"],
+        "retrieval_snapshot_ref": attribution_context["retrieval_snapshot_ref"],
+        "policy_snapshot_ref": attribution_context["policy_snapshot_ref"],
+    }
+    for key, expected in expected_echoes.items():
+        if proposal[key] != expected:
+            raise ValueError(f"evaluator_proposal.{key} does not match trusted context")
+    _validate_attribution_subject(
+        proposal["memory_ref_digests"],
+        attribution_level=proposal["attribution_level"],
+        application_memory_ref_digests=application_receipt["memory_ref_digests"],
+    )
+    return proposal
+
+
+def _observation_id(observation: Mapping[str, Any]) -> str:
+    identity = {
+        key: observation[key]
+        for key in (
+            "schema_version",
+            "scope",
+            "application_receipt_id",
+            "memory_ref_digests",
+            "retrieval_snapshot_ref",
+            "policy_snapshot_ref",
+            "outcome_ref",
+            "attribution_level",
+            "evidence_basis",
+            "evidence_refs",
+            "evaluator_ref",
+            "evaluation_version",
+        )
+    }
+    encoded = json.dumps(
+        identity,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return f"muo_{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _normalize_observation(value: object) -> dict[str, Any]:
+    raw = _object(value, "observation")
+    _require_exact_fields(raw, _OBSERVATION_FIELDS, "observation")
+    if raw.get("schema_version") != MEMORY_UTILITY_OBSERVATION_SCHEMA_VERSION:
+        raise ValueError(
+            "observation.schema_version must be memory_utility_observation_v0"
+        )
+    for key in (
+        "grants_new_action_authority",
+        "provider_write_performed",
+        "external_writes_performed",
+        "raw_content_captured",
+    ):
+        _false_boundary(raw, key, "observation")
+
+    normalized = (
+        {
+            "schema_version": MEMORY_UTILITY_OBSERVATION_SCHEMA_VERSION,
+            "observation_id": _opaque_ref(
+                raw.get("observation_id"), "observation.observation_id"
+            ),
+            "scope": _scope(raw.get("scope"), "observation.scope"),
+            "application_receipt_id": _opaque_ref(
+                raw.get("application_receipt_id"),
+                "observation.application_receipt_id",
+            ),
+            "memory_ref_digests": normalize_reward_memory_ref_digests(
+                raw.get("memory_ref_digests"),
+                "observation.memory_ref_digests",
+            ),
+            "retrieval_snapshot_ref": _opaque_ref(
+                raw.get("retrieval_snapshot_ref"),
+                "observation.retrieval_snapshot_ref",
+            ),
+            "policy_snapshot_ref": _opaque_ref(
+                raw.get("policy_snapshot_ref"), "observation.policy_snapshot_ref"
+            ),
+            "outcome_ref": _opaque_ref(
+                raw.get("outcome_ref"), "observation.outcome_ref"
+            ),
+        }
+        | _utility_fields(raw)
+        | {
+            "created_at": _timestamp(raw.get("created_at"), "observation.created_at"),
+            "grants_new_action_authority": False,
+            "provider_write_performed": False,
+            "external_writes_performed": False,
+            "raw_content_captured": False,
+        }
+    )
+    if normalized["observation_id"] != _observation_id(normalized):
+        raise ValueError("observation.observation_id does not match canonical identity")
+    return normalized
+
+
+def build_reward_memory_utility_observation(
+    application_receipt: Mapping[str, Any],
+    verified_outcome: Mapping[str, Any],
+    attribution_context: Mapping[str, Any],
+    evaluator_proposal: Mapping[str, Any],
+    *,
+    created_at: str,
+) -> dict[str, Any]:
+    """Bind a typed evaluator proposal to trusted execution and outcome facts."""
+
+    application, application_receipt_id = _application_receipt(application_receipt)
+    outcome = _verified_outcome(verified_outcome)
+    context = _attribution_context(attribution_context)
+    _validate_bindings(application, outcome, context)
+    proposal = _evaluator_proposal(
+        evaluator_proposal,
+        application_receipt=application,
+        verified_outcome=outcome,
+        attribution_context=context,
+    )
+    observation = {
+        "schema_version": MEMORY_UTILITY_OBSERVATION_SCHEMA_VERSION,
+        "observation_id": "",
+        "scope": context["scope"],
+        "application_receipt_id": application_receipt_id,
+        "memory_ref_digests": proposal["memory_ref_digests"],
+        "retrieval_snapshot_ref": context["retrieval_snapshot_ref"],
+        "policy_snapshot_ref": context["policy_snapshot_ref"],
+        "outcome_ref": outcome["outcome_ref"],
+        "utility_label": proposal["utility_label"],
+        "attribution_level": proposal["attribution_level"],
+        "evidence_basis": proposal["evidence_basis"],
+        "confidence": proposal["confidence"],
+        "reason_codes": proposal["reason_codes"],
+        "evidence_refs": proposal["evidence_refs"],
+        "evaluator_ref": proposal["evaluator_ref"],
+        "evaluation_version": proposal["evaluation_version"],
+        "created_at": _timestamp(created_at, "created_at"),
+        "grants_new_action_authority": False,
+        "provider_write_performed": False,
+        "external_writes_performed": False,
+        "raw_content_captured": False,
+    }
+    observation["observation_id"] = _observation_id(observation)
+    return validate_reward_memory_utility_observation(
+        observation,
+        application_receipt=application_receipt,
+        verified_outcome=verified_outcome,
+        attribution_context=attribution_context,
+    )
+
+
+def validate_reward_memory_utility_observation(
+    observation: Mapping[str, Any],
+    *,
+    application_receipt: Mapping[str, Any] | None = None,
+    verified_outcome: Mapping[str, Any] | None = None,
+    attribution_context: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Validate structure alone, or also bind all supplied trusted facts."""
+
+    normalized = _normalize_observation(observation)
+    trusted_values = (application_receipt, verified_outcome, attribution_context)
+    if all(value is None for value in trusted_values):
+        return normalized
+    if any(value is None for value in trusted_values):
+        raise ValueError(
+            "application_receipt, verified_outcome, and attribution_context "
+            "must be supplied together"
+        )
+
+    application, application_receipt_id = _application_receipt(application_receipt)
+    outcome = _verified_outcome(verified_outcome)
+    context = _attribution_context(attribution_context)
+    _validate_bindings(application, outcome, context)
+    expected_bindings = {
+        "scope": context["scope"],
+        "application_receipt_id": application_receipt_id,
+        "retrieval_snapshot_ref": context["retrieval_snapshot_ref"],
+        "policy_snapshot_ref": context["policy_snapshot_ref"],
+        "outcome_ref": outcome["outcome_ref"],
+    }
+    for key, expected in expected_bindings.items():
+        if normalized[key] != expected:
+            raise ValueError(f"observation.{key} does not match trusted context")
+    _validate_attribution_subject(
+        normalized["memory_ref_digests"],
+        attribution_level=normalized["attribution_level"],
+        application_memory_ref_digests=application["memory_ref_digests"],
+    )
+    return normalized

--- a/tests/capabilities/test_reward_memory_utility_attribution.py
+++ b/tests/capabilities/test_reward_memory_utility_attribution.py
@@ -1,0 +1,531 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+import pytest
+
+from loopx.capabilities.reward_memory.memory_utility import (
+    MEMORY_UTILITY_OBSERVATION_SCHEMA_VERSION,
+    build_reward_memory_utility_observation,
+    reward_memory_application_receipt_id,
+    validate_reward_memory_utility_observation,
+)
+from loopx.capabilities.reward_memory.dogfood import (
+    build_reward_memory_dogfood_batch,
+    build_reward_memory_dogfood_receipt,
+)
+
+
+CREATED_AT = "2026-08-15T00:00:00Z"
+MEMORY_A = "0123456789abcdef"
+MEMORY_B = "fedcba9876543210"
+
+
+def application_receipt(*, memories: list[str] | None = None) -> dict[str, Any]:
+    return {
+        "schema_version": "reward_memory_application_receipt_v0",
+        "application_id": "application:issue-3214",
+        "artifact_ref": "artifact:patch-3214",
+        "corpus_id": "reward-memory-corpus",
+        "surface_id": "loopx.issue_fix",
+        "mode": "function_boundary",
+        "query_kind": "business_recall",
+        "query_evidence": [
+            {
+                "query_digest": "aabbccddeeff0011",
+                "query_summary": "reviewed guidance for this patch",
+                "exact_query_exposed": False,
+            }
+        ],
+        "outcome": "applied",
+        "memory_ref_digests": memories or [MEMORY_A],
+        "reasoning_summary": "Applied the recalled guidance to the patch.",
+        "current_artifact_verified": True,
+        "result_readback_verified": True,
+        "provider_call_count": 1,
+        "model_reasoning_preserved": True,
+        "grants_new_action_authority": False,
+        "external_writes_performed": False,
+        "raw_content_captured": False,
+    }
+
+
+def verified_outcome() -> dict[str, Any]:
+    return {
+        "verified": True,
+        "outcome_ref": "effect:test-suite:3214",
+        "artifact_ref": "artifact:patch-3214",
+        "outcome_status": "succeeded",
+    }
+
+
+def attribution_context() -> dict[str, Any]:
+    return {
+        "scope": {
+            "agent_id": "codex-memory-agent",
+            "project_id": "loopx-project",
+            "corpus_id": "reward-memory-corpus",
+            "surface_id": "loopx.issue_fix",
+        },
+        "retrieval_snapshot_ref": "retrieval-snapshot:3214",
+        "policy_snapshot_ref": "policy-snapshot:v1",
+    }
+
+
+def evaluator_proposal(
+    *,
+    memories: list[str] | None = None,
+    utility_label: str = "unknown",
+    attribution_level: str = "set",
+    evidence_basis: str = "insufficient",
+    evidence_refs: list[str] | None = None,
+    confidence: float = 0.0,
+) -> dict[str, Any]:
+    context = attribution_context()
+    outcome = verified_outcome()
+    return {
+        "scope": dict(context["scope"]),
+        "application_id": "application:issue-3214",
+        "artifact_ref": outcome["artifact_ref"],
+        "outcome_ref": outcome["outcome_ref"],
+        "outcome_status": outcome["outcome_status"],
+        "retrieval_snapshot_ref": context["retrieval_snapshot_ref"],
+        "policy_snapshot_ref": context["policy_snapshot_ref"],
+        "memory_ref_digests": memories or [MEMORY_A],
+        "utility_label": utility_label,
+        "attribution_level": attribution_level,
+        "evidence_basis": evidence_basis,
+        "confidence": confidence,
+        "reason_codes": ["application-is-not-causal-evidence"],
+        "evidence_refs": evidence_refs or [],
+        "evaluator_ref": "evaluator:fixture",
+        "evaluation_version": "evaluation:v1",
+    }
+
+
+def build(
+    *,
+    application: dict[str, Any] | None = None,
+    outcome: dict[str, Any] | None = None,
+    context: dict[str, Any] | None = None,
+    proposal: dict[str, Any] | None = None,
+    created_at: str = CREATED_AT,
+) -> dict[str, Any]:
+    return build_reward_memory_utility_observation(
+        application or application_receipt(),
+        outcome or verified_outcome(),
+        context or attribution_context(),
+        proposal or evaluator_proposal(),
+        created_at=created_at,
+    )
+
+
+def dogfood_observation(application: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "raw_content_captured": False,
+        "domain_family": "issue_fix",
+        "domain_id": "issue_fix.memory_utility_boundary",
+        "application_receipt": application,
+        "module_outcome": {
+            "artifact_ref": application["artifact_ref"],
+            "outcome_verified": True,
+            "outcome_ref": "effect:test-suite:3214",
+            "outcome_status": "succeeded",
+            "summary": "Verified focused memory-utility boundary fixture.",
+        },
+        "cost": {
+            "latency_ms": 1,
+            "model_tokens": 0,
+            "provider_call_count": 1,
+        },
+        "intervention": {"count": 0, "summary": None},
+        "bot_feedback": {"captured": False, "summary": None},
+    }
+
+
+def test_applied_verified_success_is_unknown_when_attribution_is_insufficient() -> None:
+    observation = build()
+
+    assert observation["schema_version"] == MEMORY_UTILITY_OBSERVATION_SCHEMA_VERSION
+    assert observation["utility_label"] == "unknown"
+    assert observation["evidence_basis"] == "insufficient"
+    assert observation["attribution_level"] == "set"
+    assert observation["outcome_ref"] == verified_outcome()["outcome_ref"]
+    assert observation["application_receipt_id"].startswith("rma_")
+    assert observation[
+        "application_receipt_id"
+    ] == reward_memory_application_receipt_id(application_receipt())
+
+
+def test_applied_memory_can_be_harmful_with_deterministic_evidence() -> None:
+    proposal = evaluator_proposal(
+        utility_label="harmful",
+        attribution_level="item",
+        evidence_basis="deterministic_effect",
+        evidence_refs=["test-result:regression-3214"],
+        confidence=0.98,
+    )
+
+    observation = build(proposal=proposal)
+
+    assert observation["utility_label"] == "harmful"
+    assert observation["memory_ref_digests"] == [MEMORY_A]
+    assert observation["confidence"] == 0.98
+
+
+def test_multi_memory_attribution_preserves_set_level_credit() -> None:
+    application = application_receipt(memories=[MEMORY_A, MEMORY_B])
+    proposal = evaluator_proposal(memories=[MEMORY_B, MEMORY_A])
+
+    observation = build(application=application, proposal=proposal)
+
+    assert observation["attribution_level"] == "set"
+    assert observation["memory_ref_digests"] == [MEMORY_A, MEMORY_B]
+
+
+@pytest.mark.parametrize(
+    ("level", "memories", "match"),
+    [
+        ("item", [MEMORY_A, MEMORY_B], "item attribution"),
+        ("item", ["1111111111111111"], "item attribution"),
+        ("set", [MEMORY_A], "complete application memory set"),
+        ("none", [MEMORY_A], "complete application memory set"),
+    ],
+)
+def test_multi_memory_attribution_rejects_copied_or_partial_credit(
+    level: str, memories: list[str], match: str
+) -> None:
+    application = application_receipt(memories=[MEMORY_A, MEMORY_B])
+    proposal = evaluator_proposal(memories=memories, attribution_level=level)
+
+    with pytest.raises(ValueError, match=match):
+        build(application=application, proposal=proposal)
+
+
+def test_none_attribution_requires_unknown() -> None:
+    proposal = evaluator_proposal(
+        utility_label="helpful",
+        attribution_level="none",
+        evidence_basis="evaluator_inference",
+        evidence_refs=["evaluation:one"],
+    )
+
+    with pytest.raises(ValueError, match="none attribution"):
+        build(proposal=proposal)
+
+
+@pytest.mark.parametrize(
+    ("path", "replacement"),
+    [
+        (("scope", "agent_id"), "different-agent"),
+        (("application_id",), "application:different"),
+        (("artifact_ref",), "artifact:different"),
+        (("outcome_ref",), "effect:different"),
+        (("outcome_status",), "failed"),
+        (("retrieval_snapshot_ref",), "retrieval-snapshot:different"),
+        (("policy_snapshot_ref",), "policy-snapshot:different"),
+    ],
+)
+def test_evaluator_echo_drift_is_rejected(
+    path: tuple[str, ...], replacement: str
+) -> None:
+    proposal = evaluator_proposal()
+    target: dict[str, Any] = proposal
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = replacement
+
+    with pytest.raises(ValueError, match="does not match trusted context"):
+        build(proposal=proposal)
+
+
+@pytest.mark.parametrize("scope_field", ["corpus_id", "surface_id"])
+def test_trusted_scope_must_match_application_receipt(scope_field: str) -> None:
+    context = attribution_context()
+    context["scope"][scope_field] = "different-scope"
+    proposal = evaluator_proposal()
+    proposal["scope"] = dict(context["scope"])
+
+    with pytest.raises(ValueError, match=scope_field):
+        build(context=context, proposal=proposal)
+
+
+@pytest.mark.parametrize(
+    "snapshot_field", ["retrieval_snapshot_ref", "policy_snapshot_ref"]
+)
+def test_trusted_snapshot_must_match_application_receipt_when_present(
+    snapshot_field: str,
+) -> None:
+    application = application_receipt()
+    application[snapshot_field] = "snapshot:trusted"
+    context = attribution_context()
+    context[snapshot_field] = "snapshot:stale"
+    proposal = evaluator_proposal()
+    proposal[snapshot_field] = context[snapshot_field]
+
+    with pytest.raises(ValueError, match=snapshot_field):
+        build(application=application, context=context, proposal=proposal)
+
+
+def test_verified_outcome_must_be_verified_and_match_artifact() -> None:
+    unverified = verified_outcome()
+    unverified["verified"] = False
+    with pytest.raises(ValueError, match="verified.*true"):
+        build(outcome=unverified)
+
+    mismatched = verified_outcome()
+    mismatched["artifact_ref"] = "artifact:different"
+    proposal = evaluator_proposal()
+    proposal["artifact_ref"] = mismatched["artifact_ref"]
+    with pytest.raises(ValueError, match="artifact_ref must match"):
+        build(outcome=mismatched, proposal=proposal)
+
+
+def test_observation_id_is_retry_stable_and_version_or_evidence_sensitive() -> None:
+    proposal = evaluator_proposal(
+        utility_label="helpful",
+        evidence_basis="evaluator_inference",
+        evidence_refs=["evaluation:evidence-a"],
+        confidence=0.7,
+    )
+    first = build(proposal=proposal)
+    retried = build(proposal=proposal, created_at="2026-08-15T00:01:00Z")
+
+    assert first["observation_id"] == retried["observation_id"]
+    assert first["created_at"] != retried["created_at"]
+
+    new_version = deepcopy(proposal)
+    new_version["evaluation_version"] = "evaluation:v2"
+    new_evidence = deepcopy(proposal)
+    new_evidence["evidence_refs"] = ["evaluation:evidence-b"]
+    assert build(proposal=new_version)["observation_id"] != first["observation_id"]
+    assert build(proposal=new_evidence)["observation_id"] != first["observation_id"]
+
+
+def test_observation_id_is_an_evaluation_key_not_judgment_content() -> None:
+    proposal = evaluator_proposal(
+        utility_label="helpful",
+        evidence_basis="deterministic_effect",
+        evidence_refs=["test-result:3214"],
+        confidence=0.9,
+    )
+    first = build(proposal=proposal)
+    changed_judgment = deepcopy(proposal)
+    changed_judgment["utility_label"] = "harmful"
+    changed_judgment["confidence"] = 0.2
+    changed_judgment["reason_codes"] = ["same-evaluation-key-conflict"]
+
+    second = build(
+        proposal=changed_judgment,
+        created_at="2026-08-16T00:00:00+00:00",
+    )
+
+    assert second["observation_id"] == first["observation_id"]
+
+
+def test_full_application_receipt_digest_participates_in_identity() -> None:
+    first = build()
+    changed_receipt = application_receipt()
+    changed_receipt["reasoning_summary"] = "Applied the same guidance after review."
+
+    second = build(application=changed_receipt)
+
+    assert second["application_receipt_id"] != first["application_receipt_id"]
+    assert second["observation_id"] != first["observation_id"]
+
+
+@pytest.mark.parametrize(
+    ("mutation", "match"),
+    [
+        ("missing_query_evidence", "missing=.*query_evidence"),
+        ("unknown_provider_field", "unknown=.*provider_uri"),
+        ("unpreserved_reasoning", "model_reasoning_preserved must be true"),
+    ],
+)
+def test_application_receipt_identity_requires_a_complete_trusted_envelope(
+    mutation: str,
+    match: str,
+) -> None:
+    application = application_receipt()
+    if mutation == "missing_query_evidence":
+        del application["query_evidence"]
+    elif mutation == "unknown_provider_field":
+        application["provider_uri"] = "viking://private/exact-provider-reference"
+    else:
+        application["model_reasoning_preserved"] = False
+
+    with pytest.raises(ValueError, match=match):
+        reward_memory_application_receipt_id(application)
+
+
+def test_validator_rejects_tampered_observation_id() -> None:
+    observation = build()
+    observation["observation_id"] = "muo_" + "0" * 64
+
+    with pytest.raises(ValueError, match="canonical identity"):
+        validate_reward_memory_utility_observation(
+            observation,
+            application_receipt=application_receipt(),
+            verified_outcome=verified_outcome(),
+            attribution_context=attribution_context(),
+        )
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "raw_memory",
+        "transcript",
+        "provider_uri",
+        "local_path",
+        "writeback",
+        "lifecycle",
+    ],
+)
+def test_evaluator_proposal_rejects_unknown_private_or_authority_fields(
+    field: str,
+) -> None:
+    proposal = evaluator_proposal()
+    proposal[field] = "not-accepted"
+
+    with pytest.raises(ValueError, match="unknown"):
+        build(proposal=proposal)
+
+
+@pytest.mark.parametrize(
+    ("target", "unsafe_ref"),
+    [
+        ("evidence", "/Users/example/private-result.json"),
+        ("evidence", "file:///tmp/private-result.json"),
+        ("evidence", "viking://resources/private/memory.json"),
+        ("retrieval", "/private/tmp/retrieval.json"),
+        ("policy", "https://provider.invalid/policy/private"),
+        ("scope", "C:\\Users\\example\\project"),
+    ],
+)
+def test_public_observation_refs_reject_local_paths_and_provider_uris(
+    target: str, unsafe_ref: str
+) -> None:
+    context = attribution_context()
+    proposal = evaluator_proposal()
+    if target == "evidence":
+        proposal["evidence_refs"] = [unsafe_ref]
+    elif target == "retrieval":
+        context["retrieval_snapshot_ref"] = unsafe_ref
+        proposal["retrieval_snapshot_ref"] = unsafe_ref
+    elif target == "policy":
+        context["policy_snapshot_ref"] = unsafe_ref
+        proposal["policy_snapshot_ref"] = unsafe_ref
+    else:
+        context["scope"]["project_id"] = unsafe_ref
+        proposal["scope"]["project_id"] = unsafe_ref
+
+    with pytest.raises(ValueError, match="opaque public-safe reference"):
+        build(context=context, proposal=proposal)
+
+
+def test_application_receipt_rejects_false_boundaries() -> None:
+    authority_receipt = application_receipt()
+    authority_receipt["grants_new_action_authority"] = True
+    with pytest.raises(ValueError, match="must be false"):
+        build(application=authority_receipt)
+
+
+@pytest.mark.parametrize(
+    "memory_ref",
+    [
+        "provider-private-ref",
+        "ABCDEF0123456789",
+        "sha256:not-a-digest",
+    ],
+)
+def test_memory_references_must_remain_canonical_opaque_digests(
+    memory_ref: str,
+) -> None:
+    application = application_receipt(memories=[memory_ref])
+    proposal = evaluator_proposal(memories=[memory_ref])
+
+    with pytest.raises(ValueError, match="canonical opaque memory digests"):
+        build(application=application, proposal=proposal)
+
+
+@pytest.mark.parametrize(
+    "memory_ref",
+    [
+        "viking://private/exact-provider-reference",
+        "/Users/example/private-memory.json",
+        "ABCDEF0123456789",
+    ],
+)
+def test_dogfood_builder_rejects_noncanonical_memory_references(
+    memory_ref: str,
+) -> None:
+    application = application_receipt(memories=[memory_ref])
+
+    with pytest.raises(ValueError, match="memory_ref_digests"):
+        build_reward_memory_dogfood_receipt(dogfood_observation(application))
+
+
+@pytest.mark.parametrize(
+    "memory_ref",
+    [
+        "viking://private/exact-provider-reference",
+        "/Users/example/private-memory.json",
+        "ABCDEF0123456789",
+    ],
+)
+def test_dogfood_batch_rejects_noncanonical_memory_references(
+    memory_ref: str,
+) -> None:
+    receipt = build_reward_memory_dogfood_receipt(
+        dogfood_observation(application_receipt())
+    )
+    receipt["memory_ref_digests"] = [memory_ref]
+
+    with pytest.raises(ValueError, match="memory_ref_digests"):
+        build_reward_memory_dogfood_batch([receipt], [], evaluation={})
+
+
+def test_observation_is_opaque_and_cannot_grant_authority_or_write() -> None:
+    observation = build()
+    for key in (
+        "grants_new_action_authority",
+        "provider_write_performed",
+        "external_writes_performed",
+        "raw_content_captured",
+    ):
+        assert observation[key] is False
+
+    assert validate_reward_memory_utility_observation(observation) == observation
+    unknown = dict(observation)
+    unknown["transcript"] = "not accepted"
+    with pytest.raises(ValueError, match="unknown"):
+        validate_reward_memory_utility_observation(unknown)
+
+
+def test_non_unknown_utility_requires_evidence_and_rejects_duplicate_refs() -> None:
+    missing_evidence = evaluator_proposal(
+        utility_label="helpful",
+        evidence_basis="evaluator_inference",
+    )
+    with pytest.raises(ValueError, match="requires evidence_refs"):
+        build(proposal=missing_evidence)
+
+    duplicate = evaluator_proposal()
+    duplicate["reason_codes"] = ["reason:a", "reason:a"]
+    with pytest.raises(ValueError, match="duplicates"):
+        build(proposal=duplicate)
+
+
+@pytest.mark.parametrize(
+    "evidence_basis",
+    ["owner_correction", "controlled_replay", "deterministic_effect"],
+)
+def test_strong_evidence_basis_requires_a_reference_even_for_unknown(
+    evidence_basis: str,
+) -> None:
+    proposal = evaluator_proposal(evidence_basis=evidence_basis)
+
+    with pytest.raises(ValueError, match="strong evidence basis"):
+        build(proposal=proposal)


### PR DESCRIPTION
## Summary

- add the provider-neutral `memory_utility_observation_v0` Stage 1 contract under the existing Reward Memory capability
- bind complete Stage 3 application receipts, verified outcomes, scope, retrieval/policy snapshots, evaluator identity, and evidence into a stable observation identity
- keep application disposition separate from post-outcome utility, including `applied + success -> unknown` when attribution evidence is insufficient
- version Stage 5 dogfood receipts/batches from v0 to v1 so `applied`/`not_applied`/`refuted` no longer imply `helpful`/`harmful` utility
- keep the optional evaluator default-off, proposal-only, fail-open, and unable to grant authority or perform memory/provider/external writes
- reject exact provider references, local paths, malformed envelopes, duplicate application settlements, and non-canonical memory digests at both build and batch boundaries

## Compatibility and identity

This intentionally changes the preview dogfood output schema from `reward_memory_dogfood_receipt_v0` / `reward_memory_dogfood_batch_v0` to v1 instead of silently redefining `hit`, `miss`, and `refute`.

The dogfood `receipt_id` identifies one application/outcome settlement and deliberately excludes evaluator delivery state, so evaluator absence, rejection, retry, or new evidence cannot duplicate disposition or cost metrics. Utility delivery has its own stable `observation_id`; a changed evaluator version or new evidence creates a new observation identity.

## Validation

- `python -m pytest -q`: **3228 passed, 2 skipped** on a clean, non-concurrent rerun
- focused utility attribution tests: **54 passed**
- Reward Memory related tests: **114 passed**
- all six Reward Memory public smokes passed, including the Stage 5 dogfood CLI path
- `loopx canary premerge --from-git-diff --no-progress`: passed; 17/17 selected canaries/boundary checks passed, 0 warnings, 0 manual holds
- capability placement, corpus registry, public-boundary, changed-path Ruff, compile, and diff checks passed
- task contract scan returned `ok=True`; its only two warnings were the expected absence of the worktree-local `.loopx/registry.json`

The first full-suite run was executed while other validations were active and produced one unrelated timing failure in `tests/extensions/test_extension_runtime.py::test_extension_run_terminates_provider_on_timeout` (`execution_failed` vs `timeout`). That test passed immediately in isolation, and the subsequent non-concurrent full-suite run passed as reported above.

## Out of scope

- no Stage 2 reducer or read-only utility projection
- no retrieval ranking or semantic candidate filtering change
- no scheduler, quota, todo, memory lifecycle, or main-lane behavior change
- no OpenViking/provider rank-prior integration or writeback
- no new capability, global supervisor, or execution authority

Refs #3214
