### PR TITLE
fix(quota): restore settlement identity recovery seam

### DIFF
--- a/docs/development/bugs/settlement-infer-persisted-break.md
+++ b/docs/development/bugs/settlement-infer-persisted-break.md
@@ -1,0 +1,28 @@
+# `infer_persisted_heartbeat_settlement_identity` 恢复边界不变量
+
+**状态**：已锁定（PR #3360，fail-closed 边界显式化 + 语义测试）。
+
+## 不变量
+
+结算身份恢复缝只跳过**显式 typed、quota-neutral** 的 run（`quota_slot_voided` /
+`quota_scheduler_ack` / 无 `material_change` 的 `quota_monitor_poll` / 非 accountable
+的 `state_refreshed`），并取最近一次同 agent 的 `quota_slot_spent` 或 accountable
+delivery outcome 作为候选。
+
+任何**未知或不完整**的同 agent 非中性记录都不是可穿透的「中性」记录：它构成恢复边界，
+函数在该处 fail-closed（返回 `None`，回退到 frontier 规则），绝不跨越它去恢复更旧的
+settlement identity。这与 `slot_accounting._latest_unspent_accountable_delivery_run`
+及 `test_custom_non_neutral_event_still_fails_closed` 的语义一致。
+
+## 说明
+
+原实现用循环体级的无条件 `break` 隐式表达这条 fail-closed 边界，容易被误读为
+「未知记录应当穿透」。本次改动把 `break` 收进 candidate 分支，并在其后显式
+`return None`；行为保持不变，仅把边界显式化。
+
+## 验证
+
+- `test_typed_material_poll_is_recovered_not_shadowed`：生产端忠实（`material_change=true`
+  且 `delivery_outcome=outcome_progress`）的 material poll 被正确恢复，不被更旧的 spend 遮蔽。
+- `test_unknown_non_neutral_record_fails_closed`：旧 spend 之后追加缺 `delivery_outcome`
+  的不完整 poll，断言恢复 fail-closed（返回 `None`），不穿透到旧身份。

--- a/loopx/control_plane/quota/settlement.py
+++ b/loopx/control_plane/quota/settlement.py
@@ -265,7 +265,8 @@ def infer_persisted_heartbeat_settlement_identity(
             or delivery_outcome in ACCOUNTABLE_DELIVERY_OUTCOMES
         ):
             candidate = run
-        break
+            break
+        return None
 
     if candidate is None:
         return None

--- a/tests/control_plane/test_quota_settlement.py
+++ b/tests/control_plane/test_quota_settlement.py
@@ -21,6 +21,7 @@ from loopx.control_plane.quota.heartbeat_receipt import (
 )
 from loopx.control_plane.quota.settlement import (
     build_codex_app_settlement_plan,
+    infer_persisted_heartbeat_settlement_identity,
     require_settlement_terminal_closeout,
     resolve_heartbeat_settlement_identity,
     settlement_step_command,
@@ -166,6 +167,13 @@ def _append_guard_receipt(
         + "\n",
         encoding="utf-8",
     )
+
+
+def _append_run_index_record(runtime_root: Path, record: dict) -> None:
+    path = runtime_root / "goals" / GOAL_ID / "runs" / "index.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record) + "\n")
 
 
 def test_terminal_closeout_receipt_rejects_ordinary_completion_event(
@@ -458,3 +466,68 @@ def test_guard_receipt_returns_typed_failure_for_effect_without_todo(
     assert result.failure is not None
     assert result.failure.kind is SettlementFailureKind.IDENTITY_MISMATCH
     assert "effect identity without a Todo" in result.failure.reason
+
+
+def test_typed_material_poll_is_recovered_not_shadowed(tmp_path: Path) -> None:
+    _append_guard_receipt(tmp_path)
+    _append_run_index_record(
+        tmp_path,
+        {
+            "classification": "quota_slot_spent",
+            "agent_id": AGENT_ID,
+            "todo_id": TODO_ID,
+            "turn_instance_id": "turn-settlement-stale",
+        },
+    )
+    _append_run_index_record(
+        tmp_path,
+        {
+            "classification": "quota_monitor_poll",
+            "material_change": True,
+            "delivery_outcome": "outcome_progress",
+            "agent_id": AGENT_ID,
+            "todo_id": TODO_ID,
+            "turn_instance_id": TURN_ID,
+        },
+    )
+
+    result = infer_persisted_heartbeat_settlement_identity(
+        tmp_path,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        todo_id=TODO_ID,
+    )
+
+    assert result is not None
+    assert result.value is not None
+    assert result.value.turn_instance_id == TURN_ID
+
+
+def test_unknown_non_neutral_record_fails_closed(tmp_path: Path) -> None:
+    _append_guard_receipt(tmp_path)
+    _append_run_index_record(
+        tmp_path,
+        {
+            "classification": "quota_slot_spent",
+            "agent_id": AGENT_ID,
+            "todo_id": TODO_ID,
+            "turn_instance_id": TURN_ID,
+        },
+    )
+    _append_run_index_record(
+        tmp_path,
+        {
+            "classification": "quota_monitor_poll",
+            "material_change": True,
+            "agent_id": AGENT_ID,
+        },
+    )
+
+    result = infer_persisted_heartbeat_settlement_identity(
+        tmp_path,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        todo_id=TODO_ID,
+    )
+
+    assert result is None


### PR DESCRIPTION
infer_persisted_heartbeat_settlement_identity placed its break at the for-body indentation instead of inside the accountable candidate branch. Any run that survived the continue guards but was not a quota_slot_spent or accountable delivery outcome exited the loop immediately, returning None before reaching an earlier valid spend or writeback.

Move break inside the candidate branch so non-matching runs fall through to the next iteration, and lock the recovery with a red->green regression test.

## Summary

-

## Issue Or Task

- Closes #
- Contributor task ID:

## Validation

- [ ] `python3 -m py_compile loopx/*.py`
- [ ] `loopx check --scan-root .`
- [ ] Other:

## Type of Change

<!-- Mark the applicable options. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Test update

## LoopX Area

<!-- Mark the primary area. Maintainers apply the matching GitHub label. -->

- [ ] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [ ] Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
- [ ] Capability or extension (providers, adapters, skills)
- [ ] Public docs or presentation surface (README, protocols, dashboard)
- [ ] Build, packaging, installer, or CI
- [ ] Host or runtime integration

## Technical Direction

<!-- Select one. Direction labels route review; they do not imply maturity or merge authority. -->

- [ ] Core control-plane hardening
- [ ] Long-horizon benchmark evidence
- [ ] Operator surface and IM integration
- [ ] Shared Goal Authority and cross-host coordination
- [ ] Architecture and research incubator

- Target base branch:
- Direction tracker or promotion unit:

## Boundary Checklist

- [ ] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [ ] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [ ] I kept the change scoped to the linked issue/task.
- [ ] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).
