### PR TITLE
feat(deepresearch): add /loopx-deepresearch bounded research loop

### DIFF
--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -24,6 +24,7 @@ from .content_ops.catalog_entry import CONTENT_OPS_CATALOG_ENTRY
 from .value_connectors.catalog_entry import VALUE_CONNECTORS_CATALOG_ENTRY
 from .explore.catalog_entry import EXPLORE_CATALOG_ENTRY
 from .auto_research.catalog_entry import AUTO_RESEARCH_CATALOG_ENTRY
+from .deep_research.catalog_entry import DEEP_RESEARCH_CATALOG_ENTRY
 from .public_safe_outbound.catalog_entry import PUBLIC_SAFE_OUTBOUND_CATALOG_ENTRY
 from .registry import CapabilityRegistry
 
@@ -49,6 +50,7 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
     VALUE_CONNECTORS_CATALOG_ENTRY,
     EXPLORE_CATALOG_ENTRY,
     AUTO_RESEARCH_CATALOG_ENTRY,
+    DEEP_RESEARCH_CATALOG_ENTRY,
     PUBLIC_SAFE_OUTBOUND_CATALOG_ENTRY,
 )
 # Preserve the original import surface while routing all reads through the registry.

--- a/loopx/capabilities/deep_research/README.md
+++ b/loopx/capabilities/deep_research/README.md
@@ -1,0 +1,39 @@
+# Deep research (evidence-ledger research loop)
+
+`/loopx-deepresearch` turns one user question into a bounded, auditable research
+session: question, source, claim, and contradiction ledgers live in
+`.loopx/deepresearch/research.json`, the packet (`loopx deepresearch status`)
+owns what to research next and when to stop, and the final report keeps every
+citation resolvable to a recorded source.
+
+## Boundary with auto-research
+
+The built-in `auto-research` capability and this capability both do "bounded
+research" but own different truths and must not be merged casually:
+
+| | auto-research | deep-research (this) |
+| --- | --- | --- |
+| Unit of work | a LoopX **goal** with role-scoped workers | one **session ledger** in a project |
+| State authority | goal todos, hypotheses, rollout events | `.loopx/deepresearch/` ledger |
+| Progression | worker contract + terminal decision/review | packet expeditions + stop conditions |
+| Output | promoted/retired hypotheses in canonical evidence | citation-auditable markdown report |
+| Use when | open exploration inside the LoopX control plane | a single user question needing an auditable, source-cited answer |
+
+Choose one per question; they do not share state and neither can close the
+other's work.
+
+## Lifecycle
+
+`start` opens a run; `close` is the explicit terminal transition; the next
+`start` archives the closed run (state + report) under
+`.loopx/deepresearch/archive/<closed-at>/` and begins fresh. `start --new-run`
+auto-closes only a run whose stop conditions already fired; an active run
+always requires an explicit `close` first. State files are only ever rotated by
+these typed transitions — never edited by hand.
+
+## Layout
+
+- Domain state machine and report: `loopx/deepresearch.py`
+- CLI: `loopx/cli_commands/deepresearch.py` (`loopx deepresearch …`)
+- Host entry: the `/loopx-deepresearch` skill facade installed by
+  `loopx slash-commands --install`

--- a/loopx/capabilities/deep_research/README.md
+++ b/loopx/capabilities/deep_research/README.md
@@ -22,6 +22,25 @@ research" but own different truths and must not be merged casually:
 Choose one per question; they do not share state and neither can close the
 other's work.
 
+## Boundary with explore
+
+The `explore` capability owns the goal-scoped, public-safe, cross-session
+knowledge topology (questions, findings, evidence relations). deep-research owns
+a private, session-scoped transactional ledger:
+
+- deep-research keeps raw source locators (URLs or local paths that may not be
+  safe to publish), claim lineage, precise contradiction pairs with sides-with
+  adjudication, stop/close decisions, and the citation report. It works
+  standalone — with no LoopX goal and no explore opt-in.
+- explore keeps the canonical, reusable projection. Any future bridge is a
+  one-way, idempotent, public-safe derivation: explore receives sanitized,
+  opaque evidence refs only; it never reads the raw deep-research ledger or
+  report, never dual-writes research state, and a graph node resolving never
+  closes (or reopens) a research run.
+
+In short: deep-research is the only writer of `.loopx/deepresearch/`, and
+public surfaces only ever see derived, reconstructable projections.
+
 ## Lifecycle
 
 `start` opens a run; `close` is the explicit terminal transition; the next
@@ -33,7 +52,13 @@ these typed transitions — never edited by hand.
 
 ## Layout
 
-- Domain state machine and report: `loopx/deepresearch.py`
-- CLI: `loopx/cli_commands/deepresearch.py` (`loopx deepresearch …`)
+- Domain state machine and report (capability owner):
+  `loopx/capabilities/deep_research/runtime.py`
+- CLI adapter: `loopx/cli_commands/deepresearch.py` (`loopx deepresearch …`)
 - Host entry: the `/loopx-deepresearch` skill facade installed by
   `loopx slash-commands --install`
+
+Recorded claims carry caller-declared provenance: `--tool` records the tool the
+caller says produced the evidence. The CLI records that provenance; it does not
+attest that the tool actually ran — execution receipts belong to a future
+host/harness bridge, not this ledger.

--- a/loopx/capabilities/deep_research/README.md
+++ b/loopx/capabilities/deep_research/README.md
@@ -41,6 +41,14 @@ a private, session-scoped transactional ledger:
 In short: deep-research is the only writer of `.loopx/deepresearch/`, and
 public surfaces only ever see derived, reconstructable projections.
 
+One ledger invariant spans every transition that adjudicates a contradiction:
+no resolution — inside `resolve-question` or standalone
+`resolve-contradiction` — may overrule a claim that an already-answered
+question cites as evidence. The ledger never silently invalidates a recorded
+answer; late-arriving counterevidence that wins forces an explicit decision
+(side with the cited claim, or close the run and revisit the question in a new
+run) instead of leaving the report internally inconsistent.
+
 ## Lifecycle
 
 `start` opens a run; `close` is the explicit terminal transition; the next

--- a/loopx/capabilities/deep_research/__init__.py
+++ b/loopx/capabilities/deep_research/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .catalog_entry import DEEP_RESEARCH_CATALOG_ENTRY
+
+__all__ = ["DEEP_RESEARCH_CATALOG_ENTRY"]

--- a/loopx/capabilities/deep_research/catalog_entry.py
+++ b/loopx/capabilities/deep_research/catalog_entry.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+DEEP_RESEARCH_CATALOG_ENTRY: dict[str, Any] = {
+    "id": "deep-research",
+    "origin": "builtin",
+    "visibility": "public",
+    "provider_id": "loopx-core",
+    "documentation": {
+        "source_root": "loopx/capabilities/deep_research",
+        "site_root": "capabilities/deep-research",
+        "canonical": "README.md",
+    },
+    "title": "Evidence-ledger deep research loop",
+    "status": "experimental",
+    "real_world_anchor": (
+        "one user question driven by packet-cut expeditions over question, source, "
+        "claim, and contradiction ledgers, ending in a citation-auditable report"
+    ),
+    "user_value": (
+        "Run a bounded, auditable research session per project: claims must come from "
+        "recorded sources, answers must cite recorded claims, and closeout is blocked "
+        "while any contradiction stays unresolved."
+    ),
+    "entry_command": "loopx deepresearch start --question <text>",
+    "commands": [
+        {
+            "command": "loopx deepresearch start --question <text> [--max-sources N] [--new-run]",
+            "purpose": "Open a research run; archives the previous closed/stopped run instead of editing state files by hand.",
+            "write_boundary": ".loopx/deepresearch/ state and report files only",
+        },
+        {
+            "command": "loopx deepresearch status",
+            "purpose": "Emit the expedition packet: contract, ledgers, next expedition, stop conditions, evidence commands.",
+            "write_boundary": "read-only projection over the research ledger",
+        },
+        {
+            "command": "loopx deepresearch add-source --url-or-path <ref> --tool <tool> --claims-json <json>",
+            "purpose": "Record one consulted source and the claims extracted from it.",
+            "write_boundary": "one ledger transaction under the project research lock",
+        },
+        {
+            "command": "loopx deepresearch add-subquestion --text <text> --from-claim <claim-id>",
+            "purpose": "Open a subquestion that derives from a recorded claim.",
+            "write_boundary": "one ledger transaction under the project research lock",
+        },
+        {
+            "command": "loopx deepresearch resolve-question --question-id <id> --answer <text> --evidence-claims <ids>",
+            "purpose": "Answer a recorded question citing recorded evidence claims; contradictions touching the evidence must be resolved in the same transition.",
+            "write_boundary": "one ledger transaction under the project research lock",
+        },
+        {
+            "command": "loopx deepresearch resolve-contradiction --contradiction-id <id> --sides-with <claim-id> --rationale <text>",
+            "purpose": "Close one open contradiction standalone with an explicit sides-with rationale.",
+            "write_boundary": "one ledger transaction under the project research lock",
+        },
+        {
+            "command": "loopx deepresearch close [--note <text>]",
+            "purpose": "Terminal transition closing this run so the next question can start.",
+            "write_boundary": "marks and archives this project's research run",
+        },
+        {
+            "command": "loopx deepresearch report",
+            "purpose": "Render the citation-auditable markdown report from the ledgers.",
+            "write_boundary": "writes .loopx/deepresearch/report.md only",
+        },
+    ],
+    "implemented_protocols": [
+        {
+            "schema_version": "loopx_deepresearch_state_v0",
+            "module": "loopx.deepresearch",
+            "doc": "loopx/capabilities/deep_research/README.md",
+        },
+        {
+            "schema_version": "loopx_deepresearch_packet_v0",
+            "module": "loopx.deepresearch",
+            "doc": "loopx/capabilities/deep_research/README.md",
+        },
+    ],
+    "smokes": [
+        "python3 -m pytest tests/test_deepresearch_command.py -q",
+    ],
+    "docs": [
+        "loopx/capabilities/deep_research/README.md",
+    ],
+    "boundaries": [
+        (
+            "Distinct from the auto-research capability: auto-research launches "
+            "role-scoped workers inside a LoopX goal for open exploration; "
+            "deep-research is a single-session, user-facing evidence ledger whose "
+            "truth is the .loopx/deepresearch state, not goal todos."
+        ),
+        (
+            "The packet owns research progression and stop decisions; the model "
+            "executes bounded expeditions and records typed ledger transitions only."
+        ),
+        (
+            "Claims exist only when a tool the agent actually ran produced them; "
+            "reports must keep every citation resolvable to a recorded source."
+        ),
+        (
+            "One active run per project; finished or closed runs are archived under "
+            ".loopx/deepresearch/archive/ by typed transitions, never by hand edits."
+        ),
+    ],
+    "next_real_step": (
+        "Keep the deep-research entrypoint as the single evidence-ledger authority and "
+        "reuse LoopX goal/todo/quota projections rather than adding a second scheduler."
+    ),
+}

