### PR TITLE
refactor(todos): move completion fence to TypeScript

### DIFF
--- a/loopx/control_plane/effect_runtime.py
+++ b/loopx/control_plane/effect_runtime.py
@@ -32,6 +32,7 @@ _SOURCE_FILES = (
     "effect_runtime_handlers.ts",
     "effect_runtime_io.ts",
     "effect_runtime_server.ts",
+    "todos/completion_fence.ts",
     "todos/next_action.ts",
     "turn_driver/turn_journal.ts",
     "turn_driver/turn_journal_effects.ts",

--- a/loopx/control_plane/effect_runtime_handlers.ts
+++ b/loopx/control_plane/effect_runtime_handlers.ts
@@ -39,6 +39,7 @@ import {
   type TurnJournalInspectionRequest,
 } from "./turn_driver/turn_journal.ts";
 import { commitTurnJournal } from "./turn_driver/turn_journal_effects.ts";
+import { evaluateTodoCompletionFence } from "./todos/completion_fence.ts";
 import { transitionTodoNextAction } from "./todos/next_action.ts";
 
 type EffectRuntimeHandler = (params: JsonObject) => unknown | Promise<unknown>;
@@ -268,6 +269,7 @@ export function createEffectRuntimeHandlers(
       (params) => interpretTurnJournal(turnJournalInspectionRequest(params)),
     ],
     ["turn_journal.write", commitTurnJournal],
+    ["todo.completion_fence.evaluate", evaluateTodoCompletionFence],
     ["todo.next_action.transition", transitionTodoNextAction],
     [
       "effect.program_from_ordered_steps",

--- a/loopx/control_plane/todos/completion_fence.py
+++ b/loopx/control_plane/todos/completion_fence.py
@@ -1,21 +1,80 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
-from .contract import (
-    TODO_STATUS_DONE,
-    normalize_todo_id_list,
-    normalize_todo_no_followup,
-)
-from .completion_state import (
-    TodoCompletionContinuation,
-    normalize_todo_completion_continuation,
-)
+from ..effect_runtime import EffectRuntimeRejected, effect_runtime_result
+
+
+TODO_COMPLETION_FENCE_REQUEST_SCHEMA = "loopx_todo_completion_fence_request_v0"
+TODO_COMPLETION_FENCE_RESULT_SCHEMA = "loopx_todo_completion_fence_result_v0"
+
+
+def _json_successor_value(value: Any) -> Any:
+    if isinstance(value, (tuple, set)):
+        return list(value)
+    return value
+
+
+def evaluate_todo_completion_fence(
+    *,
+    todo: Mapping[str, Any],
+    projection_source: str,
+    completion_turn_key: str | None,
+    no_followup: bool,
+) -> dict[str, Any]:
+    """Ask the TypeScript Todo owner for the canonical replay-fence decision."""
+
+    raw_no_followup = todo.get("no_followup")
+    if raw_no_followup is not None and not isinstance(raw_no_followup, (bool, str)):
+        raw_no_followup = str(raw_no_followup)
+    raw_continuation = todo.get("completion_continuation")
+    if raw_continuation is not None and not isinstance(raw_continuation, str):
+        raw_continuation = str(raw_continuation)
+    raw_turn_key = todo.get("completion_turn_key")
+    if raw_turn_key is not None and not isinstance(raw_turn_key, str):
+        raw_turn_key = str(raw_turn_key)
+    try:
+        result = effect_runtime_result(
+            "todo.completion_fence.evaluate",
+            {
+                "schema_version": TODO_COMPLETION_FENCE_REQUEST_SCHEMA,
+                "projection_source": projection_source,
+                "todo": {
+                    "status": str(todo.get("status") or "open"),
+                    "no_followup": raw_no_followup,
+                    "completion_continuation": raw_continuation,
+                    "completion_turn_key": raw_turn_key,
+                    "successor_todo_ids": _json_successor_value(
+                        todo.get("successor_todo_ids")
+                    ),
+                },
+                "requested_no_followup": no_followup,
+                "requested_completion_turn_key": completion_turn_key,
+            },
+        )
+    except EffectRuntimeRejected as exc:
+        raise ValueError(str(exc)) from None
+    if not isinstance(result, Mapping):
+        raise RuntimeError("TypeScript Todo completion fence result must be an object")
+    if (
+        result.get("schema_version") != TODO_COMPLETION_FENCE_RESULT_SCHEMA
+        or result.get("outcome") not in {"continue", "replay"}
+        or not isinstance(result.get("reason"), str)
+        or not isinstance(result.get("status"), str)
+        or not isinstance(result.get("terminal_before_request"), bool)
+        or not (
+            result.get("completion_continuation") is None
+            or isinstance(result.get("completion_continuation"), str)
+        )
+    ):
+        raise RuntimeError("TypeScript Todo completion fence result shape mismatch")
+    return dict(result)
 
 
 def completed_todo_replay(
     *,
-    todo: dict[str, Any],
+    todo: Mapping[str, Any],
     goal_id: str,
     todo_id: str,
     completion_turn_key: str | None,
@@ -26,7 +85,7 @@ def completed_todo_replay(
     project: str | None,
     dry_run: bool,
 ) -> dict[str, Any] | None:
-    """Return local terminal-replay response-shape parity for a completed Todo.
+    """Project a typed TS replay decision into the legacy Python response.
 
     ``handoff_mode`` is the currently resolved goal mode, not a persisted copy
     of the original completion result. This local replay therefore is not a
@@ -37,41 +96,20 @@ def completed_todo_replay(
     no-follow-up state; it cannot replace a successor or cross a turn fence.
     """
 
-    if str(todo.get("status") or "") != TODO_STATUS_DONE:
-        return None
-    existing_turn_key = str(todo.get("completion_turn_key") or "")
-    if completion_turn_key and completion_turn_key != existing_turn_key:
-        raise ValueError(
-            "todo is already completed under a different completion_turn_key"
-        )
-    terminal_upgrade = (
-        no_followup and normalize_todo_no_followup(todo.get("no_followup")) is not True
+    # This fast path runs before the caller selects the event writer. Treat it
+    # as a materialized projection; an event-only deferred Todo falls through
+    # and is evaluated with ``projection_source=event_log`` by that writer.
+    fence = evaluate_todo_completion_fence(
+        todo=todo,
+        projection_source="materialized",
+        completion_turn_key=completion_turn_key,
+        no_followup=no_followup,
     )
-    completion_continuation = normalize_todo_completion_continuation(
-        todo.get("completion_continuation")
-    )
-    if terminal_upgrade:
-        if normalize_todo_id_list(todo.get("successor_todo_ids")):
-            raise ValueError(
-                "todo terminal closeout cannot replace an existing successor"
-            )
-        if completion_continuation is None:
-            raise ValueError(
-                "completed todo is missing completion_continuation; repair the "
-                "Todo with `loopx todo complete` without --no-follow-up before terminal "
-                "closeout"
-            )
-        if completion_continuation != TodoCompletionContinuation.ACTIVE_GOAL.value:
-            raise ValueError(
-                "todo terminal closeout recovery requires "
-                "completion_continuation=active_goal"
-            )
-        if not completion_turn_key or completion_turn_key != existing_turn_key:
-            raise ValueError(
-                "todo terminal closeout requires the original completion_turn_key"
-            )
-        return None
-    if completion_continuation is None:
+
+    # Event-projected deferred rows must pass through the event writer so the
+    # existing lease-fence receipt remains visible. Done rows preserve the
+    # earlier fast replay path for both projection sources.
+    if fence.get("outcome") != "replay" or fence.get("status") != "done":
         return None
     return {
         "ok": True,
@@ -81,8 +119,8 @@ def completed_todo_replay(
         "changed": False,
         "goal_id": goal_id,
         "todo_id": todo_id,
-        "status": TODO_STATUS_DONE,
-        "completion_continuation": completion_continuation,
+        "status": "done",
+        "completion_continuation": fence.get("completion_continuation"),
         "completion_recovery": todo.get("completion_recovery"),
         "handoff_mode": handoff_mode,
         "mutation_authority": mutation_authority,

--- a/loopx/control_plane/todos/completion_fence.ts
+++ b/loopx/control_plane/todos/completion_fence.ts
@@ -1,0 +1,270 @@
+import type { JsonObject } from "../effect_program.ts";
+
+export const TODO_COMPLETION_FENCE_REQUEST_SCHEMA =
+  "loopx_todo_completion_fence_request_v0";
+export const TODO_COMPLETION_FENCE_RESULT_SCHEMA =
+  "loopx_todo_completion_fence_result_v0";
+
+const TODO_STATUSES = ["open", "done", "blocked", "deferred"] as const;
+const COMPLETION_CONTINUATIONS = [
+  "active_goal",
+  "successor",
+  "no_followup",
+] as const;
+const TODO_ID_PATTERN = /^todo_[a-z0-9_-]{3,64}$/;
+
+export type TodoStatus = (typeof TODO_STATUSES)[number];
+export type TodoCompletionContinuation =
+  (typeof COMPLETION_CONTINUATIONS)[number];
+export type TodoCompletionProjectionSource = "materialized" | "event_log";
+
+export interface TodoCompletionFenceRequest {
+  schema_version: typeof TODO_COMPLETION_FENCE_REQUEST_SCHEMA;
+  projection_source: TodoCompletionProjectionSource;
+  todo: {
+    status: TodoStatus;
+    no_followup: boolean | string | null;
+    completion_continuation: string | null;
+    completion_turn_key: string | null;
+    successor_todo_ids: readonly string[];
+  };
+  requested_no_followup: boolean;
+  requested_completion_turn_key: string | null;
+}
+
+export type TodoCompletionFenceContinueReason =
+  | "not_terminal"
+  | "same_turn_terminal_upgrade"
+  | "untyped_completion_repair";
+
+export type TodoCompletionFenceResult =
+  | (JsonObject & {
+      schema_version: typeof TODO_COMPLETION_FENCE_RESULT_SCHEMA;
+      outcome: "continue";
+      reason: TodoCompletionFenceContinueReason;
+      status: TodoStatus;
+      terminal_before_request: boolean;
+      completion_continuation: TodoCompletionContinuation | null;
+    })
+  | (JsonObject & {
+      schema_version: typeof TODO_COMPLETION_FENCE_RESULT_SCHEMA;
+      outcome: "replay";
+      reason: "already_terminal";
+      status: "done" | "deferred";
+      terminal_before_request: true;
+      completion_continuation: TodoCompletionContinuation | null;
+    });
+
+function requiredObject(value: unknown, label: string): JsonObject {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as JsonObject;
+}
+
+function requiredBoolean(value: unknown, label: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new Error(`${label} must be a boolean`);
+  }
+  return value;
+}
+
+function optionalOpaqueString(value: unknown, label: string): string | null {
+  if (value === null || value === undefined || value === "") return null;
+  if (typeof value !== "string") {
+    throw new Error(`${label} must be a string or null`);
+  }
+  return value;
+}
+
+function todoStatus(value: unknown): TodoStatus {
+  if (typeof value !== "string") {
+    throw new Error("todo.status must be a supported string");
+  }
+  const normalized = value.trim().toLowerCase();
+  if (!TODO_STATUSES.some((status) => status === normalized)) {
+    throw new Error("todo.status is unsupported");
+  }
+  return normalized as TodoStatus;
+}
+
+function projectionSource(value: unknown): TodoCompletionProjectionSource {
+  if (value === "materialized" || value === "event_log") return value;
+  throw new Error("projection_source is unsupported");
+}
+
+function normalizeNoFollowup(value: unknown): boolean | null {
+  if (typeof value === "boolean") return value;
+  if (value === null || value === undefined) return null;
+  if (typeof value !== "string") {
+    throw new Error("todo.no_followup must be a boolean, string, or null");
+  }
+  const candidate = value.trim().toLowerCase();
+  if (["1", "true", "yes", "y", "no_followup", "no-followup"].includes(candidate)) {
+    return true;
+  }
+  if (["0", "false", "no", "n"].includes(candidate)) return false;
+  return null;
+}
+
+function normalizeCompletionContinuation(
+  value: unknown,
+): TodoCompletionContinuation | null {
+  if (value === null || value === undefined || value === "") return null;
+  if (typeof value !== "string") {
+    throw new Error("todo.completion_continuation must be a string or null");
+  }
+  const candidate = value.trim().toLowerCase();
+  return COMPLETION_CONTINUATIONS.some((item) => item === candidate)
+    ? candidate as TodoCompletionContinuation
+    : null;
+}
+
+function successorTodoIds(value: unknown): string[] {
+  if (value === null || value === undefined) return [];
+  const values = Array.isArray(value) ? value : [value];
+  if (values.some((item) => typeof item !== "string")) {
+    throw new Error("todo.successor_todo_ids must contain only strings");
+  }
+  const result: string[] = [];
+  for (const raw of values as string[]) {
+    for (const match of raw.matchAll(/\btodo_[A-Za-z0-9_-]+\b/g)) {
+      const todoId = match[0].toLowerCase();
+      if (TODO_ID_PATTERN.test(todoId) && !result.includes(todoId)) {
+        result.push(todoId);
+      }
+    }
+    const todoId = raw.trim().toLowerCase();
+    if (TODO_ID_PATTERN.test(todoId) && !result.includes(todoId)) {
+      result.push(todoId);
+    }
+  }
+  return result;
+}
+
+export function decodeTodoCompletionFenceRequest(
+  value: unknown,
+): TodoCompletionFenceRequest {
+  const request = requiredObject(value, "todo.completion_fence params");
+  if (request.schema_version !== TODO_COMPLETION_FENCE_REQUEST_SCHEMA) {
+    throw new Error("Todo completion fence request schema mismatch");
+  }
+  const todo = requiredObject(request.todo, "todo.completion_fence todo");
+  return {
+    schema_version: TODO_COMPLETION_FENCE_REQUEST_SCHEMA,
+    projection_source: projectionSource(request.projection_source),
+    todo: {
+      status: todoStatus(todo.status),
+      no_followup: normalizeNoFollowup(todo.no_followup),
+      completion_continuation: optionalOpaqueString(
+        todo.completion_continuation,
+        "todo.completion_continuation",
+      ),
+      completion_turn_key: optionalOpaqueString(
+        todo.completion_turn_key,
+        "todo.completion_turn_key",
+      ),
+      successor_todo_ids: successorTodoIds(todo.successor_todo_ids),
+    },
+    requested_no_followup: requiredBoolean(
+      request.requested_no_followup,
+      "requested_no_followup",
+    ),
+    requested_completion_turn_key: optionalOpaqueString(
+      request.requested_completion_turn_key,
+      "requested_completion_turn_key",
+    ),
+  };
+}
+
+export function evaluateTodoCompletionFence(
+  value: unknown,
+): TodoCompletionFenceResult {
+  const request = decodeTodoCompletionFenceRequest(value);
+  const status = request.todo.status;
+  const continuation = normalizeCompletionContinuation(
+    request.todo.completion_continuation,
+  );
+  const done = status === "done";
+  const terminalBeforeRequest = done ||
+    (request.projection_source === "event_log" && status === "deferred");
+
+  if (
+    done && request.requested_completion_turn_key !== null &&
+    request.requested_completion_turn_key !== request.todo.completion_turn_key
+  ) {
+    throw new Error(
+      "todo is already completed under a different completion_turn_key",
+    );
+  }
+
+  const terminalUpgrade = done && request.requested_no_followup &&
+    normalizeNoFollowup(request.todo.no_followup) !== true;
+  if (terminalUpgrade) {
+    if (request.todo.successor_todo_ids.length > 0) {
+      throw new Error(
+        "todo terminal closeout cannot replace an existing successor",
+      );
+    }
+    if (continuation === null) {
+      throw new Error(
+        "completed todo is missing completion_continuation; repair the " +
+          "Todo with `loopx todo complete` without --no-follow-up before terminal " +
+          "closeout",
+      );
+    }
+    if (continuation !== "active_goal") {
+      throw new Error(
+        "todo terminal closeout recovery requires " +
+          "completion_continuation=active_goal",
+      );
+    }
+    if (
+      request.requested_completion_turn_key === null ||
+      request.requested_completion_turn_key !== request.todo.completion_turn_key
+    ) {
+      throw new Error(
+        "todo terminal closeout requires the original completion_turn_key",
+      );
+    }
+    return {
+      schema_version: TODO_COMPLETION_FENCE_RESULT_SCHEMA,
+      outcome: "continue",
+      reason: "same_turn_terminal_upgrade",
+      status,
+      terminal_before_request: true,
+      completion_continuation: continuation,
+    };
+  }
+
+  if (done && continuation === null) {
+    return {
+      schema_version: TODO_COMPLETION_FENCE_RESULT_SCHEMA,
+      outcome: "continue",
+      reason: "untyped_completion_repair",
+      status,
+      terminal_before_request: true,
+      completion_continuation: null,
+    };
+  }
+
+  if (terminalBeforeRequest) {
+    return {
+      schema_version: TODO_COMPLETION_FENCE_RESULT_SCHEMA,
+      outcome: "replay",
+      reason: "already_terminal",
+      status,
+      terminal_before_request: true,
+      completion_continuation: continuation,
+    };
+  }
+
+  return {
+    schema_version: TODO_COMPLETION_FENCE_RESULT_SCHEMA,
+    outcome: "continue",
+    reason: "not_terminal",
+    status,
+    terminal_before_request: false,
+    completion_continuation: continuation,
+  };
+}

--- a/loopx/control_plane/todos/event_writeback.py
+++ b/loopx/control_plane/todos/event_writeback.py
@@ -22,7 +22,6 @@ from .active_state_todo_parser import parse_active_state_todos
 from .contract import (
     TODO_CONTINUATION_POLICY_VALUES,
     TODO_STATUS_DONE,
-    TODO_STATUS_OPEN,
     TODO_TASK_CLASS_USER_GATE,
     build_todo_id,
     merge_todo_id_lists,
@@ -34,14 +33,11 @@ from .contract import (
     normalize_todo_excluded_agents,
     normalize_todo_id,
     normalize_todo_id_list,
-    normalize_todo_no_followup,
     normalize_todo_task_repository,
-    todo_done_for_status,
 )
+from .completion_fence import evaluate_todo_completion_fence
 from .completion_state import (
-    TodoCompletionContinuation,
     completion_state_for_todo_write,
-    normalize_todo_completion_continuation,
 )
 from .text import (
     TODO_PRIORITY_PREFIX_PATTERN,
@@ -331,6 +327,7 @@ def complete_event_projected_goal_todo(
     dry_run: bool,
     completion_turn_key: str | None = None,
     actor_agent_id: str | None = None,
+    completion_fence: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     item = dict(context["item"])
     role = str(context["role"])
@@ -341,45 +338,21 @@ def complete_event_projected_goal_todo(
         item.pop("claimed_by", None)
     effective_claimed_by = claimed_by or normalize_todo_claimed_by(item.get("claimed_by"))
     store = AppendOnlyStateEventStore(Path(context["event_log_path"]))
-    already_done = todo_done_for_status(str(item.get("status") or TODO_STATUS_OPEN))
-    terminal_upgrade_requested = (
-        str(item.get("status") or "") == TODO_STATUS_DONE
-        and no_followup
-        and normalize_todo_no_followup(item.get("no_followup")) is not True
+    if completion_fence is None:
+        completion_fence = evaluate_todo_completion_fence(
+            todo=item,
+            projection_source="event_log",
+            completion_turn_key=completion_turn_key,
+            no_followup=no_followup,
+        )
+    already_done = bool(completion_fence["terminal_before_request"])
+    terminal_upgrade = (
+        completion_fence["reason"] == "same_turn_terminal_upgrade"
     )
     untyped_completion_repair = (
-        str(item.get("status") or "") == TODO_STATUS_DONE
-        and normalize_todo_completion_continuation(
-            item.get("completion_continuation")
-        )
-        is None
+        completion_fence["reason"] == "untyped_completion_repair"
     )
-    if terminal_upgrade_requested:
-        if normalize_todo_id_list(item.get("successor_todo_ids")):
-            raise ValueError(
-                "todo terminal closeout cannot replace an existing successor"
-            )
-        existing_continuation = normalize_todo_completion_continuation(
-            item.get("completion_continuation")
-        )
-        if existing_continuation is None:
-            raise ValueError(
-                "completed todo is missing completion_continuation; repair the "
-                "Todo with `loopx todo complete` without --no-follow-up before terminal "
-                "closeout"
-            )
-        if existing_continuation != TodoCompletionContinuation.ACTIVE_GOAL.value:
-            raise ValueError(
-                "todo terminal closeout recovery requires "
-                "completion_continuation=active_goal"
-            )
-        existing_turn_key = str(item.get("completion_turn_key") or "")
-        if not completion_turn_key or completion_turn_key != existing_turn_key:
-            raise ValueError(
-                "todo terminal closeout requires the original completion_turn_key"
-            )
-    terminal_upgrade = terminal_upgrade_requested
-    if already_done and not terminal_upgrade and not untyped_completion_repair:
+    if completion_fence["outcome"] == "replay":
         return {
             "ok": True,
             "dry_run": dry_run,
@@ -392,8 +365,8 @@ def complete_event_projected_goal_todo(
             "todo": item.get("text") or item.get("title"),
             "todo_id": todo_id,
             "status": TODO_STATUS_DONE,
-            "completion_continuation": normalize_todo_completion_continuation(
-                item.get("completion_continuation")
+            "completion_continuation": completion_fence.get(
+                "completion_continuation"
             ),
             "completion_recovery": item.get("completion_recovery"),
             "status_changed": False,

--- a/tests/control_plane/test_todo_completion_fence_runtime.py
+++ b/tests/control_plane/test_todo_completion_fence_runtime.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import pytest
+
+from loopx.control_plane import effect_runtime
+from loopx.control_plane.todos import completion_fence
+
+
+def _runtime_result(**overrides: object) -> dict[str, object]:
+    return {
+        "schema_version": completion_fence.TODO_COMPLETION_FENCE_RESULT_SCHEMA,
+        "outcome": "replay",
+        "reason": "already_terminal",
+        "status": "done",
+        "terminal_before_request": True,
+        "completion_continuation": "no_followup",
+        **overrides,
+    }
+
+
+def test_python_facade_sends_one_coarse_typed_request(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def call(method: str, params: dict[str, object]) -> dict[str, object]:
+        captured["method"] = method
+        captured["params"] = params
+        return _runtime_result()
+
+    monkeypatch.setattr(completion_fence, "effect_runtime_result", call)
+
+    result = completion_fence.evaluate_todo_completion_fence(
+        todo={
+            "status": "done",
+            "no_followup": "true",
+            "completion_continuation": "no_followup",
+            "completion_turn_key": "turn-a",
+            "successor_todo_ids": (),
+        },
+        projection_source="materialized",
+        completion_turn_key="turn-a",
+        no_followup=True,
+    )
+
+    assert result == _runtime_result()
+    assert captured["method"] == "todo.completion_fence.evaluate"
+    assert captured["params"] == {
+        "schema_version": completion_fence.TODO_COMPLETION_FENCE_REQUEST_SCHEMA,
+        "projection_source": "materialized",
+        "todo": {
+            "status": "done",
+            "no_followup": "true",
+            "completion_continuation": "no_followup",
+            "completion_turn_key": "turn-a",
+            "successor_todo_ids": [],
+        },
+        "requested_no_followup": True,
+        "requested_completion_turn_key": "turn-a",
+    }
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    [
+        None,
+        {},
+        _runtime_result(schema_version="loopx_todo_completion_fence_result_v1"),
+        _runtime_result(terminal_before_request="true"),
+        _runtime_result(completion_continuation=[]),
+    ],
+)
+def test_python_facade_rejects_malformed_runtime_results(
+    monkeypatch, malformed: object
+) -> None:
+    monkeypatch.setattr(
+        completion_fence,
+        "effect_runtime_result",
+        lambda _method, _params: malformed,
+    )
+
+    with pytest.raises(RuntimeError, match="result (must be|shape mismatch)"):
+        completion_fence.evaluate_todo_completion_fence(
+            todo={"status": "open"},
+            projection_source="materialized",
+            completion_turn_key=None,
+            no_followup=False,
+        )
+
+
+def test_python_facade_preserves_typed_rejection_as_value_error(monkeypatch) -> None:
+    def reject(_method: str, _params: dict[str, object]) -> object:
+        raise effect_runtime.EffectRuntimeRejected("typed fence rejected")
+
+    monkeypatch.setattr(completion_fence, "effect_runtime_result", reject)
+
+    with pytest.raises(ValueError, match="typed fence rejected"):
+        completion_fence.evaluate_todo_completion_fence(
+            todo={"status": "done"},
+            projection_source="materialized",
+            completion_turn_key="turn-b",
+            no_followup=True,
+        )

--- a/tests/control_plane_ts/todo_completion_fence.test.ts
+++ b/tests/control_plane_ts/todo_completion_fence.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  evaluateTodoCompletionFence,
+  TODO_COMPLETION_FENCE_REQUEST_SCHEMA,
+} from "../../loopx/control_plane/todos/completion_fence.ts";
+
+const fixture = JSON.parse(
+  readFileSync(
+    new URL(
+      "../fixtures/control_plane/todo_completion_fence_characterization_v0.json",
+      import.meta.url,
+    ),
+    "utf8",
+  ),
+) as {
+  schema_version: string;
+  source_baseline: string;
+  cases: Array<{
+    name: string;
+    request: Record<string, unknown>;
+    expected_result?: Record<string, unknown>;
+    expected_error?: string;
+  }>;
+};
+
+test("pinned Python completion-fence characterization remains exact", () => {
+  assert.equal(
+    fixture.schema_version,
+    "loopx_todo_completion_fence_characterization_v0",
+  );
+  assert.equal(fixture.source_baseline, "58adc1783");
+  assert.equal(fixture.cases.length >= 8, true);
+  for (const item of fixture.cases) {
+    if (item.expected_error) {
+      assert.throws(
+        () => evaluateTodoCompletionFence(item.request),
+        (error: unknown) =>
+          error instanceof Error && error.message === item.expected_error,
+        item.name,
+      );
+      continue;
+    }
+    assert.deepEqual(
+      evaluateTodoCompletionFence(item.request),
+      item.expected_result,
+      item.name,
+    );
+  }
+});
+
+test("terminal closeout rejects missing and contradictory durable state", () => {
+  const base = {
+    schema_version: TODO_COMPLETION_FENCE_REQUEST_SCHEMA,
+    projection_source: "materialized",
+    todo: {
+      status: "done",
+      no_followup: false,
+      completion_continuation: null,
+      completion_turn_key: "turn-a",
+      successor_todo_ids: [],
+    },
+    requested_no_followup: true,
+    requested_completion_turn_key: "turn-a",
+  };
+  assert.throws(
+    () => evaluateTodoCompletionFence(base),
+    /missing completion_continuation/,
+  );
+  assert.throws(
+    () =>
+      evaluateTodoCompletionFence({
+        ...base,
+        todo: { ...base.todo, completion_continuation: "no_followup" },
+      }),
+    /completion_continuation=active_goal/,
+  );
+});
+
+test("runtime decoder rejects malformed authority input before evaluation", () => {
+  const valid = fixture.cases[0].request;
+  assert.throws(
+    () =>
+      evaluateTodoCompletionFence({
+        ...valid,
+        schema_version: "loopx_todo_completion_fence_request_v1",
+      }),
+    /schema mismatch/,
+  );
+  assert.throws(
+    () =>
+      evaluateTodoCompletionFence({
+        ...valid,
+        projection_source: "shadow",
+      }),
+    /projection_source is unsupported/,
+  );
+  assert.throws(
+    () =>
+      evaluateTodoCompletionFence({
+        ...valid,
+        todo: {
+          ...(valid.todo as Record<string, unknown>),
+          status: "completed",
+        },
+      }),
+    /todo.status is unsupported/,
+  );
+  assert.throws(
+    () =>
+      evaluateTodoCompletionFence({
+        ...valid,
+        requested_no_followup: "true",
+      }),
+    /requested_no_followup must be a boolean/,
+  );
+});
+
+test("evaluation is input-immutable and normalizes persisted metadata", () => {
+  const request = {
+    schema_version: TODO_COMPLETION_FENCE_REQUEST_SCHEMA,
+    projection_source: "materialized",
+    todo: {
+      status: "DONE",
+      no_followup: "YES",
+      completion_continuation: "NO_FOLLOWUP",
+      completion_turn_key: "turn-a",
+      successor_todo_ids: [],
+    },
+    requested_no_followup: true,
+    requested_completion_turn_key: "turn-a",
+  };
+  const before = structuredClone(request);
+
+  const result = evaluateTodoCompletionFence(request);
+
+  assert.equal(result.outcome, "replay");
+  assert.equal(result.completion_continuation, "no_followup");
+  assert.deepEqual(request, before);
+});

--- a/tests/fixtures/control_plane/todo_completion_fence_characterization_v0.json
+++ b/tests/fixtures/control_plane/todo_completion_fence_characterization_v0.json
@@ -1,0 +1,201 @@
+{
+  "schema_version": "loopx_todo_completion_fence_characterization_v0",
+  "source_baseline": "58adc1783",
+  "cases": [
+    {
+      "name": "materialized open Todo continues",
+      "request": {
+        "schema_version": "loopx_todo_completion_fence_request_v0",
+        "projection_source": "materialized",
+        "todo": {
+          "status": "open",
+          "no_followup": null,
+          "completion_continuation": null,
+          "completion_turn_key": null,
+          "successor_todo_ids": []
+        },
+        "requested_no_followup": false,
+        "requested_completion_turn_key": null
+      },
+      "expected_result": {
+        "schema_version": "loopx_todo_completion_fence_result_v0",
+        "outcome": "continue",
+        "reason": "not_terminal",
+        "status": "open",
+        "terminal_before_request": false,
+        "completion_continuation": null
+      }
+    },
+    {
+      "name": "materialized deferred Todo remains writable",
+      "request": {
+        "schema_version": "loopx_todo_completion_fence_request_v0",
+        "projection_source": "materialized",
+        "todo": {
+          "status": "deferred",
+          "no_followup": null,
+          "completion_continuation": null,
+          "completion_turn_key": null,
+          "successor_todo_ids": []
+        },
+        "requested_no_followup": false,
+        "requested_completion_turn_key": null
+      },
+      "expected_result": {
+        "schema_version": "loopx_todo_completion_fence_result_v0",
+        "outcome": "continue",
+        "reason": "not_terminal",
+        "status": "deferred",
+        "terminal_before_request": false,
+        "completion_continuation": null
+      }
+    },
+    {
+      "name": "event-projected deferred Todo replays",
+      "request": {
+        "schema_version": "loopx_todo_completion_fence_request_v0",
+        "projection_source": "event_log",
+        "todo": {
+          "status": "deferred",
+          "no_followup": null,
+          "completion_continuation": null,
+          "completion_turn_key": null,
+          "successor_todo_ids": []
+        },
+        "requested_no_followup": true,
+        "requested_completion_turn_key": null
+      },
+      "expected_result": {
+        "schema_version": "loopx_todo_completion_fence_result_v0",
+        "outcome": "replay",
+        "reason": "already_terminal",
+        "status": "deferred",
+        "terminal_before_request": true,
+        "completion_continuation": null
+      }
+    },
+    {
+      "name": "typed done Todo replays",
+      "request": {
+        "schema_version": "loopx_todo_completion_fence_request_v0",
+        "projection_source": "materialized",
+        "todo": {
+          "status": "done",
+          "no_followup": false,
+          "completion_continuation": "active_goal",
+          "completion_turn_key": "turn-a",
+          "successor_todo_ids": []
+        },
+        "requested_no_followup": false,
+        "requested_completion_turn_key": "turn-a"
+      },
+      "expected_result": {
+        "schema_version": "loopx_todo_completion_fence_result_v0",
+        "outcome": "replay",
+        "reason": "already_terminal",
+        "status": "done",
+        "terminal_before_request": true,
+        "completion_continuation": "active_goal"
+      }
+    },
+    {
+      "name": "untyped done Todo enters repair",
+      "request": {
+        "schema_version": "loopx_todo_completion_fence_request_v0",
+        "projection_source": "materialized",
+        "todo": {
+          "status": "done",
+          "no_followup": false,
+          "completion_continuation": null,
+          "completion_turn_key": "turn-a",
+          "successor_todo_ids": []
+        },
+        "requested_no_followup": false,
+        "requested_completion_turn_key": "turn-a"
+      },
+      "expected_result": {
+        "schema_version": "loopx_todo_completion_fence_result_v0",
+        "outcome": "continue",
+        "reason": "untyped_completion_repair",
+        "status": "done",
+        "terminal_before_request": true,
+        "completion_continuation": null
+      }
+    },
+    {
+      "name": "same-turn terminal upgrade continues",
+      "request": {
+        "schema_version": "loopx_todo_completion_fence_request_v0",
+        "projection_source": "event_log",
+        "todo": {
+          "status": "done",
+          "no_followup": "false",
+          "completion_continuation": "active_goal",
+          "completion_turn_key": "turn-a",
+          "successor_todo_ids": []
+        },
+        "requested_no_followup": true,
+        "requested_completion_turn_key": "turn-a"
+      },
+      "expected_result": {
+        "schema_version": "loopx_todo_completion_fence_result_v0",
+        "outcome": "continue",
+        "reason": "same_turn_terminal_upgrade",
+        "status": "done",
+        "terminal_before_request": true,
+        "completion_continuation": "active_goal"
+      }
+    },
+    {
+      "name": "cross-turn replay is rejected",
+      "request": {
+        "schema_version": "loopx_todo_completion_fence_request_v0",
+        "projection_source": "materialized",
+        "todo": {
+          "status": "done",
+          "no_followup": true,
+          "completion_continuation": "no_followup",
+          "completion_turn_key": "turn-a",
+          "successor_todo_ids": []
+        },
+        "requested_no_followup": true,
+        "requested_completion_turn_key": "turn-b"
+      },
+      "expected_error": "todo is already completed under a different completion_turn_key"
+    },
+    {
+      "name": "terminal upgrade cannot replace a successor",
+      "request": {
+        "schema_version": "loopx_todo_completion_fence_request_v0",
+        "projection_source": "materialized",
+        "todo": {
+          "status": "done",
+          "no_followup": false,
+          "completion_continuation": "successor",
+          "completion_turn_key": "turn-a",
+          "successor_todo_ids": ["todo_successor"]
+        },
+        "requested_no_followup": true,
+        "requested_completion_turn_key": "turn-a"
+      },
+      "expected_error": "todo terminal closeout cannot replace an existing successor"
+    },
+    {
+      "name": "terminal upgrade requires original turn identity",
+      "request": {
+        "schema_version": "loopx_todo_completion_fence_request_v0",
+        "projection_source": "materialized",
+        "todo": {
+          "status": "done",
+          "no_followup": false,
+          "completion_continuation": "active_goal",
+          "completion_turn_key": "turn-a",
+          "successor_todo_ids": []
+        },
+        "requested_no_followup": true,
+        "requested_completion_turn_key": null
+      },
+      "expected_error": "todo terminal closeout requires the original completion_turn_key"
+    }
+  ]
+}

--- a/tsconfig.control-plane.json
+++ b/tsconfig.control-plane.json
@@ -16,10 +16,12 @@
     "loopx/control_plane/effect_runtime_handlers.ts",
     "loopx/control_plane/effect_runtime_io.ts",
     "loopx/control_plane/effect_runtime_server.ts",
+    "loopx/control_plane/todos/completion_fence.ts",
     "loopx/control_plane/todos/next_action.ts",
     "loopx/control_plane/turn_driver/turn_journal.ts",
     "loopx/control_plane/turn_driver/turn_journal_effects.ts",
     "tests/control_plane_ts/effect_program.test.ts",
+    "tests/control_plane_ts/todo_completion_fence.test.ts",
     "tests/control_plane_ts/todo_next_action.test.ts",
     "tests/control_plane_ts/turn_journal.test.ts",
     "tests/control_plane_ts/turn_journal_effects.test.ts"


### PR DESCRIPTION
## Summary

- move completed-Todo replay and same-turn terminal-closeout decisions into one typed TypeScript owner;
- register the decision as `todo.completion_fence.evaluate` on the existing managed Effect Runtime;
- keep Python as the transport/legacy-response facade and remove the duplicated rule block from event writeback;
- preserve materialized versus event-log projection behavior, including deferred replay and lease-fence visibility.

This is the next bounded Strangler Fig slice from the TypeScript control-plane migration RFC. It adds no second server, state store, CLI, or compatibility implementation.

## Ownership and compatibility

- Canonical rule owner: `loopx/control_plane/todos/completion_fence.ts`.
- Python owns only request normalization, runtime error translation, response-envelope validation, and legacy response projection.
- Existing `loopx todo complete` syntax and response shape remain unchanged.
- The safe-fix review removed all changes from the oversized `loopx/todos.py` hotspot; event-only paths call the same TS owner from their bounded writer.
- No host adapter, persisted schema, or user installation action changes.

## Validation

- `npm run typecheck:control-plane`
- `npm run test:control-plane` — 37 passed
- focused Python control-plane regression set — 186 passed
- supported Ruff scope — passed
- `python -m mypy` — passed
- wheel and sdist built; each installed into a fresh Python 3.11 environment and returned the typed replay result
- managed runtime warm RPC (250 samples): p50 0.347 ms, p95 0.692 ms
- interleaved full-CLI replay (10 samples per arm): baseline p95 970.129 ms, candidate p95 907.080 ms; no material regression
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 9/9 catalog canaries and 8/8 risk-profile smokes passed
- change-quality receipt: `cqr_1e74a239394fb8431717`, exact scope valid, 0 blockers

## Public/private boundary

Only product code, public-safe characterization data, and durable tests are included. Build artifacts, local runtime state, benchmark traces, credentials, and temporary performance output are excluded.

## Merge authorization

The owner authorized self-merge after maintainer review and required CI completion.
