### PR TITLE
fix(todo): persist notes on add

### DIFF
--- a/examples/control_plane/todo-cli-smoke.py
+++ b/examples/control_plane/todo-cli-smoke.py
@@ -25,6 +25,8 @@ GOAL_ID = "todo-cli-goal"
 USER_TODO = "Review the owner decision checklist before approving delivery."
 SCOPED_USER_GATE = "Choose the side-agent publishing channel before posting externally."
 AGENT_TODO = "Summarize the read-only evidence after the user checklist is done."
+AGENT_TODO_NOTE = "Start from the public-safe evidence summary."
+UPDATED_AGENT_TODO_NOTE = "Preserve the validated summary as the handoff context."
 UPDATED_AGENT_TODO = "Publish the compact evidence summary after validation passes."
 MONITOR_TODO = "Monitor the release-note draft PR until the next scheduled check."
 MONITOR_DUE_AT = "2026-01-02T00:00:00+00:00"
@@ -247,8 +249,23 @@ def main() -> int:
         assert scoped_gate["agent_id"] == "codex-side-bypass", scoped_gate
         assert scoped_gate["blocks_agent"] == "codex-side-bypass", scoped_gate
 
-        agent_payload = run_cli(registry_path, "todo", "add", "--goal-id", GOAL_ID, "--role", "agent", "--text", AGENT_TODO)
+        agent_payload = run_cli(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            AGENT_TODO,
+            "--note",
+            AGENT_TODO_NOTE,
+        )
         assert agent_payload["added"] is True, agent_payload
