### PR TITLE
fix(benchmark): classify non-http git clones as network

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/integrity.py
+++ b/loopx/capabilities/benchmark_toolkit/integrity.py
@@ -112,6 +112,10 @@ _PATH_LIKE_LABEL_PATTERN = re.compile(
 )
 _NETWORK_COMMAND_PATTERN = re.compile(r"(?is)\b(?:curl|wget)\b|\bgit\s+clone\b")
 _HTTP_URL_PATTERN = re.compile(r"(?is)https?://[^\s\"'<>]+")
+_GIT_CLONE_COMMAND_PATTERN = re.compile(r"(?is)\bgit\s+clone\b")
+_GIT_REMOTE_PATTERN = re.compile(
+    r"(?is)(?:\b(?:git|ssh)://[^\s\"'<>]+|(?<![A-Za-z0-9_.@/-])[A-Za-z0-9_.-]+@[A-Za-z0-9_.-]+:[^\s\"'<>]+)"
+)
 _COMMAND_TEXT_FIELDS = ("cmd", "command")
 _COMMAND_ARGUMENT_FIELDS = ("args", "argv")
 # ATIF currently carries a function name rather than a typed side-effect class.
@@ -358,6 +362,8 @@ def _network_request_scope(arguments: object) -> NetworkRequestScope:
     for text in command_texts:
         if not _NETWORK_COMMAND_PATTERN.search(text):
             continue
+        if _GIT_CLONE_COMMAND_PATTERN.search(text) and _GIT_REMOTE_PATTERN.search(text):
+            return NetworkRequestScope.EXTERNAL
         for url in _HTTP_URL_PATTERN.finditer(text):
             current = _scope_for_url(url.group(0))
             if current is NetworkRequestScope.EXTERNAL:

