### PR TITLE
feat(benchmark): fail closed on runtime closeout drift

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -34,38 +34,6 @@ pins an updated source. The caller owns the freshness and authority of the obser
 reference value. This capability performs no fetch, provider API call, checkout,
 install, process launch, score write, or submission.
 
-## Runtime closeout continuity
-
-A terminal result is not sufficient evidence that the process closing a run uses
-the same runtime artifact and attempt generation admitted at launch. Before writing
-a terminal score, compare the runner-owned SHA-256 bindings and its typed event-
-window qualification:
-
-```bash
-loopx benchmark runtime-continuity \
-  --launch-runtime-digest "$LAUNCH_RUNTIME_DIGEST" \
-  --closeout-runtime-digest "$CLOSEOUT_RUNTIME_DIGEST" \
-  --launch-generation-digest "$LAUNCH_GENERATION_DIGEST" \
-  --closeout-generation-digest "$CLOSEOUT_GENERATION_DIGEST" \
-  --event-window-state qualified \
-  --require-qualified \
-  --format json
-```
-
-The gate allows a closeout only when both content-addressed bindings match and the
-provider has qualified the required events within that run's launch-to-terminal
-window. A generation mismatch is routed back to its launch generation; a runtime
-artifact mismatch is rejected; missing, ambiguous, or out-of-window evidence stays
-unqualified. The compact receipt exposes equality, typed reason codes, and route
-guidance, but never the digests, run identity, event payloads, or paths. A false
-`closeout_write_allowed` is a machine-enforced obligation when callers use
-`--require-qualified`; `recommended_transition` remains provider guidance.
-
-The runner remains responsible for creating immutable artifacts and generations,
-classifying the event window from its private evidence, applying the route guidance,
-and writing the terminal row. This reducer reads no files and grants no
-runner, verifier, scoring, upload, or submission authority.
-
 ## Native Codex Goal runtime
 
 Benchmark adapters that use the Codex app-server Goal API should import
@@ -372,6 +340,38 @@ match count, and a SHA-256 selector digest; it excludes the raw container identi
 and label values. The helper grants no Docker or runner authority. Callers that need
 a privileged wrapper must supply their own `command_runner` and keep that authority
 outside the receipt.
+
+### Runtime closeout continuity
+
+A terminal result is not sufficient evidence that the process closing a run uses
+the same runtime artifact and attempt generation admitted at launch. Before writing
+a terminal score, compare the runner-owned SHA-256 bindings and its typed event-
+window qualification:
+
+```bash
+loopx benchmark runtime-continuity \
+  --launch-runtime-digest "$LAUNCH_RUNTIME_DIGEST" \
+  --closeout-runtime-digest "$CLOSEOUT_RUNTIME_DIGEST" \
+  --launch-generation-digest "$LAUNCH_GENERATION_DIGEST" \
+  --closeout-generation-digest "$CLOSEOUT_GENERATION_DIGEST" \
+  --event-window-state qualified \
+  --require-qualified \
+  --format json
+```
+
+The gate allows a closeout only when both content-addressed bindings match and the
+provider has qualified the required events within that run's launch-to-terminal
+window. A generation mismatch is routed back to its launch generation; a runtime
+artifact mismatch is rejected; missing, ambiguous, or out-of-window evidence stays
+unqualified. The compact receipt exposes equality, typed reason codes, and route
+guidance, but never the digests, run identity, event payloads, or paths. A false
+`closeout_write_allowed` is a machine-enforced obligation when callers use
+`--require-qualified`; `recommended_transition` remains provider guidance.
+
+The runner remains responsible for creating immutable artifacts and generations,
+classifying the event window from its private evidence, applying the route guidance,
+and writing the terminal row. This reducer reads no files and grants no runner,
+verifier, scoring, upload, or submission authority.
 
 Benchmark-specific private roots can be added without committing them through an
 ignored `benchmark_integrity_policy_v0` file:

--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -34,6 +34,38 @@ pins an updated source. The caller owns the freshness and authority of the obser
 reference value. This capability performs no fetch, provider API call, checkout,
 install, process launch, score write, or submission.
 
