### PR TITLE
refactor(todos): move completion state to TypeScript

### DIFF
--- a/loopx/control_plane/effect_runtime.py
+++ b/loopx/control_plane/effect_runtime.py
@@ -33,6 +33,7 @@ _SOURCE_FILES = (
     "effect_runtime_io.ts",
     "effect_runtime_server.ts",
     "todos/completion_fence.ts",
+    "todos/completion_state.ts",
     "todos/next_action.ts",
     "turn_driver/turn_journal.ts",
     "turn_driver/turn_journal_effects.ts",

--- a/loopx/control_plane/effect_runtime_handlers.ts
+++ b/loopx/control_plane/effect_runtime_handlers.ts
@@ -40,6 +40,13 @@ import {
 } from "./turn_driver/turn_journal.ts";
 import { commitTurnJournal } from "./turn_driver/turn_journal_effects.ts";
 import { evaluateTodoCompletionFence } from "./todos/completion_fence.ts";
+import {
+  buildTodoCompletionMetadataUpdates,
+  normalizeTodoCompletionValue,
+  requireTodoCompletionMetadataValue,
+  selectTodoCompletionContinuation,
+  selectTodoCompletionState,
+} from "./todos/completion_state.ts";
 import { transitionTodoNextAction } from "./todos/next_action.ts";
 
 type EffectRuntimeHandler = (params: JsonObject) => unknown | Promise<unknown>;
@@ -270,6 +277,11 @@ export function createEffectRuntimeHandlers(
     ],
     ["turn_journal.write", commitTurnJournal],
     ["todo.completion_fence.evaluate", evaluateTodoCompletionFence],
+    ["todo.completion_state.normalize", normalizeTodoCompletionValue],
+    ["todo.completion_state.require_metadata", requireTodoCompletionMetadataValue],
+    ["todo.completion_state.continuation_for_write", selectTodoCompletionContinuation],
+    ["todo.completion_state.evaluate", selectTodoCompletionState],
+    ["todo.completion_state.metadata_updates", buildTodoCompletionMetadataUpdates],
     ["todo.next_action.transition", transitionTodoNextAction],
     [
       "effect.program_from_ordered_steps",

--- a/loopx/control_plane/todos/completion_fence.ts
+++ b/loopx/control_plane/todos/completion_fence.ts
@@ -1,4 +1,9 @@
 import type { JsonObject } from "../effect_program.ts";
+import {
+  normalizeTodoCompletionContinuation,
+  normalizeTodoNoFollowup,
+  type TodoCompletionContinuation,
+} from "./completion_state.ts";
 
 export const TODO_COMPLETION_FENCE_REQUEST_SCHEMA =
   "loopx_todo_completion_fence_request_v0";
@@ -6,16 +11,9 @@ export const TODO_COMPLETION_FENCE_RESULT_SCHEMA =
   "loopx_todo_completion_fence_result_v0";
 
 const TODO_STATUSES = ["open", "done", "blocked", "deferred"] as const;
-const COMPLETION_CONTINUATIONS = [
-  "active_goal",
-  "successor",
-  "no_followup",
-] as const;
 const TODO_ID_PATTERN = /^todo_[a-z0-9_-]{3,64}$/;
 
 export type TodoStatus = (typeof TODO_STATUSES)[number];
-export type TodoCompletionContinuation =
-  (typeof COMPLETION_CONTINUATIONS)[number];
 export type TodoCompletionProjectionSource = "materialized" | "event_log";
 
 export interface TodoCompletionFenceRequest {
@@ -77,6 +75,28 @@ function optionalOpaqueString(value: unknown, label: string): string | null {
   return value;
 }
 
+function todoNoFollowup(value: unknown): boolean | null {
+  if (
+    value !== null && value !== undefined &&
+    typeof value !== "boolean" && typeof value !== "string"
+  ) {
+    throw new Error("todo.no_followup must be a boolean, string, or null");
+  }
+  return normalizeTodoNoFollowup(value);
+}
+
+function todoCompletionContinuation(
+  value: unknown,
+): TodoCompletionContinuation | null {
+  if (
+    value !== null && value !== undefined && value !== "" &&
+    typeof value !== "string"
+  ) {
+    throw new Error("todo.completion_continuation must be a string or null");
+  }
+  return normalizeTodoCompletionContinuation(value);
+}
+
 function todoStatus(value: unknown): TodoStatus {
   if (typeof value !== "string") {
     throw new Error("todo.status must be a supported string");
@@ -91,33 +111,6 @@ function todoStatus(value: unknown): TodoStatus {
 function projectionSource(value: unknown): TodoCompletionProjectionSource {
   if (value === "materialized" || value === "event_log") return value;
   throw new Error("projection_source is unsupported");
-}
-
-function normalizeNoFollowup(value: unknown): boolean | null {
-  if (typeof value === "boolean") return value;
-  if (value === null || value === undefined) return null;
-  if (typeof value !== "string") {
-    throw new Error("todo.no_followup must be a boolean, string, or null");
-  }
-  const candidate = value.trim().toLowerCase();
-  if (["1", "true", "yes", "y", "no_followup", "no-followup"].includes(candidate)) {
-    return true;
-  }
-  if (["0", "false", "no", "n"].includes(candidate)) return false;
-  return null;
-}
-
-function normalizeCompletionContinuation(
-  value: unknown,
-): TodoCompletionContinuation | null {
-  if (value === null || value === undefined || value === "") return null;
-  if (typeof value !== "string") {
-    throw new Error("todo.completion_continuation must be a string or null");
-  }
-  const candidate = value.trim().toLowerCase();
-  return COMPLETION_CONTINUATIONS.some((item) => item === candidate)
-    ? candidate as TodoCompletionContinuation
-    : null;
 }
 
 function successorTodoIds(value: unknown): string[] {
@@ -155,7 +148,7 @@ export function decodeTodoCompletionFenceRequest(
     projection_source: projectionSource(request.projection_source),
     todo: {
       status: todoStatus(todo.status),
-      no_followup: normalizeNoFollowup(todo.no_followup),
+      no_followup: todoNoFollowup(todo.no_followup),
       completion_continuation: optionalOpaqueString(
         todo.completion_continuation,
         "todo.completion_continuation",
@@ -182,7 +175,7 @@ export function evaluateTodoCompletionFence(
 ): TodoCompletionFenceResult {
   const request = decodeTodoCompletionFenceRequest(value);
   const status = request.todo.status;
-  const continuation = normalizeCompletionContinuation(
+  const continuation = todoCompletionContinuation(
     request.todo.completion_continuation,
   );
   const done = status === "done";
@@ -199,7 +192,7 @@ export function evaluateTodoCompletionFence(
   }
 
   const terminalUpgrade = done && request.requested_no_followup &&
-    normalizeNoFollowup(request.todo.no_followup) !== true;
+    normalizeTodoNoFollowup(request.todo.no_followup) !== true;
   if (terminalUpgrade) {
     if (request.todo.successor_todo_ids.length > 0) {
       throw new Error(

--- a/loopx/control_plane/todos/completion_state.py
+++ b/loopx/control_plane/todos/completion_state.py
@@ -1,73 +1,140 @@
-"""Typed durable continuation selected when a Todo becomes done."""
+"""Python compatibility facade for TypeScript-owned Todo completion state."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+from functools import lru_cache
 from typing import Any, Mapping
+
+from ..effect_runtime import EffectRuntimeRejected, effect_runtime_result
+
+
+TODO_COMPLETION_STATE_REQUEST_SCHEMA = "loopx_todo_completion_state_request_v0"
+TODO_COMPLETION_STATE_RESULT_SCHEMA = "loopx_todo_completion_state_result_v0"
 
 
 class TodoCompletionContinuation(str, Enum):
+    """Stable Python import compatibility for the persisted wire values."""
+
     ACTIVE_GOAL = "active_goal"
     SUCCESSOR = "successor"
     NO_FOLLOWUP = "no_followup"
 
 
 class TodoCompletionRecovery(str, Enum):
+    """Stable Python import compatibility for the persisted wire value."""
+
     SAME_TURN_TERMINAL_CLOSEOUT = "same_turn_terminal_closeout"
 
 
+def _string_value(value: Any) -> str:
+    return str(value or "")
+
+
+def _no_followup_value(value: Any) -> bool | str:
+    return value if isinstance(value, bool) else _string_value(value)
+
+
+def _successor_values(value: Any) -> Any:
+    if not value:
+        return []
+    if isinstance(value, (list, tuple, set, str, Mapping)):
+        return list(value)
+    return value
+
+
+def _result(method: str, params: dict[str, Any]) -> Mapping[str, Any]:
+    try:
+        result = effect_runtime_result(method, params)
+    except EffectRuntimeRejected as exc:
+        raise ValueError(str(exc)) from None
+    if not isinstance(result, Mapping):
+        raise RuntimeError("TypeScript Todo completion state result must be an object")
+    if result.get("schema_version") != TODO_COMPLETION_STATE_RESULT_SCHEMA:
+        raise RuntimeError("TypeScript Todo completion state result shape mismatch")
+    return result
+
+
+@lru_cache(maxsize=64)
+def _normalize_cached(kind: str, value: bool | str) -> bool | str | None:
+    result = _result(
+        "todo.completion_state.normalize",
+        {
+            "schema_version": TODO_COMPLETION_STATE_REQUEST_SCHEMA,
+            "kind": kind,
+            "value": value,
+        },
+    )
+    normalized = result.get("value")
+    if kind == "no_followup":
+        if normalized is not None and not isinstance(normalized, bool):
+            raise RuntimeError("TypeScript no_followup normalization shape mismatch")
+    elif normalized is not None and not isinstance(normalized, str):
+        raise RuntimeError(
+            "TypeScript completion metadata normalization shape mismatch"
+        )
+    return normalized
+
+
 def normalize_todo_no_followup(value: Any) -> bool | None:
-    if isinstance(value, bool):
-        return value
-    candidate = str(value or "").strip().lower()
-    if candidate in {"1", "true", "yes", "y", "no_followup", "no-followup"}:
-        return True
-    if candidate in {"0", "false", "no", "n"}:
-        return False
-    return None
+    normalized = _normalize_cached("no_followup", _no_followup_value(value))
+    return normalized if isinstance(normalized, bool) else None
 
 
 def normalize_todo_completion_continuation(value: Any) -> str | None:
-    candidate = str(value or "").strip().lower()
-    values = {item.value for item in TodoCompletionContinuation}
-    return candidate if candidate in values else None
+    normalized = _normalize_cached("continuation", _string_value(value))
+    return normalized if isinstance(normalized, str) else None
 
 
 def require_todo_completion_continuation(value: Any) -> str:
-    normalized = normalize_todo_completion_continuation(value)
-    if normalized:
-        return normalized
-    raise ValueError(
-        "completion_continuation must be one of: active_goal, successor, no_followup"
+    result = _result(
+        "todo.completion_state.require_metadata",
+        {
+            "schema_version": TODO_COMPLETION_STATE_REQUEST_SCHEMA,
+            "key": "completion_continuation",
+            "value": _string_value(value),
+        },
     )
+    normalized = result.get("value")
+    if not isinstance(normalized, str):
+        raise RuntimeError("TypeScript completion continuation result shape mismatch")
+    return normalized
 
 
 def normalize_todo_completion_recovery(value: Any) -> str | None:
-    candidate = str(value or "").strip().lower()
-    values = {item.value for item in TodoCompletionRecovery}
-    return candidate if candidate in values else None
+    normalized = _normalize_cached("recovery", _string_value(value))
+    return normalized if isinstance(normalized, str) else None
 
 
 def require_todo_completion_metadata(key: str, value: Any) -> str | None:
-    if key == "completion_continuation":
-        return require_todo_completion_continuation(value)
-    normalized = normalize_todo_completion_recovery(value)
-    if normalized or not value:
-        return normalized
-    raise ValueError("completion_recovery must be same_turn_terminal_closeout")
+    result = _result(
+        "todo.completion_state.require_metadata",
+        {
+            "schema_version": TODO_COMPLETION_STATE_REQUEST_SCHEMA,
+            "key": key,
+            "value": _string_value(value),
+        },
+    )
+    normalized = result.get("value")
+    if normalized is not None and not isinstance(normalized, str):
+        raise RuntimeError("TypeScript completion metadata result shape mismatch")
+    return normalized
 
 
-def completion_continuation_for_write(
-    *, no_followup: bool, has_successor: bool
-) -> str:
-    if no_followup and has_successor:
-        raise ValueError("todo completion cannot record both no_followup and a successor")
-    if no_followup:
-        return TodoCompletionContinuation.NO_FOLLOWUP.value
-    if has_successor:
-        return TodoCompletionContinuation.SUCCESSOR.value
-    return TodoCompletionContinuation.ACTIVE_GOAL.value
+def completion_continuation_for_write(*, no_followup: bool, has_successor: bool) -> str:
+    result = _result(
+        "todo.completion_state.continuation_for_write",
+        {
+            "schema_version": TODO_COMPLETION_STATE_REQUEST_SCHEMA,
+            "no_followup": no_followup,
+            "has_successor": has_successor,
+        },
+    )
+    continuation = result.get("continuation")
+    if continuation not in {item.value for item in TodoCompletionContinuation}:
+        raise RuntimeError("TypeScript completion continuation result shape mismatch")
+    return str(continuation)
 
 
 @dataclass(frozen=True, slots=True)
@@ -82,27 +149,32 @@ def completion_state_for_todo_write(
     requested_no_followup: bool,
     has_successor: bool,
 ) -> TodoCompletionState:
-    """Select durable state and audit the one supported recovery transition."""
-
-    effective_no_followup = (
-        requested_no_followup
-        or normalize_todo_no_followup(todo.get("no_followup")) is True
+    result = _result(
+        "todo.completion_state.evaluate",
+        {
+            "schema_version": TODO_COMPLETION_STATE_REQUEST_SCHEMA,
+            "todo": {
+                "status": str(todo.get("status") or ""),
+                "no_followup": _no_followup_value(todo.get("no_followup")),
+                "completion_continuation": _string_value(
+                    todo.get("completion_continuation")
+                ),
+            },
+            "requested_no_followup": requested_no_followup,
+            "has_successor": has_successor,
+        },
     )
-    continuation = completion_continuation_for_write(
-        no_followup=effective_no_followup,
-        has_successor=has_successor,
-    )
-    recovery = None
-    if (
-        str(todo.get("status") or "") == "done"
-        and requested_no_followup
-        and normalize_todo_completion_continuation(
-            todo.get("completion_continuation")
-        )
-        == TodoCompletionContinuation.ACTIVE_GOAL.value
+    continuation = result.get("continuation")
+    recovery = result.get("recovery")
+    if continuation not in {item.value for item in TodoCompletionContinuation} or (
+        recovery is not None
+        and recovery not in {item.value for item in TodoCompletionRecovery}
     ):
-        recovery = TodoCompletionRecovery.SAME_TURN_TERMINAL_CLOSEOUT.value
-    return TodoCompletionState(continuation=continuation, recovery=recovery)
+        raise RuntimeError("TypeScript Todo completion state result shape mismatch")
+    return TodoCompletionState(
+        continuation=str(continuation),
+        recovery=str(recovery) if recovery is not None else None,
+    )
 
 
 def completion_metadata_updates(
@@ -115,35 +187,32 @@ def completion_metadata_updates(
     no_followup: bool | None,
     successor_todo_ids: list[str] | None,
 ) -> dict[str, Any]:
-    """Build explicit completion metadata, including repair of untyped rows."""
-
-    updates: dict[str, Any] = {}
-    if completion_continuation is not None:
-        updates["completion_continuation"] = completion_continuation
-    if completion_recovery is not None:
-        updates["completion_recovery"] = completion_recovery
-    if not (
-        target_status == "done"
-        and normalized_status == "done"
-        and completion_continuation is None
-        and normalize_todo_completion_continuation(
-            block.get("completion_continuation")
-        )
-        is None
+    result = _result(
+        "todo.completion_state.metadata_updates",
+        {
+            "schema_version": TODO_COMPLETION_STATE_REQUEST_SCHEMA,
+            "block": {
+                "no_followup": _no_followup_value(block.get("no_followup")),
+                "completion_continuation": _string_value(
+                    block.get("completion_continuation")
+                ),
+                "successor_todo_ids": _successor_values(
+                    block.get("successor_todo_ids")
+                ),
+            },
+            "target_status": target_status,
+            "normalized_status": normalized_status,
+            "completion_continuation": completion_continuation,
+            "completion_recovery": completion_recovery,
+            "no_followup": no_followup,
+            "successor_todo_ids": successor_todo_ids,
+        },
+    )
+    updates = result.get("updates")
+    if not isinstance(updates, Mapping) or any(
+        key not in {"completion_continuation", "completion_recovery"}
+        or not isinstance(value, str)
+        for key, value in updates.items()
     ):
-        return updates
-    effective_no_followup = (
-        no_followup
-        if no_followup is not None
-        else normalize_todo_no_followup(block.get("no_followup")) is True
-    )
-    effective_successors = (
-        successor_todo_ids
-        if successor_todo_ids is not None
-        else list(block.get("successor_todo_ids") or [])
-    )
-    updates["completion_continuation"] = completion_continuation_for_write(
-        no_followup=bool(effective_no_followup),
-        has_successor=bool(effective_successors),
-    )
-    return updates
+        raise RuntimeError("TypeScript completion metadata updates shape mismatch")
+    return dict(updates)

--- a/loopx/control_plane/todos/completion_state.ts
+++ b/loopx/control_plane/todos/completion_state.ts
@@ -1,0 +1,264 @@
+import type { JsonObject } from "../effect_program.ts";
+
+export const TODO_COMPLETION_STATE_REQUEST_SCHEMA =
+  "loopx_todo_completion_state_request_v0";
+export const TODO_COMPLETION_STATE_RESULT_SCHEMA =
+  "loopx_todo_completion_state_result_v0";
+
+export const TODO_COMPLETION_CONTINUATIONS = [
+  "active_goal",
+  "successor",
+  "no_followup",
+] as const;
+export const TODO_COMPLETION_RECOVERIES = [
+  "same_turn_terminal_closeout",
+] as const;
+
+export type TodoCompletionContinuation =
+  (typeof TODO_COMPLETION_CONTINUATIONS)[number];
+export type TodoCompletionRecovery =
+  (typeof TODO_COMPLETION_RECOVERIES)[number];
+export type TodoCompletionNormalizationKind =
+  | "no_followup"
+  | "continuation"
+  | "recovery";
+
+export interface TodoCompletionStateResult extends JsonObject {
+  schema_version: typeof TODO_COMPLETION_STATE_RESULT_SCHEMA;
+  continuation: TodoCompletionContinuation;
+  recovery: TodoCompletionRecovery | null;
+}
+
+function requiredObject(value: unknown, label: string): JsonObject {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as JsonObject;
+}
+
+function requiredBoolean(value: unknown, label: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new Error(`${label} must be a boolean`);
+  }
+  return value;
+}
+
+function optionalBoolean(value: unknown, label: string): boolean | null {
+  if (value === null || value === undefined) return null;
+  return requiredBoolean(value, label);
+}
+
+function optionalString(value: unknown, label: string): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== "string") {
+    throw new Error(`${label} must be a string or null`);
+  }
+  return value;
+}
+
+function stringArray(value: unknown, label: string): string[] {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    throw new Error(`${label} must be an array of strings`);
+  }
+  return [...value];
+}
+
+function requestObject(value: unknown, operation: string): JsonObject {
+  const request = requiredObject(value, `todo.completion_state.${operation} params`);
+  if (request.schema_version !== TODO_COMPLETION_STATE_REQUEST_SCHEMA) {
+    throw new Error("Todo completion state request schema mismatch");
+  }
+  return request;
+}
+
+export function normalizeTodoNoFollowup(value: unknown): boolean | null {
+  if (typeof value === "boolean") return value;
+  if (value === null || value === undefined) return null;
+  if (typeof value !== "string") {
+    throw new Error("no_followup must be a boolean, string, or null");
+  }
+  const candidate = value.trim().toLowerCase();
+  if (["1", "true", "yes", "y", "no_followup", "no-followup"].includes(candidate)) {
+    return true;
+  }
+  if (["0", "false", "no", "n"].includes(candidate)) return false;
+  return null;
+}
+
+export function normalizeTodoCompletionContinuation(
+  value: unknown,
+): TodoCompletionContinuation | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== "string") {
+    throw new Error("completion_continuation must be a string or null");
+  }
+  const candidate = value.trim().toLowerCase();
+  return TODO_COMPLETION_CONTINUATIONS.some((item) => item === candidate)
+    ? candidate as TodoCompletionContinuation
+    : null;
+}
+
+export function requireTodoCompletionContinuation(
+  value: unknown,
+): TodoCompletionContinuation {
+  const normalized = normalizeTodoCompletionContinuation(value);
+  if (normalized !== null) return normalized;
+  throw new Error(
+    "completion_continuation must be one of: active_goal, successor, no_followup",
+  );
+}
+
+export function normalizeTodoCompletionRecovery(
+  value: unknown,
+): TodoCompletionRecovery | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== "string") {
+    throw new Error("completion_recovery must be a string or null");
+  }
+  const candidate = value.trim().toLowerCase();
+  return TODO_COMPLETION_RECOVERIES.some((item) => item === candidate)
+    ? candidate as TodoCompletionRecovery
+    : null;
+}
+
+export function requireTodoCompletionMetadata(
+  key: string,
+  value: unknown,
+): TodoCompletionContinuation | TodoCompletionRecovery | null {
+  if (key === "completion_continuation") {
+    return requireTodoCompletionContinuation(value);
+  }
+  const normalized = normalizeTodoCompletionRecovery(value);
+  if (normalized !== null || value === null || value === undefined || value === "") {
+    return normalized;
+  }
+  throw new Error("completion_recovery must be same_turn_terminal_closeout");
+}
+
+export function completionContinuationForWrite(
+  noFollowup: boolean,
+  hasSuccessor: boolean,
+): TodoCompletionContinuation {
+  if (noFollowup && hasSuccessor) {
+    throw new Error("todo completion cannot record both no_followup and a successor");
+  }
+  if (noFollowup) return "no_followup";
+  if (hasSuccessor) return "successor";
+  return "active_goal";
+}
+
+export function normalizeTodoCompletionValue(value: unknown): JsonObject {
+  const request = requestObject(value, "normalize");
+  const kind = request.kind;
+  if (kind !== "no_followup" && kind !== "continuation" && kind !== "recovery") {
+    throw new Error("completion normalization kind is unsupported");
+  }
+  const raw = request.value;
+  const normalized = kind === "no_followup"
+    ? normalizeTodoNoFollowup(raw)
+    : kind === "continuation"
+    ? normalizeTodoCompletionContinuation(raw)
+    : normalizeTodoCompletionRecovery(raw);
+  return {
+    schema_version: TODO_COMPLETION_STATE_RESULT_SCHEMA,
+    kind,
+    value: normalized,
+  };
+}
+
+export function requireTodoCompletionMetadataValue(value: unknown): JsonObject {
+  const request = requestObject(value, "require_metadata");
+  const key = optionalString(request.key, "key");
+  if (key === null) throw new Error("key must be a string");
+  return {
+    schema_version: TODO_COMPLETION_STATE_RESULT_SCHEMA,
+    value: requireTodoCompletionMetadata(key, request.value),
+  };
+}
+
+export function selectTodoCompletionContinuation(value: unknown): JsonObject {
+  const request = requestObject(value, "continuation_for_write");
+  return {
+    schema_version: TODO_COMPLETION_STATE_RESULT_SCHEMA,
+    continuation: completionContinuationForWrite(
+      requiredBoolean(request.no_followup, "no_followup"),
+      requiredBoolean(request.has_successor, "has_successor"),
+    ),
+  };
+}
+
+export function selectTodoCompletionState(value: unknown): TodoCompletionStateResult {
+  const request = requestObject(value, "evaluate");
+  const todo = requiredObject(request.todo, "todo");
+  const requestedNoFollowup = requiredBoolean(
+    request.requested_no_followup,
+    "requested_no_followup",
+  );
+  const effectiveNoFollowup = requestedNoFollowup ||
+    normalizeTodoNoFollowup(todo.no_followup) === true;
+  const continuation = completionContinuationForWrite(
+    effectiveNoFollowup,
+    requiredBoolean(request.has_successor, "has_successor"),
+  );
+  const recovery = String(todo.status ?? "") === "done" &&
+      requestedNoFollowup &&
+      normalizeTodoCompletionContinuation(todo.completion_continuation) ===
+        "active_goal"
+    ? "same_turn_terminal_closeout"
+    : null;
+  return {
+    schema_version: TODO_COMPLETION_STATE_RESULT_SCHEMA,
+    continuation,
+    recovery,
+  };
+}
+
+export function buildTodoCompletionMetadataUpdates(value: unknown): JsonObject {
+  const request = requestObject(value, "metadata_updates");
+  const block = requiredObject(request.block, "block");
+  const completionContinuation = optionalString(
+    request.completion_continuation,
+    "completion_continuation",
+  );
+  const completionRecovery = optionalString(
+    request.completion_recovery,
+    "completion_recovery",
+  );
+  const updates: JsonObject = {};
+  if (completionContinuation !== null) {
+    updates.completion_continuation = completionContinuation;
+  }
+  if (completionRecovery !== null) updates.completion_recovery = completionRecovery;
+
+  const targetStatus = optionalString(request.target_status, "target_status");
+  const normalizedStatus = optionalString(
+    request.normalized_status,
+    "normalized_status",
+  );
+  if (
+    targetStatus !== "done" || normalizedStatus !== "done" ||
+    completionContinuation !== null ||
+    normalizeTodoCompletionContinuation(block.completion_continuation) !== null
+  ) {
+    return {
+      schema_version: TODO_COMPLETION_STATE_RESULT_SCHEMA,
+      updates,
+    };
+  }
+
+  const requestedNoFollowup = optionalBoolean(request.no_followup, "no_followup");
+  const effectiveNoFollowup = requestedNoFollowup === null
+    ? normalizeTodoNoFollowup(block.no_followup) === true
+    : requestedNoFollowup;
+  const successorTodoIds = request.successor_todo_ids === null
+    ? stringArray(block.successor_todo_ids, "block.successor_todo_ids")
+    : stringArray(request.successor_todo_ids, "successor_todo_ids");
+  updates.completion_continuation = completionContinuationForWrite(
+    effectiveNoFollowup,
+    successorTodoIds.length > 0,
+  );
+  return {
+    schema_version: TODO_COMPLETION_STATE_RESULT_SCHEMA,
+    updates,
+  };
+}

--- a/tests/control_plane/test_todo_completion_state_runtime.py
+++ b/tests/control_plane/test_todo_completion_state_runtime.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import pytest
+
+from loopx.control_plane import effect_runtime
+from loopx.control_plane.todos import completion_state
+
+
+def _result(**values: object) -> dict[str, object]:
+    return {
+        "schema_version": completion_state.TODO_COMPLETION_STATE_RESULT_SCHEMA,
+        **values,
+    }
+
+
+def test_python_facade_sends_one_typed_state_request(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def call(method: str, params: dict[str, object]) -> dict[str, object]:
+        captured["method"] = method
+        captured["params"] = params
+        return _result(
+            continuation="no_followup",
+            recovery="same_turn_terminal_closeout",
+        )
+
+    monkeypatch.setattr(completion_state, "effect_runtime_result", call)
+
+    state = completion_state.completion_state_for_todo_write(
+        {
+            "status": "done",
+            "no_followup": "false",
+            "completion_continuation": "active_goal",
+        },
+        requested_no_followup=True,
+        has_successor=False,
+    )
+
+    assert state == completion_state.TodoCompletionState(
+        continuation="no_followup",
+        recovery="same_turn_terminal_closeout",
+    )
+    assert captured == {
+        "method": "todo.completion_state.evaluate",
+        "params": {
+            "schema_version": completion_state.TODO_COMPLETION_STATE_REQUEST_SCHEMA,
+            "todo": {
+                "status": "done",
+                "no_followup": "false",
+                "completion_continuation": "active_goal",
+            },
+            "requested_no_followup": True,
+            "has_successor": False,
+        },
+    }
+
+
+def test_scalar_normalization_uses_bounded_process_cache(monkeypatch) -> None:
+    calls = 0
+
+    def call(_method: str, params: dict[str, object]) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        return _result(kind=params["kind"], value=True)
+
+    completion_state._normalize_cached.cache_clear()
+    monkeypatch.setattr(completion_state, "effect_runtime_result", call)
+
+    assert completion_state.normalize_todo_no_followup("YES") is True
+    assert completion_state.normalize_todo_no_followup("YES") is True
+    assert calls == 1
+    completion_state._normalize_cached.cache_clear()
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    [
+        None,
+        {},
+        _result(continuation="implicit", recovery=None),
+        _result(continuation="active_goal", recovery="best_effort"),
+    ],
+)
+def test_python_facade_rejects_malformed_state_results(
+    monkeypatch, malformed: object
+) -> None:
+    monkeypatch.setattr(
+        completion_state,
+        "effect_runtime_result",
+        lambda _method, _params: malformed,
+    )
+
+    with pytest.raises(RuntimeError, match="result (must be|shape mismatch)"):
+        completion_state.completion_state_for_todo_write(
+            {"status": "open"},
+            requested_no_followup=False,
+            has_successor=False,
+        )
+
+
+def test_python_facade_preserves_typed_rejection_as_value_error(monkeypatch) -> None:
+    def reject(_method: str, _params: dict[str, object]) -> object:
+        raise effect_runtime.EffectRuntimeRejected("typed state rejected")
+
+    monkeypatch.setattr(completion_state, "effect_runtime_result", reject)
+
+    with pytest.raises(ValueError, match="typed state rejected"):
+        completion_state.completion_continuation_for_write(
+            no_followup=True,
+            has_successor=True,
+        )

--- a/tests/control_plane_ts/todo_completion_state.test.ts
+++ b/tests/control_plane_ts/todo_completion_state.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  buildTodoCompletionMetadataUpdates,
+  normalizeTodoCompletionValue,
+  requireTodoCompletionMetadataValue,
+  selectTodoCompletionContinuation,
+  selectTodoCompletionState,
+  TODO_COMPLETION_STATE_REQUEST_SCHEMA,
+} from "../../loopx/control_plane/todos/completion_state.ts";
+
+const fixture = JSON.parse(
+  readFileSync(
+    new URL(
+      "../fixtures/control_plane/todo_completion_state_characterization_v0.json",
+      import.meta.url,
+    ),
+    "utf8",
+  ),
+) as {
+  schema_version: string;
+  source_baseline: string;
+  cases: Array<{
+    name: string;
+    method: "normalize" | "require_metadata" | "continuation_for_write" |
+      "evaluate" | "metadata_updates";
+    request: Record<string, unknown>;
+    expected_result?: Record<string, unknown>;
+    expected_error?: string;
+  }>;
+};
+
+const methods = {
+  normalize: normalizeTodoCompletionValue,
+  require_metadata: requireTodoCompletionMetadataValue,
+  continuation_for_write: selectTodoCompletionContinuation,
+  evaluate: selectTodoCompletionState,
+  metadata_updates: buildTodoCompletionMetadataUpdates,
+} as const;
+
+test("pinned Python completion-state characterization remains exact", () => {
+  assert.equal(
+    fixture.schema_version,
+    "loopx_todo_completion_state_characterization_v0",
+  );
+  assert.equal(fixture.source_baseline, "0c59d47f6");
+  assert.equal(fixture.cases.length, 11);
+  for (const item of fixture.cases) {
+    const evaluate = methods[item.method];
+    if (item.expected_error) {
+      assert.throws(
+        () => evaluate(item.request),
+        (error: unknown) =>
+          error instanceof Error && error.message === item.expected_error,
+        item.name,
+      );
+    } else {
+      assert.deepEqual(evaluate(item.request), item.expected_result, item.name);
+    }
+  }
+});
+
+test("runtime boundary rejects malformed authority input", () => {
+  const valid = {
+    schema_version: TODO_COMPLETION_STATE_REQUEST_SCHEMA,
+    todo: {
+      status: "open",
+      no_followup: false,
+      completion_continuation: "",
+    },
+    requested_no_followup: false,
+    has_successor: false,
+  };
+  assert.throws(
+    () => selectTodoCompletionState({ ...valid, schema_version: "v1" }),
+    /schema mismatch/,
+  );
+  assert.throws(
+    () => selectTodoCompletionState({ ...valid, requested_no_followup: "false" }),
+    /requested_no_followup must be a boolean/,
+  );
+  assert.throws(
+    () => buildTodoCompletionMetadataUpdates({
+      schema_version: TODO_COMPLETION_STATE_REQUEST_SCHEMA,
+      block: { successor_todo_ids: [42] },
+      target_status: "done",
+      normalized_status: "done",
+      completion_continuation: null,
+      completion_recovery: null,
+      no_followup: null,
+      successor_todo_ids: null,
+    }),
+    /array of strings/,
+  );
+});
+
+test("state and metadata decisions do not mutate caller input", () => {
+  const request = fixture.cases.find((item) => item.method === "evaluate")!.request;
+  const before = structuredClone(request);
+  selectTodoCompletionState(request);
+  assert.deepEqual(request, before);
+
+  const metadata = fixture.cases.find(
+    (item) => item.method === "metadata_updates",
+  )!.request;
+  const metadataBefore = structuredClone(metadata);
+  buildTodoCompletionMetadataUpdates(metadata);
+  assert.deepEqual(metadata, metadataBefore);
+});

--- a/tests/fixtures/control_plane/todo_completion_state_characterization_v0.json
+++ b/tests/fixtures/control_plane/todo_completion_state_characterization_v0.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "loopx_todo_completion_state_characterization_v0",
+  "source_baseline": "0c59d47f6",
+  "cases": [
+    {
+      "name": "truthy no-followup token",
+      "method": "normalize",
+      "request": {"schema_version": "loopx_todo_completion_state_request_v0", "kind": "no_followup", "value": "YES"},
+      "expected_result": {"schema_version": "loopx_todo_completion_state_result_v0", "kind": "no_followup", "value": true}
+    },
+    {
+      "name": "unknown no-followup token",
+      "method": "normalize",
+      "request": {"schema_version": "loopx_todo_completion_state_request_v0", "kind": "no_followup", "value": "maybe"},
+      "expected_result": {"schema_version": "loopx_todo_completion_state_result_v0", "kind": "no_followup", "value": null}
+    },
+    {
+      "name": "continuation normalization",
+      "method": "normalize",
+      "request": {"schema_version": "loopx_todo_completion_state_request_v0", "kind": "continuation", "value": "SUCCESSOR"},
+      "expected_result": {"schema_version": "loopx_todo_completion_state_result_v0", "kind": "continuation", "value": "successor"}
+    },
+    {
+      "name": "invalid required continuation",
+      "method": "require_metadata",
+      "request": {"schema_version": "loopx_todo_completion_state_request_v0", "key": "completion_continuation", "value": "implicit"},
+      "expected_error": "completion_continuation must be one of: active_goal, successor, no_followup"
+    },
+    {
+      "name": "empty optional recovery",
+      "method": "require_metadata",
+      "request": {"schema_version": "loopx_todo_completion_state_request_v0", "key": "completion_recovery", "value": ""},
+      "expected_result": {"schema_version": "loopx_todo_completion_state_result_v0", "value": null}
+    },
+    {
+      "name": "contradictory terminal write",
+      "method": "continuation_for_write",
+      "request": {"schema_version": "loopx_todo_completion_state_request_v0", "no_followup": true, "has_successor": true},
+      "expected_error": "todo completion cannot record both no_followup and a successor"
+    },
+    {
+      "name": "ordinary completion keeps goal active",
+      "method": "evaluate",
+      "request": {"schema_version": "loopx_todo_completion_state_request_v0", "todo": {"status": "open", "no_followup": false, "completion_continuation": ""}, "requested_no_followup": false, "has_successor": false},
+      "expected_result": {"schema_version": "loopx_todo_completion_state_result_v0", "continuation": "active_goal", "recovery": null}
+    },
+    {
+      "name": "persisted no-followup wins",
+      "method": "evaluate",
+      "request": {"schema_version": "loopx_todo_completion_state_request_v0", "todo": {"status": "done", "no_followup": "true", "completion_continuation": "no_followup"}, "requested_no_followup": false, "has_successor": false},
+      "expected_result": {"schema_version": "loopx_todo_completion_state_result_v0", "continuation": "no_followup", "recovery": null}
+    },
+    {
+      "name": "same-turn terminal closeout is the only recovery",
+      "method": "evaluate",
+      "request": {"schema_version": "loopx_todo_completion_state_request_v0", "todo": {"status": "done", "no_followup": false, "completion_continuation": "active_goal"}, "requested_no_followup": true, "has_successor": false},
+      "expected_result": {"schema_version": "loopx_todo_completion_state_result_v0", "continuation": "no_followup", "recovery": "same_turn_terminal_closeout"}
+    },
+    {
+      "name": "repair untyped completed successor",
+      "method": "metadata_updates",
+      "request": {"schema_version": "loopx_todo_completion_state_request_v0", "block": {"no_followup": false, "completion_continuation": "", "successor_todo_ids": ["todo_next001"]}, "target_status": "done", "normalized_status": "done", "completion_continuation": null, "completion_recovery": null, "no_followup": null, "successor_todo_ids": null},
+      "expected_result": {"schema_version": "loopx_todo_completion_state_result_v0", "updates": {"completion_continuation": "successor"}}
+    },
+    {
+      "name": "explicit completion metadata is preserved",
+      "method": "metadata_updates",
+      "request": {"schema_version": "loopx_todo_completion_state_request_v0", "block": {"no_followup": false, "completion_continuation": "active_goal", "successor_todo_ids": []}, "target_status": "done", "normalized_status": "done", "completion_continuation": "no_followup", "completion_recovery": "same_turn_terminal_closeout", "no_followup": true, "successor_todo_ids": []},
+      "expected_result": {"schema_version": "loopx_todo_completion_state_result_v0", "updates": {"completion_continuation": "no_followup", "completion_recovery": "same_turn_terminal_closeout"}}
+    }
+  ]
+}

--- a/tsconfig.control-plane.json
+++ b/tsconfig.control-plane.json
@@ -17,11 +17,13 @@
     "loopx/control_plane/effect_runtime_io.ts",
     "loopx/control_plane/effect_runtime_server.ts",
     "loopx/control_plane/todos/completion_fence.ts",
+    "loopx/control_plane/todos/completion_state.ts",
     "loopx/control_plane/todos/next_action.ts",
     "loopx/control_plane/turn_driver/turn_journal.ts",
     "loopx/control_plane/turn_driver/turn_journal_effects.ts",
     "tests/control_plane_ts/effect_program.test.ts",
     "tests/control_plane_ts/todo_completion_fence.test.ts",
+    "tests/control_plane_ts/todo_completion_state.test.ts",
     "tests/control_plane_ts/todo_next_action.test.ts",
     "tests/control_plane_ts/turn_journal.test.ts",
     "tests/control_plane_ts/turn_journal_effects.test.ts"


### PR DESCRIPTION
## Outcome

Moves the complete Todo completion-state decision set to the existing managed TypeScript Effect runtime while keeping the Python API as a transport-compatible facade.

This is the next bounded Strangler Fig slice after the completion fence: TypeScript now owns normalization, the three-way continuation decision, same-turn terminal recovery, and legacy metadata repair. Python retains stable enums/DTOs, bounded scalar caching, transport, and runtime-result validation. The completion fence imports the same TS normalizers, so the rules have one owner rather than two implementations.

## Compatibility and performance

- Characterization fixture pins 11 decisions and failures against `0c59d47f6`.
- Public Python imports and persisted wire values remain unchanged.
- Managed runtime is reused; no second daemon or state store is introduced.
- Warm state-decision latency over 500 calls: p50 0.329 ms, p95 0.756 ms.
- Cached scalar normalization over 5,000 calls: p95 0.000167 ms.
- Wheel and sdist both contain the TS authority and passed isolated installation probes.

## Validation

- `npm run typecheck:control-plane`
- `npm run test:control-plane` — 40 passed
- focused Todo facade/fence/metadata/mutation/projection tests — 90 passed
- settlement, goal-mode and MCP-boundary caller tests — 47 passed
- `uv run mypy loopx/control_plane/todos/completion_state.py`
- Ruff lint and format checks on changed Python paths
- wheel + sdist isolated install probes
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` — 17/17 selected checks passed, no manual holds
- change-quality receipt `cqr_4cc3fb32a39232d5b2ac`

The first MCP-boundary invocation lacked the repository's optional `mcp` test dependency; rerunning it through the declared `--extra test` environment passed. No model-behavior test is added because this slice changes a deterministic machine-enforced state transition and does not alter model-visible instructions or action selection.
