### PR TITLE
docs(contributing): welcome all contribution shapes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,21 @@
 # Contributing To LoopX
 
-Thanks for helping improve LoopX. This project is early, so the best
-contributions are small, reviewable, and tied to a public task or clear bug.
+You want to help improve LoopX? Great, and thank you. Contributions come in
+many shapes, and not all of them are code:
+
+- filing clear bug reports with reproduction steps;
+- triaging and reproducing issues;
+- improving documentation, examples, and smoke tests;
+- answering questions in issues or discussions;
+- reviewing pull requests and helping contributors navigate the review flow;
+- implementing a public task or fixing a bug.
+
+Every one of these helps. The rest of this guide covers finding work, keeping
+public/private boundaries intact, validating changes, and getting a pull
+request merged.
+
+The best code contributions are small, reviewable, and tied to a public task
+or a clear bug.
 
 ## Find Work
 


### PR DESCRIPTION
## What changed

Rewrite the opening of `CONTRIBUTING.md` with a warmer, hyper-inspired welcome that names the many non-code ways to contribute (filing/triaging issues, docs and examples, answering questions, PR review) before diving into task claiming and validation rules. Also drops the stale "project is early" wording that README already removed.

## Why

The previous opening ("contributions are small, reviewable, and tied to a public task or clear bug") read as a gate rather than an invitation. Lowering the first-contact friction makes the contributor board and review flow easier to approach, without changing any engineering requirements below.

## Validation

- `git diff --check` clean (1 file, +16/-2)
- `loopx check --scan-path CONTRIBUTING.md`: public boundary scan clean
- `loopx canary premerge --from-git-diff`: merge gate passed, self-merge allowed, no manual holds
