### PR TITLE
fix(control-plane): dedupe progress retries by turn

### DIFF
--- a/loopx/control_plane/work_items/progress_observation.py
+++ b/loopx/control_plane/work_items/progress_observation.py
@@ -8,6 +8,7 @@ from collections.abc import Iterable, Mapping
 from enum import StrEnum
 from typing import Any
 
+from ...turn_identity import normalize_turn_instance_id
 from ..goals.goal_vision_state import normalize_goal_vision_state
 from ..todos.contract import (
     normalize_todo_task_domain,
@@ -203,10 +204,18 @@ def progress_observation_from_run(run: Mapping[str, Any]) -> dict[str, Any] | No
 def _progress_turn_instance_id(run: Mapping[str, Any]) -> str | None:
     """Return a trustworthy logical-turn id for retry de-duplication."""
 
-    direct = str(run.get("turn_instance_id") or "").strip()
+    def normalize(value: Any) -> str | None:
+        try:
+            return normalize_turn_instance_id(
+                str(value) if value is not None else None
+            )
+        except ValueError:
+            return None
+
+    direct = normalize(run.get("turn_instance_id"))
     settlement_value = run.get("settlement_identity")
     settlement = settlement_value if isinstance(settlement_value, Mapping) else {}
-    settled = str(settlement.get("turn_instance_id") or "").strip()
+    settled = normalize(settlement.get("turn_instance_id"))
     if direct and settled and direct != settled:
         return None
     return direct or settled or None

--- a/loopx/control_plane/work_items/progress_observation.py
+++ b/loopx/control_plane/work_items/progress_observation.py
@@ -200,6 +200,18 @@ def progress_observation_from_run(run: Mapping[str, Any]) -> dict[str, Any] | No
         return None
 
 
+def _progress_turn_instance_id(run: Mapping[str, Any]) -> str | None:
+    """Return a trustworthy logical-turn id for retry de-duplication."""
+
+    direct = str(run.get("turn_instance_id") or "").strip()
+    settlement_value = run.get("settlement_identity")
+    settlement = settlement_value if isinstance(settlement_value, Mapping) else {}
+    settled = str(settlement.get("turn_instance_id") or "").strip()
+    if direct and settled and direct != settled:
+        return None
+    return direct or settled or None
+
+
 def typed_progress_repeat_trigger(
     newest_first_runs: Iterable[Mapping[str, Any]],
     *,
@@ -211,9 +223,13 @@ def typed_progress_repeat_trigger(
     required_count = max(2, int(threshold))
     normalized_agent_id = str(agent_id or "").strip()
     observations: list[tuple[Mapping[str, Any], dict[str, Any]]] = []
+    observed_turn_instance_ids: set[str] = set()
     for run in newest_first_runs:
         run_agent_id = str(run.get("agent_id") or "").strip()
         if normalized_agent_id and run_agent_id not in {"", normalized_agent_id}:
+            continue
+        turn_instance_id = _progress_turn_instance_id(run)
+        if turn_instance_id and turn_instance_id in observed_turn_instance_ids:
             continue
         observation = progress_observation_from_run(run)
         if observation is None:
@@ -221,6 +237,8 @@ def typed_progress_repeat_trigger(
                 break
             continue
         observations.append((run, observation))
+        if turn_instance_id:
+            observed_turn_instance_ids.add(turn_instance_id)
         if len(observations) >= required_count:
             break
     if len(observations) < required_count:

--- a/tests/control_plane/test_progress_observation.py
+++ b/tests/control_plane/test_progress_observation.py
@@ -28,12 +28,20 @@ def _observation(**overrides: object) -> dict[str, object]:
     return value
 
 
-def _run(generated_at: str, observation: dict[str, object]) -> dict[str, object]:
-    return {
+def _run(
+    generated_at: str,
+    observation: dict[str, object],
+    *,
+    turn_instance_id: str | None = None,
+) -> dict[str, object]:
+    run: dict[str, object] = {
         "generated_at": generated_at,
         "agent_id": AGENT_ID,
         "progress_observation": normalize_progress_observation(observation),
     }
+    if turn_instance_id:
+        run["turn_instance_id"] = turn_instance_id
+    return run
 
 
 def test_normalization_rejects_prose_in_semantic_identifiers() -> None:
@@ -55,6 +63,64 @@ def test_two_equivalent_typed_observations_trigger_replan_without_text() -> None
     assert trigger["kind"] == "typed_progress_repeat"
     assert trigger["run_count"] == 2
     assert trigger["progress_baseline"]["surface_id"] == "surface-auth"
+
+
+def test_same_turn_retry_does_not_trigger_replan() -> None:
+    runs = [
+        _run(
+            "2026-08-13T01:01:01Z",
+            _observation(),
+            turn_instance_id="turn-retry",
+        ),
+        _run(
+            "2026-08-13T01:01:00Z",
+            _observation(),
+            turn_instance_id="turn-retry",
+        ),
+    ]
+
+    assert typed_progress_repeat_trigger(runs, agent_id=AGENT_ID) is None
+
+
+def test_same_turn_retry_and_prior_distinct_turn_trigger_replan() -> None:
+    runs = [
+        _run(
+            "2026-08-13T01:02:01Z",
+            _observation(),
+            turn_instance_id="turn-current",
+        ),
+        _run(
+            "2026-08-13T01:02:00Z",
+            _observation(),
+            turn_instance_id="turn-current",
+        ),
+        _run(
+            "2026-08-13T01:00:00Z",
+            _observation(),
+            turn_instance_id="turn-prior",
+        ),
+    ]
+
+    trigger = typed_progress_repeat_trigger(runs, agent_id=AGENT_ID)
+
+    assert trigger is not None
+    assert trigger["latest_generated_at"] == "2026-08-13T01:02:01Z"
+    assert trigger["oldest_counted_generated_at"] == "2026-08-13T01:00:00Z"
+
+
+def test_settlement_identity_turn_id_deduplicates_retries() -> None:
+    runs = [
+        {
+            **_run("2026-08-13T01:01:01Z", _observation()),
+            "settlement_identity": {"turn_instance_id": "turn-retry"},
+        },
+        {
+            **_run("2026-08-13T01:01:00Z", _observation()),
+            "settlement_identity": {"turn_instance_id": "turn-retry"},
+        },
+    ]
+
+    assert typed_progress_repeat_trigger(runs, agent_id=AGENT_ID) is None
 
 
 def test_text_changes_cannot_hide_an_equivalent_typed_repeat() -> None:

--- a/tests/control_plane/test_progress_observation.py
+++ b/tests/control_plane/test_progress_observation.py
@@ -123,6 +123,46 @@ def test_settlement_identity_turn_id_deduplicates_retries() -> None:
     assert typed_progress_repeat_trigger(runs, agent_id=AGENT_ID) is None
 
 
+def test_conflicting_turn_id_sources_do_not_deduplicate_retries() -> None:
+    runs = [
+        {
+            **_run(
+                "2026-08-13T01:01:01Z",
+                _observation(),
+                turn_instance_id="turn-direct",
+            ),
+            "settlement_identity": {"turn_instance_id": "turn-settled"},
+        },
+        {
+            **_run(
+                "2026-08-13T01:01:00Z",
+                _observation(),
+                turn_instance_id="turn-direct",
+            ),
+            "settlement_identity": {"turn_instance_id": "turn-settled"},
+        },
+    ]
+
+    assert typed_progress_repeat_trigger(runs, agent_id=AGENT_ID) is not None
+
+
+def test_invalid_turn_ids_do_not_deduplicate_retries() -> None:
+    runs = [
+        _run(
+            "2026-08-13T01:01:01Z",
+            _observation(),
+            turn_instance_id="turn with prose",
+        ),
+        _run(
+            "2026-08-13T01:01:00Z",
+            _observation(),
+            turn_instance_id="turn with prose",
+        ),
+    ]
+
+    assert typed_progress_repeat_trigger(runs, agent_id=AGENT_ID) is not None
+
+
 def test_text_changes_cannot_hide_an_equivalent_typed_repeat() -> None:
     runs = [
         {


### PR DESCRIPTION
## Summary

- treat repeated writebacks from one logical Turn as one progress observation
- read Turn identity from either the run row or its settlement identity
- preserve repeat-trigger behavior across genuinely distinct Turns

## Root cause

The repeat reducer counted run-history rows rather than logical Turn identities. A retry written during the same Turn could therefore satisfy the repeated-stall threshold by itself.

## Validation

- `pytest tests/control_plane/test_progress_observation.py` — 20 passed
- exact changed paths: Ruff and `py_compile` passed
- repository strict `mypy` scope — 12 source files passed
- public/private boundary scan — clean
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` — passed; 0 failures, 0 manual holds
- exact-scope quality receipt `cqr_c8cedaab125420191b2c` — valid

No local runtime state, raw histories, credentials, or generated logs are included.
