### PR TITLE
chore(release): prepare LoopX v0.5.0

### DIFF
--- a/docs/guides/kunluncode-adapter.zh-CN.html
+++ b/docs/guides/kunluncode-adapter.zh-CN.html
@@ -313,7 +313,7 @@
     <aside id="quickstart" class="quick-card" aria-label="四步快速开始">
       <div class="quick-head">四步快速开始</div>
       <pre>uv venv .venv
-uv pip install --python .venv/bin/python -e . 'mcp==1.27.2'
+uv pip install --python .venv/bin/python -e . 'mcp==1.28.1'
 
 .venv/bin/loopx-kunluncode connect \
   --project /path/to/project \
@@ -452,7 +452,7 @@ export KUNLUN_AGENT_ID=kunlun</code></pre></div>
       <section id="environment">
         <span class="section-no">04 / ENVIRONMENT</span>
         <h2>安装适配器</h2>
-        <p>普通用户安装发布包；<code>install</code> 会通过 uv 创建 adapter-owned MCP 环境，安装相同版本的 LoopX 与 <code>mcp==1.27.2</code>，不要求源码 checkout。</p>
+        <p>普通用户安装发布包；<code>install</code> 会通过 uv 创建 adapter-owned MCP 环境，安装相同版本的 LoopX 与 <code>mcp==1.28.1</code>，不要求源码 checkout。</p>
         <div class="code-wrap"><pre><code>python3 -m pip install --upgrade loopx
 loopx-kunluncode install
 loopx-kunluncode --help</code></pre></div>
@@ -460,7 +460,7 @@ loopx-kunluncode --help</code></pre></div>
         <div class="code-wrap"><pre><code>export LOOPX_SOURCE=/path/to/loopx
 cd "$LOOPX_SOURCE"
 uv venv .venv
-uv pip install --python .venv/bin/python -e . 'mcp==1.27.2'
+uv pip install --python .venv/bin/python -e . 'mcp==1.28.1'
 export LOOPX_KUNLUN="$LOOPX_SOURCE/.venv/bin/loopx-kunluncode"
 "$LOOPX_KUNLUN" install --python "$LOOPX_SOURCE/.venv/bin/python"</code></pre></div>
         <p><code>"$LOOPX_KUNLUN" --help</code> 应列出 <code>connect / install / uninstall / add / run / status</code>；内置 provisioner 不修改系统 Python。</p>
@@ -613,7 +613,7 @@ kunluncode --cwd "$TARGET_PROJECT" mcp test loopx-kunluncode</code></pre></div>
         <h2>故障排查</h2>
         <div class="cards">
           <div class="card"><h3>找不到 kunluncode</h3><p>运行 <code>command -v kunluncode</code> 和 <code>kunluncode --version</code>，修复 PATH。</p></div>
-          <div class="card"><h3>uv is required</h3><p>安装 uv，或传入已包含 LoopX 与 <code>mcp==1.27.2</code> 的 uv Python。</p></div>
+          <div class="card"><h3>uv is required</h3><p>安装 uv，或传入已包含 LoopX 与 <code>mcp==1.28.1</code> 的 uv Python。</p></div>
           <div class="card"><h3>MCP 无法连接</h3><p>依次 readback 配置、重新 install、从目标项目执行 <code>mcp test</code>。</p></div>
           <div class="card"><h3>身份不匹配</h3><p>用正确 goal/Agent 重新 connect；不要修改请求去冒充另一个 Agent。</p></div>
           <div class="card"><h3>goal-mode 未激活</h3><p>确认当前目录、registry 和 binding，再重新 connect。</p></div>
@@ -623,7 +623,7 @@ kunluncode --cwd "$TARGET_PROJECT" mcp test loopx-kunluncode</code></pre></div>
         </div>
         <h3>重新同步 Python 环境</h3>
         <div class="code-wrap"><pre><code>cd "$LOOPX_SOURCE"
-uv pip install --python .venv/bin/python -e . 'mcp==1.27.2'
+uv pip install --python .venv/bin/python -e . 'mcp==1.28.1'
 
 "$LOOPX_KUNLUN" install --python "$LOOPX_SOURCE/.venv/bin/python"</code></pre></div>
         <h3><code>should_run=false</code></h3>
@@ -635,7 +635,7 @@ uv pip install --python .venv/bin/python -e . 'mcp==1.27.2'
         <span class="section-no">12 / ACCEPTANCE</span>
         <h2>完整验收清单</h2>
         <ul class="checklist">
-          <li>uv 可用；LoopX 与 <code>mcp==1.27.2</code> 位于同一环境。</li>
+          <li>uv 可用；LoopX 与 <code>mcp==1.28.1</code> 位于同一环境。</li>
           <li>connect 返回成功，goal id 与 Agent id 正确。</li>
           <li><code>.loopx/kunluncode.json</code> 未被 Git 跟踪。</li>
           <li>已有 goal 的其他 registered agents 被保留。</li>

