### PR TITLE
Verify exact Miaoda releases in periodic report receipts

### DIFF
--- a/docs/reference/protocols/periodic-report-v0.md
+++ b/docs/reference/protocols/periodic-report-v0.md
@@ -262,10 +262,16 @@ own idempotency and readback receipt; it is not renderer authority.
 The bundled Lark extension includes an opt-in `miaoda_html` delivery sink for
 `html_artifact_v0`. It validates the single HTML, compressed archive, and
 uncompressed payload limits before any external effect. A successful receipt
-requires exact readback of the request-selected app id, published URL, and
-published state, and also records the observed access scope and login
-requirement. The project or host still owns app selection, authentication,
-audience policy, and the execute decision.
+requires exact readback of the request-selected app id and published URL plus
+the exact publication release in `finished` state. The receipt separates
+`release_readback`, `access_scope_readback`, and `content_readback`: access
+scope may be a typed `unsupported_by_app_type` result for creative HTML apps,
+while other query failures remain retryable `unavailable` evidence; the
+bundled provider marks remote content-digest verification as
+`unavailable` because the provider API does not expose published bytes or a
+digest. App existence, URL equality, and release completion must not be
+promoted to byte-for-byte content proof. The project or host still owns app
+selection, authentication, audience policy, and the execute decision.
 
 `loopx periodic-report publish-miaoda` is the concrete CLI for that sink. Its
 `periodic_report_miaoda_delivery_request_v0` must carry a complete normalized
@@ -281,12 +287,14 @@ Without `--execute`, the command performs no provider call and returns
 `periodic_report_miaoda_delivery_result_v0` with
 `status=pending_execution`, `intent_satisfied=false`, and a pending delivery
 receipt. With `--execute`, it uses authenticated `lark-cli` publication and
-requires exact readback of the same app id, online URL, and published state.
-Only that verified result sets `intent_satisfied=true`. The generation bundle
-remains usable in either case, but local HTML never satisfies the hosted
-delivery intent. The command does not accept credentials, create apps, select
-an audience, mutate access scope, send chat notifications, or apply schedule
-policy.
+requires exact readback of the same app id, online URL, and publication release
+in `finished` state. Only that verified lifecycle result sets
+`intent_satisfied=true`; access-scope and content-proof limitations remain
+explicit evidence in both the sink result and normalized delivery receipt. The
+generation bundle remains usable in either case, but local HTML never satisfies
+the hosted delivery intent. The command does not accept credentials, create
+apps, select an audience, mutate access scope, send chat notifications, or
+apply schedule policy.
 
 The normalized document's optional `editorial` input is split by ownership.
 The project profile owns bounded `kicker`, `period_label`, `language`, and zero

--- a/docs/reference/protocols/periodic-report-v0.md
+++ b/docs/reference/protocols/periodic-report-v0.md
@@ -270,7 +270,9 @@ while other query failures remain retryable `unavailable` evidence; the
 bundled provider marks remote content-digest verification as
 `unavailable` because the provider API does not expose published bytes or a
 digest. App existence, URL equality, and release completion must not be
-promoted to byte-for-byte content proof. The project or host still owns app
+promoted to byte-for-byte content proof. Receipt normalization recomputes exact
+release verification from the requested release id and provider status rather
+than trusting a provider boolean. The project or host still owns app
 selection, authentication, audience policy, and the execute decision.
 
 `loopx periodic-report publish-miaoda` is the concrete CLI for that sink. Its

--- a/loopx/capabilities/periodic_report/README.md
+++ b/loopx/capabilities/periodic_report/README.md
@@ -273,14 +273,17 @@ published URL, and published state. The sink receipt keeps three evidence
 layers separate:
 
 - `release_readback` proves the exact provider release reached its terminal
-  published state;
+  published state. The capability recomputes this from the requested release id
+  and provider status; a provider-supplied `verified` flag cannot override a
+  mismatch;
 - `access_scope_readback` records the observed scope and login requirement, or
   a typed `unsupported_by_app_type` result when the provider does not expose
   that query for creative HTML apps. Other provider-query failures remain a
   retryable `unavailable` evidence state without erasing a verified release;
 - `content_readback` states whether the remote content digest was verified.
   The bundled provider currently records `unavailable` because the provider
-  API does not expose the published bytes or their digest.
+  API does not expose the published bytes or their digest; no speculative
+  `verified` state is accepted until a provider can supply real digest evidence.
 
 An app id, online URL, or finished release therefore proves delivery lifecycle,
 not byte-for-byte equality with the local artifact.

--- a/loopx/capabilities/periodic_report/README.md
+++ b/loopx/capabilities/periodic_report/README.md
@@ -267,9 +267,23 @@ already-rendered artifact to a project-owned existing Miaoda HTML app selected
 by the delivery request; it does not
 rebuild the document or choose an audience. Before any external effect it
 checks the single HTML, compressed archive, and uncompressed payload limits.
-After publication it requires exact readback of the same app id, published
-URL, and published state, and records the observed access scope and login
-requirement in the sink receipt.
+After publication it preserves the provider's exact release id and requires
+readback of that release in `finished` state as well as the same app id,
+published URL, and published state. The sink receipt keeps three evidence
+layers separate:
+
+- `release_readback` proves the exact provider release reached its terminal
+  published state;
+- `access_scope_readback` records the observed scope and login requirement, or
+  a typed `unsupported_by_app_type` result when the provider does not expose
+  that query for creative HTML apps. Other provider-query failures remain a
+  retryable `unavailable` evidence state without erasing a verified release;
+- `content_readback` states whether the remote content digest was verified.
+  The bundled provider currently records `unavailable` because the provider
+  API does not expose the published bytes or their digest.
+
+An app id, online URL, or finished release therefore proves delivery lifecycle,
+not byte-for-byte equality with the local artifact.
 
 Projects bind the sink explicitly so report generation remains portable and
 external writes remain disabled by default:
@@ -346,10 +360,13 @@ The command resolves the installed, enabled, doctor-verified `loopx-lark`
 revision and its `lark.miaoda_html.publish` permission. Authentication remains
 inside `lark-cli`; the request accepts no token or credential. The provider
 publishes a temporary `index.html`, reads the exact app back, and sets
