### PR TITLE
Add Agent-scoped external Connector runtime

### DIFF
--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -40,6 +40,44 @@ Agent -> Capability -> Provider -> external system
 Provider readback -> Capability transition proposal -> LoopX Kernel
 ```
 
+### Agent-scoped external event connectors
+
+`loopx.extensions.external_connector_runtime` defines the provider-neutral
+binding shared by interactive group messages and document-comment streams. It
+keeps source and cursor references owner-local while exposing a content-free
+status projection with source kind, capture policy, ingress policy, response
+policy, lifecycle, and declared operations.
+
+The contract separates three independent decisions:
+
+- capture: addressed events, all events from one configured source, or an
+  incremental source stream;
+- ingress: live steering, the same session's ordered queue, or an Agent-scoped
+  asynchronous inbox; and
+- response: no response, source-thread response, topic response, or a
+  configured mirror.
+
+Live steering and session queue bindings require one exact Agent session;
+asynchronous inbox bindings require one owner-local inbox. History catch-up
+requires a cursor reference. A response-capable provider must declare both
+write and readback support.
+
+Acknowledgement is a separate fail-closed decision. LoopX permits ACK and
+cursor advancement only after a committed durable effect (including an
+explicit no-follow-up effect) and, when a response is required, verified
+provider readback. For an ordered working-session delivery, the completed and
+persisted session Turn is the minimum effect receipt; an asynchronous inbox
+requires its own accepted writeback or explicit no-follow-up receipt. Raw event
+bodies, author identities, source references, cursor values, and provider
+payloads do not enter the status projection.
+
+The Agent-bound Lark Goal Topic path is the first caller. Legacy Goal-only
+bindings remain readable, while new live, queued, and asynchronous Agent
+bindings persist the generic Connector contract alongside their
+provider-specific routing data. This runtime contract is not itself a new
+capability registry entry; providers advertise stable caller outcomes through
+their existing extension and capability surfaces.
+
 `Provider` is an implementation role. When it implements a LoopX capability,
 it is registered under that capability; a standalone extension provider may
 instead expose only its own bounded command. A provider may be built into LoopX

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -92,10 +92,13 @@ The bound Agent drains pending events in that order. Settlement rejects an
 out-of-order event and calls the common ACK decision, so a missing durable
 effect or required provider readback leaves both the event and cursor pending.
 Only a successful settlement records the event as acknowledged, and only the
-last accepted event from a captured page advances its cursor. Provider failures
-are stored as content-free error codes. The public inbox projection exposes
-only pending count, oldest age, failure count, and freshness; event ids, bodies,
-anchors, reply chains, source references, and cursor values remain owner-local.
+last accepted event from a captured page advances its cursor. After that state
+is durably committed, the processed private event body is removed; its
+content-free identity remains available for replay deduplication. Provider
+failures are stored as content-free error codes. The public inbox projection
+exposes only pending count, oldest age, failure count, and freshness; event ids,
+bodies, anchors, reply chains, source references, and cursor values remain
+owner-local.
 
 `loopx.extensions.external_connector_provider` adds the fail-closed provider
 call boundary for document comments. A document-comment registration must
@@ -112,9 +115,9 @@ The provider call sequence is permission evaluation, bounded page read,
 durable inbox capture, Agent effect, provider response with readback, then ACK.
 The runtime does not call the page reader until the registered permissions are
 ready, does not call the response writer before a committed effect receipt, and
-does not advance the cursor until response readback succeeds. Concrete provider
-adapters supply the page reader and response writer; LoopX does not own their
-credentials or raw payloads.
+does not advance the cursor until an event-bound response receipt and provider
+readback succeed. Concrete provider adapters supply the page reader and response
+writer; LoopX does not own their credentials or raw payloads.
 
 `Provider` is an implementation role. When it implements a LoopX capability,
 it is registered under that capability; a standalone extension provider may

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -78,6 +78,25 @@ provider-specific routing data. This runtime contract is not itself a new
 capability registry entry; providers advertise stable caller outcomes through
 their existing extension and capability surfaces.
 
+For asynchronous sources, the same module provides an owner-local incremental
+inbox runtime. A provider translates a bounded page into
+`agent_external_connector_event_v0` envelopes and calls the capture operation
+with the exact previously committed cursor. Capture deduplicates stable event
+ids, applies the declared addressed/all-source filter, preserves document
+anchors and reply-chain references in private storage, and assigns a restart-
+safe order. The page cursor remains pending until every accepted event from
+that page is settled; a fully filtered page may checkpoint immediately because
+it contains no accepted Agent input.
+
+The bound Agent drains pending events in that order. Settlement rejects an
+out-of-order event and calls the common ACK decision, so a missing durable
+effect or required provider readback leaves both the event and cursor pending.
+Only a successful settlement records the event as acknowledged, and only the
+last accepted event from a captured page advances its cursor. Provider failures
+are stored as content-free error codes. The public inbox projection exposes
+only pending count, oldest age, failure count, and freshness; event ids, bodies,
+anchors, reply chains, source references, and cursor values remain owner-local.
+
 `Provider` is an implementation role. When it implements a LoopX capability,
 it is registered under that capability; a standalone extension provider may
 instead expose only its own bounded command. A provider may be built into LoopX

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -97,6 +97,25 @@ are stored as content-free error codes. The public inbox projection exposes
 only pending count, oldest age, failure count, and freshness; event ids, bodies,
 anchors, reply chains, source references, and cursor values remain owner-local.
 
+`loopx.extensions.external_connector_provider` adds the fail-closed provider
+call boundary for document comments. A document-comment registration must
+reference material that was registered separately; the comment stream remains
+`external_input_only` and cannot promote itself to project authority. Exact
+provider identities, scopes, publication requirements, and official HTTPS
+repair URLs stay in owner-local permission guidance. Status exposes only
+content-free readiness and operation counts. Guidance must match the exact
+requirements persisted with the Connector, and those requirements must cover
+history capture plus response write and readback when the response policy needs
+them.
+
+The provider call sequence is permission evaluation, bounded page read,
+durable inbox capture, Agent effect, provider response with readback, then ACK.
+The runtime does not call the page reader until the registered permissions are
+ready, does not call the response writer before a committed effect receipt, and
+does not advance the cursor until response readback succeeds. Concrete provider
+adapters supply the page reader and response writer; LoopX does not own their
+credentials or raw payloads.
+
 `Provider` is an implementation role. When it implements a LoopX capability,
 it is registered under that capability; a standalone extension provider may
 instead expose only its own bounded command. A provider may be built into LoopX

--- a/loopx/extensions/external_connector_provider.py
+++ b/loopx/extensions/external_connector_provider.py
@@ -1,0 +1,665 @@
+"""Provider call boundary for Agent-scoped external Connectors.
+
+The provider owns credentials, API payloads, exact scopes, repair URLs, and
+external writes.  LoopX owns the typed binding, owner-local inbox, durable
+effect ordering, and content-free status projection.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+from urllib.parse import urlsplit
+
+from ..authority import normalize_project_materials
+from .external_connector_runtime import (
+    CONNECTOR_SCHEMA_VERSION,
+    EVENT_SCHEMA_VERSION,
+    ExternalConnectorCapability,
+    ExternalResponsePolicy,
+    ExternalSourceKind,
+    capture_external_connector_events,
+    decide_external_event_ack,
+    drain_external_connector_inbox,
+    normalize_external_connector_binding,
+    project_external_connector_status,
+    settle_external_connector_event,
+)
+
+PERMISSION_REQUIREMENT_SCHEMA_VERSION = (
+    "agent_external_connector_permission_requirement_v0"
+)
+PERMISSION_GUIDANCE_SCHEMA_VERSION = "agent_external_connector_permission_guidance_v0"
+DOCUMENT_COMMENT_REGISTRATION_SCHEMA_VERSION = (
+    "agent_document_comment_connector_registration_v0"
+)
+PROVIDER_PAGE_SCHEMA_VERSION = "agent_external_connector_provider_page_v0"
+
+SAFE_TOKEN_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,199}")
+SAFE_SCOPE_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:/-]{0,199}")
+
+ProviderPageReader = Callable[[Mapping[str, Any], str | None, int], Mapping[str, Any]]
+ProviderResponseWriter = Callable[
+    [Mapping[str, Any], Mapping[str, Any], str, str],
+    Mapping[str, Any],
+]
+
+
+def _safe_token(value: Any, *, field: str) -> str:
+    normalized = str(value or "").strip()
+    if not SAFE_TOKEN_PATTERN.fullmatch(normalized):
+        raise ValueError(f"{field} must be an opaque public-safe token")
+    return normalized
+
+
+def _scope_values(values: Sequence[str], *, field: str) -> list[str]:
+    normalized = {str(value or "").strip() for value in values}
+    if not normalized or any(
+        not SAFE_SCOPE_PATTERN.fullmatch(value) for value in normalized
+    ):
+        raise ValueError(f"{field} must contain provider scope tokens")
+    return sorted(normalized)
+
+
+def _repair_url(value: Any) -> str:
+    normalized = str(value or "").strip()
+    parsed = urlsplit(normalized)
+    if (
+        parsed.scheme != "https"
+        or not parsed.netloc
+        or parsed.username
+        or parsed.password
+        or parsed.fragment
+        or len(normalized) > 2048
+    ):
+        raise ValueError("repair_url must be a bounded official HTTPS URL")
+    return normalized
+
+
+def build_external_connector_permission_requirement(
+    *,
+    provider_kind: str,
+    provider_identity: str,
+    operation: str,
+    required_scopes: Sequence[str],
+    publication_required: bool,
+    repair_url: str,
+) -> dict[str, Any]:
+    """Build provider-owned, owner-local permission repair guidance."""
+
+    try:
+        capability = ExternalConnectorCapability(str(operation or "").strip()).value
+    except ValueError as exc:
+        allowed = ", ".join(item.value for item in ExternalConnectorCapability)
+        raise ValueError(f"operation must be one of: {allowed}") from exc
+    return {
+        "schema_version": PERMISSION_REQUIREMENT_SCHEMA_VERSION,
+        "provider_kind": _safe_token(provider_kind, field="provider_kind"),
+        "provider_identity": _safe_token(
+            provider_identity,
+            field="provider_identity",
+        ),
+        "operation": capability,
+        "required_scopes": _scope_values(
+            required_scopes,
+            field="required_scopes",
+        ),
+        "publication_required": bool(publication_required),
+        "repair_url": _repair_url(repair_url),
+    }
+
+
+def _normalize_permission_requirement(value: Mapping[str, Any]) -> dict[str, Any]:
+    if value.get("schema_version") != PERMISSION_REQUIREMENT_SCHEMA_VERSION:
+        raise ValueError("external connector permission requirement schema is invalid")
+    scopes = value.get("required_scopes")
+    if not isinstance(scopes, Sequence) or isinstance(scopes, (str, bytes)):
+        raise TypeError("required_scopes must be a sequence")
+    return build_external_connector_permission_requirement(
+        provider_kind=str(value.get("provider_kind") or ""),
+        provider_identity=str(value.get("provider_identity") or ""),
+        operation=str(value.get("operation") or ""),
+        required_scopes=[str(scope) for scope in scopes],
+        publication_required=value.get("publication_required") is True,
+        repair_url=str(value.get("repair_url") or ""),
+    )
+
+
+def _normalize_permission_requirements(
+    values: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    if isinstance(values, (str, bytes)) or any(
+        not isinstance(requirement, Mapping) for requirement in values
+    ):
+        raise TypeError("external connector permission requirements are invalid")
+    requirements = [
+        _normalize_permission_requirement(requirement) for requirement in values
+    ]
+    identities = [
+        (
+            requirement["provider_kind"],
+            requirement["provider_identity"],
+            requirement["operation"],
+        )
+        for requirement in requirements
+    ]
+    if len(identities) != len(set(identities)):
+        raise ValueError("external connector permission requirements are duplicated")
+    return requirements
+
+
+def _permission_requirement_fingerprint(
+    requirement: Mapping[str, Any],
+) -> tuple[Any, ...]:
+    return (
+        requirement["provider_kind"],
+        requirement["provider_identity"],
+        requirement["operation"],
+        tuple(requirement["required_scopes"]),
+        requirement["publication_required"],
+        requirement["repair_url"],
+    )
+
+
+def evaluate_external_connector_permissions(
+    *,
+    requirements: Sequence[Mapping[str, Any]],
+    granted_scopes: Mapping[str, Sequence[str]],
+    published: bool,
+) -> dict[str, Any]:
+    """Return exact owner-local guidance without promoting it to public status."""
+
+    normalized_requirements = _normalize_permission_requirements(requirements)
+    items: list[dict[str, Any]] = []
+    for requirement in normalized_requirements:
+        identity = str(requirement["provider_identity"])
+        granted = {
+            str(scope or "").strip() for scope in granted_scopes.get(identity, [])
+        }
+        missing_scopes = [
+            scope for scope in requirement["required_scopes"] if scope not in granted
+        ]
+        publication_ready = bool(
+            published or requirement["publication_required"] is not True
+        )
+        ready = not missing_scopes and publication_ready
+        items.append(
+            {
+                **requirement,
+                "missing_scopes": missing_scopes,
+                "publication_ready": publication_ready,
+                "ready": ready,
+            }
+        )
+    return {
+        "ok": True,
+        "schema_version": PERMISSION_GUIDANCE_SCHEMA_VERSION,
+        "ready": all(item["ready"] for item in items),
+        "requirement_count": len(items),
+        "missing_requirement_count": sum(not item["ready"] for item in items),
+        "items": items,
+        "local_private_guidance_returned": bool(items),
+        "credentials_captured": False,
+    }
+
+
+def _normalize_permission_guidance(value: Mapping[str, Any]) -> dict[str, Any]:
+    if value.get("schema_version") != PERMISSION_GUIDANCE_SCHEMA_VERSION:
+        raise ValueError("external connector permission guidance schema is invalid")
+    raw_items = value.get("items")
+    if not isinstance(raw_items, list) or any(
+        not isinstance(item, Mapping) for item in raw_items
+    ):
+        raise TypeError("external connector permission guidance items are invalid")
+    items: list[dict[str, Any]] = []
+    for raw_item in raw_items:
+        requirement = _normalize_permission_requirement(raw_item)
+        missing_scopes = raw_item.get("missing_scopes")
+        if not isinstance(missing_scopes, list):
+            raise TypeError("permission missing_scopes are invalid")
+        normalized_missing = (
+            _scope_values(
+                [str(scope) for scope in missing_scopes],
+                field="missing_scopes",
+            )
+            if missing_scopes
+            else []
+        )
+        if not set(normalized_missing).issubset(requirement["required_scopes"]):
+            raise ValueError("missing_scopes must belong to required_scopes")
+        publication_ready = raw_item.get("publication_ready") is True
+        expected_ready = not normalized_missing and publication_ready
+        if (raw_item.get("ready") is True) != expected_ready:
+            raise ValueError("permission guidance ready state is inconsistent")
+        items.append(
+            {
+                **requirement,
+                "missing_scopes": normalized_missing,
+                "publication_ready": publication_ready,
+                "ready": expected_ready,
+            }
+        )
+    ready = all(item["ready"] for item in items)
+    if (value.get("ready") is True) != ready:
+        raise ValueError("permission guidance aggregate ready state is inconsistent")
+    return {
+        "schema_version": PERMISSION_GUIDANCE_SCHEMA_VERSION,
+        "ready": ready,
+        "requirement_count": len(items),
+        "missing_requirement_count": sum(not item["ready"] for item in items),
+        "items": items,
+    }
+
+
+def _permission_guidance_for_registration(
+    *,
+    registration: Mapping[str, Any],
+    permission_guidance: Mapping[str, Any],
+) -> dict[str, Any]:
+    normalized_guidance = _normalize_permission_guidance(permission_guidance)
+    expected = sorted(
+        _permission_requirement_fingerprint(requirement)
+        for requirement in registration["permission_requirements"]
+    )
+    observed = sorted(
+        _permission_requirement_fingerprint(requirement)
+        for requirement in normalized_guidance["items"]
+    )
+    if observed != expected:
+        raise ValueError(
+            "permission guidance must match the registered Connector requirements"
+        )
+    return normalized_guidance
+
+
+def project_external_connector_permission_status(
+    guidance: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Hide exact scopes and repair URLs from status and quota projections."""
+
+    normalized = _normalize_permission_guidance(guidance)
+    items = normalized["items"]
+    operations = sorted(
+        {
+            _safe_token(item.get("operation"), field="operation")
+            for item in items
+            if isinstance(item, Mapping)
+        }
+    )
+    return {
+        "schema_version": "agent_external_connector_permission_status_v0",
+        "ready": normalized["ready"],
+        "requirement_count": len(items),
+        "missing_requirement_count": sum(
+            isinstance(item, Mapping) and item.get("ready") is not True
+            for item in items
+        ),
+        "operations": operations,
+        "publication_required": any(
+            isinstance(item, Mapping) and item.get("publication_required") is True
+            for item in items
+        ),
+        "private_scope_values_captured": False,
+        "private_repair_urls_captured": False,
+        "private_provider_identity_captured": False,
+    }
+
+
+def _validate_permission_requirements_for_connector(
+    *,
+    connector: Mapping[str, Any],
+    requirements: Sequence[Mapping[str, Any]],
+) -> None:
+    capability_values = set(connector["capabilities"])
+    for requirement in requirements:
+        if requirement["provider_kind"] != connector["provider_kind"]:
+            raise ValueError("permission provider_kind must match the Connector")
+        if requirement["operation"] not in capability_values:
+            raise ValueError("permission operation must be advertised by the Connector")
+    required_operations = {ExternalConnectorCapability.HISTORY_CATCH_UP.value}
+    if connector["response_policy"] != ExternalResponsePolicy.NO_RESPONSE.value:
+        required_operations.update(
+            {
+                ExternalConnectorCapability.RESPONSE_WRITE.value,
+                ExternalConnectorCapability.RESPONSE_READBACK.value,
+            }
+        )
+    missing_operations = required_operations.difference(
+        requirement["operation"] for requirement in requirements
+    )
+    if missing_operations:
+        raise ValueError(
+            "document-comment permission requirements do not cover provider calls"
+        )
+
+
+def build_document_comment_connector_registration(
+    *,
+    connector: Mapping[str, Any],
+    authority_material_ref: str,
+    project_materials: Mapping[str, Any] | Sequence[Mapping[str, Any]],
+    permission_requirements: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Link comments to a separately registered material without granting authority."""
+
+    normalized_connector = normalize_external_connector_binding(connector)
+    if normalized_connector["source_kind"] != ExternalSourceKind.DOCUMENT_COMMENT.value:
+        raise ValueError("document-comment registration requires document_comment")
+    material_ref = _safe_token(
+        authority_material_ref,
+        field="authority_material_ref",
+    )
+    materials = normalize_project_materials(project_materials)
+    if material_ref not in materials:
+        raise ValueError("authority material must be registered before its comments")
+    requirements = _normalize_permission_requirements(permission_requirements)
+    _validate_permission_requirements_for_connector(
+        connector=normalized_connector,
+        requirements=requirements,
+    )
+    return {
+        "schema_version": DOCUMENT_COMMENT_REGISTRATION_SCHEMA_VERSION,
+        "connector": normalized_connector,
+        "authority_material_ref": material_ref,
+        "authority_relation": "reference_only",
+        "comment_authority": "external_input_only",
+        "permission_requirements": requirements,
+    }
+
+
+def project_document_comment_connector_status(
+    *,
+    registration: Mapping[str, Any],
+    permission_guidance: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Project a content-free registration and permission status."""
+
+    normalized = _normalize_document_comment_registration(registration)
+    normalized_guidance = _permission_guidance_for_registration(
+        registration=normalized,
+        permission_guidance=permission_guidance,
+    )
+    return {
+        "schema_version": "agent_document_comment_connector_status_v0",
+        "connector": project_external_connector_status(normalized["connector"]),
+        "authority_material_bound": True,
+        "authority_relation": normalized["authority_relation"],
+        "comment_authority": normalized["comment_authority"],
+        "permissions": project_external_connector_permission_status(
+            normalized_guidance
+        ),
+        "private_authority_material_ref_captured": False,
+    }
+
+
+def _normalize_document_comment_registration(
+    value: Mapping[str, Any],
+) -> dict[str, Any]:
+    if value.get("schema_version") != DOCUMENT_COMMENT_REGISTRATION_SCHEMA_VERSION:
+        raise ValueError("document-comment Connector registration schema is invalid")
+    connector = value.get("connector")
+    if not isinstance(connector, Mapping):
+        raise TypeError("document-comment Connector is invalid")
+    normalized_connector = normalize_external_connector_binding(connector)
+    if normalized_connector["schema_version"] != CONNECTOR_SCHEMA_VERSION:
+        raise ValueError("document-comment Connector schema is invalid")
+    if normalized_connector["source_kind"] != ExternalSourceKind.DOCUMENT_COMMENT.value:
+        raise ValueError("document-comment registration source kind is invalid")
+    if value.get("authority_relation") != "reference_only":
+        raise ValueError("document-comment authority relation is invalid")
+    if value.get("comment_authority") != "external_input_only":
+        raise ValueError("document-comment authority policy is invalid")
+    requirements = value.get("permission_requirements")
+    if not isinstance(requirements, list) or any(
+        not isinstance(requirement, Mapping) for requirement in requirements
+    ):
+        raise TypeError("document-comment permission requirements are invalid")
+    normalized_requirements = _normalize_permission_requirements(requirements)
+    _validate_permission_requirements_for_connector(
+        connector=normalized_connector,
+        requirements=normalized_requirements,
+    )
+    return {
+        "schema_version": DOCUMENT_COMMENT_REGISTRATION_SCHEMA_VERSION,
+        "connector": normalized_connector,
+        "authority_material_ref": _safe_token(
+            value.get("authority_material_ref"),
+            field="authority_material_ref",
+        ),
+        "authority_relation": "reference_only",
+        "comment_authority": "external_input_only",
+        "permission_requirements": normalized_requirements,
+    }
+
+
+def build_external_connector_provider_page(
+    *,
+    events: Sequence[Mapping[str, Any]],
+    expected_cursor: str | None,
+    next_cursor: str,
+    has_more: bool,
+) -> dict[str, Any]:
+    """Build one owner-private page returned by a provider adapter."""
+
+    if len(events) > 500:
+        raise ValueError("external connector provider page exceeds 500 events")
+    for event in events:
+        if not isinstance(event, Mapping):
+            raise TypeError("provider page events must be objects")
+        if event.get("schema_version") != EVENT_SCHEMA_VERSION:
+            raise ValueError("provider page contains an invalid event schema")
+    normalized_next_cursor = str(next_cursor or "").strip()
+    if not normalized_next_cursor or len(normalized_next_cursor) > 2048:
+        raise ValueError("next_cursor must be a bounded owner-private value")
+    normalized_expected_cursor = (
+        str(expected_cursor).strip() if expected_cursor is not None else None
+    )
+    if normalized_expected_cursor is not None and (
+        not normalized_expected_cursor or len(normalized_expected_cursor) > 2048
+    ):
+        raise ValueError("expected_cursor must be a bounded owner-private value")
+    return {
+        "schema_version": PROVIDER_PAGE_SCHEMA_VERSION,
+        "expected_cursor": normalized_expected_cursor,
+        "next_cursor": normalized_next_cursor,
+        "has_more": bool(has_more),
+        "events": [dict(event) for event in events],
+    }
+
+
+def capture_document_comment_provider_page(
+    *,
+    project: str,
+    registration: Mapping[str, Any],
+    permission_guidance: Mapping[str, Any],
+    page_reader: ProviderPageReader,
+    expected_cursor: str | None,
+    limit: int = 100,
+    max_pending: int = 1000,
+    execute: bool = False,
+) -> dict[str, Any]:
+    """Read and durably capture one provider page after permission readiness."""
+
+    normalized = _normalize_document_comment_registration(registration)
+    normalized_guidance = _permission_guidance_for_registration(
+        registration=normalized,
+        permission_guidance=permission_guidance,
+    )
+    permission_status = project_external_connector_permission_status(
+        normalized_guidance
+    )
+    if permission_status["ready"] is not True:
+        return {
+            "ok": False,
+            "schema_version": "agent_external_connector_provider_capture_v0",
+            "status": "permission_required",
+            "execute": execute,
+            "external_read_performed": False,
+            "private_provider_payload_captured": False,
+        }
+    bounded_limit = max(1, min(int(limit), 500))
+    if not execute:
+        return {
+            "ok": True,
+            "schema_version": "agent_external_connector_provider_capture_v0",
+            "status": "preview_ready",
+            "execute": False,
+            "external_read_performed": False,
+            "private_provider_payload_captured": False,
+        }
+    page = page_reader(normalized["connector"], expected_cursor, bounded_limit)
+    if not isinstance(page, Mapping):
+        raise TypeError("external connector provider page is invalid")
+    if page.get("schema_version") != PROVIDER_PAGE_SCHEMA_VERSION:
+        raise ValueError("external connector provider page schema is invalid")
+    if page.get("expected_cursor") != expected_cursor:
+        raise ValueError("provider page does not match the requested cursor")
+    events = page.get("events")
+    if not isinstance(events, list) or any(
+        not isinstance(event, Mapping) for event in events
+    ):
+        raise TypeError("external connector provider page events are invalid")
+    if len(events) > bounded_limit:
+        raise ValueError("external connector provider exceeded the requested limit")
+    capture = capture_external_connector_events(
+        project=project,
+        binding=normalized["connector"],
+        events=events,
+        expected_cursor=expected_cursor,
+        next_cursor=str(page.get("next_cursor") or ""),
+        max_pending=max_pending,
+        execute=True,
+    )
+    return {
+        **capture,
+        "schema_version": "agent_external_connector_provider_capture_v0",
+        "provider_status": "captured" if capture["ok"] else capture["status"],
+        "has_more": page.get("has_more") is True,
+        "external_read_performed": True,
+        "private_provider_payload_captured": False,
+    }
+
+
+def reply_and_settle_document_comment_event(
+    *,
+    project: str,
+    registration: Mapping[str, Any],
+    permission_guidance: Mapping[str, Any],
+    event_id: str,
+    effect_receipt: Mapping[str, Any] | None,
+    reply_text: str | None,
+    response_writer: ProviderResponseWriter | None,
+    execute: bool = False,
+) -> dict[str, Any]:
+    """Enforce effect-before-response-before-ACK at the provider call site."""
+
+    normalized = _normalize_document_comment_registration(registration)
+    connector = normalized["connector"]
+    normalized_guidance = _permission_guidance_for_registration(
+        registration=normalized,
+        permission_guidance=permission_guidance,
+    )
+    permission_status = project_external_connector_permission_status(
+        normalized_guidance
+    )
+    if permission_status["ready"] is not True:
+        return {
+            "ok": False,
+            "schema_version": "agent_external_connector_provider_settlement_v0",
+            "status": "permission_required",
+            "execute": execute,
+            "external_write_performed": False,
+        }
+    pending = drain_external_connector_inbox(
+        project=project,
+        binding=connector,
+        limit=1,
+    )
+    items = pending.get("items")
+    item = items[0] if isinstance(items, list) and items else None
+    if not isinstance(item, Mapping) or str(item.get("event_id") or "") != event_id:
+        return {
+            "ok": False,
+            "schema_version": "agent_external_connector_provider_settlement_v0",
+            "status": "ordered_event_required",
+            "execute": execute,
+            "external_write_performed": False,
+        }
+    effect_decision = decide_external_event_ack(
+        event_id=event_id,
+        effect_receipt=effect_receipt,
+        response_policy=ExternalResponsePolicy.NO_RESPONSE.value,
+    )
+    if effect_decision["effect_ready"] is not True:
+        return {
+            "ok": False,
+            "schema_version": "agent_external_connector_provider_settlement_v0",
+            "status": "durable_effect_required",
+            "execute": execute,
+            "external_write_performed": False,
+            "ack_decision": effect_decision,
+        }
+    response_policy = str(connector["response_policy"])
+    response_receipt: Mapping[str, Any] | None = None
+    if response_policy != ExternalResponsePolicy.NO_RESPONSE.value:
+        text = " ".join(str(reply_text or "").split())[:1200]
+        if not text:
+            raise ValueError("response-capable Connector requires reply_text")
+        if response_writer is None:
+            raise ValueError("response-capable Connector requires a response_writer")
+        if not execute:
+            return {
+                "ok": True,
+                "schema_version": "agent_external_connector_provider_settlement_v0",
+                "status": "preview_ready",
+                "execute": False,
+                "external_write_performed": False,
+            }
+        idempotency_key = (
+            "sha256:"
+            + hashlib.sha256(
+                "\0".join(
+                    (
+                        event_id,
+                        str((effect_receipt or {}).get("effect_id") or ""),
+                        text,
+                    )
+                ).encode("utf-8")
+            ).hexdigest()
+        )
+        response_receipt = response_writer(
+            connector,
+            item,
+            text,
+            idempotency_key,
+        )
+        if not isinstance(response_receipt, Mapping):
+            raise TypeError("response_writer must return a response receipt")
+    settlement = settle_external_connector_event(
+        project=project,
+        binding=connector,
+        event_id=event_id,
+        effect_receipt=effect_receipt,
+        response_receipt=response_receipt,
+        execute=execute,
+    )
+    return {
+        **settlement,
+        "schema_version": "agent_external_connector_provider_settlement_v0",
+        "external_write_performed": bool(
+            response_receipt
+            and response_receipt.get("external_write_performed") is True
+        ),
+        "response_readback_verified": bool(
+            response_receipt
+            and response_receipt.get("verification_performed") is True
+            and (
+                response_receipt.get("response_verified") is True
+                or response_receipt.get("reply_verified") is True
+                or response_receipt.get("readback_verified") is True
+            )
+        ),
+        "private_provider_payload_captured": False,
+    }

--- a/loopx/extensions/external_connector_provider.py
+++ b/loopx/extensions/external_connector_provider.py
@@ -20,6 +20,7 @@ from .external_connector_runtime import (
     ExternalConnectorCapability,
     ExternalResponsePolicy,
     ExternalSourceKind,
+    build_external_event_response_receipt,
     capture_external_connector_events,
     decide_external_event_ack,
     drain_external_connector_inbox,
@@ -637,6 +638,22 @@ def reply_and_settle_document_comment_event(
         )
         if not isinstance(response_receipt, Mapping):
             raise TypeError("response_writer must return a response receipt")
+        if response_receipt.get("idempotency_key") != idempotency_key:
+            raise ValueError("response receipt must bind the requested idempotency_key")
+        response_receipt = build_external_event_response_receipt(
+            event_id=event_id,
+            external_write_performed=(
+                response_receipt.get("external_write_performed") is True
+            ),
+            verification_performed=(
+                response_receipt.get("verification_performed") is True
+            ),
+            response_verified=(
+                response_receipt.get("response_verified") is True
+                or response_receipt.get("reply_verified") is True
+                or response_receipt.get("readback_verified") is True
+            ),
+        )
     settlement = settle_external_connector_event(
         project=project,
         binding=connector,
@@ -655,11 +672,7 @@ def reply_and_settle_document_comment_event(
         "response_readback_verified": bool(
             response_receipt
             and response_receipt.get("verification_performed") is True
-            and (
-                response_receipt.get("response_verified") is True
-                or response_receipt.get("reply_verified") is True
-                or response_receipt.get("readback_verified") is True
-            )
+            and response_receipt.get("response_verified") is True
         ),
         "private_provider_payload_captured": False,
     }

--- a/loopx/extensions/external_connector_runtime.py
+++ b/loopx/extensions/external_connector_runtime.py
@@ -1,0 +1,310 @@
+"""Provider-neutral contracts for Agent-scoped external event connectors.
+
+Provider extensions own credentials, raw event bodies, source identifiers, and
+cursor values.  This module validates the small routing and acknowledgement
+contract that LoopX needs in order to bind one external source to one Agent.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from enum import Enum
+from pathlib import PurePosixPath
+from typing import Any
+
+CONNECTOR_SCHEMA_VERSION = "agent_external_connector_v0"
+ACK_DECISION_SCHEMA_VERSION = "agent_external_event_ack_decision_v0"
+EFFECT_RECEIPT_SCHEMA_VERSION = "agent_external_event_effect_receipt_v0"
+
+SAFE_TOKEN_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,199}")
+
+
+class ExternalSourceKind(str, Enum):
+    GROUP_MESSAGE = "group_message"
+    DOCUMENT_COMMENT = "document_comment"
+
+
+class ExternalCapturePolicy(str, Enum):
+    ADDRESSED_ONLY = "addressed_only"
+    CONFIGURED_SOURCE_ALL = "configured_source_all"
+    INCREMENTAL = "incremental"
+
+
+class ExternalIngressPolicy(str, Enum):
+    LIVE_STEERING = "live_steering"
+    SESSION_QUEUE = "session_queue"
+    ASYNC_INBOX = "async_inbox"
+
+
+class ExternalResponsePolicy(str, Enum):
+    NO_RESPONSE = "no_response"
+    SOURCE_THREAD = "source_thread"
+    TOPIC_REPLY = "topic_reply"
+    CONFIGURED_MIRROR = "configured_mirror"
+
+
+class ExternalConnectorLifecycle(str, Enum):
+    CONNECTED = "connected"
+    LISTENING = "listening"
+    STALE = "stale"
+    DISCONNECTED = "disconnected"
+
+
+class ExternalConnectorCapability(str, Enum):
+    REALTIME_RECEIVE = "realtime_receive"
+    HISTORY_CATCH_UP = "history_catch_up"
+    RESPONSE_WRITE = "response_write"
+    RESPONSE_READBACK = "response_readback"
+    ACKNOWLEDGE = "acknowledge"
+
+
+class ExternalEffectKind(str, Enum):
+    WORKING_SESSION_TURN = "working_session_turn"
+    TODO_UPDATE = "todo_update"
+    AUTHORITY_UPDATE = "authority_update"
+    DESIGN_UPDATE = "design_update"
+    NO_FOLLOW_UP = "no_follow_up"
+
+
+def _enum_value(enum_type: type[Enum], value: Any, *, field: str) -> str:
+    normalized = str(value or "").strip().lower()
+    try:
+        selected = enum_type(normalized)
+    except ValueError as exc:
+        allowed = ", ".join(str(item.value) for item in enum_type)
+        raise ValueError(f"{field} must be one of: {allowed}") from exc
+    return str(selected.value)
+
+
+def _safe_token(value: Any, *, field: str) -> str:
+    normalized = str(value or "").strip()
+    if not SAFE_TOKEN_PATTERN.fullmatch(normalized):
+        raise ValueError(f"{field} must be an opaque public-safe token")
+    return normalized
+
+
+def _owner_local_ref(value: Any, *, field: str) -> str:
+    normalized = str(value or "").strip().replace("\\", "/")
+    path = PurePosixPath(normalized)
+    if (
+        not normalized
+        or path.is_absolute()
+        or ".." in path.parts
+        or "://" in normalized
+        or any(not part or part in {".", ".."} for part in path.parts)
+    ):
+        raise ValueError(f"{field} must be an owner-local opaque reference")
+    return normalized
+
+
+def _capability_values(values: Sequence[str]) -> list[str]:
+    normalized = {
+        _enum_value(ExternalConnectorCapability, value, field="capabilities")
+        for value in values
+    }
+    return sorted(normalized)
+
+
+def build_external_connector_binding(
+    *,
+    goal_ref: str,
+    agent_ref: str,
+    provider_kind: str,
+    source_kind: str,
+    source_ref: str,
+    capture_policy: str,
+    ingress_policy: str,
+    response_policy: str,
+    cursor_ref: str | None,
+    lifecycle: str,
+    capabilities: Sequence[str],
+    session_ref: str | None = None,
+    inbox_ref: str | None = None,
+) -> dict[str, Any]:
+    """Validate and return one owner-local Agent Connector binding."""
+
+    goal = _safe_token(goal_ref, field="goal_ref")
+    agent = _safe_token(agent_ref, field="agent_ref")
+    provider = _safe_token(provider_kind, field="provider_kind")
+    source = _enum_value(ExternalSourceKind, source_kind, field="source_kind")
+    source_reference = _safe_token(source_ref, field="source_ref")
+    capture = _enum_value(
+        ExternalCapturePolicy,
+        capture_policy,
+        field="capture_policy",
+    )
+    ingress = _enum_value(
+        ExternalIngressPolicy,
+        ingress_policy,
+        field="ingress_policy",
+    )
+    response = _enum_value(
+        ExternalResponsePolicy,
+        response_policy,
+        field="response_policy",
+    )
+    lifecycle_value = _enum_value(
+        ExternalConnectorLifecycle,
+        lifecycle,
+        field="lifecycle",
+    )
+    capability_values = _capability_values(capabilities)
+    capability_set = set(capability_values)
+    session = _safe_token(session_ref, field="session_ref") if session_ref else None
+    inbox = _owner_local_ref(inbox_ref, field="inbox_ref") if inbox_ref else None
+    cursor = _owner_local_ref(cursor_ref, field="cursor_ref") if cursor_ref else None
+
+    if (
+        ingress
+        in {
+            ExternalIngressPolicy.LIVE_STEERING.value,
+            ExternalIngressPolicy.SESSION_QUEUE.value,
+        }
+        and not session
+    ):
+        raise ValueError(f"{ingress} requires an exact session_ref")
+    if ingress == ExternalIngressPolicy.ASYNC_INBOX.value and not inbox:
+        raise ValueError("async_inbox requires an owner-local inbox_ref")
+    if ingress == ExternalIngressPolicy.ASYNC_INBOX.value and session:
+        raise ValueError("async_inbox cannot bind an exact session_ref")
+    if (
+        capture == ExternalCapturePolicy.INCREMENTAL.value
+        or ExternalConnectorCapability.HISTORY_CATCH_UP.value in capability_set
+        or ExternalConnectorCapability.ACKNOWLEDGE.value in capability_set
+    ) and not cursor:
+        raise ValueError(
+            "incremental capture, history_catch_up, and acknowledge require an "
+            "owner-local cursor_ref"
+        )
+    response_capabilities = {
+        ExternalConnectorCapability.RESPONSE_WRITE.value,
+        ExternalConnectorCapability.RESPONSE_READBACK.value,
+    }
+    if response == ExternalResponsePolicy.NO_RESPONSE.value:
+        if capability_set.intersection(response_capabilities):
+            raise ValueError("no_response cannot advertise response capabilities")
+    elif not response_capabilities.issubset(capability_set):
+        raise ValueError(
+            "a response policy requires response_write and response_readback"
+        )
+
+    binding: dict[str, Any] = {
+        "schema_version": CONNECTOR_SCHEMA_VERSION,
+        "goal_ref": goal,
+        "agent_ref": agent,
+        "provider_kind": provider,
+        "source_kind": source,
+        "source_ref": source_reference,
+        "capture_policy": capture,
+        "ingress_policy": ingress,
+        "response_policy": response,
+        "cursor_ref": cursor,
+        "lifecycle": lifecycle_value,
+        "capabilities": capability_values,
+    }
+    if session:
+        binding["session_ref"] = session
+    if inbox:
+        binding["inbox_ref"] = inbox
+    return binding
+
+
+def project_external_connector_status(binding: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a content-free status projection without owner-local references."""
+
+    if binding.get("schema_version") != CONNECTOR_SCHEMA_VERSION:
+        raise ValueError("external connector binding schema is invalid")
+    normalized = build_external_connector_binding(
+        goal_ref=str(binding.get("goal_ref") or ""),
+        agent_ref=str(binding.get("agent_ref") or ""),
+        provider_kind=str(binding.get("provider_kind") or ""),
+        source_kind=str(binding.get("source_kind") or ""),
+        source_ref=str(binding.get("source_ref") or ""),
+        capture_policy=str(binding.get("capture_policy") or ""),
+        ingress_policy=str(binding.get("ingress_policy") or ""),
+        response_policy=str(binding.get("response_policy") or ""),
+        cursor_ref=(
+            str(binding.get("cursor_ref")) if binding.get("cursor_ref") else None
+        ),
+        lifecycle=str(binding.get("lifecycle") or ""),
+        capabilities=[str(value) for value in binding.get("capabilities", [])],
+        session_ref=(
+            str(binding.get("session_ref")) if binding.get("session_ref") else None
+        ),
+        inbox_ref=(str(binding.get("inbox_ref")) if binding.get("inbox_ref") else None),
+    )
+    return {
+        "schema_version": "agent_external_connector_status_v0",
+        "goal_ref": normalized["goal_ref"],
+        "agent_ref": normalized["agent_ref"],
+        "provider_kind": normalized["provider_kind"],
+        "source_kind": normalized["source_kind"],
+        "capture_policy": normalized["capture_policy"],
+        "ingress_policy": normalized["ingress_policy"],
+        "response_policy": normalized["response_policy"],
+        "lifecycle": normalized["lifecycle"],
+        "capabilities": normalized["capabilities"],
+        "session_bound": "session_ref" in normalized,
+        "inbox_bound": "inbox_ref" in normalized,
+        "cursor_bound": normalized["cursor_ref"] is not None,
+        "private_source_ref_captured": False,
+        "private_cursor_ref_captured": False,
+    }
+
+
+def decide_external_event_ack(
+    *,
+    event_id: str,
+    effect_receipt: Mapping[str, Any] | None,
+    response_policy: str,
+    response_receipt: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Fail closed until durable effect and required response readback exist."""
+
+    event = _safe_token(event_id, field="event_id")
+    response = _enum_value(
+        ExternalResponsePolicy,
+        response_policy,
+        field="response_policy",
+    )
+    effect_ready = bool(
+        isinstance(effect_receipt, Mapping)
+        and effect_receipt.get("schema_version") == EFFECT_RECEIPT_SCHEMA_VERSION
+        and str(effect_receipt.get("event_id") or "") == event
+        and SAFE_TOKEN_PATTERN.fullmatch(str(effect_receipt.get("effect_id") or ""))
+        and str(effect_receipt.get("status") or "") == "committed"
+        and str(effect_receipt.get("effect_kind") or "")
+        in {item.value for item in ExternalEffectKind}
+    )
+    response_required = response != ExternalResponsePolicy.NO_RESPONSE.value
+    response_ready = bool(
+        not response_required
+        or (
+            isinstance(response_receipt, Mapping)
+            and response_receipt.get("external_write_performed") is True
+            and response_receipt.get("verification_performed") is True
+            and (
+                response_receipt.get("response_verified") is True
+                or response_receipt.get("reply_verified") is True
+                or response_receipt.get("readback_verified") is True
+            )
+        )
+    )
+    ack_allowed = effect_ready and response_ready
+    return {
+        "schema_version": ACK_DECISION_SCHEMA_VERSION,
+        "ack_allowed": ack_allowed,
+        "effect_ready": effect_ready,
+        "response_required": response_required,
+        "response_ready": response_ready,
+        "reason": (
+            "ready"
+            if ack_allowed
+            else "durable_effect_required"
+            if not effect_ready
+            else "verified_response_required"
+        ),
+        "private_event_content_captured": False,
+        "private_provider_payload_captured": False,
+    }

--- a/loopx/extensions/external_connector_runtime.py
+++ b/loopx/extensions/external_connector_runtime.py
@@ -142,7 +142,10 @@ def _capability_values(values: Sequence[str]) -> list[str]:
     return sorted(normalized)
 
 
-def _normalized_binding(binding: Mapping[str, Any]) -> dict[str, Any]:
+def normalize_external_connector_binding(
+    binding: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Revalidate an owner-local Connector binding at a caller boundary."""
     if binding.get("schema_version") != CONNECTOR_SCHEMA_VERSION:
         raise ValueError("external connector binding schema is invalid")
     return build_external_connector_binding(
@@ -273,7 +276,7 @@ def build_external_connector_binding(
 def project_external_connector_status(binding: Mapping[str, Any]) -> dict[str, Any]:
     """Return a content-free status projection without owner-local references."""
 
-    normalized = _normalized_binding(binding)
+    normalized = normalize_external_connector_binding(binding)
     return {
         "schema_version": "agent_external_connector_status_v0",
         "goal_ref": normalized["goal_ref"],
@@ -425,7 +428,7 @@ def _binding_paths(
     project: str | Path,
     binding: Mapping[str, Any],
 ) -> tuple[dict[str, Any], Path, Path]:
-    normalized = _normalized_binding(binding)
+    normalized = normalize_external_connector_binding(binding)
     if normalized["ingress_policy"] != ExternalIngressPolicy.ASYNC_INBOX.value:
         raise ValueError("external connector inbox runtime requires async_inbox")
     inbox_ref = str(normalized.get("inbox_ref") or "")

--- a/loopx/extensions/external_connector_runtime.py
+++ b/loopx/extensions/external_connector_runtime.py
@@ -7,15 +7,25 @@ contract that LoopX needs in order to bind one external source to one Agent.
 
 from __future__ import annotations
 
+import hashlib
+import json
+import os
 import re
+import tempfile
 from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
 from enum import Enum
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Any
+
+from ..file_lock import exclusive_file_lock
 
 CONNECTOR_SCHEMA_VERSION = "agent_external_connector_v0"
 ACK_DECISION_SCHEMA_VERSION = "agent_external_event_ack_decision_v0"
 EFFECT_RECEIPT_SCHEMA_VERSION = "agent_external_event_effect_receipt_v0"
+EVENT_SCHEMA_VERSION = "agent_external_connector_event_v0"
+CURSOR_STATE_SCHEMA_VERSION = "agent_external_connector_cursor_v0"
+INBOX_STATUS_SCHEMA_VERSION = "agent_external_connector_inbox_status_v0"
 
 SAFE_TOKEN_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,199}")
 
@@ -98,12 +108,62 @@ def _owner_local_ref(value: Any, *, field: str) -> str:
     return normalized
 
 
+def _private_value(value: Any, *, field: str, limit: int = 2048) -> str:
+    normalized = str(value or "").strip()
+    if (
+        not normalized
+        or len(normalized) > limit
+        or any(ord(character) < 32 for character in normalized)
+    ):
+        raise ValueError(f"{field} must be a bounded owner-private value")
+    return normalized
+
+
+def _timestamp(value: Any, *, field: str) -> str:
+    normalized = str(value or "").strip()
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError(f"{field} must be an RFC3339 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field} must include a timezone")
+    return parsed.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
 def _capability_values(values: Sequence[str]) -> list[str]:
     normalized = {
         _enum_value(ExternalConnectorCapability, value, field="capabilities")
         for value in values
     }
     return sorted(normalized)
+
+
+def _normalized_binding(binding: Mapping[str, Any]) -> dict[str, Any]:
+    if binding.get("schema_version") != CONNECTOR_SCHEMA_VERSION:
+        raise ValueError("external connector binding schema is invalid")
+    return build_external_connector_binding(
+        goal_ref=str(binding.get("goal_ref") or ""),
+        agent_ref=str(binding.get("agent_ref") or ""),
+        provider_kind=str(binding.get("provider_kind") or ""),
+        source_kind=str(binding.get("source_kind") or ""),
+        source_ref=str(binding.get("source_ref") or ""),
+        capture_policy=str(binding.get("capture_policy") or ""),
+        ingress_policy=str(binding.get("ingress_policy") or ""),
+        response_policy=str(binding.get("response_policy") or ""),
+        cursor_ref=(
+            str(binding.get("cursor_ref")) if binding.get("cursor_ref") else None
+        ),
+        lifecycle=str(binding.get("lifecycle") or ""),
+        capabilities=[str(value) for value in binding.get("capabilities", [])],
+        session_ref=(
+            str(binding.get("session_ref")) if binding.get("session_ref") else None
+        ),
+        inbox_ref=(str(binding.get("inbox_ref")) if binding.get("inbox_ref") else None),
+    )
 
 
 def build_external_connector_binding(
@@ -213,27 +273,7 @@ def build_external_connector_binding(
 def project_external_connector_status(binding: Mapping[str, Any]) -> dict[str, Any]:
     """Return a content-free status projection without owner-local references."""
 
-    if binding.get("schema_version") != CONNECTOR_SCHEMA_VERSION:
-        raise ValueError("external connector binding schema is invalid")
-    normalized = build_external_connector_binding(
-        goal_ref=str(binding.get("goal_ref") or ""),
-        agent_ref=str(binding.get("agent_ref") or ""),
-        provider_kind=str(binding.get("provider_kind") or ""),
-        source_kind=str(binding.get("source_kind") or ""),
-        source_ref=str(binding.get("source_ref") or ""),
-        capture_policy=str(binding.get("capture_policy") or ""),
-        ingress_policy=str(binding.get("ingress_policy") or ""),
-        response_policy=str(binding.get("response_policy") or ""),
-        cursor_ref=(
-            str(binding.get("cursor_ref")) if binding.get("cursor_ref") else None
-        ),
-        lifecycle=str(binding.get("lifecycle") or ""),
-        capabilities=[str(value) for value in binding.get("capabilities", [])],
-        session_ref=(
-            str(binding.get("session_ref")) if binding.get("session_ref") else None
-        ),
-        inbox_ref=(str(binding.get("inbox_ref")) if binding.get("inbox_ref") else None),
-    )
+    normalized = _normalized_binding(binding)
     return {
         "schema_version": "agent_external_connector_status_v0",
         "goal_ref": normalized["goal_ref"],
@@ -308,3 +348,583 @@ def decide_external_event_ack(
         "private_event_content_captured": False,
         "private_provider_payload_captured": False,
     }
+
+
+def build_external_connector_event(
+    *,
+    event_id: str,
+    content: str,
+    occurred_at: str,
+    addressed: bool,
+    event_cursor: str,
+    anchor_ref: str | None = None,
+    reply_chain_ref: str | None = None,
+) -> dict[str, Any]:
+    """Return one compact owner-private event accepted from a provider.
+
+    Provider extensions translate their payloads into this envelope.  The
+    body and provider references are deliberately suitable only for the
+    owner-local inbox; public status uses :func:`inspect_external_connector_inbox`.
+    """
+
+    body = str(content or "").strip()
+    if not body or len(body) > 20_000 or "\x00" in body:
+        raise ValueError("content must be non-empty owner-private text")
+    event = {
+        "schema_version": EVENT_SCHEMA_VERSION,
+        "event_id": _safe_token(event_id, field="event_id"),
+        "content": body,
+        "occurred_at": _timestamp(occurred_at, field="occurred_at"),
+        "addressed": bool(addressed),
+        "event_cursor": _private_value(event_cursor, field="event_cursor"),
+    }
+    if anchor_ref:
+        event["anchor_ref"] = _private_value(anchor_ref, field="anchor_ref")
+    if reply_chain_ref:
+        event["reply_chain_ref"] = _private_value(
+            reply_chain_ref,
+            field="reply_chain_ref",
+        )
+    return event
+
+
+def _event_from_mapping(value: Mapping[str, Any]) -> dict[str, Any]:
+    if value.get("schema_version") != EVENT_SCHEMA_VERSION:
+        raise ValueError("external connector event schema is invalid")
+    return build_external_connector_event(
+        event_id=str(value.get("event_id") or ""),
+        content=str(value.get("content") or ""),
+        occurred_at=str(value.get("occurred_at") or ""),
+        addressed=value.get("addressed") is True,
+        event_cursor=str(value.get("event_cursor") or ""),
+        anchor_ref=(str(value.get("anchor_ref")) if value.get("anchor_ref") else None),
+        reply_chain_ref=(
+            str(value.get("reply_chain_ref")) if value.get("reply_chain_ref") else None
+        ),
+    )
+
+
+def _resolve_owner_local_path(
+    *,
+    project: str | Path,
+    ref: str,
+    field: str,
+) -> Path:
+    root = Path(project).expanduser().resolve()
+    relative = PurePosixPath(_owner_local_ref(ref, field=field))
+    resolved = (root / Path(*relative.parts)).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"{field} escapes the owner project") from exc
+    return resolved
+
+
+def _binding_paths(
+    *,
+    project: str | Path,
+    binding: Mapping[str, Any],
+) -> tuple[dict[str, Any], Path, Path]:
+    normalized = _normalized_binding(binding)
+    if normalized["ingress_policy"] != ExternalIngressPolicy.ASYNC_INBOX.value:
+        raise ValueError("external connector inbox runtime requires async_inbox")
+    inbox_ref = str(normalized.get("inbox_ref") or "")
+    cursor_ref = str(normalized.get("cursor_ref") or "")
+    if not inbox_ref or not cursor_ref:
+        raise ValueError("external connector inbox requires inbox_ref and cursor_ref")
+    inbox = _resolve_owner_local_path(
+        project=project,
+        ref=inbox_ref,
+        field="inbox_ref",
+    )
+    cursor = _resolve_owner_local_path(
+        project=project,
+        ref=cursor_ref,
+        field="cursor_ref",
+    )
+    return normalized, inbox, cursor
+
+
+def _default_cursor_state() -> dict[str, Any]:
+    return {
+        "schema_version": CURSOR_STATE_SCHEMA_VERSION,
+        "committed_cursor": None,
+        "next_sequence": 1,
+        "acknowledged_event_ids": [],
+        "last_capture_at": None,
+        "failure_count": 0,
+        "last_failure_at": None,
+        "last_error_code": None,
+    }
+
+
+def _load_cursor_state(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return _default_cursor_state()
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("external connector cursor state is unreadable") from exc
+    if (
+        not isinstance(value, Mapping)
+        or value.get("schema_version") != CURSOR_STATE_SCHEMA_VERSION
+    ):
+        raise ValueError("external connector cursor state schema is invalid")
+    state = _default_cursor_state()
+    state["committed_cursor"] = (
+        _private_value(value.get("committed_cursor"), field="committed_cursor")
+        if value.get("committed_cursor")
+        else None
+    )
+    next_sequence = value.get("next_sequence")
+    if not isinstance(next_sequence, int) or next_sequence < 1:
+        raise ValueError("external connector next_sequence is invalid")
+    state["next_sequence"] = next_sequence
+    acknowledged = value.get("acknowledged_event_ids")
+    if not isinstance(acknowledged, list):
+        raise TypeError("external connector acknowledged_event_ids is invalid")
+    state["acknowledged_event_ids"] = sorted(
+        {_safe_token(item, field="acknowledged_event_ids") for item in acknowledged}
+    )
+    for field in ("last_capture_at", "last_failure_at"):
+        state[field] = (
+            _timestamp(value.get(field), field=field) if value.get(field) else None
+        )
+    failure_count = value.get("failure_count", 0)
+    if not isinstance(failure_count, int) or failure_count < 0:
+        raise ValueError("external connector failure_count is invalid")
+    state["failure_count"] = failure_count
+    state["last_error_code"] = (
+        _safe_token(value.get("last_error_code"), field="last_error_code")
+        if value.get("last_error_code")
+        else None
+    )
+    return state
+
+
+def _write_private_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    temporary = Path(temporary_name)
+    try:
+        if hasattr(os, "fchmod"):
+            os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(dict(payload), handle, ensure_ascii=False, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _event_path(inbox: Path, event_id: str) -> Path:
+    digest = hashlib.sha256(event_id.encode("utf-8")).hexdigest()
+    return inbox / "events" / f"{digest}.json"
+
+
+def _stored_events(inbox: Path) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    events_root = inbox / "events"
+    for path in sorted(events_root.glob("*.json")) if events_root.is_dir() else []:
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError("external connector inbox event is unreadable") from exc
+        if not isinstance(value, Mapping):
+            raise TypeError("external connector inbox event is invalid")
+        event = _event_from_mapping(value)
+        sequence = value.get("sequence")
+        if not isinstance(sequence, int) or sequence < 1:
+            raise ValueError("external connector event sequence is invalid")
+        event["sequence"] = sequence
+        if value.get("page_next_cursor"):
+            event["page_next_cursor"] = _private_value(
+                value.get("page_next_cursor"),
+                field="page_next_cursor",
+            )
+        events.append(event)
+    events.sort(key=lambda item: (item["sequence"], item["event_id"]))
+    return events
+
+
+def _event_ref(event_id: str) -> str:
+    return f"sha256:{hashlib.sha256(event_id.encode('utf-8')).hexdigest()[:24]}"
+
+
+def capture_external_connector_events(
+    *,
+    project: str | Path,
+    binding: Mapping[str, Any],
+    events: Sequence[Mapping[str, Any]],
+    expected_cursor: str | None,
+    next_cursor: str,
+    max_pending: int = 1000,
+    execute: bool = False,
+) -> dict[str, Any]:
+    """Capture one bounded provider page without advancing past pending events."""
+
+    normalized, inbox, cursor_path = _binding_paths(
+        project=project,
+        binding=binding,
+    )
+    capabilities = set(normalized["capabilities"])
+    if ExternalConnectorCapability.HISTORY_CATCH_UP.value not in capabilities:
+        raise ValueError("external connector does not advertise history_catch_up")
+    requested_next_cursor = _private_value(next_cursor, field="next_cursor")
+    requested_expected_cursor = (
+        _private_value(expected_cursor, field="expected_cursor")
+        if expected_cursor is not None
+        else None
+    )
+    if len(events) > 500:
+        raise ValueError("external connector capture page exceeds 500 events")
+    bounded_pending = max(1, min(int(max_pending), 10_000))
+    canonical = [_event_from_mapping(value) for value in events]
+
+    def operation() -> dict[str, Any]:
+        state = _load_cursor_state(cursor_path)
+        if state["committed_cursor"] != requested_expected_cursor:
+            return {
+                "ok": False,
+                "schema_version": "agent_external_connector_capture_v0",
+                "status": "cursor_mismatch",
+                "execute": execute,
+                "requested_count": len(canonical),
+                "accepted_count": 0,
+                "filtered_count": 0,
+                "duplicate_count": 0,
+                "cursor_advanced": False,
+                "private_event_content_captured": False,
+                "private_cursor_value_captured": False,
+            }
+        existing = _stored_events(inbox)
+        existing_ids = {str(item["event_id"]) for item in existing}
+        accepted: list[dict[str, Any]] = []
+        duplicate_ids: set[str] = set()
+        filtered_count = 0
+        duplicate_count = 0
+        for event in canonical:
+            event_id = str(event["event_id"])
+            if event_id in existing_ids or any(
+                str(item["event_id"]) == event_id for item in accepted
+            ):
+                duplicate_count += 1
+                duplicate_ids.add(event_id)
+                continue
+            if (
+                normalized["capture_policy"]
+                == ExternalCapturePolicy.ADDRESSED_ONLY.value
+                and event["addressed"] is not True
+            ):
+                filtered_count += 1
+                continue
+            accepted.append(event)
+
+        acknowledged = set(state["acknowledged_event_ids"])
+        current_pending_count = sum(
+            str(item["event_id"]) not in acknowledged for item in existing
+        )
+        if current_pending_count + len(accepted) > bounded_pending:
+            return {
+                "ok": False,
+                "schema_version": "agent_external_connector_capture_v0",
+                "status": "backpressure_required",
+                "execute": execute,
+                "requested_count": len(canonical),
+                "accepted_count": 0,
+                "filtered_count": filtered_count,
+                "duplicate_count": duplicate_count,
+                "pending_count": current_pending_count,
+                "max_pending": bounded_pending,
+                "cursor_advanced": False,
+                "private_event_content_captured": False,
+                "private_cursor_value_captured": False,
+            }
+
+        sequence = max(
+            int(state["next_sequence"]),
+            max((int(item["sequence"]) for item in existing), default=0) + 1,
+        )
+        stored: list[dict[str, Any]] = []
+        for event in accepted:
+            stored.append({**event, "sequence": sequence})
+            sequence += 1
+        if stored:
+            stored[-1]["page_next_cursor"] = requested_next_cursor
+        cursor_advanced = bool(
+            not stored and (not duplicate_ids or duplicate_ids.issubset(acknowledged))
+        )
+        updated_state = {
+            **state,
+            "committed_cursor": (
+                requested_next_cursor if cursor_advanced else state["committed_cursor"]
+            ),
+            "next_sequence": sequence,
+            "last_capture_at": _now_iso(),
+        }
+        if execute:
+            for event in stored:
+                _write_private_json_atomic(
+                    _event_path(inbox, str(event["event_id"])),
+                    event,
+                )
+            _write_private_json_atomic(cursor_path, updated_state)
+        return {
+            "ok": True,
+            "schema_version": "agent_external_connector_capture_v0",
+            "status": "captured" if stored else "page_checkpointed",
+            "execute": execute,
+            "requested_count": len(canonical),
+            "accepted_count": len(stored),
+            "filtered_count": filtered_count,
+            "duplicate_count": duplicate_count,
+            "cursor_advanced": cursor_advanced,
+            "write_performed": execute,
+            "private_event_content_captured": False,
+            "private_cursor_value_captured": False,
+        }
+
+    if not execute:
+        return operation()
+    with exclusive_file_lock(
+        cursor_path,
+        operation="capture_external_connector_events",
+    ):
+        return operation()
+
+
+def drain_external_connector_inbox(
+    *,
+    project: str | Path,
+    binding: Mapping[str, Any],
+    limit: int = 20,
+) -> dict[str, Any]:
+    """Return ordered owner-private pending events to the bound Agent only."""
+
+    _normalized, inbox, cursor_path = _binding_paths(project=project, binding=binding)
+    state = _load_cursor_state(cursor_path)
+    acknowledged = set(state["acknowledged_event_ids"])
+    bounded_limit = max(1, min(int(limit), 100))
+    pending = [
+        event
+        for event in _stored_events(inbox)
+        if str(event["event_id"]) not in acknowledged
+    ]
+    items = pending[:bounded_limit]
+    return {
+        "ok": True,
+        "schema_version": "agent_external_connector_drain_v0",
+        "pending_count": len(pending),
+        "returned_count": len(items),
+        "items": items,
+        "local_private_content_returned": bool(items),
+        "external_reads_performed": False,
+        "external_writes_performed": False,
+    }
+
+
+def inspect_external_connector_inbox(
+    *,
+    project: str | Path,
+    binding: Mapping[str, Any],
+    now: datetime | None = None,
+    stale_after_seconds: int = 300,
+) -> dict[str, Any]:
+    """Project content-free pending, failure, and freshness state."""
+
+    normalized, inbox, cursor_path = _binding_paths(project=project, binding=binding)
+    state = _load_cursor_state(cursor_path)
+    acknowledged = set(state["acknowledged_event_ids"])
+    pending = [
+        event
+        for event in _stored_events(inbox)
+        if str(event["event_id"]) not in acknowledged
+    ]
+    current = (now or datetime.now(UTC)).astimezone(UTC)
+    oldest_age_seconds: int | None = None
+    if pending:
+        oldest = min(
+            datetime.fromisoformat(str(event["occurred_at"])) for event in pending
+        )
+        oldest_age_seconds = max(0, int((current - oldest).total_seconds()))
+    last_capture_at = state.get("last_capture_at")
+    if not last_capture_at:
+        freshness = "never_captured"
+    else:
+        captured_at = datetime.fromisoformat(str(last_capture_at))
+        freshness = (
+            "stale"
+            if (current - captured_at).total_seconds() > max(1, stale_after_seconds)
+            else "current"
+        )
+    return {
+        "ok": True,
+        "schema_version": INBOX_STATUS_SCHEMA_VERSION,
+        "goal_ref": normalized["goal_ref"],
+        "agent_ref": normalized["agent_ref"],
+        "provider_kind": normalized["provider_kind"],
+        "source_kind": normalized["source_kind"],
+        "pending_count": len(pending),
+        "oldest_pending_age_seconds": oldest_age_seconds,
+        "failure_count": state["failure_count"],
+        "last_failure_at": state["last_failure_at"],
+        "last_error_code": state["last_error_code"],
+        "freshness": freshness,
+        "cursor_bound": True,
+        "private_event_ids_captured": False,
+        "private_event_content_captured": False,
+        "private_source_ref_captured": False,
+        "private_cursor_value_captured": False,
+    }
+
+
+def record_external_connector_failure(
+    *,
+    project: str | Path,
+    binding: Mapping[str, Any],
+    error_code: str,
+    execute: bool = False,
+) -> dict[str, Any]:
+    """Persist a content-free provider failure without its payload."""
+
+    _normalized, _inbox, cursor_path = _binding_paths(
+        project=project,
+        binding=binding,
+    )
+    normalized_error = _safe_token(error_code, field="error_code")
+
+    def operation() -> dict[str, Any]:
+        state = _load_cursor_state(cursor_path)
+        updated_state = {
+            **state,
+            "failure_count": int(state["failure_count"]) + 1,
+            "last_failure_at": _now_iso(),
+            "last_error_code": normalized_error,
+        }
+        if execute:
+            _write_private_json_atomic(cursor_path, updated_state)
+        return {
+            "ok": True,
+            "schema_version": "agent_external_connector_failure_v0",
+            "execute": execute,
+            "recorded": execute,
+            "error_code": normalized_error,
+            "failure_count": updated_state["failure_count"],
+            "private_provider_payload_captured": False,
+        }
+
+    if not execute:
+        return operation()
+    with exclusive_file_lock(
+        cursor_path,
+        operation="record_external_connector_failure",
+    ):
+        return operation()
+
+
+def settle_external_connector_event(
+    *,
+    project: str | Path,
+    binding: Mapping[str, Any],
+    event_id: str,
+    effect_receipt: Mapping[str, Any] | None,
+    response_receipt: Mapping[str, Any] | None = None,
+    execute: bool = False,
+) -> dict[str, Any]:
+    """ACK one ordered event and advance its page cursor only after proof."""
+
+    normalized, inbox, cursor_path = _binding_paths(project=project, binding=binding)
+    event = _safe_token(event_id, field="event_id")
+    if ExternalConnectorCapability.ACKNOWLEDGE.value not in set(
+        normalized["capabilities"]
+    ):
+        raise ValueError("external connector does not advertise acknowledge")
+
+    def operation() -> dict[str, Any]:
+        state = _load_cursor_state(cursor_path)
+        acknowledged = set(state["acknowledged_event_ids"])
+        if event in acknowledged:
+            return {
+                "ok": True,
+                "schema_version": "agent_external_connector_settlement_v0",
+                "status": "already_acknowledged",
+                "execute": execute,
+                "event_ref": _event_ref(event),
+                "cursor_advanced": False,
+                "private_event_id_captured": False,
+                "private_cursor_value_captured": False,
+            }
+        stored = _stored_events(inbox)
+        event_record = next(
+            (item for item in stored if str(item["event_id"]) == event),
+            None,
+        )
+        if event_record is None:
+            raise ValueError("external connector event is not captured")
+        pending = [item for item in stored if str(item["event_id"]) not in acknowledged]
+        if not pending or str(pending[0]["event_id"]) != event:
+            return {
+                "ok": False,
+                "schema_version": "agent_external_connector_settlement_v0",
+                "status": "ordered_event_required",
+                "execute": execute,
+                "event_ref": _event_ref(event),
+                "cursor_advanced": False,
+                "private_event_id_captured": False,
+                "private_cursor_value_captured": False,
+            }
+        ack_decision = decide_external_event_ack(
+            event_id=event,
+            effect_receipt=effect_receipt,
+            response_policy=str(normalized["response_policy"]),
+            response_receipt=response_receipt,
+        )
+        if not ack_decision["ack_allowed"]:
+            return {
+                "ok": False,
+                "schema_version": "agent_external_connector_settlement_v0",
+                "status": ack_decision["reason"],
+                "execute": execute,
+                "event_ref": _event_ref(event),
+                "cursor_advanced": False,
+                "ack_decision": ack_decision,
+                "private_event_id_captured": False,
+                "private_cursor_value_captured": False,
+            }
+        acknowledged.add(event)
+        page_next_cursor = event_record.get("page_next_cursor")
+        cursor_advanced = bool(page_next_cursor)
+        updated_state = {
+            **state,
+            "acknowledged_event_ids": sorted(acknowledged),
+            "committed_cursor": (
+                page_next_cursor if page_next_cursor else state["committed_cursor"]
+            ),
+        }
+        if execute:
+            _write_private_json_atomic(cursor_path, updated_state)
+        return {
+            "ok": True,
+            "schema_version": "agent_external_connector_settlement_v0",
+            "status": "acknowledged" if execute else "preview_ready",
+            "execute": execute,
+            "event_ref": _event_ref(event),
+            "cursor_advanced": cursor_advanced,
+            "effect_kind": str((effect_receipt or {}).get("effect_kind") or ""),
+            "private_event_id_captured": False,
+            "private_cursor_value_captured": False,
+        }
+
+    if not execute:
+        return operation()
+    with exclusive_file_lock(
+        cursor_path,
+        operation="settle_external_connector_event",
+    ):
+        return operation()

--- a/loopx/extensions/external_connector_runtime.py
+++ b/loopx/extensions/external_connector_runtime.py
@@ -23,6 +23,7 @@ from ..file_lock import exclusive_file_lock
 CONNECTOR_SCHEMA_VERSION = "agent_external_connector_v0"
 ACK_DECISION_SCHEMA_VERSION = "agent_external_event_ack_decision_v0"
 EFFECT_RECEIPT_SCHEMA_VERSION = "agent_external_event_effect_receipt_v0"
+RESPONSE_RECEIPT_SCHEMA_VERSION = "agent_external_event_response_receipt_v0"
 EVENT_SCHEMA_VERSION = "agent_external_connector_event_v0"
 CURSOR_STATE_SCHEMA_VERSION = "agent_external_connector_cursor_v0"
 INBOX_STATUS_SCHEMA_VERSION = "agent_external_connector_inbox_status_v0"
@@ -92,6 +93,33 @@ def _safe_token(value: Any, *, field: str) -> str:
     if not SAFE_TOKEN_PATTERN.fullmatch(normalized):
         raise ValueError(f"{field} must be an opaque public-safe token")
     return normalized
+
+
+def external_event_ref(event_id: str) -> str:
+    """Return the content-free identity used to bind public-safe receipts."""
+
+    event = _safe_token(event_id, field="event_id")
+    return f"sha256:{hashlib.sha256(event.encode('utf-8')).hexdigest()[:24]}"
+
+
+def build_external_event_response_receipt(
+    *,
+    event_id: str,
+    external_write_performed: bool,
+    verification_performed: bool,
+    response_verified: bool,
+) -> dict[str, Any]:
+    """Normalize provider proof into one event-bound response receipt."""
+
+    return {
+        "schema_version": RESPONSE_RECEIPT_SCHEMA_VERSION,
+        "event_ref": external_event_ref(event_id),
+        "external_write_performed": bool(external_write_performed),
+        "verification_performed": bool(verification_performed),
+        "response_verified": bool(response_verified),
+        "private_event_id_captured": False,
+        "private_response_content_captured": False,
+    }
 
 
 def _owner_local_ref(value: Any, *, field: str) -> str:
@@ -325,13 +353,12 @@ def decide_external_event_ack(
         not response_required
         or (
             isinstance(response_receipt, Mapping)
+            and response_receipt.get("schema_version")
+            == RESPONSE_RECEIPT_SCHEMA_VERSION
+            and response_receipt.get("event_ref") == external_event_ref(event)
             and response_receipt.get("external_write_performed") is True
             and response_receipt.get("verification_performed") is True
-            and (
-                response_receipt.get("response_verified") is True
-                or response_receipt.get("reply_verified") is True
-                or response_receipt.get("readback_verified") is True
-            )
+            and response_receipt.get("response_verified") is True
         )
     )
     ack_allowed = effect_ready and response_ready
@@ -556,10 +583,6 @@ def _stored_events(inbox: Path) -> list[dict[str, Any]]:
     return events
 
 
-def _event_ref(event_id: str) -> str:
-    return f"sha256:{hashlib.sha256(event_id.encode('utf-8')).hexdigest()[:24]}"
-
-
 def capture_external_connector_events(
     *,
     project: str | Path,
@@ -608,14 +631,17 @@ def capture_external_connector_events(
             }
         existing = _stored_events(inbox)
         existing_ids = {str(item["event_id"]) for item in existing}
+        acknowledged = set(state["acknowledged_event_ids"])
         accepted: list[dict[str, Any]] = []
         duplicate_ids: set[str] = set()
         filtered_count = 0
         duplicate_count = 0
         for event in canonical:
             event_id = str(event["event_id"])
-            if event_id in existing_ids or any(
-                str(item["event_id"]) == event_id for item in accepted
+            if (
+                event_id in acknowledged
+                or event_id in existing_ids
+                or any(str(item["event_id"]) == event_id for item in accepted)
             ):
                 duplicate_count += 1
                 duplicate_ids.add(event_id)
@@ -629,7 +655,6 @@ def capture_external_connector_events(
                 continue
             accepted.append(event)
 
-        acknowledged = set(state["acknowledged_event_ids"])
         current_pending_count = sum(
             str(item["event_id"]) not in acknowledged for item in existing
         )
@@ -853,13 +878,19 @@ def settle_external_connector_event(
         state = _load_cursor_state(cursor_path)
         acknowledged = set(state["acknowledged_event_ids"])
         if event in acknowledged:
+            private_event_deleted = False
+            if execute:
+                event_path = _event_path(inbox, event)
+                private_event_deleted = event_path.is_file()
+                event_path.unlink(missing_ok=True)
             return {
                 "ok": True,
                 "schema_version": "agent_external_connector_settlement_v0",
                 "status": "already_acknowledged",
                 "execute": execute,
-                "event_ref": _event_ref(event),
+                "event_ref": external_event_ref(event),
                 "cursor_advanced": False,
+                "private_event_deleted": private_event_deleted,
                 "private_event_id_captured": False,
                 "private_cursor_value_captured": False,
             }
@@ -877,7 +908,7 @@ def settle_external_connector_event(
                 "schema_version": "agent_external_connector_settlement_v0",
                 "status": "ordered_event_required",
                 "execute": execute,
-                "event_ref": _event_ref(event),
+                "event_ref": external_event_ref(event),
                 "cursor_advanced": False,
                 "private_event_id_captured": False,
                 "private_cursor_value_captured": False,
@@ -894,7 +925,7 @@ def settle_external_connector_event(
                 "schema_version": "agent_external_connector_settlement_v0",
                 "status": ack_decision["reason"],
                 "execute": execute,
-                "event_ref": _event_ref(event),
+                "event_ref": external_event_ref(event),
                 "cursor_advanced": False,
                 "ack_decision": ack_decision,
                 "private_event_id_captured": False,
@@ -912,13 +943,19 @@ def settle_external_connector_event(
         }
         if execute:
             _write_private_json_atomic(cursor_path, updated_state)
+            event_path = _event_path(inbox, event)
+            private_event_deleted = event_path.is_file()
+            event_path.unlink(missing_ok=True)
+        else:
+            private_event_deleted = False
         return {
             "ok": True,
             "schema_version": "agent_external_connector_settlement_v0",
             "status": "acknowledged" if execute else "preview_ready",
             "execute": execute,
-            "event_ref": _event_ref(event),
+            "event_ref": external_event_ref(event),
             "cursor_advanced": cursor_advanced,
+            "private_event_deleted": private_event_deleted,
             "effect_kind": str((effect_receipt or {}).get("effect_kind") or ""),
             "private_event_id_captured": False,
             "private_cursor_value_captured": False,

--- a/loopx/extensions/external_connector_runtime.py
+++ b/loopx/extensions/external_connector_runtime.py
@@ -111,12 +111,17 @@ def build_external_event_response_receipt(
 ) -> dict[str, Any]:
     """Normalize provider proof into one event-bound response receipt."""
 
+    proof = {
+        "external_write_performed": external_write_performed,
+        "verification_performed": verification_performed,
+        "response_verified": response_verified,
+    }
+    if any(not isinstance(value, bool) for value in proof.values()):
+        raise TypeError("external response proof fields must be booleans")
     return {
         "schema_version": RESPONSE_RECEIPT_SCHEMA_VERSION,
         "event_ref": external_event_ref(event_id),
-        "external_write_performed": bool(external_write_performed),
-        "verification_performed": bool(verification_performed),
-        "response_verified": bool(response_verified),
+        **proof,
         "private_event_id_captured": False,
         "private_response_content_captured": False,
     }

--- a/loopx/extensions/lark/goal_topic_connections.py
+++ b/loopx/extensions/lark/goal_topic_connections.py
@@ -22,6 +22,16 @@ from ...control_plane.goals.configure_goal_service import (
 )
 from ...control_plane.runtime.public_safety import public_safe_compact_text
 from ...control_plane.todos.contract import normalize_todo_claimed_by
+from ..external_connector_runtime import (
+    ExternalCapturePolicy,
+    ExternalConnectorCapability,
+    ExternalConnectorLifecycle,
+    ExternalIngressPolicy,
+    ExternalResponsePolicy,
+    ExternalSourceKind,
+    build_external_connector_binding,
+    project_external_connector_status,
+)
 from .goal_channel_contracts import (
     binding_for_goal,
     goal_from_registry,
@@ -110,7 +120,7 @@ def normalize_lark_topic_event_rejection_reason(value: Any) -> str | None:
 
 
 def _routing_value(
-    enum_type: type[CaptureScope] | type[IngressMode] | type[ReplyMode],
+    enum_type: type[CaptureScope | IngressMode | ReplyMode],
     value: Any,
     *,
     default: str,
@@ -590,6 +600,47 @@ def connect_lark_goal_topic(
             external_write_performed=True,
         )
 
+    connector_binding: dict[str, Any] | None = None
+    if normalized_agent_id and ingress_mode != IngressMode.DIRECT_SESSION.value:
+        if inbox_config is not None:
+            connector_inbox_ref = inbox_config[1]
+            connector_cursor_ref = (
+                f"{inbox_config[2]['inbox_dir']}/processed.json"
+            )
+        else:
+            connector_inbox_ref = None
+            runtime_digest = hashlib.sha256(
+                f"{profile}\0{safe_chat_id}\0{root_message_id}".encode()
+            ).hexdigest()[:20]
+            connector_cursor_ref = (
+                ".loopx/inbox/lark-goal-topics/"
+                f"{runtime_digest}/processed.json"
+            )
+        connector_binding = build_external_connector_binding(
+            goal_ref=goal_id,
+            agent_ref=normalized_agent_id,
+            provider_kind="lark",
+            source_kind=ExternalSourceKind.GROUP_MESSAGE.value,
+            source_ref=safe_chat_id,
+            capture_policy=(
+                ExternalCapturePolicy.CONFIGURED_SOURCE_ALL.value
+                if effective_capture_scope == CaptureScope.CONFIGURED_CHAT_ALL.value
+                else ExternalCapturePolicy.ADDRESSED_ONLY.value
+            ),
+            ingress_policy=ExternalIngressPolicy(ingress_mode).value,
+            response_policy=ExternalResponsePolicy.TOPIC_REPLY.value,
+            cursor_ref=connector_cursor_ref,
+            lifecycle=ExternalConnectorLifecycle.CONNECTED.value,
+            capabilities=[
+                ExternalConnectorCapability.REALTIME_RECEIVE.value,
+                ExternalConnectorCapability.RESPONSE_WRITE.value,
+                ExternalConnectorCapability.RESPONSE_READBACK.value,
+                ExternalConnectorCapability.ACKNOWLEDGE.value,
+            ],
+            session_ref=normalized_session_id or None,
+            inbox_ref=connector_inbox_ref,
+        )
+
     inbox_config_ref: str | None = None
     if inbox_config is not None:
         inbox_config_ref = inbox_config[1]
@@ -651,6 +702,7 @@ def connect_lark_goal_topic(
                     else {}
                 ),
             },
+            **({"connector": connector_binding} if connector_binding else {}),
             "automation": dict(existing.get("automation") or {}),
             "receipts": receipts,
         },
@@ -676,6 +728,15 @@ def connect_lark_goal_topic(
             "reply_mode": reply_mode,
             "agent_id": normalized_agent_id,
             **({"session_id": normalized_session_id} if normalized_session_id else {}),
+            **(
+                {
+                    "connector_status": project_external_connector_status(
+                        connector_binding
+                    )
+                }
+                if connector_binding
+                else {}
+            ),
         },
     )
 
@@ -793,6 +854,8 @@ def list_lark_connections(
         )
         topic = binding.get("topic") if isinstance(binding.get("topic"), Mapping) else {}
         routing = binding.get("routing") if isinstance(binding.get("routing"), Mapping) else {}
+        connector: Mapping[str, Any] | None = None
+        connector_status: dict[str, Any] | None = None
         try:
             capture_scope = _routing_value(
                 CaptureScope,
@@ -817,6 +880,19 @@ def list_lark_connections(
                 default=ReplyMode.TOPIC_REPLY.value,
                 field="reply_mode",
             )
+            raw_connector = binding.get("connector")
+            if raw_connector is not None:
+                if not isinstance(raw_connector, Mapping):
+                    raise ValueError("connector binding must be an object")
+                connector = raw_connector
+                connector_status = project_external_connector_status(connector)
+                if (
+                    connector_status["goal_ref"] != goal_id
+                    or connector_status["agent_ref"]
+                    != str(binding.get("agent_id") or "")
+                    or connector_status["ingress_policy"] != ingress_mode
+                ):
+                    raise ValueError("connector binding does not match the Lark route")
         except ValueError:
             capture_scope = CaptureScope.ADDRESSED_ONLY.value
             ingress_mode = IngressMode.DIRECT_SESSION.value
@@ -845,6 +921,11 @@ def list_lark_connections(
                 "capture_scope": capture_scope,
                 "ingress_mode": ingress_mode,
                 "reply_mode": reply_mode,
+                **(
+                    {"connector_status": connector_status}
+                    if connector_status is not None
+                    else {}
+                ),
                 "target_ref": target_ref,
                 "topic_name": public_safe_compact_text(topic.get("name") or goal_objective(goal), limit=120),
                 "topic_setup_required": not bool(topic.get("root_message_id") or legacy_root),
@@ -1009,6 +1090,18 @@ def decide_lark_topic_event(
                 default=ReplyMode.TOPIC_REPLY.value,
                 field="reply_mode",
             )
+            connector = binding.get("connector")
+            if connector is not None:
+                if not isinstance(connector, Mapping):
+                    raise ValueError("connector binding must be an object")
+                connector_status = project_external_connector_status(connector)
+                if (
+                    connector_status["goal_ref"] != goal_id
+                    or connector_status["agent_ref"]
+                    != str(binding.get("agent_id") or "")
+                    or connector_status["ingress_policy"] != ingress_mode
+                ):
+                    raise ValueError("connector binding does not match the Lark route")
         except ValueError:
             return {
                 "matched": False,
@@ -1039,6 +1132,16 @@ def decide_lark_topic_event(
                     "capture_scope": capture_scope,
                     "ingress_mode": ingress_mode,
                     "inbox_config_ref": str(routing.get("inbox_config_ref") or ""),
+                    **(
+                        {"connector": dict(connector)}
+                        if isinstance(connector, Mapping)
+                        else {}
+                    ),
+                    **(
+                        {"event_id": str(event.get("event_id") or message_id)}
+                        if isinstance(connector, Mapping)
+                        else {}
+                    ),
                 }
             )
         return {

--- a/loopx/extensions/lark/goal_topic_runtime.py
+++ b/loopx/extensions/lark/goal_topic_runtime.py
@@ -12,6 +12,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from ..external_connector_runtime import (
+    EFFECT_RECEIPT_SCHEMA_VERSION,
+    ExternalEffectKind,
+    ExternalResponsePolicy,
+    decide_external_event_ack,
+)
 from .event_inbox import (
     MESSAGE_ID_PATTERN,
     acknowledge_lark_event_inbox,
@@ -26,7 +32,7 @@ from .goal_topic_connections import (
 )
 from .inbox_reply import CommandRunner, reply_lark_event_inbox
 
-Answer = Callable[[Mapping[str, Any], str], str]
+Answer = Callable[[Mapping[str, Any], str], str | Mapping[str, Any]]
 SnapshotProvider = Callable[[], Mapping[str, Any]]
 ProfilePoller = Callable[[str, threading.Event], None]
 SimpleRunner = Callable[[list[str]], Mapping[str, Any]]
@@ -484,19 +490,38 @@ class LarkGoalTopicRuntimeService:
                 restart_count=restart_count,
             )
             try:
-                def answer(route: Mapping[str, Any], text: str) -> str:
+                def answer(
+                    route: Mapping[str, Any], text: str
+                ) -> Mapping[str, Any]:
                     snapshot = self.snapshot_provider()
                     contexts = snapshot.get("goal_contexts")
                     contexts = contexts if isinstance(contexts, Mapping) else {}
                     context = contexts.get(str(route.get("goal_id") or ""))
                     context = context if isinstance(context, Mapping) else {}
-                    return answer_lark_goal_topic(
+                    response_text = answer_lark_goal_topic(
                         route=route,
                         text=text,
                         work_dir=str(context.get("work_dir") or self.runtime_root),
                         objective=str(context.get("objective") or route.get("goal_id") or ""),
                         runtime_controller=self.runtime_controller,
                     )
+                    return {
+                        "response_text": response_text,
+                        "effect_receipt": {
+                            "schema_version": EFFECT_RECEIPT_SCHEMA_VERSION,
+                            "event_id": str(
+                                route.get("event_id") or route.get("message_id") or ""
+                            ),
+                            "effect_id": "session-turn-"
+                            + _opaque_digest(
+                                route.get("session_id"),
+                                route.get("message_id"),
+                                route.get("topic_root_message_id"),
+                            ),
+                            "effect_kind": ExternalEffectKind.WORKING_SESSION_TURN.value,
+                            "status": "committed",
+                        },
+                    }
 
                 result = stream_lark_goal_topic_profile(
                     profile=profile,
@@ -824,7 +849,20 @@ def process_lark_goal_topic_event(
             "agent_id": route.get("agent_id"),
             "inbox_config_ref": config_ref,
         }
-    reply_text = " ".join(str(answer(route, canonical["content"]) or "").split())[:1200]
+    answer_result = answer(route, canonical["content"])
+    connector = route.get("connector")
+    connector = connector if isinstance(connector, Mapping) else None
+    effect_receipt: Mapping[str, Any] | None = None
+    if isinstance(answer_result, Mapping):
+        reply_text = " ".join(
+            str(answer_result.get("response_text") or "").split()
+        )[:1200]
+        candidate_receipt = answer_result.get("effect_receipt")
+        effect_receipt = (
+            candidate_receipt if isinstance(candidate_receipt, Mapping) else None
+        )
+    else:
+        reply_text = " ".join(str(answer_result or "").split())[:1200]
     if not reply_text:
         return {
             "ok": False,
@@ -832,6 +870,20 @@ def process_lark_goal_topic_event(
             "goal_id": route["goal_id"],
             "inbox_config_ref": config_ref,
         }
+    if connector is not None:
+        effect_decision = decide_external_event_ack(
+            event_id=canonical["event_id"],
+            effect_receipt=effect_receipt,
+            response_policy=ExternalResponsePolicy.NO_RESPONSE.value,
+        )
+        if not effect_decision["effect_ready"]:
+            return {
+                "ok": False,
+                "status": "durable_effect_required",
+                "goal_id": route["goal_id"],
+                "inbox_config_ref": config_ref,
+                "ack_decision": effect_decision,
+            }
     reply = reply_lark_event_inbox(
         project=root,
         config_path=config_path,
@@ -848,6 +900,21 @@ def process_lark_goal_topic_event(
             "blocker": reply.get("blocker"),
             "inbox_config_ref": config_ref,
         }
+    if connector is not None:
+        ack_decision = decide_external_event_ack(
+            event_id=canonical["event_id"],
+            effect_receipt=effect_receipt,
+            response_policy=str(connector.get("response_policy") or ""),
+            response_receipt=reply,
+        )
+        if not ack_decision["ack_allowed"]:
+            return {
+                "ok": False,
+                "status": str(ack_decision["reason"]),
+                "goal_id": route["goal_id"],
+                "inbox_config_ref": config_ref,
+                "ack_decision": ack_decision,
+            }
     acknowledge_lark_event_inbox(
         project=root,
         config_path=config_path,

--- a/loopx/extensions/lark/goal_topic_runtime.py
+++ b/loopx/extensions/lark/goal_topic_runtime.py
@@ -16,6 +16,7 @@ from ..external_connector_runtime import (
     EFFECT_RECEIPT_SCHEMA_VERSION,
     ExternalEffectKind,
     ExternalResponsePolicy,
+    build_external_event_response_receipt,
     decide_external_event_ack,
 )
 from .event_inbox import (
@@ -152,13 +153,17 @@ def _topic_roots_for_target(
             or str(binding.get("target_ref") or "") != target_ref
         ):
             continue
-        topic = binding.get("topic") if isinstance(binding.get("topic"), Mapping) else {}
+        topic = (
+            binding.get("topic") if isinstance(binding.get("topic"), Mapping) else {}
+        )
         channel = (
             binding.get("channel")
             if isinstance(binding.get("channel"), Mapping)
             else {}
         )
-        root_id = str(topic.get("root_message_id") or channel.get("pinned_message_id") or "")
+        root_id = str(
+            topic.get("root_message_id") or channel.get("pinned_message_id") or ""
+        )
         if MESSAGE_ID_PATTERN.fullmatch(root_id):
             roots.append(root_id)
     return roots
@@ -215,7 +220,12 @@ def poll_lark_goal_topic_profile_once(
         ]
     )
     if int(result.get("returncode") or 0) != 0:
-        return {"ok": False, "status": "consume_failed", "event_count": 0, "replied_count": 0}
+        return {
+            "ok": False,
+            "status": "consume_failed",
+            "event_count": 0,
+            "replied_count": 0,
+        }
 
     target_payload = snapshot.get("target_payload")
     target_payload = target_payload if isinstance(target_payload, Mapping) else {}
@@ -276,9 +286,7 @@ def poll_lark_goal_topic_profile_once(
             event_reasons.append(None)
             continue
         event_statuses.append(str(event_result.get("status") or "unknown"))
-        event_reasons.append(
-            str(event_result.get("reason") or "") or None
-        )
+        event_reasons.append(str(event_result.get("reason") or "") or None)
         replied_count += int(event_result.get("status") == "replied_and_acknowledged")
     return {
         "ok": True,
@@ -490,9 +498,8 @@ class LarkGoalTopicRuntimeService:
                 restart_count=restart_count,
             )
             try:
-                def answer(
-                    route: Mapping[str, Any], text: str
-                ) -> Mapping[str, Any]:
+
+                def answer(route: Mapping[str, Any], text: str) -> Mapping[str, Any]:
                     snapshot = self.snapshot_provider()
                     contexts = snapshot.get("goal_contexts")
                     contexts = contexts if isinstance(contexts, Mapping) else {}
@@ -502,7 +509,9 @@ class LarkGoalTopicRuntimeService:
                         route=route,
                         text=text,
                         work_dir=str(context.get("work_dir") or self.runtime_root),
-                        objective=str(context.get("objective") or route.get("goal_id") or ""),
+                        objective=str(
+                            context.get("objective") or route.get("goal_id") or ""
+                        ),
                         runtime_controller=self.runtime_controller,
                     )
                     return {
@@ -529,7 +538,9 @@ class LarkGoalTopicRuntimeService:
                     stop=stop,
                     runtime_root=self.runtime_root,
                     answer=answer,
-                    health_sink=lambda update: self._update_health(profile, **dict(update)),
+                    health_sink=lambda update: self._update_health(
+                        profile, **dict(update)
+                    ),
                 )
                 if stop.is_set():
                     break
@@ -663,7 +674,9 @@ def answer_lark_goal_topic(
             or session.get("channel_id") != f"goal.{goal_id}"
             or session.get("status") == "closed"
         ):
-            raise RuntimeError("bound Agent session is unavailable or no longer matches")
+            raise RuntimeError(
+                "bound Agent session is unavailable or no longer matches"
+            )
         if ingress_mode == "live_steering":
             turn, _created = runtime_controller.steer_active_turn(
                 session_id=session_id,
@@ -710,7 +723,9 @@ def answer_lark_goal_topic(
     if completed.get("status") != "completed":
         raise RuntimeError(str(completed.get("error") or "Lark Goal Topic turn failed"))
     response = completed.get("response")
-    reply_text = str(response.get("message") or "") if isinstance(response, Mapping) else ""
+    reply_text = (
+        str(response.get("message") or "") if isinstance(response, Mapping) else ""
+    )
     if not reply_text.strip():
         raise RuntimeError("Lark Goal Topic turn returned no message")
     return reply_text
@@ -726,8 +741,12 @@ def _inbox_config(
     target = goal_channel_target_for_name(target_payload, target_ref)
     if target is None:
         raise ValueError("the routed Lark target is unavailable")
-    channel = target.get("channel") if isinstance(target.get("channel"), Mapping) else {}
-    identity = target.get("identity") if isinstance(target.get("identity"), Mapping) else {}
+    channel = (
+        target.get("channel") if isinstance(target.get("channel"), Mapping) else {}
+    )
+    identity = (
+        target.get("identity") if isinstance(target.get("identity"), Mapping) else {}
+    )
     chat_id = str(channel.get("chat_id") or "")
     profile = str(route.get("app_ref") or "")
     bot_display_name = str(identity.get("bot_display_name") or profile)
@@ -817,7 +836,9 @@ def process_lark_goal_topic_event(
         "content": str(event.get("content") or ""),
         "root_id": str(event.get("root_id") or ""),
         "parent_id": str(event.get("parent_id") or ""),
-        "mentions": event.get("mentions") if isinstance(event.get("mentions"), list) else [],
+        "mentions": event.get("mentions")
+        if isinstance(event.get("mentions"), list)
+        else [],
         "reply_context_verified": event.get("reply_context_verified") is True,
         "reply_to_bot": event.get("reply_to_bot") is True,
     }
@@ -854,9 +875,9 @@ def process_lark_goal_topic_event(
     connector = connector if isinstance(connector, Mapping) else None
     effect_receipt: Mapping[str, Any] | None = None
     if isinstance(answer_result, Mapping):
-        reply_text = " ".join(
-            str(answer_result.get("response_text") or "").split()
-        )[:1200]
+        reply_text = " ".join(str(answer_result.get("response_text") or "").split())[
+            :1200
+        ]
         candidate_receipt = answer_result.get("effect_receipt")
         effect_receipt = (
             candidate_receipt if isinstance(candidate_receipt, Mapping) else None
@@ -905,7 +926,14 @@ def process_lark_goal_topic_event(
             event_id=canonical["event_id"],
             effect_receipt=effect_receipt,
             response_policy=str(connector.get("response_policy") or ""),
-            response_receipt=reply,
+            response_receipt=build_external_event_response_receipt(
+                event_id=canonical["event_id"],
+                external_write_performed=(
+                    reply.get("external_write_performed") is True
+                ),
+                verification_performed=(reply.get("verification_performed") is True),
+                response_verified=reply.get("reply_verified") is True,
+            ),
         )
         if not ack_decision["ack_allowed"]:
             return {

--- a/tests/extensions/test_external_connector_provider.py
+++ b/tests/extensions/test_external_connector_provider.py
@@ -278,6 +278,39 @@ def test_document_comment_provider_callsite_runs_effect_response_ack_order(
     assert capture["accepted_count"] == 1
     assert capture["external_read_performed"] is True
 
+    def mismatched_writer(
+        connector: dict[str, Any],
+        event: dict[str, Any],
+        text: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        call_order.append("mismatched_provider_response")
+        return {
+            "idempotency_key": "sha256:receipt-for-a-different-event",
+            "external_write_performed": True,
+            "verification_performed": True,
+            "readback_verified": True,
+        }
+
+    with pytest.raises(ValueError, match="bind the requested idempotency_key"):
+        reply_and_settle_document_comment_event(
+            project=str(tmp_path),
+            registration=registration,
+            permission_guidance=guidance,
+            event_id="event-alpha",
+            effect_receipt=_effect(),
+            reply_text="A mismatched receipt cannot acknowledge this event.",
+            response_writer=mismatched_writer,
+            execute=True,
+        )
+    assert (
+        inspect_external_connector_inbox(
+            project=tmp_path,
+            binding=registration["connector"],
+        )["pending_count"]
+        == 1
+    )
+
     def writer(
         connector: dict[str, Any],
         event: dict[str, Any],
@@ -291,6 +324,7 @@ def test_document_comment_provider_callsite_runs_effect_response_ack_order(
         assert text == "Accepted after durable writeback."
         assert idempotency_key.startswith("sha256:")
         return {
+            "idempotency_key": idempotency_key,
             "external_write_performed": True,
             "verification_performed": True,
             "readback_verified": True,
@@ -315,6 +349,7 @@ def test_document_comment_provider_callsite_runs_effect_response_ack_order(
     assert settlement["cursor_advanced"] is True
     assert call_order == [
         "provider_read",
+        "mismatched_provider_response",
         "durable_effect_committed",
         "provider_response",
     ]
@@ -377,6 +412,7 @@ def test_provider_response_is_not_called_before_durable_effect(
     ) -> dict[str, Any]:
         writes.append(idempotency_key)
         return {
+            "idempotency_key": idempotency_key,
             "external_write_performed": True,
             "verification_performed": True,
             "readback_verified": True,

--- a/tests/extensions/test_external_connector_provider.py
+++ b/tests/extensions/test_external_connector_provider.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from loopx.extensions.external_connector_provider import (
+    build_document_comment_connector_registration,
+    build_external_connector_permission_requirement,
+    build_external_connector_provider_page,
+    capture_document_comment_provider_page,
+    evaluate_external_connector_permissions,
+    project_document_comment_connector_status,
+    project_external_connector_permission_status,
+    reply_and_settle_document_comment_event,
+)
+from loopx.extensions.external_connector_runtime import (
+    EFFECT_RECEIPT_SCHEMA_VERSION,
+    ExternalCapturePolicy,
+    ExternalConnectorCapability,
+    ExternalConnectorLifecycle,
+    ExternalEffectKind,
+    ExternalIngressPolicy,
+    ExternalResponsePolicy,
+    ExternalSourceKind,
+    build_external_connector_binding,
+    build_external_connector_event,
+    inspect_external_connector_inbox,
+)
+
+
+def _connector() -> dict[str, Any]:
+    return build_external_connector_binding(
+        goal_ref="goal-alpha",
+        agent_ref="agent-alpha",
+        provider_kind="provider-fixture",
+        source_kind=ExternalSourceKind.DOCUMENT_COMMENT.value,
+        source_ref="source-fixture",
+        capture_policy=ExternalCapturePolicy.INCREMENTAL.value,
+        ingress_policy=ExternalIngressPolicy.ASYNC_INBOX.value,
+        response_policy=ExternalResponsePolicy.SOURCE_THREAD.value,
+        cursor_ref=".loopx/inbox/document-comments/cursor.json",
+        lifecycle=ExternalConnectorLifecycle.CONNECTED.value,
+        capabilities=[
+            ExternalConnectorCapability.HISTORY_CATCH_UP.value,
+            ExternalConnectorCapability.RESPONSE_WRITE.value,
+            ExternalConnectorCapability.RESPONSE_READBACK.value,
+            ExternalConnectorCapability.ACKNOWLEDGE.value,
+        ],
+        inbox_ref=".loopx/inbox/document-comments",
+    )
+
+
+def _permission(operation: str) -> dict[str, Any]:
+    return build_external_connector_permission_requirement(
+        provider_kind="provider-fixture",
+        provider_identity="fixture-bot",
+        operation=operation,
+        required_scopes=[f"comments:{operation}"],
+        publication_required=True,
+        repair_url="https://provider.example/apps/app-fixture/permissions",
+    )
+
+
+def _requirements() -> list[dict[str, Any]]:
+    return [
+        _permission(ExternalConnectorCapability.HISTORY_CATCH_UP.value),
+        _permission(ExternalConnectorCapability.RESPONSE_WRITE.value),
+        _permission(ExternalConnectorCapability.RESPONSE_READBACK.value),
+    ]
+
+
+def _registration() -> dict[str, Any]:
+    return build_document_comment_connector_registration(
+        connector=_connector(),
+        authority_material_ref="material-alpha",
+        project_materials={
+            "material-alpha": {
+                "id": "material-alpha",
+                "source_kind": "document",
+            }
+        },
+        permission_requirements=_requirements(),
+    )
+
+
+def _permission_guidance(*, ready: bool) -> dict[str, Any]:
+    scopes = {
+        "fixture-bot": [
+            "comments:history_catch_up",
+            "comments:response_write",
+            "comments:response_readback",
+        ]
+        if ready
+        else []
+    }
+    return evaluate_external_connector_permissions(
+        requirements=_requirements(),
+        granted_scopes=scopes,
+        published=ready,
+    )
+
+
+def _effect() -> dict[str, Any]:
+    return {
+        "schema_version": EFFECT_RECEIPT_SCHEMA_VERSION,
+        "event_id": "event-alpha",
+        "effect_id": "effect-alpha",
+        "effect_kind": ExternalEffectKind.TODO_UPDATE.value,
+        "status": "committed",
+    }
+
+
+def test_document_comment_registration_requires_separate_authority_material() -> None:
+    with pytest.raises(ValueError, match="registered before its comments"):
+        build_document_comment_connector_registration(
+            connector=_connector(),
+            authority_material_ref="material-alpha",
+            project_materials={},
+            permission_requirements=_requirements(),
+        )
+
+    registration = _registration()
+    assert registration["authority_relation"] == "reference_only"
+    assert registration["comment_authority"] == "external_input_only"
+    assert "content" not in registration
+
+
+def test_document_comment_registration_requires_permission_coverage() -> None:
+    with pytest.raises(ValueError, match="do not cover provider calls"):
+        build_document_comment_connector_registration(
+            connector=_connector(),
+            authority_material_ref="material-alpha",
+            project_materials={
+                "material-alpha": {
+                    "id": "material-alpha",
+                    "source_kind": "document",
+                }
+            },
+            permission_requirements=[
+                _permission(ExternalConnectorCapability.HISTORY_CATCH_UP.value)
+            ],
+        )
+
+
+def test_permission_projection_hides_exact_repair_guidance() -> None:
+    guidance = _permission_guidance(ready=False)
+    assert guidance["ready"] is False
+    assert guidance["items"][0]["missing_scopes"]
+    assert guidance["items"][0]["repair_url"].startswith("https://")
+
+    status = project_external_connector_permission_status(guidance)
+    assert status["ready"] is False
+    assert status["missing_requirement_count"] == 3
+    assert "items" not in status
+    assert "required_scopes" not in status
+    assert "repair_url" not in status
+    assert status["private_scope_values_captured"] is False
+    assert status["private_repair_urls_captured"] is False
+
+
+def test_permission_projection_rejects_forged_ready_state() -> None:
+    guidance = _permission_guidance(ready=False)
+    guidance["ready"] = True
+
+    with pytest.raises(ValueError, match="aggregate ready state is inconsistent"):
+        project_external_connector_permission_status(guidance)
+
+
+def test_document_comment_registration_rejects_unbound_permission_guidance() -> None:
+    unrelated_requirement = build_external_connector_permission_requirement(
+        provider_kind="provider-fixture",
+        provider_identity="other-bot",
+        operation=ExternalConnectorCapability.HISTORY_CATCH_UP.value,
+        required_scopes=["comments:history_catch_up"],
+        publication_required=True,
+        repair_url="https://provider.example/apps/other-bot/permissions",
+    )
+    unrelated_guidance = evaluate_external_connector_permissions(
+        requirements=[unrelated_requirement],
+        granted_scopes={"other-bot": ["comments:history_catch_up"]},
+        published=True,
+    )
+
+    with pytest.raises(ValueError, match="must match the registered Connector"):
+        project_document_comment_connector_status(
+            registration=_registration(),
+            permission_guidance=unrelated_guidance,
+        )
+
+
+def test_document_comment_registration_revalidates_authority_policy() -> None:
+    registration = _registration()
+    registration["comment_authority"] = "authoritative"
+
+    with pytest.raises(ValueError, match="authority policy is invalid"):
+        project_document_comment_connector_status(
+            registration=registration,
+            permission_guidance=_permission_guidance(ready=True),
+        )
+
+
+def test_provider_capture_does_not_read_until_permissions_are_ready(
+    tmp_path: Path,
+) -> None:
+    calls: list[str] = []
+
+    def reader(
+        connector: dict[str, Any],
+        cursor: str | None,
+        limit: int,
+    ) -> dict[str, Any]:
+        calls.append(str(connector["provider_kind"]))
+        return build_external_connector_provider_page(
+            events=[],
+            expected_cursor=cursor,
+            next_cursor="page-two",
+            has_more=False,
+        )
+
+    result = capture_document_comment_provider_page(
+        project=str(tmp_path),
+        registration=_registration(),
+        permission_guidance=_permission_guidance(ready=False),
+        page_reader=reader,
+        expected_cursor=None,
+        execute=True,
+    )
+
+    assert result["status"] == "permission_required"
+    assert result["external_read_performed"] is False
+    assert calls == []
+
+
+def test_document_comment_provider_callsite_runs_effect_response_ack_order(
+    tmp_path: Path,
+) -> None:
+    call_order: list[str] = []
+    registration = _registration()
+    guidance = _permission_guidance(ready=True)
+
+    def reader(
+        connector: dict[str, Any],
+        cursor: str | None,
+        limit: int,
+    ) -> dict[str, Any]:
+        call_order.append("provider_read")
+        assert connector["provider_kind"] == "provider-fixture"
+        assert cursor is None
+        assert limit == 100
+        return build_external_connector_provider_page(
+            events=[
+                build_external_connector_event(
+                    event_id="event-alpha",
+                    content="Please validate this comment.",
+                    occurred_at="2026-08-23T00:00:00Z",
+                    addressed=True,
+                    event_cursor="event-cursor-alpha",
+                    anchor_ref="anchor-alpha",
+                    reply_chain_ref="reply-chain-alpha",
+                )
+            ],
+            expected_cursor=cursor,
+            next_cursor="page-two",
+            has_more=False,
+        )
+
+    capture = capture_document_comment_provider_page(
+        project=str(tmp_path),
+        registration=registration,
+        permission_guidance=guidance,
+        page_reader=reader,
+        expected_cursor=None,
+        execute=True,
+    )
+    assert capture["ok"] is True
+    assert capture["accepted_count"] == 1
+    assert capture["external_read_performed"] is True
+
+    def writer(
+        connector: dict[str, Any],
+        event: dict[str, Any],
+        text: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        call_order.append("provider_response")
+        assert connector["provider_kind"] == "provider-fixture"
+        assert event["event_id"] == "event-alpha"
+        assert event["anchor_ref"] == "anchor-alpha"
+        assert text == "Accepted after durable writeback."
+        assert idempotency_key.startswith("sha256:")
+        return {
+            "external_write_performed": True,
+            "verification_performed": True,
+            "readback_verified": True,
+        }
+
+    call_order.append("durable_effect_committed")
+    settlement = reply_and_settle_document_comment_event(
+        project=str(tmp_path),
+        registration=registration,
+        permission_guidance=guidance,
+        event_id="event-alpha",
+        effect_receipt=_effect(),
+        reply_text="Accepted after durable writeback.",
+        response_writer=writer,
+        execute=True,
+    )
+
+    assert settlement["ok"] is True
+    assert settlement["status"] == "acknowledged"
+    assert settlement["external_write_performed"] is True
+    assert settlement["response_readback_verified"] is True
+    assert settlement["cursor_advanced"] is True
+    assert call_order == [
+        "provider_read",
+        "durable_effect_committed",
+        "provider_response",
+    ]
+    inbox_status = inspect_external_connector_inbox(
+        project=tmp_path,
+        binding=registration["connector"],
+    )
+    assert inbox_status["pending_count"] == 0
+    projected = project_document_comment_connector_status(
+        registration=registration,
+        permission_guidance=guidance,
+    )
+    assert projected["authority_material_bound"] is True
+    assert projected["comment_authority"] == "external_input_only"
+    assert projected["permissions"]["ready"] is True
+    assert projected["private_authority_material_ref_captured"] is False
+
+
+def test_provider_response_is_not_called_before_durable_effect(
+    tmp_path: Path,
+) -> None:
+    registration = _registration()
+    guidance = _permission_guidance(ready=True)
+
+    def reader(
+        connector: dict[str, Any],
+        cursor: str | None,
+        limit: int,
+    ) -> dict[str, Any]:
+        return build_external_connector_provider_page(
+            events=[
+                build_external_connector_event(
+                    event_id="event-alpha",
+                    content="Please validate this comment.",
+                    occurred_at="2026-08-23T00:00:00Z",
+                    addressed=True,
+                    event_cursor="event-cursor-alpha",
+                )
+            ],
+            expected_cursor=cursor,
+            next_cursor="page-two",
+            has_more=False,
+        )
+
+    capture_document_comment_provider_page(
+        project=str(tmp_path),
+        registration=registration,
+        permission_guidance=guidance,
+        page_reader=reader,
+        expected_cursor=None,
+        execute=True,
+    )
+    writes: list[str] = []
+
+    def writer(
+        connector: dict[str, Any],
+        event: dict[str, Any],
+        text: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        writes.append(idempotency_key)
+        return {
+            "external_write_performed": True,
+            "verification_performed": True,
+            "readback_verified": True,
+        }
+
+    result = reply_and_settle_document_comment_event(
+        project=str(tmp_path),
+        registration=registration,
+        permission_guidance=guidance,
+        event_id="event-alpha",
+        effect_receipt=None,
+        reply_text="This must not be sent.",
+        response_writer=writer,
+        execute=True,
+    )
+
+    assert result["status"] == "durable_effect_required"
+    assert result["external_write_performed"] is False
+    assert writes == []

--- a/tests/extensions/test_external_connector_runtime.py
+++ b/tests/extensions/test_external_connector_runtime.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import pytest
+
+from loopx.extensions.external_connector_runtime import (
+    EFFECT_RECEIPT_SCHEMA_VERSION,
+    ExternalCapturePolicy,
+    ExternalConnectorCapability,
+    ExternalConnectorLifecycle,
+    ExternalEffectKind,
+    ExternalIngressPolicy,
+    ExternalResponsePolicy,
+    ExternalSourceKind,
+    build_external_connector_binding,
+    decide_external_event_ack,
+    project_external_connector_status,
+)
+
+
+def _binding(**overrides: object) -> dict[str, object]:
+    values: dict[str, object] = {
+        "goal_ref": "goal-alpha",
+        "agent_ref": "agent-alpha",
+        "provider_kind": "provider-fixture",
+        "source_kind": ExternalSourceKind.GROUP_MESSAGE.value,
+        "source_ref": "source-fixture",
+        "capture_policy": ExternalCapturePolicy.ADDRESSED_ONLY.value,
+        "ingress_policy": ExternalIngressPolicy.LIVE_STEERING.value,
+        "response_policy": ExternalResponsePolicy.SOURCE_THREAD.value,
+        "cursor_ref": ".loopx/inbox/source-fixture/processed.json",
+        "lifecycle": ExternalConnectorLifecycle.CONNECTED.value,
+        "capabilities": [
+            ExternalConnectorCapability.REALTIME_RECEIVE.value,
+            ExternalConnectorCapability.RESPONSE_WRITE.value,
+            ExternalConnectorCapability.RESPONSE_READBACK.value,
+            ExternalConnectorCapability.ACKNOWLEDGE.value,
+        ],
+        "session_ref": "session-alpha",
+    }
+    values.update(overrides)
+    return build_external_connector_binding(**values)  # type: ignore[arg-type]
+
+
+def test_group_message_binding_targets_one_exact_working_session() -> None:
+    binding = _binding()
+
+    assert binding["source_kind"] == "group_message"
+    assert binding["agent_ref"] == "agent-alpha"
+    assert binding["session_ref"] == "session-alpha"
+    assert binding["ingress_policy"] == "live_steering"
+
+
+def test_document_comment_binding_supports_incremental_async_inbox() -> None:
+    binding = _binding(
+        source_kind=ExternalSourceKind.DOCUMENT_COMMENT.value,
+        capture_policy=ExternalCapturePolicy.INCREMENTAL.value,
+        ingress_policy=ExternalIngressPolicy.ASYNC_INBOX.value,
+        session_ref=None,
+        inbox_ref=".loopx/inbox/document-comments",
+        capabilities=[
+            ExternalConnectorCapability.HISTORY_CATCH_UP.value,
+            ExternalConnectorCapability.RESPONSE_WRITE.value,
+            ExternalConnectorCapability.RESPONSE_READBACK.value,
+            ExternalConnectorCapability.ACKNOWLEDGE.value,
+        ],
+    )
+
+    assert binding["source_kind"] == "document_comment"
+    assert binding["capture_policy"] == "incremental"
+    assert binding["ingress_policy"] == "async_inbox"
+    assert binding["inbox_ref"] == ".loopx/inbox/document-comments"
+
+
+@pytest.mark.parametrize("ingress", ["live_steering", "session_queue"])
+def test_ordered_session_delivery_requires_exact_session(ingress: str) -> None:
+    with pytest.raises(ValueError, match="exact session_ref"):
+        _binding(ingress_policy=ingress, session_ref=None)
+
+
+def test_async_delivery_requires_owner_local_inbox() -> None:
+    with pytest.raises(ValueError, match="owner-local inbox_ref"):
+        _binding(
+            ingress_policy=ExternalIngressPolicy.ASYNC_INBOX.value,
+            session_ref=None,
+            inbox_ref=None,
+        )
+
+    with pytest.raises(ValueError, match="cannot bind an exact session_ref"):
+        _binding(
+            ingress_policy=ExternalIngressPolicy.ASYNC_INBOX.value,
+            session_ref="session-alpha",
+            inbox_ref=".loopx/inbox/source-fixture",
+        )
+
+
+@pytest.mark.parametrize(
+    ("capture_policy", "capabilities"),
+    [
+        (
+            ExternalCapturePolicy.ADDRESSED_ONLY.value,
+            [ExternalConnectorCapability.HISTORY_CATCH_UP.value],
+        ),
+        (
+            ExternalCapturePolicy.INCREMENTAL.value,
+            [],
+        ),
+        (
+            ExternalCapturePolicy.ADDRESSED_ONLY.value,
+            [ExternalConnectorCapability.ACKNOWLEDGE.value],
+        ),
+    ],
+)
+def test_cursor_advancing_operations_require_incremental_checkpoint(
+    capture_policy: str,
+    capabilities: list[str],
+) -> None:
+    with pytest.raises(ValueError, match="owner-local cursor_ref"):
+        _binding(
+            cursor_ref=None,
+            capture_policy=capture_policy,
+            capabilities=capabilities,
+            response_policy=ExternalResponsePolicy.NO_RESPONSE.value,
+        )
+
+
+def test_response_policy_requires_write_and_readback_capabilities() -> None:
+    with pytest.raises(ValueError, match="response_write and response_readback"):
+        _binding(capabilities=[ExternalConnectorCapability.RESPONSE_WRITE.value])
+
+
+def test_status_projection_omits_private_source_and_cursor_references() -> None:
+    status = project_external_connector_status(_binding())
+
+    assert "source_ref" not in status
+    assert "cursor_ref" not in status
+    assert status["private_source_ref_captured"] is False
+    assert status["private_cursor_ref_captured"] is False
+    assert status["session_bound"] is True
+
+
+def test_ack_fails_closed_until_effect_and_response_are_verified() -> None:
+    missing_effect = decide_external_event_ack(
+        event_id="event-alpha",
+        effect_receipt=None,
+        response_policy=ExternalResponsePolicy.SOURCE_THREAD.value,
+        response_receipt={
+            "external_write_performed": True,
+            "verification_performed": True,
+            "response_verified": True,
+        },
+    )
+    assert missing_effect["ack_allowed"] is False
+    assert missing_effect["reason"] == "durable_effect_required"
+
+    effect_receipt = {
+        "schema_version": EFFECT_RECEIPT_SCHEMA_VERSION,
+        "event_id": "event-alpha",
+        "effect_id": "effect-alpha",
+        "effect_kind": ExternalEffectKind.TODO_UPDATE.value,
+        "status": "committed",
+    }
+    missing_readback = decide_external_event_ack(
+        event_id="event-alpha",
+        effect_receipt=effect_receipt,
+        response_policy=ExternalResponsePolicy.SOURCE_THREAD.value,
+        response_receipt={
+            "external_write_performed": True,
+            "verification_performed": False,
+        },
+    )
+    assert missing_readback["ack_allowed"] is False
+    assert missing_readback["reason"] == "verified_response_required"
+
+    ready = decide_external_event_ack(
+        event_id="event-alpha",
+        effect_receipt=effect_receipt,
+        response_policy=ExternalResponsePolicy.SOURCE_THREAD.value,
+        response_receipt={
+            "external_write_performed": True,
+            "verification_performed": True,
+            "reply_verified": True,
+        },
+    )
+    assert ready["ack_allowed"] is True
+    assert ready["reason"] == "ready"
+
+
+def test_no_response_connector_still_requires_durable_effect() -> None:
+    effect_receipt = {
+        "schema_version": EFFECT_RECEIPT_SCHEMA_VERSION,
+        "event_id": "event-alpha",
+        "effect_id": "effect-alpha",
+        "effect_kind": ExternalEffectKind.NO_FOLLOW_UP.value,
+        "status": "committed",
+    }
+    ready = decide_external_event_ack(
+        event_id="event-alpha",
+        effect_receipt=effect_receipt,
+        response_policy=ExternalResponsePolicy.NO_RESPONSE.value,
+    )
+
+    assert ready["ack_allowed"] is True
+    assert ready["response_required"] is False

--- a/tests/extensions/test_external_connector_runtime.py
+++ b/tests/extensions/test_external_connector_runtime.py
@@ -16,6 +16,7 @@ from loopx.extensions.external_connector_runtime import (
     ExternalSourceKind,
     build_external_connector_binding,
     build_external_connector_event,
+    build_external_event_response_receipt,
     capture_external_connector_events,
     decide_external_event_ack,
     drain_external_connector_inbox,
@@ -152,11 +153,12 @@ def test_ack_fails_closed_until_effect_and_response_are_verified() -> None:
         event_id="event-alpha",
         effect_receipt=None,
         response_policy=ExternalResponsePolicy.SOURCE_THREAD.value,
-        response_receipt={
-            "external_write_performed": True,
-            "verification_performed": True,
-            "response_verified": True,
-        },
+        response_receipt=build_external_event_response_receipt(
+            event_id="event-alpha",
+            external_write_performed=True,
+            verification_performed=True,
+            response_verified=True,
+        ),
     )
     assert missing_effect["ack_allowed"] is False
     assert missing_effect["reason"] == "durable_effect_required"
@@ -172,10 +174,12 @@ def test_ack_fails_closed_until_effect_and_response_are_verified() -> None:
         event_id="event-alpha",
         effect_receipt=effect_receipt,
         response_policy=ExternalResponsePolicy.SOURCE_THREAD.value,
-        response_receipt={
-            "external_write_performed": True,
-            "verification_performed": False,
-        },
+        response_receipt=build_external_event_response_receipt(
+            event_id="event-alpha",
+            external_write_performed=True,
+            verification_performed=False,
+            response_verified=False,
+        ),
     )
     assert missing_readback["ack_allowed"] is False
     assert missing_readback["reason"] == "verified_response_required"
@@ -184,14 +188,29 @@ def test_ack_fails_closed_until_effect_and_response_are_verified() -> None:
         event_id="event-alpha",
         effect_receipt=effect_receipt,
         response_policy=ExternalResponsePolicy.SOURCE_THREAD.value,
-        response_receipt={
-            "external_write_performed": True,
-            "verification_performed": True,
-            "reply_verified": True,
-        },
+        response_receipt=build_external_event_response_receipt(
+            event_id="event-alpha",
+            external_write_performed=True,
+            verification_performed=True,
+            response_verified=True,
+        ),
     )
     assert ready["ack_allowed"] is True
     assert ready["reason"] == "ready"
+
+    replayed_response = decide_external_event_ack(
+        event_id="event-alpha",
+        effect_receipt=effect_receipt,
+        response_policy=ExternalResponsePolicy.SOURCE_THREAD.value,
+        response_receipt=build_external_event_response_receipt(
+            event_id="event-other",
+            external_write_performed=True,
+            verification_performed=True,
+            response_verified=True,
+        ),
+    )
+    assert replayed_response["ack_allowed"] is False
+    assert replayed_response["reason"] == "verified_response_required"
 
 
 def test_no_response_connector_still_requires_durable_effect() -> None:
@@ -256,12 +275,13 @@ def _effect(event_id: str) -> dict[str, object]:
     }
 
 
-def _response() -> dict[str, object]:
-    return {
-        "external_write_performed": True,
-        "verification_performed": True,
-        "readback_verified": True,
-    }
+def _response(event_id: str) -> dict[str, object]:
+    return build_external_event_response_receipt(
+        event_id=event_id,
+        external_write_performed=True,
+        verification_performed=True,
+        response_verified=True,
+    )
 
 
 def test_incremental_document_comment_inbox_advances_cursor_after_last_ack(
@@ -299,7 +319,7 @@ def test_incremental_document_comment_inbox_advances_cursor_after_last_ack(
         binding=binding,
         event_id="event-one",
         effect_receipt=None,
-        response_receipt=_response(),
+        response_receipt=_response("event-one"),
         execute=True,
     )
     assert missing_effect["status"] == "durable_effect_required"
@@ -309,22 +329,26 @@ def test_incremental_document_comment_inbox_advances_cursor_after_last_ack(
         binding=binding,
         event_id="event-one",
         effect_receipt=_effect("event-one"),
-        response_receipt=_response(),
+        response_receipt=_response("event-one"),
         execute=True,
     )
     assert first["status"] == "acknowledged"
     assert first["cursor_advanced"] is False
+    assert first["private_event_deleted"] is True
 
     second = settle_external_connector_event(
         project=tmp_path,
         binding=binding,
         event_id="event-two",
         effect_receipt=_effect("event-two"),
-        response_receipt=_response(),
+        response_receipt=_response("event-two"),
         execute=True,
     )
     assert second["status"] == "acknowledged"
     assert second["cursor_advanced"] is True
+    assert second["private_event_deleted"] is True
+    events_root = tmp_path / ".loopx/inbox/document-comments/events"
+    assert list(events_root.glob("*.json")) == []
 
     next_page = capture_external_connector_events(
         project=tmp_path,
@@ -365,7 +389,7 @@ def test_external_connector_settlement_is_strictly_ordered(tmp_path: Path) -> No
         binding=binding,
         event_id="event-two",
         effect_receipt=_effect("event-two"),
-        response_receipt=_response(),
+        response_receipt=_response("event-two"),
         execute=True,
     )
 
@@ -487,7 +511,7 @@ def test_replayed_acknowledged_page_can_advance_cursor(tmp_path: Path) -> None:
         binding=binding,
         event_id="event-one",
         effect_receipt=_effect("event-one"),
-        response_receipt=_response(),
+        response_receipt=_response("event-one"),
         execute=True,
     )
 

--- a/tests/extensions/test_external_connector_runtime.py
+++ b/tests/extensions/test_external_connector_runtime.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
+from pathlib import Path
+
 import pytest
 
 from loopx.extensions.external_connector_runtime import (
@@ -12,8 +15,14 @@ from loopx.extensions.external_connector_runtime import (
     ExternalResponsePolicy,
     ExternalSourceKind,
     build_external_connector_binding,
+    build_external_connector_event,
+    capture_external_connector_events,
     decide_external_event_ack,
+    drain_external_connector_inbox,
+    inspect_external_connector_inbox,
     project_external_connector_status,
+    record_external_connector_failure,
+    settle_external_connector_event,
 )
 
 
@@ -201,3 +210,304 @@ def test_no_response_connector_still_requires_durable_effect() -> None:
 
     assert ready["ack_allowed"] is True
     assert ready["response_required"] is False
+
+
+def _document_binding() -> dict[str, object]:
+    return _binding(
+        source_kind=ExternalSourceKind.DOCUMENT_COMMENT.value,
+        capture_policy=ExternalCapturePolicy.INCREMENTAL.value,
+        ingress_policy=ExternalIngressPolicy.ASYNC_INBOX.value,
+        session_ref=None,
+        inbox_ref=".loopx/inbox/document-comments",
+        cursor_ref=".loopx/inbox/document-comments/cursor.json",
+        capabilities=[
+            ExternalConnectorCapability.HISTORY_CATCH_UP.value,
+            ExternalConnectorCapability.RESPONSE_WRITE.value,
+            ExternalConnectorCapability.RESPONSE_READBACK.value,
+            ExternalConnectorCapability.ACKNOWLEDGE.value,
+        ],
+    )
+
+
+def _comment_event(
+    event_id: str,
+    *,
+    addressed: bool = True,
+    content: str = "Please verify this decision.",
+) -> dict[str, object]:
+    return build_external_connector_event(
+        event_id=event_id,
+        content=content,
+        occurred_at="2026-08-22T10:00:00Z",
+        addressed=addressed,
+        event_cursor=f"cursor-{event_id}",
+        anchor_ref=f"anchor-{event_id}",
+        reply_chain_ref=f"thread-{event_id}",
+    )
+
+
+def _effect(event_id: str) -> dict[str, object]:
+    return {
+        "schema_version": EFFECT_RECEIPT_SCHEMA_VERSION,
+        "event_id": event_id,
+        "effect_id": f"effect-{event_id}",
+        "effect_kind": ExternalEffectKind.DESIGN_UPDATE.value,
+        "status": "committed",
+    }
+
+
+def _response() -> dict[str, object]:
+    return {
+        "external_write_performed": True,
+        "verification_performed": True,
+        "readback_verified": True,
+    }
+
+
+def test_incremental_document_comment_inbox_advances_cursor_after_last_ack(
+    tmp_path: Path,
+) -> None:
+    binding = _document_binding()
+    capture = capture_external_connector_events(
+        project=tmp_path,
+        binding=binding,
+        events=[_comment_event("event-one"), _comment_event("event-two")],
+        expected_cursor=None,
+        next_cursor="page-two",
+        execute=True,
+    )
+
+    assert capture["accepted_count"] == 2
+    assert capture["cursor_advanced"] is False
+    assert capture["private_event_content_captured"] is False
+
+    drained = drain_external_connector_inbox(
+        project=tmp_path,
+        binding=binding,
+    )
+    assert [item["event_id"] for item in drained["items"]] == [
+        "event-one",
+        "event-two",
+    ]
+    assert drained["items"][0]["content"] == "Please verify this decision."
+    assert drained["items"][0]["anchor_ref"] == "anchor-event-one"
+    assert drained["items"][0]["reply_chain_ref"] == "thread-event-one"
+    assert drained["local_private_content_returned"] is True
+
+    missing_effect = settle_external_connector_event(
+        project=tmp_path,
+        binding=binding,
+        event_id="event-one",
+        effect_receipt=None,
+        response_receipt=_response(),
+        execute=True,
+    )
+    assert missing_effect["status"] == "durable_effect_required"
+
+    first = settle_external_connector_event(
+        project=tmp_path,
+        binding=binding,
+        event_id="event-one",
+        effect_receipt=_effect("event-one"),
+        response_receipt=_response(),
+        execute=True,
+    )
+    assert first["status"] == "acknowledged"
+    assert first["cursor_advanced"] is False
+
+    second = settle_external_connector_event(
+        project=tmp_path,
+        binding=binding,
+        event_id="event-two",
+        effect_receipt=_effect("event-two"),
+        response_receipt=_response(),
+        execute=True,
+    )
+    assert second["status"] == "acknowledged"
+    assert second["cursor_advanced"] is True
+
+    next_page = capture_external_connector_events(
+        project=tmp_path,
+        binding=binding,
+        events=[_comment_event("event-three")],
+        expected_cursor="page-two",
+        next_cursor="page-three",
+        execute=False,
+    )
+    assert next_page["ok"] is True
+    assert next_page["accepted_count"] == 1
+
+    status = inspect_external_connector_inbox(
+        project=tmp_path,
+        binding=binding,
+        now=datetime(2026, 8, 22, 10, 1, tzinfo=UTC),
+    )
+    assert status["pending_count"] == 0
+    assert "items" not in status
+    assert "committed_cursor" not in status
+    assert status["private_event_content_captured"] is False
+    assert status["private_cursor_value_captured"] is False
+
+
+def test_external_connector_settlement_is_strictly_ordered(tmp_path: Path) -> None:
+    binding = _document_binding()
+    capture_external_connector_events(
+        project=tmp_path,
+        binding=binding,
+        events=[_comment_event("event-one"), _comment_event("event-two")],
+        expected_cursor=None,
+        next_cursor="page-two",
+        execute=True,
+    )
+
+    result = settle_external_connector_event(
+        project=tmp_path,
+        binding=binding,
+        event_id="event-two",
+        effect_receipt=_effect("event-two"),
+        response_receipt=_response(),
+        execute=True,
+    )
+
+    assert result["ok"] is False
+    assert result["status"] == "ordered_event_required"
+
+
+def test_addressed_capture_can_checkpoint_a_fully_filtered_page(
+    tmp_path: Path,
+) -> None:
+    binding = _document_binding()
+    binding["capture_policy"] = ExternalCapturePolicy.ADDRESSED_ONLY.value
+
+    capture = capture_external_connector_events(
+        project=tmp_path,
+        binding=binding,
+        events=[_comment_event("event-one", addressed=False)],
+        expected_cursor=None,
+        next_cursor="page-two",
+        execute=True,
+    )
+
+    assert capture["accepted_count"] == 0
+    assert capture["filtered_count"] == 1
+    assert capture["cursor_advanced"] is True
+    continuation = capture_external_connector_events(
+        project=tmp_path,
+        binding=binding,
+        events=[_comment_event("event-two")],
+        expected_cursor="page-two",
+        next_cursor="page-three",
+        execute=False,
+    )
+    assert continuation["ok"] is True
+
+
+def test_capture_fails_closed_on_stale_cursor(tmp_path: Path) -> None:
+    binding = _document_binding()
+    result = capture_external_connector_events(
+        project=tmp_path,
+        binding=binding,
+        events=[_comment_event("event-one")],
+        expected_cursor="unexpected",
+        next_cursor="page-two",
+        execute=True,
+    )
+
+    assert result["ok"] is False
+    assert result["status"] == "cursor_mismatch"
+    assert (
+        drain_external_connector_inbox(
+            project=tmp_path,
+            binding=binding,
+        )["pending_count"]
+        == 0
+    )
+
+
+def test_failure_projection_is_content_free(tmp_path: Path) -> None:
+    binding = _document_binding()
+    receipt = record_external_connector_failure(
+        project=tmp_path,
+        binding=binding,
+        error_code="provider_timeout",
+        execute=True,
+    )
+    status = inspect_external_connector_inbox(
+        project=tmp_path,
+        binding=binding,
+    )
+
+    assert receipt["recorded"] is True
+    assert status["failure_count"] == 1
+    assert status["last_error_code"] == "provider_timeout"
+    assert status["private_event_ids_captured"] is False
+    assert status["private_source_ref_captured"] is False
+
+
+def test_capture_backpressure_leaves_page_and_cursor_pending(tmp_path: Path) -> None:
+    binding = _document_binding()
+    capture_external_connector_events(
+        project=tmp_path,
+        binding=binding,
+        events=[_comment_event("event-one")],
+        expected_cursor=None,
+        next_cursor="page-two",
+        max_pending=1,
+        execute=True,
+    )
+
+    blocked = capture_external_connector_events(
+        project=tmp_path,
+        binding=binding,
+        events=[_comment_event("event-two")],
+        expected_cursor=None,
+        next_cursor="page-two",
+        max_pending=1,
+        execute=True,
+    )
+
+    assert blocked["ok"] is False
+    assert blocked["status"] == "backpressure_required"
+    assert blocked["pending_count"] == 1
+    assert blocked["cursor_advanced"] is False
+
+
+def test_replayed_acknowledged_page_can_advance_cursor(tmp_path: Path) -> None:
+    binding = _document_binding()
+    capture_external_connector_events(
+        project=tmp_path,
+        binding=binding,
+        events=[_comment_event("event-one")],
+        expected_cursor=None,
+        next_cursor="page-two",
+        execute=True,
+    )
+    settle_external_connector_event(
+        project=tmp_path,
+        binding=binding,
+        event_id="event-one",
+        effect_receipt=_effect("event-one"),
+        response_receipt=_response(),
+        execute=True,
+    )
+
+    replay = capture_external_connector_events(
+        project=tmp_path,
+        binding=binding,
+        events=[_comment_event("event-one")],
+        expected_cursor="page-two",
+        next_cursor="page-three",
+        execute=True,
+    )
+
+    assert replay["duplicate_count"] == 1
+    assert replay["cursor_advanced"] is True
+    continuation = capture_external_connector_events(
+        project=tmp_path,
+        binding=binding,
+        events=[],
+        expected_cursor="page-three",
+        next_cursor="page-four",
+        execute=False,
+    )
+    assert continuation["ok"] is True

--- a/tests/extensions/test_external_connector_runtime.py
+++ b/tests/extensions/test_external_connector_runtime.py
@@ -149,6 +149,14 @@ def test_status_projection_omits_private_source_and_cursor_references() -> None:
 
 
 def test_ack_fails_closed_until_effect_and_response_are_verified() -> None:
+    with pytest.raises(TypeError, match="proof fields must be booleans"):
+        build_external_event_response_receipt(
+            event_id="event-alpha",
+            external_write_performed="yes",  # type: ignore[arg-type]
+            verification_performed=True,
+            response_verified=True,
+        )
+
     missing_effect = decide_external_event_ack(
         event_id="event-alpha",
         effect_receipt=None,

--- a/tests/extensions/test_lark_goal_topic_connections.py
+++ b/tests/extensions/test_lark_goal_topic_connections.py
@@ -265,6 +265,24 @@ def test_session_ingress_modes_require_and_persist_exact_session(
     assert binding["agent_id"] == "agent-alpha"
     assert binding["session_id"] == "session-alpha"
     assert binding["routing"]["ingress_mode"] == ingress_mode
+    assert binding["connector"]["schema_version"] == "agent_external_connector_v0"
+    assert binding["connector"]["agent_ref"] == "agent-alpha"
+    assert binding["connector"]["source_kind"] == "group_message"
+    assert binding["connector"]["ingress_policy"] == ingress_mode
+    assert binding["connector"]["session_ref"] == "session-alpha"
+    assert binding["connector"]["cursor_ref"].endswith("/processed.json")
+    assert "source_ref" not in connected["details"]["connector_status"]
+    assert "cursor_ref" not in connected["details"]["connector_status"]
+    rows = list_lark_connections(
+        registry=registry,
+        target_path=tmp_path / "targets.json",
+        binding_paths={"goal-alpha": tmp_path / "binding.json"},
+        runner=_runner({}),
+        cli_bin="fake-lark",
+    )
+    assert rows[0]["connector_status"]["source_kind"] == "group_message"
+    assert "source_ref" not in rows[0]["connector_status"]
+    assert "cursor_ref" not in rows[0]["connector_status"]
 
 
 def test_async_inbox_registration_failure_preserves_verified_write_receipt(

--- a/tests/extensions/test_lark_goal_topic_runtime.py
+++ b/tests/extensions/test_lark_goal_topic_runtime.py
@@ -178,6 +178,129 @@ def test_mention_uses_existing_inbox_reply_and_ack_path(tmp_path: Path) -> None:
     assert projection["processed_count"] == 1
 
 
+def _connect_agent_session_topic(
+    *, tmp_path: Path, state: dict[str, Any]
+) -> tuple[Path, Path]:
+    target_path = tmp_path / "goal-channel-targets.json"
+    binding_path = tmp_path / "goal-channel.json"
+    connected = connect_lark_goal_topic(
+        registry={
+            "goals": [
+                {
+                    "id": "goal-alpha",
+                    "repo": str(tmp_path),
+                    "objective": "Alpha delivery",
+                    "coordination": {"registered_agents": ["agent-alpha"]},
+                }
+            ]
+        },
+        goal_id="goal-alpha",
+        agent_id="agent-alpha",
+        session_id="session-alpha",
+        target_path=target_path,
+        binding_path=binding_path,
+        app_ref="mew",
+        chat_id="oc_public_fixture",
+        chat_name="Product group",
+        ingress_mode="session_queue",
+        runner=_connection_runner(state),
+        cli_bin="fake-lark",
+    )
+    assert connected["ok"] is True
+    return target_path, binding_path
+
+
+def test_agent_session_topic_does_not_reply_or_ack_without_durable_effect(
+    tmp_path: Path,
+) -> None:
+    from loopx.extensions.lark.goal_topic_runtime import process_lark_goal_topic_event
+
+    state: dict[str, Any] = {}
+    target_path, binding_path = _connect_agent_session_topic(
+        tmp_path=tmp_path,
+        state=state,
+    )
+
+    result = process_lark_goal_topic_event(
+        target_payload=read_goal_channel_targets(target_path),
+        binding_payloads={"goal-alpha": read_goal_channel_binding(binding_path)},
+        event={
+            "event_id": "evt_missing_effect",
+            "message_id": "om_missing_effect",
+            "chat_id": "oc_public_fixture",
+            "root_id": "om_topic_alpha",
+            "content": "@linkmacbot please continue",
+        },
+        runtime_root=tmp_path / "runtime",
+        answer=lambda _route, _text: "work completed",
+        reply_runner=_reply_runner(state),
+    )
+
+    assert result["ok"] is False, result
+    assert result["status"] == "durable_effect_required"
+    assert result["ack_decision"]["ack_allowed"] is False
+    assert not any("+messages-reply" in call for call in state.get("calls", []))
+    projection = inspect_lark_event_inbox(
+        project=tmp_path / "runtime",
+        config_path=Path(result["inbox_config_ref"]),
+    )
+    assert projection["pending_count"] == 1
+    assert projection["processed_count"] == 0
+
+
+def test_agent_session_topic_acks_after_effect_and_verified_reply(
+    tmp_path: Path,
+) -> None:
+    from loopx.extensions.external_connector_runtime import (
+        EFFECT_RECEIPT_SCHEMA_VERSION,
+    )
+    from loopx.extensions.lark.goal_topic_runtime import process_lark_goal_topic_event
+
+    state: dict[str, Any] = {}
+    target_path, binding_path = _connect_agent_session_topic(
+        tmp_path=tmp_path,
+        state=state,
+    )
+
+    def answer(route: dict[str, Any], _text: str) -> dict[str, Any]:
+        assert route["event_id"] == "evt_effect_committed"
+        return {
+            "response_text": "work completed",
+            "effect_receipt": {
+                "schema_version": EFFECT_RECEIPT_SCHEMA_VERSION,
+                "event_id": route["event_id"],
+                "effect_id": "effect-committed",
+                "effect_kind": "todo_update",
+                "status": "committed",
+            },
+        }
+
+    result = process_lark_goal_topic_event(
+        target_payload=read_goal_channel_targets(target_path),
+        binding_payloads={"goal-alpha": read_goal_channel_binding(binding_path)},
+        event={
+            "event_id": "evt_effect_committed",
+            "message_id": "om_effect_committed",
+            "chat_id": "oc_public_fixture",
+            "root_id": "om_topic_alpha",
+            "content": "@linkmacbot please continue",
+        },
+        runtime_root=tmp_path / "runtime",
+        answer=answer,
+        reply_runner=_reply_runner(state),
+    )
+
+    assert result["ok"] is True
+    assert result["status"] == "replied_and_acknowledged", result
+    assert state["reply_text"] == "work completed"
+    projection = inspect_lark_event_inbox(
+        project=tmp_path / "runtime",
+        config_path=Path(result["inbox_config_ref"]),
+    )
+    assert projection["pending_count"] == 0
+    assert projection["processed_count"] == 1
+
+
 def test_agent_scoped_async_inbox_queues_without_chat_reply_or_ack(
     tmp_path: Path, monkeypatch: Any
 ) -> None:
@@ -226,6 +349,12 @@ def test_agent_scoped_async_inbox_queues_without_chat_reply_or_ack(
     assert binding["agent_id"] == "agent-alpha"
     assert binding["routing"]["capture_scope"] == "addressed_only"
     assert binding["routing"]["ingress_mode"] == "async_inbox"
+    assert binding["connector"]["schema_version"] == "agent_external_connector_v0"
+    assert binding["connector"]["agent_ref"] == "agent-alpha"
+    assert binding["connector"]["source_kind"] == "group_message"
+    assert binding["connector"]["ingress_policy"] == "async_inbox"
+    assert binding["connector"]["inbox_ref"] == binding["routing"]["inbox_config_ref"]
+    assert binding["connector"]["cursor_ref"].endswith("/processed.json")
     config_ref = Path(binding["routing"]["inbox_config_ref"])
     assert (tmp_path / config_ref).is_file()
     config_payload = json.loads((tmp_path / config_ref).read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

- add the provider-neutral `agent_external_connector_v0` binding for group-message and document-comment event sources
- keep source, cursor, document anchor, reply-chain, exact provider identity, scopes, and repair URLs owner-local while exposing content-free status
- make Agent-bound Lark Goal Topics persist and validate the generic Connector contract
- add a bounded incremental async inbox with stable event dedupe, strict ordering, queue backpressure, restart-safe page cursors, and content-free failure/freshness projection
- add a document-comment Provider boundary with typed permission requirements, exact registration-to-guidance binding, and publication readiness
- require document comments to reference separately registered project material while remaining `external_input_only`
- enforce permission evaluation → bounded Provider read → durable capture → Agent effect → Provider response/readback → ACK; no cursor advancement before settlement
- require a committed working-session or domain effect and an event-bound verified response receipt before ACK
- remove processed private event bodies after durable settlement while retaining content-free identities for replay deduplication

This implements the provider-neutral runtime, durable inbox, and synthetic document-comment Provider call boundary described by #3351. It does not ship a concrete external document adapter or any provider credentials.

## Review refinement

Exact-head review found that the initial response proof was only a group of booleans: it was not bound to the current event and a provider writer was not required to echo the requested idempotency key. A stale verified receipt could therefore authorize a different event's ACK. The refined contract adds `agent_external_event_response_receipt_v0`, binds it to a content-free event digest, requires document providers to return the exact requested idempotency key, and converts provider-specific readback into that typed receipt at the adapter boundary. Negative coverage proves cross-event and mismatched-idempotency receipts fail closed.

Review also found that acknowledged event files retained owner-private bodies indefinitely. Settlement now commits cursor/ack state first and then removes the processed event file. The acknowledged content-free identity remains in cursor state, capture checks it before reaccepting an event, and replay can still advance a previously acknowledged page. Coverage proves both cleanup and replay behavior.

## Architecture and TypeScript boundary

The Provider remains the external-effect adapter: credentials, raw payloads, provider API calls, exact scopes, and external response readback stay outside the kernel. The Connector module owns a new extension-domain binding, owner-local inbox, and provider-neutral receipt validation; it does not replace or duplicate an existing TypeScript Todo/quota/scheduler transition.

For the existing Lark live path, a completed persisted runtime Turn is adapted into the Connector's `working_session_turn` proof. The PR does not move a migrated TypeScript rule back into Python. Under the TypeScript migration RFC's payoff-phase rule, this new extension contract should not be translated leaf-by-leaf into TS until a complete operator-visible Connector transaction can cut over and delete the Python owner in the same bounded stage.

## Future-facing boundary

The Provider call contract lives in a separate module instead of extending the durable inbox state module further. The binding normalizer is reused at caller boundaries, so concrete adapters can validate one authority contract without duplicating Connector state rules. A concrete document provider is intentionally outside this PR; the callback boundary and exact permission/receipt contract are the compatibility seam being reviewed here.

## Validation

- `python -m pytest -q tests/extensions --disable-warnings --maxfail=1` — 429 passed
- focused Connector runtime, Provider, and Lark routing/runtime tests — 66 passed
- Ruff check and format check over the Connector runtime, Provider, Lark bridge, and focused tests — passed
- `loopx canary premerge --from-git-diff` — 13/13 selected checks passed, including 8 extension/docs risk-profile smokes and the public-boundary scan
- `git diff --check` and changed-file Python compile — passed

## Merge decision

Runtime, permission, private-retention, and external-write behavior still requires an independent reviewer. This author-owned PR will not be self-merged; the exact-head review conclusion is published as a COMMENTED fallback because GitHub does not allow formal self-approval.
