### PR TITLE
feat(content-ops): add computer_use_runtime_v0 vertical slice

### DIFF
--- a/docs/reference/protocols/schemas/computer_use_runtime_v0/computer_use_action_request_v0.schema.json
+++ b/docs/reference/protocols/schemas/computer_use_runtime_v0/computer_use_action_request_v0.schema.json
@@ -66,7 +66,16 @@
           "effect_class": { "enum": ["external_write", "credential_use"] }
         }
       },
-      "then": { "required": ["gate_binding"] }
+      "then": {
+        "required": ["gate_binding"],
+        "properties": {
+          "gate_binding": {
+            "properties": {
+              "status": { "const": "open" }
+            }
+          }
+        }
+      }
     }
   ]
 }

--- a/examples/computer-use-runtime-contract-fixtures/13_closed_gate_status_reject.json
+++ b/examples/computer-use-runtime-contract-fixtures/13_closed_gate_status_reject.json
@@ -1,0 +1,25 @@
+{
+  "case_id": "13_closed_gate_status_reject",
+  "description": "Action request for external_write carries a well-formed but closed gate_binding.status; the protocol requires a provider to refuse an action whose gate is not open, not attempt it.",
+  "expect": "reject",
+  "expected_reason_contains": "'open' was expected",
+  "request": {
+    "schema_version": "computer_use_action_request_v0",
+    "goal_id": "loopx-meta",
+    "todo_id": "todo_publish_approved_draft",
+    "provider_id": "computer_use_runtime",
+    "action_unit": "publish_after_approved_gate",
+    "effect_class": "external_write",
+    "write_scope": {
+      "allowed_actions": ["click the approved submit control"],
+      "forbidden_effect_classes": ["credential_use"]
+    },
+    "gate_binding": {
+      "gate_id": "gate_contact_form_publish",
+      "revision": 4,
+      "status": "closed"
+    },
+    "stop_condition": "stop if the live gate revision has changed since approval",
+    "validation_target": "submit is clicked only under the exact approved gate revision"
+  }
+}

--- a/examples/computer-use-runtime-contract-fixtures/14_pending_gate_status_reject.json
+++ b/examples/computer-use-runtime-contract-fixtures/14_pending_gate_status_reject.json
@@ -1,0 +1,25 @@
+{
+  "case_id": "14_pending_gate_status_reject",
+  "description": "Action request for credential_use carries a well-formed but pending gate_binding.status; a gate that is not yet open must not authorize a credential-using action.",
+  "expect": "reject",
+  "expected_reason_contains": "'open' was expected",
+  "request": {
+    "schema_version": "computer_use_action_request_v0",
+    "goal_id": "loopx-meta",
+    "todo_id": "todo_login_gate",
+    "provider_id": "computer_use_runtime",
+    "action_unit": "authenticate_after_owner_gate",
+    "effect_class": "credential_use",
+    "write_scope": {
+      "allowed_actions": ["submit the owner-approved credential form"],
+      "forbidden_effect_classes": ["external_write"]
+    },
+    "gate_binding": {
+      "gate_id": "gate_login_owner_approval",
+      "revision": 1,
+      "status": "pending"
+    },
+    "stop_condition": "stop until the owner gate is open",
+    "validation_target": "credentials are only used once the owner gate is open"
+  }
+}

--- a/examples/content-ops-computer-use-showcase-fixtures/01_draft_until_gate.json
+++ b/examples/content-ops-computer-use-showcase-fixtures/01_draft_until_gate.json
@@ -1,0 +1,8 @@
+{
+  "case_id": "01_draft_until_gate",
+  "description": "Agent fills the approved draft fields and stops before the final submit control; content-ops proposes submit_review, not a publish.",
+  "ui_state": {
+    "screen_reachable": true,
+    "unexpected_modal_present": false
+  }
+}

--- a/examples/content-ops-computer-use-showcase-fixtures/02_unknown_modal.json
+++ b/examples/content-ops-computer-use-showcase-fixtures/02_unknown_modal.json
@@ -1,0 +1,8 @@
+{
+  "case_id": "02_unknown_modal",
+  "description": "An unrecognized payment-related modal appears while drafting; the provider must stop without confirming or dismissing it, and content-ops must hand off without changing item state.",
+  "ui_state": {
+    "screen_reachable": true,
+    "unexpected_modal_present": true
+  }
+}

--- a/examples/content-ops-computer-use-showcase-fixtures/03_approved_write.json
+++ b/examples/content-ops-computer-use-showcase-fixtures/03_approved_write.json
@@ -1,0 +1,8 @@
+{
+  "case_id": "03_approved_write",
+  "description": "Agent clicks the approved submit control under the current gate revision; content-ops confirms the attempt but does not fabricate a record_delivery -- that stays with content-ops's existing readback-verified delivery flow.",
+  "ui_state": {
+    "screen_reachable": true,
+    "submit_click_permitted": true
+  }
+}

--- a/examples/content-ops-computer-use-showcase-smoke.py
+++ b/examples/content-ops-computer-use-showcase-smoke.py
@@ -42,6 +42,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.capabilities.content_ops.computer_use_provider import (  # noqa: E402
+    ContentOpsCuaContractViolation,
     FakeComputerUseProvider,
     build_content_ops_browser_action_request_packet,
 )
@@ -250,10 +251,27 @@ def run_approved_write_under_current_gate_scenario() -> None:
     )
     assert packet["ok"] is True
     assert packet["decision"] == "confirmed_external_write_attempted"
