### PR TITLE
fix(contract): allow the public Lark developer console

### DIFF
--- a/loopx/contract.py
+++ b/loopx/contract.py
@@ -67,6 +67,15 @@ LEAK_PATTERNS = {
     "private_ip": re.compile(r"\b10\.\d+\.\d+\.\d+\b|\b172\.(?:1[6-9]|2\d|3[01])\.\d+\.\d+\b|\b192\.168\.\d+\.\d+\b"),
 }
 
+# The Lark developer console is a public product surface, even though its
+# hostname shares the tenant-document marker used by private workspaces.
+# Keep this exception host-specific so tenant URLs on sibling hosts remain
+# blocked by the public/private boundary scan.
+_PUBLIC_LARK_DEVELOPER_CONSOLE_HOST = re.compile(
+    r"\bopen\." + "lark" + r"office\.com\b",
+    re.I,
+)
+
 CREDENTIAL_KEYWORD_PATTERN = re.compile(
     "|".join(
         [
@@ -782,7 +791,10 @@ def scan_public_boundary(
             continue
         for line_no, line in enumerate(text.splitlines(), start=1):
             for name, pattern in LEAK_PATTERNS.items():
-                if pattern.search(line):
+                scan_line = line
+                if name == "private_doc_url":
+                    scan_line = _PUBLIC_LARK_DEVELOPER_CONSOLE_HOST.sub("", scan_line)
+                if pattern.search(scan_line):
                     hit = f"{rel_or_abs(path, root)}:{line_no}: {name}"
                     if name == "credential" and _credential_hits_are_all_references(line):
                         credential_reference_hits.append(hit)

--- a/tests/test_contract_credential_pattern_precision.py
+++ b/tests/test_contract_credential_pattern_precision.py
@@ -13,6 +13,7 @@ BEARER = "Bear" + "er"
 TOKEN_ASSIGN = "tok" + "en="
 PASSWORD_ASSIGN = "pass" + "word="
 REAL_BEARER_VALUE = "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90"
+PRIVATE_LARK_TENANT_HOST = "tenant.lark" + "office.com"
 
 
 def _scan_line(tmp_path: Path, line: str) -> dict[str, list[str]]:
@@ -94,3 +95,29 @@ def test_blocked_private_doc_url_does_not_probe_git(
 
     assert payload["ok"] is False
     assert payload["hits"] == ["private-link.md:1: private_doc_url"]
+
+
+def test_public_lark_developer_console_is_not_a_private_doc_url(tmp_path: Path) -> None:
+    payload = _scan_line(
+        tmp_path,
+        "https://open.larkoffice.com/page/scope-apply?clientID=<app_id>",
+    )
+
+    assert payload["hits"] == []
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        f"https://{PRIVATE_LARK_TENANT_HOST}/wiki/example",
+        (
+            "https://open.larkoffice.com/page/scope-apply "
+            f"https://{PRIVATE_LARK_TENANT_HOST}/wiki/example"
+        ),
+    ],
+)
+def test_private_lark_tenant_urls_remain_blocked(tmp_path: Path, line: str) -> None:
+    payload = _scan_line(tmp_path, line)
+
+    assert len(payload["hits"]) == 1
+    assert payload["hits"][0].endswith(": private_doc_url")


### PR DESCRIPTION
## Summary

- treat `open.larkoffice.com` as the public Lark developer console during public-boundary scans
- keep tenant and sibling `larkoffice.com` hosts blocked
- add positive and negative precision coverage

## Why

PR #3460 added the official batch scope-apply URL. The boundary scanner classified the shared `larkoffice` hostname marker as a private document URL, making `loopx check` fail and cascading into the main Python and Full Public Smokes workflows.

## Validation

- `uv run --isolated --extra test python -m pytest -q tests/test_contract_credential_pattern_precision.py tests/control_plane/test_monitor_followthrough_contract.py tests/test_goal_mode_mcp_settlement.py tests/test_goal_mode_mcp_completion_validation.py tests/test_windows_install.py` (44 passed, 4 skipped)
- `uv run --isolated --extra test python -m loopx.cli check --scan-path .` (clean across 2779 files)
- `uv run --isolated --extra test python examples/canary/canary-promotion-readiness-smoke.py --no-write-evidence --dashboard-mode=skip`
- `uv run --isolated --extra test python -m ruff check loopx/contract.py tests/test_contract_credential_pattern_precision.py`
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` (standard tier, 8/8 catalog canaries, no manual holds)
- change-quality receipt `cqr_ff86b23e46efaadc2085` valid for the exact committed diff

## Future-facing pass

Applied at the existing scanner ownership boundary: one host-specific exception reuses the current private-doc classifier and avoids either weakening the tenant marker or adding capability-specific policy state.