--- a/docs/guides/kunluncode-adapter.zh-CN.md
+++ b/docs/guides/kunluncode-adapter.zh-CN.md
@@ -158,7 +158,7 @@ export KUNLUN_AGENT_ID=kunlun
 ## 4. 安装适配器
 
 普通用户直接安装发布包；`install` 会用 `uv` 创建独立的 MCP 环境，并安装与当前命令
-相同版本的 LoopX 和固定版本 `mcp==1.27.2`：
+相同版本的 LoopX 和固定版本 `mcp==1.28.1`：
 
 ```bash
 python3 -m pip install --upgrade loopx
@@ -172,7 +172,7 @@ loopx-kunluncode --help
 export LOOPX_SOURCE=/path/to/loopx
 cd "$LOOPX_SOURCE"
 uv venv .venv
-uv pip install --python .venv/bin/python -e . 'mcp==1.27.2'
+uv pip install --python .venv/bin/python -e . 'mcp==1.28.1'
 export LOOPX_KUNLUN="$LOOPX_SOURCE/.venv/bin/loopx-kunluncode"
 "$LOOPX_KUNLUN" install --python "$LOOPX_SOURCE/.venv/bin/python"
 ```
@@ -490,7 +490,7 @@ kunluncode --version
 ### `uv is required`
 
 适配器拒绝修改系统 Python。安装 `uv` 后重新运行 install/connect，或显式传入一个已经
-包含 LoopX 和 `mcp==1.27.2` 的 uv Python。
+包含 LoopX 和 `mcp==1.28.1` 的 uv Python。
 
 ### Python 不能 import LoopX 或 MCP 版本不对
 
@@ -498,7 +498,7 @@ kunluncode --version
 
 ```bash
 cd "$LOOPX_SOURCE"
-uv pip install --python .venv/bin/python -e . 'mcp==1.27.2'
+uv pip install --python .venv/bin/python -e . 'mcp==1.28.1'
 ```
 
 然后用绝对 `--python` 路径重新执行 `install`。
@@ -583,7 +583,7 @@ log 对账，并从缺失阶段继续。
 
 在称为“成功接入”前逐项确认：
 
-- [ ] `uv --version` 正常；适配器与 `mcp==1.27.2` 在同一 uv 环境；
+- [ ] `uv --version` 正常；适配器与 `mcp==1.28.1` 在同一 uv 环境；
 - [ ] `connect` 返回 `ok: true`，goal id 和 Agent id 正确；
 - [ ] `.loopx/kunluncode.json` 未被 Git 跟踪；
 - [ ] 连接已有 goal 时其他 registered agents 仍存在；

--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -450,6 +450,11 @@ path, and canary route rather than as a user-facing release baseline.
   ledger, and hardens heartbeat settlement, Todo validation, PR review
   scheduling, native Goal benchmark isolation, and public repository signal
   providers.
+- `v0.5.0` on 2026-08-20: personal control-plane workspace release at the
+  matching `v0.5.0` tag. LoopX promotes the dashboard as the supported
+  browser/PWA workspace, adds a source-built native desktop shell over the same
+  local authority, makes Goal stop/resume and repository change windows
+  operator-visible, and admits goal-bound external capability providers.
 
 When a new public release is promoted, add it here only after the matching tag,
 release note, stable ref, update path, and focused release canary agree.

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.9"
+__version__ = "0.5.0"

--- a/loopx/kunluncode_goal_mode/README.md
+++ b/loopx/kunluncode_goal_mode/README.md
@@ -51,13 +51,13 @@ loopx-kunluncode connect \
   --agent-id kunlun
 ```
 
-The provisioner installs the same LoopX distribution version and `mcp==1.27.2`
+The provisioner installs the same LoopX distribution version and `mcp==1.28.1`
 outside a source checkout. Contributors can instead use one checkout-local
 uv-managed environment:
 
 ```bash
 uv venv .venv
-uv pip install --python .venv/bin/python -e . 'mcp==1.27.2'
+uv pip install --python .venv/bin/python -e . 'mcp==1.28.1'
 .venv/bin/loopx-kunluncode connect \
   --project . \
   --goal-id my-goal \

