### PR TITLE
fix(dashboard): validate Todo defer before confirmation

### DIFF
--- a/apps/presentation/dashboard/smoke/personal-workspace-router-smoke.ts
+++ b/apps/presentation/dashboard/smoke/personal-workspace-router-smoke.ts
@@ -24,6 +24,12 @@ equal(
   "existing todo read-only analysis",
 );
 equal(routeWorkspaceInput("把 todo-1 标记完成", goalContext).actionKind, "todo.update", "todo update");
+const deferMissingCondition = routeWorkspaceInput("把 todo-1 暂缓", goalContext);
+equal(deferMissingCondition.route, "clarify", "todo defer without condition clarifies");
+equal(deferMissingCondition.missingFields.join(","), "resume_when", "todo defer names missing resume condition");
+const deferUntilPr = routeWorkspaceInput("把 todo-1 暂缓到pr_merged:huangruiteng/loopx#3399", goalContext);
+equal(deferUntilPr.route, "typed_action", "todo defer with condition routes to typed action");
+equal(deferUntilPr.normalizedParameters.resume_when, "pr_merged:huangruiteng/loopx#3399", "todo defer preserves supported condition");
 equal(routeWorkspaceInput("帮我修复 MR 冲突，跑测试，然后 push", goalContext).actionKind, "todo.create", "execution task");
 equal(routeWorkspaceInput("创建任务并设置 Heartbeat", goalContext).route, "clarify", "compound intent");
 equal(routeWorkspaceInput("创建任务并设置 Heartbeat", goalContext).missingFields.join(","), "single_intent", "compound missing field");

--- a/apps/presentation/dashboard/src/features/personal-workspace/context-drawer.tsx
+++ b/apps/presentation/dashboard/src/features/personal-workspace/context-drawer.tsx
@@ -33,6 +33,7 @@ import type {
 } from "./personal-workspace-model";
 import type { LarkGoalConnection } from "../../data/chat";
 import { attentionAgeLabel, formatCostUsd, formatDurationMs, formatTokenCount, hasGoalUsage, workspaceSessionStatusLabel } from "./personal-workspace-model";
