### PR TITLE
Fix quota guards to follow the selected Todo

### DIFF
--- a/loopx/control_plane/quota/projection_repair.py
+++ b/loopx/control_plane/quota/projection_repair.py
@@ -175,14 +175,16 @@ def build_boundary_projection_repair_hint(
             continue
         if todo_item_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
             continue
-        required = normalize_required_write_scopes(item.get("required_write_scopes"))
-        if required:
-            selected = item
-            break
+        selected = item
+        break
     if not selected:
         return None
 
-    required_scopes = normalize_required_write_scopes(selected.get("required_write_scopes"))
+    required_scopes = normalize_required_write_scopes(
+        selected.get("required_write_scopes")
+    )
+    if not required_scopes:
+        return None
     boundary = goal_boundary if isinstance(goal_boundary, dict) else {}
     allowed_scopes = normalize_required_write_scopes(boundary.get("write_scope"))
     missing_scopes = [

--- a/loopx/control_plane/quota/should_run.py
+++ b/loopx/control_plane/quota/should_run.py
@@ -12,12 +12,15 @@ from ..agents.agent_scope import (
 from ..agents.identity import (
     build_quota_agent_identity,
 )
+from ..agents.workspace_guard import build_agent_workspace_guard
 from ..quota.goal_boundary import (
     registry_goal_by_id as _registry_goal_by_id,
 )
 from ..quota.decision_summary import (
     quota_plan_items as _quota_plan_items,
 )
+from ..quota.projection_repair import build_boundary_projection_repair_hint
+from ..quota.selected_todo_projection import selected_todo_projection
 from ..quota.states import (
     AutomaticTurnPauseCause,
     automatic_turn_pause_cause,
@@ -35,16 +38,69 @@ from ..work_items.interaction_contract import (
 )
 
 from .should_run_packet import (
+    _QuotaDecisionRoute,
     _build_quota_should_run_payload,
     _execution_obligation,
     _resolve_quota_should_run_route,
     _scheduler_hint,
 )
-from .should_run_prepare import _prepare_quota_should_run_item
+from .should_run_prepare import (
+    _QuotaDecisionPreparation,
+    _prepare_quota_should_run_item,
+)
 
 
 QUOTA_PAUSED_MODE = "quota_paused"
 GOAL_STOPPED_MODE = "goal_stopped"
+
+
+def _apply_selected_todo_guards(
+    prepared: _QuotaDecisionPreparation,
+    route: _QuotaDecisionRoute,
+) -> _QuotaDecisionRoute:
+    """Bind workspace and boundary guards to the exact projected Todo.
+
+    Delivery continuity and agent steering can reorder runnable candidates.  These
+    guards therefore run after the delivery route has selected a Todo, then freeze
+    that selection while the policy route is recomputed with any resulting repair.
+    """
+
+    selected_todo = selected_todo_projection(
+        agent_lane_next_action=route.agent_lane_next_action,
+        work_lane_contract=route.payload_work_lane_contract,
+        agent_scope_frontier=route.agent_scope_frontier,
+    )
+    workspace_guard = None
+    if not prepared.inbox_reply_due:
+        workspace_guard = build_agent_workspace_guard(
+            prepared.item,
+            prepared.agent_identity,
+            agent_todo_summary=prepared.agent_todo_summary,
+            selected_todo=selected_todo,
+        )
+    boundary_projection_repair = build_boundary_projection_repair_hint(
+        prepared.goal_boundary,
+        prepared.agent_todo_summary,
+        candidate_should_run=bool(route.should_run),
+        capability_gate=prepared.capability_gate,
+        selected_todo=selected_todo,
+    )
+    if not workspace_guard and not boundary_projection_repair:
+        return route
+
+    prepared.workspace_guard = workspace_guard
+    if isinstance(route.agent_lane_next_action, dict):
+        prepared.guarded_agent_lane_next_action = route.agent_lane_next_action
+    if boundary_projection_repair:
+        prepared.boundary_projection_repair = boundary_projection_repair
+        prepared.stall_self_repair = boundary_projection_repair
+        prepared.self_repair_allowed = True
+        prepared.normal_delivery_allowed = False
+        prepared.recovery_allowed = False
+        prepared.reason = str(
+            boundary_projection_repair.get("reason") or prepared.reason
+        )
+    return _resolve_quota_should_run_route(prepared)
 
 
 def build_quota_paused_should_run_payload(
@@ -233,9 +289,11 @@ def build_quota_should_run(
             receipt_bound_todo_id=receipt_bound_todo_id,
             receipt_bound_replan_obligation_id=receipt_bound_replan_obligation_id,
         )
+        route = _resolve_quota_should_run_route(prepared)
+        route = _apply_selected_todo_guards(prepared, route)
         return _build_quota_should_run_payload(
             prepared,
-            _resolve_quota_should_run_route(prepared),
+            route,
             turn_instance_id=turn_instance_id,
         )
     if health_item:

--- a/loopx/control_plane/quota/should_run_packet.py
+++ b/loopx/control_plane/quota/should_run_packet.py
@@ -534,6 +534,9 @@ def _resolve_agent_lane_delivery_route(
 ) -> dict[str, Any] | None:
     """Project candidates once, then let TypeScript own their delivery route."""
 
+    if isinstance(prepared.guarded_agent_lane_next_action, dict):
+        return prepared.guarded_agent_lane_next_action
+
     item = prepared.item
     fallback = prepared.receipt_bound_agent_next_action
     if (

--- a/loopx/control_plane/quota/should_run_prepare.py
+++ b/loopx/control_plane/quota/should_run_prepare.py
@@ -22,7 +22,6 @@ from ..agents.identity import (
     build_identity_aware_prompt_upgrade,
     build_quota_agent_identity,
 )
-from ..agents.workspace_guard import build_agent_workspace_guard
 from ..goals.goal_frontier import (
     build_goal_frontier_projection_context_from_status,
 )
@@ -35,7 +34,6 @@ from ..quota.policy_constants import (
     MONITOR_DUE_ITEM_LIMIT,
 )
 from ..quota.projection_repair import (
-    build_boundary_projection_repair_hint,
     build_state_projection_gap,
     build_state_projection_gap_repair_hint,
 )
@@ -43,9 +41,6 @@ from ..quota.recent_runs import (
     build_monitor_debt_arbitration as _build_monitor_debt_arbitration,
     goal_latest_runs as _goal_latest_runs,
     latest_accountable_agent_delivery as _latest_accountable_agent_delivery,
-)
-from ..quota.selected_todo_projection import (
-    selected_todo_projection as _selected_todo_projection,
 )
 from ..quota.stall_repair import (
     apply_stall_repair_delivery_guard,
@@ -132,6 +127,7 @@ class _QuotaDecisionPreparation:
     scoped_user_gate_fallback: dict[str, Any] | None
     inbox_reply_due: bool
     workspace_guard: dict[str, Any] | None
+    guarded_agent_lane_next_action: dict[str, Any] | None
     agent_frontier_id: str | None
     registered_agent_ids: list[str]
     replan_obligation: dict[str, Any] | None
@@ -647,20 +643,11 @@ def _prepare_quota_should_run_item(
             )
             if isinstance(preserved_work_lane, dict):
                 work_lane_contract = preserved_work_lane
-    work_lane_selected_todo = _selected_todo_projection(
-        agent_lane_next_action=receipt_bound_agent_next_action,
-        work_lane_contract=work_lane_contract,
-    )
     if inbox_reply_due:
         task_orchestration_contract = capability_gate = capability_monitor_contract = None
         capability_monitor_fallback = scoped_user_gate_fallback = workspace_guard = None
     else:
-        workspace_guard = build_agent_workspace_guard(
-            item,
-            agent_identity,
-            agent_todo_summary=agent_todo_summary,
-            selected_todo=work_lane_selected_todo,
-        )
+        workspace_guard = None
     agent_frontier_id = (
         normalize_todo_claimed_by(agent_identity.get("agent_id"))
         if isinstance(agent_identity, dict)
@@ -712,21 +699,7 @@ def _prepare_quota_should_run_item(
         normal_delivery_allowed = False
         recovery_allowed = False
         reason = str(projection_gap_repair.get("reason") or reason)
-    boundary_projection_repair = build_boundary_projection_repair_hint(
-        goal_boundary,
-        agent_todo_summary,
-        candidate_should_run=bool(
-            normal_delivery_allowed or recovery_allowed or self_repair_allowed
-        ),
-        capability_gate=capability_gate,
-        selected_todo=work_lane_selected_todo,
-    )
-    if boundary_projection_repair:
-        stall_self_repair = boundary_projection_repair
-        self_repair_allowed = True
-        normal_delivery_allowed = False
-        recovery_allowed = False
-        reason = str(boundary_projection_repair.get("reason") or reason)
+    boundary_projection_repair = None
     return _QuotaDecisionPreparation(
         status_payload=status_payload,
         safe_goal_id=safe_goal_id,
@@ -764,6 +737,7 @@ def _prepare_quota_should_run_item(
         scoped_user_gate_fallback=scoped_user_gate_fallback,
         inbox_reply_due=inbox_reply_due,
         workspace_guard=workspace_guard,
+        guarded_agent_lane_next_action=None,
         agent_frontier_id=agent_frontier_id,
         registered_agent_ids=registered_agent_ids,
         replan_obligation=replan_obligation,

--- a/tests/control_plane/test_quota_boundary_projection_selection.py
+++ b/tests/control_plane/test_quota_boundary_projection_selection.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from loopx.control_plane.quota.should_run import build_quota_should_run
+from loopx.control_plane.testing.quota_fixtures import (
+    quota_status_payload,
+    quota_todo_item,
+)
+
+GOAL_ID = "boundary-selection-fixture"
+AGENT_ID = "codex-main"
+
+
+def test_boundary_projection_checks_the_selected_todo_only() -> None:
+    research = quota_todo_item(
+        todo_id="todo_research001",
+        index=1,
+        priority="P1",
+        title="Research the current provider contract.",
+        claimed_by=AGENT_ID,
+        required_capabilities=["network"],
+    )
+    later_implementation = quota_todo_item(
+        todo_id="todo_implementation001",
+        index=2,
+        priority="P1",
+        title="Implement the later capability adapter.",
+        claimed_by=AGENT_ID,
+        required_write_scopes=["skills/**"],
+    )
+    status = quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        agent_todo_items=[research, later_implementation],
+        recommended_action=research["text"],
+        coordination={
+            "agent_model": "peer_v1",
+            "registered_agents": [AGENT_ID],
+            "write_scope": ["docs/**"],
+        },
+        claim_scope_agent_id=AGENT_ID,
+    )
+
+    packet = build_quota_should_run(
+        status,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        available_capabilities=["network"],
+    )
+
+    assert packet["selected_todo"]["todo_id"] == research["todo_id"]
+    assert packet["effective_action"] == "normal_run"
+    assert packet["normal_delivery_allowed"] is True
+    assert packet["self_repair_allowed"] is False
+    assert "boundary_projection_gap" not in packet
+
+
+def test_boundary_projection_preserves_a_guarded_continuation_selection() -> None:
+    queue_head = quota_todo_item(
+        todo_id="todo_research001",
+        index=1,
+        priority="P1",
+        title="Research the next provider contract.",
+        claimed_by=AGENT_ID,
+    )
+    in_flight = quota_todo_item(
+        todo_id="todo_implementation001",
+        index=2,
+        priority="P1",
+        title="Continue the in-flight capability adapter.",
+        claimed_by=AGENT_ID,
+        required_write_scopes=["skills/**"],
+    )
+    status = quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        agent_todo_items=[queue_head, in_flight],
+        recommended_action=queue_head["text"],
+        coordination={
+            "agent_model": "peer_v1",
+            "registered_agents": [AGENT_ID],
+            "write_scope": ["docs/**"],
+        },
+        claim_scope_agent_id=AGENT_ID,
+        latest_runs=[
+            {
+                "generated_at": "2026-08-23T00:00:00Z",
+                "classification": "bounded_implementation_progress",
+                "progress_scope": "agent_lane",
+                "agent_id": AGENT_ID,
+                "todo_id": in_flight["todo_id"],
+                "delivery_outcome": "outcome_progress",
+                "recommended_action": in_flight["text"],
+            }
+        ],
+    )
+
+    packet = build_quota_should_run(
+        status,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+
+    assert packet["selected_todo"]["todo_id"] == in_flight["todo_id"]
+    assert packet["agent_lane_next_action"]["selected_by"] == "in_flight_todo"
+    assert packet["effective_action"] == "boundary_projection_repair"
+    assert packet["normal_delivery_allowed"] is False
+    assert packet["self_repair_allowed"] is True
+    assert (
+        packet["boundary_projection_gap"]["selected_todo"]["todo_id"]
+        == (in_flight["todo_id"])
+    )
+    assert packet["boundary_projection_gap"]["missing_write_scopes"] == ["skills/**"]

--- a/tests/control_plane/test_quota_boundary_projection_selection.py
+++ b/tests/control_plane/test_quota_boundary_projection_selection.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from typing import Any
+
+import pytest
+
 from loopx.control_plane.quota.should_run import build_quota_should_run
 from loopx.control_plane.testing.quota_fixtures import (
     quota_status_payload,
@@ -10,7 +14,9 @@ GOAL_ID = "boundary-selection-fixture"
 AGENT_ID = "codex-main"
 
 
-def test_boundary_projection_checks_the_selected_todo_only() -> None:
+def test_workspace_and_boundary_guards_check_the_selected_todo_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     research = quota_todo_item(
         todo_id="todo_research001",
         index=1,
@@ -39,6 +45,26 @@ def test_boundary_projection_checks_the_selected_todo_only() -> None:
         },
         claim_scope_agent_id=AGENT_ID,
     )
+    workspace_guard_selected_todo: dict[str, Any] = {}
+
+    def _record_workspace_guard_selection(
+        *args: object,
+        selected_todo: dict[str, Any] | None = None,
+        **kwargs: object,
+    ) -> dict[str, Any] | None:
+        workspace_guard_selected_todo.update(selected_todo or {})
+        if (selected_todo or {}).get("required_write_scopes"):
+            return {
+                "schema_version": "agent_workspace_guard_v1",
+                "reason": "selected writing todo requires an independent worktree",
+                "required_action": "move to the assigned worktree",
+            }
+        return None
+
+    monkeypatch.setattr(
+        "loopx.control_plane.quota.should_run.build_agent_workspace_guard",
+        _record_workspace_guard_selection,
+    )
 
     packet = build_quota_should_run(
         status,
@@ -48,9 +74,11 @@ def test_boundary_projection_checks_the_selected_todo_only() -> None:
     )
 
     assert packet["selected_todo"]["todo_id"] == research["todo_id"]
+    assert workspace_guard_selected_todo["todo_id"] == research["todo_id"]
     assert packet["effective_action"] == "normal_run"
     assert packet["normal_delivery_allowed"] is True
     assert packet["self_repair_allowed"] is False
+    assert "workspace_guard" not in packet
     assert "boundary_projection_gap" not in packet
 
 

--- a/tests/control_plane/test_quota_paused_precedence.py
+++ b/tests/control_plane/test_quota_paused_precedence.py
@@ -101,7 +101,9 @@ def _assert_authoritatively_paused(payload: dict) -> None:
         assert lane_key not in payload, f"paused payload leaked lane `{lane_key}`"
     # And nothing nested may contradict the pause with an execution signal.
     contradictions = _find_execution_signals(payload)
-    assert contradictions == [], f"paused payload has execution signals: {contradictions}"
+    assert contradictions == [], (
+        f"paused payload has execution signals: {contradictions}"
+    )
 
 
 def test_paused_quota_preempts_capability_bridge_repair() -> None:
@@ -121,7 +123,7 @@ def test_paused_quota_preempts_workspace_repair(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        "loopx.control_plane.quota.should_run_prepare.build_agent_workspace_guard",
+        "loopx.control_plane.quota.should_run.build_agent_workspace_guard",
         lambda *args, **kwargs: {
             "schema_version": "agent_workspace_guard_v1",
             "reason": "workspace fixture requires relocation",


### PR DESCRIPTION
## Summary

- evaluate workspace and write-scope guards after the delivery route selects the exact Todo
- preserve that selected Todo while recomputing a repair route
- stop boundary fallback from skipping an earlier read-only Todo to inspect a later writing candidate
- add regression coverage for queue-head selection and in-flight continuity

## Why

A runnable queue can contain a read-only Todo followed by a repository-writing Todo. The delivery route selected the first Todo, while boundary projection scanned forward to the later Todo and incorrectly returned a repair action. This change makes selection and guard evaluation use one identity.

## Validation

- `18` focused quota/continuity tests passed
- quota action-scope, projection-repair, and peer-workspace smokes passed
- standard premerge gate passed: `17` selected checks, `0` failures
- public-boundary scan passed for all `5` changed files
- DCO sign-off included