### PR TITLE
fix(todos): close two side doors in the hard_lease handoff gate

### DIFF
--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -642,6 +642,9 @@ loopx todo complete \
 The version check is optional; the idempotency key is required while the lease
 is active. A missing or mismatched key fails before Todo or successor state is
 written, including when two host processes intentionally share one `agent_id`.
+`todo supersede` moves the same todo to done and crosses the same fence with
+the same two options; a leased todo cannot be retired keylessly through either
+verb.
 
 ## Parsed Schema
 

--- a/docs/reference/protocols/host-integration-surface-v0.md
+++ b/docs/reference/protocols/host-integration-surface-v0.md
@@ -298,10 +298,10 @@ loopx todo complete --goal-id <goal-id> --todo-id <todo_id> --claimed-by <agent-
 
 The acquire key is an execution-instance fence. A lifecycle writer cannot rely
 on `agent_id` alone because multiple host processes may share one registered
-peer identity. While an effective lease exists, `todo complete` holds the lease
-lock through canonical state writeback and rejects a missing, stale, or
-mismatched key before creating successors. Hosts may also pass
-`--task-lease-expected-version` for an explicit version CAS.
+peer identity. While an effective lease exists, `todo complete` and
+`todo supersede` hold the lease lock through canonical state writeback and
+reject a missing, stale, or mismatched key before creating successors. Hosts
+may also pass `--task-lease-expected-version` for an explicit version CAS.
 
 If the host adapter is unavailable, the user or automation can run those
 commands and preserve the same state transitions. If a host offers an operation

--- a/loopx/bootstrap.py
+++ b/loopx/bootstrap.py
@@ -7,6 +7,10 @@ from pathlib import Path
 from typing import Any
 
 from .control_plane.runtime.time import now_local_iso
