### PR TITLE
docs: add open strategy review process

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,8 @@ a longer onboarding path.
 ## Project And Community
 
 - [Current technical directions](project/technical-directions.md)
+- [Open strategy reviews](community/open-strategy-reviews.md)
+  ([中文](community/open-strategy-reviews.zh-CN.md))
 - [Contributing](../CONTRIBUTING.md)
 - [Contributor tasks](../CONTRIBUTOR_TASKS.md)
 - [Governance](../.github/GOVERNANCE.md)

--- a/docs/community/open-strategy-reviews.md
+++ b/docs/community/open-strategy-reviews.md
@@ -1,0 +1,130 @@
+# Open Strategy Reviews
+
+> [简体中文](open-strategy-reviews.zh-CN.md)
+
+LoopX Open Strategy Reviews are periodic public working sessions for users,
+contributors, and maintainers to compare a small set of current technical
+directions. They turn broad Discussion and RFC feedback into a bounded next
+step, an owner, and an evidence request.
+
+They are not roadmap votes, release commitments, or a second governance path.
+Shipped behavior remains defined by `main`, released artifacts, and stable
+contracts. The
+[Current Technical Directions](../project/technical-directions.md) map remains
+the canonical portfolio view, and each RFC keeps the status written in that
+RFC.
+
+## When To Schedule A Review
+
+A maintainer may schedule a review when two or more public directions have
+cross-cutting questions that are hard to resolve asynchronously and at least
+two people can present evidence, a prototype, or a concrete design tension.
+
+Weekend sessions can make participation easier for volunteer contributors,
+but LoopX does not impose a weekly meeting. The maintainer chooses each date
+from contributor availability and publishes it at least 48 hours in advance.
+After the first two sessions, maintainers should keep, change, or stop the
+cadence based on the acceptance signals below.
+
+## Before The Review
+
+Create one GitHub Discussion in the **General** category as the session's
+public agenda and record. Link the current technical-directions map and every
+RFC, tracker, issue, or prototype needed as pre-reading.
+
+Limit the final agenda to four directions. A proposed agenda item should use
+this compact card:
+
+```text
+Direction:
+Problem or outcome:
+Current public evidence or prototype:
+Unresolved question:
+Requested review outcome:
+Links:
+Willing owner, if any:
+```
+
+The facilitator freezes the agenda before the meeting. Items without a public
+problem statement or a concrete question remain asynchronous Discussion
+topics instead of consuming the live session.
+
+## Session Format
+
+A first review should fit in 75 minutes:
+
+| Time | Activity |
+| --- | --- |
+| 5 minutes | Re-state the shipped baseline, governance boundary, and agenda. |
+| 48 minutes | Review up to four directions, no more than 12 minutes each. |
+| 12 minutes | Compare priorities, dependencies, and evidence gaps. |
+| 10 minutes | Confirm dispositions, owners, next artifacts, and review points. |
+
+The facilitator should invite contributors to present their own work. A
+strategy review should not become a maintainer monologue or a tour of every
+idea in the repository.
+
+## Review Dispositions
+
+Each agenda item ends in exactly one session disposition:
+
+| Disposition | Meaning |
+| --- | --- |
+| `route_to_bounded_work` | The next useful slice is clear; create or update a claimable issue or task-board row. |
+| `require_evidence` | The question needs a user case, benchmark, parity check, prototype, or other named evidence before implementation expands. |
+| `keep_visible` | The direction remains useful context, but no current owner or promotion gate justifies new work. |
+| `defer` | Stop spending meeting or implementation time until a stated trigger changes. |
+
+A disposition does not itself change an RFC stage, promote an integration
+branch, appoint a maintainer, or authorize implementation. Material changes to
+stage, scope, implementation lead, branch, or promotion gate follow the
+repository's normal pull-request and governance path.
+
+## Required Public Record
+
+Within 48 hours, add a summary comment to the session Discussion:
+
+| Direction | Current stage | Evidence reviewed | Disposition | Owner | Next artifact or evidence | Next review trigger |
+| --- | --- | --- | --- | --- | --- | --- |
+
+Then route the result:
+
+- update the technical-directions map through a pull request when canonical
+  portfolio facts changed;
+- update or open an RFC when the architectural boundary changed;
+- create a bounded issue or task-board row before implementation is claimed;
+- leave unresolved questions in the Discussion with an explicit evidence
+  request instead of converting silence into approval.
+
+The written Discussion summary is the meeting record. A call recording is
+optional and requires participant consent; it never replaces the public text.
+
+## Participation And Public Boundary
+
+- Keep agenda items, examples, and notes public-safe. Do not post credentials,
+  private customer or employer context, raw transcripts, private links, or
+  unpublished evaluation data.
+- A chat group, video call, or livestream is transport and distribution, not
+  project authority.
+- Participation, presentation, or popularity does not grant merge, release,
+  subsystem, or maintainer authority.
+- When consensus is not reached, the lead maintainer records the unresolved
+  options or the final decision and rationale in the relevant public artifact.
+- Material directional conclusions should be summarized in English and
+  Chinese so live-language choice does not silently exclude contributors.
+
+## Pilot Acceptance Signals
+
+Do not judge the pilot by attendance alone. After two sessions, continue or
+change the format based on whether:
+
+1. a contributor other than the lead maintainer independently explained or
+   challenged a LoopX direction;
+2. at least two review items produced an owner and a bounded public artifact;
+3. those artifacts received evidence, implementation, or a documented stop
+   decision before the next review; and
+4. repeated cross-direction questions became easier to find and did not need
+   to be re-litigated from chat history.
+
+If these signals do not appear, return the work to asynchronous Discussions
+instead of preserving a meeting for its own sake.

