### PR TITLE
fix(dashboard): discover the installed Python runtime

### DIFF
--- a/apps/presentation/dashboard/README.md
+++ b/apps/presentation/dashboard/README.md
@@ -22,7 +22,7 @@ status server:
 cd apps/presentation/dashboard
 npm ci
 npm run smoke:demo-readiness -- --skip-browser
-npm run dev
+npm run dev:web
 ```
 
 Then open `http://127.0.0.1:5173/`. Use the bundled example source for a public
@@ -30,6 +30,10 @@ demo, or switch to a loopback status URL only after you have started
 `loopx serve-status` locally. Do not commit `status.local.json` or live
 status exports; they can contain local registry/runtime paths and private
 project summaries.
+
+`npm run dev:web` starts only the Vite UI with the bundled example. `npm run dev`
+also starts the loopback status and Chat services and therefore requires a
+Python 3.11+ interpreter; see the development section below.
 
 The first read-only channel frontstage lives at `/frontstage`. It renders a
 public-safe `goal_channel_projection_v0` fixture as a dense channel board with
@@ -147,6 +151,16 @@ services on ports `5173`, `8766`, and `8767`. Use `npm run dev:web` when those
 LoopX services are already running separately. Vite proxies the default
 `/status.json` request to port `8766`, so an SSH user only needs to forward port
 `5173` for the normal development page.
+
+The full-stack launcher needs a Python 3.11+ interpreter for the status and
+Chat services. It honors `LOOPX_PYTHON` first, then the Python recorded by the
+LoopX installer in `.loopx-python`, then `python3.13`/`python3.12`/`python3.11`
+on `PATH` and common Homebrew locations. If your default `python3` is older,
+point it at an existing interpreter:
+
+```bash
+LOOPX_PYTHON=/path/to/python3.12 npm run dev
+```
 
 Both the root dashboard and the packaged `/chat/` route expose the same
 installable PWA manifest and icons. The default `loopx dashboard` command opens

