### PR TITLE
fix(todos): gate event-projected completion validation

### DIFF
--- a/loopx/control_plane/effect_runtime.py
+++ b/loopx/control_plane/effect_runtime.py
@@ -37,6 +37,7 @@ _SOURCE_FILES = (
     "scheduler/state_transition_rules.ts",
     "todos/completion_fence.ts",
     "todos/completion_state.ts",
+    "todos/completion_validation_plan.ts",
     "todos/next_action.ts",
     "turn_driver/turn_journal.ts",
     "turn_driver/turn_journal_effects.ts",

--- a/loopx/control_plane/effect_runtime_handlers.ts
+++ b/loopx/control_plane/effect_runtime_handlers.ts
@@ -55,6 +55,7 @@ import {
   selectTodoCompletionContinuation,
   selectTodoCompletionState,
 } from "./todos/completion_state.ts";
+import { evaluateTodoCompletionValidationPlan } from "./todos/completion_validation_plan.ts";
 import { transitionTodoNextAction } from "./todos/next_action.ts";
 import { evaluateSchedulerStateTransition } from "./scheduler/state_transition_rules.ts";
 import {
@@ -272,6 +273,7 @@ export function createEffectRuntimeHandlers(
     ["todo.completion_state.continuation_for_write", selectTodoCompletionContinuation],
     ["todo.completion_state.evaluate", selectTodoCompletionState],
     ["todo.completion_state.metadata_updates", buildTodoCompletionMetadataUpdates],
+    ["todo.completion_validation.plan", evaluateTodoCompletionValidationPlan],
     ["todo.next_action.transition", transitionTodoNextAction],
     ["scheduler.state_transition.evaluate", evaluateSchedulerStateTransition],
     ["scheduler.state.evaluate", evaluateSchedulerStateOperation],

--- a/loopx/control_plane/todos/completion_validation.py
+++ b/loopx/control_plane/todos/completion_validation.py
@@ -5,14 +5,21 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+from ...event_sourced_state import (
+    AppendOnlyStateEventStore,
+    StateEventError,
+    build_state_projection,
+)
 from ...history import load_registry
 from ...materials import find_registry_goal, goal_repo
+from ..goals.active_state_event_projection import state_event_log_candidates
+from ..goals.path_resolution import resolve_goal_local_path
 from ..runtime.validation_command import (
     CALLER_VALIDATION_RECEIPT_SCHEMA_VERSION,
     run_caller_validation,
 )
 from .active_state_editing import find_todo_block
-from .contract import TODO_STATUS_DONE
+from .contract import TODO_STATUS_DONE, normalize_todo_id
 
 # Kept safely under the 30s outer CLI/MCP subprocess budget so a timed-out
 # validation still produces a typed receipt before the outer call is killed.
@@ -33,35 +40,10 @@ def _resolve_goal_repo_workspace(registry_path: Path, goal_id: str) -> Path | No
     return repo
 
 
-def _read_declared_validation(
-    *, state_file: Path, todo_id: str, role: str | None
+def _declaration_from_mapping(
+    block: dict[str, Any],
 ) -> tuple[str | None, list[str] | None, str | None, int | None, bool]:
-    """Pre-read a todo's declared validation command without the mutation lock.
-
-    Returns ``(validation_command, validation_argv, validation_label,
-    validation_timeout_seconds, already_completed)`` from the markdown state
-    file, or ``(None, None, None, None, False)`` when the todo is not
-    materialized in markdown. Read-only; safe to call before acquiring the
-    state-file lock so a slow validation command does not block concurrent todo
-    operations on the same goal (the MUTATION lock deadline is 5s).
-    ``validation_command``, ``validation_command_argv`` and
-    ``validation_timeout_seconds`` are set only at ``todo add`` and have no
-    update path, so the values cannot drift between this pre-read and the
-    in-lock commit. A stored timeout that fails to parse as an int falls back
-    to ``None`` (the default), matching the writer-side range check that
-    guarantees a well-formed value. A stored argv that fails to parse as a
-    non-empty string list collapses to ``[]`` — never to ``None`` — so a
-    corrupted declaration still runs the gate and fails closed as a malformed
-    command instead of silently skipping validation.
-    """
-    try:
-        lines = state_file.read_text(encoding="utf-8").splitlines()
-    except FileNotFoundError:
-        return None, None, None, None, False
-    match = find_todo_block(lines, todo_id=todo_id, role=role)
-    if not match:
-        return None, None, None, None, False
-    _role, _section, _start, _end, block = match
+    """Parse a stored validation declaration from markdown or event projection."""
     try:
         timeout_seconds: int | None = (
             int(block["validation_timeout_seconds"])
@@ -71,11 +53,15 @@ def _read_declared_validation(
     except (TypeError, ValueError):
         timeout_seconds = None
     validation_argv: list[str] | None = None
-    if block.get("validation_command_argv"):
-        try:
-            parsed_argv = json.loads(block["validation_command_argv"])
-        except ValueError:
-            parsed_argv = None
+    raw_argv = block.get("validation_command_argv")
+    if raw_argv is not None and raw_argv != "":
+        if isinstance(raw_argv, list):
+            parsed_argv: Any = raw_argv
+        else:
+            try:
+                parsed_argv = json.loads(raw_argv)
+            except ValueError:
+                parsed_argv = None
         if (
             isinstance(parsed_argv, list)
             and parsed_argv
@@ -84,13 +70,121 @@ def _read_declared_validation(
             validation_argv = parsed_argv
         else:
             validation_argv = []
+    already_completed = (
+        block.get("status") == TODO_STATUS_DONE or block.get("done") is True
+    )
     return (
         block.get("validation_command") or None,
         validation_argv,
         block.get("validation_label") or None,
         timeout_seconds,
-        block.get("status") == TODO_STATUS_DONE,
+        already_completed,
     )
+
+
+def _event_projected_todo_item(
+    *,
+    state_file: Path,
+    todo_id: str,
+    role: str | None,
+    registry_path: Path,
+    goal_id: str,
+) -> dict[str, Any] | None:
+    """Read one todo from the append-only event log without holding the lock.
+
+    Do not reuse ``event_projection_todo_context`` here. That helper renders
+    Markdown and runs the public status projector, which strips
+    ``validation_command`` / argv down to ``completion_validation_required``.
+    The completion gate needs the actual declared command, so it must read the
+    raw event-sourced projection. When multiple logs contain the same todo,
+    a later log that still carries a validation declaration wins over an
+    earlier log that only has the todo identity; otherwise an older undeclared
+    snapshot would skip the gate.
+    """
+    goal = find_registry_goal(load_registry(registry_path), goal_id)
+    if goal is None:
+        log_paths = [state_file.with_name("events.jsonl")]
+    else:
+        log_paths = state_event_log_candidates(
+            goal,
+            state_path=state_file,
+            resolve_goal_local_path=resolve_goal_local_path,
+        )
+    normalized_todo_id = normalize_todo_id(todo_id) or todo_id
+    roles = [role] if role in {"user", "agent"} else ["user", "agent"]
+    undeclared_item: dict[str, Any] | None = None
+    for log_path in log_paths:
+        if not log_path.exists():
+            continue
+        try:
+            events = AppendOnlyStateEventStore(log_path).load()
+            if not events:
+                continue
+            projection = build_state_projection(events, goal_id=goal_id or None)
+        except (OSError, StateEventError):
+            continue
+        for item_role in roles:
+            summary = projection.get(f"{item_role}_todos") or {}
+            items = summary.get("items") if isinstance(summary, dict) else []
+            for item in items if isinstance(items, list) else []:
+                if not isinstance(item, dict):
+                    continue
+                if (normalize_todo_id(item.get("todo_id")) or "") != normalized_todo_id:
+                    continue
+                command, argv, _label, _timeout, _done = _declaration_from_mapping(item)
+                if command or argv is not None:
+                    return item
+                if undeclared_item is None:
+                    undeclared_item = item
+    return undeclared_item
+
+
+def _read_declared_validation(
+    *,
+    state_file: Path,
+    todo_id: str,
+    role: str | None,
+    registry_path: Path,
+    goal_id: str,
+) -> tuple[str | None, list[str] | None, str | None, int | None, bool]:
+    """Pre-read a todo's declared validation command without the mutation lock.
+
+    Returns ``(validation_command, validation_argv, validation_label,
+    validation_timeout_seconds, already_completed)`` from the markdown state
+    file, or from the event-sourced projection when the todo exists only in
+    the append-only log. Missing todos return
+    ``(None, None, None, None, False)``. Read-only; safe to call before
+    acquiring the state-file lock so a slow validation command does not block
+    concurrent todo operations on the same goal (the MUTATION lock deadline
+    is 5s). ``validation_command``, ``validation_command_argv`` and
+    ``validation_timeout_seconds`` are set only at ``todo add`` and have no
+    update path, so the values cannot drift between this pre-read and the
+    in-lock commit. A stored timeout that fails to parse as an int falls back
+    to ``None`` (the default), matching the writer-side range check that
+    guarantees a well-formed value. A stored argv that fails to parse as a
+    non-empty string list collapses to ``[]`` — never to ``None`` — so a
+    corrupted declaration still runs the gate and fails closed as a malformed
+    command instead of silently skipping validation. Markdown remains
+    authoritative when the todo is materialized there.
+    """
+    try:
+        lines = state_file.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        lines = []
+    match = find_todo_block(lines, todo_id=todo_id, role=role) if lines else None
+    if match:
+        _role, _section, _start, _end, block = match
+        return _declaration_from_mapping(block)
+    item = _event_projected_todo_item(
+        state_file=state_file,
+        todo_id=todo_id,
+        role=role,
+        registry_path=registry_path,
+        goal_id=goal_id,
+    )
+    if item is None:
+        return None, None, None, None, False
+    return _declaration_from_mapping(item)
 
 
 def _run_declared_completion_validation(
@@ -221,7 +315,13 @@ def run_completion_validation_gate(
         validation_label,
         validation_timeout_seconds,
         already_completed,
-    ) = _read_declared_validation(state_file=state_file, todo_id=todo_id, role=role)
+    ) = _read_declared_validation(
+        state_file=state_file,
+        todo_id=todo_id,
+        role=role,
+        registry_path=registry_path,
+        goal_id=goal_id,
+    )
     completion_validation = (
         _run_declared_completion_validation(
             validation_command=validation_command,

--- a/loopx/control_plane/todos/completion_validation.py
+++ b/loopx/control_plane/todos/completion_validation.py
@@ -1,25 +1,27 @@
 from __future__ import annotations
 
-import json
 import subprocess
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-from ...event_sourced_state import (
-    AppendOnlyStateEventStore,
-    StateEventError,
-    build_state_projection,
-)
+from ..effect_runtime import EffectRuntimeRejected, effect_runtime_result
 from ...history import load_registry
 from ...materials import find_registry_goal, goal_repo
-from ..goals.active_state_event_projection import state_event_log_candidates
-from ..goals.path_resolution import resolve_goal_local_path
 from ..runtime.validation_command import (
     CALLER_VALIDATION_RECEIPT_SCHEMA_VERSION,
     run_caller_validation,
 )
 from .active_state_editing import find_todo_block
-from .contract import TODO_STATUS_DONE, normalize_todo_id
+from .event_writeback import event_projection_source_authority, event_projection_todo_context
+
+
+TODO_COMPLETION_VALIDATION_PLAN_REQUEST_SCHEMA = (
+    "loopx_todo_completion_validation_plan_request_v0"
+)
+TODO_COMPLETION_VALIDATION_PLAN_RESULT_SCHEMA = (
+    "loopx_todo_completion_validation_plan_result_v0"
+)
 
 # Kept safely under the 30s outer CLI/MCP subprocess budget so a timed-out
 # validation still produces a typed receipt before the outer call is killed.
@@ -40,151 +42,144 @@ def _resolve_goal_repo_workspace(registry_path: Path, goal_id: str) -> Path | No
     return repo
 
 
-def _declaration_from_mapping(
-    block: dict[str, Any],
-) -> tuple[str | None, list[str] | None, str | None, int | None, bool]:
-    """Parse a stored validation declaration from markdown or event projection."""
-    try:
-        timeout_seconds: int | None = (
-            int(block["validation_timeout_seconds"])
-            if block.get("validation_timeout_seconds")
-            else None
-        )
-    except (TypeError, ValueError):
-        timeout_seconds = None
-    validation_argv: list[str] | None = None
-    raw_argv = block.get("validation_command_argv")
-    if raw_argv is not None and raw_argv != "":
-        if isinstance(raw_argv, list):
-            parsed_argv: Any = raw_argv
-        else:
-            try:
-                parsed_argv = json.loads(raw_argv)
-            except ValueError:
-                parsed_argv = None
-        if (
-            isinstance(parsed_argv, list)
-            and parsed_argv
-            and all(isinstance(item, str) and item for item in parsed_argv)
-        ):
-            validation_argv = parsed_argv
-        else:
-            validation_argv = []
-    already_completed = (
-        block.get("status") == TODO_STATUS_DONE or block.get("done") is True
-    )
-    return (
-        block.get("validation_command") or None,
-        validation_argv,
-        block.get("validation_label") or None,
-        timeout_seconds,
-        already_completed,
-    )
+def _json_successor_value(value: Any) -> Any:
+    if isinstance(value, (tuple, set)):
+        return list(value)
+    return value
 
 
-def _event_projected_todo_item(
-    *,
-    state_file: Path,
-    todo_id: str,
-    role: str | None,
-    registry_path: Path,
-    goal_id: str,
+def _materialized_todo_item(
+    *, state_file: Path, todo_id: str, role: str | None
 ) -> dict[str, Any] | None:
-    """Read one todo from the append-only event log without holding the lock.
-
-    Do not reuse ``event_projection_todo_context`` here. That helper renders
-    Markdown and runs the public status projector, which strips
-    ``validation_command`` / argv down to ``completion_validation_required``.
-    The completion gate needs the actual declared command, so it must read the
-    raw event-sourced projection. When multiple logs contain the same todo,
-    a later log that still carries a validation declaration wins over an
-    earlier log that only has the todo identity; otherwise an older undeclared
-    snapshot would skip the gate.
-    """
-    goal = find_registry_goal(load_registry(registry_path), goal_id)
-    if goal is None:
-        log_paths = [state_file.with_name("events.jsonl")]
-    else:
-        log_paths = state_event_log_candidates(
-            goal,
-            state_path=state_file,
-            resolve_goal_local_path=resolve_goal_local_path,
-        )
-    normalized_todo_id = normalize_todo_id(todo_id) or todo_id
-    roles = [role] if role in {"user", "agent"} else ["user", "agent"]
-    undeclared_item: dict[str, Any] | None = None
-    for log_path in log_paths:
-        if not log_path.exists():
-            continue
-        try:
-            events = AppendOnlyStateEventStore(log_path).load()
-            if not events:
-                continue
-            projection = build_state_projection(events, goal_id=goal_id or None)
-        except (OSError, StateEventError):
-            continue
-        for item_role in roles:
-            summary = projection.get(f"{item_role}_todos") or {}
-            items = summary.get("items") if isinstance(summary, dict) else []
-            for item in items if isinstance(items, list) else []:
-                if not isinstance(item, dict):
-                    continue
-                if (normalize_todo_id(item.get("todo_id")) or "") != normalized_todo_id:
-                    continue
-                command, argv, _label, _timeout, _done = _declaration_from_mapping(item)
-                if command or argv is not None:
-                    return item
-                if undeclared_item is None:
-                    undeclared_item = item
-    return undeclared_item
-
-
-def _read_declared_validation(
-    *,
-    state_file: Path,
-    todo_id: str,
-    role: str | None,
-    registry_path: Path,
-    goal_id: str,
-) -> tuple[str | None, list[str] | None, str | None, int | None, bool]:
-    """Pre-read a todo's declared validation command without the mutation lock.
-
-    Returns ``(validation_command, validation_argv, validation_label,
-    validation_timeout_seconds, already_completed)`` from the markdown state
-    file, or from the event-sourced projection when the todo exists only in
-    the append-only log. Missing todos return
-    ``(None, None, None, None, False)``. Read-only; safe to call before
-    acquiring the state-file lock so a slow validation command does not block
-    concurrent todo operations on the same goal (the MUTATION lock deadline
-    is 5s). ``validation_command``, ``validation_command_argv`` and
-    ``validation_timeout_seconds`` are set only at ``todo add`` and have no
-    update path, so the values cannot drift between this pre-read and the
-    in-lock commit. A stored timeout that fails to parse as an int falls back
-    to ``None`` (the default), matching the writer-side range check that
-    guarantees a well-formed value. A stored argv that fails to parse as a
-    non-empty string list collapses to ``[]`` — never to ``None`` — so a
-    corrupted declaration still runs the gate and fails closed as a malformed
-    command instead of silently skipping validation. Markdown remains
-    authoritative when the todo is materialized there.
-    """
     try:
         lines = state_file.read_text(encoding="utf-8").splitlines()
     except FileNotFoundError:
-        lines = []
-    match = find_todo_block(lines, todo_id=todo_id, role=role) if lines else None
-    if match:
-        _role, _section, _start, _end, block = match
-        return _declaration_from_mapping(block)
-    item = _event_projected_todo_item(
-        state_file=state_file,
-        todo_id=todo_id,
-        role=role,
-        registry_path=registry_path,
-        goal_id=goal_id,
-    )
-    if item is None:
-        return None, None, None, None, False
-    return _declaration_from_mapping(item)
+        return None
+    match = find_todo_block(lines, todo_id=todo_id, role=role)
+    if not match:
+        return None
+    item_role, _section, _start, _end, block = match
+    item = dict(block)
+    item["role"] = item_role
+    return item
+
+
+def evaluate_todo_completion_validation_plan(
+    *,
+    todo: Mapping[str, Any],
+    projection_source: str,
+    completion_turn_key: str | None,
+    no_followup: bool,
+    dry_run: bool,
+) -> dict[str, Any]:
+    """Ask the TypeScript Todo owner for the validation decision/effect plan."""
+    try:
+        result = effect_runtime_result(
+            "todo.completion_validation.plan",
+            {
+                "schema_version": TODO_COMPLETION_VALIDATION_PLAN_REQUEST_SCHEMA,
+                "projection_source": projection_source,
+                "todo": {
+                    "status": str(todo.get("status") or "open"),
+                    "no_followup": todo.get("no_followup"),
+                    "completion_continuation": todo.get("completion_continuation"),
+                    "completion_turn_key": todo.get("completion_turn_key"),
+                    "successor_todo_ids": _json_successor_value(
+                        todo.get("successor_todo_ids")
+                    ),
+                    "validation_command": todo.get("validation_command"),
+                    "validation_command_argv": todo.get("validation_command_argv"),
+                    "validation_label": todo.get("validation_label"),
+                    "validation_timeout_seconds": todo.get(
+                        "validation_timeout_seconds"
+                    ),
+                },
+                "requested_no_followup": no_followup,
+                "requested_completion_turn_key": completion_turn_key,
+                "dry_run": dry_run,
+            },
+        )
+    except EffectRuntimeRejected as exc:
+        raise ValueError(str(exc)) from None
+    if not isinstance(result, Mapping):
+        raise RuntimeError(
+            "TypeScript Todo completion validation plan result must be an object"
+        )
+    effect = result.get("effect")
+    if (
+        result.get("schema_version")
+        != TODO_COMPLETION_VALIDATION_PLAN_RESULT_SCHEMA
+        or effect not in {"skip", "run", "reject"}
+        or not isinstance(result.get("reason"), str)
+    ):
+        raise RuntimeError(
+            "TypeScript Todo completion validation plan result shape mismatch"
+        )
+    if effect == "run":
+        argv = result.get("validation_argv")
+        if not (
+            result.get("validation_command") is None
+            or isinstance(result.get("validation_command"), str)
+        ):
+            raise RuntimeError(
+                "TypeScript Todo completion validation run command shape mismatch"
+            )
+        if not (
+            argv is None
+            or (
+                isinstance(argv, list)
+                and argv
+                and all(isinstance(item, str) and item for item in argv)
+            )
+        ):
+            raise RuntimeError(
+                "TypeScript Todo completion validation run argv shape mismatch"
+            )
+        timeout_seconds = result.get("validation_timeout_seconds")
+        if not (
+            timeout_seconds is None
+            or (
+                isinstance(timeout_seconds, int)
+                and 1 <= timeout_seconds <= COMPLETION_VALIDATION_TIMEOUT_MAX_SECONDS
+            )
+        ):
+            raise RuntimeError(
+                "TypeScript Todo completion validation timeout shape mismatch"
+            )
+        if not (
+            result.get("validation_label") is None
+            or isinstance(result.get("validation_label"), str)
+        ):
+            raise RuntimeError(
+                "TypeScript Todo completion validation label shape mismatch"
+            )
+    if effect == "reject" and (
+        result.get("status") != "declaration_invalid"
+        or not isinstance(result.get("summary"), str)
+        or not (
+            result.get("validation_label") is None
+            or isinstance(result.get("validation_label"), str)
+        )
+    ):
+        raise RuntimeError(
+            "TypeScript Todo completion validation reject shape mismatch"
+        )
+    return dict(result)
+
+
+def _validation_declaration_receipt(plan: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": CALLER_VALIDATION_RECEIPT_SCHEMA_VERSION,
+        "command_label": plan.get("validation_label")
+        or "todo completion validation",
+        "exit_code": None,
+        "passed": False,
+        "status": plan.get("status") or "declaration_invalid",
+        "summary": str(plan.get("summary") or "validation declaration is invalid"),
+        "stdout_captured": False,
+        "stderr_captured": False,
+        "local_path_captured": False,
+    }
 
 
 def _run_declared_completion_validation(
@@ -298,7 +293,32 @@ def run_completion_validation_gate(
     registry_path: Path,
     goal_id: str,
     dry_run: bool,
+    no_followup: bool = False,
+    completion_turn_key: str | None = None,
 ) -> dict[str, Any] | None:
+    return run_completion_validation_gate_with_source(
+        state_file=state_file,
+        todo_id=todo_id,
+        role=role,
+        registry_path=registry_path,
+        goal_id=goal_id,
+        dry_run=dry_run,
+        no_followup=no_followup,
+        completion_turn_key=completion_turn_key,
+    ).get("failure")
+
+
+def run_completion_validation_gate_with_source(
+    *,
+    state_file: Path,
+    todo_id: str,
+    role: str | None,
+    registry_path: Path,
+    goal_id: str,
+    dry_run: bool,
+    no_followup: bool = False,
+    completion_turn_key: str | None = None,
+) -> dict[str, Any]:
     """Run the caller-approved completion validation gate, OUTSIDE the mutation lock.
 
     Returns a ``validation_blocked_completion`` failure payload when a declared
@@ -309,34 +329,62 @@ def run_completion_validation_gate(
     call before acquiring the mutation lock so a multi-second validation command
     does not block concurrent todo operations on the same goal.
     """
-    (
-        validation_command,
-        validation_argv,
-        validation_label,
-        validation_timeout_seconds,
-        already_completed,
-    ) = _read_declared_validation(
-        state_file=state_file,
-        todo_id=todo_id,
-        role=role,
-        registry_path=registry_path,
-        goal_id=goal_id,
+    projection_source = "materialized"
+    source_authority: dict[str, Any] | None = None
+    todo = _materialized_todo_item(state_file=state_file, todo_id=todo_id, role=role)
+    if todo is None:
+        event_context = event_projection_todo_context(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            state_path=state_file,
+            todo_id=todo_id,
+            role=role,
+        )
+        if event_context is None:
+            return {"failure": None, "source_authority": None}
+        projection_source = "event_log"
+        todo = dict(event_context.get("raw_item") or event_context["item"])
+        todo["role"] = event_context["role"]
+        source_authority = event_projection_source_authority(event_context)
+    plan = evaluate_todo_completion_validation_plan(
+        todo=todo,
+        projection_source=projection_source,
+        completion_turn_key=completion_turn_key,
+        no_followup=no_followup,
+        dry_run=dry_run,
     )
-    completion_validation = (
-        _run_declared_completion_validation(
-            validation_command=validation_command,
-            validation_argv=validation_argv,
-            validation_label=validation_label,
-            validation_timeout_seconds=validation_timeout_seconds,
+    completion_validation = None
+    if plan["effect"] == "reject":
+        completion_validation = _validation_declaration_receipt(plan)
+    elif plan["effect"] == "run":
+        validation_argv = plan.get("validation_argv")
+        completion_validation = _run_declared_completion_validation(
+            validation_command=(
+                str(plan["validation_command"])
+                if plan.get("validation_command") is not None
+                else None
+            ),
+            validation_argv=(
+                list(validation_argv)
+                if isinstance(validation_argv, list)
+                else None
+            ),
+            validation_label=(
+                str(plan["validation_label"])
+                if plan.get("validation_label") is not None
+                else None
+            ),
+            validation_timeout_seconds=(
+                int(plan["validation_timeout_seconds"])
+                if plan.get("validation_timeout_seconds") is not None
+                else None
+            ),
             registry_path=registry_path,
             goal_id=goal_id,
         )
-        if not dry_run and not already_completed
-        else None
-    )
     if completion_validation is None or completion_validation.get("passed") is True:
-        return None
-    return {
+        return {"failure": None, "source_authority": source_authority}
+    failure = {
         "ok": False,
         "dry_run": dry_run,
         "completed": False,
@@ -346,3 +394,4 @@ def run_completion_validation_gate(
         "validation": completion_validation,
         "validation_blocked_completion": True,
     }
+    return {"failure": failure, "source_authority": source_authority}

--- a/loopx/control_plane/todos/completion_validation_plan.ts
+++ b/loopx/control_plane/todos/completion_validation_plan.ts
@@ -1,0 +1,239 @@
+import type { JsonObject } from "../effect_program.ts";
+import {
+  evaluateTodoCompletionFence,
+  TODO_COMPLETION_FENCE_REQUEST_SCHEMA,
+  type TodoCompletionProjectionSource,
+} from "./completion_fence.ts";
+
+export const TODO_COMPLETION_VALIDATION_PLAN_REQUEST_SCHEMA =
+  "loopx_todo_completion_validation_plan_request_v0";
+export const TODO_COMPLETION_VALIDATION_PLAN_RESULT_SCHEMA =
+  "loopx_todo_completion_validation_plan_result_v0";
+
+export type TodoCompletionValidationPlanResult =
+  | (JsonObject & {
+      schema_version: typeof TODO_COMPLETION_VALIDATION_PLAN_RESULT_SCHEMA;
+      effect: "skip";
+      reason: "dry_run" | "no_declaration" | "terminal_replay";
+    })
+  | (JsonObject & {
+      schema_version: typeof TODO_COMPLETION_VALIDATION_PLAN_RESULT_SCHEMA;
+      effect: "run";
+      reason: "declared_validation";
+      validation_command: string | null;
+      validation_argv: readonly string[] | null;
+      validation_label: string | null;
+      validation_timeout_seconds: number | null;
+    })
+  | (JsonObject & {
+      schema_version: typeof TODO_COMPLETION_VALIDATION_PLAN_RESULT_SCHEMA;
+      effect: "reject";
+      reason: "invalid_declaration";
+      status: "declaration_invalid";
+      validation_label: string | null;
+      summary: string;
+    });
+
+function requiredObject(value: unknown, label: string): JsonObject {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as JsonObject;
+}
+
+function requiredBoolean(value: unknown, label: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new Error(`${label} must be a boolean`);
+  }
+  return value;
+}
+
+function projectionSource(value: unknown): TodoCompletionProjectionSource {
+  if (value === "materialized" || value === "event_log") return value;
+  throw new Error("projection_source is unsupported");
+}
+
+function optionalOpaqueString(value: unknown, label: string): string | null {
+  if (value === null || value === undefined || value === "") return null;
+  if (typeof value !== "string") {
+    throw new Error(`${label} must be a string or null`);
+  }
+  return value;
+}
+
+function compactString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const compact = value.trim();
+  return compact === "" ? null : compact;
+}
+
+function invalidDeclaration(
+  summary: string,
+  validationLabel: string | null,
+): TodoCompletionValidationPlanResult {
+  return {
+    schema_version: TODO_COMPLETION_VALIDATION_PLAN_RESULT_SCHEMA,
+    effect: "reject",
+    reason: "invalid_declaration",
+    status: "declaration_invalid",
+    validation_label: validationLabel,
+    summary,
+  };
+}
+
+function validationTimeoutSeconds(
+  value: unknown,
+): { ok: true; value: number | null } | { ok: false; summary: string } {
+  if (value === null || value === undefined || value === "") {
+    return { ok: true, value: null };
+  }
+  if (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    Number.isSafeInteger(value)
+  ) {
+    if (value >= 1 && value <= 29) return { ok: true, value };
+    return {
+      ok: false,
+      summary: "validation_timeout_seconds must be an integer between 1 and 29",
+    };
+  }
+  if (typeof value === "string" && /^[0-9]+$/.test(value.trim())) {
+    const parsed = Number(value.trim());
+    if (parsed >= 1 && parsed <= 29) return { ok: true, value: parsed };
+    return {
+      ok: false,
+      summary: "validation_timeout_seconds must be an integer between 1 and 29",
+    };
+  }
+  return {
+    ok: false,
+    summary: "validation_timeout_seconds must be an integer between 1 and 29",
+  };
+}
+
+function validationArgv(
+  value: unknown,
+): { ok: true; value: readonly string[] | null } | { ok: false; summary: string } {
+  if (value === null || value === undefined || value === "") {
+    return { ok: true, value: null };
+  }
+  let parsed: unknown = value;
+  if (typeof value === "string") {
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      return {
+        ok: false,
+        summary: "validation_command_argv must be a non-empty string array",
+      };
+    }
+  }
+  if (
+    Array.isArray(parsed) &&
+    parsed.length > 0 &&
+    parsed.every((item) => typeof item === "string" && item.length > 0)
+  ) {
+    return { ok: true, value: [...parsed] };
+  }
+  return {
+    ok: false,
+    summary: "validation_command_argv must be a non-empty string array",
+  };
+}
+
+export function evaluateTodoCompletionValidationPlan(
+  value: unknown,
+): TodoCompletionValidationPlanResult {
+  const request = requiredObject(value, "todo.completion_validation_plan params");
+  if (request.schema_version !== TODO_COMPLETION_VALIDATION_PLAN_REQUEST_SCHEMA) {
+    throw new Error("Todo completion validation plan request schema mismatch");
+  }
+  const todo = requiredObject(request.todo, "todo.completion_validation_plan todo");
+  const dryRun = requiredBoolean(request.dry_run, "dry_run");
+  if (dryRun) {
+    return {
+      schema_version: TODO_COMPLETION_VALIDATION_PLAN_RESULT_SCHEMA,
+      effect: "skip",
+      reason: "dry_run",
+    };
+  }
+
+  const source = projectionSource(request.projection_source);
+  const fence = evaluateTodoCompletionFence({
+    schema_version: TODO_COMPLETION_FENCE_REQUEST_SCHEMA,
+    projection_source: source,
+    todo: {
+      status: todo.status,
+      no_followup: todo.no_followup,
+      completion_continuation: todo.completion_continuation,
+      completion_turn_key: todo.completion_turn_key,
+      successor_todo_ids: todo.successor_todo_ids,
+    },
+    requested_no_followup: requiredBoolean(
+      request.requested_no_followup,
+      "requested_no_followup",
+    ),
+    requested_completion_turn_key: optionalOpaqueString(
+      request.requested_completion_turn_key,
+      "requested_completion_turn_key",
+    ),
+  });
+  if (fence.outcome === "replay") {
+    return {
+      schema_version: TODO_COMPLETION_VALIDATION_PLAN_RESULT_SCHEMA,
+      effect: "skip",
+      reason: "terminal_replay",
+    };
+  }
+
+  const validationLabel = optionalOpaqueString(
+    todo.validation_label,
+    "todo.validation_label",
+  );
+  const commandRaw = todo.validation_command;
+  if (
+    commandRaw !== null &&
+    commandRaw !== undefined &&
+    typeof commandRaw !== "string"
+  ) {
+    return invalidDeclaration(
+      "validation_command must be a non-empty string when declared",
+      validationLabel,
+    );
+  }
+  const validationCommand = compactString(commandRaw);
+  const argv = validationArgv(todo.validation_command_argv);
+  if (!argv.ok) return invalidDeclaration(argv.summary, validationLabel);
+  if (validationCommand !== null && argv.value !== null) {
+    return invalidDeclaration(
+      "validation_command and validation_command_argv are mutually exclusive",
+      validationLabel,
+    );
+  }
+  const timeout = validationTimeoutSeconds(todo.validation_timeout_seconds);
+  if (!timeout.ok) return invalidDeclaration(timeout.summary, validationLabel);
+  if (validationCommand === null && argv.value === null) {
+    if (timeout.value !== null) {
+      return invalidDeclaration(
+        "validation_timeout_seconds requires a validation command declaration",
+        validationLabel,
+      );
+    }
+    return {
+      schema_version: TODO_COMPLETION_VALIDATION_PLAN_RESULT_SCHEMA,
+      effect: "skip",
+      reason: "no_declaration",
+    };
+  }
+
+  return {
+    schema_version: TODO_COMPLETION_VALIDATION_PLAN_RESULT_SCHEMA,
+    effect: "run",
+    reason: "declared_validation",
+    validation_command: validationCommand,
+    validation_argv: argv.value,
+    validation_label: validationLabel,
+    validation_timeout_seconds: timeout.value,
+  };
+}

--- a/loopx/control_plane/todos/completion_validation_plan.ts
+++ b/loopx/control_plane/todos/completion_validation_plan.ts
@@ -1,5 +1,10 @@
 import type { JsonObject } from "../effect_program.ts";
 import {
+  requireBoolean,
+  requireJsonObject,
+  requireStringLiteral,
+} from "../runtime_decode.ts";
+import {
   evaluateTodoCompletionFence,
   TODO_COMPLETION_FENCE_REQUEST_SCHEMA,
   type TodoCompletionProjectionSource,
@@ -34,23 +39,12 @@ export type TodoCompletionValidationPlanResult =
       summary: string;
     });
 
-function requiredObject(value: unknown, label: string): JsonObject {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new Error(`${label} must be an object`);
-  }
-  return value as JsonObject;
-}
-
-function requiredBoolean(value: unknown, label: string): boolean {
-  if (typeof value !== "boolean") {
-    throw new Error(`${label} must be a boolean`);
-  }
-  return value;
-}
-
 function projectionSource(value: unknown): TodoCompletionProjectionSource {
-  if (value === "materialized" || value === "event_log") return value;
-  throw new Error("projection_source is unsupported");
+  return requireStringLiteral(
+    value,
+    ["materialized", "event_log"] as const,
+    "projection_source",
+  );
 }
 
 function optionalOpaqueString(value: unknown, label: string): string | null {
@@ -145,12 +139,18 @@ function validationArgv(
 export function evaluateTodoCompletionValidationPlan(
   value: unknown,
 ): TodoCompletionValidationPlanResult {
-  const request = requiredObject(value, "todo.completion_validation_plan params");
+  const request = requireJsonObject(
+    value,
+    "todo.completion_validation_plan params",
+  );
   if (request.schema_version !== TODO_COMPLETION_VALIDATION_PLAN_REQUEST_SCHEMA) {
     throw new Error("Todo completion validation plan request schema mismatch");
   }
-  const todo = requiredObject(request.todo, "todo.completion_validation_plan todo");
-  const dryRun = requiredBoolean(request.dry_run, "dry_run");
+  const todo = requireJsonObject(
+    request.todo,
+    "todo.completion_validation_plan todo",
+  );
+  const dryRun = requireBoolean(request.dry_run, "dry_run");
   if (dryRun) {
     return {
       schema_version: TODO_COMPLETION_VALIDATION_PLAN_RESULT_SCHEMA,
@@ -170,7 +170,7 @@ export function evaluateTodoCompletionValidationPlan(
       completion_turn_key: todo.completion_turn_key,
       successor_todo_ids: todo.successor_todo_ids,
     },
-    requested_no_followup: requiredBoolean(
+    requested_no_followup: requireBoolean(
       request.requested_no_followup,
       "requested_no_followup",
     ),

--- a/loopx/control_plane/todos/completion_validation_projection.py
+++ b/loopx/control_plane/todos/completion_validation_projection.py
@@ -15,10 +15,12 @@ def project_completion_validation_authority(item: dict[str, Any]) -> dict[str, A
     """Replace private validation execution details with one authority marker."""
 
     projected = dict(item)
-    required = bool(str(projected.pop("validation_command", "") or "").strip())
+    command = str(projected.pop("validation_command", "") or "").strip()
+    argv = projected.pop("validation_command_argv", None)
     projected.pop("validation_label", None)
     projected.pop("validation_timeout_seconds", None)
-    if required:
+    argv_declared = argv is not None and str(argv).strip() != ""
+    if command or argv_declared:
         projected["completion_validation_required"] = True
     return projected
 

--- a/loopx/control_plane/todos/event_writeback.py
+++ b/loopx/control_plane/todos/event_writeback.py
@@ -66,16 +66,10 @@ def _registry_goal(registry_path: Path, goal_id: str) -> dict[str, Any] | None:
 
 def _raw_event_projection_todo_item(
     *,
-    event_log_path: Path,
-    goal_id: str,
+    projection: Mapping[str, Any],
     todo_id: str,
     roles: list[str],
 ) -> dict[str, Any] | None:
-    try:
-        events = AppendOnlyStateEventStore(event_log_path).load()
-        projection = build_state_projection(events, goal_id=goal_id or None)
-    except (OSError, StateEventError):
-        return None
     for item_role in roles:
         if item_role not in TODO_SECTION_HEADINGS:
             continue
@@ -86,6 +80,43 @@ def _raw_event_projection_todo_item(
                 continue
             if normalize_todo_id(item.get("todo_id")) == todo_id:
                 return dict(item)
+    return None
+
+
+def _canonical_event_projection_source(
+    *,
+    goal: dict[str, Any],
+    state_path: Path,
+    projection_authority: Mapping[str, Any],
+) -> tuple[Path, dict[str, Any]] | None:
+    """Resolve the exact log whose fingerprint produced the public projection."""
+    authority_keys = (
+        "source_event_count",
+        "source_checksum",
+        "last_event_id",
+        "last_append_sequence",
+        "projection_version",
+    )
+    goal_id = str(goal.get("id") or "").strip()
+    for event_log_path in state_event_log_candidates(
+        goal,
+        state_path=state_path,
+        resolve_goal_local_path=resolve_goal_local_path,
+    ):
+        if not event_log_path.exists():
+            continue
+        try:
+            events = AppendOnlyStateEventStore(event_log_path).load()
+            if not events:
+                continue
+            projection = build_state_projection(events, goal_id=goal_id or None)
+        except (OSError, StateEventError):
+            return None
+        if all(
+            projection.get(key) == projection_authority.get(key)
+            for key in authority_keys
+        ):
+            return event_log_path, projection
     return None
 
 
@@ -199,23 +230,21 @@ def event_projection_todo_context(
             break
     if not matched_item or matched_role is None:
         return None
-    event_log_path = next(
-        (
-            path
-            for path in state_event_log_candidates(
-                goal,
-                state_path=state_path,
-                resolve_goal_local_path=resolve_goal_local_path,
-            )
-            if path.exists()
+    projection_authority = fields.get("state_event_projection")
+    source = _canonical_event_projection_source(
+        goal=goal,
+        state_path=state_path,
+        projection_authority=(
+            projection_authority
+            if isinstance(projection_authority, Mapping)
+            else {}
         ),
-        None,
     )
-    if event_log_path is None:
+    if source is None:
         return None
+    event_log_path, raw_projection = source
     raw_item = _raw_event_projection_todo_item(
-        event_log_path=event_log_path,
-        goal_id=goal_id,
+        projection=raw_projection,
         todo_id=normalized_todo_id,
         roles=roles,
     )

--- a/loopx/control_plane/todos/event_writeback.py
+++ b/loopx/control_plane/todos/event_writeback.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 import hashlib
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 from ...event_sourced_state import (
     AppendOnlyStateEventStore,
+    StateEventError,
     TODO_ADDED,
     TODO_CLAIMED,
     TODO_COMPLETED,
+    build_state_projection,
     make_state_event,
 )
 from ...history import load_registry
@@ -18,6 +20,7 @@ from ..goals.active_state_event_projection import (
     state_event_log_candidates,
 )
 from ..goals.path_resolution import resolve_goal_local_path
+from ..runtime.validation_command import CALLER_VALIDATION_RECEIPT_SCHEMA_VERSION
 from .active_state_todo_parser import parse_active_state_todos
 from .contract import (
     TODO_CONTINUATION_POLICY_VALUES,
@@ -59,6 +62,99 @@ def _registry_goal(registry_path: Path, goal_id: str) -> dict[str, Any] | None:
         if isinstance(goal, dict) and str(goal.get("id") or "") == goal_id:
             return goal
     return None
+
+
+def _raw_event_projection_todo_item(
+    *,
+    event_log_path: Path,
+    goal_id: str,
+    todo_id: str,
+    roles: list[str],
+) -> dict[str, Any] | None:
+    try:
+        events = AppendOnlyStateEventStore(event_log_path).load()
+        projection = build_state_projection(events, goal_id=goal_id or None)
+    except (OSError, StateEventError):
+        return None
+    for item_role in roles:
+        if item_role not in TODO_SECTION_HEADINGS:
+            continue
+        summary = projection.get(f"{item_role}_todos")
+        items = summary.get("items") if isinstance(summary, dict) else []
+        for item in items if isinstance(items, list) else []:
+            if not isinstance(item, dict):
+                continue
+            if normalize_todo_id(item.get("todo_id")) == todo_id:
+                return dict(item)
+    return None
+
+
+def event_projection_source_authority(context: Mapping[str, Any]) -> dict[str, Any]:
+    fields = context.get("fields") if isinstance(context.get("fields"), dict) else {}
+    projection = (
+        fields.get("state_event_projection")
+        if isinstance(fields, dict)
+        else None
+    )
+    projection = projection if isinstance(projection, dict) else {}
+    return {
+        "projection_source": "event_log",
+        "event_log_path": str(context.get("event_log_path") or ""),
+        "source_checksum": projection.get("source_checksum"),
+        "last_event_id": projection.get("last_event_id"),
+        "last_append_sequence": projection.get("last_append_sequence"),
+    }
+
+
+def event_projection_source_matches(
+    context: Mapping[str, Any],
+    source_authority: Mapping[str, Any] | None,
+) -> bool:
+    if not isinstance(source_authority, Mapping):
+        return True
+    if source_authority.get("projection_source") != "event_log":
+        return True
+    current = event_projection_source_authority(context)
+    return all(
+        current.get(key) == source_authority.get(key)
+        for key in (
+            "event_log_path",
+            "source_checksum",
+            "last_event_id",
+            "last_append_sequence",
+        )
+    )
+
+
+def _completion_validation_source_drift_failure(
+    *,
+    goal_id: str,
+    todo_id: str,
+    dry_run: bool,
+) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "dry_run": dry_run,
+        "completed": False,
+        "goal_id": goal_id,
+        "todo_id": todo_id,
+        "changed": False,
+        "validation": {
+            "schema_version": CALLER_VALIDATION_RECEIPT_SCHEMA_VERSION,
+            "command_label": "todo completion validation",
+            "exit_code": None,
+            "passed": False,
+            "status": "source_drift",
+            "summary": (
+                "event-log validation source changed before completion append; "
+                "retry the completion against the current canonical source"
+            ),
+            "stdout_captured": False,
+            "stderr_captured": False,
+            "local_path_captured": False,
+        },
+        "validation_blocked_completion": True,
+    }
 
 
 def event_projection_todo_context(
@@ -117,12 +213,19 @@ def event_projection_todo_context(
     )
     if event_log_path is None:
         return None
+    raw_item = _raw_event_projection_todo_item(
+        event_log_path=event_log_path,
+        goal_id=goal_id,
+        todo_id=normalized_todo_id,
+        roles=roles,
+    )
     return {
         "goal": goal,
         "fields": fields,
         "event_log_path": event_log_path,
         "role": matched_role,
         "item": matched_item,
+        "raw_item": raw_item or matched_item,
     }
 
 
@@ -328,12 +431,22 @@ def complete_event_projected_goal_todo(
     completion_turn_key: str | None = None,
     actor_agent_id: str | None = None,
     completion_fence: dict[str, Any] | None = None,
+    completion_validation_source_authority: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     item = dict(context["item"])
     role = str(context["role"])
     todo_id = normalize_todo_id(item.get("todo_id"))
     if not todo_id:
         raise ValueError("event-projected todo has no stable todo_id")
+    if not event_projection_source_matches(
+        context,
+        completion_validation_source_authority,
+    ):
+        return _completion_validation_source_drift_failure(
+            goal_id=goal_id,
+            todo_id=todo_id,
+            dry_run=dry_run,
+        )
     if clear_claim and item.get("claimed_by"):
         item.pop("claimed_by", None)
     effective_claimed_by = claimed_by or normalize_todo_claimed_by(item.get("claimed_by"))

--- a/loopx/event_sourced_state.py
+++ b/loopx/event_sourced_state.py
@@ -116,6 +116,32 @@ def compact_text(value: Any) -> str:
     return " ".join(str(value or "").strip().split())
 
 
+def _copy_todo_added_validation_fields(
+    source: dict[str, Any], target: dict[str, Any]
+) -> None:
+    """Copy caller-approved completion validation fields from a TODO_ADDED payload."""
+    for key in (
+        "validation_command",
+        "validation_label",
+        "validation_timeout_seconds",
+    ):
+        value = compact_text(source.get(key))
+        if value:
+            target[key] = value
+    argv = source.get("validation_command_argv")
+    if "validation_command_argv" not in source:
+        return
+    if isinstance(argv, list):
+        target["validation_command_argv"] = json.dumps(
+            argv, separators=(",", ":"), ensure_ascii=False
+        )
+        return
+    compact_argv = compact_text(argv)
+    # Persist a gate-visible value even for empty/corrupt payloads so complete
+    # fail-closes as malformed instead of treating the declaration as absent.
+    target["validation_command_argv"] = compact_argv if compact_argv else "[]"
+
+
 def _redact_public_backfill_text(value: Any, *, privacy: str) -> str:
     text = compact_text(value)
     if privacy != PUBLIC_PRIVACY:
@@ -326,6 +352,17 @@ def backfill_todo_events_from_markdown(
             payload["global_gate"] = global_gate
         if excluded_agents:
             payload["excluded_agents"] = excluded_agents
+        _copy_todo_added_validation_fields(record, payload)
+        if privacy == PUBLIC_PRIVACY:
+            for key in (
+                "validation_command",
+                "validation_command_argv",
+                "validation_label",
+            ):
+                if key in payload:
+                    payload[key] = _redact_public_backfill_text(
+                        payload[key], privacy=privacy
+                    )
         events.append(
             make_state_event(
                 event_id=_backfill_event_id(goal_id=normalized_goal_id, todo_id=todo_id, suffix="add"),
@@ -701,6 +738,7 @@ def _todo_from_added_event(event: dict[str, Any]) -> dict[str, Any]:
         todo["claimed_by"] = claimed_by
     if actor_agent_id:
         todo["created_by"] = actor_agent_id
+    _copy_todo_added_validation_fields(payload, todo)
     return todo
 
 
@@ -951,6 +989,14 @@ def render_todo_markdown(item: dict[str, Any]) -> list[str]:
         **monitor_metadata,
         note=item.get("note"),
         evidence=item.get("evidence"),
+        validation_command=item.get("validation_command"),
+        validation_command_argv=item.get("validation_command_argv"),
+        validation_label=item.get("validation_label"),
+        validation_timeout_seconds=(
+            str(item.get("validation_timeout_seconds"))
+            if item.get("validation_timeout_seconds") is not None
+            else None
+        ),
         completion_turn_key=item.get("completion_turn_key"),
         reason=item.get("reason"),
         completed_at=item.get("completed_at"),

--- a/loopx/event_sourced_state.py
+++ b/loopx/event_sourced_state.py
@@ -125,21 +125,10 @@ def _copy_todo_added_validation_fields(
         "validation_label",
         "validation_timeout_seconds",
     ):
-        value = compact_text(source.get(key))
-        if value:
-            target[key] = value
-    argv = source.get("validation_command_argv")
-    if "validation_command_argv" not in source:
-        return
-    if isinstance(argv, list):
-        target["validation_command_argv"] = json.dumps(
-            argv, separators=(",", ":"), ensure_ascii=False
-        )
-        return
-    compact_argv = compact_text(argv)
-    # Persist a gate-visible value even for empty/corrupt payloads so complete
-    # fail-closes as malformed instead of treating the declaration as absent.
-    target["validation_command_argv"] = compact_argv if compact_argv else "[]"
+        if key in source and source.get(key) is not None:
+            target[key] = source[key]
+    if "validation_command_argv" in source:
+        target["validation_command_argv"] = source.get("validation_command_argv")
 
 
 def _redact_public_backfill_text(value: Any, *, privacy: str) -> str:
@@ -990,7 +979,15 @@ def render_todo_markdown(item: dict[str, Any]) -> list[str]:
         note=item.get("note"),
         evidence=item.get("evidence"),
         validation_command=item.get("validation_command"),
-        validation_command_argv=item.get("validation_command_argv"),
+        validation_command_argv=(
+            json.dumps(
+                item.get("validation_command_argv"),
+                separators=(",", ":"),
+                ensure_ascii=False,
+            )
+            if isinstance(item.get("validation_command_argv"), list)
+            else item.get("validation_command_argv")
+        ),
         validation_label=item.get("validation_label"),
         validation_timeout_seconds=(
             str(item.get("validation_timeout_seconds"))

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -74,10 +74,7 @@ from .control_plane.todos.completion_policy import (
     resolve_completion_policy,
 )
 from .control_plane.todos.completion_fence import completed_todo_replay
-from .control_plane.todos.completion_validation import (
-    COMPLETION_VALIDATION_TIMEOUT_MAX_SECONDS,
-    run_completion_validation_gate,
-)
+from .control_plane.todos import completion_validation as completion_validation_module
 from .control_plane.todos.event_writeback import (
     complete_event_projected_goal_todo,
     event_projection_todo_context,
@@ -663,11 +660,11 @@ def add_todo_to_lines(
         if not (
             1
             <= validation_timeout_seconds
-            <= COMPLETION_VALIDATION_TIMEOUT_MAX_SECONDS
+            <= completion_validation_module.COMPLETION_VALIDATION_TIMEOUT_MAX_SECONDS
         ):
             raise ValueError(
                 "--validation-timeout-seconds must be between 1 and "
-                f"{COMPLETION_VALIDATION_TIMEOUT_MAX_SECONDS} (the outer "
+                f"{completion_validation_module.COMPLETION_VALIDATION_TIMEOUT_MAX_SECONDS} (the outer "
                 "CLI/MCP subprocess budget is 30s, and a timed-out "
                 "validation must still produce a typed receipt)"
             )
@@ -1313,7 +1310,7 @@ def update_goal_todo(
                 role=role,
             )
             if update_block_match and (role or update_block_match[0]) != "agent":
-                validation_failure = run_completion_validation_gate(
+                validation_failure = completion_validation_module.run_completion_validation_gate(
                     state_file=resolved_state_file,
                     todo_id=todo_id,
                     role=role,
@@ -1689,18 +1686,19 @@ def complete_goal_todo(
         project=project,
         state_file=state_file,
     )
-    # Run caller-approved validation BEFORE acquiring the mutation lock so a
-    # slow validation command does not block concurrent todo operations on the
-    # same goal (the MUTATION lock deadline is 5s). Returns a typed failure
-    # payload (ok=False) when validation blocks; otherwise None.
-    validation_failure = run_completion_validation_gate(
+    # Run caller-approved validation before locking so slow commands do not
+    # hold the 5s mutation lock; return typed failure payloads unchanged.
+    validation_gate = completion_validation_module.run_completion_validation_gate_with_source(
         state_file=resolved_state_file,
         todo_id=todo_id,
         role=role,
         registry_path=registry_path,
         goal_id=goal_id,
         dry_run=dry_run,
+        no_followup=no_followup,
+        completion_turn_key=completion_turn_key,
     )
+    validation_failure = validation_gate.get("failure")
     if validation_failure is not None:
         return validation_failure
     with exclusive_file_lock(
@@ -1866,6 +1864,7 @@ def complete_goal_todo(
                     updated_at=updated_at,
                     dry_run=dry_run,
                     actor_agent_id=mutation_authority.get("actor_agent_id"),
+                    completion_validation_source_authority=validation_gate.get("source_authority"),
                 )
                 event_result["linked_successor_id"] = completion_policy.linked_successor_id
                 event_result["mutation_authority"] = mutation_authority

--- a/tests/control_plane/test_todo_completion_validation.py
+++ b/tests/control_plane/test_todo_completion_validation.py
@@ -5,12 +5,26 @@ import re
 import shlex
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 import loopx.control_plane.todos.completion_validation as completion_validation_module
+from loopx.event_sourced_state import (
+    TODO_ADDED,
+    TODO_COMPLETED,
+    AppendOnlyStateEventStore,
+    PUBLIC_BACKFILL_REDACTION,
+    backfill_todo_events_from_markdown,
+    build_state_projection,
+    make_state_event,
+    render_todo_markdown,
+)
 from loopx.status import parse_active_state_todos
-from loopx.todos import add_goal_todo, complete_goal_todo, update_goal_todo
+from loopx.control_plane.todos.completion_validation_projection import (
+    project_completion_validation_authority,
+)
+from loopx.todos import add_goal_todo, complete_goal_todo, list_goal_todos, update_goal_todo
 
 GOAL_ID = "todo-completion-validation"
 AGENT = "codex-author"
@@ -605,3 +619,520 @@ def test_agent_todo_update_done_keeps_guard_error_without_running_gate(
     # The gate never runs for agent sections; the pre-existing guard fires.
     assert calls["count"] == 0
     assert _agent_todo(state, str(todo["todo_id"]))["status"] == "open"
+
+
+def _add_event_only_todo(
+    state: Path,
+    *,
+    todo_id: str = "todo_event_validation",
+    validation_command: str | None = None,
+    validation_command_argv: list[str] | None = None,
+    validation_label: str | None = None,
+    validation_timeout_seconds: int | None = None,
+) -> str:
+    store = AppendOnlyStateEventStore(state.with_name("events.jsonl"))
+    payload: dict[str, Any] = {
+        "role": "agent",
+        "title": "Deliver one event-projected change.",
+        "task_class": "advancement_task",
+        "claimed_by": AGENT,
+    }
+    if validation_command:
+        payload["validation_command"] = validation_command
+    if validation_command_argv is not None:
+        payload["validation_command_argv"] = validation_command_argv
+    if validation_label:
+        payload["validation_label"] = validation_label
+    if validation_timeout_seconds is not None:
+        payload["validation_timeout_seconds"] = validation_timeout_seconds
+    store.append(
+        make_state_event(
+            event_id=f"evt-{todo_id}-add",
+            goal_id=GOAL_ID,
+            event_type=TODO_ADDED,
+            refs={"todo_id": todo_id},
+            payload=payload,
+            recorded_at="2026-08-22T00:00:00+00:00",
+        )
+    )
+    return todo_id
+
+
+def _event_todo_completed_count(state: Path) -> int:
+    events = AppendOnlyStateEventStore(state.with_name("events.jsonl")).load()
+    return sum(event["event_type"] == TODO_COMPLETED for event in events)
+
+
+def test_event_projected_failing_validation_blocks_completion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo_id = _add_event_only_todo(
+        state,
+        validation_command=_FAIL_COMMAND,
+        validation_label="event-projected smoke",
+    )
+    calls = _spy_validation_runner(monkeypatch)
+
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="claim of completion",
+        no_followup=True,
+    )
+
+    assert calls["count"] == 1
+    assert result["ok"] is False
+    assert result["validation_blocked_completion"] is True
+    assert result["changed"] is False
+    assert result["validation"]["passed"] is False
+    assert _event_todo_completed_count(state) == 0
+
+
+def test_event_projected_passing_validation_commits_completion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo_id = _add_event_only_todo(
+        state,
+        validation_command=_PASS_COMMAND,
+        validation_label="event-projected smoke",
+    )
+    calls = _spy_validation_runner(monkeypatch)
+
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="validated completion",
+        no_followup=True,
+    )
+
+    assert calls["count"] == 1
+    assert result["ok"] is True
+    assert result["changed"] is True
+    assert result["source"] == "event_log"
+    assert "validation_blocked_completion" not in result
+    assert _event_todo_completed_count(state) == 1
+
+
+def test_event_projected_without_validation_keeps_fast_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo_id = _add_event_only_todo(state)
+    calls = _spy_validation_runner(monkeypatch)
+
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="undeclared fast path",
+        no_followup=True,
+    )
+
+    assert calls["count"] == 0
+    assert result["ok"] is True
+    assert result["changed"] is True
+    assert result["source"] == "event_log"
+    assert _event_todo_completed_count(state) == 1
+
+
+def test_event_projection_preserves_declared_validation_command() -> None:
+    events = backfill_todo_events_from_markdown(
+        "\n".join(
+            [
+                "## Agent Todo",
+                "",
+                "- [ ] Deliver one event-projected change.",
+                (
+                    "  <!-- loopx:todo todo_id=todo_event_val001 status=open "
+                    "task_class=advancement_task claimed_by=codex-author "
+                    "validation_command=pytest validation_label=caller-smoke "
+                    "validation_timeout_seconds=5 -->"
+                ),
+            ]
+        ),
+        goal_id=GOAL_ID,
+    )
+    projection = build_state_projection(events)
+    item = projection["agent_todos"]["items"][0]
+    assert item["validation_command"] == "pytest"
+    assert item["validation_label"] == "caller-smoke"
+    assert item["validation_timeout_seconds"] == "5"
+    rendered = "\n".join(render_todo_markdown(item))
+    assert "validation_command=pytest" in rendered
+    assert "validation_timeout_seconds=5" in rendered
+    public = project_completion_validation_authority(item)
+    assert public["completion_validation_required"] is True
+    assert "validation_command" not in public
+    assert "validation_timeout_seconds" not in public
+    assert "validation_command_argv" not in public
+    assert "validation_label" not in public
+
+
+def test_event_projected_passing_argv_commits_completion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo_id = _add_event_only_todo(
+        state,
+        todo_id="todo_event_argv_pass",
+        validation_command_argv=[sys.executable, "-c", "pass"],
+        validation_label="event argv smoke",
+    )
+    calls = _spy_validation_runner(monkeypatch)
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="validated argv completion",
+        no_followup=True,
+    )
+    assert calls["count"] == 1
+    assert result["ok"] is True
+    assert result["changed"] is True
+    assert result["source"] == "event_log"
+    assert _event_todo_completed_count(state) == 1
+
+
+def test_event_projected_failing_argv_blocks_completion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo_id = _add_event_only_todo(
+        state,
+        todo_id="todo_event_argv",
+        validation_command_argv=[sys.executable, "-c", "raise SystemExit(1)"],
+        validation_label="event argv smoke",
+    )
+    calls = _spy_validation_runner(monkeypatch)
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="claim of completion",
+        no_followup=True,
+    )
+    assert calls["count"] == 1
+    assert result["ok"] is False
+    assert result["validation_blocked_completion"] is True
+    assert _event_todo_completed_count(state) == 0
+
+
+def test_event_projected_empty_argv_fails_closed(tmp_path: Path) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo_id = _add_event_only_todo(
+        state,
+        todo_id="todo_event_empty_argv",
+        validation_command_argv=[],
+    )
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="corrupted argv must not skip the gate",
+        no_followup=True,
+    )
+    assert result["ok"] is False
+    assert result["validation_blocked_completion"] is True
+    assert result["validation"]["status"] == "command_malformed"
+    assert _event_todo_completed_count(state) == 0
+
+
+def test_event_projected_timeout_blocks_completion(tmp_path: Path) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo_id = _add_event_only_todo(
+        state,
+        todo_id="todo_event_timeout",
+        validation_command=_SLEEP_COMMAND,
+        validation_timeout_seconds=1,
+    )
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="timed-out claim",
+        no_followup=True,
+    )
+    assert result["ok"] is False
+    assert result["validation_blocked_completion"] is True
+    assert result["validation"]["status"] == "timeout"
+    assert _event_todo_completed_count(state) == 0
+
+
+def test_markdown_todo_remains_authoritative_over_event_declaration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo = _add_todo(registry)
+    _add_event_only_todo(
+        state,
+        todo_id=str(todo["todo_id"]),
+        validation_command=_FAIL_COMMAND,
+    )
+    calls = _spy_validation_runner(monkeypatch)
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=str(todo["todo_id"]),
+        agent_id=AGENT,
+        evidence="markdown has no declared command",
+        no_followup=True,
+    )
+    assert calls["count"] == 0
+    assert result["ok"] is True
+    assert result["changed"] is True
+    assert "validation_blocked_completion" not in result
+
+
+def test_event_list_projection_strips_command_but_complete_still_runs_gate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo_id = _add_event_only_todo(
+        state,
+        todo_id="todo_event_list_strip",
+        validation_command_argv=[sys.executable, "-c", "raise SystemExit(1)"],
+        validation_label="must not leak",
+        validation_timeout_seconds=5,
+    )
+    listed = list_goal_todos(registry_path=registry, goal_id=GOAL_ID)
+    item = next(todo for todo in listed["todos"] if todo["todo_id"] == todo_id)
+    assert item.get("completion_validation_required") is True
+    assert "validation_command" not in item
+    assert "validation_command_argv" not in item
+    assert "validation_label" not in item
+    assert "validation_timeout_seconds" not in item
+    calls = _spy_validation_runner(monkeypatch)
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="list stripping must not disable the gate",
+        no_followup=True,
+    )
+    assert calls["count"] == 1
+    assert result["ok"] is False
+    assert result["validation_blocked_completion"] is True
+    assert _event_todo_completed_count(state) == 0
+
+
+def test_event_projected_corrupt_argv_object_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    store = AppendOnlyStateEventStore(state.with_name("events.jsonl"))
+    todo_id = "todo_event_corrupt_argv"
+    store.append(
+        make_state_event(
+            event_id=f"evt-{todo_id}-add",
+            goal_id=GOAL_ID,
+            event_type=TODO_ADDED,
+            refs={"todo_id": todo_id},
+            payload={
+                "role": "agent",
+                "title": "Deliver one event-projected change.",
+                "task_class": "advancement_task",
+                "claimed_by": AGENT,
+                "validation_command_argv": {},
+            },
+            recorded_at="2026-08-22T00:00:00+00:00",
+        )
+    )
+    calls = _spy_validation_runner(monkeypatch)
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="corrupt argv must not skip the gate",
+        no_followup=True,
+    )
+    assert calls["count"] == 1
+    assert result["ok"] is False
+    assert result["validation_blocked_completion"] is True
+    assert result["validation"]["status"] == "command_malformed"
+    assert _event_todo_completed_count(state) == 0
+
+
+def test_event_projected_null_argv_string_fails_closed(tmp_path: Path) -> None:
+    registry, state = _write_fixture(tmp_path)
+    store = AppendOnlyStateEventStore(state.with_name("events.jsonl"))
+    todo_id = "todo_event_null_argv"
+    store.append(
+        make_state_event(
+            event_id=f"evt-{todo_id}-add",
+            goal_id=GOAL_ID,
+            event_type=TODO_ADDED,
+            refs={"todo_id": todo_id},
+            payload={
+                "role": "agent",
+                "title": "Deliver one event-projected change.",
+                "task_class": "advancement_task",
+                "claimed_by": AGENT,
+                "validation_command_argv": "null",
+            },
+            recorded_at="2026-08-22T00:00:00+00:00",
+        )
+    )
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="null argv string must fail closed",
+        no_followup=True,
+    )
+    assert result["ok"] is False
+    assert result["validation_blocked_completion"] is True
+    assert result["validation"]["status"] == "command_malformed"
+    public = project_completion_validation_authority(
+        {"validation_command_argv": "null"}
+    )
+    assert public["completion_validation_required"] is True
+    assert "validation_command_argv" not in public
+
+
+def test_event_log_for_another_goal_does_not_supply_validation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    store = AppendOnlyStateEventStore(state.with_name("events.jsonl"))
+    todo_id = "todo_event_foreign_goal"
+    store.append(
+        make_state_event(
+            event_id=f"evt-{todo_id}-add",
+            goal_id="other-goal",
+            event_type=TODO_ADDED,
+            refs={"todo_id": todo_id},
+            payload={
+                "role": "agent",
+                "title": "Deliver one event-projected change.",
+                "task_class": "advancement_task",
+                "claimed_by": AGENT,
+                "validation_command": _FAIL_COMMAND,
+            },
+            recorded_at="2026-08-22T00:00:00+00:00",
+        )
+    )
+    calls = _spy_validation_runner(monkeypatch)
+    with pytest.raises(ValueError, match="was not found"):
+        complete_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=todo_id,
+            agent_id=AGENT,
+            evidence="foreign goal declaration must not run",
+            no_followup=True,
+        )
+    assert calls["count"] == 0
+
+
+def test_missing_markdown_file_gate_still_reads_event_declaration(
+    tmp_path: Path,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo_id = _add_event_only_todo(
+        state,
+        todo_id="todo_event_no_markdown",
+        validation_command=_FAIL_COMMAND,
+    )
+    state.unlink()
+    result = completion_validation_module.run_completion_validation_gate(
+        state_file=state,
+        todo_id=todo_id,
+        role="agent",
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        dry_run=False,
+    )
+    assert result is not None
+    assert result["ok"] is False
+    assert result["validation_blocked_completion"] is True
+    assert _event_todo_completed_count(state) == 0
+
+
+def test_sidecar_declaration_is_not_masked_by_earlier_undeclared_log(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo_id = "todo_event_two_logs"
+    older = state.with_name("older-events.jsonl")
+    AppendOnlyStateEventStore(older).append(
+        make_state_event(
+            event_id=f"evt-{todo_id}-old",
+            goal_id=GOAL_ID,
+            event_type=TODO_ADDED,
+            refs={"todo_id": todo_id},
+            payload={
+                "role": "agent",
+                "title": "Deliver one event-projected change.",
+                "task_class": "advancement_task",
+                "claimed_by": AGENT,
+            },
+            recorded_at="2026-08-21T00:00:00+00:00",
+        )
+    )
+    _add_event_only_todo(
+        state,
+        todo_id=todo_id,
+        validation_command=_FAIL_COMMAND,
+    )
+    data = json.loads(registry.read_text(encoding="utf-8"))
+    data["goals"][0]["event_log"] = str(older)
+    registry.write_text(json.dumps(data), encoding="utf-8")
+    calls = _spy_validation_runner(monkeypatch)
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="older undeclared snapshot must not skip the sidecar gate",
+        no_followup=True,
+    )
+    assert calls["count"] == 1
+    assert result["ok"] is False
+    assert result["validation_blocked_completion"] is True
+    assert _event_todo_completed_count(state) == 0
+
+
+def test_public_safe_backfill_redacts_unsafe_validation_command() -> None:
+    events = backfill_todo_events_from_markdown(
+        "\n".join(
+            [
+                "## Agent Todo",
+                "",
+                "- [ ] Deliver one event-projected change.",
+                (
+                    "  <!-- loopx:todo todo_id=todo_event_val_redact status=open "
+                    "task_class=advancement_task claimed_by=codex-author "
+                    "validation_command=/Users/loopx/bin/pytest -->"
+                ),
+            ]
+        ),
+        goal_id=GOAL_ID,
+        privacy="public_safe",
+    )
+    payload = events[0]["payload"]
+    assert payload["validation_command"] == PUBLIC_BACKFILL_REDACTION
+    assert "/Users/" not in json.dumps(events)

--- a/tests/control_plane/test_todo_completion_validation.py
+++ b/tests/control_plane/test_todo_completion_validation.py
@@ -10,21 +10,21 @@ from typing import Any
 import pytest
 
 import loopx.control_plane.todos.completion_validation as completion_validation_module
+from loopx.control_plane.todos.completion_validation_projection import (
+    project_completion_validation_authority,
+)
 from loopx.event_sourced_state import (
     TODO_ADDED,
     TODO_COMPLETED,
+    TODO_DEFERRED,
+    TODO_UPDATED,
     AppendOnlyStateEventStore,
-    PUBLIC_BACKFILL_REDACTION,
-    backfill_todo_events_from_markdown,
     build_state_projection,
     make_state_event,
     render_todo_markdown,
 )
 from loopx.status import parse_active_state_todos
-from loopx.control_plane.todos.completion_validation_projection import (
-    project_completion_validation_authority,
-)
-from loopx.todos import add_goal_todo, complete_goal_todo, list_goal_todos, update_goal_todo
+from loopx.todos import add_goal_todo, complete_goal_todo, update_goal_todo
 
 GOAL_ID = "todo-completion-validation"
 AGENT = "codex-author"
@@ -459,7 +459,8 @@ def test_corrupted_argv_declaration_fails_closed(tmp_path: Path) -> None:
     assert result["validation_blocked_completion"] is True
     receipt = result["validation"]
     assert receipt["passed"] is False
-    assert receipt["status"] == "command_malformed"
+    assert receipt["status"] == "declaration_invalid"
+    assert "validation_command_argv" in receipt["summary"]
     assert _agent_todo(state, str(todo["todo_id"]))["status"] == "open"
 
 
@@ -625,23 +626,24 @@ def _add_event_only_todo(
     state: Path,
     *,
     todo_id: str = "todo_event_validation",
-    validation_command: str | None = None,
-    validation_command_argv: list[str] | None = None,
-    validation_label: str | None = None,
-    validation_timeout_seconds: int | None = None,
+    validation_command: Any = None,
+    validation_command_argv: Any = None,
+    validation_label: Any = None,
+    validation_timeout_seconds: Any = None,
+    event_log: Path | None = None,
 ) -> str:
-    store = AppendOnlyStateEventStore(state.with_name("events.jsonl"))
+    store = AppendOnlyStateEventStore(event_log or state.with_name("events.jsonl"))
     payload: dict[str, Any] = {
         "role": "agent",
         "title": "Deliver one event-projected change.",
         "task_class": "advancement_task",
         "claimed_by": AGENT,
     }
-    if validation_command:
+    if validation_command is not None:
         payload["validation_command"] = validation_command
     if validation_command_argv is not None:
         payload["validation_command_argv"] = validation_command_argv
-    if validation_label:
+    if validation_label is not None:
         payload["validation_label"] = validation_label
     if validation_timeout_seconds is not None:
         payload["validation_timeout_seconds"] = validation_timeout_seconds
@@ -658,9 +660,68 @@ def _add_event_only_todo(
     return todo_id
 
 
-def _event_todo_completed_count(state: Path) -> int:
-    events = AppendOnlyStateEventStore(state.with_name("events.jsonl")).load()
+def _defer_event_todo(state: Path, *, todo_id: str) -> None:
+    AppendOnlyStateEventStore(state.with_name("events.jsonl")).append(
+        make_state_event(
+            event_id=f"evt-{todo_id}-defer",
+            goal_id=GOAL_ID,
+            event_type=TODO_DEFERRED,
+            refs={"todo_id": todo_id},
+            payload={
+                "reason": "waiting for owner signal",
+                "resume_when": "manual",
+            },
+            recorded_at="2026-08-22T00:01:00+00:00",
+        )
+    )
+
+
+def _event_todo_completed_count(event_log: Path) -> int:
+    events = AppendOnlyStateEventStore(event_log).load()
     return sum(event["event_type"] == TODO_COMPLETED for event in events)
+
+
+def _set_registry_event_log(registry: Path, event_log: Path) -> None:
+    data = json.loads(registry.read_text(encoding="utf-8"))
+    data["goals"][0]["event_log"] = str(event_log)
+    registry.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_event_projection_preserves_private_validation_and_public_marker() -> None:
+    todo_id = "todo_event_projected_validation"
+    events = [
+        make_state_event(
+            event_id=f"evt-{todo_id}-add",
+            goal_id=GOAL_ID,
+            event_type=TODO_ADDED,
+            refs={"todo_id": todo_id},
+            payload={
+                "role": "agent",
+                "title": "Deliver one event-projected change.",
+                "task_class": "advancement_task",
+                "claimed_by": AGENT,
+                "validation_command_argv": [sys.executable, "-c", "pass"],
+                "validation_label": "event argv smoke",
+                "validation_timeout_seconds": 5,
+            },
+            recorded_at="2026-08-22T00:00:00+00:00",
+        )
+    ]
+
+    projection = build_state_projection(events, goal_id=GOAL_ID)
+    item = projection["agent_todos"]["items"][0]
+
+    assert item["validation_command_argv"] == [sys.executable, "-c", "pass"]
+    assert item["validation_label"] == "event argv smoke"
+    assert item["validation_timeout_seconds"] == 5
+    rendered = "\n".join(render_todo_markdown(item))
+    assert "validation_command_argv=" in rendered
+    public = project_completion_validation_authority(item)
+    assert public["completion_validation_required"] is True
+    assert "validation_command" not in public
+    assert "validation_command_argv" not in public
+    assert "validation_label" not in public
+    assert "validation_timeout_seconds" not in public
 
 
 def test_event_projected_failing_validation_blocks_completion(
@@ -687,452 +748,159 @@ def test_event_projected_failing_validation_blocks_completion(
     assert calls["count"] == 1
     assert result["ok"] is False
     assert result["validation_blocked_completion"] is True
-    assert result["changed"] is False
     assert result["validation"]["passed"] is False
-    assert _event_todo_completed_count(state) == 0
+    assert _event_todo_completed_count(state.with_name("events.jsonl")) == 0
 
 
-def test_event_projected_passing_validation_commits_completion(
+def test_event_projected_deferred_validation_replays_without_running_command(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     registry, state = _write_fixture(tmp_path)
     todo_id = _add_event_only_todo(
         state,
-        validation_command=_PASS_COMMAND,
-        validation_label="event-projected smoke",
-    )
-    calls = _spy_validation_runner(monkeypatch)
-
-    result = complete_goal_todo(
-        registry_path=registry,
-        goal_id=GOAL_ID,
-        todo_id=todo_id,
-        agent_id=AGENT,
-        evidence="validated completion",
-        no_followup=True,
-    )
-
-    assert calls["count"] == 1
-    assert result["ok"] is True
-    assert result["changed"] is True
-    assert result["source"] == "event_log"
-    assert "validation_blocked_completion" not in result
-    assert _event_todo_completed_count(state) == 1
-
-
-def test_event_projected_without_validation_keeps_fast_path(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    registry, state = _write_fixture(tmp_path)
-    todo_id = _add_event_only_todo(state)
-    calls = _spy_validation_runner(monkeypatch)
-
-    result = complete_goal_todo(
-        registry_path=registry,
-        goal_id=GOAL_ID,
-        todo_id=todo_id,
-        agent_id=AGENT,
-        evidence="undeclared fast path",
-        no_followup=True,
-    )
-
-    assert calls["count"] == 0
-    assert result["ok"] is True
-    assert result["changed"] is True
-    assert result["source"] == "event_log"
-    assert _event_todo_completed_count(state) == 1
-
-
-def test_event_projection_preserves_declared_validation_command() -> None:
-    events = backfill_todo_events_from_markdown(
-        "\n".join(
-            [
-                "## Agent Todo",
-                "",
-                "- [ ] Deliver one event-projected change.",
-                (
-                    "  <!-- loopx:todo todo_id=todo_event_val001 status=open "
-                    "task_class=advancement_task claimed_by=codex-author "
-                    "validation_command=pytest validation_label=caller-smoke "
-                    "validation_timeout_seconds=5 -->"
-                ),
-            ]
-        ),
-        goal_id=GOAL_ID,
-    )
-    projection = build_state_projection(events)
-    item = projection["agent_todos"]["items"][0]
-    assert item["validation_command"] == "pytest"
-    assert item["validation_label"] == "caller-smoke"
-    assert item["validation_timeout_seconds"] == "5"
-    rendered = "\n".join(render_todo_markdown(item))
-    assert "validation_command=pytest" in rendered
-    assert "validation_timeout_seconds=5" in rendered
-    public = project_completion_validation_authority(item)
-    assert public["completion_validation_required"] is True
-    assert "validation_command" not in public
-    assert "validation_timeout_seconds" not in public
-    assert "validation_command_argv" not in public
-    assert "validation_label" not in public
-
-
-def test_event_projected_passing_argv_commits_completion(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    registry, state = _write_fixture(tmp_path)
-    todo_id = _add_event_only_todo(
-        state,
-        todo_id="todo_event_argv_pass",
-        validation_command_argv=[sys.executable, "-c", "pass"],
-        validation_label="event argv smoke",
-    )
-    calls = _spy_validation_runner(monkeypatch)
-    result = complete_goal_todo(
-        registry_path=registry,
-        goal_id=GOAL_ID,
-        todo_id=todo_id,
-        agent_id=AGENT,
-        evidence="validated argv completion",
-        no_followup=True,
-    )
-    assert calls["count"] == 1
-    assert result["ok"] is True
-    assert result["changed"] is True
-    assert result["source"] == "event_log"
-    assert _event_todo_completed_count(state) == 1
-
-
-def test_event_projected_failing_argv_blocks_completion(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    registry, state = _write_fixture(tmp_path)
-    todo_id = _add_event_only_todo(
-        state,
-        todo_id="todo_event_argv",
-        validation_command_argv=[sys.executable, "-c", "raise SystemExit(1)"],
-        validation_label="event argv smoke",
-    )
-    calls = _spy_validation_runner(monkeypatch)
-    result = complete_goal_todo(
-        registry_path=registry,
-        goal_id=GOAL_ID,
-        todo_id=todo_id,
-        agent_id=AGENT,
-        evidence="claim of completion",
-        no_followup=True,
-    )
-    assert calls["count"] == 1
-    assert result["ok"] is False
-    assert result["validation_blocked_completion"] is True
-    assert _event_todo_completed_count(state) == 0
-
-
-def test_event_projected_empty_argv_fails_closed(tmp_path: Path) -> None:
-    registry, state = _write_fixture(tmp_path)
-    todo_id = _add_event_only_todo(
-        state,
-        todo_id="todo_event_empty_argv",
-        validation_command_argv=[],
-    )
-    result = complete_goal_todo(
-        registry_path=registry,
-        goal_id=GOAL_ID,
-        todo_id=todo_id,
-        agent_id=AGENT,
-        evidence="corrupted argv must not skip the gate",
-        no_followup=True,
-    )
-    assert result["ok"] is False
-    assert result["validation_blocked_completion"] is True
-    assert result["validation"]["status"] == "command_malformed"
-    assert _event_todo_completed_count(state) == 0
-
-
-def test_event_projected_timeout_blocks_completion(tmp_path: Path) -> None:
-    registry, state = _write_fixture(tmp_path)
-    todo_id = _add_event_only_todo(
-        state,
-        todo_id="todo_event_timeout",
-        validation_command=_SLEEP_COMMAND,
-        validation_timeout_seconds=1,
-    )
-    result = complete_goal_todo(
-        registry_path=registry,
-        goal_id=GOAL_ID,
-        todo_id=todo_id,
-        agent_id=AGENT,
-        evidence="timed-out claim",
-        no_followup=True,
-    )
-    assert result["ok"] is False
-    assert result["validation_blocked_completion"] is True
-    assert result["validation"]["status"] == "timeout"
-    assert _event_todo_completed_count(state) == 0
-
-
-def test_markdown_todo_remains_authoritative_over_event_declaration(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    registry, state = _write_fixture(tmp_path)
-    todo = _add_todo(registry)
-    _add_event_only_todo(
-        state,
-        todo_id=str(todo["todo_id"]),
+        todo_id="todo_event_deferred_validation",
         validation_command=_FAIL_COMMAND,
     )
+    _defer_event_todo(state, todo_id=todo_id)
     calls = _spy_validation_runner(monkeypatch)
+
     result = complete_goal_todo(
         registry_path=registry,
         goal_id=GOAL_ID,
-        todo_id=str(todo["todo_id"]),
+        todo_id=todo_id,
         agent_id=AGENT,
-        evidence="markdown has no declared command",
+        evidence="terminal replay request",
         no_followup=True,
     )
+
     assert calls["count"] == 0
     assert result["ok"] is True
-    assert result["changed"] is True
+    assert result["idempotent_replay"] is True
+    assert result["changed"] is False
     assert "validation_blocked_completion" not in result
+    assert _event_todo_completed_count(state.with_name("events.jsonl")) == 0
 
 
-def test_event_list_projection_strips_command_but_complete_still_runs_gate(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    registry, state = _write_fixture(tmp_path)
-    todo_id = _add_event_only_todo(
-        state,
-        todo_id="todo_event_list_strip",
-        validation_command_argv=[sys.executable, "-c", "raise SystemExit(1)"],
-        validation_label="must not leak",
-        validation_timeout_seconds=5,
-    )
-    listed = list_goal_todos(registry_path=registry, goal_id=GOAL_ID)
-    item = next(todo for todo in listed["todos"] if todo["todo_id"] == todo_id)
-    assert item.get("completion_validation_required") is True
-    assert "validation_command" not in item
-    assert "validation_command_argv" not in item
-    assert "validation_label" not in item
-    assert "validation_timeout_seconds" not in item
-    calls = _spy_validation_runner(monkeypatch)
-    result = complete_goal_todo(
-        registry_path=registry,
-        goal_id=GOAL_ID,
-        todo_id=todo_id,
-        agent_id=AGENT,
-        evidence="list stripping must not disable the gate",
-        no_followup=True,
-    )
-    assert calls["count"] == 1
-    assert result["ok"] is False
-    assert result["validation_blocked_completion"] is True
-    assert _event_todo_completed_count(state) == 0
-
-
-def test_event_projected_corrupt_argv_object_fails_closed(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    registry, state = _write_fixture(tmp_path)
-    store = AppendOnlyStateEventStore(state.with_name("events.jsonl"))
-    todo_id = "todo_event_corrupt_argv"
-    store.append(
-        make_state_event(
-            event_id=f"evt-{todo_id}-add",
-            goal_id=GOAL_ID,
-            event_type=TODO_ADDED,
-            refs={"todo_id": todo_id},
-            payload={
-                "role": "agent",
-                "title": "Deliver one event-projected change.",
-                "task_class": "advancement_task",
-                "claimed_by": AGENT,
-                "validation_command_argv": {},
-            },
-            recorded_at="2026-08-22T00:00:00+00:00",
-        )
-    )
-    calls = _spy_validation_runner(monkeypatch)
-    result = complete_goal_todo(
-        registry_path=registry,
-        goal_id=GOAL_ID,
-        todo_id=todo_id,
-        agent_id=AGENT,
-        evidence="corrupt argv must not skip the gate",
-        no_followup=True,
-    )
-    assert calls["count"] == 1
-    assert result["ok"] is False
-    assert result["validation_blocked_completion"] is True
-    assert result["validation"]["status"] == "command_malformed"
-    assert _event_todo_completed_count(state) == 0
-
-
-def test_event_projected_null_argv_string_fails_closed(tmp_path: Path) -> None:
-    registry, state = _write_fixture(tmp_path)
-    store = AppendOnlyStateEventStore(state.with_name("events.jsonl"))
-    todo_id = "todo_event_null_argv"
-    store.append(
-        make_state_event(
-            event_id=f"evt-{todo_id}-add",
-            goal_id=GOAL_ID,
-            event_type=TODO_ADDED,
-            refs={"todo_id": todo_id},
-            payload={
-                "role": "agent",
-                "title": "Deliver one event-projected change.",
-                "task_class": "advancement_task",
-                "claimed_by": AGENT,
-                "validation_command_argv": "null",
-            },
-            recorded_at="2026-08-22T00:00:00+00:00",
-        )
-    )
-    result = complete_goal_todo(
-        registry_path=registry,
-        goal_id=GOAL_ID,
-        todo_id=todo_id,
-        agent_id=AGENT,
-        evidence="null argv string must fail closed",
-        no_followup=True,
-    )
-    assert result["ok"] is False
-    assert result["validation_blocked_completion"] is True
-    assert result["validation"]["status"] == "command_malformed"
-    public = project_completion_validation_authority(
-        {"validation_command_argv": "null"}
-    )
-    assert public["completion_validation_required"] is True
-    assert "validation_command_argv" not in public
-
-
-def test_event_log_for_another_goal_does_not_supply_validation(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    registry, state = _write_fixture(tmp_path)
-    store = AppendOnlyStateEventStore(state.with_name("events.jsonl"))
-    todo_id = "todo_event_foreign_goal"
-    store.append(
-        make_state_event(
-            event_id=f"evt-{todo_id}-add",
-            goal_id="other-goal",
-            event_type=TODO_ADDED,
-            refs={"todo_id": todo_id},
-            payload={
-                "role": "agent",
-                "title": "Deliver one event-projected change.",
-                "task_class": "advancement_task",
-                "claimed_by": AGENT,
-                "validation_command": _FAIL_COMMAND,
-            },
-            recorded_at="2026-08-22T00:00:00+00:00",
-        )
-    )
-    calls = _spy_validation_runner(monkeypatch)
-    with pytest.raises(ValueError, match="was not found"):
-        complete_goal_todo(
-            registry_path=registry,
-            goal_id=GOAL_ID,
-            todo_id=todo_id,
-            agent_id=AGENT,
-            evidence="foreign goal declaration must not run",
-            no_followup=True,
-        )
-    assert calls["count"] == 0
-
-
-def test_missing_markdown_file_gate_still_reads_event_declaration(
-    tmp_path: Path,
-) -> None:
-    registry, state = _write_fixture(tmp_path)
-    todo_id = _add_event_only_todo(
-        state,
-        todo_id="todo_event_no_markdown",
-        validation_command=_FAIL_COMMAND,
-    )
-    state.unlink()
-    result = completion_validation_module.run_completion_validation_gate(
-        state_file=state,
-        todo_id=todo_id,
-        role="agent",
-        registry_path=registry,
-        goal_id=GOAL_ID,
-        dry_run=False,
-    )
-    assert result is not None
-    assert result["ok"] is False
-    assert result["validation_blocked_completion"] is True
-    assert _event_todo_completed_count(state) == 0
-
-
-def test_sidecar_declaration_is_not_masked_by_earlier_undeclared_log(
+def test_noncanonical_sidecar_cannot_inject_validation_command(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     registry, state = _write_fixture(tmp_path)
     todo_id = "todo_event_two_logs"
-    older = state.with_name("older-events.jsonl")
-    AppendOnlyStateEventStore(older).append(
-        make_state_event(
-            event_id=f"evt-{todo_id}-old",
-            goal_id=GOAL_ID,
-            event_type=TODO_ADDED,
-            refs={"todo_id": todo_id},
-            payload={
-                "role": "agent",
-                "title": "Deliver one event-projected change.",
-                "task_class": "advancement_task",
-                "claimed_by": AGENT,
-            },
-            recorded_at="2026-08-21T00:00:00+00:00",
-        )
-    )
+    canonical = state.with_name("canonical-events.jsonl")
+    _add_event_only_todo(state, todo_id=todo_id, event_log=canonical)
     _add_event_only_todo(
         state,
         todo_id=todo_id,
         validation_command=_FAIL_COMMAND,
     )
-    data = json.loads(registry.read_text(encoding="utf-8"))
-    data["goals"][0]["event_log"] = str(older)
-    registry.write_text(json.dumps(data), encoding="utf-8")
+    _set_registry_event_log(registry, canonical)
     calls = _spy_validation_runner(monkeypatch)
+
     result = complete_goal_todo(
         registry_path=registry,
         goal_id=GOAL_ID,
         todo_id=todo_id,
         agent_id=AGENT,
-        evidence="older undeclared snapshot must not skip the sidecar gate",
+        evidence="canonical source has no declaration",
         no_followup=True,
     )
+
+    assert calls["count"] == 0
+    assert result["ok"] is True
+    assert result["changed"] is True
+    assert result["source"] == "event_log"
+    assert _event_todo_completed_count(canonical) == 1
+    assert _event_todo_completed_count(state.with_name("events.jsonl")) == 0
+
+
+@pytest.mark.parametrize("timeout_value", [0, 30, "not-int", {"seconds": 5}])
+def test_event_projected_invalid_timeout_rejects_without_running_command(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    timeout_value: Any,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo_id = _add_event_only_todo(
+        state,
+        todo_id="todo_event_invalid_timeout",
+        validation_command=_PASS_COMMAND,
+        validation_timeout_seconds=timeout_value,
+    )
+    calls = _spy_validation_runner(monkeypatch)
+
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="invalid persisted timeout must fail closed",
+        no_followup=True,
+    )
+
+    assert calls["count"] == 0
+    assert result["ok"] is False
+    assert result["validation_blocked_completion"] is True
+    assert result["validation"]["status"] == "declaration_invalid"
+    assert "validation_timeout_seconds" in result["validation"]["summary"]
+    assert _event_todo_completed_count(state.with_name("events.jsonl")) == 0
+
+
+def test_event_projected_source_drift_after_validation_blocks_append(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo_id = _add_event_only_todo(
+        state,
+        todo_id="todo_event_source_drift",
+        validation_command=_PASS_COMMAND,
+    )
+    event_log = state.with_name("events.jsonl")
+    calls = {"count": 0}
+
+    def drifting_runner(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        calls["count"] += 1
+        AppendOnlyStateEventStore(event_log).append(
+            make_state_event(
+                event_id=f"evt-{todo_id}-drift",
+                goal_id=GOAL_ID,
+                event_type=TODO_UPDATED,
+                refs={"todo_id": todo_id},
+                payload={"title": "Changed after validation."},
+                recorded_at="2026-08-22T00:02:00+00:00",
+            )
+        )
+        return {
+            "schema_version": completion_validation_module.CALLER_VALIDATION_RECEIPT_SCHEMA_VERSION,
+            "command_label": "todo completion validation",
+            "exit_code": 0,
+            "passed": True,
+            "status": "passed",
+            "summary": "validation passed before source drift",
+            "stdout_captured": False,
+            "stderr_captured": False,
+            "local_path_captured": False,
+        }
+
+    monkeypatch.setattr(
+        completion_validation_module,
+        "run_caller_validation",
+        drifting_runner,
+    )
+
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="validated stale source",
+        no_followup=True,
+    )
+
     assert calls["count"] == 1
     assert result["ok"] is False
     assert result["validation_blocked_completion"] is True
-    assert _event_todo_completed_count(state) == 0
-
-
-def test_public_safe_backfill_redacts_unsafe_validation_command() -> None:
-    events = backfill_todo_events_from_markdown(
-        "\n".join(
-            [
-                "## Agent Todo",
-                "",
-                "- [ ] Deliver one event-projected change.",
-                (
-                    "  <!-- loopx:todo todo_id=todo_event_val_redact status=open "
-                    "task_class=advancement_task claimed_by=codex-author "
-                    "validation_command=/Users/loopx/bin/pytest -->"
-                ),
-            ]
-        ),
-        goal_id=GOAL_ID,
-        privacy="public_safe",
-    )
-    payload = events[0]["payload"]
-    assert payload["validation_command"] == PUBLIC_BACKFILL_REDACTION
-    assert "/Users/" not in json.dumps(events)
+    assert result["validation"]["status"] == "source_drift"
+    assert _event_todo_completed_count(event_log) == 0

--- a/tests/control_plane/test_todo_completion_validation.py
+++ b/tests/control_plane/test_todo_completion_validation.py
@@ -815,6 +815,37 @@ def test_noncanonical_sidecar_cannot_inject_validation_command(
     assert _event_todo_completed_count(state.with_name("events.jsonl")) == 0
 
 
+def test_empty_earlier_candidate_does_not_replace_canonical_validation_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo_id = _add_event_only_todo(
+        state,
+        todo_id="todo_event_after_empty_candidate",
+        validation_command=_FAIL_COMMAND,
+    )
+    empty_candidate = state.with_name("empty-events.jsonl")
+    empty_candidate.touch()
+    _set_registry_event_log(registry, empty_candidate)
+    calls = _spy_validation_runner(monkeypatch)
+
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="canonical fallback validation must run",
+        no_followup=True,
+    )
+
+    assert calls["count"] == 1
+    assert result["ok"] is False
+    assert result["validation_blocked_completion"] is True
+    assert _event_todo_completed_count(state.with_name("events.jsonl")) == 0
+    assert empty_candidate.read_text(encoding="utf-8") == ""
+
+
 @pytest.mark.parametrize("timeout_value", [0, 30, "not-int", {"seconds": 5}])
 def test_event_projected_invalid_timeout_rejects_without_running_command(
     tmp_path: Path,

--- a/tests/control_plane_ts/todo_completion_validation_plan.test.ts
+++ b/tests/control_plane_ts/todo_completion_validation_plan.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  evaluateTodoCompletionValidationPlan,
+  TODO_COMPLETION_VALIDATION_PLAN_REQUEST_SCHEMA,
+} from "../../loopx/control_plane/todos/completion_validation_plan.ts";
+
+const baseTodo = {
+  status: "open",
+  no_followup: null,
+  completion_continuation: null,
+  completion_turn_key: null,
+  successor_todo_ids: [],
+};
+
+function request(todo: Record<string, unknown>) {
+  return {
+    schema_version: TODO_COMPLETION_VALIDATION_PLAN_REQUEST_SCHEMA,
+    projection_source: "event_log",
+    todo: { ...baseTodo, ...todo },
+    requested_no_followup: false,
+    requested_completion_turn_key: null,
+    dry_run: false,
+  };
+}
+
+test("event-log deferred todos replay before validation execution", () => {
+  const result = evaluateTodoCompletionValidationPlan(
+    request({
+      status: "deferred",
+      validation_command: "false",
+    }),
+  );
+
+  assert.equal(result.effect, "skip");
+  assert.equal(result.reason, "terminal_replay");
+});
+
+test("valid command and argv declarations produce run effects", () => {
+  assert.deepEqual(
+    evaluateTodoCompletionValidationPlan(
+      request({
+        validation_command: "python -m pytest",
+        validation_label: "focused smoke",
+        validation_timeout_seconds: "5",
+      }),
+    ),
+    {
+      schema_version: "loopx_todo_completion_validation_plan_result_v0",
+      effect: "run",
+      reason: "declared_validation",
+      validation_command: "python -m pytest",
+      validation_argv: null,
+      validation_label: "focused smoke",
+      validation_timeout_seconds: 5,
+    },
+  );
+  assert.deepEqual(
+    evaluateTodoCompletionValidationPlan(
+      request({
+        validation_command_argv: ["python", "-c", "pass"],
+      }),
+    ),
+    {
+      schema_version: "loopx_todo_completion_validation_plan_result_v0",
+      effect: "run",
+      reason: "declared_validation",
+      validation_command: null,
+      validation_argv: ["python", "-c", "pass"],
+      validation_label: null,
+      validation_timeout_seconds: null,
+    },
+  );
+});
+
+test("invalid persisted declaration shapes reject before execution", () => {
+  for (const invalidTimeout of [0, 30, "not-int", {}]) {
+    const result = evaluateTodoCompletionValidationPlan(
+      request({
+        validation_command: "python -m pytest",
+        validation_timeout_seconds: invalidTimeout,
+      }),
+    );
+    assert.equal(result.effect, "reject");
+    assert.equal(result.reason, "invalid_declaration");
+    assert.equal(result.status, "declaration_invalid");
+    assert.match(result.summary, /validation_timeout_seconds/);
+  }
+  for (const invalidArgv of [[], ["python", 3], {}, "not-json"]) {
+    const result = evaluateTodoCompletionValidationPlan(
+      request({
+        validation_command_argv: invalidArgv,
+      }),
+    );
+    assert.equal(result.effect, "reject");
+    assert.equal(result.status, "declaration_invalid");
+    assert.match(result.summary, /validation_command_argv/);
+  }
+});
+
+test("runtime decoder rejects malformed request authority", () => {
+  assert.throws(
+    () =>
+      evaluateTodoCompletionValidationPlan({
+        ...request({ validation_command: "true" }),
+        schema_version: "loopx_todo_completion_validation_plan_request_v1",
+      }),
+    /schema mismatch/,
+  );
+  assert.throws(
+    () =>
+      evaluateTodoCompletionValidationPlan({
+        ...request({ validation_command: "true" }),
+        dry_run: "false",
+      }),
+    /dry_run must be a boolean/,
+  );
+});

--- a/tsconfig.control-plane.json
+++ b/tsconfig.control-plane.json
@@ -22,6 +22,7 @@
     "loopx/control_plane/scheduler/state_transition_rules.ts",
     "loopx/control_plane/todos/completion_fence.ts",
     "loopx/control_plane/todos/completion_state.ts",
+    "loopx/control_plane/todos/completion_validation_plan.ts",
     "loopx/control_plane/todos/next_action.ts",
     "loopx/control_plane/turn_driver/turn_journal.ts",
     "loopx/control_plane/turn_driver/turn_journal_effects.ts",
@@ -32,6 +33,7 @@
     "tests/control_plane_ts/scheduler_state_transition_rules.test.ts",
     "tests/control_plane_ts/todo_completion_fence.test.ts",
     "tests/control_plane_ts/todo_completion_state.test.ts",
+    "tests/control_plane_ts/todo_completion_validation_plan.test.ts",
     "tests/control_plane_ts/todo_next_action.test.ts",
     "tests/control_plane_ts/turn_journal.test.ts",
     "tests/control_plane_ts/turn_journal_effects.test.ts"


### PR DESCRIPTION
## Summary
- Event-only todos that declare `validation_command` or `validation_command_argv` were treated as undeclared on `complete_goal_todo`, so the fail-closed completion gate never ran.
- The gate now reads the raw event-sourced projection when the todo is not materialized in markdown. Markdown stays authoritative when `find_todo_block` finds the same todo.
- Public list/status projection still strips the command, argv, label, and timeout down to `completion_validation_required`. The gate does not reuse `event_projection_todo_context`, because that helper performs that strip.

This is the remaining hole after the everyday markdown `todo add` / `todo update --status done` path was already gated (#3082). Everyday `todo add` still writes markdown and was not the broken path.

## Test plan
- [x] `.venv/bin/python -m pytest -q tests/control_plane/test_todo_completion_validation.py tests/control_plane/test_todo_mutation_authority.py` (88 passed)
- [x] `ruff check` on the four changed files
- [ ] CI on this PR

## Notes
- Bounded future-facing pass: shared `_declaration_from_mapping` / `_copy_todo_added_validation_fields`, prefer a later declared snapshot over an earlier undeclared one, and align list projection so argv-only todos also set `completion_validation_required`.
- Out of scope: successor `TODO_ADDED` write-back, `note` projection, `complete_goal_todo` when the markdown state file is missing, and tightening the global public-safe path regex.


Made with [Cursor](https://cursor.com)