+        assert agent_payload["note"] == AGENT_TODO_NOTE, agent_payload
+        added_fields = parse_active_state_todos(state_file.read_text(encoding="utf-8"))
+        assert added_fields["agent_todos"]["items"][0]["note"] == AGENT_TODO_NOTE, added_fields
         legacy_agent = run_cli(
             legacy_registry_path,
             "todo",
@@ -293,6 +310,8 @@ def main() -> int:
             "advancement_task",
             "--action-kind",
             "run_eval",
+            "--note",
+            UPDATED_AGENT_TODO_NOTE,
             "--continuation-policy",
             "independent_handoff",
             "--required-capability",
@@ -309,6 +328,7 @@ def main() -> int:
         assert metadata_payload["metadata_updated"] is True, metadata_payload
         assert metadata_payload["task_class"] == "advancement_task", metadata_payload
         assert metadata_payload["action_kind"] == "run_eval", metadata_payload
+        assert metadata_payload["note"] == UPDATED_AGENT_TODO_NOTE, metadata_payload
         assert (
             metadata_payload["continuation_policy"] == "independent_handoff"
         ), metadata_payload
@@ -347,6 +367,7 @@ def main() -> int:
         assert fields["agent_todos"]["items"][0]["todo_id"].startswith("todo_"), fields
         assert fields["agent_todos"]["items"][0]["task_class"] == "advancement_task", fields
         assert fields["agent_todos"]["items"][0]["action_kind"] == "run_eval", fields
+        assert fields["agent_todos"]["items"][0]["note"] == UPDATED_AGENT_TODO_NOTE, fields
         assert fields["agent_todos"]["items"][0]["required_capabilities"] == [
             "shell",
             "benchmark_runner",
@@ -422,6 +443,7 @@ def main() -> int:
         assert agent_lookup["matched"] is True, agent_lookup
         assert agent_lookup["todo"]["todo_id"] == metadata_payload["todo_id"], agent_lookup
         assert agent_lookup["todo"]["action_kind"] == "run_eval", agent_lookup
+        assert agent_lookup["todo"]["note"] == UPDATED_AGENT_TODO_NOTE, agent_lookup
         assert agent_lookup["relations"]["required_capabilities"] == [
             "shell",
             "benchmark_runner",

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -617,6 +617,7 @@ def handle_todo_command(
                 role=args.role,
                 text=args.text,
                 status=args.status,
+                note=args.note,
                 task_class=args.task_class,
                 action_kind=args.action_kind,
                 task_domain=args.task_domain,

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -606,6 +606,7 @@ def add_todo_to_lines(
     validation_label: str | None = None,
     validation_timeout_seconds: int | None = None,
     monitor_metadata: dict[str, Any] | None = None,
+    note: str | None = None,
     evidence: str | None = None,
     updated_at: str | None = None,
 ) -> dict[str, Any]:
@@ -720,6 +721,7 @@ def add_todo_to_lines(
                 else None
             ),
             **normalized_monitor_metadata,
+            note=note,
             evidence=evidence,
             updated_at=updated_at,
         )
@@ -737,12 +739,20 @@ def add_todo_to_lines(
         }
         if status:
             status_changed = set_todo_marker(lines, block, normalized_status)
-        if task_class:
-            updates["task_class"] = task_class
-        if action_kind:
-            updates["action_kind"] = action_kind
-        if task_domain:
-            updates["task_domain"] = task_domain
+        for metadata_field, metadata_value in (
+            ("task_class", task_class),
+            ("action_kind", action_kind),
+            ("task_domain", task_domain),
+            ("task_repository", task_repository),
+            ("continuation_policy", continuation_policy),
+            ("claimed_by", claimed_by),
+            ("blocks_agent", blocks_agent),
+            ("unblocks_todo_id", unblocks_todo_id),
+            ("note", note),
+            ("evidence", evidence),
+        ):
+            if metadata_value:
+                updates[metadata_field] = metadata_value
         if capability_binding_ref:
             requested_binding_ref = normalize_todo_capability_binding_ref(
                 capability_binding_ref
@@ -762,10 +772,6 @@ def add_todo_to_lines(
                     "capability_binding_ref is immutable once set"
                 )
             updates["capability_binding_ref"] = requested_binding_ref
-        if task_repository:
-            updates["task_repository"] = task_repository
-        if continuation_policy:
-            updates["continuation_policy"] = continuation_policy
         if required_write_scopes is not None:
             updates["required_write_scopes"] = required_write_scopes
         if required_capabilities is not None:
@@ -778,22 +784,16 @@ def add_todo_to_lines(
             updates["decision_scope"] = decision_scope
         if required_decision_scopes is not None:
             updates["required_decision_scopes"] = required_decision_scopes
-        if claimed_by:
-            updates["claimed_by"] = claimed_by
         if bound_agent:
             updates["bound_agent"] = bound_agent
             updates["goal_bound"] = None
         elif goal_bound is not None:
             updates["bound_agent"] = None
             updates["goal_bound"] = goal_bound
-        if blocks_agent:
-            updates["blocks_agent"] = blocks_agent
         if excluded_agents is not None:
             updates["excluded_agents"] = excluded_agents
         if global_gate is not None:
             updates["global_gate"] = global_gate
-        if unblocks_todo_id:
-            updates["unblocks_todo_id"] = unblocks_todo_id
         if replan_obligation_id:
             updates["replan_obligation_id"] = require_replan_successor_rebinding(
                 existing_obligation_id=block.get("replan_obligation_id"),
@@ -802,8 +802,6 @@ def add_todo_to_lines(
         if normalized_resume_when:
             updates["resume_when"] = normalized_resume_when
         updates.update(normalized_monitor_metadata)
-        if evidence:
-            updates["evidence"] = evidence
         if updated_at and not block.get("updated_at"):
             updates["updated_at"] = updated_at
         metadata_line = metadata_line_for_todo_block(block, updates)
@@ -871,6 +869,7 @@ def add_todo_to_lines(
         "next_due_at": effective_metadata.get("next_due_at"),
         "expires_at": effective_metadata.get("expires_at"),
         "watch_only": effective_metadata.get("watch_only"),
+        "note": effective_metadata.get("note") or note,
         "evidence": effective_metadata.get("evidence") or evidence,
         "updated_at": effective_metadata.get("updated_at") or updated_at,
     }
@@ -883,6 +882,7 @@ def add_goal_todo(
     role: str,
     text: str,
     status: str | None = None,
+    note: str | None = None,
     task_class: str | None = None,
     action_kind: str | None = None,
     task_domain: str | None = None,
@@ -1112,6 +1112,7 @@ def add_goal_todo(
             validation_label=validation_label,
             validation_timeout_seconds=validation_timeout_seconds,
             monitor_metadata=normalized_monitor_metadata,
+            note=note,
             updated_at=updated_at,
         )
         added = bool(add_result["added"])
@@ -1163,6 +1164,7 @@ def add_goal_todo(
         "next_due_at": add_result.get("next_due_at"),
         "expires_at": add_result.get("expires_at"),
         "watch_only": add_result.get("watch_only"),
+        "note": add_result.get("note"),
         "state_file": str(resolved_state_file),
         "project": str(resolved_project) if resolved_project else None,
         "updated_at": updated_at if changed else None,


### PR DESCRIPTION
## Summary

- pass the already-declared `todo add --note` value through the existing Todo mutation path;
- return the persisted note from add/upsert results;
- extend the canonical Todo CLI smoke to prove add, duplicate-add update, active-state persistence, and list readback;
- consolidate equivalent truthy metadata assignments so the touched hot module remains below its reviewed maintainability ceiling.

## Why

`loopx todo add` accepted `--note` but did not pass it to `add_goal_todo`, so continuation and release instructions could disappear without an error. The canonical note schema and parser already existed; this PR repairs only the missing propagation path.

## Validation

- `loopx canary premerge --from-git-diff --goal-id loopx-meta` — 18/18 selected checks passed, zero failures, warnings, or manual holds; self-merge allowed.
- Change-quality receipt `cqr_c1e8685871c76dc959e9` — pass for the exact committed diff.
- Todo CLI end-to-end smoke — passed.
- Todo write-correctness smoke — passed.
- Focused pytest contracts — 147 passed.
- Ruff and changed-file compilation — passed.
- Public/private boundary scan — clean for all three changed files.
- Maintainability ratchet — passed; no new exception or debt.

The system Python was too old for this repository's declared Python 3.11+ requirement, so repository tests were rerun with a supported Python 3.12 runtime. No product check was skipped.

## Boundaries

No permission, benchmark, scheduler, scoring, release-publishing, or public evidence-policy behavior changes. No credentials, private state, raw logs, generated evidence, or host-local paths are included.
