### PR TITLE
fix(quota): expose bounded fallback action portfolio

### DIFF
--- a/docs/reference/effect-interpreter-packet.md
+++ b/docs/reference/effect-interpreter-packet.md
@@ -103,7 +103,14 @@ The decision is returned as:
 | `should_run` | Whether compute is allowed |
 | `effective_action` | Machine-visible effective action |
 | `recommended_action` | Next concrete action text |
+| `action_portfolio` | Primary plus bounded typed fallbacks, when present |
 | `protocol_action_packet.summary` | Compact actor-facing summary |
+
+`EffectTurn.observation.action_portfolio` is the canonical TypeScript-owned
+observation of this field. Python supplies only scope/capability-admitted todo
+rows; the TypeScript reducer validates identity, removes duplicates, bounds the
+list, and fixes the execution-failure trigger before the Turn envelope signs
+it.
 
 ### 4. Next Effect
 

--- a/docs/reference/protocols/quota-cli-hot-path-compaction-v0.md
+++ b/docs/reference/protocols/quota-cli-hot-path-compaction-v0.md
@@ -16,11 +16,17 @@ decision owner or recompute any route.
 The default projection retains:
 
 - `decision`, `should_run`, `effective_action`, and `recommended_action`;
-- selected todo and execution obligation;
+- selected todo, bounded `action_portfolio`, and execution obligation;
 - interaction mode, user channel, and executable agent/CLI actions;
 - scheduler action and autonomous-replan authority;
 - the compact vision decision, trigger kinds, required reads, and judge result;
 - warning kinds, counts, stable identities, and cold-path references.
+
+`action_portfolio` is not diagnostic candidate noise. It is retained in the
+default packet because it carries the executable fallback rule when the
+selected primary becomes unavailable at its real call site. Compaction may
+remove the larger todo/capability candidate lists only after preserving this
+bounded portfolio unchanged.
 
 Repeated vision audits use `$.vision_continuation_audit` as the canonical
 projection. Candidate lists and peer action lists retain counts and point to
@@ -50,6 +56,13 @@ traversal, omitted counts, warning references, deduplication, and peer-route
 shape remain deterministic projection-test responsibilities. The old full
 packet is not retained as a permanent second product contract; paired mode is
 reserved for explicit differential diagnosis.
+
+The portfolio also includes a future-primary scenario: a typed P0 monitor whose
+window is not due remains visible as unavailable higher-priority work while the
+actual-default model must execute the selected ready fallback. This qualifies
+model obedience to the projection; deterministic tests separately cover the
+legacy case where a sticky primary survives and the packet must still expose
+fallback actions.
 
 Live receipts may retain only bounded scenario outcomes and digests. Packets,
 prompts, raw model responses, credentials, and conversations remain outside the

--- a/docs/reference/protocols/quota-cli-hot-path-compaction-v0.md
+++ b/docs/reference/protocols/quota-cli-hot-path-compaction-v0.md
@@ -28,6 +28,12 @@ selected primary becomes unavailable at its real call site. Compaction may
 remove the larger todo/capability candidate lists only after preserving this
 bounded portfolio unchanged.
 
+The `turn_envelope_action_dimensions_v2` base/head migration has a JSON-only,
+bounded growth allowance for this additive portfolio. The allowance applies
+only while a v0/v1 baseline migrates to v2, remains a review signal, and still
+fails above 1,280 characters/bytes, 36 lines, or 896 compact characters. Once
+v2 is the baseline, the ordinary hot-path growth limits apply again.
+
 Repeated vision audits use `$.vision_continuation_audit` as the canonical
 projection. Candidate lists and peer action lists retain counts and point to
 `--include-detail agent-todos`. The complete vision audit is available through

--- a/docs/reference/protocols/turn-envelope-v0.md
+++ b/docs/reference/protocols/turn-envelope-v0.md
@@ -36,8 +36,10 @@ Action-signature coverage is versioned independently from the envelope schema.
 `turn_envelope_action_dimensions_v1` additionally covers a blocking user
 gate's `response_plan`; `turn_envelope_action_dimensions_v2` additionally signs
 `action.action_portfolio`. Base/head qualification accepts a declared coverage
-migration as a review signal, while a digest change without a supported
-coverage migration still fails closed.
+migration as a review signal. Its bounded, JSON-only v2 migration budget applies
+only when a v0/v1 baseline moves to v2; ordinary growth limits resume once v2
+is the baseline. A digest change without a supported coverage migration, or a
+v2 portfolio above that one-version budget, still fails closed.
 
 `protocol_action_packet` remains in the full decision/cold path. The envelope
 reconstructs its ordered semantic fields from `action`, `user`, work-lane,

--- a/docs/reference/protocols/turn-envelope-v0.md
+++ b/docs/reference/protocols/turn-envelope-v0.md
@@ -14,6 +14,8 @@ loopx quota should-run --goal-id <goal-id> --agent-id <agent-id> --turn-envelope
 The default `quota should-run` output remains unchanged. The v0 envelope keeps:
 
 - the selected todo, claim, and effective action;
+- the bounded action portfolio when another admitted action can take over after
+  a primary execution failure;
 - concrete user actions and gate reasons;
 - required reads;
 - write scope, approvals, guards, workspace/capability gates, and stop rule;
@@ -32,7 +34,8 @@ coverage.
 Action-signature coverage is versioned independently from the envelope schema.
 `turn_envelope_action_dimensions_v0` covers the original action projection;
 `turn_envelope_action_dimensions_v1` additionally covers a blocking user
-gate's `response_plan`. Base/head qualification accepts that declared v0-to-v1
+gate's `response_plan`; `turn_envelope_action_dimensions_v2` additionally signs
+`action.action_portfolio`. Base/head qualification accepts a declared coverage
 migration as a review signal, while a digest change without a supported
 coverage migration still fails closed.
 

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1248,6 +1248,27 @@ render it as an agent-lane pointer, not as `recommended_action` replacement.
 Human markdown should label this pointer as the current agent's todo and mark
 co-displayed global agent todo rows as goal-wide, so `--agent-id` is not
 mistaken for a filter that replaces the goal-wide queue.
+When more than one already-admitted advancement todo remains runnable, the
+same guard also includes `action_portfolio.schema_version=
+quota_action_portfolio_v0`. `primary` is the selected todo and remains the
+normal execution target. `fallback_actions` contains at most two ordered,
+agent-scoped, capability-ready alternatives. The machine trigger is
+`fallback_policy.trigger=primary_unavailable_at_execution`: a host or agent
+uses the first alternative that is still runnable only after the primary's
+real call site reports that it cannot execute, and must preserve/report the
+primary blocker instead of silently dropping it. This is an executable hot-path
+contract, not a request to choose a lower-priority todo eagerly.
+
+Correctly typed future work is handled earlier. A higher-priority
+`continuous_monitor` with a valid future `next_due_at` is not executable; quota
+selects the next ready advancement todo and records the future monitor under
+`action_portfolio.unavailable_higher_priority` with
+`availability_reason=scheduled_for_future`. Legacy state that labels such work
+as `advancement_task` cannot be reclassified from phrases such as “Monday” or
+“after the window opens”; explicit `task_class` remains authoritative. The
+portfolio still exposes bounded fallback actions for that compatibility case,
+so a failed execution preflight need not send a weak model back through the
+entire cold diagnostic packet.
 The same scoped guard may include
 `goal_route_hint.schema_version=goal_route_hint_v0`. This is a goal-level
 read-path synthesis over the current `agent_lane_next_action`,

--- a/examples/control_plane/cli-output-probe-runner.py
+++ b/examples/control_plane/cli-output-probe-runner.py
@@ -84,6 +84,11 @@ def _receipt_row(
             if isinstance(payload, dict)
             else []
         ),
+        "action_portfolio_schema_versions": (
+            semantics.action_portfolio_schema_versions(payload)
+            if isinstance(payload, dict)
+            else []
+        ),
     }
 
 

--- a/loopx/control_plane/effect_program.py
+++ b/loopx/control_plane/effect_program.py
@@ -44,6 +44,7 @@ class EffectObservation:
     should_run: bool
     effective_action: str
     recommended_action: str
+    action_portfolio: Mapping[str, Any] | None = None
     protocol_summary: str | None = None
 
 
@@ -479,6 +480,11 @@ def _effect_turn_from_payload(payload: Any) -> EffectTurn:
             should_run=observation.get("should_run") is True,
             effective_action=str(observation.get("effective_action") or ""),
             recommended_action=str(observation.get("recommended_action") or ""),
