### PR TITLE
feat(goal-channel): add botmux runtime integration

### DIFF
--- a/docs/architecture/rfcs/goal-channel-collaboration-v0.md
+++ b/docs/architecture/rfcs/goal-channel-collaboration-v0.md
@@ -89,9 +89,14 @@ loopx goal-channel configure --goal-id <goal-id> --auto-notify-human-gates
 loopx goal-channel doctor --goal-id <goal-id>
 loopx goal-channel sync --goal-id <goal-id>
 loopx goal-channel notify-gate --goal-id <goal-id>
+loopx goal-channel runtime setup --goal-id <goal-id> --bot-id <bot-id> --chat-id <chat-id>
 ```
 
 `goal-channel` is the durable control-plane object and the user-facing CLI.
+The optional [botmux runtime integration](../../integrations/botmux-goal-channel-runtime.md)
+delegates IM delivery and persistent agent sessions to botmux without changing
+Goal Channel or LoopX state authority. Delivery does not imply a state
+transition; the configured agent runtime must still invoke LoopX explicitly.
 
 ## Ownership Model
 

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -11,6 +11,7 @@ and external systems while preserving one control-plane authority.
 - [Codex peer task orchestration](codex-subagent-orchestration.md)
 - [Complex project read-only adapter](complex-project-readonly-adapter.md)
 - [Lark Kanban control-plane adapter](lark-kanban-control-plane-adapter.md)
+- [Botmux Goal Channel runtime](botmux-goal-channel-runtime.md)
 - [Extensions and capabilities](../reference/extensions.md)
 - [Host integration surface v0](../reference/protocols/host-integration-surface-v0.md)
 

--- a/docs/integrations/botmux-goal-channel-runtime.md
+++ b/docs/integrations/botmux-goal-channel-runtime.md
@@ -101,7 +101,7 @@ loopx goal-channel runtime trigger \
   --execute
 ```
 
