### PR TITLE
docs(lark): generalize scope bundle provenance

### DIFF
--- a/loopx/extensions/lark/bot_scopes.py
+++ b/loopx/extensions/lark/bot_scopes.py
@@ -1,11 +1,10 @@
 """Recommended Lark (Feishu) API scope bundle for a LoopX project bot.
 
 Each new LoopX Lark bot (e.g. a Goal Channel sender) should apply this bundle
-once instead of adding scopes reactively. The bundle is derived from two real
-bots: ``Ark-Flow LoopX`` (slash-command / card / docs-comment sink) and
-``LoopX 管家`` (Goal Channel + event inbox + kanban). ``core`` covers Goal
-Channel, reviewer notification and kanban; ``inbox`` adds message ingestion;
-``sink`` adds interactive cards and docs comments.
+once instead of adding scopes reactively. The bundle is derived from production
+Goal Channel, event-inbox, kanban, slash-command, card and docs-comment use.
+``core`` covers Goal Channel, reviewer notification and kanban; ``inbox`` adds
+message ingestion; ``sink`` adds interactive cards and docs comments.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

- describe the recommended bot scope bundle through its product use cases
- remove deployment-specific identity examples from the public module documentation
- leave runtime scope behavior unchanged

## Validation

- `python3 -m py_compile loopx/extensions/lark/bot_scopes.py`
- `python3 -m pytest -q tests/test_contract_credential_pattern_precision.py` (23 passed)
- `scripts/loopx --format json check --scan-root .` (`ok=true`, zero errors)
- focused public/private wording scan on the changed file
