### PR TITLE
fix(control-plane): 保留 compact replan ACK 的路径结论

### DIFF
--- a/docs/reference/protocols/goal-vision-replan-contract-v0.md
+++ b/docs/reference/protocols/goal-vision-replan-contract-v0.md
@@ -444,6 +444,16 @@ vision-derived duty accepts only its declared vision outcomes. Historical
 repair ACKs are not accepted by the semantic replan reducer; they remain inert
 history rather than a compatibility closure path.
 
+The compact `autonomous_replan_ack` projection preserves the aggregate
+`fresh_vision_path_outcome` in `semantic_delta` and, when that outcome is
+present in the validated `outcomes` list, adds the same run's
+`agent_vision.path_delta.outcome` as top-level `path_disposition`. Only
+`continue`, `no_change`, and `replan` are projected. The field is additive and
+observational: it does not alter settlement, and it is omitted for non-vision,
+legacy, or invalid path packets. Consumers should inspect `outcomes` rather
+than only `satisfying_outcomes`, because one accepted ACK may combine a vision
+path observation with a different obligation-satisfying outcome.
+
 ### Bad Case: ACK Hidden By Scheduler Accounting
 
 Observed failure: a monitor-only lane correctly projected

--- a/loopx/control_plane/work_items/autonomous_replan_ack.py
+++ b/loopx/control_plane/work_items/autonomous_replan_ack.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from ..runtime.time import parse_timestamp
+from .progress_observation import FRESH_VISION_PATH_DISPOSITIONS
 
 AUTONOMOUS_REPLAN_ACK_MATERIAL_RUN_WINDOW = 20
 
@@ -80,6 +81,24 @@ def compact_autonomous_replan_ack(run: dict[str, Any] | None) -> dict[str, Any] 
             if semantic_delta.get(field) is not None
         },
     }
