### PR TITLE
feat: add loopx-community-discussion public source provider

### DIFF
--- a/loopx/capabilities/value_connectors/README.md
+++ b/loopx/capabilities/value_connectors/README.md
@@ -97,6 +97,7 @@ commands delegate to those providers.
 | `finance_market_snapshot` | none | migrated to standalone extension | migration packet only; no Finance execution | none |
 | `botmail_identity` | `content-ops` | mapped | install-check only | exact send gate required |
 | `community_channel` | `content-ops` | mapped | install-check and plan | exact account/message gate required |
+| `community_discussion_public_sources` | `periodic-report` | extension package `loopx-community-discussion` | `loopx-community-discussion scan --owner <owner> --repo <repo> --format json` | none (digest delivery is a separate exact-gated external write) |
 
 `migrated` means the implementation module is owned by the outcome capability.
 `native` means the command already lived there. `mapped` records the intended

--- a/packages/loopx-community-discussion/CONTRACT.md
+++ b/packages/loopx-community-discussion/CONTRACT.md
@@ -1,0 +1,40 @@
+# Community Discussion Provider Contract
+
+`community_discussion_scan_v0` is a provider-neutral, public-safe snapshot of
+recent community discussion around a repository. Collectors emit typed
+`discussion_fact_v0` facts; consumers (periodic reports, community funnels,
+operator digests) render or aggregate facts but do not reinterpret missing
+providers as silence.
+
+## Ownership
+
+| Surface | Owner | Responsibility |
+| --- | --- | --- |
+| Contract | `loopx-community-discussion` extension | Schema, fact types, boundary rules |
+| Observation | GitHub REST/GraphQL + HN Algolia collectors | Public evidence with typed values or warnings |
+| Rendering | `loopx-community-discussion` | Deterministic markdown digest |
+| Delivery | Operator | Exact-gated external writes (Lark etc.) are never performed by this extension |
+
+## Rules
+
+- Facts are metadata-first: title, source URL, author, published timestamp,
+  relevance, and a `dedupe_key`. Raw provider payloads and full post bodies are
+  never stored.
+- A failed provider is represented as an `evidence.warnings` entry plus the
+  surviving facts, never as fabricated facts.
+- GitHub internal `[Task]`/`[Benchmark]`/`[Sweep]`/`[Chore]` issues are
+  filtered as non-community signals.
+- Maintainer-authored items are typed `maintainer_signal`; other authors are
+  `external_discussion`, so digests can prioritize user voices.
+- HN collection disables typo tolerance and requires exact substring matches
+  to keep the well-known Loopxo/Looptap/looped-music/CrowdStrike noise out.
+- Credentials are never part of a request or response packet; GitHub
+  authentication comes from the process environment only.
+- The provider rejects a request with a mismatched `schema_version` before
+  doing any network work.
+
+## Evidence
+
+Each scan carries `evidence.sources`, `evidence.rate_limit_remaining`, and
+`evidence.warnings` so downstream reports can audit freshness and partial
+provider availability.

--- a/packages/loopx-community-discussion/README.md
+++ b/packages/loopx-community-discussion/README.md
@@ -1,0 +1,64 @@
+# loopx-community-discussion
+
+Public-safe community discussion scanner for LoopX. It collects compact
+`discussion_fact_v0` facts from public sources — GitHub issues and discussions
+plus exact-match Hacker News Algolia — and freezes them into a
+`community_discussion_scan_v0` document that can feed periodic reports,
+community funnel monitoring, or an operator digest.
+
+## Facts
+
+- GitHub: recent issues in `owner/repo` (internal `[Task]`-style entries
+  filtered) and the 50 most recently updated discussions. Maintainer-authored
+  items are typed `maintainer_signal`; everyone else is
+  `external_discussion`.
+- Hacker News: exact `loopx` stories plus `loop engineering` ecosystem
+  articles. Typo tolerance is disabled and an exact substring match is
+  required, because Algolia's default fuzzy search returns thousands of
+  unrelated Loopxo/Looptap/looped-music/CrowdStrike hits.
+
+The provider is metadata-first: title, source URL, author, timestamp,
+relevance, and a dedupe key. It never stores raw provider payloads, full post
+bodies, credentials, local paths, or private context.
+
+## Auth and boundaries
+
+- Read `GH_TOKEN` or `GITHUB_TOKEN` from the environment for GitHub
+  Discussions collection and higher rate limits; the request packet never
+  carries credentials.
+- Hacker News Algolia is unauthenticated.
+- X and Reddit are not bundled. X requires a logged-in browser session (for
+  example ego-browser) or the official XMCP provider, and Reddit's public JSON
+  endpoints currently return a login wall / rate limit. Both stay exact-gated
+  external providers behind the same `discussion_fact_v0` contract.
+- This extension performs no external writes. Sending a digest (for example to
+  Lark) is a separate, exactly gated delivery step owned by the operator.
+
+## Usage
+
+Managed extension invocation (stdin request → stdout response):
+
+```bash
+python3 -m pip install .
+loopx extension install --manifest extension.toml --execute --format json
+loopx extension run loopx-community-discussion --input-json examples/request.json --execute --format json
+```
+
+Direct CLI:
+
+```bash
+loopx-community-discussion --doctor
+loopx-community-discussion scan --owner huangruiteng --repo loopx --days 14 --format json
+loopx-community-discussion scan --owner huangruiteng --repo loopx --days 14 --format md
+```
+
+`schemas/fact.schema.json`, `schemas/scan.schema.json`, and the request/response
+schemas are the versioned wire contracts. The provider validates its output
+against `community_discussion_scan_v0` before returning it.
+
+## Validation
+
+```bash
+python3 smoke/community_discussion_smoke.py                     # offline contract smoke
+python3 smoke/community_discussion_smoke.py --live owner repo   # optional live check
+```

