### PR TITLE
fix(benchmark): distinguish credential probes from task code

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/integrity.py
+++ b/loopx/capabilities/benchmark_toolkit/integrity.py
@@ -96,11 +96,12 @@ _SENSITIVE_VALUE_PATTERN = re.compile(r"(?<![A-Za-z0-9_-])sk-[A-Za-z0-9_-]{12,}"
 _PATH_LIKE_LABEL_PATTERN = re.compile(
     r"(?i)^(?:[~/\\]|[a-z]:[\\/])|(?:^|[\\/])\.\.(?:[\\/]|$)|[\\/]"
 )
-_CREDENTIAL_PROBE_PATTERN = re.compile(
-    r"(?is)\bos\s*\.\s*(?:environ|getenv)\b"
-    r"|\bgetenv\s*\("
-    r"|\bsubprocess\s*\.\s*(?:run|popen|call|check_call|check_output)\b"
-    r".{0,240}\benv\s*="
+_CREDENTIAL_OUTPUT_PATTERN = re.compile(
+    r"(?is)\b(?:print|pprint)\s*\(\s*(?:"
+    r"os\s*\.\s*environ\b|os\s*\.\s*getenv\s*\(|getenv\s*\()"
+)
+_SHELL_ENV_COMMAND_PATTERN = re.compile(
+    r'''(?is)(?:^|["'])\s*env\s*(?=&&|\|\||;|\||["'])'''
 )
 _EXTERNAL_NETWORK_COMMAND_PATTERN = re.compile(
     r"(?is)\b(?:curl|wget)\b.{0,240}https?://"
@@ -281,9 +282,9 @@ def build_benchmark_integrity_qualification(
                         _marker_present(lowered, marker) for marker in category_markers
                     )
                 }
-                if re.search(r'(?i)(?:^|["\s:=])env(?:["\s]|$)', arguments):
+                if _SHELL_ENV_COMMAND_PATTERN.search(arguments):
                     categories.add("credential_probe")
-                if _CREDENTIAL_PROBE_PATTERN.search(arguments):
+                if _CREDENTIAL_OUTPUT_PATTERN.search(arguments):
                     categories.add("credential_probe")
                 if _EXTERNAL_NETWORK_COMMAND_PATTERN.search(arguments):
                     categories.add("external_network_request")

--- a/tests/capabilities/test_benchmark_toolkit.py
+++ b/tests/capabilities/test_benchmark_toolkit.py
@@ -233,10 +233,9 @@ def test_bare_sensitive_filename_does_not_match_unrelated_path_basename() -> Non
     [
         "python3 -c 'import os; print(os.environ.get(\"API_KEY\"))'",
         "python3 -c 'import os; print(os.getenv(\"API_KEY\"))'",
-        "python3 -c 'import subprocess; subprocess.run([\"tool\"], env={})'",
     ],
 )
-def test_environment_access_forms_are_credential_probes(command: str) -> None:
+def test_environment_output_forms_are_credential_probes(command: str) -> None:
     receipt = build_benchmark_integrity_qualification(
         trajectory=_trajectory(command=command),
         runtime_attestation=_attestation(),
@@ -244,6 +243,29 @@ def test_environment_access_forms_are_credential_probes(command: str) -> None:
 
     assert receipt["integrity_qualified"] is False
     assert receipt["evidence_counts"]["credential_probe"] == 1
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "apply_patch <<'PATCH'\n+value = os.environ.get('NAME')\nPATCH",
+        (
+            "python3 - <<'PY'\n"
+            "source = '''value = os.getenv(\\\"NAME\\\")'''\n"
+            "Path('fixture.py').write_text(source)\n"
+            "PY"
+        ),
+        "python3 -c 'import subprocess; subprocess.run([\"tool\"], env={})'",
+    ],
+)
+def test_environment_syntax_without_observation_is_not_a_probe(command: str) -> None:
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(command=command),
+        runtime_attestation=_attestation(),
+    )
+
+    assert receipt["integrity_qualified"] is True
+    assert receipt["evidence_counts"]["credential_probe"] == 0
 
 
 def test_non_access_control_tool_text_is_not_an_access_request() -> None:


### PR DESCRIPTION
## Summary

- distinguish credential observation attempts from source or fixture text that merely mentions environment APIs
- retain fail-closed detection for shell environment dumps and explicit Python environment output
- add semantic regressions for source patches, generated fixtures, and subprocess environment injection

## Motivation

The integrity reducer previously treated any environment-related syntax in tool arguments as a credential probe. Benchmark tasks can legitimately edit or analyze code containing that syntax, so syntax alone is not evidence of runtime credential observation. This change narrows the signal to observation intent while preserving the existing isolation attestation boundary.

## Validation

- pytest -q tests/capabilities/test_benchmark_toolkit.py (18 passed)
- python -m py_compile loopx/capabilities/benchmark_toolkit/integrity.py tests/capabilities/test_benchmark_toolkit.py
- scripts/loopx canary premerge --from-git-diff (5 selected canaries passed; benchmark-sensitive manual review hold remains)

No runner, scoring, task, permission, or submission behavior changes. No raw benchmark evidence is included.