### PR TITLE
fix(examples): restore the nokv shadow-provider evidence against current NoKV and LoopX

### DIFF
--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0-evidence.zh-CN.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0-evidence.zh-CN.md
@@ -35,7 +35,7 @@
 python3 examples/nokv-shadow-provider/probes.py contract
 ```
 
-命令退出码为 `0`，并逐项报告以下八个通过的合同探针：
+命令退出码为 `0`，并逐项报告以下九个通过的合同探针：
 
 - `contract.bootstrap_and_preconditions`；
 - `contract.a_success_b_advance_replay_a`；
@@ -43,12 +43,15 @@ python3 examples/nokv-shadow-provider/probes.py contract
 - `contract.competing_claims`；
 - `contract.crash_windows_and_ambiguity`；
 - `contract.version_domains_and_retain_all`；
+- `contract.nokv_adapter_exception_mapping`（NoKV adapter 把 0.11.0 SDK 的
+  `FileNotFoundError` / `FileExistsError` / `RuntimeError` 全部映射为类型化
+  provider 结果，不向 authority 泄露异常）；
 - `contract.durable_completion_projection`；
 - `contract.durable_completion_fail_closed`（含显式 `completion_continuation`
   缺失或矛盾时的 fail-closed）。
 
 最终机器判定为
-`{"ok":true,"probe":"contract.summary","probes":8}`。这是使用确定性
+`{"ok":true,"probe":"contract.summary","probes":9}`。这是使用确定性
 provider fake 验证 authority/provider 合同的结果；它没有启动或验证真实
 NoKV 服务，不能替代 live-stack 证据。该命令由
 `tests/test_nokv_shadow_provider_probes.py` 作为常规 pytest 门槛守住，

--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0-evidence.zh-CN.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0-evidence.zh-CN.md
@@ -35,19 +35,24 @@
 python3 examples/nokv-shadow-provider/probes.py contract
 ```
 
-命令退出码为 `0`，并逐项报告以下六个通过的合同探针：
+命令退出码为 `0`，并逐项报告以下八个通过的合同探针：
 
 - `contract.bootstrap_and_preconditions`；
 - `contract.a_success_b_advance_replay_a`；
 - `contract.operation_identity`；
 - `contract.competing_claims`；
 - `contract.crash_windows_and_ambiguity`；
-- `contract.version_domains_and_retain_all`。
+- `contract.version_domains_and_retain_all`；
+- `contract.durable_completion_projection`；
+- `contract.durable_completion_fail_closed`（含显式 `completion_continuation`
+  缺失或矛盾时的 fail-closed）。
 
 最终机器判定为
-`{"ok":true,"probe":"contract.summary","probes":6}`。这是使用确定性
+`{"ok":true,"probe":"contract.summary","probes":8}`。这是使用确定性
 provider fake 验证 authority/provider 合同的结果；它没有启动或验证真实
-NoKV 服务，不能替代 live-stack 证据。
+NoKV 服务，不能替代 live-stack 证据。该命令由
+`tests/test_nokv_shadow_provider_probes.py` 作为常规 pytest 门槛守住，
+LoopX 生命周期合同的变化会在这里立刻显形，而不是让证据静默变红。
 
 这里的“逐字段相同”至少覆盖原始 `accepted_authority_revision`、
 `accepted_todo_revision`、`lease_id`、`lease_epoch`、`applied_at` 与

--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
@@ -7,9 +7,10 @@
   complementing
   [`host-integration-surface-v0`](../../reference/protocols/host-integration-surface-v0.md)
 - Source baseline: LoopX `c6a1da1eaa22962faaeb6d4050d867462e7665ff`
-- Provider API baseline: NoKV `90883d13539e31185f0d78131989fb51912dbd7e`,
-  used only to map the Python `publish_bytes` generation-CAS API statically;
-  the current candidate has not been run against a live NoKV stack
+- Provider API baseline: NoKV `3d75d96965` (0.11.0 line). The Python
+  `publish_bytes` generation-CAS mapping was exercised once by hand against a
+  live NoKV stack at that pin (see the example README); the run is evidence for
+  the mapping only, not part of any merge gate
 - Language note: the
   [Chinese version](./shared-goal-authority-state-provider-v0.zh-CN.md) and this
   English version are semantic mirrors. A difference between them is a defect.

