### PR TITLE
feat(ssh-source): auto-establish SSH tunnel and remote status on switch

### DIFF
--- a/apps/presentation/dashboard/src/data/ssh-host-catalog.ts
+++ b/apps/presentation/dashboard/src/data/ssh-host-catalog.ts
@@ -52,3 +52,34 @@ export function configuredSshTunnelDraft(hostAlias: string, localPortValue: stri
     statusUrl: `http://127.0.0.1:${localPort}/status.json`,
   } as const;
 }
+
+
+export const defaultSshSourceEnsureUrl = "/api/ssh-source/ensure";
+
+export type EnsureSshSourceResult = {
+  ok: true;
+  status_url: string;
+  tunnel_required: boolean;
+  remote_started: boolean;
+};
+
+export async function ensureSshSource(
+  hostAlias: string,
+  localPort: string | number,
+): Promise<EnsureSshSourceResult> {
+  const response = await fetch(defaultSshSourceEnsureUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ host_alias: hostAlias, local_port: Number(localPort) }),
+  });
+  const payload = (await response.json().catch(() => null)) as
+    | (EnsureSshSourceResult & { error?: string })
+    | null;
+  if (!response.ok) {
+    throw new Error(payload?.error ?? "无法建立 SSH 隧道来源。");
+  }
+  if (!payload?.ok) {
+    throw new Error("无法建立 SSH 隧道来源。");
+  }
+  return payload;
+}

--- a/apps/presentation/dashboard/src/features/personal-workspace/status-source-switcher.tsx
+++ b/apps/presentation/dashboard/src/features/personal-workspace/status-source-switcher.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import type { StatusSource } from "../../data/status-source-catalog";
 import {
   configuredSshTunnelDraft,
+  ensureSshSource,
   fetchConfiguredSshHosts,
   type ConfiguredSshHost,
 } from "../../data/ssh-host-catalog";
