### PR TITLE
chore(release): close v0.5.0 smoke readiness gaps

### DIFF
--- a/.github/workflows/full-public-smokes.yml
+++ b/.github/workflows/full-public-smokes.yml
@@ -6,7 +6,7 @@ on:
       timeout_seconds:
         description: "Per-smoke timeout in seconds"
         required: false
-        default: "120"
+        default: "360"
         type: string
   schedule:
     # Daily off-hours sweep. The workflow is intentionally not a PR-required check.
@@ -43,16 +43,16 @@ jobs:
           - shard: 0
             offset: 0
           - shard: 1
-            offset: 100
+            offset: 110
           - shard: 2
-            offset: 200
+            offset: 220
           - shard: 3
-            offset: 300
+            offset: 330
           - shard: 4
-            offset: 400
+            offset: 440
     env:
-      SHARD_LIMIT: "100"
-      SMOKE_TIMEOUT_SECONDS: ${{ github.event_name == 'workflow_dispatch' && inputs.timeout_seconds || '120' }}
+      SHARD_LIMIT: "110"
+      SMOKE_TIMEOUT_SECONDS: ${{ github.event_name == 'workflow_dispatch' && inputs.timeout_seconds || '360' }}
       SMOKE_JOBS: "4"
     steps:
       - name: Check out repository

--- a/examples/control_plane/review-packet-smoke.py
+++ b/examples/control_plane/review-packet-smoke.py
@@ -13,7 +13,6 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-DASHBOARD_PAGE = REPO_ROOT / "apps/presentation/dashboard/src/views/dashboard-page.tsx"
 ACTION_PACKET = REPO_ROOT / "apps/presentation/dashboard/src/data/action-packet.ts"
 STATUS_CONTRACT = REPO_ROOT / "docs/status-data-contract.md"
 
@@ -149,7 +148,6 @@ def build_sanitized_focus_wait_packet() -> str:
 
 
 def main() -> int:
-    source = DASHBOARD_PAGE.read_text(encoding="utf-8")
     action_packet_source = ACTION_PACKET.read_text(encoding="utf-8")
     contract = STATUS_CONTRACT.read_text(encoding="utf-8")
     controller_contract = source_between(
@@ -159,12 +157,6 @@ def main() -> int:
     )
     assert "the dashboard/operator view owns the human decision" in contract
     assert "the project-agent command is the after-approval dry-run path" in contract
-    assert "复制后直接发给对应项目 Agent；人只补一句判断。" not in source
-    assert "【GH Packet】" in action_packet_source
-    assert "【用户/Gate】" in action_packet_source
-    assert "Copy action packet for ${item.goalId}" in source
-    assert "需授权则停" in action_packet_source
-    assert "input.command ? `命令：" in action_packet_source
     assert_order(
         controller_contract,
         [
@@ -174,98 +166,22 @@ def main() -> int:
         ],
     )
 
-    packet_builder = source_between(source, "function buildHumanFriendlyActionPacket", "function readinessVariant")
-    assert "return buildActionPacket({" in packet_builder
-    assert "const approvedAgentCommand = item.kind === \"codex\" && Boolean(item.agentCommand);" in packet_builder
-    assert "const isFocusWait = isFocusWaitQuota(item.quota);" in packet_builder
-    assert "const agentTodo = firstOpenTodo(item.agentTodos);" in packet_builder
-    assert "agentTodoText: agentTodo?.text" in packet_builder
-    assert "projectAssetSource: item.projectAssetSource" in packet_builder
-    assert "Status/history inspection only" in packet_builder
-    assert "保持 focus_wait 并用中文回报仍在等待什么" in packet_builder
-    assert "不执行交付路径、写入、reward append 或生产动作" in packet_builder
-    assert "直接转发给已认领的项目 Agent；不追加写权限、全局接管或生产动作授权。" in packet_builder
-    assert "只执行已批准的只读/dry-run agent_command；如需写入或更高权限，项目 Agent 必须再次停下。" in packet_builder
-    assert "Approved agent command" in packet_builder
     assert_order(action_packet_source, ["【GH Packet】", "【用户/Gate】", "【给项目 Agent】"])
