### PR TITLE
Benchmark: reconcile provider board shards into canonical state

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -446,7 +446,9 @@ Without `--execute`, the command previews the reconciled board. Reconciliation i
 idempotent and monotonic: newer legal lifecycle transitions advance a stable run,
 late non-terminal rows cannot reopen a terminal run, and conflicting terminal
 states fail closed. Receipts report only compact row counts and never record source
-paths.
+paths. The command validates the complete candidate set before its first write;
+executed batches are replay-safe, while providers remain responsible for retrying a
+batch that is interrupted before its receipt is returned.
 
 ## Post-run case insight monitor
 

--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -430,6 +430,24 @@ Full post-run analysis stays in private `benchmark_case_insight_v0` storage. The
 board records only its compact status or handle, so reading the board cannot widen
 the solving agent's evidence boundary.
 
+Providers may keep separate public-safe ledgers for independent runner queues. Fold
+those shards into the canonical project board before agent readback:
+
+```bash
+loopx benchmark experiment-board-reconcile \
+  --goal-id <goal-id> \
+  --source-ledger <provider-a.jsonl> \
+  --source-ledger <provider-b.jsonl> \
+  --execute \
+  --format json
+```
+
+Without `--execute`, the command previews the reconciled board. Reconciliation is
+idempotent and monotonic: newer legal lifecycle transitions advance a stable run,
+late non-terminal rows cannot reopen a terminal run, and conflicting terminal
+states fail closed. Receipts report only compact row counts and never record source
+paths.
+
 ## Post-run case insight monitor
 
 Benchmark startup should create one `continuous_monitor` todo that owns both the

