### PR TITLE
fix(dashboard): keep empty Tasks board width consistent with populated (#3415)

### DIFF
--- a/apps/presentation/dashboard/src/features/personal-workspace/goal-tasks-view.tsx
+++ b/apps/presentation/dashboard/src/features/personal-workspace/goal-tasks-view.tsx
@@ -55,7 +55,7 @@ export function GoalTasksView({
     && conversation.slice(latestUserIndex + 1).some((item) => item.message.role === "assistant" && item.message.pending);
 
   return (
-    <div className="personal-task-kanban">
+    <>
       {latestUserMessage ? (
         <section aria-label="最近对话与 Task 状态" className="personal-task-chat-receipt">
           <span className="personal-task-chat-icon"><MessageSquareText size={18} /></span>
@@ -73,6 +73,7 @@ export function GoalTasksView({
           </footer>
         </section>
       ) : null}
+      <div className="personal-task-kanban">
       <section className="personal-object-list">
         <header>
           <strong><i className="personal-kanban-dot tone-attention" />待确认</strong>
@@ -147,11 +148,12 @@ export function GoalTasksView({
         ))}
         {!doneAgentTodos.length ? <p className="personal-task-empty">还没有完成的任务。</p> : null}
       </section>
+      </div>
       {isEmpty ? (
-        <p className="personal-task-empty" style={{ gridColumn: "1 / -1", border: 0, textAlign: "left" }}>
+        <p className="personal-task-empty">
           这个 Goal 还没有任务。用下面的输入框描述下一步，LoopX 会先展示待确认操作。
         </p>
       ) : null}
-    </div>
+    </>
   );
 }

--- a/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace.css
+++ b/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace.css
@@ -452,7 +452,7 @@
 
 /* Kanban layout for the goal Tasks tab: columns are task states. */
 .personal-task-kanban { display: grid; grid-template-columns: repeat(auto-fit, minmax(172px, 1fr)); gap: 12px; align-items: start; }
-.personal-task-chat-receipt { grid-column: 1 / -1; display: grid; grid-template-columns: 28px minmax(0, 1fr) auto; gap: 10px; align-items: center; padding: 8px 12px; border: 1px solid #d8e2f8; border-radius: 10px; background: #f8faff; box-shadow: 0 1px 3px rgb(47 102 233 / 4%); }
+.personal-task-chat-receipt { display: grid; grid-template-columns: 28px minmax(0, 1fr) auto; gap: 10px; align-items: center; padding: 8px 12px; border: 1px solid #d8e2f8; border-radius: 10px; background: #f8faff; box-shadow: 0 1px 3px rgb(47 102 233 / 4%); }
 .personal-task-chat-icon { display: grid; place-items: center; width: 28px; height: 28px; border-radius: 8px; background: var(--pw-blue-soft); color: var(--pw-blue-ink); }
 .personal-task-chat-receipt > div { min-width: 0; }
 .personal-task-chat-receipt header { display: flex; align-items: center; gap: 8px; }

--- a/examples/personal-workspace-browser-smoke.mjs
+++ b/examples/personal-workspace-browser-smoke.mjs
@@ -489,7 +489,7 @@ async function installApi(page) {
 async function main() {
   const { chromium } = loadPlaywright();
   await mkdir(outputDir, { recursive: true });
-  const results = new Map(Array.from({ length: 19 }, (_, index) => [index + 1, { status: "UNTESTED", note: "" }]));
+  const results = new Map(Array.from({ length: 20 }, (_, index) => [index + 1, { status: "UNTESTED", note: "" }]));
   const observations = [];
   const pass = (criterion, note) => results.set(criterion, { status: "PASS", note });
   const fail = (criterion, note) => results.set(criterion, { status: "FAIL", note });
@@ -727,6 +727,56 @@ async function main() {
     const goalNavigation = page.getByRole("navigation", { name: "Goal 视图" });
     const defaultTasksTab = goalNavigation.getByRole("button", { name: "Tasks" });
     if (await defaultTasksTab.getAttribute("aria-current") !== "page") throw new Error("Selecting a Goal did not prioritize its Tasks view");
+    const readBoardGeometry = async () => {
+      const kanban = page.locator(".personal-task-kanban");
+      await kanban.waitFor({ state: "visible" });
+      const kanbanBox = await kanban.boundingBox();
+      const columns = await page.locator(".personal-task-kanban > .personal-object-list").evaluateAll((els) =>
+        els.map((el) => { const rect = el.getBoundingClientRect(); return { left: rect.left, right: rect.right, width: rect.width }; })
+      );
+      return { kanbanBox, columns };
+    };
+    const assertBoardGeometry = (label, geometry) => {
+      if (!geometry.kanbanBox || geometry.columns.length !== 4) {
+        throw new Error(`${label}: expected 4 kanban columns, got ${geometry.columns?.length}`);
+      }
+      const kanbanRight = geometry.kanbanBox.x + geometry.kanbanBox.width;
+      if (Math.abs(geometry.columns[3].right - kanbanRight) > 2) {
+        throw new Error(`${label}: kanban columns do not fill the board (lastRight=${geometry.columns[3].right}, boardRight=${kanbanRight})`);
+      }
+      if (new Set(geometry.columns.map((column) => Math.round(column.width))).size !== 1) {
+        throw new Error(`${label}: kanban columns are not equal width: ${JSON.stringify(geometry.columns)}`);
+      }
+    };
+    const selectFirstGoal = async () => {
+      await page.locator(".personal-goal-link").first().click();
+      await page.locator(".personal-task-kanban").waitFor({ state: "visible" });
+    };
+    const populatedGeometry = await readBoardGeometry();
+    assertBoardGeometry("populated board", populatedGeometry);
+    await page.locator(".personal-goal-link", { hasText: "Product Release" }).first().click();
+    await page.locator(".personal-task-kanban").waitFor({ state: "visible" });
+    const emptyGeometry = await readBoardGeometry();
+    assertBoardGeometry("empty board", emptyGeometry);
+    if (Math.abs(emptyGeometry.kanbanBox.width - populatedGeometry.kanbanBox.width) > 2) {
+      throw new Error(`Empty board width ${emptyGeometry.kanbanBox.width} differs from populated ${populatedGeometry.kanbanBox.width}`);
+    }
+    const desktopViewport = page.viewportSize();
+    await page.setViewportSize({ width: 2048, height: 1200 });
+    await page.waitForTimeout(200);
+    await selectFirstGoal();
+    const populatedWide = await readBoardGeometry();
+    assertBoardGeometry("populated board (wide)", populatedWide);
+    await page.locator(".personal-goal-link", { hasText: "Product Release" }).first().click();
+    await page.locator(".personal-task-kanban").waitFor({ state: "visible" });
+    const emptyWide = await readBoardGeometry();
+    assertBoardGeometry("empty board (wide)", emptyWide);
+    if (Math.abs(emptyWide.kanbanBox.width - populatedWide.kanbanBox.width) > 2) {
+      throw new Error(`Empty board width (wide) ${emptyWide.kanbanBox.width} differs from populated ${populatedWide.kanbanBox.width}`);
+    }
+    await page.setViewportSize(desktopViewport);
+    await page.waitForTimeout(200);
+    await selectFirstGoal();
     await page.locator(".personal-object-list").first().waitFor({ state: "visible" });
     await page.getByRole("button", { name: "Goal 详情" }).click();
     await page.getByText("Repository", { exact: true }).waitFor({ state: "visible" });
@@ -1219,6 +1269,7 @@ async function main() {
     if (workerCards !== 0) throw new Error(`Redundant Agent worker strip is still visible: ${workerCards}`);
     if (!(await page.locator(".personal-digest-card").isVisible().catch(() => false))) throw new Error("Morning digest card did not render on the manager home");
     pass(17, "Manager home keeps the morning digest while omitting the redundant Agent worker strip.");
+    pass(20, "Empty and populated Tasks boards keep identical width and four equal columns at desktop and wide desktop viewports.");
     const report = { criteria: Object.fromEntries(results), observations };
     await writeFile(resolve(outputDir, "acceptance-results.json"), `${JSON.stringify(report, null, 2)}\n`, "utf8");
     console.log(`personal-workspace-browser-smoke: ok\npreview=${url}\nscreenshot=${resolve(outputDir, "desktop-first-screen.png")}`);


### PR DESCRIPTION
Fixes #3415

## Summary

- The empty Tasks board rendered narrower than a populated board: the four state columns only filled the left portion of the kanban and left a large blank area on the right.
- Root cause: the board-wide empty-state note (and the chat receipt) sat inside the auto-fit kanban grid as `grid-column: 1 / -1` items. A full-row spanning child forces every auto-fit track to stay open, so the grid kept six tracks and the four column sections occupied only the first four instead of expanding to fill.
- Fix: move the chat receipt and the empty-state note out of the kanban grid so they are siblings of the board. The board now always contains exactly its four state columns, so auto-fit collapses the empty tracks and all four columns fill the available width. Responsive auto-fit behavior is unchanged.

## Changed surfaces

- `apps/presentation/dashboard/src/features/personal-workspace/goal-tasks-view.tsx` - the kanban grid now contains only the four state columns; the chat receipt and empty-state note render outside the board.
- `apps/presentation/dashboard/src/features/personal-workspace/personal-workspace.css` - removed the now-inert `grid-column: 1 / -1` from the chat receipt rule.
- `examples/personal-workspace-browser-smoke.mjs` - added criterion 20: asserts zero-Task and populated boards share the same board width and four equal columns at the desktop (1512px) and wide-desktop (2048px) viewports.

## Validation

- `npm run smoke:personal-workspace` (browser smoke): PASS, all 20 criteria including the new board-geometry regression.
- `npx tsc --noEmit` (dashboard): clean.
- `git diff --check`: clean.
- Reproduction before the fix at 2048px: empty-board columns ~201px each inside a ~1268px board (columns did not fill). After the fix: both empty and populated states render four ~308px columns filling the ~1268px board.

No failures, skips, or manual holds. The focused browser regression plus the existing workspace smoke cover the board-geometry contract at the two desktop widths exercised by the smoke.

## Boundary

UI layout plus durable browser coverage only. No runtime, quota/status, todo, benchmark, permission, or public/private evidence changes.
