### PR TITLE
feat(install): make PyPI the default complete install path

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -102,6 +102,41 @@ jobs:
             dist/packages/*.whl
           test "$("${RUNNER_TEMP}/loopx-wheel/bin/loopx" --version)" = \
             "loopx ${RELEASE_TAG#v}"
+          skills_dir="${RUNNER_TEMP}/loopx-wheel-skills"
+          "${RUNNER_TEMP}/loopx-wheel/bin/loopx" --format json \
+            workflow-skills --install --skills-dir "${skills_dir}" \
+            > "${RUNNER_TEMP}/loopx-workflow-skills-install.json"
+          "${RUNNER_TEMP}/loopx-wheel/bin/python" - \
+            "${RUNNER_TEMP}/loopx-workflow-skills-install.json" <<'PY'
+          import json
+          from pathlib import Path
+          import sys
+
+          payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+          assert payload["ok"] is True, payload
+          assert payload["source"]["kind"] == "python_distribution", payload
+          assert payload["after"]["ready"] is True, payload
+          PY
+          "${RUNNER_TEMP}/loopx-wheel/bin/loopx" --format json \
+            workflow-skills --uninstall --skills-dir "${skills_dir}" \
+            > "${RUNNER_TEMP}/loopx-workflow-skills-uninstall.json"
+          "${RUNNER_TEMP}/loopx-wheel/bin/python" - \
+            "${RUNNER_TEMP}/loopx-workflow-skills-uninstall.json" <<'PY'
+          import json
+          from pathlib import Path
+          import sys
+
+          payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+          assert payload["ok"] is True, payload
+          assert sorted(payload["result"]["removed"]) == [
+              "loopx",
+              "loopx-doc-registry",
+              "loopx-pr-program",
+              "loopx-pr-review",
+              "loopx-project",
+              "loopx-self-repair",
+          ], payload
+          PY
 
       - name: Exercise release contract smoke
         run: python examples/release-artifacts-smoke.py

--- a/README.md
+++ b/README.md
@@ -189,17 +189,22 @@ More inspectable surfaces:
 
 ## Try LoopX
 
-Requirements: Python 3.11+, `curl`, `tar`, and a macOS or Linux shell. Git is
-only needed for contributor clone/canary workflows. The Python package has no
-runtime dependencies outside the standard library.
+Requirements: Python 3.11+ and a macOS or Linux shell. Use an active Python
+environment whose console scripts are on `PATH`; Git is only needed for
+contributor clone/canary workflows. The package has no runtime dependencies
+outside the standard library.
 
-Install without cloning:
+Install from PyPI without cloning:
 
 ```bash
-curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
-export PATH="$HOME/.local/bin:$PATH"
+python3 -m pip install --upgrade loopx
+loopx workflow-skills --install
 loopx doctor
 ```
+
+Restart your agent host after first install so it reloads the workflow skills.
+See [Installing LoopX](docs/guides/installing-loopx.md) for `pipx`, host
+command surfaces, upgrade, uninstall, and the archive fallback.
 
 Then connect from your project root:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -169,16 +169,21 @@ creator dogfooding、reproducible demo 和证据强度标签见
 
 ## 试用 LoopX
 
-要求：Python 3.11+、`curl`、`tar`，以及 macOS 或 Linux shell。普通用户不需要
-Git；Python package 除标准库外没有 runtime 依赖。
+要求：Python 3.11+，以及 macOS 或 Linux shell。使用 console scripts 已加入
+`PATH` 的 Python 环境；普通用户不需要 Git，package 除标准库外没有 runtime
+依赖。
 
-无需 clone，直接安装：
+无需 clone，直接从 PyPI 安装：
 
 ```bash
-curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
-export PATH="$HOME/.local/bin:$PATH"
+python3 -m pip install --upgrade loopx
+loopx workflow-skills --install
 loopx doctor
 ```
+
+首次安装后重启 Agent host，使其重新加载 workflow skills。`pipx`、host command
+surfaces、升级、卸载与 archive fallback 见
+[Installing LoopX](docs/guides/installing-loopx.md)。
 
 然后在项目根目录连接：
 

--- a/docs/book/chapters/05-connect-existing-project.md
+++ b/docs/book/chapters/05-connect-existing-project.md
@@ -121,19 +121,18 @@ next_action: <one concrete next step>
 
 - Python 3.11 或更高版本；
 - macOS 或 Linux shell；
-- `curl` 与 `tar`；
 - 一个已有 Git 项目。
 
-使用官方 no-clone installer：
+安装 PyPI release 及其 LoopX workflow skills：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
-export PATH="$HOME/.local/bin:$PATH"
+python3 -m pip install --upgrade loopx
+loopx workflow-skills --install
 loopx doctor
 ```
 
 !!! tip "为什么不先 clone LoopX"
-    普通使用者需要的是发布快照和 CLI，不是 LoopX 源码 checkout。clone-based install 留给希望运行
+    普通使用者需要的是已发布 CLI 和 workflow skills，不是 LoopX 源码 checkout。clone-based install 留给希望运行
     live canary 或贡献 Kernel 的开发者。
 
 `loopx doctor` 是安装事实的入口。不要只以 `which loopx` 成功作为健康证明；doctor 还会检查

--- a/docs/book/en/chapters/05-connect-existing-project.md
+++ b/docs/book/en/chapters/05-connect-existing-project.md
@@ -130,19 +130,18 @@ Prerequisites:
 
 - Python 3.11 or later;
 - a macOS or Linux shell;
-- `curl` and `tar`;
 - an existing Git project.
 
-Use the official no-clone installer:
+Install the PyPI release and its LoopX workflow skills:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
-export PATH="$HOME/.local/bin:$PATH"
+python3 -m pip install --upgrade loopx
+loopx workflow-skills --install
 loopx doctor
 ```
 
 !!! tip "Why not clone LoopX first?"
-    Most users need a release snapshot and CLI, not a Kernel source checkout. Clone-based installation is for
+    Most users need a published CLI and workflow skills, not a Kernel source checkout. Clone-based installation is for
     developers who need live canaries or intend to contribute to LoopX.
 
 Treat `loopx doctor` as the installation fact. A successful `which loopx` only proves that one executable

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -3,6 +3,7 @@
 Guides are task-oriented paths for people starting or operating LoopX.
 
 - [Getting started](getting-started.md)
+- [Installing LoopX](installing-loopx.md)
 - [Newcomer command path](newcomer-command-path.md)
 - [Minimal custom runtime example](minimal-custom-runtime-example.md)
 - [Minimal custom runtime example (中文)](minimal-custom-runtime-example.zh-CN.md)

--- a/docs/guides/custom-agent-runner-integration.md
+++ b/docs/guides/custom-agent-runner-integration.md
@@ -56,8 +56,7 @@ repository edits, and one-off tool use can remain Agent work.
 Install the CLI on the machine that owns the project workspace:
 
 ```bash
-curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
-export PATH="$HOME/.local/bin:$PATH"
+python3 -m pip install --upgrade loopx
 loopx doctor --agent-type other-agent
 ```
 

--- a/docs/guides/custom-agent-runner-integration.zh-CN.md
+++ b/docs/guides/custom-agent-runner-integration.zh-CN.md
@@ -49,8 +49,7 @@ transition policy 可复用时，才值得新增 Capability；外部实现放在
 先在拥有项目 workspace 的机器上安装 CLI：
 
 ```bash
-curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
-export PATH="$HOME/.local/bin:$PATH"
+python3 -m pip install --upgrade loopx
 loopx doctor --agent-type other-agent
 ```
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -27,9 +27,9 @@ state, but it cannot make an agent continue automatically.
 ```text
 Connect the current project to LoopX.
 Do not clone the LoopX repository for ordinary use. If `loopx` is not on PATH,
-install or repair it with the official no-clone installer:
-curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
-export PATH="$HOME/.local/bin:$PATH"
+install it from PyPI with Python 3.11+:
+python3 -m pip install --upgrade loopx
+loopx workflow-skills --install
 
 Then run `loopx doctor`. Work only from the current project root:
 1. If LoopX state already exists, reuse it and do not create or overwrite a
@@ -208,9 +208,10 @@ First-run path:
 
 ```text
 Connect this repo to LoopX from this visible Codex CLI TUI. Do not clone the
-LoopX repository for ordinary use. If `loopx` is not on PATH, install or repair
-it with the official no-clone installer:
-curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
+LoopX repository for ordinary use. If `loopx` is not on PATH, install it from
+PyPI with Python 3.11+:
+python3 -m pip install --upgrade loopx
+loopx workflow-skills --install
 
 Then run `loopx doctor`. Work only from this project root: if LoopX state
 already exists, reuse it and do not create or overwrite a goal or the active objective; if the project
@@ -349,43 +350,35 @@ Maintainers can validate the public fresh-clone path with:
 python3 examples/fresh-clone-quickstart-smoke.py
 ```
 
-## No-Clone Install
+## Install And Upgrade
 
-Install or update LoopX without cloning the repository:
+Install the current release from PyPI without cloning the repository:
 
 ```bash
-curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
-export PATH="$HOME/.local/bin:$PATH"
+python3 -m pip install --upgrade loopx
+loopx workflow-skills --install
 loopx doctor
 ```
 
-The installer downloads a GitHub archive, writes a stable local release snapshot
-under `~/.local/share/loopx/releases/`, installs the CLI wrapper under
-`~/.local/bin`, installs the `man loopx` page under
-`~/.local/share/man`, and installs the reusable LoopX skills under
-`~/.codex/skills`.
+The wheel contains the CLI and reusable LoopX workflow skills.
+`workflow-skills --install` materializes those skills under
+`~/.codex/skills` and writes a revision readback. Restart the host after first
+install so it reloads them. See [Installing LoopX](installing-loopx.md) for
+managed-environment, host-surface, rollback, and archive-fallback details.
 
-`loopx doctor` reports `install_freshness`. For a productized upgrade path, use
-the explicit self-update interface:
+For a PyPI install, upgrade the package and then refresh host material from the
+same distribution:
 
 ```bash
-loopx update --check
-loopx update --dry-run
-loopx update --execute
+python3 -m pip install --upgrade loopx
+loopx workflow-skills --install
+loopx slash-commands --install
+loopx doctor
 ```
 
-`--check` and `--dry-run` are read-only. For a GitHub repo/ref source,
-`--check` also performs a bounded version read from that exact ref. If the
-network is unavailable, it keeps the local health result and says that the
-latest source version could not be confirmed; a custom archive URL skips the
-comparison because LoopX cannot assume it matches the configured repo/ref.
-`--execute` reruns the no-clone installer, reports the source archive, keeps the
-previous release snapshot as a rollback target when possible, and validates the
-result with `loopx doctor`.
-
-This is the recommended install repair path for Codex CLI users because an
-agent can run it from inside the TUI without asking the user to clone this
-repository first.
+The GitHub Pages archive installer remains available as a fallback. Archive
+installs keep their existing `loopx update --check|--dry-run|--execute` path;
+do not mix that updater with the active PyPI executable.
 
 ## Contributor Install
 

--- a/docs/guides/installing-loopx.md
+++ b/docs/guides/installing-loopx.md
@@ -1,0 +1,91 @@
+# Installing LoopX
+
+PyPI is the default LoopX release channel. Use Python 3.11 or later in an
+active virtual environment, a managed user environment, or another environment
+whose console scripts are on `PATH`:
+
+```bash
+python3 -m pip install --upgrade loopx
+loopx workflow-skills --install
+loopx doctor
+```
+
+The package has no runtime dependencies outside the Python standard library.
+`workflow-skills --install` copies the packaged LoopX workflow skills into the
+user's Codex skill directory and writes a revision readback; it does not change
+project state or grant repository, network, or merge authority. Restart the
+host after first install so it reloads the new skills.
+
+If Python packages are externally managed on the machine, use a dedicated tool
+environment instead of modifying the system interpreter:
+
+```bash
+pipx install loopx
+loopx workflow-skills --install
+loopx doctor
+```
+
+## Host Command Surfaces
+
+The workflow-skill command installs the rich Codex workflows and managed
+`$loopx` entry. Install additional command facades only for hosts that need
+them:
+
+```bash
+loopx slash-commands --install
+```
+
+The default command-facade set covers Codex, Claude Code, and OpenCode. Other
+surfaces remain explicit; inspect `loopx slash-commands --help` before enabling
+one. Host integration changes command discovery only. It does not grant LoopX
+permission to write a repository, contact external systems, or bypass a user
+gate.
+
+## Upgrade And Repair
+
+Upgrade the Python distribution first, then refresh the host material from the
+same version:
+
+```bash
+python3 -m pip install --upgrade loopx
+loopx workflow-skills --install
+loopx slash-commands --install
+loopx doctor
+```
+
+`loopx doctor` reports `install_kind: python_distribution` for this path and
+returns the same pip-native repair sequence when packaged skills are missing or
+stale.
+
+## Archive Fallback
+
+The GitHub Pages installer remains a fallback for machines where an appropriate
+Python package environment is unavailable or the CLI is too damaged to run its
+own repair path:
+
+```bash
+curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+loopx doctor
+```
+
+This fallback installs an archive snapshot, wrapper, man page, and host
+materials together. Its update path remains `loopx update`; do not mix the
+archive and PyPI upgrade mechanisms for the same active executable.
+
+## Uninstall
+
+Remove LoopX-owned host material before uninstalling the Python package:
+
+```bash
+loopx slash-commands --uninstall
+loopx workflow-skills --uninstall
+python3 -m pip uninstall loopx
+```
+
+Both host uninstallers preserve same-name files whose content changed after
+LoopX installed them. Project-local `.loopx/`, `.codex/goals/`, evidence, and
+runtime state are not deleted by package uninstall.
+
+Contributors who need a live canary should use a real checkout and
+`scripts/install-local.sh`; see [Getting Started](getting-started.md).

--- a/docs/guides/newcomer-command-path.md
+++ b/docs/guides/newcomer-command-path.md
@@ -52,8 +52,8 @@ Use this when an agent asks for the manual shell path, or when you are setting
 up a fresh terminal without an agent driving the first step:
 
 ```bash
-curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
-export PATH="$HOME/.local/bin:$PATH"
+python3 -m pip install --upgrade loopx
+loopx workflow-skills --install
 loopx doctor
 loopx slash-commands --install
 loopx bootstrap-command-pack --project .

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,8 +52,8 @@ New to LoopX? Start with the
 ## Quick Start
 
 ```bash
-curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
-export PATH="$HOME/.local/bin:$PATH"
+python3 -m pip install --upgrade loopx
+loopx workflow-skills --install
 loopx doctor
 
 cd /path/to/your-project

--- a/docs/product/release-note-template.md
+++ b/docs/product/release-note-template.md
@@ -160,20 +160,21 @@ opt-in surface, replace the no-change declaration with one entry per surface:
 
 ## Install / Update
 
-New users should install from the named stable ref. Existing users should
-preview the update, then execute it explicitly:
+New PyPI users and existing PyPI users use the same package-native path:
+
+```bash
+python3 -m pip install --upgrade loopx
+loopx workflow-skills --install
+loopx slash-commands --install
+loopx doctor
+```
+
+Archive-fallback users should preview and execute their archive update
+explicitly:
 
 ```bash
 loopx update --check --ref stable
 loopx update --execute --ref stable
-loopx doctor
-```
-
-Fresh installs (no existing LoopX):
-
-```bash
-curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
-export PATH="$HOME/.local/bin:$PATH"
 loopx doctor
 ```
 

--- a/docs/product/runtimes/codex-cli/README.md
+++ b/docs/product/runtimes/codex-cli/README.md
@@ -8,9 +8,9 @@ bounded partner path rather than the default user experience.
 
 - [TUI-first LoopX loop](codex-cli-tui-loop.md): one visible TUI message starts
   LoopX, with session-attached automation as the preferred follow-up.
-- [Packaged install](codex-cli-packaged-install.md): no-clone install, update,
+- [Packaged install](codex-cli-packaged-install.md): PyPI install, update,
   and start path; clone-plus-canary remains a contributor route.
-- [First-run rehearsal](codex-cli-first-run-rehearsal.md): connects no-clone
+- [First-run rehearsal](codex-cli-first-run-rehearsal.md): connects PyPI
   install, one-message TUI bootstrap, and proof-capture fixtures.
 - [No-clone release verification](codex-cli-no-clone-release-verification.md):
   proves installer, bootstrap message, bundle, and proof fixtures stay aligned.

--- a/docs/product/runtimes/codex-cli/codex-cli-first-run-rehearsal.md
+++ b/docs/product/runtimes/codex-cli/codex-cli-first-run-rehearsal.md
@@ -9,7 +9,7 @@ or reading LoopX internals first.
 
 This route connects three shipped surfaces:
 
-1. no-clone install/update through the GitHub archive installer;
+1. PyPI install/update with packaged workflow skills and an archive fallback;
 2. one-message Codex CLI TUI bootstrap;
 3. proof-capture fixtures for later visible automation.
 
@@ -21,8 +21,8 @@ From the user's project repo:
 2. Paste one start message:
 
    ```text
-   Start LoopX for this repo. If `loopx` is missing, install it
-   with the official no-clone GitHub installer, then connect this project. Show
+   Start LoopX for this repo. If `loopx` is missing, install it from PyPI,
+   install the packaged workflow skills, then connect this project. Show
    me the current goal, concrete user gate if any, top todos, and next safe
    action before running longer work. Keep me in this Codex CLI TUI unless I
    explicitly accept a headless fallback. After I paste this, begin the Goal
@@ -32,8 +32,8 @@ From the user's project repo:
 3. The agent installs or repairs LoopX when needed, using:
 
    ```bash
-   curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
-   export PATH="$HOME/.local/bin:$PATH"
+   python3 -m pip install --upgrade loopx
+   loopx workflow-skills --install
    loopx doctor
    ```
 

--- a/docs/product/runtimes/codex-cli/codex-cli-no-clone-release-verification.md
+++ b/docs/product/runtimes/codex-cli/codex-cli-no-clone-release-verification.md
@@ -33,7 +33,7 @@ python3 examples/release/codex-cli-no-clone-release-verification-smoke.py
 
 ## Current Result
 
-Current release route: **ready as the default candidate, with one boundary**.
+Current archive route: **qualified as the recovery fallback, with one boundary**.
 
 Ready:
 
@@ -54,8 +54,8 @@ Boundary:
 - same-TUI automation is not the default path until visible proof plus runtime
   idle evidence pass.
 
-That means the product copy can prefer no-clone install for Codex CLI users,
-while contributor clone-plus-canary remains the development path.
+That means the archive route can remain a tested recovery option while PyPI is
+the default and contributor clone-plus-canary remains the development path.
 
 ## Release Checklist
 
@@ -68,10 +68,10 @@ python3 examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py
 python3 examples/codex-cli-proof-capture-demo-fixtures-smoke.py
 ```
 
-If the first command fails, do not advertise no-clone as the default until the
-failure is reduced to a compact blocker: missing installer dependency, archive
-layout mismatch, missing installed command, broken bootstrap generation, or
-missing public proof fixture.
+If the first command fails, do not advertise the archive fallback as qualified
+until the failure is reduced to a compact blocker: missing installer
+dependency, archive layout mismatch, missing installed command, broken
+bootstrap generation, or missing public proof fixture.
 
 ## Boundary
 

--- a/docs/product/runtimes/codex-cli/codex-cli-packaged-install.md
+++ b/docs/product/runtimes/codex-cli/codex-cli-packaged-install.md
@@ -1,13 +1,14 @@
 # Codex CLI Packaged Install Path
 
-Status: early product path.
+Status: shipped PyPI path with archive fallback.
 
 LoopX should be easy to adopt from the tool the user already has open.
 For Codex CLI users, the first successful path is:
 
 1. Open Codex CLI TUI in a project repo.
 2. Paste one LoopX start message.
-3. If `loopx` is missing, let the agent run the no-clone installer.
+3. If `loopx` is missing, let the agent install the PyPI distribution and its
+   packaged workflow skills.
 4. Return to the same TUI with current objective, gate, todo, and next safe action.
 
 The user should not have to clone this repository before learning whether
@@ -15,19 +16,18 @@ LoopX helps their project.
 
 ## Current User Path
 
-For a fresh machine, the installer can be run without a manual clone:
+For a fresh machine, install the release without a manual clone:
 
 ```bash
-curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
-export PATH="$HOME/.local/bin:$PATH"
+python3 -m pip install --upgrade loopx
+loopx workflow-skills --install
 loopx doctor
 ```
 
-The installer downloads a GitHub archive, creates a stable local release
-snapshot under `~/.local/share/loopx/releases/`, installs the
-`loopx` wrapper under `~/.local/bin`, and installs the reusable Codex
-skills under `~/.codex/skills`. It also refreshes the lightweight slash-command
-facades:
+The wheel installs the `loopx` CLI and carries the reusable Codex workflows.
+`workflow-skills --install` materializes the rich workflow skills and managed
+`$loopx` entry under `~/.codex/skills`, with a versioned readback. Additional
+host command facades remain explicit through `loopx slash-commands --install`:
 
 - `~/.codex/skills/loopx*/SKILL.md` for explicit Codex command-facade
   invocation through `$loopx` or `/skills`;
@@ -42,13 +42,10 @@ unsupported native slash surface. For an explicit Codex skill invocation, use
 loop, use `loopx codex-cli-bootstrap-message --project .`, paste the generated
 setup into the TUI, then set the generated `/goal <thin task_body>`.
 
-By default, the archive source is the public `stable` ref. Maintainers can
-override it with `LOOPX_REF=main` when intentionally testing or repairing from
-the current repository head.
-
-It intentionally skips `loopx-canary` by default because there is no
-durable live checkout in this mode. Contributors who want a canary should clone
-the repository and run `scripts/install-local.sh`.
+The GitHub Pages archive installer remains the recovery fallback when a usable
+Python package environment is unavailable. It intentionally skips
+`loopx-canary`; contributors who want a canary should clone the repository and
+run `scripts/install-local.sh`.
 
 ## Codex CLI TUI Message
 
@@ -56,7 +53,8 @@ The agent-first start message can now be stricter about install repair:
 
 ```text
 Start LoopX for this repo. If `loopx` is missing, install it with
