### PR TITLE
fix(todo): make rejected replan reentry executable

### DIFF
--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -360,10 +360,17 @@ the agent should do one of two things:
 
 This succession decision is durable Todo state. A later progress observation,
 vision ACK, coverage-exhausted result, or rewritten rationale cannot substitute
-for it. If the Todo is already complete without either branch, use the supported
-same-turn `todo complete --no-follow-up` recovery when its completion identity
-is still current; otherwise add/link a real successor. Do not create a user
-gate merely to silence a succession warning.
+for it. Every new completion therefore retains an opaque completion identity.
+A quota-bound completion still permits only the receipt-backed same-turn
+`todo complete --no-follow-up` recovery. An ordinary unscoped completion gets a
+stable `local_completion_*` identity; if a later `refresh-state` discovers that
+the finished Goal has no real successor, its typed rejection may project
+`--completion-identity-key` for one direct lifecycle reentry. That command is
+valid only for the exact already-completed Todo, its matching local identity,
+`active_goal` continuation, no successor, and the authorized lifecycle actor.
+It cannot be supplied for an open Todo or used as a quota turn identity.
+Otherwise add/link a real successor. Do not create a user gate merely to
+silence a succession warning.
 
 This keeps the active checklist honest without making LoopX a heavyweight
 project-management state machine.

--- a/docs/reference/protocols/loopx-turn-v0.md
+++ b/docs/reference/protocols/loopx-turn-v0.md
@@ -377,17 +377,26 @@ Turn journal records that outcome before quota spend. A Todo completion alone
 never terminates the goal; a fresh decision owns successor selection and goal
 termination.
 
-Every newly completed Todo persists `completion_continuation` explicitly. The
+Every newly completed Todo persists `completion_continuation` and an opaque
+completion identity explicitly. The
 value must agree with its durable relations: `successor` requires at least one
 `successor_todo_id`, `no_followup` requires `no_followup=true`, and
 `active_goal` requires neither. A completed record that omits the field is not
 interpreted as `active_goal`; it fails closed until an agent explicitly repairs
 it by replaying `loopx todo complete`. The only post-completion transition is
-the narrow #3261 recovery seam: during the original `completion_turn_key`, an
-explicit `active_goal` may be upgraded to `no_followup` after the matching
-writeback and spend receipts exist. The recovery records
-`completion_recovery=same_turn_terminal_closeout`; it cannot cross a Turn or
-replace a successor.
+the narrow #3261 recovery seam: during the original quota-bound
+`completion_turn_key`, an explicit `active_goal` may be upgraded to
+`no_followup` after the matching writeback and spend receipts exist. The
+recovery records `completion_recovery=same_turn_terminal_closeout`; it cannot
+cross a Turn or replace a successor. A completion made outside a quota Turn
+instead persists a TS-derived `local_completion_*` identity. When a strict
+`refresh-state` rejection later proves that only Todo lifecycle settlement is
+missing, it may project that exact key through `--completion-identity-key`.
+The completion fence accepts this distinct
+`lifecycle_reentry_terminal_closeout` only for the matching completed Todo with
+`active_goal`, no successor, and an authorized lifecycle actor. It does not
+reinterpret the local key as a quota receipt or permit arbitrary cross-Turn
+terminal replay.
 
 `repair_required` and `replan_required` are distinct. Repair preserves the
 current task intent. Replan changes the runnable todo set or route because the

--- a/docs/reference/protocols/model-behavior-qualification-v0.md
+++ b/docs/reference/protocols/model-behavior-qualification-v0.md
@@ -182,6 +182,32 @@ through the shipped packet and interaction-contract builders, requires
 runtime-injected `ARK_API_KEY`, invokes the canonical Ark endpoint, and prints
 only the Git-bound bounded portfolio receipt.
 
