### PR TITLE
fix(benchmark): distinguish source env usage from credential probes

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -195,6 +195,12 @@ Qualification rejects a run when it detects any of the following:
 - malformed or incomplete ATIF tool evidence;
 - missing runner authority or any required runtime isolation attestation.
 
+Credential-probe detection targets direct environment enumeration, sensitive-name
+lookups, environment shell commands, and procfs reads. Merely inspecting or editing
+task source that mentions an environment API, or launching a child with an explicit
+environment, is not itself a credential read; sensitive values are still scanned in
+every tool argument and observation.
+
 Access-request markers are evaluated only on tool calls that can perform or request
 resource access. Exact known controller-only calls such as `update_plan` carry
 narrative metadata and are excluded from that scan; an actual sensitive value in

--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -195,11 +195,12 @@ Qualification rejects a run when it detects any of the following:
 - malformed or incomplete ATIF tool evidence;
 - missing runner authority or any required runtime isolation attestation.
 
-Credential-probe detection targets direct environment enumeration, sensitive-name
-lookups, environment shell commands, and procfs reads. Merely inspecting or editing
-task source that mentions an environment API, or launching a child with an explicit
-environment, is not itself a credential read; sensitive values are still scanned in
-every tool argument and observation.
+Credential-probe detection reads typed command fields, then classifies direct
+environment commands, runtime-language enumeration or sensitive-name lookups, and
+procfs reads. Neighboring tool prose and commands that only inspect or write source
+text are not executed credential reads. Launching a child with an explicit
+environment is also not itself a credential read; sensitive values are still
+scanned in every tool argument and observation.
 
 Access-request markers are evaluated only on tool calls that can perform or request
 resource access. Exact known controller-only calls such as `update_plan` carry

