### PR TITLE
fix(goal): project terminal Todo settlement actions

### DIFF
--- a/loopx/control_plane/goals/goal_frontier/__init__.py
+++ b/loopx/control_plane/goals/goal_frontier/__init__.py
@@ -23,6 +23,7 @@ from ...work_items.autonomous_replan_ack import (
 )
 from ...work_items.autonomous_replan_obligation import (
     MONITOR_NO_CHANGE_STREAK_THRESHOLD,
+    TODO_LIFECYCLE_SETTLEMENT_RESOLUTION_MODE,
     build_autonomous_replan_obligation_payload,
     ensure_replan_novelty_policy,
     with_replan_novelty_guidance,
@@ -1252,7 +1253,7 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                 "do not invent a user gate or add a lifecycle-only filler Todo"
             ),
             extra_fields={
-                "resolution_mode": "todo_lifecycle_settlement",
+                "resolution_mode": TODO_LIFECYCLE_SETTLEMENT_RESOLUTION_MODE,
                 "satisfying_semantic_outcomes": ["new_runnable_successor"],
             },
         )

--- a/loopx/control_plane/goals/goal_frontier/__init__.py
+++ b/loopx/control_plane/goals/goal_frontier/__init__.py
@@ -1187,6 +1187,13 @@ def derive_goal_frontier_replan_obligation_from_summaries(
     if not replan_rule.derives_obligation:
         return None
     if replan_rule.rule is GoalFrontierReplanRule.TODO_SUCCESSION_GAP:
+        settlement_items = succession_gap_items[:3]
+        settlement_todo_ids = [
+            str(item.get("todo_id") or "").strip()
+            for item in settlement_items
+            if str(item.get("todo_id") or "").strip()
+        ]
+        settlement_summary = ", ".join(settlement_todo_ids)
         triggers = [
             {
                 "kind": TODO_SUCCESSION_GAP_TRIGGER,
@@ -1197,8 +1204,9 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                 or "completed advancement needs a successor or no-followup rationale",
                 "agent_id": agent_id,
                 "claimed_by": item.get("claimed_by"),
+                "completion_turn_key": item.get("completion_turn_key"),
             }
-            for item in succession_gap_items[:3]
+            for item in settlement_items
         ]
         return build_autonomous_replan_obligation_payload(
             schema_version=AUTONOMOUS_REPLAN_OBLIGATION_SCHEMA_VERSION,
@@ -1208,33 +1216,43 @@ def derive_goal_frontier_replan_obligation_from_summaries(
             trigger_count=len(succession_gap_items),
             triggers=triggers,
             guidance_actions=[
-                "create_successor",
-                "link_successor",
                 "record_no_followup",
+                "link_successor",
+                "create_successor",
             ],
             todo_actions=[
+                {
+                    "action": "settle",
+                    "role": "agent",
+                    "priority": "P0",
+                    "todo_ids": settlement_todo_ids,
+                    "text": (
+                        "settle the exact completed Todos through no-follow-up or "
+                        "link each to a real runnable successor"
+                    ),
+                },
                 {
                     "action": "add",
                     "role": "agent",
                     "priority": "P0",
                     "text": (
-                        "run a bounded successor replan: create or link the next "
-                        "runnable advancement Todo, or settle the completed Todo "
-                        "through loopx todo complete --no-follow-up; do not invent "
-                        "a user gate"
+                        "create a typed runnable successor only when concrete "
+                        "technical or validation work remains"
                     ),
-                }
+                },
             ],
             stop_condition=(
                 "stop if the successor decision requires private material, "
                 "credentials, destructive git, production actions, or owner-only decisions"
             ),
             recommended_action=(
-                "before another quiet poll, add/link the next advancement Todo or "
-                "settle the completed Todo through loopx todo complete "
-                "--no-follow-up; do not invent a user gate"
+                "settle the exact completed Todo(s) "
+                f"{settlement_summary} through loopx todo complete --no-follow-up "
+                "when no real work remains; otherwise link a real runnable successor. "
+                "do not invent a user gate or add a lifecycle-only filler Todo"
             ),
             extra_fields={
+                "resolution_mode": "todo_lifecycle_settlement",
                 "satisfying_semantic_outcomes": ["new_runnable_successor"],
             },
         )

--- a/loopx/control_plane/todos/succession_warning.py
+++ b/loopx/control_plane/todos/succession_warning.py
@@ -97,6 +97,7 @@ def _compact_succession_warning_item(item: dict[str, Any]) -> dict[str, Any]:
         "route_id",
         "route_key",
         "completed_at",
+        "completion_turn_key",
         "updated_at",
         "superseded_by",
         "done",

--- a/loopx/control_plane/work_items/autonomous_replan_obligation.py
+++ b/loopx/control_plane/work_items/autonomous_replan_obligation.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Mapping
-from typing import Any, Callable, Optional
+import shlex
+from collections.abc import Callable, Mapping
+from typing import Any
 
 from ..runtime.time import parse_timestamp
 from ..todos.contract import (
@@ -19,7 +20,7 @@ from ..todos.deferred_resume import (
 from .progress_observation import typed_progress_repeat_trigger
 
 
-PublicSafeText = Callable[..., Optional[str]]
+PublicSafeText = Callable[..., str | None]
 AckRecorded = Callable[[dict[str, Any]], bool]
 
 
@@ -66,7 +67,54 @@ def build_autonomous_replan_cli_actions(
     scoped_cli_args: str,
     quota_spend_action: str,
     replan_settlement_bound: bool,
+    lifecycle_actor_args: str = "",
 ) -> list[str]:
+    obligation = (
+        payload.get("autonomous_replan_obligation")
+        if isinstance(payload.get("autonomous_replan_obligation"), Mapping)
+        else payload
+    )
+    if obligation.get("resolution_mode") == "todo_lifecycle_settlement":
+        triggers = [
+            item
+            for item in obligation.get("triggers") or []
+            if isinstance(item, Mapping)
+            and item.get("kind") == "completed_advancement_without_successor"
+            and normalize_todo_id(item.get("todo_id"))
+        ]
+        actions: list[str] = []
+        for trigger in triggers[:3]:
+            todo_id = normalize_todo_id(trigger.get("todo_id"))
+            if todo_id is None:
+                continue
+            completion_turn_key = str(
+                trigger.get("completion_turn_key") or ""
+            ).strip()
+            completion_turn_arg = (
+                f" --turn-instance-id {shlex.quote(completion_turn_key)}"
+                if completion_turn_key
+                else ""
+            )
+            actions.append(
+                "when no real successor remains for completed Todo "
+                f"{todo_id}: loopx todo complete --goal-id {goal_id} "
+                f"--todo-id {todo_id}{completion_turn_arg}{lifecycle_actor_args} "
+                "--no-follow-up --note '<public-safe no-follow-up rationale>' "
+                "--execute"
+            )
+        actions.extend(
+            [
+                (
+                    "otherwise link or create one real runnable successor for the "
+                    "exact completed Todo; do not create lifecycle-only filler"
+                ),
+                (
+                    f"loopx --format json quota should-run --goal-id {goal_id}"
+                    f"{scoped_cli_args}"
+                ),
+            ]
+        )
+        return actions
     packet = (
         payload.get("replan_action_packet")
         if isinstance(payload.get("replan_action_packet"), Mapping)
@@ -117,10 +165,20 @@ def ensure_replan_novelty_policy(
     """Upgrade any legacy obligation onto the policy-owned evidence path."""
 
     normalized = dict(obligation)
-    normalized["recommended_action"] = with_replan_novelty_guidance(
-        str(normalized.get("recommended_action") or "run a bounded autonomous replan")
-    )
-    normalized["replan_novelty_policy"] = build_replan_novelty_policy()
+    if normalized.get("resolution_mode") == "todo_lifecycle_settlement":
+        normalized["recommended_action"] = str(
+            normalized.get("recommended_action")
+            or "settle the exact completed Todo lifecycle"
+        ).strip()
+        normalized["replan_novelty_policy"] = {
+            **build_replan_novelty_policy(),
+            "writeback": "todo_lifecycle_or_typed_successor",
+        }
+    else:
+        normalized["recommended_action"] = with_replan_novelty_guidance(
+            str(normalized.get("recommended_action") or "run a bounded autonomous replan")
+        )
+        normalized["replan_novelty_policy"] = build_replan_novelty_policy()
     trigger_identity = [
         {
             key: trigger.get(key)

--- a/loopx/control_plane/work_items/autonomous_replan_obligation.py
+++ b/loopx/control_plane/work_items/autonomous_replan_obligation.py
@@ -27,6 +27,7 @@ AckRecorded = Callable[[dict[str, Any]], bool]
 MAX_AUTONOMOUS_REPLAN_TRIGGERS = 3
 AUTONOMOUS_REPLAN_STALL_THRESHOLD = 2
 REPLAN_NOVELTY_POLICY_SCHEMA_VERSION = "replan_evidence_delivery_policy_v0"
+TODO_LIFECYCLE_SETTLEMENT_RESOLUTION_MODE = "todo_lifecycle_settlement"
 REPLAN_NOVELTY_GUIDANCE = (
     " Use the host-projected coverage ledger and produce a typed semantic delta; "
     "repeated observations cannot close replan."
@@ -59,6 +60,21 @@ def replan_obligation_id_from_packet(value: Any) -> str | None:
     return normalize_todo_replan_obligation_id(packet.get("obligation_id"))
 
 
+def todo_lifecycle_settlement_obligation(
+    value: Mapping[str, Any],
+) -> Mapping[str, Any] | None:
+    """Return the lifecycle-settlement subtype from a status payload or obligation."""
+
+    obligation = (
+        value.get("autonomous_replan_obligation")
+        if isinstance(value.get("autonomous_replan_obligation"), Mapping)
+        else value
+    )
+    if obligation.get("resolution_mode") != TODO_LIFECYCLE_SETTLEMENT_RESOLUTION_MODE:
+        return None
+    return obligation
+
+
 def build_autonomous_replan_cli_actions(
     payload: Mapping[str, Any],
     *,
@@ -69,12 +85,8 @@ def build_autonomous_replan_cli_actions(
     replan_settlement_bound: bool,
     lifecycle_actor_args: str = "",
 ) -> list[str]:
-    obligation = (
-        payload.get("autonomous_replan_obligation")
-        if isinstance(payload.get("autonomous_replan_obligation"), Mapping)
-        else payload
-    )
-    if obligation.get("resolution_mode") == "todo_lifecycle_settlement":
+    obligation = todo_lifecycle_settlement_obligation(payload)
+    if obligation is not None:
         triggers = [
             item
             for item in obligation.get("triggers") or []
@@ -99,8 +111,7 @@ def build_autonomous_replan_cli_actions(
                 "when no real successor remains for completed Todo "
                 f"{todo_id}: loopx todo complete --goal-id {goal_id} "
                 f"--todo-id {todo_id}{completion_turn_arg}{lifecycle_actor_args} "
-                "--no-follow-up --note '<public-safe no-follow-up rationale>' "
-                "--execute"
+                "--no-follow-up --note '<public-safe no-follow-up rationale>'"
             )
         actions.extend(
             [
@@ -165,7 +176,10 @@ def ensure_replan_novelty_policy(
     """Upgrade any legacy obligation onto the policy-owned evidence path."""
 
     normalized = dict(obligation)
-    if normalized.get("resolution_mode") == "todo_lifecycle_settlement":
+    if (
+        normalized.get("resolution_mode")
+        == TODO_LIFECYCLE_SETTLEMENT_RESOLUTION_MODE
+    ):
         normalized["recommended_action"] = str(
             normalized.get("recommended_action")
             or "settle the exact completed Todo lifecycle"

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -949,6 +949,7 @@ def interaction_next_cli_actions(
             replan_settlement_bound=bool(
                 settlement_identity.get("replan_obligation_id")
             ),
+            lifecycle_actor_args=lifecycle_actor_args,
         )
     return _terminal_cli_actions(
         mode=mode,

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -32,6 +32,7 @@ from ..todos.write_hint import build_capability_resolution_writeback_actions
 from .autonomous_replan_obligation import (
     build_autonomous_replan_cli_actions,
     replan_obligation_id_from_packet,
+    todo_lifecycle_settlement_obligation,
 )
 from .primary_action import (
     build_primary_action_projection,
@@ -1010,6 +1011,8 @@ def _interaction_spend_policy(
             "no spend or advancement checkpoint for capability verification; rerun "
             "quota in the same turn"
         )
+    if mode == "autonomous_replan" and not spend_after_validation:
+        return "no spend for Todo lifecycle settlement; rerun quota after the transition"
     if mode == "autonomous_replan":
         return (
             "spend only after accountable replan delta; no spend for "
@@ -1469,7 +1472,10 @@ def build_interaction_contract(
         user_required=user_required,
         must_attempt=must_attempt,
     )
-    spend_after_validation = _interaction_spend_after_validation(mode)
+    spend_after_validation = (
+        _interaction_spend_after_validation(mode)
+        and todo_lifecycle_settlement_obligation(payload) is None
+    )
     required_reads = _interaction_required_reads(payload)
     capability_reentry = build_runtime_capability_reentry_packet(
         payload,

--- a/loopx/control_plane/work_items/primary_action.py
+++ b/loopx/control_plane/work_items/primary_action.py
@@ -8,6 +8,7 @@ from ..agents.agent_scope_frontier import (
 )
 from ..todos.contract import TODO_TASK_CLASS_ADVANCEMENT
 from ..todos.projection import todo_item_is_actionable_open, todo_item_task_class
+from .autonomous_replan_obligation import todo_lifecycle_settlement_obligation
 
 
 def protocol_action_text(value: Any, *, limit: int = 220) -> str | None:
@@ -223,6 +224,15 @@ def resolve_canonical_primary_action(payload: dict[str, Any], *, mode: str) -> s
             "write a compact blocker when it is absent"
         )
     if mode == "autonomous_replan":
+        lifecycle_settlement = todo_lifecycle_settlement_obligation(payload)
+        if lifecycle_settlement is not None:
+            return protocol_action_text(
+                lifecycle_settlement.get("recommended_action"),
+                limit=360,
+            ) or (
+                "settle the exact completed Todo lifecycle or link a real runnable "
+                "successor; do not create lifecycle-only filler"
+            )
         return protocol_replan_action_packet_instruction(payload)
     if mode == "monitor_quiet_skip":
         return (

--- a/tests/control_plane/test_goal_frontier_replan_rules.py
+++ b/tests/control_plane/test_goal_frontier_replan_rules.py
@@ -19,6 +19,7 @@ from loopx.control_plane.goals.goal_frontier.replan_rules import (
 from loopx.control_plane.todos.addition import require_replan_successor_scope
 from loopx.control_plane.todos.summary_item import compact_todo_summary_item
 from loopx.control_plane.work_items.interaction_contract import (
+    build_interaction_contract,
     interaction_next_cli_actions,
 )
 
@@ -266,6 +267,52 @@ def test_todo_succession_gap_cli_actions_do_not_require_semantic_refresh() -> No
         "loopx --format json quota should-run --goal-id goal-example "
         "--agent-id current-agent --available-capability shell"
     )
+
+
+def test_todo_succession_gap_interaction_contract_is_model_actionable() -> None:
+    contract = build_interaction_contract(
+        {
+            "goal_id": "goal-example",
+            "agent_identity": {"agent_id": "current-agent"},
+            "execution_obligation": {
+                "kind": "autonomous_replan_required",
+                "must_attempt_work": True,
+                "delivery_allowed": True,
+            },
+            "autonomous_replan_obligation": {
+                "resolution_mode": "todo_lifecycle_settlement",
+                "recommended_action": (
+                    "settle the exact completed Todo(s) todo_111111111111 through "
+                    "loopx todo complete --no-follow-up when no real work remains; "
+                    "otherwise link a real runnable successor"
+                ),
+                "triggers": [
+                    {
+                        "kind": "completed_advancement_without_successor",
+                        "todo_id": "todo_111111111111",
+                        "completion_turn_key": "turn-implement",
+                    }
+                ],
+            },
+        },
+        available_capabilities=["shell"],
+    )
+
+    assert contract["mode"] == "autonomous_replan"
+    assert "todo_111111111111" in contract["agent_channel"]["primary_action"]
+    assert "produce one typed outcome" not in contract["agent_channel"][
+        "primary_action"
+    ]
+    assert contract["cli_channel"]["spend_after_validation"] is False
+    assert contract["cli_channel"]["spend_policy"] == (
+        "no spend for Todo lifecycle settlement; rerun quota after the transition"
+    )
+    assert "settlement_plan" not in contract["cli_channel"]
+    actions = contract["cli_channel"]["next_cli_actions"]
+    assert "--todo-id todo_111111111111" in actions[0]
+    assert "--turn-instance-id turn-implement" in actions[0]
+    assert all("refresh-state" not in action for action in actions)
+    assert all("spend-slot" not in action for action in actions)
 
 
 @pytest.mark.parametrize("other_agent_count", [1, 2, 8])

--- a/tests/control_plane/test_goal_frontier_replan_rules.py
+++ b/tests/control_plane/test_goal_frontier_replan_rules.py
@@ -18,6 +18,9 @@ from loopx.control_plane.goals.goal_frontier.replan_rules import (
 )
 from loopx.control_plane.todos.addition import require_replan_successor_scope
 from loopx.control_plane.todos.summary_item import compact_todo_summary_item
+from loopx.control_plane.work_items.interaction_contract import (
+    interaction_next_cli_actions,
+)
 
 
 @pytest.mark.parametrize(
@@ -165,6 +168,104 @@ def _advancement(todo_id: str, claimed_by: str) -> dict[str, object]:
         "task_class": "advancement_task",
         "claimed_by": claimed_by,
     }
+
+
+def test_todo_succession_gap_prefers_exact_lifecycle_settlement() -> None:
+    completed_items = [
+        {
+            "todo_id": "todo_111111111111",
+            "text": "Implement the bounded feature.",
+            "status": "done",
+            "task_class": "advancement_task",
+            "claimed_by": "current-agent",
+            "completion_turn_key": "turn-implement",
+        },
+        {
+            "todo_id": "todo_222222222222",
+            "text": "Validate the bounded feature.",
+            "status": "done",
+            "task_class": "advancement_task",
+            "claimed_by": "current-agent",
+            "completion_turn_key": "turn-validate",
+        },
+    ]
+    obligation = derive_goal_frontier_replan_obligation_from_summaries(
+        user_todo_summary={"open_count": 0},
+        agent_todo_summary={
+            "open_count": 0,
+            "current_agent_claimed_advancement_count": 0,
+            "todo_succession_warning": {
+                "reason_code": "completed_advancement_without_successor",
+                "count": len(completed_items),
+                "items": completed_items,
+            },
+        },
+        work_lane_contract=None,
+        agent_id="current-agent",
+        existing_replan_obligation=None,
+        acceptance_gaps=[],
+    )
+
+    assert obligation is not None
+    assert obligation["resolution_mode"] == "todo_lifecycle_settlement"
+    assert obligation["guidance_actions"][0] == "record_no_followup"
+    assert obligation["todo_actions"][0] == {
+        "action": "settle",
+        "role": "agent",
+        "priority": "P0",
+        "todo_ids": ["todo_111111111111", "todo_222222222222"],
+        "text": (
+            "settle the exact completed Todos through no-follow-up or link each "
+            "to a real runnable successor"
+        ),
+    }
+    assert "todo_111111111111, todo_222222222222" in obligation[
+        "recommended_action"
+    ]
+    assert "host-projected coverage ledger" not in obligation["recommended_action"]
+    assert obligation["replan_novelty_policy"]["writeback"] == (
+        "todo_lifecycle_or_typed_successor"
+    )
+    assert [trigger["completion_turn_key"] for trigger in obligation["triggers"]] == [
+        "turn-implement",
+        "turn-validate",
+    ]
+
+
+def test_todo_succession_gap_cli_actions_do_not_require_semantic_refresh() -> None:
+    actions = interaction_next_cli_actions(
+        {
+            "goal_id": "goal-example",
+            "agent_identity": {"agent_id": "current-agent"},
+            "autonomous_replan_obligation": {
+                "resolution_mode": "todo_lifecycle_settlement",
+                "triggers": [
+                    {
+                        "kind": "completed_advancement_without_successor",
+                        "todo_id": "todo_111111111111",
+                        "completion_turn_key": "turn-implement",
+                    },
+                    {
+                        "kind": "completed_advancement_without_successor",
+                        "todo_id": "todo_222222222222",
+                    },
+                ],
+            },
+        },
+        mode="autonomous_replan",
+        available_capabilities=["shell"],
+    )
+
+    assert "--todo-id todo_111111111111" in actions[0]
+    assert "--turn-instance-id turn-implement" in actions[0]
+    assert "--todo-id todo_222222222222" in actions[1]
+    assert "--turn-instance-id" not in actions[1]
+    assert all("refresh-state" not in action for action in actions)
+    assert all("spend-slot" not in action for action in actions)
+    assert actions[-1] == (
+        "loopx --format json quota should-run --goal-id goal-example "
+        "--agent-id current-agent --available-capability shell"
+    )
 
 
 @pytest.mark.parametrize("other_agent_count", [1, 2, 8])


### PR DESCRIPTION
## What changed

- project exact completed Todo ids and completion turn keys for terminal succession gaps;
- prefer direct `todo complete --no-follow-up` settlement when no real work remains;
- keep typed successor creation as the path only when concrete implementation or validation work remains;
- return lifecycle-specific CLI actions before re-reading quota, instead of routing through generic semantic refresh and quota spending;
- add regression coverage for the obligation projection and interaction hot path.

## Why

A completed advancement Todo without a successor is a lifecycle decision, but the interaction projection previously exposed only generic replan guidance. Agents could spend unnecessary turns re-reading the control contract or create a lifecycle-only filler successor even when the correct outcome was a direct no-follow-up settlement.

This change makes the terminal path explicit and bounded while preserving genuine technical replanning.

Fixes #3358.

## Validation

- `167 passed` across focused goal, quota, Todo authority, settlement, and host-context tests;
- `ruff check --select F` on all changed Python files;
- `git diff --check`;
- `loopx canary premerge --from-git-diff`: standard tier, 17/17 selected canaries passed, no manual holds;
- public/private scan found no credentials, private paths, raw trajectories, or verifier output.

## Scope

This changes Goal control-plane projection and interaction guidance only. It does not change benchmark scoring, task semantics, permissions, or runner launch behavior.
