### PR TITLE
feat(capability): unified public-connector registry with value-priority ranking

### DIFF
--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -25,6 +25,7 @@ from .value_connectors.catalog_entry import VALUE_CONNECTORS_CATALOG_ENTRY
 from .explore.catalog_entry import EXPLORE_CATALOG_ENTRY
 from .auto_research.catalog_entry import AUTO_RESEARCH_CATALOG_ENTRY
 from .public_safe_outbound.catalog_entry import PUBLIC_SAFE_OUTBOUND_CATALOG_ENTRY
+from .connector_registry.catalog_entry import CONNECTOR_REGISTRY_CATALOG_ENTRY
 from .registry import CapabilityRegistry
 
 CAPABILITY_CATALOG_SCHEMA_VERSION = "loopx_capability_catalog_v0"
@@ -50,6 +51,7 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
     EXPLORE_CATALOG_ENTRY,
     AUTO_RESEARCH_CATALOG_ENTRY,
     PUBLIC_SAFE_OUTBOUND_CATALOG_ENTRY,
+    CONNECTOR_REGISTRY_CATALOG_ENTRY,
 )
 # Preserve the original import surface while routing all reads through the registry.
 CAPABILITIES = BUILTIN_CAPABILITIES

--- a/loopx/capabilities/connector_registry/README.md
+++ b/loopx/capabilities/connector_registry/README.md
@@ -1,0 +1,40 @@
+# Connector Registry（统一公共连接器注册表）
+
+把 LoopX 消费方（含 finance）会用到的各类 **public connector** 统一管理起来：
+哪些**已支持**、哪些**待支持/被卡**，它们属于哪一层（L0-L5，对齐 finance
+research 的 [docs/16 信源蓝图](../../../finance_research/docs/16-connector-blueprint.md)），
+以及伴随真实使用**演化出的价值优先级**。
+
+## 分层（docs/16）
+
+- L0 基础设施：行情、联网搜索、浏览器抓取、记忆、通知
+- L1 官方披露：巨潮公告、交易所问询/监管
+- L2 资金流：龙虎榜、两融、沪深港通
+- L3 财务：同花顺财务
+- L4 舆情/另类：财联社、雪球、百度指数、公众号
+- L5 付费/专业：Wind/iFinD、Tushare
+
+## 命令
+
+```bash
+loopx connector list --format json      # 全量清单：状态/分层/价值/使用/优先级
+loopx connector rank --format json      # 价值优先级排序
+loopx connector register <id> --status supported --value-tier P0 ...
+loopx connector use <id> --ms 1234      # 记录一次真实调用（成功/耗时）
+```
+
+默认状态文件：`$LOOPX_RUNTIME_ROOT/connector-registry.json`（可用 `--path` 覆盖）。
+
+## 价值优先级演化
+
+每个 connector 记使用次数、成功/失败、累计耗时；优先级分数 =
+价值档位基准（P0=10/P1=6/P2=3）− 待支持/受阻惩罚 + 0.2×成功 − 0.5×失败。
+每次 `connector use` 都会重算分数，`rank` 输出最新排序——这就是"伴随使用
+演化出 connector 价值优先级排序"的机制。
+
+## 与 finance 的对接
+
+- finance 脚本按 connector id 标注数据源（`sina-daily`/`ths-financial`/
+  `ark-web-search`/`ego-browser`…），每次真实调用后 `loopx connector use <id>`。
+- 待支持队列（巨潮公告、龙虎榜、两融、港通）对应 finance 的 P0/P1 建设路线；
+  受阻项（财联社/雪球条款、付费源预算）在 registry 里标 `blocked` + `blocker`。

--- a/loopx/capabilities/connector_registry/README.md
+++ b/loopx/capabilities/connector_registry/README.md
@@ -2,8 +2,7 @@
 
 把 LoopX 消费方（含 finance）会用到的各类 **public connector** 统一管理起来：
 哪些**已支持**、哪些**待支持/被卡**，它们属于哪一层（L0-L5，对齐 finance
-research 的 [docs/16 信源蓝图](../../../finance_research/docs/16-connector-blueprint.md)），
-以及伴随真实使用**演化出的价值优先级**。
+research 的 docs/16 信源蓝图），以及伴随真实使用**演化出的价值优先级**。
 
 ## 分层（docs/16）
 

