### PR TITLE
fix(control-plane): fail closed on malformed runtime recovery and settlement payloads

### DIFF
--- a/loopx/control_plane/effect_program.py
+++ b/loopx/control_plane/effect_program.py
@@ -319,23 +319,26 @@ def _runtime_result_metadata(
     if not isinstance(payload, Mapping):
         raise RuntimeError("TypeScript settlement result shape mismatch")
     receipts_value = payload.get("receipts")
-    receipts = (
-        tuple(
+    if not isinstance(receipts_value, list):
+        raise RuntimeError("TypeScript settlement result receipts shape mismatch")
+    receipts_list = []
+    for receipt in receipts_value:
+        if not isinstance(receipt, Mapping):
+            raise RuntimeError("TypeScript settlement result receipts shape mismatch")
+        receipts_list.append(
             SettlementReceipt(
                 step_kind=SettlementStepKind(str(receipt["step_kind"])),
                 status=str(receipt["status"]),
                 effect_id=str(receipt["effect_id"]),
                 source_ref=str(receipt.get("source_ref") or "") or None,
             )
-            for receipt in receipts_value
-            if isinstance(receipt, Mapping)
         )
-        if isinstance(receipts_value, list)
-        else ()
-    )
+    receipts = tuple(receipts_list)
     failure_value = payload.get("failure")
     failure = None
-    if isinstance(failure_value, Mapping):
+    if failure_value is not None:
+        if not isinstance(failure_value, Mapping):
+            raise RuntimeError("TypeScript settlement result failure shape mismatch")
         details = failure_value.get("details")
         failure = SettlementFailure(
             kind=SettlementFailureKind(str(failure_value["kind"])),

--- a/loopx/control_plane/effect_program.py
+++ b/loopx/control_plane/effect_program.py
@@ -313,40 +313,107 @@ def _runtime_result(result: SettlementResult[Any]) -> dict[str, Any]:
     }
 
 
-def _runtime_result_metadata(
-    payload: Any,
-) -> tuple[tuple[SettlementReceipt, ...], SettlementFailure | None]:
+def _required_settlement_string(
+    payload: Mapping[str, Any],
+    key: str,
+    *,
+    shape: str,
+) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise RuntimeError(f"TypeScript settlement result {shape} shape mismatch")
+    return value
+
+
+_SettlementEnum = TypeVar("_SettlementEnum", bound=StrEnum)
+
+
+def _required_settlement_enum(
+    enum_type: type[_SettlementEnum],
+    payload: Mapping[str, Any],
+    key: str,
+    *,
+    shape: str,
+) -> _SettlementEnum:
+    try:
+        return enum_type(_required_settlement_string(payload, key, shape=shape))
+    except ValueError:
+        raise RuntimeError(
+            f"TypeScript settlement result {shape} shape mismatch"
+        ) from None
+
+
+def decode_settlement_receipt_payload(payload: Any) -> SettlementReceipt:
     if not isinstance(payload, Mapping):
+        raise RuntimeError("TypeScript settlement result receipts shape mismatch")
+    source_ref = payload.get("source_ref")
+    if source_ref is not None and (
+        not isinstance(source_ref, str) or not source_ref.strip()
+    ):
+        raise RuntimeError("TypeScript settlement result receipts shape mismatch")
+    return SettlementReceipt(
+        step_kind=_required_settlement_enum(
+            SettlementStepKind,
+            payload,
+            "step_kind",
+            shape="receipts",
+        ),
+        status=_required_settlement_string(payload, "status", shape="receipts"),
+        effect_id=_required_settlement_string(
+            payload,
+            "effect_id",
+            shape="receipts",
+        ),
+        source_ref=source_ref,
+    )
+
+
+def decode_settlement_result_payload(
+    payload: Any,
+) -> tuple[Any, tuple[SettlementReceipt, ...], SettlementFailure | None]:
+    """Decode the shared TS settlement envelope at the Python boundary."""
+
+    if not isinstance(payload, Mapping):
+        raise RuntimeError("TypeScript settlement result shape mismatch")
+    if "value" not in payload or "failure" not in payload:
         raise RuntimeError("TypeScript settlement result shape mismatch")
     receipts_value = payload.get("receipts")
     if not isinstance(receipts_value, list):
         raise RuntimeError("TypeScript settlement result receipts shape mismatch")
-    receipts_list = []
-    for receipt in receipts_value:
-        if not isinstance(receipt, Mapping):
-            raise RuntimeError("TypeScript settlement result receipts shape mismatch")
-        receipts_list.append(
-            SettlementReceipt(
-                step_kind=SettlementStepKind(str(receipt["step_kind"])),
-                status=str(receipt["status"]),
-                effect_id=str(receipt["effect_id"]),
-                source_ref=str(receipt.get("source_ref") or "") or None,
-            )
-        )
-    receipts = tuple(receipts_list)
+    receipts = tuple(
+        decode_settlement_receipt_payload(receipt) for receipt in receipts_value
+    )
     failure_value = payload.get("failure")
     failure = None
     if failure_value is not None:
         if not isinstance(failure_value, Mapping):
             raise RuntimeError("TypeScript settlement result failure shape mismatch")
+        if payload.get("value") is not None:
+            raise RuntimeError("TypeScript settlement result shape mismatch")
         details = failure_value.get("details")
+        if details is not None and not isinstance(details, Mapping):
+            raise RuntimeError("TypeScript settlement result failure shape mismatch")
         failure = SettlementFailure(
-            kind=SettlementFailureKind(str(failure_value["kind"])),
-            step_kind=SettlementStepKind(str(failure_value["step_kind"])),
-            reason=str(failure_value["reason"]),
-            details=dict(details) if isinstance(details, Mapping) else None,
+            kind=_required_settlement_enum(
+                SettlementFailureKind,
+                failure_value,
+                "kind",
+                shape="failure",
+            ),
+            step_kind=_required_settlement_enum(
+                SettlementStepKind,
+                failure_value,
+                "step_kind",
+                shape="failure",
+            ),
+            reason=_required_settlement_string(
+                failure_value,
+                "reason",
+                shape="failure",
+            ),
+            details=dict(details) if details is not None else None,
         )
-    return receipts, failure
+    return payload.get("value"), receipts, failure
 
 
 T = TypeVar("T")
@@ -415,7 +482,7 @@ class SettlementResult(Generic[T]):
                 "next": _runtime_result(next_result),
             },
         )