--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
@@ -6,9 +6,9 @@
 - 范围：LoopX 共享 Goal 协调的独立部署合同，用来补充
   [`host-integration-surface-v0`](../../reference/protocols/host-integration-surface-v0.md)
 - 源码基线：LoopX `c6a1da1eaa22962faaeb6d4050d867462e7665ff`
-- Provider API 基线：NoKV `90883d13539e31185f0d78131989fb51912dbd7e`；
-  只用于静态映射 Python `publish_bytes` generation-CAS API，当前 candidate 尚未在
-  真实 NoKV stack 上运行
+- Provider API 基线：NoKV `3d75d96965`（0.11.0 线）。Python `publish_bytes`
+  generation-CAS 映射已在该基线的真实 NoKV stack 上手工跑过一次（见示例 README）；
+  该次运行只是映射本身的证据，不属于任何合并门槛
 - 语言说明：[英文版](./shared-goal-authority-state-provider-v0.md)与本中文版互为
   语义镜像；两者不一致属于缺陷
 

--- a/examples/nokv-shadow-provider/README.md
+++ b/examples/nokv-shadow-provider/README.md
@@ -91,15 +91,28 @@ lease, gate, quota, or scheduling decisions.
 
 ## Validation boundary
 
-A static compatibility audit is pinned to NoKV
-[`90883d13539e31185f0d78131989fb51912dbd7e`](https://github.com/NoKV-Lab/NoKV/commit/90883d13539e31185f0d78131989fb51912dbd7e).
-At that baseline, the Python `publish_bytes` surface accepts
+The provider mapping is pinned to NoKV
+[`3d75d96965`](https://github.com/NoKV-Lab/NoKV/commit/3d75d96965) (the
+0.11.0 line). At that baseline, the Python `publish_bytes` surface accepts
 `expected_generation` for create-only or replacement CAS and exposes optional
-publication `operation_id` and `artifact_revision_id` inputs. This establishes
-that the provider mapping has a source-level API seam; it does not prove its
-live behavior. The NoKV Python SDK and required services were not available in
-the validation environment, so this candidate has no live NoKV execution
-result.
+publication `operation_id` and `artifact_revision_id` inputs; `read` and
+`stat` return the path `generation` the adapter treats as
+`provider_generation`. Since NoKV 0.11.0 the SDK raises `FileNotFoundError`
+for a missing path and `FileExistsError` for a create-only collision (earlier
+SDKs raised `RuntimeError` for both); the adapter classifies both generations
+by exception class first and by message token second, and
+`contract.nokv_adapter_exception_mapping` pins that classification offline
+with a fake client that raises the 0.11.0 exception classes.
+
+The mapping was exercised once by hand against a live NoKV stack at that
+pin (etcd, an S3-compatible object store, `nokv serve`, and `nokv-python`
+built from the same commit): the adapter verbs and the Section 10 checks
+1 to 9 passed with two independent client handles. That run is recorded
+here as evidence for the mapping only; it is not part of the merge gate,
+and it does not qualify restart, recovery, HA, or performance. SDKs built
+before NoKV 0.11.0 cannot decode a 0.11.0 control-plane routing record, so
+the earlier `90883d13539e31185f0d78131989fb51912dbd7e` audit baseline is no
+longer a usable pin.
 
 Run the merge-relevant deterministic regression from the repository root with:
 
@@ -124,6 +137,9 @@ It must prove all of the following:
 - pre/post-CAS faults and ambiguous results recover success only from a stored
   receipt or a later successful CAS after target revalidation; same-generation
   receipt absence fails unproved;
+- the NoKV adapter maps every SDK outcome it can observe (missing head,
+  create-only collision, stale generation, pre-publish failure) onto the typed
+  provider verbs and never leaks an SDK exception class into the authority;
 - a hand-evolved post-completion head read back through the provider byte-CAS
   projects to the same typed continuation outcomes (`successor | no_followup |
   active_goal`) as the LoopX durable-completion seam, failing closed on a
@@ -136,17 +152,18 @@ The durable-completion probes are the read-side comparison registered by the
 RFC's later runtime qualification slice. They do not implement or qualify the
 atomic `complete_todo_with_successor` write side.
 
-The eight current result tags are
+The nine current result tags are
 `contract.bootstrap_and_preconditions`,
 `contract.a_success_b_advance_replay_a`, `contract.operation_identity`,
 `contract.competing_claims`, `contract.crash_windows_and_ambiguity`,
 `contract.version_domains_and_retain_all`,
+`contract.nokv_adapter_exception_mapping`,
 `contract.durable_completion_projection`, and
 `contract.durable_completion_fail_closed`.
 
-The probe has no live-stack mode in this candidate. A future live exercise
-would require etcd, an S3-compatible object store, `nokv serve`, and the NoKV
-Python SDK, plus separately reviewed restart and recovery assertions. An
+The probe has no live-stack mode in this candidate. A repeatable live
+exercise would require etcd, an S3-compatible object store, `nokv serve`, and
+the NoKV Python SDK, plus separately reviewed restart and recovery assertions. An
 earlier run against the superseded last-envelope adapter is not evidence that
 the revised receipt contract passes. Do not reuse its latency, restart, or
 promotion conclusions for this implementation.

--- a/examples/nokv-shadow-provider/README.md
+++ b/examples/nokv-shadow-provider/README.md
@@ -127,8 +127,10 @@ It must prove all of the following:
 - a hand-evolved post-completion head read back through the provider byte-CAS
   projects to the same typed continuation outcomes (`successor | no_followup |
   active_goal`) as the LoopX durable-completion seam, failing closed on a
-  contradictory record (both `no_followup` and successors) and on a dangling
-  declared successor, with replay-stable projections.
+  contradictory record (both `no_followup` and successors), on a dangling
+  declared successor, on an explicit `completion_continuation` that
+  contradicts the recorded fields, and on a done record that omits its
+  explicit continuation, with replay-stable projections.
 
 The durable-completion probes are the read-side comparison registered by the
 RFC's later runtime qualification slice. They do not implement or qualify the

--- a/examples/nokv-shadow-provider/probes.py
+++ b/examples/nokv-shadow-provider/probes.py
@@ -28,6 +28,9 @@ sys.path.insert(
     ),
 )
 
