### PR TITLE
ci(sonarcloud): add non-blocking SonarCloud analysis

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,74 @@
+name: SonarCloud
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/sonarcloud.yml"
+      - "sonar-project.properties"
+      - "loopx/**"
+      - "apps/**"
+      - "scripts/**"
+      - "tests/**"
+      - "package.json"
+      - "package-lock.json"
+      - "pyproject.toml"
+      - "tsconfig.control-plane.json"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/sonarcloud.yml"
+      - "sonar-project.properties"
+      - "loopx/**"
+      - "apps/**"
+      - "scripts/**"
+      - "tests/**"
+      - "package.json"
+      - "package-lock.json"
+      - "pyproject.toml"
+      - "tsconfig.control-plane.json"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sonarcloud-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sonar:
+    name: SonarCloud analysis (non-blocking)
+    runs-on: ubuntu-latest
+    # Skip until maintainers provision SONAR_TOKEN so this is never a blocker.
+    if: ${{ secrets.SONAR_TOKEN != '' }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install test dependencies
+        run: python -m pip install --disable-pip-version-check -e ".[test]"
+
+      - name: Run fast tests with coverage XML
+        run: >-
+          python -m pytest -q -n 2
+          --cov=loopx
+          --cov-report=term
+          --cov-report=xml:coverage.xml
+
+      - name: SonarCloud scan
+        # Analysis-only: findings are reported to the PR/dashboard but never
+        # block merge. Remove this flag only if the quality gate becomes a
+        # required check.
+        continue-on-error: true
+        uses: SonarSource/sonarqube-scan-action@v8.2.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,23 @@
+sonar.organization=huangruiteng
+sonar.projectKey=huangruiteng_loopx
+sonar.projectName=LoopX
+
+# Public project links
+sonar.links.homepage=https://github.com/huangruiteng/loopx
+sonar.links.scm=https://github.com/huangruiteng/loopx
+
+sonar.sourceEncoding=UTF-8
+
+# Analyzed surfaces: Python product core, TypeScript/JavaScript product
+# surfaces, and helper scripts. Generated frontend bundles, legacy
+# deprecate/, and non-analyzed runtimes (Rust/Tauri) are excluded.
+sonar.sources=loopx,apps,scripts
+sonar.tests=tests
+sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/src-tauri/**,loopx/web/chat/assets/**,**/*.min.js,deprecate/**
+
+# Python
+sonar.python.version=3.11
+sonar.python.coverage.reportPaths=coverage.xml
+
+# Non-blocking by default: report findings, never gate the workflow.
+sonar.qualitygate.wait=false


### PR DESCRIPTION
## What

Introduces SonarCloud (SonarQube Cloud) analysis for the public repo as an **optional, non-blocking** check:

- `sonar-project.properties` — Python core + TypeScript/JavaScript product surfaces analyzed; generated frontend bundles, `deprecate/`, and Rust/Tauri excluded.
- `.github/workflows/sonarcloud.yml` — produces `coverage.xml` via `pytest --cov-report=xml` and runs `SonarSource/sonarqube-scan-action@v8.2.1` (latest patched release; clears GHSA-f79p-9c5r-xg88 and GHSA-5xq9-5g24-4g6f flagged by dependency-review).

## Design

- **Non-blocking by default**: `sonar.qualitygate.wait=false` and `continue-on-error: true`; the SonarCloud check is never required for merge.
- **Skipped until configured**: the job is gated on `secrets.SONAR_TOKEN != ''`, so it stays skipped until a maintainer provisions the secret — it cannot fail CI.
- Existing required gates (ruff/mypy, pytest coverage, TS typecheck/tests, canary ratchet) are unchanged.

## Validation

- `loopx canary premerge --from-git-diff`: passed (diff hygiene + public boundary scan).
- Workflow YAML parsed successfully; action version verified against upstream and against the two high-severity advisories.

## Maintainer setup (one-time, after merge)

1. Create the project on [sonarcloud.io](https://sonarcloud.io) from GitHub (org `huangruiteng`, key `huangruiteng_loopx`), or adjust the key/org in `sonar-project.properties`.
2. Add a `SONAR_TOKEN` repository secret.
3. Optionally enable PR decoration; the scan then posts analysis to PRs automatically.

No behavior change to runtime, install, or existing quality gates.