### PR TITLE
fix(cli): bound default public scans to the package

### DIFF
--- a/loopx/cli_commands/quota_registration.py
+++ b/loopx/cli_commands/quota_registration.py
@@ -1,21 +1,17 @@
 from __future__ import annotations
 
 import argparse
-from pathlib import Path
 
 from ..control_plane.quota.spend_sources import (
     DEFAULT_SLOT_SPEND_SOURCE,
     VALID_SLOT_SPEND_SOURCES,
 )
 from ..control_plane.scheduler.execution_context import SchedulerRuntimeProfile
+from ..paths import default_public_scan_root
 from .quota_request import (
     QUOTA_DETAIL_SECTIONS,
     register_quota_monitor_poll_request_arguments,
 )
-
-
-def _default_public_scan_root() -> str:
-    return str(Path(__file__).resolve().parents[2])
 
 
 def register_quota_command(
@@ -227,7 +223,7 @@ def register_quota_command(
     )
     quota_parser.add_argument(
         "--scan-root",
-        default=_default_public_scan_root(),
+        default=default_public_scan_root(),
         help="Public files to scan for obvious private material. Defaults to the LoopX install root.",
     )
     quota_parser.add_argument(

--- a/loopx/cli_commands/ready_score.py
+++ b/loopx/cli_commands/ready_score.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 from ..doctor import collect_doctor
+from ..paths import default_public_scan_root
 from ..quota import build_quota_should_run
 from ..ready_score import (
     build_ready_score_report,
@@ -20,12 +21,6 @@ PrintPayload = Callable[
 ]
 FormatSelector = Callable[..., str]
 AddFormat = Callable[[argparse.ArgumentParser], None]
-
-
-def default_public_scan_root() -> str:
-    return str(Path(__file__).resolve().parents[2])
-
-
 def _scan_roots(args: argparse.Namespace) -> list[Path]:
     scan_roots = [Path(item).expanduser() for item in args.scan_path]
     return scan_roots or [Path(args.scan_root).expanduser()]

--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -27,7 +27,7 @@ from ..presentation.renderers.status_markdown import render_status_markdown
 from ..quota import build_quota_should_run
 from ..review_packet import build_review_packet, render_review_packet_markdown
 from ..status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, collect_status
-from .status_registration import default_public_scan_root, register_status_commands
+from .status_registration import register_status_commands as register_status_commands
 
 PrintPayload = Callable[
     [dict[str, object], str, Callable[[dict[str, object]], str]],

--- a/loopx/cli_commands/status_registration.py
+++ b/loopx/cli_commands/status_registration.py
@@ -2,11 +2,8 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Callable
-from pathlib import Path
 
-
-def default_public_scan_root() -> str:
-    return str(Path(__file__).resolve().parents[2])
+from ..paths import default_public_scan_root
 
 
 def register_status_commands(

--- a/loopx/cli_commands/summary_all.py
+++ b/loopx/cli_commands/summary_all.py
@@ -14,6 +14,7 @@ from ..global_todos import (
     build_global_todos_error,
     render_global_todos_markdown,
 )
+from ..paths import default_public_scan_root
 from ..summary_all import (
     build_global_gates,
     build_global_gates_error,
@@ -28,12 +29,6 @@ PrintPayload = Callable[
     None,
 ]
 FormatSelector = Callable[..., str]
-
-
-def default_public_scan_root() -> str:
-    return str(Path(__file__).resolve().parents[2])
-
-
 def _scan_roots(args: argparse.Namespace) -> list[Path]:
     scan_roots = [Path(item).expanduser() for item in args.scan_path]
     return scan_roots or [Path(args.scan_root).expanduser()]

--- a/loopx/cli_commands/support_control.py
+++ b/loopx/cli_commands/support_control.py
@@ -28,6 +28,7 @@ from ..chat_server import (
 )
 from ..control_plane.scheduler.execution_context import SchedulerRuntimeProfile
 from ..dashboard_launcher import launch_dashboard
+from ..paths import default_public_scan_root
 from ..presentation.renderers.status_markdown import render_status_markdown
 from ..promotion_gate import (
     build_promotion_gate,
@@ -56,7 +57,6 @@ from ..status_server import (
 )
 from ..upgrade import build_upgrade_plan, render_upgrade_plan_markdown
 from .support_control_registry import (
-    default_public_scan_root,
     explicit_global_registry,
     resolve_heartbeat_active_state,
 )

--- a/loopx/cli_commands/support_control_registry.py
+++ b/loopx/cli_commands/support_control_registry.py
@@ -7,10 +7,6 @@ from ..paths import DEFAULT_RUNTIME_ROOT, global_registry_path
 from ..registry import registry_goals, resolve_state_file
 
 
-def default_public_scan_root() -> str:
-    return str(Path(__file__).resolve().parents[2])
-
-
 def fallback_global_registry(registry_path: Path, runtime_root_arg: str | None) -> Path:
     if registry_path.exists():
         return registry_path

--- a/loopx/cli_commands/support_control_supervisor.py
+++ b/loopx/cli_commands/support_control_supervisor.py
@@ -25,11 +25,10 @@ from ..control_plane.runtime.agent_scoped_evidence_log import (
     goal_history_runs,
 )
 from ..history import collect_history, load_registry
-from ..paths import resolve_runtime_root
+from ..paths import default_public_scan_root, resolve_runtime_root
 from ..rollout_event_log import load_rollout_events, rollout_event_log_path
 from ..status import collect_status
 from .support_control_registry import (
-    default_public_scan_root,
     fallback_global_registry,
     resolve_heartbeat_active_state,
 )

--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -35,6 +35,7 @@ from ..control_plane.turn_driver import (
     run_loopx_turn_once,
     selected_turn_todo,
 )
+from ..paths import default_public_scan_root
 from ..quota import spend_quota_slot
 from ..state_refresh import refresh_state_run
 from ..status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, collect_status
@@ -47,12 +48,6 @@ PrintPayload = Callable[
 ]
 FormatSelector = Callable[..., str]
 AddFormat = Callable[[argparse.ArgumentParser], None]
-
-
-def _default_public_scan_root() -> str:
-    return str(Path(__file__).resolve().parents[2])
-
-
 def register_turn_commands(
     subparsers: argparse._SubParsersAction,
     add_subcommand_format: AddFormat,
@@ -84,7 +79,7 @@ def register_turn_commands(
     )
     plan.add_argument(
         "--scan-root",
-        default=_default_public_scan_root(),
+        default=default_public_scan_root(),
         help="Public files to scan for obvious private material.",
     )
     plan.add_argument(
@@ -187,7 +182,7 @@ def register_turn_commands(
     )
     run_once.add_argument(
         "--scan-root",
-        default=_default_public_scan_root(),
+        default=default_public_scan_root(),
         help="Public files to scan for obvious private material.",
     )
     run_once.add_argument("--scan-path", action="append", default=[])

--- a/loopx/paths.py
+++ b/loopx/paths.py
@@ -9,6 +9,12 @@ DEFAULT_PROJECT_REGISTRY = Path(".loopx") / "registry.json"
 GLOBAL_REGISTRY_FILENAME = "registry.global.json"
 
 
+def default_public_scan_root() -> str:
+    """Return the bounded LoopX package root used by public scans."""
+
+    return str(Path(__file__).resolve().parent)
+
+
 def default_registry_path() -> Path:
     value = os.environ.get("LOOPX_REGISTRY")
     if value:

--- a/tests/test_default_public_scan_root.py
+++ b/tests/test_default_public_scan_root.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from loopx import paths
+from loopx.cli import build_parser
+
+
+DEFAULT_PUBLIC_SCAN_COMMANDS = (
+    pytest.param(["status"], id="status"),
+    pytest.param(["diagnose"], id="diagnose"),
+    pytest.param(
+        ["review-packet", "--goal-id", "fixture-goal"],
+        id="review-packet",
+    ),
+    pytest.param(
+        ["quota", "should-run", "--goal-id", "fixture-goal"],
+        id="quota-should-run",
+    ),
+    pytest.param(["ready-score"], id="ready-score"),
+    pytest.param(["global-summary"], id="global-summary"),
+    pytest.param(["global-gates"], id="global-gates"),
+    pytest.param(["global-todos"], id="global-todos"),
+    pytest.param(["global-risks"], id="global-risks"),
+    pytest.param(["serve-status"], id="serve-status"),
+    pytest.param(["chat"], id="chat"),
+    pytest.param(["dashboard"], id="dashboard"),
+    pytest.param(
+        [
+            "turn",
+            "plan",
+            "--goal-id",
+            "fixture-goal",
+            "--agent-id",
+            "fixture-agent",
+        ],
+        id="turn-plan",
+    ),
+    pytest.param(
+        [
+            "turn",
+            "run-once",
+            "--goal-id",
+            "fixture-goal",
+            "--agent-id",
+            "fixture-agent",
+            "--project",
+            ".",
+        ],
+        id="turn-run-once",
+    ),
+)
+
+
+def _simulate_installed_package(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> tuple[Path, Path]:
+    site_packages = tmp_path / "venv" / "lib" / "python3.12" / "site-packages"
+    package_root = site_packages / "loopx"
+    monkeypatch.setattr(paths, "__file__", str(package_root / "paths.py"))
+    return site_packages, package_root
+
+
+def test_default_public_scan_root_is_the_installed_loopx_package(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    site_packages, package_root = _simulate_installed_package(monkeypatch, tmp_path)
+
+    resolved = Path(paths.default_public_scan_root())
+
+    assert resolved == package_root
+    assert resolved != site_packages
+
+
+@pytest.mark.parametrize("argv", DEFAULT_PUBLIC_SCAN_COMMANDS)
+def test_installed_command_defaults_never_escape_the_loopx_package(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    argv: list[str],
+) -> None:
+    site_packages, package_root = _simulate_installed_package(monkeypatch, tmp_path)
+    parser = build_parser()
+
+    default_args = parser.parse_args(argv)
+
+    assert Path(default_args.scan_root) == package_root
+    assert Path(default_args.scan_root) != site_packages
+
+    explicit_root = tmp_path / "explicit-root"
+    explicit_path = tmp_path / "explicit-file.md"
+    explicit_args = parser.parse_args(
+        [
+            *argv,
+            "--scan-root",
+            str(explicit_root),
+            "--scan-path",
+            str(explicit_path),
+        ]
+    )
+
+    assert explicit_args.scan_root == str(explicit_root)
+    assert explicit_args.scan_path == [str(explicit_path)]


### PR DESCRIPTION
## Summary

- centralize the default public scan root in loopx.paths
- route status, diagnose, review-packet, quota, ready-score, global summaries, local service commands, Turn, and supervisor scans through the same package-root resolver
- preserve explicit --scan-root and --scan-path values
- add installed-layout regression coverage for all 14 CLI entry points

## Root cause

The duplicated CLI helpers used Path(__file__).resolve().parents[2]. From loopx/cli_commands inside an installed wheel, that resolves to the containing site-packages directory and permits the privacy scan to walk unrelated distributions. The centralized resolver lives at loopx/paths.py and therefore resolves its own parent: the installed loopx package directory.

## Validation

- focused CLI/parser suite: 231 passed
- real wheel build/install: all 14 command defaults resolved to the installed loopx package, never its site-packages parent
- standard premerge gate: 17/17 checks passed, no manual holds
- recommended Ruff scope plus strict changed-file Ruff: passed
- mypy: passed
- LoopX public-boundary check: passed (11 files; only expected missing local registry warnings)
- full pytest: 3688 passed, 10 skipped; 21 launcher tests initially selected system Python 3.9 and were rerun under the project Python 3.12 runtime, where all affected files passed (160 passed)

Closes #3356