### PR TITLE
feat(extensions): govern material capability execution

### DIFF
--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -336,7 +336,12 @@ journal. Exact provider revision, request digest, Goal binding, settlement
 identity, provider effect receipt, writeback receipt, and quota receipt remain
 attached to the same invocation. A crash after an external effect therefore
 replays with the same idempotency key and reconciles the receipt instead of
-starting an unrelated operation.
+starting an unrelated operation. One settlement effect id owns exactly one
+material invocation: retrying the same request replays it, while attempting a
+different operation or input under the same Turn receipt fails before provider
+dispatch. A new invocation also requires `should_run=true`; an existing journal
+may still be recovered with its exact typed receipt after the runnable decision
+has changed.
 
 Goal enablement alone never grants write authority. Creating or updating the
 binding is an explicit Goal configuration change: it uses preview/apply, but it

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -313,8 +313,14 @@ that operation is deliberately unavailable through direct invocation. A host
 adapter must call the governed material lifecycle in
 `loopx.extensions.governed_capability_execution`:
 
+An external-write operation also declares a typed `todo_contract` beside
+`effect_class`, containing one or more lower-snake `action_kinds` and bounded
+`target_key_prefixes`.
+
 1. obtain `quota should-run` admission for one exact Goal, Agent, Todo, and
-   `turn_instance_id`;
+   `turn_instance_id`; the selected open Agent Todo's `action_kind` and
+   `target_key` must match the operation profile's `todo_contract`, so an
+   admitted Turn cannot borrow an unrelated Goal-bound write capability;
 2. call `start_governed_external_capability(...)`, which journals intent before
    dispatch and gives the provider the settlement effect id as its stable
    idempotency key;

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -303,17 +303,42 @@ remains available as a compatibility and debugging input, but normal execution
 should resolve the binding from `--goal-id` so the LoopX registry remains the
 task ground truth.
 
-The v0 route admits read-only operations only: provider results must not contain
-domain mutations, transition proposals, effect receipts, raw payloads,
-credential-like fields, or private-looking strings. It does not write LoopX
-state or spend quota. A future material operation must use a separate governed
-Turn adapter bound to the exact Todo and settlement contract; Goal enablement
-alone never grants write authority. Creating or updating the binding is an
-explicit Goal configuration change: it uses preview/apply, but it does not
-create a Turn or spend Turn quota. Turn scope starts only when an invocation
-may produce a material external or LoopX-state effect. The Goal binding is a
-local typed projection, not a security token or proof of a remote issuer;
-service authentication and authorization remain the provider's responsibility.
+The direct `capability invoke` route admits read-only operations only: provider
+results must not contain domain mutations, transition proposals, effect
+receipts, raw payloads, credential-like fields, or private-looking strings. It
+does not write LoopX state or spend quota.
+
+An integration profile may also declare `effect_class: external_write`, but
+that operation is deliberately unavailable through direct invocation. A host
+adapter must call the governed material lifecycle in
+`loopx.extensions.governed_capability_execution`:
+
+1. obtain `quota should-run` admission for one exact Goal, Agent, Todo, and
+   `turn_instance_id`;
+2. call `start_governed_external_capability(...)`, which journals intent before
+   dispatch and gives the provider the settlement effect id as its stable
+   idempotency key;
+3. call `reconcile_governed_external_capability(...)` until the provider returns
+   a terminal `loopx_external_effect_receipt_v0`;
+4. supply typed writeback and spend callbacks. LoopX reuses the shared Turn
+   settlement driver, requires the effect receipt digest in durable writeback,
+   and never spends quota before that writeback commits.
+
+The provider may return `running`, so a service-side job can outlive the bounded
+provider process. Start and reconcile are separately replayable from a mode-0600
+journal. Exact provider revision, request digest, Goal binding, settlement
+identity, provider effect receipt, writeback receipt, and quota receipt remain
+attached to the same invocation. A crash after an external effect therefore
+replays with the same idempotency key and reconciles the receipt instead of
+starting an unrelated operation.
+
+Goal enablement alone never grants write authority. Creating or updating the
+binding is an explicit Goal configuration change: it uses preview/apply, but it
+does not create a Turn or spend Turn quota. Turn scope starts only when an
+invocation may produce a material external or LoopX-state effect. The Goal
+binding is a local typed projection, not a security token or proof of a remote
+issuer; service authentication and authorization remain the provider's
+responsibility.
 
 The generic runner is deliberately non-effectful and grants no operation
 effects. Both manifest `permissions` and runtime `required_permissions` must

--- a/loopx/control_plane/effect_runtime.py
+++ b/loopx/control_plane/effect_runtime.py
@@ -28,6 +28,7 @@ MAX_REQUEST_BYTES = 2 * 1024 * 1024
 _NODE_VERSION_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$")
 _SOURCE_FILES = (
     "effect_program.ts",
+    "governed_capability.ts",
     "effect_runtime_handlers.ts",
     "effect_runtime_io.ts",
     "effect_runtime_server.ts",

--- a/loopx/control_plane/effect_runtime_handlers.ts
+++ b/loopx/control_plane/effect_runtime_handlers.ts
@@ -30,6 +30,7 @@ import {
 } from "./effect_program.ts";
 import {
   governedCapabilitySettlementStatus,
+  validateGovernedCapabilityAdmission,
   validateGovernedCapabilityResult,
   validateGovernedCapabilitySettlementCallback,
 } from "./governed_capability.ts";
@@ -288,6 +289,14 @@ export function createEffectRuntimeHandlers(
         asObject(params.packet),
         asObject(params.identity),
       ),
+    ],
+    [
+      "governed_capability.validate_admission",
+      (params) => validateGovernedCapabilityAdmission({
+        admission: params.admission,
+        todo_id: requiredString(params.todo_id, "todo_id"),
+        todo_contract: params.todo_contract,
+      }),
     ],
     [
       "governed_capability.validate_result",

--- a/loopx/control_plane/effect_runtime_handlers.ts
+++ b/loopx/control_plane/effect_runtime_handlers.ts
@@ -29,6 +29,11 @@ import {
   type SettlementStepKind,
 } from "./effect_program.ts";
 import {
+  governedCapabilitySettlementStatus,
+  validateGovernedCapabilityResult,
+  validateGovernedCapabilitySettlementCallback,
+} from "./governed_capability.ts";
+import {
   interpretTurnJournal,
   type TurnJournalInspectionRequest,
 } from "./turn_driver/turn_journal.ts";
@@ -283,6 +288,32 @@ export function createEffectRuntimeHandlers(
         asObject(params.packet),
         asObject(params.identity),
       ),
+    ],
+    [
+      "governed_capability.validate_result",
+      (params) => validateGovernedCapabilityResult({
+        value: params.value,
+        invocation_id: requiredString(params.invocation_id, "invocation_id"),
+        effect_id: requiredString(params.effect_id, "effect_id"),
+        result_schema: requiredString(params.result_schema, "result_schema"),
+        effect_class: requiredString(params.effect_class, "effect_class"),
+      }),
+    ],
+    [
+      "governed_capability.validate_settlement_callback",
+      (params) => validateGovernedCapabilitySettlementCallback({
+        payload: params.payload,
+        effect_id: requiredString(params.effect_id, "effect_id"),
+        effect_receipt_digest: requiredString(
+          params.effect_receipt_digest,
+          "effect_receipt_digest",
+        ),
+        require_receipt_digest: params.require_receipt_digest === true,
+      }),
+    ],
+    [
+      "governed_capability.settlement_status",
+      (params) => governedCapabilitySettlementStatus(params.failure),
     ],
     [
       "settlement.identity",

--- a/loopx/control_plane/governed_capability.ts
+++ b/loopx/control_plane/governed_capability.ts
@@ -1,0 +1,200 @@
+import type { JsonObject } from "./effect_program.ts";
+
+export const EXTERNAL_EFFECT_RECEIPT_SCHEMA_VERSION =
+  "loopx_external_effect_receipt_v0";
+
+const RESULT_FIELDS = new Set([
+  "schema_version",
+  "invocation_id",
+  "status",
+  "observations",
+  "domain_state_mutations",
+  "domain_transition_receipts",
+  "transition_proposals",
+  "effect_receipt",
+  "follow_up",
+]);
+
+const EFFECT_RECEIPT_FIELDS = new Set([
+  "schema_version",
+  "invocation_id",
+  "idempotency_key",
+  "status",
+  "external_ref",
+  "evidence_digest",
+]);
+
+function requiredObject(value: unknown, label: string): JsonObject {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return { ...(value as JsonObject) };
+}
+
+function requiredString(value: unknown, label: string): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function boundedArray(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value) || value.length > 64) {
+    throw new Error(`${label} must be an array with at most 64 items`);
+  }
+  return [...value];
+}
+
+function requireExactFields(
+  value: JsonObject,
+  expected: ReadonlySet<string>,
+  label: string,
+): void {
+  const actual = Object.keys(value);
+  if (
+    actual.length !== expected.size ||
+    actual.some((field) => !expected.has(field))
+  ) {
+    throw new Error(`${label} fields are invalid`);
+  }
+}
+
+function externalEffectReceipt(
+  value: unknown,
+  invocationId: string,
+  effectId: string,
+): JsonObject {
+  const receipt = requiredObject(value, "external capability effect_receipt");
+  requireExactFields(
+    receipt,
+    EFFECT_RECEIPT_FIELDS,
+    "external capability effect_receipt",
+  );
+  if (receipt.schema_version !== EXTERNAL_EFFECT_RECEIPT_SCHEMA_VERSION) {
+    throw new Error("external capability effect_receipt schema is invalid");
+  }
+  if (receipt.invocation_id !== invocationId) {
+    throw new Error("external capability effect_receipt invocation_id is invalid");
+  }
+  if (receipt.idempotency_key !== effectId) {
+    throw new Error(
+      "external capability effect_receipt idempotency_key is invalid",
+    );
+  }
+  if (receipt.status !== "committed" && receipt.status !== "no_change") {
+    throw new Error("external capability effect_receipt status is invalid");
+  }
+  requiredString(
+    receipt.external_ref,
+    "external capability effect_receipt external_ref",
+  );
+  requiredString(
+    receipt.evidence_digest,
+    "external capability effect_receipt evidence_digest",
+  );
+  return receipt;
+}
+
+export function validateGovernedCapabilityResult(input: {
+  value: unknown;
+  invocation_id: string;
+  effect_id: string;
+  result_schema: string;
+  effect_class: string;
+}): { result: JsonObject; journal_status: "running" | "ready_to_settle" } {
+  if (input.effect_class !== "external_write") {
+    throw new Error("governed capability execution requires external_write");
+  }
+  const result = requiredObject(input.value, "external capability result");
+  requireExactFields(result, RESULT_FIELDS, "external capability result");
+  if (result.schema_version !== input.result_schema) {
+    throw new Error("external capability result schema_version is invalid");
+  }
+  if (result.invocation_id !== input.invocation_id) {
+    throw new Error("external capability result invocation_id is invalid");
+  }
+  if (
+    result.status !== "running" &&
+    result.status !== "succeeded" &&
+    result.status !== "no_change"
+  ) {
+    throw new Error("external capability result status is invalid");
+  }
+  for (const field of [
+    "observations",
+    "domain_state_mutations",
+    "domain_transition_receipts",
+    "transition_proposals",
+  ]) {
+    result[field] = boundedArray(result[field], `external capability result ${field}`);
+  }
+  result.follow_up = requiredObject(
+    result.follow_up,
+    "external capability result follow_up",
+  );
+  if (result.status === "running") {
+    if (result.effect_receipt !== null) {
+      throw new Error(
+        "running external capability cannot claim an effect receipt",
+      );
+    }
+    for (const field of [
+      "domain_state_mutations",
+      "domain_transition_receipts",
+      "transition_proposals",
+    ]) {
+      if ((result[field] as unknown[]).length > 0) {
+        throw new Error(
+          `running external capability must leave ${field} empty`,
+        );
+      }
+    }
+    return { result, journal_status: "running" };
+  }
+  result.effect_receipt = externalEffectReceipt(
+    result.effect_receipt,
+    input.invocation_id,
+    input.effect_id,
+  );
+  return { result, journal_status: "ready_to_settle" };
+}
+
+export function validateGovernedCapabilitySettlementCallback(input: {
+  payload: unknown;
+  effect_id: string;
+  effect_receipt_digest: string;
+  require_receipt_digest: boolean;
+}): JsonObject {
+  const payload = requiredObject(
+    input.payload,
+    "governed capability settlement callback",
+  );
+  const identity = requiredObject(
+    payload.settlement_identity,
+    "governed capability settlement identity",
+  );
+  if (identity.effect_id !== input.effect_id) {
+    return {
+      ok: false,
+      appended: false,
+      reason: "settlement identity mismatch",
+    };
+  }
+  if (
+    input.require_receipt_digest &&
+    payload.effect_receipt_digest !== input.effect_receipt_digest
+  ) {
+    return {
+      ok: false,
+      appended: false,
+      reason: "effect receipt was not written back",
+    };
+  }
+  return payload;
+}
+
+export function governedCapabilitySettlementStatus(
+  failure: unknown,
+): "settlement_failed" | "committed" {
+  return failure === null ? "committed" : "settlement_failed";
+}

