### PR TITLE
Settle governed continuous-monitor proposals in the Kernel

### DIFF
--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -418,6 +418,28 @@ An external-write operation also declares a typed `todo_contract` beside
 `effect_class`, containing one or more lower-snake `action_kinds` and bounded
 `target_key_prefixes`.
 
+When a long-running provider needs LoopX to keep polling its external job, the
+same operation may declare a `transition_contract`. This is an authority
+allowlist, not a provider-owned Todo schema:
+
+```json
+{
+  "proposal_kinds": [
+    "continuous_monitor_upsert",
+    "continuous_monitor_complete"
+  ],
+  "monitor_key_prefixes": ["example-provider:"],
+  "monitor_action_kinds": ["poll_external_run"],
+  "monitor_target_key_prefixes": ["external-run:"],
+  "monitor_required_capabilities": ["network"]
+}
+```
+
+The profile bounds every monitor identity, action, external target, and
+required capability that the provider may propose. A proposal outside those
+bounds fails before any LoopX state write. The provider receives no registry
+path and never calls Todo APIs directly.
+
 1. obtain `quota should-run` admission for one exact Goal, Agent, Todo, and
    `turn_instance_id`; the selected open Agent Todo's `action_kind` and
    `target_key` must match the operation profile's `todo_contract`, so an
@@ -427,22 +449,37 @@ An external-write operation also declares a typed `todo_contract` beside
    idempotency key;
 3. call `reconcile_governed_external_capability(...)` until the provider returns
    a terminal `loopx_external_effect_receipt_v0`;
-4. supply typed writeback and spend callbacks. LoopX reuses the shared Turn
+4. let the LoopX Kernel materialize each admitted
+   `loopx_continuous_monitor_proposal_v0` through the normal Todo APIs. A
+   `running` result may only create or retarget its bounded continuous monitor;
+   a successful terminal result may upsert a follow-through monitor or complete
+   an existing one;
+5. supply typed writeback and spend callbacks. LoopX reuses the shared Turn
    settlement driver, requires the effect receipt digest in durable writeback,
    and never spends quota before that writeback commits.
 
 The provider may return `running`, so a service-side job can outlive the bounded
 provider process. Start and reconcile are separately replayable from a mode-0600
 journal. Exact provider revision, request digest, Goal binding, settlement
-identity, provider effect receipt, writeback receipt, and quota receipt remain
-attached to the same invocation. A crash after an external effect therefore
-replays with the same idempotency key and reconciles the receipt instead of
-starting an unrelated operation. One settlement effect id owns exactly one
+identity, transition proposal receipts, provider effect receipt, writeback
+receipt, and quota receipt remain attached to the same invocation. Each
+materialized proposal is checkpointed immediately. A crash between the Todo
+write and that checkpoint recovers by the proposal's stable monitor key and
+completion identity instead of duplicating work. A crash after an external
+effect replays with the same idempotency key and reconciles the receipt instead
+of starting an unrelated operation. One settlement effect id owns exactly one
 material invocation: retrying the same request replays it, while attempting a
 different operation or input under the same Turn receipt fails before provider
 dispatch. A new invocation also requires `should_run=true`; an existing journal
 may still be recovered with its exact typed receipt after the runnable decision
 has changed.
+
+Transition proposals are deliberately narrower than arbitrary Goal mutation.
+The first version supports only continuous-monitor upsert and completion. It
+cannot create a general advancement Todo, change a Goal, widen capability
+authority, complete another Agent's work, or reopen a completed monitor. The
+Kernel resolves one exact monitor by its admitted binding key, applies the
+normal ownership and completion rules, and returns a content-bounded receipt.
 
 Goal enablement alone never grants write authority. Creating or updating the
 binding is an explicit Goal configuration change: it uses preview/apply, but it

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -449,23 +449,27 @@ path and never calls Todo APIs directly.
    idempotency key;
 3. call `reconcile_governed_external_capability(...)` until the provider returns
    a terminal `loopx_external_effect_receipt_v0`;
-4. let the LoopX Kernel materialize each admitted
-   `loopx_continuous_monitor_proposal_v0` through the normal Todo APIs. A
-   `running` result may only create or retarget its bounded continuous monitor;
-   a successful terminal result may upsert a follow-through monitor or complete
-   an existing one;
+4. let the LoopX Kernel materialize admitted monitor upserts through the normal
+   Todo APIs. A `running` result may only create or retarget its bounded
+   continuous monitor, so the recovery entry remains schedulable while the
+   external operation or its settlement is incomplete;
 5. supply typed writeback and spend callbacks. LoopX reuses the shared Turn
    settlement driver, requires the effect receipt digest in durable writeback,
-   and never spends quota before that writeback commits.
+   and never spends quota before that writeback commits;
+6. only after the shared Turn settlement commits, let the Kernel materialize an
+   admitted terminal monitor completion. A failed writeback or spend therefore
+   leaves the monitor open for recovery instead of closing the only retry lane.
 
 The provider may return `running`, so a service-side job can outlive the bounded
 provider process. Start and reconcile are separately replayable from a mode-0600
 journal. Exact provider revision, request digest, Goal binding, settlement
 identity, transition proposal receipts, provider effect receipt, writeback
 receipt, and quota receipt remain attached to the same invocation. Each
-materialized proposal is checkpointed immediately. A crash between the Todo
-write and that checkpoint recovers by the proposal's stable monitor key and
-completion identity instead of duplicating work. A crash after an external
+materialized proposal is checkpointed immediately. Monitor upserts belong to
+the pre-settlement phase; monitor completion belongs to the post-settlement
+phase. A crash between either Todo write and its checkpoint recovers by the
+proposal's stable monitor key and completion identity instead of duplicating
+work. A crash after an external
 effect replays with the same idempotency key and reconciles the receipt instead
 of starting an unrelated operation. One settlement effect id owns exactly one
 material invocation: retrying the same request replays it, while attempting a

