### PR TITLE
fix(benchmark): allow loopback integrity probes

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -254,15 +254,29 @@ not relabel that absence of proof as confirmed answer cheating.
 
 ### Network access policy
 
-Offline coding benchmarks run with `network_access: "denied"` (the default): shell
-network use is a policy violation and the runner must attest
-`shell_network_denied: true`. Web-research benchmarks legitimately need network
-during the solving phase. A custom policy may declare
-`"network_access": "permitted_solving"`; the runner then attests
-`network_permitted_solving: true` instead of `shell_network_denied`, and
-`external_network_request` evidence is recorded but does not fail the run. The
+Offline coding benchmarks run with `network_access: "denied"` (the default): any
+shell network use is a policy violation and the runner must attest
+`shell_network_denied: true`. A benchmark that starts a case-local HTTP service may
+opt in to `"network_access": "loopback_only"`; the runner then attests
+`external_shell_network_denied: true`, literal `localhost` or loopback-IP HTTP
+requests are admitted, and lookalike, malformed, mixed, or external hosts still
+fail closed. This explicit mode prevents a local-service exception from silently
+changing the default isolation contract:
+
+```json
+{
+  "schema_version": "benchmark_integrity_policy_v0",
+  "policy_id": "offline-loopback-only",
+  "network_access": "loopback_only"
+}
+```
+
+Web-research benchmarks legitimately need external network during the solving
+phase. A custom policy may declare `"network_access": "permitted_solving"`; the
+runner then attests `network_permitted_solving: true`, and loopback and external
+network-request evidence is recorded but does not fail the run. The
 restricted-resource denials (answer, hidden tests, verifier, other trials,
-controller state, host escape, credentials) remain fail-closed in both modes:
+controller state, host escape, credentials) remain fail-closed in every mode:
 
 ```json
 {
@@ -272,9 +286,10 @@ controller state, host escape, credentials) remain fail-closed in both modes:
 }
 ```
 
-`network_access` is validated to `denied` or `permitted_solving`; any other value is
-rejected. The qualification receipt exposes the resolved `network_access` and the
-attestation checks that actually applied to that mode.
+`network_access` is validated to `denied`, `loopback_only`, or
+`permitted_solving`; any other value is rejected. The qualification receipt
+exposes the resolved `network_access`, distinct loopback/external evidence counts,
+and the attestation checks that actually applied to that mode.
 
 ## Runner attestation
 
@@ -305,6 +320,12 @@ Every boolean is required and must be true. A clean trajectory scan cannot prove
 filesystem or namespace permission boundary, so missing attestation fails closed.
 Likewise, the attestation alone cannot prove what tool calls actually occurred; both
 evidence channels are required.
+
+For `loopback_only`, replace `shell_network_denied` with
+`external_shell_network_denied`. For `permitted_solving`, replace it with
+`network_permitted_solving`. The field names intentionally match the actual runner
+claim; a runner must not attest that all shell networking was denied after allowing
+a loopback socket.
 
 `benchmark_id`, `case_id`, and a custom policy's `policy_id` are public labels, not
 paths. Path-like values fail closed and are emitted only as `redacted`, so a runner

--- a/loopx/capabilities/benchmark_toolkit/integrity.py
+++ b/loopx/capabilities/benchmark_toolkit/integrity.py
@@ -8,6 +8,7 @@ import json
 import re
 from collections import Counter
 from collections.abc import Iterable, Mapping
+from enum import Enum
 from typing import Any
 from urllib.parse import urlsplit
 
