### PR TITLE
fix(lark): verify rendered mention readback

### DIFF
--- a/loopx/extensions/lark/docs/lark-event-inbox.md
+++ b/loopx/extensions/lark/docs/lark-event-inbox.md
@@ -324,11 +324,12 @@ enabling this capability does not grant reviewer-notification or other
 outbound authority.
 
 For text replies containing Lark `<at user_id="...">...</at>` mentions, provider
-readback may replace the markup with tokens such as `@_user_1`. Verification
-therefore compares the normalized visible-text template and requires every
-mention token to resolve to the identity requested at send time. A missing,
-extra, or differently resolved mention remains `sent_unverified`; display-name
-or raw-markup similarity alone is not accepted.
+readback may replace the markup with tokens such as `@_user_1` or render the
+visible body as `@Display Name` while retaining the token in structured mention
+metadata. Verification therefore compares the normalized visible-text template
+and requires every mention to resolve to the identity requested at send time.
+A missing, extra, ambiguous, or differently resolved mention remains
+`sent_unverified`; display-name or raw-markup similarity alone is not accepted.
 
 ## Bounded history reconciliation
 

--- a/loopx/extensions/lark/inbox_reply.py
+++ b/loopx/extensions/lark/inbox_reply.py
@@ -140,7 +140,7 @@ def _canonical_expected_text(text: str) -> tuple[str, dict[str, str]]:
     def replace(match: re.Match[str]) -> str:
         identity = match.group("identity").strip()
         token = identity_tokens.setdefault(
-            identity, f"\x1fmention:{len(identity_tokens)}\x1f"
+            identity, f"\x00mention:{len(identity_tokens)}\x00"
         )
         return token
 
@@ -161,6 +161,10 @@ def _readback_matches_reply(
     if not isinstance(mentions, list):
         return False
     matched_identities: set[str] = set()
+    keys_by_identity: dict[str, set[str]] = {}
+    display_text_by_identity: dict[str, set[str]] = {}
+    key_owners: dict[str, set[str]] = {}
+    display_text_owners: dict[str, set[str]] = {}
     for mention in mentions:
         if not isinstance(mention, Mapping):
             return False
@@ -169,12 +173,38 @@ def _readback_matches_reply(
         if not key or len(matches) != 1:
             return False
         identity = next(iter(matches))
-        actual_text = actual_text.replace(key, identity_tokens[identity])
         matched_identities.add(identity)
-    return (
-        matched_identities == set(identity_tokens)
-        and " ".join(actual_text.split()) == expected_text
-    )
+        keys_by_identity.setdefault(identity, set()).add(key)
+        key_owners.setdefault(key, set()).add(identity)
+        display_name = str(mention.get("name") or "").strip()
+        if display_name:
+            display_text = f"@{display_name}"
+            display_text_by_identity.setdefault(identity, set()).add(display_text)
+            display_text_owners.setdefault(display_text, set()).add(identity)
+    if matched_identities != set(identity_tokens):
+        return False
+    if any(len(owners) != 1 for owners in key_owners.values()):
+        return False
+
+    for identity, token in identity_tokens.items():
+        expected_count = expected_text.count(token)
+        for key in sorted(keys_by_identity.get(identity, ()), key=len, reverse=True):
+            actual_text = actual_text.replace(key, token)
+        remaining_count = expected_count - actual_text.count(token)
+        if remaining_count < 0:
+            return False
+        if remaining_count == 0:
+            continue
+        rendered_candidates = [
+            display_text
+            for display_text in display_text_by_identity.get(identity, ())
+            if display_text_owners.get(display_text) == {identity}
+            and actual_text.count(display_text) == remaining_count
+        ]
+        if len(rendered_candidates) != 1:
+            return False
+        actual_text = actual_text.replace(rendered_candidates[0], token)
+    return " ".join(actual_text.split()) == expected_text
 
 
 def _result(

--- a/tests/extensions/test_lark_inbox_reactions.py
+++ b/tests/extensions/test_lark_inbox_reactions.py
@@ -124,10 +124,14 @@ class ReplyRunner:
         *,
         matching_readback: bool = True,
         fail_reaction_delete: bool = False,
+        readback_text: str | None = None,
+        readback_mentions: list[dict[str, Any]] | None = None,
     ) -> None:
         self.calls: list[list[str]] = []
         self.matching_readback = matching_readback
         self.fail_reaction_delete = fail_reaction_delete
+        self.readback_text = readback_text
+        self.readback_mentions = readback_mentions
 
     def __call__(self, args: Sequence[str]) -> dict[str, Any]:
         call = list(args)
@@ -157,21 +161,22 @@ class ReplyRunner:
                 "stderr": "",
             }
         if "+messages-mget" in call:
+            message: dict[str, Any] = {
+                "message_id": "om_reply_fixture",
+                "content": (
+                    self.readback_text
+                    if self.readback_text is not None
+                    else "处理完成"
+                    if self.matching_readback
+                    else "provider returned different text"
+                ),
+            }
+            if self.readback_mentions is not None:
+                message["mentions"] = self.readback_mentions
             return {
                 "returncode": 0,
                 "stdout": json.dumps(
-                    {
-                        "items": [
-                            {
-                                "message_id": "om_reply_fixture",
-                                "content": (
-                                    "处理完成"
-                                    if self.matching_readback
-                                    else "provider returned different text"
-                                ),
-                            }
-                        ]
-                    },
+                    {"items": [message]},
                     ensure_ascii=False,
                 ),
                 "stderr": "",
@@ -411,6 +416,74 @@ def test_verified_reply_removes_processing_reaction(tmp_path: Path) -> None:
         )
         == {}
     )
