### PR TITLE
feat(chat): broker attached Agent sessions

### DIFF
--- a/docs/architecture/rfcs/desktop-execution-frontends-v0.zh-CN.md
+++ b/docs/architecture/rfcs/desktop-execution-frontends-v0.zh-CN.md
@@ -574,6 +574,8 @@ Ark Agent Plan 有自己的受支持模型、凭据和用量边界。适配器�
 - attach 只有在 `(host_surface, host_session_id)` 已精确绑定该 Agent 时才成立；
 - attached session 的 Web 与 Lark 消息进入同一有界 FIFO，并保留
   `origin=web|lark`；
+- 已有宿主可以保持一个最长 30 分钟的 claim 等待，并在队列出现消息时立即
+  获得旧项优先、幂等 claim；超时只返回空结果，不启动或恢复任何运行时；
 - 原宿主通过稳定 claim/completion id 领取消息并回写，重复调用不会重复生成
   Agent 回复；以及
 - 任何 attached session 路径都不得调用 managed runtime 的启动/恢复函数。

--- a/docs/architecture/rfcs/desktop-execution-frontends-v0.zh-CN.md
+++ b/docs/architecture/rfcs/desktop-execution-frontends-v0.zh-CN.md
@@ -566,6 +566,24 @@ Ark Agent Plan 有自己的受支持模型、凭据和用量边界。适配器�
 
 这是围绕已在运行的工作采用 Desktop 的短路径。
 
+第一阶段的可执行 broker 契约沉淀在 Chat session/store 与通用
+`worker-bridge attached-session-*` 命令中，而不是 Lark provider 内部：
+
+- `agent_id` 始终表示 Goal 内已登记的 LoopX Agent；
+- `executor_endpoint_id` 单独表示 `codex`、`claude-code` 或其他执行端；
+- attach 只有在 `(host_surface, host_session_id)` 已精确绑定该 Agent 时才成立；
+- attached session 的 Web 与 Lark 消息进入同一有界 FIFO，并保留
+  `origin=web|lark`；
+- 原宿主通过稳定 claim/completion id 领取消息并回写，重复调用不会重复生成
+  Agent 回复；以及
+- 任何 attached session 路径都不得调用 managed runtime 的启动/恢复函数。
+
+该阶段已经能支撑 `session_queue` 与回复 readback。`live_steering` 仍要求宿主提供
+对正在运行 Turn 的 push transport；在此之前 capability 明确为 false，入口失败
+关闭，不能用新启动的 app-server 或静默改投另一个模式冒充完成。Desktop 下一步
+需要把 bind/list/claim 状态投影成首屏 attach 管理交互，并由 Codex App 等宿主
+自动完成 claim/complete，而不是要求人手工运行 CLI。
+
 ### 切片 C：托管参考垂直
 
 1. 一个 provider-neutral 的托管运行时与托管 provider 接口；

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -9,6 +9,7 @@ and external systems while preserving one control-plane authority.
 - [Session runtime control-plane adapter](session-runtime-control-plane-adapter.md)
 - [LoopX Control Plane desktop shell](../../apps/desktop/loopx-control-plane/README.md)
 - [Worker bridge install contract](worker-bridge-install-contract.md)
+- [Attached Agent session broker](attached-agent-session-broker.md)
 - [Codex peer task orchestration](codex-subagent-orchestration.md)
 - [Complex project read-only adapter](complex-project-readonly-adapter.md)
 - [Lark Kanban control-plane adapter](lark-kanban-control-plane-adapter.md)

--- a/docs/integrations/attached-agent-session-broker.md
+++ b/docs/integrations/attached-agent-session-broker.md
@@ -1,0 +1,62 @@
+# Attached Agent Session Broker
+
+The attached Agent session broker represents an already-running host session
+inside the owner-local LoopX Chat store. It does not start, resume, or replace
+an Agent runtime.
+
+The first bridge stage supports:
+
+- exact `(Goal, registered Agent, host surface, host session)` admission;
+- distinct LoopX `agent_id` and executor `executor_endpoint_id` identities;
+- one shared ordered queue for Web and Connector messages with `origin`;
+- duplicate-safe host claim and completion receipts;
+- response readback through the existing Chat turn and Lark reply path; and
+- content-free Session list projections.
+
+The host session must already have an exact `bind-agent-thread` registration.
+Bind it to Chat with owner-local opaque values:
+
+```bash
+loopx worker-bridge attached-session-bind \
+  --goal-id <goal-id> \
+  --agent-id <registered-agent-id> \
+  --host-surface <host-surface> \
+  --host-session-id <opaque-host-session-id> \
+  --executor-endpoint-id <executor-endpoint-id> \
+  --execute
+```
+
+Web or Lark `session_queue` input is then claimed by the existing host:
+
+```bash
+loopx worker-bridge attached-session-claim \
+  --session-id <loopx-chat-session-id> \
+  --host-surface <host-surface> \
+  --host-session-id <opaque-host-session-id> \
+  --claim-id <stable-claim-id> \
+  --format json
+```
+
+Write the Agent response to an owner-local JSON file containing at least a
+`message` field, then complete the exact claim:
+
+```bash
+loopx worker-bridge attached-session-complete \
+  --session-id <loopx-chat-session-id> \
+  --turn-id <loopx-chat-turn-id> \
+  --host-surface <host-surface> \
+  --host-session-id <opaque-host-session-id> \
+  --claim-id <stable-claim-id> \
+  --completion-id <stable-completion-id> \
+  --response-json <owner-local-response.json>
+```
+
+`session_queue` and reply readback are enabled in this stage. `live_steering`
+is explicitly reported as unavailable until the host exposes a push transport
+for the already-running Turn. LoopX fails closed instead of starting a managed
+runtime or silently degrading one event into another ingress mode.
+
+Opaque host identifiers, message bodies, and response files stay in the local
+runtime store. Public Session projections contain only the LoopX Session id,
+Goal/Agent binding, executor endpoint label, host surface, capability booleans,
+and lifecycle state.

--- a/docs/integrations/attached-agent-session-broker.md
+++ b/docs/integrations/attached-agent-session-broker.md
@@ -34,8 +34,15 @@ loopx worker-bridge attached-session-claim \
   --host-surface <host-surface> \
   --host-session-id <opaque-host-session-id> \
   --claim-id <stable-claim-id> \
+  --wait-seconds 30 \
   --format json
 ```
+
+`--wait-seconds` turns claim into a bounded host subscription. An existing host
+bridge can keep one claim request open and wake as soon as the oldest queued
+message is available, instead of polling the command in a tight loop. The wait
+is capped at 30 minutes and never starts or resumes an Agent runtime. A timeout
+returns `claimed=false`; the host chooses whether to subscribe again.
 
 Write the Agent response to an owner-local JSON file containing at least a
 `message` field, then complete the exact claim:
@@ -51,10 +58,11 @@ loopx worker-bridge attached-session-complete \
   --response-json <owner-local-response.json>
 ```
 
-`session_queue` and reply readback are enabled in this stage. `live_steering`
-is explicitly reported as unavailable until the host exposes a push transport
-for the already-running Turn. LoopX fails closed instead of starting a managed
-runtime or silently degrading one event into another ingress mode.
+`session_queue`, bounded claim wait, and reply readback are enabled in this
+stage. `live_steering` is explicitly reported as unavailable until the host
+exposes a push transport for the already-running Turn. LoopX fails closed
+instead of starting a managed runtime or silently degrading one event into
+another ingress mode.
 
 Opaque host identifiers, message bodies, and response files stay in the local
 runtime store. Public Session projections contain only the LoopX Session id,

--- a/docs/integrations/attached-agent-session-broker.md
+++ b/docs/integrations/attached-agent-session-broker.md
@@ -64,6 +64,10 @@ exposes a push transport for the already-running Turn. LoopX fails closed
 instead of starting a managed runtime or silently degrading one event into
 another ingress mode.
 
+An attached Session with an active host claim cannot be closed. Complete the
+claimed Turn first, then close the Session. This preserves the host's writeback
+authority and prevents a closed Session from stranding a running Turn.
+
 Opaque host identifiers, message bodies, and response files stay in the local
 runtime store. Public Session projections contain only the LoopX Session id,
 Goal/Agent binding, executor endpoint label, host surface, capability booleans,

--- a/docs/integrations/worker-bridge-install-contract.md
+++ b/docs/integrations/worker-bridge-install-contract.md
@@ -31,6 +31,13 @@ the pull-based commands documented by the returned
 tests, expected solutions, evaluator answers, credentials, or private project
 material, and it does not authorize score or leaderboard claims.
 
