### PR TITLE
docs(benchmark): couple score and insight monitoring

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -416,7 +416,9 @@ It then reports material aggregate changes to the user and, after the solver is
 terminal, runs a post-run analyst brief and writes one private
 `benchmark_case_insight_v0` artifact. A bounded periodic review while a campaign is
 active prevents a long run from silently accumulating results. This monitor is part
-of the benchmark lifecycle, not an optional cleanup pass.
+of the benchmark lifecycle, not an optional cleanup pass. The catalog entry is a
+guidance template rather than a scheduler: the benchmark startup provider creates
+the todo, and the registered monitor runtime owns its cadence.
 
 A material user update should include the current countable arm and pair coverage,
 aggregate primary metric by arm, binary outcomes when the benchmark exposes them,
@@ -424,6 +426,8 @@ improved/flat/regressed pair counts, and the new causal insight or next probe. D
 these score fields from the experiment board or benchmark-owned scoring projection,
 not from raw private evidence. Do not send a repetitive update when no score,
 coverage, direction, insight, or material runner state changed.
+Only public-safe conclusions from the private post-run insight may enter that user
+update; raw evaluation evidence remains private.
 
 During an active-campaign review, distinguish a clean worktree from a lack of
 solver progress. `git status` observes only uncommitted changes. Bind the readback
@@ -431,9 +435,9 @@ to the exact job, compare its current `HEAD` with the start revision recorded at
 admission, and combine that committed delta with the current worktree status.
 Correlate those facts with Goal/event freshness, typed runner errors, and the
 solver's trajectory phase. A clean worktree or a high raw log-error count alone is
-not evidence that a run is stuck. Classify a run as stalled only when committed and
-uncommitted progress are both absent and the trajectory is stale or typed fatal
-runner evidence is present.
+not evidence that a run is stuck. The provider-owned classifier may mark a run
+stalled only when committed and uncommitted progress are both absent and either the
+trajectory is stale or typed fatal runner evidence is present.
 
 Use this analyst hint:
 

--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -408,10 +408,22 @@ the solving agent's evidence boundary.
 
 ## Post-run case insight monitor
 
-Benchmark startup should create one `continuous_monitor` todo. Whenever a case
-reaches a new material scored state, that monitor runs a post-run analyst brief and
-writes one private `benchmark_case_insight_v0` artifact. This monitor is part of the
-benchmark lifecycle, not an optional cleanup pass.
+Benchmark startup should create one `continuous_monitor` todo that owns both the
+campaign score update and the post-run case analysis. Whenever a case reaches a new
+material scored state, the monitor first reads the public-safe experiment-board
+projection and refreshes the countable baseline, treatment, and matched-pair totals.
+It then reports material aggregate changes to the user and, after the solver is
+terminal, runs a post-run analyst brief and writes one private
+`benchmark_case_insight_v0` artifact. A bounded periodic review while a campaign is
+active prevents a long run from silently accumulating results. This monitor is part
+of the benchmark lifecycle, not an optional cleanup pass.
+
+A material user update should include the current countable arm and pair coverage,
+aggregate primary metric by arm, binary outcomes when the benchmark exposes them,
+improved/flat/regressed pair counts, and the new causal insight or next probe. Derive
+these score fields from the experiment board or benchmark-owned scoring projection,
+not from raw private evidence. Do not send a repetitive update when no score,
+coverage, direction, insight, or material runner state changed.
 
 Use this analyst hint:
 

--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -425,6 +425,16 @@ these score fields from the experiment board or benchmark-owned scoring projecti
 not from raw private evidence. Do not send a repetitive update when no score,
 coverage, direction, insight, or material runner state changed.
 
+During an active-campaign review, distinguish a clean worktree from a lack of
+solver progress. `git status` observes only uncommitted changes. Bind the readback
+to the exact job, compare its current `HEAD` with the start revision recorded at
+admission, and combine that committed delta with the current worktree status.
+Correlate those facts with Goal/event freshness, typed runner errors, and the
+solver's trajectory phase. A clean worktree or a high raw log-error count alone is
+not evidence that a run is stuck. Classify a run as stalled only when committed and
+uncommitted progress are both absent and the trajectory is stale or typed fatal
+runner evidence is present.
+
 Use this analyst hint:
 
 > After the solver has stopped and scoring is complete, read the task, real
