### PR TITLE
fix(quota): preserve heartbeat settlement binding on reentry

### DIFF
--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -23,6 +23,7 @@ from ..control_plane.quota.error_codes import (
 from ..control_plane.quota.heartbeat_receipt import (
     fail_heartbeat_receipt,
     find_heartbeat_receipt,
+    heartbeat_receipt_settlement_replan_obligation_id,
     heartbeat_receipt_settlement_todo_id,
     heartbeat_receipt_view,
 )
@@ -126,6 +127,15 @@ class _QuotaCommandContext:
     operator_inbox_urgency_projector: Callable[..., dict[str, object]]
     detail_sections: frozenset[str]
     heartbeat_turn_id: str | None
+
+
+def _heartbeat_receipt_settlement_bindings(
+    event: Mapping[str, object],
+) -> tuple[str | None, str | None]:
+    return (
+        heartbeat_receipt_settlement_todo_id(event),
+        heartbeat_receipt_settlement_replan_obligation_id(event),
+    )
 
 
 def _scheduler_execution_context_from_args(
@@ -553,7 +563,7 @@ def handle_quota_command(
         scheduler_context = context.scheduler_context
         operator_inbox_urgency_projector = context.operator_inbox_urgency_projector
         if args.quota_command == "should-run":
-            receipt_bound_todo_id = None
+            receipt_bound_todo_id, receipt_bound_replan_obligation_id = None, None
             if heartbeat_turn_id:
                 heartbeat_receipt_existing = find_heartbeat_receipt(
                     runtime_root,
@@ -562,7 +572,10 @@ def handle_quota_command(
                     turn_instance_id=heartbeat_turn_id,
                 )
                 if heartbeat_receipt_existing:
-                    receipt_bound_todo_id = heartbeat_receipt_settlement_todo_id(
+                    (
+                        receipt_bound_todo_id,
+                        receipt_bound_replan_obligation_id,
+                    ) = _heartbeat_receipt_settlement_bindings(
                         heartbeat_receipt_existing
                     )
             payload = build_live_quota_should_run_decision(
@@ -581,6 +594,9 @@ def handle_quota_command(
                     project_live_explore_composition_frontier
                 ),
                 receipt_bound_todo_id=receipt_bound_todo_id,
+                receipt_bound_replan_obligation_id=(
+                    receipt_bound_replan_obligation_id
+                ),
             )
             if heartbeat_turn_id:
                 if heartbeat_receipt_existing:
@@ -652,6 +668,9 @@ def handle_quota_command(
                                 project_live_explore_composition_frontier
                             ),
                             receipt_bound_todo_id=receipt_bound_todo_id,
+                            receipt_bound_replan_obligation_id=(
+                                receipt_bound_replan_obligation_id
+                            ),
                         )
                         cache_metadata = None
                         heartbeat_stall_observation = (

--- a/loopx/control_plane/quota/heartbeat_receipt.py
+++ b/loopx/control_plane/quota/heartbeat_receipt.py
@@ -84,6 +84,17 @@ def heartbeat_receipt_settlement_todo_id(
     return identity[1]
 
 
+def heartbeat_receipt_settlement_replan_obligation_id(
+    event: Mapping[str, object],
+) -> str | None:
+    """Return the autonomous replan bound to a committed heartbeat receipt."""
+
+    identity = _receipt_settlement_identity(event)
+    if identity is None or identity[0] is not SettlementBindingKind.AUTONOMOUS_REPLAN:
+        return None
+    return identity[1]
+
+
 def _effective_heartbeat_receipt(
     events: list[dict[str, object]],
 ) -> dict[str, object] | None:

--- a/loopx/control_plane/quota/live_decision.py
+++ b/loopx/control_plane/quota/live_decision.py
@@ -90,6 +90,7 @@ def build_live_quota_should_run_decision(
     operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
     bounded_research_frontier_projector: BoundedResearchFrontierProjector | None = None,
     receipt_bound_todo_id: str | None = None,
+    receipt_bound_replan_obligation_id: str | None = None,
 ) -> dict[str, Any]:
     """Build one live CLI decision while keeping host observation injectable."""
 
@@ -134,6 +135,7 @@ def build_live_quota_should_run_decision(
         scheduler_execution_context=resolved_context,
         operator_inbox_urgency_projector=operator_inbox_urgency_projector,
         receipt_bound_todo_id=receipt_bound_todo_id,
+        receipt_bound_replan_obligation_id=receipt_bound_replan_obligation_id,
     )
     bind_scheduler_followup_cli_routes(
         payload,

--- a/loopx/control_plane/quota/settlement_cli.py
+++ b/loopx/control_plane/quota/settlement_cli.py
@@ -50,7 +50,7 @@ def reconcile_existing_heartbeat_receipt(
             if isinstance(existing_details_value, Mapping)
             else {}
         )
-        existing_todo_id = str(existing_details.get("todo_id") or "").strip()
+        existing_todo_id = normalize_todo_id(existing_details.get("todo_id"))
         existing_replan_obligation_id = normalize_todo_replan_obligation_id(
             existing_details.get("replan_obligation_id")
         )
@@ -89,7 +89,10 @@ def reconcile_existing_heartbeat_receipt(
             ):
                 raise HeartbeatReceiptIdentityConflictError(
                     "heartbeat receipt settlement identity conflicts with the "
-                    "current settlement binding"
+                    "current settlement binding: receipt="
+                    f"{existing_todo_id or existing_replan_obligation_id}, "
+                    "current="
+                    f"{rollout_todo_id or rollout_replan_obligation_id}"
                 )
         else:
             rollout_details = quota_rollout_details(

--- a/loopx/control_plane/quota/should_run.py
+++ b/loopx/control_plane/quota/should_run.py
@@ -149,6 +149,7 @@ def build_quota_should_run(
     ) = None,
     operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
     receipt_bound_todo_id: str | None = None,
+    receipt_bound_replan_obligation_id: str | None = None,
 ) -> dict[str, Any]:
     safe_goal_id = str(goal_id or "").strip()
     resolved_scheduler_context = resolve_scheduler_execution_context(
@@ -210,6 +211,7 @@ def build_quota_should_run(
             item=item,
             health_items=health_items,
             receipt_bound_todo_id=receipt_bound_todo_id,
+            receipt_bound_replan_obligation_id=receipt_bound_replan_obligation_id,
         )
         return _build_quota_should_run_payload(
             prepared,

--- a/loopx/control_plane/quota/should_run_packet.py
+++ b/loopx/control_plane/quota/should_run_packet.py
@@ -492,6 +492,7 @@ class _QuotaDecisionRoute:
     state: str
     quota: dict[str, Any]
     replan_decision_allowed: bool
+    receipt_bound_replan_decision: bool
     heartbeat_recommendation: dict[str, Any]
     external_evidence_observation: dict[str, Any] | None
     external_evidence_observation_recent: dict[str, Any] | None
@@ -549,6 +550,12 @@ def _resolve_quota_should_run_route(
     state = run_decision.state
     quota = run_decision.quota
     replan_decision_allowed = run_decision.replan_decision_allowed
+    receipt_bound_replan_decision = bool(
+        replan_decision_allowed
+        and isinstance(prepared.replan_obligation, Mapping)
+        and prepared.replan_obligation.get("selection_binding")
+        == "heartbeat_receipt"
+    )
     heartbeat_recommendation = build_heartbeat_recommendation(
         {**item, "quota": quota},
         goal_id=prepared.safe_goal_id,
@@ -692,6 +699,11 @@ def _resolve_quota_should_run_route(
                 )
             ),
         )
+    if receipt_bound_replan_decision:
+        # The replan obligation is the immutable settlement authority for this
+        # decision. A newly runnable Todo remains visible in summaries, but it
+        # cannot become the selected settlement target in the same packet.
+        agent_lane_next_action = None
     agent_scope_frontier = None
     agent_lane_frontier_hint = None
     if not replan_decision_allowed:
@@ -821,6 +833,7 @@ def _resolve_quota_should_run_route(
         state=state,
         quota=quota,
         replan_decision_allowed=replan_decision_allowed,
+        receipt_bound_replan_decision=receipt_bound_replan_decision,
         heartbeat_recommendation=heartbeat_recommendation,
         external_evidence_observation=external_evidence_observation,
         external_evidence_observation_recent=external_evidence_observation_recent,
@@ -984,13 +997,19 @@ def _build_quota_should_run_payload(
         payload,
         agent_lane_next_action=route.agent_lane_next_action,
     )
-    selected_todo_projection = _selected_todo_projection(
-        agent_lane_next_action=route.agent_lane_next_action,
-        work_lane_contract=route.payload_work_lane_contract,
-        agent_scope_frontier=route.agent_scope_frontier,
+    selected_todo_projection = (
+        None
+        if route.receipt_bound_replan_decision
+        else _selected_todo_projection(
+            agent_lane_next_action=route.agent_lane_next_action,
+            work_lane_contract=route.payload_work_lane_contract,
+            agent_scope_frontier=route.agent_scope_frontier,
+        )
     )
     if selected_todo_projection:
         payload["selected_todo"] = selected_todo_projection
+    elif route.receipt_bound_replan_decision:
+        payload["selected_todo"] = None
     _attach_truthy_fields(
         payload,
         agent_lane_frontier_hint=route.agent_lane_frontier_hint,

--- a/loopx/control_plane/quota/should_run_prepare.py
+++ b/loopx/control_plane/quota/should_run_prepare.py
@@ -30,6 +30,7 @@ from ..quota.goal_boundary import (
     effective_available_capabilities as _effective_available_capabilities,
     goal_boundary as _goal_boundary,
 )
+from ..quota.error_codes import HeartbeatReceiptIdentityConflictError
 from ..quota.policy_constants import (
     MONITOR_DUE_ITEM_LIMIT,
 )
@@ -63,6 +64,7 @@ from ..todos.contract import (
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_BLOCKER,
     normalize_todo_claimed_by,
+    normalize_todo_replan_obligation_id,
     normalize_todo_status,
 )
 from ..todos.projection import (
@@ -139,6 +141,29 @@ class _QuotaDecisionPreparation:
     codex_app_current_rrule: Any
     codex_app_automation_id: Any
     resolved_scheduler_context: SchedulerExecutionContextResolution
+
+
+def _preserve_receipt_bound_replan_obligation(
+    replan_obligation: Mapping[str, Any] | None,
+    receipt_bound_replan_obligation_id: str | None,
+) -> dict[str, Any] | None:
+    preserved_replan_id = normalize_todo_replan_obligation_id(
+        receipt_bound_replan_obligation_id
+    )
+    if not preserved_replan_id:
+        return dict(replan_obligation) if replan_obligation is not None else None
+    current_replan_id = normalize_todo_replan_obligation_id(
+        (replan_obligation or {}).get("obligation_id")
+    )
+    if current_replan_id != preserved_replan_id:
+        raise HeartbeatReceiptIdentityConflictError(
+            "heartbeat receipt settlement identity conflicts with the "
+            "current autonomous replan obligation"
+        )
+    preserved_replan_obligation = dict(replan_obligation or {})
+    preserved_replan_obligation["selection_binding"] = "heartbeat_receipt"
+    return preserved_replan_obligation
+
 
 def _same_todo_identity(left: dict[str, Any], right: dict[str, Any]) -> bool:
     left_id = str(left.get("todo_id") or "").strip()
@@ -369,6 +394,7 @@ def _prepare_quota_should_run_item(
     item: dict[str, Any],
     health_items: list[Any],
     receipt_bound_todo_id: str | None,
+    receipt_bound_replan_obligation_id: str | None,
 ) -> _QuotaDecisionPreparation:
     quota = item.get("quota") if isinstance(item.get("quota"), dict) else {}
     state = str(quota.get("state") or "unknown")
@@ -636,7 +662,10 @@ def _prepare_quota_should_run_item(
         goal_status=str(registry_goal.get("status") or ""),
         agent_profile=_quota_agent_profile(agent_identity),
     )
-    replan_obligation = goal_frontier_context.get("replan_obligation")
+    replan_obligation = _preserve_receipt_bound_replan_obligation(
+        goal_frontier_context.get("replan_obligation"),
+        receipt_bound_replan_obligation_id
+    )
     replan_scope = goal_frontier_context.get("replan_scope") or {}
     goal_frontier_projection = (
         goal_frontier_context.get("goal_frontier_projection")

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -798,6 +798,7 @@ def build_quota_should_run(
     ) = None,
     operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
     receipt_bound_todo_id: str | None = None,
+    receipt_bound_replan_obligation_id: str | None = None,
 ) -> dict[str, Any]:
     from .control_plane.quota.should_run import (
         build_quota_should_run as _build_quota_should_run,
@@ -814,6 +815,7 @@ def build_quota_should_run(
         scheduler_execution_context=scheduler_execution_context,
         operator_inbox_urgency_projector=operator_inbox_urgency_projector,
         receipt_bound_todo_id=receipt_bound_todo_id,
+        receipt_bound_replan_obligation_id=receipt_bound_replan_obligation_id,
     )
 
 

--- a/tests/control_plane/test_quota_settlement.py
+++ b/tests/control_plane/test_quota_settlement.py
@@ -16,6 +16,7 @@ from loopx.control_plane.effect_program import (
 )
 from loopx.control_plane.quota import effect_program as quota_effect_program
 from loopx.control_plane.quota.heartbeat_receipt import (
+    heartbeat_receipt_settlement_replan_obligation_id,
     heartbeat_receipt_settlement_todo_id,
 )
 from loopx.control_plane.quota.settlement import (
@@ -73,14 +74,16 @@ def test_settlement_identity_rejects_dual_binding_before_projection() -> None:
 
 
 def test_replan_bound_heartbeat_receipt_is_not_projected_as_a_todo() -> None:
+    obligation_id = "replan-0000000000000001"
     event = {
         "goal_id": GOAL_ID,
         "agent_id": AGENT_ID,
         "run_id": TURN_ID,
-        "details": {"replan_obligation_id": "replan-0000000000000001"},
+        "details": {"replan_obligation_id": obligation_id},
     }
 
     assert heartbeat_receipt_settlement_todo_id(event) is None
+    assert heartbeat_receipt_settlement_replan_obligation_id(event) == obligation_id
 
 
 def test_selected_todo_suppresses_stale_replan_packet_binding() -> None:

--- a/tests/control_plane/test_quota_settlement_cli.py
+++ b/tests/control_plane/test_quota_settlement_cli.py
@@ -795,6 +795,72 @@ def test_runtime_capability_reentry_preserves_receipt_bound_todo_and_rejects_exp
     assert _heartbeat_receipt_count(runtime, TURN_ID) == 1
 
 
+def test_runtime_capability_reentry_preserves_receipt_bound_autonomous_replan(
+    tmp_path: Path,
+) -> None:
+    project, runtime, registry_path = _write_fixture(tmp_path)
+    _configure_autonomous_replan_fixture(project, runtime, registry_path)
+    _configure_runtime_capability_reentry_fixture(project)
+    turn_instance_id = "turn-autonomous-replan-capability-reentry"
+    guard_args = (
+        "quota",
+        "should-run",
+        "--codex-app",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--turn-instance-id",
+        turn_instance_id,
+        "--scan-path",
+        str(project),
+    )
+
+    first_rc, first = _run_cli(registry_path, runtime, *guard_args)
+    replay_rc, replay = _run_cli(
+        registry_path,
+        runtime,
+        *guard_args,
+        "--available-capability",
+        "network",
+    )
+
+    assert first_rc == 0, first
+    assert first["decision"] == "autonomous_replan_required", first
+    obligation_id = first["replan_action_packet"]["obligation_id"]
+    assert first["heartbeat_receipt"]["settlement_identity"][
+        "replan_obligation_id"
+    ] == obligation_id
+    assert replay_rc == 0, replay
+    assert replay["decision"] == "autonomous_replan_required", replay
+    assert replay["selected_todo"] is None
+    assert replay["autonomous_replan_obligation"]["selection_binding"] == (
+        "heartbeat_receipt"
+    )
+    assert replay["replan_action_packet"]["obligation_id"] == obligation_id
+    assert replay["heartbeat_receipt"]["status"] == "replayed"
+    assert replay["heartbeat_receipt"]["settlement_identity"][
+        "replan_obligation_id"
+    ] == obligation_id
+    assert replay["interaction_contract"]["cli_channel"]["settlement_plan"][
+        "identity"
+    ]["replan_obligation_id"] == obligation_id
+    assert _heartbeat_receipt_count(runtime, turn_instance_id) == 1
+
+    conflict_rc, conflict = _run_cli(
+        registry_path,
+        runtime,
+        *guard_args,
+        "--available-capability",
+        "network",
+        "--todo-id",
+        REENTRY_TODO_ID,
+    )
+
+    assert conflict_rc == 1, conflict
+    assert conflict["error_code"] == "heartbeat_receipt_identity_conflict"
+    assert _heartbeat_receipt_count(runtime, turn_instance_id) == 1
+
 def test_peer_refresh_rejects_implicit_canonical_workspace_before_writeback(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- preserve the immutable autonomous-replan settlement identity when the same heartbeat turn is replayed with newly available capabilities
- prevent a newly runnable Todo from replacing that receipt-bound replan target
- fail closed when the current replan obligation no longer matches the receipt
- keep ordinary autonomous-replan Todo lineage unchanged

## Validation

- 31 passed: quota settlement and CLI suite
- Ruff passed on all 10 changed Python paths
- git diff checks and public/private boundary scan passed
- CLI output budget regression smoke passed in isolation
- change-quality receipt: cqr_6bf2c1217affbba2669d
- full standard premerge gate passed with 17 checks, zero failures, zero manual holds, and self_merge_allowed=true

## Validation note

The default premerge CLI aggregation intermittently reported the CLI output budget smoke as failed after it had passed in isolation. Re-running the same full gate serially through the premerge API with a 180-second per-check budget passed all catalog and risk-profile checks. Remote CI remains required before merge.

## Why coverage is sufficient

The focused suite covers both Todo-bound and autonomous-replan-bound receipt replay, capability re-entry, explicit identity conflict rejection, and single-receipt idempotency. The catalog/risk gate additionally covers quota scheduler routing, ACK behavior, monitor contracts, interface budgets, maintainability, Turn output lineage, and public-boundary safety.