### PR TITLE
fix(release): sync manpage version for v0.4.9

### DIFF
--- a/man/loopx.1
+++ b/man/loopx.1
@@ -1,4 +1,4 @@
-.TH LOOPX 1 "" "LoopX 0.4.8" "User Commands"
+.TH LOOPX 1 "" "LoopX 0.4.9" "User Commands"
 .SH NAME
 loopx \- control-plane helper for long-running agent work
 .SH SYNOPSIS


### PR DESCRIPTION
## Summary

- regenerate the checked-in `man/loopx.1` header for package version 0.4.9
- restore the exact generated-manpage contract that blocked the full-public release sweep

## Validation

- `python examples/cli-help-manpage-smoke.py`
- `python examples/release/release-version-contract-smoke.py`
- `git diff --check`
- `loopx check --scan-path man/loopx.1` (clean public boundary; unrelated registry warnings remain outside this change)

## Scope

Generated public manpage metadata only. No runtime, permission, benchmark, or release-publishing behavior changes.