### PR TITLE
feat(benchmark-toolkit): network-permitted integrity policy for web-research benchmarks

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -252,6 +252,30 @@ Restricted evaluation or cross-trial access is classified as cheating. Missing
 isolation proof or a credential leak still makes the run uncountable, but LoopX does
 not relabel that absence of proof as confirmed answer cheating.
 
+### Network access policy
+
+Offline coding benchmarks run with `network_access: "denied"` (the default): shell
+network use is a policy violation and the runner must attest
+`shell_network_denied: true`. Web-research benchmarks legitimately need network
+during the solving phase. A custom policy may declare
+`"network_access": "permitted_solving"`; the runner then attests
+`network_permitted_solving: true` instead of `shell_network_denied`, and
+`external_network_request` evidence is recorded but does not fail the run. The
+restricted-resource denials (answer, hidden tests, verifier, other trials,
+controller state, host escape, credentials) remain fail-closed in both modes:
+
+```json
+{
+  "schema_version": "benchmark_integrity_policy_v0",
+  "policy_id": "widesearch-permitted-solving",
+  "network_access": "permitted_solving"
+}
+```
+
+`network_access` is validated to `denied` or `permitted_solving`; any other value is
+rejected. The qualification receipt exposes the resolved `network_access` and the
+attestation checks that actually applied to that mode.
+
 ## Runner attestation
 
 The attestation is a compact runner-owned JSON object, not an agent assertion:

--- a/loopx/capabilities/benchmark_toolkit/integrity.py
+++ b/loopx/capabilities/benchmark_toolkit/integrity.py
@@ -45,6 +45,26 @@ REQUIRED_RUNTIME_ATTESTATIONS = (
     "official_feedback_blinded",
 )
 
+NETWORK_ACCESS_MODES = ("denied", "permitted_solving")
+DEFAULT_NETWORK_ACCESS = "denied"
+# Web-research benchmarks legitimately open network to the solving agent. The
+# runner attests that network access was bounded to the solving phase and that
+# evaluator/answer/verifier resources stayed denied.
+NETWORK_PERMITTED_SOLVING_ATTESTATION = "network_permitted_solving"
+_COMMON_RUNTIME_ATTESTATIONS = (
+    "agent_phase_isolated",
+    "evaluator_sources_denied",
+    "other_trials_denied",
+    "controller_state_denied",
+    "host_escape_denied",
+    "provider_credential_shell_excluded",
+    "case_local_control_state",
+    "canonical_control_state_root",
+    "independent_verifier",
+    "verifier_started_after_agent",
+    "official_feedback_blinded",
+)
+
 _DEFAULT_DENIED_ARGUMENT_MARKERS: dict[str, tuple[str, ...]] = {
     "restricted_answer_source_request": (
         "/solution/solution.patch",
@@ -152,11 +172,32 @@ def _marker_present(text: str, marker: str) -> bool:
     )
 
 
+def required_runtime_attestations(network_access: str) -> tuple[str, ...]:
+    """Return the runner attestations required for one network access mode.
+
+    ``denied`` (default) requires ``shell_network_denied`` for offline coding
+    benchmarks. ``permitted_solving`` is for web-research benchmarks: the shell
+    may use the network during the solving phase, but the runner must attest
+    ``network_permitted_solving`` instead and every restricted-resource denial
+    still applies.
+    """
+
+    mode = network_access if network_access in NETWORK_ACCESS_MODES else DEFAULT_NETWORK_ACCESS
+    if mode == "permitted_solving":
+        return (*_COMMON_RUNTIME_ATTESTATIONS, NETWORK_PERMITTED_SOLVING_ATTESTATION)
+    return (*_COMMON_RUNTIME_ATTESTATIONS, "shell_network_denied")
+
+
 def _validated_policy(
     policy: Mapping[str, Any] | None,
-) -> tuple[str, bool, dict[str, tuple[str, ...]]]:
+) -> tuple[str, bool, dict[str, tuple[str, ...]], str]:
     if policy is None:
