### PR TITLE
docs(rfc): sync shared-goal RFC with the shipped handoff-mode gate

### DIFF
--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
@@ -2,7 +2,7 @@
 
 - Status: Draft, under maintainer review
 - Proposed by: NoKV Lab
-- Date: 2026-08-05; revised 2026-08-16
+- Date: 2026-08-05; revised 2026-08-18
 - Scope: a separate deployment contract for LoopX shared-goal coordination,
   complementing
   [`host-integration-surface-v0`](../../reference/protocols/host-integration-surface-v0.md)
@@ -317,9 +317,10 @@ or raw evidence. It contains only the facts needed to adjudicate the command
 slice and recover its proof. As in current LoopX, a claimed todo remains `open`,
 without inventing a `claimed` lifecycle status that local mode does not have.
 In the target contract, `claimed_by` carries soft ownership and the lease/fence
-carries execution authority; the current implementation does not honor this
-yet: when the two records diverge, the markdown claimant wins on the write
-path. See Appendix B.
+carries execution authority. The default `legacy` handoff mode does not honor
+this: when the two records diverge, the markdown claimant wins on the write
+path. A goal that declares `hard_lease` turns the divergence into a typed
+error and requires the key at completion. See Appendix B.
 
 Each eligibility revision or digest is scoped to the snapshot referenced by the
 target todo: authorization covers only that todo's actor scope, dependency
@@ -657,9 +658,12 @@ Durable completion continuation read-back
 (`durable_completion.py`: `read_persisted_todo_record` /
 `project_durable_completion_outcome`) is a provider read point: it re-reads
 the persisted lifecycle record (Markdown first, event projection fallback)
-after the completion write and before settlement. Once a remote provider
-becomes canonical, this seam flips to provider-first without changing the
-typed outcome contract below.
+after the completion write and before settlement. The persisted record
+carries an explicit `completion_continuation`; the seam fails closed when a
+done record omits it or when it contradicts the recorded successor or
+no-follow-up fields, so a provider that holds completion state must store
+that field byte for byte. Once a remote provider becomes canonical, this seam
+flips to provider-first without changing the typed outcome contract below.
 
 ### P0: contract and deterministic proof
 
@@ -764,9 +768,15 @@ authority owns it. Three values:
   rejected; release and inspect remain available to clean up and view
   leftover leases.
 - `hard_lease`: changing the claim on an existing todo requires holding its
-  active lease; completion requires the key; the self-disarm-on-conflict
+  active lease; every transition that retires an existing todo as done
+  (`complete` and `supersede`) requires the key; the self-disarm-on-conflict
   behavior becomes a loud error. Assigning a claimant at todo creation stays
-  allowed: a fresh todo cannot have a lease yet.
+  allowed: a fresh todo cannot have a lease yet. One harness-owned case keeps
+  the keyed invariant without making the presenter hold the lease across a
+  human wait: completing a user-role `user_gate` todo without explicit lease
+  credentials lets the completion fence mint the key itself under the same
+  per-goal lease lock, verify it, and release it on commit; an existing
+  time-active lease is never displaced.
 
 Companion rules:
 
@@ -783,6 +793,19 @@ Companion rules:
    the result. No new bypass switches.
 5. Switching modes requires quiescence: refuse while the goal still has open
    claims or active leases, and list what blocks it. No forced switch in v0.
+
+### Status (2026-08-18)
+
+The gate shipped as the `handoff_mode` front-matter field with the
+`legacy | soft_claim | hard_lease` semantics above, the quiescence-only
+`loopx handoff-mode show|set` switch, and the delegated-authority door with
+its `handoff_gate_overridden` marker; the user-gate key minting above landed
+as a follow-up. `legacy` remains the default and keeps the divergence hole by
+design. Two side doors found after the gate landed are closed alongside this
+revision: `supersede` crosses the same lease fence as `complete`, and a forced
+state rebuild (`bootstrap --force`) carries the declared mode instead of
+resetting it to `legacy`. The next stage, a file-backed provider shadow behind
+the coordination contract of Section 11, has not started.
 
 ### Relation to Staged Delivery
 

--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
@@ -2,7 +2,7 @@
 
 - 状态：Draft，正在接受 maintainer review
 - 提案方：NoKV Lab
-- 日期：2026-08-05；修订于 2026-08-16
+- 日期：2026-08-05；修订于 2026-08-18
 - 范围：LoopX 共享 Goal 协调的独立部署合同，用来补充
   [`host-integration-surface-v0`](../../reference/protocols/host-integration-surface-v0.md)
 - 源码基线：LoopX `c6a1da1eaa22962faaeb6d4050d867462e7665ff`
@@ -274,8 +274,9 @@ owner，新 host 或 extension 也可以新增本地 artifact，而无需修改�
 该 schema 不包含 raw todo body、transcript、credential、绝对路径或 raw evidence。
 它只包含裁决这一命令切片与恢复其凭证所需的事实。与现有 LoopX 一致，claim 后
 todo 仍为 `open`，不会引入一个本地状态机不存在的 `claimed` status。在目标合同里，