+    outcomes = semantic_delta.get("outcomes")
+    if (
+        isinstance(outcomes, list)
+        and "fresh_vision_path_outcome" in outcomes
+    ):
+        agent_vision = (
+            run.get("agent_vision")
+            if isinstance(run.get("agent_vision"), dict)
+            else {}
+        )
+        path_delta = (
+            agent_vision.get("path_delta")
+            if isinstance(agent_vision.get("path_delta"), dict)
+            else {}
+        )
+        path_disposition = str(path_delta.get("outcome") or "").strip()
+        if path_disposition in FRESH_VISION_PATH_DISPOSITIONS:
+            result["path_disposition"] = path_disposition
     delta_contract = ack.get("delta_contract")
     if isinstance(delta_contract, dict):
         result["delta_contract"] = {

--- a/loopx/control_plane/work_items/progress_observation.py
+++ b/loopx/control_plane/work_items/progress_observation.py
@@ -71,6 +71,11 @@ VISION_REPLAN_REQUIRED_OUTCOMES = (
     "coverage_backed_exploration_exhausted",
     "coverage_backed_no_followup",
 )
+FRESH_VISION_PATH_DISPOSITIONS = frozenset(
+    {"continue", "no_change", "replan"}
+)
+
+
 def _stable_id(value: Any, *, field: str, required: bool = False) -> str | None:
     normalized = str(value or "").strip()
     if not normalized:
@@ -423,7 +428,7 @@ def semantic_delta_from_writeback(
         ]
         if (
             str(patch.get("acceptance_summary") or "").strip()
-            and path_outcome in {"continue", "no_change", "replan"}
+            and path_outcome in FRESH_VISION_PATH_DISPOSITIONS
             and evidence_refs
             and "fresh_vision_path_outcome" not in outcomes
         ):

--- a/tests/control_plane/test_autonomous_replan_ack.py
+++ b/tests/control_plane/test_autonomous_replan_ack.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from loopx.control_plane.goals.goal_vision import normalize_goal_vision_packet
+from loopx.control_plane.work_items.autonomous_replan_ack import (
+    compact_autonomous_replan_ack,
+)
+from loopx.control_plane.work_items.progress_observation import (
+    semantic_delta_from_writeback,
+)
+from loopx.status import compact_run
+
+
+FRESH_VISION_PATH_OUTCOME = "fresh_vision_path_outcome"
+GOAL_ID = "goal-replan-3338"
+AGENT_ID = "codex-replan-agent"
+
+
+def _validated_agent_vision(path_outcome: str) -> dict[str, Any]:
+    return normalize_goal_vision_packet(
+        {
+            "agent_id": AGENT_ID,
+            "state": "active",
+            "vision_patch": {
+                "acceptance_summary": "Keep the bounded path decision auditable."
+            },
+            "path_delta": {
+                "schema_version": "goal_path_delta_v0",
+                "outcome": path_outcome,
+                "prior_assumption": "The current path remains sufficient.",
+                "observed_reality": "The latest evidence supports this disposition.",
+                "retained": ["Keep the validated evidence boundary."],
+                "evidence_refs": ["evidence:replan-3338"],
+            },
+        },
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+
+
+def _accepted_ack_run(
+    *,
+    path_outcome: str | None,
+    satisfying_outcomes: list[str] | None = None,
+    outcomes: list[str] | None = None,
+    semantic_delta: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    resolved_satisfying_outcomes = (
+        satisfying_outcomes
+        if satisfying_outcomes is not None
+        else [FRESH_VISION_PATH_OUTCOME]
+    )
+    resolved_outcomes = outcomes if outcomes is not None else resolved_satisfying_outcomes
+    resolved_semantic_delta = semantic_delta or {
+        "schema_version": "replan_semantic_delta_v0",
+        "accepted": True,
+        "outcomes": resolved_outcomes,
+        "satisfying_outcomes": resolved_satisfying_outcomes,
+        "required_any_of": resolved_satisfying_outcomes,
+        "obligation_id": "replan-3338",
+    }
+    run: dict[str, Any] = {
+        "classification": "bounded_replan_progress",
+        "generated_at": "2026-08-19T12:00:00+08:00",
+        "agent_id": AGENT_ID,
+        "autonomous_replan_ack": {
+            "schema_version": "autonomous_replan_ack_v0",
+            "recorded": True,
+            "source": "refresh_state_semantic_delta",
+            "semantic_delta": resolved_semantic_delta,
+        },
+    }
+    if path_outcome is not None:
+        if path_outcome == "unexpected":
+            run["agent_vision"] = {
+                "schema_version": "goal_vision_replan_contract_v0",
+                "agent_id": AGENT_ID,
+                "path_delta": {"outcome": path_outcome},
+            }
+        else:
+            run["agent_vision"] = _validated_agent_vision(path_outcome)
+    return run
+
+
+@pytest.mark.parametrize("path_disposition", ["continue", "no_change", "replan"])
+def test_compact_ack_projects_validated_path_disposition(
+    path_disposition: str,
+) -> None:
+    semantic_delta = semantic_delta_from_writeback(
+        obligation={
+            "obligation_id": "replan-3338",
+            "satisfying_semantic_outcomes": ["new_surface"],
+        },
+        progress_observation={
+            "schema_version": "typed_progress_observation_v0",
+            "work_item_id": "todo-replan-3338",
+            "surface_id": "surface-new",
+            "result_class": "advanced",
+            "evidence_ids": ["evidence:new-surface"],
+        },
+        agent_vision=_validated_agent_vision(path_disposition),
+    )
+
+    assert semantic_delta["accepted"] is True
+    assert semantic_delta["outcomes"] == [
+        "new_surface",
+        FRESH_VISION_PATH_OUTCOME,
+    ]
+    assert semantic_delta["satisfying_outcomes"] == ["new_surface"]
+    compact = compact_autonomous_replan_ack(
+        _accepted_ack_run(
+            path_outcome=path_disposition,
+            semantic_delta=semantic_delta,
+        )
+    )
+
+    assert compact is not None
+    assert compact["path_disposition"] == path_disposition
+    assert compact["semantic_delta"]["satisfying_outcomes"] == ["new_surface"]
+    assert "path_disposition" not in compact["semantic_delta"]
+
+
+@pytest.mark.parametrize(
+    ("path_outcome", "satisfying_outcomes"),
+    [
+        (None, [FRESH_VISION_PATH_OUTCOME]),
+        ("wait", [FRESH_VISION_PATH_OUTCOME]),
+        ("unexpected", [FRESH_VISION_PATH_OUTCOME]),
+        ("replan", ["new_concrete_blocker"]),
+    ],
+)
+def test_compact_ack_does_not_invent_path_disposition(
+    path_outcome: str | None,
+    satisfying_outcomes: list[str],
+) -> None:
+    compact = compact_autonomous_replan_ack(
+        _accepted_ack_run(
+            path_outcome=path_outcome,
+            satisfying_outcomes=satisfying_outcomes,
+        )
+    )
+
+    assert compact is not None
+    assert "path_disposition" not in compact
+
+
+def test_compact_run_exposes_path_disposition_to_status_consumers() -> None:
+    compact = compact_run(_accepted_ack_run(path_outcome="replan"))
+
+    assert compact["autonomous_replan_ack"]["path_disposition"] == "replan"


### PR DESCRIPTION
## 问题

完整 refresh run 已保留 `agent_vision.path_delta.outcome`，但 compact `autonomous_replan_ack` 只暴露聚合后的 `fresh_vision_path_outcome`。只读取 compact ACK 的消费者因此无法区分 `continue`、`no_change` 与真实 `replan`，容易把一次有效的无变化复核误计为路径修订。

## 修复

- 当已接受 ACK 的 `semantic_delta.outcomes` 包含经过写路径验证的 `fresh_vision_path_outcome` 时，在 compact ACK 顶层投影 `path_disposition`。
- 仅允许 `continue`、`no_change`、`replan`；缺少同 run Vision、非法值或非 Vision outcome 时不生成字段。
- 复用 producer 的合法 disposition 集合，避免资格判定与 compact projection 漂移。
- 在 goal-vision 协议中记录该 additive telemetry contract。

## 关键边界

- 不改变 settlement acceptance、obligation closure 或现有 `semantic_delta` 含义。
- `no_change` 仍是有效成功结果，不要求代码、Todo 或路径发生变化。
- 投影检查全部已验证的 `outcomes`，而不是只检查 `satisfying_outcomes`：同一个合法 ACK 可能同时记录 Vision path outcome，并由另一个 outcome 满足当前 obligation。
- 旧消费者可继续忽略这个可选顶层字段。

## 验证

- 全量 pytest：`3415 passed, 10 skipped`；仅有 1 个既有 Pydantic forward-reference warning。
- 聚焦 replan / goal-vision / compact status 回归：`115 passed`。
- Ruff：`tests loopx/canary loopx/control_plane loopx/domain_packs loopx/presentation` 全部通过。
- 仓库标准 mypy：`Success: no issues found in 12 source files`。
- `loopx canary premerge --from-git-diff`：13/13 选择性检查通过，0 failures、0 warnings、0 manual holds。
- public boundary scan、changed Python compile、committed/staged/unstaged diff checks 均通过。

Closes #3338
