### PR TITLE
feat(benchmark): add post-run case insight monitor contract

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -275,6 +275,67 @@ LoopX advantage. `score_claim_eligible=true` only permits the official score and
 matched-pair gates to run; `score_claim_countable` and `matched_pair_countable` stay
 false in this receipt. Those remain separate verifier and comparison contracts.
 
+## Post-run case insight monitor
+
+Benchmark startup should create one `continuous_monitor` todo. Whenever a case
+reaches a new material scored state, that monitor runs a post-run analyst brief and
+writes one private `benchmark_case_insight_v0` artifact. This monitor is part of the
+benchmark lifecycle, not an optional cleanup pass.
+
+Use this analyst hint:
+
+> After the solver has stopped and scoring is complete, read the task, real
+> trajectory, final patch or workspace, hidden tests, grader or verifier, and full
+> failure and score details; explain the decisive evidence, why the outcome
+> happened, whether it was expected, and what LoopX should test or change next.
+
+The solver and analyst are separate roles. The solver remains unable to access
+hidden tests, evaluator sources, expected answers, or official feedback. Only the
+post-run analyst may read the complete private evaluation evidence, and only after
+the solver is terminal and scoring is complete.
+
+Record the result in this compact shape:
+
+```json
+{
+  "schema_version": "benchmark_case_insight_v0",
+  "case": {
+    "benchmark_id": "<public-id>",
+    "case_id": "<public-id>",
+    "arm": "<baseline-or-treatment>"
+  },
+  "outcome": {
+    "status": "<completed-or-runner-invalid>",
+    "score": "<official-score-or-null>",
+    "countable": "<true-or-false>"
+  },
+  "evidence_reviewed": [
+    "task",
+    "real_trajectory",
+    "final_patch_or_workspace",
+    "hidden_tests",
+    "grader_or_verifier",
+    "failure_and_score_details"
+  ],
+  "insight": {
+    "approach_summary": "<what-the-solver-tried>",
+    "decisive_evidence": ["<specific-observation>"],
+    "why_this_outcome": "<causal-explanation>",
+    "expectedness": "<expected-surprising-mixed-or-unknown>",
+    "baseline_treatment_difference": "<difference-or-not-yet-compared>",
+    "loopx_implication": "<reusable-product-or-experiment-insight>",
+    "next_probe": "<smallest-discriminating-next-step>"
+  },
+  "confidence": "<high-medium-or-low>",
+  "reuse_boundary": "<diagnostic-only-heldout-generalization-or-declared-feedback>"
+}
+```
+
+Keep the artifact and its raw evidence in private benchmark storage. Publish only a
+redacted reusable conclusion. Do not feed case-specific hidden evidence into a
+later scored solver unless the experiment explicitly declares that feedback loop;
+use held-out cases before making a general product claim.
+
 ## Related commands
 
 ```bash

--- a/loopx/capabilities/benchmark_toolkit/catalog_entry.py
+++ b/loopx/capabilities/benchmark_toolkit/catalog_entry.py
@@ -15,12 +15,12 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
     "title": "Benchmark experiment toolkit",
     "status": "active-preview",
     "real_world_anchor": (
-        "provider-neutral permission, artifact, and integrity boundaries for "
-        "benchmark experiments"
+        "provider-neutral permission, integrity, and post-run analysis boundaries "
+        "for benchmark experiments"
     ),
     "user_value": (
-        "Apply fail-closed evidence boundaries without replacing benchmark-native "
-        "runners, verifiers, or scoring semantics."
+        "Keep solving agents answer-denied while giving post-run analysts enough "
+        "evidence and structure to explain benchmark outcomes."
     ),
     "entry_command": "loopx benchmark --help",
     "commands": [
@@ -45,7 +45,85 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
             "purpose": "Classify benchmark artifacts before reading or publishing them.",
             "write_boundary": "path classification only; no file reads or writes",
         },
+        {
+            "command": "loopx capability show benchmark-toolkit --format json",
+            "purpose": (
+                "Read the post-run analyst hint and benchmark_case_insight_v0 "
+                "artifact template."
+            ),
+            "write_boundary": (
+                "read-only catalog; private analysis evidence remains outside "
+                "the solving agent and public repository"
+            ),
+        },
     ],
+    "post_run_case_analysis": {
+        "benchmark_start_hint": (
+            "When starting a benchmark, add one continuous_monitor todo that runs "
+            "the post-run analyst brief on every material scored-case transition."
+        ),
+        "monitor_todo_template": {
+            "task_class": "continuous_monitor",
+            "action_kind": "benchmark_case_insight_monitor",
+            "trigger": "material_scored_case_transition",
+            "text": (
+                "On each material scored-case transition, read the complete private "
+                "evaluation evidence, write one benchmark_case_insight_v0, and report "
+                "only new reusable insight."
+            ),
+        },
+        "hint": (
+            "After the solver has stopped and scoring is complete, read the task, "
+            "real trajectory, final patch or workspace, hidden tests, grader or "
+            "verifier, and full failure and score details; explain the decisive "
+            "evidence, why the outcome happened, whether it was expected, and what "
+            "LoopX should test or change next."
+        ),
+        "role_boundary": {
+            "solver": (
+                "must not access hidden tests, grader or verifier sources, expected "
+                "answers, or official feedback during the solving phase"
+            ),
+            "post_run_analyst": (
+                "may read the full private case evidence only after the solver is "
+                "terminal and scoring is complete"
+            ),
+        },
+        "artifact_template": {
+            "schema_version": "benchmark_case_insight_v0",
+            "case": {
+                "benchmark_id": "<public-id>",
+                "case_id": "<public-id>",
+                "arm": "<baseline-or-treatment>",
+            },
+            "outcome": {
+                "status": "<completed-or-runner-invalid>",
+                "score": "<official-score-or-null>",
+                "countable": "<true-or-false>",
+            },
+            "evidence_reviewed": [
+                "task",
+                "real_trajectory",
+                "final_patch_or_workspace",
+                "hidden_tests",
+                "grader_or_verifier",
+                "failure_and_score_details",
+            ],
+            "insight": {
+                "approach_summary": "<what-the-solver-tried>",
+                "decisive_evidence": ["<specific-observation>"],
+                "why_this_outcome": "<causal-explanation>",
+                "expectedness": "<expected-surprising-mixed-or-unknown>",
+                "baseline_treatment_difference": "<difference-or-not-yet-compared>",
+                "loopx_implication": "<reusable-product-or-experiment-insight>",
+                "next_probe": "<smallest-discriminating-next-step>",
+            },
+            "confidence": "<high-medium-or-low>",
+            "reuse_boundary": (
+                "<diagnostic-only-heldout-generalization-or-declared-feedback>"
+            ),
+        },
+    },
     "implemented_protocols": [
         {
             "schema_version": "benchmark_integrity_qualification_v0",
@@ -62,6 +140,11 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
             "module": "loopx.capabilities.benchmark_toolkit.run_permissions",
             "doc": "loopx/capabilities/benchmark_toolkit/README.md",
         },
+        {
+            "schema_version": "benchmark_case_insight_v0",
+            "module": "loopx.capabilities.benchmark_toolkit.catalog_entry",
+            "doc": "loopx/capabilities/benchmark_toolkit/README.md",
+        },
     ],
     "smokes": ["python -m pytest tests/capabilities/test_benchmark_toolkit.py -q"],
     "docs": ["loopx/capabilities/benchmark_toolkit/README.md"],
@@ -70,10 +153,11 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
         "Raw trajectories are private local inputs to integrity qualification and are never copied into receipts, ledgers, docs, or PR artifacts.",
         "A clean trajectory scan is not isolation proof: runner-owned permission and verifier-order attestations are mandatory and fail closed when absent.",
         "Integrity qualification establishes countability eligibility only; an independent official result and matched experiment contract are still required.",
-        "Benchmark-family runners remain outside the active capability; the toolkit owns only provider-neutral permission, artifact, and integrity policy.",
+        "Post-run analyst access never widens the solving agent's evidence boundary or grants feedback reuse in another scored run.",
+        "Benchmark-family runners remain outside the active capability; the toolkit owns only provider-neutral permission, artifact, integrity, and analyst-brief policy.",
     ],
     "next_real_step": (
-        "Qualify one private local run and block the paired claim when either "
-        "trajectory evidence or runner isolation attestation is incomplete."
+        "After each scored case, keep solver integrity separate and write one "
+        "private benchmark_case_insight_v0 from the complete evaluation evidence."
     ),
 }

--- a/tests/capabilities/test_benchmark_toolkit.py
+++ b/tests/capabilities/test_benchmark_toolkit.py
@@ -14,8 +14,57 @@ from loopx.capabilities.benchmark_toolkit import (
     REQUIRED_RUNTIME_ATTESTATIONS,
     build_benchmark_integrity_qualification,
 )
+from loopx.capabilities.catalog import build_capability_detail_packet
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_catalog_exposes_post_run_case_insight_monitor_contract() -> None:
+    capability = build_capability_detail_packet("benchmark-toolkit")["capability"]
+    analysis = capability["post_run_case_analysis"]
+
+    assert "continuous_monitor" in analysis["benchmark_start_hint"]
+    assert analysis["monitor_todo_template"] == {
+        "task_class": "continuous_monitor",
+        "action_kind": "benchmark_case_insight_monitor",
+        "trigger": "material_scored_case_transition",
+        "text": (
+            "On each material scored-case transition, read the complete private "
+            "evaluation evidence, write one benchmark_case_insight_v0, and report "
+            "only new reusable insight."
+        ),
+    }
+    hint = analysis["hint"]
+    for evidence_name in (
+        "real trajectory",
+        "hidden tests",
+        "grader or verifier",
+        "failure and score details",
+    ):
+        assert evidence_name in hint
+
+    assert "must not access" in analysis["role_boundary"]["solver"]
+    assert "only after" in analysis["role_boundary"]["post_run_analyst"]
+    artifact = analysis["artifact_template"]
+    assert artifact["schema_version"] == "benchmark_case_insight_v0"
+    assert artifact["evidence_reviewed"] == [
+        "task",
+        "real_trajectory",
+        "final_patch_or_workspace",
+        "hidden_tests",
+        "grader_or_verifier",
+        "failure_and_score_details",
+    ]
+    assert set(artifact["insight"]) == {
+        "approach_summary",
+        "decisive_evidence",
+        "why_this_outcome",
+        "expectedness",
+        "baseline_treatment_difference",
+        "loopx_implication",
+        "next_probe",
+    }
+    assert "reuse_boundary" in artifact
 
 
 def _attestation() -> dict[str, object]:


### PR DESCRIPTION
## Summary

- make one `continuous_monitor` todo part of benchmark startup, triggered by each material scored-case transition;
- keep the solving agent answer-denied while allowing a separate post-run analyst to read the complete private evaluation evidence after scoring;
- publish a compact `benchmark_case_insight_v0` template for causal findings, comparison insight, the next probe, confidence, and reuse boundaries.

## Why

A score says what happened but rarely explains why. Benchmark work benefits from a lightweight, repeatable post-run review that can inspect the real trajectory, final patch, hidden tests, grader or verifier, and full failure details without contaminating the solving phase.

This head replaces the earlier weak-signal trajectory reducer. It deliberately adds no parser, heuristic diagnosis engine, case-specific rules, or public receipt generator. The reusable contract is only the startup monitor hint, analyst hint, role boundary, and insight artifact shape.

## Boundaries

- The solving agent still cannot access hidden tests, evaluator sources, expected answers, or official feedback.
- The analyst runs only after the solver is terminal and scoring is complete.
- Raw evidence and case insight artifacts remain in private benchmark storage; only redacted reusable conclusions may be published.
- Case-specific hidden evidence is not fed into another scored run unless that feedback loop is explicitly declared.
- This PR does not launch benchmark jobs or change scoring, task semantics, runner behavior, submission behavior, or solver permissions.

## Validation

- `python -m pytest tests/capabilities/test_benchmark_toolkit.py tests/capabilities/test_capability_extension_registry.py -q` — 33 passed
- Ruff format/check — passed
- capability catalog JSON readback — passed
- `loopx canary premerge --from-git-diff` — 18/18 automatic checks passed, public/private boundary clean, 0 failures
- expected manual hold: benchmark-sensitive surfaces require maintainer review; this PR is not being self-merged
