### PR TITLE
feat(todos): add atomic claim-next under the goal file lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ The core tick is deliberately small:
 ```text
 loopx quota should-run      # should this registered agent act now?
 loopx todo claim            # who owns this slice?
+loopx todo claim-next       # pick and claim the next free slice
 loopx todo update           # what changed?
 loopx refresh-state         # what should the next turn see?
 loopx quota spend-slot      # account for a completed, validated slice

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -281,6 +281,7 @@ loopx start-goal --guided --project . --goal-text "你的长程目标"
 ```text
 loopx quota should-run      # 当前注册 agent 是否应该执行？
 loopx todo claim            # 谁拥有这个 slice？
+loopx todo claim-next       # 挑并认领下一条空闲 slice
 loopx todo update           # 发生了什么？
 loopx refresh-state         # 下一轮应该看到什么？
 loopx quota spend-slot      # 为完成并验证的 slice 记账

--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -296,6 +296,22 @@ loopx todo claim \
   --agent-id codex-main-control
 ```
 
+When several peers need the next free slice without racing on the same
+`todo_id`, use `todo claim-next`. Selection and the `claimed_by` write happen
+under the same goal file lock. Already claimed or actively leased todos are
+skipped. If nothing is claimable, the command returns an empty success payload
+instead of an error:
+
+```bash
+loopx todo claim-next \
+  --goal-id <goal-id> \
+  --agent-id codex-main-control
+```
+
+Optional `--task-class` filters the selected lane (default `advancement_task`).
+Optional `--acquire-lease` also takes a hard task lease after the soft claim.
+`todo claim` remains the command for a known `todo_id`.
+
 Old projects that do not yet have `coordination.registered_agents` are
 intentionally blocked when an agent tries to claim work. The CLI error includes
 the `register-agent --agent-id <agent-id> --execute` command so the agent or

--- a/docs/reference/protocols/host-integration-surface-v0.md
+++ b/docs/reference/protocols/host-integration-surface-v0.md
@@ -216,7 +216,7 @@ the host lacks authority. A host adapter may expose these write classes:
 
 | Write Class | CLI Baseline | Required Guards |
 | --- | --- | --- |
-| Todo claim and lifecycle | `loopx todo claim/update/complete` | registered agent id, active-state file lock, task class, active task-lease execution key when present, optional successor handoff with `blocks_agent` / `unblocks_todo_id` |
+| Todo claim and lifecycle | `loopx todo claim/claim-next/update/complete` | registered agent id, active-state file lock, task class, active task-lease execution key when present, optional successor handoff with `blocks_agent` / `unblocks_todo_id`. `claim-next` picks and claims the next runnable todo that is not already claimed or leased |
 | User/agent todo creation | `loopx todo add --role user --task-class user_gate\|user_action` / `--role agent` | public-safe text, concrete actor, duplicate detection |
 | Gate decision | `loopx operator-gate --decision approve|reject|defer` | explicit controller/user decision, dry-run preview before write |
 | Human reward | `loopx reward ... --dry-run` then explicit write | run-bound judgment, public-safe reason, no score impersonation |
@@ -282,6 +282,7 @@ loopx doctor
 loopx --format json status --agent-id <agent-id>
 loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota should-run --goal-id <goal-id> --agent-id <agent-id>
 loopx todo claim --goal-id <goal-id> --todo-id <todo_id> --claimed-by <agent-id>
+loopx todo claim-next --goal-id <goal-id> --agent-id <agent-id>
 loopx todo complete --goal-id <goal-id> --todo-id <todo_id> --claimed-by <agent-id> --evidence "<public-safe evidence>"
 loopx refresh-state --goal-id <goal-id> --agent-id <agent-id>
 loopx quota spend-slot --goal-id <goal-id> --todo-id <selected-todo-id> --slots 1 --source heartbeat --execute --agent-id <agent-id>

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -598,6 +598,8 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
         "trigger_hints": (
             "todo lifecycle",
             "todo claim",
+            "todo claim-next",
+            "loopx/control_plane/todos/claim_next.py",
             "todo list",
             "todo complete",
             "todo supersede",

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -15,6 +15,7 @@ from ..control_plane.quota.settlement import (
     resolve_heartbeat_settlement_identity,
     settlement_result_payload,
 )
+from ..control_plane.todos.claim_next import claim_next_goal_todo
 from ..control_plane.todos.handoff_mode import HandoffModeError
 from ..control_plane.todos.markdown import render_todo_markdown
 from ..control_plane.work_items.task_lease import TaskLeaseError
@@ -50,6 +51,7 @@ from .todo_argument_validation import (
     validate_todo_add_options,
     validate_todo_archive_completed_options,
     validate_todo_capture_followups_options,
+    validate_todo_claim_next_options,
     validate_todo_claim_options,
     validate_todo_complete_options,
     validate_todo_list_options,
@@ -163,6 +165,7 @@ def register_todo_command(
             "add",
             "list",
             "claim",
+            "claim-next",
             "update",
             "complete",
             "supersede",
@@ -172,8 +175,9 @@ def register_todo_command(
         ],
         default=None,
         help=(
-            "Use add to append a checkbox todo, claim to soft-claim by registered "
-            "agent id, list to read projected todos, update/complete/supersede to transition by todo_id, or "
+            "Use add to append a checkbox todo, claim to soft-claim a known todo_id, "
+            "claim-next to pick and claim the next runnable todo in one locked call, "
+            "list to read projected todos, update/complete/supersede to transition by todo_id, or "
             "archive-completed to move older completed todos into Completed Work Archive. "
             "Use suggest to generate an agent-facing candidate todo analysis prompt without writing state. "
             "Use capture-followups to record a capped public-safe unclaimed follow-up batch."
@@ -265,7 +269,8 @@ def register_todo_command(
             "For todo add/update, explicitly register the routing lane. Use "
             "advancement_task for executable delivery work; user_gate for blocking "
             "owner/controller decisions; user_action for non-blocking user-visible "
-            "todos; continuous_monitor and blocker are non-executable lanes."
+            "todos; continuous_monitor and blocker are non-executable lanes. For "
+            "claim-next, filter the selected lane; default is advancement_task."
         ),
     )
     todo_parser.add_argument(
@@ -388,7 +393,8 @@ def register_todo_command(
             "For agent todo add/claim/update, assign the soft execution owner to a "
             "registered public-safe agent id such as codex-main-control. This names "
             "the assignment target, not the lifecycle actor; multi-agent lifecycle "
-            "commands still require --agent-id. User todos use --bound-agent or "
+            "commands still require --agent-id. For claim-next it is optional and "
+            "must match --agent-id. User todos use --bound-agent or "
             "--goal-bound instead."
         ),
     )
@@ -513,6 +519,14 @@ def register_todo_command(
         "--clear-claim",
         action="store_true",
         help="For todo update, remove the soft claimed_by owner from the todo.",
+    )
+    todo_parser.add_argument(
+        "--acquire-lease",
+        action="store_true",
+        help=(
+            "For todo claim-next, also acquire an optional hard task lease on "
+            "the claimed todo after the soft claimed_by write."
+        ),
     )
     todo_parser.add_argument(
         "--no-follow-up",
@@ -696,6 +710,19 @@ def handle_todo_command(
                 agent_id=args.agent_id,
                 claim_only=True,
                 **_todo_path_args(args),
+                dry_run=bool(args.dry_run),
+            )
+        elif args.todo_command == "claim-next":
+            validate_todo_claim_next_options(args)
+            payload = claim_next_goal_todo(
+                registry_path=registry_path,
+                goal_id=args.goal_id,
+                agent_id=args.agent_id,
+                claimed_by=args.claimed_by,
+                task_class=args.task_class,
+                acquire_lease=bool(args.acquire_lease),
+                **_todo_path_args(args),
+                runtime_root_arg=runtime_root_arg,
                 dry_run=bool(args.dry_run),
             )
         elif args.todo_command == "update":

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -58,6 +58,7 @@ TODO_OPTION_FIELDS = (
     ("--expires-at", "expires_at"),
     ("--watch-only", "watch_only"),
     ("--clear-claim", "clear_claim"),
+    ("--acquire-lease", "acquire_lease"),
     ("--no-follow-up", "no_follow_up"),
     ("--next-agent-todo", "next_agent_todo"),
     ("--next-user-todo", "next_user_todo"),
@@ -311,6 +312,33 @@ def validate_todo_claim_options(args: argparse.Namespace) -> None:
     )
 
 
+def validate_todo_claim_next_options(args: argparse.Namespace) -> None:
+    if not args.agent_id:
+        raise ValueError("todo claim-next requires --agent-id")
+    if args.claimed_by and args.claimed_by != args.agent_id:
+        raise ValueError(
+            "todo claim-next uses --agent-id as the claimant; --claimed-by must "
+            "match --agent-id when both are provided"
+        )
+    if args.todo_id:
+        raise ValueError(
+            "todo claim-next selects the next todo itself; do not pass --todo-id"
+        )
+    _validate_todo_option_subset(
+        args,
+        {
+            "agent_id",
+            "claimed_by",
+            "task_class",
+            "acquire_lease",
+            "state_file",
+        },
+        "todo claim-next only accepts --agent-id, optional --claimed-by, "
+        "--task-class, --acquire-lease, --project, --state-file, and --dry-run; "
+        "unsupported: ",
+    )
+
+
 def validate_todo_update_options(args: argparse.Namespace) -> None:
     if not args.todo_id:
         raise ValueError("todo update requires --todo-id")
@@ -457,6 +485,7 @@ def validate_shared_todo_options(args: argparse.Namespace) -> None:
     agent_id_allowed_for_read = args.todo_command == "list"
     agent_id_allowed_for_lifecycle = args.todo_command in {
         "claim",
+        "claim-next",
         "update",
         "complete",
         "supersede",

--- a/loopx/cli_commands/todo_event.py
+++ b/loopx/cli_commands/todo_event.py
@@ -12,6 +12,7 @@ RolloutEventAppender = Callable[..., dict[str, object]]
 TODO_EVENT_KINDS = {
     "add": "todo_add",
     "claim": "todo_claim",
+    "claim-next": "todo_claim_next",
     "update": "todo_update",
     "complete": "todo_complete",
     "supersede": "todo_supersede",
@@ -37,6 +38,7 @@ def append_todo_rollout_event(
         not payload.get("ok")
         or payload.get("dry_run")
         or (payload.get("idempotent_replay") and not turn_instance_id)
+        or (args.todo_command == "claim-next" and not payload.get("claimed"))
     ):
         return
     append_cli_rollout_event(

--- a/loopx/control_plane/todos/claim_next.py
+++ b/loopx/control_plane/todos/claim_next.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+from contextlib import ExitStack
+from pathlib import Path
+from typing import Any
+
+from ...agent_registry import require_registered_agent_id
+from ...file_lock import exclusive_file_lock
+from ...history import load_registry
+from ...paths import resolve_runtime_root
+from ...state_refresh import now_local, resolve_goal_state
+from ..runtime.local_state_write_correctness import (
+    build_todo_write_correctness_dry_run_packet,
+)
+from ..work_items.task_lease import (
+    acquire_task_lease,
+    lease_is_active,
+    read_lease,
+    task_lease_dir,
+)
+from .active_state_editing import find_todo_block, replace_updated_at
+from .active_state_todo_parser import parse_active_state_todos
+from .claim_visibility import build_agent_claim_scoped_open_items
+from .contract import (
+    TODO_TASK_CLASS_ADVANCEMENT,
+    normalize_todo_claimed_by,
+    normalize_todo_id,
+)
+from .handoff_mode import enter_todo_ownership_handoff_gate
+from .line_update import apply_todo_update_to_lines
+from .mutation_authority import authorize_todo_lifecycle_mutation
+from .projection import (
+    todo_item_is_actionable_open,
+    todo_item_task_class,
+)
+
+
+CLAIM_NEXT_SCHEMA_VERSION = "todo_claim_next_v0"
+CLAIM_NEXT_EMPTY_REASON = "no_claimable_todo"
+CLAIM_NEXT_LEASE_IDEMPOTENCY_PREFIX = "claim-next"
+
+
+def active_leased_todo_ids(*, runtime_root: Path, goal_id: str) -> set[str]:
+    """Return todo ids that currently hold a time-active task lease."""
+
+    lease_dir = task_lease_dir(runtime_root=runtime_root, goal_id=goal_id)
+    if not lease_dir.is_dir():
+        return set()
+    leased: set[str] = set()
+    for path in lease_dir.glob("todo_*.json"):
+        lease = read_lease(path)
+        if not lease_is_active(lease):
+            continue
+        todo_id = normalize_todo_id((lease or {}).get("todo_id") or path.stem)
+        if todo_id:
+            leased.add(todo_id)
+    return leased
+
+
+def todo_is_claimable(
+    item: dict[str, Any],
+    *,
+    leased_todo_ids: set[str],
+) -> bool:
+    """Return True when the item is still free to pick-and-claim.
+
+    Already claimed or actively leased items stay out of claim-next so
+    concurrent callers cannot collide on the same todo.
+    """
+
+    todo_id = normalize_todo_id(item.get("todo_id"))
+    if not todo_id:
+        return False
+    if normalize_todo_claimed_by(item.get("claimed_by")):
+        return False
+    if todo_id in leased_todo_ids:
+        return False
+    return True
+
+
+def select_claimable_todo(
+    items: list[dict[str, Any]],
+    *,
+    agent_id: str,
+    task_class: str | None,
+    leased_todo_ids: set[str],
+) -> dict[str, Any] | None:
+    """Pick the next claimable todo using the existing selected-todo order."""
+
+    requested_task_class = str(task_class or TODO_TASK_CLASS_ADVANCEMENT).strip()
+    open_items = [
+        item
+        for item in items
+        if isinstance(item, dict)
+        if todo_item_is_actionable_open(item)
+        if todo_item_task_class(item) == requested_task_class
+    ]
+    selectable, _claim_scope = build_agent_claim_scoped_open_items(
+        open_items,
+        agent_identity={"agent_id": agent_id},
+        diagnostic_item_limit=0,
+    )
+    for item in selectable:
+        if todo_is_claimable(item, leased_todo_ids=leased_todo_ids):
+            return item
+    return None
+
+
+def _empty_claim_next_payload(
+    *,
+    goal_id: str,
+    agent_id: str,
+    task_class: str,
+    dry_run: bool,
+    state_file: Path,
+    project: Path | None,
+) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "schema_version": CLAIM_NEXT_SCHEMA_VERSION,
+        "command": "claim-next",
+        "claimed": False,
+        "changed": False,
+        "dry_run": dry_run,
+        "empty_reason": CLAIM_NEXT_EMPTY_REASON,
+        "goal_id": goal_id,
+        "agent_id": agent_id,
+        "task_class": task_class,
+        "todo_id": None,
+        "claimed_by": None,
+        "state_file": str(state_file),
+        "project": str(project) if project else None,
+    }
+
+
+def claim_next_goal_todo(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    agent_id: str,
+    claimed_by: str | None = None,
+    task_class: str | None = None,
+    acquire_lease: bool = False,
+    project: Path | None = None,
+    state_file: Path | None = None,
+    runtime_root_arg: str | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Select the next runnable todo and claim it under the goal file lock."""
+
+    normalized_agent_id = normalize_todo_claimed_by(agent_id)
+    if not normalized_agent_id:
+        raise ValueError(
+            "todo claim-next requires --agent-id as a public-safe agent token "
+            "such as codex-main-control"
+        )
+    normalized_claimed_by = (
+        normalize_todo_claimed_by(claimed_by) if claimed_by else None
+    )
+    if claimed_by and not normalized_claimed_by:
+        raise ValueError(
+            "claimed_by must be a public-safe agent token such as codex-main-control"
+        )
+    if normalized_claimed_by and normalized_claimed_by != normalized_agent_id:
+        raise ValueError(
+            "todo claim-next uses --agent-id as the claimant; --claimed-by must "
+            "match --agent-id when both are provided"
+        )
+    requested_task_class = str(task_class or TODO_TASK_CLASS_ADVANCEMENT).strip()
+    registry = load_registry(registry_path)
+    goal, resolved_project, resolved_state_file = resolve_goal_state(
+        registry=registry,
+        goal_id=goal_id,
+        project_override=project,
+        state_file_override=state_file,
+    )
+    if goal is None:
+        raise ValueError(f"goal {goal_id!r} is not present in the registry")
+    if not resolved_state_file.exists():
+        raise ValueError(f"active state file does not exist: {resolved_state_file}")
+    runtime_root = resolve_runtime_root(registry, runtime_root_arg)
+    effective_agent_id = require_registered_agent_id(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        agent_id=normalized_agent_id,
+        field="agent_id",
+    )
+
+    with exclusive_file_lock(
+        resolved_state_file,
+        agent_id=effective_agent_id,
+        operation="todo_claim_next",
+    ), ExitStack() as handoff_gate_stack:
+        original = resolved_state_file.read_text(encoding="utf-8")
+        lines = original.splitlines()
+        fields = parse_active_state_todos(original, item_limit=None)
+        agent_items = list((fields.get("agent_todos") or {}).get("items") or [])
+        leased_todo_ids = active_leased_todo_ids(
+            runtime_root=runtime_root,
+            goal_id=goal_id,
+        )
+        selected = select_claimable_todo(
+            agent_items,
+            agent_id=effective_agent_id,
+            task_class=requested_task_class,
+            leased_todo_ids=leased_todo_ids,
+        )
+        if selected is None:
+            return _empty_claim_next_payload(
+                goal_id=goal_id,
+                agent_id=effective_agent_id,
+                task_class=requested_task_class,
+                dry_run=dry_run,
+                state_file=resolved_state_file,
+                project=resolved_project,
+            )
+        selected_todo_id = normalize_todo_id(selected.get("todo_id"))
+        if not selected_todo_id:
+            return _empty_claim_next_payload(
+                goal_id=goal_id,
+                agent_id=effective_agent_id,
+                task_class=requested_task_class,
+                dry_run=dry_run,
+                state_file=resolved_state_file,
+                project=resolved_project,
+            )
+        existing_block_match = find_todo_block(
+            lines,
+            todo_id=selected_todo_id,
+            role="agent",
+        )
+        if not existing_block_match:
+            raise ValueError(
+                f"todo_id {selected_todo_id!r} was not found in active agent todos"
+            )
+        _existing_role, _section, _start, _end, existing_block = existing_block_match
+        authority_todo = dict(existing_block)
+        authority_todo["role"] = "agent"
+        mutation_authority = authorize_todo_lifecycle_mutation(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            command="claim",
+            todo=authority_todo,
+            actor_agent_id=effective_agent_id,
+            authority_action=None,
+            requested_claimed_by=effective_agent_id,
+        )
+        handoff_gate = enter_todo_ownership_handoff_gate(
+            handoff_gate_stack,
+            state_text=original,
+            registry_path=registry_path,
+            goal_id=goal_id,
+            todo_id=selected_todo_id,
+            mutation_authority=mutation_authority,
+            actor_agent_id=effective_agent_id,
+            ownership_mutation=True,
+        )
+        updated_at = now_local()
+        update_result = apply_todo_update_to_lines(
+            lines,
+            todo_id=selected_todo_id,
+            role="agent",
+            claimed_by=effective_agent_id,
+            claim_only=True,
+            updated_at=updated_at,
+        )
+        changed = bool(update_result["changed"])
+        new_text = "\n".join(lines) + ("\n" if original.endswith("\n") else "")
+        if changed:
+            new_text = replace_updated_at(new_text, updated_at)
+        if changed and not dry_run:
+            resolved_state_file.write_text(new_text, encoding="utf-8")
+        payload: dict[str, Any] = {
+            "ok": True,
+            "schema_version": CLAIM_NEXT_SCHEMA_VERSION,
+            "command": "claim-next",
+            "claimed": True,
+            "dry_run": dry_run,
+            "changed": changed,
+            "goal_id": goal_id,
+            "agent_id": effective_agent_id,
+            "mutation_authority": mutation_authority,
+            **handoff_gate,
+            **update_result,
+            "state_file": str(resolved_state_file),
+            "project": str(resolved_project) if resolved_project else None,
+            "updated_at": updated_at if changed else None,
+        }
+        if acquire_lease:
+            if dry_run:
+                payload["task_lease"] = {
+                    "ok": True,
+                    "dry_run": True,
+                    "would_acquire": True,
+                    "todo_id": selected_todo_id,
+                    "owner": effective_agent_id,
+                }
+            else:
+                payload["task_lease"] = acquire_task_lease(
+                    registry_path=registry_path,
+                    runtime_root=runtime_root,
+                    goal_id=goal_id,
+                    todo_id=selected_todo_id,
+                    owner=effective_agent_id,
+                    idempotency_key=(
+                        f"{CLAIM_NEXT_LEASE_IDEMPOTENCY_PREFIX}:"
+                        f"{selected_todo_id}:{effective_agent_id}"
+                    ),
+                )
+        if dry_run:
+            payload["local_state_write_correctness"] = (
+                build_todo_write_correctness_dry_run_packet(
+                    goal_id=goal_id,
+                    write_class="todo_claim",
+                    state_text=original,
+                    todo_id=selected_todo_id,
+                    role="agent",
+                    section=str(update_result.get("section") or ""),
+                    claimed_by=effective_agent_id,
+                    changed=changed,
+                )
+            )
+        return payload

--- a/loopx/control_plane/todos/markdown.py
+++ b/loopx/control_plane/todos/markdown.py
@@ -101,6 +101,29 @@ def render_todo_markdown(payload: dict[str, Any]) -> str:
             )
         return "\n".join(lines)
 
+    if payload.get("command") == "claim-next":
+        lines = [
+            "# LoopX Todo Claim Next",
+            "",
+            f"- ok: `{payload.get('ok')}`",
+            f"- claimed: `{payload.get('claimed')}`",
+            f"- dry_run: `{payload.get('dry_run')}`",
+            f"- goal_id: `{payload.get('goal_id')}`",
+            f"- agent_id: `{payload.get('agent_id')}`",
+            f"- todo_id: `{payload.get('todo_id')}`",
+            f"- claimed_by: `{payload.get('claimed_by')}`",
+            f"- task_class: `{payload.get('task_class')}`",
+            f"- state_file: `{payload.get('state_file')}`",
+        ]
+        if payload.get("empty_reason"):
+            lines.append(f"- empty_reason: `{payload.get('empty_reason')}`")
+        if payload.get("error"):
+            lines.append(f"- error: {payload.get('error')}")
+        elif payload.get("todo"):
+            marker = todo_marker_for_status(payload.get("status") or TODO_STATUS_OPEN)
+            lines.extend(["", "## Todo", "", f"- [{marker}] {payload.get('todo')}"])
+        return "\n".join(lines)
+
     lines = [
         "# LoopX Todo",
         "",

--- a/tests/control_plane/test_todo_claim_next.py
+++ b/tests/control_plane/test_todo_claim_next.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+from multiprocessing import get_context
+from pathlib import Path
+from typing import Any
+
+from loopx.control_plane.testing.canary_harness import write_fixture_registry
+from loopx.control_plane.todos.active_state_todo_parser import parse_active_state_todos
+from loopx.control_plane.todos.claim_next import (
+    CLAIM_NEXT_EMPTY_REASON,
+    claim_next_goal_todo,
+    select_claimable_todo,
+    todo_is_claimable,
+)
+from loopx.control_plane.work_items.task_lease import acquire_task_lease
+from loopx.todos import add_goal_todo, update_goal_todo
+
+
+GOAL_ID = "todo-claim-next"
+AGENT_A = "codex-worker-a"
+AGENT_B = "codex-worker-b"
+AGENT_C = "codex-worker-c"
+AGENT_D = "codex-worker-d"
+AGENTS = (AGENT_A, AGENT_B, AGENT_C, AGENT_D)
+
+
+def _write_fixture(tmp_path: Path, *, agents: tuple[str, ...] = AGENTS) -> tuple[Path, Path, Path]:
+    project = tmp_path / "project"
+    runtime = tmp_path / "runtime"
+    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".loopx" / "registry.json"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(
+        "\n".join(
+            [
+                "---",
+                "status: active",
+                "updated_at: 2026-08-23T00:00:00+00:00",
+                "---",
+                "",
+                "# Active Goal State",
+                "",
+                "## Objective",
+                "",
+                "Exercise atomic claim-next.",
+                "",
+                "## Agent Todo",
+                "",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    write_fixture_registry(
+        project=project,
+        runtime_root=runtime,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        domain="todo-claim-next-fixture",
+        adapter_kind="generic_project_goal_v0",
+        registered_agents=agents,
+        quota_allowed_slots=None,
+    )
+    return registry_path, state_file, runtime
+
+
+def _add_open_unclaimed(registry: Path, *, text: str) -> dict[str, Any]:
+    return add_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="agent",
+        text=text,
+        task_class="advancement_task",
+    )
+
+
+def _parsed_agent_items(state_file: Path) -> list[dict[str, Any]]:
+    fields = parse_active_state_todos(state_file.read_text(encoding="utf-8"), item_limit=None)
+    return list((fields.get("agent_todos") or {}).get("items") or [])
+
+
+def _claim_next_worker(payload: tuple[str, str]) -> dict[str, Any]:
+    registry_path, agent_id = payload
+    return claim_next_goal_todo(
+        registry_path=Path(registry_path),
+        goal_id=GOAL_ID,
+        agent_id=agent_id,
+    )
+
+
+def test_claim_next_assigns_unique_todos_under_real_concurrency(tmp_path: Path) -> None:
+    registry, _state, _runtime = _write_fixture(tmp_path)
+    added = [
+        _add_open_unclaimed(registry, text=f"Deliver unique slice {index}.")
+        for index in range(4)
+    ]
+    added_ids = {item["todo_id"] for item in added}
+    assert len(added_ids) == 4
+
+    ctx = get_context("spawn")
+    with ctx.Pool(processes=4) as pool:
+        results = pool.map(
+            _claim_next_worker,
+            [(str(registry), agent_id) for agent_id in AGENTS],
+        )
+
+    claimed_ids = [payload["todo_id"] for payload in results]
+    claimants = [payload["claimed_by"] for payload in results]
+    assert all(payload["ok"] is True and payload["claimed"] is True for payload in results)
+    assert len(set(claimed_ids)) == 4, claimed_ids
+    assert set(claimed_ids) == added_ids
+    assert set(claimants) == set(AGENTS)
+    empty = claim_next_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_A,
+    )
+    assert empty["ok"] is True
+    assert empty["claimed"] is False
+    assert empty["empty_reason"] == CLAIM_NEXT_EMPTY_REASON
+    assert empty["todo_id"] is None
+
+
+def test_same_agent_does_not_reselect_an_already_claimed_todo(tmp_path: Path) -> None:
+    registry, _state, _runtime = _write_fixture(tmp_path, agents=(AGENT_A,))
+    first = _add_open_unclaimed(registry, text="First unique slice.")
+    second = _add_open_unclaimed(registry, text="Second unique slice.")
+    claimed_first = claim_next_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_A,
+    )
+    claimed_second = claim_next_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_A,
+    )
+    assert claimed_first["todo_id"] == first["todo_id"]
+    assert claimed_second["todo_id"] == second["todo_id"]
+    assert claimed_first["claimed_by"] == AGENT_A
+    assert claimed_second["claimed_by"] == AGENT_A
+
+
+def test_claim_next_optional_lease_attaches_to_the_claimed_todo(tmp_path: Path) -> None:
+    registry, _state, _runtime = _write_fixture(tmp_path, agents=(AGENT_A,))
+    added = _add_open_unclaimed(registry, text="Lease this slice after claim.")
+    payload = claim_next_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_A,
+        acquire_lease=True,
+    )
+    assert payload["ok"] is True
+    assert payload["todo_id"] == added["todo_id"]
+    lease = payload["task_lease"]["lease"]
+    assert lease["owner"] == AGENT_A
+    assert lease["todo_id"] == added["todo_id"]
+
+
+def test_claim_next_returns_empty_when_no_work_is_available(tmp_path: Path) -> None:
+    registry, _state, _runtime = _write_fixture(tmp_path, agents=(AGENT_A,))
+    payload = claim_next_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_A,
+    )
+    assert payload["ok"] is True
+    assert payload["claimed"] is False
+    assert payload["empty_reason"] == CLAIM_NEXT_EMPTY_REASON
+    assert payload["todo_id"] is None
+    assert payload["command"] == "claim-next"
+
+
+def test_claimed_or_leased_todos_are_not_selected(tmp_path: Path) -> None:
+    registry, state, runtime = _write_fixture(tmp_path, agents=(AGENT_A, AGENT_B))
+    claimed = _add_open_unclaimed(registry, text="Already owned slice.")
+    leased = _add_open_unclaimed(registry, text="Hard-leased slice.")
+    free = _add_open_unclaimed(registry, text="Free runnable slice.")
+    update_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=claimed["todo_id"],
+        claimed_by=AGENT_A,
+        agent_id=AGENT_A,
+        claim_only=True,
+    )
+    acquire_task_lease(
+        registry_path=registry,
+        runtime_root=runtime,
+        goal_id=GOAL_ID,
+        todo_id=leased["todo_id"],
+        owner=AGENT_A,
+        idempotency_key="lease-owned-by-a",
+    )
+    payload = claim_next_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_B,
+    )
+    assert payload["ok"] is True
+    assert payload["claimed"] is True
+    assert payload["todo_id"] == free["todo_id"]
+    assert payload["claimed_by"] == AGENT_B
+    items = {item["todo_id"]: item for item in _parsed_agent_items(state)}
+    assert items[claimed["todo_id"]]["claimed_by"] == AGENT_A
+    assert items[leased["todo_id"]].get("claimed_by") in {None, ""}
+    assert items[free["todo_id"]]["claimed_by"] == AGENT_B
+
+
+def test_todo_is_claimable_rejects_claimed_and_leased_items() -> None:
+    leased_ids = {"todo_leaseditem01"}
+    assert todo_is_claimable(
+        {"todo_id": "todo_freeitem0001", "claimed_by": None},
+        leased_todo_ids=leased_ids,
+    )
+    assert not todo_is_claimable(
+        {"todo_id": "todo_claimeditem1", "claimed_by": AGENT_A},
+        leased_todo_ids=leased_ids,
+    )
+    assert not todo_is_claimable(
+        {"todo_id": "todo_leaseditem01", "claimed_by": None},
+        leased_todo_ids=leased_ids,
+    )
+
+
+def test_select_claimable_todo_follows_selected_todo_order() -> None:
+    items = [
+        {
+            "todo_id": "todo_lateritem001",
+            "index": 2,
+            "priority": "P1",
+            "status": "open",
+            "task_class": "advancement_task",
+            "text": "Later slice.",
+        },
+        {
+            "todo_id": "todo_firstitem001",
+            "index": 1,
+            "priority": "P0",
+            "status": "open",
+            "task_class": "advancement_task",
+            "text": "First slice.",
+        },
+        {
+            "todo_id": "todo_claimeditem1",
+            "index": 0,
+            "priority": "P0",
+            "status": "open",
+            "task_class": "advancement_task",
+            "claimed_by": AGENT_A,
+            "text": "Already claimed.",
+        },
+    ]
+    selected = select_claimable_todo(
+        items,
+        agent_id=AGENT_B,
+        task_class="advancement_task",
+        leased_todo_ids=set(),
+    )
+    assert selected is not None
+    assert selected["todo_id"] == "todo_firstitem001"
+
+
+def test_claim_next_cli_empty_result_is_ok(tmp_path: Path) -> None:
+    from loopx.control_plane.testing.canary_harness import run_json_cli_result
+
+    registry, _state, _runtime = _write_fixture(tmp_path, agents=(AGENT_A,))
+    returncode, payload = run_json_cli_result(
+        "todo",
+        "claim-next",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_A,
+        registry_path=registry,
+    )
+    assert returncode == 0, payload
+    assert payload["ok"] is True
+    assert payload["claimed"] is False
+    assert payload["empty_reason"] == CLAIM_NEXT_EMPTY_REASON
+
+
+def test_claim_next_cli_claims_next_todo(tmp_path: Path) -> None:
+    from loopx.control_plane.testing.canary_harness import run_json_cli
+
+    registry, _state, _runtime = _write_fixture(tmp_path, agents=(AGENT_A, AGENT_B))
+    first = _add_open_unclaimed(registry, text="First runnable slice.")
+    second = _add_open_unclaimed(registry, text="Second runnable slice.")
+    payload = run_json_cli(
+        "todo",
+        "claim-next",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_A,
+        registry_path=registry,
+        include_returncode=False,
+    )
+    assert payload["ok"] is True
+    assert payload["claimed"] is True
+    assert payload["todo_id"] == first["todo_id"]
+    assert payload["claimed_by"] == AGENT_A
+    next_payload = run_json_cli(
+        "todo",
+        "claim-next",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_B,
+        registry_path=registry,
+        include_returncode=False,
+    )
+    assert next_payload["todo_id"] == second["todo_id"]
+    assert next_payload["claimed_by"] == AGENT_B

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -12,6 +12,7 @@ from loopx.cli_commands.todo_argument_validation import (
     validate_todo_add_options,
     validate_todo_archive_completed_options,
     validate_todo_capture_followups_options,
+    validate_todo_claim_next_options,
     validate_todo_claim_options,
     validate_todo_complete_options,
     validate_todo_list_options,
@@ -557,6 +558,56 @@ def test_todo_claim_validation_preserves_exact_diagnostics(
 
     with pytest.raises(ValueError) as exc_info:
         validate_todo_claim_options(args)
+
+    assert str(exc_info.value) == expected
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected"),
+    [
+        ([], "todo claim-next requires --agent-id"),
+        (
+            [
+                "--agent-id",
+                "codex-worker-a",
+                "--claimed-by",
+                "codex-worker-b",
+            ],
+            "todo claim-next uses --agent-id as the claimant; --claimed-by must "
+            "match --agent-id when both are provided",
+        ),
+        (
+            [
+                "--agent-id",
+                "codex-worker-a",
+                "--todo-id",
+                "todo_example",
+            ],
+            "todo claim-next selects the next todo itself; do not pass --todo-id",
+        ),
+        (
+            [
+                "--agent-id",
+                "codex-worker-a",
+                "--note",
+                "not allowed",
+            ],
+            "todo claim-next only accepts --agent-id, optional --claimed-by, "
+            "--task-class, --acquire-lease, --project, --state-file, and --dry-run; "
+            "unsupported: --note",
+        ),
+    ],
+)
+def test_todo_claim_next_validation_preserves_exact_diagnostics(
+    extra_args: list[str],
+    expected: str,
+) -> None:
+    args = build_parser().parse_args(
+        ["todo", "claim-next", "--goal-id", "example-goal", *extra_args]
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_todo_claim_next_options(args)
 
     assert str(exc_info.value) == expected
 


### PR DESCRIPTION
## Motive

TaskForge batch 3a, L2: today `quota should-run` can pick a `selected_todo`, but `todo claim` and `task-lease acquire` still need an explicit `--todo-id`. Select and lock are two calls. Concurrent workers all grab the same next item and bounce on the lease.

This PR adds in-kernel pick-and-claim so N callers each get a different todo in one locked call.

This does not depend on L1 (PR #3520). Claim-next uses the existing selected-todo ranking plus `claimed_by` / active leases only.

## Behavior change

- New command: `loopx todo claim-next --goal-id <goal> --agent-id <agent> [--task-class ...] [--acquire-lease]`
- Under the goal file lock it:
  1. reuses the existing selected-todo ranking (`build_agent_claim_scoped_open_items`)
  2. skips already claimed or actively leased todos
  3. writes `claimed_by` for the caller
  4. optionally acquires a hard task lease
- If nothing is claimable, it returns an empty success payload (`ok=true`, `claimed=false`, `empty_reason=no_claimable_todo`) instead of an error.
- `todo claim --todo-id` is unchanged.

## Compatibility

- Additive command. Existing `todo claim` / `todo update --claimed-by` stay as they are.
- Default lane is `advancement_task`, matching selected-todo.
- Soft `claimed_by` remains the default; `--acquire-lease` is opt-in and does not replace quota, capability, or workspace guards.
- Does not read or write L1 `depends_on_todo_ids`.

## Test evidence

Branch: `codex/todo-claim-next` (from `lightencc/loopx`).

```
python -m pytest -q tests/control_plane/test_todo_claim_next.py \
  tests/test_cli_argument_diagnostics.py::test_todo_claim_next_validation_preserves_exact_diagnostics
# 13 passed

python -m ruff check <touched paths>
# All checks passed!

python -m mypy
# Success: no issues found in 12 source files

loopx canary premerge --from-git-diff
# status: passed; merge_gate_passed=true; selected catalog canaries=9 failures=0
```

Discriminant (production `todo_is_claimable` claimed_by skip removed, then restored):

```
# red: test_same_agent_does_not_reselect_an_already_claimed_todo failed
#      second claim-next returned the already-claimed todo
# green: 1 passed, then 9 passed in the claim-next file
```

Self-tests cover: four concurrent processes each get a different todo with no duplicate claims; a follow-up call with no work returns empty success; claimed or leased items are not selected; optional lease attaches to the claimed todo.

## Merge gate

Runtime todo lifecycle change. Merge stays with the owner. This PR is opened only; it is not merged here.