+            action_portfolio=(
+                dict(observation["action_portfolio"])
+                if isinstance(observation.get("action_portfolio"), Mapping)
+                else None
+            ),
             protocol_summary=(
                 str(observation["protocol_summary"])
                 if observation.get("protocol_summary") is not None

--- a/loopx/control_plane/effect_program.ts
+++ b/loopx/control_plane/effect_program.ts
@@ -32,6 +32,7 @@ export interface EffectObservation<Decision extends string> {
   should_run: boolean;
   effective_action: string;
   recommended_action: string;
+  action_portfolio: JsonObject | null;
   protocol_summary: string | null;
 }
 
@@ -274,6 +275,7 @@ export function interpretQuotaShouldRunPacket(
   const cliChannel = asObject(interaction.cli_channel);
   const gate = asObject(packet.capability_gate);
   const protocol = asObject(packet.protocol_action_packet);
+  const actionPortfolio = asObject(packet.action_portfolio);
   return {
     request: {
       kind: "quota_should_run",
@@ -296,6 +298,8 @@ export function interpretQuotaShouldRunPacket(
       should_run: Boolean(packet.should_run),
       effective_action: truthyString(packet.effective_action),
       recommended_action: truthyString(packet.recommended_action),
+      action_portfolio:
+        Object.keys(actionPortfolio).length > 0 ? actionPortfolio : null,
       protocol_summary: nullableTruthyString(protocol.summary),
     },
     next_effect: {
@@ -354,6 +358,7 @@ export function interpretTurnResultPacket(
       effective_action: truthyString(packet.effective_action) || resultKind,
       recommended_action:
         truthyString(packet.recommended_action) || "settle the turn receipt",
+      action_portfolio: null,
       protocol_summary: nullableTruthyString(packet.summary),
     },
     next_effect: {

--- a/loopx/control_plane/effect_runtime.py
+++ b/loopx/control_plane/effect_runtime.py
@@ -48,6 +48,7 @@ _SOURCE_FILES = (
     "turn_driver/delivery_continuity.ts",
     "turn_driver/settlement.ts",
     "work_items/delivery_outcome.ts",
+    "work_items/action_portfolio.ts",
     "work_items/replan_settlement.ts",
     "turn_transaction_contract.json",
 )

--- a/loopx/control_plane/effect_runtime_handlers.ts
+++ b/loopx/control_plane/effect_runtime_handlers.ts
@@ -69,6 +69,7 @@ import {
   projectReplanSettlementContract,
   projectTodoLifecycleSettlementReentry,
 } from "./work_items/replan_settlement.ts";
+import { projectQuotaActionPortfolio } from "./work_items/action_portfolio.ts";
 
 type EffectRuntimeHandler = (params: JsonObject) => unknown | Promise<unknown>;
 
@@ -267,6 +268,7 @@ export function createEffectRuntimeHandlers(
     ["scheduler.state.load", loadSchedulerState],
     ["scheduler.state.write", writeSchedulerState],
     ["turn.delivery_route.evaluate", evaluateDeliveryRoute],
+    ["work_item.action_portfolio.project", projectQuotaActionPortfolio],
     ["goal.vision_checkpoint.evaluate", buildVisionCheckpoint],
     [
       "quota.delivery_workspace_causality.evaluate",

--- a/loopx/control_plane/quota/should_run_packet.py
+++ b/loopx/control_plane/quota/should_run_packet.py
@@ -96,6 +96,7 @@ from ..todos.user_gate import (
     build_user_todo_notification as _build_user_todo_notification,
 )
 from ..todos.write_hint import build_todo_write_hint
+from ..work_items.action_portfolio import build_quota_action_portfolio
 from ..work_items.execution_obligation import build_execution_obligation
 from ..work_items.goal_route_hint import build_goal_route_hint
 from ..work_items.interaction_contract import (
@@ -406,6 +407,7 @@ def _apply_agent_monitor_only_precedence(
         frontier.pop("vision_continuation_audit", None)
     for key in (
         "agent_command",
+        "action_portfolio",
         "agent_lane_frontier_hint",
         "agent_lane_next_action",
         "agent_scope_frontier",
@@ -1195,6 +1197,24 @@ def _build_quota_should_run_payload(
         payload["selected_todo"] = selected_todo_projection
     elif route.receipt_bound_replan_decision:
         payload["selected_todo"] = None
+    action_portfolio = (
+        build_quota_action_portfolio(
+            primary=route.agent_lane_next_action,
+            agent_id=normalize_todo_claimed_by(
+                (prepared.agent_identity or {}).get("agent_id")
+            ),
+            agent_todo_summary=prepared.agent_todo_summary,
+            capability_gate=prepared.capability_gate,
+            blocked_priority_fallback=prepared.blocked_priority_fallback,
+        )
+        if route.should_run
+        and route.normal_delivery_allowed
+        and not route.receipt_bound_replan_decision
+        and not prepared.agent_monitor_only
+        else None
+    )
+    if action_portfolio is not None:
+        payload["action_portfolio"] = action_portfolio
     _attach_truthy_fields(
         payload,
         agent_lane_frontier_hint=route.agent_lane_frontier_hint,

--- a/loopx/control_plane/quota/should_run_packet.py
+++ b/loopx/control_plane/quota/should_run_packet.py
@@ -696,6 +696,29 @@ class _QuotaDecisionRoute:
     payload_work_lane_contract: dict[str, Any] | None
 
 
+def _project_quota_action_portfolio(
+    prepared: _QuotaDecisionPreparation,
+    route: _QuotaDecisionRoute,
+) -> dict[str, Any] | None:
+    if (
+        not route.should_run
+        or not route.normal_delivery_allowed
+        or prepared.receipt_bound_todo_id is not None
+        or route.receipt_bound_replan_decision
+        or prepared.agent_monitor_only
+    ):
+        return None
+    return build_quota_action_portfolio(
+        primary=route.agent_lane_next_action,
+        agent_id=normalize_todo_claimed_by(
+            (prepared.agent_identity or {}).get("agent_id")
+        ),
+        agent_todo_summary=prepared.agent_todo_summary,
+        capability_gate=prepared.capability_gate,
+        blocked_priority_fallback=prepared.blocked_priority_fallback,
+    )
+
+
 def _resolve_quota_should_run_route(
     prepared: _QuotaDecisionPreparation,
 ) -> _QuotaDecisionRoute:
@@ -1197,22 +1220,7 @@ def _build_quota_should_run_payload(
         payload["selected_todo"] = selected_todo_projection
     elif route.receipt_bound_replan_decision:
         payload["selected_todo"] = None
-    action_portfolio = (
-        build_quota_action_portfolio(
-            primary=route.agent_lane_next_action,
-            agent_id=normalize_todo_claimed_by(
-                (prepared.agent_identity or {}).get("agent_id")
-            ),
-            agent_todo_summary=prepared.agent_todo_summary,
-            capability_gate=prepared.capability_gate,
-            blocked_priority_fallback=prepared.blocked_priority_fallback,
-        )
-        if route.should_run
-        and route.normal_delivery_allowed
-        and not route.receipt_bound_replan_decision
-        and not prepared.agent_monitor_only
-        else None
-    )
+    action_portfolio = _project_quota_action_portfolio(prepared, route)
     if action_portfolio is not None:
         payload["action_portfolio"] = action_portfolio
     _attach_truthy_fields(

--- a/loopx/control_plane/quota/should_run_prepare.py
+++ b/loopx/control_plane/quota/should_run_prepare.py
@@ -59,6 +59,7 @@ from ..todos.contract import (
     TODO_STATUS_OPEN,
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_BLOCKER,
+    TODO_TASK_CLASS_MONITOR,
     normalize_todo_claimed_by,
     normalize_todo_id,
     normalize_todo_replan_obligation_id,
@@ -66,6 +67,9 @@ from ..todos.contract import (
 )
 from ..todos.projection import (
     todo_item_is_actionable_open as projection_todo_item_is_actionable_open,
+    todo_item_is_due_monitor as projection_todo_item_is_due_monitor,
+    todo_item_is_expired_monitor as projection_todo_item_is_expired_monitor,
+    todo_item_next_due_at as projection_todo_item_next_due_at,
     todo_item_task_class as projection_todo_item_task_class,
 )
 from ..todos.quota_summary import (
@@ -201,12 +205,19 @@ def _blocked_priority_fallback(
             continue
         if _same_todo_identity(item, selected):
             break
-        if _todo_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
+        task_class = _todo_task_class(item)
+        future_monitor = bool(
+            task_class == TODO_TASK_CLASS_MONITOR
+            and projection_todo_item_next_due_at(item) is not None
+            and not projection_todo_item_is_expired_monitor(item)
+            and not projection_todo_item_is_due_monitor(item)
+        )
+        if task_class != TODO_TASK_CLASS_ADVANCEMENT and not future_monitor:
             continue
         if item.get("done") is True:
             continue
         status = normalize_todo_status(item.get("status")) or TODO_STATUS_OPEN
-        if status == TODO_STATUS_OPEN:
+        if status == TODO_STATUS_OPEN and not future_monitor:
             continue
         text = str(item.get("text") or "").strip()
         if not text:
@@ -224,7 +235,8 @@ def _blocked_priority_fallback(
         "notify_user": False,
         "requires_user_action": False,
         "reason": (
-            "a higher-priority agent todo is blocked or deferred before the "
+            "a higher-priority agent todo is blocked, deferred, or scheduled "
+            "for a future monitor window before the "
             "selected executable fallback"
         ),
         "blocked_items": blocked_items[:3],

--- a/loopx/control_plane/quota/turn_envelope.py
+++ b/loopx/control_plane/quota/turn_envelope.py
@@ -29,6 +29,7 @@ CONTRACT_CAPSULE_SCHEMA_VERSION = "loopx_contract_capsule_v0"
 ACTION_SIGNATURE_SCHEMA_VERSION = "loopx_action_signature_v0"
 ACTION_SIGNATURE_COVERAGE_V0 = "turn_envelope_action_dimensions_v0"
 ACTION_SIGNATURE_COVERAGE_V1 = "turn_envelope_action_dimensions_v1"
+ACTION_SIGNATURE_COVERAGE_V2 = "turn_envelope_action_dimensions_v2"
 ACTION_SIGNATURE_COVERAGE = ACTION_SIGNATURE_COVERAGE_V0
 ACTIONABLE_WARNING_FIELDS = (
     "state_projection_gap",
@@ -688,6 +689,10 @@ def _action_projection(
             recommended_action=recommended_action,
         ),
     }
+    if effect_turn.observation.action_portfolio is not None:
+        action["action_portfolio"] = dict(
+            effect_turn.observation.action_portfolio
+        )
     user = _user_channel(interaction, payload)
     scheduler = _scheduler(payload, turn=effect_turn)
     next_cli_actions = list(effect_turn.next_effect.cli_actions) or list(
@@ -782,7 +787,11 @@ def turn_envelope_action_signature_document(envelope: Mapping[str, Any]) -> dict
     )
     response_plan = envelope.get("response_plan")
     coverage = (
-        ACTION_SIGNATURE_COVERAGE_V1
+        ACTION_SIGNATURE_COVERAGE_V2
+        if isinstance(
+            _mapping(envelope.get("action")).get("action_portfolio"), Mapping
+        )
+        else ACTION_SIGNATURE_COVERAGE_V1
         if isinstance(response_plan, Mapping)
         else ACTION_SIGNATURE_COVERAGE_V0
     )

--- a/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
+++ b/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from ...bootstrap_command_pack import build_start_goal_guided_packet
 from ..quota.cli_projection import compact_quota_should_run_cli_payload
+from ..quota.should_run import build_quota_should_run
 from ..quota.turn_envelope import quota_action_signature_document
 from ..work_items.interaction_contract import build_interaction_contract
 from .control_plane_composition_scenarios import (
@@ -37,6 +38,7 @@ from .selected_todo_tool_behavior import (
     SELECTED_TODO_TOOL_FIXTURE_ACTION_TEXT,
     SELECTED_TODO_TOOL_FIXTURE_TODO_ID,
 )
+from .quota_fixtures import quota_status_payload, quota_todo_item
 
 ACTUAL_DEFAULT_MODEL_BEHAVIOR_PORTFOLIO_SCHEMA_VERSION = (
     "actual_default_model_behavior_portfolio_v0"
@@ -127,6 +129,14 @@ _SCENARIOS = (
         "turn",
         None,
         "execute",
+    ),
+    _ScenarioSpec(
+        "turn_future_primary_fallback",
+        "turn",
+        None,
+        "execute",
+        "quota_action_portfolio",
+        ("future_primary", "selected_fallback", "priority_preservation"),
     ),
     _ScenarioSpec(
         "turn_human_gate",
@@ -482,6 +492,48 @@ def _selected_todo_scenario_source() -> dict[str, Any]:
     return payload
 
 
+def _future_primary_fallback_scenario_source() -> dict[str, Any]:
+    future_primary = quota_todo_item(
+        todo_id="todo_future_primary",
+        index=1,
+        priority="P0",
+        title="Poll the primary target at its next due window.",
+        claimed_by=ACTUAL_DEFAULT_MODEL_BEHAVIOR_FIXTURE_AGENT_ID,
+        task_class="continuous_monitor",
+        action_kind="monitor",
+        target_key="public-fixture-primary",
+        cadence="daily",
+        next_due_at="2099-01-01T00:00:00Z",
+        watch_only=True,
+    )
+    ready_fallback = quota_todo_item(
+        todo_id="todo_ready_fallback",
+        index=2,
+        priority="P1",
+        title="Advance the ready bounded fallback slice.",
+        claimed_by=ACTUAL_DEFAULT_MODEL_BEHAVIOR_FIXTURE_AGENT_ID,
+    )
+    status = quota_status_payload(
+        goal_id=ACTUAL_DEFAULT_MODEL_BEHAVIOR_FIXTURE_GOAL_ID,
+        status="active",
+        agent_todo_items=[future_primary, ready_fallback],
+        recommended_action=future_primary["text"],
+        next_action=future_primary["text"],
+        coordination={
+            "agent_model": "peer_v1",
+            "registered_agents": [
+                ACTUAL_DEFAULT_MODEL_BEHAVIOR_FIXTURE_AGENT_ID
+            ],
+        },
+        claim_scope_agent_id=ACTUAL_DEFAULT_MODEL_BEHAVIOR_FIXTURE_AGENT_ID,
+    )
+    return build_quota_should_run(
+        status,
+        goal_id=ACTUAL_DEFAULT_MODEL_BEHAVIOR_FIXTURE_GOAL_ID,
+        agent_id=ACTUAL_DEFAULT_MODEL_BEHAVIOR_FIXTURE_AGENT_ID,
+    )
+
+
 def _terminal_settlement_scenario_source() -> dict[str, Any]:
     payload = _turn_scenario_source(human_gate=False)
     payload["selected_todo"] = {
@@ -658,6 +710,9 @@ def _build_actual_default_model_behavior_scenario_sources(
             "turn_same_agent_continuation": _turn_scenario_source(
                 human_gate=False,
                 continuation_policy="same_agent_non_delivery",
+            ),
+            "turn_future_primary_fallback": (
+                _future_primary_fallback_scenario_source()
             ),
             "turn_human_gate": _turn_scenario_source(human_gate=True),
             "turn_quota_hot_path_compaction_regression": (
@@ -926,6 +981,25 @@ def _scenario_contract(
                 raise ValueError(
                     "same-agent scenario must preserve the completing peer"
                 )
+    if spec.scenario_id == "turn_future_primary_fallback":
+        signature = quota_action_signature_document(source_packet)
+        action = dict(signature.get("action") or {})
+        selected = dict(action.get("selected_todo") or {})
+        portfolio = dict(action.get("action_portfolio") or {})
+        unavailable = list(portfolio.get("unavailable_higher_priority") or [])
+        if not (
+            selected.get("todo_id") == "todo_ready_fallback"
+            and portfolio.get("primary", {}).get("todo_id")
+            == "todo_ready_fallback"
+            and unavailable
+            and unavailable[0].get("todo_id") == "todo_future_primary"
+            and unavailable[0].get("availability_reason")
+            == "scheduled_for_future"
+        ):
+            raise ValueError(
+                "future-primary scenario must execute the ready fallback while "
+                "preserving the unavailable higher-priority monitor"
+            )
     if spec.scenario_id == "turn_human_gate":
         required = {
             "selected_todo_id": None,

--- a/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
+++ b/loopx/control_plane/testing/actual_default_model_behavior_portfolio.py
@@ -882,6 +882,29 @@ def _validate_required_vision_replan_scenario(
         raise ValueError("required-vision scenario must remain immediately runnable")
 
 
+def _validate_future_primary_fallback_scenario(
+    source_packet: Mapping[str, Any],
+) -> None:
+    signature = quota_action_signature_document(source_packet)
+    action = dict(signature.get("action") or {})
+    selected = dict(action.get("selected_todo") or {})
+    portfolio = dict(action.get("action_portfolio") or {})
+    primary = dict(portfolio.get("primary") or {})
+    unavailable = list(portfolio.get("unavailable_higher_priority") or [])
+    first_unavailable = dict(unavailable[0]) if unavailable else {}
+    if not (
+        selected.get("todo_id") == "todo_ready_fallback"
+        and primary.get("todo_id") == "todo_ready_fallback"
+        and first_unavailable.get("todo_id") == "todo_future_primary"
+        and first_unavailable.get("availability_reason")
+        == "scheduled_for_future"
+    ):
+        raise ValueError(
+            "future-primary scenario must execute the ready fallback while "
+            "preserving the unavailable higher-priority monitor"
+        )
+
+
 def _scenario_contract(
     spec: _ScenarioSpec,
     source_packet: Mapping[str, Any],
@@ -982,24 +1005,7 @@ def _scenario_contract(
                     "same-agent scenario must preserve the completing peer"
                 )
     if spec.scenario_id == "turn_future_primary_fallback":
-        signature = quota_action_signature_document(source_packet)
-        action = dict(signature.get("action") or {})
-        selected = dict(action.get("selected_todo") or {})
-        portfolio = dict(action.get("action_portfolio") or {})
-        unavailable = list(portfolio.get("unavailable_higher_priority") or [])
-        if not (
-            selected.get("todo_id") == "todo_ready_fallback"
-            and portfolio.get("primary", {}).get("todo_id")
-            == "todo_ready_fallback"
-            and unavailable
-            and unavailable[0].get("todo_id") == "todo_future_primary"
-            and unavailable[0].get("availability_reason")
-            == "scheduled_for_future"
-        ):
-            raise ValueError(
-                "future-primary scenario must execute the ready fallback while "
-                "preserving the unavailable higher-priority monitor"
-            )
+        _validate_future_primary_fallback_scenario(source_packet)
     if spec.scenario_id == "turn_human_gate":
         required = {
             "selected_todo_id": None,

--- a/loopx/control_plane/testing/cli_output_differential.py
+++ b/loopx/control_plane/testing/cli_output_differential.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Literal
 from ..quota.turn_envelope import (
     ACTION_SIGNATURE_COVERAGE_V0,
     ACTION_SIGNATURE_COVERAGE_V1,
+    ACTION_SIGNATURE_COVERAGE_V2,
 )
 
 
@@ -139,11 +140,22 @@ def _action_signature_migration(
 ) -> str | None:
     base_coverages = base.get("action_signature_coverages")
     candidate_coverages = candidate.get("action_signature_coverages")
-    if base_coverages != [ACTION_SIGNATURE_COVERAGE_V0]:
+    allowed_migrations = {
+        (ACTION_SIGNATURE_COVERAGE_V0, ACTION_SIGNATURE_COVERAGE_V1),
+        (ACTION_SIGNATURE_COVERAGE_V0, ACTION_SIGNATURE_COVERAGE_V2),
+        (ACTION_SIGNATURE_COVERAGE_V1, ACTION_SIGNATURE_COVERAGE_V2),
+    }
+    if not (
+        isinstance(base_coverages, list)
+        and len(base_coverages) == 1
+        and isinstance(candidate_coverages, list)
+        and len(candidate_coverages) == 1
+    ):
         return None
-    if candidate_coverages != [ACTION_SIGNATURE_COVERAGE_V1]:
+    migration = (base_coverages[0], candidate_coverages[0])
+    if migration not in allowed_migrations:
         return None
-    return f"{ACTION_SIGNATURE_COVERAGE_V0} -> {ACTION_SIGNATURE_COVERAGE_V1}"
+    return f"{migration[0]} -> {migration[1]}"
 
 
 def _compare_row(base: dict[str, Any], candidate: dict[str, Any]) -> dict[str, Any]:

--- a/loopx/control_plane/testing/cli_output_differential.py
+++ b/loopx/control_plane/testing/cli_output_differential.py
@@ -14,6 +14,7 @@ from ..quota.turn_envelope import (
 CLI_OUTPUT_PROBE_SCHEMA_VERSION = "loopx_cli_output_probe_v0"
 CLI_OUTPUT_FIXTURE_CONTRACT_VERSION = "loopx_cli_output_public_fixture_v0"
 CLI_OUTPUT_DIFFERENTIAL_SCHEMA_VERSION = "loopx_cli_output_differential_v0"
+ACTION_PORTFOLIO_SCHEMA_VERSION_V0 = "quota_action_portfolio_v0"
 
 Metric = Literal["chars", "utf8_bytes", "lines", "compact_payload_chars"]
 
@@ -99,6 +100,16 @@ _GROWTH_ALLOWANCE_BY_POLICY: dict[str, GrowthAllowance] = {
     ),
 }
 
+# action_dimensions_v2 adds the bounded, executable fallback portfolio to the
+# signed hot path.  This allowance applies only while a base row migrates from
+# v0/v1 to v2; once v2 is the baseline, ordinary policy budgets apply again.
+_ACTION_PORTFOLIO_V0_MIGRATION_GROWTH_ALLOWANCE: dict[Metric, int] = {
+    "chars": 1_280,
+    "utf8_bytes": 1_280,
+    "lines": 36,
+    "compact_payload_chars": 896,
+}
+
 
 def _rows_by_id(receipt: dict[str, Any]) -> dict[str, dict[str, Any]]:
     if receipt.get("schema_version") != CLI_OUTPUT_PROBE_SCHEMA_VERSION:
@@ -158,6 +169,18 @@ def _action_signature_migration(
     return f"{migration[0]} -> {migration[1]}"
 
 
+def _action_portfolio_schema_migration(
+    base: dict[str, Any], candidate: dict[str, Any]
+) -> str | None:
+    base_versions = base.get("action_portfolio_schema_versions")
+    candidate_versions = candidate.get("action_portfolio_schema_versions")
+    if base_versions == [] and candidate_versions == [
+        ACTION_PORTFOLIO_SCHEMA_VERSION_V0
+    ]:
+        return f"none -> {ACTION_PORTFOLIO_SCHEMA_VERSION_V0}"
+    return None
+
+
 def _compare_row(base: dict[str, Any], candidate: dict[str, Any]) -> dict[str, Any]:
     row_id = str(base["row_id"])
     failures: list[str] = []
@@ -168,6 +191,35 @@ def _compare_row(base: dict[str, Any], candidate: dict[str, Any]) -> dict[str, A
         failures.append("qualification_policy changed")
     if candidate.get("format") != output_format:
         failures.append("format changed")
+
+    base_signature = base.get("action_signature_sha256")
+    signature_changed = bool(
+        base_signature
+        and candidate.get("action_signature_sha256") != base_signature
+    )
+    signature_migration = (
+        _action_signature_migration(base, candidate) if signature_changed else None
+    )
+    base_portfolio_versions = base.get("action_portfolio_schema_versions")
+    candidate_portfolio_versions = candidate.get("action_portfolio_schema_versions")
+    portfolio_schema_changed = base_portfolio_versions != candidate_portfolio_versions
+    portfolio_schema_migration = (
+        _action_portfolio_schema_migration(base, candidate)
+        if portfolio_schema_changed
+        else None
+    )
+    portfolio_growth_migration = bool(
+        output_format == "json"
+        and (
+            portfolio_schema_migration
+            or (
+                signature_migration
+                and signature_migration.endswith(
+                    f" -> {ACTION_SIGNATURE_COVERAGE_V2}"
+                )
+            )
+        )
+    )
 
     deltas: dict[str, int | None] = {}
     allowances: dict[str, int | None] = {}
@@ -185,6 +237,11 @@ def _compare_row(base: dict[str, Any], candidate: dict[str, Any]) -> dict[str, A
             metric=metric,
             base=base_value,
         )
+        if portfolio_growth_migration:
+            allowance = max(
+                allowance,
+                _ACTION_PORTFOLIO_V0_MIGRATION_GROWTH_ALLOWANCE[metric],
+            )
         deltas[metric] = delta
         allowances[metric] = allowance
         if delta > allowance:
@@ -207,13 +264,20 @@ def _compare_row(base: dict[str, Any], candidate: dict[str, Any]) -> dict[str, A
     base_anchor = base.get("markdown_anchor")
     if base_anchor and candidate.get("markdown_anchor") != base_anchor:
         failures.append("markdown_anchor changed")
-    base_signature = base.get("action_signature_sha256")
-    if base_signature and candidate.get("action_signature_sha256") != base_signature:
-        migration = _action_signature_migration(base, candidate)
-        if migration is None:
+    if signature_changed:
+        if signature_migration is None:
             failures.append("action_signature semantic digest changed")
         else:
-            review_signals.append(f"action_signature coverage migrated: {migration}")
+            review_signals.append(
+                f"action_signature coverage migrated: {signature_migration}"
+            )
+    if portfolio_schema_changed:
+        if portfolio_schema_migration is None:
+            failures.append("action_portfolio schema coverage changed")
+        else:
+            review_signals.append(
+                f"action_portfolio schema migrated: {portfolio_schema_migration}"
+            )
 
     return {
         "row_id": row_id,

--- a/loopx/control_plane/testing/cli_output_semantics.py
+++ b/loopx/control_plane/testing/cli_output_semantics.py
@@ -83,5 +83,24 @@ def action_signature_coverages(value: Any) -> list[str]:
     return sorted(coverages)
 
 
+def action_portfolio_schema_versions(value: Any) -> list[str]:
+    versions: set[str] = set()
+
+    def collect(current: Any) -> None:
+        if isinstance(current, dict):
+            for key, child in current.items():
+                if key == "action_portfolio" and isinstance(child, dict):
+                    schema_version = child.get("schema_version")
+                    if isinstance(schema_version, str) and schema_version:
+                        versions.add(schema_version)
+                collect(child)
+        elif isinstance(current, list):
+            for child in current:
+                collect(child)
+
+    collect(value)
+    return sorted(versions)
+
+
 def markdown_headings(text: str) -> list[str]:
     return [line.strip() for line in text.splitlines() if _MARKDOWN_HEADING.match(line)]

--- a/loopx/control_plane/turn_driver/turn_journal.ts
+++ b/loopx/control_plane/turn_driver/turn_journal.ts
@@ -187,6 +187,7 @@ export function interpretTurnJournalEffect(
       recommended_action: replayLegal
         ? "Retain the terminal Turn journal tombstone."
         : "Inspect the structured Turn journal violations before replay.",
+      action_portfolio: null,
       protocol_summary: replayLegal
         ? "Turn journal replay is legal and effect-free."
         : `Turn journal replay is blocked by ${violations.length} structured violation(s).`,

--- a/loopx/control_plane/work_items/action_portfolio.py
+++ b/loopx/control_plane/work_items/action_portfolio.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ..effect_runtime import EffectRuntimeRejected, effect_runtime_result
+from ..todos.contract import (
+    TODO_TASK_CLASS_ADVANCEMENT,
+    TODO_TASK_CLASS_MONITOR,
+    normalize_todo_claimed_by,
+    normalize_todo_id,
+)
+from ..todos.projection import (
+    todo_item_is_actionable_open,
+    todo_item_task_class,
+)
+from ..todos.summary_item import compact_todo_summary_item
+from .primary_action import protocol_action_text
+
+
+ACTION_PORTFOLIO_REQUEST_SCHEMA_VERSION = "quota_action_portfolio_request_v0"
+ACTION_PORTFOLIO_SCHEMA_VERSION = "quota_action_portfolio_v0"
+
+
+def _compact_candidate(value: Mapping[str, Any]) -> dict[str, Any] | None:
+    todo_id = normalize_todo_id(value.get("todo_id"))
+    text = protocol_action_text(value.get("text"), limit=500)
+    if not todo_id or not text:
+        return None
+    compact = compact_todo_summary_item(dict(value), text=text)
+    for field in (
+        "source",
+        "selected_by",
+        "claim_required_before_work",
+        "availability_reason",
+    ):
+        if value.get(field) is not None:
+            compact[field] = value[field]
+    return compact
+
+
+def _runnable_candidates(
+    *,
+    agent_id: str,
+    agent_todo_summary: Mapping[str, Any] | None,
+    capability_gate: Mapping[str, Any] | None,
+) -> list[dict[str, Any]]:
+    if not isinstance(agent_todo_summary, Mapping):
+        return []
+    capability_candidates = (
+        capability_gate.get("runnable_candidates")
+        if isinstance(capability_gate, Mapping)
+        else None
+    )
+    if isinstance(capability_candidates, list):
+        sources = [capability_candidates]
+    else:
+        sources = [
+            agent_todo_summary.get(field)
+            for field in (
+                "active_next_action_executable_items",
+                "first_executable_items",
+                "executable_backlog_items",
+            )
+            if isinstance(agent_todo_summary.get(field), list)
+        ]
+
+    candidates: list[dict[str, Any]] = []
+    for items in sources:
+        for item in items:
+            if not isinstance(item, Mapping):
+                continue
+            candidate = dict(item)
+            claimed_by = normalize_todo_claimed_by(candidate.get("claimed_by"))
+            if (
+                not todo_item_is_actionable_open(candidate)
+                or todo_item_task_class(candidate) != TODO_TASK_CLASS_ADVANCEMENT
+                or (claimed_by is not None and claimed_by != agent_id)
+            ):
+                continue
+            compact = _compact_candidate(candidate)
+            if compact is None:
+                continue
+            if claimed_by is None:
+                compact["claim_required_before_work"] = True
+            candidates.append(compact)
+    return candidates
+
+
+def _unavailable_higher_priority_candidates(
+    blocked_priority_fallback: Mapping[str, Any] | None,
+) -> list[dict[str, Any]]:
+    if not isinstance(blocked_priority_fallback, Mapping):
+        return []
+    items = blocked_priority_fallback.get("blocked_items")
+    unavailable: list[dict[str, Any]] = []
+    for item in items if isinstance(items, list) else []:
+        if not isinstance(item, Mapping):
+            continue
+        candidate = dict(item)
+        task_class = todo_item_task_class(candidate)
+        if task_class == TODO_TASK_CLASS_MONITOR and candidate.get("next_due_at"):
+            candidate["availability_reason"] = "scheduled_for_future"
+        elif candidate.get("status"):
+            candidate["availability_reason"] = (
+                f"status_{str(candidate['status']).strip().lower()}"
+            )
+        else:
+            candidate["availability_reason"] = "not_currently_executable"
+        compact = _compact_candidate(candidate)
+        if compact is not None:
+            unavailable.append(compact)
+    return unavailable
+
+
+def build_quota_action_portfolio(
+    *,
+    primary: Mapping[str, Any] | None,
+    agent_id: str | None,
+    agent_todo_summary: Mapping[str, Any] | None,
+    capability_gate: Mapping[str, Any] | None,
+    blocked_priority_fallback: Mapping[str, Any] | None,
+    max_fallback_actions: int = 2,
+) -> dict[str, Any] | None:
+    """Adapt gated Python projections into the TypeScript-owned portfolio."""
+
+    safe_agent_id = normalize_todo_claimed_by(agent_id)
+    compact_primary = _compact_candidate(primary) if primary is not None else None
+    if not safe_agent_id or compact_primary is None:
+        return None
+    try:
+        projected = effect_runtime_result(
+            "work_item.action_portfolio.project",
+            {
+                "schema_version": ACTION_PORTFOLIO_REQUEST_SCHEMA_VERSION,
+                "primary": compact_primary,
+                "candidates": _runnable_candidates(
+                    agent_id=safe_agent_id,
+                    agent_todo_summary=agent_todo_summary,
+                    capability_gate=capability_gate,
+                ),
+                "unavailable_higher_priority": (
+                    _unavailable_higher_priority_candidates(
+                        blocked_priority_fallback
+                    )
+                ),
+                "max_fallback_actions": max_fallback_actions,
+            },
+        )
+    except EffectRuntimeRejected as exc:
+        raise ValueError(str(exc)) from None
+    if projected is None:
+        return None
+    if not isinstance(projected, Mapping) or (
+        projected.get("schema_version") != ACTION_PORTFOLIO_SCHEMA_VERSION
+    ):
+        raise RuntimeError("TypeScript quota action portfolio shape mismatch")
+    return dict(projected)

--- a/loopx/control_plane/work_items/action_portfolio.py
+++ b/loopx/control_plane/work_items/action_portfolio.py
@@ -53,17 +53,17 @@ def _runnable_candidates(
         else None
     )
     if isinstance(capability_candidates, list):
-        sources = [capability_candidates]
+        sources: list[list[Any]] = [capability_candidates]
     else:
-        sources = [
-            agent_todo_summary.get(field)
-            for field in (
-                "active_next_action_executable_items",
-                "first_executable_items",
-                "executable_backlog_items",
-            )
-            if isinstance(agent_todo_summary.get(field), list)
-        ]
+        sources = []
+        for field in (
+            "active_next_action_executable_items",
+            "first_executable_items",
+            "executable_backlog_items",
+        ):
+            items = agent_todo_summary.get(field)
+            if isinstance(items, list):
+                sources.append(items)
 
     candidates: list[dict[str, Any]] = []
     for items in sources:

--- a/loopx/control_plane/work_items/action_portfolio.ts
+++ b/loopx/control_plane/work_items/action_portfolio.ts
@@ -51,6 +51,54 @@ function candidateIdentity(candidate: ActionCandidate): string {
   return candidate.todo_id || candidate.text;
 }
 
+function requireRunnableAdvancement(
+  candidate: ActionCandidate,
+  label: string,
+): void {
+  if (candidate.status !== "open") {
+    throw new Error(`${label}.status must be open`);
+  }
+  if (candidate.task_class !== "advancement_task") {
+    throw new Error(`${label}.task_class must be advancement_task`);
+  }
+}
+
+function primaryProjection(candidate: ActionCandidate): JsonObject {
+  return { todo_id: candidate.todo_id };
+}
+
+function fallbackProjection(candidate: ActionCandidate): JsonObject {
+  const projected: JsonObject = {
+    todo_id: candidate.todo_id,
+    text: candidate.text,
+  };
+  for (const field of ["priority", "action_kind", "claimed_by"] as const) {
+    if (candidate[field] !== undefined) projected[field] = candidate[field];
+  }
+  if (candidate.claim_required_before_work === true) {
+    projected.claim_required_before_work = true;
+  }
+  return projected;
+}
+
+function unavailableProjection(candidate: ActionCandidate): JsonObject {
+  const projected: JsonObject = {
+    todo_id: candidate.todo_id,
+    text: candidate.text,
+    availability_reason: candidate.availability_reason,
+  };
+  for (const field of [
+    "priority",
+    "status",
+    "task_class",
+    "action_kind",
+    "next_due_at",
+  ] as const) {
+    if (candidate[field] !== undefined) projected[field] = candidate[field];
+  }
+  return projected;
+}
+
 /**
  * Build the bounded, model-facing action set for one quota decision.
  *
@@ -67,6 +115,7 @@ export function projectQuotaActionPortfolio(value: unknown): JsonObject | null {
     );
   }
   const primary = actionCandidate(request.primary, "action_portfolio_request.primary");
+  requireRunnableAdvancement(primary, "action_portfolio_request.primary");
   const maximum = request.max_fallback_actions === undefined
     ? 2
     : requireInteger(
@@ -87,6 +136,10 @@ export function projectQuotaActionPortfolio(value: unknown): JsonObject | null {
       rawCandidate,
       `action_portfolio_request.candidates[${index}]`,
     );
+    requireRunnableAdvancement(
+      candidate,
+      `action_portfolio_request.candidates[${index}]`,
+    );
     const identity = candidateIdentity(candidate);
     if (seen.has(identity)) continue;
     seen.add(identity);
@@ -104,6 +157,11 @@ export function projectQuotaActionPortfolio(value: unknown): JsonObject | null {
       rawCandidate,
       `action_portfolio_request.unavailable_higher_priority[${index}]`,
     );
+    if (!candidate.availability_reason) {
+      throw new Error(
+        `action_portfolio_request.unavailable_higher_priority[${index}].availability_reason must be a non-empty string`,
+      );
+    }
     const identity = candidateIdentity(candidate);
     if (identity === candidateIdentity(primary) || seenUnavailable.has(identity)) {
       continue;
@@ -118,14 +176,16 @@ export function projectQuotaActionPortfolio(value: unknown): JsonObject | null {
   }
   return {
     schema_version: ACTION_PORTFOLIO_SCHEMA_VERSION,
-    primary,
+    primary: primaryProjection(primary),
     fallback_policy: {
       trigger: "primary_unavailable_at_execution",
       selection: "first_still_runnable_in_order",
       preserve_primary_blocker: true,
       max_fallback_actions: maximum,
     },
-    fallback_actions: fallbackActions,
-    unavailable_higher_priority: unavailableHigherPriority,
+    fallback_actions: fallbackActions.map(fallbackProjection),
+    unavailable_higher_priority: unavailableHigherPriority.map(
+      unavailableProjection,
+    ),
   };
 }

--- a/loopx/control_plane/work_items/action_portfolio.ts
+++ b/loopx/control_plane/work_items/action_portfolio.ts
@@ -1,0 +1,131 @@
+import {
+  optionalNonEmptyString,
+  requireInteger,
+  requireJsonObject,
+  requireNonEmptyString,
+} from "../runtime_decode.ts";
+
+import type { JsonObject } from "../effect_program.ts";
+
+export const ACTION_PORTFOLIO_SCHEMA_VERSION = "quota_action_portfolio_v0";
+export const ACTION_PORTFOLIO_REQUEST_SCHEMA_VERSION =
+  "quota_action_portfolio_request_v0";
+
+const MAX_FALLBACK_ACTIONS = 3;
+
+interface ActionCandidate extends JsonObject {
+  todo_id: string;
+  text: string;
+}
+
+function actionCandidate(value: unknown, label: string): ActionCandidate {
+  const raw = requireJsonObject(value, label);
+  const candidate: ActionCandidate = {
+    todo_id: requireNonEmptyString(raw.todo_id, `${label}.todo_id`),
+    text: requireNonEmptyString(raw.text, `${label}.text`),
+  };
+  for (const field of [
+    "priority",
+    "status",
+    "task_class",
+    "action_kind",
+    "claimed_by",
+    "source",
+    "selected_by",
+    "availability_reason",
+    "next_due_at",
+  ] as const) {
+    const normalized = optionalNonEmptyString(raw[field], `${label}.${field}`);
+    if (normalized !== null) candidate[field] = normalized;
+  }
+  if (raw.index !== null && raw.index !== undefined) {
+    candidate.index = requireInteger(raw.index, `${label}.index`);
+  }
+  if (raw.claim_required_before_work === true) {
+    candidate.claim_required_before_work = true;
+  }
+  return candidate;
+}
+
+function candidateIdentity(candidate: ActionCandidate): string {
+  return candidate.todo_id || candidate.text;
+}
+
+/**
+ * Build the bounded, model-facing action set for one quota decision.
+ *
+ * Python owns repository/status projection and supplies only candidates that
+ * already passed agent-scope and capability gates. TypeScript owns the stable
+ * portfolio semantics: validation, identity de-duplication, ordering, and the
+ * fallback trigger exposed to hosts and models.
+ */
+export function projectQuotaActionPortfolio(value: unknown): JsonObject | null {
+  const request = requireJsonObject(value, "action_portfolio_request");
+  if (request.schema_version !== ACTION_PORTFOLIO_REQUEST_SCHEMA_VERSION) {
+    throw new Error(
+      `action_portfolio_request.schema_version must be ${ACTION_PORTFOLIO_REQUEST_SCHEMA_VERSION}`,
+    );
+  }
+  const primary = actionCandidate(request.primary, "action_portfolio_request.primary");
+  const maximum = request.max_fallback_actions === undefined
+    ? 2
+    : requireInteger(
+      request.max_fallback_actions,
+      "action_portfolio_request.max_fallback_actions",
+    );
+  if (maximum < 1 || maximum > MAX_FALLBACK_ACTIONS) {
+    throw new Error(
+      `action_portfolio_request.max_fallback_actions must be between 1 and ${MAX_FALLBACK_ACTIONS}`,
+    );
+  }
+
+  const rawCandidates = Array.isArray(request.candidates) ? request.candidates : [];
+  const seen = new Set<string>([candidateIdentity(primary)]);
+  const fallbackActions: ActionCandidate[] = [];
+  for (const [index, rawCandidate] of rawCandidates.entries()) {
+    const candidate = actionCandidate(
+      rawCandidate,
+      `action_portfolio_request.candidates[${index}]`,
+    );
+    const identity = candidateIdentity(candidate);
+    if (seen.has(identity)) continue;
+    seen.add(identity);
+    fallbackActions.push(candidate);
+    if (fallbackActions.length >= maximum) break;
+  }
+
+  const rawUnavailable = Array.isArray(request.unavailable_higher_priority)
+    ? request.unavailable_higher_priority
+    : [];
+  const unavailableHigherPriority: ActionCandidate[] = [];
+  const seenUnavailable = new Set<string>();
+  for (const [index, rawCandidate] of rawUnavailable.entries()) {
+    const candidate = actionCandidate(
+      rawCandidate,
+      `action_portfolio_request.unavailable_higher_priority[${index}]`,
+    );
+    const identity = candidateIdentity(candidate);
+    if (identity === candidateIdentity(primary) || seenUnavailable.has(identity)) {
+      continue;
+    }
+    seenUnavailable.add(identity);
+    unavailableHigherPriority.push(candidate);
+    if (unavailableHigherPriority.length >= MAX_FALLBACK_ACTIONS) break;
+  }
+
+  if (fallbackActions.length === 0 && unavailableHigherPriority.length === 0) {
+    return null;
+  }
+  return {
+    schema_version: ACTION_PORTFOLIO_SCHEMA_VERSION,
+    primary,
+    fallback_policy: {
+      trigger: "primary_unavailable_at_execution",
+      selection: "first_still_runnable_in_order",
+      preserve_primary_blocker: true,
+      max_fallback_actions: maximum,
+    },
+    fallback_actions: fallbackActions,
+    unavailable_higher_priority: unavailableHigherPriority,
+  };
+}

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -1159,6 +1159,8 @@ def _build_interaction_agent_channel(
         "quiet_noop_allowed": quiet_noop_allowed,
     }
     channel.update(build_primary_action_projection(payload, mode=mode))
+    if isinstance(payload.get("action_portfolio"), dict):
+        channel["action_portfolio_ref"] = "$.action_portfolio"
     if capability_reentry is not None:
         candidate = capability_reentry["candidates"][0]
         target = candidate["verification_target"]

--- a/tests/control_plane/test_actual_default_model_behavior_portfolio.py
+++ b/tests/control_plane/test_actual_default_model_behavior_portfolio.py
@@ -608,6 +608,19 @@ def test_live_packet_builder_uses_production_blocking_gate_plan(tmp_path: Path) 
     assert "next_task_action.operation" in (
         capability_signature["action"]["primary_action"]
     )
+    future_fallback = packets["turn_future_primary_fallback"]
+    future_signature = quota_action_signature_document(future_fallback)
+    assert future_signature["action"]["selected_todo"]["todo_id"] == (
+        "todo_ready_fallback"
+    )
+    future_portfolio = future_signature["action"]["action_portfolio"]
+    assert future_portfolio["primary"]["todo_id"] == "todo_ready_fallback"
+    assert future_portfolio["unavailable_higher_priority"][0]["todo_id"] == (
+        "todo_future_primary"
+    )
+    assert future_portfolio["unavailable_higher_priority"][0][
+        "availability_reason"
+    ] == "scheduled_for_future"
     regression_source = build_quota_hot_path_compaction_regression_source()
     regression = packets["turn_quota_hot_path_compaction_regression"]
     assert (
@@ -830,7 +843,7 @@ def test_catalog_declares_independent_bounded_repeat_policy() -> None:
     }
 
     assert catalog["topology"] == "actual_default_one_arm"
-    assert len(catalog["scenarios"]) == 16
+    assert len(catalog["scenarios"]) == 17
     assert all(
         scenario["packet_view"]
         == (
@@ -1007,10 +1020,10 @@ def test_portfolio_turn_actor_reads_actual_default_packet_without_semantic_echo(
     )
 
     assert result["qualification_passed"] is True
-    assert result["scenario_count"] == 16
+    assert result["scenario_count"] == 17
     assert result["contrast_count"] == 4
-    assert result["actor_call_budget"] == 32
-    assert result["actor_call_count"] == 32
+    assert result["actor_call_budget"] == 34
+    assert result["actor_call_count"] == 34
     assert result["failure_count"] == 0
     assert result["skip_count"] == 0
     assert result["contrast_failure_count"] == 0
@@ -1042,7 +1055,7 @@ def test_portfolio_real_tool_scenarios_choose_from_latest_quota_result(
     boundary = result["boundary"]
     assert boundary["tools_enabled"] is True
     assert boundary["tool_enabled_scenario_count"] == 5
-    assert boundary["packet_interpretation_scenario_count"] == 11
+    assert boundary["packet_interpretation_scenario_count"] == 12
     assert boundary["automatic_retries"] is False
     assert boundary["raw_model_responses_persisted"] is False
     assert boundary["raw_packets_persisted"] is False

--- a/tests/control_plane/test_cli_output_differential.py
+++ b/tests/control_plane/test_cli_output_differential.py
@@ -13,6 +13,7 @@ from loopx.control_plane.testing.cli_output_differential import (
     select_cli_output_base_ref,
 )
 from loopx.control_plane.testing.cli_output_semantics import (
+    action_portfolio_schema_versions,
     action_signature_coverages,
 )
 
@@ -35,6 +36,7 @@ def _row(**overrides: object) -> dict[str, object]:
         "markdown_anchor": "# LoopX Status",
         "action_signature_sha256": "semantic-signature",
         "action_signature_coverages": ["turn_envelope_action_dimensions_v0"],
+        "action_portfolio_schema_versions": [],
     }
     row.update(overrides)
     return row
@@ -105,6 +107,16 @@ def test_measurement_records_semantic_shape_without_runtime_hash_noise() -> None
     assert action_signature_coverages(json.loads(payload("first", "source"))) == [
         "turn_envelope_action_dimensions_v0",
     ]
+    assert action_portfolio_schema_versions(
+        {
+            "action_portfolio": {"schema_version": "quota_action_portfolio_v0"},
+            "nested": {
+                "action_portfolio": {
+                    "schema_version": "quota_action_portfolio_v0"
+                }
+            },
+        }
+    ) == ["quota_action_portfolio_v0"]
 
     with_observability_field = json.loads(payload("third-runtime", "third-source"))
     with_observability_field["action_signature"]["diagnostic_note"] = "new"
@@ -190,15 +202,77 @@ def test_action_portfolio_coverage_migration_requires_review() -> None:
     candidate = _row(
         action_signature_sha256="portfolio-semantic-signature",
         action_signature_coverages=["turn_envelope_action_dimensions_v2"],
+        chars=41_000,
+        utf8_bytes=41_000,
+        lines=1_030,
+        compact_payload_chars=20_750,
     )
 
     result = compare_cli_output_receipts(_receipt(_row()), _receipt(candidate))
 
     assert result["ok"] is True
     assert result["review_required"] is True
+    assert result["rows"][0]["allowances"] == {
+        "chars": 1_280,
+        "utf8_bytes": 1_280,
+        "lines": 36,
+        "compact_payload_chars": 896,
+    }
     assert result["rows"][0]["review_signals"] == [
         "action_signature coverage migrated: "
         "turn_envelope_action_dimensions_v0 -> turn_envelope_action_dimensions_v2"
+    ]
+
+
+def test_action_portfolio_migration_still_fails_above_bounded_growth() -> None:
+    candidate = _row(
+        action_signature_sha256="oversized-portfolio-semantic-signature",
+        action_signature_coverages=["turn_envelope_action_dimensions_v2"],
+        chars=41_281,
+    )
+
+    result = compare_cli_output_receipts(_receipt(_row()), _receipt(candidate))
+
+    assert result["ok"] is False
+    assert "chars grew by 1281; allowance is 1280" in (
+        result["rows"][0]["failures"]
+    )
+
+
+def test_quota_action_portfolio_schema_migration_has_same_bounded_budget() -> None:
+    candidate = _row(
+        action_signature_sha256=None,
+        action_signature_coverages=[],
+        action_portfolio_schema_versions=["quota_action_portfolio_v0"],
+        chars=41_000,
+        utf8_bytes=41_000,
+        lines=1_030,
+        compact_payload_chars=20_750,
+    )
+    base = _row(
+        action_signature_sha256=None,
+        action_signature_coverages=[],
+    )
+
+    result = compare_cli_output_receipts(_receipt(base), _receipt(candidate))
+
+    assert result["ok"] is True
+    assert result["review_required"] is True
+    assert result["rows"][0]["review_signals"] == [
+        "action_portfolio schema migrated: none -> quota_action_portfolio_v0"
+    ]
+
+
+def test_unknown_action_portfolio_schema_migration_fails_closed() -> None:
+    candidate = _row(
+        action_portfolio_schema_versions=["quota_action_portfolio_v1"],
+    )
+
+    result = compare_cli_output_receipts(_receipt(_row()), _receipt(candidate))
+
+    assert result["ok"] is False
+    assert result["rows"][0]["failures"] == [
+        "action_portfolio schema coverage changed"
     ]
 
 

--- a/tests/control_plane/test_cli_output_differential.py
+++ b/tests/control_plane/test_cli_output_differential.py
@@ -186,10 +186,26 @@ def test_declared_action_signature_coverage_migration_requires_review() -> None:
     ]
 
 
+def test_action_portfolio_coverage_migration_requires_review() -> None:
+    candidate = _row(
+        action_signature_sha256="portfolio-semantic-signature",
+        action_signature_coverages=["turn_envelope_action_dimensions_v2"],
+    )
+
+    result = compare_cli_output_receipts(_receipt(_row()), _receipt(candidate))
+
+    assert result["ok"] is True
+    assert result["review_required"] is True
+    assert result["rows"][0]["review_signals"] == [
+        "action_signature coverage migrated: "
+        "turn_envelope_action_dimensions_v0 -> turn_envelope_action_dimensions_v2"
+    ]
+
+
 def test_unknown_action_signature_coverage_migration_fails_closed() -> None:
     candidate = _row(
         action_signature_sha256="unknown-semantic-signature",
-        action_signature_coverages=["turn_envelope_action_dimensions_v2"],
+        action_signature_coverages=["turn_envelope_action_dimensions_v3"],
     )
 
     result = compare_cli_output_receipts(_receipt(_row()), _receipt(candidate))

--- a/tests/control_plane/test_quota_action_portfolio.py
+++ b/tests/control_plane/test_quota_action_portfolio.py
@@ -142,3 +142,18 @@ def test_typed_future_monitor_selects_ready_work_and_preserves_priority() -> Non
     assert unavailable[0]["todo_id"] == PRIMARY_ID
     assert unavailable[0]["availability_reason"] == "scheduled_for_future"
     assert unavailable[0]["next_due_at"] == "2099-01-01T00:00:00Z"
+
+
+def test_receipt_bound_turn_cannot_switch_to_a_fallback_todo() -> None:
+    packet = build_quota_should_run(
+        _legacy_future_primary_status(),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        receipt_bound_todo_id=PRIMARY_ID,
+    )
+
+    assert packet["selected_todo"]["todo_id"] == PRIMARY_ID
+    assert packet["agent_lane_next_action"]["selection_binding"] == (
+        "heartbeat_receipt"
+    )
+    assert "action_portfolio" not in packet

--- a/tests/control_plane/test_quota_action_portfolio.py
+++ b/tests/control_plane/test_quota_action_portfolio.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from loopx.control_plane.effect_program import interpret_quota_should_run_packet
+from loopx.control_plane.quota.cli_projection import (
+    compact_quota_should_run_cli_payload,
+)
+from loopx.control_plane.quota.should_run import build_quota_should_run
+from loopx.control_plane.quota.turn_envelope import (
+    ACTION_SIGNATURE_COVERAGE_V2,
+    build_turn_envelope,
+)
+from loopx.control_plane.testing.quota_fixtures import (
+    quota_status_payload,
+    quota_todo_item,
+)
+
+
+GOAL_ID = "action-portfolio-fixture"
+AGENT_ID = "codex-main"
+PRIMARY_ID = "todo_primary001"
+FALLBACK_ID = "todo_fallback001"
+
+
+def _legacy_future_primary_status() -> dict:
+    fallback = quota_todo_item(
+        todo_id=FALLBACK_ID,
+        index=2,
+        priority="P2",
+        title="Advance the independent fallback slice.",
+        claimed_by=AGENT_ID,
+    )
+    primary = quota_todo_item(
+        todo_id=PRIMARY_ID,
+        index=1,
+        priority="P0",
+        title="Run the Monday-only primary operation after its window opens.",
+        claimed_by=AGENT_ID,
+        action_kind="monitor",
+    )
+    return quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        agent_todo_items=[primary, fallback],
+        recommended_action=primary["text"],
+        next_action=primary["text"],
+        coordination={
+            "agent_model": "peer_v1",
+            "registered_agents": [AGENT_ID],
+        },
+        claim_scope_agent_id=AGENT_ID,
+        latest_runs=[
+            {
+                "generated_at": "2026-08-22T10:00:00Z",
+                "classification": "bounded_implementation_progress",
+                "progress_scope": "agent_lane",
+                "agent_id": AGENT_ID,
+                "todo_id": PRIMARY_ID,
+                "delivery_outcome": "outcome_progress",
+                "recommended_action": primary["text"],
+            }
+        ],
+    )
+
+
+def test_sticky_primary_exposes_bounded_fallback_on_every_hot_path() -> None:
+    packet = build_quota_should_run(
+        _legacy_future_primary_status(),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+
+    assert packet["selected_todo"]["todo_id"] == PRIMARY_ID
+    portfolio = packet["action_portfolio"]
+    assert portfolio["primary"]["todo_id"] == PRIMARY_ID
+    assert [item["todo_id"] for item in portfolio["fallback_actions"]] == [
+        FALLBACK_ID
+    ]
+    assert portfolio["fallback_policy"]["trigger"] == (
+        "primary_unavailable_at_execution"
+    )
+    assert packet["interaction_contract"]["agent_channel"][
+        "action_portfolio_ref"
+    ] == "$.action_portfolio"
+
+    compact = compact_quota_should_run_cli_payload(packet)
+    assert compact["action_portfolio"] == portfolio
+    effect_turn = interpret_quota_should_run_packet(packet)
+    assert effect_turn.observation.action_portfolio == portfolio
+
+    envelope = build_turn_envelope(packet)
+    assert envelope["action"]["action_portfolio"] == portfolio
+    assert envelope["action_signature"]["coverage"] == (
+        ACTION_SIGNATURE_COVERAGE_V2
+    )
+    assert envelope["action_signature"]["matches"] is True
+    assert envelope["compaction"]["within_budget"] is True
+
+
+def test_typed_future_monitor_selects_ready_work_and_preserves_priority() -> None:
+    future_monitor = quota_todo_item(
+        todo_id=PRIMARY_ID,
+        index=1,
+        priority="P0",
+        title="Poll the primary target at its next due window.",
+        claimed_by=AGENT_ID,
+        task_class="continuous_monitor",
+        action_kind="monitor",
+        target_key="fixture-primary",
+        cadence="daily",
+        next_due_at="2099-01-01T00:00:00Z",
+        watch_only=True,
+    )
+    fallback = quota_todo_item(
+        todo_id=FALLBACK_ID,
+        index=2,
+        priority="P1",
+        title="Advance the ready fallback slice.",
+        claimed_by=AGENT_ID,
+    )
+    status = quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        agent_todo_items=[future_monitor, fallback],
+        recommended_action=future_monitor["text"],
+        next_action=future_monitor["text"],
+        coordination={
+            "agent_model": "peer_v1",
+            "registered_agents": [AGENT_ID],
+        },
+        claim_scope_agent_id=AGENT_ID,
+    )
+
+    packet = build_quota_should_run(
+        status,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+
+    assert packet["selected_todo"]["todo_id"] == FALLBACK_ID
+    assert packet["recommended_action"] == fallback["text"]
+    unavailable = packet["action_portfolio"]["unavailable_higher_priority"]
+    assert unavailable[0]["todo_id"] == PRIMARY_ID
+    assert unavailable[0]["availability_reason"] == "scheduled_for_future"
+    assert unavailable[0]["next_due_at"] == "2099-01-01T00:00:00Z"

--- a/tests/control_plane_ts/action_portfolio.test.ts
+++ b/tests/control_plane_ts/action_portfolio.test.ts
@@ -89,4 +89,17 @@ test("malformed candidates fail closed at the typed boundary", () => {
     }),
     /todo_id/,
   );
+  assert.throws(
+    () => projectQuotaActionPortfolio({
+      schema_version: ACTION_PORTFOLIO_REQUEST_SCHEMA_VERSION,
+      primary: candidate("todo_primary001", "Run the primary slice.", "P0"),
+      candidates: [
+        {
+          ...candidate("todo_blocked001", "Blocked work.", "P1"),
+          status: "blocked",
+        },
+      ],
+    }),
+    /status must be open/,
+  );
 });

--- a/tests/control_plane_ts/action_portfolio.test.ts
+++ b/tests/control_plane_ts/action_portfolio.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ACTION_PORTFOLIO_REQUEST_SCHEMA_VERSION,
+  projectQuotaActionPortfolio,
+} from "../../loopx/control_plane/work_items/action_portfolio.ts";
+
+function candidate(todoId: string, text: string, priority: string) {
+  return {
+    todo_id: todoId,
+    text,
+    priority,
+    status: "open",
+    task_class: "advancement_task",
+    claimed_by: "codex-main",
+  };
+}
+
+test("action portfolio preserves primary and bounds ordered fallbacks", () => {
+  const primary = candidate("todo_primary001", "Run the primary slice.", "P0");
+  const result = projectQuotaActionPortfolio({
+    schema_version: ACTION_PORTFOLIO_REQUEST_SCHEMA_VERSION,
+    primary,
+    candidates: [
+      primary,
+      candidate("todo_fallback001", "Run fallback one.", "P1"),
+      candidate("todo_fallback001", "Duplicate fallback one.", "P1"),
+      candidate("todo_fallback002", "Run fallback two.", "P2"),
+      candidate("todo_fallback003", "Run fallback three.", "P3"),
+    ],
+    unavailable_higher_priority: [],
+    max_fallback_actions: 2,
+  });
+
+  assert.equal(result?.schema_version, "quota_action_portfolio_v0");
+  assert.deepEqual(
+    (result?.fallback_actions as Array<Record<string, unknown>>).map(
+      (item) => item.todo_id,
+    ),
+    ["todo_fallback001", "todo_fallback002"],
+  );
+  assert.deepEqual(result?.fallback_policy, {
+    trigger: "primary_unavailable_at_execution",
+    selection: "first_still_runnable_in_order",
+    preserve_primary_blocker: true,
+    max_fallback_actions: 2,
+  });
+});
+
+test("future or blocked higher priority work keeps the portfolio visible", () => {
+  const result = projectQuotaActionPortfolio({
+    schema_version: ACTION_PORTFOLIO_REQUEST_SCHEMA_VERSION,
+    primary: candidate("todo_fallback001", "Run the ready fallback.", "P1"),
+    candidates: [],
+    unavailable_higher_priority: [
+      {
+        ...candidate("todo_monitor001", "Poll at the next window.", "P0"),
+        task_class: "continuous_monitor",
+        availability_reason: "scheduled_for_future",
+        next_due_at: "2099-01-01T00:00:00Z",
+      },
+    ],
+  });
+
+  assert.equal(
+    (result?.unavailable_higher_priority as Array<Record<string, unknown>>)[0]
+      .availability_reason,
+    "scheduled_for_future",
+  );
+  assert.deepEqual(result?.fallback_actions, []);
+});
+
+test("a single primary needs no redundant portfolio", () => {
+  assert.equal(projectQuotaActionPortfolio({
+    schema_version: ACTION_PORTFOLIO_REQUEST_SCHEMA_VERSION,
+    primary: candidate("todo_primary001", "Run the only slice.", "P0"),
+    candidates: [],
+    unavailable_higher_priority: [],
+  }), null);
+});
+
+test("malformed candidates fail closed at the typed boundary", () => {
+  assert.throws(
+    () => projectQuotaActionPortfolio({
+      schema_version: ACTION_PORTFOLIO_REQUEST_SCHEMA_VERSION,
+      primary: candidate("todo_primary001", "Run the primary slice.", "P0"),
+      candidates: [{ text: "missing typed identity" }],
+    }),
+    /todo_id/,
+  );
+});


### PR DESCRIPTION
Fixes #3512.

## Root cause

`quota should-run` exposed one scalar hot-path action even when the same agent had other scope- and capability-admitted work. Delivery continuity could legitimately keep an open Todo selected after `outcome_progress`; if legacy state had typed future work as `advancement_task`, neither the selector nor the host could infer a time gate from prose. The remaining runnable candidates survived only in cold diagnostic lists, so weaker models repeatedly retried the selected P0.

## Change

- add the typed `quota_action_portfolio_v0` contract: selected primary plus at most two ordered fallbacks, activated only when the primary is unavailable at its real execution call site;
- keep Python responsible for agent-scope/capability admission while a TypeScript reducer validates identities, deduplicates, bounds, and fixes portfolio semantics;
- recognize correctly typed future `continuous_monitor` work as unavailable higher-priority context and select the next executable advancement Todo without guessing from text;
- retain the portfolio in default CLI compaction, Effect observation, interaction reference, Turn envelope, and action signature (`turn_envelope_action_dimensions_v2`);
- add deterministic legacy-sticky and typed-future regressions plus an actual-default model-behavior scenario;
- extract portfolio assembly and scenario validation from existing decision functions so the maintainability ratchet remains clean.

This is additive for consumers. `recommended_action` and `selected_todo` remain the normal primary route. Fallback does not authorize eager priority inversion: it activates only after primary execution unavailability and preserves the primary blocker.

## Validation

- `npm run typecheck:control-plane`
- `npm run test:control-plane` — 103 passed
- focused Python suite — 141 passed
- CLI output budget/differential suite — 34 passed
- `python -m mypy`
- touched-file `ruff check`
- `loopx check` — no errors (unrelated existing runtime warnings only)
- live Doubao future-primary scenario — 2/2 selected `todo_ready_fallback`, both `execute`, no safety violations
- base/head CLI differential — typed portfolio/action-signature migrations passed their one-version bounded growth gate; unknown or oversized migrations fail closed
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` — 18/18 passed, no manual holds
- change-quality receipt `cqr_6c354c74a3ca72437ead` — valid for the exact 23-file diff

## Future-facing pass

Applied at the adjacent ownership boundary: portfolio state/effect semantics now live in TypeScript; Python only adapts existing projections. No broader todo or quota migration was needed.
