### PR TITLE
test(todos): preserve omitted monitor schedule fields

### DIFF
--- a/tests/control_plane/test_monitor_followthrough_contract.py
+++ b/tests/control_plane/test_monitor_followthrough_contract.py
@@ -94,6 +94,38 @@ def test_exact_todo_id_precedes_ambiguous_target_key(tmp_path: Path) -> None:
     assert first["todo_id"] != second["todo_id"]
 
 
+def test_todo_update_preserves_omitted_monitor_schedule_fields(tmp_path: Path) -> None:
+    registry, runtime, _state = _write_fixture(tmp_path)
+    monitor = _add_monitor(
+        registry,
+        text="Poll a public release target.",
+        target_key="public-release:42",
+    )
+
+    updated = run_json_cli(
+        "todo",
+        "update",
+        "--goal-id",
+        GOAL_ID,
+        "--todo-id",
+        monitor["todo_id"],
+        "--role",
+        "agent",
+        "--agent-id",
+        AGENT_ID,
+        "--note",
+        "No material change.",
+        "--watch-only",
+        registry_path=registry,
+        runtime_root=runtime,
+    )
+
+    assert updated["target_key"] == "public-release:42"
+    assert updated["cadence"] == "1h"
+    assert updated["next_due_at"] == "2099-01-01T00:00:00+00:00"
+    assert updated["watch_only"] == "true"
+
+
 def test_monitor_resume_when_is_a_supported_bounded_policy(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- cover sparse `todo update` monitor metadata patches through the public CLI
- assert omitted target and schedule fields remain durable when only note/watch state changes
- prevent a monitor refresh from silently losing its routing identity or cadence

## Validation

- `python -m pytest -q tests/control_plane/test_monitor_followthrough_contract.py` (16 passed)
- `scripts/loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard --goal-id loopx-deepswe-bench --no-progress` (4/4 selected canaries passed)
- `git diff --check`

This is regression coverage only; runtime behavior is unchanged.