--- a/loopx/kunluncode_goal_mode/cli.py
+++ b/loopx/kunluncode_goal_mode/cli.py
@@ -25,7 +25,7 @@ from loopx.kunluncode_goal_mode.runtime import (
 from loopx.registry import atomic_write_json
 
 
-MCP_REQUIREMENT = "mcp==1.27.2"
+MCP_REQUIREMENT = "mcp==1.28.1"
 MCP_SCRIPT = Path(__file__).with_name("server.py").resolve()
 DEFAULT_MCP_VENV = (
     Path.home() / ".local" / "share" / "loopx" / "kunluncode-mcp" / ".venv"
@@ -65,7 +65,7 @@ def _compatible_python(value: str | Path) -> bool:
                 "from importlib.metadata import version; "
                 "from mcp.server.fastmcp import FastMCP; "
                 "import loopx.kunluncode_goal_mode.server; "
-                "assert version('mcp') == '1.27.2'"
+                "assert version('mcp') == '1.28.1'"
             ),
         ],
         timeout=30,
@@ -192,7 +192,7 @@ def install_mcp(*, python: str | None, dry_run: bool, replace: bool) -> str:
         selected_python = provision_mcp_python(dry_run=dry_run)
     if not dry_run and not _compatible_python(selected_python):
         raise RuntimeError(
-            f"{selected_python} must import LoopX and mcp==1.27.2; use uv to sync the adapter environment"
+            f"{selected_python} must import LoopX and mcp==1.28.1; use uv to sync the adapter environment"
         )
     existing = next(
         (

--- a/man/loopx.1
+++ b/man/loopx.1
@@ -1,4 +1,4 @@
-.TH LOOPX 1 "" "LoopX 0.4.9" "User Commands"
+.TH LOOPX 1 "" "LoopX 0.5.0" "User Commands"
 .SH NAME
 loopx \- control-plane helper for long-running agent work
 .SH SYNOPSIS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.4.9"
+version = "0.5.0"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ deepseek-harness = [
 ]
 test = [
   "jsonschema>=4.23,<5",
-  "mcp==1.27.2",
+  "mcp==1.28.1",
   "types-jsonschema>=4.23,<5",
   "pytest>=8,<9",
   "pytest-cov>=5,<7",

--- a/tests/test_license_metadata.py
+++ b/tests/test_license_metadata.py
@@ -31,8 +31,8 @@ def test_root_license_is_canonical_apache_2_with_historical_notices() -> None:
 
 def test_python_distributions_declare_apache_2() -> None:
     root_project = _project_metadata("pyproject.toml")
-    assert root_project["version"] == "0.4.9"
-    assert '__version__ = "0.4.9"' in (ROOT / "loopx/__init__.py").read_text()
+    assert root_project["version"] == "0.5.0"
+    assert '__version__ = "0.5.0"' in (ROOT / "loopx/__init__.py").read_text()
     assert root_project["license"] == "Apache-2.0"
     assert set(root_project["license-files"]) == {"LICENSE", "NOTICE", "LICENSE-MIT"}
 


### PR DESCRIPTION
## Summary

- prepare the package, CLI, test contract, and generated manpage for LoopX `0.5.0`
- upgrade the test/KunlunCode MCP SDK pin from `1.27.2` to the patched `1.28.1`
- add the v0.5.0 personal control-plane workspace entry to the public release timeline

## Why 0.5.0

This is a minor release because the tag range adds a major user-visible product surface: the supported browser/PWA Personal Agent Workspace, plus the source-built native desktop shell over the same local authority. It also makes Goal stop/resume and repository change windows operator-visible and adds goal-bound external capability admission.

The MCP upgrade closes `GHSA-vj7q-gjh5-988w`. LoopX uses `mcp.server.fastmcp.FastMCP`, not the advisory's deprecated WebSocket transport, but a new release must not retain a known vulnerable direct pin.

## Review and validation

- changed surfaces: package/version metadata, KunlunCode adapter dependency probe, generated manpage, bilingual adapter docs, release-readiness timeline
- `35 passed`: `tests/test_kunluncode_goal_mode.py` and `tests/test_license_metadata.py` in a fresh environment resolving `mcp==1.28.1`
- fresh install imported `FastMCP` and the LoopX server and reported `loopx 0.5.0`
- release version, release artifact, release-readiness-doc, and manpage contracts passed
- wheel/sdist build, Twine metadata validation, and checksum writer/verifier passed
- Ruff passed on changed Python/test files; repository-configured strict mypy passed on all 12 kernel contracts
- risk-based pre-merge canary: 18/18 selected checks passed, plus 4/4 direct checks
- public/private boundary: all 9 changed files clean
- failures/skips: none; manual holds: none
- change-quality receipt: `cqr_274d974ca56582235ee9`, exact scope `274d974ca56582235ee9a65aab8e7ba5a35c7dc2b252e91eef4db2950f6cf243`

## Release boundary

This PR does not create a tag, move `stable`, publish a GitHub Release, or upload to PyPI. Those actions remain a separate post-merge release gate after 05:00 Asia/Shanghai, with final bilingual release-body validation and remote readback.
