### PR TITLE
fix(quota): preserve heartbeat receipt Todo on replay

### DIFF
--- a/loopx/control_plane/quota/should_run_packet.py
+++ b/loopx/control_plane/quota/should_run_packet.py
@@ -667,9 +667,10 @@ def _resolve_quota_should_run_route(
     due_monitor_attempt = work_lane_contract_is_due_monitor_attempt(
         prepared.work_lane_contract
     )
-    agent_lane_next_action = None
+    agent_lane_next_action = prepared.receipt_bound_agent_next_action
     if (
-        not due_monitor_attempt
+        agent_lane_next_action is None
+        and not due_monitor_attempt
         and not prepared.inbox_reply_due
         and not task_orchestration_contract_is_actionable(
             prepared.task_orchestration_contract

--- a/loopx/control_plane/quota/should_run_prepare.py
+++ b/loopx/control_plane/quota/should_run_prepare.py
@@ -10,6 +10,7 @@ from ...quota import (
     _resolve_reward_memory_experiment_from_status,
 )
 from ..agents.agent_lane_recommendation import (
+    build_agent_lane_next_action,
     scope_status_item_to_agent_lane as _scope_status_item_to_agent_lane,
 )
 from ..agents.agent_scope import (
@@ -82,6 +83,7 @@ from ..work_items.capability_monitor_fallback import (
 from ..work_items.primary_action import protocol_action_text as _protocol_action_text
 from ..work_items.work_lane import (
     lark_inbox_reply_due_work_lane_contract,
+    preserve_heartbeat_receipt_bound_work_lane,
     scoped_user_gate_due_monitor_contract,
     work_lane_contract_is_lark_inbox_reply_due,
 )
@@ -118,6 +120,7 @@ class _QuotaDecisionPreparation:
     monitor_debt_arbitration: dict[str, Any]
     agent_monitor_only: bool
     work_lane_contract: dict[str, Any] | None
+    receipt_bound_agent_next_action: dict[str, Any] | None
     task_orchestration_contract: dict[str, Any] | None
     capability_gate: dict[str, Any] | None
     capability_monitor_fallback: dict[str, Any] | None
@@ -551,8 +554,40 @@ def _prepare_quota_should_run_item(
         current_contract=work_lane_contract,
     )
     inbox_reply_due = work_lane_contract_is_lark_inbox_reply_due(work_lane_contract)
+    receipt_bound_agent_next_action = None
+    if (
+        receipt_bound_todo_id
+        and not inbox_reply_due
+        and not task_orchestration_contract_is_actionable(task_orchestration_contract)
+    ):
+        candidate = build_agent_lane_next_action(
+            agent_identity=agent_identity,
+            agent_todo_summary=agent_todo_summary,
+            capability_gate=capability_gate,
+            scoped_user_gate_fallback=scoped_user_gate_fallback,
+            receipt_bound_todo_id=receipt_bound_todo_id,
+            active_next_action=(
+                item.get("active_state_next_action")
+                or (
+                    item.get("project_asset", {}).get("next_action")
+                    if isinstance(item.get("project_asset"), dict)
+                    else None
+                )
+            ),
+        )
+        if (
+            isinstance(candidate, dict)
+            and candidate.get("selection_binding") == "heartbeat_receipt"
+        ):
+            receipt_bound_agent_next_action = candidate
+            preserved_work_lane = preserve_heartbeat_receipt_bound_work_lane(
+                work_lane_contract,
+                selected_todo=candidate,
+            )
+            if isinstance(preserved_work_lane, dict):
+                work_lane_contract = preserved_work_lane
     work_lane_selected_todo = _selected_todo_projection(
-        agent_lane_next_action=None,
+        agent_lane_next_action=receipt_bound_agent_next_action,
         work_lane_contract=work_lane_contract,
     )
     if inbox_reply_due:
@@ -658,6 +693,7 @@ def _prepare_quota_should_run_item(
         monitor_debt_arbitration=monitor_debt_arbitration,
         agent_monitor_only=agent_monitor_only,
         work_lane_contract=work_lane_contract,
+        receipt_bound_agent_next_action=receipt_bound_agent_next_action,
         task_orchestration_contract=task_orchestration_contract,
         capability_gate=capability_gate,
         capability_monitor_fallback=capability_monitor_fallback,

--- a/loopx/control_plane/work_items/work_lane.py
+++ b/loopx/control_plane/work_items/work_lane.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from ..todos.contract import normalize_todo_id
 from ..todos.projection import todo_priority_label, todo_priority_rank
 
 
@@ -109,6 +110,43 @@ def work_lane_contract_is_due_monitor_attempt(
         and contract.get("monitor_kind") == WORK_LANE_TODO_MONITOR_DUE_KIND
         and contract.get("must_attempt_work") is True
     )
+
+
+def preserve_heartbeat_receipt_bound_work_lane(
+    contract: dict[str, Any] | None,
+    *,
+    selected_todo: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Keep a committed same-turn Todo binding ahead of a newly due monitor."""
+
+    if not isinstance(contract, dict) or not work_lane_contract_is_due_monitor_attempt(
+        contract
+    ):
+        return contract
+    if not isinstance(selected_todo, dict):
+        return contract
+    todo_id = normalize_todo_id(selected_todo.get("todo_id"))
+    if not todo_id or selected_todo.get("selection_binding") != "heartbeat_receipt":
+        return contract
+    return {
+        "schema_version": WORK_LANE_CONTRACT_SCHEMA_VERSION,
+        "lane": "advancement_task",
+        "next_lane": str(contract.get("lane") or "continuous_monitor"),
+        "obligation": "continue_heartbeat_receipt_bound_todo",
+        "must_attempt_work": True,
+        "selection_binding": "heartbeat_receipt",
+        "selected_todo_id": todo_id,
+        "reason_codes": [
+            "heartbeat_receipt_bound_replay",
+            "same_turn_settlement_identity",
+        ],
+        "monitor_policy": "defer_new_priority_selection_until_next_turn",
+        "deferred_work_lane": contract,
+        "action": (
+            "continue the Todo already bound to this heartbeat turn; reconsider "
+            "newly due monitor priority on the next turn"
+        ),
+    }
 
 
 def work_lane_contract_is_lark_inbox_reply_due(

--- a/tests/control_plane/test_quota_settlement_cli.py
+++ b/tests/control_plane/test_quota_settlement_cli.py
@@ -12,6 +12,7 @@ GOAL_ID = "settlement-cli-fixture"
 AGENT_ID = "codex-settlement-cli"
 TODO_ID = "todo_fixture_settlement"
 REENTRY_TODO_ID = "todo_fixture_network_reentry"
+DUE_MONITOR_TODO_ID = "todo_fixture_due_monitor"
 TURN_ID = "turn-settlement-cli-1"
 
 
@@ -177,6 +178,24 @@ def _configure_runtime_capability_reentry_fixture(project: Path) -> None:
             f"  <!-- loopx:todo todo_id={REENTRY_TODO_ID} status=open "
             "task_class=advancement_task action_kind=inspect_target "
             "required_capabilities=network -->\n",
+        ),
+        encoding="utf-8",
+    )
+
+
+def _append_newly_due_monitor(project: Path) -> None:
+    state_path = project / f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_text = state_path.read_text(encoding="utf-8")
+    state_path.write_text(
+        state_text.replace(
+            "## Agent Todo\n\n",
+            "## Agent Todo\n\n"
+            "- [ ] [P0-monitor] Observe the newly due public target.\n"
+            f"  <!-- loopx:todo todo_id={DUE_MONITOR_TODO_ID} status=open "
+            "task_class=continuous_monitor action_kind=observe "
+            f"claimed_by={AGENT_ID} target_key=due-monitor-fixture "
+            "required_capabilities=network%2Cexternal_evidence_poll "
+            "cadence=1m next_due_at=2000-01-01T00%3A00%3A00Z -->\n",
         ),
         encoding="utf-8",
     )
@@ -769,6 +788,164 @@ def test_runtime_capability_reentry_preserves_receipt_bound_todo_and_rejects_exp
     assert "explicitly requested Todo" in conflict["reason"]
     assert conflict["heartbeat_receipt"]["status"] == "write_failed"
     assert _heartbeat_receipt_count(runtime, TURN_ID) == 1
+
+
+def test_same_turn_receipt_replay_defers_newly_due_higher_priority_monitor(
+    tmp_path: Path,
+) -> None:
+    project, runtime, registry_path = _write_fixture(tmp_path)
+    guard_args = (
+        "quota",
+        "should-run",
+        "--codex-app",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--turn-instance-id",
+        TURN_ID,
+        "--scan-path",
+        str(project),
+    )
+
+    first_rc, first = _run_cli(registry_path, runtime, *guard_args)
+    assert first_rc == 0, first
+    assert first["selected_todo"]["todo_id"] == TODO_ID
+    assert first["heartbeat_receipt"]["settlement_identity"]["todo_id"] == TODO_ID
+
+    _append_newly_due_monitor(project)
+    capability_args = (
+        "--available-capability",
+        "network",
+        "--available-capability",
+        "external_evidence_poll",
+    )
+    replay_rc, replay = _run_cli(
+        registry_path,
+        runtime,
+        *guard_args,
+        *capability_args,
+    )
+
+    assert replay_rc == 0, replay
+    assert replay["selected_todo"]["todo_id"] == TODO_ID
+    assert replay["selected_todo"]["selection_binding"] == "heartbeat_receipt"
+    assert replay["agent_lane_next_action"]["todo_id"] == TODO_ID
+    assert replay["work_lane_contract"]["selection_binding"] == "heartbeat_receipt"
+    assert replay["work_lane_contract"]["selected_todo_id"] == TODO_ID
+    assert (
+        replay["work_lane_contract"]["deferred_work_lane"]["selected_todo_id"]
+        == DUE_MONITOR_TODO_ID
+    )
+    assert replay["heartbeat_receipt"]["status"] == "replayed"
+    plan = replay["interaction_contract"]["cli_channel"]["settlement_plan"]
+    assert plan["identity"]["todo_id"] == TODO_ID
+    assert _heartbeat_receipt_count(runtime, TURN_ID) == 1
+
+    next_turn_rc, next_turn = _run_cli(
+        registry_path,
+        runtime,
+        "quota",
+        "should-run",
+        "--codex-app",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--turn-instance-id",
+        "turn-settlement-cli-2",
+        "--scan-path",
+        str(project),
+        *capability_args,
+    )
+    assert next_turn_rc == 0, next_turn
+    assert next_turn["selected_todo"]["todo_id"] == DUE_MONITOR_TODO_ID
+
+    binding = (
+        "--agent-id",
+        AGENT_ID,
+        "--todo-id",
+        TODO_ID,
+        "--turn-instance-id",
+        TURN_ID,
+    )
+    complete_args = (
+        "todo",
+        "complete",
+        "--goal-id",
+        GOAL_ID,
+        *binding,
+        "--claimed-by",
+        AGENT_ID,
+        "--evidence",
+        "receipt-bound delivery validated",
+        "--next-agent-todo",
+        "Continue after the receipt-bound delivery.",
+        "--next-claimed-by",
+        AGENT_ID,
+        "--next-action-kind",
+        "implement",
+    )
+    complete_rc, complete = _run_cli(registry_path, runtime, *complete_args)
+    complete_replay_rc, complete_replay = _run_cli(
+        registry_path,
+        runtime,
+        *complete_args,
+    )
+    assert complete_rc == 0, complete
+    assert complete_replay_rc == 0, complete_replay
+    assert complete_replay["idempotent_replay"] is True
+
+    refresh_args = (
+        "refresh-state",
+        "--goal-id",
+        GOAL_ID,
+        "--classification",
+        "receipt_bound_delivery_validated",
+        "--delivery-batch-scale",
+        "single_surface",
+        "--delivery-outcome",
+        "outcome_progress",
+        *binding,
+        "--no-global-sync",
+        "--suppress-external-sinks",
+    )
+    refresh_rc, refresh = _run_cli(registry_path, runtime, *refresh_args)
+    refresh_replay_rc, refresh_replay = _run_cli(
+        registry_path,
+        runtime,
+        *refresh_args,
+    )
+    assert refresh_rc == 0, refresh
+    assert refresh_replay_rc == 0, refresh_replay
+    assert refresh_replay["idempotent_replay"] is True
+    assert _classification_count(runtime, "receipt_bound_delivery_validated") == 1
+
+    spend_args = (
+        "quota",
+        "spend-slot",
+        "--goal-id",
+        GOAL_ID,
+        "--slots",
+        "1",
+        "--source",
+        "heartbeat",
+        "--execute",
+        *binding,
+        "--scan-path",
+        str(project),
+    )
+    spend_rc, spend = _run_cli(registry_path, runtime, *spend_args)
+    spend_replay_rc, spend_replay = _run_cli(
+        registry_path,
+        runtime,
+        *spend_args,
+    )
+    assert spend_rc == 0, spend
+    assert spend_replay_rc == 0, spend_replay
+    assert spend_replay["idempotent_replay"] is True
+    assert spend_replay["appended"] is False
+    assert _spend_run_count(runtime) == 1
 
 
 def test_read_only_settlement_omits_non_causal_delivery_workspace(


### PR DESCRIPTION
## Summary

- keep a committed same-turn heartbeat receipt Todo authoritative when a higher-priority monitor becomes due before capability re-entry
- retain the monitor as typed deferred work so a fresh turn can select it normally
- cover real CLI replay plus idempotent Todo closeout, refresh, and quota spend

## Validation

- 40 focused control-plane tests passed
- Ruff and Python compile checks passed on all changed files
- targeted mypy differential matched origin/main exactly (25 existing errors in both base and head; no new type error)
- LoopX public/private scan passed for all changed files
- source-checkout replay against the live loopx-meta receipt preserved one Todo identity across selected Todo, work lane, receipt, and settlement plan
- LoopX premerge canary passed 17/17 selected checks with no manual holds
- change-quality receipt: cqr_4778491b5ea778d28b67

## Boundary

No permission, quota-allocation, scheduler-cadence, monitor-priority-across-turns, or external-write semantics change. No private state, credentials, local paths, or generated logs are included.