### PR TITLE
docs(todos): state the user-role update validation gate in the contract

### DIFF
--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -580,6 +580,13 @@ be bypassed. An evidence-backed peer
 transition. This closeout records `self_merged=false` and does not
 create a successor review todo for observation-only work.
 
+User-role todos may still write `done` through `todo update --status done`;
+when the todo declares `validation_command` (or `validation_command_json`),
+that update runs the same completion validation gate as `todo complete` and
+fails closed with a typed `validation_blocked_completion` receipt instead of
+committing `done`. Todos without a declared command keep the unchanged fast
+path.
+
 Use `--resume-when` when deferring a successor that should wake up after a
 machine-readable condition instead of living only in prose:
 

--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -581,7 +581,8 @@ transition. This closeout records `self_merged=false` and does not
 create a successor review todo for observation-only work.
 
 User-role todos may still write `done` through `todo update --status done`;
-when the todo declares `validation_command` (or `validation_command_json`),
+when the todo declares `validation_command` (or the `validation_command_argv`
+declared via `--validation-command-json`),
 that update runs the same completion validation gate as `todo complete` and
 fails closed with a typed `validation_blocked_completion` receipt instead of
 committing `done`. Todos without a declared command keep the unchanged fast

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -1262,11 +1262,10 @@ def update_goal_todo(
     # validation command). Returns a typed failure payload (ok=False) when
     # validation blocks; otherwise None.
     if status:
-        try:
-            update_completes_todo = normalize_todo_status(status) == TODO_STATUS_DONE
-        except ValueError:
-            update_completes_todo = False  # invalid status surfaces in-lock, unchanged
-        if update_completes_todo:
+        # normalize_todo_status returns None (never raises) for an invalid
+        # status, which simply skips this gate; the in-lock write path then
+        # surfaces the same invalid-status error as before.
+        if normalize_todo_status(status) == TODO_STATUS_DONE:
             update_block_match = find_todo_block(
                 resolved_state_file.read_text(encoding="utf-8").splitlines(),
                 todo_id=todo_id,


### PR DESCRIPTION
Addresses the two non-blocking P2 notes from the #3291 review (merged as `cca1e8ef`):

1. **Contract sentence** (`docs/project-agent-todo-contract.md`): the completion section now states explicitly that a user-role `todo update --status done` on a todo with a declared `validation_command` (or `validation_command_json`) runs the same completion validation gate as `todo complete` and fails closed with a typed `validation_blocked_completion` receipt instead of committing; undeclared todos keep the unchanged fast path. This prevents the "use `todo update` for lower-level, non-terminal status changes" framing earlier in the file from being misread as a gate bypass.
2. **Dead defensive code** (`loopx/todos.py`): the pre-lock gate in `update_goal_todo` drops its `try/except ValueError` around `normalize_todo_status` — that helper returns `None` for an invalid status rather than raising, so the except branch was unreachable and the `None == TODO_STATUS_DONE` comparison already skips the gate with behavior unchanged. A comment now records why no guard is needed.

Tests: `tests/control_plane/test_todo_completion_validation.py` → 25 passed (the gate's four update-path cases included).

Refs #3291, #3082.