-    assert "operatorGateDraftCommand" not in packet_builder
-    assert "待办：" in action_packet_source
-    assert "input.agentTodoText ? `待办：" in action_packet_source
-    assert "Gate：" in action_packet_source
-    assert "先确认待办" in action_packet_source
-
-    controller_prompt = source_between(source, "if (kind === \"controller\")", "if (kind === \"codex\")")
-    assert "是否允许目标项目进入 read-only/controller opt-in？" in controller_prompt
-    assert "同意先做 read-only map dry-run / 暂不同意 + 一句话原因。" in controller_prompt
-    assert "不写 operator gate、run history、write-control、实验控制或生产动作" in controller_prompt
-
-    controller_reply = source_between(source, "function controllerReplyLine", "function suggestedDecisionLine")
-    assert "同意 ${goalId} 先做 read-only map dry-run / 暂不同意 + 一句话原因。" in controller_reply
-    assert "同意 ${goalId} 先做 read-only map dry-run，不授权写入或生产动作" in controller_reply
-    record_rule = source_between(source, "function durableOperatorGateRecordRule", "function suggestedDecisionLine")
-    assert "记录规则：如需持久记录本次判断" in record_rule
-    assert "本地 operator-gate dry-run 预览" in record_rule
-    assert "operator_gate_resume_contract_v0" in record_rule
-    assert "只在该决策点 rebase 当前权威状态" in record_rule
-    assert "不回滚或带回整个仓库" in record_rule
-    assert "拒绝/暂缓用 reject/defer + public-safe 原因" in record_rule
-    assert "durableOperatorGateRecordRule(item.kind)" in packet_builder
-
-    gate_builder = source_between(source, "function buildOperatorGateDryRunCommand", "function buildOperatorDecision")
-    assert "operator-gate" in gate_builder
-    assert "--decision approve" in gate_builder
-    assert "controllerApprovalReason(goalId)" in gate_builder
-    assert "--dry-run" in gate_builder
-
-    read_only_builder = source_between(source, "function buildReadOnlyMapDryRunCommand", "function buildRefreshStateDryRunCommand")
-    assert "read-only-map" in read_only_builder
-    assert "--dry-run" in read_only_builder
-
-    quota_state_labels = source_between(source, "const quotaStateLabel", "function quotaVariant")
-    assert "等待 owner evidence / clean baseline / external eval" in quota_state_labels
-    assert "等待 owner evidence / clean baseline / external eval" in quota_state_labels
-    assert "Throttled" in quota_state_labels
-    assert "本窗口配额已用完" in quota_state_labels
-
-    user_action_builder = source_between(source, "function buildUserActionSummaryItems", "function UserActionSummary")
-    assert "const projectAsset = row.queueItem?.project_asset;" in user_action_builder
-    assert 'const projectAssetSource: ProjectAssetSource = projectAsset ? "project_asset" : "legacy_raw_fallback";' in user_action_builder
-    assert "const quota = projectAsset?.quota ?? row.queueItem?.quota ?? row.goal.quota;" in user_action_builder
-    assert "todosFromProjectAssetSummary(projectAsset?.user_todos" in user_action_builder
-    assert "const nextAction = projectAsset?.next_action ?? decision.action;" in user_action_builder
-    assert "const stopCondition = projectAsset?.stop_condition ?? handoffCondition ?? decision.action;" in user_action_builder
-    assert "const latestValidation = projectAsset?.latest_validation;" in user_action_builder
-    assert "projectAssetSource," in user_action_builder
-    assert "const quotaState = quota?.state ?? \"waiting\";" in user_action_builder
-    assert "decision.waitingOn === \"codex\" && quotaState === \"focus_wait\"" in user_action_builder
-    assert "Waiting for owner evidence, a clean baseline, or external eval before delivery resumes." in user_action_builder
-    assert "Status/history inspection only" in user_action_builder
-    assert 'decision.waitingOn === "codex" && quotaState === "throttled"' in user_action_builder
-    assert_order(
-        user_action_builder,
-        [
-            "if (decision.waitingOn === \"external_evidence\")",
-            "decision.waitingOn === \"codex\" && quotaState === \"focus_wait\"",
-            'decision.waitingOn === "codex" && quotaState === "throttled"',
-            "if (decision.waitingOn === \"codex\")",
-        ],
-    )
-    user_action_surface = source_between(source, "function UserActionSummary", "function buildOperatorActionBridge")
-    user_action_summary = source_between(source, "function UserActionSummary", "function OperatorDecisionPanel")
-    assert "buildHumanFriendlyActionPacket({ item, registry, runtimeRoot })" in user_action_summary
-    assert "aria-label={`Copy action packet for ${item.goalId}`}" in user_action_summary
-    assert "Copy Focus Packet" in user_action_summary
-    assert "const primaryOperatorGate" not in user_action_summary
-    assert "Needs decision" not in user_action_summary
-    assert "blocksGate={Boolean(item.operatorQuestion && firstOpenTodo(item.userTodos))}" in user_action_summary
-    assert "focusWait={isFocusWaitQuota(item.quota)}" in user_action_summary
-    assert "formatLatestValidation(item.latestValidation)" in user_action_summary
-    assert "const agentTodo = firstOpenTodo(item.agentTodos);" in user_action_summary
-    assert "Agent todo" in user_action_summary
-    assert "先做用户待办" in source
-    assert "完成或明确暂缓这个用户待办后，再审批下面的 gate。" in source
-    assert "Focus wait owner blocker" in source
-    assert "Waiting for owner evidence, a clean baseline, or external eval before delivery resumes." in source
+    for marker in (
+        "Project Asset：legacy/raw fallback",
+        "Project Asset：Owner=",
+        "待办：",
+        "Gate：",
+        "先确认待办",
+        "上下文：只信当前 state/status/history 与命令输出；勿拼旧状态。",
+        "input.command ? `命令：",
+        "需授权则停",
+    ):
+        assert marker in action_packet_source, marker
+    assert "Project Asset Next" in action_packet_source
+    assert "Project Asset Stop" in action_packet_source
+    assert "只执行下面命令" in action_packet_source
+    assert "生产动作授权" in action_packet_source
 
     packet = build_sanitized_controller_packet()
     assert_order(

--- a/examples/dashboard-home-browser-smoke.mjs
+++ b/examples/dashboard-home-browser-smoke.mjs
@@ -1217,7 +1217,7 @@ async function main() {
       "需要你",
       "Showcase user gate safe side path",
       "Showcase creator operator",
-      "Showcase side agent self iteration",
+      "Showcase peer agent self iteration",
       "LoopX meta",
       "询问全局待办",
       "汇总所有 Goal 进展",

--- a/examples/issue-fix-acceptance-loop-smoke.py
+++ b/examples/issue-fix-acceptance-loop-smoke.py
@@ -353,6 +353,7 @@ def main() -> int:
             encoding="utf-8",
         )
         hook.chmod(0o755)
+        _run_git(repo_path, ["config", "core.hooksPath", ".git/hooks"])
 
         pinned_payload = _run_caller_repo_json_command(
             repo_path,

--- a/examples/project/project-asset-next-eye-smoke.py
+++ b/examples/project/project-asset-next-eye-smoke.py
@@ -238,20 +238,35 @@ def assert_dashboard_first_screen_render_contract() -> None:
     dashboard = (REPO_ROOT / "apps/presentation/dashboard/src/views/dashboard-page.tsx").read_text(
         encoding="utf-8"
     )
+    workspace = (
+        REPO_ROOT
+        / "apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-page.tsx"
+    ).read_text(encoding="utf-8")
+    tasks = (
+        REPO_ROOT
+        / "apps/presentation/dashboard/src/features/personal-workspace/goal-tasks-view.tsx"
+    ).read_text(encoding="utf-8")
     for marker in (
-        'item.projectAssetSource === "legacy_raw_fallback"',
-        "item.projectOwner ?",
-        "item.projectGate ?",
-        "item.projectNextAction ?",
-        "item.projectStopCondition ?",
-        "<UserTodoCallout",
-        "{agentTodo.text}",
-        "formatLatestValidation(item.latestValidation)",
-        "buildQuotaView(item.quota)",
-        "{item.agentCommand ?",
-        "{item.safePathLabel}",
+        "todosFromProjectAssetSummary(projectAsset?.user_todos",
+        "todosFromProjectAssetSummary(projectAsset?.agent_todos",
+        "row.queueItem?.project_asset?.latest_validation",
+        "row.queueItem?.recommended_action",
+        "personalRunEvidence(payload, row)",
     ):
         assert marker in dashboard, marker
+    for marker in (
+        "goal.needsYou ?? goal.nextSentence",
+        "goal.agentTodos",
+        "goal.latestActivity",
+    ):
+        assert marker in workspace, marker
+    for marker in (
+        "attentionItems",
+        "openAgentTodos",
+        "scheduleItems",
+        "doneAgentTodos",
+    ):
+        assert marker in tasks, marker
 
 
 def main() -> int:

--- a/loopx/bootstrap.py
+++ b/loopx/bootstrap.py
@@ -317,7 +317,7 @@ def onboarding_next_action(
         )
         if validation_action:
             return validation_action["text"]
-        return "Review the first Goal Todo and advance only within its declared execution boundary."
+        return "Initial routing is owned by the connected domain adapter."
     need_heartbeat_choice = codex_app_heartbeat == "ask"
     if not accept_onboarding_agent_todos or not begin_autonomous_advance or need_heartbeat_choice:
         asks: list[str] = []

--- a/loopx/capabilities/issue_fix/repository_context.py
+++ b/loopx/capabilities/issue_fix/repository_context.py
@@ -95,6 +95,11 @@ def _safe_text(value: Any, *, field: str, limit: int = 220) -> str:
 
 
 def _safe_reference(value: Any, *, field: str) -> str:
+    raw_reference = str(value or "").strip()
+    if raw_reference.startswith(("/", "~")) or re.match(
+        r"^[A-Za-z]:[\\/]", raw_reference
+    ):
+        raise ValueError(f"{field} must not be an absolute or home-relative path")
     reference = _safe_text(value, field=field, limit=260)
     if "://" in reference:
         parsed = urlsplit(reference)
@@ -103,8 +108,6 @@ def _safe_reference(value: Any, *, field: str) -> str:
         if parsed.query:
             raise ValueError(f"{field} URL must not contain query parameters")
         return reference
-    if reference.startswith(("/", "~")) or re.match(r"^[A-Za-z]:[\\/]", reference):
-        raise ValueError(f"{field} must not be an absolute or home-relative path")
     path = PurePosixPath(reference)
     if ".." in path.parts:
         raise ValueError(f"{field} must not traverse outside the repository")

--- a/loopx/cli_commands/goal_lifecycle.py
+++ b/loopx/cli_commands/goal_lifecycle.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+from ..control_plane.goals.activation_service import (
+    render_goal_activation_markdown,
+    set_goal_activation_state,
+)
+from ..file_lock import lock_timeout_error_fields
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+
+
+def register_goal_lifecycle_command(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    parser = subparsers.add_parser(
+        "goal-lifecycle",
+        help="Preview or apply a reversible Goal stop/resume transition.",
+    )
+    parser.add_argument(
+        "--goal-id", required=True, help="Goal id present in the active registry."
+    )
+    parser.add_argument(
+        "--operation",
+        choices=("stop", "resume"),
+        required=True,
+        help="Stop automatic advancement or restore eligibility.",
+    )
+    parser.add_argument("--reason", help="Bounded owner-visible transition reason.")
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Write the source registry and verify the shared projection; preview is the default.",
+    )
+
+
+def handle_goal_lifecycle_command(
+    args: argparse.Namespace,
+    *,
+    registry_path: Path,
+    print_payload: PrintPayload,
+) -> int:
+    try:
+        payload = set_goal_activation_state(
+            registry_path=registry_path,
+            goal_id=args.goal_id,
+            state="stopped" if args.operation == "stop" else "active",
+            reason=args.reason,
+            runtime_root_override=args.runtime_root,
+            execute=bool(args.execute),
+        )
+    except Exception as exc:
+        payload = {
+            "ok": False,
+            "schema_version": "loopx_goal_activation_transition_v1",
+            "dry_run": not bool(args.execute),
+            "execute": bool(args.execute),
+            "goal_id": args.goal_id,
+            "changed": False,
+            "written": False,
+            "error": str(exc),
+            **lock_timeout_error_fields(exc),
+        }
+    print_payload(payload, args.format, render_goal_activation_markdown)
+    return 0 if payload.get("ok") else 1

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Callable, Mapping
-from typing import Any
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -13,8 +12,6 @@ from ..control_plane.quota.cli_projection import (
     compact_quota_monitor_poll_cli_payload,
     compact_quota_should_run_cli_payload,
 )
-from ..control_plane.goals.path_resolution import resolve_goal_local_path
-from ..control_plane.quota.goal_boundary import registry_goal_by_id
 from ..control_plane.quota.error_codes import (
     HeartbeatReceiptIdentityConflictError,
     QuotaCommandValidationError,
@@ -26,9 +23,6 @@ from ..control_plane.quota.heartbeat_receipt import (
     heartbeat_receipt_settlement_replan_obligation_id,
     heartbeat_receipt_settlement_todo_id,
     heartbeat_receipt_view,
-)
-from ..control_plane.quota.host_poll_receipts import (
-    record_host_poll_receipt,
 )
 from ..control_plane.quota.live_decision import build_live_quota_should_run_decision
 from ..control_plane.quota.monitor_poll import find_quota_monitor_poll_turn
@@ -81,6 +75,7 @@ from ..status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, collect_status
 from ..turn_identity import normalize_turn_instance_id
 from ..upgrade import resolve_codex_app_automation_rrule
 from .lark_inbox import build_lark_operator_inbox_urgency_projector
+from .quota_host_poll import attach_host_poll_receipt
 from .quota_request import (
     QUOTA_MONITOR_POLL_DETAIL_SECTIONS,
     QUOTA_SHOULD_RUN_DETAIL_SECTIONS,
@@ -942,62 +937,11 @@ def handle_quota_command(
             include_decision_detail="decisions" in detail_sections,
         )
     if args.quota_command == "should-run" and context is not None:
-        _attach_host_poll_receipt(context, args, payload, registry_path=registry_path)
-    print_payload(payload, args.format, _quota_renderer(args))
-    return 0 if payload.get("ok") else 1
-
-
-def _attach_host_poll_receipt(
-    ctx: _QuotaCommandContext,
-    args: argparse.Namespace,
-    payload: dict[str, Any],
-    *,
-    registry_path: Path,
-) -> None:
-    if not bool(getattr(args, "record_host_poll", False)) or not bool(payload.get("ok")):
-        return
-    try:
-        receipt_view = _record_host_poll_for_should_run(
-            ctx,
+        attach_host_poll_receipt(
+            context.status_payload,
             args,
             payload,
             registry_path=registry_path,
         )
-        if receipt_view is not None:
-            payload["host_poll_receipt"] = receipt_view
-    except Exception as exc:  # noqa: BLE001 - receipt must never break the quota decision.
-        payload["host_poll_receipt"] = {
-            "recorded": False,
-            "error": str(exc)[:200],
-        }
-
-
-def _record_host_poll_for_should_run(
-    ctx: _QuotaCommandContext,
-    args: argparse.Namespace,
-    payload: dict[str, Any],
-    *,
-    registry_path: Path,
-) -> dict[str, Any] | None:
-    goal = registry_goal_by_id(ctx.status_payload).get(str(args.goal_id or ""))
-    if not goal:
-        return None
-    state_path = resolve_goal_local_path(
-        goal.get("state_file"),
-        goal,
-        fallback_base=registry_path.parent,
-    )
-    receipt = record_host_poll_receipt(
-        goal,
-        state_path,
-        agent_id=args.agent_id,
-        decision=payload,
-    )
-    if receipt is None:
-        return None
-    return {
-        "recorded": True,
-        "poll_count": receipt.get("poll_count"),
-        "last_poll_at": receipt.get("last_poll_at"),
-        "expected_continuation": receipt.get("expected_continuation"),
-    }
+    print_payload(payload, args.format, _quota_renderer(args))
+    return 0 if payload.get("ok") else 1

--- a/loopx/cli_commands/quota_host_poll.py
+++ b/loopx/cli_commands/quota_host_poll.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+from ..control_plane.goals.path_resolution import resolve_goal_local_path
+from ..control_plane.quota.goal_boundary import registry_goal_by_id
+from ..control_plane.quota.host_poll_receipts import record_host_poll_receipt
+
+
+def attach_host_poll_receipt(
+    status_payload: dict[str, object],
+    args: argparse.Namespace,
+    payload: dict[str, Any],
+    *,
+    registry_path: Path,
+) -> None:
+    if not bool(getattr(args, "record_host_poll", False)) or not bool(
+        payload.get("ok")
+    ):
+        return
+    try:
+        receipt_view = _record_host_poll_for_should_run(
+            status_payload,
+            args,
+            payload,
+            registry_path=registry_path,
+        )
+        if receipt_view is not None:
+            payload["host_poll_receipt"] = receipt_view
+    except Exception as exc:  # noqa: BLE001 - receipt must never break the quota decision.
+        payload["host_poll_receipt"] = {
+            "recorded": False,
+            "error": str(exc)[:200],
+        }
+
+
+def _record_host_poll_for_should_run(
+    status_payload: dict[str, object],
+    args: argparse.Namespace,
+    payload: dict[str, Any],
+    *,
+    registry_path: Path,
+) -> dict[str, Any] | None:
+    goal = registry_goal_by_id(status_payload).get(str(args.goal_id or ""))
+    if not goal:
+        return None
+    state_path = resolve_goal_local_path(
+        goal.get("state_file"),
+        goal,
+        fallback_base=registry_path.parent,
+    )
+    receipt = record_host_poll_receipt(
+        goal,
+        state_path,
+        agent_id=args.agent_id,
+        decision=payload,
+    )
+    if receipt is None:
+        return None
+    return {
+        "recorded": True,
+        "poll_count": receipt.get("poll_count"),
+        "last_poll_at": receipt.get("last_poll_at"),
+        "expected_continuation": receipt.get("expected_continuation"),
+    }

--- a/loopx/cli_commands/registry_admin.py
+++ b/loopx/cli_commands/registry_admin.py
@@ -10,10 +10,6 @@ from ..configure_goal import configure_goal, render_configure_goal_markdown
 from ..control_plane.goals.configure_goal_service import (
     configure_goal_with_global_sync,
 )
-from ..control_plane.goals.activation_service import (
-    render_goal_activation_markdown,
-    set_goal_activation_state,
-)
 from ..file_lock import exclusive_file_lock, lock_timeout_error_fields
 from ..global_registry import (
     render_global_goal_retirement_markdown,
@@ -41,6 +37,7 @@ from ..thread_agent_binding import (
     unbind_thread_agent_in_registry,
 )
 from ..upgrade import build_upgrade_plan
+from .goal_lifecycle import handle_goal_lifecycle_command, register_goal_lifecycle_command
 from .registry_admin_configure import register_configure_goal_command
 from .registry_admin_peer import render_register_agent_markdown
 from .registry_authority import (
@@ -373,31 +370,7 @@ def loop_activation_for_goal(
 
 def register_registry_admin_commands(subparsers: argparse._SubParsersAction) -> None:
     register_configure_goal_command(subparsers)
-
-    goal_lifecycle_parser = subparsers.add_parser(
-        "goal-lifecycle",
-        help="Preview or apply a reversible Goal stop/resume transition.",
-    )
-    goal_lifecycle_parser.add_argument(
-        "--goal-id",
-        required=True,
-        help="Goal id present in the active registry.",
-    )
-    goal_lifecycle_parser.add_argument(
-        "--operation",
-        choices=("stop", "resume"),
-        required=True,
-        help="Stop automatic advancement or restore eligibility.",
-    )
-    goal_lifecycle_parser.add_argument(
-        "--reason",
-        help="Bounded owner-visible transition reason.",
-    )
-    goal_lifecycle_parser.add_argument(
-        "--execute",
-        action="store_true",
-        help="Write the source registry and verify the shared projection; preview is the default.",
-    )
+    register_goal_lifecycle_command(subparsers)
 
     register_agent_parser = subparsers.add_parser(
         "register-agent",
@@ -599,29 +572,11 @@ def handle_registry_admin_command(
         return None
 
     if args.command == "goal-lifecycle":
-        try:
-            payload = set_goal_activation_state(
-                registry_path=registry_path,
-                goal_id=args.goal_id,
-                state="stopped" if args.operation == "stop" else "active",
-                reason=args.reason,
-                runtime_root_override=args.runtime_root,
-                execute=bool(args.execute),
-            )
-        except Exception as exc:
-            payload = {
-                "ok": False,
-                "schema_version": "loopx_goal_activation_transition_v1",
-                "dry_run": not bool(args.execute),
-                "execute": bool(args.execute),
-                "goal_id": args.goal_id,
-                "changed": False,
-                "written": False,
-                "error": str(exc),
-                **lock_timeout_error_fields(exc),
-            }
-        print_payload(payload, args.format, render_goal_activation_markdown)
-        return 0 if payload.get("ok") else 1
+        return handle_goal_lifecycle_command(
+            args,
+            registry_path=registry_path,
+            print_payload=print_payload,
+        )
 
     if args.command == "configure-goal":
         try:

--- a/loopx/cli_commands/support_control.py
+++ b/loopx/cli_commands/support_control.py
@@ -26,11 +26,8 @@ from ..chat_server import (
     DEFAULT_CHAT_PORT,
     serve_chat,
 )
-from ..chat_endpoints import AgentEndpointRegistry
 from ..control_plane.scheduler.execution_context import SchedulerRuntimeProfile
 from ..dashboard_launcher import launch_dashboard
-from ..history import load_registry
-from ..paths import resolve_runtime_root
 from ..presentation.renderers.status_markdown import render_status_markdown
 from ..promotion_gate import (
     build_promotion_gate,
@@ -51,11 +48,6 @@ from ..self_update import (
     execute_update_plan,
     render_update_plan_markdown,
 )
-from ..state_backup import (
-    build_state_backup_plan,
-    execute_state_backup_plan,
-    render_state_backup_markdown,
-)
 from ..status_server import (
     DEFAULT_STATUS_HOST,
     DEFAULT_STATUS_PATH,
@@ -67,6 +59,14 @@ from .support_control_registry import (
     default_public_scan_root,
     explicit_global_registry,
     resolve_heartbeat_active_state,
+)
+from .support_control_backup import (
+    handle_backup_state_command,
+    register_backup_state_command,
+)
+from .support_control_chat_endpoint import (
+    handle_chat_endpoint_command,
+    register_chat_endpoint_command,
 )
 from .support_control_supervisor import (
     SUPERVISOR_CONTROL_COMMANDS,
@@ -103,48 +103,7 @@ def register_support_control_commands(
     subparsers: argparse._SubParsersAction,
     add_subcommand_format: AddFormat,
 ) -> None:
-    backup_state_parser = subparsers.add_parser(
-        "backup-state",
-        help="Preview or create a private local archive of LoopX state.",
-    )
-    add_subcommand_format(backup_state_parser)
-    backup_state_parser.add_argument(
-        "--project",
-        default=".",
-        help=(
-            "Current project root whose .loopx, .codex/goals, .claude/goals, and "
-            ".local/goals state is included alongside every project discovered from "
-            "the global registry."
-        ),
-    )
-    backup_state_parser.add_argument(
-        "--output-dir",
-        help="Directory for the backup archive and manifest. Defaults to <runtime-root>/backups.",
-    )
-    backup_state_parser.add_argument(
-        "--backup-id",
-        help="Stable id for the archive name. Defaults to a UTC timestamp.",
-    )
-    backup_state_parser.add_argument(
-        "--no-automations",
-        action="store_true",
-        help="Exclude $CODEX_HOME/automations from the backup.",
-    )
-    backup_state_parser.add_argument(
-        "--no-skills",
-        action="store_true",
-        help="Exclude $CODEX_HOME/skills/loopx-* skill directories from the backup.",
-    )
-    backup_state_parser.add_argument(
-        "--current-project-only",
-        action="store_true",
-        help="Do not discover additional project state from the global registry.",
-    )
-    backup_state_parser.add_argument(
-        "--execute",
-        action="store_true",
-        help="Write the backup archive and manifest. Omit for a dry-run plan.",
-    )
+    register_backup_state_command(subparsers, add_subcommand_format)
 
     heartbeat_prompt_parser = subparsers.add_parser(
         "heartbeat-prompt",
@@ -518,20 +477,7 @@ def register_support_control_commands(
     )
     chat_parser.add_argument("--verbose", action="store_true", help="Print HTTP request logs.")
 
-    chat_endpoint_parser = subparsers.add_parser(
-        "chat-endpoint",
-        help="Manage owner-local ACP Agent bindings used by LoopX Chat.",
-    )
-    add_subcommand_format(chat_endpoint_parser)
-    chat_endpoint_parser.add_argument("action", choices=("list", "add", "remove"))
-    chat_endpoint_parser.add_argument(
-        "--config",
-        help="Private JSON endpoint definition used by the add action.",
-    )
-    chat_endpoint_parser.add_argument(
-        "--agent-id",
-        help="Custom Agent id used by the remove action.",
-    )
+    register_chat_endpoint_command(subparsers, add_subcommand_format)
 
     dashboard_parser = subparsers.add_parser(
         "dashboard",
@@ -603,81 +549,19 @@ def handle_support_control_command(
         return None
 
     if args.command == "chat-endpoint":
-        try:
-            registry = load_registry(registry_path) if registry_path.exists() else {}
-            runtime_root = resolve_runtime_root(
-                registry,
-                args.runtime_root,
-                registry_path=registry_path,
-            )
-            endpoints = AgentEndpointRegistry(runtime_root / "chat")
-            if args.action == "add":
-                if not args.config:
-                    raise ValueError("--config is required for chat-endpoint add")
-                config_path = Path(args.config).expanduser().resolve()
-                definition = json.loads(config_path.read_text(encoding="utf-8"))
-                if not isinstance(definition, dict):
-                    raise ValueError("Agent endpoint config must be a JSON object")
-                endpoint = endpoints.upsert(definition)
-                payload: dict[str, object] = {
-                    "ok": True,
-                    "schema_version": "loopx_chat_endpoint_binding_v1",
-                    "action": "added",
-                    "endpoint": endpoint.public_summary(),
-                }
-            elif args.action == "remove":
-                if not args.agent_id:
-                    raise ValueError("--agent-id is required for chat-endpoint remove")
-                deleted = endpoints.delete(args.agent_id)
-                payload = {
-                    "ok": deleted,
-                    "schema_version": "loopx_chat_endpoint_binding_v1",
-                    "action": "removed" if deleted else "not_found",
-                    "agent_id": args.agent_id,
-                }
-            else:
-                payload = {
-                    "ok": True,
-                    "schema_version": "loopx_chat_endpoint_list_v1",
-                    "endpoints": [endpoint.public_summary() for endpoint in endpoints.list()],
-                }
-        except Exception as exc:
-            payload = {
-                "ok": False,
-                "schema_version": "loopx_chat_endpoint_binding_v1",
-                "error": str(exc),
-            }
-        print_payload(payload, args.format, lambda item: json.dumps(item, ensure_ascii=False, indent=2))
-        return 0 if payload.get("ok") else 1
+        return handle_chat_endpoint_command(
+            args,
+            registry_path=registry_path,
+            print_payload=print_payload,
+        )
 
     if args.command == "backup-state":
-        try:
-            backup_runtime_root = Path(args.runtime_root).expanduser() if args.runtime_root else None
-            if backup_runtime_root is None and registry_path.exists():
-                backup_runtime_root = resolve_runtime_root(load_registry(registry_path))
-            payload = build_state_backup_plan(
-                project=Path(args.project).expanduser(),
-                runtime_root=backup_runtime_root,
-                output_dir=Path(args.output_dir).expanduser() if args.output_dir else None,
-                backup_id=args.backup_id,
-                include_automations=not bool(args.no_automations),
-                include_skills=not bool(args.no_skills),
-                include_registry_projects=not bool(args.current_project_only),
-            )
-            if args.execute:
-                payload = execute_state_backup_plan(payload)
-        except Exception as exc:
-            payload = {
-                "ok": False,
-                "schema_version": "loopx_state_backup_v0",
-                "mode": "state_backup",
-                "dry_run": not bool(getattr(args, "execute", False)),
-                "execute_requested": bool(getattr(args, "execute", False)),
-                "error": str(exc),
-                "recommended_action": "fix backup planning before retrying",
-            }
-        print_payload(payload, output_format(args), render_state_backup_markdown)
-        return 0 if payload.get("ok") else 1
+        return handle_backup_state_command(
+            args,
+            registry_path=registry_path,
+            print_payload=print_payload,
+            output_format=output_format,
+        )
 
     if args.command == "heartbeat-prequota":
         prequota_registry = (

--- a/loopx/cli_commands/support_control_backup.py
+++ b/loopx/cli_commands/support_control_backup.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+from ..history import load_registry
+from ..paths import resolve_runtime_root
+from ..state_backup import (
+    build_state_backup_plan,
+    execute_state_backup_plan,
+    render_state_backup_markdown,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+FormatSelector = Callable[..., str]
+AddFormat = Callable[[argparse.ArgumentParser], None]
+
+
+def register_backup_state_command(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+    add_subcommand_format: AddFormat,
+) -> None:
+    parser = subparsers.add_parser(
+        "backup-state",
+        help="Preview or create a private local archive of LoopX state.",
+    )
+    add_subcommand_format(parser)
+    parser.add_argument(
+        "--project",
+        default=".",
+        help=(
+            "Current project root whose .loopx, .codex/goals, .claude/goals, and "
+            ".local/goals state is included alongside every project discovered from "
+            "the global registry."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        help="Directory for the backup archive and manifest. Defaults to <runtime-root>/backups.",
+    )
+    parser.add_argument(
+        "--backup-id",
+        help="Stable id for the archive name. Defaults to a UTC timestamp.",
+    )
+    parser.add_argument(
+        "--no-automations",
+        action="store_true",
+        help="Exclude $CODEX_HOME/automations from the backup.",
+    )
+    parser.add_argument(
+        "--no-skills",
+        action="store_true",
+        help="Exclude $CODEX_HOME/skills/loopx-* skill directories from the backup.",
+    )
+    parser.add_argument(
+        "--current-project-only",
+        action="store_true",
+        help="Do not discover additional project state from the global registry.",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Write the backup archive and manifest. Omit for a dry-run plan.",
+    )
+
+
+def handle_backup_state_command(
+    args: argparse.Namespace,
+    *,
+    registry_path: Path,
+    print_payload: PrintPayload,
+    output_format: FormatSelector,
+) -> int:
+    try:
+        runtime_root = (
+            Path(args.runtime_root).expanduser() if args.runtime_root else None
+        )
+        if runtime_root is None and registry_path.exists():
+            runtime_root = resolve_runtime_root(load_registry(registry_path))
+        payload = build_state_backup_plan(
+            project=Path(args.project).expanduser(),
+            runtime_root=runtime_root,
+            output_dir=Path(args.output_dir).expanduser() if args.output_dir else None,
+            backup_id=args.backup_id,
+            include_automations=not bool(args.no_automations),
+            include_skills=not bool(args.no_skills),
+            include_registry_projects=not bool(args.current_project_only),
+        )
+        if args.execute:
+            payload = execute_state_backup_plan(payload)
+    except Exception as exc:
+        payload = {
+            "ok": False,
+            "schema_version": "loopx_state_backup_v0",
+            "mode": "state_backup",
+            "dry_run": not bool(getattr(args, "execute", False)),
+            "execute_requested": bool(getattr(args, "execute", False)),
+            "error": str(exc),
+            "recommended_action": "fix backup planning before retrying",
+        }
+    print_payload(payload, output_format(args), render_state_backup_markdown)
+    return 0 if payload.get("ok") else 1

--- a/loopx/cli_commands/support_control_chat_endpoint.py
+++ b/loopx/cli_commands/support_control_chat_endpoint.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+from ..chat_endpoints import AgentEndpointRegistry
+from ..history import load_registry
+from ..paths import resolve_runtime_root
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+AddFormat = Callable[[argparse.ArgumentParser], None]
+
+
+def register_chat_endpoint_command(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+    add_subcommand_format: AddFormat,
+) -> None:
+    parser = subparsers.add_parser(
+        "chat-endpoint",
+        help="Manage owner-local ACP Agent bindings used by LoopX Chat.",
+    )
+    add_subcommand_format(parser)
+    parser.add_argument("action", choices=("list", "add", "remove"))
+    parser.add_argument(
+        "--config", help="Private JSON endpoint definition used by the add action."
+    )
+    parser.add_argument("--agent-id", help="Custom Agent id used by the remove action.")
+
+
+def handle_chat_endpoint_command(
+    args: argparse.Namespace,
+    *,
+    registry_path: Path,
+    print_payload: PrintPayload,
+) -> int:
+    try:
+        registry = load_registry(registry_path) if registry_path.exists() else {}
+        runtime_root = resolve_runtime_root(
+            registry,
+            args.runtime_root,
+            registry_path=registry_path,
+        )
+        endpoints = AgentEndpointRegistry(runtime_root / "chat")
+        if args.action == "add":
+            if not args.config:
+                raise ValueError("--config is required for chat-endpoint add")
+            definition = json.loads(
+                Path(args.config).expanduser().resolve().read_text(encoding="utf-8")
+            )
+            if not isinstance(definition, dict):
+                raise ValueError("Agent endpoint config must be a JSON object")
+            endpoint = endpoints.upsert(definition)
+            payload: dict[str, object] = {
+                "ok": True,
+                "schema_version": "loopx_chat_endpoint_binding_v1",
+                "action": "added",
+                "endpoint": endpoint.public_summary(),
+            }
+        elif args.action == "remove":
+            if not args.agent_id:
+                raise ValueError("--agent-id is required for chat-endpoint remove")
+            deleted = endpoints.delete(args.agent_id)
+            payload = {
+                "ok": deleted,
+                "schema_version": "loopx_chat_endpoint_binding_v1",
+                "action": "removed" if deleted else "not_found",
+                "agent_id": args.agent_id,
+            }
+        else:
+            payload = {
+                "ok": True,
+                "schema_version": "loopx_chat_endpoint_list_v1",
+                "endpoints": [
+                    endpoint.public_summary() for endpoint in endpoints.list()
+                ],
+            }
+    except Exception as exc:
+        payload = {
+            "ok": False,
+            "schema_version": "loopx_chat_endpoint_binding_v1",
+            "error": str(exc),
+        }
+    print_payload(
+        payload,
+        args.format,
+        lambda item: json.dumps(item, ensure_ascii=False, indent=2),
+    )
+    return 0 if payload.get("ok") else 1

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -652,11 +652,15 @@ def handle_todo_command(
                 validation_label=args.validation_label,
                 validation_timeout_seconds=args.validation_timeout_seconds,
                 monitor_metadata={
-                    "target_key": args.monitor_target_key,
-                    "cadence": args.cadence,
-                    "next_due_at": args.next_due_at,
-                    "expires_at": args.expires_at,
-                    "watch_only": "true" if args.watch_only else None,
+                    key: value
+                    for key, value in {
+                        "target_key": args.monitor_target_key,
+                        "cadence": args.cadence,
+                        "next_due_at": args.next_due_at,
+                        "expires_at": args.expires_at,
+                        "watch_only": "true" if args.watch_only else None,
+                    }.items()
+                    if value is not None
                 },
                 **_todo_path_args(args),
                 dry_run=bool(args.dry_run),
@@ -729,11 +733,15 @@ def handle_todo_command(
                 clear_resume_when=bool(args.clear_resume_when),
                 no_followup=True if args.no_follow_up else None,
                 monitor_metadata={
-                    "target_key": args.monitor_target_key,
-                    "cadence": args.cadence,
-                    "next_due_at": args.next_due_at,
-                    "expires_at": args.expires_at,
-                    "watch_only": "true" if args.watch_only else None,
+                    key: value
+                    for key, value in {
+                        "target_key": args.monitor_target_key,
+                        "cadence": args.cadence,
+                        "next_due_at": args.next_due_at,
+                        "expires_at": args.expires_at,
+                        "watch_only": "true" if args.watch_only else None,
+                    }.items()
+                    if value is not None
                 },
                 clear_claim=bool(args.clear_claim),
                 **_todo_path_args(args),

--- a/loopx/control_plane/testing/cli_output_budget.py
+++ b/loopx/control_plane/testing/cli_output_budget.py
@@ -634,6 +634,12 @@ CLI_OUTPUT_COMMAND_CLASSIFICATIONS: tuple[CliOutputCommandClassification, ...] =
         rationale="explicit provider setup, sync, doctor, and gate-notification command family",
     ),
     CliOutputCommandClassification(
+        command_id="goal-lifecycle",
+        qualification="explicit_cold_path_exception",
+        surface_id=None,
+        rationale="explicit operator preview, stop, and resume command family",
+    ),
+    CliOutputCommandClassification(
         command_id="evidence-log",
         qualification="qualified_default",
         surface_id="evidence_log_thin",

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -85,6 +85,10 @@ COMMAND_GROUPS: list[dict[str, object]] = [
                 "purpose": "Set up, inspect, sync, or notify the provider channel bound to one goal.",
             },
             {
+                "command": "loopx goal-lifecycle --help",
+                "purpose": "Preview, stop, or resume a Goal without deleting its history, todos, or evidence.",
+            },
+            {
                 "command": "loopx evidence-log --goal-id <goal-id> --agent-id <agent-id> --thin",
                 "purpose": "Read the current agent's thin public-safe ledger before replan or handoff.",
             },

--- a/man/loopx.1
+++ b/man/loopx.1
@@ -75,6 +75,9 @@ Render a handoff or review packet with any required evidence\-log reads.
 \fBloopx goal\-channel \-\-help\fR
 Set up, inspect, sync, or notify the provider channel bound to one goal.
 .TP
+\fBloopx goal\-lifecycle \-\-help\fR
+Preview, stop, or resume a Goal without deleting its history, todos, or evidence.
+.TP
 \fBloopx evidence\-log \-\-goal\-id <goal\-id> \-\-agent\-id <agent\-id> \-\-thin\fR
 Read the current agent's thin public\-safe ledger before replan or handoff.
 .TP


### PR DESCRIPTION
## Summary

Prepare the exact `v0.5.0` source tree for release by closing the remaining public-smoke and command-ownership gaps found during the release qualification sweep.

- extract goal lifecycle, host-poll receipt, state-backup, and chat-endpoint command owners from oversized CLI modules without changing their public contracts;
- preserve monitor expiry on partial todo updates, reject raw absolute repository references before compaction, and keep no-scan onboarding routing with the connected domain adapter;
- update durable dashboard/review-packet smoke semantics and expand the five-shard public-smoke workflow from 500 to 550 slots for the current 501-check inventory;
- raise the per-smoke workflow timeout to 360 seconds so legitimate deep public checks are not cut off by the runner envelope.

## Product and architecture judgment

The release sweep exposed two different issues: real control-plane edge cases and stale validation ownership. The runtime fixes stay at their existing typed boundaries, while the CLI extraction moves cohesive command families into named owners instead of adding a generic helper layer. The smoke changes remove coupling to a retired dashboard implementation and keep the independent contract assertions in `action-packet.ts` and the Personal Workspace read model.

No permission boundary, benchmark scoring/task semantics, default capability activation, or production action authority changes in this PR.

## Validation

- changed-path Ruff, strict configured mypy, focused mypy for the four extracted modules, and Python compile checks;
- focused CLI, quota, todo, state-backup, chat-endpoint, onboarding, issue-fix, dashboard projection, public-boundary, and module-size smokes;
- full pytest on the exact PR head;
- `loopx change-quality` strict exact-scope receipt and `loopx canary premerge --from-git-diff --goal-id loopx-meta` before merge;
- after merge, the five-shard `full-public-smokes` workflow is the canonical same-SHA 501-check release hold.

## Release hold

Do not tag or publish `v0.5.0` until the merge commit's full-public workflow is green. The final release body, artifacts, attestations, stable ref, and PyPI publication will all be verified against that exact merge commit.
