### PR TITLE
fix(quota): bind monitor polls to heartbeat receipts

### DIFF
--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -209,10 +209,14 @@ def _prepare_quota_command_context(
         )
     except ValueError as exc:
         raise QuotaCommandValidationError(str(exc)) from exc
-    if heartbeat_turn_id and command not in {"should-run", "spend-slot"}:
+    if heartbeat_turn_id and command not in {
+        "should-run",
+        "monitor-poll",
+        "spend-slot",
+    }:
         raise QuotaCommandValidationError(
-            "--turn-instance-id is only valid with `quota should-run` or "
-            "`quota spend-slot`"
+            "--turn-instance-id is only valid with `quota should-run`, "
+            "`quota monitor-poll`, or `quota spend-slot`"
         )
     if getattr(args, "replan_obligation_id", None) and command != "spend-slot":
         raise QuotaCommandValidationError(
@@ -515,6 +519,33 @@ def _quota_renderer(
     }.get(command, render_quota_markdown)
 
 
+def _receipt_bound_monitor_todo_id(
+    args: argparse.Namespace,
+    *,
+    runtime_root: Path,
+    turn_instance_id: str | None,
+) -> str | None:
+    if not turn_instance_id:
+        return None
+    receipt = find_heartbeat_receipt(
+        runtime_root,
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        turn_instance_id=turn_instance_id,
+    )
+    if receipt is None:
+        raise HeartbeatReceiptIdentityConflictError(
+            "turn-scoped monitor-poll requires a committed heartbeat receipt; "
+            "run quota should-run with the same --turn-instance-id first"
+        )
+    todo_id = heartbeat_receipt_settlement_todo_id(receipt)
+    if todo_id is None:
+        raise HeartbeatReceiptIdentityConflictError(
+            "turn-scoped monitor-poll requires a heartbeat receipt bound to a Todo"
+        )
+    return todo_id
+
+
 def handle_quota_command(
     args: argparse.Namespace,
     *,
@@ -685,6 +716,12 @@ def handle_quota_command(
                 next_user_todo=args.next_user_todo,
                 next_user_task_class=args.next_user_task_class,
                 next_claimed_by=args.next_claimed_by,
+                turn_instance_id=heartbeat_turn_id,
+                receipt_bound_todo_id=_receipt_bound_monitor_todo_id(
+                    args,
+                    runtime_root=runtime_root,
+                    turn_instance_id=heartbeat_turn_id,
+                ),
                 scheduler_execution_context=scheduler_context,
                 operator_inbox_urgency_projector=operator_inbox_urgency_projector,
                 bounded_research_frontier_projector=(

--- a/loopx/cli_commands/quota_registration.py
+++ b/loopx/cli_commands/quota_registration.py
@@ -160,9 +160,10 @@ def register_quota_command(
     quota_parser.add_argument(
         "--turn-instance-id",
         help=(
-            "Stable heartbeat settlement id for `quota should-run` and "
-            "`quota spend-slot`. The guard persists one idempotent receipt; "
-            "reuse the same id through writeback, spend, and retries."
+            "Stable heartbeat settlement id for `quota should-run`, "
+            "`quota monitor-poll`, and `quota spend-slot`. The guard persists "
+            "one idempotent receipt; reuse the same id through monitor "
+            "writeback, refresh-state, spend, and retries."
         ),
     )
     quota_parser.add_argument(

--- a/loopx/control_plane/agents/agent_lane_recommendation.py
+++ b/loopx/control_plane/agents/agent_lane_recommendation.py
@@ -5,9 +5,11 @@ from typing import Any, Callable, Optional
 
 from ..todos.contract import (
     TODO_TASK_CLASS_ADVANCEMENT,
+    TODO_TASK_CLASS_MONITOR,
     normalize_todo_claimed_by,
     normalize_todo_id,
 )
+from ..todos.projection import todo_item_is_due_monitor
 from ..todos.summary_item import compact_todo_summary_item
 from ..work_items.primary_action import protocol_action_text
 from ..work_items.work_lane import (
@@ -20,7 +22,10 @@ from .agent_scope import (
     agent_scope_item_claimed_by,
     agent_scope_item_claimed_by_agent_or_unclaimed,
 )
-from .capability_gate import _agent_lane_candidate_sort_key
+from .capability_gate import (
+    _agent_lane_candidate_sort_key,
+    missing_required_capabilities,
+)
 
 
 PublicSafeText = Callable[..., Optional[str]]
@@ -28,6 +33,60 @@ ActionAlignment = Callable[[Any, Any], bool]
 TimestampParser = Callable[[Any], Any]
 AGENT_LANE_NEXT_ACTION_SCHEMA_VERSION = "agent_lane_next_action_v0"
 AGENT_LANE_PROGRESS_SCOPE = "agent_lane"
+
+
+def build_receipt_bound_monitor_next_action(
+    *,
+    agent_identity: dict[str, Any] | None,
+    agent_todo_items: list[dict[str, Any]],
+    available_capabilities: Any,
+    receipt_bound_todo_id: str | None,
+) -> dict[str, Any] | None:
+    """Recover an exact due monitor omitted by priority-limited hot lanes."""
+
+    if not isinstance(agent_identity, dict):
+        return None
+    agent_id = normalize_todo_claimed_by(agent_identity.get("agent_id"))
+    todo_id = normalize_todo_id(receipt_bound_todo_id)
+    if not agent_id or not todo_id:
+        return None
+    for item in agent_todo_items:
+        if normalize_todo_id(item.get("todo_id")) != todo_id:
+            continue
+        if (
+            not _todo_item_is_actionable_open(item)
+            or _todo_task_class(item) != TODO_TASK_CLASS_MONITOR
+            or not todo_item_is_due_monitor(item)
+            or missing_required_capabilities(
+                item,
+                available_capabilities=available_capabilities,
+            )
+            or not agent_scope_item_claimed_by_agent_or_unclaimed(
+                item,
+                agent_id=agent_id,
+            )
+        ):
+            return None
+        text = protocol_action_text(item.get("text"), limit=500)
+        if not text:
+            return None
+        payload = compact_todo_summary_item(item, text=text)
+        payload.update(
+            {
+                "schema_version": AGENT_LANE_NEXT_ACTION_SCHEMA_VERSION,
+                "agent_id": agent_id,
+                "source": "heartbeat_receipt.monitor_todo",
+                "selected_by": "current_agent_claimed_todo",
+                "confidence": "selected",
+                "preserves_goal_next_action": True,
+                "selection_binding": "heartbeat_receipt",
+            }
+        )
+        if not agent_scope_item_claimed_by(item):
+            payload["selected_by"] = "unclaimed_todo"
+            payload["claim_required_before_work"] = True
+        return payload
+    return None
 
 
 def is_status_neutral_run(

--- a/loopx/control_plane/quota/cli_projection.py
+++ b/loopx/control_plane/quota/cli_projection.py
@@ -105,6 +105,7 @@ _RETAINED_MONITOR_POLL_SELECTED_TODO_FIELDS = (
     "unblocks_todo_id",
     "agent_id",
     "selected_by",
+    "selection_binding",
 )
 _RETAINED_MONITOR_POLL_INTERACTION_FIELDS = {
     "user_channel": (

--- a/loopx/control_plane/quota/monitor_poll.py
+++ b/loopx/control_plane/quota/monitor_poll.py
@@ -316,6 +316,39 @@ def _monitor_successor_receipts(
     return receipts, successor_ids
 
 
+def _monitor_poll_replay_conflict_fields(
+    *,
+    existing: dict[str, Any],
+    monitor_event: dict[str, Any],
+    todo_id: str | None,
+    target_key: str | None,
+    result_hash: str | None,
+    material_change: bool,
+) -> list[str]:
+    conflicts: list[str] = []
+    recorded_todo_id = normalize_todo_id(
+        existing.get("todo_id") or monitor_event.get("todo_id")
+    )
+    if todo_id != recorded_todo_id:
+        conflicts.append("todo_id")
+    recorded_target_key = (
+        str(
+            existing.get("target_key")
+            or monitor_event.get("target_key")
+            or ""
+        ).strip()
+        or None
+    )
+    if target_key is not None and target_key != recorded_target_key:
+        conflicts.append("target_key")
+    recorded_result_hash = str(monitor_event.get("result_hash") or "").strip() or None
+    if result_hash != recorded_result_hash:
+        conflicts.append("result_hash")
+    if material_change is not bool(monitor_event.get("material_change")):
+        conflicts.append("material_change")
+    return conflicts
+
+
 def _allows_registry_due_monitor_poll(
     before: dict[str, Any],
     *,
@@ -450,8 +483,10 @@ def record_quota_monitor_poll_for_decision(
     _index_lock_held: bool = False,
     status_reloader: Callable[[], dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
-    normalized_turn_instance_id = normalize_turn_instance_id(turn_instance_id)
-    normalized_todo_id = normalize_todo_id(todo_id) if todo_id else None
+    normalized_turn_instance_id, normalized_todo_id = (
+        normalize_turn_instance_id(turn_instance_id),
+        normalize_todo_id(todo_id) if todo_id else None,
+    )
     safe_target_key = str(target_key or "").strip() or None
     safe_result_hash = str(result_hash or "").strip() or None
 
@@ -525,17 +560,33 @@ def record_quota_monitor_poll_for_decision(
             )
             if existing:
                 artifact = _load_monitor_poll_artifact(existing)
+                monitor_event = (
+                    artifact.get("monitor_event")
+                    if isinstance(artifact.get("monitor_event"), dict)
+                    else {}
+                )
+                replay_conflicts = _monitor_poll_replay_conflict_fields(
+                    existing=existing,
+                    monitor_event=monitor_event,
+                    todo_id=normalized_todo_id,
+                    target_key=safe_target_key,
+                    result_hash=safe_result_hash,
+                    material_change=material_change,
+                )
+                if replay_conflicts:
+                    conflict = failure(
+                        "turn-scoped monitor-poll request conflicts with the "
+                        "existing idempotent poll event"
+                    )
+                    conflict["error_code"] = "heartbeat_receipt_identity_conflict"
+                    conflict["conflict_fields"] = replay_conflicts
+                    return conflict
                 after = after_decision(
                     _status_with_monitor_poll(
                         status_payload,
                         goal_id=goal_id,
                         index_record=existing,
                     )
-                )
-                monitor_event = (
-                    artifact.get("monitor_event")
-                    if isinstance(artifact.get("monitor_event"), dict)
-                    else {}
                 )
                 replay_receipts, replay_successor_ids = _monitor_successor_receipts(
                     monitor_event.get("todo_writeback")

--- a/loopx/control_plane/quota/should_run_prepare.py
+++ b/loopx/control_plane/quota/should_run_prepare.py
@@ -11,6 +11,7 @@ from ...quota import (
 )
 from ..agents.agent_lane_recommendation import (
     build_agent_lane_next_action,
+    build_receipt_bound_monitor_next_action,
     scope_status_item_to_agent_lane as _scope_status_item_to_agent_lane,
 )
 from ..agents.agent_scope import (
@@ -575,6 +576,16 @@ def _prepare_quota_should_run_item(
                 )
             ),
         )
+        if not (
+            isinstance(candidate, dict)
+            and candidate.get("selection_binding") == "heartbeat_receipt"
+        ):
+            candidate = build_receipt_bound_monitor_next_action(
+                agent_identity=agent_identity,
+                agent_todo_items=agent_todo_source_items,
+                available_capabilities=effective_available_capabilities,
+                receipt_bound_todo_id=receipt_bound_todo_id,
+            )
         if (
             isinstance(candidate, dict)
             and candidate.get("selection_binding") == "heartbeat_receipt"

--- a/loopx/control_plane/work_items/work_lane.py
+++ b/loopx/control_plane/work_items/work_lane.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from ..todos.contract import normalize_todo_id
+from ..todos.contract import TODO_TASK_CLASS_MONITOR, normalize_todo_id
 from ..todos.projection import todo_priority_label, todo_priority_rank
 
 
@@ -128,6 +128,28 @@ def preserve_heartbeat_receipt_bound_work_lane(
     todo_id = normalize_todo_id(selected_todo.get("todo_id"))
     if not todo_id or selected_todo.get("selection_binding") != "heartbeat_receipt":
         return contract
+    if selected_todo.get("task_class") == TODO_TASK_CLASS_MONITOR:
+        return {
+            **contract,
+            "schema_version": WORK_LANE_CONTRACT_SCHEMA_VERSION,
+            "lane": "continuous_monitor",
+            "obligation": "attempt_due_monitor",
+            "must_attempt_work": True,
+            "selection_binding": "heartbeat_receipt",
+            "selected_todo_id": todo_id,
+            "monitor_due_items": [selected_todo],
+            "reason_codes": [
+                "due_monitor_context",
+                "heartbeat_receipt_bound_replay",
+                "same_turn_settlement_identity",
+            ],
+            "monitor_policy": "settle_receipt_bound_monitor_before_reselection",
+            "deferred_work_lane": contract,
+            "action": (
+                "settle the due monitor already bound to this heartbeat turn; "
+                "reconsider newly runnable monitor priority on the next turn"
+            ),
+        }
     return {
         "schema_version": WORK_LANE_CONTRACT_SCHEMA_VERSION,
         "lane": "advancement_task",

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -17,6 +17,7 @@ from .control_plane.quota.heartbeat_recommendation import (
 from .control_plane.quota.decision_summary import (
     goal_status_health_ok as _goal_status_health_ok,
 )
+from .control_plane.quota.error_codes import HeartbeatReceiptIdentityConflictError
 from .control_plane.quota.goal_boundary import registry_goal_by_id as _registry_goal_by_id
 from .control_plane.quota.policy_constants import (
     AUTONOMOUS_CANDIDATE_CONTEXT_FIELDS,  # noqa: F401
@@ -77,6 +78,7 @@ from .control_plane.scheduler.state import (
 )
 from .control_plane.todos.contract import (
     normalize_todo_claimed_by,
+    normalize_todo_id,
 )
 from .control_plane.todos.projection import (
     todo_index_rank as projection_todo_index_rank,
@@ -943,6 +945,7 @@ def record_quota_monitor_poll(
     next_user_task_class: str | None = None,
     next_claimed_by: str | None = None,
     turn_instance_id: str | None = None,
+    receipt_bound_todo_id: str | None = None,
     scheduler_execution_context: Mapping[str, Any] | SchedulerExecutionContextResolution | None = None,
     operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
     bounded_research_frontier_projector: (
@@ -951,6 +954,23 @@ def record_quota_monitor_poll(
     status_reloader: Callable[[], dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     safe_goal_id = _validate_goal_id_path_segment(str(goal_id or ""))
+    normalized_requested_todo_id = normalize_todo_id(todo_id) if todo_id else None
+    normalized_receipt_todo_id = (
+        normalize_todo_id(receipt_bound_todo_id)
+        if receipt_bound_todo_id
+        else None
+    )
+    if (
+        normalized_receipt_todo_id
+        and normalized_requested_todo_id
+        and normalized_requested_todo_id != normalized_receipt_todo_id
+    ):
+        raise HeartbeatReceiptIdentityConflictError(
+            "turn-scoped monitor-poll Todo conflicts with the committed "
+            "heartbeat receipt: expected "
+            f"{normalized_receipt_todo_id}, requested {normalized_requested_todo_id}"
+        )
+    effective_todo_id = normalized_requested_todo_id or normalized_receipt_todo_id
 
     def should_run(current_status: dict[str, Any]) -> dict[str, Any]:
         decision_status = current_status
@@ -975,6 +995,7 @@ def record_quota_monitor_poll(
             available_capabilities=available_capabilities,
             scheduler_execution_context=scheduler_execution_context,
             operator_inbox_urgency_projector=operator_inbox_urgency_projector,
+            receipt_bound_todo_id=normalized_receipt_todo_id,
         )
 
     before = should_run(status_payload)
@@ -989,7 +1010,7 @@ def record_quota_monitor_poll(
         source=source,
         reason_summary=reason_summary,
         agent_id=agent_id,
-        todo_id=todo_id,
+        todo_id=effective_todo_id,
         target_key=target_key,
         result_hash=result_hash,
         material_change=material_change,

--- a/tests/control_plane/test_monitor_followthrough_contract.py
+++ b/tests/control_plane/test_monitor_followthrough_contract.py
@@ -279,8 +279,15 @@ def test_unchanged_due_poll_reloads_status_before_followthrough_decision(
     )
 
 
+@pytest.mark.parametrize(
+    ("material_change", "result_hash"),
+    [(False, "unchanged-42"), (True, "material-42")],
+    ids=["quiet", "material"],
+)
 def test_turn_scoped_monitor_poll_preserves_receipt_todo_after_capability_reentry(
     tmp_path: Path,
+    material_change: bool,
+    result_hash: str,
 ) -> None:
     registry, runtime, _state = _write_fixture(tmp_path)
     admitted = _add_monitor(
@@ -345,8 +352,8 @@ def test_turn_scoped_monitor_poll_preserves_receipt_todo_after_capability_reentr
         "--target-key",
         "public-issue:42",
         "--result-hash",
-        "material-42",
-        "--material-change",
+        result_hash,
+        *(("--material-change",) if material_change else ()),
         "--execute",
     )
     result = run_json_cli(
@@ -360,6 +367,7 @@ def test_turn_scoped_monitor_poll_preserves_receipt_todo_after_capability_reentr
         "heartbeat_receipt"
     )
     assert result["todo_writeback"]["todo_id"] == admitted["todo_id"]
+    assert result["material_change"] is material_change
     assert result["turn_instance_id"] == turn_id
     assert result["replayed"] is False
 
@@ -372,7 +380,7 @@ def test_turn_scoped_monitor_poll_preserves_receipt_todo_after_capability_reentr
     assert replay["appended"] is False
 
     different_replay_command = list(command)
-    different_replay_command[different_replay_command.index("material-42")] = (
+    different_replay_command[different_replay_command.index(result_hash)] = (
         "different-observation"
     )
     returncode, replay_conflict = run_json_cli_result(

--- a/tests/control_plane/test_monitor_followthrough_contract.py
+++ b/tests/control_plane/test_monitor_followthrough_contract.py
@@ -279,6 +279,159 @@ def test_unchanged_due_poll_reloads_status_before_followthrough_decision(
     )
 
 
+def test_turn_scoped_monitor_poll_preserves_receipt_todo_after_capability_reentry(
+    tmp_path: Path,
+) -> None:
+    registry, runtime, _state = _write_fixture(tmp_path)
+    admitted = _add_monitor(
+        registry,
+        text="[P1] Poll the admitted public issue target.",
+        target_key="public-issue:42",
+        next_due_at="2000-01-01T00:00:00+00:00",
+    )
+    newly_runnable = add_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="agent",
+        text="[P0] Poll the higher-priority public review queue.",
+        task_class="continuous_monitor",
+        claimed_by=AGENT_ID,
+        required_capabilities=["network", "external_evidence_poll"],
+        monitor_metadata={
+            "target_key": "public-review-queue",
+            "cadence": "1h",
+            "next_due_at": "2000-01-01T00:00:00+00:00",
+            "watch_only": "true",
+        },
+    )
+    turn_id = "2026-08-18T20:33:30.889Z"
+
+    guard = run_json_cli(
+        "quota",
+        "should-run",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--runtime-profile",
+        "generic_cli",
+        "--turn-instance-id",
+        turn_id,
+        registry_path=registry,
+        runtime_root=runtime,
+    )
+    assert guard["selected_todo"]["todo_id"] == admitted["todo_id"]
+    assert guard["heartbeat_receipt"]["settlement_identity"]["todo_id"] == admitted[
+        "todo_id"
+    ]
+
+    command = (
+        "quota",
+        "monitor-poll",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--runtime-profile",
+        "generic_cli",
+        "--turn-instance-id",
+        turn_id,
+        "--available-capability",
+        "network",
+        "--available-capability",
+        "external_evidence_poll",
+        "--todo-id",
+        admitted["todo_id"],
+        "--target-key",
+        "public-issue:42",
+        "--result-hash",
+        "material-42",
+        "--material-change",
+        "--execute",
+    )
+    result = run_json_cli(
+        *command,
+        registry_path=registry,
+        runtime_root=runtime,
+    )
+
+    assert result["before"]["selected_todo"]["todo_id"] == admitted["todo_id"]
+    assert result["before"]["selected_todo"]["selection_binding"] == (
+        "heartbeat_receipt"
+    )
+    assert result["todo_writeback"]["todo_id"] == admitted["todo_id"]
+    assert result["turn_instance_id"] == turn_id
+    assert result["replayed"] is False
+
+    replay = run_json_cli(
+        *command,
+        registry_path=registry,
+        runtime_root=runtime,
+    )
+    assert replay["replayed"] is True
+    assert replay["appended"] is False
+
+    different_replay_command = list(command)
+    different_replay_command[different_replay_command.index("material-42")] = (
+        "different-observation"
+    )
+    returncode, replay_conflict = run_json_cli_result(
+        *different_replay_command,
+        registry_path=registry,
+        runtime_root=runtime,
+    )
+    assert returncode == 1
+    assert replay_conflict["error_code"] == "heartbeat_receipt_identity_conflict"
+    assert replay_conflict["conflict_fields"] == ["result_hash"]
+
+    wrong_todo_command = list(command)
+    wrong_todo_command[wrong_todo_command.index(admitted["todo_id"])] = (
+        newly_runnable["todo_id"]
+    )
+    returncode, conflict = run_json_cli_result(
+        *wrong_todo_command,
+        registry_path=registry,
+        runtime_root=runtime,
+    )
+    assert returncode == 1
+    assert conflict["error_code"] == "heartbeat_receipt_identity_conflict"
+    assert admitted["todo_id"] in conflict["reason"]
+
+
+def test_turn_scoped_monitor_poll_requires_committed_receipt(tmp_path: Path) -> None:
+    registry, runtime, _state = _write_fixture(tmp_path)
+    monitor = _add_monitor(
+        registry,
+        text="Poll a public release target.",
+        target_key="public-release:42",
+        next_due_at="2000-01-01T00:00:00+00:00",
+    )
+
+    returncode, result = run_json_cli_result(
+        "quota",
+        "monitor-poll",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--runtime-profile",
+        "generic_cli",
+        "--turn-instance-id",
+        "2026-08-18T20:33:31.000Z",
+        "--todo-id",
+        monitor["todo_id"],
+        "--result-hash",
+        "unchanged-42",
+        "--execute",
+        registry_path=registry,
+        runtime_root=runtime,
+    )
+
+    assert returncode == 1
+    assert result["error_code"] == "heartbeat_receipt_identity_conflict"
+    assert "requires a committed heartbeat receipt" in result["reason"]
+
+
 def test_material_poll_user_action_does_not_block_existing_advancement(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- let `quota monitor-poll` reuse the heartbeat turn instance id and load the committed receipt
- preserve the exact receipt-bound monitor Todo when real runtime capabilities make a higher-priority monitor newly runnable
- fail closed when a turn receipt is missing or its Todo identity conflicts, and validate exact-result semantics on idempotent replay
- cover dynamic capability re-entry for both quiet and material polls, writeback identity, replay, and negative conflict paths

## Why

The heartbeat guard can bind a due monitor before execution capabilities are observed. Previously, `monitor-poll` recomputed selection after those capabilities were supplied, so a newly runnable higher-priority monitor could replace the Todo already committed in the heartbeat receipt. That made a valid bounded poll impossible to settle under its original turn identity.

## Validation

- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: passed 17/17 selected checks, zero failures, warnings, or manual holds on the latest `main` baseline
- focused pytest suites: 49 passed across monitor followthrough, runtime capability re-entry, monitor CLI projection, and quota settlement
- quiet and material receipt-bound CLI regression: 3 relevant parameterized/negative cases passed
- CLI output budget smoke: passed
- repository mypy target: passed (12 source files)
- Ruff across all nine changed Python files: passed
- Python compile and base/head plus working-tree diff checks: passed
- changed-file public/private boundary scan: passed; three unrelated existing global-state warnings remain outside this PR

## Product and architecture judgment

The kernel problem is settlement identity, not monitor priority. The implementation keeps priority selection unchanged between turns while binding same-turn writeback to the receipt already committed by `quota should-run`. It reuses the typed receipt, Todo, capability, work-lane, and idempotency contracts; it does not add a scheduler, durable capability grant, or fallback heuristic. Missing receipts, mismatched Todos, changed result hashes, and changed materiality fail closed.

## Scope and review

- no scoring, benchmark semantics, permission boundary, or scheduler cadence changes
- no private state, credentials, local paths, raw logs, or generated artifacts included
- change-quality receipt: `cqr_2349a66108eebda347f2`
- exact committed-scope fingerprint: `2349a66108eebda347f259b31ffef0c736f362f87978540287193d381cd0166d`
- owner authorization for self-merge is recorded in the governing task; merge remains gated on fresh PR CI for head `86e158c45b6a9baf4d502ffd4a2c12906e75fcfa`
