### PR TITLE
fix(ci): align public smokes with current contracts

### DIFF
--- a/.github/workflows/desktop-release-artifacts.yml
+++ b/.github/workflows/desktop-release-artifacts.yml
@@ -68,7 +68,7 @@ jobs:
           echo "release-tag=${release_tag}" >> "${GITHUB_OUTPUT}"
 
       - name: Set up Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm

--- a/examples/lark-goal-topic-connection-smoke.py
+++ b/examples/lark-goal-topic-connection-smoke.py
@@ -86,6 +86,7 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
                         "status": "active",
                         "objective": "Alpha delivery",
                         "adapter": {"kind": "generic_project_goal_v0"},
+                        "coordination": {"registered_agents": ["agent-alpha"]},
                     },
                     {
                         "id": "goal-beta",
@@ -95,6 +96,7 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
                         "status": "active",
                         "objective": "Beta delivery",
                         "adapter": {"kind": "generic_project_goal_v0"},
+                        "coordination": {"registered_agents": ["agent-alpha"]},
                     },
                 ],
             }
@@ -224,6 +226,7 @@ def main() -> None:
                     "chat_name": "Product group",
                     "goal_id": goal_id,
                     "incoming_mode": "mentions",
+                    "agent_id": "agent-alpha",
                 }
                 preview = request(base, "/api/chat/lark/connections", method="POST", body={**body, "execute": False})
                 assert preview["status"] == "preview_ready", preview
@@ -233,6 +236,8 @@ def main() -> None:
             connections = request(base, "/api/chat/lark/connections")
             assert len(connections["connections"]) == 2, connections
             assert {row["goal_id"] for row in connections["connections"]} == {"goal-alpha", "goal-beta"}
+            assert {row["agent_id"] for row in connections["connections"]} == {"agent-alpha"}
+            assert {row["ingress_mode"] for row in connections["connections"]} == {"async_inbox"}
             assert "oc_" not in json.dumps(connections) and "om_" not in json.dumps(connections)
 
             target_path = runtime / "goal-channel-targets.json"

--- a/examples/project/configure-goal-smoke.py
+++ b/examples/project/configure-goal-smoke.py
@@ -189,6 +189,7 @@ def main() -> int:
         assert dry["after"]["lark_event_inbox"] == {
             "enabled": True,
             "config_pointer_registered": True,
+            "agent_scoped_count": 0,
         }, dry
         assert dry["after"]["lark_kanban_heartbeat_sync"] == {
             "enabled": True,


### PR DESCRIPTION
## Summary

- move the desktop release workflow to the repository-required `actions/setup-node@v6` runtime
- register and bind the Lark E2E fixture Agent so the current Agent-scoped `async_inbox` default is exercised and read back
- align the configure-goal smoke with the typed `agent_scoped_count` read model

## Validation

- `python examples/github-actions-runtime-smoke.py`
- `python examples/lark-goal-topic-connection-smoke.py`
- `python examples/project/configure-goal-smoke.py`
- `pytest -q tests/test_chat_lark_api_contract.py tests/extensions/test_lark_goal_topic_connections.py` — 31 passed
- `python -m py_compile examples/lark-goal-topic-connection-smoke.py examples/project/configure-goal-smoke.py`
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` — 18/18 selected checks passed; no failures, skips, warnings, or manual holds
- public/private boundary scan clean for all 3 changed files

## Quality receipt

- exact scope: 3 files at `04d7a06d743011775b5a8d6978176c4ffa952437`
- receipt: `cqr_ed49b20a7a54370b6c5c`
- decision: pass; no blockers, warnings, or advisories

## Merge decision

This is a narrow CI/fixture contract repair with no runtime behavior change. The risk-based gate reports `self_merge_allowed=true`, so it is eligible for maintainer self-merge after GitHub checks pass.