### PR TITLE
fix(pi): deliver guided start-goal packet without editor popup

### DIFF
--- a/loopx/pi_goal_mode/README.md
+++ b/loopx/pi_goal_mode/README.md
@@ -9,7 +9,9 @@ into a LoopX-governed visible goal loop.
 - **`/loopx`** — with no arguments, runs `loopx bootstrap-command-pack --project .`
   and shows the packet as a widget plus a transcript entry. With a goal text
   argument, runs `loopx start-goal --guided --project . --goal-text "<text>"
-  --host-surface pi` and places the returned packet in the editor for review.
+  --host-surface pi` and delivers the returned packet directly to the agent as
+  a follow-up user message (`sendUserMessage` with `triggerTurn`), so the
+  guided transaction starts without a popup box or a manual Enter step.
   `/loopx resume` re-arms auto-continuation after a user-driven pause or an
   aborted run.
 - **`loopx_goal_activate`** — agent-callable tool. Binds the current session to

--- a/loopx/pi_goal_mode/loopx-goal.ts
+++ b/loopx/pi_goal_mode/loopx-goal.ts
@@ -156,14 +156,18 @@ export default function (pi: ExtensionAPI) {
       }
       // Start a guided goal for the exact Pi host; the returned packet
       // includes ordered todos and the heartbeat task_body the agent needs.
+      // Deliver the packet straight to the agent as a user message (the same
+      // followUp/triggerTurn pattern the quota loop uses for heartbeat
+      // injection) instead of prefilling the editor: no popup box, no manual
+      // Enter step before the agent follows the ordered transaction.
       try {
         const stdout = await runLoopxCli(
           ["start-goal", "--guided", "--project", ".", "--goal-text", trimmed, "--host-surface", "pi"],
           ctx.cwd,
         );
-        ctx.ui.setEditorText(stdout);
+        pi.sendUserMessage(stdout, { deliverAs: "followUp", triggerTurn: true });
         ctx.ui.notify(
-          "LoopX start-goal packet ready in the editor; review and send it, then the agent calls loopx_goal_activate.",
+          "LoopX start-goal packet delivered to the agent; it will follow the ordered transaction.",
           "info",
         );
       } catch (error) {

--- a/tests/test_pi_goal_mode.py
+++ b/tests/test_pi_goal_mode.py
@@ -39,6 +39,18 @@ def test_pi_extension_registers_command_tool_and_events() -> None:
     assert "sendUserMessage" in text
 
 
+def test_pi_guided_start_goal_delivers_packet_without_editor_box() -> None:
+    text = extension_source()
+    # /loopx <goal text> must hand the guided start-goal packet straight to the
+    # agent (same followUp/triggerTurn pattern as heartbeat injection) instead
+    # of prefilling the editor: no popup box, no manual Enter step before the
+    # agent follows the ordered transaction.
+    assert 'pi.sendUserMessage(stdout, { deliverAs: "followUp", triggerTurn: true })' in text
+    # The editor-prefill flow must not remain anywhere in the extension: it is
+    # the mechanism that pops a box and forces the user to press Enter.
+    assert "setEditorText" not in text
+
+
 def test_pi_extension_disposes_the_loop_on_session_shutdown() -> None:
     adapter = extension_source()
     runtime = runtime_source()


### PR DESCRIPTION
## What

`/loopx <goal text>` in the Pi host previously ran `loopx start-goal --guided` and stuffed the whole guided packet into the editor via `ctx.ui.setEditorText(stdout)`. That made a box pop up listing the task info, and the user had to press **Enter** before the agent would follow the ordered transaction ("switch to the execution window").

## Change

- `loopx/pi_goal_mode/loopx-goal.ts` — the guided branch now delivers the packet straight to the agent with `pi.sendUserMessage(stdout, { deliverAs: "followUp", triggerTurn: true })` — the same followUp/triggerTurn pattern the quota loop already uses for heartbeat injection — plus a compact non-blocking notify. No editor prefill, no popup box, no manual Enter step.
- `tests/test_pi_goal_mode.py` — new `test_pi_guided_start_goal_delivers_packet_without_editor_box` pins the contract: the start-goal path must use the sendUserMessage followUp/triggerTurn form and `setEditorText` must not appear in the extension source.
- `loopx/pi_goal_mode/README.md` — surface section updated to describe the no-Enter guided delivery.

## Validation

- `pytest tests/test_pi_goal_mode.py` → 10 passed (includes the new contract test and the node runtime contract `pi_goal_loop_runtime.test.mjs`).
- `pytest tests/test_slash_command_install.py tests/test_agent_onboarding_pi_host.py` → 40 passed, 1 failed: `test_pi_onboarding_install_command_executes_from_another_cwd` — **pre-existing on main at the base commit** (agent-onboard subprocess env dependency; verified same failure at `344fbe74` with no changes).
- `examples/slash-command-install-smoke.py` → ok.

## Notes

The local `.pi/extensions/` install will be refreshed from this source so the running Pi session picks up the fix (also gains the already-tracked abort-pause feature); that is untracked local state, not part of this PR.