### PR TITLE
chore(release): normalize public diff hygiene

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Vite bundles may retain whitespace-only lines inside generated template literals.
+loopx/web/chat/assets/*.js whitespace=-blank-at-eol

--- a/docs/guides/personal-workspace-user-guide.md
+++ b/docs/guides/personal-workspace-user-guide.md
@@ -34,11 +34,11 @@ loopx dashboard
 graph TD
     A[LoopX 控制台] --> B[LoopX 管家模式 (全局总览)]
     A --> C[Goal 频道模式 (单一目标深度)]
-    
+
     B --> B1[你不在的时候 (离线统计)]
     B --> B2[4 泳道任务流 (需要你 / 执行中 / 观察中 / 已安排)]
     B --> B3[全局快捷问询与创建 Goal]
-    
+
     C --> C1[Tasks 4 列看板]
     C --> C2[Chat 完整对话流]
     C --> C3[Files 产出交付物]


### PR DESCRIPTION
## Summary

- remove two whitespace-only lines from the public Personal Workspace guide
- classify whitespace-only lines retained inside generated Vite JavaScript template literals with a path-scoped Git attribute

## Why

The exact `v0.4.9...v0.5.0` release-range canary passed all 18 semantic checks but failed its direct `git diff --check`: two Markdown lines had trailing spaces and the checked-in generated chat bundle contains whitespace-only lines inside generated template literals. Hand-editing that bundle would be overwritten by the next reproducible Vite build, so the generated path now carries the narrow Git whitespace policy instead.

## Validation

- `git diff --check v0.4.9` passed
- dashboard PWA smoke passed
- personal-workspace docs asset smoke passed (7 assets)
- public boundary check passed
- change-quality receipt `cqr_fd5160a7795f05173703` valid, no risks
- risk-based pre-merge canary: 9/9 passed, 0 failures, 0 manual holds, self-merge allowed

No runtime code, generated bundle content, credentials, private state, local paths, or raw run evidence are included.