--- a/scripts/dashboard-dev.sh
+++ b/scripts/dashboard-dev.sh
@@ -96,17 +96,70 @@ cleanup() {
 
 trap cleanup EXIT INT TERM
 
-for candidate in python3.13 python3.12 python3.11 python3; do
-  if command -v "${candidate}" >/dev/null 2>&1 \
-    && "${candidate}" -c 'import sys; raise SystemExit(sys.version_info < (3, 11))' 2>/dev/null; then
-    PYTHON_BIN="${candidate}"
-    break
-  fi
-done
+python_version_ok() {
+  "$1" -c 'import sys; raise SystemExit(sys.version_info < (3, 11))' 2>/dev/null
+}
 
-if [ -z "${PYTHON_BIN}" ]; then
+select_python_runtime() {
+  local candidate=""
+  local configured_python=""
+  local authoritative=0
+
+  if [ -n "${LOOPX_PYTHON:-}" ]; then
+    configured_python="${LOOPX_PYTHON}"
+    authoritative=1
+  elif [ -f "${REPO_ROOT}/.loopx-python" ]; then
+    IFS= read -r configured_python <"${REPO_ROOT}/.loopx-python"
+  fi
+
+  if [ -n "${configured_python}" ]; then
+    if { [ -x "${configured_python}" ] || command -v "${configured_python}" >/dev/null 2>&1; } \
+      && python_version_ok "${configured_python}"; then
+      echo "Using LoopX Python: ${configured_python}"
+      PYTHON_BIN="${configured_python}"
+      return 0
+    fi
+    if [ "${authoritative}" -eq 1 ]; then
+      echo "LOOPX_PYTHON is set but does not resolve to a Python 3.11+ interpreter: ${configured_python}" >&2
+      return 1
+    fi
+    echo "Ignoring non-functional Python recorded in .loopx-python: ${configured_python}" >&2
+  fi
+
+  for candidate in python3.13 python3.12 python3.11 python3; do
+    if command -v "${candidate}" >/dev/null 2>&1 \
+      && python_version_ok "$(command -v "${candidate}")"; then
+      PYTHON_BIN="$(command -v "${candidate}")"
+      return 0
+    fi
+  done
+
+  for candidate in \
+    "${HOME}/.local/bin/python3.13" \
+    "${HOME}/.local/bin/python3.12" \
+    "${HOME}/.local/bin/python3.11" \
+    /opt/homebrew/bin/python3.13 \
+    /opt/homebrew/bin/python3.12 \
+    /opt/homebrew/bin/python3.11 \
+    /usr/local/bin/python3.13 \
+    /usr/local/bin/python3.12 \
+    /usr/local/bin/python3.11; do
+    if [ -x "${candidate}" ] && python_version_ok "${candidate}"; then
+      echo "Using Python from ${candidate}"
+      PYTHON_BIN="${candidate}"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+if ! select_python_runtime; then
   echo "LoopX requires Python 3.11 or newer to start status and Chat services." >&2
-  echo "Starting the Vite UI only; use the bundled example until Python is upgraded." >&2
+  echo "Install Python 3.11+ (for example: brew install python@3.12), or set" >&2
+  echo "LOOPX_PYTHON to an existing Python 3.11+ executable and retry, e.g.:" >&2
+  echo "  LOOPX_PYTHON=/path/to/python3.12 npm run dev" >&2
+  echo "Starting the Vite UI only; use 'npm run dev:web' for the same UI-only preview." >&2
   cd "${DASHBOARD_DIR}"
   exec npm run dev:web
 fi

--- a/scripts/dashboard-dev.sh
+++ b/scripts/dashboard-dev.sh
@@ -100,6 +100,20 @@ python_version_ok() {
   "$1" -c 'import sys; raise SystemExit(sys.version_info < (3, 11))' 2>/dev/null
 }
 
+select_python_candidate() {
+  local requested="$1"
+  local resolved=""
+  if [ -x "${requested}" ]; then
+    resolved="${requested}"
+  elif ! resolved="$(command -v "${requested}" 2>/dev/null)"; then
+    return 1
+  fi
+  if ! python_version_ok "${resolved}"; then
+    return 1
+  fi
+  PYTHON_BIN="${resolved}"
+}
+
 select_python_runtime() {
   local candidate=""
   local configured_python=""
@@ -113,10 +127,8 @@ select_python_runtime() {
   fi
 
   if [ -n "${configured_python}" ]; then
-    if { [ -x "${configured_python}" ] || command -v "${configured_python}" >/dev/null 2>&1; } \
-      && python_version_ok "${configured_python}"; then
-      echo "Using LoopX Python: ${configured_python}"
-      PYTHON_BIN="${configured_python}"
+    if select_python_candidate "${configured_python}"; then
+      echo "Using LoopX Python: ${PYTHON_BIN}"
       return 0
     fi
     if [ "${authoritative}" -eq 1 ]; then
@@ -127,9 +139,7 @@ select_python_runtime() {
   fi
 
   for candidate in python3.13 python3.12 python3.11 python3; do
-    if command -v "${candidate}" >/dev/null 2>&1 \
-      && python_version_ok "$(command -v "${candidate}")"; then
-      PYTHON_BIN="$(command -v "${candidate}")"
+    if select_python_candidate "${candidate}"; then
       return 0
     fi
   done
@@ -144,9 +154,8 @@ select_python_runtime() {
     /usr/local/bin/python3.13 \
     /usr/local/bin/python3.12 \
     /usr/local/bin/python3.11; do
-    if [ -x "${candidate}" ] && python_version_ok "${candidate}"; then
-      echo "Using Python from ${candidate}"
-      PYTHON_BIN="${candidate}"
+    if select_python_candidate "${candidate}"; then
+      echo "Using Python from ${PYTHON_BIN}"
       return 0
     fi
   done

--- a/tests/test_dashboard_command.py
+++ b/tests/test_dashboard_command.py
@@ -430,6 +430,43 @@ def test_dashboard_launcher_uses_installer_recorded_python(
     assert "recorded:-m loopx.cli chat" in commands
 
 
+def test_dashboard_launcher_ignores_stale_recorded_python(
+    tmp_path: Path,
+) -> None:
+    release_root, dashboard_script, fake_bin = _prepare_dashboard_runtime_fixture(
+        tmp_path
+    )
+    discovered_python = fake_bin / "python3.13"
+
+    command_log = tmp_path / "commands.log"
+    _write_logging_python_stub(discovered_python, label="discovered")
+    (release_root / ".loopx-python").write_text(
+        f"{tmp_path / 'missing-python'}\n",
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        ["bash", str(dashboard_script)],
+        cwd=release_root,
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:/usr/bin:/bin",
+            "LOOPX_COMMAND_LOG": str(command_log),
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "Ignoring non-functional Python recorded in .loopx-python" in (
+        completed.stderr
+    )
+    commands = command_log.read_text(encoding="utf-8")
+    assert "discovered:-m loopx.cli serve-status" in commands
+    assert "discovered:-m loopx.cli chat" in commands
+
+
 def test_dashboard_launcher_discovers_agent_bins_outside_restricted_path(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_dashboard_command.py
+++ b/tests/test_dashboard_command.py
@@ -39,6 +39,35 @@ def _serve_capabilities(handler_cls: type[_CapabilitiesHandler] = _CapabilitiesH
     return server, thread
 
 
+def _prepare_dashboard_runtime_fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
+    release_root = tmp_path / "release"
+    scripts_dir = release_root / "scripts"
+    dashboard_dir = release_root / "apps" / "presentation" / "dashboard"
+    fake_bin = tmp_path / "bin"
+    scripts_dir.mkdir(parents=True)
+    (dashboard_dir / "node_modules" / ".bin").mkdir(parents=True)
+    (dashboard_dir / "node_modules" / ".bin" / "vite").touch()
+    fake_bin.mkdir()
+    shutil.copy2(
+        Path(__file__).resolve().parents[1] / "scripts" / "dashboard-dev.sh",
+        scripts_dir / "dashboard-dev.sh",
+    )
+    for executable in (fake_bin / "node", fake_bin / "npm"):
+        executable.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+        executable.chmod(0o755)
+    return release_root, scripts_dir / "dashboard-dev.sh", fake_bin
+
+
+def _write_logging_python_stub(path: Path, *, label: str) -> None:
+    path.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf "{label}:%s\\n" "$*" >> "$LOOPX_COMMAND_LOG"\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
 def test_dashboard_command_is_registered() -> None:
     try:
         args = build_parser().parse_args(["dashboard"])
@@ -320,6 +349,85 @@ def test_dashboard_launcher_selects_a_compatible_nvm_node(
         "ci",
         "run dev:web",
     ]
+
+
+def test_dashboard_launcher_prefers_explicit_loopx_python(
+    tmp_path: Path,
+) -> None:
+    release_root, dashboard_script, fake_bin = _prepare_dashboard_runtime_fixture(
+        tmp_path
+    )
+    configured_python = tmp_path / "configured-python"
+    recorded_python = tmp_path / "recorded-python"
+
+    command_log = tmp_path / "commands.log"
+    for executable, label in (
+        (configured_python, "configured"),
+        (recorded_python, "recorded"),
+    ):
+        _write_logging_python_stub(executable, label=label)
+    (release_root / ".loopx-python").write_text(
+        f"{recorded_python}\n",
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        ["bash", str(dashboard_script)],
+        cwd=release_root,
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:/usr/bin:/bin",
+            "LOOPX_COMMAND_LOG": str(command_log),
+            "LOOPX_PYTHON": str(configured_python),
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert f"Using LoopX Python: {configured_python}" in completed.stdout
+    commands = command_log.read_text(encoding="utf-8")
+    assert "configured:-m loopx.cli serve-status" in commands
+    assert "configured:-m loopx.cli chat" in commands
+    assert "recorded:" not in commands
+
+
+def test_dashboard_launcher_uses_installer_recorded_python(
+    tmp_path: Path,
+) -> None:
+    release_root, dashboard_script, fake_bin = _prepare_dashboard_runtime_fixture(
+        tmp_path
+    )
+    recorded_python = tmp_path / "recorded-python"
+
+    command_log = tmp_path / "commands.log"
+    _write_logging_python_stub(recorded_python, label="recorded")
+    (release_root / ".loopx-python").write_text(
+        f"{recorded_python}\n",
+        encoding="utf-8",
+    )
+
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:/usr/bin:/bin",
+        "LOOPX_COMMAND_LOG": str(command_log),
+    }
+    env.pop("LOOPX_PYTHON", None)
+    completed = subprocess.run(
+        ["bash", str(dashboard_script)],
+        cwd=release_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert f"Using LoopX Python: {recorded_python}" in completed.stdout
+    commands = command_log.read_text(encoding="utf-8")
+    assert "recorded:-m loopx.cli serve-status" in commands
+    assert "recorded:-m loopx.cli chat" in commands
 
 
 def test_dashboard_launcher_discovers_agent_bins_outside_restricted_path(


### PR DESCRIPTION
## Summary

- honor `LOOPX_PYTHON` and the installer-recorded `.loopx-python` runtime
- discover compatible Python 3.11+ interpreters on `PATH` and common local locations
- make the fresh-clone public preview explicitly use the UI-only `dev:web` path
- add focused launcher regressions for explicit and installer-recorded runtimes

## Root cause

The dashboard launcher only searched a narrow set of command names on `PATH`. A valid interpreter selected by the LoopX installer could be missed, causing the full-stack launcher to fall back to the UI-only preview.

## Validation

- `pytest tests/test_dashboard_command.py` — 18 passed
- `bash -n scripts/dashboard-dev.sh` — passed
- changed Python path: Ruff and `py_compile` passed
- repository strict `mypy` scope — 12 source files passed
- public/private boundary scan — clean
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` — passed; 0 failures, 0 manual holds
- exact-scope quality receipt `cqr_4f1ff8349f43807b1a9f` — valid

No local runtime state, credentials, or generated dashboard artifacts are included.
