### PR TITLE
fix(pi): pause goal loop after abort

### DIFF
--- a/loopx/pi_goal_mode/README.md
+++ b/loopx/pi_goal_mode/README.md
@@ -10,7 +10,8 @@ into a LoopX-governed visible goal loop.
   and shows the packet as a widget plus a transcript entry. With a goal text
   argument, runs `loopx start-goal --guided --project . --goal-text "<text>"
   --host-surface pi` and places the returned packet in the editor for review.
-  `/loopx resume` re-arms auto-continuation after a user-driven pause.
+  `/loopx resume` re-arms auto-continuation after a user-driven pause or an
+  aborted run.
 - **`loopx_goal_activate`** — agent-callable tool. Binds the current session to
   a LoopX goal (`goalId`, heartbeat `objective`/task_body, optional `agentId`,
   `registryPath`, `availableCapabilities`), then starts the quota-gated loop.
@@ -20,6 +21,11 @@ into a LoopX-governed visible goal loop.
   follow-up), wait with scheduler-hint backoff (unchanged-poll limits apply), or
   stop at a validated terminal no-follow-up. Probe failures fail closed with a
   bounded retry; the extension never self-declares closure.
+- **Abort boundary** — pressing Escape while Pi is running persists
+  `autoResume: false` before `agent_settled`, cancels any pending backoff timer,
+  and fences an in-flight quota probe. For persistent sessions, the loop stays
+  paused across Pi restarts until `/loopx resume` or a fresh goal activation
+  explicitly re-arms it.
 
 ## Install / uninstall
 
@@ -56,9 +62,9 @@ previous run's goal and must activate again through `loopx_goal_activate`.
 
 The extension reads only LoopX public-safe state and never copies raw
 transcripts, credentials, or local session paths. Continuation is governed by
-LoopX quota; user prompts pause auto-resume; `/loopx resume` or re-activation
-re-arms it. No external writes happen without the active LoopX state or owner
-authorization.
+LoopX quota; user prompts and aborted runs pause auto-resume; `/loopx resume`
+or re-activation re-arms it. No external writes happen without the active
+LoopX state or owner authorization.
 
 On `session_shutdown` (session switch, fork, or reload) the extension instance
 is atomically disposed: every timer is cancelled and an in-flight quota probe

--- a/loopx/pi_goal_mode/loopx-goal.ts
+++ b/loopx/pi_goal_mode/loopx-goal.ts
@@ -31,6 +31,7 @@ import {
   createBindingStore,
   createEphemeralSessionIdentity,
   createGoalLoop,
+  hasAbortedAssistantMessage,
   sessionKey,
 } from "./pi-goal-loop-runtime.mjs";
 
