### PR TITLE
fix(smoke): make public checks hermetic

### DIFF
--- a/examples/cli-help-manpage-smoke.py
+++ b/examples/cli-help-manpage-smoke.py
@@ -52,7 +52,7 @@ def assert_concise_default_help(output: str) -> None:
     assert "evidence-log --goal-id ID --agent-id AGENT --thin" in output, output
     assert "man loopx" in output, output
     assert LONG_TAIL_COMMAND not in output, output
-    assert len(output.splitlines()) <= 38, output
+    assert len(output.splitlines()) <= 39, output
 
 
 def assert_default_help_surface() -> None:
@@ -165,6 +165,7 @@ def assert_installer_manpage_surface() -> None:
             "LOOPX_SHELL_PROFILE": str(profile),
             "LOOPX_INSTALL_SKILL": "0",
             "LOOPX_INSTALL_CANARY": "0",
+            "LOOPX_PYTHON": sys.executable,
             "LOOPX_PROMOTE_DEFAULT": "1",
             "LOOPX_RELEASE_ID": "help-manpage-smoke-release",
             "PATH": os.environ.get("PATH", ""),

--- a/examples/control_plane/refresh-state-agent-lane-scope-smoke.py
+++ b/examples/control_plane/refresh-state-agent-lane-scope-smoke.py
@@ -106,9 +106,26 @@ def expect_value_error(message: str, callback) -> None:
     assert error and message in error, error
 
 
+def fixture_delivery_workspace(
+    current_path: Path | None = None,
+    *,
+    peer_independent_worktree_required: bool = False,
+) -> dict[str, object]:
+    del current_path
+    return {
+        "schema_version": "delivery_workspace_v0",
+        "task_repository": "git:github.com/loopx/refresh-state-fixture",
+        "repository_source": "smoke_fixture",
+        "workspace_kind": "independent_git_worktree",
+        "peer_independent_worktree_required": peer_independent_worktree_required,
+    }
+
+
 def main() -> None:
     original_now_local = state_refresh.now_local
+    original_capture_delivery_workspace = state_refresh.capture_delivery_workspace
     try:
+        state_refresh.capture_delivery_workspace = fixture_delivery_workspace
         with tempfile.TemporaryDirectory(prefix="loopx-agent-lane-refresh-") as raw_tmp:
             registry_path, runtime, project = write_fixture(Path(raw_tmp))
             state_path = project / f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
@@ -425,6 +442,7 @@ def main() -> None:
             assert "next_action_projection_warning" not in primary_goal_item, primary_goal_item
     finally:
         state_refresh.now_local = original_now_local
+        state_refresh.capture_delivery_workspace = original_capture_delivery_workspace
 
     print("refresh-state-agent-lane-scope-smoke ok")
 

--- a/man/loopx.1
+++ b/man/loopx.1
@@ -100,6 +100,9 @@ Use installed slash skills for `/loopx`; enable the adapter only when native `/l
 \fBOpenCode goal bridge\fR
 Opt into `\-\-with\-goal\-bridge`, then use `loopx_goal_activate` to bind the quota\-gated bridge.
 .TP
+\fBKunlunCode native Goal controller\fR
+Run `loopx\-kunluncode connect`, verify the managed MCP entry, then let `loopx\-kunluncode run` create or resume a verifier\-gated native Goal Pro.
+.TP
 \fBOther agent or shell\fR
 Use a CLI, task, automation, heartbeat, or scheduler hook; otherwise drive LoopX manually.
 .TP


### PR DESCRIPTION
## Summary

- fixture delivery-workspace capture in the refresh-state lane-scope smoke so the smoke validates lane behavior independent of the CI checkout topology
- update the intentional default-help line budget and regenerate the canonical manpage after the KunlunCode host entry
- pin the manpage installer subprocess to the smoke Python interpreter for hermetic validation

This repairs the two remaining failures from main Full Public Smokes run 32187119635. Product runtime behavior and the actual CLI help output are unchanged.

## Validation

- focused full-public runner: 2/2 passed
- canonical manpage renderer check: passed
- Ruff: passed
- mypy: passed (12 source files)
- Python compile and diff checks: passed
- LoopX public/private boundary check: passed for all 3 changed files
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: passed, 8 selected checks, 0 failures, 0 warnings, 0 manual holds
- change-quality receipt: cqr_212d599a2e9347a615ab
- scope fingerprint: 212d599a2e9347a615abccf3f73aab0e1acdee33f6a1d3e1328dcd1534021737

## Boundaries

No credentials, private state, raw logs, local absolute paths, or generated run evidence are included. The manpage is the canonical generated public artifact.