### PR TITLE
test(security): pin loopback CORS, worker-command charset, and state-file symlink containment

### DIFF
--- a/tests/test_state_file_containment.py
+++ b/tests/test_state_file_containment.py
@@ -79,3 +79,20 @@ def test_relative_override_escaping_project_is_rejected(tmp_path: Path) -> None:
             project_override=project,
             state_file_override=Path("../outside.md"),
         )
+
+
+def test_symlink_override_escaping_project_is_rejected(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    outside = tmp_path / "outside.md"
+    outside.write_text("## Next Action\n", encoding="utf-8")
+    inside = project / "inside.md"
+    inside.symlink_to(outside)
+
+    with pytest.raises(ValueError, match="escapes project root"):
+        resolve_goal_state(
+            registry=_registry(project),
+            goal_id="loopx-meta",
+            project_override=project,
+            state_file_override=inside,
+        )

--- a/tests/test_status_server_cors.py
+++ b/tests/test_status_server_cors.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import http.client
 import threading
 
+import pytest
+
 from loopx.status_server import (
     StatusHTTPServer,
     StatusRequestHandler,
@@ -32,6 +34,20 @@ def test_cors_response_headers_missing_origin_needs_no_cors() -> None:
     assert cors_response_headers(None) == {}
 
 
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "null",
+        "http://127.0.0.1.evil.example",
+        "http://localhost.evil.example",
+        "http://localhost@evil.example",
+        "http://[::1",
+    ],
+)
+def test_cors_response_headers_spoofed_loopback_origins_are_rejected(origin: str) -> None:
+    assert cors_response_headers(origin) == {}
+
+
 def _start_server() -> tuple[StatusHTTPServer, threading.Thread]:
     server = StatusHTTPServer(("127.0.0.1", 0), StatusRequestHandler)
     server.verbose = False
@@ -44,6 +60,13 @@ def _get(port: int, *, origin: str | None) -> http.client.HTTPResponse:
     conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
     headers = {"Origin": origin} if origin else {}
     conn.request("GET", "/healthz", headers=headers)
+    return conn.getresponse()
+
+
+def _options(port: int, *, origin: str | None) -> http.client.HTTPResponse:
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    headers = {"Origin": origin} if origin else {}
+    conn.request("OPTIONS", "/healthz", headers=headers)
     return conn.getresponse()
 
 
@@ -79,6 +102,31 @@ def test_healthz_with_loopback_origin_echoes_acao() -> None:
         response = _get(server.server_address[1], origin=origin)
         response.read()
         assert response.status == 200
+        assert response.getheader("Access-Control-Allow-Origin") == origin
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+def test_options_preflight_with_foreign_origin_omits_acao() -> None:
+    server, thread = _start_server()
+    try:
+        response = _options(server.server_address[1], origin="https://evil.example")
+        response.read()
+        assert response.status == 204
+        assert response.getheader("Access-Control-Allow-Origin") is None
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+def test_options_preflight_with_loopback_origin_echoes_acao() -> None:
+    server, thread = _start_server()
+    try:
+        origin = f"http://127.0.0.1:{server.server_address[1]}"
+        response = _options(server.server_address[1], origin=origin)
+        response.read()
+        assert response.status == 204
         assert response.getheader("Access-Control-Allow-Origin") == origin
     finally:
         server.shutdown()

--- a/tests/test_worker_command_validation.py
+++ b/tests/test_worker_command_validation.py
@@ -45,6 +45,23 @@ def test_validate_worker_command_rejects_unsafe_commands(command: str) -> None:
         validate_worker_command(command, field="worker_turn_command")
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "ENV=x python3 worker.py",
+        "LD_PRELOAD=/tmp/x python3",
+        "evil *",
+        "evil ?",
+        "a\tb",
+    ],
+)
+def test_validate_worker_command_rejects_env_assignment_and_glob_variants(
+    command: str,
+) -> None:
+    with pytest.raises(ValueError, match="unsafe shell metacharacters"):
+        validate_worker_command(command, field="worker_turn_command")
+
+
 def test_spec_builder_rejects_unsafe_worker_command() -> None:
     spec = {
         "goal_id": "loopx-meta",


### PR DESCRIPTION
Several security-boundary defense branches had no regression fixtures pinning them — they could regress silently. This PR is **test-only** (no production code changed).

## What is pinned

1. **state-file override containment** (`state_refresh.py`): a symlink placed inside the project that resolves outside the project root is rejected after `resolve()` dereference + `is_relative_to` containment.
2. **worker command validation** (`visible_multi_agent_launcher.py`): env-assignment prefixes (`ENV=x`, `LD_PRELOAD=...`), glob metacharacters (`*`, `?`), and tab are outside the whitelist charset and are rejected.
3. **status server CORS** (`status_server.py`): spoofed loopback lookalike origins receive no CORS headers (exact-hostname matching, including the `urlparse` ValueError branch), and `OPTIONS` preflight omits `Access-Control-Allow-Origin` for non-loopback origins.

## Verification

- the three touched files: 42 passed (29 pre-existing + 13 new)
- `tests/canary`: 20 passed (no baseline change — test-only)