### PR TITLE
feat(capability): gate loopx-benchmark skill on benchmark-toolkit enablement

### DIFF
--- a/loopx/cli_commands/capability.py
+++ b/loopx/cli_commands/capability.py
@@ -15,6 +15,11 @@ from ..capabilities.catalog import (
 from ..extensions.capability_admission import (
     bind_external_capability_to_goal,
     invoke_external_capability,
+    set_goal_enabled_capability,
+)
+from ..workflow_skill_install import (
+    install_capability_gated_skills,
+    uninstall_capability_gated_skills,
 )
 from ..extensions.runtime import (
     MAX_EXTENSION_REQUEST_BYTES,
@@ -152,6 +157,24 @@ def register_capability_commands(
     )
     bind_parser.add_argument("--execute", action="store_true")
     bind_parser.set_defaults(capability_operation_parser=bind_parser)
+    enable_parser = capability_sub.add_parser(
+        "enable",
+        help="Enable one builtin capability for a Goal and install its gated host skills.",
+    )
+    add_subcommand_format(enable_parser)
+    enable_parser.add_argument("capability_id")
+    enable_parser.add_argument("--goal-id", required=True)
+    enable_parser.add_argument("--execute", action="store_true")
+    enable_parser.set_defaults(capability_operation_parser=enable_parser)
+    disable_parser = capability_sub.add_parser(
+        "disable",
+        help="Disable one builtin capability for a Goal and uninstall its gated host skills.",
+    )
+    add_subcommand_format(disable_parser)
+    disable_parser.add_argument("capability_id")
+    disable_parser.add_argument("--goal-id", required=True)
+    disable_parser.add_argument("--execute", action="store_true")
+    disable_parser.set_defaults(capability_operation_parser=disable_parser)
     invoke_parser = capability_sub.add_parser(
         "invoke",
         help="Preview or run one external capability enabled for a Goal.",
@@ -239,6 +262,36 @@ def handle_capability_command(
                 operations=args.operation,
                 execute=args.execute,
             )
+            renderer = _render_external_binding
+        elif args.capability_command in {"enable", "disable"}:
+            enabled = args.capability_command == "enable"
+            payload = set_goal_enabled_capability(
+                registry_path=registry_path,
+                goal_id=args.goal_id,
+                capability_id=args.capability_id,
+                enabled=enabled,
+                execute=args.execute,
+            )
+            if args.execute and payload.get("changed"):
+                payload["skill_lifecycle"] = (
+                    install_capability_gated_skills(
+                        args.capability_id, execute=True
+                    )
+                    if enabled
+                    else uninstall_capability_gated_skills(
+                        args.capability_id, execute=True
+                    )
+                )
+            elif not args.execute:
+                payload["skill_lifecycle"] = (
+                    install_capability_gated_skills(
+                        args.capability_id, execute=False
+                    )
+                    if enabled
+                    else uninstall_capability_gated_skills(
+                        args.capability_id, execute=False
+                    )
+                )
             renderer = _render_external_binding
         elif args.capability_command == "invoke":
             if args.goal_binding_json == "-" and args.input_json == "-":

--- a/loopx/extensions/capability_admission.py
+++ b/loopx/extensions/capability_admission.py
@@ -677,3 +677,91 @@ def invoke_external_capability(
             "provider_invoked": True,
         },
     }
+
+
+GOAL_ENABLED_CAPABILITIES_FIELD = "enabled_capabilities"
+GOAL_ENABLED_CAPABILITY_RECEIPT_SCHEMA_VERSION = (
+    "loopx_goal_enabled_capability_receipt_v0"
+)
+
+
+def set_goal_enabled_capability(
+    *,
+    registry_path: str | Path,
+    goal_id: str,
+    capability_id: str,
+    enabled: bool,
+    execute: bool = False,
+) -> dict[str, Any]:
+    """Add or remove one builtin capability id on the Goal's enabled list.
+
+    Builtin capabilities are catalog-visible and always implemented, but a Goal
+    opts into the capability-driven skill lifecycle only when the capability id
+    appears in its ``enabled_capabilities``. Enable installs the capability's
+    gated host skills; disable removes them.
+    """
+
+    path = Path(registry_path).expanduser()
+
+    def prepare(registry: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+        goal = find_registry_goal(registry, str(goal_id))
+        if goal is None:
+            raise ValueError(f"LoopX registry does not contain Goal `{goal_id}`")
+        raw = goal.get(GOAL_ENABLED_CAPABILITIES_FIELD)
+        current = [str(item) for item in raw] if isinstance(raw, list) else []
+        next_values = [item for item in current if item != capability_id]
+        changed = capability_id in current
+        if enabled:
+            next_values = sorted({*next_values, capability_id})
+            changed = capability_id not in current
+        updated_goal = {
+            **goal,
+            GOAL_ENABLED_CAPABILITIES_FIELD: next_values,
+        }
+        return changed, updated_goal
+
+    def commit(registry: dict[str, Any]) -> dict[str, Any]:
+        changed, updated_goal = prepare(registry)
+        receipt: dict[str, Any] = {
+            "ok": True,
+            "schema_version": GOAL_ENABLED_CAPABILITY_RECEIPT_SCHEMA_VERSION,
+            "status": "ready" if not execute else "no_change" if not changed else "written",
+            "dry_run": not execute,
+            "executed": execute,
+            "changed": changed,
+            "written": False,
+            "registry": str(path),
+            "goal_id": str(goal_id),
+            "capability_id": str(capability_id),
+            "enabled": bool(enabled),
+            "enabled_capabilities": updated_goal.get(GOAL_ENABLED_CAPABILITIES_FIELD),
+        }
+        if not (execute and changed):
+            return receipt, updated_goal
+        goals = registry.get("goals")
+        if not isinstance(goals, list):
+            raise ValueError("LoopX registry goals must be a list")
+        registry["goals"] = [
+            updated_goal
+            if isinstance(item, Mapping) and item.get("id") == str(goal_id)
+            else item
+            for item in goals
+        ]
+        atomic_write_json(path, registry, preserve_mode=True)
+        receipt["written"] = True
+        receipt["status"] = "written"
+        return receipt, updated_goal
+
+    if execute:
+        with exclusive_file_lock(path, operation="set_goal_enabled_capability"):
+            if not path.is_file():
+                raise ValueError(f"LoopX registry does not exist: {path}")
+            registry = load_registry(path)
+            receipt, _ = commit(registry)
+            return receipt
+    else:
+        if not path.is_file():
+            raise ValueError(f"LoopX registry does not exist: {path}")
+        registry = load_registry(path)
+        receipt, _ = commit(registry)
+        return receipt

--- a/loopx/workflow_skill_install.py
+++ b/loopx/workflow_skill_install.py
@@ -40,6 +40,12 @@ _PACKAGED_SKILL_SENTINEL = PurePosixPath(
 # lock file at the path installs have always used.
 _INSTALL_LOCK_STEM = ".loopx-workflow-skills"
 
+# Capability ids whose gated host skills are installed only while the
+# capability is enabled for a Goal, and removed again when it is disabled.
+CAPABILITY_GATED_HOST_SKILLS: dict[str, tuple[str, ...]] = {
+    "benchmark-toolkit": ("loopx-benchmark",),
+}
+
 
 def _valid_source_root(path: Path) -> bool:
     return all(
@@ -138,6 +144,126 @@ def _install_one_skill(source: Path, target: Path) -> str:
         if backup and backup.exists():
             shutil.rmtree(backup)
     return "updated" if backup else "created"
+
+
+def capability_gated_skill_ids(capability_id: str) -> tuple[str, ...]:
+    """Return the host skill ids gated on one capability id enablement."""
+    return CAPABILITY_GATED_HOST_SKILLS.get(str(capability_id or ""), ())
+
+
+def install_capability_gated_skills(
+    capability_id: str,
+    *,
+    skills_dir: Path | None = None,
+    execute: bool = False,
+) -> dict[str, Any]:
+    """Install host skills that are gated on ``capability_id`` enablement.
+
+    Preview returns what would be installed without writing. Execute installs
+    each gated skill id atomically from the canonical workflow-skills source.
+    """
+
+    skill_ids = capability_gated_skill_ids(capability_id)
+    target_root = (skills_dir or default_workflow_skills_dir()).expanduser().resolve()
+    source = resolve_workflow_skill_source()
+    if not skill_ids:
+        return {
+            "ok": True,
+            "capability_id": capability_id,
+            "operation": "install" if execute else "preview",
+            "skills_dir": str(target_root),
+            "installed": {},
+            "reason": "no gated host skills for this capability",
+        }
+    if not source.get("available"):
+        return {
+            "ok": False,
+            "capability_id": capability_id,
+            "operation": "install" if execute else "preview",
+            "skills_dir": str(target_root),
+            "installed": {},
+            "reason": source["reason"],
+        }
+    installed: dict[str, str] = {}
+    if execute:
+        with _exclusive_install_lock(target_root):
+            for skill_id in skill_ids:
+                installed[skill_id] = _install_one_skill(
+                    Path(source["skills_root"]) / skill_id,
+                    target_root / skill_id,
+                )
+    else:
+        for skill_id in skill_ids:
+            target = target_root / skill_id
+            source_dir = Path(source["skills_root"]) / skill_id
+            if target.is_dir() and hash_skill_tree(source_dir) == hash_skill_tree(target):
+                installed[skill_id] = "unchanged"
+            elif target.is_dir():
+                installed[skill_id] = "would_update"
+            else:
+                installed[skill_id] = "would_create"
+    return {
+        "ok": True,
+        "capability_id": capability_id,
+        "operation": "install" if execute else "preview",
+        "skills_dir": str(target_root),
+        "installed": installed,
+    }
+
+
+def uninstall_capability_gated_skills(
+    capability_id: str,
+    *,
+    skills_dir: Path | None = None,
+    execute: bool = False,
+) -> dict[str, Any]:
+    """Remove host skills gated on ``capability_id`` when it is disabled.
+
+    A gated skill is removed only when it still matches the canonical source
+    (i.e. was not locally modified after installation). Preview returns the
+    would-be removed set without writing.
+    """
+
+    skill_ids = capability_gated_skill_ids(capability_id)
+    target_root = (skills_dir or default_workflow_skills_dir()).expanduser().resolve()
+    source = resolve_workflow_skill_source()
+    if not skill_ids:
+        return {
+            "ok": True,
+            "capability_id": capability_id,
+            "operation": "uninstall" if execute else "preview",
+            "skills_dir": str(target_root),
+            "removed": [],
+            "preserved_modified": [],
+            "reason": "no gated host skills for this capability",
+        }
+    removed: list[str] = []
+    preserved_modified: list[str] = []
+    for skill_id in skill_ids:
+        target = target_root / skill_id
+        if not target.exists():
+            continue
+        if source.get("available") and hash_skill_tree(
+            Path(source["skills_root"]) / skill_id
+        ) == hash_skill_tree(target):
+            if execute:
+                shutil.rmtree(target)
+            removed.append(skill_id)
+        else:
+            preserved_modified.append(skill_id)
+    return {
+        "ok": not preserved_modified,
+        "capability_id": capability_id,
+        "operation": "uninstall" if execute else "preview",
+        "skills_dir": str(target_root),
+        "removed": removed,
+        "preserved_modified": preserved_modified,
+        "reason": (
+            "removed gated host skills"
+            if not preserved_modified
+            else "preserved gated skills whose content changed after installation"
+        ),
+    }
 
 
 def _load_manifest(skills_dir: Path) -> dict[str, Any] | None:

--- a/skills/loopx-benchmark/SKILL.md
+++ b/skills/loopx-benchmark/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: loopx-benchmark
+description: Use when running, tracking, scoring, or analyzing a benchmark experiment with LoopX, including launching solver arms, recording experiment-board rows, qualifying integrity, comparing baseline vs treatment, or writing case insights. Triggers on benchmark, bench, eval, experiment board, experiment-board, arm, baseline/treatment comparison, campaign monitor, and scored-case transitions.
+---
+
+# LoopX Benchmark Workflow
+
+Use this skill whenever a task involves a benchmark experiment: launching solver
+arms, recording or reading the experiment board, qualifying a run, comparing
+baseline/treatment, or summarizing scores. The `benchmark-toolkit` capability
+owns the provider-neutral boundaries; this skill is the agent-facing playbook so
+solver, monitor, and post-run analyst lanes all follow the same contract.
+
+## Capability surface
+
+- `loopx capability show benchmark-toolkit --format json` — catalog entry with
+  usage hints, role boundaries, and the post-run case-insight template.
+- `loopx benchmark --help` — subcommands (experiment-board-show,
+  experiment-board-upsert, source-revision-fence, integrity-qualification,
+  classify-artifacts).
+
+## Required sequence (do not skip steps)
+
+1. **Read the experiment board before launching or selecting a case.**
+   ```bash
+   loopx benchmark experiment-board-show --goal-id <GOAL_ID> --format json
+   ```
+   Inspect baseline, treatment, explore, countability, effort, and insight rows
+   before choosing the next arm.
+
+2. **Qualify the source revision before each new run admission.**
+   ```bash
+   loopx benchmark source-revision-fence \
+     --source-checkout <clean-source> \
+     --expected-revision <PIN> \
+     --observed-reference-revision <OBSERVED_HEAD> \
+     --require-admitted --format json
+   ```
+   The fence fails closed unless the clean pinned source matches the observed
+   reference head.
+
+3. **Preregister or mark the run row when it starts.**
+   ```bash
+   loopx benchmark experiment-board-upsert --goal-id <GOAL_ID> \
+     --row-json <running-row.json> --execute --format json
+   ```
+   The running row uses `status=running`, empty `metrics`, and
+   `countability={integrity_qualified:false, official_result_present:false,
+   score_countable:false}`. Keep the same stable `run_id` for every transition.
+
+4. **Upsert terminal score, countability, effort, and insight when it ends.**
+   ```bash
+   loopx benchmark experiment-board-upsert --goal-id <GOAL_ID> \
+     --row-json <terminal-row.json> --execute --format json
+   ```
+   The terminal row sets `status=completed`, fills `metrics` (primary metric plus
+   guardrails), and updates `countability`. Only mark `score_countable=true` when
+   `integrity_qualified=true` and `official_result_present=true`. Fill `effort`
+   and set `insight.status` to `complete` after the post-run analysis.
+
+5. **Read matched comparisons before selecting the next arm.**
+   ```bash
+   loopx benchmark experiment-board-show --goal-id <GOAL_ID> --format json
+   ```
+   Only claim paired results from `matched_pair_countable` comparisons. Keep
+   diagnostic-only explore rows in a separate evidence lane.
+
+## Run-row contract
+
+- `benchmark_id`, `study_id`, `case_id`, `run_id`, `arm_id`, `arm_role`,
+  `attempt`, `status`, `observed_at`, `model_id`, `protocol_id`,
+  `comparison_protocol_id`, `claim_scope`, `primary_metric`,
+  `guardrail_metrics`, `metrics`, `countability`, `treatment_fidelity`,
+  `effort`, `insight` are the canonical row fields (`schema_version` =
+  `benchmark_experiment_board_row_v0`).
+- Baseline rows must use `treatment_fidelity=not_applicable` and cannot name a
+  `comparison_anchor_run_id`. Non-baseline rows must name a
+  `comparison_anchor_run_id`.
+- Metrics are `{"name": {"value": <number>, "unit": <str>,
+  "higher_is_better": <bool>}}`; at most 16 entries. The `primary_metric` must
+  not also be a guardrail metric.
+- `score_countable` requires `status=completed`, `integrity_qualified=true`,
+  and `official_result_present=true`. `score=0` is a valid completed result.
+
+## Source, integrity, and artifact boundaries
+
+- `source-revision-fence` is read-only and caller-observed: it performs no
+  fetch, install, or launch. It blocks new admissions only.
+- `integrity-qualification` reduces private trajectory and runner isolation
+  evidence to a compact public-safe receipt (hashes, counts, reason codes).
+- `classify-artifacts` classifies benchmark artifact paths without reading them;
+  use it before reading or publishing any candidate artifact.
+- The solver lane must not read hidden tests, verifier sources, gold answers, or
+  official feedback during the solving phase. The post-run analyst may read full
+  private evidence only after the solver is terminal and scoring is complete.
+
+## Campaign monitoring and post-run insight
+
+- When a campaign starts, add one `continuous_monitor` todo that refreshes the
+  aggregate score/coverage and writes `benchmark_case_insight_v0` on every
+  material scored-case transition.
+- Report only public-safe conclusions (countable baselines, countable
+  treatments, matched pairs, aggregate primary metric by arm, improved/flat/
+  regressed pair counts). Never copy raw private evidence into a user update.
+- After a solver stops and scoring completes, read the task, real trajectory,
+  final workspace, hidden tests, verifier, and failure/score details; write one
+  `benchmark_case_insight_v0` explaining the decisive evidence, why the outcome
+  happened, and what LoopX should test next.
+- Do not send a repetitive user update when nothing material changed.

--- a/skills/loopx-benchmark/agents/openai.yaml
+++ b/skills/loopx-benchmark/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "LoopX Benchmark"
+  short_description: "Run and track benchmark experiments with the LoopX experiment board"
+  default_prompt: "Use the LoopX benchmark workflow: read the experiment board first, preregister each run row, qualify sources and integrity, then close terminal rows and compare arms before selecting the next case."

--- a/tests/extensions/test_external_capability_admission.py
+++ b/tests/extensions/test_external_capability_admission.py
@@ -709,3 +709,42 @@ def test_capability_bind_cli_resolves_registry_runtime_root(
     )
     payload = json.loads(capsys.readouterr().out)
     assert payload["status"] == "written"
+
+
+def test_set_goal_enabled_capability_round_trip(tmp_path):
+    from loopx.extensions.capability_admission import set_goal_enabled_capability
+    from loopx.history import load_registry
+
+    reg = {
+        "schema_version": "0.1",
+        "goals": [{"id": "g1", "status": "active", "repo": str(tmp_path / "proj")}],
+    }
+    (tmp_path / "proj").mkdir()
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(json.dumps(reg))
+
+    preview = set_goal_enabled_capability(
+        registry_path=registry_path, goal_id="g1", capability_id="benchmark-toolkit", enabled=True, execute=False
+    )
+    assert preview["changed"] is True
+    assert preview["dry_run"] is True
+    assert "benchmark-toolkit" not in load_registry(registry_path)["goals"][0].get("enabled_capabilities", [])
+
+    enabled = set_goal_enabled_capability(
+        registry_path=registry_path, goal_id="g1", capability_id="benchmark-toolkit", enabled=True, execute=True
+    )
+    assert enabled["changed"] is True
+    assert enabled["written"] is True
+    assert load_registry(registry_path)["goals"][0]["enabled_capabilities"] == ["benchmark-toolkit"]
+
+    unchanged = set_goal_enabled_capability(
+        registry_path=registry_path, goal_id="g1", capability_id="benchmark-toolkit", enabled=True, execute=True
+    )
+    assert unchanged["changed"] is False
+    assert unchanged["status"] == "no_change"
+
+    disabled = set_goal_enabled_capability(
+        registry_path=registry_path, goal_id="g1", capability_id="benchmark-toolkit", enabled=False, execute=True
+    )
+    assert disabled["changed"] is True
+    assert load_registry(registry_path)["goals"][0]["enabled_capabilities"] == []

--- a/tests/test_workflow_skill_install.py
+++ b/tests/test_workflow_skill_install.py
@@ -187,3 +187,45 @@ def test_install_and_inspect_dsh_native_entry(tmp_path: Path) -> None:
     generic = workflow_skill_install(skills_dir=skills_dir)
     assert generic["install_required"] is True
     assert generic["entry"]["status"] == "updated"
+
+
+def test_capability_gated_skills_install_and_uninstall(tmp_path: Path) -> None:
+    from loopx.workflow_skill_install import (
+        capability_gated_skill_ids,
+        install_capability_gated_skills,
+        uninstall_capability_gated_skills,
+    )
+
+    assert "loopx-benchmark" in capability_gated_skill_ids("benchmark-toolkit")
+    assert capability_gated_skill_ids("issue-fix") == ()
+
+    skills_dir = tmp_path / "gated skills"
+
+    preview = install_capability_gated_skills(
+        "benchmark-toolkit", skills_dir=skills_dir, execute=False
+    )
+    assert preview["installed"]["loopx-benchmark"] == "would_create"
+    assert not (skills_dir / "loopx-benchmark").exists()
+
+    installed = install_capability_gated_skills(
+        "benchmark-toolkit", skills_dir=skills_dir, execute=True
+    )
+    assert installed["installed"]["loopx-benchmark"] == "created"
+    assert (skills_dir / "loopx-benchmark" / "SKILL.md").is_file()
+
+    unrelated = install_capability_gated_skills(
+        "issue-fix", skills_dir=skills_dir, execute=True
+    )
+    assert unrelated["installed"] == {}
+
+    removed = uninstall_capability_gated_skills(
+        "benchmark-toolkit", skills_dir=skills_dir, execute=True
+    )
+    assert removed["removed"] == ["loopx-benchmark"]
+    assert removed["preserved_modified"] == []
+    assert not (skills_dir / "loopx-benchmark").exists()
+
+    again = uninstall_capability_gated_skills(
+        "benchmark-toolkit", skills_dir=skills_dir, execute=True
+    )
+    assert again["removed"] == []


### PR DESCRIPTION
## Summary
- Add `skills/loopx-benchmark` playbook (read board → source fence → preregister running → terminal closeout → read comparisons) as the agent-facing benchmark-toolkit workflow.
- Add a capability-gated host-skill lifecycle: `loopx-benchmark` is **not** in the always-installed packaged set; it is installed only when `benchmark-toolkit` is enabled for a Goal and uninstalled when disabled.
- Add goal-scoped builtin capability `enable`/`disable` (`enabled_capabilities` on the Goal registry entry) wired to install/uninstall of the gated skill; `--execute` writes the registry and installs/uninstalls, without it previews.
- Uninstall preserves locally modified gated skills (hash-matched before removal).

## Validation
- `tests/test_workflow_skill_install.py` + `tests/test_packaged_skill_metadata.py` + `tests/extensions/test_external_capability_admission.py` pass (36 tests).
- Public-safe scan on all changed surfaces: clean.
- CLI end-to-end: `capability enable benchmark-toolkit --execute` installs the skill; `capability disable` removes it.

## Scope
Runtime/control-plane behavior + one provider-neutral skill. No benchmark jobs launched, no scoring/runner change for existing benchmarks, no credentials/private state/logs.