### PR TITLE
fix(runtime): probe Windows Effect process without signals

### DIFF
--- a/loopx/control_plane/effect_runtime.py
+++ b/loopx/control_plane/effect_runtime.py
@@ -114,6 +114,10 @@ def _probe_node() -> tuple[str, str | None, str | None]:
 def _pid_is_alive(value: object) -> bool:
     if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
         return False
+    if os.name == "nt":
+        # Windows signal 0 is CTRL_C_EVENT, not the side-effect-free POSIX
+        # existence probe provided by kill(pid, 0).
+        return _windows_pid_is_alive(value)
     try:
         os.kill(value, 0)
     except ProcessLookupError:
@@ -123,6 +127,37 @@ def _pid_is_alive(value: object) -> bool:
     except OSError:
         return False
     return True
+
+
+def _windows_pid_is_alive(pid: int) -> bool:
+    """Probe a Windows process without sending a console control event."""
+
+    import ctypes
+    from ctypes import wintypes
+
+    synchronize = 0x00100000
+    wait_timeout = 0x00000102
+    error_access_denied = 5
+    kernel32 = getattr(ctypes, "WinDLL")("kernel32", use_last_error=True)
+    open_process = kernel32.OpenProcess
+    open_process.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    open_process.restype = wintypes.HANDLE
+    wait_for_single_object = kernel32.WaitForSingleObject
+    wait_for_single_object.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+    wait_for_single_object.restype = wintypes.DWORD
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = [wintypes.HANDLE]
+    close_handle.restype = wintypes.BOOL
+
+    handle = open_process(synchronize, False, pid)
+    if not handle:
+        # An access-denied process still exists; it is merely outside the
+        # caller's query authority.
+        return bool(getattr(ctypes, "get_last_error")() == error_access_denied)
+    try:
+        return bool(wait_for_single_object(handle, 0) == wait_timeout)
+    finally:
+        close_handle(handle)
 
 
 def _start_lock_holder_pid(path: Path) -> int | None:
@@ -273,7 +308,7 @@ def _start_runtime(*, fingerprint: str, info_path: Path) -> dict[str, Any]:
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 start_new_session=os.name != "nt",
-                close_fds=os.name != "nt",
+                close_fds=True,
             )
         except OSError as exc:
             raise EffectRuntimeStartupError(

--- a/tests/control_plane/test_effect_runtime_integration.py
+++ b/tests/control_plane/test_effect_runtime_integration.py
@@ -7,6 +7,7 @@ import signal
 import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from types import SimpleNamespace
 
 from loopx.control_plane import effect_runtime
 
@@ -29,6 +30,21 @@ def _digest(path: Path) -> str | None:
         return hashlib.sha256(path.read_bytes()).hexdigest()
     except FileNotFoundError:
         return None
+
+
+def test_windows_pid_liveness_uses_a_non_signaling_probe(monkeypatch) -> None:
+    calls: list[int] = []
+    fake_os = SimpleNamespace(name="nt")
+
+    def probe(pid: int) -> bool:
+        calls.append(pid)
+        return True
+
+    monkeypatch.setattr(effect_runtime, "os", fake_os)
+    monkeypatch.setattr(effect_runtime, "_windows_pid_is_alive", probe)
+
+    assert effect_runtime._pid_is_alive(1234) is True
+    assert calls == [1234]
 
 
 def test_managed_runtime_is_reused_and_restart_safe_for_typed_write(
@@ -321,10 +337,16 @@ def test_early_runtime_exit_surfaces_stable_startup_diagnostic(
         def poll(self) -> int:
             return 23
 
+    launch: dict[str, object] = {}
+
+    def popen(*_args, **kwargs):
+        launch.update(kwargs)
+        return _ExitedProcess()
+
     monkeypatch.setattr(
         effect_runtime.subprocess,
         "Popen",
-        lambda *_args, **_kwargs: _ExitedProcess(),
+        popen,
     )
 
     try:
@@ -334,6 +356,7 @@ def test_early_runtime_exit_surfaces_stable_startup_diagnostic(
         assert "exit_code=23" in str(exc)
     else:
         raise AssertionError("an early runtime exit must fail with a stable diagnostic")
+    assert launch["close_fds"] is True
 
 
 def test_managed_runtime_releases_memory_after_idle_timeout(


### PR DESCRIPTION
## Summary

- replace the POSIX-only `kill(pid, 0)` liveness probe on Windows with a read-only process-handle wait
- prevent the managed Node runtime from inheriting caller and installer pipe handles
- preserve the existing POSIX probe and the managed runtime RPC/startup/shutdown contracts
- add regression contracts for non-signaling liveness and closed descriptor inheritance

## Root cause

PR #3416 added a shared managed TypeScript Effect runtime and read its persisted PID before every request. On POSIX, `os.kill(pid, 0)` is a side-effect-free existence probe. On Windows, Python documents `os.kill` as a signal/termination API; signal value `0` maps to the console Ctrl-C event rather than POSIX probe semantics. The metadata read therefore interrupted the test runner while it was blocked in `socket.recv`, producing 19 passing tests followed by `KeyboardInterrupt`.

The Windows branch now opens the process with `SYNCHRONIZE`, checks it using `WaitForSingleObject(..., 0)`, and closes the handle. `WAIT_TIMEOUT` means the process remains live. Access-denied processes are treated as live because existence was established but query authority was unavailable.

The first native rerun then exposed the adjacent lifecycle bug: 37 tests passed, but `test_windows_installer_promotes_release_and_runs_doctor` timed out after 180 seconds. The installed `doctor --deep` process started the runtime with `close_fds=False`, so the long-lived Node child inherited the installer's captured stdout/stderr pipe handles and `subprocess.communicate()` could not observe EOF. Runtime launch now always closes unrelated descriptors; its own standard streams remain explicitly connected to `DEVNULL`.

## Validation

- exact Windows workflow selection on macOS: `35 passed, 6 skipped`
- Effect runtime integration: `11 passed`
- Ruff on changed paths: passed
- repository MyPy contract: passed
- `npm run typecheck:control-plane`: passed
- `npm run test:control-plane`: 18 passed
- `git diff --check`: passed
- first native Windows diagnostic rerun: 37 passed before the installer pipe-inheritance timeout identified above
- LoopX change-quality receipt: `cqr_8de9da1b2b723f2a082d`, exact-scope valid on the latest `main`
- LoopX premerge canary: direct diff checks, Python compile, and selected control-plane canaries passed locally; native Windows behavior remains held for the `windows-latest` PR check

## Risk boundary

This changes Windows process liveness observation and prevents unrelated handle inheritance at runtime launch. It does not change Effect Program interpretation, effect identity, retry safety, journal persistence, adapter behavior, installation semantics, or runtime shutdown authority.
