### PR TITLE
fix(goal): project terminal Todo settlement on refresh

### DIFF
--- a/loopx/cli_commands/project_lifecycle.py
+++ b/loopx/cli_commands/project_lifecycle.py
@@ -25,6 +25,10 @@ from ..control_plane.work_items.delivery_batch_scale import (
 )
 from ..control_plane.work_items.delivery_outcome import DELIVERY_OUTCOME_CHOICES
 from ..control_plane.work_items.progress_observation import ProgressResultClass
+from ..control_plane.work_items.semantic_replan_writeback import (
+    ReplanWritebackRejected,
+    project_replan_writeback_rejection,
+)
 from ..extensions.lark.goal_channel_lifecycle import (
     goal_channel_gate_sync_failure,
     sync_human_gate_after_refresh,
@@ -694,6 +698,16 @@ def handle_project_lifecycle_command(
                 "dry_run": bool(args.dry_run),
                 "error": str(exc),
             }
+            if isinstance(exc, ReplanWritebackRejected):
+                transition = project_replan_writeback_rejection(
+                    exc,
+                    goal_id=args.goal_id,
+                    agent_id=args.agent_id,
+                )
+                payload["replan_transition"] = transition
+                payload["error"] += " Required transition: " + "; ".join(
+                    transition["next_cli_actions"]
+                )
         projected_capabilities = runtime_capabilities_for_cli_projection(
             args.available_capabilities
         )

--- a/loopx/control_plane/effect_runtime_handlers.ts
+++ b/loopx/control_plane/effect_runtime_handlers.ts
@@ -63,7 +63,10 @@ import {
   evaluateDeliveryContinuity,
 } from "./turn_driver/delivery_continuity.ts";
 import { reduceTurnSettlementTransaction } from "./turn_driver/settlement.ts";
-import { projectReplanSettlementContract } from "./work_items/replan_settlement.ts";
+import {
+  projectReplanSettlementContract,
+  projectTodoLifecycleSettlementReentry,
+} from "./work_items/replan_settlement.ts";
 
 type EffectRuntimeHandler = (params: JsonObject) => unknown | Promise<unknown>;
 
@@ -376,6 +379,10 @@ export function createEffectRuntimeHandlers(
     ],
     ["turn.settlement.reduce", reduceTurnSettlementTransaction],
     ["work_item.replan_settlement.project", projectReplanSettlementContract],
+    [
+      "work_item.replan_settlement.reentry",
+      projectTodoLifecycleSettlementReentry,
+    ],
   ]);
 }
 

--- a/loopx/control_plane/todos/todo_summary.py
+++ b/loopx/control_plane/todos/todo_summary.py
@@ -501,6 +501,7 @@ def compact_todo_item(item: dict[str, Any]) -> dict[str, Any]:
         "evidence",
         "reason",
         "completed_at",
+        "completion_turn_key",
         "updated_at",
         "superseded_by",
         "completion_validation_required",

--- a/loopx/control_plane/work_items/autonomous_replan_obligation.py
+++ b/loopx/control_plane/work_items/autonomous_replan_obligation.py
@@ -18,6 +18,9 @@ from ..todos.deferred_resume import (
     todo_summary_monitor_blocked_resume_items,
 )
 from .progress_observation import typed_progress_repeat_trigger
+from .replan_settlement import (
+    project_todo_lifecycle_settlement_reentry as project_todo_lifecycle_reentry_effect,
+)
 
 
 PublicSafeText = Callable[..., str | None]
