### PR TITLE
fix(ssh-source): tolerate slow remote status probes in ensure

### DIFF
--- a/loopx/control_plane/status/ssh_tunnel.py
+++ b/loopx/control_plane/status/ssh_tunnel.py
@@ -36,7 +36,7 @@ _REMOTE_BOOTSTRAP = (
 )
 
 
-def _loopback_status_ok(port: int, *, timeout: float = 2.0) -> bool:
+def _loopback_status_ok(port: int, *, timeout: float = 8.0) -> bool:
     try:
         with urllib.request.urlopen(
             f"http://127.0.0.1:{port}/status.json", timeout=timeout


### PR DESCRIPTION
## Summary

`ensure_ssh_source` probed the tunneled status URL with a 2s per-attempt timeout. Slow-but-working remote status servers (observed ~4s responses for ark-devbox) were misreported as unreachable, so the app returned "SSH tunnel source is not reachable" instead of switching. Raise the probe timeout to 8s.

## Validation

- `python3 -m py_compile loopx/control_plane/status/ssh_tunnel.py`: clean.
- `git diff --check`: clean.
