### PR TITLE
feat(todo): add explicit per-section --limit to todo list

### DIFF
--- a/loopx/canary/module_metric_baseline.json
+++ b/loopx/canary/module_metric_baseline.json
@@ -103,7 +103,7 @@
     "loopx/todos.py": {
       "any_count": 48,
       "dict_any_count": 0,
-      "lines": 2276
+      "lines": 2285
     },
     "loopx/worker_bridge.py": {
       "any_count": 28,

--- a/loopx/canary/module_metric_baseline.json
+++ b/loopx/canary/module_metric_baseline.json
@@ -103,7 +103,7 @@
     "loopx/todos.py": {
       "any_count": 48,
       "dict_any_count": 0,
-      "lines": 2269
+      "lines": 2276
     },
     "loopx/worker_bridge.py": {
       "any_count": 28,

--- a/loopx/canary/module_metric_baseline.json
+++ b/loopx/canary/module_metric_baseline.json
@@ -103,7 +103,7 @@
     "loopx/todos.py": {
       "any_count": 48,
       "dict_any_count": 0,
-      "lines": 2249
+      "lines": 2269
     },
     "loopx/worker_bridge.py": {
       "any_count": 28,

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -545,9 +545,15 @@ def register_todo_command(
     )
     todo_parser.add_argument(
         "--limit",
-        dest="suggestion_limit",
+        dest="todo_limit",
         type=int,
-        help="For todo suggest, maximum candidate count. Values above 5 are clamped to 5.",
+        help=(
+            "For todo suggest, maximum candidate count; values above 5 are "
+            "clamped to 5. For todo list, explicit per-section cold-path cap: "
+            "keep the top N todos of each role section after filtering; must "
+            "be an integer >= 1, and the payload discloses the truncation via "
+            "explicit_limit."
+        ),
     )
     todo_parser.add_argument(
         "--trigger",
@@ -600,6 +606,7 @@ def handle_todo_command(
                 status=args.status,
                 todo_id=args.todo_id,
                 agent_id=args.agent_id,
+                limit=args.todo_limit,
                 **_todo_path_args(args),
                 runtime_root_arg=runtime_root_arg,
             )
@@ -848,7 +855,7 @@ def handle_todo_command(
                 project=Path(args.project).expanduser() if args.project else None,
                 agent_id=args.agent_id,
                 sources=args.suggestion_sources,
-                limit=args.suggestion_limit,
+                limit=args.todo_limit,
                 trigger=args.suggestion_trigger,
             )
             payload["dry_run"] = True

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -71,7 +71,7 @@ TODO_OPTION_FIELDS = (
     ("--self-merged", "self_merged"),
     ("--agent-id", "agent_id"),
     ("--from", "suggestion_sources"),
-    ("--limit", "suggestion_limit"),
+    ("--limit", "todo_limit"),
     ("--trigger", "suggestion_trigger"),
     ("--state-file", "state_file"),
     ("--execute", "execute"),
@@ -275,9 +275,10 @@ def _validate_todo_option_subset(args: argparse.Namespace, allowed_fields: Itera
 def validate_todo_list_options(args: argparse.Namespace) -> None:
     _validate_todo_option_subset(
         args,
-        {"role", "todo_id", "status", "agent_id", "state_file"},
+        {"role", "todo_id", "status", "agent_id", "todo_limit", "state_file"},
         "todo list only accepts --goal-id, optional --role, --status, --todo-id, "
-        "--agent-id, --project, --state-file, --dry-run, and --format; unsupported: ",
+        "--agent-id, --limit, --project, --state-file, --dry-run, and --format; "
+        "unsupported: ",
     )
 
 
@@ -408,7 +409,7 @@ def validate_todo_archive_completed_options(args: argparse.Namespace) -> None:
 def validate_todo_suggest_options(args: argparse.Namespace) -> None:
     _validate_todo_option_subset(
         args,
-        {"agent_id", "suggestion_sources", "suggestion_limit", "suggestion_trigger"},
+        {"agent_id", "suggestion_sources", "todo_limit", "suggestion_trigger"},
         "todo suggest only accepts --goal-id, optional --project, --agent-id, "
         "--from, --limit, --trigger, --dry-run, and --format; unsupported: ",
     )
@@ -520,14 +521,15 @@ def validate_shared_todo_options(args: argparse.Namespace) -> None:
         )
     if (
         args.todo_command not in {"suggest", "capture-followups"}
-        and (
-            args.suggestion_sources
-            or args.suggestion_limit is not None
-            or args.suggestion_trigger
-        )
+        and (args.suggestion_sources or args.suggestion_trigger)
+    ):
+        raise ValueError("--from and --trigger are supported only by todo suggest")
+    if (
+        args.todo_command not in {"suggest", "list", "capture-followups"}
+        and args.todo_limit is not None
     ):
         raise ValueError(
-            "--from, --limit, and --trigger are supported only by todo suggest"
+            "--limit is supported only by todo suggest and todo list"
         )
 
 

--- a/loopx/control_plane/testing/cli_output_budget.py
+++ b/loopx/control_plane/testing/cli_output_budget.py
@@ -272,7 +272,10 @@ CLI_OUTPUT_BUDGET_SPECS: tuple[CliOutputBudgetSpec, ...] = (
         owner="todo control plane",
         consumer_action="select and inspect current work items",
         qualification_policy="baseline_and_growth",
-        cold_path="role/status filters and direct todo-id lifecycle commands",
+        cold_path=(
+            "role/status filters, full per-role sections without --limit, and "
+            "direct todo-id lifecycle commands"
+        ),
         semantic_json_keys=("todos", "agent_todos", "filter_semantics"),
         markdown_anchor="# LoopX Todo List",
         max_chars={
@@ -517,6 +520,21 @@ CLI_OUTPUT_MODE_VARIANT_SPECS: tuple[CliOutputModeVariantSpec, ...] = (
         markdown_anchor="# Heartbeat Automation Prompt",
         max_chars={"json": 19_000, "markdown": 18_000},
         max_lines={"json": 58, "markdown": 280},
+    ),
+    CliOutputModeVariantSpec(
+        variant_id="todo_list_limited",
+        parent_surface_id="todo_list",
+        command="todo list --limit 3",
+        output_formats=("json", "markdown"),
+        semantic_json_keys=(
+            "todos",
+            "agent_todos",
+            "explicit_limit",
+            "todo_list_projection",
+        ),
+        markdown_anchor="# LoopX Todo List",
+        max_chars={"json": 40_000, "markdown": 1_200},
+        max_lines={"json": 1_100, "markdown": 24},
     ),
 )
 

--- a/loopx/control_plane/todos/list_projection.py
+++ b/loopx/control_plane/todos/list_projection.py
@@ -193,17 +193,20 @@ def todo_list_projection_contract(
     *,
     matched_todo_count: int,
     returned_todo_count: int,
+    view: str = "agent_lane_hot_path",
+    item_limit_per_role: int = AGENT_LANE_TODO_LIST_ITEM_LIMIT,
+    full_detail_cold_paths: tuple[str, ...] = (
+        "todo list with --role, --status, or --todo-id",
+        "todo list without --agent-id",
+        "active state",
+    ),
 ) -> dict[str, Any]:
     return {
         "schema_version": AGENT_LANE_TODO_LIST_PROJECTION_SCHEMA_VERSION,
-        "view": "agent_lane_hot_path",
+        "view": view,
         "matched_todo_count": matched_todo_count,
         "returned_todo_count": returned_todo_count,
-        "item_limit_per_role": AGENT_LANE_TODO_LIST_ITEM_LIMIT,
+        "item_limit_per_role": item_limit_per_role,
         "counts_cover_full_match": True,
-        "full_detail_cold_paths": [
-            "todo list with --role, --status, or --todo-id",
-            "todo list without --agent-id",
-            "active state",
-        ],
+        "full_detail_cold_paths": list(full_detail_cold_paths),
     }

--- a/loopx/control_plane/todos/list_projection.py
+++ b/loopx/control_plane/todos/list_projection.py
@@ -226,7 +226,19 @@ def compact_explicit_limit_todo_summary(
     return compact
 
 
-def compact_todo_projection_overlay(value: Any) -> Any:
+AGENT_LANE_OVERLAY_FULL_DETAIL_COLD_PATH = (
+    "todo list without --agent-id or active state"
+)
+EXPLICIT_LIMIT_OVERLAY_FULL_DETAIL_COLD_PATH = (
+    "todo list without --limit or active state"
+)
+
+
+def compact_todo_projection_overlay(
+    value: Any,
+    *,
+    full_detail_cold_path: str = AGENT_LANE_OVERLAY_FULL_DETAIL_COLD_PATH,
+) -> Any:
     if not isinstance(value, dict):
         return value
     compact = {
@@ -235,7 +247,7 @@ def compact_todo_projection_overlay(value: Any) -> Any:
     for key, child in value.items():
         if isinstance(child, list):
             compact[f"{key.removesuffix('_todo_ids')}_count"] = len(child)
-    compact["full_detail_cold_path"] = "todo list without --agent-id or active state"
+    compact["full_detail_cold_path"] = full_detail_cold_path
     return compact
 
 

--- a/loopx/control_plane/todos/list_projection.py
+++ b/loopx/control_plane/todos/list_projection.py
@@ -1,13 +1,24 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 AGENT_LANE_TODO_LIST_PROJECTION_SCHEMA_VERSION = "agent_lane_todo_list_projection_v0"
 AGENT_LANE_TODO_LIST_SUMMARY_SCHEMA_VERSION = (
     "agent_lane_todo_list_summary_compaction_v0"
 )
+EXPLICIT_LIMIT_TODO_LIST_SUMMARY_SCHEMA_VERSION = (
+    "explicit_limit_todo_list_summary_compaction_v0"
+)
 AGENT_LANE_TODO_LIST_ITEM_LIMIT = 12
 AGENT_LANE_TODO_LIST_TEXT_LIMIT = 180
+AGENT_LANE_HOT_PATH_VIEW: Literal["agent_lane_hot_path"] = "agent_lane_hot_path"
+EXPLICIT_LIMIT_COLD_PATH_VIEW: Literal["explicit_limit_cold_path"] = (
+    "explicit_limit_cold_path"
+)
+TodoListProjectionView = Literal[
+    "agent_lane_hot_path",
+    "explicit_limit_cold_path",
+]
 
 _RETAINED_LANE_LIMITS = {
     "items": AGENT_LANE_TODO_LIST_ITEM_LIMIT,
@@ -176,6 +187,45 @@ def compact_agent_lane_todo_summary(
     return compact
 
 
+def compact_explicit_limit_todo_summary(
+    summary: dict[str, Any],
+    *,
+    role: str,
+    item_limit: int,
+) -> dict[str, Any]:
+    """Bound every item-bearing lane for the explicit-limit cold path."""
+    compact: dict[str, Any] = {}
+    compacted_lanes: dict[str, dict[str, int]] = {}
+    omitted_nonempty_dict_count = 0
+    for key, value in summary.items():
+        if isinstance(value, list):
+            compact[key] = [_compact_item(item) for item in value[:item_limit]]
+            if len(value) > item_limit:
+                compacted_lanes[key] = {
+                    "shown": item_limit,
+                    "total": len(value),
+                }
+            continue
+        if isinstance(value, dict):
+            if key in _RETAINED_DICTS:
+                compact[key] = value
+            else:
+                omitted_nonempty_dict_count += bool(value)
+            continue
+        compact[key] = value
+    compact["payload_compaction"] = {
+        "schema_version": EXPLICIT_LIMIT_TODO_LIST_SUMMARY_SCHEMA_VERSION,
+        "view": EXPLICIT_LIMIT_COLD_PATH_VIEW,
+        "role": role,
+        "item_limit": item_limit,
+        "item_text_limit": AGENT_LANE_TODO_LIST_TEXT_LIMIT,
+        "compacted_lanes": compacted_lanes,
+        "omitted_nonempty_dict_count": omitted_nonempty_dict_count,
+        "full_detail_cold_path": "todo list without --limit or active state",
+    }
+    return compact
+
+
 def compact_todo_projection_overlay(value: Any) -> Any:
     if not isinstance(value, dict):
         return value
@@ -193,7 +243,7 @@ def todo_list_projection_contract(
     *,
     matched_todo_count: int,
     returned_todo_count: int,
-    view: str = "agent_lane_hot_path",
+    view: TodoListProjectionView = AGENT_LANE_HOT_PATH_VIEW,
     item_limit_per_role: int = AGENT_LANE_TODO_LIST_ITEM_LIMIT,
     full_detail_cold_paths: tuple[str, ...] = (
         "todo list with --role, --status, or --todo-id",

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -229,6 +229,7 @@ def filtered_todo_summary(
     agent_id: str | None = None,
     resume_source_items: list[dict[str, Any]] | None = None,
     rollout_events: list[dict[str, Any]] | None = None,
+    item_limit: int | None = None,
 ) -> dict[str, Any]:
     items = list((summary or {}).get("items") or [])
     normalized_status = normalize_todo_status(status)
@@ -269,7 +270,7 @@ def filtered_todo_summary(
             role=role,
             resume_source_items=resume_source_items,
             rollout_events=rollout_events,
-            item_limit=None,
+            item_limit=item_limit,
         )
         or empty_todo_summary(role=role)
     )
@@ -393,6 +394,7 @@ def list_goal_todos(
     project: Path | None = None,
     state_file: Path | None = None,
     runtime_root_arg: str | None = None,
+    limit: int | None = None,
 ) -> dict[str, Any]:
     normalized_todo_id = normalize_todo_id(todo_id) if todo_id else None
     if todo_id and not normalized_todo_id:
@@ -400,6 +402,8 @@ def list_goal_todos(
     normalized_agent_id = normalize_todo_claimed_by(agent_id) if agent_id else None
     if agent_id and not normalized_agent_id:
         raise ValueError("agent_id must be a public-safe agent token such as codex-main-control")
+    if limit is not None and limit < 1:
+        raise ValueError("todo list --limit must be at least 1")
     registry = load_registry(registry_path)
     goal, resolved_project, resolved_state_file = resolve_goal_state(
         registry=registry,
@@ -459,6 +463,7 @@ def list_goal_todos(
     summaries: dict[str, dict[str, Any]] = {}
     todos: list[dict[str, Any]] = []
     unfiltered_count = 0
+    uncapped_todo_count = 0
     for item_role in roles:
         key = f"{item_role}_todos"
         raw_summary = fields.get(key) if isinstance(fields, dict) else None
@@ -471,9 +476,11 @@ def list_goal_todos(
             agent_id=normalized_agent_id,
             resume_source_items=resume_source_items,
             rollout_events=rollout_events,
+            item_limit=limit,
         )
         summaries[key] = summary
         todos.extend(summary.get("items") or [])
+        uncapped_todo_count += int(summary.get("total_count") or 0)
 
     matched_todo_count = len(todos)
     agent_lane_hot_path = bool(
@@ -525,6 +532,20 @@ def list_goal_todos(
         payload["todo_list_projection"] = todo_list_projection_contract(
             matched_todo_count=matched_todo_count,
             returned_todo_count=len(todos),
+        )
+    if limit is not None:
+        payload["explicit_limit"] = limit
+        payload["unfiltered_todo_count"] = unfiltered_count
+        payload["returned_todo_count"] = len(todos)
+        payload["todo_list_projection"] = todo_list_projection_contract(
+            matched_todo_count=uncapped_todo_count,
+            returned_todo_count=len(todos),
+            view="explicit_limit_cold_path",
+            item_limit_per_role=limit,
+            full_detail_cold_paths=(
+                "todo list without --limit",
+                "active state",
+            ),
         )
     if normalized_todo_id:
         payload["todo_id_filter"] = normalized_todo_id

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -89,6 +89,8 @@ from .control_plane.todos.line_update import (
     upsert_todo_metadata,
 )
 from .control_plane.todos.list_projection import (
+    AGENT_LANE_OVERLAY_FULL_DETAIL_COLD_PATH,
+    EXPLICIT_LIMIT_OVERLAY_FULL_DETAIL_COLD_PATH,
     compact_agent_lane_todo_summary,
     compact_explicit_limit_todo_summary,
     compact_todo_projection_overlay,
@@ -570,8 +572,15 @@ def list_goal_todos(
         if projection_fields.get("state_event_projection"):
             payload["state_event_projection"] = projection_fields["state_event_projection"]
         payload["projection_overlay"] = (
-            compact_todo_projection_overlay(projection_overlay)
-            if agent_lane_hot_path
+            compact_todo_projection_overlay(
+                projection_overlay,
+                full_detail_cold_path=(
+                    EXPLICIT_LIMIT_OVERLAY_FULL_DETAIL_COLD_PATH
+                    if limit is not None
+                    else AGENT_LANE_OVERLAY_FULL_DETAIL_COLD_PATH
+                ),
+            )
+            if agent_lane_hot_path or limit is not None
             else projection_overlay
         )
     if projection_fields.get("state_event_projection_warning"):

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -484,7 +484,7 @@ def list_goal_todos(
 
     matched_todo_count = len(todos)
     agent_lane_hot_path = bool(
-        normalized_agent_id
+        normalized_agent_id and limit is None
         and role is None
         and status is None
         and normalized_todo_id is None

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -90,6 +90,7 @@ from .control_plane.todos.line_update import (
 )
 from .control_plane.todos.list_projection import (
     compact_agent_lane_todo_summary,
+    compact_explicit_limit_todo_summary,
     compact_todo_projection_overlay,
     todo_item_relations,
     todo_list_projection_contract,
@@ -478,6 +479,12 @@ def list_goal_todos(
             rollout_events=rollout_events,
             item_limit=limit,
         )
+        if limit is not None:
+            summary = compact_explicit_limit_todo_summary(
+                summary,
+                role=item_role,
+                item_limit=limit,
+            )
         summaries[key] = summary
         todos.extend(summary.get("items") or [])
         uncapped_todo_count += int(summary.get("total_count") or 0)

--- a/tests/control_plane/test_cli_output_budget.py
+++ b/tests/control_plane/test_cli_output_budget.py
@@ -680,6 +680,8 @@ def _mode_variant_commands(
         "heartbeat_prompt_brief": common + ["heartbeat-prompt", "--brief", *heartbeat],
         "heartbeat_prompt_compact": common + ["heartbeat-prompt", "--compact", *heartbeat],
         "heartbeat_prompt_full": common + ["heartbeat-prompt", "--full", *heartbeat],
+        "todo_list_limited": common
+        + ["todo", "list", "--goal-id", GOAL_ID, "--limit", "3"],
     }
 
 
@@ -737,6 +739,7 @@ def test_manifest_covers_the_declared_agent_facing_surface_set() -> None:
         "heartbeat_prompt_brief",
         "heartbeat_prompt_compact",
         "heartbeat_prompt_full",
+        "todo_list_limited",
     }
     assert set(CLI_OUTPUT_MODE_VARIANT_BY_ID) == expected_variants
     assert manifest["mode_variant_count"] == len(expected_variants)
@@ -1350,6 +1353,86 @@ def test_explicit_compact_and_detail_modes_are_characterized(tmp_path: Path) -> 
                 text=text,
                 measurement=measurement,
             )
+
+
+def test_todo_list_explicit_limit_stays_bounded_and_default_path_unchanged(
+    tmp_path: Path,
+) -> None:
+    with _stable_budget_fixture_root(tmp_path / "todo-list-limit") as stable_root:
+        project, runtime, registry_path, state_file = _write_fixture(
+            stable_root,
+            SCENARIOS[1],
+        )
+        limited_command = _mode_variant_commands(
+            project=project,
+            runtime=runtime,
+            registry_path=registry_path,
+            state_file=state_file,
+            output_format="json",
+        )["todo_list_limited"]
+        cold_default_command = [
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime),
+            "--format",
+            "json",
+            "todo",
+            "list",
+            "--goal-id",
+            GOAL_ID,
+        ]
+        default_command = _surface_commands(
+            project=project,
+            runtime=runtime,
+            registry_path=registry_path,
+            state_file=state_file,
+            output_format="json",
+        )["todo_list"]
+
+        limited_exit_code, limited_text = _invoke_cli(limited_command)
+        cold_default_exit_code, cold_default_text = _invoke_cli(cold_default_command)
+        default_exit_code, default_text = _invoke_cli(default_command)
+
+    assert limited_exit_code == 0, limited_text
+    assert cold_default_exit_code == 0, cold_default_text
+    assert default_exit_code == 0, default_text
+    spec = CLI_OUTPUT_MODE_VARIANT_BY_ID["todo_list_limited"]
+    measurement = measure_cli_output(limited_text, output_format="json")
+    assert_cli_output_mode_variant(
+        spec,
+        output_format="json",
+        text=limited_text,
+        measurement=measurement,
+    )
+    limited_payload = json.loads(limited_text)
+    assert limited_payload["explicit_limit"] == 3
+    assert limited_payload["todo_list_projection"]["view"] == (
+        "explicit_limit_cold_path"
+    )
+    assert limited_payload["todo_list_projection"]["matched_todo_count"] == 36
+    assert limited_payload["returned_todo_count"] == 3
+    assert len(limited_payload["agent_todos"]["items"]) == 3
+    assert limited_payload["agent_todos"]["total_count"] == 36
+    assert int(measurement["chars"]) < len(cold_default_text)
+
+    cold_default_payload = json.loads(cold_default_text)
+    assert cold_default_payload["todo_count"] == 36
+    assert len(cold_default_payload["todos"]) == 36
+    for absent_key in ("explicit_limit", "returned_todo_count", "todo_list_projection"):
+        assert absent_key not in cold_default_payload
+
+    default_payload = json.loads(default_text)
+    assert "explicit_limit" not in default_payload
+    assert "returned_todo_count" in default_payload
+    assert default_payload["todo_list_projection"]["view"] == "agent_lane_hot_path"
+    assert_cli_output_baseline(
+        CLI_OUTPUT_BUDGET_BY_ID["todo_list"],
+        scenario="crowded",
+        output_format="json",
+        text=default_text,
+        measurement=measure_cli_output(default_text, output_format="json"),
+    )
 
 
 def test_turn_envelope_cli_preserves_codex_app_scheduler_binding(

--- a/tests/control_plane/test_cli_output_budget.py
+++ b/tests/control_plane/test_cli_output_budget.py
@@ -23,6 +23,11 @@ from loopx.control_plane.testing.cli_output_budget import (
     measure_cli_output,
     public_manifest,
 )
+from loopx.event_sourced_state import (
+    AppendOnlyStateEventStore,
+    TODO_ADDED,
+    make_state_event,
+)
 from loopx.heartbeat_prompt import build_heartbeat_prompt
 from loopx.help_surface import COMMAND_GROUPS
 from loopx.rollout_event_log import rollout_event_log_path
@@ -301,6 +306,50 @@ def _write_todo_list_limit_stress_fixture(state_file: Path) -> None:
             ]
         )
     state_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_todo_list_limit_overlay_stress_fixture(state_file: Path) -> None:
+    lines = [
+        "---",
+        "status: active",
+        "updated_at: 2026-01-01T00:00:00+00:00",
+        "---",
+        "",
+        "# Todo List Limit Overlay Stress Fixture",
+        "",
+        "## Agent Todo",
+        "",
+    ]
+    for index in range(3_000):
+        lines.extend(
+            [
+                f"- [ ] Observe overlay lineage {index:04d}.",
+                (
+                    "  <!-- loopx:todo "
+                    f"todo_id=todo_overlay_{index:04d} status=open "
+                    "task_class=continuous_monitor "
+                    f"action_kind=observe_{index % 4} claimed_by=codex-alpha -->"
+                ),
+            ]
+        )
+    state_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    store = AppendOnlyStateEventStore(state_file.with_name("events.jsonl"))
+    store.append(
+        make_state_event(
+            event_id="evt-limit-overlay",
+            goal_id=GOAL_ID,
+            event_type=TODO_ADDED,
+            refs={"todo_id": "todo_overlay_0000"},
+            payload={
+                "role": "agent",
+                "title": "Overlay the first advancement step.",
+                "task_class": "continuous_monitor",
+                "claimed_by": AGENT_IDS[0],
+            },
+            recorded_at="2026-01-01T00:00:00Z",
+            producer="todo-list-limit-overlay-budget",
+        )
+    )
 
 
 def _invoke_cli(args: list[str]) -> tuple[int, str]:
@@ -1518,6 +1567,46 @@ def test_todo_list_explicit_limit_bounds_monitor_and_blocker_lanes(
         "shown": 3,
         "total": 100,
     }
+
+
+def test_todo_list_explicit_limit_bounds_projection_overlay_ids(
+    tmp_path: Path,
+) -> None:
+    with _stable_budget_fixture_root(
+        tmp_path / "todo-list-limit-overlay",
+    ) as stable_root:
+        project, runtime, registry_path, state_file = _write_fixture(
+            stable_root,
+            SCENARIOS[1],
+        )
+        _write_todo_list_limit_overlay_stress_fixture(state_file)
+        command = _mode_variant_commands(
+            project=project,
+            runtime=runtime,
+            registry_path=registry_path,
+            state_file=state_file,
+            output_format="json",
+        )["todo_list_limited"]
+        exit_code, text = _invoke_cli(command)
+
+    assert exit_code == 0, text
+    spec = CLI_OUTPUT_MODE_VARIANT_BY_ID["todo_list_limited"]
+    measurement = measure_cli_output(text, output_format="json")
+    assert_cli_output_mode_variant(
+        spec,
+        output_format="json",
+        text=text,
+        measurement=measurement,
+    )
+    payload = json.loads(text)
+    overlay = payload["projection_overlay"]
+    assert overlay["markdown_only_count"] == 2_999
+    assert overlay["event_only_count"] == 0
+    assert overlay["overlaid_count"] == 1
+    assert overlay["full_detail_cold_path"] == (
+        "todo list without --limit or active state"
+    )
+    assert [key for key in overlay if key.endswith("_todo_ids")] == []
 
 
 def test_turn_envelope_cli_preserves_codex_app_scheduler_binding(

--- a/tests/control_plane/test_cli_output_budget.py
+++ b/tests/control_plane/test_cli_output_budget.py
@@ -264,6 +264,45 @@ def _write_user_todo_fixture(state_file: Path) -> None:
     )
 
 
+def _write_todo_list_limit_stress_fixture(state_file: Path) -> None:
+    lines = [
+        "---",
+        "status: active",
+        "updated_at: 2026-01-01T00:00:00+00:00",
+        "---",
+        "",
+        "# Todo List Limit Stress Fixture",
+        "",
+        "## Agent Todo",
+        "",
+    ]
+    for index in range(100):
+        lines.extend(
+            [
+                f"- [ ] Observe bounded public monitor {index:03d}.",
+                (
+                    "  <!-- loopx:todo "
+                    f"todo_id=todo_monitor_{index:03d} status=open "
+                    "task_class=continuous_monitor "
+                    f"action_kind=observe_{index % 4} claimed_by=codex-alpha -->"
+                ),
+            ]
+        )
+    for index in range(100):
+        lines.extend(
+            [
+                f"- [ ] Resolve bounded public blocker {index:03d}.",
+                (
+                    "  <!-- loopx:todo "
+                    f"todo_id=todo_blocker_{index:03d} status=blocked "
+                    "task_class=blocker "
+                    f"action_kind=resolve_{index % 4} claimed_by=codex-alpha -->"
+                ),
+            ]
+        )
+    state_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
 def _invoke_cli(args: list[str]) -> tuple[int, str]:
     output = io.StringIO()
     ambient_thread_id = os.environ.pop("CODEX_THREAD_ID", None)
@@ -1433,6 +1472,52 @@ def test_todo_list_explicit_limit_stays_bounded_and_default_path_unchanged(
         text=default_text,
         measurement=measure_cli_output(default_text, output_format="json"),
     )
+
+
+def test_todo_list_explicit_limit_bounds_monitor_and_blocker_lanes(
+    tmp_path: Path,
+) -> None:
+    with _stable_budget_fixture_root(tmp_path / "todo-list-limit-lanes") as stable_root:
+        project, runtime, registry_path, state_file = _write_fixture(
+            stable_root,
+            SCENARIOS[1],
+        )
+        _write_todo_list_limit_stress_fixture(state_file)
+        command = _mode_variant_commands(
+            project=project,
+            runtime=runtime,
+            registry_path=registry_path,
+            state_file=state_file,
+            output_format="json",
+        )["todo_list_limited"]
+        exit_code, text = _invoke_cli(command)
+
+    assert exit_code == 0, text
+    spec = CLI_OUTPUT_MODE_VARIANT_BY_ID["todo_list_limited"]
+    measurement = measure_cli_output(text, output_format="json")
+    assert_cli_output_mode_variant(
+        spec,
+        output_format="json",
+        text=text,
+        measurement=measurement,
+    )
+    payload = json.loads(text)
+    summary = payload["agent_todos"]
+    assert summary["total_count"] == 200
+    assert len(summary["items"]) == 3
+    assert len(summary["monitor_open_items"]) == 3
+    assert len(summary["blocker_items"]) == 3
+    compaction = summary["payload_compaction"]
+    assert compaction["view"] == "explicit_limit_cold_path"
+    assert compaction["item_limit"] == 3
+    assert compaction["compacted_lanes"]["monitor_open_items"] == {
+        "shown": 3,
+        "total": 100,
+    }
+    assert compaction["compacted_lanes"]["blocker_items"] == {
+        "shown": 3,
+        "total": 100,
+    }
 
 
 def test_turn_envelope_cli_preserves_codex_app_scheduler_binding(

--- a/tests/control_plane/test_todo_list_explicit_limit.py
+++ b/tests/control_plane/test_todo_list_explicit_limit.py
@@ -6,6 +6,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+from loopx.event_sourced_state import (
+    AppendOnlyStateEventStore,
+    TODO_ADDED,
+    make_state_event,
+)
 from loopx.todos import list_goal_todos
 
 GOAL_ID = "todo-list-explicit-limit-goal"
@@ -313,3 +318,68 @@ def test_cli_limit_path_and_typed_rejections(tmp_path: Path) -> None:
     non_integer = _run_cli(registry_path, "--limit", "many")
     assert non_integer.returncode == 2
     assert "invalid int value" in non_integer.stderr
+
+
+def test_explicit_limit_bounds_projection_overlay_lineage(
+    tmp_path: Path,
+) -> None:
+    registry_path = _write_fixture(
+        tmp_path,
+        item_count_per_role=200,
+        agent_id=AGENT_ID,
+    )
+    state_file = (
+        tmp_path / "project" / ".local/goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    )
+    store = AppendOnlyStateEventStore(state_file.with_name("events.jsonl"))
+    store.append(
+        make_state_event(
+            event_id="evt-explicit-limit-overlay",
+            goal_id=GOAL_ID,
+            event_type=TODO_ADDED,
+            refs={"todo_id": "todo_agent_open_000"},
+            payload={
+                "role": "agent",
+                "title": "Overlay the first advancement step.",
+                "task_class": "continuous_monitor",
+                "claimed_by": AGENT_ID,
+            },
+            recorded_at="2026-01-01T00:00:00Z",
+            producer="todo-list-explicit-limit-overlay",
+        )
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "todo",
+            "list",
+            "--format",
+            "json",
+            "--goal-id",
+            GOAL_ID,
+            "--limit",
+            "3",
+        ],
+        cwd=REPO_ROOT,
+        env={**os.environ, "LOOPX_REGISTRY": str(registry_path)},
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+
+    assert payload["source"] == "event_projection_with_markdown_overlay"
+    assert payload["explicit_limit"] == 3
+    assert payload["returned_todo_count"] == 6
+    overlay = payload["projection_overlay"]
+    assert overlay["overlaid_count"] == 1
+    assert overlay["event_only_count"] == 0
+    assert overlay["markdown_only_count"] == 399
+    assert overlay["full_detail_cold_path"] == (
+        "todo list without --limit or active state"
+    )
+    assert [key for key in overlay if key.endswith("_todo_ids")] == []

--- a/tests/control_plane/test_todo_list_explicit_limit.py
+++ b/tests/control_plane/test_todo_list_explicit_limit.py
@@ -9,17 +9,35 @@ from pathlib import Path
 from loopx.todos import list_goal_todos
 
 GOAL_ID = "todo-list-explicit-limit-goal"
+AGENT_ID = "codex-explicit-limit"
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-def _todo_line(*, todo_id: str, text: str) -> list[str]:
+def _todo_line(
+    *,
+    todo_id: str,
+    text: str,
+    status: str = "open",
+    metadata: str = "",
+) -> list[str]:
+    marker = "x" if status == "done" else " "
+    metadata_suffix = f" {metadata}" if metadata else ""
     return [
-        f"- [ ] {text}",
-        f"  <!-- loopx:todo todo_id={todo_id} status=open -->",
+        f"- [{marker}] {text}",
+        (
+            "  <!-- loopx:todo "
+            f"todo_id={todo_id} status={status}{metadata_suffix} -->"
+        ),
     ]
 
 
-def _write_fixture(tmp_path: Path) -> Path:
+def _write_fixture(
+    tmp_path: Path,
+    *,
+    item_count_per_role: int = 8,
+    agent_id: str | None = None,
+    terminal_agent_index: int | None = None,
+) -> Path:
     project = tmp_path / "project"
     runtime = tmp_path / "runtime"
     state_relative = Path(".local/goals") / GOAL_ID / "ACTIVE_GOAL_STATE.md"
@@ -37,19 +55,23 @@ def _write_fixture(tmp_path: Path) -> Path:
         "## User Todo",
         "",
     ]
-    for index in range(8):
+    for index in range(item_count_per_role):
         lines.extend(
             _todo_line(
                 todo_id=f"todo_user_open_{index:03d}",
                 text=f"Owner decision {index} for the crowded goal.",
+                metadata=(f"bound_agent={agent_id}" if agent_id else ""),
             )
         )
     lines.extend(["", "## Agent Todo", ""])
-    for index in range(8):
+    for index in range(item_count_per_role):
+        status = "done" if index == terminal_agent_index else "open"
         lines.extend(
             _todo_line(
-                todo_id=f"todo_agent_open_{index:03d}",
+                todo_id=f"todo_agent_{status}_{index:03d}",
                 text=f"Advancement step {index} for the crowded goal.",
+                status=status,
+                metadata=(f"claimed_by={agent_id}" if agent_id else ""),
             )
         )
     state_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
@@ -141,6 +163,35 @@ def test_explicit_limit_is_stable_under_role_filter(tmp_path: Path) -> None:
     assert payload["returned_todo_count"] == 3
     assert payload["todo_list_projection"]["matched_todo_count"] == 8
     assert payload["unfiltered_todo_count"] == 8
+
+
+def test_explicit_limit_takes_precedence_over_agent_lane_hot_path(
+    tmp_path: Path,
+) -> None:
+    registry_path = _write_fixture(
+        tmp_path,
+        item_count_per_role=18,
+        agent_id=AGENT_ID,
+        terminal_agent_index=5,
+    )
+
+    payload = list_goal_todos(
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        limit=20,
+    )
+
+    # An explicit limit selects the disclosed cold path instead of layering the
+    # existing 12-item agent-lane hot-path cap on top of the caller's limit.
+    assert payload["todo_count"] == len(payload["todos"]) == 36
+    assert payload["returned_todo_count"] == 36
+    assert payload["todo_list_projection"]["matched_todo_count"] == 36
+    assert payload["todo_list_projection"]["item_limit_per_role"] == 20
+    assert payload["todo_list_projection"]["view"] == "explicit_limit_cold_path"
+    assert "payload_compaction" not in payload["user_todos"]
+    assert "payload_compaction" not in payload["agent_todos"]
+    assert any(item["status"] == "done" for item in payload["agent_todos"]["items"])
 
 
 def test_default_payload_keeps_the_pre_limit_shape(tmp_path: Path) -> None:

--- a/tests/control_plane/test_todo_list_explicit_limit.py
+++ b/tests/control_plane/test_todo_list_explicit_limit.py
@@ -189,8 +189,10 @@ def test_explicit_limit_takes_precedence_over_agent_lane_hot_path(
     assert payload["todo_list_projection"]["matched_todo_count"] == 36
     assert payload["todo_list_projection"]["item_limit_per_role"] == 20
     assert payload["todo_list_projection"]["view"] == "explicit_limit_cold_path"
-    assert "payload_compaction" not in payload["user_todos"]
-    assert "payload_compaction" not in payload["agent_todos"]
+    for role_key in ("user_todos", "agent_todos"):
+        compaction = payload[role_key]["payload_compaction"]
+        assert compaction["view"] == "explicit_limit_cold_path"
+        assert compaction["item_limit"] == 20
     assert any(item["status"] == "done" for item in payload["agent_todos"]["items"])
 
 

--- a/tests/control_plane/test_todo_list_explicit_limit.py
+++ b/tests/control_plane/test_todo_list_explicit_limit.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from loopx.todos import list_goal_todos
+
+GOAL_ID = "todo-list-explicit-limit-goal"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _todo_line(*, todo_id: str, text: str) -> list[str]:
+    return [
+        f"- [ ] {text}",
+        f"  <!-- loopx:todo todo_id={todo_id} status=open -->",
+    ]
+
+
+def _write_fixture(tmp_path: Path) -> Path:
+    project = tmp_path / "project"
+    runtime = tmp_path / "runtime"
+    state_relative = Path(".local/goals") / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    state_file = project / state_relative
+    state_file.parent.mkdir(parents=True)
+
+    lines = [
+        "---",
+        "status: active",
+        "updated_at: 2026-01-01T00:00:00+00:00",
+        "---",
+        "",
+        "# Todo List Explicit Limit Fixture",
+        "",
+        "## User Todo",
+        "",
+    ]
+    for index in range(8):
+        lines.extend(
+            _todo_line(
+                todo_id=f"todo_user_open_{index:03d}",
+                text=f"Owner decision {index} for the crowded goal.",
+            )
+        )
+    lines.extend(["", "## Agent Todo", ""])
+    for index in range(8):
+        lines.extend(
+            _todo_line(
+                todo_id=f"todo_agent_open_{index:03d}",
+                text=f"Advancement step {index} for the crowded goal.",
+            )
+        )
+    state_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    registry_path = project / ".loopx/registry.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": str(state_relative),
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path
+
+
+def test_explicit_limit_keeps_top_n_per_role_and_discloses_truncation(
+    tmp_path: Path,
+) -> None:
+    registry_path = _write_fixture(tmp_path)
+
+    unlimited = list_goal_todos(registry_path=registry_path, goal_id=GOAL_ID)
+    payload = list_goal_todos(
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        limit=3,
+    )
+
+    assert [item["todo_id"] for item in payload["user_todos"]["items"]] == [
+        item["todo_id"]
+        for item in unlimited["user_todos"]["items"][:3]
+    ]
+    assert [item["todo_id"] for item in payload["agent_todos"]["items"]] == [
+        item["todo_id"]
+        for item in unlimited["agent_todos"]["items"][:3]
+    ]
+    # Per-section unfiltered totals survive the cap: each summary's
+    # total_count is the pre-cap filtered count for its role.
+    assert payload["user_todos"]["total_count"] == 8
+    assert payload["agent_todos"]["total_count"] == 8
+    assert payload["explicit_limit"] == 3
+    assert payload["unfiltered_todo_count"] == 16
+    # todo_count keeps the cold-path invariant todo_count == len(todos):
+    # it reports the returned (post-cap) totals, while the pre-cap match
+    # total stays disclosed via todo_list_projection.matched_todo_count.
+    assert payload["todo_count"] == 6
+    assert len(payload["todos"]) == 6
+    assert payload["returned_todo_count"] == 6
+    assert payload["todo_list_projection"] == {
+        "schema_version": "agent_lane_todo_list_projection_v0",
+        "view": "explicit_limit_cold_path",
+        "matched_todo_count": 16,
+        "returned_todo_count": 6,
+        "item_limit_per_role": 3,
+        "counts_cover_full_match": True,
+        "full_detail_cold_paths": [
+            "todo list without --limit",
+            "active state",
+        ],
+    }
+
+
+def test_explicit_limit_is_stable_under_role_filter(tmp_path: Path) -> None:
+    registry_path = _write_fixture(tmp_path)
+
+    payload = list_goal_todos(
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        role="agent",
+        limit=3,
+    )
+
+    assert len(payload["agent_todos"]["items"]) == 3
+    assert payload["agent_todos"]["total_count"] == 8
+    assert "user_todos" not in payload
+    assert payload["explicit_limit"] == 3
+    assert payload["todo_count"] == 3
+    assert payload["returned_todo_count"] == 3
+    assert payload["todo_list_projection"]["matched_todo_count"] == 8
+    assert payload["unfiltered_todo_count"] == 8
+
+
+def test_default_payload_keeps_the_pre_limit_shape(tmp_path: Path) -> None:
+    registry_path = _write_fixture(tmp_path)
+
+    payload = list_goal_todos(registry_path=registry_path, goal_id=GOAL_ID)
+
+    # The no-limit cold path is byte-identical to the pre---limit shape:
+    # no explicit-limit disclosure fields appear.
+    assert set(payload) == {
+        "ok",
+        "dry_run",
+        "read_only",
+        "command",
+        "goal_id",
+        "role",
+        "status_filter",
+        "source",
+        "todo_count",
+        "todos",
+        "state_file",
+        "project",
+        "user_todos",
+        "agent_todos",
+    }
+    assert payload["todo_count"] == 16
+    assert len(payload["todos"]) == 16
+    for absent_key in (
+        "explicit_limit",
+        "returned_todo_count",
+        "todo_list_projection",
+        "unfiltered_todo_count",
+    ):
+        assert absent_key not in payload
+
+
+def test_todo_id_lookup_ignores_the_section_cap(tmp_path: Path) -> None:
+    registry_path = _write_fixture(tmp_path)
+
+    payload = list_goal_todos(
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        todo_id="todo_agent_open_007",
+        limit=3,
+    )
+
+    assert payload["matched"] is True
+    assert payload["todo"]["todo_id"] == "todo_agent_open_007"
+    assert payload["todo_count"] == 1
+    assert [item["todo_id"] for item in payload["todos"]] == ["todo_agent_open_007"]
+
+
+def test_explicit_limit_rejects_non_positive_values(tmp_path: Path) -> None:
+    registry_path = _write_fixture(tmp_path)
+
+    for rejected in (0, -1):
+        try:
+            list_goal_todos(
+                registry_path=registry_path,
+                goal_id=GOAL_ID,
+                limit=rejected,
+            )
+        except ValueError as exc:
+            assert str(exc) == "todo list --limit must be at least 1"
+        else:
+            raise AssertionError(f"limit={rejected} was not rejected")
+
+
+def _run_cli(registry_path: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "todo",
+            "list",
+            "--goal-id",
+            GOAL_ID,
+            *extra,
+        ],
+        cwd=REPO_ROOT,
+        env={**os.environ, "LOOPX_REGISTRY": str(registry_path)},
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_cli_limit_path_and_typed_rejections(tmp_path: Path) -> None:
+    registry_path = _write_fixture(tmp_path)
+
+    limited = _run_cli(registry_path, "--limit", "3")
+    assert limited.returncode == 0, limited.stderr
+    payload = json.loads(limited.stdout)
+    assert payload["explicit_limit"] == 3
+    assert payload["todo_count"] == 6
+    assert payload["returned_todo_count"] == 6
+    assert payload["todo_list_projection"]["matched_todo_count"] == 16
+
+    default = _run_cli(registry_path)
+    assert default.returncode == 0, default.stderr
+    default_payload = json.loads(default.stdout)
+    assert "explicit_limit" not in default_payload
+    assert "returned_todo_count" not in default_payload
+    assert "todo_list_projection" not in default_payload
+    assert default_payload["todo_count"] == 16
+
+    for rejected in ("0", "-1"):
+        result = _run_cli(registry_path, "--limit", rejected)
+        assert result.returncode == 1, result.stdout
+        error_payload = json.loads(result.stdout)
+        assert error_payload["ok"] is False
+        assert error_payload["error"] == "todo list --limit must be at least 1"
+
+    non_integer = _run_cli(registry_path, "--limit", "many")
+    assert non_integer.returncode == 2
+    assert "invalid int value" in non_integer.stderr

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -238,8 +238,8 @@ def test_todo_list_validation_preserves_exact_unsupported_diagnostic() -> None:
 
     assert str(exc_info.value) == (
         "todo list only accepts --goal-id, optional --role, --status, --todo-id, "
-        "--agent-id, --project, --state-file, --dry-run, and --format; unsupported: "
-        "--note, --evidence"
+        "--agent-id, --limit, --project, --state-file, --dry-run, and --format; "
+        "unsupported: --note, --evidence"
     )
 
 
@@ -258,6 +258,8 @@ def test_todo_list_validation_accepts_read_filters() -> None:
             "todo_example",
             "--agent-id",
             "codex-example",
+            "--limit",
+            "3",
             "--project",
             ".",
             "--state-file",


### PR DESCRIPTION
Implements the GH-C88 / #2881 slice greenlit in the issue thread ("按你的来"): an explicit `--limit N` cold path for `todo list`, mirroring the existing `history --limit 5` and `evidence-log --thin --limit 5` budget precedents. `--thin` is deliberately deferred to a later slice.

## Semantics

- `todo list --limit N` caps each role section (user / agent) at N items **after** role/status/todo_id/agent filtering, applied through the existing `compact_todo_group` `item_limit` seam — no ad-hoc slicing, stable under role filters.
- Truncation is explicitly disclosed, never silent: the payload gains `explicit_limit`, `returned_todo_count`, `unfiltered_todo_count`, and the `todo_list_projection` contract (schema `agent_lane_todo_list_projection_v0`, `view: "explicit_limit_cold_path"`, `matched_todo_count` = pre-cap filtered total, `item_limit_per_role: N`, `counts_cover_full_match: true`). `todo_count` keeps the cold-path invariant `todo_count == len(payload["todos"])`; the pre-cap total lives in `todo_list_projection.matched_todo_count`.
- Without `--limit`, output is unchanged — proven by an A/B compare against a snapshot of upstream/main running the same fixtures across 7 cases (cold default, hot `--agent-id` lane, `--todo-id` lookup, `--role`, `--role --status`, crowded hot, crowded cold): **byte-identical**, no new keys.
- `--todo-id` single lookups are unaffected (N ≥ 1 never drops a single match). `--limit` must be ≥ 1: library-level `ValueError` mirroring the sibling `todo suggestion --limit must be at least 1`; CLI surfaces 0/-1 as an `ok:false` payload.

## The --limit flag collision

`todo` uses one shared parser across subcommands, and `--limit` already existed as a suggest-only flag (`suggestion_limit`, clamp 5). Resolved by generalizing the existing flag the way the repo already generalized `--target-key`: dest renamed to `todo_limit`, help text covers both subcommands, **suggest keeps its exact clamp-5 behavior**, list gains N≥1 semantics, and the shared argument validation was split (`--from`/`--trigger` stay suggest-only; `--limit` opens to list). The diagnostics' exact-message tests were updated accordingly.

## Budget registration

`todo_list_limited` variant registered in `loopx/control_plane/testing/cli_output_budget.py` (`explicit_cold_path_exception`, cold_path `--limit`) with characterized budgets (json 40k chars / 1,100 lines; markdown 1,200 / 24) measured against a crowded synthetic goal: limited output lands at 36,814 chars / 1,035 lines vs 73.7k chars unlimited — roughly halved — while the no-limit default stays inside the parent surface's existing budget. The parent `todo list` entry's cold_path now names `--limit`.

## Tests & validation

- New `tests/control_plane/test_todo_list_explicit_limit.py` (6 tests): crowded 8+8 fixture with limit=3 (per-role prefix order, 8/8 unfiltered counts, exact projection dict); role-filter stability; default-payload key-set deep-equality; `--todo-id` with limit; 0/-1 `ValueError`; CLI round-trip incl. non-integer rejection.
- `test_cli_output_budget.py` +83: variant in the manifest and `_mode_variant_commands`, crowded-goal bounded-output and default-unchanged assertions.
- `-k todo` full-tree: 368 passed; diagnostics + control_plane + canary: 1404 passed with 2 failures reproducing identically on a pristine main snapshot (pre-existing/environmental); final focused merge run: 132 passed.
- Canary: todos.py 2249 → 2269 (exact new count, honest bump); 20/20 green. mypy: 2416 → 2416 errors, zero new (only line-number drift plus mypy's nondeterministic key-ordering in two untouched-module lines).

Refs GH-C88, closes the design proposal in #2881.