### PR TITLE
fix(smoke): validate dashboard PWA source contract

### DIFF
--- a/examples/dashboard-pwa-bundle-smoke.py
+++ b/examples/dashboard-pwa-bundle-smoke.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verify both shipped dashboard entrypoints expose the shared PWA contract."""
+"""Verify dashboard source assets and shipped bundles expose the PWA contract."""
 
 from __future__ import annotations
 
@@ -8,21 +8,27 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-ROOT_BUNDLE = REPO_ROOT / "apps" / "presentation" / "dashboard" / "dist"
+ROOT_SOURCE = REPO_ROOT / "apps" / "presentation" / "dashboard"
+ROOT_BUNDLE = ROOT_SOURCE / "dist"
 CHAT_BUNDLE = REPO_ROOT / "loopx" / "web" / "chat"
 
 
-def assert_pwa_bundle(label: str, bundle: Path, manifest_href: str) -> None:
-    index = bundle / "index.html"
-    manifest_path = bundle / "manifest.webmanifest"
-    icon_192 = bundle / "pwa" / "icon-192.png"
-    icon_512 = bundle / "pwa" / "icon-512.png"
-
+def assert_pwa_contract(
+    label: str,
+    *,
+    index: Path,
+    asset_root: Path,
+    manifest_href: str,
+) -> None:
     assert index.is_file(), f"{label}: missing {index}"
     index_text = index.read_text(encoding="utf-8")
     assert f'<link rel="manifest" href="{manifest_href}" />' in index_text, (
         f"{label}: index does not reference {manifest_href}"
     )
+
+    manifest_path = asset_root / "manifest.webmanifest"
+    icon_192 = asset_root / "pwa" / "icon-192.png"
+    icon_512 = asset_root / "pwa" / "icon-512.png"
     assert manifest_path.is_file(), f"{label}: missing {manifest_path}"
     assert icon_192.is_file(), f"{label}: missing {icon_192}"
     assert icon_512.is_file(), f"{label}: missing {icon_512}"
@@ -37,8 +43,28 @@ def assert_pwa_bundle(label: str, bundle: Path, manifest_href: str) -> None:
     ], manifest
 
 
+def assert_pwa_bundle(label: str, bundle: Path, manifest_href: str) -> None:
+    assert_pwa_contract(
+        label,
+        index=bundle / "index.html",
+        asset_root=bundle,
+        manifest_href=manifest_href,
+    )
+
+
 def main() -> int:
-    assert_pwa_bundle("root dashboard", ROOT_BUNDLE, "manifest.webmanifest")
+    # The full-public suite is Python-only and starts from a clean checkout, so
+    # the ignored Vite output is not guaranteed to exist. Always validate the
+    # tracked build inputs; the dedicated frontstage build job proves that Vite
+    # can produce the root bundle. When a local build is present, validate it too.
+    assert_pwa_contract(
+        "root dashboard source",
+        index=ROOT_SOURCE / "index.html",
+        asset_root=ROOT_SOURCE / "public",
+        manifest_href="manifest.webmanifest",
+    )
+    if ROOT_BUNDLE.is_dir():
+        assert_pwa_bundle("root dashboard bundle", ROOT_BUNDLE, "manifest.webmanifest")
     assert_pwa_bundle("chat dashboard", CHAT_BUNDLE, "/chat/manifest.webmanifest")
     print("dashboard-pwa-bundle-smoke ok")
     return 0


### PR DESCRIPTION
## Summary

- validate tracked dashboard PWA build inputs in clean Python-only checkouts
- continue validating the packaged chat bundle on every run
- validate the ignored root Vite bundle too when a local build has produced it

## Why

The post-merge full-public sweep for `3ea26af4` failed because the PWA smoke required `apps/presentation/dashboard/dist/index.html`, but that ignored Vite output is not present in the workflow's clean Python-only checkout. The dedicated frontstage build remains the build oracle; this smoke now owns the source/package contract without adding an undeclared network build to the full-public runner.

## Validation

- clean checkout without `dist/`: `python examples/dashboard-pwa-bundle-smoke.py`
- `npm ci --ignore-scripts`
- `npm run build`
- `npm run smoke:pwa-bundle`
- exact failed shard: 110/110 passed, 0 failures, 0 timeouts, 0 warnings, 0 tracked side effects
- Ruff, Python compile, diff check, public/private marker scan
- LoopX change-quality receipt `cqr_1c919bdaf278711ce6d0`
- risk-based pre-merge canary: 4/4 passed, 0 manual holds, self-merge allowed

No credentials, private state, local paths, generated bundles, or raw run evidence are included.