@@ -436,6 +446,10 @@ The solver and analyst are separate roles. The solver remains unable to access
 hidden tests, evaluator sources, expected answers, or official feedback. Only the
 post-run analyst may read the complete private evaluation evidence, and only after
 the solver is terminal and scoring is complete.
+
+The active-campaign monitor may inspect the solver-owned trajectory and exact-job
+runtime while the solver is active, but it must not read hidden evaluator evidence
+or send its findings back into the solving arm.
 
 Record the result in this compact shape:
 

--- a/loopx/capabilities/benchmark_toolkit/catalog_entry.py
+++ b/loopx/capabilities/benchmark_toolkit/catalog_entry.py
@@ -143,6 +143,11 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
             "action_kind": "benchmark_case_insight_monitor",
             "trigger": "material_scored_case_transition",
             "active_campaign_review": "bounded_periodic",
+            "delivery_contract": {
+                "catalog_role": "guidance_template",
+                "creation_owner": "benchmark_startup_provider",
+                "scheduler_owner": "registered_monitor_runtime",
+            },
             "text": (
                 "On each material scored-case transition and bounded active-campaign "
                 "review, refresh the public-safe aggregate score and coverage summary, "
@@ -152,7 +157,11 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
             ),
         },
         "aggregate_reporting": {
-            "source": "experiment_board_public_safe_projection",
+            "score_source": "experiment_board_public_safe_projection",
+            "insight_boundary": (
+                "report only public-safe conclusions from post-run insight; never "
+                "copy raw private evidence into the user update"
+            ),
             "report_on": [
                 "new_countable_terminal",
                 "countability_or_pairing_change",
@@ -186,11 +195,21 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
             "trajectory_basis": (
                 "solver_trajectory_phase_without_hidden_evaluator_feedback"
             ),
-            "classification_rule": (
-                "Do not classify a run as stuck from a clean worktree or raw log-error "
-                "count alone; require absent committed and uncommitted progress plus "
-                "a stale trajectory or typed fatal runner evidence."
-            ),
+            "classification_owner": "benchmark_monitor_provider",
+            "stalled_when": {
+                "all": [
+                    "no_committed_progress",
+                    "no_uncommitted_progress",
+                ],
+                "any": [
+                    "trajectory_stale",
+                    "typed_fatal_runner_error",
+                ],
+            },
+            "non_signals": [
+                "clean_worktree_alone",
+                "raw_log_error_count_alone",
+            ],
         },
         "hint": (
             "After the solver has stopped and scoring is complete, read the task, "

--- a/loopx/capabilities/benchmark_toolkit/catalog_entry.py
+++ b/loopx/capabilities/benchmark_toolkit/catalog_entry.py
@@ -174,6 +174,24 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
                 "direction, insight, or material runner state changed."
             ),
         },