-the official no-clone GitHub installer, then connect this project. Show me the
+`python3 -m pip install --upgrade loopx`, run
+`loopx workflow-skills --install`, then connect this project. Show me the
 current objective, concrete user gate if any, top todos, and next safe action before
 running longer work. Keep me in this Codex CLI TUI unless I explicitly accept a
 headless fallback.
@@ -78,8 +76,17 @@ This keeps the product hierarchy clear:
 
 ## Update Path
 
-For users installed through the archive script, update through the explicit
-LoopX CLI flow:
+For PyPI users, upgrade the distribution and refresh host material together:
+
+```bash
+python3 -m pip install --upgrade loopx
+loopx workflow-skills --install
+loopx slash-commands --install
+loopx doctor
+```
+
+For users installed through the archive fallback, keep the explicit archive
+update flow:
 
 ```bash
 loopx update --check
@@ -122,12 +129,9 @@ which is useful for validating local changes before promotion.
 
 ## Future Packaging
 
-The no-clone archive installer is the first bridge. A mature release channel
-should later add:
+PyPI is the current default. Later channels may add:
 
 - a signed or checksum-pinned release archive;
-- `pipx install loopx` or `uv tool install loopx` after package
-  publishing is ready;
 - a Homebrew formula for macOS users;
 - signed release manifests that report current release id, latest available
   release, and installed skill freshness.

--- a/docs/product/runtimes/codex-cli/codex-cli-tui-loop.md
+++ b/docs/product/runtimes/codex-cli/codex-cli-tui-loop.md
@@ -23,8 +23,9 @@ The best first-run experience is one TUI setup message:
 ```text
 Connect this repo to LoopX from this visible Codex CLI TUI. Do not clone the
 LoopX repository for ordinary use. If `loopx` is not on PATH, install or repair
