### PR TITLE
fix(goals): stop orphaned global projections

### DIFF
--- a/loopx/control_plane/goals/activation_service.py
+++ b/loopx/control_plane/goals/activation_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +22,42 @@ from .configure_goal_service import resolve_configure_goal_sync_target
 
 GOAL_ACTIVATION_TRANSITION_SCHEMA_VERSION = "loopx_goal_activation_transition_v1"
 GOAL_ACTIVATION_READBACK_SCHEMA_VERSION = "loopx_goal_activation_readback_v1"
+GOAL_ACTIVATION_AUTHORITY_ROUTE_SCHEMA_VERSION = (
+    "loopx_goal_activation_authority_route_v1"
+)
+
+
+class GoalActivationAuthorityRouteMode(str, Enum):
+    SOURCE_TO_GLOBAL = "source_to_global"
+    REQUESTED_TO_GLOBAL = "requested_to_global"
+    ORPHANED_GLOBAL_STOP_FALLBACK = "orphaned_global_stop_fallback"
+
+
+class GoalActivationSourceStatus(str, Enum):
+    AVAILABLE = "available"
+    REGISTRY_MISSING = "registry_missing"
+    REGISTRY_UNREADABLE = "registry_unreadable"
+    GOAL_MISSING = "goal_missing"
+
+
+@dataclass(frozen=True, slots=True)
+class GoalActivationAuthorityRoute:
+    source_registry: Path
+    target_registry: Path
+    sync_runtime_root: str | None
+    mode: GoalActivationAuthorityRouteMode
+    source_status: GoalActivationSourceStatus
+
+    def public_summary(self) -> dict[str, Any]:
+        orphaned = (
+            self.mode is GoalActivationAuthorityRouteMode.ORPHANED_GLOBAL_STOP_FALLBACK
+        )
+        return {
+            "schema_version": GOAL_ACTIVATION_AUTHORITY_ROUTE_SCHEMA_VERSION,
+            "mode": self.mode.value,
+            "source_status": self.source_status.value,
+            "resume_requires_source_repair": orphaned,
+        }
 
 
 def _same_path(left: Path, right: Path) -> bool:
@@ -43,30 +81,97 @@ def _goal(payload: dict[str, Any], goal_id: str) -> dict[str, Any]:
     return goal
 
 
+def _goal_or_none(
+    payload: dict[str, Any],
+    goal_id: str,
+) -> dict[str, Any] | None:
+    return next(
+        (
+            item
+            for item in registry_goals(payload)
+            if str(item.get("id") or "") == goal_id
+        ),
+        None,
+    )
+
+
+def _is_global_registry(path: Path, payload: dict[str, Any]) -> bool:
+    role = str(payload.get("registry_role") or payload.get("role") or "")
+    return role == "global-local" or path.name == "registry.global.json"
+
+
+def _source_status(
+    source_registry: Path,
+    *,
+    goal_id: str,
+) -> GoalActivationSourceStatus:
+    if not source_registry.exists():
+        return GoalActivationSourceStatus.REGISTRY_MISSING
+    try:
+        source_payload = load_registry(source_registry)
+    except (OSError, UnicodeError, ValueError):
+        return GoalActivationSourceStatus.REGISTRY_UNREADABLE
+    if _goal_or_none(source_payload, goal_id) is None:
+        return GoalActivationSourceStatus.GOAL_MISSING
+    return GoalActivationSourceStatus.AVAILABLE
+
+
 def _source_and_target(
     *,
     registry_path: Path,
     goal_id: str,
+    target_state: GoalActivationState,
     runtime_root_override: str | None,
-) -> tuple[Path, Path, str | None]:
+) -> GoalActivationAuthorityRoute:
     requested_registry = registry_path.expanduser().resolve()
-    requested_goal = _goal(load_registry(requested_registry), goal_id)
+    requested_payload = load_registry(requested_registry)
+    requested_goal = _goal(requested_payload, goal_id)
     source_ref = str(requested_goal.get("source_registry") or "").strip()
     if source_ref:
         source_registry = Path(source_ref).expanduser().resolve()
