### PR TITLE
fix(benchmark): ignore heredoc payloads in credential audit

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/environment_access.py
+++ b/loopx/capabilities/benchmark_toolkit/environment_access.py
@@ -238,6 +238,7 @@ def _command_strings(function_name: str, raw_arguments: object) -> tuple[str, ..
 
 
 def _shell_segments(command: str) -> tuple[tuple[str, ...], ...]:
+    command = _without_shell_heredoc_bodies(command)
     try:
         lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|\n")
         lexer.whitespace = " \t\r"
@@ -258,6 +259,67 @@ def _shell_segments(command: str) -> tuple[tuple[str, ...], ...]:
     if current:
         segments.append(tuple(current))
     return tuple(segments)
+
+
+def _heredoc_delimiters(command_line: str) -> tuple[tuple[str, bool], ...]:
+    """Return quoted-normalized heredoc delimiters declared by one shell line."""
+
+    try:
+        lexer = shlex.shlex(command_line, posix=True, punctuation_chars=";&|\n<>")
+        lexer.whitespace = " \t\r"
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        tokens = list(lexer)
+    except ValueError:
+        return ()
+
+    delimiters: list[tuple[str, bool]] = []
+    index = 0
+    while index < len(tokens):
+        if tokens[index] != "<<":
+            index += 1
+            continue
+        index += 1
+        strip_tabs = index < len(tokens) and tokens[index] == "-"
+        if strip_tabs:
+            index += 1
+        if index >= len(tokens):
+            break
+        delimiter = tokens[index]
+        if not strip_tabs and delimiter.startswith("-") and len(delimiter) > 1:
+            # ``shlex`` returns ``-EOF`` for the ordinary ``<<-EOF`` spelling.
+            strip_tabs = True
+            delimiter = delimiter[1:]
+        if delimiter and all(character not in ";&|\n<>" for character in delimiter):
+            delimiters.append((delimiter, strip_tabs))
+        index += 1
+    return tuple(delimiters)
+
+
+def _without_shell_heredoc_bodies(command: str) -> str:
+    """Exclude stdin payloads from shell-command classification.
+
+    Patch and file-generation tools commonly receive source text through a
+    heredoc.  That payload is data, not a sequence of shell commands, so a
+    source line such as ``env := value`` must not be classified as an executed
+    ``env`` credential probe.  Command lines before and after the payload stay
+    visible to the classifier.
+    """
+
+    visible_lines: list[str] = []
+    pending: list[tuple[str, bool]] = []
+    for raw_line in command.splitlines(keepends=True):
+        if pending:
+            delimiter, strip_tabs = pending[0]
+            candidate = raw_line.rstrip("\r\n")
+            if strip_tabs:
+                candidate = candidate.lstrip("\t")
+            if candidate == delimiter:
+                pending.pop(0)
+            continue
+        visible_lines.append(raw_line)
+        pending.extend(_heredoc_delimiters(raw_line))
+    return "".join(visible_lines)
 
 
 def _shell_executable(tokens: tuple[str, ...]) -> tuple[str, tuple[str, ...]]:

--- a/tests/capabilities/test_benchmark_toolkit.py
+++ b/tests/capabilities/test_benchmark_toolkit.py
@@ -344,6 +344,19 @@ def test_bare_sensitive_filename_does_not_match_unrelated_path_basename() -> Non
         ("cmd", "/usr/bin/env", True),
         ("cmd", "/usr/bin/printenv API_KEY", True),
         ("cmd", "cat /proc/self/environ", True),
+        (
+            "cmd",
+            (
+                "tool --apply-patch <<'PATCH'\n"
+                "*** Begin Patch\n"
+                "+\tenv := moduleTestEnv(t)\n"
+                "*** End Patch\n"
+                "PATCH\n"
+            ),
+            False,
+        ),
+        ("cmd", "cat <<EOF\nenv\nEOF", False),
+        ("cmd", "cat <<-EOF\n\tenv\n\tEOF\nenv", True),
         ("cmd", "grep -R 'os.getenv(\"API_KEY\")' src", False),
         ("cmd", "rg 'os.environ.copy\\(\\)' src", False),
         ("cmd", "grep -R 'printenv API_KEY' src", False),


### PR DESCRIPTION
## Summary

- exclude shell heredoc bodies from credential-probe command classification
- keep command lines before and after heredocs visible to the audit
- cover quoted delimiters, tab-stripping heredocs, and post-heredoc commands

## Motivation

Patch and file-generation commands commonly carry source code as heredoc data. A source line beginning with `env` is not an executed shell `env` command and must not invalidate an otherwise clean benchmark trajectory.

## Validation

- `pytest -q tests/capabilities/test_benchmark_toolkit.py` (50 passed)
- `python -m ruff check loopx/capabilities/benchmark_toolkit/environment_access.py tests/capabilities/test_benchmark_toolkit.py`
- `python -m compileall -q loopx/capabilities/benchmark_toolkit/environment_access.py`
- `git diff --check`
- replayed the triggering private trajectory locally; qualification changes from one false `credential_probe` blocker to a clean integrity result without recording private content