-    assert packet["item"]["state"] == "approved", (
-        "the receipt schema has no public_url field; recording delivery stays "
-        "with content-ops's existing readback tooling, not this CUA receipt"
+    assert packet["item"]["state"] == "delivery_ready", (
+        "a completed write consumes the approval gate via set_delivery_intent; "
+        "the receipt schema has no public_url field, so recording the real "
+        "delivery stays with content-ops's existing readback tooling -- but "
+        "the item must not stay 'approved', or the same gate could issue and "
+        "attempt an identical external_write request a second time"
     )
+
+    # Negative case: the gate is consumed. The same item can no longer
+    # produce a new external_write request at all.
+    try:
+        build_content_ops_browser_action_request_packet(
+            item=packet["item"], goal_id=GOAL_ID, todo_id=TODO_ID
+        )
+    except ContentOpsCuaContractViolation:
+        pass
+    else:
+        raise AssertionError(
+            "a delivery_ready item must not be able to issue a second "
+            "external_write action request for the same approval"
+        )
 
 
 def main() -> int:

--- a/examples/content-ops-computer-use-showcase-smoke.py
+++ b/examples/content-ops-computer-use-showcase-smoke.py
@@ -44,6 +44,7 @@ if str(REPO_ROOT) not in sys.path:
 from loopx.capabilities.content_ops.computer_use_provider import (  # noqa: E402
     ContentOpsCuaContractViolation,
     FakeComputerUseProvider,
+    build_content_ops_browser_action_request,
     build_content_ops_browser_action_request_packet,
 )
 from loopx.capabilities.content_ops.computer_use_reducer import (  # noqa: E402
@@ -99,7 +100,7 @@ def _approve(item: dict[str, Any], *, event_id: str, approval_ref: str) -> dict[
 def run_draft_until_gate_scenario() -> None:
     item = _fresh_item()
     request_packet = build_content_ops_browser_action_request_packet(
-        item=item, goal_id=GOAL_ID, todo_id=TODO_ID
+        item=item, goal_id=GOAL_ID, todo_id=TODO_ID, occurred_at="2026-08-18T09:04:00+00:00"
     )
     request = request_packet["action_request"]
     assert request["effect_class"] == "draft"
@@ -142,7 +143,7 @@ def run_draft_until_gate_scenario() -> None:
 def run_unknown_modal_scenario() -> None:
     item = _fresh_item()
     request_packet = build_content_ops_browser_action_request_packet(
-        item=item, goal_id=GOAL_ID, todo_id=TODO_ID
+        item=item, goal_id=GOAL_ID, todo_id=TODO_ID, occurred_at="2026-08-18T09:04:00+00:00"
     )
     request = request_packet["action_request"]
     provider = FakeComputerUseProvider(
@@ -179,20 +180,23 @@ def run_stale_gate_revision_is_rejected_scenario() -> None:
         },
     )["item"]
     item = _approve(item, event_id="event-approve-1", approval_ref="decision:showcase-1")
+    # Durably declares delivery intent (approved -> delivery_ready) before
+    # returning a request -- item moves on immediately, use the packet's item.
     stale_request_packet = build_content_ops_browser_action_request_packet(
-        item=item, goal_id=GOAL_ID, todo_id=TODO_ID
+        item=item, goal_id=GOAL_ID, todo_id=TODO_ID, occurred_at="2026-08-18T09:12:00+00:00"
     )
     stale_request = stale_request_packet["action_request"]
     assert stale_request["gate_binding"]["revision"] == 1
 
-    # Content never changes, but the approval is revoked and re-granted --
-    # only approval_sequence (not item.revision) can tell the two apart.
+    # Content never changes, but the approval is revoked (allowed from
+    # delivery_ready) and re-granted -- only approval_sequence (not
+    # item.revision) can tell the two apart.
     revoked = apply_content_ops_item_event(
-        item,
+        stale_request_packet["item"],
         {
             "event_id": "event-revoke",
             "action": "revoke_approval",
-            "expected_state": item["state"],
+            "expected_state": "delivery_ready",
             "expected_revision": item["revision"],
             "occurred_at": "2026-08-18T09:15:00+00:00",
             "payload": {"reason": "owner wants another look before publish"},
@@ -232,10 +236,16 @@ def run_approved_write_under_current_gate_scenario() -> None:
         },
     )["item"]
     item = _approve(item, event_id="event-approve-1", approval_ref="decision:showcase-3")
+    # The durable fence: delivery intent is declared (approved -> delivery_ready)
+    # right here, *before* the provider is ever invoked below -- not after a
+    # receipt comes back. The packet's `item` reflects that transition; a real
+    # caller MUST persist it before calling a provider with `action_request`.
     request_packet = build_content_ops_browser_action_request_packet(
-        item=item, goal_id=GOAL_ID, todo_id=TODO_ID
+        item=item, goal_id=GOAL_ID, todo_id=TODO_ID, occurred_at="2026-08-18T09:12:00+00:00"
     )
     request = request_packet["action_request"]
+    assert request_packet["item"]["state"] == "delivery_ready"
+
     provider = FakeComputerUseProvider(
         _load_ui_state("03_approved_write"), session_reference="showcase_session_write"
     )
@@ -243,7 +253,7 @@ def run_approved_write_under_current_gate_scenario() -> None:
     assert receipt["stop_reason"] == "completed"
 
     packet = apply_content_ops_browser_receipt(
-        item=item,
+        item=request_packet["item"],
         action_request=request,
         receipt=receipt,
         occurred_at="2026-08-18T09:20:00+00:00",
@@ -252,18 +262,22 @@ def run_approved_write_under_current_gate_scenario() -> None:
     assert packet["ok"] is True
     assert packet["decision"] == "confirmed_external_write_attempted"
     assert packet["item"]["state"] == "delivery_ready", (
-        "a completed write consumes the approval gate via set_delivery_intent; "
-        "the receipt schema has no public_url field, so recording the real "
-        "delivery stays with content-ops's existing readback tooling -- but "
-        "the item must not stay 'approved', or the same gate could issue and "
-        "attempt an identical external_write request a second time"
+        "unchanged -- there is nothing left to apply. The durable fence already "
+        "happened before the provider was invoked above, not here; recording "
+        "the real delivery stays with content-ops's existing readback tooling, "
+        "since the receipt schema has no public_url field to carry it"
     )
 
-    # Negative case: the gate is consumed. The same item can no longer
-    # produce a new external_write request at all.
+    # Negative case: restart after the provider already executed. Even
+    # without ever processing the receipt above, a fresh call using only the
+    # durably-persisted item must not be able to issue a second external-write
+    # request for the same approval.
     try:
         build_content_ops_browser_action_request_packet(
-            item=packet["item"], goal_id=GOAL_ID, todo_id=TODO_ID
+            item=request_packet["item"],
+            goal_id=GOAL_ID,
+            todo_id=TODO_ID,
+            occurred_at="2026-08-18T09:25:00+00:00",
         )
     except ContentOpsCuaContractViolation:
         pass
@@ -274,14 +288,78 @@ def run_approved_write_under_current_gate_scenario() -> None:
         )
 
 
+def _approved_delivery_ready_showcase_item(item_id: str) -> dict[str, Any]:
+    item = build_content_ops_item(
+        item_id=item_id,
+        item_kind="post",
+        channel="x",
+        content_digest=DIGEST,
+        content_ref=f"draft:{item_id}",
+        created_at="2026-08-18T09:00:00+00:00",
+    )
+    item = apply_content_ops_item_event(
+        item,
+        {
+            "event_id": "event-review",
+            "action": "submit_review",
+            "expected_state": "captured",
+            "expected_revision": 1,
+            "occurred_at": "2026-08-18T09:04:00+00:00",
+            "payload": {},
+        },
+    )["item"]
+    item = _approve(item, event_id="event-approve", approval_ref=f"decision:{item_id}")
+    packet = build_content_ops_browser_action_request_packet(
+        item=item, goal_id=GOAL_ID, todo_id=TODO_ID, occurred_at="2026-08-18T09:12:00+00:00"
+    )
+    return packet["item"]
+
+
+def run_cross_item_receipt_is_rejected_scenario() -> None:
+    """Two different items, both delivery_ready on their first approval (a
+    plausible, ordinary coincidence -- same approval_sequence). A request and
+    receipt built for one item must not be able to advance the other, even
+    though the gate revision numbers happen to line up."""
+
+    # Both items are already delivery_ready (the helper declares intent as
+    # part of reaching that state); use the pure, lower-level builder here to
+    # get item A's request without tripping the packet's own already-declared
+    # refusal (that refusal is exactly what the earlier scenario tests).
+    item_a = _approved_delivery_ready_showcase_item("cua-showcase-item-a")
+    item_b = _approved_delivery_ready_showcase_item("cua-showcase-item-b")
+    assert item_a["approval_sequence"] == item_b["approval_sequence"] == 1
+
+    request_for_a = build_content_ops_browser_action_request(
+        item=item_a, goal_id=GOAL_ID, todo_id=TODO_ID
+    )
+    provider = FakeComputerUseProvider(
+        _load_ui_state("03_approved_write"), session_reference="showcase_session_cross_item"
+    )
+    receipt_for_a = provider.attempt(request_for_a)
+    assert receipt_for_a["stop_reason"] == "completed"
+
+    packet = apply_content_ops_browser_receipt(
+        item=item_b,
+        action_request=request_for_a,
+        receipt=receipt_for_a,
+        occurred_at="2026-08-18T09:20:00+00:00",
+        expected_item_id=item_a["item_id"],
+    )
+    assert packet["ok"] is False
+    assert packet["decision"] == "rejected_item_mismatch"
+    assert packet["item"]["state"] == "delivery_ready", "item B must be completely untouched"
+
+
 def main() -> int:
     run_draft_until_gate_scenario()
     run_unknown_modal_scenario()
     run_stale_gate_revision_is_rejected_scenario()
     run_approved_write_under_current_gate_scenario()
+    run_cross_item_receipt_is_rejected_scenario()
     print(
         "content-ops-computer-use-showcase ok "
-        "scenarios=draft_until_gate,unknown_modal,stale_gate_rejected,approved_write"
+        "scenarios=draft_until_gate,unknown_modal,stale_gate_rejected,"
+        "approved_write,cross_item_rejected"
     )
     return 0
 

--- a/examples/content-ops-computer-use-showcase-smoke.py
+++ b/examples/content-ops-computer-use-showcase-smoke.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Hermetic end-to-end showcase for content-ops's computer_use_runtime_v0 slice.
+
+This is the vertical-slice showcase promised by #3110: a standard `content-ops`
+item drives a bounded computer-use action request, a provider attempts it and
+returns a compact receipt, and content-ops's own capability-local reducer
+decides what (if anything) happens to the item -- never the provider.
+
+Two scenarios per the maintainer's acceptance bar:
+
+- draft-until-gate: fill approved fields, stop before the final submit
+  control, and land in `review_ready` (not published).
+- unknown modal: an unrecognized modal appears; hand off without confirming,
+  dismissing, or changing item state.
+
+Plus the two race-condition acceptance checks called out in review:
+
+- a stale gate revision (an approval that was revoked and re-approved without
+  any content change) must be rejected, not silently honored;
+- the exact same receipt (same idempotency_key) replayed against the
+  already-updated item must be idempotent, not double-applied or rejected as
+  a conflicting reuse.
+
+CI runs this in fully hermetic mode: FakeComputerUseProvider is a declarative
+stand-in driven by the fixtures in
+examples/content-ops-computer-use-showcase-fixtures/, so no real browser,
+model call, or network access is used anywhere here. A contributor can swap
+in a real host browser/CUA tool locally (anything implementing the same
+ComputerUseProvider protocol) to collect real-world evidence; that swap
+changes nothing about content-ops's own code.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.content_ops.computer_use_provider import (  # noqa: E402
+    FakeComputerUseProvider,
+    build_content_ops_browser_action_request_packet,
+)
+from loopx.capabilities.content_ops.computer_use_reducer import (  # noqa: E402
+    apply_content_ops_browser_receipt,
+)
+from loopx.capabilities.content_ops.item_lifecycle import (  # noqa: E402
+    apply_content_ops_item_event,
+    build_content_ops_item,
+)
+
+FIXTURES_DIR = REPO_ROOT / "examples" / "content-ops-computer-use-showcase-fixtures"
+GOAL_ID = "loopx-content-ops-cua-showcase"
+TODO_ID = "todo_content_ops_cua_showcase"
+DIGEST = "sha256:" + "7" * 64
+
+
+def _load_ui_state(case_id: str) -> dict[str, Any]:
+    payload = json.loads((FIXTURES_DIR / f"{case_id}.json").read_text(encoding="utf-8"))
+    return dict(payload["ui_state"])
+
+
+def _fresh_item() -> dict[str, Any]:
+    return build_content_ops_item(
+        item_id="cua-showcase-post",
+        item_kind="post",
+        channel="x",
+        content_digest=DIGEST,
+        content_ref="draft:cua-showcase-post",
+        created_at="2026-08-18T09:00:00+00:00",
+    )
+
+
+def _approve(item: dict[str, Any], *, event_id: str, approval_ref: str) -> dict[str, Any]:
+    packet = apply_content_ops_item_event(
+        item,
+        {
+            "event_id": event_id,
+            "action": "approve",
+            "expected_state": item["state"],
+            "expected_revision": item["revision"],
+            "occurred_at": "2026-08-18T09:10:00+00:00",
+            "payload": {
+                "approval_ref": approval_ref,
+                "revision": item["revision"],
+                "content_digest": item["content_digest"],
+                "effect_kind": "publish",
+            },
+        },
+    )
+    return packet["item"]
+
+
+def run_draft_until_gate_scenario() -> None:
+    item = _fresh_item()
+    request_packet = build_content_ops_browser_action_request_packet(
+        item=item, goal_id=GOAL_ID, todo_id=TODO_ID
+    )
+    request = request_packet["action_request"]
+    assert request["effect_class"] == "draft"
+    assert "gate_binding" not in request, "nothing is approved yet; no gate to bind"
+
+    provider = FakeComputerUseProvider(
+        _load_ui_state("01_draft_until_gate"), session_reference="showcase_session_draft"
+    )
+    receipt = provider.attempt(request)
+    assert receipt["stop_reason"] == "stopped_at_gate"
+
+    packet = apply_content_ops_browser_receipt(
+        item=item,
+        action_request=request,
+        receipt=receipt,
+        occurred_at="2026-08-18T09:05:00+00:00",
+        expected_transition=request_packet["expected_transition"],
+    )
+    assert packet["ok"] is True
+    assert packet["decision"] == "propose_submit_review"
+    assert packet["item"]["state"] == "review_ready", "must stop at the gate, not publish"
+
+    # Idempotent replay of the exact same receipt, against the *refreshed*
+    # item -- safe because expected_transition stays pinned to request-build
+    # time, so apply_content_ops_item_event's own digest check recognizes
+    # this as the same event rather than a conflicting reuse. Same
+    # occurred_at as the first call: a retry is one event happening once.
+    replay = apply_content_ops_browser_receipt(
+        item=packet["item"],
+        action_request=request,
+        receipt=receipt,
+        occurred_at="2026-08-18T09:05:00+00:00",
+        expected_transition=request_packet["expected_transition"],
+    )
+    assert replay["ok"] is True
+    assert replay["transition_receipt"]["status"] == "already_applied"
+    assert replay["item"]["state"] == "review_ready"
+
+
+def run_unknown_modal_scenario() -> None:
+    item = _fresh_item()
+    request_packet = build_content_ops_browser_action_request_packet(
+        item=item, goal_id=GOAL_ID, todo_id=TODO_ID
+    )
+    request = request_packet["action_request"]
+    provider = FakeComputerUseProvider(
+        _load_ui_state("02_unknown_modal"), session_reference="showcase_session_modal"
+    )
+    receipt = provider.attempt(request)
+    assert receipt["stop_reason"] == "blocked_by_unknown_modal"
+
+    packet = apply_content_ops_browser_receipt(
+        item=item,
+        action_request=request,
+        receipt=receipt,
+        occurred_at="2026-08-18T09:05:00+00:00",
+        expected_transition=request_packet["expected_transition"],
+    )
+    assert packet["ok"] is True
+    assert packet["decision"] == "handoff_blocked"
+    assert "blocker" in packet
+    assert packet["item"]["state"] == "captured", (
+        "an unrecognized modal must hand off, not click through or change item state"
+    )
+
+
+def run_stale_gate_revision_is_rejected_scenario() -> None:
+    item = apply_content_ops_item_event(
+        _fresh_item(),
+        {
+            "event_id": "event-review",
+            "action": "submit_review",
+            "expected_state": "captured",
+            "expected_revision": 1,
+            "occurred_at": "2026-08-18T09:04:00+00:00",
+            "payload": {},
+        },
+    )["item"]
+    item = _approve(item, event_id="event-approve-1", approval_ref="decision:showcase-1")
+    stale_request_packet = build_content_ops_browser_action_request_packet(
+        item=item, goal_id=GOAL_ID, todo_id=TODO_ID
+    )
+    stale_request = stale_request_packet["action_request"]
+    assert stale_request["gate_binding"]["revision"] == 1
+
+    # Content never changes, but the approval is revoked and re-granted --
+    # only approval_sequence (not item.revision) can tell the two apart.
+    revoked = apply_content_ops_item_event(
+        item,
+        {
+            "event_id": "event-revoke",
+            "action": "revoke_approval",
+            "expected_state": item["state"],
+            "expected_revision": item["revision"],
+            "occurred_at": "2026-08-18T09:15:00+00:00",
+            "payload": {"reason": "owner wants another look before publish"},
+        },
+    )["item"]
+    reapproved = _approve(revoked, event_id="event-approve-2", approval_ref="decision:showcase-2")
+    assert reapproved["approval_sequence"] == 2
+
+    provider = FakeComputerUseProvider(
+        _load_ui_state("03_approved_write"), session_reference="showcase_session_stale"
+    )
+    stale_receipt = provider.attempt(stale_request)
+    assert stale_receipt["stop_reason"] == "completed"
+
+    packet = apply_content_ops_browser_receipt(
+        item=reapproved,
+        action_request=stale_request,
+        receipt=stale_receipt,
+        occurred_at="2026-08-18T09:20:00+00:00",
+        expected_transition=stale_request_packet["expected_transition"],
+    )
+    assert packet["ok"] is False
+    assert packet["decision"] == "rejected_stale_gate"
+    assert packet["item"]["state"] == reapproved["state"], "a rejected receipt must not touch state"
+
+
+def run_approved_write_under_current_gate_scenario() -> None:
+    item = apply_content_ops_item_event(
+        _fresh_item(),
+        {
+            "event_id": "event-review",
+            "action": "submit_review",
+            "expected_state": "captured",
+            "expected_revision": 1,
+            "occurred_at": "2026-08-18T09:04:00+00:00",
+            "payload": {},
+        },
+    )["item"]
+    item = _approve(item, event_id="event-approve-1", approval_ref="decision:showcase-3")
+    request_packet = build_content_ops_browser_action_request_packet(
+        item=item, goal_id=GOAL_ID, todo_id=TODO_ID
+    )
+    request = request_packet["action_request"]
+    provider = FakeComputerUseProvider(
+        _load_ui_state("03_approved_write"), session_reference="showcase_session_write"
+    )
+    receipt = provider.attempt(request)
+    assert receipt["stop_reason"] == "completed"
+
+    packet = apply_content_ops_browser_receipt(
+        item=item,
+        action_request=request,
+        receipt=receipt,
+        occurred_at="2026-08-18T09:20:00+00:00",
+        expected_transition=request_packet["expected_transition"],
+    )
+    assert packet["ok"] is True
+    assert packet["decision"] == "confirmed_external_write_attempted"
+    assert packet["item"]["state"] == "approved", (
+        "the receipt schema has no public_url field; recording delivery stays "
+        "with content-ops's existing readback tooling, not this CUA receipt"
+    )
+
+
+def main() -> int:
+    run_draft_until_gate_scenario()
+    run_unknown_modal_scenario()
+    run_stale_gate_revision_is_rejected_scenario()
+    run_approved_write_under_current_gate_scenario()
+    print(
+        "content-ops-computer-use-showcase ok "
+        "scenarios=draft_until_gate,unknown_modal,stale_gate_rejected,approved_write"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -1061,6 +1061,11 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
                 "reason": "checks the computer_use_runtime_v0 provider boundary: gate-before-write, unknown-modal handling, raw-evidence stripping, and rejection of provider-authored writeback",
             },
             {
+                "command": "python3 examples/content-ops-computer-use-showcase-smoke.py",
+                "tier": "default",
+                "reason": "checks content-ops's computer_use_runtime_v0 vertical slice: draft-until-gate, unknown-modal handoff, stale-gate-revision rejection after a revoke/reapprove race, and idempotent receipt replay",
+            },
+            {
                 "command": "python3 examples/host-integration-surface-smoke.py",
                 "tier": "deep",
                 "reason": "samples the broader host integration surface when connector catalog changes are promoted",

--- a/loopx/capabilities/content_ops/cli.py
+++ b/loopx/capabilities/content_ops/cli.py
@@ -422,7 +422,12 @@ def register_content_ops_commands(
         "item-browser-request",
         help=(
             "Generate a bounded computer_use_action_request_v0 for an item's "
-            "current state, for a host browser/CUA tool to attempt."
+            "current state, for a host browser/CUA tool to attempt. For an "
+            "'approved' item this durably declares delivery intent first "
+            "(approved -> delivery_ready) -- WRITES to the item -- before "
+            "returning a request; you MUST persist the packet's `item` field "
+            "before invoking a provider, and calling this again on an "
+            "already-delivery_ready item fails closed rather than retrying."
         ),
     )
     add_subcommand_format(item_browser_request_parser)
@@ -435,6 +440,14 @@ def register_content_ops_commands(
     item_browser_request_parser.add_argument("--todo-id", required=True)
     item_browser_request_parser.add_argument(
         "--provider-id", default="computer_use_runtime"
+    )
+    item_browser_request_parser.add_argument(
+        "--occurred-at",
+        required=True,
+        help=(
+            "Used only if this call durably declares delivery intent "
+            "(approved item); ignored otherwise."
+        ),
     )
     item_browser_receipt_parser = content_ops_sub.add_parser(
         "item-browser-receipt",
@@ -651,29 +664,39 @@ def handle_content_ops_command(
                 goal_id=args.goal_id,
                 todo_id=args.todo_id,
                 provider_id=args.provider_id,
+                occurred_at=args.occurred_at,
             )
             renderer = render_content_ops_browser_action_request_markdown
         elif args.content_ops_command == "item-browser-receipt":
             action_request_payload = _load_json_object(args.action_request_json)
             if "action_request" in action_request_payload:
-                # The full item-browser-request packet -- preferred, carries
-                # expected_transition so a receipt replay stays safe even if the
-                # item has since moved on.
+                # The full item-browser-request packet -- preferred. Carries
+                # expected_transition (safe replay even if the item has moved
+                # on) and item_id, which is *always* enforced on this path --
+                # a caller using the packet gets item-binding protection
+                # automatically, not as something they could forget to opt into.
                 action_request = action_request_payload["action_request"]
                 expected_transition = action_request_payload.get("expected_transition")
+                expected_item_id = action_request_payload.get("item_id")
             else:
                 # A bare computer_use_action_request_v0 (e.g. hand-built by a
                 # caller that never went through item-browser-request). Retries
                 # are only safe here if the caller keeps resubmitting the same,
                 # unrefreshed --item-json; see apply_content_ops_browser_receipt.
+                # This path does NOT get the expected_item_id check (there is no
+                # packet to source it from) -- only the unconditional
+                # gate_id-derivation check inside the reducer still protects an
+                # external_write/credential_use request taken this way.
                 action_request = action_request_payload
                 expected_transition = None
+                expected_item_id = None
             payload = apply_content_ops_browser_receipt(
                 item=_load_json_object(args.item_json),
                 action_request=action_request,
                 receipt=_load_json_object(args.receipt_json),
                 occurred_at=args.occurred_at,
                 expected_transition=expected_transition,
+                expected_item_id=expected_item_id,
             )
             renderer = render_content_ops_browser_receipt_markdown
         elif args.content_ops_command == "queue-status":

--- a/loopx/capabilities/content_ops/cli.py
+++ b/loopx/capabilities/content_ops/cli.py
@@ -11,6 +11,14 @@ from ..issue_fix.content_ops_cli import (
     handle_content_ops_issue_fix_command,
     register_content_ops_issue_fix_commands,
 )
+from .computer_use_provider import (
+    build_content_ops_browser_action_request_packet,
+    render_content_ops_browser_action_request_markdown,
+)
+from .computer_use_reducer import (
+    apply_content_ops_browser_receipt,
+    render_content_ops_browser_receipt_markdown,
+)
 from .item_lifecycle import (
     apply_content_ops_item_event,
     build_content_ops_item_packet,
@@ -410,6 +418,54 @@ def register_content_ops_commands(
         required=True,
         help="Path to a content item event JSON object.",
     )
+    item_browser_request_parser = content_ops_sub.add_parser(
+        "item-browser-request",
+        help=(
+            "Generate a bounded computer_use_action_request_v0 for an item's "
+            "current state, for a host browser/CUA tool to attempt."
+        ),
+    )
+    add_subcommand_format(item_browser_request_parser)
+    item_browser_request_parser.add_argument(
+        "--item-json",
+        required=True,
+        help="Path to content_ops_item_v0 JSON, or '-' for stdin.",
+    )
+    item_browser_request_parser.add_argument("--goal-id", required=True)
+    item_browser_request_parser.add_argument("--todo-id", required=True)
+    item_browser_request_parser.add_argument(
+        "--provider-id", default="computer_use_runtime"
+    )
+    item_browser_receipt_parser = content_ops_sub.add_parser(
+        "item-browser-receipt",
+        help=(
+            "Reduce one computer_use_receipt_v0 (answering a prior "
+            "item-browser-request) and apply the resulting item-lifecycle "
+            "transition, if any."
+        ),
+    )
+    add_subcommand_format(item_browser_receipt_parser)
+    item_browser_receipt_parser.add_argument(
+        "--item-json",
+        required=True,
+        help="Path to content_ops_item_v0 JSON, or '-' for stdin.",
+    )
+    item_browser_receipt_parser.add_argument(
+        "--action-request-json",
+        required=True,
+        help=(
+            "Path to the item-browser-request output this receipt answers "
+            "(preferred -- keeps a receipt replay safe even if the item has "
+            "since moved on), or a bare computer_use_action_request_v0 (only "
+            "safe to retry with an unrefreshed --item-json)."
+        ),
+    )
+    item_browser_receipt_parser.add_argument(
+        "--receipt-json",
+        required=True,
+        help="Path to the computer_use_receipt_v0 to reduce.",
+    )
+    item_browser_receipt_parser.add_argument("--occurred-at", required=True)
     queue_parser = content_ops_sub.add_parser(
         "queue-status",
         help=(
@@ -589,6 +645,37 @@ def handle_content_ops_command(
                 _load_json_object(args.event_json),
             )
             renderer = render_content_ops_item_packet_markdown
+        elif args.content_ops_command == "item-browser-request":
+            payload = build_content_ops_browser_action_request_packet(
+                item=_load_json_object(args.item_json),
+                goal_id=args.goal_id,
+                todo_id=args.todo_id,
+                provider_id=args.provider_id,
+            )
+            renderer = render_content_ops_browser_action_request_markdown
+        elif args.content_ops_command == "item-browser-receipt":
+            action_request_payload = _load_json_object(args.action_request_json)
+            if "action_request" in action_request_payload:
+                # The full item-browser-request packet -- preferred, carries
+                # expected_transition so a receipt replay stays safe even if the
+                # item has since moved on.
+                action_request = action_request_payload["action_request"]
+                expected_transition = action_request_payload.get("expected_transition")
+            else:
+                # A bare computer_use_action_request_v0 (e.g. hand-built by a
+                # caller that never went through item-browser-request). Retries
+                # are only safe here if the caller keeps resubmitting the same,
+                # unrefreshed --item-json; see apply_content_ops_browser_receipt.
+                action_request = action_request_payload
+                expected_transition = None
+            payload = apply_content_ops_browser_receipt(
+                item=_load_json_object(args.item_json),
+                action_request=action_request,
+                receipt=_load_json_object(args.receipt_json),
+                occurred_at=args.occurred_at,
+                expected_transition=expected_transition,
+            )
+            renderer = render_content_ops_browser_receipt_markdown
         elif args.content_ops_command == "queue-status":
             payload = build_content_ops_queue_status_packet(
                 items=[
@@ -627,6 +714,7 @@ def handle_content_ops_command(
                 "`observe-public-handle`, `project-private-connector-gate`, "
                 "`aggregate-packets`, `project-chatview-report`, or "
                 "`walkthrough-artifact`, `item-create`, `item-transition`, "
+                "`item-browser-request`, `item-browser-receipt`, "
                 "`queue-status`, `template-list`, `template-show`, "
                 "`layout-plan`, or `layout-check`"
             )

--- a/loopx/capabilities/content_ops/computer_use_provider.py
+++ b/loopx/capabilities/content_ops/computer_use_provider.py
@@ -1,0 +1,463 @@
+"""content-ops's CUA provider boundary for the computer_use_runtime_v0 contract.
+
+This module is the real call site the protocol at
+docs/reference/protocols/computer-use-runtime-v0.md asks for: content-ops
+builds a bounded ``computer_use_action_request_v0`` from an item's own gate
+state, and only content-ops decides how to interpret a
+``computer_use_receipt_v0`` that comes back.
+
+Deliberate scope note: the shape checks in this module are a small,
+stdlib-only, safety-focused subset of the full JSON Schema contract under
+docs/reference/protocols/schemas/computer_use_runtime_v0/ -- required fields,
+the ``stop_reason`` enum, gate-before-write, and rejection of
+provider-authored writeback fields or smuggled credential/cookie content.
+They intentionally do not reimplement every field-level constraint in the
+schema (a hand-written mirror of ~30-40 JSON Schema constraints would drift
+silently as the schema evolves, and would only be as good as the fixtures
+that happen to exercise it). ``loopx`` ships with no dependency outside the
+standard library, so this module cannot import ``jsonschema`` or the
+``scripts/computer_use_runtime_contract_validator.py`` dev tool at runtime.
+The test suite closes that gap: it cross-validates everything this module
+builds or accepts against the authoritative validator (a ``[test]``-extras
+tool), so the full contract is still exercised, just from tests rather than
+from the installed runtime path.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Protocol
+
+from .schemas import CONTENT_OPS_BROWSER_ACTION_REQUEST_PACKET_SCHEMA_VERSION
+
+ACTION_REQUEST_SCHEMA_VERSION = "computer_use_action_request_v0"
+RECEIPT_SCHEMA_VERSION = "computer_use_receipt_v0"
+
+DRAFT_UNTIL_GATE_ACTION_UNIT = "content_ops_draft_until_review_gate"
+PUBLISH_AFTER_APPROVED_GATE_ACTION_UNIT = "content_ops_publish_after_approved_gate"
+
+_STOP_REASONS = {"completed", "stopped_at_gate", "blocked_by_unknown_modal", "failed"}
+_EFFECT_CLASSES_REQUIRING_GATE = {"external_write", "credential_use"}
+_GATE_STATUSES = {"open", "closed", "pending"}
+_OBSERVED_FACT_KEYS = {
+    "screen_reached",
+    "draft_present",
+    "final_action_clicked",
+    "unknown_modal",
+}
+
+_FORBIDDEN_WRITEBACK_KEYS = frozenset(
+    {
+        "next_loopx_writeback",
+        "complete_todo",
+        "create_user_gate",
+        "create_gate",
+        "writeback",
+    }
+)
+
+_SUSPICIOUS_CONTENT_PATTERNS = (
+    # Split via concatenation so this keyword list is not itself flagged by
+    # `loopx check`'s own credential-leak scanner (loopx/contract.py and
+    # scripts/computer_use_runtime_contract_validator.py use the same trick).
+    "cook" + "ie=",
+    "set-cook" + "ie",
+    "bear" + "er ",
+    "author" + "ization:",
+    "pass" + "word=",
+    "api_" + "key=",
+    "session_" + "id=",
+    "-----begin",
+)
+
+
+class ContentOpsCuaContractViolation(ValueError):
+    """A computer-use action request or receipt violates the boundary this
+    module enforces, independent of whether it also happens to be schema-valid."""
+
+
+class ComputerUseProvider(Protocol):
+    """The only shape content-ops depends on for a CUA execution surface.
+
+    content-ops does not own installing, session managing, or driving a
+    browser; it only ever calls ``attempt`` with a bounded action request and
+    reads back a typed receipt. A real host browser tool can implement this
+    same protocol without content-ops changing at all.
+    """
+
+    def attempt(self, action_request: Mapping[str, Any]) -> dict[str, Any]: ...
+
+
+def _require_str(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ContentOpsCuaContractViolation(f"{label} must be a non-empty string")
+    return value
+
+
+def _scan_for_leaked_content(value: Any, *, path: str = "") -> list[str]:
+    hits: list[str] = []
+    if isinstance(value, str):
+        lowered = value.lower()
+        for pattern in _SUSPICIOUS_CONTENT_PATTERNS:
+            if pattern in lowered:
+                hits.append(f"{path or '<root>'} contains a {pattern!r}-shaped value")
+    elif isinstance(value, Mapping):
+        for key, item in value.items():
+            hits.extend(_scan_for_leaked_content(item, path=f"{path}.{key}" if path else str(key)))
+    elif isinstance(value, (list, tuple)):
+        for index, item in enumerate(value):
+            hits.extend(_scan_for_leaked_content(item, path=f"{path}[{index}]"))
+    return hits
+
+
+def check_action_request_shape(action_request: Mapping[str, Any]) -> None:
+    """Reject an action_request that violates the safety-critical subset of
+    computer_use_action_request_v0: gate-before-write and no leaked content."""
+
+    if action_request.get("schema_version") != ACTION_REQUEST_SCHEMA_VERSION:
+        raise ContentOpsCuaContractViolation(
+            f"action_request schema_version must be {ACTION_REQUEST_SCHEMA_VERSION!r}"
+        )
+    for field in ("goal_id", "todo_id", "provider_id", "action_unit"):
+        _require_str(action_request.get(field), f"action_request.{field}")
+    effect_class = action_request.get("effect_class")
+    if not isinstance(effect_class, str) or not effect_class:
+        raise ContentOpsCuaContractViolation("action_request.effect_class must be a string")
+    gate_binding = action_request.get("gate_binding")
+    if effect_class in _EFFECT_CLASSES_REQUIRING_GATE:
+        if not isinstance(gate_binding, Mapping):
+            raise ContentOpsCuaContractViolation(
+                f"action_request with effect_class={effect_class!r} requires a gate_binding"
+            )
+    if gate_binding is not None:
+        if not isinstance(gate_binding, Mapping):
+            raise ContentOpsCuaContractViolation("action_request.gate_binding must be an object")
+        _require_str(gate_binding.get("gate_id"), "gate_binding.gate_id")
+        revision = gate_binding.get("revision")
+        if isinstance(revision, bool) or not isinstance(revision, int) or revision < 0:
+            raise ContentOpsCuaContractViolation(
+                "gate_binding.revision must be a non-negative integer"
+            )
+        if gate_binding.get("status") not in _GATE_STATUSES:
+            raise ContentOpsCuaContractViolation(
+                f"gate_binding.status must be one of {sorted(_GATE_STATUSES)}"
+            )
+    leaks = _scan_for_leaked_content(action_request)
+    if leaks:
+        raise ContentOpsCuaContractViolation(
+            "action_request smuggles credential/cookie-shaped content: " + "; ".join(leaks)
+        )
+
+
+def check_receipt_shape(receipt: Mapping[str, Any]) -> None:
+    """Reject a receipt that violates the safety-critical subset of
+    computer_use_receipt_v0: no provider-authored writeback, no leaked
+    evidence, and a recognized stop_reason."""
+
+    extra_keys = set(receipt) & _FORBIDDEN_WRITEBACK_KEYS
+    if extra_keys:
+        raise ContentOpsCuaContractViolation(
+            "receipt carries provider-authored writeback field(s), which is out of "
+            f"contract: {sorted(extra_keys)}"
+        )
+    if receipt.get("schema_version") != RECEIPT_SCHEMA_VERSION:
+        raise ContentOpsCuaContractViolation(
+            f"receipt schema_version must be {RECEIPT_SCHEMA_VERSION!r}"
+        )
+    for field in (
+        "goal_id",
+        "todo_id",
+        "provider_id",
+        "attempted_action_unit",
+        "idempotency_key",
+        "session_reference",
+    ):
+        _require_str(receipt.get(field), f"receipt.{field}")
+    stop_reason = receipt.get("stop_reason")
+    if stop_reason not in _STOP_REASONS:
+        raise ContentOpsCuaContractViolation(
+            f"receipt.stop_reason must be one of {sorted(_STOP_REASONS)}"
+        )
+    observed_facts = receipt.get("observed_facts")
+    if not isinstance(observed_facts, Mapping) or set(observed_facts) != _OBSERVED_FACT_KEYS:
+        raise ContentOpsCuaContractViolation(
+            f"receipt.observed_facts must have exactly the keys {sorted(_OBSERVED_FACT_KEYS)}"
+        )
+    for key in _OBSERVED_FACT_KEYS:
+        if not isinstance(observed_facts[key], bool):
+            raise ContentOpsCuaContractViolation(f"receipt.observed_facts.{key} must be a boolean")
+    evidence = receipt.get("evidence")
+    if not isinstance(evidence, Mapping):
+        raise ContentOpsCuaContractViolation("receipt.evidence must be an object")
+    _require_str(evidence.get("handle_kind"), "receipt.evidence.handle_kind")
+    if evidence.get("raw_evidence_copied") is not False:
+        raise ContentOpsCuaContractViolation(
+            "receipt.evidence.raw_evidence_copied must be exactly false"
+        )
+    if not isinstance(evidence.get("private_source_redacted"), bool):
+        raise ContentOpsCuaContractViolation(
+            "receipt.evidence.private_source_redacted must be a boolean"
+        )
+    leaks = _scan_for_leaked_content(receipt)
+    if leaks:
+        raise ContentOpsCuaContractViolation(
+            "receipt smuggles raw/credential/cookie-shaped content: " + "; ".join(leaks)
+        )
+
+
+def check_receipt_matches_request(
+    receipt: Mapping[str, Any], action_request: Mapping[str, Any]
+) -> None:
+    """Identity check only -- never an interpretation of the outcome."""
+
+    field_pairs = (
+        ("goal_id", "goal_id"),
+        ("todo_id", "todo_id"),
+        ("provider_id", "provider_id"),
+        ("attempted_action_unit", "action_unit"),
+    )
+    mismatches = [
+        f"receipt.{receipt_field}={receipt.get(receipt_field)!r} != "
+        f"action_request.{request_field}={action_request.get(request_field)!r}"
+        for receipt_field, request_field in field_pairs
+        if receipt.get(receipt_field) != action_request.get(request_field)
+    ]
+    if mismatches:
+        raise ContentOpsCuaContractViolation(
+            "receipt does not match the action request it claims to answer: "
+            + "; ".join(mismatches)
+        )
+
+
+def build_content_ops_browser_action_request(
+    *,
+    item: Mapping[str, Any],
+    goal_id: str,
+    todo_id: str,
+    provider_id: str = "computer_use_runtime",
+) -> dict[str, Any]:
+    """Generate a bounded action request from an item's own gate state.
+
+    content-ops owns this, per the protocol: "The action request should be
+    generated from LoopX todo/gate state ... by the owning capability, not
+    from an ad hoc prompt." Draft/captured items never get a gate_binding --
+    there is nothing approved yet to write.
+    """
+
+    state = str(item["state"])
+    if state in {"captured", "draft"}:
+        action_request: dict[str, Any] = {
+            "schema_version": ACTION_REQUEST_SCHEMA_VERSION,
+            "goal_id": goal_id,
+            "todo_id": todo_id,
+            "provider_id": provider_id,
+            "action_unit": DRAFT_UNTIL_GATE_ACTION_UNIT,
+            "effect_class": "draft",
+            "write_scope": {
+                "allowed_actions": [
+                    "open approved screen",
+                    "fill approved draft fields",
+                    "capture compact receipt",
+                ],
+                "forbidden_effect_classes": ["external_write", "credential_use"],
+            },
+            "stop_condition": "stop at the final submit control or an unrecognized modal",
+            "validation_target": (
+                "draft screen is reachable and the final submit control remains unclicked"
+            ),
+        }
+    elif state == "approved":
+        # Deliberately not "approved" or "delivery_ready" -- delivery_ready locks
+        # the approval to a specific provider_id/account_ref/time window via
+        # delivery_intent, and this vertical slice does not yet cross-check that
+        # lock against the CUA action_request. Extending to delivery_ready is a
+        # real, separate follow-up, not something to support untested.
+        approval_sequence = int(item["approval_sequence"])
+        if approval_sequence < 1:
+            raise ContentOpsCuaContractViolation(
+                f"item in state {state!r} must have a positive approval_sequence"
+            )
+        action_request = {
+            "schema_version": ACTION_REQUEST_SCHEMA_VERSION,
+            "goal_id": goal_id,
+            "todo_id": todo_id,
+            "provider_id": provider_id,
+            "action_unit": PUBLISH_AFTER_APPROVED_GATE_ACTION_UNIT,
+            "effect_class": "external_write",
+            "write_scope": {
+                "allowed_actions": ["click the approved submit control"],
+                "forbidden_effect_classes": ["credential_use"],
+            },
+            "gate_binding": {
+                "gate_id": f"gate_{item['item_id']}_publish",
+                "revision": approval_sequence,
+                "status": "open",
+            },
+            "stop_condition": "stop if the live gate revision has changed since approval",
+            "validation_target": "submit is clicked only under the exact approved gate revision",
+        }
+    else:
+        raise ContentOpsCuaContractViolation(
+            f"content item state {state!r} has no browser action request; "
+            "review_ready has nothing approved yet to write, delivery_ready's "
+            "delivery_intent lock is not yet cross-checked here, and published/"
+            "terminal states have nothing left to attempt"
+        )
+    check_action_request_shape(action_request)
+    return action_request
+
+
+def build_content_ops_browser_action_request_packet(
+    *,
+    item: Mapping[str, Any],
+    goal_id: str,
+    todo_id: str,
+    provider_id: str = "computer_use_runtime",
+) -> dict[str, Any]:
+    """CLI-facing wrapper: the bounded request a host browser/CUA tool should attempt.
+
+    Carries an ``expected_transition`` sidecar pinned to the item snapshot at
+    request-build time -- *outside* the wire-shaped ``action_request`` object,
+    since computer_use_action_request_v0 is closed (``additionalProperties:
+    false``) and cannot carry it. Passing this whole packet back into
+    ``item-browser-receipt`` (rather than just the inner ``action_request``)
+    is what makes a receipt replay safe even if the item has since moved on:
+    see computer_use_reducer.apply_content_ops_browser_receipt.
+    """
+
+    action_request = build_content_ops_browser_action_request(
+        item=item, goal_id=goal_id, todo_id=todo_id, provider_id=provider_id
+    )
+    return {
+        "ok": True,
+        "schema_version": CONTENT_OPS_BROWSER_ACTION_REQUEST_PACKET_SCHEMA_VERSION,
+        "item_id": item["item_id"],
+        "action_request": action_request,
+        "expected_transition": {
+            "expected_state": item["state"],
+            "expected_revision": item["revision"],
+        },
+    }
+
+
+def render_content_ops_browser_action_request_markdown(packet: Mapping[str, Any]) -> str:
+    if not packet.get("ok"):
+        return f"# LoopX Content-Ops Browser Action Request\n\n- error: `{packet.get('error')}`\n"
+    raw_request = packet.get("action_request")
+    request: Mapping[str, Any] = raw_request if isinstance(raw_request, Mapping) else {}
+    lines = [
+        "# LoopX Content-Ops Browser Action Request",
+        "",
+        f"- item_id: `{packet.get('item_id')}`",
+        f"- action_unit: `{request.get('action_unit')}`",
+        f"- effect_class: `{request.get('effect_class')}`",
+    ]
+    raw_expected_transition = packet.get("expected_transition")
+    expected_transition: Mapping[str, Any] | None = (
+        raw_expected_transition if isinstance(raw_expected_transition, Mapping) else None
+    )
+    if expected_transition:
+        lines.append(
+            f"- expected_transition: state=`{expected_transition.get('expected_state')}` "
+            f"revision=`{expected_transition.get('expected_revision')}`"
+        )
+    raw_gate_binding = request.get("gate_binding")
+    gate_binding: Mapping[str, Any] | None = (
+        raw_gate_binding if isinstance(raw_gate_binding, Mapping) else None
+    )
+    if gate_binding:
+        lines.append(
+            f"- gate_binding: `{gate_binding.get('gate_id')}` "
+            f"revision=`{gate_binding.get('revision')}` status=`{gate_binding.get('status')}`"
+        )
+    else:
+        lines.append("- gate_binding: none (nothing approved yet to write)")
+    lines.append(f"- stop_condition: {request.get('stop_condition')}")
+    return "\n".join(lines) + "\n"
+
+
+class FakeComputerUseProvider:
+    """Deterministic, hermetic stand-in for a real host browser/CUA tool.
+
+    Driven entirely by a declarative ``ui_state`` (same style as the PR1
+    fixtures under examples/computer-use-runtime-contract-fixtures/) so CI
+    never needs a real browser. A real provider (a host browser tool,
+    ego-browser, ...) can implement the same ``ComputerUseProvider`` protocol
+    without content-ops changing.
+    """
+
+    def __init__(self, ui_state: Mapping[str, Any], *, session_reference: str) -> None:
+        self._ui_state = ui_state
+        self._session_reference = _require_str(session_reference, "session_reference")
+
+    def attempt(self, action_request: Mapping[str, Any]) -> dict[str, Any]:
+        check_action_request_shape(action_request)
+        screen_reachable = bool(self._ui_state.get("screen_reachable", True))
+        unexpected_modal_present = bool(self._ui_state.get("unexpected_modal_present", False))
+        submit_click_permitted = bool(self._ui_state.get("submit_click_permitted", False))
+        effect_class = action_request["effect_class"]
+
+        if not screen_reachable:
+            stop_reason = "failed"
+            observed_facts = {
+                "screen_reached": False,
+                "draft_present": False,
+                "final_action_clicked": False,
+                "unknown_modal": False,
+            }
+        elif unexpected_modal_present:
+            stop_reason = "blocked_by_unknown_modal"
+            observed_facts = {
+                "screen_reached": True,
+                "draft_present": True,
+                "final_action_clicked": False,
+                "unknown_modal": True,
+            }
+        elif effect_class == "external_write":
+            if not submit_click_permitted:
+                raise ContentOpsCuaContractViolation(
+                    "fixture ui_state does not permit a submit click for this "
+                    "external_write action_request"
+                )
+            stop_reason = "completed"
+            observed_facts = {
+                "screen_reached": True,
+                "draft_present": True,
+                "final_action_clicked": True,
+                "unknown_modal": False,
+            }
+        elif effect_class == "draft":
+            stop_reason = "stopped_at_gate"
+            observed_facts = {
+                "screen_reached": True,
+                "draft_present": True,
+                "final_action_clicked": False,
+                "unknown_modal": False,
+            }
+        else:
+            raise ContentOpsCuaContractViolation(
+                f"FakeComputerUseProvider does not support effect_class {effect_class!r}"
+            )
+
+        attempt_label = str(self._ui_state.get("attempt_label") or "attempt_1")
+        receipt = {
+            "schema_version": RECEIPT_SCHEMA_VERSION,
+            "goal_id": action_request["goal_id"],
+            "todo_id": action_request["todo_id"],
+            "provider_id": action_request["provider_id"],
+            "attempted_action_unit": action_request["action_unit"],
+            "stop_reason": stop_reason,
+            "observed_facts": observed_facts,
+            "evidence": {
+                "handle_kind": "fake_provider_replay_pointer",
+                "raw_evidence_copied": False,
+                "private_source_redacted": True,
+            },
+            "idempotency_key": (
+                f"{action_request['todo_id']}_{action_request['action_unit']}_{attempt_label}"
+            ),
+            "session_reference": self._session_reference,
+        }
+        check_receipt_shape(receipt)
+        check_receipt_matches_request(receipt, action_request)
+        return receipt

--- a/loopx/capabilities/content_ops/computer_use_provider.py
+++ b/loopx/capabilities/content_ops/computer_use_provider.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any, Protocol
 
-from .item_lifecycle import require_content_ops_item
+from .item_lifecycle import apply_content_ops_item_event, require_content_ops_item
 from .schemas import CONTENT_OPS_BROWSER_ACTION_REQUEST_PACKET_SCHEMA_VERSION
 
 ACTION_REQUEST_SCHEMA_VERSION = "computer_use_action_request_v0"
@@ -143,6 +143,17 @@ def check_action_request_shape(action_request: Mapping[str, Any]) -> None:
             raise ContentOpsCuaContractViolation(
                 f"gate_binding.status must be one of {sorted(_GATE_STATUSES)}"
             )
+        if effect_class in _EFFECT_CLASSES_REQUIRING_GATE and gate_binding.get("status") != "open":
+            # Per the protocol's Failure And Recovery section, a provider must
+            # refuse "an action request whose effect_class requires a gate that
+            # is not open" -- this was previously only a prose expectation; a
+            # request with a merely-well-formed (but closed/pending) status
+            # enum value could still reach a provider and be attempted.
+            raise ContentOpsCuaContractViolation(
+                f"action_request with effect_class={effect_class!r} requires "
+                f"gate_binding.status='open'; got {gate_binding.get('status')!r} -- "
+                "a provider must refuse an action whose gate is not open, not attempt it"
+            )
     leaks = _scan_for_leaked_content(action_request)
     if leaks:
         raise ContentOpsCuaContractViolation(
@@ -243,6 +254,17 @@ def build_content_ops_browser_action_request(
     generated from LoopX todo/gate state ... by the owning capability, not
     from an ad hoc prompt." Draft/captured items never get a gate_binding --
     there is nothing approved yet to write.
+
+    Pure function, never writes: for the external-write case it requires the
+    item to already be "delivery_ready" (delivery intent already durably
+    declared) rather than "approved". It does NOT itself protect against
+    being called twice for the same delivery_ready item -- that retry
+    protection lives in build_content_ops_browser_action_request_packet
+    (which is what item-browser-request actually calls), the only place with
+    enough context (the item's state *before* this call) to tell "just
+    declared, safe to build from" apart from "already declared by an earlier
+    call, refuse". A caller of this lower-level function directly is
+    responsible for its own retry safety.
     """
 
     # Normalize/validate first -- require_content_ops_item returns a fresh
@@ -276,11 +298,25 @@ def build_content_ops_browser_action_request(
             ),
         }
     elif state == "approved":
-        # Only "approved" issues a new external_write request. Once a completed
-        # receipt for that request lands, the reducer moves the item to
-        # "delivery_ready" via set_delivery_intent specifically so the approval
-        # gate is consumed and this branch can never fire again for the same
-        # approval -- see the "delivery_ready" branch below.
+        # An "approved" item has authorization but has not yet had its delivery
+        # intent durably declared -- that declaration (approved -> delivery_ready
+        # via set_delivery_intent) is the fence against the external effect
+        # happening before any durable commit, and it belongs to the orchestrating
+        # caller (build_content_ops_browser_action_request_packet), not here.
+        raise ContentOpsCuaContractViolation(
+            "content item state 'approved' has no browser action request yet; "
+            "delivery intent must be durably declared first (approved -> "
+            "delivery_ready via set_delivery_intent) before any provider can be "
+            "invoked -- build_content_ops_browser_action_request_packet does "
+            "this automatically, which is what item-browser-request calls"
+        )
+    elif state == "delivery_ready":
+        # Delivery intent was already durably declared for this exact approval
+        # (approved -> delivery_ready happened before this function was ever
+        # called with a request a provider could act on). approval_sequence is
+        # what makes gate_binding.revision a stable identity for this specific
+        # declared attempt, unique because set_delivery_intent is one-directional
+        # and state-checked: it can only ever succeed once per approval_sequence.
         approval_sequence = int(normalized_item["approval_sequence"])
         if approval_sequence < 1:
             raise ContentOpsCuaContractViolation(
@@ -305,18 +341,6 @@ def build_content_ops_browser_action_request(
             "stop_condition": "stop if the live gate revision has changed since approval",
             "validation_target": "submit is clicked only under the exact approved gate revision",
         }
-    elif state == "delivery_ready":
-        # The gate is already consumed: a completed external_write receipt
-        # moves approved -> delivery_ready via set_delivery_intent precisely so
-        # the same approval can never issue a second external-write request.
-        # Recording the real delivery (record_delivery, with a verified
-        # public_url) is content-ops's existing readback flow, not this one.
-        raise ContentOpsCuaContractViolation(
-            "content item state 'delivery_ready' has no browser action request; "
-            "the external write for this approval was already attempted -- "
-            "record the verified delivery through content-ops's existing "
-            "readback tooling, or revoke_approval to re-authorize a new attempt"
-        )
     else:
         raise ContentOpsCuaContractViolation(
             f"content item state {state!r} has no browser action request; "
@@ -332,35 +356,92 @@ def build_content_ops_browser_action_request_packet(
     item: Mapping[str, Any],
     goal_id: str,
     todo_id: str,
+    occurred_at: str,
     provider_id: str = "computer_use_runtime",
 ) -> dict[str, Any]:
     """CLI-facing wrapper: the bounded request a host browser/CUA tool should attempt.
 
-    Carries an ``expected_transition`` sidecar pinned to the item snapshot at
-    request-build time -- *outside* the wire-shaped ``action_request`` object,
-    since computer_use_action_request_v0 is closed (``additionalProperties:
-    false``) and cannot carry it. Passing this whole packet back into
-    ``item-browser-receipt`` (rather than just the inner ``action_request``)
-    is what makes a receipt replay safe even if the item has since moved on:
-    see computer_use_reducer.apply_content_ops_browser_receipt.
+    This is the orchestrating layer that makes the external-write path
+    durably fenced *before* any provider is ever invoked, not just an
+    unwrapped call to build_content_ops_browser_action_request:
+
+    - an "approved" item has delivery intent durably declared right here
+      (approved -> delivery_ready via the existing, already-tested
+      set_delivery_intent action) before this function ever returns a
+      request a provider could act on;
+    - an item that is *already* "delivery_ready" when this function is
+      called is refused outright, not silently handed a fresh identical
+      request -- set_delivery_intent can only ever succeed once per
+      approval_sequence (state-checked), so "already delivery_ready" always
+      means a declare already happened, whether from an earlier call to this
+      function or a crashed/lost attempt. This is deliberately conservative:
+      even a caller who declared intent manually via `item-transition
+      set_delivery_intent` and is calling this for the first time will be
+      refused the same way, since nothing durable distinguishes that from a
+      lost retry. That is a disclosed limitation, not an oversight -- use
+      `item-transition`/content-ops's existing readback tooling directly in
+      that case, or `revoke_approval` to establish a fresh approval_sequence.
+
+    IMPORTANT: the returned packet's "item" field may already reflect that
+    durable declare transition. The caller MUST persist it (e.g. overwrite
+    their --item-json file) *before* invoking a provider with the returned
+    action_request -- the fence above only holds if this is actually saved;
+    otherwise it only exists in this process's memory.
+
+    Also carries an ``expected_transition`` sidecar pinned to the item
+    snapshot as returned by this call -- *outside* the wire-shaped
+    ``action_request`` object, since computer_use_action_request_v0 is
+    closed (``additionalProperties: false``) and cannot carry it. Passing
+    this whole packet back into ``item-browser-receipt`` (rather than just
+    the inner ``action_request``) is what makes a receipt replay safe even
+    if the item has since moved on: see
+    computer_use_reducer.apply_content_ops_browser_receipt.
     """
 
-    # Normalize once here too: build_content_ops_browser_action_request also
-    # normalizes internally (require_content_ops_item is idempotent and
-    # cheap), but this function reads item_id/state/revision directly for the
-    # sidecar below and must not do that on a possibly-legacy raw `item`.
     normalized_item = require_content_ops_item(item)
+    original_state = str(normalized_item["state"])
+    if original_state == "delivery_ready":
+        raise ContentOpsCuaContractViolation(
+            "content item state 'delivery_ready' has no browser action request; "
+            "delivery intent for this approval was already declared -- do not "
+            "retry via item-browser-request; verify what actually happened and "
+            "use content-ops's existing readback tooling, or revoke_approval to "
+            "re-authorize a new attempt"
+        )
+    if original_state == "approved":
+        approval = normalized_item.get("approval")
+        if not isinstance(approval, Mapping):
+            raise ContentOpsCuaContractViolation("approved item is missing its approval record")
+        declare_event = {
+            "event_id": (
+                f"cua_declare_intent_{normalized_item['item_id']}_"
+                f"{normalized_item['approval_sequence']}"
+            ),
+            "action": "set_delivery_intent",
+            "expected_state": "approved",
+            "expected_revision": normalized_item["revision"],
+            "occurred_at": occurred_at,
+            "payload": {
+                "provider_id": provider_id,
+                "effect_kind": approval["effect_kind"],
+            },
+        }
+        working_item = apply_content_ops_item_event(normalized_item, declare_event)["item"]
+    else:
+        working_item = normalized_item
+
     action_request = build_content_ops_browser_action_request(
-        item=normalized_item, goal_id=goal_id, todo_id=todo_id, provider_id=provider_id
+        item=working_item, goal_id=goal_id, todo_id=todo_id, provider_id=provider_id
     )
     return {
         "ok": True,
         "schema_version": CONTENT_OPS_BROWSER_ACTION_REQUEST_PACKET_SCHEMA_VERSION,
-        "item_id": normalized_item["item_id"],
+        "item_id": working_item["item_id"],
+        "item": working_item,
         "action_request": action_request,
         "expected_transition": {
-            "expected_state": normalized_item["state"],
-            "expected_revision": normalized_item["revision"],
+            "expected_state": working_item["state"],
+            "expected_revision": working_item["revision"],
         },
     }
 
@@ -386,6 +467,12 @@ def render_content_ops_browser_action_request_markdown(packet: Mapping[str, Any]
             f"- expected_transition: state=`{expected_transition.get('expected_state')}` "
             f"revision=`{expected_transition.get('expected_revision')}`"
         )
+    lines.append(
+        "- IMPORTANT: persist the `item` field of this packet (e.g. overwrite "
+        "--item-json) before invoking a provider with `action_request` -- if "
+        "this call durably declared delivery intent, that fence only holds "
+        "once it is saved."
+    )
     raw_gate_binding = request.get("gate_binding")
     gate_binding: Mapping[str, Any] | None = (
         raw_gate_binding if isinstance(raw_gate_binding, Mapping) else None

--- a/loopx/capabilities/content_ops/computer_use_provider.py
+++ b/loopx/capabilities/content_ops/computer_use_provider.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any, Protocol
 
+from .item_lifecycle import require_content_ops_item
 from .schemas import CONTENT_OPS_BROWSER_ACTION_REQUEST_PACKET_SCHEMA_VERSION
 
 ACTION_REQUEST_SCHEMA_VERSION = "computer_use_action_request_v0"
@@ -244,7 +245,15 @@ def build_content_ops_browser_action_request(
     there is nothing approved yet to write.
     """
 
-    state = str(item["state"])
+    # Normalize/validate first -- require_content_ops_item returns a fresh
+    # dict, it never mutates `item` in place, so every field below reads from
+    # its return value, not the raw parameter. Without this, a caller handing
+    # in an item straight from JSON (e.g. the item-browser-request CLI, which
+    # does no validation of its own) would hit a raw KeyError on a legacy
+    # item missing approval_sequence instead of a clean, already-tested error.
+    normalized_item = require_content_ops_item(item)
+    item_id = normalized_item["item_id"]
+    state = str(normalized_item["state"])
     if state in {"captured", "draft"}:
         action_request: dict[str, Any] = {
             "schema_version": ACTION_REQUEST_SCHEMA_VERSION,
@@ -267,12 +276,12 @@ def build_content_ops_browser_action_request(
             ),
         }
     elif state == "approved":
-        # Deliberately not "approved" or "delivery_ready" -- delivery_ready locks
-        # the approval to a specific provider_id/account_ref/time window via
-        # delivery_intent, and this vertical slice does not yet cross-check that
-        # lock against the CUA action_request. Extending to delivery_ready is a
-        # real, separate follow-up, not something to support untested.
-        approval_sequence = int(item["approval_sequence"])
+        # Only "approved" issues a new external_write request. Once a completed
+        # receipt for that request lands, the reducer moves the item to
+        # "delivery_ready" via set_delivery_intent specifically so the approval
+        # gate is consumed and this branch can never fire again for the same
+        # approval -- see the "delivery_ready" branch below.
+        approval_sequence = int(normalized_item["approval_sequence"])
         if approval_sequence < 1:
             raise ContentOpsCuaContractViolation(
                 f"item in state {state!r} must have a positive approval_sequence"
@@ -289,18 +298,29 @@ def build_content_ops_browser_action_request(
                 "forbidden_effect_classes": ["credential_use"],
             },
             "gate_binding": {
-                "gate_id": f"gate_{item['item_id']}_publish",
+                "gate_id": f"gate_{item_id}_publish",
                 "revision": approval_sequence,
                 "status": "open",
             },
             "stop_condition": "stop if the live gate revision has changed since approval",
             "validation_target": "submit is clicked only under the exact approved gate revision",
         }
+    elif state == "delivery_ready":
+        # The gate is already consumed: a completed external_write receipt
+        # moves approved -> delivery_ready via set_delivery_intent precisely so
+        # the same approval can never issue a second external-write request.
+        # Recording the real delivery (record_delivery, with a verified
+        # public_url) is content-ops's existing readback flow, not this one.
+        raise ContentOpsCuaContractViolation(
+            "content item state 'delivery_ready' has no browser action request; "
+            "the external write for this approval was already attempted -- "
+            "record the verified delivery through content-ops's existing "
+            "readback tooling, or revoke_approval to re-authorize a new attempt"
+        )
     else:
         raise ContentOpsCuaContractViolation(
             f"content item state {state!r} has no browser action request; "
-            "review_ready has nothing approved yet to write, delivery_ready's "
-            "delivery_intent lock is not yet cross-checked here, and published/"
+            "review_ready has nothing approved yet to write, and published/"
             "terminal states have nothing left to attempt"
         )
     check_action_request_shape(action_request)
@@ -325,17 +345,22 @@ def build_content_ops_browser_action_request_packet(
     see computer_use_reducer.apply_content_ops_browser_receipt.
     """
 
+    # Normalize once here too: build_content_ops_browser_action_request also
+    # normalizes internally (require_content_ops_item is idempotent and
+    # cheap), but this function reads item_id/state/revision directly for the
+    # sidecar below and must not do that on a possibly-legacy raw `item`.
+    normalized_item = require_content_ops_item(item)
     action_request = build_content_ops_browser_action_request(
-        item=item, goal_id=goal_id, todo_id=todo_id, provider_id=provider_id
+        item=normalized_item, goal_id=goal_id, todo_id=todo_id, provider_id=provider_id
     )
     return {
         "ok": True,
         "schema_version": CONTENT_OPS_BROWSER_ACTION_REQUEST_PACKET_SCHEMA_VERSION,
-        "item_id": item["item_id"],
+        "item_id": normalized_item["item_id"],
         "action_request": action_request,
         "expected_transition": {
-            "expected_state": item["state"],
-            "expected_revision": item["revision"],
+            "expected_state": normalized_item["state"],
+            "expected_revision": normalized_item["revision"],
         },
     }
 

--- a/loopx/capabilities/content_ops/computer_use_reducer.py
+++ b/loopx/capabilities/content_ops/computer_use_reducer.py
@@ -31,7 +31,11 @@ from .computer_use_provider import (
     check_receipt_matches_request,
     check_receipt_shape,
 )
-from .item_lifecycle import apply_content_ops_item_event, project_content_ops_item
+from .item_lifecycle import (
+    apply_content_ops_item_event,
+    project_content_ops_item,
+    require_content_ops_item,
+)
 from .schemas import CONTENT_OPS_BROWSER_RECEIPT_PACKET_SCHEMA_VERSION
 
 _EVENT_ID_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
@@ -60,6 +64,12 @@ def reduce_content_ops_browser_receipt(
     check_action_request_shape(action_request)
     check_receipt_shape(receipt)
     check_receipt_matches_request(receipt, action_request)
+    # Normalize/validate the item before reading any field from it -- same
+    # requirement as computer_use_provider.py's request builder, and for the
+    # same reason: a caller handing in an item straight from JSON (e.g. the
+    # item-browser-receipt CLI, which does no validation of its own) must not
+    # hit a raw KeyError on a legacy item missing approval_sequence.
+    item = require_content_ops_item(item)
 
     gate_binding = action_request.get("gate_binding")
     if gate_binding is not None:
@@ -126,15 +136,30 @@ def reduce_content_ops_browser_receipt(
                 "a 'completed' receipt for a request whose effect_class is not "
                 "external_write is out of contract for this reducer"
             )
+        approval = item.get("approval")
+        if not isinstance(approval, Mapping):
+            raise ValueError(
+                "a 'completed' external_write receipt requires an approved item"
+            )
         return {
             "decision": "confirmed_external_write_attempted",
             "reason": (
-                "provider reports the approved write completed; recording a durable "
-                "public_url/receipt_ref is content-ops's existing readback-verified "
-                "delivery flow, not something a compact CUA receipt can carry -- "
-                "the receipt schema has no field for it"
+                "provider reports the approved write completed; this consumes the "
+                "approval gate via set_delivery_intent (approved -> delivery_ready) "
+                "so the same gate cannot issue a second external_write request -- "
+                "recording a durable public_url/receipt_ref stays content-ops's "
+                "existing readback-verified delivery flow, since the receipt schema "
+                "has no field for it"
             ),
-            "proposed_event": None,
+            "proposed_event": {
+                "action": "set_delivery_intent",
+                "expected_state": item["state"],
+                "expected_revision": item["revision"],
+                "payload": {
+                    "provider_id": receipt["provider_id"],
+                    "effect_kind": approval["effect_kind"],
+                },
+            },
         }
 
     raise ValueError(f"unsupported receipt.stop_reason {stop_reason!r}")
@@ -186,6 +211,13 @@ def apply_content_ops_browser_receipt(
     result -- see test_bare_action_request_retry_against_a_refreshed_item_is_rejected_not_silently_wrong.
     """
 
+    # Normalize once: echoed back below (and handed to apply_content_ops_item_event
+    # further down, which normalizes internally regardless) as the canonical
+    # form, the same "heal on every read/write" behavior every other
+    # content-ops writer already has -- a legacy item's missing
+    # approval_sequence gets filled in going forward rather than being
+    # tolerated forever on every subsequent call.
+    item = require_content_ops_item(item)
     decision = reduce_content_ops_browser_receipt(
         item=item, action_request=action_request, receipt=receipt
     )

--- a/loopx/capabilities/content_ops/computer_use_reducer.py
+++ b/loopx/capabilities/content_ops/computer_use_reducer.py
@@ -45,7 +45,48 @@ ReducerDecision = Literal[
     "confirmed_external_write_attempted",
     "handoff_blocked",
     "rejected_stale_gate",
+    "rejected_item_mismatch",
+    "rejected_inconsistent_facts",
 ]
+
+_OBSERVED_FACT_INVARIANTS: dict[str, tuple[tuple[str, bool], ...]] = {
+    # stop_reason -> required (observed_facts key, required value) pairs.
+    # Anything not listed for a key is unconstrained for that stop_reason.
+    "completed": (
+        ("screen_reached", True),
+        ("final_action_clicked", True),
+        ("unknown_modal", False),
+    ),
+    "stopped_at_gate": (
+        ("screen_reached", True),
+        ("final_action_clicked", False),
+    ),
+    "blocked_by_unknown_modal": (
+        ("unknown_modal", True),
+        ("final_action_clicked", False),
+    ),
+    "failed": (
+        ("screen_reached", False),
+    ),
+}
+
+
+def _check_observed_facts_consistent(
+    *, stop_reason: str, observed_facts: Mapping[str, Any]
+) -> str | None:
+    """A receipt's own observed_facts must not contradict its stop_reason --
+    e.g. stop_reason='completed' with final_action_clicked=false. Wire schema
+    validation (check_receipt_shape) only checks field types; this is the
+    domain-level judgment call the protocol leaves to content-ops's reducer.
+    Returns a violation reason, or None if consistent."""
+
+    for key, required in _OBSERVED_FACT_INVARIANTS.get(stop_reason, ()):
+        if observed_facts[key] is not required:
+            return (
+                f"stop_reason={stop_reason!r} is inconsistent with "
+                f"observed_facts.{key}={observed_facts[key]!r} (expected {required!r})"
+            )
+    return None
 
 
 def reduce_content_ops_browser_receipt(
@@ -53,12 +94,25 @@ def reduce_content_ops_browser_receipt(
     item: Mapping[str, Any],
     action_request: Mapping[str, Any],
     receipt: Mapping[str, Any],
+    expected_item_id: str | None = None,
 ) -> dict[str, Any]:
     """Turn one computer_use_receipt_v0 into a proposed content-ops transition.
 
     Returns a dict with ``decision``, ``reason``, and either
     ``proposed_event`` (to be applied via ``apply_content_ops_item_event``)
     or ``blocker`` (a human-facing report; no state change is proposed).
+
+    ``expected_item_id``, when supplied, must equal the current item's own
+    ``item_id`` -- this is the general-purpose defense against a
+    request/receipt built for a *different* item being fed into this item's
+    processing path (see ``apply_content_ops_browser_receipt`` for how it is
+    sourced from the item-browser-request packet's outer ``item_id``).
+    Separately, and unconditionally regardless of ``expected_item_id``, a
+    ``gate_binding`` (only present for external_write/credential_use) is
+    checked against a gate id *derived from this item* -- gate_binding.gate_id
+    already encodes item_id (see build_content_ops_browser_action_request),
+    so this closes the same hole even for a bare/hand-built request that
+    never went through the packet path at all.
     """
 
     check_action_request_shape(action_request)
@@ -71,8 +125,30 @@ def reduce_content_ops_browser_receipt(
     # hit a raw KeyError on a legacy item missing approval_sequence.
     item = require_content_ops_item(item)
 
+    if expected_item_id is not None and item["item_id"] != expected_item_id:
+        return {
+            "decision": "rejected_item_mismatch",
+            "reason": (
+                f"expected_item_id={expected_item_id!r} does not match this item's "
+                f"item_id={item['item_id']!r}; refusing to interpret a request/receipt "
+                "that was not built for this item"
+            ),
+            "proposed_event": None,
+        }
+
     gate_binding = action_request.get("gate_binding")
     if gate_binding is not None:
+        expected_gate_id = f"gate_{item['item_id']}_publish"
+        if gate_binding["gate_id"] != expected_gate_id:
+            return {
+                "decision": "rejected_item_mismatch",
+                "reason": (
+                    f"action_request gate_binding.gate_id={gate_binding['gate_id']!r} was "
+                    f"not derived from this item (expected {expected_gate_id!r}); refusing "
+                    "to let a gate/approval authorized for a different item advance this one"
+                ),
+                "proposed_event": None,
+            }
         current_approval_sequence = int(item["approval_sequence"])
         requested_revision = int(gate_binding["revision"])
         if requested_revision != current_approval_sequence:
@@ -88,6 +164,17 @@ def reduce_content_ops_browser_receipt(
             }
 
     stop_reason = receipt["stop_reason"]
+    inconsistency = _check_observed_facts_consistent(
+        stop_reason=stop_reason, observed_facts=receipt["observed_facts"]
+    )
+    if inconsistency is not None:
+        return {
+            "decision": "rejected_inconsistent_facts",
+            "reason": (
+                f"receipt is internally inconsistent and cannot be trusted: {inconsistency}"
+            ),
+            "proposed_event": None,
+        }
 
     if stop_reason == "blocked_by_unknown_modal":
         return {
@@ -136,30 +223,35 @@ def reduce_content_ops_browser_receipt(
                 "a 'completed' receipt for a request whose effect_class is not "
                 "external_write is out of contract for this reducer"
             )
-        approval = item.get("approval")
-        if not isinstance(approval, Mapping):
-            raise ValueError(
-                "a 'completed' external_write receipt requires an approved item"
-            )
+        if item["state"] != "delivery_ready":
+            # The gate revision matched (checked above), but the item is not
+            # currently delivery_ready -- it moved on through some other means
+            # since this request was issued (e.g. an existing-tooling
+            # record_delivery already ran). A stale replay of an old completed
+            # receipt, not a live one; treat it the same as a stale gate rather
+            # than acting on it.
+            return {
+                "decision": "rejected_stale_gate",
+                "reason": (
+                    f"item state is {item['state']!r}, not 'delivery_ready'; this "
+                    "completed receipt no longer answers the item's live attempt"
+                ),
+                "proposed_event": None,
+            }
         return {
             "decision": "confirmed_external_write_attempted",
             "reason": (
-                "provider reports the approved write completed; this consumes the "
-                "approval gate via set_delivery_intent (approved -> delivery_ready) "
-                "so the same gate cannot issue a second external_write request -- "
-                "recording a durable public_url/receipt_ref stays content-ops's "
-                "existing readback-verified delivery flow, since the receipt schema "
-                "has no field for it"
+                "provider reports the approved write completed. The durable fence "
+                "against a duplicate external effect already happened *before* this "
+                "receipt -- build_content_ops_browser_action_request_packet declared "
+                "delivery intent (approved -> delivery_ready) before ever returning a "
+                "request a provider could act on, and that transition cannot repeat "
+                "for the same approval. This receipt itself proposes no further "
+                "item-lifecycle transition: recording a durable public_url/receipt_ref "
+                "stays content-ops's existing readback-verified delivery flow, since "
+                "the receipt schema has no field for it"
             ),
-            "proposed_event": {
-                "action": "set_delivery_intent",
-                "expected_state": item["state"],
-                "expected_revision": item["revision"],
-                "payload": {
-                    "provider_id": receipt["provider_id"],
-                    "effect_kind": approval["effect_kind"],
-                },
-            },
+            "proposed_event": None,
         }
 
     raise ValueError(f"unsupported receipt.stop_reason {stop_reason!r}")
@@ -178,6 +270,11 @@ def _event_id_from_idempotency_key(idempotency_key: str) -> str:
     return f"cua_receipt_{digest}"
 
 
+_REJECTED_DECISIONS = frozenset(
+    {"rejected_stale_gate", "rejected_item_mismatch", "rejected_inconsistent_facts"}
+)
+
+
 def apply_content_ops_browser_receipt(
     *,
     item: Mapping[str, Any],
@@ -185,12 +282,22 @@ def apply_content_ops_browser_receipt(
     receipt: Mapping[str, Any],
     occurred_at: str,
     expected_transition: Mapping[str, Any] | None = None,
+    expected_item_id: str | None = None,
 ) -> dict[str, Any]:
     """CLI-facing wrapper: reduce a receipt and, if it proposes one, apply the
     transition through the existing, already-tested item-lifecycle event path.
 
-    A rejected-as-stale receipt or a handoff never touches item state; the
-    caller gets back the item exactly as it was.
+    A rejected receipt (stale gate, wrong item, or internally inconsistent
+    facts) or a handoff never touches item state; the caller gets back the
+    item exactly as it was.
+
+    ``expected_item_id`` should be the outer ``item_id`` from the
+    ``item-browser-request`` packet that produced ``action_request`` -- see
+    ``reduce_content_ops_browser_receipt`` for what it protects against. The
+    preferred (packet-based) CLI path always supplies it; only a caller using
+    a bare/hand-built ``action_request`` goes without this specific check
+    (the unconditional gate_id-derivation check inside the reducer still
+    applies for external_write/credential_use regardless).
 
     ``expected_transition`` should be the ``expected_transition`` sidecar from
     the ``item-browser-request`` packet that produced ``action_request`` --
@@ -219,7 +326,10 @@ def apply_content_ops_browser_receipt(
     # tolerated forever on every subsequent call.
     item = require_content_ops_item(item)
     decision = reduce_content_ops_browser_receipt(
-        item=item, action_request=action_request, receipt=receipt
+        item=item,
+        action_request=action_request,
+        receipt=receipt,
+        expected_item_id=expected_item_id,
     )
     base = {
         "schema_version": CONTENT_OPS_BROWSER_RECEIPT_PACKET_SCHEMA_VERSION,
@@ -229,7 +339,7 @@ def apply_content_ops_browser_receipt(
     if "blocker" in decision:
         base["blocker"] = decision["blocker"]
 
-    if decision["decision"] == "rejected_stale_gate":
+    if decision["decision"] in _REJECTED_DECISIONS:
         return {
             **base,
             "ok": False,

--- a/loopx/capabilities/content_ops/computer_use_reducer.py
+++ b/loopx/capabilities/content_ops/computer_use_reducer.py
@@ -1,0 +1,274 @@
+"""content-ops's capability-local reducer for computer_use_runtime_v0 receipts.
+
+Per the protocol, the reducer is deliberately not specified by the contract
+itself -- it is capability-local, combining a receipt with the action request
+that carried the current gate binding, plus domain policy that only
+content-ops knows. This module never writes LoopX state directly: it returns
+a *proposed* content-ops item-lifecycle event (or no event at all), and the
+caller applies it through the existing, already-tested
+``apply_content_ops_item_event`` -- the same optimistic-concurrency path used
+by every other content-ops writer.
+
+Gate identity note: ``gate_binding.revision`` is bound to the item's
+``approval_sequence`` counter (loopx/capabilities/content_ops/item_lifecycle.py),
+not to the item's content ``revision``. The two are independent: content
+``revision`` only changes on ``revise``, but ``approval_sequence`` advances on
+every ``approve`` -- including a re-approval that follows a ``revoke_approval``
+with no content change in between. Reusing content ``revision`` for gate
+staleness would let a revoked-then-reapproved gate collide with the revoked
+one whenever the content itself never changed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Mapping
+from typing import Any, Literal
+
+from .computer_use_provider import (
+    check_action_request_shape,
+    check_receipt_matches_request,
+    check_receipt_shape,
+)
+from .item_lifecycle import apply_content_ops_item_event, project_content_ops_item
+from .schemas import CONTENT_OPS_BROWSER_RECEIPT_PACKET_SCHEMA_VERSION
+
+_EVENT_ID_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+ReducerDecision = Literal[
+    "propose_submit_review",
+    "confirmed_external_write_attempted",
+    "handoff_blocked",
+    "rejected_stale_gate",
+]
+
+
+def reduce_content_ops_browser_receipt(
+    *,
+    item: Mapping[str, Any],
+    action_request: Mapping[str, Any],
+    receipt: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Turn one computer_use_receipt_v0 into a proposed content-ops transition.
+
+    Returns a dict with ``decision``, ``reason``, and either
+    ``proposed_event`` (to be applied via ``apply_content_ops_item_event``)
+    or ``blocker`` (a human-facing report; no state change is proposed).
+    """
+
+    check_action_request_shape(action_request)
+    check_receipt_shape(receipt)
+    check_receipt_matches_request(receipt, action_request)
+
+    gate_binding = action_request.get("gate_binding")
+    if gate_binding is not None:
+        current_approval_sequence = int(item["approval_sequence"])
+        requested_revision = int(gate_binding["revision"])
+        if requested_revision != current_approval_sequence:
+            return {
+                "decision": "rejected_stale_gate",
+                "reason": (
+                    f"action_request gate_binding.revision={requested_revision} does not "
+                    f"match the item's current approval_sequence={current_approval_sequence}; "
+                    "the approval this request was authorized under has since been revoked "
+                    "and/or replaced"
+                ),
+                "proposed_event": None,
+            }
+
+    stop_reason = receipt["stop_reason"]
+
+    if stop_reason == "blocked_by_unknown_modal":
+        return {
+            "decision": "handoff_blocked",
+            "reason": (
+                "provider reported an unrecognized modal and stopped rather than "
+                "clicking through it; hand off to a human"
+            ),
+            "proposed_event": None,
+            "blocker": {
+                "item_id": item["item_id"],
+                "attempted_action_unit": receipt["attempted_action_unit"],
+                "evidence_handle": receipt["evidence"]["handle_kind"],
+                "session_reference": receipt["session_reference"],
+            },
+        }
+
+    if stop_reason == "failed":
+        return {
+            "decision": "handoff_blocked",
+            "reason": "provider could not reach the target screen",
+            "proposed_event": None,
+            "blocker": {
+                "item_id": item["item_id"],
+                "attempted_action_unit": receipt["attempted_action_unit"],
+                "evidence_handle": receipt["evidence"]["handle_kind"],
+                "session_reference": receipt["session_reference"],
+            },
+        }
+
+    if stop_reason == "stopped_at_gate":
+        return {
+            "decision": "propose_submit_review",
+            "reason": "provider stopped at the final submit control as instructed",
+            "proposed_event": {
+                "action": "submit_review",
+                "expected_state": item["state"],
+                "expected_revision": item["revision"],
+                "payload": {},
+            },
+        }
+
+    if stop_reason == "completed":
+        if action_request.get("effect_class") != "external_write":
+            raise ValueError(
+                "a 'completed' receipt for a request whose effect_class is not "
+                "external_write is out of contract for this reducer"
+            )
+        return {
+            "decision": "confirmed_external_write_attempted",
+            "reason": (
+                "provider reports the approved write completed; recording a durable "
+                "public_url/receipt_ref is content-ops's existing readback-verified "
+                "delivery flow, not something a compact CUA receipt can carry -- "
+                "the receipt schema has no field for it"
+            ),
+            "proposed_event": None,
+        }
+
+    raise ValueError(f"unsupported receipt.stop_reason {stop_reason!r}")
+
+
+def _event_id_from_idempotency_key(idempotency_key: str) -> str:
+    """content-ops item events require an opaque token id; a receipt's
+    idempotency_key is a looser 1-200 char string with no such constraint.
+    Reuse it directly when it already fits, otherwise derive a stable token
+    so the same idempotency_key always maps to the same event_id and a
+    provider retry lands on content-ops's existing idempotent-replay path."""
+
+    if _EVENT_ID_TOKEN_RE.fullmatch(idempotency_key):
+        return idempotency_key
+    digest = hashlib.sha256(idempotency_key.encode("utf-8")).hexdigest()
+    return f"cua_receipt_{digest}"
+
+
+def apply_content_ops_browser_receipt(
+    *,
+    item: Mapping[str, Any],
+    action_request: Mapping[str, Any],
+    receipt: Mapping[str, Any],
+    occurred_at: str,
+    expected_transition: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """CLI-facing wrapper: reduce a receipt and, if it proposes one, apply the
+    transition through the existing, already-tested item-lifecycle event path.
+
+    A rejected-as-stale receipt or a handoff never touches item state; the
+    caller gets back the item exactly as it was.
+
+    ``expected_transition`` should be the ``expected_transition`` sidecar from
+    the ``item-browser-request`` packet that produced ``action_request`` --
+    i.e. the item's state/revision *at request-build time*, not whatever the
+    item's state happens to be right now. Passing it makes a receipt replay
+    safe even after the item has already moved on: the same
+    idempotency_key always builds the exact same event body, so
+    ``apply_content_ops_item_event``'s own digest-based idempotent-replay
+    check (not a bespoke one here) is what recognizes the retry and no-ops it.
+
+    Without it (a caller that hand-built ``action_request`` without going
+    through ``item-browser-request``), expected_state/expected_revision are
+    read from ``item`` fresh on every call. That is only replay-safe if the
+    caller keeps re-submitting the *same, unrefreshed* item snapshot on every
+    retry (safe by determinism, not by the idempotent-replay path); a caller
+    that refreshes the item between retries will get a clear
+    "reused with different content" error rather than a silently wrong
+    result -- see test_bare_action_request_retry_against_a_refreshed_item_is_rejected_not_silently_wrong.
+    """
+
+    decision = reduce_content_ops_browser_receipt(
+        item=item, action_request=action_request, receipt=receipt
+    )
+    base = {
+        "schema_version": CONTENT_OPS_BROWSER_RECEIPT_PACKET_SCHEMA_VERSION,
+        "decision": decision["decision"],
+        "reason": decision["reason"],
+    }
+    if "blocker" in decision:
+        base["blocker"] = decision["blocker"]
+
+    if decision["decision"] == "rejected_stale_gate":
+        return {
+            **base,
+            "ok": False,
+            "item": dict(item),
+            "projection": project_content_ops_item(item),
+        }
+
+    if decision["proposed_event"] is None:
+        return {
+            **base,
+            "ok": True,
+            "item": dict(item),
+            "projection": project_content_ops_item(item),
+        }
+
+    proposed_event = dict(decision["proposed_event"])
+    if expected_transition is not None:
+        proposed_event["expected_state"] = expected_transition["expected_state"]
+        proposed_event["expected_revision"] = expected_transition["expected_revision"]
+
+    event = {
+        "event_id": _event_id_from_idempotency_key(str(receipt["idempotency_key"])),
+        "occurred_at": occurred_at,
+        **proposed_event,
+    }
+    transition_packet = apply_content_ops_item_event(item, event)
+    return {
+        **base,
+        "ok": True,
+        "item": transition_packet["item"],
+        "projection": transition_packet["projection"],
+        "transition_receipt": transition_packet["receipt"],
+    }
+
+
+def render_content_ops_browser_receipt_markdown(packet: Mapping[str, Any]) -> str:
+    raw_projection = packet.get("projection")
+    projection: Mapping[str, Any] = raw_projection if isinstance(raw_projection, Mapping) else {}
+    lines = [
+        "# LoopX Content-Ops Browser Receipt",
+        "",
+        f"- ok: `{packet.get('ok')}`",
+        f"- decision: `{packet.get('decision')}`",
+        f"- reason: {packet.get('reason')}",
+        f"- item_id: `{projection.get('item_id')}`",
+        f"- state: `{projection.get('state')}`",
+    ]
+    raw_blocker = packet.get("blocker")
+    blocker: Mapping[str, Any] | None = raw_blocker if isinstance(raw_blocker, Mapping) else None
+    if blocker:
+        lines.extend(
+            [
+                "",
+                "## Blocker",
+                "",
+                f"- attempted_action_unit: `{blocker.get('attempted_action_unit')}`",
+                f"- evidence_handle: `{blocker.get('evidence_handle')}`",
+            ]
+        )
+    raw_transition_receipt = packet.get("transition_receipt")
+    transition_receipt: Mapping[str, Any] | None = (
+        raw_transition_receipt if isinstance(raw_transition_receipt, Mapping) else None
+    )
+    if transition_receipt:
+        lines.extend(
+            [
+                "",
+                "## Transition",
+                "",
+                f"- transition_status: `{transition_receipt.get('status')}`",
+                f"- transition: `{transition_receipt.get('from_state')} -> {transition_receipt.get('to_state')}`",
+            ]
+        )
+    return "\n".join(lines) + "\n"

--- a/loopx/capabilities/content_ops/item_lifecycle.py
+++ b/loopx/capabilities/content_ops/item_lifecycle.py
@@ -56,6 +56,7 @@ _ITEM_KEYS = {
     "created_at",
     "updated_at",
     "autopublish_allowed",
+    "approval_sequence",
 }
 
 
@@ -299,6 +300,16 @@ def _require_item(item: Mapping[str, Any]) -> dict[str, Any]:
     revision = candidate.get("revision")
     if isinstance(revision, bool) or not isinstance(revision, int) or revision < 1:
         raise ValueError("revision must be a positive integer")
+    approval_sequence = candidate.get("approval_sequence")
+    if (
+        isinstance(approval_sequence, bool)
+        or not isinstance(approval_sequence, int)
+        or approval_sequence < 0
+    ):
+        raise ValueError("approval_sequence must be a non-negative integer")
+    approval = candidate.get("approval")
+    if isinstance(approval, Mapping) and approval_sequence < 1:
+        raise ValueError("approval_sequence must be positive while approval is present")
     _digest(candidate.get("content_digest"), "content_digest")
     _token(candidate.get("content_ref"), "content_ref")
     _source_refs(candidate.get("source_refs"))
@@ -357,6 +368,7 @@ def build_content_ops_item(
         "content_digest": _digest(content_digest, "content_digest"),
         "content_ref": _token(content_ref, "content_ref"),
         "source_refs": _source_refs(source_refs),
+        "approval_sequence": 0,
         "approval": None,
         "delivery_intent": None,
         "delivery_receipt": None,
@@ -537,6 +549,7 @@ def _transition(item: dict[str, Any], event: Mapping[str, Any]) -> None:
         ):
             raise ValueError("valid_from must not be after valid_until")
         item["approval"] = approval
+        item["approval_sequence"] = int(item["approval_sequence"]) + 1
         item["state"] = "approved"
         return
 
@@ -721,6 +734,7 @@ def project_content_ops_item(item: Mapping[str, Any]) -> dict[str, Any]:
         "channel": current["channel"],
         "state": state,
         "revision": current["revision"],
+        "approval_sequence": current["approval_sequence"],
         "approval_present": current.get("approval") is not None,
         "delivery_intent_present": current.get("delivery_intent") is not None,
         "published_url": delivery.get("public_url"),

--- a/loopx/capabilities/content_ops/item_lifecycle.py
+++ b/loopx/capabilities/content_ops/item_lifecycle.py
@@ -284,7 +284,15 @@ def _validate_effect_records(item: Mapping[str, Any]) -> None:
             raise ValueError("readback_receipt content_digest does not match item")
 
 
-def _require_item(item: Mapping[str, Any]) -> dict[str, Any]:
+def require_content_ops_item(item: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate and normalize a raw content_ops_item_v0 mapping into a fresh,
+    fully-populated dict -- never mutates ``item`` in place. Every reader of
+    a caller-supplied item mapping (inside this module or elsewhere in
+    content-ops, e.g. computer_use_provider.py / computer_use_reducer.py)
+    must call this first and use its *return value*, not the raw input --
+    that's what makes old content_ops_item_v0 data (missing fields added
+    after it was written, e.g. approval_sequence) still safely readable."""
+
     candidate = copy.deepcopy(dict(item))
     extra = sorted(set(candidate) - _ITEM_KEYS)
     if extra:
@@ -300,6 +308,23 @@ def _require_item(item: Mapping[str, Any]) -> dict[str, Any]:
     revision = candidate.get("revision")
     if isinstance(revision, bool) or not isinstance(revision, int) or revision < 1:
         raise ValueError("revision must be a positive integer")
+    if "approval_sequence" not in candidate:
+        # Backward compatibility: a persisted content_ops_item_v0 written before
+        # approval_sequence existed has no way to report its true historical
+        # approval count, and any approval it may already carry predates CUA
+        # gate semantics entirely. Default to 0 unconditionally rather than
+        # inferring 1 for a currently-approved item -- the migration point
+        # only needs future approvals to increment correctly, not a
+        # retroactively "correct" historical value. A consequence, not a bug:
+        # a pre-existing approved item cannot issue a CUA action request until
+        # a fresh approve event establishes CUA-aware gate authority for it
+        # (see build_content_ops_browser_action_request's own
+        # approval_sequence < 1 check, which is where that requirement
+        # belongs -- this generic item-lifecycle validation does not need to
+        # know anything about CUA). schema_version stays content_ops_item_v0
+        # on purpose: this is additive normalization at the read boundary,
+        # not a breaking schema change.
+        candidate["approval_sequence"] = 0
     approval_sequence = candidate.get("approval_sequence")
     if (
         isinstance(approval_sequence, bool)
@@ -307,9 +332,6 @@ def _require_item(item: Mapping[str, Any]) -> dict[str, Any]:
         or approval_sequence < 0
     ):
         raise ValueError("approval_sequence must be a non-negative integer")
-    approval = candidate.get("approval")
-    if isinstance(approval, Mapping) and approval_sequence < 1:
-        raise ValueError("approval_sequence must be positive while approval is present")
     _digest(candidate.get("content_digest"), "content_digest")
     _token(candidate.get("content_ref"), "content_ref")
     _source_refs(candidate.get("source_refs"))
@@ -380,13 +402,13 @@ def build_content_ops_item(
         "updated_at": timestamp,
         "autopublish_allowed": False,
     }
-    return _require_item(item)
+    return require_content_ops_item(item)
 
 
 def validate_content_ops_item(item: Mapping[str, Any]) -> dict[str, Any]:
     errors: list[str] = []
     try:
-        _require_item(item)
+        require_content_ops_item(item)
     except ValueError as exc:
         errors.append(str(exc))
     return {
@@ -700,7 +722,7 @@ def _transition(item: dict[str, Any], event: Mapping[str, Any]) -> None:
 
 
 def project_content_ops_item(item: Mapping[str, Any]) -> dict[str, Any]:
-    current = _require_item(item)
+    current = require_content_ops_item(item)
     state = str(current["state"])
     next_actions = {
         "captured": ["revise", "submit_review", "skip", "supersede"],
@@ -762,7 +784,7 @@ def build_content_ops_queue_projection(
     timestamp = _timestamp(generated_at, "generated_at")
     if not items:
         raise ValueError("content queue requires at least one item")
-    normalized = [_require_item(item) for item in items]
+    normalized = [require_content_ops_item(item) for item in items]
     item_projections = [project_content_ops_item(item) for item in normalized]
 
     counts: dict[str, int] = {}
@@ -870,7 +892,7 @@ def build_content_ops_item_packet(**kwargs: Any) -> dict[str, Any]:
 def apply_content_ops_item_event(
     item: Mapping[str, Any], event: Mapping[str, Any]
 ) -> dict[str, Any]:
-    current = _require_item(item)
+    current = require_content_ops_item(item)
     normalized_event, event_digest = _require_event(event)
     last_event = current.get("last_event")
     if (
@@ -911,7 +933,7 @@ def apply_content_ops_item_event(
         "event_digest": event_digest,
         "action": normalized_event["action"],
     }
-    _require_item(updated)
+    require_content_ops_item(updated)
     return {
         "ok": True,
         "schema_version": CONTENT_OPS_ITEM_TRANSITION_PACKET_SCHEMA_VERSION,

--- a/loopx/capabilities/content_ops/schemas.py
+++ b/loopx/capabilities/content_ops/schemas.py
@@ -49,3 +49,10 @@ PUBLISH_GATE_SCHEMA_VERSION = "publish_gate_v0"
 MATERIAL_MEMORY_SCHEMA_VERSION = "material_memory_v0"
 CONNECTOR_TRIAL_SCHEMA_VERSION = "connector_trial_v0"
 CONTENT_OPS_VALIDATION_SCHEMA_VERSION = "content_ops_surface_validation_v0"
+
+CONTENT_OPS_BROWSER_ACTION_REQUEST_PACKET_SCHEMA_VERSION = (
+    "content_ops_browser_action_request_packet_v0"
+)
+CONTENT_OPS_BROWSER_RECEIPT_PACKET_SCHEMA_VERSION = (
+    "content_ops_browser_receipt_packet_v0"
+)

--- a/tests/test_content_ops_computer_use.py
+++ b/tests/test_content_ops_computer_use.py
@@ -29,6 +29,7 @@ from loopx.capabilities.content_ops.computer_use_provider import (
     ContentOpsCuaContractViolation,
     FakeComputerUseProvider,
     build_content_ops_browser_action_request,
+    build_content_ops_browser_action_request_packet,
     check_action_request_shape,
     check_receipt_shape,
 )
@@ -95,6 +96,36 @@ def _approve(item: dict[str, Any], *, event_id: str, approval_ref: str) -> dict[
     return packet["item"]
 
 
+def _declare_delivery_intent(
+    item: dict[str, Any],
+    *,
+    event_id: str,
+    provider_id: str = "computer_use_runtime",
+    occurred_at: str = "2026-08-18T09:12:00+00:00",
+) -> dict[str, Any]:
+    """Directly construct a delivery_ready item via the existing
+    set_delivery_intent action -- bypassing build_content_ops_browser_action_request_packet's
+    own orchestration, for tests that want to exercise a lower-level function
+    in isolation without also exercising the packet's declare-then-build
+    behavior itself."""
+
+    packet = apply_content_ops_item_event(
+        item,
+        {
+            "event_id": event_id,
+            "action": "set_delivery_intent",
+            "expected_state": item["state"],
+            "expected_revision": item["revision"],
+            "occurred_at": occurred_at,
+            "payload": {
+                "provider_id": provider_id,
+                "effect_kind": item["approval"]["effect_kind"],
+            },
+        },
+    )
+    return packet["item"]
+
+
 def test_draft_action_request_has_no_gate_binding_and_passes_real_validator() -> None:
     item = _item()
     request = build_content_ops_browser_action_request(
@@ -105,8 +136,20 @@ def test_draft_action_request_has_no_gate_binding_and_passes_real_validator() ->
     real_validate_action_request(request)
 
 
-def test_approved_action_request_binds_gate_to_approval_sequence() -> None:
+def test_approved_item_has_no_request_until_delivery_intent_is_declared() -> None:
+    """build_content_ops_browser_action_request is pure and never writes --
+    an "approved" item alone is not enough to get a request; delivery intent
+    must already be durably declared (delivery_ready) first."""
+
     item = _apply_review_and_approve()
+    assert item["state"] == "approved"
+    with pytest.raises(ContentOpsCuaContractViolation, match="delivery intent must be durably declared"):
+        build_content_ops_browser_action_request(item=item, goal_id=GOAL_ID, todo_id=TODO_ID)
+
+
+def test_delivery_ready_action_request_binds_gate_to_approval_sequence() -> None:
+    item = _declare_delivery_intent(_apply_review_and_approve(), event_id="event-declare-1")
+    assert item["state"] == "delivery_ready"
     assert item["approval_sequence"] == 1
     request = build_content_ops_browser_action_request(
         item=item, goal_id=GOAL_ID, todo_id=TODO_ID
@@ -122,32 +165,98 @@ def test_approved_action_request_binds_gate_to_approval_sequence() -> None:
         real_validate_action_request(request, known_gate_revision=2)
 
 
+def test_packet_declares_delivery_intent_before_returning_a_request_and_refuses_on_retry() -> None:
+    """The actual durable-fence behavior item-browser-request relies on:
+    build_content_ops_browser_action_request_packet durably transitions an
+    approved item to delivery_ready *before* ever returning a request a
+    provider could act on, and refuses outright on a second call for the
+    same (now already-delivery_ready) item -- fail closed on retry, not a
+    silent rebuild of an identical request."""
+
+    item = _apply_review_and_approve()
+    assert item["state"] == "approved"
+
+    packet = build_content_ops_browser_action_request_packet(
+        item=item, goal_id=GOAL_ID, todo_id=TODO_ID, occurred_at="2026-08-18T09:12:00+00:00"
+    )
+    assert packet["ok"] is True
+    assert packet["item"]["state"] == "delivery_ready"
+    assert packet["action_request"]["gate_binding"]["revision"] == 1
+    assert packet["expected_transition"] == {
+        "expected_state": "delivery_ready",
+        "expected_revision": item["revision"],
+    }
+
+    # "restart": call it again using the item exactly as the first call
+    # returned it (what a caller must persist before invoking a provider).
+    with pytest.raises(ContentOpsCuaContractViolation, match="already declared"):
+        build_content_ops_browser_action_request_packet(
+            item=packet["item"],
+            goal_id=GOAL_ID,
+            todo_id=TODO_ID,
+            occurred_at="2026-08-18T09:13:00+00:00",
+        )
+
+
+def test_provider_already_executed_but_never_landed_must_not_execute_again_after_restart() -> None:
+    """The exact scenario from review: the provider has already executed
+    (we hold a completed receipt) but nothing about that was ever applied
+    anywhere (simulating a crash/lost receipt before any commit). After
+    "restart" -- a fresh call with only the durably-persisted item in hand --
+    a second external-write request must not be producible."""
+
+    item = _apply_review_and_approve()
+    packet = build_content_ops_browser_action_request_packet(
+        item=item, goal_id=GOAL_ID, todo_id=TODO_ID, occurred_at="2026-08-18T09:12:00+00:00"
+    )
+    provider = FakeComputerUseProvider(
+        {"screen_reachable": True, "submit_click_permitted": True},
+        session_reference="fake_crash_session",
+    )
+    receipt = provider.attempt(packet["action_request"])
+    assert receipt["stop_reason"] == "completed"
+    # Simulate the crash: the receipt is never processed by item-browser-receipt
+    # at all. "Restart" means only packet["item"] (already persisted) survives.
+
+    with pytest.raises(ContentOpsCuaContractViolation, match="already declared"):
+        build_content_ops_browser_action_request_packet(
+            item=packet["item"],
+            goal_id=GOAL_ID,
+            todo_id=TODO_ID,
+            occurred_at="2026-08-18T09:20:00+00:00",
+        )
+
+
 def test_legacy_approved_item_needs_a_fresh_approve_before_it_can_drive_cua() -> None:
     """A content_ops_item_v0 approved before approval_sequence existed --
     e.g. handed straight from a JSON file to item-browser-request, which
     does no validation of its own -- must fail closed rather than crash or
     silently issue a request at an inferred-nothing gate revision. Only a
     fresh approve event (establishing real, CUA-aware gate identity) unlocks
-    it. Also exercises build_content_ops_browser_action_request normalizing
-    its raw `item` input via require_content_ops_item before reading any
-    field, the same defensive pattern the rest of content-ops already uses."""
+    it. set_delivery_intent itself does not care about approval_sequence (it
+    only checks approval/effect_kind), so a legacy item CAN still reach
+    delivery_ready with approval_sequence=0 -- the check that matters lives
+    in build_content_ops_browser_action_request's delivery_ready branch,
+    which is where this must actually fail."""
 
     legacy_approved = dict(_apply_review_and_approve())
     del legacy_approved["approval_sequence"]
 
+    legacy_delivery_ready = _declare_delivery_intent(legacy_approved, event_id="event-declare-legacy")
+    assert legacy_delivery_ready["approval_sequence"] == 0
     with pytest.raises(ContentOpsCuaContractViolation, match="positive approval_sequence"):
         build_content_ops_browser_action_request(
-            item=legacy_approved, goal_id=GOAL_ID, todo_id=TODO_ID
+            item=legacy_delivery_ready, goal_id=GOAL_ID, todo_id=TODO_ID
         )
 
-    # approve only runs from review_ready, so re-establishing gate authority
-    # for an already-approved legacy item goes through revoke_approval first.
+    # Re-establishing real, CUA-aware gate authority goes through
+    # revoke_approval (allowed from delivery_ready) then a fresh approve.
     back_to_review = apply_content_ops_item_event(
-        legacy_approved,
+        legacy_delivery_ready,
         {
             "event_id": "event-revoke-legacy",
             "action": "revoke_approval",
-            "expected_state": "approved",
+            "expected_state": "delivery_ready",
             "expected_revision": 1,
             "occurred_at": "2026-08-18T09:11:00+00:00",
             "payload": {"reason": "re-establish CUA-aware gate authority"},
@@ -157,8 +266,9 @@ def test_legacy_approved_item_needs_a_fresh_approve_before_it_can_drive_cua() ->
         back_to_review, event_id="event-approve-legacy", approval_ref="decision:legacy-1"
     )
     assert reapproved["approval_sequence"] == 1
+    redeclared = _declare_delivery_intent(reapproved, event_id="event-declare-legacy-2")
     request = build_content_ops_browser_action_request(
-        item=reapproved, goal_id=GOAL_ID, todo_id=TODO_ID
+        item=redeclared, goal_id=GOAL_ID, todo_id=TODO_ID
     )
     assert request["gate_binding"]["revision"] == 1
 
@@ -281,12 +391,13 @@ def test_unreachable_screen_hands_off_without_any_state_transition() -> None:
 
 
 def test_stale_gate_revision_after_revoke_and_reapprove_is_rejected() -> None:
-    item = _apply_review_and_approve()
+    item = _declare_delivery_intent(_apply_review_and_approve(), event_id="event-declare-stale")
     stale_request = build_content_ops_browser_action_request(
         item=item, goal_id=GOAL_ID, todo_id=TODO_ID
     )
     assert stale_request["gate_binding"]["revision"] == 1
 
+    # revoke_approval is allowed from delivery_ready too.
     revoked = apply_content_ops_item_event(
         item,
         {
@@ -332,7 +443,7 @@ def test_reducer_normalizes_a_legacy_item_before_the_gate_staleness_check() -> N
     validation of its own -- would crash with a raw KeyError instead of
     being handled by the same, already-tested logic as everywhere else."""
 
-    item = _apply_review_and_approve()
+    item = _declare_delivery_intent(_apply_review_and_approve(), event_id="event-declare-legacy-recv")
     request = build_content_ops_browser_action_request(
         item=item, goal_id=GOAL_ID, todo_id=TODO_ID
     )
@@ -368,16 +479,16 @@ def test_reducer_normalizes_a_legacy_item_before_the_gate_staleness_check() -> N
     assert packet["item"]["approval_sequence"] == 0
 
 
-def test_completed_write_consumes_the_gate_via_set_delivery_intent() -> None:
-    """A completed external_write receipt must not leave the item in
-    "approved" -- that would let the exact same gate issue a second,
-    identical external_write request and be attempted again. The reducer
-    consumes the gate by proposing set_delivery_intent (approved ->
-    delivery_ready), which needs no fabricated public_url/receipt_ref --
-    recording the real delivery still stays with content-ops's existing
-    readback tooling, not this reducer."""
+def test_completed_write_under_current_gate_is_confirmed_with_no_further_transition() -> None:
+    """The durable fence against a duplicate external effect now happens
+    *before* this receipt is ever processed (delivery intent was already
+    declared -- see test_packet_declares_delivery_intent_before_returning_a_request_and_refuses_on_retry
+    and test_provider_already_executed_but_never_landed_must_not_execute_again_after_restart).
+    So a completed receipt for the current, live gate proposes nothing
+    further: record_delivery (with a real public_url) stays content-ops's
+    existing readback-verified delivery flow, not this reducer's job."""
 
-    item = _apply_review_and_approve()
+    item = _declare_delivery_intent(_apply_review_and_approve(), event_id="event-declare-completed")
     request = build_content_ops_browser_action_request(
         item=item, goal_id=GOAL_ID, todo_id=TODO_ID
     )
@@ -391,53 +502,57 @@ def test_completed_write_consumes_the_gate_via_set_delivery_intent() -> None:
 
     decision = reduce_content_ops_browser_receipt(item=item, action_request=request, receipt=receipt)
     assert decision["decision"] == "confirmed_external_write_attempted"
-    assert decision["proposed_event"] == {
-        "action": "set_delivery_intent",
-        "expected_state": "approved",
-        "expected_revision": item["revision"],
-        "payload": {
-            "provider_id": receipt["provider_id"],
-            "effect_kind": item["approval"]["effect_kind"],
-        },
-    }
+    assert decision["proposed_event"] is None
 
-    event = {
-        "event_id": receipt["idempotency_key"],
-        "occurred_at": "2026-08-18T09:20:00+00:00",
-        **decision["proposed_event"],
-    }
-    packet = apply_content_ops_item_event(item, event)
-    assert packet["item"]["state"] == "delivery_ready"
+    packet = apply_content_ops_browser_receipt(
+        item=item, action_request=request, receipt=receipt, occurred_at="2026-08-18T09:20:00+00:00"
+    )
+    assert packet["ok"] is True
+    assert packet["item"]["state"] == "delivery_ready", "unchanged: nothing left to apply"
 
 
-def test_completed_write_gate_cannot_be_reissued_after_it_is_consumed() -> None:
-    """The negative case: once a completed receipt has consumed the gate
-    (approved -> delivery_ready), building a new browser action request for
-    the same item must fail rather than silently producing an identical
-    external_write request that could be attempted a second time."""
+def test_completed_receipt_for_an_item_that_moved_past_delivery_ready_is_stale() -> None:
+    """A stale replay of an old completed receipt after the item has since
+    moved on through other means (e.g. an already-completed record_delivery
+    via content-ops's existing tooling) must not be silently accepted just
+    because the gate revision still numerically matches."""
 
-    item = _apply_review_and_approve()
+    item = _declare_delivery_intent(_apply_review_and_approve(), event_id="event-declare-moved-on")
     request = build_content_ops_browser_action_request(
         item=item, goal_id=GOAL_ID, todo_id=TODO_ID
     )
     provider = FakeComputerUseProvider(
         {"screen_reachable": True, "submit_click_permitted": True},
-        session_reference="fake_session_5",
+        session_reference="fake_session_moved_on",
     )
     receipt = provider.attempt(request)
-    decision = reduce_content_ops_browser_receipt(item=item, action_request=request, receipt=receipt)
-    event = {
-        "event_id": receipt["idempotency_key"],
-        "occurred_at": "2026-08-18T09:20:00+00:00",
-        **decision["proposed_event"],
-    }
-    delivery_ready_item = apply_content_ops_item_event(item, event)["item"]
-    assert delivery_ready_item["state"] == "delivery_ready"
 
-    with pytest.raises(ContentOpsCuaContractViolation, match="already attempted"):
-        build_content_ops_browser_action_request(
-            item=delivery_ready_item, goal_id=GOAL_ID, todo_id=TODO_ID
-        )
+    published = apply_content_ops_item_event(
+        item,
+        {
+            "event_id": "event-record-delivery",
+            "action": "record_delivery",
+            "expected_state": "delivery_ready",
+            "expected_revision": item["revision"],
+            "occurred_at": "2026-08-18T09:25:00+00:00",
+            "payload": {
+                "provider_id": "computer_use_runtime",
+                "effect_kind": item["approval"]["effect_kind"],
+                "content_digest": item["content_digest"],
+                "public_url": "https://x.com/example/status/1",
+                "receipt_ref": "receipt:x-1",
+            },
+        },
+    )["item"]
+    assert published["state"] == "published"
+    assert published["approval_sequence"] == item["approval_sequence"], (
+        "record_delivery does not touch approval_sequence, so the stale receipt's "
+        "gate revision still numerically matches -- state must still be checked"
+    )
+
+    decision = reduce_content_ops_browser_receipt(item=published, action_request=request, receipt=receipt)
+    assert decision["decision"] == "rejected_stale_gate"
+    assert decision["proposed_event"] is None
 
 
 def test_provider_authored_writeback_field_is_rejected_by_both_validators() -> None:
@@ -474,6 +589,180 @@ def test_smuggled_credential_in_evidence_is_rejected_by_both_validators() -> Non
         real_validate_receipt(receipt)
 
 
+def _approved_delivery_ready_item(item_id: str, *, declare_event_id: str) -> dict[str, Any]:
+    item = build_content_ops_item(
+        item_id=item_id,
+        item_kind="post",
+        channel="x",
+        content_digest=DIGEST_V1,
+        content_ref=f"draft:{item_id}",
+        created_at="2026-08-18T09:00:00+00:00",
+    )
+    item = apply_content_ops_item_event(
+        item,
+        {
+            "event_id": "event-review",
+            "action": "submit_review",
+            "expected_state": "captured",
+            "expected_revision": 1,
+            "occurred_at": "2026-08-18T09:05:00+00:00",
+            "payload": {},
+        },
+    )["item"]
+    item = _approve(item, event_id="event-approve", approval_ref=f"decision:{item_id}")
+    return _declare_delivery_intent(item, event_id=declare_event_id)
+
+
+def test_receipt_built_for_a_different_item_cannot_advance_this_one() -> None:
+    """The concrete A-on-B reproduction from review: two different items,
+    both delivery_ready with the same approval_sequence (a plausible,
+    ordinary coincidence -- both are simply on their first approval). A's
+    request/receipt must not be able to advance B, even though the gate
+    revision numbers line up, because gate_binding.gate_id already encodes
+    which item a gate belongs to and the reducer must check it."""
+
+    item_a = _approved_delivery_ready_item("cua-item-a", declare_event_id="event-declare-a")
+    item_b = _approved_delivery_ready_item("cua-item-b", declare_event_id="event-declare-b")
+    assert item_a["approval_sequence"] == item_b["approval_sequence"] == 1
+
+    request_for_a = build_content_ops_browser_action_request(
+        item=item_a, goal_id=GOAL_ID, todo_id=TODO_ID
+    )
+    provider = FakeComputerUseProvider(
+        {"screen_reachable": True, "submit_click_permitted": True},
+        session_reference="fake_session_a",
+    )
+    receipt_for_a = provider.attempt(request_for_a)
+
+    # Unconditional protection: reduce_content_ops_browser_receipt itself
+    # derives the expected gate_id from item_b and refuses, with no
+    # expected_item_id needed -- this is what protects a bare/hand-built
+    # request path too.
+    decision = reduce_content_ops_browser_receipt(
+        item=item_b, action_request=request_for_a, receipt=receipt_for_a
+    )
+    assert decision["decision"] == "rejected_item_mismatch"
+    assert decision["proposed_event"] is None
+
+    packet = apply_content_ops_browser_receipt(
+        item=item_b,
+        action_request=request_for_a,
+        receipt=receipt_for_a,
+        occurred_at="2026-08-18T09:20:00+00:00",
+    )
+    assert packet["ok"] is False
+    assert packet["decision"] == "rejected_item_mismatch"
+    assert packet["item"]["state"] == "delivery_ready", "B must be completely untouched"
+
+    # The packet-path check (expected_item_id) catches the same thing even
+    # for a request with no gate_binding at all (the draft path).
+    draft_item_a = _item()
+    draft_request_a = build_content_ops_browser_action_request(
+        item=draft_item_a, goal_id=GOAL_ID, todo_id=TODO_ID
+    )
+    draft_provider = FakeComputerUseProvider(
+        {"screen_reachable": True}, session_reference="fake_session_draft_a"
+    )
+    draft_receipt_a = draft_provider.attempt(draft_request_a)
+    draft_item_b = build_content_ops_item(
+        item_id="cua-draft-item-b",
+        item_kind="post",
+        channel="x",
+        content_digest=DIGEST_V1,
+        content_ref="draft:cua-draft-item-b",
+        created_at="2026-08-18T09:00:00+00:00",
+    )
+    mismatch = apply_content_ops_browser_receipt(
+        item=draft_item_b,
+        action_request=draft_request_a,
+        receipt=draft_receipt_a,
+        occurred_at="2026-08-18T09:20:00+00:00",
+        expected_item_id=draft_item_a["item_id"],
+    )
+    assert mismatch["ok"] is False
+    assert mismatch["decision"] == "rejected_item_mismatch"
+    assert mismatch["item"]["state"] == "captured", "B must be completely untouched"
+
+
+def test_gated_write_with_non_open_status_is_rejected_by_both_shape_check_and_provider() -> None:
+    """The protocol's Failure And Recovery obligation -- a provider must
+    refuse an action request whose effect_class requires a gate that is not
+    open -- was previously only prose; a merely well-formed 'closed' or
+    'pending' status enum value could still reach and be attempted by a
+    provider."""
+
+    item = _approved_delivery_ready_item("cua-item-gate-status", declare_event_id="event-declare-status")
+    request = build_content_ops_browser_action_request(item=item, goal_id=GOAL_ID, todo_id=TODO_ID)
+    assert request["gate_binding"]["status"] == "open"
+
+    for bad_status in ("closed", "pending"):
+        tampered = dict(request, gate_binding=dict(request["gate_binding"], status=bad_status))
+        with pytest.raises(ContentOpsCuaContractViolation, match="requires gate_binding.status='open'"):
+            check_action_request_shape(tampered)
+        with pytest.raises(RealContractViolation):
+            real_validate_action_request(tampered)
+
+        provider = FakeComputerUseProvider(
+            {"screen_reachable": True, "submit_click_permitted": True},
+            session_reference=f"fake_session_gate_{bad_status}",
+        )
+        with pytest.raises(ContentOpsCuaContractViolation, match="requires gate_binding.status='open'"):
+            provider.attempt(tampered)
+
+
+def test_completed_receipt_with_final_action_not_clicked_is_rejected() -> None:
+    """The exact reproduction from review: shape validation alone does not
+    catch an internally contradictory receipt (completed, but
+    final_action_clicked=false) -- that domain judgment belongs to the
+    reducer, not the wire schema."""
+
+    item = _approved_delivery_ready_item("cua-item-facts-1", declare_event_id="event-declare-facts-1")
+    request = build_content_ops_browser_action_request(item=item, goal_id=GOAL_ID, todo_id=TODO_ID)
+    provider = FakeComputerUseProvider(
+        {"screen_reachable": True, "submit_click_permitted": True},
+        session_reference="fake_session_facts_1",
+    )
+    receipt = provider.attempt(request)
+    assert receipt["stop_reason"] == "completed"
+    contradictory = dict(
+        receipt,
+        observed_facts=dict(receipt["observed_facts"], final_action_clicked=False),
+    )
+    # Shape check alone (field types only) does not catch this.
+    check_receipt_shape(contradictory)
+
+    decision = reduce_content_ops_browser_receipt(
+        item=item, action_request=request, receipt=contradictory
+    )
+    assert decision["decision"] == "rejected_inconsistent_facts"
+    assert decision["proposed_event"] is None
+
+
+def test_stopped_at_gate_receipt_with_final_action_clicked_is_rejected() -> None:
+    """A different stop_reason's invariant: stopped_at_gate claims the final
+    submit control was *not* clicked -- a receipt claiming both cannot be
+    trusted."""
+
+    item = _item()
+    request = build_content_ops_browser_action_request(item=item, goal_id=GOAL_ID, todo_id=TODO_ID)
+    provider = FakeComputerUseProvider(
+        {"screen_reachable": True}, session_reference="fake_session_facts_2"
+    )
+    receipt = provider.attempt(request)
+    assert receipt["stop_reason"] == "stopped_at_gate"
+    contradictory = dict(
+        receipt,
+        observed_facts=dict(receipt["observed_facts"], final_action_clicked=True),
+    )
+    check_receipt_shape(contradictory)
+
+    decision = reduce_content_ops_browser_receipt(
+        item=item, action_request=request, receipt=contradictory
+    )
+    assert decision["decision"] == "rejected_inconsistent_facts"
+    assert decision["proposed_event"] is None
+
+
 def _run_cli(args: list[str], *, cwd: Path) -> dict[str, Any]:
     result = subprocess.run(
         [sys.executable, "-m", "loopx.cli", "--format", "json", "content-ops", *args],
@@ -499,6 +788,8 @@ def test_cli_drives_the_full_draft_until_gate_round_trip(tmp_path: Path) -> None
             GOAL_ID,
             "--todo-id",
             TODO_ID,
+            "--occurred-at",
+            "2026-08-18T09:04:00+00:00",
         ],
         cwd=REPO_ROOT,
     )
@@ -509,6 +800,7 @@ def test_cli_drives_the_full_draft_until_gate_round_trip(tmp_path: Path) -> None
         "expected_state": "captured",
         "expected_revision": 1,
     }
+    assert request_packet["item"]["state"] == "captured", "draft path never writes"
 
     # Write the *full* item-browser-request packet (not just the inner
     # action_request) -- this is the preferred path, since it carries

--- a/tests/test_content_ops_computer_use.py
+++ b/tests/test_content_ops_computer_use.py
@@ -122,6 +122,47 @@ def test_approved_action_request_binds_gate_to_approval_sequence() -> None:
         real_validate_action_request(request, known_gate_revision=2)
 
 
+def test_legacy_approved_item_needs_a_fresh_approve_before_it_can_drive_cua() -> None:
+    """A content_ops_item_v0 approved before approval_sequence existed --
+    e.g. handed straight from a JSON file to item-browser-request, which
+    does no validation of its own -- must fail closed rather than crash or
+    silently issue a request at an inferred-nothing gate revision. Only a
+    fresh approve event (establishing real, CUA-aware gate identity) unlocks
+    it. Also exercises build_content_ops_browser_action_request normalizing
+    its raw `item` input via require_content_ops_item before reading any
+    field, the same defensive pattern the rest of content-ops already uses."""
+
+    legacy_approved = dict(_apply_review_and_approve())
+    del legacy_approved["approval_sequence"]
+
+    with pytest.raises(ContentOpsCuaContractViolation, match="positive approval_sequence"):
+        build_content_ops_browser_action_request(
+            item=legacy_approved, goal_id=GOAL_ID, todo_id=TODO_ID
+        )
+
+    # approve only runs from review_ready, so re-establishing gate authority
+    # for an already-approved legacy item goes through revoke_approval first.
+    back_to_review = apply_content_ops_item_event(
+        legacy_approved,
+        {
+            "event_id": "event-revoke-legacy",
+            "action": "revoke_approval",
+            "expected_state": "approved",
+            "expected_revision": 1,
+            "occurred_at": "2026-08-18T09:11:00+00:00",
+            "payload": {"reason": "re-establish CUA-aware gate authority"},
+        },
+    )["item"]
+    reapproved = _approve(
+        back_to_review, event_id="event-approve-legacy", approval_ref="decision:legacy-1"
+    )
+    assert reapproved["approval_sequence"] == 1
+    request = build_content_ops_browser_action_request(
+        item=reapproved, goal_id=GOAL_ID, todo_id=TODO_ID
+    )
+    assert request["gate_binding"]["revision"] == 1
+
+
 def _apply_review_and_approve() -> dict[str, Any]:
     item = apply_content_ops_item_event(
         _item(),
@@ -281,7 +322,61 @@ def test_stale_gate_revision_after_revoke_and_reapprove_is_rejected() -> None:
         real_validate_action_request(stale_request, known_gate_revision=2)
 
 
-def test_completed_write_under_current_gate_is_confirmed_but_not_written_back() -> None:
+def test_reducer_normalizes_a_legacy_item_before_the_gate_staleness_check() -> None:
+    """The receipt-side counterpart to
+    test_legacy_approved_item_needs_a_fresh_approve_before_it_can_drive_cua:
+    reduce_content_ops_browser_receipt must normalize its raw `item` input
+    (require_content_ops_item) before reading approval_sequence for the gate
+    staleness check, or a legacy item missing that field -- e.g. handed
+    straight from a JSON file to item-browser-receipt, which does no
+    validation of its own -- would crash with a raw KeyError instead of
+    being handled by the same, already-tested logic as everywhere else."""
+
+    item = _apply_review_and_approve()
+    request = build_content_ops_browser_action_request(
+        item=item, goal_id=GOAL_ID, todo_id=TODO_ID
+    )
+    provider = FakeComputerUseProvider(
+        {"screen_reachable": True, "submit_click_permitted": True},
+        session_reference="fake_session_legacy_receipt",
+    )
+    receipt = provider.attempt(request)
+
+    legacy_item = dict(item)
+    del legacy_item["approval_sequence"]
+
+    decision = reduce_content_ops_browser_receipt(
+        item=legacy_item, action_request=request, receipt=receipt
+    )
+    # require_content_ops_item defaults the missing field to 0, which for
+    # this *already-approved* legacy item does not match the live request's
+    # gate_binding.revision=1 -- so this is correctly rejected as stale, not
+    # silently accepted and not a crash.
+    assert decision["decision"] == "rejected_stale_gate"
+
+    packet = apply_content_ops_browser_receipt(
+        item=legacy_item,
+        action_request=request,
+        receipt=receipt,
+        occurred_at="2026-08-18T09:20:00+00:00",
+    )
+    assert packet["ok"] is False
+    assert packet["decision"] == "rejected_stale_gate"
+    # The echoed-back item is the normalized form (approval_sequence now
+    # present), not the raw legacy input -- the same "heal on every
+    # read/write" behavior apply_content_ops_item_event already has.
+    assert packet["item"]["approval_sequence"] == 0
+
+
+def test_completed_write_consumes_the_gate_via_set_delivery_intent() -> None:
+    """A completed external_write receipt must not leave the item in
+    "approved" -- that would let the exact same gate issue a second,
+    identical external_write request and be attempted again. The reducer
+    consumes the gate by proposing set_delivery_intent (approved ->
+    delivery_ready), which needs no fabricated public_url/receipt_ref --
+    recording the real delivery still stays with content-ops's existing
+    readback tooling, not this reducer."""
+
     item = _apply_review_and_approve()
     request = build_content_ops_browser_action_request(
         item=item, goal_id=GOAL_ID, todo_id=TODO_ID
@@ -296,11 +391,53 @@ def test_completed_write_under_current_gate_is_confirmed_but_not_written_back() 
 
     decision = reduce_content_ops_browser_receipt(item=item, action_request=request, receipt=receipt)
     assert decision["decision"] == "confirmed_external_write_attempted"
-    assert decision["proposed_event"] is None, (
-        "record_delivery requires a real public_url/receipt_ref that the closed "
-        "computer_use_receipt_v0 schema has no field to carry; recording delivery "
-        "stays with content-ops's existing readback tooling, not this reducer"
+    assert decision["proposed_event"] == {
+        "action": "set_delivery_intent",
+        "expected_state": "approved",
+        "expected_revision": item["revision"],
+        "payload": {
+            "provider_id": receipt["provider_id"],
+            "effect_kind": item["approval"]["effect_kind"],
+        },
+    }
+
+    event = {
+        "event_id": receipt["idempotency_key"],
+        "occurred_at": "2026-08-18T09:20:00+00:00",
+        **decision["proposed_event"],
+    }
+    packet = apply_content_ops_item_event(item, event)
+    assert packet["item"]["state"] == "delivery_ready"
+
+
+def test_completed_write_gate_cannot_be_reissued_after_it_is_consumed() -> None:
+    """The negative case: once a completed receipt has consumed the gate
+    (approved -> delivery_ready), building a new browser action request for
+    the same item must fail rather than silently producing an identical
+    external_write request that could be attempted a second time."""
+
+    item = _apply_review_and_approve()
+    request = build_content_ops_browser_action_request(
+        item=item, goal_id=GOAL_ID, todo_id=TODO_ID
     )
+    provider = FakeComputerUseProvider(
+        {"screen_reachable": True, "submit_click_permitted": True},
+        session_reference="fake_session_5",
+    )
+    receipt = provider.attempt(request)
+    decision = reduce_content_ops_browser_receipt(item=item, action_request=request, receipt=receipt)
+    event = {
+        "event_id": receipt["idempotency_key"],
+        "occurred_at": "2026-08-18T09:20:00+00:00",
+        **decision["proposed_event"],
+    }
+    delivery_ready_item = apply_content_ops_item_event(item, event)["item"]
+    assert delivery_ready_item["state"] == "delivery_ready"
+
+    with pytest.raises(ContentOpsCuaContractViolation, match="already attempted"):
+        build_content_ops_browser_action_request(
+            item=delivery_ready_item, goal_id=GOAL_ID, todo_id=TODO_ID
+        )
 
 
 def test_provider_authored_writeback_field_is_rejected_by_both_validators() -> None:

--- a/tests/test_content_ops_computer_use.py
+++ b/tests/test_content_ops_computer_use.py
@@ -1,0 +1,497 @@
+"""Tests for content-ops's computer_use_runtime_v0 vertical slice.
+
+These tests do two jobs at once:
+
+1. Exercise content-ops's own stdlib-only provider/reducer boundary
+   (loopx/capabilities/content_ops/computer_use_provider.py and
+   computer_use_reducer.py), which is all that ships in a plain
+   ``pip install loopx``.
+2. Cross-validate everything that boundary builds or accepts against the
+   authoritative jsonschema-based validator in
+   scripts/computer_use_runtime_contract_validator.py (a ``[test]``-extras
+   dev tool, not shipped). This is how the full computer_use_runtime_v0
+   contract stays a real, exercised call site even though production code
+   deliberately does not import jsonschema -- see the module docstring in
+   computer_use_provider.py for why.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from loopx.capabilities.content_ops.computer_use_provider import (
+    ContentOpsCuaContractViolation,
+    FakeComputerUseProvider,
+    build_content_ops_browser_action_request,
+    check_action_request_shape,
+    check_receipt_shape,
+)
+from loopx.capabilities.content_ops.computer_use_reducer import (
+    apply_content_ops_browser_receipt,
+    reduce_content_ops_browser_receipt,
+)
+from loopx.capabilities.content_ops.item_lifecycle import (
+    apply_content_ops_item_event,
+    build_content_ops_item,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from computer_use_runtime_contract_validator import (  # noqa: E402
+    ContractViolation as RealContractViolation,
+)
+from computer_use_runtime_contract_validator import (  # noqa: E402
+    validate_action_request as real_validate_action_request,
+)
+from computer_use_runtime_contract_validator import (  # noqa: E402
+    validate_receipt as real_validate_receipt,
+)
+from computer_use_runtime_contract_validator import (  # noqa: E402
+    validate_receipt_matches_request as real_validate_receipt_matches_request,
+)
+
+GOAL_ID = "loopx-content-ops-cua-showcase"
+TODO_ID = "todo_content_ops_cua_showcase"
+DIGEST_V1 = "sha256:" + "1" * 64
+
+
+def _item() -> dict[str, Any]:
+    return build_content_ops_item(
+        item_id="cua-showcase-post",
+        item_kind="post",
+        channel="x",
+        content_digest=DIGEST_V1,
+        content_ref="draft:cua-showcase-post",
+        created_at="2026-08-18T09:00:00+00:00",
+    )
+
+
+def _approve(item: dict[str, Any], *, event_id: str, approval_ref: str) -> dict[str, Any]:
+    packet = apply_content_ops_item_event(
+        item,
+        {
+            "event_id": event_id,
+            "action": "approve",
+            "expected_state": item["state"],
+            "expected_revision": item["revision"],
+            "occurred_at": "2026-08-18T09:10:00+00:00",
+            "payload": {
+                "approval_ref": approval_ref,
+                "revision": item["revision"],
+                "content_digest": item["content_digest"],
+                "effect_kind": "publish",
+            },
+        },
+    )
+    return packet["item"]
+
+
+def test_draft_action_request_has_no_gate_binding_and_passes_real_validator() -> None:
+    item = _item()
+    request = build_content_ops_browser_action_request(
+        item=item, goal_id=GOAL_ID, todo_id=TODO_ID
+    )
+    assert request["effect_class"] == "draft"
+    assert "gate_binding" not in request
+    real_validate_action_request(request)
+
+
+def test_approved_action_request_binds_gate_to_approval_sequence() -> None:
+    item = _apply_review_and_approve()
+    assert item["approval_sequence"] == 1
+    request = build_content_ops_browser_action_request(
+        item=item, goal_id=GOAL_ID, todo_id=TODO_ID
+    )
+    assert request["effect_class"] == "external_write"
+    assert request["gate_binding"] == {
+        "gate_id": "gate_cua-showcase-post_publish",
+        "revision": 1,
+        "status": "open",
+    }
+    real_validate_action_request(request, known_gate_revision=1)
+    with pytest.raises(RealContractViolation, match="stale"):
+        real_validate_action_request(request, known_gate_revision=2)
+
+
+def _apply_review_and_approve() -> dict[str, Any]:
+    item = apply_content_ops_item_event(
+        _item(),
+        {
+            "event_id": "event-review",
+            "action": "submit_review",
+            "expected_state": "captured",
+            "expected_revision": 1,
+            "occurred_at": "2026-08-18T09:05:00+00:00",
+            "payload": {},
+        },
+    )["item"]
+    return _approve(item, event_id="event-approve-1", approval_ref="decision:cua-showcase-1")
+
+
+def test_external_write_action_request_without_gate_binding_is_rejected() -> None:
+    forged = {
+        "schema_version": "computer_use_action_request_v0",
+        "goal_id": GOAL_ID,
+        "todo_id": TODO_ID,
+        "provider_id": "computer_use_runtime",
+        "action_unit": "content_ops_publish_after_approved_gate",
+        "effect_class": "external_write",
+        "write_scope": {
+            "allowed_actions": ["click the approved submit control"],
+            "forbidden_effect_classes": ["credential_use"],
+        },
+        "stop_condition": "stop if the live gate revision has changed since approval",
+        "validation_target": "submit is clicked only under the exact approved gate revision",
+    }
+    with pytest.raises(ContentOpsCuaContractViolation, match="requires a gate_binding"):
+        check_action_request_shape(forged)
+    with pytest.raises(RealContractViolation):
+        real_validate_action_request(forged)
+
+
+def test_draft_round_trip_stops_at_gate_and_proposes_submit_review() -> None:
+    item = _item()
+    request = build_content_ops_browser_action_request(
+        item=item, goal_id=GOAL_ID, todo_id=TODO_ID
+    )
+    provider = FakeComputerUseProvider(
+        {"screen_reachable": True, "unexpected_modal_present": False},
+        session_reference="fake_session_1",
+    )
+    receipt = provider.attempt(request)
+    assert receipt["stop_reason"] == "stopped_at_gate"
+    real_validate_receipt(receipt)
+    real_validate_receipt_matches_request(receipt, request)
+
+    decision = reduce_content_ops_browser_receipt(item=item, action_request=request, receipt=receipt)
+    assert decision["decision"] == "propose_submit_review"
+    event = {
+        "event_id": receipt["idempotency_key"],
+        "expected_state": item["state"],
+        "expected_revision": item["revision"],
+        "occurred_at": "2026-08-18T09:05:00+00:00",
+        **decision["proposed_event"],
+    }
+    packet = apply_content_ops_item_event(item, event)
+    assert packet["item"]["state"] == "review_ready"
+    assert packet["receipt"]["status"] == "applied"
+
+    # Idempotent replay: the same provider retry (same idempotency_key/event_id)
+    # must not be double-processed.
+    replay = apply_content_ops_item_event(packet["item"], event)
+    assert replay["receipt"]["status"] == "already_applied"
+    assert replay["item"]["state"] == "review_ready"
+
+
+def test_unknown_modal_hands_off_without_any_state_transition() -> None:
+    item = _item()
+    request = build_content_ops_browser_action_request(
+        item=item, goal_id=GOAL_ID, todo_id=TODO_ID
+    )
+    provider = FakeComputerUseProvider(
+        {"screen_reachable": True, "unexpected_modal_present": True},
+        session_reference="fake_session_2",
+    )
+    receipt = provider.attempt(request)
+    assert receipt["stop_reason"] == "blocked_by_unknown_modal"
+    real_validate_receipt(receipt)
+
+    decision = reduce_content_ops_browser_receipt(item=item, action_request=request, receipt=receipt)
+    assert decision["decision"] == "handoff_blocked"
+    assert decision["proposed_event"] is None
+    assert decision["blocker"]["item_id"] == item["item_id"]
+    # The reducer proposed nothing; the item itself must be untouched.
+    assert item["state"] == "captured"
+
+
+def test_unreachable_screen_hands_off_without_any_state_transition() -> None:
+    """The other stop_reason that means 'hand off, don't guess' --
+    stop_reason=failed, when the provider can't even reach the target
+    screen. Exercises FakeComputerUseProvider's screen_reachable=False branch
+    and the reducer's `failed` branch, neither of which any other test in
+    this file drives."""
+
+    item = _item()
+    request = build_content_ops_browser_action_request(
+        item=item, goal_id=GOAL_ID, todo_id=TODO_ID
+    )
+    provider = FakeComputerUseProvider(
+        {"screen_reachable": False}, session_reference="fake_session_unreachable"
+    )
+    receipt = provider.attempt(request)
+    assert receipt["stop_reason"] == "failed"
+    assert receipt["observed_facts"]["screen_reached"] is False
+    real_validate_receipt(receipt)
+
+    decision = reduce_content_ops_browser_receipt(item=item, action_request=request, receipt=receipt)
+    assert decision["decision"] == "handoff_blocked"
+    assert decision["proposed_event"] is None
+    assert decision["blocker"]["item_id"] == item["item_id"]
+    assert item["state"] == "captured"
+
+
+def test_stale_gate_revision_after_revoke_and_reapprove_is_rejected() -> None:
+    item = _apply_review_and_approve()
+    stale_request = build_content_ops_browser_action_request(
+        item=item, goal_id=GOAL_ID, todo_id=TODO_ID
+    )
+    assert stale_request["gate_binding"]["revision"] == 1
+
+    revoked = apply_content_ops_item_event(
+        item,
+        {
+            "event_id": "event-revoke",
+            "action": "revoke_approval",
+            "expected_state": item["state"],
+            "expected_revision": item["revision"],
+            "occurred_at": "2026-08-18T09:15:00+00:00",
+            "payload": {"reason": "owner wants another look before publish"},
+        },
+    )["item"]
+    reapproved = _approve(revoked, event_id="event-approve-2", approval_ref="decision:cua-showcase-2")
+    assert reapproved["approval_sequence"] == 2, (
+        "content revision never changed across revoke/reapprove, so only the "
+        "dedicated approval_sequence counter distinguishes the two approvals"
+    )
+
+    provider = FakeComputerUseProvider(
+        {"screen_reachable": True, "submit_click_permitted": True},
+        session_reference="fake_session_3",
+    )
+    stale_receipt = provider.attempt(stale_request)
+    assert stale_receipt["stop_reason"] == "completed"
+    real_validate_receipt(stale_receipt)
+
+    decision = reduce_content_ops_browser_receipt(
+        item=reapproved, action_request=stale_request, receipt=stale_receipt
+    )
+    assert decision["decision"] == "rejected_stale_gate"
+    assert decision["proposed_event"] is None
+
+    with pytest.raises(RealContractViolation, match="stale"):
+        real_validate_action_request(stale_request, known_gate_revision=2)
+
+
+def test_completed_write_under_current_gate_is_confirmed_but_not_written_back() -> None:
+    item = _apply_review_and_approve()
+    request = build_content_ops_browser_action_request(
+        item=item, goal_id=GOAL_ID, todo_id=TODO_ID
+    )
+    provider = FakeComputerUseProvider(
+        {"screen_reachable": True, "submit_click_permitted": True},
+        session_reference="fake_session_4",
+    )
+    receipt = provider.attempt(request)
+    real_validate_receipt(receipt)
+    real_validate_action_request(request, known_gate_revision=item["approval_sequence"])
+
+    decision = reduce_content_ops_browser_receipt(item=item, action_request=request, receipt=receipt)
+    assert decision["decision"] == "confirmed_external_write_attempted"
+    assert decision["proposed_event"] is None, (
+        "record_delivery requires a real public_url/receipt_ref that the closed "
+        "computer_use_receipt_v0 schema has no field to carry; recording delivery "
+        "stays with content-ops's existing readback tooling, not this reducer"
+    )
+
+
+def test_provider_authored_writeback_field_is_rejected_by_both_validators() -> None:
+    item = _item()
+    request = build_content_ops_browser_action_request(
+        item=item, goal_id=GOAL_ID, todo_id=TODO_ID
+    )
+    provider = FakeComputerUseProvider(
+        {"screen_reachable": True}, session_reference="fake_session_5"
+    )
+    receipt = dict(provider.attempt(request))
+    receipt["complete_todo"] = True
+
+    with pytest.raises(ContentOpsCuaContractViolation, match="writeback"):
+        check_receipt_shape(receipt)
+    with pytest.raises(RealContractViolation):
+        real_validate_receipt(receipt)
+
+
+def test_smuggled_credential_in_evidence_is_rejected_by_both_validators() -> None:
+    item = _item()
+    request = build_content_ops_browser_action_request(
+        item=item, goal_id=GOAL_ID, todo_id=TODO_ID
+    )
+    provider = FakeComputerUseProvider(
+        {"screen_reachable": True}, session_reference="fake_session_6"
+    )
+    receipt = dict(provider.attempt(request))
+    receipt = dict(receipt, evidence=dict(receipt["evidence"], handle_kind="session_id=abc123"))
+
+    with pytest.raises(ContentOpsCuaContractViolation, match="smuggles"):
+        check_receipt_shape(receipt)
+    with pytest.raises(RealContractViolation):
+        real_validate_receipt(receipt)
+
+
+def _run_cli(args: list[str], *, cwd: Path) -> dict[str, Any]:
+    result = subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "--format", "json", "content-ops", *args],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert result.returncode in (0, 1), result.stderr
+    return json.loads(result.stdout)
+
+
+def test_cli_drives_the_full_draft_until_gate_round_trip(tmp_path: Path) -> None:
+    item_path = tmp_path / "item.json"
+    item_path.write_text(json.dumps(_item()), encoding="utf-8")
+
+    request_packet = _run_cli(
+        [
+            "item-browser-request",
+            "--item-json",
+            str(item_path),
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            TODO_ID,
+        ],
+        cwd=REPO_ROOT,
+    )
+    assert request_packet["ok"] is True
+    assert request_packet["action_request"]["effect_class"] == "draft"
+    assert "gate_binding" not in request_packet["action_request"]
+    assert request_packet["expected_transition"] == {
+        "expected_state": "captured",
+        "expected_revision": 1,
+    }
+
+    # Write the *full* item-browser-request packet (not just the inner
+    # action_request) -- this is the preferred path, since it carries
+    # expected_transition and stays replay-safe even after the item moves on.
+    request_path = tmp_path / "request.json"
+    request_path.write_text(json.dumps(request_packet), encoding="utf-8")
+
+    provider = FakeComputerUseProvider(
+        {"screen_reachable": True}, session_reference="fake_cli_session"
+    )
+    receipt = provider.attempt(request_packet["action_request"])
+    receipt_path = tmp_path / "receipt.json"
+    receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+
+    receipt_packet = _run_cli(
+        [
+            "item-browser-receipt",
+            "--item-json",
+            str(item_path),
+            "--action-request-json",
+            str(request_path),
+            "--receipt-json",
+            str(receipt_path),
+            "--occurred-at",
+            "2026-08-18T09:05:00+00:00",
+        ],
+        cwd=REPO_ROOT,
+    )
+    assert receipt_packet["ok"] is True
+    assert receipt_packet["decision"] == "propose_submit_review"
+    assert receipt_packet["item"]["state"] == "review_ready"
+    assert receipt_packet["transition_receipt"]["status"] == "applied"
+
+    # Same receipt replayed (same idempotency_key -> same event_id) must be a
+    # no-op -- using the *same* occurred_at as the first call, since a retry
+    # of the same physical attempt is one event happening once, not two.
+    updated_item_path = tmp_path / "item_after.json"
+    updated_item_path.write_text(
+        json.dumps(receipt_packet["item"]), encoding="utf-8"
+    )
+    replay_packet = _run_cli(
+        [
+            "item-browser-receipt",
+            "--item-json",
+            str(updated_item_path),
+            "--action-request-json",
+            str(request_path),
+            "--receipt-json",
+            str(receipt_path),
+            "--occurred-at",
+            "2026-08-18T09:05:00+00:00",
+        ],
+        cwd=REPO_ROOT,
+    )
+    assert replay_packet["ok"] is True
+    assert replay_packet["transition_receipt"]["status"] == "already_applied"
+    assert replay_packet["item"]["state"] == "review_ready"
+
+
+def test_bare_action_request_retry_with_unrefreshed_item_is_safe_by_determinism() -> None:
+    """A caller that never went through item-browser-request (no
+    expected_transition sidecar) can still retry safely -- but only by
+    resubmitting the exact same, unrefreshed item snapshot every time, which
+    converges to the same result deterministically rather than by hitting
+    apply_content_ops_item_event's idempotent-replay path."""
+
+    item = _item()
+    request = build_content_ops_browser_action_request(
+        item=item, goal_id=GOAL_ID, todo_id=TODO_ID
+    )
+    provider = FakeComputerUseProvider(
+        {"screen_reachable": True}, session_reference="fake_bare_session"
+    )
+    receipt = provider.attempt(request)
+
+    first = apply_content_ops_browser_receipt(
+        item=item, action_request=request, receipt=receipt, occurred_at="2026-08-18T09:05:00+00:00"
+    )
+    assert first["ok"] is True
+    assert first["transition_receipt"]["status"] == "applied"
+    assert first["item"]["state"] == "review_ready"
+
+    # Retry against the *same* pre-transition `item` (not first["item"]), with
+    # the *same* occurred_at -- a retry describes one event happening once,
+    # not a second, later one.
+    second = apply_content_ops_browser_receipt(
+        item=item, action_request=request, receipt=receipt, occurred_at="2026-08-18T09:05:00+00:00"
+    )
+    assert second["ok"] is True
+    assert second["item"]["state"] == "review_ready"
+    assert second["item"] == first["item"], "deterministic reapplication converges to the same item"
+
+
+def test_bare_action_request_retry_against_a_refreshed_item_is_rejected_not_silently_wrong() -> None:
+    """The unsafe half of the bare-path characterization: a caller that DOES
+    refresh --item-json between retries (a very plausible, arguably more
+    correct calling pattern) does not get silent corruption or a spurious
+    already_applied -- it gets a loud, clear error, because
+    reduce_content_ops_browser_receipt recomputes expected_state from
+    whatever item it is given, and that recomputed value now disagrees with
+    what was actually stored in last_event."""
+
+    item = _item()
+    request = build_content_ops_browser_action_request(
+        item=item, goal_id=GOAL_ID, todo_id=TODO_ID
+    )
+    provider = FakeComputerUseProvider(
+        {"screen_reachable": True}, session_reference="fake_bare_session_2"
+    )
+    receipt = provider.attempt(request)
+
+    first = apply_content_ops_browser_receipt(
+        item=item, action_request=request, receipt=receipt, occurred_at="2026-08-18T09:05:00+00:00"
+    )
+    assert first["item"]["state"] == "review_ready"
+
+    with pytest.raises(ValueError, match="different content"):
+        apply_content_ops_browser_receipt(
+            item=first["item"],  # refreshed: already reflects the first transition
+            action_request=request,
+            receipt=receipt,
+            occurred_at="2026-08-18T09:06:00+00:00",
+        )

--- a/tests/test_content_ops_item_lifecycle.py
+++ b/tests/test_content_ops_item_lifecycle.py
@@ -280,6 +280,110 @@ def test_approval_sequence_advances_on_reapproval_even_without_content_revise() 
     )
 
 
+def _drop_approval_sequence(item: dict[str, object]) -> dict[str, object]:
+    """Simulate a content_ops_item_v0 persisted before approval_sequence
+    existed -- schema_version never changed, so old data has no such field."""
+
+    legacy = dict(item)
+    del legacy["approval_sequence"]
+    return legacy
+
+
+def test_legacy_v0_items_without_approval_sequence_are_still_readable() -> None:
+    captured_legacy = _drop_approval_sequence(_item())
+    assert validate_content_ops_item(captured_legacy)["ok"] is True
+    assert project_content_ops_item(captured_legacy)["state"] == "captured"
+
+    review_ready_legacy = _drop_approval_sequence(
+        _apply(_item(), "event-review", "submit_review")
+    )
+    assert validate_content_ops_item(review_ready_legacy)["ok"] is True
+
+    approved = _apply(
+        _apply(_item(), "event-review", "submit_review"),
+        "event-approve",
+        "approve",
+        {
+            "approval_ref": "decision:partner-launch-reply-v1",
+            "revision": 1,
+            "content_digest": DIGEST_V1,
+            "effect_kind": "reply",
+        },
+    )
+    approved_legacy = _drop_approval_sequence(approved)
+    # Unconditional default: 0, even though this item is currently approved.
+    # No attempt to retroactively infer "1" for an approval that predates the
+    # counter -- reading/validating must not crash, but that's all this
+    # normalization promises. (Whether such an item can drive a CUA request
+    # at approval_sequence=0 is computer_use_provider's own concern, tested
+    # in tests/test_content_ops_computer_use.py, not this generic read path.)
+    assert validate_content_ops_item(approved_legacy)["ok"] is True
+    assert project_content_ops_item(approved_legacy)["approval_sequence"] == 0
+
+    # A fresh approve event (even a plain re-approval, no revoke needed here
+    # since it's still "approved") establishes the first real, CUA-aware
+    # gate identity: 0 -> 1, same as any brand-new item's first approval.
+    revoked = apply_content_ops_item_event(
+        approved_legacy,
+        {
+            "event_id": "event-revoke",
+            "action": "revoke_approval",
+            "expected_state": "approved",
+            "expected_revision": 1,
+            "occurred_at": "2026-08-03T09:20:00+08:00",
+            "payload": {"reason": "owner wants another look"},
+        },
+    )["item"]
+    reapproved = _apply(
+        revoked,
+        "event-approve-2",
+        "approve",
+        {
+            "approval_ref": "decision:partner-launch-reply-v1-b",
+            "revision": 1,
+            "content_digest": DIGEST_V1,
+            "effect_kind": "reply",
+        },
+    )
+    assert reapproved["approval_sequence"] == 1
+
+
+def test_cli_item_transition_reads_a_legacy_item_missing_approval_sequence(
+    tmp_path: Path,
+) -> None:
+    legacy_item_path = tmp_path / "legacy_item.json"
+    legacy_item_path.write_text(
+        json.dumps(_drop_approval_sequence(_item())), encoding="utf-8"
+    )
+    event_path = tmp_path / "event.json"
+    event_path.write_text(
+        json.dumps(_event(_item(), "event-review", "submit_review")),
+        encoding="utf-8",
+    )
+    transition = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "content-ops",
+            "item-transition",
+            "--item-json",
+            str(legacy_item_path),
+            "--event-json",
+            str(event_path),
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    transitioned = json.loads(transition.stdout)
+    assert transitioned["projection"]["state"] == "review_ready"
+    assert transitioned["item"]["approval_sequence"] == 0
+
+
 def test_superseded_item_is_terminal_and_links_successor() -> None:
     item = _apply(
         _item(),

--- a/tests/test_content_ops_item_lifecycle.py
+++ b/tests/test_content_ops_item_lifecycle.py
@@ -210,6 +210,76 @@ def test_event_retry_is_idempotent_and_changed_reuse_is_rejected() -> None:
         apply_content_ops_item_event(first["item"], changed)
 
 
+def test_mismatched_expected_state_or_revision_is_rejected_not_silently_applied() -> None:
+    """A fresh event_id (not a replay) whose expected_state/expected_revision
+    disagree with the item's real current values must fail loudly. Nothing
+    else in this codebase re-derives expected_state/expected_revision for the
+    caller -- callers (including content-ops's CUA reducer) rely entirely on
+    this rejection to catch a stale or forged optimistic-concurrency claim."""
+
+    item = _apply(_item(), "event-review", "submit_review")
+
+    with pytest.raises(ValueError, match="expected_state does not match"):
+        apply_content_ops_item_event(
+            item,
+            _event(item, "event-wrong-state", "approve", {}, "2026-08-03T09:07:00+08:00")
+            | {"expected_state": "captured"},
+        )
+
+    with pytest.raises(ValueError, match="expected_revision does not match"):
+        apply_content_ops_item_event(
+            item,
+            _event(item, "event-wrong-revision", "approve", {}, "2026-08-03T09:07:00+08:00")
+            | {"expected_revision": item["revision"] + 1},
+        )
+
+
+def test_approval_sequence_advances_on_reapproval_even_without_content_revise() -> None:
+    item = _apply(_item(), "event-review", "submit_review")
+    assert item["approval_sequence"] == 0
+
+    item = _apply(
+        item,
+        "event-approve-1",
+        "approve",
+        {
+            "approval_ref": "decision:partner-launch-reply-v1-a",
+            "revision": 1,
+            "content_digest": DIGEST_V1,
+            "effect_kind": "reply",
+        },
+    )
+    first_gate_revision = item["approval_sequence"]
+    assert first_gate_revision == 1
+
+    item = _apply(item, "event-revoke", "revoke_approval", {"reason": "owner asked to re-check tone"})
+    assert item["state"] == "review_ready"
+    assert item["approval"] is None
+    assert item["approval_sequence"] == first_gate_revision, (
+        "approval_sequence must survive revoke so a stale in-flight action "
+        "request cannot be confused with the new approval below"
+    )
+
+    item = _apply(
+        item,
+        "event-approve-2",
+        "approve",
+        {
+            "approval_ref": "decision:partner-launch-reply-v1-b",
+            "revision": 1,
+            "content_digest": DIGEST_V1,
+            "effect_kind": "reply",
+        },
+    )
+    second_gate_revision = item["approval_sequence"]
+
+    assert second_gate_revision > first_gate_revision, (
+        "content revision (1) never changed across the revoke/reapprove cycle, "
+        "so only a dedicated approval_sequence counter -- not item.revision -- "
+        "can distinguish the revoked approval from the live one"
+    )
+
+
 def test_superseded_item_is_terminal_and_links_successor() -> None:
     item = _apply(
         _item(),


### PR DESCRIPTION
## Summary

- Vertical-slice PR (2 of 2, per maintainer guidance in #3110) for `computer_use_runtime_v0`: the first real consumer of PR1's contract, implemented inside `content-ops` for a draft-until-gate publish workflow, per the maintainer's four-layer ownership framework (Capability / CUA provider-runtime / Extension-package / Kernel).
- Adds an `approval_sequence` counter to `content_ops`'s item lifecycle (`loopx/capabilities/content_ops/item_lifecycle.py`), independent of content `revision`, so a `gate_binding` can tell a revoked-then-reapproved approval apart from the one it replaced even when the content itself never changed in between.
- Adds `loopx/capabilities/content_ops/computer_use_provider.py` and `computer_use_reducer.py`: a capability-local provider boundary and reducer that build a bounded action request from an item's live gate state, accept a receipt back, and propose (never write) a content-ops transition -- the write itself goes through the existing, already-tested `apply_content_ops_item_event`.
- Adds two narrow, outcome-named CLI commands: `content-ops item-browser-request` / `item-browser-receipt`. No new top-level `computer-use` command, and nothing added to `value-connectors`.
- Adds a hermetic showcase (`examples/content-ops-computer-use-showcase-smoke.py` + 3 fixtures) covering draft-until-gate, unknown-modal handoff, stale-gate-revision rejection after a revoke/reapprove race, and the approved-write boundary; wired into the canary planner alongside PR1's own contract smoke.
- No browser-automation dependency added. CI runs a fully hermetic `FakeComputerUseProvider`; a real host browser/CUA tool can implement the same `ComputerUseProvider` protocol without any change to `content-ops` code.

## Issue Or Task

- Relates to #3110 (this PR covers the Vertical-slice phase; PR1, #3279, covered the Contract phase and is merged)
- Contributor task ID: n/a

## Validation

- [x] `python3 -m py_compile loopx/*.py`
- [x] `loopx check --scan-root .`
- [x] Other:
  - `python3 -m pytest -q` -- full suite. Diffed this branch's failure list against the same-environment `upstream/main` baseline (56 known environment-specific failures, unrelated to content-ops/CUA, pre-dating this branch): zero new failures, only the 15 new tests added here contribute new passes. Absolute pass/fail counts vary by machine due to pre-existing subprocess-test environment sensitivity; the diff is what's being asserted here, not a universally clean run.
  - `python3 -m pytest -q -n 2 --cov=loopx --cov-fail-under=19.6` (exact CI invocation; same diff result as above, coverage gate passes)
  - `python -m ruff check tests loopx/canary loopx/control_plane loopx/domain_packs loopx/presentation` (CI's actual lint scope)
  - `python -m mypy` (CI's actual scope -- an explicit kernel-file allowlist in `pyproject.toml`; `content_ops/` is not in it, see note below)
  - `python3 examples/content-ops-computer-use-showcase-smoke.py` (`ok scenarios=draft_until_gate,unknown_modal,stale_gate_rejected,approved_write`)
  - `python3 examples/computer-use-runtime-contract-smoke.py` (PR1's own smoke, still green: `cases=12 accept=4 reject=8`)
  - `python3 examples/control_plane/control-plane-maintainability-ratchet-smoke.py` (0 magnitude regressions)
  - `python3 examples/control_plane/cli-output-budget-regression-smoke.py`

**Note on scope of static checks**: `loopx/capabilities/content_ops/*.py` (including the two new modules) is outside both CI's `ruff` invocation (`tests loopx/canary loopx/control_plane loopx/domain_packs loopx/presentation`) and `mypy`'s `[tool.mypy] files` allowlist. I ran both against the new/changed files directly anyway (clean on my own machine), but that's not enforced by CI today -- flagging this the same way PR1 flagged the `gate_binding.status=pending` alignment, so it's a maintainer decision rather than something that silently regresses unnoticed.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] Test update

## LoopX Area

- [ ] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [ ] Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
- [x] Capability or extension (providers, adapters, skills)
- [ ] Public docs or presentation surface (README, protocols, dashboard)
- [ ] Build, packaging, installer, or CI
- [ ] Host or runtime integration

## Technical Direction

- [ ] Core control-plane hardening
- [ ] Long-horizon benchmark evidence
- [ ] Operator surface and IM integration
- [ ] Shared Goal Authority and cross-host coordination
- [x] Architecture and research incubator

- Target base branch: main
- Direction tracker or promotion unit: #3110 (second of two agreed PRs; no separate tracker)

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).

---

### What changed, mapped to your ownership framework in #3110

- **Ownership placement**: the first vertical slice lives inside `content-ops` (draft-until-gate publish), not `value-connectors` -- per your correction that `value-connectors` is a compatibility facade, not a CUA owner.
- **Receipt vs. reducer vs. Kernel**: `computer_use_provider.py` only ever produces/consumes facts (a receipt never authors a writeback). `computer_use_reducer.py` is capability-local and only *proposes* a transition (`submit_review`) or a no-op handoff (unknown modal / unreachable screen / stale gate) -- it never calls `apply_content_ops_item_event` with anything the existing item-lifecycle state machine wouldn't already accept from a human-authored event. The Kernel-equivalent authority stays exactly where it already was: `apply_content_ops_item_event`'s existing optimistic-concurrency and idempotent-replay checks, unmodified except for the new `approval_sequence` field they now also track.
- **CLI is outcome-led**: no `loopx computer-use plan/receipt`, no `--connector-kind computer_use` on `value-connectors plan`. `item-browser-request`/`item-browser-receipt` are content-ops-owned and named for the outcome (advancing an item via a browser), not the mechanism.
- **`gate_binding.status=pending` alignment** (the first PR1 review leftover): resolved by construction rather than by adding a branch for it -- a bounded action request is only ever built once an item has an `approval` (`captured`/`draft` get no `gate_binding` at all, since there's nothing to gate yet); the `review_ready` state, which is the only state that would map to `pending`, never has a live write in flight, so `pending` never actually needs to appear on a real request. `content-ops` item states line up with `gate_binding.status` as: no gate before approval, `open` while approved, `closed` once published/terminal.
- **Validator has a real call site** (the second PR1 review leftover, escalated as a packaging question -- see #3110 comment thread): `content_ops`'s production code cannot import PR1's `jsonschema`-based validator (it's a `[test]`-extras-only dependency, and `scripts/`/`docs/` aren't packaged). Per your call on that thread, production code (`computer_use_provider.py`) reimplements only the safety-critical subset in the standard library, and the test suite (`tests/test_content_ops_computer_use.py`) cross-validates everything this module builds or accepts against PR1's real validator -- so the full contract is genuinely exercised, just from tests rather than the installed runtime path.
- **No abstraction before a second consumer**: `FakeComputerUseProvider` stays inside `content_ops/`, not extracted anywhere shared; `delivery_ready`/`set_delivery_intent` support is deliberately not added to the browser-action-request builder (the provider/account/time-window lock it implies is not yet cross-checked against a CUA request, and nothing exercises it); no shared CUA provider SPI.
- **`record_delivery` stays out of the CUA path entirely**: `computer_use_receipt_v0` is a closed schema with no field for a real `public_url`, so a `completed` receipt for the approved-write action is confirmed as attempted but never forced into `record_delivery` -- that step stays with `content-ops`'s existing readback-verified delivery flow.
- **Showcase proves the LoopX control plane, not a browser library**: `FakeComputerUseProvider` is a declarative stand-in driven by fixture `ui_state`, same style as your PR1 fixtures. No Playwright or browser-automation dependency added anywhere. `ComputerUseProvider` is a plain `Protocol`, so a real host browser tool can implement it without any `content-ops` code changing -- I have not yet run the two scenarios against a real host tool myself; only the hermetic Fake is exercised in this PR.