-it with the official no-clone installer:
-curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
+it from PyPI with Python 3.11+:
+python3 -m pip install --upgrade loopx
+loopx workflow-skills --install
 
 Then run `loopx doctor`. Work only from this project root: if LoopX state
 already exists, reuse it and do not create or overwrite a goal; if the project
@@ -43,8 +44,8 @@ the loop is heartbeat automation every 3 minutes with `<thin task_body>`. The
 message should be enough for a terminal agent to:
 
 - run `loopx doctor`;
-- install or repair the local CLI if it is missing, using the no-clone archive
-  installer before asking the user to clone the LoopX repo;
+- install or repair the local CLI if it is missing, using PyPI and the packaged
+  workflow-skill installer before asking the user to clone the LoopX repo;
 - reuse existing LoopX state without creating or overwriting a goal;
 - connect the repo when needed, using bootstrap only for clear initialization;
 - ensure `.loopx/`, `.codex/goals/`, and `.local/` stay local;
@@ -101,7 +102,7 @@ loopx codex-cli-tui-bootstrap-smoke-bundle --project . --goal-id <goal-id> --age
 ```
 
 This packet is for product and release validation, not an extra user step. It
-checks the no-clone install repair path, the copy-only paste block, the quota
+checks the PyPI-first install repair path, the copy-only paste block, the quota
 guard command, and the bounded writeback/spend commands without launching
 Codex, reading transcripts, inspecting session files, mutating a session, or
 spending quota.

--- a/examples/codex-cli-bootstrap-message-smoke.py
+++ b/examples/codex-cli-bootstrap-message-smoke.py
@@ -48,6 +48,8 @@ MUST_HAVE = (
     "refresh-state",
     "quota spend-slot",
     "Do not spend quota for a setup-only turn",
+    "python3 -m pip install --upgrade loopx",
+    "workflow-skills --install",
     "huangruiteng.github.io/loopx/install.sh",
 )
 
@@ -58,6 +60,8 @@ def assert_message_contract(payload: dict[str, object]) -> None:
     assert payload["invocation_mode"] == "codex_cli_setup_then_goal_mode", payload
     assert payload["goal_id"] == GOAL_ID, payload
     assert payload["agent_id"] == AGENT_ID, payload
+    assert "python3 -m pip install --upgrade loopx" in str(payload["install_repair_command"]), payload
+    assert "workflow-skills --install" in str(payload["install_repair_command"]), payload
     assert "huangruiteng.github.io/loopx/install.sh" in str(payload["install_repair_command"]), payload
     assert payload["existing_goal_probe_command"] == payload["quota_guard_command"], payload
     assert "heartbeat-prompt --thin" in str(payload["heartbeat_prompt_command"]), payload
@@ -219,6 +223,7 @@ def main() -> int:
     assert "Post-Bootstrap Thin Loop Prompt" in cli_markdown, cli_markdown
     assert "Transcript-Free Validation Checklist" in cli_markdown, cli_markdown
     assert "huangruiteng.github.io/loopx/install.sh" in cli_markdown, cli_markdown
+    assert "python3 -m pip install --upgrade loopx" in cli_markdown, cli_markdown
 
     cli_message_only = run_cli(
         "codex-cli-bootstrap-message",

--- a/examples/codex-cli-first-run-rehearsal-smoke.py
+++ b/examples/codex-cli-first-run-rehearsal-smoke.py
@@ -40,11 +40,12 @@ def assert_doc() -> None:
 
     must_have = (
         "Codex CLI First-Run Rehearsal",
-        "no-clone install/update through the GitHub archive installer",
+        "PyPI install/update with packaged workflow skills and an archive fallback",
         "one-message Codex CLI TUI bootstrap",
         "proof-capture fixtures for later visible automation",
         "Start LoopX for this repo",
-        "huangruiteng.github.io/loopx/install.sh",
+        "python3 -m pip install --upgrade loopx",
+        "loopx workflow-skills --install",
         "loopx codex-cli-bootstrap-message --project . --goal-id <goal-id> --message-only",
         "loopx codex-cli-tui-bootstrap-smoke-bundle",
         "loopx --format json codex-cli-visible-attach-acceptance",
@@ -73,7 +74,7 @@ def assert_indexes() -> None:
     assert link in product, product
     assert "product/README.md" in docs, docs
     assert f"../product/runtimes/codex-cli/{link}" in getting_started, getting_started
-    assert "no-clone install" in product, product
+    assert "PyPI" in product, product
     assert "one-message TUI bootstrap" in product, product
     assert "proof-capture fixtures" in getting_started, getting_started
 
@@ -94,7 +95,8 @@ def assert_cli_surfaces_align() -> None:
     assert not message.startswith("/goal "), message
     assert "setup/bootstrap instruction" in normalized, message
     assert "/goal <thin task_body>" in normalized, message
-    assert "huangruiteng.github.io/loopx/install.sh" in normalized, message
+    assert "python3 -m pip install --upgrade loopx" in normalized, message
+    assert "workflow-skills --install" in normalized, message
     assert "Codex CLI TUI" in normalized, message
     assert "quota should-run" in normalized, message
     assert "quota spend-slot" in normalized, message

--- a/examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py
+++ b/examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py
@@ -138,6 +138,8 @@ def main() -> None:
         assert "--message-only" in bundle["message_only_command"], bundle
         assert str(fresh_repo) in bundle["message_only_command"], bundle
         assert "huangruiteng.github.io/loopx/install.sh" in bundle["install_repair_command"], bundle
+        assert "python3 -m pip install --upgrade loopx" in bundle["install_repair_command"], bundle
+        assert "workflow-skills --install" in bundle["install_repair_command"], bundle
         assert "quota should-run" in bundle["quota_guard_command"], bundle
         assert "--agent-id codex-side-bypass" in bundle["quota_guard_command"], bundle
         assert "refresh-state --goal-id public-fresh-codex-cli-goal" in bundle["refresh_command"], bundle
@@ -182,6 +184,7 @@ def main() -> None:
         assert "# Codex CLI LoopX Bootstrap Message" not in message_only, message_only
         assert "Fresh Repo Install Repair" not in message_only, message_only
         assert "huangruiteng.github.io/loopx/install.sh" in message_only, message_only
+        assert "python3 -m pip install --upgrade loopx" in message_only, message_only
         assert "/goal <thin task_body>" in message_only, message_only
         assert "quota should-run" in message_only, message_only
         assert "refresh-state --goal-id public-fresh-codex-cli-goal" in message_only, message_only

--- a/examples/fresh-clone-quickstart-smoke.py
+++ b/examples/fresh-clone-quickstart-smoke.py
@@ -68,6 +68,7 @@ def main() -> int:
             "LOOPX_SHELL_PROFILE": str(profile),
             "LOOPX_INSTALL_SKILL": "1",
             "LOOPX_INSTALL_CANARY": "1",
+            "LOOPX_PYTHON": sys.executable,
             "LOOPX_PROMOTE_DEFAULT": "1",
             "LOOPX_RELEASE_ID": "fresh-clone-smoke-release",
             "PATH": os.environ.get("PATH", ""),
@@ -144,7 +145,9 @@ def main() -> int:
         )
         assert bootstrap["ok"] is True, bootstrap
         assert bootstrap["goal_id"] == GOAL_ID, bootstrap
-        assert "huangruiteng.github.io/loopx/install.sh" in bootstrap["install_repair_command"], bootstrap
+        assert "python3 -m pip install --upgrade loopx" in bootstrap["install_repair_command"], bootstrap
+        assert "loopx workflow-skills --install" in bootstrap["install_repair_command"], bootstrap
+        assert "huangruiteng.github.io/loopx/install.sh" in bootstrap["archive_fallback_install_command"], bootstrap
         assert "loopx doctor" in bootstrap["install_repair_command"], bootstrap
         assert (project / ".loopx" / "registry.json").is_file(), bootstrap
         assert (project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md").is_file(), bootstrap

--- a/examples/release-artifacts-smoke.py
+++ b/examples/release-artifacts-smoke.py
@@ -159,6 +159,9 @@ def main() -> int:
         "vars.PYPI_PUBLISH_ENABLED == 'true'",
         "environment:\n      name: pypi",
         "pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33",
+        "workflow-skills --install --skills-dir",
+        "workflow-skills --uninstall --skills-dir",
+        'payload["source"]["kind"] == "python_distribution"',
     )
     for text in required_contract:
         assert text in workflow, text

--- a/examples/release/codex-cli-no-clone-release-verification-smoke.py
+++ b/examples/release/codex-cli-no-clone-release-verification-smoke.py
@@ -87,7 +87,7 @@ def assert_docs() -> None:
         "codex-cli-bootstrap-message",
         "codex-cli-tui-bootstrap-smoke-bundle",
         "codex-cli-visible-attach-acceptance",
-        "Current release route: **ready as the default candidate, with one boundary**.",
+        "Current archive route: **qualified as the recovery fallback, with one boundary**.",
         "network access to GitHub archive endpoints",
         "same-TUI automation is not the default path",
         "python3 examples/release/codex-cli-no-clone-release-verification-smoke.py",
@@ -161,7 +161,8 @@ def assert_installed_release(
     assert not message.startswith("/goal "), message
     assert "setup/bootstrap instruction" in normalized_message, message
     assert "/goal <thin task_body>" in normalized_message, message
-    assert "huangruiteng.github.io/loopx/install.sh" in normalized_message, message
+    assert "python3 -m pip install --upgrade loopx" in normalized_message, message
+    assert "workflow-skills --install" in normalized_message, message
     assert "Codex CLI TUI" in normalized_message, message
     assert "quota should-run" in normalized_message, message
     assert "quota spend-slot" in normalized_message, message

--- a/loopx/agent_onboarding.py
+++ b/loopx/agent_onboarding.py
@@ -17,7 +17,7 @@ from .host_loop_activation import (
 from .install_contract import NO_CLONE_INSTALL_URL
 from .project_prompt import (
     render_available_capability_args,
-    render_codex_cli_no_clone_preflight,
+    render_codex_cli_install_preflight,
     render_quota_guard_command,
     shell_arg,
 )
@@ -396,7 +396,7 @@ def build_agent_onboarding_packet(
         available_capabilities=normalized_available_capabilities,
     )
     commands: dict[str, Any] = {
-        "doctor_or_install": render_codex_cli_no_clone_preflight(
+        "doctor_or_install": render_codex_cli_install_preflight(
             cli_bin=cli_bin,
             doctor_agent_type=canonical_agent_type,
         ),

--- a/loopx/bootstrap.py
+++ b/loopx/bootstrap.py
@@ -18,7 +18,10 @@ from .execution_profile import (
     execution_profile_summary,
 )
 from .global_registry import sync_project_registry_to_global
-from .install_contract import NO_CLONE_INSTALL_URL
+from .install_contract import (
+    ARCHIVE_FALLBACK_INSTALL_COMMAND,
+    DEFAULT_INSTALL_REPAIR_COMMAND,
+)
 from .onboarding import build_onboarding_scan
 from .orchestration import (
     DEFAULT_ORCHESTRATION_MODE,
@@ -33,11 +36,6 @@ DEFAULT_OBJECTIVE = "Improve this project through bounded, verified goal segment
 DEFAULT_DOMAIN = "project-goal-control-plane"
 GENERIC_ONBOARDING_ADAPTER_KINDS = frozenset(
     {"generic_project_goal_v0", "read_only_project_map_v0"}
-)
-NO_CLONE_INSTALL_REPAIR_COMMAND = (
-    f"curl -fsSL {NO_CLONE_INSTALL_URL} | bash\n"
-    'export PATH="$HOME/.local/bin:$PATH"\n'
-    "loopx doctor"
 )
 HEARTBEAT_OPT_IN_STATUS_REQUIRED = (
     "requires explicit heartbeat=yes/no before a recurring Codex App automation is installed"
@@ -873,10 +871,11 @@ def bootstrap_project(
                     "Fix global registry write access, then rerun this command.",
                     "Use --no-global-sync only for an explicit local-only setup.",
                 ],
-                "install_repair_command": NO_CLONE_INSTALL_REPAIR_COMMAND,
+                "install_repair_command": DEFAULT_INSTALL_REPAIR_COMMAND,
+                "archive_fallback_install_command": ARCHIVE_FALLBACK_INSTALL_COMMAND,
                 "install_repair_note": (
-                    "If this local LoopX install is missing or stale, rerun the no-clone installer, "
-                    "refresh PATH, and confirm with loopx doctor before continuing project delivery."
+                    "If this local LoopX install is missing or stale, repair the PyPI distribution "
+                    "and packaged workflow skills, then confirm with loopx doctor before continuing."
                 ),
                 "private_boundary_note": "Add .loopx/ and .codex/goals/ to the project .gitignore if the goal state contains private evidence.",
                 "error": str(global_writability.get("error") or "global registry is not writable"),
@@ -962,10 +961,11 @@ def bootstrap_project(
             f"loopx --registry {runtime_root / 'registry.global.json'} status",
             f"loopx --registry {relative_state_file(project, registry_path)} history --goal-id {goal_id}",
         ],
-        "install_repair_command": NO_CLONE_INSTALL_REPAIR_COMMAND,
+        "install_repair_command": DEFAULT_INSTALL_REPAIR_COMMAND,
+        "archive_fallback_install_command": ARCHIVE_FALLBACK_INSTALL_COMMAND,
         "install_repair_note": (
-            "If this local LoopX install is missing or stale, rerun the no-clone installer, "
-            "refresh PATH, and confirm with loopx doctor before continuing project delivery."
+            "If this local LoopX install is missing or stale, repair the PyPI distribution "
+            "and packaged workflow skills, then confirm with loopx doctor before continuing."
         ),
         "private_boundary_note": "Add .loopx/ and .codex/goals/ to the project .gitignore if the goal state contains private evidence.",
     }
@@ -1107,6 +1107,17 @@ def render_bootstrap_markdown(payload: dict[str, Any]) -> str:
                 str(payload.get("install_repair_note") or ""),
                 "```bash",
                 str(payload.get("install_repair_command")),
