### PR TITLE
docs(benchmark): link bilingual engineering plan

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -20,8 +20,9 @@ publication authority.
 
 ## Engineering build map
 
-The canonical engineering plan is [Section 11 of the research
-RFC](../docs/architecture/rfcs/long-horizon-harness-benchmark-research-program-v0.md#11-engineering-construction-plan).
+The canonical engineering plan is [Section 11 of the English research
+RFC](../docs/architecture/rfcs/long-horizon-harness-benchmark-research-program-v0.md#11-engineering-construction-plan)
+and [中文第 11 节](../docs/architecture/rfcs/long-horizon-harness-benchmark-research-program-v0.zh-CN.md#11-工程建设计划).
 It separates repository readiness from benchmark claims:
 
 - **E0--E1:** typed contracts, public/private boundaries, native runner


### PR DESCRIPTION
## Summary

- link the benchmark workspace engineering map directly to both the English
  and Chinese RFC Section 11 anchors;
- keep the README as a short bilingual entry point while the RFC remains the
  canonical engineering plan.

## Validation

- `python3 examples/docs-governance-smoke.py` — passed
- `loopx check --scan-path benchmark/README.md` — passed; 1 file scanned, 0 errors
- `git diff --check` — passed

## Scope

- docs-only, single-purpose discoverability cleanup;
- no benchmark runner, scoring, permission, task, or evidence behavior changes;
- no private or generated artifacts included.
