### PR TITLE
fix(todos): run declared validation gate on user-role done updates

### DIFF
--- a/loopx/canary/module_metric_baseline.json
+++ b/loopx/canary/module_metric_baseline.json
@@ -103,7 +103,7 @@
     "loopx/todos.py": {
       "any_count": 48,
       "dict_any_count": 0,
-      "lines": 2229
+      "lines": 2249
     },
     "loopx/worker_bridge.py": {
       "any_count": 28,

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -1254,6 +1254,35 @@ def update_goal_todo(
         project=project,
         state_file=state_file,
     )
+    # Run caller-approved validation BEFORE acquiring the mutation lock when
+    # this update writes a completion, mirroring complete_goal_todo's pre-lock
+    # gate (the MUTATION lock deadline is 5s). Agent-role completions keep the
+    # existing in-lock guard error below, so this covers the remaining paths
+    # that can write `status=done` directly (user-role todos with a declared
+    # validation command). Returns a typed failure payload (ok=False) when
+    # validation blocks; otherwise None.
+    if status:
+        try:
+            update_completes_todo = normalize_todo_status(status) == TODO_STATUS_DONE
+        except ValueError:
+            update_completes_todo = False  # invalid status surfaces in-lock, unchanged
+        if update_completes_todo:
+            update_block_match = find_todo_block(
+                resolved_state_file.read_text(encoding="utf-8").splitlines(),
+                todo_id=todo_id,
+                role=role,
+            )
+            if update_block_match and (role or update_block_match[0]) != "agent":
+                validation_failure = run_completion_validation_gate(
+                    state_file=resolved_state_file,
+                    todo_id=todo_id,
+                    role=role,
+                    registry_path=registry_path,
+                    goal_id=goal_id,
+                    dry_run=dry_run,
+                )
+                if validation_failure is not None:
+                    return validation_failure
     with exclusive_file_lock(
         resolved_state_file,
         agent_id=agent_id or claimed_by,

--- a/tests/control_plane/test_todo_completion_validation.py
+++ b/tests/control_plane/test_todo_completion_validation.py
@@ -10,7 +10,7 @@ import pytest
 
 import loopx.control_plane.todos.completion_validation as completion_validation_module
 from loopx.status import parse_active_state_todos
-from loopx.todos import add_goal_todo, complete_goal_todo
+from loopx.todos import add_goal_todo, complete_goal_todo, update_goal_todo
 
 GOAL_ID = "todo-completion-validation"
 AGENT = "codex-author"
@@ -466,3 +466,142 @@ def test_empty_argv_declaration_reports_neutral_message(
     assert receipt is not None
     assert receipt["status"] == "command_malformed"
     assert "validation command must not be empty" in receipt["summary"]
+
+
+def _user_todo(state: Path, todo_id: str) -> dict:
+    todos = parse_active_state_todos(state.read_text(encoding="utf-8"))
+    return next(
+        item
+        for item in todos["user_todos"]["items"]
+        if item["todo_id"] == todo_id
+    )
+
+
+def _spy_validation_runner(monkeypatch: pytest.MonkeyPatch) -> dict:
+    original_runner = completion_validation_module.run_caller_validation
+    calls = {"count": 0}
+
+    def counting_runner(*args, **kwargs):  # type: ignore[no-untyped-def]
+        calls["count"] += 1
+        return original_runner(*args, **kwargs)
+
+    monkeypatch.setattr(
+        completion_validation_module, "run_caller_validation", counting_runner
+    )
+    return calls
+
+
+def test_user_todo_update_done_runs_declared_validation_gate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo = add_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="user",
+        text="Operator-recorded outcome.",
+        task_class="user_action",
+        validation_command=_FAIL_COMMAND,
+        validation_label="caller-declared smoke",
+    )
+    calls = _spy_validation_runner(monkeypatch)
+    result = update_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=str(todo["todo_id"]),
+        status="done",
+        evidence="claim of completion",
+    )
+    # The declared command ran once and blocked the update: nothing committed.
+    assert calls["count"] == 1
+    assert result["ok"] is False
+    assert result["changed"] is False
+    assert result["validation_blocked_completion"] is True
+    receipt = result["validation"]
+    assert receipt["passed"] is False
+    assert receipt["exit_code"] == 1
+    assert receipt["stdout_captured"] is False
+    assert _user_todo(state, str(todo["todo_id"]))["status"] == "open"
+
+
+def test_user_todo_update_done_without_declaration_keeps_fast_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo = add_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="user",
+        text="Operator-recorded outcome.",
+        task_class="user_action",
+    )
+    calls = _spy_validation_runner(monkeypatch)
+    result = update_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=str(todo["todo_id"]),
+        status="done",
+    )
+    assert calls["count"] == 0
+    assert result["ok"] is True
+    assert "validation_blocked_completion" not in result
+    assert _user_todo(state, str(todo["todo_id"]))["status"] == "done"
+
+
+def test_repeated_done_update_does_not_rerun_validation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo = add_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="user",
+        text="Operator-recorded outcome.",
+        task_class="user_action",
+        validation_command=_PASS_COMMAND,
+    )
+    calls = _spy_validation_runner(monkeypatch)
+    first = update_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=str(todo["todo_id"]),
+        status="done",
+        evidence="validated completion",
+    )
+    assert first["ok"] is True
+    assert calls["count"] == 1  # the passing command ran once via the update gate
+    assert _user_todo(state, str(todo["todo_id"]))["status"] == "done"
+
+    second = update_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=str(todo["todo_id"]),
+        status="done",
+        note="re-acknowledged",
+    )
+    # Already-completed short-circuit: the command is not re-run.
+    assert second["ok"] is True
+    assert calls["count"] == 1
+    assert _user_todo(state, str(todo["todo_id"]))["status"] == "done"
+
+
+def test_agent_todo_update_done_keeps_guard_error_without_running_gate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo = _add_todo(registry, validation_command=_FAIL_COMMAND)
+    calls = _spy_validation_runner(monkeypatch)
+    with pytest.raises(ValueError, match="must use complete_goal_todo"):
+        update_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=str(todo["todo_id"]),
+            status="done",
+        )
+    # The gate never runs for agent sections; the pre-existing guard fires.
+    assert calls["count"] == 0
+    assert _agent_todo(state, str(todo["todo_id"]))["status"] == "open"


