### PR TITLE
chore(governance): route frontend reviews to maxliu

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,10 @@
 /CONTRIBUTOR_TASKS.md @huangruiteng
 /docs/project/technical-directions*.md @huangruiteng
 
+# Frontend source and bundled web assets.
+/apps/presentation/dashboard/** @huangruiteng @maxliu
+/loopx/web/chat/** @huangruiteng @maxliu
+
 # Lark integration review routing.
 /loopx/extensions/lark/** @huangruiteng @steven-kid
 /loopx/cli_commands/lark_*.py @huangruiteng @steven-kid


### PR DESCRIPTION
## Summary

- route dashboard frontend source reviews to `@huangruiteng` and `@maxliu`
- route bundled chat web assets through the same reviewer pair
- keep repository governance and all non-frontend ownership unchanged

## Validation

- parsed every active CODEOWNERS row for a path plus valid owner tokens
- `git diff --check`
- credential/private-path scan of `.github/CODEOWNERS`

## Coordination note

`@maxliu` has been invited with repository `write` permission. GitHub will recognize the new CODEOWNER and allow formal review requests after that invitation is accepted.

No local/private artifacts, generated logs, credentials, or unrelated work are included.
