### PR TITLE
fix(install): recover ownerless release locks

### DIFF
--- a/examples/release/release-promotion-concurrency-smoke.py
+++ b/examples/release/release-promotion-concurrency-smoke.py
@@ -50,6 +50,25 @@ def release_path(stdout: str) -> Path:
     raise AssertionError(stdout)
 
 
+def write_lock_test_python(path: Path) -> None:
+    path.write_text(
+        "#!/bin/sh\n"
+        "if [ \"${1:-}\" = \"-\" ] && "
+        "{ [ -z \"${LOOPX_INSTALL_GUARD_FILE:-}\" ] || "
+        "[ \"${LOOPX_INSTALL_GUARD_HELD:-0}\" = \"1\" ]; }; then\n"
+        "  cat >/dev/null\n"
+        "  printf '%s\\n' \"$0\"\n"
+        "  exit 0\n"
+        "fi\n"
+        "case \" $* \" in\n"
+        "  *\" promotion-gate \"*) exit 0 ;;\n"
+        "esac\n"
+        "exec \"$LOOPX_TEST_REAL_PYTHON\" \"$@\"\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
 def assert_install_waits_for_promotion_guard(root: Path) -> None:
     env = {**install_env(root), "LOOPX_RELEASE_ID": "guarded"}
     releases_dir = Path(env["LOOPX_RELEASES_DIR"])
@@ -101,7 +120,11 @@ def assert_legacy_lock_timeout_preserves_live_owner(root: Path) -> None:
     fast_sleep = fast_bin / "sleep"
     fast_sleep.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     fast_sleep.chmod(0o755)
+    python_wrapper = fast_bin / "python"
+    write_lock_test_python(python_wrapper)
     env["PATH"] = f"{fast_bin}{os.pathsep}{env['PATH']}"
+    env["LOOPX_PYTHON"] = str(python_wrapper)
+    env["LOOPX_TEST_REAL_PYTHON"] = sys.executable
 
     try:
         process = subprocess.run(
@@ -120,6 +143,51 @@ def assert_legacy_lock_timeout_preserves_live_owner(root: Path) -> None:
     finally:
         if legacy_lock.exists():
             shutil.rmtree(legacy_lock)
+
+
+def assert_empty_legacy_lock_is_reaped(root: Path) -> None:
+    env = {**install_env(root), "LOOPX_RELEASE_ID": "empty-lock-recovery"}
+    releases_dir = Path(env["LOOPX_RELEASES_DIR"])
+    legacy_lock = releases_dir / ".install-lock"
+    legacy_lock.mkdir(parents=True)
+
+    fast_bin = root / "empty-lock-fast-bin"
+    fast_bin.mkdir()
+    fast_sleep = fast_bin / "sleep"
+    fast_sleep.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fast_sleep.chmod(0o755)
+    python_wrapper = fast_bin / "python"
+    write_lock_test_python(python_wrapper)
+    env["PATH"] = f"{fast_bin}{os.pathsep}{env['PATH']}"
+    env["LOOPX_PYTHON"] = str(python_wrapper)
+    env["LOOPX_TEST_REAL_PYTHON"] = sys.executable
+
+    process = subprocess.Popen(
+        [str(INSTALL_SCRIPT)],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    acquired = False
+    try:
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline and process.poll() is None:
+            pid_file = legacy_lock / "pid"
+            if pid_file.is_file() and pid_file.read_text(encoding="utf-8").strip() == str(
+                process.pid
+            ):
+                acquired = True
+                break
+            time.sleep(0.05)
+    finally:
+        if process.poll() is None:
+            process.terminate()
+        stdout, stderr = process.communicate(timeout=10)
+        if legacy_lock.exists():
+            shutil.rmtree(legacy_lock)
+    assert acquired, (stdout, stderr)
 
 
 def assert_concurrent_release_ids_are_distinct(root: Path) -> None:
@@ -238,6 +306,7 @@ def main() -> int:
         root = Path(tmp)
         assert_install_waits_for_promotion_guard(root)
         assert_legacy_lock_timeout_preserves_live_owner(root)
+        assert_empty_legacy_lock_is_reaped(root)
         assert_concurrent_release_ids_are_distinct(root)
         assert_incomplete_candidate_does_not_replace_default(root)
         assert_resolved_archive_commit_is_recorded(root)

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -188,7 +188,16 @@ acquire_install_lock() {
     if [[ -f "$install_lock/pid" ]]; then
       owner_pid="$(cat "$install_lock/pid" 2>/dev/null || true)"
     fi
-    if [[ "$owner_pid" =~ ^[0-9]+$ ]] && ! kill -0 "$owner_pid" 2>/dev/null; then
+    if [[ ! "$owner_pid" =~ ^[0-9]+$ ]]; then
+      # A live installer can briefly own the directory before publishing its
+      # PID. Give that handoff a grace period, then reclaim interrupted locks
+      # that never acquired an owner.
+      sleep 1
+      if [[ -f "$install_lock/pid" ]]; then
+        owner_pid="$(cat "$install_lock/pid" 2>/dev/null || true)"
+      fi
+    fi
+    if [[ ! "$owner_pid" =~ ^[0-9]+$ ]] || ! kill -0 "$owner_pid" 2>/dev/null; then
       local stale_lock="$install_lock.stale.$$"
       if mv "$install_lock" "$stale_lock" 2>/dev/null; then
         rm -rf "$stale_lock"


### PR DESCRIPTION
## Summary

- recover an interrupted local install when `.install-lock` exists without a usable owner PID
- give a newly-created lock one second to publish its PID before deciding it is ownerless
- preserve valid live-owner locks and keep stale-lock takeover atomic
- add durable coverage for both ownerless-lock recovery and live-owner preservation

## Root cause

An interrupted install can leave the release lock directory behind before its `pid` file is written. The existing recovery path only reclaimed a lock when a valid PID existed and was already dead, so every later installer waited for the full lock timeout on an ownerless directory.

## Validation

- `bash -n scripts/install-local.sh`
- changed Python `py_compile`
- focused ownerless recovery and live-owner preservation assertions
- `examples/release/release-promotion-concurrency-smoke.py` on the final rebased head
- standard premerge selection: direct checks passed; catalog canaries 9/9 passed
- the command harness terminated the monolithic standard run at its five-minute ceiling after catalog completion; the same selected risk-profile commands were then executed individually with the repository Python and passed 8/8
- changed-file public/private boundary scan: clean
- `git diff --check origin/main...HEAD`

No check was skipped. There are no manual holds. The boundary command reported only pre-existing global registry warnings unrelated to these two changed files.

## Safety and scope

- a valid live PID is never stolen
- stale takeover still uses an atomic rename before exact-directory cleanup
- no unrelated release directory, local state, credential, or generated evidence is included
- the bounded future-facing pass was applied at the existing installer lock-owner boundary; no broader installer framework was added

Self-merge is requested under the maintainer-authorized narrow installer/runtime-helper policy after exact-head checks complete.
