### PR TITLE
fix(lark): route Goal Topic events directly to Agent

### DIFF
--- a/apps/presentation/dashboard/src/data/chat.ts
+++ b/apps/presentation/dashboard/src/data/chat.ts
@@ -1004,6 +1004,7 @@ export type LarkGoalConnection = {
   health_error_code: string | null;
   incoming_mode: "mentions" | "all";
   event_count: number;
+  last_event_reason: string | null;
   last_event_status: string | null;
   listener_error_code: string | null;
   listener_status: "starting" | "listening" | "retrying" | "stopped" | null;
@@ -1027,6 +1028,7 @@ const larkConnectionsSchema = z.object({
     health_error_code: z.string().nullable().default(null),
     incoming_mode: z.enum(["mentions", "all"]),
     event_count: z.number().int().nonnegative().default(0),
+    last_event_reason: z.string().nullable().default(null),
     last_event_status: z.string().nullable().default(null),
     listener_error_code: z.string().nullable().default(null),
     listener_status: z.enum(["starting", "listening", "retrying", "stopped"]).nullable().default(null),

--- a/apps/presentation/dashboard/src/features/personal-workspace/lark-settings-page.tsx
+++ b/apps/presentation/dashboard/src/features/personal-workspace/lark-settings-page.tsx
@@ -48,6 +48,33 @@ function larkConnectionHealth(connection: LarkGoalConnection): { label: string; 
   if (connection.last_event_status === "processing_failed") {
     return { label: "消息处理失败", detail: "已收到消息事件，但 Agent 处理失败。请查看本地诊断后重试。", ready: false };
   }
+  if (connection.last_event_status === "ignored" && connection.last_event_reason === "not_addressed") {
+    return {
+      label: "最近消息未直接 @ 机器人",
+      detail: "监听正常；当前连接只响应直接 @ 机器人或对机器人的回复。",
+      ready: true,
+    };
+  }
+  if (connection.last_event_status === "ignored" && connection.last_event_reason === "self_message") {
+    return { label: "监听中", detail: "已忽略机器人自身发送的消息，避免重复回复。", ready: true };
+  }
+  if (
+    connection.health_error_code === "lark_event_route_mismatch"
+    || ["chat_mismatch", "topic_mismatch"].includes(connection.last_event_reason ?? "")
+  ) {
+    return {
+      label: "消息未匹配当前 Goal Topic",
+      detail: "事件来自其他群聊或 Topic。请重新选择群聊并连接该 Goal，然后发送一条新的 @ 消息。",
+      ready: false,
+    };
+  }
+  if (["invalid_event", "binding_unavailable"].includes(connection.last_event_reason ?? "")) {
+    return {
+      label: "消息无法路由到 Goal",
+      detail: "当前连接信息不完整。请重新连接该 Goal 后再发送一条新的 @ 消息。",
+      ready: false,
+    };
+  }
   if (connection.last_event_status === "replied_and_acknowledged") {
     return { label: "监听中", detail: `已处理 ${connection.event_count} 条事件，成功回复 ${connection.replied_count} 条。`, ready: true };
   }

--- a/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-contract.test.mjs
+++ b/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-contract.test.mjs
@@ -264,6 +264,8 @@ assert.match(larkSettings, /im:message\.group_at_msg:readonly/, "Group mention p
 assert.match(larkSettings, /发布新版/, "Permission guidance reminds operators to publish a new app version");
 assert.match(larkSettings, /未收到消息事件/, "Connections explain when Feishu event delivery has not been observed");
 assert.match(larkSettings, /message_context_permission_required/, "Received events with missing context permissions get an actionable repair hint");
+assert.match(larkSettings, /最近消息未直接 @ 机器人/, "Ignored unaddressed messages explain why LoopX did not reply");
+assert.match(larkSettings, /消息未匹配当前 Goal Topic/, "Route mismatches receive an actionable connection repair hint");
 assert.match(larkSettings, /connectLarkGoalTopic\([^)]*execute:\s*false/s, "Connect flow previews before execution");
 assert.match(larkSettings, /connectLarkGoalTopic\([^)]*execute:\s*true/s, "Connect flow performs the approved external write");
 assert.match(larkSettings, /Register another Lark App/, "App chooser exposes Feishu registration");

--- a/examples/personal-workspace-browser-smoke.mjs
+++ b/examples/personal-workspace-browser-smoke.mjs
@@ -65,6 +65,7 @@ async function installApi(page) {
     larkWrites: [],
     actionTransitions: [],
     turnRequests: [],
+    get larkConnections() { return runtime.larkConnections; },
   };
   await page.route(`http://127.0.0.1:${port}/status.json`, async (route) => {
     const fixture = require(resolve(repoRoot, "examples/status.example.json"));
@@ -157,7 +158,7 @@ async function installApi(page) {
           app_label: "LoopX Mew", app_ref: body.app_ref, chat_name: body.chat_name, enabled: true,
           event_count: 0, health_error_code: "lark_event_delivery_unverified",
           goal_id: body.goal_id, goal_title: goal?.id ?? body.goal_id, incoming_mode: body.incoming_mode,
-          last_event_status: null, listener_error_code: null, listener_status: "listening", replied_count: 0,
+          last_event_reason: null, last_event_status: null, listener_error_code: null, listener_status: "listening", replied_count: 0,
           reply_mode: "topic_reply", target_ref: "product-group", topic_name: goal?.id ?? body.goal_id,
           topic_setup_required: false, reply_ready: false,
         });
@@ -581,6 +582,27 @@ async function main() {
     if (!(await connectedRow.getByText("事件订阅待验证", { exact: false }).isVisible())) throw new Error("A zero-event listener was presented as automatic-reply ready");
     if (!(await connectedRow.getByRole("link", { name: "查看飞书事件配置" }).isVisible())) throw new Error("An unverified Lark event subscription lacked repair guidance");
     if (api.larkWrites.length !== 1 || api.larkWrites[0].execute !== true) throw new Error("Lark connect did not perform exactly one approved external write");
+    Object.assign(api.larkConnections[0], {
+      event_count: 1,
+      health_error_code: "lark_event_route_mismatch",
+      last_event_reason: "topic_mismatch",
+      last_event_status: "ignored",
+    });
+    const mismatchReadback = await page.evaluate(async () => (await fetch("/api/chat/lark/connections")).json());
+    if (mismatchReadback.connections?.[0]?.last_event_reason !== "topic_mismatch") {
+      throw new Error(`Lark route mismatch API readback mismatch: ${JSON.stringify(mismatchReadback)}`);
+    }
+    await page.getByRole("button", { name: "关闭 Lark 设置" }).click();
+    await page.reload({ waitUntil: "networkidle" });
+    await page.getByTestId("personal-goal-home").waitFor({ state: "visible" });
+    await page.getByRole("button", { name: "通知设置", exact: true }).click();
+    const routeMismatchRow = page.locator(".personal-lark-table-row", { hasText: "Product group" });
+    try {
+      await routeMismatchRow.getByText("消息未匹配当前 Goal Topic", { exact: false }).waitFor({ state: "visible" });
+    } catch (error) {
+      throw new Error(`${error.message}; body=${(await page.locator("body").innerText()).slice(0, 4000)}`);
+    }
+    await routeMismatchRow.getByText("请重新选择群聊并连接该 Goal", { exact: false }).waitFor({ state: "visible" });
     await page.locator(".personal-lark-table-row", { hasText: "Product group" }).getByRole("button", { name: /配置/ }).click();
     await page.getByRole("dialog", { name: "Edit Lark Connection" }).waitFor({ state: "visible" });
     await page.getByRole("dialog", { name: "Edit Lark Connection" }).getByRole("button", { name: "Cancel" }).click();

--- a/loopx/canary/module_metric_baseline.json
+++ b/loopx/canary/module_metric_baseline.json
@@ -20,6 +20,11 @@
       "dict_any_count": 0,
       "lines": 1984
     },
+    "loopx/chat_server.py": {
+      "any_count": 25,
+      "dict_any_count": 0,
+      "lines": 1513
+    },
     "loopx/capabilities/auto_research/demo_e2e.py": {
       "any_count": 0,
       "dict_any_count": 0,

--- a/loopx/extensions/lark/event_collector.py
+++ b/loopx/extensions/lark/event_collector.py
@@ -166,10 +166,10 @@ def _jq_projection(chat_id: str) -> str:
     return (
         f"select(.chat_id == {chat_literal}) | "
         '{schema_version:"lark_event_inbox_event_v0",'
-        "event_id:(.event_id // .message_id),message_id:.message_id,"
+        "event_id:(.event_id // .message_id // .id),"
+        "message_id:(.message_id // .id),"
         "create_time:.create_time,content:.content,sender_id:.sender_id,"
-        "chat_id:.chat_id,root_id:.root_id,parent_id:.parent_id,"
-        "mentions:(.mentions // [])}"
+        "chat_id:.chat_id}"
     )
 
 

--- a/loopx/extensions/lark/event_collector_runtime.py
+++ b/loopx/extensions/lark/event_collector_runtime.py
@@ -247,6 +247,18 @@ def enrich_lark_event_reply_context(
     if current is None or str(current.get("chat_id") or "") != configured_chat_id:
         return enriched
 
+    # The compact lark-cli event stream intentionally carries only stable event
+    # envelope fields. Message-level routing fields live on the message lookup
+    # response, so copy them into the canonical event before deciding whether
+    # this bot was addressed and which Goal Topic owns the message.
+    for field in ("content", "mentions", "mentioned"):
+        value = current.get(field)
+        if value not in (None, "", [], False):
+            enriched[field] = value
+    current_sender_type, current_sender_id = _sender_identity(current)
+    if current_sender_id:
+        enriched["sender_id"] = current_sender_id
+
     parent_id = str(current.get("parent_id") or "").strip()
     root_id = str(current.get("root_id") or "").strip()
     if MESSAGE_ID_PATTERN.fullmatch(root_id):
@@ -269,7 +281,6 @@ def enrich_lark_event_reply_context(
         enriched["message_context_status"] = parent_status
     if parent is None or str(parent.get("chat_id") or "") != configured_chat_id:
         return enriched
-    current_sender_type, _ = _sender_identity(current)
     parent_sender_type, parent_sender_id = _sender_identity(parent)
     enriched["reply_context_verified"] = True
     enriched["message_context_status"] = "message_context_verified"

--- a/loopx/extensions/lark/event_inbox.py
+++ b/loopx/extensions/lark/event_inbox.py
@@ -255,6 +255,8 @@ def _event_attention_kind(
     bot_display_name: str,
     capture_scope: str,
 ) -> str | None:
+    if lark_event_mentions_bot(event, bot_display_name=bot_display_name):
+        return "direct_mention"
     normalized = dict(event)
     normalized["reply_to_operator"] = bool(
         event.get("reply_context_verified") is True
@@ -266,6 +268,30 @@ def _event_attention_kind(
         capture_scope=capture_scope,
     )
     return "reply_to_bot" if kind == "reply_to_operator" else kind
+
+
+def _normalized_mention_name(value: Any) -> str:
+    return " ".join(str(value or "").strip().lstrip("@").split()).casefold()
+
+
+def lark_event_mentions_bot(
+    event: Mapping[str, Any], *, bot_display_name: str
+) -> bool:
+    """Recognize provider-native direct mentions without message readback."""
+
+    if event.get("mentioned") is True:
+        return True
+    expected = _normalized_mention_name(bot_display_name)
+    mentions = event.get("mentions")
+    return bool(
+        expected
+        and isinstance(mentions, list)
+        and any(
+            isinstance(mention, Mapping)
+            and _normalized_mention_name(mention.get("name")) == expected
+            for mention in mentions
+        )
+    )
 
 
 def ingest_lark_event_inbox(

--- a/loopx/extensions/lark/goal_topic_connections.py
+++ b/loopx/extensions/lark/goal_topic_connections.py
@@ -506,6 +506,7 @@ def list_lark_connections(
             else listener_status in {"starting", "listening"}
         )
         last_event_status = str(listener.get("last_event_status") or "")
+        last_event_reason = str(listener.get("last_event_reason") or "")
         event_count = int(listener.get("event_count") or 0)
         event_blocker = (
             last_event_status
@@ -514,12 +515,26 @@ def list_lark_connections(
                 "message_context_permission_required",
                 "message_context_lookup_failed",
                 "message_context_unavailable",
+                "topic_context_ambiguous",
+                "topic_context_missing",
                 "processing_failed",
                 "answer_empty",
                 "reply_failed",
             }
             else None
         )
+        if (
+            event_blocker is None
+            and last_event_status == "ignored"
+            and last_event_reason
+            in {
+                "invalid_event",
+                "binding_unavailable",
+                "chat_mismatch",
+                "topic_mismatch",
+            }
+        ):
+            event_blocker = "lark_event_route_mismatch"
         event_delivery_unverified = bool(
             runtime_health is not None
             and listener_status == "listening"
@@ -569,6 +584,7 @@ def list_lark_connections(
                 "listener_status": listener_status or None,
                 "listener_error_code": listener.get("error_code"),
                 "last_event_status": last_event_status or None,
+                "last_event_reason": last_event_reason or None,
                 "event_count": event_count,
                 "replied_count": int(listener.get("replied_count") or 0),
             }
@@ -576,12 +592,14 @@ def list_lark_connections(
     return sorted(rows, key=lambda row: (str(row["app_label"]).casefold(), str(row["goal_title"]).casefold()))
 
 
-def route_lark_topic_event(
+def decide_lark_topic_event(
     *,
     target_payload: Mapping[str, Any],
     binding_payloads: Mapping[str, Mapping[str, Any]],
     event: Mapping[str, Any],
-) -> dict[str, str] | None:
+) -> dict[str, Any]:
+    """Return a content-free routing decision for one provider event."""
+
     chat_id = str(event.get("chat_id") or "")
     root_id = str(event.get("root_id") or "")
     message_id = str(event.get("message_id") or "")
@@ -590,11 +608,15 @@ def route_lark_topic_event(
         and MESSAGE_ID_PATTERN.fullmatch(root_id)
         and MESSAGE_ID_PATTERN.fullmatch(message_id)
     ):
-        return None
+        return {"matched": False, "reason": "invalid_event", "route": None}
+    has_binding = False
+    matched_chat = False
+    matched_topic = False
     for goal_id, payload in binding_payloads.items():
         binding = binding_for_goal(payload, goal_id)
         if not binding or binding.get("enabled") is not True:
             continue
+        has_binding = True
         target_ref = str(binding.get("target_ref") or "")
         target = goal_channel_target_for_name(target_payload, target_ref)
         if target is None:
@@ -605,41 +627,15 @@ def route_lark_topic_event(
         binding_channel = binding.get("channel") if isinstance(binding.get("channel"), Mapping) else {}
         topic_root = str(topic.get("root_message_id") or binding_channel.get("pinned_message_id") or "")
         routing = binding.get("routing") if isinstance(binding.get("routing"), Mapping) else {}
-        incoming_mode = str(routing.get("incoming_mode") or "mentions")
-        if str(channel.get("chat_id") or "") != chat_id or topic_root != root_id:
+        if str(channel.get("chat_id") or "") != chat_id:
             continue
+        matched_chat = True
+        if topic_root != root_id:
+            continue
+        matched_topic = True
         if str(event.get("sender_id") or "") == str(identity.get("bot_app_id") or ""):
-            return None
-        bot_display_name = " ".join(str(identity.get("bot_display_name") or "").split())
-        provider_mentions = event.get("mentions")
-        provider_mentioned = bool(
-            bot_display_name
-            and isinstance(provider_mentions, list)
-            and any(
-                isinstance(mention, Mapping)
-                and " ".join(str(mention.get("name") or "").split()).casefold()
-                == bot_display_name.casefold()
-                for mention in provider_mentions
-            )
-        )
-        rendered_content = " ".join(str(event.get("content") or "").split())
-        rendered_mentioned = bool(
-            bot_display_name
-            and "@" in rendered_content
-            and bot_display_name.casefold() in rendered_content.casefold()
-        )
-        addressed = bool(
-            event.get("mentioned") is True
-            or provider_mentioned
-            or rendered_mentioned
-            or (
-                event.get("reply_context_verified") is True
-                and event.get("reply_to_bot") is True
-            )
-        )
-        if incoming_mode == "mentions" and not addressed:
-            return None
-        return {
+            return {"matched": False, "reason": "self_message", "route": None}
+        route = {
             "app_ref": str(identity.get("sender_profile") or "default"),
             "goal_id": goal_id,
             "message_id": message_id,
@@ -647,7 +643,32 @@ def route_lark_topic_event(
             "target_ref": target_ref,
             "topic_root_message_id": topic_root,
         }
-    return None
+        return {"matched": True, "reason": "matched", "route": route}
+    reason = (
+        "binding_unavailable"
+        if not has_binding
+        else "chat_mismatch"
+        if not matched_chat
+        else "topic_mismatch"
+        if not matched_topic
+        else "binding_unavailable"
+    )
+    return {"matched": False, "reason": reason, "route": None}
+
+
+def route_lark_topic_event(
+    *,
+    target_payload: Mapping[str, Any],
+    binding_payloads: Mapping[str, Mapping[str, Any]],
+    event: Mapping[str, Any],
+) -> dict[str, str] | None:
+    decision = decide_lark_topic_event(
+        target_payload=target_payload,
+        binding_payloads=binding_payloads,
+        event=event,
+    )
+    route = decision.get("route")
+    return dict(route) if isinstance(route, Mapping) else None
 
 
 def reply_lark_goal_topic(

--- a/loopx/extensions/lark/goal_topic_runtime.py
+++ b/loopx/extensions/lark/goal_topic_runtime.py
@@ -18,7 +18,6 @@ from .event_inbox import (
     ingest_lark_event_inbox,
     inspect_lark_event_inbox,
 )
-from .event_collector_runtime import enrich_lark_event_reply_context
 from .goal_channel_contracts import binding_for_goal
 from .goal_channel_targets import goal_channel_target_for_name
 from .goal_topic_connections import route_lark_topic_event
@@ -35,11 +34,14 @@ HealthSink = Callable[[Mapping[str, Any]], None]
 
 _EVENT_PROJECTION = (
     '{schema_version:"lark_event_inbox_event_v0",'
-    "event_id:(.event_id // .message_id),message_id:.message_id,"
+    "event_id:(.event_id // .message_id // .id),"
+    "message_id:(.message_id // .id),"
     "create_time:.create_time,content:.content,sender_id:.sender_id,"
-    "chat_id:.chat_id,root_id:(.root_id // .thread_id),thread_id:.thread_id,"
-    "parent_id:.parent_id,"
-    "mentions:(.mentions // [])}"
+    "chat_id:.chat_id,"
+    "root_id:(.root_id // .message.root_id // .event.message.root_id),"
+    "parent_id:(.parent_id // .reply_to // .message.parent_id // .message.reply_to "
+    "// .event.message.parent_id // .event.message.reply_to),"
+    "thread_id:(.thread_id // .message.thread_id // .event.message.thread_id)}"
 )
 
 
@@ -109,10 +111,10 @@ def _default_process_factory(args: list[str]) -> subprocess.Popen[str]:
 
 def _target_for_profile_chat(
     target_payload: Mapping[str, Any], *, profile: str, chat_id: str
-) -> Mapping[str, Any] | None:
+) -> tuple[str, Mapping[str, Any]] | None:
     targets = target_payload.get("targets")
     targets = targets if isinstance(targets, Mapping) else {}
-    for target in targets.values():
+    for target_ref, target in targets.items():
         if not isinstance(target, Mapping) or target.get("enabled") is not True:
             continue
         channel = target.get("channel")
@@ -123,8 +125,34 @@ def _target_for_profile_chat(
             str(channel.get("chat_id") or "") == chat_id
             and str(identity.get("sender_profile") or "") == profile
         ):
-            return target
+            return str(target_ref), target
     return None
+
+
+def _topic_roots_for_target(
+    binding_payloads: Mapping[str, Any], *, target_ref: str
+) -> list[str]:
+    roots: list[str] = []
+    for goal_id, payload in binding_payloads.items():
+        if not isinstance(payload, Mapping):
+            continue
+        binding = binding_for_goal(payload, str(goal_id))
+        if (
+            not binding
+            or binding.get("enabled") is not True
+            or str(binding.get("target_ref") or "") != target_ref
+        ):
+            continue
+        topic = binding.get("topic") if isinstance(binding.get("topic"), Mapping) else {}
+        channel = (
+            binding.get("channel")
+            if isinstance(binding.get("channel"), Mapping)
+            else {}
+        )
+        root_id = str(topic.get("root_message_id") or channel.get("pinned_message_id") or "")
+        if MESSAGE_ID_PATTERN.fullmatch(root_id):
+            roots.append(root_id)
+    return roots
 
 
 def _event_payloads(stdout: Any) -> list[Mapping[str, Any]]:
@@ -189,34 +217,29 @@ def poll_lark_goal_topic_profile_once(
     event_statuses: list[str] = []
     for event in events:
         chat_id = str(event.get("chat_id") or "")
-        target = _target_for_profile_chat(
+        target_match = _target_for_profile_chat(
             target_payload,
             profile=profile,
             chat_id=chat_id,
         )
-        if target is None:
+        if target_match is None:
             event_statuses.append("target_unmatched")
             continue
-        identity = target.get("identity")
-        identity = identity if isinstance(identity, Mapping) else {}
-        bot_app_id = str(identity.get("bot_app_id") or "")
-        enriched = enrich_lark_event_reply_context(
-            event,
-            runner=provider_runner,
-            command_prefix=[cli_bin],
-            profile=profile,
-            profile_app_id=bot_app_id,
-            configured_chat_id=chat_id,
-        )
-        root_id = str(enriched.get("root_id") or "")
-        context_status = str(enriched.get("message_context_status") or "")
-        if not MESSAGE_ID_PATTERN.fullmatch(root_id) and context_status in {
-            "message_context_permission_required",
-            "message_context_lookup_failed",
-            "message_context_unavailable",
-        }:
-            event_statuses.append(context_status)
-            continue
+        target_ref, _target = target_match
+        routed_event = dict(event)
+        root_id = str(routed_event.get("root_id") or "")
+        if not MESSAGE_ID_PATTERN.fullmatch(root_id):
+            candidate_roots = _topic_roots_for_target(
+                binding_payloads,
+                target_ref=target_ref,
+            )
+            if len(candidate_roots) > 1:
+                event_statuses.append("topic_context_ambiguous")
+                continue
+            if not candidate_roots:
+                event_statuses.append("topic_context_missing")
+                continue
+            routed_event["root_id"] = candidate_roots[0]
         try:
             event_result = process_lark_goal_topic_event(
                 target_payload=target_payload,
@@ -225,7 +248,7 @@ def poll_lark_goal_topic_profile_once(
                     for goal_id, payload in binding_payloads.items()
                     if isinstance(payload, Mapping)
                 },
-                event=enriched,
+                event=routed_event,
                 runtime_root=runtime_root,
                 answer=answer,
                 reply_runner=reply_runner,

--- a/tests/extensions/test_lark_goal_topic_connections.py
+++ b/tests/extensions/test_lark_goal_topic_connections.py
@@ -9,6 +9,7 @@ import pytest
 from loopx.extensions.lark.goal_topic_connections import (
     LarkGroupChatLookupError,
     connect_lark_goal_topic,
+    decide_lark_topic_event,
     disconnect_lark_goal_topic,
     list_lark_apps,
     list_lark_connections,
@@ -341,6 +342,87 @@ def test_connection_health_reports_received_event_processing_blocker(tmp_path: P
     assert rows[0]["health_error_code"] == "message_context_permission_required"
 
 
+def test_connection_health_reports_ambiguous_topic_context(tmp_path: Path) -> None:
+    state: dict[str, Any] = {}
+    runner = _runner(state)
+    target_path = tmp_path / "goal-channel-targets.json"
+    binding_path = tmp_path / "goal-channel.json"
+    result = connect_lark_goal_topic(
+        registry=_registry(tmp_path),
+        goal_id="goal-alpha",
+        target_path=target_path,
+        binding_path=binding_path,
+        app_ref="mew",
+        chat_id=CHAT_ID,
+        chat_name="Product group",
+        incoming_mode="mentions",
+        runner=runner,
+        cli_bin="fake-lark",
+    )
+    assert result["ok"] is True
+
+    rows = list_lark_connections(
+        registry=_registry(tmp_path),
+        target_path=target_path,
+        binding_paths={"goal-alpha": binding_path},
+        runner=runner,
+        cli_bin="fake-lark",
+        runtime_health={
+            "mew": {
+                "status": "listening",
+                "event_count": 1,
+                "replied_count": 0,
+                "last_event_status": "topic_context_ambiguous",
+                "error_code": None,
+            }
+        },
+    )
+
+    assert rows[0]["reply_ready"] is False
+    assert rows[0]["health_error_code"] == "topic_context_ambiguous"
+
+
+def test_connection_health_reports_safe_topic_route_mismatch(tmp_path: Path) -> None:
+    state: dict[str, Any] = {}
+    target_path = tmp_path / "goal-channel-targets.json"
+    binding_path = tmp_path / "goal-channel.json"
+    connected = connect_lark_goal_topic(
+        registry=_registry(tmp_path),
+        goal_id="goal-alpha",
+        target_path=target_path,
+        binding_path=binding_path,
+        app_ref="mew",
+        chat_id=CHAT_ID,
+        chat_name="Product group",
+        incoming_mode="mentions",
+        runner=_runner(state),
+        cli_bin="fake-lark",
+    )
+    assert connected["ok"] is True
+
+    rows = list_lark_connections(
+        registry=_registry(tmp_path),
+        target_path=target_path,
+        binding_paths={"goal-alpha": binding_path},
+        runner=_runner(state),
+        cli_bin="fake-lark",
+        runtime_health={
+            "mew": {
+                "status": "listening",
+                "event_count": 1,
+                "replied_count": 0,
+                "last_event_status": "ignored",
+                "last_event_reason": "topic_mismatch",
+                "error_code": None,
+            }
+        },
+    )
+
+    assert rows[0]["reply_ready"] is False
+    assert rows[0]["health_error_code"] == "lark_event_route_mismatch"
+    assert rows[0]["last_event_reason"] == "topic_mismatch"
+
+
 def test_connect_uses_bot_chat_access_when_member_listing_is_unavailable(
     tmp_path: Path,
 ) -> None:
@@ -417,7 +499,7 @@ def test_existing_target_cli_bin_has_priority_for_connection(tmp_path: Path) -> 
     assert {call[0] for call in state["calls"]} == {"target-lark-cli"}
 
 
-def test_routes_mentions_by_topic_and_replies_in_thread(tmp_path: Path) -> None:
+def test_routes_bound_topic_messages_and_replies_in_thread(tmp_path: Path) -> None:
     state: dict[str, Any] = {}
     runner = _runner(state)
     target_path = tmp_path / "goal-channel-targets.json"
@@ -440,7 +522,8 @@ def test_routes_mentions_by_topic_and_replies_in_thread(tmp_path: Path) -> None:
         binding_payloads={"goal-alpha": read_goal_channel_binding(binding_path)},
         event={"chat_id": CHAT_ID, "root_id": "om_topic_alpha", "message_id": "om_incoming", "mentioned": False},
     )
-    assert unmentioned is None
+    assert unmentioned is not None
+    assert unmentioned["goal_id"] == "goal-alpha"
 
     route = route_lark_topic_event(
         target_payload=read_goal_channel_targets(target_path),
@@ -521,6 +604,86 @@ def test_routes_mentions_by_topic_and_replies_in_thread(tmp_path: Path) -> None:
     assert reply["ok"] is True
     assert "--reply-in-thread" in state["reply_args"]
     assert state["reply_args"][state["reply_args"].index("--message-id") + 1] == "om_incoming"
+
+
+def test_topic_route_decision_reports_safe_reason_codes(tmp_path: Path) -> None:
+    state: dict[str, Any] = {}
+    target_path = tmp_path / "goal-channel-targets.json"
+    binding_path = tmp_path / "goal-channel.json"
+    connect_lark_goal_topic(
+        registry=_registry(tmp_path),
+        goal_id="goal-alpha",
+        target_path=target_path,
+        binding_path=binding_path,
+        app_ref="mew",
+        chat_id=CHAT_ID,
+        chat_name="Product group",
+        incoming_mode="mentions",
+        runner=_runner(state),
+        cli_bin="fake-lark",
+    )
+    targets = read_goal_channel_targets(target_path)
+    bindings = {"goal-alpha": read_goal_channel_binding(binding_path)}
+
+    cases = [
+        ({"chat_id": CHAT_ID}, "invalid_event"),
+        (
+            {
+                "chat_id": "oc_other_fixture",
+                "root_id": "om_topic_alpha",
+                "message_id": "om_incoming",
+                "mentioned": True,
+            },
+            "chat_mismatch",
+        ),
+        (
+            {
+                "chat_id": CHAT_ID,
+                "root_id": "om_other_topic",
+                "message_id": "om_incoming",
+                "mentioned": True,
+            },
+            "topic_mismatch",
+        ),
+        (
+            {
+                "chat_id": CHAT_ID,
+                "root_id": "om_topic_alpha",
+                "message_id": "om_incoming",
+                "sender_id": APP_ID,
+                "mentioned": True,
+            },
+            "self_message",
+        ),
+    ]
+    for event, reason in cases:
+        decision = decide_lark_topic_event(
+            target_payload=targets,
+            binding_payloads=bindings,
+            event=event,
+        )
+        assert decision == {"matched": False, "reason": reason, "route": None}
+
+    matched = decide_lark_topic_event(
+        target_payload=targets,
+        binding_payloads=bindings,
+        event={
+            "chat_id": CHAT_ID,
+            "root_id": "om_topic_alpha",
+            "message_id": "om_incoming",
+            "content": "@_user_1 你好",
+            "mentions": [
+                {
+                    "key": "@_user_1",
+                    "id": {"open_id": "ou_public_fixture"},
+                    "name": " @LoopX   Mew ",
+                }
+            ],
+        },
+    )
+    assert matched["matched"] is True
+    assert matched["reason"] == "matched"
+    assert matched["route"]["goal_id"] == "goal-alpha"
 
 
 def test_disconnect_removes_only_the_selected_goal_topic(tmp_path: Path) -> None:

--- a/tests/extensions/test_lark_goal_topic_runtime.py
+++ b/tests/extensions/test_lark_goal_topic_runtime.py
@@ -20,12 +20,14 @@ def test_goal_topic_runtime_exposes_the_inbox_bridge() -> None:
     assert callable(getattr(module, "process_lark_goal_topic_event", None))
 
 
-def test_existing_collector_preserves_topic_routing_fields() -> None:
+def test_existing_collector_uses_the_real_compact_event_schema() -> None:
     projection = _jq_projection("oc_public_fixture")
 
-    assert "root_id:.root_id" in projection
-    assert "parent_id:.parent_id" in projection
-    assert "mentions:(.mentions // [])" in projection
+    assert "message_id:(.message_id // .id)" in projection
+    assert "root_id" not in projection
+    assert "parent_id" not in projection
+    assert "mentions" not in projection
+    assert "mentioned" not in projection
 
 
 def _connection_runner(state: dict[str, Any]):
@@ -552,8 +554,11 @@ def test_profile_poll_routes_provider_event_through_existing_reply_path(tmp_path
         "event_id": "evt_incoming",
         "message_id": "om_incoming",
         "chat_id": "oc_public_fixture",
+        "root_id": "om_topic_alpha",
+        "parent_id": "om_topic_alpha",
+        "thread_id": "omt_topic_alpha",
         "create_time": "2026-08-14T21:00:00Z",
-        "content": "@linkmacbot 你现在 loopx 的版本是什么",
+        "content": "@_user_1 你现在 loopx 的版本是什么",
     }
 
     def consume_runner(args: list[str]) -> dict[str, Any]:
@@ -561,28 +566,7 @@ def test_profile_poll_routes_provider_event_through_existing_reply_path(tmp_path
         return {"returncode": 0, "stdout": json.dumps(event) + "\n", "stderr": ""}
 
     def provider_runner(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
-        assert "+messages-mget" in args
-        state["provider_attempts"] = int(state.get("provider_attempts") or 0) + 1
-        if state["provider_attempts"] == 1:
-            return subprocess.CompletedProcess(
-                args,
-                0,
-                json.dumps({"data": {"items": []}}),
-                "",
-            )
-        payload = {
-            "data": {
-                "items": [
-                    {
-                        "message_id": "om_incoming",
-                        "chat_id": "oc_public_fixture",
-                        "root_id": "om_topic_alpha",
-                        "sender": {"sender_type": "user", "id": "ou_public_fixture"},
-                    }
-                ]
-            }
-        }
-        return subprocess.CompletedProcess(args, 0, json.dumps(payload), "")
+        raise AssertionError(f"event routing must not query message history: {args}")
 
     result = poll_lark_goal_topic_profile_once(
         profile="mew",
@@ -607,11 +591,15 @@ def test_profile_poll_routes_provider_event_through_existing_reply_path(tmp_path
     }
     assert state["consume_args"][:3] == ["fake-lark", "--profile", "mew"]
     assert "event" in state["consume_args"]
-    assert state["provider_attempts"] == 2
+    projection = state["consume_args"][state["consume_args"].index("--jq") + 1]
+    assert "message_id:(.message_id // .id)" in projection
+    assert "root_id:(.root_id // .message.root_id" in projection
+    assert "parent_id:(.parent_id // .reply_to" in projection
+    assert "thread_id" in projection
     assert state["reply_text"] == "当前运行的是 LoopX 开发版。"
 
 
-def test_profile_poll_reports_message_permission_failure_without_creating_inbox(
+def test_profile_poll_routes_the_only_goal_in_a_chat_without_querying_message_history(
     tmp_path: Path,
 ) -> None:
     from loopx.extensions.lark.goal_topic_runtime import poll_lark_goal_topic_profile_once
@@ -627,7 +615,9 @@ def test_profile_poll_reports_message_permission_failure_without_creating_inbox(
                     "channel": {"chat_id": "oc_public_fixture"},
                     "identity": {
                         "sender_profile": "mew",
+                        "sender_identity": "bot",
                         "bot_app_id": "cli_public_fixture",
+                        "bot_display_name": "linkmacbot",
                         "cli_bin": "fake-lark",
                     },
                 }
@@ -653,20 +643,88 @@ def test_profile_poll_reports_message_permission_failure_without_creating_inbox(
         "event_id": "evt_incoming",
         "message_id": "om_incoming",
         "chat_id": "oc_public_fixture",
-        "content": "@linkmacbot hello",
+        "content": "hello",
     }
 
     def provider_runner(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
-        return subprocess.CompletedProcess(
-            args,
-            1,
-            json.dumps({"code": 230027, "message": "private provider detail"}),
-            "",
-        )
+        raise AssertionError(f"event routing must not query message history: {args}")
 
     result = poll_lark_goal_topic_profile_once(
         profile="mew",
         snapshot=snapshot,
+        runtime_root=tmp_path / "runtime",
+        answer=lambda route, text: (
+            "goal-alpha received hello"
+            if route.get("goal_id") == "goal-alpha" and text == "hello"
+            else "unexpected route"
+        ),
+        consume_runner=lambda _args: {
+            "returncode": 0,
+            "stdout": json.dumps(event) + "\n",
+            "stderr": "",
+        },
+        provider_runner=provider_runner,
+        reply_runner=_reply_runner({}),
+    )
+
+    assert result["event_count"] == 1
+    assert result["replied_count"] == 1, result
+    assert result["event_statuses"] == ["replied_and_acknowledged"]
+
+
+def test_profile_poll_reports_ambiguous_topic_context_without_querying_message_history(
+    tmp_path: Path,
+) -> None:
+    from loopx.extensions.lark.goal_topic_runtime import poll_lark_goal_topic_profile_once
+
+    target = {
+        "name": "mew-product",
+        "provider": "lark",
+        "enabled": True,
+        "channel": {"chat_id": "oc_public_fixture"},
+        "identity": {
+            "sender_profile": "mew",
+            "bot_app_id": "cli_public_fixture",
+            "cli_bin": "fake-lark",
+        },
+    }
+    binding_payloads: dict[str, Any] = {}
+    for goal_id, topic_root in (
+        ("goal-alpha", "om_topic_alpha"),
+        ("goal-beta", "om_topic_beta"),
+    ):
+        binding_payloads[goal_id] = {
+            "schema_version": "loopx_goal_channel_lark_binding_v0",
+            "bindings": {
+                goal_id: {
+                    "goal_id": goal_id,
+                    "provider": "lark",
+                    "enabled": True,
+                    "target_ref": "mew-product",
+                    "topic": {"root_message_id": topic_root},
+                    "routing": {"incoming_mode": "mentions", "reply_mode": "topic_reply"},
+                }
+            },
+        }
+    event = {
+        "event_id": "evt_incoming",
+        "message_id": "om_incoming",
+        "chat_id": "oc_public_fixture",
+        "content": "hello",
+    }
+
+    def provider_runner(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        raise AssertionError(f"event routing must not query message history: {args}")
+
+    result = poll_lark_goal_topic_profile_once(
+        profile="mew",
+        snapshot={
+            "target_payload": {
+                "schema_version": "loopx_goal_channel_provider_targets_v0",
+                "targets": {"mew-product": target},
+            },
+            "binding_payloads": binding_payloads,
+        },
         runtime_root=tmp_path / "runtime",
         answer=lambda _route, _text: "must not reply",
         consume_runner=lambda _args: {
@@ -680,5 +738,5 @@ def test_profile_poll_reports_message_permission_failure_without_creating_inbox(
 
     assert result["event_count"] == 1
     assert result["replied_count"] == 0
-    assert result["event_statuses"] == ["message_context_permission_required"]
+    assert result["event_statuses"] == ["topic_context_ambiguous"]
     assert not (tmp_path / "runtime").exists()

--- a/tests/test_chat_lark_api_contract.py
+++ b/tests/test_chat_lark_api_contract.py
@@ -320,6 +320,7 @@ def test_lark_connections_include_app_reply_health(monkeypatch: Any, tmp_path: P
                 "goal_title": "Goal Alpha",
                 "health_error_code": "lark_message_permissions_required",
                 "incoming_mode": "mentions",
+                "last_event_reason": "topic_mismatch",
                 "reply_mode": "topic_reply",
                 "reply_ready": False,
                 "target_ref": "target-alpha",
@@ -375,6 +376,7 @@ def test_lark_connections_include_app_reply_health(monkeypatch: Any, tmp_path: P
     assert calls[0]["runtime_health"]["workspace-bot"]["status"] == "listening"
     assert responses[0]["connections"][0]["reply_ready"] is False
     assert responses[0]["connections"][0]["health_error_code"] == "lark_message_permissions_required"
+    assert responses[0]["connections"][0]["last_event_reason"] == "topic_mismatch"
 
 
 def test_connect_refreshes_the_app_level_event_consumer(monkeypatch: Any, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- route each provider event directly to the bound Goal Agent and forward the Agent output to the original Lark message
- preserve exact Topic routing when root_id is available; use a safe fallback only when the group has exactly one Goal Topic binding
- surface missing or ambiguous Topic context in connection health instead of silently dropping messages
- keep event processing independent from message-history readback and history permissions

## Root cause

The installed Lark CLI event schema exposes stable message envelope fields but may omit Topic root metadata. The RFC runtime attempted message-history enrichment before invoking the Agent, so permission or readback failures stranded otherwise valid messages.

## Safety

- no credential or profile model changes
- no automatic state write or Preview bypass
- ambiguous multi-Goal routing is rejected with a structured blocker
- public UI exposes only status and redacted error categories

## Validation

- 46 focused Lark runtime, connection, inbox, and API tests passed
- Lark extension compile check
- personal workspace contract smoke
- dashboard TypeScript and Vite build
- personal workspace browser smoke
- public/private boundary and diff checks