--- a/tests/capabilities/test_benchmark_toolkit.py
+++ b/tests/capabilities/test_benchmark_toolkit.py
@@ -419,6 +419,48 @@ def test_structured_external_network_requests_remain_fail_closed(
     assert receipt["evidence_counts"]["external_network_request"] == 1
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git clone git@github.com:owner/repo.git",
+        "git clone ssh://git@github.com/owner/repo.git",
+        "git clone git://github.com/owner/repo.git",
+    ],
+)
+def test_non_http_git_clone_requests_remain_fail_closed(command: str) -> None:
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(command=command),
+        runtime_attestation=_attestation(),
+    )
+
+    assert receipt["integrity_qualified"] is False
+    assert receipt["classification"] == "integrity_policy_violation"
+    assert receipt["evidence_counts"]["external_network_request"] == 1
+
+
+def test_structured_non_http_git_clone_request_remains_fail_closed() -> None:
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(
+            arguments={"argv": ["git", "clone", "git@github.com:owner/repo.git"]}
+        ),
+        runtime_attestation=_attestation(),
+    )
+
+    assert receipt["integrity_qualified"] is False
+    assert receipt["classification"] == "integrity_policy_violation"
+    assert receipt["evidence_counts"]["external_network_request"] == 1
+
+
+def test_local_git_clone_path_is_not_network_access() -> None:
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(command="git clone ../fixture-repo worktree"),
+        runtime_attestation=_attestation(),
+    )
+
+    assert receipt["integrity_qualified"] is True
+    assert receipt["evidence_counts"]["external_network_request"] == 0
+
+
 def test_structured_loopback_argv_uses_explicit_loopback_scope() -> None:
     receipt = build_benchmark_integrity_qualification(
         trajectory=_trajectory(

--- a/tests/capabilities/test_benchmark_toolkit.py
+++ b/tests/capabilities/test_benchmark_toolkit.py
@@ -461,6 +461,53 @@ def test_local_git_clone_path_is_not_network_access() -> None:
     assert receipt["evidence_counts"]["external_network_request"] == 0
 
 
+def test_http_git_clone_remains_external_network_access() -> None:
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(command="git clone https://github.com/owner/repo.git"),
+        runtime_attestation=_attestation(),
+    )
+
+    assert receipt["integrity_qualified"] is False
+    assert receipt["classification"] == "integrity_policy_violation"
+    assert receipt["evidence_counts"]["external_network_request"] == 1
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git clone -b main --depth 1 git@github.com:owner/repo.git",
+        "git clone git+ssh://git@github.com/owner/repo.git",
+    ],
+)
+def test_non_http_git_clone_variants_remain_fail_closed(command: str) -> None:
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(command=command),
+        runtime_attestation=_attestation(),
+    )
+
+    assert receipt["integrity_qualified"] is False
+    assert receipt["classification"] == "integrity_policy_violation"
+    assert receipt["evidence_counts"]["external_network_request"] == 1
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git clone /abs/path/repo.git",
+        "git clone file:///abs/path/repo.git",
+        "git clone /tmp/cache@2/repo.git",
+    ],
+)
+def test_local_git_clone_paths_are_not_external_network_access(command: str) -> None:
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(command=command),
+        runtime_attestation=_attestation(),
+    )
+
+    assert receipt["integrity_qualified"] is True
+    assert receipt["evidence_counts"]["external_network_request"] == 0
+
+
 def test_structured_loopback_argv_uses_explicit_loopback_scope() -> None:
     receipt = build_benchmark_integrity_qualification(
         trajectory=_trajectory(


### PR DESCRIPTION
## Root Cause

The benchmark integrity scanner recognized `git clone` as a network-capable command, but it only classified network access when the command text also contained an `http(s)://` URL. Common clone forms such as `git@github.com:owner/repo.git`, `ssh://git@github.com/owner/repo.git`, and `git://github.com/owner/repo.git` therefore produced no `external_network_request` evidence.

That means an offline benchmark trajectory could clone from a remote repository over SSH/git protocol and still be marked `integrity_qualified=true` as long as the runner attested the default denied-network runtime fields. The failure sits in `_network_request_scope()`: command detection and URL classification were split, and non-HTTP git remotes fell through to `NetworkRequestScope.NONE`.

## Options Considered

| Option | Impact | Performance | Fit | Decision |
| --- | --- | --- | --- | --- |
| Treat every `git clone` without HTTP URL as external | Maximum fail-closed behavior | Constant-time regex scan | Too broad; local path clones would be false positives | Rejected |
| Add explicit non-HTTP git remote detection | Covers real external clone forms while preserving local clones | Constant-time regex scan over command text | Matches existing regex-based private trajectory audit | Selected |
| Shell-parse commands with a dedicated parser | More precise long-term | More complexity/dependency risk | Too large for this boundary fix | Deferred |

## What Changed

- Added a narrow git remote detector for `git://`, `ssh://`, and scp-like `user@host:path` clone targets.
- `_network_request_scope()` now returns `external` when a `git clone` command carries one of those remote forms.
- Added regressions for string commands, structured argv, and local path clone non-regression.

No new dependencies. No TS migration: this is the benchmark toolkit Python integrity reducer, not an existing TypeScript control-plane effect/state owner.

## Validation

- `/opt/homebrew/bin/uv run --with 'pytest>=8,<9' python -m pytest tests/capabilities/test_benchmark_toolkit.py -q`
- `/opt/homebrew/bin/uv run --with 'ruff>=0.6,<1' ruff check loopx/capabilities/benchmark_toolkit/integrity.py tests/capabilities/test_benchmark_toolkit.py`
- `git diff --check`
- `/opt/homebrew/bin/uv run python -m loopx.cli canary premerge --from-git-diff`

Canary result: `manual_review_required` with no check failures. The manual hold is expected because this touches benchmark-sensitive integrity policy code.

## Risk

Low-to-medium. This intentionally makes SSH/git-protocol remote clones count as external network access in benchmark integrity receipts. Local path clones remain allowed and covered by regression. Because this is benchmark-sensitive evidence code, it should receive maintainer review before merge.
