### PR TITLE
Bind benchmark runtime evidence to the exact job container

### DIFF
--- a/benchmark/deepswe/README.md
+++ b/benchmark/deepswe/README.md
@@ -178,6 +178,8 @@ Before each launch, a no-agent preflight must prove:
 - formal installed LoopX CLI and skill readback from the pinned revision;
 - real app-server discovery of the required LoopX skills;
 - worker-before-verifier ordering;
+- exact-job container binding before runtime isolation inspection when concurrent
+  jobs can share an image;
 - compact result and terminal-closeout destinations.
 
 The runner owns task execution and verifier invocation. LoopX settlement occurs

--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -239,6 +239,37 @@ evidence channels are required.
 paths. Path-like values fail closed and are emitted only as `redacted`, so a runner
 cannot move an operator directory into the public receipt through identifier fields.
 
+### Exact-job container binding
+
+Runtime evidence must belong to the same job as the score. An image-only Docker
+lookup is ambiguous as soon as two benchmark arms use the same image concurrently.
+Before inspecting isolation settings, bind the container with the runner-owned job
+or trial label, the service label, and the expected image:
+
+```python
+from loopx.capabilities.benchmark_toolkit import (
+    compact_docker_container_binding_receipt,
+    select_exact_docker_container,
+)
+
+binding = select_exact_docker_container(
+    ancestor_image="benchmark-runner:fixture",
+    required_labels={
+        "com.docker.compose.project": job_id,
+        "com.docker.compose.service": "main",
+    },
+)
+container_name = binding.container_name  # private runner state; do not publish
+receipt = compact_docker_container_binding_receipt(binding)
+```
+
+The selector fails closed unless exactly one running container matches. The compact
+`benchmark_exact_container_binding_v0` receipt records only the required label keys,
+match count, and a SHA-256 selector digest; it excludes the raw container identity
+and label values. The helper grants no Docker or runner authority. Callers that need
+a privileged wrapper must supply their own `command_runner` and keep that authority
+outside the receipt.
+
 Benchmark-specific private roots can be added without committing them through an
 ignored `benchmark_integrity_policy_v0` file:
 

--- a/loopx/capabilities/benchmark_toolkit/__init__.py
+++ b/loopx/capabilities/benchmark_toolkit/__init__.py
@@ -8,6 +8,13 @@ from .artifacts import (
     filter_public_benchmark_artifact_paths,
     materialize_public_benchmark_artifacts,
 )