+## Runtime closeout continuity
+
+A terminal result is not sufficient evidence that the process closing a run uses
+the same runtime artifact and attempt generation admitted at launch. Before writing
+a terminal score, compare the runner-owned SHA-256 bindings and its typed event-
+window qualification:
+
+```bash
+loopx benchmark runtime-continuity \
+  --launch-runtime-digest "$LAUNCH_RUNTIME_DIGEST" \
+  --closeout-runtime-digest "$CLOSEOUT_RUNTIME_DIGEST" \
+  --launch-generation-digest "$LAUNCH_GENERATION_DIGEST" \
+  --closeout-generation-digest "$CLOSEOUT_GENERATION_DIGEST" \
+  --event-window-state qualified \
+  --require-qualified \
+  --format json
+```
+
+The gate allows a closeout only when both content-addressed bindings match and the
+provider has qualified the required events within that run's launch-to-terminal
+window. A generation mismatch is routed back to its launch generation; a runtime
+artifact mismatch is rejected; missing, ambiguous, or out-of-window evidence stays
+unqualified. The compact receipt exposes equality, typed reason codes, and route
+guidance, but never the digests, run identity, event payloads, or paths. A false
+`closeout_write_allowed` is a machine-enforced obligation when callers use
+`--require-qualified`; `recommended_transition` remains provider guidance.
+
+The runner remains responsible for creating immutable artifacts and generations,
+classifying the event window from its private evidence, applying the route guidance,
+and writing the terminal row. This reducer reads no files and grants no
+runner, verifier, scoring, upload, or submission authority.
+
 ## Native Codex Goal runtime
 
 Benchmark adapters that use the Codex app-server Goal API should import
@@ -373,12 +405,14 @@ A countable experiment uses the toolkit in this order:
 6. Capture ATIF tool evidence and a runner-owned runtime attestation.
 7. During active monitoring, classify exact-job runtime evidence; do not infer
    liveness from an occupied admission slot.
-8. Run `integrity-qualification`; stop on any blocker.
-9. Run the independent verifier only after the agent phase.
-10. Reduce the official result through the benchmark-owned scoring path.
-11. Upsert terminal score, countability, effort, treatment fidelity, and insight
+8. Before a terminal write, require runtime continuity between the launch artifact,
+   closeout artifact, launch generation, closeout generation, and event window.
+9. Run `integrity-qualification`; stop on any blocker.
+10. Run the independent verifier only after the agent phase.
+11. Reduce the official result through the benchmark-owned scoring path.
+12. Upsert terminal score, countability, effort, treatment fidelity, and insight
     status; release its reservation; then read the matched-comparison projection.
-12. Apply attempt-countability, treatment-fidelity, and matched-pair gates before any
+13. Apply attempt-countability, treatment-fidelity, and matched-pair gates before any
     comparison claim.
 
 Integrity qualification is necessary but not sufficient for a score claim. It does

--- a/loopx/capabilities/benchmark_toolkit/__init__.py
+++ b/loopx/capabilities/benchmark_toolkit/__init__.py
@@ -116,6 +116,13 @@ from .run_permissions import (
     compact_run_permission_policy_for_quota,
     validate_run_permission_policy,
 )
