### PR TITLE
fix(benchmark): classify native Goal deadline expiry

### DIFF
--- a/benchmark/native_codex_goal.py
+++ b/benchmark/native_codex_goal.py
@@ -8,6 +8,7 @@ Goal state-machine implementation.
 
 from loopx.capabilities.benchmark_toolkit.native_codex_goal import (
     NativeGoalConfig,
+    NativeGoalDeadlineExceeded,
     NativeGoalEventTransport,
     NativeGoalProtocolError,
     NativeGoalTransport,
@@ -47,6 +48,7 @@ __all__ = [
     "NativeCodexProfile",
     "NativeCodexProfileError",
     "NativeGoalConfig",
+    "NativeGoalDeadlineExceeded",
     "NativeGoalEventTransport",
     "NativeGoalProtocolError",
     "NativeGoalTransport",

--- a/benchmark/tests/test_native_codex_goal.py
+++ b/benchmark/tests/test_native_codex_goal.py
@@ -311,15 +311,7 @@ def test_goal_runtime_waits_for_automatic_continuation_until_terminal() -> None:
     )
 
 
-def test_goal_runtime_fails_closed_when_active_goal_never_continues() -> None:
-    transport = ContinuationTransport(terminal_after_second_turn=False)
-    transport.events = transport.events[:2]
-
-    with pytest.raises(NativeGoalProtocolError, match="goal_timeout_before_terminal"):
-        run_native_goal_until_terminal(transport, _config(), timeout_sec=0.01)
-
-
-def test_goal_runtime_exposes_a_typed_total_deadline() -> None:
+def test_goal_runtime_exposes_typed_deadline_when_active_goal_never_continues() -> None:
     transport = ContinuationTransport(terminal_after_second_turn=False)
     transport.events = transport.events[:2]
 

--- a/benchmark/tests/test_native_codex_goal.py
+++ b/benchmark/tests/test_native_codex_goal.py
@@ -14,6 +14,7 @@ import pytest
 from benchmark.deepswe import run_native_codex_goal as runnable_goal
 from benchmark.native_codex_goal import (
     NativeGoalConfig,
+    NativeGoalDeadlineExceeded,
     NativeGoalProtocolError,
     compact_native_goal_receipt,
     observe_native_goal_event,
@@ -316,6 +317,21 @@ def test_goal_runtime_fails_closed_when_active_goal_never_continues() -> None:
 
     with pytest.raises(NativeGoalProtocolError, match="goal_timeout_before_terminal"):
         run_native_goal_until_terminal(transport, _config(), timeout_sec=0.01)
+
+
+def test_goal_runtime_exposes_a_typed_total_deadline() -> None:
+    transport = ContinuationTransport(terminal_after_second_turn=False)
+    transport.events = transport.events[:2]
+
+    with pytest.raises(
+        NativeGoalDeadlineExceeded,
+        match="goal_timeout_before_terminal",
+    ):
+        run_native_goal_until_terminal(
+            transport,
+            _config(),
+            timeout_sec=0.01,
+        )
 
 
 def _write_fake_app_server(path: Path) -> None:

--- a/loopx/capabilities/benchmark_toolkit/__init__.py
+++ b/loopx/capabilities/benchmark_toolkit/__init__.py
@@ -38,6 +38,7 @@ from .integrity import (
 )
 from .native_codex_goal import (
     NativeGoalConfig,
+    NativeGoalDeadlineExceeded,
     NativeGoalEventTransport,
     NativeGoalProtocolError,
     NativeGoalTransport,
@@ -135,6 +136,7 @@ __all__ = [
     "NativeCodexProfile",
     "NativeCodexProfileError",
     "NativeGoalConfig",
+    "NativeGoalDeadlineExceeded",
     "NativeGoalEventTransport",
     "NativeGoalLifecycleFacts",
     "NativeGoalProtocolError",

--- a/loopx/capabilities/benchmark_toolkit/native_codex_goal.py
+++ b/loopx/capabilities/benchmark_toolkit/native_codex_goal.py
@@ -25,6 +25,10 @@ class NativeGoalProtocolError(RuntimeError):
     """The app-server exchange did not prove the required Goal transaction."""
 
 
+class NativeGoalDeadlineExceeded(NativeGoalProtocolError):
+    """The admitted native Goal remained active through its total deadline."""
+
+
 class NativeGoalTransport(Protocol):
     def request(self, method: str, params: Mapping[str, Any]) -> Mapping[str, Any]: ...
 
@@ -426,7 +430,7 @@ def run_native_goal_until_terminal(
     while True:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
-            raise NativeGoalProtocolError("goal_timeout_before_terminal")
+            raise NativeGoalDeadlineExceeded("goal_timeout_before_terminal")
         try:
             wait_native_goal_turn(
                 transport,
@@ -436,7 +440,9 @@ def run_native_goal_until_terminal(
             )
         except NativeGoalProtocolError as exc:
             if str(exc) == "goal_turn_timeout":
-                raise NativeGoalProtocolError("goal_timeout_before_terminal") from exc
+                raise NativeGoalDeadlineExceeded(
+                    "goal_timeout_before_terminal"
+                ) from exc
             raise
         completed_before = turn.turn_completed_count
         if refresh_native_goal_status(transport, turn) != "active":


### PR DESCRIPTION
## Summary

- Add NativeGoalDeadlineExceeded as a typed NativeGoalProtocolError subtype.
- Preserve the existing goal_timeout_before_terminal message and catch compatibility.
- Export the type through both the toolkit and benchmark compatibility surfaces.

## Motivation

A native Goal that remains active through its admitted total deadline has no terminal verifier result. Benchmark controllers need to classify that outcome as runner-invalid and retryable without brittle string-only exception matching or treating it as a task-score failure.

## Validation

- PYTHONPATH=. pytest -q benchmark/tests/test_native_codex_goal.py: 18 passed.
- loopx canary premerge --from-git-diff: 5/5 selected checks passed; zero failures and warnings.
- Public/private boundary scan: clean.
- Manual hold: benchmark_sensitive, so this PR requires maintainer review and is not self-merged.

This changes no benchmark score, runner deadline, task semantics, permission boundary, or job admission behavior.