### PR TITLE
fix(update): avoid os.getuid on platforms where it is unavailable

### DIFF
--- a/loopx/self_update.py
+++ b/loopx/self_update.py
@@ -563,9 +563,10 @@ def restart_managed_loopx_services() -> list[str]:
             continue
         labels.append(plist.stem)
     restarted: list[str] = []
+    uid = os.getuid() if hasattr(os, "getuid") else 0
     for label in labels:
         result = subprocess.run(
-            ["launchctl", "kickstart", "-k", f"gui/{os.getuid()}/{label}"],
+            ["launchctl", "kickstart", "-k", f"gui/{uid}/{label}"],
             capture_output=True,
             text=True,
             timeout=30,

--- a/tests/test_self_update_runtime_activation.py
+++ b/tests/test_self_update_runtime_activation.py
@@ -208,6 +208,7 @@ def test_restart_managed_loopx_services_restarts_only_loopx_launchagents(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("loopx.self_update.sys.platform", "darwin")
+    monkeypatch.setattr("loopx.self_update.os.getuid", lambda: 501)
     monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
     agents = tmp_path / "Library" / "LaunchAgents"
     agents.mkdir(parents=True)


### PR DESCRIPTION
## Summary

Follow-up to #3457: `restart_managed_loopx_services()` called `os.getuid()` directly, which does not exist on Windows and broke the added unit test in the `windows-powershell` CI job. Resolve the uid defensively (`hasattr`) and mock it in the test so the helper is platform-neutral.

## Validation

- `python3 -m py_compile loopx/self_update.py tests/test_self_update_runtime_activation.py`: clean.
- `git diff --check`: clean.
