### PR TITLE
feat(benchmark): qualify active runtime observations

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -490,6 +490,11 @@ solver-trajectory slice, even when no case became terminal. This readback is for
 campaign supervision and insight discovery only; it must not expose hidden
 evaluator evidence to the solving arm.
 
+This is a provider obligation, not an effect performed by the reducer: the
+runtime-observation command only returns a typed classification and recommended
+transition. The provider remains responsible for the monitor cycle, trajectory
+readback, terminal write, reconciliation, and slot release.
+
 Use this analyst hint:
 
 > After the solver has stopped and scoring is complete, read the task, real

--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -367,12 +367,14 @@ A countable experiment uses the toolkit in this order:
 3. Upsert the planned or running row, then launch one frozen case/arm; do not expose
    evaluator sources or official feedback.
 4. Capture ATIF tool evidence and a runner-owned runtime attestation.
-5. Run `integrity-qualification`; stop on any blocker.
-6. Run the independent verifier only after the agent phase.
-7. Reduce the official result through the benchmark-owned scoring path.
-8. Upsert terminal score, countability, effort, treatment fidelity, and insight
+5. During active monitoring, classify exact-job runtime evidence; do not infer
+   liveness from an occupied admission slot.
+6. Run `integrity-qualification`; stop on any blocker.
+7. Run the independent verifier only after the agent phase.
+8. Reduce the official result through the benchmark-owned scoring path.
+9. Upsert terminal score, countability, effort, treatment fidelity, and insight
    status, then read the matched-comparison projection.
-9. Apply attempt-countability, treatment-fidelity, and matched-pair gates before any
+10. Apply attempt-countability, treatment-fidelity, and matched-pair gates before any
    comparison claim.
 
 Integrity qualification is necessary but not sufficient for a score claim. It does
@@ -462,6 +464,31 @@ solver's trajectory phase. A clean worktree or a high raw log-error count alone 
 not evidence that a run is stuck. The provider-owned classifier may mark a run
 stalled only when committed and uncommitted progress are both absent and either the
 trajectory is stale or typed fatal runner evidence is present.
+
+Admission-ledger occupancy is not process liveness. On each bounded active review,
+the provider should reduce compact facts through:
+
+```bash
+loopx benchmark runtime-observation \
+  --admission-active \
+  --job-receipt-state resolved \
+  --runner-owner-state alive \
+  --require-healthy \
+  --format json
+```
+
+Only a resolved exact-job receipt plus a live exact runner owner is healthy active.
+A terminal result, typed fatal runner error, or exact owner missing after the
+provider's startup grace produces a reconciliation transition; the provider must
+write the terminal classification before releasing its slot. Missing or ambiguous
+runtime authority fails closed. The reducer performs no process discovery, writes,
+or slot release, and its receipt contains no run identity, process arguments, raw
+error, or path.
+
+Every due active-campaign monitor cycle must also advance at least one bounded
+solver-trajectory slice, even when no case became terminal. This readback is for
+campaign supervision and insight discovery only; it must not expose hidden
+evaluator evidence to the solving arm.
 
 Use this analyst hint:
 

--- a/loopx/capabilities/benchmark_toolkit/__init__.py
+++ b/loopx/capabilities/benchmark_toolkit/__init__.py
@@ -36,11 +36,6 @@ from .integrity import (
     REQUIRED_RUNTIME_ATTESTATIONS,
     build_benchmark_integrity_qualification,
 )