+from .container_binding import (
+    BENCHMARK_EXACT_CONTAINER_BINDING_SCHEMA_VERSION,
+    DockerContainerBinding,
+    DockerContainerBindingError,
+    compact_docker_container_binding_receipt,
+    select_exact_docker_container,
+)
 from .integrity import (
     BENCHMARK_INTEGRITY_POLICY_SCHEMA_VERSION,
     BENCHMARK_INTEGRITY_QUALIFICATION_SCHEMA_VERSION,
@@ -70,6 +77,7 @@ from .run_permissions import (
 
 __all__ = [
     "BENCHMARK_CANDIDATE_SOURCE_BOUNDARY_SCHEMA_VERSION",
+    "BENCHMARK_EXACT_CONTAINER_BINDING_SCHEMA_VERSION",
     "BENCHMARK_INTEGRITY_POLICY_SCHEMA_VERSION",
     "BENCHMARK_INTEGRITY_QUALIFICATION_SCHEMA_VERSION",
     "BENCHMARK_RUNTIME_INTEGRITY_ATTESTATION_SCHEMA_VERSION",
@@ -82,6 +90,8 @@ __all__ = [
     "REQUIRED_RUNTIME_ATTESTATIONS",
     "RUN_PERMISSION_POLICY_SCHEMA_VERSION",
     "RUN_PERMISSION_QUOTA_PROJECTION_SCHEMA_VERSION",
+    "DockerContainerBinding",
+    "DockerContainerBindingError",
     "NativeCodexGoalPrompt",
     "NativeCodexIsolationEnvelope",
     "NativeCodexIsolationError",
@@ -102,6 +112,7 @@ __all__ = [
     "build_run_permission_policy",
     "classify_benchmark_artifact_path",
     "classify_benchmark_candidate_source_path",
+    "compact_docker_container_binding_receipt",
     "compact_native_codex_goal_prompt_receipt",
     "compact_native_codex_profile_receipt",
     "compact_native_goal_receipt",
@@ -121,6 +132,7 @@ __all__ = [
     "run_native_goal_process_until_terminal",
     "run_native_goal_turn",
     "run_native_goal_until_terminal",
+    "select_exact_docker_container",
     "start_native_goal_turn",
     "validate_run_permission_policy",
     "wait_native_goal_turn",

--- a/loopx/capabilities/benchmark_toolkit/catalog_entry.py
+++ b/loopx/capabilities/benchmark_toolkit/catalog_entry.py
@@ -136,6 +136,11 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
             "doc": "loopx/capabilities/benchmark_toolkit/README.md",
         },
         {
+            "schema_version": "benchmark_exact_container_binding_v0",
+            "module": "loopx.capabilities.benchmark_toolkit.container_binding",
+            "doc": "loopx/capabilities/benchmark_toolkit/README.md",
+        },
+        {
             "schema_version": "run_permission_policy_v0",
             "module": "loopx.capabilities.benchmark_toolkit.run_permissions",
             "doc": "loopx/capabilities/benchmark_toolkit/README.md",
@@ -152,6 +157,7 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
         "The toolkit never grants runner, Docker, model, upload, submission, or publication authority; each effect remains separately gated.",
         "Raw trajectories are private local inputs to integrity qualification and are never copied into receipts, ledgers, docs, or PR artifacts.",
         "A clean trajectory scan is not isolation proof: runner-owned permission and verifier-order attestations are mandatory and fail closed when absent.",
+        "Concurrent Docker runs must bind runtime evidence to one exact job-owned container; image-only discovery is not sufficient.",
         "Integrity qualification establishes countability eligibility only; an independent official result and matched experiment contract are still required.",
         "Post-run analyst access never widens the solving agent's evidence boundary or grants feedback reuse in another scored run.",
         "Benchmark-family runners remain outside the active capability; the toolkit owns only provider-neutral permission, artifact, integrity, and analyst-brief policy.",

--- a/loopx/capabilities/benchmark_toolkit/container_binding.py
+++ b/loopx/capabilities/benchmark_toolkit/container_binding.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+
+BENCHMARK_EXACT_CONTAINER_BINDING_SCHEMA_VERSION = (
+    "benchmark_exact_container_binding_v0"
+)
+
+CommandRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+
+class DockerContainerBindingError(RuntimeError):
+    """Raised when a runner cannot prove one exact Docker container binding."""
+
+
+@dataclass(frozen=True, slots=True)
+class DockerContainerBinding:
+    """Private runner handle plus the public-safe facts that identify its selector."""
+
+    container_name: str
+    selector_sha256: str
+    required_label_keys: tuple[str, ...]
+
+
+def _run_command(argv: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        argv,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _validate_selector_part(value: object) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+    ):
+        raise DockerContainerBindingError("invalid_docker_container_selector")
+    return value
+
+
+def select_exact_docker_container(
+    *,
+    ancestor_image: str,
+    required_labels: Mapping[str, str],
+    command_runner: CommandRunner | None = None,
+) -> DockerContainerBinding:
+    """Resolve exactly one running container from runner-owned job identity.
+
+    The returned container name is private runtime state. Publish only the output of
+    :func:`compact_docker_container_binding_receipt`.
+    """
+
+    image = _validate_selector_part(ancestor_image)
+    if not isinstance(required_labels, Mapping) or not required_labels:
+        raise DockerContainerBindingError("invalid_docker_container_selector")
+
+    labels: list[tuple[str, str]] = []
+    for raw_key, raw_value in required_labels.items():
+        key = _validate_selector_part(raw_key)
+        value = _validate_selector_part(raw_value)
+        if "=" in key:
+            raise DockerContainerBindingError("invalid_docker_container_selector")
+        labels.append((key, value))
+    labels.sort()
+
+    selector = {
+        "ancestor_image": image,
+        "required_labels": labels,
+    }
+    selector_sha256 = hashlib.sha256(
+        json.dumps(selector, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+    command = ["docker", "ps", "--filter", f"ancestor={image}"]
+    for key, value in labels:
+        command.extend(("--filter", f"label={key}={value}"))
+    command.extend(("--format", "{{.Names}}"))
+
+    try:
+        completed = (command_runner or _run_command)(command)
+    except OSError as error:
+        raise DockerContainerBindingError(
+            "docker_container_discovery_failed"
+        ) from error
+    if completed.returncode != 0 or not isinstance(completed.stdout, str):
+        raise DockerContainerBindingError("docker_container_discovery_failed")
+
+    matches = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    if len(matches) != 1:
+        raise DockerContainerBindingError("docker_container_binding_not_exact")
+
+    return DockerContainerBinding(
+        container_name=matches[0],
+        selector_sha256=selector_sha256,
+        required_label_keys=tuple(key for key, _ in labels),
+    )
+
+
+def compact_docker_container_binding_receipt(
+    binding: DockerContainerBinding,
+) -> dict[str, object]:
+    """Return a public-safe proof that one exact runner container was selected."""
+
+    return {
+        "schema_version": BENCHMARK_EXACT_CONTAINER_BINDING_SCHEMA_VERSION,
+        "authority": "runner",
+        "exact_job_binding": True,
+        "match_count": 1,
+        "ancestor_image_bound": True,
+        "required_label_keys": list(binding.required_label_keys),
+        "selector_sha256": binding.selector_sha256,
+        "public_boundary": {
+            "raw_container_name_recorded": False,
+            "raw_container_id_recorded": False,
+            "raw_label_values_recorded": False,
+        },
+    }

--- a/tests/capabilities/test_benchmark_toolkit.py
+++ b/tests/capabilities/test_benchmark_toolkit.py
@@ -4,19 +4,111 @@ import copy
 import json
 import os
 import subprocess
+from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
 
 from loopx.capabilities.benchmark_toolkit import (
+    BENCHMARK_EXACT_CONTAINER_BINDING_SCHEMA_VERSION,
     BENCHMARK_INTEGRITY_POLICY_SCHEMA_VERSION,
     BENCHMARK_RUNTIME_INTEGRITY_ATTESTATION_SCHEMA_VERSION,
     REQUIRED_RUNTIME_ATTESTATIONS,
+    DockerContainerBindingError,
     build_benchmark_integrity_qualification,
+    compact_docker_container_binding_receipt,
+    select_exact_docker_container,
 )
 from loopx.capabilities.catalog import build_capability_detail_packet
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_exact_container_binding_uses_job_labels_and_hides_runtime_identity() -> None:
+    observed_command: list[str] = []
+    private_job = "fixture-job-private-value"
+    private_container = "fixture-job-private-value-main-1"
+
+    def fake_runner(argv: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        observed_command.extend(str(value) for value in argv)
+        return subprocess.CompletedProcess(argv, 0, f"{private_container}\n", "")
+
+    binding = select_exact_docker_container(
+        ancestor_image="benchmark-runner:fixture",
+        required_labels={
+            "com.docker.compose.project": private_job,
+            "com.docker.compose.service": "main",
+        },
+        command_runner=fake_runner,
+    )
+
+    assert binding.container_name == private_container
+    assert "ancestor=benchmark-runner:fixture" in observed_command
+    assert f"label=com.docker.compose.project={private_job}" in observed_command
+    assert "label=com.docker.compose.service=main" in observed_command
+
+    receipt = compact_docker_container_binding_receipt(binding)
+    assert receipt["schema_version"] == BENCHMARK_EXACT_CONTAINER_BINDING_SCHEMA_VERSION
+    assert receipt["exact_job_binding"] is True
+    assert receipt["match_count"] == 1
+    assert receipt["required_label_keys"] == [
+        "com.docker.compose.project",
+        "com.docker.compose.service",
+    ]
+    rendered = json.dumps(receipt, sort_keys=True)
+    assert private_job not in rendered
+    assert private_container not in rendered
+    assert "benchmark-runner:fixture" not in rendered
+
+
+@pytest.mark.parametrize("stdout", ["", "container-a\ncontainer-b\n"])
+def test_exact_container_binding_fails_closed_on_non_exact_match(stdout: str) -> None:
+    private_value = "private-selector-value"
+
+    def fake_runner(argv: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(argv, 0, stdout, "")
+
+    with pytest.raises(
+        DockerContainerBindingError,
+        match="^docker_container_binding_not_exact$",
+    ) as error:
+        select_exact_docker_container(
+            ancestor_image="benchmark-runner:fixture",
+            required_labels={"job.identity": private_value},
+            command_runner=fake_runner,
+        )
+
+    assert private_value not in str(error.value)
+    for private_match in stdout.splitlines():
+        assert private_match not in str(error.value)
+
+
+def test_exact_container_binding_rejects_invalid_or_failed_discovery() -> None:
+    with pytest.raises(
+        DockerContainerBindingError,
+        match="^invalid_docker_container_selector$",
+    ):
+        select_exact_docker_container(
+            ancestor_image="benchmark-runner:fixture\nleak",
+            required_labels={"job.identity": "job-1"},
+        )
+
+    private_stderr = "private Docker diagnostic"
+
+    def failing_runner(argv: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(argv, 1, "", private_stderr)
+
+    with pytest.raises(
+        DockerContainerBindingError,
+        match="^docker_container_discovery_failed$",
+    ) as error:
+        select_exact_docker_container(
+            ancestor_image="benchmark-runner:fixture",
+            required_labels={"job.identity": "job-1"},
+            command_runner=failing_runner,
+        )
+
+    assert private_stderr not in str(error.value)
 
 
 def test_catalog_exposes_post_run_case_insight_monitor_contract() -> None:


### PR DESCRIPTION
## Summary

- add a benchmark-toolkit helper that resolves a running Docker container from the expected image plus runner-owned job and service labels;
- fail closed unless the selector matches exactly one container;
- emit a compact receipt that excludes the raw container identity and label values;
- document exact-job binding as a DeepSWE runtime-attestation preflight requirement.

## Motivation

Concurrent benchmark arms can legitimately use the same container image. An image-only lookup can therefore attach a runtime isolation snapshot to the wrong job, leaving the score and its runtime evidence unbound. This change makes that binding explicit and reusable before a runner inspects network, privilege, capability, or mount settings.

## Boundary

The helper does not launch jobs, change scoring, grant Docker access, or broaden benchmark permissions. The caller still owns runner authority and may inject an existing command wrapper. Public receipts retain only stable label keys, a match count, and a selector digest.

## Validation

- `python -m pytest tests/capabilities/test_capability_documentation.py tests/capabilities/test_benchmark_toolkit.py -q` — 26 passed
- focused `ruff` checks — passed
- `python -m compileall -q loopx/capabilities/benchmark_toolkit` — passed
- `loopx canary premerge --from-git-diff` — 18 automated checks passed with zero failures, including public/private boundary checks; the expected `benchmark_sensitive` manual-review hold remains, so this PR is not being self-merged
