### PR TITLE
fix(control-plane): inherit existing agent identity in unbound /loopx sessions

### DIFF
--- a/docs/book/chapters/02-session-goal-loopx.md
+++ b/docs/book/chapters/02-session-goal-loopx.md
@@ -45,7 +45,7 @@ LoopX 同时处理 Goal、Agent 和 Host，但三者回答的是不同问题：
 | 身份 | 回答的问题 | 稳定性与选择规则 |
 | --- | --- | --- |
 | `goal_id` | 正在推进哪个长期项目边界？ | 绑定 registry、Todo、Gate 和 evidence lineage；复用时选择已有的精确 id |
-| `agent_id` | 当前由哪个 peer/lane 承担工作？ | 绑定 claim、Vision、quota 与 writeback；新接入默认注册 fresh identity |
+| `agent_id` | 当前由哪个 peer/lane 承担工作？ | 绑定 claim、Vision、quota 与 writeback；只有不存在已注册 lane 或显式 `--new-peer` 时新接入才默认注册 fresh identity |
 | `host_surface` / runtime profile | 这一轮实际由哪个产品表面执行和唤醒？ | 绑定 App heartbeat、visible Goal 或其他 host loop；必须按当前运行面显式声明 |
 
 已有 Goal 可以继续复用，不代表新 session 应接管已有 Agent identity。最新 Goal-start 合同要求：

--- a/docs/book/chapters/05-connect-existing-project.md
+++ b/docs/book/chapters/05-connect-existing-project.md
@@ -195,8 +195,9 @@ Guided start 会把两个选择分开：
 1. **Goal selection**：如果项目只有一个已注册 Goal，复用它的精确 `goal_id`；如果有多个，返回
    只读 `goal_selection_gate`。从 `choices` 中选择一个精确重跑命令，在此之前不写 Todo、不注册
    Agent，也不激活 Host loop。
-2. **Agent identity**：对带任务文本的新接入，未指定 `--agent-id` 时默认要求 fresh identity。
-   已有 Agent 是 takeover choice，不是自动默认值。
+2. **Agent identity**：对带任务文本的新接入，未指定 `--agent-id` 时，只有 Goal 没有任何已注册
+   lane（或显式 `--new-peer`）才默认 fresh identity；已有已注册 lane 时，`start-goal` 会返回
+   identity gate，要求选择一个已有 lane。已有 Agent 是 takeover choice，不是自动默认值。
 
 不要根据 objective 的文字相似度选择 Goal，也不要因为 registry 中只有一个 Agent 就自动接管它。
 推荐路径是先预览、再原子注册一个新的 public-safe id：

--- a/docs/book/chapters/07-codex-cli.md
+++ b/docs/book/chapters/07-codex-cli.md
@@ -87,10 +87,11 @@ heartbeat。若 packet 报告 scheduler context 缺失，先修复 runtime profi
 
 ## 5. 保持身份与 Todo 归属
 
-新的 argument-bearing guided start 默认要求 fresh Agent identity，即使 Goal 中只有一个已注册身份。
-已有 id 只在用户明确要求 takeover 那个 peer 时复用。完成选择后，visible Goal、quota、refresh 与
-writeback 都应显式保留同一个 `--agent-id`；缺失或不匹配时应 fail closed，而不是回退到“唯一
-身份”。
+新的 argument-bearing guided start 在 Goal 已有已注册身份（哪怕只有一个）时不会默认注册 fresh
+Agent，而是返回 identity gate 要求选择其中一个 lane；只有 Goal 没有任何已注册 lane 或显式
+`--new-peer` 时才默认 fresh。已有 id 只在用户明确要求 takeover 那个 peer 时复用。完成选择后，
+visible Goal、quota、refresh 与 writeback 都应显式保留同一个 `--agent-id`；缺失或不匹配时应
+fail closed，而不是回退到“唯一身份”。
 
 Agent identity 表达 LoopX 工作 lane，不证明具体 Host。判断工作是否真的在 Codex CLI 运行，要看
 `host_surface`、runtime profile 或对应 run metadata。