--- a/docs/community/open-strategy-reviews.zh-CN.md
+++ b/docs/community/open-strategy-reviews.zh-CN.md
@@ -1,0 +1,107 @@
+# 开放战略 Review
+
+> [English](open-strategy-reviews.md)
+
+LoopX Open Strategy Review 是面向用户、贡献者和 maintainer 的阶段性公开工作会议，
+用于比较少量当前技术方向，把宽泛的 Discussion 与 RFC 反馈收敛为有界下一步、owner
+和明确的证据要求。
+
+它不是 roadmap 投票、交付承诺或第二套治理路径。真实已交付行为仍由 `main`、release
+artifact 与稳定契约定义；
+[当前技术方向](../project/technical-directions.zh-CN.md)仍是 canonical portfolio，
+每份 RFC 的效力以其自身标注的状态为准。
+
+## 何时召开
+
+当两个以上公开方向存在难以异步解决的交叉问题，并且至少两个人可以展示证据、原型或
+具体设计张力时，maintainer 可以发起一次 review。
+
+周末可能更方便业余贡献者参加，但 LoopX 不把它固化为每周会议。Maintainer 根据贡献者
+可用时间逐次决定日期，并至少提前 48 小时公布。前两期结束后，再根据本文的验收信号
+决定保留、调整或停止 cadence。
+
+## 会前准备
+
+在 GitHub **General** 分类创建一个 Discussion，作为本期公开议程与记录。它必须链接
+当前技术方向地图，以及所有必要的 RFC、tracker、issue 或 prototype pre-read。
+
+最终议程最多保留四个方向。候选议题使用以下卡片：
+
+```text
+方向：
+问题或目标结果：
+当前公开证据或原型：
+未解决问题：
+希望本次 review 得到什么：
+链接：
+愿意承担的 owner（如有）：
+```
+
+主持人在会前冻结议程。没有公开问题陈述或具体问题的条目继续留在异步 Discussion，
+不占用实时会议。
+
+## 会议结构
+
+第一期控制在 75 分钟：
+
+| 时间 | 内容 |
+| --- | --- |
+| 5 分钟 | 重申已交付基线、治理边界和本次议程。 |
+| 48 分钟 | 最多四个方向，每个不超过 12 分钟。 |
+| 12 分钟 | 横向比较优先级、依赖与证据缺口。 |
+| 10 分钟 | 确认 disposition、owner、下一产物与复核点。 |
+
+主持人应优先让贡献者讲自己的工作。战略 review 不应变成 maintainer 单人演讲，也不
+应该巡礼仓库中的所有想法。
+
+## Review Disposition
+
+每个议题只落入一个本期 disposition：
+
+| Disposition | 含义 |
+| --- | --- |
+| `route_to_bounded_work` | 下一最小切片已经清楚；创建或更新可认领 issue / task-board 条目。 |
+| `require_evidence` | 扩大实现前，先补指定用户案例、benchmark、parity、prototype 或其他证据。 |
+| `keep_visible` | 方向仍有上下文价值，但当前没有 owner 或 promotion gate 支撑新增投入。 |
+| `defer` | 在明确 trigger 改变前，停止继续消耗会议和实现时间。 |
+
+Disposition 本身不会改变 RFC stage、晋级 integration branch、任命 maintainer 或授权
+实现。Stage、scope、implementation lead、branch 或 promotion gate 的实质变化，继续
+遵循仓库正常 PR 与治理路径。
+
+## 必须留下的公开记录
+
+会后 48 小时内，在本期 Discussion 追加总结评论：
+
+| 方向 | 当前阶段 | 已复核证据 | Disposition | Owner | 下一产物或证据 | 下次复核 trigger |
+| --- | --- | --- | --- | --- | --- | --- |
+
+随后按结果路由：
+
+- canonical portfolio 事实变化时，通过 PR 更新技术方向地图；
+- 架构边界变化时，更新或创建 RFC；
+- 任何实现被认领前，先创建有界 issue 或 task-board 条目；
+- 未解决问题继续留在 Discussion，并写明证据要求，不能把沉默解释为同意。
+
+Discussion 的文字总结是会议记录。录音录像可选且需要参与者同意，不能替代公开文本。
+
+## 参与和公开边界
+
+- 议题、示例和纪要必须公开安全。不得发布凭据、私有客户或雇主背景、原始逐字稿、
+  私有链接或未公开评测数据。
+- 聊天群、视频会议或直播只是 transport 与分发渠道，不是项目 authority。
+- 参会、演讲或受欢迎程度不会授予 merge、release、subsystem 或 maintainer 权限。
+- 无法达成共识时，由 lead maintainer 在相关公开 artifact 中记录未决选项，或记录最终
+  决定与理由。
+- 影响方向的实质结论应同时提供中英文摘要，避免实时会议语言静默排除贡献者。
+
+## 前两期验收信号
+
+不要只按参会人数判断成败。两期之后，根据以下结果决定是否继续或调整：
+
+1. lead maintainer 之外的贡献者能独立解释或质疑一个 LoopX 方向；
+2. 至少两个 review 条目形成 owner 与有界公开 artifact；
+3. 这些 artifact 在下一次 review 前获得证据、实现结果或有记录的停止决定；
+4. 跨方向的重复问题更容易被检索，不需要不断从聊天记录重新争论。
+
+如果这些信号没有出现，就把工作退回异步 Discussion，不为维持会议而维持会议。

