### PR TITLE
fix(dashboard/desktop): frontend follows loopx release across upgrade flow

### DIFF
--- a/apps/desktop/loopx-control-plane/README.md
+++ b/apps/desktop/loopx-control-plane/README.md
@@ -1,4 +1,4 @@
-# Loopx Desktop
+# LoopX Desktop
 
 This directory contains the experimental Tauri shell for the LoopX personal
 Agent workspace. It reuses the existing React dashboard and LoopX HTTP
@@ -21,7 +21,7 @@ The shell:
 
 1. verifies or starts `loopx serve-status` on `127.0.0.1:8766`;
 2. verifies or starts `loopx chat` on `127.0.0.1:8767`;
-3. serves the compiled dashboard from a random loopback port;
+3. loads the versioned LoopX Chat workspace from the local Chat service;
 4. opens the existing personal workspace in one native window;
 5. terminates only the service process groups it started when the window exits.
 
@@ -33,9 +33,9 @@ accepted. A service left running by an older installation is reported as stale
 with a restart instruction instead of silently handling current control-plane
 writes with old code.
 
-The WebView can navigate only inside its own loopback asset origin. Dashboard
-requests to the status and Chat services remain restricted to loopback CORS and
-the existing preview/apply authority boundary.
+The WebView is pinned to the loopback Chat origin served by the installed
+LoopX release. Dashboard requests to the status and Chat services remain
+restricted to loopback CORS and the existing preview/apply authority boundary.
 
 ## Coexistence With `loopx dashboard`
 