--- a/docs/book/chapters/state-substrate.md
+++ b/docs/book/chapters/state-substrate.md
@@ -51,7 +51,7 @@ Todo 写入、Agent 注册和 Host activation 都不应发生。目标文本相�
 共享一部分 acceptance，都不是静默合并 Goal 的依据。
 
 还要把 Goal reuse 与 Agent takeover 分开。新 Agent 可以读取同一 Goal 的公共 frontier 和历史，
-但默认注册 fresh `agent_id`；复用已有 Agent identity 需要用户明确选择那个精确 id。这样历史
+但在无已注册 lane 时默认注册 fresh `agent_id`；复用已有 Agent identity 需要用户明确选择那个精确 id。这样历史
 lineage 能连续，执行责任却不会被新 session 冒名继承。
 
 因此，恢复模型不是：

--- a/docs/book/en/chapters/02-session-goal-loopx.md
+++ b/docs/book/en/chapters/02-session-goal-loopx.md
@@ -47,7 +47,7 @@ LoopX coordinates Goals, Agents, and Hosts, but each identity answers a differen
 | Identity | Question it answers | Stability and selection rule |
 | --- | --- | --- |
 | `goal_id` | Which long-running project boundary are we advancing? | Binds registry state, Todos, Gates, and evidence lineage; reuse requires the exact existing id |
-| `agent_id` | Which peer or work lane owns the current responsibility? | Binds claims, Vision, quota, and writeback; new onboarding defaults to a fresh identity |
+| `agent_id` | Which peer or work lane owns the current responsibility? | Binds claims, Vision, quota, and writeback; new onboarding defaults to a fresh identity only when no registered lane exists or `--new-peer` is explicit |
 | `host_surface` / runtime profile | Which product surface executes and wakes this turn? | Binds App heartbeat, a visible Goal, or another Host loop; declare the surface that is actually running |
 
 Reusing a Goal does not imply that a new session should take over an existing Agent identity. The current

--- a/docs/book/en/chapters/05-connect-existing-project.md
+++ b/docs/book/en/chapters/05-connect-existing-project.md
@@ -208,7 +208,9 @@ Guided start keeps two decisions separate:
    several, return a read-only `goal_selection_gate`. Select one exact rerun command from `choices`. Before
    that selection, do not write Todos, register an Agent, or activate a Host loop.
 2. **Agent identity:** for new onboarding with task text, omitting `--agent-id` defaults to fresh identity
-   registration. Existing Agents are explicit takeover choices, not automatic defaults.
+   registration only when the Goal has no registered lanes (or `--new-peer` is explicit). When registered
+   lanes exist, `start-goal` returns an identity gate that requires selecting one existing lane. Existing
+   Agents are explicit takeover choices, not automatic defaults.
 
 Do not select a Goal from objective similarity, and do not take over an Agent merely because it is the only
 registered identity. Preview and then atomically register a new public-safe id:

--- a/docs/book/en/chapters/07-codex-cli.md
+++ b/docs/book/en/chapters/07-codex-cli.md
@@ -90,8 +90,10 @@ ignoring the warning.
 
 ## 5. Preserve identity and Todo ownership
 
-An argument-bearing guided start defaults to a fresh Agent identity even when the Goal has only one
-registered Agent. Reuse an existing id only when the user explicitly requests takeover of that peer.
+An argument-bearing guided start does not default to a fresh Agent identity when the Goal has registered
+Agents (even a single one); it returns an identity gate that requires selecting one lane. Fresh
+registration is the default only for a Goal with no registered lanes or an explicit `--new-peer`. Reuse
+an existing id only when the user explicitly requests takeover of that peer.
 After selection, the visible Goal, quota, refresh, and writeback paths should preserve the same explicit
 `--agent-id`. A missing or mismatched identity must fail closed rather than fall back to “the only Agent.”
 