-`intent_satisfied=true` only when the same app id, online URL, and published
-state agree. It does not create an app, change the app's audience, or change its
-access scope. Disable or roll back the bundled extension to remove the provider
-without affecting already-generated local artifacts.
+`intent_satisfied=true` only when the same app id and online URL agree and the
+exact release returned by publication reads back as `finished`. Access-scope
+readback is evidence only: an app-type-specific unsupported response is kept as
+a typed boundary instead of being treated as a guessed scope. The command does
+not claim remote content-digest verification, create an app, change the app's
+audience, or change its access scope. Disable or roll back the bundled extension
+to remove the provider without affecting already-generated local artifacts.
 
 ## Default editorial contract
 

--- a/loopx/capabilities/periodic_report/bindings.py
+++ b/loopx/capabilities/periodic_report/bindings.py
@@ -39,7 +39,7 @@ _ACCESS_SCOPE_READBACK_STATUSES = {
     "unsupported_by_app_type",
     "verified",
 }
-_CONTENT_READBACK_STATUSES = {"verified", "unavailable"}
+_CONTENT_READBACK_STATUSES = {"unavailable"}
 
 
 def _mapping(value: object, label: str) -> dict[str, Any]:
@@ -84,13 +84,22 @@ def _boolean(value: object, label: str) -> bool:
 
 
 def _normalize_periodic_report_release_readback(
-    value: object, label: str
+    value: object,
+    label: str,
+    *,
+    expected_release_id: object,
 ) -> dict[str, Any]:
     receipt = _mapping(value, label)
+    release_id = _text(receipt.get("release_id"), f"{label}.release_id")
+    status = _token(receipt.get("status"), f"{label}.status")
+    expected = _text(expected_release_id, f"{label}.expected_release_id")
+    verified = release_id == expected and status == "finished"
+    if _boolean(receipt.get("verified"), f"{label}.verified") is not verified:
+        raise ValueError(f"{label}.verified does not match exact release readback")
     normalized = {
-        "release_id": _text(receipt.get("release_id"), f"{label}.release_id"),
-        "status": _token(receipt.get("status"), f"{label}.status"),
-        "verified": _boolean(receipt.get("verified"), f"{label}.verified"),
+        "release_id": release_id,
+        "status": status,
+        "verified": verified,
     }
     if set(receipt) != set(normalized):
         raise ValueError(f"{label} contains unsupported fields")