--- a/loopx/control_plane/governed_capability.ts
+++ b/loopx/control_plane/governed_capability.ts
@@ -216,11 +216,34 @@ export function validateGovernedCapabilityResult(input: {
     }
     return { result, journal_status: "running" };
   }
-  result.effect_receipt = externalEffectReceipt(
+  const receipt = externalEffectReceipt(
     result.effect_receipt,
     input.invocation_id,
     input.effect_id,
   );
+  if (result.status === "no_change") {
+    if (receipt.status !== "no_change") {
+      throw new Error(
+        "no-change external capability requires a no-change effect receipt",
+      );
+    }
+    for (const field of [
+      "domain_state_mutations",
+      "domain_transition_receipts",
+      "transition_proposals",
+    ]) {
+      if ((result[field] as unknown[]).length > 0) {
+        throw new Error(
+          `no-change external capability must leave ${field} empty`,
+        );
+      }
+    }
+  } else if (receipt.status !== "committed") {
+    throw new Error(
+      "succeeded external capability requires a committed effect receipt",
+    );
+  }
+  result.effect_receipt = receipt;
   return { result, journal_status: "ready_to_settle" };
 }
 

--- a/loopx/control_plane/governed_capability.ts
+++ b/loopx/control_plane/governed_capability.ts
@@ -95,6 +95,71 @@ function externalEffectReceipt(
   return receipt;
 }
 
