### PR TITLE
fix(todos): rebind stale generated Next Action

### DIFF
--- a/docs/reference/protocols/long-horizon-agent-state-protocol-v0.md
+++ b/docs/reference/protocols/long-horizon-agent-state-protocol-v0.md
@@ -123,6 +123,15 @@ timeline. Use an independent state file only when the work has a distinct
 `goal_id`, durable objective, protected boundary, owner policy, or backlog that
 would be misleading if compressed into the parent goal's `Next Action`.
 
+The goal-level `Next Action` remains a stable tie-breaker among equally ranked
+work. When it carries a typed todo binding, adding an executable agent todo may
+rebind it only if the new todo has strictly higher priority and belongs to the
+same agent lane (or replaces an unclaimed generated route). Manual or untyped
+operator text and routes already owned by another agent remain authoritative.
+Startup checks that are merely recommended stay below concrete task work;
+required connection, permission, or runtime setup must instead be represented
+as an explicit high-priority prerequisite or blocker.
+
 Every new rollout event that should participate in concurrent-agent views should
 try to include at least one stable join key: `agent_id`, `todo_id`, `run_id`,
 `lane.lane_id`, or `case_id`. Events that cannot expose a join

--- a/loopx/control_plane/todos/next_action.ts
+++ b/loopx/control_plane/todos/next_action.ts
@@ -31,6 +31,7 @@ export interface TodoNextActionSnapshot {
   status: string;
   task_class: string | null;
   priority: TodoPriority | null;
+  claimed_by: string | null;
   text: string;
   index: number;
   completion_continuation: string | null;
@@ -43,6 +44,13 @@ export type TodoNextActionRequest =
       operation: "bind";
       lines: readonly string[];
       todo_id: string;
+    }
+  | {
+      schema_version: typeof TODO_NEXT_ACTION_REQUEST_SCHEMA;
+      operation: "reconcile_added";
+      lines: readonly string[];
+      todo_id: string;
+      agent_todos: readonly TodoNextActionSnapshot[];
     }
   | {
       schema_version: typeof TODO_NEXT_ACTION_REQUEST_SCHEMA;
@@ -62,6 +70,7 @@ export interface TodoNextActionResult extends JsonObject {
     | "not_terminal"
     | "awaiting_successor"
     | "route_unmatched"
+    | "reprioritized"
     | "settled";
   changed: boolean;
   matched: boolean;
@@ -107,6 +116,7 @@ function todoSnapshot(value: unknown, index: number): TodoNextActionSnapshot {
     status,
     task_class: optionalString(item.task_class, `${label}.task_class`),
     priority: nullableTodoPriority(item.priority, `${label}.priority`),
+    claimed_by: optionalString(item.claimed_by, `${label}.claimed_by`),
     text: normalizeText(requiredString(item.text, `${label}.text`)),
     index: Number(item.index),
     completion_continuation: optionalString(
@@ -143,11 +153,22 @@ export function decodeTodoNextActionRequest(
       todo_id: todoId,
     };
   }
-  if (operation !== "settle_completion") {
+  if (operation !== "reconcile_added" && operation !== "settle_completion") {
     throw new Error("Todo Next Action operation is unsupported");
   }
   if (!Array.isArray(request.agent_todos)) {
     throw new Error("todo.next_action agent_todos must be an array");
+  }
+  if (operation === "reconcile_added") {
+    return {
+      schema_version: TODO_NEXT_ACTION_REQUEST_SCHEMA,
+      operation,
+      lines,
+      todo_id: todoId,
+      agent_todos: request.agent_todos.map((value, index) =>
+        todoSnapshot(value, index)
+      ),
+    };
   }
   const materializedTodoIds = stringArray(
     request.materialized_todo_ids,
@@ -331,6 +352,75 @@ function nextOpenAgentTodo(
   return candidates[0] ?? null;
 }
 
+function replaceNextAction(
+  lines: readonly string[],
+  todo: TodoNextActionSnapshot,
+): string[] | null {
+  const bounds = headingBounds(lines, "Next Action");
+  if (!bounds) return null;
+  const [start, end] = bounds;
+  return [
+    ...lines.slice(0, start),
+    "## Next Action",
+    "",
+    `- ${todo.text}`,
+    bindingLine(todo.todo_id),
+    "",
+    ...lines.slice(end),
+  ];
+}
+
+function reconcileAddedTodo(
+  request: Extract<TodoNextActionRequest, { operation: "reconcile_added" }>,
+): TodoNextActionResult {
+  const added = request.agent_todos.find(
+    (todo) => todo.todo_id === request.todo_id,
+  );
+  if (
+    added?.status !== "open" ||
+    added.task_class !== "advancement_task"
+  ) {
+    return unchangedResult("reconcile_added", "unchanged", request.lines);
+  }
+  const matches = bindingMatches(request.lines);
+  if (
+    matches.length !== 1 ||
+    matches[0].schema !== NEXT_ACTION_BINDING_SCHEMA ||
+    visibleNextActionEntries(request.lines).length !== 1
+  ) {
+    return unchangedResult("reconcile_added", "route_unmatched", request.lines);
+  }
+  const bound = request.agent_todos.find(
+    (todo) => todo.todo_id === matches[0].todoId,
+  );
+  if (
+    bound?.status !== "open" ||
+    bound.task_class !== "advancement_task" ||
+    priorityRank(added.priority) >= priorityRank(bound.priority)
+  ) {
+    return unchangedResult("reconcile_added", "unchanged", request.lines, true);
+  }
+  // An unclaimed bootstrap route may yield to concrete claimed work. A route
+  // already owned by another peer remains authoritative for that peer's lane.
+  if (bound.claimed_by && bound.claimed_by !== added.claimed_by) {
+    return unchangedResult("reconcile_added", "unchanged", request.lines, true);
+  }
+  const updated = replaceNextAction(request.lines, added);
+  if (!updated) {
+    return unchangedResult("reconcile_added", "route_unmatched", request.lines, true);
+  }
+  return {
+    schema_version: TODO_NEXT_ACTION_RESULT_SCHEMA,
+    operation: "reconcile_added",
+    outcome: "reprioritized",
+    changed: true,
+    matched: true,
+    lines: updated,
+    next_todo_id: added.todo_id,
+    next_action: added.text,
+  };
+}
+
 function settleCompletedTodo(
   request: Extract<TodoNextActionRequest, { operation: "settle_completion" }>,
 ): TodoNextActionResult {
@@ -436,7 +526,11 @@ export function transitionTodoNextAction(
   value: unknown,
 ): TodoNextActionResult {
   const request = decodeTodoNextActionRequest(value);
-  return request.operation === "bind"
-    ? bindNextAction(request.lines, request.todo_id)
-    : settleCompletedTodo(request);
+  if (request.operation === "bind") {
+    return bindNextAction(request.lines, request.todo_id);
+  }
+  if (request.operation === "reconcile_added") {
+    return reconcileAddedTodo(request);
+  }
+  return settleCompletedTodo(request);
 }

--- a/loopx/control_plane/todos/next_action.ts
+++ b/loopx/control_plane/todos/next_action.ts
@@ -354,18 +354,22 @@ function nextOpenAgentTodo(
 
 function replaceNextAction(
   lines: readonly string[],
-  todo: TodoNextActionSnapshot,
+  todo: TodoNextActionSnapshot | null,
 ): string[] | null {
   const bounds = headingBounds(lines, "Next Action");
   if (!bounds) return null;
   const [start, end] = bounds;
+  const replacement = ["## Next Action", ""];
+  if (todo) {
+    replacement.push(
+      `- ${todo.text}`,
+      bindingLine(todo.todo_id),
+      "",
+    );
+  }
   return [
     ...lines.slice(0, start),
-    "## Next Action",
-    "",
-    `- ${todo.text}`,
-    bindingLine(todo.todo_id),
-    "",
+    ...replacement,
     ...lines.slice(end),
   ];
 }
@@ -478,8 +482,9 @@ function settleCompletedTodo(
     };
   }
 
-  const bounds = headingBounds(request.lines, "Next Action");
-  if (!bounds) {
+  const nextTodo = nextOpenAgentTodo(request.agent_todos);
+  const updated = replaceNextAction(request.lines, nextTodo);
+  if (!updated) {
     return {
       ...unchangedResult(
         "settle_completion",
@@ -491,21 +496,6 @@ function settleCompletedTodo(
       match_source: matchSource,
     };
   }
-  const [start, end] = bounds;
-  const nextTodo = nextOpenAgentTodo(request.agent_todos);
-  const replacement = ["## Next Action", ""];
-  if (nextTodo) {
-    replacement.push(
-      `- ${nextTodo.text}`,
-      bindingLine(nextTodo.todo_id),
-      "",
-    );
-  }
-  const updated = [
-    ...request.lines.slice(0, start),
-    ...replacement,
-    ...request.lines.slice(end),
-  ];
   const changed = updated.some((line, index) => line !== request.lines[index]) ||
     updated.length !== request.lines.length;
   return {

--- a/loopx/control_plane/todos/next_action_runtime.py
+++ b/loopx/control_plane/todos/next_action_runtime.py
@@ -61,6 +61,7 @@ def _agent_todo_snapshots(lines: list[str]) -> list[dict[str, Any]]:
                 or TODO_STATUS_OPEN,
                 "task_class": str(block.get("task_class") or "").strip() or None,
                 "priority": todo_priority_label(block, text_mode="prefix"),
+                "claimed_by": str(block.get("claimed_by") or "").strip() or None,
                 "text": str(block.get("text") or "").strip(),
                 "index": int(block.get("index") or 0),
                 "completion_continuation": (
@@ -157,6 +158,42 @@ def bind_next_action_to_todo(lines: list[str], *, todo_id: str) -> bool:
         params={"todo_id": normalized_todo_id},
     )
     return bool(result["changed"])
+
+
+def reconcile_added_todo_next_action(
+    lines: list[str],
+    *,
+    added_todo_id: str,
+) -> bool:
+    """Let higher-priority task work replace a lower-priority typed route."""
+
+    normalized_todo_id = normalize_todo_id(added_todo_id)
+    if not normalized_todo_id:
+        raise ValueError("Next Action reconciliation requires a valid added todo_id")
+    result = _apply_transition(
+        lines,
+        operation="reconcile_added",
+        params={
+            "todo_id": normalized_todo_id,
+            "agent_todos": _agent_todo_snapshots(lines),
+        },
+    )
+    return bool(result["changed"])
+
+
+def apply_added_todo_next_action(
+    lines: list[str],
+    *,
+    role: str,
+    add_result: dict[str, Any],
+) -> bool:
+    """Return whether todo addition or its typed Next Action projection changed."""
+
+    changed = bool(add_result["changed"])
+    todo_id = str(add_result.get("todo_id") or "")
+    if role != "agent" or not todo_id:
+        return changed
+    return reconcile_added_todo_next_action(lines, added_todo_id=todo_id) or changed
 
 
 def settle_completed_todo_next_action(

--- a/loopx/control_plane/todos/next_action_runtime.py
+++ b/loopx/control_plane/todos/next_action_runtime.py
@@ -191,7 +191,12 @@ def apply_added_todo_next_action(
 
     changed = bool(add_result["changed"])
     todo_id = str(add_result.get("todo_id") or "")
-    if role != "agent" or not todo_id:
+    if (
+        not changed
+        or role != "agent"
+        or add_result.get("task_class") != "advancement_task"
+        or not todo_id
+    ):
         return changed
     return reconcile_added_todo_next_action(lines, added_todo_id=todo_id) or changed
 

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -88,7 +88,7 @@ from .control_plane.todos.line_update import (
     link_superseding_todo_id,
     upsert_todo_metadata,
 )
-from .control_plane.todos.next_action_runtime import settle_completed_todo_next_action
+from .control_plane.todos.next_action_runtime import apply_added_todo_next_action, settle_completed_todo_next_action
 from .control_plane.todos.list_projection import (
     AGENT_LANE_OVERLAY_FULL_DETAIL_COLD_PATH,
     EXPLICIT_LIMIT_OVERLAY_FULL_DETAIL_COLD_PATH,
@@ -1156,7 +1156,7 @@ def add_goal_todo(
         )
         added = bool(add_result["added"])
         metadata_updated = bool(add_result["metadata_updated"])
-        changed = bool(add_result["changed"])
+        changed = apply_added_todo_next_action(lines, role=role, add_result=add_result)
 
         new_text = "\n".join(lines) + ("\n" if original.endswith("\n") else "")
         if changed:

--- a/tests/control_plane/test_todo_next_action_settlement.py
+++ b/tests/control_plane/test_todo_next_action_settlement.py
@@ -7,6 +7,7 @@ from loopx.bootstrap import render_state_markdown
 from loopx.control_plane.effect_runtime import MAX_REQUEST_BYTES
 from loopx.control_plane.todos.next_action_runtime import (
     _agent_todo_snapshots,
+    apply_added_todo_next_action,
     reconcile_added_todo_next_action,
 )
 from loopx.control_plane.todos.projection import TODO_MISSING_PRIORITY_RANK, todo_priority_rank
@@ -297,6 +298,38 @@ def test_higher_priority_todo_preserves_multi_entry_operator_route() -> None:
     assert reconcile_added_todo_next_action(lines, added_todo_id="todo_task") is False
     assert "- Preserve this operator-authored route." in lines
     assert "todo_id=todo_startup" in "\n".join(lines)
+
+
+def test_unchanged_and_non_advancement_adds_skip_the_ts_transition(
+    monkeypatch,
+) -> None:
+    def reject_unexpected_transition(*_args, **_kwargs):
+        raise AssertionError("non-candidate Todo addition crossed the TS boundary")
+
+    monkeypatch.setattr(
+        "loopx.control_plane.todos.next_action_runtime.effect_runtime_result",
+        reject_unexpected_transition,
+    )
+    lines = ["## Next Action", "", "- Preserve the existing route.", ""]
+
+    assert apply_added_todo_next_action(
+        lines,
+        role="agent",
+        add_result={
+            "changed": False,
+            "todo_id": "todo_existing",
+            "task_class": "advancement_task",
+        },
+    ) is False
+    assert apply_added_todo_next_action(
+        lines,
+        role="agent",
+        add_result={
+            "changed": True,
+            "todo_id": "todo_monitor",
+            "task_class": "continuous_monitor",
+        },
+    ) is True
 
 
 def test_refresh_record_preserves_a_long_wrapped_next_action_losslessly(

--- a/tests/control_plane/test_todo_next_action_settlement.py
+++ b/tests/control_plane/test_todo_next_action_settlement.py
@@ -5,7 +5,10 @@ from pathlib import Path
 
 from loopx.bootstrap import render_state_markdown
 from loopx.control_plane.effect_runtime import MAX_REQUEST_BYTES
-from loopx.control_plane.todos.next_action_runtime import _agent_todo_snapshots
+from loopx.control_plane.todos.next_action_runtime import (
+    _agent_todo_snapshots,
+    reconcile_added_todo_next_action,
+)
 from loopx.control_plane.todos.projection import TODO_MISSING_PRIORITY_RANK, todo_priority_rank
 from loopx.state_projection import active_state_next_action_entries
 from loopx.state_refresh import build_state_refresh_record
@@ -120,6 +123,180 @@ def test_bootstrap_binds_generated_connection_validation_next_action(
         state_text
     )
     assert "loopx:next-action" not in json.dumps(record)
+
+
+def test_higher_priority_agent_todo_rebinds_generated_onboarding_next_action(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    state = repo / "ACTIVE_GOAL_STATE.md"
+    state.write_text(
+        render_state_markdown(
+            project=repo,
+            goal_id=GOAL_ID,
+            adapter_kind="read_only_project_map_v0",
+            objective="Implement and validate the task.",
+            updated_at="2026-08-21T00:00:00+08:00",
+            goal_doc=None,
+            execution_profile=None,
+        ),
+        encoding="utf-8",
+    )
+    registry = tmp_path / "registry.global.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "common_runtime_root": str(tmp_path / "runtime"),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "harness_self_improvement",
+                        "status": "active",
+                        "repo": str(repo),
+                        "state_file": state.name,
+                        "adapter": {"kind": "read_only_project_map_v0"},
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": [AGENT_ID],
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    added = add_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="agent",
+        text="[P0] Implement and validate the requested behavior.",
+        task_class="advancement_task",
+        action_kind="implementation",
+        claimed_by=AGENT_ID,
+    )
+
+    state_text = state.read_text(encoding="utf-8")
+    assert added["todo_id"]
+    assert active_state_next_action_entries(state_text) == [
+        "[P0] Implement and validate the requested behavior."
+    ]
+    assert f"todo_id={added['todo_id']} -->" in state_text
+
+
+def test_agent_todo_add_preserves_same_priority_and_manual_next_actions(
+    tmp_path: Path,
+) -> None:
+    registry, state = _write_fixture(
+        tmp_path,
+        next_action="Keep the owner-approved route unchanged.",
+    )
+    manual = add_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="agent",
+        text="[P0] Implement the requested behavior.",
+        task_class="advancement_task",
+        action_kind="implementation",
+        claimed_by=AGENT_ID,
+    )
+    assert manual["todo_id"]
+    assert active_state_next_action_entries(state.read_text(encoding="utf-8")) == [
+        "Keep the owner-approved route unchanged."
+    ]
+
+    state.write_text(
+        state.read_text(encoding="utf-8").replace(
+            "- Keep the owner-approved route unchanged.\n",
+            "- [P0] Implement the requested behavior.\n"
+            "<!-- loopx:next-action schema=loopx_next_action_binding_v0 "
+            f"todo_id={manual['todo_id']} -->\n",
+            1,
+        ),
+        encoding="utf-8",
+    )
+    same_priority = add_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="agent",
+        text="[P0] Add focused validation.",
+        task_class="advancement_task",
+        action_kind="validation_review",
+        claimed_by=AGENT_ID,
+    )
+    assert same_priority["todo_id"]
+    assert active_state_next_action_entries(state.read_text(encoding="utf-8")) == [
+        "[P0] Implement the requested behavior."
+    ]
+
+
+def test_higher_priority_todo_does_not_take_over_another_claimed_lane(
+    tmp_path: Path,
+) -> None:
+    bound_text = "[P1] Continue the first peer's selected route."
+    registry, state = _write_fixture(tmp_path, next_action=bound_text)
+    bound = add_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="agent",
+        text=bound_text,
+        task_class="advancement_task",
+        action_kind="implementation",
+        claimed_by=AGENT_ID,
+    )
+    state.write_text(
+        state.read_text(encoding="utf-8").replace(
+            f"- {bound_text}\n",
+            f"- {bound_text}\n"
+            "<!-- loopx:next-action schema=loopx_next_action_binding_v0 "
+            f"todo_id={bound['todo_id']} -->\n",
+            1,
+        ),
+        encoding="utf-8",
+    )
+    registry_payload = json.loads(registry.read_text(encoding="utf-8"))
+    registry_payload["goals"][0]["coordination"]["registered_agents"].append(
+        "codex-other"
+    )
+    registry.write_text(json.dumps(registry_payload), encoding="utf-8")
+
+    added = add_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="agent",
+        text="[P0] Execute the other peer's independent route.",
+        task_class="advancement_task",
+        action_kind="implementation",
+        claimed_by="codex-other",
+    )
+
+    assert added["todo_id"]
+    assert active_state_next_action_entries(state.read_text(encoding="utf-8")) == [
+        bound_text
+    ]
+
+
+def test_higher_priority_todo_preserves_multi_entry_operator_route() -> None:
+    lines = [
+        "## Agent Todo",
+        "",
+        "- [ ] [P1] Run the generated startup check.",
+        "  <!-- loopx:todo todo_id=todo_startup task_class=advancement_task -->",
+        "- [ ] [P0] Implement the requested behavior.",
+        "  <!-- loopx:todo todo_id=todo_task task_class=advancement_task claimed_by=codex -->",
+        "",
+        "## Next Action",
+        "",
+        "- [P1] Run the generated startup check.",
+        "<!-- loopx:next-action schema=loopx_next_action_binding_v0 todo_id=todo_startup -->",
+        "- Preserve this operator-authored route.",
+        "",
+    ]
+
+    assert reconcile_added_todo_next_action(lines, added_todo_id="todo_task") is False
+    assert "- Preserve this operator-authored route." in lines
+    assert "todo_id=todo_startup" in "\n".join(lines)
 
 
 def test_refresh_record_preserves_a_long_wrapped_next_action_losslessly(

--- a/tests/control_plane_ts/todo_next_action.test.ts
+++ b/tests/control_plane_ts/todo_next_action.test.ts
@@ -17,6 +17,7 @@ function todo(
     status: "open",
     task_class: "advancement_task",
     priority: "P1",
+    claimed_by: null,
     text: `[P1] ${todoId}`,
     index: 1,
     completion_continuation: null,
@@ -24,6 +25,88 @@ function todo(
     ...overrides,
   };
 }
+
+function reconcileRequest(
+  lines: string[],
+  todos: TodoNextActionSnapshot[],
+  addedTodoId = "todo_task",
+): Record<string, unknown> {
+  return {
+    schema_version: TODO_NEXT_ACTION_REQUEST_SCHEMA,
+    operation: "reconcile_added",
+    lines,
+    todo_id: addedTodoId,
+    agent_todos: todos,
+  };
+}
+
+test("strictly higher-priority same-lane work replaces a generated route", () => {
+  const startup = todo("todo_startup", {
+    text: "[P1] Run the generated startup check.",
+  });
+  const task = todo("todo_task", {
+    priority: "P0",
+    claimed_by: "codex",
+    text: "[P0] Implement and validate the requested behavior.",
+    index: 2,
+  });
+  const lines = [
+    "## Next Action",
+    "",
+    `- ${startup.text}`,
+    `<!-- loopx:next-action schema=${NEXT_ACTION_BINDING_SCHEMA} todo_id=${startup.todo_id} -->`,
+    "",
+  ];
+  const before = structuredClone(lines);
+
+  const result = transitionTodoNextAction(
+    reconcileRequest(lines, [startup, task]),
+  );
+
+  assert.equal(result.outcome, "reprioritized");
+  assert.equal(result.next_todo_id, task.todo_id);
+  assert.equal(result.next_action, task.text);
+  assert.deepEqual(lines, before);
+});
+
+test("reconciliation preserves equal, cross-lane, and multi-entry routes", () => {
+  const startup = todo("todo_startup", {
+    claimed_by: "codex-first",
+    text: "[P1] Continue the selected route.",
+  });
+  const baseLines = [
+    "## Next Action",
+    "",
+    `- ${startup.text}`,
+    `<!-- loopx:next-action schema=${NEXT_ACTION_BINDING_SCHEMA} todo_id=${startup.todo_id} -->`,
+    "",
+  ];
+  const cases = [
+    todo("todo_task", { priority: "P1", claimed_by: "codex-first" }),
+    todo("todo_task", { priority: "P0", claimed_by: "codex-other" }),
+  ];
+
+  for (const task of cases) {
+    const result = transitionTodoNextAction(
+      reconcileRequest(baseLines, [startup, task]),
+    );
+    assert.equal(result.changed, false);
+    assert.deepEqual(result.lines, baseLines);
+  }
+
+  const unclaimedStartup = todo("todo_startup", { claimed_by: null });
+  const task = todo("todo_task", { priority: "P0", claimed_by: "codex" });
+  const multiEntry = [
+    ...baseLines.slice(0, -1),
+    "- Preserve this operator-authored route.",
+    "",
+  ];
+  const result = transitionTodoNextAction(
+    reconcileRequest(multiEntry, [unclaimedStartup, task]),
+  );
+  assert.equal(result.changed, false);
+  assert.deepEqual(result.lines, multiEntry);
+});
 
 test("completion orders open work by typed priority, not display text", () => {
   const completed = todo("todo_completed", {


### PR DESCRIPTION
## Problem

A machine-bound, low-priority startup route could remain in the durable goal-level Next Action after an agent authored a strictly higher-priority executable Todo. Quota selection already chose the higher-priority work, but status and refresh projections could still present the stale route to clients.

## Change

- add a typed Todo transition that rebinds Next Action only on a strict priority improvement;
- preserve manual or untyped operator text, equal-priority tie-breaking, multi-entry routes, and routes claimed by another agent;
- keep recommended startup checks below concrete task work while requiring real connection, permission, or runtime gates to use explicit prerequisites or blockers;
- document the goal-level and per-agent-lane precedence contract.

This changes default behavior only when an agent Todo is added while Next Action has exactly one typed binding to compatible lower-priority work.

## Validation

- `pytest -q tests/control_plane/test_todo_next_action_settlement.py tests/control_plane/test_quota_cli_projection.py tests/control_plane/test_capability_gate.py tests/control_plane/test_status_agent_lane_projection.py` (35 passed)
- `npm run typecheck:control-plane`
- `npm run test:control-plane` (110 passed)
- `python examples/project/onboarding-no-scan-projection-smoke.py`
- `python3 examples/control_plane/control-plane-maintainability-ratchet-smoke.py`
- `loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard` (17 selected checks passed; public boundary passed)

Review requested; this PR will not be self-merged.