### PR TITLE
fix(todos): gate event-projected completion validation

### DIFF
--- a/loopx/control_plane/todos/completion_validation.py
+++ b/loopx/control_plane/todos/completion_validation.py
@@ -5,14 +5,21 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+from ...event_sourced_state import (
+    AppendOnlyStateEventStore,
+    StateEventError,
+    build_state_projection,
+)
 from ...history import load_registry
 from ...materials import find_registry_goal, goal_repo
+from ..goals.active_state_event_projection import state_event_log_candidates
+from ..goals.path_resolution import resolve_goal_local_path
 from ..runtime.validation_command import (
     CALLER_VALIDATION_RECEIPT_SCHEMA_VERSION,
     run_caller_validation,
 )
 from .active_state_editing import find_todo_block
-from .contract import TODO_STATUS_DONE
+from .contract import TODO_STATUS_DONE, normalize_todo_id
 
 # Kept safely under the 30s outer CLI/MCP subprocess budget so a timed-out
 # validation still produces a typed receipt before the outer call is killed.
@@ -33,35 +40,10 @@ def _resolve_goal_repo_workspace(registry_path: Path, goal_id: str) -> Path | No
     return repo
 
 
-def _read_declared_validation(
-    *, state_file: Path, todo_id: str, role: str | None
+def _declaration_from_mapping(
+    block: dict[str, Any],
 ) -> tuple[str | None, list[str] | None, str | None, int | None, bool]:
-    """Pre-read a todo's declared validation command without the mutation lock.
-
-    Returns ``(validation_command, validation_argv, validation_label,
-    validation_timeout_seconds, already_completed)`` from the markdown state
-    file, or ``(None, None, None, None, False)`` when the todo is not
-    materialized in markdown. Read-only; safe to call before acquiring the
-    state-file lock so a slow validation command does not block concurrent todo
-    operations on the same goal (the MUTATION lock deadline is 5s).
-    ``validation_command``, ``validation_command_argv`` and
-    ``validation_timeout_seconds`` are set only at ``todo add`` and have no
-    update path, so the values cannot drift between this pre-read and the
-    in-lock commit. A stored timeout that fails to parse as an int falls back
-    to ``None`` (the default), matching the writer-side range check that
-    guarantees a well-formed value. A stored argv that fails to parse as a
-    non-empty string list collapses to ``[]`` — never to ``None`` — so a
-    corrupted declaration still runs the gate and fails closed as a malformed
-    command instead of silently skipping validation.
-    """
-    try:
-        lines = state_file.read_text(encoding="utf-8").splitlines()
-    except FileNotFoundError:
-        return None, None, None, None, False
-    match = find_todo_block(lines, todo_id=todo_id, role=role)
-    if not match:
-        return None, None, None, None, False
-    _role, _section, _start, _end, block = match
+    """Parse a stored validation declaration from markdown or event projection."""
     try:
         timeout_seconds: int | None = (
             int(block["validation_timeout_seconds"])
@@ -71,11 +53,15 @@ def _read_declared_validation(
     except (TypeError, ValueError):
         timeout_seconds = None
     validation_argv: list[str] | None = None
-    if block.get("validation_command_argv"):
-        try:
-            parsed_argv = json.loads(block["validation_command_argv"])
-        except ValueError:
-            parsed_argv = None
+    raw_argv = block.get("validation_command_argv")
+    if raw_argv is not None and raw_argv != "":
+        if isinstance(raw_argv, list):
+            parsed_argv: Any = raw_argv
+        else:
+            try:
+                parsed_argv = json.loads(raw_argv)
+            except ValueError:
+                parsed_argv = None
         if (
             isinstance(parsed_argv, list)
             and parsed_argv
@@ -84,13 +70,121 @@ def _read_declared_validation(
             validation_argv = parsed_argv
         else:
             validation_argv = []
+    already_completed = (
+        block.get("status") == TODO_STATUS_DONE or block.get("done") is True
+    )
     return (
         block.get("validation_command") or None,
         validation_argv,
         block.get("validation_label") or None,
         timeout_seconds,
-        block.get("status") == TODO_STATUS_DONE,
+        already_completed,
     )
+
+
+def _event_projected_todo_item(
+    *,
+    state_file: Path,
+    todo_id: str,
+    role: str | None,
+    registry_path: Path,
+    goal_id: str,
+) -> dict[str, Any] | None:
+    """Read one todo from the append-only event log without holding the lock.
+
+    Do not reuse ``event_projection_todo_context`` here. That helper renders
+    Markdown and runs the public status projector, which strips
+    ``validation_command`` / argv down to ``completion_validation_required``.
+    The completion gate needs the actual declared command, so it must read the
+    raw event-sourced projection. When multiple logs contain the same todo,
+    a later log that still carries a validation declaration wins over an
+    earlier log that only has the todo identity; otherwise an older undeclared
+    snapshot would skip the gate.
+    """
+    goal = find_registry_goal(load_registry(registry_path), goal_id)
+    if goal is None:
+        log_paths = [state_file.with_name("events.jsonl")]
+    else:
+        log_paths = state_event_log_candidates(
+            goal,
+            state_path=state_file,
+            resolve_goal_local_path=resolve_goal_local_path,
+        )
+    normalized_todo_id = normalize_todo_id(todo_id) or todo_id
+    roles = [role] if role in {"user", "agent"} else ["user", "agent"]
+    undeclared_item: dict[str, Any] | None = None
+    for log_path in log_paths:
+        if not log_path.exists():
+            continue
+        try:
+            events = AppendOnlyStateEventStore(log_path).load()
+            if not events:
+                continue
+            projection = build_state_projection(events, goal_id=goal_id or None)
+        except (OSError, StateEventError):
+            continue
+        for item_role in roles:
+            summary = projection.get(f"{item_role}_todos") or {}
+            items = summary.get("items") if isinstance(summary, dict) else []
+            for item in items if isinstance(items, list) else []:
+                if not isinstance(item, dict):
+                    continue
+                if (normalize_todo_id(item.get("todo_id")) or "") != normalized_todo_id:
+                    continue
+                command, argv, _label, _timeout, _done = _declaration_from_mapping(item)
+                if command or argv is not None:
+                    return item
+                if undeclared_item is None:
+                    undeclared_item = item
+    return undeclared_item
+
+
+def _read_declared_validation(
+    *,
+    state_file: Path,
+    todo_id: str,
+    role: str | None,
+    registry_path: Path,
+    goal_id: str,
+) -> tuple[str | None, list[str] | None, str | None, int | None, bool]:
+    """Pre-read a todo's declared validation command without the mutation lock.
+
+    Returns ``(validation_command, validation_argv, validation_label,
+    validation_timeout_seconds, already_completed)`` from the markdown state
+    file, or from the event-sourced projection when the todo exists only in
+    the append-only log. Missing todos return
+    ``(None, None, None, None, False)``. Read-only; safe to call before
+    acquiring the state-file lock so a slow validation command does not block
+    concurrent todo operations on the same goal (the MUTATION lock deadline
+    is 5s). ``validation_command``, ``validation_command_argv`` and
+    ``validation_timeout_seconds`` are set only at ``todo add`` and have no
+    update path, so the values cannot drift between this pre-read and the
+    in-lock commit. A stored timeout that fails to parse as an int falls back
+    to ``None`` (the default), matching the writer-side range check that
+    guarantees a well-formed value. A stored argv that fails to parse as a
+    non-empty string list collapses to ``[]`` — never to ``None`` — so a
+    corrupted declaration still runs the gate and fails closed as a malformed
+    command instead of silently skipping validation. Markdown remains
+    authoritative when the todo is materialized there.
+    """
+    try:
+        lines = state_file.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        lines = []
+    match = find_todo_block(lines, todo_id=todo_id, role=role) if lines else None
+    if match:
+        _role, _section, _start, _end, block = match
+        return _declaration_from_mapping(block)
+    item = _event_projected_todo_item(
+        state_file=state_file,
+        todo_id=todo_id,
+        role=role,
+        registry_path=registry_path,
+        goal_id=goal_id,
+    )
+    if item is None:
+        return None, None, None, None, False
+    return _declaration_from_mapping(item)
 
 
 def _run_declared_completion_validation(
@@ -221,7 +315,13 @@ def run_completion_validation_gate(
         validation_label,
         validation_timeout_seconds,
         already_completed,
-    ) = _read_declared_validation(state_file=state_file, todo_id=todo_id, role=role)
+    ) = _read_declared_validation(
+        state_file=state_file,
+        todo_id=todo_id,
+        role=role,
+        registry_path=registry_path,
+        goal_id=goal_id,
+    )
     completion_validation = (
         _run_declared_completion_validation(
             validation_command=validation_command,

--- a/loopx/control_plane/todos/completion_validation_projection.py
+++ b/loopx/control_plane/todos/completion_validation_projection.py
@@ -15,10 +15,12 @@ def project_completion_validation_authority(item: dict[str, Any]) -> dict[str, A
     """Replace private validation execution details with one authority marker."""
 
     projected = dict(item)
-    required = bool(str(projected.pop("validation_command", "") or "").strip())
+    command = str(projected.pop("validation_command", "") or "").strip()
+    argv = projected.pop("validation_command_argv", None)
     projected.pop("validation_label", None)
     projected.pop("validation_timeout_seconds", None)
-    if required:
+    argv_declared = argv is not None and str(argv).strip() != ""
+    if command or argv_declared:
         projected["completion_validation_required"] = True
     return projected
 

--- a/loopx/event_sourced_state.py
+++ b/loopx/event_sourced_state.py
@@ -116,6 +116,32 @@ def compact_text(value: Any) -> str:
     return " ".join(str(value or "").strip().split())
 
 
+def _copy_todo_added_validation_fields(
+    source: dict[str, Any], target: dict[str, Any]
+) -> None:
+    """Copy caller-approved completion validation fields from a TODO_ADDED payload."""
+    for key in (
+        "validation_command",
+        "validation_label",
+        "validation_timeout_seconds",
+    ):
+        value = compact_text(source.get(key))
+        if value:
+            target[key] = value
+    argv = source.get("validation_command_argv")
+    if "validation_command_argv" not in source:
+        return
+    if isinstance(argv, list):
+        target["validation_command_argv"] = json.dumps(
+            argv, separators=(",", ":"), ensure_ascii=False
+        )
+        return
+    compact_argv = compact_text(argv)
+    # Persist a gate-visible value even for empty/corrupt payloads so complete
+    # fail-closes as malformed instead of treating the declaration as absent.
+    target["validation_command_argv"] = compact_argv if compact_argv else "[]"
+
+
 def _redact_public_backfill_text(value: Any, *, privacy: str) -> str:
     text = compact_text(value)
     if privacy != PUBLIC_PRIVACY:
@@ -326,6 +352,17 @@ def backfill_todo_events_from_markdown(
             payload["global_gate"] = global_gate
         if excluded_agents:
             payload["excluded_agents"] = excluded_agents
+        _copy_todo_added_validation_fields(record, payload)
+        if privacy == PUBLIC_PRIVACY:
+            for key in (
+                "validation_command",
+                "validation_command_argv",
+                "validation_label",
+            ):
+                if key in payload:
+                    payload[key] = _redact_public_backfill_text(
+                        payload[key], privacy=privacy
+                    )
         events.append(
             make_state_event(
                 event_id=_backfill_event_id(goal_id=normalized_goal_id, todo_id=todo_id, suffix="add"),
@@ -701,6 +738,7 @@ def _todo_from_added_event(event: dict[str, Any]) -> dict[str, Any]:
         todo["claimed_by"] = claimed_by
     if actor_agent_id:
         todo["created_by"] = actor_agent_id
+    _copy_todo_added_validation_fields(payload, todo)
     return todo
 
 
@@ -951,6 +989,14 @@ def render_todo_markdown(item: dict[str, Any]) -> list[str]:
         **monitor_metadata,
         note=item.get("note"),
         evidence=item.get("evidence"),
+        validation_command=item.get("validation_command"),
+        validation_command_argv=item.get("validation_command_argv"),
+        validation_label=item.get("validation_label"),
+        validation_timeout_seconds=(
+            str(item.get("validation_timeout_seconds"))
+            if item.get("validation_timeout_seconds") is not None
+            else None
+        ),
         completion_turn_key=item.get("completion_turn_key"),
         reason=item.get("reason"),
         completed_at=item.get("completed_at"),

--- a/tests/control_plane/test_todo_completion_validation.py
+++ b/tests/control_plane/test_todo_completion_validation.py
@@ -5,12 +5,26 @@ import re
 import shlex
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 import loopx.control_plane.todos.completion_validation as completion_validation_module
+from loopx.event_sourced_state import (
+    TODO_ADDED,
+    TODO_COMPLETED,
+    AppendOnlyStateEventStore,
+    PUBLIC_BACKFILL_REDACTION,
+    backfill_todo_events_from_markdown,
+    build_state_projection,
+    make_state_event,
+    render_todo_markdown,
+)
 from loopx.status import parse_active_state_todos
-from loopx.todos import add_goal_todo, complete_goal_todo, update_goal_todo
+from loopx.control_plane.todos.completion_validation_projection import (
+    project_completion_validation_authority,
+)
+from loopx.todos import add_goal_todo, complete_goal_todo, list_goal_todos, update_goal_todo
 
 GOAL_ID = "todo-completion-validation"
 AGENT = "codex-author"
@@ -605,3 +619,520 @@ def test_agent_todo_update_done_keeps_guard_error_without_running_gate(
     # The gate never runs for agent sections; the pre-existing guard fires.
     assert calls["count"] == 0
     assert _agent_todo(state, str(todo["todo_id"]))["status"] == "open"
+
+
+def _add_event_only_todo(
+    state: Path,
+    *,
+    todo_id: str = "todo_event_validation",
+    validation_command: str | None = None,
+    validation_command_argv: list[str] | None = None,
+    validation_label: str | None = None,
+    validation_timeout_seconds: int | None = None,
+) -> str:
+    store = AppendOnlyStateEventStore(state.with_name("events.jsonl"))
+    payload: dict[str, Any] = {
+        "role": "agent",
+        "title": "Deliver one event-projected change.",
+        "task_class": "advancement_task",
+        "claimed_by": AGENT,
+    }
+    if validation_command:
+        payload["validation_command"] = validation_command
+    if validation_command_argv is not None:
+        payload["validation_command_argv"] = validation_command_argv
+    if validation_label:
+        payload["validation_label"] = validation_label
+    if validation_timeout_seconds is not None:
+        payload["validation_timeout_seconds"] = validation_timeout_seconds
+    store.append(
+        make_state_event(
+            event_id=f"evt-{todo_id}-add",
+            goal_id=GOAL_ID,
+            event_type=TODO_ADDED,
+            refs={"todo_id": todo_id},
+            payload=payload,
+            recorded_at="2026-08-22T00:00:00+00:00",
+        )
+    )
+    return todo_id
+
+
+def _event_todo_completed_count(state: Path) -> int:
+    events = AppendOnlyStateEventStore(state.with_name("events.jsonl")).load()
+    return sum(event["event_type"] == TODO_COMPLETED for event in events)
+
+
+def test_event_projected_failing_validation_blocks_completion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo_id = _add_event_only_todo(
+        state,
+        validation_command=_FAIL_COMMAND,
+        validation_label="event-projected smoke",
+    )
+    calls = _spy_validation_runner(monkeypatch)
+
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="claim of completion",
+        no_followup=True,
+    )
+
+    assert calls["count"] == 1
+    assert result["ok"] is False
+    assert result["validation_blocked_completion"] is True
+    assert result["changed"] is False
+    assert result["validation"]["passed"] is False
+    assert _event_todo_completed_count(state) == 0
+
+
+def test_event_projected_passing_validation_commits_completion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo_id = _add_event_only_todo(
+        state,
+        validation_command=_PASS_COMMAND,
+        validation_label="event-projected smoke",
+    )
+    calls = _spy_validation_runner(monkeypatch)
+
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="validated completion",
+        no_followup=True,
+    )
+
+    assert calls["count"] == 1
+    assert result["ok"] is True
+    assert result["changed"] is True
+    assert result["source"] == "event_log"
+    assert "validation_blocked_completion" not in result
+    assert _event_todo_completed_count(state) == 1
+
+
+def test_event_projected_without_validation_keeps_fast_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo_id = _add_event_only_todo(state)
+    calls = _spy_validation_runner(monkeypatch)
+
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="undeclared fast path",
+        no_followup=True,
+    )
+
+    assert calls["count"] == 0
+    assert result["ok"] is True
+    assert result["changed"] is True
+    assert result["source"] == "event_log"
+    assert _event_todo_completed_count(state) == 1
+
+
+def test_event_projection_preserves_declared_validation_command() -> None:
+    events = backfill_todo_events_from_markdown(
+        "\n".join(
+            [
+                "## Agent Todo",
+                "",
+                "- [ ] Deliver one event-projected change.",
+                (
+                    "  <!-- loopx:todo todo_id=todo_event_val001 status=open "
+                    "task_class=advancement_task claimed_by=codex-author "
+                    "validation_command=pytest validation_label=caller-smoke "
+                    "validation_timeout_seconds=5 -->"
+                ),
+            ]
+        ),
+        goal_id=GOAL_ID,
+    )
+    projection = build_state_projection(events)
+    item = projection["agent_todos"]["items"][0]
+    assert item["validation_command"] == "pytest"
+    assert item["validation_label"] == "caller-smoke"
+    assert item["validation_timeout_seconds"] == "5"
+    rendered = "\n".join(render_todo_markdown(item))
+    assert "validation_command=pytest" in rendered
+    assert "validation_timeout_seconds=5" in rendered
+    public = project_completion_validation_authority(item)
+    assert public["completion_validation_required"] is True
+    assert "validation_command" not in public
+    assert "validation_timeout_seconds" not in public
+    assert "validation_command_argv" not in public
+    assert "validation_label" not in public
+
+
+def test_event_projected_passing_argv_commits_completion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo_id = _add_event_only_todo(
+        state,
+        todo_id="todo_event_argv_pass",
+        validation_command_argv=[sys.executable, "-c", "pass"],
+        validation_label="event argv smoke",
+    )
+    calls = _spy_validation_runner(monkeypatch)
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="validated argv completion",
+        no_followup=True,
+    )
+    assert calls["count"] == 1
+    assert result["ok"] is True
+    assert result["changed"] is True
+    assert result["source"] == "event_log"
+    assert _event_todo_completed_count(state) == 1
+
+
+def test_event_projected_failing_argv_blocks_completion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo_id = _add_event_only_todo(
+        state,
+        todo_id="todo_event_argv",
+        validation_command_argv=[sys.executable, "-c", "raise SystemExit(1)"],
+        validation_label="event argv smoke",
+    )
+    calls = _spy_validation_runner(monkeypatch)
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="claim of completion",
+        no_followup=True,
+    )
+    assert calls["count"] == 1
+    assert result["ok"] is False
+    assert result["validation_blocked_completion"] is True
+    assert _event_todo_completed_count(state) == 0
+
+
+def test_event_projected_empty_argv_fails_closed(tmp_path: Path) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo_id = _add_event_only_todo(
+        state,
+        todo_id="todo_event_empty_argv",
+        validation_command_argv=[],
+    )
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="corrupted argv must not skip the gate",
+        no_followup=True,
+    )
+    assert result["ok"] is False
+    assert result["validation_blocked_completion"] is True
+    assert result["validation"]["status"] == "command_malformed"
+    assert _event_todo_completed_count(state) == 0
+
+
+def test_event_projected_timeout_blocks_completion(tmp_path: Path) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo_id = _add_event_only_todo(
+        state,
+        todo_id="todo_event_timeout",
+        validation_command=_SLEEP_COMMAND,
+        validation_timeout_seconds=1,
+    )
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="timed-out claim",
+        no_followup=True,
+    )
+    assert result["ok"] is False
+    assert result["validation_blocked_completion"] is True
+    assert result["validation"]["status"] == "timeout"
+    assert _event_todo_completed_count(state) == 0
+
+
+def test_markdown_todo_remains_authoritative_over_event_declaration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo = _add_todo(registry)
+    _add_event_only_todo(
+        state,
+        todo_id=str(todo["todo_id"]),
+        validation_command=_FAIL_COMMAND,
+    )
+    calls = _spy_validation_runner(monkeypatch)
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=str(todo["todo_id"]),
+        agent_id=AGENT,
+        evidence="markdown has no declared command",
+        no_followup=True,
+    )
+    assert calls["count"] == 0
+    assert result["ok"] is True
+    assert result["changed"] is True
+    assert "validation_blocked_completion" not in result
+
+
+def test_event_list_projection_strips_command_but_complete_still_runs_gate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo_id = _add_event_only_todo(
+        state,
+        todo_id="todo_event_list_strip",
+        validation_command_argv=[sys.executable, "-c", "raise SystemExit(1)"],
+        validation_label="must not leak",
+        validation_timeout_seconds=5,
+    )
+    listed = list_goal_todos(registry_path=registry, goal_id=GOAL_ID)
+    item = next(todo for todo in listed["todos"] if todo["todo_id"] == todo_id)
+    assert item.get("completion_validation_required") is True
+    assert "validation_command" not in item
+    assert "validation_command_argv" not in item
+    assert "validation_label" not in item
+    assert "validation_timeout_seconds" not in item
+    calls = _spy_validation_runner(monkeypatch)
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="list stripping must not disable the gate",
+        no_followup=True,
+    )
+    assert calls["count"] == 1
+    assert result["ok"] is False
+    assert result["validation_blocked_completion"] is True
+    assert _event_todo_completed_count(state) == 0
+
+
+def test_event_projected_corrupt_argv_object_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    store = AppendOnlyStateEventStore(state.with_name("events.jsonl"))
+    todo_id = "todo_event_corrupt_argv"
+    store.append(
+        make_state_event(
+            event_id=f"evt-{todo_id}-add",
+            goal_id=GOAL_ID,
+            event_type=TODO_ADDED,
+            refs={"todo_id": todo_id},
+            payload={
+                "role": "agent",
+                "title": "Deliver one event-projected change.",
+                "task_class": "advancement_task",
+                "claimed_by": AGENT,
+                "validation_command_argv": {},
+            },
+            recorded_at="2026-08-22T00:00:00+00:00",
+        )
+    )
+    calls = _spy_validation_runner(monkeypatch)
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="corrupt argv must not skip the gate",
+        no_followup=True,
+    )
+    assert calls["count"] == 1
+    assert result["ok"] is False
+    assert result["validation_blocked_completion"] is True
+    assert result["validation"]["status"] == "command_malformed"
+    assert _event_todo_completed_count(state) == 0
+
+
+def test_event_projected_null_argv_string_fails_closed(tmp_path: Path) -> None:
+    registry, state = _write_fixture(tmp_path)
+    store = AppendOnlyStateEventStore(state.with_name("events.jsonl"))
+    todo_id = "todo_event_null_argv"
+    store.append(
+        make_state_event(
+            event_id=f"evt-{todo_id}-add",
+            goal_id=GOAL_ID,
+            event_type=TODO_ADDED,
+            refs={"todo_id": todo_id},
+            payload={
+                "role": "agent",
+                "title": "Deliver one event-projected change.",
+                "task_class": "advancement_task",
+                "claimed_by": AGENT,
+                "validation_command_argv": "null",
+            },
+            recorded_at="2026-08-22T00:00:00+00:00",
+        )
+    )
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="null argv string must fail closed",
+        no_followup=True,
+    )
+    assert result["ok"] is False
+    assert result["validation_blocked_completion"] is True
+    assert result["validation"]["status"] == "command_malformed"
+    public = project_completion_validation_authority(
+        {"validation_command_argv": "null"}
+    )
+    assert public["completion_validation_required"] is True
+    assert "validation_command_argv" not in public
+
+
+def test_event_log_for_another_goal_does_not_supply_validation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    store = AppendOnlyStateEventStore(state.with_name("events.jsonl"))
+    todo_id = "todo_event_foreign_goal"
+    store.append(
+        make_state_event(
+            event_id=f"evt-{todo_id}-add",
+            goal_id="other-goal",
+            event_type=TODO_ADDED,
+            refs={"todo_id": todo_id},
+            payload={
+                "role": "agent",
+                "title": "Deliver one event-projected change.",
+                "task_class": "advancement_task",
+                "claimed_by": AGENT,
+                "validation_command": _FAIL_COMMAND,
+            },
+            recorded_at="2026-08-22T00:00:00+00:00",
+        )
+    )
+    calls = _spy_validation_runner(monkeypatch)
+    with pytest.raises(ValueError, match="was not found"):
+        complete_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=todo_id,
+            agent_id=AGENT,
+            evidence="foreign goal declaration must not run",
+            no_followup=True,
+        )
+    assert calls["count"] == 0
+
+
+def test_missing_markdown_file_gate_still_reads_event_declaration(
+    tmp_path: Path,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo_id = _add_event_only_todo(
+        state,
+        todo_id="todo_event_no_markdown",
+        validation_command=_FAIL_COMMAND,
+    )
+    state.unlink()
+    result = completion_validation_module.run_completion_validation_gate(
+        state_file=state,
+        todo_id=todo_id,
+        role="agent",
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        dry_run=False,
+    )
+    assert result is not None
+    assert result["ok"] is False
+    assert result["validation_blocked_completion"] is True
+    assert _event_todo_completed_count(state) == 0
+
+
+def test_sidecar_declaration_is_not_masked_by_earlier_undeclared_log(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo_id = "todo_event_two_logs"
+    older = state.with_name("older-events.jsonl")
+    AppendOnlyStateEventStore(older).append(
+        make_state_event(
+            event_id=f"evt-{todo_id}-old",
+            goal_id=GOAL_ID,
+            event_type=TODO_ADDED,
+            refs={"todo_id": todo_id},
+            payload={
+                "role": "agent",
+                "title": "Deliver one event-projected change.",
+                "task_class": "advancement_task",
+                "claimed_by": AGENT,
+            },
+            recorded_at="2026-08-21T00:00:00+00:00",
+        )
+    )
+    _add_event_only_todo(
+        state,
+        todo_id=todo_id,
+        validation_command=_FAIL_COMMAND,
+    )
+    data = json.loads(registry.read_text(encoding="utf-8"))
+    data["goals"][0]["event_log"] = str(older)
+    registry.write_text(json.dumps(data), encoding="utf-8")
+    calls = _spy_validation_runner(monkeypatch)
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="older undeclared snapshot must not skip the sidecar gate",
+        no_followup=True,
+    )
+    assert calls["count"] == 1
+    assert result["ok"] is False
+    assert result["validation_blocked_completion"] is True
+    assert _event_todo_completed_count(state) == 0
+
+
+def test_public_safe_backfill_redacts_unsafe_validation_command() -> None:
+    events = backfill_todo_events_from_markdown(
+        "\n".join(
+            [
+                "## Agent Todo",
+                "",
+                "- [ ] Deliver one event-projected change.",
+                (
+                    "  <!-- loopx:todo todo_id=todo_event_val_redact status=open "
+                    "task_class=advancement_task claimed_by=codex-author "
+                    "validation_command=/Users/loopx/bin/pytest -->"
+                ),
+            ]
+        ),
+        goal_id=GOAL_ID,
+        privacy="public_safe",
+    )
+    payload = events[0]["payload"]
+    assert payload["validation_command"] == PUBLIC_BACKFILL_REDACTION
+    assert "/Users/" not in json.dumps(events)


### PR DESCRIPTION
## Summary
- Event-only todos that declare `validation_command` or `validation_command_argv` were treated as undeclared on `complete_goal_todo`, so the fail-closed completion gate never ran.
- The gate now reads the raw event-sourced projection when the todo is not materialized in markdown. Markdown stays authoritative when `find_todo_block` finds the same todo.
- Public list/status projection still strips the command, argv, label, and timeout down to `completion_validation_required`. The gate does not reuse `event_projection_todo_context`, because that helper performs that strip.

This is the remaining hole after the everyday markdown `todo add` / `todo update --status done` path was already gated (#3082). Everyday `todo add` still writes markdown and was not the broken path.

## Test plan
- [x] `.venv/bin/python -m pytest -q tests/control_plane/test_todo_completion_validation.py tests/control_plane/test_todo_mutation_authority.py` (88 passed)
- [x] `ruff check` on the four changed files
- [ ] CI on this PR

## Notes
- Bounded future-facing pass: shared `_declaration_from_mapping` / `_copy_todo_added_validation_fields`, prefer a later declared snapshot over an earlier undeclared one, and align list projection so argv-only todos also set `completion_validation_required`.
- Out of scope: successor `TODO_ADDED` write-back, `note` projection, `complete_goal_todo` when the markdown state file is missing, and tightening the global public-safe path regex.


Made with [Cursor](https://cursor.com)