+export function validateGovernedCapabilityAdmission(input: {
+  admission: unknown;
+  todo_id: string;
+  todo_contract: unknown;
+}): JsonObject {
+  const admission = requiredObject(
+    input.admission,
+    "governed capability admission",
+  );
+  const selectedTodo = requiredObject(
+    admission.selected_todo,
+    "governed capability selected_todo",
+  );
+  if (selectedTodo.todo_id !== input.todo_id) {
+    throw new Error(
+      "governed capability selected_todo does not match the settlement Todo",
+    );
+  }
+  if (selectedTodo.role !== "agent" || selectedTodo.status !== "open") {
+    throw new Error(
+      "governed capability selected_todo must be an open agent Todo",
+    );
+  }
+  const todoContract = requiredObject(
+    input.todo_contract,
+    "governed capability todo_contract",
+  );
+  requireExactFields(
+    todoContract,
+    new Set(["action_kinds", "target_key_prefixes"]),
+    "governed capability todo_contract",
+  );
+  const actionKinds = boundedArray(
+    todoContract.action_kinds,
+    "governed capability todo_contract action_kinds",
+  );
+  const targetKeyPrefixes = boundedArray(
+    todoContract.target_key_prefixes,
+    "governed capability todo_contract target_key_prefixes",
+  );
+  if (
+    actionKinds.length === 0 ||
+    actionKinds.some((value) => typeof value !== "string") ||
+    !actionKinds.includes(selectedTodo.action_kind)
+  ) {
+    throw new Error(
+      "governed capability operation is not authorized by selected_todo action_kind",
+    );
+  }
+  const targetKey = requiredString(
+    selectedTodo.target_key,
+    "governed capability selected_todo target_key",
+  );
+  if (
+    targetKeyPrefixes.length === 0 ||
+    targetKeyPrefixes.some((value) => typeof value !== "string") ||
+    !targetKeyPrefixes.some((prefix) => targetKey.startsWith(prefix as string))
+  ) {
+    throw new Error(
+      "governed capability operation is not authorized by selected_todo target_key",
+    );
+  }
+  return selectedTodo;
+}
+
 export function validateGovernedCapabilityResult(input: {
   value: unknown;
   invocation_id: string;

--- a/loopx/extensions/capability_admission.py
+++ b/loopx/extensions/capability_admission.py
@@ -498,8 +498,8 @@ def prepare_external_capability_invocation(
 
     Read-only callers omit ``authority`` and retain the original deterministic
     invocation identity. Material adapters pass the typed settlement identity;
-    this keeps otherwise identical operations in separate governed Turns from
-    collapsing onto one provider idempotency key.
+    its effect id exclusively owns the invocation identity so one governed Turn
+    cannot dispatch multiple distinct external writes under one quota receipt.
     """
 
     binding = resolve_external_capability_binding(
@@ -539,14 +539,21 @@ def prepare_external_capability_invocation(
         if authority is not None
         else None
     )
-    invocation_seed = {
-        "goal_binding_digest": goal["binding_digest"],
-        "capability_id": capability_id,
-        "operation": operation,
-        "provider_input_digest": _canonical_digest(provided),
-    }
-    if normalized_authority is not None:
-        invocation_seed["authority_digest"] = _canonical_digest(normalized_authority)
+    invocation_seed = (
+        {
+            "settlement_effect_id": _token(
+                normalized_authority.get("effect_id"),
+                "external capability authority effect_id",
+            )
+        }
+        if normalized_authority is not None
+        else {
+            "goal_binding_digest": goal["binding_digest"],
+            "capability_id": capability_id,
+            "operation": operation,
+            "provider_input_digest": _canonical_digest(provided),
+        }
+    )
     invocation_id = (
         "capability-" + _canonical_digest(invocation_seed).split(":", 1)[1][:24]
     )

--- a/loopx/extensions/capability_admission.py
+++ b/loopx/extensions/capability_admission.py
@@ -483,19 +483,24 @@ def validate_external_capability_result(
     return result
 
 
-def invoke_external_capability(
+def prepare_external_capability_invocation(
     *,
     state_file: str | Path,
     capability_id: str,
     operation: str,
+    provider_input: Mapping[str, Any],
     goal_binding: Mapping[str, Any] | None = None,
     registry_path: str | Path | None = None,
     goal_id: str | None = None,
-    provider_input: Mapping[str, Any],
-    execute: bool = False,
-    environment: Mapping[str, str] | None = None,
+    authority: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Preview or run one read-only provider enabled for a durable Goal."""
+    """Resolve and freeze one Goal-bound provider request before dispatch.
+
+    Read-only callers omit ``authority`` and retain the original deterministic
+    invocation identity. Material adapters pass the typed settlement identity;
+    this keeps otherwise identical operations in separate governed Turns from
+    collapsing onto one provider idempotency key.
+    """
 
     binding = resolve_external_capability_binding(
         state_file=state_file,
@@ -503,10 +508,6 @@ def invoke_external_capability(
         operation=operation,
     )
     operation_profile = _mapping(binding.get("operation"), "operation profile")
-    if operation_profile.get("effect_class") != "read_only":
-        raise ValueError(
-            "material external capability invocation requires a governed Turn adapter"
-        )
     if goal_binding is None:
         if registry_path is None or goal_id is None:
             raise ValueError(
@@ -533,12 +534,19 @@ def invoke_external_capability(
         expected_goal_id=expected_goal_id,
     )
     provided = _provider_input(provider_input)
+    normalized_authority = (
+        _mapping(authority, "external capability authority")
+        if authority is not None
+        else None
+    )
     invocation_seed = {
         "goal_binding_digest": goal["binding_digest"],
         "capability_id": capability_id,
         "operation": operation,
         "provider_input_digest": _canonical_digest(provided),
     }
+    if normalized_authority is not None:
+        invocation_seed["authority_digest"] = _canonical_digest(normalized_authority)
     invocation_id = (
         "capability-" + _canonical_digest(invocation_seed).split(":", 1)[1][:24]
     )
@@ -559,6 +567,57 @@ def invoke_external_capability(
         "context_refs": provided["context_refs"],
         "input": provided["input"],
     }
+    if normalized_authority is not None:
+        request["authority"] = normalized_authority
+    return {
+        "binding": binding,
+        "operation_profile": operation_profile,
+        "goal": goal,
+        "provider_input": provided,
+        "request": request,
+        "invocation_id": invocation_id,
+        "request_digest": _canonical_digest(request),
+    }
+
+
+def invoke_external_capability(
+    *,
+    state_file: str | Path,
+    capability_id: str,
+    operation: str,
+    goal_binding: Mapping[str, Any] | None = None,
+    registry_path: str | Path | None = None,
+    goal_id: str | None = None,
+    provider_input: Mapping[str, Any],
+    execute: bool = False,
+    environment: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Preview or run one read-only provider enabled for a durable Goal."""
+
+    prepared = prepare_external_capability_invocation(
+        state_file=state_file,
+        capability_id=capability_id,
+        operation=operation,
+        goal_binding=goal_binding,
+        registry_path=registry_path,
+        goal_id=goal_id,
+        provider_input=provider_input,
+    )
+    binding = prepared["binding"]
+    assert isinstance(binding, Mapping)
+    operation_profile = prepared["operation_profile"]
+    assert isinstance(operation_profile, Mapping)
+    if operation_profile.get("effect_class") != "read_only":
+        raise ValueError(
+            "material external capability invocation requires a governed Turn adapter"
+        )
+    goal = prepared["goal"]
+    assert isinstance(goal, Mapping)
+    provided = prepared["provider_input"]
+    assert isinstance(provided, Mapping)
+    invocation_id = str(prepared["invocation_id"])
+    request = prepared["request"]
+    assert isinstance(request, Mapping)
     receipt: dict[str, Any] = {
         "ok": True,
         "schema_version": EXTERNAL_CAPABILITY_INVOCATION_SCHEMA_VERSION,
@@ -579,7 +638,7 @@ def invoke_external_capability(
             "turn_required": False,
         },
         "invocation_id": invocation_id,
-        "request_digest": _canonical_digest(request),
+        "request_digest": prepared["request_digest"],
         "context_ref_count": len(provided["context_refs"]),
         "effects": {
             "provider_invoked": False,

--- a/loopx/extensions/governed_capability_execution.py
+++ b/loopx/extensions/governed_capability_execution.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from ..control_plane.effect_program import settlement_result_payload
+from ..control_plane.effect_runtime import effect_runtime_result
 from ..control_plane.host_adapter_settlement import (
     HostGuardState,
     classify_host_guard_snapshot,
@@ -34,8 +35,6 @@ GOVERNED_CAPABILITY_RUN_SCHEMA_VERSION = "loopx_governed_capability_run_v0"
 GOVERNED_CAPABILITY_RECEIPT_SCHEMA_VERSION = (
     "loopx_governed_capability_execution_receipt_v0"
 )
-EXTERNAL_EFFECT_RECEIPT_SCHEMA_VERSION = "loopx_external_effect_receipt_v0"
-
 MaterialEffect = Callable[[Mapping[str, Any]], Mapping[str, Any]]
 
 
@@ -130,38 +129,31 @@ def _require_admission(
         )
 
 
-def _effect_receipt(
-    value: object,
+def _validated_governed_capability_result(
+    value: Mapping[str, Any],
     *,
     invocation_id: str,
     effect_id: str,
-) -> dict[str, Any]:
-    receipt = _mapping(value, "external capability effect_receipt")
-    allowed = {
-        "schema_version",
-        "invocation_id",
-        "idempotency_key",
-        "status",
-        "external_ref",
-        "evidence_digest",
-    }
-    if set(receipt) != allowed:
-        raise ValueError("external capability effect_receipt fields are invalid")
-    if receipt.get("schema_version") != EXTERNAL_EFFECT_RECEIPT_SCHEMA_VERSION:
-        raise ValueError("external capability effect_receipt schema is invalid")
-    if receipt.get("invocation_id") != invocation_id:
-        raise ValueError("external capability effect_receipt invocation_id is invalid")
-    if receipt.get("idempotency_key") != effect_id:
-        raise ValueError(
-            "external capability effect_receipt idempotency_key is invalid"
-        )
-    if receipt.get("status") not in {"committed", "no_change"}:
-        raise ValueError("external capability effect_receipt status is invalid")
-    for field in ("external_ref", "evidence_digest"):
-        if not isinstance(receipt.get(field), str) or not receipt[field].strip():
-            raise ValueError(f"external capability effect_receipt {field} is invalid")
-    validate_public_safe_value(receipt, path="provider_result.effect_receipt")
-    return receipt
+    operation: Mapping[str, Any],
+) -> tuple[dict[str, Any], str]:
+    payload = effect_runtime_result(
+        "governed_capability.validate_result",
+        {
+            "value": dict(value),
+            "invocation_id": invocation_id,
+            "effect_id": effect_id,
+            "result_schema": operation.get("result_schema"),
+            "effect_class": operation.get("effect_class"),
+        },
+    )
+    if not isinstance(payload, Mapping):
+        raise RuntimeError("TypeScript governed capability result shape mismatch")
+    result = _mapping(payload.get("result"), "external capability result")
+    journal_status = str(payload.get("journal_status") or "")
+    if journal_status not in {"running", "ready_to_settle"}:
+        raise RuntimeError("TypeScript governed capability status shape mismatch")
+    validate_public_safe_value(result, path="provider_result")
+    return result, journal_status
 
 
 def validate_governed_capability_result(
@@ -171,63 +163,14 @@ def validate_governed_capability_result(
     effect_id: str,
     operation: Mapping[str, Any],
 ) -> dict[str, Any]:
-    """Validate one asynchronous material provider observation."""
+    """Adapt the TS-owned material provider state validation."""
 
-    result = _mapping(value, "external capability result")
-    allowed = {
-        "schema_version",
-        "invocation_id",
-        "status",
-        "observations",
-        "domain_state_mutations",
-        "domain_transition_receipts",
-        "transition_proposals",
-        "effect_receipt",
-        "follow_up",
-    }
-    if sorted(set(result) - allowed):
-        raise ValueError("external capability result has unsupported fields")
-    if operation.get("effect_class") != "external_write":
-        raise ValueError("governed capability execution requires external_write")
-    if result.get("schema_version") != operation.get("result_schema"):
-        raise ValueError("external capability result schema_version is invalid")
-    if result.get("invocation_id") != invocation_id:
-        raise ValueError("external capability result invocation_id is invalid")
-    status = str(result.get("status") or "")
-    if status not in {"running", "succeeded", "no_change"}:
-        raise ValueError("external capability result status is invalid")
-    for field in (
-        "observations",
-        "domain_state_mutations",
-        "domain_transition_receipts",
-        "transition_proposals",
-    ):
-        items = result.get(field)
-        if not isinstance(items, list) or len(items) > 64:
-            raise ValueError(f"external capability result {field} is invalid")
-    if not isinstance(result.get("follow_up"), Mapping):
-        raise ValueError("external capability result follow_up is invalid")
-    if status == "running":
-        if result.get("effect_receipt") is not None:
-            raise ValueError(
-                "running external capability cannot claim an effect receipt"
-            )
-        for field in (
-            "domain_state_mutations",
-            "domain_transition_receipts",
-            "transition_proposals",
-        ):
-            if result[field]:
-                raise ValueError(
-                    f"running external capability must leave {field} empty"
-                )
-    else:
-        result["effect_receipt"] = _effect_receipt(
-            result.get("effect_receipt"),
-            invocation_id=invocation_id,
-            effect_id=effect_id,
-        )
-    validate_public_safe_value(result, path="provider_result")
+    result, _journal_status = _validated_governed_capability_result(
+        value,
+        invocation_id=invocation_id,
+        effect_id=effect_id,
+        operation=operation,
+    )
     return result
 
 
@@ -350,16 +293,14 @@ def start_governed_external_capability(
             request=request,
             environment=environment,
         )
-        validated = validate_governed_capability_result(
+        validated, journal_status = _validated_governed_capability_result(
             provider_result,
             invocation_id=invocation_id,
             effect_id=str(identity["effect_id"]),
             operation=operation_profile,
         )
         journal["provider_result"] = validated
-        journal["status"] = (
-            "running" if validated["status"] == "running" else "ready_to_settle"
-        )
+        journal["status"] = journal_status
         _write_journal(path, journal)
         return _public_receipt(journal, dry_run=False)
 
@@ -372,24 +313,16 @@ def _settlement_callback(
     effect_id: str,
     require_receipt_digest: bool,
 ) -> dict[str, Any]:
-    payload = _mapping(effect(context), "governed capability settlement callback")
-    identity = payload.get("settlement_identity")
-    if not isinstance(identity, Mapping) or identity.get("effect_id") != effect_id:
-        return {
-            "ok": False,
-            "appended": False,
-            "reason": "settlement identity mismatch",
-        }
-    if (
-        require_receipt_digest
-        and payload.get("effect_receipt_digest") != effect_receipt_digest
-    ):
-        return {
-            "ok": False,
-            "appended": False,
-            "reason": "effect receipt was not written back",
-        }
-    return payload
+    payload = effect_runtime_result(
+        "governed_capability.validate_settlement_callback",
+        {
+            "payload": dict(effect(context)),
+            "effect_id": effect_id,
+            "effect_receipt_digest": effect_receipt_digest,
+            "require_receipt_digest": require_receipt_digest,
+        },
+    )
+    return _mapping(payload, "governed capability settlement callback")
 
 
 def reconcile_governed_external_capability(
@@ -428,18 +361,14 @@ def reconcile_governed_external_capability(
                 request=request,
                 environment=environment,
             )
-            provider_result = validate_governed_capability_result(
+            provider_result, journal_status = _validated_governed_capability_result(
                 observed,
                 invocation_id=invocation_id,
                 effect_id=str(identity["effect_id"]),
                 operation=operation_profile,
             )
             journal["provider_result"] = provider_result
-            journal["status"] = (
-                "running"
-                if provider_result["status"] == "running"
-                else "ready_to_settle"
-            )
+            journal["status"] = journal_status
             _write_journal(path, journal)
             if provider_result["status"] == "running":
                 return _public_receipt(journal, dry_run=False)
@@ -505,10 +434,22 @@ def reconcile_governed_external_capability(
             committed_effect_id=str(identity["effect_id"]),
         )
         journal["settlement_result"] = settlement_result_payload(settlement)
-        if settlement.failure is not None:
-            journal["status"] = "settlement_failed"
+        settlement_status = effect_runtime_result(
+            "governed_capability.settlement_status",
+            {
+                "failure": (
+                    settlement.failure.as_dict()
+                    if settlement.failure is not None
+                    else None
+                )
+            },
+        )
+        if settlement_status == "settlement_failed":
+            journal["status"] = settlement_status
             _write_journal(path, journal)
             return {**_public_receipt(journal, dry_run=False), "ok": False}
-        journal["status"] = "committed"
+        if settlement_status != "committed":
+            raise RuntimeError("TypeScript governed capability status shape mismatch")
+        journal["status"] = settlement_status
         _write_journal(path, journal)
         return _public_receipt(journal, dry_run=False)

--- a/loopx/extensions/governed_capability_execution.py
+++ b/loopx/extensions/governed_capability_execution.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
 from collections.abc import Callable, Mapping
 from copy import deepcopy
 from pathlib import Path
@@ -29,7 +30,6 @@ from ..control_plane.turn_driver.transaction import (
 from ..file_lock import exclusive_file_lock
 from .capability_admission import prepare_external_capability_invocation
 from .runtime import execute_extension_runtime_binding
-
 
 GOVERNED_CAPABILITY_RUN_SCHEMA_VERSION = "loopx_governed_capability_run_v0"
 GOVERNED_CAPABILITY_RECEIPT_SCHEMA_VERSION = (
@@ -92,13 +92,19 @@ def _read_journal(path: Path) -> dict[str, Any]:
 
 def _write_journal(path: Path, value: Mapping[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_name(f".{path.name}.tmp.{os.getpid()}")
-    temporary.write_text(
-        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
+    serialized = json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.tmp.",
+        dir=path.parent,
     )
-    temporary.chmod(0o600)
-    os.replace(temporary, path)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            output.write(serialized)
+        os.replace(temporary, path)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
 
 
 def _settlement_identity(transaction_plan: Mapping[str, Any]) -> dict[str, Any]:
@@ -110,6 +116,7 @@ def _require_admission(
     admission: Mapping[str, Any],
     *,
     expected_identity: Mapping[str, Any],
+    todo_contract: Mapping[str, Any],
 ) -> None:
     guard = classify_host_guard_snapshot(
         json.dumps(dict(admission), ensure_ascii=False, sort_keys=True)
@@ -127,6 +134,14 @@ def _require_admission(
         raise ValueError(
             "quota guard settlement identity does not match the invocation"
         )
+    effect_runtime_result(
+        "governed_capability.validate_admission",
+        {
+            "admission": dict(admission),
+            "todo_id": expected["todo_id"],
+            "todo_contract": dict(todo_contract),
+        },
+    )
 
 
 def _validated_governed_capability_result(
@@ -229,7 +244,6 @@ def start_governed_external_capability(
         turn_instance_id=turn_instance_id,
     )
     identity = _settlement_identity(transaction_plan)
-    _require_admission(admission, expected_identity=identity)
     prepared = prepare_external_capability_invocation(
         state_file=state_file,
         capability_id=capability_id,
@@ -242,6 +256,14 @@ def start_governed_external_capability(
     operation_profile = _mapping(prepared["operation_profile"], "operation profile")
     if operation_profile.get("effect_class") != "external_write":
         raise ValueError("governed capability execution requires external_write")
+    _require_admission(
+        admission,
+        expected_identity=identity,
+        todo_contract=_mapping(
+            operation_profile.get("todo_contract"),
+            "operation todo_contract",
+        ),
+    )
     request = _mapping(prepared["request"], "provider request")
     request["lifecycle"] = {
         "phase": "start",

--- a/loopx/extensions/governed_capability_execution.py
+++ b/loopx/extensions/governed_capability_execution.py
@@ -68,7 +68,12 @@ def _mapping(value: object, label: str) -> dict[str, Any]:
 
 
 def _journal_path(run_dir: str | Path, invocation_id: str) -> Path:
-    if not invocation_id.startswith("capability-") or not invocation_id[11:].isalnum():
+    suffix = invocation_id.removeprefix("capability-")
+    if (
+        not invocation_id.startswith("capability-")
+        or len(suffix) != 24
+        or any(character not in "0123456789abcdef" for character in suffix)
+    ):
         raise ValueError("governed capability invocation_id is invalid")
     return Path(run_dir).expanduser() / f"{invocation_id}.json"
 
@@ -87,6 +92,8 @@ def _read_journal(path: Path) -> dict[str, Any]:
         or value.get("schema_version") != GOVERNED_CAPABILITY_RUN_SCHEMA_VERSION
     ):
         raise ValueError("governed capability invocation journal is invalid")
+    if os.name != "nt" and path.stat().st_mode & 0o077:
+        raise ValueError("governed capability invocation journal must use mode 0600")
     return value
 
 
@@ -116,8 +123,11 @@ def _require_admission(
     admission: Mapping[str, Any],
     *,
     expected_identity: Mapping[str, Any],
-    todo_contract: Mapping[str, Any],
+    require_should_run: bool,
+    todo_contract: Mapping[str, Any] | None,
 ) -> None:
+    if require_should_run and admission.get("should_run") is not True:
+        raise ValueError("governed capability admission requires should_run=true")
     guard = classify_host_guard_snapshot(
         json.dumps(dict(admission), ensure_ascii=False, sort_keys=True)
     )
@@ -134,14 +144,15 @@ def _require_admission(
         raise ValueError(
             "quota guard settlement identity does not match the invocation"
         )
-    effect_runtime_result(
-        "governed_capability.validate_admission",
-        {
-            "admission": dict(admission),
-            "todo_id": expected["todo_id"],
-            "todo_contract": dict(todo_contract),
-        },
-    )
+    if todo_contract is not None:
+        effect_runtime_result(
+            "governed_capability.validate_admission",
+            {
+                "admission": dict(admission),
+                "todo_id": expected["todo_id"],
+                "todo_contract": dict(todo_contract),
+            },
+        )
 
 
 def _validated_governed_capability_result(
@@ -187,6 +198,122 @@ def validate_governed_capability_result(
         operation=operation,
     )
     return result
+
+
+def _validate_journal(
+    journal: Mapping[str, Any],
+    *,
+    invocation_id: str,
+) -> None:
+    if journal.get("invocation_id") != invocation_id:
+        raise ValueError("governed capability journal invocation identity is invalid")
+    transaction_plan = _mapping(journal.get("transaction_plan"), "transaction plan")
+    identity = _settlement_identity(transaction_plan)
+    expected_top_level = {
+        key: identity.get(key)
+        for key in ("goal_id", "agent_id", "todo_id", "turn_instance_id", "effect_id")
+    }
+    if any(journal.get(key) != value for key, value in expected_top_level.items()):
+        raise ValueError("governed capability journal settlement identity is invalid")
+
+    request = _mapping(journal.get("request"), "provider request")
+    if request.get("invocation_id") != invocation_id:
+        raise ValueError("governed capability journal request identity is invalid")
+    if request.get("authority") != identity:
+        raise ValueError("governed capability journal request authority is invalid")
+    lifecycle = _mapping(request.get("lifecycle"), "provider request lifecycle")
+    if set(lifecycle) != {"phase", "idempotency_key"} or not (
+        lifecycle.get("phase") == "start"
+        and lifecycle.get("idempotency_key") == identity.get("effect_id")
+    ):
+        raise ValueError("governed capability journal start lifecycle is invalid")
+    validate_public_safe_value(request, path="provider_request")
+    if journal.get("request_digest") != _canonical_digest(request):
+        raise ValueError("governed capability journal request digest is invalid")
+
+    operation_profile = _mapping(journal.get("operation_profile"), "operation profile")
+    if operation_profile.get("effect_class") != "external_write":
+        raise ValueError("governed capability journal effect class is invalid")
+    _mapping(journal.get("provider_binding"), "provider binding")
+    status = str(journal.get("status") or "")
+    provider_result = journal.get("provider_result")
+    if provider_result is None:
+        if status != "starting":
+            raise ValueError("governed capability journal provider state is invalid")
+        return
+    result = _mapping(provider_result, "external capability result")
+    validated, provider_status = _validated_governed_capability_result(
+        result,
+        invocation_id=invocation_id,
+        effect_id=str(identity["effect_id"]),
+        operation=operation_profile,
+    )
+    if validated != result:
+        raise ValueError("governed capability journal provider result is invalid")
+    allowed_statuses = (
+        {"running"}
+        if provider_status == "running"
+        else {"ready_to_settle", "settlement_failed", "committed"}
+    )
+    if status not in allowed_statuses:
+        raise ValueError("governed capability journal status is invalid")
+    if provider_status == "running":
+        if any(
+            journal.get(field) is not None
+            for field in ("writeback", "quota_spend", "settlement_result")
+        ):
+            raise ValueError("running governed capability has settlement receipts")
+        return
+
+    effect_receipt = _mapping(result.get("effect_receipt"), "external effect receipt")
+    effect_receipt_digest = _canonical_digest(effect_receipt)
+    for field, require_receipt_digest in (
+        ("writeback", True),
+        ("quota_spend", False),
+    ):
+        stored = journal.get(field)
+        if stored is None:
+            continue
+        payload = _mapping(stored, f"governed capability {field}")
+        checked = effect_runtime_result(
+            "governed_capability.validate_settlement_callback",
+            {
+                "payload": payload,
+                "effect_id": identity["effect_id"],
+                "effect_receipt_digest": effect_receipt_digest,
+                "require_receipt_digest": require_receipt_digest,
+            },
+        )
+        if checked != payload:
+            raise ValueError(f"governed capability journal {field} is invalid")
+    if status == "committed":
+        for field in ("writeback", "quota_spend"):
+            receipt_payload = journal.get(field)
+            if not (
+                isinstance(receipt_payload, Mapping)
+                and receipt_payload.get("ok") is True
+                and receipt_payload.get("appended") is True
+            ):
+                raise ValueError(
+                    f"committed governed capability has no {field} receipt"
+                )
+        settlement_result = journal.get("settlement_result")
+        if not (
+            isinstance(settlement_result, Mapping)
+            and settlement_result.get("failure") is None
+        ):
+            raise ValueError(
+                "committed governed capability has no successful settlement result"
+            )
+    elif status == "settlement_failed":
+        settlement_result = journal.get("settlement_result")
+        if not (
+            isinstance(settlement_result, Mapping)
+            and isinstance(settlement_result.get("failure"), Mapping)
+        ):
+            raise ValueError(
+                "failed governed capability has no typed settlement failure"
+            )
 
 
 def _public_receipt(journal: Mapping[str, Any], *, dry_run: bool) -> dict[str, Any]:
@@ -259,9 +386,14 @@ def start_governed_external_capability(
     _require_admission(
         admission,
         expected_identity=identity,
-        todo_contract=_mapping(
-            operation_profile.get("todo_contract"),
-            "operation todo_contract",
+        require_should_run=not execute,
+        todo_contract=(
+            _mapping(
+                operation_profile.get("todo_contract"),
+                "operation todo_contract",
+            )
+            if not execute
+            else None
         ),
     )
     request = _mapping(prepared["request"], "provider request")
@@ -300,6 +432,7 @@ def start_governed_external_capability(
     with exclusive_file_lock(path, operation="start_governed_external_capability"):
         if path.exists():
             current = _read_journal(path)
+            _validate_journal(current, invocation_id=invocation_id)
             if (
                 current.get("request_digest") != request_digest
                 or current.get("effect_id") != identity["effect_id"]
@@ -309,6 +442,15 @@ def start_governed_external_capability(
                 return _public_receipt(current, dry_run=False)
             journal = current
         else:
+            _require_admission(
+                admission,
+                expected_identity=identity,
+                require_should_run=True,
+                todo_contract=_mapping(
+                    operation_profile.get("todo_contract"),
+                    "operation todo_contract",
+                ),
+            )
             _write_journal(path, journal)
         provider_result = execute_extension_runtime_binding(
             binding,
@@ -360,6 +502,7 @@ def reconcile_governed_external_capability(
     path = _journal_path(run_dir, invocation_id)
     with exclusive_file_lock(path, operation="reconcile_governed_external_capability"):
         journal = _read_journal(path)
+        _validate_journal(journal, invocation_id=invocation_id)
         if journal.get("status") == "committed":
             return _public_receipt(journal, dry_run=False)
         identity = _settlement_identity(

--- a/loopx/extensions/governed_capability_execution.py
+++ b/loopx/extensions/governed_capability_execution.py
@@ -1,0 +1,514 @@
+"""Provider-neutral governed execution for material external capabilities.
+
+The provider owns its domain operation and asynchronous run. LoopX owns the
+selected-Todo admission, durable invocation journal, typed effect receipt,
+writeback-before-spend ordering, and settlement replay identity.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Callable, Mapping
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from ..control_plane.effect_program import settlement_result_payload
+from ..control_plane.host_adapter_settlement import (
+    HostGuardState,
+    classify_host_guard_snapshot,
+)
+from ..control_plane.runtime.public_safety import validate_public_safe_value
+from ..control_plane.turn_driver.settlement import execute_turn_driver_settlement
+from ..control_plane.turn_driver.transaction import (
+    TRANSACTION_PHASES,
+    build_loopx_turn_transaction_plan,
+)
+from ..file_lock import exclusive_file_lock
+from .capability_admission import prepare_external_capability_invocation
+from .runtime import execute_extension_runtime_binding
+
+
+GOVERNED_CAPABILITY_RUN_SCHEMA_VERSION = "loopx_governed_capability_run_v0"
+GOVERNED_CAPABILITY_RECEIPT_SCHEMA_VERSION = (
+    "loopx_governed_capability_execution_receipt_v0"
+)
+EXTERNAL_EFFECT_RECEIPT_SCHEMA_VERSION = "loopx_external_effect_receipt_v0"
+
+MaterialEffect = Callable[[Mapping[str, Any]], Mapping[str, Any]]
+
+
+def default_governed_capability_run_dir(
+    runtime_root: str | Path | None = None,
+) -> Path:
+    root = (
+        Path(runtime_root).expanduser()
+        if runtime_root is not None
+        else Path.home() / ".codex" / "loopx"
+    )
+    return root / "extensions" / "governed-capability-runs"
+
+
+def _canonical_digest(value: object) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    import hashlib
+
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _mapping(value: object, label: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be an object")
+    return {str(key): deepcopy(item) for key, item in value.items()}
+
+
+def _journal_path(run_dir: str | Path, invocation_id: str) -> Path:
+    if not invocation_id.startswith("capability-") or not invocation_id[11:].isalnum():
+        raise ValueError("governed capability invocation_id is invalid")
+    return Path(run_dir).expanduser() / f"{invocation_id}.json"
+
+
+def _read_journal(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError("governed capability invocation does not exist") from exc
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            "governed capability invocation journal is unreadable"
+        ) from exc
+    if (
+        not isinstance(value, dict)
+        or value.get("schema_version") != GOVERNED_CAPABILITY_RUN_SCHEMA_VERSION
+    ):
+        raise ValueError("governed capability invocation journal is invalid")
+    return value
+
+
+def _write_journal(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp.{os.getpid()}")
+    temporary.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temporary.chmod(0o600)
+    os.replace(temporary, path)
+
+
+def _settlement_identity(transaction_plan: Mapping[str, Any]) -> dict[str, Any]:
+    settlement = _mapping(transaction_plan.get("settlement_plan"), "settlement plan")
+    return _mapping(settlement.get("identity"), "settlement identity")
+
+
+def _require_admission(
+    admission: Mapping[str, Any],
+    *,
+    expected_identity: Mapping[str, Any],
+) -> None:
+    guard = classify_host_guard_snapshot(
+        json.dumps(dict(admission), ensure_ascii=False, sort_keys=True)
+    )
+    if guard.state is not HostGuardState.SELECTED:
+        raise ValueError(guard.reason or "quota guard did not select a Todo")
+    if guard.settlement_identity is None:
+        raise ValueError("quota guard did not return a typed settlement identity")
+    observed = guard.settlement_identity.as_dict()
+    expected = {
+        key: str(expected_identity.get(key) or "")
+        for key in ("goal_id", "agent_id", "todo_id", "turn_instance_id", "effect_id")
+    }
+    if any(observed.get(key) != value for key, value in expected.items()):
+        raise ValueError(
+            "quota guard settlement identity does not match the invocation"
+        )
+
+
+def _effect_receipt(
+    value: object,
+    *,
+    invocation_id: str,
+    effect_id: str,
+) -> dict[str, Any]:
+    receipt = _mapping(value, "external capability effect_receipt")
+    allowed = {
+        "schema_version",
+        "invocation_id",
+        "idempotency_key",
+        "status",
+        "external_ref",
+        "evidence_digest",
+    }
+    if set(receipt) != allowed:
+        raise ValueError("external capability effect_receipt fields are invalid")
+    if receipt.get("schema_version") != EXTERNAL_EFFECT_RECEIPT_SCHEMA_VERSION:
+        raise ValueError("external capability effect_receipt schema is invalid")
+    if receipt.get("invocation_id") != invocation_id:
+        raise ValueError("external capability effect_receipt invocation_id is invalid")
+    if receipt.get("idempotency_key") != effect_id:
+        raise ValueError(
+            "external capability effect_receipt idempotency_key is invalid"
+        )
+    if receipt.get("status") not in {"committed", "no_change"}:
+        raise ValueError("external capability effect_receipt status is invalid")
+    for field in ("external_ref", "evidence_digest"):
+        if not isinstance(receipt.get(field), str) or not receipt[field].strip():
+            raise ValueError(f"external capability effect_receipt {field} is invalid")
+    validate_public_safe_value(receipt, path="provider_result.effect_receipt")
+    return receipt
+
+
+def validate_governed_capability_result(
+    value: Mapping[str, Any],
+    *,
+    invocation_id: str,
+    effect_id: str,
+    operation: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Validate one asynchronous material provider observation."""
+
+    result = _mapping(value, "external capability result")
+    allowed = {
+        "schema_version",
+        "invocation_id",
+        "status",
+        "observations",
+        "domain_state_mutations",
+        "domain_transition_receipts",
+        "transition_proposals",
+        "effect_receipt",
+        "follow_up",
+    }
+    if sorted(set(result) - allowed):
+        raise ValueError("external capability result has unsupported fields")
+    if operation.get("effect_class") != "external_write":
+        raise ValueError("governed capability execution requires external_write")
+    if result.get("schema_version") != operation.get("result_schema"):
+        raise ValueError("external capability result schema_version is invalid")
+    if result.get("invocation_id") != invocation_id:
+        raise ValueError("external capability result invocation_id is invalid")
+    status = str(result.get("status") or "")
+    if status not in {"running", "succeeded", "no_change"}:
+        raise ValueError("external capability result status is invalid")
+    for field in (
+        "observations",
+        "domain_state_mutations",
+        "domain_transition_receipts",
+        "transition_proposals",
+    ):
+        items = result.get(field)
+        if not isinstance(items, list) or len(items) > 64:
+            raise ValueError(f"external capability result {field} is invalid")
+    if not isinstance(result.get("follow_up"), Mapping):
+        raise ValueError("external capability result follow_up is invalid")
+    if status == "running":
+        if result.get("effect_receipt") is not None:
+            raise ValueError(
+                "running external capability cannot claim an effect receipt"
+            )
+        for field in (
+            "domain_state_mutations",
+            "domain_transition_receipts",
+            "transition_proposals",
+        ):
+            if result[field]:
+                raise ValueError(
+                    f"running external capability must leave {field} empty"
+                )
+    else:
+        result["effect_receipt"] = _effect_receipt(
+            result.get("effect_receipt"),
+            invocation_id=invocation_id,
+            effect_id=effect_id,
+        )
+    validate_public_safe_value(result, path="provider_result")
+    return result
+
+
+def _public_receipt(journal: Mapping[str, Any], *, dry_run: bool) -> dict[str, Any]:
+    provider_result = journal.get("provider_result")
+    result = provider_result if isinstance(provider_result, Mapping) else {}
+    return {
+        "ok": True,
+        "schema_version": GOVERNED_CAPABILITY_RECEIPT_SCHEMA_VERSION,
+        "status": journal.get("status"),
+        "dry_run": dry_run,
+        "executed": not dry_run,
+        "invocation_id": journal.get("invocation_id"),
+        "request_digest": journal.get("request_digest"),
+        "goal_id": journal.get("goal_id"),
+        "agent_id": journal.get("agent_id"),
+        "todo_id": journal.get("todo_id"),
+        "turn_instance_id": journal.get("turn_instance_id"),
+        "effect_id": journal.get("effect_id"),
+        "provider_status": result.get("status"),
+        "provider_result_digest": (_canonical_digest(result) if result else None),
+        "settlement_result": journal.get("settlement_result"),
+        "effects": {
+            "provider_invoked": bool(provider_result),
+            "external_write_observed": bool(result.get("effect_receipt")),
+            "loopx_state_written": isinstance(journal.get("writeback"), Mapping),
+            "quota_spent": isinstance(journal.get("quota_spend"), Mapping),
+        },
+    }
+
+
+def start_governed_external_capability(
+    *,
+    state_file: str | Path,
+    run_dir: str | Path,
+    registry_path: str | Path,
+    goal_id: str,
+    agent_id: str,
+    todo_id: str,
+    turn_instance_id: str,
+    capability_id: str,
+    operation: str,
+    provider_input: Mapping[str, Any],
+    admission: Mapping[str, Any],
+    execute: bool = False,
+    environment: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Preview or idempotently start one selected-Todo material operation."""
+
+    transaction_plan = build_loopx_turn_transaction_plan(
+        planned=True,
+        lineage={"goal_id": goal_id, "agent_id": agent_id, "todo_id": todo_id},
+        host="external-capability-provider",
+        execution_mode="governed-asynchronous",
+        session_action="resume",
+        turn_instance_id=turn_instance_id,
+    )
+    identity = _settlement_identity(transaction_plan)
+    _require_admission(admission, expected_identity=identity)
+    prepared = prepare_external_capability_invocation(
+        state_file=state_file,
+        capability_id=capability_id,
+        operation=operation,
+        registry_path=registry_path,
+        goal_id=goal_id,
+        provider_input=provider_input,
+        authority=identity,
+    )
+    operation_profile = _mapping(prepared["operation_profile"], "operation profile")
+    if operation_profile.get("effect_class") != "external_write":
+        raise ValueError("governed capability execution requires external_write")
+    request = _mapping(prepared["request"], "provider request")
+    request["lifecycle"] = {
+        "phase": "start",
+        "idempotency_key": identity["effect_id"],
+    }
+    validate_public_safe_value(request, path="provider_request")
+    request_digest = _canonical_digest(request)
+    binding = _mapping(prepared["binding"], "provider binding")
+    invocation_id = str(prepared["invocation_id"])
+    journal: dict[str, Any] = {
+        "schema_version": GOVERNED_CAPABILITY_RUN_SCHEMA_VERSION,
+        "status": "ready" if not execute else "starting",
+        "invocation_id": invocation_id,
+        "request_digest": request_digest,
+        "request": request,
+        "provider_binding": binding,
+        "operation_profile": operation_profile,
+        "transaction_plan": transaction_plan,
+        "goal_id": goal_id,
+        "agent_id": agent_id,
+        "todo_id": todo_id,
+        "turn_instance_id": turn_instance_id,
+        "effect_id": identity["effect_id"],
+        "completed_phases": [],
+        "provider_result": None,
+        "writeback": None,
+        "quota_spend": None,
+        "settlement_result": None,
+    }
+    if not execute:
+        return _public_receipt(journal, dry_run=True)
+
+    path = _journal_path(run_dir, invocation_id)
+    with exclusive_file_lock(path, operation="start_governed_external_capability"):
+        if path.exists():
+            current = _read_journal(path)
+            if (
+                current.get("request_digest") != request_digest
+                or current.get("effect_id") != identity["effect_id"]
+            ):
+                raise ValueError("governed capability invocation replay does not match")
+            if isinstance(current.get("provider_result"), Mapping):
+                return _public_receipt(current, dry_run=False)
+            journal = current
+        else:
+            _write_journal(path, journal)
+        provider_result = execute_extension_runtime_binding(
+            binding,
+            request=request,
+            environment=environment,
+        )
+        validated = validate_governed_capability_result(
+            provider_result,
+            invocation_id=invocation_id,
+            effect_id=str(identity["effect_id"]),
+            operation=operation_profile,
+        )
+        journal["provider_result"] = validated
+        journal["status"] = (
+            "running" if validated["status"] == "running" else "ready_to_settle"
+        )
+        _write_journal(path, journal)
+        return _public_receipt(journal, dry_run=False)
+
+
+def _settlement_callback(
+    effect: MaterialEffect,
+    *,
+    context: Mapping[str, Any],
+    effect_receipt_digest: str,
+    effect_id: str,
+    require_receipt_digest: bool,
+) -> dict[str, Any]:
+    payload = _mapping(effect(context), "governed capability settlement callback")
+    identity = payload.get("settlement_identity")
+    if not isinstance(identity, Mapping) or identity.get("effect_id") != effect_id:
+        return {
+            "ok": False,
+            "appended": False,
+            "reason": "settlement identity mismatch",
+        }
+    if (
+        require_receipt_digest
+        and payload.get("effect_receipt_digest") != effect_receipt_digest
+    ):
+        return {
+            "ok": False,
+            "appended": False,
+            "reason": "effect receipt was not written back",
+        }
+    return payload
+
+
+def reconcile_governed_external_capability(
+    *,
+    run_dir: str | Path,
+    invocation_id: str,
+    writeback: MaterialEffect,
+    spend: MaterialEffect,
+    environment: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Poll and idempotently settle one asynchronous material invocation."""
+
+    path = _journal_path(run_dir, invocation_id)
+    with exclusive_file_lock(path, operation="reconcile_governed_external_capability"):
+        journal = _read_journal(path)
+        if journal.get("status") == "committed":
+            return _public_receipt(journal, dry_run=False)
+        identity = _settlement_identity(
+            _mapping(journal.get("transaction_plan"), "transaction plan")
+        )
+        operation_profile = _mapping(
+            journal.get("operation_profile"), "operation profile"
+        )
+        provider_result = journal.get("provider_result")
+        if not isinstance(provider_result, Mapping):
+            raise ValueError("governed capability provider start has no receipt")
+        if provider_result.get("status") == "running":
+            request = _mapping(journal.get("request"), "provider request")
+            request["lifecycle"] = {
+                "phase": "reconcile",
+                "idempotency_key": identity["effect_id"],
+                "follow_up": deepcopy(provider_result.get("follow_up")),
+            }
+            observed = execute_extension_runtime_binding(
+                _mapping(journal.get("provider_binding"), "provider binding"),
+                request=request,
+                environment=environment,
+            )
+            provider_result = validate_governed_capability_result(
+                observed,
+                invocation_id=invocation_id,
+                effect_id=str(identity["effect_id"]),
+                operation=operation_profile,
+            )
+            journal["provider_result"] = provider_result
+            journal["status"] = (
+                "running"
+                if provider_result["status"] == "running"
+                else "ready_to_settle"
+            )
+            _write_journal(path, journal)
+            if provider_result["status"] == "running":
+                return _public_receipt(journal, dry_run=False)
+
+        effect_receipt = _mapping(
+            provider_result.get("effect_receipt"), "external effect receipt"
+        )
+        effect_receipt_digest = _canonical_digest(effect_receipt)
+        context = {
+            "settlement_identity": identity,
+            "invocation_id": invocation_id,
+            "provider_result_digest": _canonical_digest(provider_result),
+            "effect_receipt": effect_receipt,
+            "effect_receipt_digest": effect_receipt_digest,
+        }
+
+        def checkpoint(
+            step_kind: object,
+            payload: Mapping[str, Any],
+            phases: tuple[str, ...],
+        ) -> None:
+            step_name = str(getattr(step_kind, "value", step_kind))
+            journal["writeback" if step_name == "durable_writeback" else step_name] = (
+                dict(payload)
+            )
+            journal["completed_phases"] = list(phases)
+            _write_journal(path, journal)
+
+        settlement = execute_turn_driver_settlement(
+            _mapping(journal.get("transaction_plan"), "transaction plan"),
+            transaction_phases=TRANSACTION_PHASES,
+            completed_phases=(
+                tuple(str(item) for item in journal["completed_phases"])
+                if isinstance(journal.get("completed_phases"), list)
+                and journal["completed_phases"]
+                else ("host_execute", "typed_result", "validation")
+            ),
+            writeback_payload=(
+                journal.get("writeback")
+                if isinstance(journal.get("writeback"), Mapping)
+                else None
+            ),
+            quota_spend_payload=(
+                journal.get("quota_spend")
+                if isinstance(journal.get("quota_spend"), Mapping)
+                else None
+            ),
+            writeback=lambda: _settlement_callback(
+                writeback,
+                context=context,
+                effect_receipt_digest=effect_receipt_digest,
+                effect_id=str(identity["effect_id"]),
+                require_receipt_digest=True,
+            ),
+            spend=lambda: _settlement_callback(
+                spend,
+                context=context,
+                effect_receipt_digest=effect_receipt_digest,
+                effect_id=str(identity["effect_id"]),
+                require_receipt_digest=False,
+            ),
+            checkpoint=checkpoint,
+            committed_effect_id=str(identity["effect_id"]),
+        )
+        journal["settlement_result"] = settlement_result_payload(settlement)
+        if settlement.failure is not None:
+            journal["status"] = "settlement_failed"
+            _write_journal(path, journal)
+            return {**_public_receipt(journal, dry_run=False), "ok": False}
+        journal["status"] = "committed"
+        _write_journal(path, journal)
+        return _public_receipt(journal, dry_run=False)

--- a/loopx/extensions/manifest.py
+++ b/loopx/extensions/manifest.py
@@ -22,10 +22,8 @@ _EXTENSION_ID_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
 _PROTOCOL_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}_v\d+$")
 _OPERATION_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
 _PYTHON_MODULE_RE = re.compile(r"^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*$")
-_EXTERNAL_CAPABILITY_EFFECT_CLASS = "read_only"
-_PYTHON_CALLABLE_RE = re.compile(
-    r"^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*:[A-Za-z_]\w*$"
-)
+_EXTERNAL_CAPABILITY_EFFECT_CLASSES = {"read_only", "external_write"}
+_PYTHON_CALLABLE_RE = re.compile(r"^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*:[A-Za-z_]\w*$")
 _SURFACE_ID_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
 _SURFACE_KIND_RE = re.compile(r"^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$")
 _PRESENTATION_SURFACE_KEYS = {
@@ -126,14 +124,10 @@ def _presentation_surfaces(
             raise ValueError(f"{item_context} must be a TOML table")
         unsupported = sorted(set(item) - _PRESENTATION_SURFACE_KEYS)
         if unsupported:
-            raise ValueError(
-                f"{item_context} contains unsupported keys {unsupported}"
-            )
+            raise ValueError(f"{item_context} contains unsupported keys {unsupported}")
         surface_id = _required_string(item, "id", context=item_context)
         if not _SURFACE_ID_RE.fullmatch(surface_id):
-            raise ValueError(
-                f"{item_context} id must be a bounded lower-kebab token"
-            )
+            raise ValueError(f"{item_context} id must be a bounded lower-kebab token")
         if surface_id in seen_ids:
             raise ValueError(
                 f"{context} has duplicate presentation surface id `{surface_id}`"
@@ -142,9 +136,7 @@ def _presentation_surfaces(
 
         kind = _required_string(item, "kind", context=item_context)
         if not _SURFACE_KIND_RE.fullmatch(kind):
-            raise ValueError(
-                f"{item_context} kind must be a bounded lower_snake token"
-            )
+            raise ValueError(f"{item_context} kind must be a bounded lower_snake token")
         view_schema = _required_string(item, "view_schema", context=item_context)
         if not _PROTOCOL_RE.fullmatch(view_schema):
             raise ValueError(
@@ -273,7 +265,9 @@ def _integration_profile(
     context: str,
 ) -> tuple[dict[str, Any], str]:
     if runtime is None:
-        raise ValueError(f"{context} integration_profile requires an executable runtime")
+        raise ValueError(
+            f"{context} integration_profile requires an executable runtime"
+        )
     ref = str(profile_ref or "").strip()
     if not ref:
         raise ValueError(f"{context} integration_profile must be a relative JSON path")
@@ -299,7 +293,9 @@ def _integration_profile(
     try:
         value = json.loads(raw_bytes.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise ValueError(f"{context} integration_profile must be a JSON object") from exc
+        raise ValueError(
+            f"{context} integration_profile must be a JSON object"
+        ) from exc
     if not isinstance(value, Mapping):
         raise ValueError(f"{context} integration_profile must be a JSON object")
     allowed_profile_fields = {
@@ -350,8 +346,7 @@ def _integration_profile(
         unknown_operation_fields = sorted(set(item) - allowed_operation_fields)
         if unknown_operation_fields:
             raise ValueError(
-                f"{operation_context} has unsupported fields "
-                f"{unknown_operation_fields}"
+                f"{operation_context} has unsupported fields {unknown_operation_fields}"
             )
         operation_id = _required_string(item, "id", context=operation_context)
         if not _OPERATION_RE.fullmatch(operation_id):
@@ -363,13 +358,11 @@ def _integration_profile(
                 f"{context} integration_profile has duplicate operation `{operation_id}`"
             )
         operation_ids.add(operation_id)
-        effect_class = _required_string(
-            item, "effect_class", context=operation_context
-        )
-        if effect_class != _EXTERNAL_CAPABILITY_EFFECT_CLASS:
+        effect_class = _required_string(item, "effect_class", context=operation_context)
+        if effect_class not in _EXTERNAL_CAPABILITY_EFFECT_CLASSES:
             raise ValueError(
-                f"{operation_context} effect_class must be "
-                f"`{_EXTERNAL_CAPABILITY_EFFECT_CLASS}` in the v0 profile"
+                f"{operation_context} effect_class must be one of "
+                f"{sorted(_EXTERNAL_CAPABILITY_EFFECT_CLASSES)}"
             )
         permission = _required_string(
             item, "required_permission", context=operation_context
@@ -464,9 +457,7 @@ def load_extension_manifest(path: str | Path) -> dict[str, Any]:
             f"{context} has unsupported schema_version `{schema_version}`; "
             f"expected `{EXTENSION_MANIFEST_SCHEMA_VERSION}`"
         )
-    extension_id = validate_extension_id(
-        _required_string(raw, "id", context=context)
-    )
+    extension_id = validate_extension_id(_required_string(raw, "id", context=context))
     version = _required_string(raw, "version", context=context)
     requires_loopx_api = _required_string(raw, "requires_loopx_api", context=context)
     _require_compatible_loopx_api(requires_loopx_api, context=context)

--- a/loopx/extensions/manifest.py
+++ b/loopx/extensions/manifest.py
@@ -21,6 +21,7 @@ _API_CLAUSE = re.compile(r"^(>=|<=|==|>|<)?\s*(\d+)$")
 _EXTENSION_ID_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
 _PROTOCOL_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}_v\d+$")
 _OPERATION_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+_TARGET_KEY_PREFIX_RE = re.compile(r"^[a-z0-9][a-z0-9_.:-]{0,127}$")
 _PYTHON_MODULE_RE = re.compile(r"^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*$")
 _EXTERNAL_CAPABILITY_EFFECT_CLASSES = {"read_only", "external_write"}
 _PYTHON_CALLABLE_RE = re.compile(r"^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*:[A-Za-z_]\w*$")
@@ -342,6 +343,7 @@ def _integration_profile(
             "required_permission",
             "request_schema",
             "result_schema",
+            "todo_contract",
         }
         unknown_operation_fields = sorted(set(item) - allowed_operation_fields)
         if unknown_operation_fields:
@@ -363,6 +365,55 @@ def _integration_profile(
             raise ValueError(
                 f"{operation_context} effect_class must be one of "
                 f"{sorted(_EXTERNAL_CAPABILITY_EFFECT_CLASSES)}"
+            )
+        todo_contract = item.get("todo_contract")
+        if effect_class == "external_write":
+            if not isinstance(todo_contract, Mapping):
+                raise ValueError(
+                    f"{operation_context} external_write requires todo_contract"
+                )
+            if set(todo_contract) != {"action_kinds", "target_key_prefixes"}:
+                raise ValueError(
+                    f"{operation_context} todo_contract fields are invalid"
+                )
+            action_kinds = _string_list(
+                todo_contract,
+                "action_kinds",
+                context=f"{operation_context} todo_contract",
+            )
+            target_key_prefixes = _string_list(
+                todo_contract,
+                "target_key_prefixes",
+                context=f"{operation_context} todo_contract",
+            )
+            if (
+                not 1 <= len(action_kinds) <= 32
+                or len(action_kinds) != len(set(action_kinds))
+                or any(not _OPERATION_RE.fullmatch(value) for value in action_kinds)
+            ):
+                raise ValueError(
+                    f"{operation_context} todo_contract action_kinds are invalid"
+                )
+            if (
+                not 1 <= len(target_key_prefixes) <= 32
+                or len(target_key_prefixes) != len(set(target_key_prefixes))
+                or any(
+                    not _TARGET_KEY_PREFIX_RE.fullmatch(value)
+                    for value in target_key_prefixes
+                )
+            ):
+                raise ValueError(
+                    f"{operation_context} todo_contract target_key_prefixes are "
+                    "invalid"
+                )
+            todo_contract = {
+                "action_kinds": action_kinds,
+                "target_key_prefixes": target_key_prefixes,
+            }
+        elif todo_contract is not None:
+            raise ValueError(
+                f"{operation_context} todo_contract is only valid for "
+                "external_write"
             )
         permission = _required_string(
             item, "required_permission", context=operation_context
@@ -391,6 +442,8 @@ def _integration_profile(
             "request_schema": request_schema,
             "result_schema": result_schema,
         }
+        if todo_contract is not None:
+            normalized_operation["todo_contract"] = todo_contract
         normalized_operations.append(normalized_operation)
     normalized = {
         "schema_version": EXTERNAL_CAPABILITY_PROFILE_SCHEMA_VERSION,

--- a/tests/control_plane_ts/governed_capability.test.ts
+++ b/tests/control_plane_ts/governed_capability.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   governedCapabilitySettlementStatus,
+  validateGovernedCapabilityAdmission,
   validateGovernedCapabilityResult,
   validateGovernedCapabilitySettlementCallback,
 } from "../../loopx/control_plane/governed_capability.ts";
@@ -37,6 +38,52 @@ function result(status: "running" | "succeeded") {
     follow_up: { kind: status === "running" ? "poll" : "none" },
   };
 }
+
+test("material admission binds the exact Todo action to the operation", () => {
+  const admission = {
+    selected_todo: {
+      todo_id: "todo_material1",
+      role: "agent",
+      status: "open",
+      action_kind: "publish_requirement",
+      target_key: "requirement:REQ-1",
+    },
+  };
+  assert.equal(
+    validateGovernedCapabilityAdmission({
+      admission,
+      todo_id: "todo_material1",
+      todo_contract: {
+        action_kinds: ["publish_requirement"],
+        target_key_prefixes: ["requirement:"],
+      },
+    }).todo_id,
+    "todo_material1",
+  );
+  assert.throws(
+    () => validateGovernedCapabilityAdmission({
+      admission,
+      todo_id: "todo_material1",
+      todo_contract: {
+        action_kinds: ["deploy_release"],
+        target_key_prefixes: ["release:"],
+      },
+    }),
+    /not authorized by selected_todo action_kind/,
+  );
+
+  assert.throws(
+    () => validateGovernedCapabilityAdmission({
+      admission,
+      todo_id: "todo_material1",
+      todo_contract: {
+        action_kinds: ["publish_requirement"],
+        target_key_prefixes: ["release:"],
+      },
+    }),
+    /not authorized by selected_todo target_key/,
+  );
+});
 
 test("material provider state reduces to a typed journal status", () => {
   assert.equal(

--- a/tests/control_plane_ts/governed_capability.test.ts
+++ b/tests/control_plane_ts/governed_capability.test.ts
@@ -15,7 +15,7 @@ const authority = {
   effect_class: "external_write",
 } as const;
 
-function result(status: "running" | "succeeded") {
+function result(status: "running" | "succeeded" | "no_change") {
   return {
     schema_version: authority.result_schema,
     invocation_id: authority.invocation_id,
@@ -31,7 +31,7 @@ function result(status: "running" | "succeeded") {
             schema_version: "loopx_external_effect_receipt_v0",
             invocation_id: authority.invocation_id,
             idempotency_key: authority.effect_id,
-            status: "committed",
+            status: status === "no_change" ? "no_change" : "committed",
             external_ref: "synthetic-run-1",
             evidence_digest: "sha256:synthetic-evidence",
           },
@@ -120,6 +120,32 @@ test("terminal effect receipts bind the exact settlement effect", () => {
   assert.throws(
     () => validateGovernedCapabilityResult({ ...authority, value: invalid }),
     /idempotency_key is invalid/,
+  );
+});
+
+test("terminal result and effect receipt cannot contradict each other", () => {
+  const falseCommit = result("no_change");
+  assert.ok(falseCommit.effect_receipt);
+  falseCommit.effect_receipt.status = "committed";
+  assert.throws(
+    () => validateGovernedCapabilityResult({ ...authority, value: falseCommit }),
+    /requires a no-change effect receipt/,
+  );
+
+  const falseNoChange = result("succeeded");
+  assert.ok(falseNoChange.effect_receipt);
+  falseNoChange.effect_receipt.status = "no_change";
+  assert.throws(
+    () => validateGovernedCapabilityResult({ ...authority, value: falseNoChange }),
+    /requires a committed effect receipt/,
+  );
+
+  const mutatedNoChange = result("no_change");
+  mutatedNoChange.domain_state_mutations.push({ kind: "contradictory-write" });
+  assert.throws(
+    () =>
+      validateGovernedCapabilityResult({ ...authority, value: mutatedNoChange }),
+    /must leave domain_state_mutations empty/,
   );
 });
 

--- a/tests/control_plane_ts/governed_capability.test.ts
+++ b/tests/control_plane_ts/governed_capability.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  governedCapabilitySettlementStatus,
+  validateGovernedCapabilityResult,
+  validateGovernedCapabilitySettlementCallback,
+} from "../../loopx/control_plane/governed_capability.ts";
+
+const authority = {
+  invocation_id: "capability-synthetic",
+  effect_id: "goal:agent:todo:turn",
+  result_schema: "synthetic_material_result_v0",
+  effect_class: "external_write",
+} as const;
+
+function result(status: "running" | "succeeded") {
+  return {
+    schema_version: authority.result_schema,
+    invocation_id: authority.invocation_id,
+    status,
+    observations: [],
+    domain_state_mutations: [],
+    domain_transition_receipts: [],
+    transition_proposals: [],
+    effect_receipt:
+      status === "running"
+        ? null
+        : {
+            schema_version: "loopx_external_effect_receipt_v0",
+            invocation_id: authority.invocation_id,
+            idempotency_key: authority.effect_id,
+            status: "committed",
+            external_ref: "synthetic-run-1",
+            evidence_digest: "sha256:synthetic-evidence",
+          },
+    follow_up: { kind: status === "running" ? "poll" : "none" },
+  };
+}
+
+test("material provider state reduces to a typed journal status", () => {
+  assert.equal(
+    validateGovernedCapabilityResult({
+      ...authority,
+      value: result("running"),
+    }).journal_status,
+    "running",
+  );
+  assert.equal(
+    validateGovernedCapabilityResult({
+      ...authority,
+      value: result("succeeded"),
+    }).journal_status,
+    "ready_to_settle",
+  );
+});
+
+test("running providers cannot claim partial effects", () => {
+  const invalid = result("running");
+  invalid.domain_state_mutations.push({ kind: "partial-write" });
+
+  assert.throws(
+    () => validateGovernedCapabilityResult({ ...authority, value: invalid }),
+    /must leave domain_state_mutations empty/,
+  );
+});
+
+test("terminal effect receipts bind the exact settlement effect", () => {
+  const invalid = result("succeeded");
+  assert.ok(invalid.effect_receipt);
+  invalid.effect_receipt.idempotency_key = "different-effect";
+
+  assert.throws(
+    () => validateGovernedCapabilityResult({ ...authority, value: invalid }),
+    /idempotency_key is invalid/,
+  );
+});
+
+test("writeback proves the effect receipt before settlement can spend", () => {
+  const context = {
+    effect_id: authority.effect_id,
+    effect_receipt_digest: "sha256:receipt",
+    require_receipt_digest: true,
+  };
+  const rejected = validateGovernedCapabilitySettlementCallback({
+    ...context,
+    payload: {
+      ok: true,
+      appended: true,
+      settlement_identity: { effect_id: authority.effect_id },
+    },
+  });
+  assert.deepEqual(rejected, {
+    ok: false,
+    appended: false,
+    reason: "effect receipt was not written back",
+  });
+
+  const committed = validateGovernedCapabilitySettlementCallback({
+    ...context,
+    payload: {
+      ok: true,
+      appended: true,
+      settlement_identity: { effect_id: authority.effect_id },
+      effect_receipt_digest: context.effect_receipt_digest,
+    },
+  });
+  assert.equal(committed.ok, true);
+});
+
+test("settlement terminal state is TS-owned", () => {
+  assert.equal(governedCapabilitySettlementStatus(null), "committed");
+  assert.equal(
+    governedCapabilitySettlementStatus({ kind: "quota_spend_rejected" }),
+    "settlement_failed",
+  );
+});

--- a/tests/extensions/test_external_capability_admission.py
+++ b/tests/extensions/test_external_capability_admission.py
@@ -228,16 +228,40 @@ def test_manifest_accepts_external_write_for_the_governed_adapter(
 ) -> None:
     provider = _provider(tmp_path / "provider")
     profile = _profile(tmp_path / "profile.json")
-    profile.write_text(
-        profile.read_text(encoding="utf-8").replace("read_only", "external_write"),
-        encoding="utf-8",
-    )
+    payload = json.loads(profile.read_text(encoding="utf-8"))
+    operation = payload["operations"][0]
+    operation["effect_class"] = "external_write"
+    operation["todo_contract"] = {
+        "action_kinds": ["publish_requirement"],
+        "target_key_prefixes": ["requirement:"],
+    }
+    profile.write_text(json.dumps(payload), encoding="utf-8")
     manifest = _manifest(tmp_path / "extension.toml", provider=provider)
 
     loaded = load_extension_manifest(manifest)
 
     operation = loaded["capabilities"][0]["integration_profile"]["operations"][0]
     assert operation["effect_class"] == "external_write"
+    assert operation["todo_contract"] == {
+        "action_kinds": ["publish_requirement"],
+        "target_key_prefixes": ["requirement:"],
+    }
+
+
+def test_manifest_rejects_external_write_without_todo_contract(
+    tmp_path: Path,
+) -> None:
+    provider = _provider(tmp_path / "provider")
+    profile = _profile(tmp_path / "profile.json")
+    profile.write_text(
+        profile.read_text(encoding="utf-8").replace("read_only", "external_write"),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="requires todo_contract"):
+        load_extension_manifest(
+            _manifest(tmp_path / "extension.toml", provider=provider)
+        )
 
 
 def test_manifest_rejects_unknown_external_capability_effect_class(

--- a/tests/extensions/test_external_capability_admission.py
+++ b/tests/extensions/test_external_capability_admission.py
@@ -223,7 +223,7 @@ def test_manifest_rejects_profile_path_escape(tmp_path: Path) -> None:
         load_extension_manifest(manifest)
 
 
-def test_manifest_rejects_unimplemented_external_write_profile(
+def test_manifest_accepts_external_write_for_the_governed_adapter(
     tmp_path: Path,
 ) -> None:
     provider = _provider(tmp_path / "provider")
@@ -234,8 +234,26 @@ def test_manifest_rejects_unimplemented_external_write_profile(
     )
     manifest = _manifest(tmp_path / "extension.toml", provider=provider)
 
-    with pytest.raises(ValueError, match="must be `read_only` in the v0 profile"):
-        load_extension_manifest(manifest)
+    loaded = load_extension_manifest(manifest)
+
+    operation = loaded["capabilities"][0]["integration_profile"]["operations"][0]
+    assert operation["effect_class"] == "external_write"
+
+
+def test_manifest_rejects_unknown_external_capability_effect_class(
+    tmp_path: Path,
+) -> None:
+    provider = _provider(tmp_path / "provider")
+    profile = _profile(tmp_path / "profile.json")
+    profile.write_text(
+        profile.read_text(encoding="utf-8").replace("read_only", "unknown_effect"),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="effect_class must be one of"):
+        load_extension_manifest(
+            _manifest(tmp_path / "extension.toml", provider=provider)
+        )
 
 
 def test_read_only_external_capability_is_bound_to_goal_not_turn(

--- a/tests/extensions/test_governed_capability_execution.py
+++ b/tests/extensions/test_governed_capability_execution.py
@@ -320,6 +320,65 @@ def test_material_start_rejects_an_unrelated_selected_todo_action(
     assert not (tmp_path / "provider-calls.txt").exists()
 
 
+def test_material_start_requires_a_runnable_admission(tmp_path: Path) -> None:
+    arguments = _start_arguments(tmp_path)
+    arguments["admission"] = {
+        **arguments["admission"],
+        "should_run": False,
+    }
+
+    with pytest.raises(ValueError, match="requires should_run=true"):
+        start_governed_external_capability(**arguments, execute=True)
+
+    assert not (tmp_path / "provider-calls.txt").exists()
+
+
+def test_material_start_recovers_an_existing_journal_without_new_run_authority(
+    tmp_path: Path,
+) -> None:
+    arguments = _start_arguments(tmp_path)
+    started = start_governed_external_capability(**arguments, execute=True)
+    arguments["admission"] = {
+        **arguments["admission"],
+        "should_run": False,
+    }
+    arguments["admission"].pop("selected_todo")
+
+    replay = start_governed_external_capability(**arguments, execute=True)
+
+    assert replay["invocation_id"] == started["invocation_id"]
+    assert (tmp_path / "provider-calls.txt").read_text(
+        encoding="utf-8"
+    ).splitlines() == ["start"]
+
+
+def test_material_turn_rejects_a_second_distinct_invocation(tmp_path: Path) -> None:
+    arguments = _start_arguments(tmp_path)
+    first = start_governed_external_capability(**arguments, execute=True)
+    second_arguments = {
+        **arguments,
+        "provider_input": {
+            "context_refs": [
+                {
+                    "kind": "synthetic-requirement",
+                    "ref": "REQ-2",
+                    "digest": "sha256:synthetic-context-2",
+                }
+            ],
+            "input": {"requirement_key": "REQ-2"},
+        },
+    }
+    second_preview = start_governed_external_capability(**second_arguments)
+
+    assert second_preview["invocation_id"] == first["invocation_id"]
+    assert second_preview["request_digest"] != first["request_digest"]
+    with pytest.raises(ValueError, match="replay does not match"):
+        start_governed_external_capability(**second_arguments, execute=True)
+    assert (tmp_path / "provider-calls.txt").read_text(
+        encoding="utf-8"
+    ).splitlines() == ["start"]
+
+
 def test_material_settlement_fails_closed_without_effect_receipt_writeback(
     tmp_path: Path,
 ) -> None:
@@ -353,6 +412,26 @@ def test_material_settlement_fails_closed_without_effect_receipt_writeback(
     assert failed["ok"] is False
     assert failed["status"] == "settlement_failed"
     assert calls == ["writeback"]
+
+
+def test_material_reconcile_rejects_tampered_journal_request(tmp_path: Path) -> None:
+    arguments = _start_arguments(tmp_path)
+    started = start_governed_external_capability(**arguments, execute=True)
+    journal_path = Path(arguments["run_dir"]) / f"{started['invocation_id']}.json"
+    journal = json.loads(journal_path.read_text(encoding="utf-8"))
+    journal["request"]["input"]["requirement_key"] = "tampered"
+    journal_path.write_text(
+        json.dumps(journal, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="request digest is invalid"):
+        reconcile_governed_external_capability(
+            run_dir=arguments["run_dir"],
+            invocation_id=str(started["invocation_id"]),
+            writeback=lambda _context: {},
+            spend=lambda _context: {},
+        )
 
 
 def test_material_reconcile_resumes_at_spend_without_repeating_writeback(

--- a/tests/extensions/test_governed_capability_execution.py
+++ b/tests/extensions/test_governed_capability_execution.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+
+from loopx.control_plane.effect_program import SettlementIdentity
+from loopx.extensions.capability_admission import (
+    bind_external_capability_to_goal,
+    invoke_external_capability,
+)
+from loopx.extensions.governed_capability_execution import (
+    reconcile_governed_external_capability,
+    start_governed_external_capability,
+)
+from loopx.extensions.runtime import install_extension
+
+
+def _provider(path: Path, *, call_log: Path) -> Path:
+    path.write_text(
+        f"""#!{sys.executable}
+import json
+import sys
+from pathlib import Path
+
+if "--doctor" in sys.argv:
+    raise SystemExit(0)
+
+request = json.load(sys.stdin)
+phase = request["lifecycle"]["phase"]
+with Path({str(call_log)!r}).open("a", encoding="utf-8") as output:
+    output.write(phase + "\\n")
+result = {{
+    "schema_version": "fixture_material_capability_result_v0",
+    "invocation_id": request["invocation_id"],
+    "status": "running" if phase == "start" else "succeeded",
+    "observations": [{{"kind": "synthetic-progress", "phase": phase}}],
+    "domain_state_mutations": [],
+    "domain_transition_receipts": [],
+    "transition_proposals": [],
+    "effect_receipt": None,
+    "follow_up": {{"kind": "poll", "ref": "synthetic-run-1"}},
+}}
+if phase == "reconcile":
+    result["domain_state_mutations"] = [{{"kind": "synthetic-update"}}]
+    result["domain_transition_receipts"] = [{{"kind": "synthetic-commit"}}]
+    result["effect_receipt"] = {{
+        "schema_version": "loopx_external_effect_receipt_v0",
+        "invocation_id": request["invocation_id"],
+        "idempotency_key": request["lifecycle"]["idempotency_key"],
+        "status": "committed",
+        "external_ref": "synthetic-run-1",
+        "evidence_digest": "sha256:synthetic-evidence",
+    }}
+json.dump(result, sys.stdout)
+""",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+    return path
+
+
+def _installed_material_extension(tmp_path: Path) -> tuple[Path, Path, Path]:
+    call_log = tmp_path / "provider-calls.txt"
+    provider = _provider(tmp_path / "provider", call_log=call_log)
+    (tmp_path / "profile.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "loopx_external_domain_capability_profile_v0",
+                "capability_id": "fixture-material-delivery",
+                "protocol": "fixture_material_provider_v0",
+                "operations": [
+                    {
+                        "id": "publish",
+                        "effect_class": "external_write",
+                        "required_permission": "fixture.delivery.write",
+                        "request_schema": "fixture_material_capability_request_v0",
+                        "result_schema": "fixture_material_capability_result_v0",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    manifest = tmp_path / "extension.toml"
+    manifest.write_text(
+        f"""\
+schema_version = "loopx_extension_manifest_v0"
+id = "fixture-material-provider"
+version = "0.1.0"
+requires_loopx_api = ">=1,<2"
+permissions = ["fixture.delivery.write"]
+
+[runtime]
+protocol = "fixture_material_provider_v0"
+entrypoint = {json.dumps(str(provider))}
+doctor_args = ["--doctor"]
+required_permissions = ["fixture.delivery.write"]
+timeout_seconds = 5
+
+[[provides]]
+id = "fixture-material-delivery"
+kind = "requirement_delivery"
+title = "Fixture material delivery"
+status = "active-preview"
+user_value = "Publish one synthetic external change."
+next_real_step = "Reconcile one governed provider run."
+real_world_anchor = "A synthetic external service."
+entry_command = "loopx capability invoke"
+visibility = "public"
+integration_profile = "profile.json"
+""",
+        encoding="utf-8",
+    )
+    state_file = tmp_path / "extensions.json"
+    install_extension(manifest, state_file=state_file, execute=True)
+    registry = tmp_path / "registry.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "schema_version": "loopx_registry_v1",
+                "goals": [
+                    {
+                        "id": "fixture-goal",
+                        "title": "Fixture Goal",
+                        "repo": str(tmp_path),
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    bind_external_capability_to_goal(
+        registry_path=registry,
+        state_file=state_file,
+        goal_id="fixture-goal",
+        capability_id="fixture-material-delivery",
+        operations=["publish"],
+        execute=True,
+    )
+    return state_file, registry, call_log
+
+
+def _identity(
+    *, turn_instance_id: str = "fixture-material-turn-1"
+) -> SettlementIdentity:
+    return SettlementIdentity(
+        goal_id="fixture-goal",
+        agent_id="fixture-agent",
+        todo_id="todo_fixturematerial1",
+        turn_instance_id=turn_instance_id,
+    )
+
+
+def _admission(identity: SettlementIdentity) -> dict[str, object]:
+    return {
+        "ok": True,
+        "should_run": True,
+        "heartbeat_receipt": {"settlement_identity": identity.as_dict()},
+    }
+
+
+def _start_arguments(tmp_path: Path) -> dict[str, object]:
+    state_file, registry, _call_log = _installed_material_extension(tmp_path)
+    identity = _identity()
+    return {
+        "state_file": state_file,
+        "run_dir": tmp_path / "runs",
+        "registry_path": registry,
+        "goal_id": identity.goal_id,
+        "agent_id": identity.agent_id,
+        "todo_id": identity.todo_id,
+        "turn_instance_id": identity.turn_instance_id,
+        "capability_id": "fixture-material-delivery",
+        "operation": "publish",
+        "provider_input": {
+            "context_refs": [
+                {
+                    "kind": "synthetic-requirement",
+                    "ref": "REQ-1",
+                    "digest": "sha256:synthetic-context",
+                }
+            ],
+            "input": {"requirement_key": "REQ-1"},
+        },
+        "admission": _admission(identity),
+    }
+
+
+def test_material_start_is_previewable_and_provider_idempotent(tmp_path: Path) -> None:
+    arguments = _start_arguments(tmp_path)
+    call_log = tmp_path / "provider-calls.txt"
+
+    preview = start_governed_external_capability(**arguments)
+    started = start_governed_external_capability(**arguments, execute=True)
+    replay = start_governed_external_capability(**arguments, execute=True)
+
+    assert preview["status"] == "ready"
+    assert preview["executed"] is False
+    assert started["status"] == "running"
+    assert replay["invocation_id"] == started["invocation_id"]
+    assert call_log.read_text(encoding="utf-8").splitlines() == ["start"]
+
+
+def test_material_operation_remains_unavailable_through_direct_invoke(
+    tmp_path: Path,
+) -> None:
+    arguments = _start_arguments(tmp_path)
+
+    with pytest.raises(ValueError, match="requires a governed Turn adapter"):
+        invoke_external_capability(
+            state_file=arguments["state_file"],
+            registry_path=arguments["registry_path"],
+            goal_id="fixture-goal",
+            capability_id="fixture-material-delivery",
+            operation="publish",
+            provider_input=arguments["provider_input"],
+            execute=True,
+        )
+
+
+def test_material_reconcile_writes_receipt_before_spending_and_replays(
+    tmp_path: Path,
+) -> None:
+    arguments = _start_arguments(tmp_path)
+    started = start_governed_external_capability(**arguments, execute=True)
+    identity = _identity()
+    calls: list[str] = []
+
+    def writeback(context: Mapping[str, object]) -> dict[str, object]:
+        calls.append("writeback")
+        return {
+            "ok": True,
+            "appended": True,
+            "settlement_identity": context["settlement_identity"],
+            "effect_receipt_digest": context["effect_receipt_digest"],
+        }
+
+    def spend(context: Mapping[str, object]) -> dict[str, object]:
+        calls.append("spend")
+        return {
+            "ok": True,
+            "appended": True,
+            "settlement_identity": context["settlement_identity"],
+        }
+
+    committed = reconcile_governed_external_capability(
+        run_dir=arguments["run_dir"],
+        invocation_id=str(started["invocation_id"]),
+        writeback=writeback,
+        spend=spend,
+    )
+    replay = reconcile_governed_external_capability(
+        run_dir=arguments["run_dir"],
+        invocation_id=str(started["invocation_id"]),
+        writeback=writeback,
+        spend=spend,
+    )
+
+    assert committed["status"] == "committed"
+    assert committed["effect_id"] == identity.effect_id
+    assert committed["effects"] == {
+        "provider_invoked": True,
+        "external_write_observed": True,
+        "loopx_state_written": True,
+        "quota_spent": True,
+    }
+    assert calls == ["writeback", "spend"]
+    assert replay["status"] == "committed"
+    assert calls == ["writeback", "spend"]
+    assert (tmp_path / "provider-calls.txt").read_text(
+        encoding="utf-8"
+    ).splitlines() == ["start", "reconcile"]
+
+
+def test_material_start_rejects_a_different_selected_turn(tmp_path: Path) -> None:
+    arguments = _start_arguments(tmp_path)
+    arguments["admission"] = _admission(
+        _identity(turn_instance_id="different-material-turn")
+    )
+
+    with pytest.raises(ValueError, match="does not match the invocation"):
+        start_governed_external_capability(**arguments, execute=True)
+
+
+def test_material_settlement_fails_closed_without_effect_receipt_writeback(
+    tmp_path: Path,
+) -> None:
+    arguments = _start_arguments(tmp_path)
+    started = start_governed_external_capability(**arguments, execute=True)
+    calls: list[str] = []
+
+    def incomplete_writeback(context: Mapping[str, object]) -> dict[str, object]:
+        calls.append("writeback")
+        return {
+            "ok": True,
+            "appended": True,
+            "settlement_identity": context["settlement_identity"],
+        }
+
+    def spend(context: Mapping[str, object]) -> dict[str, object]:
+        calls.append("spend")
+        return {
+            "ok": True,
+            "appended": True,
+            "settlement_identity": context["settlement_identity"],
+        }
+
+    failed = reconcile_governed_external_capability(
+        run_dir=arguments["run_dir"],
+        invocation_id=str(started["invocation_id"]),
+        writeback=incomplete_writeback,
+        spend=spend,
+    )
+
+    assert failed["ok"] is False
+    assert failed["status"] == "settlement_failed"
+    assert calls == ["writeback"]
+
+
+def test_material_reconcile_resumes_at_spend_without_repeating_writeback(
+    tmp_path: Path,
+) -> None:
+    arguments = _start_arguments(tmp_path)
+    started = start_governed_external_capability(**arguments, execute=True)
+    calls: list[str] = []
+    spend_attempts = 0
+
+    def writeback(context: Mapping[str, object]) -> dict[str, object]:
+        calls.append("writeback")
+        return {
+            "ok": True,
+            "appended": True,
+            "settlement_identity": context["settlement_identity"],
+            "effect_receipt_digest": context["effect_receipt_digest"],
+        }
+
+    def spend(context: Mapping[str, object]) -> dict[str, object]:
+        nonlocal spend_attempts
+        calls.append("spend")
+        spend_attempts += 1
+        return {
+            "ok": spend_attempts > 1,
+            "appended": spend_attempts > 1,
+            "settlement_identity": context["settlement_identity"],
+            "reason": "synthetic first-attempt failure",
+        }
+
+    first = reconcile_governed_external_capability(
+        run_dir=arguments["run_dir"],
+        invocation_id=str(started["invocation_id"]),
+        writeback=writeback,
+        spend=spend,
+    )
+    second = reconcile_governed_external_capability(
+        run_dir=arguments["run_dir"],
+        invocation_id=str(started["invocation_id"]),
+        writeback=writeback,
+        spend=spend,
+    )
+
+    assert first["status"] == "settlement_failed"
+    assert second["status"] == "committed"
+    assert calls == ["writeback", "spend", "spend"]
+    assert (tmp_path / "provider-calls.txt").read_text(
+        encoding="utf-8"
+    ).splitlines() == ["start", "reconcile"]

--- a/tests/extensions/test_governed_capability_execution.py
+++ b/tests/extensions/test_governed_capability_execution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import stat
 import sys
 from collections.abc import Mapping
 from pathlib import Path
@@ -8,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from loopx.control_plane.effect_program import SettlementIdentity
+from loopx.control_plane.effect_runtime import EffectRuntimeRejected
 from loopx.extensions.capability_admission import (
     bind_external_capability_to_goal,
     invoke_external_capability,
@@ -76,6 +78,10 @@ def _installed_material_extension(tmp_path: Path) -> tuple[Path, Path, Path]:
                     {
                         "id": "publish",
                         "effect_class": "external_write",
+                        "todo_contract": {
+                            "action_kinds": ["fixture_material_delivery"],
+                            "target_key_prefixes": ["fixture-material:"],
+                        },
                         "required_permission": "fixture.delivery.write",
                         "request_schema": "fixture_material_capability_request_v0",
                         "result_schema": "fixture_material_capability_result_v0",
@@ -159,6 +165,13 @@ def _admission(identity: SettlementIdentity) -> dict[str, object]:
     return {
         "ok": True,
         "should_run": True,
+        "selected_todo": {
+            "todo_id": identity.todo_id,
+            "role": "agent",
+            "status": "open",
+            "action_kind": "fixture_material_delivery",
+            "target_key": "fixture-material:delivery-1",
+        },
         "heartbeat_receipt": {"settlement_identity": identity.as_dict()},
     }
 
@@ -203,6 +216,8 @@ def test_material_start_is_previewable_and_provider_idempotent(tmp_path: Path) -
     assert started["status"] == "running"
     assert replay["invocation_id"] == started["invocation_id"]
     assert call_log.read_text(encoding="utf-8").splitlines() == ["start"]
+    journal = Path(arguments["run_dir"]) / f"{started['invocation_id']}.json"
+    assert stat.S_IMODE(journal.stat().st_mode) == 0o600
 
 
 def test_material_operation_remains_unavailable_through_direct_invoke(
@@ -284,6 +299,25 @@ def test_material_start_rejects_a_different_selected_turn(tmp_path: Path) -> Non
 
     with pytest.raises(ValueError, match="does not match the invocation"):
         start_governed_external_capability(**arguments, execute=True)
+
+
+def test_material_start_rejects_an_unrelated_selected_todo_action(
+    tmp_path: Path,
+) -> None:
+    arguments = _start_arguments(tmp_path)
+    admission = _admission(_identity())
+    selected_todo = admission["selected_todo"]
+    assert isinstance(selected_todo, dict)
+    selected_todo["action_kind"] = "different_material_action"
+    arguments["admission"] = admission
+
+    with pytest.raises(
+        EffectRuntimeRejected,
+        match="not authorized by selected_todo",
+    ):
+        start_governed_external_capability(**arguments, execute=True)
+
+    assert not (tmp_path / "provider-calls.txt").exists()
 
 
 def test_material_settlement_fails_closed_without_effect_receipt_writeback(


### PR DESCRIPTION
## What

- Admit extension-owned `external_write` operations in Goal-bound integration profiles while keeping direct `capability invoke` read-only.
- Add a provider-neutral start/reconcile adapter with a mode-0600 durable journal, exact selected-Todo settlement identity, stable provider idempotency, typed external effect receipts, and writeback-before-spend replay.
- Require every material operation to declare a typed `todo_contract`; the selected open Agent Todo must match both an allowed `action_kind` and `target_key` prefix.
- Keep provider lifecycle and settlement-state authority in the TypeScript Effect runtime; Python only bridges extension dispatch, journal I/O, and public-safety validation.
- Document the material lifecycle and add Python/TypeScript admission and fault-replay coverage.

## Why

Goal binding answers which capability is enabled. It does not grant material write authority. External writes need one exact governed Turn so crashes after a remote effect can reconcile the same receipt instead of launching an unrelated operation or spending quota before durable writeback.

The selected Todo must also authorize the concrete operation. Without the typed action/target match, an admitted Turn could borrow an unrelated write capability that happened to be enabled for the same Goal.

## Boundary

- Providers remain extension-owned and authentication remains provider-owned.
- `loopx capability invoke` still rejects `external_write`.
- A material adapter must present a typed `quota should-run` selection for the exact Goal, Agent, Todo, and turn instance.
- The selected Todo must be open, Agent-owned, and match the operation's `todo_contract`.
- A terminal provider result must bind its effect receipt to the settlement effect id.
- Durable writeback must prove the effect receipt digest before quota spend can run.

## Validation

- TypeScript typecheck passed.
- TypeScript control-plane tests: 31 passed.
- Focused material/read-only extension tests: 33 passed.
- Extension suite excluding one environment-dependent scaffold test: 381 passed.
- The full suite previously reached 390 passing tests before the local Python environment failed to create an `ensurepip` venv; remote exact-head CI is the authoritative full-suite result.
- Changed-surface Ruff passed.
- Standard premerge gate passed: 10/10 selected checks, public boundary clean, 0 manual holds.

## Future-facing refactor pass

Applied in this PR: material admission, provider result transitions, effect-receipt binding, settlement callback validation, and terminal settlement status are owned by the established TypeScript Effect runtime instead of introducing a second Python state machine.
