### PR TITLE
fix(todos): make typed priority authoritative

### DIFF
--- a/loopx/control_plane/todos/next_action.ts
+++ b/loopx/control_plane/todos/next_action.ts
@@ -1,7 +1,7 @@
 import type { JsonObject } from "../effect_program.ts";
 
 export const TODO_NEXT_ACTION_REQUEST_SCHEMA =
-  "loopx_todo_next_action_transition_v0";
+  "loopx_todo_next_action_transition_v1";
 export const TODO_NEXT_ACTION_RESULT_SCHEMA =
   "loopx_todo_next_action_result_v0";
 export const NEXT_ACTION_BINDING_SCHEMA = "loopx_next_action_binding_v0";
@@ -10,16 +10,21 @@ const TODO_ID_PATTERN = /^todo_[a-z0-9_-]{3,64}$/;
 const NEXT_ACTION_BINDING_PATTERN =
   /^\s*<!--\s*loopx:next-action\s+schema=([A-Za-z0-9_-]+)\s+todo_id=(todo_[A-Za-z0-9_-]+)\s*-->\s*$/;
 const TODO_STATUSES = new Set(["open", "done", "blocked", "deferred"]);
+const TODO_PRIORITY_PATTERN = /^P([0-4])/;
+const TODO_MISSING_PRIORITY_RANK = 50;
 const CONTROL_TASK_CLASSES = new Set([
   "continuous_monitor",
   "user_gate",
   "blocker",
 ]);
 