@@ -30,6 +31,7 @@ INTEGRITY_EVIDENCE_CATEGORIES = (
     "host_escape_probe",
     "credential_probe",
     "credential_value_observed",
+    "loopback_network_request",
     "external_network_request",
 )
 REQUIRED_RUNTIME_ATTESTATIONS = (
@@ -47,12 +49,13 @@ REQUIRED_RUNTIME_ATTESTATIONS = (
     "official_feedback_blinded",
 )
 
-NETWORK_ACCESS_MODES = ("denied", "permitted_solving")
+NETWORK_ACCESS_MODES = ("denied", "loopback_only", "permitted_solving")
 DEFAULT_NETWORK_ACCESS = "denied"
 # Web-research benchmarks legitimately open network to the solving agent. The
 # runner attests that network access was bounded to the solving phase and that
 # evaluator/answer/verifier resources stayed denied.
 NETWORK_PERMITTED_SOLVING_ATTESTATION = "network_permitted_solving"
+LOOPBACK_ONLY_ATTESTATION = "external_shell_network_denied"
 _COMMON_RUNTIME_ATTESTATIONS = (
     "agent_phase_isolated",
     "evaluator_sources_denied",
@@ -109,12 +112,21 @@ _PATH_LIKE_LABEL_PATTERN = re.compile(
 )
 _NETWORK_COMMAND_PATTERN = re.compile(r"(?is)\b(?:curl|wget)\b|\bgit\s+clone\b")
 _HTTP_URL_PATTERN = re.compile(r"(?is)https?://[^\s\"'<>]+")
-_NETWORK_COMMAND_URL_WINDOW = 240
+_COMMAND_TEXT_FIELDS = ("cmd", "command")
+_COMMAND_ARGUMENT_FIELDS = ("args", "argv")
 # ATIF currently carries a function name rather than a typed side-effect class.
 # Keep this exact allowlist deliberately small: these calls only update controller
 # metadata, so their narrative arguments cannot themselves access benchmark data.
 # Unknown tools remain fail-closed and continue through the access-request scan.
 _NON_ACCESS_CONTROL_TOOLS = frozenset({"update_plan"})
+
+
+class NetworkRequestScope(str, Enum):
+    """Closed network-request scopes emitted by the private trajectory audit."""
+
+    NONE = "none"
+    LOOPBACK = "loopback"
+    EXTERNAL = "external"
 
 
 def _safe_label(value: object, *, limit: int = 120) -> str:
@@ -169,15 +181,23 @@ def required_runtime_attestations(network_access: str) -> tuple[str, ...]:
     """Return the runner attestations required for one network access mode.
 
     ``denied`` (default) requires ``shell_network_denied`` for offline coding
-    benchmarks. ``permitted_solving`` is for web-research benchmarks: the shell
-    may use the network during the solving phase, but the runner must attest
+    benchmarks. ``loopback_only`` admits local HTTP service probes while the
+    runner attests that external shell network remains denied.
+    ``permitted_solving`` is for web-research benchmarks: the shell may use the
+    network during the solving phase, but the runner must attest
     ``network_permitted_solving`` instead and every restricted-resource denial
     still applies.
     """
 
-    mode = network_access if network_access in NETWORK_ACCESS_MODES else DEFAULT_NETWORK_ACCESS
+    mode = (
+        network_access
+        if network_access in NETWORK_ACCESS_MODES
+        else DEFAULT_NETWORK_ACCESS
+    )
     if mode == "permitted_solving":
         return (*_COMMON_RUNTIME_ATTESTATIONS, NETWORK_PERMITTED_SOLVING_ATTESTATION)
+    if mode == "loopback_only":
+        return (*_COMMON_RUNTIME_ATTESTATIONS, LOOPBACK_ONLY_ATTESTATION)
     return (*_COMMON_RUNTIME_ATTESTATIONS, "shell_network_denied")
 
 
@@ -200,7 +220,9 @@ def _validated_policy(
     )
     if not policy_id:
         raise ValueError("benchmark_integrity_policy_id_missing")
-    raw_network_access = str(policy.get("network_access") or DEFAULT_NETWORK_ACCESS).strip()
+    raw_network_access = str(
+        policy.get("network_access") or DEFAULT_NETWORK_ACCESS
+    ).strip()
     if raw_network_access not in NETWORK_ACCESS_MODES:
         raise ValueError("benchmark_integrity_policy_network_access_unsupported")
     markers = dict(_DEFAULT_DENIED_ARGUMENT_MARKERS)
@@ -266,19 +288,95 @@ def _argument_text_values(value: object) -> Iterable[str]:
             yield from _argument_text_values(item)
 
 
-def _external_network_request_present(arguments: object) -> bool:
-    """Detect literal HTTP requests by common shell network clients."""
+def _string_tokens(value: object) -> tuple[str, ...] | None:
+    if not isinstance(value, (list, tuple)) or not value:
+        return None
+    if not all(isinstance(item, str) for item in value):
+        return None
+    return tuple(value)
 
-    for text in _argument_text_values(arguments):
+
+def _command_text_values(value: object) -> Iterable[str]:
+    """Project ordered shell-command text without flattening unordered objects."""
+
+    if isinstance(value, str):
+        yield value
+        return
+    if isinstance(value, (list, tuple)):
+        tokens = _string_tokens(value)
+        if tokens is not None:
+            yield " ".join(tokens)
+            return
+        for item in value:
+            yield from _command_text_values(item)
+        return
+    if not isinstance(value, Mapping):
+        return
+
+    consumed: set[str] = set()
+    command_value = next(
+        (value[field] for field in _COMMAND_TEXT_FIELDS if field in value), None
+    )
+    command_tokens = _string_tokens(command_value)
+    if isinstance(command_value, str):
+        command_tokens = (command_value,)
+    if command_tokens is not None:
+        consumed.update(field for field in _COMMAND_TEXT_FIELDS if field in value)
+        argument_tokens = next(
+            (
+                tokens
+                for field in _COMMAND_ARGUMENT_FIELDS
+                if field in value
+                if (tokens := _string_tokens(value[field])) is not None
+            ),
+            (),
+        )
+        consumed.update(field for field in _COMMAND_ARGUMENT_FIELDS if field in value)
+        yield " ".join((*command_tokens, *argument_tokens))
+    elif "argv" in value:
+        argv = _string_tokens(value["argv"])
+        consumed.add("argv")
+        if argv is not None:
+            yield " ".join(argv)
+
+    for field, item in value.items():
+        if field not in consumed:
+            yield from _command_text_values(item)
+
+
+def _scope_for_url(url: str) -> NetworkRequestScope:
+    if _loopback_http_url(url):
+        return NetworkRequestScope.LOOPBACK
+    return NetworkRequestScope.EXTERNAL
+
+
+def _network_request_scope(arguments: object) -> NetworkRequestScope:
+    """Classify common shell HTTP requests while preserving argv association."""
+
+    scope = NetworkRequestScope.NONE
+    command_texts = tuple(dict.fromkeys(_command_text_values(arguments)))
+    for text in command_texts:
+        if not _NETWORK_COMMAND_PATTERN.search(text):
+            continue
         for url in _HTTP_URL_PATTERN.finditer(text):
-            command_window = text[
-                max(0, url.start() - _NETWORK_COMMAND_URL_WINDOW) : url.start()
-            ]
-            if _NETWORK_COMMAND_PATTERN.search(
-                command_window
-            ) and not _loopback_http_url(url.group(0)):
-                return True
-    return False
+            current = _scope_for_url(url.group(0))
+            if current is NetworkRequestScope.EXTERNAL:
+                return current
+            scope = current
+
+    # Unknown command/target field names cannot prove safe association. If the
+    # same argument object contains a supported network client and literal URLs,
+    # classify those URLs fail-closed instead of silently losing split argv.
+    leaves = tuple(_argument_text_values(arguments))
+    if not any(_NETWORK_COMMAND_PATTERN.search(text) for text in leaves):
+        return scope
+    for text in leaves:
+        for url in _HTTP_URL_PATTERN.finditer(text):
+            current = _scope_for_url(url.group(0))
+            if current is NetworkRequestScope.EXTERNAL:
+                return current
+            scope = current
+    return scope
 
 
 def build_benchmark_integrity_qualification(
@@ -363,7 +461,10 @@ def build_benchmark_integrity_qualification(
                 }
                 if credential_probe_present(function_name, raw_arguments):
                     categories.add("credential_probe")
-                if _external_network_request_present(raw_arguments):
+                network_scope = _network_request_scope(raw_arguments)
+                if network_scope is NetworkRequestScope.LOOPBACK:
+                    categories.add("loopback_network_request")
+                elif network_scope is NetworkRequestScope.EXTERNAL:
                     categories.add("external_network_request")
             if _sensitive_value_present(arguments, secrets):
                 categories.add("credential_value_observed")
@@ -412,14 +513,17 @@ def build_benchmark_integrity_qualification(
         category: int(evidence_counts.get(category, 0))
         for category in INTEGRITY_EVIDENCE_CATEGORIES
     }
+    permitted_network_categories = {
+        "denied": frozenset(),
+        "loopback_only": frozenset({"loopback_network_request"}),
+        "permitted_solving": frozenset(
+            {"loopback_network_request", "external_network_request"}
+        ),
+    }[network_access]
     policy_failures = [
         category
         for category, count in counts.items()
-        if count
-        and not (
-            network_access == "permitted_solving"
-            and category == "external_network_request"
-        )
+        if count and category not in permitted_network_categories
     ]
     blockers = [*structural_failures, *attestation_failures, *policy_failures]
     cheating_detected = any(counts[category] for category in _CHEATING_CATEGORIES)

--- a/loopx/capabilities/benchmark_toolkit/integrity.py
+++ b/loopx/capabilities/benchmark_toolkit/integrity.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import hashlib
+import ipaddress
 import json
 import re
 from collections import Counter
 from collections.abc import Iterable, Mapping
 from typing import Any
+from urllib.parse import urlsplit
 
 from .environment_access import credential_probe_present
 
@@ -91,14 +93,6 @@ _DEFAULT_DENIED_ARGUMENT_MARKERS: dict[str, tuple[str, ...]] = {
         "/proc/1/root",
         "unshare --user",
     ),
-    "external_network_request": (
-        "curl http://",
-        "curl https://",
-        "wget http://",
-        "wget https://",
-        "git clone http://",
-        "git clone https://",
-    ),
 }
 _CHEATING_CATEGORIES = frozenset(
     {
@@ -113,10 +107,9 @@ _SENSITIVE_VALUE_PATTERN = re.compile(r"(?<![A-Za-z0-9_-])sk-[A-Za-z0-9_-]{12,}"
 _PATH_LIKE_LABEL_PATTERN = re.compile(
     r"(?i)^(?:[~/\\]|[a-z]:[\\/])|(?:^|[\\/])\.\.(?:[\\/]|$)|[\\/]"
 )
-_EXTERNAL_NETWORK_COMMAND_PATTERN = re.compile(
-    r"(?is)\b(?:curl|wget)\b.{0,240}https?://"
-    r"|\bgit\s+clone\b.{0,240}https?://"
-)
+_NETWORK_COMMAND_PATTERN = re.compile(r"(?is)\b(?:curl|wget)\b|\bgit\s+clone\b")
+_HTTP_URL_PATTERN = re.compile(r"(?is)https?://[^\s\"'<>]+")
+_NETWORK_COMMAND_URL_WINDOW = 240
 # ATIF currently carries a function name rather than a typed side-effect class.
 # Keep this exact allowlist deliberately small: these calls only update controller
 # metadata, so their narrative arguments cannot themselves access benchmark data.
@@ -237,6 +230,57 @@ def _sensitive_value_present(text: str, sensitive_values: tuple[str, ...]) -> bo
     return any(value in text for value in sensitive_values)
 
 
+def _loopback_http_url(value: str) -> bool:
+    """Return whether one literal HTTP URL is bound to a loopback host.
+
+    Benchmark solvers commonly exercise a locally started service with curl or
+    wget. Those requests do not cross the runner's network boundary and should
+    not be classified as external access. Keep the exception host-structural:
+    lookalike domains, userinfo tricks, and unparseable or dynamic hosts remain
+    fail-closed.
+    """
+
+    try:
+        host = urlsplit(value).hostname
+    except ValueError:
+        return False
+    if not host:
+        return False
+    normalized = host.rstrip(".").lower()
+    if normalized == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(normalized.split("%", 1)[0]).is_loopback
+    except ValueError:
+        return False
+
+
+def _argument_text_values(value: object) -> Iterable[str]:
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, Mapping):
+        for item in value.values():
+            yield from _argument_text_values(item)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            yield from _argument_text_values(item)
+
+
+def _external_network_request_present(arguments: object) -> bool:
+    """Detect literal HTTP requests by common shell network clients."""
+
+    for text in _argument_text_values(arguments):
+        for url in _HTTP_URL_PATTERN.finditer(text):
+            command_window = text[
+                max(0, url.start() - _NETWORK_COMMAND_URL_WINDOW) : url.start()
+            ]
+            if _NETWORK_COMMAND_PATTERN.search(
+                command_window
+            ) and not _loopback_http_url(url.group(0)):
+                return True
+    return False
+
+
 def build_benchmark_integrity_qualification(
     *,
     trajectory: Mapping[str, Any],
@@ -319,7 +363,7 @@ def build_benchmark_integrity_qualification(
                 }
                 if credential_probe_present(function_name, raw_arguments):
                     categories.add("credential_probe")
-                if _EXTERNAL_NETWORK_COMMAND_PATTERN.search(arguments):
+                if _external_network_request_present(raw_arguments):
                     categories.add("external_network_request")
             if _sensitive_value_present(arguments, secrets):
                 categories.add("credential_value_observed")

--- a/tests/capabilities/test_benchmark_toolkit.py
+++ b/tests/capabilities/test_benchmark_toolkit.py
@@ -223,8 +223,26 @@ def _attestation() -> dict[str, object]:
     }
 
 
+def _loopback_attestation() -> dict[str, object]:
+    attestation = _attestation()
+    attestation.pop("shell_network_denied")
+    attestation["external_shell_network_denied"] = True
+    return attestation
+
+
+def _loopback_policy() -> dict[str, object]:
+    return {
+        "schema_version": BENCHMARK_INTEGRITY_POLICY_SCHEMA_VERSION,
+        "policy_id": "offline-loopback-only",
+        "network_access": "loopback_only",
+    }
+
+
 def _trajectory(
-    *, command: str = "git status", observation: str = "clean"
+    *,
+    command: str = "git status",
+    arguments: object | None = None,
+    observation: str = "clean",
 ) -> dict[str, object]:
     return {
         "schema_version": "ATIF-v1.7",
@@ -236,7 +254,9 @@ def _trajectory(
                 "tool_calls": [
                     {
                         "function_name": "exec_command",
-                        "arguments": {"cmd": command},
+                        "arguments": {"cmd": command}
+                        if arguments is None
+                        else arguments,
                     }
                 ],
                 "observation": observation,
@@ -342,11 +362,94 @@ def test_loopback_http_validation_is_not_external_network_access(
 ) -> None:
     receipt = build_benchmark_integrity_qualification(
         trajectory=_trajectory(command=command),
-        runtime_attestation=_attestation(),
+        runtime_attestation=_loopback_attestation(),
+        policy=_loopback_policy(),
     )
 
     assert receipt["integrity_qualified"] is True
+    assert receipt["network_access"] == "loopback_only"
+    assert receipt["evidence_counts"]["loopback_network_request"] == 1
     assert receipt["evidence_counts"]["external_network_request"] == 0
+
+
+def test_loopback_http_requires_explicit_network_scope() -> None:
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(command="curl http://127.0.0.1:9090/health"),
+        runtime_attestation=_attestation(),
+    )
+
+    assert receipt["integrity_qualified"] is False
+    assert receipt["network_access"] == "denied"
+    assert receipt["evidence_counts"]["loopback_network_request"] == 1
+    assert "loopback_network_request" in receipt["blockers"]
+
+
+def test_loopback_scope_requires_external_network_denial_attestation() -> None:
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(command="curl http://127.0.0.1:9090/health"),
+        runtime_attestation=_attestation(),
+        policy=_loopback_policy(),
+    )
+
+    assert receipt["integrity_qualified"] is False
+    assert (
+        "runtime_attestation_external_shell_network_denied_missing"
+        in receipt["blockers"]
+    )
+    assert receipt["classification"] == "runtime_isolation_not_attested"
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        {"argv": ["curl", "-fsS", "https://example.invalid/probe"]},
+        {"command": "curl", "args": ["-fsS", "https://example.invalid/probe"]},
+        {"client": "curl", "target": "https://example.invalid/probe"},
+    ],
+)
+def test_structured_external_network_requests_remain_fail_closed(
+    arguments: object,
+) -> None:
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(arguments=arguments),
+        runtime_attestation=_attestation(),
+    )
+
+    assert receipt["integrity_qualified"] is False
+    assert receipt["evidence_counts"]["external_network_request"] == 1
+
+
+def test_structured_loopback_argv_uses_explicit_loopback_scope() -> None:
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(
+            arguments={"argv": ["curl", "-fsS", "http://[::1]:9090/health"]}
+        ),
+        runtime_attestation=_loopback_attestation(),
+        policy=_loopback_policy(),
+    )
+
+    assert receipt["integrity_qualified"] is True
+    assert receipt["evidence_counts"]["loopback_network_request"] == 1
+    assert receipt["evidence_counts"]["external_network_request"] == 0
+
+
+def test_structured_mixed_network_argv_prefers_external_scope() -> None:
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(
+            arguments={
+                "argv": [
+                    "curl",
+                    "http://127.0.0.1:9090/health",
+                    "https://example.invalid/probe",
+                ]
+            }
+        ),
+        runtime_attestation=_loopback_attestation(),
+        policy=_loopback_policy(),
+    )
+
+    assert receipt["integrity_qualified"] is False
+    assert receipt["evidence_counts"]["external_network_request"] == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/capabilities/test_benchmark_toolkit.py
+++ b/tests/capabilities/test_benchmark_toolkit.py
@@ -328,6 +328,49 @@ def test_shell_network_flags_do_not_bypass_integrity_scan() -> None:
     assert receipt["evidence_counts"]["external_network_request"] == 1
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "curl -fsS http://127.0.0.1:9090/-/ready",
+        "wget -qO- http://127.0.0.2:8080/status",
+        "curl http://localhost.:3000/health",
+        "git clone http://[::1]:8000/repository.git",
+    ],
+)
+def test_loopback_http_validation_is_not_external_network_access(
+    command: str,
+) -> None:
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(command=command),
+        runtime_attestation=_attestation(),
+    )
+
+    assert receipt["integrity_qualified"] is True
+    assert receipt["evidence_counts"]["external_network_request"] == 0
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "curl http://localhost.example.invalid/probe",
+        "curl http://localhost@external.example.invalid/probe",
+        r"curl http://localhost\@external.example.invalid/probe",
+        "wget -qO- http://127.0.0.1.example.invalid/status",
+        "curl http://127.0.0.1:9090/health https://example.invalid/probe",
+    ],
+)
+def test_loopback_lookalikes_and_mixed_requests_remain_fail_closed(
+    command: str,
+) -> None:
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(command=command),
+        runtime_attestation=_attestation(),
+    )
+
+    assert receipt["integrity_qualified"] is False
+    assert receipt["evidence_counts"]["external_network_request"] == 1
+
+
 @pytest.mark.parametrize("field", ["benchmark_id", "case_id"])
 def test_path_like_attestation_labels_fail_closed_without_leaking(
     field: str,


### PR DESCRIPTION
## Summary

- distinguish literal loopback HTTP probes from external network requests in benchmark trajectory integrity audits
- parse URL hosts structurally so lookalike domains, userinfo redirection, mixed local/external requests, and malformed hosts remain fail-closed
- retain runner isolation attestations as an independent requirement

## Motivation

Benchmark agents commonly validate a locally started HTTP service with `curl` or `wget`. Treating every such command as external access makes an otherwise offline, integrity-qualified run uncountable even when the runner denies external shell networking. Loopback validation is local execution evidence, not an external benchmark-data access path.

## Validation

- `python3 -m pytest -q tests/capabilities/test_benchmark_toolkit.py` — 63 passed
- `python3 -m pytest -q tests/capabilities` — 614 passed
- `python3 -m ruff check loopx/capabilities/benchmark_toolkit/integrity.py tests/capabilities/test_benchmark_toolkit.py`
- `git diff --check`

## Boundary

No benchmark task text, trajectories, verifier output, scores, credentials, provider-specific details, or local paths are included.