### PR TITLE
fix(benchmark): harden integrity request classification

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -230,7 +230,8 @@ JSON parser details cannot echo private data.
 
 Qualification rejects a run when it detects any of the following:
 
-- answer, hidden-test, verifier, other-trial, or controller-private source access;
+- answer, out-of-scope task-source, hidden-test, verifier, other-trial, or
+  controller-private source access;
 - host escape, credential probing or exposure, or shell network access;
 - malformed or incomplete ATIF tool evidence;
 - missing runner authority or any required runtime isolation attestation.
@@ -246,6 +247,15 @@ Access-request markers are evaluated only on tool calls that can perform or requ
 resource access. Exact known controller-only calls such as `update_plan` carry
 narrative metadata and are excluded from that scan; an actual sensitive value in
 their arguments still fails qualification. Unknown tool names remain fail-closed.
+
+Task-source boundaries are benchmark-owned rather than inferred from repository
+names or shell prose. A runner that forbids solver access to an upstream checkout,
+reference package, or other task source should add its private path or command marker
+to `denied_argument_markers.restricted_task_source_request`. Matching inspects typed
+argument strings before JSON escaping; the public receipt keeps only the category,
+count, step id, tool name, and argument digest, never the configured marker or raw
+command. This records an explicit access request even when it returns no content,
+without adding a benchmark-specific substring denylist to LoopX core.
 
 `benchmark_cheating_detected` is narrower than `integrity_qualified=false`.
 Restricted evaluation or cross-trial access is classified as cheating. Missing

--- a/loopx/capabilities/benchmark_toolkit/integrity.py
+++ b/loopx/capabilities/benchmark_toolkit/integrity.py
@@ -24,6 +24,7 @@ BENCHMARK_INTEGRITY_QUALIFICATION_SCHEMA_VERSION = (
 
 INTEGRITY_EVIDENCE_CATEGORIES = (
     "restricted_answer_source_request",
+    "restricted_task_source_request",
     "restricted_test_source_request",
     "verifier_source_request",
     "other_trial_request",
@@ -100,6 +101,7 @@ _DEFAULT_DENIED_ARGUMENT_MARKERS: dict[str, tuple[str, ...]] = {
 _CHEATING_CATEGORIES = frozenset(
     {
         "restricted_answer_source_request",
+        "restricted_task_source_request",
         "restricted_test_source_request",
         "verifier_source_request",
         "other_trial_request",
@@ -450,13 +452,19 @@ def build_benchmark_integrity_qualification(
             raw_arguments = raw_call.get("arguments") or {}
             arguments = _canonical_text(raw_arguments)
             lowered = arguments.lower()
+            argument_texts = (
+                lowered,
+                *(text.lower() for text in _argument_text_values(raw_arguments)),
+            )
             categories: set[str] = set()
             if function_name.lower() not in _NON_ACCESS_CONTROL_TOOLS:
                 categories = {
                     category
                     for category, category_markers in markers.items()
                     if any(
-                        _marker_present(lowered, marker) for marker in category_markers
+                        _marker_present(text, marker)
+                        for marker in category_markers
+                        for text in argument_texts
                     )
                 }
                 if credential_probe_present(function_name, raw_arguments):

--- a/tests/capabilities/test_benchmark_toolkit.py
+++ b/tests/capabilities/test_benchmark_toolkit.py
@@ -322,6 +322,30 @@ def test_restricted_source_cross_trial_and_credential_exposure_fail_closed() -> 
         assert private_value not in rendered
 
 
+def test_explicit_out_of_scope_task_source_request_fails_even_when_empty() -> None:
+    private_marker = 'find / -name "solution.py" -path'
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(
+            command='find / -name "solution.py" -path "*/upstream-project/*"',
+            observation="",
+        ),
+        runtime_attestation=_attestation(),
+        policy={
+            "schema_version": BENCHMARK_INTEGRITY_POLICY_SCHEMA_VERSION,
+            "policy_id": "fixture-policy",
+            "denied_argument_markers": {
+                "restricted_task_source_request": [private_marker]
+            },
+        },
+    )
+
+    assert receipt["integrity_qualified"] is False
+    assert receipt["benchmark_cheating_detected"] is True
+    assert receipt["classification"] == "restricted_evaluation_access_detected"
+    assert receipt["evidence_counts"]["restricted_task_source_request"] == 1
+    assert private_marker not in json.dumps(receipt, sort_keys=True)
+
+
 def test_missing_runner_isolation_is_uncountable_without_inventing_cheating() -> None:
     attestation = copy.deepcopy(_attestation())
     attestation["evaluator_sources_denied"] = False


### PR DESCRIPTION
## Summary

- add a typed, runner-configured category for explicit out-of-scope task-source access requests
- inspect typed argument strings without JSON escaping so exact private markers remain effective while receipts stay redacted
- classify shell HTTP targets semantically so loopback service validation is not mislabeled as external network access

## Motivation

A denied request can be policy-relevant even when it returns no content. Conversely, local service probes are a normal validation technique and should not be treated as external network attempts. The previous argument scan could miss quoted exact markers and over-classified every HTTP command.

## Boundaries

- task-source markers remain benchmark-owned and opt-in; core contains no benchmark-specific path or repository name
- receipts retain only category, count, step, tool name, and argument digest
- loopback recognition does not grant network access or replace the runner isolation attestation

## Validation

- `python -m ruff check ...`
- `python -m ruff format --check ...`
- `pytest -q tests/capabilities/test_benchmark_toolkit.py` (60 passed)
- `pytest -q tests/capabilities` (611 passed)
- `loopx canary premerge --from-git-diff --tier standard` (18/18 checks passed; benchmark-sensitive manual review hold remains)
- public/private boundary scan clean

## Review hold

This changes a benchmark integrity boundary, so it is intentionally proposed for maintainer review rather than self-merged.