### PR TITLE
fix(evidence): 修复 Todo 身份过滤与 UTC 时序

### DIFF
--- a/loopx/control_plane/runtime/agent_scoped_evidence_log.py
+++ b/loopx/control_plane/runtime/agent_scoped_evidence_log.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import shlex
 from collections.abc import Iterable, Mapping
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
+from ..todos.contract import normalize_todo_id_list
 from .public_safety import public_safe_compact_text
 from .time import parse_timestamp
 
@@ -13,6 +14,8 @@ SCHEMA_VERSION = "agent_scoped_evidence_log_v0"
 REQUIRED_READ_SCHEMA_VERSION = "loopx_agent_required_read_v0"
 READ_RECEIPT_SCHEMA_VERSION = "evidence_log_read_receipt_v0"
 MAX_PROJECTED_READ_RECEIPTS = 12
+_MIN_TIMESTAMP = datetime.min.replace(tzinfo=timezone.utc)
+
 
 def _compact_text(value: Any, *, limit: int = 220) -> str | None:
     return public_safe_compact_text(value, limit=limit)
@@ -170,19 +173,21 @@ def project_evidence_log_read_receipts(
     ]
     return sorted(
         receipts,
-        key=lambda item: str(item.get("recorded_at") or ""),
+        key=_sort_key,
         reverse=True,
     )[: max(0, int(limit))]
 
 
 def _run_mentions_todo(run: Mapping[str, Any], todo_id: str) -> bool:
+    structured_todo_id = str(run.get("todo_id") or "").strip()
+    if structured_todo_id:
+        return structured_todo_id == todo_id
     needles = (
-        run.get("todo_id"),
         run.get("classification"),
         run.get("recommended_action"),
         run.get("health_check"),
     )