--- a/loopx/capabilities/deep_research/catalog_entry.py
+++ b/loopx/capabilities/deep_research/catalog_entry.py
@@ -58,8 +58,8 @@ DEEP_RESEARCH_CATALOG_ENTRY: dict[str, Any] = {
         },
         {
             "command": "loopx deepresearch close [--note <text>]",
-            "purpose": "Terminal transition closing this run so the next question can start.",
-            "write_boundary": "marks and archives this project's research run",
+            "purpose": "Terminal transition marking this run closed and its ledger immutable; the next start archives it.",
+            "write_boundary": "marks the run closed; the next start performs the archive rotation",
         },
         {
             "command": "loopx deepresearch report",

--- a/loopx/capabilities/deep_research/catalog_entry.py
+++ b/loopx/capabilities/deep_research/catalog_entry.py
@@ -70,12 +70,12 @@ DEEP_RESEARCH_CATALOG_ENTRY: dict[str, Any] = {
     "implemented_protocols": [
         {
             "schema_version": "loopx_deepresearch_state_v0",
-            "module": "loopx.deepresearch",
+            "module": "loopx.capabilities.deep_research.runtime",
             "doc": "loopx/capabilities/deep_research/README.md",
         },
         {
             "schema_version": "loopx_deepresearch_packet_v0",
-            "module": "loopx.deepresearch",
+            "module": "loopx.capabilities.deep_research.runtime",
             "doc": "loopx/capabilities/deep_research/README.md",
         },
     ],
@@ -93,12 +93,23 @@ DEEP_RESEARCH_CATALOG_ENTRY: dict[str, Any] = {
             "truth is the .loopx/deepresearch state, not goal todos."
         ),
         (
+            "Distinct from the explore capability: explore owns the goal-scoped, "
+            "public-safe, cross-session question/finding topology; deep-research "
+            "owns this private, session-scoped ledger — raw source locators, claim "
+            "lineage, contradiction adjudication, stop/close/report. Any future "
+            "bridge is a one-way, idempotent, public-safe projection: explore "
+            "never reads the raw ledger, never dual-writes, and graph resolution "
+            "never closes a research run."
+        ),
+        (
             "The packet owns research progression and stop decisions; the model "
             "executes bounded expeditions and records typed ledger transitions only."
         ),
         (
-            "Claims exist only when a tool the agent actually ran produced them; "
-            "reports must keep every citation resolvable to a recorded source."
+            "Claims carry caller-declared provenance: --tool records the tool the "
+            "caller says produced the evidence, and the CLI records it without "
+            "attesting execution; reports must keep every citation resolvable to a "
+            "recorded source."
         ),
         (
             "One active run per project; finished or closed runs are archived under "

--- a/loopx/capabilities/deep_research/catalog_entry.py
+++ b/loopx/capabilities/deep_research/catalog_entry.py
@@ -103,7 +103,9 @@ DEEP_RESEARCH_CATALOG_ENTRY: dict[str, Any] = {
         ),
         (
             "The packet owns research progression and stop decisions; the model "
-            "executes bounded expeditions and records typed ledger transitions only."
+            "executes bounded expeditions and records typed ledger transitions only. "
+            "No contradiction adjudication — in-call or standalone — may overrule "
+            "a claim an already-answered question cites as evidence."
         ),
         (
             "Claims carry caller-declared provenance: --tool records the tool the "

--- a/loopx/capabilities/deep_research/runtime.py
+++ b/loopx/capabilities/deep_research/runtime.py
@@ -1,3 +1,11 @@
+"""Domain owner for the deep-research capability.
+
+State machine, ledger transitions, packet, and report for the
+`/loopx-deepresearch` bounded research loop. The CLI
+(`loopx/cli_commands/deepresearch.py`) is a thin adapter over this module;
+nothing else may mutate `.loopx/deepresearch/` state.
+"""
+
 from __future__ import annotations
 
 import json
@@ -5,7 +13,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from .file_lock import exclusive_file_lock
+from ...file_lock import exclusive_file_lock
 
 COMMAND = "/loopx-deepresearch"
 STATE_SCHEMA_VERSION = "loopx_deepresearch_state_v0"
@@ -32,6 +40,21 @@ def report_path(project: Path) -> Path:
     return project / ".loopx" / "deepresearch" / _REPORT_FILENAME
 
 
+def _require_within_project(project: Path, target: Path) -> Path:
+    """Constrain every ledger write to the resolved project root.
+
+    `--project` is caller-chosen, so the only trustworthy boundary is that the
+    resolved write target stays inside the resolved project directory: this is
+    the auditable answer to "a user-controlled component reaches the write
+    path" — the component selects the root, never a filename.
+    """
+    root = project.expanduser().resolve()
+    resolved = target.expanduser().resolve()
+    if resolved != root and root not in resolved.parents:
+        raise ValueError(f"refusing to touch a path outside the project root: {resolved}")
+    return resolved
+
+
 def load_state(project: Path) -> dict[str, Any] | None:
     path = state_path(project)
     if not path.exists():
@@ -44,7 +67,7 @@ def load_state(project: Path) -> dict[str, Any] | None:
 
 def _save_state(project: Path, state: dict[str, Any]) -> None:
     state["updated_at"] = _now_iso()
-    path = state_path(project)
+    path = _require_within_project(project, state_path(project))
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(state, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
@@ -104,10 +127,10 @@ def _archive_current_run(project: Path, state: dict[str, Any]) -> Path:
     """
     stamp = str(state.get("closed_at") or state.get("updated_at") or _now_iso())
     safe = "".join(ch if ch.isalnum() or ch in "-+" else "-" for ch in stamp)
-    target = archive_root(project) / safe
+    target = _require_within_project(project, archive_root(project) / safe)
     suffix = 2
     while target.exists():  # same-second closes must not overwrite each other
-        target = archive_root(project) / f"{safe}-{suffix}"
+        target = _require_within_project(project, archive_root(project) / f"{safe}-{suffix}")
         suffix += 1
     target.mkdir(parents=True, exist_ok=True)
     state_path(project).rename(target / _STATE_FILENAME)
@@ -407,6 +430,30 @@ def _resolve_question_unlocked(
     open_contradictions = [
         x for x in state["contradictions"] if x["status"] == "open"
     ]
+    # Any contradiction touching the evidence — open or already resolved — must
+    # not have been adjudicated against a cited claim: otherwise the citation
+    # report would back the answer with a side the same ledger ruled out.
+    touching = [
+        x
+        for x in state["contradictions"]
+        if x["claim_a"] in evidence_claims or x["claim_b"] in evidence_claims
+    ]
+    for contradiction in touching:
+        if (
+            contradiction["status"] == "resolved"
+            and contradiction["sides_with"] not in evidence_claims
+        ):
+            overruled = next(
+                cid
+                for cid in (contradiction["claim_a"], contradiction["claim_b"])
+                if cid in evidence_claims
+            )
+            raise ValueError(
+                f"contradiction {contradiction['id']} was resolved against "
+                f"{overruled}; an answer cannot cite the overruled side — cite the "
+                f"adjudicated {contradiction['sides_with']} instead or drop "
+                f"{overruled} from --evidence-claims"
+            )
     blocking = [
         x
         for x in open_contradictions
@@ -427,6 +474,13 @@ def _resolve_question_unlocked(
                 raise ValueError(
                     f"contradiction {contradiction['id']} resolution must side with "
                     f"{contradiction['claim_a']} or {contradiction['claim_b']}"
+                )
+            if sides_with not in evidence_claims:
+                raise ValueError(
+                    f"contradiction {contradiction['id']} resolution sides with "
+                    f"{sides_with}, which is not among this question's evidence claims "
+                    f"{evidence_claims}; the adjudicated side must back the answer — "
+                    "cite it in --evidence-claims"
                 )
             rationale = str(resolution.get("rationale", "")).strip()
             if not rationale:
@@ -537,12 +591,30 @@ def _priority_rank(priority: str) -> int:
 
 def build_packet(state: dict[str, Any], *, cli_bin: str, project: Path) -> dict[str, Any]:
     stop = evaluate_stop(state)
+    run_status = state.get("status", "active")
     open_questions = sorted(
         (q for q in state["questions"] if q["status"] == "open"),
         key=lambda q: (_priority_rank(q["priority"]), q["id"]),
     )
     next_expedition: dict[str, Any] | None = None
-    if not stop["stopped"]:
+    terminal_guidance: dict[str, Any] | None = None
+    if run_status == "closed":
+        # A closed run rejects every ledger mutation, so an expedition would be
+        # an instruction the ledger cannot accept: the packet must project the
+        # terminal state instead of a runnable action.
+        terminal_guidance = {
+            "run_status": "closed",
+            "ledger_immutable": True,
+            "why": (
+                "this run is closed and its ledger is immutable; every evidence "
+                "mutation is rejected until the next start"
+            ),
+            "next_start": (
+                f"{cli_bin} deepresearch start --project {project} "
+                "--question <new-question> (archives this closed run and begins fresh)"
+            ),
+        }
+    elif not stop["stopped"]:
         open_contradictions = [x for x in state["contradictions"] if x["status"] == "open"]
         if open_questions:
             target = open_questions[0]
@@ -574,13 +646,15 @@ def build_packet(state: dict[str, Any], *, cli_bin: str, project: Path) -> dict[
         "schema_version": PACKET_SCHEMA_VERSION,
         "command": COMMAND,
         "question": state["question"],
-        "run_status": state.get("status", "active"),
+        "run_status": run_status,
         "research_contract": {
             "question": state["question"],
             "budget": state["budget"],
             "created_at": state["created_at"],
             "rules": [
-                "claims come only from tool output you actually saw; never fabricate URLs or content",
+                "claims come only from tool output the caller actually saw; --tool is "
+                "caller-declared provenance the CLI records, not an execution "
+                "attestation; never fabricate URLs or content",
                 "every subquestion derives from a recorded claim",
                 "every resolution cites recorded evidence claim ids",
                 "contradictions block resolution until an explicit sides-with rationale is recorded",
@@ -616,6 +690,7 @@ def build_packet(state: dict[str, Any], *, cli_bin: str, project: Path) -> dict[
         ],
         "stop_conditions": stop,
         "next_expedition": next_expedition,
+        "terminal_guidance": terminal_guidance,
         "evidence_commands": {
             "add_source": (
                 f"{cli_bin} deepresearch add-source --project {project} "
@@ -714,7 +789,7 @@ def write_report(project: Path) -> dict[str, Any]:
     with exclusive_file_lock(state_path(project), operation="deepresearch_report"):
         state = _require_state(project)
         content = render_report(state)
-        path = report_path(project)
+        path = _require_within_project(project, report_path(project))
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
         stop = evaluate_stop(state)

--- a/loopx/capabilities/deep_research/runtime.py
+++ b/loopx/capabilities/deep_research/runtime.py
@@ -26,6 +26,7 @@ COVERAGE_WINDOW_SOURCES = 3
 
 _STATE_FILENAME = "research.json"
 _REPORT_FILENAME = "report.md"
+_LEDGER_DIR = Path(".loopx") / "deepresearch"
 
 
 def _now_iso() -> str:
@@ -33,11 +34,11 @@ def _now_iso() -> str:
 
 
 def state_path(project: Path) -> Path:
-    return project / ".loopx" / "deepresearch" / _STATE_FILENAME
+    return project / _LEDGER_DIR / _STATE_FILENAME
 
 
 def report_path(project: Path) -> Path:
-    return project / ".loopx" / "deepresearch" / _REPORT_FILENAME
+    return project / _LEDGER_DIR / _REPORT_FILENAME
 
 
 def _require_within_project(project: Path, target: Path) -> Path:
@@ -115,7 +116,7 @@ def _normalize_source_ref(ref: str) -> str:
 
 
 def archive_root(project: Path) -> Path:
-    return project / ".loopx" / "deepresearch" / "archive"
+    return project / _LEDGER_DIR / "archive"
 
 
 def _archive_current_run(project: Path, state: dict[str, Any]) -> Path:
@@ -401,6 +402,75 @@ def resolve_question(
         )
 
 
+def _adjudicate_touching_contradictions(
+    state: dict[str, Any],
+    evidence_claims: list[str],
+    contradiction_resolutions: list[dict[str, Any]],
+) -> None:
+    """Enforce the adjudication invariant for one answer transition.
+
+    Any contradiction touching the evidence — open or already resolved — must
+    not end up adjudicated against a cited claim: otherwise the citation report
+    would back the answer with a side the ledger itself ruled out. Open ones
+    are resolved in this transition, but only toward a side that belongs to the
+    answer's evidence.
+    """
+    touching = [
+        x
+        for x in state["contradictions"]
+        if x["claim_a"] in evidence_claims or x["claim_b"] in evidence_claims
+    ]
+    for contradiction in touching:
+        if (
+            contradiction["status"] == "resolved"
+            and contradiction["sides_with"] not in evidence_claims
+        ):
+            overruled = next(
+                cid
+                for cid in (contradiction["claim_a"], contradiction["claim_b"])
+                if cid in evidence_claims
+            )
+            raise ValueError(
+                f"contradiction {contradiction['id']} was resolved against "
+                f"{overruled}; an answer cannot cite the overruled side — cite the "
+                f"adjudicated {contradiction['sides_with']} instead or drop "
+                f"{overruled} from --evidence-claims"
+            )
+    by_id = {r.get("contradiction_id"): r for r in contradiction_resolutions}
+    for contradiction in touching:
+        if contradiction["status"] != "open":
+            continue
+        resolution = by_id.get(contradiction["id"])
+        if resolution is None:
+            raise ValueError(
+                f"open contradiction {contradiction['id']} involves your evidence; "
+                "resolve it via --contradiction-resolution with an explicit sides-with "
+                "claim id and rationale"
+            )
+        sides_with = resolution.get("sides_with")
+        if sides_with not in {contradiction["claim_a"], contradiction["claim_b"]}:
+            raise ValueError(
+                f"contradiction {contradiction['id']} resolution must side with "
+                f"{contradiction['claim_a']} or {contradiction['claim_b']}"
+            )
+        if sides_with not in evidence_claims:
+            raise ValueError(
+                f"contradiction {contradiction['id']} resolution sides with "
+                f"{sides_with}, which is not among this question's evidence claims "
+                f"{evidence_claims}; the adjudicated side must back the answer — "
+                "cite it in --evidence-claims"
+            )
+        rationale = str(resolution.get("rationale", "")).strip()
+        if not rationale:
+            raise ValueError(
+                f"contradiction {contradiction['id']} resolution needs a non-empty rationale"
+            )
+        contradiction["status"] = "resolved"
+        contradiction["sides_with"] = sides_with
+        contradiction["resolution"] = rationale
+        contradiction["resolved_at"] = _now_iso()
+
+
 def _resolve_question_unlocked(
     project: Path,
     state: dict[str, Any],
@@ -427,70 +497,7 @@ def _resolve_question_unlocked(
         )
     if not evidence_claims:
         raise ValueError("resolving a question requires at least one recorded evidence claim")
-    open_contradictions = [
-        x for x in state["contradictions"] if x["status"] == "open"
-    ]
-    # Any contradiction touching the evidence — open or already resolved — must
-    # not have been adjudicated against a cited claim: otherwise the citation
-    # report would back the answer with a side the same ledger ruled out.
-    touching = [
-        x
-        for x in state["contradictions"]
-        if x["claim_a"] in evidence_claims or x["claim_b"] in evidence_claims
-    ]
-    for contradiction in touching:
-        if (
-            contradiction["status"] == "resolved"
-            and contradiction["sides_with"] not in evidence_claims
-        ):
-            overruled = next(
-                cid
-                for cid in (contradiction["claim_a"], contradiction["claim_b"])
-                if cid in evidence_claims
-            )
-            raise ValueError(
-                f"contradiction {contradiction['id']} was resolved against "
-                f"{overruled}; an answer cannot cite the overruled side — cite the "
-                f"adjudicated {contradiction['sides_with']} instead or drop "
-                f"{overruled} from --evidence-claims"
-            )
-    blocking = [
-        x
-        for x in open_contradictions
-        if x["claim_a"] in evidence_claims or x["claim_b"] in evidence_claims
-    ]
-    if blocking:
-        by_id = {r.get("contradiction_id"): r for r in contradiction_resolutions}
-        for contradiction in blocking:
-            resolution = by_id.get(contradiction["id"])
-            if resolution is None:
-                raise ValueError(
-                    f"open contradiction {contradiction['id']} involves your evidence; "
-                    "resolve it via --contradiction-resolution with an explicit sides-with "
-                    "claim id and rationale"
-                )
-            sides_with = resolution.get("sides_with")
-            if sides_with not in {contradiction["claim_a"], contradiction["claim_b"]}:
-                raise ValueError(
-                    f"contradiction {contradiction['id']} resolution must side with "
-                    f"{contradiction['claim_a']} or {contradiction['claim_b']}"
-                )
-            if sides_with not in evidence_claims:
-                raise ValueError(
-                    f"contradiction {contradiction['id']} resolution sides with "
-                    f"{sides_with}, which is not among this question's evidence claims "
-                    f"{evidence_claims}; the adjudicated side must back the answer — "
-                    "cite it in --evidence-claims"
-                )
-            rationale = str(resolution.get("rationale", "")).strip()
-            if not rationale:
-                raise ValueError(
-                    f"contradiction {contradiction['id']} resolution needs a non-empty rationale"
-                )
-            contradiction["status"] = "resolved"
-            contradiction["sides_with"] = sides_with
-            contradiction["resolution"] = rationale
-            contradiction["resolved_at"] = _now_iso()
+    _adjudicate_touching_contradictions(state, evidence_claims, contradiction_resolutions)
     question["status"] = "answered"
     question["answer"] = answer
     question["evidence_claims"] = list(evidence_claims)
@@ -589,6 +596,26 @@ def _priority_rank(priority: str) -> int:
     return {"P0": 0, "P1": 1, "P2": 2}.get(priority, 3)
 
 
+def _closed_run_guidance(cli_bin: str, project: Path) -> dict[str, Any]:
+    """Typed terminal projection replacing the expedition on a closed run.
+
+    A closed run rejects every ledger mutation, so an expedition would be an
+    instruction the ledger cannot accept.
+    """
+    return {
+        "run_status": "closed",
+        "ledger_immutable": True,
+        "why": (
+            "this run is closed and its ledger is immutable; every evidence "
+            "mutation is rejected until the next start"
+        ),
+        "next_start": (
+            f"{cli_bin} deepresearch start --project {project} "
+            "--question <new-question> (archives this closed run and begins fresh)"
+        ),
+    }
+
+
 def build_packet(state: dict[str, Any], *, cli_bin: str, project: Path) -> dict[str, Any]:
     stop = evaluate_stop(state)
     run_status = state.get("status", "active")
@@ -599,21 +626,7 @@ def build_packet(state: dict[str, Any], *, cli_bin: str, project: Path) -> dict[
     next_expedition: dict[str, Any] | None = None
     terminal_guidance: dict[str, Any] | None = None
     if run_status == "closed":
-        # A closed run rejects every ledger mutation, so an expedition would be
-        # an instruction the ledger cannot accept: the packet must project the
-        # terminal state instead of a runnable action.
-        terminal_guidance = {
-            "run_status": "closed",
-            "ledger_immutable": True,
-            "why": (
-                "this run is closed and its ledger is immutable; every evidence "
-                "mutation is rejected until the next start"
-            ),
-            "next_start": (
-                f"{cli_bin} deepresearch start --project {project} "
-                "--question <new-question> (archives this closed run and begins fresh)"
-            ),
-        }
+        terminal_guidance = _closed_run_guidance(cli_bin, project)
     elif not stop["stopped"]:
         open_contradictions = [x for x in state["contradictions"] if x["status"] == "open"]
         if open_questions:

--- a/loopx/capabilities/deep_research/runtime.py
+++ b/loopx/capabilities/deep_research/runtime.py
@@ -498,12 +498,56 @@ def _resolve_question_unlocked(
     if not evidence_claims:
         raise ValueError("resolving a question requires at least one recorded evidence claim")
     _adjudicate_touching_contradictions(state, evidence_claims, contradiction_resolutions)
+    # The in-call adjudications above may overrule claims cited by OTHER
+    # already-answered questions; the current question's own citations were
+    # validated by the membership rules inside the adjudication.
+    _reject_overruled_answer_evidence(state, exclude_question_id=question_id)
     question["status"] = "answered"
     question["answer"] = answer
     question["evidence_claims"] = list(evidence_claims)
     question["resolved_at"] = _now_iso()
     _save_state(project, state)
     return {"question_id": question_id, "state": state}
+
+
+def _reject_overruled_answer_evidence(
+    state: dict[str, Any],
+    *,
+    exclude_question_id: str | None = None,
+    prospective: tuple[dict[str, Any], str] | None = None,
+) -> None:
+    """Ledger invariant: no answered question may cite an overruled claim.
+
+    A resolved contradiction adjudicates one of its two claims as the loser;
+    the citation report must never back an already-recorded answer with a side
+    the same ledger ruled against. Enforced on every transition that
+    adjudicates a contradiction — in-call (resolve-question) via the resolved
+    scan, standalone (resolve-contradiction) via `prospective`, which lets the
+    check run before any mutation. `exclude_question_id` covers the question
+    being resolved right now: its own citations are governed by the
+    sides-with-membership rules in _adjudicate_touching_contradictions.
+    """
+    resolved = [x for x in state["contradictions"] if x["status"] == "resolved"]
+    if prospective is not None:
+        contradiction, sides_with = prospective
+        resolved.append({**contradiction, "status": "resolved", "sides_with": sides_with})
+    for contradiction in resolved:
+        sides_with = contradiction["sides_with"]
+        loser = (
+            contradiction["claim_b"]
+            if sides_with == contradiction["claim_a"]
+            else contradiction["claim_a"]
+        )
+        for question in state["questions"]:
+            if question["status"] != "answered" or question["id"] == exclude_question_id:
+                continue
+            if loser in question.get("evidence_claims", []):
+                raise ValueError(
+                    f"contradiction {contradiction['id']} overrules {loser}, which is cited "
+                    f"as evidence by answered question {question['id']}; the ledger cannot "
+                    "silently invalidate an answer it already recorded — re-resolve toward "
+                    "the cited side, or close the run and reopen the question in a new run"
+                )
 
 
 def resolve_contradiction(
@@ -518,7 +562,8 @@ def resolve_contradiction(
     Question resolution closes contradictions touching its evidence, but a
     contradiction can outlive the question that produced its claims; without
     this path the closeout gate would deadlock. Still a typed, audited
-    transition — not a manual state edit.
+    transition — not a manual state edit — and it cannot overrule evidence an
+    already-answered question cites.
     """
     rationale = rationale.strip()
     if not rationale:
@@ -539,6 +584,7 @@ def resolve_contradiction(
                 f"resolution must side with {contradiction['claim_a']} or "
                 f"{contradiction['claim_b']}, got {sides_with!r}"
             )
+        _reject_overruled_answer_evidence(state, prospective=(contradiction, sides_with))
         contradiction["status"] = "resolved"
         contradiction["sides_with"] = sides_with
         contradiction["resolution"] = rationale
@@ -670,7 +716,9 @@ def build_packet(state: dict[str, Any], *, cli_bin: str, project: Path) -> dict[
                 "attestation; never fabricate URLs or content",
                 "every subquestion derives from a recorded claim",
                 "every resolution cites recorded evidence claim ids",
-                "contradictions block resolution until an explicit sides-with rationale is recorded",
+                "contradictions block resolution until an explicit sides-with rationale is "
+                "recorded, and no adjudication — in-call or standalone — may overrule a "
+                "claim an already-answered question cites as evidence",
             ],
         },
         "ledger_summary": {

--- a/loopx/capabilities/deep_research/runtime.py
+++ b/loopx/capabilities/deep_research/runtime.py
@@ -413,7 +413,7 @@ def _adjudicate_touching_contradictions(
     not end up adjudicated against a cited claim: otherwise the citation report
     would back the answer with a side the ledger itself ruled out. Open ones
     are resolved in this transition, but only toward a side that belongs to the
-    answer's evidence.
+    answer's evidence, and the overruled side must not be cited.
     """
     touching = [
         x
@@ -421,50 +421,62 @@ def _adjudicate_touching_contradictions(
         if x["claim_a"] in evidence_claims or x["claim_b"] in evidence_claims
     ]
     for contradiction in touching:
-        if (
-            contradiction["status"] == "resolved"
-            and contradiction["sides_with"] not in evidence_claims
-        ):
-            overruled = next(
-                cid
-                for cid in (contradiction["claim_a"], contradiction["claim_b"])
-                if cid in evidence_claims
+        if contradiction["status"] == "resolved":
+            loser = (
+                contradiction["claim_b"]
+                if contradiction["sides_with"] == contradiction["claim_a"]
+                else contradiction["claim_a"]
             )
-            raise ValueError(
-                f"contradiction {contradiction['id']} was resolved against "
-                f"{overruled}; an answer cannot cite the overruled side — cite the "
-                f"adjudicated {contradiction['sides_with']} instead or drop "
-                f"{overruled} from --evidence-claims"
-            )
+            if loser in evidence_claims:
+                raise ValueError(
+                    f"contradiction {contradiction['id']} was resolved against "
+                    f"{loser}; an answer cannot cite the overruled side — cite the "
+                    f"adjudicated {contradiction['sides_with']} instead or drop "
+                    f"{loser} from --evidence-claims"
+                )
     by_id = {r.get("contradiction_id"): r for r in contradiction_resolutions}
+    validated_resolutions: list[tuple[dict[str, Any], str, str]] = []
     for contradiction in touching:
         if contradiction["status"] != "open":
             continue
-        resolution = by_id.get(contradiction["id"])
+        cid = contradiction["id"]
+        resolution = by_id.get(cid)
         if resolution is None:
             raise ValueError(
-                f"open contradiction {contradiction['id']} involves your evidence; "
+                f"open contradiction {cid} involves your evidence; "
                 "resolve it via --contradiction-resolution with an explicit sides-with "
                 "claim id and rationale"
             )
+        claim_a, claim_b = contradiction["claim_a"], contradiction["claim_b"]
         sides_with = resolution.get("sides_with")
-        if sides_with not in {contradiction["claim_a"], contradiction["claim_b"]}:
+        if sides_with not in {claim_a, claim_b}:
             raise ValueError(
-                f"contradiction {contradiction['id']} resolution must side with "
-                f"{contradiction['claim_a']} or {contradiction['claim_b']}"
+                f"contradiction {cid} resolution must side with "
+                f"{claim_a} or {claim_b}"
             )
         if sides_with not in evidence_claims:
             raise ValueError(
-                f"contradiction {contradiction['id']} resolution sides with "
+                f"contradiction {cid} resolution sides with "
                 f"{sides_with}, which is not among this question's evidence claims "
                 f"{evidence_claims}; the adjudicated side must back the answer — "
                 "cite it in --evidence-claims"
             )
+        loser = claim_b if sides_with == claim_a else claim_a
+        if loser in evidence_claims:
+            raise ValueError(
+                f"contradiction {cid} was resolved against "
+                f"{loser}; an answer cannot cite the overruled side — cite the "
+                f"adjudicated {sides_with} instead or drop "
+                f"{loser} from --evidence-claims"
+            )
         rationale = str(resolution.get("rationale", "")).strip()
         if not rationale:
             raise ValueError(
-                f"contradiction {contradiction['id']} resolution needs a non-empty rationale"
+                f"contradiction {cid} resolution needs a non-empty rationale"
             )
+        validated_resolutions.append((contradiction, sides_with, rationale))
+
+    for contradiction, sides_with, rationale in validated_resolutions:
         contradiction["status"] = "resolved"
         contradiction["sides_with"] = sides_with
         contradiction["resolution"] = rationale

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -86,6 +86,7 @@ from .cli_commands import (
     handle_project_command,
     handle_project_lifecycle_command,
     handle_pr_review_command,
+    handle_deepresearch_command,
     handle_quota_command,
     handle_ready_score_command,
     handle_review_batch_command,
@@ -127,6 +128,7 @@ from .cli_commands import (
     register_project_commands,
     register_project_lifecycle_commands,
     register_pr_review_command,
+    register_deepresearch_command,
     register_quota_command,
     register_ready_score_command,
     register_review_batch_commands,
@@ -306,6 +308,7 @@ def build_parser() -> LoopXArgumentParser:
     register_status_commands(sub, add_subcommand_format)
     register_summary_all_command(sub, add_subcommand_format)
     register_pr_review_command(sub, add_subcommand_format)
+    register_deepresearch_command(sub, add_subcommand_format)
     register_slash_commands_command(sub, add_subcommand_format)
     register_workflow_skills_command(sub, add_subcommand_format)
     register_dreaming_commands(sub, add_subcommand_format)
@@ -809,6 +812,14 @@ def main(argv: list[str] | None = None) -> int:
     )
     if pr_review_result is not None:
         return pr_review_result
+
+    deepresearch_result = handle_deepresearch_command(
+        args,
+        output_format=output_format,
+        print_payload=print_payload,
+    )
+    if deepresearch_result is not None:
+        return deepresearch_result
 
     slash_commands_result = handle_slash_commands_command(
         args,

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -56,6 +56,7 @@ from .preset import handle_preset_command, register_preset_commands
 from .presentation import handle_presentation_command, register_presentation_commands
 from .dash import handle_dash_command, register_dash_commands
 from .pr_review import handle_pr_review_command, register_pr_review_command
+from .deepresearch import handle_deepresearch_command, register_deepresearch_command
 from .quota import handle_quota_command, register_quota_command
 from .ready_score import handle_ready_score_command, register_ready_score_command
 from .review_batch import handle_review_batch_command, register_review_batch_commands
@@ -177,6 +178,7 @@ __all__ = [
     "handle_project_lifecycle_command",
     "handle_project_command",
     "handle_pr_review_command",
+    "handle_deepresearch_command",
     "handle_quota_command",
     "handle_ready_score_command",
     "handle_review_batch_command",
@@ -220,6 +222,7 @@ __all__ = [
     "register_project_lifecycle_commands",
     "register_project_commands",
     "register_pr_review_command",
+    "register_deepresearch_command",
     "register_preset_commands",
     "register_presentation_commands",
     "register_dash_commands",

--- a/loopx/cli_commands/deepresearch.py
+++ b/loopx/cli_commands/deepresearch.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from ..deepresearch import (
+from ..capabilities.deep_research.runtime import (
     DEFAULT_MAX_SOURCES,
     DEFAULT_MAX_SUBQUESTIONS,
     add_source,
@@ -134,7 +134,10 @@ def register_deepresearch_command(
     add_source_parser.add_argument(
         "--tool",
         default="unspecified",
-        help="Tool that produced the evidence: web_search, web_fetch, local_read, ...",
+        help=(
+            "Tool that produced the evidence: web_search, web_fetch, local_read, ... "
+            "Caller-declared provenance: the CLI records it, it does not attest the tool ran."
+        ),
     )
     add_source_parser.add_argument("--title", help="Optional human-readable source title.")
     add_source_parser.add_argument(
@@ -359,6 +362,11 @@ def _render_markdown(payload: dict[str, Any]) -> str:
         if expedition:
             lines.append(
                 f"- next expedition: {expedition['question_id']} — {expedition['text']}"
+            )
+        guidance = packet.get("terminal_guidance")
+        if guidance:
+            lines.append(
+                f"- run closed: ledger immutable; next start: {guidance.get('next_start')}"
             )
     if payload.get("report_path"):
         lines.append(f"- report: {payload['report_path']}")

--- a/loopx/cli_commands/deepresearch.py
+++ b/loopx/cli_commands/deepresearch.py
@@ -13,12 +13,14 @@ from ..deepresearch import (
     add_source,
     add_subquestion,
     build_packet,
+    close_research,
     load_state,
     resolve_contradiction,
     resolve_question,
     start_research,
     write_report,
 )
+from ..file_lock import LockAcquireTimeoutError, lock_timeout_error_fields
 
 PrintPayload = Callable[..., None]
 FormatSelector = Callable[[argparse.Namespace], str]
@@ -30,6 +32,7 @@ _ACTIONS = (
     "add-subquestion",
     "resolve-question",
     "resolve-contradiction",
+    "close",
     "report",
 )
 
@@ -114,6 +117,15 @@ def register_deepresearch_command(
         default=DEFAULT_MAX_SUBQUESTIONS,
         help=f"Subquestion budget. Defaults to {DEFAULT_MAX_SUBQUESTIONS}.",
     )
+    start.add_argument(
+        "--new-run",
+        action="store_true",
+        help=(
+            "When the current run has already stopped, close and archive it, then start "
+            "fresh. An active (not stopped) run still requires an explicit "
+            "`deepresearch close` first."
+        ),
+    )
 
     action("status", "Emit the expedition packet: contract, ledgers, next expedition, stop conditions.")
 
@@ -167,6 +179,15 @@ def register_deepresearch_command(
     )
     contradiction_parser.add_argument("--rationale", required=True)
 
+    close_parser = action(
+        "close",
+        "Terminal transition: close this research run so the next question can start.",
+    )
+    close_parser.add_argument(
+        "--note",
+        help="Optional close rationale (budget blown, abandoned, complete, ...).",
+    )
+
     action("report", "Render the citation-auditable markdown report and write it next to the state.")
 
 
@@ -194,6 +215,7 @@ def handle_deepresearch_command(
                 question=args.question,
                 max_sources=args.max_sources,
                 max_subquestions=args.max_subquestions,
+                new_run=bool(getattr(args, "new_run", False)),
             )
             return emit(
                 {
@@ -202,6 +224,17 @@ def handle_deepresearch_command(
                     "question": state["question"],
                     "state_path": str(project / ".loopx" / "deepresearch" / "research.json"),
                     "packet": build_packet(state, cli_bin="loopx", project=project),
+                }
+            )
+        if action == "close":
+            result = close_research(project, note=args.note)
+            return emit(
+                {
+                    "ok": True,
+                    "schema_version": "loopx_deepresearch_closed_v0",
+                    "run_status": result["status"],
+                    "closed_at": result["closed_at"],
+                    "packet": build_packet(result["state"], cli_bin="loopx", project=project),
                 }
             )
         if action == "status":
@@ -297,8 +330,12 @@ def handle_deepresearch_command(
                 }
             )
         raise ValueError(f"unknown deepresearch action: {action}")
-    except ValueError as error:
-        return emit({"ok": False, "error": str(error), "action": action})
+    except (ValueError, LockAcquireTimeoutError) as error:
+        payload: dict[str, Any] = {"ok": False, "error": str(error), "action": action}
+        # Lock contention is an operational condition, not a crash: the JSON
+        # contract must stay machine-consumable instead of leaking a traceback.
+        payload.update(lock_timeout_error_fields(error))
+        return emit(payload)
 
 
 def _render_markdown(payload: dict[str, Any]) -> str:

--- a/loopx/cli_commands/deepresearch.py
+++ b/loopx/cli_commands/deepresearch.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from ..deepresearch import (
+    DEFAULT_MAX_SOURCES,
+    DEFAULT_MAX_SUBQUESTIONS,
+    add_source,
+    add_subquestion,
+    build_packet,
+    load_state,
+    resolve_contradiction,
+    resolve_question,
+    start_research,
+    write_report,
+)
+
+PrintPayload = Callable[..., None]
+FormatSelector = Callable[[argparse.Namespace], str]
+
+_ACTIONS = (
+    "start",
+    "status",
+    "add-source",
+    "add-subquestion",
+    "resolve-question",
+    "resolve-contradiction",
+    "report",
+)
+
+
+def _parse_claims_json(raw: str | None) -> list[dict[str, Any]]:
+    if not raw:
+        return []
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"--claims-json is not valid JSON: {error}") from error
+    if not isinstance(data, list) or not all(isinstance(item, dict) for item in data):
+        raise ValueError("--claims-json must be a JSON array of claim objects")
+    return data
+
+
+def _parse_contradiction_resolutions(values: list[str] | None) -> list[dict[str, Any]]:
+    resolutions: list[dict[str, Any]] = []
+    for raw in values or []:
+        tokens = shlex.split(raw)
+        fields: dict[str, str] = {}
+        key: str | None = None
+        for token in tokens:
+            if token.startswith("--") and "=" not in token:
+                key = token[2:].replace("-", "_")
+            elif token.startswith("--") and "=" in token:
+                name, value = token[2:].split("=", 1)
+                fields[name.replace("-", "_")] = value
+            elif "=" in token:
+                name, value = token.split("=", 1)
+                fields[name.replace("-", "_")] = value
+            elif key is not None:
+                fields[key] = token
+                key = None
+            else:
+                raise ValueError(
+                    f"unexpected token {token!r} in --contradiction-resolution; use "
+                    "'contradiction-id=<x> sides-with=<claim> rationale=<why>'"
+                )
+        if "contradiction_id" not in fields or "sides_with" not in fields:
+            raise ValueError(
+                f"--contradiction-resolution needs 'contradiction-id=<x> sides-with=<claim> "
+                f"rationale=<why>'; got {raw!r}"
+            )
+        fields.setdefault("rationale", "")
+        resolutions.append(fields)
+    return resolutions
+
+
+def register_deepresearch_command(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    parser = subparsers.add_parser(
+        "deepresearch",
+        help="Bounded deep-research loop: packet-driven expeditions, evidence ledgers, "
+        "citation-auditable report (/loopx-deepresearch).",
+    )
+    actions = parser.add_subparsers(dest="deepresearch_action", metavar="{start,status,add-source,add-subquestion,resolve-question,report}")
+
+    def action(name: str, help_text: str) -> argparse.ArgumentParser:
+        sub = actions.add_parser(name, help=help_text)
+        sub.add_argument(
+            "--project",
+            default=".",
+            help="Project directory holding .loopx/deepresearch/. Defaults to the current directory.",
+        )
+        add_subcommand_format(sub)
+        return sub
+
+    start = action("start", "Start a new bounded deep research for this project.")
+    start.add_argument("--question", required=True, help="The main research question.")
+    start.add_argument(
+        "--max-sources",
+        type=int,
+        default=DEFAULT_MAX_SOURCES,
+        help=f"Source budget. Defaults to {DEFAULT_MAX_SOURCES}.",
+    )
+    start.add_argument(
+        "--max-subquestions",
+        type=int,
+        default=DEFAULT_MAX_SUBQUESTIONS,
+        help=f"Subquestion budget. Defaults to {DEFAULT_MAX_SUBQUESTIONS}.",
+    )
+
+    action("status", "Emit the expedition packet: contract, ledgers, next expedition, stop conditions.")
+
+    add_source_parser = action("add-source", "Record one consulted source and the claims extracted from it.")
+    add_source_parser.add_argument("--url-or-path", required=True)
+    add_source_parser.add_argument(
+        "--tool",
+        default="unspecified",
+        help="Tool that produced the evidence: web_search, web_fetch, local_read, ...",
+    )
+    add_source_parser.add_argument("--title", help="Optional human-readable source title.")
+    add_source_parser.add_argument(
+        "--claims-json",
+        help='JSON array: [{"text": "...", "stance": "supports|neutral|contradicts|refines", "relates_claim": "c1"|null}]',
+    )
+
+    add_subquestion_parser = action("add-subquestion", "Open a subquestion derived from a recorded claim.")
+    add_subquestion_parser.add_argument("--text", required=True)
+    add_subquestion_parser.add_argument("--priority", choices=("P0", "P1", "P2"), default="P1")
+    add_subquestion_parser.add_argument(
+        "--from-claim",
+        required=True,
+        help="Claim id this subquestion derives from; required so lineage cannot be bypassed.",
+    )
+
+    resolve_parser = action("resolve-question", "Answer a recorded question citing recorded evidence claims.")
+    resolve_parser.add_argument("--question-id", required=True)
+    resolve_parser.add_argument("--answer", required=True)
+    resolve_parser.add_argument(
+        "--evidence-claims",
+        nargs="+",
+        required=True,
+        help="Recorded claim ids backing the answer (space separated).",
+    )
+    resolve_parser.add_argument(
+        "--contradiction-resolution",
+        action="append",
+        help="'contradiction-id=x1 sides-with=c2 rationale=\"why\"' — required for open "
+        "contradictions touching your evidence.",
+    )
+
+    contradiction_parser = action(
+        "resolve-contradiction",
+        "Close one open contradiction standalone with an explicit sides-with rationale.",
+    )
+    contradiction_parser.add_argument("--contradiction-id", required=True)
+    contradiction_parser.add_argument(
+        "--sides-with",
+        required=True,
+        help="The claim id the evidence actually supports.",
+    )
+    contradiction_parser.add_argument("--rationale", required=True)
+
+    action("report", "Render the citation-auditable markdown report and write it next to the state.")
+
+
+def handle_deepresearch_command(
+    args: argparse.Namespace,
+    *,
+    output_format: FormatSelector,
+    print_payload: PrintPayload,
+) -> int | None:
+    if args.command != "deepresearch":
+        return None
+    action = getattr(args, "deepresearch_action", None)
+    if action is None:
+        raise ValueError("deepresearch requires an action: " + ", ".join(_ACTIONS))
+    project = Path(getattr(args, "project", ".")).expanduser().resolve()
+
+    def emit(payload: dict[str, Any]) -> int:
+        print_payload(payload, output_format(args), lambda data: _render_markdown(data))
+        return 0 if payload.get("ok") is True else 1
+
+    try:
+        if action == "start":
+            state = start_research(
+                project,
+                question=args.question,
+                max_sources=args.max_sources,
+                max_subquestions=args.max_subquestions,
+            )
+            return emit(
+                {
+                    "ok": True,
+                    "schema_version": "loopx_deepresearch_started_v0",
+                    "question": state["question"],
+                    "state_path": str(project / ".loopx" / "deepresearch" / "research.json"),
+                    "packet": build_packet(state, cli_bin="loopx", project=project),
+                }
+            )
+        if action == "status":
+            state = load_state(project)
+            if state is None:
+                return emit(
+                    {
+                        "ok": False,
+                        "error": "no active deepresearch state in this project; run "
+                        "`loopx deepresearch start --question <text>` first",
+                    }
+                )
+            return emit(
+                {
+                    "ok": True,
+                    "packet": build_packet(state, cli_bin="loopx", project=project),
+                }
+            )
+        if action == "add-source":
+            result = add_source(
+                project,
+                url_or_path=args.url_or_path,
+                tool=args.tool,
+                title=args.title,
+                claims=_parse_claims_json(args.claims_json),
+            )
+            return emit(
+                {
+                    "ok": True,
+                    "schema_version": "loopx_deepresearch_source_added_v0",
+                    "source_id": result["source_id"],
+                    "claim_ids": result["claim_ids"],
+                    "packet": build_packet(result["state"], cli_bin="loopx", project=project),
+                }
+            )
+        if action == "add-subquestion":
+            result = add_subquestion(
+                project,
+                text=args.text,
+                priority=args.priority,
+                from_claim=args.from_claim,
+            )
+            return emit(
+                {
+                    "ok": True,
+                    "schema_version": "loopx_deepresearch_subquestion_added_v0",
+                    "question_id": result["question_id"],
+                    "packet": build_packet(result["state"], cli_bin="loopx", project=project),
+                }
+            )
+        if action == "resolve-question":
+            result = resolve_question(
+                project,
+                question_id=args.question_id,
+                answer=args.answer,
+                evidence_claims=list(args.evidence_claims),
+                contradiction_resolutions=_parse_contradiction_resolutions(
+                    args.contradiction_resolution
+                ),
+            )
+            return emit(
+                {
+                    "ok": True,
+                    "schema_version": "loopx_deepresearch_question_resolved_v0",
+                    "question_id": result["question_id"],
+                    "packet": build_packet(result["state"], cli_bin="loopx", project=project),
+                }
+            )
+        if action == "resolve-contradiction":
+            result = resolve_contradiction(
+                project,
+                contradiction_id=args.contradiction_id,
+                sides_with=args.sides_with,
+                rationale=args.rationale,
+            )
+            return emit(
+                {
+                    "ok": True,
+                    "schema_version": "loopx_deepresearch_contradiction_resolved_v0",
+                    "contradiction_id": result["contradiction_id"],
+                    "packet": build_packet(result["state"], cli_bin="loopx", project=project),
+                }
+            )
+        if action == "report":
+            result = write_report(project)
+            return emit(
+                {
+                    "ok": True,
+                    "schema_version": result["schema_version"],
+                    "report_path": result["path"],
+                    "stop_conditions": result["stop_conditions"],
+                    "content": result["content"],
+                }
+            )
+        raise ValueError(f"unknown deepresearch action: {action}")
+    except ValueError as error:
+        return emit({"ok": False, "error": str(error), "action": action})
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    lines = ["# LoopX Deepresearch", ""]
+    action = payload.get("action") or "packet"
+    lines.append(f"- action: `{action}`")
+    lines.append(f"- ok: `{payload.get('ok')}`")
+    if payload.get("error"):
+        lines.append(f"- error: {payload['error']}")
+    packet = payload.get("packet")
+    if packet is not None:
+        stop = packet.get("stop_conditions", {})
+        summary = packet.get("ledger_summary", {})
+        lines.append(
+            f"- ledgers: questions open/answered {summary.get('questions')}, "
+            f"sources {summary.get('sources')}, claims {summary.get('claims')}, "
+            f"open contradictions {summary.get('open_contradictions')}"
+        )
+        lines.append(f"- stopped: `{stop.get('stopped')}` ({'; '.join(stop.get('reasons', [])) or 'not yet'})")
+        expedition = packet.get("next_expedition")
+        if expedition:
+            lines.append(
+                f"- next expedition: {expedition['question_id']} — {expedition['text']}"
+            )
+    if payload.get("report_path"):
+        lines.append(f"- report: {payload['report_path']}")
+    return "\n".join(lines) + "\n"

--- a/loopx/deepresearch.py
+++ b/loopx/deepresearch.py
@@ -1,0 +1,636 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .file_lock import exclusive_file_lock
+
+COMMAND = "/loopx-deepresearch"
+STATE_SCHEMA_VERSION = "loopx_deepresearch_state_v0"
+PACKET_SCHEMA_VERSION = "loopx_deepresearch_packet_v0"
+REPORT_SCHEMA_VERSION = "loopx_deepresearch_report_v0"
+
+DEFAULT_MAX_SOURCES = 12
+DEFAULT_MAX_SUBQUESTIONS = 8
+COVERAGE_WINDOW_SOURCES = 3
+
+_STATE_FILENAME = "research.json"
+_REPORT_FILENAME = "report.md"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def state_path(project: Path) -> Path:
+    return project / ".loopx" / "deepresearch" / _STATE_FILENAME
+
+
+def report_path(project: Path) -> Path:
+    return project / ".loopx" / "deepresearch" / _REPORT_FILENAME
+
+
+def load_state(project: Path) -> dict[str, Any] | None:
+    path = state_path(project)
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or data.get("schema_version") != STATE_SCHEMA_VERSION:
+        raise ValueError(f"unsupported deepresearch state at {path}")
+    return data
+
+
+def _save_state(project: Path, state: dict[str, Any]) -> None:
+    state["updated_at"] = _now_iso()
+    path = state_path(project)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(state, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def _require_state(project: Path) -> dict[str, Any]:
+    state = load_state(project)
+    if state is None:
+        raise ValueError(
+            "no active deepresearch state in this project; run "
+            "`loopx deepresearch start --question <text>` first"
+        )
+    return state
+
+
+def _next_id(items: list[dict[str, Any]], prefix: str) -> str:
+    used = {str(item.get("id", "")) for item in items}
+    n = 1
+    while f"{prefix}{n}" in used:
+        n += 1
+    return f"{prefix}{n}"
+
+
+def _normalize_source_ref(ref: str) -> str:
+    return ref.strip().rstrip("/").lower()
+
+
+def start_research(
+    project: Path,
+    *,
+    question: str,
+    max_sources: int,
+    max_subquestions: int,
+) -> dict[str, Any]:
+    question = question.strip()
+    if not question:
+        raise ValueError("--question must be a non-empty research question")
+    if max_sources < 1:
+        raise ValueError("--max-sources must be >= 1")
+    if max_subquestions < 0:
+        raise ValueError("--max-subquestions must be >= 0")
+    with exclusive_file_lock(state_path(project), operation="deepresearch_start"):
+        existing = load_state(project)
+        if existing is not None:
+            raise ValueError(
+                "deepresearch state already exists for this project "
+                f"(question: {existing['question']!r}); run `status`/`report`, or remove "
+                f"{state_path(project)} to start over"
+            )
+        state = {
+            "schema_version": STATE_SCHEMA_VERSION,
+            "question": question,
+            "created_at": _now_iso(),
+            "updated_at": _now_iso(),
+            "budget": {
+                "max_sources": max_sources,
+                "max_subquestions": max_subquestions,
+            },
+            "questions": [
+                {
+                    "id": "q1",
+                    "text": question,
+                    "status": "open",
+                    "priority": "P0",
+                    "parent_claim": None,
+                    "answer": None,
+                    "evidence_claims": [],
+                    "resolved_at": None,
+                }
+            ],
+            "sources": [],
+            "claims": [],
+            "contradictions": [],
+        }
+        _save_state(project, state)
+    return state
+
+
+def add_source(
+    project: Path,
+    *,
+    url_or_path: str,
+    tool: str,
+    title: str | None,
+    claims: list[dict[str, Any]],
+) -> dict[str, Any]:
+    # Load, validate the whole batch, allocate ids, mutate, and save all under
+    # one project-level lock: concurrent deepresearch commands are a normal
+    # agent-host shape, and an unlocked read-modify-write loses updates even
+    # when the atomic rename itself succeeds.
+    with exclusive_file_lock(state_path(project), operation="deepresearch_add_source"):
+        state = _require_state(project)
+        url_or_path = url_or_path.strip()
+        tool = tool.strip() or "unspecified"
+        if not url_or_path:
+            raise ValueError("--url-or-path must be non-empty")
+        normalized = _normalize_source_ref(url_or_path)
+        for source in state["sources"]:
+            if _normalize_source_ref(str(source["url_or_path"])) == normalized:
+                raise ValueError(
+                    f"source already recorded as {source['id']} "
+                    f"({source['url_or_path']}); reuse its claims instead of re-reading"
+                )
+        if len(state["sources"]) >= int(state["budget"]["max_sources"]):
+            raise ValueError(
+                f"source budget exhausted ({state['budget']['max_sources']}); "
+                "resolve open questions with existing evidence or raise --max-sources at start"
+            )
+        # Validate every claim against the pre-existing ledger before any
+        # mutation: a mid-batch ValueError must not leave partial state behind,
+        # and a claim can only relate to a claim recorded before this batch —
+        # which also makes self-reference (c2 contradicting itself) impossible.
+        known_before = {c["id"] for c in state["claims"]}
+        prepared: list[dict[str, Any]] = []
+        for claim in claims:
+            text = str(claim.get("text", "")).strip()
+            if not text:
+                raise ValueError("each claim needs non-empty 'text'")
+            stance = str(claim.get("stance") or "neutral")
+            if stance not in {"supports", "neutral", "contradicts", "refines"}:
+                raise ValueError(
+                    f"claim stance must be supports|neutral|contradicts|refines, got {stance!r}"
+                )
+            relates_claim = claim.get("relates_claim")
+            if stance == "contradicts" and not relates_claim:
+                raise ValueError(
+                    "a contradicting claim must cite the claim it contradicts via 'relates_claim'"
+                )
+            if relates_claim is not None and relates_claim not in known_before:
+                raise ValueError(
+                    f"relates_claim {relates_claim!r} is not a recorded claim (self-reference "
+                    "is not a contradiction)"
+                )
+            prepared.append({"text": text, "stance": stance, "relates_claim": relates_claim})
+        # Mutation phase: nothing below can fail on user input anymore.
+        source_id = _next_id(state["sources"], "s")
+        claim_ids: list[str] = []
+        for claim in prepared:
+            claim_id = _next_id(state["claims"], "c")
+            if claim["relates_claim"] == claim_id:  # defensive: unreachable given known_before
+                raise ValueError(f"claim {claim_id} cannot reference itself")
+            state["claims"].append(
+                {
+                    "id": claim_id,
+                    "text": claim["text"],
+                    "source_id": source_id,
+                    "stance": claim["stance"],
+                    "relates_claim": claim["relates_claim"],
+                    "added_at": _now_iso(),
+                }
+            )
+            claim_ids.append(claim_id)
+            if claim["stance"] == "contradicts":
+                state["contradictions"].append(
+                    {
+                        "id": _next_id(state["contradictions"], "x"),
+                        "claim_a": claim_id,
+                        "claim_b": claim["relates_claim"],
+                        "status": "open",
+                        "sides_with": None,
+                        "resolution": None,
+                        "resolved_at": None,
+                    }
+                )
+        state["sources"].append(
+            {
+                "id": source_id,
+                "url_or_path": url_or_path,
+                "tool": tool,
+                "title": (title or "").strip() or None,
+                "accessed_at": _now_iso(),
+                "claims": claim_ids,
+            }
+        )
+        _save_state(project, state)
+    return {
+        "source_id": source_id,
+        "claim_ids": claim_ids,
+        "state": state,
+    }
+
+
+def add_subquestion(
+    project: Path,
+    *,
+    text: str,
+    priority: str,
+    from_claim: str | None,
+) -> dict[str, Any]:
+    with exclusive_file_lock(state_path(project), operation="deepresearch_add_subquestion"):
+        state = _require_state(project)
+        text = text.strip()
+        if not text:
+            raise ValueError("--text must be non-empty")
+        if priority not in {"P0", "P1", "P2"}:
+            raise ValueError("--priority must be P0|P1|P2")
+        # Machine-enforced lineage: a subquestion without a recorded parent
+        # claim is free-roaming, whatever the packet prose says. Enforced here
+        # so Python callers cannot bypass the argparse layer.
+        if not from_claim:
+            raise ValueError(
+                "from_claim is required: every subquestion must derive from a recorded claim"
+            )
+        known = {c["id"] for c in state["claims"]}
+        if from_claim not in known:
+            raise ValueError(
+                f"--from-claim {from_claim!r} is not a recorded claim; subquestions must "
+                "derive from evidence, not open in free space"
+            )
+        open_subquestions = [q for q in state["questions"] if q["id"] != "q1"]
+        if len(open_subquestions) >= int(state["budget"]["max_subquestions"]):
+            raise ValueError(
+                f"subquestion budget exhausted ({state['budget']['max_subquestions']})"
+            )
+        question = {
+            "id": _next_id(state["questions"], "q"),
+            "text": text,
+            "status": "open",
+            "priority": priority,
+            "parent_claim": from_claim,
+            "answer": None,
+            "evidence_claims": [],
+            "resolved_at": None,
+        }
+        state["questions"].append(question)
+        _save_state(project, state)
+    return {"question_id": question["id"], "state": state}
+
+
+def resolve_question(
+    project: Path,
+    *,
+    question_id: str,
+    answer: str,
+    evidence_claims: list[str],
+    contradiction_resolutions: list[dict[str, Any]],
+) -> dict[str, Any]:
+    with exclusive_file_lock(state_path(project), operation="deepresearch_resolve_question"):
+        state = _require_state(project)
+        return _resolve_question_unlocked(
+            project,
+            state,
+            question_id=question_id,
+            answer=answer,
+            evidence_claims=evidence_claims,
+            contradiction_resolutions=contradiction_resolutions,
+        )
+
+
+def _resolve_question_unlocked(
+    project: Path,
+    state: dict[str, Any],
+    *,
+    question_id: str,
+    answer: str,
+    evidence_claims: list[str],
+    contradiction_resolutions: list[dict[str, Any]],
+) -> dict[str, Any]:
+    answer = answer.strip()
+    if not answer:
+        raise ValueError("--answer must be non-empty")
+    question = next((q for q in state["questions"] if q["id"] == question_id), None)
+    if question is None:
+        raise ValueError(f"--question-id {question_id!r} is not a recorded question")
+    if question["status"] != "open":
+        raise ValueError(f"question {question_id} is already {question['status']}")
+    known_claims = {c["id"] for c in state["claims"]}
+    unknown = [cid for cid in evidence_claims if cid not in known_claims]
+    if unknown:
+        raise ValueError(
+            f"evidence claims not recorded: {unknown}; record sources/claims first — "
+            "an answer without ledger evidence is exactly the drift this command exists to stop"
+        )
+    if not evidence_claims:
+        raise ValueError("resolving a question requires at least one recorded evidence claim")
+    open_contradictions = [
+        x for x in state["contradictions"] if x["status"] == "open"
+    ]
+    blocking = [
+        x
+        for x in open_contradictions
+        if x["claim_a"] in evidence_claims or x["claim_b"] in evidence_claims
+    ]
+    if blocking:
+        by_id = {r.get("contradiction_id"): r for r in contradiction_resolutions}
+        for contradiction in blocking:
+            resolution = by_id.get(contradiction["id"])
+            if resolution is None:
+                raise ValueError(
+                    f"open contradiction {contradiction['id']} involves your evidence; "
+                    "resolve it via --contradiction-resolution with an explicit sides-with "
+                    "claim id and rationale"
+                )
+            sides_with = resolution.get("sides_with")
+            if sides_with not in {contradiction["claim_a"], contradiction["claim_b"]}:
+                raise ValueError(
+                    f"contradiction {contradiction['id']} resolution must side with "
+                    f"{contradiction['claim_a']} or {contradiction['claim_b']}"
+                )
+            rationale = str(resolution.get("rationale", "")).strip()
+            if not rationale:
+                raise ValueError(
+                    f"contradiction {contradiction['id']} resolution needs a non-empty rationale"
+                )
+            contradiction["status"] = "resolved"
+            contradiction["sides_with"] = sides_with
+            contradiction["resolution"] = rationale
+            contradiction["resolved_at"] = _now_iso()
+    question["status"] = "answered"
+    question["answer"] = answer
+    question["evidence_claims"] = list(evidence_claims)
+    question["resolved_at"] = _now_iso()
+    _save_state(project, state)
+    return {"question_id": question_id, "state": state}
+
+
+def resolve_contradiction(
+    project: Path,
+    *,
+    contradiction_id: str,
+    sides_with: str,
+    rationale: str,
+) -> dict[str, Any]:
+    """Close a contradiction standalone with an explicit sides-with rationale.
+
+    Question resolution closes contradictions touching its evidence, but a
+    contradiction can outlive the question that produced its claims; without
+    this path the closeout gate would deadlock. Still a typed, audited
+    transition — not a manual state edit.
+    """
+    rationale = rationale.strip()
+    if not rationale:
+        raise ValueError("--rationale must be non-empty")
+    with exclusive_file_lock(
+        state_path(project), operation="deepresearch_resolve_contradiction"
+    ):
+        state = _require_state(project)
+        contradiction = next(
+            (x for x in state["contradictions"] if x["id"] == contradiction_id), None
+        )
+        if contradiction is None:
+            raise ValueError(f"--contradiction-id {contradiction_id!r} is not recorded")
+        if contradiction["status"] != "open":
+            raise ValueError(f"contradiction {contradiction_id} is already resolved")
+        if sides_with not in {contradiction["claim_a"], contradiction["claim_b"]}:
+            raise ValueError(
+                f"resolution must side with {contradiction['claim_a']} or "
+                f"{contradiction['claim_b']}, got {sides_with!r}"
+            )
+        contradiction["status"] = "resolved"
+        contradiction["sides_with"] = sides_with
+        contradiction["resolution"] = rationale
+        contradiction["resolved_at"] = _now_iso()
+        _save_state(project, state)
+    return {"contradiction_id": contradiction_id, "state": state}
+
+
+def evaluate_stop(state: dict[str, Any]) -> dict[str, Any]:
+    budget = state["budget"]
+    open_questions = [q for q in state["questions"] if q["status"] == "open"]
+    blocking_open = [q for q in open_questions if q["priority"] in {"P0", "P1"}]
+    open_contradictions = [x for x in state["contradictions"] if x["status"] == "open"]
+    reasons: list[str] = []
+    stopped = False
+    if not open_questions:
+        stopped = True
+        reasons.append("all questions answered")
+    elif not blocking_open:
+        stopped = True
+        reasons.append("only P2 questions remain open; complete with declared open questions")
+    if len(state["sources"]) >= int(budget["max_sources"]):
+        stopped = True
+        reasons.append(
+            f"source budget exhausted ({len(state['sources'])}/{budget['max_sources']})"
+        )
+    recent = state["sources"][-COVERAGE_WINDOW_SOURCES:]
+    if (
+        len(recent) == COVERAGE_WINDOW_SOURCES
+        and not any(source["claims"] for source in recent)
+    ):
+        stopped = True
+        reasons.append(
+            f"coverage stop: last {COVERAGE_WINDOW_SOURCES} sources contributed no claims"
+        )
+    # Conservative v0 closeout gate: an unresolved contradiction makes the
+    # ledger internally inconsistent, so `stopped: true` must never claim the
+    # research closed out over one — even when every question is answered and
+    # the resolution path used evidence the contradiction does not touch.
+    if open_contradictions:
+        stopped = False
+        reasons.append(
+            f"{len(open_contradictions)} open contradiction(s) must be resolved before "
+            "completion (deepresearch resolve-contradiction)"
+        )
+    return {
+        "stopped": stopped,
+        "reasons": reasons,
+        "open_questions": len(open_questions),
+        "open_contradictions": len(open_contradictions),
+    }
+
+
+def _priority_rank(priority: str) -> int:
+    return {"P0": 0, "P1": 1, "P2": 2}.get(priority, 3)
+
+
+def build_packet(state: dict[str, Any], *, cli_bin: str, project: Path) -> dict[str, Any]:
+    stop = evaluate_stop(state)
+    open_questions = sorted(
+        (q for q in state["questions"] if q["status"] == "open"),
+        key=lambda q: (_priority_rank(q["priority"]), q["id"]),
+    )
+    next_expedition: dict[str, Any] | None = None
+    if not stop["stopped"]:
+        open_contradictions = [x for x in state["contradictions"] if x["status"] == "open"]
+        if open_questions:
+            target = open_questions[0]
+            next_expedition = {
+                "question_id": target["id"],
+                "text": target["text"],
+                "derived_from_claim": target["parent_claim"],
+                "guidance": (
+                    "gather evidence for exactly this question within a small budget, then record "
+                    "findings with the evidence commands below; do not free-roam other topics"
+                ),
+            }
+        elif open_contradictions:
+            target = open_contradictions[0]
+            next_expedition = {
+                "question_id": None,
+                "kind": "contradiction_resolution",
+                "text": (
+                    f"resolve contradiction {target['id']}: {target['claim_a']} vs "
+                    f"{target['claim_b']}"
+                ),
+                "guidance": (
+                    "the ledger cannot close out over an unresolved contradiction; pick the "
+                    "claim the evidence actually supports via `deepresearch resolve-contradiction` "
+                    "with an explicit sides-with rationale"
+                ),
+            }
+    return {
+        "schema_version": PACKET_SCHEMA_VERSION,
+        "command": COMMAND,
+        "question": state["question"],
+        "research_contract": {
+            "question": state["question"],
+            "budget": state["budget"],
+            "created_at": state["created_at"],
+            "rules": [
+                "claims come only from tool output you actually saw; never fabricate URLs or content",
+                "every subquestion derives from a recorded claim",
+                "every resolution cites recorded evidence claim ids",
+                "contradictions block resolution until an explicit sides-with rationale is recorded",
+            ],
+        },
+        "ledger_summary": {
+            "questions": {
+                "open": len(open_questions),
+                "answered": len([q for q in state["questions"] if q["status"] == "answered"]),
+            },
+            "sources": len(state["sources"]),
+            "claims": len(state["claims"]),
+            "open_contradictions": stop["open_contradictions"],
+        },
+        "open_questions": [
+            {
+                "id": q["id"],
+                "priority": q["priority"],
+                "text": q["text"],
+                "parent_claim": q["parent_claim"],
+            }
+            for q in open_questions
+        ],
+        "contradictions": [
+            {
+                "id": x["id"],
+                "claim_a": x["claim_a"],
+                "claim_b": x["claim_b"],
+                "status": x["status"],
+                "sides_with": x["sides_with"],
+            }
+            for x in state["contradictions"]
+        ],
+        "stop_conditions": stop,
+        "next_expedition": next_expedition,
+        "evidence_commands": {
+            "add_source": (
+                f"{cli_bin} deepresearch add-source --project {project} "
+                "--url-or-path <url-or-file> --tool <web_search|web_fetch|local_read|...> "
+                "--claims-json '[{\"text\": \"...\", \"stance\": \"supports|neutral|contradicts|refines\", \"relates_claim\": null}]'"
+            ),
+            "add_subquestion": (
+                f"{cli_bin} deepresearch add-subquestion --project {project} "
+                "--text '<sub>' --priority P1 --from-claim <claim-id>"
+            ),
+            "resolve_question": (
+                f"{cli_bin} deepresearch resolve-question --project {project} "
+                "--question-id <id> --answer '<answer>' --evidence-claims c1 c2 "
+                "[--contradiction-resolution contradiction-id=X sides-with=cY rationale='...']"
+            ),
+            "resolve_contradiction": (
+                f"{cli_bin} deepresearch resolve-contradiction --project {project} "
+                "--contradiction-id <id> --sides-with <claim-id> --rationale '<why>'"
+            ),
+            "report": f"{cli_bin} deepresearch report --project {project}",
+        },
+    }
+
+
+def render_report(state: dict[str, Any]) -> str:
+    lines: list[str] = [
+        "# Deep research report",
+        "",
+        f"- question: {state['question']}",
+        f"- state schema: `{STATE_SCHEMA_VERSION}`",
+        f"- created: {state['created_at']} · updated: {state['updated_at']}",
+        "",
+        "## Answers",
+        "",
+    ]
+    answered = [q for q in state["questions"] if q["status"] == "answered"]
+    if not answered:
+        lines.append("_No question has been answered yet._")
+    for question in answered:
+        lines.append(f"### {question['id']}: {question['text']}")
+        lines.append("")
+        lines.append(str(question["answer"]))
+        lines.append("")
+        lines.append(
+            "evidence: "
+            + ", ".join(f"`{cid}`" for cid in question.get("evidence_claims", []))
+        )
+        lines.append("")
+    open_questions = [q for q in state["questions"] if q["status"] == "open"]
+    if open_questions:
+        lines.append("## Open questions")
+        lines.append("")
+        for question in open_questions:
+            lines.append(f"- **{question['priority']}** {question['id']}: {question['text']}")
+        lines.append("")
+    if state["contradictions"]:
+        lines.append("## Contradictions")
+        lines.append("")
+        for contradiction in state["contradictions"]:
+            if contradiction["status"] == "resolved":
+                lines.append(
+                    f"- {contradiction['id']}: {contradiction['claim_a']} vs "
+                    f"{contradiction['claim_b']} — resolved, sides with "
+                    f"{contradiction['sides_with']}: {contradiction['resolution']}"
+                )
+            else:
+                lines.append(
+                    f"- {contradiction['id']}: {contradiction['claim_a']} vs "
+                    f"{contradiction['claim_b']} — **OPEN**"
+                )
+        lines.append("")
+    lines.append("## Claims")
+    lines.append("")
+    for claim in state["claims"]:
+        lines.append(f"- `{claim['id']}` [{claim['stance']}] {claim['text']} — source `{claim['source_id']}`")
+    lines.append("")
+    lines.append("## Sources")
+    lines.append("")
+    lines.append("| id | tool | url / path | claims |")
+    lines.append("| --- | --- | --- | --- |")
+    for source in state["sources"]:
+        claims = ", ".join(source["claims"]) or "—"
+        title = f" — {source['title']}" if source.get("title") else ""
+        lines.append(
+            f"| `{source['id']}` | {source['tool']} | {source['url_or_path']}{title} | {claims} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_report(project: Path) -> dict[str, Any]:
+    state = _require_state(project)
+    content = render_report(state)
+    path = report_path(project)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "path": str(path),
+        "content": content,
+        "stop_conditions": evaluate_stop(state),
+    }

--- a/loopx/deepresearch.py
+++ b/loopx/deepresearch.py
@@ -61,6 +61,24 @@ def _require_state(project: Path) -> dict[str, Any]:
     return state
 
 
+def _require_active_state(project: Path) -> dict[str, Any]:
+    """Single, unbypassable precondition for every ledger mutation.
+
+    `closed` is a terminal receipt: a closed run's ledger is immutable, so a
+    mutation after close would silently diverge the archived audit trail from
+    the close summary. Enforced here in the domain owner — not in argparse —
+    so Python callers cannot bypass it.
+    """
+    state = _require_state(project)
+    if state.get("status", "active") == "closed":
+        raise ValueError(
+            "research run is closed"
+            + (f" (closed_at {state.get('closed_at')})" if state.get("closed_at") else "")
+            + "; the ledger is immutable after close — start a new run instead"
+        )
+    return state
+
+
 def _next_id(items: list[dict[str, Any]], prefix: str) -> str:
     used = {str(item.get("id", "")) for item in items}
     n = 1
@@ -202,7 +220,7 @@ def add_source(
     # agent-host shape, and an unlocked read-modify-write loses updates even
     # when the atomic rename itself succeeds.
     with exclusive_file_lock(state_path(project), operation="deepresearch_add_source"):
-        state = _require_state(project)
+        state = _require_active_state(project)
         url_or_path = url_or_path.strip()
         tool = tool.strip() or "unspecified"
         if not url_or_path:
@@ -301,7 +319,7 @@ def add_subquestion(
     from_claim: str | None,
 ) -> dict[str, Any]:
     with exclusive_file_lock(state_path(project), operation="deepresearch_add_subquestion"):
-        state = _require_state(project)
+        state = _require_active_state(project)
         text = text.strip()
         if not text:
             raise ValueError("--text must be non-empty")
@@ -349,7 +367,7 @@ def resolve_question(
     contradiction_resolutions: list[dict[str, Any]],
 ) -> dict[str, Any]:
     with exclusive_file_lock(state_path(project), operation="deepresearch_resolve_question"):
-        state = _require_state(project)
+        state = _require_active_state(project)
         return _resolve_question_unlocked(
             project,
             state,
@@ -447,7 +465,7 @@ def resolve_contradiction(
     with exclusive_file_lock(
         state_path(project), operation="deepresearch_resolve_contradiction"
     ):
-        state = _require_state(project)
+        state = _require_active_state(project)
         contradiction = next(
             (x for x in state["contradictions"] if x["id"] == contradiction_id), None
         )
@@ -689,14 +707,20 @@ def render_report(state: dict[str, Any]) -> str:
 
 
 def write_report(project: Path) -> dict[str, Any]:
-    state = _require_state(project)
-    content = render_report(state)
-    path = report_path(project)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(content, encoding="utf-8")
+    # Snapshot, render, and write share the lifecycle lock with close/start
+    # rotation: otherwise a report that read the previous run can land next to
+    # the next run's state file — a cross-run citation mismatch the archive
+    # cannot explain.
+    with exclusive_file_lock(state_path(project), operation="deepresearch_report"):
+        state = _require_state(project)
+        content = render_report(state)
+        path = report_path(project)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        stop = evaluate_stop(state)
     return {
         "schema_version": REPORT_SCHEMA_VERSION,
         "path": str(path),
         "content": content,
-        "stop_conditions": evaluate_stop(state),
+        "stop_conditions": stop,
     }

--- a/loopx/deepresearch.py
+++ b/loopx/deepresearch.py
@@ -73,12 +73,61 @@ def _normalize_source_ref(ref: str) -> str:
     return ref.strip().rstrip("/").lower()
 
 
+def archive_root(project: Path) -> Path:
+    return project / ".loopx" / "deepresearch" / "archive"
+
+
+def _archive_current_run(project: Path, state: dict[str, Any]) -> Path:
+    """Move the closed run's state (and report) under archive/<closed_at>/.
+
+    A typed terminal rotation — the only path besides uninstall that removes
+    research.json, so a finished run never blocks the next question and the
+    audit trail stays on disk.
+    """
+    stamp = str(state.get("closed_at") or state.get("updated_at") or _now_iso())
+    safe = "".join(ch if ch.isalnum() or ch in "-+" else "-" for ch in stamp)
+    target = archive_root(project) / safe
+    suffix = 2
+    while target.exists():  # same-second closes must not overwrite each other
+        target = archive_root(project) / f"{safe}-{suffix}"
+        suffix += 1
+    target.mkdir(parents=True, exist_ok=True)
+    state_path(project).rename(target / _STATE_FILENAME)
+    report = report_path(project)
+    if report.exists():
+        report.rename(target / _REPORT_FILENAME)
+    return target
+
+
+def close_research(project: Path, *, note: str | None = None) -> dict[str, Any]:
+    """Terminal transition: an explicit operator decision to end this run.
+
+    Closing is allowed at any point (budget blown, question abandoned, or
+    research complete) because it is the run owner saying "done" — unlike
+    stop_conditions, which the packet computes from ledger state. A closed run
+    never blocks `start`; the next start archives it and begins fresh.
+    """
+    with exclusive_file_lock(state_path(project), operation="deepresearch_close"):
+        state = _require_state(project)
+        if state.get("status", "active") == "closed":
+            raise ValueError("research run is already closed")
+        state["status"] = "closed"
+        state["closed_at"] = _now_iso()
+        if note and note.strip():
+            state["close_note"] = note.strip()
+        stop = evaluate_stop(state)
+        state["close_summary"] = stop
+        _save_state(project, state)
+    return {"status": "closed", "closed_at": state["closed_at"], "state": state}
+
+
 def start_research(
     project: Path,
     *,
     question: str,
     max_sources: int,
     max_subquestions: int,
+    new_run: bool = False,
 ) -> dict[str, Any]:
     question = question.strip()
     if not question:
@@ -90,13 +139,29 @@ def start_research(
     with exclusive_file_lock(state_path(project), operation="deepresearch_start"):
         existing = load_state(project)
         if existing is not None:
-            raise ValueError(
-                "deepresearch state already exists for this project "
-                f"(question: {existing['question']!r}); run `status`/`report`, or remove "
-                f"{state_path(project)} to start over"
-            )
+            if existing.get("status", "active") == "closed":
+                _archive_current_run(project, existing)
+            elif new_run and evaluate_stop(existing)["stopped"]:
+                existing["status"] = "closed"
+                existing["closed_at"] = _now_iso()
+                existing["close_note"] = "auto-closed by start --new-run"
+                _save_state(project, existing)
+                _archive_current_run(project, existing)
+            else:
+                if evaluate_stop(existing)["stopped"]:
+                    raise ValueError(
+                        "a finished research run exists for this project; close it with "
+                        "`loopx deepresearch close` (or rerun start with --new-run) "
+                        "before starting a new question"
+                    )
+                raise ValueError(
+                    f"an active research run exists for this project (question: "
+                    f"{existing['question']!r}); finish and `loopx deepresearch close` it "
+                    "before starting a new question"
+                )
         state = {
             "schema_version": STATE_SCHEMA_VERSION,
+            "status": "active",
             "question": question,
             "created_at": _now_iso(),
             "updated_at": _now_iso(),
@@ -491,6 +556,7 @@ def build_packet(state: dict[str, Any], *, cli_bin: str, project: Path) -> dict[
         "schema_version": PACKET_SCHEMA_VERSION,
         "command": COMMAND,
         "question": state["question"],
+        "run_status": state.get("status", "active"),
         "research_contract": {
             "question": state["question"],
             "budget": state["budget"],

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -289,6 +289,7 @@ def _command_prompt_specs(*, cli_bin: str, include_legacy_aliases: bool) -> list
                 "Record every finding through the typed subcommands (`add-source`, `add-subquestion`, `resolve-question`); never edit the state file directly, and never fabricate URLs or claims — a claim exists only if a tool you actually ran produced it.",
                 "Resolve a question only with recorded evidence claim ids; an open contradiction blocks resolution until an explicit sides-with claim and rationale are recorded.",
                 "Re-run `status` after every expedition; stop when `stop_conditions.stopped` is true, then run `deepresearch report` and present the report path.",
+                "One active run per project: to research a new question, run `deepresearch close` (or `start --new-run` once stopped) — the previous run is archived by that typed transition, never by editing state files.",
             ],
         },
     ]

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -277,6 +277,20 @@ def _command_prompt_specs(*, cli_bin: str, include_legacy_aliases: bool) -> list
                 "This command is read-only; do not comment, approve, merge, rerun CI, or spend quota unless separately authorized.",
             ],
         },
+        {
+            "command": "/loopx-deepresearch",
+            "name": "loopx-deepresearch",
+            "description": "Run a bounded LoopX deep-research loop: packet-driven expeditions, evidence ledgers, citation-auditable report.",
+            "argument_hint": "<research question> [--max-sources N]",
+            "instructions": [
+                "Visible command arguments: `$ARGUMENTS`.",
+                f"Run `{cli_bin} --format json deepresearch status --project .` first; if no research is active, treat `$ARGUMENTS` as the question and run `{cli_bin} --format json deepresearch start --project . --question $ARGUMENTS`.",
+                "Keep `research_contract`, `stop_conditions`, `next_expedition`, and `evidence_commands` from the packet visible; the packet owns what to research next and when to stop.",
+                "Record every finding through the typed subcommands (`add-source`, `add-subquestion`, `resolve-question`); never edit the state file directly, and never fabricate URLs or claims — a claim exists only if a tool you actually ran produced it.",
+                "Resolve a question only with recorded evidence claim ids; an open contradiction blocks resolution until an explicit sides-with claim and rationale are recorded.",
+                "Re-run `status` after every expedition; stop when `stop_conditions.stopped` is true, then run `deepresearch report` and present the report path.",
+            ],
+        },
     ]
     if include_legacy_aliases:
         legacy_specs = []

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -289,7 +289,7 @@ def _command_prompt_specs(*, cli_bin: str, include_legacy_aliases: bool) -> list
                 "Record every finding through the typed subcommands (`add-source`, `add-subquestion`, `resolve-question`); never edit the state file directly, and never fabricate URLs or claims — a claim exists only if a tool you actually ran produced it.",
                 "Resolve a question only with recorded evidence claim ids; an open contradiction blocks resolution until an explicit sides-with claim and rationale are recorded.",
                 "Re-run `status` after every expedition; stop when `stop_conditions.stopped` is true, then run `deepresearch report` and present the report path.",
-                "One active run per project: to research a new question, run `deepresearch close` (or `start --new-run` once stopped) — the previous run is archived by that typed transition, never by editing state files.",
+                "One active run per project: to research a new question, run `deepresearch close` (or `start --new-run` once stopped) — close marks the terminal state and the next start archives it, never by editing state files.",
             ],
         },
     ]

--- a/tests/capabilities/test_capability_extension_registry.py
+++ b/tests/capabilities/test_capability_extension_registry.py
@@ -40,6 +40,7 @@ BUILTIN_IDS = [
     "value-connectors",
     "explore",
     "auto-research",
+    "deep-research",
     "public-safe-outbound",
 ]
 

--- a/tests/test_deepresearch_command.py
+++ b/tests/test_deepresearch_command.py
@@ -660,6 +660,166 @@ def test_deep_research_is_a_registered_capability() -> None:
     assert entry["next_real_step"]
 
 
+def test_closed_run_rejects_every_ledger_mutation(tmp_path: Path) -> None:
+    # Reviewer probe: `start -> close -> add-source` used to return ok=true and
+    # silently mutate a terminal run's ledger. Every mutation must fail closed.
+    _start(tmp_path)
+    _payload(
+        _run_cli(
+            "deepresearch",
+            "add-source",
+            "--project",
+            ".",
+            "--url-or-path",
+            "docs/before-close.md",
+            "--tool",
+            "local_read",
+            "--claims-json",
+            json.dumps(
+                [
+                    {"text": "seed claim", "stance": "supports"},
+                    {"text": "seed claim two", "stance": "neutral"},
+                ]
+            ),
+            cwd=tmp_path,
+        )
+    )
+    _payload(_run_cli("deepresearch", "close", "--project", ".", cwd=tmp_path))
+
+    mutations = [
+        ("deepresearch", "add-source", "--project", ".",
+         "--url-or-path", "docs/after-close.md", "--tool", "local_read",
+         "--claims-json", json.dumps([{"text": "late claim", "stance": "neutral"}])),
+        ("deepresearch", "add-subquestion", "--project", ".",
+         "--text", "late question", "--from-claim", "c1"),
+        ("deepresearch", "resolve-question", "--project", ".",
+         "--question-id", "q1", "--answer", "late answer", "--evidence-claims", "c1"),
+        ("deepresearch", "resolve-contradiction", "--project", ".",
+         "--contradiction-id", "x1", "--sides-with", "c1", "--rationale", "late"),
+    ]
+    for args in mutations:
+        result = _run_cli(*args, cwd=tmp_path)
+        data = json.loads(result.stdout)
+        assert data["ok"] is False, args
+        assert "closed" in data["error"], args
+    state = json.loads(
+        (tmp_path / ".loopx" / "deepresearch" / "research.json").read_text(encoding="utf-8")
+    )
+    assert state["status"] == "closed"
+    assert len(state["sources"]) == 1
+    assert len(state["claims"]) == 2
+    assert state["questions"][0]["status"] == "open"
+
+
+def test_report_generation_is_serialized_with_run_rotation(tmp_path: Path) -> None:
+    # Reviewer barrier probe: a report that read the previous run must never
+    # land next to the next run's state file. Report and close/start rotation
+    # share one lifecycle lock, so the paused-report interleaving resolves by
+    # serialization, not by luck.
+    import threading
+
+    from loopx import deepresearch
+    from loopx.deepresearch import start_research, write_report
+
+    _start(tmp_path, question="old question")
+    # Make the old run stopped so the interleaved start (--new-run) can rotate
+    # it once the report releases the lifecycle lock.
+    _payload(
+        _run_cli(
+            "deepresearch",
+            "add-source",
+            "--project",
+            ".",
+            "--url-or-path",
+            "docs/old.md",
+            "--tool",
+            "local_read",
+            "--claims-json",
+            json.dumps([{"text": "old claim", "stance": "supports"}]),
+            cwd=tmp_path,
+        )
+    )
+    _payload(
+        _run_cli(
+            "deepresearch",
+            "resolve-question",
+            "--project",
+            ".",
+            "--question-id",
+            "q1",
+            "--answer",
+            "Old answer.",
+            "--evidence-claims",
+            "c1",
+            cwd=tmp_path,
+        )
+    )
+
+    render_entered = threading.Event()
+    release_render = threading.Event()
+    original_render = deepresearch.render_report
+
+    def paused_render(state: dict) -> str:
+        if state["question"] == "old question":
+            render_entered.set()
+            assert release_render.wait(timeout=10)
+        return original_render(state)
+
+    deepresearch.render_report = paused_render
+    try:
+        report_done: list[dict] = []
+
+        def run_report() -> None:
+            report_done.append(write_report(tmp_path))
+
+        thread = threading.Thread(target=run_report)
+        thread.start()
+        assert render_entered.wait(timeout=10)
+
+        # While the paused report holds the lifecycle lock, rotation must wait.
+        start_done: list[dict] = []
+
+        def run_start() -> None:
+            start_done.append(
+                start_research(
+                    tmp_path,
+                    question="new question",
+                    max_sources=12,
+                    max_subquestions=8,
+                    new_run=True,
+                )
+            )
+
+        starter = threading.Thread(target=run_start)
+        starter.start()
+        starter.join(timeout=1.5)
+        assert not start_done, "rotation completed while the report held the lifecycle lock"
+
+        release_render.set()
+        thread.join(timeout=10)
+        starter.join(timeout=10)
+        assert report_done and start_done
+    finally:
+        deepresearch.render_report = original_render
+
+    root_state = json.loads(
+        (tmp_path / ".loopx" / "deepresearch" / "research.json").read_text(encoding="utf-8")
+    )
+    assert root_state["question"] == "new question"
+    # The serialized outcome: the paused report — rendered from the old run —
+    # travelled WITH the old run into the archive. The root never shows a
+    # report from a different run than its state (here: no report at all
+    # until the new run generates one).
+    root_report = tmp_path / ".loopx" / "deepresearch" / "report.md"
+    if root_report.exists():
+        assert "new question" in root_report.read_text(encoding="utf-8")
+        assert "old question" not in root_report.read_text(encoding="utf-8")
+    archive_dirs = list((tmp_path / ".loopx" / "deepresearch" / "archive").iterdir())
+    assert len(archive_dirs) == 1
+    archived_report = (archive_dirs[0] / "report.md").read_text(encoding="utf-8")
+    assert "old question" in archived_report
+
+
 def test_skill_facade_installs_for_skill_facade_surfaces(tmp_path: Path) -> None:
     from loopx.slash_command_install import install_slash_commands
 

--- a/tests/test_deepresearch_command.py
+++ b/tests/test_deepresearch_command.py
@@ -1,0 +1,521 @@
+"""Host contract for the /loopx-deepresearch command.
+
+Deep research drifts exactly the way long-horizon coding work does: the
+question blurs, "I read it somewhere" replaces evidence, and nothing says when
+to stop. These tests pin the three guards the command exists to enforce: claims
+must come from recorded sources, answers must cite recorded claims, and the
+stop decision belongs to the packet, not the model's mood.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run_cli(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "--format", "json", *args],
+        cwd=cwd,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _payload(result: subprocess.CompletedProcess[str]) -> dict:
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert data["ok"] is True, data.get("error")
+    return data
+
+
+def _start(tmp_path: Path, *, question: str = "How does loopx gate agent loops?") -> None:
+    result = _run_cli(
+        "deepresearch", "start", "--project", ".", "--question", question, cwd=tmp_path
+    )
+    assert _payload(result)["packet"]["next_expedition"]["question_id"] == "q1"
+
+
+def test_full_round_trip_resolves_question_and_writes_report(tmp_path: Path) -> None:
+    _start(tmp_path)
+    added = _payload(
+        _run_cli(
+            "deepresearch",
+            "add-source",
+            "--project",
+            ".",
+            "--url-or-path",
+            "docs/quota.md",
+            "--tool",
+            "local_read",
+            "--claims-json",
+            json.dumps(
+                [
+                    {"text": "every continuation enters through quota should-run", "stance": "supports"},
+                ]
+            ),
+            cwd=tmp_path,
+        )
+    )
+    assert added["source_id"] == "s1"
+    assert added["claim_ids"] == ["c1"]
+
+    resolved = _payload(
+        _run_cli(
+            "deepresearch",
+            "resolve-question",
+            "--project",
+            ".",
+            "--question-id",
+            "q1",
+            "--answer",
+            "Every agent-loop continuation is admitted by quota should-run.",
+            "--evidence-claims",
+            "c1",
+            cwd=tmp_path,
+        )
+    )
+    stop = resolved["packet"]["stop_conditions"]
+    assert stop["stopped"] is True
+    assert "all questions answered" in stop["reasons"]
+
+    report = _payload(_run_cli("deepresearch", "report", "--project", ".", cwd=tmp_path))
+    report_path = Path(report["report_path"])
+    assert report_path.is_file()
+    content = report_path.read_text(encoding="utf-8")
+    assert "docs/quota.md" in content
+    assert "`c1`" in content
+
+
+def test_status_without_state_reports_exact_gate(tmp_path: Path) -> None:
+    result = _run_cli("deepresearch", "status", "--project", ".", cwd=tmp_path)
+    data = json.loads(result.stdout)
+    assert data["ok"] is False
+    assert "deepresearch start" in data["error"]
+
+
+def test_duplicate_source_is_rejected_so_claims_are_reused(tmp_path: Path) -> None:
+    _start(tmp_path)
+    args = (
+        "deepresearch",
+        "add-source",
+        "--project",
+        ".",
+        "--url-or-path",
+        "https://example.com/a/",
+        "--tool",
+        "web_fetch",
+    )
+    _payload(_run_cli(*args, "--claims-json", "[]", cwd=tmp_path))
+    duplicate = _run_cli(*args, "--claims-json", "[]", cwd=tmp_path)
+    data = json.loads(duplicate.stdout)
+    assert data["ok"] is False
+    assert "already recorded as s1" in data["error"]
+
+
+def test_answers_without_ledger_evidence_are_rejected(tmp_path: Path) -> None:
+    _start(tmp_path)
+    result = _run_cli(
+        "deepresearch",
+        "resolve-question",
+        "--project",
+        ".",
+        "--question-id",
+        "q1",
+        "--answer",
+        "I remember reading something once.",
+        "--evidence-claims",
+        "c99",
+        cwd=tmp_path,
+    )
+    data = json.loads(result.stdout)
+    assert data["ok"] is False
+    assert "not recorded" in data["error"]
+
+
+def test_subquestions_must_derive_from_recorded_claims(tmp_path: Path) -> None:
+    _start(tmp_path)
+    free_roam = _run_cli(
+        "deepresearch",
+        "add-subquestion",
+        "--project",
+        ".",
+        "--text",
+        "something unrelated I got curious about",
+        "--priority",
+        "P1",
+        "--from-claim",
+        "c7",
+        cwd=tmp_path,
+    )
+    assert "not a recorded claim" in json.loads(free_roam.stdout)["error"]
+
+    # Omitting --from-claim must fail too: the argparse layer must not offer a
+    # lineage bypass the domain layer rejects.
+    omitted = _run_cli(
+        "deepresearch",
+        "add-subquestion",
+        "--project",
+        ".",
+        "--text",
+        "no lineage provided",
+        "--priority",
+        "P1",
+        cwd=tmp_path,
+    )
+    assert omitted.returncode != 0
+
+    _payload(
+        _run_cli(
+            "deepresearch",
+            "add-source",
+            "--project",
+            ".",
+            "--url-or-path",
+            "docs/skills.md",
+            "--tool",
+            "local_read",
+            "--claims-json",
+            json.dumps([{"text": "skills are discovered from host roots", "stance": "neutral"}]),
+            cwd=tmp_path,
+        )
+    )
+    derived = _payload(
+        _run_cli(
+            "deepresearch",
+            "add-subquestion",
+            "--project",
+            ".",
+            "--text",
+            "which roots exist per host?",
+            "--priority",
+            "P1",
+            "--from-claim",
+            "c1",
+            cwd=tmp_path,
+        )
+    )
+    assert derived["question_id"] == "q2"
+
+    # Python callers must hit the same wall, not just argparse users.
+    from loopx.deepresearch import add_subquestion as domain_add_subquestion
+
+    try:
+        domain_add_subquestion(tmp_path, text="bypass attempt", priority="P1", from_claim=None)
+    except ValueError as error:
+        assert "from_claim is required" in str(error)
+    else:
+        raise AssertionError("domain layer accepted a subquestion without lineage")
+
+
+def test_contradiction_blocks_resolution_until_sides_with_rationale(tmp_path: Path) -> None:
+    _start(tmp_path)
+    _payload(
+        _run_cli(
+            "deepresearch",
+            "add-source",
+            "--project",
+            ".",
+            "--url-or-path",
+            "https://a.example/x",
+            "--tool",
+            "web_fetch",
+            "--claims-json",
+            json.dumps([{"text": "gate runs per turn", "stance": "supports"}]),
+            cwd=tmp_path,
+        )
+    )
+    _payload(
+        _run_cli(
+            "deepresearch",
+            "add-source",
+            "--project",
+            ".",
+            "--url-or-path",
+            "https://b.example/y",
+            "--tool",
+            "web_fetch",
+            "--claims-json",
+            json.dumps(
+                [
+                    {
+                        "text": "gate runs per hour only",
+                        "stance": "contradicts",
+                        "relates_claim": "c1",
+                    }
+                ]
+            ),
+            cwd=tmp_path,
+        )
+    )
+    status = _payload(_run_cli("deepresearch", "status", "--project", ".", cwd=tmp_path))
+    assert status["packet"]["ledger_summary"]["open_contradictions"] == 1
+
+    blocked = _run_cli(
+        "deepresearch",
+        "resolve-question",
+        "--project",
+        ".",
+        "--question-id",
+        "q1",
+        "--answer",
+        "something",
+        "--evidence-claims",
+        "c1",
+        "c2",
+        cwd=tmp_path,
+    )
+    assert "open contradiction x1" in json.loads(blocked.stdout)["error"]
+
+    resolved = _payload(
+        _run_cli(
+            "deepresearch",
+            "resolve-question",
+            "--project",
+            ".",
+            "--question-id",
+            "q1",
+            "--answer",
+            "The gate runs per turn; the hourly source described a different cadence.",
+            "--evidence-claims",
+            "c1",
+            "c2",
+            "--contradiction-resolution",
+            "contradiction-id=x1 sides-with=c1 rationale='primary source shows per-turn admission'",
+            cwd=tmp_path,
+        )
+    )
+    assert resolved["packet"]["ledger_summary"]["open_contradictions"] == 0
+
+
+def test_coverage_stop_when_recent_sources_add_no_claims(tmp_path: Path) -> None:
+    _start(tmp_path)
+    for n in range(3):
+        _payload(
+            _run_cli(
+                "deepresearch",
+                "add-source",
+                "--project",
+                ".",
+                "--url-or-path",
+                f"https://empty.example/{n}",
+                "--tool",
+                "web_fetch",
+                "--claims-json",
+                "[]",
+                cwd=tmp_path,
+            )
+        )
+    status = _payload(_run_cli("deepresearch", "status", "--project", ".", cwd=tmp_path))
+    stop = status["packet"]["stop_conditions"]
+    assert stop["stopped"] is True
+    assert any("coverage stop" in reason for reason in stop["reasons"])
+    assert status["packet"]["next_expedition"] is None
+
+
+def test_open_contradiction_blocks_completion_until_resolved(tmp_path: Path) -> None:
+    # Reviewer repro: c1, a claim contradicting it (c2), then an unrelated c3;
+    # resolving q1 with c3 only must NOT let the packet claim completion.
+    _start(tmp_path)
+    _payload(
+        _run_cli(
+            "deepresearch",
+            "add-source",
+            "--project",
+            ".",
+            "--url-or-path",
+            "https://a.example/x",
+            "--tool",
+            "web_fetch",
+            "--claims-json",
+            json.dumps([{"text": "gate runs per turn", "stance": "supports"}]),
+            cwd=tmp_path,
+        )
+    )
+    _payload(
+        _run_cli(
+            "deepresearch",
+            "add-source",
+            "--project",
+            ".",
+            "--url-or-path",
+            "https://b.example/y",
+            "--tool",
+            "web_fetch",
+            "--claims-json",
+            json.dumps(
+                [
+                    {
+                        "text": "gate runs per hour only",
+                        "stance": "contradicts",
+                        "relates_claim": "c1",
+                    }
+                ]
+            ),
+            cwd=tmp_path,
+        )
+    )
+    _payload(
+        _run_cli(
+            "deepresearch",
+            "add-source",
+            "--project",
+            ".",
+            "--url-or-path",
+            "https://c.example/z",
+            "--tool",
+            "web_fetch",
+            "--claims-json",
+            json.dumps([{"text": "unrelated detail", "stance": "neutral"}]),
+            cwd=tmp_path,
+        )
+    )
+    _payload(
+        _run_cli(
+            "deepresearch",
+            "resolve-question",
+            "--project",
+            ".",
+            "--question-id",
+            "q1",
+            "--answer",
+            "Something answered on unrelated evidence.",
+            "--evidence-claims",
+            "c3",
+            cwd=tmp_path,
+        )
+    )
+    status = _payload(_run_cli("deepresearch", "status", "--project", ".", cwd=tmp_path))
+    stop = status["packet"]["stop_conditions"]
+    assert stop["stopped"] is False
+    assert any("open contradiction" in reason for reason in stop["reasons"])
+    expedition = status["packet"]["next_expedition"]
+    assert expedition is not None
+    assert expedition["kind"] == "contradiction_resolution"
+
+    resolved = _payload(
+        _run_cli(
+            "deepresearch",
+            "resolve-contradiction",
+            "--project",
+            ".",
+            "--contradiction-id",
+            "x1",
+            "--sides-with",
+            "c1",
+            "--rationale",
+            "primary source shows per-turn admission",
+            cwd=tmp_path,
+        )
+    )
+    assert resolved["packet"]["stop_conditions"]["stopped"] is True
+
+
+def test_self_contradiction_is_rejected(tmp_path: Path) -> None:
+    _start(tmp_path)
+    result = _run_cli(
+        "deepresearch",
+        "add-source",
+        "--project",
+        ".",
+        "--url-or-path",
+        "https://self.example/a",
+        "--tool",
+        "web_fetch",
+        "--claims-json",
+        json.dumps(
+            [{"text": "claims contradiction with itself", "stance": "contradicts", "relates_claim": "c1"}]
+        ),
+        cwd=tmp_path,
+    )
+    data = json.loads(result.stdout)
+    assert data["ok"] is False
+    assert "not a recorded claim" in data["error"]
+
+
+def test_invalid_batch_persists_nothing(tmp_path: Path) -> None:
+    _start(tmp_path)
+    result = _run_cli(
+        "deepresearch",
+        "add-source",
+        "--project",
+        ".",
+        "--url-or-path",
+        "https://partial.example/a",
+        "--tool",
+        "web_fetch",
+        "--claims-json",
+        json.dumps(
+            [
+                {"text": "valid claim first", "stance": "supports"},
+                {"text": "invalid stance second", "stance": "sideways"},
+            ]
+        ),
+        cwd=tmp_path,
+    )
+    assert json.loads(result.stdout)["ok"] is False
+    state = json.loads(
+        (tmp_path / ".loopx" / "deepresearch" / "research.json").read_text(encoding="utf-8")
+    )
+    assert state["sources"] == []
+    assert state["claims"] == []
+
+
+def test_concurrent_add_source_keeps_every_update(tmp_path: Path) -> None:
+    # The reviewer's probe: unlocked read-modify-write lost 17/20 concurrent
+    # updates. Under the project lock every source must survive.
+    _start(tmp_path, question="concurrency contract")
+    processes = [
+        subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "--format",
+                "json",
+                "deepresearch",
+                "add-source",
+                "--project",
+                ".",
+                "--url-or-path",
+                f"https://race.example/{index}",
+                "--tool",
+                "web_fetch",
+                "--claims-json",
+                json.dumps([{"text": f"claim {index}", "stance": "neutral"}]),
+            ],
+            cwd=tmp_path,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        for index in range(8)
+    ]
+    outputs = [process.communicate()[0] for process in processes]
+    for process, output in zip(processes, outputs):
+        assert process.returncode == 0, output
+        assert json.loads(output)["ok"] is True
+    state = json.loads(
+        (tmp_path / ".loopx" / "deepresearch" / "research.json").read_text(encoding="utf-8")
+    )
+    assert len(state["sources"]) == 8
+    assert len(state["claims"]) == 8
+
+
+def test_skill_facade_installs_for_skill_facade_surfaces(tmp_path: Path) -> None:
+    from loopx.slash_command_install import install_slash_commands
+
+    # The facade spec is host-generic: every skill-facade surface (gemini,
+    # cursor, and agy once its surface PR merges) installs it from the same
+    # specs list, so proving one surface proves the wiring.
+    home = tmp_path / "gemini-home"
+    payload = install_slash_commands(execute=True, surfaces=["gemini"], gemini_home=str(home))
+    assert payload["ok"] is True
+    skill = home / "skills" / "loopx-deepresearch" / "SKILL.md"
+    assert skill.is_file()
+    body = skill.read_text(encoding="utf-8")
+    assert "deepresearch status" in body
+    assert "never fabricate URLs" in body

--- a/tests/test_deepresearch_command.py
+++ b/tests/test_deepresearch_command.py
@@ -505,6 +505,161 @@ def test_concurrent_add_source_keeps_every_update(tmp_path: Path) -> None:
     assert len(state["claims"]) == 8
 
 
+def test_second_run_lifecycle_close_then_start(tmp_path: Path) -> None:
+    # Reviewer repro: after one completed run, a second start used to demand
+    # deleting internal state files by hand. The typed lifecycle must keep the
+    # capability runnable per project forever.
+    _start(tmp_path, question="first question")
+    _payload(
+        _run_cli(
+            "deepresearch",
+            "add-source",
+            "--project",
+            ".",
+            "--url-or-path",
+            "docs/one.md",
+            "--tool",
+            "local_read",
+            "--claims-json",
+            json.dumps([{"text": "first claim", "stance": "supports"}]),
+            cwd=tmp_path,
+        )
+    )
+    _payload(
+        _run_cli(
+            "deepresearch",
+            "resolve-question",
+            "--project",
+            ".",
+            "--question-id",
+            "q1",
+            "--answer",
+            "First answer.",
+            "--evidence-claims",
+            "c1",
+            cwd=tmp_path,
+        )
+    )
+    _payload(_run_cli("deepresearch", "report", "--project", ".", cwd=tmp_path))
+    state_file = tmp_path / ".loopx" / "deepresearch" / "research.json"
+    assert state_file.is_file()
+
+    # While stopped-but-open, a plain start is refused with a typed pointer…
+    blocked = _run_cli(
+        "deepresearch", "start", "--project", ".", "--question", "second question", cwd=tmp_path
+    )
+    blocked_data = json.loads(blocked.stdout)
+    assert blocked_data["ok"] is False
+    assert "deepresearch close" in blocked_data["error"]
+
+    # …while an ACTIVE run points at closing first, not at deleting files.
+    second = _run_cli(
+        "deepresearch",
+        "start",
+        "--project",
+        ".",
+        "--question",
+        "second question",
+        "--new-run",
+        cwd=tmp_path,
+    )
+    assert json.loads(second.stdout)["ok"] is True
+    fresh = json.loads(state_file.read_text(encoding="utf-8"))
+    assert fresh["question"] == "second question"
+    assert fresh["status"] == "active"
+    archive_dirs = list((tmp_path / ".loopx" / "deepresearch" / "archive").iterdir())
+    assert len(archive_dirs) == 1
+    assert (archive_dirs[0] / "research.json").is_file()
+    assert (archive_dirs[0] / "report.md").is_file()
+
+    # An active (not stopped) run requires an explicit close.
+    active = _run_cli(
+        "deepresearch",
+        "start",
+        "--project",
+        ".",
+        "--question",
+        "third question",
+        "--new-run",
+        cwd=tmp_path,
+    )
+    active_data = json.loads(active.stdout)
+    assert active_data["ok"] is False
+    assert "active research run exists" in active_data["error"]
+
+    closed = _payload(
+        _run_cli(
+            "deepresearch", "close", "--project", ".", "--note", "moving on", cwd=tmp_path
+        )
+    )
+    assert closed["run_status"] == "closed"
+    restart = _payload(
+        _run_cli(
+            "deepresearch",
+            "start",
+            "--project",
+            ".",
+            "--question",
+            "third question",
+            cwd=tmp_path,
+        )
+    )
+    assert restart["packet"]["run_status"] == "active"
+    assert len(list((tmp_path / ".loopx" / "deepresearch" / "archive").iterdir())) == 2
+
+
+def test_lock_contention_returns_typed_json_not_traceback(tmp_path: Path) -> None:
+    # Reviewer probe: holding the state lock made the CLI print a traceback
+    # under --format json. The JSON contract must survive lock timeouts.
+    from loopx.deepresearch import state_path
+    from loopx.file_lock import exclusive_file_lock
+
+    _start(tmp_path)
+    with exclusive_file_lock(state_path(tmp_path)):
+        result = _run_cli(
+            "deepresearch",
+            "status",
+            "--project",
+            ".",
+            cwd=tmp_path,
+        )
+        contended = _run_cli(
+            "deepresearch",
+            "add-source",
+            "--project",
+            ".",
+            "--url-or-path",
+            "https://locked.example/a",
+            "--tool",
+            "web_fetch",
+            "--claims-json",
+            "[]",
+            cwd=tmp_path,
+        )
+    # status is a read-only path and stays usable; the mutation hits the lock.
+    assert json.loads(result.stdout)["ok"] is True
+    data = json.loads(contended.stdout)
+    assert data["ok"] is False
+    assert data["error_code"] == "lock_acquire_timeout"
+    assert "Traceback" not in contended.stdout
+    assert "Traceback" not in contended.stderr
+
+
+def test_deep_research_is_a_registered_capability() -> None:
+    from loopx.capabilities.catalog import BUILTIN_CAPABILITIES
+
+    entry = next(
+        (item for item in BUILTIN_CAPABILITIES if item["id"] == "deep-research"), None
+    )
+    assert entry is not None
+    assert entry["entry_command"] == "loopx deepresearch start --question <text>"
+    boundaries = " ".join(entry["boundaries"])
+    # The ownership question the reviewer asked must be answered in the catalog
+    # itself: how this capability differs from auto-research.
+    assert "auto-research" in boundaries
+    assert entry["next_real_step"]
+
+
 def test_skill_facade_installs_for_skill_facade_surfaces(tmp_path: Path) -> None:
     from loopx.slash_command_install import install_slash_commands
 

--- a/tests/test_deepresearch_command.py
+++ b/tests/test_deepresearch_command.py
@@ -283,7 +283,7 @@ def test_contradiction_blocks_resolution_until_sides_with_rationale(tmp_path: Pa
     assert status["packet"]["ledger_summary"]["open_contradictions"] == 1
 
     blocked = _resolve_question(
-        tmp_path, question_id="q1", answer="something", evidence=["c1", "c2"]
+        tmp_path, question_id="q1", answer="something", evidence=["c1"]
     )
     assert "open contradiction x1" in json.loads(blocked.stdout)["error"]
 
@@ -292,13 +292,70 @@ def test_contradiction_blocks_resolution_until_sides_with_rationale(tmp_path: Pa
             tmp_path,
             question_id="q1",
             answer="The gate runs per turn; the hourly source described a different cadence.",
-            evidence=["c1", "c2"],
+            evidence=["c1"],
             resolutions=[
                 "contradiction-id=x1 sides-with=c1 rationale='primary source shows per-turn admission'"
             ],
         )
     )
     assert resolved["packet"]["ledger_summary"]["open_contradictions"] == 0
+
+
+def test_in_call_resolution_rejects_citing_both_sides_of_contradiction(tmp_path: Path) -> None:
+    # Reviewer probe (r6): resolving q1 with evidence citing both c1 and c2
+    # while adjudicating sides-with=c1 must be rejected before state mutation.
+    _start(tmp_path)
+    _seed_contradiction(tmp_path)
+    result = _resolve_question(
+        tmp_path,
+        question_id="q1",
+        answer="The gate runs per turn.",
+        evidence=["c1", "c2"],
+        resolutions=[
+            "contradiction-id=x1 sides-with=c1 rationale='primary source shows per-turn admission'"
+        ],
+    )
+    data = json.loads(result.stdout)
+    assert data["ok"] is False
+    assert "resolved against c2" in data["error"]
+    state = json.loads(
+        (tmp_path / ".loopx" / "deepresearch" / "research.json").read_text(encoding="utf-8")
+    )
+    assert state["questions"][0]["status"] == "open"
+    assert state["contradictions"][0]["status"] == "open"
+
+
+def test_pre_resolved_contradiction_rejects_citing_both_sides(tmp_path: Path) -> None:
+    _start(tmp_path)
+    _seed_contradiction(tmp_path)
+    _payload(
+        _run_cli(
+            "deepresearch",
+            "resolve-contradiction",
+            "--project",
+            ".",
+            "--contradiction-id",
+            "x1",
+            "--sides-with",
+            "c1",
+            "--rationale",
+            "primary source is authoritative",
+            cwd=tmp_path,
+        )
+    )
+    result = _resolve_question(
+        tmp_path,
+        question_id="q1",
+        answer="Per turn.",
+        evidence=["c1", "c2"],
+    )
+    data = json.loads(result.stdout)
+    assert data["ok"] is False
+    assert "resolved against c2" in data["error"]
+    state = json.loads(
+        (tmp_path / ".loopx" / "deepresearch" / "research.json").read_text(encoding="utf-8")
+    )
+    assert state["questions"][0]["status"] == "open"
 
 
 def test_coverage_stop_when_recent_sources_add_no_claims(tmp_path: Path) -> None:

--- a/tests/test_deepresearch_command.py
+++ b/tests/test_deepresearch_command.py
@@ -39,6 +39,69 @@ def _start(tmp_path: Path, *, question: str = "How does loopx gate agent loops?"
     assert _payload(result)["packet"]["next_expedition"]["question_id"] == "q1"
 
 
+def _add_source(
+    tmp_path: Path, ref: str, claims: list[dict], *, tool: str = "web_fetch"
+) -> dict:
+    return _payload(
+        _run_cli(
+            "deepresearch",
+            "add-source",
+            "--project",
+            ".",
+            "--url-or-path",
+            ref,
+            "--tool",
+            tool,
+            "--claims-json",
+            json.dumps(claims),
+            cwd=tmp_path,
+        )
+    )
+
+
+def _seed_contradiction(tmp_path: Path) -> None:
+    """c1 (supports) then c2 (contradicts c1) — leaves open contradiction x1."""
+    _add_source(
+        tmp_path, "https://a.example/x", [{"text": "gate runs per turn", "stance": "supports"}]
+    )
+    _add_source(
+        tmp_path,
+        "https://b.example/y",
+        [
+            {
+                "text": "gate runs per hour only",
+                "stance": "contradicts",
+                "relates_claim": "c1",
+            }
+        ],
+    )
+
+
+def _resolve_question(
+    tmp_path: Path,
+    *,
+    question_id: str,
+    answer: str,
+    evidence: list[str],
+    resolutions: list[str] | None = None,
+):
+    args = [
+        "deepresearch",
+        "resolve-question",
+        "--project",
+        ".",
+        "--question-id",
+        question_id,
+        "--answer",
+        answer,
+        "--evidence-claims",
+        *evidence,
+    ]
+    for resolution in resolutions or []:
+        args += ["--contradiction-resolution", resolution]
+    return _run_cli(*args, cwd=tmp_path)
+
+
 def test_full_round_trip_resolves_question_and_writes_report(tmp_path: Path) -> None:
     _start(tmp_path)
     added = _payload(
@@ -215,79 +278,24 @@ def test_subquestions_must_derive_from_recorded_claims(tmp_path: Path) -> None:
 
 def test_contradiction_blocks_resolution_until_sides_with_rationale(tmp_path: Path) -> None:
     _start(tmp_path)
-    _payload(
-        _run_cli(
-            "deepresearch",
-            "add-source",
-            "--project",
-            ".",
-            "--url-or-path",
-            "https://a.example/x",
-            "--tool",
-            "web_fetch",
-            "--claims-json",
-            json.dumps([{"text": "gate runs per turn", "stance": "supports"}]),
-            cwd=tmp_path,
-        )
-    )
-    _payload(
-        _run_cli(
-            "deepresearch",
-            "add-source",
-            "--project",
-            ".",
-            "--url-or-path",
-            "https://b.example/y",
-            "--tool",
-            "web_fetch",
-            "--claims-json",
-            json.dumps(
-                [
-                    {
-                        "text": "gate runs per hour only",
-                        "stance": "contradicts",
-                        "relates_claim": "c1",
-                    }
-                ]
-            ),
-            cwd=tmp_path,
-        )
-    )
+    _seed_contradiction(tmp_path)
     status = _payload(_run_cli("deepresearch", "status", "--project", ".", cwd=tmp_path))
     assert status["packet"]["ledger_summary"]["open_contradictions"] == 1
 
-    blocked = _run_cli(
-        "deepresearch",
-        "resolve-question",
-        "--project",
-        ".",
-        "--question-id",
-        "q1",
-        "--answer",
-        "something",
-        "--evidence-claims",
-        "c1",
-        "c2",
-        cwd=tmp_path,
+    blocked = _resolve_question(
+        tmp_path, question_id="q1", answer="something", evidence=["c1", "c2"]
     )
     assert "open contradiction x1" in json.loads(blocked.stdout)["error"]
 
     resolved = _payload(
-        _run_cli(
-            "deepresearch",
-            "resolve-question",
-            "--project",
-            ".",
-            "--question-id",
-            "q1",
-            "--answer",
-            "The gate runs per turn; the hourly source described a different cadence.",
-            "--evidence-claims",
-            "c1",
-            "c2",
-            "--contradiction-resolution",
-            "contradiction-id=x1 sides-with=c1 rationale='primary source shows per-turn admission'",
-            cwd=tmp_path,
+        _resolve_question(
+            tmp_path,
+            question_id="q1",
+            answer="The gate runs per turn; the hourly source described a different cadence.",
+            evidence=["c1", "c2"],
+            resolutions=[
+                "contradiction-id=x1 sides-with=c1 rationale='primary source shows per-turn admission'"
+            ],
         )
     )
     assert resolved["packet"]["ledger_summary"]["open_contradictions"] == 0
@@ -322,72 +330,16 @@ def test_open_contradiction_blocks_completion_until_resolved(tmp_path: Path) -> 
     # Reviewer repro: c1, a claim contradicting it (c2), then an unrelated c3;
     # resolving q1 with c3 only must NOT let the packet claim completion.
     _start(tmp_path)
-    _payload(
-        _run_cli(
-            "deepresearch",
-            "add-source",
-            "--project",
-            ".",
-            "--url-or-path",
-            "https://a.example/x",
-            "--tool",
-            "web_fetch",
-            "--claims-json",
-            json.dumps([{"text": "gate runs per turn", "stance": "supports"}]),
-            cwd=tmp_path,
-        )
+    _seed_contradiction(tmp_path)
+    _add_source(
+        tmp_path, "https://c.example/z", [{"text": "unrelated detail", "stance": "neutral"}]
     )
     _payload(
-        _run_cli(
-            "deepresearch",
-            "add-source",
-            "--project",
-            ".",
-            "--url-or-path",
-            "https://b.example/y",
-            "--tool",
-            "web_fetch",
-            "--claims-json",
-            json.dumps(
-                [
-                    {
-                        "text": "gate runs per hour only",
-                        "stance": "contradicts",
-                        "relates_claim": "c1",
-                    }
-                ]
-            ),
-            cwd=tmp_path,
-        )
-    )
-    _payload(
-        _run_cli(
-            "deepresearch",
-            "add-source",
-            "--project",
-            ".",
-            "--url-or-path",
-            "https://c.example/z",
-            "--tool",
-            "web_fetch",
-            "--claims-json",
-            json.dumps([{"text": "unrelated detail", "stance": "neutral"}]),
-            cwd=tmp_path,
-        )
-    )
-    _payload(
-        _run_cli(
-            "deepresearch",
-            "resolve-question",
-            "--project",
-            ".",
-            "--question-id",
-            "q1",
-            "--answer",
-            "Something answered on unrelated evidence.",
-            "--evidence-claims",
-            "c3",
-            cwd=tmp_path,
+        _resolve_question(
+            tmp_path,
+            question_id="q1",
+            answer="Something answered on unrelated evidence.",
+            evidence=["c3"],
         )
     )
     status = _payload(_run_cli("deepresearch", "status", "--project", ".", cwd=tmp_path))
@@ -422,58 +374,13 @@ def test_resolution_cannot_side_with_claim_outside_answer_evidence(tmp_path: Pat
     # report could back the answer with the side the same transition ruled
     # against. The adjudicated side must be part of the answer's evidence.
     _start(tmp_path)
-    _payload(
-        _run_cli(
-            "deepresearch",
-            "add-source",
-            "--project",
-            ".",
-            "--url-or-path",
-            "https://a.example/x",
-            "--tool",
-            "web_fetch",
-            "--claims-json",
-            json.dumps([{"text": "gate runs per turn", "stance": "supports"}]),
-            cwd=tmp_path,
-        )
-    )
-    _payload(
-        _run_cli(
-            "deepresearch",
-            "add-source",
-            "--project",
-            ".",
-            "--url-or-path",
-            "https://b.example/y",
-            "--tool",
-            "web_fetch",
-            "--claims-json",
-            json.dumps(
-                [
-                    {
-                        "text": "gate runs per hour only",
-                        "stance": "contradicts",
-                        "relates_claim": "c1",
-                    }
-                ]
-            ),
-            cwd=tmp_path,
-        )
-    )
-    result = _run_cli(
-        "deepresearch",
-        "resolve-question",
-        "--project",
-        ".",
-        "--question-id",
-        "q1",
-        "--answer",
-        "Per hour.",
-        "--evidence-claims",
-        "c1",
-        "--contradiction-resolution",
-        "contradiction-id=x1 sides-with=c2 rationale='hourly source is primary'",
-        cwd=tmp_path,
+    _seed_contradiction(tmp_path)
+    result = _resolve_question(
+        tmp_path,
+        question_id="q1",
+        answer="Per hour.",
+        evidence=["c1"],
+        resolutions=["contradiction-id=x1 sides-with=c2 rationale='hourly source is primary'"],
     )
     data = json.loads(result.stdout)
     assert data["ok"] is False
@@ -488,44 +395,7 @@ def test_pre_resolved_contradiction_rejects_overruled_evidence(tmp_path: Path) -
     # Same hole through two calls: adjudicate x1 standalone (sides-with c2),
     # then answer citing only the overruled c1.
     _start(tmp_path)
-    _payload(
-        _run_cli(
-            "deepresearch",
-            "add-source",
-            "--project",
-            ".",
-            "--url-or-path",
-            "https://a.example/x",
-            "--tool",
-            "web_fetch",
-            "--claims-json",
-            json.dumps([{"text": "gate runs per turn", "stance": "supports"}]),
-            cwd=tmp_path,
-        )
-    )
-    _payload(
-        _run_cli(
-            "deepresearch",
-            "add-source",
-            "--project",
-            ".",
-            "--url-or-path",
-            "https://b.example/y",
-            "--tool",
-            "web_fetch",
-            "--claims-json",
-            json.dumps(
-                [
-                    {
-                        "text": "gate runs per hour only",
-                        "stance": "contradicts",
-                        "relates_claim": "c1",
-                    }
-                ]
-            ),
-            cwd=tmp_path,
-        )
-    )
+    _seed_contradiction(tmp_path)
     _payload(
         _run_cli(
             "deepresearch",
@@ -541,22 +411,121 @@ def test_pre_resolved_contradiction_rejects_overruled_evidence(tmp_path: Path) -
             cwd=tmp_path,
         )
     )
-    result = _run_cli(
-        "deepresearch",
-        "resolve-question",
-        "--project",
-        ".",
-        "--question-id",
-        "q1",
-        "--answer",
-        "Per turn.",
-        "--evidence-claims",
-        "c1",
-        cwd=tmp_path,
+    result = _resolve_question(
+        tmp_path, question_id="q1", answer="Per turn.", evidence=["c1"]
     )
     data = json.loads(result.stdout)
     assert data["ok"] is False
     assert "resolved against c1" in data["error"]
+
+
+def test_standalone_resolution_cannot_overrule_answered_evidence(tmp_path: Path) -> None:
+    # Reviewer probe (r5): answer q1 citing c1 first, THEN add contradicting
+    # c2 and adjudicate x1 standalone toward c2. That used to succeed and left
+    # the ledger claiming the answer rests on a side it ruled against.
+    _start(tmp_path)
+    _add_source(
+        tmp_path,
+        "https://a.example/x",
+        [{"text": "gate runs per turn", "stance": "supports"}],
+    )
+    _payload(_resolve_question(tmp_path, question_id="q1", answer="Per turn.", evidence=["c1"]))
+    _add_source(
+        tmp_path,
+        "https://b.example/y",
+        [
+            {
+                "text": "gate runs per hour only",
+                "stance": "contradicts",
+                "relates_claim": "c1",
+            }
+        ],
+    )
+
+    overruled = _run_cli(
+        "deepresearch",
+        "resolve-contradiction",
+        "--project",
+        ".",
+        "--contradiction-id",
+        "x1",
+        "--sides-with",
+        "c2",
+        "--rationale",
+        "hourly source is primary",
+        cwd=tmp_path,
+    )
+    data = json.loads(overruled.stdout)
+    assert data["ok"] is False
+    assert "cited as evidence by answered question q1" in data["error"]
+    state = json.loads(
+        (tmp_path / ".loopx" / "deepresearch" / "research.json").read_text(encoding="utf-8")
+    )
+    assert state["contradictions"][0]["status"] == "open"
+
+    # Siding with the cited side stays legal and unblocks completion.
+    consistent = _payload(
+        _run_cli(
+            "deepresearch",
+            "resolve-contradiction",
+            "--project",
+            ".",
+            "--contradiction-id",
+            "x1",
+            "--sides-with",
+            "c1",
+            "--rationale",
+            "primary source shows per-turn admission",
+            cwd=tmp_path,
+        )
+    )
+    assert consistent["packet"]["stop_conditions"]["stopped"] is True
+
+
+def test_in_call_resolution_cannot_overrule_other_answered_question(tmp_path: Path) -> None:
+    # The same invariant on the resolve-question path: adjudicating x1 toward
+    # c2 while answering q2 must not overrule c1 already cited by answered q1.
+    _start(tmp_path)
+    _add_source(
+        tmp_path,
+        "https://a.example/x",
+        [{"text": "gate runs per turn", "stance": "supports"}],
+    )
+    _payload(_resolve_question(tmp_path, question_id="q1", answer="Per turn.", evidence=["c1"]))
+    _add_source(
+        tmp_path,
+        "https://b.example/y",
+        [
+            {
+                "text": "gate runs per hour only",
+                "stance": "contradicts",
+                "relates_claim": "c1",
+            }
+        ],
+    )
+    _payload(
+        _run_cli(
+            "deepresearch",
+            "add-subquestion",
+            "--project",
+            ".",
+            "--text",
+            "Which cadence is correct?",
+            "--from-claim",
+            "c2",
+            cwd=tmp_path,
+        )
+    )
+    result = _resolve_question(
+        tmp_path,
+        question_id="q2",
+        answer="Hourly.",
+        evidence=["c2"],
+        resolutions=["contradiction-id=x1 sides-with=c2 rationale='hourly source is primary'"],
+    )
+    data = json.loads(result.stdout)
+    assert data["ok"] is False
+    assert "cited as evidence by answered question q1" in data["error"]
 
 
 def test_self_contradiction_is_rejected(tmp_path: Path) -> None:

--- a/tests/test_deepresearch_command.py
+++ b/tests/test_deepresearch_command.py
@@ -201,7 +201,9 @@ def test_subquestions_must_derive_from_recorded_claims(tmp_path: Path) -> None:
     assert derived["question_id"] == "q2"
 
     # Python callers must hit the same wall, not just argparse users.
-    from loopx.deepresearch import add_subquestion as domain_add_subquestion
+    from loopx.capabilities.deep_research.runtime import (
+        add_subquestion as domain_add_subquestion,
+    )
 
     try:
         domain_add_subquestion(tmp_path, text="bypass attempt", priority="P1", from_claim=None)
@@ -414,6 +416,149 @@ def test_open_contradiction_blocks_completion_until_resolved(tmp_path: Path) -> 
     assert resolved["packet"]["stop_conditions"]["stopped"] is True
 
 
+def test_resolution_cannot_side_with_claim_outside_answer_evidence(tmp_path: Path) -> None:
+    # Reviewer repro: x1 records c2 contradicting c1; resolving q1 citing only
+    # c1 while adjudicating sides-with=c2 used to succeed, so the citation
+    # report could back the answer with the side the same transition ruled
+    # against. The adjudicated side must be part of the answer's evidence.
+    _start(tmp_path)
+    _payload(
+        _run_cli(
+            "deepresearch",
+            "add-source",
+            "--project",
+            ".",
+            "--url-or-path",
+            "https://a.example/x",
+            "--tool",
+            "web_fetch",
+            "--claims-json",
+            json.dumps([{"text": "gate runs per turn", "stance": "supports"}]),
+            cwd=tmp_path,
+        )
+    )
+    _payload(
+        _run_cli(
+            "deepresearch",
+            "add-source",
+            "--project",
+            ".",
+            "--url-or-path",
+            "https://b.example/y",
+            "--tool",
+            "web_fetch",
+            "--claims-json",
+            json.dumps(
+                [
+                    {
+                        "text": "gate runs per hour only",
+                        "stance": "contradicts",
+                        "relates_claim": "c1",
+                    }
+                ]
+            ),
+            cwd=tmp_path,
+        )
+    )
+    result = _run_cli(
+        "deepresearch",
+        "resolve-question",
+        "--project",
+        ".",
+        "--question-id",
+        "q1",
+        "--answer",
+        "Per hour.",
+        "--evidence-claims",
+        "c1",
+        "--contradiction-resolution",
+        "contradiction-id=x1 sides-with=c2 rationale='hourly source is primary'",
+        cwd=tmp_path,
+    )
+    data = json.loads(result.stdout)
+    assert data["ok"] is False
+    assert "not among this question's evidence claims" in data["error"]
+    state = json.loads(
+        (tmp_path / ".loopx" / "deepresearch" / "research.json").read_text(encoding="utf-8")
+    )
+    assert state["questions"][0]["status"] == "open"
+
+
+def test_pre_resolved_contradiction_rejects_overruled_evidence(tmp_path: Path) -> None:
+    # Same hole through two calls: adjudicate x1 standalone (sides-with c2),
+    # then answer citing only the overruled c1.
+    _start(tmp_path)
+    _payload(
+        _run_cli(
+            "deepresearch",
+            "add-source",
+            "--project",
+            ".",
+            "--url-or-path",
+            "https://a.example/x",
+            "--tool",
+            "web_fetch",
+            "--claims-json",
+            json.dumps([{"text": "gate runs per turn", "stance": "supports"}]),
+            cwd=tmp_path,
+        )
+    )
+    _payload(
+        _run_cli(
+            "deepresearch",
+            "add-source",
+            "--project",
+            ".",
+            "--url-or-path",
+            "https://b.example/y",
+            "--tool",
+            "web_fetch",
+            "--claims-json",
+            json.dumps(
+                [
+                    {
+                        "text": "gate runs per hour only",
+                        "stance": "contradicts",
+                        "relates_claim": "c1",
+                    }
+                ]
+            ),
+            cwd=tmp_path,
+        )
+    )
+    _payload(
+        _run_cli(
+            "deepresearch",
+            "resolve-contradiction",
+            "--project",
+            ".",
+            "--contradiction-id",
+            "x1",
+            "--sides-with",
+            "c2",
+            "--rationale",
+            "hourly source is primary",
+            cwd=tmp_path,
+        )
+    )
+    result = _run_cli(
+        "deepresearch",
+        "resolve-question",
+        "--project",
+        ".",
+        "--question-id",
+        "q1",
+        "--answer",
+        "Per turn.",
+        "--evidence-claims",
+        "c1",
+        cwd=tmp_path,
+    )
+    data = json.loads(result.stdout)
+    assert data["ok"] is False
+    assert "resolved against c1" in data["error"]
+
+
 def test_self_contradiction_is_rejected(tmp_path: Path) -> None:
     _start(tmp_path)
     result = _run_cli(
@@ -611,7 +756,7 @@ def test_second_run_lifecycle_close_then_start(tmp_path: Path) -> None:
 def test_lock_contention_returns_typed_json_not_traceback(tmp_path: Path) -> None:
     # Reviewer probe: holding the state lock made the CLI print a traceback
     # under --format json. The JSON contract must survive lock timeouts.
-    from loopx.deepresearch import state_path
+    from loopx.capabilities.deep_research.runtime import state_path
     from loopx.file_lock import exclusive_file_lock
 
     _start(tmp_path)
@@ -711,6 +856,26 @@ def test_closed_run_rejects_every_ledger_mutation(tmp_path: Path) -> None:
     assert state["questions"][0]["status"] == "open"
 
 
+def test_closed_packet_projects_terminal_guidance_not_expedition(tmp_path: Path) -> None:
+    # Reviewer repro: `start -> early close -> status` used to return
+    # run_status=closed with stop_conditions.stopped=false and a runnable
+    # next_expedition — an instruction the same ledger would reject. The
+    # closed packet must project the terminal state instead.
+    _start(tmp_path)
+    closed = _payload(_run_cli("deepresearch", "close", "--project", ".", cwd=tmp_path))
+    packet = closed["packet"]
+    assert packet["run_status"] == "closed"
+    assert packet["stop_conditions"]["stopped"] is False  # q1 is still open
+    assert packet["next_expedition"] is None
+    guidance = packet["terminal_guidance"]
+    assert guidance["ledger_immutable"] is True
+    assert "deepresearch start" in guidance["next_start"]
+
+    status = _payload(_run_cli("deepresearch", "status", "--project", ".", cwd=tmp_path))
+    assert status["packet"]["next_expedition"] is None
+    assert status["packet"]["terminal_guidance"]["ledger_immutable"] is True
+
+
 def test_report_generation_is_serialized_with_run_rotation(tmp_path: Path) -> None:
     # Reviewer barrier probe: a report that read the previous run must never
     # land next to the next run's state file. Report and close/start rotation
@@ -718,8 +883,8 @@ def test_report_generation_is_serialized_with_run_rotation(tmp_path: Path) -> No
     # serialization, not by luck.
     import threading
 
-    from loopx import deepresearch
-    from loopx.deepresearch import start_research, write_report
+    from loopx.capabilities.deep_research import runtime as deepresearch
+    from loopx.capabilities.deep_research.runtime import start_research, write_report
 
     _start(tmp_path, question="old question")
     # Make the old run stopped so the interleaved start (--new-run) can rotate

--- a/tests/test_windows_install.py
+++ b/tests/test_windows_install.py
@@ -85,6 +85,7 @@ def test_windows_installer_promotes_release_and_runs_doctor(tmp_path: Path) -> N
     expected_skills = {
         "loopx",
         *PACKAGED_HOST_SKILL_IDS,
+        "loopx-deepresearch",
         "loopx-global-summary",
         "loopx-global-gates",
         "loopx-global-todos",


### PR DESCRIPTION
## What

Applies the `/loopx-pr-review` architecture to deep research: the CLI owns the workflow state, the model executes packet-cut bounded expeditions. Deep research drifts exactly the way long-horizon coding work does — the question blurs, "I read it somewhere" replaces evidence, nothing says when to stop — and this command enforces the three guards against it.

## Mechanics

- `loopx/capabilities/deep_research/runtime.py` (capability owner; the CLI in `loopx/cli_commands/deepresearch.py` is a thin adapter): durable state in `.loopx/deepresearch/` — question ledger (subquestions must derive from a recorded claim, no free-roaming), source ledger (URL-deduped, tool-attributed), claim ledger (stance + relations), auto-opened contradiction log that **blocks resolution until an explicit sides-with claim and rationale is recorded**.
- Packet (`deepresearch status`): research contract, ledger summary, `run_status`, `next_expedition` (top open question), `stop_conditions` (all-answered / only-P2-remaining / source budget / **coverage stop** when the last 3 sources contribute no claims), copy-paste evidence commands. A **closed run projects no expedition**: `next_expedition` is `null` and a typed `terminal_guidance` (immutable ledger + next-start command) replaces it — the packet never instructs an action the ledger would reject.
- Subcommands: `start / status / add-source / add-subquestion / resolve-question / resolve-contradiction / close / report`. Answers citing unrecorded claims are rejected; a contradiction resolution must **side with a claim that is part of the answer's `--evidence-claims`** and the **overruled loser cannot be cited** (the citation report can never back an answer with the side the same ledger adjudicated against, whether the adjudication happened in this call or an earlier standalone one).
- Lifecycle: `close` is the explicit terminal transition — after it **every ledger mutation fails closed** (`closed run is immutable`); the next `start` archives state + report under `.loopx/deepresearch/archive/<closed-at>/`; `start --new-run` auto-closes only a run whose stop conditions already fired. Report generation and run rotation share one lifecycle lock, so a report can never land next to a different run's state; lock contention surfaces as typed `error_code=lock_acquire_timeout` JSON, not a traceback.
- `report`: citation-auditable markdown — every claim cites its source id, sources table, contradictions with resolutions, open questions declared.
- Provenance semantics: `--tool` (and the source ref) are **caller-declared provenance** — the CLI records them, it does not attest that the tool ran. Execution receipts belong to a future host/harness bridge, not this ledger.
- Capability boundaries (also in the catalog entry and capability README): distinct from `auto-research` (goal-scoped workers vs this single-session ledger) and from `explore` (goal-scoped, public-safe, cross-session topology vs this private, session-scoped ledger with raw source locators). Any future explore bridge is a one-way, idempotent, public-safe projection: explore never reads the raw ledger, never dual-writes, and graph resolution never closes a research run.
- Installer spec `/loopx-deepresearch`: host-generic skill facade for every skill-facade surface, instructing packet-first execution and typed writeback only.

## Validation

- `tests/test_deepresearch_command.py`: **24/24** — round trip with report citations, exact gate without state, duplicate-source reuse, answer-without-ledger-evidence rejection, subquestion free-roaming rejection (CLI + domain), contradiction block + sides-with resolution, coverage stop, open-contradiction completion block, sides-with-outside-evidence rejection (in-call and pre-resolved), standalone/in-call resolution cannot overrule answered evidence, citing both sides of a contradiction rejection (in-call and pre-resolved), closed packet terminal projection, closed-run mutation immutability (4 mutation probes), report/rotation race serialization, lock-contention typed JSON, 8-process concurrent add-source, second-run close→start archive rotation, capability registration, facade install.
- Neighbor suites: capability catalog registry (`deep-research` in the builtin order), Windows install assertions, maintainability ratchet — green. Focused+neighbors on this head: 24 passed, 4 skipped (Windows-only skips), ruff clean on touched files.
- **Live E2E with the real `agy` (Antigravity CLI) binary**: after installing the surface, a headless `agy -p "/loopx-deepresearch <question>"` session ran the full loop — packet-first start, 4 real sources recorded via `add-source`, 8 claims, question resolved citing all 8 evidence claims, stop conditions fired, report rendered with every citation resolving to a real file. (agy surface is PR #3450; E2E ran on a local merge of both branches.)

Follow-up ideas (not in scope here): web-search capability gating per host, coverage-window tuning, `loopx status` projection of research state, run_id/ledger_revision + bounded expedition-candidate projection for an explore-harness bridge (real-caller driven, separate slice).