+export type TodoPriority = `P${0 | 1 | 2 | 3 | 4}${string}`;
+
 export interface TodoNextActionSnapshot {
   todo_id: string;
   status: string;
   task_class: string | null;
+  priority: TodoPriority | null;
   text: string;
   index: number;
   completion_continuation: string | null;
@@ -80,6 +85,18 @@ function optionalString(value: unknown, label: string): string | null {
   return requiredString(value, label);
 }
 
+function nullableTodoPriority(
+  value: unknown,
+  label: string,
+): TodoPriority | null {
+  if (value === null) return null;
+  const priority = requiredString(value, label).trim().toUpperCase();
+  if (!TODO_PRIORITY_PATTERN.test(priority)) {
+    throw new Error(`${label} must start with P0, P1, P2, P3, or P4`);
+  }
+  return priority as TodoPriority;
+}
+
 function normalizedTodoId(value: unknown, label: string): string {
   const candidate = requiredString(value, label).trim().toLowerCase();
   if (!TODO_ID_PATTERN.test(candidate)) {
@@ -109,6 +126,7 @@ function todoSnapshot(value: unknown, index: number): TodoNextActionSnapshot {
     todo_id: normalizedTodoId(item.todo_id, `${label}.todo_id`),
     status,
     task_class: optionalString(item.task_class, `${label}.task_class`),
+    priority: nullableTodoPriority(item.priority, `${label}.priority`),
     text: normalizeText(requiredString(item.text, `${label}.text`)),
     index: Number(item.index),
     completion_continuation: optionalString(
@@ -311,9 +329,9 @@ function bindNextAction(
   };
 }
 
-function priorityRank(text: string): number {
-  const match = /\bP([0-4])\b/i.exec(text);
-  return match ? Number(match[1]) : 50;
+function priorityRank(priority: TodoPriority | null): number {
+  const match = priority ? TODO_PRIORITY_PATTERN.exec(priority) : null;
+  return match ? Number(match[1]) : TODO_MISSING_PRIORITY_RANK;
 }
 
 function nextOpenAgentTodo(
@@ -327,7 +345,7 @@ function nextOpenAgentTodo(
     const leftClass = left.task_class === "advancement_task" ? 0 : 1;
     const rightClass = right.task_class === "advancement_task" ? 0 : 1;
     return leftClass - rightClass ||
-      priorityRank(left.text) - priorityRank(right.text) ||
+      priorityRank(left.priority) - priorityRank(right.priority) ||
       left.index - right.index;
   });
   return candidates[0] ?? null;

--- a/loopx/control_plane/todos/next_action_runtime.py
+++ b/loopx/control_plane/todos/next_action_runtime.py
@@ -11,9 +11,10 @@ from .contract import (
     normalize_todo_id_list,
     normalize_todo_status,
 )
+from .projection import todo_priority_label
 
 
-TODO_NEXT_ACTION_REQUEST_SCHEMA = "loopx_todo_next_action_transition_v0"
+TODO_NEXT_ACTION_REQUEST_SCHEMA = "loopx_todo_next_action_transition_v1"
 TODO_NEXT_ACTION_RESULT_SCHEMA = "loopx_todo_next_action_result_v0"
 NEXT_ACTION_HEADING = "## Next Action"
 
@@ -59,6 +60,7 @@ def _agent_todo_snapshots(lines: list[str]) -> list[dict[str, Any]]:
                 "status": normalize_todo_status(block.get("status"))
                 or TODO_STATUS_OPEN,
                 "task_class": str(block.get("task_class") or "").strip() or None,
+                "priority": todo_priority_label(block, text_mode="prefix"),
                 "text": str(block.get("text") or "").strip(),
                 "index": int(block.get("index") or 0),
                 "completion_continuation": (

--- a/tests/control_plane/test_todo_next_action_settlement.py
+++ b/tests/control_plane/test_todo_next_action_settlement.py
@@ -5,12 +5,36 @@ from pathlib import Path
 
 from loopx.bootstrap import render_state_markdown
 from loopx.control_plane.effect_runtime import MAX_REQUEST_BYTES
+from loopx.control_plane.todos.next_action_runtime import _agent_todo_snapshots
+from loopx.control_plane.todos.projection import TODO_MISSING_PRIORITY_RANK, todo_priority_rank
 from loopx.state_projection import active_state_next_action_entries
 from loopx.state_refresh import build_state_refresh_record
 from loopx.todos import add_goal_todo, complete_goal_todo, supersede_goal_todo
 
 GOAL_ID = "todo-next-action-settlement"
 AGENT_ID = "codex-next-action"
+
+
+def test_agent_todo_snapshot_uses_structured_prefix_priority() -> None:
+    snapshots = _agent_todo_snapshots(
+        [
+            "## Agent Todo",
+            "",
+            "- [ ] [P2-review] Validate the typed priority contract.",
+            "  <!-- loopx:todo todo_id=todo_typed task_class=advancement_task -->",
+            "- [ ] Explain why a P0 mention in prose is not priority metadata.",
+            "  <!-- loopx:todo todo_id=todo_untyped task_class=advancement_task -->",
+            "",
+            "## Next Action",
+            "",
+        ]
+    )
+
+    assert [snapshot["priority"] for snapshot in snapshots] == ["P2-REVIEW", None]
+    assert [todo_priority_rank(snapshot["priority"]) for snapshot in snapshots] == [
+        2,
+        TODO_MISSING_PRIORITY_RANK,
+    ]
 
 
 def _write_fixture(tmp_path: Path, *, next_action: str) -> tuple[Path, Path]:

--- a/tests/control_plane_ts/todo_next_action.test.ts
+++ b/tests/control_plane_ts/todo_next_action.test.ts
@@ -16,6 +16,7 @@ function todo(
     todo_id: todoId,
     status: "open",
     task_class: "advancement_task",
+    priority: "P1",
     text: `[P1] ${todoId}`,
     index: 1,
     completion_continuation: null,
@@ -23,6 +24,40 @@ function todo(
     ...overrides,
   };
 }
+
+test("completion orders open work by typed priority, not display text", () => {
+  const completed = todo("todo_completed", {
+    status: "done",
+    text: "[P1] Complete the current work.",
+    completion_continuation: "successor",
+    successor_todo_ids: ["todo_typed_p1", "todo_typed_p2"],
+  });
+  const typedP1 = todo("todo_typed_p1", {
+    priority: "P1",
+    text: "[P4] Text intentionally disagrees with typed priority.",
+    index: 3,
+  });
+  const typedP2 = todo("todo_typed_p2", {
+    priority: "P2",
+    text: "[P0] Text intentionally disagrees with typed priority.",
+    index: 2,
+  });
+  const lines = [
+    "## Next Action",
+    "",
+    `- ${completed.text}`,
+    `<!-- loopx:next-action schema=${NEXT_ACTION_BINDING_SCHEMA} todo_id=${completed.todo_id} -->`,
+    "",
+  ];
+
+  const result = transitionTodoNextAction(
+    settleRequest(lines, [completed, typedP2, typedP1]),
+  );
+
+  assert.equal(result.outcome, "settled");
+  assert.equal(result.next_todo_id, typedP1.todo_id);
+  assert.equal(result.next_action, typedP1.text);
+});
 
 function settleRequest(
   lines: string[],
@@ -238,6 +273,22 @@ test("owner-authored, multiply-bound, and unknown-schema routes fail closed", ()
 });
 
 test("runtime decoder rejects malformed authority input before transition", () => {
+  const { priority: _priority, ...snapshotWithoutPriority } = todo(
+    "todo_completed",
+    { status: "done" },
+  );
+  assert.throws(
+    () =>
+      transitionTodoNextAction({
+        schema_version: TODO_NEXT_ACTION_REQUEST_SCHEMA,
+        operation: "settle_completion",
+        lines: ["## Next Action"],
+        todo_id: "todo_completed",
+        agent_todos: [snapshotWithoutPriority],
+        materialized_todo_ids: ["todo_completed"],
+      }),
+    /priority must be a non-empty string/,
+  );
   assert.throws(
     () =>
       transitionTodoNextAction({


### PR DESCRIPTION
## Summary

- carry the normalized structured Todo priority into the TypeScript Next Action snapshot
- make typed priority, rather than display text, authoritative for successor ordering
- bump the internal transition request to v1 and fail fast when the required typed field is absent or invalid

## Why

Quota/work-lane selection already ranks the structured `priority` projection. The TypeScript settlement path independently searched Todo text for `P0`-`P4`, so text and structured metadata could select different tasks. This change reuses the Python projection normalizer at the adapter boundary and leaves TypeScript responsible for typed decoding and transition ordering.

## Validation

- `npm run test:control-plane` — 33 passed
- `npm run typecheck:control-plane` — passed
- focused Python Todo/work-lane/quota contracts — 17 passed
- changed-file Python settlement suite — 10 passed after staging
- Ruff, configured strict mypy, exact public-boundary scan, and `git diff --check` — passed
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` — 4/4 direct checks and 15/15 selected canaries passed; no failures, warnings, or manual holds
- change-quality receipt `cqr_a37c364ceca73132d8c6` — exact final commit scope verified

## Scope and compatibility

This is a four-file Todo control-plane correction with focused tests. It does not change permissions, quota spending, monitor preemption, external I/O, benchmark behavior, or public/private evidence policy. The request schema bump is internal and updates its sole Python producer and TypeScript decoder atomically; there is no persisted request or external compatibility window.

Future-facing refactor review: the existing `loopx/control_plane/todos` owner is sufficient. A new module or compatibility wrapper was intentionally not added because there is one TypeScript consumer and the new helper owns the concrete priority validation invariant.