-    return any(todo_id in str(value or "") for value in needles)
+    return any(todo_id in normalize_todo_id_list(value) for value in needles)
 
 
 def _run_matches(
@@ -206,8 +211,23 @@ def _run_matches(
     return True
 
 
-def _sort_key(row: Mapping[str, Any]) -> tuple[str, str]:
-    return (str(row.get("recorded_at") or ""), str(row.get("source") or ""))
+def _chronology_key(value: Any) -> tuple[int, datetime, str]:
+    raw = str(value or "")
+    try:
+        parsed = parse_timestamp(value)
+    except OverflowError:
+        # UTC conversion can overflow at datetime's representable boundaries.
+        parsed = None
+    if parsed is None:
+        # Keep malformed legacy rows deterministic, but never let them outrank
+        # a row with a valid timestamp.
+        return (0, _MIN_TIMESTAMP, raw)
+    return (1, parsed, raw)
+
+
+def _sort_key(row: Mapping[str, Any]) -> tuple[int, datetime, str, str]:
+    rank, recorded_at, raw = _chronology_key(row.get("recorded_at"))
+    return (rank, recorded_at, raw, str(row.get("source") or ""))
 
 
 def goal_history_runs(
@@ -327,7 +347,10 @@ def _other_agent_frontier(
         if not other_agent or other_agent == agent_id:
             continue
         current = latest_by_agent.get(other_agent)
-        if current is None or str(run.get("generated_at") or "") > str(current.get("recorded_at") or ""):
+        is_newer = current is None or _chronology_key(
+            run.get("generated_at")
+        ) > _chronology_key(current.get("recorded_at"))
+        if is_newer:
             row = _safe_run_history_row(run)
             row["agent_id"] = other_agent
             latest_by_agent[other_agent] = row

--- a/tests/control_plane/test_agent_scoped_evidence_log.py
+++ b/tests/control_plane/test_agent_scoped_evidence_log.py
@@ -6,6 +6,7 @@ import pytest
 
 from loopx.control_plane.runtime.agent_scoped_evidence_log import (
     build_agent_scoped_evidence_log,
+    project_evidence_log_read_receipts,
 )
 
 
@@ -64,4 +65,132 @@ def test_evidence_log_keeps_safe_compact_prose() -> None:
 
     assert payload["ledger"][0]["summary"] == (
         "authorization token label is safe as prose"
+    )
+
+
+def test_history_todo_filter_avoids_prefix_collisions() -> None:
+    payload = build_agent_scoped_evidence_log(
+        goal_id="public-goal",
+        agent_id="codex-agent",
+        rollout_events=[],
+        history_runs=[
+            {
+                "goal_id": "public-goal",
+                "agent_id": "codex-agent",
+                "generated_at": "2026-08-18T00:00:00Z",
+                "todo_id": "todo_abcd",
+                "classification": "todo_abc follow-up after todo_abcd",
+            },
+            {
+                "goal_id": "public-goal",
+                "agent_id": "codex-agent",
+                "generated_at": "2026-08-18T01:00:00Z",
+                "classification": "todo_abc completed",
+            },
+            {
+                "goal_id": "public-goal",
+                "agent_id": "codex-agent",
+                "generated_at": "2026-08-18T02:00:00Z",
+                "todo_id": "todo_abc",
+                "classification": "todo_abc completed",
+            },
+        ],
+        todo_id="todo_abc",
+    )
+
+    assert payload["run_history_ref_count"] == 2
+    assert [row["classification"] for row in payload["ledger"]] == [
+        "todo_abc completed",
+        "todo_abc completed",
+    ]
+
+
+def test_chronology_normalizes_offsets_for_receipts_ledger_and_frontier() -> None:
+    receipt_events = [
+        {
+            "event_kind": "evidence_log_read",
+            "status": "completed",
+            "goal_id": "public-goal",
+            "agent_id": "codex-agent",
+            "event_id": "read-early",
+            "recorded_at": "2026-08-18T10:00:00+08:00",
+            "details": {"command": "loopx evidence-log"},
+        },
+        {
+            "event_kind": "evidence_log_read",
+            "status": "completed",
+            "goal_id": "public-goal",
+            "agent_id": "codex-agent",
+            "event_id": "read-late",
+            "recorded_at": "2026-08-18T03:00:00Z",
+            "details": {"command": "loopx evidence-log"},
+        },
+        {
+            "event_kind": "evidence_log_read",
+            "status": "completed",
+            "goal_id": "public-goal",
+            "agent_id": "codex-agent",
+            "event_id": "read-overflow",
+            "recorded_at": "9999-12-31T23:59:59-23:59",
+            "details": {"command": "loopx evidence-log"},
+        },
+    ]
+    receipts = project_evidence_log_read_receipts(receipt_events)
+    assert [row["event_id"] for row in receipts] == [
+        "read-late",
+        "read-early",
+        "read-overflow",
+    ]
+
+    payload = build_agent_scoped_evidence_log(
+        goal_id="public-goal",
+        agent_id="codex-agent",
+        rollout_events=[],
+        history_runs=[
+            {
+                "goal_id": "public-goal",
+                "agent_id": "codex-agent",
+                "generated_at": "2026-08-18T10:00:00+08:00",
+                "classification": "current-early",
+            },
+            {
+                "goal_id": "public-goal",
+                "agent_id": "codex-agent",
+                "generated_at": "2026-08-18T03:00:00Z",
+                "classification": "current-late",
+            },
+            {
+                "goal_id": "public-goal",
+                "agent_id": "other-agent",
+                "generated_at": "2026-08-18T10:00:00+08:00",
+                "classification": "other-early",
+            },
+            {
+                "goal_id": "public-goal",
+                "agent_id": "other-agent",
+                "generated_at": "2026-08-18T03:00:00Z",
+                "classification": "other-late",
+            },
+            {
+                "goal_id": "public-goal",
+                "agent_id": "other-agent",
+                "generated_at": "not-a-timestamp",
+                "classification": "other-malformed",
+            },
+            {
+                "goal_id": "public-goal",
+                "agent_id": "codex-agent",
+                "generated_at": "not-a-timestamp",
+                "classification": "current-malformed",
+            },
+        ],
+    )
+
+    assert [row["classification"] for row in payload["ledger"]] == [
+        "current-late",
+        "current-early",
+        "current-malformed",
+    ]
+    assert payload["other_agent_frontier"]["items"][0]["classification"] == (
+        "other-late"
     )


### PR DESCRIPTION
## 问题

Agent-scoped evidence log 目前有两个会影响 replan / handoff 证据边界的问题：

- compact run 的 Todo 过滤使用 substring，查询 `todo_abc` 会误命中 `todo_abcd`；
- read receipts、合并 ledger 和 other-agent frontier 按原始 ISO-8601 字符串比较，不同 timezone offset 下可能选错“最新”记录。

## 修复

- 结构化 `todo_id` 存在时只接受精确身份；仅在旧 run 缺少结构化字段时，复用现有 Todo 规范化解析器读取有限 prose 字段。
- 统一复用 `parse_timestamp` 将合法时间换算为 UTC 后比较。
- 合法时间始终优先于缺失、畸形或 UTC 换算溢出的旧时间；非法值仍以原始字符串保持确定性排序。
- 同一 chronology key 覆盖 read receipts、当前 agent ledger 和 other-agent frontier。

## 边界

- 不改变 wire schema、provider、sink、quota、外部写入或隐私边界。
- 未新增协议文档：现有 `agent-scoped-evidence-ledger-v0` 已规定事件精确 Todo 过滤、run 的 bounded mention 和 newest-first chronology，本 PR 使实现与既有契约一致。

## 验证

- 相关 pytest：`93 passed`，`0 failed`，`0 skipped`。
- Ruff：`tests loopx/canary loopx/control_plane loopx/domain_packs loopx/presentation` 全部通过。
- 聚焦 smoke：
  - `agent-scoped-evidence-log-smoke.py`
  - `agent-management-live-status-smoke.py`
  - `todo-contract-smoke.py`
- `loopx canary premerge --from-git-diff`：
  - 7/7 catalog canaries 通过；
  - 8/8 risk-profile smokes 通过；
  - `0 failures`、`0 warnings`、`0 manual holds`。
- committed diff check 与 changed Python compile 均通过。

这些检查直接覆盖本 PR 修改的 identity filtering、三处 chronology projection，以及相邻 replan / progress / goal-vision / CLI output-budget 合同，同时保留端到端 CLI 和状态投影验证。

Closes #3310