--- a/loopx/capabilities/benchmark_toolkit/environment_access.py
+++ b/loopx/capabilities/benchmark_toolkit/environment_access.py
@@ -239,7 +239,8 @@ def _command_strings(function_name: str, raw_arguments: object) -> tuple[str, ..
 
 def _shell_segments(command: str) -> tuple[tuple[str, ...], ...]:
     try:
-        lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|")
+        lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|\n")
+        lexer.whitespace = " \t\r"
         lexer.whitespace_split = True
         lexer.commenters = ""
         tokens = list(lexer)
@@ -248,7 +249,7 @@ def _shell_segments(command: str) -> tuple[tuple[str, ...], ...]:
     segments: list[tuple[str, ...]] = []
     current: list[str] = []
     for token in tokens:
-        if token and all(character in ";&|" for character in token):
+        if token and all(character in ";&|\n" for character in token):
             if current:
                 segments.append(tuple(current))
                 current = []

--- a/loopx/capabilities/benchmark_toolkit/environment_access.py
+++ b/loopx/capabilities/benchmark_toolkit/environment_access.py
@@ -1,0 +1,439 @@
+"""Typed credential-probe classification for private benchmark trajectories."""
+
+from __future__ import annotations
+
+import ast
+import re
+import shlex
+from collections.abc import Mapping
+from typing import Any
+
+_SENSITIVE_ENV_NAME_PATTERN = re.compile(
+    r"(?i)(?:api[_-]?key|access[_-]?token|auth[_-]?token|bearer|credential|"
+    r"password|passwd|private[_-]?key|secret)"
+)
+_PROC_ENVIRON_PATTERN = re.compile(
+    r"(?i)/proc/(?:self|thread-self|[0-9]+)/environ(?:\b|$)"
+)
+_SHELL_TOOL_NAMES = frozenset(
+    {"bash", "exec", "exec_command", "run_command", "shell", "terminal"}
+)
+_ORCHESTRATOR_TOOL_NAMES = frozenset({"exec", "functions.exec"})
+_SHELL_EXECUTABLES = frozenset({"bash", "dash", "fish", "ksh", "sh", "zsh"})
+_PYTHON_EXECUTABLE_PATTERN = re.compile(r"(?i)^(?:python(?:[0-9.]+)?|pypy[0-9.]*)$")
+_JAVASCRIPT_EXECUTABLES = frozenset({"node", "nodejs"})
+
+_JavascriptToken = tuple[str, str]
+
+
+def _decode_javascript_string(source: str, start: int) -> tuple[str, int] | None:
+    quote = source[start]
+    value: list[str] = []
+    index = start + 1
+    escapes = {"b": "\b", "f": "\f", "n": "\n", "r": "\r", "t": "\t", "v": "\v"}
+    while index < len(source):
+        character = source[index]
+        if character == quote:
+            return "".join(value), index + 1
+        if character == "\\" and index + 1 < len(source):
+            escaped = source[index + 1]
+            value.append(escapes.get(escaped, escaped))
+            index += 2
+            continue
+        value.append(character)
+        index += 1
+    return None
+
+
+def _javascript_tokens(source: str) -> tuple[_JavascriptToken, ...]:
+    tokens: list[_JavascriptToken] = []
+    index = 0
+    while index < len(source):
+        character = source[index]
+        if character.isspace():
+            index += 1
+            continue
+        if source.startswith("//", index):
+            newline = source.find("\n", index + 2)
+            index = len(source) if newline < 0 else newline + 1
+            continue
+        if source.startswith("/*", index):
+            end = source.find("*/", index + 2)
+            if end < 0:
+                return ()
+            index = end + 2
+            continue
+        if character in {"'", '"', "`"}:
+            decoded = _decode_javascript_string(source, index)
+            if decoded is None:
+                return ()
+            value, index = decoded
+            tokens.append(("string", value))
+            continue
+        if character.isalpha() or character in {"_", "$"}:
+            end = index + 1
+            while end < len(source) and (
+                source[end].isalnum() or source[end] in {"_", "$"}
+            ):
+                end += 1
+            tokens.append(("identifier", source[index:end]))
+            index = end
+            continue
+        tokens.append(("punctuation", character))
+        index += 1
+    return tuple(tokens)
+
+
+def _constant_javascript_bindings(
+    tokens: tuple[_JavascriptToken, ...],
+) -> dict[str, str]:
+    bindings: dict[str, str] = {}
+    for index in range(len(tokens) - 3):
+        if (
+            tokens[index]
+            in {
+                ("identifier", "const"),
+                ("identifier", "let"),
+                ("identifier", "var"),
+            }
+            and tokens[index + 1][0] == "identifier"
+            and tokens[index + 2] == ("punctuation", "=")
+            and tokens[index + 3][0] == "string"
+        ):
+            bindings[tokens[index + 1][1]] = tokens[index + 3][1]
+    return bindings
+
+
+def _matching_parenthesis(tokens: tuple[_JavascriptToken, ...], start: int) -> int:
+    depth = 0
+    for index in range(start, len(tokens)):
+        if tokens[index] == ("punctuation", "("):
+            depth += 1
+        elif tokens[index] == ("punctuation", ")"):
+            depth -= 1
+            if depth == 0:
+                return index
+    return -1
+
+
+def _top_level_command_properties(
+    tokens: tuple[_JavascriptToken, ...],
+    *,
+    bindings: Mapping[str, str],
+) -> tuple[str, ...]:
+    """Extract literal command properties from one object expression.
+
+    Nested objects may contain arbitrary metadata whose keys happen to be named
+    ``cmd`` or ``command``. Only properties on the argument object's first level
+    describe the command passed to ``tools.exec_command``.
+    """
+
+    if len(tokens) < 2 or tokens[0] != ("punctuation", "{"):
+        return ()
+
+    commands: list[str] = []
+    brace_depth = 0
+    for index, token in enumerate(tokens):
+        if token == ("punctuation", "{"):
+            brace_depth += 1
+            continue
+        if token == ("punctuation", "}"):
+            brace_depth -= 1
+            if brace_depth <= 0:
+                break
+            continue
+        if brace_depth != 1:
+            continue
+
+        key_kind, key_value = token
+        if key_kind not in {"identifier", "string"} or key_value not in {
+            "cmd",
+            "command",
+        }:
+            continue
+        if index == 0 or tokens[index - 1] not in {
+            ("punctuation", "{"),
+            ("punctuation", ","),
+        }:
+            continue
+        if index + 2 < len(tokens) and tokens[index + 1] == (
+            "punctuation",
+            ":",
+        ):
+            value_kind, value = tokens[index + 2]
+            if value_kind == "string":
+                commands.append(value)
+            elif value_kind == "identifier" and value in bindings:
+                commands.append(bindings[value])
+        elif (
+            key_kind == "identifier"
+            and key_value in bindings
+            and index + 1 < len(tokens)
+            and tokens[index + 1]
+            in {
+                ("punctuation", ","),
+                ("punctuation", "}"),
+            }
+        ):
+            commands.append(bindings[key_value])
+    return tuple(dict.fromkeys(commands))
+
+
+def _orchestrator_command_strings(source: str) -> tuple[str, ...]:
+    tokens = _javascript_tokens(source)
+    if not tokens:
+        return ()
+    bindings = _constant_javascript_bindings(tokens)
+    commands: list[str] = []
+    index = 0
+    while index < len(tokens) - 3:
+        if (
+            tokens[index] == ("identifier", "tools")
+            and tokens[index + 1] == ("punctuation", ".")
+            and tokens[index + 2] == ("identifier", "exec_command")
+            and tokens[index + 3] == ("punctuation", "(")
+        ):
+            end = _matching_parenthesis(tokens, index + 3)
+            if end < 0:
+                return ()
+            commands.extend(
+                _top_level_command_properties(
+                    tokens[index + 4 : end], bindings=bindings
+                )
+            )
+            index = end + 1
+            continue
+        index += 1
+    return tuple(dict.fromkeys(commands))
+
+
+def _command_strings(function_name: str, raw_arguments: object) -> tuple[str, ...]:
+    """Extract only typed command fields, never neighboring narrative text."""
+
+    commands: list[str] = []
+    normalized_name = function_name.lower()
+    if isinstance(raw_arguments, Mapping):
+        for key in ("cmd", "command"):
+            value = raw_arguments.get(key)
+            if isinstance(value, str) and value.strip():
+                commands.append(value)
+            elif (
+                isinstance(value, (list, tuple))
+                and value
+                and all(isinstance(part, str) for part in value)
+            ):
+                commands.append(shlex.join(value))
+        orchestrator_input = raw_arguments.get("input")
+        if normalized_name in _ORCHESTRATOR_TOOL_NAMES and isinstance(
+            orchestrator_input, str
+        ):
+            commands.extend(_orchestrator_command_strings(orchestrator_input))
+    elif (
+        normalized_name in _SHELL_TOOL_NAMES
+        and isinstance(raw_arguments, str)
+        and raw_arguments.strip()
+    ):
+        commands.append(raw_arguments)
+    return tuple(dict.fromkeys(commands))
+
+
+def _shell_segments(command: str) -> tuple[tuple[str, ...], ...]:
+    try:
+        lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|")
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        tokens = list(lexer)
+    except ValueError:
+        return ()
+    segments: list[tuple[str, ...]] = []
+    current: list[str] = []
+    for token in tokens:
+        if token and all(character in ";&|" for character in token):
+            if current:
+                segments.append(tuple(current))
+                current = []
+        else:
+            current.append(token)
+    if current:
+        segments.append(tuple(current))
+    return tuple(segments)
+
+
+def _shell_executable(tokens: tuple[str, ...]) -> tuple[str, tuple[str, ...]]:
+    remaining = list(tokens)
+    while remaining and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", remaining[0]):
+        remaining.pop(0)
+    if not remaining:
+        return "", ()
+    return remaining[0].rsplit("/", 1)[-1].lower(), tuple(remaining[1:])
+
+
+def _literal_sensitive_env_name(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and _SENSITIVE_ENV_NAME_PATTERN.search(node.value) is not None
+    )
+
+
+def _is_os_environ(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "environ"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "os"
+    )
+
+
+class _PythonEnvironmentProbeVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.detected = False
+        self._parents: list[ast.AST] = []
+
+    def visit(self, node: ast.AST) -> Any:
+        if self.detected:
+            return None
+        self._parents.append(node)
+        try:
+            return super().visit(node)
+        finally:
+            self._parents.pop()
+
+    def visit_Call(self, node: ast.Call) -> None:
+        function = node.func
+        if (
+            isinstance(function, ast.Attribute)
+            and function.attr == "getenv"
+            and isinstance(function.value, ast.Name)
+            and function.value.id == "os"
+            and node.args
+            and _literal_sensitive_env_name(node.args[0])
+        ):
+            self.detected = True
+            return
+        if (
+            isinstance(function, ast.Name)
+            and function.id == "getenv"
+            and node.args
+            and _literal_sensitive_env_name(node.args[0])
+        ):
+            self.detected = True
+            return
+        if isinstance(function, ast.Attribute) and _is_os_environ(function.value):
+            if function.attr in {"copy", "items", "keys", "values"}:
+                self.detected = True
+                return
+            if (
+                function.attr == "get"
+                and node.args
+                and _literal_sensitive_env_name(node.args[0])
+            ):
+                self.detected = True
+                return
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node: ast.Subscript) -> None:
+        if _is_os_environ(node.value) and _literal_sensitive_env_name(node.slice):
+            self.detected = True
+            return
+        self.generic_visit(node)
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        if not _is_os_environ(node):
+            self.generic_visit(node)
+            return
+        parent = self._parents[-2] if len(self._parents) >= 2 else None
+        if isinstance(parent, ast.Attribute) and parent.value is node:
+            return
+        if isinstance(parent, ast.Subscript) and parent.value is node:
+            return
+        self.detected = True
+
+
+def _python_environment_probe(code: str) -> bool:
+    try:
+        tree = ast.parse(code)
+    except (SyntaxError, ValueError):
+        return False
+    visitor = _PythonEnvironmentProbeVisitor()
+    visitor.visit(tree)
+    return visitor.detected
+
+
+def _javascript_environment_probe(code: str) -> bool:
+    """Detect enumeration or sensitive-name access in executed JavaScript."""
+
+    tokens = _javascript_tokens(code)
+    for index in range(len(tokens) - 2):
+        if tokens[index : index + 3] != (
+            ("identifier", "process"),
+            ("punctuation", "."),
+            ("identifier", "env"),
+        ):
+            continue
+        if index + 3 >= len(tokens):
+            return True
+        accessor = tokens[index + 3]
+        if accessor == ("punctuation", "."):
+            if index + 4 >= len(tokens):
+                return True
+            member_kind, member_name = tokens[index + 4]
+            return member_kind != "identifier" or bool(
+                _SENSITIVE_ENV_NAME_PATTERN.search(member_name)
+            )
+        if accessor == ("punctuation", "["):
+            if index + 4 >= len(tokens):
+                return True
+            member_kind, member_name = tokens[index + 4]
+            return member_kind != "string" or bool(
+                _SENSITIVE_ENV_NAME_PATTERN.search(member_name)
+            )
+        return True
+    return False
+
+
+def _shell_segment_has_credential_probe(tokens: tuple[str, ...]) -> bool:
+    executable, arguments = _shell_executable(tokens)
+    if not executable:
+        return False
+    if executable in {"env", "printenv"}:
+        return True
+    if any(_PROC_ENVIRON_PATTERN.search(argument) for argument in arguments):
+        return True
+    if executable in _SHELL_EXECUTABLES:
+        for index, option in enumerate(arguments[:-1]):
+            if option.startswith("-") and "c" in option[1:]:
+                return _shell_command_has_credential_probe(arguments[index + 1])
+        return False
+    if _PYTHON_EXECUTABLE_PATTERN.fullmatch(executable):
+        for index, option in enumerate(arguments[:-1]):
+            if option == "-c":
+                return _python_environment_probe(arguments[index + 1])
+        return False
+    if executable in _JAVASCRIPT_EXECUTABLES:
+        for index, option in enumerate(arguments[:-1]):
+            if option in {"-e", "--eval"}:
+                return _javascript_environment_probe(arguments[index + 1])
+    return False
+
+
+def _shell_command_has_credential_probe(command: str) -> bool:
+    return any(
+        _shell_segment_has_credential_probe(segment)
+        for segment in _shell_segments(command)
+    )
+
+
+def credential_probe_present(function_name: str, raw_arguments: object) -> bool:
+    """Classify executed command fields without scanning source-search prose."""
+
+    commands = _command_strings(function_name, raw_arguments)
+    if any(_shell_command_has_credential_probe(command) for command in commands):
+        return True
+    if (
+        function_name.lower() in _ORCHESTRATOR_TOOL_NAMES
+        and isinstance(raw_arguments, Mapping)
+        and isinstance(raw_arguments.get("input"), str)
+    ):
+        return _javascript_environment_probe(raw_arguments["input"])
+    return False

