### PR TITLE
fix(quota): preserve heartbeat settlement identity

### DIFF
--- a/loopx/control_plane/work_items/runtime_capability_reentry.py
+++ b/loopx/control_plane/work_items/runtime_capability_reentry.py
@@ -9,6 +9,7 @@ from ..scheduler.execution_context import (
     SchedulerExecutionContextResolution,
     render_scheduler_execution_args,
 )
+from ..todos.contract import normalize_todo_id
 
 
 RUNTIME_CAPABILITY_REENTRY_SCHEMA_VERSION = "runtime_capability_reentry_v0"
@@ -93,6 +94,13 @@ def build_runtime_capability_reentry_packet(
     if not scheduler_args:
         return None
 
+    selected_todo = (
+        payload.get("selected_todo")
+        if isinstance(payload.get("selected_todo"), Mapping)
+        else {}
+    )
+    selected_todo_id = normalize_todo_id(selected_todo.get("todo_id"))
+
     goal_id = str(payload.get("goal_id") or "<GOAL_ID>")
     agent_identity = (
         payload.get("agent_identity")
@@ -121,6 +129,12 @@ def build_runtime_capability_reentry_packet(
             capability,
         )
         if verification_target is None:
+            continue
+        if (
+            selected_todo_id
+            and normalize_todo_id(verification_target.get("todo_id"))
+            != selected_todo_id
+        ):
             continue
         cli_args = [
             *base_args,

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -1180,21 +1180,25 @@ def refresh_state_run(
             current_path=delivery_workspace_path,
             peer_independent_worktree_required=peer_independent_worktree_required,
         )
-        if delivery_workspace_path is not None:
-            if delivery_workspace is None:
-                raise ValueError(
-                    "--delivery-workspace-path must identify a git checkout with "
-                    "a credential-free origin repository"
-                )
-            if (
-                peer_independent_worktree_required
-                and delivery_workspace.get("workspace_kind")
+        if delivery_workspace_path is not None and delivery_workspace is None:
+            raise ValueError(
+                "--delivery-workspace-path must identify a git checkout with "
+                "a credential-free origin repository"
+            )
+        if (
+            peer_independent_worktree_required
+            and (
+                delivery_workspace is None
+                or delivery_workspace.get("workspace_kind")
                 != "independent_git_worktree"
-            ):
-                raise ValueError(
-                    "--delivery-workspace-path must identify the independent git "
-                    "worktree that produced this peer delivery"
-                )
+            )
+        ):
+            raise ValueError(
+                "accountable peer delivery must be refreshed from the independent "
+                "git worktree that produced it, or name that worktree with "
+                "--delivery-workspace-path"
+            )
+        if delivery_workspace_path is not None and delivery_workspace is not None:
             delivery_workspace["repository_source"] = (
                 "refresh_state.delivery_workspace_path"
             )

--- a/tests/control_plane/test_quota_settlement_cli.py
+++ b/tests/control_plane/test_quota_settlement_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shlex
 import subprocess
 import sys
@@ -93,6 +94,7 @@ def _run_cli(
     registry_path: Path,
     runtime: Path,
     *args: str,
+    cwd: Path = REPO_ROOT,
 ) -> tuple[int, dict[str, Any]]:
     result = subprocess.run(
         [
@@ -107,10 +109,14 @@ def _run_cli(
             "json",
             *args,
         ],
-        cwd=REPO_ROOT,
+        cwd=cwd,
         check=False,
         capture_output=True,
         text=True,
+        env={
+            **os.environ,
+            "PYTHONPATH": str(REPO_ROOT),
+        },
     )
     return result.returncode, json.loads(result.stdout)
 
@@ -757,8 +763,7 @@ def test_runtime_capability_reentry_preserves_receipt_bound_todo_and_rejects_exp
     assert first_rc == 0, first
     assert first["selected_todo"]["todo_id"] == TODO_ID
     assert first["heartbeat_receipt"]["settlement_identity"]["todo_id"] == TODO_ID
-    candidates = first["runtime_capability_reentry"]["candidates"]
-    assert candidates[0]["verification_target"]["todo_id"] == REENTRY_TODO_ID
+    assert "runtime_capability_reentry" not in first
     assert replay_rc == 0, replay
     assert replay["selected_todo"]["todo_id"] == TODO_ID
     assert replay["selected_todo"]["selection_binding"] == "heartbeat_receipt"
@@ -788,6 +793,127 @@ def test_runtime_capability_reentry_preserves_receipt_bound_todo_and_rejects_exp
     assert "explicitly requested Todo" in conflict["reason"]
     assert conflict["heartbeat_receipt"]["status"] == "write_failed"
     assert _heartbeat_receipt_count(runtime, TURN_ID) == 1
+
+
+def test_peer_refresh_rejects_implicit_canonical_workspace_before_writeback(
+    tmp_path: Path,
+) -> None:
+    project, runtime, registry_path = _write_fixture(tmp_path)
+    _initialize_git_checkout(project)
+    subprocess.run(["git", "add", "."], cwd=project, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=LoopX Test",
+            "-c",
+            "user.email=loopx-test@example.invalid",
+            "commit",
+            "--quiet",
+            "-m",
+            "fixture",
+        ],
+        cwd=project,
+        check=True,
+    )
+    binding = (
+        "--agent-id",
+        AGENT_ID,
+        "--todo-id",
+        TODO_ID,
+        "--turn-instance-id",
+        TURN_ID,
+    )
+    _guard_rc, guard = _run_cli(
+        registry_path,
+        runtime,
+        "quota",
+        "should-run",
+        "--codex-app",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--turn-instance-id",
+        TURN_ID,
+        "--scan-path",
+        str(project),
+    )
+    assert guard["heartbeat_receipt"]["settlement_identity"]["todo_id"] == TODO_ID
+
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    registry["goals"][0]["coordination"]["registered_agents"].append(
+        "codex-settlement-peer"
+    )
+    registry_path.write_text(
+        json.dumps(registry, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    state_path = project / f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_path.write_text(
+        state_path.read_text(encoding="utf-8").replace(
+            "action_kind=validate -->",
+            f"action_kind=validate claimed_by={AGENT_ID} -->",
+        ),
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "add", "."], cwd=project, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=LoopX Test",
+            "-c",
+            "user.email=loopx-test@example.invalid",
+            "commit",
+            "--quiet",
+            "-m",
+            "peer fixture",
+        ],
+        cwd=project,
+        check=True,
+    )
+    linked_worktree = tmp_path / "linked-worktree"
+    subprocess.run(
+        ["git", "worktree", "add", "--quiet", "--detach", str(linked_worktree)],
+        cwd=project,
+        check=True,
+    )
+
+    refresh_args = (
+        "refresh-state",
+        "--goal-id",
+        GOAL_ID,
+        "--classification",
+        "peer_delivery_validated",
+        "--delivery-batch-scale",
+        "single_surface",
+        "--delivery-outcome",
+        "outcome_progress",
+        *binding,
+        "--no-global-sync",
+        "--suppress-external-sinks",
+    )
+    canonical_rc, canonical = _run_cli(
+        registry_path,
+        runtime,
+        *refresh_args,
+        cwd=project,
+    )
+    assert canonical_rc == 1, canonical
+    assert "must be refreshed from the independent git worktree" in canonical["error"]
+    assert _classification_count(runtime, "peer_delivery_validated") == 0
+
+    linked_rc, linked = _run_cli(
+        registry_path,
+        runtime,
+        *refresh_args,
+        cwd=linked_worktree,
+    )
+    assert linked_rc == 0, linked
+    assert linked["delivery_workspace"]["workspace_kind"] == (
+        "independent_git_worktree"
+    )
 
 
 def test_same_turn_receipt_replay_defers_newly_due_higher_priority_monitor(

--- a/tests/control_plane/test_runtime_capability_reentry.py
+++ b/tests/control_plane/test_runtime_capability_reentry.py
@@ -144,6 +144,30 @@ def test_runtime_capability_gap_returns_verified_reentry_packet() -> None:
     )
 
 
+def test_runtime_capability_reentry_does_not_switch_from_selected_todo() -> None:
+    payload = {
+        **_blocked_payload(missing=["network"]),
+        "effective_action": "bounded_delivery",
+        "selected_todo": {
+            "todo_id": "todo_selected",
+            "task_class": "advancement_task",
+        },
+        "execution_obligation": {
+            "must_attempt_work": True,
+            "delivery_allowed": True,
+        },
+    }
+
+    contract = build_interaction_contract(
+        payload,
+        available_capabilities=["shell"],
+        scheduler_execution_context=MANAGED_AGENT_CONTEXT,
+    )
+
+    assert "runtime_capability_reentry" not in contract["cli_channel"]
+    assert contract["agent_channel"].get("next_task_action") is None
+
+
 def test_verified_reentry_inherits_capability_into_followup_actions() -> None:
     contract = build_interaction_contract(
         {


### PR DESCRIPTION
## Summary

- Keep runtime capability re-entry bound to the Todo selected for the current heartbeat receipt, so a newly observable capability cannot silently retarget settlement to an unrelated Todo.
- Enforce the existing peer-workspace contract before accountable refresh writeback, including when the producing workspace is inferred from the current directory rather than passed explicitly.
- Add focused unit and real CLI regressions for selected-Todo filtering, pre-writeback canonical-checkout rejection, and linked-worktree success.

## Changed surfaces

- Runtime capability re-entry projection.
- Accountable refresh delivery-workspace validation.
- Quota settlement CLI and runtime re-entry tests.

## Validation

- Focused pytest: 14 passed.
- Ruff on all four changed files: passed.
- Compileall on all four changed files: passed.
- git diff check: passed.
- LoopX public/private boundary scan: clean for all four changed files.
- Change-quality exact-scope receipt: cqr_dd1f503bd21acbf9d714, valid with no blockers.
- Risk-based premerge gate: 15/15 checks passed (7 catalog canaries and 8 risk-profile smokes), with zero failures, warnings, or manual holds.

An informational targeted mypy run still traverses the repository and reports the existing repo-wide type-check baseline; it is not represented as a passing validation for this PR. The changed-line Optional narrowing found during that diagnostic was fixed before the final receipt and validation run.

## Coverage rationale

The focused tests prove both failure modes at their real boundaries: capability re-entry cannot target a different selected Todo, canonical peer refresh fails before writeback, and an actual linked worktree succeeds. The broader premerge selection covers quota planning, work-lane policy, scheduler/monitor behavior, autonomous replan, refresh-state write correctness, canary planning/execution, and smoke-suite infrastructure.

## Boundary and residual risk

- No credentials, private state, raw logs, local paths, generated evidence, or benchmark artifacts are included.
- No scoring, task semantics, permission boundary, release surface, or benchmark launch behavior changes.
- The behavior change is intentionally fail-closed and aligns runtime projection with the existing selected-Todo and independent-worktree settlement contracts.