+from loopx.control_plane.todos.completion_state import (  # noqa: E402
+    completion_continuation_for_write,
+)
 from loopx.control_plane.todos.durable_completion import (  # noqa: E402
     project_durable_completion_outcome,
 )
@@ -641,9 +644,13 @@ def _evolve_completion_head(provider, todo_mutations: dict) -> None:
 
     The v0 authority proof only knows ``claim_work``; durable completion is a
     later slice.  Each mutated todo is committed the way the future atomic
-    ``complete_todo_with_successor`` write will leave it (``status="done"`` plus
-    the declared continuation fields), so the probes read the bytes back through
-    the provider seam rather than through an in-memory fixture.
+    ``complete_todo_with_successor`` write will leave it (``status="done"``,
+    the declared continuation fields, and the explicit
+    ``completion_continuation`` the LoopX lifecycle records durably), so the
+    probes read the bytes back through the provider seam rather than through
+    an in-memory fixture.  The continuation is derived with the same LoopX
+    helper the lifecycle write uses; a mutation may pin an explicit
+    ``completion_continuation`` to model a contradictory record.
     """
     head, generation = load_head(provider, "goal-completion")
     todos = head["coordination"]["todos"]
@@ -653,6 +660,11 @@ def _evolve_completion_head(provider, todo_mutations: dict) -> None:
         record["todo_revision"] = record["todo_revision"] + 1
         for key, value in fields.items():
             record[key] = value
+        if "completion_continuation" not in record:
+            record["completion_continuation"] = completion_continuation_for_write(
+                no_followup=record.get("no_followup") is True,
+                has_successor=bool(record.get("successor_todo_ids")),
+            )
         todos[todo_id] = record
     result = provider.compare_and_put(generation, head)
     assert result["result"] == "applied", result
@@ -733,47 +745,67 @@ def probe_durable_completion_fail_closed() -> None:
     bootstrap(
         provider,
         "goal-completion",
-        ["todo_done04", "todo_done05", "todo_next01"],
+        ["todo_done04", "todo_done05", "todo_done06", "todo_next01"],
     )
     _evolve_completion_head(
         provider,
         {
             # Contradiction: both no_followup and a (existing) successor.
-            "todo_done04": {"no_followup": True, "successor_todo_ids": ["todo_next01"]},
+            "todo_done04": {
+                "no_followup": True,
+                "successor_todo_ids": ["todo_next01"],
+                "completion_continuation": "no_followup",
+            },
             # Dangling: one declared successor exists, one does not.
             "todo_done05": {
                 "successor_todo_ids": ["todo_next01", "todo_missing9"]
+            },
+            # The explicit continuation contradicts the recorded fields.
+            "todo_done06": {
+                "successor_todo_ids": ["todo_next01"],
+                "completion_continuation": "active_goal",
             },
         },
     )
     head, _generation = load_head(provider, "goal-completion")
     todos = head["coordination"]["todos"]
     existing = set(todos)
+    expected_failures = {
+        "todo_done04": "both no_followup and successor_todo_ids",
+        "todo_done05": "declares missing successor Todo ids: todo_missing9",
+        "todo_done06": "completion_continuation contradicts successor_todo_ids",
+    }
+    for todo_id, expected in expected_failures.items():
+        try:
+            project_durable_completion_outcome(
+                todo={"todo_id": todo_id, **todos[todo_id]},
+                expected_todo_id=todo_id,
+                existing_todo_ids=existing,
+            )
+        except ValueError as exc:
+            assert expected in str(exc), (todo_id, str(exc))
+        else:
+            raise AssertionError(f"{todo_id} did not fail closed")
+    # A durably done record without its explicit continuation is not
+    # projectable: the seam fails closed instead of guessing.
+    stripped = {"todo_id": "todo_done05", **todos["todo_done05"]}
+    del stripped["completion_continuation"]
+    stripped["successor_todo_ids"] = ["todo_next01"]
     try:
         project_durable_completion_outcome(
-            todo={"todo_id": "todo_done04", **todos["todo_done04"]},
-            expected_todo_id="todo_done04",
-            existing_todo_ids=existing,
+            todo=stripped, expected_todo_id="todo_done05", existing_todo_ids=existing
         )
     except ValueError as exc:
-        assert "both no_followup and successor_todo_ids" in str(exc)
+        assert "missing completion_continuation" in str(exc)
     else:
-        raise AssertionError("contradictory durable state did not fail closed")
-    try:
-        project_durable_completion_outcome(
-            todo={"todo_id": "todo_done05", **todos["todo_done05"]},
-            expected_todo_id="todo_done05",
-            existing_todo_ids=existing,
-        )
-    except ValueError as exc:
-        assert "declares missing successor Todo ids: todo_missing9" in str(exc)
-    else:
-        raise AssertionError("dangling successor did not fail closed")
+        raise AssertionError("missing completion_continuation did not fail closed")
     out(
         "contract.durable_completion_fail_closed",
         ok=True,
         contradiction_rejected=True,
         dangling_successor_rejected=True,
+        continuation_contradiction_rejected=True,
+        missing_continuation_rejected=True,
     )
 
 

--- a/examples/nokv-shadow-provider/probes.py
+++ b/examples/nokv-shadow-provider/probes.py
@@ -37,6 +37,7 @@ from loopx.control_plane.todos.durable_completion import (  # noqa: E402
 
 from provider import (  # noqa: E402
     CoordinationAuthority,
+    NoKVCoordinationProvider,
     bootstrap_aggregate,
     sample_envelope,
 )
@@ -809,6 +810,132 @@ def probe_durable_completion_fail_closed() -> None:
     )
 
 
+class FakeNoKVClient:
+    """Minimal double for the NoKV Python SDK ``Client`` surface the adapter uses.
+
+    It raises the exception classes the SDK raises since NoKV 0.11.0
+    (``nokv-python`` maps ``NotFound`` to ``FileNotFoundError`` and
+    ``AlreadyExists`` to ``FileExistsError``; other RPC failures stay
+    ``RuntimeError``).  Generations restart at 1 per path lifetime and every
+    replacement advances by one, like the live workspace.
+    """
+
+    def __init__(self):
+        self.paths: dict[tuple[str, str], tuple[bytes, int]] = {}
+        self.stat_failure: Exception | None = None
+
+    def stat(self, workbench: str, path: str) -> dict:
+        if self.stat_failure is not None:
+            failure, self.stat_failure = self.stat_failure, None
+            raise failure
+        try:
+            _bytes, generation = self.paths[(workbench, path)]
+        except KeyError:
+            raise FileNotFoundError("workspace request failed: path does not exist") from None
+        return {"generation": generation}
+
+    def read(self, workbench: str, path: str) -> dict:
+        try:
+            data, generation = self.paths[(workbench, path)]
+        except KeyError:
+            raise FileNotFoundError("workspace request failed: path does not exist") from None
+        return {"bytes": data, "metadata": {"generation": generation}}
+
+    def publish_bytes(self, workbench: str, path: str, data: bytes, **options) -> dict:
+        expected = options.get("expected_generation")
+        current = self.paths.get((workbench, path))
+        if expected is None:
+            if current is not None:
+                raise FileExistsError(
+                    "artifact publication failed during complete: workspace request "
+                    "failed: path already exists"
+                )
+            generation = 1
+        else:
+            if current is None or current[1] != expected:
+                raise RuntimeError(
+                    "artifact publication failed during complete: workspace request "
+                    f"failed: path generation mismatch: expected {expected}"
+                )
+            generation = current[1] + 1
+        self.paths[(workbench, path)] = (bytes(data), generation)
+        return {"generation": generation}
+
+
+def probe_nokv_adapter_exception_mapping() -> None:
+    """The NoKV byte-CAS adapter must classify SDK exceptions into RFC verbs.
+
+    ``load`` returns ``(None, 0)`` for an uninitialized head, and
+    ``compare_and_put`` returns typed ``applied | conflict | ambiguous | failed``
+    for every SDK outcome it can observe: it never leaks ``FileNotFoundError``,
+    ``FileExistsError``, or ``RuntimeError`` to the authority.
+    """
+
+    client = FakeNoKVClient()
+    goal_id = "adapter-mapping"
+    provider = NoKVCoordinationProvider(client, "wb-adapter", goal_id)
+    head = bootstrap_aggregate(goal_id, {})
+
+    assert provider.load() == (None, 0)
+    created = provider.compare_and_put(0, head)
+    assert created == {"result": "applied", "provider_generation": 1}, created
+    loaded, generation = provider.load()
+    assert loaded == head and generation == 1
+
+    # bootstrap race: the loser observed generation 0 before the winner landed
+    lost_race = provider.compare_and_put(0, head)
+    assert lost_race["result"] == "conflict", lost_race
+    assert lost_race["current_provider_generation"] == 1
+    provider._generation = lambda: 0  # the stat pre-check raced too
+    lost_race_at_publish = provider.compare_and_put(0, head)
+    assert lost_race_at_publish == {"result": "ambiguous"}, lost_race_at_publish
+    del provider._generation
+
+    # replacement CAS: stale expected generation, both before and at publish
+    advanced = copy.deepcopy(head)
+    advanced["authority_revision"] = 1
+    replaced = provider.compare_and_put(1, advanced)
+    assert replaced == {"result": "applied", "provider_generation": 2}, replaced
+    stale = provider.compare_and_put(1, advanced)
+    assert stale == {"result": "conflict", "current_provider_generation": 2}, stale
+    provider._generation = lambda: 1
+    stale_at_publish = provider.compare_and_put(1, advanced)
+    assert stale_at_publish == {"result": "ambiguous"}, stale_at_publish
+    del provider._generation
+
+    # a provider failure before any publish attempt proves that nothing was written
+    client.stat_failure = RuntimeError("RPC transport failed: connection refused")
+    failed = provider.compare_and_put(2, advanced)
+    assert failed["result"] == "failed", failed
+    assert provider.load() == (advanced, 2)
+
+    # legacy SDKs raised RuntimeError for a missing path; both spellings stay classified
+    class LegacyClient(FakeNoKVClient):
+        def read(self, workbench: str, path: str) -> dict:
+            if (workbench, path) not in self.paths:
+                raise RuntimeError("workspace request failed: path not found")
+            return super().read(workbench, path)
+
+        def stat(self, workbench: str, path: str) -> dict:
+            if (workbench, path) not in self.paths:
+                raise RuntimeError("workspace request failed: path not found")
+            return super().stat(workbench, path)
+
+    legacy = NoKVCoordinationProvider(LegacyClient(), "wb-legacy", goal_id)
+    assert legacy.load() == (None, 0)
+    assert legacy.compare_and_put(0, head)["result"] == "applied"
+
+    out(
+        "contract.nokv_adapter_exception_mapping",
+        ok=True,
+        uninitialized_load_typed=True,
+        create_only_race_typed=True,
+        stale_generation_typed=True,
+        pre_publish_failure_typed=True,
+        legacy_runtime_error_still_classified=True,
+    )
+
+
 PROBES = (
     probe_bootstrap_and_preconditions,
     probe_a_b_replay_a,
@@ -816,6 +943,7 @@ PROBES = (
     probe_competing_claims,
     probe_crash_windows_and_ambiguity,
     probe_version_domains_and_retain_all,
+    probe_nokv_adapter_exception_mapping,
     probe_durable_completion_projection,
     probe_durable_completion_fail_closed,
 )

--- a/examples/nokv-shadow-provider/provider.py
+++ b/examples/nokv-shadow-provider/provider.py
@@ -162,14 +162,22 @@ class ProviderProtocolError(RuntimeError):
 
 
 class NoKVCoordinationProvider:
-    """Map one goal's deterministic head bytes to a NoKV generation CAS."""
+    """Map one goal's deterministic head bytes to a NoKV generation CAS.
 
-    _TRANSIENT_READ_ERRORS = (
-        "exceeds the artifact logical size",
-        "fence changed",
-        "retry budget",
-        "read fence",
-    )
+    The NoKV Python SDK raises ``FileNotFoundError`` for a missing path and
+    ``FileExistsError`` for a create-only collision since NoKV 0.11.0
+    (``nokv-python`` maps the ``NotFound`` / ``AlreadyExists`` RPC codes to
+    those ``OSError`` subclasses); every other RPC, transport, or publication
+    failure is a ``RuntimeError``. Earlier SDKs raised ``RuntimeError`` for
+    all of them. The adapter classifies by exception class first and by the
+    documented not-found message tokens second, so both generations of the
+    SDK map onto the same typed provider verbs. It never treats human error
+    text as commit proof: a publish that raises is ``ambiguous`` and the
+    authority reloads its atomically stored receipt index.
+    """
+
+    _CLIENT_ERRORS = (RuntimeError, OSError)
+    _NOT_FOUND_TOKENS = ("not found", "does not exist", "no such path")
 
     def __init__(self, client, workbench: str, goal_id: str):
         self.client = client