+The same `worker-bridge` surface also carries the provider-neutral
+[`attached Agent session broker`](attached-agent-session-broker.md). That
+broker binds an already-running host session and lets that exact host claim and
+complete queued Web or Connector messages. It never starts a replacement
+runtime. Host session ids, message bodies, and response files remain
+owner-local.
+
 The retired benchmark result/writeback layer is preserved for source
 archaeology under
 [`deprecate/benchmark-legacy/`](https://github.com/huangruiteng/loopx/blob/main/deprecate/benchmark-legacy/README.md).

--- a/loopx/attached_session.py
+++ b/loopx/attached_session.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import hashlib
+import math
+import time
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -16,6 +18,8 @@ from .thread_agent_binding import resolve_thread_agent_binding
 ATTACHED_SESSION_BROKER_SCHEMA_VERSION = "loopx_attached_agent_session_broker_v0"
 ATTACHED_SESSION_ADAPTER_KIND = "attached_host_session"
 ATTACHED_SESSION_UPSTREAM_MODE = "host_broker"
+MAX_ATTACHED_SESSION_CLAIM_WAIT_SECONDS = 1_800.0
+ATTACHED_SESSION_CLAIM_POLL_INTERVAL_SECONDS = 0.1
 
 
 def _binding_lock_path(
@@ -155,6 +159,7 @@ def bind_attached_agent_session(
             attached_capabilities={
                 "live_steering": False,
                 "session_queue": True,
+                "claim_wait": True,
                 "reply_readback": True,
             },
         )
@@ -196,8 +201,9 @@ def claim_attached_agent_turn(
     host_surface: str,
     host_session_id: str,
     claim_id: str,
+    wait_seconds: float = 0.0,
 ) -> dict[str, Any]:
-    """Claim the oldest queued Web/connector message for the exact host session."""
+    """Claim or bounded-wait for the oldest queued message for the exact host."""
 
     _require_attached_host(
         store=store,
@@ -205,12 +211,32 @@ def claim_attached_agent_turn(
         host_surface=host_surface,
         host_session_id=host_session_id,
     )
-    turn = store.claim_next_queued_turn(session_id, host_claim_id=claim_id)
+    normalized_wait = float(wait_seconds)
+    if (
+        not math.isfinite(normalized_wait)
+        or normalized_wait < 0
+        or normalized_wait > MAX_ATTACHED_SESSION_CLAIM_WAIT_SECONDS
+    ):
+        raise ValueError(
+            "wait_seconds must be between 0 and "
+            f"{int(MAX_ATTACHED_SESSION_CLAIM_WAIT_SECONDS)}"
+        )
+    deadline = time.monotonic() + normalized_wait
+    turn = None
+    while turn is None:
+        turn = store.claim_next_queued_turn(session_id, host_claim_id=claim_id)
+        if turn is not None or normalized_wait == 0:
+            break
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        time.sleep(min(ATTACHED_SESSION_CLAIM_POLL_INTERVAL_SECONDS, remaining))
     return {
         "ok": True,
         "schema_version": ATTACHED_SESSION_BROKER_SCHEMA_VERSION,
         "action": "claim",
         "claimed": turn is not None,
+        "waited": normalized_wait > 0,
         "turn": (
             {
                 "session_id": session_id,

--- a/loopx/attached_session.py
+++ b/loopx/attached_session.py
@@ -1,0 +1,302 @@
+"""Provider-neutral broker contract for already-running Agent sessions."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from .chat_store import CHAT_SESSION_MODE_ATTACHED, ChatSessionStore
+from .control_plane.todos.contract import normalize_todo_claimed_by
+from .file_lock import exclusive_file_lock
+from .registry import find_registry_goal
+from .thread_agent_binding import resolve_thread_agent_binding
+
+ATTACHED_SESSION_BROKER_SCHEMA_VERSION = "loopx_attached_agent_session_broker_v0"
+ATTACHED_SESSION_ADAPTER_KIND = "attached_host_session"
+ATTACHED_SESSION_UPSTREAM_MODE = "host_broker"
+
+
+def _binding_lock_path(
+    store: ChatSessionStore,
+    *,
+    goal_id: str,
+    agent_id: str,
+    channel_id: str,
+) -> Path:
+    material = f"{goal_id}\0{agent_id}\0{channel_id}".encode()
+    digest = hashlib.sha256(material).hexdigest()
+    return store.root / "attached-bindings" / f"{digest}.json"
+
+
+def _registered_agent(goal: dict[str, Any], agent_id: str) -> str:
+    normalized = normalize_todo_claimed_by(agent_id)
+    if not normalized:
+        raise ValueError("agent_id must be a public-safe registered Agent id")
+    coordination = goal.get("coordination")
+    coordination = coordination if isinstance(coordination, dict) else {}
+    registered = coordination.get("registered_agents")
+    registered_ids = {
+        normalize_todo_claimed_by(item)
+        for item in (registered if isinstance(registered, list) else [])
+    }
+    if normalized not in registered_ids:
+        raise ValueError(f"agent_id={normalized!r} is not registered for this Goal")
+    return normalized
+
+
+def _require_bound_host(
+    *,
+    goal: dict[str, Any],
+    agent_id: str,
+    host_surface: str,
+    host_session_id: str,
+) -> None:
+    binding = resolve_thread_agent_binding(
+        goal,
+        host_surface=host_surface,
+        thread_id=host_session_id,
+    )
+    if binding.get("status") != "bound" or binding.get("agent_id") != agent_id:
+        raise ValueError(
+            "the host session must already be bound to the exact registered Agent"
+        )
+
+
+def bind_attached_agent_session(
+    *,
+    store: ChatSessionStore,
+    registry: dict[str, Any],
+    goal_id: str,
+    agent_id: str,
+    host_surface: str,
+    host_session_id: str,
+    executor_endpoint_id: str,
+    channel_id: str | None = None,
+    execute: bool,
+) -> dict[str, Any]:
+    """Bind one existing host session without starting or resuming an adapter."""
+
+    goal = find_registry_goal(registry, goal_id)
+    if goal is None:
+        raise ValueError(f"goal_id not found in registry: {goal_id}")
+    normalized_agent = _registered_agent(goal, agent_id)
+    _require_bound_host(
+        goal=goal,
+        agent_id=normalized_agent,
+        host_surface=host_surface,
+        host_session_id=host_session_id,
+    )
+    selected_channel = channel_id or f"goal.{goal_id}"
+    lock_path = _binding_lock_path(
+        store,
+        goal_id=goal_id,
+        agent_id=normalized_agent,
+        channel_id=selected_channel,
+    )
+    with exclusive_file_lock(
+        lock_path,
+        agent_id="loopx-chat",
+        operation="bind_attached_agent_session",
+    ):
+        latest = store.latest_session(
+            goal_id=goal_id,
+            agent_id=normalized_agent,
+            channel_id=selected_channel,
+        )
+        if latest is not None:
+            exact_match = (
+                latest.get("session_mode") == CHAT_SESSION_MODE_ATTACHED
+                and latest.get("host_surface") == host_surface
+                and latest.get("upstream_thread_id") == host_session_id
+                and latest.get("executor_endpoint_id") == executor_endpoint_id
+            )
+            if not exact_match:
+                raise ValueError(
+                    "an active working Session already exists for this Goal, Agent, and channel"
+                )
+            return {
+                "ok": True,
+                "schema_version": ATTACHED_SESSION_BROKER_SCHEMA_VERSION,
+                "action": "bind",
+                "execute": execute,
+                "changed": False,
+                "created": False,
+                "session": store.public_session(latest),
+            }
+        if not execute:
+            return {
+                "ok": True,
+                "schema_version": ATTACHED_SESSION_BROKER_SCHEMA_VERSION,
+                "action": "bind",
+                "execute": False,
+                "changed": True,
+                "created": False,
+                "binding": {
+                    "goal_id": goal_id,
+                    "agent_id": normalized_agent,
+                    "executor_endpoint_id": executor_endpoint_id,
+                    "host_surface": host_surface,
+                    "channel_id": selected_channel,
+                    "session_mode": CHAT_SESSION_MODE_ATTACHED,
+                },
+            }
+        session = store.create_session(
+            goal_id=goal_id,
+            agent_id=normalized_agent,
+            executor_endpoint_id=executor_endpoint_id,
+            adapter_kind=ATTACHED_SESSION_ADAPTER_KIND,
+            upstream_thread_id=host_session_id,
+            upstream_mode=ATTACHED_SESSION_UPSTREAM_MODE,
+            channel_id=selected_channel,
+            session_mode=CHAT_SESSION_MODE_ATTACHED,
+            host_surface=host_surface,
+            attached_capabilities={
+                "live_steering": False,
+                "session_queue": True,
+                "reply_readback": True,
+            },
+        )
+    return {
+        "ok": True,
+        "schema_version": ATTACHED_SESSION_BROKER_SCHEMA_VERSION,
+        "action": "bind",
+        "execute": True,
+        "changed": True,
+        "created": True,
+        "session": store.public_session(session),
+    }
+
+
+def _require_attached_host(
+    *,
+    store: ChatSessionStore,
+    session_id: str,
+    host_surface: str,
+    host_session_id: str,
+) -> dict[str, Any]:
+    session = store.load_session(session_id)
+    if session is None or session.get("status") == "closed":
+        raise KeyError("attached Agent session was not found")
+    if session.get("session_mode") != CHAT_SESSION_MODE_ATTACHED:
+        raise ValueError("the selected Session is not an attached host session")
+    if (
+        session.get("host_surface") != host_surface
+        or session.get("upstream_thread_id") != host_session_id
+    ):
+        raise ValueError("attached host identity does not match the Session binding")
+    return session
+
+
+def claim_attached_agent_turn(
+    *,
+    store: ChatSessionStore,
+    session_id: str,
+    host_surface: str,
+    host_session_id: str,
+    claim_id: str,
+) -> dict[str, Any]:
+    """Claim the oldest queued Web/connector message for the exact host session."""
+
+    _require_attached_host(
+        store=store,
+        session_id=session_id,
+        host_surface=host_surface,
+        host_session_id=host_session_id,
+    )
+    turn = store.claim_next_queued_turn(session_id, host_claim_id=claim_id)
+    return {
+        "ok": True,
+        "schema_version": ATTACHED_SESSION_BROKER_SCHEMA_VERSION,
+        "action": "claim",
+        "claimed": turn is not None,
+        "turn": (
+            {
+                "session_id": session_id,
+                "turn_id": str(turn.get("turn_id") or ""),
+                "client_turn_id": str(turn.get("client_turn_id") or ""),
+                "claim_id": str(turn.get("host_claim_id") or ""),
+                "origin": str(turn.get("origin") or "external"),
+                "message": str(turn.get("message") or ""),
+                "created_at": turn.get("created_at"),
+                "expires_at": turn.get("expires_at"),
+            }
+            if turn is not None
+            else None
+        ),
+    }
+
+
+def complete_attached_agent_turn(
+    *,
+    store: ChatSessionStore,
+    session_id: str,
+    turn_id: str,
+    host_surface: str,
+    host_session_id: str,
+    claim_id: str,
+    completion_id: str,
+    response: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Write back one attached-host response with duplicate-safe receipts."""
+
+    _require_attached_host(
+        store=store,
+        session_id=session_id,
+        host_surface=host_surface,
+        host_session_id=host_session_id,
+    )
+    message = str(response.get("message") or "").strip()
+    if not message:
+        raise ValueError("response.message is required")
+    if len(message) > 200_000:
+        raise ValueError("response.message is too large")
+    normalized_response = {
+        "schema_version": "loopx_chat_agent_response_v0",
+        "message": message,
+        "proposals": list(response.get("proposals") or [])[:5],
+        "gate": response.get("gate") if isinstance(response.get("gate"), Mapping) else None,
+    }
+    _turn, created = store.complete_attached_turn(
+        session_id,
+        turn_id,
+        claim_id=claim_id,
+        completion_id=completion_id,
+        response=normalized_response,
+        agent_message=message,
+    )
+    return {
+        "ok": True,
+        "schema_version": ATTACHED_SESSION_BROKER_SCHEMA_VERSION,
+        "action": "complete",
+        "completed": True,
+        "created": created,
+        "session_id": session_id,
+        "turn_id": turn_id,
+        "completion_id": completion_id,
+    }
+
+
+def render_attached_session_broker_markdown(payload: dict[str, Any]) -> str:
+    action = str(payload.get("action") or "attached-session")
+    if not payload.get("ok"):
+        return f"# Attached Agent Session\n\n- Action: `{action}`\n- Error: {payload.get('error')}"
+    if action == "claim":
+        turn = payload.get("turn")
+        if not isinstance(turn, dict):
+            return "# Attached Agent Session\n\nNo queued message is available."
+        return (
+            "# Attached Agent Session\n\n"
+            f"- Turn: `{turn.get('turn_id')}`\n"
+            f"- Origin: `{turn.get('origin')}`\n\n"
+            f"{turn.get('message')}"
+        )
+    session = payload.get("session")
+    session_id = session.get("session_id") if isinstance(session, dict) else payload.get("session_id")
+    return (
+        "# Attached Agent Session\n\n"
+        f"- Action: `{action}`\n"
+        f"- Session: `{session_id or 'preview'}`\n"
+        f"- Changed: `{bool(payload.get('changed') or payload.get('created'))}`"
+    )

--- a/loopx/attached_session.py
+++ b/loopx/attached_session.py
@@ -9,6 +9,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from .chat import normalize_agent_response
 from .chat_store import CHAT_SESSION_MODE_ATTACHED, ChatSessionStore
 from .control_plane.todos.contract import normalize_todo_claimed_by
 from .file_lock import exclusive_file_lock
@@ -273,17 +274,15 @@ def complete_attached_agent_turn(
         host_surface=host_surface,
         host_session_id=host_session_id,
     )
-    message = str(response.get("message") or "").strip()
+    normalized_response = normalize_agent_response(
+        response,
+        protected_paths=(store.root,),
+    )
+    message = str(normalized_response.get("message") or "")
     if not message:
         raise ValueError("response.message is required")
     if len(message) > 200_000:
         raise ValueError("response.message is too large")
-    normalized_response = {
-        "schema_version": "loopx_chat_agent_response_v0",
-        "message": message,
-        "proposals": list(response.get("proposals") or [])[:5],
-        "gate": response.get("gate") if isinstance(response.get("gate"), Mapping) else None,
-    }
     _turn, created = store.complete_attached_turn(
         session_id,
         turn_id,

--- a/loopx/attached_session_api.py
+++ b/loopx/attached_session_api.py
@@ -1,0 +1,78 @@
+"""Loopback API mixin for binding already-running Agent sessions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .attached_session import bind_attached_agent_session
+
+
+def _compact_id(value: Any, *, limit: int = 160) -> str:
+    text = str(value or "").strip()
+    if len(text) > limit or any(ord(character) < 32 for character in text):
+        raise ValueError("attached session field must be a bounded opaque string")
+    return text
+
+
+class AttachedSessionRequestMixin:
+    """Serve the owner-local attached Session binding endpoint."""
+
+    server: Any
+
+    def _read_json(self) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def _registry_and_goal(
+        self,
+        goal_id: str,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        raise NotImplementedError
+
+    def _send_json(self, payload: dict[str, Any], *, status: int = 200) -> None:
+        raise NotImplementedError
+
+    def _send_error(self, message: str, **kwargs: Any) -> None:
+        raise NotImplementedError
+
+    def _attach_session(self) -> None:
+        try:
+            body = self._read_json()
+            allowed = {
+                "goal_id",
+                "agent_id",
+                "host_surface",
+                "host_session_id",
+                "executor_endpoint_id",
+                "channel_id",
+            }
+            if set(body) - allowed:
+                raise ValueError("unknown attached session field")
+            required = {
+                key: _compact_id(body.get(key))
+                for key in (
+                    "goal_id",
+                    "agent_id",
+                    "host_surface",
+                    "host_session_id",
+                    "executor_endpoint_id",
+                )
+            }
+            missing = [key for key, value in required.items() if not value]
+            if missing:
+                raise ValueError(f"missing attached session fields: {', '.join(missing)}")
+            registry, _goal = self._registry_and_goal(required["goal_id"])
+            packet = bind_attached_agent_session(
+                store=self.server.chat_store,
+                registry=registry,
+                goal_id=required["goal_id"],
+                agent_id=required["agent_id"],
+                host_surface=required["host_surface"],
+                host_session_id=required["host_session_id"],
+                executor_endpoint_id=required["executor_endpoint_id"],
+                channel_id=_compact_id(body.get("channel_id")) or None,
+                execute=True,
+            )
+        except Exception as exc:  # noqa: BLE001 - compact loopback validation error.
+            self._send_error(str(exc))
+            return
+        self._send_json(packet, status=201 if packet.get("created") else 200)

--- a/loopx/attached_session_api.py
+++ b/loopx/attached_session_api.py
@@ -15,7 +15,7 @@ def _compact_id(value: Any, *, limit: int = 160) -> str:
 
 
 class AttachedSessionRequestMixin:
-    """Serve the owner-local attached Session binding endpoint."""
+    """Serve owner-local attached Session binding and lifecycle boundaries."""
 
     server: Any
 
@@ -76,3 +76,20 @@ class AttachedSessionRequestMixin:
             self._send_error(str(exc))
             return
         self._send_json(packet, status=201 if packet.get("created") else 200)
+
+    def _close_session(self, session_id: str) -> None:
+        try:
+            closed = self.server.runtime_controller.close_session(session_id)
+        except RuntimeError as exc:
+            if str(exc) != "attached_session_turn_active":
+                raise
+            self._send_error(
+                "complete the active attached Agent turn before closing the session",
+                status=409,
+                error_code="attached_session_turn_active",
+            )
+            return
+        if not closed:
+            self._send_error("chat session was not found", status=404)
+            return
+        self._send_json({"ok": True, "session_id": session_id, "closed": True})

--- a/loopx/chat.py
+++ b/loopx/chat.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 import re
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping
 
 from .todos import add_goal_todo
 
@@ -190,6 +190,29 @@ def _normalize_gate(value: Any, *, protected_paths: Iterable[Path | str]) -> dic
     }
 
 
+def normalize_agent_response(
+    payload: Mapping[str, Any],
+    *,
+    protected_paths: Iterable[Path | str] = (),
+) -> dict[str, Any]:
+    """Normalize one structured provider response to the public Chat contract."""
+
+    protected = tuple(protected_paths)
+    message = redact_local_paths(
+        str(payload.get("message") or ""),
+        protected_paths=protected,
+    ).strip()
+    return {
+        "schema_version": CHAT_AGENT_RESPONSE_SCHEMA_VERSION,
+        "message": message,
+        "proposals": _normalize_proposals(
+            payload.get("proposals"),
+            protected_paths=protected,
+        ),
+        "gate": _normalize_gate(payload.get("gate"), protected_paths=protected),
+    }
+
+
 def parse_agent_response(
     raw_text: str,
     *,
@@ -205,13 +228,7 @@ def parse_agent_response(
         except json.JSONDecodeError:
             payload = None
         if isinstance(payload, dict):
-            message = redact_local_paths(str(payload.get("message") or ""), protected_paths=protected).strip()
-            return {
-                "schema_version": CHAT_AGENT_RESPONSE_SCHEMA_VERSION,
-                "message": message,
-                "proposals": _normalize_proposals(payload.get("proposals"), protected_paths=protected),
-                "gate": _normalize_gate(payload.get("gate"), protected_paths=protected),
-            }
+            return normalize_agent_response(payload, protected_paths=protected)
         key = re.search(r'"message"\s*:\s*', body)
         if key:
             try:

--- a/loopx/chat_runtime.py
+++ b/loopx/chat_runtime.py
@@ -13,7 +13,7 @@ from typing import Any, Callable, Protocol
 from .chat_acp import ACPStdioAdapter
 from .chat_agent import CodexChatAgentError, CodexChatAgentSession, CodexChatTimeoutError
 from .chat_endpoints import AgentEndpointRegistry
-from .chat_store import ChatSessionStore, utc_now
+from .chat_store import CHAT_SESSION_MODE_ATTACHED, ChatSessionStore, utc_now
 from .chat_providers import ClaudeCodeAdapter, direct_model_from_environment
 
 
@@ -378,6 +378,7 @@ class ChatRuntimeController:
             persisted = self.store.create_session(
                 goal_id=goal_id,
                 agent_id=agent_id,
+                executor_endpoint_id=agent_id,
                 adapter_kind=str(capability["adapter_kind"]),
                 upstream_thread_id=adapter.upstream_thread_id,
                 upstream_mode="chat" if agent_id == "codex" else "default",
@@ -395,6 +396,11 @@ class ChatRuntimeController:
         objective: str,
     ) -> ChatRuntimeAdapter:
         session_id = str(session["session_id"])
+        if session.get("session_mode") == CHAT_SESSION_MODE_ATTACHED:
+            raise CodexChatAgentError(
+                "The attached host Session must be served by its existing host bridge.",
+                error_code="attached_session_requires_host_bridge",
+            )
         with self.lock:
             current = self.adapters.get(session_id)
             if current is not None and current.healthcheck():
@@ -507,6 +513,15 @@ class ChatRuntimeController:
         session = self.store.load_session(session_id)
         if session is None:
             raise KeyError("chat session was not found")
+        if session.get("session_mode") == CHAT_SESSION_MODE_ATTACHED:
+            if attachments:
+                raise ValueError("attached host session queue does not yet accept attachments")
+            return self.store.create_queued_turn(
+                session_id,
+                client_turn_id=client_turn_id,
+                message=message,
+                origin="web",
+            )
         adapter = self._ensure_adapter(session, work_dir=work_dir, objective=objective)
         turn, created = self.store.create_turn(
             session_id,
@@ -550,6 +565,18 @@ class ChatRuntimeController:
             mode="live_steering",
             message=message,
         )
+        if session.get("session_mode") == CHAT_SESSION_MODE_ATTACHED:
+            capabilities = session.get("attached_capabilities")
+            capabilities = capabilities if isinstance(capabilities, dict) else {}
+            if capabilities.get("live_steering") is not True:
+                if created:
+                    self.store.update_ingress_receipt(
+                        session_id,
+                        client_ingress_id,
+                        status="failed",
+                        error_code="attached_session_live_steering_unavailable",
+                    )
+                raise RuntimeError("attached_session_live_steering_unavailable")
         if not created:
             if receipt.get("status") == "delivered":
                 delivered_turn_id = str(receipt.get("active_turn_id") or "")
@@ -635,6 +662,7 @@ class ChatRuntimeController:
         message: str,
         work_dir: Path,
         objective: str,
+        origin: str = "external",
     ) -> tuple[dict[str, Any], bool]:
         """Persist a bounded same-Session Turn and dispatch it in FIFO order."""
 
@@ -645,12 +673,14 @@ class ChatRuntimeController:
             session_id,
             client_turn_id=client_turn_id,
             message=message,
+            origin=origin,
         )
-        self.resume_session_queue(
-            session_id=session_id,
-            work_dir=work_dir,
-            objective=objective,
-        )
+        if session.get("session_mode") != CHAT_SESSION_MODE_ATTACHED:
+            self.resume_session_queue(
+                session_id=session_id,
+                work_dir=work_dir,
+                objective=objective,
+            )
         return turn, created
 
     def resume_session_queue(
@@ -661,6 +691,9 @@ class ChatRuntimeController:
         objective: str,
     ) -> None:
         if self.closed.is_set():
+            return
+        session = self.store.load_session(session_id)
+        if session is None or session.get("session_mode") == CHAT_SESSION_MODE_ATTACHED:
             return
         with self.lock:
             if session_id in self.session_queue_workers:
@@ -959,6 +992,16 @@ class ChatRuntimeController:
         session = self.store.load_session(session_id)
         if session is None or session.get("status") == "closed":
             raise KeyError("chat session was not found")
+        if session.get("session_mode") == CHAT_SESSION_MODE_ATTACHED:
+            if session.get("active_turn_id"):
+                return session
+            restored = self.store.update_session(
+                session_id,
+                status="ready",
+                active_turn_id=None,
+                last_error_code=None,
+            )
+            return restored
         self.store.update_session(
             session_id,
             status="stale",

--- a/loopx/chat_runtime.py
+++ b/loopx/chat_runtime.py
@@ -822,10 +822,6 @@ class ChatRuntimeController:
                 )
             if adapter.upstream_thread_id != str((self.store.load_session(session_id) or {}).get("upstream_thread_id") or ""):
                 self.store.update_session(session_id, upstream_thread_id=adapter.upstream_thread_id)
-            for proposal in response.get("proposals") or []:
-                self.store.append_event(session_id, turn_id, kind="proposal.ready", payload={"proposal": proposal})
-            if response.get("gate"):
-                self.store.append_event(session_id, turn_id, kind="gate.ready", payload={"gate": response["gate"]})
             completed = utc_now()
             self.store.update_turn(
                 session_id,
@@ -835,7 +831,11 @@ class ChatRuntimeController:
                 completed_at=completed,
                 last_activity_at=completed,
             )
-            self.store.append_event(session_id, turn_id, kind="turn.completed", payload={"response": response})
+            self.store.append_completed_response_events(
+                session_id,
+                turn_id,
+                response=response,
+            )
             self.store.update_session(
                 session_id,
                 status="ready",
@@ -974,6 +974,8 @@ class ChatRuntimeController:
         session = self.store.load_session(session_id)
         if session is None:
             return False
+        if session.get("session_mode") == CHAT_SESSION_MODE_ATTACHED:
+            return self.store.close_attached_session(session_id)
         with self.lock:
             adapter = self.adapters.pop(session_id, None)
             event_buffers = [

--- a/loopx/chat_server.py
+++ b/loopx/chat_server.py
@@ -1397,9 +1397,7 @@ class ChatRequestHandler(
         if not path.startswith(prefix):
             return self._send_error("unknown path", status=404)
         session_id = path[len(prefix) :].strip("/")
-        if not self.server.runtime_controller.close_session(session_id):
-            return self._send_error("chat session was not found", status=404)
-        self._send_json({"ok": True, "session_id": session_id, "closed": True})
+        self._close_session(session_id)
 
     def log_message(self, format: str, *args: object) -> None:
         if self.server.verbose:

--- a/loopx/chat_server.py
+++ b/loopx/chat_server.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
+from .attached_session_api import AttachedSessionRequestMixin
 from .chat import (
     TodoReviewPreviewConflict,
     apply_todo_review_preview,
@@ -75,6 +76,7 @@ DEFAULT_CHAT_STATUS_PATH = "/status.json"
 CHAT_CAPABILITIES_PATH = "/api/chat/capabilities"
 CHAT_ENDPOINTS_PATH = "/api/chat/endpoints"
 CHAT_SESSIONS_PATH = "/api/chat/sessions"
+CHAT_ATTACH_SESSION_PATH = f"{CHAT_SESSIONS_PATH}/attach"
 CHAT_PROJECTION_MESSAGES_PATH = "/api/chat/projection-messages"
 MANAGER_AGENT_GOAL_ID = "loopx-manager"
 MANAGER_AGENT_OBJECTIVE = (
@@ -424,7 +426,11 @@ class ChatHTTPServer(ThreadingHTTPServer):
         super().server_close()
 
 
-class ChatRequestHandler(LarkChatRequestMixin, BaseHTTPRequestHandler):
+class ChatRequestHandler(
+    AttachedSessionRequestMixin,
+    LarkChatRequestMixin,
+    BaseHTTPRequestHandler,
+):
     server: ChatHTTPServer
 
     def _send_json(self, payload: dict[str, Any], *, status: int = 200) -> None:
@@ -1288,6 +1294,7 @@ class ChatRequestHandler(LarkChatRequestMixin, BaseHTTPRequestHandler):
                     "resume": True,
                     "interrupt": True,
                     "typed_actions": True,
+                    "attached_session_broker": True,
                     "action_kinds": sorted(ACTION_KINDS),
                     "adapters": self.server.runtime_controller.capabilities(),
                     "lark_cli": self.server.lark_cli_resolution.public_snapshot(),
@@ -1340,6 +1347,7 @@ class ChatRequestHandler(LarkChatRequestMixin, BaseHTTPRequestHandler):
         path = urlparse(self.path).path
         post_dispatch = {
             CHAT_SESSIONS_PATH: self._create_session,
+            CHAT_ATTACH_SESSION_PATH: self._attach_session,
             CHAT_PROJECTION_MESSAGES_PATH: self._record_projection_exchange,
             CHAT_ACTION_PREVIEW_PATH: self._action_preview,
             CHAT_TODO_DRY_RUN_PATH: lambda: self._todo(apply=False),

--- a/loopx/chat_store.py
+++ b/loopx/chat_store.py
@@ -193,7 +193,8 @@ class ChatSessionStore:
         capabilities = {
             str(key): bool(value)
             for key, value in (attached_capabilities or {}).items()
-            if str(key) in {"live_steering", "session_queue", "reply_readback"}
+            if str(key)
+            in {"live_steering", "session_queue", "claim_wait", "reply_readback"}
         }
         normalized_goal_id = _opaque_id(goal_id, field="goal_id")
         normalized_agent_id = _opaque_id(agent_id, field="agent_id")

--- a/loopx/chat_store.py
+++ b/loopx/chat_store.py
@@ -20,6 +20,8 @@ CHAT_TURN_SCHEMA_VERSION = "loopx_chat_turn_state_v1"
 CHAT_EVENT_SCHEMA_VERSION = "loopx_chat_event_v1"
 CHAT_MESSAGE_SCHEMA_VERSION = "loopx_chat_message_v1"
 CHAT_INGRESS_SCHEMA_VERSION = "loopx_chat_ingress_receipt_v1"
+CHAT_SESSION_MODE_MANAGED = "managed_runtime"
+CHAT_SESSION_MODE_ATTACHED = "attached_host"
 RESUMABLE_SESSION_STATES = {"ready", "busy", "stale", "resuming"}
 SESSION_QUEUE_MAX_PENDING = 20
 SESSION_QUEUE_TTL_SECONDS = 3600
@@ -170,21 +172,58 @@ class ChatSessionStore:
         upstream_mode: str = "default",
         channel_id: str | None = None,
         session_id: str | None = None,
+        session_mode: str = CHAT_SESSION_MODE_MANAGED,
+        executor_endpoint_id: str | None = None,
+        host_surface: str | None = None,
+        attached_capabilities: dict[str, bool] | None = None,
     ) -> dict[str, Any]:
         now = utc_now()
         token = _opaque_id(session_id or uuid.uuid4().hex, field="session_id")
+        normalized_mode = _opaque_id(session_mode, field="session_mode")
+        if normalized_mode not in {
+            CHAT_SESSION_MODE_MANAGED,
+            CHAT_SESSION_MODE_ATTACHED,
+        }:
+            raise ValueError("session_mode must be managed_runtime or attached_host")
+        normalized_host_surface = (
+            _opaque_id(host_surface, field="host_surface") if host_surface else None
+        )
+        if normalized_mode == CHAT_SESSION_MODE_ATTACHED and not normalized_host_surface:
+            raise ValueError("attached_host sessions require host_surface")
+        capabilities = {
+            str(key): bool(value)
+            for key, value in (attached_capabilities or {}).items()
+            if str(key) in {"live_steering", "session_queue", "reply_readback"}
+        }
+        normalized_goal_id = _opaque_id(goal_id, field="goal_id")
+        normalized_agent_id = _opaque_id(agent_id, field="agent_id")
+        normalized_executor_endpoint_id = _opaque_id(
+            executor_endpoint_id or agent_id,
+            field="executor_endpoint_id",
+        )
+        normalized_adapter_kind = _opaque_id(adapter_kind, field="adapter_kind")
+        normalized_upstream_thread_id = _upstream_id(upstream_thread_id)
+        normalized_upstream_mode = _opaque_id(upstream_mode, field="upstream_mode")
+        normalized_channel_id = _opaque_id(
+            channel_id or f"goal.{goal_id}",
+            field="channel_id",
+        )
         session_dir = self._session_dir(token)
         session_dir.mkdir(parents=True, exist_ok=False, mode=0o700)
         (session_dir / "turns").mkdir(mode=0o700)
         payload = {
             "schema_version": CHAT_SESSION_SCHEMA_VERSION,
             "session_id": token,
-            "goal_id": _opaque_id(goal_id, field="goal_id"),
-            "agent_id": _opaque_id(agent_id, field="agent_id"),
-            "adapter_kind": _opaque_id(adapter_kind, field="adapter_kind"),
-            "upstream_thread_id": _upstream_id(upstream_thread_id),
-            "upstream_mode": _opaque_id(upstream_mode, field="upstream_mode"),
-            "channel_id": _opaque_id(channel_id or f"goal.{goal_id}", field="channel_id"),
+            "goal_id": normalized_goal_id,
+            "agent_id": normalized_agent_id,
+            "executor_endpoint_id": normalized_executor_endpoint_id,
+            "adapter_kind": normalized_adapter_kind,
+            "upstream_thread_id": normalized_upstream_thread_id,
+            "upstream_mode": normalized_upstream_mode,
+            "session_mode": normalized_mode,
+            "host_surface": normalized_host_surface,
+            "attached_capabilities": capabilities,
+            "channel_id": normalized_channel_id,
             "status": "ready",
             "active_turn_id": None,
             "last_error_code": None,
@@ -278,19 +317,28 @@ class ChatSessionStore:
         text: str,
         turn_id: str | None = None,
         attachments: list[dict[str, Any]] | None = None,
+        origin: str | None = None,
+        message_id: str | None = None,
     ) -> dict[str, Any]:
         session_dir = self._session_dir(session_id)
         path = session_dir / "messages.jsonl"
         payload = {
             "schema_version": CHAT_MESSAGE_SCHEMA_VERSION,
-            "message_id": uuid.uuid4().hex,
+            "message_id": _opaque_id(
+                message_id or uuid.uuid4().hex,
+                field="message_id",
+            ),
             "turn_id": _opaque_id(turn_id, field="turn_id") if turn_id else None,
             "role": role,
             "text": str(text),
+            **({"origin": _opaque_id(origin, field="origin")} if origin else {}),
             **({"attachments": attachments} if attachments else {}),
             "created_at": utc_now(),
         }
         with exclusive_file_lock(path, agent_id="loopx-chat", operation="append_chat_message"):
+            for existing in _read_jsonl(path):
+                if existing.get("message_id") == payload["message_id"]:
+                    return existing
             _append_jsonl(path, payload)
         return payload
 
@@ -369,6 +417,7 @@ class ChatSessionStore:
         client_turn_id: str,
         message: str,
         attachments: list[dict[str, Any]] | None = None,
+        origin: str = "web",
     ) -> tuple[dict[str, Any], bool]:
         client_id = _opaque_id(client_turn_id, field="client_turn_id")
         existing = self.turn_for_client(session_id, client_id)
@@ -391,6 +440,7 @@ class ChatSessionStore:
             "client_turn_id": client_id,
             "status": "queued",
             "message": str(message),
+            "origin": _opaque_id(origin, field="origin"),
             "upstream_turn_id": None,
             "response": None,
             "error_code": None,
@@ -413,6 +463,7 @@ class ChatSessionStore:
             text=message,
             turn_id=turn_id,
             attachments=attachments,
+            origin=origin,
         )
         self.append_event(session_id, turn_id, kind="turn.queued", payload={})
         return payload, True
@@ -424,6 +475,7 @@ class ChatSessionStore:
         client_turn_id: str,
         message: str,
         ttl_seconds: int = SESSION_QUEUE_TTL_SECONDS,
+        origin: str = "external",
     ) -> tuple[dict[str, Any], bool]:
         """Persist one bounded follow-up without replacing the active Turn."""
 
@@ -449,6 +501,7 @@ class ChatSessionStore:
             "client_turn_id": client_id,
             "status": "queued",
             "message": str(message),
+            "origin": _opaque_id(origin, field="origin"),
             "upstream_turn_id": None,
             "response": None,
             "error_code": None,
@@ -467,7 +520,13 @@ class ChatSessionStore:
         path = self._turn_path(session_id, turn_id)
         _atomic_write_json(path, payload)
         os.chmod(path, 0o600)
-        self.append_message(session_id, role="user", text=message, turn_id=turn_id)
+        self.append_message(
+            session_id,
+            role="user",
+            text=message,
+            turn_id=turn_id,
+            origin=origin,
+        )
         self.append_event(
             session_id,
             turn_id,
@@ -501,7 +560,12 @@ class ChatSessionStore:
             ),
         )
 
-    def claim_next_queued_turn(self, session_id: str) -> dict[str, Any] | None:
+    def claim_next_queued_turn(
+        self,
+        session_id: str,
+        *,
+        host_claim_id: str | None = None,
+    ) -> dict[str, Any] | None:
         """Atomically make the oldest live queued Turn active for its Session."""
 
         session_path = self._session_path(session_id)
@@ -513,7 +577,18 @@ class ChatSessionStore:
             session = self.load_session(session_id)
             if session is None:
                 raise KeyError("chat session was not found")
-            if session.get("status") == "closed" or session.get("active_turn_id"):
+            if session.get("status") == "closed":
+                return None
+            active_turn_id = str(session.get("active_turn_id") or "")
+            if active_turn_id:
+                active = self.load_turn(session_id, active_turn_id)
+                if (
+                    active
+                    and host_claim_id
+                    and active.get("host_claim_id") == host_claim_id
+                    and active.get("status") in {"starting", "running"}
+                ):
+                    return active
                 return None
             now = datetime.now(timezone.utc)
             for turn in self.queued_turns(session_id):
@@ -537,6 +612,30 @@ class ChatSessionStore:
                         payload={"error_code": "session_queue_expired"},
                     )
                     continue
+                if host_claim_id:
+                    now_text = utc_now()
+                    turn.update(
+                        {
+                            "status": "running",
+                            "host_claim_id": _opaque_id(
+                                host_claim_id,
+                                field="host_claim_id",
+                            ),
+                            "started_at": turn.get("started_at") or now_text,
+                            "last_activity_at": now_text,
+                        }
+                    )
+                    _atomic_write_json(
+                        self._turn_path(session_id, turn_id),
+                        turn,
+                        preserve_mode=True,
+                    )
+                    self.append_event(
+                        session_id,
+                        turn_id,
+                        kind="turn.claimed_by_attached_host",
+                        payload={"host_claim_id": host_claim_id},
+                    )
                 session.update(
                     {
                         "status": "busy",
@@ -572,7 +671,8 @@ class ChatSessionStore:
             allowed = {
                 "status", "upstream_turn_id", "response", "error_code", "error",
                 "started_at", "first_event_at", "completed_at", "last_activity_at",
-                "delta_count", "sse_reconnect_count", "expires_at",
+                "delta_count", "sse_reconnect_count", "expires_at", "host_claim_id",
+                "completion_id",
             }
             unknown = set(changes) - allowed
             if unknown:
@@ -580,6 +680,96 @@ class ChatSessionStore:
             payload.update(changes)
             _atomic_write_json(path, payload, preserve_mode=True)
             return payload
+
+    def complete_attached_turn(
+        self,
+        session_id: str,
+        turn_id: str,
+        *,
+        claim_id: str,
+        completion_id: str,
+        response: dict[str, Any],
+        agent_message: str,
+    ) -> tuple[dict[str, Any], bool]:
+        """Complete one attached-host claim with idempotent transcript writeback."""
+
+        turn_path = self._turn_path(session_id, turn_id)
+        normalized_claim_id = _opaque_id(claim_id, field="claim_id")
+        normalized_completion_id = _opaque_id(completion_id, field="completion_id")
+        with exclusive_file_lock(
+            turn_path,
+            agent_id="loopx-chat",
+            operation="complete_attached_chat_turn",
+        ):
+            session = self.load_session(session_id)
+            turn = self.load_turn(session_id, turn_id)
+            if session is None or turn is None:
+                raise KeyError("attached Agent turn was not found")
+            created = turn.get("status") != "completed"
+            if not created:
+                if turn.get("completion_id") != normalized_completion_id:
+                    raise ValueError("the Turn was already completed by another receipt")
+            else:
+                if (
+                    session.get("active_turn_id") != turn_id
+                    or turn.get("status") != "running"
+                ):
+                    raise ValueError(
+                        "the Turn is not the active claimed attached-host Turn"
+                    )
+                if turn.get("host_claim_id") != normalized_claim_id:
+                    raise ValueError(
+                        "claim_id does not own the active attached-host Turn"
+                    )
+                completed_at = utc_now()
+                turn.update(
+                    {
+                        "status": "completed",
+                        "response": response,
+                        "completion_id": normalized_completion_id,
+                        "completed_at": completed_at,
+                        "last_activity_at": completed_at,
+                        "error_code": None,
+                        "error": None,
+                    }
+                )
+                _atomic_write_json(turn_path, turn, preserve_mode=True)
+
+            completed_at = str(turn.get("completed_at") or utc_now())
+            stored_response = turn.get("response")
+            transcript_message = (
+                str(stored_response.get("message") or agent_message)
+                if isinstance(stored_response, dict)
+                else agent_message
+            )
+            self.append_message(
+                session_id,
+                role="agent",
+                text=transcript_message,
+                turn_id=turn_id,
+                origin="attached_host",
+                message_id=f"attached.{normalized_completion_id}",
+            )
+            if created:
+                self.append_event(
+                    session_id,
+                    turn_id,
+                    kind="turn.completed",
+                    payload={
+                        "delivery_mode": CHAT_SESSION_MODE_ATTACHED,
+                        "completion_id": normalized_completion_id,
+                    },
+                )
+            current_session = self.load_session(session_id)
+            if current_session and current_session.get("active_turn_id") == turn_id:
+                self.update_session(
+                    session_id,
+                    status="ready",
+                    active_turn_id=None,
+                    last_activity_at=completed_at,
+                    last_error_code=None,
+                )
+            return turn, created
 
     def _event_rows_locked(self, session_id: str, turn_id: str) -> list[dict[str, Any]]:
         key = (session_id, turn_id)
@@ -691,6 +881,7 @@ class ChatSessionStore:
         return compacted
 
     def public_session(self, payload: dict[str, Any]) -> dict[str, Any]:
+        session_mode = str(payload.get("session_mode") or CHAT_SESSION_MODE_MANAGED)
         return {
             key: payload.get(key)
             for key in (
@@ -698,6 +889,16 @@ class ChatSessionStore:
                 "active_turn_id", "last_error_code", "created_at", "updated_at", "last_activity_at",
             )
         } | {
+            "session_mode": session_mode,
+            "executor_endpoint_id": str(
+                payload.get("executor_endpoint_id") or payload.get("agent_id") or ""
+            ),
+            "host_surface": payload.get("host_surface"),
+            "attached_capabilities": (
+                dict(payload.get("attached_capabilities") or {})
+                if session_mode == CHAT_SESSION_MODE_ATTACHED
+                else {}
+            ),
             "channel_id": _session_channel(payload),
             "resumable": bool(payload.get("upstream_thread_id"))
             and payload.get("status") in RESUMABLE_SESSION_STATES,

--- a/loopx/chat_store.py
+++ b/loopx/chat_store.py
@@ -682,6 +682,37 @@ class ChatSessionStore:
             _atomic_write_json(path, payload, preserve_mode=True)
             return payload
 
+    def append_completed_response_events(
+        self,
+        session_id: str,
+        turn_id: str,
+        *,
+        response: dict[str, Any],
+        terminal_metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Emit the canonical structured-response events for a completed Turn."""
+
+        for proposal in response.get("proposals") or []:
+            self.append_event(
+                session_id,
+                turn_id,
+                kind="proposal.ready",
+                payload={"proposal": proposal},
+            )
+        if response.get("gate"):
+            self.append_event(
+                session_id,
+                turn_id,
+                kind="gate.ready",
+                payload={"gate": response["gate"]},
+            )
+        self.append_event(
+            session_id,
+            turn_id,
+            kind="turn.completed",
+            payload={**(terminal_metadata or {}), "response": response},
+        )
+
     def complete_attached_turn(
         self,
         session_id: str,
@@ -752,15 +783,16 @@ class ChatSessionStore:
                 message_id=f"attached.{normalized_completion_id}",
             )
             if created:
-                self.append_event(
-                    session_id,
-                    turn_id,
-                    kind="turn.completed",
-                    payload={
-                        "delivery_mode": CHAT_SESSION_MODE_ATTACHED,
-                        "completion_id": normalized_completion_id,
-                    },
-                )
+                if isinstance(stored_response, dict):
+                    self.append_completed_response_events(
+                        session_id,
+                        turn_id,
+                        response=stored_response,
+                        terminal_metadata={
+                            "delivery_mode": CHAT_SESSION_MODE_ATTACHED,
+                            "completion_id": normalized_completion_id,
+                        },
+                    )
             current_session = self.load_session(session_id)
             if current_session and current_session.get("active_turn_id") == turn_id:
                 self.update_session(
@@ -771,6 +803,44 @@ class ChatSessionStore:
                     last_error_code=None,
                 )
             return turn, created
+
+    def close_attached_session(self, session_id: str) -> bool:
+        """Close an idle attached Session without stranding a claimed Turn."""
+
+        session_path = self._session_path(session_id)
+        with exclusive_file_lock(
+            session_path,
+            agent_id="loopx-chat",
+            operation="close_attached_chat_session",
+        ):
+            session = self.load_session(session_id)
+            if session is None:
+                return False
+            if session.get("session_mode") != CHAT_SESSION_MODE_ATTACHED:
+                raise ValueError("the selected Session is not an attached host session")
+            if session.get("status") == "closed":
+                return True
+            active_turn_id = str(session.get("active_turn_id") or "")
+            if active_turn_id:
+                active_turn = self.load_turn(session_id, active_turn_id)
+                if active_turn and active_turn.get("status") not in {
+                    "completed",
+                    "interrupted",
+                    "timed_out",
+                    "failed",
+                }:
+                    raise RuntimeError("attached_session_turn_active")
+            now = utc_now()
+            session.update(
+                {
+                    "status": "closed",
+                    "active_turn_id": None,
+                    "last_activity_at": now,
+                    "updated_at": now,
+                }
+            )
+            _atomic_write_json(session_path, session, preserve_mode=True)
+            return True
 
     def _event_rows_locked(self, session_id: str, turn_id: str) -> list[dict[str, Any]]:
         key = (session_id, turn_id)

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -444,6 +444,7 @@ def main(argv: list[str] | None = None) -> int:
         args,
         print_payload=print_payload,
         output_format=output_format,
+        registry_path=registry_path,
     )
     if worker_bridge_result is not None:
         return worker_bridge_result

--- a/loopx/cli_commands/worker_bridge.py
+++ b/loopx/cli_commands/worker_bridge.py
@@ -343,6 +343,15 @@ def register_worker_bridge_commands(
     attached_claim_parser.add_argument("--host-surface", required=True)
     attached_claim_parser.add_argument("--host-session-id", required=True)
     attached_claim_parser.add_argument("--claim-id", required=True)
+    attached_claim_parser.add_argument(
+        "--wait-seconds",
+        type=float,
+        default=0.0,
+        help=(
+            "Wait up to this many seconds for one queued message before returning. "
+            "The bounded host subscription is capped at 1800 seconds."
+        ),
+    )
 
     attached_complete_parser = worker_bridge_sub.add_parser(
         "attached-session-complete",
@@ -436,6 +445,7 @@ def handle_worker_bridge_command(
                     host_surface=args.host_surface,
                     host_session_id=args.host_session_id,
                     claim_id=args.claim_id,
+                    wait_seconds=args.wait_seconds,
                 )
             else:
                 if args.response_json == "-":

--- a/loopx/cli_commands/worker_bridge.py
+++ b/loopx/cli_commands/worker_bridge.py
@@ -6,6 +6,15 @@ import sys
 from collections.abc import Callable
 from pathlib import Path
 
+from ..attached_session import (
+    bind_attached_agent_session,
+    claim_attached_agent_turn,
+    complete_attached_agent_turn,
+    render_attached_session_broker_markdown,
+)
+from ..chat_store import CHAT_SESSION_MODE_ATTACHED, ChatSessionStore
+from ..history import load_registry
+from ..paths import resolve_runtime_root
 from ..worker_bridge import (
     DEFAULT_ACTIVE_USER_CODEX_BIN,
     DEFAULT_ACTIVE_USER_SIMULATOR_CONTEXT_DIR,
@@ -44,6 +53,10 @@ WORKER_BRIDGE_COMMANDS = {
     "active-user-observe",
     "active-user-simulator-output",
     "contract",
+    "attached-session-bind",
+    "attached-session-claim",
+    "attached-session-complete",
+    "attached-session-list",
 }
 
 
@@ -300,12 +313,61 @@ def register_worker_bridge_commands(
         help="Compact classification label for optional counter/checkpoint writeback.",
     )
 
+    attached_bind_parser = worker_bridge_sub.add_parser(
+        "attached-session-bind",
+        help="Bind an already-running host session to one registered LoopX Agent.",
+    )
+    add_subcommand_format(attached_bind_parser)
+    attached_bind_parser.add_argument("--goal-id", required=True)
+    attached_bind_parser.add_argument("--agent-id", required=True)
+    attached_bind_parser.add_argument("--host-surface", required=True)
+    attached_bind_parser.add_argument("--host-session-id", required=True)
+    attached_bind_parser.add_argument("--executor-endpoint-id", required=True)
+    attached_bind_parser.add_argument("--channel-id")
+    attached_bind_parser.add_argument("--execute", action="store_true")
+
+    attached_list_parser = worker_bridge_sub.add_parser(
+        "attached-session-list",
+        help="List content-free attached Session descriptors.",
+    )
+    add_subcommand_format(attached_list_parser)
+    attached_list_parser.add_argument("--goal-id")
+    attached_list_parser.add_argument("--agent-id")
+
+    attached_claim_parser = worker_bridge_sub.add_parser(
+        "attached-session-claim",
+        help="Claim the oldest queued Web or Connector message for an attached host.",
+    )
+    add_subcommand_format(attached_claim_parser)
+    attached_claim_parser.add_argument("--session-id", required=True)
+    attached_claim_parser.add_argument("--host-surface", required=True)
+    attached_claim_parser.add_argument("--host-session-id", required=True)
+    attached_claim_parser.add_argument("--claim-id", required=True)
+
+    attached_complete_parser = worker_bridge_sub.add_parser(
+        "attached-session-complete",
+        help="Write back one duplicate-safe attached-host response.",
+    )
+    add_subcommand_format(attached_complete_parser)
+    attached_complete_parser.add_argument("--session-id", required=True)
+    attached_complete_parser.add_argument("--turn-id", required=True)
+    attached_complete_parser.add_argument("--host-surface", required=True)
+    attached_complete_parser.add_argument("--host-session-id", required=True)
+    attached_complete_parser.add_argument("--claim-id", required=True)
+    attached_complete_parser.add_argument("--completion-id", required=True)
+    attached_complete_parser.add_argument(
+        "--response-json",
+        required=True,
+        help="Owner-local response JSON path, or '-' for stdin.",
+    )
+
 
 def handle_worker_bridge_command(
     args: argparse.Namespace,
     *,
     print_payload: PrintPayload,
     output_format: OutputFormat,
+    registry_path: Path | None = None,
 ) -> int | None:
     if args.command != "worker-bridge":
         return None
@@ -319,7 +381,7 @@ def handle_worker_bridge_command(
                 "`active-user-contract`, "
                 "`active-user-codex-simulator-contract`, "
                 "`active-user-intervention`, `active-user-simulator-output`, "
-                "or `active-user-observe`."
+                "`active-user-observe`, or one of the `attached-session-*` commands."
             ),
         }
         print_payload(
@@ -329,8 +391,72 @@ def handle_worker_bridge_command(
         )
         return 1
 
+    renderer = render_worker_bridge_install_contract_markdown
     try:
-        if args.worker_bridge_command == "contract":
+        if args.worker_bridge_command.startswith("attached-session-"):
+            effective_registry_path = registry_path or Path(args.registry)
+            registry = load_registry(effective_registry_path)
+            runtime_root = resolve_runtime_root(
+                registry,
+                args.runtime_root,
+                registry_path=effective_registry_path,
+            )
+            store = ChatSessionStore(runtime_root)
+            renderer = render_attached_session_broker_markdown
+            if args.worker_bridge_command == "attached-session-bind":
+                payload = bind_attached_agent_session(
+                    store=store,
+                    registry=registry,
+                    goal_id=args.goal_id,
+                    agent_id=args.agent_id,
+                    host_surface=args.host_surface,
+                    host_session_id=args.host_session_id,
+                    executor_endpoint_id=args.executor_endpoint_id,
+                    channel_id=args.channel_id,
+                    execute=bool(args.execute),
+                )
+            elif args.worker_bridge_command == "attached-session-list":
+                payload = {
+                    "ok": True,
+                    "schema_version": "loopx_attached_agent_session_broker_v0",
+                    "action": "list",
+                    "sessions": [
+                        session
+                        for session in store.list_sessions(
+                            goal_id=args.goal_id,
+                            agent_id=args.agent_id,
+                        )
+                        if session.get("session_mode") == CHAT_SESSION_MODE_ATTACHED
+                    ],
+                }
+            elif args.worker_bridge_command == "attached-session-claim":
+                payload = claim_attached_agent_turn(
+                    store=store,
+                    session_id=args.session_id,
+                    host_surface=args.host_surface,
+                    host_session_id=args.host_session_id,
+                    claim_id=args.claim_id,
+                )
+            else:
+                if args.response_json == "-":
+                    response = json.loads(sys.stdin.read())
+                else:
+                    response = json.loads(
+                        Path(args.response_json).expanduser().read_text(encoding="utf-8")
+                    )
+                if not isinstance(response, dict):
+                    raise ValueError("response JSON must be an object")
+                payload = complete_attached_agent_turn(
+                    store=store,
+                    session_id=args.session_id,
+                    turn_id=args.turn_id,
+                    host_surface=args.host_surface,
+                    host_session_id=args.host_session_id,
+                    claim_id=args.claim_id,
+                    completion_id=args.completion_id,
+                    response=response,
+                )
+        elif args.worker_bridge_command == "contract":
             payload = build_worker_bridge_install_contract(
                 project_root=args.project_root,
                 runtime_root=args.worker_bridge_runtime_root,
@@ -429,6 +555,6 @@ def handle_worker_bridge_command(
     print_payload(
         payload,
         output_format(args),
-        render_worker_bridge_install_contract_markdown,
+        renderer,
     )
     return 0 if payload.get("ok") else 1

--- a/loopx/extensions/lark/goal_topic_runtime.py
+++ b/loopx/extensions/lark/goal_topic_runtime.py
@@ -652,6 +652,7 @@ def answer_lark_goal_topic(
                 message=message,
                 work_dir=resolved_work_dir,
                 objective=str(objective or goal_id),
+                origin="lark",
             )
     else:
         # Compatibility path for bindings created before the three ingress modes.

--- a/tests/test_attached_session_broker.py
+++ b/tests/test_attached_session_broker.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from loopx.attached_session import (
+    bind_attached_agent_session,
+    claim_attached_agent_turn,
+    complete_attached_agent_turn,
+)
+from loopx.chat_runtime import ChatRuntimeController
+from loopx.chat_server import ChatRequestHandler
+from loopx.chat_store import CHAT_SESSION_MODE_ATTACHED, ChatSessionStore
+from loopx.extensions.lark.goal_topic_runtime import answer_lark_goal_topic
+
+GOAL_ID = "sample-goal"
+AGENT_ID = "codex-sample-worker"
+HOST_SURFACE = "codex-app-ssh"
+HOST_SESSION_ID = "opaque-host-session"
+
+
+def _registry() -> dict[str, object]:
+    return {
+        "goals": [
+            {
+                "id": GOAL_ID,
+                "coordination": {
+                    "registered_agents": [AGENT_ID],
+                    "thread_agent_bindings": [
+                        {
+                            "host_surface": HOST_SURFACE,
+                            "thread_id": HOST_SESSION_ID,
+                            "agent_id": AGENT_ID,
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+
+
+def _bind(store: ChatSessionStore) -> dict[str, object]:
+    packet = bind_attached_agent_session(
+        store=store,
+        registry=_registry(),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        host_surface=HOST_SURFACE,
+        host_session_id=HOST_SESSION_ID,
+        executor_endpoint_id="codex",
+        execute=True,
+    )
+    assert packet["created"] is True
+    return packet
+
+
+def test_bind_requires_exact_registered_thread_and_is_idempotent(tmp_path: Path) -> None:
+    store = ChatSessionStore(tmp_path)
+    preview = bind_attached_agent_session(
+        store=store,
+        registry=_registry(),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        host_surface=HOST_SURFACE,
+        host_session_id=HOST_SESSION_ID,
+        executor_endpoint_id="codex",
+        execute=False,
+    )
+    assert preview["changed"] is True
+    assert not list(store.sessions_root.glob("*/session.json"))
+
+    created = _bind(store)
+    session = created["session"]
+    assert session["agent_id"] == AGENT_ID
+    assert session["executor_endpoint_id"] == "codex"
+    assert session["session_mode"] == CHAT_SESSION_MODE_ATTACHED
+    assert session["attached_capabilities"] == {
+        "live_steering": False,
+        "session_queue": True,
+        "reply_readback": True,
+    }
+
+    duplicate = bind_attached_agent_session(
+        store=store,
+        registry=_registry(),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        host_surface=HOST_SURFACE,
+        host_session_id=HOST_SESSION_ID,
+        executor_endpoint_id="codex",
+        execute=True,
+    )
+    assert duplicate["created"] is False
+    assert duplicate["session"]["session_id"] == session["session_id"]
+
+    with pytest.raises(ValueError, match="exact registered Agent"):
+        bind_attached_agent_session(
+            store=store,
+            registry=_registry(),
+            goal_id=GOAL_ID,
+            agent_id=AGENT_ID,
+            host_surface=HOST_SURFACE,
+            host_session_id="different-host-session",
+            executor_endpoint_id="codex",
+            execute=True,
+        )
+
+
+def test_concurrent_bind_and_completion_are_duplicate_safe(tmp_path: Path) -> None:
+    store = ChatSessionStore(tmp_path)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        packets = list(executor.map(lambda _index: _bind_or_reuse(store), range(2)))
+    assert sorted(packet["created"] for packet in packets) == [False, True]
+    session_id = str(packets[0]["session"]["session_id"])
+
+    queued, created = store.create_queued_turn(
+        session_id,
+        client_turn_id="concurrent-completion",
+        message="complete once",
+        origin="web",
+    )
+    assert created
+    claim_attached_agent_turn(
+        store=store,
+        session_id=session_id,
+        host_surface=HOST_SURFACE,
+        host_session_id=HOST_SESSION_ID,
+        claim_id="shared-claim",
+    )
+
+    def complete(_index: int) -> dict[str, object]:
+        return complete_attached_agent_turn(
+            store=store,
+            session_id=session_id,
+            turn_id=str(queued["turn_id"]),
+            host_surface=HOST_SURFACE,
+            host_session_id=HOST_SESSION_ID,
+            claim_id="shared-claim",
+            completion_id="shared-completion",
+            response={"message": "one durable response"},
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        completions = list(executor.map(complete, range(2)))
+    assert sorted(packet["created"] for packet in completions) == [False, True]
+    agent_messages = [item for item in store.messages(session_id) if item["role"] == "agent"]
+    assert len(agent_messages) == 1
+
+
+def test_loopback_attach_api_binds_without_exposing_host_session(tmp_path: Path) -> None:
+    store = ChatSessionStore(tmp_path)
+    responses: list[dict[str, object]] = []
+
+    class Handler:
+        server = SimpleNamespace(chat_store=store)
+
+        def _read_json(self) -> dict[str, str]:
+            return {
+                "goal_id": GOAL_ID,
+                "agent_id": AGENT_ID,
+                "host_surface": HOST_SURFACE,
+                "host_session_id": HOST_SESSION_ID,
+                "executor_endpoint_id": "codex",
+            }
+
+        def _registry_and_goal(
+            self,
+            goal_id: str,
+        ) -> tuple[dict[str, object], dict[str, object]]:
+            assert goal_id == GOAL_ID
+            return _registry(), {"id": GOAL_ID}
+
+        def _send_json(self, payload: dict[str, object], *, status: int = 200) -> None:
+            responses.append({**payload, "http_status": status})
+
+        def _send_error(self, message: str, **_kwargs: object) -> None:
+            responses.append({"ok": False, "error": message})
+
+    ChatRequestHandler._attach_session(Handler())  # type: ignore[arg-type]
+
+    assert responses[0]["http_status"] == 201
+    session = responses[0]["session"]
+    assert isinstance(session, dict)
+    assert session["session_mode"] == CHAT_SESSION_MODE_ATTACHED
+    assert "upstream_thread_id" not in session
+
+
+def _bind_or_reuse(store: ChatSessionStore) -> dict[str, object]:
+    return bind_attached_agent_session(
+        store=store,
+        registry=_registry(),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        host_surface=HOST_SURFACE,
+        host_session_id=HOST_SESSION_ID,
+        executor_endpoint_id="codex",
+        execute=True,
+    )
+
+
+def test_web_and_lark_share_ordered_attached_session_without_spawning(
+    tmp_path: Path,
+) -> None:
+    store = ChatSessionStore(tmp_path)
+    session = _bind(store)["session"]
+    session_id = str(session["session_id"])
+    runtime = ChatRuntimeController(store=store, codex_bin="missing-codex")
+
+    web_turn, web_created = runtime.submit_turn(
+        session_id=session_id,
+        client_turn_id="web-1",
+        message="web question",
+        work_dir=tmp_path,
+        objective="sample objective",
+    )
+    lark_turn, lark_created = runtime.enqueue_turn(
+        session_id=session_id,
+        client_turn_id="lark-1",
+        message="lark question",
+        work_dir=tmp_path,
+        objective="sample objective",
+        origin="lark",
+    )
+    assert web_created and lark_created
+    assert not runtime.adapters
+
+    first = claim_attached_agent_turn(
+        store=store,
+        session_id=session_id,
+        host_surface=HOST_SURFACE,
+        host_session_id=HOST_SESSION_ID,
+        claim_id="claim-web-1",
+    )
+    assert first["turn"]["turn_id"] == web_turn["turn_id"]
+    assert first["turn"]["origin"] == "web"
+    duplicate_claim = claim_attached_agent_turn(
+        store=store,
+        session_id=session_id,
+        host_surface=HOST_SURFACE,
+        host_session_id=HOST_SESSION_ID,
+        claim_id="claim-web-1",
+    )
+    assert duplicate_claim["turn"]["turn_id"] == web_turn["turn_id"]
+
+    completed = complete_attached_agent_turn(
+        store=store,
+        session_id=session_id,
+        turn_id=str(web_turn["turn_id"]),
+        host_surface=HOST_SURFACE,
+        host_session_id=HOST_SESSION_ID,
+        claim_id="claim-web-1",
+        completion_id="complete-web-1",
+        response={"message": "web answer"},
+    )
+    assert completed["created"] is True
+    duplicate_completion = complete_attached_agent_turn(
+        store=store,
+        session_id=session_id,
+        turn_id=str(web_turn["turn_id"]),
+        host_surface=HOST_SURFACE,
+        host_session_id=HOST_SESSION_ID,
+        claim_id="claim-web-1",
+        completion_id="complete-web-1",
+        response={"message": "different retry payload"},
+    )
+    assert duplicate_completion["created"] is False
+    assert [
+        item["text"] for item in store.messages(session_id) if item["role"] == "agent"
+    ] == ["web answer"]
+
+    second = claim_attached_agent_turn(
+        store=store,
+        session_id=session_id,
+        host_surface=HOST_SURFACE,
+        host_session_id=HOST_SESSION_ID,
+        claim_id="claim-lark-1",
+    )
+    assert second["turn"]["turn_id"] == lark_turn["turn_id"]
+    assert second["turn"]["origin"] == "lark"
+    messages = store.messages(session_id)
+    assert [item.get("origin") for item in messages[:3]] == [
+        "web",
+        "lark",
+        "attached_host",
+    ]
+
+
+def test_attached_live_steering_fails_closed_with_durable_receipt(tmp_path: Path) -> None:
+    store = ChatSessionStore(tmp_path)
+    session_id = str(_bind(store)["session"]["session_id"])
+    runtime = ChatRuntimeController(store=store, codex_bin="missing-codex")
+
+    with pytest.raises(RuntimeError, match="attached_session_live_steering_unavailable"):
+        runtime.steer_active_turn(
+            session_id=session_id,
+            client_ingress_id="lark-steer-1",
+            message="steer now",
+        )
+    receipt = store.create_ingress_receipt(
+        session_id,
+        client_ingress_id="lark-steer-1",
+        mode="live_steering",
+        message="steer now",
+    )[0]
+    assert receipt["status"] == "failed"
+    assert receipt["error_code"] == "attached_session_live_steering_unavailable"
+
+
+def test_lark_session_queue_waits_for_attached_host_reply_readback(tmp_path: Path) -> None:
+    store = ChatSessionStore(tmp_path)
+    session_id = str(_bind(store)["session"]["session_id"])
+    runtime = ChatRuntimeController(store=store, codex_bin="missing-codex")
+    result: dict[str, str] = {}
+
+    def answer() -> None:
+        result["reply"] = answer_lark_goal_topic(
+            route={
+                "goal_id": GOAL_ID,
+                "agent_id": AGENT_ID,
+                "session_id": session_id,
+                "ingress_mode": "session_queue",
+                "message_id": "om_synthetic_message",
+                "topic_root_message_id": "om_synthetic_root",
+            },
+            text="question from lark",
+            work_dir=tmp_path,
+            objective="sample objective",
+            runtime_controller=runtime,
+        )
+
+    waiter = threading.Thread(target=answer)
+    waiter.start()
+    deadline = time.monotonic() + 2
+    while not store.queued_turns(session_id) and time.monotonic() < deadline:
+        time.sleep(0.01)
+    claimed = claim_attached_agent_turn(
+        store=store,
+        session_id=session_id,
+        host_surface=HOST_SURFACE,
+        host_session_id=HOST_SESSION_ID,
+        claim_id="claim-lark-reply",
+    )
+    assert claimed["turn"]["origin"] == "lark"
+    complete_attached_agent_turn(
+        store=store,
+        session_id=session_id,
+        turn_id=claimed["turn"]["turn_id"],
+        host_surface=HOST_SURFACE,
+        host_session_id=HOST_SESSION_ID,
+        claim_id="claim-lark-reply",
+        completion_id="complete-lark-reply",
+        response={"message": "reply from attached host"},
+    )
+    waiter.join(timeout=2)
+    assert not waiter.is_alive()
+    assert result["reply"] == "reply from attached host"

--- a/tests/test_attached_session_broker.py
+++ b/tests/test_attached_session_broker.py
@@ -82,6 +82,7 @@ def test_bind_requires_exact_registered_thread_and_is_idempotent(tmp_path: Path)
     assert session["attached_capabilities"] == {
         "live_steering": False,
         "session_queue": True,
+        "claim_wait": True,
         "reply_readback": True,
     }
 
@@ -150,6 +151,51 @@ def test_concurrent_bind_and_completion_are_duplicate_safe(tmp_path: Path) -> No
     assert sorted(packet["created"] for packet in completions) == [False, True]
     agent_messages = [item for item in store.messages(session_id) if item["role"] == "agent"]
     assert len(agent_messages) == 1
+
+
+def test_attached_host_can_wait_for_queue_wakeup(tmp_path: Path) -> None:
+    store = ChatSessionStore(tmp_path)
+    session_id = str(_bind(store)["session"]["session_id"])
+
+    def queue_message() -> None:
+        time.sleep(0.02)
+        store.create_queued_turn(
+            session_id,
+            client_turn_id="wake-host",
+            message="wake the attached host",
+            origin="lark",
+        )
+
+    producer = threading.Thread(target=queue_message)
+    producer.start()
+    claimed = claim_attached_agent_turn(
+        store=store,
+        session_id=session_id,
+        host_surface=HOST_SURFACE,
+        host_session_id=HOST_SESSION_ID,
+        claim_id="wake-claim",
+        wait_seconds=1,
+    )
+    producer.join(timeout=1)
+
+    assert claimed["claimed"] is True
+    assert claimed["waited"] is True
+    assert claimed["turn"]["message"] == "wake the attached host"
+
+
+def test_attached_host_claim_wait_is_bounded(tmp_path: Path) -> None:
+    store = ChatSessionStore(tmp_path)
+    session_id = str(_bind(store)["session"]["session_id"])
+
+    with pytest.raises(ValueError, match="between 0 and 1800"):
+        claim_attached_agent_turn(
+            store=store,
+            session_id=session_id,
+            host_surface=HOST_SURFACE,
+            host_session_id=HOST_SESSION_ID,
+            claim_id="unbounded-claim",
+            wait_seconds=1_801,
+        )
 
 
 def test_loopback_attach_api_binds_without_exposing_host_session(tmp_path: Path) -> None:

--- a/tests/test_attached_session_broker.py
+++ b/tests/test_attached_session_broker.py
@@ -336,6 +336,144 @@ def test_web_and_lark_share_ordered_attached_session_without_spawning(
     ]
 
 
+def test_attached_completion_uses_canonical_response_and_terminal_events(
+    tmp_path: Path,
+) -> None:
+    store = ChatSessionStore(tmp_path)
+    session_id = str(_bind(store)["session"]["session_id"])
+    turn, _created = store.create_queued_turn(
+        session_id,
+        client_turn_id="web-response-contract",
+        message="return structured response",
+        origin="web",
+    )
+    turn_id = str(turn["turn_id"])
+    claim_attached_agent_turn(
+        store=store,
+        session_id=session_id,
+        host_surface=HOST_SURFACE,
+        host_session_id=HOST_SESSION_ID,
+        claim_id="response-contract-claim",
+    )
+
+    complete_attached_agent_turn(
+        store=store,
+        session_id=session_id,
+        turn_id=turn_id,
+        host_surface=HOST_SURFACE,
+        host_session_id=HOST_SESSION_ID,
+        claim_id="response-contract-claim",
+        completion_id="response-contract-completion",
+        response={
+            "message": "structured answer",
+            "proposals": [
+                "not-a-proposal",
+                {
+                    "kind": "todo",
+                    "text": "Follow the durable contract",
+                    "priority": "invalid",
+                    "rationale": "Keep the next action bounded.",
+                },
+            ],
+            "gate": {
+                "kind": "approval_gate",
+                "message": "Approval is required.",
+                "required_action": "Review the bounded proposal.",
+            },
+        },
+    )
+
+    completed = store.load_turn(session_id, turn_id)
+    assert completed is not None
+    response = completed["response"]
+    assert response["proposals"] == [
+        {
+            "kind": "todo",
+            "text": "Follow the durable contract",
+            "priority": "P1",
+            "rationale": "Keep the next action bounded.",
+        }
+    ]
+    events = store.events_after(session_id, turn_id, None)
+    assert [event["kind"] for event in events[-3:]] == [
+        "proposal.ready",
+        "gate.ready",
+        "turn.completed",
+    ]
+    assert events[-1]["payload"]["response"] == response
+
+
+def test_attached_close_rejects_active_claim_and_preserves_completion(
+    tmp_path: Path,
+) -> None:
+    store = ChatSessionStore(tmp_path)
+    session_id = str(_bind(store)["session"]["session_id"])
+    runtime = ChatRuntimeController(store=store, codex_bin="missing-codex")
+    turn, _created = runtime.submit_turn(
+        session_id=session_id,
+        client_turn_id="close-active-claim",
+        message="finish before close",
+        work_dir=tmp_path,
+        objective="sample objective",
+    )
+    turn_id = str(turn["turn_id"])
+    claim_attached_agent_turn(
+        store=store,
+        session_id=session_id,
+        host_surface=HOST_SURFACE,
+        host_session_id=HOST_SESSION_ID,
+        claim_id="close-active-claim",
+    )
+
+    responses: list[dict[str, object]] = []
+
+    class Handler:
+        path = f"/api/chat/sessions/{session_id}"
+        server = SimpleNamespace(runtime_controller=runtime)
+
+        def _require_loopback_origin(self) -> bool:
+            return True
+
+        def _send_error(self, message: str, **kwargs: object) -> None:
+            responses.append({"ok": False, "error": message, **kwargs})
+
+        def _send_json(self, payload: dict[str, object], *, status: int = 200) -> None:
+            responses.append({**payload, "status": status})
+
+        def _close_session(self, target_session_id: str) -> None:
+            ChatRequestHandler._close_session(self, target_session_id)  # type: ignore[arg-type]
+
+    ChatRequestHandler.do_DELETE(Handler())  # type: ignore[arg-type]
+    assert responses == [
+        {
+            "ok": False,
+            "error": "complete the active attached Agent turn before closing the session",
+            "status": 409,
+            "error_code": "attached_session_turn_active",
+        }
+    ]
+
+    session = store.load_session(session_id)
+    active_turn = store.load_turn(session_id, turn_id)
+    assert session is not None and session["status"] == "busy"
+    assert session["active_turn_id"] == turn_id
+    assert active_turn is not None and active_turn["status"] == "running"
+
+    complete_attached_agent_turn(
+        store=store,
+        session_id=session_id,
+        turn_id=turn_id,
+        host_surface=HOST_SURFACE,
+        host_session_id=HOST_SESSION_ID,
+        claim_id="close-active-claim",
+        completion_id="close-active-completion",
+        response={"message": "completed before close"},
+    )
+    assert runtime.wait_for_turn(session_id=session_id, turn_id=turn_id)["status"] == "completed"
+    assert runtime.close_session(session_id) is True
+    assert store.load_session(session_id)["status"] == "closed"  # type: ignore[index]
+
+
 def test_attached_live_steering_fails_closed_with_durable_receipt(tmp_path: Path) -> None:
     store = ChatSessionStore(tmp_path)
     session_id = str(_bind(store)["session"]["session_id"])

--- a/tests/test_attached_session_cli.py
+++ b/tests/test_attached_session_cli.py
@@ -94,6 +94,8 @@ def test_attached_session_cli_bind_claim_and_complete(
                 "opaque-host-session",
                 "--claim-id",
                 "claim-1",
+                "--wait-seconds",
+                "1",
             ]
         )
         == 0

--- a/tests/test_attached_session_cli.py
+++ b/tests/test_attached_session_cli.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from loopx.chat_store import ChatSessionStore
+from loopx.cli import main
+
+
+def _registry_payload() -> dict[str, object]:
+    return {
+        "goals": [
+            {
+                "id": "sample-goal",
+                "coordination": {
+                    "registered_agents": ["codex-sample-worker"],
+                    "thread_agent_bindings": [
+                        {
+                            "host_surface": "codex-app-ssh",
+                            "thread_id": "opaque-host-session",
+                            "agent_id": "codex-sample-worker",
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+
+
+def _base_args(registry_path: Path, runtime_root: Path) -> list[str]:
+    return [
+        "--registry",
+        str(registry_path),
+        "--runtime-root",
+        str(runtime_root),
+        "--format",
+        "json",
+        "worker-bridge",
+    ]
+
+
+def test_attached_session_cli_bind_claim_and_complete(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(json.dumps(_registry_payload()), encoding="utf-8")
+    runtime_root = tmp_path / "runtime"
+    base = _base_args(registry_path, runtime_root)
+
+    assert (
+        main(
+            [
+                *base,
+                "attached-session-bind",
+                "--goal-id",
+                "sample-goal",
+                "--agent-id",
+                "codex-sample-worker",
+                "--host-surface",
+                "codex-app-ssh",
+                "--host-session-id",
+                "opaque-host-session",
+                "--executor-endpoint-id",
+                "codex",
+                "--execute",
+            ]
+        )
+        == 0
+    )
+    bound = json.loads(capsys.readouterr().out)
+    session_id = bound["session"]["session_id"]
+    assert "upstream_thread_id" not in bound["session"]
+
+    store = ChatSessionStore(runtime_root)
+    queued, created = store.create_queued_turn(
+        session_id,
+        client_turn_id="lark-message-1",
+        message="hello from connector",
+        origin="lark",
+    )
+    assert created
+
+    assert (
+        main(
+            [
+                *base,
+                "attached-session-claim",
+                "--session-id",
+                session_id,
+                "--host-surface",
+                "codex-app-ssh",
+                "--host-session-id",
+                "opaque-host-session",
+                "--claim-id",
+                "claim-1",
+            ]
+        )
+        == 0
+    )
+    claimed = json.loads(capsys.readouterr().out)
+    assert claimed["turn"]["turn_id"] == queued["turn_id"]
+    assert claimed["turn"]["message"] == "hello from connector"
+
+    response_path = tmp_path / "response.json"
+    response_path.write_text(json.dumps({"message": "hello from host"}), encoding="utf-8")
+    assert (
+        main(
+            [
+                *base,
+                "attached-session-complete",
+                "--session-id",
+                session_id,
+                "--turn-id",
+                str(queued["turn_id"]),
+                "--host-surface",
+                "codex-app-ssh",
+                "--host-session-id",
+                "opaque-host-session",
+                "--claim-id",
+                "claim-1",
+                "--completion-id",
+                "completion-1",
+                "--response-json",
+                str(response_path),
+            ]
+        )
+        == 0
+    )
+    completed = json.loads(capsys.readouterr().out)
+    assert completed["created"] is True
+    assert store.load_turn(session_id, str(queued["turn_id"]))["status"] == "completed"


### PR DESCRIPTION
## Summary

- add a provider-neutral broker that binds an already-running host session to an exact registered LoopX Agent without starting a replacement runtime
- keep LoopX Agent identity separate from executor endpoint identity, and converge Web/Connector input through one bounded FIFO with durable origins
- expose owner-local attach/list/claim/complete commands plus a loopback attach API, with concurrent duplicate-safe receipts and content-free public projections
- normalize attached-host responses through the canonical Chat response contract and emit the same proposal, gate, and terminal response events as managed runtimes
- reject closing an attached Session while a host claim is active, so the host can still complete the Turn and durable state cannot become `closed + running`

## Changed surfaces

- Chat session/store, structured-response normalization, lifecycle, and runtime dispatch
- loopback Chat API and worker-bridge CLI
- Lark Goal Topic session queue origin
- public integration/RFC documentation
- focused broker, CLI, Web/SSE, close/readback, and malformed-response tests

## Validation

- `pytest` focused broker/CLI/Lark/host-parity/Chat API/attachment/CORS matrix — 78 passed
- control-plane maintainability ratchet — passed with no unreviewed or magnitude regressions
- constrained mypy for the changed Chat response, attached broker/API, and durable-store boundary — passed
- focused Ruff, changed Python compile, and diff checks — passed
- risk-based premerge gate — 4 direct checks, 9 catalog canaries, 8 risk-profile smokes, and public-boundary scan passed; no failures, skips, warnings, or manual holds
- strict change-quality receipt — `cqr_498df39091aa7a6b9f1f`, valid for exact head `b74770d3d4372b4b76d187bbdc9ce0b856864559`

## Boundary

This stage supports queued input, bounded host claim wakeup, reply readback, and recoverable close supervision. Attached-session live steering remains explicitly unavailable and fails closed; the broker never starts or resumes a managed runtime.
