### PR TITLE
feat(benchmark): harden widesearch runner and verifier reward contract

### DIFF
--- a/benchmark/widesearch/README.md
+++ b/benchmark/widesearch/README.md
@@ -47,6 +47,38 @@ uv run --python 3.12 --with dateparser==1.2.2 \
 模型凭据：`ARK_OPENAI_BASE_URL` / `ARK_OPENAI_API_KEY` / `ARK_OPENAI_MODEL`
 （本地可从 cc-switch `volcengine-ark-deepseek` 读取）。
 
+## Hosted Responses API 兼容（重要）
+
+本地 `codex app-server` 默认会发送 `multi_agent_v1` 动态工具命名空间；部分
+hosted Responses 端点会拒绝 `namespace` 工具类型（`unknown tool type:
+namespace`）。runner 已默认带 `-c features.multi_agent=false` 保持工具面最小且
+provider-neutral，同时保留 goal 工具。部分端点还会拒绝 web_search 的
+`external_web_access` 字段，可用 `--disable-web-search` 关闭原生 web_search
+工具（agent 改用 shell 联网，配合真沙盒网络策略）。
+
+## 真沙盒（pier/colima）跑法
+
+`benchmark/widesearch/pier/` 提供可复用的 pier 任务模板（task.toml、agent
+image、verifier image、verifier test.sh、job.yaml）。要点：
+
+- **workspace/jobs_dir 必须放 `$HOME` 下**：colima 不 bind-mount macOS 的
+  `/tmp`，verifier 目录挂到 `/logs/verifier` 会静默失败，导致 reward 永远回
+  不到宿主。
+- **verifier 镜像需 `WORKDIR /app`**：pier 用 `docker compose cp` 把答案放
+  进 verifier 容器，`/app` 必须存在。
+- **verifier 的 reward.json 必须纯数值**：pier 的 `VerifierResult` 只收
+  `dict[str, float | int]`，字符串 detail 字段会触发校验错误。提交前可用：
+
+  ```bash
+  loopx benchmark verify-verifier-reward /path/to/reward.json --require-valid
+  ```
+
+  或用 Python API `verify_verifier_reward_json`。
+- **gold 只给 verifier**：evaluator 在 separate verifier 环境运行，agent 镜像
+  里不含 gold。
+- **agent 镜像 `/bin/sh` 需是 bash**：pier 用 `set -o pipefail` 执行 agent
+  setup，Debian 默认 dash 不支持（`ln -sf /usr/bin/bash /bin/sh`）。
+
 ## 测试
 
 ```bash

--- a/benchmark/widesearch/pier/README.md
+++ b/benchmark/widesearch/pier/README.md
@@ -1,0 +1,43 @@
+# WideSearch real-sandbox templates (pier)
+
+Reusable, provider-neutral pier wiring for the WideSearch real-sandbox path.
+Copy these templates into a local pier dataset root and fill the `<PLACEHOLDER>`
+values. Do not commit credentials, local absolute paths, raw runs, or verifier
+output; inject secrets through the job environment at runtime.
+
+Layout expected by pier (task root):
+
+```text
+<task-root>/
+  task.toml            <- task.toml.template
+  environment/
+    Dockerfile         <- environment/Dockerfile.template
+  tests/
+    Dockerfile         <- tests/Dockerfile.template
+    test.sh            <- tests/test.sh.template
+    widesearch_evaluator.py
+    <gold.csv>
+  instruction.md
+```
+
+Key wiring facts:
+
+- Workspace and `jobs_dir` must live under `$HOME`: colima does not bind-mount
+  macOS `/tmp`, so the verifier's `/logs/verifier` bind mount silently fails
+  there and the reward never returns to the host.
+- The verifier image must create `/app` (`WORKDIR /app`) because pier copies the
+  answer artifact into the verifier container with `docker compose cp`.
+- `test.sh` writes `reward.json` with numeric-only values. Pier's
+  `VerifierResult` is `dict[str, float | int]`; a string detail field fails the
+  trial. Validate before writing with
+  `loopx benchmark verify-verifier-reward <reward.json> --require-valid`.
+- The agent image must have `/bin/sh` symlinked to bash (`set -o pipefail` is
+  used by the pier agent setup; Debian dash does not support it).
+- Gold lives only in the verifier image; the agent image never contains it.
+
+Model credentials: for countable runs the agent image should reach the hosted
+model through a local gateway so the API key is not shell-readable in the
+container (matching `provider_credential_shell_excluded` in the integrity
+attestation). Use `network_access: "permitted_solving"` in the integrity policy
+for web-research benchmarks (see
+`loopx.capabilities.benchmark_toolkit.integrity`).

--- a/benchmark/widesearch/pier/environment/Dockerfile.template
+++ b/benchmark/widesearch/pier/environment/Dockerfile.template
@@ -1,0 +1,8 @@
+# Agent image for the WideSearch pier sandbox.
+# Replace <BASE_IMAGE> with an image that ships codex + loopx + python3.
+# The /bin/sh -> bash link is required because pier runs agent setup with
+# `set -o pipefail`, which dash (Debian's default /bin/sh) does not support.
+FROM <BASE_IMAGE>
+RUN ln -sf /usr/bin/bash /bin/sh
+WORKDIR /app
+CMD ["/bin/bash"]

--- a/benchmark/widesearch/pier/job.yaml.template
+++ b/benchmark/widesearch/pier/job.yaml.template
@@ -1,0 +1,44 @@
+# Pier job for the WideSearch real-sandbox path.
+# - Keep jobs_dir / datasets under $HOME: colima does not bind-mount macOS
+#   /tmp, so verifier bind mounts of /logs/verifier silently fail there.
+# - Inject model credentials through the environment; do not bake secrets into
+#   the job file. For countable runs the agent image should reach the model
+#   through a local gateway so the key is not shell-readable in the container.
+job_name: widesearch-<RUN_LABEL>
+jobs_dir: <JOBS_DIR_UNDER_HOME>
+n_attempts: 1
+n_concurrent_trials: 1
+quiet: false
+debug: true
+environment:
+  type: docker
+agents:
+  - name: codex
+    model_name: <MODEL_NAME>
+    kwargs:
+      command_model_name: <MODEL_NAME>
+      config_toml: |
+        model = "<MODEL_NAME>"
+        model_provider = "custom"
+        sandbox_mode = "danger-full-access"
+        approval_policy = "never"
+        [model_providers.custom]
+        name = "hosted-responses"
+        base_url = "<MODEL_BASE_URL>"
+        env_key = "OPENAI_API_KEY"
+        wire_api = "responses"
+        [tools]
+        web_search = true
+    env:
+      OPENAI_BASE_URL: "<MODEL_BASE_URL>"
+      OPENAI_API_KEY: "<INJECT_VIA_RUNTIME_ENV>"
+datasets:
+  - path: <DATASET_ROOT_UNDER_HOME>
+    task_names: ["<CASE_ID>"]
+artifacts:
+  - /app/final_answer.md
+verifier:
+  env:
+    JUDGE_BASE_URL: "<JUDGE_BASE_URL>"
+    JUDGE_MODEL: "<JUDGE_MODEL>"
+    JUDGE_API_KEY: "<INJECT_VIA_RUNTIME_ENV>"

--- a/benchmark/widesearch/pier/task.toml.template
+++ b/benchmark/widesearch/pier/task.toml.template
@@ -1,0 +1,38 @@
+schema_version = "1.1"
+artifacts = ["/app/final_answer.md"]
+
+[task]
+name = "widesearch/<CASE_ID>"
+description = "Web research table task."
+
+[metadata]
+task_id = "<CASE_ID>"
+display_title = "Web research table"
+category = "research"
+
+[verifier]
+environment_mode = "separate"
+timeout_sec = 1800.0
+
+# LLM judge for the evaluator's free-text columns; inject via the pier job.
+[verifier.env]
+JUDGE_BASE_URL = "<JUDGE_BASE_URL>"
+JUDGE_MODEL = "<JUDGE_MODEL>"
+
+[verifier.environment]
+build_timeout_sec = 1800.0
+cpus = 2
+memory_mb = 4096
+allow_internet = true
+
+[agent]
+timeout_sec = 5400.0
+
+[environment]
+build_timeout_sec = 1800.0
+docker_image = "<AGENT_IMAGE>"
+os = "linux"
+cpus = 2
+memory_mb = 8192
+gpus = 0
+allow_internet = true

--- a/benchmark/widesearch/pier/tests/Dockerfile.template
+++ b/benchmark/widesearch/pier/tests/Dockerfile.template
@@ -1,0 +1,10 @@
+# Verifier image (separate environment; the agent never sees this image).
+# WORKDIR /app must exist so pier can `docker compose cp` the answer artifact
+# into the verifier container.
+FROM python:3.11-slim
+WORKDIR /app
+RUN pip install --no-cache-dir dateparser==1.2.2
+COPY test.sh /tests/test.sh
+COPY widesearch_evaluator.py /tests/widesearch_evaluator.py
+COPY <GOLD_CSV> /tests/gold.csv
+RUN chmod +x /tests/test.sh

--- a/benchmark/widesearch/pier/tests/test.sh.template
+++ b/benchmark/widesearch/pier/tests/test.sh.template
@@ -1,0 +1,58 @@
+#!/bin/bash
+# WideSearch verifier: runs the official evaluator against the sealed answer.
+# Writes reward.json with numeric-only values (pier VerifierResult contract).
+set -uo pipefail
+mkdir -p /logs/verifier
+log() { echo "[verifier] $*"; }
+ANSWER=/app/final_answer.md
+GOLD=/tests/gold.csv
+TASK=/tests/task.json
+if [ ! -f "$ANSWER" ]; then
+  echo -1 > /logs/verifier/reward.txt
+  log "final_answer.md missing"
+  exit 0
+fi
+python3 - /tests/evaluator.py <<'PYEOF'
+import json, sys
+answer = sys.argv[1]
+task = {
+  "schema_version": "vebench.widesearch.task.v1",
+  "case_id": "ws_en_001",
+  "evaluation": {
+    "unique_columns": ["subject", "university"],
+    "required": ["subject","university","qsworlduniversityrankingsbysubject2025","qsworlduniversityrankings2025","timeshighereducationworlduniversityrankings2025","homepage","applicationdeadline","applicationfee"],
+    "eval_pipeline": {
+      "subject": {"preprocess": ["norm_str"], "metric": ["in_match"]},
+      "university": {"preprocess": ["norm_str"], "metric": ["in_match"]},
+      "qsworlduniversityrankingsbysubject2025": {"preprocess": ["norm_str"], "metric": ["in_match"]},
+      "qsworlduniversityrankings2025": {"preprocess": ["norm_str"], "metric": ["in_match"]},
+      "timeshighereducationworlduniversityrankings2025": {"preprocess": ["norm_str"], "metric": ["in_match"]},
+      "homepage": {"preprocess": ["norm_str"], "metric": ["in_match"]},
+      "applicationdeadline": {"preprocess": ["norm_str"], "metric": ["llm_judge"], "criterion": "Approximately the same semantics as the reference."},
+      "applicationfee": {"preprocess": ["norm_str"], "metric": ["llm_judge"], "criterion": "Approximately the same semantics as the reference."}
+    }
+  }
+}
+json.dump(task, open("/tests/task.json","w"), ensure_ascii=False)
+PYEOF
+log "running evaluator"
+python3 /tests/evaluator.py \
+  --task "$TASK" --gold "$GOLD" --answer "$ANSWER" \
+  --case-id ws_en_001 --benchmark-id widesearch > /tmp/result.json 2>/tmp/result.err
+rc=$?
+if [ $rc -ne 0 ]; then
+  echo -1 > /logs/verifier/reward.txt
+  log "evaluator failed rc=$rc"
+  exit 0
+fi
+python3 - <<'PYEOF'
+import json
+r = json.load(open("/tmp/result.json"))
+score = float(r.get("score", 0.0))
+# Numeric-only reward payload (pier VerifierResult requires all-numeric values).
+json.dump(
+    {"reward": score, "score": score, "success_rate": r.get("metrics", {}).get("success_rate")},
+    open("/logs/verifier/reward.json", "w"),
+)
+PYEOF
+log "reward written"

--- a/benchmark/widesearch/run_widesearch_case.py
+++ b/benchmark/widesearch/run_widesearch_case.py
@@ -39,6 +39,31 @@ def _objective(case_id: str, workspace: Path, instruction: str, treatment: bool)
     )
 
 
+def _app_server_command(*, codex_bin: str, enable_web_search: bool) -> list[str]:
+    """Build the app-server Goal command with hosted Responses API compatibility.
+
+    The codex app-server emits a ``multi_agent_v1`` dynamic-tool namespace by
+    default; some hosted Responses endpoints reject ``namespace`` tool types.
+    Disabling the multi-agent feature keeps the Goal tool surface minimal and
+    provider-neutral while preserving the goal tools (get/create/update_goal)
+    that the benchmark needs. Web search is toggled independently because some
+    hosted endpoints also reject the ``external_web_access`` web_search field.
+    """
+
+    command = [
+        codex_bin,
+        "app-server",
+        "--listen",
+        "stdio://",
+        "--enable",
+        "goals",
+        "-c",
+        "features.multi_agent=false",
+    ]
+    command += ["-c", "tools.web_search=true" if enable_web_search else "tools.web_search=false"]
+    return command
+
+
 def _native_goal_modules():
     sys.path.insert(0, str(REPO_ROOT))
     from loopx.capabilities.benchmark_toolkit.native_codex_goal import (  # noqa: PLC0415
@@ -56,6 +81,7 @@ def run_case(
     arm: str,
     data_root: Path,
     timeout_sec: int,
+    enable_web_search: bool = True,
 ) -> dict:
     raw = data_root / "widesearch.jsonl"
     gold_dir = data_root / "gold"
@@ -81,16 +107,10 @@ def run_case(
     turn = run_native(
         config,
         codex_bin=os.environ.get("CODEX_BIN", "codex"),
-        process_command=[
-            os.environ.get("CODEX_BIN", "codex"),
-            "app-server",
-            "--listen",
-            "stdio://",
-            "--enable",
-            "goals",
-            "-c",
-            "tools.web_search=true",
-        ],
+        process_command=_app_server_command(
+            codex_bin=os.environ.get("CODEX_BIN", "codex"),
+            enable_web_search=enable_web_search,
+        ),
         process_env={**os.environ},
         process_cwd=str(workspace),
         goal_timeout_sec=timeout_sec,
@@ -115,12 +135,21 @@ def main() -> int:
     p.add_argument("--case", default="ws_en_001")
     p.add_argument("--data-root", type=Path, required=True)
     p.add_argument("--timeout-sec", type=int, default=7200)
+    p.add_argument(
+        "--disable-web-search",
+        action="store_true",
+        help=(
+            "Disable the native web_search tool in the app-server Goal config "
+            "(some hosted Responses endpoints reject its external_web_access field)."
+        ),
+    )
     args = p.parse_args()
     outcome = run_case(
         case_id=args.case,
         arm=args.arm,
         data_root=args.data_root,
         timeout_sec=args.timeout_sec,
+        enable_web_search=not args.disable_web_search,
     )
     print(json.dumps(outcome, ensure_ascii=False, sort_keys=True))
     return 0 if outcome["status"] == "completed" else 2

--- a/benchmark/widesearch/tests/test_run_config.py
+++ b/benchmark/widesearch/tests/test_run_config.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_runner() -> object:
+    path = Path(__file__).resolve().parents[1] / "run_widesearch_case.py"
+    sys.path.insert(0, str(path.parent))
+    spec = importlib.util.spec_from_file_location("run_widesearch_case", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_app_server_command_disables_multi_agent_for_responses_compat() -> None:
+    mod = _load_runner()
+    command = mod._app_server_command(codex_bin="codex", enable_web_search=True)
+    assert "features.multi_agent=false" in command
+    assert "tools.web_search=true" in command
+    assert command[0] == "codex"
+
+
+def test_app_server_command_can_disable_web_search() -> None:
+    mod = _load_runner()
+    command = mod._app_server_command(codex_bin="codex", enable_web_search=False)
+    assert "tools.web_search=false" in command
+    assert "tools.web_search=true" not in command

--- a/loopx/capabilities/benchmark_toolkit/__init__.py
+++ b/loopx/capabilities/benchmark_toolkit/__init__.py
@@ -36,6 +36,11 @@ from .integrity import (
     REQUIRED_RUNTIME_ATTESTATIONS,
     build_benchmark_integrity_qualification,
 )
+from .reward_contract import (
+    REWARD_CONTRACT_SCHEMA_VERSION,
+    verify_verifier_reward_file,
+    verify_verifier_reward_json,
+)
 from .native_codex_goal import (
     NativeGoalConfig,
     NativeGoalDeadlineExceeded,
@@ -179,6 +184,8 @@ __all__ = [
     "refresh_native_goal_status",
     "render_benchmark_experiment_board_markdown",
     "render_native_codex_goal_prompt",
+    "verify_verifier_reward_file",
+    "verify_verifier_reward_json",
     "run_native_goal_process",
     "run_native_goal_process_until_terminal",
     "run_native_goal_turn",

--- a/loopx/capabilities/benchmark_toolkit/catalog_entry.py
+++ b/loopx/capabilities/benchmark_toolkit/catalog_entry.py
@@ -88,6 +88,20 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
             "write_boundary": "path classification only; no file reads or writes",
         },
         {
+            "command": (
+                "loopx benchmark verify-verifier-reward <reward.json> "
+                "--require-valid --format json"
+            ),
+            "purpose": (
+                "Validate a verifier reward.json against the numeric-only "
+                "verifier reward contract (pier VerifierResult compatible)."
+            ),
+            "write_boundary": (
+                "read-only local reward file; emits stable counts, labels, and "
+                "reason codes only, never raw reward values"
+            ),
+        },
+        {
             "command": "loopx capability show benchmark-toolkit --format json",
             "purpose": (
                 "Read the post-run analyst hint and benchmark_case_insight_v0 "

--- a/loopx/capabilities/benchmark_toolkit/reward_contract.py
+++ b/loopx/capabilities/benchmark_toolkit/reward_contract.py
@@ -1,0 +1,94 @@
+"""Public-safe verifier reward contract for benchmark runners.
+
+Pier's ``VerifierResult`` models the verifier reward as
+``dict[str, float | int]``. A reward payload that carries string detail fields
+or nested objects fails that schema and turns a completed evaluation into a
+runner error. This module gives a runner one compact, provider-neutral check
+before writing the reward file so a wiring mistake fails fast instead of after
+a long agent run.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+REWARD_CONTRACT_SCHEMA_VERSION = "verifier_reward_contract_v0"
+REWARD_MAX_ENTRIES = 64
+
+
+def _numeric(value: Any) -> bool:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    return not (isinstance(value, float) and (math.isnan(value) or math.isinf(value)))
+
+
+def verify_verifier_reward_json(reward: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate one verifier reward mapping against the numeric-only contract.
+
+    Returns a compact public-safe receipt. Raw reward values are not echoed;
+    only stable counts, labels, and reason codes are emitted.
+    """
+
+    if not isinstance(reward, Mapping):
+        return {
+            "ok": False,
+            "schema_version": REWARD_CONTRACT_SCHEMA_VERSION,
+            "valid": False,
+            "reason_code": "reward_not_object",
+            "entry_count": 0,
+            "invalid_keys": [],
+        }
+    entries = dict(reward)
+    invalid_keys = [
+        str(key) for key, value in entries.items() if not _numeric(value)
+    ]
+    too_many = len(entries) > REWARD_MAX_ENTRIES
+    valid = not invalid_keys and not too_many
+    return {
+        "ok": valid,
+        "schema_version": REWARD_CONTRACT_SCHEMA_VERSION,
+        "valid": valid,
+        "reason_code": (
+            "ok"
+            if valid
+            else "reward_non_numeric_values"
+            if invalid_keys
+            else "reward_too_many_entries"
+        ),
+        "entry_count": len(entries),
+        "invalid_keys": sorted(invalid_keys),
+    }
+
+
+def verify_verifier_reward_file(path: str | Path) -> dict[str, Any]:
+    """Read one reward.json path and validate it against the numeric contract.
+
+    The file content is parsed in memory and never copied into the returned
+    receipt. Missing or malformed JSON is reduced to a fail-closed reason code.
+    """
+
+    try:
+        payload = json.loads(Path(path).expanduser().read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {
+            "ok": False,
+            "schema_version": REWARD_CONTRACT_SCHEMA_VERSION,
+            "valid": False,
+            "reason_code": "reward_file_missing",
+            "entry_count": 0,
+            "invalid_keys": [],
+        }
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return {
+            "ok": False,
+            "schema_version": REWARD_CONTRACT_SCHEMA_VERSION,
+            "valid": False,
+            "reason_code": "reward_file_invalid",
+            "entry_count": 0,
+            "invalid_keys": [],
+        }
+    return verify_verifier_reward_json(payload)

--- a/loopx/cli_commands/benchmark_boundary.py
+++ b/loopx/cli_commands/benchmark_boundary.py
@@ -17,6 +17,7 @@ from ..capabilities.benchmark_toolkit import (
     compact_benchmark_source_revision_fence_receipt,
     filter_public_benchmark_artifact_paths,
     inspect_benchmark_source_revision_fence,
+    verify_verifier_reward_file,
 )
 
 PrintPayload = Callable[
@@ -30,6 +31,7 @@ BENCHMARK_TOOLKIT_COMMANDS = {
     "classify-artifacts",
     "integrity-qualification",
     "source-revision-fence",
+    "verify-verifier-reward",
 }
 
 
@@ -137,6 +139,14 @@ def register_benchmark_boundary_commands(
     integrity_parser.add_argument("--sensitive-value-env", action="append", default=[])
     integrity_parser.add_argument("--require-qualified", action="store_true")
 
+    reward_parser = benchmark_subparsers.add_parser(
+        "verify-verifier-reward",
+        help="Validate a verifier reward.json against the numeric-only contract.",
+    )
+    add_subcommand_format(reward_parser)
+    reward_parser.add_argument("reward_json", help="Path to a verifier reward.json.")
+    reward_parser.add_argument("--require-valid", action="store_true")
+
 
 def _invalid_integrity_input() -> dict[str, object]:
     return {
@@ -156,6 +166,16 @@ def _invalid_integrity_input() -> dict[str, object]:
             "sensitive_values_recorded": False,
         },
     }
+
+
+def _render_reward_contract(payload: dict[str, object]) -> str:
+    return (
+        "# Verifier Reward Contract\n\n"
+        f"- Valid: `{payload.get('valid')}`\n"
+        f"- Reason: `{payload.get('reason_code')}`\n"
+        f"- Entries: `{payload.get('entry_count')}`\n"
+        f"- Invalid keys: `{','.join(payload.get('invalid_keys') or [])}`\n"
+    )
 
 
 def _invalid_source_revision_fence_input() -> dict[str, object]:
@@ -210,6 +230,13 @@ def handle_benchmark_boundary_command(
             payload = _invalid_source_revision_fence_input()
         print_payload(payload, output_format(args), _render_source_revision_fence)
         return 1 if args.require_admitted and not payload.get("admitted") else 0
+
+    if args.benchmark_command == "verify-verifier-reward":
+        if args.reward_json == "-":
+            raise ValueError("verify-verifier-reward requires a file path")
+        payload = verify_verifier_reward_file(args.reward_json)
+        print_payload(payload, output_format(args), _render_reward_contract)
+        return 1 if args.require_valid and not payload.get("valid") else 0
 
     try:
         trajectory = _read_json_object(args.trajectory_json, "--trajectory-json")

--- a/tests/capabilities/test_reward_contract.py
+++ b/tests/capabilities/test_reward_contract.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from loopx.capabilities.benchmark_toolkit.reward_contract import (
+    verify_verifier_reward_file,
+    verify_verifier_reward_json,
+)
+
+
+def test_numeric_reward_passes() -> None:
+    receipt = verify_verifier_reward_json(
+        {"reward": 0.0, "score": 0.0, "success_rate": 0.0}
+    )
+    assert receipt["valid"] is True
+    assert receipt["reason_code"] == "ok"
+    assert receipt["invalid_keys"] == []
+
+
+def test_string_detail_rejected() -> None:
+    receipt = verify_verifier_reward_json(
+        {"reward": 0.0, "detail": "widesearch official evaluator"}
+    )
+    assert receipt["valid"] is False
+    assert receipt["reason_code"] == "reward_non_numeric_values"
+    assert receipt["invalid_keys"] == ["detail"]
+
+
+def test_nested_and_bool_rejected() -> None:
+    receipt = verify_verifier_reward_json({"reward": {"value": 1}})
+    assert receipt["valid"] is False
+    assert receipt["invalid_keys"] == ["reward"]
+
+    receipt_bool = verify_verifier_reward_json({"reward": True})
+    assert receipt_bool["valid"] is False
+
+
+def test_non_finite_float_rejected() -> None:
+    import math
+
+    receipt = verify_verifier_reward_json({"reward": float("nan")})
+    assert receipt["valid"] is False
+
+
+def test_file_round_trip(tmp_path) -> None:
+    good = tmp_path / "reward.json"
+    good.write_text(json.dumps({"reward": 0.0}), encoding="utf-8")
+    assert verify_verifier_reward_file(good)["valid"] is True
+
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps({"reward": "oops"}), encoding="utf-8")
+    assert verify_verifier_reward_file(bad)["valid"] is False
+
+    assert verify_verifier_reward_file(tmp_path / "missing.json")["reason_code"] == (
+        "reward_file_missing"
+    )
+
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text("not json", encoding="utf-8")
+    assert verify_verifier_reward_file(malformed)["reason_code"] == (
+        "reward_file_invalid"
+    )
+
+
+def test_too_many_entries_rejected() -> None:
+    receipt = verify_verifier_reward_json(
+        {f"k{i}": 1.0 for i in range(65)}
+    )
+    assert receipt["valid"] is False
+    assert receipt["reason_code"] == "reward_too_many_entries"
+
+
+def test_non_object_rejected() -> None:
+    receipt = verify_verifier_reward_json([1, 2])  # type: ignore[arg-type]
+    assert receipt["valid"] is False
+    assert receipt["reason_code"] == "reward_not_object"


### PR DESCRIPTION
## Summary
Runnable hardening for the WideSearch benchmark path, provider-neutral and public-safe:

1. **Runner fix** (`benchmark/widesearch/run_widesearch_case.py`): disable the codex app-server `multi_agent` feature (`-c features.multi_agent=false`) — its dynamic `multi_agent_v1` namespace tool is rejected by some hosted Responses endpoints (`unknown tool type: namespace`). Make the native web_search tool toggleable via `--disable-web-search` for endpoints that reject `external_web_access`.

2. **Real-sandbox templates** (`benchmark/widesearch/pier/`): reusable Harbor/pier task wiring — task.toml, agent image (bash `/bin/sh` fix), verifier image (`WORKDIR /app`), numeric-only verifier test.sh, and job.yaml. Documents: keep workspace/jobs under `$HOME` (colima doesn't bind-mount `/tmp`), gold only in the verifier image, and the numeric-only reward contract.

3. **Reward contract validator** (`benchmark_toolkit.reward_contract`): `verify_verifier_reward_json` / `verify_verifier_reward_file` validate a verifier reward against the numeric-only contract (pier `VerifierResult` is `dict[str, float|int]`; a string detail field fails the trial). New CLI: `loopx benchmark verify-verifier-reward <reward.json> --require-valid`.

4. README + catalog entries for the real-sandbox path, ARK Responses compatibility, and the reward contract.

## Validation
- 66 tests pass (7 new reward-contract, 2 new runner-config, existing benchmark_toolkit + widesearch suites).
- CLI smoke: valid reward passes, string-detail reward fails with `reward_non_numeric_values`.
- Public-safe scan clean on every changed surface (no company info, no credentials, no local paths, no raw evidence).

## Scope
Narrow benchmark runner + verifier-contract hardening. No benchmark jobs launched, no scoring change for existing benchmarks, no credentials/private state.