### PR TITLE
fix(quota): make unknown workspace causality repairable

### DIFF
--- a/loopx/control_plane/quota/settlement_workspace_causality.py
+++ b/loopx/control_plane/quota/settlement_workspace_causality.py
@@ -20,6 +20,7 @@ DELIVERY_WORKSPACE_CAUSALITY_REQUEST_SCHEMA = (
 DELIVERY_WORKSPACE_CAUSALITY_RESULT_SCHEMA = (
     "loopx_delivery_workspace_causality_result_v0"
 )
+DELIVERY_WORKSPACE_RESOLUTION_SCHEMA_VERSION = "delivery_workspace_resolution_v0"
 DELIVERY_WORKSPACE_REQUIREMENTS = frozenset({"required", "not_required", "unknown"})
 
 
@@ -209,6 +210,81 @@ def delivery_workspace_causality_from_event_details(
             ),
         )
     )
+
+
+def missing_delivery_workspace_resolution(
+    causality: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Return the TS-owned admission decision for a missing workspace snapshot."""
+
+    prepared = _prepared_causality(causality)
+    if prepared is None:
+        return None
+    result = _runtime_result(
+        "missing_workspace",
+        expected_todo_id=None,
+        causality=prepared,
+    )
+    value = result.get("resolution")
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise RuntimeError(
+            "TypeScript delivery workspace resolution result shape mismatch"
+        )
+    decision = value.get("decision")
+    expected = {
+        "require_snapshot": (
+            "required",
+            "declared_workspace_snapshot_required",
+            False,
+        ),
+        "omit_snapshot": (
+            "not_required",
+            "explicit_non_delivery_contract",
+            False,
+        ),
+        "repair_contract": (
+            "unknown",
+            "todo_delivery_contract_not_explicit",
+            True,
+        ),
+    }.get(decision)
+    if expected is None:
+        raise RuntimeError(
+            "TypeScript delivery workspace resolution result shape mismatch"
+        )
+    requirement, reason, has_resolutions = expected
+    expected_keys = {
+        "schema_version",
+        "todo_id",
+        "decision",
+        "requirement",
+        "reason",
+    }
+    accepted_resolutions = value.get("accepted_resolutions")
+    if has_resolutions:
+        expected_keys.add("accepted_resolutions")
+    if (
+        set(value) != expected_keys
+        or value.get("schema_version")
+        != DELIVERY_WORKSPACE_RESOLUTION_SCHEMA_VERSION
+        or normalize_todo_id(value.get("todo_id")) != value.get("todo_id")
+        or value.get("requirement") != requirement
+        or value.get("reason") != reason
+        or (
+            has_resolutions
+            and accepted_resolutions
+            != [
+                "declare_repository_or_write_contract",
+                "declare_explicit_non_delivery_contract",
+            ]
+        )
+    ):
+        raise RuntimeError(
+            "TypeScript delivery workspace resolution result shape mismatch"
+        )
+    return dict(value)
 
 
 def completed_todo_workspace_causality(

--- a/loopx/control_plane/quota/settlement_workspace_causality.ts
+++ b/loopx/control_plane/quota/settlement_workspace_causality.ts
@@ -7,6 +7,8 @@ export const DELIVERY_WORKSPACE_CAUSALITY_REQUEST_SCHEMA =
   "loopx_delivery_workspace_causality_request_v0";
 export const DELIVERY_WORKSPACE_CAUSALITY_RESULT_SCHEMA =
   "loopx_delivery_workspace_causality_result_v0";
+export const DELIVERY_WORKSPACE_RESOLUTION_SCHEMA_VERSION =
+  "delivery_workspace_resolution_v0";
 
 export const DELIVERY_WORKSPACE_REQUIREMENTS = [
   "required",
@@ -29,7 +31,35 @@ type DeliveryWorkspaceCausalityOperation =
   | "classify"
   | "normalize"
   | "event_fields"
+  | "missing_workspace"
   | "from_event";
+
+export type DeliveryWorkspaceResolution =
+  | {
+      schema_version: typeof DELIVERY_WORKSPACE_RESOLUTION_SCHEMA_VERSION;
+      todo_id: string;
+      decision: "require_snapshot";
+      requirement: "required";
+      reason: "declared_workspace_snapshot_required";
+    }
+  | {
+      schema_version: typeof DELIVERY_WORKSPACE_RESOLUTION_SCHEMA_VERSION;
+      todo_id: string;
+      decision: "omit_snapshot";
+      requirement: "not_required";
+      reason: "explicit_non_delivery_contract";
+    }
+  | {
+      schema_version: typeof DELIVERY_WORKSPACE_RESOLUTION_SCHEMA_VERSION;
+      todo_id: string;
+      decision: "repair_contract";
+      requirement: "unknown";
+      reason: "todo_delivery_contract_not_explicit";
+      accepted_resolutions: readonly [
+        "declare_repository_or_write_contract",
+        "declare_explicit_non_delivery_contract",
+      ];
+    };
 
 function optionalObject(value: unknown, label: string): JsonObject | null {
   if (value === null || value === undefined) return null;
@@ -56,7 +86,8 @@ function stringArray(value: unknown, label: string): readonly string[] {
 function operation(value: unknown): DeliveryWorkspaceCausalityOperation {
   if (
     value === "classify" || value === "normalize" ||
-    value === "event_fields" || value === "from_event"
+    value === "event_fields" || value === "missing_workspace" ||
+    value === "from_event"
   ) return value;
   throw new Error("delivery workspace causality operation is unsupported");
 }
@@ -123,6 +154,43 @@ export function classifyDeliveryWorkspaceCausality(
     requirement,
     source,
     reason,
+  };
+}
+
+export function resolveMissingDeliveryWorkspace(
+  value: unknown,
+): DeliveryWorkspaceResolution | null {
+  const causality = normalizeDeliveryWorkspaceCausality(value, null);
+  if (!causality) return null;
+  const base = {
+    schema_version: DELIVERY_WORKSPACE_RESOLUTION_SCHEMA_VERSION,
+    todo_id: causality.todo_id,
+  } as const;
+  if (causality.requirement === "required") {
+    return {
+      ...base,
+      decision: "require_snapshot",
+      requirement: "required",
+      reason: "declared_workspace_snapshot_required",
+    };
+  }
+  if (causality.requirement === "not_required") {
+    return {
+      ...base,
+      decision: "omit_snapshot",
+      requirement: "not_required",
+      reason: "explicit_non_delivery_contract",
+    };
+  }
+  return {
+    ...base,
+    decision: "repair_contract",
+    requirement: "unknown",
+    reason: "todo_delivery_contract_not_explicit",
+    accepted_resolutions: [
+      "declare_repository_or_write_contract",
+      "declare_explicit_non_delivery_contract",
+    ],
   };
 }
 
@@ -196,6 +264,11 @@ export function evaluateDeliveryWorkspaceCausality(value: unknown): JsonObject {
   if (selectedOperation === "event_fields") {
     return result({
       fields: deliveryWorkspaceCausalityEventFields(request.causality),
+    });
+  }
+  if (selectedOperation === "missing_workspace") {
+    return result({
+      resolution: resolveMissingDeliveryWorkspace(request.causality),
     });
   }
   const nested = normalizeDeliveryWorkspaceCausality(

--- a/loopx/control_plane/quota/slot_accounting.py
+++ b/loopx/control_plane/quota/slot_accounting.py
@@ -36,7 +36,10 @@ from .settlement import (
     resolve_settlement_delivery_workspace_causality,
     settlement_result_payload,
 )
-from .settlement_workspace_causality import completed_todo_workspace_causality
+from .settlement_workspace_causality import (
+    completed_todo_workspace_causality,
+    missing_delivery_workspace_resolution,
+)
 from .settlement_validation import completion_validation_spend_error
 from .spend_sources import DEFAULT_SLOT_SPEND_SOURCE, VALID_SLOT_SPEND_SOURCES
 
@@ -311,15 +314,26 @@ def _missing_delivery_workspace_preview(
     agent_id: str | None,
     before: dict[str, Any],
 ) -> dict[str, Any] | None:
-    requirement = str(
-        (delivery_workspace_causality or {}).get("requirement") or ""
-    )
-    if (
-        not delivery_workspace_causality
-        or requirement != "required"
-        or delivery_workspace_repository(delivery_workspace)
+    if not delivery_workspace_causality or delivery_workspace_repository(
+        delivery_workspace
     ):
         return None
+    resolution = missing_delivery_workspace_resolution(
+        delivery_workspace_causality
+    )
+    if resolution is None or resolution["decision"] == "omit_snapshot":
+        return None
+    requirement = resolution["requirement"]
+    reason = (
+        "quota spend requires a valid delivery workspace snapshot for "
+        f"settlement causality requirement {requirement}"
+        if resolution["decision"] == "require_snapshot"
+        else (
+            "quota spend requires an explicit Todo delivery contract; declare "
+            "repository/write requirements or mark the Todo as explicit "
+            "non-delivery, then retry the same settlement"
+        )
+    )
     return {
         "ok": False,
         "mode": "spend-slot",
@@ -329,12 +343,10 @@ def _missing_delivery_workspace_preview(
         "agent_id": agent_id,
         "appended": False,
         "registry_mutated": False,
-        "reason": (
-            "quota spend requires a valid delivery workspace snapshot for "
-            f"settlement causality requirement {requirement}"
-        ),
+        "reason": reason,
         "delivery_workspace": delivery_workspace,
         "delivery_workspace_causality": delivery_workspace_causality,
+        "delivery_workspace_resolution": resolution,
         "delivery_workspace_validated": False,
         "before": before,
         "after": None,

--- a/loopx/control_plane/quota/slot_accounting.py
+++ b/loopx/control_plane/quota/slot_accounting.py
@@ -316,7 +316,7 @@ def _missing_delivery_workspace_preview(
     )
     if (
         not delivery_workspace_causality
-        or requirement == "not_required"
+        or requirement != "required"
         or delivery_workspace_repository(delivery_workspace)
     ):
         return None

--- a/tests/control_plane/test_delivery_workspace_causality.py
+++ b/tests/control_plane/test_delivery_workspace_causality.py
@@ -6,6 +6,7 @@ from loopx.control_plane.quota.settlement_workspace_causality import (
     build_delivery_workspace_causality,
     delivery_workspace_causality_event_fields,
     delivery_workspace_causality_from_event_details,
+    missing_delivery_workspace_resolution,
 )
 
 
@@ -81,7 +82,7 @@ def test_non_delivery_policy_cannot_override_repository_write_contract(
     assert causality["reason"] == "declared_repository_or_write_contract"
 
 
-def test_underspecified_legacy_todo_keeps_workspace_guard_fail_closed() -> None:
+def test_underspecified_current_todo_keeps_workspace_guard_fail_closed() -> None:
     causality = build_delivery_workspace_causality(
         {"todo_id": "todo_legacy", "action_kind": "inspect"}
     )
@@ -89,6 +90,23 @@ def test_underspecified_legacy_todo_keeps_workspace_guard_fail_closed() -> None:
     assert causality is not None
     assert causality["requirement"] == "unknown"
     assert causality["reason"] == "todo_write_contract_not_explicit"
+
+
+def test_unknown_causality_projects_typed_contract_repair() -> None:
+    causality = build_delivery_workspace_causality({"todo_id": "todo_unknown"})
+
+    assert causality is not None
+    assert missing_delivery_workspace_resolution(causality) == {
+        "schema_version": "delivery_workspace_resolution_v0",
+        "todo_id": "todo_unknown",
+        "decision": "repair_contract",
+        "requirement": "unknown",
+        "reason": "todo_delivery_contract_not_explicit",
+        "accepted_resolutions": [
+            "declare_repository_or_write_contract",
+            "declare_explicit_non_delivery_contract",
+        ],
+    }
 
 
 def test_event_fields_round_trip_without_nested_rollout_details() -> None:

--- a/tests/control_plane/test_delivery_workspace_causality_runtime.py
+++ b/tests/control_plane/test_delivery_workspace_causality_runtime.py
@@ -102,3 +102,80 @@ def test_python_facade_surfaces_typed_runtime_rejection(monkeypatch) -> None:
         causality.build_delivery_workspace_causality(
             {"todo_id": "todo_write", "required_capabilities": ["filesystem_write"]}
         )
+
+
+def test_python_facade_projects_typed_missing_workspace_resolution(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def call(method: str, params: dict[str, object]) -> dict[str, object]:
+        captured["method"] = method
+        captured["params"] = params
+        return _result(
+            resolution={
+                "schema_version": causality.DELIVERY_WORKSPACE_RESOLUTION_SCHEMA_VERSION,
+                "todo_id": "todo_unknown",
+                "decision": "repair_contract",
+                "requirement": "unknown",
+                "reason": "todo_delivery_contract_not_explicit",
+                "accepted_resolutions": [
+                    "declare_repository_or_write_contract",
+                    "declare_explicit_non_delivery_contract",
+                ],
+            }
+        )
+
+    monkeypatch.setattr(causality, "effect_runtime_result", call)
+    source = {
+        "schema_version": causality.DELIVERY_WORKSPACE_CAUSALITY_SCHEMA_VERSION,
+        "todo_id": "todo_unknown",
+        "requirement": "unknown",
+        "source": "selected_todo_contract",
+        "reason": "todo_write_contract_not_explicit",
+    }
+
+    resolution = causality.missing_delivery_workspace_resolution(source)
+
+    assert resolution is not None
+    assert resolution["decision"] == "repair_contract"
+    assert captured["method"] == "quota.delivery_workspace_causality.evaluate"
+    assert captured["params"] == {
+        "schema_version": causality.DELIVERY_WORKSPACE_CAUSALITY_REQUEST_SCHEMA,
+        "operation": "missing_workspace",
+        "expected_todo_id": None,
+        "causality": source,
+    }
+
+
+def test_python_facade_rejects_contradictory_workspace_resolution(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        causality,
+        "effect_runtime_result",
+        lambda _method, _params: _result(
+            resolution={
+                "schema_version": causality.DELIVERY_WORKSPACE_RESOLUTION_SCHEMA_VERSION,
+                "todo_id": "todo_unknown",
+                "decision": "repair_contract",
+                "requirement": "not_required",
+                "reason": "todo_delivery_contract_not_explicit",
+                "accepted_resolutions": [
+                    "declare_repository_or_write_contract",
+                    "declare_explicit_non_delivery_contract",
+                ],
+            }
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="resolution result shape mismatch"):
+        causality.missing_delivery_workspace_resolution(
+            {
+                "schema_version": causality.DELIVERY_WORKSPACE_CAUSALITY_SCHEMA_VERSION,
+                "todo_id": "todo_unknown",
+                "requirement": "unknown",
+                "source": "selected_todo_contract",
+                "reason": "todo_write_contract_not_explicit",
+            }
+        )

--- a/tests/control_plane/test_quota_slot_accounting.py
+++ b/tests/control_plane/test_quota_slot_accounting.py
@@ -658,10 +658,8 @@ def test_heartbeat_spend_recovers_completed_todo_identity_after_reselection(
     assert preview["settlement_identity"]["effect_id"] == effect_id
 
 
-@pytest.mark.parametrize("workspace_requirement", ["required", "unknown"])
-def test_typed_workspace_causality_fails_closed_without_workspace_snapshot(
+def test_required_workspace_causality_fails_closed_without_workspace_snapshot(
     tmp_path: Path,
-    workspace_requirement: str,
 ) -> None:
     runtime = tmp_path / "runtime"
     original_todo_id = "todo_completed_delivery"
@@ -670,7 +668,7 @@ def test_typed_workspace_causality_fails_closed_without_workspace_snapshot(
         runtime,
         todo_id=original_todo_id,
         turn_instance_id=turn_instance_id,
-        workspace_requirement=workspace_requirement,
+        workspace_requirement="required",
     )
     before = _normal_run_before(todo_id="todo_new_successor")
 
@@ -692,9 +690,43 @@ def test_typed_workspace_causality_fails_closed_without_workspace_snapshot(
 
     assert preview["ok"] is False
     assert "requires a valid delivery workspace snapshot" in preview["reason"]
-    assert preview["delivery_workspace_causality"]["requirement"] == (
-        workspace_requirement
+    assert preview["delivery_workspace_causality"]["requirement"] == "required"
+    assert preview["delivery_workspace_validated"] is False
+
+
+def test_unknown_workspace_causality_allows_legacy_spend_without_snapshot(
+    tmp_path: Path,
+) -> None:
+    runtime = tmp_path / "runtime"
+    original_todo_id = "todo_completed_delivery"
+    turn_instance_id = "turn-completed-delivery"
+    _write_typed_settlement_fixture(
+        runtime,
+        todo_id=original_todo_id,
+        turn_instance_id=turn_instance_id,
+        workspace_requirement="unknown",
     )
+    before = _normal_run_before(todo_id="todo_new_successor")
+
+    preview = build_quota_slot_preview_for_decision(
+        _normal_run_status(runtime),
+        goal_id=GOAL_ID,
+        before=before,
+        after_decision=lambda _: {
+            **before,
+            "quota": {**before["quota"], "spent_slots": 1},
+        },
+        quota_status_builder=lambda goal, **_: goal["quota"],
+        self_repair_spend_actions=frozenset(),
+        agent_id=AGENT_A,
+        todo_id=original_todo_id,
+        turn_instance_id=turn_instance_id,
+        source="heartbeat",
+    )
+
+    assert preview["ok"] is True, preview
+    assert preview["delivery_completion_spend"] is True
+    assert preview["delivery_workspace_causality"]["requirement"] == "unknown"
     assert preview["delivery_workspace_validated"] is False
 
 

--- a/tests/control_plane/test_quota_slot_accounting.py
+++ b/tests/control_plane/test_quota_slot_accounting.py
@@ -694,7 +694,7 @@ def test_required_workspace_causality_fails_closed_without_workspace_snapshot(
     assert preview["delivery_workspace_validated"] is False
 
 
-def test_unknown_workspace_causality_allows_legacy_spend_without_snapshot(
+def test_current_unknown_workspace_causality_fails_closed_without_snapshot(
     tmp_path: Path,
 ) -> None:
     runtime = tmp_path / "runtime"
@@ -724,9 +724,12 @@ def test_unknown_workspace_causality_allows_legacy_spend_without_snapshot(
         source="heartbeat",
     )
 
-    assert preview["ok"] is True, preview
-    assert preview["delivery_completion_spend"] is True
+    assert preview["ok"] is False
+    assert "requires an explicit Todo delivery contract" in preview["reason"]
     assert preview["delivery_workspace_causality"]["requirement"] == "unknown"
+    assert preview["delivery_workspace_resolution"]["decision"] == (
+        "repair_contract"
+    )
     assert preview["delivery_workspace_validated"] is False
 
 

--- a/tests/control_plane_ts/settlement_workspace_causality.test.ts
+++ b/tests/control_plane_ts/settlement_workspace_causality.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 import {
   DELIVERY_WORKSPACE_CAUSALITY_REQUEST_SCHEMA,
   evaluateDeliveryWorkspaceCausality,
+  resolveMissingDeliveryWorkspace,
 } from "../../loopx/control_plane/quota/settlement_workspace_causality.ts";
 
 const fixture = JSON.parse(
@@ -71,4 +72,34 @@ test("causality decisions do not mutate caller input", () => {
   const before = structuredClone(request);
   evaluateDeliveryWorkspaceCausality(request);
   assert.deepEqual(request, before);
+});
+
+test("missing workspace resolution preserves all three typed requirements", () => {
+  const causality = (requirement: string) => ({
+    schema_version: "delivery_workspace_causality_v0",
+    todo_id: `todo_${requirement}`,
+    requirement,
+    source: "selected_todo_contract",
+    reason: `fixture_${requirement}`,
+  });
+
+  assert.equal(
+    resolveMissingDeliveryWorkspace(causality("required"))?.decision,
+    "require_snapshot",
+  );
+  assert.equal(
+    resolveMissingDeliveryWorkspace(causality("not_required"))?.decision,
+    "omit_snapshot",
+  );
+  assert.deepEqual(resolveMissingDeliveryWorkspace(causality("unknown")), {
+    schema_version: "delivery_workspace_resolution_v0",
+    todo_id: "todo_unknown",
+    decision: "repair_contract",
+    requirement: "unknown",
+    reason: "todo_delivery_contract_not_explicit",
+    accepted_resolutions: [
+      "declare_repository_or_write_contract",
+      "declare_explicit_non_delivery_contract",
+    ],
+  });
 });


### PR DESCRIPTION
## Summary

An ordinary or legacy Todo with no explicit repository/write contract produces `delivery_workspace_causality.requirement=unknown`. The previous quota error exposed no machine-readable recovery path, so an Agent could complete the Todo and durable writeback yet repeatedly fail quota settlement.

This PR keeps `unknown` fail-closed and makes the state repairable instead of treating it as equivalent to `not_required`.

## Final design

- TypeScript now owns a discriminated missing-workspace resolution:
  - `require_snapshot` for an explicit repository/write contract;
  - `omit_snapshot` for an explicit non-delivery contract;
  - `repair_contract` for `unknown`, with the two accepted repair outcomes.
- Python consumes that typed decision and projects an actionable settlement error. It no longer reinterprets `unknown` as safe.
- A persisted current `unknown` remains blocked, while an explicitly non-delivery Todo can still settle without a workspace snapshot.
- Workspace evidence still wins when present, so foreign-worktree and causal snapshot guards remain enforced.

This deliberately does not guess that a missing receipt field proves legacy non-delivery. A completed Todo projection may have drifted after the original turn, so such a guess could suppress a real workspace guard.

## Validation

- `npm run typecheck:control-plane`
- `npm run test:control-plane` — 117 passed
- focused causality/quota Python tests — 48 passed
- quota settlement CLI and Turn executor/controller tests — 107 passed
- Ruff, Python compile, and `git diff --check`
- exact-diff premerge: 13/14 selected checks passed; `peer-agent-runtime-v1-smoke.py` fails identically on `origin/main` at the same base SHA in `agent-onboard-host-loop-activation-smoke.py`, outside the changed quota surface. All eight risk-profile smokes and the five other selected catalog canaries passed.

## Scope and risk

Changed surfaces are limited to quota settlement workspace causality, its Python runtime decoder/preview, and focused TS/Python tests. The new runtime operation runs only when a causal settlement lacks a workspace snapshot, so the normal validated-workspace path gains no additional cross-runtime call.