--- a/packages/loopx-community-discussion/examples/request.json
+++ b/packages/loopx-community-discussion/examples/request.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": "loopx_community_discussion_request_v0",
+  "owner": "huangruiteng",
+  "repo": "loopx",
+  "days": 14
+}

--- a/packages/loopx-community-discussion/extension.toml
+++ b/packages/loopx-community-discussion/extension.toml
@@ -1,0 +1,12 @@
+schema_version = "loopx_extension_manifest_v0"
+id = "loopx-community-discussion"
+version = "0.1.0"
+requires_loopx_api = ">=1,<2"
+permissions = []
+
+[runtime]
+protocol = "loopx_community_discussion_extension_v0"
+entrypoint = "loopx-community-discussion"
+doctor_args = ["--doctor"]
+required_permissions = []
+timeout_seconds = 30

--- a/packages/loopx-community-discussion/pyproject.toml
+++ b/packages/loopx-community-discussion/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=69"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "loopx-community-discussion"
+version = "0.1.0"
+description = "Public-safe community discussion scanner for LoopX"
+readme = "README.md"
+requires-python = ">=3.11"
+
+[project.scripts]
+loopx-community-discussion = "loopx_community_discussion.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/packages/loopx-community-discussion/schemas/fact.schema.json
+++ b/packages/loopx-community-discussion/schemas/fact.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "discussion_fact_v0",
+  "title": "LoopX community discussion fact",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "fact_type",
+    "source",
+    "source_url",
+    "title",
+    "author",
+    "published_at",
+    "relevance",
+    "relevance_reason",
+    "dedupe_key"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "discussion_fact_v0"
+    },
+    "fact_type": {
+      "enum": [
+        "external_discussion",
+        "maintainer_signal",
+        "ecosystem_signal",
+        "packaging",
+        "press",
+        "unanswered_question",
+        "source_error"
+      ]
+    },
+    "source": {
+      "enum": [
+        "github",
+        "hacker_news",
+        "web",
+        "reddit",
+        "x"
+      ]
+    },
+    "source_url": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "title": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "author": {
+      "type": "string"
+    },
+    "published_at": {
+      "type": "string"
+    },
+    "relevance": {
+      "enum": [
+        "strong",
+        "weak"
+      ]
+    },
+    "relevance_reason": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "dedupe_key": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    }
+  }
+}

--- a/packages/loopx-community-discussion/schemas/request.schema.json
+++ b/packages/loopx-community-discussion/schemas/request.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "loopx_community_discussion_request_v0",
+  "title": "loopx-community-discussion extension request",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "owner",
+    "repo"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "loopx_community_discussion_request_v0"
+    },
+    "owner": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "repo": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "days": {
+      "default": 14,
+      "minimum": 1,
+      "maximum": 90,
+      "type": "integer"
+    }
+  }
+}

--- a/packages/loopx-community-discussion/schemas/response.schema.json
+++ b/packages/loopx-community-discussion/schemas/response.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "loopx_community_discussion_response_v0",
+  "title": "loopx-community-discussion extension response",
+  "type": "object",
+  "additionalProperties": false,
+  "oneOf": [
+    {
+      "properties": {
+        "ok": {
+          "const": true
+        },
+        "request_schema_version": {
+          "const": "loopx_community_discussion_request_v0"
+        },
+        "result": {
+          "$ref": "scan.schema.json"
+        }
+      },
+      "required": [
+        "request_schema_version",
+        "result"
+      ]
+    },
+    {
+      "properties": {
+        "ok": {
+          "const": false
+        },
+        "error": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "error"
+      ]
+    }
+  ],
+  "properties": {
+    "doctor": {
+      "const": "ok",
+      "type": "string"
+    },
+    "error": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "extension_id": {
+      "const": "loopx-community-discussion"
+    },
+    "ok": {
+      "type": "boolean"
+    },
+    "request_schema_version": {
+      "const": "loopx_community_discussion_request_v0"
+    },
+    "result": {
+      "type": "object"
+    }
+  }
+}