@@ -177,40 +185,30 @@ class NoKVCoordinationProvider:
         self.goal_id = goal_id
         self.head_path = f"goals/{goal_id}/coordination-head.json"
 
-    @staticmethod
-    def _not_found(exc: RuntimeError) -> bool:
+    @classmethod
+    def _not_found(cls, exc: BaseException) -> bool:
+        if isinstance(exc, FileNotFoundError):
+            return True
         message = str(exc).lower()
-        return any(token in message for token in (
-            "not found",
-            "does not exist",
-            "no such path",
-        ))
+        return any(token in message for token in cls._NOT_FOUND_TOKENS)
 
-    def load(self, retries: int = 10):
+    def load(self):
         """Return ``(aggregate | None, provider_generation)``."""
-        last_error = None
-        for attempt in range(retries):
-            try:
-                result = self.client.read(self.workbench, self.head_path)
-            except RuntimeError as exc:
-                if self._not_found(exc):
-                    return None, 0
-                message = str(exc).lower()
-                if any(token in message for token in self._TRANSIENT_READ_ERRORS):
-                    last_error = exc
-                    time.sleep(0.01 * (attempt + 1))
-                    continue
-                raise
-            aggregate = json.loads(bytes(result["bytes"]))
-            if not isinstance(aggregate, dict):
-                raise ProviderProtocolError("coordination head must be an object")
-            return aggregate, int(result["metadata"]["generation"])
-        raise last_error or RuntimeError("NoKV read retry budget exhausted")
+        try:
+            result = self.client.read(self.workbench, self.head_path)
+        except self._CLIENT_ERRORS as exc:
+            if self._not_found(exc):
+                return None, 0
+            raise
+        aggregate = json.loads(bytes(result["bytes"]))
+        if not isinstance(aggregate, dict):
+            raise ProviderProtocolError("coordination head must be an object")
+        return aggregate, int(result["metadata"]["generation"])
 
     def _generation(self) -> int:
         try:
             metadata = self.client.stat(self.workbench, self.head_path)
