### PR TITLE
fix(connector-registry): preserve local connector state

### DIFF
--- a/loopx/capabilities/connector_registry/cli.py
+++ b/loopx/capabilities/connector_registry/cli.py
@@ -47,14 +47,20 @@ def _render_rank_markdown(payload: dict[str, object]) -> str:
     return "\n".join(lines)
 
 
+def _add_registry_path(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--path", type=Path)
+
+
 def register_connector_commands(sub, add_subcommand_format: AddFormat) -> None:
     parser = sub.add_parser("connector", help="Unified public-connector registry")
     actions = parser.add_subparsers(dest="connector_action", required=True)
 
     p_list = actions.add_parser("list", help="List connectors with status, layer, value, usage")
+    _add_registry_path(p_list)
     add_subcommand_format(p_list)
 
     p_rank = actions.add_parser("rank", help="Show the value-priority ranking")
+    _add_registry_path(p_rank)
     add_subcommand_format(p_rank)
 
     p_reg = actions.add_parser("register", help="Register or update a connector")
@@ -67,7 +73,7 @@ def register_connector_commands(sub, add_subcommand_format: AddFormat) -> None:
     p_reg.add_argument("--value-tier", choices=["P0", "P1", "P2"])
     p_reg.add_argument("--purpose")
     p_reg.add_argument("--blocker")
-    p_reg.add_argument("--path", type=Path)
+    _add_registry_path(p_reg)
     add_subcommand_format(p_reg)
 
     p_use = actions.add_parser("use", help="Record a connector call")
@@ -75,7 +81,7 @@ def register_connector_commands(sub, add_subcommand_format: AddFormat) -> None:
     p_use.add_argument("--fail", action="store_true")
     p_use.add_argument("--ms", type=int, default=0)
     p_use.add_argument("--note")
-    p_use.add_argument("--path", type=Path)
+    _add_registry_path(p_use)
     add_subcommand_format(p_use)
 
 

--- a/loopx/capabilities/connector_registry/core.py
+++ b/loopx/capabilities/connector_registry/core.py
@@ -117,15 +117,24 @@ def load_connector_registry(path: Path | None = None) -> dict[str, Any]:
                 state = raw
         except (OSError, ValueError):
             pass
-    # Re-sync against the builtin catalog, preserving any stored usage.
+    # Re-sync against the builtin catalog while preserving local operator state.
+    stored_connectors = {
+        str(c.get("id")): dict(c)
+        for c in state.get("connectors", [])
+        if isinstance(c, Mapping) and c.get("id")
+    }
     merged_connectors: list[dict[str, Any]] = []
     usage = state.get("usage") if isinstance(state.get("usage"), dict) else {}
     merged_usage: dict[str, dict[str, Any]] = {}
     for c in BUILTIN_CONNECTOR_CATALOG:
-        merged_connectors.append(dict(c))
-        merged_usage[c["id"]] = {**(_fresh_usage(c)), **(usage.get(c["id"]) or {})}
+        connector_id = c["id"]
+        merged = {**dict(c), **(stored_connectors.get(connector_id) or {}), "id": connector_id}
+        merged_connectors.append(merged)
+        merged_usage[connector_id] = {**(_fresh_usage(merged)), **(usage.get(connector_id) or {})}
     seen = {c["id"] for c in BUILTIN_CONNECTOR_CATALOG}
     for stored in state.get("connectors", []):
+        if not isinstance(stored, Mapping):
+            continue
         cid = str(stored.get("id") or "")
         if cid and cid not in seen:
             merged_connectors.append(dict(stored))

--- a/loopx/capabilities/connector_registry/tests/test_connector_registry.py
+++ b/loopx/capabilities/connector_registry/tests/test_connector_registry.py
@@ -92,8 +92,7 @@ def test_cli_path_override_reads_the_registry_it_writes(tmp_path: Path) -> None:
         ],
         check=True,
         cwd=Path.cwd(),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         text=True,
     )
     assert json.loads(register.stdout)["ok"] is True
@@ -112,8 +111,7 @@ def test_cli_path_override_reads_the_registry_it_writes(tmp_path: Path) -> None:
         ],
         check=True,
         cwd=Path.cwd(),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         text=True,
     )
     payload = json.loads(listed.stdout)
@@ -133,8 +131,7 @@ def test_cli_path_override_reads_the_registry_it_writes(tmp_path: Path) -> None:
         ],
         check=True,
         cwd=Path.cwd(),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         text=True,
     )
     assert any(row["id"] == "probe-cli" for row in json.loads(ranked.stdout)["ranked"])

