### PR TITLE
feat(benchmark): qualify treatment plans by typed action roles

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -235,6 +235,24 @@ receipt = build_benchmark_plan_fidelity_receipt(
 assert receipt["qualified"] is True
 ```
 
+Adapters that do not import the Python API can invoke the same shipped boundary:
+
+```bash
+loopx benchmark plan-fidelity \
+  --action-kind implementation \
+  --action-kind independent_validation \
+  --role-action-kind technical_work=implementation \
+  --role-action-kind independent_validation=independent_validation \
+  --required-role-count technical_work=1 \
+  --required-role-count independent_validation=1 \
+  --require-qualified \
+  --format json
+```
+
+This command is the provider-neutral integration seam for treatment adapters. It
+returns non-zero with a compact receipt when the plan is unqualified or its typed
+contract is invalid, so a runner can stop before recording a qualified closeout.
+
 Matching is exact. A token such as `implementation_detail` does not inherit the
 `implementation` role unless the provider declares it. One token cannot belong to
 two roles, required roles must have an explicit mapping, and invalid contracts fail

--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -205,6 +205,47 @@ permissions, host and cross-trial isolation, credential propagation, canonical
 case-local state, verifier ordering, public/private evidence reduction, and matched-
 pair countability.
 
+## Treatment plan fidelity
+
+A treatment adapter may require the solver to create distinct technical-work and
+independent-validation Todos before editing. Do not qualify that requirement from
+Todo title words or from one hard-coded spelling of `action_kind`. Providers may
+use different exact public-safe tokens for the same semantic role.
+
+Declare the provider's accepted tokens explicitly and reduce only the typed action
+kinds through the stable benchmark roles:
+
+```python
+from loopx.capabilities.benchmark_toolkit import (
+    BenchmarkPlanRole,
+    build_benchmark_plan_fidelity_receipt,
+)
+
+receipt = build_benchmark_plan_fidelity_receipt(
+    action_kinds=["implementation", "implementation", "validation"],
+    role_action_kinds={
+        BenchmarkPlanRole.TECHNICAL_WORK: ["implement", "implementation"],
+        BenchmarkPlanRole.INDEPENDENT_VALIDATION: ["validate", "validation"],
+    },
+    required_role_counts={
+        BenchmarkPlanRole.TECHNICAL_WORK: 1,
+        BenchmarkPlanRole.INDEPENDENT_VALIDATION: 1,
+    },
+)
+assert receipt["qualified"] is True
+```
+
+Matching is exact. A token such as `implementation_detail` does not inherit the
+`implementation` role unless the provider declares it. One token cannot belong to
+two roles, required roles must have an explicit mapping, and invalid contracts fail
+closed. The public-safe receipt records semantic counts and blockers, never Todo
+text, raw action-kind values, paths, or trajectory content.
+
+This reducer proves only the declared plan shape. It does not prove that the Todos
+were created before editing, that their contents cover the task, that validation
+was independent, that implementation is correct, or that the run is score-countable.
+The runner and post-run integrity/fidelity adapters retain those responsibilities.
+
 ## Integrity qualification
 
 Run integrity qualification after the agent phase and after the runner has produced

--- a/loopx/capabilities/benchmark_toolkit/__init__.py
+++ b/loopx/capabilities/benchmark_toolkit/__init__.py
@@ -93,6 +93,11 @@ from .native_codex_profile import (
     native_codex_profile_environment,
     render_native_codex_goal_prompt,
 )
+from .plan_fidelity import (
+    BENCHMARK_PLAN_FIDELITY_SCHEMA_VERSION,
+    BenchmarkPlanRole,
+    build_benchmark_plan_fidelity_receipt,
+)
 from .public_trajectory import (
     NATIVE_GOAL_LIFECYCLE_SCHEMA_VERSION,
     PUBLIC_TRAJECTORY_SUMMARY_SCHEMA_VERSION,
@@ -149,6 +154,7 @@ __all__ = [
     "BENCHMARK_EXPERIMENT_BOARD_SCHEMA_VERSION",
     "BENCHMARK_INTEGRITY_POLICY_SCHEMA_VERSION",
     "BENCHMARK_INTEGRITY_QUALIFICATION_SCHEMA_VERSION",
+    "BENCHMARK_PLAN_FIDELITY_SCHEMA_VERSION",
     "BENCHMARK_RUNTIME_CONTINUITY_SCHEMA_VERSION",
     "BENCHMARK_RUNTIME_INTEGRITY_ATTESTATION_SCHEMA_VERSION",
     "BENCHMARK_RUNTIME_OBSERVATION_SCHEMA_VERSION",
@@ -167,6 +173,7 @@ __all__ = [
     "RUN_PERMISSION_QUOTA_PROJECTION_SCHEMA_VERSION",
     "BenchmarkEventWindowState",
     "BenchmarkJobReceiptState",
+    "BenchmarkPlanRole",
     "BenchmarkRunnerOwnerState",
     "BenchmarkRuntimeClassification",
     "BenchmarkRuntimeContinuityClassification",
@@ -201,6 +208,7 @@ __all__ = [
     "build_benchmark_concurrency_status",
     "build_benchmark_experiment_board",
     "build_benchmark_integrity_qualification",
+    "build_benchmark_plan_fidelity_receipt",
     "build_benchmark_runtime_continuity",
     "build_benchmark_runtime_observation",
     "build_native_codex_isolation_envelope",

--- a/loopx/capabilities/benchmark_toolkit/catalog_entry.py
+++ b/loopx/capabilities/benchmark_toolkit/catalog_entry.py
@@ -224,6 +224,7 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
             "upsert_preregistered_or_running_row_when_a_run_starts",
             "classify_exact_runtime_observation_during_active_monitor_cycles",
             "require_runtime_continuity_before_terminal_closeout_write",
+            "qualify_treatment_plan_roles_from_typed_action_kinds",
             "upsert_terminal_score_countability_effort_and_insight_status",
             "release_case_slot_after_terminal_or_runner_invalid_transition",
             "read_matched_comparisons_before_selecting_the_next_arm",
@@ -274,6 +275,24 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
             "Keep diagnostic-only explore rows separate and make paired claims "
             "only from matched_pair_countable comparisons."
         ),
+        "treatment_plan_fidelity": {
+            "stable_roles": [
+                "technical_work",
+                "independent_validation",
+                "review_refine",
+            ],
+            "matching": "provider_declared_exact_action_kind_tokens",
+            "required_boundary": (
+                "Use typed action_kind values through the benchmark plan-fidelity "
+                "reducer; do not infer semantic roles from Todo title text, "
+                "substrings, or one provider's preferred spelling."
+            ),
+            "authority_boundary": (
+                "Plan-role qualification proves only declared Todo shape; it does "
+                "not prove ordering, task coverage, validation independence, "
+                "technical correctness, integrity, or score countability."
+            ),
+        },
     },
     "concurrency_occupancy": {
         "benchmark_start_hint": (

--- a/loopx/capabilities/benchmark_toolkit/catalog_entry.py
+++ b/loopx/capabilities/benchmark_toolkit/catalog_entry.py
@@ -101,6 +101,26 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
         },
         {
             "command": (
+                "loopx benchmark plan-fidelity "
+                "--action-kind implementation "
+                "--action-kind independent_validation "
+                "--role-action-kind technical_work=implementation "
+                "--role-action-kind independent_validation=independent_validation "
+                "--required-role-count technical_work=1 "
+                "--required-role-count independent_validation=1 "
+                "--require-qualified --format json"
+            ),
+            "purpose": (
+                "Reduce a provider's exact public-safe Todo action kinds to stable "
+                "treatment-plan roles before closeout."
+            ),
+            "write_boundary": (
+                "read-only typed plan facts; emits semantic counts and blockers, "
+                "never Todo text or raw action-kind values"
+            ),
+        },
+        {
+            "command": (
                 "loopx benchmark experiment-board-upsert --goal-id <goal-id> "
                 "--row-json <compact-row.json> --execute --format json"
             ),

--- a/loopx/capabilities/benchmark_toolkit/plan_fidelity.py
+++ b/loopx/capabilities/benchmark_toolkit/plan_fidelity.py
@@ -113,7 +113,9 @@ def build_benchmark_plan_fidelity_receipt(
         classified_count += 1
 
     missing_roles = [
-        role for role, minimum in required.items() if counts[role] < minimum
+        role
+        for role in BenchmarkPlanRole
+        if role in required and counts[role] < required[role]
     ]
     qualified = not missing_roles
     return {

--- a/loopx/capabilities/benchmark_toolkit/plan_fidelity.py
+++ b/loopx/capabilities/benchmark_toolkit/plan_fidelity.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from enum import Enum
+from typing import Any
+
+BENCHMARK_PLAN_FIDELITY_SCHEMA_VERSION = "benchmark_plan_fidelity_v0"
+
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:@+-]{0,127}$")
+
+
+class BenchmarkPlanRole(str, Enum):
+    """Stable semantic roles used to qualify a benchmark treatment plan."""
+
+    TECHNICAL_WORK = "technical_work"
+    INDEPENDENT_VALIDATION = "independent_validation"
+    REVIEW_REFINE = "review_refine"
+
+
+def _role(value: BenchmarkPlanRole | str) -> BenchmarkPlanRole:
+    try:
+        return BenchmarkPlanRole(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("invalid_benchmark_plan_role") from exc
+
+
+def _token(value: Any, *, field: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"invalid_{field}")
+    text = value.strip()
+    if not _TOKEN_RE.fullmatch(text):
+        raise ValueError(f"invalid_{field}")
+    return text
+
+
+def _positive_int(value: Any, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"invalid_{field}")
+    if value > 1024:
+        raise ValueError(f"invalid_{field}")
+    return value
+
+
+def _normalize_role_action_kinds(
+    value: Mapping[BenchmarkPlanRole | str, Sequence[str]],
+) -> dict[BenchmarkPlanRole, tuple[str, ...]]:
+    if not isinstance(value, Mapping) or not value:
+        raise ValueError("invalid_role_action_kind_contract")
+    normalized: dict[BenchmarkPlanRole, tuple[str, ...]] = {}
+    token_owner: dict[str, BenchmarkPlanRole] = {}
+    for raw_role, raw_tokens in value.items():
+        role = _role(raw_role)
+        if role in normalized:
+            raise ValueError("duplicate_benchmark_plan_role")
+        if isinstance(raw_tokens, (str, bytes)) or not isinstance(raw_tokens, Sequence):
+            raise TypeError("invalid_role_action_kind_contract")
+        tokens = tuple(
+            sorted({_token(item, field="action_kind") for item in raw_tokens})
+        )
+        if not tokens:
+            raise ValueError("invalid_role_action_kind_contract")
+        for token in tokens:
+            if token in token_owner:
+                raise ValueError("action_kind_contract_overlap")
+            token_owner[token] = role
+        normalized[role] = tokens
+    return normalized
+
+
+def _normalize_required_role_counts(
+    value: Mapping[BenchmarkPlanRole | str, int],
+) -> dict[BenchmarkPlanRole, int]:
+    if not isinstance(value, Mapping) or not value:
+        raise ValueError("invalid_required_role_counts")
+    normalized: dict[BenchmarkPlanRole, int] = {}
+    for raw_role, raw_count in value.items():
+        role = _role(raw_role)
+        if role in normalized:
+            raise ValueError("duplicate_required_benchmark_plan_role")
+        normalized[role] = _positive_int(raw_count, field="required_role_count")
+    return normalized
+
+
+def build_benchmark_plan_fidelity_receipt(
+    *,
+    action_kinds: Sequence[str],
+    role_action_kinds: Mapping[BenchmarkPlanRole | str, Sequence[str]],
+    required_role_counts: Mapping[BenchmarkPlanRole | str, int],
+) -> dict[str, Any]:
+    """Reduce provider Todo action kinds to a public-safe plan-fidelity receipt.
+
+    The provider declares exact action-kind tokens for each stable semantic role.
+    LoopX intentionally performs no substring, title, or prose inference.
+    """
+
+    if isinstance(action_kinds, (str, bytes)) or not isinstance(action_kinds, Sequence):
+        raise TypeError("invalid_action_kinds")
+    observed_tokens = [_token(item, field="action_kind") for item in action_kinds]
+    contract = _normalize_role_action_kinds(role_action_kinds)
+    required = _normalize_required_role_counts(required_role_counts)
+    if any(role not in contract for role in required):
+        raise ValueError("required_role_missing_action_kind_contract")
+
+    token_roles = {token: role for role, tokens in contract.items() for token in tokens}
+    counts = {role: 0 for role in BenchmarkPlanRole}
+    classified_count = 0
+    for token in observed_tokens:
+        role = token_roles.get(token)
+        if role is None:
+            continue
+        counts[role] += 1
+        classified_count += 1
+
+    missing_roles = [
+        role for role, minimum in required.items() if counts[role] < minimum
+    ]
+    qualified = not missing_roles
+    return {
+        "schema_version": BENCHMARK_PLAN_FIDELITY_SCHEMA_VERSION,
+        "qualified": qualified,
+        "classification": (
+            "plan_role_contract_qualified"
+            if qualified
+            else "required_plan_role_missing"
+        ),
+        "observed_role_counts": {
+            role.value: counts[role] for role in BenchmarkPlanRole
+        },
+        "required_role_counts": {
+            role.value: required[role] for role in BenchmarkPlanRole if role in required
+        },
+        "classified_action_count": classified_count,
+        "unclassified_action_count": len(observed_tokens) - classified_count,
+        "blockers": [f"required_role_missing:{role.value}" for role in missing_roles],
+        "exact_action_kind_matching": True,
+        "public_boundary": {
+            "todo_text_recorded": False,
+            "raw_action_kinds_recorded": False,
+            "path_recorded": False,
+            "trajectory_recorded": False,
+        },
+        "write_performed": False,
+    }

--- a/loopx/cli_commands/benchmark_boundary.py
+++ b/loopx/cli_commands/benchmark_boundary.py
@@ -10,16 +10,19 @@ from pathlib import Path
 
 from ..capabilities.benchmark_toolkit import (
     BENCHMARK_INTEGRITY_QUALIFICATION_SCHEMA_VERSION,
+    BENCHMARK_PLAN_FIDELITY_SCHEMA_VERSION,
     BENCHMARK_RUNTIME_CONTINUITY_SCHEMA_VERSION,
     BENCHMARK_SOURCE_REVISION_FENCE_SCHEMA_VERSION,
     BenchmarkEventWindowState,
     BenchmarkJobReceiptState,
+    BenchmarkPlanRole,
     BenchmarkRunnerOwnerState,
     BenchmarkRuntimeContinuityClassification,
     BenchmarkRuntimeContinuityTransition,
     BenchmarkSourceRevisionFenceError,
     build_benchmark_candidate_source_boundary,
     build_benchmark_integrity_qualification,
+    build_benchmark_plan_fidelity_receipt,
     build_benchmark_runtime_continuity,
     build_benchmark_runtime_observation,
     compact_benchmark_source_revision_fence_receipt,
@@ -38,6 +41,7 @@ BENCHMARK_TOOLKIT_COMMANDS = {
     "candidate-source-boundary",
     "classify-artifacts",
     "integrity-qualification",
+    "plan-fidelity",
     "runtime-continuity",
     "runtime-observation",
     "source-revision-fence",
@@ -91,6 +95,47 @@ def _render_integrity(payload: dict[str, object]) -> str:
         f"- Cheating detected: `{payload.get('benchmark_cheating_detected')}`\n"
         + blocker_text
     )
+
+
+def _render_plan_fidelity(payload: dict[str, object]) -> str:
+    blockers = payload.get("blockers")
+    blocker_text = ""
+    if isinstance(blockers, list) and blockers:
+        blocker_text = (
+            "- Blockers: " + ", ".join(f"`{item}`" for item in blockers) + "\n"
+        )
+    return (
+        "# Benchmark Treatment Plan Fidelity\n\n"
+        f"- Classification: `{payload.get('classification')}`\n"
+        f"- Qualified: `{payload.get('qualified')}`\n"
+        f"- Classified actions: `{payload.get('classified_action_count')}`\n"
+        f"- Unclassified actions: `{payload.get('unclassified_action_count')}`\n"
+        + blocker_text
+    )
+
+
+def _parse_role_action_kinds(values: list[str]) -> dict[BenchmarkPlanRole, list[str]]:
+    contract: dict[BenchmarkPlanRole, list[str]] = {}
+    for value in values:
+        raw_role, separator, action_kind = value.partition("=")
+        if not separator:
+            raise ValueError("invalid_role_action_kind_assignment")
+        role = BenchmarkPlanRole(raw_role)
+        contract.setdefault(role, []).append(action_kind)
+    return contract
+
+
+def _parse_required_role_counts(values: list[str]) -> dict[BenchmarkPlanRole, int]:
+    required: dict[BenchmarkPlanRole, int] = {}
+    for value in values:
+        raw_role, separator, raw_count = value.partition("=")
+        if not separator:
+            raise ValueError("invalid_required_role_count_assignment")
+        role = BenchmarkPlanRole(raw_role)
+        if role in required:
+            raise ValueError("duplicate_required_benchmark_plan_role")
+        required[role] = int(raw_count)
+    return required
 
 
 def _render_source_revision_fence(payload: dict[str, object]) -> str:
@@ -195,6 +240,26 @@ def register_benchmark_boundary_commands(
     )
     continuity_parser.add_argument("--require-qualified", action="store_true")
 
+    plan_parser = benchmark_subparsers.add_parser(
+        "plan-fidelity",
+        help="Reduce exact provider Todo action kinds to stable treatment-plan roles.",
+    )
+    add_subcommand_format(plan_parser)
+    plan_parser.add_argument("--action-kind", action="append", required=True)
+    plan_parser.add_argument(
+        "--role-action-kind",
+        action="append",
+        required=True,
+        metavar="ROLE=ACTION_KIND",
+    )
+    plan_parser.add_argument(
+        "--required-role-count",
+        action="append",
+        required=True,
+        metavar="ROLE=COUNT",
+    )
+    plan_parser.add_argument("--require-qualified", action="store_true")
+
     integrity_parser = benchmark_subparsers.add_parser(
         "integrity-qualification",
         help="Reduce private trajectory and runner attestations to a compact receipt.",
@@ -284,6 +349,27 @@ def _invalid_runtime_continuity_input() -> dict[str, object]:
     }
 
 
+def _invalid_plan_fidelity_input() -> dict[str, object]:
+    return {
+        "schema_version": BENCHMARK_PLAN_FIDELITY_SCHEMA_VERSION,
+        "qualified": False,
+        "classification": "plan_fidelity_input_invalid",
+        "observed_role_counts": {role.value: 0 for role in BenchmarkPlanRole},
+        "required_role_counts": {},
+        "classified_action_count": 0,
+        "unclassified_action_count": 0,
+        "blockers": ["plan_fidelity_input_invalid"],
+        "exact_action_kind_matching": True,
+        "public_boundary": {
+            "todo_text_recorded": False,
+            "raw_action_kinds_recorded": False,
+            "path_recorded": False,
+            "trajectory_recorded": False,
+        },
+        "write_performed": False,
+    }
+
+
 def handle_benchmark_boundary_command(
     args: argparse.Namespace,
     *,
@@ -345,6 +431,20 @@ def handle_benchmark_boundary_command(
         except (TypeError, ValueError):
             payload = _invalid_runtime_continuity_input()
         print_payload(payload, output_format(args), _render_runtime_continuity)
+        return 1 if args.require_qualified and not payload.get("qualified") else 0
+
+    if args.benchmark_command == "plan-fidelity":
+        try:
+            payload = build_benchmark_plan_fidelity_receipt(
+                action_kinds=args.action_kind,
+                role_action_kinds=_parse_role_action_kinds(args.role_action_kind),
+                required_role_counts=_parse_required_role_counts(
+                    args.required_role_count
+                ),
+            )
+        except (TypeError, ValueError):
+            payload = _invalid_plan_fidelity_input()
+        print_payload(payload, output_format(args), _render_plan_fidelity)
         return 1 if args.require_qualified and not payload.get("qualified") else 0
 
     if args.benchmark_command == "verify-verifier-reward":

--- a/tests/capabilities/test_benchmark_plan_fidelity.py
+++ b/tests/capabilities/test_benchmark_plan_fidelity.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from loopx.capabilities.benchmark_toolkit import (
+    BENCHMARK_PLAN_FIDELITY_SCHEMA_VERSION,
+    BenchmarkPlanRole,
+    build_benchmark_plan_fidelity_receipt,
+)
+
+
+def _contract() -> dict[BenchmarkPlanRole, list[str]]:
+    return {
+        BenchmarkPlanRole.TECHNICAL_WORK: ["implement", "implementation"],
+        BenchmarkPlanRole.INDEPENDENT_VALIDATION: ["validate", "validation"],
+        BenchmarkPlanRole.REVIEW_REFINE: ["review", "review_refine"],
+    }
+
+
+def _required() -> dict[BenchmarkPlanRole, int]:
+    return {
+        BenchmarkPlanRole.TECHNICAL_WORK: 1,
+        BenchmarkPlanRole.INDEPENDENT_VALIDATION: 1,
+    }
+
+
+def test_explicit_action_kind_aliases_qualify_stable_semantic_roles() -> None:
+    receipt = build_benchmark_plan_fidelity_receipt(
+        action_kinds=["implementation", "implementation", "validation"],
+        role_action_kinds=_contract(),
+        required_role_counts=_required(),
+    )
+
+    assert receipt["schema_version"] == BENCHMARK_PLAN_FIDELITY_SCHEMA_VERSION
+    assert receipt["qualified"] is True
+    assert receipt["classification"] == "plan_role_contract_qualified"
+    assert receipt["observed_role_counts"] == {
+        "technical_work": 2,
+        "independent_validation": 1,
+        "review_refine": 0,
+    }
+    assert receipt["classified_action_count"] == 3
+    assert receipt["unclassified_action_count"] == 0
+    assert receipt["blockers"] == []
+    assert receipt["exact_action_kind_matching"] is True
+
+
+def test_unconfigured_near_match_does_not_satisfy_required_role() -> None:
+    receipt = build_benchmark_plan_fidelity_receipt(
+        action_kinds=["implementation_detail", "validation_review"],
+        role_action_kinds=_contract(),
+        required_role_counts=_required(),
+    )
+
+    assert receipt["qualified"] is False
+    assert receipt["classification"] == "required_plan_role_missing"
+    assert receipt["observed_role_counts"]["technical_work"] == 0
+    assert receipt["observed_role_counts"]["independent_validation"] == 0
+    assert receipt["unclassified_action_count"] == 2
+    assert receipt["blockers"] == [
+        "required_role_missing:technical_work",
+        "required_role_missing:independent_validation",
+    ]
+
+
+def test_caller_can_explicitly_map_compound_provider_tokens() -> None:
+    contract = _contract()
+    contract[BenchmarkPlanRole.TECHNICAL_WORK].append("implementation_detail")
+    contract[BenchmarkPlanRole.INDEPENDENT_VALIDATION].append("validation_review")
+    receipt = build_benchmark_plan_fidelity_receipt(
+        action_kinds=["implementation_detail", "validation_review"],
+        role_action_kinds=contract,
+        required_role_counts=_required(),
+    )
+
+    assert receipt["qualified"] is True
+    assert receipt["observed_role_counts"]["technical_work"] == 1
+    assert receipt["observed_role_counts"]["independent_validation"] == 1
+
+
+def test_receipt_does_not_record_todo_text_or_action_kind_tokens() -> None:
+    private_like_token = "provider_private_implementation"
+    receipt = build_benchmark_plan_fidelity_receipt(
+        action_kinds=[private_like_token, "validation"],
+        role_action_kinds={
+            **_contract(),
+            BenchmarkPlanRole.TECHNICAL_WORK: [
+                "implement",
+                private_like_token,
+            ],
+        },
+        required_role_counts=_required(),
+    )
+
+    rendered = json.dumps(receipt, sort_keys=True)
+    assert private_like_token not in rendered
+    assert receipt["public_boundary"] == {
+        "todo_text_recorded": False,
+        "raw_action_kinds_recorded": False,
+        "path_recorded": False,
+        "trajectory_recorded": False,
+    }
+    assert receipt["write_performed"] is False
+
+
+def test_overlapping_action_kind_contract_fails_closed() -> None:
+    contract = _contract()
+    contract[BenchmarkPlanRole.INDEPENDENT_VALIDATION].append("implementation")
+
+    with pytest.raises(ValueError, match="^action_kind_contract_overlap$"):
+        build_benchmark_plan_fidelity_receipt(
+            action_kinds=["implementation", "validation"],
+            role_action_kinds=contract,
+            required_role_counts=_required(),
+        )
+
+
+def test_required_role_without_mapping_fails_closed() -> None:
+    with pytest.raises(
+        ValueError,
+        match="^required_role_missing_action_kind_contract$",
+    ):
+        build_benchmark_plan_fidelity_receipt(
+            action_kinds=["implementation"],
+            role_action_kinds={
+                BenchmarkPlanRole.TECHNICAL_WORK: ["implementation"],
+            },
+            required_role_counts=_required(),
+        )
+
+
+@pytest.mark.parametrize(
+    (
+        "action_kinds",
+        "role_action_kinds",
+        "required_role_counts",
+        "error_type",
+        "message",
+    ),
+    [
+        (
+            "implementation",
+            _contract(),
+            _required(),
+            TypeError,
+            "invalid_action_kinds",
+        ),
+        (
+            ["implementation/unsafe"],
+            _contract(),
+            _required(),
+            ValueError,
+            "invalid_action_kind",
+        ),
+        (
+            [1],
+            _contract(),
+            _required(),
+            TypeError,
+            "invalid_action_kind",
+        ),
+        (
+            ["implementation"],
+            {"unknown_role": ["implementation"]},
+            _required(),
+            ValueError,
+            "invalid_benchmark_plan_role",
+        ),
+        (
+            ["implementation"],
+            _contract(),
+            {BenchmarkPlanRole.TECHNICAL_WORK: 0},
+            ValueError,
+            "invalid_required_role_count",
+        ),
+    ],
+)
+def test_invalid_plan_contract_inputs_fail_closed(
+    action_kinds: object,
+    role_action_kinds: object,
+    required_role_counts: object,
+    error_type: type[Exception],
+    message: str,
+) -> None:
+    with pytest.raises(error_type, match=rf"^{message}$"):
+        build_benchmark_plan_fidelity_receipt(
+            action_kinds=action_kinds,  # type: ignore[arg-type]
+            role_action_kinds=role_action_kinds,  # type: ignore[arg-type]
+            required_role_counts=required_role_counts,  # type: ignore[arg-type]
+        )

--- a/tests/capabilities/test_benchmark_plan_fidelity.py
+++ b/tests/capabilities/test_benchmark_plan_fidelity.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -9,6 +11,8 @@ from loopx.capabilities.benchmark_toolkit import (
     BenchmarkPlanRole,
     build_benchmark_plan_fidelity_receipt,
 )
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _contract() -> dict[BenchmarkPlanRole, list[str]]:
@@ -190,3 +194,98 @@ def test_invalid_plan_contract_inputs_fail_closed(
             role_action_kinds=role_action_kinds,  # type: ignore[arg-type]
             required_role_counts=required_role_counts,  # type: ignore[arg-type]
         )
+
+
+def test_cli_qualifies_real_provider_tokens_without_echoing_them() -> None:
+    private_like_token = "provider-private-work"
+    completed = subprocess.run(
+        [
+            str(REPO_ROOT / "scripts/loopx"),
+            "benchmark",
+            "plan-fidelity",
+            "--action-kind",
+            private_like_token,
+            "--action-kind",
+            "independent_validation",
+            "--role-action-kind",
+            f"technical_work={private_like_token}",
+            "--role-action-kind",
+            "independent_validation=independent_validation",
+            "--required-role-count",
+            "technical_work=1",
+            "--required-role-count",
+            "independent_validation=1",
+            "--require-qualified",
+            "--format",
+            "json",
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    receipt = json.loads(completed.stdout)
+    assert receipt["qualified"] is True
+    assert receipt["observed_role_counts"]["technical_work"] == 1
+    assert receipt["observed_role_counts"]["independent_validation"] == 1
+    assert private_like_token not in completed.stdout
+
+
+def test_cli_fails_closed_for_unmapped_near_match() -> None:
+    completed = subprocess.run(
+        [
+            str(REPO_ROOT / "scripts/loopx"),
+            "benchmark",
+            "plan-fidelity",
+            "--action-kind",
+            "implementation_detail",
+            "--role-action-kind",
+            "technical_work=implementation",
+            "--required-role-count",
+            "technical_work=1",
+            "--require-qualified",
+            "--format",
+            "json",
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    receipt = json.loads(completed.stdout)
+    assert receipt["classification"] == "required_plan_role_missing"
+    assert receipt["blockers"] == ["required_role_missing:technical_work"]
+    assert "implementation_detail" not in completed.stdout
+
+
+def test_cli_reduces_invalid_mapping_to_public_safe_receipt() -> None:
+    invalid_assignment = "provider-private-assignment"
+    completed = subprocess.run(
+        [
+            str(REPO_ROOT / "scripts/loopx"),
+            "benchmark",
+            "plan-fidelity",
+            "--action-kind",
+            "implementation",
+            "--role-action-kind",
+            invalid_assignment,
+            "--required-role-count",
+            "technical_work=1",
+            "--require-qualified",
+            "--format",
+            "json",
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    receipt = json.loads(completed.stdout)
+    assert receipt["classification"] == "plan_fidelity_input_invalid"
+    assert receipt["blockers"] == ["plan_fidelity_input_invalid"]
+    assert invalid_assignment not in completed.stdout

--- a/tests/capabilities/test_benchmark_toolkit.py
+++ b/tests/capabilities/test_benchmark_toolkit.py
@@ -213,6 +213,25 @@ def test_catalog_exposes_post_run_case_insight_monitor_contract() -> None:
     assert "reuse_boundary" in artifact
 
 
+def test_catalog_exposes_typed_treatment_plan_fidelity_contract() -> None:
+    capability = build_capability_detail_packet("benchmark-toolkit")["capability"]
+    usage = capability["agent_usage"]
+
+    assert (
+        "qualify_treatment_plan_roles_from_typed_action_kinds"
+        in usage["required_sequence"]
+    )
+    contract = usage["treatment_plan_fidelity"]
+    assert contract["stable_roles"] == [
+        "technical_work",
+        "independent_validation",
+        "review_refine",
+    ]
+    assert contract["matching"] == "provider_declared_exact_action_kind_tokens"
+    assert "do not infer" in contract["required_boundary"]
+    assert "does not prove" in contract["authority_boundary"]
+
+
 def _attestation() -> dict[str, object]:
     return {
         "schema_version": BENCHMARK_RUNTIME_INTEGRITY_ATTESTATION_SCHEMA_VERSION,


### PR DESCRIPTION
## Motivation

Benchmark treatment adapters may use different exact action-kind tokens for the same semantic Todo role. Qualifying plan shape with one hard-coded spelling creates false negatives even when the provider emitted a valid technical-work or validation Todo.

## What changed

- Add stable technical-work, independent-validation, and review-refine roles.
- Let each provider declare exact accepted action-kind tokens.
- Fail closed for fuzzy matches, overlapping token ownership, invalid counts, or missing required mappings.
- Emit a compact public-safe receipt with semantic counts and blockers only.
- Document that plan qualification does not prove ordering, task coverage, validation independence, correctness, integrity, or score countability.

## Validation

- 139 focused benchmark-toolkit tests passed.
- Ruff check and format checks passed.
- Catalog planner smoke passed.
- Standard premerge canary: all direct, catalog, risk-profile, and public-boundary checks passed.
- The expected benchmark-sensitive manual review hold remains; this PR is not self-merged.

## Public boundary

No task text, raw trajectories, verifier output, credentials, private paths, or provider-private tokens are recorded in the receipt or included in this change.