### PR TITLE
docs(benchmark): add engineering construction plan

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -18,6 +18,29 @@ This directory may contain thin examples and practice notes, but it is not
 installed as a second LoopX Python package and does not grant execution or
 publication authority.
 
+## Engineering build map
+
+The canonical engineering plan is [Section 11 of the research
+RFC](../docs/architecture/rfcs/long-horizon-harness-benchmark-research-program-v0.md#11-engineering-construction-plan).
+It separates repository readiness from benchmark claims:
+
+- **E0--E1:** typed contracts, public/private boundaries, native runner
+  preflight, and one conformance slice;
+- **E2:** experiment-board lifecycle, concurrency admission, exact runtime
+  observation, continuity, reconciliation, and safe closeout;
+- **E3:** preregistered matched arms, treatment fidelity, integrity,
+  countability, and uncertainty;
+- **E4:** cross-benchmark replication and non-benchmark product qualification.
+
+The active workspace should keep benchmark-family launch, verifier, scoring, and
+failure semantics in adapters while reusable permission, integrity, lifecycle,
+and public-safe projection rules stay in
+[`benchmark-toolkit`](../loopx/capabilities/benchmark_toolkit/README.md).
+Contributors should start with a bounded synthetic fixture or conformance seam;
+live tasks, hidden evaluation, credentials, raw trajectories, submissions, and
+unpublished comparisons remain maintainer-owned. Engineering readiness does not
+by itself establish a C2 uplift claim.
+
 ## Current work
 
 - [`deepswe/README.md`](deepswe/README.md) records the current public-safe

--- a/docs/architecture/rfcs/long-horizon-harness-benchmark-research-program-v0.md
+++ b/docs/architecture/rfcs/long-horizon-harness-benchmark-research-program-v0.md
@@ -676,7 +676,150 @@ The goal is not to fork each benchmark into a LoopX edition. It is to make
 LoopX a well-behaved harness participant whose results can be reproduced and
 audited by benchmark maintainers.
 
-## 11. Research Program Milestones
+## 11. Engineering Construction Plan
+
+The research contract above says what a benchmark result may prove. This
+section says how the repository should build, validate, and operate the
+supporting engineering. The two ladders are intentionally orthogonal:
+
+- **Engineering readiness** describes whether a reusable contract, runner seam,
+  evidence boundary, and operational path are implemented and qualified.
+- **Claim level (C0--C4)** describes what the resulting experiment is allowed to
+  say about LoopX. Reaching an engineering stage never upgrades a research
+  claim by itself.
+
+### 11.1 Ownership layers
+
+Build each benchmark integration in these layers, from the most reusable to the
+most benchmark-specific:
+
+1. **Provider-neutral toolkit**
+   - owns typed permissions, source and artifact boundaries, integrity receipts,
+     runtime observations, experiment-board projections, countability gates,
+     and public-safe post-run contracts;
+   - grants no runner, model, Docker, verifier, upload, submission, or
+     publication authority.
+2. **Native runtime bridge**
+   - owns the real host transaction used by a supported harness, such as the
+     native Codex Goal transport and continuation lifecycle;
+   - keeps process, environment, and task-bridge authority with the runner.
+3. **Benchmark adapter**
+   - owns task provisioning, benchmark-native lifecycle, verifier invocation,
+     score reduction, checkpoint semantics, and benchmark-specific failure
+     attribution;
+   - must import toolkit contracts instead of recreating generic state or
+     integrity logic.
+4. **Study and analysis layer**
+   - owns manifests, preregistered arm selection, paired comparisons,
+     uncertainty, and offline interpretation;
+   - may not grant runtime authority or rewrite benchmark-native results.
+
+Do not create a second active benchmark package, a generic score authority, or a
+benchmark-specific capability merely to make a runner installable. A new
+module needs a real caller, a named owner, a focused contract, and a validation
+surface in the same change or an explicitly staged follow-up.
+
+### 11.2 Engineering readiness stages
+
+Use these stages in PRs, contributor tasks, and pilot updates. They are delivery
+gates, not release promises:
+
+- **E0 -- Contract and boundary foundation**
+  - typed schema and ownership decision recorded;
+  - public/private and authority boundaries have negative coverage;
+  - no live benchmark run is required.
+- **E1 -- Native runner conformance**
+  - a pinned public-safe runner path can preflight, execute, verify, and reduce
+    one synthetic or approved task slice;
+  - source, runtime, treatment, and integrity receipts are emitted without raw
+    task material;
+  - setup, solver, verifier, and scoring failures remain distinguishable.
+- **E2 -- Campaign operations**
+  - experiment-board identity, concurrency admission, exact-job observation,
+    runtime continuity, terminal closeout, and safe reconciliation work across
+    repeated transitions;
+  - a provider can recover or quarantine an invalid run without changing the
+    score authority.
+- **E3 -- Matched-study readiness**
+  - baseline, passive, governed, and ablation arms have a declared manifest;
+  - task/model/harness/budget identity, treatment delivery, integrity, and
+    countability are independently checked;
+  - paired analysis and stopping rules are registered before outcome inspection.
+- **E4 -- Replication and promotion readiness**
+  - a named mechanism reproduces across a second benchmark family or has a
+    documented null result;
+  - protocol tax, uncertainty, authority risk, and public/private handling are
+    reviewed;
+  - non-benchmark product qualification and maintainer promotion remain
+    separate required gates.
+
+The current repository is strongest at E0--E2. E3 is the next engineering and
+research target; E4 remains a future promotion gate. A benchmark adapter may be
+technically E1-ready while its study is still C0, and a C2 result is not valid
+when its E2 runtime evidence is incomplete.
+
+### 11.3 Required delivery slice
+
+Every benchmark engineering PR or contributor task should identify a bounded
+slice containing:
+
+- the caller outcome and owning layer;
+- the schema or transition contract, including illegal states;
+- one real or synthetic call site;
+- characterization and negative or mutation coverage;
+- the compact public-safe receipt or projection;
+- the private-input boundary and artifact classification;
+- the exact validation commands and expected disposition;
+- documentation that links to this RFC without copying benchmark-specific truth
+  into generic toolkit docs.
+
+Prefer one complete vertical seam over a broad inactive framework. For example,
+an adapter should first prove one native preflight and one official-result
+reduction before adding a general campaign scheduler, a large ledger, or a
+benchmark-family abstraction with no caller.
+
+### 11.4 Community contribution routing
+
+Community contributors can work safely on public synthetic slices and reusable
+contracts:
+
+- adapter lifecycle and result-reduction fixtures;
+- integrity, source, artifact, and authority-parity negative tests;
+- experiment-board transitions, reconciliation, and concurrency reducers;
+- public-safe trajectory and case-insight projections;
+- manifest validation, matched-pair analysis, uncertainty, and protocol-tax
+  tooling;
+- benchmark-maintainer-friendly trace or runner conformance fixes;
+- documentation and examples that state claim level and non-goals.
+
+Live tasks, hidden verifiers, raw trajectories, credentials, official
+submissions, unpublished comparisons, and leaderboard operations remain
+maintainer-owned. A contributor task must state its target base branch, smallest
+useful slice, non-goals, and validation plan; an RFC or direction tracker alone
+does not authorize implementation.
+
+### 11.5 Engineering readiness review
+
+Before calling a slice ready, reviewers should answer:
+
+1. Is the behavior owned by the toolkit, native runtime, benchmark adapter, or
+   offline evaluator, and is that ownership visible in the code layout?
+2. Does a real caller exercise the new contract, or should the proposal remain
+   an RFC/fixture instead of production structure?
+3. Can an invalid, incomplete, or authority-mismatched run fail closed without
+   leaking private data or silently becoming countable?
+4. Are public receipts sufficient to explain classification without copying raw
+   evidence?
+5. Are benchmark-native score and LoopX control observations still separate?
+6. Does the validation cover the negative path and the next likely mutation?
+7. What is the highest C-level claim this engineering can support, and what
+   evidence is still missing?
+
+This review is deliberately part of ordinary engineering hygiene. It does not
+authorize a live run, a leaderboard submission, a capability promotion, or a
+change to LoopX defaults.
+
+## 12. Research Program Milestones
 
 ### M0: RFC and source registry
 
@@ -722,7 +865,7 @@ audited by benchmark maintainers.
 - evaluate capability candidates on held-out tasks;
 - require maintainer review and non-benchmark canaries before promotion.
 
-## 12. Acceptance Criteria
+## 13. Acceptance Criteria
 
 This RFC is successful when:
 
@@ -745,7 +888,7 @@ This RFC is successful when:
 14. production promotion requires product qualification beyond benchmark
     evidence.
 
-## 13. Non-Goals
+## 14. Non-Goals
 
 - One universal long-horizon score or leaderboard.
 - Replacing benchmark-native harnesses, graders, or submission rules.
@@ -757,7 +900,7 @@ This RFC is successful when:
 - Requiring ALE, LHTB, and DeepSWE to share one runner implementation.
 - Claiming model capability when the experiment changed the harness.
 
-## 14. Risks and Mitigations
+## 15. Risks and Mitigations
 
 | Risk | Mitigation |
 |---|---|
@@ -774,7 +917,7 @@ This RFC is successful when:
 | One mechanism bundles several behavior changes | Single-mechanism ablations before combined profiles. |
 | Research policy gains production authority | Offline evaluator and explicit maintainer promotion gate. |
 
-## 15. Open Research Questions
+## 16. Open Research Questions
 
 1. Which benchmark-native checkpoints are frequent enough for causal analysis
    without changing agent behavior?
@@ -793,7 +936,7 @@ This RFC is successful when:
 8. How should benchmark maintainers and harness researchers share trace schemas
    without standardizing away meaningful harness differences?
 
-## 16. RFC Maintenance Protocol
+## 17. RFC Maintenance Protocol
 
 This is a living research RFC, not a frozen benchmark snapshot.
 
@@ -818,8 +961,9 @@ This is a living research RFC, not a frozen benchmark snapshot.
 |---|---|
 | 2026-08-16 | Adopt ALE, LHTB, and DeepSWE as a complementary initial portfolio; separate capability evidence from mechanism research; require native outcomes and typed treatment integrity. |
 | 2026-08-16 | Make the current DeepSWE pilot the design-driving practice for the LoopX benchmark capability; treat legacy code/research as candidate reuse and add structured anti-cheating and authority-parity qualification. |
+| 2026-08-23 | Add an engineering readiness ladder and bounded delivery-slice rules so repository construction is tracked separately from C0--C4 research claims. |
 
-## 17. References
+## 18. References
 
 - [Agents' Last Exam project](https://agents-last-exam.org/)
 - [Agents' Last Exam paper](https://arxiv.org/abs/2606.05405)

--- a/docs/architecture/rfcs/long-horizon-harness-benchmark-research-program-v0.zh-CN.md
+++ b/docs/architecture/rfcs/long-horizon-harness-benchmark-research-program-v0.zh-CN.md
@@ -586,7 +586,127 @@ benchmark 协作应产生可 review 的 upstream value：
 目标不是 fork 出每个 benchmark 的 LoopX edition，而是让 LoopX 成为行为规范的 harness
 participant，其结果可以被 benchmark maintainer 复现和审计。
 
-## 11. 研究计划里程碑
+## 11. 工程建设计划
+
+上面的研究合同定义 benchmark 结果可以证明什么；本节定义仓库应该如何建设、验证和
+运行这些工程。两条阶梯刻意保持正交：
+
+- **工程 readiness** 描述可复用 contract、runner seam、evidence boundary 与运行路径
+  是否已经实现并通过 qualification；
+- **主张等级（C0--C4）** 描述实验最终可以对 LoopX 说什么。达到某个工程阶段不会
+  自动提升研究主张等级。
+
+### 11.1 Ownership 分层
+
+每个 benchmark integration 都应从最可复用到最具体地分成以下层：
+
+1. **Provider-neutral toolkit**
+   - 负责 typed permission、source/artifact boundary、integrity receipt、runtime
+     observation、experiment-board projection、countability gate 与 public-safe
+     post-run contract；
+   - 不授予 runner、model、Docker、verifier、upload、submission 或 publication authority。
+2. **Native runtime bridge**
+   - 负责支持的 harness 所使用的真实 host transaction，例如 native Codex Goal transport
+     与 continuation lifecycle；
+   - process、environment 与 task bridge authority 仍归 runner 所有。
+3. **Benchmark adapter**
+   - 负责 task provisioning、benchmark-native lifecycle、verifier invocation、score
+     reduction、checkpoint 语义与 benchmark-specific failure attribution；
+   - 必须导入 toolkit contract，不能重新实现 generic state 或 integrity logic。
+4. **Study 与 analysis layer**
+   - 负责 manifest、preregistered arm selection、paired comparison、uncertainty 与
+     offline interpretation；
+   - 不得授予 runtime authority，也不得重写 benchmark-native result。
+
+不要为了让 runner 可安装，就创建第二套 active benchmark package、generic score authority，
+或 benchmark-specific capability。新增 module 必须有真实 caller、明确 owner、聚焦 contract
+和同一变更中的 validation surface；否则应明确拆成后续阶段。
+
+### 11.2 工程 readiness 阶段
+
+在 PR、contributor task 与 pilot update 中统一使用以下阶段。它们是 delivery gate，不是
+release promise：
+
+- **E0：Contract 与 boundary foundation**
+  - 记录 typed schema 与 ownership 决策；
+  - public/private 和 authority boundary 有 negative coverage；
+  - 不要求 live benchmark run。
+- **E1：Native runner conformance**
+  - 一个固定的 public-safe runner path 能对 synthetic 或获准 task slice 完成 preflight、
+    execute、verify 与 reduce；
+  - source、runtime、treatment 与 integrity receipt 在不包含 raw task material 的情况下
+    生成；
+  - setup、solver、verifier 与 scoring failure 保持可区分。
+- **E2：Campaign operations**
+  - experiment-board identity、concurrency admission、exact-job observation、runtime
+    continuity、terminal closeout 与 safe reconciliation 能覆盖重复 transition；
+  - provider 可以恢复或 quarantine invalid run，而不改变 score authority。
+- **E3：Matched-study readiness**
+  - baseline、passive、governed 与 ablation arm 有声明过的 manifest；
+  - task/model/harness/budget identity、treatment delivery、integrity 与 countability
+    独立检查；
+  - paired analysis 与 stopping rule 在 outcome inspection 前注册。
+- **E4：Replication 与 promotion readiness**
+  - 一个命名机制在第二个 benchmark family 复现，或形成记录清晰的 null result；
+  - protocol tax、uncertainty、authority risk 与 public/private handling 经过 review；
+  - non-benchmark product qualification 与 maintainer promotion 仍是独立的必需 gate。
+
+当前仓库最强的是 E0--E2；E3 是下一阶段工程与研究目标，E4 仍是未来 promotion gate。
+一个 adapter 可以在工程上达到 E1，但其 study 仍然只有 C0；如果 E2 runtime evidence
+不完整，C2 result 也不成立。
+
+### 11.3 必需的 delivery slice
+
+每个 benchmark engineering PR 或 contributor task 都应声明一个有界 slice，包含：
+
+- caller outcome 与 owning layer；
+- schema 或 transition contract，包括 illegal state；
+- 一个真实或 synthetic call site；
+- characterization 以及 negative/mutation coverage；
+- compact public-safe receipt 或 projection；
+- private-input boundary 与 artifact classification；
+- 精确的 validation command 与 expected disposition；
+- 链接回本文的文档，而不是把 benchmark-specific truth 复制进 generic toolkit docs。
+
+优先交付完整的 vertical seam，而不是宽泛的 inactive framework。例如，adapter 应先证明
+一个 native preflight 和一个 official-result reduction，再考虑添加没有 caller 的通用
+campaign scheduler、大型 ledger 或 benchmark-family abstraction。
+
+### 11.4 社区贡献路由
+
+社区贡献者可以在公开 synthetic slice 和可复用 contract 上安全工作：
+
+- adapter lifecycle 与 result-reduction fixture；
+- integrity、source、artifact 与 authority-parity negative test；
+- experiment-board transition、reconciliation 与 concurrency reducer；
+- public-safe trajectory 与 case-insight projection；
+- manifest validation、matched-pair analysis、uncertainty 与 protocol-tax tooling；
+- 对 benchmark maintainer 友好的 trace 或 runner conformance fix；
+- 明确 claim level 与 non-goal 的文档和 example。
+
+Live task、hidden verifier、raw trajectory、credential、official submission、未公开比较
+和 leaderboard operation 仍由 maintainer 负责。Contributor task 必须写明目标 base branch、
+最小有用 slice、non-goal 与 validation plan；RFC 或 direction tracker 本身不授权实现。
+
+### 11.5 工程 readiness review
+
+在称一个 slice ready 之前，reviewer 应回答：
+
+1. 行为由 toolkit、native runtime、benchmark adapter 还是 offline evaluator 拥有，代码
+   布局是否表达了这个 ownership？
+2. 是否有真实 caller 执行新 contract？如果没有，提案是否应该停留在 RFC/fixture，而不是
+   变成 production structure？
+3. invalid、incomplete 或 authority-mismatched run 能否 fail closed，并且不泄露私有数据、
+   不会静默变成 countable？
+4. public receipt 是否足够解释 classification，而无需复制 raw evidence？
+5. benchmark-native score 与 LoopX control observation 是否仍然分离？
+6. validation 是否覆盖 negative path 和下一种可能 mutation？
+7. 这项工程最多支持哪个 C-level claim，还缺什么证据？
+
+该 review 是普通工程 hygiene 的一部分，不授权 live run、leaderboard submission、capability
+promotion 或修改 LoopX default。
+
+## 12. 研究计划里程碑
 
 ### M0：RFC 与 source registry
 
@@ -630,7 +750,7 @@ participant，其结果可以被 benchmark maintainer 复现和审计。
 - 在 held-out task 上评估 capability candidate；
 - promotion 前要求 maintainer review 与 non-benchmark canary。
 
-## 12. 验收标准
+## 13. 验收标准
 
 满足以下条件时，本 RFC 才算成功：
 
@@ -650,7 +770,7 @@ participant，其结果可以被 benchmark maintainer 复现和审计。
 13. 只有 current-pilot characterization 证明合同后，才复用现有 benchmark 代码；
 14. production promotion 需要 benchmark 证据之外的 product qualification。
 
-## 13. 非目标
+## 14. 非目标
 
 - 一个通用 long-horizon score 或 leaderboard。
 - 替换 benchmark-native harness、grader 或 submission rule。
@@ -661,7 +781,7 @@ participant，其结果可以被 benchmark maintainer 复现和审计。
 - 要求 ALE、LHTB 与 DeepSWE 使用同一个 runner implementation。
 - 在实验改变 harness 时主张 model capability。
 
-## 14. 风险与缓解
+## 15. 风险与缓解
 
 | 风险 | 缓解 |
 |---|---|
@@ -678,7 +798,7 @@ participant，其结果可以被 benchmark maintainer 复现和审计。
 | 一个机制打包多个行为变化 | combined profile 前先做 single-mechanism ablation。 |
 | Research policy 获得生产 authority | offline evaluator 与 maintainer promotion gate。 |
 
-## 15. 开放研究问题
+## 16. 开放研究问题
 
 1. 哪些 benchmark-native checkpoint 足够频繁，既能做因果分析，又不改变 agent 行为？
 2. provider 间 model/tool latency 差异很大时，应如何估计 protocol tax？
@@ -691,7 +811,7 @@ participant，其结果可以被 benchmark maintainer 复现和审计。
 8. benchmark maintainer 与 harness researcher 如何共享 trace schema，同时不抹平有意义的
    harness 差异？
 
-## 16. RFC 维护协议
+## 17. RFC 维护协议
 
 这是活的研究 RFC，不是冻结的 benchmark 快照。
 
@@ -711,8 +831,9 @@ participant，其结果可以被 benchmark maintainer 复现和审计。
 |---|---|
 | 2026-08-16 | 采用 ALE、LHTB 与 DeepSWE 作为互补初始组合；区分能力论证与机制研究；要求原生 outcome 与 typed treatment integrity。 |
 | 2026-08-16 | 以当前 DeepSWE pilot 驱动 LoopX benchmark capability 设计；legacy code/research 只作为复用候选，并加入结构化反作弊与 authority-parity qualification。 |
+| 2026-08-23 | 增加工程 readiness 阶梯与有界 delivery-slice 规则，将仓库建设与 C0--C4 研究主张分开跟踪。 |
 
-## 17. 参考资料
+## 18. 参考资料
 
 - [Agents' Last Exam 项目](https://agents-last-exam.org/)
 - [Agents' Last Exam 论文](https://arxiv.org/abs/2606.05405)


### PR DESCRIPTION
## Summary

- add an engineering construction section to the long-horizon benchmark RFC;
- keep the English and Chinese RFC mirrors synchronized;
- separate engineering readiness (E0-E4) from the C0-C4 research claim ladder;
- define ownership layers, bounded delivery slices, community contribution
  routing, and an engineering readiness review;
- add a short benchmark workspace build map that links to the RFC as the
  canonical source instead of duplicating the detailed plan.

## Why

The benchmark RFC defined what results may prove, but did not yet give
contributors a repository-level construction path. The new section makes the
toolkit, native runtime bridge, benchmark adapter, and offline study layers
explicit, while preserving benchmark-native score authority and the private
evidence boundary.

## Validation

- `python3 examples/docs-governance-smoke.py` — passed
- `loopx check --scan-path benchmark/README.md --scan-path docs/architecture/rfcs/long-horizon-harness-benchmark-research-program-v0.md --scan-path docs/architecture/rfcs/long-horizon-harness-benchmark-research-program-v0.zh-CN.md` — passed; 3 files scanned, 0 errors
- `git diff --check` — passed
- `loopx canary premerge --from-git-diff` — 18/18 selected checks passed, including public-boundary checks; the canary reports one manual hold because benchmark-sensitive surfaces require maintainer review

## Scope and review judgment

- docs-only change; no runner, scoring, permission, or benchmark task behavior
  changes;
- no raw tasks, trajectories, verifier output, credentials, local paths, or
  private evidence included;
- self-merge is appropriate after maintainer review because the change is
  single-purpose, public, reversible, and does not launch or alter a benchmark
  run.