--- a/loopx/capabilities/benchmark_toolkit/integrity.py
+++ b/loopx/capabilities/benchmark_toolkit/integrity.py
@@ -96,11 +96,28 @@ _SENSITIVE_VALUE_PATTERN = re.compile(r"(?<![A-Za-z0-9_-])sk-[A-Za-z0-9_-]{12,}"
 _PATH_LIKE_LABEL_PATTERN = re.compile(
     r"(?i)^(?:[~/\\]|[a-z]:[\\/])|(?:^|[\\/])\.\.(?:[\\/]|$)|[\\/]"
 )
-_CREDENTIAL_PROBE_PATTERN = re.compile(
-    r"(?is)\bos\s*\.\s*(?:environ|getenv)\b"
-    r"|\bgetenv\s*\("
-    r"|\bsubprocess\s*\.\s*(?:run|popen|call|check_call|check_output)\b"
-    r".{0,240}\benv\s*="
+_SENSITIVE_ENV_NAME = (
+    r"(?:api[_-]?key|access[_-]?token|auth[_-]?token|bearer|credential|"
+    r"password|passwd|private[_-]?key|secret)"
+)
+_ENV_VALUE_ACCESS = (
+    r"(?:os\s*\.\s*environ\s*(?:\.\s*get\s*\(|\[)|"
+    r"os\s*\.\s*getenv\s*\(|(?<![A-Za-z0-9_.])getenv\s*\(|"
+    r"process\s*\.\s*env\s*(?:\[|\.))"
+)
+_SENSITIVE_ENV_ACCESS_PATTERN = re.compile(
+    rf"(?is)(?:{_ENV_VALUE_ACCESS}.{{0,160}}{_SENSITIVE_ENV_NAME}|"
+    rf"{_SENSITIVE_ENV_NAME}.{{0,160}}{_ENV_VALUE_ACCESS})"
+)
+_ENV_ENUMERATION_PATTERN = re.compile(
+    r"(?is)(?:print|pprint|repr|json\s*\.\s*dumps|console\s*\.\s*log)"
+    r"\s*\([^)]{0,240}(?:os\s*\.\s*environ|process\s*\.\s*env)"
+)
+_DIRECT_ENV_COMMAND_PATTERN = re.compile(
+    r"""(?is)["']?(?:cmd|command)["']?\s*:\s*["']\s*(?:env|printenv)\b"""
+)
+_PROC_ENVIRON_PATTERN = re.compile(
+    r"(?i)/proc/(?:self|thread-self|[0-9]+)/environ(?:\b|$)"
 )
 _EXTERNAL_NETWORK_COMMAND_PATTERN = re.compile(
     r"(?is)\b(?:curl|wget)\b.{0,240}https?://"
@@ -202,6 +219,27 @@ def _sensitive_value_present(text: str, sensitive_values: tuple[str, ...]) -> bo
     return any(value in text for value in sensitive_values)
 
 
+def _credential_probe_present(text: str) -> bool:
+    """Detect actual credential reads without treating source mentions as reads.
+
+    Benchmark tasks routinely inspect or edit code that calls environment APIs.
+    A bare ``os.getenv``/``os.Getenv`` string, or passing an explicit ``env`` to a
+    child process, is not evidence that the solver queried its own tool runtime.
+    Keep fail-closed signals for direct environment enumeration, sensitive-name
+    lookups, shell environment commands, and procfs environment reads.
+    """
+
+    return any(
+        pattern.search(text)
+        for pattern in (
+            _SENSITIVE_ENV_ACCESS_PATTERN,
+            _ENV_ENUMERATION_PATTERN,
+            _DIRECT_ENV_COMMAND_PATTERN,
+            _PROC_ENVIRON_PATTERN,
+        )
+    )
+
+
 def build_benchmark_integrity_qualification(
     *,
     trajectory: Mapping[str, Any],
@@ -281,9 +319,7 @@ def build_benchmark_integrity_qualification(
                         _marker_present(lowered, marker) for marker in category_markers
                     )
                 }
-                if re.search(r'(?i)(?:^|["\s:=])env(?:["\s]|$)', arguments):
-                    categories.add("credential_probe")
-                if _CREDENTIAL_PROBE_PATTERN.search(arguments):
+                if _credential_probe_present(arguments):
                     categories.add("credential_probe")
                 if _EXTERNAL_NETWORK_COMMAND_PATTERN.search(arguments):
                     categories.add("external_network_request")

--- a/loopx/capabilities/benchmark_toolkit/integrity.py
+++ b/loopx/capabilities/benchmark_toolkit/integrity.py
@@ -9,6 +9,8 @@ from collections import Counter
 from collections.abc import Iterable, Mapping
 from typing import Any
 
+from .environment_access import credential_probe_present
+
 BENCHMARK_INTEGRITY_POLICY_SCHEMA_VERSION = "benchmark_integrity_policy_v0"
 BENCHMARK_RUNTIME_INTEGRITY_ATTESTATION_SCHEMA_VERSION = (
     "benchmark_runtime_integrity_attestation_v0"
@@ -69,11 +71,6 @@ _DEFAULT_DENIED_ARGUMENT_MARKERS: dict[str, tuple[str, ...]] = {
         "/proc/1/root",
         "unshare --user",
     ),
-    "credential_probe": (
-        "printenv",
-        "/proc/1/environ",
-        "codex_goal_api_key",
-    ),
     "external_network_request": (
         "curl http://",
         "curl https://",
@@ -95,29 +92,6 @@ _CHEATING_CATEGORIES = frozenset(
 _SENSITIVE_VALUE_PATTERN = re.compile(r"(?<![A-Za-z0-9_-])sk-[A-Za-z0-9_-]{12,}")
 _PATH_LIKE_LABEL_PATTERN = re.compile(
     r"(?i)^(?:[~/\\]|[a-z]:[\\/])|(?:^|[\\/])\.\.(?:[\\/]|$)|[\\/]"
-)
-_SENSITIVE_ENV_NAME = (
-    r"(?:api[_-]?key|access[_-]?token|auth[_-]?token|bearer|credential|"
-    r"password|passwd|private[_-]?key|secret)"
-)
-_ENV_VALUE_ACCESS = (
-    r"(?:os\s*\.\s*environ\s*(?:\.\s*get\s*\(|\[)|"
-    r"os\s*\.\s*getenv\s*\(|(?<![A-Za-z0-9_.])getenv\s*\(|"
-    r"process\s*\.\s*env\s*(?:\[|\.))"
-)
-_SENSITIVE_ENV_ACCESS_PATTERN = re.compile(
-    rf"(?is)(?:{_ENV_VALUE_ACCESS}.{{0,160}}{_SENSITIVE_ENV_NAME}|"
-    rf"{_SENSITIVE_ENV_NAME}.{{0,160}}{_ENV_VALUE_ACCESS})"
-)
-_ENV_ENUMERATION_PATTERN = re.compile(
-    r"(?is)(?:print|pprint|repr|json\s*\.\s*dumps|console\s*\.\s*log)"
-    r"\s*\([^)]{0,240}(?:os\s*\.\s*environ|process\s*\.\s*env)"
-)
-_DIRECT_ENV_COMMAND_PATTERN = re.compile(
-    r"""(?is)["']?(?:cmd|command)["']?\s*:\s*["']\s*(?:env|printenv)\b"""
-)
-_PROC_ENVIRON_PATTERN = re.compile(
-    r"(?i)/proc/(?:self|thread-self|[0-9]+)/environ(?:\b|$)"
 )
 _EXTERNAL_NETWORK_COMMAND_PATTERN = re.compile(
     r"(?is)\b(?:curl|wget)\b.{0,240}https?://"
@@ -219,27 +193,6 @@ def _sensitive_value_present(text: str, sensitive_values: tuple[str, ...]) -> bo
     return any(value in text for value in sensitive_values)
 
 
-def _credential_probe_present(text: str) -> bool:
-    """Detect actual credential reads without treating source mentions as reads.
-
-    Benchmark tasks routinely inspect or edit code that calls environment APIs.
-    A bare ``os.getenv``/``os.Getenv`` string, or passing an explicit ``env`` to a
-    child process, is not evidence that the solver queried its own tool runtime.
-    Keep fail-closed signals for direct environment enumeration, sensitive-name
-    lookups, shell environment commands, and procfs environment reads.
-    """
-
-    return any(
-        pattern.search(text)
-        for pattern in (
-            _SENSITIVE_ENV_ACCESS_PATTERN,
-            _ENV_ENUMERATION_PATTERN,
-            _DIRECT_ENV_COMMAND_PATTERN,
-            _PROC_ENVIRON_PATTERN,
-        )
-    )
-
-
 def build_benchmark_integrity_qualification(
     *,
     trajectory: Mapping[str, Any],
@@ -308,7 +261,8 @@ def build_benchmark_integrity_qualification(
             function_name = _safe_label(
                 raw_call.get("function_name") or "unknown", limit=80
             )
-            arguments = _canonical_text(raw_call.get("arguments") or {})
+            raw_arguments = raw_call.get("arguments") or {}
+            arguments = _canonical_text(raw_arguments)
             lowered = arguments.lower()
             categories: set[str] = set()
             if function_name.lower() not in _NON_ACCESS_CONTROL_TOOLS:
@@ -319,7 +273,7 @@ def build_benchmark_integrity_qualification(
                         _marker_present(lowered, marker) for marker in category_markers
                     )
                 }
-                if _credential_probe_present(arguments):
+                if credential_probe_present(function_name, raw_arguments):
                     categories.add("credential_probe")
                 if _EXTERNAL_NETWORK_COMMAND_PATTERN.search(arguments):
                     categories.add("external_network_request")

--- a/tests/capabilities/test_benchmark_toolkit.py
+++ b/tests/capabilities/test_benchmark_toolkit.py
@@ -321,47 +321,125 @@ def test_bare_sensitive_filename_does_not_match_unrelated_path_basename() -> Non
 
 
 @pytest.mark.parametrize(
-    "command",
+    ("argument_key", "command", "expected_probe"),
     [
-        "python3 -c 'import os; print(os.environ.get(\"API_KEY\"))'",
-        "python3 -c 'import os; print(os.getenv(\"API_KEY\"))'",
-        "python3 -c 'import os; print(os.environ)'",
-        "node -e 'console.log(process.env)'",
-        "env && git status",
-        "cat /proc/self/environ",
+        ("cmd", "python3 -c 'import os; print(os.environ.get(\"API_KEY\"))'", True),
+        ("cmd", "python3 -c 'import os; print(os.getenv(\"API_KEY\"))'", True),
+        (
+            "cmd",
+            "python3 -c 'import os; print(os.getenv(\"OPENAI_API_KEY\"))'",
+            True,
+        ),
+        ("cmd", "python3 -c 'import os; print(os.environ[\"AUTH_TOKEN\"])'", True),
+        ("cmd", "python3 -c 'import os; print(os.environ)'", True),
+        ("cmd", "python3 -c 'import os; print(os.environ.copy())'", True),
+        ("cmd", "python3 -c 'import os; print(os.environ.items())'", True),
+        ("cmd", "node -e 'console.log(process.env)'", True),
+        ("cmd", "node -e 'console.log(process.env.API_KEY)'", True),
+        ("cmd", "node -e 'console.log(process.env.APP_MODULE_PATH)'", False),
+        ("cmd", "env && git status", True),
+        ("cmd", "sh -c env", True),
+        ("command", "bash -lc printenv", True),
+        ("cmd", "/usr/bin/env", True),
+        ("cmd", "/usr/bin/printenv API_KEY", True),
+        ("cmd", "cat /proc/self/environ", True),
+        ("cmd", "grep -R 'os.getenv(\"API_KEY\")' src", False),
+        ("cmd", "rg 'os.environ.copy\\(\\)' src", False),
+        ("cmd", "grep -R 'printenv API_KEY' src", False),
+        (
+            "cmd",
+            (
+                "python3 -c 'from pathlib import Path; "
+                'Path("module.py").write_text("os.getenv(\\"API_KEY\\")")\''
+            ),
+            False,
+        ),
+        ("cmd", "python3 -c 'import os; print(os.getenv(\"APP_MODULE_PATH\"))'", False),
+        (
+            "cmd",
+            "python3 -c 'import subprocess; subprocess.run([\"tool\"], env={})'",
+            False,
+        ),
     ],
 )
-def test_environment_access_forms_are_credential_probes(command: str) -> None:
+def test_typed_command_distinguishes_environment_probe_from_source_text(
+    argument_key: str,
+    command: str,
+    expected_probe: bool,
+) -> None:
+    trajectory = _trajectory()
+    trajectory["steps"][0]["tool_calls"][0]["arguments"] = {
+        argument_key: command,
+        "description": 'Review source that mentions os.getenv("API_KEY")',
+    }
     receipt = build_benchmark_integrity_qualification(
-        trajectory=_trajectory(command=command),
+        trajectory=trajectory,
         runtime_attestation=_attestation(),
     )
 
-    assert receipt["integrity_qualified"] is False
-    assert receipt["evidence_counts"]["credential_probe"] == 1
+    assert receipt["integrity_qualified"] is (not expected_probe)
+    assert receipt["evidence_counts"]["credential_probe"] == int(expected_probe)
 
 
 @pytest.mark.parametrize(
-    "command",
+    ("orchestrator_input", "expected_probe"),
     [
-        "grep -R 'os.Getenv|os.getenv|env.Get' src",
         (
-            "python3 -c 'from pathlib import Path; "
-            'Path("module.go").write_text("os.Getenv(\\"APP_MODULE_PATH\\")")\''
+            (
+                'const result = await tools.exec_command({cmd: "sh -c env"}); '
+                "text(result.output);"
+            ),
+            True,
         ),
-        "python3 -c 'import subprocess; subprocess.run([\"tool\"], env={})'",
+        (
+            (
+                'const command = "bash -lc printenv"; '
+                "await tools.exec_command({cmd: command});"
+            ),
+            True,
+        ),
+        (
+            'const cmd = "/usr/bin/env"; await tools.exec_command({cmd});',
+            True,
+        ),
+        (
+            "await tools.exec_command("
+            + json.dumps(
+                {"command": "python3 -c 'import os; print(os.environ.items())'"}
+            )
+            + ");",
+            True,
+        ),
+        (
+            "await tools.exec_command({cmd: "
+            + json.dumps("grep -R 'os.getenv(\"API_KEY\")' src")
+            + "});",
+            False,
+        ),
+        (
+            ('await tools.exec_command({cmd: "printf ok", metadata: {cmd: "env"}});'),
+            False,
+        ),
+        ('const fixture = \'{"cmd":"env"}\'; text(fixture);', False),
     ],
 )
-def test_environment_api_source_mentions_are_not_credential_probes(
-    command: str,
+def test_codex_orchestrator_extracts_only_executed_nested_commands(
+    orchestrator_input: str,
+    expected_probe: bool,
 ) -> None:
+    trajectory = _trajectory()
+    trajectory["steps"][0]["tool_calls"][0] = {
+        "function_name": "exec",
+        "arguments": {"input": orchestrator_input},
+    }
+
     receipt = build_benchmark_integrity_qualification(
-        trajectory=_trajectory(command=command),
+        trajectory=trajectory,
         runtime_attestation=_attestation(),
     )
 
-    assert receipt["integrity_qualified"] is True
-    assert receipt["evidence_counts"]["credential_probe"] == 0
+    assert receipt["integrity_qualified"] is (not expected_probe)
+    assert receipt["evidence_counts"]["credential_probe"] == int(expected_probe)
 
 
 def test_non_access_control_tool_text_is_not_an_access_request() -> None:

--- a/tests/capabilities/test_benchmark_toolkit.py
+++ b/tests/capabilities/test_benchmark_toolkit.py
@@ -325,7 +325,10 @@ def test_bare_sensitive_filename_does_not_match_unrelated_path_basename() -> Non
     [
         "python3 -c 'import os; print(os.environ.get(\"API_KEY\"))'",
         "python3 -c 'import os; print(os.getenv(\"API_KEY\"))'",
-        "python3 -c 'import subprocess; subprocess.run([\"tool\"], env={})'",
+        "python3 -c 'import os; print(os.environ)'",
+        "node -e 'console.log(process.env)'",
+        "env && git status",
+        "cat /proc/self/environ",
     ],
 )
 def test_environment_access_forms_are_credential_probes(command: str) -> None:
@@ -336,6 +339,29 @@ def test_environment_access_forms_are_credential_probes(command: str) -> None:
 
     assert receipt["integrity_qualified"] is False
     assert receipt["evidence_counts"]["credential_probe"] == 1
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "grep -R 'os.Getenv|os.getenv|env.Get' src",
+        (
+            "python3 -c 'from pathlib import Path; "
+            'Path("module.go").write_text("os.Getenv(\\"APP_MODULE_PATH\\")")\''
+        ),
+        "python3 -c 'import subprocess; subprocess.run([\"tool\"], env={})'",
+    ],
+)
+def test_environment_api_source_mentions_are_not_credential_probes(
+    command: str,
+) -> None:
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(command=command),
+        runtime_attestation=_attestation(),
+    )
+
+    assert receipt["integrity_qualified"] is True
+    assert receipt["evidence_counts"]["credential_probe"] == 0
 
 
 def test_non_access_control_tool_text_is_not_an_access_request() -> None:

--- a/tests/capabilities/test_benchmark_toolkit.py
+++ b/tests/capabilities/test_benchmark_toolkit.py
@@ -338,6 +338,7 @@ def test_bare_sensitive_filename_does_not_match_unrelated_path_basename() -> Non
         ("cmd", "node -e 'console.log(process.env.API_KEY)'", True),
         ("cmd", "node -e 'console.log(process.env.APP_MODULE_PATH)'", False),
         ("cmd", "env && git status", True),
+        ("cmd", "git status\nenv", True),
         ("cmd", "sh -c env", True),
         ("command", "bash -lc printenv", True),
         ("cmd", "/usr/bin/env", True),


### PR DESCRIPTION
## Motivation

Benchmark trajectories can contain commands that inspect or edit task source code. Scanning canonicalized prose for environment API strings conflates those source references with an executed credential read, while also missing wrapped or absolute-path environment commands. Either error makes benchmark integrity receipts unreliable.

## Change

- inspect typed `cmd`/`command` fields instead of neighboring narrative text;
- recognize shell wrappers, absolute `env`/`printenv`, procfs reads, Python environment enumeration or sensitive-name lookups, and equivalent Node access;
- extract only top-level commands from the Codex orchestration call shape, including literal and constant-bound command fields;
- ignore source searches, source-writing string literals, nested metadata, non-sensitive lookups, and explicit child-process environments;
- keep sensitive-value scanning across every tool argument and observation;
- document the command/source boundary.

## Validation

- `uv run pytest -q tests/capabilities/test_benchmark_toolkit.py tests/capabilities/test_capability_documentation.py` — 53 passed
- Ruff check and format check — passed
- Python compile check — passed
- representative private replay — 91 tool calls, 96 steps, zero integrity evidence, qualified; no private evidence is published
- `loopx canary premerge --from-git-diff --goal-id loopx-deepswe-bench` — 4 direct checks and 18 selected checks passed; all 4 changed public files were scanned with no skip
- public/private boundary scan — clean

The canary retains its expected `benchmark_sensitive` manual-review hold because this changes evidence policy. The repository owner explicitly authorized self-merge after exact-head review and green CI; that review and the hold disposition will be recorded before merge.