+from .control_plane.todos.handoff_mode import (
+    HANDOFF_MODE_LEGACY,
+    goal_handoff_mode,
+)
 from .control_plane.todos.active_state_editing import (
     TODO_SECTION_HEADINGS,
     insertion_anchor,
@@ -433,6 +437,7 @@ def render_state_markdown(
     accept_onboarding_agent_todos: bool = False,
     begin_autonomous_advance: bool = False,
     codex_app_heartbeat: str = "ask",
+    handoff_mode: str = HANDOFF_MODE_LEGACY,
 ) -> str:
     safe_objective = objective.replace('"', '\\"')
     profile_summary = execution_profile_summary(execution_profile)
@@ -450,13 +455,19 @@ def render_state_markdown(
         begin_autonomous_advance=begin_autonomous_advance,
         codex_app_heartbeat=codex_app_heartbeat,
     )
+    # ``handoff_mode`` travels in the state front matter (RFC shared-goal
+    # authority, Appendix B). Legacy is the absent default and is never
+    # materialized, so an untouched goal keeps its byte-for-byte shape.
+    handoff_mode_line = (
+        f"handoff_mode: {handoff_mode}\n" if handoff_mode != HANDOFF_MODE_LEGACY else ""
+    )
     state_text = f"""---
 status: active
 owner_mode: goal
 objective: "{safe_objective}"
 updated_at: {updated_at}
 adapter_id: {goal_id}
----
+{handoff_mode_line}---
 
 # Active Goal State
 
@@ -765,12 +776,18 @@ def bootstrap_project(
         "replaced": "would-replace",
     }
     force_bootstrap_warning = None
+    declared_handoff_mode = HANDOFF_MODE_LEGACY
     if state_exists and force:
+        # A forced rebuild replaces todos, never the goal's handoff contract:
+        # the declared mode is carried into the rewritten front matter, and an
+        # invalid declaration fails closed before anything is rewritten.
+        declared_handoff_mode = goal_handoff_mode(state_file.read_text(encoding="utf-8"))
         force_bootstrap_warning = {
             "kind": "force_reconnect_existing_active_state",
             "state_file": str(state_file),
             "state_action": state_action,
             "will_replace_active_state": state_action == "replaced",
+            "handoff_mode": declared_handoff_mode,
             "preserve_todos_requested": bool(preserve_todos),
             "recommended_scope_migration": (
                 "Use configure-goal --write-scope ... --execute to change write scope "
@@ -897,6 +914,7 @@ def bootstrap_project(
                     accept_onboarding_agent_todos=accept_onboarding_agent_todos,
                     begin_autonomous_advance=begin_autonomous_advance,
                     codex_app_heartbeat=codex_app_heartbeat,
+                    handoff_mode=declared_handoff_mode,
                 ),
                 encoding="utf-8",
             )

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -387,16 +387,17 @@ def register_todo_command(
     todo_parser.add_argument(
         "--task-lease-idempotency-key",
         help=(
-            "For todo complete, prove the execution instance that owns an active "
-            "hard task lease. Required when that todo has an effective lease."
+            "For todo complete and todo supersede, prove the execution instance "
+            "that owns an active hard task lease. Required when that todo has an "
+            "effective lease."
         ),
     )
     todo_parser.add_argument(
         "--task-lease-expected-version",
         type=int,
         help=(
-            "For todo complete, optionally CAS the active hard task lease version. "
-            "Requires --task-lease-idempotency-key."
+            "For todo complete and todo supersede, optionally CAS the active hard "
+            "task lease version. Requires --task-lease-idempotency-key."
         ),
     )
     todo_parser.add_argument(
@@ -828,6 +829,8 @@ def handle_todo_command(
                 next_excluded_agents=args.next_excluded_agents,
                 agent_id=args.agent_id,
                 authority_reason=args.authority_reason,
+                task_lease_idempotency_key=args.task_lease_idempotency_key,
+                task_lease_expected_version=args.task_lease_expected_version,
                 **_todo_path_args(args),
                 dry_run=bool(args.dry_run),
             )

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -363,6 +363,10 @@ def validate_todo_complete_options(args: argparse.Namespace) -> None:
 def validate_todo_supersede_options(args: argparse.Namespace) -> None:
     if not args.todo_id:
         raise ValueError("todo supersede requires --todo-id")
+    if args.task_lease_expected_version is not None and not args.task_lease_idempotency_key:
+        raise ValueError(
+            "--task-lease-expected-version requires --task-lease-idempotency-key"
+        )
     if args.explore_result_node_refs or args.clear_explore_result_node_refs:
         raise ValueError("todo supersede does not update --explore-result-node-ref; use todo update first")
     if args.decision_outcome:
@@ -467,7 +471,7 @@ def validate_shared_todo_options(args: argparse.Namespace) -> None:
             "--replan-obligation-id is supported only by todo add"
         )
     if (
-        args.todo_command != "complete"
+        args.todo_command not in {"complete", "supersede"}
         and (
             args.task_lease_idempotency_key
             or args.task_lease_expected_version is not None
@@ -475,7 +479,7 @@ def validate_shared_todo_options(args: argparse.Namespace) -> None:
     ):
         raise ValueError(
             "--task-lease-idempotency-key and --task-lease-expected-version "
-            "are supported only by todo complete"
+            "are supported only by todo complete and todo supersede"
         )
     if args.capability_binding_ref and args.todo_command != "add":
         raise ValueError(

--- a/loopx/control_plane/work_items/task_lease.py
+++ b/loopx/control_plane/work_items/task_lease.py
@@ -4,7 +4,7 @@ import fnmatch
 import json
 import re
 from collections.abc import Callable, Iterator
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -31,6 +31,7 @@ from ..todos.handoff_mode import (
     HANDOFF_MODE_SOFT_CLAIM,
     HandoffModeError,
     goal_handoff_mode_for_goal,
+    resolve_todo_completion_handoff,
 )
 
 TASK_LEASE_SCHEMA_VERSION = "task_lease_v0"
@@ -497,6 +498,51 @@ def hold_task_lease_mutation_fence(
         fence = _VerifiedTaskLeaseFence(fence_payload)
         fence.release_hook = lambda: remove_lease(lease_path)
         yield fence
+
+
+def enter_terminal_todo_lease_fence(
+    stack: ExitStack,
+    *,
+    registry_path: Path,
+    goal_id: str,
+    todo_id: str,
+    todo: dict[str, Any],
+    actor_agent_id: str | None,
+    state_text: str,
+    mutation_authority: dict[str, Any],
+    idempotency_key: str | None = None,
+    expected_version: int | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Resolve the goal handoff and hold the lease fence for one terminal write.
+
+    Every transition that moves an existing todo to ``done`` (complete and
+    supersede alike) is a completion for the lease contract: it must cross
+    the same per-goal lease fence with the same typed outcomes, so a leased
+    todo cannot be retired keylessly through a sibling verb. The caller keeps
+    the state-file lock and ``stack`` open across its write and then calls
+    ``release_verified_task_lease_fence`` with the commit outcome.
+    """
+
+    handoff = resolve_todo_completion_handoff(
+        state_text=state_text,
+        mutation_authority=mutation_authority,
+    )
+    fence = stack.enter_context(
+        hold_task_lease_mutation_fence(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            todo_id=todo_id,
+            todo=todo,
+            actor_agent_id=actor_agent_id,
+            idempotency_key=idempotency_key,
+            expected_version=expected_version,
+            require_active_when_key_supplied=(
+                idempotency_key is not None or expected_version is not None
+            ),
+            handoff=handoff,
+        )
+    )
+    return handoff, fence
 
 
 def release_verified_task_lease_fence(

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -119,6 +119,7 @@ from .control_plane.todos.handoff_mode import (
     resolve_todo_completion_handoff,
 )
 from .control_plane.work_items.task_lease import (
+    enter_terminal_todo_lease_fence,
     hold_task_lease_mutation_fence,
     release_verified_task_lease_fence,
 )
@@ -1995,6 +1996,7 @@ def supersede_goal_todo(
     next_continuation_policy: str | None = None,
     next_excluded_agents: list[str] | None = None,
     agent_id: str | None = None, authority_reason: str | None = None,
+    task_lease_idempotency_key: str | None = None, task_lease_expected_version: int | None = None,
     project: Path | None = None,
     state_file: Path | None = None,
     dry_run: bool = False,
@@ -2014,10 +2016,8 @@ def supersede_goal_todo(
         state_file=state_file,
     )
     with exclusive_file_lock(
-        resolved_state_file,
-        agent_id=agent_id,
-        operation="todo_supersede",
-    ):
+        resolved_state_file, agent_id=agent_id, operation="todo_supersede",
+    ), ExitStack() as lease_fence_stack:
         original = resolved_state_file.read_text(encoding="utf-8")
         lines = original.splitlines()
         updated_at = now_local()
@@ -2037,21 +2037,17 @@ def supersede_goal_todo(
             todo=authority_todo,
             actor_agent_id=agent_id, authority_reason=authority_reason,
         )
+        completion_handoff, task_lease_fence = enter_terminal_todo_lease_fence(
+            lease_fence_stack, registry_path=registry_path, goal_id=goal_id, todo_id=todo_id,
+            todo=authority_todo, actor_agent_id=agent_id, state_text=original, mutation_authority=mutation_authority,
+            idempotency_key=task_lease_idempotency_key, expected_version=task_lease_expected_version,
+        )
         effective_next_claimed_by = (
-            require_registered_agent_id(
-                registry_path=registry_path,
-                goal_id=goal_id,
-                agent_id=next_claimed_by,
-                field="next_claimed_by",
-            )
-            if next_claimed_by
-            else None
+            require_registered_agent_id(registry_path=registry_path, goal_id=goal_id, agent_id=next_claimed_by, field="next_claimed_by")
+            if next_claimed_by else None
         )
         effective_next_excluded_agents = require_registered_todo_excluded_agents(
-            registry_path=registry_path,
-            goal_id=goal_id,
-            excluded_agents=next_excluded_agents,
-            field="next_excluded_agents",
+            registry_path=registry_path, goal_id=goal_id, excluded_agents=next_excluded_agents, field="next_excluded_agents",
         )
         if effective_next_claimed_by and not next_agent_todo:
             raise ValueError("--next-claimed-by requires --next-agent-todo")
@@ -2183,6 +2179,7 @@ def supersede_goal_todo(
             new_text = replace_updated_at(new_text, updated_at)
         if changed and not dry_run:
             resolved_state_file.write_text(new_text, encoding="utf-8")
+        release_verified_task_lease_fence(task_lease_fence, committed=changed and not dry_run)
     return {
         "ok": True,
         "dry_run": dry_run,
@@ -2191,6 +2188,7 @@ def supersede_goal_todo(
         **update_result,
         "changed": changed,
         "mutation_authority": mutation_authority,
+        "task_lease_fence": task_lease_fence, **completion_handoff,
         "next_todos": next_results,
         "state_file": str(resolved_state_file),
         "project": str(resolved_project) if resolved_project else None,

--- a/tests/control_plane/test_goal_handoff_mode.py
+++ b/tests/control_plane/test_goal_handoff_mode.py
@@ -1734,3 +1734,87 @@ def test_legacy_pin_supersede_ignores_missing_lease_but_fences_effective_lease(
     assert error.value.code == "lease_fence_required"
     assert _agent_todo(state, leased_todo["todo_id"])["done"] is False
 
+
+# ---------------------------------------------------------------------------
+# force bootstrap rewrites the state file: the declared mode must travel with it
+# ---------------------------------------------------------------------------
+
+
+def _force_bootstrap(registry: Path, state: Path, tmp_path: Path, **overrides: Any) -> dict[str, Any]:
+    from loopx.bootstrap import bootstrap_project
+
+    options: dict[str, Any] = dict(
+        project=state.parent,
+        registry_path=registry,
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        objective="Rebuild the active state without changing the handoff contract.",
+        domain="harness_self_improvement",
+        role="owner",
+        parent_goal_id=None,
+        state_file=state,
+        goal_doc=None,
+        adapter_kind="harness_self_improvement",
+        adapter_status="active",
+        next_probe=None,
+        spawn_allowed=False,
+        max_children=0,
+        allowed_domains=None,
+        write_scope=None,
+        onboarding_scan_enabled=False,
+        preserve_todos=False,
+        force=True,
+        dry_run=False,
+        sync_global=False,
+    )
+    options.update(overrides)
+    return bootstrap_project(**options)
+
+
+def test_force_bootstrap_replace_preserves_declared_handoff_mode(tmp_path: Path) -> None:
+    """Appendix B rule 5: a mode change needs quiescence; a forced state rebuild
+    is not a mode change and must not silently fall back to legacy."""
+
+    registry, state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+    _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+
+    payload = _force_bootstrap(registry, state, tmp_path)
+
+    assert payload["state_action"] == "replaced"
+    assert payload["force_bootstrap_warning"]["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
+    rebuilt = state.read_text(encoding="utf-8")
+    assert goal_handoff_mode(rebuilt) == HANDOFF_MODE_HARD_LEASE
+    assert todo["todo_id"] not in rebuilt
+
+
+def test_force_bootstrap_replace_keeps_legacy_default_absent(tmp_path: Path) -> None:
+    registry, state = _write_workspace(tmp_path)
+
+    payload = _force_bootstrap(registry, state, tmp_path)
+
+    assert payload["state_action"] == "replaced"
+    assert payload["force_bootstrap_warning"]["handoff_mode"] == HANDOFF_MODE_LEGACY
+    assert "handoff_mode:" not in state.read_text(encoding="utf-8")
+    assert goal_handoff_mode(state.read_text(encoding="utf-8")) == HANDOFF_MODE_LEGACY
+
+
+def test_force_bootstrap_dry_run_reports_preserved_mode_without_writing(tmp_path: Path) -> None:
+    registry, state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_SOFT_CLAIM)
+    before = state.read_bytes()
+
+    payload = _force_bootstrap(registry, state, tmp_path, dry_run=True)
+
+    assert payload["force_bootstrap_warning"]["handoff_mode"] == HANDOFF_MODE_SOFT_CLAIM
+    assert state.read_bytes() == before
+
+
+def test_force_bootstrap_replace_refuses_invalid_declared_mode(tmp_path: Path) -> None:
+    registry, state = _write_workspace(tmp_path, handoff_mode="banana")
+    before = state.read_bytes()
+
+    with pytest.raises(HandoffModeError) as error:
+        _force_bootstrap(registry, state, tmp_path)
+
+    assert error.value.code == "invalid_handoff_mode"
+    assert state.read_bytes() == before

--- a/tests/control_plane/test_goal_handoff_mode.py
+++ b/tests/control_plane/test_goal_handoff_mode.py
@@ -58,6 +58,7 @@ from loopx.todos import (
     add_goal_todo,
     complete_goal_todo,
     list_goal_todos,
+    supersede_goal_todo,
     update_goal_todo,
 )
 
@@ -1538,3 +1539,198 @@ def test_holder_gate_normalizes_lease_owner_case_variants(tmp_path: Path) -> Non
         )
         assert gate["active"] is True
         assert gate["owner"] == AGENT_A
+
+
+# ---------------------------------------------------------------------------
+# supersede is a completion-equivalent transition (status -> done) and must
+# cross the same lease fence as complete
+# ---------------------------------------------------------------------------
+
+
+def test_hard_lease_supersede_without_lease_is_typed_rejected(tmp_path: Path) -> None:
+    registry, state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+    before = state.read_bytes()
+
+    with pytest.raises(TaskLeaseError) as error:
+        supersede_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=todo["todo_id"],
+            agent_id=AGENT_A,
+            reason="no lease exists",
+        )
+
+    assert error.value.code == "handoff_mode_requires_lease"
+    assert error.value.payload["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
+    assert state.read_bytes() == before
+
+
+def test_hard_lease_supersede_by_non_holder_without_key_is_typed_rejected(
+    tmp_path: Path,
+) -> None:
+    registry, state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry)
+    _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+    lease_file = task_lease_path(
+        runtime_root=tmp_path / "runtime", goal_id=GOAL_ID, todo_id=todo["todo_id"]
+    )
+    before = state.read_bytes()
+
+    with pytest.raises(TaskLeaseError) as error:
+        supersede_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=todo["todo_id"],
+            agent_id=AGENT_B,
+            reason="peer supersedes without any key",
+        )
+
+    assert error.value.code == "lease_fence_required"
+    assert state.read_bytes() == before
+    assert _agent_todo(state, todo["todo_id"])["done"] is False
+    assert lease_file.exists()
+
+
+def test_hard_lease_supersede_by_holder_without_key_is_typed_rejected(
+    tmp_path: Path,
+) -> None:
+    """The fence is keyed to the execution instance, not to the agent identity."""
+
+    registry, state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+    _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+
+    with pytest.raises(TaskLeaseError) as error:
+        supersede_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=todo["todo_id"],
+            agent_id=AGENT_A,
+            reason="holder forgot the key",
+        )
+
+    assert error.value.code == "lease_fence_required"
+    assert _agent_todo(state, todo["todo_id"])["done"] is False
+
+
+def test_hard_lease_supersede_with_verified_key_succeeds_and_releases_lease(
+    tmp_path: Path,
+) -> None:
+    registry, state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+    _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+    lease_file = task_lease_path(
+        runtime_root=tmp_path / "runtime", goal_id=GOAL_ID, todo_id=todo["todo_id"]
+    )
+
+    result = supersede_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        agent_id=AGENT_A,
+        reason="superseded with the verified key",
+        next_agent_todo="Continue the superseding work.",
+        task_lease_idempotency_key="turn-lease-1",
+    )
+
+    assert result["ok"] is True
+    assert result["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
+    assert result["task_lease_fence"]["required"] is True
+    assert result["task_lease_fence"]["execution_instance_verified"] is True
+    assert result["task_lease_fence"]["released"] is True
+    assert _agent_todo(state, todo["todo_id"])["done"] is True
+    assert not lease_file.exists()
+    assert result["next_todos"][0]["added"] is True
+
+
+def test_hard_lease_supersede_dry_run_keeps_lease_and_state(tmp_path: Path) -> None:
+    registry, state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+    _acquire(registry, tmp_path, todo["todo_id"], owner=AGENT_A)
+    lease_file = task_lease_path(
+        runtime_root=tmp_path / "runtime", goal_id=GOAL_ID, todo_id=todo["todo_id"]
+    )
+    before = state.read_bytes()
+
+    result = supersede_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        agent_id=AGENT_A,
+        reason="preview only",
+        task_lease_idempotency_key="turn-lease-1",
+        dry_run=True,
+    )
+
+    assert result["dry_run"] is True
+    assert result["task_lease_fence"]["execution_instance_verified"] is True
+    assert result["task_lease_fence"].get("released") is not True
+    assert lease_file.exists()
+    assert state.read_bytes() == before
+
+
+def test_hard_lease_delegated_supersede_passes_gate_with_marker(tmp_path: Path) -> None:
+    """The delegated door mirrors complete: it opens the claim gate, never an
+    effective lease. Without a lease the fence is optional and the marker rides."""
+
+    registry, state = _write_workspace(
+        tmp_path,
+        handoff_mode=HANDOFF_MODE_HARD_LEASE,
+        lifecycle_authority=[
+            {
+                "agent_id": ORCHESTRATOR,
+                "actions": ["supersede"],
+                "requires_reason": True,
+            }
+        ],
+    )
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+
+    result = supersede_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        agent_id=ORCHESTRATOR,
+        authority_reason="retire stale work",
+        reason="delegated supersede",
+    )
+
+    assert result["ok"] is True
+    assert result["handoff_gate_overridden"] is True
+    assert result["task_lease_fence"]["required"] is False
+    assert _agent_todo(state, todo["todo_id"])["done"] is True
+
+
+def test_legacy_pin_supersede_ignores_missing_lease_but_fences_effective_lease(
+    tmp_path: Path,
+) -> None:
+    """Legacy parity with complete since the completion fence landed: no lease
+    means no fence; an effective foreign lease requires the key."""
+
+    registry, state = _write_workspace(tmp_path)
+    free_todo = _add_todo(registry, claimed_by=AGENT_A)
+    free = supersede_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=free_todo["todo_id"],
+        agent_id=AGENT_A,
+        reason="legacy supersede without any lease",
+    )
+    assert free["ok"] is True
+    assert free["handoff_mode"] == HANDOFF_MODE_LEGACY
+    assert free["task_lease_fence"]["required"] is False
+
+    leased_todo = _add_todo(registry)
+    _acquire(registry, tmp_path, leased_todo["todo_id"], owner=AGENT_A)
+    with pytest.raises(TaskLeaseError) as error:
+        supersede_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=leased_todo["todo_id"],
+            agent_id=AGENT_B,
+            reason="legacy peer supersedes a leased todo",
+        )
+    assert error.value.code == "lease_fence_required"
+    assert _agent_todo(state, leased_todo["todo_id"])["done"] is False
+

