### PR TITLE
docs(readme): emphasize long-horizon goals in the Personal Agent Workspace section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ to hand off across turns, tools, and agents.
 
 ## Meet the Personal Agent Workspace
 
-Turn scattered agent sessions into one local-first workspace for Goals,
-attention, conversations, tasks, files, schedules, and recovery.
+Keep long-horizon goals in one local-first workspace. Goals, attention,
+conversations, tasks, files, schedules, and recovery stay durable across days,
+restarts, and harnesses, so work that began last week resumes exactly where
+the last bounded turn stopped instead of living in chat memory.
 
 <a href="docs/assets/personal-workspace/loopx-dashboard-launch.mp4">
   <img src="docs/assets/personal-workspace/loopx-dashboard-tour.webp" alt="Animated tour of the LoopX personal Agent workspace, from one-command launch to Manager overview, Goal task board, protected action preview, and Goal details" width="960">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,8 +35,9 @@ LoopX 是开放且 Provider-neutral 的轻量 state kernel，也是 local-first
 
 ## 认识个人 Agent 工作区
 
-把分散的 Agent 会话收进同一个 local-first 工作区，统一管理 Goal、待关注事项、
-对话、任务、文件、定时计划与恢复状态。
+把长程目标收进同一个 local-first 工作区。Goal、待关注事项、对话、任务、
+文件、定时计划与恢复状态跨天数、跨重启、跨 harness 保持持久，上周开始的工作
+会从上一次有界 Turn 停止的地方精确恢复，而不是活在聊天记忆里。
 
 <a href="docs/assets/personal-workspace/loopx-dashboard-launch.mp4">
   <img src="docs/assets/personal-workspace/loopx-dashboard-tour.webp" alt="LoopX 个人 Agent 工作区动画导览：从一键启动，到管家总览、Goal 任务看板、受保护操作预览和 Goal 详情" width="960">


### PR DESCRIPTION
Rewrite the Meet the Personal Agent Workspace opening so the long-horizon framing leads: durable Goals/state across days, restarts, and harnesses, resuming where the last bounded turn stopped rather than living in chat memory. Mirrored in README.zh-CN.md.