### PR TITLE
fix(quota): settle legacy monitor workspace evidence

### DIFF
--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -114,12 +114,17 @@ def _delivery_workspace_supplement_required(
     refresh-state call may therefore arrive after the durable-writeback receipt
     exists, while the monitor run itself has no delivery workspace snapshot.
     Keep ordinary replays idempotent, but let an explicit workspace path append
-    one causal refresh record when the original Todo required repository work.
+    one causal refresh record unless the original Todo explicitly declared a
+    non-delivery settlement. This also repairs legacy monitor Todos whose
+    workspace requirement was left unknown.
     """
 
     if delivery_workspace_path is None:
         return False
-    if str((delivery_workspace_causality or {}).get("requirement") or "") != "required":
+    if (
+        str((delivery_workspace_causality or {}).get("requirement") or "")
+        == "not_required"
+    ):
         return False
     return delivery_workspace_repository(
         prior_writeback.get("delivery_workspace")

--- a/tests/control_plane/test_quota_settlement_cli.py
+++ b/tests/control_plane/test_quota_settlement_cli.py
@@ -502,11 +502,15 @@ def test_standard_codex_app_settlement_is_receipted_and_idempotent(
     assert _spend_run_count(runtime) == 1
 
 
-def test_material_monitor_writeback_can_add_required_workspace_before_spend(
+def _assert_material_monitor_writeback_can_add_workspace_before_spend(
     tmp_path: Path,
+    *,
+    repository_write: bool,
+    expected_requirement: str,
 ) -> None:
     project, runtime, registry_path = _write_fixture(tmp_path)
-    _configure_repository_write_todo(project)
+    if repository_write:
+        _configure_repository_write_todo(project)
     _initialize_git_checkout(project)
     binding = (
         "--agent-id",
@@ -533,9 +537,10 @@ def test_material_monitor_writeback_can_add_required_workspace_before_spend(
         str(project),
     )
     assert guard_rc == 0, guard
-    assert guard["heartbeat_receipt"]["delivery_workspace_causality"][
-        "requirement"
-    ] == "required"
+    assert (
+        guard["heartbeat_receipt"]["delivery_workspace_causality"]["requirement"]
+        == expected_requirement
+    )
 
     runs_dir = runtime / "goals" / GOAL_ID / "runs"
     runs_dir.mkdir(parents=True, exist_ok=True)
@@ -638,6 +643,26 @@ def test_material_monitor_writeback_can_add_required_workspace_before_spend(
     assert spend_rc == 0, spend
     assert spend["delivery_workspace_validated"] is True
     assert spend["settlement_result"]["ok"] is True
+
+
+def test_material_monitor_writeback_can_add_required_workspace_before_spend(
+    tmp_path: Path,
+) -> None:
+    _assert_material_monitor_writeback_can_add_workspace_before_spend(
+        tmp_path,
+        repository_write=True,
+        expected_requirement="required",
+    )
+
+
+def test_material_monitor_writeback_can_add_unknown_workspace_before_spend(
+    tmp_path: Path,
+) -> None:
+    _assert_material_monitor_writeback_can_add_workspace_before_spend(
+        tmp_path,
+        repository_write=False,
+        expected_requirement="unknown",
+    )
 
 
 def test_same_turn_identityless_guard_upgrades_and_settles_full_chain(


### PR DESCRIPTION
## Summary

- let an explicit delivery workspace supplement a legacy monitor turn whose workspace requirement was projected as `unknown`
- keep explicit `not_required` settlements non-delivery and unchanged
- cover both repository-required and legacy unknown workspace causality through the full guard, refresh, and spend chain

## Why

A material monitor poll can write durable evidence and then become impossible to settle when an older or underspecified Todo has no repository-write metadata. The guard projects `unknown`, `refresh-state` refuses the workspace supplement, and `spend-slot` correctly rejects the missing causal workspace. This change makes that chain completable without weakening explicit non-delivery contracts.

## Validation

- 11 focused quota-settlement and state-refresh tests passed
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 15 selected checks plus 4 direct checks passed; no failures, skips, or manual holds
- changed Python files compiled
- `git diff --check` passed
- changed-line public/private boundary scan passed
- change-quality receipt: `cqr_988dff8422f8784d9639`

## Risk

Narrow control-plane runtime change. It only broadens the existing supplement path for `unknown`; an explicit `not_required` contract remains a hard stop. No schema, permission, scheduler, quota amount, or default lane changes.
