### PR TITLE
chore(release): prepare v0.4.9

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -443,6 +443,13 @@ path, and canary route rather than as a user-facing release baseline.
   matching `v0.4.8` tag. LoopX adopts Apache-2.0 for the open core, ships as a
   first-class PyPI distribution, adds per-Todo validation budgets, and tightens
   benchmark integrity qualification and Content Ops presentation density.
+- `v0.4.9` on 2026-08-19: cross-platform host and long-loop reliability release
+  at the matching `v0.4.9` tag. LoopX makes PyPI the default complete install
+  path, adds native Windows PowerShell and KunlunCode Goal Pro support, ships an
+  opt-in repository change-window provider with a durable pending-change
+  ledger, and hardens heartbeat settlement, Todo validation, PR review
+  scheduling, native Goal benchmark isolation, and public repository signal
+  providers.
 
 When a new public release is promoted, add it here only after the matching tag,
 release note, stable ref, update path, and focused release canary agree.

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.8"
+__version__ = "0.4.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.4.8"
+version = "0.4.9"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_license_metadata.py
+++ b/tests/test_license_metadata.py
@@ -31,8 +31,8 @@ def test_root_license_is_canonical_apache_2_with_historical_notices() -> None:
 
 def test_python_distributions_declare_apache_2() -> None:
     root_project = _project_metadata("pyproject.toml")
-    assert root_project["version"] == "0.4.8"
-    assert '__version__ = "0.4.8"' in (ROOT / "loopx/__init__.py").read_text()
+    assert root_project["version"] == "0.4.9"
+    assert '__version__ = "0.4.9"' in (ROOT / "loopx/__init__.py").read_text()
     assert root_project["license"] == "Apache-2.0"
     assert set(root_project["license-files"]) == {"LICENSE", "NOTICE", "LICENSE-MIT"}
 


### PR DESCRIPTION
# LoopX v0.4.9

## At a Glance

PyPI-first installation, native Windows and KunlunCode hosts, a repository
change-window that cannot silently lose gated code, and substantially more
reliable long-loop settlement and review scheduling.

### Upgrade

PyPI installs should upgrade in place. Archive installs should keep using the
stable archive updater and must not mix the two active executable paths.

```bash
python3 -m pip install --upgrade 'loopx==0.4.9'
loopx workflow-skills --install
loopx slash-commands --install
loopx --version && loopx doctor
```

### Highlights