@@ -75,6 +78,37 @@ def todo_lifecycle_settlement_obligation(
     return obligation
 
 
+def project_todo_lifecycle_settlement_reentry(
+    payload: Mapping[str, Any],
+    *,
+    goal_id: str,
+    lifecycle_actor_args: str,
+    scoped_cli_args: str,
+) -> dict[str, Any] | None:
+    """Adapt a lifecycle obligation to the TS-owned reentry projection."""
+
+    obligation = todo_lifecycle_settlement_obligation(payload)
+    if obligation is None:
+        return None
+    triggers = [
+        {
+            key: item.get(key)
+            for key in ("kind", "todo_id", "completion_turn_key")
+            if item.get(key) is not None
+        }
+        for item in obligation.get("triggers") or []
+        if isinstance(item, Mapping)
+        and item.get("kind") == "completed_advancement_without_successor"
+        and normalize_todo_id(item.get("todo_id"))
+    ]
+    return project_todo_lifecycle_reentry_effect(
+        goal_id=goal_id,
+        triggers=triggers,
+        lifecycle_actor_args=shlex.split(lifecycle_actor_args),
+        quota_scoped_args=shlex.split(scoped_cli_args),
+    )
+
+
 def build_autonomous_replan_cli_actions(
     payload: Mapping[str, Any],
     *,
@@ -85,47 +119,14 @@ def build_autonomous_replan_cli_actions(
     settlement_chain_ready: bool,
     lifecycle_actor_args: str = "",
 ) -> list[str]:
-    obligation = todo_lifecycle_settlement_obligation(payload)
-    if obligation is not None:
-        triggers = [
-            item
-            for item in obligation.get("triggers") or []
-            if isinstance(item, Mapping)
-            and item.get("kind") == "completed_advancement_without_successor"
-            and normalize_todo_id(item.get("todo_id"))
-        ]
-        actions: list[str] = []
-        for trigger in triggers[:3]:
-            todo_id = normalize_todo_id(trigger.get("todo_id"))
-            if todo_id is None:
-                continue
-            completion_turn_key = str(
-                trigger.get("completion_turn_key") or ""
-            ).strip()
-            completion_turn_arg = (
-                f" --turn-instance-id {shlex.quote(completion_turn_key)}"
-                if completion_turn_key
-                else ""
-            )
-            actions.append(
-                "when no real successor remains for completed Todo "
-                f"{todo_id}: loopx todo complete --goal-id {goal_id} "
-                f"--todo-id {todo_id}{completion_turn_arg}{lifecycle_actor_args} "
-                "--no-follow-up --note '<public-safe no-follow-up rationale>'"
-            )
-        actions.extend(
-            [
-                (
-                    "otherwise link or create one real runnable successor for the "
-                    "exact completed Todo; do not create lifecycle-only filler"
-                ),
-                (
-                    f"loopx --format json quota should-run --goal-id {goal_id}"
-                    f"{scoped_cli_args}"
-                ),
-            ]
-        )
-        return actions
+    lifecycle_reentry = project_todo_lifecycle_settlement_reentry(
+        payload,
+        goal_id=goal_id,
+        lifecycle_actor_args=lifecycle_actor_args,
+        scoped_cli_args=scoped_cli_args,
+    )
+    if lifecycle_reentry is not None:
+        return list(lifecycle_reentry["next_cli_actions"])
     packet = (
         payload.get("replan_action_packet")
         if isinstance(payload.get("replan_action_packet"), Mapping)

--- a/loopx/control_plane/work_items/replan_settlement.py
+++ b/loopx/control_plane/work_items/replan_settlement.py
@@ -9,6 +9,58 @@ from ..effect_runtime import EffectRuntimeRejected, effect_runtime_result
 
 REPLAN_SETTLEMENT_REQUEST_SCHEMA = "loopx_replan_settlement_request_v0"
 REPLAN_SETTLEMENT_CONTRACT_SCHEMA = "replan_settlement_contract_v0"
+TODO_LIFECYCLE_REENTRY_REQUEST_SCHEMA = "loopx_todo_lifecycle_reentry_request_v0"
+TODO_LIFECYCLE_REENTRY_SCHEMA = "todo_lifecycle_settlement_reentry_v0"
+
+
+def project_todo_lifecycle_settlement_reentry(
+    *,
+    goal_id: str,
+    triggers: list[dict[str, Any]],
+    lifecycle_actor_args: list[str],
+    quota_scoped_args: list[str],
+) -> dict[str, Any]:
+    """Return TS-owned exact actions for a terminal Todo succession gap."""
+
+    try:
+        result = effect_runtime_result(
+            "work_item.replan_settlement.reentry",
+            {
+                "schema_version": TODO_LIFECYCLE_REENTRY_REQUEST_SCHEMA,
+                "goal_id": goal_id,
+                "triggers": triggers,
+                "lifecycle_actor_args": lifecycle_actor_args,
+                "quota_scoped_args": quota_scoped_args,
+            },
+        )
+    except EffectRuntimeRejected as exc:
+        raise ValueError(str(exc)) from None
+    if not isinstance(result, Mapping):
+        raise RuntimeError("TypeScript Todo lifecycle reentry result must be an object")
+    projected_triggers = result.get("triggers")
+    next_cli_actions = result.get("next_cli_actions")
+    if (
+        result.get("schema_version") != TODO_LIFECYCLE_REENTRY_SCHEMA
+        or result.get("resolution_mode") != "todo_lifecycle_settlement"
+        or not isinstance(projected_triggers, list)
+        or not projected_triggers
+        or any(
+            not isinstance(trigger, Mapping)
+            or trigger.get("kind") != "completed_advancement_without_successor"
+            or not isinstance(trigger.get("todo_id"), str)
+            or not trigger.get("todo_id")
+            or (
+                trigger.get("completion_turn_key") is not None
+                and not isinstance(trigger.get("completion_turn_key"), str)
+            )
+            for trigger in projected_triggers
+        )
+        or not isinstance(next_cli_actions, list)
+        or not next_cli_actions
+        or any(not isinstance(action, str) or not action for action in next_cli_actions)
+    ):
+        raise RuntimeError("TypeScript Todo lifecycle reentry result shape mismatch")
+    return dict(result)
 
 
 def project_replan_settlement_contract(

--- a/loopx/control_plane/work_items/replan_settlement.py
+++ b/loopx/control_plane/work_items/replan_settlement.py
@@ -39,6 +39,14 @@ def project_todo_lifecycle_settlement_reentry(
         raise RuntimeError("TypeScript Todo lifecycle reentry result must be an object")
     projected_triggers = result.get("triggers")
     next_cli_actions = result.get("next_cli_actions")
+    expected_triggers = [
+        {
+            "kind": trigger.get("kind"),
+            "todo_id": trigger.get("todo_id"),
+            "completion_turn_key": trigger.get("completion_turn_key") or None,
+        }
+        for trigger in triggers[:3]
+    ]
     if (
         result.get("schema_version") != TODO_LIFECYCLE_REENTRY_SCHEMA
         or result.get("resolution_mode") != "todo_lifecycle_settlement"
@@ -55,6 +63,7 @@ def project_todo_lifecycle_settlement_reentry(
             )
             for trigger in projected_triggers
         )
+        or [dict(trigger) for trigger in projected_triggers] != expected_triggers
         or not isinstance(next_cli_actions, list)
         or not next_cli_actions
         or any(not isinstance(action, str) or not action for action in next_cli_actions)

--- a/loopx/control_plane/work_items/replan_settlement.ts
+++ b/loopx/control_plane/work_items/replan_settlement.ts
@@ -9,6 +9,91 @@ export const REPLAN_SETTLEMENT_REQUEST_SCHEMA =
   "loopx_replan_settlement_request_v0";
 export const REPLAN_SETTLEMENT_CONTRACT_SCHEMA =
   "replan_settlement_contract_v0";
+export const TODO_LIFECYCLE_REENTRY_REQUEST_SCHEMA =
+  "loopx_todo_lifecycle_reentry_request_v0";
+export const TODO_LIFECYCLE_REENTRY_SCHEMA =
+  "todo_lifecycle_settlement_reentry_v0";
+
+function shellArgument(value: string): string {
+  if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(value)) return value;
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function argumentSuffix(values: readonly string[]): string {
+  return values.length > 0
+    ? ` ${values.map(shellArgument).join(" ")}`
+    : "";
+}
+
+function lifecycleTrigger(value: unknown, index: number): JsonObject {
+  const trigger = requireJsonObject(value, `triggers[${index}]`);
+  if (trigger.kind !== "completed_advancement_without_successor") {
+    throw new Error(`triggers[${index}].kind is unsupported`);
+  }
+  return {
+    kind: trigger.kind,
+    todo_id: requireNonEmptyString(
+      trigger.todo_id,
+      `triggers[${index}].todo_id`,
+    ),
+    completion_turn_key: optionalNonEmptyString(
+      trigger.completion_turn_key,
+      `triggers[${index}].completion_turn_key`,
+    ),
+  };
+}
+
+export function projectTodoLifecycleSettlementReentry(value: unknown): JsonObject {
+  const request = requireJsonObject(
+    value,
+    "work_item.replan_settlement.reentry params",
+  );
+  if (request.schema_version !== TODO_LIFECYCLE_REENTRY_REQUEST_SCHEMA) {
+    throw new Error("Todo lifecycle reentry request schema mismatch");
+  }
+  const goalId = requireNonEmptyString(request.goal_id, "goal_id");
+  if (!Array.isArray(request.triggers) || request.triggers.length === 0) {
+    throw new Error("triggers must be a non-empty array");
+  }
+  const triggers = request.triggers.slice(0, 3).map(lifecycleTrigger);
+  const lifecycleActorArgs = Array.isArray(request.lifecycle_actor_args)
+    ? request.lifecycle_actor_args.map((item, index) =>
+      requireNonEmptyString(item, `lifecycle_actor_args[${index}]`)
+    )
+    : [];
+  const quotaScopedArgs = Array.isArray(request.quota_scoped_args)
+    ? request.quota_scoped_args.map((item, index) =>
+      requireNonEmptyString(item, `quota_scoped_args[${index}]`)
+    )
+    : [];
+  const nextCliActions = triggers.map((trigger) => {
+    const todoId = String(trigger.todo_id);
+    const completionTurnKey = trigger.completion_turn_key;
+    const completionTurnArgs = typeof completionTurnKey === "string"
+      ? ["--turn-instance-id", completionTurnKey]
+      : [];
+    return (
+      `when no real successor remains for completed Todo ${todoId}: ` +
+      `loopx todo complete --goal-id ${shellArgument(goalId)} ` +
+      `--todo-id ${shellArgument(todoId)}` +
+      argumentSuffix(completionTurnArgs) +
+      argumentSuffix(lifecycleActorArgs) +
+      " --no-follow-up --note '<public-safe no-follow-up rationale>'"
+    );
+  });
+  nextCliActions.push(
+    "otherwise link or create one real runnable successor for the exact " +
+      "completed Todo; do not create lifecycle-only filler",
+    `loopx --format json quota should-run --goal-id ${shellArgument(goalId)}` +
+      argumentSuffix(quotaScopedArgs),
+  );
+  return {
+    schema_version: TODO_LIFECYCLE_REENTRY_SCHEMA,
+    resolution_mode: "todo_lifecycle_settlement",
+    triggers,
+    next_cli_actions: nextCliActions,
+  };
+}
 
 export function projectReplanSettlementContract(value: unknown): JsonObject {
   const request = requireJsonObject(value, "work_item.replan_settlement params");

--- a/loopx/control_plane/work_items/semantic_replan_writeback.py
+++ b/loopx/control_plane/work_items/semantic_replan_writeback.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import shlex
+from collections.abc import Mapping
 from typing import Any
 
 from ...agent_registry import registered_agent_ids_for_goal
@@ -20,8 +22,92 @@ from ..todos.quota_summary import (
     select_quota_todo_summary,
 )
 from ..todos.succession_warning import todo_succession_gap_items
+from .autonomous_replan_obligation import (
+    build_autonomous_replan_cli_actions,
+    project_todo_lifecycle_settlement_reentry,
+)
 from .progress_observation import semantic_delta_from_writeback
 from .work_lane_context import build_work_lane_context_contract
+
+
+REPLAN_WRITEBACK_REJECTION_SCHEMA_VERSION = "replan_writeback_rejection_v0"
+
+
+class ReplanWritebackRejected(ValueError):
+    """A strict writeback rejection with its actionable obligation attached."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        obligation: Mapping[str, Any],
+        semantic_delta: Mapping[str, Any] | None,
+    ) -> None:
+        super().__init__(message)
+        self.obligation = dict(obligation)
+        self.semantic_delta = dict(semantic_delta or {})
+
+
+def project_replan_writeback_rejection(
+    rejection: ReplanWritebackRejected,
+    *,
+    goal_id: str,
+    agent_id: str | None,
+) -> dict[str, Any]:
+    """Project exact recovery actions without weakening the writeback gate."""
+
+    safe_agent_id = str(agent_id or "").strip()
+    scoped_cli_args = (
+        f" --agent-id {shlex.quote(safe_agent_id)}" if safe_agent_id else ""
+    )
+    obligation = rejection.obligation
+    compact_triggers = [
+        {
+            key: trigger.get(key)
+            for key in ("kind", "todo_id", "completion_turn_key")
+            if trigger.get(key) is not None
+        }
+        for trigger in obligation.get("triggers") or []
+        if isinstance(trigger, Mapping)
+    ]
+    lifecycle_reentry = project_todo_lifecycle_settlement_reentry(
+        obligation,
+        goal_id=goal_id,
+        lifecycle_actor_args=scoped_cli_args,
+        scoped_cli_args=scoped_cli_args,
+    )
+    triggers = (
+        lifecycle_reentry["triggers"]
+        if lifecycle_reentry is not None
+        else compact_triggers
+    )
+    next_cli_actions = (
+        lifecycle_reentry["next_cli_actions"]
+        if lifecycle_reentry is not None
+        else build_autonomous_replan_cli_actions(
+            obligation,
+            goal_id=goal_id,
+            settlement_args="",
+            scoped_cli_args=scoped_cli_args,
+            quota_spend_action="",
+            settlement_chain_ready=False,
+            lifecycle_actor_args=scoped_cli_args,
+        )
+    )
+    return {
+        "schema_version": REPLAN_WRITEBACK_REJECTION_SCHEMA_VERSION,
+        "required": True,
+        "host_action": (
+            "settle_todo_lifecycle"
+            if lifecycle_reentry is not None
+            else "write_typed_semantic_delta"
+        ),
+        "obligation_id": obligation.get("obligation_id"),
+        "resolution_mode": obligation.get("resolution_mode"),
+        "reason_code": rejection.semantic_delta.get("reason_code"),
+        "triggers": triggers,
+        "next_cli_actions": next_cli_actions,
+    }
 
 
 def _obligation_was_created_by_current_completion(
@@ -242,11 +328,19 @@ def enforce_open_replan_writeback(
     if isinstance(semantic_delta, dict) and semantic_delta.get("accepted") is True:
         return semantic_delta
     if isinstance(semantic_delta, dict) and semantic_delta.get("reason_code"):
-        raise ValueError(str(semantic_delta.get("reason") or "invalid replan writeback"))
-    raise ValueError(
-        "an open autonomous replan obligation requires a typed semantic delta; "
-        "this writeback does not change an accepted surface, hypothesis, probe "
-        "family, concrete blocker, coverage-backed terminal, or required vision "
-        "outcome. Host-projected replan context is authoritative; write a typed "
-        "progress observation or a fresh evidence-linked vision path outcome."
+        raise ReplanWritebackRejected(
+            str(semantic_delta.get("reason") or "invalid replan writeback"),
+            obligation=obligation,
+            semantic_delta=semantic_delta,
+        )
+    raise ReplanWritebackRejected(
+        (
+            "an open autonomous replan obligation requires a typed semantic delta; "
+            "this writeback does not change an accepted surface, hypothesis, probe "
+            "family, concrete blocker, coverage-backed terminal, or required vision "
+            "outcome. Host-projected replan context is authoritative; write a typed "
+            "progress observation or a fresh evidence-linked vision path outcome."
+        ),
+        obligation=obligation,
+        semantic_delta=semantic_delta,
     )

--- a/tests/control_plane/test_refresh_state_replan_gate.py
+++ b/tests/control_plane/test_refresh_state_replan_gate.py
@@ -8,17 +8,21 @@ from pathlib import Path
 
 import pytest
 
+from loopx.cli import main as cli_main
 from loopx.control_plane.status.autonomous_replan_projection import (
     AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD,
 )
 from loopx.control_plane.work_items.semantic_replan_writeback import (
+    ReplanWritebackRejected,
     _obligation_was_created_by_current_completion,
     qualify_replan_writeback,
+    project_replan_writeback_rejection,
 )
 from loopx.state_refresh import (
     enforce_open_replan_writeback,
     refresh_state_run,
 )
+from loopx.todos import add_goal_todo
 
 GOAL_ID = "replan-gate-fixture"
 AGENT_ID = "codex-replan-gate-agent"
@@ -896,6 +900,156 @@ def test_semantic_no_followup_cannot_replace_todo_lifecycle_settlement() -> None
             },
             agent_vision=_terminal_no_followup_vision(),
         )
+
+
+def test_todo_lifecycle_rejection_projects_exact_direct_settlement() -> None:
+    with pytest.raises(ReplanWritebackRejected) as captured:
+        enforce_open_replan_writeback(
+            newest_first_runs=[],
+            state_text=_completed_advancement_without_successor_state(),
+            agent_id=AGENT_ID,
+            goal_id=GOAL_ID,
+        )
+
+    transition = project_replan_writeback_rejection(
+        captured.value,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+
+    assert transition["resolution_mode"] == "todo_lifecycle_settlement"
+    assert transition["triggers"] == [
+        {
+            "kind": "completed_advancement_without_successor",
+            "todo_id": "todo_unsettled_completion",
+            "completion_turn_key": "turn-unsettled",
+        }
+    ]
+    actions = transition["next_cli_actions"]
+    assert "--todo-id todo_unsettled_completion" in actions[0]
+    assert "--turn-instance-id turn-unsettled" in actions[0]
+    assert "--agent-id codex-replan-gate-agent" in actions[0]
+    assert all("refresh-state" not in action for action in actions)
+    assert all("spend-slot" not in action for action in actions)
+
+
+def test_todo_complete_then_refresh_cli_projects_direct_settlement(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    state = project / "ACTIVE_GOAL_STATE.md"
+    state.write_text(
+        "\n".join(
+            [
+                "---",
+                f"goal_id: {GOAL_ID}",
+                "updated_at: 2026-08-22T00:00:00+00:00",
+                "---",
+                "",
+                "## Agent Todo",
+                "",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    runtime_root = tmp_path / "runtime"
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "common_runtime_root": str(runtime_root),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": state.name,
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": [AGENT_ID],
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    todos = [
+        add_goal_todo(
+            registry_path=registry_path,
+            goal_id=GOAL_ID,
+            role="agent",
+            text=f"Complete terminal slice {index}.",
+            task_class="advancement_task",
+            claimed_by=AGENT_ID,
+        )
+        for index in (1, 2)
+    ]
+
+    for todo in todos:
+        assert cli_main(
+            [
+                "--registry",
+                str(registry_path),
+                "--format",
+                "json",
+                "todo",
+                "complete",
+                "--goal-id",
+                GOAL_ID,
+                "--todo-id",
+                str(todo["todo_id"]),
+                "--role",
+                "agent",
+                "--agent-id",
+                AGENT_ID,
+                "--evidence",
+                f"validated terminal slice {todo['todo_id']}",
+            ]
+        ) == 0
+        capsys.readouterr()
+
+    exit_code = cli_main(
+        [
+            "--registry",
+            str(registry_path),
+            "--format",
+            "json",
+            "refresh-state",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--progress-scope",
+            "agent_lane",
+            "--classification",
+            "terminal_delivery_closeout",
+            "--delivery-batch-scale",
+            "single_surface",
+            "--delivery-outcome",
+            "surface_only",
+            "--no-global-sync",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["ok"] is False
+    transition = payload["replan_transition"]
+    assert transition["resolution_mode"] == "todo_lifecycle_settlement"
+    assert "Required transition:" in payload["error"]
+    projected_ids = {trigger["todo_id"] for trigger in transition["triggers"]}
+    expected_ids = {str(todo["todo_id"]) for todo in todos}
+    assert projected_ids == expected_ids
+    actions = transition["next_cli_actions"]
+    for todo_id in expected_ids:
+        assert any(f"--todo-id {todo_id}" in action for action in actions)
+        assert f"--todo-id {todo_id}" in payload["error"]
+    assert all("refresh-state" not in action for action in actions)
+    assert all("spend-slot" not in action for action in actions)
 
 
 def test_persisted_semantic_no_followup_ack_cannot_retire_todo_gap() -> None:

--- a/tests/control_plane/test_replan_settlement_runtime.py
+++ b/tests/control_plane/test_replan_settlement_runtime.py
@@ -6,6 +6,22 @@ from loopx.control_plane import effect_runtime
 from loopx.control_plane.work_items import replan_settlement
 
 
+def _reentry(**overrides: object) -> dict[str, object]:
+    return {
+        "schema_version": replan_settlement.TODO_LIFECYCLE_REENTRY_SCHEMA,
+        "resolution_mode": "todo_lifecycle_settlement",
+        "triggers": [
+            {
+                "kind": "completed_advancement_without_successor",
+                "todo_id": "todo_current001",
+                "completion_turn_key": "turn-current001",
+            }
+        ],
+        "next_cli_actions": ["loopx todo complete --todo-id todo_current001"],
+        **overrides,
+    }
+
+
 def _contract(**overrides: object) -> dict[str, object]:
     return {
         "schema_version": replan_settlement.REPLAN_SETTLEMENT_CONTRACT_SCHEMA,
@@ -85,4 +101,61 @@ def test_python_facade_preserves_typed_rejection(monkeypatch) -> None:
         replan_settlement.project_replan_settlement_contract(
             selected_todo_id=None,
             semantic_replan_obligation_id="replan-0000000000000001",
+        )
+
+
+def test_python_facade_projects_todo_lifecycle_reentry_request(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def call(method: str, params: dict[str, object]) -> dict[str, object]:
+        captured["method"] = method
+        captured["params"] = params
+        return _reentry()
+
+    monkeypatch.setattr(replan_settlement, "effect_runtime_result", call)
+    result = replan_settlement.project_todo_lifecycle_settlement_reentry(
+        goal_id="goal-example",
+        triggers=list(_reentry()["triggers"]),
+        lifecycle_actor_args=["--agent-id", "current-agent"],
+        quota_scoped_args=["--agent-id", "current-agent"],
+    )
+
+    assert result == _reentry()
+    assert captured == {
+        "method": "work_item.replan_settlement.reentry",
+        "params": {
+            "schema_version": replan_settlement.TODO_LIFECYCLE_REENTRY_REQUEST_SCHEMA,
+            "goal_id": "goal-example",
+            "triggers": _reentry()["triggers"],
+            "lifecycle_actor_args": ["--agent-id", "current-agent"],
+            "quota_scoped_args": ["--agent-id", "current-agent"],
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    [
+        None,
+        {},
+        _reentry(resolution_mode="semantic_replan"),
+        _reentry(triggers=[]),
+        _reentry(next_cli_actions=[]),
+    ],
+)
+def test_python_facade_rejects_malformed_todo_lifecycle_reentry(
+    monkeypatch,
+    malformed: object,
+) -> None:
+    monkeypatch.setattr(
+        replan_settlement,
+        "effect_runtime_result",
+        lambda _method, _params: malformed,
+    )
+    with pytest.raises(RuntimeError, match="result (must be|shape mismatch)"):
+        replan_settlement.project_todo_lifecycle_settlement_reentry(
+            goal_id="goal-example",
+            triggers=list(_reentry()["triggers"]),
+            lifecycle_actor_args=[],
+            quota_scoped_args=[],
         )

--- a/tests/control_plane/test_replan_settlement_runtime.py
+++ b/tests/control_plane/test_replan_settlement_runtime.py
@@ -140,6 +140,15 @@ def test_python_facade_projects_todo_lifecycle_reentry_request(monkeypatch) -> N
         {},
         _reentry(resolution_mode="semantic_replan"),
         _reentry(triggers=[]),
+        _reentry(
+            triggers=[
+                {
+                    "kind": "completed_advancement_without_successor",
+                    "todo_id": "todo_other001",
+                    "completion_turn_key": "turn-current001",
+                }
+            ]
+        ),
         _reentry(next_cli_actions=[]),
     ],
 )

--- a/tests/control_plane_ts/replan_settlement.test.ts
+++ b/tests/control_plane_ts/replan_settlement.test.ts
@@ -127,3 +127,28 @@ test("Todo lifecycle reentry rejects untyped succession triggers", () => {
     /kind is unsupported/,
   );
 });
+
+test("Todo lifecycle reentry shell-quotes projected identities", () => {
+  const projection = projectTodoLifecycleSettlementReentry({
+    schema_version: TODO_LIFECYCLE_REENTRY_REQUEST_SCHEMA,
+    goal_id: "goal with space",
+    triggers: [
+      {
+        kind: "completed_advancement_without_successor",
+        todo_id: "todo_1",
+        completion_turn_key: "turn'quoted",
+      },
+    ],
+    lifecycle_actor_args: ["--agent-id", "agent with space"],
+    quota_scoped_args: ["--agent-id", "agent with space"],
+  });
+
+  assert.equal(
+    (projection.next_cli_actions as string[])[0],
+    "when no real successor remains for completed Todo todo_1: loopx todo complete --goal-id 'goal with space' --todo-id todo_1 --turn-instance-id 'turn'\"'\"'quoted' --agent-id 'agent with space' --no-follow-up --note '<public-safe no-follow-up rationale>'",
+  );
+  assert.equal(
+    (projection.next_cli_actions as string[]).at(-1),
+    "loopx --format json quota should-run --goal-id 'goal with space' --agent-id 'agent with space'",
+  );
+});

--- a/tests/control_plane_ts/replan_settlement.test.ts
+++ b/tests/control_plane_ts/replan_settlement.test.ts
@@ -3,7 +3,9 @@ import test from "node:test";
 
 import {
   projectReplanSettlementContract,
+  projectTodoLifecycleSettlementReentry,
   REPLAN_SETTLEMENT_REQUEST_SCHEMA,
+  TODO_LIFECYCLE_REENTRY_REQUEST_SCHEMA,
 } from "../../loopx/control_plane/work_items/replan_settlement.ts";
 
 function request(overrides: Record<string, unknown> = {}) {
@@ -61,5 +63,67 @@ test("typed projection rejects a missing semantic obligation", () => {
       }),
     ),
     /semantic_replan_obligation_id must be a non-empty string/,
+  );
+});
+
+test("Todo lifecycle reentry preserves exact completion identities", () => {
+  assert.deepEqual(
+    projectTodoLifecycleSettlementReentry({
+      schema_version: TODO_LIFECYCLE_REENTRY_REQUEST_SCHEMA,
+      goal_id: "goal-example",
+      triggers: [
+        {
+          kind: "completed_advancement_without_successor",
+          todo_id: "todo_111111111111",
+          completion_turn_key: "turn-implement",
+        },
+        {
+          kind: "completed_advancement_without_successor",
+          todo_id: "todo_222222222222",
+        },
+      ],
+      lifecycle_actor_args: ["--agent-id", "current-agent"],
+      quota_scoped_args: [
+        "--agent-id",
+        "current-agent",
+        "--available-capability",
+        "shell",
+      ],
+    }),
+    {
+      schema_version: "todo_lifecycle_settlement_reentry_v0",
+      resolution_mode: "todo_lifecycle_settlement",
+      triggers: [
+        {
+          kind: "completed_advancement_without_successor",
+          todo_id: "todo_111111111111",
+          completion_turn_key: "turn-implement",
+        },
+        {
+          kind: "completed_advancement_without_successor",
+          todo_id: "todo_222222222222",
+          completion_turn_key: null,
+        },
+      ],
+      next_cli_actions: [
+        "when no real successor remains for completed Todo todo_111111111111: loopx todo complete --goal-id goal-example --todo-id todo_111111111111 --turn-instance-id turn-implement --agent-id current-agent --no-follow-up --note '<public-safe no-follow-up rationale>'",
+        "when no real successor remains for completed Todo todo_222222222222: loopx todo complete --goal-id goal-example --todo-id todo_222222222222 --agent-id current-agent --no-follow-up --note '<public-safe no-follow-up rationale>'",
+        "otherwise link or create one real runnable successor for the exact completed Todo; do not create lifecycle-only filler",
+        "loopx --format json quota should-run --goal-id goal-example --agent-id current-agent --available-capability shell",
+      ],
+    },
+  );
+});
+
+test("Todo lifecycle reentry rejects untyped succession triggers", () => {
+  assert.throws(
+    () => projectTodoLifecycleSettlementReentry({
+      schema_version: TODO_LIFECYCLE_REENTRY_REQUEST_SCHEMA,
+      goal_id: "goal-example",
+      triggers: [{ kind: "vision_acceptance_gap", todo_id: "todo_1" }],
+      lifecycle_actor_args: [],
+      quota_scoped_args: [],
+    }),
+    /kind is unsupported/,
   );
 });


### PR DESCRIPTION
## What changed

- keep `refresh-state` strict when terminal advancement Todos still need lifecycle settlement, but return a typed `replan_transition` with the exact completed Todo ids, completion turn keys, and direct `todo complete --no-follow-up` actions;
- preserve `completion_turn_key` through the real Todo summary path instead of losing it during compaction;
- move lifecycle-settlement reentry projection from Python string assembly into the TypeScript Effect runtime, with Python limited to typed adaptation and result-shape validation;
- append the exact transition actions to the human-readable error while preserving the structured JSON packet;
- cover the real `todo complete` twice -> `refresh-state` rejection path and the TS/Python runtime boundary.

## Why

The direct settlement semantics from #3362 were only visible after another quota read. A normal terminal turn could complete its last Todos and call `refresh-state`, which reduced the new lifecycle obligation to a generic semantic-delta error. That made the model guess an extra quota read or loop on refresh even though the control plane already knew the exact settlement actions.

This change closes that projection seam without weakening successor or semantic-replan enforcement. Genuine remaining work still requires a real runnable successor; terminal lifecycle settlement does not spend quota or require another semantic refresh.

## Validation

- TypeScript control-plane suite: 87 passed;
- focused and adjacent Python suites: 194 passed;
- focused post-refinement Python suites: 78 passed;
- TypeScript typecheck passed;
- Ruff undefined-name scan and `git diff --check` passed;
- `loopx canary premerge --from-git-diff`: standard tier, 17/17 selected checks passed, no failures, skips, or manual holds;
- public/private scan found no credentials, private paths, raw logs, or local state in the candidate paths.

## Scope

This changes Todo lifecycle/replan projection and its CLI rejection packet. It does not change quota accounting, Todo succession strictness, permissions, benchmark behavior, or runner launch behavior.

Fixes #3473.