--- a/loopx/capabilities/benchmark_toolkit/__init__.py
+++ b/loopx/capabilities/benchmark_toolkit/__init__.py
@@ -23,6 +23,7 @@ from .experiment_board import (
     build_benchmark_experiment_board,
     default_benchmark_experiment_board_path,
     normalize_benchmark_experiment_board_row,
+    preview_benchmark_experiment_board_reconcile,
     preview_benchmark_experiment_board_upsert,
     read_benchmark_experiment_board_rows,
     render_benchmark_experiment_board_markdown,
@@ -35,11 +36,6 @@ from .integrity import (
     INTEGRITY_EVIDENCE_CATEGORIES,
     REQUIRED_RUNTIME_ATTESTATIONS,
     build_benchmark_integrity_qualification,
-)
-from .reward_contract import (
-    REWARD_CONTRACT_SCHEMA_VERSION,
-    verify_verifier_reward_file,
-    verify_verifier_reward_json,
 )
 from .native_codex_goal import (
     NativeGoalConfig,
@@ -91,6 +87,11 @@ from .public_trajectory import (
     PublicTrajectorySummaryError,
     build_native_goal_public_trajectory_summary,
 )
+from .reward_contract import (
+    REWARD_CONTRACT_SCHEMA_VERSION,
+    verify_verifier_reward_file,
+    verify_verifier_reward_json,
+)
 from .run_permissions import (
     DEFAULT_RUN_PERMISSION_ALLOWED_ACTIONS,
     DEFAULT_RUN_PERMISSION_FORBIDDEN_ACTIONS,
@@ -128,6 +129,7 @@ __all__ = [
     "NATIVE_GOAL_LIFECYCLE_SCHEMA_VERSION",
     "PUBLIC_TRAJECTORY_SUMMARY_SCHEMA_VERSION",
     "REQUIRED_RUNTIME_ATTESTATIONS",
+    "REWARD_CONTRACT_SCHEMA_VERSION",
     "RUN_PERMISSION_POLICY_SCHEMA_VERSION",
     "RUN_PERMISSION_QUOTA_PROJECTION_SCHEMA_VERSION",
     "BenchmarkSourceRevisionFence",
@@ -177,6 +179,7 @@ __all__ = [
     "native_codex_profile_environment",
     "normalize_benchmark_experiment_board_row",
     "observe_native_goal_event",
+    "preview_benchmark_experiment_board_reconcile",
     "preview_benchmark_experiment_board_upsert",
     "probe_native_goal_process",
     "read_benchmark_experiment_board_rows",
@@ -184,8 +187,6 @@ __all__ = [
     "refresh_native_goal_status",
     "render_benchmark_experiment_board_markdown",
     "render_native_codex_goal_prompt",
-    "verify_verifier_reward_file",
-    "verify_verifier_reward_json",
     "run_native_goal_process",
     "run_native_goal_process_until_terminal",
     "run_native_goal_turn",
@@ -194,5 +195,7 @@ __all__ = [
     "start_native_goal_turn",
     "upsert_benchmark_experiment_board_row",
     "validate_run_permission_policy",
+    "verify_verifier_reward_file",
+    "verify_verifier_reward_json",
     "wait_native_goal_turn",
 ]

--- a/loopx/capabilities/benchmark_toolkit/catalog_entry.py
+++ b/loopx/capabilities/benchmark_toolkit/catalog_entry.py
@@ -82,6 +82,21 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
         },
         {
             "command": (
+                "loopx benchmark experiment-board-reconcile --goal-id <goal-id> "
+                "--source-ledger <provider-board.jsonl> --execute --format json"
+            ),
+            "purpose": (
+                "Monotonically fold one or more provider-owned public-safe board "
+                "shards into the canonical project experiment board; omit --execute "
+                "for a no-write preview."
+            ),
+            "write_boundary": (
+                "explicit project-local canonical board write; source paths are "
+                "never recorded and conflicting terminal states fail closed"
+            ),
+        },
+        {
+            "command": (
                 "loopx benchmark integrity-qualification "
                 "--trajectory-json <private.json> "
                 "--runtime-attestation-json <attestation.json> "
@@ -131,7 +146,8 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
         "benchmark_start_hint": (
             "At benchmark start, read the experiment board before selecting or "
             "launching a case; update the same stable row at every material run "
-            "transition."
+            "transition. Providers that keep separate board shards reconcile them "
+            "into the canonical board before agent readback."
         ),
         "required_sequence": [
             "read_experiment_board_before_launch_or_case_selection",
@@ -152,6 +168,10 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
             "write": (
                 "loopx benchmark experiment-board-upsert --goal-id <goal-id> "
                 "--row-json <compact-row.json> --execute --format json"
+            ),
+            "reconcile": (
+                "loopx benchmark experiment-board-reconcile --goal-id <goal-id> "
+                "--source-ledger <provider-board.jsonl> --execute --format json"
             ),
         },
         "selection_rule": (

--- a/loopx/capabilities/benchmark_toolkit/experiment_board.py
+++ b/loopx/capabilities/benchmark_toolkit/experiment_board.py
@@ -24,6 +24,7 @@ _RUN_STATUS_TRANSITIONS = {
     "runner_invalid": {"runner_invalid"},
     "cancelled": {"cancelled"},
 }
+_TERMINAL_RUN_STATUSES = {"completed", "runner_invalid", "cancelled"}
 _CLAIM_SCOPES = {"matched_study", "diagnostic_only", "inventory_only"}
 _TREATMENT_FIDELITY = {"qualified", "failed", "pending", "not_applicable"}
 _INSIGHT_STATUSES = {"pending", "complete", "not_required"}
@@ -436,6 +437,124 @@ def upsert_benchmark_experiment_board_row(
         "row": row,
         "write": write,
     }
+
+
+def _benchmark_experiment_board_row_key_tuple(
+    payload: Mapping[str, Any],
+) -> tuple[str, str, str, str]:
+    key = benchmark_experiment_board_row_key(payload)
+    return (
+        key["benchmark_id"],
+        key["study_id"],
+        key["case_id"],
+        key["run_id"],
+    )
+
+
+def _benchmark_experiment_board_observed_at(payload: Mapping[str, Any]) -> datetime:
+    return datetime.fromisoformat(str(payload["observed_at"]))
+
+
+def _select_reconciled_benchmark_experiment_board_row(
+    current: dict[str, Any] | None,
+    candidates: list[dict[str, Any]],
+) -> tuple[dict[str, Any], int]:
+    ordered = sorted(candidates, key=_benchmark_experiment_board_observed_at)
+    selected = current
+    stale_skipped = 0
+    for candidate in ordered:
+        if selected is None:
+            selected = candidate
+            continue
+        if selected == candidate:
+            continue
+
+        selected_at = _benchmark_experiment_board_observed_at(selected)
+        candidate_at = _benchmark_experiment_board_observed_at(candidate)
+        selected_status = str(selected["status"])
+        candidate_status = str(candidate["status"])
+
+        if candidate_at == selected_at:
+            raise ValueError(
+                "benchmark experiment board sources contain ambiguous rows at "
+                "the same observed_at timestamp"
+            )
+        if candidate_at < selected_at:
+            stale_skipped += 1
+            continue
+        if selected_status in _TERMINAL_RUN_STATUSES:
+            if candidate_status in _TERMINAL_RUN_STATUSES:
+                if candidate_status != selected_status:
+                    raise ValueError(
+                        "benchmark experiment board sources contain conflicting "
+                        "terminal states"
+                    )
+                selected = candidate
+                continue
+            stale_skipped += 1
+            continue
+        if candidate_status not in _RUN_STATUS_TRANSITIONS[selected_status]:
+            stale_skipped += 1
+            continue
+        selected = candidate
+
+    if selected is None:
+        raise ValueError("benchmark experiment board reconcile requires source rows")
+    return selected, stale_skipped
+
+
+def preview_benchmark_experiment_board_reconcile(
+    rows: Iterable[Mapping[str, Any]],
+    source_rows: Iterable[Mapping[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    """Fold provider-owned board shards into one monotonic canonical projection."""
+
+    normalized_rows = [
+        normalize_benchmark_experiment_board_row(dict(row)) for row in rows
+    ]
+    normalized_sources = [
+        normalize_benchmark_experiment_board_row(dict(row)) for row in source_rows
+    ]
+    if not normalized_sources:
+        raise ValueError("benchmark experiment board reconcile requires source rows")
+
+    existing_by_key = {
+        _benchmark_experiment_board_row_key_tuple(row): row for row in normalized_rows
+    }
+    candidates_by_key: dict[tuple[str, str, str, str], list[dict[str, Any]]] = {}
+    for row in normalized_sources:
+        candidates_by_key.setdefault(
+            _benchmark_experiment_board_row_key_tuple(row), []
+        ).append(row)
+
+    result_by_key = dict(existing_by_key)
+    counts = {
+        "source_row_count": len(normalized_sources),
+        "candidate_run_count": len(candidates_by_key),
+        "inserted": 0,
+        "updated": 0,
+        "unchanged": 0,
+        "stale_skipped": 0,
+    }
+    for key, candidates in candidates_by_key.items():
+        current = existing_by_key.get(key)
+        selected, stale_skipped = _select_reconciled_benchmark_experiment_board_row(
+            current, candidates
+        )
+        counts["stale_skipped"] += stale_skipped
+        result_by_key[key] = selected
+        if current is None:
+            counts["inserted"] += 1
+        elif current == selected:
+            counts["unchanged"] += 1
+        else:
+            counts["updated"] += 1
+
+    ordered_keys = [
+        _benchmark_experiment_board_row_key_tuple(row) for row in normalized_rows
+    ]
+    ordered_keys.extend(key for key in candidates_by_key if key not in existing_by_key)
+    return [result_by_key[key] for key in ordered_keys], counts
 
 
 def _metric_delta(

--- a/loopx/capabilities/benchmark_toolkit/experiment_board.py
+++ b/loopx/capabilities/benchmark_toolkit/experiment_board.py
@@ -455,6 +455,42 @@ def _benchmark_experiment_board_observed_at(payload: Mapping[str, Any]) -> datet
     return datetime.fromisoformat(str(payload["observed_at"]))
 
 
+def _advance_reconciled_benchmark_experiment_board_row(
+    selected: dict[str, Any],
+    candidate: dict[str, Any],
+) -> tuple[dict[str, Any], bool]:
+    if selected == candidate:
+        return selected, False
+
+    selected_status = str(selected["status"])
+    candidate_status = str(candidate["status"])
+    if (
+        selected_status in _TERMINAL_RUN_STATUSES
+        and candidate_status in _TERMINAL_RUN_STATUSES
+        and candidate_status != selected_status
+    ):
+        raise ValueError(
+            "benchmark experiment board sources contain conflicting terminal states"
+        )
+
+    selected_at = _benchmark_experiment_board_observed_at(selected)
+    candidate_at = _benchmark_experiment_board_observed_at(candidate)
+    if candidate_at == selected_at:
+        raise ValueError(
+            "benchmark experiment board sources contain ambiguous rows at "
+            "the same observed_at timestamp"
+        )
+    if candidate_at < selected_at:
+        return selected, True
+    if selected_status in _TERMINAL_RUN_STATUSES:
+        if candidate_status in _TERMINAL_RUN_STATUSES:
+            return candidate, False
+        return selected, True
+    if candidate_status not in _RUN_STATUS_TRANSITIONS[selected_status]:
+        return selected, True
+    return candidate, False
+
+
 def _select_reconciled_benchmark_experiment_board_row(
     current: dict[str, Any] | None,
     candidates: list[dict[str, Any]],
@@ -466,37 +502,11 @@ def _select_reconciled_benchmark_experiment_board_row(
         if selected is None:
             selected = candidate
             continue
-        if selected == candidate:
-            continue
-
-        selected_at = _benchmark_experiment_board_observed_at(selected)
-        candidate_at = _benchmark_experiment_board_observed_at(candidate)
-        selected_status = str(selected["status"])
-        candidate_status = str(candidate["status"])
-
-        if candidate_at == selected_at:
-            raise ValueError(
-                "benchmark experiment board sources contain ambiguous rows at "
-                "the same observed_at timestamp"
-            )
-        if candidate_at < selected_at:
-            stale_skipped += 1
-            continue
-        if selected_status in _TERMINAL_RUN_STATUSES:
-            if candidate_status in _TERMINAL_RUN_STATUSES:
-                if candidate_status != selected_status:
-                    raise ValueError(
-                        "benchmark experiment board sources contain conflicting "
-                        "terminal states"
-                    )
-                selected = candidate
-                continue
-            stale_skipped += 1
-            continue
-        if candidate_status not in _RUN_STATUS_TRANSITIONS[selected_status]:
-            stale_skipped += 1
-            continue
-        selected = candidate
+        selected, skipped = _advance_reconciled_benchmark_experiment_board_row(
+            selected,
+            candidate,
+        )
+        stale_skipped += int(skipped)
 
     if selected is None:
         raise ValueError("benchmark experiment board reconcile requires source rows")

--- a/loopx/cli_commands/benchmark_experiment_board.py
+++ b/loopx/cli_commands/benchmark_experiment_board.py
@@ -126,6 +126,48 @@ def _board_payload(
     )
 
 
+def _reconcile_experiment_board(
+    args: argparse.Namespace,
+    *,
+    ledger_path: Path,
+    rows: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    source_rows = [
+        row
+        for source_path in args.source_ledger
+        for row in read_benchmark_experiment_board_rows(source_path)
+    ]
+    reconciled_rows, reconciliation = preview_benchmark_experiment_board_reconcile(
+        rows,
+        source_rows,
+    )
+    if not args.execute:
+        return reconciled_rows, {
+            **reconciliation,
+            "status": "preview_reconciled",
+            "write_performed": False,
+            "row_count": len(reconciled_rows),
+            "path_recorded": False,
+            "dry_run": True,
+        }
+
+    existing_by_key = {_row_key(row): row for row in rows}
+    for row in reconciled_rows:
+        if existing_by_key.get(_row_key(row)) != row:
+            upsert_benchmark_experiment_board_row(ledger_path, row)
+    written_rows = read_benchmark_experiment_board_rows(ledger_path)
+    return written_rows, {
+        **reconciliation,
+        "status": "reconciled",
+        "write_performed": bool(
+            reconciliation["inserted"] or reconciliation["updated"]
+        ),
+        "row_count": len(written_rows),
+        "path_recorded": False,
+        "dry_run": False,
+    }
+
+
 def handle_benchmark_experiment_board_command(
     args: argparse.Namespace,
     *,
@@ -166,41 +208,11 @@ def handle_benchmark_experiment_board_command(
                     "dry_run": True,
                 }
         elif args.benchmark_command == "experiment-board-reconcile":
-            source_rows = [
-                row
-                for source_path in args.source_ledger
-                for row in read_benchmark_experiment_board_rows(source_path)
-            ]
-            reconciled_rows, reconciliation = (
-                preview_benchmark_experiment_board_reconcile(rows, source_rows)
+            rows, write = _reconcile_experiment_board(
+                args,
+                ledger_path=ledger_path,
+                rows=rows,
             )
-            if args.execute:
-                existing_by_key = {_row_key(row): row for row in rows}
-                for row in reconciled_rows:
-                    key = _row_key(row)
-                    if existing_by_key.get(key) != row:
-                        upsert_benchmark_experiment_board_row(ledger_path, row)
-                rows = read_benchmark_experiment_board_rows(ledger_path)
-                write = {
-                    **reconciliation,
-                    "status": "reconciled",
-                    "write_performed": bool(
-                        reconciliation["inserted"] or reconciliation["updated"]
-                    ),
-                    "row_count": len(rows),
-                    "path_recorded": False,
-                    "dry_run": False,
-                }
-            else:
-                rows = reconciled_rows
-                write = {
-                    **reconciliation,
-                    "status": "preview_reconciled",
-                    "write_performed": False,
-                    "row_count": len(rows),
-                    "path_recorded": False,
-                    "dry_run": True,
-                }
         payload = _board_payload(
             rows=rows,
             benchmark_id=args.benchmark_id,

--- a/loopx/cli_commands/benchmark_experiment_board.py
+++ b/loopx/cli_commands/benchmark_experiment_board.py
@@ -8,8 +8,10 @@ from pathlib import Path
 from typing import Any
 
 from ..capabilities.benchmark_toolkit import (
+    benchmark_experiment_board_row_key,
     build_benchmark_experiment_board,
     default_benchmark_experiment_board_path,
+    preview_benchmark_experiment_board_reconcile,
     preview_benchmark_experiment_board_upsert,
     read_benchmark_experiment_board_rows,
     render_benchmark_experiment_board_markdown,
@@ -23,8 +25,19 @@ OutputFormat = Callable[[argparse.Namespace], str]
 
 BENCHMARK_EXPERIMENT_BOARD_COMMANDS = {
     "experiment-board-show",
+    "experiment-board-reconcile",
     "experiment-board-upsert",
 }
+
+
+def _row_key(row: dict[str, Any]) -> tuple[str, str, str, str]:
+    key = benchmark_experiment_board_row_key(row)
+    return (
+        key["benchmark_id"],
+        key["study_id"],
+        key["case_id"],
+        key["run_id"],
+    )
 
 
 def _read_json_object(path_text: str) -> dict[str, Any]:
@@ -78,6 +91,27 @@ def register_benchmark_experiment_board_commands(
         help="Write project-local domain state. Without this flag, preview only.",
     )
 
+    reconcile_parser = benchmark_subparsers.add_parser(
+        "experiment-board-reconcile",
+        help="Preview or reconcile provider board shards into the canonical board.",
+    )
+    add_subcommand_format(reconcile_parser)
+    _add_board_location_arguments(reconcile_parser)
+    reconcile_parser.add_argument(
+        "--source-ledger",
+        action="append",
+        required=True,
+        help=(
+            "Provider-owned public-safe experiment-board JSONL path. Repeat for "
+            "multiple shards."
+        ),
+    )
+    reconcile_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Write project-local domain state. Without this flag, preview only.",
+    )
+
 
 def _board_payload(
     *,
@@ -126,6 +160,42 @@ def handle_benchmark_experiment_board_command(
                 )
                 write = {
                     "status": f"preview_{preview_status}",
+                    "write_performed": False,
+                    "row_count": len(rows),
+                    "path_recorded": False,
+                    "dry_run": True,
+                }
+        elif args.benchmark_command == "experiment-board-reconcile":
+            source_rows = [
+                row
+                for source_path in args.source_ledger
+                for row in read_benchmark_experiment_board_rows(source_path)
+            ]
+            reconciled_rows, reconciliation = (
+                preview_benchmark_experiment_board_reconcile(rows, source_rows)
+            )
+            if args.execute:
+                existing_by_key = {_row_key(row): row for row in rows}
+                for row in reconciled_rows:
+                    key = _row_key(row)
+                    if existing_by_key.get(key) != row:
+                        upsert_benchmark_experiment_board_row(ledger_path, row)
+                rows = read_benchmark_experiment_board_rows(ledger_path)
+                write = {
+                    **reconciliation,
+                    "status": "reconciled",
+                    "write_performed": bool(
+                        reconciliation["inserted"] or reconciliation["updated"]
+                    ),
+                    "row_count": len(rows),
+                    "path_recorded": False,
+                    "dry_run": False,
+                }
+            else:
+                rows = reconciled_rows
+                write = {
+                    **reconciliation,
+                    "status": "preview_reconciled",
                     "write_performed": False,
                     "row_count": len(rows),
                     "path_recorded": False,

--- a/tests/capabilities/test_benchmark_experiment_board.py
+++ b/tests/capabilities/test_benchmark_experiment_board.py
@@ -11,6 +11,7 @@ from loopx.capabilities.benchmark_toolkit import (
     build_benchmark_experiment_board,
     default_benchmark_experiment_board_path,
     normalize_benchmark_experiment_board_row,
+    preview_benchmark_experiment_board_reconcile,
     read_benchmark_experiment_board_rows,
     render_benchmark_experiment_board_markdown,
     upsert_benchmark_experiment_board_row,
@@ -100,6 +101,21 @@ def _baseline(**overrides: object) -> dict[str, object]:
         observed_at="2026-08-18T00:00:00+00:00",
         f2p=0,
         fidelity="not_applicable",
+    )
+    payload.update(overrides)
+    return payload
+
+
+def _running_baseline(**overrides: object) -> dict[str, object]:
+    payload = _baseline(
+        status="running",
+        metrics={},
+        countability={
+            "integrity_qualified": False,
+            "official_result_present": False,
+            "score_countable": False,
+        },
+        insight={"status": "pending"},
     )
     payload.update(overrides)
     return payload
@@ -304,6 +320,59 @@ def test_upsert_rejects_stale_transition_after_terminal_state(tmp_path: Path) ->
     assert rows[0]["status"] == "completed"
 
 
+def test_reconcile_promotes_terminal_and_skips_late_nonterminal_source() -> None:
+    canonical = _running_baseline(observed_at="2026-08-18T00:10:00+00:00")
+    source_running = _running_baseline(
+        observed_at="2026-08-18T00:20:00+00:00",
+        arm_id="provider-running",
+    )
+    source_terminal = _baseline(
+        observed_at="2026-08-18T00:30:00+00:00",
+        arm_id="provider-terminal",
+    )
+    stale_late_running = _running_baseline(
+        observed_at="2026-08-18T00:40:00+00:00",
+        arm_id="stale-provider",
+    )
+
+    rows, receipt = preview_benchmark_experiment_board_reconcile(
+        [canonical],
+        [stale_late_running, source_terminal, source_running],
+    )
+
+    assert rows == [normalize_benchmark_experiment_board_row(source_terminal)]
+    assert receipt == {
+        "source_row_count": 3,
+        "candidate_run_count": 1,
+        "inserted": 0,
+        "updated": 1,
+        "unchanged": 0,
+        "stale_skipped": 1,
+    }
+
+    repeated, repeated_receipt = preview_benchmark_experiment_board_reconcile(
+        rows,
+        [stale_late_running, source_terminal, source_running],
+    )
+    assert repeated == rows
+    assert repeated_receipt["unchanged"] == 1
+    assert repeated_receipt["stale_skipped"] == 2
+
+
+def test_reconcile_rejects_conflicting_terminal_sources() -> None:
+    completed = _baseline(observed_at="2026-08-18T00:30:00+00:00")
+    runner_invalid = _running_baseline(
+        status="runner_invalid",
+        observed_at="2026-08-18T00:40:00+00:00",
+    )
+
+    with pytest.raises(ValueError, match="conflicting terminal states"):
+        preview_benchmark_experiment_board_reconcile(
+            [],
+            [completed, runner_invalid],
+        )
+
+
 def test_cli_previews_then_writes_and_reads_board(tmp_path: Path) -> None:
     row_path = tmp_path / "row.json"
     row_path.write_text(json.dumps(_baseline()), encoding="utf-8")
@@ -371,6 +440,66 @@ def test_cli_previews_then_writes_and_reads_board(tmp_path: Path) -> None:
     assert shown_payload["agent_guidance"]["next_action"] == (
         "close_running_rows_or_review_matched_comparisons"
     )
+
+
+def test_cli_reconciles_provider_ledgers_without_recording_paths(
+    tmp_path: Path,
+) -> None:
+    source_running = tmp_path / "provider-a.jsonl"
+    source_terminal = tmp_path / "provider-b.jsonl"
+    upsert_benchmark_experiment_board_row(
+        source_running,
+        _running_baseline(observed_at="2026-08-18T00:10:00+00:00"),
+    )
+    upsert_benchmark_experiment_board_row(
+        source_terminal,
+        _baseline(observed_at="2026-08-18T00:20:00+00:00"),
+    )
+    command = [
+        str(REPO_ROOT / "scripts/loopx"),
+        "benchmark",
+        "experiment-board-reconcile",
+        "--goal-id",
+        "fixture-goal",
+        "--project",
+        str(tmp_path),
+        "--source-ledger",
+        str(source_running),
+        "--source-ledger",
+        str(source_terminal),
+        "--format",
+        "json",
+    ]
+    ledger = default_benchmark_experiment_board_path(
+        project=tmp_path, goal_id="fixture-goal"
+    )
+
+    preview = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    preview_payload = json.loads(preview.stdout)
+    assert preview_payload["summary"]["run_count"] == 1
+    assert preview_payload["write"]["status"] == "preview_reconciled"
+    assert preview_payload["write"]["inserted"] == 1
+    assert not ledger.exists()
+
+    executed = subprocess.run(
+        [*command, "--execute"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    executed_payload = json.loads(executed.stdout)
+    assert executed_payload["write"]["status"] == "reconciled"
+    assert executed_payload["write"]["write_performed"] is True
+    assert executed_payload["runs"][0]["status"] == "completed"
+    assert str(tmp_path) not in executed.stdout
+    assert read_benchmark_experiment_board_rows(ledger)[0]["status"] == "completed"
 
 
 def test_cli_omitted_project_routes_board_to_registered_goal_repo(
@@ -464,5 +593,6 @@ def test_capability_show_teaches_agents_to_use_the_board() -> None:
     )
     assert "experiment-board-show" in usage["board_commands"]["read"]
     assert "experiment-board-upsert" in usage["board_commands"]["write"]
+    assert "experiment-board-reconcile" in usage["board_commands"]["reconcile"]
     assert "## Agent Usage" in rendered
     assert "read_experiment_board_before_launch_or_case_selection" in rendered

--- a/tests/capabilities/test_benchmark_experiment_board.py
+++ b/tests/capabilities/test_benchmark_experiment_board.py
@@ -373,6 +373,20 @@ def test_reconcile_rejects_conflicting_terminal_sources() -> None:
         )
 
 
+def test_reconcile_rejects_older_terminal_conflict_with_canonical_row() -> None:
+    canonical = _baseline(observed_at="2026-08-18T00:40:00+00:00")
+    older_runner_invalid = _running_baseline(
+        status="runner_invalid",
+        observed_at="2026-08-18T00:30:00+00:00",
+    )
+
+    with pytest.raises(ValueError, match="conflicting terminal states"):
+        preview_benchmark_experiment_board_reconcile(
+            [canonical],
+            [older_runner_invalid],
+        )
+
+
 def test_cli_previews_then_writes_and_reads_board(tmp_path: Path) -> None:
     row_path = tmp_path / "row.json"
     row_path.write_text(json.dumps(_baseline()), encoding="utf-8")


### PR DESCRIPTION
## Summary

- add `loopx benchmark experiment-board-reconcile` for folding repeated public-safe provider ledgers into the canonical project experiment board
- preserve monotonic run lifecycle: terminal rows cannot be reopened and conflicting terminal states fail closed regardless of timestamp ordering
- keep preview as the default; `--execute` is required for writes and receipts never record source paths
- teach the benchmark-toolkit catalog and documentation when providers should reconcile before agent readback

## Motivation

Long-running benchmark providers may partition run state across independent queues. Even when each provider ledger is correct, the agent-facing canonical board can lag and omit active or terminal rows. That breaks coverage, concurrency, and post-run monitor readback. This change puts the projection rule in the existing provider-neutral benchmark-toolkit instead of duplicating it in each runner.

## Review refinements

- terminal-state conflicts now fail closed before timestamp staleness can hide an older contradictory terminal source
- the reconcile reducer and CLI execute/preview flow were split into cohesive helpers, removing both newly reported critical cognitive-complexity issues
- docs state that the whole candidate set is validated before the first write, executed row writes are replay-safe, and interrupted batches must be retried
- the branch was refreshed onto `main` after PR #3491 merged; both runtime-observation and board-reconcile contracts remain present in docs, catalog, exports, and tests

## Validation

- focused benchmark reconcile/runtime/toolkit/source-fence pytest matrix — 86 passed under the declared Python 3.13 launcher
- Ruff check and format check — passed
- changed-file compileall and exact diff hygiene — passed
- Radon: selector A(4), transition helper B(10), reconcile helper B(8), CLI handler B(8)
- change-quality receipt `cqr_6cfc549b6c1a383d89e1` — valid for exact final diff
- standard premerge canary — 18/18 selected checks passed; 0 failures; public-boundary scan clean

The initial local pytest invocation selected the host Python 3.9 for `scripts/loopx` subprocesses and produced four runtime-version errors before any assertion ran; the full matrix was rerun with the repository-declared worktree Python 3.13 and passed 86/86.

## Boundaries

This PR does not launch benchmark jobs, change scoring, countability, task, comparison, submission, or permission semantics, read raw trajectories or evaluator material, or publish provider-specific state. The canary retained its generic benchmark-sensitive manual-review hold; the maintainer explicitly authorized self-review/refine/admin-bypass merge for this PR.