--- a/docs/reference/protocols/codex-app-host-command-registry-v0.md
+++ b/docs/reference/protocols/codex-app-host-command-registry-v0.md
@@ -153,10 +153,12 @@ After parsing, the host hands the agent or CLI a compact packet:
 }
 ```
 
-Codex App CLI reads `CODEX_THREAD_ID` when `--thread-id` is omitted. A stable
-thread ID with no binding is a new host session and defaults to fresh agent
-registration. Selecting an existing lane is an explicit takeover choice. The
-selected fresh or existing identity must be persisted with
+Codex App CLI reads `CODEX_THREAD_ID` when `--thread-id` is omitted, including
+`codex-app-ssh` remote sessions. A stable thread ID with no binding returns an
+identity gate that requires selecting an existing lane when registered agents
+exist; fresh registration is the default only for a goal with no registered
+lanes or explicit `--new-peer`. Selecting an existing lane is an explicit
+takeover choice. The selected fresh or existing identity must be persisted with
 `loopx bind-agent-thread --execute`, and its source/global readback must verify
 before Todo writeback. Later `/loopx` calls in the same
 `(host_surface, goal_id, thread_id)` reuse that agent ID and carry it through

--- a/docs/reference/protocols/loopx-goal-command-v0.md
+++ b/docs/reference/protocols/loopx-goal-command-v0.md
@@ -106,10 +106,14 @@ Agent identity follows the same fail-closed rule. `agent-onboard` keeps its
 fresh-registration path, while Codex App `start-goal --guided` consumes the
 ambient `CODEX_THREAD_ID` when `--thread-id` is omitted and must reuse a
 matching stable opaque thread binding when available. A stable thread ID with
-no binding is a new host session and defaults to fresh registration. Existing
-identities are takeover choices, never an implicit default; selecting one
-requires explicit user intent for that exact agent. A missing thread ID remains
-fail-closed and requires explicit `--agent-id` or new-session intent with
+no binding is no longer treated as fresh onboarding when registered lanes
+exist: `start-goal` returns an identity gate that requires selecting one
+existing lane, and fresh registration is the default only for a goal with no
+registered lanes or explicit `--new-peer`. Existing identities are takeover
+choices, never an implicit automatic selection; selecting one requires
+explicit user intent for that exact agent. A missing thread ID follows the
+same gate when registered lanes exist and remains fail-closed otherwise,
+requiring explicit `--agent-id`, lane selection, or new-session intent with
 `--new-peer`. LoopX persists `(host_surface, goal_id, thread_id) -> agent_id` with
 `bind-agent-thread --execute`; later `/loopx` calls reuse that bound identity
 across `start-goal`, heartbeat, quota, refresh-state, and Todo commands. The

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -747,11 +747,13 @@ def build_loopx_bootstrap_command_pack(
         host_surface=host_surface,
         thread_id=normalized_thread_id,
     )
+    has_registered_agents = bool(registered_agents)
+    binding_missing = thread_binding.get("status") == "missing"
     thread_binding["selection_required"] = bool(
         explicit_goal_start
-        and agent_type == "codex-app"
-        and not normalized_thread_id
         and not new_peer
+        and has_registered_agents
+        and (not normalized_thread_id or binding_missing)
     )
     effective_agent_id = agent_id
     if not effective_agent_id and thread_binding.get("status") == "bound":
@@ -759,14 +761,7 @@ def build_loopx_bootstrap_command_pack(
 
     fresh_agent_default = bool(
         explicit_goal_start
-        and (
-            new_peer
-            or (
-                normalized_thread_id
-                and thread_binding.get("status") == "missing"
-            )
-            or (not normalized_thread_id and agent_type != "codex-app")
-        )
+        and (new_peer or not has_registered_agents)
     )
 
     bootstrap_preview_command = _bootstrap_command(
@@ -1575,8 +1570,10 @@ def build_start_goal_guided_packet(
                 ),
                 "choices": identity_selection_gate.get("choices") or [],
                 "purpose": (
-                    "register a fresh identity by default for a stable unbound host "
-                    "session; select an existing identity only for explicit takeover"
+                    "follow identity_selection_gate.default_action: select an existing "
+                    "lane (and persist the thread binding when a thread id is available) "
+                    "unless default_action is register_fresh_agent for a genuinely new "
+                    "peer or a goal with no registered lanes"
                 ),
             },
         )

--- a/loopx/cli_commands/_host_thread.py
+++ b/loopx/cli_commands/_host_thread.py
@@ -8,6 +8,12 @@ def current_host_thread_id(args: argparse.Namespace) -> str | None:
     explicit = getattr(args, "thread_id", None)
     if explicit:
         return str(explicit)
-    if getattr(args, "host_surface", None) == "codex-app":
+    host_surface = getattr(args, "host_surface", None)
+    if host_surface in {
+        "codex-app",
+        "codex-app-ssh",
+        "codex-ide-plugin",
+        "codex-cli-tui",
+    }:
         return os.environ.get("CODEX_THREAD_ID") or None
     return None

--- a/loopx/host_loop_activation.py
+++ b/loopx/host_loop_activation.py
@@ -1276,7 +1276,8 @@ def build_host_loop_activation_packet(
             )
         else:
             gate_steps = [
-                "Select one registered agent lane from identity_selection_gate.",
+                "Select one registered agent lane from identity_selection_gate; do not register a fresh agent.",
+                "When a thread id is available, persist the thread-to-agent binding so later /loopx calls reuse this lane.",
                 "Run that choice's host-specific activation_input_command.",
             ]
             gate_criterion = "One registered agent identity is explicitly selected."

--- a/tests/control_plane/test_start_goal_compact_projection.py
+++ b/tests/control_plane/test_start_goal_compact_projection.py
@@ -835,7 +835,7 @@ def test_start_goal_binds_selected_lane_before_todo_writeback(
     }
 
 
-def test_start_goal_with_unbound_thread_defaults_to_fresh_registration(
+def test_start_goal_with_unbound_thread_requires_existing_lane_selection(
     tmp_path: Path,
 ) -> None:
     project = _write_connected_project(tmp_path)
@@ -857,16 +857,16 @@ def test_start_goal_with_unbound_thread_defaults_to_fresh_registration(
 
     gate = payload["guided_transaction"]["identity_selection_gate"]
     assert payload["guided_transaction"]["blocked_by"] == "agent_identity_selection"
-    assert gate["state"] == "fresh_agent_registration_required"
-    assert gate["default_action"] == "register_fresh_agent"
-    assert gate["fresh_agent_registration"]["recommended"] is True
+    assert gate["state"] == "thread_binding_selection_required"
+    assert gate["default_action"] == "select_agent_identity"
+    assert gate["fresh_agent_registration"] is None
     assert all(
         choice["requires_explicit_takeover_intent"] is True
         for choice in gate["choices"]
     )
 
 
-def test_start_goal_unbound_thread_does_not_reuse_the_only_registered_agent(
+def test_start_goal_unbound_thread_requires_lane_selection_even_for_single_registered_agent(
     tmp_path: Path,
 ) -> None:
     project = _write_connected_project(tmp_path)
@@ -885,9 +885,10 @@ def test_start_goal_unbound_thread_does_not_reuse_the_only_registered_agent(
     assert payload["agent_id"] is None
     assert payload["guided_transaction"]["blocked_by"] == "agent_identity_selection"
     gate = payload["guided_transaction"]["identity_selection_gate"]
-    assert gate["state"] == "fresh_agent_registration_required"
-    assert gate["default_action"] == "register_fresh_agent"
-    assert gate["fresh_agent_registration"]["recommended"] is True
+    assert gate["state"] == "thread_binding_selection_required"
+    assert gate["default_action"] == "select_agent_identity"
+    assert gate["fresh_agent_registration"] is None
+    assert gate["choices"][0]["agent_id"] == AGENT_ID
 
 
 def test_start_goal_without_thread_id_requires_explicit_lane_selection(tmp_path: Path) -> None:
@@ -912,7 +913,7 @@ def test_start_goal_without_thread_id_requires_explicit_lane_selection(tmp_path:
     assert gate["choices"][0]["requires_explicit_takeover_intent"] is True
 
 
-def test_cli_codex_app_unbound_ambient_thread_defaults_to_fresh_registration(
+def test_cli_codex_app_unbound_ambient_thread_requires_lane_selection(
     tmp_path: Path, monkeypatch
 ) -> None:
     project = _write_connected_project(tmp_path)
@@ -941,6 +942,134 @@ def test_cli_codex_app_unbound_ambient_thread_defaults_to_fresh_registration(
     payload = json.loads(output.getvalue())
     assert payload["thread_id"] == "thread-new-session"
     assert payload["agent_id"] is None
+    gate = payload["guided_transaction"]["identity_selection_gate"]
+    assert gate["state"] == "thread_binding_selection_required"
+    assert gate["default_action"] == "select_agent_identity"
+    assert gate["fresh_agent_registration"] is None
+    assert gate["choices"][0]["agent_id"] == AGENT_ID
+
+
+def test_cli_codex_app_ssh_reuses_ambient_thread_binding(
+    tmp_path: Path, monkeypatch
+) -> None:
+    project = _write_connected_project(tmp_path)
+    registry_path = project / ".loopx" / "registry.json"
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    registry["goals"][0]["coordination"]["thread_agent_bindings"] = [
+        {
+            "thread_id": "thread-ssh-ambient",
+            "host_surface": "codex-app-ssh",
+            "agent_id": AGENT_ID,
+        }
+    ]
+    registry_path.write_text(json.dumps(registry, indent=2) + "\n", encoding="utf-8")
+    monkeypatch.setenv("CODEX_THREAD_ID", "thread-ssh-ambient")
+
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(
+            [
+                "--format",
+                "json",
+                "start-goal",
+                "--guided",
+                "--project",
+                str(project),
+                "--goal-id",
+                GOAL_ID,
+                "--host-surface",
+                "codex-app-ssh",
+                "--goal-text",
+                GOAL_TEXT,
+            ]
+        )
+
+    assert exit_code == 0
+    payload = json.loads(output.getvalue())
+    assert payload["thread_id"] == "thread-ssh-ambient"
+    assert payload["agent_id"] == AGENT_ID
+    assert payload["thread_agent_binding"]["status"] == "bound"
+    assert payload["guided_transaction"].get("blocked_by") is None
+
+
+def test_cli_codex_app_ssh_unbound_ambient_thread_requires_lane_selection(
+    tmp_path: Path, monkeypatch
+) -> None:
+    project = _write_connected_project(tmp_path)
+    monkeypatch.setenv("CODEX_THREAD_ID", "thread-ssh-new")
+
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(
+            [
+                "--format",
+                "json",
+                "start-goal",
+                "--guided",
+                "--project",
+                str(project),
+                "--goal-id",
+                GOAL_ID,
+                "--host-surface",
+                "codex-app-ssh",
+                "--goal-text",
+                GOAL_TEXT,
+            ]
+        )
+
+    assert exit_code == 0
+    payload = json.loads(output.getvalue())
+    assert payload["thread_id"] == "thread-ssh-new"
+    assert payload["agent_id"] is None
+    gate = payload["guided_transaction"]["identity_selection_gate"]
+    assert gate["state"] == "thread_binding_selection_required"
+    assert gate["default_action"] == "select_agent_identity"
+    assert gate["fresh_agent_registration"] is None
+    assert gate["choices"][0]["agent_id"] == AGENT_ID
+
+
+def test_start_goal_non_codex_surface_with_registered_agents_requires_lane_selection(
+    tmp_path: Path,
+) -> None:
+    project = _write_connected_project(tmp_path)
+
+    payload = build_start_goal_guided_packet(
+        project=project,
+        goal_id=GOAL_ID,
+        agent_id=None,
+        cli_bin="loopx",
+        host_surface="claude-code",
+        goal_text=GOAL_TEXT,
+        available_capabilities=["network"],
+    )
+
+    gate = payload["guided_transaction"]["identity_selection_gate"]
+    assert payload["guided_transaction"]["blocked_by"] == "agent_identity_selection"
+    assert gate["state"] == "thread_binding_selection_required"
+    assert gate["default_action"] == "select_agent_identity"
+    assert gate["fresh_agent_registration"] is None
+    assert gate["choices"][0]["agent_id"] == AGENT_ID
+
+
+def test_start_goal_non_codex_surface_without_registered_agents_defaults_to_fresh(
+    tmp_path: Path,
+) -> None:
+    project = _write_connected_project(tmp_path)
+    registry_path = project / ".loopx" / "registry.json"
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    registry["goals"][0]["coordination"]["registered_agents"] = []
+    registry_path.write_text(json.dumps(registry, indent=2) + "\n", encoding="utf-8")
+
+    payload = build_start_goal_guided_packet(
+        project=project,
+        goal_id=GOAL_ID,
+        agent_id=None,
+        cli_bin="loopx",
+        host_surface="claude-code",
+        goal_text=GOAL_TEXT,
+        available_capabilities=["network"],
+    )
+
     gate = payload["guided_transaction"]["identity_selection_gate"]
     assert gate["state"] == "fresh_agent_registration_required"
     assert gate["default_action"] == "register_fresh_agent"


### PR DESCRIPTION
## Problem

Closes #3314. Typing `/loopx <task>` inside an existing Codex App session over SSH (`codex-app-ssh`) registers a brand-new LoopX agent for every invocation instead of continuing the session's agent identity. One thread accumulated one agent per task while its thread binding stayed empty.

## Root cause

1. `current_host_thread_id()` read `CODEX_THREAD_ID` only for `codex-app`; `codex-app-ssh` always returned `None`, so a stable thread id never reached `start-goal` or `bind-agent-thread`.
2. `build_loopx_bootstrap_command_pack()` defaulted to `register_fresh_agent` whenever the thread had no binding (or no thread id on non-`codex-app` surfaces), and the identity gate instructed the model to register fresh by default.

## Change

- Read `CODEX_THREAD_ID` for `codex-app-ssh` and the other codex surfaces, so remote desktop sessions can reuse bound lanes and persist new bindings.
- Default to fresh registration only for a genuinely new peer (`--new-peer`) or a goal with no registered lanes. When registered lanes exist and the thread is unbound, return the existing-lane selection gate (fresh registration is no longer recommended).
- Add the thread-binding persistence step to the selection gate and make the guided packet's identity-gate purpose text match the actual default.
- Update protocol/book docs (EN + ZH) and rename the smokes that encoded the old default.

## Validation

- `tests/control_plane/test_start_goal_compact_projection.py`: 37 passed (3 renamed, 3 new coverage: codex-app-ssh ambient binding reuse, codex-app-ssh unbound selection, non-codex surface with/without registered lanes).
- Related suites: `test_host_loop_activation.py`, `test_host_parity_smoke.py`, `test_cli_output_budget.py`, `test_scheduler_fallback_hint.py`, `test_scheduler_ack_current_host_binding.py` — no new failures (traex/fine-grained subprocess failures are pre-existing on main in this env: `scripts/loopx` resolves to the installed older CLI).
- `loopx canary premerge --from-git-diff`: passed (diff hygiene, py_compile, catalog canaries, risk-profile smokes, public/private boundary scan), `self_merge_allowed: true`.