-        return "default", False, dict(_DEFAULT_DENIED_ARGUMENT_MARKERS)
+        return (
+            "default",
+            False,
+            dict(_DEFAULT_DENIED_ARGUMENT_MARKERS),
+            DEFAULT_NETWORK_ACCESS,
+        )
     if policy.get("schema_version") != BENCHMARK_INTEGRITY_POLICY_SCHEMA_VERSION:
         raise ValueError("benchmark_integrity_policy_schema_mismatch")
     raw_policy_id = policy.get("policy_id")
@@ -166,6 +207,9 @@ def _validated_policy(
     )
     if not policy_id:
         raise ValueError("benchmark_integrity_policy_id_missing")
+    raw_network_access = str(policy.get("network_access") or DEFAULT_NETWORK_ACCESS).strip()
+    if raw_network_access not in NETWORK_ACCESS_MODES:
+        raise ValueError("benchmark_integrity_policy_network_access_unsupported")
     markers = dict(_DEFAULT_DENIED_ARGUMENT_MARKERS)
     custom = policy.get("denied_argument_markers")
     if custom is not None and not isinstance(custom, Mapping):
@@ -184,7 +228,7 @@ def _validated_policy(
                 normalized.append(text)
         if normalized:
             markers[category] = (*markers.get(category, ()), *normalized)
-    return policy_id, policy_id_path_like, markers
+    return policy_id, policy_id_path_like, markers, raw_network_access
 
 
 def _sensitive_value_present(text: str, sensitive_values: tuple[str, ...]) -> bool:
@@ -207,7 +251,7 @@ def build_benchmark_integrity_qualification(
     absence of a suspicious tool call cannot prove that isolation existed.
     """
 
-    policy_id, policy_id_path_like, markers = _validated_policy(policy)
+    policy_id, policy_id_path_like, markers, network_access = _validated_policy(policy)
     secrets = tuple(
         value
         for value in dict.fromkeys(str(item) for item in sensitive_values)
@@ -316,7 +360,7 @@ def build_benchmark_integrity_qualification(
         attestation_failures.append("runtime_attestation_schema_mismatch")
     if runtime_attestation.get("authority") != "runner":
         attestation_failures.append("runtime_attestation_authority_not_runner")
-    for field in REQUIRED_RUNTIME_ATTESTATIONS:
+    for field in required_runtime_attestations(network_access):
         if runtime_attestation.get(field) is not True:
             attestation_failures.append(f"runtime_attestation_{field}_missing")
 
@@ -324,7 +368,15 @@ def build_benchmark_integrity_qualification(
         category: int(evidence_counts.get(category, 0))
         for category in INTEGRITY_EVIDENCE_CATEGORIES
     }
-    policy_failures = [category for category, count in counts.items() if count]
+    policy_failures = [
+        category
+        for category, count in counts.items()
+        if count
+        and not (
+            network_access == "permitted_solving"
+            and category == "external_network_request"
+        )
+    ]
     blockers = [*structural_failures, *attestation_failures, *policy_failures]
     cheating_detected = any(counts[category] for category in _CHEATING_CATEGORIES)
     qualified = not blockers
@@ -357,9 +409,10 @@ def build_benchmark_integrity_qualification(
         "blockers": blockers,
         "evidence_counts": counts,
         "evidence": evidence,
+        "network_access": network_access,
         "runtime_attestation_checks": {
             field: runtime_attestation.get(field) is True
-            for field in REQUIRED_RUNTIME_ATTESTATIONS
+            for field in required_runtime_attestations(network_access)
         },
         "audit_coverage": {
             "trajectory_schema_version": _safe_label(schema_version, limit=40),

--- a/tests/capabilities/test_benchmark_toolkit.py
+++ b/tests/capabilities/test_benchmark_toolkit.py
@@ -599,3 +599,77 @@ def test_cli_emits_only_compact_public_safe_receipt(tmp_path: Path) -> None:
     assert payload["public_boundary"]["input_paths_recorded"] is False
     assert secret not in completed.stdout
     assert str(tmp_path) not in completed.stdout
+
+
+def _permitted_attestation() -> dict[str, object]:
+    attestation = _attestation()
+    attestation.pop("shell_network_denied")
+    attestation["network_permitted_solving"] = True
+    return attestation
+
+
+def _permitted_policy() -> dict[str, object]:
+    return {
+        "schema_version": BENCHMARK_INTEGRITY_POLICY_SCHEMA_VERSION,
+        "policy_id": "widesearch-permitted-solving",
+        "network_access": "permitted_solving",
+    }
+
+
+def test_permitted_solving_network_policy_qualifies_web_research_trajectory() -> None:
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(
+            command="curl -fsS https://example.invalid/probe",
+            observation="html page",
+        ),
+        runtime_attestation=_permitted_attestation(),
+        policy=_permitted_policy(),
+    )
+
+    assert receipt["integrity_qualified"] is True
+    assert receipt["integrity_countable"] is True
+    assert receipt["network_access"] == "permitted_solving"
+    assert receipt["evidence_counts"]["external_network_request"] == 1
+    assert receipt["blockers"] == []
+
+
+def test_permitted_solving_network_policy_still_fails_on_restricted_access() -> None:
+    trajectory = _trajectory(
+        command="curl -fsS https://example.invalid && cat /private/evaluator/solution/solution.patch"
+    )
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=trajectory,
+        runtime_attestation=_permitted_attestation(),
+        policy=_permitted_policy(),
+    )
+
+    assert receipt["integrity_qualified"] is False
+    assert receipt["classification"] == "restricted_evaluation_access_detected"
+    assert receipt["benchmark_cheating_detected"] is True
+    assert receipt["evidence_counts"]["restricted_answer_source_request"] == 1
+
+
+def test_permitted_solving_policy_requires_network_permitted_attestation() -> None:
+    attestation = _attestation()
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(command="curl -fsS https://example.invalid"),
+        runtime_attestation=attestation,
+        policy=_permitted_policy(),
+    )
+
+    assert receipt["integrity_qualified"] is False
+    assert "runtime_attestation_network_permitted_solving_missing" in receipt["blockers"]
+    assert receipt["classification"] == "runtime_isolation_not_attested"
+
+
+def test_unsupported_network_access_mode_is_rejected() -> None:
+    with pytest.raises(ValueError, match="network_access"):
+        build_benchmark_integrity_qualification(
+            trajectory=_trajectory(),
+            runtime_attestation=_permitted_attestation(),
+            policy={
+                "schema_version": BENCHMARK_INTEGRITY_POLICY_SCHEMA_VERSION,
+                "policy_id": "bad-mode",
+                "network_access": "always",
+            },
+        )


### PR DESCRIPTION
## Summary
`integrity-qualification` previously hard-coded `shell_network_denied` and treated any external network request as a policy violation — correct for offline coding benchmarks (SWE-bench/terminal-bench) but it rejects legitimate web-research benchmarks (e.g. widesearch) where the solving agent must fetch web pages.

Add an optional `network_access` policy mode:
- `denied` (default): unchanged behavior; runner attests `shell_network_denied`, external network evidence fails the run.
- `permitted_solving`: runner attests `network_permitted_solving` instead; external network requests are recorded as evidence but do not fail the run. Restricted answer/hidden-test/verifier/other-trial/controller/host/credential denials remain fail-closed in both modes.

The receipt exposes the resolved `network_access` and the attestation checks that applied for that mode.

## Validation
- 54 tests pass in `tests/capabilities/test_benchmark_toolkit.py` (4 new: permitted mode qualifies a web-research trajectory; restricted access still fails in permitted mode; `network_permitted_solving` attestation required; unsupported mode rejected).
- Public-safe scan clean on all changed surfaces.

## Scope
Narrow benchmark-toolkit control-plane contract + docs + tests. No benchmark jobs launched, no scoring change for existing benchmarks, no credentials/private state.