### PR TITLE
Keep active task leases when the registered-agent roster changes

### DIFF
--- a/docs/reference/protocols/peer-agent-runtime-v1.md
+++ b/docs/reference/protocols/peer-agent-runtime-v1.md
@@ -29,7 +29,11 @@ rank-bearing `role` field, including null-valued placeholders.
 
 ## Work Ownership
 
-1. An explicit todo `claimed_by` or active task lease wins.
+1. An explicit todo `claimed_by` or active task lease wins. An active task
+   lease keeps protecting its todo until release or expiry even if that owner
+   is later removed from `registered_agents`. New acquires still require a
+   registered owner. Use `configure-goal --add-registered-agent` /
+   `--remove-registered-agent` to change the roster without replacing it.
 2. An unclaimed todo must be claimed or leased before delivery.
 3. An explicitly agent-scoped replan obligation stays with that agent.
 4. An unscoped replan obligation is assigned to exactly one registered peer by

--- a/examples/cli-registry-admin-command-modularization-smoke.py
+++ b/examples/cli-registry-admin-command-modularization-smoke.py
@@ -232,7 +232,13 @@ def main() -> None:
     require("handle_registry_admin_command" in init_source, "__init__ did not export registry admin handler")
 
     for command, options in {
-        "configure-goal": ("--quota-compute", "--registered-agent", "--execute"),
+        "configure-goal": (
+            "--quota-compute",
+            "--registered-agent",
+            "--add-registered-agent",
+            "--remove-registered-agent",
+            "--execute",
+        ),
         "register-agent": ("--agent-id", "--require-new", "--execute"),
         "archive-runtime": ("--archive-root", "--allow-registered", "--execute"),
         "retire-global-goal": ("--goal-id", "--execute"),

--- a/loopx/cli_commands/registry_admin.py
+++ b/loopx/cli_commands/registry_admin.py
@@ -629,6 +629,8 @@ def handle_registry_admin_command(
                 explore_graph_enabled=args.explore_graph_enabled,
                 lark_kanban_heartbeat_sync=args.lark_kanban_heartbeat_sync,
                 registered_agents=args.registered_agents,
+                add_registered_agents=args.add_registered_agents,
+                remove_registered_agents=args.remove_registered_agents,
                 clear_registered_agents=bool(args.clear_registered_agents),
                 peer_task_coordinator=args.peer_task_coordinator,
                 clear_peer_task_coordinator=bool(

--- a/loopx/cli_commands/registry_admin_configure.py
+++ b/loopx/cli_commands/registry_admin_configure.py
@@ -154,8 +154,33 @@ def register_configure_goal_command(subparsers: argparse._SubParsersAction) -> N
         action="append",
         default=None,
         help=(
-            "Registered public-safe agent id allowed to claim todos and receive scoped "
-            "heartbeat prompts. Repeatable; comma-separated values are also accepted."
+            "Replace coordination.registered_agents with this public-safe agent id "
+            "set. Repeatable; comma-separated values are also accepted. Prefer "
+            "--add-registered-agent / --remove-registered-agent to change the roster "
+            "without a full replace. Dropping an owner who still holds an active "
+            "task lease emits a warning; the lease keeps protecting until release "
+            "or expiry."
+        ),
+    )
+    configure_goal_parser.add_argument(
+        "--add-registered-agent",
+        dest="add_registered_agents",
+        action="append",
+        default=None,
+        help=(
+            "Add one registered public-safe agent id without replacing the current "
+            "roster. Repeatable; comma-separated values are also accepted."
+        ),
+    )
+    configure_goal_parser.add_argument(
+        "--remove-registered-agent",
+        dest="remove_registered_agents",
+        action="append",
+        default=None,
+        help=(
+            "Remove one registered agent id without replacing the current roster. "
+            "Repeatable; comma-separated values are also accepted. Active task "
+            "leases held by a removed owner stay in force until release or expiry."
         ),
     )
     configure_goal_parser.add_argument(

--- a/loopx/configure_goal.py
+++ b/loopx/configure_goal.py
@@ -436,7 +436,10 @@ def configure_goal(
     clear_explore_harness_profile: bool = False,
     explore_graph_enabled: bool | None = None,
     registered_agents: list[str] | None = None,
+    add_registered_agents: list[str] | None = None,
+    remove_registered_agents: list[str] | None = None,
     clear_registered_agents: bool = False,
+    runtime_root_override: str | None = None,
     peer_task_coordinator: str | None = None,
     clear_peer_task_coordinator: bool = False,
     agent_profiles: list[dict[str, Any]] | None = None,
@@ -486,6 +489,16 @@ def configure_goal(
         )
     if clear_registered_agents and registered_agents:
         raise ValueError("--clear-registered-agents cannot be combined with --registered-agent")
+    if clear_registered_agents and (add_registered_agents or remove_registered_agents):
+        raise ValueError(
+            "--clear-registered-agents cannot be combined with "
+            "--add-registered-agent or --remove-registered-agent"
+        )
+    if registered_agents is not None and (add_registered_agents or remove_registered_agents):
+        raise ValueError(
+            "--registered-agent cannot be combined with "
+            "--add-registered-agent or --remove-registered-agent"
+        )
     if clear_peer_task_coordinator and peer_task_coordinator:
         raise ValueError(
             "--clear-peer-task-coordinator cannot be combined with "
@@ -501,7 +514,12 @@ def configure_goal(
         ).strip()
         if not automation_prompt_migration_ack:
             raise ValueError("--ack-automation-prompt-migration requires a migration id")
-        if registered_agents is not None or clear_registered_agents:
+        if (
+            registered_agents is not None
+            or add_registered_agents
+            or remove_registered_agents
+            or clear_registered_agents
+        ):
             raise ValueError(
                 "--ack-automation-prompt-migration cannot change registered agents; "
                 "complete the runtime cutover first, then update the peer set separately"
@@ -587,6 +605,8 @@ def configure_goal(
         if allowed_domains:
             raise ValueError("--multi-subagent-feature off cannot be combined with --allowed-domain")
     registered_agents = _clean_registered_agents(registered_agents)
+    add_registered_agents = _clean_registered_agents(add_registered_agents)
+    remove_registered_agents = _clean_registered_agents(remove_registered_agents)
     if peer_task_coordinator is not None:
         peer_task_coordinator = normalize_todo_claimed_by(peer_task_coordinator)
         if not peer_task_coordinator:
@@ -632,12 +652,30 @@ def configure_goal(
         if isinstance(goal.get("coordination"), dict)
         else {}
     )
-    effective_registered_agents = (
-        []
-        if clear_registered_agents
-        else registered_agents
-        if registered_agents is not None
-        else normalize_registered_agents(existing_coordination.get("registered_agents"))
+    existing_registered_agents = normalize_registered_agents(
+        existing_coordination.get("registered_agents")
+    )
+    if clear_registered_agents:
+        effective_registered_agents = []
+    elif registered_agents is not None:
+        effective_registered_agents = list(registered_agents)
+    else:
+        effective_registered_agents = list(existing_registered_agents)
+        for agent in add_registered_agents or []:
+            if agent not in effective_registered_agents:
+                effective_registered_agents.append(agent)
+        if remove_registered_agents:
+            drop = set(remove_registered_agents)
+            effective_registered_agents = [
+                agent
+                for agent in effective_registered_agents
+                if agent not in drop
+            ]
+    roster_write = bool(
+        clear_registered_agents
+        or registered_agents is not None
+        or add_registered_agents
+        or remove_registered_agents
     )
     if (
         normalized_lark_inbox_agent
@@ -768,6 +806,8 @@ def configure_goal(
     elif execute and legacy_hierarchy_before and not migration_completed_before and (
         agent_model is not None
         or registered_agents is not None
+        or add_registered_agents
+        or remove_registered_agents
         or peer_task_coordinator is not None
         or clear_peer_task_coordinator
         or clear_registered_agents
@@ -978,6 +1018,8 @@ def configure_goal(
     if (
         clear_registered_agents
         or registered_agents is not None
+        or add_registered_agents
+        or remove_registered_agents
         or peer_task_coordinator is not None
         or clear_peer_task_coordinator
         or normalized_agent_profiles
@@ -1006,8 +1048,8 @@ def configure_goal(
             coordination.pop("supervisor", None)
             coordination.pop("todo_lifecycle_authority", None)
             coordination.pop("peer_task_coordination", None)
-        elif registered_agents is not None:
-            coordination["registered_agents"] = registered_agents
+        elif roster_write:
+            coordination["registered_agents"] = effective_registered_agents
             current_peer_task_coordination = (
                 coordination.get("peer_task_coordination")
                 if isinstance(coordination.get("peer_task_coordination"), dict)
@@ -1018,7 +1060,7 @@ def configure_goal(
             )
             if (
                 current_peer_coordinator
-                and current_peer_coordinator not in registered_agents
+                and current_peer_coordinator not in effective_registered_agents
             ):
                 coordination.pop("peer_task_coordination", None)
             existing_profiles = (
@@ -1029,7 +1071,7 @@ def configure_goal(
             retained_profiles = {
                 agent: profile
                 for agent, profile in existing_profiles.items()
-                if agent in registered_agents
+                if agent in effective_registered_agents
             }
             if retained_profiles:
                 coordination["agent_profiles"] = retained_profiles
@@ -1044,9 +1086,9 @@ def configure_goal(
                 {
                     agent: mode
                     for agent, mode in raw_work_modes.items()
-                    if agent in registered_agents
+                    if agent in effective_registered_agents
                 },
-                registered_agents=registered_agents,
+                registered_agents=effective_registered_agents,
             )
             if retained_work_modes:
                 coordination["agent_work_modes"] = retained_work_modes
@@ -1057,13 +1099,13 @@ def configure_goal(
                 for entry in coordination.get("todo_lifecycle_authority") or []
                 if isinstance(entry, Mapping)
                 and normalize_todo_claimed_by(entry.get("agent_id"))
-                in registered_agents
+                in effective_registered_agents
             ]
             if retained_authority:
                 coordination["todo_lifecycle_authority"] = (
                     normalize_todo_lifecycle_authority(
                         retained_authority,
-                        registered_agents=registered_agents,
+                        registered_agents=effective_registered_agents,
                     )
                 )
             else:
@@ -1184,6 +1226,21 @@ def configure_goal(
 
     after = _settings_summary(goal)
     changed_fields = _changed_fields(before, after)
+    dropped_registered_agents = [
+        agent
+        for agent in existing_registered_agents
+        if agent not in set(after.get("registered_agents") or [])
+    ]
+    from .control_plane.work_items.task_lease import (
+        active_lease_owner_roster_warnings,
+    )
+
+    active_lease_owner_warnings = active_lease_owner_roster_warnings(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        dropped_owners=dropped_registered_agents,
+        runtime_root_override=runtime_root_override,
+    )
     dry_run = not execute
     model_changed = bool(
         before.get("legacy_hierarchy_present")
@@ -1233,6 +1290,7 @@ def configure_goal(
         "before": before,
         "after": after,
         "written": bool(execute and changed_fields),
+        "active_lease_owner_warnings": active_lease_owner_warnings,
         "automation_prompt_migration": {
             "migration_id": automation_prompt_migration_ack,
             "status": (
@@ -1293,6 +1351,12 @@ def render_configure_goal_markdown(payload: dict[str, Any]) -> str:
         return "\n".join(lines)
     fields = payload.get("changed_fields") or []
     lines.append(f"- changed_fields: `{', '.join(fields) if fields else 'none'}`")
+    for warning in payload.get("active_lease_owner_warnings") or []:
+        if not isinstance(warning, dict):
+            continue
+        message = warning.get("message") or warning.get("code")
+        if message:
+            lines.append(f"- warning: {message}")
     global_sync = payload.get("global_sync")
     if isinstance(global_sync, dict):
         selected_target = (

--- a/loopx/control_plane/goals/configure_goal_service.py
+++ b/loopx/control_plane/goals/configure_goal_service.py
@@ -239,6 +239,7 @@ def configure_goal_with_global_sync(
         registry_path=registry_path,
         goal_id=goal_id,
         execute=False,
+        runtime_root_override=runtime_root_override,
         **configure_options,
     )
     changed = bool(preview.get("changed"))
@@ -264,6 +265,7 @@ def configure_goal_with_global_sync(
             registry_path=registry_path,
             goal_id=goal_id,
             execute=True,
+            runtime_root_override=runtime_root_override,
             **configure_options,
         )
         applied["global_sync"] = preview["global_sync"]
@@ -300,6 +302,7 @@ def configure_goal_with_global_sync(
         registry_path=registry_path,
         goal_id=goal_id,
         execute=True,
+        runtime_root_override=runtime_root_override,
         **configure_options,
     )
     if not applied.get("written"):

--- a/loopx/control_plane/work_items/task_lease.py
+++ b/loopx/control_plane/work_items/task_lease.py
@@ -279,11 +279,13 @@ def hold_task_lease_mutation_fence(
     authority door marker. In hard_lease mode (without the door) the fence is
     mandatory: no effective lease is a typed error instead of a silent
     ``{"required": False}``, and a time-active lease whose owner constraint is
-    no longer effective (the legacy self-disarm state) fails loudly instead of
-    letting a keyless completion through. For a user-role ``user_gate``
-    completion that supplies no explicit lease credentials, the fence mints
-    the key itself under the same per-goal lease lock; an existing
-    time-active lease is never displaced.
+    no longer effective for a reason other than roster membership (claim
+    mismatch, excluded owner, or closed todo) fails loudly instead of letting
+    a keyless completion through. Leaving the roster does not self-disarm an
+    otherwise time-active lease. For a user-role ``user_gate`` completion that
+    supplies no explicit lease credentials, the fence mints the key itself
+    under the same per-goal lease lock; an existing time-active lease is
+    never displaced.
     """
 
     normalized_goal_id = normalize_goal_id(goal_id)
@@ -332,7 +334,13 @@ def hold_task_lease_mutation_fence(
                     normalized_goal_id,
                 ),
             )
-            active = constraint.get("effective") is True
+            if constraint.get("effective") is True:
+                active = True
+            elif constraint.get("reason") == "owner_not_registered":
+                # Time-active leases keep fencing completion after a roster drop.
+                active = True
+            else:
+                active = False
 
         if (
             auto_acquire_lease
@@ -837,6 +845,77 @@ def lease_is_active(lease: dict[str, Any] | None, *, at: datetime | None = None)
     return bool(expires_at and expires_at > (at or now_utc()))
 
 
+def list_active_task_leases(
+    *,
+    runtime_root: Path,
+    goal_id: str,
+    at: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Return time-active leases. Roster membership is not a filter."""
+
+    at = at or now_utc()
+    lease_dir = task_lease_dir(runtime_root=runtime_root, goal_id=goal_id)
+    leases: list[dict[str, Any]] = []
+    if not lease_dir.exists():
+        return leases
+    for path in sorted(lease_dir.glob("todo_*.json")):
+        lease = read_lease(path)
+        if not lease_is_active(lease, at=at):
+            continue
+        assert lease is not None
+        leases.append(
+            {
+                "todo_id": lease.get("todo_id"),
+                "owner": lease.get("owner"),
+                "expires_at": lease.get("expires_at"),
+                "version": lease.get("version"),
+                "lease_epoch": lease_epoch(lease),
+                "write_scopes": lease.get("write_scopes") or [],
+                "lease": lease,
+                "lease_path": str(path),
+            }
+        )
+    return leases
+
+
+def active_lease_owner_roster_warnings(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    dropped_owners: list[str],
+    runtime_root_override: str | None = None,
+) -> list[dict[str, Any]]:
+    """Warn when a roster drop would leave an owner holding a time-active lease."""
+
+    if not dropped_owners:
+        return []
+    dropped = set(dropped_owners)
+    runtime_root = runtime_root_from_registry(registry_path, runtime_root_override)
+    warnings: list[dict[str, Any]] = []
+    for item in list_active_task_leases(runtime_root=runtime_root, goal_id=goal_id):
+        owner = normalize_todo_claimed_by(item.get("owner"))
+        if owner not in dropped:
+            continue
+        todo_id = item.get("todo_id")
+        expires_at = item.get("expires_at")
+        warnings.append(
+            {
+                "code": "active_lease_owner_dropped_from_roster",
+                "owner": owner,
+                "todo_id": todo_id,
+                "expires_at": expires_at,
+                "lease_path": item.get("lease_path"),
+                "message": (
+                    f"Dropping registered agent {owner!r} who still holds an "
+                    f"active task lease on {todo_id!r} until {expires_at}. "
+                    "The lease keeps protecting that todo until release or "
+                    "expiry; new acquires still require a registered owner."
+                ),
+            }
+        )
+    return warnings
+
+
 def scope_root(scope: str) -> str:
     value = scope.strip()
     if value in {"*", "**", "./"}:
@@ -916,14 +995,12 @@ def active_conflicts(
     at: datetime,
 ) -> list[dict[str, Any]]:
     conflicts: list[dict[str, Any]] = []
-    registered_agents = registered_agent_ids_from_registry(registry_path, goal_id)
-    lease_dir = task_lease_dir(runtime_root=runtime_root, goal_id=goal_id)
-    if not lease_dir.exists():
-        return conflicts
-    for path in sorted(lease_dir.glob("todo_*.json")):
-        lease = read_lease(path)
-        if not lease_is_active(lease, at=at):
-            continue
+    for item in list_active_task_leases(
+        runtime_root=runtime_root,
+        goal_id=goal_id,
+        at=at,
+    ):
+        lease = item["lease"]
         lease_todo_id = normalize_lease_todo_id(lease.get("todo_id"))
         if lease_todo_id == todo_id:
             continue
@@ -935,7 +1012,6 @@ def active_conflicts(
         if task_lease_owner_constraint(
             todo,
             owner=lease.get("owner"),
-            registered_agents=registered_agents,
         ).get("effective") is not True:
             continue
         if write_scopes_overlap(write_scopes, normalize_required_write_scopes(lease.get("write_scopes"))):
@@ -947,7 +1023,7 @@ def active_conflicts(
                     "version": lease.get("version"),
                     "lease_epoch": lease_epoch(lease),
                     "write_scopes": lease.get("write_scopes") or [],
-                    "lease_path": str(path),
+                    "lease_path": item["lease_path"],
                 }
             )
     return conflicts
@@ -1039,7 +1115,7 @@ def acquire_task_lease(
             todo_id=todo_id,
             action="acquire",
         )
-        todo = require_task_lease_owner_allowed(
+        require_task_lease_owner_allowed(
             registry_path=registry_path,
             goal_id=goal_id,
             todo_id=todo_id,
@@ -1047,15 +1123,7 @@ def acquire_task_lease(
         )
         existing = read_lease(lease_path)
         assert_expected_version(existing, expected_version)
-        existing_is_effective = bool(
-            lease_is_active(existing, at=at)
-            and task_lease_owner_constraint(
-                todo,
-                owner=(existing or {}).get("owner"),
-                registered_agents=registered_agent_ids_from_registry(registry_path, goal_id),
-            ).get("effective")
-            is True
-        )
+        existing_is_effective = lease_is_active(existing, at=at)
         if existing_is_effective:
             if (
                 existing.get("owner") == owner
@@ -1380,10 +1448,14 @@ def inspect_task_lease(
                 owner=lease.get("owner"),
                 registered_agents=registered_agent_ids_from_registry(registry_path, goal_id),
             )
-            if executor_constraint.get("effective") is not True:
-                active = False
-            else:
+            if executor_constraint.get("effective") is True:
                 executor_constraint = None
+            elif executor_constraint.get("reason") == "owner_not_registered":
+                # Time-active leases keep protecting after the owner leaves
+                # the roster; inspect still reports the registration gap.
+                pass
+            else:
+                active = False
     handoff_mode = _optional_handoff_mode(registry_path, goal_id)
     return {
         "ok": True,

--- a/loopx/status_server.py
+++ b/loopx/status_server.py
@@ -551,6 +551,7 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
             "heartbeat_prompt_migration": payload.get("heartbeat_prompt_migration"),
             "supervisor_prompt": payload.get("supervisor_prompt"),
             "global_sync": payload.get("global_sync"),
+            "active_lease_owner_warnings": payload.get("active_lease_owner_warnings") or [],
         }
 
     def _handle_configure_goal_dry_run(self) -> None:

--- a/tests/control_plane/test_roster_safe_leases.py
+++ b/tests/control_plane/test_roster_safe_leases.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from loopx.cli import main
+from loopx.configure_goal import configure_goal
+from loopx.control_plane.work_items import task_lease as task_lease_module
+from loopx.control_plane.work_items.task_lease import (
+    TaskLeaseError,
+    acquire_task_lease,
+    inspect_task_lease,
+    lease_is_active,
+    read_lease,
+    release_task_lease,
+    task_lease_path,
+)
+from loopx.todos import add_goal_todo
+
+
+GOAL_ID = "roster-safe-leases"
+AGENT_A = "codex-worker-a"
+AGENT_B = "codex-worker-b"
+AGENT_C = "codex-worker-c"
+
+
+def _write_fixture(tmp_path: Path, *, agents: list[str] | None = None) -> tuple[Path, Path]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    state = repo / "ACTIVE_GOAL_STATE.md"
+    state.write_text(
+        "\n".join(
+            [
+                "---",
+                f"goal_id: {GOAL_ID}",
+                "updated_at: 2026-08-23T00:00:00+00:00",
+                "---",
+                "",
+                "## Agent Todo",
+                "",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    registry = tmp_path / "registry.global.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "common_runtime_root": str(tmp_path / "runtime"),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "harness_self_improvement",
+                        "status": "active",
+                        "repo": str(repo),
+                        "state_file": state.name,
+                        "adapter": {"kind": "harness_self_improvement"},
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": list(agents or [AGENT_A, AGENT_B]),
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return registry, state
+
+
+def _add_open_todo(registry: Path, *, text: str) -> dict[str, Any]:
+    return add_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="agent",
+        text=text,
+        task_class="advancement_task",
+    )
+
+
+def _acquire(
+    registry: Path,
+    runtime_root: Path,
+    todo_id: str,
+    *,
+    owner: str,
+    key: str,
+    ttl_seconds: int = 600,
+    write_scopes: list[str] | None = None,
+) -> dict[str, Any]:
+    return acquire_task_lease(
+        registry_path=registry,
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        owner=owner,
+        idempotency_key=key,
+        ttl_seconds=ttl_seconds,
+        write_scopes=write_scopes,
+    )
+
+
+def _stored_agents(registry: Path) -> list[str]:
+    payload = json.loads(registry.read_text(encoding="utf-8"))
+    return list(payload["goals"][0]["coordination"]["registered_agents"])
+
+
+def test_wholesale_roster_replace_does_not_drop_active_lease_protection(
+    tmp_path: Path,
+) -> None:
+    registry, _state = _write_fixture(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    todo = _add_open_todo(registry, text="Hold this todo under an active lease.")
+    acquired = _acquire(registry, runtime_root, todo["todo_id"], owner=AGENT_A, key="a-turn-1")
+    lease_before = dict(acquired["lease"])
+
+    replaced = configure_goal(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        registered_agents=[AGENT_B],
+        execute=True,
+    )
+
+    assert replaced["written"] is True
+    assert replaced["after"]["registered_agents"] == [AGENT_B]
+    assert _stored_agents(registry) == [AGENT_B]
+    warnings = replaced.get("active_lease_owner_warnings") or []
+    assert warnings, replaced
+    assert warnings[0]["owner"] == AGENT_A
+    assert warnings[0]["todo_id"] == todo["todo_id"]
+
+    with pytest.raises(TaskLeaseError) as steal:
+        _acquire(registry, runtime_root, todo["todo_id"], owner=AGENT_B, key="b-turn-1")
+    assert steal.value.code == "todo_lease_conflict"
+
+    persisted = read_lease(
+        task_lease_path(
+            runtime_root=runtime_root,
+            goal_id=GOAL_ID,
+            todo_id=todo["todo_id"],
+        )
+    )
+    assert persisted is not None
+    assert lease_is_active(persisted) is True
+    assert persisted["owner"] == AGENT_A
+    assert persisted["idempotency_key"] == lease_before["idempotency_key"]
+    assert persisted["version"] == lease_before["version"]
+
+    inspected = inspect_task_lease(
+        registry_path=registry,
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+    )
+    assert inspected["active"] is True
+    assert inspected["lease"]["owner"] == AGENT_A
+
+
+def test_dropped_owner_lease_can_be_taken_only_after_release(
+    tmp_path: Path,
+) -> None:
+    registry, _state = _write_fixture(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    todo = _add_open_todo(registry, text="Release then allow the remaining owner to acquire.")
+    acquired = _acquire(registry, runtime_root, todo["todo_id"], owner=AGENT_A, key="a-turn-1")
+    configure_goal(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        registered_agents=[AGENT_B],
+        execute=True,
+    )
+
+    with pytest.raises(TaskLeaseError) as steal:
+        _acquire(registry, runtime_root, todo["todo_id"], owner=AGENT_B, key="b-turn-1")
+    assert steal.value.code == "todo_lease_conflict"
+
+    released = release_task_lease(
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        todo_id=todo["todo_id"],
+        owner=AGENT_A,
+        idempotency_key="a-turn-1",
+        expected_version=int(acquired["lease"]["version"]),
+        registry_path=registry,
+    )
+    assert released["released"] is True
+
+    taken = _acquire(registry, runtime_root, todo["todo_id"], owner=AGENT_B, key="b-turn-2")
+    assert taken["acquired"] is True
+    assert taken["lease"]["owner"] == AGENT_B
+
+
+def test_dropped_owner_lease_can_be_taken_only_after_expiry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime(2026, 8, 23, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(task_lease_module, "now_utc", lambda: now)
+    registry, _state = _write_fixture(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    todo = _add_open_todo(registry, text="Expire then allow the remaining owner to acquire.")
+    _acquire(
+        registry,
+        runtime_root,
+        todo["todo_id"],
+        owner=AGENT_A,
+        key="a-turn-1",
+        ttl_seconds=60,
+    )
+    configure_goal(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        registered_agents=[AGENT_B],
+        execute=True,
+    )
+
+    with pytest.raises(TaskLeaseError) as steal:
+        _acquire(registry, runtime_root, todo["todo_id"], owner=AGENT_B, key="b-turn-1")
+    assert steal.value.code == "todo_lease_conflict"
+
+    monkeypatch.setattr(
+        task_lease_module,
+        "now_utc",
+        lambda: now + timedelta(seconds=61),
+    )
+    taken = _acquire(registry, runtime_root, todo["todo_id"], owner=AGENT_B, key="b-turn-2")
+    assert taken["acquired"] is True
+    assert taken["lease"]["owner"] == AGENT_B
+
+
+def test_incremental_add_does_not_change_existing_owner_or_lease_state(
+    tmp_path: Path,
+) -> None:
+    registry, _state = _write_fixture(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    todo_a = _add_open_todo(registry, text="A keeps this lease while C is added.")
+    todo_b = _add_open_todo(registry, text="B keeps this lease while C is added.")
+    lease_a = _acquire(
+        registry,
+        runtime_root,
+        todo_a["todo_id"],
+        owner=AGENT_A,
+        key="a-turn-1",
+        write_scopes=["docs/**"],
+    )
+    lease_b = _acquire(
+        registry,
+        runtime_root,
+        todo_b["todo_id"],
+        owner=AGENT_B,
+        key="b-turn-1",
+        write_scopes=["tests/**"],
+    )
+    agents_before = _stored_agents(registry)
+    lease_a_before = dict(lease_a["lease"])
+    lease_b_before = dict(lease_b["lease"])
+
+    added = configure_goal(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        add_registered_agents=[AGENT_C],
+        execute=True,
+    )
+
+    assert added["written"] is True
+    assert added["after"]["registered_agents"] == [AGENT_A, AGENT_B, AGENT_C]
+    assert added.get("active_lease_owner_warnings") in (None, [])
+    assert _stored_agents(registry) == [AGENT_A, AGENT_B, AGENT_C]
+    assert agents_before == [AGENT_A, AGENT_B]
+
+    persisted_a = read_lease(
+        task_lease_path(
+            runtime_root=runtime_root,
+            goal_id=GOAL_ID,
+            todo_id=todo_a["todo_id"],
+        )
+    )
+    persisted_b = read_lease(
+        task_lease_path(
+            runtime_root=runtime_root,
+            goal_id=GOAL_ID,
+            todo_id=todo_b["todo_id"],
+        )
+    )
+    assert persisted_a == lease_a_before
+    assert persisted_b == lease_b_before
+
+    with pytest.raises(TaskLeaseError) as steal_a:
+        _acquire(registry, runtime_root, todo_a["todo_id"], owner=AGENT_B, key="b-steal-a")
+    assert steal_a.value.code == "todo_lease_conflict"
+    with pytest.raises(TaskLeaseError) as steal_b:
+        _acquire(registry, runtime_root, todo_b["todo_id"], owner=AGENT_A, key="a-steal-b")
+    assert steal_b.value.code == "todo_lease_conflict"
+
+
+def test_incremental_remove_keeps_active_lease_and_warns(
+    tmp_path: Path,
+) -> None:
+    registry, _state = _write_fixture(tmp_path, agents=[AGENT_A, AGENT_B, AGENT_C])
+    runtime_root = tmp_path / "runtime"
+    todo = _add_open_todo(registry, text="Removing A from the roster must not wipe the lease.")
+    acquired = _acquire(registry, runtime_root, todo["todo_id"], owner=AGENT_A, key="a-turn-1")
+
+    removed = configure_goal(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        remove_registered_agents=[AGENT_A],
+        execute=True,
+    )
+
+    assert removed["after"]["registered_agents"] == [AGENT_B, AGENT_C]
+    warnings = removed.get("active_lease_owner_warnings") or []
+    assert any(item["owner"] == AGENT_A for item in warnings), removed
+
+    with pytest.raises(TaskLeaseError) as steal:
+        _acquire(registry, runtime_root, todo["todo_id"], owner=AGENT_B, key="b-turn-1")
+    assert steal.value.code == "todo_lease_conflict"
+    persisted = read_lease(
+        task_lease_path(
+            runtime_root=runtime_root,
+            goal_id=GOAL_ID,
+            todo_id=todo["todo_id"],
+        )
+    )
+    assert persisted is not None
+    assert persisted["owner"] == AGENT_A
+    assert persisted["version"] == acquired["lease"]["version"]
+
+
+def test_new_acquire_still_requires_owner_on_roster(tmp_path: Path) -> None:
+    registry, _state = _write_fixture(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    held = _add_open_todo(registry, text="A already holds this one.")
+    free = _add_open_todo(registry, text="A cannot acquire a new todo after leaving the roster.")
+    _acquire(registry, runtime_root, held["todo_id"], owner=AGENT_A, key="a-held")
+    configure_goal(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        registered_agents=[AGENT_B],
+        execute=True,
+    )
+
+    with pytest.raises(TaskLeaseError) as error:
+        _acquire(registry, runtime_root, free["todo_id"], owner=AGENT_A, key="a-new")
+    assert error.value.code == "owner_not_registered"
+
+
+def test_off_roster_owner_write_scope_still_conflicts(tmp_path: Path) -> None:
+    registry, _state = _write_fixture(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    held = _add_open_todo(registry, text="A holds overlapping docs scope.")
+    other = _add_open_todo(registry, text="B should not take overlapping docs scope.")
+    _acquire(
+        registry,
+        runtime_root,
+        held["todo_id"],
+        owner=AGENT_A,
+        key="a-docs",
+        write_scopes=["docs/**"],
+    )
+    configure_goal(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        registered_agents=[AGENT_B],
+        execute=True,
+    )
+
+    with pytest.raises(TaskLeaseError) as error:
+        _acquire(
+            registry,
+            runtime_root,
+            other["todo_id"],
+            owner=AGENT_B,
+            key="b-docs",
+            write_scopes=["docs/readme.md"],
+        )
+    assert error.value.code == "write_scope_conflict"
+
+
+def test_configure_goal_rejects_combining_replace_with_incremental(
+    tmp_path: Path,
+) -> None:
+    registry, _state = _write_fixture(tmp_path)
+
+    with pytest.raises(ValueError, match="cannot be combined"):
+        configure_goal(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            registered_agents=[AGENT_B],
+            add_registered_agents=[AGENT_C],
+            execute=False,
+        )
+
+
+def test_configure_goal_cli_add_registered_agent(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    registry, _state = _write_fixture(tmp_path)
+
+    exit_code = main(
+        [
+            "--registry",
+            str(registry),
+            "--runtime-root",
+            str(tmp_path / "runtime"),
+            "--format",
+            "json",
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--add-registered-agent",
+            AGENT_C,
+            "--execute",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["written"] is True
+    assert payload["after"]["registered_agents"] == [AGENT_A, AGENT_B, AGENT_C]
+    assert _stored_agents(registry) == [AGENT_A, AGENT_B, AGENT_C]


### PR DESCRIPTION
## Motivation

TaskForge batch 3a: LoopX cannot yet serve as a multi-agent execution kernel while a running roster change silently disarms in-flight locks. `configure-goal --registered-agent` currently replaces `coordination.registered_agents` wholesale, and an active task lease stopped protecting its todo as soon as the owner left that list. A second executor could then acquire the same todo.

## Behavior change

- An active task lease keeps protecting its todo until release or expiry even if the owner is later removed from `registered_agents`.
- New `task-lease acquire` still requires the caller to be on the roster.
- Write-scope conflicts, `task-lease inspect`, and completion fencing follow the same rule: roster membership no longer self-disarms a time-active lease.
- `configure-goal` keeps `--registered-agent` as a full replace, and adds `--add-registered-agent` / `--remove-registered-agent` for in-place roster edits.
- If a replace, remove, or clear would drop an owner who still holds an active lease, the command emits an explicit `active_lease_owner_warnings` payload (and markdown warning). It does not refuse the roster change and does not wipe the lease.

## Compatibility

- `--registered-agent` remains a wholesale replacement.
- `--clear-registered-agents` is unchanged except for the new warning when it would drop an active-lease owner.
- `--registered-agent` cannot be combined with the new incremental flags.
- Existing callers that only add agents by repeating `--registered-agent` still replace the whole list; hosts that want a true add should switch to `--add-registered-agent`.
- HTTP `configure-goal` compact responses now include `active_lease_owner_warnings`. Incremental add/remove is CLI/Python only in this PR.

## Tests

Worktree validation:

```text
python -m pytest -q tests/control_plane/test_roster_safe_leases.py
# 9 passed
python -m ruff check <touched paths>
# All checks passed
loopx canary premerge --from-git-diff
# status: passed; selected=18 failures=0
```

Core scenes in `tests/control_plane/test_roster_safe_leases.py`:

1. A holds a lease, roster is replaced with only B, B's acquire of the same todo is rejected (`todo_lease_conflict`); the lease stays active.
2. After A releases, or after the lease expires, B can acquire.
3. Incremental add of C does not change A/B roster membership or either lease record.
4. Wholesale replace or incremental remove that would drop an active-lease owner emits `active_lease_owner_warnings`.
5. New acquire still requires the owner to be registered.

Discriminant proof (restore the roster-coupled `existing_is_effective` check): the same-todo steal tests fail with `DID NOT RAISE TaskLeaseError`; restoring the time-active check returns them to green.

## Future-facing pass

Applied: lease protection now keys off time-active status rather than roster membership, and the drop-warning helper lives next to `list_active_task_leases` so `configure_goal.py` stays under the 1500-line module budget. Deferred: HTTP/dashboard incremental add/remove, and whether renew should stay roster-gated (this PR keeps renew as a new grant and still requires registration).

Do not self-merge: this is a runtime behavior change.