### PR TITLE
chore(release): prepare LoopX v0.5.1

### DIFF
--- a/docs/guides/personal-workspace-user-guide.md
+++ b/docs/guides/personal-workspace-user-guide.md
@@ -145,7 +145,29 @@ loopx goal-lifecycle --goal-id <goal-id> --operation resume --execute
 - **代码仓只读绑定**：明确展示当前绑定的 GitHub / 本地仓库、生效分支及只读隔离属性；
 - **Lark / 飞书话题连接**：
   - 展示当前绑定的飞书群组与 Topic 话题；
-  - **触发规则（Trigger）**：明确标注为 **`Someone mentions the Agent`**（仅在群聊话题内显式 @ 该机器人时触发，避免群聊闲聊打扰）。
+  - **Capture scope**：可选择只接收明确 @ / 回复 App 的消息，或接收该 Goal Topic
+    的全部消息；这只改变捕获范围，不扩大 Agent 权限；
+  - **Agent ingress**：为 Goal 当前已注册的目标 Agent 选择一种明确的收信方式：
+    - **Steering (`live_steering`)**：投递到该 Agent 当前精确的活跃 Turn；没有匹配的
+      活跃 Turn、Session 已过期或运行时不支持原生 steering 时安全拒绝；
+    - **Queuing (`session_queue`)**：写入同一精确 Agent Session 的有界 FIFO，当前
+      Turn 完成后按顺序处理，并支持重启恢复；
+    - **Async inbox (`async_inbox`)**：写入该 Agent 的本地私有收件箱，等待后续显式
+      `lark-inbox drain`；投递本身不会创建内联 Session，也不会提前回复或 ACK；
+  - **Reply mode**：回复仍限定在来源 Topic 内，避免跨群或跨 Goal 投递。
+
+在「通知设置 → Lark / 飞书 → Connections」中选择 Goal、Target Agent、群聊、
+Capture scope 与 Agent ingress，保存后可在同一页读回当前模式、Session 绑定状态、
+监听状态和最近事件结果。Steering 与 Queuing 要求该 Goal / Agent 已有工作 Session；
+Async inbox 不要求活跃 Turn，适合后台 Agent 稍后处理。发送一条新的 @ 消息验证所选
+模式；若选择 Async inbox，可用以下命令读回待处理事件：
+
+```bash
+loopx lark-inbox drain --goal-id <goal-id> --agent-id <agent-id>
+```
+
+要停用该 Goal 的话题入站，在 Connections 中选择 **Disconnect**。断开只移除这个
+Goal 的 Topic 路由，不删除 Goal、Agent Session、历史 Todo 或其他 Goal 的连接。
 
 ---
 

--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -455,6 +455,11 @@ path, and canary route rather than as a user-facing release baseline.
   browser/PWA workspace, adds a source-built native desktop shell over the same
   local authority, makes Goal stop/resume and repository change windows
   operator-visible, and admits goal-bound external capability providers.
+- `v0.5.1` on 2026-08-21: operator workflow and collaboration hardening at the
+  matching `v0.5.1` tag. LoopX adds downloadable macOS and Windows desktop
+  previews, first-class DeepSeek Harness packaging, botmux Goal Channel turns,
+  three Agent-scoped Lark ingress modes, and fixes Goal lifecycle, Todo defer,
+  quota settlement, replan closeout, and event-sourced freshness paths.
 
 When a new public release is promoted, add it here only after the matching tag,
 release note, stable ref, update path, and focused release canary agree.

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/man/loopx.1
+++ b/man/loopx.1
@@ -1,4 +1,4 @@
-.TH LOOPX 1 "" "LoopX 0.5.0" "User Commands"
+.TH LOOPX 1 "" "LoopX 0.5.1" "User Commands"
 .SH NAME
 loopx \- control-plane helper for long-running agent work
 .SH SYNOPSIS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.5.0"
+version = "0.5.1"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_license_metadata.py
+++ b/tests/test_license_metadata.py
@@ -31,8 +31,8 @@ def test_root_license_is_canonical_apache_2_with_historical_notices() -> None:
 
 def test_python_distributions_declare_apache_2() -> None:
     root_project = _project_metadata("pyproject.toml")
-    assert root_project["version"] == "0.5.0"
-    assert '__version__ = "0.5.0"' in (ROOT / "loopx/__init__.py").read_text()
+    assert root_project["version"] == "0.5.1"
+    assert '__version__ = "0.5.1"' in (ROOT / "loopx/__init__.py").read_text()
     assert root_project["license"] == "Apache-2.0"
     assert set(root_project["license-files"]) == {"LICENSE", "NOTICE", "LICENSE-MIT"}
 


### PR DESCRIPTION
## Summary

- synchronize the public package, module, man-page, and metadata contracts at `0.5.1`;
- record the `v0.5.1` release boundary and the shipped operator/runtime improvements;
- document all three Agent-scoped Lark ingress modes (`live_steering`, `session_queue`, and `async_inbox`) with UI configuration, readback, drain, and disconnect behavior.

The final GitHub release notes are prepared separately as an ignored artifact. They preserve bilingual community attribution for the five non-founder contributors in `v0.5.0...HEAD` (including first-time contributor `@now-ing`) and include activation, validation, rollback, authority/privacy boundaries, and versioned documentation for every materially changed optional surface.

## Validation

- `python -m mypy` — passed
- focused Python regression — 244 passed across release-adjacent control-plane, host, Lark, Pi, quota, settlement, and replan modules
- `pytest tests/test_license_metadata.py` — 4 passed
- release version contract and artifact smokes — passed
- release-readiness doc smoke for five optional surfaces — passed
- `python -m build` and `twine check` — passed for the v0.5.1 sdist and wheel
- dashboard production build — passed (existing non-blocking bundle-size warning only)
- Pi runtime tests — 34 passed; focused Python Pi tests — 16 passed
- exact-path public/private scan and `git diff --check` — passed
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` — passed: 9 catalog canaries, 8 risk-profile smokes, 1 public-boundary check, no failures, warnings, or manual holds
- change-quality receipt `cqr_f29271ea99dbcbb0f5e5` — valid for the exact committed six-file diff

## Release boundary

- Previous tag: `v0.5.0`
- Intended tag after merge: `v0.5.1`
- Publication remains a post-merge maintainer action; this PR does not create a tag or publish artifacts.

## Public/private and presentation review

- No credentials, local paths, raw traces, generated dashboard assets, or private state are included.
- README and other public first-screen surfaces are unchanged, so the first-screen review gate is not triggered.