### PR DESCRIPTION
Closes the update-path bypass audited in #3082 (hole 2 there): a user-role todo declared with a `validation_command` enforced the gate on `todo complete` but silently skipped it on `todo update --status done`, because the update guard only rejects the agent role (`todos.py:1424-1429`) and a user-role todo falls through to the direct `done` write. The declared-field contract is "declared ⇒ enforced, undeclared ⇒ fast path unchanged", independent of which command declares it, so the update path fails closed too.

## Change

In `update_goal_todo`, after `resolve_todo_state_path` and before the exclusive lock — mirroring `complete_goal_todo`'s pre-lock gate (`todos.py:1653-1666`, the MUTATION lock deadline is 5s) — when the normalized requested status is `done`:

- parse the target block read-only and **skip the gate for agent-role sections**, so the existing in-lock guard error ("agent todo completion must use complete_goal_todo") is byte-for-byte unchanged;
- run `run_completion_validation_gate` and return its typed `validation_blocked_completion` payload (`ok=False`, nothing committed) when a declared command does not pass.

The gate's internal fast paths keep everything else unchanged: no declared command → no-op; `dry_run` → no-op; `already_completed` → no-op, so repeated done updates never re-run the command. An invalid `--status` string still surfaces in-lock exactly as before (the pre-lock normalize is try/except-guarded).

## Tests

Four focused additions to `tests/control_plane/test_todo_completion_validation.py` (25 total in the file, all green):

1. user todo + failing declared command via `update --status done` → blocked with typed receipt, state stays `open`, spy confirms exactly 1 execution;
2. user todo without declaration → unchanged fast path, 0 executions, completes;
3. re-update of an already-done todo → `already_completed` short-circuit, still 1 total execution;
4. agent-role update `--status done` → existing guard `ValueError` fires with 0 gate executions.

Canary: honest `todos.py` line-ceiling bump (2229 → 2249) in `loopx/canary/module_metric_baseline.json`; `tests/canary` 20/20.

The audit's open question (hole 3, `todo supersede` also writing `done` gate-free) is intentionally not touched — supersede is void-and-replace, not a completion claim, and the thread is waiting on the maintainer's call between (a) gate it, (b) distinguishable terminal form, (c) exempt.

Refs #3082.