--- a/loopx/capabilities/connector_registry/__init__.py
+++ b/loopx/capabilities/connector_registry/__init__.py
@@ -1,0 +1,33 @@
+"""Unified public-connector registry for LoopX.
+
+Manages the supported / pending public connectors (layered L0-L5, see the
+finance research docs/16 blueprint), their value tiers, usage counters, and an
+evolving value-priority ranking so any consumer can discover and rank
+connectors in one place.
+"""
+
+from .catalog_entry import CONNECTOR_REGISTRY_CATALOG_ENTRY
+from .core import (
+    BUILTIN_CONNECTOR_CATALOG,
+    CONNECTOR_REGISTRY_SCHEMA_VERSION,
+    default_registry_path,
+    list_connectors,
+    load_connector_registry,
+    rank_connectors,
+    record_connector_use,
+    register_connector,
+    save_connector_registry,
+)
+
+__all__ = [
+    "BUILTIN_CONNECTOR_CATALOG",
+    "CONNECTOR_REGISTRY_CATALOG_ENTRY",
+    "CONNECTOR_REGISTRY_SCHEMA_VERSION",
+    "default_registry_path",
+    "list_connectors",
+    "load_connector_registry",
+    "rank_connectors",
+    "record_connector_use",
+    "register_connector",
+    "save_connector_registry",
+]

--- a/loopx/capabilities/connector_registry/catalog_entry.py
+++ b/loopx/capabilities/connector_registry/catalog_entry.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+CONNECTOR_REGISTRY_CATALOG_ENTRY: dict[str, Any] = {
+    "id": "connector-registry",
+    "origin": "builtin",
+    "visibility": "public",
+    "provider_id": "loopx-core",
+    "documentation": {
+        "source_root": "loopx/capabilities/connector_registry",
+        "site_root": "capabilities/connector-registry",
+        "canonical": "README.md",
+    },
+    "title": "Unified public-connector registry with value-priority ranking",
+    "status": "active-preview",
+    "real_world_anchor": (
+        "the set of public connectors (market data, announcements, capital flow, "
+        "financials, news/alt, paid) that LoopX consumers like finance can use"
+    ),
+    "user_value": (
+        "One place to see which connectors are supported vs pending/blocked, "
+        "their layer (L0-L5), and a usage-driven value-priority ranking."
+    ),
+    "next_real_step": (
+        "run `loopx connector list --format json` to see the catalog and ranking; "
+        "record each real call with `loopx connector use <id>`."
+    ),
+    "entry_command": "loopx connector list --format json",
+    "commands": [
+        {
+            "command": "loopx connector list --format json",
+            "purpose": "List all public connectors with status, layer, value tier, usage, and priority.",
+            "write_boundary": "read-only",
+        },
+        {
+            "command": "loopx connector register <id> --status supported --value-tier P1 ...",
+            "purpose": "Register or update a connector in the local registry.",
+            "write_boundary": "local registry write only",
+        },
+        {
+            "command": "loopx connector use <id> --ok --ms <elapsed-ms>",
+            "purpose": "Record a real connector call so the value-priority ranking evolves.",
+            "write_boundary": "local registry write only",
+        },
+        {
+            "command": "loopx connector rank --format json",
+            "purpose": "Show the value-priority ranking across all connectors.",
+            "write_boundary": "read-only",
+        },
+    ],
+}