+
+
+def test_verified_reply_accepts_provider_token_or_rendered_mention_name(
+    tmp_path: Path,
+) -> None:
+    config, _, project = _fixture(tmp_path, lifecycle=False)
+    for readback_text in (
+        "@_user_1 please review",
+        "@Public Reviewer please review",
+    ):
+        runner = ReplyRunner(
+            readback_text=readback_text,
+            readback_mentions=[
+                {
+                    "key": "@_user_1",
+                    "name": "Public Reviewer",
+                    "id": {"open_id": "ou_public_reviewer"},
+                }
+            ],
+        )
+
+        result = reply_lark_event_inbox(
+            project=project,
+            config_path=config,
+            message_id="om_reaction_fixture",
+            text=(
+                '<at open_id="ou_public_reviewer">Public Reviewer</at> '
+                "please review"
+            ),
+            execute=True,
+            runner=runner,
+        )
+
+        assert result["ok"] is True
+        assert result["status"] == "sent_verified"
+        assert result["reply_verified"] is True
+
+
+def test_rendered_mention_name_does_not_override_identity_mismatch(
+    tmp_path: Path,
+) -> None:
+    config, _, project = _fixture(tmp_path, lifecycle=False)
+    runner = ReplyRunner(
+        readback_text="@Public Reviewer please review",
+        readback_mentions=[
+            {
+                "key": "@_user_1",
+                "name": "Public Reviewer",
+                "id": {"open_id": "ou_different_reviewer"},
+            }
+        ],
+    )
+
+    result = reply_lark_event_inbox(
+        project=project,
+        config_path=config,
+        message_id="om_reaction_fixture",
+        text=(
+            '<at open_id="ou_public_reviewer">Public Reviewer</at> '
+            "please review"
+        ),
+        execute=True,
+        runner=runner,
+    )
+
+    assert result["ok"] is False
+    assert result["status"] == "sent_unverified"
+    assert result["reply_verified"] is False
 
 
 def test_unverified_reply_preserves_processing_reaction(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- preserve semantic verification when Lark readback returns the raw mention token
- accept a provider-rendered `@Display Name` only when structured mention metadata resolves to the exact identity requested at send time
- fail closed on missing, extra, ambiguous, or mismatched mention identities
- keep the internal canonical mention sentinel intact during whitespace normalization

## Why

Lark may render a reply body with a display name while retaining the original `@_user_N` token only in structured mention metadata. Comparing the visible body only to that token can mark a successfully delivered reply as unverified. The verifier now reconciles both representations against the same structured identity contract.

## Validation

- `python3 -m pytest -q tests/extensions/test_lark_inbox_reactions.py tests/extensions/test_lark_goal_topic_runtime.py tests/extensions/test_lark_goal_topic_connections.py` (47 passed)
- `git diff --check`
- `loopx check --scan-root .` (0 errors; public boundary scan clean)