-        receipts, failure = _runtime_result_metadata(reduced)
+        _, receipts, failure = decode_settlement_result_payload(reduced)
         return SettlementResult(
             value=next_result.value,
             receipts=receipts,

--- a/loopx/control_plane/goals/active_state_event_projection.py
+++ b/loopx/control_plane/goals/active_state_event_projection.py
@@ -56,6 +56,7 @@ def active_state_event_projection_fields(
     event_log_basename: str = DEFAULT_STATE_EVENT_LOG_BASENAME,
 ) -> dict[str, Any]:
     goal_id = str(goal.get("id") or "").strip()
+    first_warning: dict[str, Any] | None = None
     for event_log_path in state_event_log_candidates(
         goal,
         state_path=state_path,
@@ -79,15 +80,17 @@ def active_state_event_projection_fields(
                 item_limit=item_limit,
             )
         except (OSError, StateEventError) as exc:
-            return {
-                "state_event_projection_warning": {
-                    "schema_version": STATE_EVENT_READ_WARNING_SCHEMA_VERSION,
-                    "source": "event_log",
-                    "event_log": event_log_path.name,
-                    "fallback": "markdown_active_state",
-                    "reason": type(exc).__name__,
+            if first_warning is None:
+                first_warning = {
+                    "state_event_projection_warning": {
+                        "schema_version": STATE_EVENT_READ_WARNING_SCHEMA_VERSION,
+                        "source": "event_log",
+                        "event_log": event_log_path.name,
+                        "fallback": "markdown_active_state",
+                        "reason": type(exc).__name__,
+                    }
                 }
-            }
+            continue
         if fields:
             fields["state_event_projection"] = {
                 "schema_version": STATE_EVENT_PROJECTION_SCHEMA_VERSION,
@@ -100,4 +103,4 @@ def active_state_event_projection_fields(
                 "projection_version": projection.get("projection_version"),
             }
             return fields
-    return {}
+    return first_warning or {}

--- a/loopx/control_plane/settlement_driver.py
+++ b/loopx/control_plane/settlement_driver.py
@@ -12,12 +12,12 @@ from collections.abc import Callable, Mapping
 from typing import Any
 
 from .effect_program import (
-    SettlementFailure,
-    SettlementFailureKind,
     SettlementIdentity,
     SettlementReceipt,
     SettlementResult,
     SettlementStepKind,
+    decode_settlement_receipt_payload,
+    decode_settlement_result_payload,
 )
 from .effect_runtime import effect_runtime_result
 
@@ -26,45 +26,13 @@ def _identity_payload(identity: SettlementIdentity) -> dict[str, Any]:
     return identity.as_dict()
 
 
-def _receipt_from_payload(payload: Mapping[str, Any]) -> SettlementReceipt:
-    return SettlementReceipt(
-        step_kind=SettlementStepKind(str(payload["step_kind"])),
-        status=str(payload["status"]),
-        effect_id=str(payload["effect_id"]),
-        source_ref=str(payload.get("source_ref") or "") or None,
-    )
-
-
 def decode_settlement_result(
     payload: Any,
     *,
     value_decoder: Callable[[Any], Any] | None = None,
     projection_payload: Mapping[str, Any] | None = None,
 ) -> SettlementResult[Any]:
-    if not isinstance(payload, Mapping):
-        raise RuntimeError("TypeScript settlement result shape mismatch")
-    receipts_value = payload.get("receipts")
-    if not isinstance(receipts_value, list):
-        raise RuntimeError("TypeScript settlement result receipts shape mismatch")
-    receipts_list = []
-    for receipt in receipts_value:
-        if not isinstance(receipt, Mapping):
-            raise RuntimeError("TypeScript settlement result receipts shape mismatch")
-        receipts_list.append(_receipt_from_payload(receipt))
-    receipts = tuple(receipts_list)
-    failure_value = payload.get("failure")
-    failure = None
-    if failure_value is not None:
-        if not isinstance(failure_value, Mapping):
-            raise RuntimeError("TypeScript settlement result failure shape mismatch")
-        details = failure_value.get("details")
-        failure = SettlementFailure(
-            kind=SettlementFailureKind(str(failure_value["kind"])),
-            step_kind=SettlementStepKind(str(failure_value["step_kind"])),
-            reason=str(failure_value["reason"]),
-            details=dict(details) if isinstance(details, Mapping) else None,
-        )
-    value = payload.get("value")
+    value, receipts, failure = decode_settlement_result_payload(payload)
     if value_decoder is not None and value is not None:
         value = value_decoder(value)
     return SettlementResult(
@@ -114,4 +82,4 @@ def settlement_receipt(
     )
     if not isinstance(payload, Mapping):
         raise RuntimeError("TypeScript settlement receipt shape mismatch")
-    return _receipt_from_payload(payload)
+    return decode_settlement_receipt_payload(payload)

--- a/loopx/control_plane/settlement_driver.py
+++ b/loopx/control_plane/settlement_driver.py
@@ -44,18 +44,19 @@ def decode_settlement_result(
     if not isinstance(payload, Mapping):
         raise RuntimeError("TypeScript settlement result shape mismatch")
     receipts_value = payload.get("receipts")
-    receipts = (
-        tuple(
-            _receipt_from_payload(receipt)
-            for receipt in receipts_value
-            if isinstance(receipt, Mapping)
-        )
-        if isinstance(receipts_value, list)
-        else ()
-    )
+    if not isinstance(receipts_value, list):
+        raise RuntimeError("TypeScript settlement result receipts shape mismatch")
+    receipts_list = []
+    for receipt in receipts_value:
+        if not isinstance(receipt, Mapping):
+            raise RuntimeError("TypeScript settlement result receipts shape mismatch")
+        receipts_list.append(_receipt_from_payload(receipt))
+    receipts = tuple(receipts_list)
     failure_value = payload.get("failure")
     failure = None
-    if isinstance(failure_value, Mapping):
+    if failure_value is not None:
+        if not isinstance(failure_value, Mapping):
+            raise RuntimeError("TypeScript settlement result failure shape mismatch")
         details = failure_value.get("details")
         failure = SettlementFailure(
             kind=SettlementFailureKind(str(failure_value["kind"])),

--- a/loopx/control_plane/todos/event_writeback.py
+++ b/loopx/control_plane/todos/event_writeback.py
@@ -108,7 +108,7 @@ def _canonical_event_projection_source(
                 continue
             projection = build_state_projection(events, goal_id=goal_id or None)
         except (OSError, StateEventError):
-            return None
+            continue
         if all(
             projection.get(key) == projection_authority.get(key)
             for key in authority_keys

--- a/loopx/control_plane/turn_driver/session_recovery.py
+++ b/loopx/control_plane/turn_driver/session_recovery.py
@@ -36,10 +36,12 @@ def reconcile_failed_turn_retry_request(
     *,
     session_binding_resolver: SessionBindingResolver | None,
 ) -> dict[str, Any]:
-    recovery_value = journal.get("host_recovery")
-    recovery = dict(recovery_value) if isinstance(recovery_value, Mapping) else {}
-    if not recovery:
+    if "host_recovery" not in journal:
         return dict(request)
+    recovery_value = journal.get("host_recovery")
+    if not isinstance(recovery_value, Mapping):
+        raise ValueError("failed-Turn host recovery shape mismatch")
+    recovery = dict(recovery_value)
     if recovery.get("schema_version") != HOST_RECOVERY_SCHEMA_VERSION:
         raise ValueError("failed-Turn host recovery has an unsupported schema")
     if recovery.get("kind") not in HOST_RECOVERY_KINDS:

--- a/tests/control_plane/test_quota_settlement.py
+++ b/tests/control_plane/test_quota_settlement.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -282,6 +283,28 @@ def test_settlement_result_short_circuits_without_erasing_failure(
     assert result.failure is not None
     assert result.failure.kind is failure_kind
     assert result.receipts == failed.receipts
+
+
+def test_settlement_result_bind_rejects_corrupted_receipts() -> None:
+    def writeback(value: int) -> SettlementResult[int]:
+        return SettlementResult.pure(value + 1)
+
+    with patch.object(core_effect_program, "effect_runtime_result") as runtime_result:
+        runtime_result.side_effect = [
+            {"execute": True},
+            {
+                "value": {
+                    "completed_phases": [],
+                    "writeback": None,
+                    "quota_spend": None,
+                },
+                "receipts": ["corrupted-receipt"],
+                "failure": None,
+            },
+        ]
+
+        with pytest.raises(RuntimeError, match="receipts shape mismatch"):
+            SettlementResult.pure(2).bind(writeback)
 
 
 def test_codex_app_plan_projects_one_identity_across_settlement_steps() -> None:

--- a/tests/control_plane/test_settlement_driver.py
+++ b/tests/control_plane/test_settlement_driver.py
@@ -7,6 +7,7 @@ from loopx.control_plane.effect_program import (
     SettlementStepKind,
 )
 from loopx.control_plane.settlement_driver import (
+    decode_settlement_result,
     effect_ids_match,
     settlement_receipt,
 )
@@ -209,3 +210,24 @@ def test_turn_settlement_fails_closed_when_prepared_outcome_is_unknown(
     assert result.failure.kind.value == "effect_outcome_unknown"
     assert result.failure.step_kind is SettlementStepKind.DURABLE_WRITEBACK
     assert calls["writeback"] == 0
+
+
+def test_decode_settlement_result_rejects_corrupted_failure_payload() -> None:
+    with pytest.raises(RuntimeError, match="failure shape mismatch"):
+        decode_settlement_result(
+            {
+                "value": {
+                    "completed_phases": [],
+                    "writeback": None,
+                    "quota_spend": None,
+                },
+                "receipts": [
+                    {
+                        "step_kind": "validation",
+                        "status": "committed",
+                        "effect_id": "effect-1",
+                    },
+                ],
+                "failure": "corrupted-failure",
+            }
+        )

--- a/tests/control_plane/test_settlement_driver.py
+++ b/tests/control_plane/test_settlement_driver.py
@@ -231,3 +231,48 @@ def test_decode_settlement_result_rejects_corrupted_failure_payload() -> None:
                 "failure": "corrupted-failure",
             }
         )
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        (
+            {"value": {}, "receipts": [], "failure": {"kind": "cancelled"}},
+            "result shape mismatch",
+        ),
+        (
+            {
+                "value": None,
+                "receipts": [],
+                "failure": {
+                    "kind": "cancelled",
+                    "step_kind": "durable_writeback",
+                    "reason": "cancelled",
+                    "details": "corrupted-details",
+                },
+            },
+            "failure shape mismatch",
+        ),
+        (
+            {
+                "value": {},
+                "receipts": [
+                    {
+                        "step_kind": "validation",
+                        "status": 1,
+                        "effect_id": "effect-1",
+                    }
+                ],
+                "failure": None,
+            },
+            "receipts shape mismatch",
+        ),
+        ({"value": {}, "receipts": []}, "result shape mismatch"),
+    ],
+)
+def test_decode_settlement_result_rejects_invalid_union_states(
+    payload: object,
+    message: str,
+) -> None:
+    with pytest.raises(RuntimeError, match=message):
+        decode_settlement_result(payload)

--- a/tests/control_plane/test_todo_completion_validation.py
+++ b/tests/control_plane/test_todo_completion_validation.py
@@ -927,6 +927,39 @@ def test_empty_earlier_candidate_does_not_replace_canonical_validation_source(
     assert empty_candidate.read_text(encoding="utf-8") == ""
 
 
+def test_corrupted_earlier_candidate_does_not_block_canonical_completion_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo_id = _add_event_only_todo(
+        state,
+        todo_id="todo_event_after_corrupted_candidate",
+        validation_command=_PASS_COMMAND,
+    )
+    canonical = state.with_name("events.jsonl")
+    corrupted_candidate = state.with_name("corrupted-events.jsonl")
+    corrupted_candidate.write_text("{not-json\n", encoding="utf-8")
+    _set_registry_event_log(registry, corrupted_candidate)
+    calls = _spy_validation_runner(monkeypatch)
+
+    result = complete_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=todo_id,
+        agent_id=AGENT,
+        evidence="canonical source remains usable",
+        no_followup=True,
+    )
+
+    assert calls["count"] == 1
+    assert result["ok"] is True
+    assert result["changed"] is True
+    assert result["source"] == "event_log"
+    assert _event_todo_completed_count(canonical) == 1
+    assert corrupted_candidate.read_text(encoding="utf-8") == "{not-json\n"
+
+
 @pytest.mark.parametrize("timeout_value", [0, 30, "not-int", {"seconds": 5}])
 def test_event_projected_invalid_timeout_rejects_without_running_command(
     tmp_path: Path,

--- a/tests/test_loopx_turn_executor.py
+++ b/tests/test_loopx_turn_executor.py
@@ -427,6 +427,63 @@ def test_run_once_resumes_session_observed_by_recoverable_failed_turn(
     assert calls == {"host": 2, "writeback": 1, "spend": 1, "scheduler": 1}
 
 
+@pytest.mark.parametrize("host_recovery", ["corrupted", {}])
+def test_run_once_rejects_corrupted_failed_turn_recovery_before_host_retry(
+    tmp_path: Path,
+    host_recovery: object,
+) -> None:
+    plan = _codex_plan()
+    calls = {"host": 0, "writeback": 0, "spend": 0, "scheduler": 0}
+    writeback, spend, scheduler = _callbacks(calls)
+
+    def host(request: dict[str, object]) -> dict[str, object]:
+        calls["host"] += 1
+        if calls["host"] == 1:
+            raise BuiltInHostError(
+                "codex_cli_timeout",
+                recovery_kind="resume_session",
+            )
+        return _host_result(plan)
+
+    common = {
+        "host_runner": host,
+        "session_binding_resolver": lambda _turn_envelope: {
+            "schema_version": "loopx_turn_session_binding_v0",
+            "goal_id": "fixture-goal",
+            "agent_id": "codex-fixture",
+            "todo_id": "todo_fixture0001",
+        },
+        "project": tmp_path,
+        "runtime_root": tmp_path / "runtime",
+        "goal_id": "fixture-goal",
+        "timeout_seconds": 5,
+        "execute": True,
+        "task_validator": _passing_validator,
+        "writeback": writeback,
+        "spend": spend,
+        "scheduler": scheduler,
+    }
+
+    failed = run_loopx_turn_once(plan, **common)
+    journal_paths = [
+        path
+        for path in (tmp_path / "runtime" / "goals" / "fixture-goal" / "turns").glob(
+            "*.json"
+        )
+        if not path.name.endswith(".lock.holder.json")
+    ]
+    assert len(journal_paths) == 1
+    journal = json.loads(journal_paths[0].read_text(encoding="utf-8"))
+    journal["host_recovery"] = host_recovery
+    journal_paths[0].write_text(json.dumps(journal), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="host recovery"):
+        run_loopx_turn_once(plan, retry_failed=True, **common)
+
+    assert failed["reason"] == "codex_cli_timeout"
+    assert calls == {"host": 1, "writeback": 0, "spend": 0, "scheduler": 0}
+
+
 def test_run_once_recoverable_failed_turn_rejects_session_identity_drift(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Fail closed when TypeScript settlement output or failed-Turn recovery state is malformed, and keep event-log projection usable when an earlier candidate is corrupt but a later canonical candidate remains verifiable.

## Behavior

- reject missing, malformed, or internally contradictory settlement envelopes at the Python/TypeScript boundary;
- reject malformed receipt fields, failure details, and the illegal `value + failure` union state;
- reject a present but malformed `host_recovery` record before retrying the host or running settlement effects;
- continue candidate scanning after an unreadable event log, while preserving the existing warning/Markdown fallback when no valid event-log candidate exists;
- bind Todo completion writeback to the exact later candidate whose projection fingerprint was validated.

## Bounded refactor

TypeScript remains the canonical owner of settlement unions, receipts, failure classification, and Turn settlement reduction. The Python compatibility surface now has one shared strict decoder for TypeScript settlement results and receipts; the duplicate decoder in `settlement_driver.py` was removed.

This is intentionally not a new leaf migration: it adds no handler and no cross-runtime call. Moving failed-Turn recovery by itself would add bridge chatter without cutting over the complete retry transaction, contrary to the transaction-payoff phase of the TypeScript migration RFC.

- canonical semantic owner: unchanged, TypeScript Effect runtime;
- Python decoder owners: two to one;
- new bridge code / RPC operations: zero;
- cross-runtime calls on normal and recovery paths: unchanged;
- product code: +114 / -70 lines, with the net increase providing explicit runtime-boundary validation;
- tests: +180 lines of negative and end-to-end regression coverage;
- facade exit: the remaining Python settlement facade exits with the native TS CLI / provider transaction cutover.

## Validation

- `npm run typecheck:control-plane`
- `npm run test:control-plane` — 117 passed
- focused Turn, settlement, Effect Program, and Todo completion tests — 208 passed
- event-sourced status, downstream read-path, and Todo-list projection smokes — passed
- Ruff and Python compile checks — passed
- `git diff --check origin/main...HEAD` — passed
- `loopx canary premerge --from-git-diff` — 17/17 passed, no manual holds
- public/private boundary scan — clean

No benchmark jobs, scoring behavior, permission boundary, private state, generated logs, credentials, or local paths are included.