-from .reward_contract import (
-    REWARD_CONTRACT_SCHEMA_VERSION,
-    verify_verifier_reward_file,
-    verify_verifier_reward_json,
-)
 from .native_codex_goal import (
     NativeGoalConfig,
     NativeGoalDeadlineExceeded,
@@ -91,6 +86,11 @@ from .public_trajectory import (
     PublicTrajectorySummaryError,
     build_native_goal_public_trajectory_summary,
 )
+from .reward_contract import (
+    REWARD_CONTRACT_SCHEMA_VERSION,
+    verify_verifier_reward_file,
+    verify_verifier_reward_json,
+)
 from .run_permissions import (
     DEFAULT_RUN_PERMISSION_ALLOWED_ACTIONS,
     DEFAULT_RUN_PERMISSION_FORBIDDEN_ACTIONS,
@@ -100,6 +100,14 @@ from .run_permissions import (
     build_run_permission_policy,
     compact_run_permission_policy_for_quota,
     validate_run_permission_policy,
+)
+from .runtime_observation import (
+    BENCHMARK_RUNTIME_OBSERVATION_SCHEMA_VERSION,
+    BenchmarkJobReceiptState,
+    BenchmarkRunnerOwnerState,
+    BenchmarkRuntimeClassification,
+    BenchmarkRuntimeTransition,
+    build_benchmark_runtime_observation,
 )
 from .source_revision_fence import (
     BENCHMARK_SOURCE_REVISION_FENCE_SCHEMA_VERSION,
@@ -118,6 +126,7 @@ __all__ = [
     "BENCHMARK_INTEGRITY_POLICY_SCHEMA_VERSION",
     "BENCHMARK_INTEGRITY_QUALIFICATION_SCHEMA_VERSION",
     "BENCHMARK_RUNTIME_INTEGRITY_ATTESTATION_SCHEMA_VERSION",
+    "BENCHMARK_RUNTIME_OBSERVATION_SCHEMA_VERSION",
     "BENCHMARK_SOURCE_REVISION_FENCE_SCHEMA_VERSION",
     "DEFAULT_RUN_PERMISSION_ALLOWED_ACTIONS",
     "DEFAULT_RUN_PERMISSION_FORBIDDEN_ACTIONS",
@@ -128,8 +137,13 @@ __all__ = [
     "NATIVE_GOAL_LIFECYCLE_SCHEMA_VERSION",
     "PUBLIC_TRAJECTORY_SUMMARY_SCHEMA_VERSION",
     "REQUIRED_RUNTIME_ATTESTATIONS",
+    "REWARD_CONTRACT_SCHEMA_VERSION",
     "RUN_PERMISSION_POLICY_SCHEMA_VERSION",
     "RUN_PERMISSION_QUOTA_PROJECTION_SCHEMA_VERSION",
+    "BenchmarkJobReceiptState",
+    "BenchmarkRunnerOwnerState",
+    "BenchmarkRuntimeClassification",
+    "BenchmarkRuntimeTransition",
     "BenchmarkSourceRevisionFence",
     "BenchmarkSourceRevisionFenceError",
     "DockerContainerBinding",
@@ -156,6 +170,7 @@ __all__ = [
     "build_benchmark_candidate_source_boundary",
     "build_benchmark_experiment_board",
     "build_benchmark_integrity_qualification",
+    "build_benchmark_runtime_observation",
     "build_native_codex_isolation_envelope",
     "build_native_goal_public_trajectory_summary",
     "build_run_permission_policy",
@@ -184,8 +199,6 @@ __all__ = [
     "refresh_native_goal_status",
     "render_benchmark_experiment_board_markdown",
     "render_native_codex_goal_prompt",
-    "verify_verifier_reward_file",
-    "verify_verifier_reward_json",
     "run_native_goal_process",
     "run_native_goal_process_until_terminal",
     "run_native_goal_turn",
@@ -194,5 +207,7 @@ __all__ = [
     "start_native_goal_turn",
     "upsert_benchmark_experiment_board_row",
     "validate_run_permission_policy",
+    "verify_verifier_reward_file",
+    "verify_verifier_reward_json",
     "wait_native_goal_turn",
 ]

--- a/loopx/capabilities/benchmark_toolkit/catalog_entry.py
+++ b/loopx/capabilities/benchmark_toolkit/catalog_entry.py
@@ -68,6 +68,21 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
         },
         {
             "command": (
+                "loopx benchmark runtime-observation --admission-active "
+                "--job-receipt-state resolved --runner-owner-state alive "
+                "--require-healthy --format json"
+            ),
+            "purpose": (
+                "Classify exact-job runtime evidence without treating an active "
+                "admission-ledger row as proof of process liveness."
+            ),
+            "write_boundary": (
+                "read-only compact provider facts; caller owns discovery, startup "
+                "grace, terminal writes, reconciliation, and slot release"
+            ),
+        },
+        {
+            "command": (
                 "loopx benchmark experiment-board-upsert --goal-id <goal-id> "
                 "--row-json <compact-row.json> --execute --format json"
             ),
@@ -137,6 +152,7 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
             "read_experiment_board_before_launch_or_case_selection",
             "qualify_source_revision_before_each_new_run_admission",
             "upsert_preregistered_or_running_row_when_a_run_starts",
+            "classify_exact_runtime_observation_during_active_monitor_cycles",
             "upsert_terminal_score_countability_effort_and_insight_status",
             "read_matched_comparisons_before_selecting_the_next_arm",
         ],
@@ -178,9 +194,11 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
             },
             "text": (
                 "On each material scored-case transition and bounded active-campaign "
-                "review, refresh the public-safe aggregate score and coverage summary, "
-                "report material changes to the user, and after solver termination "
-                "read the complete private evaluation evidence and write one "
+                "review, validate exact-job runtime authority and advance at least one "
+                "bounded solver-trajectory slice even when no case became terminal; "
+                "refresh the public-safe aggregate score and coverage summary, report "
+                "material changes to the user, and after solver termination read the "
+                "complete private evaluation evidence and write one "
                 "benchmark_case_insight_v0."
             ),
         },
@@ -217,9 +235,19 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
                 "current_worktree_status",
             ],
             "runtime_basis": [
+                "active_admission_ledger",
+                "exact_job_runtime_receipt",
+                "exact_runner_owner_liveness_after_startup_grace",
+                "terminal_result_presence",
                 "goal_state_and_event_freshness",
                 "typed_runner_error_category",
             ],
+            "runtime_contract": (
+                "Admission-ledger occupancy is not liveness. A healthy active run "
+                "requires a resolved exact-job receipt and a live exact runner owner; "
+                "terminal or lost-owner observations require provider reconciliation "
+                "before slot release."
+            ),
             "trajectory_basis": (
                 "solver_trajectory_phase_without_hidden_evaluator_feedback"
             ),
@@ -323,6 +351,11 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
             "doc": "loopx/capabilities/benchmark_toolkit/README.md",
         },
         {
+            "schema_version": "benchmark_runtime_observation_v0",
+            "module": "loopx.capabilities.benchmark_toolkit.runtime_observation",
+            "doc": "loopx/capabilities/benchmark_toolkit/README.md",
+        },
+        {
             "schema_version": "benchmark_exact_container_binding_v0",
             "module": "loopx.capabilities.benchmark_toolkit.container_binding",
             "doc": "loopx/capabilities/benchmark_toolkit/README.md",
@@ -352,12 +385,14 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
         "Raw trajectories are private local inputs to integrity qualification and are never copied into receipts, ledgers, docs, or PR artifacts.",
         "A clean trajectory scan is not isolation proof: runner-owned permission and verifier-order attestations are mandatory and fail closed when absent.",
         "Concurrent Docker runs must bind runtime evidence to one exact job-owned container; image-only discovery is not sufficient.",
+        "Admission-ledger occupancy never proves runner liveness; active health requires a resolved exact-job receipt and a live exact runner owner after startup grace.",
         "Integrity qualification establishes countability eligibility only; an independent official result and matched experiment contract are still required.",
         "Post-run analyst access never widens the solving agent's evidence boundary or grants feedback reuse in another scored run.",
         "The experiment board is a compact projection, not a score authority: benchmark-family runners and scoring adapters remain outside the active capability.",
     ],
     "next_real_step": (
-        "Use the board before launch and after each scored case while keeping "
-        "solver integrity separate from private benchmark_case_insight_v0 analysis."
+        "Use the board before launch, classify exact runtime during active monitor "
+        "cycles, and advance one bounded trajectory review even without a terminal "
+        "case while keeping solver integrity separate from private analysis."
     ),
 }

--- a/loopx/capabilities/benchmark_toolkit/catalog_entry.py
+++ b/loopx/capabilities/benchmark_toolkit/catalog_entry.py
@@ -246,7 +246,8 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
                 "Admission-ledger occupancy is not liveness. A healthy active run "
                 "requires a resolved exact-job receipt and a live exact runner owner; "
                 "terminal or lost-owner observations require provider reconciliation "
-                "before slot release."
+                "before slot release. These are provider obligations; the reducer "
+                "classifies facts but performs no monitor, write, or release effect."
             ),
             "trajectory_basis": (
                 "solver_trajectory_phase_without_hidden_evaluator_feedback"

--- a/loopx/capabilities/benchmark_toolkit/runtime_observation.py
+++ b/loopx/capabilities/benchmark_toolkit/runtime_observation.py
@@ -53,6 +53,12 @@ def _coerce_enum(value: str | Enum, enum_type: type[Enum], *, field: str) -> Enu
         raise ValueError(f"invalid_{field}") from exc
 
 
+def _require_bool(value: bool, *, field: str) -> bool:
+    if not isinstance(value, bool):
+        raise TypeError(f"{field}_must_be_boolean")
+    return value
+
+
 def build_benchmark_runtime_observation(
     *,
     admission_active: bool,
@@ -68,6 +74,15 @@ def build_benchmark_runtime_observation(
     run identity, process argument, path, or raw error.
     """
 
+    admitted = _require_bool(admission_active, field="admission_active")
+    terminal = _require_bool(
+        terminal_result_present,
+        field="terminal_result_present",
+    )
+    fatal_error = _require_bool(
+        typed_fatal_runner_error,
+        field="typed_fatal_runner_error",
+    )
     receipt = _coerce_enum(
         job_receipt_state,
         BenchmarkJobReceiptState,
@@ -79,22 +94,22 @@ def build_benchmark_runtime_observation(
         field="runner_owner_state",
     )
 
-    if not admission_active:
+    if not admitted:
         classification = BenchmarkRuntimeClassification.NOT_ADMITTED
         transition = BenchmarkRuntimeTransition.NONE
         reconciliation_required = False
-    elif terminal_result_present:
-        classification = BenchmarkRuntimeClassification.TERMINAL_PENDING_RECONCILE
-        transition = BenchmarkRuntimeTransition.WRITE_TERMINAL_THEN_RELEASE
-        reconciliation_required = True
-    elif typed_fatal_runner_error:
-        classification = BenchmarkRuntimeClassification.RUNNER_INVALID_PENDING_RECONCILE
-        transition = BenchmarkRuntimeTransition.WRITE_RUNNER_INVALID_THEN_RELEASE
-        reconciliation_required = True
     elif receipt is not BenchmarkJobReceiptState.RESOLVED:
         classification = BenchmarkRuntimeClassification.RUNTIME_AUTHORITY_UNRESOLVED
         transition = BenchmarkRuntimeTransition.REPAIR_RUNTIME_AUTHORITY
         reconciliation_required = False
+    elif terminal:
+        classification = BenchmarkRuntimeClassification.TERMINAL_PENDING_RECONCILE
+        transition = BenchmarkRuntimeTransition.WRITE_TERMINAL_THEN_RELEASE
+        reconciliation_required = True
+    elif fatal_error:
+        classification = BenchmarkRuntimeClassification.RUNNER_INVALID_PENDING_RECONCILE
+        transition = BenchmarkRuntimeTransition.WRITE_RUNNER_INVALID_THEN_RELEASE
+        reconciliation_required = True
     elif owner is BenchmarkRunnerOwnerState.ALIVE:
         classification = BenchmarkRuntimeClassification.RUNNING_QUALIFIED
         transition = BenchmarkRuntimeTransition.NONE
@@ -113,11 +128,11 @@ def build_benchmark_runtime_observation(
         "schema_version": BENCHMARK_RUNTIME_OBSERVATION_SCHEMA_VERSION,
         "classification": classification.value,
         "healthy_active": healthy_active,
-        "admission_active": bool(admission_active),
+        "admission_active": admitted,
         "job_receipt_state": receipt.value,
         "runner_owner_state": owner.value,
-        "terminal_result_present": bool(terminal_result_present),
-        "typed_fatal_runner_error": bool(typed_fatal_runner_error),
+        "terminal_result_present": terminal,
+        "typed_fatal_runner_error": fatal_error,
         "ledger_occupancy_sufficient": False,
         "exact_runtime_authority_required": True,
         "reconciliation_required": reconciliation_required,

--- a/loopx/capabilities/benchmark_toolkit/runtime_observation.py
+++ b/loopx/capabilities/benchmark_toolkit/runtime_observation.py
@@ -1,0 +1,132 @@
+"""Compact, provider-neutral runtime observation for benchmark monitors."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+BENCHMARK_RUNTIME_OBSERVATION_SCHEMA_VERSION = "benchmark_runtime_observation_v0"
+
+
+class BenchmarkJobReceiptState(str, Enum):
+    """Whether the provider bound runtime evidence to exactly one admitted job."""
+
+    RESOLVED = "resolved"
+    MISSING = "missing"
+    AMBIGUOUS = "ambiguous"
+
+
+class BenchmarkRunnerOwnerState(str, Enum):
+    """Liveness of the exact runner owner after provider-defined startup grace."""
+
+    ALIVE = "alive"
+    ABSENT_AFTER_GRACE = "absent_after_grace"
+    UNKNOWN = "unknown"
+
+
+class BenchmarkRuntimeClassification(str, Enum):
+    """Public-safe monitor classification for one admitted run."""
+
+    NOT_ADMITTED = "not_admitted"
+    RUNNING_QUALIFIED = "running_qualified"
+    TERMINAL_PENDING_RECONCILE = "terminal_pending_reconcile"
+    RUNNER_INVALID_PENDING_RECONCILE = "runner_invalid_pending_reconcile"
+    RUNTIME_AUTHORITY_UNRESOLVED = "runtime_authority_unresolved"
+    RUNNER_LOST_PENDING_RECONCILE = "runner_lost_pending_reconcile"
+    STARTUP_OR_LIVENESS_UNRESOLVED = "startup_or_liveness_unresolved"
+
+
+class BenchmarkRuntimeTransition(str, Enum):
+    """Provider-owned next transition; this reducer never performs it."""
+
+    NONE = "none"
+    WRITE_TERMINAL_THEN_RELEASE = "write_terminal_then_release"
+    WRITE_RUNNER_INVALID_THEN_RELEASE = "write_runner_invalid_then_release"
+    REPAIR_RUNTIME_AUTHORITY = "repair_runtime_authority"
+    REOBSERVE_AFTER_STARTUP_GRACE = "reobserve_after_startup_grace"
+
+
+def _coerce_enum(value: str | Enum, enum_type: type[Enum], *, field: str) -> Enum:
+    try:
+        return enum_type(value)
+    except ValueError as exc:
+        raise ValueError(f"invalid_{field}") from exc
+
+
+def build_benchmark_runtime_observation(
+    *,
+    admission_active: bool,
+    job_receipt_state: str | BenchmarkJobReceiptState,
+    runner_owner_state: str | BenchmarkRunnerOwnerState,
+    terminal_result_present: bool = False,
+    typed_fatal_runner_error: bool = False,
+) -> dict[str, Any]:
+    """Reduce provider facts without treating the admission ledger as liveness.
+
+    The caller owns process discovery, startup-grace policy, terminal writes, and
+    slot release.  This helper only classifies compact facts and never records a
+    run identity, process argument, path, or raw error.
+    """
+
+    receipt = _coerce_enum(
+        job_receipt_state,
+        BenchmarkJobReceiptState,
+        field="job_receipt_state",
+    )
+    owner = _coerce_enum(
+        runner_owner_state,
+        BenchmarkRunnerOwnerState,
+        field="runner_owner_state",
+    )
+
+    if not admission_active:
+        classification = BenchmarkRuntimeClassification.NOT_ADMITTED
+        transition = BenchmarkRuntimeTransition.NONE
+        reconciliation_required = False
+    elif terminal_result_present:
+        classification = BenchmarkRuntimeClassification.TERMINAL_PENDING_RECONCILE
+        transition = BenchmarkRuntimeTransition.WRITE_TERMINAL_THEN_RELEASE
+        reconciliation_required = True
+    elif typed_fatal_runner_error:
+        classification = BenchmarkRuntimeClassification.RUNNER_INVALID_PENDING_RECONCILE
+        transition = BenchmarkRuntimeTransition.WRITE_RUNNER_INVALID_THEN_RELEASE
+        reconciliation_required = True
+    elif receipt is not BenchmarkJobReceiptState.RESOLVED:
+        classification = BenchmarkRuntimeClassification.RUNTIME_AUTHORITY_UNRESOLVED
+        transition = BenchmarkRuntimeTransition.REPAIR_RUNTIME_AUTHORITY
+        reconciliation_required = False
+    elif owner is BenchmarkRunnerOwnerState.ALIVE:
+        classification = BenchmarkRuntimeClassification.RUNNING_QUALIFIED
+        transition = BenchmarkRuntimeTransition.NONE
+        reconciliation_required = False
+    elif owner is BenchmarkRunnerOwnerState.ABSENT_AFTER_GRACE:
+        classification = BenchmarkRuntimeClassification.RUNNER_LOST_PENDING_RECONCILE
+        transition = BenchmarkRuntimeTransition.WRITE_RUNNER_INVALID_THEN_RELEASE
+        reconciliation_required = True
+    else:
+        classification = BenchmarkRuntimeClassification.STARTUP_OR_LIVENESS_UNRESOLVED
+        transition = BenchmarkRuntimeTransition.REOBSERVE_AFTER_STARTUP_GRACE
+        reconciliation_required = False
+
+    healthy_active = classification is BenchmarkRuntimeClassification.RUNNING_QUALIFIED
+    return {
+        "schema_version": BENCHMARK_RUNTIME_OBSERVATION_SCHEMA_VERSION,
+        "classification": classification.value,
+        "healthy_active": healthy_active,
+        "admission_active": bool(admission_active),
+        "job_receipt_state": receipt.value,
+        "runner_owner_state": owner.value,
+        "terminal_result_present": bool(terminal_result_present),
+        "typed_fatal_runner_error": bool(typed_fatal_runner_error),
+        "ledger_occupancy_sufficient": False,
+        "exact_runtime_authority_required": True,
+        "reconciliation_required": reconciliation_required,
+        "recommended_transition": transition.value,
+        "public_boundary": {
+            "run_identity_recorded": False,
+            "process_arguments_recorded": False,
+            "raw_error_recorded": False,
+            "path_recorded": False,
+        },
+        "write_performed": False,
+    }

--- a/loopx/cli_commands/benchmark_boundary.py
+++ b/loopx/cli_commands/benchmark_boundary.py
@@ -11,9 +11,12 @@ from pathlib import Path
 from ..capabilities.benchmark_toolkit import (
     BENCHMARK_INTEGRITY_QUALIFICATION_SCHEMA_VERSION,
     BENCHMARK_SOURCE_REVISION_FENCE_SCHEMA_VERSION,
+    BenchmarkJobReceiptState,
+    BenchmarkRunnerOwnerState,
     BenchmarkSourceRevisionFenceError,
     build_benchmark_candidate_source_boundary,
     build_benchmark_integrity_qualification,
+    build_benchmark_runtime_observation,
     compact_benchmark_source_revision_fence_receipt,
     filter_public_benchmark_artifact_paths,
     inspect_benchmark_source_revision_fence,
@@ -30,6 +33,7 @@ BENCHMARK_TOOLKIT_COMMANDS = {
     "candidate-source-boundary",
     "classify-artifacts",
     "integrity-qualification",
+    "runtime-observation",
     "source-revision-fence",
     "verify-verifier-reward",
 }
@@ -97,6 +101,17 @@ def _render_source_revision_fence(payload: dict[str, object]) -> str:
     )
 
 
+def _render_runtime_observation(payload: dict[str, object]) -> str:
+    return (
+        "# Benchmark Runtime Observation\n\n"
+        f"- Classification: `{payload.get('classification')}`\n"
+        f"- Healthy active: `{payload.get('healthy_active')}`\n"
+        f"- Reconciliation required: `{payload.get('reconciliation_required')}`\n"
+        f"- Recommended transition: `{payload.get('recommended_transition')}`\n"
+        "- Admission ledger alone proves liveness: `False`\n"
+    )
+
+
 def register_benchmark_boundary_commands(
     benchmark_subparsers: argparse._SubParsersAction,
     add_subcommand_format: Callable[[argparse.ArgumentParser], None],
@@ -127,6 +142,26 @@ def register_benchmark_boundary_commands(
     revision_parser.add_argument("--expected-revision", required=True)
     revision_parser.add_argument("--observed-reference-revision", required=True)
     revision_parser.add_argument("--require-admitted", action="store_true")
+
+    runtime_parser = benchmark_subparsers.add_parser(
+        "runtime-observation",
+        help="Classify exact-job runtime evidence without trusting ledger occupancy.",
+    )
+    add_subcommand_format(runtime_parser)
+    runtime_parser.add_argument("--admission-active", action="store_true")
+    runtime_parser.add_argument(
+        "--job-receipt-state",
+        choices=[item.value for item in BenchmarkJobReceiptState],
+        required=True,
+    )
+    runtime_parser.add_argument(
+        "--runner-owner-state",
+        choices=[item.value for item in BenchmarkRunnerOwnerState],
+        required=True,
+    )
+    runtime_parser.add_argument("--terminal-result-present", action="store_true")
+    runtime_parser.add_argument("--typed-fatal-runner-error", action="store_true")
+    runtime_parser.add_argument("--require-healthy", action="store_true")
 
     integrity_parser = benchmark_subparsers.add_parser(
         "integrity-qualification",
@@ -230,6 +265,17 @@ def handle_benchmark_boundary_command(
             payload = _invalid_source_revision_fence_input()
         print_payload(payload, output_format(args), _render_source_revision_fence)
         return 1 if args.require_admitted and not payload.get("admitted") else 0
+
+    if args.benchmark_command == "runtime-observation":
+        payload = build_benchmark_runtime_observation(
+            admission_active=args.admission_active,
+            job_receipt_state=args.job_receipt_state,
+            runner_owner_state=args.runner_owner_state,
+            terminal_result_present=args.terminal_result_present,
+            typed_fatal_runner_error=args.typed_fatal_runner_error,
+        )
+        print_payload(payload, output_format(args), _render_runtime_observation)
+        return 1 if args.require_healthy and not payload.get("healthy_active") else 0
 
     if args.benchmark_command == "verify-verifier-reward":
         if args.reward_json == "-":

--- a/tests/capabilities/test_benchmark_runtime_observation.py
+++ b/tests/capabilities/test_benchmark_runtime_observation.py
@@ -75,6 +75,19 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
                 "admission_active": True,
                 "job_receipt_state": "missing",
                 "runner_owner_state": "alive",
+                "terminal_result_present": True,
+            },
+            "runtime_authority_unresolved",
+            False,
+            False,
+            "repair_runtime_authority",
+        ),
+        (
+            {
+                "admission_active": True,
+                "job_receipt_state": "ambiguous",
+                "runner_owner_state": "alive",
+                "typed_fatal_runner_error": True,
             },
             "runtime_authority_unresolved",
             False,
@@ -154,6 +167,29 @@ def test_runtime_observation_rejects_unknown_typed_states() -> None:
             job_receipt_state="guessed",
             runner_owner_state="alive",
         )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("admission_active", "false"),
+        ("terminal_result_present", 1),
+        ("typed_fatal_runner_error", "true"),
+    ],
+)
+def test_runtime_observation_rejects_non_boolean_facts(
+    field: str,
+    value: object,
+) -> None:
+    facts: dict[str, object] = {
+        "admission_active": True,
+        "job_receipt_state": "resolved",
+        "runner_owner_state": "alive",
+    }
+    facts[field] = value
+
+    with pytest.raises(TypeError, match=rf"^{field}_must_be_boolean$"):
+        build_benchmark_runtime_observation(**facts)
 
 
 def test_runtime_observation_cli_can_fail_closed() -> None:

--- a/tests/capabilities/test_benchmark_runtime_observation.py
+++ b/tests/capabilities/test_benchmark_runtime_observation.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from loopx.capabilities.benchmark_toolkit import (
+    BENCHMARK_RUNTIME_OBSERVATION_SCHEMA_VERSION,
+    build_benchmark_runtime_observation,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.parametrize(
+    (
+        "facts",
+        "classification",
+        "healthy",
+        "reconciliation_required",
+        "transition",
+    ),
+    [
+        (
+            {
+                "admission_active": False,
+                "job_receipt_state": "resolved",
+                "runner_owner_state": "alive",
+                "terminal_result_present": True,
+            },
+            "not_admitted",
+            False,
+            False,
+            "none",
+        ),
+        (
+            {
+                "admission_active": True,
+                "job_receipt_state": "resolved",
+                "runner_owner_state": "alive",
+            },
+            "running_qualified",
+            True,
+            False,
+            "none",
+        ),
+        (
+            {
+                "admission_active": True,
+                "job_receipt_state": "resolved",
+                "runner_owner_state": "alive",
+                "terminal_result_present": True,
+            },
+            "terminal_pending_reconcile",
+            False,
+            True,
+            "write_terminal_then_release",
+        ),
+        (
+            {
+                "admission_active": True,
+                "job_receipt_state": "resolved",
+                "runner_owner_state": "alive",
+                "typed_fatal_runner_error": True,
+            },
+            "runner_invalid_pending_reconcile",
+            False,
+            True,
+            "write_runner_invalid_then_release",
+        ),
+        (
+            {
+                "admission_active": True,
+                "job_receipt_state": "missing",
+                "runner_owner_state": "alive",
+            },
+            "runtime_authority_unresolved",
+            False,
+            False,
+            "repair_runtime_authority",
+        ),
+        (
+            {
+                "admission_active": True,
+                "job_receipt_state": "resolved",
+                "runner_owner_state": "absent_after_grace",
+            },
+            "runner_lost_pending_reconcile",
+            False,
+            True,
+            "write_runner_invalid_then_release",
+        ),
+        (
+            {
+                "admission_active": True,
+                "job_receipt_state": "resolved",
+                "runner_owner_state": "unknown",
+            },
+            "startup_or_liveness_unresolved",
+            False,
+            False,
+            "reobserve_after_startup_grace",
+        ),
+    ],
+)
+def test_runtime_observation_requires_exact_authority_and_owner_liveness(
+    facts: dict[str, object],
+    classification: str,
+    healthy: bool,
+    reconciliation_required: bool,
+    transition: str,
+) -> None:
+    receipt = build_benchmark_runtime_observation(**facts)
+
+    assert receipt["schema_version"] == BENCHMARK_RUNTIME_OBSERVATION_SCHEMA_VERSION
+    assert receipt["classification"] == classification
+    assert receipt["healthy_active"] is healthy
+    assert receipt["reconciliation_required"] is reconciliation_required
+    assert receipt["recommended_transition"] == transition
+    assert receipt["ledger_occupancy_sufficient"] is False
+    assert receipt["exact_runtime_authority_required"] is True
+    assert receipt["write_performed"] is False
+
+
+def test_runtime_observation_receipt_is_public_safe() -> None:
+    private_values = [
+        "private-run-id",
+        "/private/worktree",
+        "--job-name private-run-id",
+        "private runner failure",
+    ]
+    receipt = build_benchmark_runtime_observation(
+        admission_active=True,
+        job_receipt_state="ambiguous",
+        runner_owner_state="unknown",
+    )
+
+    assert receipt["public_boundary"] == {
+        "run_identity_recorded": False,
+        "process_arguments_recorded": False,
+        "raw_error_recorded": False,
+        "path_recorded": False,
+    }
+    rendered = json.dumps(receipt, sort_keys=True)
+    assert all(private_value not in rendered for private_value in private_values)
+
+
+def test_runtime_observation_rejects_unknown_typed_states() -> None:
+    with pytest.raises(ValueError, match="^invalid_job_receipt_state$"):
+        build_benchmark_runtime_observation(
+            admission_active=True,
+            job_receipt_state="guessed",
+            runner_owner_state="alive",
+        )
+
+
+def test_runtime_observation_cli_can_fail_closed() -> None:
+    command = [
+        str(REPO_ROOT / "scripts/loopx"),
+        "benchmark",
+        "runtime-observation",
+        "--admission-active",
+        "--job-receipt-state",
+        "resolved",
+        "--runner-owner-state",
+        "absent_after_grace",
+        "--require-healthy",
+        "--format",
+        "json",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    receipt = json.loads(completed.stdout)
+    assert receipt["classification"] == "runner_lost_pending_reconcile"
+    assert receipt["healthy_active"] is False
+    assert receipt["recommended_transition"] == "write_runner_invalid_then_release"

--- a/tests/capabilities/test_benchmark_toolkit.py
+++ b/tests/capabilities/test_benchmark_toolkit.py
@@ -155,9 +155,17 @@ def test_catalog_exposes_post_run_case_insight_monitor_contract() -> None:
         "current_worktree_status",
     ]
     assert active["runtime_basis"] == [
+        "active_admission_ledger",
+        "exact_job_runtime_receipt",
+        "exact_runner_owner_liveness_after_startup_grace",
+        "terminal_result_presence",
         "goal_state_and_event_freshness",
         "typed_runner_error_category",
     ]
+    assert "Admission-ledger occupancy is not liveness" in active["runtime_contract"]
+    assert "resolved exact-job receipt" in active["runtime_contract"]
+    assert "advance at least one" in monitor_template["text"]
+    assert "even when no case became terminal" in monitor_template["text"]
     assert "solver_trajectory_phase" in active["trajectory_basis"]
     assert active["classification_owner"] == "benchmark_monitor_provider"
     assert active["stalled_when"] == {
@@ -658,7 +666,9 @@ def test_permitted_solving_policy_requires_network_permitted_attestation() -> No
     )
 
     assert receipt["integrity_qualified"] is False
-    assert "runtime_attestation_network_permitted_solving_missing" in receipt["blockers"]
+    assert (
+        "runtime_attestation_network_permitted_solving_missing" in receipt["blockers"]
+    )
     assert receipt["classification"] == "runtime_isolation_not_attested"
 
 


### PR DESCRIPTION
## Summary

- add a typed, provider-neutral `benchmark_runtime_observation_v0` reducer and `loopx benchmark runtime-observation` CLI
- require exact-job receipt plus exact runner-owner liveness before an admitted run is considered healthy
- turn terminal, fatal, lost-owner, and unresolved-authority states into explicit provider-owned next transitions
- declare the provider obligation to advance at least one solver-trajectory slice during bounded active monitor cycles, even when no case becomes terminal

## Motivation

An admission ledger is scheduling state, not process-liveness evidence. A monitor that trusts occupancy alone can silently preserve a dead or already-terminal run, underfill concurrency, and skip useful trajectory review while waiting. This change gives providers one compact read-only classification contract without moving process discovery, reconciliation, or slot release into LoopX core.

## Boundaries

- no benchmark jobs are launched
- no scoring, task, comparison, or permission semantics change
- no process discovery, terminal write, reconciliation, or slot release is performed
- receipts contain no run identity, process arguments, raw errors, paths, trajectories, or evaluator evidence

## Review refinements

- exact-job receipt authority now fails closed before terminal or typed-fatal transitions can recommend a write or slot release
- direct Python callers must provide real booleans instead of relying on truthy coercion
- docs and catalog text distinguish provider obligations from reducer effects

## Validation

- focused benchmark runtime/toolkit/experiment-board/source-fence pytest matrix — 82 passed
- focused Ruff check and format check — passed
- focused mypy for `runtime_observation.py` — passed
- compileall plus CLI positive/negative walkthroughs — passed
- change-quality receipt `cqr_90bb5ddcbf08738e2252` — valid for exact final diff
- standard premerge canary — 18/18 selected checks passed; 0 failures; public-boundary scan clean

The canary retained its generic benchmark-sensitive manual-review hold. The maintainer explicitly authorized self-review/refine/admin-bypass merge for this PR; no benchmark job, scoring, task, submission, or permission semantics change is included.