--- a/loopx/capabilities/connector_registry/tests/test_connector_registry.py
+++ b/loopx/capabilities/connector_registry/tests/test_connector_registry.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 from pathlib import Path
 
 from loopx.capabilities.connector_registry.core import (
@@ -45,3 +47,94 @@ def test_register_use_rank_persists(tmp_path: Path) -> None:
     packet = list_connectors(reloaded)
     assert packet["summary"]["supported"] >= 1
     assert json.dumps(packet, ensure_ascii=False)
+
+
+def test_builtin_connector_updates_survive_catalog_resync(tmp_path: Path) -> None:
+    path = tmp_path / "connector-registry.json"
+    state = load_connector_registry(path)
+    result = register_connector(
+        state,
+        "cninfo-announcement",
+        status="supported",
+        blocker="",
+    )
+    save_connector_registry(
+        {**state, "connectors": result["connectors"], "usage": result["usage_map"]},
+        path,
+    )
+
+    reloaded = load_connector_registry(path)
+    entry = next(c for c in reloaded["connectors"] if c["id"] == "cninfo-announcement")
+    assert entry["status"] == "supported"
+    assert entry.get("blocker") == ""
+
+
+def test_cli_path_override_reads_the_registry_it_writes(tmp_path: Path) -> None:
+    path = tmp_path / "connector-registry.json"
+    register = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "connector",
+            "register",
+            "probe-cli",
+            "--status",
+            "supported",
+            "--value-tier",
+            "P0",
+            "--layer",
+            "L1",
+            "--path",
+            str(path),
+            "--format",
+            "json",
+        ],
+        check=True,
+        cwd=Path.cwd(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert json.loads(register.stdout)["ok"] is True
+
+    listed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "connector",
+            "list",
+            "--path",
+            str(path),
+            "--format",
+            "json",
+        ],
+        check=True,
+        cwd=Path.cwd(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    payload = json.loads(listed.stdout)
+    assert any(row["id"] == "probe-cli" for row in payload["ranked"])
+
+    ranked = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "connector",
+            "rank",
+            "--path",
+            str(path),
+            "--format",
+            "json",
+        ],
+        check=True,
+        cwd=Path.cwd(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert any(row["id"] == "probe-cli" for row in json.loads(ranked.stdout)["ranked"])


### PR DESCRIPTION
## Root Cause

`connector register/use --path ...` wrote to the caller-selected registry, but `connector list` and `connector rank` did not expose the same `--path` option. The handler already read `args.path`; argparse never populated it for the read commands, so a custom registry could be written but not read back through the public CLI.

The same path had a second persistence bug: `load_connector_registry()` rebuilt every builtin connector from `BUILTIN_CONNECTOR_CATALOG` and preserved only usage. Local operator updates to a builtin row (`status`, `blocker`, `value_tier`, and related metadata) therefore disappeared on the next load.

Call path:

`loopx.cli` → `handle_connector_command()` → `register_connector()` / `save_connector_registry()` → `load_connector_registry()` → builtin catalog resync.

## Options Considered

| Option | Impact | Performance | Fit | Decision |
| --- | --- | --- | --- | --- |
| Only add `--path` to `list/rank` | Fixes one CLI symptom | No meaningful cost | Persisted builtin updates still disappear | Rejected |
| Preserve stored connector fields during builtin catalog resync | Keeps catalog rows as defaults while honoring local state | O(n) over the small catalog | Matches the current capability owner and one-file registry model | Selected |
| Persist builtin defaults and local overrides separately | Stronger schema long-term | Adds migration and review surface | Too broad for this bug fix | Deferred |

## What Changed

- `load_connector_registry()` now overlays stored connector fields on builtin defaults for matching ids while keeping the catalog id authoritative.
- `connector list` and `connector rank` now accept `--path`, matching `register` and `use`.
- Regression coverage proves builtin updates survive reload and custom-path writes are visible to list/rank.
- Maintainer refinement uses `subprocess.run(capture_output=True)` in the new CLI regression, preserving behavior with a smaller standard-library surface.

No dependency, permission, scoring, scheduler, or public API removal is introduced. This remains in the existing Python connector-registry capability owner; it does not duplicate an established TypeScript control-plane transition owner.

## Validation

- `uv run --no-project --with 'pytest>=8,<9' python -m pytest -q loopx/capabilities/connector_registry/tests/test_connector_registry.py` — 4 passed
- `uv run --no-project --with 'ruff>=0.12,<0.16' ruff check --select E4,E7,E9,F ...` — passed for the three changed files
- `npm run test:control-plane` — 84 passed
- `uv run --no-project python -m loopx.cli canary premerge --from-git-diff` — passed; 4/4 selected canaries, no manual holds, self-merge allowed
- `git diff --check` — passed

The capability directory predates CI's lint scope; an unrestricted modern Ruff run also reports four pre-existing import/UTC modernization suggestions in `cli.py` and `core.py`. They are unrelated to this behavior fix and are not represented as passing validation.

## Risk

Low. The change is limited to `loopx/capabilities/connector_registry`. Builtin catalog rows still supply defaults and newly introduced catalog fields, while explicit local edits now survive reload as the CLI contract implies. The only default-behavior change is disclosed: updates to builtin connector rows become durable instead of being silently reset.

Future-facing pass: the shared `--path` argument stays centralized inside the capability. A separate persisted override map would be a larger schema migration and is intentionally deferred.