-        except RuntimeError as exc:
+        except self._CLIENT_ERRORS as exc:
             if self._not_found(exc):
                 return 0
             raise
@@ -224,7 +222,7 @@ class NoKVCoordinationProvider:
         """Serialize and conditionally store an opaque aggregate."""
         try:
             current = self._generation()
-        except RuntimeError as exc:
+        except self._CLIENT_ERRORS as exc:
             # No publish was attempted, so this provider failure proves no write.
             return {"result": "failed", "error": str(exc)}
         if current != expected_provider_generation:
@@ -242,9 +240,11 @@ class NoKVCoordinationProvider:
                 operation_id=uuid.uuid4().hex,
                 artifact_revision_id=uuid.uuid4().hex,
             )
-        except RuntimeError:
-            # Do not parse human error text as commit proof.  The authority
-            # reloads and trusts only its atomically stored receipt index.
+        except self._CLIENT_ERRORS:
+            # Do not parse human error text as commit proof: a create-only
+            # collision (``FileExistsError``), a generation mismatch, or a lost
+            # response all reload; the authority trusts only its atomically
+            # stored receipt index.
             return {"result": "ambiguous"}
         return {
             "result": "applied",

--- a/tests/test_nokv_shadow_provider_probes.py
+++ b/tests/test_nokv_shadow_provider_probes.py
@@ -24,6 +24,7 @@ EXPECTED_TAGS = (
     "contract.competing_claims",
     "contract.crash_windows_and_ambiguity",
     "contract.version_domains_and_retain_all",
+    "contract.nokv_adapter_exception_mapping",
     "contract.durable_completion_projection",
     "contract.durable_completion_fail_closed",
 )

--- a/tests/test_nokv_shadow_provider_probes.py
+++ b/tests/test_nokv_shadow_provider_probes.py
@@ -1,0 +1,46 @@
+"""Keep the RFC shared-goal provider evidence command green.
+
+``examples/nokv-shadow-provider/README.md`` names
+``python3 examples/nokv-shadow-provider/probes.py contract`` as the merge
+evidence for the coordination contract. The probes import the LoopX
+durable-completion seam, so a lifecycle contract change can silently turn that
+evidence red; this test runs the command exactly as documented.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+PROBES = REPOSITORY_ROOT / "examples" / "nokv-shadow-provider" / "probes.py"
+
+EXPECTED_TAGS = (
+    "contract.bootstrap_and_preconditions",
+    "contract.a_success_b_advance_replay_a",
+    "contract.operation_identity",
+    "contract.competing_claims",
+    "contract.crash_windows_and_ambiguity",
+    "contract.version_domains_and_retain_all",
+    "contract.durable_completion_projection",
+    "contract.durable_completion_fail_closed",
+)
+
+
+def test_contract_probes_pass_as_documented() -> None:
+    completed = subprocess.run(
+        [sys.executable, str(PROBES), "contract"],
+        cwd=REPOSITORY_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr[-2000:]
+    rows = [json.loads(line) for line in completed.stdout.splitlines() if line.strip()]
+    tags = [row["probe"] for row in rows]
+    assert tags == [*EXPECTED_TAGS, "contract.summary"], tags
+    assert all(row["ok"] is True for row in rows)
+    assert rows[-1]["probes"] == len(EXPECTED_TAGS)


### PR DESCRIPTION
RFC shared-goal-authority-state-provider-v0 的参考实现 `examples/nokv-shadow-provider/` 在两个方向上同时漂移了，这个 PR 用两个提交分别修掉，并把证据命令挂进 pytest。

## 问题一：证据命令在 main 上已经是红的（#3261 之后）

README 写明 `python3 examples/nokv-shadow-provider/probes.py contract` 是合并证据。#3261 让 `durable_completion` 对 done 记录强制要求显式的 `completion_continuation`，而 #3212 手工演化的 post-completion head 没有这个字段，第 7 个探针直接崩：

```
ValueError: durable completion is missing completion_continuation; repair the Todo with `loopx todo complete`
```

bisect：`1e582e1a`（#3250）8/8 绿 → `0cd999ca`（#3261）红。没有任何 CI/测试跑这条命令，所以证据静默变红。

**修法（ce4e228f）**：演化 head 时用生命周期写入同一个 helper `completion_continuation_for_write` 派生显式续接；fail-closed 探针补两条新 seam 规则（续接与记录字段矛盾、done 记录缺续接）；新增 `tests/test_nokv_shadow_provider_probes.py` 按 README 原样跑这条命令，生命周期合同再变会以失败测试出现，而不是过期的证据声明；evidence 文档从"六个探针"改成与 README 一致。

## 问题二：NoKV 0.11.0 SDK 的异常类变了，adapter 一行 CAS 都跑不通

RFC 把 provider 映射静态钉在 NoKV `90883d1`，从未在 live stack 上跑过。NoKV 0.11.0 起 Python SDK 对缺路径抛 `FileNotFoundError`、create-only 冲突抛 `FileExistsError`（`NotFound` / `AlreadyExists` RPC 码映射到 OSError 子类；其余仍是 `RuntimeError`）。`NoKVCoordinationProvider` 只 catch `RuntimeError`，对 live 0.11.0 stack 实测（etcd + S3 兼容对象存储 + `nokv serve` + 同一 commit 构建的 `nokv-python`）：

- `load()` 空 head 直接抛 `FileNotFoundError`（合同要求 `(None, 0)`）
- bootstrap `compare_and_put(0, head)` 在 `stat` 处抛出
- create-only 竞争把 `FileExistsError` 裸抛给 authority（合同要求 typed `conflict|ambiguous`）

**修法（68e7dd64）**：先按异常类判断（`FileNotFoundError` = not found），再按文档化的消息 token 判断，两代 SDK 映射到同一套类型化 provider 动词；publish 抛出的任何异常仍是 `ambiguous`，authority 只信原子存储的 receipt index。删掉那份从未匹配过任何 NoKV 消息的 transient-read token 列表。新增确定性探针 `contract.nokv_adapter_exception_mapping`（fake client 抛 0.11.0 的异常类）：空 head、create-only 竞争（stat 前与 publish 时）、过期 generation（stat 前与 publish 时）、publish 前传输失败、legacy `RuntimeError` 拼写。README 与 RFC 双语镜像里的 Provider API 基线改钉到 NoKV `3d75d96965`（0.11.0 线）。

补丁后在同一 live stack 上手工跑过一次：adapter 四个动词用例 + RFC §10 检查 1–9（双 client、真线程竞争同一 todo、独立 todo 内部 rebase、A/B/A 逐字段重放、identity mismatch、提交后丢响应靠 receipt 恢复、未提交 `provider_outcome_unproved`、持续无关争用 → typed `failed`）全部通过。README 如实写明：这次运行只是映射本身的证据，不属于合并门槛，也不证明 restart/recovery/HA/性能。

## 验证

- `python3 examples/nokv-shadow-provider/probes.py contract` → 9/9，`{"ok":true,"probe":"contract.summary","probes":9}`；每个提交单独可跑（第一个提交 8/8）。
- `tests/test_nokv_shadow_provider_probes.py` 通过；ruff 干净；`git diff --check` 干净。

@huangruiteng