+import { todoResumeWhenFromMessage } from "./personal-workspace-router";
 
 const focusableSelector = [
   "a[href]",
@@ -47,7 +48,6 @@ type TodoOperation = "block" | "complete" | "defer" | "successor_create";
 
 const todoTransitions = [
   { label: "标记阻塞", operation: "block" },
-  { label: "暂缓", operation: "defer" },
   { label: "创建后续 Todo", operation: "successor_create" },
 ] as const satisfies readonly { label: string; operation: TodoOperation }[];
 
@@ -73,6 +73,7 @@ export function ContextDrawer({ agents, callbacks, goalNotifications = [], goals
   const [repositoryCopyState, setRepositoryCopyState] = useState<"idle" | "copied" | "error">("idle");
   const [runDrawerTab, setRunDrawerTab] = useState<"record" | "details">("record");
   const [todoAgentId, setTodoAgentId] = useState(agents.find((agent) => agent.available)?.agentId ?? "codex");
+  const [todoResumeWhen, setTodoResumeWhen] = useState("");
   const closeRef = useRef<HTMLButtonElement>(null);
   const drawerRef = useRef<HTMLDivElement>(null);
   const selectionIdentity = selection.kind === "run" ? `run:${selection.item.runId}`
@@ -87,6 +88,7 @@ export function ContextDrawer({ agents, callbacks, goalNotifications = [], goals
     setRepositoryCopyState("idle");
     setDiagnosticsOpen(false);
     setRunDrawerTab("record");
+    setTodoResumeWhen("");
   }, [selectionIdentity]);
 
   useEffect(() => {
@@ -145,6 +147,7 @@ export function ContextDrawer({ agents, callbacks, goalNotifications = [], goals
     || Boolean(selection.item.latestActivity)
     || Boolean(selection.item.outputs?.length)
   );
+  const normalizedTodoResumeWhen = todoResumeWhenFromMessage(todoResumeWhen);
 
   async function sendCorrection() {
     if (selection.kind !== "run" || !correction.trim()) return;
@@ -152,7 +155,7 @@ export function ContextDrawer({ agents, callbacks, goalNotifications = [], goals
     setCorrection("");
   }
 
-  async function previewTodoTransition(todo: WorkspaceTodo, operation: TodoOperation, label: string) {
+  async function previewTodoTransition(todo: WorkspaceTodo, operation: TodoOperation, label: string, resumeWhen?: string) {
     if (operation === "successor_create") {
       await callbacks.onPreviewAction?.({
         actionKind: "todo.create",
@@ -168,10 +171,11 @@ export function ContextDrawer({ agents, callbacks, goalNotifications = [], goals
       context: { goal_id: todo.goalId, kind: "todo", todo_id: todo.todoId },
       idempotencyKey: `workspace-todo-${todo.todoId}-${operation}-${Date.now().toString(36)}`,
       normalizedParameters: {
+        agent_id: todo.claimedBy ?? todoAgentId,
         goal_id: todo.goalId,
         operation,
         ...(operation === "block" ? { note: "Owner 标记为阻塞，等待补充上下文。" } : {}),
-        ...(operation === "defer" ? { resume_when: "owner_resume" } : {}),
+        ...(operation === "defer" && resumeWhen ? { resume_when: resumeWhen } : {}),
         todo_id: todo.todoId,
       },
       summary: `${label}：${todo.text}`,
@@ -266,6 +270,24 @@ export function ContextDrawer({ agents, callbacks, goalNotifications = [], goals
                   normalizedParameters: { agent_id: todoAgentId, goal_id: selection.item.goalId, operation: "reassign", todo_id: selection.item.todoId },
                   summary: `重新分配：${selection.item.text}`,
                 })} type="button">检查变更</button>
+              </label>
+              <label className="personal-inline-agent-select personal-inline-resume-when">暂缓至
+                <input
+                  aria-label="Todo 暂缓恢复条件"
+                  aria-invalid={Boolean(todoResumeWhen.trim()) && !normalizedTodoResumeWhen}
+                  onChange={(event) => setTodoResumeWhen(event.target.value)}
+                  placeholder="例如 pr_merged:owner/repo#123"
+                  value={todoResumeWhen}
+                />
+                <button
+                  className="personal-secondary-action"
+                  disabled={!normalizedTodoResumeWhen}
+                  onClick={() => void previewTodoTransition(selection.item, "defer", "暂缓", normalizedTodoResumeWhen ?? undefined)}
+                  type="button"
+                >检查暂缓</button>
+                <small>{todoResumeWhen.trim() && !normalizedTodoResumeWhen
+                  ? "条件格式不受支持；请使用下列三种可判定条件"
+                  : "支持 todo_done、pr_merged、capacity_available 条件"}</small>
               </label>
               <details className="personal-compact-menu">
                 <summary><MoreHorizontal size={17} />更多操作</summary>

--- a/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-contract.test.mjs
+++ b/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-contract.test.mjs
@@ -23,9 +23,12 @@ for (const field of ["dependencies", "nextTransition", "ownerLabel", "todoId", "
   assert.match(model, new RegExp(`${field}\\??:`), `Todo exposes ${field}`);
 }
 assert.match(drawer, /actionKind: "todo\.update"/, "Todo mutations use typed previews");
-for (const operation of ["reassign", "block", "defer"]) {
+for (const operation of ["reassign", "block"]) {
   assert.match(drawer, new RegExp(`operation:\\s*"${operation}"`), `Todo supports ${operation}`);
 }
+assert.match(drawer, /previewTodoTransition\(selection\.item, "defer"/, "Todo defer collects a resume condition before preview");
+assert.match(drawer, /resume_when:\s*resumeWhen/, "Todo defer sends its explicit resume condition");
+assert.doesNotMatch(drawer + page, /owner_resume/, "Personal Workspace never emits the unsupported owner_resume sentinel");
 assert.match(drawer, /previewTodoTransition\(selection\.item, "complete"/, "Todo complete is the primary drawer action");
 assert.match(drawer, /actionKind: "todo\.create"/, "Todo successor uses the canonical create action");
 

--- a/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-page.tsx
+++ b/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-page.tsx
@@ -1211,7 +1211,9 @@ export function PersonalWorkspacePage({
       });
       if (intentRoute.route === "clarify") {
         setComposer(message);
-        setActionFeedback("这句话包含多个可能修改状态的操作。请一次描述一项操作，我会逐项展示确认预览。");
+        setActionFeedback(intentRoute.missingFields.includes("resume_when")
+          ? "暂缓 Todo 需要可自动判断的恢复条件。请补充 todo_done:<todo_id>、pr_merged:[owner/repo]#<number> 或 capacity_available:<capability>。"
+          : "这句话包含多个可能修改状态的操作。请一次描述一项操作，我会逐项展示确认预览。");
         return;
       }
       if (intentRoute.actionKind === "goal.create") {
@@ -1309,9 +1311,12 @@ export function PersonalWorkspacePage({
           context: { kind: "todo", goal_id: selectedGoalId, todo_id: matchedTodo.todoId, natural_language: message },
           idempotencyKey: `workspace-todo-update-${matchedTodo.todoId}-${todoOperation}-${Date.now().toString(36)}`,
           normalizedParameters: {
+            agent_id: selectedAgentId,
             ...(todoOperation === "reassign" && requestedAgent ? { endpoint_id: requestedAgent.agentId } : {}),
             ...(todoOperation === "block" ? { note: message } : {}),
-            ...(todoOperation === "defer" ? { resume_when: "owner_resume" } : {}),
+            ...(todoOperation === "defer" && typeof intentRoute.normalizedParameters.resume_when === "string"
+              ? { resume_when: intentRoute.normalizedParameters.resume_when }
+              : {}),
             goal_id: selectedGoalId,
             operation: todoOperation,
             todo_id: matchedTodo.todoId,

--- a/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-router.ts
+++ b/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-router.ts
@@ -41,6 +41,14 @@ function executionIntent(message: string) {
     && /(帮我|请|给我|直接|现在|开始|bytedcli|codebase|git|rebase|push|提交|推送)/iu.test(message);
 }
 
+export function todoResumeWhenFromMessage(rawMessage: string) {
+  const message = normalizedMessage(rawMessage).toLowerCase();
+  const match = message.match(
+    /(?:^|[\s，,；;：（(:]|到|至)(?<condition>todo_done:todo_[a-z0-9_-]{3,64}|pr_merged:(?:(?:[a-z0-9_.-]{1,80})\/(?:[a-z0-9_.-]{1,100}))?#[1-9][0-9]{0,8}|capacity_available:[a-z][a-z0-9_:-]{0,63})(?=$|[\s，,。；;）)])/iu,
+  );
+  return match?.groups?.condition ?? null;
+}
+
 export function routeWorkspaceInput(rawMessage: string, context: WorkspaceRouterContext): WorkspaceRouterResult {
   const message = normalizedMessage(rawMessage);
   const candidates: Array<{ actionKind: WorkspaceRouterActionKind; confidence: number; normalizedParameters: Record<string, unknown> }> = [];
@@ -87,10 +95,25 @@ export function routeWorkspaceInput(rawMessage: string, context: WorkspaceRouter
           : agent && !negates(message, /交给|分配给|改派/u) && /交给|分配给|改派/u.test(message) ? "reassign"
             : null;
     if (operation) {
+      const resumeWhen = operation === "defer" ? todoResumeWhenFromMessage(message) : null;
+      if (operation === "defer" && !resumeWhen) {
+        return {
+          actionKind: "todo.update",
+          confidence: 0.97,
+          missingFields: ["resume_when"],
+          normalizedParameters: { goal_id: context.goalId, operation, todo_id: todo.todoId },
+          route: "clarify",
+        };
+      }
       candidates.push({
         actionKind: "todo.update",
         confidence: 0.97,
-        normalizedParameters: { goal_id: context.goalId, operation, todo_id: todo.todoId },
+        normalizedParameters: {
+          goal_id: context.goalId,
+          operation,
+          ...(resumeWhen ? { resume_when: resumeWhen } : {}),
+          todo_id: todo.todoId,
+        },
       });
     }
   }

--- a/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace.css
+++ b/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace.css
@@ -565,6 +565,8 @@
 .personal-inline-agent-select { display: grid; grid-column: 1 / -1; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 8px; padding: 8px; border: 1px solid var(--pw-line); border-radius: 10px; color: var(--pw-muted); font-size: 11px; }
 .personal-inline-agent-select select { min-width: 0; min-height: 36px; padding: 0 8px; border: 1px solid var(--pw-line-strong); border-radius: 8px; background: #fff; color: #333; }
 .personal-inline-agent-select .personal-secondary-action { width: auto; min-height: 36px; padding: 0 12px; margin: 0; }
+.personal-inline-resume-when input { min-width: 0; min-height: 36px; padding: 0 8px; border: 1px solid var(--pw-line-strong); border-radius: 8px; background: #fff; color: #333; }
+.personal-inline-resume-when small { grid-column: 2 / -1; color: var(--pw-faint); }
 .personal-primary-action, .personal-secondary-action, .personal-danger-action { display: flex; align-items: center; justify-content: center; gap: 8px; width: 100%; min-height: 42px; margin-top: 12px; border-radius: 11px; cursor: pointer; font-weight: 650; font-size: 13.5px; }
 .personal-primary-action { border: 1px solid var(--pw-blue); background: var(--pw-blue); color: #fff; box-shadow: 0 2px 6px rgb(47 102 233 / 28%); }
 .personal-primary-action:hover { background: var(--pw-blue-ink); }
@@ -872,6 +874,7 @@
 .personal-workspace-shell[data-pw-theme="brutal"] .personal-compact-menu > div button:hover { background: #fff8d6; }
 .personal-workspace-shell[data-pw-theme="brutal"] .personal-inline-agent-select { border: 2px solid #141414; border-radius: 4px; }
 .personal-workspace-shell[data-pw-theme="brutal"] .personal-inline-agent-select select { border: 2px solid #141414; border-radius: 4px; color: #141414; }
+.personal-workspace-shell[data-pw-theme="brutal"] .personal-inline-resume-when input { border: 2px solid #141414; border-radius: 4px; color: #141414; }
 
 /* ===== 晨间摘要 + Agent 全景 + 会话提示 + 优先级徽章 ===== */
 .personal-digest-card { display: flex; align-items: center; justify-content: space-between; gap: 14px; margin-bottom: 12px; padding: 13px 16px; border: 1px solid var(--pw-line); border-radius: 14px; background: linear-gradient(135deg, #fff, #fbf7ee); }

--- a/examples/loopx-chat-actions-smoke.py
+++ b/examples/loopx-chat-actions-smoke.py
@@ -878,12 +878,69 @@ def assert_http_action_api(root: Path) -> None:
         assert todo_updated["proposal"]["receipt"]["outcome"] == "todo_updated", todo_updated
         assert "Verify typed action lifecycle and receipts" in state_path.read_text(encoding="utf-8")
 
+        todo_state_before_defer = state_path.read_text(encoding="utf-8")
+        code, unsupported_defer = request_json(
+            f"{base_url}/api/actions/preview",
+            method="POST",
+            body={
+                "action_kind": "todo.update",
+                "summary": "Defer without an evaluable condition",
+                "normalized_parameters": {
+                    "goal_id": "goal-one",
+                    "todo_id": current_todo_id,
+                    "operation": "defer",
+                    "resume_when": "owner_resume",
+                },
+                "context": {"kind": "goal", "goal_id": "goal-one"},
+                "idempotency_key": "http-todo-defer-unsupported",
+            },
+        )
+        assert code == 400, unsupported_defer
+        assert unsupported_defer["error_code"] == "invalid_action_preview", unsupported_defer
+        assert "supported condition" in unsupported_defer["error"], unsupported_defer
+        assert not any(
+            proposal.get("idempotency_key") == "http-todo-defer-unsupported"
+            for proposal in service.store.list()
+        ), service.store.list()
+        assert state_path.read_text(encoding="utf-8") == todo_state_before_defer
+
+        code, valid_defer_preview = request_json(
+            f"{base_url}/api/actions/preview",
+            method="POST",
+            body={
+                "action_kind": "todo.update",
+                "summary": "Defer until another Todo is done",
+                "normalized_parameters": {
+                    "goal_id": "goal-one",
+                    "todo_id": current_todo_id,
+                    "operation": "defer",
+                    "agent_id": "codex",
+                    "resume_when": f"todo_done:{current_todo_id}",
+                },
+                "context": {"kind": "goal", "goal_id": "goal-one"},
+                "idempotency_key": "http-todo-defer-supported",
+            },
+        )
+        assert code == 201, valid_defer_preview
+        assert valid_defer_preview["proposal"]["validation_evidence"] == [
+            "Canonical LoopX Todo dry-run validated the requested transition."
+        ], valid_defer_preview
+        assert state_path.read_text(encoding="utf-8") == todo_state_before_defer
+        code, valid_defer_applied = request_json(
+            f"{base_url}/api/actions/{valid_defer_preview['proposal']['proposal_id']}/apply",
+            method="POST",
+            body={},
+        )
+        assert code == 200, valid_defer_applied
+        assert valid_defer_applied["proposal"]["receipt"]["outcome"] == "todo_updated", valid_defer_applied
+        assert f"resume_when=todo_done:{current_todo_id}" in state_path.read_text(encoding="utf-8")
+
         for index, parameters in enumerate(
             (
                 {"operation": "reassign", "agent_id": "codex"},
-                {"operation": "block", "note": "Waiting for owner evidence"},
-                {"operation": "defer", "resume_when": f"todo_done:{current_todo_id}"},
-                {"operation": "successor", "successor_todo_ids": [current_todo_id]},
+                {"operation": "block", "note": "Waiting for owner evidence", "agent_id": "codex"},
+                {"operation": "defer", "resume_when": f"todo_done:{current_todo_id}", "agent_id": "codex"},
+                {"operation": "successor", "successor_todo_ids": [current_todo_id], "agent_id": "codex"},
             )
         ):
             code, transition_preview = request_json(

--- a/examples/personal-workspace-browser-smoke.mjs
+++ b/examples/personal-workspace-browser-smoke.mjs
@@ -893,9 +893,17 @@ async function main() {
     await page.getByText("确认执行").waitFor({ state: "visible" });
     if (!api.actionPreviews.some((preview) => preview.action_kind === "todo.update" && preview.normalized_parameters.operation === "reassign")) throw new Error("Todo reassign did not create a typed preview");
     await page.getByRole("button", { name: "关闭", exact: true }).click();
+    await taskRow.click();
+    await page.getByLabel("Todo 暂缓恢复条件").fill("pr_merged:huangruiteng/loopx#3399");
+    await page.screenshot({ path: resolve(outputDir, "todo-defer-resume-condition.png"), fullPage: false, animations: "disabled" });
+    await page.getByRole("button", { name: "检查暂缓", exact: true }).click();
+    await page.getByText("确认执行").waitFor({ state: "visible" });
+    const explicitDefer = api.actionPreviews.findLast((preview) => preview.action_kind === "todo.update" && preview.normalized_parameters.operation === "defer");
+    if (explicitDefer?.normalized_parameters.resume_when !== "pr_merged:huangruiteng/loopx#3399") throw new Error(`Todo defer did not preserve its supported resume condition: ${JSON.stringify(explicitDefer)}`);
+    if (JSON.stringify(api.actionPreviews).includes("owner_resume")) throw new Error("Personal Workspace emitted the unsupported owner_resume sentinel");
+    await page.getByRole("button", { name: "关闭", exact: true }).click();
     for (const [label, actionKind, operation] of [
       ["标记阻塞", "todo.update", "block"],
-      ["暂缓", "todo.update", "defer"],
       ["标记完成", "todo.update", "complete"],
       ["创建后续 Todo", "todo.create", null],
     ]) {

--- a/loopx/chat_actions.py
+++ b/loopx/chat_actions.py
@@ -15,14 +15,16 @@ from .chat_action_store import ActionConflictError, ChatActionStore
 from .chat_goal_lifecycle_actions import ChatGoalLifecycleActionMixin
 from .chat_monitor_actions import ChatMonitorActionMixin
 from .chat_store import ChatSessionStore
+from .chat_todo_actions import ChatTodoActionMixin
 from .configure_goal import configure_goal
 from .control_plane.runtime.time import now_utc, parse_timestamp, utc_isoformat
 from .control_plane.scheduler.monitor_todo import monitor_next_due_at
+from .control_plane.todos.contract import require_supported_todo_resume_when
 from .history import load_registry
 from .host_loop_activation import build_host_loop_activation_packet
 from .quota import build_quota_should_run
 from .registry import registry_goals
-from .todos import add_goal_todo, complete_goal_todo, update_goal_todo
+from .todos import add_goal_todo, update_goal_todo
 
 
 CHAT_ACTION_RESPONSE_SCHEMA_VERSION = "loopx_chat_action_response_v1"
@@ -138,7 +140,9 @@ def _monitor_text(parameters: Mapping[str, Any]) -> str | None:
     return None
 
 
-class ChatActionService(ChatGoalLifecycleActionMixin, ChatMonitorActionMixin):
+class ChatActionService(
+    ChatGoalLifecycleActionMixin, ChatMonitorActionMixin, ChatTodoActionMixin
+):
     """Validate previews and route applies through canonical LoopX services."""
 
     def __init__(
@@ -381,9 +385,9 @@ class ChatActionService(ChatGoalLifecycleActionMixin, ChatMonitorActionMixin):
             elif values.get("agent_id"):
                 result["agent_id"] = _opaque(values["agent_id"], field="agent_id")
             if values.get("resume_when"):
-                result["resume_when"] = _text(
-                    values["resume_when"], field="resume_when", limit=240
-                ).lower()
+                result["resume_when"] = require_supported_todo_resume_when(
+                    _text(values["resume_when"], field="resume_when", limit=240)
+                )
             if values.get("successor_todo_ids") is not None:
                 if not isinstance(values["successor_todo_ids"], list):
                     raise ValueError("successor_todo_ids must be a list")
@@ -1183,65 +1187,6 @@ class ChatActionService(ChatGoalLifecycleActionMixin, ChatMonitorActionMixin):
         )
         return {"proposal": stored, "turn": None}
 
-    def _apply_todo_update(
-        self, proposal_id: str, proposal: dict[str, Any], parameters: dict[str, Any]
-    ) -> dict[str, Any]:
-        goal_id = str(parameters["goal_id"])
-        current_fingerprint = self._goal_state_fingerprint(goal_id)
-        if current_fingerprint != proposal.get("expected_state_fingerprint"):
-            stale = self.store.apply(
-                proposal_id, current_state_fingerprint=current_fingerprint, receipt={}
-            )
-            return {"proposal": stale, "turn": None}
-        operation = str(parameters.get("operation") or "edit")
-        if operation == "complete":
-            result = complete_goal_todo(
-                registry_path=self.registry_path,
-                goal_id=goal_id,
-                todo_id=str(parameters["todo_id"]),
-                note=parameters.get("note"),
-                no_followup=bool(parameters.get("no_followup", True)),
-                successor_todo_ids=parameters.get("successor_todo_ids"),
-                agent_id=parameters.get("agent_id"),
-                authority_reason="owner-confirmed typed Chat action",
-                dry_run=False,
-            )
-        else:
-            status = parameters.get("status")
-            if operation == "block":
-                status = "blocked"
-            elif operation == "defer":
-                status = "deferred"
-            result = update_goal_todo(
-                registry_path=self.registry_path,
-                goal_id=goal_id,
-                todo_id=str(parameters["todo_id"]),
-                text=parameters.get("text"),
-                status=status,
-                note=parameters.get("note"),
-                claimed_by=parameters.get("agent_id") if operation == "reassign" else None,
-                resume_when=parameters.get("resume_when"),
-                successor_todo_ids=parameters.get("successor_todo_ids"),
-                agent_id=parameters.get("agent_id"),
-                authority_reason="owner-confirmed typed Chat action",
-                dry_run=False,
-            )
-        todo_id = _opaque(result.get("todo_id"), field="todo_id")
-        receipt = {
-            "receipt_id": _digest({"proposal_id": proposal_id, "todo_id": todo_id})[:32],
-            "outcome": (
-                "todo_completed"
-                if operation == "complete"
-                else "todo_updated" if result.get("changed") else "todo_unchanged"
-            ),
-            "projection_verified": True,
-            "resource_ids": {"goal_id": goal_id, "todo_id": todo_id},
-        }
-        stored = self.store.apply(
-            proposal_id, current_state_fingerprint=current_fingerprint, receipt=receipt
-        )
-        return {"proposal": stored, "turn": None}
-
     def preview(self, request: Mapping[str, Any]) -> dict[str, Any]:
         unknown = set(request) - {
             "action_kind",
@@ -1287,6 +1232,12 @@ class ChatActionService(ChatGoalLifecycleActionMixin, ChatMonitorActionMixin):
             evidence = ["The recoverable Goal and Agent Chat Session is available."]
             permission = "scoped_correction"
         elif action_kind in {"todo.update", "monitor.update"}:
+            if action_kind == "todo.update":
+                canonical_preview = self._run_todo_update(normalized, dry_run=True)
+                if canonical_preview.get("ok") is not True:
+                    raise ValueError(
+                        str(canonical_preview.get("error") or "Todo transition failed canonical dry-run validation")
+                    )
             goal_fingerprint = self._goal_state_fingerprint(normalized["goal_id"])
             if action_kind == "monitor.update" and normalized.get("operation") == "run_now":
                 session_id = normalized.get("session_id")
@@ -1304,7 +1255,11 @@ class ChatActionService(ChatGoalLifecycleActionMixin, ChatMonitorActionMixin):
                 )
             else:
                 fingerprint = goal_fingerprint
-            evidence = ["Canonical LoopX Todo state validated the requested transition."]
+            evidence = [
+                "Canonical LoopX Todo dry-run validated the requested transition."
+                if action_kind == "todo.update"
+                else "Canonical LoopX Todo state validated the requested transition."
+            ]
             permission = "durable_write"
         else:
             fingerprint = self._registry_fingerprint()

--- a/loopx/chat_todo_actions.py
+++ b/loopx/chat_todo_actions.py
@@ -1,0 +1,82 @@
+"""Typed Chat actions for canonical Todo lifecycle transitions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .todos import complete_goal_todo, update_goal_todo
+
+
+class ChatTodoActionMixin:
+    """Keep Todo preview/apply parity separate from general orchestration."""
+
+    def _run_todo_update(
+        self, parameters: dict[str, Any], *, dry_run: bool
+    ) -> dict[str, Any]:
+        goal_id = str(parameters["goal_id"])
+        operation = str(parameters.get("operation") or "edit")
+        if operation == "complete":
+            return complete_goal_todo(
+                registry_path=self.registry_path,
+                goal_id=goal_id,
+                todo_id=str(parameters["todo_id"]),
+                note=parameters.get("note"),
+                no_followup=bool(parameters.get("no_followup", True)),
+                successor_todo_ids=parameters.get("successor_todo_ids"),
+                agent_id=parameters.get("agent_id"),
+                authority_reason="owner-confirmed typed Chat action",
+                dry_run=dry_run,
+            )
+        status = parameters.get("status")
+        if operation == "block":
+            status = "blocked"
+        elif operation == "defer":
+            status = "deferred"
+        return update_goal_todo(
+            registry_path=self.registry_path,
+            goal_id=goal_id,
+            todo_id=str(parameters["todo_id"]),
+            text=parameters.get("text"),
+            status=status,
+            note=parameters.get("note"),
+            claimed_by=(
+                parameters.get("agent_id") if operation == "reassign" else None
+            ),
+            resume_when=parameters.get("resume_when"),
+            successor_todo_ids=parameters.get("successor_todo_ids"),
+            agent_id=parameters.get("agent_id"),
+            authority_reason="owner-confirmed typed Chat action",
+            dry_run=dry_run,
+        )
+
+    def _apply_todo_update(
+        self, proposal_id: str, proposal: dict[str, Any], parameters: dict[str, Any]
+    ) -> dict[str, Any]:
+        from .chat_actions import _digest, _opaque
+
+        goal_id = str(parameters["goal_id"])
+        current_fingerprint = self._goal_state_fingerprint(goal_id)
+        if current_fingerprint != proposal.get("expected_state_fingerprint"):
+            stale = self.store.apply(
+                proposal_id, current_state_fingerprint=current_fingerprint, receipt={}
+            )
+            return {"proposal": stale, "turn": None}
+        operation = str(parameters.get("operation") or "edit")
+        result = self._run_todo_update(parameters, dry_run=False)
+        todo_id = _opaque(result.get("todo_id"), field="todo_id")
+        receipt = {
+            "receipt_id": _digest({"proposal_id": proposal_id, "todo_id": todo_id})[
+                :32
+            ],
+            "outcome": (
+                "todo_completed"
+                if operation == "complete"
+                else "todo_updated" if result.get("changed") else "todo_unchanged"
+            ),
+            "projection_verified": True,
+            "resource_ids": {"goal_id": goal_id, "todo_id": todo_id},
+        }
+        stored = self.store.apply(
+            proposal_id, current_state_fingerprint=current_fingerprint, receipt=receipt
+        )
+        return {"proposal": stored, "turn": None}


### PR DESCRIPTION
## Summary

- fail Todo update previews closed against the canonical Todo dry-run contract
- replace the unsupported Personal Workspace `owner_resume` sentinel with explicit supported resume conditions
- clarify free-text defer requests that omit an evaluable condition
- attribute Todo lifecycle changes to the selected Agent in multi-agent Goals
- move Todo preview/apply parity into the bounded Chat Todo action mixin

Fixes #3399.

## Validation

- `python examples/loopx-chat-actions-smoke.py`
- `npm run smoke:personal-workspace-router`
- Personal Workspace drawer contract smoke
- `npm run build:desktop`
- `npm run smoke:demo-readiness`
- `npm run smoke:personal-workspace`
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` (6 catalog canaries plus public boundary; passed with no holds)
- change-quality receipt `cqr_b069b090b4d0a113933f` (valid for the exact committed diff)

## Boundaries

- no credentials, private state, local paths, or raw execution evidence included