@@ -108,13 +117,12 @@ def _normalize_periodic_report_access_scope_readback(
     if retryable is not (status == "unavailable"):
         raise ValueError(f"{label}.retryable does not match status")
     normalized: dict[str, Any] = {"status": status, "retryable": retryable}
-    if receipt.get("scope") is not None:
+    if status == "verified":
         normalized["scope"] = _text(receipt.get("scope"), f"{label}.scope")
-    if receipt.get("require_login") is not None:
         normalized["require_login"] = _boolean(
             receipt.get("require_login"), f"{label}.require_login"
         )
-    if status in {"unavailable", "unsupported_by_app_type"}:
+    else:
         normalized["reason"] = _token(receipt.get("reason"), f"{label}.reason")
     if set(receipt) != set(normalized):
         raise ValueError(f"{label} contains unsupported fields")
@@ -131,14 +139,13 @@ def _normalize_periodic_report_content_readback(
     digest_verified = _boolean(
         receipt.get("digest_verified"), f"{label}.digest_verified"
     )
-    if digest_verified is not (status == "verified"):
+    if digest_verified is not False:
         raise ValueError(f"{label}.digest_verified does not match status")
     normalized: dict[str, Any] = {
         "status": status,
         "digest_verified": digest_verified,
     }
-    if status == "unavailable":
-        normalized["reason"] = _token(receipt.get("reason"), f"{label}.reason")
+    normalized["reason"] = _token(receipt.get("reason"), f"{label}.reason")
     if set(receipt) != set(normalized):
         raise ValueError(f"{label} contains unsupported fields")
     return normalized
@@ -665,20 +672,46 @@ def build_periodic_report_delivery_receipt(
             and result.get("idempotency_key")
         ):
             raise ValueError(f"{label} sent result requires exact readback")
-        if status == "sent" and result.get("sink_kind") == "miaoda_html":
-            missing_evidence = sorted(
-                key
-                for key in (
-                    "access_scope_readback",
-                    "content_readback",
-                    "release_readback",
-                )
-                if result.get(key) is None
+        if result.get("sink_kind") == "miaoda_html":
+            evidence_keys = (
+                "access_scope_readback",
+                "content_readback",
+                "release_readback",
             )
-            if missing_evidence:
+            if status == "sent":
+                missing_evidence = sorted(
+                    key for key in evidence_keys if result.get(key) is None
+                )
+                if missing_evidence:
+                    raise ValueError(
+                        f"{label} sent Miaoda result is missing structured readback: "
+                        + ", ".join(missing_evidence)
+                    )
+            if result.get("release_readback") is not None:
+                result["release_readback"] = (
+                    _normalize_periodic_report_release_readback(
+                        result["release_readback"],
+                        f"{label}.release_readback",
+                        expected_release_id=result.get("release_id"),
+                    )
+                )
+            if result.get("access_scope_readback") is not None:
+                result["access_scope_readback"] = (
+                    _normalize_periodic_report_access_scope_readback(
+                        result["access_scope_readback"],
+                        f"{label}.access_scope_readback",
+                    )
+                )
+            if result.get("content_readback") is not None:
+                result["content_readback"] = (
+                    _normalize_periodic_report_content_readback(
+                        result["content_readback"],
+                        f"{label}.content_readback",
+                    )
+                )
+            if status == "sent" and result["release_readback"]["verified"] is not True:
                 raise ValueError(
-                    f"{label} sent Miaoda result is missing structured readback: "
-                    + ", ".join(missing_evidence)
+                    f"{label} sent Miaoda result requires exact release readback"
                 )
         results_by_identity[sink_identity] = result
 
@@ -729,27 +762,13 @@ def build_periodic_report_delivery_receipt(
             for key in ("idempotency_key", "receipt_ref", "result_id"):
                 if sink_result.get(key):
                     receipt[key] = sink_result[key]
-            if sink_result.get("release_readback") is not None:
-                receipt["release_readback"] = (
-                    _normalize_periodic_report_release_readback(
-                        sink_result["release_readback"],
-                        f"sink_result[{sink_identity[0]}:{sink_identity[1]}].release_readback",
-                    )
-                )
-            if sink_result.get("access_scope_readback") is not None:
-                receipt["access_scope_readback"] = (
-                    _normalize_periodic_report_access_scope_readback(
-                        sink_result["access_scope_readback"],
-                        f"sink_result[{sink_identity[0]}:{sink_identity[1]}].access_scope_readback",
-                    )
-                )
-            if sink_result.get("content_readback") is not None:
-                receipt["content_readback"] = (
-                    _normalize_periodic_report_content_readback(
-                        sink_result["content_readback"],
-                        f"sink_result[{sink_identity[0]}:{sink_identity[1]}].content_readback",
-                    )
-                )
+            for key in (
+                "release_readback",
+                "access_scope_readback",
+                "content_readback",
+            ):
+                if sink_result.get(key) is not None:
+                    receipt[key] = sink_result[key]
         sink_receipts.append(receipt)
     unknown = sorted(set(results_by_identity) - expected_identities)
     if unknown:

--- a/loopx/capabilities/periodic_report/bindings.py
+++ b/loopx/capabilities/periodic_report/bindings.py
@@ -13,7 +13,6 @@ from .adapters import (
 )
 from .core import _reject_raw_keys
 
-
 GENERATION_BUNDLE_SCHEMA = "periodic_report_generation_bundle_v0"
 GENERATION_RECEIPT_SCHEMA = "periodic_report_generation_receipt_v0"
 SINK_BINDING_SCHEMA = "periodic_report_sink_binding_v0"
@@ -35,6 +34,12 @@ _READINESS_ITEM_STATUSES = {
     "unknown",
     "unverified",
 }
+_ACCESS_SCOPE_READBACK_STATUSES = {
+    "unavailable",
+    "unsupported_by_app_type",
+    "verified",
+}
+_CONTENT_READBACK_STATUSES = {"verified", "unavailable"}
 
 
 def _mapping(value: object, label: str) -> dict[str, Any]:
@@ -76,6 +81,67 @@ def _boolean(value: object, label: str) -> bool:
     if not isinstance(value, bool):
         raise ValueError(f"{label} must be a boolean")
     return value
+
+
+def _normalize_periodic_report_release_readback(
+    value: object, label: str
+) -> dict[str, Any]:
+    receipt = _mapping(value, label)
+    normalized = {
+        "release_id": _text(receipt.get("release_id"), f"{label}.release_id"),
+        "status": _token(receipt.get("status"), f"{label}.status"),
+        "verified": _boolean(receipt.get("verified"), f"{label}.verified"),
+    }
+    if set(receipt) != set(normalized):
+        raise ValueError(f"{label} contains unsupported fields")
+    return normalized
+
+
+def _normalize_periodic_report_access_scope_readback(
+    value: object, label: str
+) -> dict[str, Any]:
+    receipt = _mapping(value, label)
+    status = _token(receipt.get("status"), f"{label}.status")
+    if status not in _ACCESS_SCOPE_READBACK_STATUSES:
+        raise ValueError(f"{label}.status is invalid")
+    retryable = _boolean(receipt.get("retryable"), f"{label}.retryable")
+    if retryable is not (status == "unavailable"):
+        raise ValueError(f"{label}.retryable does not match status")
+    normalized: dict[str, Any] = {"status": status, "retryable": retryable}
+    if receipt.get("scope") is not None:
+        normalized["scope"] = _text(receipt.get("scope"), f"{label}.scope")
+    if receipt.get("require_login") is not None:
+        normalized["require_login"] = _boolean(
+            receipt.get("require_login"), f"{label}.require_login"
+        )
+    if status in {"unavailable", "unsupported_by_app_type"}:
+        normalized["reason"] = _token(receipt.get("reason"), f"{label}.reason")
+    if set(receipt) != set(normalized):
+        raise ValueError(f"{label} contains unsupported fields")
+    return normalized
+
+
+def _normalize_periodic_report_content_readback(
+    value: object, label: str
+) -> dict[str, Any]:
+    receipt = _mapping(value, label)
+    status = _token(receipt.get("status"), f"{label}.status")
+    if status not in _CONTENT_READBACK_STATUSES:
+        raise ValueError(f"{label}.status is invalid")
+    digest_verified = _boolean(
+        receipt.get("digest_verified"), f"{label}.digest_verified"
+    )
+    if digest_verified is not (status == "verified"):
+        raise ValueError(f"{label}.digest_verified does not match status")
+    normalized: dict[str, Any] = {
+        "status": status,
+        "digest_verified": digest_verified,
+    }
+    if status == "unavailable":
+        normalized["reason"] = _token(receipt.get("reason"), f"{label}.reason")
+    if set(receipt) != set(normalized):
+        raise ValueError(f"{label} contains unsupported fields")
+    return normalized
 
 
 def _canonical_copy(value: Mapping[str, Any]) -> dict[str, Any]:
@@ -599,6 +665,21 @@ def build_periodic_report_delivery_receipt(
             and result.get("idempotency_key")
         ):
             raise ValueError(f"{label} sent result requires exact readback")
+        if status == "sent" and result.get("sink_kind") == "miaoda_html":
+            missing_evidence = sorted(
+                key
+                for key in (
+                    "access_scope_readback",
+                    "content_readback",
+                    "release_readback",
+                )
+                if result.get(key) is None
+            )
+            if missing_evidence:
+                raise ValueError(
+                    f"{label} sent Miaoda result is missing structured readback: "
+                    + ", ".join(missing_evidence)
+                )
         results_by_identity[sink_identity] = result
 
     sink_receipts: list[dict[str, Any]] = []
@@ -648,6 +729,27 @@ def build_periodic_report_delivery_receipt(
             for key in ("idempotency_key", "receipt_ref", "result_id"):
                 if sink_result.get(key):
                     receipt[key] = sink_result[key]
+            if sink_result.get("release_readback") is not None:
+                receipt["release_readback"] = (
+                    _normalize_periodic_report_release_readback(
+                        sink_result["release_readback"],
+                        f"sink_result[{sink_identity[0]}:{sink_identity[1]}].release_readback",
+                    )
+                )
+            if sink_result.get("access_scope_readback") is not None:
+                receipt["access_scope_readback"] = (
+                    _normalize_periodic_report_access_scope_readback(
+                        sink_result["access_scope_readback"],
+                        f"sink_result[{sink_identity[0]}:{sink_identity[1]}].access_scope_readback",
+                    )
+                )
+            if sink_result.get("content_readback") is not None:
+                receipt["content_readback"] = (
+                    _normalize_periodic_report_content_readback(
+                        sink_result["content_readback"],
+                        f"sink_result[{sink_identity[0]}:{sink_identity[1]}].content_readback",
+                    )
+                )
         sink_receipts.append(receipt)
     unknown = sorted(set(results_by_identity) - expected_identities)
     if unknown:

--- a/loopx/extensions/lark/miaoda_report.py
+++ b/loopx/extensions/lark/miaoda_report.py
@@ -54,20 +54,39 @@ def _reject_unknown_fields(
         raise ValueError(f"{label} contains unsupported fields: {', '.join(unknown)}")
 
 
-def _json_response(result: Mapping[str, Any], label: str) -> dict[str, Any]:
+def _json_payload(result: Mapping[str, Any], label: str) -> tuple[int, dict[str, Any]]:
     try:
         returncode = int(result["returncode"])
     except (KeyError, TypeError, ValueError) as exc:
         raise ValueError(f"{label} returned an invalid process receipt") from exc
-    if returncode != 0:
-        raise ValueError(f"{label} failed")
+    raw_payload = str(result.get("stdout") or result.get("stderr") or "")
     try:
-        payload = json.loads(str(result.get("stdout") or ""))
+        payload = json.loads(raw_payload)
     except json.JSONDecodeError as exc:
         raise ValueError(f"{label} returned invalid JSON") from exc
-    if not isinstance(payload, Mapping) or payload.get("ok") is not True:
+    if not isinstance(payload, Mapping):
+        raise TypeError(f"{label} returned invalid JSON")
+    return returncode, {str(key): value for key, value in payload.items()}
+
+
+def _json_response(result: Mapping[str, Any], label: str) -> dict[str, Any]:
+    returncode, payload = _json_payload(result, label)
+    if returncode != 0 or payload.get("ok") is not True:
         raise ValueError(f"{label} did not return an ok receipt")
-    return {str(key): value for key, value in payload.items()}
+    return payload
+
+
+def _api_error_code(payload: Mapping[str, Any]) -> int | None:
+    error = payload.get("error")
+    candidates = [payload.get("code")]
+    if isinstance(error, Mapping):
+        candidates.append(error.get("code"))
+    for value in candidates:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            continue
+    return None
 
 
 def _default_runner(
@@ -154,6 +173,52 @@ class LarkCliMiaodaProvider:
             page_token = _text(data.get("page_token"), "Miaoda page_token")
         raise ValueError("Miaoda app readback could not find the requested app")
 
+    def _read_access_scope(
+        self,
+        app_id: str,
+        *,
+        app_type: str,
+    ) -> dict[str, Any]:
+        label = "Miaoda access-scope readback"
+        returncode, payload = _json_payload(
+            self._runner(
+                [
+                    *self._prefix,
+                    "apps",
+                    "+access-scope-get",
+                    "--app-id",
+                    app_id,
+                    "--format",
+                    "json",
+                ],
+                None,
+                120.0,
+            ),
+            label,
+        )
+        if returncode == 0 and payload.get("ok") is True:
+            data = self._data(payload)
+            receipt: dict[str, Any] = {"status": "verified", "retryable": False}
+            access_scope = data.get("access_scope") or data.get("scope")
+            if access_scope is not None:
+                receipt["scope"] = _text(access_scope, "Miaoda access_scope")
+            if data.get("require_login") is not None:
+                if not isinstance(data["require_login"], bool):
+                    raise TypeError("Miaoda require_login must be a boolean")
+                receipt["require_login"] = data["require_login"]
+            return receipt
+        if _api_error_code(payload) == 40002 and app_type == "html":
+            return {
+                "status": "unsupported_by_app_type",
+                "retryable": False,
+                "reason": "creative_html_scope_readback_unavailable",
+            }
+        return {
+            "status": "unavailable",
+            "retryable": True,
+            "reason": "provider_query_failed",
+        }
+
     def publish(
         self,
         artifact: Mapping[str, Any],
@@ -179,20 +244,56 @@ class LarkCliMiaodaProvider:
                 cwd=root,
             )
         data = self._data(payload)
+        release_id = _text(data.get("release_id"), "Miaoda publish release_id")
         online_url = str(data.get("online_url") or data.get("url") or "").strip()
         if not online_url:
             online_url = _text(
                 self._list_app(app_id).get("online_url"),
                 "Miaoda publish online_url",
             )
-        return {"app_id": app_id, "online_url": online_url}
+        return {
+            "app_id": app_id,
+            "online_url": online_url,
+            "release_id": release_id,
+        }
 
-    def readback(self, app_id: str) -> dict[str, Any]:
+    def readback(self, app_id: str, release_id: str) -> dict[str, Any]:
         item = self._list_app(app_id)
+        release = self._data(
+            self._call(
+                [
+                    "apps",
+                    "+release-get",
+                    "--app-id",
+                    app_id,
+                    "--release-id",
+                    release_id,
+                    "--format",
+                    "json",
+                ],
+                label="Miaoda release readback",
+            )
+        )
+        observed_release_id = _text(
+            release.get("release_id"), "Miaoda readback release_id"
+        )
+        release_status = _text(release.get("status"), "Miaoda readback release status")
+        app_type = _text(item.get("app_type"), "Miaoda readback app_type")
         return {
             "app_id": _text(item.get("app_id"), "Miaoda readback app_id"),
             "online_url": _text(item.get("online_url"), "Miaoda readback online_url"),
             "is_published": item.get("is_published") is True,
+            "release_readback": {
+                "release_id": observed_release_id,
+                "status": release_status,
+                "verified": (
+                    observed_release_id == release_id and release_status == "finished"
+                ),
+            },
+            "access_scope_readback": self._read_access_scope(
+                app_id,
+                app_type=app_type,
+            ),
         }
 
 

--- a/loopx/extensions/lark/miaoda_report.py
+++ b/loopx/extensions/lark/miaoda_report.py
@@ -89,6 +89,14 @@ def _api_error_code(payload: Mapping[str, Any]) -> int | None:
     return None
 
 
+def _unavailable_access_scope() -> dict[str, Any]:
+    return {
+        "status": "unavailable",
+        "retryable": True,
+        "reason": "provider_query_failed",
+    }
+
+
 def _default_runner(
     args: Sequence[str],
     cwd: Path | None = None,
@@ -180,44 +188,49 @@ class LarkCliMiaodaProvider:
         app_type: str,
     ) -> dict[str, Any]:
         label = "Miaoda access-scope readback"
-        returncode, payload = _json_payload(
-            self._runner(
-                [
-                    *self._prefix,
-                    "apps",
-                    "+access-scope-get",
-                    "--app-id",
-                    app_id,
-                    "--format",
-                    "json",
-                ],
-                None,
-                120.0,
-            ),
-            label,
-        )
+        try:
+            returncode, payload = _json_payload(
+                self._runner(
+                    [
+                        *self._prefix,
+                        "apps",
+                        "+access-scope-get",
+                        "--app-id",
+                        app_id,
+                        "--format",
+                        "json",
+                    ],
+                    None,
+                    120.0,
+                ),
+                label,
+            )
+        except (OSError, subprocess.TimeoutExpired, TypeError, ValueError):
+            return _unavailable_access_scope()
         if returncode == 0 and payload.get("ok") is True:
-            data = self._data(payload)
-            receipt: dict[str, Any] = {"status": "verified", "retryable": False}
-            access_scope = data.get("access_scope") or data.get("scope")
-            if access_scope is not None:
-                receipt["scope"] = _text(access_scope, "Miaoda access_scope")
-            if data.get("require_login") is not None:
-                if not isinstance(data["require_login"], bool):
+            try:
+                data = self._data(payload)
+                access_scope = _text(
+                    data.get("access_scope") or data.get("scope"),
+                    "Miaoda access_scope",
+                )
+                if not isinstance(data.get("require_login"), bool):
                     raise TypeError("Miaoda require_login must be a boolean")
-                receipt["require_login"] = data["require_login"]
-            return receipt
+            except (TypeError, ValueError):
+                return _unavailable_access_scope()
+            return {
+                "status": "verified",
+                "retryable": False,
+                "scope": access_scope,
+                "require_login": data["require_login"],
+            }
         if _api_error_code(payload) == 40002 and app_type == "html":
             return {
                 "status": "unsupported_by_app_type",
                 "retryable": False,
                 "reason": "creative_html_scope_readback_unavailable",
             }
-        return {
-            "status": "unavailable",
-            "retryable": True,
-            "reason": "provider_query_failed",
-        }
+        return _unavailable_access_scope()
 
     def publish(
         self,

--- a/loopx/extensions/lark/presentation/periodic_report.py
+++ b/loopx/extensions/lark/presentation/periodic_report.py
@@ -17,17 +17,18 @@ from ....capabilities.periodic_report.adapters import (
 from ....capabilities.periodic_report.audience import (
     build_periodic_report_announcement_plan,
 )
+from ....capabilities.periodic_report.bindings import (
+    _normalize_periodic_report_access_scope_readback,
+    _normalize_periodic_report_release_readback,
+)
 from ....capabilities.periodic_report.core import _reject_raw_keys
 from .message_card import build_lark_markdown_reply_card
-
 
 LarkSendEffect = Callable[[Mapping[str, Any], str], Mapping[str, Any]]
 LarkReadbackEffect = Callable[[str], Mapping[str, Any]]
 LarkRecipientMentionRenderer = Callable[[str], str]
-MiaodaPublishEffect = Callable[
-    [Mapping[str, Any], str, str], Mapping[str, Any]
-]
-MiaodaReadbackEffect = Callable[[str], Mapping[str, Any]]
+MiaodaPublishEffect = Callable[[Mapping[str, Any], str, str], Mapping[str, Any]]
+MiaodaReadbackEffect = Callable[[str, str], Mapping[str, Any]]
 
 MIAODA_HTML_MAX_BYTES = 10 * 1024 * 1024
 MIAODA_ARCHIVE_MAX_BYTES = 20 * 1024 * 1024
@@ -128,9 +129,7 @@ def _miaoda_html_preflight(artifact: Mapping[str, Any]) -> dict[str, Any]:
     }
     exceeded = [name for name, value in sizes.items() if value > limits[name]]
     if exceeded:
-        details = ", ".join(
-            f"{name}={sizes[name]}>{limits[name]}" for name in exceeded
-        )
+        details = ", ".join(f"{name}={sizes[name]}>{limits[name]}" for name in exceeded)
         raise ValueError(f"Miaoda HTML publication size limit exceeded: {details}")
     return {
         "status": "passed",
@@ -290,15 +289,27 @@ def periodic_report_miaoda_html_sink_adapter(
             published.get("online_url") or published.get("url"),
             "Miaoda online_url",
         )
-        observed = dict(readback(app_id))
+        release_id = _required_text(
+            published.get("release_id"), "Miaoda publish release_id"
+        )
+        observed = dict(readback(app_id, release_id))
         observed_app_id = str(observed.get("app_id") or "").strip()
         observed_url = str(
             observed.get("online_url") or observed.get("url") or ""
         ).strip()
+        release_readback = _normalize_periodic_report_release_readback(
+            observed.get("release_readback"), "Miaoda release_readback"
+        )
+        access_scope_readback = _normalize_periodic_report_access_scope_readback(
+            observed.get("access_scope_readback"), "Miaoda access_scope_readback"
+        )
         verified = (
             observed.get("is_published") is True
             and observed_app_id == app_id
             and observed_url == online_url
+            and release_readback["release_id"] == release_id
+            and release_readback["status"] == "finished"
+            and release_readback["verified"] is True
         )
         result: dict[str, Any] = {
             **base,
@@ -307,18 +318,22 @@ def periodic_report_miaoda_html_sink_adapter(
             "receipt_ref": online_url,
             "result_id": app_id,
             "online_url": online_url,
+            "release_id": release_id,
+            "release_readback": release_readback,
+            "access_scope_readback": access_scope_readback,
+            "content_readback": {
+                "status": "unavailable",
+                "digest_verified": False,
+                "reason": "provider_does_not_expose_remote_content_digest",
+            },
             "readback_verified": verified,
             "external_writes_performed": True,
         }
-        access_scope = observed.get("access_scope") or observed.get("scope")
+        access_scope = access_scope_readback.get("scope")
         if access_scope is not None:
-            result["access_scope"] = _required_text(
-                access_scope, "Miaoda access_scope"
-            )
-        if observed.get("require_login") is not None:
-            if not isinstance(observed["require_login"], bool):
-                raise ValueError("Miaoda require_login must be a boolean")
-            result["require_login"] = observed["require_login"]
+            result["access_scope"] = _required_text(access_scope, "Miaoda access_scope")
+        if access_scope_readback.get("require_login") is not None:
+            result["require_login"] = access_scope_readback["require_login"]
         return result
 
     adapter = PeriodicReportSinkAdapter(

--- a/loopx/extensions/lark/presentation/periodic_report.py
+++ b/loopx/extensions/lark/presentation/periodic_report.py
@@ -298,7 +298,9 @@ def periodic_report_miaoda_html_sink_adapter(
             observed.get("online_url") or observed.get("url") or ""
         ).strip()
         release_readback = _normalize_periodic_report_release_readback(
-            observed.get("release_readback"), "Miaoda release_readback"
+            observed.get("release_readback"),
+            "Miaoda release_readback",
+            expected_release_id=release_id,
         )
         access_scope_readback = _normalize_periodic_report_access_scope_readback(
             observed.get("access_scope_readback"), "Miaoda access_scope_readback"

--- a/tests/extensions/test_periodic_report_miaoda.py
+++ b/tests/extensions/test_periodic_report_miaoda.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from typing import Any
 
 import pytest
 
 from loopx.capabilities.periodic_report import (
     PeriodicReportAdapterRegistry,
+    build_periodic_report_delivery_receipt,
     build_periodic_report_document,
+    build_periodic_report_extension_readiness,
     build_periodic_report_generation_bundle,
     build_periodic_report_source_result,
 )
@@ -166,16 +169,26 @@ def test_miaoda_publish_requires_exact_app_and_url_readback() -> None:
         return {
             "app_id": app_id,
             "url": "https://example.test/app/app_example123",
+            "release_id": "release_example123",
         }
 
-    def readback(app_id: str) -> dict[str, Any]:
-        calls.append(f"readback:{app_id}")
+    def readback(app_id: str, release_id: str) -> dict[str, Any]:
+        calls.append(f"readback:{app_id}:{release_id}")
         return {
             "app_id": app_id,
             "online_url": "https://example.test/app/app_example123",
             "is_published": True,
-            "access_scope": "Range",
-            "require_login": True,
+            "release_readback": {
+                "release_id": release_id,
+                "status": "finished",
+                "verified": True,
+            },
+            "access_scope_readback": {
+                "status": "verified",
+                "retryable": False,
+                "scope": "Range",
+                "require_login": True,
+            },
         }
 
     result = _registry(publish=publish, readback=readback).deliver(
@@ -192,11 +205,22 @@ def test_miaoda_publish_requires_exact_app_and_url_readback() -> None:
     assert result["receipt_ref"] == "https://example.test/app/app_example123"
     assert result["result_id"] == "app_example123"
     assert result["readback_verified"] is True
+    assert result["release_readback"] == {
+        "release_id": "release_example123",
+        "status": "finished",
+        "verified": True,
+    }
+    assert result["access_scope_readback"]["status"] == "verified"
+    assert result["content_readback"] == {
+        "status": "unavailable",
+        "digest_verified": False,
+        "reason": "provider_does_not_expose_remote_content_digest",
+    }
     assert result["access_scope"] == "Range"
     assert result["require_login"] is True
     assert calls == [
         "publish:app_example123:miaoda-live",
-        "readback:app_example123",
+        "readback:app_example123:release_example123",
     ]
 
 
@@ -209,11 +233,22 @@ def test_miaoda_publish_fails_closed_on_wrong_artifact_or_readback(
         publish=lambda _artifact, app_id, _key: {
             "app_id": app_id,
             "online_url": "https://example.test/app/app_example123",
+            "release_id": "release_example123",
         },
-        readback=lambda app_id: {
+        readback=lambda app_id, release_id: {
             "app_id": app_id,
             "online_url": "https://example.test/app/other",
             "is_published": True,
+            "release_readback": {
+                "release_id": release_id,
+                "status": "processing",
+                "verified": False,
+            },
+            "access_scope_readback": {
+                "status": "unsupported_by_app_type",
+                "retryable": False,
+                "reason": "creative_html_scope_readback_unavailable",
+            },
         },
     )
 
@@ -253,6 +288,48 @@ def test_miaoda_publish_fails_closed_on_wrong_artifact_or_readback(
                 "app_id": "app_example123",
             },
         )
+
+
+def test_miaoda_access_scope_failure_does_not_erase_finished_release() -> None:
+    artifact = periodic_report_html_renderer_adapter().render(_document())
+    result = _registry(
+        publish=lambda _artifact, app_id, _key: {
+            "app_id": app_id,
+            "online_url": "https://example.test/app/app_example123",
+            "release_id": "release_example123",
+        },
+        readback=lambda app_id, release_id: {
+            "app_id": app_id,
+            "online_url": "https://example.test/app/app_example123",
+            "is_published": True,
+            "release_readback": {
+                "release_id": release_id,
+                "status": "finished",
+                "verified": True,
+            },
+            "access_scope_readback": {
+                "status": "unavailable",
+                "retryable": True,
+                "reason": "provider_query_failed",
+            },
+        },
+    ).deliver(
+        "miaoda_html_delivery",
+        artifact,
+        {
+            "execute": True,
+            "idempotency_key": "scope-readback-unavailable",
+            "app_id": "app_example123",
+        },
+    )
+
+    assert result["status"] == "sent"
+    assert result["readback_verified"] is True
+    assert result["access_scope_readback"] == {
+        "status": "unavailable",
+        "retryable": True,
+        "reason": "provider_query_failed",
+    }
 
 
 def test_hosted_intent_preview_is_not_satisfied_by_local_html() -> None:
@@ -296,6 +373,29 @@ def test_hosted_intent_executes_lark_cli_publish_and_exact_readback() -> None:
                 .startswith("<!doctype html>")
             )
             payload = {"ok": True, "data": {"release_id": "release_example"}}
+        elif "+release-get" in command:
+            assert command[command.index("--release-id") + 1] == "release_example"
+            payload = {
+                "ok": True,
+                "data": {
+                    "release_id": "release_example",
+                    "status": "finished",
+                    "online_url": "https://example.test/page/example123",
+                },
+            }
+        elif "+access-scope-get" in command:
+            return {
+                "returncode": 1,
+                "stderr": json.dumps(
+                    {
+                        "ok": False,
+                        "error": {
+                            "code": 40002,
+                            "message": "unsupported for this app type",
+                        },
+                    }
+                ),
+            }
         else:
             payload = {
                 "ok": True,
@@ -326,8 +426,95 @@ def test_hosted_intent_executes_lark_cli_publish_and_exact_readback() -> None:
     assert result["status"] == "satisfied"
     assert result["intent_satisfied"] is True
     assert result["sink_result"]["readback_verified"] is True
+    assert result["sink_result"]["release_readback"]["status"] == "finished"
+    assert result["sink_result"]["access_scope_readback"] == {
+        "status": "unsupported_by_app_type",
+        "retryable": False,
+        "reason": "creative_html_scope_readback_unavailable",
+    }
+    assert result["sink_result"]["content_readback"]["digest_verified"] is False
     assert result["delivery_receipt"]["status"] == "succeeded"
-    assert ["+html-publish" in call for call in calls] == [True, False, False]
+    sink_receipt = result["delivery_receipt"]["sink_receipts"][0]
+    assert sink_receipt["release_readback"]["release_id"] == "release_example"
+    assert sink_receipt["access_scope_readback"]["status"] == (
+        "unsupported_by_app_type"
+    )
+    assert sink_receipt["content_readback"]["status"] == "unavailable"
+    assert [
+        next((item for item in call if item.startswith("+")), "") for call in calls
+    ] == [
+        "+html-publish",
+        "+list",
+        "+list",
+        "+release-get",
+        "+access-scope-get",
+    ]
+
+
+@pytest.mark.parametrize(
+    "missing_field",
+    ["release_readback", "access_scope_readback", "content_readback"],
+)
+def test_delivery_receipt_rejects_weak_miaoda_success(
+    missing_field: str,
+) -> None:
+    request = _delivery_request()
+    generation = request["generation_bundle"]["generation_receipt"]
+    binding = request["profile"]["sink_bindings"][0]
+    readiness = build_periodic_report_extension_readiness(
+        generation_receipt=generation,
+        sink_bindings=[binding],
+        extension_receipts=[
+            {
+                "extension_id": "loopx-lark",
+                "extension_version": "1.5.0",
+                "protocol": "periodic_report_sink_v0",
+                "status": "ready",
+                "readback_verified": True,
+                "capabilities": [binding["capability"]],
+            }
+        ],
+    )
+    sink_result = deepcopy(
+        _registry(
+            publish=lambda _artifact, app_id, _key: {
+                "app_id": app_id,
+                "online_url": "https://example.test/app/app_example123",
+                "release_id": "release_example123",
+            },
+            readback=lambda app_id, release_id: {
+                "app_id": app_id,
+                "online_url": "https://example.test/app/app_example123",
+                "is_published": True,
+                "release_readback": {
+                    "release_id": release_id,
+                    "status": "finished",
+                    "verified": True,
+                },
+                "access_scope_readback": {
+                    "status": "unsupported_by_app_type",
+                    "retryable": False,
+                    "reason": "creative_html_scope_readback_unavailable",
+                },
+            },
+        ).deliver(
+            "miaoda_html_delivery",
+            request["generation_bundle"]["artifacts"][0],
+            {
+                "execute": True,
+                "idempotency_key": "weak-receipt-test",
+                "app_id": "app_example123",
+            },
+        )
+    )
+    sink_result.pop(missing_field)
+
+    with pytest.raises(ValueError, match="missing structured readback"):
+        build_periodic_report_delivery_receipt(
+            generation_receipt=generation,
+            readiness_receipt=readiness,
+            sink_results=[sink_result],
+        )
 
 
 def test_hosted_intent_requires_explicit_profile_sink() -> None:

--- a/tests/extensions/test_periodic_report_miaoda.py
+++ b/tests/extensions/test_periodic_report_miaoda.py
@@ -17,6 +17,7 @@ from loopx.capabilities.periodic_report import (
 from loopx.cli import main
 from loopx.extensions.lark.miaoda_report import (
     DELIVERY_INTENT_SCHEMA,
+    LarkCliMiaodaProvider,
     MIAODA_DELIVERY_REQUEST_SCHEMA,
     deliver_periodic_report_to_miaoda,
 )
@@ -132,6 +133,59 @@ def _extension_activation() -> dict[str, Any]:
         "doctor_verified": True,
         "required_permissions": ["lark.miaoda_html.publish"],
     }
+
+
+def _sent_miaoda_delivery_receipt_inputs() -> tuple[
+    dict[str, Any], dict[str, Any], dict[str, Any]
+]:
+    request = _delivery_request()
+    generation = request["generation_bundle"]["generation_receipt"]
+    binding = request["profile"]["sink_bindings"][0]
+    readiness = build_periodic_report_extension_readiness(
+        generation_receipt=generation,
+        sink_bindings=[binding],
+        extension_receipts=[
+            {
+                "extension_id": "loopx-lark",
+                "extension_version": "1.5.0",
+                "protocol": "periodic_report_sink_v0",
+                "status": "ready",
+                "readback_verified": True,
+                "capabilities": [binding["capability"]],
+            }
+        ],
+    )
+    sink_result = _registry(
+        publish=lambda _artifact, app_id, _key: {
+            "app_id": app_id,
+            "online_url": "https://example.test/app/app_example123",
+            "release_id": "release_example123",
+        },
+        readback=lambda app_id, release_id: {
+            "app_id": app_id,
+            "online_url": "https://example.test/app/app_example123",
+            "is_published": True,
+            "release_readback": {
+                "release_id": release_id,
+                "status": "finished",
+                "verified": True,
+            },
+            "access_scope_readback": {
+                "status": "unsupported_by_app_type",
+                "retryable": False,
+                "reason": "creative_html_scope_readback_unavailable",
+            },
+        },
+    ).deliver(
+        "miaoda_html_delivery",
+        request["generation_bundle"]["artifacts"][0],
+        {
+            "execute": True,
+            "idempotency_key": "weak-receipt-test",
+            "app_id": "app_example123",
+        },
+    )
+    return generation, readiness, sink_result
 
 
 def test_miaoda_preview_runs_size_preflight_without_external_effects() -> None:
@@ -451,6 +505,50 @@ def test_hosted_intent_executes_lark_cli_publish_and_exact_readback() -> None:
     ]
 
 
+def test_miaoda_access_scope_protocol_failure_is_retryable_evidence() -> None:
+    def runner(
+        args: Any,
+        _cwd: Any = None,
+        _timeout: Any = None,
+    ) -> dict[str, Any]:
+        command = [str(item) for item in args]
+        if "+access-scope-get" in command:
+            return {"returncode": 1, "stderr": "provider returned no JSON"}
+        if "+release-get" in command:
+            payload = {
+                "ok": True,
+                "data": {"release_id": "release_example", "status": "finished"},
+            }
+        else:
+            payload = {
+                "ok": True,
+                "data": {
+                    "has_more": False,
+                    "items": [
+                        {
+                            "app_id": "app_example123",
+                            "app_type": "html",
+                            "is_published": True,
+                            "online_url": "https://example.test/page/example123",
+                        }
+                    ],
+                },
+            }
+        return {"returncode": 0, "stdout": json.dumps(payload)}
+
+    observed = LarkCliMiaodaProvider(
+        cli_bin="lark-cli",
+        runner=runner,
+    ).readback("app_example123", "release_example")
+
+    assert observed["release_readback"]["verified"] is True
+    assert observed["access_scope_readback"] == {
+        "status": "unavailable",
+        "retryable": True,
+        "reason": "provider_query_failed",
+    }
+
+
 @pytest.mark.parametrize(
     "missing_field",
     ["release_readback", "access_scope_readback", "content_readback"],
@@ -458,58 +556,61 @@ def test_hosted_intent_executes_lark_cli_publish_and_exact_readback() -> None:
 def test_delivery_receipt_rejects_weak_miaoda_success(
     missing_field: str,
 ) -> None:
-    request = _delivery_request()
-    generation = request["generation_bundle"]["generation_receipt"]
-    binding = request["profile"]["sink_bindings"][0]
-    readiness = build_periodic_report_extension_readiness(
-        generation_receipt=generation,
-        sink_bindings=[binding],
-        extension_receipts=[
-            {
-                "extension_id": "loopx-lark",
-                "extension_version": "1.5.0",
-                "protocol": "periodic_report_sink_v0",
-                "status": "ready",
-                "readback_verified": True,
-                "capabilities": [binding["capability"]],
-            }
-        ],
-    )
-    sink_result = deepcopy(
-        _registry(
-            publish=lambda _artifact, app_id, _key: {
-                "app_id": app_id,
-                "online_url": "https://example.test/app/app_example123",
-                "release_id": "release_example123",
-            },
-            readback=lambda app_id, release_id: {
-                "app_id": app_id,
-                "online_url": "https://example.test/app/app_example123",
-                "is_published": True,
-                "release_readback": {
-                    "release_id": release_id,
-                    "status": "finished",
-                    "verified": True,
-                },
-                "access_scope_readback": {
-                    "status": "unsupported_by_app_type",
-                    "retryable": False,
-                    "reason": "creative_html_scope_readback_unavailable",
-                },
-            },
-        ).deliver(
-            "miaoda_html_delivery",
-            request["generation_bundle"]["artifacts"][0],
-            {
-                "execute": True,
-                "idempotency_key": "weak-receipt-test",
-                "app_id": "app_example123",
-            },
-        )
-    )
+    generation, readiness, canonical_result = _sent_miaoda_delivery_receipt_inputs()
+    sink_result = deepcopy(canonical_result)
     sink_result.pop(missing_field)
 
     with pytest.raises(ValueError, match="missing structured readback"):
+        build_periodic_report_delivery_receipt(
+            generation_receipt=generation,
+            readiness_receipt=readiness,
+            sink_results=[sink_result],
+        )
+
+
+@pytest.mark.parametrize(
+    ("invalid_evidence", "error"),
+    [
+        ("release_id", "requires exact release readback"),
+        ("release_status", "requires exact release readback"),
+        ("release_verified", "verified does not match exact release readback"),
+        ("access_scope", "scope is required"),
+        ("content_proof", "content_readback.status is invalid"),
+    ],
+)
+def test_delivery_receipt_rejects_semantically_weak_miaoda_success(
+    invalid_evidence: str,
+    error: str,
+) -> None:
+    generation, readiness, canonical_result = _sent_miaoda_delivery_receipt_inputs()
+    sink_result = deepcopy(canonical_result)
+    if invalid_evidence == "release_id":
+        sink_result["release_readback"] = {
+            "release_id": "release_other",
+            "status": "finished",
+            "verified": False,
+        }
+    elif invalid_evidence == "release_status":
+        sink_result["release_readback"] = {
+            "release_id": sink_result["release_id"],
+            "status": "processing",
+            "verified": False,
+        }
+    elif invalid_evidence == "release_verified":
+        sink_result["release_readback"]["verified"] = False
+    elif invalid_evidence == "access_scope":
+        sink_result["access_scope_readback"] = {
+            "status": "verified",
+            "retryable": False,
+            "require_login": True,
+        }
+    else:
+        sink_result["content_readback"] = {
+            "status": "verified",
+            "digest_verified": True,
+        }
+
+    with pytest.raises(ValueError, match=error):
         build_periodic_report_delivery_receipt(
             generation_receipt=generation,
             readiness_receipt=readiness,


### PR DESCRIPTION
## Summary

- preserve the exact release ID returned by Miaoda HTML publication and require that same release to read back as `finished`
- distinguish verified, app-type-unsupported, and retryable-unavailable access-scope evidence without weakening verified delivery lifecycle evidence
- record explicitly that remote content-digest proof is unavailable instead of treating app/URL/release state as byte equality
- propagate the structured readback evidence into normalized periodic-report delivery receipts and document the contract

## Validation

- `pytest -q tests/extensions/test_periodic_report*.py tests/capabilities/test_periodic_report*.py` (83 passed)
- focused Ruff format/import/lint checks passed
- `loopx canary premerge --from-git-diff --goal-id ... --tier standard` (14 checks executed, 0 failures, 0 warnings, 0 manual holds)
- public-boundary scan passed for all six changed files
- read-only provider acceptance confirmed exact finished-release readback and the creative-HTML unsupported access-scope classification without publishing identifiers

## Boundaries

This does not create apps, select or mutate audiences, change access scope, expose credentials, or claim remote content-digest verification. Access-scope query failures are evidence states; exact app, URL, and finished-release agreement remains the delivery success condition.

## Future-facing review

The typed readback normalizers remain owned by the existing `periodic_report` capability and are reused by the bundled Lark extension. No new capability or speculative provider abstraction was added.