--- a/tests/control_plane/test_goal_handoff_mode_cli.py
+++ b/tests/control_plane/test_goal_handoff_mode_cli.py
@@ -458,3 +458,65 @@ def test_cli_task_lease_acquire_in_soft_mode_maps_typed_error_code(
     assert payload["ok"] is False
     assert payload["error_code"] == "handoff_mode_forbids_lease"
     assert payload["handoff_mode"] == HANDOFF_MODE_SOFT_CLAIM
+
+
+# ---------------------------------------------------------------------------
+# (f) supersede crosses the same lease fence as complete through the CLI.
+# ---------------------------------------------------------------------------
+
+
+def test_todo_supersede_cli_requires_key_in_hard_lease_and_accepts_it(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    registry, _state = _write_workspace(tmp_path, handoff_mode=HANDOFF_MODE_HARD_LEASE)
+    todo = _add_todo(registry, claimed_by=AGENT_A)
+    acquire_task_lease(
+        registry_path=registry,
+        runtime_root=tmp_path / "runtime",
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        owner=AGENT_A,
+        idempotency_key="turn-lease-1",
+        ttl_seconds=600,
+    )
+
+    exit_code, payload = _run_cli(
+        capsys,
+        registry,
+        "todo",
+        "supersede",
+        "--goal-id",
+        GOAL_ID,
+        "--todo-id",
+        todo["todo_id"],
+        "--agent-id",
+        AGENT_A,
+        "--reason",
+        "keyless supersede must be fenced",
+    )
+    assert exit_code == 1
+    assert payload["ok"] is False
+    assert payload["error_code"] == "lease_fence_required"
+
+    exit_code, payload = _run_cli(
+        capsys,
+        registry,
+        "todo",
+        "supersede",
+        "--goal-id",
+        GOAL_ID,
+        "--todo-id",
+        todo["todo_id"],
+        "--agent-id",
+        AGENT_A,
+        "--reason",
+        "keyed supersede",
+        "--task-lease-idempotency-key",
+        "turn-lease-1",
+    )
+    assert exit_code == 0
+    assert payload["ok"] is True
+    assert payload["handoff_mode"] == HANDOFF_MODE_HARD_LEASE
+    assert payload["task_lease_fence"]["execution_instance_verified"] is True
+    assert payload["task_lease_fence"]["released"] is True


### PR DESCRIPTION
按 RFC 附录 B（#3042）的合同验收 #3164 落地后的门禁完整性，用真实测试找到两扇绕过门禁的侧门，一并关上。

## 问题

**一、`todo supersede` 不过完成栅栏。** `supersede` 和 `complete` 一样把已有 todo 置为 done，但它只走生命周期授权（看 `claimed_by`），从不进入租约栅栏。在 `hard_lease` 下这就是键控完成门旁边的一扇无钥匙侧门，实测：

- 非持约人 `complete` 无钥匙 → `lease_fence_required` 拒绝 ✅
- 非持约人 `supersede` 无钥匙 → **成功**，todo 置 done，租约文件原地留下成孤儿 ❌
- 持约人自己 `supersede` 不带钥匙 → **成功**，而同一人 `complete` 不带钥匙被拒 ❌

附录 B 写的是 "hard_lease：完成必须带钥匙"，两个动词现在必须说同一种话。

**二、`bootstrap --force` 把 `handoff_mode` 静默打回 legacy。** 不带 `--preserve-todos` 的强制重建从固定模板渲染前置 YAML，`handoff_mode: hard_lease` 消失，goal 变回最松的模式，既不检查静止态也没有任何回执，而单机租约文件还活着。附录 B 第 5 条把每一次模式变更绑在静止态上；强制重建替换的是 todo，不是交接合同。

## 这个 PR 做了什么

- `task_lease.py` 新增 `enter_terminal_todo_lease_fence`：解析完成 handoff、持有 `hold_task_lease_mutation_fence`，两个动词共用同一个入口、同一套类型化结果、同一扇委托授权门。
- `supersede_goal_todo` 在生命周期授权之后进入栅栏，写入提交后释放已验证的租约（dry-run 与被拒的写入不碰租约），结果里像 `complete` 一样带 `task_lease_fence`、`handoff_mode` 与越门标记。
- CLI `todo supersede` 接受 `--task-lease-idempotency-key` / `--task-lease-expected-version`，校验规则与 `complete` 相同。
- `render_state_markdown` 接受声明的模式写入前置；`bootstrap_project` 在强制重建前读出已声明的模式并带入新文件，`force_bootstrap_warning.handoff_mode` 报告它（dry-run 也报），非法声明 fail closed 而不是覆盖。`legacy` 仍是缺席默认值，未声明的 goal 字节形状不变。
- 两处文档同步（todo contract、host-integration-surface）：supersede 与 complete 过同一道栅栏。

## 必须说清楚的行为变更

legacy / soft_claim 下与 #3028 之后的 `complete` 对齐：没有租约时零变化；存在有效租约时 `supersede` 现在也要求钥匙（`complete` 早已如此）。这是 legacy 有租约场景下一个真实的、有意的差异，已用 characterization 用例钉住。

## 验证

- 新增 12 个用例：hard_lease 下 supersede 无租约/非持约人/持约人无钥匙三种拒绝、带钥匙成功并释放租约、dry-run 不动租约、委托授权门带标记通过、legacy 平价钉子；CLI 端到端（无钥匙被拒 + 带钥匙成功）；强制重建保留模式（hard_lease）、legacy 保持缺席、dry-run 只报告不写、非法模式 fail closed。写测试时先红后绿。
- `tests/control_plane` + `tests/canary` 全量 1324 通过；唯一失败项 `test_scheduler_ack_current_replays_host_binding_after_update` 在未改动的 `origin/main` 上同样失败（环境性）。
- `tests/architecture`、`tests/cli_commands`、CLI 诊断、entrypoint、turn driver、maintainability ratchet、m6 gates 共 224 通过；仓库 mypy profile 通过；ruff 干净；`loopx/todos.py` 2246 行，未改动模块预算上限（2249）。

## 不做的事

不动 legacy 的分叉洞本身；不动 #3198 的 user gate 自动铸钥匙；不加任何新的绕过开关。

@huangruiteng
