### PR TITLE
refactor(quota): cut over delivery routing transaction

### DIFF
--- a/docs/architecture/rfcs/typescript-control-plane-migration-v0.md
+++ b/docs/architecture/rfcs/typescript-control-plane-migration-v0.md
@@ -251,7 +251,9 @@ continuity-versus-fallback selection and the selected Todo's settlement boundary
 behind one request. Python still prepares the normal fallback candidate and
 projects the typed result into the legacy quota packet, but it no longer composes
 two leaf decisions. The in-flight path moves from two cross-runtime calls to one;
-the no-anchor and preempted paths remain at one. The Python facade exits when the
+no-anchor paths with a fallback candidate and preempted paths remain at one,
+while an empty no-anchor candidate set remains at zero through a projection-layer
+short circuit. The Python facade exits when the
 quota route and CLI caller move into the native TypeScript transaction. Vision
 checkpointing remains a separate refresh/writeback transaction because it does
 not share the delivery-selection lifecycle phase.

--- a/docs/architecture/rfcs/typescript-control-plane-migration-v0.md
+++ b/docs/architecture/rfcs/typescript-control-plane-migration-v0.md
@@ -246,6 +246,16 @@ multi-helper bridge. The remaining fine-grained settlement facade can be
 deleted after quota, host-adapter, and task-lease callers move to their own
 coarse transactions.
 
+Quota delivery routing is the next bounded payoff cutover. TypeScript now owns
+continuity-versus-fallback selection and the selected Todo's settlement boundary
+behind one request. Python still prepares the normal fallback candidate and
+projects the typed result into the legacy quota packet, but it no longer composes
+two leaf decisions. The in-flight path moves from two cross-runtime calls to one;
+the no-anchor and preempted paths remain at one. The Python facade exits when the
+quota route and CLI caller move into the native TypeScript transaction. Vision
+checkpointing remains a separate refresh/writeback transaction because it does
+not share the delivery-selection lifecycle phase.
+
 ### Stage 3 — CLI and App convergence
 
 Ship a native TS CLI that imports the kernel in-process. Keep one automatically

--- a/docs/architecture/rfcs/typescript-control-plane-migration-v0.zh-CN.md
+++ b/docs/architecture/rfcs/typescript-control-plane-migration-v0.zh-CN.md
@@ -214,6 +214,14 @@ authority 的 writeback、spend 与 terminal provider 的机械 adapter。因此
 Quota、host-adapter 与 task-lease caller 迁到各自的 coarse transaction 后，即可删除
 剩余细粒度 settlement facade。
 
+Quota delivery routing 是下一笔 bounded payoff cutover。TypeScript 通过一次请求拥有
+continuity 与 fallback 的选择，以及 selected Todo 的 settlement boundary。Python 仍
+准备正常 fallback candidate，并把 typed result 投影成 legacy quota packet，但不再
+组合两条 leaf decision。In-flight 路径的跨 runtime 调用从两次降为一次；无 anchor
+与 preempted 路径保持一次。Quota route 与 CLI caller 进入 native TypeScript
+transaction 后，Python facade 即可退出。Vision checkpointing 属于不同的
+refresh/writeback 生命周期阶段，因此继续作为独立 transaction。
+
 ### Stage 3 — CLI 与 App 汇合
 
 交付 native TS CLI，并在进程内 import kernel。只保留一个自动选择的 authority

--- a/docs/architecture/rfcs/typescript-control-plane-migration-v0.zh-CN.md
+++ b/docs/architecture/rfcs/typescript-control-plane-migration-v0.zh-CN.md
@@ -217,8 +217,9 @@ Quota、host-adapter 与 task-lease caller 迁到各自的 coarse transaction �
 Quota delivery routing 是下一笔 bounded payoff cutover。TypeScript 通过一次请求拥有
 continuity 与 fallback 的选择，以及 selected Todo 的 settlement boundary。Python 仍
 准备正常 fallback candidate，并把 typed result 投影成 legacy quota packet，但不再
-组合两条 leaf decision。In-flight 路径的跨 runtime 调用从两次降为一次；无 anchor
-与 preempted 路径保持一次。Quota route 与 CLI caller 进入 native TypeScript
+组合两条 leaf decision。In-flight 路径的跨 runtime 调用从两次降为一次；存在 fallback
+candidate 的无 anchor 路径与 preempted 路径保持一次，而 anchor 和 candidate 均为空时
+由 projection 层短路并保持零次调用。Quota route 与 CLI caller 进入 native TypeScript
 transaction 后，Python facade 即可退出。Vision checkpointing 属于不同的
 refresh/writeback 生命周期阶段，因此继续作为独立 transaction。
 

