### PR TITLE
fix(turn): recover prepared settlement effects safely

### DIFF
--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -28,7 +28,9 @@ from ..control_plane.runtime.status_projection_cache import (
 from ..control_plane.todos.durable_completion import (
     project_durable_completion_intent,
     project_durable_completion_outcome,
+    project_durable_terminal_completion_readback,
     read_persisted_todo_record,
+    read_persisted_todo_record_with_source,
 )
 from ..control_plane.scheduler.execution_context import (
     scheduler_execution_context_for_turn,
@@ -905,6 +907,44 @@ def handle_turn_command(
                 except (OSError, ValueError):
                     return None
 
+            def terminal_completion_readback() -> dict[str, object] | None:
+                todo_id = str(selected_todo.get("todo_id") or "")
+                if not todo_id:
+                    raise ValueError("terminal completion requires one selected Todo")
+                _state_project, state_file = resolve_todo_state_path(
+                    registry_path=registry_path,
+                    goal_id=args.goal_id,
+                    project=None,
+                    state_file=None,
+                )
+                (
+                    durable_todo,
+                    existing_todo_ids,
+                    projection_source,
+                ) = read_persisted_todo_record_with_source(
+                    state_file,
+                    todo_id=todo_id,
+                    registry_path=registry_path,
+                    goal_id=args.goal_id,
+                )
+                readback = project_durable_terminal_completion_readback(
+                    todo=durable_todo,
+                    expected_todo_id=todo_id,
+                    expected_completion_turn_key=(
+                        settlement_identity.turn_instance_id
+                    ),
+                    projection_source=projection_source,
+                    existing_todo_ids=existing_todo_ids,
+                )
+                if readback["kind"] == "absent":
+                    return None
+                completion = readback.get("completion")
+                if not isinstance(completion, dict):
+                    raise ValueError(
+                        "terminal completion readback is missing its completion"
+                    )
+                return completion
+
             def writeback_resolver(effect_ref: str) -> dict[str, object]:
                 try:
                     require_effect_ref(
@@ -985,7 +1025,7 @@ def handle_turn_command(
                         settlement_identity,
                         event_kind="todo_complete",
                     )
-                    completion = completion_readback()
+                    completion = terminal_completion_readback()
                     if event is None and completion is None:
                         return {"kind": "absent"}
                     if (

--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -6,10 +6,21 @@ from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any
 
+from ..cli_rollout import append_cli_rollout_event
 from ..capabilities.explore.composition_frontier import (
     project_live_explore_composition_frontier,
 )
 from ..control_plane.quota.live_decision import build_live_quota_should_run_decision
+from ..control_plane.quota.heartbeat_receipt import (
+    ensure_turn_heartbeat_settlement_receipt,
+)
+from ..control_plane.quota.settlement import (
+    SettlementIdentity,
+    SettlementStepKind,
+    find_settlement_spend_run,
+    find_settlement_step_event,
+    find_settlement_writeback,
+)
 from ..control_plane.quota.turn_envelope import build_turn_envelope
 from ..control_plane.runtime.status_projection_cache import (
     resolve_status_projection_cache_runtime_root,
@@ -48,6 +59,8 @@ PrintPayload = Callable[
 ]
 FormatSelector = Callable[..., str]
 AddFormat = Callable[[argparse.ArgumentParser], None]
+
+
 def register_turn_commands(
     subparsers: argparse._SubParsersAction,
     add_subcommand_format: AddFormat,
@@ -266,9 +279,7 @@ def _render_loopx_turn_execution_markdown(payload: dict[str, object]) -> str:
     effects = payload.get("effects") if isinstance(payload.get("effects"), dict) else {}
     receipt = payload.get("receipt") if isinstance(payload.get("receipt"), dict) else {}
     validation = (
-        payload.get("validation")
-        if isinstance(payload.get("validation"), dict)
-        else {}
+        payload.get("validation") if isinstance(payload.get("validation"), dict) else {}
     )
     return "\n".join(
         [
@@ -367,10 +378,8 @@ def handle_turn_command(
             registry_path=registry_path,
             runtime_root_override=runtime_root_arg,
         )
-        operator_inbox_urgency_projector = (
-            build_lark_operator_inbox_urgency_projector(
-                runtime_root_arg=runtime_root,
-            )
+        operator_inbox_urgency_projector = build_lark_operator_inbox_urgency_projector(
+            runtime_root_arg=runtime_root,
         )
         status_payload = collect_status(
             registry_path=registry_path,
@@ -426,7 +435,11 @@ def handle_turn_command(
             decision,
             scheduler_execution_context=scheduler_context,
         )
-        if args.turn_command == "run-once" and args.host == "codex-cli" and not supplied_resume_fields:
+        if (
+            args.turn_command == "run-once"
+            and args.host == "codex-cli"
+            and not supplied_resume_fields
+        ):
             session_binding = codex_cli_session_binding(runtime_root, turn_envelope)
         payload = build_loopx_turn_plan(
             turn_envelope,
@@ -474,7 +487,9 @@ def handle_turn_command(
                         "LoopX Turn resume journal belongs to another agent"
                     )
             project = Path(args.project).expanduser().resolve()
-            planned_host = payload.get("host") if isinstance(payload.get("host"), dict) else {}
+            planned_host = (
+                payload.get("host") if isinstance(payload.get("host"), dict) else {}
+            )
             if planned_host.get("kind") != args.host:
                 raise ValueError("--host must match the journaled LoopX Turn plan")
             if args.host == "generic-cli":
@@ -510,8 +525,101 @@ def handle_turn_command(
                 )
             else:
                 task_validator = None
-            envelope = payload.get("turn_envelope") if isinstance(payload.get("turn_envelope"), dict) else {}
+            envelope = (
+                payload.get("turn_envelope")
+                if isinstance(payload.get("turn_envelope"), dict)
+                else {}
+            )
             selected_todo = selected_turn_todo(envelope)
+            transaction = (
+                payload.get("transaction")
+                if isinstance(payload.get("transaction"), Mapping)
+                else {}
+            )
+            settlement_plan = (
+                transaction.get("settlement_plan")
+                if isinstance(transaction.get("settlement_plan"), Mapping)
+                else {}
+            )
+            raw_identity = (
+                settlement_plan.get("identity")
+                if isinstance(settlement_plan.get("identity"), Mapping)
+                else {}
+            )
+            settlement_identity = SettlementIdentity(
+                goal_id=str(raw_identity.get("goal_id") or args.goal_id),
+                agent_id=str(raw_identity.get("agent_id") or args.agent_id),
+                todo_id=str(
+                    raw_identity.get("todo_id") or selected_todo.get("todo_id") or ""
+                ),
+                turn_instance_id=str(
+                    raw_identity.get("turn_instance_id")
+                    or transaction.get("turn_instance_id")
+                    or transaction.get("turn_key")
+                    or ""
+                ),
+            )
+            persisted_effect_id = str(raw_identity.get("effect_id") or "")
+            if (
+                persisted_effect_id
+                and persisted_effect_id != settlement_identity.effect_id
+            ):
+                raise ValueError("Turn settlement identity effect_id is inconsistent")
+            if args.execute:
+                ensure_turn_heartbeat_settlement_receipt(
+                    runtime_root,
+                    settlement_identity,
+                )
+
+            def require_effect_ref(
+                effect_ref: str,
+                step_kind: SettlementStepKind,
+            ) -> None:
+                expected = f"{settlement_identity.effect_id}#{step_kind.value}"
+                if effect_ref != expected:
+                    raise ValueError(
+                        f"{step_kind.value} effect ref does not match Turn identity"
+                    )
+
+            def append_settlement_event(
+                effect_payload: Mapping[str, object],
+                *,
+                event_kind: str,
+                status: str,
+                details: Mapping[str, object],
+            ) -> None:
+                event_payload = {
+                    **dict(effect_payload),
+                    "ok": True,
+                    "goal_id": args.goal_id,
+                    "runtime_root": str(runtime_root),
+                }
+                append_cli_rollout_event(
+                    event_payload,
+                    registry_path=registry_path,
+                    runtime_root_arg=runtime_root_arg,
+                    event_kind=event_kind,
+                    agent_id=settlement_identity.agent_id,
+                    todo_id=settlement_identity.todo_id,
+                    run_id=settlement_identity.turn_instance_id,
+                    status=status,
+                    summary=f"Turn settlement {event_kind} recorded",
+                    details={
+                        **dict(details),
+                        "settlement_effect_id": settlement_identity.effect_id,
+                    },
+                    idempotency_fields=[
+                        "goal_id",
+                        "event_kind",
+                        "agent_id",
+                        "todo_id",
+                        "run_id",
+                        *(("status",) if event_kind == "todo_complete" else ()),
+                    ],
+                )
+                if event_payload.get("rollout_event_log_error"):
+                    raise OSError(f"failed to persist {event_kind} settlement receipt")
+
             writeback_contract = (
                 envelope.get("writeback")
                 if isinstance(envelope.get("writeback"), dict)
@@ -530,14 +638,18 @@ def handle_turn_command(
                 *,
                 completion_todo_id: str | None = None,
                 completion_turn_key: str | None = None,
+                effect_ref: str,
             ) -> dict[str, object]:
+                require_effect_ref(effect_ref, SettlementStepKind.DURABLE_WRITEBACK)
                 # The host workspace is execution context, not state authority.
                 state_project = None
                 result_kind = str(result.get("result_kind") or "")
                 if result_kind in {"repair_required", "replan_required"}:
                     todo_id = str(selected_todo.get("todo_id") or "")
                     if not todo_id:
-                        raise ValueError(f"{result_kind} requires one selected todo for typed writeback")
+                        raise ValueError(
+                            f"{result_kind} requires one selected todo for typed writeback"
+                        )
                     update_goal_todo(
                         registry_path=registry_path,
                         goal_id=args.goal_id,
@@ -549,7 +661,7 @@ def handle_turn_command(
                         project=state_project,
                         dry_run=False,
                     )
-                return refresh_state_run(
+                refresh = refresh_state_run(
                     registry_path=registry_path,
                     runtime_root_override=runtime_root_arg,
                     goal_id=args.goal_id,
@@ -561,6 +673,8 @@ def handle_turn_command(
                     delivery_batch_scale=str(result["delivery_batch_scale"]),
                     delivery_outcome=str(result["delivery_outcome"]),
                     delivery_workspace_path=delivery_workspace_path,
+                    todo_id=settlement_identity.todo_id,
+                    turn_instance_id=settlement_identity.turn_instance_id,
                     agent_id=args.agent_id,
                     progress_scope="goal",
                     autonomous_replan_recorded=result_kind == "replan_required",
@@ -577,6 +691,18 @@ def handle_turn_command(
                     dry_run=False,
                     sync_global=not bool(args.no_global_sync),
                 )
+                if refresh.get("ok") and (
+                    refresh.get("appended")
+                    or refresh.get("idempotent_replay")
+                    or refresh.get("receipt_repair_required")
+                ):
+                    append_settlement_event(
+                        refresh,
+                        event_kind="refresh_state",
+                        status="appended",
+                        details={"command": "turn run-once"},
+                    )
+                return refresh
 
             def completion_intent(_result: dict[str, object]) -> dict[str, object]:
                 todo_id = str(selected_todo.get("todo_id") or "")
@@ -602,7 +728,11 @@ def handle_turn_command(
                     existing_todo_ids=existing_todo_ids,
                 )
 
-            def todo_completion(result: dict[str, object]) -> dict[str, object]:
+            def todo_completion(
+                result: dict[str, object],
+                *,
+                effect_ref: str,
+            ) -> dict[str, object]:
                 todo_id = str(selected_todo.get("todo_id") or "")
                 if not todo_id:
                     raise ValueError(
@@ -613,7 +743,7 @@ def handle_turn_command(
                     goal_id=args.goal_id,
                     todo_id=todo_id,
                     role="agent",
-                    completion_turn_key=str(result["turn_key"]),
+                    completion_turn_key=settlement_identity.turn_instance_id,
                     evidence=(
                         "LoopX Turn validated completion: "
                         + str(result.get("summary") or result["classification"])
@@ -655,35 +785,64 @@ def handle_turn_command(
                         "appended": False,
                         "reason": f"durable completion projection failed: {exc}",
                     }
-                return {
+                completion_payload = {
                     "ok": bool(completion.get("ok")),
                     # A completed Todo is idempotent under Turn replay: after an
                     # interrupted journal write, the retry may observe it done.
-                    "appended": bool(completion.get("completed")) and bool(
-                        completion.get("changed")
-                        or completion.get("idempotent_replay")
+                    "appended": bool(completion.get("completed"))
+                    and bool(
+                        completion.get("changed") or completion.get("idempotent_replay")
                     ),
                     "completion": completion_outcome,
                 }
+                if completion_payload["ok"] and completion_payload["appended"]:
+                    append_settlement_event(
+                        completion_payload,
+                        event_kind="todo_complete",
+                        status=(
+                            "terminal_no_followup"
+                            if completion_outcome.get("continuation") == "no_followup"
+                            else "completed"
+                        ),
+                        details={
+                            "command": "turn run-once",
+                            "no_followup": (
+                                completion_outcome.get("continuation") == "no_followup"
+                            ),
+                        },
+                    )
+                return completion_payload
 
-            def completion_writeback(result: dict[str, object]) -> dict[str, object]:
-                completion = todo_completion(result)
+            def completion_writeback(
+                result: dict[str, object],
+                *,
+                effect_ref: str,
+            ) -> dict[str, object]:
+                completion = todo_completion(result, effect_ref=effect_ref)
                 if not completion.get("ok"):
                     return completion
                 todo_id = str(selected_todo.get("todo_id") or "")
                 refresh = writeback(
                     result,
                     completion_todo_id=todo_id,
-                    completion_turn_key=str(result["turn_key"]),
+                    completion_turn_key=settlement_identity.turn_instance_id,
+                    effect_ref=effect_ref,
                 )
                 return {
                     "ok": bool(refresh.get("ok")),
-                    "appended": bool(completion.get("appended")) and bool(
-                        refresh.get("appended")
-                    ),
+                    "appended": bool(completion.get("appended"))
+                    and bool(refresh.get("appended")),
                     "classification": refresh.get("classification"),
                     "completion": completion["completion"],
                 }
+
+            def terminal_closeout(
+                result: dict[str, object],
+                *,
+                effect_ref: str,
+            ) -> dict[str, object]:
+                require_effect_ref(effect_ref, SettlementStepKind.TERMINAL_CLOSEOUT)
+                return todo_completion(result, effect_ref=effect_ref)
 
             def current_status() -> dict[str, object]:
                 return collect_status(
@@ -695,8 +854,9 @@ def handle_turn_command(
                     available_capabilities=args.available_capabilities,
                 )
 
-            def spend() -> dict[str, object]:
-                return spend_quota_slot(
+            def spend(*, effect_ref: str) -> dict[str, object]:
+                require_effect_ref(effect_ref, SettlementStepKind.QUOTA_SPEND)
+                spent = spend_quota_slot(
                     current_status(),
                     goal_id=args.goal_id,
                     slots=1,
@@ -707,6 +867,156 @@ def handle_turn_command(
                     available_capabilities=args.available_capabilities,
                     operator_inbox_urgency_projector=operator_inbox_urgency_projector,
                 )
+                if spent.get("ok") and (
+                    spent.get("appended")
+                    or spent.get("idempotent_replay")
+                    or spent.get("receipt_repair_required")
+                ):
+                    append_settlement_event(
+                        spent,
+                        event_kind="quota_spend",
+                        status="appended",
+                        details={"command": "turn run-once"},
+                    )
+                return spent
+
+            def completion_readback() -> dict[str, object] | None:
+                todo_id = str(selected_todo.get("todo_id") or "")
+                if not todo_id:
+                    return None
+                try:
+                    _state_project, state_file = resolve_todo_state_path(
+                        registry_path=registry_path,
+                        goal_id=args.goal_id,
+                        project=None,
+                        state_file=None,
+                    )
+                    durable_todo, existing_todo_ids = read_persisted_todo_record(
+                        state_file,
+                        todo_id=todo_id,
+                        registry_path=registry_path,
+                        goal_id=args.goal_id,
+                    )
+                    return project_durable_completion_outcome(
+                        todo=durable_todo,
+                        expected_todo_id=todo_id,
+                        existing_todo_ids=existing_todo_ids,
+                    )
+                except (OSError, ValueError):
+                    return None
+
+            def writeback_resolver(effect_ref: str) -> dict[str, object]:
+                try:
+                    require_effect_ref(
+                        effect_ref,
+                        SettlementStepKind.DURABLE_WRITEBACK,
+                    )
+                    run = find_settlement_writeback(runtime_root, settlement_identity)
+                    event = find_settlement_step_event(
+                        runtime_root,
+                        settlement_identity,
+                        event_kind="refresh_state",
+                    )
+                    if run is None and event is None:
+                        return {"kind": "absent"}
+                    if run is None:
+                        return {
+                            "kind": "unknown",
+                            "reason": "refresh-state receipt has no durable run",
+                        }
+                    if event is None:
+                        append_settlement_event(
+                            run,
+                            event_kind="refresh_state",
+                            status="receipt_repaired",
+                            details={"command": "turn recovery probe"},
+                        )
+                    committed: dict[str, object] = {
+                        "ok": True,
+                        "appended": True,
+                        "effect_ref": effect_ref,
+                        "classification": run.get("classification"),
+                    }
+                    completion = completion_readback()
+                    if completion is not None:
+                        committed["completion"] = completion
+                    return {"kind": "committed", "payload": committed}
+                except (OSError, ValueError):
+                    return {"kind": "unknown", "reason": "writeback readback failed"}
+
+            def spend_resolver(effect_ref: str) -> dict[str, object]:
+                try:
+                    require_effect_ref(effect_ref, SettlementStepKind.QUOTA_SPEND)
+                    run = find_settlement_spend_run(runtime_root, settlement_identity)
+                    event = find_settlement_step_event(
+                        runtime_root,
+                        settlement_identity,
+                        event_kind="quota_spend",
+                    )
+                    if event is not None:
+                        return {
+                            "kind": "committed",
+                            "payload": {
+                                "ok": True,
+                                "appended": True,
+                                "effect_ref": effect_ref,
+                                "mode": "spend-slot",
+                            },
+                        }
+                    return {
+                        "kind": "unknown",
+                        "reason": (
+                            "quota outcome has no identity-bound receipt"
+                            if run is None
+                            else "quota run cannot be bound to this effect"
+                        ),
+                    }
+                except (OSError, ValueError):
+                    return {"kind": "unknown", "reason": "quota readback failed"}
+
+            def terminal_closeout_resolver(effect_ref: str) -> dict[str, object]:
+                try:
+                    require_effect_ref(
+                        effect_ref,
+                        SettlementStepKind.TERMINAL_CLOSEOUT,
+                    )
+                    event = find_settlement_step_event(
+                        runtime_root,
+                        settlement_identity,
+                        event_kind="todo_complete",
+                    )
+                    completion = completion_readback()
+                    if event is None and completion is None:
+                        return {"kind": "absent"}
+                    if (
+                        completion is None
+                        or completion.get("continuation") != "no_followup"
+                    ):
+                        return {
+                            "kind": "unknown",
+                            "reason": "Todo state does not prove terminal no-followup",
+                        }
+                    if event is None:
+                        append_settlement_event(
+                            {"ok": True, "appended": True},
+                            event_kind="todo_complete",
+                            status="terminal_no_followup",
+                            details={
+                                "command": "turn recovery probe",
+                                "no_followup": True,
+                            },
+                        )
+                    return {
+                        "kind": "committed",
+                        "payload": {
+                            "ok": True,
+                            "appended": True,
+                            "effect_ref": effect_ref,
+                            "completion": completion,
+                        },
+                    }
+                except (OSError, ValueError):
+                    return {"kind": "unknown", "reason": "closeout readback failed"}
 
             def scheduler(_spend_payload: dict[str, object]) -> dict[str, object]:
                 turn_scheduler_context = (
@@ -730,18 +1040,27 @@ def handle_turn_command(
                         project_live_explore_composition_frontier
                     ),
                 )
-                hint = latest.get("scheduler_hint") if isinstance(latest.get("scheduler_hint"), dict) else {}
+                hint = (
+                    latest.get("scheduler_hint")
+                    if isinstance(latest.get("scheduler_hint"), dict)
+                    else {}
+                )
                 phase = hint.get("execution_phase")
-                return dict(phase) if isinstance(phase, dict) else {
-                    "disposition": "contract_error",
-                    "completed": False,
-                    "acknowledged": False,
-                    "apply_needed": False,
-                }
+                return (
+                    dict(phase)
+                    if isinstance(phase, dict)
+                    else {
+                        "disposition": "contract_error",
+                        "completed": False,
+                        "acknowledged": False,
+                        "apply_needed": False,
+                    }
+                )
 
             host_runner = None
             session_binding_resolver = None
             if args.host == "codex-cli":
+
                 def run_built_in_host(
                     request: Mapping[str, Any],
                 ) -> dict[str, Any]:
@@ -779,8 +1098,13 @@ def handle_turn_command(
                 writeback=writeback if args.execute else None,
                 completion_writeback=completion_writeback if args.execute else None,
                 completion_intent=completion_intent if args.execute else None,
-                terminal_closeout=todo_completion if args.execute else None,
+                terminal_closeout=terminal_closeout if args.execute else None,
                 spend=spend if args.execute else None,
+                writeback_resolver=writeback_resolver if args.execute else None,
+                spend_resolver=spend_resolver if args.execute else None,
+                terminal_closeout_resolver=(
+                    terminal_closeout_resolver if args.execute else None
+                ),
                 scheduler=scheduler if args.execute else None,
             )
         else:

--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -17,7 +17,7 @@ from ..control_plane.quota.heartbeat_receipt import (
 from ..control_plane.quota.settlement import (
     SettlementIdentity,
     SettlementStepKind,
-    find_settlement_spend_run,
+    find_quota_spend_run_by_effect_ref,
     find_settlement_step_event,
     find_settlement_writeback,
 )
@@ -868,18 +868,26 @@ def handle_turn_command(
                     workspace_path=delivery_workspace_path,
                     available_capabilities=args.available_capabilities,
                     operator_inbox_urgency_projector=operator_inbox_urgency_projector,
+                    effect_ref=effect_ref,
                 )
                 if spent.get("ok") and (
                     spent.get("appended")
                     or spent.get("idempotent_replay")
                     or spent.get("receipt_repair_required")
                 ):
-                    append_settlement_event(
-                        spent,
+                    event = find_settlement_step_event(
+                        runtime_root,
+                        settlement_identity,
                         event_kind="quota_spend",
-                        status="appended",
-                        details={"command": "turn run-once"},
                     )
+                    if event is None:
+                        append_settlement_event(
+                            spent,
+                            event_kind="quota_spend",
+                            status="appended",
+                            details={"command": "turn run-once"},
+                        )
+                    return {**spent, "appended": True, "effect_ref": effect_ref}
                 return spent
 
             def completion_readback() -> dict[str, object] | None:
@@ -987,29 +995,38 @@ def handle_turn_command(
             def spend_resolver(effect_ref: str) -> dict[str, object]:
                 try:
                     require_effect_ref(effect_ref, SettlementStepKind.QUOTA_SPEND)
-                    run = find_settlement_spend_run(runtime_root, settlement_identity)
+                    run = find_quota_spend_run_by_effect_ref(
+                        runtime_root,
+                        goal_id=settlement_identity.goal_id,
+                        effect_ref=effect_ref,
+                    )
                     event = find_settlement_step_event(
                         runtime_root,
                         settlement_identity,
                         event_kind="quota_spend",
                     )
-                    if event is not None:
+                    if run is None and event is None:
+                        return {"kind": "absent"}
+                    if run is None:
                         return {
-                            "kind": "committed",
-                            "payload": {
-                                "ok": True,
-                                "appended": True,
-                                "effect_ref": effect_ref,
-                                "mode": "spend-slot",
-                            },
+                            "kind": "unknown",
+                            "reason": "quota receipt has no durable spend run",
                         }
+                    if event is None:
+                        append_settlement_event(
+                            run,
+                            event_kind="quota_spend",
+                            status="receipt_repaired",
+                            details={"command": "turn recovery probe"},
+                        )
                     return {
-                        "kind": "unknown",
-                        "reason": (
-                            "quota outcome has no identity-bound receipt"
-                            if run is None
-                            else "quota run cannot be bound to this effect"
-                        ),
+                        "kind": "committed",
+                        "payload": {
+                            "ok": True,
+                            "appended": True,
+                            "effect_ref": effect_ref,
+                            "mode": "spend-slot",
+                        },
                     }
                 except (OSError, ValueError):
                     return {"kind": "unknown", "reason": "quota readback failed"}

--- a/loopx/control_plane/effect_program.py
+++ b/loopx/control_plane/effect_program.py
@@ -113,6 +113,7 @@ class SettlementFailureKind(StrEnum):
     CANCELLED = "cancelled"
     PERMISSION_DENIED = "permission_denied"
     BUDGET_REJECTED = "budget_rejected"
+    EFFECT_OUTCOME_UNKNOWN = "effect_outcome_unknown"
 
 
 @lru_cache(maxsize=4096)

--- a/loopx/control_plane/effect_program.ts
+++ b/loopx/control_plane/effect_program.ts
@@ -90,6 +90,7 @@ export const SETTLEMENT_FAILURE_KINDS = [
   "cancelled",
   "permission_denied",
   "budget_rejected",
+  "effect_outcome_unknown",
 ] as const;
 export type SettlementFailureKind = (typeof SETTLEMENT_FAILURE_KINDS)[number];
 

--- a/loopx/control_plane/quota/heartbeat_receipt.py
+++ b/loopx/control_plane/quota/heartbeat_receipt.py
@@ -133,6 +133,67 @@ def find_heartbeat_receipt(
     )
 
 
+def ensure_turn_heartbeat_settlement_receipt(
+    runtime_root: Path,
+    identity: SettlementIdentity,
+) -> dict[str, object]:
+    """Idempotently bind a Turn-created quota guard to its settlement identity."""
+
+    log_path = rollout_event_log_path(runtime_root, identity.goal_id)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with exclusive_file_lock(log_path):
+        events = load_rollout_events(log_path)
+        matching = _heartbeat_receipt_events(
+            events,
+            goal_id=identity.goal_id,
+            agent_id=identity.agent_id,
+            turn_instance_id=identity.turn_instance_id,
+        )
+        effective = _effective_heartbeat_receipt(matching)
+        expected = (
+            identity.binding_kind,
+            identity.binding_id,
+            identity.effect_id,
+        )
+        if effective is not None:
+            observed = _receipt_settlement_identity(effective)
+            if observed is not None:
+                if observed != expected:
+                    raise HeartbeatReceiptIdentityConflictError(
+                        "Turn heartbeat receipt belongs to another settlement identity"
+                    )
+                return effective
+
+        details = {
+            "turn_instance_id": identity.turn_instance_id,
+            "todo_id": str(identity.todo_id or ""),
+            "replan_obligation_id": str(identity.replan_obligation_id or ""),
+            "settlement_effect_id": identity.effect_id,
+            "stall_observation": "not_applicable",
+            "source": "loopx_turn_run_once",
+        }
+        source_event_id = (
+            str(effective.get("event_id") or "").strip()
+            if effective is not None
+            else ""
+        )
+        receipt = build_rollout_event(
+            goal_id=identity.goal_id,
+            event_kind="quota_should_run",
+            agent_id=identity.agent_id,
+            todo_id=identity.todo_id,
+            run_id=identity.turn_instance_id,
+            status="turn_run_once",
+            summary=f"Turn settlement guard prepared for turn={identity.turn_instance_id}",
+            source_event_id=source_event_id or None,
+            caused_by=source_event_id or None,
+            details=details,
+        )
+        with log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(receipt, sort_keys=True, ensure_ascii=False) + "\n")
+        return receipt
+
+
 def upgrade_identityless_heartbeat_receipt(
     runtime_root: Path,
     *,

--- a/loopx/control_plane/quota/settlement.py
+++ b/loopx/control_plane/quota/settlement.py
@@ -54,6 +54,7 @@ __all__ = [
     "SettlementStepKind",
     "build_codex_app_settlement_plan",
     "build_turn_scoped_cli_settlement_plan",
+    "find_quota_spend_run_by_effect_ref",
     "find_settlement_spend_run",
     "find_settlement_step_event",
     "find_settlement_writeback",
@@ -444,6 +445,25 @@ def find_settlement_spend_run(
         if normalize_todo_claimed_by(run.get("agent_id")) != identity.agent_id:
             continue
         return run
+    return None
+
+
+def find_quota_spend_run_by_effect_ref(
+    runtime_root: Path,
+    *,
+    goal_id: str,
+    effect_ref: str,
+) -> dict[str, Any] | None:
+    """Return the durable quota run for one provider-owned effect attempt."""
+
+    normalized_effect_ref = str(effect_ref or "").strip()
+    if not normalized_effect_ref:
+        return None
+    for run in reversed(_run_index_records(runtime_root, goal_id)):
+        if str(run.get("classification") or "") != "quota_slot_spent":
+            continue
+        if str(run.get("effect_ref") or "") == normalized_effect_ref:
+            return run
     return None
 
 

--- a/loopx/control_plane/quota/slot_accounting.py
+++ b/loopx/control_plane/quota/slot_accounting.py
@@ -793,6 +793,7 @@ def build_quota_slot_spend_event(
             "replan_obligation_id": preview.get("replan_obligation_id"),
             "turn_instance_id": preview.get("turn_instance_id"),
             "settlement_identity": preview.get("settlement_identity"),
+            "effect_ref": preview.get("effect_ref"),
             "slots": slots,
             "reason_summary": (
                 f"{slots} automatic agent slot(s) completed under an eligible quota guard"
@@ -834,6 +835,8 @@ def build_quota_slot_spend_event(
     if safe_agent_id:
         record["agent_id"] = safe_agent_id
         record["quota_event"]["agent_id"] = safe_agent_id
+    if preview.get("effect_ref"):
+        record["effect_ref"] = preview["effect_ref"]
     if preview.get("turn_instance_id"):
         record["turn_instance_id"] = preview["turn_instance_id"]
         if preview.get("todo_id"):
@@ -1114,6 +1117,7 @@ def record_quota_slot_spend_from_preview(
     if record.get("agent_id"):
         index_record["agent_id"] = record["agent_id"]
     for field in (
+        "effect_ref",
         "turn_instance_id",
         "todo_id",
         "replan_obligation_id",

--- a/loopx/control_plane/todos/durable_completion.py
+++ b/loopx/control_plane/todos/durable_completion.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from collections.abc import Collection
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Literal, Mapping
 
 from .active_state_editing import (
     TODO_SECTION_HEADINGS,
@@ -35,7 +35,11 @@ from .completion_state import (
     normalize_todo_completion_continuation,
     normalize_todo_completion_recovery,
 )
+from .completion_fence import evaluate_todo_completion_fence
 from .event_writeback import event_projection_todo_context
+
+
+TodoCompletionProjectionSource = Literal["materialized", "event_log"]
 
 
 def read_persisted_todo_record(
@@ -55,8 +59,29 @@ def read_persisted_todo_record(
     durable lifecycle, so the caller can fail closed instead of projecting a
     fabricated continuation.
     """
+    todo, existing_todo_ids, _projection_source = (
+        read_persisted_todo_record_with_source(
+            state_file,
+            todo_id=todo_id,
+            registry_path=registry_path,
+            goal_id=goal_id,
+        )
+    )
+    return todo, existing_todo_ids
+
+
+def read_persisted_todo_record_with_source(
+    state_file: Path,
+    *,
+    todo_id: str,
+    registry_path: Path | None = None,
+    goal_id: str | None = None,
+) -> tuple[dict[str, Any], set[str], TodoCompletionProjectionSource]:
+    """Read one durable Todo together with its authoritative projection source."""
+
     lines = state_file.read_text(encoding="utf-8").splitlines()
     block: dict[str, Any] | None = None
+    projection_source: TodoCompletionProjectionSource = "materialized"
     match = find_todo_block(lines, todo_id=todo_id)
     if match is not None:
         _role, _section, _start, _end, block = match
@@ -80,6 +105,7 @@ def read_persisted_todo_record(
         )
         if context is not None:
             block = dict(context["item"])
+            projection_source = "event_log"
             for candidate_role in ("user", "agent"):
                 summary = context["fields"].get(f"{candidate_role}_todos")
                 items = summary.get("items") if isinstance(summary, dict) else []
@@ -95,7 +121,7 @@ def read_persisted_todo_record(
             f"durable completion todo_id {normalized_todo_id!r} was not found "
             "in persisted Todo lifecycle state"
         )
-    return block, existing_todo_ids
+    return block, existing_todo_ids, projection_source
 
 
 def project_durable_completion_outcome(
@@ -125,6 +151,48 @@ def project_durable_completion_outcome(
         existing_todo_ids=existing_todo_ids,
         require_done=True,
     )
+
+
+def project_durable_terminal_completion_readback(
+    *,
+    todo: Mapping[str, Any],
+    expected_todo_id: str,
+    expected_completion_turn_key: str,
+    projection_source: TodoCompletionProjectionSource,
+    existing_todo_ids: Collection[str] | None = None,
+) -> dict[str, Any]:
+    """Resolve terminal completion evidence under the canonical Turn fence.
+
+    A still-open Todo or a same-Turn terminal upgrade proves the terminal
+    effect absent.  A completed no-follow-up Todo proves the effect committed
+    only when its durable ``completion_turn_key`` matches the recovering Turn.
+    The TypeScript fence raises for missing, cross-Turn, or contradictory
+    completion identity so callers can map uncertainty to fail-closed recovery.
+    """
+
+    fence = evaluate_todo_completion_fence(
+        todo=todo,
+        projection_source=projection_source,
+        completion_turn_key=expected_completion_turn_key,
+        no_followup=True,
+    )
+    if fence["outcome"] == "continue":
+        if fence["reason"] == "same_turn_terminal_upgrade" or (
+            fence["reason"] == "not_terminal" and fence["status"] == "open"
+        ):
+            return {"kind": "absent"}
+        raise ValueError("durable terminal completion is not safely replayable")
+    if normalize_todo_status(todo.get("status")) != TODO_STATUS_DONE:
+        raise ValueError("durable terminal completion is not safely replayable")
+
+    completion = project_durable_completion_outcome(
+        todo=todo,
+        expected_todo_id=expected_todo_id,
+        existing_todo_ids=existing_todo_ids,
+    )
+    if completion.get("continuation") != TodoCompletionContinuation.NO_FOLLOWUP.value:
+        raise ValueError("durable terminal completion is not no-follow-up")
+    return {"kind": "committed", "completion": completion}
 
 
 def project_durable_completion_intent(

--- a/loopx/control_plane/turn_driver/executor.py
+++ b/loopx/control_plane/turn_driver/executor.py
@@ -28,9 +28,14 @@ from .session_recovery import (
     require_host_recovery_kind,
 )
 from .settlement import (
+    TurnEffectResolver,
+    TurnSettlementJournalAdapter,
     completion_writeback_outcome,
     execute_turn_driver_settlement,
+    invoke_result_effect,
     terminal_closeout_requirement,
+    turn_effect_resolvers,
+    verified_terminal_closeout_effect,
 )
 from .transaction import (
     LOOPX_TURN_EXECUTION_SCHEMA_VERSION,
@@ -89,11 +94,11 @@ HOST_RESULT_FIELDS = {
     "summary",
 }
 
-Writeback = Callable[[dict[str, Any]], dict[str, Any]]
-CompletionWriteback = Callable[[dict[str, Any]], dict[str, Any]]
+Writeback = Callable[..., dict[str, Any]]
+CompletionWriteback = Callable[..., dict[str, Any]]
 CompletionIntent = Callable[[dict[str, Any]], dict[str, Any]]
-TerminalCloseout = Callable[[dict[str, Any]], dict[str, Any]]
-Spend = Callable[[], dict[str, Any]]
+TerminalCloseout = Callable[..., dict[str, Any]]
+Spend = Callable[..., dict[str, Any]]
 Scheduler = Callable[[dict[str, Any]], dict[str, Any]]
 HostRunner = Callable[[Mapping[str, Any]], dict[str, Any]]
 TaskValidator = Callable[
@@ -136,7 +141,9 @@ def _normalize_task_validator_argv(value: Sequence[str]) -> list[str]:
 
 
 def build_loopx_turn_host_request(plan: Mapping[str, Any]) -> dict[str, Any]:
-    transaction = plan.get("transaction") if isinstance(plan.get("transaction"), dict) else {}
+    transaction = (
+        plan.get("transaction") if isinstance(plan.get("transaction"), dict) else {}
+    )
     turn_key = str(transaction.get("turn_key") or "")
     if not TURN_KEY_RE.fullmatch(turn_key):
         raise ValueError("LoopX Turn plan has no valid transaction turn_key")
@@ -245,13 +252,9 @@ def _normalize_host_path_delta(
                 "material_replan agent_vision_json requires goal_path_delta_v0"
             )
         elif agent_vision["path_delta"].get("outcome") != "replan":
-            errors.append(
-                "material_replan goal_path_delta_v0 outcome must be replan"
-            )
+            errors.append("material_replan goal_path_delta_v0 outcome must be replan")
         if unchanged_reason:
-            errors.append(
-                "material_replan cannot also declare vision_unchanged_reason"
-            )
+            errors.append("material_replan cannot also declare vision_unchanged_reason")
     elif path_delta_mode == "unchanged":
         if agent_vision is not None:
             errors.append("unchanged path_delta_mode cannot include agent_vision_json")
@@ -275,7 +278,9 @@ def validate_loopx_turn_host_result(
     if result.get("schema_version") != LOOPX_TURN_RESULT_SCHEMA_VERSION:
         errors.append("unsupported host result schema_version")
 
-    transaction = plan.get("transaction") if isinstance(plan.get("transaction"), dict) else {}
+    transaction = (
+        plan.get("transaction") if isinstance(plan.get("transaction"), dict) else {}
+    )
     turn_key = str(transaction.get("turn_key") or "")
     if not turn_key or str(result.get("turn_key") or "") != turn_key:
         errors.append("host result turn_key does not match the transaction plan")
@@ -349,9 +354,10 @@ def validate_loopx_turn_host_result(
         normalized["path_delta_mode"] = path_delta_mode
         if agent_vision is not None:
             normalized["agent_vision"] = agent_vision
-    elif str(result.get("path_delta_mode") or "").strip() or str(
-        result.get("agent_vision_json") or ""
-    ).strip():
+    elif (
+        str(result.get("path_delta_mode") or "").strip()
+        or str(result.get("agent_vision_json") or "").strip()
+    ):
         errors.append(
             "wait and user_action_required results cannot declare a path delta"
         )
@@ -394,7 +400,9 @@ def _task_validation_receipt(
         LoopXTurnResultKind.REPAIR_REQUIRED.value,
         LoopXTurnResultKind.REPLAN_REQUIRED.value,
     }:
-        errors.append("task validation recovery_kind must be repair_required or replan_required")
+        errors.append(
+            "task validation recovery_kind must be repair_required or replan_required"
+        )
     if status in {"failed", "inconclusive", "unavailable"} and recovery_kind is None:
         errors.append("failed task validation requires a typed recovery_kind")
     if status in {"passed", "progress", "not_required"} and recovery_kind is not None:
@@ -575,7 +583,10 @@ def _load_journal(path: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
     value = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(value, dict) or value.get("schema_version") != LOOPX_TURN_JOURNAL_SCHEMA_VERSION:
+    if (
+        not isinstance(value, dict)
+        or value.get("schema_version") != LOOPX_TURN_JOURNAL_SCHEMA_VERSION
+    ):
         raise ValueError("LoopX Turn journal has an unsupported schema")
     return value
 
@@ -655,10 +666,14 @@ def load_loopx_turn_plan_from_journal(
     plan = journal.get("plan")
     if not isinstance(plan, dict):
         raise TypeError("LoopX Turn resume journal does not contain a plan")
-    transaction = plan.get("transaction") if isinstance(plan.get("transaction"), dict) else {}
+    transaction = (
+        plan.get("transaction") if isinstance(plan.get("transaction"), dict) else {}
+    )
     if transaction.get("turn_key") != turn_key or journal.get("turn_key") != turn_key:
         raise ValueError("LoopX Turn resume journal has mismatched turn lineage")
-    envelope = plan.get("turn_envelope") if isinstance(plan.get("turn_envelope"), dict) else {}
+    envelope = (
+        plan.get("turn_envelope") if isinstance(plan.get("turn_envelope"), dict) else {}
+    )
     if envelope.get("goal_id") != goal_id or journal.get("goal_id") != goal_id:
         raise ValueError("LoopX Turn resume journal belongs to another goal")
     return dict(plan)
@@ -695,7 +710,9 @@ def _host_failure(
     failed_phase: str,
     reason: str,
 ) -> dict[str, Any]:
-    transaction = plan.get("transaction") if isinstance(plan.get("transaction"), dict) else {}
+    transaction = (
+        plan.get("transaction") if isinstance(plan.get("transaction"), dict) else {}
+    )
     result = {"turn_key": transaction.get("turn_key"), "result_kind": kind.value}
     return {
         "ok": False,
@@ -738,13 +755,25 @@ def _run_host(
         }
     encoded = completed.stdout.encode("utf-8")
     if len(encoded) > HOST_RESULT_MAX_BYTES:
-        return {"ok": False, "reason": "host stdout exceeded the result budget", "returncode": 0}
+        return {
+            "ok": False,
+            "reason": "host stdout exceeded the result budget",
+            "returncode": 0,
+        }
     try:
         value = json.loads(completed.stdout)
     except json.JSONDecodeError:
-        return {"ok": False, "reason": "host stdout is not one JSON value", "returncode": 0}
+        return {
+            "ok": False,
+            "reason": "host stdout is not one JSON value",
+            "returncode": 0,
+        }
     if not isinstance(value, dict):
-        return {"ok": False, "reason": "host stdout must be one JSON object", "returncode": 0}
+        return {
+            "ok": False,
+            "reason": "host stdout must be one JSON object",
+            "returncode": 0,
+        }
     return {"ok": True, "value": value, "returncode": 0}
 
 
@@ -770,16 +799,28 @@ def _run_host_runner(
         return {"ok": False, "reason": type(exc).__name__, "returncode": None}
     if not isinstance(value, dict):
         return {"ok": False, "reason": "built-in host result must be one JSON object"}
-    encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode(
+        "utf-8"
+    )
     if len(encoded) > HOST_RESULT_MAX_BYTES:
-        return {"ok": False, "reason": "built-in host result exceeded the result budget"}
+        return {
+            "ok": False,
+            "reason": "built-in host result exceeded the result budget",
+        }
     return {"ok": True, "value": value, "returncode": 0}
 
 
 def _compact_callback(payload: Mapping[str, Any]) -> dict[str, Any]:
     return {
         key: payload.get(key)
-        for key in ("ok", "appended", "classification", "generated_at", "slots", "reason")
+        for key in (
+            "ok",
+            "appended",
+            "classification",
+            "generated_at",
+            "slots",
+            "reason",
+        )
         if key in payload
     }
 
@@ -796,7 +837,9 @@ def _execution_payload(
     replayed: bool,
     effects: Mapping[str, bool],
 ) -> dict[str, Any]:
-    transaction = plan.get("transaction") if isinstance(plan.get("transaction"), dict) else {}
+    transaction = (
+        plan.get("transaction") if isinstance(plan.get("transaction"), dict) else {}
+    )
     turn_key = str(transaction.get("turn_key") or "")
     planned_host = plan.get("host") if isinstance(plan.get("host"), dict) else {}
     writeback = _mapping(journal.get("writeback"))
@@ -805,7 +848,8 @@ def _execution_payload(
         journal.get("completed_phases") or []
     )
     return {
-        "ok": journal.get("status") in {
+        "ok": journal.get("status")
+        in {
             "preview",
             "committed",
             "stopped",
@@ -1044,14 +1088,6 @@ def _ensure_turn_settlement_plan(
     plan: Mapping[str, Any],
     transaction_plan: dict[str, Any],
 ) -> None:
-    """Upgrade a legacy transaction plan with a typed settlement plan.
-
-    Turn plans produced by older LoopX releases (for example plans read from a
-    scored-workspace image) do not carry ``settlement_plan``. Rebuild it from
-    the plan's own ``turn_envelope`` lineage so the typed closeout can bind
-    validation -> writeback -> spend instead of failing every legacy run.
-    """
-
     if isinstance(transaction_plan.get("settlement_plan"), Mapping):
         return
     envelope = plan.get("turn_envelope")
@@ -1071,9 +1107,7 @@ def _ensure_turn_settlement_plan(
         planned=True,
         lineage=lineage,
         host=str(host_fields.get("kind") or "generic-cli"),
-        execution_mode=str(
-            host_fields.get("execution_mode") or "isolated-headless"
-        ),
+        execution_mode=str(host_fields.get("execution_mode") or "isolated-headless"),
         session_action=str(host_fields.get("session_action") or "resume"),
         turn_instance_id=transaction_plan.get("turn_instance_id"),
     )
@@ -1095,12 +1129,11 @@ def _typed_settlement_stage(
     completion_intent: CompletionIntent | None,
     terminal_closeout: TerminalCloseout | None,
     spend: Spend,
+    effect_resolvers: Mapping[SettlementStepKind, TurnEffectResolver],
     scheduler: Scheduler,
 ) -> dict[str, Any]:
     transaction_plan = (
-        plan.get("transaction")
-        if isinstance(plan.get("transaction"), Mapping)
-        else {}
+        plan.get("transaction") if isinstance(plan.get("transaction"), Mapping) else {}
     )
     _ensure_turn_settlement_plan(plan, transaction_plan)
 
@@ -1125,7 +1158,7 @@ def _typed_settlement_stage(
             )
         )
 
-    def writeback_effect() -> Mapping[str, Any]:
+    def writeback_effect(effect_ref: str) -> Mapping[str, Any]:
         if completion_intent_error:
             return {
                 "ok": False,
@@ -1133,13 +1166,16 @@ def _typed_settlement_stage(
                 "reason": completion_intent_error,
             }
         if (
-            result.get("result_kind")
-            == LoopXTurnResultKind.VALIDATED_COMPLETION.value
+            result.get("result_kind") == LoopXTurnResultKind.VALIDATED_COMPLETION.value
             and not terminal_closeout_required
         ):
             if completion_writeback is None:
-                raise ValueError("validated_completion requires a todo lifecycle adapter")
-            callback_payload = completion_writeback(result)
+                raise ValueError(
+                    "validated_completion requires a todo lifecycle adapter"
+                )
+            callback_payload = invoke_result_effect(
+                completion_writeback, result, effect_ref
+            )
             completion_outcome = completion_writeback_outcome(
                 callback_payload,
                 plan=plan,
@@ -1161,66 +1197,23 @@ def _typed_settlement_stage(
                 **callback_payload,
                 "completion": completion_outcome,
             }
-        return writeback(result)
+        return invoke_result_effect(writeback, result, effect_ref)
 
-    def checkpoint(
-        step_kind: SettlementStepKind,
-        payload: Mapping[str, Any],
-        phases: tuple[str, ...],
-    ) -> None:
-        if step_kind is SettlementStepKind.DURABLE_WRITEBACK:
-            effects["state_written"] = True
-            journal["writeback"] = {
-                **_compact_callback(payload),
-                **(
-                    {"completion": payload["completion"]}
-                    if isinstance(payload.get("completion"), dict)
-                    else {}
-                ),
-            }
-        elif step_kind is SettlementStepKind.QUOTA_SPEND:
-            effects["quota_spent"] = True
-            journal["quota_spend"] = _compact_callback(payload)
-        journal["completed_phases"] = list(phases)
-        _write_journal(journal_path, journal)
+    journal_adapter = TurnSettlementJournalAdapter(
+        journal,
+        effects,
+        lambda: _write_journal(journal_path, journal),
+        _compact_callback,
+    )
 
     terminal_effect = None
     terminal_checkpoint = None
     if terminal_closeout_required:
         assert terminal_closeout is not None
-
-        def verified_terminal_effect() -> Mapping[str, Any]:
-            callback_payload = terminal_closeout(result)
-            outcome = completion_writeback_outcome(callback_payload, plan=plan)
-            if outcome is None or outcome.get("continuation") != "no_followup":
-                return {
-                    "ok": False,
-                    "appended": False,
-                    "reason": (
-                        "terminal closeout adapter did not durably record the "
-                        "selected Todo as no_followup"
-                    ),
-                }
-            return {**callback_payload, "completion": outcome}
-
-        def checkpoint_terminal(payload: Mapping[str, Any]) -> None:
-            compact = {
-                **_compact_callback(payload),
-                **(
-                    {"completion": payload["completion"]}
-                    if isinstance(payload.get("completion"), Mapping)
-                    else {}
-                ),
-            }
-            journal["terminal_closeout"] = compact
-            journal["writeback"] = {
-                **_mapping(journal.get("writeback")),
-                "completion": compact.get("completion"),
-            }
-            _write_journal(journal_path, journal)
-
-        terminal_effect = verified_terminal_effect
-        terminal_checkpoint = checkpoint_terminal
+        terminal_effect = verified_terminal_closeout_effect(
+            terminal_closeout, result=result, plan=plan
+        )
+        terminal_checkpoint = journal_adapter.checkpoint_terminal
 
     settlement_result = execute_turn_driver_settlement(
         transaction_plan,
@@ -1238,7 +1231,7 @@ def _typed_settlement_stage(
         ),
         writeback=writeback_effect,
         spend=spend,
-        checkpoint=checkpoint,
+        checkpoint=journal_adapter.checkpoint,
         committed_effect_id=_journal_committed_effect_id(journal),
         terminal_closeout_required=terminal_closeout_required,
         terminal_closeout_payload=(
@@ -1248,6 +1241,10 @@ def _typed_settlement_stage(
         ),
         terminal_closeout=terminal_effect,
         terminal_checkpoint=terminal_checkpoint,
+        prepare=journal_adapter.prepare,
+        abort=journal_adapter.abort,
+        effect_attempts=journal_adapter.effect_attempts,
+        effect_resolvers=effect_resolvers,
     )
 
     journal["settlement_result"] = settlement_result_payload(settlement_result)
@@ -1287,7 +1284,9 @@ def _typed_settlement_stage(
 
     settlement_state = settlement_result.value
     if settlement_state is None or settlement_state.quota_spend is None:
-        raise ValueError("typed Turn settlement completed without a quota spend receipt")
+        raise ValueError(
+            "typed Turn settlement completed without a quota spend receipt"
+        )
     completed_phases = list(settlement_state.completed_phases)
     spend_payload = dict(settlement_state.quota_spend)
     _write_journal(journal_path, journal)
@@ -1343,6 +1342,9 @@ def run_loopx_turn_once(
     completion_intent: CompletionIntent | None = None,
     terminal_closeout: TerminalCloseout | None = None,
     spend: Spend | None = None,
+    writeback_resolver: TurnEffectResolver | None = None,
+    spend_resolver: TurnEffectResolver | None = None,
+    terminal_closeout_resolver: TurnEffectResolver | None = None,
     scheduler: Scheduler | None = None,
 ) -> dict[str, Any]:
     if host_runner is not None and host_argv is not None:
@@ -1381,7 +1383,9 @@ def run_loopx_turn_once(
             effects=empty_effects,
         )
     if writeback is None or spend is None or scheduler is None:
-        raise ValueError("executing run-once requires writeback, spend, and scheduler callbacks")
+        raise ValueError(
+            "executing run-once requires writeback, spend, and scheduler callbacks"
+        )
 
     turn_key = str(request["turn_key"])
     journal_path = turn_journal_path(runtime_root, goal_id=goal_id, turn_key=turn_key)
@@ -1389,7 +1393,8 @@ def run_loopx_turn_once(
         journal = _load_journal(journal_path)
         if journal and (
             journal.get("status") in {"committed", "stopped"}
-            or journal.get("status") == "failed" and not retry_failed
+            or journal.get("status") == "failed"
+            and not retry_failed
         ):
             return _execution_payload(
                 plan,
@@ -1404,7 +1409,11 @@ def run_loopx_turn_once(
                 journal,
                 session_binding_resolver=session_binding_resolver,
             )
-            receipt = journal.get("receipt") if isinstance(journal.get("receipt"), dict) else {}
+            receipt = (
+                journal.get("receipt")
+                if isinstance(journal.get("receipt"), dict)
+                else {}
+            )
             if receipt.get("failed_phase") == "validation":
                 if journal.get("validation_stage") != "task_postcondition":
                     journal.pop("host_result", None)
@@ -1481,5 +1490,10 @@ def run_loopx_turn_once(
             completion_intent=completion_intent,
             terminal_closeout=terminal_closeout,
             spend=spend,
+            effect_resolvers=turn_effect_resolvers(
+                writeback=writeback_resolver,
+                spend=spend_resolver,
+                terminal_closeout=terminal_closeout_resolver,
+            ),
             scheduler=scheduler,
         )

--- a/loopx/control_plane/turn_driver/settlement.py
+++ b/loopx/control_plane/turn_driver/settlement.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
@@ -19,7 +20,11 @@ from .transaction import (
 )
 
 
-TurnEffect = Callable[[], Mapping[str, Any]]
+TurnEffect = Callable[..., Mapping[str, Any]]
+TurnEffectResolver = Callable[[str], Mapping[str, Any]]
+ResultEffect = Callable[..., Mapping[str, Any]]
+TurnSettlementPrepare = Callable[[SettlementStepKind, str], None]
+TurnSettlementAbort = Callable[[SettlementStepKind, str], None]
 TurnSettlementCheckpoint = Callable[
     [SettlementStepKind, Mapping[str, Any], tuple[str, ...]],
     None,
@@ -38,6 +43,164 @@ class TurnSettlementState:
 
 TURN_SETTLEMENT_TRANSACTION_SCHEMA_VERSION = "loopx_turn_settlement_transaction_v0"
 TURN_SETTLEMENT_REDUCTION_SCHEMA_VERSION = "loopx_turn_settlement_reduction_v0"
+
+
+def _invoke_turn_effect(effect: TurnEffect, effect_ref: str) -> Mapping[str, Any]:
+    """Invoke a provider with a stable ref while retaining zero-arg callbacks."""
+
+    try:
+        signature = inspect.signature(effect)
+    except (TypeError, ValueError):
+        return effect(effect_ref)
+    try:
+        signature.bind(effect_ref=effect_ref)
+    except TypeError:
+        pass
+    else:
+        return effect(effect_ref=effect_ref)
+    try:
+        signature.bind()
+    except TypeError:
+        signature.bind(effect_ref)
+        return effect(effect_ref)
+    return effect()
+
+
+def invoke_result_effect(
+    effect: ResultEffect,
+    result: Mapping[str, Any],
+    effect_ref: str,
+) -> Mapping[str, Any]:
+    """Invoke a result provider with optional stable-ref compatibility."""
+
+    try:
+        signature = inspect.signature(effect)
+    except (TypeError, ValueError):
+        return effect(result, effect_ref)
+    try:
+        signature.bind(result, effect_ref=effect_ref)
+    except TypeError:
+        pass
+    else:
+        return effect(result, effect_ref=effect_ref)
+    try:
+        signature.bind(result)
+    except TypeError:
+        signature.bind(result, effect_ref)
+        return effect(result, effect_ref)
+    return effect(result)
+
+
+def turn_effect_resolvers(
+    *,
+    writeback: TurnEffectResolver | None,
+    spend: TurnEffectResolver | None,
+    terminal_closeout: TurnEffectResolver | None,
+) -> dict[SettlementStepKind, TurnEffectResolver]:
+    """Collect configured provider readbacks under their typed steps."""
+
+    return {
+        step: resolver
+        for step, resolver in (
+            (SettlementStepKind.DURABLE_WRITEBACK, writeback),
+            (SettlementStepKind.QUOTA_SPEND, spend),
+            (SettlementStepKind.TERMINAL_CLOSEOUT, terminal_closeout),
+        )
+        if resolver is not None
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class TurnSettlementJournalAdapter:
+    """Mechanically persist prepared effects and committed provider payloads."""
+
+    journal: dict[str, Any]
+    effects: dict[str, bool]
+    persist: Callable[[], None]
+    compact_payload: Callable[[Mapping[str, Any]], Mapping[str, Any]]
+
+    @property
+    def effect_attempts(self) -> Mapping[str, Mapping[str, Any]]:
+        attempts = self.journal.get("effect_attempts")
+        return attempts if isinstance(attempts, Mapping) else {}
+
+    def prepare(self, step_kind: SettlementStepKind, effect_ref: str) -> None:
+        attempts = self.journal.setdefault("effect_attempts", {})
+        if not isinstance(attempts, dict):
+            raise RuntimeError("Turn journal effect_attempts shape mismatch")
+        attempts[step_kind.value] = {
+            "status": "prepared",
+            "effect_ref": effect_ref,
+        }
+        self.persist()
+
+    def abort(self, step_kind: SettlementStepKind, effect_ref: str) -> None:
+        self._forget(step_kind, effect_ref)
+        self.persist()
+
+    def checkpoint(
+        self,
+        step_kind: SettlementStepKind,
+        payload: Mapping[str, Any],
+        phases: tuple[str, ...],
+    ) -> None:
+        if step_kind is SettlementStepKind.DURABLE_WRITEBACK:
+            self.effects["state_written"] = True
+            self.journal["writeback"] = self._completion_payload(payload)
+        elif step_kind is SettlementStepKind.QUOTA_SPEND:
+            self.effects["quota_spent"] = True
+            self.journal["quota_spend"] = dict(self.compact_payload(payload))
+        self.journal["completed_phases"] = list(phases)
+        self._forget(step_kind, str(payload.get("effect_ref") or ""), strict=False)
+        self.persist()
+
+    def checkpoint_terminal(self, payload: Mapping[str, Any]) -> None:
+        compact = self._completion_payload(payload)
+        self.journal["terminal_closeout"] = compact
+        writeback = self.journal.get("writeback")
+        self.journal["writeback"] = {
+            **(dict(writeback) if isinstance(writeback, Mapping) else {}),
+            "completion": compact.get("completion"),
+        }
+        self._forget(
+            SettlementStepKind.TERMINAL_CLOSEOUT,
+            str(payload.get("effect_ref") or ""),
+            strict=False,
+        )
+        self.persist()
+
+    def _completion_payload(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        return {
+            **dict(self.compact_payload(payload)),
+            **(
+                {"completion": dict(payload["completion"])}
+                if isinstance(payload.get("completion"), Mapping)
+                else {}
+            ),
+        }
+
+    def _forget(
+        self,
+        step_kind: SettlementStepKind,
+        effect_ref: str,
+        *,
+        strict: bool = True,
+    ) -> None:
+        attempts = self.journal.get("effect_attempts")
+        if not isinstance(attempts, dict):
+            return
+        attempt = attempts.get(step_kind.value)
+        if (
+            isinstance(attempt, Mapping)
+            and effect_ref
+            and (attempt.get("effect_ref") != effect_ref)
+        ):
+            if strict:
+                raise RuntimeError("Turn journal prepared effect ref changed")
+            return
+        attempts.pop(step_kind.value, None)
+        if not attempts:
+            self.journal.pop("effect_attempts", None)
 
 
 def completion_writeback_outcome(
@@ -95,6 +258,79 @@ def terminal_closeout_requirement(
     return outcome["continuation"] == "no_followup", None
 
 
+def verified_terminal_closeout_effect(
+    effect: ResultEffect,
+    *,
+    result: Mapping[str, Any],
+    plan: Mapping[str, Any],
+) -> TurnEffect:
+    """Wrap terminal closeout with its durable no-followup postcondition."""
+
+    def verified(effect_ref: str) -> Mapping[str, Any]:
+        callback_payload = invoke_result_effect(effect, result, effect_ref)
+        outcome = completion_writeback_outcome(callback_payload, plan=plan)
+        if outcome is None or outcome.get("continuation") != "no_followup":
+            return {
+                "ok": False,
+                "appended": False,
+                "reason": (
+                    "terminal closeout adapter did not durably record the "
+                    "selected Todo as no_followup"
+                ),
+            }
+        return {**callback_payload, "completion": outcome}
+
+    return verified
+
+
+def _resolve_prepared_effect(
+    resolvers: Mapping[SettlementStepKind, TurnEffectResolver],
+    step_kind: SettlementStepKind,
+    effect_ref: str,
+) -> tuple[bool, Mapping[str, Any] | None, Mapping[str, Any] | None]:
+    """Return execute, committed payload, or a fail-closed observation."""
+
+    resolver = resolvers.get(step_kind)
+    if resolver is None:
+        return (
+            False,
+            None,
+            {
+                "kind": "unknown",
+                "reason": "provider readback is unavailable",
+            },
+        )
+    try:
+        resolution = dict(resolver(effect_ref))
+    except Exception as exc:
+        return (
+            False,
+            None,
+            {
+                "kind": "unknown",
+                "reason": f"provider readback raised {type(exc).__name__}",
+            },
+        )
+    kind = str(resolution.get("kind") or "unknown")
+    if kind == "absent":
+        return True, None, None
+    if kind != "committed":
+        observation = (
+            resolution
+            if kind == "unknown"
+            else {
+                "kind": "unknown",
+                "reason": f"unsupported provider readback kind: {kind}",
+            }
+        )
+        return False, None, observation
+    raw_payload = resolution.get("payload")
+    observed = dict(raw_payload) if isinstance(raw_payload, Mapping) else {}
+    if observed.get("ok") is True and observed.get("appended") is True:
+        return False, observed, None
+    return False, None, resolution
+
+
 def execute_turn_driver_settlement(
     transaction_plan: Mapping[str, Any],
     *,
@@ -110,6 +346,10 @@ def execute_turn_driver_settlement(
     terminal_closeout_payload: Mapping[str, Any] | None = None,
     terminal_closeout: TurnEffect | None = None,
     terminal_checkpoint: TerminalCloseoutCheckpoint | None = None,
+    prepare: TurnSettlementPrepare | None = None,
+    abort: TurnSettlementAbort | None = None,
+    effect_attempts: Mapping[str, Mapping[str, Any]] | None = None,
+    effect_resolvers: Mapping[SettlementStepKind, TurnEffectResolver] | None = None,
 ) -> SettlementResult[TurnSettlementState]:
     """Run external effect providers and reduce one complete Turn settlement.
 
@@ -124,6 +364,14 @@ def execute_turn_driver_settlement(
     spend_value = quota_spend_payload
     terminal_value = terminal_closeout_payload
     failed_attempt: tuple[SettlementStepKind, Mapping[str, Any]] | None = None
+    attempts = {
+        (step.value if isinstance(step, SettlementStepKind) else str(step)): dict(
+            attempt
+        )
+        for step, attempt in (effect_attempts or {}).items()
+    }
+    observations: dict[str, Mapping[str, Any]] = {}
+    resolvers = dict(effect_resolvers or {})
 
     def committed(payload: Mapping[str, Any]) -> bool:
         # This transport guard only prevents a later provider from running
@@ -162,6 +410,8 @@ def execute_turn_driver_settlement(
                     if failed_attempt is not None
                     else None
                 ),
+                "effect_attempts": attempts,
+                "provider_observations": observations,
             },
         )
         if (
@@ -185,30 +435,64 @@ def execute_turn_driver_settlement(
             if not isinstance(raw_effect, Mapping):
                 raise RuntimeError("TypeScript Turn settlement provider shape mismatch")
             step_kind = SettlementStepKind(str(raw_effect.get("step_kind") or ""))
+            action = str(raw_effect.get("action") or "")
+            effect_ref = str(raw_effect.get("effect_ref") or "")
+            if action not in {"prepare_and_execute", "resolve_prepared"}:
+                raise RuntimeError("TypeScript Turn settlement action mismatch")
+            if not effect_ref:
+                raise RuntimeError("TypeScript Turn settlement effect ref is empty")
             raw_phases = raw_effect.get("completed_phases")
             if not isinstance(raw_phases, list):
                 raise RuntimeError("TypeScript Turn settlement phases shape mismatch")
             authorized_phases = tuple(str(phase) for phase in raw_phases)
+            should_execute = action == "prepare_and_execute"
+            if action == "prepare_and_execute":
+                if prepare is not None:
+                    prepare(step_kind, effect_ref)
+                attempts[step_kind.value] = {
+                    "status": "prepared",
+                    "effect_ref": effect_ref,
+                }
+            else:
+                should_execute, observed, observation = _resolve_prepared_effect(
+                    resolvers, step_kind, effect_ref
+                )
+                if observation is not None:
+                    observations[step_kind.value] = observation
+                    break
+
             if step_kind is SettlementStepKind.TERMINAL_CLOSEOUT:
                 if terminal_closeout is None or terminal_checkpoint is None:
                     raise ValueError(
                         "terminal closeout requires an effect provider and checkpoint"
                     )
-                observed = dict(terminal_closeout())
+                if should_execute:
+                    observed = dict(_invoke_turn_effect(terminal_closeout, effect_ref))
+                assert observed is not None
                 if committed(observed):
                     terminal_value = observed
                     terminal_checkpoint(observed)
+                    attempts.pop(step_kind.value, None)
                 else:
+                    if abort is not None:
+                        abort(step_kind, effect_ref)
+                    attempts.pop(step_kind.value, None)
                     failed_attempt = (step_kind, observed)
                     break
                 continue
 
-            observed = dict(providers[step_kind]())
+            if should_execute:
+                observed = dict(_invoke_turn_effect(providers[step_kind], effect_ref))
+            assert observed is not None
             if not committed(observed):
+                if abort is not None:
+                    abort(step_kind, effect_ref)
+                attempts.pop(step_kind.value, None)
                 failed_attempt = (step_kind, observed)
                 break
             phases = authorized_phases
             checkpoint(step_kind, observed, phases)
+            attempts.pop(step_kind.value, None)
             if step_kind is SettlementStepKind.DURABLE_WRITEBACK:
                 writeback_value = observed
             else:

--- a/loopx/control_plane/turn_driver/settlement.ts
+++ b/loopx/control_plane/turn_driver/settlement.ts
@@ -1,5 +1,6 @@
 import {
   commitStepPayload,
+  isCommittedPayload,
   requireMatchingEffectId,
   seedCommittedSteps,
   settlementFailed,
@@ -17,6 +18,7 @@ import {
   optionalNonEmptyString,
   requireBoolean,
   requireJsonObject,
+  requireNonEmptyString,
   requireStringArray,
   requireStringLiteral,
 } from "../runtime_decode.ts";
@@ -39,15 +41,45 @@ const PROVIDER_STEP_KINDS = [
 ] as const;
 type ProviderStepKind = (typeof PROVIDER_STEP_KINDS)[number];
 
+const PROVIDER_RESOLUTION_KINDS = ["committed", "absent", "unknown"] as const;
+type ProviderResolutionKind = (typeof PROVIDER_RESOLUTION_KINDS)[number];
+
+interface PreparedEffectAttempt {
+  status: "prepared";
+  effect_ref: string;
+}
+
+interface ProviderObservation {
+  kind: ProviderResolutionKind;
+  payload: JsonObject | null;
+  reason: string | null;
+}
+
 interface FailedProviderAttempt {
   step_kind: ProviderStepKind;
   payload: JsonObject;
 }
 
-interface ProviderEffect {
+interface ProviderExecutionEffect {
   step_kind: ProviderStepKind;
+  action: "prepare_and_execute";
+  effect_ref: string;
   completed_phases: readonly string[];
 }
+
+interface ProviderResolutionEffect {
+  step_kind: ProviderStepKind;
+  action: "resolve_prepared";
+  effect_ref: string;
+  completed_phases: readonly string[];
+  resolution_policy: {
+    committed: "checkpoint";
+    absent: "execute";
+    unknown: "fail_closed";
+  };
+}
+
+type ProviderEffect = ProviderExecutionEffect | ProviderResolutionEffect;
 
 interface TurnSettlementRequest {
   schema_version: typeof TURN_SETTLEMENT_TRANSACTION_SCHEMA_VERSION;
@@ -60,6 +92,8 @@ interface TurnSettlementRequest {
   terminal_closeout_required: boolean;
   terminal_closeout_payload: JsonObject | null;
   failed_provider_attempt: FailedProviderAttempt | null;
+  effect_attempts: Partial<Record<ProviderStepKind, PreparedEffectAttempt>>;
+  provider_observations: Partial<Record<ProviderStepKind, ProviderObservation>>;
 }
 
 export interface TurnSettlementState {
@@ -111,6 +145,56 @@ function decodeFailedProviderAttempt(
   };
 }
 
+function decodeProviderRecord<Value>(
+  value: unknown,
+  label: string,
+  decode: (value: unknown, label: string) => Value,
+): Partial<Record<ProviderStepKind, Value>> {
+  if (value === null || value === undefined) return {};
+  const record = requireJsonObject(value, label);
+  const decoded: Partial<Record<ProviderStepKind, Value>> = {};
+  for (const [rawStep, rawValue] of Object.entries(record)) {
+    const step = requireStringLiteral(
+      rawStep,
+      PROVIDER_STEP_KINDS,
+      `${label} step`,
+    );
+    decoded[step] = decode(rawValue, `${label}.${step}`);
+  }
+  return decoded;
+}
+
+function decodePreparedAttempt(
+  value: unknown,
+  label: string,
+): PreparedEffectAttempt {
+  const attempt = requireJsonObject(value, label);
+  return {
+    status: requireStringLiteral(
+      attempt.status,
+      ["prepared"] as const,
+      `${label}.status`,
+    ),
+    effect_ref: requireNonEmptyString(attempt.effect_ref, `${label}.effect_ref`),
+  };
+}
+
+function decodeProviderObservation(
+  value: unknown,
+  label: string,
+): ProviderObservation {
+  const observation = requireJsonObject(value, label);
+  return {
+    kind: requireStringLiteral(
+      observation.kind,
+      PROVIDER_RESOLUTION_KINDS,
+      `${label}.kind`,
+    ),
+    payload: optionalObject(observation.payload, `${label}.payload`),
+    reason: optionalNonEmptyString(observation.reason, `${label}.reason`),
+  };
+}
+
 function decodeRequest(value: unknown): TurnSettlementRequest {
   const request = requireJsonObject(value, "Turn settlement request");
   const schemaVersion = requireStringLiteral(
@@ -154,6 +238,16 @@ function decodeRequest(value: unknown): TurnSettlementRequest {
     ),
     failed_provider_attempt: decodeFailedProviderAttempt(
       request.failed_provider_attempt,
+    ),
+    effect_attempts: decodeProviderRecord(
+      request.effect_attempts,
+      "effect_attempts",
+      decodePreparedAttempt,
+    ),
+    provider_observations: decodeProviderRecord(
+      request.provider_observations,
+      "provider_observations",
+      decodeProviderObservation,
     ),
   };
 }
@@ -228,6 +322,7 @@ function providerFailure(
 
 function pendingProviderEffects(
   request: TurnSettlementRequest,
+  identity: SettlementIdentity,
   firstStep: ProviderStepKind,
 ): readonly ProviderEffect[] {
   const completed = new Set(request.completed_phases);
@@ -240,6 +335,8 @@ function pendingProviderEffects(
     }
     effects.push({
       step_kind: step,
+      action: "prepare_and_execute",
+      effect_ref: `${identity.effect_id}#${step}`,
       completed_phases: request.transaction_phases.slice(0, phaseIndex + 1),
     });
   }
@@ -249,10 +346,137 @@ function pendingProviderEffects(
   if (request.terminal_closeout_required) {
     effects.push({
       step_kind: "terminal_closeout",
+      action: "prepare_and_execute",
+      effect_ref: `${identity.effect_id}#terminal_closeout`,
       completed_phases: [...request.completed_phases],
     });
   }
   return effects;
+}
+
+function providerExecution(
+  request: TurnSettlementRequest,
+  identity: SettlementIdentity,
+  firstStep: ProviderStepKind,
+  effects: readonly ProviderEffect[],
+  receipts: SettlementResult<unknown>["receipts"],
+): TurnSettlementReduction {
+  const attempts = Object.entries(request.effect_attempts) as Array<
+    [ProviderStepKind, PreparedEffectAttempt]
+  >;
+  const observations = Object.entries(request.provider_observations) as Array<
+    [ProviderStepKind, ProviderObservation]
+  >;
+  if (attempts.length === 0) {
+    if (observations.length > 0) {
+      return reduction(
+        settlementFailed({
+          kind: "receipt_missing",
+          step_kind: observations[0][0],
+          reason: "Turn settlement has a provider observation without a prepared effect",
+          receipts,
+        }),
+      );
+    }
+    return execution(effects);
+  }
+
+  const unexpected = attempts.find(([step]) => step !== firstStep);
+  if (attempts.length !== 1 || unexpected) {
+    const step = unexpected?.[0] ?? attempts[1]?.[0] ?? attempts[0][0];
+    return reduction(
+      settlementFailed({
+        kind: "receipt_missing",
+        step_kind: step,
+        reason: "Prepared settlement effects do not match the next ordered provider",
+        receipts,
+      }),
+    );
+  }
+
+  const attempt = attempts[0][1];
+  const expectedRef = `${identity.effect_id}#${firstStep}`;
+  if (attempt.effect_ref !== expectedRef) {
+    return reduction(
+      settlementFailed({
+        kind: "identity_mismatch",
+        step_kind: firstStep,
+        reason:
+          `Prepared settlement effect does not match the current operation: ` +
+          `journal effect is ${attempt.effect_ref} but plan effect is ${expectedRef}`,
+        receipts,
+      }),
+    );
+  }
+
+  const strayObservation = observations.find(([step]) => step !== firstStep);
+  if (strayObservation) {
+    return reduction(
+      settlementFailed({
+        kind: "receipt_missing",
+        step_kind: strayObservation[0],
+        reason: "Provider observation does not match the prepared settlement effect",
+        receipts,
+      }),
+    );
+  }
+  const observation = request.provider_observations[firstStep];
+  if (observation?.kind === "unknown") {
+    return reduction(
+      settlementFailed({
+        kind: "effect_outcome_unknown",
+        step_kind: firstStep,
+        reason:
+          observation.reason ??
+          "Provider could not resolve the prepared settlement effect",
+        receipts,
+      }),
+    );
+  }
+  if (
+    observation?.kind === "committed" &&
+    !isCommittedPayload(observation.payload)
+  ) {
+    return reduction(
+      settlementFailed({
+        kind: "receipt_missing",
+        step_kind: firstStep,
+        reason:
+          "Provider reported a committed settlement effect without a durable committed payload",
+        receipts,
+      }),
+    );
+  }
+  if (observation !== undefined) {
+    return reduction(
+      settlementFailed({
+        kind: "effect_outcome_unknown",
+        step_kind: firstStep,
+        reason:
+          "Prepared provider observation was not durably checkpointed by the adapter",
+        receipts,
+      }),
+    );
+  }
+
+  const effect = effects.find((candidate) => candidate.step_kind === firstStep);
+  if (!effect) {
+    throw new Error(`Turn settlement has no provider effect for ${firstStep}`);
+  }
+  return execution([
+    {
+      step_kind: firstStep,
+      action: "resolve_prepared",
+      effect_ref: expectedRef,
+      completed_phases: effect.completed_phases,
+      resolution_policy: {
+        committed: "checkpoint",
+        absent: "execute",
+        unknown: "fail_closed",
+      },
+    },
+    ...effects.filter((candidate) => candidate.step_kind !== firstStep),
+  ]);
 }
 
 /**
@@ -295,8 +519,15 @@ export function reduceTurnSettlementTransaction(
     if (base.step_kind === "validation" || base.step_kind === "terminal_closeout") {
       throw new Error(`unsupported base settlement step ${base.step_kind}`);
     }
+    const effects = pendingProviderEffects(request, identity, base.step_kind);
     return request.failed_provider_attempt === null
-      ? execution(pendingProviderEffects(request, base.step_kind))
+      ? providerExecution(
+          request,
+          identity,
+          base.step_kind,
+          effects,
+          base.result.receipts,
+        )
       : providerFailure(
           identity,
           request,
@@ -308,13 +539,22 @@ export function reduceTurnSettlementTransaction(
   let receipts = [...base.result.receipts];
   if (request.terminal_closeout_required) {
     if (request.terminal_closeout_payload === null) {
+      const effects: readonly ProviderEffect[] = [
+        {
+          step_kind: "terminal_closeout",
+          action: "prepare_and_execute",
+          effect_ref: `${identity.effect_id}#terminal_closeout`,
+          completed_phases: [...request.completed_phases],
+        },
+      ];
       return request.failed_provider_attempt === null
-        ? execution([
-            {
-              step_kind: "terminal_closeout",
-              completed_phases: [...request.completed_phases],
-            },
-          ])
+        ? providerExecution(
+            request,
+            identity,
+            "terminal_closeout",
+            effects,
+            receipts,
+          )
         : providerFailure(
             identity,
             request,
@@ -341,6 +581,20 @@ export function reduceTurnSettlementTransaction(
         kind: "terminal_closeout_rejected",
         step_kind: "terminal_closeout",
         reason: "Turn settlement contains an unrequested terminal closeout",
+        receipts,
+      }),
+    );
+  }
+
+  const danglingAttempt = Object.keys(request.effect_attempts)[0] as
+    | ProviderStepKind
+    | undefined;
+  if (danglingAttempt) {
+    return reduction(
+      settlementFailed({
+        kind: "receipt_missing",
+        step_kind: danglingAttempt,
+        reason: "Turn settlement has a prepared effect after its provider phase",
         receipts,
       }),
     );

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -39,6 +39,7 @@ from .control_plane.quota.scheduler_ack import (
     record_quota_scheduler_ack_for_decision,
 )
 from .control_plane.quota.settlement import (
+    find_quota_spend_run_by_effect_ref,
     find_settlement_spend_run,
     infer_persisted_heartbeat_settlement_identity,
     require_settlement_spend,
@@ -858,6 +859,7 @@ def build_quota_slot_preview(
     todo_id: str | None = None,
     replan_obligation_id: str | None = None,
     turn_instance_id: str | None = None,
+    effect_ref: str | None = None,
     source: str = DEFAULT_SLOT_SPEND_SOURCE,
 ) -> dict[str, Any]:
     safe_goal_id = str(goal_id or "").strip()
@@ -867,7 +869,7 @@ def build_quota_slot_preview(
         agent_id=agent_id,
         available_capabilities=available_capabilities, operator_inbox_urgency_projector=operator_inbox_urgency_projector,
     )
-    return build_quota_slot_preview_for_decision(
+    preview = build_quota_slot_preview_for_decision(
         status_payload,
         goal_id=safe_goal_id,
         slots=slots,
@@ -887,6 +889,9 @@ def build_quota_slot_preview(
         turn_instance_id=turn_instance_id,
         source=source,
     )
+    if not effect_ref:
+        return preview
+    return {**preview, "effect_ref": str(effect_ref).strip()}
 
 
 
@@ -1121,8 +1126,62 @@ def spend_quota_slot(
     todo_id: str | None = None,
     replan_obligation_id: str | None = None,
     turn_instance_id: str | None = None,
+    effect_ref: str | None = None,
 ) -> dict[str, Any]:
     safe_goal_id = _validate_goal_id_path_segment(str(goal_id or ""))
+    normalized_effect_ref = str(effect_ref or "").strip()
+    raw_runtime_root = status_payload.get("runtime_root")
+    if effect_ref is not None and not normalized_effect_ref:
+        return {
+            "ok": False,
+            "mode": "spend-slot",
+            "dry_run": not execute,
+            "appended": False,
+            "goal_id": safe_goal_id,
+            "reason": "effect_ref must be a non-empty string when provided",
+        }
+    if normalized_effect_ref:
+        if not raw_runtime_root:
+            return {
+                "ok": False,
+                "mode": "spend-slot",
+                "dry_run": not execute,
+                "appended": False,
+                "goal_id": safe_goal_id,
+                "effect_ref": normalized_effect_ref,
+                "reason": "effect-bound quota spend requires runtime_root",
+            }
+        prior_effect_run = find_quota_spend_run_by_effect_ref(
+            Path(str(raw_runtime_root)).expanduser(),
+            goal_id=safe_goal_id,
+            effect_ref=normalized_effect_ref,
+        )
+        if prior_effect_run is not None:
+            prior_agent_id = normalize_todo_claimed_by(
+                prior_effect_run.get("agent_id")
+            )
+            requested_agent_id = normalize_todo_claimed_by(agent_id)
+            if requested_agent_id and prior_agent_id != requested_agent_id:
+                return {
+                    "ok": False,
+                    "mode": "spend-slot",
+                    "dry_run": not execute,
+                    "appended": False,
+                    "goal_id": safe_goal_id,
+                    "effect_ref": normalized_effect_ref,
+                    "reason": "effect_ref already belongs to a different agent",
+                }
+            return {
+                "ok": True,
+                "mode": "spend-slot",
+                "dry_run": not execute,
+                "appended": False,
+                "idempotent_replay": True,
+                "goal_id": safe_goal_id,
+                "agent_id": prior_agent_id or None,
+                "effect_ref": normalized_effect_ref,
+                "reason": "quota spend replayed for the same provider effect",
+            }
     if turn_instance_id and source != DEFAULT_SLOT_SPEND_SOURCE:
         return {
             "ok": False,
@@ -1132,7 +1191,6 @@ def spend_quota_slot(
             "goal_id": safe_goal_id,
             "reason": "turn-scoped settlement is valid only for heartbeat spend",
         }
-    raw_runtime_root = status_payload.get("runtime_root")
     if (
         not turn_instance_id
         and source == DEFAULT_SLOT_SPEND_SOURCE
@@ -1240,6 +1298,7 @@ def spend_quota_slot(
         todo_id=todo_id,
         replan_obligation_id=replan_obligation_id,
         turn_instance_id=turn_instance_id,
+        effect_ref=normalized_effect_ref or None,
         source=source,
     )
     if not preview.get("ok"):

--- a/tests/control_plane/test_durable_completion_projection.py
+++ b/tests/control_plane/test_durable_completion_projection.py
@@ -8,7 +8,9 @@ import pytest
 from loopx.control_plane.todos.durable_completion import (
     project_durable_completion_intent,
     project_durable_completion_outcome,
+    project_durable_terminal_completion_readback,
     read_persisted_todo_record,
+    read_persisted_todo_record_with_source,
 )
 from loopx.event_sourced_state import (
     TODO_ADDED,
@@ -81,6 +83,79 @@ def test_projects_terminal_intent_without_premature_completion() -> None:
         "todo_id": "todo_fixture0001",
         "continuation": "no_followup",
     }
+
+
+@pytest.mark.parametrize(
+    ("status", "projection_source"),
+    [
+        ("blocked", "materialized"),
+        ("deferred", "materialized"),
+        ("deferred", "event_log"),
+    ],
+)
+def test_terminal_readback_does_not_treat_ambiguous_state_as_absent(
+    status: str,
+    projection_source: str,
+) -> None:
+    with pytest.raises(ValueError, match="not safely replayable"):
+        project_durable_terminal_completion_readback(
+            todo={
+                "todo_id": "todo_fixture0001",
+                "status": status,
+                "no_followup": True,
+            },
+            expected_todo_id="todo_fixture0001",
+            expected_completion_turn_key="sha256:current-turn",
+            projection_source=projection_source,
+        )
+
+
+def test_terminal_readback_reports_explicitly_open_state_absent() -> None:
+    assert project_durable_terminal_completion_readback(
+        todo={
+            "todo_id": "todo_fixture0001",
+            "status": "open",
+            "no_followup": True,
+        },
+        expected_todo_id="todo_fixture0001",
+        expected_completion_turn_key="sha256:current-turn",
+        projection_source="materialized",
+    ) == {"kind": "absent"}
+
+
+def test_terminal_readback_commits_same_turn_no_followup() -> None:
+    assert project_durable_terminal_completion_readback(
+        todo={
+            "todo_id": "todo_fixture0001",
+            "status": "done",
+            "completion_continuation": "no_followup",
+            "completion_turn_key": "sha256:current-turn",
+            "no_followup": True,
+        },
+        expected_todo_id="todo_fixture0001",
+        expected_completion_turn_key="sha256:current-turn",
+        projection_source="materialized",
+    ) == {
+        "kind": "committed",
+        "completion": {
+            "todo_id": "todo_fixture0001",
+            "continuation": "no_followup",
+        },
+    }
+
+
+def test_terminal_readback_allows_same_turn_terminal_upgrade() -> None:
+    assert project_durable_terminal_completion_readback(
+        todo={
+            "todo_id": "todo_fixture0001",
+            "status": "done",
+            "completion_continuation": "active_goal",
+            "completion_turn_key": "sha256:current-turn",
+        },
+        expected_todo_id="todo_fixture0001",
+        expected_completion_turn_key="sha256:current-turn",
+        projection_source="materialized",
+    ) == {"kind": "absent"}
 
 
 def test_no_followup_without_existing_ids_needs_no_successor_verification() -> None:
@@ -204,10 +279,11 @@ def test_read_persisted_todo_record_projects_declared_successor(
         ),
         encoding="utf-8",
     )
-    todo, existing_todo_ids = read_persisted_todo_record(
+    todo, existing_todo_ids, projection_source = read_persisted_todo_record_with_source(
         state_file,
         todo_id="todo_fixture0001",
     )
+    assert projection_source == "materialized"
     assert existing_todo_ids == {"todo_fixture0001", "todo_fixture0002"}
     outcome = project_durable_completion_outcome(
         todo=todo,
@@ -324,12 +400,13 @@ def test_read_persisted_todo_record_falls_back_to_event_projection(
         encoding="utf-8",
     )
 
-    todo, existing_todo_ids = read_persisted_todo_record(
+    todo, existing_todo_ids, projection_source = read_persisted_todo_record_with_source(
         state_file,
         todo_id="todo_fixture0001",
         registry_path=registry,
         goal_id=goal_id,
     )
+    assert projection_source == "event_log"
     assert existing_todo_ids == {"todo_fixture0001"}
     outcome = project_durable_completion_outcome(
         todo=todo,

--- a/tests/control_plane/test_settlement_driver.py
+++ b/tests/control_plane/test_settlement_driver.py
@@ -1,5 +1,7 @@
 """Focused tests for the remaining shared settlement projection facade."""
 
+import pytest
+
 from loopx.control_plane.effect_program import (
     SettlementIdentity,
     SettlementStepKind,
@@ -8,6 +10,7 @@ from loopx.control_plane.settlement_driver import (
     effect_ids_match,
     settlement_receipt,
 )
+from loopx.control_plane.turn_driver.settlement import execute_turn_driver_settlement
 
 
 IDENTITY = SettlementIdentity(
@@ -16,6 +19,14 @@ IDENTITY = SettlementIdentity(
     todo_id="todo_fixture0001",
     turn_instance_id="fixture-turn",
 )
+PHASES = (
+    "host_execute",
+    "typed_result",
+    "validation",
+    "durable_writeback",
+    "quota_spend",
+)
+TRANSACTION = {"settlement_plan": {"identity": IDENTITY.as_dict()}}
 
 
 def test_effect_ids_match_allows_missing_and_equal_provenance() -> None:
@@ -34,3 +45,167 @@ def test_settlement_receipt_is_committed_under_the_identity() -> None:
     assert receipt.status == "committed"
     assert receipt.effect_id == IDENTITY.effect_id
     assert receipt.source_ref == "rollout_event:abc"
+
+
+def test_turn_settlement_prepares_before_invoking_legacy_callbacks() -> None:
+    events: list[str] = []
+
+    result = execute_turn_driver_settlement(
+        TRANSACTION,
+        transaction_phases=PHASES,
+        completed_phases=PHASES[:3],
+        writeback_payload=None,
+        quota_spend_payload=None,
+        writeback=lambda: events.append("writeback") or {"ok": True, "appended": True},
+        spend=lambda: events.append("spend") or {"ok": True, "appended": True},
+        checkpoint=lambda step, _payload, _phases: events.append(
+            f"checkpoint:{step.value}"
+        ),
+        prepare=lambda step, _effect_ref: events.append(f"prepare:{step.value}"),
+    )
+
+    assert result.failure is None
+    assert events == [
+        "prepare:durable_writeback",
+        "writeback",
+        "checkpoint:durable_writeback",
+        "prepare:quota_spend",
+        "spend",
+        "checkpoint:quota_spend",
+    ]
+
+
+def test_turn_settlement_passes_stable_effect_refs_to_new_callbacks() -> None:
+    observed_refs: list[str] = []
+
+    result = execute_turn_driver_settlement(
+        TRANSACTION,
+        transaction_phases=PHASES,
+        completed_phases=PHASES[:3],
+        writeback_payload=None,
+        quota_spend_payload=None,
+        writeback=lambda effect_ref: (
+            observed_refs.append(effect_ref) or {"ok": True, "appended": True}
+        ),
+        spend=lambda *, effect_ref: (
+            observed_refs.append(effect_ref) or {"ok": True, "appended": True}
+        ),
+        checkpoint=lambda _step, _payload, _phases: None,
+        prepare=lambda _step, _effect_ref: None,
+    )
+
+    assert result.failure is None
+    assert observed_refs == [
+        f"{IDENTITY.effect_id}#durable_writeback",
+        f"{IDENTITY.effect_id}#quota_spend",
+    ]
+
+
+def test_turn_settlement_checkpoints_committed_readback_without_reexecution() -> None:
+    effect_ref = f"{IDENTITY.effect_id}#durable_writeback"
+    events: list[str] = []
+
+    result = execute_turn_driver_settlement(
+        TRANSACTION,
+        transaction_phases=PHASES,
+        completed_phases=PHASES[:3],
+        writeback_payload=None,
+        quota_spend_payload=None,
+        writeback=lambda: pytest.fail("committed effect must not execute again"),
+        spend=lambda: {"ok": True, "appended": True},
+        checkpoint=lambda step, _payload, _phases: events.append(
+            f"checkpoint:{step.value}"
+        ),
+        prepare=lambda step, _effect_ref: events.append(f"prepare:{step.value}"),
+        effect_attempts={
+            "durable_writeback": {"status": "prepared", "effect_ref": effect_ref}
+        },
+        effect_resolvers={
+            SettlementStepKind.DURABLE_WRITEBACK: lambda observed_ref: {
+                "kind": "committed",
+                "payload": {
+                    "ok": True,
+                    "appended": True,
+                    "effect_ref": observed_ref,
+                },
+            }
+        },
+    )
+
+    assert result.failure is None
+    assert events == [
+        "checkpoint:durable_writeback",
+        "prepare:quota_spend",
+        "checkpoint:quota_spend",
+    ]
+
+
+def test_turn_settlement_reexecutes_absent_readback_with_the_same_ref() -> None:
+    effect_ref = f"{IDENTITY.effect_id}#durable_writeback"
+    observed_refs: list[str] = []
+
+    result = execute_turn_driver_settlement(
+        TRANSACTION,
+        transaction_phases=PHASES,
+        completed_phases=PHASES[:3],
+        writeback_payload=None,
+        quota_spend_payload=None,
+        writeback=lambda observed_ref: (
+            observed_refs.append(observed_ref) or {"ok": True, "appended": True}
+        ),
+        spend=lambda: {"ok": True, "appended": True},
+        checkpoint=lambda _step, _payload, _phases: None,
+        prepare=lambda _step, _effect_ref: None,
+        effect_attempts={
+            "durable_writeback": {"status": "prepared", "effect_ref": effect_ref}
+        },
+        effect_resolvers={
+            SettlementStepKind.DURABLE_WRITEBACK: lambda _effect_ref: {"kind": "absent"}
+        },
+    )
+
+    assert result.failure is None
+    assert observed_refs == [effect_ref]
+
+
+@pytest.mark.parametrize(
+    "resolver",
+    [
+        None,
+        lambda _effect_ref: {
+            "kind": "unknown",
+            "reason": "provider readback timed out",
+        },
+    ],
+)
+def test_turn_settlement_fails_closed_when_prepared_outcome_is_unknown(
+    resolver,
+) -> None:
+    effect_ref = f"{IDENTITY.effect_id}#durable_writeback"
+    calls = {"writeback": 0}
+    resolvers = (
+        {} if resolver is None else {SettlementStepKind.DURABLE_WRITEBACK: resolver}
+    )
+
+    result = execute_turn_driver_settlement(
+        TRANSACTION,
+        transaction_phases=PHASES,
+        completed_phases=PHASES[:3],
+        writeback_payload=None,
+        quota_spend_payload=None,
+        writeback=lambda: (
+            calls.__setitem__("writeback", calls["writeback"] + 1)
+            or {"ok": True, "appended": True}
+        ),
+        spend=lambda: {"ok": True, "appended": True},
+        checkpoint=lambda _step, _payload, _phases: None,
+        effect_attempts={
+            "durable_writeback": {"status": "prepared", "effect_ref": effect_ref}
+        },
+        effect_resolvers=resolvers,
+    )
+
+    assert result.failure is not None
+    assert result.failure.kind.value == "effect_outcome_unknown"
+    assert result.failure.step_kind is SettlementStepKind.DURABLE_WRITEBACK
+    assert calls["writeback"] == 0

--- a/tests/control_plane_ts/turn_settlement.test.ts
+++ b/tests/control_plane_ts/turn_settlement.test.ts
@@ -38,6 +38,8 @@ function request(
     terminal_closeout_required: false,
     terminal_closeout_payload: null,
     failed_provider_attempt: null,
+    effect_attempts: {},
+    provider_observations: {},
     ...overrides,
   };
 }
@@ -78,10 +80,14 @@ test("preflight authorizes ordered providers without settling early", () => {
   assert.deepEqual(reduced.provider_effects, [
     {
       step_kind: "durable_writeback",
+      action: "prepare_and_execute",
+      effect_ref: `${identity.effect_id}#durable_writeback`,
       completed_phases: [...phases.slice(0, 4)],
     },
     {
       step_kind: "quota_spend",
+      action: "prepare_and_execute",
+      effect_ref: `${identity.effect_id}#quota_spend`,
       completed_phases: [...phases.slice(0, 5)],
     },
   ]);
@@ -161,4 +167,134 @@ test("non-prefix journals fail closed instead of inventing provider work", () =>
     reduced.result.failure?.reason ?? "",
     /ordered transaction prefix/,
   );
+});
+
+test("prepared provider attempts authorize one identity-bound readback", () => {
+  const effectRef = `${identity.effect_id}#durable_writeback`;
+  const reduced = reduceTurnSettlementTransaction(
+    request({
+      completed_phases: [...phases.slice(0, 3)],
+      writeback_payload: null,
+      quota_spend_payload: null,
+      effect_attempts: {
+        durable_writeback: { status: "prepared", effect_ref: effectRef },
+      },
+    }),
+  );
+
+  assert.equal(reduced.decision, "execute");
+  assert.deepEqual(reduced.provider_effects, [
+    {
+      step_kind: "durable_writeback",
+      action: "resolve_prepared",
+      effect_ref: effectRef,
+      completed_phases: [...phases.slice(0, 4)],
+      resolution_policy: {
+        committed: "checkpoint",
+        absent: "execute",
+        unknown: "fail_closed",
+      },
+    },
+    {
+      step_kind: "quota_spend",
+      action: "prepare_and_execute",
+      effect_ref: `${identity.effect_id}#quota_spend`,
+      completed_phases: [...phases.slice(0, 5)],
+    },
+  ]);
+});
+
+test("prepared provider attempts reject identity drift before readback", () => {
+  const reduced = reduceTurnSettlementTransaction(
+    request({
+      completed_phases: [...phases.slice(0, 3)],
+      writeback_payload: null,
+      quota_spend_payload: null,
+      effect_attempts: {
+        durable_writeback: {
+          status: "prepared",
+          effect_ref: "another-effect#durable_writeback",
+        },
+      },
+    }),
+  );
+
+  assert.equal(reduced.decision, "failed");
+  assert.equal(reduced.result.failure?.kind, "identity_mismatch");
+  assert.equal(reduced.result.failure?.step_kind, "durable_writeback");
+  assert.deepEqual(reduced.provider_effects, []);
+});
+
+test("unknown prepared provider outcomes fail closed", () => {
+  const effectRef = `${identity.effect_id}#durable_writeback`;
+  const reduced = reduceTurnSettlementTransaction(
+    request({
+      completed_phases: [...phases.slice(0, 3)],
+      writeback_payload: null,
+      quota_spend_payload: null,
+      effect_attempts: {
+        durable_writeback: { status: "prepared", effect_ref: effectRef },
+      },
+      provider_observations: {
+        durable_writeback: {
+          kind: "unknown",
+          payload: null,
+          reason: "provider readback timed out",
+        },
+      },
+    }),
+  );
+
+  assert.equal(reduced.decision, "failed");
+  assert.equal(reduced.result.failure?.kind, "effect_outcome_unknown");
+  assert.equal(reduced.result.failure?.step_kind, "durable_writeback");
+  assert.match(reduced.result.failure?.reason ?? "", /readback timed out/);
+  assert.deepEqual(reduced.provider_effects, []);
+});
+
+test("committed readback without a durable payload fails closed", () => {
+  const effectRef = `${identity.effect_id}#durable_writeback`;
+  const reduced = reduceTurnSettlementTransaction(
+    request({
+      completed_phases: [...phases.slice(0, 3)],
+      writeback_payload: null,
+      quota_spend_payload: null,
+      effect_attempts: {
+        durable_writeback: { status: "prepared", effect_ref: effectRef },
+      },
+      provider_observations: {
+        durable_writeback: {
+          kind: "committed",
+          payload: { ok: true, appended: false },
+          reason: null,
+        },
+      },
+    }),
+  );
+
+  assert.equal(reduced.decision, "failed");
+  assert.equal(reduced.result.failure?.kind, "receipt_missing");
+  assert.equal(reduced.result.failure?.step_kind, "durable_writeback");
+  assert.deepEqual(reduced.provider_effects, []);
+});
+
+test("prepared attempts cannot skip an earlier provider step", () => {
+  const reduced = reduceTurnSettlementTransaction(
+    request({
+      completed_phases: [...phases.slice(0, 3)],
+      writeback_payload: null,
+      quota_spend_payload: null,
+      effect_attempts: {
+        quota_spend: {
+          status: "prepared",
+          effect_ref: `${identity.effect_id}#quota_spend`,
+        },
+      },
+    }),
+  );
+
+  assert.equal(reduced.decision, "failed");
+  assert.equal(reduced.result.failure?.kind, "receipt_missing");
+  assert.equal(reduced.result.failure?.step_kind, "quota_spend");
+  assert.deepEqual(reduced.provider_effects, []);
 });

--- a/tests/test_loopx_turn_driver.py
+++ b/tests/test_loopx_turn_driver.py
@@ -1496,6 +1496,135 @@ def test_turn_run_once_cli_projects_durable_no_followup_continuation(
     }
 
 
+@pytest.mark.parametrize(
+    "durable_completion_turn_key",
+    [None, "sha256:different-turn"],
+    ids=["missing-turn-key", "different-turn-key"],
+)
+def test_turn_run_once_cli_terminal_recovery_rejects_unowned_completion(
+    tmp_path: Path,
+    durable_completion_turn_key: str | None,
+) -> None:
+    project, runtime, registry = _write_live_fixture(
+        tmp_path,
+        todo_metadata_extra="no_followup=true",
+    )
+    host_project = tmp_path / "isolated-host-workspace"
+    host_project.mkdir()
+    host_script, validation_script = _completion_host_and_validation_scripts()
+    argv = _turn_run_once_completion_argv(
+        host_project,
+        runtime,
+        registry,
+        host_script,
+        validation_script,
+    )
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(argv)
+    payload = json.loads(output.getvalue())
+    assert exit_code == 0, payload
+
+    turn_key = payload["resume_turn_key"]
+    state_path = (
+        project
+        / ".codex"
+        / "goals"
+        / "loopx-turn-fixture"
+        / "ACTIVE_GOAL_STATE.md"
+    )
+    state = state_path.read_text(encoding="utf-8")
+    current_turn_field = f" completion_turn_key={turn_key}"
+    assert current_turn_field in state
+    replacement = (
+        ""
+        if durable_completion_turn_key is None
+        else f" completion_turn_key={durable_completion_turn_key}"
+    )
+    state_path.write_text(
+        state.replace(current_turn_field, replacement),
+        encoding="utf-8",
+    )
+
+    event_path = (
+        runtime / "goals" / "loopx-turn-fixture" / "rollout-event-log.jsonl"
+    )
+    events = [
+        json.loads(line)
+        for line in event_path.read_text(encoding="utf-8").splitlines()
+    ]
+    events_without_terminal = [
+        event
+        for event in events
+        if not (
+            event.get("event_kind") == "todo_complete"
+            and event.get("run_id") == turn_key
+        )
+    ]
+    assert len(events_without_terminal) == len(events) - 1
+    event_path.write_text(
+        "".join(json.dumps(event) + "\n" for event in events_without_terminal),
+        encoding="utf-8",
+    )
+
+    journal_path = next(
+        (runtime / "goals" / "loopx-turn-fixture" / "turns").glob("*.json")
+    )
+    journal = json.loads(journal_path.read_text(encoding="utf-8"))
+    identity = journal["plan"]["transaction"]["settlement_plan"]["identity"]
+    journal["status"] = "in_progress"
+    journal["completed_phases"] = [
+        "host_execute",
+        "typed_result",
+        "validation",
+        "durable_writeback",
+        "quota_spend",
+    ]
+    journal["effect_attempts"] = {
+        "terminal_closeout": {
+            "status": "prepared",
+            "effect_ref": f"{identity['effect_id']}#terminal_closeout",
+        }
+    }
+    for key in (
+        "terminal_closeout",
+        "settlement_result",
+        "scheduler",
+        "receipt",
+        "reason",
+    ):
+        journal.pop(key, None)
+    journal_path.write_text(json.dumps(journal), encoding="utf-8")
+
+    resumed_output = io.StringIO()
+    with contextlib.redirect_stdout(resumed_output):
+        resumed_exit_code = cli_main(
+            [
+                *argv[:-1],
+                "--resume-turn-key",
+                turn_key,
+                "--execute",
+            ]
+        )
+    resumed = json.loads(resumed_output.getvalue())
+
+    assert resumed_exit_code == 1, resumed
+    assert resumed["settlement_result"]["failure"] == {
+        "kind": "effect_outcome_unknown",
+        "step_kind": "terminal_closeout",
+        "reason": "closeout readback failed",
+    }
+    recovered_events = [
+        json.loads(line)
+        for line in event_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert not any(
+        event.get("event_kind") == "todo_complete"
+        and event.get("run_id") == turn_key
+        for event in recovered_events
+    )
+
+
 def test_turn_run_once_cli_fails_closed_on_dangling_declared_successor(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_loopx_turn_driver.py
+++ b/tests/test_loopx_turn_driver.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+import loopx.cli_commands.turn as turn_command
 from loopx.cli import main as cli_main
 from loopx.control_plane.quota.turn_envelope import build_turn_envelope
 from loopx.control_plane.turn_driver import (
@@ -1426,6 +1427,106 @@ def _turn_journal(runtime: Path) -> dict[str, object]:
         (runtime / "goals" / "loopx-turn-fixture" / "turns").glob("*.json")
     )
     return json.loads(journal_path.read_text(encoding="utf-8"))
+
+
+def test_turn_run_once_cli_repairs_committed_quota_spend_after_receipt_crash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project, runtime, registry = _write_live_fixture(tmp_path)
+    host_project = tmp_path / "isolated-host-workspace"
+    host_project.mkdir()
+    host_script, validation_script = _completion_host_and_validation_scripts()
+    argv = _turn_run_once_completion_argv(
+        host_project,
+        runtime,
+        registry,
+        host_script,
+        validation_script,
+    )
+    append_rollout_event = turn_command.append_cli_rollout_event
+
+    def crash_before_quota_receipt(
+        payload: dict[str, object],
+        **kwargs: object,
+    ) -> dict[str, object]:
+        if kwargs.get("event_kind") == "quota_spend":
+            raise OSError("injected crash before quota receipt")
+        return append_rollout_event(payload, **kwargs)
+
+    monkeypatch.setattr(
+        turn_command,
+        "append_cli_rollout_event",
+        crash_before_quota_receipt,
+    )
+    first_output = io.StringIO()
+    with contextlib.redirect_stdout(first_output):
+        first_exit_code = cli_main(argv)
+    first = json.loads(first_output.getvalue())
+
+    assert first_exit_code == 1, first
+    assert first["error"] == "injected crash before quota receipt"
+    interrupted = _turn_journal(runtime)
+    turn_key = interrupted["turn_key"]
+    effect_id = interrupted["plan"]["transaction"]["settlement_plan"][
+        "identity"
+    ]["effect_id"]
+    assert interrupted["effect_attempts"] == {
+        "quota_spend": {
+            "status": "prepared",
+            "effect_ref": f"{effect_id}#quota_spend",
+        }
+    }
+    index_path = runtime / "goals" / "loopx-turn-fixture" / "runs" / "index.jsonl"
+    rows = [
+        json.loads(line)
+        for line in index_path.read_text(encoding="utf-8").splitlines()
+    ]
+    quota_rows = [row for row in rows if row.get("classification") == "quota_slot_spent"]
+    assert len(quota_rows) == 1
+    assert quota_rows[0]["effect_ref"] == f"{effect_id}#quota_spend"
+    assert quota_rows[0]["agent_id"] == "codex-fixture"
+
+    monkeypatch.setattr(
+        turn_command,
+        "append_cli_rollout_event",
+        append_rollout_event,
+    )
+    resumed_output = io.StringIO()
+    with contextlib.redirect_stdout(resumed_output):
+        resumed_exit_code = cli_main(
+            [
+                *argv[:-1],
+                "--resume-turn-key",
+                turn_key,
+                "--execute",
+            ]
+        )
+    resumed = json.loads(resumed_output.getvalue())
+
+    assert resumed_exit_code == 0, resumed
+    assert resumed["status"] == "committed"
+    replayed_rows = [
+        json.loads(line)
+        for line in index_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert sum(
+        row.get("classification") == "quota_slot_spent"
+        for row in replayed_rows
+    ) == 1
+    events_path = (
+        runtime / "goals" / "loopx-turn-fixture" / "rollout-event-log.jsonl"
+    )
+    events = [
+        json.loads(line)
+        for line in events_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert any(
+        event.get("event_kind") == "quota_spend"
+        and event.get("run_id") == turn_key
+        and event.get("status") == "receipt_repaired"
+        for event in events
+    )
 
 
 def test_turn_run_once_cli_projects_declared_successor_continuation(

--- a/tests/test_loopx_turn_executor.py
+++ b/tests/test_loopx_turn_executor.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from loopx.control_plane.turn_driver import executor as turn_executor
 from loopx.control_plane.turn_driver import (
     LOOPX_TURN_RESULT_SCHEMA_VERSION,
     build_loopx_turn_plan,
@@ -241,9 +242,13 @@ def _callbacks(calls: dict[str, int]):
 
 
 def _journal(runtime_root: Path) -> dict[str, object]:
-    journal_paths = list(
-        (runtime_root / "goals" / "fixture-goal" / "turns").glob("*.json")
-    )
+    journal_paths = [
+        path
+        for path in (runtime_root / "goals" / "fixture-goal" / "turns").glob(
+            "*.json"
+        )
+        if not path.name.endswith(".lock.holder.json")
+    ]
     assert len(journal_paths) == 1
     return json.loads(journal_paths[0].read_text(encoding="utf-8"))
 
@@ -486,6 +491,53 @@ def test_run_once_commits_once_and_replays_without_duplicate_effects(tmp_path: P
     assert not any(replay["effects"].values())
     assert count_path.read_text(encoding="utf-8") == "1"
     assert calls == {"writeback": 1, "spend": 1, "scheduler": 1}
+
+
+def test_provider_can_commit_before_its_journal_checkpoint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = _plan()
+    calls = {"writeback": 0, "spend": 0, "scheduler": 0}
+    writeback, spend, scheduler = _callbacks(calls)
+    write_journal = turn_executor._write_journal
+
+    def fail_before_writeback_checkpoint(
+        path: Path,
+        journal: Mapping[str, object],
+    ) -> None:
+        if "writeback" in journal and "quota_spend" not in journal:
+            raise RuntimeError("injected crash before writeback checkpoint")
+        write_journal(path, journal)
+
+    monkeypatch.setattr(
+        turn_executor,
+        "_write_journal",
+        fail_before_writeback_checkpoint,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="injected crash before writeback checkpoint",
+    ):
+        run_loopx_turn_once(
+            plan,
+            host_runner=lambda _request: _host_result(plan),
+            project=tmp_path,
+            runtime_root=tmp_path / "runtime",
+            goal_id="fixture-goal",
+            timeout_seconds=5,
+            execute=True,
+            task_validator=_passing_validator,
+            writeback=writeback,
+            spend=spend,
+            scheduler=scheduler,
+        )
+
+    journal = _journal(tmp_path / "runtime")
+    assert calls == {"writeback": 1, "spend": 0, "scheduler": 0}
+    assert journal["completed_phases"] == list(TRANSACTION_PHASES[:3])
+    assert "writeback" not in journal
 
 
 def test_run_once_legacy_plan_without_settlement_plan_is_upgraded(

--- a/tests/test_loopx_turn_executor.py
+++ b/tests/test_loopx_turn_executor.py
@@ -42,7 +42,11 @@ def _plan() -> dict[str, object]:
                     "text": "Advance one public fixture",
                 },
             },
-            "user": {"action_required": False, "open_count": 0, "notify": "DONT_NOTIFY"},
+            "user": {
+                "action_required": False,
+                "open_count": 0,
+                "notify": "DONT_NOTIFY",
+            },
             "writeback": {"spend_after_validation": True},
             "scheduler": {"action": "run_now"},
             "action_signature": {
@@ -85,7 +89,9 @@ def _adaptive_plan() -> dict[str, object]:
     )
 
 
-def _host_result(plan: dict[str, object], *, kind: str = "validated_progress") -> dict[str, object]:
+def _host_result(
+    plan: dict[str, object], *, kind: str = "validated_progress"
+) -> dict[str, object]:
     transaction = plan["transaction"]
     assert isinstance(transaction, dict)
     result: dict[str, object] = {
@@ -150,7 +156,9 @@ def test_task_validation_stage_reads_result_kind_through_effect_turn(
     assert payload["status"] == "stopped"
 
 
-def test_typed_settlement_fails_closed_when_journal_receipt_payload_is_missing() -> None:
+def test_typed_settlement_fails_closed_when_journal_receipt_payload_is_missing() -> (
+    None
+):
     transaction = _plan()["transaction"]
     assert isinstance(transaction, dict)
     calls = {"writeback": 0, "spend": 0, "checkpoint": 0}
@@ -161,10 +169,14 @@ def test_typed_settlement_fails_closed_when_journal_receipt_payload_is_missing()
         completed_phases=TRANSACTION_PHASES[:4],
         writeback_payload=None,
         quota_spend_payload=None,
-        writeback=lambda: calls.__setitem__("writeback", calls["writeback"] + 1)
-        or {"ok": True, "appended": True},
-        spend=lambda: calls.__setitem__("spend", calls["spend"] + 1)
-        or {"ok": True, "appended": True},
+        writeback=lambda: (
+            calls.__setitem__("writeback", calls["writeback"] + 1)
+            or {"ok": True, "appended": True}
+        ),
+        spend=lambda: (
+            calls.__setitem__("spend", calls["spend"] + 1)
+            or {"ok": True, "appended": True}
+        ),
         checkpoint=lambda _kind, _payload, _phases: calls.__setitem__(
             "checkpoint", calls["checkpoint"] + 1
         ),
@@ -181,9 +193,7 @@ def test_typed_settlement_fails_closed_when_plan_has_no_settlement_plan() -> Non
     transaction = _plan()["transaction"]
     assert isinstance(transaction, dict)
     legacy = {
-        key: value
-        for key, value in transaction.items()
-        if key != "settlement_plan"
+        key: value for key, value in transaction.items() if key != "settlement_plan"
     }
     calls = {"writeback": 0, "spend": 0, "checkpoint": 0}
 
@@ -193,10 +203,14 @@ def test_typed_settlement_fails_closed_when_plan_has_no_settlement_plan() -> Non
         completed_phases=TRANSACTION_PHASES[:3],
         writeback_payload=None,
         quota_spend_payload=None,
-        writeback=lambda: calls.__setitem__("writeback", calls["writeback"] + 1)
-        or {"ok": True, "appended": True},
-        spend=lambda: calls.__setitem__("spend", calls["spend"] + 1)
-        or {"ok": True, "appended": True},
+        writeback=lambda: (
+            calls.__setitem__("writeback", calls["writeback"] + 1)
+            or {"ok": True, "appended": True}
+        ),
+        spend=lambda: (
+            calls.__setitem__("spend", calls["spend"] + 1)
+            or {"ok": True, "appended": True}
+        ),
         checkpoint=lambda _kind, _payload, _phases: calls.__setitem__(
             "checkpoint", calls["checkpoint"] + 1
         ),
@@ -244,9 +258,7 @@ def _callbacks(calls: dict[str, int]):
 def _journal(runtime_root: Path) -> dict[str, object]:
     journal_paths = [
         path
-        for path in (runtime_root / "goals" / "fixture-goal" / "turns").glob(
-            "*.json"
-        )
+        for path in (runtime_root / "goals" / "fixture-goal" / "turns").glob("*.json")
         if not path.name.endswith(".lock.holder.json")
     ]
     assert len(journal_paths) == 1
@@ -324,7 +336,9 @@ def test_run_once_rejects_oversized_built_in_host_result(tmp_path: Path) -> None
     assert calls == {"writeback": 0, "spend": 0, "scheduler": 0}
 
 
-def test_run_once_explicitly_retries_failed_host_without_duplicate_effects(tmp_path: Path) -> None:
+def test_run_once_explicitly_retries_failed_host_without_duplicate_effects(
+    tmp_path: Path,
+) -> None:
     plan = _plan()
     calls = {"host": 0, "writeback": 0, "spend": 0, "scheduler": 0}
     writeback, spend, scheduler = _callbacks(calls)
@@ -454,7 +468,9 @@ def test_run_once_recoverable_failed_turn_rejects_session_identity_drift(
     assert calls == {"host": 1, "writeback": 0, "spend": 0, "scheduler": 0}
 
 
-def test_run_once_commits_once_and_replays_without_duplicate_effects(tmp_path: Path) -> None:
+def test_run_once_commits_once_and_replays_without_duplicate_effects(
+    tmp_path: Path,
+) -> None:
     plan = _plan()
     result_path = tmp_path / "result.json"
     result_path.write_text(json.dumps(_host_result(plan)), encoding="utf-8")
@@ -481,8 +497,7 @@ def test_run_once_commits_once_and_replays_without_duplicate_effects(tmp_path: P
     assert first["status"] == "committed"
     assert first["receipt"]["status"] == "committed"
     assert [
-        receipt["step_kind"]
-        for receipt in first["settlement_result"]["receipts"]
+        receipt["step_kind"] for receipt in first["settlement_result"]["receipts"]
     ] == ["validation", "durable_writeback", "quota_spend"]
     assert first["effects"]["host_invoked"] is True
     assert first["effects"]["state_written"] is True
@@ -499,7 +514,15 @@ def test_provider_can_commit_before_its_journal_checkpoint(
 ) -> None:
     plan = _plan()
     calls = {"writeback": 0, "spend": 0, "scheduler": 0}
-    writeback, spend, scheduler = _callbacks(calls)
+    _writeback, spend, scheduler = _callbacks(calls)
+    provider_records: dict[str, dict[str, object]] = {}
+
+    def writeback(_result: dict[str, object], effect_ref: str) -> dict[str, object]:
+        calls["writeback"] += 1
+        payload = {"ok": True, "appended": True, "effect_ref": effect_ref}
+        provider_records[effect_ref] = payload
+        return payload
+
     write_journal = turn_executor._write_journal
 
     def fail_before_writeback_checkpoint(
@@ -538,6 +561,32 @@ def test_provider_can_commit_before_its_journal_checkpoint(
     assert calls == {"writeback": 1, "spend": 0, "scheduler": 0}
     assert journal["completed_phases"] == list(TRANSACTION_PHASES[:3])
     assert "writeback" not in journal
+    prepared = journal["effect_attempts"]["durable_writeback"]
+    assert prepared["status"] == "prepared"
+    assert prepared["effect_ref"] in provider_records
+
+    monkeypatch.setattr(turn_executor, "_write_journal", write_journal)
+    resumed = run_loopx_turn_once(
+        plan,
+        host_runner=lambda _request: pytest.fail("host must not run during recovery"),
+        project=tmp_path,
+        runtime_root=tmp_path / "runtime",
+        goal_id="fixture-goal",
+        timeout_seconds=5,
+        execute=True,
+        task_validator=_passing_validator,
+        writeback=writeback,
+        writeback_resolver=lambda effect_ref: {
+            "kind": "committed",
+            "payload": provider_records[effect_ref],
+        },
+        spend=spend,
+        scheduler=scheduler,
+    )
+
+    assert resumed["status"] == "committed"
+    assert calls == {"writeback": 1, "spend": 1, "scheduler": 1}
+    assert "effect_attempts" not in _journal(tmp_path / "runtime")
 
 
 def test_run_once_legacy_plan_without_settlement_plan_is_upgraded(
@@ -571,13 +620,9 @@ def test_run_once_legacy_plan_without_settlement_plan_is_upgraded(
     assert committed["status"] == "committed"
     assert committed["receipt"]["status"] == "committed"
     assert committed["settlement_result"]["ok"] is True
-    assert (
-        [
-            receipt["step_kind"]
-            for receipt in committed["settlement_result"]["receipts"]
-        ]
-        == ["validation", "durable_writeback", "quota_spend"]
-    )
+    assert [
+        receipt["step_kind"] for receipt in committed["settlement_result"]["receipts"]
+    ] == ["validation", "durable_writeback", "quota_spend"]
     assert calls == {"writeback": 1, "spend": 1, "scheduler": 1}
 
 
@@ -627,12 +672,14 @@ def test_adaptive_completion_upgrades_legacy_plan_with_primary_todo_identity(
                 "continuation": "no_followup",
             },
         },
-        spend=lambda: calls.__setitem__("spend", calls["spend"] + 1)
-        or {"ok": True, "appended": True},
-        scheduler=lambda _spend: calls.__setitem__(
-            "scheduler", calls["scheduler"] + 1
-        )
-        or {"completed": True, "acknowledged": True},
+        spend=lambda: (
+            calls.__setitem__("spend", calls["spend"] + 1)
+            or {"ok": True, "appended": True}
+        ),
+        scheduler=lambda _spend: (
+            calls.__setitem__("scheduler", calls["scheduler"] + 1)
+            or {"completed": True, "acknowledged": True}
+        ),
     )
 
     assert committed["status"] == "committed"
@@ -783,12 +830,17 @@ def test_invalid_completion_outcome_fails_closed_without_spending(
                 "continuation": "no_followup",
             },
         },
-        spend=lambda: calls.__setitem__("spend", calls["spend"] + 1) or {
-            "ok": True,
-            "appended": True,
-        },
-        scheduler=lambda _spend: calls.__setitem__("scheduler", calls["scheduler"] + 1)
-        or {"completed": True, "acknowledged": True},
+        spend=lambda: (
+            calls.__setitem__("spend", calls["spend"] + 1)
+            or {
+                "ok": True,
+                "appended": True,
+            }
+        ),
+        scheduler=lambda _spend: (
+            calls.__setitem__("scheduler", calls["scheduler"] + 1)
+            or {"completed": True, "acknowledged": True}
+        ),
     )
 
     assert payload["result_kind"] == "writeback_failed"
@@ -816,8 +868,9 @@ def test_terminal_closeout_runs_only_after_matching_spend_receipt(
         timeout_seconds=5,
         execute=True,
         task_validator=_passing_validator,
-        writeback=lambda _result: events.append("writeback")
-        or {"ok": True, "appended": True},
+        writeback=lambda _result: (
+            events.append("writeback") or {"ok": True, "appended": True}
+        ),
         completion_writeback=lambda _result: pytest.fail(
             "terminal completion must not use the pre-spend lifecycle callback"
         ),
@@ -825,26 +878,27 @@ def test_terminal_closeout_runs_only_after_matching_spend_receipt(
             "todo_id": "todo_fixture0001",
             "continuation": "no_followup",
         },
-        spend=lambda: events.append("spend")
-        or {"ok": True, "appended": True},
-        terminal_closeout=lambda _result: events.append("terminal_closeout")
-        or {
-            "ok": True,
-            "appended": True,
-            "completion": {
-                "todo_id": "todo_fixture0001",
-                "continuation": "no_followup",
-            },
-        },
-        scheduler=lambda _spend: events.append("scheduler")
-        or {"completed": True, "acknowledged": True},
+        spend=lambda: events.append("spend") or {"ok": True, "appended": True},
+        terminal_closeout=lambda _result: (
+            events.append("terminal_closeout")
+            or {
+                "ok": True,
+                "appended": True,
+                "completion": {
+                    "todo_id": "todo_fixture0001",
+                    "continuation": "no_followup",
+                },
+            }
+        ),
+        scheduler=lambda _spend: (
+            events.append("scheduler") or {"completed": True, "acknowledged": True}
+        ),
     )
 
     assert payload["status"] == "committed"
     assert events == ["writeback", "spend", "terminal_closeout", "scheduler"]
     assert [
-        receipt["step_kind"]
-        for receipt in payload["settlement_result"]["receipts"]
+        receipt["step_kind"] for receipt in payload["settlement_result"]["receipts"]
     ] == ["validation", "durable_writeback", "quota_spend", "terminal_closeout"]
     assert payload["todo_completion"] == {
         "todo_id": "todo_fixture0001",
@@ -896,10 +950,10 @@ def test_terminal_closeout_lost_receipt_retries_without_repeating_effects(
         "timeout_seconds": 5,
         "execute": True,
         "task_validator": _passing_validator,
-        "writeback": lambda _result: calls.__setitem__(
-            "writeback", calls["writeback"] + 1
-        )
-        or {"ok": True, "appended": True},
+        "writeback": lambda _result: (
+            calls.__setitem__("writeback", calls["writeback"] + 1)
+            or {"ok": True, "appended": True}
+        ),
         "completion_writeback": lambda _result: pytest.fail(
             "terminal completion must not use the pre-spend lifecycle callback"
         ),
@@ -907,13 +961,15 @@ def test_terminal_closeout_lost_receipt_retries_without_repeating_effects(
             "todo_id": "todo_fixture0001",
             "continuation": "no_followup",
         },
-        "spend": lambda: calls.__setitem__("spend", calls["spend"] + 1)
-        or {"ok": True, "appended": True},
+        "spend": lambda: (
+            calls.__setitem__("spend", calls["spend"] + 1)
+            or {"ok": True, "appended": True}
+        ),
         "terminal_closeout": terminal_closeout,
-        "scheduler": lambda _spend: calls.__setitem__(
-            "scheduler", calls["scheduler"] + 1
-        )
-        or {"completed": True, "acknowledged": True},
+        "scheduler": lambda _spend: (
+            calls.__setitem__("scheduler", calls["scheduler"] + 1)
+            or {"completed": True, "acknowledged": True}
+        ),
     }
 
     failed = run_loopx_turn_once(plan, **common)
@@ -994,6 +1050,7 @@ def test_validated_completion_recovers_after_writeback_without_repeating_complet
     recovered = run_loopx_turn_once(
         plan,
         spend=healthy_spend,
+        spend_resolver=lambda _effect_ref: {"kind": "absent"},
         **common,
     )
 
@@ -1035,14 +1092,21 @@ def test_run_once_recovers_after_process_exit_before_writeback(tmp_path: Path) -
     assert interrupted["task_validation"]["status"] == "passed"
     assert "writeback" not in interrupted
 
-    recovered = run_loopx_turn_once(plan, writeback=healthy_writeback, **common)
+    recovered = run_loopx_turn_once(
+        plan,
+        writeback=healthy_writeback,
+        writeback_resolver=lambda _effect_ref: {"kind": "absent"},
+        **common,
+    )
 
     assert recovered["status"] == "committed"
     assert count_path.read_text(encoding="utf-8") == "1"
     assert calls == {"writeback": 1, "spend": 1, "scheduler": 1}
 
 
-def test_run_once_resumes_after_writeback_without_duplicate_effects(tmp_path: Path) -> None:
+def test_run_once_resumes_after_writeback_without_duplicate_effects(
+    tmp_path: Path,
+) -> None:
     plan = _plan()
     result_path = tmp_path / "result.json"
     result_path.write_text(json.dumps(_host_result(plan)), encoding="utf-8")
@@ -1084,7 +1148,12 @@ def test_run_once_resumes_after_writeback_without_duplicate_effects(tmp_path: Pa
         goal_id="fixture-goal",
         turn_key=str(transaction["turn_key"]),
     )
-    recovered = run_loopx_turn_once(resumed_plan, spend=healthy_spend, **common)
+    recovered = run_loopx_turn_once(
+        resumed_plan,
+        spend=healthy_spend,
+        spend_resolver=lambda _effect_ref: {"kind": "absent"},
+        **common,
+    )
 
     assert recovered["status"] == "committed"
     assert count_path.read_text(encoding="utf-8") == "1"
@@ -1113,8 +1182,10 @@ def test_cancellation_before_writeback_preserves_prefix_and_resumes(
         "timeout_seconds": 5,
         "execute": True,
         "task_validator": _passing_validator,
-        "spend": lambda: calls.__setitem__("spend", calls["spend"] + 1)
-        or {"ok": True, "appended": True},
+        "spend": lambda: (
+            calls.__setitem__("spend", calls["spend"] + 1)
+            or {"ok": True, "appended": True}
+        ),
         "scheduler": lambda _spend: {"completed": True, "acknowledged": True},
     }
     with pytest.raises(KeyboardInterrupt):
@@ -1127,10 +1198,11 @@ def test_cancellation_before_writeback_preserves_prefix_and_resumes(
     ]
     recovered = run_loopx_turn_once(
         plan,
-        writeback=lambda _result: calls.__setitem__(
-            "writeback", calls["writeback"] + 1
-        )
-        or {"ok": True, "appended": True},
+        writeback=lambda _result: (
+            calls.__setitem__("writeback", calls["writeback"] + 1)
+            or {"ok": True, "appended": True}
+        ),
+        writeback_resolver=lambda _effect_ref: {"kind": "absent"},
         **common,
     )
 
@@ -1217,12 +1289,14 @@ def test_permission_denial_from_host_is_typed_and_explicitly_retried(
         "timeout_seconds": 5,
         "execute": True,
         "task_validator": _passing_validator,
-        "writeback": lambda _result: calls.__setitem__(
-            "writeback", calls["writeback"] + 1
-        )
-        or {"ok": True, "appended": True},
-        "spend": lambda: calls.__setitem__("spend", calls["spend"] + 1)
-        or {"ok": True, "appended": True},
+        "writeback": lambda _result: (
+            calls.__setitem__("writeback", calls["writeback"] + 1)
+            or {"ok": True, "appended": True}
+        ),
+        "spend": lambda: (
+            calls.__setitem__("spend", calls["spend"] + 1)
+            or {"ok": True, "appended": True}
+        ),
         "scheduler": lambda _spend: {"completed": True, "acknowledged": True},
     }
     failed = run_loopx_turn_once(plan, **common)
@@ -1277,8 +1351,11 @@ def test_permission_denial_during_spend_preserves_writeback_and_resumes(
     ]
     recovered = run_loopx_turn_once(
         plan,
-        spend=lambda: calls.__setitem__("spend", calls["spend"] + 1)
-        or {"ok": True, "appended": True},
+        spend=lambda: (
+            calls.__setitem__("spend", calls["spend"] + 1)
+            or {"ok": True, "appended": True}
+        ),
+        spend_resolver=lambda _effect_ref: {"kind": "absent"},
         **common,
     )
 
@@ -1326,16 +1403,17 @@ def test_budget_rejection_is_typed_and_retry_does_not_repeat_writeback(
     assert failed["receipt"]["failed_phase"] == "quota_spend"
     assert failed["settlement_result"]["failure"]["kind"] == "budget_rejected"
     assert [
-        receipt["step_kind"]
-        for receipt in failed["settlement_result"]["receipts"]
+        receipt["step_kind"] for receipt in failed["settlement_result"]["receipts"]
     ] == ["validation", "durable_writeback"]
     assert failed["effects"]["state_written"] is True
     assert failed["effects"]["quota_spent"] is False
 
     recovered = run_loopx_turn_once(
         plan,
-        spend=lambda: calls.__setitem__("spend", calls["spend"] + 1)
-        or {"ok": True, "appended": True},
+        spend=lambda: (
+            calls.__setitem__("spend", calls["spend"] + 1)
+            or {"ok": True, "appended": True}
+        ),
         retry_failed=True,
         **common,
     )
@@ -1456,7 +1534,9 @@ def test_material_result_cannot_use_not_required_validation_receipt(
 def test_run_once_stops_without_writeback_or_spend(tmp_path: Path) -> None:
     plan = _plan()
     result_path = tmp_path / "result.json"
-    result_path.write_text(json.dumps(_host_result(plan, kind="wait")), encoding="utf-8")
+    result_path.write_text(
+        json.dumps(_host_result(plan, kind="wait")), encoding="utf-8"
+    )
     calls = {"writeback": 0, "spend": 0, "scheduler": 0}
     writeback, spend, scheduler = _callbacks(calls)
 
@@ -1488,7 +1568,11 @@ def test_run_once_projects_scheduler_action_without_false_ack(tmp_path: Path) ->
 
     def scheduler(_spend: dict[str, object]) -> dict[str, object]:
         calls["scheduler"] += 1
-        return {"completed": False, "apply_needed": True, "disposition": "host_action_required"}
+        return {
+            "completed": False,
+            "apply_needed": True,
+            "disposition": "host_action_required",
+        }
 
     payload = run_loopx_turn_once(
         plan,


### PR DESCRIPTION
## Summary

- Characterize the crash window where an external settlement provider commits before LoopX persists the corresponding journal checkpoint.
- Persist an identity-bound `prepared` effect attempt before invoking each external provider.
- Recover prepared effects through a TypeScript-owned tri-state protocol:
  - `committed`: checkpoint the observed receipt without executing again;
  - `absent`: execute again with the same stable `effect_ref`;
  - `unknown`: fail closed to prevent duplicate external effects.
- Validate settlement identity and ordered receipt-prefix invariants before recovery.
- Preserve compatibility with legacy zero-argument callbacks while allowing new callbacks to receive `effect_ref`.

## Issue Or Task

- Follow-up to #3412 and the maintainer request to move settlement transaction semantics into TypeScript.
- Contributor task ID: N/A

## Commit Structure

1. `test(turn): characterize ambiguous provider checkpoint recovery`
   - Adds the fault-injection contract covering a provider commit followed by a crash before journal checkpointing.

2. `fix(turn): recover prepared settlement effects safely`
   - Implements durable prepared attempts, stable effect references, tri-state provider readback, and fail-closed recovery.

## Recovery Semantics

For every external settlement effect, LoopX now follows this sequence:

1. Derive a stable effect reference from the settlement identity and step.
2. Persist the effect attempt as `prepared`.
3. Invoke the provider with that effect reference.
4. Atomically checkpoint the provider receipt and clear the prepared attempt.

When recovery finds a prepared attempt:

- a committed provider observation is checkpointed without re-execution;
- an absent observation is re-executed with the original effect reference;
- a missing or uncertain observation fails closed.

This closes the ambiguous crash window without treating an unknown external outcome as safe to retry.

## Validation

- [x] `python -m pytest -q tests/control_plane/test_settlement_driver.py tests/test_loopx_turn_executor.py::test_provider_can_commit_before_its_journal_checkpoint`
  - 9 passed
- [x] `node --no-warnings --experimental-strip-types --test tests/control_plane_ts/turn_settlement.test.ts`
  - 11 passed
- [x] Ruff checks for all changed Python files
- [x] `git diff --check upstream/main...HEAD`
- [ ] Full repository suite
  - Not used as merge evidence because the Windows environment encounters unrelated Unix-only collection and external integration assumptions.
- [ ] `npm run typecheck:control-plane`
  - Could not be rerun in the current sandbox because `node_modules` is unavailable and package-registry access is disabled.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] Test update

## LoopX Area

- [x] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [ ] Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
- [ ] Capability or extension (providers, adapters, skills)
- [ ] Public docs or presentation surface (README, protocols, dashboard)
- [ ] Build, packaging, installer, or CI
- [x] Host or runtime integration

## Technical Direction

- [x] Core control-plane hardening
- [ ] Long-horizon benchmark evidence
- [ ] Operator surface and IM integration
- [ ] Shared Goal Authority and cross-host coordination
- [ ] Architecture and research incubator

- Target base branch: `main`
- Direction tracker or promotion unit: N/A

## Review Structure

This PR keeps the settlement recovery change cohesive while separating it into
two independently reviewable commits:

1. `test(turn): characterize ambiguous provider checkpoint recovery`
   - Adds only the fault-injection contract for the crash window where a
     provider commits before the journal checkpoint is persisted.

2. `fix(turn): recover prepared settlement effects safely`
   - Moves the recovery decision semantics into TypeScript and keeps Python
     responsible for journal persistence and provider transport.
   - Implements stable `effect_ref`, durable prepared attempts, and
     committed/absent/unknown provider readback.

The first commit establishes the behavioral contract; the second implements it.
No unrelated cleanup or speculative extension framework is included.

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).