+### Focused Terminal Rejection Reentry
+
+The terminal-settlement actor also has a focused `rejection-reentry` scenario
+for changes to the post-completion recovery packet. The fixture completes two
+real unscoped advancement Todos, invokes the shipped `refresh-state` CLI and
+requires its non-zero typed rejection, then gives that actual tool result to
+the model. The model must execute each exact
+`todo complete --no-follow-up --completion-identity-key ...` action, re-enter
+the projected `quota should-run` command, observe `should_run=false`, and stop.
+Repeating refresh, changing a completion identity, spending quota, inventing a
+successor, returning early, or calling another tool after terminal quota fails
+the qualification.
+
+```bash
+python3 scripts/qualify-doubao-terminal-settlement-live.py \
+  --scenario rejection-reentry \
+  --qualification-id <public-safe-run-id>
+```
+
+Ordinary CI uses the same actor with a scripted provider transport to prove the
+fixture, CLI, state machine, negative cases, and bounded receipt. Only a run of
+the command above with a runtime-injected key and a non-zero provider call count
+is evidence that a named Doubao model followed the projection. Raw prompts,
+tool results, provider responses, commands, Todo ids, and local paths are not
+retained in its receipt.
+
 ## New-User Onboarding Closed Loop
 
 `onboarding_actual_behavior_qualification_v0` extends the same low-frequency

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -197,6 +197,14 @@ def register_todo_command(
         ),
     )
     todo_parser.add_argument(
+        "--completion-identity-key",
+        help=(
+            "For todo complete --no-follow-up lifecycle reentry, reuse the "
+            "exact completion identity projected by LoopX. This is not a quota "
+            "turn id and cannot be combined with --turn-instance-id."
+        ),
+    )
+    todo_parser.add_argument(
         "--replan-obligation-id",
         help=(
             "For todo add, bind one newly selected runnable advancement successor "
@@ -753,6 +761,7 @@ def handle_todo_command(
             settlement_result = None
             settlement_identity = None
             completion_turn_key = None
+            completion_identity_source = None
             if getattr(args, "turn_instance_id", None):
                 runtime_root = resolve_runtime_root(
                     load_registry(registry_path),
@@ -790,6 +799,10 @@ def handle_todo_command(
                             + settlement_result.failure.reason
                         )
                 completion_turn_key = identity.effect_id
+                completion_identity_source = "turn_settlement"
+            elif getattr(args, "completion_identity_key", None):
+                completion_turn_key = str(args.completion_identity_key)
+                completion_identity_source = "lifecycle_reentry"
             payload = complete_goal_todo(
                 registry_path=registry_path,
                 goal_id=args.goal_id,
@@ -798,6 +811,7 @@ def handle_todo_command(
                 decision_outcome=args.decision_outcome,
                 evidence=args.evidence,
                 completion_turn_key=completion_turn_key,
+                completion_identity_source=completion_identity_source,
                 task_lease_idempotency_key=args.task_lease_idempotency_key,
                 task_lease_expected_version=args.task_lease_expected_version,
                 note=args.note,

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -342,6 +342,13 @@ def validate_todo_complete_options(args: argparse.Namespace) -> None:
         raise ValueError(
             "--task-lease-expected-version requires --task-lease-idempotency-key"
         )
+    if args.turn_instance_id and args.completion_identity_key:
+        raise ValueError(
+            "todo complete accepts either --turn-instance-id or "
+            "--completion-identity-key, not both"
+        )
+    if args.completion_identity_key and not args.no_follow_up:
+        raise ValueError("--completion-identity-key is only valid with --no-follow-up")
     if any(getattr(args, field) for field in ("task_repository", "bound_agent", "goal_bound", "blocks_agent", "clear_blocks_agent", "excluded_agents", "clear_excluded_agents", "global_gate", "clear_global_gate", "unblocks_todo_id", "resume_when")):
         raise ValueError("todo complete does not update current todo routing metadata; use todo update first")
     if any(getattr(args, field) for field in ("monitor_target_key", "cadence", "next_due_at", "expires_at")):

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -11,6 +11,7 @@ TODO_OPTION_FIELDS = (
     ("--follow-up", "followups"),
     ("--todo-id", "todo_id"),
     ("--turn-instance-id", "turn_instance_id"),
+    ("--completion-identity-key", "completion_identity_key"),
     ("--replan-obligation-id", "replan_obligation_id"),
     ("--status", "status"),
     ("--note", "note"),
@@ -470,6 +471,13 @@ def validate_shared_todo_options(args: argparse.Namespace) -> None:
     if getattr(args, "turn_instance_id", None) and args.todo_command != "complete":
         raise ValueError(
             "--turn-instance-id is supported only by todo complete settlement"
+        )
+    if (
+        getattr(args, "completion_identity_key", None)
+        and args.todo_command != "complete"
+    ):
+        raise ValueError(
+            "--completion-identity-key is supported only by todo complete reentry"
         )
     if (
         getattr(args, "replan_obligation_id", None)

--- a/loopx/control_plane/effect_runtime_handlers.ts
+++ b/loopx/control_plane/effect_runtime_handlers.ts
@@ -41,7 +41,10 @@ import {
   type TurnJournalInspectionRequest,
 } from "./turn_driver/turn_journal.ts";
 import { commitTurnJournal } from "./turn_driver/turn_journal_effects.ts";
-import { evaluateTodoCompletionFence } from "./todos/completion_fence.ts";
+import {
+  evaluateTodoCompletionFence,
+  projectTodoCompletionIdentity,
+} from "./todos/completion_fence.ts";
 import {
   buildTodoCompletionMetadataUpdates,
   normalizeTodoCompletionValue,
@@ -376,6 +379,7 @@ export function createEffectRuntimeHandlers(
       ),
     ],
     ["turn.settlement.reduce", reduceTurnSettlementTransaction],
+    ["todo.completion_identity.project", projectTodoCompletionIdentity],
     ["work_item.replan_settlement.project", projectReplanSettlementContract],
     [
       "work_item.replan_settlement.reentry",

--- a/loopx/control_plane/testing/model_tool_behavior.py
+++ b/loopx/control_plane/testing/model_tool_behavior.py
@@ -496,9 +496,16 @@ def execute_loopx_cli(
     source_root: Path,
     project_root: Path,
     argument_overrides: Mapping[str, str] | None = None,
+    accepted_return_codes: Sequence[int] = (0,),
     timeout_seconds: float = 60,
 ) -> str:
-    """Execute only the parsed LoopX argv against an isolated project."""
+    """Execute only the parsed LoopX argv against an isolated project.
+
+    Most behavior actors accept only successful CLI calls. A scenario that
+    starts from a typed, actionable rejection may explicitly accept that
+    command's documented non-zero code while still failing closed on every
+    other result.
+    """
 
     tokens = loopx_command_tokens(command)
     if not tokens:
@@ -524,12 +531,10 @@ def execute_loopx_cli(
         text=True,
         timeout=timeout_seconds,
     )
-    if completed.returncode != 0:
+    if completed.returncode not in accepted_return_codes:
         detail = completed.stderr.strip() or completed.stdout.strip()
         bounded_detail = (
-            detail
-            if len(detail) <= 1_000
-            else detail[:500] + "\n...\n" + detail[-500:]
+            detail if len(detail) <= 1_000 else detail[:500] + "\n...\n" + detail[-500:]
         )
         raise RuntimeError(
             "LoopX CLI command failed with "

--- a/loopx/control_plane/testing/terminal_settlement_tool_behavior.py
+++ b/loopx/control_plane/testing/terminal_settlement_tool_behavior.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from ...heartbeat_prompt import build_heartbeat_prompt
+from ...todos import add_goal_todo, complete_goal_todo
 from ..quota.turn_envelope import quota_action_signature_document
 from .doubao_model_behavior_actor import (
     ARK_API_KEY_ENV,
@@ -31,7 +32,11 @@ from .selected_todo_tool_behavior import bounded_workspace_read_plan
 TERMINAL_SETTLEMENT_TOOL_BEHAVIOR_RECEIPT_SCHEMA_VERSION = (
     "terminal_settlement_tool_behavior_receipt_v0"
 )
+TERMINAL_SETTLEMENT_REENTRY_TOOL_BEHAVIOR_RECEIPT_SCHEMA_VERSION = (
+    "terminal_settlement_reentry_tool_behavior_receipt_v0"
+)
 TERMINAL_SETTLEMENT_TOOL_BEHAVIOR_MAX_CALLS = 10
+TERMINAL_SETTLEMENT_REENTRY_TOOL_BEHAVIOR_MAX_CALLS = 5
 
 TERMINAL_SETTLEMENT_FIXTURE_GOAL_ID = "terminal-settlement-fixture"
 TERMINAL_SETTLEMENT_FIXTURE_AGENT_ID = "codex-terminal-settlement"
@@ -41,6 +46,8 @@ TERMINAL_SETTLEMENT_FIXTURE_ACTION_TEXT = (
     f"Read `{TERMINAL_SETTLEMENT_FIXTURE_PROOF}`, verify the bounded delivery, "
     "then settle this final Todo from the quota-projected plan. It has no successor."
 )
+TERMINAL_SETTLEMENT_REENTRY_FIXTURE_GOAL_ID = "terminal-reentry-fixture"
+TERMINAL_SETTLEMENT_REENTRY_FIXTURE_AGENT_ID = "codex-terminal-reentry"
 _EXPECTED_RECEIPT_STEPS = [
     "validation",
     "durable_writeback",
@@ -58,6 +65,26 @@ class _TerminalSettlementFixture:
     global_registry_path: Path
     source_root: Path
     proof_target: Path
+
+
+@dataclass(frozen=True)
+class _TerminalSettlementReentryFixture:
+    project_root: Path
+    source_root: Path
+    rejection_command: str
+    rejection_packet: dict[str, Any]
+    projected_actions_by_todo: dict[str, str]
+    quota_reentry_action: str
+
+
+@dataclass
+class _ReentryQualificationState:
+    fixture: _TerminalSettlementReentryFixture
+    messages: list[dict[str, Any]]
+    steps: list[dict[str, Any]] = field(default_factory=list)
+    settled_todo_ids: list[str] = field(default_factory=list)
+    provider_call_count: int = 0
+    terminal_quota_observed: bool = False
 
 
 @dataclass
@@ -211,6 +238,226 @@ def _build_fixture(root: Path) -> _TerminalSettlementFixture:
         global_registry_path=global_registry_path,
         source_root=source_root,
         proof_target=proof_target,
+    )
+
+
+def _reentry_projection(
+    packet: Mapping[str, Any],
+    *,
+    expected_todo_ids: set[str],
+) -> tuple[dict[str, str], str]:
+    transition = packet.get("replan_transition")
+    if not (
+        packet.get("ok") is False
+        and isinstance(transition, Mapping)
+        and transition.get("schema_version") == "replan_writeback_rejection_v0"
+        and transition.get("host_action") == "settle_todo_lifecycle"
+        and transition.get("resolution_mode") == "todo_lifecycle_settlement"
+        and isinstance(transition.get("obligation_id"), str)
+        and transition.get("obligation_id")
+    ):
+        raise ValueError("real refresh rejection did not expose lifecycle reentry")
+    triggers = transition.get("triggers")
+    actions = transition.get("next_cli_actions")
+    if not isinstance(triggers, list) or not isinstance(actions, list):
+        raise ValueError("lifecycle reentry projection is incomplete")
+    projected_ids: set[str] = set()
+    projected_keys: dict[str, str] = {}
+    for trigger in triggers:
+        if not isinstance(trigger, Mapping):
+            raise ValueError("lifecycle reentry trigger is malformed")
+        todo_id = str(trigger.get("todo_id") or "")
+        completion_key = str(trigger.get("completion_turn_key") or "")
+        if (
+            trigger.get("kind") != "completed_advancement_without_successor"
+            or todo_id not in expected_todo_ids
+            or trigger.get("completion_identity_source") != "unscoped_completion"
+            or not completion_key.startswith("local_completion_")
+        ):
+            raise ValueError("lifecycle reentry completion identity is malformed")
+        projected_ids.add(todo_id)
+        projected_keys[todo_id] = completion_key
+    if projected_ids != expected_todo_ids:
+        raise ValueError("lifecycle reentry did not project every completed Todo")
+
+    actions_by_todo: dict[str, str] = {}
+    quota_action = ""
+    for action_value in actions:
+        if not isinstance(action_value, str):
+            raise ValueError("lifecycle reentry action must be a string")
+        tokens = loopx_command_tokens(action_value)
+        if not tokens:
+            continue
+        command_kind, command_action = _command_path(tokens)
+        if command_kind == "todo" and command_action == "complete":
+            todo_id = argument_value(tokens, "--todo-id") or ""
+            if (
+                todo_id not in expected_todo_ids
+                or argument_value(tokens, "--goal-id")
+                != TERMINAL_SETTLEMENT_REENTRY_FIXTURE_GOAL_ID
+                or argument_value(tokens, "--agent-id")
+                != TERMINAL_SETTLEMENT_REENTRY_FIXTURE_AGENT_ID
+                or argument_value(tokens, "--completion-identity-key")
+                != projected_keys[todo_id]
+                or "--turn-instance-id" in tokens
+                or "--replan-obligation-id" in tokens
+                or "--no-follow-up" not in tokens
+            ):
+                raise ValueError("lifecycle reentry action identity is malformed")
+            actions_by_todo[todo_id] = action_value
+        elif command_kind == "quota" and command_action == "should-run":
+            quota_action = action_value
+        elif command_kind in {"refresh_state", "quota"}:
+            raise ValueError("lifecycle reentry projected a prohibited write/spend")
+    if set(actions_by_todo) != expected_todo_ids or not quota_action:
+        raise ValueError("lifecycle reentry executable action set is incomplete")
+    return actions_by_todo, quota_action
+
+
+def _build_reentry_fixture(root: Path) -> _TerminalSettlementReentryFixture:
+    source_root = Path(__file__).resolve().parents[3]
+    project_root = root / "project"
+    runtime_root = root / "runtime"
+    state_relative = (
+        Path(".codex")
+        / "goals"
+        / TERMINAL_SETTLEMENT_REENTRY_FIXTURE_GOAL_ID
+        / "ACTIVE_GOAL_STATE.md"
+    )
+    state_path = project_root / state_relative
+    registry_path = project_root / ".loopx" / "registry.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "init", "-q"],
+        cwd=project_root,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    subprocess.run(
+        [
+            "git",
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/example/terminal-reentry-fixture.git",
+        ],
+        cwd=project_root,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    state_path.write_text(
+        "---\n"
+        "status: active\n"
+        "owner_mode: goal\n"
+        'objective: "Close validated terminal work without inventing a successor."\n'
+        "updated_at: 2026-08-23T00:00:00+08:00\n"
+        "---\n\n"
+        "# Terminal Reentry Behavior Fixture\n\n"
+        "## Objective\n\n"
+        "Close validated terminal work without inventing a successor.\n\n"
+        "## Next Action\n\n"
+        "- Settle the two validated completed slices and stop.\n\n"
+        "## User Todo / Owner Review Reading Queue\n\n"
+        "## Agent Todo\n\n",
+        encoding="utf-8",
+    )
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "updated_at": "2026-08-23T00:00:00+08:00",
+                "common_runtime_root": str(runtime_root),
+                "goals": [
+                    {
+                        "id": TERMINAL_SETTLEMENT_REENTRY_FIXTURE_GOAL_ID,
+                        "domain": "terminal-reentry-live-fixture",
+                        "status": "active",
+                        "repo": str(project_root),
+                        "state_file": str(state_relative),
+                        "adapter": {
+                            "kind": "fixture_connected_delivery_v0",
+                            "status": "connected-delivery",
+                        },
+                        "coordination": {
+                            "registered_agents": [
+                                TERMINAL_SETTLEMENT_REENTRY_FIXTURE_AGENT_ID
+                            ],
+                            "agent_model": "peer_v1",
+                        },
+                        "authority_sources": [],
+                        "quota": {
+                            "compute": 1.0,
+                            "window_hours": 24,
+                            "allowed_slots": 5,
+                        },
+                    }
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    todos = [
+        add_goal_todo(
+            registry_path=registry_path,
+            goal_id=TERMINAL_SETTLEMENT_REENTRY_FIXTURE_GOAL_ID,
+            role="agent",
+            text=f"Validate terminal slice {index}.",
+            task_class="advancement_task",
+            claimed_by=TERMINAL_SETTLEMENT_REENTRY_FIXTURE_AGENT_ID,
+        )
+        for index in (1, 2)
+    ]
+    expected_todo_ids = {str(todo["todo_id"]) for todo in todos}
+    for todo_id in expected_todo_ids:
+        result = complete_goal_todo(
+            registry_path=registry_path,
+            goal_id=TERMINAL_SETTLEMENT_REENTRY_FIXTURE_GOAL_ID,
+            todo_id=todo_id,
+            role="agent",
+            evidence=f"validated terminal result for {todo_id}",
+            agent_id=TERMINAL_SETTLEMENT_REENTRY_FIXTURE_AGENT_ID,
+        )
+        if result.get("ok") is not True:
+            raise ValueError("unscoped completion did not commit")
+
+    rejection_command = (
+        "loopx --format json refresh-state "
+        f"--goal-id {TERMINAL_SETTLEMENT_REENTRY_FIXTURE_GOAL_ID} "
+        f"--agent-id {TERMINAL_SETTLEMENT_REENTRY_FIXTURE_AGENT_ID} "
+        "--progress-scope agent_lane "
+        "--classification terminal_delivery_closeout "
+        "--delivery-batch-scale single_surface "
+        "--delivery-outcome surface_only --no-global-sync"
+    )
+    rejection_output = execute_loopx_cli(
+        rejection_command,
+        source_root=source_root,
+        project_root=project_root,
+        accepted_return_codes=(1,),
+    )
+    rejection_packet = json.loads(rejection_output)
+    if not isinstance(rejection_packet, dict):
+        raise ValueError("refresh rejection must be a JSON object")
+    projected_actions, quota_action = _reentry_projection(
+        rejection_packet,
+        expected_todo_ids=expected_todo_ids,
+    )
+    return _TerminalSettlementReentryFixture(
+        project_root=project_root,
+        source_root=source_root,
+        rejection_command=rejection_command,
+        rejection_packet=rejection_packet,
+        projected_actions_by_todo=projected_actions,
+        quota_reentry_action=quota_action,
     )
 
 
@@ -462,6 +709,71 @@ def _receipt(
     }
 
 
+def _execute_reentry_cli(
+    command: str,
+    *,
+    state: _ReentryQualificationState,
+    accepted_return_codes: tuple[int, ...] = (0,),
+) -> dict[str, Any]:
+    tokens = loopx_command_tokens(command)
+    if tokens and "--format" not in tokens:
+        command = shlex.join([tokens[0], "--format", "json", *tokens[1:]])
+    output = execute_loopx_cli(
+        command,
+        source_root=state.fixture.source_root,
+        project_root=state.fixture.project_root,
+        accepted_return_codes=accepted_return_codes,
+    )
+    payload = json.loads(output)
+    if not isinstance(payload, dict):
+        raise ValueError("LoopX reentry command output must be an object")
+    return payload
+
+
+def _reentry_receipt(
+    state: _ReentryQualificationState,
+    *,
+    qualification_id: str,
+    actor_ref: str,
+    passed: bool,
+    failure_code: str | None,
+) -> dict[str, Any]:
+    expected_count = len(state.fixture.projected_actions_by_todo)
+    return {
+        "schema_version": (
+            TERMINAL_SETTLEMENT_REENTRY_TOOL_BEHAVIOR_RECEIPT_SCHEMA_VERSION
+        ),
+        "qualification_id": qualification_id,
+        "actor_ref": actor_ref,
+        "scenario": "post_refresh_rejection_reentry",
+        "qualification_passed": passed,
+        "failure_code": failure_code,
+        "provider_call_count": state.provider_call_count,
+        "tool_call_count": len(state.steps),
+        "projected_todo_count": expected_count,
+        "settled_todo_count": len(state.settled_todo_ids),
+        "completion_identity_preserved": bool(
+            passed and len(state.settled_todo_ids) == expected_count
+        ),
+        "terminal_quota_observed": state.terminal_quota_observed,
+        "model_stopped_after_terminal_quota": bool(
+            passed and state.terminal_quota_observed
+        ),
+        "observed_tool_sequence": [step["kind"] for step in state.steps],
+        "tool_call_receipts": list(state.steps),
+        "boundary": {
+            "raw_prompt_persisted": False,
+            "raw_provider_response_persisted": False,
+            "raw_command_persisted": False,
+            "filesystem_writes_executed": True,
+            "writes_limited_to_temporary_fixture": True,
+            "external_writes_executed": False,
+            "shell_commands_executed": False,
+            "read_only_host_commands_executed": True,
+        },
+    }
+
+
 class DoubaoTerminalSettlementToolBehaviorActor:
     """Prove the model follows the real post-spend terminal closeout plan."""
 
@@ -638,6 +950,215 @@ class DoubaoTerminalSettlementToolBehaviorActor:
                 return receipt(passed=False, failure_code=failure_code)
             if kind == "terminal_closeout":
                 return receipt(passed=True, failure_code=None)
+            state.messages.extend(
+                [
+                    {
+                        "role": "assistant",
+                        "content": step.assistant_content,
+                        "tool_calls": [tool_call.provider_value],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call.call_id,
+                        "content": output,
+                    },
+                ]
+            )
+
+        return receipt(passed=False, failure_code="tool_call_budget_exhausted")
+
+    def qualify_reentry(
+        self,
+        *,
+        qualification_id: str,
+        fixture_root: Path,
+    ) -> dict[str, Any]:
+        """Prove the model executes a real rejected-refresh recovery packet."""
+
+        fixture = _build_reentry_fixture(fixture_root)
+        seed_call_id = "seed-refresh-rejection"
+        state = _ReentryQualificationState(
+            fixture=fixture,
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You are Codex recovering one LoopX terminal turn. The "
+                        "latest exec tool result is the authoritative typed "
+                        "recovery projection. The user confirms no real successor "
+                        "remains. Use one command per tool call. Execute every "
+                        "projected Todo lifecycle settlement with a concise "
+                        "public-safe note; do not repeat refresh-state, inspect the "
+                        "workspace, spend quota, or invent filler work. Then run "
+                        "the projected quota should-run command. When it reports "
+                        "should_run=false, return a concise final response without "
+                        "another tool call."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": (
+                        "Both validated implementation slices are complete and the "
+                        "bounded Goal is exhausted. No real successor remains. "
+                        "Recover from the latest typed rejection and close out."
+                    ),
+                },
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": seed_call_id,
+                            "type": "function",
+                            "function": {
+                                "name": "exec_command",
+                                "arguments": json.dumps(
+                                    {"cmd": fixture.rejection_command},
+                                    ensure_ascii=False,
+                                    sort_keys=True,
+                                    separators=(",", ":"),
+                                ),
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": seed_call_id,
+                    "content": json.dumps(
+                        fixture.rejection_packet,
+                        ensure_ascii=False,
+                        sort_keys=True,
+                    ),
+                },
+            ],
+        )
+        actor_ref = self._client.actor_ref
+
+        def receipt(*, passed: bool, failure_code: str | None) -> dict[str, Any]:
+            return _reentry_receipt(
+                state,
+                qualification_id=qualification_id,
+                actor_ref=actor_ref,
+                passed=passed,
+                failure_code=failure_code,
+            )
+
+        for _ in range(TERMINAL_SETTLEMENT_REENTRY_TOOL_BEHAVIOR_MAX_CALLS):
+            step = self._client.next_step(state.messages)
+            state.provider_call_count += 1
+            tool_call = step.tool_call
+            if tool_call is None:
+                if state.terminal_quota_observed:
+                    return receipt(passed=True, failure_code=None)
+                return receipt(
+                    passed=False,
+                    failure_code=(
+                        "model_returned_before_terminal_quota"
+                        if len(state.settled_todo_ids)
+                        == len(fixture.projected_actions_by_todo)
+                        else "model_returned_before_lifecycle_settlement"
+                    ),
+                )
+
+            tokens = loopx_command_tokens(tool_call.command)
+            command_kind, command_action = (
+                _command_path(tokens) if tokens else ("unknown", None)
+            )
+            kind = "unexpected_command"
+            output = ""
+            failure_code: str | None = None
+            try:
+                if state.terminal_quota_observed:
+                    raise ValueError("model_called_tool_after_terminal_quota")
+                if command_kind == "refresh_state":
+                    raise ValueError("repeated_refresh_state")
+                if command_kind == "todo" and command_action == "complete":
+                    if not tokens:
+                        raise ValueError("lifecycle_settlement_command_malformed")
+                    todo_id = argument_value(tokens, "--todo-id") or ""
+                    expected_action = fixture.projected_actions_by_todo.get(todo_id)
+                    expected_tokens = (
+                        loopx_command_tokens(expected_action)
+                        if expected_action is not None
+                        else None
+                    )
+                    if todo_id in state.settled_todo_ids:
+                        raise ValueError("repeated_lifecycle_settlement")
+                    note = str(argument_value(tokens, "--note") or "").strip()
+                    if (
+                        expected_tokens is None
+                        or argument_value(tokens, "--goal-id")
+                        != TERMINAL_SETTLEMENT_REENTRY_FIXTURE_GOAL_ID
+                        or argument_value(tokens, "--agent-id")
+                        != TERMINAL_SETTLEMENT_REENTRY_FIXTURE_AGENT_ID
+                        or argument_value(tokens, "--completion-identity-key")
+                        != argument_value(
+                            expected_tokens,
+                            "--completion-identity-key",
+                        )
+                        or "--turn-instance-id" in tokens
+                        or "--replan-obligation-id" in tokens
+                        or "--no-follow-up" not in tokens
+                        or not note
+                        or note == "<public-safe no-follow-up rationale>"
+                    ):
+                        raise ValueError("lifecycle_settlement_identity_mismatch")
+                    payload = _execute_reentry_cli(tool_call.command, state=state)
+                    if not (
+                        payload.get("ok") is True
+                        and payload.get("todo_id") == todo_id
+                        and payload.get("completion_continuation") == "no_followup"
+                        and payload.get("completion_recovery")
+                        == "lifecycle_reentry_terminal_closeout"
+                    ):
+                        raise ValueError("lifecycle_settlement_execution_failed")
+                    state.settled_todo_ids.append(todo_id)
+                    kind = "todo_lifecycle_settlement"
+                    output = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+                elif command_kind == "quota" and command_action == "should-run":
+                    if len(state.settled_todo_ids) != len(
+                        fixture.projected_actions_by_todo
+                    ):
+                        raise ValueError("quota_reentry_before_lifecycle_settlement")
+                    if not tokens or (
+                        argument_value(tokens, "--goal-id")
+                        != TERMINAL_SETTLEMENT_REENTRY_FIXTURE_GOAL_ID
+                        or argument_value(tokens, "--agent-id")
+                        != TERMINAL_SETTLEMENT_REENTRY_FIXTURE_AGENT_ID
+                    ):
+                        raise ValueError("quota_reentry_identity_mismatch")
+                    payload = _execute_reentry_cli(
+                        tool_call.command,
+                        state=state,
+                        accepted_return_codes=(0, 1),
+                    )
+                    if payload.get("should_run") is not False:
+                        raise ValueError("quota_reentry_did_not_terminate")
+                    state.terminal_quota_observed = True
+                    kind = "terminal_quota_reentry"
+                    output = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+                elif command_kind == "todo" and command_action == "add":
+                    raise ValueError("invented_lifecycle_successor")
+                elif command_kind == "quota" and command_action == "spend-slot":
+                    raise ValueError("unexpected_quota_spend")
+                else:
+                    raise ValueError("unexpected_command")
+            except (RuntimeError, ValueError, json.JSONDecodeError) as exc:
+                failure_code = str(exc)
+
+            step_receipt = {
+                "ordinal": len(state.steps) + 1,
+                "kind": kind if failure_code is None else failure_code,
+                "command_digest": digest_text(tool_call.command),
+            }
+            if failure_code is not None:
+                step_receipt["redacted_command_shape"] = _redacted_command_shape(
+                    tool_call.command
+                )
+            state.steps.append(step_receipt)
+            if failure_code is not None:
+                return receipt(passed=False, failure_code=failure_code)
             state.messages.extend(
                 [
                     {

--- a/loopx/control_plane/todos/completion_fence.py
+++ b/loopx/control_plane/todos/completion_fence.py
@@ -37,6 +37,24 @@ def local_todo_completion_identity(*, goal_id: str, todo_id: str) -> str:
     return str(result["completion_identity_key"])
 
 
+def resolve_todo_completion_identity(
+    *,
+    todo: Mapping[str, Any],
+    goal_id: str,
+    todo_id: str,
+    completion_turn_key: str | None,
+    completion_identity_source: str | None,
+) -> tuple[str | None, str | None]:
+    """Bind an unscoped open completion to its stable local identity."""
+
+    if completion_turn_key is not None or str(todo.get("status") or "") == "done":
+        return completion_turn_key, completion_identity_source
+    return (
+        local_todo_completion_identity(goal_id=goal_id, todo_id=todo_id),
+        "unscoped_completion",
+    )
+
+
 def _json_successor_value(value: Any) -> Any:
     if isinstance(value, (tuple, set)):
         return list(value)

--- a/loopx/control_plane/todos/completion_fence.py
+++ b/loopx/control_plane/todos/completion_fence.py
@@ -8,6 +8,33 @@ from ..effect_runtime import EffectRuntimeRejected, effect_runtime_result
 
 TODO_COMPLETION_FENCE_REQUEST_SCHEMA = "loopx_todo_completion_fence_request_v0"
 TODO_COMPLETION_FENCE_RESULT_SCHEMA = "loopx_todo_completion_fence_result_v0"
+TODO_COMPLETION_IDENTITY_REQUEST_SCHEMA = "loopx_todo_completion_identity_request_v0"
+TODO_COMPLETION_IDENTITY_RESULT_SCHEMA = "loopx_todo_completion_identity_v0"
+
+
+def local_todo_completion_identity(*, goal_id: str, todo_id: str) -> str:
+    """Return the TS-owned stable identity for an unscoped completion."""
+
+    try:
+        result = effect_runtime_result(
+            "todo.completion_identity.project",
+            {
+                "schema_version": TODO_COMPLETION_IDENTITY_REQUEST_SCHEMA,
+                "goal_id": goal_id,
+                "todo_id": todo_id,
+            },
+        )
+    except EffectRuntimeRejected as exc:
+        raise ValueError(str(exc)) from None
+    if not (
+        isinstance(result, Mapping)
+        and result.get("schema_version") == TODO_COMPLETION_IDENTITY_RESULT_SCHEMA
+        and result.get("identity_source") == "unscoped_completion"
+        and isinstance(result.get("completion_identity_key"), str)
+        and str(result["completion_identity_key"]).startswith("local_completion_")
+    ):
+        raise RuntimeError("TypeScript Todo completion identity result shape mismatch")
+    return str(result["completion_identity_key"])
 
 
 def _json_successor_value(value: Any) -> Any:
@@ -22,6 +49,9 @@ def evaluate_todo_completion_fence(
     projection_source: str,
     completion_turn_key: str | None,
     no_followup: bool,
+    goal_id: str | None = None,
+    todo_id: str | None = None,
+    completion_identity_source: str | None = None,
 ) -> dict[str, Any]:
     """Ask the TypeScript Todo owner for the canonical replay-fence decision."""
 
@@ -51,6 +81,9 @@ def evaluate_todo_completion_fence(
                 },
                 "requested_no_followup": no_followup,
                 "requested_completion_turn_key": completion_turn_key,
+                "requested_completion_identity_source": completion_identity_source,
+                "goal_id": goal_id,
+                "todo_id": todo_id,
             },
         )
     except EffectRuntimeRejected as exc:
@@ -78,6 +111,7 @@ def completed_todo_replay(
     goal_id: str,
     todo_id: str,
     completion_turn_key: str | None,
+    completion_identity_source: str | None,
     no_followup: bool,
     handoff_mode: str,
     mutation_authority: dict[str, Any],
@@ -104,6 +138,9 @@ def completed_todo_replay(
         projection_source="materialized",
         completion_turn_key=completion_turn_key,
         no_followup=no_followup,
+        goal_id=goal_id,
+        todo_id=todo_id,
+        completion_identity_source=completion_identity_source,
     )
 
     # Event-projected deferred rows must pass through the event writer so the

--- a/loopx/control_plane/todos/completion_fence.ts
+++ b/loopx/control_plane/todos/completion_fence.ts
@@ -104,10 +104,6 @@ export function localTodoCompletionIdentity(
   return `local_completion_${digest.slice(0, 32)}`;
 }
 
-export function isLocalTodoCompletionIdentity(value: string): boolean {
-  return /^local_completion_[0-9a-f]{32}$/.test(value);
-}
-
 export function projectTodoCompletionIdentity(value: unknown): JsonObject {
   const request = requiredObject(value, "todo.completion_identity params");
   if (request.schema_version !== TODO_COMPLETION_IDENTITY_REQUEST_SCHEMA) {

--- a/loopx/control_plane/todos/completion_fence.ts
+++ b/loopx/control_plane/todos/completion_fence.ts
@@ -1,7 +1,10 @@
+import { createHash } from "node:crypto";
+
 import type { JsonObject } from "../effect_program.ts";
 import {
   requireBoolean as requiredBoolean,
   requireJsonObject as requiredObject,
+  requireNonEmptyString,
 } from "../runtime_decode.ts";
 import {
   normalizeTodoCompletionContinuation,
@@ -13,12 +16,20 @@ export const TODO_COMPLETION_FENCE_REQUEST_SCHEMA =
   "loopx_todo_completion_fence_request_v0";
 export const TODO_COMPLETION_FENCE_RESULT_SCHEMA =
   "loopx_todo_completion_fence_result_v0";
+export const TODO_COMPLETION_IDENTITY_REQUEST_SCHEMA =
+  "loopx_todo_completion_identity_request_v0";
+export const TODO_COMPLETION_IDENTITY_RESULT_SCHEMA =
+  "loopx_todo_completion_identity_v0";
 
 const TODO_STATUSES = ["open", "done", "blocked", "deferred"] as const;
 const TODO_ID_PATTERN = /^todo_[a-z0-9_-]{3,64}$/;
 
 export type TodoStatus = (typeof TODO_STATUSES)[number];
 export type TodoCompletionProjectionSource = "materialized" | "event_log";
+export type TodoCompletionIdentitySource =
+  | "turn_settlement"
+  | "unscoped_completion"
+  | "lifecycle_reentry";
 
 export interface TodoCompletionFenceRequest {
   schema_version: typeof TODO_COMPLETION_FENCE_REQUEST_SCHEMA;
@@ -32,11 +43,16 @@ export interface TodoCompletionFenceRequest {
   };
   requested_no_followup: boolean;
   requested_completion_turn_key: string | null;
+  requested_completion_identity_source: TodoCompletionIdentitySource | null;
+  goal_id: string | null;
+  todo_id: string | null;
 }
 
 export type TodoCompletionFenceContinueReason =
   | "not_terminal"
   | "same_turn_terminal_upgrade"
+  | "lifecycle_reentry_terminal_upgrade"
+  | "unscoped_completion_identity_repair"
   | "untyped_completion_repair";
 
 export type TodoCompletionFenceResult =
@@ -63,6 +79,50 @@ function optionalOpaqueString(value: unknown, label: string): string | null {
     throw new Error(`${label} must be a string or null`);
   }
   return value;
+}
+
+function completionIdentitySource(
+  value: unknown,
+): TodoCompletionIdentitySource | null {
+  if (value === null || value === undefined || value === "") return null;
+  if (
+    value === "turn_settlement" || value === "unscoped_completion" ||
+    value === "lifecycle_reentry"
+  ) {
+    return value;
+  }
+  throw new Error("requested_completion_identity_source is unsupported");
+}
+
+export function localTodoCompletionIdentity(
+  goalId: string,
+  todoId: string,
+): string {
+  const digest = createHash("sha256")
+    .update(`loopx-local-todo-completion-v0\0${goalId}\0${todoId}`, "utf8")
+    .digest("hex");
+  return `local_completion_${digest.slice(0, 32)}`;
+}
+
+export function isLocalTodoCompletionIdentity(value: string): boolean {
+  return /^local_completion_[0-9a-f]{32}$/.test(value);
+}
+
+export function projectTodoCompletionIdentity(value: unknown): JsonObject {
+  const request = requiredObject(value, "todo.completion_identity params");
+  if (request.schema_version !== TODO_COMPLETION_IDENTITY_REQUEST_SCHEMA) {
+    throw new Error("Todo completion identity request schema mismatch");
+  }
+  const goalId = requireNonEmptyString(request.goal_id, "goal_id");
+  const todoId = requireNonEmptyString(request.todo_id, "todo_id");
+  if (!TODO_ID_PATTERN.test(todoId)) {
+    throw new Error("todo_id has an unsupported shape");
+  }
+  return {
+    schema_version: TODO_COMPLETION_IDENTITY_RESULT_SCHEMA,
+    identity_source: "unscoped_completion",
+    completion_identity_key: localTodoCompletionIdentity(goalId, todoId),
+  };
 }
 
 function todoNoFollowup(value: unknown): boolean | null {
@@ -157,6 +217,11 @@ export function decodeTodoCompletionFenceRequest(
       request.requested_completion_turn_key,
       "requested_completion_turn_key",
     ),
+    requested_completion_identity_source: completionIdentitySource(
+      request.requested_completion_identity_source,
+    ),
+    goal_id: optionalOpaqueString(request.goal_id, "goal_id"),
+    todo_id: optionalOpaqueString(request.todo_id, "todo_id"),
   };
 }
 
@@ -171,10 +236,25 @@ export function evaluateTodoCompletionFence(
   const done = status === "done";
   const terminalBeforeRequest = done ||
     (request.projection_source === "event_log" && status === "deferred");
+  const requestedKey = request.requested_completion_turn_key;
+  const storedKey = request.todo.completion_turn_key;
+  const expectedLocalKey = request.goal_id !== null && request.todo_id !== null
+    ? localTodoCompletionIdentity(request.goal_id, request.todo_id)
+    : null;
+  const unscopedIdentityRepair = done && storedKey === null &&
+    request.requested_completion_identity_source === "lifecycle_reentry" &&
+    requestedKey !== null && requestedKey === expectedLocalKey;
 
   if (
-    done && request.requested_completion_turn_key !== null &&
-    request.requested_completion_turn_key !== request.todo.completion_turn_key
+    request.requested_completion_identity_source === "lifecycle_reentry" &&
+    !done
+  ) {
+    throw new Error("Todo lifecycle reentry requires an already completed Todo");
+  }
+
+  if (
+    done && requestedKey !== null && requestedKey !== storedKey &&
+    !unscopedIdentityRepair
   ) {
     throw new Error(
       "todo is already completed under a different completion_turn_key",
@@ -203,8 +283,8 @@ export function evaluateTodoCompletionFence(
       );
     }
     if (
-      request.requested_completion_turn_key === null ||
-      request.requested_completion_turn_key !== request.todo.completion_turn_key
+      requestedKey === null ||
+      (requestedKey !== storedKey && !unscopedIdentityRepair)
     ) {
       throw new Error(
         "todo terminal closeout requires the original completion_turn_key",
@@ -213,7 +293,11 @@ export function evaluateTodoCompletionFence(
     return {
       schema_version: TODO_COMPLETION_FENCE_RESULT_SCHEMA,
       outcome: "continue",
-      reason: "same_turn_terminal_upgrade",
+      reason: unscopedIdentityRepair
+        ? "unscoped_completion_identity_repair"
+        : request.requested_completion_identity_source === "lifecycle_reentry"
+        ? "lifecycle_reentry_terminal_upgrade"
+        : "same_turn_terminal_upgrade",
       status,
       terminal_before_request: true,
       completion_continuation: continuation,

--- a/loopx/control_plane/todos/completion_state.py
+++ b/loopx/control_plane/todos/completion_state.py
@@ -26,6 +26,7 @@ class TodoCompletionRecovery(str, Enum):
     """Stable Python import compatibility for the persisted wire value."""
 
     SAME_TURN_TERMINAL_CLOSEOUT = "same_turn_terminal_closeout"
+    LIFECYCLE_REENTRY_TERMINAL_CLOSEOUT = "lifecycle_reentry_terminal_closeout"
 
 
 def _string_value(value: Any) -> str:
@@ -148,6 +149,7 @@ def completion_state_for_todo_write(
     *,
     requested_no_followup: bool,
     has_successor: bool,
+    completion_identity_source: str | None = None,
 ) -> TodoCompletionState:
     result = _result(
         "todo.completion_state.evaluate",
@@ -162,6 +164,7 @@ def completion_state_for_todo_write(
             },
             "requested_no_followup": requested_no_followup,
             "has_successor": has_successor,
+            "completion_identity_source": completion_identity_source,
         },
     )
     continuation = result.get("continuation")

--- a/loopx/control_plane/todos/completion_state.ts
+++ b/loopx/control_plane/todos/completion_state.ts
@@ -17,6 +17,7 @@ export const TODO_COMPLETION_CONTINUATIONS = [
 ] as const;
 export const TODO_COMPLETION_RECOVERIES = [
   "same_turn_terminal_closeout",
+  "lifecycle_reentry_terminal_closeout",
 ] as const;
 
 export type TodoCompletionContinuation =
@@ -116,7 +117,10 @@ export function requireTodoCompletionMetadata(
   if (normalized !== null || value === null || value === undefined || value === "") {
     return normalized;
   }
-  throw new Error("completion_recovery must be same_turn_terminal_closeout");
+  throw new Error(
+    "completion_recovery must be same_turn_terminal_closeout or " +
+      "lifecycle_reentry_terminal_closeout",
+  );
 }
 
 export function completionContinuationForWrite(
@@ -184,11 +188,25 @@ export function selectTodoCompletionState(value: unknown): TodoCompletionStateRe
     effectiveNoFollowup,
     requiredBoolean(request.has_successor, "has_successor"),
   );
+  const completionIdentitySource = optionalString(
+    request.completion_identity_source,
+    "completion_identity_source",
+  );
+  if (
+    completionIdentitySource !== null &&
+    completionIdentitySource !== "turn_settlement" &&
+    completionIdentitySource !== "unscoped_completion" &&
+    completionIdentitySource !== "lifecycle_reentry"
+  ) {
+    throw new Error("completion_identity_source is unsupported");
+  }
   const recovery = String(todo.status ?? "") === "done" &&
       requestedNoFollowup &&
       normalizeTodoCompletionContinuation(todo.completion_continuation) ===
         "active_goal"
-    ? "same_turn_terminal_closeout"
+    ? completionIdentitySource === "lifecycle_reentry"
+      ? "lifecycle_reentry_terminal_closeout"
+      : "same_turn_terminal_closeout"
     : null;
   return {
     schema_version: TODO_COMPLETION_STATE_RESULT_SCHEMA,

--- a/loopx/control_plane/todos/completion_validation.py
+++ b/loopx/control_plane/todos/completion_validation.py
@@ -71,6 +71,9 @@ def evaluate_todo_completion_validation_plan(
     completion_turn_key: str | None,
     no_followup: bool,
     dry_run: bool,
+    completion_identity_source: str | None = None,
+    goal_id: str | None = None,
+    todo_id: str | None = None,
 ) -> dict[str, Any]:
     """Ask the TypeScript Todo owner for the validation decision/effect plan."""
     try:
@@ -96,6 +99,9 @@ def evaluate_todo_completion_validation_plan(
                 },
                 "requested_no_followup": no_followup,
                 "requested_completion_turn_key": completion_turn_key,
+                "requested_completion_identity_source": completion_identity_source,
+                "goal_id": goal_id,
+                "todo_id": todo_id,
                 "dry_run": dry_run,
             },
         )
@@ -295,6 +301,7 @@ def run_completion_validation_gate(
     dry_run: bool,
     no_followup: bool = False,
     completion_turn_key: str | None = None,
+    completion_identity_source: str | None = None,
 ) -> dict[str, Any] | None:
     return run_completion_validation_gate_with_source(
         state_file=state_file,
@@ -305,6 +312,7 @@ def run_completion_validation_gate(
         dry_run=dry_run,
         no_followup=no_followup,
         completion_turn_key=completion_turn_key,
+        completion_identity_source=completion_identity_source,
     ).get("failure")
 
 
@@ -318,6 +326,7 @@ def run_completion_validation_gate_with_source(
     dry_run: bool,
     no_followup: bool = False,
     completion_turn_key: str | None = None,
+    completion_identity_source: str | None = None,
 ) -> dict[str, Any]:
     """Run the caller-approved completion validation gate, OUTSIDE the mutation lock.
 
@@ -352,6 +361,9 @@ def run_completion_validation_gate_with_source(
         completion_turn_key=completion_turn_key,
         no_followup=no_followup,
         dry_run=dry_run,
+        completion_identity_source=completion_identity_source,
+        goal_id=goal_id,
+        todo_id=todo_id,
     )
     completion_validation = None
     if plan["effect"] == "reject":

--- a/loopx/control_plane/todos/completion_validation_plan.ts
+++ b/loopx/control_plane/todos/completion_validation_plan.ts
@@ -178,6 +178,10 @@ export function evaluateTodoCompletionValidationPlan(
       request.requested_completion_turn_key,
       "requested_completion_turn_key",
     ),
+    requested_completion_identity_source:
+      request.requested_completion_identity_source,
+    goal_id: request.goal_id,
+    todo_id: request.todo_id,
   });
   if (fence.outcome === "replay") {
     return {

--- a/loopx/control_plane/todos/contract.py
+++ b/loopx/control_plane/todos/contract.py
@@ -1100,7 +1100,8 @@ _TODO_METADATA_FIELD_SCHEMA = (
         "completion_recovery",
         normalize_todo_completion_recovery,
         invalid_message=(
-            "completion_recovery must be same_turn_terminal_closeout"
+            "completion_recovery must be same_turn_terminal_closeout or "
+            "lifecycle_reentry_terminal_closeout"
         ),
     ),
     _TodoMetadataField(

--- a/loopx/control_plane/todos/event_writeback.py
+++ b/loopx/control_plane/todos/event_writeback.py
@@ -458,6 +458,7 @@ def complete_event_projected_goal_todo(
     updated_at: str,
     dry_run: bool,
     completion_turn_key: str | None = None,
+    completion_identity_source: str | None = None,
     actor_agent_id: str | None = None,
     completion_fence: dict[str, Any] | None = None,
     completion_validation_source_authority: dict[str, Any] | None = None,
@@ -486,13 +487,20 @@ def complete_event_projected_goal_todo(
             projection_source="event_log",
             completion_turn_key=completion_turn_key,
             no_followup=no_followup,
+            goal_id=goal_id,
+            todo_id=todo_id,
+            completion_identity_source=completion_identity_source,
         )
     already_done = bool(completion_fence["terminal_before_request"])
-    terminal_upgrade = (
-        completion_fence["reason"] == "same_turn_terminal_upgrade"
-    )
+    terminal_upgrade = completion_fence["reason"] in {
+        "same_turn_terminal_upgrade",
+        "lifecycle_reentry_terminal_upgrade",
+    }
     untyped_completion_repair = (
         completion_fence["reason"] == "untyped_completion_repair"
+    )
+    unscoped_identity_repair = (
+        completion_fence["reason"] == "unscoped_completion_identity_repair"
     )
     if completion_fence["outcome"] == "replay":
         return {
@@ -589,6 +597,7 @@ def complete_event_projected_goal_todo(
         item,
         requested_no_followup=no_followup,
         has_successor=bool(normalized_successor_todo_ids),
+        completion_identity_source=completion_identity_source,
     )
     completion_continuation = completion_state.continuation
     completion_recovery = completion_state.recovery
@@ -624,7 +633,12 @@ def complete_event_projected_goal_todo(
         producer="loopx.todo.complete",
         actor_agent_id=actor_agent_id,
     )
-    if (not already_done or terminal_upgrade or untyped_completion_repair) and not dry_run:
+    if (
+        not already_done
+        or terminal_upgrade
+        or untyped_completion_repair
+        or unscoped_identity_repair
+    ) and not dry_run:
         store.append(completion_event)
 
     result = {
@@ -640,12 +654,16 @@ def complete_event_projected_goal_todo(
         "status_changed": not already_done,
         "text_changed": False,
         "metadata_updated": (
-            (not already_done) or terminal_upgrade or untyped_completion_repair
+            (not already_done)
+            or terminal_upgrade
+            or untyped_completion_repair
+            or unscoped_identity_repair
         ),
         "changed": (
             (not already_done)
             or terminal_upgrade
             or untyped_completion_repair
+            or unscoped_identity_repair
             or bool(next_results)
         ),
         "claimed_by": normalize_todo_claimed_by(effective_claimed_by),

--- a/loopx/control_plane/todos/unblock_resume.py
+++ b/loopx/control_plane/todos/unblock_resume.py
@@ -84,6 +84,19 @@ def _find_todo(
     )
 
 
+def completion_decision_target(
+    lines: list[str],
+    completion_todo: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Return the agent Todo whose decision is resolved by this completion."""
+
+    target_todo_id = normalize_todo_id(completion_todo.get("unblocks_todo_id"))
+    if not target_todo_id:
+        return None
+    target = _find_todo(lines, role="agent", todo_id=target_todo_id)
+    return {**target, "role": "agent"} if target else None
+
+
 def plan_completed_user_unblock_resume(
     lines: list[str],
     *,

--- a/loopx/control_plane/work_items/replan_settlement.py
+++ b/loopx/control_plane/work_items/replan_settlement.py
@@ -39,14 +39,7 @@ def project_todo_lifecycle_settlement_reentry(
         raise RuntimeError("TypeScript Todo lifecycle reentry result must be an object")
     projected_triggers = result.get("triggers")
     next_cli_actions = result.get("next_cli_actions")
-    expected_triggers = [
-        {
-            "kind": trigger.get("kind"),
-            "todo_id": trigger.get("todo_id"),
-            "completion_turn_key": trigger.get("completion_turn_key") or None,
-        }
-        for trigger in triggers[:3]
-    ]
+    expected_triggers = triggers[:3]
     if (
         result.get("schema_version") != TODO_LIFECYCLE_REENTRY_SCHEMA
         or result.get("resolution_mode") != "todo_lifecycle_settlement"
@@ -57,13 +50,41 @@ def project_todo_lifecycle_settlement_reentry(
             or trigger.get("kind") != "completed_advancement_without_successor"
             or not isinstance(trigger.get("todo_id"), str)
             or not trigger.get("todo_id")
-            or (
-                trigger.get("completion_turn_key") is not None
-                and not isinstance(trigger.get("completion_turn_key"), str)
-            )
+            or not isinstance(trigger.get("completion_turn_key"), str)
+            or not trigger.get("completion_turn_key")
+            or trigger.get("completion_identity_source")
+            not in {"turn_settlement", "unscoped_completion"}
             for trigger in projected_triggers
         )
-        or [dict(trigger) for trigger in projected_triggers] != expected_triggers
+        or any(
+            dict(projected).get("kind") != expected.get("kind")
+            or dict(projected).get("todo_id") != expected.get("todo_id")
+            or (
+                expected.get("completion_turn_key") is not None
+                and dict(projected).get("completion_turn_key")
+                != expected.get("completion_turn_key")
+            )
+            or (
+                expected.get("completion_turn_key") is None
+                and not str(
+                    dict(projected).get("completion_turn_key") or ""
+                ).startswith("local_completion_")
+            )
+            or dict(projected).get("completion_identity_source")
+            != (
+                "unscoped_completion"
+                if expected.get("completion_turn_key") is None
+                or str(expected.get("completion_turn_key") or "").startswith(
+                    "local_completion_"
+                )
+                else "turn_settlement"
+            )
+            for projected, expected in zip(
+                projected_triggers,
+                expected_triggers,
+                strict=True,
+            )
+        )
         or not isinstance(next_cli_actions, list)
         or not next_cli_actions
         or any(not isinstance(action, str) or not action for action in next_cli_actions)

--- a/loopx/control_plane/work_items/replan_settlement.ts
+++ b/loopx/control_plane/work_items/replan_settlement.ts
@@ -5,7 +5,6 @@ import {
   requireNonEmptyString,
 } from "../runtime_decode.ts";
 import {
-  isLocalTodoCompletionIdentity,
   localTodoCompletionIdentity,
 } from "../todos/completion_fence.ts";
 
@@ -63,16 +62,15 @@ export function projectTodoLifecycleSettlementReentry(value: unknown): JsonObjec
     (trigger) => {
       const todoId = String(trigger.todo_id);
       const persistedKey = trigger.completion_turn_key;
+      const localIdentityKey = localTodoCompletionIdentity(goalId, todoId);
       const completionIdentityKey = typeof persistedKey === "string"
         ? persistedKey
-        : localTodoCompletionIdentity(goalId, todoId);
+        : localIdentityKey;
       return {
         kind: trigger.kind,
         todo_id: todoId,
         completion_turn_key: completionIdentityKey,
-        completion_identity_source: isLocalTodoCompletionIdentity(
-            completionIdentityKey,
-          )
+        completion_identity_source: completionIdentityKey === localIdentityKey
           ? "unscoped_completion"
           : "turn_settlement",
       };

--- a/loopx/control_plane/work_items/replan_settlement.ts
+++ b/loopx/control_plane/work_items/replan_settlement.ts
@@ -4,6 +4,10 @@ import {
   requireJsonObject,
   requireNonEmptyString,
 } from "../runtime_decode.ts";
+import {
+  isLocalTodoCompletionIdentity,
+  localTodoCompletionIdentity,
+} from "../todos/completion_fence.ts";
 
 export const REPLAN_SETTLEMENT_REQUEST_SCHEMA =
   "loopx_replan_settlement_request_v0";
@@ -55,7 +59,25 @@ export function projectTodoLifecycleSettlementReentry(value: unknown): JsonObjec
   if (!Array.isArray(request.triggers) || request.triggers.length === 0) {
     throw new Error("triggers must be a non-empty array");
   }
-  const triggers = request.triggers.slice(0, 3).map(lifecycleTrigger);
+  const triggers = request.triggers.slice(0, 3).map(lifecycleTrigger).map(
+    (trigger) => {
+      const todoId = String(trigger.todo_id);
+      const persistedKey = trigger.completion_turn_key;
+      const completionIdentityKey = typeof persistedKey === "string"
+        ? persistedKey
+        : localTodoCompletionIdentity(goalId, todoId);
+      return {
+        kind: trigger.kind,
+        todo_id: todoId,
+        completion_turn_key: completionIdentityKey,
+        completion_identity_source: isLocalTodoCompletionIdentity(
+            completionIdentityKey,
+          )
+          ? "unscoped_completion"
+          : "turn_settlement",
+      };
+    },
+  );
   const lifecycleActorArgs = Array.isArray(request.lifecycle_actor_args)
     ? request.lifecycle_actor_args.map((item, index) =>
       requireNonEmptyString(item, `lifecycle_actor_args[${index}]`)
@@ -68,15 +90,16 @@ export function projectTodoLifecycleSettlementReentry(value: unknown): JsonObjec
     : [];
   const nextCliActions = triggers.map((trigger) => {
     const todoId = String(trigger.todo_id);
-    const completionTurnKey = trigger.completion_turn_key;
-    const completionTurnArgs = typeof completionTurnKey === "string"
-      ? ["--turn-instance-id", completionTurnKey]
-      : [];
+    const completionIdentityKey = String(trigger.completion_turn_key);
+    const completionIdentityArgs =
+      trigger.completion_identity_source === "unscoped_completion"
+        ? ["--completion-identity-key", completionIdentityKey]
+        : ["--turn-instance-id", completionIdentityKey];
     return (
       `when no real successor remains for completed Todo ${todoId}: ` +
       `loopx todo complete --goal-id ${shellArgument(goalId)} ` +
       `--todo-id ${shellArgument(todoId)}` +
-      argumentSuffix(completionTurnArgs) +
+      argumentSuffix(completionIdentityArgs) +
       argumentSuffix(lifecycleActorArgs) +
       " --no-follow-up --note '<public-safe no-follow-up rationale>'"
     );

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -73,7 +73,10 @@ from .control_plane.todos.completion_policy import (
     linked_successors_from_state,
     resolve_completion_policy,
 )
-from .control_plane.todos.completion_fence import completed_todo_replay
+from .control_plane.todos.completion_fence import (
+    completed_todo_replay,
+    local_todo_completion_identity,
+)
 from .control_plane.todos import completion_validation as completion_validation_module
 from .control_plane.todos.event_writeback import (
     complete_event_projected_goal_todo,
@@ -1649,6 +1652,7 @@ def complete_goal_todo(
     decision_outcome: str | None = None,
     evidence: str | None = None,
     completion_turn_key: str | None = None,
+    completion_identity_source: str | None = None,
     task_lease_idempotency_key: str | None = None,
     task_lease_expected_version: int | None = None,
     note: str | None = None,
@@ -1697,6 +1701,7 @@ def complete_goal_todo(
         dry_run=dry_run,
         no_followup=no_followup,
         completion_turn_key=completion_turn_key,
+        completion_identity_source=completion_identity_source,
     )
     validation_failure = validation_gate.get("failure")
     if validation_failure is not None:
@@ -1739,6 +1744,15 @@ def complete_goal_todo(
             raise ValueError(
                 f"todo_id {normalized_todo_id!r} was not found in active user or agent todos"
             )
+        if (
+            completion_turn_key is None
+            and str(completion_todo.get("status") or "") != TODO_STATUS_DONE
+        ):
+            completion_turn_key = local_todo_completion_identity(
+                goal_id=goal_id,
+                todo_id=str(completion_todo.get("todo_id") or todo_id),
+            )
+            completion_identity_source = "unscoped_completion"
         decision_target = None
         target_todo_id = normalize_todo_id(completion_todo.get("unblocks_todo_id"))
         if target_todo_id:
@@ -1769,6 +1783,7 @@ def complete_goal_todo(
             goal_id=goal_id,
             todo_id=todo_id,
             completion_turn_key=completion_turn_key, no_followup=no_followup,
+            completion_identity_source=completion_identity_source,
             handoff_mode=completion_handoff["handoff_mode"],
             mutation_authority=mutation_authority,
             state_file=str(resolved_state_file),
@@ -1785,7 +1800,12 @@ def complete_goal_todo(
                 todo=completion_todo,
                 actor_agent_id=agent_id or claimed_by,
                 idempotency_key=(
-                    task_lease_idempotency_key or completion_turn_key
+                    task_lease_idempotency_key
+                    or (
+                        completion_turn_key
+                        if completion_identity_source != "unscoped_completion"
+                        else None
+                    )
                 ),
                 expected_version=task_lease_expected_version,
                 require_active_when_key_supplied=(
@@ -1809,6 +1829,7 @@ def complete_goal_todo(
                     completion_todo.get("successor_todo_ids")
                 )
             ),
+            completion_identity_source=completion_identity_source,
         )
         linked_successors = linked_successors_from_state(
             lines=lines,
@@ -1844,6 +1865,7 @@ def complete_goal_todo(
                     context=event_context,
                     evidence=evidence,
                     completion_turn_key=completion_turn_key,
+                    completion_identity_source=completion_identity_source,
                     note=note,
                     no_followup=no_followup,
                     successor_todo_ids=normalized_successor_todo_ids,

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -75,7 +75,7 @@ from .control_plane.todos.completion_policy import (
 )
 from .control_plane.todos.completion_fence import (
     completed_todo_replay,
-    local_todo_completion_identity,
+    resolve_todo_completion_identity,
 )
 from .control_plane.todos import completion_validation as completion_validation_module
 from .control_plane.todos.event_writeback import (
@@ -109,6 +109,7 @@ from .control_plane.todos.text import (
 )
 from .control_plane.todos.unblock_resume import (
     apply_completed_user_todo_lifecycle,
+    completion_decision_target,
     require_completion_decision_outcome,
 )
 from .control_plane.todos.write_policy import (
@@ -1744,29 +1745,14 @@ def complete_goal_todo(
             raise ValueError(
                 f"todo_id {normalized_todo_id!r} was not found in active user or agent todos"
             )
-        if (
-            completion_turn_key is None
-            and str(completion_todo.get("status") or "") != TODO_STATUS_DONE
-        ):
-            completion_turn_key = local_todo_completion_identity(
-                goal_id=goal_id,
-                todo_id=str(completion_todo.get("todo_id") or todo_id),
-            )
-            completion_identity_source = "unscoped_completion"
-        decision_target = None
-        target_todo_id = normalize_todo_id(completion_todo.get("unblocks_todo_id"))
-        if target_todo_id:
-            target_match = find_todo_block(
-                lines,
-                todo_id=target_todo_id,
-                role="agent",
-            )
-            if target_match:
-                target_role, _target_section, _target_start, _target_end, target_block = (
-                    target_match
-                )
-                decision_target = dict(target_block)
-                decision_target["role"] = target_role
+        completion_turn_key, completion_identity_source = resolve_todo_completion_identity(
+            todo=completion_todo,
+            goal_id=goal_id,
+            todo_id=str(completion_todo.get("todo_id") or todo_id),
+            completion_turn_key=completion_turn_key,
+            completion_identity_source=completion_identity_source,
+        )
+        decision_target = completion_decision_target(lines, completion_todo)
         mutation_authority = authorize_todo_lifecycle_mutation(
             registry_path=registry_path,
             goal_id=goal_id,
@@ -1799,14 +1785,9 @@ def complete_goal_todo(
                 todo_id=todo_id,
                 todo=completion_todo,
                 actor_agent_id=agent_id or claimed_by,
-                idempotency_key=(
-                    task_lease_idempotency_key
-                    or (
-                        completion_turn_key
-                        if completion_identity_source != "unscoped_completion"
-                        else None
-                    )
-                ),
+                idempotency_key=(task_lease_idempotency_key or completion_turn_key)
+                if completion_identity_source != "unscoped_completion"
+                else task_lease_idempotency_key,
                 expected_version=task_lease_expected_version,
                 require_active_when_key_supplied=(
                     task_lease_idempotency_key is not None

--- a/scripts/qualify-doubao-terminal-settlement-live.py
+++ b/scripts/qualify-doubao-terminal-settlement-live.py
@@ -29,6 +29,15 @@ def _parser() -> argparse.ArgumentParser:
         )
     )
     parser.add_argument("--qualification-id", required=True)
+    parser.add_argument(
+        "--scenario",
+        choices=("ordered-settlement", "rejection-reentry"),
+        default="ordered-settlement",
+        help=(
+            "Qualification path: the existing quota settlement chain or the "
+            "post-refresh-rejection lifecycle reentry path."
+        ),
+    )
     parser.add_argument("--attempts", type=int, default=2)
     parser.add_argument("--timeout-seconds", type=float, default=90.0)
     parser.add_argument("--repo-root", type=Path, default=Path.cwd())
@@ -53,8 +62,13 @@ def main() -> int:
         for attempt in range(1, args.attempts + 1):
             run_id = f"{args.qualification_id}:r{attempt}"
             run_digest = sha256(run_id.encode("utf-8")).hexdigest()[:16]
+            qualify = (
+                actor.qualify_reentry
+                if args.scenario == "rejection-reentry"
+                else actor.qualify
+            )
             receipts.append(
-                actor.qualify(
+                qualify(
                     qualification_id=run_id,
                     fixture_root=temp_root / run_digest,
                 )
@@ -63,11 +77,13 @@ def main() -> int:
     result = {
         "schema_version": "terminal_settlement_model_behavior_live_v0",
         "qualification_id": args.qualification_id,
+        "scenario": args.scenario,
         "qualification_passed": passed,
         "attempts_required": args.attempts,
         "attempts_completed": len(receipts),
         "provider_call_count": sum(
-            int(item.get("tool_call_count") or 0) for item in receipts
+            int(item.get("provider_call_count") or item.get("tool_call_count") or 0)
+            for item in receipts
         ),
         "receipts": receipts,
         "source": source,

--- a/tests/control_plane/test_refresh_state_replan_gate.py
+++ b/tests/control_plane/test_refresh_state_replan_gate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 from copy import deepcopy
 from pathlib import Path
 
@@ -921,9 +922,10 @@ def test_todo_lifecycle_rejection_projects_exact_direct_settlement() -> None:
     assert transition["triggers"] == [
         {
             "kind": "completed_advancement_without_successor",
-            "todo_id": "todo_unsettled_completion",
-            "completion_turn_key": "turn-unsettled",
-        }
+                "todo_id": "todo_unsettled_completion",
+                "completion_turn_key": "turn-unsettled",
+                "completion_identity_source": "turn_settlement",
+            }
     ]
     actions = transition["next_cli_actions"]
     assert "--todo-id todo_unsettled_completion" in actions[0]
@@ -948,6 +950,8 @@ def test_todo_complete_then_refresh_cli_projects_direct_settlement(
                 "updated_at: 2026-08-22T00:00:00+00:00",
                 "---",
                 "",
+                "## User Todo / Owner Review Reading Queue",
+                "",
                 "## Agent Todo",
                 "",
             ]
@@ -967,6 +971,10 @@ def test_todo_complete_then_refresh_cli_projects_direct_settlement(
                         "status": "active",
                         "repo": str(project),
                         "state_file": state.name,
+                        "adapter": {
+                            "kind": "fixture_connected_delivery_v0",
+                            "status": "connected-delivery",
+                        },
                         "coordination": {
                             "agent_model": "peer_v1",
                             "registered_agents": [AGENT_ID],
@@ -1044,12 +1052,163 @@ def test_todo_complete_then_refresh_cli_projects_direct_settlement(
     projected_ids = {trigger["todo_id"] for trigger in transition["triggers"]}
     expected_ids = {str(todo["todo_id"]) for todo in todos}
     assert projected_ids == expected_ids
+    assert all(
+        trigger["completion_identity_source"] == "unscoped_completion"
+        and str(trigger["completion_turn_key"]).startswith("local_completion_")
+        for trigger in transition["triggers"]
+    )
     actions = transition["next_cli_actions"]
     for todo_id in expected_ids:
         assert any(f"--todo-id {todo_id}" in action for action in actions)
         assert f"--todo-id {todo_id}" in payload["error"]
+    lifecycle_actions = [
+        action for action in actions if "loopx todo complete" in action
+    ]
+    assert len(lifecycle_actions) == 2
+    assert all("--completion-identity-key" in action for action in lifecycle_actions)
+    assert all("--turn-instance-id" not in action for action in lifecycle_actions)
     assert all("refresh-state" not in action for action in actions)
     assert all("spend-slot" not in action for action in actions)
+
+    for action in lifecycle_actions:
+        tokens = shlex.split(action)
+        loopx_index = tokens.index("loopx")
+        assert cli_main(
+            [
+                "--registry",
+                str(registry_path),
+                "--format",
+                "json",
+                *tokens[loopx_index + 1 :],
+            ]
+        ) == 0
+        settled = json.loads(capsys.readouterr().out)
+        assert settled["completion_continuation"] == "no_followup"
+        assert settled["completion_recovery"] == (
+            "lifecycle_reentry_terminal_closeout"
+        )
+
+    quota_action = next(action for action in actions if "quota should-run" in action)
+    quota_tokens = shlex.split(quota_action)
+    loopx_index = quota_tokens.index("loopx")
+    terminal_exit = cli_main(
+        [
+            "--registry",
+            str(registry_path),
+            *quota_tokens[loopx_index + 1 :],
+        ]
+    )
+    terminal_quota = json.loads(capsys.readouterr().out)
+    assert terminal_exit == 1
+    assert terminal_quota["should_run"] is False
+    assert terminal_quota["effective_action"] == "terminal_no_followup"
+
+
+def test_legacy_unscoped_completion_projects_executable_identity_repair(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    state = project / "ACTIVE_GOAL_STATE.md"
+    state.write_text(
+        "---\n"
+        f"goal_id: {GOAL_ID}\n"
+        "updated_at: 2026-08-22T00:00:00+00:00\n"
+        "---\n\n"
+        "## User Todo / Owner Review Reading Queue\n\n"
+        "## Agent Todo\n\n"
+        "- [x] [P0] Complete legacy terminal slice.\n"
+        "  <!-- loopx:todo todo_id=todo_legacy_unscoped status=done "
+        "task_class=advancement_task "
+        f"claimed_by={AGENT_ID} no_followup=false "
+        "completion_continuation=active_goal "
+        "completed_at=2026-08-22T00%3A00%3A00%2B00%3A00 -->\n",
+        encoding="utf-8",
+    )
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "common_runtime_root": str(tmp_path / "runtime"),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": state.name,
+                        "adapter": {
+                            "kind": "fixture_connected_delivery_v0",
+                            "status": "connected-delivery",
+                        },
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": [AGENT_ID],
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert cli_main(
+        [
+            "--registry",
+            str(registry_path),
+            "--format",
+            "json",
+            "refresh-state",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--progress-scope",
+            "agent_lane",
+            "--classification",
+            "terminal_delivery_closeout",
+            "--delivery-batch-scale",
+            "single_surface",
+            "--delivery-outcome",
+            "surface_only",
+            "--no-global-sync",
+        ]
+    ) == 1
+    rejection = json.loads(capsys.readouterr().out)
+    transition = rejection["replan_transition"]
+    assert transition["triggers"] == [
+        {
+            "kind": "completed_advancement_without_successor",
+            "todo_id": "todo_legacy_unscoped",
+            "completion_turn_key": transition["triggers"][0][
+                "completion_turn_key"
+            ],
+            "completion_identity_source": "unscoped_completion",
+        }
+    ]
+    completion_key = transition["triggers"][0]["completion_turn_key"]
+    assert str(completion_key).startswith("local_completion_")
+    action = next(
+        item for item in transition["next_cli_actions"] if "loopx todo complete" in item
+    )
+    action_tokens = shlex.split(action)
+    loopx_index = action_tokens.index("loopx")
+    assert cli_main(
+        [
+            "--registry",
+            str(registry_path),
+            "--format",
+            "json",
+            *action_tokens[loopx_index + 1 :],
+        ]
+    ) == 0
+    repaired = json.loads(capsys.readouterr().out)
+
+    assert repaired["completion_continuation"] == "no_followup"
+    assert repaired["completion_recovery"] == (
+        "lifecycle_reentry_terminal_closeout"
+    )
+    assert f"completion_turn_key={completion_key}" in state.read_text(encoding="utf-8")
 
 
 def test_persisted_semantic_no_followup_ack_cannot_retire_todo_gap() -> None:

--- a/tests/control_plane/test_refresh_state_replan_gate.py
+++ b/tests/control_plane/test_refresh_state_replan_gate.py
@@ -985,6 +985,24 @@ def test_todo_complete_then_refresh_cli_projects_direct_settlement(
         ),
         encoding="utf-8",
     )
+    assert cli_main(
+        [
+            "--registry",
+            str(registry_path),
+            "--format",
+            "json",
+            "todo",
+            "list",
+            "--goal-id",
+            GOAL_ID,
+            "--completion-identity-key",
+            "local_completion_00000000000000000000000000000000",
+        ]
+    ) == 1
+    unsupported_identity = json.loads(capsys.readouterr().out)
+    assert unsupported_identity["error"] == (
+        "--completion-identity-key is supported only by todo complete reentry"
+    )
     todos = [
         add_goal_todo(
             registry_path=registry_path,

--- a/tests/control_plane/test_replan_settlement_runtime.py
+++ b/tests/control_plane/test_replan_settlement_runtime.py
@@ -15,6 +15,7 @@ def _reentry(**overrides: object) -> dict[str, object]:
                 "kind": "completed_advancement_without_successor",
                 "todo_id": "todo_current001",
                 "completion_turn_key": "turn-current001",
+                "completion_identity_source": "turn_settlement",
             }
         ],
         "next_cli_actions": ["loopx todo complete --todo-id todo_current001"],

--- a/tests/control_plane/test_terminal_settlement_tool_behavior.py
+++ b/tests/control_plane/test_terminal_settlement_tool_behavior.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from loopx.control_plane.testing.model_tool_behavior import (
+    ScriptedAssistantAction,
     ScriptedDoubaoExecTransport,
     ScriptedExecToolAction,
 )
@@ -67,6 +68,48 @@ def _terminal_action(request: Mapping[str, Any]) -> ScriptedExecToolAction:
     )
 
 
+def _latest_reentry_transition(request: Mapping[str, Any]) -> dict[str, Any]:
+    for message in request["messages"]:
+        if message.get("role") != "tool":
+            continue
+        try:
+            payload = json.loads(message["content"])
+        except (json.JSONDecodeError, TypeError):
+            continue
+        transition = (
+            payload.get("replan_transition") if isinstance(payload, dict) else None
+        )
+        if isinstance(transition, dict):
+            return transition
+    raise AssertionError("scripted model did not receive the real rejection packet")
+
+
+def _reentry_todo_action(index: int):
+    def action(request: Mapping[str, Any]) -> ScriptedExecToolAction:
+        transition = _latest_reentry_transition(request)
+        commands = [
+            item
+            for item in transition["next_cli_actions"]
+            if "loopx todo complete" in item
+        ]
+        command = commands[index]
+        command = command[command.index("loopx ") :].replace(
+            "<public-safe no-follow-up rationale>",
+            f"validated terminal slice {index + 1}; no successor remains",
+        )
+        return ScriptedExecToolAction(command=command)
+
+    return action
+
+
+def _reentry_quota_action(request: Mapping[str, Any]) -> ScriptedExecToolAction:
+    transition = _latest_reentry_transition(request)
+    command = next(
+        item for item in transition["next_cli_actions"] if "quota should-run" in item
+    )
+    return ScriptedExecToolAction(command=command)
+
+
 def test_real_tool_loop_settles_final_todo_after_spend(tmp_path: Path) -> None:
     fixture = _build_fixture(tmp_path / "oracle")
     transport = ScriptedDoubaoExecTransport(
@@ -93,7 +136,7 @@ def test_real_tool_loop_settles_final_todo_after_spend(tmp_path: Path) -> None:
     )
 
     assert receipt["failure_code"] is None, str(receipt["failure_code"])
-    assert receipt["qualification_passed"] is True
+    assert receipt["qualification_passed"] is True, json.dumps(receipt, sort_keys=True)
     assert receipt["observed_tool_sequence"] == [
         "quota_should_run",
         "delivery_validation",
@@ -201,3 +244,102 @@ def test_tool_loop_rejects_spend_before_writeback(tmp_path: Path) -> None:
     assert receipt["qualification_passed"] is False
     assert receipt["failure_code"] == "quota_spend_before_writeback"
     assert receipt["settlement_receipt_steps"] == []
+
+
+def test_real_rejection_loop_settles_projected_todos_then_stops(
+    tmp_path: Path,
+) -> None:
+    transport = ScriptedDoubaoExecTransport(
+        [
+            _reentry_todo_action(0),
+            _reentry_todo_action(1),
+            _reentry_quota_action,
+            ScriptedAssistantAction(content="Terminal lifecycle is settled."),
+        ]
+    )
+
+    receipt = DoubaoTerminalSettlementToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify_reentry(
+        qualification_id="terminal-reentry-tool-loop-001",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is True, json.dumps(receipt, sort_keys=True)
+    assert receipt["failure_code"] is None
+    assert receipt["provider_call_count"] == 4
+    assert receipt["tool_call_count"] == 3
+    assert receipt["projected_todo_count"] == 2
+    assert receipt["settled_todo_count"] == 2
+    assert receipt["completion_identity_preserved"] is True
+    assert receipt["terminal_quota_observed"] is True
+    assert receipt["model_stopped_after_terminal_quota"] is True
+    assert receipt["observed_tool_sequence"] == [
+        "todo_lifecycle_settlement",
+        "todo_lifecycle_settlement",
+        "terminal_quota_reentry",
+    ]
+    transition = _latest_reentry_transition(transport.requests[0])
+    assert len(transition["triggers"]) == 2
+    assert all(
+        trigger["completion_identity_source"] == "unscoped_completion"
+        for trigger in transition["triggers"]
+    )
+    assert all(
+        str(trigger["completion_turn_key"]).startswith("local_completion_")
+        for trigger in transition["triggers"]
+    )
+    receipt_text = json.dumps(receipt, sort_keys=True)
+    assert all(
+        trigger["todo_id"] not in receipt_text for trigger in transition["triggers"]
+    )
+
+
+def test_rejection_loop_rejects_repeated_refresh(tmp_path: Path) -> None:
+    transport = ScriptedDoubaoExecTransport(
+        [
+            ScriptedExecToolAction(
+                command=(
+                    "loopx refresh-state --goal-id terminal-reentry-fixture "
+                    "--agent-id codex-terminal-reentry"
+                )
+            )
+        ]
+    )
+
+    receipt = DoubaoTerminalSettlementToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify_reentry(
+        qualification_id="terminal-reentry-repeat-refresh",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is False
+    assert receipt["failure_code"] == "repeated_refresh_state"
+    assert receipt["settled_todo_count"] == 0
+
+
+def test_rejection_loop_rejects_completion_identity_drift(tmp_path: Path) -> None:
+    def drifted_action(request: Mapping[str, Any]) -> ScriptedExecToolAction:
+        action = _reentry_todo_action(0)(request)
+        command = action.command.replace(
+            "local_completion_",
+            "local_completion_drift_",
+            1,
+        )
+        return ScriptedExecToolAction(command=command)
+
+    transport = ScriptedDoubaoExecTransport([drifted_action])
+    receipt = DoubaoTerminalSettlementToolBehaviorActor(
+        api_key="test-only-placeholder",
+        transport=transport,
+    ).qualify_reentry(
+        qualification_id="terminal-reentry-identity-drift",
+        fixture_root=tmp_path / "actor",
+    )
+
+    assert receipt["qualification_passed"] is False
+    assert receipt["failure_code"] == "lifecycle_settlement_identity_mismatch"
+    assert receipt["settled_todo_count"] == 0

--- a/tests/control_plane/test_todo_completion_fence_runtime.py
+++ b/tests/control_plane/test_todo_completion_fence_runtime.py
@@ -55,7 +55,24 @@ def test_python_facade_sends_one_coarse_typed_request(monkeypatch) -> None:
         },
         "requested_no_followup": True,
         "requested_completion_turn_key": "turn-a",
+        "requested_completion_identity_source": None,
+        "goal_id": None,
+        "todo_id": None,
     }
+
+
+def test_python_facade_projects_stable_unscoped_completion_identity() -> None:
+    first = completion_fence.local_todo_completion_identity(
+        goal_id="goal-example",
+        todo_id="todo_local001",
+    )
+    second = completion_fence.local_todo_completion_identity(
+        goal_id="goal-example",
+        todo_id="todo_local001",
+    )
+
+    assert first == second
+    assert first.startswith("local_completion_")
 
 
 @pytest.mark.parametrize(

--- a/tests/control_plane/test_todo_completion_state_runtime.py
+++ b/tests/control_plane/test_todo_completion_state_runtime.py
@@ -51,8 +51,27 @@ def test_python_facade_sends_one_typed_state_request(monkeypatch) -> None:
             },
             "requested_no_followup": True,
             "has_successor": False,
+            "completion_identity_source": None,
         },
     }
+
+
+def test_lifecycle_reentry_has_distinct_recovery_receipt() -> None:
+    state = completion_state.completion_state_for_todo_write(
+        {
+            "status": "done",
+            "no_followup": "false",
+            "completion_continuation": "active_goal",
+        },
+        requested_no_followup=True,
+        has_successor=False,
+        completion_identity_source="lifecycle_reentry",
+    )
+
+    assert state == completion_state.TodoCompletionState(
+        continuation="no_followup",
+        recovery="lifecycle_reentry_terminal_closeout",
+    )
 
 
 def test_scalar_normalization_uses_bounded_process_cache(monkeypatch) -> None:

--- a/tests/control_plane/test_todo_metadata_schema.py
+++ b/tests/control_plane/test_todo_metadata_schema.py
@@ -151,6 +151,21 @@ def test_todo_metadata_round_trip_preserves_terminal_recovery_state() -> None:
     }
 
 
+def test_todo_metadata_round_trip_preserves_lifecycle_reentry_recovery() -> None:
+    line = format_todo_metadata_line(
+        todo_id="todo_terminal002",
+        status="done",
+        no_followup=True,
+        completion_continuation="no_followup",
+        completion_recovery="lifecycle_reentry_terminal_closeout",
+    )
+
+    assert line is not None
+    assert parse_todo_metadata_line(line)["completion_recovery"] == (
+        "lifecycle_reentry_terminal_closeout"
+    )
+
+
 def test_todo_metadata_parser_ignores_noncanonical_field_names() -> None:
     parsed = parse_todo_metadata_line(
         "  <!-- loopx:todo "
@@ -226,7 +241,6 @@ def test_todo_metadata_formatter_enforces_cross_field_constraints() -> None:
             claimed_by="codex-quality",
             excluded_agents=["codex-quality"],
         )
-
 
 
 def test_multi_subagent_todo_parser_projects_untruncated_admission_authority() -> None:

--- a/tests/control_plane_ts/replan_settlement.test.ts
+++ b/tests/control_plane_ts/replan_settlement.test.ts
@@ -131,6 +131,30 @@ test("Todo lifecycle reentry rejects untyped succession triggers", () => {
   );
 });
 
+test("local-shaped turn identities remain turn-scoped unless exactly derived", () => {
+  const projection = projectTodoLifecycleSettlementReentry({
+    schema_version: TODO_LIFECYCLE_REENTRY_REQUEST_SCHEMA,
+    goal_id: "goal-example",
+    triggers: [{
+      kind: "completed_advancement_without_successor",
+      todo_id: "todo_333333333333",
+      completion_turn_key: "local_completion_00000000000000000000000000000000",
+    }],
+    lifecycle_actor_args: [],
+    quota_scoped_args: [],
+  });
+
+  assert.equal(
+    (projection.triggers as Record<string, unknown>[])[0]
+      ?.completion_identity_source,
+    "turn_settlement",
+  );
+  assert.match(
+    (projection.next_cli_actions as string[])[0] ?? "",
+    /--turn-instance-id local_completion_0{32}/,
+  );
+});
+
 test("Todo lifecycle reentry shell-quotes projected identities", () => {
   const projection = projectTodoLifecycleSettlementReentry({
     schema_version: TODO_LIFECYCLE_REENTRY_REQUEST_SCHEMA,

--- a/tests/control_plane_ts/replan_settlement.test.ts
+++ b/tests/control_plane_ts/replan_settlement.test.ts
@@ -98,16 +98,19 @@ test("Todo lifecycle reentry preserves exact completion identities", () => {
           kind: "completed_advancement_without_successor",
           todo_id: "todo_111111111111",
           completion_turn_key: "turn-implement",
+          completion_identity_source: "turn_settlement",
         },
         {
           kind: "completed_advancement_without_successor",
           todo_id: "todo_222222222222",
-          completion_turn_key: null,
+          completion_turn_key:
+            "local_completion_2fdda7fd139a77f97e72ca43d6e6a72a",
+          completion_identity_source: "unscoped_completion",
         },
       ],
       next_cli_actions: [
         "when no real successor remains for completed Todo todo_111111111111: loopx todo complete --goal-id goal-example --todo-id todo_111111111111 --turn-instance-id turn-implement --agent-id current-agent --no-follow-up --note '<public-safe no-follow-up rationale>'",
-        "when no real successor remains for completed Todo todo_222222222222: loopx todo complete --goal-id goal-example --todo-id todo_222222222222 --agent-id current-agent --no-follow-up --note '<public-safe no-follow-up rationale>'",
+        "when no real successor remains for completed Todo todo_222222222222: loopx todo complete --goal-id goal-example --todo-id todo_222222222222 --completion-identity-key local_completion_2fdda7fd139a77f97e72ca43d6e6a72a --agent-id current-agent --no-follow-up --note '<public-safe no-follow-up rationale>'",
         "otherwise link or create one real runnable successor for the exact completed Todo; do not create lifecycle-only filler",
         "loopx --format json quota should-run --goal-id goal-example --agent-id current-agent --available-capability shell",
       ],

--- a/tests/control_plane_ts/todo_completion_fence.test.ts
+++ b/tests/control_plane_ts/todo_completion_fence.test.ts
@@ -4,6 +4,8 @@ import test from "node:test";
 
 import {
   evaluateTodoCompletionFence,
+  projectTodoCompletionIdentity,
+  TODO_COMPLETION_IDENTITY_REQUEST_SCHEMA,
   TODO_COMPLETION_FENCE_REQUEST_SCHEMA,
 } from "../../loopx/control_plane/todos/completion_fence.ts";
 
@@ -139,4 +141,74 @@ test("evaluation is input-immutable and normalizes persisted metadata", () => {
   assert.equal(result.outcome, "replay");
   assert.equal(result.completion_continuation, "no_followup");
   assert.deepEqual(request, before);
+});
+
+test("unscoped completion identity is stable and repairs a legacy terminal gap", () => {
+  const identity = projectTodoCompletionIdentity({
+    schema_version: TODO_COMPLETION_IDENTITY_REQUEST_SCHEMA,
+    goal_id: "goal-example",
+    todo_id: "todo_legacy001",
+  });
+  assert.equal(identity.identity_source, "unscoped_completion");
+  assert.match(
+    String(identity.completion_identity_key),
+    /^local_completion_[0-9a-f]{32}$/,
+  );
+  assert.deepEqual(
+    evaluateTodoCompletionFence({
+      schema_version: TODO_COMPLETION_FENCE_REQUEST_SCHEMA,
+      projection_source: "materialized",
+      goal_id: "goal-example",
+      todo_id: "todo_legacy001",
+      todo: {
+        status: "done",
+        no_followup: false,
+        completion_continuation: "active_goal",
+        completion_turn_key: null,
+        successor_todo_ids: [],
+      },
+      requested_no_followup: true,
+      requested_completion_turn_key: identity.completion_identity_key,
+      requested_completion_identity_source: "lifecycle_reentry",
+    }),
+    {
+      schema_version: "loopx_todo_completion_fence_result_v0",
+      outcome: "continue",
+      reason: "unscoped_completion_identity_repair",
+      status: "done",
+      terminal_before_request: true,
+      completion_continuation: "active_goal",
+    },
+  );
+});
+
+test("lifecycle reentry rejects invented identities and open Todos", () => {
+  const base = {
+    schema_version: TODO_COMPLETION_FENCE_REQUEST_SCHEMA,
+    projection_source: "materialized",
+    goal_id: "goal-example",
+    todo_id: "todo_legacy001",
+    todo: {
+      status: "done",
+      no_followup: false,
+      completion_continuation: "active_goal",
+      completion_turn_key: null,
+      successor_todo_ids: [],
+    },
+    requested_no_followup: true,
+    requested_completion_turn_key: "local_completion_00000000000000000000000000000000",
+    requested_completion_identity_source: "lifecycle_reentry",
+  };
+  assert.throws(
+    () => evaluateTodoCompletionFence(base),
+    /different completion_turn_key/,
+  );
+  assert.throws(
+    () =>
+      evaluateTodoCompletionFence({
+        ...base,
+        todo: { ...base.todo, status: "open" },
+      }),
+    /requires an already completed Todo/,
+  );
 });

--- a/tests/control_plane_ts/todo_completion_state.test.ts
+++ b/tests/control_plane_ts/todo_completion_state.test.ts
@@ -109,3 +109,24 @@ test("state and metadata decisions do not mutate caller input", () => {
   buildTodoCompletionMetadataUpdates(metadata);
   assert.deepEqual(metadata, metadataBefore);
 });
+
+test("lifecycle reentry emits a distinct terminal recovery", () => {
+  assert.deepEqual(
+    selectTodoCompletionState({
+      schema_version: TODO_COMPLETION_STATE_REQUEST_SCHEMA,
+      todo: {
+        status: "done",
+        no_followup: false,
+        completion_continuation: "active_goal",
+      },
+      requested_no_followup: true,
+      has_successor: false,
+      completion_identity_source: "lifecycle_reentry",
+    }),
+    {
+      schema_version: "loopx_todo_completion_state_result_v0",
+      continuation: "no_followup",
+      recovery: "lifecycle_reentry_terminal_closeout",
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Fixes #3473 by making the Todo lifecycle actions projected after a rejected `refresh-state` executable by the real CLI and completion fence.

- separates local Todo completion identity from quota turn settlement identity
- derives a stable TS-owned `local_completion_<digest>` identity for unscoped completions
- adds a narrow `--completion-identity-key` CLI path for projected `--no-follow-up` lifecycle reentry
- permits legacy null-identity repair only for the exact TS-derived key on an already completed Todo
- preserves receipt-backed `--turn-instance-id` behavior for quota-scoped settlement
- executes projected actions end-to-end in regression tests, then verifies terminal quota exit
- adds a real Ark/Doubao model-behavior scenario for rejection -> two lifecycle settlements -> terminal quota -> stop

## Ownership and refactor boundary

Completion identity derivation, fence legality, and reentry action projection remain TypeScript-owned. Python adapts the typed contract and persists the resulting identity; it does not recreate the state rule. A bounded companion refactor moves identity normalization and decision-target lookup out of the hot `loopx/todos.py` facade, keeping that module at its maintainability ceiling instead of adding new debt.

This remains a domain-local Todo reducer/ACK contract rather than a new generic Effect Program abstraction: no second external effect or ordered receipt chain is introduced.

## Validation

- 178 focused Python control-plane tests passed
- TypeScript control-plane typecheck passed
- 92 TypeScript control-plane tests passed
- live weak-model qualification (`doubao-seed-2-1-turbo-260628`) passed 2/2 attempts on commit `6b5714373`
  - exact sequence each time: two Todo lifecycle settlements, terminal quota read, then stop
  - completion identity preserved; no repeated refresh or quota spend
- `loopx canary premerge --from-git-diff --tier standard` passed
  - 18/18 selected checks executed
  - 0 failures, 0 warnings, 0 manual holds
  - maintainability ratchet and public/private boundary scan passed