--- a/loopx/control_plane/agents/agent_lane_recommendation.py
+++ b/loopx/control_plane/agents/agent_lane_recommendation.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any
 
 from ..todos.contract import (
     TODO_TASK_CLASS_ADVANCEMENT,
@@ -28,8 +29,7 @@ from .capability_gate import (
     missing_required_capabilities,
 )
 
-
-PublicSafeText = Callable[..., Optional[str]]
+PublicSafeText = Callable[..., str | None]
 ActionAlignment = Callable[[Any, Any], bool]
 TimestampParser = Callable[[Any], Any]
 AGENT_LANE_NEXT_ACTION_SCHEMA_VERSION = "agent_lane_next_action_v0"
@@ -380,7 +380,7 @@ def build_agent_lane_next_action(
     active_next_action: Any = None,
     scoped_user_gate_fallback: dict[str, Any] | None = None,
     receipt_bound_todo_id: str | None = None,
-    delivery_continuity: dict[str, Any] | None = None,
+    selected_todo_override: dict[str, Any] | None = None,
 ) -> dict[str, Any] | None:
     if not isinstance(agent_identity, dict):
         return None
@@ -471,10 +471,9 @@ def build_agent_lane_next_action(
 
     preferred_todo_ids = _todo_ids_from_action(active_next_action)
     receipt_todo_id = normalize_todo_id(receipt_bound_todo_id)
-    in_flight_todo_id = (
-        normalize_todo_id(delivery_continuity.get("todo_id"))
-        if isinstance(delivery_continuity, dict)
-        and delivery_continuity.get("decision") == "resume_in_flight"
+    override_todo_id = (
+        normalize_todo_id(selected_todo_override.get("todo_id"))
+        if isinstance(selected_todo_override, dict)
         else None
     )
     active_next_action_items = (
@@ -519,8 +518,8 @@ def build_agent_lane_next_action(
                 and normalize_todo_id(candidate.get("todo_id")) == receipt_todo_id
                 else 1,
                 0
-                if in_flight_todo_id
-                and normalize_todo_id(candidate.get("todo_id")) == in_flight_todo_id
+                if override_todo_id
+                and normalize_todo_id(candidate.get("todo_id")) == override_todo_id
                 else 1,
                 _agent_lane_candidate_sort_key(
                     candidate,
@@ -533,10 +532,13 @@ def build_agent_lane_next_action(
             text = protocol_action_text(raw_item.get("text"), limit=500)
             claimed_by = agent_scope_item_claimed_by(raw_item)
             todo_id = str(raw_item.get("todo_id") or "").strip()
+            override_selected = bool(
+                override_todo_id
+                and normalize_todo_id(todo_id) == override_todo_id
+            )
             selected_by = (
-                "in_flight_todo"
-                if in_flight_todo_id
-                and normalize_todo_id(todo_id) == in_flight_todo_id
+                str(selected_todo_override.get("selected_by") or "selected_todo_override")
+                if override_selected and isinstance(selected_todo_override, dict)
                 else "active_next_action_todo"
                 if todo_id and todo_id in preferred_todo_ids
                 else "current_agent_claimed_todo"
@@ -549,12 +551,14 @@ def build_agent_lane_next_action(
             if receipt_todo_id and normalize_todo_id(todo_id) == receipt_todo_id:
                 payload["selection_binding"] = "heartbeat_receipt"
             lineage_source = source
-            if selected_by == "in_flight_todo":
-                lineage_source = "delivery_continuity.latest_accountable_delivery"
-                payload["selection_reason"] = delivery_continuity.get("reason")
-                payload["delivery_boundary"] = delivery_continuity.get(
-                    "delivery_boundary"
+            if override_selected and isinstance(selected_todo_override, dict):
+                lineage_source = str(
+                    selected_todo_override.get("source") or lineage_source
                 )
+                if selected_todo_override.get("selection_reason") is not None:
+                    payload["selection_reason"] = selected_todo_override[
+                        "selection_reason"
+                    ]
             if (
                 source == "capability_gate.runnable_candidates"
                 and selected_by == "active_next_action_todo"

--- a/loopx/control_plane/effect_runtime_handlers.ts
+++ b/loopx/control_plane/effect_runtime_handlers.ts
@@ -59,8 +59,7 @@ import {
 } from "./scheduler/state_store.ts";
 import { buildVisionCheckpoint } from "./goals/vision_checkpoint.ts";
 import {
-  evaluateDeliveryBoundary,
-  evaluateDeliveryContinuity,
+  evaluateDeliveryRoute,
 } from "./turn_driver/delivery_continuity.ts";
 import { reduceTurnSettlementTransaction } from "./turn_driver/settlement.ts";
 import {
@@ -264,8 +263,7 @@ export function createEffectRuntimeHandlers(
     ["scheduler.state.evaluate", evaluateSchedulerStateOperation],
     ["scheduler.state.load", loadSchedulerState],
     ["scheduler.state.write", writeSchedulerState],
-    ["turn.delivery_boundary.evaluate", evaluateDeliveryBoundary],
-    ["turn.delivery_continuity.evaluate", evaluateDeliveryContinuity],
+    ["turn.delivery_route.evaluate", evaluateDeliveryRoute],
     ["goal.vision_checkpoint.evaluate", buildVisionCheckpoint],
     [
       "quota.delivery_workspace_causality.evaluate",

--- a/loopx/control_plane/quota/should_run_packet.py
+++ b/loopx/control_plane/quota/should_run_packet.py
@@ -574,6 +574,8 @@ def _resolve_agent_lane_delivery_route(
 
     continuity_todo = prepared.delivery_continuity_todo
     delivery_anchor = prepared.delivery_continuity_anchor
+    if not isinstance(delivery_anchor, dict) and fallback is None:
+        return None
     delivery_route = evaluate_delivery_route(
         agent_id=delivery_agent_id,
         previous_todo_id=(

--- a/loopx/control_plane/quota/should_run_packet.py
+++ b/loopx/control_plane/quota/should_run_packet.py
@@ -78,10 +78,7 @@ from ..scheduler.state import (
     CODEX_APP_SURFACE,
     load_scheduler_state,
 )
-from ..turn_driver.delivery_continuity import (
-    evaluate_delivery_boundary,
-    evaluate_delivery_continuity,
-)
+from ..turn_driver.delivery_continuity import evaluate_delivery_route
 from ..runtime.decision_freshness import decision_freshness_warning as _decision_freshness_warning
 from ..runtime.promotion_readiness import promotion_readiness_warning as _promotion_readiness_warning
 from ..todos.contract import (
@@ -114,6 +111,7 @@ from ..work_items.work_lane import (
 )
 
 from .should_run_prepare import _QuotaDecisionPreparation
+
 
 def _compact_autonomous_candidate_context(
     value: Any,
@@ -527,34 +525,139 @@ def _delivery_preemptions_for_route(
     return preemptions
 
 
-def _delivery_continuity_for_route(
+def _resolve_agent_lane_delivery_route(
     prepared: _QuotaDecisionPreparation,
     *,
-    preemptions: list[str],
+    due_monitor_attempt: bool,
+    receipt_bound_replan_decision: bool,
+    delivery_preemptions: list[str],
 ) -> dict[str, Any] | None:
-    anchor = prepared.delivery_continuity_anchor
-    if not isinstance(anchor, dict):
-        return None
+    """Project candidates once, then let TypeScript own their delivery route."""
+
+    item = prepared.item
+    fallback = prepared.receipt_bound_agent_next_action
+    if (
+        fallback is None
+        and not due_monitor_attempt
+        and not prepared.inbox_reply_due
+        and not task_orchestration_contract_is_actionable(
+            prepared.task_orchestration_contract
+        )
+        and not prepared.capability_monitor_fallback
+    ):
+        fallback = build_agent_lane_next_action(
+            agent_identity=prepared.agent_identity,
+            agent_todo_summary=prepared.agent_todo_summary,
+            capability_gate=prepared.capability_gate,
+            scoped_user_gate_fallback=prepared.scoped_user_gate_fallback,
+            receipt_bound_todo_id=prepared.receipt_bound_todo_id,
+            active_next_action=(
+                item.get("active_state_next_action")
+                or (
+                    item.get("project_asset", {}).get("next_action")
+                    if isinstance(item.get("project_asset"), dict)
+                    else None
+                )
+            ),
+        )
+    if receipt_bound_replan_decision:
+        # The replan obligation is the immutable settlement authority for this
+        # decision. A newly runnable Todo remains visible in summaries, but it
+        # cannot become the selected settlement target in the same packet.
+        fallback = None
+
+    delivery_agent_id = normalize_todo_claimed_by(
+        (prepared.agent_identity or {}).get("agent_id")
+    )
+    if not delivery_agent_id:
+        return fallback
 
     continuity_todo = prepared.delivery_continuity_todo
-    return evaluate_delivery_continuity(
-        agent_id=str((prepared.agent_identity or {}).get("agent_id") or ""),
-        previous_todo_id=anchor.get("todo_id"),
-        previous_delivery_outcome=anchor.get("delivery_outcome"),
-        current_todo=continuity_todo,
-        actionable=bool(
+    delivery_anchor = prepared.delivery_continuity_anchor
+    delivery_route = evaluate_delivery_route(
+        agent_id=delivery_agent_id,
+        previous_todo_id=(
+            delivery_anchor.get("todo_id")
+            if isinstance(delivery_anchor, dict)
+            else None
+        ),
+        previous_delivery_outcome=(
+            delivery_anchor.get("delivery_outcome")
+            if isinstance(delivery_anchor, dict)
+            else None
+        ),
+        continuity_todo=continuity_todo,
+        continuity_actionable=bool(
             isinstance(continuity_todo, dict)
             and projection_todo_item_is_actionable_open(continuity_todo)
         ),
-        capability_ready=bool(
+        continuity_capability_ready=bool(
             isinstance(continuity_todo, dict)
             and not missing_required_capabilities(
                 continuity_todo,
                 available_capabilities=prepared.effective_available_capabilities,
             )
         ),
-        preemptions=preemptions,
+        fallback_todo=fallback,
+        fallback_actionable=bool(
+            isinstance(fallback, dict)
+            and projection_todo_item_is_actionable_open(fallback)
+        ),
+        fallback_capability_ready=bool(
+            isinstance(fallback, dict)
+            and not missing_required_capabilities(
+                fallback,
+                available_capabilities=prepared.effective_available_capabilities,
+            )
+        ),
+        preemptions=delivery_preemptions,
     )
+
+    selection = delivery_route["selection"]
+    if selection == "continuity":
+        delivery_continuity = delivery_route.get("continuity") or {}
+        selected_action = build_agent_lane_next_action(
+            agent_identity=prepared.agent_identity,
+            agent_todo_summary=prepared.agent_todo_summary,
+            capability_gate=prepared.capability_gate,
+            scoped_user_gate_fallback=prepared.scoped_user_gate_fallback,
+            receipt_bound_todo_id=prepared.receipt_bound_todo_id,
+            selected_todo_override={
+                "todo_id": delivery_continuity.get("todo_id"),
+                "selected_by": "in_flight_todo",
+                "source": "delivery_continuity.latest_accountable_delivery",
+                "selection_reason": delivery_continuity.get("reason"),
+            },
+            active_next_action=(
+                item.get("active_state_next_action")
+                or (
+                    item.get("project_asset", {}).get("next_action")
+                    if isinstance(item.get("project_asset"), dict)
+                    else None
+                )
+            ),
+        )
+        if not isinstance(selected_action, dict):
+            raise RuntimeError(
+                "TypeScript selected delivery continuity without a "
+                "projectable Todo candidate"
+            )
+    elif selection == "fallback":
+        selected_action = fallback
+    else:
+        selected_action = None
+
+    boundary = delivery_route.get("boundary")
+    if (
+        isinstance(selected_action, dict)
+        and isinstance(boundary, dict)
+        and boundary["delivery_boundary"] == "in_flight_continuation"
+    ):
+        return {
+            **selected_action,
+            "delivery_boundary": boundary["delivery_boundary"],
+        }
+    return selected_action
 
 
 @dataclass(slots=True)
@@ -584,7 +687,6 @@ class _QuotaDecisionRoute:
     next_action_warning: dict[str, Any] | None
     goal_route_hint: dict[str, Any] | None
     payload_work_lane_contract: dict[str, Any] | None
-    delivery_continuity: dict[str, Any] | None
 
 
 def _resolve_quota_should_run_route(
@@ -764,59 +866,12 @@ def _resolve_quota_should_run_route(
         capability_repair_allowed=capability_repair_allowed,
         workspace_repair_allowed=workspace_repair_allowed,
     )
-    delivery_continuity = _delivery_continuity_for_route(
+    agent_lane_next_action = _resolve_agent_lane_delivery_route(
         prepared,
-        preemptions=delivery_preemptions,
+        due_monitor_attempt=due_monitor_attempt,
+        receipt_bound_replan_decision=receipt_bound_replan_decision,
+        delivery_preemptions=delivery_preemptions,
     )
-    agent_lane_next_action = prepared.receipt_bound_agent_next_action
-    if (
-        agent_lane_next_action is None
-        and not due_monitor_attempt
-        and not prepared.inbox_reply_due
-        and not task_orchestration_contract_is_actionable(
-            prepared.task_orchestration_contract
-        )
-        and not prepared.capability_monitor_fallback
-    ):
-        agent_lane_next_action = build_agent_lane_next_action(
-            agent_identity=prepared.agent_identity,
-            agent_todo_summary=prepared.agent_todo_summary,
-            capability_gate=prepared.capability_gate,
-            scoped_user_gate_fallback=prepared.scoped_user_gate_fallback,
-            receipt_bound_todo_id=prepared.receipt_bound_todo_id,
-            delivery_continuity=delivery_continuity,
-            active_next_action=(
-                item.get("active_state_next_action")
-                or (
-                    item.get("project_asset", {}).get("next_action")
-                    if isinstance(item.get("project_asset"), dict)
-                    else None
-                )
-            ),
-        )
-    if receipt_bound_replan_decision:
-        # The replan obligation is the immutable settlement authority for this
-        # decision. A newly runnable Todo remains visible in summaries, but it
-        # cannot become the selected settlement target in the same packet.
-        agent_lane_next_action = None
-    if isinstance(agent_lane_next_action, dict):
-        boundary = evaluate_delivery_boundary(
-            agent_id=str((prepared.agent_identity or {}).get("agent_id") or ""),
-            current_todo=agent_lane_next_action,
-            actionable=projection_todo_item_is_actionable_open(
-                agent_lane_next_action
-            ),
-            capability_ready=not missing_required_capabilities(
-                agent_lane_next_action,
-                available_capabilities=prepared.effective_available_capabilities,
-            ),
-            preemptions=delivery_preemptions,
-        )
-        if boundary["delivery_boundary"] == "in_flight_continuation":
-            agent_lane_next_action = {
-                **agent_lane_next_action,
-                "delivery_boundary": boundary["delivery_boundary"],
-            }
     agent_scope_frontier = None
     agent_lane_frontier_hint = None
     if not replan_decision_allowed:
@@ -960,7 +1015,6 @@ def _resolve_quota_should_run_route(
         next_action_warning=next_action_warning,
         goal_route_hint=goal_route_hint,
         payload_work_lane_contract=payload_work_lane_contract,
-        delivery_continuity=delivery_continuity,
     )
 
 

--- a/loopx/control_plane/turn_driver/delivery_continuity.py
+++ b/loopx/control_plane/turn_driver/delivery_continuity.py
@@ -12,11 +12,10 @@ from ..todos.contract import (
 )
 from ..todos.projection import todo_item_task_class
 
-
-DELIVERY_CONTINUITY_REQUEST_SCHEMA = "loopx_delivery_continuity_request_v0"
 DELIVERY_CONTINUITY_RESULT_SCHEMA = "loopx_delivery_continuity_result_v0"
-DELIVERY_BOUNDARY_REQUEST_SCHEMA = "loopx_delivery_boundary_request_v0"
 DELIVERY_BOUNDARY_RESULT_SCHEMA = "loopx_delivery_boundary_result_v0"
+DELIVERY_ROUTING_REQUEST_SCHEMA = "loopx_delivery_routing_request_v0"
+DELIVERY_ROUTING_RESULT_SCHEMA = "loopx_delivery_routing_result_v0"
 DELIVERY_BOUNDARY_IN_FLIGHT = "in_flight_continuation"
 DELIVERY_BOUNDARY_SEMANTIC_CLOSEOUT = "semantic_closeout"
 DELIVERY_BOUNDARY_VALUES = (
@@ -35,6 +34,19 @@ DELIVERY_CONTINUITY_PREEMPTIONS = {
     "control_repair",
     "delivery_not_allowed",
 }
+DELIVERY_CONTINUITY_REASONS = {
+    *DELIVERY_CONTINUITY_PREEMPTIONS,
+    "no_previous_todo",
+    "previous_delivery_not_progress",
+    "current_todo_missing",
+    "todo_identity_changed",
+    "todo_not_open",
+    "todo_not_advancement",
+    "todo_not_actionable",
+    "todo_capability_blocked",
+    "todo_claimed_by_other_agent",
+    "same_open_todo_after_progress",
+}
 DELIVERY_BOUNDARY_REASONS = {
     *DELIVERY_CONTINUITY_PREEMPTIONS,
     "no_selected_todo",
@@ -45,6 +57,7 @@ DELIVERY_BOUNDARY_REASONS = {
     "todo_claimed_by_other_agent",
     "open_advancement_todo",
 }
+DELIVERY_ROUTING_SELECTIONS = {"continuity", "fallback", "none"}
 
 
 def normalize_delivery_boundary(value: Any) -> str:
@@ -84,92 +97,115 @@ def _normalize_preemptions(preemptions: Sequence[str]) -> list[str]:
     return normalized
 
 
-def evaluate_delivery_continuity(
+def _valid_continuity_result(value: Any) -> bool:
+    return bool(
+        isinstance(value, Mapping)
+        and value.get("schema_version") == DELIVERY_CONTINUITY_RESULT_SCHEMA
+        and value.get("decision") in DELIVERY_CONTINUITY_DECISIONS
+        and value.get("reason") in DELIVERY_CONTINUITY_REASONS
+        and value.get("delivery_boundary") in DELIVERY_BOUNDARY_VALUES
+        and (value.get("todo_id") is None or isinstance(value.get("todo_id"), str))
+    )
+
+
+def _valid_boundary_result(value: Any) -> bool:
+    return bool(
+        isinstance(value, Mapping)
+        and value.get("schema_version") == DELIVERY_BOUNDARY_RESULT_SCHEMA
+        and value.get("delivery_boundary") in DELIVERY_BOUNDARY_VALUES
+        and value.get("reason") in DELIVERY_BOUNDARY_REASONS
+        and (value.get("todo_id") is None or isinstance(value.get("todo_id"), str))
+    )
+
+
+def evaluate_delivery_route(
     *,
     agent_id: str,
     previous_todo_id: str | None,
     previous_delivery_outcome: str | None,
-    current_todo: Mapping[str, Any] | None,
-    actionable: bool,
-    capability_ready: bool,
+    continuity_todo: Mapping[str, Any] | None,
+    continuity_actionable: bool,
+    continuity_capability_ready: bool,
+    fallback_todo: Mapping[str, Any] | None,
+    fallback_actionable: bool,
+    fallback_capability_ready: bool,
     preemptions: Sequence[str] = (),
 ) -> dict[str, Any]:
-    """Ask the TypeScript Turn owner whether one open Todo remains in flight."""
+    """Resolve continuity selection and settlement boundary in one TS request."""
 
     safe_agent_id = normalize_todo_claimed_by(agent_id)
     if not safe_agent_id:
-        raise ValueError("delivery continuity requires a valid agent_id")
-    normalized_preemptions = _normalize_preemptions(preemptions)
-    todo_payload = _delivery_todo_payload(
-        current_todo,
-        actionable=actionable,
-        capability_ready=capability_ready,
+        raise ValueError("delivery routing requires a valid agent_id")
+    continuity_payload = _delivery_todo_payload(
+        continuity_todo,
+        actionable=continuity_actionable,
+        capability_ready=continuity_capability_ready,
+    )
+    fallback_payload = _delivery_todo_payload(
+        fallback_todo,
+        actionable=fallback_actionable,
+        capability_ready=fallback_capability_ready,
     )
     try:
         result = effect_runtime_result(
-            "turn.delivery_continuity.evaluate",
+            "turn.delivery_route.evaluate",
             {
-                "schema_version": DELIVERY_CONTINUITY_REQUEST_SCHEMA,
+                "schema_version": DELIVERY_ROUTING_REQUEST_SCHEMA,
                 "agent_id": safe_agent_id,
                 "previous_todo_id": normalize_todo_id(previous_todo_id),
                 "previous_delivery_outcome": (
                     str(previous_delivery_outcome or "").strip() or None
                 ),
-                "current_todo": todo_payload,
-                "preemptions": normalized_preemptions,
-            },
-        )
-    except EffectRuntimeRejected as exc:
-        raise ValueError(str(exc)) from None
-    if not isinstance(result, Mapping):
-        raise RuntimeError("TypeScript delivery continuity result must be an object")
-    if (
-        result.get("schema_version") != DELIVERY_CONTINUITY_RESULT_SCHEMA
-        or result.get("decision") not in DELIVERY_CONTINUITY_DECISIONS
-        or not isinstance(result.get("reason"), str)
-        or result.get("delivery_boundary") not in DELIVERY_BOUNDARY_VALUES
-        or not (result.get("todo_id") is None or isinstance(result.get("todo_id"), str))
-    ):
-        raise RuntimeError("TypeScript delivery continuity result shape mismatch")
-    return dict(result)
-
-
-def evaluate_delivery_boundary(
-    *,
-    agent_id: str,
-    current_todo: Mapping[str, Any] | None,
-    actionable: bool,
-    capability_ready: bool,
-    preemptions: Sequence[str] = (),
-) -> dict[str, Any]:
-    """Ask the TypeScript Turn owner how this selected Todo should settle."""
-
-    safe_agent_id = normalize_todo_claimed_by(agent_id)
-    if not safe_agent_id:
-        raise ValueError("delivery boundary requires a valid agent_id")
-    try:
-        result = effect_runtime_result(
-            "turn.delivery_boundary.evaluate",
-            {
-                "schema_version": DELIVERY_BOUNDARY_REQUEST_SCHEMA,
-                "agent_id": safe_agent_id,
-                "current_todo": _delivery_todo_payload(
-                    current_todo,
-                    actionable=actionable,
-                    capability_ready=capability_ready,
-                ),
+                "continuity_todo": continuity_payload,
+                "fallback_todo": fallback_payload,
                 "preemptions": _normalize_preemptions(preemptions),
             },
         )
     except EffectRuntimeRejected as exc:
         raise ValueError(str(exc)) from None
     if not isinstance(result, Mapping):
-        raise RuntimeError("TypeScript delivery boundary result must be an object")
+        raise TypeError("TypeScript delivery routing result must be an object")
+    continuity = result.get("continuity")
+    boundary = result.get("boundary")
+    selection = result.get("selection")
+    continuity_expected = normalize_todo_id(previous_todo_id) is not None
+    selected_todo_id = (
+        (continuity_payload or {}).get("todo_id")
+        if selection == "continuity"
+        else (fallback_payload or {}).get("todo_id")
+        if selection == "fallback"
+        else None
+    )
     if (
-        result.get("schema_version") != DELIVERY_BOUNDARY_RESULT_SCHEMA
-        or result.get("delivery_boundary") not in DELIVERY_BOUNDARY_VALUES
-        or result.get("reason") not in DELIVERY_BOUNDARY_REASONS
-        or not (result.get("todo_id") is None or isinstance(result.get("todo_id"), str))
+        result.get("schema_version") != DELIVERY_ROUTING_RESULT_SCHEMA
+        or selection not in DELIVERY_ROUTING_SELECTIONS
+        or not (continuity is None or _valid_continuity_result(continuity))
+        or not (boundary is None or _valid_boundary_result(boundary))
+        or continuity_expected != isinstance(continuity, Mapping)
+        or (
+            selection == "continuity"
+            and (
+                continuity_payload is None
+                or continuity is None
+                or continuity.get("decision") != "resume_in_flight"
+                or continuity.get("todo_id") != selected_todo_id
+                or not isinstance(boundary, Mapping)
+                or boundary.get("delivery_boundary")
+                != continuity.get("delivery_boundary")
+            )
+        )
+        or (
+            isinstance(continuity, Mapping)
+            and continuity.get("decision") == "resume_in_flight"
+            and selection != "continuity"
+        )
+        or (selection == "fallback" and fallback_payload is None)
+        or (selection == "none" and boundary is not None)
+        or (selection != "none" and boundary is None)
+        or (
+            isinstance(boundary, Mapping)
+            and boundary.get("todo_id") != selected_todo_id
+        )
     ):
-        raise RuntimeError("TypeScript delivery boundary result shape mismatch")
+        raise RuntimeError("TypeScript delivery routing result shape mismatch")
     return dict(result)

--- a/loopx/control_plane/turn_driver/delivery_continuity.py
+++ b/loopx/control_plane/turn_driver/delivery_continuity.py
@@ -136,10 +136,15 @@ def evaluate_delivery_route(
     safe_agent_id = normalize_todo_claimed_by(agent_id)
     if not safe_agent_id:
         raise ValueError("delivery routing requires a valid agent_id")
-    continuity_payload = _delivery_todo_payload(
-        continuity_todo,
-        actionable=continuity_actionable,
-        capability_ready=continuity_capability_ready,
+    safe_previous_todo_id = normalize_todo_id(previous_todo_id)
+    continuity_payload = (
+        _delivery_todo_payload(
+            continuity_todo,
+            actionable=continuity_actionable,
+            capability_ready=continuity_capability_ready,
+        )
+        if safe_previous_todo_id
+        else None
     )
     fallback_payload = _delivery_todo_payload(
         fallback_todo,
@@ -152,7 +157,7 @@ def evaluate_delivery_route(
             {
                 "schema_version": DELIVERY_ROUTING_REQUEST_SCHEMA,
                 "agent_id": safe_agent_id,
-                "previous_todo_id": normalize_todo_id(previous_todo_id),
+                "previous_todo_id": safe_previous_todo_id,
                 "previous_delivery_outcome": (
                     str(previous_delivery_outcome or "").strip() or None
                 ),
@@ -168,7 +173,7 @@ def evaluate_delivery_route(
     continuity = result.get("continuity")
     boundary = result.get("boundary")
     selection = result.get("selection")
-    continuity_expected = normalize_todo_id(previous_todo_id) is not None
+    continuity_expected = safe_previous_todo_id is not None
     selected_todo_id = (
         (continuity_payload or {}).get("todo_id")
         if selection == "continuity"

--- a/loopx/control_plane/turn_driver/delivery_continuity.ts
+++ b/loopx/control_plane/turn_driver/delivery_continuity.ts
@@ -1,17 +1,24 @@
 import type { JsonObject } from "../effect_program.ts";
 import {
+  optionalNonEmptyString,
+  requireBoolean,
+  requireJsonObject,
+  requireNonEmptyString,
+  requireStringLiteral,
+} from "../runtime_decode.ts";
+import {
   decodeOptionalMaterialDeliveryOutcome,
   type MaterialDeliveryOutcome,
 } from "../work_items/delivery_outcome.ts";
 
-export const DELIVERY_CONTINUITY_REQUEST_SCHEMA =
-  "loopx_delivery_continuity_request_v0";
 export const DELIVERY_CONTINUITY_RESULT_SCHEMA =
   "loopx_delivery_continuity_result_v0";
-export const DELIVERY_BOUNDARY_REQUEST_SCHEMA =
-  "loopx_delivery_boundary_request_v0";
 export const DELIVERY_BOUNDARY_RESULT_SCHEMA =
   "loopx_delivery_boundary_result_v0";
+export const DELIVERY_ROUTING_REQUEST_SCHEMA =
+  "loopx_delivery_routing_request_v0";
+export const DELIVERY_ROUTING_RESULT_SCHEMA =
+  "loopx_delivery_routing_result_v0";
 
 export const DELIVERY_BOUNDARIES = [
   "in_flight_continuation",
@@ -31,6 +38,7 @@ export type DeliveryContinuityPreemption =
   (typeof DELIVERY_CONTINUITY_PREEMPTIONS)[number];
 
 type TodoStatus = "open" | "done" | "blocked" | "deferred";
+const TODO_STATUSES = ["open", "done", "blocked", "deferred"] as const;
 
 export interface DeliveryContinuityTodo {
   todo_id: string;
@@ -41,8 +49,7 @@ export interface DeliveryContinuityTodo {
   capability_ready: boolean;
 }
 
-export interface DeliveryContinuityRequest {
-  schema_version: typeof DELIVERY_CONTINUITY_REQUEST_SCHEMA;
+interface DeliveryContinuityFacts {
   agent_id: string;
   previous_todo_id: string | null;
   previous_delivery_outcome: MaterialDeliveryOutcome | null;
@@ -76,8 +83,7 @@ export type DeliveryContinuityResult = JsonObject & {
   delivery_boundary: DeliveryBoundary;
 };
 
-interface DeliveryBoundaryRequest {
-  schema_version: typeof DELIVERY_BOUNDARY_REQUEST_SCHEMA;
+interface DeliveryBoundaryFacts {
   agent_id: string;
   current_todo: DeliveryContinuityTodo | null;
   preemptions: readonly DeliveryContinuityPreemption[];
@@ -100,40 +106,32 @@ export type DeliveryBoundaryResult = JsonObject & {
   todo_id: string | null;
 };
 
-function requiredObject(value: unknown, label: string): JsonObject {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new Error(`${label} must be an object`);
-  }
-  return value as JsonObject;
+export type DeliveryRoutingSelection = "continuity" | "fallback" | "none";
+
+interface DeliveryRoutingRequest {
+  schema_version: typeof DELIVERY_ROUTING_REQUEST_SCHEMA;
+  agent_id: string;
+  previous_todo_id: string | null;
+  previous_delivery_outcome: MaterialDeliveryOutcome | null;
+  continuity_todo: DeliveryContinuityTodo | null;
+  fallback_todo: DeliveryContinuityTodo | null;
+  preemptions: readonly DeliveryContinuityPreemption[];
 }
 
-function requiredString(value: unknown, label: string): string {
-  if (typeof value !== "string" || !value.trim()) {
-    throw new Error(`${label} must be a non-empty string`);
-  }
-  return value.trim();
-}
+export type DeliveryRoutingResult = JsonObject & {
+  schema_version: typeof DELIVERY_ROUTING_RESULT_SCHEMA;
+  selection: DeliveryRoutingSelection;
+  continuity: DeliveryContinuityResult | null;
+  boundary: DeliveryBoundaryResult | null;
+};
 
-function optionalString(value: unknown, label: string): string | null {
-  if (value === null || value === undefined || value === "") return null;
-  return requiredString(value, label);
-}
-
-function requiredBoolean(value: unknown, label: string): boolean {
-  if (typeof value !== "boolean") {
-    throw new Error(`${label} must be a boolean`);
-  }
-  return value;
-}
-
-function todoStatus(value: unknown): TodoStatus {
-  if (
-    value === "open" || value === "done" || value === "blocked" ||
-    value === "deferred"
-  ) {
-    return value;
-  }
-  throw new Error("current_todo.status is unsupported");
+function todoStatus(value: unknown, label: string): TodoStatus {
+  return requireStringLiteral(
+    value,
+    TODO_STATUSES,
+    label,
+    `${label} is unsupported`,
+  );
 }
 
 function preemptions(value: unknown): DeliveryContinuityPreemption[] {
@@ -154,55 +152,22 @@ function preemptions(value: unknown): DeliveryContinuityPreemption[] {
   return result;
 }
 
-function currentTodo(value: unknown): DeliveryContinuityTodo | null {
-  if (value === null || value === undefined) return null;
-  const todo = requiredObject(value, "current_todo");
-  return {
-    todo_id: requiredString(todo.todo_id, "current_todo.todo_id"),
-    status: todoStatus(todo.status),
-    task_class: requiredString(todo.task_class, "current_todo.task_class"),
-    claimed_by: optionalString(todo.claimed_by, "current_todo.claimed_by"),
-    actionable: requiredBoolean(todo.actionable, "current_todo.actionable"),
-    capability_ready: requiredBoolean(
-      todo.capability_ready,
-      "current_todo.capability_ready",
-    ),
-  };
-}
-
-export function decodeDeliveryContinuityRequest(
+function currentTodo(
   value: unknown,
-): DeliveryContinuityRequest {
-  const request = requiredObject(value, "turn.delivery_continuity params");
-  if (request.schema_version !== DELIVERY_CONTINUITY_REQUEST_SCHEMA) {
-    throw new Error("Delivery continuity request schema mismatch");
-  }
+  label = "current_todo",
+): DeliveryContinuityTodo | null {
+  if (value === null || value === undefined) return null;
+  const todo = requireJsonObject(value, label);
   return {
-    schema_version: DELIVERY_CONTINUITY_REQUEST_SCHEMA,
-    agent_id: requiredString(request.agent_id, "agent_id"),
-    previous_todo_id: optionalString(
-      request.previous_todo_id,
-      "previous_todo_id",
+    todo_id: requireNonEmptyString(todo.todo_id, `${label}.todo_id`),
+    status: todoStatus(todo.status, `${label}.status`),
+    task_class: requireNonEmptyString(todo.task_class, `${label}.task_class`),
+    claimed_by: optionalNonEmptyString(todo.claimed_by, `${label}.claimed_by`),
+    actionable: requireBoolean(todo.actionable, `${label}.actionable`),
+    capability_ready: requireBoolean(
+      todo.capability_ready,
+      `${label}.capability_ready`,
     ),
-    previous_delivery_outcome: decodeOptionalMaterialDeliveryOutcome(
-      request.previous_delivery_outcome,
-      "previous_delivery_outcome",
-    ),
-    current_todo: currentTodo(request.current_todo),
-    preemptions: preemptions(request.preemptions),
-  };
-}
-
-function decodeDeliveryBoundaryRequest(value: unknown): DeliveryBoundaryRequest {
-  const request = requiredObject(value, "turn.delivery_boundary params");
-  if (request.schema_version !== DELIVERY_BOUNDARY_REQUEST_SCHEMA) {
-    throw new Error("Delivery boundary request schema mismatch");
-  }
-  return {
-    schema_version: DELIVERY_BOUNDARY_REQUEST_SCHEMA,
-    agent_id: requiredString(request.agent_id, "agent_id"),
-    current_todo: currentTodo(request.current_todo),
-    preemptions: preemptions(request.preemptions),
   };
 }
 
@@ -222,10 +187,9 @@ function result(
   };
 }
 
-export function evaluateDeliveryContinuity(
-  value: unknown,
+function resolveDeliveryContinuity(
+  request: DeliveryContinuityFacts,
 ): DeliveryContinuityResult {
-  const request = decodeDeliveryContinuityRequest(value);
   const todoId = request.previous_todo_id;
   const preemption = request.preemptions[0];
   if (preemption !== undefined) {
@@ -287,8 +251,9 @@ function boundaryResult(
   };
 }
 
-export function evaluateDeliveryBoundary(value: unknown): DeliveryBoundaryResult {
-  const request = decodeDeliveryBoundaryRequest(value);
+function resolveDeliveryBoundary(
+  request: DeliveryBoundaryFacts,
+): DeliveryBoundaryResult {
   const todo = request.current_todo;
   const todoId = todo?.todo_id ?? null;
   const preemption = request.preemptions[0];
@@ -322,4 +287,64 @@ export function evaluateDeliveryBoundary(value: unknown): DeliveryBoundaryResult
     "open_advancement_todo",
     todoId,
   );
+}
+
+function decodeDeliveryRoutingRequest(value: unknown): DeliveryRoutingRequest {
+  const request = requireJsonObject(value, "turn.delivery_route params");
+  if (request.schema_version !== DELIVERY_ROUTING_REQUEST_SCHEMA) {
+    throw new Error("Delivery routing request schema mismatch");
+  }
+  return {
+    schema_version: DELIVERY_ROUTING_REQUEST_SCHEMA,
+    agent_id: requireNonEmptyString(request.agent_id, "agent_id"),
+    previous_todo_id: optionalNonEmptyString(
+      request.previous_todo_id,
+      "previous_todo_id",
+    ),
+    previous_delivery_outcome: decodeOptionalMaterialDeliveryOutcome(
+      request.previous_delivery_outcome,
+      "previous_delivery_outcome",
+    ),
+    continuity_todo: currentTodo(request.continuity_todo, "continuity_todo"),
+    fallback_todo: currentTodo(request.fallback_todo, "fallback_todo"),
+    preemptions: preemptions(request.preemptions),
+  };
+}
+
+/** Resolve one quota delivery route behind one runtime request/response. */
+export function evaluateDeliveryRoute(value: unknown): DeliveryRoutingResult {
+  const request = decodeDeliveryRoutingRequest(value);
+  const continuity = request.previous_todo_id === null
+    ? null
+    : resolveDeliveryContinuity({
+      agent_id: request.agent_id,
+      previous_todo_id: request.previous_todo_id,
+      previous_delivery_outcome: request.previous_delivery_outcome,
+      current_todo: request.continuity_todo,
+      preemptions: request.preemptions,
+    });
+  const selection: DeliveryRoutingSelection =
+    continuity?.decision === "resume_in_flight"
+      ? "continuity"
+      : request.fallback_todo === null
+      ? "none"
+      : "fallback";
+  const selectedTodo = selection === "continuity"
+    ? request.continuity_todo
+    : selection === "fallback"
+    ? request.fallback_todo
+    : null;
+  const boundary = selectedTodo === null
+    ? null
+    : resolveDeliveryBoundary({
+      agent_id: request.agent_id,
+      current_todo: selectedTodo,
+      preemptions: request.preemptions,
+    });
+  return {
+    schema_version: DELIVERY_ROUTING_RESULT_SCHEMA,
+    selection,
+    continuity,
+    boundary,
+  };
 }

--- a/tests/control_plane/test_delivery_continuity_runtime.py
+++ b/tests/control_plane/test_delivery_continuity_runtime.py
@@ -6,7 +6,7 @@ from loopx.control_plane import effect_runtime
 from loopx.control_plane.turn_driver import delivery_continuity
 
 
-def _runtime_result(**overrides: object) -> dict[str, object]:
+def _continuity_result(**overrides: object) -> dict[str, object]:
     return {
         "schema_version": delivery_continuity.DELIVERY_CONTINUITY_RESULT_SCHEMA,
         "decision": "resume_in_flight",
@@ -17,84 +17,73 @@ def _runtime_result(**overrides: object) -> dict[str, object]:
     }
 
 
-def test_python_facade_sends_one_coarse_typed_request(monkeypatch) -> None:
-    captured: dict[str, object] = {}
-
-    def call(method: str, params: dict[str, object]) -> dict[str, object]:
-        captured["method"] = method
-        captured["params"] = params
-        return _runtime_result()
-
-    monkeypatch.setattr(delivery_continuity, "effect_runtime_result", call)
-    result = delivery_continuity.evaluate_delivery_continuity(
-        agent_id="codex-main",
-        previous_todo_id="todo_current001",
-        previous_delivery_outcome="outcome_progress",
-        current_todo={
-            "todo_id": "todo_current001",
-            "status": "open",
-            "task_class": "advancement_task",
-            "claimed_by": "codex-main",
-        },
-        actionable=True,
-        capability_ready=True,
-    )
-
-    assert result == _runtime_result()
-    assert captured["method"] == "turn.delivery_continuity.evaluate"
-    assert captured["params"] == {
-        "schema_version": delivery_continuity.DELIVERY_CONTINUITY_REQUEST_SCHEMA,
-        "agent_id": "codex-main",
-        "previous_todo_id": "todo_current001",
-        "previous_delivery_outcome": "outcome_progress",
-        "current_todo": {
-            "todo_id": "todo_current001",
-            "status": "open",
-            "task_class": "advancement_task",
-            "claimed_by": "codex-main",
-            "actionable": True,
-            "capability_ready": True,
-        },
-        "preemptions": [],
+def _boundary_result(**overrides: object) -> dict[str, object]:
+    return {
+        "schema_version": delivery_continuity.DELIVERY_BOUNDARY_RESULT_SCHEMA,
+        "delivery_boundary": delivery_continuity.DELIVERY_BOUNDARY_IN_FLIGHT,
+        "reason": "open_advancement_todo",
+        "todo_id": "todo_current001",
+        **overrides,
     }
 
 
-def test_python_facade_asks_ts_for_initial_settlement_boundary(monkeypatch) -> None:
+def _route_result(**overrides: object) -> dict[str, object]:
+    return {
+        "schema_version": delivery_continuity.DELIVERY_ROUTING_RESULT_SCHEMA,
+        "selection": "continuity",
+        "continuity": _continuity_result(),
+        "boundary": _boundary_result(),
+        **overrides,
+    }
+
+
+def test_python_facade_sends_one_delivery_routing_transaction(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
     def call(method: str, params: dict[str, object]) -> dict[str, object]:
         captured["method"] = method
         captured["params"] = params
-        return {
-            "schema_version": delivery_continuity.DELIVERY_BOUNDARY_RESULT_SCHEMA,
-            "delivery_boundary": delivery_continuity.DELIVERY_BOUNDARY_IN_FLIGHT,
-            "reason": "open_advancement_todo",
-            "todo_id": "todo_current001",
-        }
+        return _route_result()
 
     monkeypatch.setattr(delivery_continuity, "effect_runtime_result", call)
-    result = delivery_continuity.evaluate_delivery_boundary(
+    current = {
+        "todo_id": "todo_current001",
+        "status": "open",
+        "task_class": "advancement_task",
+        "claimed_by": "codex-main",
+    }
+    fallback = {
+        "todo_id": "todo_queuehead001",
+        "status": "open",
+        "task_class": "advancement_task",
+        "claimed_by": "codex-main",
+    }
+    result = delivery_continuity.evaluate_delivery_route(
         agent_id="codex-main",
-        current_todo={
-            "todo_id": "todo_current001",
-            "status": "open",
-            "task_class": "advancement_task",
-            "claimed_by": "codex-main",
-        },
-        actionable=True,
-        capability_ready=True,
+        previous_todo_id="todo_current001",
+        previous_delivery_outcome="outcome_progress",
+        continuity_todo=current,
+        continuity_actionable=True,
+        continuity_capability_ready=True,
+        fallback_todo=fallback,
+        fallback_actionable=True,
+        fallback_capability_ready=True,
     )
 
-    assert result["delivery_boundary"] == "in_flight_continuation"
-    assert captured["method"] == "turn.delivery_boundary.evaluate"
+    assert result == _route_result()
+    assert captured["method"] == "turn.delivery_route.evaluate"
     assert captured["params"] == {
-        "schema_version": delivery_continuity.DELIVERY_BOUNDARY_REQUEST_SCHEMA,
+        "schema_version": delivery_continuity.DELIVERY_ROUTING_REQUEST_SCHEMA,
         "agent_id": "codex-main",
-        "current_todo": {
-            "todo_id": "todo_current001",
-            "status": "open",
-            "task_class": "advancement_task",
-            "claimed_by": "codex-main",
+        "previous_todo_id": "todo_current001",
+        "previous_delivery_outcome": "outcome_progress",
+        "continuity_todo": {
+            **current,
+            "actionable": True,
+            "capability_ready": True,
+        },
+        "fallback_todo": {
+            **fallback,
             "actionable": True,
             "capability_ready": True,
         },
@@ -107,9 +96,15 @@ def test_python_facade_asks_ts_for_initial_settlement_boundary(monkeypatch) -> N
     [
         None,
         {},
-        _runtime_result(schema_version="loopx_delivery_continuity_result_v1"),
-        _runtime_result(decision="continue maybe"),
-        _runtime_result(todo_id=[]),
+        _route_result(schema_version="loopx_delivery_routing_result_v1"),
+        _route_result(selection="continue maybe"),
+        _route_result(continuity=None),
+        _route_result(continuity=_continuity_result(todo_id=[])),
+        _route_result(boundary=_boundary_result(reason="free-form prose")),
+        _route_result(
+            boundary=_boundary_result(delivery_boundary="semantic_closeout")
+        ),
+        _route_result(selection="none"),
     ],
 )
 def test_python_facade_rejects_malformed_runtime_results(
@@ -120,14 +115,17 @@ def test_python_facade_rejects_malformed_runtime_results(
         "effect_runtime_result",
         lambda _method, _params: malformed,
     )
-    with pytest.raises(RuntimeError, match="result (must be|shape mismatch)"):
-        delivery_continuity.evaluate_delivery_continuity(
+    with pytest.raises((TypeError, RuntimeError), match="result (must be|shape mismatch)"):
+        delivery_continuity.evaluate_delivery_route(
             agent_id="codex-main",
             previous_todo_id="todo_current001",
             previous_delivery_outcome="outcome_progress",
-            current_todo=None,
-            actionable=False,
-            capability_ready=False,
+            continuity_todo=None,
+            continuity_actionable=False,
+            continuity_capability_ready=False,
+            fallback_todo=None,
+            fallback_actionable=False,
+            fallback_capability_ready=False,
         )
 
 
@@ -137,11 +135,14 @@ def test_python_facade_preserves_typed_rejection(monkeypatch) -> None:
 
     monkeypatch.setattr(delivery_continuity, "effect_runtime_result", reject)
     with pytest.raises(ValueError, match="typed transition rejected"):
-        delivery_continuity.evaluate_delivery_continuity(
+        delivery_continuity.evaluate_delivery_route(
             agent_id="codex-main",
             previous_todo_id="todo_current001",
             previous_delivery_outcome="outcome_progress",
-            current_todo=None,
-            actionable=False,
-            capability_ready=False,
+            continuity_todo=None,
+            continuity_actionable=False,
+            continuity_capability_ready=False,
+            fallback_todo=None,
+            fallback_actionable=False,
+            fallback_capability_ready=False,
         )

--- a/tests/control_plane/test_delivery_continuity_runtime.py
+++ b/tests/control_plane/test_delivery_continuity_runtime.py
@@ -146,3 +146,30 @@ def test_python_facade_preserves_typed_rejection(monkeypatch) -> None:
             fallback_actionable=False,
             fallback_capability_ready=False,
         )
+
+
+def test_python_facade_ignores_unreachable_continuity_without_anchor(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def call(_method: str, params: dict[str, object]) -> dict[str, object]:
+        captured.update(params)
+        return _route_result(selection="none", continuity=None, boundary=None)
+
+    monkeypatch.setattr(delivery_continuity, "effect_runtime_result", call)
+    result = delivery_continuity.evaluate_delivery_route(
+        agent_id="codex-main",
+        previous_todo_id=None,
+        previous_delivery_outcome=None,
+        continuity_todo={"todo_id": "legacy-short-id"},
+        continuity_actionable=True,
+        continuity_capability_ready=True,
+        fallback_todo=None,
+        fallback_actionable=False,
+        fallback_capability_ready=False,
+    )
+
+    assert result["selection"] == "none"
+    assert captured["previous_todo_id"] is None
+    assert captured["continuity_todo"] is None

--- a/tests/control_plane/test_delivery_continuity_selection.py
+++ b/tests/control_plane/test_delivery_continuity_selection.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from loopx.control_plane.quota.should_run import build_quota_should_run
 from loopx.control_plane.testing.quota_fixtures import (
     quota_status_payload,
@@ -113,3 +115,33 @@ def test_same_turn_receipt_still_outranks_cross_heartbeat_continuity() -> None:
     )
     assert packet["selected_todo"].get("selected_by") != "in_flight_todo"
     assert "delivery_continuity" not in packet
+
+
+def test_empty_agent_lane_does_not_call_delivery_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_route(**_kwargs):
+        pytest.fail("an empty projected candidate set must not cross the runtime")
+
+    monkeypatch.setattr(
+        "loopx.control_plane.quota.should_run_packet.evaluate_delivery_route",
+        unexpected_route,
+    )
+    packet = build_quota_should_run(
+        quota_status_payload(
+            goal_id=GOAL_ID,
+            status="active",
+            agent_todo_items=[],
+            recommended_action="Wait for new work.",
+            coordination={
+                "agent_model": "peer_v1",
+                "registered_agents": [AGENT_ID],
+            },
+            claim_scope_agent_id=AGENT_ID,
+        ),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+
+    assert "selected_todo" not in packet
+    assert "agent_lane_next_action" not in packet

--- a/tests/control_plane_ts/delivery_continuity.test.ts
+++ b/tests/control_plane_ts/delivery_continuity.test.ts
@@ -2,48 +2,82 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
-  DELIVERY_BOUNDARY_REQUEST_SCHEMA,
-  DELIVERY_CONTINUITY_REQUEST_SCHEMA,
-  evaluateDeliveryBoundary,
-  evaluateDeliveryContinuity,
+  DELIVERY_ROUTING_REQUEST_SCHEMA,
+  evaluateDeliveryRoute,
 } from "../../loopx/control_plane/turn_driver/delivery_continuity.ts";
 
-function request(overrides: Record<string, unknown> = {}) {
+function todo(overrides: Record<string, unknown> = {}) {
   return {
-    schema_version: DELIVERY_CONTINUITY_REQUEST_SCHEMA,
-    agent_id: "codex-main",
-    previous_todo_id: "todo_current001",
-    previous_delivery_outcome: "outcome_progress",
-    current_todo: {
-      todo_id: "todo_current001",
-      status: "open",
-      task_class: "advancement_task",
-      claimed_by: "codex-main",
-      actionable: true,
-      capability_ready: true,
-    },
-    preemptions: [],
+    todo_id: "todo_current001",
+    status: "open",
+    task_class: "advancement_task",
+    claimed_by: "codex-main",
+    actionable: true,
+    capability_ready: true,
     ...overrides,
   };
 }
 
-test("same open Todo resumes after accountable progress", () => {
-  assert.deepEqual(evaluateDeliveryContinuity(request()), {
-    schema_version: "loopx_delivery_continuity_result_v0",
-    decision: "resume_in_flight",
-    reason: "same_open_todo_after_progress",
-    todo_id: "todo_current001",
-    delivery_boundary: "in_flight_continuation",
+function route(overrides: Record<string, unknown> = {}) {
+  return evaluateDeliveryRoute({
+    schema_version: DELIVERY_ROUTING_REQUEST_SCHEMA,
+    agent_id: "codex-main",
+    previous_todo_id: "todo_current001",
+    previous_delivery_outcome: "outcome_progress",
+    continuity_todo: todo(),
+    fallback_todo: todo({ todo_id: "todo_queuehead001" }),
+    preemptions: [],
+    ...overrides,
+  });
+}
+
+test("one routing transaction keeps continuity ahead of the fallback", () => {
+  assert.deepEqual(route(), {
+    schema_version: "loopx_delivery_routing_result_v0",
+    selection: "continuity",
+    continuity: {
+      schema_version: "loopx_delivery_continuity_result_v0",
+      decision: "resume_in_flight",
+      reason: "same_open_todo_after_progress",
+      todo_id: "todo_current001",
+      delivery_boundary: "in_flight_continuation",
+    },
+    boundary: {
+      schema_version: "loopx_delivery_boundary_result_v0",
+      delivery_boundary: "in_flight_continuation",
+      reason: "open_advancement_todo",
+      todo_id: "todo_current001",
+    },
+  });
+});
+
+test("one routing transaction releases to fallback or no selection", () => {
+  const fallback = route({ previous_delivery_outcome: "outcome_gap" });
+  assert.equal(fallback.selection, "fallback");
+  assert.equal(fallback.boundary?.todo_id, "todo_queuehead001");
+
+  assert.deepEqual(route({
+    previous_todo_id: null,
+    previous_delivery_outcome: null,
+    continuity_todo: null,
+    fallback_todo: null,
+  }), {
+    schema_version: "loopx_delivery_routing_result_v0",
+    selection: "none",
+    continuity: null,
+    boundary: null,
   });
 });
 
 test("an initially selected open advancement Todo settles as in flight", () => {
-  assert.deepEqual(evaluateDeliveryBoundary({
-    schema_version: DELIVERY_BOUNDARY_REQUEST_SCHEMA,
-    agent_id: "codex-main",
-    current_todo: request().current_todo,
-    preemptions: [],
-  }), {
+  const result = route({
+    previous_todo_id: null,
+    previous_delivery_outcome: null,
+    continuity_todo: null,
+    fallback_todo: todo(),
+  });
+  assert.equal(result.selection, "fallback");
+  assert.deepEqual(result.boundary, {
     schema_version: "loopx_delivery_boundary_result_v0",
     delivery_boundary: "in_flight_continuation",
     reason: "open_advancement_todo",
@@ -52,60 +86,63 @@ test("an initially selected open advancement Todo settles as in flight", () => {
 });
 
 test("non-advancement and preempted selections settle strictly", () => {
-  const selectedTodo = request().current_todo as Record<string, unknown>;
-  assert.equal(evaluateDeliveryBoundary({
-    schema_version: DELIVERY_BOUNDARY_REQUEST_SCHEMA,
-    agent_id: "codex-main",
-    current_todo: { ...selectedTodo, task_class: "monitor_task" },
-    preemptions: [],
-  }).delivery_boundary, "semantic_closeout");
-  assert.equal(evaluateDeliveryBoundary({
-    schema_version: DELIVERY_BOUNDARY_REQUEST_SCHEMA,
-    agent_id: "codex-main",
-    current_todo: selectedTodo,
+  const nonAdvancement = route({
+    previous_todo_id: null,
+    previous_delivery_outcome: null,
+    continuity_todo: null,
+    fallback_todo: todo({ task_class: "monitor_task" }),
+  });
+  assert.equal(nonAdvancement.boundary?.delivery_boundary, "semantic_closeout");
+
+  const preempted = route({
+    previous_todo_id: null,
+    previous_delivery_outcome: null,
+    continuity_todo: null,
+    fallback_todo: todo(),
     preemptions: ["autonomous_replan"],
-  }).reason, "autonomous_replan");
+  });
+  assert.equal(preempted.boundary?.reason, "autonomous_replan");
 });
 
 test("terminal and outcome-gap anchors release normal reselection", () => {
-  assert.equal(
-    evaluateDeliveryContinuity(request({
-      current_todo: {
-        ...(request().current_todo as Record<string, unknown>),
-        status: "done",
-      },
-    })).reason,
-    "todo_not_open",
-  );
-  assert.equal(
-    evaluateDeliveryContinuity(request({
-      previous_delivery_outcome: "outcome_gap",
-    })).reason,
-    "previous_delivery_not_progress",
-  );
+  const terminal = route({
+    continuity_todo: todo({ status: "done" }),
+  });
+  assert.equal(terminal.selection, "fallback");
+  assert.equal(terminal.continuity?.reason, "todo_not_open");
+
+  const outcomeGap = route({ previous_delivery_outcome: "outcome_gap" });
+  assert.equal(outcomeGap.selection, "fallback");
+  assert.equal(outcomeGap.continuity?.reason, "previous_delivery_not_progress");
 });
 
 test("typed control obligations preempt sticky delivery", () => {
-  const result = evaluateDeliveryContinuity(request({
+  const result = route({
+    fallback_todo: null,
     preemptions: ["autonomous_replan", "delivery_not_allowed"],
-  }));
-  assert.equal(result.decision, "preempt");
-  assert.equal(result.reason, "autonomous_replan");
-  assert.equal(result.delivery_boundary, "semantic_closeout");
+  });
+  assert.equal(result.selection, "none");
+  assert.equal(result.continuity?.decision, "preempt");
+  assert.equal(result.continuity?.reason, "autonomous_replan");
+  assert.equal(result.continuity?.delivery_boundary, "semantic_closeout");
 });
 
 test("runtime decoder rejects malformed projection facts", () => {
   assert.throws(
-    () => evaluateDeliveryContinuity(request({ preemptions: ["urgent prose"] })),
+    () => route({ preemptions: ["urgent prose"] }),
     /unsupported reason/,
   );
   assert.throws(
-    () => evaluateDeliveryContinuity(request({
-      current_todo: {
-        ...(request().current_todo as Record<string, unknown>),
-        actionable: "true",
-      },
-    })),
-    /actionable must be a boolean/,
+    () => route({ continuity_todo: todo({ actionable: "true" }) }),
+    /continuity_todo.actionable must be a boolean/,
+  );
+  assert.throws(
+    () => route({
+      previous_todo_id: null,
+      previous_delivery_outcome: null,
+      continuity_todo: null,
+      fallback_todo: todo({ capability_ready: "yes" }),
+    }),
+    /fallback_todo.capability_ready must be a boolean/,
   );
 });


### PR DESCRIPTION
## Summary

- replace separate delivery-continuity and settlement-boundary runtime calls with one TypeScript-owned `turn.delivery_route.evaluate` transaction
- keep Python as a one-request/one-response projection adapter and remove its continuity-specific semantic composition
- preserve the complete public quota packet while cutting one cross-runtime call from the continuity hot path
- preserve the old zero-call path when neither an anchor nor a projected candidate exists
- record the cutover and facade-exit criteria in both TypeScript migration RFCs

## Ownership and migration economics

- Canonical owner before: Python composed two TypeScript leaf decisions and re-selected continuity in quota projection.
- Canonical owner after: TypeScript selects `continuity | fallback | none` and returns the matching boundary atomically; Python only projects candidates and the selected Todo into the existing packet.
- Cross-runtime calls: continuity path `2 → 1`; fallback/preempted path `1 → 1`; empty no-anchor candidate set `0 → 0`.
- Product diff: `+370/-246` (net `+124`); Python product code `+255/-154`, TypeScript product code `+115/-92`.
- Bridge cost: the fail-closed Python facade is `+107/-66`; it validates request/result identity and cannot recreate route semantics.
- Tests: `+237/-140`; docs: `+21/-0`.
- Removed migration surface: both leaf runtime handlers, their request schemas, leaf Python APIs, and the continuity-specific quota helper.
- Facade exit: delete the Python facade when quota packet assembly/CLI moves into the TypeScript runtime; the separate vision-checkpoint transaction remains intentionally outside this routing transaction.

## Review refinements

- fixed the scheduler regression by not serializing or validating a continuity candidate when no normalized previous-Todo anchor exists
- added a negative regression proving a legacy/non-delivery Todo is ignored on that unreachable path
- preserved the empty-lane zero-call behavior with a test that fails if the runtime is invoked without an anchor or candidate
- clarified the exact call economics in both RFC languages

## Validation

- `npm run typecheck:control-plane`
- `npm run test:control-plane` — 85/85
- focused Python delivery/quota/scheduler suite — 358/358
- final exact-head subset after rebase — 203/203
- strict mypy of the changed Python runtime facade; Ruff and diff hygiene pass
- exact latest-`origin/main` parity — four complete 69,352-byte packets (continuity, outcome gap, blocked, receipt-bound), byte-for-byte equal
- clean wheel and sdist install plus delivery-route semantic probes
- matched warm quota latency, 10 × 400 packets:
  - p50: `3.072ms → 1.968ms`
  - p95: `3.988ms → 2.725ms`
- maintainability ratchet: no diff-owned finding
- public/private boundary scan: pass
- change-quality receipt: `cqr_bd745300ec144c955c37` (`pass`, exact head/base)

`loopx canary premerge --from-git-diff` selected 18 checks. Seventeen pass, including every direct check, maintainability and hot-path checks, all eight risk-profile smokes, public-boundary validation, and the exact-scope quality receipt. Its sole failing catalog smoke is inherited from current `main`: `agent-identity-readmodel-smoke.py` still requires the removed `registered_agents=` error prose. The same failure reproduces on exact base commit `5ddef829b` and does not exercise this PR's changed files. Canary therefore reports `self_merge_allowed=false`; this PR remains open rather than bypassing that gate.

## Test strategy

The behavior contract is deterministic and the public packet is unchanged, so exact full-packet parity plus typed negative-boundary tests are the authoritative oracle. No model-behavior test was added because this change does not alter model-facing prompts, action vocabulary, or tool-selection guidance.

## Future-facing pass

Applied within scope: removed duplicate leaf authority, extracted one cohesive Python projection boundary, and retained the zero-cost empty route. No new server, schema framework, or speculative compatibility layer was added.