@@ -30,6 +31,7 @@ export function StatusSourceSwitcher({
   sources,
 }: StatusSourceControl) {
   const [adding, setAdding] = useState(false);
+  const [ensuring, setEnsuring] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [addMode, setAddMode] = useState<"configured" | "manual">("configured");
   const [configuredHosts, setConfiguredHosts] = useState<ConfiguredSshHost[]>([]);
@@ -95,12 +97,22 @@ export function StatusSourceSwitcher({
     closeForm();
   }
 
-  function submitConfigured() {
+  async function submitConfigured() {
     if ("error" in configuredDraft) {
       setError(configuredDraft.error ?? "SSH 来源参数无效。");
       return;
     }
+    setEnsuring(true);
+    setError(null);
+    try {
+      await ensureSshSource(hostAlias, localPort);
+    } catch (caught) {
+      setEnsuring(false);
+      setError(caught instanceof Error ? caught.message : "无法建立 SSH 隧道来源。");
+      return;
+    }
     const result = onAdd({ label: configuredDraft.label, statusUrl: configuredDraft.statusUrl });
+    setEnsuring(false);
     if (result.error) {
       setError(result.error);
       return;
@@ -215,7 +227,7 @@ export function StatusSourceSwitcher({
               </div>
               {configuredHostsError ? <p className="is-error">{configuredHostsError}</p> : null}
               <p>已读取全部显式 Host（含 Include）；通配规则不会作为具体来源。先运行命令，LoopX 不读取密钥或配置细节。</p>
-              <button className="personal-status-source-add" disabled={"error" in configuredDraft} onClick={submitConfigured} type="button">添加只读来源</button>
+              <button className="personal-status-source-add" disabled={"error" in configuredDraft || ensuring} onClick={() => void submitConfigured()} type="button">{ensuring ? "正在建立隧道…" : "添加只读来源"}</button>
             </>
           ) : (
             <>

--- a/examples/personal-workspace-browser-smoke.mjs
+++ b/examples/personal-workspace-browser-smoke.mjs
@@ -138,6 +138,13 @@ async function installApi(page) {
     }
     await route.fulfill({ contentType: "application/json", json: fixture, status: 200 });
   });
+  await page.route(`http://127.0.0.1:${port}/api/ssh-source/ensure`, async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      json: { ok: true, status_url: "http://127.0.0.1:8876/status.json", tunnel_required: true, remote_started: true },
+      status: 200,
+    });
+  });
   await page.route(`http://127.0.0.1:${port}/ssh-hosts`, async (route) => {
     await route.fulfill({
       contentType: "application/json",

--- a/loopx/chat_server.py
+++ b/loopx/chat_server.py
@@ -28,6 +28,7 @@ from .control_plane.status.ssh_host_catalog import (
     SSH_HOST_CATALOG_PATH,
     ssh_host_catalog_payload,
 )
+from .control_plane.status.ssh_tunnel import ensure_ssh_source
 from .chat_lark_api import (
     LarkChatRequestMixin,
     build_goal_repository_contexts as build_goal_repository_contexts,
@@ -100,6 +101,7 @@ CHAT_LARK_CHATS_PATH = "/api/chat/lark/chats"
 CHAT_LARK_CONNECTIONS_PATH = "/api/chat/lark/connections"
 CHAT_ACTIONS_PATH = "/api/actions"
 CHAT_ACTION_PREVIEW_PATH = f"{CHAT_ACTIONS_PATH}/preview"
+SSH_SOURCE_ENSURE_PATH = "/api/ssh-source/ensure"
 
 
 def chat_cors_response_headers(origin: str | None) -> dict[str, str]:
@@ -499,6 +501,29 @@ class ChatRequestHandler(
         self._send_json(
             ssh_host_catalog_payload(getattr(self.server, "ssh_config_path", None))
         )
+
+    def _ssh_source_ensure(self) -> None:
+        if not is_loopback_host(str(self.server.server_address[0])):
+            self._send_error(
+                "SSH source management requires a loopback LoopX Chat server.",
+                status=403,
+            )
+            return
+        if not self._require_loopback_origin():
+            return
+        try:
+            body = self._read_json()
+            alias = str(body.get("host_alias") or "")
+            local_port = body.get("local_port")
+            result = ensure_ssh_source(
+                alias,
+                local_port,
+                ssh_config_path=getattr(self.server, "ssh_config_path", None),
+            )
+        except (ValueError, TypeError) as exc:
+            self._send_error(str(exc), status=400)
+            return
+        self._send_json(result)
 
     def _registry_and_goal(self, goal_id: str) -> tuple[dict[str, Any], dict[str, Any]]:
         registry = load_registry(self.server.registry_path)
@@ -1358,6 +1383,7 @@ class ChatRequestHandler(
             CHAT_GOAL_CHANNEL_CONFIGURE_PATH: self._goal_channel_configure,
             CHAT_LARK_APP_SETUPS_PATH: self._lark_setup_start,
             CHAT_LARK_CONNECTIONS_PATH: self._lark_connect,
+            SSH_SOURCE_ENSURE_PATH: self._ssh_source_ensure,
         }
         if path in post_dispatch:
             return post_dispatch[path]()

--- a/loopx/control_plane/status/ssh_tunnel.py
+++ b/loopx/control_plane/status/ssh_tunnel.py
@@ -1,0 +1,140 @@
+"""Ensure an SSH-tunneled LoopX status source is reachable.
+
+The personal-workspace source switcher lets an owner point at a configured
+SSH host that runs LoopX on its remote loopback. This module automatically
+opens the local tunnel and starts the remote status service when missing, so
+switching sources in the app does not require manual ssh commands.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import time
+import urllib.error
+import urllib.request
+
+from .ssh_host_catalog import configured_ssh_host_aliases
+
+
+REMOTE_STATUS_PORT = 8766
+_MIN_TUNNEL_PORT = 1024
+_MAX_TUNNEL_PORT = 65535
+_DEFAULT_WAIT_SECONDS = 12.0
+
+# Fixed remote bootstrap: resolve the loopx binary and start a loopback
+# status server. Only the (already validated) SSH alias is interpolated as an
+# ssh argv; this script is never built from user text.
+_REMOTE_BOOTSTRAP = (
+    "mkdir -p \"$HOME/.codex/loopx\" && "
+    "bin=\"$HOME/.local/bin/loopx\"; "
+    "[ -x \"$bin\" ] || bin=\"$(command -v loopx || true)\"; "
+    "[ -n \"$bin\" ] || { echo 'loopx not found on remote' >&2; exit 1; }; "
+    "nohup \"$bin\" --registry \"$HOME/.codex/loopx/registry.global.json\" "
+    "serve-status --global-registry --host 127.0.0.1 --port 8766 --limit 80 "
+    ">/tmp/loopx-serve-status.log 2>&1 &"
+)
+
+
+def _loopback_status_ok(port: int, *, timeout: float = 2.0) -> bool:
+    try:
+        with urllib.request.urlopen(
+            f"http://127.0.0.1:{port}/status.json", timeout=timeout
+        ) as response:
+            return response.status == 200
+    except (OSError, urllib.error.URLError):
+        return False
+
+
+def _remote_status_ok(alias: str, *, timeout: float = 5.0) -> bool:
+    try:
+        result = subprocess.run(
+            [
+                "ssh",
+                "-o",
+                "ConnectTimeout=3",
+                alias,
+                "curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8766/status.json",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0 and result.stdout.strip().endswith("200")
+
+
+def _start_remote_status(alias: str) -> None:
+    subprocess.run(
+        ["ssh", "-o", "ConnectTimeout=5", alias, _REMOTE_BOOTSTRAP],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=25,
+    )
+
+
+def ensure_ssh_source(
+    alias: str,
+    local_port: int,
+    *,
+    ssh_config_path: Path | None = None,
+    wait_seconds: float = _DEFAULT_WAIT_SECONDS,
+) -> dict[str, object]:
+    """Open the tunnel and remote status service for a configured SSH host."""
+    if not isinstance(alias, str) or not alias:
+        raise ValueError("host alias is required")
+    aliases = configured_ssh_host_aliases(ssh_config_path)
+    if alias not in aliases:
+        raise ValueError(f"unknown SSH host alias: {alias}")
+    if not isinstance(local_port, int) or not (
+        _MIN_TUNNEL_PORT <= local_port <= _MAX_TUNNEL_PORT
+    ):
+        raise ValueError("local tunnel port must be an integer in 1024..65535")
+
+    tunnel_required = not _loopback_status_ok(local_port)
+    remote_started = False
+    if tunnel_required:
+        subprocess.run(
+            [
+                "ssh",
+                "-f",
+                "-N",
+                "-o",
+                "ExitOnForwardFailure=yes",
+                "-o",
+                "ServerAliveInterval=30",
+                "-L",
+                f"{local_port}:127.0.0.1:{REMOTE_STATUS_PORT}",
+                alias,
+            ],
+            check=True,
+            timeout=30,
+        )
+        deadline = time.monotonic() + wait_seconds
+        while time.monotonic() < deadline:
+            if _loopback_status_ok(local_port):
+                break
+            time.sleep(0.25)
+        if not _loopback_status_ok(local_port):
+            if not _remote_status_ok(alias):
+                _start_remote_status(alias)
+                remote_started = True
+            deadline = time.monotonic() + wait_seconds
+            while time.monotonic() < deadline:
+                if _loopback_status_ok(local_port):
+                    break
+                time.sleep(0.25)
+
+    if not _loopback_status_ok(local_port):
+        raise ValueError(
+            f"SSH tunnel source is not reachable: http://127.0.0.1:{local_port}/status.json"
+        )
+
+    return {
+        "ok": True,
+        "status_url": f"http://127.0.0.1:{local_port}/status.json",
+        "tunnel_required": tunnel_required,
+        "remote_started": remote_started,
+    }

--- a/tests/test_ssh_tunnel_source.py
+++ b/tests/test_ssh_tunnel_source.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import subprocess
+from unittest import mock
+
+import pytest
+
+from loopx.control_plane.status.ssh_tunnel import ensure_ssh_source
+
+
+def test_ensure_ssh_source_opens_tunnel_and_returns_status_url() -> None:
+    calls: list[list[str]] = []
+    probe_count = 0
+
+    def fake_loopback(port: int, **kwargs: object) -> bool:
+        nonlocal probe_count
+        probe_count += 1
+        return probe_count >= 2
+
+    with mock.patch(
+        "loopx.control_plane.status.ssh_tunnel.configured_ssh_host_aliases",
+        return_value=["ark-devbox"],
+    ), mock.patch(
+        "loopx.control_plane.status.ssh_tunnel._loopback_status_ok", fake_loopback
+    ), mock.patch(
+        "loopx.control_plane.status.ssh_tunnel._remote_status_ok", return_value=True
+    ), mock.patch(
+        "loopx.control_plane.status.ssh_tunnel.subprocess.run",
+        side_effect=lambda args, **kwargs: calls.append(list(args)),
+    ):
+        result = ensure_ssh_source("ark-devbox", 8877, wait_seconds=0.01)
+
+    assert result == {
+        "ok": True,
+        "status_url": "http://127.0.0.1:8877/status.json",
+        "tunnel_required": True,
+        "remote_started": False,
+    }
+    tunnel_call = calls[0]
+    assert tunnel_call[0] == "ssh"
+    assert "-L" in tunnel_call
+    assert "8877:127.0.0.1:8766" in tunnel_call
+    assert "ark-devbox" in tunnel_call
+    # The alias and port are passed as separate argv entries, never through a shell.
+    assert "; " not in " ".join(tunnel_call)
+
+
+def test_ensure_ssh_source_starts_remote_status_when_missing() -> None:
+    probe_count = 0
+
+    def fake_loopback(port: int, **kwargs: object) -> bool:
+        nonlocal probe_count
+        probe_count += 1
+        return probe_count >= 4
+
+    with mock.patch(
+        "loopx.control_plane.status.ssh_tunnel.configured_ssh_host_aliases",
+        return_value=["ark-devbox"],
+    ), mock.patch(
+        "loopx.control_plane.status.ssh_tunnel._loopback_status_ok", fake_loopback
+    ), mock.patch(
+        "loopx.control_plane.status.ssh_tunnel._remote_status_ok", return_value=False
+    ), mock.patch(
+        "loopx.control_plane.status.ssh_tunnel._start_remote_status", return_value=None
+    ) as start_remote, mock.patch(
+        "loopx.control_plane.status.ssh_tunnel.subprocess.run", return_value=None
+    ):
+        result = ensure_ssh_source("ark-devbox", 8877, wait_seconds=0.01)
+
+    start_remote.assert_called_once_with("ark-devbox")
+    assert result["remote_started"] is True
+
+
+def test_ensure_ssh_source_rejects_unknown_alias() -> None:
+    with mock.patch(
+        "loopx.control_plane.status.ssh_tunnel.configured_ssh_host_aliases",
+        return_value=["ark-devbox"],
+    ):
+        with pytest.raises(ValueError, match="unknown SSH host alias"):
+            ensure_ssh_source("evil-host;id", 8877)
+
+
+def test_ensure_ssh_source_rejects_invalid_port() -> None:
+    with mock.patch(
+        "loopx.control_plane.status.ssh_tunnel.configured_ssh_host_aliases",
+        return_value=["ark-devbox"],
+    ):
+        with pytest.raises(ValueError, match="local tunnel port"):
+            ensure_ssh_source("ark-devbox", 22)
+        with pytest.raises(ValueError, match="local tunnel port"):
+            ensure_ssh_source("ark-devbox", "8877")


### PR DESCRIPTION
## Summary

Switching to an SSH-tunnel control-plane source in the app previously required the owner to manually run `ssh -N -L <port>:127.0.0.1:8766 <host>` and start the remote `loopx serve-status`; otherwise the frontend just showed "Load failed".

This PR automates that flow:

- New loopback Chat endpoint `POST /api/ssh-source/ensure` (`loopx/control_plane/status/ssh_tunnel.py`):
  - validates the alias against the safe `~/.ssh/config` explicit-Host catalog and the local port (1024–65535);
  - opens the tunnel (`ssh -f -N -L <port>:127.0.0.1:8766 <alias>`) when the local status URL is not reachable;
  - starts the remote `loopx serve-status` on 8766 when missing;
  - waits until the tunneled `status.json` responds, then returns the status URL.
- Frontend: adding/selecting a "已配置 SSH" source now calls `ensure` first, shows "正在建立隧道…" progress and actionable errors instead of a generic load failure.

Security: the endpoint is loopback-host + loopback-origin only, accepts only explicit safe aliases, and passes alias/port as ssh argv (no shell interpolation). It starts a local tunnel and a remote status service on the owner's configured host; it does not grant browser shell access beyond that.

## Validation

- `python3 -m py_compile` on the new module, chat_server, and tests: clean.
- Unit tests `tests/test_ssh_tunnel_source.py` (tunnel argv safety, remote-start, unknown alias, invalid port).
- Frontend `npx tsc --noEmit`: clean.
- `git diff --check`: clean.

## Boundary

New SSH-source automation endpoint + frontend wiring. No control-plane, quota, todo, permission, or public/private evidence changes.