--- a/loopx/control_plane/effect_runtime_handlers.ts
+++ b/loopx/control_plane/effect_runtime_handlers.ts
@@ -311,6 +311,7 @@ export function createEffectRuntimeHandlers(
         effect_id: requiredString(params.effect_id, "effect_id"),
         result_schema: requiredString(params.result_schema, "result_schema"),
         effect_class: requiredString(params.effect_class, "effect_class"),
+        transition_contract: params.transition_contract,
       }),
     ],
     [

--- a/loopx/control_plane/governed_capability.ts
+++ b/loopx/control_plane/governed_capability.ts
@@ -1,5 +1,9 @@
 import type { JsonObject } from "./effect_program.ts";
-import { requireNonEmptyString as requiredString } from "./runtime_decode.ts";
+import {
+  assertNever,
+  requireNonEmptyString as requiredString,
+  requireStringLiteral,
+} from "./runtime_decode.ts";
 
 export const EXTERNAL_EFFECT_RECEIPT_SCHEMA_VERSION =
   "loopx_external_effect_receipt_v0";
@@ -54,6 +58,23 @@ const MONITOR_COMPLETE_FIELDS = new Set([
   "monitor_key",
   "evidence",
 ]);
+const TRANSITION_PROPOSAL_KINDS = [
+  "continuous_monitor_upsert",
+  "continuous_monitor_complete",
+] as const;
+type TransitionProposalKind = typeof TRANSITION_PROPOSAL_KINDS[number];
+type ValidatedTransitionProposal =
+  | (JsonObject & {
+    kind: "continuous_monitor_upsert";
+    proposal_id: string;
+    monitor_key: string;
+    required_capabilities: string[];
+  })
+  | (JsonObject & {
+    kind: "continuous_monitor_complete";
+    proposal_id: string;
+    monitor_key: string;
+  });
 const PROPOSAL_ID_RE = /^[a-z][a-z0-9_.:-]{2,95}$/;
 const MONITOR_KEY_RE = /^[a-z][a-z0-9_.-]{0,31}:[a-z][a-z0-9_.:-]{2,95}$/;
 const ACTION_KIND_RE = /^[a-z][a-z0-9_]{0,63}$/;
@@ -149,7 +170,7 @@ function validateTransitionProposals(input: {
   value: unknown;
   status: string;
   transition_contract: unknown;
-}): JsonObject[] {
+}): ValidatedTransitionProposal[] {
   const proposals = boundedArray(
     input.value,
     "external capability result transition_proposals",
@@ -195,22 +216,18 @@ function validateTransitionProposals(input: {
   return proposals.map((raw, index) => {
     const label = `external capability transition_proposals[${index}]`;
     const proposal = requiredObject(raw, label);
-    const kind = boundedString(proposal.kind, `${label} kind`, 64);
+    const kind: TransitionProposalKind = requireStringLiteral(
+      proposal.kind,
+      TRANSITION_PROPOSAL_KINDS,
+      `${label} kind`,
+      `${label} kind is unsupported`,
+    );
     if (!allowedKinds.includes(kind)) {
       throw new Error(`${label} kind is not admitted by transition_contract`);
     }
     if (input.status === "running" && kind !== "continuous_monitor_upsert") {
       throw new Error(`${label} running result may only upsert a monitor`);
     }
-    const expectedFields = kind === "continuous_monitor_upsert"
-      ? MONITOR_UPSERT_FIELDS
-      : kind === "continuous_monitor_complete"
-      ? MONITOR_COMPLETE_FIELDS
-      : null;
-    if (expectedFields === null) {
-      throw new Error(`${label} kind is unsupported`);
-    }
-    requireExactFields(proposal, expectedFields, label);
     if (proposal.schema_version !== CONTINUOUS_MONITOR_PROPOSAL_SCHEMA_VERSION) {
       throw new Error(`${label} schema_version is invalid`);
     }
@@ -234,55 +251,72 @@ function validateTransitionProposals(input: {
     if (!allowedMonitorKeyPrefixes.some((prefix) => monitorKey.startsWith(prefix))) {
       throw new Error(`${label} monitor_key is not admitted`);
     }
-    if (kind === "continuous_monitor_upsert") {
-      const actionKind = boundedString(
-        proposal.action_kind,
-        `${label} action_kind`,
-        64,
-      );
-      if (!ACTION_KIND_RE.test(actionKind) || !allowedActions.includes(actionKind)) {
-        throw new Error(`${label} action_kind is not admitted`);
+    switch (kind) {
+      case "continuous_monitor_upsert": {
+        requireExactFields(proposal, MONITOR_UPSERT_FIELDS, label);
+        const actionKind = boundedString(
+          proposal.action_kind,
+          `${label} action_kind`,
+          64,
+        );
+        if (!ACTION_KIND_RE.test(actionKind) || !allowedActions.includes(actionKind)) {
+          throw new Error(`${label} action_kind is not admitted`);
+        }
+        const targetKey = boundedString(
+          proposal.target_key,
+          `${label} target_key`,
+          128,
+        );
+        if (!allowedTargetPrefixes.some((prefix) => targetKey.startsWith(prefix))) {
+          throw new Error(`${label} target_key is not admitted`);
+        }
+        const requiredCapabilities = boundedStringArray(
+          proposal.required_capabilities,
+          `${label} required_capabilities`,
+          16,
+        );
+        if (
+          new Set(requiredCapabilities).size !== requiredCapabilities.length ||
+          requiredCapabilities.some((capability) =>
+            !ACTION_KIND_RE.test(capability) || !allowedCapabilities.includes(capability)
+          )
+        ) {
+          throw new Error(`${label} required_capabilities are not admitted`);
+        }
+        return {
+          ...proposal,
+          kind,
+          proposal_id: proposalId,
+          monitor_key: monitorKey,
+          text: boundedString(proposal.text, `${label} text`, 240),
+          action_kind: actionKind,
+          target_key: targetKey,
+          cadence: boundedString(proposal.cadence, `${label} cadence`, 32),
+          next_due_at: boundedString(
+            proposal.next_due_at,
+            `${label} next_due_at`,
+            64,
+          ),
+          expires_at: boundedString(
+            proposal.expires_at,
+            `${label} expires_at`,
+            64,
+          ),
+          required_capabilities: requiredCapabilities,
+        };
       }
-      const targetKey = boundedString(
-        proposal.target_key,
-        `${label} target_key`,
-        128,
-      );
-      if (!allowedTargetPrefixes.some((prefix) => targetKey.startsWith(prefix))) {
-        throw new Error(`${label} target_key is not admitted`);
-      }
-      const requiredCapabilities = boundedStringArray(
-        proposal.required_capabilities,
-        `${label} required_capabilities`,
-        16,
-      );
-      if (
-        new Set(requiredCapabilities).size !== requiredCapabilities.length ||
-        requiredCapabilities.some((capability) =>
-          !ACTION_KIND_RE.test(capability) || !allowedCapabilities.includes(capability)
-        )
-      ) {
-        throw new Error(`${label} required_capabilities are not admitted`);
-      }
-      return {
-        ...proposal,
-        proposal_id: proposalId,
-        monitor_key: monitorKey,
-        text: boundedString(proposal.text, `${label} text`, 240),
-        action_kind: actionKind,
-        target_key: targetKey,
-        cadence: boundedString(proposal.cadence, `${label} cadence`, 32),
-        next_due_at: boundedString(proposal.next_due_at, `${label} next_due_at`, 64),
-        expires_at: boundedString(proposal.expires_at, `${label} expires_at`, 64),
-        required_capabilities: requiredCapabilities,
-      };
+      case "continuous_monitor_complete":
+        requireExactFields(proposal, MONITOR_COMPLETE_FIELDS, label);
+        return {
+          ...proposal,
+          kind,
+          proposal_id: proposalId,
+          monitor_key: monitorKey,
+          evidence: boundedString(proposal.evidence, `${label} evidence`, 240),
+        };
+      default:
+        return assertNever(kind, `${label} kind dispatch is incomplete`);
     }
-    return {
-      ...proposal,
-      proposal_id: proposalId,
-      monitor_key: monitorKey,
-      evidence: boundedString(proposal.evidence, `${label} evidence`, 240),
-    };
   });
 }
 

--- a/loopx/control_plane/governed_capability.ts
+++ b/loopx/control_plane/governed_capability.ts
@@ -3,6 +3,8 @@ import { requireNonEmptyString as requiredString } from "./runtime_decode.ts";
 
 export const EXTERNAL_EFFECT_RECEIPT_SCHEMA_VERSION =
   "loopx_external_effect_receipt_v0";
+export const CONTINUOUS_MONITOR_PROPOSAL_SCHEMA_VERSION =
+  "loopx_continuous_monitor_proposal_v0";
 
 const RESULT_FIELDS = new Set([
   "schema_version",
@@ -25,6 +27,37 @@ const EFFECT_RECEIPT_FIELDS = new Set([
   "evidence_digest",
 ]);
 
+const TRANSITION_CONTRACT_FIELDS = new Set([
+  "proposal_kinds",
+  "monitor_key_prefixes",
+  "monitor_action_kinds",
+  "monitor_target_key_prefixes",
+  "monitor_required_capabilities",
+]);
+const MONITOR_UPSERT_FIELDS = new Set([
+  "schema_version",
+  "proposal_id",
+  "kind",
+  "monitor_key",
+  "text",
+  "action_kind",
+  "target_key",
+  "cadence",
+  "next_due_at",
+  "expires_at",
+  "required_capabilities",
+]);
+const MONITOR_COMPLETE_FIELDS = new Set([
+  "schema_version",
+  "proposal_id",
+  "kind",
+  "monitor_key",
+  "evidence",
+]);
+const PROPOSAL_ID_RE = /^[a-z][a-z0-9_.:-]{2,95}$/;
+const MONITOR_KEY_RE = /^[a-z][a-z0-9_.-]{0,31}:[a-z][a-z0-9_.:-]{2,95}$/;
+const ACTION_KIND_RE = /^[a-z][a-z0-9_]{0,63}$/;
+
 function requiredObject(value: unknown, label: string): JsonObject {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new Error(`${label} must be an object`);
@@ -37,6 +70,29 @@ function boundedArray(value: unknown, label: string): unknown[] {
     throw new Error(`${label} must be an array with at most 64 items`);
   }
   return [...value];
+}
+
+function boundedString(value: unknown, label: string, limit: number): string {
+  const result = requiredString(value, label);
+  if (result.length > limit || result.includes("\n") || result.includes("\r")) {
+    throw new Error(`${label} must be bounded single-line text`);
+  }
+  return result;
+}
+
+function boundedStringArray(
+  value: unknown,
+  label: string,
+  limit: number,
+): string[] {
+  const result = boundedArray(value, label);
+  if (
+    result.length > limit ||
+    result.some((item) => typeof item !== "string" || item.length === 0)
+  ) {
+    throw new Error(`${label} must contain bounded non-empty strings`);
+  }
+  return result as string[];
 }
 
 function requireExactFields(
@@ -87,6 +143,147 @@ function externalEffectReceipt(
     "external capability effect_receipt evidence_digest",
   );
   return receipt;
+}
+
+function validateTransitionProposals(input: {
+  value: unknown;
+  status: string;
+  transition_contract: unknown;
+}): JsonObject[] {
+  const proposals = boundedArray(
+    input.value,
+    "external capability result transition_proposals",
+  );
+  if (proposals.length === 0) {
+    return [];
+  }
+  const contract = requiredObject(
+    input.transition_contract,
+    "governed capability transition_contract",
+  );
+  requireExactFields(
+    contract,
+    TRANSITION_CONTRACT_FIELDS,
+    "governed capability transition_contract",
+  );
+  const allowedKinds = boundedStringArray(
+    contract.proposal_kinds,
+    "governed capability transition_contract proposal_kinds",
+    8,
+  );
+  const allowedActions = boundedStringArray(
+    contract.monitor_action_kinds,
+    "governed capability transition_contract monitor_action_kinds",
+    32,
+  );
+  const allowedMonitorKeyPrefixes = boundedStringArray(
+    contract.monitor_key_prefixes,
+    "governed capability transition_contract monitor_key_prefixes",
+    32,
+  );
+  const allowedTargetPrefixes = boundedStringArray(
+    contract.monitor_target_key_prefixes,
+    "governed capability transition_contract monitor_target_key_prefixes",
+    32,
+  );
+  const allowedCapabilities = boundedStringArray(
+    contract.monitor_required_capabilities,
+    "governed capability transition_contract monitor_required_capabilities",
+    32,
+  );
+  const seenProposalIds = new Set<string>();
+  return proposals.map((raw, index) => {
+    const label = `external capability transition_proposals[${index}]`;
+    const proposal = requiredObject(raw, label);
+    const kind = boundedString(proposal.kind, `${label} kind`, 64);
+    if (!allowedKinds.includes(kind)) {
+      throw new Error(`${label} kind is not admitted by transition_contract`);
+    }
+    if (input.status === "running" && kind !== "continuous_monitor_upsert") {
+      throw new Error(`${label} running result may only upsert a monitor`);
+    }
+    const expectedFields = kind === "continuous_monitor_upsert"
+      ? MONITOR_UPSERT_FIELDS
+      : kind === "continuous_monitor_complete"
+      ? MONITOR_COMPLETE_FIELDS
+      : null;
+    if (expectedFields === null) {
+      throw new Error(`${label} kind is unsupported`);
+    }
+    requireExactFields(proposal, expectedFields, label);
+    if (proposal.schema_version !== CONTINUOUS_MONITOR_PROPOSAL_SCHEMA_VERSION) {
+      throw new Error(`${label} schema_version is invalid`);
+    }
+    const proposalId = boundedString(
+      proposal.proposal_id,
+      `${label} proposal_id`,
+      96,
+    );
+    if (!PROPOSAL_ID_RE.test(proposalId) || seenProposalIds.has(proposalId)) {
+      throw new Error(`${label} proposal_id is invalid or duplicated`);
+    }
+    seenProposalIds.add(proposalId);
+    const monitorKey = boundedString(
+      proposal.monitor_key,
+      `${label} monitor_key`,
+      128,
+    );
+    if (!MONITOR_KEY_RE.test(monitorKey)) {
+      throw new Error(`${label} monitor_key is invalid`);
+    }
+    if (!allowedMonitorKeyPrefixes.some((prefix) => monitorKey.startsWith(prefix))) {
+      throw new Error(`${label} monitor_key is not admitted`);
+    }
+    if (kind === "continuous_monitor_upsert") {
+      const actionKind = boundedString(
+        proposal.action_kind,
+        `${label} action_kind`,
+        64,
+      );
+      if (!ACTION_KIND_RE.test(actionKind) || !allowedActions.includes(actionKind)) {
+        throw new Error(`${label} action_kind is not admitted`);
+      }
+      const targetKey = boundedString(
+        proposal.target_key,
+        `${label} target_key`,
+        128,
+      );
+      if (!allowedTargetPrefixes.some((prefix) => targetKey.startsWith(prefix))) {
+        throw new Error(`${label} target_key is not admitted`);
+      }
+      const requiredCapabilities = boundedStringArray(
+        proposal.required_capabilities,
+        `${label} required_capabilities`,
+        16,
+      );
+      if (
+        new Set(requiredCapabilities).size !== requiredCapabilities.length ||
+        requiredCapabilities.some((capability) =>
+          !ACTION_KIND_RE.test(capability) || !allowedCapabilities.includes(capability)
+        )
+      ) {
+        throw new Error(`${label} required_capabilities are not admitted`);
+      }
+      return {
+        ...proposal,
+        proposal_id: proposalId,
+        monitor_key: monitorKey,
+        text: boundedString(proposal.text, `${label} text`, 240),
+        action_kind: actionKind,
+        target_key: targetKey,
+        cadence: boundedString(proposal.cadence, `${label} cadence`, 32),
+        next_due_at: boundedString(proposal.next_due_at, `${label} next_due_at`, 64),
+        expires_at: boundedString(proposal.expires_at, `${label} expires_at`, 64),
+        required_capabilities: requiredCapabilities,
+      };
+    }
+    return {
+      ...proposal,
+      proposal_id: proposalId,
+      monitor_key: monitorKey,
+      evidence: boundedString(proposal.evidence, `${label} evidence`, 240),
+    };
+  });
 }
 
 export function validateGovernedCapabilityAdmission(input: {
@@ -160,6 +357,7 @@ export function validateGovernedCapabilityResult(input: {
   effect_id: string;
   result_schema: string;
   effect_class: string;
+  transition_contract?: unknown;
 }): { result: JsonObject; journal_status: "running" | "ready_to_settle" } {
   if (input.effect_class !== "external_write") {
     throw new Error("governed capability execution requires external_write");
@@ -183,10 +381,14 @@ export function validateGovernedCapabilityResult(input: {
     "observations",
     "domain_state_mutations",
     "domain_transition_receipts",
-    "transition_proposals",
   ]) {
     result[field] = boundedArray(result[field], `external capability result ${field}`);
   }
+  result.transition_proposals = validateTransitionProposals({
+    value: result.transition_proposals,
+    status: result.status as string,
+    transition_contract: input.transition_contract,
+  });
   result.follow_up = requiredObject(
     result.follow_up,
     "external capability result follow_up",
@@ -200,7 +402,6 @@ export function validateGovernedCapabilityResult(input: {
     for (const field of [
       "domain_state_mutations",
       "domain_transition_receipts",
-      "transition_proposals",
     ]) {
       if ((result[field] as unknown[]).length > 0) {
         throw new Error(

--- a/loopx/control_plane/work_items/governed_transition_proposal.py
+++ b/loopx/control_plane/work_items/governed_transition_proposal.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 from collections.abc import Callable, Mapping, Sequence
 from copy import deepcopy
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
@@ -40,6 +41,19 @@ _RECEIPT_FIELDS = {
 
 
 TransitionCheckpoint = Callable[[list[dict[str, Any]]], None]
+
+
+class GovernedTransitionSettlementPhase(StrEnum):
+    """Turn-settlement phase that owns one admitted Kernel transition."""
+
+    PRE_SETTLEMENT = "pre_settlement"
+    POST_SETTLEMENT = "post_settlement"
+
+
+_SETTLEMENT_PHASE_BY_PROPOSAL_KIND = {
+    "continuous_monitor_upsert": GovernedTransitionSettlementPhase.PRE_SETTLEMENT,
+    "continuous_monitor_complete": GovernedTransitionSettlementPhase.POST_SETTLEMENT,
+}
 
 
 def _canonical_digest(value: object) -> str:
@@ -254,13 +268,18 @@ def settle_governed_transition_proposals(
     proposals: Sequence[Mapping[str, Any]],
     existing_receipts: object,
     checkpoint: TransitionCheckpoint,
+    phase: GovernedTransitionSettlementPhase,
 ) -> list[dict[str, Any]]:
-    """Apply each admitted proposal once and checkpoint its Kernel receipt."""
+    """Apply admitted proposals for one settlement phase and checkpoint receipts."""
 
     receipts = validate_governed_transition_receipts(existing_receipts)
     by_proposal_id = {str(item["proposal_id"]): item for item in receipts}
     for raw in proposals:
         proposal = _mapping(raw, "governed transition proposal")
+        kind = str(proposal.get("kind") or "")
+        proposal_phase = _SETTLEMENT_PHASE_BY_PROPOSAL_KIND.get(kind)
+        if proposal_phase is None:
+            raise ValueError("governed transition proposal kind is unsupported")
         proposal_id = str(proposal.get("proposal_id") or "")
         proposal_digest = _canonical_digest(proposal)
         replay = by_proposal_id.get(proposal_id)
@@ -274,7 +293,8 @@ def settle_governed_transition_proposals(
                     "governed transition proposal replay does not match its receipt"
                 )
             continue
-        kind = str(proposal.get("kind") or "")
+        if proposal_phase is not phase:
+            continue
         if kind == "continuous_monitor_upsert":
             result = _upsert_monitor(
                 registry_path=Path(registry_path).expanduser(),
@@ -291,7 +311,7 @@ def settle_governed_transition_proposals(
                 proposal=proposal,
             )
         else:
-            raise ValueError("governed transition proposal kind is unsupported")
+            raise RuntimeError("governed transition proposal dispatch is incomplete")
         receipt = {
             "schema_version": GOVERNED_TRANSITION_RECEIPT_SCHEMA_VERSION,
             "proposal_id": proposal_id,

--- a/loopx/control_plane/work_items/governed_transition_proposal.py
+++ b/loopx/control_plane/work_items/governed_transition_proposal.py
@@ -1,0 +1,310 @@
+"""Materialize governed provider proposals through LoopX-owned Todo APIs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable, Mapping, Sequence
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from ...todos import (
+    add_goal_todo,
+    complete_goal_todo,
+    list_goal_todos,
+    update_goal_todo,
+)
+from ..runtime.public_safety import validate_public_safe_value
+from ..todos.contract import (
+    TODO_STATUS_DONE,
+    TODO_STATUS_OPEN,
+    TODO_TASK_CLASS_MONITOR,
+    normalize_todo_capability_binding_ref,
+)
+
+GOVERNED_TRANSITION_RECEIPT_SCHEMA_VERSION = (
+    "loopx_governed_transition_proposal_receipt_v0"
+)
+_RECEIPT_FIELDS = {
+    "schema_version",
+    "proposal_id",
+    "proposal_digest",
+    "kind",
+    "monitor_key",
+    "action",
+    "todo_id",
+    "status",
+    "target_key",
+}
+
+
+TransitionCheckpoint = Callable[[list[dict[str, Any]]], None]
+
+
+def _canonical_digest(value: object) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _mapping(value: object, label: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be an object")
+    return {str(key): deepcopy(item) for key, item in value.items()}
+
+
+def validate_governed_transition_receipts(
+    value: object,
+) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or len(value) > 64:
+        raise ValueError(
+            "governed transition proposal receipts must contain at most 64 items"
+        )
+    receipts: list[dict[str, Any]] = []
+    proposal_ids: set[str] = set()
+    for index, raw in enumerate(value):
+        receipt = _mapping(raw, f"governed transition receipt[{index}]")
+        if set(receipt) != _RECEIPT_FIELDS:
+            raise ValueError("governed transition proposal receipt fields are invalid")
+        if receipt.get("schema_version") != GOVERNED_TRANSITION_RECEIPT_SCHEMA_VERSION:
+            raise ValueError("governed transition proposal receipt schema is invalid")
+        proposal_id = str(receipt.get("proposal_id") or "")
+        if not proposal_id or proposal_id in proposal_ids:
+            raise ValueError("governed transition proposal receipt identity is invalid")
+        proposal_ids.add(proposal_id)
+        if receipt.get("kind") not in {
+            "continuous_monitor_upsert",
+            "continuous_monitor_complete",
+        }:
+            raise ValueError("governed transition proposal receipt kind is invalid")
+        if receipt.get("status") != "committed":
+            raise ValueError("governed transition proposal receipt status is invalid")
+        for field in (
+            "proposal_digest",
+            "monitor_key",
+            "action",
+            "todo_id",
+        ):
+            if not isinstance(receipt.get(field), str) or not receipt[field]:
+                raise ValueError(
+                    f"governed transition proposal receipt {field} is invalid"
+                )
+        if receipt.get("target_key") is not None and not isinstance(
+            receipt.get("target_key"), str
+        ):
+            raise ValueError(
+                "governed transition proposal receipt target_key is invalid"
+            )
+        validate_public_safe_value(receipt, path=f"transition_receipts[{index}]")
+        receipts.append(receipt)
+    return receipts
+
+
+def _monitor_for_key(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    monitor_key: str,
+) -> dict[str, Any] | None:
+    projection = list_goal_todos(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        role="agent",
+    )
+    matches = [
+        item
+        for item in projection.get("todos", [])
+        if isinstance(item, dict)
+        and normalize_todo_capability_binding_ref(item.get("capability_binding_ref"))
+        == monitor_key
+    ]
+    if len(matches) > 1:
+        raise ValueError("governed monitor proposal matched multiple Todos")
+    if not matches:
+        return None
+    item = matches[0]
+    if item.get("task_class") != TODO_TASK_CLASS_MONITOR:
+        raise ValueError("governed monitor proposal matched a non-monitor Todo")
+    return item
+
+
+def _upsert_monitor(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    agent_id: str,
+    proposal: Mapping[str, Any],
+) -> dict[str, Any]:
+    monitor_key = str(proposal["monitor_key"])
+    current = _monitor_for_key(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        monitor_key=monitor_key,
+    )
+    monitor_metadata = {
+        "target_key": str(proposal["target_key"]),
+        "cadence": str(proposal["cadence"]),
+        "next_due_at": str(proposal["next_due_at"]),
+        "expires_at": str(proposal["expires_at"]),
+    }
+    if current is None:
+        result = add_goal_todo(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            role="agent",
+            text=str(proposal["text"]),
+            status=TODO_STATUS_OPEN,
+            task_class=TODO_TASK_CLASS_MONITOR,
+            action_kind=str(proposal["action_kind"]),
+            capability_binding_ref=monitor_key,
+            required_capabilities=[
+                str(item) for item in proposal["required_capabilities"]
+            ],
+            claimed_by=agent_id,
+            agent_id=agent_id,
+            monitor_metadata=monitor_metadata,
+        )
+        action = "created" if result.get("added") else "reused"
+    else:
+        if current.get("status") == TODO_STATUS_DONE:
+            raise ValueError("governed monitor proposal cannot reopen a completed Todo")
+        if current.get("status") != TODO_STATUS_OPEN:
+            raise ValueError("governed monitor proposal requires an open monitor Todo")
+        owner = str(current.get("claimed_by") or "")
+        if owner and owner != agent_id:
+            raise ValueError("governed monitor proposal cannot reassign another Agent")
+        result = update_goal_todo(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            todo_id=str(current["todo_id"]),
+            role="agent",
+            text=str(proposal["text"]),
+            status=TODO_STATUS_OPEN,
+            task_class=TODO_TASK_CLASS_MONITOR,
+            action_kind=str(proposal["action_kind"]),
+            required_capabilities=[
+                str(item) for item in proposal["required_capabilities"]
+            ],
+            claimed_by=agent_id,
+            agent_id=agent_id,
+            monitor_metadata=monitor_metadata,
+        )
+        action = "updated" if result.get("changed") else "unchanged"
+    return {
+        "action": action,
+        "todo_id": str(result["todo_id"]),
+        "target_key": str(proposal["target_key"]),
+    }
+
+
+def _complete_monitor(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    agent_id: str,
+    effect_id: str,
+    proposal: Mapping[str, Any],
+) -> dict[str, Any]:
+    current = _monitor_for_key(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        monitor_key=str(proposal["monitor_key"]),
+    )
+    if current is None:
+        raise ValueError("governed monitor completion has no materialized Todo")
+    owner = str(current.get("claimed_by") or "")
+    if owner and owner != agent_id:
+        raise ValueError("governed monitor completion cannot mutate another Agent")
+    completion_key = (
+        "governed_transition_"
+        + hashlib.sha256(f"{effect_id}:{proposal['proposal_id']}".encode()).hexdigest()[
+            :32
+        ]
+    )
+    result = complete_goal_todo(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        todo_id=str(current["todo_id"]),
+        role="agent",
+        evidence=str(proposal["evidence"]),
+        completion_turn_key=completion_key,
+        no_followup=True,
+        claimed_by=agent_id,
+        agent_id=agent_id,
+        authority_reason="validated governed external-capability proposal",
+    )
+    return {
+        "action": ("replayed" if result.get("idempotent_replay") else "completed"),
+        "todo_id": str(result["todo_id"]),
+        "target_key": current.get("target_key"),
+    }
+
+
+def settle_governed_transition_proposals(
+    *,
+    registry_path: str | Path,
+    goal_id: str,
+    agent_id: str,
+    effect_id: str,
+    proposals: Sequence[Mapping[str, Any]],
+    existing_receipts: object,
+    checkpoint: TransitionCheckpoint,
+) -> list[dict[str, Any]]:
+    """Apply each admitted proposal once and checkpoint its Kernel receipt."""
+
+    receipts = validate_governed_transition_receipts(existing_receipts)
+    by_proposal_id = {str(item["proposal_id"]): item for item in receipts}
+    for raw in proposals:
+        proposal = _mapping(raw, "governed transition proposal")
+        proposal_id = str(proposal.get("proposal_id") or "")
+        proposal_digest = _canonical_digest(proposal)
+        replay = by_proposal_id.get(proposal_id)
+        if replay is not None:
+            if (
+                replay.get("proposal_digest") != proposal_digest
+                or replay.get("kind") != proposal.get("kind")
+                or replay.get("monitor_key") != proposal.get("monitor_key")
+            ):
+                raise ValueError(
+                    "governed transition proposal replay does not match its receipt"
+                )
+            continue
+        kind = str(proposal.get("kind") or "")
+        if kind == "continuous_monitor_upsert":
+            result = _upsert_monitor(
+                registry_path=Path(registry_path).expanduser(),
+                goal_id=goal_id,
+                agent_id=agent_id,
+                proposal=proposal,
+            )
+        elif kind == "continuous_monitor_complete":
+            result = _complete_monitor(
+                registry_path=Path(registry_path).expanduser(),
+                goal_id=goal_id,
+                agent_id=agent_id,
+                effect_id=effect_id,
+                proposal=proposal,
+            )
+        else:
+            raise ValueError("governed transition proposal kind is unsupported")
+        receipt = {
+            "schema_version": GOVERNED_TRANSITION_RECEIPT_SCHEMA_VERSION,
+            "proposal_id": proposal_id,
+            "proposal_digest": proposal_digest,
+            "kind": kind,
+            "monitor_key": str(proposal["monitor_key"]),
+            "action": str(result["action"]),
+            "todo_id": str(result["todo_id"]),
+            "status": "committed",
+            "target_key": result.get("target_key"),
+        }
+        validate_public_safe_value(receipt, path="transition_receipt")
+        receipts.append(receipt)
+        by_proposal_id[proposal_id] = receipt
+        checkpoint(receipts)
+    return receipts

--- a/loopx/extensions/governed_capability_execution.py
+++ b/loopx/extensions/governed_capability_execution.py
@@ -27,6 +27,10 @@ from ..control_plane.turn_driver.transaction import (
     TRANSACTION_PHASES,
     build_loopx_turn_transaction_plan,
 )
+from ..control_plane.work_items.governed_transition_proposal import (
+    settle_governed_transition_proposals,
+    validate_governed_transition_receipts,
+)
 from ..file_lock import exclusive_file_lock
 from .capability_admission import prepare_external_capability_invocation
 from .runtime import execute_extension_runtime_binding
@@ -119,6 +123,20 @@ def _settlement_identity(transaction_plan: Mapping[str, Any]) -> dict[str, Any]:
     return _mapping(settlement.get("identity"), "settlement identity")
 
 
+def _journal_registry_path(journal: Mapping[str, Any]) -> Path | None:
+    if journal.get("kernel_context") is None:
+        if journal.get("kernel_context_digest") is not None:
+            raise ValueError("governed capability kernel context is invalid")
+        return None
+    context = _mapping(journal.get("kernel_context"), "governed kernel context")
+    if journal.get("kernel_context_digest") != _canonical_digest(context):
+        raise ValueError("governed capability kernel context digest is invalid")
+    registry_path = str(context.get("registry_path") or "")
+    if not registry_path:
+        raise ValueError("governed capability kernel context is incomplete")
+    return Path(registry_path)
+
+
 def _require_admission(
     admission: Mapping[str, Any],
     *,
@@ -170,6 +188,7 @@ def _validated_governed_capability_result(
             "effect_id": effect_id,
             "result_schema": operation.get("result_schema"),
             "effect_class": operation.get("effect_class"),
+            "transition_contract": operation.get("transition_contract"),
         },
     )
     if not isinstance(payload, Mapping):
@@ -215,6 +234,12 @@ def _validate_journal(
     }
     if any(journal.get(key) != value for key, value in expected_top_level.items()):
         raise ValueError("governed capability journal settlement identity is invalid")
+    registry_path = _journal_registry_path(journal)
+    transition_receipts = validate_governed_transition_receipts(
+        journal.get("transition_receipts", [])
+    )
+    if transition_receipts and registry_path is None:
+        raise ValueError("governed transition receipts require Kernel context")
 
     request = _mapping(journal.get("request"), "provider request")
     if request.get("invocation_id") != invocation_id:
@@ -240,6 +265,10 @@ def _validate_journal(
     if provider_result is None:
         if status != "starting":
             raise ValueError("governed capability journal provider state is invalid")
+        if transition_receipts:
+            raise ValueError(
+                "governed capability has transition receipts before provider result"
+            )
         return
     result = _mapping(provider_result, "external capability result")
     validated, provider_status = _validated_governed_capability_result(
@@ -334,14 +363,50 @@ def _public_receipt(journal: Mapping[str, Any], *, dry_run: bool) -> dict[str, A
         "effect_id": journal.get("effect_id"),
         "provider_status": result.get("status"),
         "provider_result_digest": (_canonical_digest(result) if result else None),
+        "transition_receipts": deepcopy(journal.get("transition_receipts", [])),
         "settlement_result": journal.get("settlement_result"),
         "effects": {
             "provider_invoked": bool(provider_result),
             "external_write_observed": bool(result.get("effect_receipt")),
+            "loopx_transitions_written": bool(journal.get("transition_receipts")),
             "loopx_state_written": isinstance(journal.get("writeback"), Mapping),
             "quota_spent": isinstance(journal.get("quota_spend"), Mapping),
         },
     }
+
+
+def _settle_journal_transition_proposals(
+    *,
+    journal: dict[str, Any],
+    path: Path,
+) -> None:
+    provider_result = _mapping(
+        journal.get("provider_result"), "external capability result"
+    )
+    raw_proposals = provider_result.get("transition_proposals")
+    if not isinstance(raw_proposals, list):
+        raise ValueError("external capability transition_proposals must be an array")
+    if not raw_proposals:
+        return
+    registry_path = _journal_registry_path(journal)
+    if registry_path is None:
+        raise ValueError("governed transition proposals require Kernel context")
+
+    def checkpoint(receipts: list[dict[str, Any]]) -> None:
+        journal["transition_receipts"] = deepcopy(receipts)
+        _write_journal(path, journal)
+
+    journal["transition_receipts"] = settle_governed_transition_proposals(
+        registry_path=registry_path,
+        goal_id=str(journal["goal_id"]),
+        agent_id=str(journal["agent_id"]),
+        effect_id=str(journal["effect_id"]),
+        proposals=[
+            _mapping(item, "governed transition proposal") for item in raw_proposals
+        ],
+        existing_receipts=journal.get("transition_receipts", []),
+        checkpoint=checkpoint,
+    )
 
 
 def start_governed_external_capability(
@@ -405,6 +470,9 @@ def start_governed_external_capability(
     request_digest = _canonical_digest(request)
     binding = _mapping(prepared["binding"], "provider binding")
     invocation_id = str(prepared["invocation_id"])
+    kernel_context = {
+        "registry_path": str(Path(registry_path).expanduser().resolve()),
+    }
     journal: dict[str, Any] = {
         "schema_version": GOVERNED_CAPABILITY_RUN_SCHEMA_VERSION,
         "status": "ready" if not execute else "starting",
@@ -419,8 +487,11 @@ def start_governed_external_capability(
         "todo_id": todo_id,
         "turn_instance_id": turn_instance_id,
         "effect_id": identity["effect_id"],
+        "kernel_context": kernel_context,
+        "kernel_context_digest": _canonical_digest(kernel_context),
         "completed_phases": [],
         "provider_result": None,
+        "transition_receipts": [],
         "writeback": None,
         "quota_spend": None,
         "settlement_result": None,
@@ -439,6 +510,7 @@ def start_governed_external_capability(
             ):
                 raise ValueError("governed capability invocation replay does not match")
             if isinstance(current.get("provider_result"), Mapping):
+                _settle_journal_transition_proposals(journal=current, path=path)
                 return _public_receipt(current, dry_run=False)
             journal = current
         else:
@@ -466,6 +538,7 @@ def start_governed_external_capability(
         journal["provider_result"] = validated
         journal["status"] = journal_status
         _write_journal(path, journal)
+        _settle_journal_transition_proposals(journal=journal, path=path)
         return _public_receipt(journal, dry_run=False)
 
 
@@ -535,8 +608,11 @@ def reconcile_governed_external_capability(
             journal["provider_result"] = provider_result
             journal["status"] = journal_status
             _write_journal(path, journal)
+            _settle_journal_transition_proposals(journal=journal, path=path)
             if provider_result["status"] == "running":
                 return _public_receipt(journal, dry_run=False)
+
+        _settle_journal_transition_proposals(journal=journal, path=path)
 
         effect_receipt = _mapping(
             provider_result.get("effect_receipt"), "external effect receipt"
@@ -548,6 +624,7 @@ def reconcile_governed_external_capability(
             "provider_result_digest": _canonical_digest(provider_result),
             "effect_receipt": effect_receipt,
             "effect_receipt_digest": effect_receipt_digest,
+            "transition_receipts": deepcopy(journal["transition_receipts"]),
         }
 
         def checkpoint(

--- a/loopx/extensions/governed_capability_execution.py
+++ b/loopx/extensions/governed_capability_execution.py
@@ -28,6 +28,7 @@ from ..control_plane.turn_driver.transaction import (
     build_loopx_turn_transaction_plan,
 )
 from ..control_plane.work_items.governed_transition_proposal import (
+    GovernedTransitionSettlementPhase,
     settle_governed_transition_proposals,
     validate_governed_transition_receipts,
 )
@@ -379,6 +380,7 @@ def _settle_journal_transition_proposals(
     *,
     journal: dict[str, Any],
     path: Path,
+    phase: GovernedTransitionSettlementPhase,
 ) -> None:
     provider_result = _mapping(
         journal.get("provider_result"), "external capability result"
@@ -406,6 +408,7 @@ def _settle_journal_transition_proposals(
         ],
         existing_receipts=journal.get("transition_receipts", []),
         checkpoint=checkpoint,
+        phase=phase,
     )
 
 
@@ -510,7 +513,11 @@ def start_governed_external_capability(
             ):
                 raise ValueError("governed capability invocation replay does not match")
             if isinstance(current.get("provider_result"), Mapping):
-                _settle_journal_transition_proposals(journal=current, path=path)
+                _settle_journal_transition_proposals(
+                    journal=current,
+                    path=path,
+                    phase=GovernedTransitionSettlementPhase.PRE_SETTLEMENT,
+                )
                 return _public_receipt(current, dry_run=False)
             journal = current
         else:
@@ -538,7 +545,11 @@ def start_governed_external_capability(
         journal["provider_result"] = validated
         journal["status"] = journal_status
         _write_journal(path, journal)
-        _settle_journal_transition_proposals(journal=journal, path=path)
+        _settle_journal_transition_proposals(
+            journal=journal,
+            path=path,
+            phase=GovernedTransitionSettlementPhase.PRE_SETTLEMENT,
+        )
         return _public_receipt(journal, dry_run=False)
 
 
@@ -608,11 +619,19 @@ def reconcile_governed_external_capability(
             journal["provider_result"] = provider_result
             journal["status"] = journal_status
             _write_journal(path, journal)
-            _settle_journal_transition_proposals(journal=journal, path=path)
+            _settle_journal_transition_proposals(
+                journal=journal,
+                path=path,
+                phase=GovernedTransitionSettlementPhase.PRE_SETTLEMENT,
+            )
             if provider_result["status"] == "running":
                 return _public_receipt(journal, dry_run=False)
 
-        _settle_journal_transition_proposals(journal=journal, path=path)
+        _settle_journal_transition_proposals(
+            journal=journal,
+            path=path,
+            phase=GovernedTransitionSettlementPhase.PRE_SETTLEMENT,
+        )
 
         effect_receipt = _mapping(
             provider_result.get("effect_receipt"), "external effect receipt"
@@ -692,6 +711,11 @@ def reconcile_governed_external_capability(
             return {**_public_receipt(journal, dry_run=False), "ok": False}
         if settlement_status != "committed":
             raise RuntimeError("TypeScript governed capability status shape mismatch")
+        _settle_journal_transition_proposals(
+            journal=journal,
+            path=path,
+            phase=GovernedTransitionSettlementPhase.POST_SETTLEMENT,
+        )
         journal["status"] = settlement_status
         _write_journal(path, journal)
         return _public_receipt(journal, dry_run=False)

--- a/loopx/extensions/manifest.py
+++ b/loopx/extensions/manifest.py
@@ -24,6 +24,10 @@ _OPERATION_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
 _TARGET_KEY_PREFIX_RE = re.compile(r"^[a-z0-9][a-z0-9_.:-]{0,127}$")
 _PYTHON_MODULE_RE = re.compile(r"^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*$")
 _EXTERNAL_CAPABILITY_EFFECT_CLASSES = {"read_only", "external_write"}
+_EXTERNAL_CAPABILITY_TRANSITION_PROPOSAL_KINDS = {
+    "continuous_monitor_upsert",
+    "continuous_monitor_complete",
+}
 _PYTHON_CALLABLE_RE = re.compile(r"^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*:[A-Za-z_]\w*$")
 _SURFACE_ID_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
 _SURFACE_KIND_RE = re.compile(r"^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$")
@@ -344,6 +348,7 @@ def _integration_profile(
             "request_schema",
             "result_schema",
             "todo_contract",
+            "transition_contract",
         }
         unknown_operation_fields = sorted(set(item) - allowed_operation_fields)
         if unknown_operation_fields:
@@ -367,6 +372,7 @@ def _integration_profile(
                 f"{sorted(_EXTERNAL_CAPABILITY_EFFECT_CLASSES)}"
             )
         todo_contract = item.get("todo_contract")
+        transition_contract = item.get("transition_contract")
         if effect_class == "external_write":
             if not isinstance(todo_contract, Mapping):
                 raise ValueError(
@@ -403,16 +409,120 @@ def _integration_profile(
                 )
             ):
                 raise ValueError(
-                    f"{operation_context} todo_contract target_key_prefixes are "
-                    "invalid"
+                    f"{operation_context} todo_contract target_key_prefixes are invalid"
                 )
             todo_contract = {
                 "action_kinds": action_kinds,
                 "target_key_prefixes": target_key_prefixes,
             }
+            if transition_contract is not None:
+                if not isinstance(transition_contract, Mapping):
+                    raise ValueError(
+                        f"{operation_context} transition_contract must be an object"
+                    )
+                transition_context = f"{operation_context} transition_contract"
+                if set(transition_contract) != {
+                    "proposal_kinds",
+                    "monitor_key_prefixes",
+                    "monitor_action_kinds",
+                    "monitor_target_key_prefixes",
+                    "monitor_required_capabilities",
+                }:
+                    raise ValueError(f"{transition_context} fields are invalid")
+                proposal_kinds = _string_list(
+                    transition_contract,
+                    "proposal_kinds",
+                    context=transition_context,
+                )
+                monitor_key_prefixes = _string_list(
+                    transition_contract,
+                    "monitor_key_prefixes",
+                    context=transition_context,
+                )
+                monitor_action_kinds = _string_list(
+                    transition_contract,
+                    "monitor_action_kinds",
+                    context=transition_context,
+                )
+                monitor_target_key_prefixes = _string_list(
+                    transition_contract,
+                    "monitor_target_key_prefixes",
+                    context=transition_context,
+                )
+                monitor_required_capabilities = _string_list(
+                    transition_contract,
+                    "monitor_required_capabilities",
+                    context=transition_context,
+                )
+                if (
+                    not 1 <= len(proposal_kinds) <= 8
+                    or len(proposal_kinds) != len(set(proposal_kinds))
+                    or any(
+                        value not in _EXTERNAL_CAPABILITY_TRANSITION_PROPOSAL_KINDS
+                        for value in proposal_kinds
+                    )
+                ):
+                    raise ValueError(f"{transition_context} proposal_kinds are invalid")
+                if (
+                    not 1 <= len(monitor_key_prefixes) <= 32
+                    or len(monitor_key_prefixes) != len(set(monitor_key_prefixes))
+                    or any(
+                        not _TARGET_KEY_PREFIX_RE.fullmatch(value)
+                        for value in monitor_key_prefixes
+                    )
+                ):
+                    raise ValueError(
+                        f"{transition_context} monitor_key_prefixes are invalid"
+                    )
+                if (
+                    not 1 <= len(monitor_action_kinds) <= 32
+                    or len(monitor_action_kinds) != len(set(monitor_action_kinds))
+                    or any(
+                        not _OPERATION_RE.fullmatch(value)
+                        for value in monitor_action_kinds
+                    )
+                ):
+                    raise ValueError(
+                        f"{transition_context} monitor_action_kinds are invalid"
+                    )
+                if (
+                    not 1 <= len(monitor_target_key_prefixes) <= 32
+                    or len(monitor_target_key_prefixes)
+                    != len(set(monitor_target_key_prefixes))
+                    or any(
+                        not _TARGET_KEY_PREFIX_RE.fullmatch(value)
+                        for value in monitor_target_key_prefixes
+                    )
+                ):
+                    raise ValueError(
+                        f"{transition_context} monitor_target_key_prefixes are invalid"
+                    )
+                if (
+                    not 1 <= len(monitor_required_capabilities) <= 32
+                    or len(monitor_required_capabilities)
+                    != len(set(monitor_required_capabilities))
+                    or any(
+                        not _OPERATION_RE.fullmatch(value)
+                        for value in monitor_required_capabilities
+                    )
+                ):
+                    raise ValueError(
+                        f"{transition_context} monitor_required_capabilities are invalid"
+                    )
+                transition_contract = {
+                    "proposal_kinds": proposal_kinds,
+                    "monitor_key_prefixes": monitor_key_prefixes,
+                    "monitor_action_kinds": monitor_action_kinds,
+                    "monitor_target_key_prefixes": monitor_target_key_prefixes,
+                    "monitor_required_capabilities": monitor_required_capabilities,
+                }
         elif todo_contract is not None:
             raise ValueError(
-                f"{operation_context} todo_contract is only valid for "
+                f"{operation_context} todo_contract is only valid for external_write"
+            )
+        elif transition_contract is not None:
+            raise ValueError(
+                f"{operation_context} transition_contract is only valid for "
                 "external_write"
             )
         permission = _required_string(
@@ -444,6 +554,8 @@ def _integration_profile(
         }
         if todo_contract is not None:
             normalized_operation["todo_contract"] = todo_contract
+        if transition_contract is not None:
+            normalized_operation["transition_contract"] = transition_contract
         normalized_operations.append(normalized_operation)
     normalized = {
         "schema_version": EXTERNAL_CAPABILITY_PROFILE_SCHEMA_VERSION,

--- a/tests/control_plane_ts/governed_capability.test.ts
+++ b/tests/control_plane_ts/governed_capability.test.ts
@@ -15,6 +15,39 @@ const authority = {
   effect_class: "external_write",
 } as const;
 
+const transitionContract = {
+  proposal_kinds: [
+    "continuous_monitor_upsert",
+    "continuous_monitor_complete",
+  ],
+  monitor_key_prefixes: ["fixture:"],
+  monitor_action_kinds: ["poll_delivery"],
+  monitor_target_key_prefixes: ["delivery-run:"],
+  monitor_required_capabilities: ["network"],
+};
+
+const monitorUpsert = {
+  schema_version: "loopx_continuous_monitor_proposal_v0",
+  proposal_id: "monitor_upsert_1",
+  kind: "continuous_monitor_upsert",
+  monitor_key: "fixture:delivery-run",
+  text: "Poll the synthetic delivery run.",
+  action_kind: "poll_delivery",
+  target_key: "delivery-run:synthetic-1",
+  cadence: "5m",
+  next_due_at: "2099-01-01T00:05:00+00:00",
+  expires_at: "2099-01-02T00:00:00+00:00",
+  required_capabilities: ["network"],
+};
+
+const monitorComplete = {
+  schema_version: "loopx_continuous_monitor_proposal_v0",
+  proposal_id: "monitor_complete_1",
+  kind: "continuous_monitor_complete",
+  monitor_key: "fixture:delivery-run",
+  evidence: "Synthetic delivery reached a terminal state.",
+};
+
 function result(status: "running" | "succeeded" | "no_change") {
   return {
     schema_version: authority.result_schema,
@@ -110,6 +143,113 @@ test("running providers cannot claim partial effects", () => {
     () => validateGovernedCapabilityResult({ ...authority, value: invalid }),
     /must leave domain_state_mutations empty/,
   );
+});
+
+test("running providers may propose one admitted continuous monitor", () => {
+  const running = result("running");
+  running.transition_proposals = [{ ...monitorUpsert }];
+
+  const validated = validateGovernedCapabilityResult({
+    ...authority,
+    transition_contract: transitionContract,
+    value: running,
+  });
+
+  assert.equal(validated.journal_status, "running");
+  assert.deepEqual(validated.result.transition_proposals, [monitorUpsert]);
+});
+
+test("transition proposals fail closed outside profile authority", () => {
+  const running = result("running");
+  running.transition_proposals = [{ ...monitorUpsert }];
+  assert.throws(
+    () => validateGovernedCapabilityResult({ ...authority, value: running }),
+    /transition_contract must be an object/,
+  );
+
+  const wrongAction = result("running");
+  wrongAction.transition_proposals = [{
+    ...monitorUpsert,
+    action_kind: "deploy_release",
+  }];
+  assert.throws(
+    () => validateGovernedCapabilityResult({
+      ...authority,
+      transition_contract: transitionContract,
+      value: wrongAction,
+    }),
+    /action_kind is not admitted/,
+  );
+
+  const wrongMonitor = result("running");
+  wrongMonitor.transition_proposals = [{
+    ...monitorUpsert,
+    monitor_key: "unrelated:delivery-run",
+  }];
+  assert.throws(
+    () => validateGovernedCapabilityResult({
+      ...authority,
+      transition_contract: transitionContract,
+      value: wrongMonitor,
+    }),
+    /monitor_key is not admitted/,
+  );
+
+  const wrongTarget = result("running");
+  wrongTarget.transition_proposals = [{
+    ...monitorUpsert,
+    target_key: "unrelated:synthetic-1",
+  }];
+  assert.throws(
+    () => validateGovernedCapabilityResult({
+      ...authority,
+      transition_contract: transitionContract,
+      value: wrongTarget,
+    }),
+    /target_key is not admitted/,
+  );
+
+  const wrongCapability = result("running");
+  wrongCapability.transition_proposals = [{
+    ...monitorUpsert,
+    required_capabilities: ["production_access"],
+  }];
+  assert.throws(
+    () => validateGovernedCapabilityResult({
+      ...authority,
+      transition_contract: transitionContract,
+      value: wrongCapability,
+    }),
+    /required_capabilities are not admitted/,
+  );
+});
+
+test("running providers cannot complete a monitor", () => {
+  const running = result("running");
+  running.transition_proposals = [{ ...monitorComplete }];
+
+  assert.throws(
+    () => validateGovernedCapabilityResult({
+      ...authority,
+      transition_contract: transitionContract,
+      value: running,
+    }),
+    /running result may only upsert a monitor/,
+  );
+});
+
+test("successful providers may complete an admitted monitor", () => {
+  const succeeded = result("succeeded");
+  succeeded.transition_proposals = [{ ...monitorComplete }];
+
+  const validated = validateGovernedCapabilityResult({
+    ...authority,
+    transition_contract: transitionContract,
+    value: succeeded,
+  });
+
+  assert.equal(validated.journal_status, "ready_to_settle");
+  assert.deepEqual(validated.result.transition_proposals, [monitorComplete]);
 });
 
 test("terminal effect receipts bind the exact settlement effect", () => {

--- a/tests/extensions/test_external_capability_admission.py
+++ b/tests/extensions/test_external_capability_admission.py
@@ -235,6 +235,16 @@ def test_manifest_accepts_external_write_for_the_governed_adapter(
         "action_kinds": ["publish_requirement"],
         "target_key_prefixes": ["requirement:"],
     }
+    operation["transition_contract"] = {
+        "proposal_kinds": [
+            "continuous_monitor_upsert",
+            "continuous_monitor_complete",
+        ],
+        "monitor_key_prefixes": ["fixture:"],
+        "monitor_action_kinds": ["poll_requirement"],
+        "monitor_target_key_prefixes": ["requirement-run:"],
+        "monitor_required_capabilities": ["network"],
+    }
     profile.write_text(json.dumps(payload), encoding="utf-8")
     manifest = _manifest(tmp_path / "extension.toml", provider=provider)
 
@@ -246,6 +256,64 @@ def test_manifest_accepts_external_write_for_the_governed_adapter(
         "action_kinds": ["publish_requirement"],
         "target_key_prefixes": ["requirement:"],
     }
+    assert operation["transition_contract"] == {
+        "proposal_kinds": [
+            "continuous_monitor_upsert",
+            "continuous_monitor_complete",
+        ],
+        "monitor_key_prefixes": ["fixture:"],
+        "monitor_action_kinds": ["poll_requirement"],
+        "monitor_target_key_prefixes": ["requirement-run:"],
+        "monitor_required_capabilities": ["network"],
+    }
+
+
+def test_manifest_rejects_transition_contract_on_read_only_operation(
+    tmp_path: Path,
+) -> None:
+    provider = _provider(tmp_path / "provider")
+    profile = _profile(tmp_path / "profile.json")
+    payload = json.loads(profile.read_text(encoding="utf-8"))
+    payload["operations"][0]["transition_contract"] = {
+        "proposal_kinds": ["continuous_monitor_upsert"],
+        "monitor_key_prefixes": ["fixture:"],
+        "monitor_action_kinds": ["poll_requirement"],
+        "monitor_target_key_prefixes": ["requirement-run:"],
+        "monitor_required_capabilities": ["network"],
+    }
+    profile.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="only valid for external_write"):
+        load_extension_manifest(
+            _manifest(tmp_path / "extension.toml", provider=provider)
+        )
+
+
+def test_manifest_rejects_unbounded_transition_contract_authority(
+    tmp_path: Path,
+) -> None:
+    provider = _provider(tmp_path / "provider")
+    profile = _profile(tmp_path / "profile.json")
+    payload = json.loads(profile.read_text(encoding="utf-8"))
+    operation = payload["operations"][0]
+    operation["effect_class"] = "external_write"
+    operation["todo_contract"] = {
+        "action_kinds": ["publish_requirement"],
+        "target_key_prefixes": ["requirement:"],
+    }
+    operation["transition_contract"] = {
+        "proposal_kinds": ["arbitrary_todo_write"],
+        "monitor_key_prefixes": ["fixture:"],
+        "monitor_action_kinds": ["poll_requirement"],
+        "monitor_target_key_prefixes": ["requirement-run:"],
+        "monitor_required_capabilities": ["network"],
+    }
+    profile.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="proposal_kinds are invalid"):
+        load_extension_manifest(
+            _manifest(tmp_path / "extension.toml", provider=provider)
+        )
 
 
 def test_manifest_rejects_external_write_without_todo_contract(

--- a/tests/extensions/test_governed_capability_execution.py
+++ b/tests/extensions/test_governed_capability_execution.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+import loopx.extensions.governed_capability_execution as governed_execution
 from loopx.control_plane.effect_program import SettlementIdentity
 from loopx.control_plane.effect_runtime import EffectRuntimeRejected
 from loopx.extensions.capability_admission import (
@@ -19,6 +20,7 @@ from loopx.extensions.governed_capability_execution import (
     start_governed_external_capability,
 )
 from loopx.extensions.runtime import install_extension
+from loopx.todos import list_goal_todos
 
 
 def _provider(path: Path, *, call_log: Path) -> Path:
@@ -42,7 +44,19 @@ result = {{
     "observations": [{{"kind": "synthetic-progress", "phase": phase}}],
     "domain_state_mutations": [],
     "domain_transition_receipts": [],
-    "transition_proposals": [],
+    "transition_proposals": [{{
+        "schema_version": "loopx_continuous_monitor_proposal_v0",
+        "proposal_id": "fixture_monitor_upsert_1",
+        "kind": "continuous_monitor_upsert",
+        "monitor_key": "fixture:material-run",
+        "text": "Poll the synthetic material run.",
+        "action_kind": "poll_material_delivery",
+        "target_key": "fixture-run:synthetic-run-1",
+        "cadence": "5m",
+        "next_due_at": "2099-01-01T00:05:00+00:00",
+        "expires_at": "2099-01-02T00:00:00+00:00",
+        "required_capabilities": ["network"],
+    }}],
     "effect_receipt": None,
     "follow_up": {{"kind": "poll", "ref": "synthetic-run-1"}},
 }}
@@ -57,6 +71,13 @@ if phase == "reconcile":
         "external_ref": "synthetic-run-1",
         "evidence_digest": "sha256:synthetic-evidence",
     }}
+    result["transition_proposals"] = [{{
+        "schema_version": "loopx_continuous_monitor_proposal_v0",
+        "proposal_id": "fixture_monitor_complete_1",
+        "kind": "continuous_monitor_complete",
+        "monitor_key": "fixture:material-run",
+        "evidence": "Synthetic provider reached its terminal state.",
+    }}]
 json.dump(result, sys.stdout)
 """,
         encoding="utf-8",
@@ -81,6 +102,16 @@ def _installed_material_extension(tmp_path: Path) -> tuple[Path, Path, Path]:
                         "todo_contract": {
                             "action_kinds": ["fixture_material_delivery"],
                             "target_key_prefixes": ["fixture-material:"],
+                        },
+                        "transition_contract": {
+                            "proposal_kinds": [
+                                "continuous_monitor_upsert",
+                                "continuous_monitor_complete",
+                            ],
+                            "monitor_key_prefixes": ["fixture:"],
+                            "monitor_action_kinds": ["poll_material_delivery"],
+                            "monitor_target_key_prefixes": ["fixture-run:"],
+                            "monitor_required_capabilities": ["network"],
                         },
                         "required_permission": "fixture.delivery.write",
                         "request_schema": "fixture_material_capability_request_v0",
@@ -123,16 +154,26 @@ integration_profile = "profile.json"
     )
     state_file = tmp_path / "extensions.json"
     install_extension(manifest, state_file=state_file, execute=True)
+    active_state = tmp_path / "ACTIVE_GOAL_STATE.md"
+    active_state.write_text(
+        "---\nstatus: active\n---\n\n# Active Goal State\n\n## Agent Todo\n",
+        encoding="utf-8",
+    )
     registry = tmp_path / "registry.json"
     registry.write_text(
         json.dumps(
             {
                 "schema_version": "loopx_registry_v1",
+                "common_runtime_root": str(tmp_path / "runtime"),
                 "goals": [
                     {
                         "id": "fixture-goal",
                         "title": "Fixture Goal",
                         "repo": str(tmp_path),
+                        "state_file": "ACTIVE_GOAL_STATE.md",
+                        "coordination": {
+                            "registered_agents": ["fixture-agent"],
+                        },
                     }
                 ],
             }
@@ -214,10 +255,70 @@ def test_material_start_is_previewable_and_provider_idempotent(tmp_path: Path) -
     assert preview["status"] == "ready"
     assert preview["executed"] is False
     assert started["status"] == "running"
+    assert started["effects"]["loopx_transitions_written"] is True
+    assert started["transition_receipts"][0]["action"] == "created"
     assert replay["invocation_id"] == started["invocation_id"]
+    assert replay["transition_receipts"] == started["transition_receipts"]
     assert call_log.read_text(encoding="utf-8").splitlines() == ["start"]
+    monitors = list_goal_todos(
+        registry_path=Path(arguments["registry_path"]),
+        goal_id="fixture-goal",
+        role="agent",
+    )["todos"]
+    assert len(monitors) == 1
+    assert monitors[0]["capability_binding_ref"] == "fixture:material-run"
+    assert monitors[0]["status"] == "open"
     journal = Path(arguments["run_dir"]) / f"{started['invocation_id']}.json"
     assert stat.S_IMODE(journal.stat().st_mode) == 0o600
+
+
+def test_material_start_recovers_monitor_after_pre_receipt_crash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    arguments = _start_arguments(tmp_path)
+    original_write_journal = governed_execution._write_journal
+    write_count = 0
+
+    def crash_before_transition_receipt(
+        path: Path,
+        payload: Mapping[str, object],
+    ) -> None:
+        nonlocal write_count
+        write_count += 1
+        if write_count == 3:
+            raise RuntimeError("synthetic checkpoint crash")
+        original_write_journal(path, payload)
+
+    monkeypatch.setattr(
+        governed_execution,
+        "_write_journal",
+        crash_before_transition_receipt,
+    )
+    with pytest.raises(RuntimeError, match="synthetic checkpoint crash"):
+        start_governed_external_capability(**arguments, execute=True)
+
+    monkeypatch.setattr(
+        governed_execution,
+        "_write_journal",
+        original_write_journal,
+    )
+    replay = start_governed_external_capability(**arguments, execute=True)
+
+    assert replay["status"] == "running"
+    assert replay["transition_receipts"][0]["action"] in {
+        "unchanged",
+        "updated",
+    }
+    assert (tmp_path / "provider-calls.txt").read_text(
+        encoding="utf-8"
+    ).splitlines() == ["start"]
+    monitors = list_goal_todos(
+        registry_path=Path(arguments["registry_path"]),
+        goal_id="fixture-goal",
+        role="agent",
+    )["todos"]
+    assert len(monitors) == 1
 
 
 def test_material_operation_remains_unavailable_through_direct_invoke(
@@ -280,15 +381,27 @@ def test_material_reconcile_writes_receipt_before_spending_and_replays(
     assert committed["effects"] == {
         "provider_invoked": True,
         "external_write_observed": True,
+        "loopx_transitions_written": True,
         "loopx_state_written": True,
         "quota_spent": True,
     }
+    assert [item["kind"] for item in committed["transition_receipts"]] == [
+        "continuous_monitor_upsert",
+        "continuous_monitor_complete",
+    ]
     assert calls == ["writeback", "spend"]
     assert replay["status"] == "committed"
     assert calls == ["writeback", "spend"]
     assert (tmp_path / "provider-calls.txt").read_text(
         encoding="utf-8"
     ).splitlines() == ["start", "reconcile"]
+    monitors = list_goal_todos(
+        registry_path=Path(arguments["registry_path"]),
+        goal_id="fixture-goal",
+        role="agent",
+    )["todos"]
+    assert len(monitors) == 1
+    assert monitors[0]["status"] == "done"
 
 
 def test_material_start_rejects_a_different_selected_turn(tmp_path: Path) -> None:

--- a/tests/extensions/test_governed_capability_execution.py
+++ b/tests/extensions/test_governed_capability_execution.py
@@ -525,6 +525,44 @@ def test_material_settlement_fails_closed_without_effect_receipt_writeback(
     assert failed["ok"] is False
     assert failed["status"] == "settlement_failed"
     assert calls == ["writeback"]
+    assert [item["kind"] for item in failed["transition_receipts"]] == [
+        "continuous_monitor_upsert"
+    ]
+    monitors = list_goal_todos(
+        registry_path=Path(arguments["registry_path"]),
+        goal_id="fixture-goal",
+        role="agent",
+    )["todos"]
+    assert len(monitors) == 1
+    assert monitors[0]["status"] == "open"
+
+    def complete_writeback(context: Mapping[str, object]) -> dict[str, object]:
+        calls.append("writeback")
+        return {
+            "ok": True,
+            "appended": True,
+            "settlement_identity": context["settlement_identity"],
+            "effect_receipt_digest": context["effect_receipt_digest"],
+        }
+
+    committed = reconcile_governed_external_capability(
+        run_dir=arguments["run_dir"],
+        invocation_id=str(started["invocation_id"]),
+        writeback=complete_writeback,
+        spend=spend,
+    )
+
+    assert committed["status"] == "committed"
+    assert calls == ["writeback", "writeback", "spend"]
+    assert (tmp_path / "provider-calls.txt").read_text(
+        encoding="utf-8"
+    ).splitlines() == ["start", "reconcile"]
+    monitors = list_goal_todos(
+        registry_path=Path(arguments["registry_path"]),
+        goal_id="fixture-goal",
+        role="agent",
+    )["todos"]
+    assert monitors[0]["status"] == "done"
 
 
 def test_material_reconcile_rejects_tampered_journal_request(tmp_path: Path) -> None:
@@ -581,6 +619,11 @@ def test_material_reconcile_resumes_at_spend_without_repeating_writeback(
         writeback=writeback,
         spend=spend,
     )
+    monitors_after_failure = list_goal_todos(
+        registry_path=Path(arguments["registry_path"]),
+        goal_id="fixture-goal",
+        role="agent",
+    )["todos"]
     second = reconcile_governed_external_capability(
         run_dir=arguments["run_dir"],
         invocation_id=str(started["invocation_id"]),
@@ -589,8 +632,92 @@ def test_material_reconcile_resumes_at_spend_without_repeating_writeback(
     )
 
     assert first["status"] == "settlement_failed"
+    assert monitors_after_failure[0]["status"] == "open"
     assert second["status"] == "committed"
     assert calls == ["writeback", "spend", "spend"]
     assert (tmp_path / "provider-calls.txt").read_text(
         encoding="utf-8"
     ).splitlines() == ["start", "reconcile"]
+
+
+def test_material_reconcile_recovers_completion_after_pre_receipt_crash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    arguments = _start_arguments(tmp_path)
+    started = start_governed_external_capability(**arguments, execute=True)
+    original_write_journal = governed_execution._write_journal
+    calls: list[str] = []
+    crashed = False
+
+    def writeback(context: Mapping[str, object]) -> dict[str, object]:
+        calls.append("writeback")
+        return {
+            "ok": True,
+            "appended": True,
+            "settlement_identity": context["settlement_identity"],
+            "effect_receipt_digest": context["effect_receipt_digest"],
+        }
+
+    def spend(context: Mapping[str, object]) -> dict[str, object]:
+        calls.append("spend")
+        return {
+            "ok": True,
+            "appended": True,
+            "settlement_identity": context["settlement_identity"],
+        }
+
+    def crash_before_completion_receipt(
+        path: Path,
+        payload: Mapping[str, object],
+    ) -> None:
+        nonlocal crashed
+        raw_receipts = payload.get("transition_receipts")
+        receipts = raw_receipts if isinstance(raw_receipts, list) else []
+        if not crashed and any(
+            isinstance(item, Mapping)
+            and item.get("kind") == "continuous_monitor_complete"
+            for item in receipts
+        ):
+            crashed = True
+            raise RuntimeError("synthetic completion checkpoint crash")
+        original_write_journal(path, payload)
+
+    monkeypatch.setattr(
+        governed_execution,
+        "_write_journal",
+        crash_before_completion_receipt,
+    )
+    with pytest.raises(RuntimeError, match="synthetic completion checkpoint crash"):
+        reconcile_governed_external_capability(
+            run_dir=arguments["run_dir"],
+            invocation_id=str(started["invocation_id"]),
+            writeback=writeback,
+            spend=spend,
+        )
+
+    monkeypatch.setattr(
+        governed_execution,
+        "_write_journal",
+        original_write_journal,
+    )
+    replay = reconcile_governed_external_capability(
+        run_dir=arguments["run_dir"],
+        invocation_id=str(started["invocation_id"]),
+        writeback=writeback,
+        spend=spend,
+    )
+
+    assert replay["status"] == "committed"
+    assert calls == ["writeback", "spend"]
+    assert replay["transition_receipts"][-1]["action"] == "replayed"
+    assert (tmp_path / "provider-calls.txt").read_text(
+        encoding="utf-8"
+    ).splitlines() == ["start", "reconcile"]
+    monitors = list_goal_todos(
+        registry_path=Path(arguments["registry_path"]),
+        goal_id="fixture-goal",
+        role="agent",
+    )["todos"]
+    assert len(monitors) == 1
+    assert monitors[0]["status"] == "done"


### PR DESCRIPTION
## Summary

- add an optional, bounded `transition_contract` to governed external-write operations
- validate continuous-monitor proposals at the TypeScript authority boundary
- materialize admitted monitor upserts and completions through LoopX-owned Todo APIs
- checkpoint content-bounded transition receipts in the governed journal for crash-safe replay
- document the provider/Kernel ownership boundary and add synthetic end-to-end coverage

## Motivation

Long-running external providers can already return typed transition proposals, but integrations still need a private adapter to turn those proposals into durable LoopX monitor state. This change closes that provider-neutral gap without giving providers registry access or arbitrary Goal mutation authority.

The first version deliberately supports only bounded continuous-monitor upsert and completion. The integration profile allowlists proposal kinds, monitor-key prefixes, action kinds, target-key prefixes, and required capabilities.

## Validation

- `python3 -m pytest -q tests/extensions/test_governed_capability_execution.py tests/extensions/test_external_capability_admission.py` (40 passed)
- `npm run typecheck:control-plane`
- `npm run test:control-plane` (103 passed)
- `python3 examples/docs-governance-smoke.py`
- `python3 -m loopx.cli canary premerge --from-git-diff --tier standard --format json --no-progress`
- public-boundary scan clean for all 9 changed files

## Safety properties

- provider receives no registry path and cannot call Todo APIs directly
- proposals outside the exact profile authority fail before state mutation
- running results cannot complete monitors
- another Agent's monitor and completed monitors cannot be mutated
- a crash after Todo mutation but before receipt checkpoint replays without duplicate monitors
- legacy journals with no transition proposals remain readable

Signed-off-by: huangruiteng <huangrt01@163.com>