### PR TITLE
fix(control-plane): rotate rearmed replan obligations

### DIFF
--- a/loopx/control_plane/goals/goal_frontier/__init__.py
+++ b/loopx/control_plane/goals/goal_frontier/__init__.py
@@ -1333,15 +1333,7 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                 "successor work, update the agent vision, record evidence gap, or "
                 "record no-follow-up"
             ),
-            extra_fields=(
-                {
-                    "rearmed_after_obligation_id": (
-                        rearmed_after_obligation_id
-                    )
-                }
-                if rearmed_after_obligation_id
-                else None
-            ),
+            rearmed_after_obligation_id=rearmed_after_obligation_id,
         )
     if replan_rule.rule is GoalFrontierReplanRule.LONG_TODO_CHAIN:
         assert long_chain_trigger is not None

--- a/loopx/control_plane/goals/goal_frontier/__init__.py
+++ b/loopx/control_plane/goals/goal_frontier/__init__.py
@@ -11,6 +11,7 @@ from ...agents.agent_scope import (
 from ...agents.profile import agent_profile_requires_vision
 from ...agents.runtime_model import peer_work_key, select_peer_for_work
 from ...runtime.time import parse_timestamp
+from ...todos.contract import normalize_todo_replan_obligation_id
 from ...todos.projection import todo_item_is_watch_only_monitor
 from ...todos.succession_warning import (
     TODO_SUCCESSION_WARNING_REASON_CODE,
@@ -1073,6 +1074,22 @@ def _vision_gap_acknowledged(
     )
 
 
+def _acknowledged_replan_obligation_id(
+    latest_replan_ack: dict[str, Any] | None,
+) -> str | None:
+    """Return the exact obligation generation closed by the latest ACK."""
+
+    semantic_delta = (
+        latest_replan_ack.get("semantic_delta")
+        if isinstance(latest_replan_ack, dict)
+        and isinstance(latest_replan_ack.get("semantic_delta"), dict)
+        else {}
+    )
+    return normalize_todo_replan_obligation_id(
+        semantic_delta.get("obligation_id")
+    )
+
+
 def derive_goal_frontier_replan_obligation_from_summaries(
     *,
     user_todo_summary: dict[str, Any] | None,
@@ -1258,6 +1275,9 @@ def derive_goal_frontier_replan_obligation_from_summaries(
             },
         )
     if replan_rule.rule is GoalFrontierReplanRule.VISION_ACCEPTANCE_GAP:
+        rearmed_after_obligation_id = _acknowledged_replan_obligation_id(
+            latest_replan_ack
+        )
         return build_autonomous_replan_obligation_payload(
             schema_version=AUTONOMOUS_REPLAN_OBLIGATION_SCHEMA_VERSION,
             agent_id=agent_id,
@@ -1276,6 +1296,7 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                     **{
                         key: gap.get(key)
                         for key in (
+                            "generated_at",
                             "completed_todo_id",
                             "completed_todo_count",
                             "completed_todo_threshold",
@@ -1311,6 +1332,15 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                 "run a bounded vision-gap replan before another quiet poll: create "
                 "successor work, update the agent vision, record evidence gap, or "
                 "record no-follow-up"
+            ),
+            extra_fields=(
+                {
+                    "rearmed_after_obligation_id": (
+                        rearmed_after_obligation_id
+                    )
+                }
+                if rearmed_after_obligation_id
+                else None
             ),
         )
     if replan_rule.rule is GoalFrontierReplanRule.LONG_TODO_CHAIN:

--- a/loopx/control_plane/work_items/autonomous_replan_obligation.py
+++ b/loopx/control_plane/work_items/autonomous_replan_obligation.py
@@ -193,6 +193,13 @@ def ensure_replan_novelty_policy(
             str(normalized.get("recommended_action") or "run a bounded autonomous replan")
         )
         normalized["replan_novelty_policy"] = build_replan_novelty_policy()
+    rearmed_after_obligation_id = normalize_todo_replan_obligation_id(
+        normalized.get("rearmed_after_obligation_id")
+    )
+    if rearmed_after_obligation_id:
+        normalized["rearmed_after_obligation_id"] = rearmed_after_obligation_id
+    else:
+        normalized.pop("rearmed_after_obligation_id", None)
     trigger_identity = [
         {
             key: trigger.get(key)
@@ -212,6 +219,7 @@ def ensure_replan_novelty_policy(
         "schema_version": normalized.get("schema_version"),
         "agent_id": normalized.get("agent_id"),
         "frontier_identity": normalized.get("frontier_identity"),
+        "rearmed_after_obligation_id": rearmed_after_obligation_id,
         "trigger_identity": trigger_identity,
     }
     normalized["obligation_id"] = "replan-" + hashlib.sha256(

--- a/loopx/control_plane/work_items/autonomous_replan_obligation.py
+++ b/loopx/control_plane/work_items/autonomous_replan_obligation.py
@@ -725,6 +725,7 @@ def build_autonomous_replan_obligation_payload(
     recommended_action: str,
     agent_id: str | None = None,
     include_agent_id: bool = False,
+    rearmed_after_obligation_id: str | None = None,
     extra_fields: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
@@ -742,6 +743,8 @@ def build_autonomous_replan_obligation_payload(
         payload["agent_id"] = agent_id
     if extra_fields:
         payload.update(extra_fields)
+    if rearmed_after_obligation_id is not None:
+        payload["rearmed_after_obligation_id"] = rearmed_after_obligation_id
     return ensure_replan_novelty_policy(payload)
 
 

--- a/tests/control_plane/test_goal_frontier_replan_rules.py
+++ b/tests/control_plane/test_goal_frontier_replan_rules.py
@@ -8,6 +8,7 @@ from loopx.control_plane.goals.goal_frontier import (
     derive_goal_frontier_replan_obligation_from_summaries,
 )
 from loopx.control_plane.goals.goal_frontier.ack_policy import (
+    autonomous_replan_ack_satisfies_obligation,
     replan_successor_transition_ack,
 )
 from loopx.control_plane.goals.goal_frontier.replan_rules import (
@@ -621,6 +622,83 @@ def test_stale_ack_does_not_settle_newer_vision_gap() -> None:
     )
 
     assert obligation is not None, "an older non-vision ack must not settle a newer gap"
+
+
+def test_rearmed_vision_obligation_rotates_acked_generation_identity() -> None:
+    """A newer vision gap must not reuse an already-settled obligation id."""
+
+    summaries = {
+        "user_todo_summary": {"open_count": 0},
+        "agent_todo_summary": {
+            "open_count": 0,
+            "claimed_advancement_open_count": 0,
+            "current_agent_claimed_advancement_count": 0,
+            "unclaimed_priority_open_items": [],
+            "executable_backlog_items": [],
+            "claim_scope": {"other_agent_claimed_items": []},
+        },
+        "work_lane_contract": {
+            "lane": "advancement_task",
+            "must_attempt_work": True,
+        },
+        "agent_id": "current-agent",
+        "existing_replan_obligation": None,
+    }
+    original = derive_goal_frontier_replan_obligation_from_summaries(
+        **summaries,
+        acceptance_gaps=_vision_gap_with_generated_at(
+            "2026-08-13T09:00:00+08:00"
+        ),
+    )
+    assert original is not None
+    original_id = original["obligation_id"]
+    refreshed_without_ack = derive_goal_frontier_replan_obligation_from_summaries(
+        **summaries,
+        acceptance_gaps=_vision_gap_with_generated_at(
+            "2026-08-13T09:30:00+08:00"
+        ),
+    )
+    assert refreshed_without_ack is not None
+    assert refreshed_without_ack["obligation_id"] == original_id
+    prior_ack = _ack(
+        "2026-08-13T10:00:00+08:00",
+        delta_kind="successor_link",
+    )
+    prior_ack["semantic_delta"] = {
+        "schema_version": "replan_semantic_delta_v0",
+        "accepted": True,
+        "outcomes": ["new_runnable_successor"],
+        "satisfying_outcomes": ["new_runnable_successor"],
+        "obligation_id": original_id,
+    }
+
+    def derive_rearmed() -> dict[str, object]:
+        obligation = derive_goal_frontier_replan_obligation_from_summaries(
+            **summaries,
+            latest_replan_ack=prior_ack,
+            acceptance_gaps=_vision_gap_with_generated_at(
+                "2026-08-13T11:00:00+08:00"
+            ),
+        )
+        assert obligation is not None
+        return obligation
+
+    rearmed = derive_rearmed()
+    repeated_read = derive_rearmed()
+
+    assert rearmed["obligation_id"] != original_id
+    assert rearmed["obligation_id"] == repeated_read["obligation_id"]
+    assert rearmed["rearmed_after_obligation_id"] == original_id
+    assert rearmed["triggers"][0]["generated_at"] == (
+        "2026-08-13T11:00:00+08:00"
+    )
+    assert not autonomous_replan_ack_satisfies_obligation(
+        prior_ack,
+        replan_obligation=rearmed,
+        acceptance_gaps=_vision_gap_with_generated_at(
+            "2026-08-13T11:00:00+08:00"
+        ),
+    )
 
 
 def test_open_user_action_owns_empty_frontier_without_obligation() -> None:

--- a/tests/control_plane/test_refresh_state_replan_gate.py
+++ b/tests/control_plane/test_refresh_state_replan_gate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
@@ -729,6 +730,53 @@ def test_current_obligation_runnable_successor_is_the_semantic_receipt() -> None
     )
 
     assert after_transition is None
+    assert semantic_delta is None
+
+
+def test_rearmed_vision_obligation_accepts_only_its_fresh_successor_id() -> None:
+    """Quota/write-time reduction agrees after an older generation was ACKed."""
+
+    state_text = _completed_advancement_chain_state()
+    original_vision = _open_vision_after_prior_ack()
+    original_id = _current_obligation_id(
+        [original_vision],
+        state_text=state_text,
+    )
+    prior_ack = {
+        "classification": "bounded_replan_progress",
+        "generated_at": "2026-08-13T11:28:00+08:00",
+        "agent_id": AGENT_ID,
+        "autonomous_replan_ack": {
+            "schema_version": "autonomous_replan_ack_v0",
+            "recorded": True,
+            "source": "fixture",
+            "semantic_delta": {
+                "schema_version": "replan_semantic_delta_v0",
+                "accepted": True,
+                "outcomes": ["new_runnable_successor"],
+                "satisfying_outcomes": ["new_runnable_successor"],
+                "required_any_of": ["new_runnable_successor"],
+                "obligation_id": original_id,
+            },
+        },
+    }
+    rearmed_vision = deepcopy(original_vision)
+    rearmed_vision["generated_at"] = "2026-08-13T11:29:00+08:00"
+    rearmed_runs = [rearmed_vision, prior_ack, original_vision]
+
+    rearmed_id = _current_obligation_id(
+        rearmed_runs,
+        state_text=state_text,
+    )
+    remaining, semantic_delta = qualify_replan_writeback(
+        newest_first_runs=rearmed_runs,
+        state_text=_state_with_replan_successor(rearmed_id),
+        agent_id=AGENT_ID,
+        goal_id=GOAL_ID,
+    )
+
+    assert rearmed_id != original_id
+    assert remaining is None
     assert semantic_delta is None
 
 

--- a/tests/control_plane/test_replan_novelty_policy.py
+++ b/tests/control_plane/test_replan_novelty_policy.py
@@ -159,6 +159,23 @@ def test_payload_builder_defaults_to_novelty_guidance_and_policy() -> None:
     assert policy["writeback"] == "typed_semantic_delta"
 
 
+def test_payload_builder_owns_rearm_lineage_field() -> None:
+    payload = build_autonomous_replan_obligation_payload(
+        schema_version="autonomous_replan_obligation_v0",
+        stall_threshold=1,
+        trigger_count=1,
+        triggers=[{"kind": "vision_acceptance_gap"}],
+        guidance_actions=["create_successor"],
+        todo_actions=[],
+        stop_condition="stop on owner-only authority",
+        recommended_action="run a bounded frontier replan",
+        rearmed_after_obligation_id="replan-0123456789abcdef",
+    )
+
+    assert payload["rearmed_after_obligation_id"] == "replan-0123456789abcdef"
+    assert payload["obligation_id"] != "replan-0123456789abcdef"
+
+
 def test_payload_builder_replaces_conflicting_policy_extra_fields() -> None:
     payload = build_autonomous_replan_obligation_payload(
         schema_version="autonomous_replan_obligation_v0",
@@ -298,4 +315,3 @@ def test_policy_normalization_precedes_deterministic_peer_scope_selection() -> N
 
     assert len(selected) == 1
     assert selected <= set(registered_agents)
-


### PR DESCRIPTION
## Summary

- rotate a vision-gap replan obligation after its prior generation is acknowledged
- keep the new generation deterministic across repeated reads
- retain the gap timestamp while preventing an old ACK from satisfying the rearmed obligation
- verify quota/write-time settlement accepts only the fresh successor identity

## Root cause

Vision-gap obligations derived the same identity after a prior generation had been acknowledged. When the gap rearmed, the stale ACK could still match that reused identity and incorrectly close the new obligation.

## Validation

- `pytest tests/control_plane/test_goal_frontier_replan_rules.py tests/control_plane/test_refresh_state_replan_gate.py` — 62 passed
- exact changed paths: Ruff and `py_compile` passed
- repository strict `mypy` scope — 12 source files passed
- public/private boundary scan — clean
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` — passed; 0 failures, 0 manual holds
- exact-scope quality receipt `cqr_b59ec68bb8d93bf3f8c2` — valid

No private goal state, raw run history, credentials, or generated logs are included.
