### PR TITLE
fix(desktop/update): keep desktop usable across loopx update (self-heal + service restart)

### DIFF
--- a/apps/desktop/loopx-control-plane/src-tauri/src/services.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/services.rs
@@ -127,23 +127,37 @@ impl ServiceSet {
     fn ensure(&mut self, kind: ServiceKind) -> Result<(), ServiceError> {
         let executable = loopx_executable();
         let expected_runtime_identity = runtime_identity_for_executable(&executable);
-        match probe(kind, expected_runtime_identity.as_ref()) {
-            Probe::Matching => return Ok(()),
-            Probe::Foreign => {
-                return Err(ServiceError(format!(
-                    "port {} is occupied by a service that is not LoopX {}",
-                    kind.port(),
-                    kind.label()
-                )));
+        let mut stale_retries = 0;
+        loop {
+            match probe(kind, expected_runtime_identity.as_ref()) {
+                Probe::Matching => return Ok(()),
+                Probe::Foreign => {
+                    return Err(ServiceError(format!(
+                        "port {} is occupied by a service that is not LoopX {}",
+                        kind.port(),
+                        kind.label()
+                    )));
+                }
+                Probe::Stale => {
+                    // Self-heal: the port is owned by a LoopX service from a
+                    // different installed release (for example before a
+                    // `loopx update` restarted it). Terminate that stale
+                    // listener and retry so the current release's service is
+                    // started; unknown (Foreign) processes keep the hard error.
+                    stale_retries += 1;
+                    if stale_retries > 3 {
+                        return Err(ServiceError(format!(
+                            "port {} is serving LoopX {} from a different installed runtime and could not be restarted",
+                            kind.port(),
+                            kind.label()
+                        )));
+                    }
+                    terminate_listener(kind.port());
+                    thread::sleep(Duration::from_millis(400));
+                    continue;
+                }
+                Probe::Unavailable => break,
             }
-            Probe::Stale => {
-                return Err(ServiceError(format!(
-                    "port {} is serving LoopX {} from a different installed runtime; stop the old `loopx dashboard` or desktop app, then reopen LoopX",
-                    kind.port(),
-                    kind.label()
-                )));
-            }
-            Probe::Unavailable => {}
         }
 
         let mut command = Command::new(&executable);
@@ -199,6 +213,26 @@ impl ServiceSet {
 impl Drop for ServiceSet {
     fn drop(&mut self) {
         self.stop();
+    }
+}
+
+fn terminate_listener(port: u16) {
+    #[cfg(not(windows))]
+    {
+        let output = Command::new("lsof")
+            .args(["-tiTCP", &format!(":{port}"), "-sTCP:LISTEN"])
+            .output();
+        if let Ok(output) = output {
+            for line in String::from_utf8_lossy(&output.stdout).lines() {
+                if let Ok(pid) = line.trim().parse::<i32>() {
+                    let _ = Command::new("kill").arg(pid.to_string()).status();
+                }
+            }
+        }
+    }
+    #[cfg(windows)]
+    {
+        // Windows keeps the owner-facing error path; no process is terminated.
     }
 }
 

--- a/loopx/self_update.py
+++ b/loopx/self_update.py
@@ -5,6 +5,7 @@ import os
 import re
 import shlex
 import subprocess
+import sys
 from typing import Any
 from urllib.parse import quote
 from urllib.request import Request, urlopen
@@ -540,6 +541,40 @@ def build_update_plan(
     }
 
 
+def restart_managed_loopx_services() -> list[str]:
+    """Best-effort restart of user LaunchAgent-managed LoopX services on macOS.
+
+    After ``loopx update`` replaces the installed release, running status/chat
+    services still belong to the previous release. Restarting the managed
+    LaunchAgents makes them run the new ``loopx`` immediately, so the dashboard
+    and desktop shell keep working without a release-identity mismatch.
+    """
+    if sys.platform != "darwin":
+        return []
+    agents_dir = Path.home() / "Library" / "LaunchAgents"
+    if not agents_dir.is_dir():
+        return []
+    labels: list[str] = []
+    for plist in sorted(agents_dir.glob("*.plist")):
+        stem = plist.stem.lower()
+        if "loopx" not in stem and "goal-harness" not in stem:
+            continue
+        if not (stem.endswith(".status") or stem.endswith(".chat")):
+            continue
+        labels.append(plist.stem)
+    restarted: list[str] = []
+    for label in labels:
+        result = subprocess.run(
+            ["launchctl", "kickstart", "-k", f"gui/{os.getuid()}/{label}"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0:
+            restarted.append(label)
+    return restarted
+
+
 def execute_update_plan(payload: dict[str, Any], *, timeout_seconds: int = 600) -> dict[str, Any]:
     if os.name == "nt":
         updated = dict(payload)
@@ -592,6 +627,8 @@ def execute_update_plan(payload: dict[str, Any], *, timeout_seconds: int = 600) 
     updated["ok"] = install_result.returncode == 0 and doctor_result.returncode == 0
     if not updated["ok"]:
         updated["recommended_action"] = "inspect update execution tails and restore from rollback plan if needed"
+        return updated
+    execution["restarted_services"] = restart_managed_loopx_services()
     return updated
 
 

--- a/tests/test_self_update_runtime_activation.py
+++ b/tests/test_self_update_runtime_activation.py
@@ -10,7 +10,7 @@ from unittest import mock
 from loopx import __version__
 import pytest
 
-from loopx.self_update import build_update_plan, execute_update_plan
+from loopx.self_update import build_update_plan, execute_update_plan, restart_managed_loopx_services
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -201,6 +201,36 @@ def test_cli_rejects_installed_doctor_snapshot_outside_check(tmp_path: Path) -> 
     payload = json.loads(result.stdout)
     assert payload["ok"] is False
     assert payload["error"] == "--installed-doctor-json requires update --check"
+
+
+def test_restart_managed_loopx_services_restarts_only_loopx_launchagents(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("loopx.self_update.sys.platform", "darwin")
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    agents = tmp_path / "Library" / "LaunchAgents"
+    agents.mkdir(parents=True)
+    for name in (
+        "com.loopx.status.plist",
+        "com.loopx.chat.plist",
+        "com.goal-harness.status.plist",
+        "unrelated.plist",
+    ):
+        (agents / name).write_text("<plist/>", encoding="utf-8")
+
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(list(args))
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr("loopx.self_update.subprocess.run", fake_run)
+
+    restarted = restart_managed_loopx_services()
+    assert set(restarted) == {"com.loopx.status", "com.loopx.chat", "com.goal-harness.status"}
+    assert len(calls) == 3
+    assert all(call[0] == "launchctl" for call in calls)
 
 
 @pytest.mark.skipif(os.name != "nt", reason="native Windows update boundary")


### PR DESCRIPTION
## Summary

`loopx update` upgrades the CLI and the packaged `/chat/` frontend, but running status/chat services stayed on the previous release. The desktop shell (and `loopx dashboard`) then rejected them via the release-identity fence, so after every update the desktop app needed a manual service restart.

This PR makes the whole stack move together with one `loopx update`:

1. **Desktop self-heal**: when the shell finds a verified-stale LoopX service on its port (same fingerprint, different release), it terminates that listener and retries so the current release's service is started. Unknown (Foreign) processes keep the hard error; Windows keeps the owner-facing error path.
2. **Update restarts managed services**: after a successful `loopx update --execute`, restart user LaunchAgent-managed status/chat services on macOS so the dashboard and desktop immediately run the new release (best-effort, non-fatal; recorded in the execution payload).

## Changes

- `apps/desktop/loopx-control-plane/src-tauri/src/services.rs` — auto-restart stale LoopX listeners with a retry cap.
- `loopx/self_update.py` — add `restart_managed_loopx_services()` and call it after a successful update.
- `tests/test_self_update_runtime_activation.py` — cover the restart helper.

## Validation

- `cargo check` (src-tauri): clean.
- `python3 -m py_compile loopx/self_update.py tests/test_self_update_runtime_activation.py`: clean.
- Manual behavior check of `restart_managed_loopx_services` (darwin label selection + non-darwin no-op).
- `git diff --check`: clean.

## Boundary

Desktop shell + update flow only. The release-identity fence stays for unknown processes; no control-plane, quota, todo, permission, or public/private evidence changes.