-soft ownership 由 `claimed_by` 表示，执行权由 lease/fence 表示；当前实现尚未做到
-这一点：两本账分叉时，软认领方在写路径上实际胜出，详见附录 B。
+soft ownership 由 `claimed_by` 表示，执行权由 lease/fence 表示；默认的 `legacy`
+交接模式没有做到这一点：两本账分叉时，软认领方在写路径上实际胜出。声明了
+`hard_lease` 的 goal 会把分叉变成类型化错误，并在完成时要求钥匙，详见附录 B。
 
 这里的 eligibility revision/digest 都是目标 todo 所引用的快照：authorization 只覆盖
 该 todo 的 actor scope，dependency 只覆盖它的传递依赖闭包，gate 只覆盖实际约束
@@ -568,8 +569,10 @@ history、quota、scheduler 或 evidence 的通用存储抽象，这些账继续
 （`durable_completion.py`：`read_persisted_todo_record` /
 `project_durable_completion_outcome`）是一个 provider read point：它在完成写入之后、
 settlement 之前重新读取已落盘的 lifecycle record（Markdown 优先，event projection
-兜底）。一旦远端 provider 成为 canonical，这个 seam 翻转为 provider-first，且不改变
-下述 typed outcome 合同。
+兜底）。落盘记录带有显式的 `completion_continuation`；done 记录缺少该字段、或该字段
+与 successor / no-follow-up 字段矛盾时，seam 都 fail closed，因此持有完成状态的
+provider 必须逐字节保存这个字段。一旦远端 provider 成为 canonical，这个 seam 翻转为
+provider-first，且不改变下述 typed outcome 合同。
 
 ### P0：合同与 deterministic proof
 
@@ -655,9 +658,13 @@ HA 或 production qualification 声明。
   存在；这是有意保留的默认值，不是疏漏。
 - `soft_claim`：该 goal 只用软认领。acquire/renew/transfer 被拒绝；release 与
   inspect 保留，用于清理和查看遗留租约。
-- `hard_lease`：改动已有 todo 的认领关系必须持有它的活租约；完成必须带钥匙；
-  "矛盾态自动失效"改为响亮报错。新建 todo 时顺手指定认领人仍然允许——新 todo
-  不可能已有租约。
+- `hard_lease`：改动已有 todo 的认领关系必须持有它的活租约；所有把已有 todo
+  置为 done 的转移（`complete` 与 `supersede`）都必须带钥匙；"矛盾态自动失效"
+  改为响亮报错。新建 todo 时顺手指定认领人仍然允许——新 todo 不可能已有租约。
+  有一个由 harness 自己持有的例外保住"带钥匙"这个不变量、又不逼 presenter 在
+  人工等待期间一直持约：完成 user 角色的 `user_gate` todo 且没有显式租约凭证时，
+  完成栅栏会在同一把 per-goal 租约锁下自己铸出钥匙、验证、并在提交后释放；
+  已存在的时间有效租约永远不会被顶掉。
 
 配套约定：
 
@@ -670,6 +677,16 @@ HA 或 production qualification 声明。
    绕过开关。
 5. 切换模式要求静止：goal 内仍有未完成的认领或活租约时拒绝切换，并列出
    阻挡者。v0 不提供强制切换。
+
+### 现状（2026-08-18）
+
+门禁已经落地：状态文件前置的 `handoff_mode` 字段与上述 `legacy | soft_claim |
+hard_lease` 语义、只允许静止态切换的 `loopx handoff-mode show|set`、以及带
+`handoff_gate_overridden` 标记的委托授权门；上面的 user gate 自动铸钥匙作为后续
+补充落地。`legacy` 仍是默认值，分叉洞按设计保留。门禁落地后发现的两扇侧门随本次
+修订一并关上：`supersede` 与 `complete` 过同一道租约栅栏；强制重建状态
+（`bootstrap --force`）保留已声明的模式而不是把它重置回 `legacy`。下一阶段，即
+第 11 节协调合同后面的 file-backed provider shadow，尚未开始。
 
 ### 与分阶段交付的关系
 


### PR DESCRIPTION
只改文档，中英镜像同步。RFC 正文还在描述门禁落地前的状态，附录 B 读起来还是一份计划；此后 #3164 落地、#3198 补了 user gate 自动铸钥匙、#3261 让第 11 节登记的 durable-completion seam 强制要求显式 `completion_continuation`，正文都没跟上。

## 改了什么

- 第 4 节：`legacy`（默认）保留"分叉时软认领方在写路径上胜出"；`hard_lease` 把分叉变成类型化错误并在完成时要求钥匙。
- 第 11 节：落盘记录带显式 `completion_continuation`，读 seam 在缺失或矛盾时 fail closed，持有完成状态的 provider 必须逐字节保存这个字段。
- 附录 B：`hard_lease` 对所有把 todo 置为 done 的转移（`complete` 与 `supersede`）要求钥匙；把 #3198 由 harness 持有的 user gate 铸钥匙写成唯一的键控例外（不变量不变，presenter 不必在人工等待期间持约）；新增一段带日期的现状：什么已经落地、随本次修订关掉的两扇侧门、file-backed provider shadow 尚未开始。
- 修订日期 → 2026-08-18。

## 依赖

附录 B 现状段提到的两扇侧门由 #3306 关闭；本 PR 是文档随代码走，建议在 #3306 之后合并。Provider API 基线那两行由 #3307 更新，与本 PR 不重叠。

@huangruiteng