--- a/apps/desktop/loopx-control-plane/src-tauri/Cargo.lock
+++ b/apps/desktop/loopx-control-plane/src-tauri/Cargo.lock
@@ -48,12 +48,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
-name = "ascii"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
-
-[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,12 +464,6 @@ dependencies = [
  "serde",
  "windows-link 0.2.1",
 ]
-
-[[package]]
-name = "chunked_transfer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "combine"
@@ -1531,12 +1519,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "hyper"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2021,11 +2003,9 @@ name = "loopx-control-plane"
 version = "0.1.0"
 dependencies = [
  "command-group",
- "portpicker",
  "serde_json",
  "tauri",
  "tauri-build",
- "tauri-plugin-localhost",
  "tauri-plugin-single-instance",
 ]
 
@@ -2603,15 +2583,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "portpicker"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
-dependencies = [
- "rand",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2625,15 +2596,6 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
 
 [[package]]
 name = "precomputed-hash"
@@ -2732,36 +2694,6 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "rand"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "raw-window-handle"
@@ -3552,21 +3484,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tauri-plugin-localhost"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8d72c024121b1a3d9268293d49a56baf01a8c785561c85d17872588b839e55"
-dependencies = [
- "http",
- "log",
- "serde",
- "serde_json",
- "tauri",
- "thiserror 2.0.20",
- "tiny_http",
-]
-
-[[package]]
 name = "tauri-plugin-single-instance"
 version = "2.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3772,18 +3689,6 @@ checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny_http"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
-dependencies = [
- "ascii",
- "chunked_transfer",
- "httpdate",
- "log",
 ]
 
 [[package]]
@@ -5044,26 +4949,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]

--- a/apps/desktop/loopx-control-plane/src-tauri/Cargo.toml
+++ b/apps/desktop/loopx-control-plane/src-tauri/Cargo.toml
@@ -19,8 +19,6 @@ tauri-build = { version = "2.5.6", features = [] }
 
 [dependencies]
 command-group = "5.0.1"
-portpicker = "0.1.1"
 serde_json = "1.0"
 tauri = { version = "2.11.1", features = [] }
-tauri-plugin-localhost = "2.3.2"
 tauri-plugin-single-instance = "2.4.3"

--- a/apps/desktop/loopx-control-plane/src-tauri/src/lib.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/lib.rs
@@ -16,14 +16,13 @@ fn show_main_window(app: &AppHandle) {
 }
 
 pub fn run() {
-    let asset_port =
-        portpicker::pick_unused_port().expect("no free loopback port for desktop assets");
-    #[cfg(not(dev))]
-    let asset_origin = format!("http://127.0.0.1:{asset_port}");
+    // Release builds load the versioned LoopX Chat workspace that ships inside
+    // the installed `loopx` release, so `loopx update` refreshes the frontend
+    // and backend together instead of reusing a separately built asset bundle.
     #[cfg(dev)]
     let web_origin = "http://127.0.0.1:5173".to_string();
     #[cfg(not(dev))]
-    let web_origin = asset_origin.clone();
+    let web_origin = "http://127.0.0.1:8767/chat/".to_string();
     let services = Arc::new(Mutex::new(None::<ServiceSet>));
     let services_for_setup = Arc::clone(&services);
     let navigation_origin: Url = web_origin.parse().expect("valid desktop origin");
@@ -35,24 +34,19 @@ pub fn run() {
                 .callback(|app, _args, _cwd| show_main_window(app))
                 .build(),
         )
-        .plugin(
-            tauri_plugin_localhost::Builder::new(asset_port)
-                .host("127.0.0.1")
-                .build(),
-        )
         .setup(move |app| {
             let started = ServiceSet::start()?;
             *services_for_setup.lock().expect("service state lock") = Some(started);
 
             let origin: Url = web_origin.parse()?;
             app.add_capability(
-                CapabilityBuilder::new("desktop-localhost")
+                CapabilityBuilder::new("desktop-loopx-chat")
                     .remote(origin.to_string())
                     .window("main"),
             )?;
 
             WebviewWindowBuilder::new(app, "main", WebviewUrl::External(origin))
-                .title("Loopx")
+                .title("LoopX")
                 .inner_size(1280.0, 820.0)
                 .min_inner_size(960.0, 640.0)
                 .on_navigation(move |url| url.origin() == navigation_origin.origin())

--- a/apps/desktop/loopx-control-plane/src-tauri/tauri.conf.json
+++ b/apps/desktop/loopx-control-plane/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "Loopx",
+  "productName": "LoopX",
   "version": "0.1.0",
   "identifier": "io.loopx.control-plane",
   "build": {

--- a/examples/macos-dashboard-launchagent-status-smoke.py
+++ b/examples/macos-dashboard-launchagent-status-smoke.py
@@ -70,6 +70,11 @@ def main() -> int:
             "exit 2\n",
         )
         write_executable(
+            fake_bin / "loopx",
+            "#!/usr/bin/env bash\n"
+            "echo loopx \"$@\"\n",
+        )
+        write_executable(
             fake_bin / "loopx-canary",
             "#!/usr/bin/env bash\n"
             "echo loopx-canary \"$@\"\n",
@@ -112,6 +117,10 @@ def main() -> int:
         assert " chat --global-registry " in default_chat_plist, default_chat_plist
         assert "--port 8767" in default_chat_plist, default_chat_plist
         assert "--no-open" in default_chat_plist, default_chat_plist
+        assert "export LOOPX_PYTHON=" in default_plist, default_plist
+        assert "export LOOPX_PYTHON=" in default_chat_plist, default_chat_plist
+        assert "/loopx --registry" in default_plist, default_plist
+        assert "/loopx-canary" not in default_plist, default_plist
 
         run_script(
             fake_bin,

--- a/scripts/macos-dashboard-launchagent.sh
+++ b/scripts/macos-dashboard-launchagent.sh
@@ -76,14 +76,14 @@ require_macos() {
 }
 
 resolve_status_command() {
-  if [[ -x "$bin_dir/loopx-canary" ]]; then
-    printf '%s\n' "$bin_dir/loopx-canary"
-  elif [[ -x "$bin_dir/loopx" ]]; then
+  if [[ -x "$bin_dir/loopx" ]]; then
     printf '%s\n' "$bin_dir/loopx"
-  elif command -v loopx-canary >/dev/null 2>&1; then
-    command -v loopx-canary
+  elif [[ -x "$bin_dir/loopx-canary" ]]; then
+    printf '%s\n' "$bin_dir/loopx-canary"
   elif command -v loopx >/dev/null 2>&1; then
     command -v loopx
+  elif command -v loopx-canary >/dev/null 2>&1; then
+    command -v loopx-canary
   else
     echo "loopx is not installed; run scripts/install-local.sh first." >&2
     exit 1
@@ -99,6 +99,15 @@ resolve_python_command() {
     echo "python3 is not on PATH; install Python 3 or add it to PATH." >&2
     exit 1
   fi
+}
+
+resolve_loopx_python() {
+  local python_command
+  if python_command="$(bash "$repo_root/scripts/loopx-python.sh" 2>/dev/null)"; then
+    printf '%s\n' "$python_command"
+    return 0
+  fi
+  resolve_python_command
 }
 
 resolve_optional_command() {
@@ -168,7 +177,7 @@ write_plists() {
   local status_command python_command codex_command claude_command lark_cli_command
   local path_prefix command_path command_dir status_shell chat_shell dashboard_shell control_plane_write_arg lark_cli_arg
   status_command="$(resolve_status_command)"
-  python_command="$(resolve_python_command)"
+  python_command="$(resolve_loopx_python)"
   codex_command="$(resolve_optional_command codex)"
   claude_command="$(resolve_optional_command claude)"
   lark_cli_command="$(resolve_lark_cli_command "$python_command" 2>/dev/null || true)"
@@ -191,8 +200,8 @@ write_plists() {
   if [[ -n "$lark_cli_command" ]]; then
     lark_cli_arg=" --lark-cli-bin $(shell_quote "$lark_cli_command")"
   fi
-  status_shell="export PATH=$(shell_quote "$path_prefix"):\$PATH; exec $(shell_quote "$status_command") --registry $(shell_quote "$registry") serve-status --global-registry --host $(shell_quote "$host") --port $(shell_quote "$status_port") --limit $(shell_quote "$status_limit")$control_plane_write_arg"
-  chat_shell="export PATH=$(shell_quote "$path_prefix"):\$PATH; exec $(shell_quote "$status_command") --registry $(shell_quote "$registry") chat --global-registry --host $(shell_quote "$host") --port $(shell_quote "$chat_port") --codex-bin $(shell_quote "$codex_command") --claude-bin $(shell_quote "$claude_command")$lark_cli_arg --no-open"
+  status_shell="export LOOPX_PYTHON=$(shell_quote "$python_command"); export PATH=$(shell_quote "$path_prefix"):\$PATH; exec $(shell_quote "$status_command") --registry $(shell_quote "$registry") serve-status --global-registry --host $(shell_quote "$host") --port $(shell_quote "$status_port") --limit $(shell_quote "$status_limit")$control_plane_write_arg"
+  chat_shell="export LOOPX_PYTHON=$(shell_quote "$python_command"); export PATH=$(shell_quote "$path_prefix"):\$PATH; exec $(shell_quote "$status_command") --registry $(shell_quote "$registry") chat --global-registry --host $(shell_quote "$host") --port $(shell_quote "$chat_port") --codex-bin $(shell_quote "$codex_command") --claude-bin $(shell_quote "$claude_command")$lark_cli_arg --no-open"
   dashboard_shell="export PATH=$(shell_quote "$path_prefix"):\$PATH; exec $(shell_quote "$python_command") -m http.server $(shell_quote "$dashboard_port") --bind $(shell_quote "$host") --directory $(shell_quote "$dashboard_dist_dir")"
 
   mkdir -p "$launch_agents_dir" "$logs_dir"


### PR DESCRIPTION
## Root cause

After a `loopx update`, the surfaces that kept showing the old frontend did so for two reasons:

1. The desktop shell served a separately built, gitignored dashboard `dist` bundle that `loopx update` never refreshes. Upgrading the CLI did not upgrade the frontend (e.g. the SSH control-plane source switching from #3409 was missing).
2. The launchagent re-wrote the status/chat plists on `restart` without pinning the Python the `loopx` wrapper actually uses. Under the minimal launchd PATH the wrapper fell back to the system Python 3.9, so upgraded services failed to start.

## Fix

- Release builds of the desktop shell now load the versioned LoopX Chat workspace from the local Chat service (`http://127.0.0.1:8767/chat/`). `ServiceSet` already starts/reuses that service with release-identity fencing (#3435), so `loopx update` refreshes frontend and backend together.
- `scripts/macos-dashboard-launchagent.sh` now resolves the interpreter via `scripts/loopx-python.sh` and exports `LOOPX_PYTHON` into the status/chat plist shells, and prefers the default `loopx` command over `loopx-canary` so managed services follow the release that `loopx update` ships.
- Corrected the app brand to `LoopX` (window title, product name, README heading) and dropped the now-unused localhost asset server from the desktop shell.

## Changes

- `apps/desktop/loopx-control-plane/src-tauri/src/lib.rs` — load Chat workspace URL; drop asset server; title `LoopX`.
- `apps/desktop/loopx-control-plane/src-tauri/tauri.conf.json` — `productName` `LoopX`.
- `apps/desktop/loopx-control-plane/src-tauri/Cargo.toml` + `Cargo.lock` — remove `tauri-plugin-localhost` and `portpicker`.
- `apps/desktop/loopx-control-plane/README.md` — updated runtime model + heading.
- `scripts/macos-dashboard-launchagent.sh` — resolve/export `LOOPX_PYTHON`; prefer default `loopx`.
- `examples/macos-dashboard-launchagent-status-smoke.py` — pin the new behaviors.

## Validation

- `cargo check` (src-tauri): clean.
- `bash -n scripts/macos-dashboard-launchagent.sh`: clean.
- `examples/macos-dashboard-launchagent-status-smoke.py`: ok.
- `git diff --check`: clean.

## Boundary

Desktop shell frontend source, launchagent packaging, and branding only. No control-plane, quota, todo, permission, or public/private evidence changes.
