### PR TITLE
fix(smoke): load LoopX in KunlunCode public check

### DIFF
--- a/examples/kunluncode-app-server-goal-pro-smoke.py
+++ b/examples/kunluncode-app-server-goal-pro-smoke.py
@@ -7,10 +7,15 @@ import argparse
 import json
 import os
 import shutil
+import sys
 import tempfile
 from pathlib import Path
 
-from loopx.kunluncode_goal_mode.app_server import (
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.kunluncode_goal_mode.app_server import (  # noqa: E402
     KUNLUN_APP_SERVER_PROTOCOL_VERSION,
     KunlunAppServerClient,
     build_app_server_command,


### PR DESCRIPTION
## Summary

- bootstrap the repository root before the KunlunCode app-server smoke imports `loopx`
- preserve the existing optional-binary behavior: a missing `kunluncode` executable remains a successful explicit skip
- restore the Full Public Smokes shard that started failing on main with `ModuleNotFoundError`

## Root cause

The new public smoke was executed by `examples/run-smokes.py` as a script under `examples/`. Python therefore placed the script directory, not the repository root, on `sys.path`. The smoke imported `loopx` before checking whether the optional KunlunCode binary was available, so the main workflow failed before reaching its typed skip path.

## Validation

- focused full-public runner for `examples/kunluncode-app-server-goal-pro-smoke.py`: passed, zero failures and warnings
- Ruff: passed
- repository mypy target: passed
- changed-file `py_compile`: passed
- `git diff --check`: passed
- public/private boundary scan: passed
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: passed 2/2 selected checks, zero failures, warnings, or manual holds
- change-quality receipt: `cqr_2fb272ad09efee4924fe`

## Scope

This is a single-file public-smoke execution repair. It changes no KunlunCode protocol, Goal semantics, benchmark behavior, permissions, workflow configuration, or product runtime. No private state, credentials, raw logs, generated evidence, or local paths are included.

This narrow cleanup is eligible for maintainer self-review and self-merge after required checks pass.
