### PR TITLE
fix(smoke): reconcile public contracts after merges

### DIFF
--- a/examples/capability-extension-registry-smoke.py
+++ b/examples/capability-extension-registry-smoke.py
@@ -75,6 +75,7 @@ next_real_step = "Keep explicit enablement bounded."
         "explore",
         "auto-research",
         "public-safe-outbound",
+        "connector-registry",
     ]
     assert all(item["provider_id"] == "loopx-core" for item in baseline["capabilities"])
     value_summary = next(

--- a/examples/control_plane/agent-identity-readmodel-smoke.py
+++ b/examples/control_plane/agent-identity-readmodel-smoke.py
@@ -20,6 +20,10 @@ from loopx.control_plane.agents.runtime_model import (  # noqa: E402
     peer_work_key,
     select_peer_for_work,
 )
+from loopx.control_plane.quota.error_codes import (  # noqa: E402
+    QuotaIdentityPrecondition,
+    QuotaIdentityPreconditionError,
+)
 
 
 AGENTS = ["codex-alpha", "codex-beta", "codex-reviewer"]
@@ -153,8 +157,14 @@ def assert_assignment_is_deterministic() -> None:
 def assert_errors_are_actionable() -> None:
     try:
         build_quota_agent_identity(peer_goal(), agent_id="codex-missing")
-    except ValueError as exc:
-        assert "registered_agents=" in str(exc), exc
+    except QuotaIdentityPreconditionError as exc:
+        assert (
+            exc.precondition
+            is QuotaIdentityPrecondition.REQUESTED_AGENT_REGISTERED
+        ), exc
+        assert exc.error_code == "quota_agent_not_registered", exc
+        assert exc.agent_id == "codex-missing", exc
+        assert "selected registry" in exc.recommended_action, exc
     else:
         raise AssertionError("unregistered agent should fail")
 

--- a/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
+++ b/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
@@ -575,6 +575,7 @@ def main() -> int:
             "loopx-pr-program",
             "loopx-pr-review",
             "loopx-doc-registry",
+            "loopx-benchmark",
             "loopx-self-repair",
         }, delivery
         assert delivery["delivery_options"] == [

--- a/examples/release/local-install-promotion-boundary-smoke.py
+++ b/examples/release/local-install-promotion-boundary-smoke.py
@@ -82,6 +82,7 @@ def assert_untrusted_checkout_is_canary_only() -> None:
         expected_skill_ids = {
             "loopx",
             "loopx-doc-registry",
+            "loopx-benchmark",
             "loopx-pr-program",
             "loopx-pr-review",
             "loopx-project",

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -242,6 +242,10 @@ COMMAND_GROUPS: list[dict[str, object]] = [
                 "command": "loopx extension",
                 "purpose": "Inspect and manage doctor-verified subprocess extension activations.",
             },
+            {
+                "command": "loopx connector",
+                "purpose": "List, register, rank, and record usage for public connector providers.",
+            },
             {"command": "loopx issue-fix", "purpose": "Build public-safe issue or PR fix workflow packets."},
             {
                 "command": "loopx review-batch",

--- a/man/loopx.1
+++ b/man/loopx.1
@@ -210,6 +210,9 @@ Record the exploration topology (nodes, edges, findings) and project it to a Fei
 \fBloopx extension\fR
 Inspect and manage doctor\-verified subprocess extension activations.
 .TP
+\fBloopx connector\fR
+List, register, rank, and record usage for public connector providers.
+.TP
 \fBloopx issue\-fix\fR
 Build public\-safe issue or PR fix workflow packets.
 .TP


### PR DESCRIPTION
## What

Repair the six Full Public Smokes failures currently reproducible on main by aligning durable contract smokes with three already-shipped changes:

- expose the built-in `connector-registry` in the capability catalog expectation and classify the public `loopx connector` command in the manual;
- assert the typed, bounded `QuotaIdentityPreconditionError` contract instead of the retired roster-bearing prose error;
- include the now-packaged `loopx-benchmark` workflow skill in install and host-onboarding expectations.

This does not weaken the underlying contracts. It updates stale assertions to the typed/public surfaces introduced by #3469, #3470, and #3471.

## Validation

- `examples/capability-extension-registry-smoke.py`: passed
- `examples/cli-help-manpage-smoke.py`: passed
- `examples/release/local-install-promotion-boundary-smoke.py`: passed
- `examples/control_plane/agent-identity-readmodel-smoke.py`: passed
- `examples/control_plane/agent-onboard-host-loop-activation-smoke.py`: passed
- `examples/control_plane/peer-agent-runtime-v1-smoke.py`: passed
- `examples/install-local-smoke.py`: passed standalone in 122s
- focused Ruff `E4,E7,E9,F`: passed
- `git diff --check`: passed
- `loopx canary premerge --from-git-diff`: 17/18 passed; the same `install-local-smoke.py` exceeded the generic 120s canary timeout locally, then passed unchanged with a longer standalone allowance
- public/private scan: no credentials, local paths, raw logs, private state, or generated evidence added

## Future-facing pass

Applied at the touched ownership boundaries: the identity smoke now validates the typed precondition enum and public recovery fields, and the new public connector command is intentionally owned by the generated manual rather than hidden in help-only classification. No broader refactor is needed for this contract-reconciliation change.