-Read botmux's four-state result:
+Read botmux's typed lifecycle result:
 
 ```bash
 loopx goal-channel runtime status --goal-id <goal-id>

--- a/docs/integrations/botmux-goal-channel-runtime.md
+++ b/docs/integrations/botmux-goal-channel-runtime.md
@@ -1,0 +1,137 @@
+# Botmux Goal Channel Runtime
+
+LoopX can bind an existing [botmux](https://github.com/deepcoldy/botmux) bot
+to one Goal Channel. Botmux owns IM delivery, Lark event subscriptions,
+persistent agent sessions, streaming cards, and terminal access. LoopX remains
+the only authority for goal state, todos, gates, quota, evidence, and accepted
+transitions.
+
+This integration does not replace the existing Lark Goal Channel projection.
+The two surfaces are complementary:
+
+```text
+LoopX Goal Channel sync -> Lark status, Kanban, and gate notifications
+Lark interaction -> botmux -> configured agent runtime -> LoopX command
+```
+
+A notification or botmux delivery receipt is an observation only. It does not
+change canonical LoopX state. State changes only when the configured agent
+runtime explicitly invokes a validated LoopX transition.
+
+## Prerequisites
+
+- botmux is installed and running;
+- the selected botmux bot can invoke the installed LoopX CLI or managed skill;
+- the bot is allowed to talk in the selected Lark chat;
+- botmux runs on the host that owns the LoopX project checkout;
+- the bot's `defaultWorkingDir` or the selected chat's oncall `workingDir`
+  resolves to the LoopX project root;
+- the botmux Dashboard token is available in an environment variable.
+
+LoopX never stores the Dashboard token. The local-private runtime binding stores
+only the environment variable name.
+
+## Configure
+
+Export the existing botmux Dashboard token:
+
+```bash
+export BOTMUX_DASHBOARD_TOKEN='<local-private-token>'
+```
+
+Preview the binding first:
+
+```bash
+loopx goal-channel runtime setup \
+  --goal-id <goal-id> \
+  --bot-id <botmux-lark-app-id> \
+  --chat-id <lark-chat-id>
+```
+
+The preview probes botmux liveness, confirms that the selected bot is online,
+in the selected chat, and bound to the LoopX project directory, then uses
+botmux's dry-run trigger contract to verify the chat route. Apply the
+local-private binding explicitly:
+
+```bash
+loopx goal-channel runtime setup \
+  --goal-id <goal-id> \
+  --bot-id <botmux-lark-app-id> \
+  --chat-id <lark-chat-id> \
+  --execute
+```
+
+The binding is written beside the project registry as
+`.loopx/goal-channel-runtime.json` with owner-only permissions. It contains
+private provider identifiers and must remain ignored and untracked.
+
+## Operate
+
+Verify readiness without changing provider state:
+
+```bash
+loopx goal-channel runtime doctor --goal-id <goal-id>
+```
+
+Preview the next bounded turn:
+
+```bash
+loopx goal-channel runtime trigger --goal-id <goal-id>
+```
+
+Queue it explicitly:
+
+```bash
+loopx goal-channel runtime trigger --goal-id <goal-id> --execute
+```
+
+The default instruction asks the configured agent runtime to use its installed
+LoopX CLI or managed skill, select the active next action, and require artifact,
+validation, and state writeback before the turn stops. Use `--instruction` only
+when the owner needs a different bounded instruction.
+
+The default semantic turn key is derived from the current goal state. Repeating
+the same command does not dispatch another turn. After a deliberate state-free
+follow-up, provide an explicit new key:
+
+```bash
+loopx goal-channel runtime trigger \
+  --goal-id <goal-id> \
+  --turn-key <owner-chosen-semantic-key> \
+  --execute
+```
+
+Read botmux's four-state result:
+
+```bash
+loopx goal-channel runtime status --goal-id <goal-id>
+```
+
+Add `--execute` only when the observed state should be persisted to the
+local-private LoopX receipt.
+
+## Failure Semantics
+
+- The first visible-chat dispatch records an `attempting` receipt before the
+  provider call. If the connection fails after submission, LoopX reports
+  `botmux_dispatch_outcome_unknown` and does not blindly retry.
+- Follow-up turns reuse the stored botmux session and botmux's native
+  `turnIdempotencyKey`.
+- `running`, `completed`, `failed`, and `not_found` are provider observations.
+  They do not independently complete, reopen, or otherwise mutate a LoopX goal.
+- A Lark message or botmux card is delivery evidence, not LoopX transition
+  authority.
+
+## Disable Or Roll Back
+
+The integration is opt-in and does not alter botmux configuration. Preview and
+then disable only the selected goal binding:
+
+```bash
+loopx goal-channel runtime disable --goal-id <goal-id>
+loopx goal-channel runtime disable --goal-id <goal-id> --execute
+```
+
+Disabling clears the selected goal's active botmux session pointer but leaves
+other goal bindings and the botmux daemon untouched. Existing Goal Channel
+status/Kanban sync remains independent.

--- a/loopx/cli_commands/goal_channel.py
+++ b/loopx/cli_commands/goal_channel.py
@@ -31,6 +31,16 @@ from ..extensions.runtime import (
 from ..control_plane.runtime.runtime_projection_route import (
     resolve_goal_source_runtime_route,
 )
+from ..control_plane.goals.botmux_runtime import (
+    BOTMUX_DEFAULT_ENDPOINT,
+    BOTMUX_DEFAULT_TOKEN_ENV,
+    default_botmux_runtime_binding_path,
+    disable_botmux_runtime,
+    doctor_botmux_runtime,
+    setup_botmux_runtime,
+    status_botmux_runtime,
+    trigger_botmux_runtime,
+)
 from ..history import load_registry
 from ..paths import registry_project_root, resolve_runtime_root
 from ..quota import build_quota_should_run
@@ -176,6 +186,66 @@ def register_goal_channel_commands(
     notify.add_argument("--cooldown-seconds", type=int, default=3600)
     notify.add_argument("--execute", action="store_true")
 
+    runtime = sub.add_parser(
+        "runtime",
+        help="Bind and drive an optional IM/runtime provider for a Goal Channel.",
+    )
+    runtime_sub = runtime.add_subparsers(
+        dest="goal_channel_runtime_command",
+        required=True,
+    )
+    runtime_setup = runtime_sub.add_parser(
+        "setup",
+        help="Verify and bind one botmux runtime. Dry-run unless --execute.",
+    )
+    add_subcommand_format(runtime_setup)
+    _add_runtime_common_args(runtime_setup)
+    runtime_setup.add_argument("--endpoint", default=BOTMUX_DEFAULT_ENDPOINT)
+    runtime_setup.add_argument("--bot-id", required=True)
+    runtime_setup.add_argument("--chat-id", required=True)
+    runtime_setup.add_argument("--token-env", default=BOTMUX_DEFAULT_TOKEN_ENV)
+    runtime_setup.add_argument("--execute", action="store_true")
+
+    runtime_doctor = runtime_sub.add_parser(
+        "doctor",
+        help="Verify the configured botmux daemon, bot, project, and chat route.",
+    )
+    add_subcommand_format(runtime_doctor)
+    _add_runtime_common_args(runtime_doctor)
+
+    runtime_trigger = runtime_sub.add_parser(
+        "trigger",
+        help="Queue one bounded LoopX turn through the configured botmux runtime.",
+    )
+    add_subcommand_format(runtime_trigger)
+    _add_runtime_common_args(runtime_trigger)
+    runtime_trigger.add_argument("--instruction")
+    runtime_trigger.add_argument(
+        "--turn-key",
+        help="Explicit semantic revision key for a deliberate new runtime turn.",
+    )
+    runtime_trigger.add_argument("--execute", action="store_true")
+
+    runtime_status = runtime_sub.add_parser(
+        "status",
+        help="Read the four-state result of the current botmux runtime turn.",
+    )
+    add_subcommand_format(runtime_status)
+    _add_runtime_common_args(runtime_status)
+    runtime_status.add_argument(
+        "--execute",
+        action="store_true",
+        help="Persist the observed runtime state into the local-private receipt.",
+    )
+
+    runtime_disable = runtime_sub.add_parser(
+        "disable",
+        help="Disable this goal's botmux runtime binding. Dry-run unless --execute.",
+    )
+    add_subcommand_format(runtime_disable)
+    _add_runtime_common_args(runtime_disable)
+    runtime_disable.add_argument("--execute", action="store_true")
+
 
 def _add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--goal-id", required=True)
@@ -184,6 +254,14 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
         help="Local-private Goal Channel binding path beside the project registry.",
     )
     parser.add_argument("--target-path", help=argparse.SUPPRESS)
+
+
+def _add_runtime_common_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--goal-id", required=True)
+    parser.add_argument(
+        "--runtime-binding-path",
+        help="Local-private botmux runtime binding path beside the project registry.",
+    )
 
 
 def _error_packet(
@@ -399,6 +477,82 @@ def handle_goal_channel_command(
         runtime_root_arg,
         registry_path=registry_path,
     )
+    if command == "runtime":
+        assert goal_id is not None
+        source_registry, source_registry_path, _ = _source_context(
+            registry=registry,
+            registry_path=registry_path,
+            goal_id=goal_id,
+        )
+        runtime_binding_path = (
+            Path(str(args.runtime_binding_path)).expanduser()
+            if getattr(args, "runtime_binding_path", None)
+            else default_botmux_runtime_binding_path(source_registry_path)
+        )
+        runtime_command = str(args.goal_channel_runtime_command)
+        try:
+            if runtime_command == "setup":
+                payload = setup_botmux_runtime(
+                    registry=source_registry,
+                    registry_path=source_registry_path,
+                    goal_id=goal_id,
+                    binding_path=runtime_binding_path,
+                    endpoint=args.endpoint,
+                    bot_id=args.bot_id,
+                    chat_id=args.chat_id,
+                    token_env=args.token_env,
+                    execute=execute,
+                )
+            elif runtime_command == "doctor":
+                payload = doctor_botmux_runtime(
+                    goal_id=goal_id,
+                    binding_path=runtime_binding_path,
+                )
+            elif runtime_command == "trigger":
+                payload = trigger_botmux_runtime(
+                    registry=source_registry,
+                    registry_path=source_registry_path,
+                    goal_id=goal_id,
+                    binding_path=runtime_binding_path,
+                    instruction=args.instruction,
+                    turn_key=args.turn_key,
+                    execute=execute,
+                )
+            elif runtime_command == "status":
+                payload = status_botmux_runtime(
+                    goal_id=goal_id,
+                    binding_path=runtime_binding_path,
+                    execute=execute,
+                )
+            elif runtime_command == "disable":
+                payload = disable_botmux_runtime(
+                    goal_id=goal_id,
+                    binding_path=runtime_binding_path,
+                    execute=execute,
+                )
+            else:
+                raise ValueError(
+                    f"unknown goal-channel runtime command: {runtime_command}"
+                )
+        except ValueError:
+            payload = {
+                "schema_version": "loopx_goal_channel_runtime_operation_v0",
+                "ok": False,
+                "goal_id": goal_id,
+                "provider": "botmux",
+                "operation": f"runtime_{runtime_command}",
+                "execute": execute,
+                "status": "blocked",
+                "external_write_performed": False,
+                "readback_verified": False,
+                "idempotency_key": None,
+                "receipt_id": None,
+                "public_summary": "the botmux runtime configuration is invalid",
+                "private_provider_payload_captured": False,
+                "blocker": "invalid_configuration",
+            }
+        print_payload(payload, output_format(args), render_goal_channel_markdown)
+        return 0 if payload.get("ok") else 1
     if command == "configure" and bool(args.auto_notify_human_gates):
         assert goal_id is not None
         _, source_registry_path, binding_path = _source_context(

--- a/loopx/cli_commands/goal_channel.py
+++ b/loopx/cli_commands/goal_channel.py
@@ -228,7 +228,7 @@ def register_goal_channel_commands(
 
     runtime_status = runtime_sub.add_parser(
         "status",
-        help="Read the four-state result of the current botmux runtime turn.",
+        help="Read the typed lifecycle result of the current botmux runtime turn.",
     )
     add_subcommand_format(runtime_status)
     _add_runtime_common_args(runtime_status)

--- a/loopx/control_plane/goals/botmux_runtime.py
+++ b/loopx/control_plane/goals/botmux_runtime.py
@@ -66,6 +66,15 @@ class BotmuxDispatchState(str, Enum):
     REJECTED = "rejected"
 
 
+_TERMINAL_DISPATCH_STATES = frozenset(
+    {
+        BotmuxDispatchState.COMPLETED,
+        BotmuxDispatchState.FAILED,
+        BotmuxDispatchState.NOT_FOUND,
+    }
+)
+
+
 _DISPATCH_TRANSITIONS: dict[
     BotmuxDispatchState | None,
     frozenset[BotmuxDispatchState],
@@ -1266,19 +1275,43 @@ def _status_botmux_runtime(
             blocker="botmux_unreachable",
             public_summary="the botmux runtime status is temporarily unknown",
         )
-    state = _dispatch_state(result.get("state"))
-    if state not in {
+    provider_state = _dispatch_state(result.get("state"))
+    if provider_state not in {
         BotmuxDispatchState.RUNNING,
         BotmuxDispatchState.COMPLETED,
         BotmuxDispatchState.FAILED,
         BotmuxDispatchState.NOT_FOUND,
     }:
-        state = BotmuxDispatchState.UNKNOWN
+        provider_state = BotmuxDispatchState.UNKNOWN
+    latest_payload = read_botmux_runtime_binding(binding_path)
+    latest_binding = botmux_binding_for_goal(latest_payload, goal_id) or binding
+    latest_receipts = latest_binding.get("receipts")
+    latest_receipts = (
+        latest_receipts if isinstance(latest_receipts, Mapping) else {}
+    )
+    latest_receipt = latest_receipts.get(dispatch_key)
+    local_state = (
+        _dispatch_state(latest_receipt.get("state"))
+        if isinstance(latest_receipt, Mapping)
+        else None
+    )
+    provider_observation_ignored = (
+        local_state in _TERMINAL_DISPATCH_STATES
+        and provider_state != local_state
+    )
+    state = local_state if provider_observation_ignored else provider_state
     output = result.get("output")
     output_available = bool(
         isinstance(output, Mapping) and str(output.get("content") or "").strip()
     )
+    local_receipt_updated = execute
     if execute:
+        updates = None
+        if provider_observation_ignored:
+            updates = {
+                "provider_observation": provider_state.value,
+                "provider_observation_ignored": True,
+            }
         _persist_dispatch_receipt(
             binding_path=binding_path,
             goal_id=goal_id,
@@ -1286,6 +1319,19 @@ def _status_botmux_runtime(
             dispatch_key=dispatch_key,
             state=state,
             timestamp_field="status_checked_at",
+            updates=updates,
+        )
+    details: dict[str, Any] = {
+        "dispatch_state": state.value,
+        "output_available": output_available,
+        "local_receipt_updated": local_receipt_updated,
+    }
+    if provider_observation_ignored:
+        details.update(
+            {
+                "provider_observation": provider_state.value,
+                "provider_observation_ignored": True,
+            }
         )
     return _operation_packet(
         ok=state != BotmuxDispatchState.UNKNOWN,
@@ -1302,11 +1348,7 @@ def _status_botmux_runtime(
         readback_verified=state == BotmuxDispatchState.COMPLETED,
         idempotency_key=dispatch_key,
         receipt_id=_receipt_id(dispatch_key),
-        details={
-            "dispatch_state": state.value,
-            "output_available": output_available,
-            "local_receipt_updated": execute,
-        },
+        details=details,
     )
 
 

--- a/loopx/control_plane/goals/botmux_runtime.py
+++ b/loopx/control_plane/goals/botmux_runtime.py
@@ -1,0 +1,1161 @@
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+import os
+import re
+import tempfile
+from collections.abc import Callable, Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlparse
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from ...file_lock import exclusive_file_lock
+from ...paths import registry_project_root
+from ...registry import registry_goals
+
+
+BOTMUX_RUNTIME_BINDING_SCHEMA_VERSION = "loopx_goal_channel_botmux_binding_v0"
+BOTMUX_RUNTIME_OPERATION_SCHEMA_VERSION = "loopx_goal_channel_runtime_operation_v0"
+BOTMUX_PROVIDER = "botmux"
+BOTMUX_DEFAULT_ENDPOINT = "http://127.0.0.1:7891"
+BOTMUX_DEFAULT_TOKEN_ENV = "BOTMUX_DASHBOARD_TOKEN"
+BOTMUX_HTTP_TIMEOUT_SECONDS = 4.0
+
+_SAFE_TOKEN = re.compile(r"^[A-Za-z0-9._:-]{1,200}$")
+_ENV_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_PRIVATE_PACKET_KEYS = {
+    "bot_id",
+    "chat_id",
+    "endpoint",
+    "expected_working_dir",
+    "message_id",
+    "session_id",
+    "token",
+    "token_env",
+    "trigger_id",
+}
+
+JsonRequester = Callable[..., dict[str, Any]]
+
+
+class BotmuxApiError(RuntimeError):
+    def __init__(self, status: int, payload: Mapping[str, Any] | None = None) -> None:
+        super().__init__(f"botmux API returned HTTP {status}")
+        self.status = status
+        self.payload = dict(payload or {})
+
+
+class BotmuxTransportError(RuntimeError):
+    pass
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    def redirect_request(
+        self,
+        req: Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> None:
+        return None
+
+
+_NO_REDIRECT_OPENER = build_opener(_NoRedirectHandler())
+
+
+def default_botmux_runtime_binding_path(registry_path: Path) -> Path:
+    expanded = registry_path.expanduser().resolve()
+    if expanded.parent.name != ".loopx":
+        raise ValueError(
+            "Botmux Goal Channel runtime binding requires a project source registry"
+        )
+    return expanded.parent / "goal-channel-runtime.json"
+
+
+def _write_private_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    destination = path.expanduser()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+        dir=destination.parent,
+    )
+    temporary = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(dict(payload), handle, ensure_ascii=False, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, destination)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def read_botmux_runtime_binding(path: Path) -> dict[str, Any]:
+    binding_path = path.expanduser()
+    if not binding_path.exists():
+        return {
+            "schema_version": BOTMUX_RUNTIME_BINDING_SCHEMA_VERSION,
+            "bindings": {},
+        }
+    payload = json.loads(binding_path.read_text(encoding="utf-8"))
+    if (
+        not isinstance(payload, dict)
+        or payload.get("schema_version") != BOTMUX_RUNTIME_BINDING_SCHEMA_VERSION
+        or not isinstance(payload.get("bindings"), dict)
+    ):
+        raise ValueError("Botmux Goal Channel runtime binding is invalid")
+    return payload
+
+
+def botmux_binding_for_goal(
+    payload: Mapping[str, Any],
+    goal_id: str,
+) -> dict[str, Any] | None:
+    bindings = payload.get("bindings")
+    binding = bindings.get(goal_id) if isinstance(bindings, Mapping) else None
+    return dict(binding) if isinstance(binding, Mapping) else None
+
+
+def _save_binding(
+    *,
+    binding_path: Path,
+    payload: Mapping[str, Any],
+    goal_id: str,
+    binding: Mapping[str, Any],
+) -> None:
+    bindings = payload.get("bindings")
+    mutable = dict(bindings) if isinstance(bindings, Mapping) else {}
+    mutable[goal_id] = dict(binding)
+    _write_private_json_atomic(
+        binding_path,
+        {
+            "schema_version": BOTMUX_RUNTIME_BINDING_SCHEMA_VERSION,
+            "bindings": mutable,
+        },
+    )
+
+
+def _goal_from_registry(
+    registry: Mapping[str, Any],
+    goal_id: str,
+) -> dict[str, Any]:
+    match = next(
+        (
+            dict(goal)
+            for goal in registry_goals(dict(registry))
+            if str(goal.get("id") or "") == goal_id
+        ),
+        None,
+    )
+    if match is None:
+        raise ValueError(f"Goal `{goal_id}` is not registered")
+    return match
+
+
+def _validated_endpoint(value: str) -> str:
+    endpoint = str(value or "").strip().rstrip("/")
+    parsed = urlparse(endpoint)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+        or parsed.path not in {"", "/"}
+    ):
+        raise ValueError("botmux endpoint must be one HTTP(S) origin")
+    if parsed.scheme == "http":
+        hostname = str(parsed.hostname or "").lower()
+        try:
+            is_loopback = ipaddress.ip_address(hostname).is_loopback
+        except ValueError:
+            is_loopback = hostname == "localhost"
+        if not is_loopback:
+            raise ValueError("remote botmux endpoint must use HTTPS")
+    return endpoint
+
+
+def _validated_token_env(value: str) -> str:
+    token_env = str(value or "").strip()
+    if not _ENV_NAME.fullmatch(token_env):
+        raise ValueError("botmux token env must be one environment variable name")
+    return token_env
+
+
+def _validated_private_id(value: str, label: str) -> str:
+    normalized = str(value or "").strip()
+    if not _SAFE_TOKEN.fullmatch(normalized):
+        raise ValueError(f"botmux {label} is invalid")
+    return normalized
+
+
+def _normalized_working_dir(value: str) -> Path:
+    working_dir = Path(str(value or "").strip()).expanduser()
+    if not str(value or "").strip() or not working_dir.is_absolute():
+        raise ValueError("botmux working directory must be absolute")
+    return working_dir.resolve()
+
+
+def _dashboard_auth_for_binding(binding: Mapping[str, Any]) -> str:
+    token_env = _validated_token_env(str(binding.get("token_env") or ""))
+    token = str(os.environ.get(token_env) or "").strip()
+    if not token or any(ord(character) <= 32 for character in token) or ";" in token:
+        raise ValueError("botmux dashboard token is unavailable")
+    return token
+
+
+def _request_json(
+    *,
+    endpoint: str,
+    path: str,
+    method: str = "GET",
+    dashboard_auth: str | None = None,
+    payload: Mapping[str, Any] | None = None,
+    timeout_seconds: float = BOTMUX_HTTP_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    body = (
+        json.dumps(dict(payload), ensure_ascii=False, separators=(",", ":")).encode(
+            "utf-8"
+        )
+        if payload is not None
+        else None
+    )
+    headers = {"accept": "application/json"}
+    if body is not None:
+        headers["content-type"] = "application/json"
+    if dashboard_auth:
+        headers["cookie"] = f"botmux_dashboard_token={dashboard_auth}"
+    request = Request(
+        f"{endpoint}{path}",
+        data=body,
+        headers=headers,
+        method=method,
+    )
+    try:
+        with _NO_REDIRECT_OPENER.open(  # noqa: S310 - endpoint is explicit local-private operator configuration and redirects are disabled.
+            request,
+            timeout=timeout_seconds,
+        ) as response:
+            raw = response.read()
+    except HTTPError as exc:
+        try:
+            error_payload = json.loads(exc.read().decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            error_payload = {}
+        raise BotmuxApiError(
+            exc.code,
+            error_payload if isinstance(error_payload, Mapping) else {},
+        ) from exc
+    except (URLError, TimeoutError, OSError) as exc:
+        raise BotmuxTransportError("botmux transport failed") from exc
+    try:
+        parsed = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise BotmuxTransportError("botmux returned a non-JSON response") from exc
+    if not isinstance(parsed, dict):
+        raise BotmuxTransportError("botmux returned an invalid JSON response")
+    return parsed
+
+
+def _operation_packet(
+    *,
+    ok: bool,
+    goal_id: str,
+    operation: str,
+    execute: bool,
+    status: str,
+    public_summary: str,
+    blocker: str | None = None,
+    external_write_performed: bool = False,
+    readback_verified: bool = False,
+    idempotency_key: str | None = None,
+    receipt_id: str | None = None,
+    details: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    packet: dict[str, Any] = {
+        "schema_version": BOTMUX_RUNTIME_OPERATION_SCHEMA_VERSION,
+        "ok": ok,
+        "goal_id": goal_id,
+        "provider": BOTMUX_PROVIDER,
+        "operation": operation,
+        "execute": execute,
+        "status": status,
+        "external_write_performed": external_write_performed,
+        "readback_verified": readback_verified,
+        "idempotency_key": idempotency_key,
+        "receipt_id": receipt_id,
+        "public_summary": public_summary,
+        "private_provider_payload_captured": False,
+    }
+    if blocker:
+        packet["blocker"] = blocker
+    if details:
+        packet["details"] = dict(details)
+    _assert_public_packet(packet)
+    return packet
+
+
+def _assert_public_packet(packet: Mapping[str, Any]) -> None:
+    def visit(value: Any) -> None:
+        if isinstance(value, Mapping):
+            for key, child in value.items():
+                if key in _PRIVATE_PACKET_KEYS:
+                    raise ValueError(
+                        f"public botmux packet contains private key `{key}`"
+                    )
+                visit(child)
+        elif isinstance(value, list):
+            for child in value:
+                visit(child)
+
+    visit(packet)
+
+
+def _probe_botmux(
+    *,
+    binding: Mapping[str, Any],
+    requester: JsonRequester,
+) -> dict[str, Any]:
+    endpoint = _validated_endpoint(str(binding.get("endpoint") or ""))
+    bot_id = _validated_private_id(str(binding.get("bot_id") or ""), "bot id")
+    chat_id = _validated_private_id(str(binding.get("chat_id") or ""), "chat id")
+    expected_working_dir = _normalized_working_dir(
+        str(binding.get("expected_working_dir") or "")
+    )
+    dashboard_auth = _dashboard_auth_for_binding(binding)
+    health = requester(endpoint=endpoint, path="/__health")
+    if health.get("ok") is not True:
+        raise ValueError("botmux health probe failed")
+    bots_payload = requester(
+        endpoint=endpoint,
+        path="/api/bots",
+        dashboard_auth=dashboard_auth,
+    )
+    bots = bots_payload.get("bots")
+    bots = bots if isinstance(bots, list) else []
+    selected = next(
+        (
+            dict(item)
+            for item in bots
+            if isinstance(item, Mapping)
+            and str(item.get("larkAppId") or "") == bot_id
+        ),
+        None,
+    )
+    if selected is None:
+        raise ValueError("configured botmux bot is not online")
+    groups_payload = requester(
+        endpoint=endpoint,
+        path="/api/groups",
+        dashboard_auth=dashboard_auth,
+    )
+    chats = groups_payload.get("chats")
+    chats = chats if isinstance(chats, list) else []
+    selected_chat = next(
+        (
+            dict(item)
+            for item in chats
+            if isinstance(item, Mapping)
+            and str(item.get("chatId") or "") == chat_id
+        ),
+        None,
+    )
+    if selected_chat is None:
+        raise ValueError("configured botmux chat is not visible")
+    member_bots = selected_chat.get("memberBots")
+    member_bots = member_bots if isinstance(member_bots, list) else []
+    selected_member = next(
+        (
+            dict(item)
+            for item in member_bots
+            if isinstance(item, Mapping)
+            and str(item.get("larkAppId") or "") == bot_id
+            and item.get("inChat") is True
+        ),
+        None,
+    )
+    if selected_member is None:
+        raise ValueError("configured botmux bot is not in the selected chat")
+    oncall = selected_member.get("oncallChat")
+    oncall = oncall if isinstance(oncall, Mapping) else {}
+    configured_working_dirs = {
+        _normalized_working_dir(value)
+        for value in (
+            str(selected.get("defaultWorkingDir") or ""),
+            str(oncall.get("workingDir") or ""),
+        )
+        if value
+    }
+    if expected_working_dir not in configured_working_dirs:
+        raise ValueError(
+            "configured botmux bot or chat does not bind the LoopX project directory"
+        )
+    route = requester(
+        endpoint=endpoint,
+        path="/api/trigger",
+        method="POST",
+        dashboard_auth=dashboard_auth,
+        payload={
+            "source": {"type": "webhook"},
+            "target": {
+                "kind": "turn",
+                "botId": bot_id,
+                "chatId": chat_id,
+            },
+            "instruction": "LoopX botmux route readiness probe.",
+            "envelope": {
+                "format": "json",
+                "sourceName": "loopx",
+                "trusted": False,
+            },
+            "options": {"dryRun": True},
+        },
+    )
+    route_verified = bool(
+        route.get("ok") is True and str(route.get("action") or "") == "dry_run"
+    )
+    if not route_verified:
+        raise ValueError("botmux did not verify the configured chat route")
+    return {
+        "health_verified": True,
+        "bot_online": True,
+        "project_working_dir_verified": True,
+        "chat_route_verified": True,
+    }
+
+
+def _setup_botmux_runtime(
+    *,
+    registry: Mapping[str, Any],
+    registry_path: Path,
+    goal_id: str,
+    binding_path: Path,
+    endpoint: str,
+    bot_id: str,
+    chat_id: str,
+    token_env: str = BOTMUX_DEFAULT_TOKEN_ENV,
+    execute: bool = False,
+    requester: JsonRequester = _request_json,
+) -> dict[str, Any]:
+    _goal_from_registry(registry, goal_id)
+    payload = read_botmux_runtime_binding(binding_path)
+    prior = botmux_binding_for_goal(payload, goal_id) or {}
+    endpoint = _validated_endpoint(endpoint)
+    bot_id = _validated_private_id(bot_id, "bot id")
+    chat_id = _validated_private_id(chat_id, "chat id")
+    token_env = _validated_token_env(token_env)
+    expected_working_dir = registry_project_root(registry_path)
+    same_route = bool(
+        prior.get("endpoint") == endpoint
+        and prior.get("bot_id") == bot_id
+        and prior.get("chat_id") == chat_id
+        and prior.get("token_env") == token_env
+        and prior.get("expected_working_dir") == str(expected_working_dir)
+    )
+    binding = {
+        "goal_id": goal_id,
+        "provider": BOTMUX_PROVIDER,
+        "enabled": True,
+        "endpoint": endpoint,
+        "bot_id": bot_id,
+        "chat_id": chat_id,
+        "token_env": token_env,
+        "expected_working_dir": str(expected_working_dir),
+        "session": dict(prior.get("session") or {}) if same_route else {},
+        "receipts": dict(prior.get("receipts") or {}) if same_route else {},
+    }
+    try:
+        probe = _probe_botmux(binding=binding, requester=requester)
+    except ValueError as exc:
+        blocker = (
+            "botmux_auth_unavailable"
+            if "token is unavailable" in str(exc)
+            else "botmux_configuration_invalid"
+        )
+        return _operation_packet(
+            ok=False,
+            goal_id=goal_id,
+            operation="runtime_setup",
+            execute=execute,
+            status="blocked",
+            blocker=blocker,
+            public_summary="the botmux runtime binding could not be verified",
+        )
+    except BotmuxApiError:
+        return _operation_packet(
+            ok=False,
+            goal_id=goal_id,
+            operation="runtime_setup",
+            execute=execute,
+            status="blocked",
+            blocker="botmux_api_rejected",
+            public_summary="botmux rejected the runtime readiness probe",
+        )
+    except BotmuxTransportError:
+        return _operation_packet(
+            ok=False,
+            goal_id=goal_id,
+            operation="runtime_setup",
+            execute=execute,
+            status="blocked",
+            blocker="botmux_unreachable",
+            public_summary="the configured botmux daemon is unreachable",
+        )
+    if execute:
+        binding["verified_at"] = _now_iso()
+        _save_binding(
+            binding_path=binding_path,
+            payload=payload,
+            goal_id=goal_id,
+            binding=binding,
+        )
+    return _operation_packet(
+        ok=True,
+        goal_id=goal_id,
+        operation="runtime_setup",
+        execute=execute,
+        status="configured" if execute else "preview_ready",
+        public_summary=(
+            "configured the verified botmux runtime binding"
+            if execute
+            else "the botmux runtime binding is ready to configure"
+        ),
+        readback_verified=bool(execute),
+        details=probe,
+    )
+
+
+def doctor_botmux_runtime(
+    *,
+    goal_id: str,
+    binding_path: Path,
+    requester: JsonRequester = _request_json,
+) -> dict[str, Any]:
+    binding = botmux_binding_for_goal(
+        read_botmux_runtime_binding(binding_path),
+        goal_id,
+    )
+    if binding is None or binding.get("enabled") is not True:
+        return _operation_packet(
+            ok=False,
+            goal_id=goal_id,
+            operation="runtime_doctor",
+            execute=False,
+            status="blocked",
+            blocker="botmux_binding_missing",
+            public_summary="configure a botmux runtime binding for this goal",
+        )
+    try:
+        probe = _probe_botmux(binding=binding, requester=requester)
+    except ValueError as exc:
+        blocker = (
+            "botmux_auth_unavailable"
+            if "token is unavailable" in str(exc)
+            else "botmux_configuration_invalid"
+        )
+        return _operation_packet(
+            ok=False,
+            goal_id=goal_id,
+            operation="runtime_doctor",
+            execute=False,
+            status="blocked",
+            blocker=blocker,
+            public_summary="the botmux runtime binding is not ready",
+        )
+    except BotmuxApiError:
+        return _operation_packet(
+            ok=False,
+            goal_id=goal_id,
+            operation="runtime_doctor",
+            execute=False,
+            status="blocked",
+            blocker="botmux_api_rejected",
+            public_summary="botmux rejected the runtime readiness probe",
+        )
+    except BotmuxTransportError:
+        return _operation_packet(
+            ok=False,
+            goal_id=goal_id,
+            operation="runtime_doctor",
+            execute=False,
+            status="blocked",
+            blocker="botmux_unreachable",
+            public_summary="the configured botmux daemon is unreachable",
+        )
+    return _operation_packet(
+        ok=True,
+        goal_id=goal_id,
+        operation="runtime_doctor",
+        execute=False,
+        status="ready",
+        public_summary="the botmux runtime binding is ready",
+        readback_verified=True,
+        details=probe,
+    )
+
+
+def _disable_botmux_runtime(
+    *,
+    goal_id: str,
+    binding_path: Path,
+    execute: bool = False,
+) -> dict[str, Any]:
+    payload = read_botmux_runtime_binding(binding_path)
+    binding = botmux_binding_for_goal(payload, goal_id)
+    if binding is None:
+        return _operation_packet(
+            ok=True,
+            goal_id=goal_id,
+            operation="runtime_disable",
+            execute=execute,
+            status="not_configured",
+            public_summary="no botmux runtime binding is configured for this goal",
+        )
+    if execute:
+        binding["enabled"] = False
+        binding["session"] = {}
+        binding["disabled_at"] = _now_iso()
+        _save_binding(
+            binding_path=binding_path,
+            payload=payload,
+            goal_id=goal_id,
+            binding=binding,
+        )
+    return _operation_packet(
+        ok=True,
+        goal_id=goal_id,
+        operation="runtime_disable",
+        execute=execute,
+        status="disabled" if execute else "preview_ready",
+        public_summary=(
+            "disabled the botmux runtime binding for this goal"
+            if execute
+            else "the botmux runtime binding is ready to disable"
+        ),
+        readback_verified=bool(execute),
+    )
+
+
+def build_botmux_loopx_instruction(goal_id: str) -> str:
+    return (
+        f"Continue the active LoopX goal `{goal_id}` in the current project using "
+        "the installed LoopX CLI or managed skill. Read canonical goal state and "
+        "execute the active next action. Complete a coherent artifact, targeted "
+        "validation, and state writeback. Continue the next bounded segment while "
+        "no explicit gate, quota, authority, or production access blocker applies. "
+        "When stopping, report the exact stop reason and a pasteable resume command."
+    )
+
+
+def goal_runtime_revision(
+    *,
+    registry: Mapping[str, Any],
+    registry_path: Path,
+    goal_id: str,
+) -> str:
+    goal = _goal_from_registry(registry, goal_id)
+    raw_state_path = str(goal.get("state_file") or "").strip()
+    state_bytes = b""
+    if raw_state_path:
+        state_path = Path(raw_state_path).expanduser()
+        if not state_path.is_absolute():
+            state_path = registry_project_root(registry_path) / state_path
+        try:
+            state_bytes = state_path.read_bytes()
+        except OSError:
+            state_bytes = b""
+    digest = hashlib.sha256(
+        goal_id.encode("utf-8") + b"\0" + state_bytes
+    ).hexdigest()
+    return digest[:24]
+
+
+def _dispatch_key(*, goal_id: str, revision: str, instruction: str) -> str:
+    digest = hashlib.sha256(
+        json.dumps(
+            [goal_id, revision, instruction],
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _provider_turn_key(dispatch_key: str) -> str:
+    return f"loopx-{dispatch_key.removeprefix('sha256:')[:32]}"
+
+
+def _receipt_id(dispatch_key: str) -> str:
+    return f"runtime_{dispatch_key.removeprefix('sha256:')[:16]}"
+
+
+def _trigger_botmux_runtime(
+    *,
+    registry: Mapping[str, Any],
+    registry_path: Path,
+    goal_id: str,
+    binding_path: Path,
+    instruction: str | None = None,
+    turn_key: str | None = None,
+    execute: bool = False,
+    requester: JsonRequester = _request_json,
+) -> dict[str, Any]:
+    payload = read_botmux_runtime_binding(binding_path)
+    binding = botmux_binding_for_goal(payload, goal_id)
+    if binding is None or binding.get("enabled") is not True:
+        return _operation_packet(
+            ok=False,
+            goal_id=goal_id,
+            operation="runtime_trigger",
+            execute=execute,
+            status="blocked",
+            blocker="botmux_binding_missing",
+            public_summary="configure a botmux runtime binding for this goal",
+        )
+    selected_instruction = str(
+        instruction or build_botmux_loopx_instruction(goal_id)
+    ).strip()
+    if not selected_instruction:
+        raise ValueError("botmux runtime instruction must not be empty")
+    revision = str(
+        turn_key
+        or goal_runtime_revision(
+            registry=registry,
+            registry_path=registry_path,
+            goal_id=goal_id,
+        )
+    )
+    dispatch_key = _dispatch_key(
+        goal_id=goal_id,
+        revision=revision,
+        instruction=selected_instruction,
+    )
+    receipts = dict(binding.get("receipts") or {})
+    prior = receipts.get(dispatch_key)
+    if isinstance(prior, Mapping) and str(prior.get("state") or "") in {
+        "attempting",
+        "queued",
+        "running",
+        "completed",
+        "failed",
+        "not_found",
+        "unknown",
+    }:
+        state = str(prior.get("state") or "")
+        return _operation_packet(
+            ok=True,
+            goal_id=goal_id,
+            operation="runtime_trigger",
+            execute=execute,
+            status="already_dispatched",
+            public_summary="the same botmux runtime turn was already dispatched",
+            idempotency_key=dispatch_key,
+            receipt_id=_receipt_id(dispatch_key),
+            details={"dispatch_state": state, "session_reused": True},
+        )
+    session = dict(binding.get("session") or {})
+    existing_session_id = str(session.get("session_id") or "").strip()
+    if not execute:
+        return _operation_packet(
+            ok=True,
+            goal_id=goal_id,
+            operation="runtime_trigger",
+            execute=False,
+            status="preview_ready",
+            public_summary="the next LoopX turn is ready for botmux dispatch",
+            idempotency_key=dispatch_key,
+            receipt_id=_receipt_id(dispatch_key),
+            details={
+                "dispatch_state": "preview",
+                "session_reused": bool(existing_session_id),
+            },
+        )
+    endpoint = _validated_endpoint(str(binding.get("endpoint") or ""))
+    bot_id = _validated_private_id(str(binding.get("bot_id") or ""), "bot id")
+    dashboard_auth = _dashboard_auth_for_binding(binding)
+    target: dict[str, Any] = {"kind": "turn", "botId": bot_id}
+    options: dict[str, Any] = {"asyncReturnSessionId": True}
+    if existing_session_id:
+        target["sessionId"] = _validated_private_id(
+            existing_session_id,
+            "session id",
+        )
+        options["turnIdempotencyKey"] = _provider_turn_key(dispatch_key)
+    else:
+        target["chatId"] = _validated_private_id(
+            str(binding.get("chat_id") or ""),
+            "chat id",
+        )
+    receipts[dispatch_key] = {
+        "state": "attempting",
+        "attempted_at": _now_iso(),
+        "session_reused": bool(existing_session_id),
+    }
+    binding["receipts"] = receipts
+    _save_binding(
+        binding_path=binding_path,
+        payload=payload,
+        goal_id=goal_id,
+        binding=binding,
+    )
+    try:
+        response = requester(
+            endpoint=endpoint,
+            path="/api/trigger",
+            method="POST",
+            dashboard_auth=dashboard_auth,
+            payload={
+                "source": {"type": "webhook"},
+                "target": target,
+                "instruction": selected_instruction,
+                "envelope": {
+                    "format": "json",
+                    "sourceName": "loopx",
+                    "trusted": False,
+                },
+                "options": options,
+            },
+        )
+    except BotmuxTransportError:
+        return _operation_packet(
+            ok=False,
+            goal_id=goal_id,
+            operation="runtime_trigger",
+            execute=True,
+            status="dispatch_unknown",
+            blocker="botmux_dispatch_outcome_unknown",
+            public_summary=(
+                "botmux dispatch outcome is unknown; inspect the existing receipt "
+                "before retrying"
+            ),
+            idempotency_key=dispatch_key,
+            receipt_id=_receipt_id(dispatch_key),
+        )
+    except BotmuxApiError as exc:
+        receipts[dispatch_key] = {
+            **dict(receipts[dispatch_key]),
+            "state": "rejected",
+            "rejected_at": _now_iso(),
+            "http_status": exc.status,
+        }
+        binding["receipts"] = receipts
+        _save_binding(
+            binding_path=binding_path,
+            payload=read_botmux_runtime_binding(binding_path),
+            goal_id=goal_id,
+            binding=binding,
+        )
+        return _operation_packet(
+            ok=False,
+            goal_id=goal_id,
+            operation="runtime_trigger",
+            execute=True,
+            status="rejected",
+            blocker="botmux_api_rejected",
+            public_summary="botmux rejected the LoopX runtime turn",
+            idempotency_key=dispatch_key,
+            receipt_id=_receipt_id(dispatch_key),
+        )
+    response_target = response.get("target")
+    response_target = (
+        response_target if isinstance(response_target, Mapping) else {}
+    )
+    async_payload = response.get("async")
+    async_payload = async_payload if isinstance(async_payload, Mapping) else {}
+    session_id = str(
+        response_target.get("sessionId") or async_payload.get("sessionId") or ""
+    ).strip()
+    if response.get("ok") is not True or not session_id:
+        return _operation_packet(
+            ok=False,
+            goal_id=goal_id,
+            operation="runtime_trigger",
+            execute=True,
+            status="dispatch_unknown",
+            blocker="botmux_dispatch_receipt_invalid",
+            public_summary="botmux did not return a verifiable runtime session receipt",
+            idempotency_key=dispatch_key,
+            receipt_id=_receipt_id(dispatch_key),
+        )
+    receipts[dispatch_key] = {
+        **dict(receipts[dispatch_key]),
+        "state": "queued",
+        "queued_at": _now_iso(),
+        "session_id": session_id,
+        "trigger_id": str(response.get("triggerId") or ""),
+    }
+    binding["receipts"] = receipts
+    binding["session"] = {
+        "session_id": session_id,
+        "active_dispatch_key": dispatch_key,
+        "updated_at": _now_iso(),
+    }
+    _save_binding(
+        binding_path=binding_path,
+        payload=read_botmux_runtime_binding(binding_path),
+        goal_id=goal_id,
+        binding=binding,
+    )
+    return _operation_packet(
+        ok=True,
+        goal_id=goal_id,
+        operation="runtime_trigger",
+        execute=True,
+        status="queued",
+        public_summary="queued one LoopX turn through the botmux runtime",
+        external_write_performed=True,
+        idempotency_key=dispatch_key,
+        receipt_id=_receipt_id(dispatch_key),
+        details={"dispatch_state": "queued", "session_reused": bool(existing_session_id)},
+    )
+
+
+def _status_botmux_runtime(
+    *,
+    goal_id: str,
+    binding_path: Path,
+    execute: bool = False,
+    requester: JsonRequester = _request_json,
+) -> dict[str, Any]:
+    payload = read_botmux_runtime_binding(binding_path)
+    binding = botmux_binding_for_goal(payload, goal_id)
+    if binding is None:
+        return _operation_packet(
+            ok=False,
+            goal_id=goal_id,
+            operation="runtime_status",
+            execute=execute,
+            status="blocked",
+            blocker="botmux_binding_missing",
+            public_summary="configure a botmux runtime binding for this goal",
+        )
+    session = dict(binding.get("session") or {})
+    session_id = str(session.get("session_id") or "").strip()
+    dispatch_key = str(session.get("active_dispatch_key") or "").strip()
+    if not session_id or not dispatch_key:
+        return _operation_packet(
+            ok=True,
+            goal_id=goal_id,
+            operation="runtime_status",
+            execute=execute,
+            status="idle",
+            public_summary="no botmux runtime turn has been dispatched for this goal",
+            details={"dispatch_state": "idle", "output_available": False},
+        )
+    try:
+        result = requester(
+            endpoint=_validated_endpoint(str(binding.get("endpoint") or "")),
+            path=(
+                "/api/sessions/"
+                f"{quote(_validated_private_id(session_id, 'session id'), safe='')}"
+                "/trigger-result"
+            ),
+            dashboard_auth=_dashboard_auth_for_binding(binding),
+        )
+    except ValueError:
+        return _operation_packet(
+            ok=False,
+            goal_id=goal_id,
+            operation="runtime_status",
+            execute=execute,
+            status="blocked",
+            blocker="botmux_auth_unavailable",
+            public_summary="the botmux runtime status cannot be read without auth",
+        )
+    except BotmuxApiError as exc:
+        if exc.status == 404 and (
+            exc.payload.get("error") == "unknown_session"
+            or exc.payload.get("state") == "not_found"
+        ):
+            result = {"state": "not_found"}
+        else:
+            return _operation_packet(
+                ok=False,
+                goal_id=goal_id,
+                operation="runtime_status",
+                execute=execute,
+                status="blocked",
+                blocker="botmux_api_rejected",
+                public_summary="botmux rejected the runtime status read",
+            )
+    except BotmuxTransportError:
+        return _operation_packet(
+            ok=False,
+            goal_id=goal_id,
+            operation="runtime_status",
+            execute=execute,
+            status="unknown",
+            blocker="botmux_unreachable",
+            public_summary="the botmux runtime status is temporarily unknown",
+        )
+    state = str(result.get("state") or "unknown")
+    if state not in {"running", "completed", "failed", "not_found"}:
+        state = "unknown"
+    output = result.get("output")
+    output_available = bool(
+        isinstance(output, Mapping) and str(output.get("content") or "").strip()
+    )
+    if execute:
+        receipts = dict(binding.get("receipts") or {})
+        receipt = dict(receipts.get(dispatch_key) or {})
+        receipt["state"] = state
+        receipt["status_checked_at"] = _now_iso()
+        receipts[dispatch_key] = receipt
+        binding["receipts"] = receipts
+        _save_binding(
+            binding_path=binding_path,
+            payload=payload,
+            goal_id=goal_id,
+            binding=binding,
+        )
+    return _operation_packet(
+        ok=state != "unknown",
+        goal_id=goal_id,
+        operation="runtime_status",
+        execute=execute,
+        status=state,
+        blocker="botmux_status_unknown" if state == "unknown" else None,
+        public_summary=f"the botmux runtime turn is {state}",
+        readback_verified=state == "completed",
+        idempotency_key=dispatch_key,
+        receipt_id=_receipt_id(dispatch_key),
+        details={
+            "dispatch_state": state,
+            "output_available": output_available,
+            "local_receipt_updated": execute,
+        },
+    )
+
+
+def setup_botmux_runtime(
+    *,
+    registry: Mapping[str, Any],
+    registry_path: Path,
+    goal_id: str,
+    binding_path: Path,
+    endpoint: str,
+    bot_id: str,
+    chat_id: str,
+    token_env: str = BOTMUX_DEFAULT_TOKEN_ENV,
+    execute: bool = False,
+    requester: JsonRequester = _request_json,
+) -> dict[str, Any]:
+    if not execute:
+        return _setup_botmux_runtime(
+            registry=registry,
+            registry_path=registry_path,
+            goal_id=goal_id,
+            binding_path=binding_path,
+            endpoint=endpoint,
+            bot_id=bot_id,
+            chat_id=chat_id,
+            token_env=token_env,
+            execute=False,
+            requester=requester,
+        )
+    with exclusive_file_lock(binding_path, operation="botmux_runtime_setup"):
+        return _setup_botmux_runtime(
+            registry=registry,
+            registry_path=registry_path,
+            goal_id=goal_id,
+            binding_path=binding_path,
+            endpoint=endpoint,
+            bot_id=bot_id,
+            chat_id=chat_id,
+            token_env=token_env,
+            execute=True,
+            requester=requester,
+        )
+
+
+def disable_botmux_runtime(
+    *,
+    goal_id: str,
+    binding_path: Path,
+    execute: bool = False,
+) -> dict[str, Any]:
+    if not execute:
+        return _disable_botmux_runtime(
+            goal_id=goal_id,
+            binding_path=binding_path,
+            execute=False,
+        )
+    with exclusive_file_lock(binding_path, operation="botmux_runtime_disable"):
+        return _disable_botmux_runtime(
+            goal_id=goal_id,
+            binding_path=binding_path,
+            execute=True,
+        )
+
+
+def trigger_botmux_runtime(
+    *,
+    registry: Mapping[str, Any],
+    registry_path: Path,
+    goal_id: str,
+    binding_path: Path,
+    instruction: str | None = None,
+    turn_key: str | None = None,
+    execute: bool = False,
+    requester: JsonRequester = _request_json,
+) -> dict[str, Any]:
+    if not execute:
+        return _trigger_botmux_runtime(
+            registry=registry,
+            registry_path=registry_path,
+            goal_id=goal_id,
+            binding_path=binding_path,
+            instruction=instruction,
+            turn_key=turn_key,
+            execute=False,
+            requester=requester,
+        )
+    with exclusive_file_lock(binding_path, operation="botmux_runtime_trigger"):
+        return _trigger_botmux_runtime(
+            registry=registry,
+            registry_path=registry_path,
+            goal_id=goal_id,
+            binding_path=binding_path,
+            instruction=instruction,
+            turn_key=turn_key,
+            execute=True,
+            requester=requester,
+        )
+
+
+def status_botmux_runtime(
+    *,
+    goal_id: str,
+    binding_path: Path,
+    execute: bool = False,
+    requester: JsonRequester = _request_json,
+) -> dict[str, Any]:
+    if not execute:
+        return _status_botmux_runtime(
+            goal_id=goal_id,
+            binding_path=binding_path,
+            execute=False,
+            requester=requester,
+        )
+    with exclusive_file_lock(binding_path, operation="botmux_runtime_status"):
+        return _status_botmux_runtime(
+            goal_id=goal_id,
+            binding_path=binding_path,
+            execute=True,
+            requester=requester,
+        )
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/loopx/control_plane/goals/botmux_runtime.py
+++ b/loopx/control_plane/goals/botmux_runtime.py
@@ -8,6 +8,7 @@ import re
 import tempfile
 from collections.abc import Callable, Mapping
 from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
@@ -52,6 +53,69 @@ class BotmuxApiError(RuntimeError):
 
 class BotmuxTransportError(RuntimeError):
     pass
+
+
+class BotmuxDispatchState(str, Enum):
+    ATTEMPTING = "attempting"
+    QUEUED = "queued"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    NOT_FOUND = "not_found"
+    UNKNOWN = "unknown"
+    REJECTED = "rejected"
+
+
+_DISPATCH_TRANSITIONS: dict[
+    BotmuxDispatchState | None,
+    frozenset[BotmuxDispatchState],
+] = {
+    None: frozenset({BotmuxDispatchState.ATTEMPTING}),
+    BotmuxDispatchState.ATTEMPTING: frozenset(
+        {
+            BotmuxDispatchState.QUEUED,
+            BotmuxDispatchState.UNKNOWN,
+            BotmuxDispatchState.REJECTED,
+        }
+    ),
+    BotmuxDispatchState.QUEUED: frozenset(
+        {
+            BotmuxDispatchState.QUEUED,
+            BotmuxDispatchState.RUNNING,
+            BotmuxDispatchState.COMPLETED,
+            BotmuxDispatchState.FAILED,
+            BotmuxDispatchState.NOT_FOUND,
+            BotmuxDispatchState.UNKNOWN,
+        }
+    ),
+    BotmuxDispatchState.RUNNING: frozenset(
+        {
+            BotmuxDispatchState.RUNNING,
+            BotmuxDispatchState.COMPLETED,
+            BotmuxDispatchState.FAILED,
+            BotmuxDispatchState.NOT_FOUND,
+            BotmuxDispatchState.UNKNOWN,
+        }
+    ),
+    BotmuxDispatchState.UNKNOWN: frozenset(
+        {
+            BotmuxDispatchState.UNKNOWN,
+            BotmuxDispatchState.RUNNING,
+            BotmuxDispatchState.COMPLETED,
+            BotmuxDispatchState.FAILED,
+            BotmuxDispatchState.NOT_FOUND,
+        }
+    ),
+    BotmuxDispatchState.COMPLETED: frozenset({BotmuxDispatchState.COMPLETED}),
+    BotmuxDispatchState.FAILED: frozenset({BotmuxDispatchState.FAILED}),
+    BotmuxDispatchState.NOT_FOUND: frozenset({BotmuxDispatchState.NOT_FOUND}),
+    BotmuxDispatchState.REJECTED: frozenset(
+        {
+            BotmuxDispatchState.REJECTED,
+            BotmuxDispatchState.ATTEMPTING,
+        }
+    ),
+}
 
 
 class _NoRedirectHandler(HTTPRedirectHandler):
@@ -142,6 +206,110 @@ def _save_binding(
             "schema_version": BOTMUX_RUNTIME_BINDING_SCHEMA_VERSION,
             "bindings": mutable,
         },
+    )
+
+
+def _dispatch_state(value: object) -> BotmuxDispatchState | None:
+    try:
+        return BotmuxDispatchState(str(value or ""))
+    except ValueError:
+        return None
+
+
+def _transition_dispatch_receipt(
+    receipt: Mapping[str, Any] | None,
+    *,
+    state: BotmuxDispatchState,
+    timestamp_field: str,
+    updates: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    current = _dispatch_state(receipt.get("state")) if isinstance(receipt, Mapping) else None
+    allowed = _DISPATCH_TRANSITIONS.get(current, frozenset())
+    if state not in allowed:
+        raise ValueError(
+            f"invalid botmux dispatch transition: "
+            f"{current.value if current else 'none'}->{state.value}"
+        )
+    transitioned = dict(receipt or {})
+    transitioned["state"] = state.value
+    transitioned[timestamp_field] = _now_iso()
+    if updates:
+        transitioned.update(dict(updates))
+    return transitioned
+
+
+def _persist_dispatch_receipt(
+    *,
+    binding_path: Path,
+    goal_id: str,
+    binding: dict[str, Any],
+    dispatch_key: str,
+    state: BotmuxDispatchState,
+    timestamp_field: str,
+    updates: Mapping[str, Any] | None = None,
+    session: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload = read_botmux_runtime_binding(binding_path)
+    current_binding = botmux_binding_for_goal(payload, goal_id)
+    if current_binding is None:
+        raise ValueError("botmux runtime binding disappeared during dispatch")
+    receipts = dict(current_binding.get("receipts") or {})
+    receipt = _transition_dispatch_receipt(
+        receipts.get(dispatch_key)
+        if isinstance(receipts.get(dispatch_key), Mapping)
+        else None,
+        state=state,
+        timestamp_field=timestamp_field,
+        updates=updates,
+    )
+    receipts[dispatch_key] = receipt
+    current_binding["receipts"] = receipts
+    if session is not None:
+        current_binding["session"] = dict(session)
+    binding.clear()
+    binding.update(current_binding)
+    _save_binding(
+        binding_path=binding_path,
+        payload=payload,
+        goal_id=goal_id,
+        binding=current_binding,
+    )
+    return receipt
+
+
+def _active_dispatch_receipt(
+    binding: Mapping[str, Any],
+) -> tuple[str, dict[str, Any]] | None:
+    receipts = binding.get("receipts")
+    receipts = receipts if isinstance(receipts, Mapping) else {}
+    session = binding.get("session")
+    session = session if isinstance(session, Mapping) else {}
+    active_key = str(session.get("active_dispatch_key") or "").strip()
+    active = receipts.get(active_key) if active_key else None
+    if active_key and isinstance(active, Mapping):
+        return active_key, dict(active)
+
+    candidates = [
+        (str(key), dict(value))
+        for key, value in receipts.items()
+        if isinstance(value, Mapping)
+        and _dispatch_state(value.get("state"))
+        in {
+            BotmuxDispatchState.ATTEMPTING,
+            BotmuxDispatchState.UNKNOWN,
+            BotmuxDispatchState.REJECTED,
+        }
+    ]
+    if not candidates:
+        return None
+    return max(
+        candidates,
+        key=lambda item: str(
+            item[1].get("unknown_at")
+            or item[1].get("rejected_at")
+            or item[1].get("attempted_at")
+            or ""
+        ),
     )
 
 
@@ -355,6 +523,8 @@ def _probe_botmux(
     )
     if selected is None:
         raise ValueError("configured botmux bot is not online")
+    if selected.get("online") is not True:
+        raise ValueError("configured botmux bot is offline")
     groups_payload = requester(
         endpoint=endpoint,
         path="/api/groups",
@@ -743,16 +913,20 @@ def _trigger_botmux_runtime(
     )
     receipts = dict(binding.get("receipts") or {})
     prior = receipts.get(dispatch_key)
-    if isinstance(prior, Mapping) and str(prior.get("state") or "") in {
-        "attempting",
-        "queued",
-        "running",
-        "completed",
-        "failed",
-        "not_found",
-        "unknown",
+    prior_state = (
+        _dispatch_state(prior.get("state"))
+        if isinstance(prior, Mapping)
+        else None
+    )
+    if prior_state in {
+        BotmuxDispatchState.ATTEMPTING,
+        BotmuxDispatchState.QUEUED,
+        BotmuxDispatchState.RUNNING,
+        BotmuxDispatchState.COMPLETED,
+        BotmuxDispatchState.FAILED,
+        BotmuxDispatchState.NOT_FOUND,
+        BotmuxDispatchState.UNKNOWN,
     }:
-        state = str(prior.get("state") or "")
         return _operation_packet(
             ok=True,
             goal_id=goal_id,
@@ -762,7 +936,10 @@ def _trigger_botmux_runtime(
             public_summary="the same botmux runtime turn was already dispatched",
             idempotency_key=dispatch_key,
             receipt_id=_receipt_id(dispatch_key),
-            details={"dispatch_state": state, "session_reused": True},
+            details={
+                "dispatch_state": prior_state.value,
+                "session_reused": True,
+            },
         )
     session = dict(binding.get("session") or {})
     existing_session_id = str(session.get("session_id") or "").strip()
@@ -797,17 +974,23 @@ def _trigger_botmux_runtime(
             str(binding.get("chat_id") or ""),
             "chat id",
         )
-    receipts[dispatch_key] = {
-        "state": "attempting",
-        "attempted_at": _now_iso(),
-        "session_reused": bool(existing_session_id),
-    }
-    binding["receipts"] = receipts
-    _save_binding(
+    _persist_dispatch_receipt(
         binding_path=binding_path,
-        payload=payload,
         goal_id=goal_id,
         binding=binding,
+        dispatch_key=dispatch_key,
+        state=BotmuxDispatchState.ATTEMPTING,
+        timestamp_field="attempted_at",
+        updates={"session_reused": bool(existing_session_id)},
+        session={
+            **(
+                {"session_id": existing_session_id}
+                if existing_session_id
+                else {}
+            ),
+            "active_dispatch_key": dispatch_key,
+            "updated_at": _now_iso(),
+        },
     )
     try:
         response = requester(
@@ -828,6 +1011,15 @@ def _trigger_botmux_runtime(
             },
         )
     except BotmuxTransportError:
+        _persist_dispatch_receipt(
+            binding_path=binding_path,
+            goal_id=goal_id,
+            binding=binding,
+            dispatch_key=dispatch_key,
+            state=BotmuxDispatchState.UNKNOWN,
+            timestamp_field="unknown_at",
+            updates={"unknown_reason": "transport_failure"},
+        )
         return _operation_packet(
             ok=False,
             goal_id=goal_id,
@@ -843,18 +1035,14 @@ def _trigger_botmux_runtime(
             receipt_id=_receipt_id(dispatch_key),
         )
     except BotmuxApiError as exc:
-        receipts[dispatch_key] = {
-            **dict(receipts[dispatch_key]),
-            "state": "rejected",
-            "rejected_at": _now_iso(),
-            "http_status": exc.status,
-        }
-        binding["receipts"] = receipts
-        _save_binding(
+        _persist_dispatch_receipt(
             binding_path=binding_path,
-            payload=read_botmux_runtime_binding(binding_path),
             goal_id=goal_id,
             binding=binding,
+            dispatch_key=dispatch_key,
+            state=BotmuxDispatchState.REJECTED,
+            timestamp_field="rejected_at",
+            updates={"http_status": exc.status},
         )
         return _operation_packet(
             ok=False,
@@ -877,6 +1065,15 @@ def _trigger_botmux_runtime(
         response_target.get("sessionId") or async_payload.get("sessionId") or ""
     ).strip()
     if response.get("ok") is not True or not session_id:
+        _persist_dispatch_receipt(
+            binding_path=binding_path,
+            goal_id=goal_id,
+            binding=binding,
+            dispatch_key=dispatch_key,
+            state=BotmuxDispatchState.UNKNOWN,
+            timestamp_field="unknown_at",
+            updates={"unknown_reason": "invalid_provider_receipt"},
+        )
         return _operation_packet(
             ok=False,
             goal_id=goal_id,
@@ -888,24 +1085,22 @@ def _trigger_botmux_runtime(
             idempotency_key=dispatch_key,
             receipt_id=_receipt_id(dispatch_key),
         )
-    receipts[dispatch_key] = {
-        **dict(receipts[dispatch_key]),
-        "state": "queued",
-        "queued_at": _now_iso(),
-        "session_id": session_id,
-        "trigger_id": str(response.get("triggerId") or ""),
-    }
-    binding["receipts"] = receipts
-    binding["session"] = {
-        "session_id": session_id,
-        "active_dispatch_key": dispatch_key,
-        "updated_at": _now_iso(),
-    }
-    _save_binding(
+    _persist_dispatch_receipt(
         binding_path=binding_path,
-        payload=read_botmux_runtime_binding(binding_path),
         goal_id=goal_id,
         binding=binding,
+        dispatch_key=dispatch_key,
+        state=BotmuxDispatchState.QUEUED,
+        timestamp_field="queued_at",
+        updates={
+            "session_id": session_id,
+            "trigger_id": str(response.get("triggerId") or ""),
+        },
+        session={
+            "session_id": session_id,
+            "active_dispatch_key": dispatch_key,
+            "updated_at": _now_iso(),
+        },
     )
     return _operation_packet(
         ok=True,
@@ -944,6 +1139,55 @@ def _status_botmux_runtime(
     session_id = str(session.get("session_id") or "").strip()
     dispatch_key = str(session.get("active_dispatch_key") or "").strip()
     if not session_id or not dispatch_key:
+        active = _active_dispatch_receipt(binding)
+        if active is not None:
+            active_key, receipt = active
+            receipt_state = _dispatch_state(receipt.get("state"))
+            if receipt_state == BotmuxDispatchState.ATTEMPTING:
+                receipt_state = BotmuxDispatchState.UNKNOWN
+                if execute:
+                    _persist_dispatch_receipt(
+                        binding_path=binding_path,
+                        goal_id=goal_id,
+                        binding=binding,
+                        dispatch_key=active_key,
+                        state=BotmuxDispatchState.UNKNOWN,
+                        timestamp_field="unknown_at",
+                        updates={"unknown_reason": "unresolved_attempt"},
+                    )
+            if receipt_state in {
+                BotmuxDispatchState.UNKNOWN,
+                BotmuxDispatchState.REJECTED,
+            }:
+                public_state = receipt_state.value
+                return _operation_packet(
+                    ok=False,
+                    goal_id=goal_id,
+                    operation="runtime_status",
+                    execute=execute,
+                    status=public_state,
+                    blocker=(
+                        "botmux_dispatch_outcome_unknown"
+                        if receipt_state == BotmuxDispatchState.UNKNOWN
+                        else "botmux_api_rejected"
+                    ),
+                    public_summary=(
+                        "the botmux runtime dispatch outcome is unknown"
+                        if receipt_state == BotmuxDispatchState.UNKNOWN
+                        else "the botmux runtime dispatch was rejected"
+                    ),
+                    idempotency_key=active_key,
+                    receipt_id=_receipt_id(active_key),
+                    details={
+                        "dispatch_state": public_state,
+                        "output_available": False,
+                        "local_receipt_updated": bool(
+                            execute
+                            and _dispatch_state(receipt.get("state"))
+                            == BotmuxDispatchState.ATTEMPTING
+                        ),
+                    },
+                )
         return _operation_packet(
             ok=True,
             goal_id=goal_id,
@@ -990,6 +1234,29 @@ def _status_botmux_runtime(
                 public_summary="botmux rejected the runtime status read",
             )
     except BotmuxTransportError:
+        if execute:
+            receipts = binding.get("receipts")
+            receipts = receipts if isinstance(receipts, Mapping) else {}
+            receipt = receipts.get(dispatch_key)
+            current_state = (
+                _dispatch_state(receipt.get("state"))
+                if isinstance(receipt, Mapping)
+                else None
+            )
+            if current_state in {
+                BotmuxDispatchState.QUEUED,
+                BotmuxDispatchState.RUNNING,
+                BotmuxDispatchState.UNKNOWN,
+            }:
+                _persist_dispatch_receipt(
+                    binding_path=binding_path,
+                    goal_id=goal_id,
+                    binding=binding,
+                    dispatch_key=dispatch_key,
+                    state=BotmuxDispatchState.UNKNOWN,
+                    timestamp_field="unknown_at",
+                    updates={"unknown_reason": "status_transport_failure"},
+                )
         return _operation_packet(
             ok=False,
             goal_id=goal_id,
@@ -999,39 +1266,44 @@ def _status_botmux_runtime(
             blocker="botmux_unreachable",
             public_summary="the botmux runtime status is temporarily unknown",
         )
-    state = str(result.get("state") or "unknown")
-    if state not in {"running", "completed", "failed", "not_found"}:
-        state = "unknown"
+    state = _dispatch_state(result.get("state"))
+    if state not in {
+        BotmuxDispatchState.RUNNING,
+        BotmuxDispatchState.COMPLETED,
+        BotmuxDispatchState.FAILED,
+        BotmuxDispatchState.NOT_FOUND,
+    }:
+        state = BotmuxDispatchState.UNKNOWN
     output = result.get("output")
     output_available = bool(
         isinstance(output, Mapping) and str(output.get("content") or "").strip()
     )
     if execute:
-        receipts = dict(binding.get("receipts") or {})
-        receipt = dict(receipts.get(dispatch_key) or {})
-        receipt["state"] = state
-        receipt["status_checked_at"] = _now_iso()
-        receipts[dispatch_key] = receipt
-        binding["receipts"] = receipts
-        _save_binding(
+        _persist_dispatch_receipt(
             binding_path=binding_path,
-            payload=payload,
             goal_id=goal_id,
             binding=binding,
+            dispatch_key=dispatch_key,
+            state=state,
+            timestamp_field="status_checked_at",
         )
     return _operation_packet(
-        ok=state != "unknown",
+        ok=state != BotmuxDispatchState.UNKNOWN,
         goal_id=goal_id,
         operation="runtime_status",
         execute=execute,
-        status=state,
-        blocker="botmux_status_unknown" if state == "unknown" else None,
-        public_summary=f"the botmux runtime turn is {state}",
-        readback_verified=state == "completed",
+        status=state.value,
+        blocker=(
+            "botmux_status_unknown"
+            if state == BotmuxDispatchState.UNKNOWN
+            else None
+        ),
+        public_summary=f"the botmux runtime turn is {state.value}",
+        readback_verified=state == BotmuxDispatchState.COMPLETED,
         idempotency_key=dispatch_key,
         receipt_id=_receipt_id(dispatch_key),
         details={
-            "dispatch_state": state,
+            "dispatch_state": state.value,
             "output_available": output_available,
             "local_receipt_updated": execute,
         },

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -125,6 +125,7 @@ nav:
       - integrations/README.md
       - Worker Bridge: integrations/worker-bridge-install-contract.md
       - Lark Kanban: integrations/lark-kanban-control-plane-adapter.md
+      - Botmux Goal Channel Runtime: integrations/botmux-goal-channel-runtime.md
       - Lark Provider: integrations/lark-provider/README.md
       - Runtime Connector Catalog: integrations/runtime-connector-catalog.md
   - Reference:

--- a/tests/control_plane/test_botmux_goal_channel_runtime.py
+++ b/tests/control_plane/test_botmux_goal_channel_runtime.py
@@ -1,0 +1,755 @@
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from loopx.cli import build_parser
+from loopx.control_plane.goals.botmux_runtime import (
+    BOTMUX_RUNTIME_BINDING_SCHEMA_VERSION,
+    BotmuxApiError,
+    botmux_binding_for_goal,
+    disable_botmux_runtime,
+    doctor_botmux_runtime,
+    read_botmux_runtime_binding,
+    setup_botmux_runtime,
+    status_botmux_runtime,
+    trigger_botmux_runtime,
+)
+
+
+GOAL_ID = "goal-public-fixture"
+BOT_ID = "cli_public_fixture"
+CHAT_ID = "oc_public_fixture"
+SESSION_ID = "session-public-fixture"
+
+
+def _registry(tmp_path: Path) -> tuple[dict[str, Any], Path]:
+    registry_path = tmp_path / ".loopx" / "registry.json"
+    registry_path.parent.mkdir(parents=True)
+    state_path = tmp_path / "ACTIVE_GOAL_STATE.md"
+    state_path.write_text("# Active Goal\n\n- next: validate botmux\n", encoding="utf-8")
+    registry = {
+        "goals": [
+            {
+                "id": GOAL_ID,
+                "objective": "Validate a public-safe botmux runtime binding.",
+                "repo": str(tmp_path),
+                "state_file": str(state_path),
+            }
+        ]
+    }
+    registry_path.write_text(json.dumps(registry), encoding="utf-8")
+    return registry, registry_path
+
+
+def _relative_registry(tmp_path: Path) -> tuple[dict[str, Any], Path]:
+    registry_path = tmp_path / ".loopx" / "registry.json"
+    registry_path.parent.mkdir(parents=True)
+    state_path = tmp_path / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text("# Active Goal\n\n- next: relative state\n", encoding="utf-8")
+    registry = {
+        "goals": [
+            {
+                "id": GOAL_ID,
+                "objective": "Validate a relative project state path.",
+                "repo": str(tmp_path),
+                "state_file": str(state_path.relative_to(tmp_path)),
+            }
+        ]
+    }
+    registry_path.write_text(json.dumps(registry), encoding="utf-8")
+    return registry, registry_path
+
+
+def _requester(
+    calls: list[dict[str, Any]],
+    working_dir: Path,
+):
+    def request(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        path = str(kwargs["path"])
+        if path == "/__health":
+            return {"ok": True}
+        if path == "/api/bots":
+            return {
+                "bots": [
+                    {
+                        "larkAppId": BOT_ID,
+                        "online": True,
+                        "defaultWorkingDir": str(working_dir),
+                    }
+                ]
+            }
+        if path == "/api/groups":
+            return {
+                "chats": [
+                    {
+                        "chatId": chat_id,
+                        "memberBots": [
+                            {
+                                "larkAppId": BOT_ID,
+                                "inChat": True,
+                                "oncallChat": None,
+                            }
+                        ],
+                    }
+                    for chat_id in (CHAT_ID, "oc_second_public_fixture")
+                ]
+            }
+        if path == "/api/trigger":
+            body = kwargs["payload"]
+            if body["options"].get("dryRun") is True:
+                return {"ok": True, "action": "dry_run"}
+            return {
+                "ok": True,
+                "action": "queued",
+                "triggerId": "trigger-public-fixture",
+                "target": {"sessionId": SESSION_ID},
+            }
+        if path.endswith("/trigger-result"):
+            return {
+                "ok": True,
+                "state": "completed",
+                "output": {"content": "validated"},
+            }
+        raise AssertionError(f"unexpected botmux request: {kwargs}")
+
+    return request
+
+
+def _assert_public_packet(payload: dict[str, Any]) -> None:
+    serialized = json.dumps(payload, ensure_ascii=False)
+    assert BOT_ID not in serialized
+    assert CHAT_ID not in serialized
+    assert SESSION_ID not in serialized
+    assert "BOTMUX_TEST_TOKEN" not in serialized
+    assert str(Path.home()) not in serialized
+
+
+def test_runtime_cli_parses_setup_doctor_trigger_and_status() -> None:
+    parser = build_parser()
+
+    setup = parser.parse_args(
+        [
+            "goal-channel",
+            "runtime",
+            "setup",
+            "--goal-id",
+            GOAL_ID,
+            "--bot-id",
+            BOT_ID,
+            "--chat-id",
+            CHAT_ID,
+        ]
+    )
+    doctor = parser.parse_args(
+        ["goal-channel", "runtime", "doctor", "--goal-id", GOAL_ID]
+    )
+    trigger = parser.parse_args(
+        ["goal-channel", "runtime", "trigger", "--goal-id", GOAL_ID]
+    )
+    status = parser.parse_args(
+        ["goal-channel", "runtime", "status", "--goal-id", GOAL_ID]
+    )
+    disable = parser.parse_args(
+        ["goal-channel", "runtime", "disable", "--goal-id", GOAL_ID]
+    )
+
+    assert setup.goal_channel_runtime_command == "setup"
+    assert setup.endpoint == "http://127.0.0.1:7891"
+    assert doctor.goal_channel_runtime_command == "doctor"
+    assert trigger.goal_channel_runtime_command == "trigger"
+    assert status.goal_channel_runtime_command == "status"
+    assert disable.goal_channel_runtime_command == "disable"
+
+
+def test_setup_is_dry_run_then_writes_owner_private_binding(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, registry_path = _registry(tmp_path)
+    binding_path = tmp_path / ".loopx" / "goal-channel-runtime.json"
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setenv("BOTMUX_TEST_TOKEN", "secret-public-fixture")
+
+    preview = setup_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        endpoint="http://127.0.0.1:7891",
+        bot_id=BOT_ID,
+        chat_id=CHAT_ID,
+        token_env="BOTMUX_TEST_TOKEN",
+        requester=_requester(calls, tmp_path),
+    )
+
+    assert preview["ok"] is True
+    assert preview["status"] == "preview_ready"
+    assert not binding_path.exists()
+    assert calls[-1]["payload"]["options"] == {"dryRun": True}
+
+    configured = setup_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        endpoint="http://127.0.0.1:7891",
+        bot_id=BOT_ID,
+        chat_id=CHAT_ID,
+        token_env="BOTMUX_TEST_TOKEN",
+        execute=True,
+        requester=_requester(calls, tmp_path),
+    )
+
+    assert configured["ok"] is True
+    assert configured["status"] == "configured"
+    assert configured["readback_verified"] is True
+    assert binding_path.stat().st_mode & 0o777 == 0o600
+    stored = read_botmux_runtime_binding(binding_path)
+    assert stored["schema_version"] == BOTMUX_RUNTIME_BINDING_SCHEMA_VERSION
+    binding = botmux_binding_for_goal(stored, GOAL_ID)
+    assert binding is not None
+    assert binding["bot_id"] == BOT_ID
+    assert binding["chat_id"] == CHAT_ID
+    assert binding["token_env"] == "BOTMUX_TEST_TOKEN"
+    _assert_public_packet(configured)
+
+
+def test_doctor_accepts_runtime_agnostic_bot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, registry_path = _registry(tmp_path)
+    binding_path = tmp_path / ".loopx" / "goal-channel-runtime.json"
+    monkeypatch.setenv("BOTMUX_TEST_TOKEN", "secret-public-fixture")
+    setup_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        endpoint="http://127.0.0.1:7891",
+        bot_id=BOT_ID,
+        chat_id=CHAT_ID,
+        token_env="BOTMUX_TEST_TOKEN",
+        execute=True,
+        requester=_requester([], tmp_path),
+    )
+
+    def another_runtime(**kwargs: Any) -> dict[str, Any]:
+        if kwargs["path"] == "/__health":
+            return {"ok": True}
+        if kwargs["path"] == "/api/bots":
+            return {
+                "bots": [
+                    {
+                        "larkAppId": BOT_ID,
+                        "cliId": "codex",
+                        "defaultWorkingDir": str(tmp_path),
+                    }
+                ]
+            }
+        if kwargs["path"] == "/api/groups":
+            return {
+                "chats": [
+                    {
+                        "chatId": CHAT_ID,
+                        "memberBots": [
+                            {"larkAppId": BOT_ID, "inChat": True, "oncallChat": None}
+                        ],
+                    }
+                ]
+            }
+        if kwargs["path"] == "/api/trigger":
+            return {"ok": True, "action": "dry_run"}
+        raise AssertionError(f"unexpected request: {kwargs}")
+
+    result = doctor_botmux_runtime(
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        requester=another_runtime,
+    )
+
+    assert result["ok"] is True
+    assert result["status"] == "ready"
+    _assert_public_packet(result)
+
+
+def test_disable_is_goal_scoped_and_previewable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, registry_path = _registry(tmp_path)
+    binding_path = tmp_path / ".loopx" / "goal-channel-runtime.json"
+    monkeypatch.setenv("BOTMUX_TEST_TOKEN", "secret-public-fixture")
+    setup_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        endpoint="http://127.0.0.1:7891",
+        bot_id=BOT_ID,
+        chat_id=CHAT_ID,
+        token_env="BOTMUX_TEST_TOKEN",
+        execute=True,
+        requester=_requester([], tmp_path),
+    )
+
+    preview = disable_botmux_runtime(
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+    )
+    before = botmux_binding_for_goal(
+        read_botmux_runtime_binding(binding_path),
+        GOAL_ID,
+    )
+    disabled = disable_botmux_runtime(
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        execute=True,
+    )
+    after = botmux_binding_for_goal(
+        read_botmux_runtime_binding(binding_path),
+        GOAL_ID,
+    )
+
+    assert preview["status"] == "preview_ready"
+    assert before is not None and before["enabled"] is True
+    assert disabled["status"] == "disabled"
+    assert after is not None
+    assert after["enabled"] is False
+    assert after["session"] == {}
+    _assert_public_packet(disabled)
+
+
+def test_doctor_rejects_failed_health_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, registry_path = _registry(tmp_path)
+    binding_path = tmp_path / ".loopx" / "goal-channel-runtime.json"
+    monkeypatch.setenv("BOTMUX_TEST_TOKEN", "secret-public-fixture")
+    setup_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        endpoint="http://127.0.0.1:7891",
+        bot_id=BOT_ID,
+        chat_id=CHAT_ID,
+        token_env="BOTMUX_TEST_TOKEN",
+        execute=True,
+        requester=_requester([], tmp_path),
+    )
+
+    result = doctor_botmux_runtime(
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        requester=lambda **kwargs: {"ok": False},
+    )
+
+    assert result["ok"] is False
+    assert result["blocker"] == "botmux_configuration_invalid"
+
+
+def test_setup_rejects_botmux_route_for_another_project(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, registry_path = _registry(tmp_path)
+    binding_path = tmp_path / ".loopx" / "goal-channel-runtime.json"
+    monkeypatch.setenv("BOTMUX_TEST_TOKEN", "secret-public-fixture")
+
+    result = setup_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        endpoint="http://127.0.0.1:7891",
+        bot_id=BOT_ID,
+        chat_id=CHAT_ID,
+        token_env="BOTMUX_TEST_TOKEN",
+        execute=True,
+        requester=_requester([], tmp_path / "another-project"),
+    )
+
+    assert result["ok"] is False
+    assert result["blocker"] == "botmux_configuration_invalid"
+    assert not binding_path.exists()
+
+
+def test_trigger_is_previewable_idempotent_and_reuses_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, registry_path = _registry(tmp_path)
+    binding_path = tmp_path / ".loopx" / "goal-channel-runtime.json"
+    monkeypatch.setenv("BOTMUX_TEST_TOKEN", "secret-public-fixture")
+    setup_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        endpoint="http://127.0.0.1:7891",
+        bot_id=BOT_ID,
+        chat_id=CHAT_ID,
+        token_env="BOTMUX_TEST_TOKEN",
+        execute=True,
+        requester=_requester([], tmp_path),
+    )
+    calls: list[dict[str, Any]] = []
+
+    preview = trigger_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        requester=_requester(calls, tmp_path),
+    )
+    queued = trigger_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        execute=True,
+        requester=_requester(calls, tmp_path),
+    )
+    duplicate = trigger_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        execute=True,
+        requester=_requester(calls, tmp_path),
+    )
+
+    assert preview["status"] == "preview_ready"
+    assert preview["external_write_performed"] is False
+    assert queued["status"] == "queued"
+    assert queued["external_write_performed"] is True
+    assert duplicate["status"] == "already_dispatched"
+    trigger_calls = [call for call in calls if call["path"] == "/api/trigger"]
+    assert len(trigger_calls) == 1
+    first_target = trigger_calls[0]["payload"]["target"]
+    assert first_target == {
+        "kind": "turn",
+        "botId": BOT_ID,
+        "chatId": CHAT_ID,
+    }
+    _assert_public_packet(queued)
+    _assert_public_packet(duplicate)
+
+    followup_calls: list[dict[str, Any]] = []
+    followup = trigger_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        turn_key="explicit-next-segment",
+        execute=True,
+        requester=_requester(followup_calls, tmp_path),
+    )
+    followup_body = followup_calls[0]["payload"]
+    assert followup["status"] == "queued"
+    assert followup_body["target"] == {
+        "kind": "turn",
+        "botId": BOT_ID,
+        "sessionId": SESSION_ID,
+    }
+    assert "turnIdempotencyKey" in followup_body["options"]
+
+
+def test_relative_state_file_changes_default_dispatch_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, registry_path = _relative_registry(tmp_path)
+    binding_path = tmp_path / ".loopx" / "goal-channel-runtime.json"
+    monkeypatch.setenv("BOTMUX_TEST_TOKEN", "secret-public-fixture")
+    setup_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        endpoint="http://127.0.0.1:7891",
+        bot_id=BOT_ID,
+        chat_id=CHAT_ID,
+        token_env="BOTMUX_TEST_TOKEN",
+        execute=True,
+        requester=_requester([], tmp_path),
+    )
+
+    first = trigger_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        requester=_requester([], tmp_path),
+    )
+    state_path = tmp_path / registry["goals"][0]["state_file"]
+    state_path.write_text("# Active Goal\n\n- next: changed state\n", encoding="utf-8")
+    second = trigger_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        requester=_requester([], tmp_path),
+    )
+
+    assert first["idempotency_key"] != second["idempotency_key"]
+
+
+def test_rebinding_to_another_chat_drops_prior_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, registry_path = _registry(tmp_path)
+    binding_path = tmp_path / ".loopx" / "goal-channel-runtime.json"
+    monkeypatch.setenv("BOTMUX_TEST_TOKEN", "secret-public-fixture")
+    setup_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        endpoint="http://127.0.0.1:7891",
+        bot_id=BOT_ID,
+        chat_id=CHAT_ID,
+        token_env="BOTMUX_TEST_TOKEN",
+        execute=True,
+        requester=_requester([], tmp_path),
+    )
+    trigger_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        execute=True,
+        requester=_requester([], tmp_path),
+    )
+
+    new_chat = "oc_second_public_fixture"
+    setup_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        endpoint="http://127.0.0.1:7891",
+        bot_id=BOT_ID,
+        chat_id=new_chat,
+        token_env="BOTMUX_TEST_TOKEN",
+        execute=True,
+        requester=_requester([], tmp_path),
+    )
+
+    binding = botmux_binding_for_goal(
+        read_botmux_runtime_binding(binding_path),
+        GOAL_ID,
+    )
+    assert binding is not None
+    assert binding["chat_id"] == new_chat
+    assert binding["session"] == {}
+    assert binding["receipts"] == {}
+
+
+def test_status_reads_four_state_and_updates_local_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, registry_path = _registry(tmp_path)
+    binding_path = tmp_path / ".loopx" / "goal-channel-runtime.json"
+    monkeypatch.setenv("BOTMUX_TEST_TOKEN", "secret-public-fixture")
+    setup_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        endpoint="http://127.0.0.1:7891",
+        bot_id=BOT_ID,
+        chat_id=CHAT_ID,
+        token_env="BOTMUX_TEST_TOKEN",
+        execute=True,
+        requester=_requester([], tmp_path),
+    )
+    trigger_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        execute=True,
+        requester=_requester([], tmp_path),
+    )
+
+    result = status_botmux_runtime(
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        execute=True,
+        requester=_requester([], tmp_path),
+    )
+
+    assert result["ok"] is True
+    assert result["status"] == "completed"
+    assert result["readback_verified"] is True
+    assert result["details"] == {
+        "dispatch_state": "completed",
+        "output_available": True,
+        "local_receipt_updated": True,
+    }
+    _assert_public_packet(result)
+
+
+def test_status_maps_confirmed_unknown_session_to_not_found(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, registry_path = _registry(tmp_path)
+    binding_path = tmp_path / ".loopx" / "goal-channel-runtime.json"
+    monkeypatch.setenv("BOTMUX_TEST_TOKEN", "secret-public-fixture")
+    setup_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        endpoint="http://127.0.0.1:7891",
+        bot_id=BOT_ID,
+        chat_id=CHAT_ID,
+        token_env="BOTMUX_TEST_TOKEN",
+        execute=True,
+        requester=_requester([], tmp_path),
+    )
+    trigger_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        execute=True,
+        requester=_requester([], tmp_path),
+    )
+
+    def missing(**kwargs: Any) -> dict[str, Any]:
+        raise BotmuxApiError(404, {"error": "unknown_session"})
+
+    result = status_botmux_runtime(
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        requester=missing,
+    )
+
+    assert result["ok"] is True
+    assert result["status"] == "not_found"
+
+
+def test_terminal_failure_requires_new_turn_key_before_redispatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, registry_path = _registry(tmp_path)
+    binding_path = tmp_path / ".loopx" / "goal-channel-runtime.json"
+    monkeypatch.setenv("BOTMUX_TEST_TOKEN", "secret-public-fixture")
+    setup_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        endpoint="http://127.0.0.1:7891",
+        bot_id=BOT_ID,
+        chat_id=CHAT_ID,
+        token_env="BOTMUX_TEST_TOKEN",
+        execute=True,
+        requester=_requester([], tmp_path),
+    )
+    trigger_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        execute=True,
+        requester=_requester([], tmp_path),
+    )
+
+    def failed(**kwargs: Any) -> dict[str, Any]:
+        return {"ok": True, "state": "failed"}
+
+    status_botmux_runtime(
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        execute=True,
+        requester=failed,
+    )
+    calls: list[dict[str, Any]] = []
+    duplicate = trigger_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        execute=True,
+        requester=_requester(calls, tmp_path),
+    )
+
+    assert duplicate["status"] == "already_dispatched"
+    assert calls == []
+
+
+def test_concurrent_trigger_dispatches_provider_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, registry_path = _registry(tmp_path)
+    binding_path = tmp_path / ".loopx" / "goal-channel-runtime.json"
+    monkeypatch.setenv("BOTMUX_TEST_TOKEN", "secret-public-fixture")
+    setup_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        endpoint="http://127.0.0.1:7891",
+        bot_id=BOT_ID,
+        chat_id=CHAT_ID,
+        token_env="BOTMUX_TEST_TOKEN",
+        execute=True,
+        requester=_requester([], tmp_path),
+    )
+    provider_call_count = 0
+    provider_call_lock = threading.Lock()
+    results: list[dict[str, Any]] = []
+
+    def delayed_provider(**kwargs: Any) -> dict[str, Any]:
+        nonlocal provider_call_count
+        with provider_call_lock:
+            provider_call_count += 1
+        time.sleep(0.05)
+        return {
+            "ok": True,
+            "action": "queued",
+            "triggerId": "trigger-public-fixture",
+            "target": {"sessionId": SESSION_ID},
+        }
+
+    def run_trigger() -> None:
+        results.append(
+            trigger_botmux_runtime(
+                registry=registry,
+                registry_path=registry_path,
+                goal_id=GOAL_ID,
+                binding_path=binding_path,
+                execute=True,
+                requester=delayed_provider,
+            )
+        )
+
+    threads = [threading.Thread(target=run_trigger) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert provider_call_count == 1
+    assert sorted(result["status"] for result in results) == [
+        "already_dispatched",
+        "queued",
+    ]

--- a/tests/control_plane/test_botmux_goal_channel_runtime.py
+++ b/tests/control_plane/test_botmux_goal_channel_runtime.py
@@ -12,6 +12,7 @@ from loopx.cli import build_parser
 from loopx.control_plane.goals.botmux_runtime import (
     BOTMUX_RUNTIME_BINDING_SCHEMA_VERSION,
     BotmuxApiError,
+    BotmuxTransportError,
     botmux_binding_for_goal,
     disable_botmux_runtime,
     doctor_botmux_runtime,
@@ -251,6 +252,7 @@ def test_doctor_accepts_runtime_agnostic_bot(
                     {
                         "larkAppId": BOT_ID,
                         "cliId": "codex",
+                        "online": True,
                         "defaultWorkingDir": str(tmp_path),
                     }
                 ]
@@ -279,6 +281,47 @@ def test_doctor_accepts_runtime_agnostic_bot(
     assert result["ok"] is True
     assert result["status"] == "ready"
     _assert_public_packet(result)
+
+
+def test_setup_rejects_explicitly_offline_bot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, registry_path = _registry(tmp_path)
+    binding_path = tmp_path / ".loopx" / "goal-channel-runtime.json"
+    monkeypatch.setenv("BOTMUX_TEST_TOKEN", "secret-public-fixture")
+
+    def offline(**kwargs: Any) -> dict[str, Any]:
+        if kwargs["path"] == "/__health":
+            return {"ok": True}
+        if kwargs["path"] == "/api/bots":
+            return {
+                "bots": [
+                    {
+                        "larkAppId": BOT_ID,
+                        "online": False,
+                        "defaultWorkingDir": str(tmp_path),
+                    }
+                ]
+            }
+        raise AssertionError("offline bot must stop readiness before chat probing")
+
+    result = setup_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        endpoint="http://127.0.0.1:7891",
+        bot_id=BOT_ID,
+        chat_id=CHAT_ID,
+        token_env="BOTMUX_TEST_TOKEN",
+        execute=True,
+        requester=offline,
+    )
+
+    assert result["ok"] is False
+    assert result["blocker"] == "botmux_configuration_invalid"
+    assert not binding_path.exists()
 
 
 def test_disable_is_goal_scoped_and_previewable(
@@ -603,6 +646,60 @@ def test_status_reads_four_state_and_updates_local_receipt(
     _assert_public_packet(result)
 
 
+def test_status_transport_failure_does_not_regress_terminal_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, registry_path = _registry(tmp_path)
+    binding_path = tmp_path / ".loopx" / "goal-channel-runtime.json"
+    monkeypatch.setenv("BOTMUX_TEST_TOKEN", "secret-public-fixture")
+    setup_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        endpoint="http://127.0.0.1:7891",
+        bot_id=BOT_ID,
+        chat_id=CHAT_ID,
+        token_env="BOTMUX_TEST_TOKEN",
+        execute=True,
+        requester=_requester([], tmp_path),
+    )
+    trigger_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        execute=True,
+        requester=_requester([], tmp_path),
+    )
+    status_botmux_runtime(
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        execute=True,
+        requester=_requester([], tmp_path),
+    )
+
+    def unavailable(**kwargs: Any) -> dict[str, Any]:
+        raise BotmuxTransportError("fixture status failure")
+
+    observed = status_botmux_runtime(
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        execute=True,
+        requester=unavailable,
+    )
+    binding = botmux_binding_for_goal(
+        read_botmux_runtime_binding(binding_path),
+        GOAL_ID,
+    )
+    assert binding is not None
+    dispatch_key = binding["session"]["active_dispatch_key"]
+
+    assert observed["status"] == "unknown"
+    assert binding["receipts"][dispatch_key]["state"] == "completed"
+
+
 def test_status_maps_confirmed_unknown_session_to_not_found(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -693,6 +790,140 @@ def test_terminal_failure_requires_new_turn_key_before_redispatch(
 
     assert duplicate["status"] == "already_dispatched"
     assert calls == []
+
+
+@pytest.mark.parametrize(
+    ("failure_kind", "expected_reason"),
+    [
+        ("transport", "transport_failure"),
+        ("invalid_receipt", "invalid_provider_receipt"),
+    ],
+)
+def test_unknown_dispatch_is_persisted_and_status_never_reports_idle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_kind: str,
+    expected_reason: str,
+) -> None:
+    registry, registry_path = _registry(tmp_path)
+    binding_path = tmp_path / ".loopx" / "goal-channel-runtime.json"
+    monkeypatch.setenv("BOTMUX_TEST_TOKEN", "secret-public-fixture")
+    setup_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        endpoint="http://127.0.0.1:7891",
+        bot_id=BOT_ID,
+        chat_id=CHAT_ID,
+        token_env="BOTMUX_TEST_TOKEN",
+        execute=True,
+        requester=_requester([], tmp_path),
+    )
+    provider_calls = 0
+
+    def uncertain_provider(**kwargs: Any) -> dict[str, Any]:
+        nonlocal provider_calls
+        provider_calls += 1
+        if failure_kind == "transport":
+            raise BotmuxTransportError("fixture transport failure")
+        return {"ok": True, "action": "queued"}
+
+    dispatched = trigger_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        execute=True,
+        requester=uncertain_provider,
+    )
+    binding = botmux_binding_for_goal(
+        read_botmux_runtime_binding(binding_path),
+        GOAL_ID,
+    )
+    assert binding is not None
+    active_key = str(binding["session"]["active_dispatch_key"])
+    receipt = binding["receipts"][active_key]
+
+    assert dispatched["status"] == "dispatch_unknown"
+    assert receipt["state"] == "unknown"
+    assert receipt["unknown_reason"] == expected_reason
+    assert "attempted_at" in receipt
+
+    status = status_botmux_runtime(
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+    )
+    assert status["ok"] is False
+    assert status["status"] == "unknown"
+    assert status["blocker"] == "botmux_dispatch_outcome_unknown"
+    assert status["details"]["dispatch_state"] == "unknown"
+
+    duplicate = trigger_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        execute=True,
+        requester=uncertain_provider,
+    )
+    assert duplicate["status"] == "already_dispatched"
+    assert duplicate["details"]["dispatch_state"] == "unknown"
+    assert provider_calls == 1
+
+
+def test_status_promotes_unresolved_attempt_to_unknown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, registry_path = _registry(tmp_path)
+    binding_path = tmp_path / ".loopx" / "goal-channel-runtime.json"
+    monkeypatch.setenv("BOTMUX_TEST_TOKEN", "secret-public-fixture")
+    setup_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        endpoint="http://127.0.0.1:7891",
+        bot_id=BOT_ID,
+        chat_id=CHAT_ID,
+        token_env="BOTMUX_TEST_TOKEN",
+        execute=True,
+        requester=_requester([], tmp_path),
+    )
+    payload = read_botmux_runtime_binding(binding_path)
+    binding = botmux_binding_for_goal(payload, GOAL_ID)
+    assert binding is not None
+    dispatch_key = "sha256:" + ("a" * 64)
+    binding["receipts"] = {
+        dispatch_key: {
+            "state": "attempting",
+            "attempted_at": "2026-01-01T00:00:00+00:00",
+            "session_reused": False,
+        }
+    }
+    binding["session"] = {"active_dispatch_key": dispatch_key}
+    payload["bindings"][GOAL_ID] = binding
+    binding_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    status = status_botmux_runtime(
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        execute=True,
+    )
+    persisted = botmux_binding_for_goal(
+        read_botmux_runtime_binding(binding_path),
+        GOAL_ID,
+    )
+
+    assert status["status"] == "unknown"
+    assert status["details"]["local_receipt_updated"] is True
+    assert persisted is not None
+    assert persisted["receipts"][dispatch_key]["state"] == "unknown"
+    assert (
+        persisted["receipts"][dispatch_key]["unknown_reason"]
+        == "unresolved_attempt"
+    )
 
 
 def test_concurrent_trigger_dispatches_provider_once(

--- a/tests/control_plane/test_botmux_goal_channel_runtime.py
+++ b/tests/control_plane/test_botmux_goal_channel_runtime.py
@@ -600,7 +600,7 @@ def test_rebinding_to_another_chat_drops_prior_session(
     assert binding["receipts"] == {}
 
 
-def test_status_reads_four_state_and_updates_local_receipt(
+def test_status_reads_typed_lifecycle_and_updates_local_receipt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -698,6 +698,92 @@ def test_status_transport_failure_does_not_regress_terminal_receipt(
 
     assert observed["status"] == "unknown"
     assert binding["receipts"][dispatch_key]["state"] == "completed"
+
+
+@pytest.mark.parametrize(
+    ("local_state", "provider_state"),
+    [
+        ("completed", "running"),
+        ("failed", "unknown"),
+        ("not_found", None),
+    ],
+)
+def test_status_ignores_provider_regression_after_local_terminal_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    local_state: str,
+    provider_state: str | None,
+) -> None:
+    registry, registry_path = _registry(tmp_path)
+    binding_path = tmp_path / ".loopx" / "goal-channel-runtime.json"
+    monkeypatch.setenv("BOTMUX_TEST_TOKEN", "secret-public-fixture")
+    setup_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        endpoint="http://127.0.0.1:7891",
+        bot_id=BOT_ID,
+        chat_id=CHAT_ID,
+        token_env="BOTMUX_TEST_TOKEN",
+        execute=True,
+        requester=_requester([], tmp_path),
+    )
+    trigger_botmux_runtime(
+        registry=registry,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        execute=True,
+        requester=_requester([], tmp_path),
+    )
+
+    def terminal(**kwargs: Any) -> dict[str, Any]:
+        return {"ok": True, "state": local_state}
+
+    status_botmux_runtime(
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        execute=True,
+        requester=terminal,
+    )
+
+    def stale(**kwargs: Any) -> dict[str, Any]:
+        return {"ok": True, "state": provider_state}
+
+    observed = status_botmux_runtime(
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        execute=True,
+        requester=stale,
+    )
+    binding = botmux_binding_for_goal(
+        read_botmux_runtime_binding(binding_path),
+        GOAL_ID,
+    )
+    assert binding is not None
+    dispatch_key = binding["session"]["active_dispatch_key"]
+
+    assert observed["ok"] is True
+    assert observed["status"] == local_state
+    assert "blocker" not in observed
+    assert observed["details"] == {
+        "dispatch_state": local_state,
+        "output_available": False,
+        "local_receipt_updated": True,
+        "provider_observation": provider_state or "unknown",
+        "provider_observation_ignored": True,
+    }
+    assert binding["receipts"][dispatch_key]["state"] == local_state
+    assert (
+        binding["receipts"][dispatch_key]["provider_observation"]
+        == (provider_state or "unknown")
+    )
+    assert (
+        binding["receipts"][dispatch_key]["provider_observation_ignored"]
+        is True
+    )
+    _assert_public_packet(observed)
 
 
 def test_status_maps_confirmed_unknown_session_to_not_found(


### PR DESCRIPTION
## Summary

- add `goal-channel runtime setup|doctor|trigger|status|disable` for an optional, runtime-neutral botmux integration
- verify botmux health, bot availability, chat membership, and project working-directory binding before activation
- keep local-private, owner-only bindings and at-most-once dispatch receipts with goal-scoped file locking
- preserve the authority boundary: botmux notification and delivery are observations only; canonical LoopX state changes only through validated LoopX transitions

## Issue Or Task

- Closes #
- Contributor task ID: operator-surface-im-integration-botmux

## Validation

- [x] `python3 -m py_compile loopx/cli_commands/goal_channel.py loopx/control_plane/goals/botmux_runtime.py tests/control_plane/test_botmux_goal_channel_runtime.py`
- [x] `loopx check --scan-path ...` for all seven changed public files (0 findings)
- [x] focused Goal Channel/runtime tests: 67 passed
- [x] runtime-neutral bot test: a bot using another CLI adapter passes setup/doctor when route and project bindings are valid
- [x] concurrent trigger test: two simultaneous calls produce one provider dispatch
- [x] offline bot negative test: explicit `online=false` blocks setup before chat probing
- [x] uncertain dispatch tests: transport failure and invalid provider receipt persist `unknown`, status never reports idle, and duplicate retry does not re-dispatch
- [x] terminal receipt regression test: later status transport failures do not overwrite completed/failed state
- [x] `python -m ruff check tests loopx/canary loopx/control_plane loopx/domain_packs loopx/presentation loopx/cli_commands/goal_channel.py`
- [x] `python examples/control_plane/cli-output-budget-regression-smoke.py`
- [x] `python examples/canary/smoke-suite-runner-smoke.py`
- [x] `loopx canary premerge --from-git-diff`: 18/18 selected checks passed, no manual holds
- [x] fake-dashboard CLI E2E: setup -> doctor -> trigger -> status completed; binding mode 0600; auth Cookie verified
- [x] botmux 3.15.0 core-only protocol probe: daemon ready, agent session launched, and model output observed

The broad repository pytest run reported 16 environment/known unrelated failures with 3355 passed and 2 skipped. Re-running the failure set with an absolute source `PYTHONPATH` reduced it to 4 environment failures: two retained-case tests because this host has `/tmp/.git`, and two onboarding tests that deliberately replace the subprocess environment and cannot import an uninstalled checkout. The host also lacks `ensurepip`, which blocks the extension-scaffold venv test.

Provider observation hold: in the real core-only protocol probe, the configured agent produced the requested output, but botmux's `trigger-result` did not converge before timeout and shutdown persisted `dispatch_unknown`. The LoopX integration preserves that fail-closed observation and does not infer a canonical state transition from message delivery or model output.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [x] Test update

## LoopX Area

- [x] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [ ] Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
- [ ] Capability or extension (providers, adapters, skills)
- [x] Public docs or presentation surface (README, protocols, dashboard)
- [ ] Build, packaging, installer, or CI
- [x] Host or runtime integration

## Technical Direction

- [ ] Core control-plane hardening
- [ ] Long-horizon benchmark evidence
- [x] Operator surface and IM integration
- [x] Shared Goal Authority and cross-host coordination
- [ ] Architecture and research incubator

- Target base branch: `main`
- Direction tracker or promotion unit: Goal Channel collaboration v0 / Agent IM boundaries

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).

