### PR TITLE
chore(desktop): retire the 5174 dashboard LaunchAgent and stub Tauri frontend

### DIFF
--- a/apps/desktop/loopx-control-plane/src-tauri/tauri.conf.json
+++ b/apps/desktop/loopx-control-plane/src-tauri/tauri.conf.json
@@ -5,9 +5,8 @@
   "identifier": "io.loopx.control-plane",
   "build": {
     "beforeDevCommand": "bash scripts/dashboard.sh dev",
-    "beforeBuildCommand": "bash scripts/dashboard.sh build",
     "devUrl": "http://127.0.0.1:5173",
-    "frontendDist": "../../../presentation/dashboard/dist"
+    "frontendDist": "../static"
   },
   "app": {
     "windows": [],

--- a/apps/desktop/loopx-control-plane/static/index.html
+++ b/apps/desktop/loopx-control-plane/static/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <title>LoopX Desktop</title>
+  </head>
+  <body>
+    <p>LoopX desktop shell loads the local Chat workspace at /chat/.</p>
+  </body>
+</html>

--- a/apps/presentation/dashboard/README.md
+++ b/apps/presentation/dashboard/README.md
@@ -228,8 +228,8 @@ normal operator view for all projects connected into the shared registry:
 loopx serve-status --global-registry --port 8766 --limit 80
 ```
 
-On macOS, keep both the status feed and the built dashboard static app running
-after login with the user-level LaunchAgent helper:
+On macOS, keep the status feed and the Chat service running after login with
+the user-level LaunchAgent helper:
 
 ```bash
 ../../scripts/macos-dashboard-launchagent.sh install
@@ -239,7 +239,7 @@ The helper starts:
 
 ```text
 http://127.0.0.1:8766/status.json
-http://127.0.0.1:5174/
+http://127.0.0.1:8767/chat/
 ```
 
 Use `../../scripts/macos-dashboard-launchagent.sh restart|stop|uninstall|status`
@@ -251,10 +251,10 @@ an older daemon. Logs live under `~/Library/Logs/loopx/`.
 The status output path is covered without touching real macOS services by
 `python3 examples/macos-dashboard-launchagent-status-smoke.py`.
 
-Then open the dashboard root:
+Then open the packaged personal workspace:
 
 ```text
-http://127.0.0.1:5174/
+http://127.0.0.1:8767/chat/
 ```
 
 ### Named local and SSH-tunnel sources

--- a/examples/macos-dashboard-launchagent-status-smoke.py
+++ b/examples/macos-dashboard-launchagent-status-smoke.py
@@ -47,11 +47,8 @@ def main() -> int:
         tmp = Path(raw_tmp)
         fake_bin = tmp / "bin"
         home = tmp / "home"
-        dashboard_dist = tmp / "dashboard-dist"
         fake_bin.mkdir()
         home.mkdir()
-        dashboard_dist.mkdir()
-        (dashboard_dist / "index.html").write_text("<!doctype html><title>LoopX</title>\n", encoding="utf-8")
 
         write_executable(
             fake_bin / "uname",
@@ -91,8 +88,8 @@ def main() -> int:
 
         old_output = run_status(fake_bin, home, schema_version=1)
         assert "- com.loopx.status: loaded" in old_output, old_output
-        assert "- com.loopx.dashboard: loaded" in old_output, old_output
         assert "- com.loopx.chat: loaded" in old_output, old_output
+        assert "- com.loopx.dashboard" not in old_output, old_output
         assert "- status_contract: schema_version=1 producer=loopx status expected>=2" in old_output, old_output
         assert "- control_plane_write_api: disabled" in old_output, old_output
         assert "warning: status feed is using an old contract; run:" in old_output, old_output
@@ -107,8 +104,7 @@ def main() -> int:
         assert "URLs:" in current_output, current_output
         assert "Logs:" in current_output, current_output
 
-        install_env = {"LOOPX_DASHBOARD_DIST_DIR": str(dashboard_dist)}
-        run_script(fake_bin, home, ["install"], schema_version=2, extra_env=install_env)
+        run_script(fake_bin, home, ["install"], schema_version=2)
         status_plist = home / "Library" / "LaunchAgents" / "com.loopx.status.plist"
         chat_plist = home / "Library" / "LaunchAgents" / "com.loopx.chat.plist"
         default_plist = status_plist.read_text(encoding="utf-8")
@@ -121,13 +117,13 @@ def main() -> int:
         assert "export LOOPX_PYTHON=" in default_chat_plist, default_chat_plist
         assert "/loopx --registry" in default_plist, default_plist
         assert "/loopx-canary" not in default_plist, default_plist
+        assert not (home / "Library" / "LaunchAgents" / "com.loopx.dashboard.plist").exists(), "retired dashboard LaunchAgent should not be installed"
 
         run_script(
             fake_bin,
             home,
             ["--enable-control-plane-write-api", "restart"],
             schema_version=2,
-            extra_env=install_env,
         )
         write_plist = status_plist.read_text(encoding="utf-8")
         assert "--enable-control-plane-write-api" in write_plist, write_plist

--- a/scripts/macos-dashboard-launchagent.sh
+++ b/scripts/macos-dashboard-launchagent.sh
@@ -3,14 +3,11 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="${LOOPX_REPO_ROOT:-$(cd "$script_dir/.." && pwd)}"
-dashboard_dir="${LOOPX_DASHBOARD_DIR:-$repo_root/apps/presentation/dashboard}"
-dashboard_dist_dir="${LOOPX_DASHBOARD_DIST_DIR:-$dashboard_dir/dist}"
 bin_dir="${LOOPX_BIN_DIR:-$HOME/.local/bin}"
 registry="${LOOPX_GLOBAL_REGISTRY:-$HOME/.codex/loopx/registry.global.json}"
 status_port="${LOOPX_STATUS_PORT:-8766}"
 status_limit="${LOOPX_STATUS_LIMIT:-80}"
 status_contract_min_version="${LOOPX_STATUS_CONTRACT_MIN_VERSION:-2}"
-dashboard_port="${LOOPX_DASHBOARD_PORT:-5174}"
 chat_port="${LOOPX_CHAT_PORT:-8767}"
 host="${LOOPX_DASHBOARD_HOST:-127.0.0.1}"
 label_prefix="${LOOPX_LAUNCH_LABEL_PREFIX:-com.loopx}"
@@ -19,10 +16,8 @@ uid="$(id -u)"
 launch_agents_dir="$HOME/Library/LaunchAgents"
 logs_dir="$HOME/Library/Logs/loopx"
 status_label="$label_prefix.status"
-dashboard_label="$label_prefix.dashboard"
 chat_label="$label_prefix.chat"
 status_plist="$launch_agents_dir/$status_label.plist"
-dashboard_plist="$launch_agents_dir/$dashboard_label.plist"
 chat_plist="$launch_agents_dir/$chat_label.plist"
 control_plane_write_api_enabled=false
 
@@ -33,7 +28,6 @@ Usage: $0 [--enable-control-plane-write-api] install|uninstall|start|stop|restar
 Installs user-level macOS LaunchAgents for:
   - LoopX global status feed: http://$host:$status_port/status.json
   - LoopX Chat and Lark:      http://$host:$chat_port/
-  - LoopX dashboard:          http://$host:$dashboard_port/
 
 Default mode is read-only for control-plane settings. Pass
 --enable-control-plane-write-api with install or restart to write that explicit
@@ -41,14 +35,11 @@ opt-in flag into the status LaunchAgent plist.
 
 Environment overrides:
   LOOPX_REPO_ROOT
-  LOOPX_DASHBOARD_DIR
-  LOOPX_DASHBOARD_DIST_DIR
   LOOPX_BIN_DIR
   LOOPX_GLOBAL_REGISTRY
   LOOPX_STATUS_PORT
   LOOPX_STATUS_LIMIT
   LOOPX_STATUS_CONTRACT_MIN_VERSION
-  LOOPX_DASHBOARD_PORT
   LOOPX_CHAT_PORT
   LOOPX_DASHBOARD_HOST
   LOOPX_LAUNCH_LABEL_PREFIX
@@ -162,20 +153,9 @@ raise SystemExit(1)
 PY
 }
 
-check_inputs() {
-  [[ -d "$dashboard_dir" ]] || {
-    echo "Dashboard directory not found: $dashboard_dir" >&2
-    exit 1
-  }
-  [[ -f "$dashboard_dist_dir/index.html" ]] || {
-    echo "Dashboard dist is missing; run a dashboard build before installing the LaunchAgent." >&2
-    exit 1
-  }
-}
-
 write_plists() {
   local status_command python_command codex_command claude_command lark_cli_command
-  local path_prefix command_path command_dir status_shell chat_shell dashboard_shell control_plane_write_arg lark_cli_arg
+  local path_prefix command_path command_dir status_shell chat_shell control_plane_write_arg lark_cli_arg
   status_command="$(resolve_status_command)"
   python_command="$(resolve_loopx_python)"
   codex_command="$(resolve_optional_command codex)"
@@ -202,7 +182,6 @@ write_plists() {
   fi
   status_shell="export LOOPX_PYTHON=$(shell_quote "$python_command"); export PATH=$(shell_quote "$path_prefix"):\$PATH; exec $(shell_quote "$status_command") --registry $(shell_quote "$registry") serve-status --global-registry --host $(shell_quote "$host") --port $(shell_quote "$status_port") --limit $(shell_quote "$status_limit")$control_plane_write_arg"
   chat_shell="export LOOPX_PYTHON=$(shell_quote "$python_command"); export PATH=$(shell_quote "$path_prefix"):\$PATH; exec $(shell_quote "$status_command") --registry $(shell_quote "$registry") chat --global-registry --host $(shell_quote "$host") --port $(shell_quote "$chat_port") --codex-bin $(shell_quote "$codex_command") --claude-bin $(shell_quote "$claude_command")$lark_cli_arg --no-open"
-  dashboard_shell="export PATH=$(shell_quote "$path_prefix"):\$PATH; exec $(shell_quote "$python_command") -m http.server $(shell_quote "$dashboard_port") --bind $(shell_quote "$host") --directory $(shell_quote "$dashboard_dist_dir")"
 
   mkdir -p "$launch_agents_dir" "$logs_dir"
 
@@ -262,33 +241,6 @@ EOF
 </plist>
 EOF
 
-  cat >"$dashboard_plist" <<EOF
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key>
-  <string>$dashboard_label</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/bin/zsh</string>
-    <string>-c</string>
-    <string>$(xml_escape "$dashboard_shell")</string>
-  </array>
-  <key>RunAtLoad</key>
-  <true/>
-  <key>KeepAlive</key>
-  <true/>
-  <key>ThrottleInterval</key>
-  <integer>10</integer>
-  <key>StandardOutPath</key>
-  <string>$logs_dir/dashboard.out.log</string>
-  <key>StandardErrorPath</key>
-  <string>$logs_dir/dashboard.err.log</string>
-</dict>
-</plist>
-EOF
 }
 
 bootout_one() {
@@ -307,11 +259,9 @@ bootstrap_one() {
 start_agents() {
   bootstrap_one "$status_label" "$status_plist"
   bootstrap_one "$chat_label" "$chat_plist"
-  bootstrap_one "$dashboard_label" "$dashboard_plist"
 }
 
 stop_agents() {
-  bootout_one "$dashboard_label" "$dashboard_plist"
   bootout_one "$chat_label" "$chat_plist"
   bootout_one "$status_label" "$status_plist"
 }
@@ -352,15 +302,11 @@ print_status() {
   launchctl print "gui/$uid/$status_label" >/dev/null 2>&1 \
     && echo "- $status_label: loaded" \
     || echo "- $status_label: not loaded"
-  launchctl print "gui/$uid/$dashboard_label" >/dev/null 2>&1 \
-    && echo "- $dashboard_label: loaded" \
-    || echo "- $dashboard_label: not loaded"
   launchctl print "gui/$uid/$chat_label" >/dev/null 2>&1 \
     && echo "- $chat_label: loaded" \
     || echo "- $chat_label: not loaded"
   echo
   echo "URLs:"
-  echo "- dashboard: http://$host:$dashboard_port/"
   echo "- Chat:      http://$host:$chat_port/"
   echo "- status:    http://$host:$status_port/status.json"
   print_status_contract_health
@@ -368,8 +314,6 @@ print_status() {
   echo "Logs:"
   echo "- $logs_dir/status.out.log"
   echo "- $logs_dir/status.err.log"
-  echo "- $logs_dir/dashboard.out.log"
-  echo "- $logs_dir/dashboard.err.log"
   echo "- $logs_dir/chat.out.log"
   echo "- $logs_dir/chat.err.log"
 }
@@ -378,18 +322,17 @@ main() {
   require_macos
   case "${1:-}" in
     install)
-      check_inputs
       write_plists
       start_agents
       print_status
       ;;
     uninstall)
       stop_agents
-      rm -f "$status_plist" "$dashboard_plist" "$chat_plist"
+      rm -f "$status_plist" "$chat_plist"
       print_status
       ;;
     start)
-      [[ -f "$status_plist" && -f "$dashboard_plist" && -f "$chat_plist" ]] || {
+      [[ -f "$status_plist" && -f "$chat_plist" ]] || {
         echo "LaunchAgents are not installed; run: $0 install" >&2
         exit 1
       }
@@ -401,7 +344,6 @@ main() {
       print_status
       ;;
     restart)
-      check_inputs
       write_plists
       start_agents
       print_status

--- a/tests/test_dashboard_command.py
+++ b/tests/test_dashboard_command.py
@@ -128,7 +128,7 @@ def test_macos_launchagent_passes_discovered_lark_cli_without_login_shell() -> N
     assert "--lark-cli-bin" in script
     assert "resolve_lark_cli_command" in script
     assert "<string>-lc</string>" not in script
-    assert script.count("<string>-c</string>") == 3
+    assert script.count("<string>-c</string>") == 2
 
 
 def test_dashboard_command_runs_the_dashboard_launcher(


### PR DESCRIPTION
## Summary

The `dashboard` LaunchAgent on `http://127.0.0.1:5174/` served `apps/presentation/dashboard/dist`, a gitignored root-base build that `loopx update` never refreshes. After #3446 both the desktop shell and the browser load the versioned `/chat/` workspace, so 5174 is now a redundant, stale-prone copy of the same app.

## Changes

- `scripts/macos-dashboard-launchagent.sh`: remove the 5174 dashboard service; the helper now manages only `status` (8766) and `chat` (8767).
- `examples/macos-dashboard-launchagent-status-smoke.py`: drop dashboard expectations; assert the dashboard LaunchAgent is no longer installed.
- `apps/presentation/dashboard/README.md`: point launchagent docs at the packaged `/chat/` workspace instead of 5174.
- `apps/desktop/loopx-control-plane/src-tauri/tauri.conf.json` + new `static/index.html`: Tauri `frontendDist` uses a minimal static stub and no longer runs `beforeBuildCommand` (the desktop shell loads the External Chat URL at runtime).

## Validation

- `bash -n scripts/macos-dashboard-launchagent.sh`: clean.
- `python3 examples/macos-dashboard-launchagent-status-smoke.py`: ok.
- `cargo check` (src-tauri): clean.
- `git diff --check`: clean.

## Boundary

LaunchAgent packaging, dashboard docs, and Tauri build configuration only. No control-plane, quota, todo, permission, or public/private evidence changes.
