### PR TITLE
fix(install): use the cross-platform file lock for workflow skill install

### DIFF
--- a/loopx/workflow_skill_install.py
+++ b/loopx/workflow_skill_install.py
@@ -10,6 +10,7 @@ import shlex
 import tempfile
 from typing import Any, Iterator, Mapping
 
+from .file_lock import exclusive_file_lock
 from .skill_install_readback import (
     ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS,
     PACKAGED_HOST_SKILL_IDS,
@@ -35,6 +36,9 @@ MANAGED_ENTRY_PREVIEW_STATUSES = {*MANAGED_ENTRY_STATUSES, "would_create"}
 _PACKAGED_SKILL_SENTINEL = PurePosixPath(
     "share/loopx/skills/loopx-project/SKILL.md"
 )
+# `exclusive_file_lock` appends `.lock`, so the sibling it guards keeps the
+# lock file at the path installs have always used.
+_INSTALL_LOCK_STEM = ".loopx-workflow-skills"
 
 
 def _valid_source_root(path: Path) -> bool:
@@ -100,16 +104,12 @@ def default_workflow_skills_dir(env: Mapping[str, str] | None = None) -> Path:
 
 @contextmanager
 def _exclusive_install_lock(skills_dir: Path) -> Iterator[None]:
-    import fcntl
-
     skills_dir.mkdir(parents=True, exist_ok=True)
-    lock_path = skills_dir / ".loopx-workflow-skills.lock"
-    with lock_path.open("a+", encoding="utf-8") as handle:
-        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
-        try:
-            yield
-        finally:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    with exclusive_file_lock(
+        skills_dir / _INSTALL_LOCK_STEM,
+        operation="workflow_skill_install",
+    ):
+        yield
 
 
 def _install_one_skill(source: Path, target: Path) -> str:

--- a/tests/test_workflow_skill_install.py
+++ b/tests/test_workflow_skill_install.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 import json
 from pathlib import Path
+from typing import Any, Iterator
 
+import pytest
+
+from loopx import file_lock
+from loopx import workflow_skill_install as install_module
 from loopx.skill_install_readback import (
     ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS,
     PACKAGED_HOST_SKILL_IDS,
@@ -82,6 +88,67 @@ def test_uninstall_preserves_locally_modified_skill(tmp_path: Path) -> None:
     assert removed["result"]["preserved_modified"] == ["loopx-project"]
     assert modified.is_file()
     assert (skills_dir / SKILL_INSTALL_READBACK_FILENAME).is_file()
+
+
+class _ByteRangeLockBackend:
+    """Stand-in for ``msvcrt`` so the Windows lock branch runs on any host."""
+
+    LK_NBLCK = 1
+    LK_UNLCK = 0
+
+    def __init__(self) -> None:
+        self.modes: list[int] = []
+
+    def locking(self, file_descriptor: int, mode: int, length: int) -> None:
+        self.modes.append(mode)
+
+
+def test_install_takes_the_windows_lock_branch_without_fcntl(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = _ByteRangeLockBackend()
+    monkeypatch.setattr(file_lock, "fcntl", None)
+    monkeypatch.setattr(file_lock, "msvcrt", backend)
+    skills_dir = tmp_path / "skills"
+
+    installed = workflow_skill_install(skills_dir=skills_dir, execute=True)
+
+    assert installed["ok"] is True
+    assert installed["after"]["ready"] is True
+    assert backend.modes == [backend.LK_NBLCK, backend.LK_UNLCK]
+
+
+def test_install_serializes_on_the_shared_workflow_skill_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    skills_dir = tmp_path / "skills"
+    held: list[Path] = []
+    locked: list[Path] = []
+    real_readback = install_module.write_skill_install_readback
+
+    @contextmanager
+    def recording_lock(path: Path, **kwargs: Any) -> Iterator[Path]:
+        locked.append(path)
+        held.append(path)
+        try:
+            yield path
+        finally:
+            held.pop()
+
+    def recording_readback(**kwargs: Any) -> Any:
+        assert held, "the install readback was written outside the lock"
+        return real_readback(**kwargs)
+
+    monkeypatch.setattr(install_module, "exclusive_file_lock", recording_lock)
+    monkeypatch.setattr(install_module, "write_skill_install_readback", recording_readback)
+
+    installed = workflow_skill_install(skills_dir=skills_dir, execute=True)
+
+    assert installed["ok"] is True
+    assert locked == [skills_dir / ".loopx-workflow-skills"]
+    assert held == []
 
 
 def test_inspect_does_not_create_target(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- `_exclusive_install_lock` imported `fcntl` unconditionally, so `loopx workflow-skills --install` aborted on native Windows before doing any work.
- It now goes through `exclusive_file_lock` from `loopx/file_lock.py`, which is where the fcntl/msvcrt contract already lives, so mutual exclusion is preserved rather than dropped on the platform that lacks `fcntl`.
- The lock file stays where it has always been. `exclusive_file_lock` appends `.lock` to the path it guards, so guarding `<skills_dir>/.loopx-workflow-skills` produces `<skills_dir>/.loopx-workflow-skills.lock`.

## Issue Or Task

- Closes #3355
- Contributor task ID:

## Validation

Run on native Windows 11, CPython 3.13.7, no WSL.

- [x] `python -m pytest tests/test_workflow_skill_install.py` -> 6 passed. Two of those four pre-existing tests were failing on Windows before this change, for the same reason the CLI was: `test_install_is_idempotent_and_uninstall_removes_managed_skills` and `test_uninstall_preserves_locally_modified_skill`.
- [x] Every test file that touches `workflow_skill_install`, `file_lock`, `skill_install_readback` or `slash_command_install`: 130 passed, 3 failed, 3 skipped. The same three fail on the unpatched tree, so they are not from this change: `test_file_lock.py::test_stalled_holder_times_out_and_records_independent_incident`, `test_loopx_turn_journal_inspection.py::test_inspection_returns_versioned_allowlisted_projection_without_mutation`, and `test_windows_install.py::test_windows_installer_rolls_back_late_user_surface_failure` (that last one wants `pwsh` on PATH).
- [x] `python -m ruff check` on the touched files and on the paths CONTRIBUTING lists: clean. `python -m mypy`: no issues in 12 source files. `git diff --check`: clean.
- [x] End to end against a scratch `CODEX_HOME`: `workflow-skills --install` succeeds, a second run reports every skill `unchanged` with `entry: unchanged` and `after.ready: true`, `doctor` reports `skill_delivery_status: ready` with all five required skills valid, and `--uninstall` removes them cleanly.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Test update

## LoopX Area

- [ ] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [ ] Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
- [x] Capability or extension (providers, adapters, skills)
- [ ] Public docs or presentation surface (README, protocols, dashboard)
- [ ] Build, packaging, installer, or CI
- [ ] Host or runtime integration

## Technical Direction

- [x] Core control-plane hardening
- [ ] Long-horizon benchmark evidence
- [ ] Operator surface and IM integration
- [ ] Shared Goal Authority and cross-host coordination
- [ ] Architecture and research incubator

- Target base branch: `main`
- Direction tracker or promotion unit:

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).

## Two notes

The coverage follows the triage note about exercising the Windows backend. `test_install_takes_the_windows_lock_branch_without_fcntl` forces `file_lock.fcntl` to `None` and swaps in a byte-range stand-in, so the msvcrt branch is asserted on any host rather than only on Windows CI. `test_install_serializes_on_the_shared_workflow_skill_lock` records the lock and asserts the readback write happens inside the hold and that the guarded path is the historical one.

One behaviour difference worth calling out before review: the old lock was a blocking `flock(LOCK_EX)` with no deadline, while `exclusive_file_lock` uses the `MUTATION` policy's five second timeout and then raises `LockAcquireTimeoutError` with holder information. I kept the shared default rather than passing a custom timeout, since every other caller in the repository does the same and the install itself copies roughly 265 KB of skills, but if you would rather the installer wait longer than a concurrent install can take, that is a one-argument change.

While validating I also hit something unrelated: `tests/test_contract_scan_unreadable_files.py` cannot even be collected on Windows, because a module-level `pytest.mark.skipif` calls `os.geteuid()`, which does not exist there. I left it alone since it is outside this issue.