--- a/docs/project/technical-directions.md
+++ b/docs/project/technical-directions.md
@@ -161,6 +161,12 @@ describes a possible future.
 4. Keep discussion and direction tracking in the umbrella issue; keep concrete
    implementation and review in its own issue or PR.
 
+Periodic [Open Strategy Reviews](../community/open-strategy-reviews.md) may
+compare up to four directions when cross-cutting questions benefit from live
+discussion. The review is advisory: it records a disposition, owner, next
+artifact or evidence request, and review trigger. It does not vote a direction
+into `main`, change an RFC stage, or authorize implementation.
+
 A material stage, owner, integration-branch, promotion-gate, or scope change
 must update this page through a PR. The RFC index and task board should change
 in the same PR when their routing changes. After merge, maintainers update the

--- a/docs/project/technical-directions.zh-CN.md
+++ b/docs/project/technical-directions.zh-CN.md
@@ -141,6 +141,11 @@ module 或重复 authority。
    不得悄悄依赖只存在于未晋级分支的契约。
 4. Umbrella issue 用于方向讨论与决策；具体实现和 review 使用独立 issue 或 PR。
 
+当跨方向问题适合实时讨论时，阶段性的
+[开放战略 Review](../community/open-strategy-reviews.zh-CN.md)可以比较最多四个方向。
+Review 只记录 disposition、owner、下一产物或证据要求及复核 trigger，不通过投票把
+方向写入 `main`，也不改变 RFC stage 或直接授权实现。
+
 阶段、owner、integration branch、promotion gate 或 scope 出现实质变化时，必须通过
 PR 更新本文；如果 RFC index 或 task board 的路由也发生变化，应在同一 PR 更新。
 合并后由 maintainer 更新置顶 Discussion；Discussion 不能覆盖仓库已合并事实。


### PR DESCRIPTION
## Summary

- add a bilingual public process for periodic LoopX Open Strategy Reviews
- cap each live review at four directions and require a public pre-read card
- record one disposition, owner, next artifact or evidence request, and review trigger per direction
- link the process from the canonical technical-directions map and documentation index

## Why

LoopX already has a canonical technical-directions map, RFC portfolio, long-lived direction trackers, and a pinned community Discussion. What was missing was a thin review layer for comparing several cross-cutting directions without turning a meeting, chat group, or popularity vote into project authority.

This process keeps repository artifacts authoritative while giving contributors a bounded way to present evidence, challenge directions, and leave actionable ownership after a live review.

## First pilot

Agenda collection is open in [Discussion #3296](https://github.com/huangruiteng/loopx/discussions/3296). The exact weekend time remains intentionally uncommitted until contributor availability is collected.

## Impact and boundaries

- documentation and community workflow only; no runtime or default behavior changes
- no fixed weekly meeting or automation is introduced
- a review disposition does not change an RFC stage, promote a branch, appoint a maintainer, or authorize implementation
- material direction changes still require the existing issue/RFC/PR governance path
- public/private and participant-consent boundaries are explicit

## Validation

- `python3 examples/docs-governance-smoke.py`
- `git diff --cached --check`
- `git diff --check`
- quick premerge validation with `--from-git-diff`: 4/4 selected checks passed, including the public-boundary scan; no warnings or manual holds

## Excluded

The dirty primary checkout and its untracked `tmp/` artifacts were left untouched. No private context, local path, meeting transcript, credential, or internal link is included.