### PR TITLE
feat(goal-channel): default human-gate auto-notify on for new goal channels

### DIFF
--- a/loopx/extensions/lark/goal_channel_setup.py
+++ b/loopx/extensions/lark/goal_channel_setup.py
@@ -10,16 +10,20 @@ from urllib.parse import urlparse
 
 from ...control_plane.runtime.public_safety import public_safe_compact_text
 from .goal_channel_contracts import (
+    HUMAN_GATE_AUTO_NOTIFY_SETTING,
     binding_for_goal,
+    clear_human_gate_auto_notify_marker,
     control_message,
     goal_from_registry,
     goal_objective,
+    human_gate_auto_notify_marker_path,
     now_iso,
     operation_packet,
     provider_idempotency_key,
     read_goal_channel_binding,
     save_goal_binding,
     semantic_key,
+    write_human_gate_auto_notify_marker,
 )
 from .goal_channel_transport import (
     APP_ID_PATTERN,
@@ -49,6 +53,15 @@ from .presentation.kanban import (
 
 def _mapping(value: Any) -> dict[str, Any]:
     return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _default_goal_channel_automation(
+    raw_binding: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Human-gate auto-notify is on by default for newly configured channels."""
+    automation = _mapping(raw_binding.get("automation"))
+    automation.setdefault(HUMAN_GATE_AUTO_NOTIFY_SETTING, True)
+    return automation
 
 
 def _base_url_from_payload(payload: Mapping[str, Any]) -> str:
@@ -758,6 +771,7 @@ def setup_lark_goal_channel(
                 "bot_display_name": effective_bot_name,
                 "cli_bin": effective_cli_bin,
             }
+        automation = _default_goal_channel_automation(raw_existing)
         saved_binding: dict[str, Any] = {
             "goal_id": goal_id,
             "provider": "lark",
@@ -770,7 +784,7 @@ def setup_lark_goal_channel(
                 "base_url": kanban_url,
             },
             "identity": saved_identity,
-            "automation": _mapping(raw_existing.get("automation")),
+            "automation": automation,
             "receipts": mutable_receipts,
         }
         if effective_target_name:
@@ -781,6 +795,11 @@ def setup_lark_goal_channel(
             goal_id=goal_id,
             binding=saved_binding,
         )
+        marker_path = human_gate_auto_notify_marker_path(binding_path, goal_id)
+        if automation.get(HUMAN_GATE_AUTO_NOTIFY_SETTING) is True:
+            write_human_gate_auto_notify_marker(marker_path)
+        else:
+            clear_human_gate_auto_notify_marker(marker_path)
     return operation_packet(
         ok=True,
         goal_id=goal_id,

--- a/tests/extensions/test_lark_goal_channel.py
+++ b/tests/extensions/test_lark_goal_channel.py
@@ -476,6 +476,64 @@ def test_setup_execute_persists_private_binding_after_verified_pin(
     _assert_public_packet(payload)
 
 
+def test_setup_execute_defaults_human_gate_auto_notify_on(tmp_path: Path) -> None:
+    registry_path = tmp_path / ".loopx" / "registry.json"
+    binding_path = tmp_path / ".loopx" / "goal-channel.json"
+    kanban_path = tmp_path / ".loopx" / "lark-kanban.json"
+    calls: list[list[str]] = []
+
+    payload = setup_lark_goal_channel(
+        registry=_registry(tmp_path),
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        kanban_config_path=kanban_path,
+        bot_app_id="cli_public_fixture",
+        execute=True,
+        runner=_fake_runner(calls),
+    )
+    assert payload["ok"] is True
+    assert payload["status"] == "configured"
+    persisted = read_goal_channel_binding(binding_path)["bindings"][GOAL_ID]
+    assert persisted["automation"]["human_gate_auto_notify_enabled"] is True
+    marker_path = goal_channel_contracts.human_gate_auto_notify_marker_path(
+        binding_path, GOAL_ID
+    )
+    assert goal_channel_contracts.human_gate_auto_notify_marker_enabled(marker_path)
+
+
+def test_setup_execute_preserves_explicit_auto_notify_opt_out(tmp_path: Path) -> None:
+    binding_path = tmp_path / ".loopx" / "goal-channel.json"
+    binding_path.parent.mkdir(parents=True)
+    kanban_path = tmp_path / ".loopx" / "lark-kanban.json"
+    _write_binding(binding_path, kanban_path)
+    payload = read_goal_channel_binding(binding_path)
+    payload["bindings"][GOAL_ID]["automation"] = {
+        "human_gate_auto_notify_enabled": False
+    }
+    write_goal_channel_binding(binding_path, payload)
+    calls: list[list[str]] = []
+
+    result = setup_lark_goal_channel(
+        registry=_registry(tmp_path),
+        registry_path=tmp_path / ".loopx" / "registry.json",
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        kanban_config_path=kanban_path,
+        bot_app_id="cli_public_fixture",
+        execute=True,
+        runner=_fake_runner(calls),
+    )
+    assert result["ok"] is True
+    assert result["status"] == "configured"
+    persisted = read_goal_channel_binding(binding_path)["bindings"][GOAL_ID]
+    assert persisted["automation"]["human_gate_auto_notify_enabled"] is False
+    marker_path = goal_channel_contracts.human_gate_auto_notify_marker_path(
+        binding_path, GOAL_ID
+    )
+    assert not goal_channel_contracts.human_gate_auto_notify_marker_enabled(marker_path)
+
+
 def test_configure_auto_notify_is_preview_first_and_persists_private_opt_in(
     tmp_path: Path,
 ) -> None:
@@ -556,9 +614,12 @@ def test_configure_can_disable_auto_notify_for_incomplete_binding(
     _assert_public_packet(payload)
 
 
-def test_auto_notify_gate_is_disabled_by_default_and_suppressible(
+def test_auto_notify_gate_is_disabled_when_unconfigured_and_suppressible(
     tmp_path: Path,
 ) -> None:
+    # A raw binding with no automation setting is unconfigured (disabled); the
+    # setup path now defaults human-gate auto-notify to on (see
+    # test_setup_execute_defaults_human_gate_auto_notify_on).
     binding_path = tmp_path / ".loopx" / "goal-channel.json"
     binding_path.parent.mkdir(parents=True)
     kanban_path = tmp_path / ".loopx" / "lark-kanban.json"


### PR DESCRIPTION
## Why

A Goal Channel set up via `goal-channel setup`/`attach` leaves `automation` empty, so `human_gate_auto_notify_enabled` is off. Human/user gates (e.g. "付费数据源待决策" style operator gates) are then only surfaced in the agent session — they never reach the bound Lark group unless an operator separately runs `goal-channel configure --auto-notify-human-gates`. The capability exists but is not the default, so blockers silently stay out of the collaboration channel.

## What

`setup_lark_goal_channel` now:
- initializes `automation.human_gate_auto_notify_enabled` to `true` when the setting is absent (an explicit `false` is preserved),
- syncs the `human-gate-auto-notify` marker file so the extension-failure fallback path and the binding stay consistent.

`attach` and shared-target setup inherit this default because they route through `setup_lark_goal_channel`. Opting out remains explicit via `goal-channel configure --no-auto-notify-human-gates`.

## Tests

- `test_setup_execute_defaults_human_gate_auto_notify_on` — new setup persists `true` and writes the marker.
- `test_setup_execute_preserves_explicit_auto_notify_opt_out` — an explicit `false` survives setup and clears the marker.
- renamed the stale `..._is_disabled_by_default_...` test to `..._is_disabled_when_unconfigured_...`.
- Full lark goal-channel suite: 96 passed.