### PR TITLE
test(update): remove os.getuid monkeypatch that fails on Windows

### DIFF
--- a/tests/test_self_update_runtime_activation.py
+++ b/tests/test_self_update_runtime_activation.py
@@ -208,7 +208,6 @@ def test_restart_managed_loopx_services_restarts_only_loopx_launchagents(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("loopx.self_update.sys.platform", "darwin")
-    monkeypatch.setattr("loopx.self_update.os.getuid", lambda: 501)
     monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
     agents = tmp_path / "Library" / "LaunchAgents"
     agents.mkdir(parents=True)


### PR DESCRIPTION
## Summary

Follow-up to #3458: the merged version keeps a `monkeypatch.setattr("loopx.self_update.os.getuid", ...)` in the new unit test, but `os.getuid` does not exist on Windows, so the `windows-powershell` CI job still fails. The production code already guards with `hasattr`; the test only inspects the launchctl calls, so the monkeypatch line is unnecessary. Remove it.

## Validation

- `python3 -m py_compile tests/test_self_update_runtime_activation.py`: clean.
- `git diff --check`: clean.
