### PR TITLE
fix(quota): enforce a typed public-safe failure boundary

### DIFF
--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -269,6 +269,17 @@ def _prepare_quota_command_context(
     )
 
 
+def _verbose_debug_fields(error: Exception, *, verbose: bool) -> dict[str, object]:
+    if not verbose:
+        return {}
+    return {
+        "verbose_debug": {
+            "error_type": type(error).__name__,
+            "error": str(error),
+        }
+    }
+
+
 def _quota_failure_payload(
     args: argparse.Namespace,
     *,
@@ -278,6 +289,9 @@ def _quota_failure_payload(
 ) -> dict[str, object]:
     command = args.quota_command
     lock_timeout_fields = lock_timeout_error_fields(error)
+    verbose_debug = _verbose_debug_fields(
+        error, verbose=bool(getattr(args, "verbose", False))
+    )
     if command not in QUOTA_EVENT_KINDS:
         return {
             "ok": False,
@@ -305,6 +319,7 @@ def _quota_failure_payload(
                     "source": "quota",
                 }
             ],
+            **verbose_debug,
             **lock_timeout_fields,
         }
 
@@ -323,6 +338,7 @@ def _quota_failure_payload(
         "recommended_action": (
             "fix quota/status collection before spending automatic compute"
         ),
+        **verbose_debug,
         **lock_timeout_fields,
     }
     if lock_timeout_fields:

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -376,6 +376,86 @@ def _quota_failure_payload(
     return payload
 
 
+def _quota_validation_failure_payload(
+    args: argparse.Namespace,
+    exc: ValueError,
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+) -> dict[str, object]:
+    command = args.quota_command
+    if command not in QUOTA_EVENT_KINDS:
+        return {
+            "ok": False,
+            "mode": command,
+            "registry": str(registry_path),
+            "runtime_root": runtime_root_arg,
+            "error_code": "QUOTA_VALIDATION_FAILED",
+            "error": str(exc),
+            "summary": {
+                "registered_goals": 0,
+                "health_blockers": 0,
+                "next_automatic_turn": None,
+                "states": {},
+            },
+            "groups": {},
+            "health_items": [],
+        }
+    return {
+        "ok": False,
+        "mode": command,
+        "goal_id": args.goal_id,
+        "decision": "skip",
+        "should_run": False,
+        "error_code": "QUOTA_VALIDATION_FAILED",
+        "reason": str(exc),
+        "state": "blocked_validation",
+        "waiting_on": "codex",
+        "status": "quota_validation_failed",
+        "source": "quota",
+        "recommended_action": "fix the command arguments before retrying",
+    }
+
+
+def _quota_scheduler_fail_current_payload(
+    status_payload: dict[str, object],
+    args: argparse.Namespace,
+    *,
+    runtime_root: Path,
+    scheduler_context: Mapping[str, object] | SchedulerExecutionContextResolution | None,
+    operator_inbox_urgency_projector: Callable[..., dict[str, object]],
+) -> dict[str, object]:
+    observed_rrule = str(args.codex_app_current_rrule or "").strip()
+    if not observed_rrule:
+        host_observation = resolve_codex_app_automation_rrule(
+            goal_id=args.goal_id,
+            agent_id=args.agent_id,
+        )
+        if host_observation.get("available") is True:
+            observed_rrule = str(host_observation.get("rrule") or "")
+    failure_decision = build_quota_should_run(
+        status_payload,
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        available_capabilities=args.available_capabilities,
+        codex_app_current_rrule=observed_rrule,
+        scheduler_execution_context=scheduler_context,
+        operator_inbox_urgency_projector=operator_inbox_urgency_projector,
+    )
+    return record_quota_scheduler_failure_for_decision(
+        failure_decision,
+        runtime_root=runtime_root,
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        execute=bool(args.execute),
+        surface=args.surface,
+        state_key=args.state_key,
+        failed_rrule=args.failed_rrule,
+        observed_host_rrule=observed_rrule,
+        failure_kind=args.failure_kind,
+    )
+
+
 def _quota_renderer(
     args: argparse.Namespace,
 ) -> Callable[[dict[str, object]], str]:
@@ -575,34 +655,12 @@ def handle_quota_command(
                 operator_inbox_urgency_projector=operator_inbox_urgency_projector,
             )
         elif args.quota_command == "scheduler-fail-current":
-            observed_rrule = str(args.codex_app_current_rrule or "").strip()
-            if not observed_rrule:
-                host_observation = resolve_codex_app_automation_rrule(
-                    goal_id=args.goal_id,
-                    agent_id=args.agent_id,
-                )
-                if host_observation.get("available") is True:
-                    observed_rrule = str(host_observation.get("rrule") or "")
-            failure_decision = build_quota_should_run(
+            payload = _quota_scheduler_fail_current_payload(
                 status_payload,
-                goal_id=args.goal_id,
-                agent_id=args.agent_id,
-                available_capabilities=args.available_capabilities,
-                codex_app_current_rrule=observed_rrule,
-                scheduler_execution_context=scheduler_context,
-                operator_inbox_urgency_projector=operator_inbox_urgency_projector,
-            )
-            payload = record_quota_scheduler_failure_for_decision(
-                failure_decision,
+                args,
                 runtime_root=runtime_root,
-                goal_id=args.goal_id,
-                agent_id=args.agent_id,
-                execute=bool(args.execute),
-                surface=args.surface,
-                state_key=args.state_key,
-                failed_rrule=args.failed_rrule,
-                observed_host_rrule=observed_rrule,
-                failure_kind=args.failure_kind,
+                scheduler_context=scheduler_context,
+                operator_inbox_urgency_projector=operator_inbox_urgency_projector,
             )
         elif args.quota_command == "spend-slot":
             payload = spend_quota_slot(
@@ -635,41 +693,12 @@ def handle_quota_command(
     except ValueError as exc:
         # Validation errors carry bounded, public-safe messages —
         # surface them directly rather than routing through _quota_failure_payload.
-        command = args.quota_command
-        if command not in QUOTA_EVENT_KINDS:
-            payload = {
-                "ok": False,
-                "mode": command,
-                "registry": str(registry_path),
-                "runtime_root": runtime_root_arg,
-                "error_code": "QUOTA_VALIDATION_FAILED",
-                "error": str(exc),
-                "summary": {
-                    "registered_goals": 0,
-                    "health_blockers": 0,
-                    "next_automatic_turn": None,
-                    "states": {},
-                },
-                "groups": {},
-                "health_items": [],
-            }
-        else:
-            payload = {
-                "ok": False,
-                "mode": command,
-                "goal_id": args.goal_id,
-                "decision": "skip",
-                "should_run": False,
-                "error_code": "QUOTA_VALIDATION_FAILED",
-                "reason": str(exc),
-                "state": "blocked_validation",
-                "waiting_on": "codex",
-                "status": "quota_validation_failed",
-                "source": "quota",
-                "recommended_action": (
-                    "fix the command arguments before retrying"
-                ),
-            }
+        payload = _quota_validation_failure_payload(
+            args,
+            exc,
+            registry_path=registry_path,
+            runtime_root_arg=runtime_root_arg,
+        )
     except Exception as exc:  # noqa: BLE001 - CLI fail-safe boundary; error_code is typed below.
         payload = _quota_failure_payload(
             args,

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -616,6 +616,44 @@ def handle_quota_command(
             payload = build_quota_plan(status_payload, mode=args.quota_command)
         if cache_metadata:
             payload["status_projection_cache"] = cache_metadata
+    except ValueError as exc:
+        # Validation errors carry bounded, public-safe messages —
+        # surface them directly rather than routing through _quota_failure_payload.
+        command = args.quota_command
+        if command not in QUOTA_EVENT_KINDS:
+            payload = {
+                "ok": False,
+                "mode": command,
+                "registry": str(registry_path),
+                "runtime_root": runtime_root_arg,
+                "error_code": "QUOTA_VALIDATION_FAILED",
+                "error": str(exc),
+                "summary": {
+                    "registered_goals": 0,
+                    "health_blockers": 0,
+                    "next_automatic_turn": None,
+                    "states": {},
+                },
+                "groups": {},
+                "health_items": [],
+            }
+        else:
+            payload = {
+                "ok": False,
+                "mode": command,
+                "goal_id": args.goal_id,
+                "decision": "skip",
+                "should_run": False,
+                "error_code": "QUOTA_VALIDATION_FAILED",
+                "reason": str(exc),
+                "state": "blocked_validation",
+                "waiting_on": "codex",
+                "status": "quota_validation_failed",
+                "source": "quota",
+                "recommended_action": (
+                    "fix the command arguments before retrying"
+                ),
+            }
     except Exception as exc:  # noqa: BLE001 - CLI fail-safe boundary; error_code is typed below.
         payload = _quota_failure_payload(
             args,

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -285,7 +285,7 @@ def _quota_failure_payload(
             "registry": str(registry_path),
             "runtime_root": runtime_root_arg,
             "error_code": quota_error_code(error),
-            "error": str(error),
+            "error": "quota collection failed",
             "summary": {
                 "registered_goals": 0,
                 "health_blockers": 1,
@@ -299,7 +299,9 @@ def _quota_failure_payload(
                     "status": "quota_collection_failed",
                     "waiting_on": "codex",
                     "severity": "high",
-                    "recommended_action": str(error),
+                    "recommended_action": (
+                        "fix quota/status collection before spending automatic compute"
+                    ),
                     "source": "quota",
                 }
             ],
@@ -313,7 +315,7 @@ def _quota_failure_payload(
         "decision": "skip",
         "should_run": False,
         "error_code": quota_error_code(error),
-        "reason": str(error),
+        "reason": "quota collection failed",
         "state": "blocked_health",
         "waiting_on": "codex",
         "status": "quota_collection_failed",

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -15,7 +15,10 @@ from ..control_plane.quota.cli_projection import (
 )
 from ..control_plane.goals.path_resolution import resolve_goal_local_path
 from ..control_plane.quota.goal_boundary import registry_goal_by_id
-from ..control_plane.quota.error_codes import quota_error_code
+from ..control_plane.quota.error_codes import (
+    QuotaCommandValidationError,
+    quota_error_code,
+)
 from ..control_plane.quota.heartbeat_receipt import (
     fail_heartbeat_receipt,
     find_heartbeat_receipt,
@@ -129,12 +132,12 @@ def _scheduler_execution_context_from_args(
         args.execution_mode,
     )
     if args.codex_app and (args.runtime_profile or any(explicit_scheduler_fields)):
-        raise ValueError(
+        raise QuotaCommandValidationError(
             "--codex-app cannot be combined with --runtime-profile, "
             "--host-surface, --scheduler-owner, or --execution-mode"
         )
     if args.runtime_profile and any(explicit_scheduler_fields):
-        raise ValueError(
+        raise QuotaCommandValidationError(
             "--runtime-profile cannot be combined with --host-surface, "
             "--scheduler-owner, or --execution-mode"
         )
@@ -163,10 +166,12 @@ def _prepare_quota_command_context(
 ) -> _QuotaCommandContext:
     command = args.quota_command
     if bool(getattr(args, "turn_envelope", False)) and command != "should-run":
-        raise ValueError("--turn-envelope is only valid with `quota should-run`")
+        raise QuotaCommandValidationError(
+            "--turn-envelope is only valid with `quota should-run`"
+        )
     requested_details = set(getattr(args, "include_details", None) or ())
     if requested_details and command not in {"should-run", "monitor-poll"}:
-        raise ValueError(
+        raise QuotaCommandValidationError(
             "--include-detail is only valid with `quota should-run` or "
             "`quota monitor-poll`"
         )
@@ -178,7 +183,7 @@ def _prepare_quota_command_context(
         )
         unsupported_details = sorted(requested_details - allowed_details)
         if unsupported_details:
-            raise ValueError(
+            raise QuotaCommandValidationError(
                 f"`quota {command}` does not accept --include-detail "
                 f"{', '.join(unsupported_details)}"
             )
@@ -186,24 +191,40 @@ def _prepare_quota_command_context(
         bool(getattr(args, "include_scheduler_detail", False))
         and command != "should-run"
     ):
-        raise ValueError(
+        raise QuotaCommandValidationError(
             "--include-scheduler-detail is only valid with `quota should-run`"
         )
     if bool(getattr(args, "record_host_poll", False)) and command != "should-run":
-        raise ValueError("--record-host-poll is only valid with `quota should-run`")
+        raise QuotaCommandValidationError(
+            "--record-host-poll is only valid with `quota should-run`"
+        )
 
-    heartbeat_turn_id = normalize_turn_instance_id(
-        getattr(args, "turn_instance_id", None)
-    )
+    try:
+        heartbeat_turn_id = normalize_turn_instance_id(
+            getattr(args, "turn_instance_id", None)
+        )
+    except ValueError as exc:
+        raise QuotaCommandValidationError(str(exc)) from exc
     if heartbeat_turn_id and command not in {"should-run", "spend-slot"}:
-        raise ValueError(
+        raise QuotaCommandValidationError(
             "--turn-instance-id is only valid with `quota should-run` or "
             "`quota spend-slot`"
         )
     if heartbeat_turn_id and not args.agent_id:
-        raise ValueError("turn-scoped quota settlement requires --agent-id")
+        raise QuotaCommandValidationError(
+            "turn-scoped quota settlement requires --agent-id"
+        )
     if heartbeat_turn_id and command == "should-run" and bool(args.dry_run):
-        raise ValueError("turn-scoped `quota should-run` cannot use --dry-run")
+        raise QuotaCommandValidationError(
+            "turn-scoped `quota should-run` cannot use --dry-run"
+        )
+
+    scheduler_context = (
+        _scheduler_execution_context_from_args(args)
+        if command in QUOTA_SCHEDULER_COMMANDS
+        else None
+    )
+    validate_quota_command_request(args)
 
     scan_roots = [Path(item).expanduser() for item in args.scan_path]
     if not scan_roots:
@@ -221,11 +242,6 @@ def _prepare_quota_command_context(
     status_goal_id = args.goal_id if command not in {"status", "plan"} else None
     projection_cache_ttl_seconds = int(
         getattr(args, "projection_cache_ttl_seconds", 120)
-    )
-    scheduler_context = (
-        _scheduler_execution_context_from_args(args)
-        if command in QUOTA_SCHEDULER_COMMANDS
-        else None
     )
     status_payload = None
     cache_metadata = None
@@ -264,7 +280,6 @@ def _prepare_quota_command_context(
     elif isinstance(status_payload.get("projection_cache"), dict):
         cache_metadata = dict(status_payload["projection_cache"])
 
-    validate_quota_command_request(args)
     return _QuotaCommandContext(
         runtime_root=runtime_root,
         scan_roots=scan_roots,
@@ -388,7 +403,7 @@ def _quota_failure_payload(
 
 def _quota_validation_failure_payload(
     args: argparse.Namespace,
-    exc: ValueError,
+    exc: QuotaCommandValidationError,
     *,
     registry_path: Path,
     runtime_root_arg: str | None,
@@ -713,9 +728,8 @@ def handle_quota_command(
             payload = build_quota_plan(status_payload, mode=args.quota_command)
         if cache_metadata:
             payload["status_projection_cache"] = cache_metadata
-    except ValueError as exc:
-        # Validation errors carry bounded, public-safe messages —
-        # surface them directly rather than routing through _quota_failure_payload.
+    except QuotaCommandValidationError as exc:
+        # Only typed CLI validation diagnostics are public-safe by contract.
         payload = _quota_validation_failure_payload(
             args,
             exc,

--- a/loopx/cli_commands/quota_registration.py
+++ b/loopx/cli_commands/quota_registration.py
@@ -76,6 +76,15 @@ def register_quota_command(
         ),
     )
     quota_parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help=(
+            "Include the raw exception detail in failure payloads for maintainer "
+            "diagnosis. Off by default so the public failure payload stays "
+            "path-free."
+        ),
+    )
+    quota_parser.add_argument(
         "--include-scheduler-detail",
         action="store_true",
         # Deprecated compatibility alias. Remove in the next breaking release.

--- a/loopx/cli_commands/quota_request.py
+++ b/loopx/cli_commands/quota_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 
+from ..control_plane.quota.error_codes import QuotaCommandValidationError
 from ..control_plane.todos.contract import TODO_CONTINUATION_POLICY_VALUES
 
 QUOTA_SHOULD_RUN_DETAIL_SECTIONS = (
@@ -79,22 +80,28 @@ def register_quota_monitor_poll_request_arguments(
 def validate_quota_command_request(args: argparse.Namespace) -> None:
     command = args.quota_command
     if command not in {"status", "plan"} and not args.goal_id:
-        raise ValueError(f"`loopx quota {command}` requires --goal-id")
+        raise QuotaCommandValidationError(
+            f"`loopx quota {command}` requires --goal-id"
+        )
     scheduler_commands = {
         "scheduler-ack",
         "scheduler-ack-current",
         "scheduler-fail-current",
     }
     if command in scheduler_commands and not args.agent_id:
-        raise ValueError(f"`loopx quota {command}` requires --agent-id")
+        raise QuotaCommandValidationError(
+            f"`loopx quota {command}` requires --agent-id"
+        )
     if command == "void-slot" and not args.void_generated_at:
-        raise ValueError("`loopx quota void-slot` requires --void-generated-at")
+        raise QuotaCommandValidationError(
+            "`loopx quota void-slot` requires --void-generated-at"
+        )
     if (
         command not in {"status", "plan", "should-run"}
         and args.dry_run
         and args.execute
     ):
-        raise ValueError(
+        raise QuotaCommandValidationError(
             f"`loopx quota {command}` accepts only one of --dry-run or --execute"
         )
 

--- a/loopx/control_plane/quota/error_codes.py
+++ b/loopx/control_plane/quota/error_codes.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 import json
 
 
+class QuotaCommandValidationError(ValueError):
+    """Public-safe diagnostic for an invalid ``loopx quota`` invocation."""
+
+
 def quota_error_code(exc: BaseException) -> str:
     if isinstance(exc, json.JSONDecodeError):
         return "quota_state_invalid_json"
-    if isinstance(exc, ValueError):
+    if isinstance(exc, QuotaCommandValidationError):
         return "quota_invalid_arguments"
     if isinstance(exc, PermissionError):
         return "quota_state_permission_denied"

--- a/tests/control_plane/test_quota_error_codes.py
+++ b/tests/control_plane/test_quota_error_codes.py
@@ -4,13 +4,20 @@ import json
 
 import pytest
 
-from loopx.control_plane.quota.error_codes import quota_error_code
+from loopx.control_plane.quota.error_codes import (
+    QuotaCommandValidationError,
+    quota_error_code,
+)
 
 
 @pytest.mark.parametrize(
     ("exc", "expected"),
     [
-        (ValueError("bad argument"), "quota_invalid_arguments"),
+        (
+            QuotaCommandValidationError("bad argument"),
+            "quota_invalid_arguments",
+        ),
+        (ValueError("bad state value"), "quota_unexpected_collection_error"),
         (OSError("state unavailable"), "quota_state_io_failed"),
         (PermissionError("state denied"), "quota_state_permission_denied"),
         (KeyError("missing"), "quota_state_missing_field"),

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -176,6 +176,7 @@ def test_quota_include_detail_rejects_non_should_run_command(
     assert exit_code == 1
     payload = json.loads(capsys.readouterr().out)
     assert payload["ok"] is False
+    assert payload["error_code"] == "QUOTA_VALIDATION_FAILED"
     assert payload["error"] == (
         "--include-detail is only valid with `quota should-run` or "
         "`quota monitor-poll`"
@@ -210,6 +211,9 @@ def test_quota_include_detail_rejects_other_command_sections(
     assert exit_code == 1
     payload = json.loads(capsys.readouterr().out)
     assert payload["ok"] is False
+    assert payload["error_code"] == "QUOTA_VALIDATION_FAILED"
+    assert payload["state"] == "blocked_validation"
+    assert payload["status"] == "quota_validation_failed"
     assert payload["reason"] == (
         f"`quota {command}` does not accept --include-detail {section}"
     )
@@ -366,6 +370,49 @@ def test_deprecated_scheduler_detail_alias_is_hidden_from_help(
     help_text = capsys.readouterr().out
     assert "--include-detail" in help_text
     assert "--include-scheduler-detail" not in help_text
+
+
+def test_quota_collection_failure_payload_is_path_free_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from loopx.cli_commands import quota as quota_command
+
+    def fail_collect_status(**_kwargs: object) -> dict[str, object]:
+        raise FileNotFoundError("/private/internal/secret.json")
+
+    monkeypatch.setattr(quota_command, "collect_status", fail_collect_status)
+
+    exit_code = main(["--format", "json", "quota", "status"])
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["error_code"] == "quota_state_io_failed"
+    assert payload["error"] == "quota collection failed"
+    assert "verbose_debug" not in payload
+    assert "/private/internal/secret.json" not in json.dumps(payload, sort_keys=True)
+
+
+def test_quota_collection_failure_verbose_surfaces_raw_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from loopx.cli_commands import quota as quota_command
+
+    def fail_collect_status(**_kwargs: object) -> dict[str, object]:
+        raise FileNotFoundError("/private/internal/secret.json")
+
+    monkeypatch.setattr(quota_command, "collect_status", fail_collect_status)
+
+    exit_code = main(["--format", "json", "quota", "status", "--verbose"])
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["error"] == "quota collection failed"
+    assert payload["verbose_debug"]["error_type"] == "FileNotFoundError"
+    assert payload["verbose_debug"]["error"] == "/private/internal/secret.json"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -394,6 +394,30 @@ def test_quota_collection_failure_payload_is_path_free_by_default(
     assert "/private/internal/secret.json" not in json.dumps(payload, sort_keys=True)
 
 
+def test_quota_runtime_value_error_is_not_treated_as_public_safe_validation(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from loopx.cli_commands import quota as quota_command
+
+    def fail_collect_status(**_kwargs: object) -> dict[str, object]:
+        raise ValueError("/private/internal/runtime-secret.json")
+
+    monkeypatch.setattr(quota_command, "collect_status", fail_collect_status)
+
+    exit_code = main(["--format", "json", "quota", "status"])
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["error_code"] == "quota_unexpected_collection_error"
+    assert payload["error"] == "quota collection failed"
+    assert "verbose_debug" not in payload
+    assert "/private/internal/runtime-secret.json" not in json.dumps(
+        payload, sort_keys=True
+    )
+
+
 def test_quota_collection_failure_verbose_surfaces_raw_exception(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],


### PR DESCRIPTION
## Summary

- preserve the useful core of #2846: default quota failures no longer expose raw exception text, while `--verbose` remains an explicit maintainer opt-in;
- replace the broad `except ValueError` boundary with the typed `QuotaCommandValidationError`, so a runtime `ValueError` cannot be mistaken for a public-safe CLI diagnostic;
- validate quota arguments before loading status state, and classify an untyped runtime `ValueError` as `quota_unexpected_collection_error`;
- add positive and negative regression coverage for exact validation diagnostics, default path redaction, verbose diagnostics, and runtime `ValueError` redaction.

This supersedes #2846 because that PR's old base could no longer accept a maintainer fix without either a merge conflict or a DCO range polluted by later `main` history. The four signed commits from @rootkiller6788 are preserved as the second parent of the signed merge commit in this branch; the maintainer commit only tightens the exception boundary found during final review.

## Behavior change disclosure

- Default quota failure payloads use stable public-safe text instead of `str(error)`.
- Raw exception type and message are available only with explicit `--verbose`.
- Only `QuotaCommandValidationError` produces `QUOTA_VALIDATION_FAILED`; a runtime `ValueError` is now `quota_unexpected_collection_error`.
- Quota argument validation runs before status/projection-cache reads.

## Validation

- 452 focused tests across quota, scheduler execution context, CLI output budgets, turn envelopes, presentation, architecture boundaries, and the maintainability ratchet;
- Ruff on all changed Python and test files;
- `py_compile` on changed product modules;
- `git diff --check origin/main...HEAD`;
- `loopx canary premerge --from-git-diff`: 17/17 selected smokes passed, with no failures, skips, warnings, or manual holds.

## Public/private boundary

No credentials, local state, raw logs, or real private paths are included. The `/private/internal/...` strings in the tests are synthetic sentinels used only to prove that default payloads redact exception details.

## Merge decision

Ready for merge after hosted checks pass. Use a merge commit rather than squash so the original contributor's signed commits remain attributable.