--- a/loopx/capabilities/connector_registry/cli.py
+++ b/loopx/capabilities/connector_registry/cli.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from .core import (
+    list_connectors,
+    load_connector_registry,
+    rank_connectors,
+    record_connector_use,
+    register_connector,
+    save_connector_registry,
+)
+
+
+PrintPayload = Callable[[dict[str, object], str, Callable[[dict[str, object]], str]], None]
+AddFormat = Callable[[argparse.ArgumentParser], None]
+FormatSelector = Callable[..., str]
+
+
+def _render_list_markdown(payload: dict[str, object]) -> str:
+    lines = ["# LoopX Connector Registry", ""]
+    summary = payload.get("summary", {})
+    lines.append(f"- supported={summary.get('supported')} pending={summary.get('pending')} blocked={summary.get('blocked')}")
+    lines.append("")
+    lines.append("| id | name | layer | kind | status | value | score | ok/fail |")
+    lines.append("| --- | --- | --- | --- | --- | --- | --- | --- |")
+    for row in payload.get("ranked", []):
+        u = row.get("usage", {})
+        lines.append(
+            f"| {row.get('id')} | {row.get('name')} | {row.get('layer')} | "
+            f"{row.get('kind')} | {row.get('status')} | {row.get('value_tier')} | "
+            f"{row.get('score')} | {u.get('ok', 0)}/{u.get('fail', 0)} |"
+        )
+    return "\n".join(lines)
+
+
+def _render_rank_markdown(payload: dict[str, object]) -> str:
+    lines = ["# LoopX Connector Value Rank", "", "| # | id | value | score | uses |"]
+    lines.append("| --- | --- | --- | --- | --- |")
+    for i, row in enumerate(payload.get("ranked", []), start=1):
+        u = row.get("usage", {})
+        lines.append(
+            f"| {i} | {row.get('id')} | {row.get('value_tier')} | {row.get('score')} | {u.get('count', 0)} |"
+        )
+    return "\n".join(lines)
+
+
+def register_connector_commands(sub, add_subcommand_format: AddFormat) -> None:
+    parser = sub.add_parser("connector", help="Unified public-connector registry")
+    actions = parser.add_subparsers(dest="connector_action", required=True)
+
+    p_list = actions.add_parser("list", help="List connectors with status, layer, value, usage")
+    add_subcommand_format(p_list)
+
+    p_rank = actions.add_parser("rank", help="Show the value-priority ranking")
+    add_subcommand_format(p_rank)
+
+    p_reg = actions.add_parser("register", help="Register or update a connector")
+    p_reg.add_argument("connector_id")
+    p_reg.add_argument("--name")
+    p_reg.add_argument("--layer", choices=["L0", "L1", "L2", "L3", "L4", "L5"])
+    p_reg.add_argument("--kind")
+    p_reg.add_argument("--status", choices=["supported", "pending", "blocked"])
+    p_reg.add_argument("--credential")
+    p_reg.add_argument("--value-tier", choices=["P0", "P1", "P2"])
+    p_reg.add_argument("--purpose")
+    p_reg.add_argument("--blocker")
+    p_reg.add_argument("--path", type=Path)
+    add_subcommand_format(p_reg)
+
+    p_use = actions.add_parser("use", help="Record a connector call")
+    p_use.add_argument("connector_id")
+    p_use.add_argument("--fail", action="store_true")
+    p_use.add_argument("--ms", type=int, default=0)
+    p_use.add_argument("--note")
+    p_use.add_argument("--path", type=Path)
+    add_subcommand_format(p_use)
+
+
+def handle_connector_command(
+    args: argparse.Namespace,
+    *,
+    output_format: FormatSelector,
+    print_payload: PrintPayload,
+) -> int | None:
+    if args.command != "connector":
+        return None
+    action = getattr(args, "connector_action", None)
+    if action == "list":
+        state = load_connector_registry(getattr(args, "path", None))
+        print_payload(list_connectors(state), output_format(args), _render_list_markdown)
+        return 0
+    if action == "rank":
+        state = load_connector_registry(getattr(args, "path", None))
+        print_payload({"schema_version": "connector_registry_v1", "ok": True,
+                       "ranked": rank_connectors(state)}, output_format(args), _render_rank_markdown)
+        return 0
+    if action == "register":
+        state = load_connector_registry(args.path)
+        result = register_connector(
+            state, args.connector_id, name=args.name, layer=args.layer, kind=args.kind,
+            status=args.status, credential=args.credential, value_tier=args.value_tier,
+            purpose=args.purpose, blocker=args.blocker,
+        )
+        merged = {**state, "connectors": result["connectors"], "usage": result["usage_map"],
+                  "updated_at": result["updated_at"]}
+        save_connector_registry(merged, args.path)
+        print_payload(result, output_format(args), lambda p: f"registered: {args.connector_id}")
+        return 0
+    if action == "use":
+        state = load_connector_registry(args.path)
+        try:
+            result = record_connector_use(state, args.connector_id, ok=not args.fail,
+                                          ms=args.ms, manual_note=args.note)
+        except KeyError as exc:
+            print_payload({"ok": False, "error": str(exc)}, output_format(args),
+                          lambda p: f"error: {p['error']}")
+            return 1
+        merged = {**state, "connectors": result["connectors"], "usage": result["usage_map"],
+                  "updated_at": result["updated_at"]}
+        save_connector_registry(merged, args.path)
+        print_payload(result, output_format(args), lambda p: f"recorded {p['connector_id']} ok={not args.fail}")
+        return 0
+    return None

