### PR TITLE
fix(ci): document classic PAT requirement for stargazer history

### DIFF
--- a/.github/workflows/frontstage-pages.yml
+++ b/.github/workflows/frontstage-pages.yml
@@ -140,9 +140,10 @@ jobs:
       - name: Fetch complete GitHub stargazer history
         if: github.event_name != 'pull_request'
         env:
-          # List-stargazers rejects the GitHub Actions installation token even
-          # with Metadata: read. Keep this existing fine-grained token limited
-          # to this public repository and read-only metadata.
+          # Since July 2026, GitHub limits stargazer listing to repository
+          # admins/collaborators and rejects fine-grained PATs even with
+          # Metadata: read. Use a classic PAT from an admin/collaborator
+          # account with only the public_repo scope.
           GH_TOKEN: ${{ secrets.STAR_HISTORY_READ_TOKEN }}
         run: |
           scripts/fetch-github-stargazers.sh \

--- a/scripts/fetch-github-stargazers.sh
+++ b/scripts/fetch-github-stargazers.sh
@@ -10,7 +10,7 @@ if [[ ! "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ || -z "$output_json" 
   exit 2
 fi
 if [[ -z "${GH_TOKEN:-}" ]]; then
-  echo "::error title=Missing star-history credential::Set STAR_HISTORY_READ_TOKEN to a fine-grained token limited to this public repository with read-only Metadata access." >&2
+  echo "::error title=Missing star-history credential::Set STAR_HISTORY_READ_TOKEN to a classic PAT from an admin/collaborator account with the public_repo scope." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Why

GitHub's July 2026 restriction on stargazer listing endpoints only allows admins/collaborators. In practice, a fine-grained PAT with `Metadata: read` still returns HTTP 403 for `stargazers` — even when created by the repository owner. A classic PAT from an admin/collaborator account with only the `public_repo` scope works for both REST and GraphQL enumeration.

## Change

- Update the Frontstage workflow comment to state the real credential requirement.
- Update the missing-credential error message in `scripts/fetch-github-stargazers.sh` so operators do not create another fine-grained PAT that silently fails.

No runtime behavior changes. Local `examples/frontstage-pages-workflow-smoke.py` passes.