### PR TITLE
feat(packages): add docs adoption metrics to loopx-repo-health

### DIFF
--- a/packages/loopx-repo-health/CONTRACT.md
+++ b/packages/loopx-repo-health/CONTRACT.md
@@ -24,6 +24,12 @@ but do not reinterpret missing metrics as zero.
 - `traffic_14d` requires repository access; unavailable surfaces become zero
   counts with a warning, so consumers can distinguish "no traffic" from
   "no access".
+- `traffic_14d.paths` is the bounded top-paths list returned by GitHub
+  (`traffic/popular/paths`). `traffic_14d.docs_views` is derived from those
+  paths with the single classification rule: README (`/readme...`),
+  `docs/` tree (including blob/tree links), and `wiki/` tree. The derived
+  `uniques` value is the sum of per-path uniques and is not de-duplicated
+  across paths.
 - Credentials are never part of the request or response packet; authentication
   comes from the process environment only.
 - The provider rejects a request with a mismatched `schema_version` before

--- a/packages/loopx-repo-health/README.md
+++ b/packages/loopx-repo-health/README.md
@@ -9,13 +9,43 @@ community-funnel monitoring, and content material.
 
 - Counts: stars, forks, watchers, open issues, releases, contributors, sampled
   PR total, sampled commented-issue total.
-- Traffic (14-day window): views and clones (requires repository access).
+- Traffic (14-day window): repo views, clones, top paths, and derived docs
+  views (requires repository access).
 - Latency: PR merge p25/p75 and first-human-response p25/p75, computed from a
   bounded recent sample.
 - Recent star timeline: weekly buckets from the newest stargazer pages.
 
 Every metric comes from public repository data. The provider never accepts or
 emits raw trajectories, benchmark evidence, credentials, or private links.
+
+## Metric model
+
+The snapshot is organized into two groups so reports and digests can stay
+plain-language while remaining CHAOSS-aligned.
+
+Adoption and awareness (easy to read, best for recaps):
+
+| plain language | snapshot field | CHAOSS alignment |
+| --- | --- | --- |
+| people who visited the repo page | `traffic_14d.views.uniques` | activity/attention proxy |
+| people who read docs or README | `traffic_14d.docs_views.uniques` | documentation activity proxy |
+| people who cloned the repo | `traffic_14d.clones.uniques` | adoption/trial proxy |
+| stars / forks / watchers | `counts.stars/forks/watchers` | popularity/social proof |
+
+Community health (CHAOSS working-group aligned):
+
+| plain language | snapshot field | CHAOSS alignment |
+| --- | --- | --- |
+| active contributor count | `counts.contributors` | bus factor input |
+| time to first human response | `latency.first_response_*` | time-to-first-response |
+| PR merge turnaround | `latency.pr_merge_*` | code review latency |
+| release cadence input | `counts.releases` | release frequency input |
+
+`traffic_14d.docs_views` is derived from the top paths returned by GitHub with
+one classification rule: README, `docs/` tree (including blob/tree links), and
+`wiki/` tree. Its `uniques` is the sum of per-path uniques and is not
+de-duplicated across paths. Consumers must not reinterpret missing metrics as
+zero; unavailable traffic surfaces are reported as zero with a warning.
 
 ## Auth and boundaries
 

--- a/packages/loopx-repo-health/extension.toml
+++ b/packages/loopx-repo-health/extension.toml
@@ -1,6 +1,6 @@
 schema_version = "loopx_extension_manifest_v0"
 id = "loopx-repo-health"
-version = "0.1.0"
+version = "0.2.0"
 requires_loopx_api = ">=1,<2"
 permissions = []
 

--- a/packages/loopx-repo-health/pyproject.toml
+++ b/packages/loopx-repo-health/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx-repo-health"
-version = "0.1.0"
+version = "0.2.0"
 description = "Public-safe GitHub repo-health snapshot provider for LoopX"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/loopx-repo-health/schemas/response.schema.json
+++ b/packages/loopx-repo-health/schemas/response.schema.json
@@ -236,6 +236,52 @@
               ],
               "type": "object"
             },
