### PR TITLE
docs(agents): remind agents to sign off every commit for DCO

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,15 @@ Every tracked repository change must be pushed on a branch and reviewed through
 a pull request before it reaches `main`. Do not push broad mixed commits or
 direct commits to `main`.
 
+### DCO Sign-Off
+
+Every commit in a pull-request branch must include a
+`Signed-off-by: Your Name <your.email@example.com>` trailer, or the `DCO`
+check will reject the PR. Always commit with `git commit -s`. If a commit is
+already missing the trailer, amend it with `git commit --amend -s` (or an
+interactive rebase for multiple commits) before pushing. See CONTRIBUTING.md
+for the full DCO policy.
+
 Only skip this worktree/PR gate when the user explicitly says the change is
 local-only and must not be proposed for the repository.
 


### PR DESCRIPTION
## Summary

AGENTS.md is the instruction file that coding agents actually read, but it never mentioned the DCO sign-off requirement. The DCO check frequently fails on missing `Signed-off-by` trailers, so add a short reminder under **Commit And PR Hygiene**:

- every commit must include a `Signed-off-by` trailer or the DCO check rejects the PR;
- always commit with `git commit -s`;
- if a trailer is already missing, amend with `git commit --amend -s` or an interactive rebase before pushing;
- full policy stays in CONTRIBUTING.md.

Docs-only change, no runtime behavior.