- **A complete package-native install across more hosts:** PyPI is now the
  default complete install path, native PowerShell 7 is supported on Windows,
  and KunlunCode Goal Pro can run through its real app-server lifecycle with an
  independent completion verifier. Usage posture: install the package, then
  activate only the host integration you need.
  ([#3301](https://github.com/huangruiteng/loopx/pull/3301),
  [#2769](https://github.com/huangruiteng/loopx/pull/2769),
  [#2791](https://github.com/huangruiteng/loopx/pull/2791))
- **Gated repository work now has durable continuity:** the opt-in repository
  change-window evaluates typed timezone schedules, preserves existing local
  Git hooks, and records blocked unmerged work in a global public-safe ledger
  until it is merged, superseded, or abandoned.
  ([#3319](https://github.com/huangruiteng/loopx/pull/3319))
- **Heartbeat and Todo effects settle against one identity:** capability
  re-entry, monitor polling, replay, Todo-less replans, and terminal closeout
  retain the exact Todo/effect binding instead of silently switching work or
  repeating committed effects.
  ([#3258](https://github.com/huangruiteng/loopx/pull/3258),
  [#3261](https://github.com/huangruiteng/loopx/pull/3261),
  [#3270](https://github.com/huangruiteng/loopx/pull/3270),
  [#3304](https://github.com/huangruiteng/loopx/pull/3304),
  [#3321](https://github.com/huangruiteng/loopx/pull/3321),
  [#3328](https://github.com/huangruiteng/loopx/pull/3328),
  [#3329](https://github.com/huangruiteng/loopx/pull/3329),
  [#3330](https://github.com/huangruiteng/loopx/pull/3330),
  [#3333](https://github.com/huangruiteng/loopx/pull/3333),
  [#3334](https://github.com/huangruiteng/loopx/pull/3334))
- **Public repository signals become reusable extensions:** `loopx-repo-health`
  emits public-safe repository health snapshots, while
  `loopx-community-discussion` captures maintainer signals, external discussion,
  and explicit adoption declarations without private source bodies.
  ([#3272](https://github.com/huangruiteng/loopx/pull/3272),
  [#3299](https://github.com/huangruiteng/loopx/pull/3299),
  [#3325](https://github.com/huangruiteng/loopx/pull/3325),
  [#3326](https://github.com/huangruiteng/loopx/pull/3326))
- **Native Goal benchmark evidence is more attributable:** installed profiles,
  provider environment binding, host isolation, exact-container identity,
  post-run analyst packets, and public lifecycle summaries now fail closed at
  their owning boundaries. This release makes no benchmark-uplift claim.
  ([#3271](https://github.com/huangruiteng/loopx/pull/3271),
  [#3273](https://github.com/huangruiteng/loopx/pull/3273),
  [#3275](https://github.com/huangruiteng/loopx/pull/3275),
  [#3276](https://github.com/huangruiteng/loopx/pull/3276),
  [#3277](https://github.com/huangruiteng/loopx/pull/3277),
  [#3278](https://github.com/huangruiteng/loopx/pull/3278),
  [#3289](https://github.com/huangruiteng/loopx/pull/3289),
  [#3298](https://github.com/huangruiteng/loopx/pull/3298),
  [#3303](https://github.com/huangruiteng/loopx/pull/3303),
  [#3327](https://github.com/huangruiteng/loopx/pull/3327))

### Replan Fixes

- Todo-less autonomous replans now settle through a typed semantic result
  instead of remaining permanently active after acceptance is already closed.
  ([#3304](https://github.com/huangruiteng/loopx/pull/3304))
- Capability re-entry and monitor polling preserve the heartbeat receipt's
  exact Todo/effect identity, so a same-turn queue change cannot redirect
  accounting to another candidate.
  ([#3321](https://github.com/huangruiteng/loopx/pull/3321),
  [#3328](https://github.com/huangruiteng/loopx/pull/3328),
  [#3329](https://github.com/huangruiteng/loopx/pull/3329),
  [#3330](https://github.com/huangruiteng/loopx/pull/3330),
  [#3334](https://github.com/huangruiteng/loopx/pull/3334))
- Terminal closeout and failed-turn retry now resume the proven session/effect
  and reject ambiguous or unauthorized replay.
  ([#3258](https://github.com/huangruiteng/loopx/pull/3258),
  [#3261](https://github.com/huangruiteng/loopx/pull/3261),
  [#3262](https://github.com/huangruiteng/loopx/pull/3262),
  [#3266](https://github.com/huangruiteng/loopx/pull/3266),
  [#3270](https://github.com/huangruiteng/loopx/pull/3270))

### Contributors

Community contributors in this release are
[@yuefengw](https://github.com/yuefengw),
[@NIU-123370](https://github.com/NIU-123370),
[@wchwawa](https://github.com/wchwawa),
[@liubf21](https://github.com/liubf21),
[@ObVious55](https://github.com/ObVious55), and first-time external contributors
[@KarlLeen](https://github.com/KarlLeen),
[@yixuanchen189756-source](https://github.com/yixuanchen189756-source), and
[@sxw228](https://github.com/sxw228). Their concrete work is linked in
`Community Contributors` below.

## Release Decision

**Who should upgrade:** Operators using heartbeat automation, terminal Todo settlement, PyPI installation, native Windows, KunlunCode, public repository signal providers, or native Goal qualification should upgrade. Users pinned to a stable v0.4.8 workflow that does not touch these surfaces may wait for their normal maintenance window.

**What this release solves:** It closes effect-identity and replay gaps that could strand long-running work, makes complete installation portable across Python and Windows hosts, preserves code blocked by local repository schedules, and binds public benchmark and repository evidence to typed sources.

**Breaking changes:** No. Existing persisted goal state remains compatible. The recommended complete install path changes from the archive bootstrap to PyPI; existing archive installs remain supported but should keep using `loopx update` rather than mixing package managers. New host, provider, benchmark, Reward Memory, and change-window surfaces remain explicit opt-ins.

**How to verify:** After publication, the package must report `0.4.9`, doctor must pass, the chosen host or capability must read back its own status, and the release assets, attestations, PyPI project, and `stable` ref must all resolve to the same qualified release commit.

**Contributors:** Maintainer @huangruiteng prepared the release; community contributions came from @yuefengw, @NIU-123370, @wchwawa, @liubf21, @ObVious55, and first-time external contributors @KarlLeen, @yixuanchen189756-source, and @sxw228.

```bash
python3 -m pip install --upgrade 'loopx==0.4.9'
loopx --version
loopx doctor
loopx change-window status --repo-path . --format json
```

## State Kernel & Control Plane

- **One settlement identity across re-entry, replay, and monitors:** heartbeat
  receipts retain the admitted Todo while capabilities become available,
  monitor-poll recording moves behind a bounded CLI owner, and replay cannot
  bind spend/writeback to a different effect.
  ([#3321](https://github.com/huangruiteng/loopx/pull/3321),
  [#3328](https://github.com/huangruiteng/loopx/pull/3328),
  [#3329](https://github.com/huangruiteng/loopx/pull/3329),
  [#3330](https://github.com/huangruiteng/loopx/pull/3330),
  [#3333](https://github.com/huangruiteng/loopx/pull/3333),
  [#3334](https://github.com/huangruiteng/loopx/pull/3334))
- **Terminal work fails closed without losing progress:** ambiguous spends,
  same-turn terminal closeout, preserved failed sessions, and no-follow-up
  acknowledgements now use typed lifecycle truth.
  ([#3258](https://github.com/huangruiteng/loopx/pull/3258),
  [#3261](https://github.com/huangruiteng/loopx/pull/3261),
  [#3262](https://github.com/huangruiteng/loopx/pull/3262),
  [#3266](https://github.com/huangruiteng/loopx/pull/3266),
  [#3270](https://github.com/huangruiteng/loopx/pull/3270),
  [#3304](https://github.com/huangruiteng/loopx/pull/3304))
- **Todo and evidence contracts are stricter and more complete:** user-role
  completion runs declared validation, `todo add --note` persists its note,
  evidence filtering uses the correct agent identity and UTC ordering, and the
  hard-lease gate closes alternate claim/completion paths.
  ([#3291](https://github.com/huangruiteng/loopx/pull/3291),
  [#3293](https://github.com/huangruiteng/loopx/pull/3293),
  [#3306](https://github.com/huangruiteng/loopx/pull/3306),
  [#3311](https://github.com/huangruiteng/loopx/pull/3311),
  [#3323](https://github.com/huangruiteng/loopx/pull/3323))
- **Review and identity routing stay durable:** unbound `/loopx` sessions can
  inherit the existing registered identity, and PR review observation keeps an
  ignored age-fair exact-head cursor rather than restarting from queue order.
  ([#3315](https://github.com/huangruiteng/loopx/pull/3315),
  [#3317](https://github.com/huangruiteng/loopx/pull/3317))

## Capabilities & Workflows

- **Repository change window:** a built-in outcome capability plus bundled
  Git-hook provider offers typed IANA-timezone policy, install/status/verify/
  uninstall lifecycle, preservation of a pre-existing repository-local hook
  route, linked-worktree consistency, and a global content-free pending-change
  ledger. It is default-off and does not replace branch protection.
  ([#3319](https://github.com/huangruiteng/loopx/pull/3319))
- **Reward Memory post-outcome utility:** a default-off proposal-only evaluator
  can classify a used memory as helpful, harmful, neutral, or unknown against
  trusted scope and outcome references without mutating disposition or making
  the model a source of outcome truth.
  ([#3280](https://github.com/huangruiteng/loopx/pull/3280))
- **Public repository signals:** two independently packaged optional providers
  expose repository health, maintainer/external discussion, and adoption facts
  through versioned public-safe schemas and the extension lifecycle.
  ([#3272](https://github.com/huangruiteng/loopx/pull/3272),
  [#3299](https://github.com/huangruiteng/loopx/pull/3299),
  [#3325](https://github.com/huangruiteng/loopx/pull/3325),
  [#3326](https://github.com/huangruiteng/loopx/pull/3326))
- **Machine-checkable Computer Use boundary:** schemas and negative fixtures
  define action-unit, gate-revision, replay, credential-smuggling, provider
  writeback, and final-effect rules. This is a protocol/validator layer, not a
  bundled browser provider or permission grant.
  ([#3279](https://github.com/huangruiteng/loopx/pull/3279))

## Quality & Testing

- **Public smokes are hermetic again:** installed-source loading and shared
  workflow assumptions no longer make the KunlunCode and public smoke lanes
  fail because of the caller's environment.
  ([#3302](https://github.com/huangruiteng/loopx/pull/3302),
  [#3331](https://github.com/huangruiteng/loopx/pull/3331),
  [#3332](https://github.com/huangruiteng/loopx/pull/3332))
- **Synthetic boundaries remain explicit:** stride comparisons and restored
  NoKV shadow-provider evidence cover deterministic seams without turning
  synthetic results into product or benchmark claims.
  ([#3290](https://github.com/huangruiteng/loopx/pull/3290),
  [#3307](https://github.com/huangruiteng/loopx/pull/3307))
- **Contributor and review hygiene is machine-visible:** DCO reminders, the
  Contributor Covenant, non-closing stale-issue reminders, and current task
  metadata make collaboration clearer without auto-rejecting old work.
  ([#3294](https://github.com/huangruiteng/loopx/pull/3294),
  [#3297](https://github.com/huangruiteng/loopx/pull/3297),
  [#3316](https://github.com/huangruiteng/loopx/pull/3316),
  [#3322](https://github.com/huangruiteng/loopx/pull/3322),
  [#3324](https://github.com/huangruiteng/loopx/pull/3324))

## Benchmarks & Integrations

- **Native Codex Goal path:** the active DeepSWE adapter now uses the real
  app-server Goal lifecycle, verifies installed profiles and discovered skills,
  separates provider environment from agent access, supports explicit Linux
  isolation, binds runtime observations to the exact job container, and emits a
  public lifecycle summary without raw events or task text.
  ([#3271](https://github.com/huangruiteng/loopx/pull/3271),
  [#3273](https://github.com/huangruiteng/loopx/pull/3273),
  [#3275](https://github.com/huangruiteng/loopx/pull/3275),
  [#3276](https://github.com/huangruiteng/loopx/pull/3276),
  [#3277](https://github.com/huangruiteng/loopx/pull/3277),
  [#3278](https://github.com/huangruiteng/loopx/pull/3278),
  [#3289](https://github.com/huangruiteng/loopx/pull/3289),
  [#3298](https://github.com/huangruiteng/loopx/pull/3298),
  [#3303](https://github.com/huangruiteng/loopx/pull/3303),
  [#3327](https://github.com/huangruiteng/loopx/pull/3327))
- **KunlunCode Goal Pro:** the packaged adapter provisions its owned MCP
  environment, drives the real app-server Goal transaction, requires native
  verifier completion, journals only compact ignored state, and reconciles
  interrupted terminal writeback without model-owned LoopX lifecycle effects.
  ([#2791](https://github.com/huangruiteng/loopx/pull/2791))
- **Native Windows PowerShell:** the package and trusted-checkout paths support
  Python 3.11+, PowerShell 7, atomic release pointers, explicit PATH opt-in,
  cross-process file locks, deep doctor validation, and fail-closed snapshot
  upgrade/rollback.
  ([#2769](https://github.com/huangruiteng/loopx/pull/2769))
- **No benchmark outcome claim:** v0.4.9 improves harness fidelity,
  attribution, and public evidence contracts; it does not claim a
  stable-versus-candidate score or long-horizon uplift.

## Documentation & Compatibility

- **PyPI is the recommended complete install path:** packaged workflow skills,
  command facades, doctor repair, canonical project metadata, and uninstall
  guidance live under one package-native workflow; the archive path remains a
  recovery fallback.
  ([#3301](https://github.com/huangruiteng/loopx/pull/3301))
- **Public authority boundaries are easier to inspect:** the shared-goal RFC
  matches the shipped handoff-mode gate, the NoKV RFC separates storage from
  LoopX authority, the Computer Use protocol is machine-checkable, and open
  strategy/contribution processes no longer depend on private context.
  ([#3263](https://github.com/huangruiteng/loopx/pull/3263),
  [#3279](https://github.com/huangruiteng/loopx/pull/3279),
  [#3295](https://github.com/huangruiteng/loopx/pull/3295),
  [#3308](https://github.com/huangruiteng/loopx/pull/3308))
- **Compatibility:** no persisted-state migration is required. New capability,
  provider, host, and benchmark routes remain opt-in; archive installs remain
  supported; package and archive upgrade mechanisms should not be mixed for one
  active executable.

## Community Contributors

- [@yuefengw](https://github.com/yuefengw) added post-outcome Reward Memory
  utility attribution and repaired Todo evidence identity/UTC ordering in
  [#3280](https://github.com/huangruiteng/loopx/pull/3280) and
  [#3311](https://github.com/huangruiteng/loopx/pull/3311).
- [@NIU-123370](https://github.com/NIU-123370) added user-role validation
  execution and its public contract, a synthetic stride-boundary fixture, and
  the Explore Feishu CLI module extraction in
  [#3291](https://github.com/huangruiteng/loopx/pull/3291),
  [#3293](https://github.com/huangruiteng/loopx/pull/3293),
  [#3290](https://github.com/huangruiteng/loopx/pull/3290), and
  [#3309](https://github.com/huangruiteng/loopx/pull/3309).
- [@wchwawa](https://github.com/wchwawa) closed hard-lease side doors, restored
  current NoKV shadow evidence, and synchronized the shared-goal RFC in
  [#3306](https://github.com/huangruiteng/loopx/pull/3306),
  [#3307](https://github.com/huangruiteng/loopx/pull/3307), and
  [#3308](https://github.com/huangruiteng/loopx/pull/3308).
- [@liubf21](https://github.com/liubf21) retired the covered GH-C91 task after
  its implementation landed in
  [#3287](https://github.com/huangruiteng/loopx/pull/3287).
- [@ObVious55](https://github.com/ObVious55) made failed-turn retry resume its
  preserved session in [#3262](https://github.com/huangruiteng/loopx/pull/3262).
- First-time external contributor [@KarlLeen](https://github.com/KarlLeen)
  authored the machine-checkable Computer Use runtime contract in
  [#3279](https://github.com/huangruiteng/loopx/pull/3279).
- First-time external contributor
  [@yixuanchen189756-source](https://github.com/yixuanchen189756-source)
  integrated native KunlunCode Goal Pro in
  [#2791](https://github.com/huangruiteng/loopx/pull/2791).
- First-time external contributor [@sxw228](https://github.com/sxw228) added
  native Windows PowerShell support in
  [#2769](https://github.com/huangruiteng/loopx/pull/2769).

## Optional Capability Activation & Use

### Repository Change Window

**Activation:** Preview and then install the repository-local Git-hook provider. The default typed policy blocks Monday through Friday from 10:00 to 21:00 in `Asia/Shanghai`; pass an IANA timezone and repeated weekday flags to customize it.

**Validation:** Read both policy/decision state and managed-hook integrity back from the same repository.

**Disable / rollback:** Preview and execute `uninstall`; LoopX restores the exact repository-local `core.hooksPath` value that preceded installation and retains pending-change history for typed resolution.

**Authority boundary:** The provider is local workflow enforcement. It does not grant commit, push, PR, merge, protected-branch, credential, or production authority and does not replace server-side branch protection.

**Docs:** https://github.com/huangruiteng/loopx/blob/v0.4.9/loopx/capabilities/repository_change_window/README.md

```bash
loopx change-window install --repo-path . --format json
loopx change-window install --repo-path . --execute --format json
loopx change-window status --repo-path . --format json
loopx change-window verify --repo-path . --format json
loopx change-window uninstall --repo-path . --execute --format json
```

### PyPI Complete Installation

**Activation:** Install the pinned package, then explicitly install packaged workflow skills and command facades for the current host.

**Validation:** `loopx --version` must report `0.4.9` and `loopx doctor` must identify a healthy Python distribution install.

**Disable / rollback:** Remove LoopX-owned host material before uninstalling, or pin `loopx==0.4.8` for package rollback. Do not mix the archive and PyPI update mechanisms for one active executable.

**Authority boundary:** Installation exposes local commands and skills only. It grants no repository, network, credential, provider, merge, or external-write authority and preserves project-local state on uninstall.

**Docs:** https://github.com/huangruiteng/loopx/blob/v0.4.9/docs/guides/installing-loopx.md

```bash
python3 -m pip install --upgrade 'loopx==0.4.9'
loopx workflow-skills --install
loopx slash-commands --install
loopx --version && loopx doctor
loopx slash-commands --uninstall && loopx workflow-skills --uninstall
python3 -m pip install 'loopx==0.4.8'
```

### Public Repository Signal Extensions

**Activation:** Install the two co-located provider packages from a v0.4.9 source checkout, then register only the extension manifests you intend to use.

**Validation:** Run each provider doctor and a bounded managed request before relying on its versioned public-safe response schema.

**Disable / rollback:** Disable each extension in LoopX, then uninstall its Python distribution. Disabling does not delete prior public-safe projection records.

**Authority boundary:** These providers read public repository/discussion metadata only. They do not grant credentials, private-source access, outreach, repository writes, benchmark evidence access, or merge authority.

**Docs:** https://github.com/huangruiteng/loopx/blob/v0.4.9/packages/loopx-repo-health/README.md and https://github.com/huangruiteng/loopx/blob/v0.4.9/packages/loopx-community-discussion/README.md

```bash
git clone --branch v0.4.9 https://github.com/huangruiteng/loopx.git loopx-v0.4.9
python3 -m pip install ./loopx-v0.4.9/packages/loopx-repo-health ./loopx-v0.4.9/packages/loopx-community-discussion
loopx extension install --manifest ./loopx-v0.4.9/packages/loopx-repo-health/extension.toml --execute --format json
loopx extension install --manifest ./loopx-v0.4.9/packages/loopx-community-discussion/extension.toml --execute --format json
loopx extension doctor loopx-repo-health --execute --format json
loopx extension doctor loopx-community-discussion --execute --format json
loopx extension disable loopx-repo-health --execute --format json
loopx extension disable loopx-community-discussion --execute --format json
python3 -m pip uninstall -y loopx-repo-health loopx-community-discussion
```

### Reward Memory Post-Outcome Utility

**Activation:** Reward Memory remains a per-goal, per-agent, default-off experiment. Preview `configure-goal`, then execute it only with an ignored repo-relative v1 experiment config and an explicit registered-agent allowlist.

**Validation:** Read back `experiment-status`; the new utility evaluator remains proposal-only and is exercised through bounded reviewed observations.

**Disable / rollback:** Clear the goal's Reward Memory config and agent allowlist with the typed configuration command.

**Authority boundary:** Activation grants no generic write, merge, provider, or outcome authority. Model proposals cannot become trusted utility observations without separately trusted scope, outcome, retrieval, and policy references.

**Docs:** https://github.com/huangruiteng/loopx/blob/v0.4.9/loopx/capabilities/reward_memory/README.md

```bash
loopx configure-goal --goal-id my-goal --reward-memory-config .loopx/config/reward-memory/experiment.json --reward-memory-agent my-agent
loopx configure-goal --goal-id my-goal --reward-memory-config .loopx/config/reward-memory/experiment.json --reward-memory-agent my-agent --execute
loopx reward-memory experiment-status --goal-id my-goal --agent-id my-agent --format json
loopx configure-goal --goal-id my-goal --clear-reward-memory-config --execute
```

### KunlunCode Goal Pro

**Activation:** Install LoopX, provision the adapter-owned MCP environment, and connect one project/goal/agent binding before running the native Goal Pro controller.

**Validation:** Test the named MCP registration and read the joint native/LoopX status; the terminal state is accepted only after KunlunCode reports `verification_passed`.

**Disable / rollback:** Stop invoking `run`; uninstall the host-wide MCP entry with `loopx-kunluncode uninstall`. Remove ignored project bindings only after a committed journal or explicit abandonment.

**Authority boundary:** KunlunCode permission mode does not grant LoopX lifecycle, repository, credential, provider, merge, or production authority. The model cannot directly complete the bound LoopX Todo before the native verifier.

**Docs:** https://github.com/huangruiteng/loopx/blob/v0.4.9/loopx/kunluncode_goal_mode/README.md

```bash
python3 -m pip install --upgrade 'loopx==0.4.9'
loopx-kunluncode install
loopx-kunluncode connect --project . --goal-id my-goal --agent-id kunlun
kunluncode --cwd "$PWD" mcp test loopx-kunluncode
loopx-kunluncode status --project .
loopx-kunluncode uninstall
```

### Native Windows PowerShell

**Activation:** From PowerShell 7 with Python 3.11+, install the PyPI package and packaged skills. A trusted-checkout snapshot may instead invoke `scripts/install-windows.ps1` with explicit PATH opt-in.

**Validation:** Run deep doctor in a fresh PowerShell process so PATH and release-pointer readback are real.

**Disable / rollback:** Run the managed host uninstallers before package uninstall. Snapshot rollback is fail-closed: check out the intended trusted revision, rerun the installer, and verify deep doctor rather than editing the release pointer manually.

**Authority boundary:** Native installation changes local command, skill, optional PATH, and snapshot files only. It grants no repository, network, credential, external-system, merge, or production authority and does not delete project-local state.

**Docs:** https://github.com/huangruiteng/loopx/blob/v0.4.9/docs/guides/installing-loopx.md#native-windows-powershell-7

```bash
pwsh -NoLogo -NoProfile -Command 'py -3.11 -m pip install --upgrade loopx'
pwsh -NoLogo -NoProfile -Command 'loopx workflow-skills --install; loopx doctor --deep'
pwsh -NoLogo -NoProfile -Command 'loopx slash-commands --uninstall; loopx workflow-skills --uninstall; py -3.11 -m pip uninstall -y loopx'
```

### Native Goal Benchmark Qualification

**Activation:** There is no persistent switch. Opt in per run from the v0.4.9 source checkout, with task/objective files, an explicit model route, and separately prepared installed-profile evidence.

**Validation:** Use `--preflight-only` to prove app-server initialization, thread creation, Goal attachment, and installed profile/skill discovery without starting a model turn.

**Disable / rollback:** Stop invoking the runner and use a dedicated v0.4.8 checkout to restore the prior harness. Remove only runner-created per-run profile/isolation directories after their controller is terminal.

**Authority boundary:** The runner does not grant access to task answers, verifier output, credentials, uploads, submissions, leaderboard actions, or LoopX settlement. The controller owns execution, isolation, verification, and countability; this release makes no score/uplift claim.

**Docs:** https://github.com/huangruiteng/loopx/blob/v0.4.9/benchmark/deepswe/README.md

```bash
python benchmark/deepswe/run_native_codex_goal.py --cwd task-worktree --objective-file objective.txt --task-file task.txt --model model-route --preflight-only
git -C dedicated-loopx-benchmark-checkout switch --detach v0.4.8
```

## Install / Update

New PyPI users and existing PyPI users use the same package-native path:

```bash
python3 -m pip install --upgrade 'loopx==0.4.9'
loopx workflow-skills --install
loopx slash-commands --install
loopx doctor
```

Archive-fallback users should preview and execute their stable update:

```bash
loopx update --check --ref stable
loopx update --execute --ref stable
loopx doctor
```

## 中文摘要

v0.4.9 把完整安装切换到 PyPI 默认路径，加入原生 Windows PowerShell 与
KunlunCode Goal Pro host，提供默认关闭的仓库变更时间窗与未合入工作台账，并修复
长循环 heartbeat、Todo、replan 与 terminal settlement 的身份漂移和重放问题。

### 升级决策

**谁需要升级：**使用 heartbeat automation、terminal Todo settlement、PyPI 安装、原生 Windows、KunlunCode、公共仓库信号 provider 或 native Goal qualification 的 operator 应升级；不涉及这些路径且已稳定固定在 v0.4.8 的用户可以等到正常维护窗口。

**解决了什么：**本版本关闭会让长循环工作搁浅的 effect identity 与 replay 缺口，使完整安装覆盖更多主机，并确保受仓库时间门禁阻塞的代码、公共 benchmark 证据和仓库信号都有可追踪的 typed source。

**是否有破坏性变更：**无。已有持久状态兼容；推荐的完整安装入口从 archive bootstrap 改为 PyPI，已有 archive 安装仍受支持，但同一 active executable 不应混用两套更新机制。新 host、provider、benchmark、Reward Memory 与 change-window 路径均保持显式 opt-in。

**如何验证：**发布后确认 package 报告 `0.4.9`、doctor 通过、所选 host/capability 可读回状态，并验证 release assets、attestations、PyPI 与 `stable` ref 绑定同一 qualified commit。

**贡献者：**版本由 maintainer @huangruiteng 准备；社区贡献来自 @yuefengw、@NIU-123370、@wchwawa、@liubf21、@ObVious55，以及首次外部贡献者 @KarlLeen、@yixuanchen189756-source 和 @sxw228。

```bash
python3 -m pip install --upgrade 'loopx==0.4.9'
loopx --version
loopx doctor
loopx change-window status --repo-path . --format json
```

### 状态内核与控制面

- heartbeat capability re-entry、monitor poll 与 replay 共享同一 Todo/effect
  identity；终态 closeout、失败 session 恢复与 Todo-less replan 不再靠模糊 ACK
  收口。
  ([#3258](https://github.com/huangruiteng/loopx/pull/3258),
  [#3261](https://github.com/huangruiteng/loopx/pull/3261),
  [#3262](https://github.com/huangruiteng/loopx/pull/3262),
  [#3270](https://github.com/huangruiteng/loopx/pull/3270),
  [#3304](https://github.com/huangruiteng/loopx/pull/3304),
  [#3321](https://github.com/huangruiteng/loopx/pull/3321),
  [#3328](https://github.com/huangruiteng/loopx/pull/3328),
  [#3329](https://github.com/huangruiteng/loopx/pull/3329),
  [#3330](https://github.com/huangruiteng/loopx/pull/3330),
  [#3334](https://github.com/huangruiteng/loopx/pull/3334))
- user-role validation、Todo note、agent/UTC evidence filter、hard-lease side door
  与 exact-head review cursor 都进入 typed state，而不是依赖旁路文本。
  ([#3291](https://github.com/huangruiteng/loopx/pull/3291),
  [#3293](https://github.com/huangruiteng/loopx/pull/3293),
  [#3306](https://github.com/huangruiteng/loopx/pull/3306),
  [#3311](https://github.com/huangruiteng/loopx/pull/3311),
  [#3317](https://github.com/huangruiteng/loopx/pull/3317),
  [#3323](https://github.com/huangruiteng/loopx/pull/3323))

### 能力与工作流

- Repository Change Window 提供 typed 时区/时间表、保留已有 hook 的 provider、
  install/status/verify/uninstall 与全局 pending-change ledger；默认关闭且不替代
  branch protection。([#3319](https://github.com/huangruiteng/loopx/pull/3319))
- Reward Memory 新增默认关闭、proposal-only 的 post-outcome utility attribution；
  两个独立 extension 提供 public repo health、community discussion 与 adoption
  facts。([#3280](https://github.com/huangruiteng/loopx/pull/3280),
  [#3272](https://github.com/huangruiteng/loopx/pull/3272),
  [#3299](https://github.com/huangruiteng/loopx/pull/3299),
  [#3325](https://github.com/huangruiteng/loopx/pull/3325),
  [#3326](https://github.com/huangruiteng/loopx/pull/3326))
- Computer Use 增加 machine-checkable protocol/schema/negative fixtures；它是 validator
  层，不包含 browser provider，也不授予 UI write 权限。
  ([#3279](https://github.com/huangruiteng/loopx/pull/3279))

### 质量与测试

- public smokes 恢复 hermetic source loading；KunlunCode、release artifact 与公共
  smoke 不再被 caller 环境误伤。
  ([#3302](https://github.com/huangruiteng/loopx/pull/3302),
  [#3331](https://github.com/huangruiteng/loopx/pull/3331),
  [#3332](https://github.com/huangruiteng/loopx/pull/3332))
- DCO、Contributor Covenant、stale issue reminder 与 contributor task metadata
  让公共协作规则可读且不会自动关闭旧 issue。
  ([#3294](https://github.com/huangruiteng/loopx/pull/3294),
  [#3297](https://github.com/huangruiteng/loopx/pull/3297),
  [#3316](https://github.com/huangruiteng/loopx/pull/3316),
  [#3322](https://github.com/huangruiteng/loopx/pull/3322),
  [#3324](https://github.com/huangruiteng/loopx/pull/3324))

### 基准与集成

- Native Codex Goal benchmark 连接真实 app-server Goal lifecycle，验证 installed
  profile 与 skill discovery，并补齐 provider env、host isolation、exact container、
  post-run analyst 与 public lifecycle summary；本版本不声明 benchmark uplift。
  ([#3271](https://github.com/huangruiteng/loopx/pull/3271),
  [#3273](https://github.com/huangruiteng/loopx/pull/3273),
  [#3275](https://github.com/huangruiteng/loopx/pull/3275),
  [#3276](https://github.com/huangruiteng/loopx/pull/3276),
  [#3277](https://github.com/huangruiteng/loopx/pull/3277),
  [#3298](https://github.com/huangruiteng/loopx/pull/3298),
  [#3303](https://github.com/huangruiteng/loopx/pull/3303),
  [#3327](https://github.com/huangruiteng/loopx/pull/3327))
- KunlunCode Goal Pro 和原生 Windows PowerShell 成为可安装、可验证、可卸载的 host
  surface。([#2791](https://github.com/huangruiteng/loopx/pull/2791),
  [#2769](https://github.com/huangruiteng/loopx/pull/2769))

### 文档与兼容性

- PyPI 成为推荐的 complete install path；archive 保留为 recovery fallback，且同一
  executable 不应混用两套更新机制。
  ([#3301](https://github.com/huangruiteng/loopx/pull/3301))
- shared-goal、NoKV、Computer Use 与开放策略/贡献流程的 authority boundary 均已
  公开化、typed 化。([#3263](https://github.com/huangruiteng/loopx/pull/3263),
  [#3279](https://github.com/huangruiteng/loopx/pull/3279),
  [#3295](https://github.com/huangruiteng/loopx/pull/3295),
  [#3308](https://github.com/huangruiteng/loopx/pull/3308))
- 无持久状态迁移要求；所有新 capability/provider/host/benchmark 路径保持显式
  opt-in。

### 社区贡献者

- [@yuefengw](https://github.com/yuefengw)：Reward Memory post-outcome utility
  与 Todo evidence identity/UTC ordering
  ([#3280](https://github.com/huangruiteng/loopx/pull/3280),
  [#3311](https://github.com/huangruiteng/loopx/pull/3311))。
- [@NIU-123370](https://github.com/NIU-123370)：user-role validation、stride
  fixture 与 Explore Feishu CLI 拆分
  ([#3291](https://github.com/huangruiteng/loopx/pull/3291),
  [#3293](https://github.com/huangruiteng/loopx/pull/3293),
  [#3290](https://github.com/huangruiteng/loopx/pull/3290),
  [#3309](https://github.com/huangruiteng/loopx/pull/3309))。
- [@wchwawa](https://github.com/wchwawa)：hard-lease 修复、NoKV shadow evidence
  与 shared-goal RFC 同步
  ([#3306](https://github.com/huangruiteng/loopx/pull/3306),
  [#3307](https://github.com/huangruiteng/loopx/pull/3307),
  [#3308](https://github.com/huangruiteng/loopx/pull/3308))。
- [@liubf21](https://github.com/liubf21)：在实现落地后清理 GH-C91 task
  ([#3287](https://github.com/huangruiteng/loopx/pull/3287))。
- [@ObVious55](https://github.com/ObVious55)：失败 Turn 恢复已保存 session
  ([#3262](https://github.com/huangruiteng/loopx/pull/3262))。
- 首次外部贡献者 [@KarlLeen](https://github.com/KarlLeen)：Computer Use runtime
  contract ([#3279](https://github.com/huangruiteng/loopx/pull/3279))。
- 首次外部贡献者 [@yixuanchen189756-source](https://github.com/yixuanchen189756-source)：
  KunlunCode Goal Pro ([#2791](https://github.com/huangruiteng/loopx/pull/2791))。
- 首次外部贡献者 [@sxw228](https://github.com/sxw228)：原生 Windows PowerShell
  支持 ([#2769](https://github.com/huangruiteng/loopx/pull/2769))。

### 可选能力启用与使用

#### Repository Change Window

**启用：**先 preview，再安装 repository-local Git-hook provider。默认 typed policy 为 `Asia/Shanghai` 时区周一到周五 10:00–21:00；可用 IANA timezone 和重复 weekday 参数定制。

**验证：**在同一仓库读回 policy/decision 与 managed-hook integrity。

**停用 / 回退：**preview 后执行 `uninstall`；LoopX 恢复安装前的 repository-local `core.hooksPath`，pending-change history 继续保留用于 typed resolution。

**权限边界：**它只是本地 workflow enforcement，不授予 commit、push、PR、merge、protected branch、credential 或 production 权限，也不替代 server-side branch protection。

**文档：**https://github.com/huangruiteng/loopx/blob/v0.4.9/loopx/capabilities/repository_change_window/README.md

```bash
loopx change-window install --repo-path . --execute --format json
loopx change-window status --repo-path . --format json
loopx change-window verify --repo-path . --format json
loopx change-window uninstall --repo-path . --execute --format json
```

#### PyPI Complete Installation

**启用：**安装 pinned package，并显式安装当前 host 所需的 packaged workflow skills 与 command facades。

**验证：**`loopx --version` 必须报告 `0.4.9`，`loopx doctor` 必须识别健康的 Python distribution install。

**停用 / 回退：**先移除 LoopX-owned host material，再卸载 package；需要回退时 pin `loopx==0.4.8`。同一 active executable 不混用 archive 与 PyPI 更新机制。

**权限边界：**安装只暴露本地 command/skill，不授予 repository、network、credential、provider、merge 或 external-write 权限；卸载保留 project-local state。

**文档：**https://github.com/huangruiteng/loopx/blob/v0.4.9/docs/guides/installing-loopx.md

```bash
python3 -m pip install --upgrade 'loopx==0.4.9'
loopx workflow-skills --install
loopx slash-commands --install
loopx --version && loopx doctor
loopx slash-commands --uninstall && loopx workflow-skills --uninstall
python3 -m pip install 'loopx==0.4.8'
```

#### Public Repository Signal Extensions

**启用：**从 v0.4.9 source checkout 安装两个 co-located provider package，并只注册需要的 extension manifest。

**验证：**运行两个 provider doctor 与 bounded managed request，再依赖其 versioned public-safe schema。

**停用 / 回退：**先 `extension disable`，再卸载对应 Python distribution；既有 public-safe projection 不会因 disable 删除。

**权限边界：**provider 只读公共 repository/discussion metadata，不授予 credential、private-source、outreach、repository write、benchmark evidence 或 merge 权限。

**文档：**https://github.com/huangruiteng/loopx/blob/v0.4.9/packages/loopx-repo-health/README.md 和 https://github.com/huangruiteng/loopx/blob/v0.4.9/packages/loopx-community-discussion/README.md

```bash
git clone --branch v0.4.9 https://github.com/huangruiteng/loopx.git loopx-v0.4.9
python3 -m pip install ./loopx-v0.4.9/packages/loopx-repo-health ./loopx-v0.4.9/packages/loopx-community-discussion
loopx extension install --manifest ./loopx-v0.4.9/packages/loopx-repo-health/extension.toml --execute --format json
loopx extension install --manifest ./loopx-v0.4.9/packages/loopx-community-discussion/extension.toml --execute --format json
loopx extension doctor loopx-repo-health --execute --format json
loopx extension doctor loopx-community-discussion --execute --format json
loopx extension disable loopx-repo-health --execute --format json
loopx extension disable loopx-community-discussion --execute --format json
python3 -m pip uninstall -y loopx-repo-health loopx-community-discussion
```

#### Reward Memory Post-Outcome Utility

**启用：**Reward Memory 仍是 per-goal/per-agent/default-off experiment；先 preview，再以 ignored repo-relative v1 config 和显式 registered-agent allowlist 执行 `configure-goal`。

**验证：**读回 `experiment-status`；新 utility evaluator 保持 proposal-only，并只处理 bounded reviewed observation。

**停用 / 回退：**用 typed configuration command 清除 goal 的 Reward Memory config 与 agent allowlist。

**权限边界：**启用不授予 generic write、merge、provider 或 outcome authority；model proposal 必须有独立可信的 scope、outcome、retrieval 和 policy reference 才能成为 utility observation。

**文档：**https://github.com/huangruiteng/loopx/blob/v0.4.9/loopx/capabilities/reward_memory/README.md

```bash
loopx configure-goal --goal-id my-goal --reward-memory-config .loopx/config/reward-memory/experiment.json --reward-memory-agent my-agent
loopx configure-goal --goal-id my-goal --reward-memory-config .loopx/config/reward-memory/experiment.json --reward-memory-agent my-agent --execute
loopx reward-memory experiment-status --goal-id my-goal --agent-id my-agent --format json
loopx configure-goal --goal-id my-goal --clear-reward-memory-config --execute
```

#### KunlunCode Goal Pro

**启用：**安装 LoopX，provision adapter-owned MCP environment，并在运行 native Goal Pro 前连接一个 project/goal/agent binding。

**验证：**测试 named MCP registration 并读回 native/LoopX joint status；只有 KunlunCode 报告 `verification_passed` 才接受 terminal state。

**停用 / 回退：**停止调用 `run`，用 `loopx-kunluncode uninstall` 移除 host-wide MCP entry；只有 journal 已 committed 或明确放弃时才移除 ignored project binding。

**权限边界：**KunlunCode permission mode 不授予 LoopX lifecycle、repository、credential、provider、merge 或 production 权限；native verifier 之前 model 不能直接完成绑定 Todo。

**文档：**https://github.com/huangruiteng/loopx/blob/v0.4.9/loopx/kunluncode_goal_mode/README.md

```bash
python3 -m pip install --upgrade 'loopx==0.4.9'
loopx-kunluncode install
loopx-kunluncode connect --project . --goal-id my-goal --agent-id kunlun
kunluncode --cwd "$PWD" mcp test loopx-kunluncode
loopx-kunluncode status --project .
loopx-kunluncode uninstall
```

#### Native Windows PowerShell

**启用：**在 PowerShell 7 与 Python 3.11+ 中安装 PyPI package 和 packaged skills；trusted-checkout snapshot 可显式调用 `scripts/install-windows.ps1` 并 opt in PATH。

**验证：**在新的 PowerShell process 运行 deep doctor，确保 PATH 与 release-pointer readback 真实生效。

**停用 / 回退：**package uninstall 前先运行 managed host uninstallers。Snapshot rollback 必须 checkout 目标 trusted revision、重跑 installer 并验证 deep doctor，不能手工编辑 release pointer。

**权限边界：**native install 只改变本地 command、skill、optional PATH 与 snapshot 文件，不授予 repository、network、credential、external system、merge 或 production 权限，也不删除 project-local state。

**文档：**https://github.com/huangruiteng/loopx/blob/v0.4.9/docs/guides/installing-loopx.md#native-windows-powershell-7

```bash
pwsh -NoLogo -NoProfile -Command 'py -3.11 -m pip install --upgrade loopx'
pwsh -NoLogo -NoProfile -Command 'loopx workflow-skills --install; loopx doctor --deep'
pwsh -NoLogo -NoProfile -Command 'loopx slash-commands --uninstall; loopx workflow-skills --uninstall; py -3.11 -m pip uninstall -y loopx'
```

#### Native Goal Benchmark Qualification

**启用：**无 persistent switch；每次从 v0.4.9 source checkout 显式提供 task/objective file、model route 与独立 prepared installed-profile evidence。

**验证：**使用 `--preflight-only` 验证 app-server initialize、thread creation、Goal attachment 与 installed profile/skill discovery，不启动 model turn。

**停用 / 回退：**停止调用 runner，并在 dedicated checkout 切换到 v0.4.8 恢复旧 harness；controller terminal 后只清理由 runner 创建的 per-run profile/isolation directory。

**权限边界：**runner 不授予 task answer、verifier output、credential、upload、submission、leaderboard 或 LoopX settlement 权限；controller 仍负责 execution、isolation、verification 与 countability，本版本不声明 score/uplift。

**文档：**https://github.com/huangruiteng/loopx/blob/v0.4.9/benchmark/deepswe/README.md

```bash
python benchmark/deepswe/run_native_codex_goal.py --cwd task-worktree --objective-file objective.txt --task-file task.txt --model model-route --preflight-only
git -C dedicated-loopx-benchmark-checkout switch --detach v0.4.8
```

### 发布验证

- Package version and public tag: `0.4.9` / `v0.4.9`.
- Tag target: release PR merge commit; the exact full SHA is inserted after merge and before publication.
- Required exact-commit lanes: full pytest, Ruff, strict mypy, risk-based canary,
  full-public smoke suite, install/upgrade/host checks, public-boundary scan,
  repeated actual-default Doubao qualification, and the release-qualification
  reducer. Failures and skips remain explicit.
- No stable-versus-candidate benchmark outcome claim is made, so the expensive
  matched outcome baseline is not required.

Compare: https://github.com/huangruiteng/loopx/compare/v0.4.8...v0.4.9