--- a/loopx/capabilities/connector_registry/core.py
+++ b/loopx/capabilities/connector_registry/core.py
@@ -1,0 +1,246 @@
+"""Connector registry core: catalog, durable state, usage, value ranking."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+
+CONNECTOR_REGISTRY_SCHEMA_VERSION = "connector_registry_v1"
+LAYER_LABELS = {
+    "L0": "infra",
+    "L1": "official",
+    "L2": "capital-flow",
+    "L3": "financial",
+    "L4": "sentiment-alt",
+    "L5": "paid-professional",
+}
+VALUE_BASE = {"P0": 10.0, "P1": 6.0, "P2": 3.0}
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+BUILTIN_CONNECTOR_CATALOG: list[dict[str, Any]] = [
+    # L0 基础设施
+    {"id": "sina-daily", "name": "新浪日线行情", "layer": "L0", "kind": "market_data",
+     "status": "supported", "credential": None, "value_tier": "P1",
+     "purpose": "A股日线/技术信号（sina_utils / fetch_daily / signals）"},
+    {"id": "ths-financial", "name": "同花顺财务摘要", "layer": "L3", "kind": "financial",
+     "status": "supported", "credential": None, "value_tier": "P1",
+     "purpose": "resilience/filing 财务观察（fetch_financials）"},
+    {"id": "ark-web-search", "name": "ARK 联网搜索", "layer": "L0", "kind": "search",
+     "status": "supported", "credential": "ark", "value_tier": "P1",
+     "purpose": "web_search 查询规划+综合（ark_search.py，密钥仅进程内）"},
+    {"id": "ego-browser", "name": "ego-browser 网页抓取", "layer": "L0", "kind": "fetch",
+     "status": "supported", "credential": None, "value_tier": "P1",
+     "purpose": "真浏览器检索/抓取（公告核实等）"},
+    {"id": "openviking", "name": "OpenViking 记忆/向量", "layer": "L0", "kind": "memory",
+     "status": "supported", "credential": None, "value_tier": "P2",
+     "purpose": "reward-memory / 经验召回"},
+    {"id": "lark-notify", "name": "飞书通知", "layer": "L0", "kind": "notification",
+     "status": "supported", "credential": "lark", "value_tier": "P1",
+     "purpose": "goal-channel 候选通知与确认"},
+    # L1 官方披露
+    {"id": "cninfo-announcement", "name": "巨潮公告", "layer": "L1", "kind": "announcement",
+     "status": "pending", "credential": None, "value_tier": "P0",
+     "purpose": "官方公告流 → filing/事件标记（接口已实测可达）"},
+    {"id": "exchange-disclosures", "name": "交易所披露（问询/监管函）", "layer": "L1",
+     "kind": "announcement", "status": "pending", "credential": None, "value_tier": "P0",
+     "purpose": "问询/处罚等监管事件"},
+    # L2 资金流
+    {"id": "capital-flow-lhb", "name": "龙虎榜", "layer": "L2", "kind": "capital_flow",
+     "status": "pending", "credential": None, "value_tier": "P0",
+     "purpose": "机构席位异动 → 时机确认"},
+    {"id": "capital-flow-margin", "name": "两融余额", "layer": "L2", "kind": "capital_flow",
+     "status": "pending", "credential": None, "value_tier": "P1",
+     "purpose": "杠杆资金异动"},
+    {"id": "capital-flow-connect", "name": "沪深港通持股", "layer": "L2", "kind": "capital_flow",
+     "status": "pending", "credential": None, "value_tier": "P1",
+     "purpose": "北向持股变化"},
+    # L4 舆情/另类
+    {"id": "cls-telegraph", "name": "财联社电报", "layer": "L4", "kind": "news",
+     "status": "blocked", "credential": None, "value_tier": "P2",
+     "purpose": "快讯（仅确认信号）", "blocker": "抓取条款/合规"},
+    {"id": "xueqiu-sentiment", "name": "雪球/股吧情绪", "layer": "L4", "kind": "sentiment",
+     "status": "blocked", "credential": None, "value_tier": "P2",
+     "purpose": "情绪确认信号", "blocker": "反爬/条款"},
+    {"id": "baidu-index", "name": "百度指数热度", "layer": "L4", "kind": "alt",
+     "status": "pending", "credential": None, "value_tier": "P2",
+     "purpose": "关注度（另类）"},
+    {"id": "wechat-articles", "name": "微信公众号信源", "layer": "L4", "kind": "news",
+     "status": "pending", "credential": None, "value_tier": "P2",
+     "purpose": "行业/公司深度"},
+    # L5 付费/专业
+    {"id": "wind-ifind", "name": "Wind/iFinD/Choice", "layer": "L5", "kind": "financial",
+     "status": "blocked", "credential": "paid", "value_tier": "P2",
+     "purpose": "专业财务/数据", "blocker": "账号/预算"},
+    {"id": "tushare-pro", "name": "Tushare 积分", "layer": "L5", "kind": "financial",
+     "status": "blocked", "credential": "paid", "value_tier": "P2",
+     "purpose": "结构化数据", "blocker": "积分/预算"},
+]
+
+
+def default_registry_path() -> Path:
+    runtime_root = Path(os.environ.get("LOOPX_RUNTIME_ROOT") or (Path.home() / ".codex" / "loopx"))
+    return runtime_root / "connector-registry.json"
+
+
+def _catalog_index() -> dict[str, dict[str, Any]]:
+    return {c["id"]: dict(c) for c in BUILTIN_CONNECTOR_CATALOG}
+
+
+def _fresh_usage(connector: Mapping[str, Any]) -> dict[str, Any]:
+    tier = str(connector.get("value_tier") or "P2")
+    return {"count": 0, "ok": 0, "fail": 0, "total_ms": 0, "last_used_at": None,
+            "score": VALUE_BASE.get(tier, 3.0), "manual_note": None}
+
+
+def _new_state() -> dict[str, Any]:
+    connectors = [dict(c) for c in BUILTIN_CONNECTOR_CATALOG]
+    usage = {c["id"]: _fresh_usage(c) for c in connectors}
+    return {"schema_version": CONNECTOR_REGISTRY_SCHEMA_VERSION, "updated_at": _now_iso(),
+            "connectors": connectors, "usage": usage}
+
+
+def load_connector_registry(path: Path | None = None) -> dict[str, Any]:
+    state_path = path or default_registry_path()
+    state = _new_state()
+    if state_path.exists():
+        try:
+            raw = json.loads(state_path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict) and isinstance(raw.get("connectors"), list):
+                state = raw
+        except (OSError, ValueError):
+            pass
+    # Re-sync against the builtin catalog, preserving any stored usage.
+    catalog = _catalog_index()
+    merged_connectors: list[dict[str, Any]] = []
+    usage = state.get("usage") if isinstance(state.get("usage"), dict) else {}
+    merged_usage: dict[str, dict[str, Any]] = {}
+    for c in BUILTIN_CONNECTOR_CATALOG:
+        merged_connectors.append(dict(c))
+        merged_usage[c["id"]] = {**(_fresh_usage(c)), **(usage.get(c["id"]) or {})}
+    seen = {c["id"] for c in BUILTIN_CONNECTOR_CATALOG}
+    for stored in state.get("connectors", []):
+        cid = str(stored.get("id") or "")
+        if cid and cid not in seen:
+            merged_connectors.append(dict(stored))
+            merged_usage[cid] = usage.get(cid) or _fresh_usage(stored)
+    return {"schema_version": CONNECTOR_REGISTRY_SCHEMA_VERSION, "updated_at": state.get("updated_at"),
+            "connectors": merged_connectors, "usage": merged_usage}
+
+
+def save_connector_registry(state: Mapping[str, Any], path: Path | None = None) -> Path:
+    state_path = path or default_registry_path()
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(dict(state), ensure_ascii=False, indent=2))
+    return state_path
+
+
+def _score(usage: Mapping[str, Any], connector: Mapping[str, Any]) -> float:
+    tier = str(connector.get("value_tier") or "P2")
+    base = VALUE_BASE.get(tier, 3.0)
+    status = str(connector.get("status") or "pending")
+    status_penalty = 0.0 if status == "supported" else 2.0
+    return round(base - status_penalty + 0.2 * int(usage.get("ok") or 0)
+                 - 0.5 * int(usage.get("fail") or 0), 2)
+
+
+def rank_connectors(state: Mapping[str, Any]) -> list[dict[str, Any]]:
+    rows = []
+    for c in state.get("connectors", []):
+        u = state.get("usage", {}).get(c["id"], {})
+        rows.append({**c, "score": _score(u, c), "usage": u})
+    rows.sort(key=lambda r: (-r["score"], r["value_tier"], r["id"]))
+    return rows
+
+
+def list_connectors(state: Mapping[str, Any]) -> dict[str, Any]:
+    ranked = rank_connectors(state)
+    supported = [r for r in ranked if r["status"] == "supported"]
+    pending = [r for r in ranked if r["status"] == "pending"]
+    blocked = [r for r in ranked if r["status"] == "blocked"]
+    return {
+        "schema_version": CONNECTOR_REGISTRY_SCHEMA_VERSION,
+        "ok": True,
+        "ranked": ranked,
+        "supported": supported,
+        "pending": pending,
+        "blocked": blocked,
+        "summary": {"supported": len(supported), "pending": len(pending), "blocked": len(blocked)},
+    }
+
+
+def register_connector(
+    state: Mapping[str, Any],
+    connector_id: str,
+    *,
+    name: str | None = None,
+    layer: str | None = None,
+    kind: str | None = None,
+    status: str | None = None,
+    credential: str | None = None,
+    value_tier: str | None = None,
+    purpose: str | None = None,
+    blocker: str | None = None,
+) -> dict[str, Any]:
+    connectors = list(state.get("connectors", []))
+    entry = next((c for c in connectors if c.get("id") == connector_id), None)
+    if entry is None:
+        entry = {"id": connector_id, "status": "pending", "value_tier": "P2",
+                 "layer": layer or "L0", "name": name or connector_id}
+        connectors.append(entry)
+    if name is not None:
+        entry["name"] = name
+    if layer is not None:
+        entry["layer"] = layer
+    if kind is not None:
+        entry["kind"] = kind
+    if status is not None:
+        entry["status"] = status
+    if credential is not None:
+        entry["credential"] = credential
+    if value_tier is not None:
+        entry["value_tier"] = value_tier
+    if purpose is not None:
+        entry["purpose"] = purpose
+    if blocker is not None:
+        entry["blocker"] = blocker
+    usage = dict(state.get("usage", {}))
+    usage.setdefault(connector_id, _fresh_usage(entry))
+    return {"schema_version": CONNECTOR_REGISTRY_SCHEMA_VERSION, "ok": True,
+            "connector": entry, "usage": usage[connector_id],
+            "connectors": connectors, "usage_map": usage,
+            "updated_at": _now_iso()}
+
+
+def record_connector_use(
+    state: Mapping[str, Any],
+    connector_id: str,
+    *,
+    ok: bool = True,
+    ms: int = 0,
+    manual_note: str | None = None,
+) -> dict[str, Any]:
+    connectors = list(state.get("connectors", []))
+    entry = next((c for c in connectors if c.get("id") == connector_id), None)
+    if entry is None:
+        raise KeyError(f"unknown connector: {connector_id}")
+    usage = {k: dict(v) for k, v in (state.get("usage", {}) or {}).items()}
+    u = usage.setdefault(connector_id, _fresh_usage(entry))
+    u["count"] = int(u.get("count") or 0) + 1
+    u["ok"] = int(u.get("ok") or 0) + (1 if ok else 0)
+    u["fail"] = int(u.get("fail") or 0) + (0 if ok else 1)
+    u["total_ms"] = int(u.get("total_ms") or 0) + int(ms or 0)
+    u["last_used_at"] = _now_iso()
+    if manual_note is not None:
+        u["manual_note"] = manual_note
+    u["score"] = _score(u, entry)
+    return {"schema_version": CONNECTOR_REGISTRY_SCHEMA_VERSION, "ok": True,
+            "connector_id": connector_id, "usage": u, "score": u["score"],
+            "connectors": connectors, "usage_map": usage, "updated_at": _now_iso()}

--- a/loopx/capabilities/connector_registry/tests/test_connector_registry.py
+++ b/loopx/capabilities/connector_registry/tests/test_connector_registry.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from loopx.capabilities.connector_registry.core import (
+    BUILTIN_CONNECTOR_CATALOG,
+    list_connectors,
+    load_connector_registry,
+    rank_connectors,
+    record_connector_use,
+    register_connector,
+    save_connector_registry,
+)
+
+
+def test_builtin_catalog_covers_layers(tmp_path: Path) -> None:
+    layers = {c["layer"] for c in BUILTIN_CONNECTOR_CATALOG}
+    assert layers == {"L0", "L1", "L2", "L3", "L4", "L5"}
+    ids = [c["id"] for c in BUILTIN_CONNECTOR_CATALOG]
+    assert len(ids) == len(set(ids))
+    assert "cninfo-announcement" in ids
+    assert "ark-web-search" in ids
+
+
+def test_register_use_rank_persists(tmp_path: Path) -> None:
+    path = tmp_path / "connector-registry.json"
+    state = load_connector_registry(path)
+    result = register_connector(state, "probe-connector", status="supported",
+                                value_tier="P0", layer="L1", kind="announcement")
+    state2 = {**state, "connectors": result["connectors"], "usage": result["usage_map"]}
+    used = record_connector_use(state2, "probe-connector", ok=True, ms=120)
+    state3 = {**state2, "connectors": used["connectors"], "usage": used["usage_map"]}
+    save_connector_registry(state3, path)
+
+    reloaded = load_connector_registry(path)
+    entry = next(c for c in reloaded["connectors"] if c["id"] == "probe-connector")
+    assert entry["status"] == "supported"
+    assert reloaded["usage"]["probe-connector"]["count"] == 1
+    assert reloaded["usage"]["probe-connector"]["ok"] == 1
+
+    ranked = rank_connectors(reloaded)
+    top = ranked[0]
+    assert top["score"] > 0
+    packet = list_connectors(reloaded)
+    assert packet["summary"]["supported"] >= 1
+    assert json.dumps(packet, ensure_ascii=False)

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -60,6 +60,10 @@ from .capabilities.value_connectors.cli import (
     handle_value_connector_command,
     register_value_connector_commands,
 )
+from .capabilities.connector_registry.cli import (
+    handle_connector_command,
+    register_connector_commands,
+)
 from .cli_commands import (
     handle_turn_command,
     handle_benchmark_command,
@@ -278,6 +282,8 @@ def build_parser() -> LoopXArgumentParser:
     register_semantic_preference_commands(sub, add_subcommand_format)
 
     register_value_connector_commands(sub, add_subcommand_format)
+
+    register_connector_commands(sub, add_subcommand_format)
 
     register_ml_experiment_commands(sub, add_subcommand_format)
 
@@ -691,6 +697,12 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "value-connectors":
         return handle_value_connector_command(args, output_format=output_format, print_payload=print_payload)
+
+    connector_result = handle_connector_command(
+        args, output_format=output_format, print_payload=print_payload,
+    )
+    if connector_result is not None:
+        return connector_result
 
     registry_admin_result = handle_registry_admin_command(
         args,


### PR DESCRIPTION
## What

New builtin capability **connector-registry**: one place to manage the
supported / pending / blocked public connectors that LoopX consumers (finance
included) use, with layer (L0-L5, per the finance research docs/16 blueprint),
value tier, usage counters, and an evolving value-priority ranking.

Commands:
- `loopx connector list` — status/layer/value/usage/score per connector
- `loopx connector register <id> --status ... --value-tier ...`
- `loopx connector use <id> --ms <ms> [--fail]` — record a real call so ranking evolves
- `loopx connector rank` — value-priority ordering

Score = value-tier base (P0=10/P1=6/P2=3) − pending/blocked penalty + 0.2×ok − 0.5×fail.
State at `LOOPX_RUNTIME_ROOT/connector-registry.json` (overridable with `--path`).

## Validation

- `py_compile` on all touched modules
- `pytest loopx/capabilities/connector_registry/tests` — 2 passed
- CLI smoke: `connector list/use/rank --format json` all ok; `capability list`
  exposes `connector-registry`

## Scope

New capability package + catalog/cli wiring + README + tests. No control-plane
runtime or permission changes; registry is local-only state.
