### PR TITLE
fix(history): 按 UTC instant 排序 Canonical Run History

### DIFF
--- a/loopx/history.py
+++ b/loopx/history.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -32,7 +33,7 @@ from .control_plane.runtime.run_index_rebuild import (
     collision_review_groups,
     validate_reviewed_collision_plan,
 )
-from .control_plane.runtime.time import now_local_iso
+from .control_plane.runtime.time import now_local_iso, parse_timestamp
 from .doctor import PROMOTION_READINESS_CLASSIFICATIONS
 from .execution_profile import compact_execution_profile
 from .explore_graph import compact_explore_graph_policy
@@ -63,6 +64,24 @@ REGISTRY_ATTENTION_FIELDS = (
 
 def now_local() -> str:
     return now_local_iso()
+
+
+_MIN_TIMESTAMP = datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _chronology_key(value: Any) -> tuple[int, datetime, str]:
+    """Return a UTC-aware ordering key while keeping legacy rows deterministic."""
+
+    raw = str(value or "")
+    try:
+        parsed = parse_timestamp(value)
+    except OverflowError:
+        # UTC conversion can overflow at datetime's representable boundaries.
+        parsed = None
+    if parsed is None:
+        # Malformed or missing legacy rows must never outrank valid timestamps.
+        return (0, _MIN_TIMESTAMP, raw)
+    return (1, parsed, raw)
 
 
 def unique_run_paths(runs_dir: Path, generated_at: str) -> tuple[Path, Path]:
@@ -223,7 +242,10 @@ def collect_history(
             run
             for _, run in sorted(
                 enumerate(runs),
-                key=lambda item: (str(item[1].get("generated_at") or ""), item[0]),
+                key=lambda item: (
+                    *_chronology_key(item[1].get("generated_at")),
+                    item[0],
+                ),
                 reverse=True,
             )
         ]
@@ -271,7 +293,9 @@ def collect_history(
                     goal_record[field] = meta.get(field)
         goals.append(goal_record)
 
-    all_runs.sort(key=lambda item: str(item.get("generated_at") or ""), reverse=True)
+    all_runs.sort(
+        key=lambda item: _chronology_key(item.get("generated_at")), reverse=True
+    )
     return {
         "ok": True,
         "registry": str(registry_path),

--- a/tests/test_history_chronology.py
+++ b/tests/test_history_chronology.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from loopx.history import collect_history
+
+
+def _write_history_fixture(
+    tmp_path: Path,
+    runs_by_goal: dict[str, list[dict[str, Any]]],
+) -> tuple[Path, Path]:
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text("{}\n", encoding="utf-8")
+    runtime_root = tmp_path / "runtime"
+
+    for goal_id, runs in runs_by_goal.items():
+        runs_dir = runtime_root / "goals" / goal_id / "runs"
+        runs_dir.mkdir(parents=True)
+        rows = []
+        for position, run in enumerate(runs):
+            row = dict(run)
+            row.setdefault("json_path", f"artifacts/{goal_id}-{position}.json")
+            row.setdefault("markdown_path", f"artifacts/{goal_id}-{position}.md")
+            rows.append(json.dumps(row))
+        (runs_dir / "index.jsonl").write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+    return registry_path, runtime_root
+
+
+def test_collect_history_orders_goal_runs_by_utc_instant(tmp_path: Path) -> None:
+    registry_path, runtime_root = _write_history_fixture(
+        tmp_path,
+        {
+            "goal-a": [
+                {
+                    "classification": "offset-earlier",
+                    "generated_at": "2026-08-19T00:30:00+08:00",
+                    "agent_id": "agent-a",
+                    "agent_vision": {"agent_id": "agent-a", "revision": "earlier"},
+                },
+                {
+                    "classification": "utc-later",
+                    "generated_at": "2026-08-18T17:00:00Z",
+                    "agent_id": "agent-a",
+                    "agent_vision": {"agent_id": "agent-a", "revision": "later"},
+                },
+            ]
+        },
+    )
+
+    history = collect_history(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        goal_id="goal-a",
+        limit=10,
+    )
+
+    goal = history["goals"][0]
+    assert [run["classification"] for run in goal["latest_runs"]] == [
+        "utc-later",
+        "offset-earlier",
+    ]
+    assert goal["latest_status_run"]["classification"] == "utc-later"
+    semantic_agent = goal["semantic_history"]["agents"][0]
+    assert semantic_agent["latest_agent_vision_run"]["classification"] == "utc-later"
+
+
+def test_collect_history_orders_runs_across_goals_by_utc_instant(
+    tmp_path: Path,
+) -> None:
+    registry_path, runtime_root = _write_history_fixture(
+        tmp_path,
+        {
+            "goal-a": [
+                {
+                    "classification": "offset-earlier",
+                    "generated_at": "2026-08-19T00:30:00+08:00",
+                }
+            ],
+            "goal-b": [
+                {
+                    "classification": "utc-later",
+                    "generated_at": "2026-08-18T17:00:00Z",
+                }
+            ],
+        },
+    )
+
+    history = collect_history(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        goal_id=None,
+        limit=1,
+    )
+
+    assert [run["classification"] for run in history["runs"]] == ["utc-later"]
+
+
+def test_collect_history_keeps_invalid_legacy_timestamps_below_valid_runs(
+    tmp_path: Path,
+) -> None:
+    registry_path, runtime_root = _write_history_fixture(
+        tmp_path,
+        {
+            "goal-a": [
+                {
+                    "classification": "malformed",
+                    "generated_at": "not-a-time",
+                },
+                {
+                    "classification": "overflow",
+                    "generated_at": "0001-01-01T00:00:00+14:00",
+                },
+                {
+                    "classification": "same-instant-z",
+                    "generated_at": "2026-01-01T00:00:00Z",
+                },
+                {
+                    "classification": "same-instant-offset",
+                    "generated_at": "2026-01-01T08:00:00+08:00",
+                },
+                {
+                    "classification": "missing",
+                    "generated_at": None,
+                },
+            ]
+        },
+    )
+
+    history = collect_history(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        goal_id="goal-a",
+        limit=10,
+    )
+
+    classifications = [
+        run["classification"] for run in history["goals"][0]["latest_runs"]
+    ]
+    assert classifications == [
+        "same-instant-offset",
+        "same-instant-z",
+        "malformed",
+        "overflow",
+        "missing",
+    ]


### PR DESCRIPTION
## 变更概述

Closes #3346

`collect_history()` 之前直接按 `generated_at` 原始字符串倒序。不同本地时区的 ISO-8601 offset 会导致字典序与真实时间轴不一致，从而选错 `latest_status_run`、semantic history 或跨 Goal 的 top-level run。

本 PR：

- 复用 `control_plane.runtime.time.parse_timestamp()`，按 UTC instant 排序；
- 合法时间始终优先于缺失、畸形或 UTC 转换溢出的 legacy 值；
- 保留原始时间文本，并为相同 instant 保留确定性 tie-break；
- 同时修复单 Goal runs 与跨 Goal `all_runs`；
- 不修改持久化 schema，也不扩大到其他独立 run-index 读取路径。

## 验证

- `3517 passed, 10 skipped` 全量 pytest；
- 新增跨 offset、跨 Goal `limit=1`、semantic history、缺失/畸形/Overflow timestamp 回归测试；
- 两个 run-history smoke 通过；
- Ruff、标准 mypy 通过；
- `loopx canary premerge --from-git-diff` 通过：4/4 catalog canaries；
- changed files public/private boundary scan clean。

## 兼容性

旧的 index 行不会被重写；无法解析的历史时间仍会被保留，但不会压过合法时间戳。