+        "active_progress_readback": {
+            "workspace_basis": [
+                "recorded_start_revision_to_current_head",
+                "current_worktree_status",
+            ],
+            "runtime_basis": [
+                "goal_state_and_event_freshness",
+                "typed_runner_error_category",
+            ],
+            "trajectory_basis": (
+                "solver_trajectory_phase_without_hidden_evaluator_feedback"
+            ),
+            "classification_rule": (
+                "Do not classify a run as stuck from a clean worktree or raw log-error "
+                "count alone; require absent committed and uncommitted progress plus "
+                "a stale trajectory or typed fatal runner evidence."
+            ),
+        },
         "hint": (
             "After the solver has stopped and scoring is complete, read the task, "
             "real trajectory, final patch or workspace, hidden tests, grader or "
@@ -185,6 +203,11 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
             "solver": (
                 "must not access hidden tests, grader or verifier sources, expected "
                 "answers, or official feedback during the solving phase"
+            ),
+            "active_campaign_monitor": (
+                "may inspect the solver-owned trajectory and exact-job runtime while "
+                "the solver is active, but must not read hidden evaluator evidence or "
+                "send findings back into the solving arm"
             ),
             "post_run_analyst": (
                 "may read the full private case evidence only after the solver is "

--- a/loopx/capabilities/benchmark_toolkit/catalog_entry.py
+++ b/loopx/capabilities/benchmark_toolkit/catalog_entry.py
@@ -133,17 +133,45 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
     },
     "post_run_case_analysis": {
         "benchmark_start_hint": (
-            "When starting a benchmark, add one continuous_monitor todo that runs "
-            "the post-run analyst brief on every material scored-case transition."
+            "When starting a benchmark, add one continuous_monitor todo that "
+            "refreshes aggregate score coverage and runs the post-run analyst brief "
+            "on every material scored-case transition, with bounded periodic reviews "
+            "while the campaign is active."
         ),
         "monitor_todo_template": {
             "task_class": "continuous_monitor",
             "action_kind": "benchmark_case_insight_monitor",
             "trigger": "material_scored_case_transition",
+            "active_campaign_review": "bounded_periodic",
             "text": (
-                "On each material scored-case transition, read the complete private "
-                "evaluation evidence, write one benchmark_case_insight_v0, and report "
-                "only new reusable insight."
+                "On each material scored-case transition and bounded active-campaign "
+                "review, refresh the public-safe aggregate score and coverage summary, "
+                "report material changes to the user, and after solver termination "
+                "read the complete private evaluation evidence and write one "
+                "benchmark_case_insight_v0."
+            ),
+        },
+        "aggregate_reporting": {
+            "source": "experiment_board_public_safe_projection",
+            "report_on": [
+                "new_countable_terminal",
+                "countability_or_pairing_change",
+                "aggregate_score_or_direction_change",
+                "new_reusable_case_insight",
+                "systematic_runner_or_treatment_fidelity_issue",
+            ],
+            "report_fields": [
+                "countable_baseline_cases",
+                "countable_treatment_cases",
+                "matched_pair_count",
+                "aggregate_primary_metric_by_arm",
+                "binary_outcome_by_arm_when_available",
+                "improved_flat_regressed_pair_counts",
+                "new_case_insights_and_next_probe",
+            ],
+            "unchanged_policy": (
+                "Do not send a repetitive user update when no score, coverage, "
+                "direction, insight, or material runner state changed."
             ),
         },
         "hint": (

--- a/tests/capabilities/test_benchmark_toolkit.py
+++ b/tests/capabilities/test_benchmark_toolkit.py
@@ -116,21 +116,22 @@ def test_catalog_exposes_post_run_case_insight_monitor_contract() -> None:
     analysis = capability["post_run_case_analysis"]
 
     assert "continuous_monitor" in analysis["benchmark_start_hint"]
-    assert analysis["monitor_todo_template"] == {
+    monitor_template = analysis["monitor_todo_template"]
+    assert {
         "task_class": "continuous_monitor",
         "action_kind": "benchmark_case_insight_monitor",
         "trigger": "material_scored_case_transition",
         "active_campaign_review": "bounded_periodic",
-        "text": (
-            "On each material scored-case transition and bounded active-campaign "
-            "review, refresh the public-safe aggregate score and coverage summary, "
-            "report material changes to the user, and after solver termination "
-            "read the complete private evaluation evidence and write one "
-            "benchmark_case_insight_v0."
-        ),
+    }.items() <= monitor_template.items()
+    assert monitor_template["delivery_contract"] == {
+        "catalog_role": "guidance_template",
+        "creation_owner": "benchmark_startup_provider",
+        "scheduler_owner": "registered_monitor_runtime",
     }
+    assert "benchmark_case_insight_v0" in monitor_template["text"]
     reporting = analysis["aggregate_reporting"]
-    assert reporting["source"] == "experiment_board_public_safe_projection"
+    assert reporting["score_source"] == "experiment_board_public_safe_projection"
+    assert "never copy raw private evidence" in reporting["insight_boundary"]
     assert reporting["report_on"] == [
         "new_countable_terminal",
         "countability_or_pairing_change",
@@ -158,8 +159,15 @@ def test_catalog_exposes_post_run_case_insight_monitor_contract() -> None:
         "typed_runner_error_category",
     ]
     assert "solver_trajectory_phase" in active["trajectory_basis"]
-    assert "clean worktree" in active["classification_rule"]
-    assert "raw log-error count alone" in active["classification_rule"]
+    assert active["classification_owner"] == "benchmark_monitor_provider"
+    assert active["stalled_when"] == {
+        "all": ["no_committed_progress", "no_uncommitted_progress"],
+        "any": ["trajectory_stale", "typed_fatal_runner_error"],
+    }
+    assert active["non_signals"] == [
+        "clean_worktree_alone",
+        "raw_log_error_count_alone",
+    ]
     hint = analysis["hint"]
     for evidence_name in (
         "real trajectory",

--- a/tests/capabilities/test_benchmark_toolkit.py
+++ b/tests/capabilities/test_benchmark_toolkit.py
@@ -120,12 +120,34 @@ def test_catalog_exposes_post_run_case_insight_monitor_contract() -> None:
         "task_class": "continuous_monitor",
         "action_kind": "benchmark_case_insight_monitor",
         "trigger": "material_scored_case_transition",
+        "active_campaign_review": "bounded_periodic",
         "text": (
-            "On each material scored-case transition, read the complete private "
-            "evaluation evidence, write one benchmark_case_insight_v0, and report "
-            "only new reusable insight."
+            "On each material scored-case transition and bounded active-campaign "
+            "review, refresh the public-safe aggregate score and coverage summary, "
+            "report material changes to the user, and after solver termination "
+            "read the complete private evaluation evidence and write one "
+            "benchmark_case_insight_v0."
         ),
     }
+    reporting = analysis["aggregate_reporting"]
+    assert reporting["source"] == "experiment_board_public_safe_projection"
+    assert reporting["report_on"] == [
+        "new_countable_terminal",
+        "countability_or_pairing_change",
+        "aggregate_score_or_direction_change",
+        "new_reusable_case_insight",
+        "systematic_runner_or_treatment_fidelity_issue",
+    ]
+    assert reporting["report_fields"] == [
+        "countable_baseline_cases",
+        "countable_treatment_cases",
+        "matched_pair_count",
+        "aggregate_primary_metric_by_arm",
+        "binary_outcome_by_arm_when_available",
+        "improved_flat_regressed_pair_counts",
+        "new_case_insights_and_next_probe",
+    ]
+    assert "Do not send a repetitive" in reporting["unchanged_policy"]
     hint = analysis["hint"]
     for evidence_name in (
         "real trajectory",

--- a/tests/capabilities/test_benchmark_toolkit.py
+++ b/tests/capabilities/test_benchmark_toolkit.py
@@ -148,6 +148,18 @@ def test_catalog_exposes_post_run_case_insight_monitor_contract() -> None:
         "new_case_insights_and_next_probe",
     ]
     assert "Do not send a repetitive" in reporting["unchanged_policy"]
+    active = analysis["active_progress_readback"]
+    assert active["workspace_basis"] == [
+        "recorded_start_revision_to_current_head",
+        "current_worktree_status",
+    ]
+    assert active["runtime_basis"] == [
+        "goal_state_and_event_freshness",
+        "typed_runner_error_category",
+    ]
+    assert "solver_trajectory_phase" in active["trajectory_basis"]
+    assert "clean worktree" in active["classification_rule"]
+    assert "raw log-error count alone" in active["classification_rule"]
     hint = analysis["hint"]
     for evidence_name in (
         "real trajectory",
@@ -158,6 +170,10 @@ def test_catalog_exposes_post_run_case_insight_monitor_contract() -> None:
         assert evidence_name in hint
 
     assert "must not access" in analysis["role_boundary"]["solver"]
+    active_monitor = analysis["role_boundary"]["active_campaign_monitor"]
+    assert "exact-job runtime" in active_monitor
+    assert "must not read hidden evaluator evidence" in active_monitor
+    assert "send findings back" in active_monitor
     assert "only after" in analysis["role_boundary"]["post_run_analyst"]
     artifact = analysis["artifact_template"]
     assert artifact["schema_version"] == "benchmark_case_insight_v0"


### PR DESCRIPTION
## Summary

- Make aggregate score and coverage readback part of the existing post-run insight monitor lifecycle.
- Add bounded periodic active-campaign reviews and material-change reporting fields.
- Preserve the existing action_kind and primary trigger for compatibility.

## Motivation

Long benchmark campaigns should not accumulate terminal results without updating the experiment board, paired score view, and user-facing insight. The same continuous monitor can own both compact public-safe score projection and private post-run trajectory analysis, while suppressing repetitive no-change updates.

## Validation

- pytest -q tests/capabilities/test_benchmark_toolkit.py: 50 passed.
- loopx canary premerge --from-git-diff: 18/18 selected checks passed; zero failures and warnings.
- Public/private boundary scan: clean.
- Manual hold: benchmark_sensitive, so this PR requires maintainer review and is not self-merged.

The change adds no benchmark-family runner, scoring authority, raw evidence, credentials, or private paths.