-        _goal(load_registry(source_registry), goal_id)
-        return source_registry, requested_registry, str(requested_registry.parent)
+        source_status = _source_status(source_registry, goal_id=goal_id)
+        if source_status is GoalActivationSourceStatus.AVAILABLE:
+            return GoalActivationAuthorityRoute(
+                source_registry=source_registry,
+                target_registry=requested_registry,
+                sync_runtime_root=str(requested_registry.parent),
+                mode=GoalActivationAuthorityRouteMode.SOURCE_TO_GLOBAL,
+                source_status=source_status,
+            )
+        if target_state is GoalActivationState.STOPPED and _is_global_registry(
+            requested_registry, requested_payload
+        ):
+            return GoalActivationAuthorityRoute(
+                source_registry=requested_registry,
+                target_registry=requested_registry,
+                sync_runtime_root=None,
+                mode=GoalActivationAuthorityRouteMode.ORPHANED_GLOBAL_STOP_FALLBACK,
+                source_status=source_status,
+            )
+        if target_state is GoalActivationState.ACTIVE:
+            raise ValueError(
+                "Goal source registry is unavailable; repair the source route "
+                "before resuming this Goal"
+            )
+        raise ValueError(
+            "Goal source registry is unavailable; repair the source route "
+            "before changing this Goal"
+        )
 
     resolution = resolve_configure_goal_sync_target(
         registry_path=requested_registry,
         goal_id=goal_id,
         runtime_root_override=runtime_root_override,
     )