+            "docs_views": {
+              "properties": {
+                "count": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "uniques": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "count",
+                "uniques"
+              ],
+              "type": "object"
+            },
+            "paths": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "uniques": {
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "path",
+                  "title",
+                  "count",
+                  "uniques"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
             "views": {
               "properties": {
                 "count": {
@@ -256,7 +302,9 @@
           },
           "required": [
             "views",
-            "clones"
+            "clones",
+            "paths",
+            "docs_views"
           ],
           "type": "object"
         }

--- a/packages/loopx-repo-health/smoke/repo_health_snapshot_smoke.py
+++ b/packages/loopx-repo-health/smoke/repo_health_snapshot_smoke.py
@@ -43,6 +43,27 @@ def _fixture() -> dict:
         "traffic_14d": {
             "views": {"count": 88117, "uniques": 27496},
             "clones": {"count": 29250, "uniques": 4602},
+            "paths": [
+                {
+                    "path": "/README.md",
+                    "title": "loopx",
+                    "count": 21403,
+                    "uniques": 13201,
+                },
+                {
+                    "path": "/docs/architecture.md",
+                    "title": "Architecture",
+                    "count": 5210,
+                    "uniques": 3120,
+                },
+                {
+                    "path": "/issues",
+                    "title": "Issues",
+                    "count": 9801,
+                    "uniques": 5110,
+                },
+            ],
+            "docs_views": {"count": 26613, "uniques": 16321},
         },
         "latency": {
             "pr_merge_p25_min": 12.0,
@@ -84,9 +105,50 @@ def _run_offline() -> int:
         print("FAIL: negative traffic accepted", file=sys.stderr)
         return 1
 
+    broken = copy.deepcopy(fixture)
+    broken["traffic_14d"]["paths"] = [{"path": "/docs", "title": "Docs", "count": -1, "uniques": 0}]
+    if validate_snapshot(broken) == []:
+        print("FAIL: negative path traffic accepted", file=sys.stderr)
+        return 1
+
+    from loopx_repo_health.github import is_docs_path
+
+    docs_examples = [
+        "/README.md",
+        "/readme",
+        "/docs/getting-started.md",
+        "/wiki/Home",
+        "/blob/main/docs/guide.md",
+        "/tree/main/docs",
+        "/huangruiteng/loopx/blob/main/README.zh-CN.md",
+        "/huangruiteng/loopx/blob/main/docs/guides/getting-started.md",
+        "/huangruiteng/loopx/tree/main/docs",
+    ]
+    for path in docs_examples:
+        if not is_docs_path(path):
+            print(f"FAIL: {path} should classify as docs", file=sys.stderr)
+            return 1
+    non_docs_examples = [
+        "/issues",
+        "/pulls",
+        "/",
+        "/blob/main/loopx/cli.py",
+        "/releases",
+        "/huangruiteng/loopx",
+        "/huangruiteng/loopx/pulls",
+        "/huangruiteng/loopx/blob/main/loopx/cli.py",
+    ]
+    for path in non_docs_examples:
+        if is_docs_path(path):
+            print(f"FAIL: {path} should not classify as docs", file=sys.stderr)
+            return 1
+
     md = render_markdown(fixture)
     if "Repo Health: huangruiteng/loopx" not in md or "| stars | 4804 |" not in md:
         print("FAIL: markdown projection missing expected rows", file=sys.stderr)
+        return 1
+    if "| docs_views | 26613 | 16321 |" not in md or "| /docs/architecture.md |" not in md:
+        print("FAIL: markdown projection missing docs/top-path rows", file=sys.stderr)
         return 1
 
     print("ok: offline contract smoke passed")

--- a/packages/loopx-repo-health/src/loopx_repo_health/__init__.py
+++ b/packages/loopx-repo-health/src/loopx_repo_health/__init__.py
@@ -1,5 +1,5 @@
 __all__ = ["__version__", "SNAPSHOT_SCHEMA_VERSION", "validate_snapshot"]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 from .contract import SNAPSHOT_SCHEMA_VERSION, validate_snapshot  # noqa: E402

--- a/packages/loopx-repo-health/src/loopx_repo_health/contract.py
+++ b/packages/loopx-repo-health/src/loopx_repo_health/contract.py
@@ -63,12 +63,26 @@ def validate_snapshot(payload: dict[str, Any]) -> list[str]:
                 violations.append(f"counts.{metric} must be a non-negative integer")
     traffic = payload.get("traffic_14d")
     if isinstance(traffic, dict):
-        for surface in ("views", "clones"):
+        for surface in ("views", "clones", "docs_views"):
             item = traffic.get(surface)
             if not isinstance(item, dict) or not all(
                 isinstance(item.get(k), int) and item[k] >= 0 for k in ("count", "uniques")
             ):
                 violations.append(f"traffic_14d.{surface} must have non-negative count/uniques")
+        paths = traffic.get("paths")
+        if not isinstance(paths, list):
+            violations.append("traffic_14d.paths must be an array")
+        else:
+            for row in paths:
+                if not isinstance(row, dict):
+                    violations.append("traffic_14d.paths rows must be objects")
+                    continue
+                for key in ("path", "title"):
+                    if not isinstance(row.get(key), str):
+                        violations.append(f"traffic_14d.paths row {key} must be a string")
+                for key in ("count", "uniques"):
+                    if not isinstance(row.get(key), int) or row[key] < 0:
+                        violations.append(f"traffic_14d.paths row {key} must be a non-negative integer")
     else:
         violations.append("traffic_14d must be an object")
     latency = payload.get("latency")

--- a/packages/loopx-repo-health/src/loopx_repo_health/github.py
+++ b/packages/loopx-repo-health/src/loopx_repo_health/github.py
@@ -23,13 +23,30 @@ from .contract import RepoHealthSnapshot, SNAPSHOT_SCHEMA_VERSION
 
 
 API_BASE = "https://api.github.com"
-USER_AGENT = "loopx-repo-health/0.1.0"
+USER_AGENT = "loopx-repo-health/0.2.0"
 REQUEST_TIMEOUT_SECONDS = 15
 _LINK_LAST_PAGE = re.compile(r'[?&]page=(\d+)>;\s*rel="last"')
+_DOCS_PATH_PATTERN = re.compile(
+    r"^(?:/[^/]+/[^/]+)?"
+    r"(?:/docs(?:/|$)|/wiki(?:/|$)|/(?:blob|tree)/[^/]+/docs(?:/|$)|/blob/[^/]+/readme(?:\.|$)|/readme(?:\.|$))",
+    re.IGNORECASE,
+)
 
 
 class GitHubError(RuntimeError):
     pass
+
+
+def is_docs_path(path: str) -> bool:
+    """Return True when a GitHub popular path is a documentation surface.
+
+    Documentation surfaces are the README file, the ``docs/`` tree (including
+    blob/tree links into it), and the ``wiki/`` tree. This is the single
+    classification rule for the derived ``docs_views`` metric; changing it
+    changes metric semantics and requires contract revision.
+    """
+
+    return bool(_DOCS_PATH_PATTERN.match(path))
 
 
 def _token() -> str | None:
@@ -168,8 +185,8 @@ class GitHubRepoHealthCollector:
         )
         return _last_page(headers) or 0
 
-    def _collect_traffic(self) -> dict[str, dict[str, int]]:
-        result: dict[str, dict[str, int]] = {}
+    def _collect_traffic(self) -> dict[str, Any]:
+        result: dict[str, Any] = {}
         for surface in ("views", "clones"):
             try:
                 payload, _ = _request_json(f"/repos/{self.owner}/{self.repo}/traffic/{surface}")
@@ -177,6 +194,27 @@ class GitHubRepoHealthCollector:
             except GitHubError as exc:
                 result[surface] = {"count": 0, "uniques": 0}
                 self.warnings.append(f"traffic/{surface} unavailable: {exc}")
+        try:
+            payload, _ = _request_json(f"/repos/{self.owner}/{self.repo}/traffic/popular/paths")
+            rows = [
+                {
+                    "path": str(item.get("path", "")),
+                    "title": str(item.get("title", "")),
+                    "count": int(item.get("count", 0)),
+                    "uniques": int(item.get("uniques", 0)),
+                }
+                for item in payload or []
+            ]
+            docs_rows = [row for row in rows if is_docs_path(row["path"])]
+            result["paths"] = rows
+            result["docs_views"] = {
+                "count": sum(row["count"] for row in docs_rows),
+                "uniques": sum(row["uniques"] for row in docs_rows),
+            }
+        except GitHubError as exc:
+            result["paths"] = []
+            result["docs_views"] = {"count": 0, "uniques": 0}
+            self.warnings.append(f"traffic/popular/paths unavailable: {exc}")
         return result
 
     def _closed_pull_requests(self, limit: int = 200) -> list[dict[str, Any]]:

--- a/packages/loopx-repo-health/src/loopx_repo_health/render.py
+++ b/packages/loopx-repo-health/src/loopx_repo_health/render.py
@@ -48,9 +48,22 @@ def render_markdown(snapshot: dict[str, Any]) -> str:
         "| surface | count | uniques |",
         "| --- | --- | --- |",
     ]
-    for surface in ("views", "clones"):
+    for surface in ("views", "clones", "docs_views"):
         item = traffic.get(surface, {})
         lines.append(f"| {surface} | {item.get('count', 0)} | {item.get('uniques', 0)} |")
+    paths = traffic.get("paths") or []
+    if paths:
+        lines += [
+            "",
+            "### Top paths",
+            "",
+            "| path | title | count | uniques |",
+            "| --- | --- | --- | --- |",
+        ]
+        for row in paths[:10]:
+            lines.append(
+                f"| {row.get('path', '')} | {row.get('title', '')} | {row.get('count', 0)} | {row.get('uniques', 0)} |"
+            )
     lines += [
         "",
         "## Latency",


### PR DESCRIPTION
## Summary

Extends `repo_health_snapshot_v0` in the `loopx-repo-health` extension provider with two new `traffic_14d` fields:

- `paths`: the bounded top popular paths returned by GitHub (`traffic/popular/paths`), each with `path`, `title`, `count`, `uniques`.
- `docs_views`: derived `count`/`uniques` aggregated from paths classified as documentation surfaces.

The docs classification rule is frozen in one place: README (`/readme...`), the `docs/` tree (including blob/tree links), and the `wiki/` tree; repo-qualified GitHub path prefixes are accepted. `docs_views.uniques` is the sum of per-path uniques and is not de-duplicated across paths (documented in CONTRACT.md).

Also adds a plain-language metric model to the package README mapping adoption metrics (repo visits, docs views, unique cloners) and community-health metrics (first response, PR merge latency, contributors, releases) to CHAOSS alignment. Package version bumps to 0.2.0.

## Changed surfaces

- Contract/validator (`contract.py`, `response.schema.json`)
- GitHub collector (`github.py`) — new popular-paths fetch + docs classifier
- Markdown projection (`render.py`) — docs_views row + top paths table
- Offline smoke (`repo_health_snapshot_smoke.py`) — fixture, negative cases, classifier cases
- Docs (`README.md`, `CONTRACT.md`)

## Checks run

- `python3 smoke/repo_health_snapshot_smoke.py` — offline contract smoke passed
- Live snapshot `huangruiteng/loopx` — passed contract validation against real GitHub API
- Docs classifier verified against live popular paths: 6/10 top paths classified as docs; `docs_views` = 10,239 count / 7,407 uniques for the 14-day window
- `loopx canary premerge --from-git-diff` — passed: diff hygiene, compile checks, catalog canaries (7), risk-profile smokes (8), public/private boundary scan; 0 failures, 0 warnings, 0 manual holds

## Merge decision

Owner authorized self-merge for LoopX capability sedimentation. Canary gate reports `self_merge_allowed: true`; will self-merge after CI is green.