@@ -235,6 +236,16 @@ export default function (pi: ExtensionAPI) {
   pi.on("agent_settled", async (_event, ctx) => {
     const { key } = bindContext(ctx);
     await loop.settle(key);
+  });
+
+  // Escape aborts the active Pi run with an assistant stopReason of
+  // "aborted". Persist the pause during agent_end, before agent_settled can
+  // ask LoopX for another continuation. The owner must explicitly run
+  // `/loopx resume` (or activate a goal again) to re-arm the loop.
+  pi.on("agent_end", async (event, ctx) => {
+    if (!hasAbortedAssistantMessage(event.messages)) return;
+    const { key } = bindContext(ctx);
+    await loop.interrupt(key);
   });
 
   // User-driven prompts pause the auto loop; only prompts we injected for the

--- a/loopx/pi_goal_mode/pi-goal-loop-runtime.mjs
+++ b/loopx/pi_goal_mode/pi-goal-loop-runtime.mjs
@@ -93,7 +93,19 @@ function casMatches(current, expected) {
   if (expected.goalId !== undefined && (current?.goalId || "") !== expected.goalId) {
     return false
   }
+  if (expected.autoResume !== undefined && current?.autoResume !== expected.autoResume) {
+    return false
+  }
   return true
+}
+
+// Pi emits only messages created by the just-finished run in agent_end. An
+// assistant message with stopReason=aborted is the durable signal that the
+// owner pressed Escape (or otherwise aborted the active run), so the host
+// adapter must pause before agent_settled can evaluate another continuation.
+export function hasAbortedAssistantMessage(messages) {
+  return Array.isArray(messages) &&
+    messages.some((message) => message?.role === "assistant" && message?.stopReason === "aborted")
 }
 
 // File-backed binding store scoped to one project. Bindings live under the
@@ -381,7 +393,7 @@ export function createGoalLoop(options) {
     // the persisted generation and rejects the stale commit.
     const capturedGen = binding.generation || 0
     const capturedGoalId = binding.goalId
-    const expected = { generation: capturedGen, goalId: capturedGoalId }
+    const expected = { generation: capturedGen, goalId: capturedGoalId, autoResume: true }
 
     let decision
     try {
@@ -549,6 +561,29 @@ export function createGoalLoop(options) {
         if (disposed || epoch !== instanceEpoch) return
         cancelScheduled(key)
       }
+    },
+    async interrupt(key) {
+      if (disposed) return null
+      const instanceEpoch = epoch
+      const services = contexts.get(key)
+      if (!services) return null
+      let binding = null
+      try {
+        binding = await services.store.read(key)
+      } catch {
+        return null
+      }
+      if (disposed || epoch !== instanceEpoch) return null
+      if (!binding || binding.terminal) return binding
+      const expected = { generation: binding.generation || 0, goalId: binding.goalId }
+      const committed = await services.store.write(key, { autoResume: false }, expected)
+      if (!committed || disposed || epoch !== instanceEpoch) return committed
+      cancelScheduled(key)
+      services.notify(
+        `LoopX goal ${committed.goalId} auto-continuation paused after abort; run /loopx resume to continue.`,
+        "info",
+      )
+      return committed
     },
     async resume(key) {
       if (disposed) return null

--- a/tests/pi_goal_loop_runtime.test.mjs
+++ b/tests/pi_goal_loop_runtime.test.mjs
@@ -11,6 +11,7 @@ import {
   createEphemeralSessionIdentity,
   createGoalLoop,
   createMemoryBindingStore,
+  hasAbortedAssistantMessage,
   sanitizedKey,
   sessionKey,
   waitPlan,
@@ -34,6 +35,9 @@ function memoryBindingStore() {
           return null
         }
         if (expected.goalId !== undefined && (current.goalId || "") !== expected.goalId) {
+          return null
+        }
+        if (expected.autoResume !== undefined && current.autoResume !== expected.autoResume) {
           return null
         }
       }
@@ -282,6 +286,65 @@ test("a user-driven prompt pauses auto-resume and cancels the scheduled timer", 
 })
 
 
+test("an aborted Pi run pauses durably and cancels the scheduled timer", async () => {
+  const fixture = harness(backoffDecision())
+  fixture.loop.bind("session-abort", fixture.services)
+  await fixture.activate("session-abort")
+  await fixture.loop.settle("session-abort")
+  assert.equal(fixture.scheduled.length, 1)
+
+  await fixture.loop.interrupt("session-abort")
+
+  const binding = await fixture.store.read("session-abort")
+  assert.equal(binding.autoResume, false)
+  assert.equal(fixture.scheduled[0].cleared, true)
+
+  const probesBefore = fixture.calls.quota
+  await fixture.loop.settle("session-abort")
+  assert.equal(fixture.calls.quota, probesBefore)
+
+  fixture.setDecision({ should_run: true, scheduler_hint: { action: "run_now" } })
+  await fixture.loop.resume("session-abort")
+  await fixture.loop.settle("session-abort")
+  assert.equal(fixture.calls.quota, probesBefore + 1)
+  assert.equal(fixture.calls.send, 1)
+})
+
+
+test("agent_end abort detection ignores non-aborted and non-assistant messages", () => {
+  assert.equal(hasAbortedAssistantMessage(null), false)
+  assert.equal(hasAbortedAssistantMessage([{ role: "assistant", stopReason: "stop" }]), false)
+  assert.equal(hasAbortedAssistantMessage([{ role: "user", stopReason: "aborted" }]), false)
+  assert.equal(
+    hasAbortedAssistantMessage([
+      { role: "toolResult", content: [] },
+      { role: "assistant", stopReason: "aborted" },
+    ]),
+    true,
+  )
+})
+
+
+test("auto-resume compare-and-swap rejects a continuation write after pause", async () => {
+  const store = createMemoryBindingStore()
+  await store.write("session-cas-pause", {
+    goalId: "goal-cas-pause",
+    generation: 1,
+    autoResume: true,
+  })
+  await store.write("session-cas-pause", { autoResume: false })
+
+  const committed = await store.write(
+    "session-cas-pause",
+    { lastInjectedPrompt: "must-not-send" },
+    { generation: 1, goalId: "goal-cas-pause", autoResume: true },
+  )
+
+  assert.equal(committed, null)
+  assert.equal((await store.read("session-cas-pause")).lastInjectedPrompt, "")
+})
+
+
 test("an injected follow-up prompt keeps auto-resume armed", async () => {
   const fixture = harness({ should_run: true, scheduler_hint: { action: "run_now" } })
   fixture.loop.bind("session-injected", fixture.services)
@@ -362,6 +425,30 @@ test("user intervention during an in-flight probe stops continuation", async () 
 })
 
 
+test("abort during an in-flight probe fences the pending continuation", async () => {
+  let releaseDecision
+  const pendingDecision = new Promise((resolve) => {
+    releaseDecision = resolve
+  })
+  const fixture = harness(pendingDecision)
+  fixture.loop.bind("session-abort-race", fixture.services)
+  await fixture.activate("session-abort-race")
+  const settled = fixture.loop.settle("session-abort-race")
+  for (let index = 0; index < 5 && fixture.calls.quota === 0; index += 1) {
+    await Promise.resolve()
+  }
+  assert.equal(fixture.calls.quota, 1)
+
+  await fixture.loop.interrupt("session-abort-race")
+  releaseDecision({ should_run: true, scheduler_hint: { action: "run_now" } })
+  await settled
+
+  assert.equal(fixture.calls.send, 0)
+  assert.equal(fixture.scheduled.length, 0)
+  assert.equal((await fixture.store.read("session-abort-race")).autoResume, false)
+})
+
+
 test("coalesces concurrent settles into one quota decision", async () => {
   let releaseDecision
   const pendingDecision = new Promise((resolve) => {
@@ -434,6 +521,38 @@ test("binding store round-trips through the filesystem and retires cleanly", asy
     await store.remove(key)
     assert.equal(await store.read(key), null)
     await store.remove(key)
+  } finally {
+    await fs.rm(root, { recursive: true, force: true })
+  }
+})
+
+
+test("an abort pause survives runtime replacement for a persistent session", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-goal-loop-abort-"))
+  try {
+    const store = createBindingStore(root)
+    const first = harness({ should_run: true, scheduler_hint: { action: "run_now" } })
+    first.loop.bind("session-persisted-abort", {
+      ...first.services,
+      store,
+    })
+    await first.loop.activate("session-persisted-abort", {
+      goalId: "goal-persisted-abort",
+      taskBody: "persisted body",
+    })
+    await first.loop.interrupt("session-persisted-abort")
+    first.loop.dispose()
+
+    const second = harness({ should_run: true, scheduler_hint: { action: "run_now" } })
+    second.loop.bind("session-persisted-abort", {
+      ...second.services,
+      store,
+    })
+    await second.loop.settle("session-persisted-abort")
+
+    assert.equal(second.calls.quota, 0)
+    assert.equal(second.calls.send, 0)
+    assert.equal((await store.read("session-persisted-abort")).autoResume, false)
   } finally {
     await fs.rm(root, { recursive: true, force: true })
   }

--- a/tests/test_slash_command_install.py
+++ b/tests/test_slash_command_install.py
@@ -506,6 +506,8 @@ def test_pi_install_writes_self_contained_extension_into_project(
     assert 'pi.registerCommand("loopx"' in text
     assert "loopx_goal_activate" in text
     assert "agent_settled" in text
+    assert 'pi.on("agent_end"' in text
+    assert "hasAbortedAssistantMessage" in text
     assert "pi.on(\"session_shutdown\"" in text
     assert "loop.dispose()" in text
     # The quota/wait/store loop core lives in the sibling runtime module so it


### PR DESCRIPTION
Closes #3381.

## Summary

- detect Pi `agent_end` runs whose assistant message ended with `stopReason: "aborted"`
- persist `autoResume: false` before `agent_settled`, cancel pending timers, and fence in-flight continuation writes with the existing compare-and-swap contract
- keep the goal paused across persistent-session restarts until `/loopx resume` or a fresh activation
- document the abort boundary and keep the packaged Pi extension contract covered

## Validation

- `node --test tests/pi_goal_loop_runtime.test.mjs` — 34 passed
- `pytest -q tests/test_slash_command_install.py -k pi` — 6 passed
- `loopx check` across all five changed paths — public/private boundary clean
- standard premerge selection — 17 checks passed; the receipt was then requalified after `main` advanced
- final-base quick premerge gate — 4 checks passed, zero failures or manual holds
- change-quality receipt `cqr_739b872e70ba6af56fbc` — valid for the exact final diff

## Boundary

The change stays inside the built-in Pi host adapter and its focused tests/docs. It adds no new scheduler, capability, configuration, credentials, local paths, raw sessions, or generated evidence.
