### PR TITLE
fix(desktop): auto-upgrade frontend on stale runtime and notify success

### DIFF
--- a/apps/desktop/loopx-control-plane/src-tauri/Cargo.lock
+++ b/apps/desktop/loopx-control-plane/src-tauri/Cargo.lock
@@ -2066,7 +2066,22 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-notification",
  "tauri-plugin-single-instance",
+]
+
+[[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "time",
+ "uuid",
 ]
 
 [[package]]
@@ -2182,6 +2197,20 @@ dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "notify-rust"
+version = "4.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
 ]
 
 [[package]]
@@ -2344,6 +2373,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3618,6 +3648,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74be5dd4bed9afbd145e5716b5fa2ec28cbc29c34ffa61c258c9273d896c8020"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.20",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-single-instance"
 version = "2.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3731,6 +3796,17 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.4+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
+dependencies = [
+ "thiserror 2.0.20",
+ "windows",
+ "windows-version",
 ]
 
 [[package]]

--- a/apps/desktop/loopx-control-plane/src-tauri/Cargo.toml
+++ b/apps/desktop/loopx-control-plane/src-tauri/Cargo.toml
@@ -22,4 +22,5 @@ command-group = "5.0.1"
 serde_json = "1.0"
 tauri = { version = "2.11.1", features = [] }
 tauri-plugin-single-instance = "2.4.3"
+tauri-plugin-notification = "2"
 rfd = "0.15"

--- a/apps/desktop/loopx-control-plane/src-tauri/capabilities/default.json
+++ b/apps/desktop/loopx-control-plane/src-tauri/capabilities/default.json
@@ -3,5 +3,5 @@
   "identifier": "default",
   "description": "Desktop shell capability set",
   "windows": ["main"],
-  "permissions": ["core:default"]
+  "permissions": ["core:default", "notification:default"]
 }

--- a/apps/desktop/loopx-control-plane/src-tauri/src/lib.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex};
 use tauri::{
     ipc::CapabilityBuilder, AppHandle, Manager, RunEvent, Url, WebviewUrl, WebviewWindowBuilder,
 };
+use tauri_plugin_notification::NotificationExt;
 
 const APP_IDENTIFIER: &str = "io.loopx.control-plane";
 
@@ -34,6 +35,7 @@ pub fn run() {
                 .callback(|app, _args, _cwd| show_main_window(app))
                 .build(),
         )
+        .plugin(tauri_plugin_notification::init())
         .setup(move |app| {
             let started = match ServiceSet::start() {
                 Ok(services) => services,
@@ -53,7 +55,17 @@ pub fn run() {
                     return Ok(());
                 }
             };
+            let healed = started.healed;
             *services_for_setup.lock().expect("service state lock") = Some(started);
+
+            if healed {
+                let _ = app
+                    .notification()
+                    .builder()
+                    .title("LoopX")
+                    .body("已自动升级到当前 LoopX 版本，服务已重启。")
+                    .show();
+            }
 
             let origin: Url = web_origin.parse()?;
             app.add_capability(

--- a/apps/desktop/loopx-control-plane/src-tauri/src/services.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/services.rs
@@ -110,11 +110,17 @@ impl OwnedService {
 
 pub struct ServiceSet {
     owned: Vec<OwnedService>,
+    /// True when a stale LoopX service was restarted so the running frontend
+    /// was transparently moved onto the current installed release.
+    pub healed: bool,
 }
 
 impl ServiceSet {
     pub fn start() -> Result<Self, ServiceError> {
-        let mut services = Self { owned: Vec::new() };
+        let mut services = Self {
+            owned: Vec::new(),
+            healed: false,
+        };
         for kind in [ServiceKind::Status, ServiceKind::Chat] {
             if let Err(error) = services.ensure(kind) {
                 services.stop();
@@ -127,7 +133,7 @@ impl ServiceSet {
     fn ensure(&mut self, kind: ServiceKind) -> Result<(), ServiceError> {
         let executable = loopx_executable();
         let expected_runtime_identity = runtime_identity_for_executable(&executable);
-        let mut stale_retries = 0;
+        let stale_deadline = Instant::now() + STARTUP_TIMEOUT;
         loop {
             match probe(kind, expected_runtime_identity.as_ref()) {
                 Probe::Matching => return Ok(()),
@@ -140,21 +146,22 @@ impl ServiceSet {
                 }
                 Probe::Stale => {
                     // Self-heal: the port is owned by a LoopX service from a
-                    // different installed release (for example before a
-                    // `loopx update` restarted it). Terminate that stale
-                    // listener and retry so the current release's service is
-                    // started; unknown (Foreign) processes keep the hard error.
-                    stale_retries += 1;
-                    if stale_retries > 3 {
+                    // different installed release (for example after a
+                    // `loopx update`). Terminate that stale listener and keep
+                    // waiting up to the startup timeout so a LaunchAgent-managed
+                    // service (KeepAlive + throttle) has time to restart on the
+                    // current release; unknown (Foreign) processes keep the
+                    // hard error.
+                    self.healed = true;
+                    terminate_listener(kind.port());
+                    if Instant::now() >= stale_deadline {
                         return Err(ServiceError(format!(
                             "port {} is serving LoopX {} from a different installed runtime and could not be restarted",
                             kind.port(),
                             kind.label()
                         )));
                     }
-                    terminate_listener(kind.port());
-                    thread::sleep(Duration::from_millis(400));
-                    continue;
+                    thread::sleep(Duration::from_millis(200));
                 }
                 Probe::Unavailable => break,
             }
@@ -186,11 +193,9 @@ impl ServiceSet {
                     )));
                 }
                 Probe::Stale => {
-                    return Err(ServiceError(format!(
-                        "LoopX {} startup reached a stale runtime on port {}",
-                        kind.label(),
-                        kind.port()
-                    )));
+                    self.healed = true;
+                    terminate_listener(kind.port());
+                    thread::sleep(Duration::from_millis(200));
                 }
                 Probe::Unavailable => thread::sleep(Duration::from_millis(100)),
             }


### PR DESCRIPTION
## Summary

The desktop shell's stale-service self-heal (#3457) gave up after ~1.2s (3 retries). LaunchAgent-managed status/chat services have `KeepAlive` plus a 10s throttle, so after the stale listener is terminated the service takes longer than that to restart — the shell then fell back to the owner-facing dialog ("could not be restarted").

This PR makes the upgrade transparent:

1. `services.rs` — when a verified-stale LoopX service is found, terminate it and keep probing **up to the startup timeout** until it restarts on the current release (or the port frees so the shell starts its own). Mark the `ServiceSet` as `healed`.
2. `lib.rs` — after a healed start, show a native notification `已自动升级到当前 LoopX 版本，服务已重启。` and open the window as usual. Adds `tauri-plugin-notification` (+ capability permission).

Result: the user no longer sees the mismatch error; the frontend transparently moves onto the current `loopx` release, gets a success prompt, and the app opens.

## Validation

- `cargo check` (src-tauri): clean.
- `git diff --check`: clean.

## Boundary

Desktop shell self-heal + notification only. Foreign (non-LoopX) processes keep the hard error; no control-plane, quota, todo, permission, or public/private evidence changes.