-    target_registry = Path(str(resolution["target_global_registry"])).expanduser().resolve()
-    return (
-        requested_registry,
-        target_registry,
-        str(resolution["target_runtime_root"]),
+    target_registry = (
+        Path(str(resolution["target_global_registry"])).expanduser().resolve()
+    )
+    return GoalActivationAuthorityRoute(
+        source_registry=requested_registry,
+        target_registry=target_registry,
+        sync_runtime_root=str(resolution["target_runtime_root"]),
+        mode=GoalActivationAuthorityRouteMode.REQUESTED_TO_GLOBAL,
+        source_status=GoalActivationSourceStatus.AVAILABLE,
     )
 
 
@@ -110,11 +215,15 @@ def set_goal_activation_state(
     if not normalized_goal_id:
         raise ValueError("goal id is required")
     target_state = normalize_goal_activation_state(state)
-    source_registry, target_registry, sync_runtime_root = _source_and_target(
+    authority_route = _source_and_target(
         registry_path=registry_path,
         goal_id=normalized_goal_id,
+        target_state=target_state,
         runtime_root_override=runtime_root_override,
     )
+    source_registry = authority_route.source_registry
+    target_registry = authority_route.target_registry
+    sync_runtime_root = authority_route.sync_runtime_root
     source_goal = _goal(load_registry(source_registry), normalized_goal_id)
     before_state = goal_activation_state(source_goal)
     changed = before_state is not target_state
@@ -142,6 +251,7 @@ def set_goal_activation_state(
         "partial_write": False,
         "source_registry": str(source_registry),
         "target_global_registry": str(target_registry),
+        "authority_route": authority_route.public_summary(),
         "activation": proposed_activation,
         "readback": {
             "schema_version": GOAL_ACTIVATION_READBACK_SCHEMA_VERSION,
@@ -151,6 +261,14 @@ def set_goal_activation_state(
     }
     if not execute:
         return payload
+
+    if (
+        authority_route.mode
+        is GoalActivationAuthorityRouteMode.ORPHANED_GLOBAL_STOP_FALLBACK
+    ):
+        payload["recommended_action"] = (
+            "Repair the Goal source registry route before resuming this Goal."
+        )
 
     registries_are_distinct = not _same_path(source_registry, target_registry)
     if registries_are_distinct:

--- a/tests/control_plane/test_goal_activation.py
+++ b/tests/control_plane/test_goal_activation.py
@@ -64,6 +64,43 @@ def connected_registries(tmp_path: Path) -> tuple[Path, Path]:
     return source_registry, runtime_root / "registry.global.json"
 
 
+def _orphaned_global_registry(
+    tmp_path: Path,
+    *,
+    source_status: str = "registry_missing",
+    activation_state: str = "active",
+) -> tuple[Path, Path]:
+    source_registry = tmp_path / "removed-project" / ".loopx" / "registry.json"
+    if source_status == "goal_missing":
+        _write_json(source_registry, {"schema_version": "0.1", "goals": []})
+    elif source_status == "registry_unreadable":
+        source_registry.parent.mkdir(parents=True, exist_ok=True)
+        source_registry.write_text("not-json\n", encoding="utf-8")
+    elif source_status != "registry_missing":
+        raise ValueError(f"unsupported source status fixture: {source_status}")
+    global_registry = tmp_path / "runtime" / "registry.global.json"
+    _write_json(
+        global_registry,
+        {
+            "schema_version": "0.1",
+            "registry_role": "global-local",
+            "goals": [
+                {
+                    "id": "orphaned-goal",
+                    "display_name": "Orphaned Goal",
+                    "source_registry": str(source_registry),
+                    "activation": build_goal_activation(
+                        state=activation_state,
+                        updated_at="2026-08-20T00:00:00+00:00",
+                        reason="Fixture setup",
+                    ),
+                }
+            ],
+        },
+    )
+    return source_registry, global_registry
+
+
 def test_activation_contract_defaults_active_and_rejects_unknown_state() -> None:
     assert goal_activation_state({}) is GoalActivationState.ACTIVE
     assert goal_activation_state({"activation_state": "stopped"}) is GoalActivationState.STOPPED
@@ -89,6 +126,90 @@ def test_stop_preview_is_zero_write(connected_registries: tuple[Path, Path]) -> 
     assert result["written"] is False
     assert source_registry.read_bytes() == before_source
     assert global_registry.read_bytes() == before_global
+
+
+@pytest.mark.parametrize(
+    "source_status",
+    ["registry_missing", "registry_unreadable", "goal_missing"],
+)
+def test_stop_orphaned_global_goal_uses_fail_safe_fallback(
+    tmp_path: Path,
+    source_status: str,
+) -> None:
+    source_registry, global_registry = _orphaned_global_registry(
+        tmp_path,
+        source_status=source_status,
+    )
+
+    result = set_goal_activation_state(
+        registry_path=global_registry,
+        goal_id="orphaned-goal",
+        state="stopped",
+        execute=True,
+    )
+
+    assert result["ok"] is True
+    assert result["written"] is True
+    assert result["readback"]["verified"] is True
+    assert result["authority_route"] == {
+        "schema_version": "loopx_goal_activation_authority_route_v1",
+        "mode": "orphaned_global_stop_fallback",
+        "source_status": source_status,
+        "resume_requires_source_repair": True,
+    }
+    assert (
+        goal_activation_state(_goal(global_registry, "orphaned-goal"))
+        is GoalActivationState.STOPPED
+    )
+    if source_status == "registry_missing":
+        assert source_registry.exists() is False
+
+
+def test_resume_orphaned_global_goal_fails_closed(tmp_path: Path) -> None:
+    _source_registry, global_registry = _orphaned_global_registry(
+        tmp_path,
+        activation_state="stopped",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="repair the source route before resuming",
+    ):
+        set_goal_activation_state(
+            registry_path=global_registry,
+            goal_id="orphaned-goal",
+            state="active",
+            execute=True,
+        )
+
+    assert (
+        goal_activation_state(_goal(global_registry, "orphaned-goal"))
+        is GoalActivationState.STOPPED
+    )
+
+
+def test_stop_does_not_fallback_for_non_global_registry(tmp_path: Path) -> None:
+    _source_registry, projected_registry = _orphaned_global_registry(tmp_path)
+    project_registry = tmp_path / "project" / ".loopx" / "registry.json"
+    payload = load_registry(projected_registry)
+    payload.pop("registry_role", None)
+    _write_json(project_registry, payload)
+
+    with pytest.raises(
+        ValueError,
+        match="repair the source route before changing",
+    ):
+        set_goal_activation_state(
+            registry_path=project_registry,
+            goal_id="orphaned-goal",
+            state="stopped",
+            execute=True,
+        )
+
+    assert (
+        goal_activation_state(_goal(project_registry, "orphaned-goal"))
+        is GoalActivationState.ACTIVE
+    )
 
 
 def test_stop_and_resume_sync_source_global_and_quota(
@@ -283,3 +404,36 @@ def test_owner_confirmed_typed_action_stops_goal(
     assert applied["proposal"]["receipt"]["projection_verified"] is True
     assert applied["proposal"]["receipt"]["outcome"] == "goal_stopped"
     assert goal_activation_state(_goal(global_registry)) is GoalActivationState.STOPPED
+
+
+def test_owner_confirmed_typed_action_stops_orphaned_global_goal(
+    tmp_path: Path,
+) -> None:
+    _source_registry, global_registry = _orphaned_global_registry(tmp_path)
+    service = ChatActionService(
+        store=ChatActionStore(tmp_path / "actions"),
+        registry_path=global_registry,
+    )
+    proposal = service.preview(
+        {
+            "action_kind": "goal.lifecycle",
+            "summary": "Stop an orphaned Goal",
+            "normalized_parameters": {
+                "goal_id": "orphaned-goal",
+                "operation": "stop",
+                "reason": "Owner confirmed from the workspace",
+            },
+            "context": {"kind": "goal_directory"},
+            "idempotency_key": "stop-orphaned-goal",
+        }
+    )
+
+    applied = service.apply(str(proposal["proposal_id"]))
+
+    assert applied["proposal"]["status"] == "applied"
+    assert applied["proposal"]["receipt"]["projection_verified"] is True
+    assert applied["proposal"]["receipt"]["outcome"] == "goal_stopped"
+    assert (
+        goal_activation_state(_goal(global_registry, "orphaned-goal"))
+        is GoalActivationState.STOPPED
+    )


### PR DESCRIPTION
## Summary

- let an owner-confirmed stop use the authoritative global Goal row when its projected source registry is missing, unreadable, or no longer contains the Goal;
- keep resume fail-closed until the source route is repaired, so the fallback can only reduce automatic execution authority;
- expose a typed, public-safe authority-route receipt and cover the typed chat-action path plus negative boundaries.

## Behavior and authority boundary

The existing path required the projected source registry for both stop and resume. A stale source route therefore blocked the safe stop operation shown in the dashboard. This change distinguishes the direction of authority:

- `stop`: the shared global registry may become the locked source and target for a verified global-only fallback;
- `resume`: still requires a healthy source registry and fails with repair guidance;
- non-global registries never receive the fallback.

## Validation

- `13 passed` — focused Goal activation and typed-action tests on the refreshed exact `main` base;
- `1442 passed` — broader `tests/control_plane` run before the unrelated base refresh; two subprocess tests initially selected system Python 3.9 and failed the repository's Python 3.11+ guard, then both passed when rerun with `LOOPX_PYTHON` set to the supported interpreter;
- `2 passed` — exact environment-only rerun;
- strict repository `mypy`: passed;
- Ruff on both changed files: passed;
- `py_compile` on changed Python: passed;
- public/private boundary scan on both changed files: clean;
- risk-based pre-merge: 1 catalog canary and 8 risk-profile smokes passed, 0 failures, 0 manual holds;
- exact-diff Change Quality receipt `cqr_9c026efeda5d35a809fa`: valid after refreshing `main`;
- final pre-merge status: passed, `self_merge_allowed=true`.

## Scope hygiene

Only the lifecycle runtime and its focused regression tests are included. Local registries, screenshots, worktree paths, credentials, raw logs, and historical gate artifacts are excluded.
