### PR TITLE
refactor(runtime): generalize mutation lock timeout

### DIFF
--- a/loopx/control_plane/effect_runtime_io.ts
+++ b/loopx/control_plane/effect_runtime_io.ts
@@ -88,7 +88,7 @@ export async function withFileMutationLock<T>(
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
       await reclaimStaleMutationLock(lockPath);
       if (Date.now() >= deadline) {
-        throw new Error("Turn journal mutation lock timed out");
+        throw new Error("Effect runtime mutation lock timed out");
       }
       await new Promise((resolve) => setTimeout(resolve, MUTATION_LOCK_POLL_MS));
     }


### PR DESCRIPTION
## Summary

Generalize the shared Effect runtime mutation-lock timeout diagnostic:

```text
Turn journal mutation lock timed out
```

becomes:

```text
Effect runtime mutation lock timed out
```

`withFileMutationLock` is now shared by runtime domains beyond the turn journal. Keeping the old label would misidentify the owner when scheduler state or later Effect handlers time out.

## Scope

- one diagnostic string at the existing shared lock boundary
- no lock, timing, recovery, exception type, or caller behavior change
- no new abstraction, branch, compatibility wrapper, or test-only product hook

This future-facing cleanup is separated from #3440 so the generic runtime contract can land independently and #3440 can focus on scheduler authority migration.

## Validation

- `npm run typecheck:control-plane` — passed
- `npm run test:control-plane` — 46/46 passed on current `main`
- exact-scope change-quality receipt `cqr_8d4db53c50cd88ca46aa` — verified valid
- premerge canary — passed with the project Python 3.13 environment
- diff, DCO, and public/private boundary hygiene — clean

The first premerge invocation selected system Python 3.9 for one nested canary and failed because that interpreter lacks `tomllib`. Running the same canary directly and rerunning the whole gate through the repository's Python 3.13 environment passed. No product code was changed to accommodate the wrong interpreter.