+                "```",
+            ]
+        )
+    if payload.get("archive_fallback_install_command"):
+        lines.extend(
+            [
+                "",
+                "### Archive Fallback",
+                "Use this only when an appropriate Python package environment is unavailable.",
+                "```bash",
+                str(payload.get("archive_fallback_install_command")),
                 "```",
             ]
         )

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -97,6 +97,7 @@ from .cli_commands import (
     handle_version_command,
     handle_host_mode_plan_command,
     handle_worker_bridge_command,
+    handle_workflow_skills_command,
     register_benchmark_command_group,
     register_turn_commands,
     register_bootstrap_connect_command,
@@ -135,6 +136,7 @@ from .cli_commands import (
     register_version_command,
     register_host_mode_plan_command,
     register_worker_bridge_commands,
+    register_workflow_skills_command,
 )
 from .cli_commands.opencode2_goal_worker import (
     handle_opencode2_goal_worker_command,
@@ -288,6 +290,7 @@ def build_parser() -> LoopXArgumentParser:
     register_summary_all_command(sub, add_subcommand_format)
     register_pr_review_command(sub, add_subcommand_format)
     register_slash_commands_command(sub, add_subcommand_format)
+    register_workflow_skills_command(sub, add_subcommand_format)
     register_dreaming_commands(sub, add_subcommand_format)
     register_evidence_log_command(sub, add_subcommand_format)
     register_explore_commands(sub, add_subcommand_format)
@@ -350,6 +353,7 @@ def main(argv: list[str] | None = None) -> int:
             "new-project-prompt",
             "start-goal",
             "slash-commands",
+            "workflow-skills",
             "heartbeat-prompt",
             "supervisor-event",
             "supervisor-observe",
@@ -394,6 +398,14 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "doctor":
         return handle_doctor_command(args, print_payload)
+
+    workflow_skills_result = handle_workflow_skills_command(
+        args,
+        output_format=output_format,
+        print_payload=print_payload,
+    )
+    if workflow_skills_result is not None:
+        return workflow_skills_result
 
     if args.command == "first-run-report":
         return handle_first_run_report_command(args, print_payload)

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -122,6 +122,10 @@ from .task_lease import handle_task_lease_command, register_task_lease_command
 from .todo import handle_todo_command, register_todo_command
 from .version import handle_version_command, register_version_command
 from .worker_bridge import handle_worker_bridge_command, register_worker_bridge_commands
+from .workflow_skills import (
+    handle_workflow_skills_command,
+    register_workflow_skills_command,
+)
 
 __all__ = [
     "handle_turn_command",
@@ -190,6 +194,7 @@ __all__ = [
     "handle_todo_command",
     "handle_version_command",
     "handle_worker_bridge_command",
+    "handle_workflow_skills_command",
     "register_turn_commands",
     "register_host_mode_plan_command",
     "register_benchmark_boundary_commands",
@@ -233,4 +238,5 @@ __all__ = [
     "register_todo_command",
     "register_version_command",
     "register_worker_bridge_commands",
+    "register_workflow_skills_command",
 ]

--- a/loopx/cli_commands/workflow_skills.py
+++ b/loopx/cli_commands/workflow_skills.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+from ..workflow_skill_install import (
+    render_workflow_skill_install_markdown,
+    workflow_skill_install,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+FormatSelector = Callable[..., str]
+
+
+def register_workflow_skills_command(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    parser = subparsers.add_parser(
+        "workflow-skills",
+        help="Inspect, install, or uninstall the packaged LoopX workflow skills.",
+    )
+    add_subcommand_format(parser)
+    mutation = parser.add_mutually_exclusive_group()
+    mutation.add_argument(
+        "--install",
+        action="store_true",
+        help="Install the packaged workflow skills and managed $loopx entry skill.",
+    )
+    mutation.add_argument(
+        "--uninstall",
+        action="store_true",
+        help="Remove unchanged LoopX-managed workflow skills.",
+    )
+    parser.add_argument(
+        "--skills-dir",
+        help="Target host skill root. Defaults to CODEX_HOME/skills or ~/.codex/skills.",
+    )
+    parser.add_argument(
+        "--cli-bin",
+        default="loopx",
+        help="LoopX executable name embedded in the generated $loopx entry skill.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Inspect the requested operation without writing files.",
+    )
+
+
+def handle_workflow_skills_command(
+    args: argparse.Namespace,
+    *,
+    output_format: FormatSelector,
+    print_payload: PrintPayload,
+) -> int | None:
+    if args.command != "workflow-skills":
+        return None
+    payload = workflow_skill_install(
+        skills_dir=Path(args.skills_dir) if args.skills_dir else None,
+        execute=bool((args.install or args.uninstall) and not args.dry_run),
+        uninstall=bool(args.uninstall),
+        cli_bin=args.cli_bin,
+    )
+    print_payload(
+        payload,
+        output_format(args),
+        render_workflow_skill_install_markdown,
+    )
+    return 0 if payload.get("ok") is True else 1

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from enum import Enum
+from importlib.metadata import PackageNotFoundError, distribution
 import json
 import os
 import re
@@ -127,7 +128,7 @@ def resolve_command_path(name: str) -> Path | None:
 
 
 def current_script_invocation_path() -> Path | None:
-    """Return the active LoopX wrapper when doctor was invoked by absolute path."""
+    """Return the active LoopX executable when invoked through its console script."""
     if not sys.argv or not sys.argv[0]:
         return None
     path = Path(sys.argv[0]).expanduser()
@@ -137,9 +138,34 @@ def current_script_invocation_path() -> Path | None:
         path = path.resolve()
     except OSError:
         path = path.absolute()
-    if path.exists() and path.name == "loopx" and path.parent.name == "scripts":
+    if path.exists() and path.name == "loopx":
         return path
     return None
+
+
+def python_distribution_install(module_path: Path) -> dict[str, Any]:
+    """Identify a wheel/sdist install that owns the imported LoopX module."""
+
+    try:
+        installed = distribution("loopx")
+    except PackageNotFoundError:
+        return {"available": False}
+    installer = (installed.read_text("INSTALLER") or "").strip() or "unknown"
+    expected = module_path.resolve()
+    owns_module = any(
+        item.as_posix().endswith("loopx/doctor.py")
+        and Path(item.locate()).resolve() == expected
+        for item in installed.files or ()
+    )
+    if not owns_module:
+        return {"available": False}
+    return {
+        "available": True,
+        "kind": "python_distribution",
+        "version": installed.version,
+        "installer": installer,
+        "root": str(Path(installed.locate_file("")).resolve()),
+    }
 
 
 def is_release_snapshot(root: Path | None) -> bool:
@@ -367,6 +393,7 @@ def build_install_freshness(
     freshness_source: dict[str, Any] | None = None,
     require_installed_skills: bool = True,
     doctor_agent_type: str | None = None,
+    python_distribution: dict[str, Any] | None = None,
     now: datetime | None = None,
 ) -> dict[str, Any]:
     reference = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
@@ -379,6 +406,11 @@ def build_install_freshness(
     skill_problem = require_installed_skills and any(
         not skill.get("exists") or not skill.get("required_phrases") for skill in skills.values()
     )
+    distribution_install = (
+        python_distribution
+        if isinstance(python_distribution, dict) and python_distribution.get("available")
+        else None
+    )
     if command_path is None:
         status = "missing"
         reason = "loopx is not on PATH"
@@ -387,6 +419,10 @@ def build_install_freshness(
         status = "repair_recommended"
         reason = "installed LoopX skills are missing or stale"
         requires_upgrade = True
+    elif distribution_install:
+        status = "python_distribution"
+        reason = "LoopX is installed as a managed Python distribution"
+        requires_upgrade = False
     elif release_id and age_hours is not None and age_hours > INSTALL_FRESHNESS_STALE_HOURS:
         status = "stale"
         reason = f"default release snapshot is older than {INSTALL_FRESHNESS_STALE_HOURS} hours"
@@ -424,7 +460,7 @@ def build_install_freshness(
     manifest_source = (
         manifest_body.get("source") if isinstance(manifest_body.get("source"), dict) else {}
     )
-    upgrade_command = no_clone_upgrade_command(
+    no_clone_command = no_clone_upgrade_command(
         manifest_source.get("ref"),
         doctor_agent_type=doctor_agent_type,
     )
@@ -436,6 +472,14 @@ def build_install_freshness(
     contributor_upgrade_command = (
         f"{repo_root / 'scripts' / 'install-local.sh'}\n"
         f"loopx doctor{doctor_agent_arg}"
+    )
+    upgrade_command = (
+        f"{shlex.quote(sys.executable)} -m pip install --upgrade loopx\n"
+        "loopx workflow-skills --install\n"
+        "loopx slash-commands --install\n"
+        f"loopx doctor{doctor_agent_arg}"
+        if distribution_install
+        else no_clone_command
     )
     manifest_source_git_commit = manifest_source.get("git_commit")
     manifest_source_revision = (
@@ -466,13 +510,20 @@ def build_install_freshness(
         and freshness_revision_relation == GitRevisionRelation.INSTALLED_BEHIND
     )
 
-    if release_id and source_commit_is_behind and command_path is not None and not skill_problem:
+    if (
+        not distribution_install
+        and release_id
+        and source_commit_is_behind
+        and command_path is not None
+        and not skill_problem
+    ):
         status = "stale"
         reason = f"release manifest source commit is behind {freshness_source_label} commit"
         requires_upgrade = True
 
     if (
-        manifest_package_version_matches_runtime is False
+        not distribution_install
+        and manifest_package_version_matches_runtime is False
         and command_path is not None
         and not skill_problem
     ):
@@ -494,10 +545,19 @@ def build_install_freshness(
         "release_id": release_id,
         "release_age_hours": age_hours,
         "upgrade_command": upgrade_command,
-        "no_clone_upgrade_command": upgrade_command,
+        "no_clone_upgrade_command": no_clone_command,
         "contributor_upgrade_command": contributor_upgrade_command,
         "doctor_after_upgrade": f"loopx doctor{doctor_agent_arg}",
         "installed_skills_required": require_installed_skills,
+        "install_kind": (
+            "python_distribution" if distribution_install else "release_or_checkout"
+        ),
+        "python_distribution_version": (
+            distribution_install.get("version") if distribution_install else None
+        ),
+        "python_distribution_installer": (
+            distribution_install.get("installer") if distribution_install else None
+        ),
         "release_manifest_available": manifest.get("available"),
         "release_manifest_path": manifest.get("path"),
         "release_manifest_reason": manifest.get("reason"),
@@ -765,13 +825,14 @@ def collect_doctor(
     loopx_path = resolve_command_path("loopx")
     invocation_path = current_script_invocation_path()
     loopx_canary_path = resolve_command_path("loopx-canary")
-    command_path_primary = loopx_path or invocation_path
+    command_path_primary = invocation_path or loopx_path
     canary_path = loopx_canary_path
     command_path = command_path_primary
     command_realpath = command_path.resolve() if command_path else None
     canary_realpath = canary_path.resolve() if canary_path else None
     loopx_canary_realpath = loopx_canary_path.resolve() if loopx_canary_path else None
     module_path = Path(__file__).resolve()
+    python_distribution = python_distribution_install(module_path)
     package_dir = module_path.parent
     repo_root = package_dir.parent
     install_script = repo_root / "scripts" / "install-local.sh"
@@ -840,7 +901,13 @@ def collect_doctor(
         "current_invocation": {
             "module_path": str(module_path),
             "repo_root": str(repo_root),
-            "source": "release_snapshot" if is_release_snapshot(repo_root) else "live_checkout",
+            "source": (
+                "python_distribution"
+                if python_distribution.get("available")
+                else "release_snapshot"
+                if is_release_snapshot(repo_root)
+                else "live_checkout"
+            ),
         },
         "promotion_readiness": add_promotion_readiness_freshness(
             latest_promotion_readiness_event(DEFAULT_RUNTIME_ROOT)
@@ -856,6 +923,7 @@ def collect_doctor(
         freshness_source=freshness_source,
         require_installed_skills=installed_skills_required,
         doctor_agent_type=canonical_agent_type,
+        python_distribution=python_distribution,
     )
     if installed_skills_required:
         skill_delivery_status = (
@@ -1087,6 +1155,14 @@ def collect_doctor(
             "install_script": str(install_script),
             "wrapper_script": str(wrapper_script),
             "release_manifest_path": release_manifest.get("path"),
+            "install_kind": (
+                "python_distribution"
+                if python_distribution.get("available")
+                else "release_snapshot"
+                if release_root
+                else "live_checkout"
+            ),
+            "python_distribution": python_distribution,
         },
         "release_manifest": release_manifest,
         "release_provenance": release_provenance,
@@ -1117,9 +1193,15 @@ def collect_doctor(
             if canonical_agent_type
             and agent_type_uses_host_managed_skills(canonical_agent_type)
             else (
-                f"Run `{repo_root / 'scripts' / 'install-local.sh'}` and start a new shell, "
-                f"or export PATH=\"{local_bin}:$PATH\". For no-clone repair, run "
-                f"`curl -fsSL {NO_CLONE_INSTALL_URL} | bash`."
+                "Run `loopx workflow-skills --install`, then "
+                "`loopx slash-commands --install`, and rerun doctor. Upgrade this "
+                f"installation with `{shlex.quote(sys.executable)} -m pip install --upgrade loopx`."
+                if python_distribution.get("available")
+                else (
+                    f"Run `{repo_root / 'scripts' / 'install-local.sh'}` and start a new shell, "
+                    f"or export PATH=\"{local_bin}:$PATH\". For no-clone repair, run "
+                    f"`curl -fsSL {NO_CLONE_INSTALL_URL} | bash`."
+                )
             )
         ),
     }
@@ -1216,9 +1298,12 @@ def render_doctor_markdown(payload: dict[str, Any]) -> str:
                 "## Install Freshness",
                 f"- schema_version: `{freshness.get('schema_version')}`",
                 f"- status: `{freshness.get('status')}`",
+                f"- install_kind: `{freshness.get('install_kind')}`",
                 f"- requires_upgrade: `{freshness.get('requires_upgrade')}`",
                 f"- current_version: `{freshness.get('current_version')}`",
                 f"- current_version_tag: `{freshness.get('current_version_tag')}`",
+                f"- python_distribution_version: `{freshness.get('python_distribution_version')}`",
+                f"- python_distribution_installer: `{freshness.get('python_distribution_installer')}`",
                 f"- manifest_package_version: `{freshness.get('manifest_package_version')}`",
                 f"- manifest_package_version_tag: `{freshness.get('manifest_package_version_tag')}`",
                 f"- manifest_package_version_matches_runtime: `{freshness.get('manifest_package_version_matches_runtime')}`",

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -825,7 +825,7 @@ def collect_doctor(
     loopx_path = resolve_command_path("loopx")
     invocation_path = current_script_invocation_path()
     loopx_canary_path = resolve_command_path("loopx-canary")
-    command_path_primary = invocation_path or loopx_path
+    command_path_primary = loopx_path or invocation_path
     canary_path = loopx_canary_path
     command_path = command_path_primary
     command_realpath = command_path.resolve() if command_path else None

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -177,6 +177,10 @@ COMMAND_GROUPS: list[dict[str, object]] = [
                 "command": "loopx project-skill --help",
                 "purpose": "Install, inspect, or remove release-owned skills in selected project agent hosts.",
             },
+            {
+                "command": "loopx workflow-skills",
+                "purpose": "Inspect, install, or remove packaged user-level LoopX workflow skills.",
+            },
         ],
     },
     {

--- a/loopx/install_contract.py
+++ b/loopx/install_contract.py
@@ -1,1 +1,14 @@
 NO_CLONE_INSTALL_URL = "https://huangruiteng.github.io/loopx/install.sh"
+
+DEFAULT_INSTALL_COMMAND = "python3 -m pip install --upgrade loopx"
+DEFAULT_WORKFLOW_SKILL_INSTALL_COMMAND = "loopx workflow-skills --install"
+DEFAULT_INSTALL_REPAIR_COMMAND = (
+    f"{DEFAULT_INSTALL_COMMAND}\n"
+    f"{DEFAULT_WORKFLOW_SKILL_INSTALL_COMMAND}\n"
+    "loopx doctor"
+)
+ARCHIVE_FALLBACK_INSTALL_COMMAND = (
+    f"curl -fsSL {NO_CLONE_INSTALL_URL} | bash\n"
+    'export PATH="$HOME/.local/bin:$PATH"\n'
+    "loopx doctor"
+)

--- a/loopx/project_prompt.py
+++ b/loopx/project_prompt.py
@@ -59,7 +59,7 @@ fi
 {cli_bin_arg} doctor >/dev/null"""
 
 
-def render_codex_cli_no_clone_preflight(
+def render_codex_cli_install_preflight(
     *,
     cli_bin: str = "loopx",
     doctor_agent_type: str | None = None,
@@ -72,11 +72,18 @@ def render_codex_cli_no_clone_preflight(
     )
     return f"""export PATH="$HOME/.local/bin:$PATH"
 if ! command -v {cli_bin_arg} >/dev/null 2>&1; then
-  if command -v curl >/dev/null 2>&1; then
+  if command -v python3 >/dev/null 2>&1 && python3 -m pip --version >/dev/null 2>&1; then
+    python3 -m pip install --upgrade loopx
+    if command -v {cli_bin_arg} >/dev/null 2>&1; then
+      {cli_bin_arg} workflow-skills --install --cli-bin {cli_bin_arg}
+    fi
+  fi
+  if ! command -v {cli_bin_arg} >/dev/null 2>&1 && command -v curl >/dev/null 2>&1; then
     curl -fsSL {NO_CLONE_INSTALL_URL} | bash
     export PATH="$HOME/.local/bin:$PATH"
-  else
-    echo "loopx is not on PATH and curl is unavailable; install curl or use a contributor clone with scripts/install-local.sh" >&2
+  fi
+  if ! command -v {cli_bin_arg} >/dev/null 2>&1; then
+    echo "loopx is not on PATH; use a Python 3.11+ environment, the archive fallback, or a contributor checkout" >&2
     exit 1
   fi
 fi
@@ -435,7 +442,7 @@ def build_codex_cli_bootstrap_message(
         agent_id=agent_id,
         scheduler_execution_context=CODEX_CLI_VISIBLE_SCHEDULER_CONTEXT,
     )
-    install_repair_command = render_codex_cli_no_clone_preflight(cli_bin=cli_bin)
+    install_repair_command = render_codex_cli_install_preflight(cli_bin=cli_bin)
     refresh_command = render_refresh_state_command(
         resolved_goal_id,
         cli_bin=cli_bin,
@@ -449,7 +456,7 @@ def build_codex_cli_bootstrap_message(
         progress_scope="agent_lane" if agent_id else None,
     )
     first_run_validation_checklist = [
-        f"{cli_bin} doctor passed after no-clone install repair or existing install",
+        f"{cli_bin} doctor passed after PyPI install repair or an existing install",
         "repo bootstrap/connect completed conservatively or a concrete install/connect blocker was shown",
         f"thin heartbeat task_body generated from {cli_bin} heartbeat-prompt --thin, not hand-written",
         "host loop surface activated from the thin task_body: Codex CLI /goal or Codex App heartbeat automation initially every 3 minutes, then following quota scheduler_hint",

--- a/loopx/skill_install_readback.py
+++ b/loopx/skill_install_readback.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 import hashlib
 import json
 import os
+from email.parser import Parser
 from pathlib import Path
 import shutil
 import subprocess
@@ -15,6 +16,23 @@ SKILL_INSTALL_READBACK_SCHEMA_VERSION = "loopx_skill_install_readback_v0"
 SKILL_INSTALL_READBACK_FILENAME = ".loopx-skill-install.json"
 SKILL_INSTALL_OWNER = "loopx_install_script"
 SKILL_INSTALL_INTEGRATION_MODE = "fixed_install_script"
+PYTHON_DISTRIBUTION_SKILL_INSTALL_OWNER = "loopx_workflow_skills_cli"
+PYTHON_DISTRIBUTION_SKILL_INSTALL_MODE = "python_distribution_cli"
+SKILL_INSTALL_OWNERS = {
+    SKILL_INSTALL_OWNER,
+    PYTHON_DISTRIBUTION_SKILL_INSTALL_OWNER,
+}
+SKILL_INSTALL_INTEGRATION_MODES = {
+    SKILL_INSTALL_INTEGRATION_MODE,
+    PYTHON_DISTRIBUTION_SKILL_INSTALL_MODE,
+}
+SKILL_INSTALL_PROFILES = {
+    (SKILL_INSTALL_OWNER, SKILL_INSTALL_INTEGRATION_MODE),
+    (
+        PYTHON_DISTRIBUTION_SKILL_INSTALL_OWNER,
+        PYTHON_DISTRIBUTION_SKILL_INSTALL_MODE,
+    ),
+}
 LOOPX_MANAGED_SLASH_COMMAND_MARKER = "<!-- loopx-managed-slash-command:v1"
 PACKAGED_HOST_SKILL_IDS = [
     "loopx-project",
@@ -258,6 +276,22 @@ def _source_readback(
             "git_dirty": release_source.get("git_dirty"),
         }
 
+    for metadata_path in sorted(source_root.glob("loopx-*.dist-info/METADATA")):
+        try:
+            metadata = Parser().parsestr(metadata_path.read_text(encoding="utf-8"))
+        except OSError:
+            continue
+        if metadata.get("Name", "").strip().lower() != "loopx":
+            continue
+        version = metadata.get("Version", "").strip()
+        if version:
+            return {
+                "kind": "python_distribution",
+                "revision": version,
+                "revision_kind": "package_version",
+                "git_dirty": False,
+            }
+
     commit = _git_value(source_root, "rev-parse", "HEAD")
     status = _git_value(source_root, "status", "--porcelain")
     return {
@@ -285,7 +319,17 @@ def build_skill_install_readback(
     skill_ids: Sequence[str],
     source_root: Path,
     installed_at: str | None = None,
+    owner: str = SKILL_INSTALL_OWNER,
+    integration_mode: str = SKILL_INSTALL_INTEGRATION_MODE,
 ) -> dict[str, Any]:
+    if owner not in SKILL_INSTALL_OWNERS:
+        raise ValueError(f"unsupported skill install owner: {owner}")
+    if integration_mode not in SKILL_INSTALL_INTEGRATION_MODES:
+        raise ValueError(f"unsupported skill install integration mode: {integration_mode}")
+    if (owner, integration_mode) not in SKILL_INSTALL_PROFILES:
+        raise ValueError(
+            "skill install owner and integration mode do not form a supported profile"
+        )
     normalized_ids = sorted(
         {skill_id.strip() for skill_id in skill_ids if skill_id.strip()}
     )
@@ -299,8 +343,8 @@ def build_skill_install_readback(
         source["revision_kind"] = "skills_digest"
     return {
         "schema_version": SKILL_INSTALL_READBACK_SCHEMA_VERSION,
-        "owner": SKILL_INSTALL_OWNER,
-        "integration_mode": SKILL_INSTALL_INTEGRATION_MODE,
+        "owner": owner,
+        "integration_mode": integration_mode,
         "installed_at": installed_at
         or datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
         "source": source,
@@ -318,6 +362,8 @@ def write_skill_install_readback(
     skill_ids: Sequence[str],
     source_root: Path,
     installed_at: str | None = None,
+    owner: str = SKILL_INSTALL_OWNER,
+    integration_mode: str = SKILL_INSTALL_INTEGRATION_MODE,
 ) -> Path:
     skills_dir.mkdir(parents=True, exist_ok=True)
     payload = build_skill_install_readback(
@@ -325,6 +371,8 @@ def write_skill_install_readback(
         skill_ids=skill_ids,
         source_root=source_root,
         installed_at=installed_at,
+        owner=owner,
+        integration_mode=integration_mode,
     )
     target = skills_dir / SKILL_INSTALL_READBACK_FILENAME
     with tempfile.NamedTemporaryFile(
@@ -434,8 +482,11 @@ def inspect_skill_install_readback(
     manifest_valid = bool(
         isinstance(manifest, dict)
         and manifest.get("schema_version") == SKILL_INSTALL_READBACK_SCHEMA_VERSION
-        and manifest.get("owner") == SKILL_INSTALL_OWNER
-        and manifest.get("integration_mode") == SKILL_INSTALL_INTEGRATION_MODE
+        and (
+            manifest.get("owner"),
+            manifest.get("integration_mode"),
+        )
+        in SKILL_INSTALL_PROFILES
         and set(required_ids).issubset(manifest_ids)
         and source_revision
     )
@@ -452,7 +503,7 @@ def inspect_skill_install_readback(
     ready = not missing_ids and integrity_ok
     if ready:
         status = "ready_for_host_load"
-        reason = "required workflow skills match the fixed-installer readback"
+        reason = "required workflow skills match the managed install readback"
     elif manifest_error:
         status, reason = "manifest_missing_or_invalid", manifest_error
     elif missing_ids:
@@ -460,7 +511,7 @@ def inspect_skill_install_readback(
         reason = f"missing required workflow skills: {','.join(missing_ids)}"
     elif not manifest_valid:
         status = "manifest_contract_invalid"
-        reason = "install readback does not satisfy the fixed-installer contract"
+        reason = "install readback does not satisfy the managed install contract"
     elif not manifest_digest_valid:
         status = "manifest_digest_mismatch"
         reason = "install readback skill manifest digest does not match its items"
@@ -475,7 +526,7 @@ def inspect_skill_install_readback(
         )
     else:
         status = "manifest_contract_invalid"
-        reason = "install readback does not satisfy the fixed-installer contract"
+        reason = "install readback does not satisfy the managed install contract"
 
     return {
         "schema_version": SKILL_INSTALL_READBACK_SCHEMA_VERSION,

--- a/loopx/workflow_skill_install.py
+++ b/loopx/workflow_skill_install.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from importlib.metadata import PackageNotFoundError, distribution
+import json
+import os
+from pathlib import Path, PurePosixPath
+import shutil
+import shlex
+import tempfile
+from typing import Any, Iterator, Mapping
+
+from .skill_install_readback import (
+    ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS,
+    PACKAGED_HOST_SKILL_IDS,
+    PYTHON_DISTRIBUTION_SKILL_INSTALL_MODE,
+    PYTHON_DISTRIBUTION_SKILL_INSTALL_OWNER,
+    SKILL_INSTALL_OWNERS,
+    SKILL_INSTALL_READBACK_FILENAME,
+    hash_skill_tree,
+    inspect_skill_install_readback,
+    write_skill_install_readback,
+)
+from .slash_command_install import materialize_loopx_entry_skill
+
+
+WORKFLOW_SKILL_INSTALL_SCHEMA_VERSION = "loopx_workflow_skill_install_v0"
+MANAGED_ENTRY_STATUSES = {
+    "created",
+    "updated",
+    "unchanged",
+    "upgraded_legacy_managed",
+}
+MANAGED_ENTRY_PREVIEW_STATUSES = {*MANAGED_ENTRY_STATUSES, "would_create"}
+_PACKAGED_SKILL_SENTINEL = PurePosixPath(
+    "share/loopx/skills/loopx-project/SKILL.md"
+)
+
+
+def _valid_source_root(path: Path) -> bool:
+    return all(
+        (path / skill_id / "SKILL.md").is_file()
+        for skill_id in PACKAGED_HOST_SKILL_IDS
+    )
+
+
+def resolve_workflow_skill_source() -> dict[str, Any]:
+    """Find the canonical workflow skills in a checkout or installed wheel."""
+
+    checkout_root = Path(__file__).resolve().parents[1]
+    checkout_skills = checkout_root / "skills"
+    if _valid_source_root(checkout_skills):
+        return {
+            "available": True,
+            "kind": "source_checkout",
+            "skills_root": checkout_skills,
+            "source_root": checkout_root,
+            "reason": "workflow skills are available from the source checkout",
+        }
+
+    try:
+        installed = distribution("loopx")
+    except PackageNotFoundError:
+        installed = None
+    if installed is not None:
+        for item in installed.files or ():
+            item_path = PurePosixPath(item.as_posix())
+            if not item_path.as_posix().endswith(_PACKAGED_SKILL_SENTINEL.as_posix()):
+                continue
+            sentinel = Path(item.locate()).resolve()
+            skills_root = sentinel.parents[1]
+            if _valid_source_root(skills_root):
+                return {
+                    "available": True,
+                    "kind": "python_distribution",
+                    "skills_root": skills_root,
+                    "source_root": Path(installed.locate_file("")).resolve(),
+                    "distribution_version": installed.version,
+                    "reason": "workflow skills are available from the installed Python distribution",
+                }
+
+    return {
+        "available": False,
+        "kind": "missing",
+        "skills_root": None,
+        "source_root": checkout_root,
+        "reason": (
+            "the active LoopX installation does not contain the packaged workflow skills; "
+            "upgrade LoopX before installing host skills"
+        ),
+    }
+
+
+def default_workflow_skills_dir(env: Mapping[str, str] | None = None) -> Path:
+    source_env = os.environ if env is None else env
+    configured = str(source_env.get("CODEX_HOME") or "").strip()
+    codex_root = Path(configured).expanduser() if configured else Path.home() / ".codex"
+    return codex_root / "skills"
+
+
+@contextmanager
+def _exclusive_install_lock(skills_dir: Path) -> Iterator[None]:
+    import fcntl
+
+    skills_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = skills_dir / ".loopx-workflow-skills.lock"
+    with lock_path.open("a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _install_one_skill(source: Path, target: Path) -> str:
+    if target.is_dir() and hash_skill_tree(source) == hash_skill_tree(target):
+        return "unchanged"
+
+    temporary = Path(
+        tempfile.mkdtemp(prefix=f".{target.name}.tmp.", dir=target.parent)
+    )
+    backup: Path | None = None
+    try:
+        shutil.copytree(source, temporary, dirs_exist_ok=True)
+        if target.exists():
+            backup = target.with_name(f".{target.name}.previous.{os.getpid()}")
+            if backup.exists():
+                shutil.rmtree(backup)
+            target.replace(backup)
+        temporary.replace(target)
+    except BaseException:
+        if not target.exists() and backup and backup.exists():
+            backup.replace(target)
+        raise
+    finally:
+        if temporary.exists():
+            shutil.rmtree(temporary)
+        if backup and backup.exists():
+            shutil.rmtree(backup)
+    return "updated" if backup else "created"
+
+
+def _load_manifest(skills_dir: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(
+            (skills_dir / SKILL_INSTALL_READBACK_FILENAME).read_text(encoding="utf-8")
+        )
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _uninstall_managed_skills(skills_dir: Path) -> dict[str, Any]:
+    manifest = _load_manifest(skills_dir)
+    if not manifest or manifest.get("owner") not in SKILL_INSTALL_OWNERS:
+        return {
+            "ok": False,
+            "removed": [],
+            "preserved_modified": [],
+            "reason": "no LoopX-managed workflow-skill readback is available",
+        }
+
+    skills = manifest.get("skills")
+    items = skills.get("items") if isinstance(skills, dict) else {}
+    if not isinstance(items, dict):
+        items = {}
+    managed_ids = [
+        str(item)
+        for item in manifest.get("materialized_skill_ids") or []
+        if str(item).strip()
+    ]
+    removed: list[str] = []
+    preserved_modified: list[str] = []
+    for skill_id in managed_ids:
+        target = skills_dir / skill_id
+        recorded = items.get(skill_id)
+        if not target.exists():
+            continue
+        if not isinstance(recorded, dict) or recorded != hash_skill_tree(target):
+            preserved_modified.append(skill_id)
+            continue
+        shutil.rmtree(target)
+        removed.append(skill_id)
+
+    manifest_path = skills_dir / SKILL_INSTALL_READBACK_FILENAME
+    if not preserved_modified:
+        manifest_path.unlink(missing_ok=True)
+    return {
+        "ok": not preserved_modified,
+        "removed": removed,
+        "preserved_modified": preserved_modified,
+        "reason": (
+            "removed LoopX-managed workflow skills"
+            if not preserved_modified
+            else "preserved workflow skills whose content changed after installation"
+        ),
+    }
+
+
+def workflow_skill_install(
+    *,
+    skills_dir: Path | None = None,
+    execute: bool = False,
+    uninstall: bool = False,
+    cli_bin: str = "loopx",
+) -> dict[str, Any]:
+    target_root = (skills_dir or default_workflow_skills_dir()).expanduser().resolve()
+    source = resolve_workflow_skill_source()
+    source_root = Path(source["source_root"])
+    before = inspect_skill_install_readback(
+        skills_dir=target_root,
+        required_skill_ids=ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS,
+        source_root=source_root,
+    )
+    if uninstall:
+        result = (
+            _uninstall_managed_skills(target_root)
+            if execute
+            else {
+                "ok": True,
+                "removed": [],
+                "preserved_modified": [],
+                "reason": "uninstall preview; pass --uninstall to execute",
+            }
+        )
+        return {
+            "ok": result["ok"],
+            "schema_version": WORKFLOW_SKILL_INSTALL_SCHEMA_VERSION,
+            "operation": "uninstall" if execute else "uninstall_preview",
+            "skills_dir": str(target_root),
+            "source": _public_source(source),
+            "before": before,
+            "result": result,
+        }
+
+    if not source.get("available"):
+        return {
+            "ok": False,
+            "schema_version": WORKFLOW_SKILL_INSTALL_SCHEMA_VERSION,
+            "operation": "install" if execute else "inspect",
+            "skills_dir": str(target_root),
+            "source": _public_source(source),
+            "before": before,
+            "reason": source["reason"],
+        }
+
+    if not execute:
+        return {
+            "ok": True,
+            "schema_version": WORKFLOW_SKILL_INSTALL_SCHEMA_VERSION,
+            "operation": "inspect",
+            "skills_dir": str(target_root),
+            "source": _public_source(source),
+            "before": before,
+            "install_required": not before.get("ready"),
+            "install_command": shlex.join(
+                ["loopx", "workflow-skills", "--install", "--skills-dir", str(target_root)]
+            ),
+        }
+
+    entry_preview = materialize_loopx_entry_skill(
+        skills_dir=target_root,
+        execute=False,
+        cli_bin=cli_bin,
+    )
+    if entry_preview["status"] not in MANAGED_ENTRY_PREVIEW_STATUSES:
+        return {
+            "ok": False,
+            "schema_version": WORKFLOW_SKILL_INSTALL_SCHEMA_VERSION,
+            "operation": "install",
+            "skills_dir": str(target_root),
+            "source": _public_source(source),
+            "before": before,
+            "entry": entry_preview,
+            "reason": "the managed $loopx entry skill cannot be materialized safely",
+        }
+
+    installed: dict[str, str] = {}
+    with _exclusive_install_lock(target_root):
+        for skill_id in PACKAGED_HOST_SKILL_IDS:
+            installed[skill_id] = _install_one_skill(
+                Path(source["skills_root"]) / skill_id,
+                target_root / skill_id,
+            )
+        entry = materialize_loopx_entry_skill(
+            skills_dir=target_root,
+            execute=True,
+            cli_bin=cli_bin,
+        )
+        if entry["status"] not in MANAGED_ENTRY_STATUSES:
+            return {
+                "ok": False,
+                "schema_version": WORKFLOW_SKILL_INSTALL_SCHEMA_VERSION,
+                "operation": "install",
+                "skills_dir": str(target_root),
+                "source": _public_source(source),
+                "installed": installed,
+                "entry": entry,
+                "reason": "the managed $loopx entry skill could not be materialized",
+            }
+        write_skill_install_readback(
+            skills_dir=target_root,
+            skill_ids=ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS,
+            source_root=source_root,
+            owner=PYTHON_DISTRIBUTION_SKILL_INSTALL_OWNER,
+            integration_mode=PYTHON_DISTRIBUTION_SKILL_INSTALL_MODE,
+        )
+
+    after = inspect_skill_install_readback(
+        skills_dir=target_root,
+        required_skill_ids=ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS,
+        source_root=source_root,
+    )
+    return {
+        "ok": bool(after.get("ready")),
+        "schema_version": WORKFLOW_SKILL_INSTALL_SCHEMA_VERSION,
+        "operation": "install",
+        "skills_dir": str(target_root),
+        "source": _public_source(source),
+        "installed": installed,
+        "entry": entry,
+        "after": after,
+        "rollback_command": shlex.join(
+            [
+                "loopx",
+                "workflow-skills",
+                "--uninstall",
+                "--skills-dir",
+                str(target_root),
+            ]
+        ),
+    }
+
+
+def _public_source(source: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "available": bool(source.get("available")),
+        "kind": source.get("kind"),
+        "distribution_version": source.get("distribution_version"),
+        "reason": source.get("reason"),
+    }
+
+
+def render_workflow_skill_install_markdown(payload: Mapping[str, Any]) -> str:
+    source = payload.get("source") or {}
+    lines = [
+        "# LoopX Workflow Skills",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- operation: `{payload.get('operation')}`",
+        f"- skills_dir: `{payload.get('skills_dir')}`",
+        f"- source: `{source.get('kind')}`",
+        f"- ready_before: `{(payload.get('before') or {}).get('ready')}`",
+    ]
+    if payload.get("install_command"):
+        lines.append(f"- install: `{payload['install_command']}`")
+    if payload.get("rollback_command"):
+        lines.append(f"- rollback: `{payload['rollback_command']}`")
+    result = payload.get("result") or {}
+    if result:
+        lines.extend(
+            [
+                f"- removed: `{','.join(result.get('removed') or [])}`",
+                f"- preserved_modified: `{','.join(result.get('preserved_modified') or [])}`",
+                f"- reason: {result.get('reason')}",
+            ]
+        )
+    if payload.get("reason"):
+        lines.append(f"- reason: {payload['reason']}")
+    return "\n".join(lines) + "\n"

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -88,6 +88,7 @@ nav:
   - Getting Started:
       - guides/README.md
       - Quick Start: guides/getting-started.md
+      - Installation: guides/installing-loopx.md
       - Newcomer Command Path: guides/newcomer-command-path.md
       - Minimal Custom Runtime Example: guides/minimal-custom-runtime-example.md
       - Custom Runner Integration: guides/custom-agent-runner-integration.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,48 @@ include = ["loopx*"]
 "loopx.opencode2_goal_mode" = ["*.mjs", "README.md"]
 "loopx.pi_goal_mode" = ["*.ts", "*.mjs", "README.md"]
 
+[tool.setuptools.data-files]
+"share/loopx/skills/loopx-project" = [
+  "skills/loopx-project/SKILL.md",
+]
+"share/loopx/skills/loopx-project/agents" = [
+  "skills/loopx-project/agents/openai.yaml",
+]
+"share/loopx/skills/loopx-pr-program" = [
+  "skills/loopx-pr-program/SKILL.md",
+]
+"share/loopx/skills/loopx-pr-program/agents" = [
+  "skills/loopx-pr-program/agents/openai.yaml",
+]
+"share/loopx/skills/loopx-pr-program/references" = [
+  "skills/loopx-pr-program/references/snapshot-contract.md",
+]
+"share/loopx/skills/loopx-pr-program/scripts" = [
+  "skills/loopx-pr-program/scripts/diff_snapshot.py",
+]
+"share/loopx/skills/loopx-pr-review" = [
+  "skills/loopx-pr-review/SKILL.md",
+]
+"share/loopx/skills/loopx-pr-review/agents" = [
+  "skills/loopx-pr-review/agents/openai.yaml",
+]
+"share/loopx/skills/loopx-doc-registry" = [
+  "skills/loopx-doc-registry/SKILL.md",
+]
+"share/loopx/skills/loopx-doc-registry/agents" = [
+  "skills/loopx-doc-registry/agents/openai.yaml",
+]
+"share/loopx/skills/loopx-self-repair" = [
+  "skills/loopx-self-repair/SKILL.md",
+]
+"share/loopx/skills/loopx-self-repair/agents" = [
+  "skills/loopx-self-repair/agents/openai.yaml",
+]
+"share/loopx/skills/loopx-self-repair/references" = [
+  "skills/loopx-self-repair/references/repair-patterns.md",
+  "skills/loopx-self-repair/references/upstream-issue-escalation.md",
+]
+
 [tool.pytest.ini_options]
 norecursedirs = ["deprecate"]
 

--- a/tests/test_doctor_install_freshness.py
+++ b/tests/test_doctor_install_freshness.py
@@ -294,7 +294,7 @@ def test_python_distribution_ignores_archive_manifest_version(tmp_path: Path) ->
     assert freshness["manifest_package_version_matches_runtime"] is False
 
 
-def test_current_console_script_wins_over_path_lookup(
+def test_current_python_console_script_is_recognized(
     tmp_path: Path,
     monkeypatch,
 ) -> None:

--- a/tests/test_doctor_install_freshness.py
+++ b/tests/test_doctor_install_freshness.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from loopx import __version__
 from loopx.doctor import (
     build_install_freshness,
+    current_script_invocation_path,
     git_revision_relation,
     trusted_release_ref_for_root,
 )
@@ -231,6 +232,102 @@ def test_other_agent_freshness_does_not_require_codex_skill_directory(
     assert str(freshness["upgrade_command"]).endswith(
         "loopx doctor --agent-type other-agent"
     )
+
+
+def test_python_distribution_uses_pip_native_upgrade_path(tmp_path: Path) -> None:
+    freshness = build_install_freshness(
+        command_path=tmp_path / "loopx",
+        release_root=None,
+        repo_root=tmp_path,
+        skills={
+            "loopx-project": {
+                "exists": True,
+                "required_phrases": True,
+            }
+        },
+        python_distribution={
+            "available": True,
+            "kind": "python_distribution",
+            "version": "0.4.8",
+            "installer": "pip",
+        },
+    )
+
+    assert freshness["status"] == "python_distribution"
+    assert freshness["requires_upgrade"] is False
+    assert freshness["install_kind"] == "python_distribution"
+    assert freshness["python_distribution_version"] == "0.4.8"
+    assert "-m pip install --upgrade loopx" in str(freshness["upgrade_command"])
+    assert "loopx workflow-skills --install" in str(freshness["upgrade_command"])
+    assert "huangruiteng.github.io" in str(freshness["no_clone_upgrade_command"])
+
+
+def test_python_distribution_ignores_archive_manifest_version(tmp_path: Path) -> None:
+    freshness = build_install_freshness(
+        command_path=tmp_path / "bin" / "loopx",
+        release_root=tmp_path / "releases" / "20260713T030000Z",
+        repo_root=tmp_path,
+        skills={"loopx-project": {"exists": True, "required_phrases": True}},
+        release_manifest={
+            "available": True,
+            "manifest": {
+                "package": {"version": "0.4.7"},
+                "source": {"git_commit": "a" * 40},
+            },
+        },
+        freshness_source={
+            "label": "loopx/loopx@main",
+            "git_commit": "b" * 40,
+            "revision_relation": "installed_behind",
+        },
+        python_distribution={
+            "available": True,
+            "kind": "python_distribution",
+            "version": "0.4.8",
+            "installer": "pip",
+        },
+        now=datetime(2026, 7, 13, 4, tzinfo=timezone.utc),
+    )
+
+    assert freshness["status"] == "python_distribution"
+    assert freshness["requires_upgrade"] is False
+    assert freshness["manifest_package_version_matches_runtime"] is False
+
+
+def test_current_console_script_wins_over_path_lookup(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    console_script = tmp_path / "venv" / "bin" / "loopx"
+    console_script.parent.mkdir(parents=True)
+    console_script.write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setattr("loopx.doctor.sys.argv", [str(console_script), "doctor"])
+
+    assert current_script_invocation_path() == console_script.resolve()
+
+
+def test_python_distribution_missing_skills_recommends_repair(tmp_path: Path) -> None:
+    freshness = build_install_freshness(
+        command_path=tmp_path / "loopx",
+        release_root=None,
+        repo_root=tmp_path,
+        skills={
+            "loopx-project": {
+                "exists": False,
+                "required_phrases": False,
+            }
+        },
+        python_distribution={
+            "available": True,
+            "kind": "python_distribution",
+            "version": "0.4.8",
+            "installer": "pip",
+        },
+    )
+
+    assert freshness["status"] == "repair_recommended"
+    assert freshness["requires_upgrade"] is True
+    assert "loopx workflow-skills --install" in str(freshness["upgrade_command"])
 
 
 def test_trusted_release_ref_matches_manifest_repository(tmp_path: Path) -> None:

--- a/tests/test_skill_delivery_parity.py
+++ b/tests/test_skill_delivery_parity.py
@@ -11,6 +11,8 @@ import re
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from loopx.skill_install_readback import (
     PACKAGED_HOST_SKILL_IDS,
     ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS,
@@ -151,6 +153,21 @@ class TestReadbackLifecycle:
             source_root=REPO_ROOT)
         assert not ins["ready"]
         assert ins["status"] == "skills_dir_not_configured"
+
+    def test_rejects_crossed_install_profile(self):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td) / "skills"
+            for sid in PACKAGED_HOST_SKILL_IDS:
+                _write_fixture_skill(d, sid)
+
+            with pytest.raises(ValueError, match="supported profile"):
+                build_skill_install_readback(
+                    skills_dir=d,
+                    skill_ids=PACKAGED_HOST_SKILL_IDS,
+                    source_root=REPO_ROOT,
+                    owner="loopx_install_script",
+                    integration_mode="python_distribution_cli",
+                )
 
 
 # -- Install dedupe -----------------------------------------------------------

--- a/tests/test_workflow_skill_install.py
+++ b/tests/test_workflow_skill_install.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from loopx.skill_install_readback import (
+    ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS,
+    PACKAGED_HOST_SKILL_IDS,
+    PYTHON_DISTRIBUTION_SKILL_INSTALL_MODE,
+    PYTHON_DISTRIBUTION_SKILL_INSTALL_OWNER,
+    SKILL_INSTALL_READBACK_FILENAME,
+)
+from loopx.workflow_skill_install import (
+    resolve_workflow_skill_source,
+    workflow_skill_install,
+)
+
+
+def test_source_checkout_contains_packaged_workflow_skills() -> None:
+    source = resolve_workflow_skill_source()
+
+    assert source["available"] is True
+    assert source["kind"] == "source_checkout"
+    for skill_id in PACKAGED_HOST_SKILL_IDS:
+        assert (Path(source["skills_root"]) / skill_id / "SKILL.md").is_file()
+
+
+def test_install_is_idempotent_and_uninstall_removes_managed_skills(
+    tmp_path: Path,
+) -> None:
+    skills_dir = tmp_path / "host skills"
+
+    installed = workflow_skill_install(skills_dir=skills_dir, execute=True)
+
+    assert installed["ok"] is True
+    assert installed["after"]["ready"] is True
+    assert sorted(installed["after"]["materialized_skill_ids"]) == sorted(
+        ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS
+    )
+    assert set(installed["installed"]) == set(PACKAGED_HOST_SKILL_IDS)
+    assert "'" in installed["rollback_command"]
+    manifest = json.loads(
+        (skills_dir / SKILL_INSTALL_READBACK_FILENAME).read_text(encoding="utf-8")
+    )
+    assert manifest["owner"] == PYTHON_DISTRIBUTION_SKILL_INSTALL_OWNER
+    assert manifest["integration_mode"] == PYTHON_DISTRIBUTION_SKILL_INSTALL_MODE
+
+    repeated = workflow_skill_install(skills_dir=skills_dir, execute=True)
+
+    assert repeated["ok"] is True
+    assert set(repeated["installed"].values()) == {"unchanged"}
+    assert repeated["entry"]["status"] == "unchanged"
+
+    removed = workflow_skill_install(
+        skills_dir=skills_dir,
+        execute=True,
+        uninstall=True,
+    )
+
+    assert removed["ok"] is True
+    assert sorted(removed["result"]["removed"]) == sorted(
+        ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS
+    )
+    assert not (skills_dir / SKILL_INSTALL_READBACK_FILENAME).exists()
+
+
+def test_uninstall_preserves_locally_modified_skill(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    installed = workflow_skill_install(skills_dir=skills_dir, execute=True)
+    assert installed["ok"] is True
+
+    modified = skills_dir / "loopx-project" / "SKILL.md"
+    modified.write_text(modified.read_text(encoding="utf-8") + "\nlocal edit\n", encoding="utf-8")
+
+    removed = workflow_skill_install(
+        skills_dir=skills_dir,
+        execute=True,
+        uninstall=True,
+    )
+
+    assert removed["ok"] is False
+    assert removed["result"]["preserved_modified"] == ["loopx-project"]
+    assert modified.is_file()
+    assert (skills_dir / SKILL_INSTALL_READBACK_FILENAME).is_file()
+
+
+def test_inspect_does_not_create_target(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+
+    inspected = workflow_skill_install(skills_dir=skills_dir)
+
+    assert inspected["ok"] is True
+    assert inspected["operation"] == "inspect"
+    assert inspected["install_required"] is True
+    assert not skills_dir.exists()


### PR DESCRIPTION
## Summary

- make `python3 -m pip install --upgrade loopx` the default user installation path
- package the five built-in workflow skills in the wheel and add an explicit, idempotent `loopx workflow-skills --install` projection step
- teach `loopx doctor`, onboarding, bootstrap, and readback to distinguish Python-distribution installs from archive snapshots
- retain the GitHub Pages/archive installer as a documented fallback instead of the primary path

## Product and architecture judgment

Issue #2821 exposed a structural reliability problem: the first-run path depended on a public bootstrap host before LoopX could diagnose or recover anything. PyPI already distributed the Python package, but the wheel did not contain the complete host workflow surface. This change closes that gap rather than merely replacing one download URL with another.

The Python distribution remains the product payload; host-visible skills are projected explicitly so installation does not silently mutate every supported agent home. The projection has typed provenance, atomic replacement, idempotent readback, and a conservative uninstall that preserves user-modified files. Source-checkout/archive installs remain supported through their existing contract.

## Validation

- full Python suite: `3197 passed, 4 skipped`
- focused install/doctor suites: `46 passed`, then `34 passed` after the final PATH correction
- clean Python 3.12 wheel build/install/readback/uninstall rehearsal passed
- `mkdocs build --strict` passed
- changed-Python compile and CI ruff contract passed
- premerge gate passed: 9/9 catalog canaries, 8/8 risk-profile smokes, public/private boundary scan, no manual holds; `self_merge_allowed=true`
- `install-local-smoke.py` was also compared against `origin/main`: main took 130.00s in the same clean environment, confirming the initial 120s timeout was existing smoke runtime rather than a branch regression. The final premerge run used the supported 180s per-check budget and completed the unchanged smoke in 113.647s.

## Release sequencing

The current PyPI release predates `workflow-skills`; the documented complete flow becomes executable beginning with the next PyPI release containing this PR. No release is performed by this PR.

## Boundary review

No credentials, local paths, private benchmark artifacts, raw trajectories, or generated logs are included.

Follow-up to #2821.
