### PR TITLE
docs: require bounded future-facing refactors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,6 +209,27 @@ Treat code volume as a cost, especially during refactors. A good LoopX change
 should make the next change easier to localize, test, and revert; it should not
 turn a design possibility into unused production structure.
 
+### Bounded Future-Facing Refactoring
+
+During development and again before approving or merging each PR, explicitly
+ask whether the touched behavior or its adjacent owning boundary has a small,
+related, behavior-preserving refactor that would make the next likely product
+or control-plane change easier. Prefer removing duplicate authority,
+strengthening typed contracts, narrowing module ownership, and retiring
+obsolete compatibility seams over adding speculative frameworks. For
+control-plane work, keep state-machine and effect authority in the typed
+TypeScript boundary when that is the established owner; Python may adapt or
+bridge that contract, but must not silently recreate a second source of truth.
+
+Apply the refactor in the current PR when it shares the same domain or change
+reason, remains locally reviewable and reversible, and is covered by
+characterization or parity validation; it need not be strictly required for
+the immediate fix. Do not use this principle to justify broad migration or
+unrelated cleanup. When the valuable related refactor is larger than a bounded
+companion change, record a focused follow-up instead. PR review and merge notes
+should state whether this future-facing pass was applied, deferred, or found
+unnecessary, with the concrete boundary considered.
+
 ## Capability And Extension Placement
 
 Before adding an ability, decide its capability owner and provider boundary;


### PR DESCRIPTION
## Summary

- require a future-facing refactor pass during development and PR review
- allow small related companion refactors when they share the same domain or change reason
- keep TypeScript as the typed control-plane authority where that ownership is established
- require bounded scope, parity validation, and explicit apply/defer/not-needed review notes

## Validation

- `git diff --check` — passed
- public/private boundary scan — clean
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` — 9 selected checks passed; 0 failures, 0 manual holds
- exact-scope quality receipt `cqr_87be8541fd62b9230aff` — valid

This change only updates public maintainer policy. It includes no runtime state, credentials, local paths, or generated logs.