--- a/packages/loopx-community-discussion/schemas/scan.schema.json
+++ b/packages/loopx-community-discussion/schemas/scan.schema.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "community_discussion_scan_v0",
+  "title": "LoopX community discussion scan",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "scan_at",
+    "window_days",
+    "repo",
+    "stats",
+    "facts",
+    "evidence"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "community_discussion_scan_v0"
+    },
+    "scan_at": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "window_days": {
+      "minimum": 1,
+      "type": "integer"
+    },
+    "repo": {
+      "additionalProperties": false,
+      "properties": {
+        "owner": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "owner",
+        "name"
+      ],
+      "type": "object"
+    },
+    "stats": {
+      "additionalProperties": false,
+      "properties": {
+        "raw_facts": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "deduped_facts": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "source_errors": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "strong": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "raw_facts",
+        "deduped_facts",
+        "source_errors",
+        "strong"
+      ],
+      "type": "object"
+    },
+    "facts": {
+      "items": {
+        "$ref": "fact.schema.json"
+      },
+      "type": "array"
+    },
+    "evidence": {
+      "additionalProperties": false,
+      "properties": {
+        "sources": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "rate_limit_remaining": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "sources",
+        "warnings"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/packages/loopx-community-discussion/smoke/community_discussion_smoke.py
+++ b/packages/loopx-community-discussion/smoke/community_discussion_smoke.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Offline contract smoke for loopx-community-discussion.
+
+Run without network: python3 smoke/community_discussion_smoke.py
+Optional live check (requires GH_TOKEN for discussions):
+python3 smoke/community_discussion_smoke.py --live owner repo
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from loopx_community_discussion.contract import SCAN_SCHEMA_VERSION, dedupe_key, validate_scan
+from loopx_community_discussion.normalize import make_fact, merge_facts
+from loopx_community_discussion.render import render_markdown
+
+
+def _fixture() -> dict:
+    external = make_fact(
+        fact_type="external_discussion",
+        source="github",
+        source_url="https://github.com/huangruiteng/loopx/issues/1",
+        title="Question: how do I set a stop condition?",
+        author="external-user",
+        published_at="2026-08-17T00:00:00Z",
+    )
+    maintainer = make_fact(
+        fact_type="maintainer_signal",
+        source="github",
+        source_url="https://github.com/huangruiteng/loopx/issues/2",
+        title="RFC: typed handoff packets",
+        author="huangruiteng",
+        published_at="2026-08-16T00:00:00Z",
+    )
+    ecosystem = make_fact(
+        fact_type="ecosystem_signal",
+        source="hacker_news",
+        source_url="https://news.ycombinator.com/item?id=1",
+        title="Loop Engineering in Claude",
+        author="alice",
+        published_at="2026-08-15T00:00:00Z",
+        text="loop engineering is a useful frame",
+    )
+    duplicate = make_fact(
+        fact_type="external_discussion",
+        source="github",
+        source_url="https://github.com/huangruiteng/loopx/issues/1",
+        title="Question: how do I set a stop condition?",
+        author="external-user",
+        published_at="2026-08-17T00:00:00Z",
+    )
+    facts = merge_facts([external, maintainer, ecosystem, duplicate])  # type: ignore[list-item]
+    return {
+        "schema_version": SCAN_SCHEMA_VERSION,
+        "scan_at": "2026-08-17T00:00:00+00:00",
+        "window_days": 14,
+        "repo": {"owner": "huangruiteng", "name": "loopx"},
+        "stats": {
+            "raw_facts": 4,
+            "deduped_facts": len(facts),
+            "source_errors": 0,
+            "strong": sum(1 for f in facts if f["relevance"] == "strong"),
+        },
+        "facts": facts,
+        "evidence": {"sources": ["github-rest", "hn-algolia"], "rate_limit_remaining": 4800, "warnings": []},
+    }
+
+
+def _run_offline() -> int:
+    fixture = _fixture()
+    if len(fixture["facts"]) != 3:
+        print(f"FAIL: dedupe should collapse duplicate facts, got {len(fixture['facts'])}", file=sys.stderr)
+        return 1
+    violations = validate_scan(fixture)
+    if violations:
+        print(f"FAIL: fixture should be valid: {violations}", file=sys.stderr)
+        return 1
+
+    broken = copy.deepcopy(fixture)
+    broken["facts"][0]["fact_type"] = "not_a_type"
+    if validate_scan(broken) == []:
+        print("FAIL: invalid fact_type accepted", file=sys.stderr)
+        return 1
+
+    broken = copy.deepcopy(fixture)
+    broken["schema_version"] = "community_discussion_scan_v1"
+    if validate_scan(broken) == []:
+        print("FAIL: mismatched schema_version accepted", file=sys.stderr)
+        return 1
+
+    broken = copy.deepcopy(fixture)
+    broken["facts"][0]["relevance"] = "unknown"
+    if validate_scan(broken) == []:
+        print("FAIL: invalid relevance accepted", file=sys.stderr)
+        return 1
+
+    broken = copy.deepcopy(fixture)
+    broken["facts"][0]["dedupe_key"] = "abc"
+    if validate_scan(broken) == []:
+        print("FAIL: short dedupe_key accepted", file=sys.stderr)
+        return 1
+
+    noise = make_fact(
+        fact_type="external_discussion",
+        source="hacker_news",
+        source_url="https://example.com/loopxo",
+        title="Loopxo token launch",
+        author="scammer",
+        published_at="2026-08-17T00:00:00Z",
+    )
+    if noise is not None:
+        print("FAIL: Loopxo noise should be filtered", file=sys.stderr)
+        return 1
+
+    if dedupe_key("https://a.io/x", "Title A") != dedupe_key("  HTTPS://A.IO/x  ", "title   a"):
+        print("FAIL: dedupe_key should normalize URL and title case/space", file=sys.stderr)
+        return 1
+
+    md = render_markdown(fixture)
+    if "## External discussions" not in md or "https://github.com/huangruiteng/loopx/issues/1" not in md:
+        print("FAIL: markdown digest missing external discussion section", file=sys.stderr)
+        return 1
+
+    print("ok: offline contract smoke passed")
+    return 0
+
+
+def _run_live(owner: str, repo: str) -> int:
+    from loopx_community_discussion.cli import build_scan
+
+    scan = build_scan(owner, repo, 14)
+    violations = validate_scan(scan)
+    if violations:
+        print(f"FAIL: live scan invalid: {violations}", file=sys.stderr)
+        return 1
+    print(f"ok: live scan for {owner}/{repo} passed contract validation ({len(scan['facts'])} facts)")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--live", nargs=2, metavar=("OWNER", "REPO"))
+    args = parser.parse_args()
+    if args.live:
+        return _run_live(*args.live)
+    return _run_offline()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/loopx-community-discussion/src/loopx_community_discussion/__init__.py
+++ b/packages/loopx-community-discussion/src/loopx_community_discussion/__init__.py
@@ -1,0 +1,5 @@
+"""Public-safe community discussion scanner for LoopX."""
+
+from .contract import FACT_SCHEMA_VERSION, SCAN_SCHEMA_VERSION
+
+__all__ = ["FACT_SCHEMA_VERSION", "SCAN_SCHEMA_VERSION"]

--- a/packages/loopx-community-discussion/src/loopx_community_discussion/cli.py
+++ b/packages/loopx-community-discussion/src/loopx_community_discussion/cli.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from collections.abc import Sequence
+from typing import Any
+
+from .contract import SCAN_SCHEMA_VERSION, validate_scan
+from .normalize import merge_facts
+from .render import render_markdown
+from .sources.github import collect_github
+from .sources.hn import collect_hn
+
+
+EXTENSION_ID = "loopx-community-discussion"
+REQUEST_SCHEMA_VERSION = "loopx_community_discussion_request_v0"
+RESPONSE_SCHEMA_VERSION = "loopx_community_discussion_response_v0"
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog=EXTENSION_ID)
+    parser.add_argument("--doctor", action="store_true", help="run the managed-runtime health check")
+    sub = parser.add_subparsers(dest="command")
+    scan = sub.add_parser("scan", help="collect a community discussion scan")
+    scan.add_argument("--owner", required=True)
+    scan.add_argument("--repo", required=True)
+    scan.add_argument("--days", type=int, default=14)
+    scan.add_argument("--format", choices=("json", "md"), default="json")
+    return parser
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    json.dump(payload, sys.stdout, sort_keys=True, ensure_ascii=False)
+    sys.stdout.write("\n")
+
+
+def _doctor() -> int:
+    _emit(
+        {
+            "ok": True,
+            "schema_version": RESPONSE_SCHEMA_VERSION,
+            "extension_id": EXTENSION_ID,
+            "doctor": "ok",
+        }
+    )
+    return 0
+
+
+def build_scan(owner: str, repo: str, days: int) -> dict[str, Any]:
+    if not owner.strip() or not repo.strip():
+        raise ValueError("owner and repo must be non-empty strings")
+    if days < 1 or days > 90:
+        raise ValueError("days must be between 1 and 90")
+    github_facts, github_evidence = collect_github(owner.strip(), repo.strip(), days)
+    hn_facts, hn_evidence = collect_hn(days)
+    raw_facts = github_facts + hn_facts
+    facts = merge_facts(raw_facts)
+    evidence = {
+        "sources": sorted(set(github_evidence["sources"] + hn_evidence["sources"])),
+        "rate_limit_remaining": github_evidence["rate_limit_remaining"],
+        "warnings": github_evidence["warnings"] + hn_evidence["warnings"],
+    }
+    return {
+        "schema_version": SCAN_SCHEMA_VERSION,
+        "scan_at": dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat(),
+        "window_days": days,
+        "repo": {"owner": owner.strip(), "name": repo.strip()},
+        "stats": {
+            "raw_facts": len(raw_facts),
+            "deduped_facts": len(facts),
+            "source_errors": sum(1 for f in facts if f["fact_type"] == "source_error"),
+            "strong": sum(1 for f in facts if f["relevance"] == "strong"),
+        },
+        "facts": facts,
+        "evidence": evidence,
+    }
+
+
+def _scan_command(args: argparse.Namespace) -> int:
+    try:
+        scan = build_scan(args.owner, args.repo, args.days)
+    except (ValueError, OSError) as exc:
+        _emit({"ok": False, "error": str(exc)})
+        return 1
+    violations = validate_scan(scan)
+    if violations:
+        _emit({"ok": False, "error": f"scan contract violated: {violations}"})
+        return 1
+    if args.format == "md":
+        sys.stdout.write(render_markdown(scan))
+    else:
+        _emit(scan)
+    return 0
+
+
+def _run_request(payload: dict[str, Any]) -> int:
+    if not isinstance(payload, dict):
+        raise ValueError("extension input must be a JSON object")
+    if payload.get("schema_version") != REQUEST_SCHEMA_VERSION:
+        raise ValueError(f"extension input must use {REQUEST_SCHEMA_VERSION}")
+    scan = build_scan(str(payload.get("owner") or ""), str(payload.get("repo") or ""), int(payload.get("days") or 14))
+    violations = validate_scan(scan)
+    if violations:
+        raise ValueError(f"scan contract violated: {violations}")
+    _emit(
+        {
+            "ok": True,
+            "schema_version": RESPONSE_SCHEMA_VERSION,
+            "extension_id": EXTENSION_ID,
+            "request_schema_version": REQUEST_SCHEMA_VERSION,
+            "result": scan,
+        }
+    )
+    return 0
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.doctor:
+        return _doctor()
+    try:
+        if args.command == "scan":
+            return _scan_command(args)
+        payload = json.load(sys.stdin)
+        return _run_request(payload)
+    except (json.JSONDecodeError, OSError, ValueError, KeyError) as exc:
+        _emit(
+            {
+                "ok": False,
+                "schema_version": RESPONSE_SCHEMA_VERSION,
+                "extension_id": EXTENSION_ID,
+                "error": str(exc),
+            }
+        )
+        return 1
+
+
+def main() -> int:
+    return run()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/loopx-community-discussion/src/loopx_community_discussion/contract.py
+++ b/packages/loopx-community-discussion/src/loopx_community_discussion/contract.py
@@ -1,0 +1,88 @@
+"""Public-safe community discussion fact and scan contract.
+
+Facts are metadata-first: title, source URL, author, timestamp, relevance.
+They never carry raw provider payloads, full post bodies, credentials, local
+paths, or private context.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+
+FACT_SCHEMA_VERSION = "discussion_fact_v0"
+SCAN_SCHEMA_VERSION = "community_discussion_scan_v0"
+
+FACT_TYPES = {
+    "external_discussion",
+    "maintainer_signal",
+    "ecosystem_signal",
+    "packaging",
+    "press",
+    "unanswered_question",
+    "source_error",
+}
+SOURCES = {"github", "hacker_news", "web", "reddit", "x"}
+RELEVANCE = {"strong", "weak"}
+
+
+def dedupe_key(source_url: str, title: str) -> str:
+    raw = f"{source_url.strip().lower()}::{' '.join(title.split()).lower()}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def validate_fact(fact: dict[str, Any]) -> list[str]:
+    violations: list[str] = []
+    if fact.get("schema_version") != FACT_SCHEMA_VERSION:
+        violations.append(f"schema_version must be {FACT_SCHEMA_VERSION}")
+    if fact.get("fact_type") not in FACT_TYPES:
+        violations.append(f"fact_type must be one of {sorted(FACT_TYPES)}")
+    if fact.get("source") not in SOURCES:
+        violations.append(f"source must be one of {sorted(SOURCES)}")
+    for key in ("source_url", "title", "relevance_reason"):
+        if not isinstance(fact.get(key), str) or not fact[key].strip():
+            violations.append(f"{key} must be a non-empty string")
+    for key in ("author", "published_at"):
+        if not isinstance(fact.get(key), str):
+            violations.append(f"{key} must be a string")
+    if fact.get("relevance") not in RELEVANCE:
+        violations.append(f"relevance must be one of {sorted(RELEVANCE)}")
+    key = fact.get("dedupe_key")
+    if not isinstance(key, str) or len(key) != 64 or any(c not in "0123456789abcdef" for c in key):
+        violations.append("dedupe_key must be a 64-char lowercase hex sha256")
+    return violations
+
+
+def validate_scan(scan: dict[str, Any]) -> list[str]:
+    violations: list[str] = []
+    if scan.get("schema_version") != SCAN_SCHEMA_VERSION:
+        violations.append(f"schema_version must be {SCAN_SCHEMA_VERSION}")
+    for key in ("scan_at", "repo", "stats", "facts", "evidence"):
+        if key not in scan:
+            violations.append(f"missing required field {key}")
+    repo = scan.get("repo")
+    if not isinstance(repo, dict) or not isinstance(repo.get("owner"), str) or not isinstance(repo.get("name"), str):
+        violations.append("repo must be an object with string owner and name")
+    stats = scan.get("stats")
+    if isinstance(stats, dict):
+        for metric in ("raw_facts", "deduped_facts", "source_errors", "strong"):
+            if not isinstance(stats.get(metric), int) or stats[metric] < 0:
+                violations.append(f"stats.{metric} must be a non-negative integer")
+    else:
+        violations.append("stats must be an object")
+    facts = scan.get("facts")
+    if not isinstance(facts, list):
+        violations.append("facts must be an array")
+    else:
+        for index, fact in enumerate(facts):
+            if not isinstance(fact, dict):
+                violations.append(f"facts[{index}] must be an object")
+                continue
+            violations.extend(f"facts[{index}].{v}" for v in validate_fact(fact))
+    evidence = scan.get("evidence")
+    if not isinstance(evidence, dict) or not isinstance(evidence.get("sources"), list) or not isinstance(
+        evidence.get("warnings"), list
+    ):
+        violations.append("evidence must be an object with sources and warnings arrays")
+    return violations

--- a/packages/loopx-community-discussion/src/loopx_community_discussion/normalize.py
+++ b/packages/loopx-community-discussion/src/loopx_community_discussion/normalize.py
@@ -1,0 +1,76 @@
+"""Disambiguation and deduplication helpers for community discussion facts."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .contract import dedupe_key
+
+
+NOISE_TERMS = (
+    "loopxo",
+    "looptap",
+    "looped",
+    "crowdstrike",
+    "loophole",
+    "loopy",
+    "loopear",
+)
+
+STRONG_TERMS = (
+    "huangruiteng",
+    "loop engineering",
+    "agent control plane",
+    "local-first agent",
+    "github.com/huangruiteng/loopx",
+    "loopx project",
+    "loopx repo",
+)
+
+
+def classify_relevance(title: str, url: str, text: str = "") -> tuple[str, str]:
+    haystack = " ".join((title, url, text)).lower()
+    if any(term in haystack for term in NOISE_TERMS):
+        return "noise", "matched noise term"
+    if any(term in haystack for term in STRONG_TERMS):
+        return "strong", "matched project disambiguation term"
+    return "weak", "no explicit project disambiguation term"
+
+
+def make_fact(
+    *,
+    fact_type: str,
+    source: str,
+    source_url: str,
+    title: str,
+    author: str,
+    published_at: str,
+    text: str = "",
+) -> dict[str, Any] | None:
+    relevance, reason = classify_relevance(title, source_url, text)
+    if relevance == "noise":
+        return None
+    return {
+        "schema_version": "discussion_fact_v0",
+        "fact_type": fact_type,
+        "source": source,
+        "source_url": source_url,
+        "title": title[:300],
+        "author": author,
+        "published_at": published_at,
+        "relevance": relevance,
+        "relevance_reason": reason,
+        "dedupe_key": dedupe_key(source_url, title),
+    }
+
+
+def merge_facts(facts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[str] = set()
+    deduped: list[dict[str, Any]] = []
+    for fact in facts:
+        key = fact["dedupe_key"]
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(fact)
+    return sorted(deduped, key=lambda f: f.get("published_at") or "", reverse=True)

--- a/packages/loopx-community-discussion/src/loopx_community_discussion/render.py
+++ b/packages/loopx-community-discussion/src/loopx_community_discussion/render.py
@@ -1,0 +1,65 @@
+"""Deterministic markdown digest projection for a community discussion scan."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+SECTION_CAPS = {
+    "external_discussion": 8,
+    "maintainer_signal": 5,
+    "ecosystem_signal": 5,
+    "press": 5,
+    "packaging": 5,
+}
+
+
+def _fact_line(fact: dict[str, Any]) -> str:
+    author = f" — {fact['author']}" if fact.get("author") else ""
+    return f"- [{fact['title']}]({fact['source_url']}){author}"
+
+
+def render_markdown(scan: dict[str, Any]) -> str:
+    repo = scan["repo"]
+    lines = [
+        f"# Community discussion: {repo['owner']}/{repo['name']}",
+        "",
+        f"Window: last {scan['window_days']} days · scan at {scan['scan_at']}",
+        "",
+    ]
+    stats = scan["stats"]
+    lines.append(
+        f"Facts: {stats['deduped_facts']} deduped "
+        f"({stats['strong']} strong, {stats['source_errors']} source errors)"
+    )
+    lines.append("")
+
+    by_type: dict[str, list[dict[str, Any]]] = {}
+    for fact in scan["facts"]:
+        by_type.setdefault(fact["fact_type"], []).append(fact)
+
+    sections = [
+        ("External discussions", "external_discussion"),
+        ("Maintainer signals", "maintainer_signal"),
+        ("Ecosystem signals", "ecosystem_signal"),
+        ("Press & packaging", "press", "packaging"),
+    ]
+    for title, *types in sections:
+        items: list[dict[str, Any]] = []
+        for fact_type in types:
+            items.extend(by_type.get(fact_type, []))
+        if not items:
+            continue
+        cap = min(SECTION_CAPS.get(types[0], 5), len(items))
+        lines.append(f"## {title}")
+        lines.append("")
+        lines.extend(_fact_line(fact) for fact in items[:cap])
+        lines.append("")
+
+    warnings = (scan.get("evidence") or {}).get("warnings") or []
+    if warnings:
+        lines.append("## Warnings")
+        lines.append("")
+        lines.extend(f"- {warning}" for warning in warnings[:10])
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"

--- a/packages/loopx-community-discussion/src/loopx_community_discussion/sources/__init__.py
+++ b/packages/loopx-community-discussion/src/loopx_community_discussion/sources/__init__.py
@@ -1,0 +1,1 @@
+"""Public-source collectors for community discussion facts."""

--- a/packages/loopx-community-discussion/src/loopx_community_discussion/sources/github.py
+++ b/packages/loopx-community-discussion/src/loopx_community_discussion/sources/github.py
@@ -1,0 +1,186 @@
+"""Bounded GitHub issue + discussion collector.
+
+Reads only public repository metadata. Authentication is read from the
+environment (`GH_TOKEN` or `GITHUB_TOKEN`); the request packet never carries
+credentials. Internal `[Task]`-style issues are filtered as non-community
+signals; maintainer-authored items are typed separately from external
+discussion so a digest can prioritize user voices.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+from ..normalize import make_fact
+
+
+API_BASE = "https://api.github.com"
+USER_AGENT = "loopx-community-discussion/0.1.0"
+REQUEST_TIMEOUT_SECONDS = 20
+
+INTERNAL_ISSUE_MARKERS = (
+    "[task]",
+    "[benchmark]",
+    "[sweep]",
+    "[chore]",
+)
+
+
+class GitHubSourceError(RuntimeError):
+    pass
+
+
+def _token() -> str | None:
+    return os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+
+
+def _headers() -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": USER_AGENT,
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    token = _token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _rest(path: str, params: dict[str, str]) -> tuple[Any, dict[str, str]]:
+    url = f"{API_BASE}{path}?{urllib.parse.urlencode(params)}"
+    req = urllib.request.Request(url, headers=_headers())
+    try:
+        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as resp:
+            headers = {k.lower(): v for k, v in resp.headers.items()}
+            body = resp.read().decode("utf-8")
+            return (json.loads(body) if body else None, headers)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:300]
+        raise GitHubSourceError(f"GET {path} failed with {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise GitHubSourceError(f"GET {path} unreachable: {exc.reason}") from exc
+
+
+def _graphql(query: str) -> dict[str, Any]:
+    token = _token()
+    if not token:
+        raise GitHubSourceError("GitHub Discussions collection requires GH_TOKEN or GITHUB_TOKEN")
+    req = urllib.request.Request(
+        f"{API_BASE}/graphql",
+        data=json.dumps({"query": query}).encode("utf-8"),
+        headers={**_headers(), "Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as resp:
+            body = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:300]
+        raise GitHubSourceError(f"GraphQL failed with {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise GitHubSourceError(f"GraphQL unreachable: {exc.reason}") from exc
+    data = json.loads(body)
+    if data.get("errors"):
+        raise GitHubSourceError(f"GraphQL errors: {data['errors'][:2]}")
+    return data
+
+
+def _issue_facts(owner: str, repo: str, since: str, rate_bucket: dict[str, Any]) -> list[dict[str, Any]]:
+    query = f"repo:{owner}/{repo} is:issue updated:>{since}"
+    data, headers = _rest(
+        "/search/issues",
+        {"q": query, "per_page": "100", "sort": "updated", "order": "desc"},
+    )
+    rate_bucket["rate_limit_remaining"] = _min_remaining(
+        rate_bucket.get("rate_limit_remaining"), headers.get("x-ratelimit-remaining")
+    )
+    facts: list[dict[str, Any]] = []
+    for item in data.get("items", []):
+        title = item.get("title") or ""
+        if title.lower().startswith(INTERNAL_ISSUE_MARKERS):
+            continue
+        author = (item.get("user") or {}).get("login") or ""
+        fact_type = "maintainer_signal" if author == owner else "external_discussion"
+        fact = make_fact(
+            fact_type=fact_type,
+            source="github",
+            source_url=item.get("html_url") or "",
+            title=title,
+            author=author,
+            published_at=item.get("created_at") or "",
+            text=(item.get("body") or "")[:2000],
+        )
+        if fact:
+            facts.append(fact)
+    return facts
+
+
+def _discussion_facts(owner: str, repo: str, rate_bucket: dict[str, Any]) -> list[dict[str, Any]]:
+    query = """
+    query {
+      repository(owner: "%s", name: "%s") {
+        discussions(first: 50, orderBy: {field: UPDATED_AT, direction: DESC}) {
+          nodes {
+            title
+            url
+            createdAt
+            updatedAt
+            author { login }
+            category { name }
+          }
+        }
+      }
+    }
+    """ % (owner, repo)
+    data = _graphql(query)
+    repo_data = (data.get("data") or {}).get("repository") or {}
+    nodes = ((repo_data.get("discussions") or {}).get("nodes")) or []
+    facts: list[dict[str, Any]] = []
+    for node in nodes:
+        author = (node.get("author") or {}).get("login") or ""
+        fact_type = "maintainer_signal" if author == owner else "external_discussion"
+        fact = make_fact(
+            fact_type=fact_type,
+            source="github",
+            source_url=node.get("url") or "",
+            title=node.get("title") or "",
+            author=author,
+            published_at=node.get("createdAt") or "",
+        )
+        if fact:
+            facts.append(fact)
+    return facts
+
+
+def _min_remaining(current: int | None, raw: str | None) -> int | None:
+    if raw is None:
+        return current
+    parsed = int(raw)
+    return parsed if current is None else min(current, parsed)
+
+
+def collect_github(owner: str, repo: str, days: int) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    since = (dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    rate_bucket: dict[str, Any] = {"rate_limit_remaining": None}
+    warnings: list[str] = []
+    facts: list[dict[str, Any]] = []
+    try:
+        facts.extend(_issue_facts(owner, repo, since, rate_bucket))
+    except GitHubSourceError as exc:
+        warnings.append(f"github issues skipped: {exc}")
+    try:
+        facts.extend(_discussion_facts(owner, repo, rate_bucket))
+    except GitHubSourceError as exc:
+        warnings.append(f"github discussions skipped: {exc}")
+    evidence = {
+        "sources": ["github-rest", "github-graphql"],
+        "rate_limit_remaining": rate_bucket["rate_limit_remaining"],
+        "warnings": warnings,
+    }
+    return facts, evidence

--- a/packages/loopx-community-discussion/src/loopx_community_discussion/sources/hn.py
+++ b/packages/loopx-community-discussion/src/loopx_community_discussion/sources/hn.py
@@ -1,0 +1,90 @@
+"""Exact-match Hacker News Algolia collector.
+
+Algolia's default typo tolerance returns thousands of unrelated hits for
+"loopx" (Loopxo, Looptap, looped music, CrowdStrike, 2018 crypto scams).
+This collector disables typo tolerance, restricts searchable attributes, and
+requires an exact substring match so only real mentions survive.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+from ..normalize import make_fact
+
+
+SEARCH_URL = "https://hn.algolia.com/api/v1/search"
+USER_AGENT = "loopx-community-discussion/0.1.0"
+REQUEST_TIMEOUT_SECONDS = 20
+
+
+class HNSourceError(RuntimeError):
+    pass
+
+
+def _search(query: str, since_unix: int, limit: int = 200) -> dict[str, Any]:
+    params = urllib.parse.urlencode(
+        {
+            "query": query,
+            "tags": "story",
+            "hitsPerPage": str(limit),
+            "numericFilters": f"created_at_i>{since_unix}",
+            "typoTolerance": "false",
+            "restrictSearchableAttributes": "title,url,story_text",
+        }
+    )
+    req = urllib.request.Request(f"{SEARCH_URL}?{params}", headers={"User-Agent": USER_AGENT})
+    last_error: Exception | None = None
+    for attempt in range(2):
+        try:
+            with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as resp:
+                body = resp.read().decode("utf-8")
+            return json.loads(body)
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")[:300]
+            raise HNSourceError(f"HN search failed with {exc.code}: {detail}") from exc
+        except urllib.error.URLError as exc:
+            last_error = exc
+            time.sleep(1.0)
+    raise HNSourceError(f"HN search unreachable: {last_error}") from last_error
+
+
+def collect_hn(days: int) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    since_unix = int((dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=days)).timestamp())
+    warnings: list[str] = []
+    facts: list[dict[str, Any]] = []
+    for query, default_type in (("loopx", "external_discussion"), ("loop engineering", "ecosystem_signal")):
+        try:
+            data = _search(query, since_unix)
+        except HNSourceError as exc:
+            warnings.append(f"hn query '{query}' skipped: {exc}")
+            continue
+        for hit in data.get("hits", []):
+            title = hit.get("title") or "(untitled)"
+            item_url = hit.get("url") or f"https://news.ycombinator.com/item?id={hit.get('objectID')}"
+            text = (hit.get("story_text") or "")[:2000]
+            haystack = " ".join((title, item_url, text)).lower()
+            if query.lower() not in haystack:
+                continue
+            fact_type = default_type
+            if query != "loopx" and "loopx" in haystack:
+                fact_type = "external_discussion"
+            fact = make_fact(
+                fact_type=fact_type,
+                source="hacker_news",
+                source_url=item_url,
+                title=title,
+                author=hit.get("author") or "",
+                published_at=hit.get("created_at") or "",
+                text=text,
+            )
+            if fact:
+                facts.append(fact)
+    evidence = {"sources": ["hn-algolia"], "rate_limit_remaining": None, "warnings": warnings}
+    return facts, evidence


### PR DESCRIPTION
Adds an independently packaged LoopX extension (`packages/loopx-community-discussion`) that turns public community discussion into typed `discussion_fact_v0` facts and a `community_discussion_scan_v0` document.

**Changed surfaces**

- New optional extension package: GitHub issues + GitHub discussions (GraphQL, needs `GH_TOKEN`) and exact-match HN Algolia (typo tolerance disabled to avoid Loopxo/Looptap/CrowdStrike noise).
- Deterministic markdown digest renderer and versioned JSON schemas (fact / scan / request / response).
- Offline contract smoke (`smoke/community_discussion_smoke.py`) plus optional live scan.
- One row in the `value-connectors` connector profile table.

**Boundary**

- Metadata-only facts (title, URL, author, timestamp, relevance, dedupe key); no raw payloads, post bodies, credentials, local paths, or private context.
- No external writes; digest delivery (e.g. Lark) stays an operator-owned, exactly gated step.
- X and Reddit are documented as non-bundled providers (X needs a logged-in browser/XMCP; Reddit public JSON is currently walled/rate-limited).

**Validation**

- `python3 -m py_compile` on the new package: passed.
- `python3 packages/loopx-community-discussion/smoke/community_discussion_smoke.py`: passed (dedupe, schema, noise filter, markdown render).
- Live scan `huangruiteng/loopx --days 14` with `GH_TOKEN`: 65 facts, 0 source errors.
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: passed 18/18, change-quality receipt `cqr_40a75c4512fd885373ac` valid for the exact scope fingerprint `40a75c4512fd885373acf32f3bf15a9829fb547612f5f79ca48839f2ba1dd47e`.