+from .runtime_continuity import (
+    BENCHMARK_RUNTIME_CONTINUITY_SCHEMA_VERSION,
+    BenchmarkEventWindowState,
+    BenchmarkRuntimeContinuityClassification,
+    BenchmarkRuntimeContinuityTransition,
+    build_benchmark_runtime_continuity,
+)
 from .runtime_observation import (
     BENCHMARK_RUNTIME_OBSERVATION_SCHEMA_VERSION,
     BenchmarkJobReceiptState,
@@ -142,6 +149,7 @@ __all__ = [
     "BENCHMARK_EXPERIMENT_BOARD_SCHEMA_VERSION",
     "BENCHMARK_INTEGRITY_POLICY_SCHEMA_VERSION",
     "BENCHMARK_INTEGRITY_QUALIFICATION_SCHEMA_VERSION",
+    "BENCHMARK_RUNTIME_CONTINUITY_SCHEMA_VERSION",
     "BENCHMARK_RUNTIME_INTEGRITY_ATTESTATION_SCHEMA_VERSION",
     "BENCHMARK_RUNTIME_OBSERVATION_SCHEMA_VERSION",
     "BENCHMARK_SOURCE_REVISION_FENCE_SCHEMA_VERSION",
@@ -157,9 +165,12 @@ __all__ = [
     "REWARD_CONTRACT_SCHEMA_VERSION",
     "RUN_PERMISSION_POLICY_SCHEMA_VERSION",
     "RUN_PERMISSION_QUOTA_PROJECTION_SCHEMA_VERSION",
+    "BenchmarkEventWindowState",
     "BenchmarkJobReceiptState",
     "BenchmarkRunnerOwnerState",
     "BenchmarkRuntimeClassification",
+    "BenchmarkRuntimeContinuityClassification",
+    "BenchmarkRuntimeContinuityTransition",
     "BenchmarkRuntimeTransition",
     "BenchmarkSourceRevisionFence",
     "BenchmarkSourceRevisionFenceError",
@@ -190,6 +201,7 @@ __all__ = [
     "build_benchmark_concurrency_status",
     "build_benchmark_experiment_board",
     "build_benchmark_integrity_qualification",
+    "build_benchmark_runtime_continuity",
     "build_benchmark_runtime_observation",
     "build_native_codex_isolation_envelope",
     "build_native_goal_public_trajectory_summary",

--- a/loopx/capabilities/benchmark_toolkit/catalog_entry.py
+++ b/loopx/capabilities/benchmark_toolkit/catalog_entry.py
@@ -83,6 +83,24 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
         },
         {
             "command": (
+                "loopx benchmark runtime-continuity "
+                "--launch-runtime-digest <sha256> "
+                "--closeout-runtime-digest <sha256> "
+                "--launch-generation-digest <sha256> "
+                "--closeout-generation-digest <sha256> "
+                "--event-window-state <state> --require-qualified --format json"
+            ),
+            "purpose": (
+                "Fail closed unless terminal closeout retains the launch runtime "
+                "artifact, attempt generation, and qualified event window."
+            ),
+            "write_boundary": (
+                "read-only compact provider facts; emits no digest, run identity, "
+                "event payload, or path, and performs no closeout write"
+            ),
+        },
+        {
+            "command": (
                 "loopx benchmark experiment-board-upsert --goal-id <goal-id> "
                 "--row-json <compact-row.json> --execute --format json"
             ),
@@ -205,6 +223,7 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
             "atomically_admit_case_slot_before_runner_launch",
             "upsert_preregistered_or_running_row_when_a_run_starts",
             "classify_exact_runtime_observation_during_active_monitor_cycles",
+            "require_runtime_continuity_before_terminal_closeout_write",
             "upsert_terminal_score_countability_effort_and_insight_status",
             "release_case_slot_after_terminal_or_runner_invalid_transition",
             "read_matched_comparisons_before_selecting_the_next_arm",

--- a/loopx/capabilities/benchmark_toolkit/runtime_continuity.py
+++ b/loopx/capabilities/benchmark_toolkit/runtime_continuity.py
@@ -1,0 +1,140 @@
+"""Fail-closed continuity checks for benchmark runtime closeout."""
+
+from __future__ import annotations
+
+import re
+from enum import Enum
+from typing import Any
+
+BENCHMARK_RUNTIME_CONTINUITY_SCHEMA_VERSION = "benchmark_runtime_continuity_v0"
+_SHA256_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+
+
+class BenchmarkEventWindowState(str, Enum):
+    """Provider-qualified relationship between runtime events and one run."""
+
+    QUALIFIED = "qualified"
+    MISSING = "missing"
+    AMBIGUOUS = "ambiguous"
+    OUTSIDE_LAUNCH_WINDOW = "outside_launch_window"
+
+
+class BenchmarkRuntimeContinuityClassification(str, Enum):
+    """Why a terminal closeout is or is not safe to write."""
+
+    INPUT_INVALID = "continuity_input_invalid"
+    QUALIFIED = "qualified"
+    GENERATION_MISMATCH = "generation_mismatch"
+    RUNTIME_ARTIFACT_MISMATCH = "runtime_artifact_mismatch"
+    EVENT_WINDOW_MISSING = "event_window_missing"
+    EVENT_WINDOW_AMBIGUOUS = "event_window_ambiguous"
+    EVENT_WINDOW_OUTSIDE_LAUNCH = "event_window_outside_launch"
+
+
+class BenchmarkRuntimeContinuityTransition(str, Enum):
+    """Provider-owned transition selected by the continuity gate."""
+
+    REPAIR_CONTINUITY_EVIDENCE = "repair_continuity_evidence"
+    ACCEPT_CLOSEOUT = "accept_closeout"
+    ROUTE_TO_LAUNCH_GENERATION = "route_to_launch_generation"
+    REJECT_RUNTIME_ARTIFACT = "reject_runtime_artifact"
+    REPAIR_EVENT_WINDOW_EVIDENCE = "repair_event_window_evidence"
+
+
+def _normalize_digest(value: str, *, field: str) -> str:
+    digest = str(value).strip()
+    if not _SHA256_DIGEST.fullmatch(digest):
+        raise ValueError(f"invalid_{field}")
+    return digest
+
+
+def _coerce_event_window_state(
+    value: str | BenchmarkEventWindowState,
+) -> BenchmarkEventWindowState:
+    try:
+        return BenchmarkEventWindowState(value)
+    except ValueError as exc:
+        raise ValueError("invalid_event_window_state") from exc
+
+
+def build_benchmark_runtime_continuity(
+    *,
+    launch_runtime_digest: str,
+    closeout_runtime_digest: str,
+    launch_generation_digest: str,
+    closeout_generation_digest: str,
+    event_window_state: str | BenchmarkEventWindowState,
+) -> dict[str, Any]:
+    """Compare launch and closeout facts without emitting private identities.
+
+    The runner owns artifact generation, event attribution, and all writes. This
+    reducer only allows a closeout when its content-addressed runtime artifact and
+    generation match launch and the provider has qualified the required event
+    window. Raw digests and event payloads are never copied into the receipt.
+    """
+
+    launch_runtime = _normalize_digest(
+        launch_runtime_digest,
+        field="launch_runtime_digest",
+    )
+    closeout_runtime = _normalize_digest(
+        closeout_runtime_digest,
+        field="closeout_runtime_digest",
+    )
+    launch_generation = _normalize_digest(
+        launch_generation_digest,
+        field="launch_generation_digest",
+    )
+    closeout_generation = _normalize_digest(
+        closeout_generation_digest,
+        field="closeout_generation_digest",
+    )
+    window = _coerce_event_window_state(event_window_state)
+
+    runtime_matches = launch_runtime == closeout_runtime
+    generation_matches = launch_generation == closeout_generation
+    event_window_qualified = window is BenchmarkEventWindowState.QUALIFIED
+
+    if not generation_matches:
+        classification = BenchmarkRuntimeContinuityClassification.GENERATION_MISMATCH
+        transition = BenchmarkRuntimeContinuityTransition.ROUTE_TO_LAUNCH_GENERATION
+    elif not runtime_matches:
+        classification = (
+            BenchmarkRuntimeContinuityClassification.RUNTIME_ARTIFACT_MISMATCH
+        )
+        transition = BenchmarkRuntimeContinuityTransition.REJECT_RUNTIME_ARTIFACT
+    elif window is BenchmarkEventWindowState.MISSING:
+        classification = BenchmarkRuntimeContinuityClassification.EVENT_WINDOW_MISSING
+        transition = BenchmarkRuntimeContinuityTransition.REPAIR_EVENT_WINDOW_EVIDENCE
+    elif window is BenchmarkEventWindowState.AMBIGUOUS:
+        classification = BenchmarkRuntimeContinuityClassification.EVENT_WINDOW_AMBIGUOUS
+        transition = BenchmarkRuntimeContinuityTransition.REPAIR_EVENT_WINDOW_EVIDENCE
+    elif window is BenchmarkEventWindowState.OUTSIDE_LAUNCH_WINDOW:
+        classification = (
+            BenchmarkRuntimeContinuityClassification.EVENT_WINDOW_OUTSIDE_LAUNCH
+        )
+        transition = BenchmarkRuntimeContinuityTransition.REPAIR_EVENT_WINDOW_EVIDENCE
+    else:
+        classification = BenchmarkRuntimeContinuityClassification.QUALIFIED
+        transition = BenchmarkRuntimeContinuityTransition.ACCEPT_CLOSEOUT
+
+    qualified = classification is BenchmarkRuntimeContinuityClassification.QUALIFIED
+    return {
+        "schema_version": BENCHMARK_RUNTIME_CONTINUITY_SCHEMA_VERSION,
+        "classification": classification.value,
+        "qualified": qualified,
+        "closeout_write_allowed": qualified,
+        "runtime_artifact_matches": runtime_matches,
+        "generation_matches": generation_matches,
+        "event_window_state": window.value,
+        "event_window_qualified": event_window_qualified,
+        "recommended_transition": transition.value,
+        "public_boundary": {
+            "runtime_artifact_digest_recorded": False,
+            "generation_digest_recorded": False,
+            "event_payload_recorded": False,
+            "run_identity_recorded": False,
+            "path_recorded": False,
+        },
+        "write_performed": False,
+    }

--- a/loopx/cli_commands/benchmark_boundary.py
+++ b/loopx/cli_commands/benchmark_boundary.py
@@ -10,12 +10,17 @@ from pathlib import Path
 
 from ..capabilities.benchmark_toolkit import (
     BENCHMARK_INTEGRITY_QUALIFICATION_SCHEMA_VERSION,
+    BENCHMARK_RUNTIME_CONTINUITY_SCHEMA_VERSION,
     BENCHMARK_SOURCE_REVISION_FENCE_SCHEMA_VERSION,
+    BenchmarkEventWindowState,
     BenchmarkJobReceiptState,
     BenchmarkRunnerOwnerState,
+    BenchmarkRuntimeContinuityClassification,
+    BenchmarkRuntimeContinuityTransition,
     BenchmarkSourceRevisionFenceError,
     build_benchmark_candidate_source_boundary,
     build_benchmark_integrity_qualification,
+    build_benchmark_runtime_continuity,
     build_benchmark_runtime_observation,
     compact_benchmark_source_revision_fence_receipt,
     filter_public_benchmark_artifact_paths,
@@ -33,6 +38,7 @@ BENCHMARK_TOOLKIT_COMMANDS = {
     "candidate-source-boundary",
     "classify-artifacts",
     "integrity-qualification",
+    "runtime-continuity",
     "runtime-observation",
     "source-revision-fence",
     "verify-verifier-reward",
@@ -112,6 +118,16 @@ def _render_runtime_observation(payload: dict[str, object]) -> str:
     )
 
 
+def _render_runtime_continuity(payload: dict[str, object]) -> str:
+    return (
+        "# Benchmark Runtime Continuity\n\n"
+        f"- Classification: `{payload.get('classification')}`\n"
+        f"- Qualified: `{payload.get('qualified')}`\n"
+        f"- Closeout write allowed: `{payload.get('closeout_write_allowed')}`\n"
+        f"- Recommended transition: `{payload.get('recommended_transition')}`\n"
+    )
+
+
 def register_benchmark_boundary_commands(
     benchmark_subparsers: argparse._SubParsersAction,
     add_subcommand_format: Callable[[argparse.ArgumentParser], None],
@@ -162,6 +178,22 @@ def register_benchmark_boundary_commands(
     runtime_parser.add_argument("--terminal-result-present", action="store_true")
     runtime_parser.add_argument("--typed-fatal-runner-error", action="store_true")
     runtime_parser.add_argument("--require-healthy", action="store_true")
+
+    continuity_parser = benchmark_subparsers.add_parser(
+        "runtime-continuity",
+        help="Require launch and closeout runtime evidence to remain continuous.",
+    )
+    add_subcommand_format(continuity_parser)
+    continuity_parser.add_argument("--launch-runtime-digest", required=True)
+    continuity_parser.add_argument("--closeout-runtime-digest", required=True)
+    continuity_parser.add_argument("--launch-generation-digest", required=True)
+    continuity_parser.add_argument("--closeout-generation-digest", required=True)
+    continuity_parser.add_argument(
+        "--event-window-state",
+        choices=[item.value for item in BenchmarkEventWindowState],
+        required=True,
+    )
+    continuity_parser.add_argument("--require-qualified", action="store_true")
 
     integrity_parser = benchmark_subparsers.add_parser(
         "integrity-qualification",
@@ -228,6 +260,30 @@ def _invalid_source_revision_fence_input() -> dict[str, object]:
     }
 
 
+def _invalid_runtime_continuity_input() -> dict[str, object]:
+    return {
+        "schema_version": BENCHMARK_RUNTIME_CONTINUITY_SCHEMA_VERSION,
+        "classification": BenchmarkRuntimeContinuityClassification.INPUT_INVALID.value,
+        "qualified": False,
+        "closeout_write_allowed": False,
+        "runtime_artifact_matches": False,
+        "generation_matches": False,
+        "event_window_state": "invalid",
+        "event_window_qualified": False,
+        "recommended_transition": (
+            BenchmarkRuntimeContinuityTransition.REPAIR_CONTINUITY_EVIDENCE.value
+        ),
+        "public_boundary": {
+            "runtime_artifact_digest_recorded": False,
+            "generation_digest_recorded": False,
+            "event_payload_recorded": False,
+            "run_identity_recorded": False,
+            "path_recorded": False,
+        },
+        "write_performed": False,
+    }
+
+
 def handle_benchmark_boundary_command(
     args: argparse.Namespace,
     *,
@@ -276,6 +332,20 @@ def handle_benchmark_boundary_command(
         )
         print_payload(payload, output_format(args), _render_runtime_observation)
         return 1 if args.require_healthy and not payload.get("healthy_active") else 0
+
+    if args.benchmark_command == "runtime-continuity":
+        try:
+            payload = build_benchmark_runtime_continuity(
+                launch_runtime_digest=args.launch_runtime_digest,
+                closeout_runtime_digest=args.closeout_runtime_digest,
+                launch_generation_digest=args.launch_generation_digest,
+                closeout_generation_digest=args.closeout_generation_digest,
+                event_window_state=args.event_window_state,
+            )
+        except (TypeError, ValueError):
+            payload = _invalid_runtime_continuity_input()
+        print_payload(payload, output_format(args), _render_runtime_continuity)
+        return 1 if args.require_qualified and not payload.get("qualified") else 0
 
     if args.benchmark_command == "verify-verifier-reward":
         if args.reward_json == "-":

--- a/tests/capabilities/test_benchmark_runtime_continuity.py
+++ b/tests/capabilities/test_benchmark_runtime_continuity.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from loopx.capabilities.benchmark_toolkit import (
+    BENCHMARK_RUNTIME_CONTINUITY_SCHEMA_VERSION,
+    build_benchmark_runtime_continuity,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNTIME_DIGEST = "a" * 64
+GENERATION_DIGEST = "b" * 64
+
+
+def _continuity(**overrides: str) -> dict[str, object]:
+    facts = {
+        "launch_runtime_digest": RUNTIME_DIGEST,
+        "closeout_runtime_digest": RUNTIME_DIGEST,
+        "launch_generation_digest": GENERATION_DIGEST,
+        "closeout_generation_digest": GENERATION_DIGEST,
+        "event_window_state": "qualified",
+    }
+    facts.update(overrides)
+    return build_benchmark_runtime_continuity(**facts)
+
+
+def test_runtime_continuity_qualifies_one_launch_generation() -> None:
+    receipt = _continuity()
+
+    assert receipt["schema_version"] == BENCHMARK_RUNTIME_CONTINUITY_SCHEMA_VERSION
+    assert receipt["classification"] == "qualified"
+    assert receipt["qualified"] is True
+    assert receipt["closeout_write_allowed"] is True
+    assert receipt["runtime_artifact_matches"] is True
+    assert receipt["generation_matches"] is True
+    assert receipt["event_window_qualified"] is True
+    assert receipt["recommended_transition"] == "accept_closeout"
+
+
+@pytest.mark.parametrize(
+    ("overrides", "classification", "transition"),
+    [
+        (
+            {"closeout_generation_digest": "c" * 64},
+            "generation_mismatch",
+            "route_to_launch_generation",
+        ),
+        (
+            {"closeout_runtime_digest": "c" * 64},
+            "runtime_artifact_mismatch",
+            "reject_runtime_artifact",
+        ),
+        (
+            {"event_window_state": "missing"},
+            "event_window_missing",
+            "repair_event_window_evidence",
+        ),
+        (
+            {"event_window_state": "ambiguous"},
+            "event_window_ambiguous",
+            "repair_event_window_evidence",
+        ),
+        (
+            {"event_window_state": "outside_launch_window"},
+            "event_window_outside_launch",
+            "repair_event_window_evidence",
+        ),
+    ],
+)
+def test_runtime_continuity_mutations_fail_closed(
+    overrides: dict[str, str],
+    classification: str,
+    transition: str,
+) -> None:
+    receipt = _continuity(**overrides)
+
+    assert receipt["classification"] == classification
+    assert receipt["qualified"] is False
+    assert receipt["closeout_write_allowed"] is False
+    assert receipt["recommended_transition"] == transition
+
+
+def test_runtime_continuity_prioritizes_generation_routing() -> None:
+    receipt = _continuity(
+        closeout_generation_digest="c" * 64,
+        closeout_runtime_digest="d" * 64,
+        event_window_state="missing",
+    )
+
+    assert receipt["classification"] == "generation_mismatch"
+    assert receipt["recommended_transition"] == "route_to_launch_generation"
+
+
+def test_runtime_continuity_receipt_does_not_emit_private_evidence() -> None:
+    receipt = _continuity()
+    rendered = json.dumps(receipt, sort_keys=True)
+
+    assert receipt["public_boundary"] == {
+        "runtime_artifact_digest_recorded": False,
+        "generation_digest_recorded": False,
+        "event_payload_recorded": False,
+        "run_identity_recorded": False,
+        "path_recorded": False,
+    }
+    assert RUNTIME_DIGEST not in rendered
+    assert GENERATION_DIGEST not in rendered
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("launch_runtime_digest", "a" * 63),
+        ("closeout_runtime_digest", "A" * 64),
+        ("launch_generation_digest", "generation-1"),
+        ("closeout_generation_digest", ""),
+        ("event_window_state", "guessed"),
+    ],
+)
+def test_runtime_continuity_rejects_untyped_evidence(
+    field: str,
+    value: str,
+) -> None:
+    with pytest.raises(ValueError):
+        _continuity(**{field: value})
+
+
+def test_runtime_continuity_cli_fails_closed_without_echoing_digests() -> None:
+    command = [
+        str(REPO_ROOT / "scripts/loopx"),
+        "benchmark",
+        "runtime-continuity",
+        "--launch-runtime-digest",
+        RUNTIME_DIGEST,
+        "--closeout-runtime-digest",
+        RUNTIME_DIGEST,
+        "--launch-generation-digest",
+        GENERATION_DIGEST,
+        "--closeout-generation-digest",
+        "c" * 64,
+        "--event-window-state",
+        "qualified",
+        "--require-qualified",
+        "--format",
+        "json",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    receipt = json.loads(completed.stdout)
+    assert receipt["classification"] == "generation_mismatch"
+    assert receipt["recommended_transition"] == "route_to_launch_generation"
+    assert RUNTIME_DIGEST not in completed.stdout
+    assert GENERATION_DIGEST not in completed.stdout
+
+
+def test_runtime_continuity_cli_reduces_invalid_input_without_echo() -> None:
+    command = [
+        str(REPO_ROOT / "scripts/loopx"),
+        "benchmark",
+        "runtime-continuity",
+        "--launch-runtime-digest",
+        "private-invalid-digest",
+        "--closeout-runtime-digest",
+        RUNTIME_DIGEST,
+        "--launch-generation-digest",
+        GENERATION_DIGEST,
+        "--closeout-generation-digest",
+        GENERATION_DIGEST,
+        "--event-window-state",
+        "qualified",
+        "--require-qualified",
+        "--format",
+        "json",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    receipt = json.loads(completed.stdout)
+    assert receipt["classification"] == "continuity_input_invalid"
+    assert receipt["recommended_transition"] == "repair_continuity_evidence"
+    assert "private-invalid-digest" not in completed.stdout


### PR DESCRIPTION
## Summary

- add a provider-neutral runtime continuity reducer for terminal benchmark closeout
- require launch and closeout to retain the same content-addressed runtime artifact and attempt generation
- fail closed on missing, ambiguous, or out-of-window event evidence, with typed generation-aware route guidance
- expose the gate through `loopx benchmark runtime-continuity` and the benchmark capability lifecycle

## Motivation

An exact-job runtime observation can establish current liveness and reconciliation state, but a terminal result still needs a separate continuity proof. Without it, a stale attempt generation or a changed runtime artifact can be attached to the wrong closeout and become score-countable.

This change makes `closeout_write_allowed` the machine gate. The recommended transition remains provider guidance: route a stale generation back to its launch generation, reject an artifact mismatch, or repair event-window evidence.

## Boundaries

- the runner remains responsible for artifact creation, event-window qualification, routing, and terminal writes
- LoopX reads no files and launches no benchmark jobs
- the compact receipt never emits runtime or generation digests, run identities, event payloads, or paths
- scoring, verifier semantics, permission boundaries, and existing runner behavior are unchanged until a caller opts into the new gate

## Validation

- `python -m pytest -q tests/capabilities/test_benchmark_runtime_continuity.py tests/capabilities/test_benchmark_runtime_observation.py tests/capabilities/test_benchmark_source_revision_fence.py tests/capabilities/test_benchmark_toolkit.py` — 88 passed
- `ruff check` and `ruff format --check` on changed Python surfaces — passed
- `loopx canary premerge --from-git-diff --format json` — standard tier passed for docs, public-boundary, benchmark-sensitive, and Python surfaces
- public/private wording and credential/path scan on all candidate paths — clean
