### PR TITLE
fix(dashboard)+feat(lark): keep bundle assets on rebuild; add recommended LoopX bot scope bundle

### DIFF
--- a/apps/presentation/dashboard/vite.chat.config.ts
+++ b/apps/presentation/dashboard/vite.chat.config.ts
@@ -31,6 +31,9 @@ export default defineConfig({
   plugins: [react(), tailwindcss(), emitSharedPwaAssets()],
   build: {
     outDir: resolve(import.meta.dirname, "../../../loopx/web/chat"),
-    emptyOutDir: true,
+    // Keep prior hashed assets: a running dashboard or an in-flight page may
+    // still reference an older index.html; deleting old files turns a stale
+    // page into a white screen. index.html always points at the newest hashes.
+    emptyOutDir: false,
   },
 });

--- a/loopx/extensions/lark/README.md
+++ b/loopx/extensions/lark/README.md
@@ -71,3 +71,28 @@ exact authority, gate, revision, idempotency, and readback contract.
 The declarative capability and permission surface is maintained in
 [`extension.toml`](extension.toml). Provider readiness never grants a new
 permission or silently enables an external write.
+
+## 创建 LoopX 机器人（推荐权限集）
+
+每个新的 LoopX 企业自建应用（例如 Goal Channel 的发送 bot）应一次性申请
+推荐权限集，而不是边用边补。清单见
+[`bot_scopes.py`](bot_scopes.py)（`RECOMMENDED_BOT_SCOPES`），按用途分三档：
+
+- 核心（Goal Channel / reviewer / kanban）：`im:message`、`im:chat:read`、
+  `im:chat:create`、`im:chat:update`、`im:chat.members:read`、
+  `im:chat.members:write_only`、`contact:user.base:readonly`、
+  `contact:contact.base:readonly`、`application:application:self_manage`、
+  `application:bot.basic_info:read`
+- 收件箱（事件订阅收消息，敏感需审核）：`im:message.group_msg`、
+  `im:message.p2p_msg:readonly`
+- 交互/文档 sink：`cardkit:card:read/write`、`docs:document.comment:read/create/delete`
+
+拿到 App ID（`cli_xxx`）后，可在开发者后台一键批量申请：
+
+```text
+https://open.larkoffice.com/page/scope-apply?clientID=<app_id>&scopes=<scope1%2Cscope2...>
+```
+
+（`recommended_bot_scope_apply_url(app_id)` 会拼出完整 URL。）随后用
+`lark-cli config init --app-id <app_id> --app-secret-stdin --name <profile> --brand lark`
+注册 bot profile，再走 `loopx goal-channel setup`。敏感 scope 需企业管理员审核。

--- a/loopx/extensions/lark/bot_scopes.py
+++ b/loopx/extensions/lark/bot_scopes.py
@@ -1,0 +1,64 @@
+"""Recommended Lark (Feishu) API scope bundle for a LoopX project bot.
+
+Each new LoopX Lark bot (e.g. a Goal Channel sender) should apply this bundle
+once instead of adding scopes reactively. The bundle is derived from two real
+bots: ``Ark-Flow LoopX`` (slash-command / card / docs-comment sink) and
+``LoopX 管家`` (Goal Channel + event inbox + kanban). ``core`` covers Goal
+Channel, reviewer notification and kanban; ``inbox`` adds message ingestion;
+``sink`` adds interactive cards and docs comments.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+APP_ID_PATTERN = re.compile(r"cli_[A-Za-z0-9_-]+")
+_OFFICIAL_SCOPE_APPLY_HOSTS = ("open.feishu.cn", "open.larkoffice.com")
+
+# 核心：发消息、建群/查群/群成员管理 —— goal-channel、reviewer、kanban 必需
+CORE_BOT_SCOPES = (
+    "im:message",
+    "im:chat:read",
+    "im:chat:create",
+    "im:chat:update",
+    "im:chat.members:read",
+    "im:chat.members:write_only",
+    "contact:user.base:readonly",
+    "contact:contact.base:readonly",
+    "application:application:self_manage",
+    "application:bot.basic_info:read",
+)
+
+# 收件箱：事件订阅收群/单聊消息（敏感，需审核）
+INBOX_BOT_SCOPES = (
+    "im:message.group_msg",
+    "im:message.p2p_msg:readonly",
+)
+
+# 交互/文档 sink：指令确认卡片、文档评论
+SINK_BOT_SCOPES = (
+    "cardkit:card:read",
+    "cardkit:card:write",
+    "docs:document.comment:read",
+    "docs:document.comment:create",
+    "docs:document.comment:delete",
+)
+
+RECOMMENDED_BOT_SCOPES = CORE_BOT_SCOPES + INBOX_BOT_SCOPES + SINK_BOT_SCOPES
+
+
+def recommended_bot_scope_apply_url(app_id: str, host: str = "open.larkoffice.com") -> str:
+    """Return the developer-console batch scope-apply URL for one LoopX bot.
+
+    Mirrors the console URL that the Lark platform returns for missing scopes so
+    a new bot can apply the whole recommended bundle in one click.
+    """
+    if not APP_ID_PATTERN.fullmatch(str(app_id or "")):
+        raise ValueError("app id must begin with cli_")
+    if host not in _OFFICIAL_SCOPE_APPLY_HOSTS:
+        raise ValueError("unsupported scope-apply host")
+    scopes = ",".join(RECOMMENDED_BOT_SCOPES)
+    from urllib.parse import quote
+
+    return f"https://{host}/page/scope-apply?clientID={quote(app_id)}&scopes={quote(scopes)}"


### PR DESCRIPTION
## What

Two small fixes bundled as two logical commits:

1. `fix(dashboard)`: the chat bundle rebuild emptied `loopx/web/chat` and
   deleted the previous hashed assets while a running dashboard or an
   in-flight page could still reference the older `index.html` — that stale
   page turned into a white screen (the JS/CSS 404'd). `emptyOutDir` is now
   `false` so rebuilds keep old hashed assets; `index.html` still points at the
   newest hashes.
2. `feat(lark)`: add a recommended LoopX bot permission bundle
   (`RECOMMENDED_BOT_SCOPES` in `bot_scopes.py`, split into core / inbox /
   sink tiers, derived from the Ark-Flow LoopX and LoopX 管家 bots) plus a
   helper that builds the developer-console batch scope-apply URL, and
   document "创建 LoopX 机器人" in the lark extension README so a new bot can
   apply the whole bundle in one shot.

## Validation

- `python3 -m py_compile` on the touched Python modules passes; a direct run of
  `recommended_bot_scope_apply_url` builds a valid console URL and rejects bad
  app ids.
- `git diff --check` clean.
- No runtime/control-plane behavior changes: new module + docs + one vite
  build option.
