### PR TITLE
feat(coordination): Stage 2 slice - aggregate head, file provider, claim_work executor

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -119,6 +119,7 @@ jobs:
           tests/test_doctor_install_freshness.py
           tests/test_file_lock.py
           tests/test_file_lock_cross_process.py
+          tests/control_plane/test_coordination_file_provider.py
           tests/control_plane/test_effect_runtime_integration.py
           tests/test_self_update_runtime_activation.py
           tests/test_windows_install.py

--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0-evidence.zh-CN.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0-evidence.zh-CN.md
@@ -168,3 +168,26 @@ live NoKV 测试。确定性 fake 的通过结果与这项静态 API 核对必�
 
 真实栈若产生原始日志，应保留在 ignored local state；公共文档只记录可复跑
 命令、候选 commit、机器可判定的不变量和明确的未验证项。
+
+## 7. Stage 2 切片复跑记录（2026-08-23）
+
+按第 5 节的复跑要求逐项记录本轮 live 证据：
+
+1. **精确 commit**：LoopX 侧为 Stage 2 分支（本记录随该分支评审，git 树即
+   源码 digest），基于 Stage 1 Part 2 分支头；NoKV 侧为 `v0.11.0` 标签，
+   经其 Python SDK wheel 驱动。
+2. **探针源码**：`examples/nokv-shadow-provider/live_e2e.py`（随分支评审）。
+   驱动的是生产 `CoordinationAuthorityExecutor` 与生产 head 编解码，不再是
+   参考实现。
+3. **A → B → replay A 断言**：八场景矩阵对 file provider 与 NoKV provider
+   逐行结果一致（含精确重放行：重建 executor 后 `already_applied` 且
+   receipt 逐字段相等；lost-response 行：ambiguous 后经 receipt index 收敛
+   到 `already_applied`）。
+4. **same-id/different-request 负例**：同 operation_id 改语义字段返回
+   `rejected/operation_identity_mismatch`，且聚合与 generation 不变。
+5. **未执行与限定**：renew/release/reclaim、retention 策略、HA、多节点
+   未验证。SIGKILL 重启演练已在本地 dev 栈执行（owner 被杀后运维式重开：
+   head 字节级一致、原 receipt 精确重放、三版本域恢复推进）；该演练脚本
+   因绑定具体部署形态保留在本地忽略状态，不入公共树。回执增长、并发包络
+   等数字是单节点 dev 栈的量化观测，按第 5 节规则不构成生产结论；其含义
+   已写入 RFC 第 11 节 Stage 2 状态小节。

--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
@@ -704,26 +704,41 @@ flips to provider-first without changing the typed outcome contract below.
 The first Stage 2 slice exists on this branch, additively:
 
 - `loopx.control_plane.coordination.head`: the `loopx_coordination_head_v0`
-  aggregate codec. Validation is closed-set and fail-closed, including
-  bool-disguised integers and corrupt lease records; `handoff_mode` is now a
-  recorded head field, pinned to `hard_lease` in v0 (a `soft_claim` goal
-  fails bootstrap closed instead of having its declared semantics silently
-  inverted). Canonical bytes are defined as sorted-key, minimal-separator
-  UTF-8 JSON with non-finite numbers rejected; digests and provider byte
-  parity are defined against exactly that encoding, so "deterministic
-  serialization" is a contract term here, not an implementation accident.
-- `loopx.control_plane.coordination.file_provider`: one goal, one document,
-  exclusive-lock generation compare, exclusive temp create plus fsync plus
-  atomic replace. Crash windows report `ambiguous`; a head with no faithful
-  strict-JSON form reports typed `failed` before any write reaches disk.
+  aggregate codec. Validation is closed-set and fail-closed for every field
+  the executor later dereferences: todos, lease records, and each
+  receipt-index entry (entry shape, digest form, receipt schema, operation
+  identity, todo membership, revisions, epochs, and parseable timestamps),
+  including bool-disguised integers; `handoff_mode` is a recorded head
+  field, pinned to `hard_lease` in v0 (a `soft_claim` goal fails bootstrap
+  closed instead of having its declared semantics silently inverted).
+  Canonical bytes are defined as sorted-key, minimal-separator UTF-8 JSON
+  with non-finite numbers rejected; digests and provider byte parity are
+  defined against exactly that encoding, so "deterministic serialization"
+  is a contract term here, not an implementation accident. The Markdown
+  shadow constructor lives in its own bridge module
+  (`goal_state_shadow`), keeping the codec's import closure inside the
+  repository's strict type gate.
+- `loopx.control_plane.coordination.file_provider`: one goal, one document.
+  Locking goes through `loopx.file_lock`, the repository's one
+  cross-platform lock owner, with its bounded deadline (a lock that cannot
+  be acquired in time is a typed `failed` because no write was attempted).
+  Durability is a fixed commit sequence: write-all of the canonical bytes
+  (short writes are continued, never ignored), file fsync, atomic rename,
+  then parent-directory fsync on POSIX; `applied` is returned only after
+  the whole sequence converges, and any storage fault inside it reports
+  `ambiguous`. A head with no faithful strict-JSON form reports typed
+  `failed` before any write reaches disk.
 - `loopx.control_plane.coordination.executor`: Section 5 steps 1-10 for
   `claim_work`. Every domain decision is delegated to the Stage 1 core; the
   composition is lease acquire followed by the hard-lease-gated claim,
   because a claim-first or legacy-mode composition silently bypasses the
-  Appendix B holder gate (the tests pin this). A provider `failed` verdict
-  is verified against the reloaded receipt index rather than trusted, so a
-  provider that misreports a landed write cannot manufacture a claim whose
-  caller was told it failed.
+  Appendix B holder gate (the tests pin this). `lease_ttl_seconds` is
+  bounded by the local task-lease authority's own ceiling, so the shared
+  envelope cannot mint a lease the local contract would refuse and an
+  unbounded caller value cannot escape as timestamp-arithmetic overflow. A
+  provider `failed` verdict is verified against the reloaded receipt index
+  rather than trusted, so a provider that misreports a landed write cannot
+  manufacture a claim whose caller was told it failed.
 
 Design selection was comparative: three executor candidates (core-delegating,
 inline-rules reference, journal-style receipt log inside the same document)

--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
@@ -685,7 +685,8 @@ independent version domains. Likewise, a restore may preserve frozen bytes and
 lineage without granting current authority: promoting restored state to the
 live authority head requires an explicit lineage and binding fence.
 
-The file-backed provider shadow is Stage 2. It has not started in this slice.
+The file-backed provider shadow is Stage 2; its first slice and the evidence
+behind it are recorded in the Stage 2 status subsection below.
 
 Durable completion continuation read-back
 (`durable_completion.py`: `read_persisted_todo_record` /
@@ -697,6 +698,78 @@ done record omits it or when it contradicts the recorded successor or
 no-follow-up fields, so a provider that holds completion state must store
 that field byte for byte. Once a remote provider becomes canonical, this seam
 flips to provider-first without changing the typed outcome contract below.
+
+#### Stage 2 slice status (2026-08-23)
+
+The first Stage 2 slice exists on this branch, additively:
+
+- `loopx.control_plane.coordination.head`: the `loopx_coordination_head_v0`
+  aggregate codec. Validation is closed-set and fail-closed, including
+  bool-disguised integers and corrupt lease records; `handoff_mode` is now a
+  recorded head field, pinned to `hard_lease` in v0 (a `soft_claim` goal
+  fails bootstrap closed instead of having its declared semantics silently
+  inverted). Canonical bytes are defined as sorted-key, minimal-separator
+  UTF-8 JSON with non-finite numbers rejected; digests and provider byte
+  parity are defined against exactly that encoding, so "deterministic
+  serialization" is a contract term here, not an implementation accident.
+- `loopx.control_plane.coordination.file_provider`: one goal, one document,
+  exclusive-lock generation compare, exclusive temp create plus fsync plus
+  atomic replace. Crash windows report `ambiguous`; a head with no faithful
+  strict-JSON form reports typed `failed` before any write reaches disk.
+- `loopx.control_plane.coordination.executor`: Section 5 steps 1-10 for
+  `claim_work`. Every domain decision is delegated to the Stage 1 core; the
+  composition is lease acquire followed by the hard-lease-gated claim,
+  because a claim-first or legacy-mode composition silently bypasses the
+  Appendix B holder gate (the tests pin this). A provider `failed` verdict
+  is verified against the reloaded receipt index rather than trusted, so a
+  provider that misreports a landed write cannot manufacture a claim whose
+  caller was told it failed.
+
+Design selection was comparative: three executor candidates (core-delegating,
+inline-rules reference, journal-style receipt log inside the same document)
+ran one scenario battery. Only core-delegating candidates follow a flipped
+core rule without local edits, and the journal codec saves no meaningful
+bytes under `retain_all_v0`; the shipped executor is the core-delegating
+candidate.
+
+Live qualification ran against a single-node NoKV dev stack at the 0.11.0
+tag through its Python SDK: the eight-scenario invariant matrix in
+`examples/nokv-shadow-provider/live_e2e.py` passes identically for the file
+provider and the NoKV provider (same-todo race with one winner,
+independent-todo progress, exact replay, identity mismatch, stale-revision
+conflict, lost-response recovery through the receipt index, receipt
+retention, authority-revision advancement), and a SIGKILL of the serving
+owner followed by an operator-style reopen preserved the head byte for
+byte, replayed the original receipt exactly through a fresh executor, and
+resumed CAS across all three version domains. Renew/release/reclaim,
+retention policy, HA, and multi-node deployments remain unexercised, as the
+Later-qualification list already states.
+
+Measured boundaries Stage 3 must respect rather than rediscover:
+
+- `retain_all_v0` costs roughly 750 bytes per receipt inside the one CAS
+  document; on the dev stack, claim latency grew about sevenfold across the
+  first 120 receipts, and cumulative republish bytes grow quadratically
+  (about 84x the final head size after 120 claims). The Section 12 retention
+  decision is load-bearing before any production canary.
+- Under 12 concurrent independent-todo claims, the internal rebase budget
+  admitted 8 and the rest returned typed failures. The Section 1
+  independence promise holds at two endpoints and degrades beyond that; the
+  supported concurrency envelope and retry budget belong in the acceptance
+  checks once a multi-agent canary is scoped.
+- The NoKV document generation restarts after remove/recreate and after
+  restore into a new workbench lineage. A conditional replace carrying a
+  stale generation observation was observed to succeed on a recreated path,
+  and a restored line re-reaches generation numbers whose receipts differ
+  from the original line. This confirms the boundary sentence above:
+  `provider_generation` alone cannot carry restore or lifecycle identity;
+  the lineage/binding fence needs an explicit provider-contract field in the
+  next stage.
+- `provider_outcome_unproved` is a real terminal state in live runs, observed
+  without fault injection. Replay through the receipt index makes
+  re-submission idempotent, so a bounded re-attempt at the same generation
+  would be safe; whether v0 adopts that liveness amendment is an owner
+  decision recorded here, not silently implemented.
 
 ### P0: contract and deterministic proof
 

--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
@@ -707,7 +707,9 @@ The first Stage 2 slice exists on this branch, additively:
   aggregate codec. Validation is closed-set and fail-closed for every field
   the executor later dereferences: todos, lease records, and each
   receipt-index entry (entry shape, digest form, receipt schema, operation
-  identity, todo membership, revisions, epochs, and parseable timestamps),
+  identity, todo membership, revisions, epochs, and timezone-aware UTC
+  timestamps: a naive timestamp reads differently under each host's
+  local timezone, so it fails closed),
   including bool-disguised integers; `handoff_mode` is a recorded head
   field, pinned to `hard_lease` in v0 (a `soft_claim` goal fails bootstrap
   closed instead of having its declared semantics silently inverted).

--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
@@ -612,7 +612,7 @@ provider-first，且不改变下述 typed outcome 合同。
   aggregate 编解码。校验对 executor 后续无条件解引用的每个字段都是封闭
   字段集且 fail-closed 的：todo、lease 记录、以及每条 receipt-index 条目
   （条目形状、digest 形式、receipt schema、operation 身份、todo 归属、
-  revision/epoch、可解析的时间戳），包括伪装成整数的 bool；`handoff_mode`
+  revision/epoch、带时区的 UTC 时间戳（naive 值会随执行主机时区漂移，fail closed）），包括伪装成整数的 bool；`handoff_mode`
   是 head 的记录字段，v0 钦定为 `hard_lease`（`soft_claim` goal 在
   bootstrap 处 fail closed，而不是被静默反转其声明语义）。规范字节被定义
   为按键排序、最小分隔符、UTF-8 的 JSON，且拒绝非有限浮点数；digest 与

--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
@@ -592,7 +592,8 @@ Stage 2 的 aggregate 与 provider shadow。该 aggregate 必须把 `handoff_mod
 lineage，却不会因此获得当前权威；把恢复状态晋升为 live authority head，必须经过
 显式的 lineage 与 binding fence。
 
-File-backed provider shadow 属于 Stage 2；这一切片尚未开始它。
+File-backed provider shadow 属于 Stage 2；其第一个切片与证据记录在下方的
+Stage 2 状态小节。
 
 完成续接（continuation）的持久化读回
 （`durable_completion.py`：`read_persisted_todo_record` /
@@ -602,6 +603,62 @@ settlement 之前重新读取已落盘的 lifecycle record（Markdown 优先，e
 与 successor / no-follow-up 字段矛盾时，seam 都 fail closed，因此持有完成状态的
 provider 必须逐字节保存这个字段。一旦远端 provider 成为 canonical，这个 seam 翻转为
 provider-first，且不改变下述 typed outcome 合同。
+
+#### Stage 2 切片状态（2026-08-23）
+
+第一个 Stage 2 切片已经以增量方式存在于本分支：
+
+- `loopx.control_plane.coordination.head`：`loopx_coordination_head_v0`
+  aggregate 编解码。校验是封闭字段集且 fail-closed 的，包括伪装成整数的
+  bool 与损坏的 lease 记录；`handoff_mode` 成为 head 的记录字段，v0 钦定为
+  `hard_lease`（`soft_claim` goal 在 bootstrap 处 fail closed，而不是被静默
+  反转其声明语义）。规范字节被定义为按键排序、最小分隔符、UTF-8 的 JSON，
+  且拒绝非有限浮点数；digest 与 provider 字节级 parity 都以这一编码为基准，
+  "deterministic serialization" 因此是合同条款，而非实现巧合。
+- `loopx.control_plane.coordination.file_provider`：一个 goal 一份文档，
+  排他锁内 generation 比较，独占临时文件创建加 fsync 加原子替换。崩溃窗口
+  报告 `ambiguous`；无法忠实序列化为严格 JSON 的 head 在任何字节落盘之前
+  报告 typed `failed`。
+- `loopx.control_plane.coordination.executor`：`claim_work` 的第 5 节步骤
+  1-10。所有领域决策都委托给 Stage 1 core；组合顺序是先 lease acquire、再
+  过 hard-lease holder gate 的 claim——claim-first 或 legacy 模式的组合会
+  静默绕过附录 B 的 holder gate（测试钉住了这一点）。Provider 的 `failed`
+  判据经重载 receipt index 核查而非盲信，误报已落盘写入的 provider 无法
+  制造"调用方被告知失败"的幽灵 claim。
+
+设计选型是对比出来的：三个 executor 候选（core 委托、内联规则参考实现、
+同文档内 journal 式回执日志）跑同一场景电池。只有 core 委托的候选能在不改
+本地代码的情况下跟随 core 规则翻转；journal 编码在 `retain_all_v0` 下也
+省不出有意义的字节。最终交付的是 core 委托候选。
+
+Live 资格验证在 0.11.0 标签的单节点 NoKV dev 栈上通过其 Python SDK 完成：
+`examples/nokv-shadow-provider/live_e2e.py` 的八场景不变量矩阵对 file
+provider 与 NoKV provider 逐行结果一致（同 todo 竞争恰一胜者、独立 todo
+推进、精确重放、identity 不匹配、陈旧 revision 冲突、丢失响应经 receipt
+index 恢复、回执保留、authority_revision 推进）；对 serving owner 的
+SIGKILL 加运维式重开保持了 head 字节级一致，经全新 executor 精确重放原始
+receipt，并在三个版本域上恢复 CAS 推进。renew/release/reclaim、retention
+策略、HA 与多节点部署仍未验证，与后续资格清单一致。
+
+Stage 3 必须尊重而非重新发现的实测边界：
+
+- `retain_all_v0` 在单 CAS 文档内的成本约每 receipt 750 字节；dev 栈上
+  claim 延迟在前 120 个 receipt 内增长约 7 倍，累计重发布字节呈平方增长
+  （120 次 claim 后约为最终 head 体量的 84 倍）。第 12 节的 retention 决策
+  在任何生产 canary 之前都是承重项。
+- 12 个并发独立 todo claim 下，内部 rebase 预算放行 8 个，其余返回 typed
+  失败。第 1 节的独立性承诺在两个端点成立、超出即退化；受支持的并发包络
+  与重试预算应在多 agent canary 立项时进入验收检查。
+- NoKV 文档 generation 在 remove/recreate 之后、以及 restore 进新 workbench
+  lineage 之后会重新起算。携带陈旧 generation 观测的条件替换在重建路径上
+  被实测成功；恢复线会重新到达 generation 数值相同、receipt 却不同于原线
+  的状态。这坐实了上文边界句：仅靠 `provider_generation` 无法承载 restore
+  或生命周期身份；lineage/binding fence 需要在下一阶段成为显式的 provider
+  合同字段。
+- `provider_outcome_unproved` 是 live 运行中真实出现的终态（无故障注入即
+  观测到）。经 receipt index 的重放让重新提交幂等，因此同 generation 的
+  有界重试是安全的；v0 是否采纳该活性修正是 owner 决策，在此记录而非静默
+  实现。
 
 ### P0：合同与 deterministic proof
 

--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
@@ -609,22 +609,32 @@ provider-first，且不改变下述 typed outcome 合同。
 第一个 Stage 2 切片已经以增量方式存在于本分支：
 
 - `loopx.control_plane.coordination.head`：`loopx_coordination_head_v0`
-  aggregate 编解码。校验是封闭字段集且 fail-closed 的，包括伪装成整数的
-  bool 与损坏的 lease 记录；`handoff_mode` 成为 head 的记录字段，v0 钦定为
-  `hard_lease`（`soft_claim` goal 在 bootstrap 处 fail closed，而不是被静默
-  反转其声明语义）。规范字节被定义为按键排序、最小分隔符、UTF-8 的 JSON，
-  且拒绝非有限浮点数；digest 与 provider 字节级 parity 都以这一编码为基准，
-  "deterministic serialization" 因此是合同条款，而非实现巧合。
-- `loopx.control_plane.coordination.file_provider`：一个 goal 一份文档，
-  排他锁内 generation 比较，独占临时文件创建加 fsync 加原子替换。崩溃窗口
-  报告 `ambiguous`；无法忠实序列化为严格 JSON 的 head 在任何字节落盘之前
-  报告 typed `failed`。
+  aggregate 编解码。校验对 executor 后续无条件解引用的每个字段都是封闭
+  字段集且 fail-closed 的：todo、lease 记录、以及每条 receipt-index 条目
+  （条目形状、digest 形式、receipt schema、operation 身份、todo 归属、
+  revision/epoch、可解析的时间戳），包括伪装成整数的 bool；`handoff_mode`
+  是 head 的记录字段，v0 钦定为 `hard_lease`（`soft_claim` goal 在
+  bootstrap 处 fail closed，而不是被静默反转其声明语义）。规范字节被定义
+  为按键排序、最小分隔符、UTF-8 的 JSON，且拒绝非有限浮点数；digest 与
+  provider 字节级 parity 都以这一编码为基准，"deterministic serialization"
+  因此是合同条款，而非实现巧合。Markdown shadow 构造器独立为桥接模块
+  （`goal_state_shadow`），使编解码模块的 import 闭包留在仓库的 strict
+  类型门之内。
+- `loopx.control_plane.coordination.file_provider`：一个 goal 一份文档。
+  锁经由 `loopx.file_lock`——仓库唯一的跨平台锁 owner——并带其有界等待
+  （超时未获锁是 typed `failed`，因为尚未尝试任何写入）。持久化是固定的
+  提交序列：规范字节 write-all（短写会被继续写完，绝不忽略）、文件
+  fsync、原子 rename、POSIX 上再对父目录 fsync；只有整个序列收敛后才返回
+  `applied`，序列内任何存储故障都报告 `ambiguous`。无法忠实序列化为严格
+  JSON 的 head 在任何字节落盘之前报告 typed `failed`。
 - `loopx.control_plane.coordination.executor`：`claim_work` 的第 5 节步骤
   1-10。所有领域决策都委托给 Stage 1 core；组合顺序是先 lease acquire、再
   过 hard-lease holder gate 的 claim——claim-first 或 legacy 模式的组合会
-  静默绕过附录 B 的 holder gate（测试钉住了这一点）。Provider 的 `failed`
-  判据经重载 receipt index 核查而非盲信，误报已落盘写入的 provider 无法
-  制造"调用方被告知失败"的幽灵 claim。
+  静默绕过附录 B 的 holder gate（测试钉住了这一点）。`lease_ttl_seconds`
+  受本地 task-lease authority 自身上限约束：共享 envelope 铸不出本地合同
+  会拒绝的 lease，无界的调用方数值也不可能以时间戳运算溢出的形式逃逸。
+  Provider 的 `failed` 判据经重载 receipt index 核查而非盲信，误报已落盘
+  写入的 provider 无法制造"调用方被告知失败"的幽灵 claim。
 
 设计选型是对比出来的：三个 executor 候选（core 委托、内联规则参考实现、
 同文档内 journal 式回执日志）跑同一场景电池。只有 core 委托的候选能在不改

--- a/examples/nokv-shadow-provider/README.md
+++ b/examples/nokv-shadow-provider/README.md
@@ -114,6 +114,20 @@ before NoKV 0.11.0 cannot decode a 0.11.0 control-plane routing record, so
 the earlier `90883d13539e31185f0d78131989fb51912dbd7e` audit baseline is no
 longer a usable pin.
 
+Since the Stage 2 slice, the live qualification is scripted and repeatable:
+`live_e2e.py` runs one eight-scenario invariant matrix (competition, replay,
+identity mismatch, stale revision, lost response, retention, revision
+advancement) through the production `CoordinationAuthorityExecutor` against
+the file-backed control provider and, when `NOKV_COORDINATION_LIVE=1` and the
+stack variables are set, against this NoKV provider, then prints a
+public-safe parity table. Without a reachable stack the NoKV rows report
+unverified and the script stays green, so it is evidence tooling, not a
+merge gate.
+
+```bash
+python3 examples/nokv-shadow-provider/live_e2e.py
+```
+
 Run the merge-relevant deterministic regression from the repository root with:
 
 ```bash

--- a/examples/nokv-shadow-provider/live_e2e.py
+++ b/examples/nokv-shadow-provider/live_e2e.py
@@ -1,0 +1,264 @@
+"""Repeatable live Stage-2 slice: production executor over file and NoKV providers.
+
+This is the bounded live qualification the direction tracker asks for before
+any provider promotion: the SAME invariant scenarios run against the
+file-backed control provider and the live NoKV candidate, and the script
+prints a compact public-safe pass/fail/unverified matrix. It is evidence
+tooling, not a merge gate: without a reachable stack it reports every live
+row as unverified and exits 0 only when nothing that DID run failed.
+
+Environment (all required for the NoKV rows):
+  NOKV_COORDINATION_LIVE=1
+  NOKV_ETCD / NOKV_ETCD_PREFIX / NOKV_ROOT_ID
+  NOKV_BUCKET / NOKV_OBJECT_ENDPOINT / NOKV_OBJECT_ROOT
+  NOKV_OBJECT_KEY / NOKV_OBJECT_SECRET
+
+Run from the repository root:
+  python3 examples/nokv-shadow-provider/live_e2e.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import threading
+import uuid
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from loopx.control_plane.coordination.executor import (  # noqa: E402
+    CoordinationAuthorityExecutor,
+    sample_claim_envelope,
+)
+from loopx.control_plane.coordination.file_provider import (  # noqa: E402
+    FileCoordinationProvider,
+)
+from loopx.control_plane.coordination.head import bootstrap_head  # noqa: E402
+
+from provider import NoKVCoordinationProvider  # noqa: E402
+
+
+def eligibility() -> dict:
+    return {
+        "authorization_projection_revision": 3,
+        "authorization_projection_digest": "sha256:bootstrap-auth",
+        "allowed_agent_ids": ["agent-a", "agent-b"],
+        "dependencies_satisfied": True,
+        "dependency_revision": 12,
+        "gates_open": True,
+        "gate_revision": 5,
+    }
+
+
+def todo() -> dict:
+    return {
+        "todo_revision": 7,
+        "status": "open",
+        "claimed_by": None,
+        "eligibility": eligibility(),
+        "repository": "git:example/repo",
+        "code_revision": "0123456789abcdef",
+        "last_lease_epoch": 6,
+    }
+
+
+def claim(executor, agent: str, todo_id: str, operation_id: str, ttl: int = 600):
+    return executor.apply(
+        sample_claim_envelope(
+            goal_id=executor.goal_id,
+            operation_id=operation_id,
+            agent_id=agent,
+            device_id=f"dev-{agent}",
+            todo_id=todo_id,
+            expected_todo_revision=7,
+            expected_preconditions={
+                "authorization_projection_revision": 3,
+                "authorization_projection_digest": "sha256:bootstrap-auth",
+                "dependency_revision": 12,
+                "gate_revision": 5,
+            },
+            lease_ttl_seconds=ttl,
+        )
+    )
+
+
+def scenario_matrix(make_provider) -> dict:
+    """The shared invariant script, provider-agnostic. Returns row -> bool."""
+
+    rows: dict[str, bool] = {}
+    goal_id = "g" + uuid.uuid4().hex[:8]
+    provider_a = make_provider(goal_id)
+    provider_b = make_provider(goal_id)
+    head = bootstrap_head(goal_id, {"todo-1": todo(), "todo-2": todo()})
+    assert provider_a.load() == (None, 0)
+    assert provider_a.compare_and_put(0, head)["result"] == "applied"
+    executor_a = CoordinationAuthorityExecutor(
+        provider_a, goal_id=goal_id, now=lambda: 1_800_000_000.0
+    )
+    executor_b = CoordinationAuthorityExecutor(
+        provider_b, goal_id=goal_id, now=lambda: 1_800_000_000.0
+    )
+
+    # same-todo race with two independent handles and a real thread barrier
+    barrier = threading.Barrier(2)
+    outcomes: dict[str, dict] = {}
+
+    def race(name, executor, agent):
+        barrier.wait()
+        outcomes[name] = claim(executor, agent, "todo-1", f"race-{agent}")
+
+    threads = [
+        threading.Thread(target=race, args=("a", executor_a, "agent-a")),
+        threading.Thread(target=race, args=("b", executor_b, "agent-b")),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    kinds = sorted(outcome["result"] for outcome in outcomes.values())
+    rows["same_todo_one_winner"] = kinds == ["applied", "conflict"]
+
+    winner = next(o for o in outcomes.values() if o["result"] == "applied")
+    winner_agent = winner["original_receipt"]["actor"]["agent_id"]
+    other_agent = "agent-b" if winner_agent == "agent-a" else "agent-a"
+
+    # independent todo applies for the other endpoint after internal rebase
+    second = claim(executor_b, other_agent, "todo-2", "independent-1")
+    rows["independent_todo_applies"] = second["result"] == "applied"
+
+    # exact replay across a reconstructed executor
+    replay_executor = CoordinationAuthorityExecutor(
+        make_provider(goal_id), goal_id=goal_id, now=lambda: 1_800_000_000.0
+    )
+    replayed = claim(replay_executor, winner_agent, "todo-1", f"race-{winner_agent}")
+    rows["replay_returns_original_receipt"] = (
+        replayed["result"] == "already_applied"
+        and replayed["original_receipt"] == winner["original_receipt"]
+    )
+
+    # identity reuse with different semantics
+    mutated = claim(
+        replay_executor, winner_agent, "todo-1", f"race-{winner_agent}", ttl=601
+    )
+    rows["identity_mismatch_rejected"] = (
+        mutated["result"] == "rejected"
+        and mutated["reason"] == "operation_identity_mismatch"
+    )
+
+    # stale caller revision conflicts without state change
+    head_now, generation_now = provider_a.load()
+    stale = claim(executor_a, winner_agent, "todo-2", "stale-1")
+    rows["stale_revision_conflicts"] = (
+        stale["result"] == "conflict"
+        and provider_a.load() == (head_now, generation_now)
+    )
+
+    # lost response after commit recovers through the receipt index
+    class LossyOnce:
+        def __init__(self, inner):
+            self.inner = inner
+            self.armed = True
+
+        def load(self):
+            return self.inner.load()
+
+        def compare_and_put(self, expected, proposed):
+            outcome = self.inner.compare_and_put(expected, proposed)
+            if self.armed and outcome.get("result") == "applied":
+                self.armed = False
+                return {"result": "ambiguous"}
+            return outcome
+
+    lossy_executor = CoordinationAuthorityExecutor(
+        LossyOnce(make_provider(goal_id)),
+        goal_id=goal_id,
+        now=lambda: 1_800_000_000.0,
+    )
+    goal2 = "g" + uuid.uuid4().hex[:8]
+    provider2 = make_provider(goal2)
+    provider2.compare_and_put(0, bootstrap_head(goal2, {"todo-1": todo()}))
+    lossy2 = CoordinationAuthorityExecutor(
+        LossyOnce(provider2), goal_id=goal2, now=lambda: 1_800_000_000.0
+    )
+    lost = claim(lossy2, "agent-a", "todo-1", "lost-1")
+    rows["lost_response_recovers_receipt"] = lost["result"] == "already_applied"
+    del lossy_executor
+
+    final_head, _ = provider_a.load()
+    rows["receipts_retained"] = len(final_head["receipt_index"]) == 2
+    rows["authority_revision_advanced_twice"] = final_head["authority_revision"] == 2
+    return rows
+
+
+def file_matrix(root: Path) -> dict:
+    return scenario_matrix(
+        lambda goal_id: FileCoordinationProvider(root / "coordination", goal_id)
+    )
+
+
+def nokv_matrix() -> tuple[dict | None, str | None]:
+    if os.environ.get("NOKV_COORDINATION_LIVE") != "1":
+        return None, "NOKV_COORDINATION_LIVE unset"
+    try:
+        import nokv
+    except ImportError:
+        return None, "nokv SDK not installed"
+    env = os.environ
+    routing = nokv.RoutingConfig.etcd([env["NOKV_ETCD"]], env["NOKV_ETCD_PREFIX"], 10)
+
+    def make_client():
+        objects = nokv.ObjectStoreConfig.s3(
+            env["NOKV_BUCKET"],
+            region="us-east-1",
+            root=env["NOKV_OBJECT_ROOT"],
+            endpoint=env["NOKV_OBJECT_ENDPOINT"],
+            access_key_id=env["NOKV_OBJECT_KEY"],
+            secret_access_key=env["NOKV_OBJECT_SECRET"],
+        )
+        return nokv.Client(env["NOKV_ROOT_ID"], routing, objects)
+
+    workbench = "wbstage2" + uuid.uuid4().hex[:10]
+    make_client().create_workspace(workbench)
+
+    def make_provider(goal_id):
+        return NoKVCoordinationProvider(make_client(), workbench, goal_id)
+
+    return scenario_matrix(make_provider), None
+
+
+def main() -> int:
+    matrix: dict[str, dict] = {}
+    with tempfile.TemporaryDirectory() as root:
+        matrix["file_provider"] = file_matrix(Path(root))
+    nokv_rows, skip_reason = nokv_matrix()
+    if nokv_rows is None:
+        matrix["nokv_provider"] = {"unverified": skip_reason}
+    else:
+        matrix["nokv_provider"] = nokv_rows
+        parity = {
+            row: matrix["file_provider"].get(row) == value
+            for row, value in nokv_rows.items()
+        }
+        matrix["file_nokv_parity"] = {
+            "identical_row_outcomes": all(parity.values()),
+            "rows": len(parity),
+        }
+    print(json.dumps(matrix, indent=2, sort_keys=True))
+    failed = [
+        f"{provider}.{row}"
+        for provider, rows in matrix.items()
+        for row, value in rows.items()
+        if value is False
+    ]
+    if failed:
+        print("FAILED rows:", failed, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/control_plane/coordination/executor.py
+++ b/loopx/control_plane/coordination/executor.py
@@ -55,6 +55,11 @@ _PRECONDITION_FIELDS = {
     "gate_revision",
 }
 _MAX_CAS_ATTEMPTS = 8
+# The local task-lease authority's ceiling
+# (work_items.task_lease.MAX_TASK_LEASE_TTL_SECONDS), mirrored here so this
+# module's import closure stays inside the strict type gate; a pin test
+# asserts the two never drift.
+MAX_LEASE_TTL_SECONDS = 24 * 60 * 60
 
 # Core code -> RFC reason vocabulary for the claim_work slice. Actor and
 # owner ineligibility collapse onto the RFC's one actor reason; ownership
@@ -220,8 +225,19 @@ class CoordinationAuthorityExecutor:
         if not isinstance(digest, str) or not digest.startswith("sha256:"):
             raise EnvelopeError("expected authorization projection digest is invalid")
         ttl = command["lease_ttl_seconds"]
-        if not isinstance(ttl, int) or isinstance(ttl, bool) or ttl <= 0:
-            raise EnvelopeError("lease_ttl_seconds must be positive")
+        # The bound is the local task-lease authority's own ceiling, so the
+        # shared envelope cannot mint a lease the local contract would refuse,
+        # and an unbounded caller value can never reach wall-clock arithmetic
+        # (an astronomical TTL overflows timestamp formatting).
+        if (
+            not isinstance(ttl, int)
+            or isinstance(ttl, bool)
+            or ttl <= 0
+            or ttl > MAX_LEASE_TTL_SECONDS
+        ):
+            raise EnvelopeError(
+                f"lease_ttl_seconds must be between 1 and {MAX_LEASE_TTL_SECONDS}"
+            )
         # Transport metadata is deliberately excluded from the semantic request.
         return {
             "schema_version": COMMAND_SCHEMA_VERSION,

--- a/loopx/control_plane/coordination/executor.py
+++ b/loopx/control_plane/coordination/executor.py
@@ -1,0 +1,508 @@
+"""The authority execution layer over a coordination provider (RFC section 5).
+
+The executor owns exactly what the Stage 1 core refuses: envelope
+normalization and request digests, aggregate-level preconditions
+(todo revisions, eligibility snapshots, dependency and gate booleans),
+receipt construction and replay, wall-clock expiry minting, the three version
+domains (``provider_generation`` / ``authority_revision`` / ``lease_epoch``),
+and the bounded load -> decide -> compare_and_put -> reload loop. Every
+domain decision about actors and leases is delegated to
+``authority_core.decide``; no coordination rule is re-derived here.
+
+The only command in this slice is ``claim_work`` (RFC section 5.1): one
+accepted transition records the claim, the lease with its next epoch, and the
+original receipt in the same provider CAS.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from .authority_core import (
+    DecisionOutcome,
+    LeaseAcquireCommand,
+    TodoAction,
+    TodoMutationCommand,
+    decide,
+)
+from .head import (
+    HeadValidationError,
+    canonical_head_bytes,
+    claim_snapshot_for_todo,
+    validated_head,
+)
+
+COMMAND_SCHEMA_VERSION = "loopx_command_v0"
+RECEIPT_SCHEMA_VERSION = "loopx_authority_receipt_v0"
+
+_ENVELOPE_FIELDS = {"schema_version", "operation_id", "actor", "goal_id", "command", "transport"}
+_ACTOR_FIELDS = {"agent_id", "device_id"}
+_COMMAND_FIELDS = {
+    "type",
+    "todo_id",
+    "expected_todo_revision",
+    "expected_preconditions",
+    "lease_ttl_seconds",
+}
+_PRECONDITION_FIELDS = {
+    "authorization_projection_revision",
+    "authorization_projection_digest",
+    "dependency_revision",
+    "gate_revision",
+}
+_MAX_CAS_ATTEMPTS = 8
+
+# Core code -> RFC reason vocabulary for the claim_work slice. Actor and
+# owner ineligibility collapse onto the RFC's one actor reason; ownership
+# codes that the executor's aggregate prechecks should have intercepted are
+# aggregate-integrity failures, so they fail closed instead of masquerading
+# as caller errors.
+_CORE_TO_RFC_REASON = {
+    "actor_required": "actor_ineligible",
+    "actor_not_registered": "actor_ineligible",
+    "actor_excluded": "actor_ineligible",
+    "claim_actor_mismatch": "actor_ineligible",
+    "invalid_owner": "actor_ineligible",
+    "owner_not_registered": "actor_ineligible",
+    "owner_excluded_from_todo": "actor_ineligible",
+    "todo_not_open": "todo_not_open",
+    "todo_not_found": "todo_not_found",
+}
+_FAIL_CLOSED_CORE_CODES = {
+    "claim_owner_mismatch",
+    "owner_conflicts_with_claim",
+    "invalid_lease_snapshot",
+}
+
+
+def _classified(plan: Any) -> dict[str, Any]:
+    """Map one non-APPLY core TransitionPlan onto an RFC result class."""
+
+    if plan.code in _FAIL_CLOSED_CORE_CODES:
+        # The executor's revision and open/unclaimed prechecks make these
+        # unreachable on a well-formed head; reaching one means the aggregate
+        # and the core disagree, which is an integrity failure, not caller error.
+        return {"result": "failed", "reason": f"aggregate_integrity:{plan.code}"}
+    if plan.outcome is DecisionOutcome.CONFLICT:
+        return {"result": "conflict", "reason": plan.code}
+    if plan.outcome is DecisionOutcome.NO_CHANGE:
+        # A replay the receipt index does not know about cannot be proven to
+        # be this operation's own effect (acceptance check 6): fail closed.
+        return {"result": "failed", "reason": f"state_without_receipt:{plan.code}"}
+    return {
+        "result": "rejected",
+        "reason": _CORE_TO_RFC_REASON.get(plan.code, plan.code),
+    }
+
+
+class EnvelopeError(ValueError):
+    """The command envelope violates the reviewed v0 contract."""
+
+
+def _digest(value: dict[str, Any]) -> str:
+    encoded = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _lease_id(operation_id: str) -> str:
+    return "lease_" + hashlib.sha256(f"lease:{operation_id}".encode()).hexdigest()[:24]
+
+
+def _format_time(timestamp: float) -> str:
+    return (
+        datetime.fromtimestamp(timestamp, timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _parse_time(value: str) -> float:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+
+
+def sample_claim_envelope(
+    *,
+    goal_id: str,
+    operation_id: str,
+    agent_id: str,
+    device_id: str,
+    todo_id: str,
+    expected_todo_revision: int,
+    expected_preconditions: dict[str, Any],
+    lease_ttl_seconds: int,
+    transport: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build one well-formed ``claim_work`` envelope (tests and adapters)."""
+
+    envelope: dict[str, Any] = {
+        "schema_version": COMMAND_SCHEMA_VERSION,
+        "operation_id": operation_id,
+        "actor": {"agent_id": agent_id, "device_id": device_id},
+        "goal_id": goal_id,
+        "command": {
+            "type": "claim_work",
+            "todo_id": todo_id,
+            "expected_todo_revision": expected_todo_revision,
+            "expected_preconditions": copy.deepcopy(expected_preconditions),
+            "lease_ttl_seconds": lease_ttl_seconds,
+        },
+    }
+    if transport is not None:
+        envelope["transport"] = copy.deepcopy(transport)
+    return envelope
+
+
+class CoordinationAuthorityExecutor:
+    """Apply normalized coordination commands through one provider CAS."""
+
+    def __init__(
+        self,
+        provider: Any,
+        *,
+        goal_id: str,
+        now: Callable[[], float],
+    ):
+        self.provider = provider
+        self.goal_id = goal_id
+        self.now = now
+
+    # ---- envelope normalization (RFC section 5) -----------------------------
+
+    def _semantic_request(self, envelope: Any) -> dict[str, Any]:
+        if not isinstance(envelope, dict):
+            raise EnvelopeError("command envelope must be an object")
+        unknown = set(envelope) - _ENVELOPE_FIELDS
+        if unknown:
+            raise EnvelopeError(f"unknown command envelope fields: {sorted(unknown)}")
+        if envelope.get("schema_version") != COMMAND_SCHEMA_VERSION:
+            raise EnvelopeError("unsupported command envelope schema")
+        operation_id = envelope.get("operation_id")
+        if not isinstance(operation_id, str) or not operation_id:
+            raise EnvelopeError("operation_id must be a non-empty string")
+        if envelope.get("goal_id") != self.goal_id:
+            raise EnvelopeError("command goal_id does not match this authority")
+        if "transport" in envelope and not isinstance(envelope["transport"], dict):
+            raise EnvelopeError("transport metadata must be an object")
+        actor = envelope.get("actor")
+        if not isinstance(actor, dict) or set(actor) != _ACTOR_FIELDS:
+            raise EnvelopeError("actor must contain only agent_id and device_id")
+        if not all(isinstance(actor[key], str) and actor[key] for key in _ACTOR_FIELDS):
+            raise EnvelopeError("actor ids must be non-empty strings")
+        command = envelope.get("command")
+        if not isinstance(command, dict) or set(command) != _COMMAND_FIELDS:
+            raise EnvelopeError("claim_work fields do not match the v0 contract")
+        if command.get("type") != "claim_work":
+            raise EnvelopeError("this slice supports only claim_work")
+        if not isinstance(command["todo_id"], str) or not command["todo_id"]:
+            raise EnvelopeError("todo_id must be a non-empty string")
+        revision = command["expected_todo_revision"]
+        if not isinstance(revision, int) or isinstance(revision, bool):
+            raise EnvelopeError("expected_todo_revision must be an integer")
+        preconditions = command["expected_preconditions"]
+        if not isinstance(preconditions, dict) or set(preconditions) != _PRECONDITION_FIELDS:
+            raise EnvelopeError("expected_preconditions fields do not match v0")
+        for field in (
+            "authorization_projection_revision",
+            "dependency_revision",
+            "gate_revision",
+        ):
+            value = preconditions[field]
+            if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                raise EnvelopeError("expected_preconditions revisions must be non-negative")
+        digest = preconditions["authorization_projection_digest"]
+        if not isinstance(digest, str) or not digest.startswith("sha256:"):
+            raise EnvelopeError("expected authorization projection digest is invalid")
+        ttl = command["lease_ttl_seconds"]
+        if not isinstance(ttl, int) or isinstance(ttl, bool) or ttl <= 0:
+            raise EnvelopeError("lease_ttl_seconds must be positive")
+        # Transport metadata is deliberately excluded from the semantic request.
+        return {
+            "schema_version": COMMAND_SCHEMA_VERSION,
+            "operation_id": operation_id,
+            "actor": {key: actor[key] for key in sorted(_ACTOR_FIELDS)},
+            "goal_id": self.goal_id,
+            "command": {
+                key: copy.deepcopy(command[key]) for key in sorted(_COMMAND_FIELDS)
+            },
+        }
+
+    # ---- replay -------------------------------------------------------------
+
+    def _replay(
+        self,
+        head: dict[str, Any],
+        provider_generation: int,
+        operation_id: str,
+        request_digest: str,
+    ) -> dict[str, Any] | None:
+        entry = head["receipt_index"].get(operation_id)
+        if entry is None:
+            return None
+        if entry.get("request_digest") != request_digest:
+            return {
+                "result": "rejected",
+                "reason": "operation_identity_mismatch",
+                "operation_id": operation_id,
+                "observed_authority_revision": head["authority_revision"],
+                "provider_generation": provider_generation,
+            }
+        receipt = entry.get("original_receipt")
+        if not isinstance(receipt, dict):
+            raise HeadValidationError("receipt entry lacks original_receipt")
+        return self._success("already_applied", receipt, head, provider_generation)
+
+    def _success(
+        self,
+        result: str,
+        receipt: dict[str, Any],
+        head: dict[str, Any],
+        generation: int,
+    ) -> dict[str, Any]:
+        lease = head["coordination"]["leases"].get(receipt["todo_id"])
+        if lease is None or (
+            lease.get("lease_id") != receipt.get("lease_id")
+            or lease.get("lease_epoch") != receipt.get("lease_epoch")
+        ):
+            status = "superseded"
+        elif _parse_time(lease["expires_at"]) <= self.now():
+            status = "expired"
+        else:
+            status = "active"
+        return {
+            "result": result,
+            "original_receipt": copy.deepcopy(receipt),
+            "observed_authority_revision": head["authority_revision"],
+            "authorization_status": status,
+            "provider_generation": generation,
+        }
+
+    # ---- the one transition of this slice -----------------------------------
+
+    def _claim_transition(
+        self,
+        head: dict[str, Any],
+        request: dict[str, Any],
+        request_digest: str,
+    ) -> dict[str, Any] | tuple[dict[str, Any], dict[str, Any]]:
+        """Return either a typed non-apply dict, or (next_head, receipt)."""
+
+        command = request["command"]
+        todo_id = command["todo_id"]
+        todo = head["coordination"]["todos"].get(todo_id)
+        if todo is None:
+            return {"result": "rejected", "reason": "todo_not_found"}
+        if todo["todo_revision"] != command["expected_todo_revision"]:
+            return {
+                "result": "conflict",
+                "reason": "todo_revision_mismatch",
+                "expected_todo_revision": command["expected_todo_revision"],
+                "observed_todo_revision": todo["todo_revision"],
+            }
+        eligibility = todo["eligibility"]
+        observed_preconditions = {
+            field: eligibility[field] for field in _PRECONDITION_FIELDS
+        }
+        if observed_preconditions != command["expected_preconditions"]:
+            return {
+                "result": "conflict",
+                "reason": "precondition_snapshot_mismatch",
+                "expected_preconditions": copy.deepcopy(
+                    command["expected_preconditions"]
+                ),
+                "observed_preconditions": observed_preconditions,
+            }
+        if todo["status"] != "open" or todo["claimed_by"] is not None:
+            return {"result": "rejected", "reason": "todo_not_open"}
+        if eligibility["dependencies_satisfied"] is not True:
+            return {"result": "rejected", "reason": "dependencies_not_satisfied"}
+        if eligibility["gates_open"] is not True:
+            return {"result": "rejected", "reason": "gate_closed"}
+
+        actor = request["actor"]["agent_id"]
+        snapshot = claim_snapshot_for_todo(head, todo_id)
+
+        # Composition order is fixed by the Stage 1 core: the lease is minted
+        # first, then the claim passes the hard-lease holder gate against the
+        # freshly minted lease. Claim-first would silently bypass the
+        # Appendix B invariant that ownership changes require the holder.
+        acquire_plan = decide(
+            snapshot,
+            LeaseAcquireCommand(
+                owner=actor,
+                idempotency_key=_lease_id(request["operation_id"]),
+                ttl_seconds=command["lease_ttl_seconds"],
+            ),
+        )
+        if acquire_plan.outcome is not DecisionOutcome.APPLY:
+            return _classified(acquire_plan)
+        assert acquire_plan.next_snapshot is not None
+
+        claim_plan = decide(
+            acquire_plan.next_snapshot,
+            TodoMutationCommand(
+                action=TodoAction.CLAIM,
+                actor_agent_id=actor,
+                requested_claimed_by=actor,
+                ownership_mutation=True,
+            ),
+        )
+        if claim_plan.outcome is not DecisionOutcome.APPLY:
+            return _classified(claim_plan)
+        assert claim_plan.next_snapshot is not None
+        core_lease = claim_plan.next_snapshot.lease
+        assert core_lease is not None
+
+        now = float(self.now())
+        expires_at = _format_time(now + command["lease_ttl_seconds"])
+        next_head = copy.deepcopy(head)
+        next_head["authority_revision"] += 1
+        next_todo = next_head["coordination"]["todos"][todo_id]
+        next_todo.update(
+            {
+                "todo_revision": todo["todo_revision"] + 1,
+                # LoopX keeps a claimed todo open; ``claimed_by`` plus the
+                # lease carry ownership without a new lifecycle status.
+                "status": "open",
+                "claimed_by": actor,
+                "last_lease_epoch": core_lease.lease_epoch,
+            }
+        )
+        next_head["coordination"]["leases"][todo_id] = {
+            "lease_id": core_lease.idempotency_key,
+            "owner": core_lease.owner,
+            "lease_epoch": core_lease.lease_epoch,
+            "expires_at": expires_at,
+            "write_scopes": list(core_lease.write_scopes),
+        }
+        receipt = {
+            "schema_version": RECEIPT_SCHEMA_VERSION,
+            "operation_id": request["operation_id"],
+            "request_digest": request_digest,
+            "command": "claim_work",
+            "actor": copy.deepcopy(request["actor"]),
+            "todo_id": todo_id,
+            "accepted_authority_revision": next_head["authority_revision"],
+            "accepted_todo_revision": next_todo["todo_revision"],
+            "applied_at": _format_time(now),
+            "lease_id": core_lease.idempotency_key,
+            "lease_epoch": core_lease.lease_epoch,
+            "expires_at": expires_at,
+        }
+        next_head["receipt_index"][request["operation_id"]] = {
+            "request_digest": request_digest,
+            "original_receipt": copy.deepcopy(receipt),
+        }
+        return next_head, receipt
+
+    # ---- RFC section 5 steps 1-10 -------------------------------------------
+
+    def apply(self, envelope: dict[str, Any]) -> dict[str, Any]:
+        request = self._semantic_request(envelope)
+        operation_id = request["operation_id"]
+        request_digest = _digest(request)
+
+        head, provider_generation = self.provider.load()
+        if head is None:
+            return {
+                "result": "failed",
+                "reason": "coordination_head_uninitialized",
+                "provider_generation": provider_generation,
+            }
+        head = validated_head(head, goal_id=self.goal_id)
+
+        for _attempt in range(_MAX_CAS_ATTEMPTS):
+            replay = self._replay(head, provider_generation, operation_id, request_digest)
+            if replay is not None:
+                return replay
+            transition = self._claim_transition(head, request, request_digest)
+            if isinstance(transition, dict):
+                transition.update(
+                    {
+                        "observed_authority_revision": head["authority_revision"],
+                        "provider_generation": provider_generation,
+                    }
+                )
+                return transition
+            proposed, original_receipt = transition
+            provider_result = self.provider.compare_and_put(
+                provider_generation, proposed
+            )
+            result_kind = provider_result.get("result")
+            if result_kind == "applied":
+                return self._success(
+                    "applied",
+                    original_receipt,
+                    proposed,
+                    provider_result["provider_generation"],
+                )
+            if result_kind not in {"conflict", "ambiguous", "failed"}:
+                raise HeadValidationError(
+                    f"unknown provider result: {provider_result!r}"
+                )
+            if result_kind == "failed":
+                # The verb claims the write provably never happened. That
+                # claim is verified, not trusted: one reload against the
+                # receipt index catches a provider that misreported a landed
+                # write as failed, at the cost of a single load.
+                try:
+                    check, check_generation = self.provider.load()
+                    if check is not None:
+                        check = validated_head(check, goal_id=self.goal_id)
+                        replay = self._replay(
+                            check, check_generation, operation_id, request_digest
+                        )
+                        if replay is not None:
+                            return replay
+                except Exception:  # noqa: BLE001 - verification is best-effort
+                    pass
+                return {
+                    "result": "failed",
+                    "reason": "provider_failed_before_cas",
+                    "observed_authority_revision": head["authority_revision"],
+                    "provider_generation": provider_generation,
+                }
+
+            latest, latest_generation = self.provider.load()
+            if latest is None:
+                return {
+                    "result": "failed",
+                    "reason": "coordination_head_missing_after_cas",
+                    "provider_generation": latest_generation,
+                }
+            latest = validated_head(latest, goal_id=self.goal_id)
+            replay = self._replay(
+                latest, latest_generation, operation_id, request_digest
+            )
+            if replay is not None:
+                return replay
+            if latest_generation == provider_generation:
+                # Same generation and no receipt: the ambiguous attempt
+                # provably did not land. Receipt absence never proves success,
+                # so an eventual applied requires a new successful CAS.
+                return {
+                    "result": "failed",
+                    "reason": "provider_outcome_unproved",
+                    "observed_authority_revision": latest["authority_revision"],
+                    "provider_generation": latest_generation,
+                }
+            head, provider_generation = latest, latest_generation
+
+        return {
+            "result": "failed",
+            "reason": "provider_contention_exhausted",
+            "observed_authority_revision": head["authority_revision"],
+            "provider_generation": provider_generation,
+        }
+
+
+def deterministic_head_bytes(head: dict[str, Any]) -> bytes:
+    """Canonical bytes for providers that store raw bytes (NoKV adapter)."""
+
+    return canonical_head_bytes(head)

--- a/loopx/control_plane/coordination/file_provider.py
+++ b/loopx/control_plane/coordination/file_provider.py
@@ -57,6 +57,21 @@ def _write_all(descriptor: int, payload: bytes) -> None:
         view = view[written:]
 
 
+# The commit-sequence steps below are module seams on purpose: fault
+# injection in tests targets the provider's own document commit without
+# touching the global os attributes that loopx.file_lock's holder
+# bookkeeping also uses (its Windows sidecar path calls os.fsync and
+# os.replace of its own).
+
+
+def _fsync_file(descriptor: int) -> None:
+    os.fsync(descriptor)
+
+
+def _replace_document(source: Path, target: Path) -> None:
+    os.replace(source, target)
+
+
 def _fsync_directory(directory: Path) -> None:
     # The rename only becomes durable once the parent directory entry is
     # flushed. Windows exposes no directory-handle fsync; there the rename's
@@ -193,10 +208,10 @@ class FileCoordinationProvider:
             )
             try:
                 _write_all(descriptor, envelope)
-                os.fsync(descriptor)
+                _fsync_file(descriptor)
             finally:
                 os.close(descriptor)
-            os.replace(temp_path, self._document)
+            _replace_document(temp_path, self._document)
             _fsync_directory(self.directory)
         except OSError:
             # The commit sequence did not provably converge: the temp write

--- a/loopx/control_plane/coordination/file_provider.py
+++ b/loopx/control_plane/coordination/file_provider.py
@@ -114,11 +114,15 @@ class FileCoordinationProvider:
             raise ProviderProtocolError(
                 f"coordination document is not valid JSON: {exc}"
             ) from exc
+        generation = envelope.get("provider_generation") if isinstance(envelope, dict) else None
         if (
             not isinstance(envelope, dict)
             or set(envelope) != {"provider_generation", "head"}
-            or not isinstance(envelope["provider_generation"], int)
-            or envelope["provider_generation"] < 1
+            # bool is an int subclass; JSON true must not load as generation 1
+            # and silently repair a corrupt envelope into a valid lineage.
+            or not isinstance(generation, int)
+            or isinstance(generation, bool)
+            or generation < 1
             or not isinstance(envelope["head"], dict)
         ):
             raise ProviderProtocolError(
@@ -140,6 +144,7 @@ class FileCoordinationProvider:
 
         if (
             not isinstance(expected_provider_generation, int)
+            or isinstance(expected_provider_generation, bool)
             or expected_provider_generation < 0
         ):
             return {

--- a/loopx/control_plane/coordination/file_provider.py
+++ b/loopx/control_plane/coordination/file_provider.py
@@ -3,19 +3,31 @@
 Storage plane only (RFC section 6.2): it serializes the opaque head it is
 given, replaces the document atomically, and reports typed outcomes. It never
 parses commands, mints clocks or leases, or interprets the head. Concurrency
-is resolved by generation compare inside an exclusive file lock; crash
-windows surface as ``ambiguous`` so the authority reloads and trusts only its
-atomically stored receipt index.
+is resolved by generation compare while holding the repository's one
+cross-platform lock owner (``loopx.file_lock``) with its bounded deadline; a
+lock that cannot be acquired in time is a typed ``failed`` because no write
+was attempted.
+
+Durability is a fixed commit sequence: write the complete canonical bytes to
+an exclusive temporary file (short writes are continued, never ignored),
+fsync the file, atomically rename it over the document, then fsync the parent
+directory so the rename itself is durable. ``applied`` is returned only after
+the whole sequence converges; any storage fault inside the sequence surfaces
+as ``ambiguous`` so the authority reloads and trusts only its atomically
+stored receipt index. On Windows there is no directory-handle fsync; the
+rename's durability there follows platform semantics and the directory step
+is a no-op.
 """
 
 from __future__ import annotations
 
-import fcntl
 import hashlib
 import json
 import os
 from pathlib import Path
 from typing import Any
+
+from ...file_lock import LockAcquireTimeoutError, exclusive_file_lock
 
 
 class ProviderProtocolError(RuntimeError):
@@ -34,17 +46,47 @@ def _canonical(envelope: dict[str, Any]) -> bytes:
     ).encode("utf-8")
 
 
+def _write_all(descriptor: int, payload: bytes) -> None:
+    # os.write may write fewer bytes than asked; a partial write that is not
+    # continued would let a truncated document masquerade as applied.
+    view = memoryview(payload)
+    while view:
+        written = os.write(descriptor, view)
+        if written <= 0:
+            raise OSError("write made no progress")
+        view = view[written:]
+
+
+def _fsync_directory(directory: Path) -> None:
+    # The rename only becomes durable once the parent directory entry is
+    # flushed. Windows exposes no directory-handle fsync; there the rename's
+    # durability follows platform semantics.
+    if os.name != "posix":  # pragma: no cover - exercised on Windows hosts
+        return
+    descriptor = os.open(directory, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
 class FileCoordinationProvider:
     """Map one goal's head document onto an atomically replaced JSON file."""
 
-    def __init__(self, directory: Path | str, goal_id: str):
+    def __init__(
+        self,
+        directory: Path | str,
+        goal_id: str,
+        *,
+        lock_timeout_seconds: float | None = None,
+    ):
         if not goal_id:
             raise ProviderProtocolError("provider goal_id must be non-empty")
         self.directory = Path(directory)
         self.goal_id = goal_id
+        self._lock_timeout_seconds = lock_timeout_seconds
         digest = hashlib.sha256(goal_id.encode("utf-8")).hexdigest()[:16]
         self._document = self.directory / f"coordination-head-{digest}.json"
-        self._lock_path = self.directory / f"coordination-head-{digest}.lock"
 
     def _read_envelope(self) -> tuple[dict[str, Any] | None, int]:
         try:
@@ -91,55 +133,80 @@ class FileCoordinationProvider:
             }
         try:
             self.directory.mkdir(parents=True, exist_ok=True)
-            lock_file = os.open(self._lock_path, os.O_CREAT | os.O_RDWR, 0o644)
         except OSError as exc:
             # No replace was attempted, so this failure proves no write.
             return {"result": "failed", "error": str(exc)}
+        outcome: dict[str, Any] | None = None
         try:
-            fcntl.flock(lock_file, fcntl.LOCK_EX)
-            current_head, current_generation = self._read_envelope()
-            del current_head
-            if current_generation != expected_provider_generation:
-                return {
-                    "result": "conflict",
-                    "current_provider_generation": current_generation,
-                }
-            next_generation = expected_provider_generation + 1
-            try:
-                envelope = _canonical(
-                    {"provider_generation": next_generation, "head": head}
+            with exclusive_file_lock(
+                self._document,
+                timeout_seconds=self._lock_timeout_seconds,
+                operation="coordination_compare_and_put",
+            ):
+                outcome = self._replace_under_lock(
+                    expected_provider_generation, head
                 )
-            except (TypeError, ValueError) as exc:
-                # Serialization runs before any write, so this failure proves
-                # no write; it must surface as the typed verb, never as an
-                # unclassified exception through the seam.
-                return {
-                    "result": "failed",
-                    "error": f"head is not canonically serializable: {exc}",
-                }
-            temp_path = self._document.with_suffix(
-                f".tmp-{os.getpid()}-{next_generation}"
+        except LockAcquireTimeoutError as exc:
+            # Bounded wait expired before any write was attempted.
+            return {"result": "failed", "error": str(exc)}
+        except ProviderProtocolError:
+            raise
+        except OSError as exc:
+            if outcome is not None:
+                # The verdict was already computed; a release-bookkeeping
+                # failure afterwards must not misreport a durable write.
+                return outcome
+            return {"result": "failed", "error": str(exc)}
+        return outcome
+
+    def _replace_under_lock(
+        self,
+        expected_provider_generation: int,
+        head: dict[str, Any],
+    ) -> dict[str, Any]:
+        current_head, current_generation = self._read_envelope()
+        del current_head
+        if current_generation != expected_provider_generation:
+            return {
+                "result": "conflict",
+                "current_provider_generation": current_generation,
+            }
+        next_generation = expected_provider_generation + 1
+        try:
+            envelope = _canonical(
+                {"provider_generation": next_generation, "head": head}
+            )
+        except (TypeError, ValueError) as exc:
+            # Serialization runs before any write, so this failure proves
+            # no write; it must surface as the typed verb, never as an
+            # unclassified exception through the seam.
+            return {
+                "result": "failed",
+                "error": f"head is not canonically serializable: {exc}",
+            }
+        temp_path = self._document.with_suffix(
+            f".tmp-{os.getpid()}-{next_generation}"
+        )
+        try:
+            descriptor = os.open(
+                temp_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644
             )
             try:
-                descriptor = os.open(
-                    temp_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644
-                )
-                try:
-                    os.write(descriptor, envelope)
-                    os.fsync(descriptor)
-                finally:
-                    os.close(descriptor)
-                os.replace(temp_path, self._document)
+                _write_all(descriptor, envelope)
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+            os.replace(temp_path, self._document)
+            _fsync_directory(self.directory)
+        except OSError:
+            # The commit sequence did not provably converge: the temp write
+            # may or may not have been renamed, and a rename may or may not
+            # be durable yet. Never parse error text as commit proof —
+            # report ambiguous and let the authority reload its atomically
+            # stored receipt index.
+            try:
+                temp_path.unlink(missing_ok=True)
             except OSError:
-                # The replace outcome is unknown from here: the temp write may
-                # or may not have been renamed. Never parse error text as
-                # commit proof — report ambiguous and let the authority
-                # reload its atomically stored receipt index.
-                try:
-                    temp_path.unlink(missing_ok=True)
-                except OSError:
-                    pass
-                return {"result": "ambiguous"}
-            return {"result": "applied", "provider_generation": next_generation}
-        finally:
-            os.close(lock_file)
+                pass
+            return {"result": "ambiguous"}
+        return {"result": "applied", "provider_generation": next_generation}

--- a/loopx/control_plane/coordination/file_provider.py
+++ b/loopx/control_plane/coordination/file_provider.py
@@ -1,0 +1,145 @@
+"""File-backed coordination provider: one atomic CAS document per goal.
+
+Storage plane only (RFC section 6.2): it serializes the opaque head it is
+given, replaces the document atomically, and reports typed outcomes. It never
+parses commands, mints clocks or leases, or interprets the head. Concurrency
+is resolved by generation compare inside an exclusive file lock; crash
+windows surface as ``ambiguous`` so the authority reloads and trusts only its
+atomically stored receipt index.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+class ProviderProtocolError(RuntimeError):
+    """Persisted bytes or a provider outcome violated the storage contract."""
+
+
+def _canonical(envelope: dict[str, Any]) -> bytes:
+    # allow_nan=False: non-finite floats would produce bytes a strict JSON
+    # reader rejects, so they must fail before ever reaching the document.
+    return json.dumps(
+        envelope,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+class FileCoordinationProvider:
+    """Map one goal's head document onto an atomically replaced JSON file."""
+
+    def __init__(self, directory: Path | str, goal_id: str):
+        if not goal_id:
+            raise ProviderProtocolError("provider goal_id must be non-empty")
+        self.directory = Path(directory)
+        self.goal_id = goal_id
+        digest = hashlib.sha256(goal_id.encode("utf-8")).hexdigest()[:16]
+        self._document = self.directory / f"coordination-head-{digest}.json"
+        self._lock_path = self.directory / f"coordination-head-{digest}.lock"
+
+    def _read_envelope(self) -> tuple[dict[str, Any] | None, int]:
+        try:
+            raw = self._document.read_bytes()
+        except FileNotFoundError:
+            return None, 0
+        try:
+            envelope = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ProviderProtocolError(
+                f"coordination document is not valid JSON: {exc}"
+            ) from exc
+        if (
+            not isinstance(envelope, dict)
+            or set(envelope) != {"provider_generation", "head"}
+            or not isinstance(envelope["provider_generation"], int)
+            or envelope["provider_generation"] < 1
+            or not isinstance(envelope["head"], dict)
+        ):
+            raise ProviderProtocolError(
+                "coordination document envelope does not match the v0 contract"
+            )
+        return envelope["head"], envelope["provider_generation"]
+
+    def load(self) -> tuple[dict[str, Any] | None, int]:
+        """Return ``(head | None, provider_generation)``."""
+
+        return self._read_envelope()
+
+    def compare_and_put(
+        self,
+        expected_provider_generation: int,
+        head: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Serialize and conditionally replace the opaque head document."""
+
+        if (
+            not isinstance(expected_provider_generation, int)
+            or expected_provider_generation < 0
+        ):
+            return {
+                "result": "failed",
+                "error": "expected_provider_generation must be a non-negative integer",
+            }
+        try:
+            self.directory.mkdir(parents=True, exist_ok=True)
+            lock_file = os.open(self._lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+        except OSError as exc:
+            # No replace was attempted, so this failure proves no write.
+            return {"result": "failed", "error": str(exc)}
+        try:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            current_head, current_generation = self._read_envelope()
+            del current_head
+            if current_generation != expected_provider_generation:
+                return {
+                    "result": "conflict",
+                    "current_provider_generation": current_generation,
+                }
+            next_generation = expected_provider_generation + 1
+            try:
+                envelope = _canonical(
+                    {"provider_generation": next_generation, "head": head}
+                )
+            except (TypeError, ValueError) as exc:
+                # Serialization runs before any write, so this failure proves
+                # no write; it must surface as the typed verb, never as an
+                # unclassified exception through the seam.
+                return {
+                    "result": "failed",
+                    "error": f"head is not canonically serializable: {exc}",
+                }
+            temp_path = self._document.with_suffix(
+                f".tmp-{os.getpid()}-{next_generation}"
+            )
+            try:
+                descriptor = os.open(
+                    temp_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644
+                )
+                try:
+                    os.write(descriptor, envelope)
+                    os.fsync(descriptor)
+                finally:
+                    os.close(descriptor)
+                os.replace(temp_path, self._document)
+            except OSError:
+                # The replace outcome is unknown from here: the temp write may
+                # or may not have been renamed. Never parse error text as
+                # commit proof — report ambiguous and let the authority
+                # reload its atomically stored receipt index.
+                try:
+                    temp_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+                return {"result": "ambiguous"}
+            return {"result": "applied", "provider_generation": next_generation}
+        finally:
+            os.close(lock_file)

--- a/loopx/control_plane/coordination/goal_state_shadow.py
+++ b/loopx/control_plane/coordination/goal_state_shadow.py
@@ -1,0 +1,98 @@
+"""Bridge the legacy Markdown goal state into a coordination bootstrap head.
+
+This is the read side of the RFC section 11 shadow: it projects the current
+``ACTIVE_GOAL_STATE.md`` text through loopx's own todo projection and admits
+exactly the open, unclaimed agent todos into an explicit ``bootstrap_head``.
+Nothing is written back.
+
+It lives apart from ``head`` deliberately: the head module is the pure v0
+document codec with a stdlib-plus-core import closure and sits inside the
+repository's strict type gate, while this bridge is the one place the
+coordination contract reaches into the untyped legacy projection world
+(`todos.contract`, ``todos.handoff_mode``, the active-state parser). When
+that world joins the typed gate, this module follows.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from ..todos.contract import normalize_todo_claimed_by, normalize_todo_id
+from ..todos.handoff_mode import goal_handoff_mode
+from .authority_core import HandoffMode
+from .head import HeadValidationError, bootstrap_head
+
+
+def _static_projection_digest(allowed_agent_ids: list[str]) -> str:
+    encoded = json.dumps(sorted(allowed_agent_ids), separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def bootstrap_head_from_goal_state(
+    state_text: str,
+    *,
+    goal_id: str,
+    repository: str,
+    code_revision: str,
+    allowed_agent_ids: list[str],
+    with_report: bool = False,
+) -> dict[str, Any] | tuple[dict[str, Any], dict[str, Any]]:
+    """Shadow the current Markdown active state into a bootstrap head.
+
+    Claimed and done todos are reported, never silently dropped; a
+    ``soft_claim`` goal fails closed instead of having its declared no-lease
+    semantics silently inverted by shared ``claim_work``.
+    """
+
+    from ..todos.active_state_todo_parser import parse_active_state_todos
+
+    source_mode = goal_handoff_mode(state_text)
+    if source_mode == HandoffMode.SOFT_CLAIM.value:
+        raise HeadValidationError(
+            "a soft_claim goal cannot bootstrap into shared authority: its"
+            " declared mode rejects lease minting, which shared claim_work"
+            " performs on every accepted claim"
+        )
+    projected = parse_active_state_todos(state_text)
+    skipped: dict[str, str] = {}
+    todos: dict[str, Any] = {}
+    for item in projected["agent_todos"]["items"]:
+        todo_id = normalize_todo_id(item.get("todo_id"))
+        if not todo_id:
+            continue
+        if item.get("done"):
+            skipped[todo_id] = "done"
+            continue
+        if normalize_todo_claimed_by(item.get("claimed_by")):
+            skipped[todo_id] = "claimed"
+            continue
+        todos[todo_id] = {
+            "todo_revision": 0,
+            "status": "open",
+            "claimed_by": None,
+            "eligibility": {
+                "authorization_projection_revision": 0,
+                "authorization_projection_digest": _static_projection_digest(
+                    allowed_agent_ids
+                ),
+                "allowed_agent_ids": list(allowed_agent_ids),
+                "dependencies_satisfied": True,
+                "dependency_revision": 0,
+                "gates_open": True,
+                "gate_revision": 0,
+            },
+            "repository": repository,
+            "code_revision": code_revision,
+            "last_lease_epoch": 0,
+        }
+    head = bootstrap_head(goal_id, todos)
+    if not with_report:
+        return head
+    report = {
+        "skipped": skipped,
+        "source_handoff_mode": source_mode,
+        "admitted": sorted(todos),
+    }
+    return head, report

--- a/loopx/control_plane/coordination/head.py
+++ b/loopx/control_plane/coordination/head.py
@@ -1,0 +1,407 @@
+"""The ``loopx_coordination_head_v0`` aggregate for the shared-goal RFC.
+
+One goal's coordination facts, its replayable receipt index, and the
+``retain_all_v0`` retention declaration form one document; a coordination
+provider stores it behind an opaque generation CAS and never interprets it.
+This module owns the document's shape: fail-closed validation, deterministic
+canonical bytes, the adapters that project aggregate facts into the Stage 1
+core's snapshot types, and the explicit bootstrap constructors (RFC section 8).
+
+It performs no I/O and makes no domain decisions: transitions belong to
+``authority_core.decide`` and the execution layer in ``executor``.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import re
+from pathlib import PurePosixPath, PureWindowsPath
+from typing import Any, cast
+
+from ..todos.contract import normalize_todo_claimed_by, normalize_todo_id
+from ..todos.handoff_mode import goal_handoff_mode
+from .authority_core import (
+    CoordinationSnapshot,
+    HandoffMode,
+    LeaseSnapshot,
+    TodoSnapshot,
+)
+
+HEAD_SCHEMA_VERSION = "loopx_coordination_head_v0"
+RECEIPT_SCHEMA_VERSION = "loopx_authority_receipt_v0"
+RETAIN_ALL = {"mode": "retain_all_v0"}
+
+_HEAD_FIELDS = {
+    "schema_version",
+    "goal_id",
+    "handoff_mode",
+    "authority_revision",
+    "coordination",
+    "receipt_index",
+    "receipt_retention",
+}
+_TODO_FIELDS = {
+    "todo_revision",
+    "status",
+    "claimed_by",
+    "eligibility",
+    "repository",
+    "code_revision",
+    "last_lease_epoch",
+}
+_ELIGIBILITY_FIELDS = {
+    "authorization_projection_revision",
+    "authorization_projection_digest",
+    "allowed_agent_ids",
+    "dependencies_satisfied",
+    "dependency_revision",
+    "gates_open",
+    "gate_revision",
+}
+_ELIGIBILITY_REVISION_FIELDS = (
+    "authorization_projection_revision",
+    "dependency_revision",
+    "gate_revision",
+)
+_LEASE_FIELDS = {"lease_id", "owner", "lease_epoch", "expires_at", "write_scopes"}
+_REPOSITORY_PATTERN = re.compile(r"git:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)+")
+_CODE_REVISION_PATTERN = re.compile(r"[0-9a-fA-F]{7,64}")
+
+
+class HeadValidationError(ValueError):
+    """The aggregate document violates the reviewed v0 contract."""
+
+
+def canonical_head_bytes(head: dict[str, Any]) -> bytes:
+    """Deterministic canonical serialization of one head document.
+
+    This is the one canonical encoding (sorted keys, minimal separators,
+    UTF-8 without ASCII escapes) that digests and byte-level provider parity
+    are defined against. Values with no faithful strict-JSON form fail closed
+    here: non-finite floats would serialize into bytes a strict RFC 8259
+    reader rejects, so they must never become "canonical" bytes.
+    """
+
+    try:
+        return json.dumps(
+            head,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as error:
+        raise HeadValidationError(
+            f"head is not canonically serializable: {error}"
+        ) from None
+
+
+def head_digest(head: dict[str, Any]) -> str:
+    return "sha256:" + hashlib.sha256(canonical_head_bytes(head)).hexdigest()
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise HeadValidationError(message)
+
+
+def _is_count(value: Any, *, minimum: int = 0) -> bool:
+    # bool is an int subclass; a True epoch would silently mint True+1.
+    return isinstance(value, int) and not isinstance(value, bool) and value >= minimum
+
+
+def _validated_todo(todo_id: str, source: Any) -> dict[str, Any]:
+    _require(
+        isinstance(todo_id, str) and bool(todo_id),
+        "head todo ids must be non-empty strings",
+    )
+    _require(
+        isinstance(source, dict) and set(source) == _TODO_FIELDS,
+        f"head todo {todo_id!r} fields do not match v0",
+    )
+    _require(
+        _is_count(source["todo_revision"]),
+        f"head todo {todo_id!r} todo_revision must be a non-negative integer",
+    )
+    _require(
+        _is_count(source["last_lease_epoch"]),
+        f"head todo {todo_id!r} last_lease_epoch must be a non-negative integer",
+    )
+    repository = source["repository"]
+    _require(
+        isinstance(repository, str)
+        and bool(repository)
+        and not repository.startswith("file://")
+        and not PurePosixPath(repository).is_absolute()
+        and not PureWindowsPath(repository).is_absolute()
+        and _REPOSITORY_PATTERN.fullmatch(repository) is not None,
+        f"head todo {todo_id!r} repository is not portable",
+    )
+    code_revision = source["code_revision"]
+    _require(
+        isinstance(code_revision, str)
+        and _CODE_REVISION_PATTERN.fullmatch(code_revision) is not None,
+        f"head todo {todo_id!r} code_revision is invalid",
+    )
+    eligibility = source["eligibility"]
+    _require(
+        isinstance(eligibility, dict) and set(eligibility) == _ELIGIBILITY_FIELDS,
+        f"head todo {todo_id!r} eligibility fields do not match v0",
+    )
+    for field in _ELIGIBILITY_REVISION_FIELDS:
+        _require(
+            _is_count(eligibility[field]),
+            f"head todo {todo_id!r} eligibility revisions are invalid",
+        )
+    digest = eligibility["authorization_projection_digest"]
+    _require(
+        isinstance(digest, str) and digest.startswith("sha256:"),
+        f"head todo {todo_id!r} authorization digest is invalid",
+    )
+    allowed = eligibility["allowed_agent_ids"]
+    _require(
+        isinstance(allowed, list)
+        and all(isinstance(agent, str) and agent for agent in allowed),
+        f"head todo {todo_id!r} allowed_agent_ids are invalid",
+    )
+    _require(
+        isinstance(eligibility["dependencies_satisfied"], bool)
+        and isinstance(eligibility["gates_open"], bool),
+        f"head todo {todo_id!r} eligibility decisions are invalid",
+    )
+    return cast(dict[str, Any], source)
+
+
+def validated_head(head: Any, *, goal_id: str) -> dict[str, Any]:
+    """Fail closed unless ``head`` is a complete v0 aggregate for ``goal_id``."""
+
+    _require(isinstance(head, dict), "coordination head must be an object")
+    _require(set(head) == _HEAD_FIELDS, "coordination head fields do not match v0")
+    _require(
+        head["schema_version"] == HEAD_SCHEMA_VERSION and head["goal_id"] == goal_id,
+        "coordination head identity mismatch",
+    )
+    _require(
+        head["handoff_mode"] == HandoffMode.HARD_LEASE.value,
+        "v0 shared authority is defined only for the hard_lease handoff mode",
+    )
+    _require(
+        _is_count(head["authority_revision"]),
+        "authority_revision must be a non-negative integer",
+    )
+    coordination = head["coordination"]
+    _require(
+        isinstance(coordination, dict) and set(coordination) == {"todos", "leases"},
+        "coordination must contain todos and leases",
+    )
+    _require(
+        isinstance(coordination["todos"], dict)
+        and isinstance(coordination["leases"], dict),
+        "coordination must contain todos and leases objects",
+    )
+    for todo_id, todo in coordination["todos"].items():
+        _validated_todo(todo_id, todo)
+    for todo_id, lease in coordination["leases"].items():
+        _require(
+            todo_id in coordination["todos"],
+            f"lease {todo_id!r} has no todo in the head",
+        )
+        _require(
+            isinstance(lease, dict) and set(lease) == _LEASE_FIELDS,
+            f"lease {todo_id!r} fields do not match v0",
+        )
+        _require(
+            isinstance(lease["lease_id"], str)
+            and bool(lease["lease_id"])
+            and isinstance(lease["owner"], str)
+            and bool(lease["owner"]),
+            f"lease {todo_id!r} identity fields must be non-empty strings",
+        )
+        _require(
+            _is_count(lease["lease_epoch"], minimum=1),
+            f"lease {todo_id!r} lease_epoch must be a positive integer",
+        )
+        _require(
+            isinstance(lease["expires_at"], str) and bool(lease["expires_at"]),
+            f"lease {todo_id!r} expires_at must be a timestamp string",
+        )
+        _require(
+            lease["write_scopes"] == [],
+            f"lease {todo_id!r} write_scopes must be empty in v0",
+        )
+    _require(isinstance(head["receipt_index"], dict), "receipt_index must be an object")
+    _require(head["receipt_retention"] == RETAIN_ALL, "v0 requires retain_all_v0")
+    return cast(dict[str, Any], head)
+
+
+def bootstrap_head(goal_id: str, todos: dict[str, Any]) -> dict[str, Any]:
+    """Build the explicit migration head from already-existing open todos."""
+
+    _require(
+        isinstance(goal_id, str) and bool(goal_id),
+        "bootstrap goal_id must be a non-empty string",
+    )
+    _require(isinstance(todos, dict), "bootstrap todos must be an object")
+    normalized: dict[str, Any] = {}
+    for todo_id, source in todos.items():
+        todo = _validated_todo(todo_id, source)
+        _require(
+            todo["status"] == "open" and todo["claimed_by"] is None,
+            f"bootstrap todo {todo_id!r} must be open and unclaimed",
+        )
+        normalized[todo_id] = {
+            "todo_revision": todo["todo_revision"],
+            "status": "open",
+            "claimed_by": None,
+            "eligibility": {
+                field: copy.deepcopy(todo["eligibility"][field])
+                for field in sorted(_ELIGIBILITY_FIELDS)
+            },
+            "repository": todo["repository"],
+            "code_revision": todo["code_revision"],
+            "last_lease_epoch": todo["last_lease_epoch"],
+        }
+    return {
+        "schema_version": HEAD_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        # The shared head owns the mode once a goal migrates (Appendix B);
+        # v0 defines shared coordination only for hard_lease, and recording
+        # it in the CAS'd document keeps every acceptance auditable against
+        # the mode that authorized it.
+        "handoff_mode": HandoffMode.HARD_LEASE.value,
+        "authority_revision": 0,
+        "coordination": {"todos": normalized, "leases": {}},
+        "receipt_index": {},
+        "receipt_retention": copy.deepcopy(RETAIN_ALL),
+    }
+
+
+def _static_projection_digest(allowed_agent_ids: list[str]) -> str:
+    encoded = json.dumps(sorted(allowed_agent_ids), separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def bootstrap_head_from_goal_state(
+    state_text: str,
+    *,
+    goal_id: str,
+    repository: str,
+    code_revision: str,
+    allowed_agent_ids: list[str],
+    with_report: bool = False,
+) -> dict[str, Any] | tuple[dict[str, Any], dict[str, Any]]:
+    """Shadow the current Markdown active state into a bootstrap head.
+
+    Reads the goal state through loopx's own projection and admits exactly the
+    open, unclaimed agent todos (the only shape v0 bootstrap accepts); claimed
+    and done todos are reported, never silently dropped. This is the read side
+    of the RFC section 11 shadow; nothing is written back.
+    """
+
+    from ..todos.active_state_todo_parser import parse_active_state_todos
+
+    source_mode = goal_handoff_mode(state_text)
+    _require(
+        source_mode != HandoffMode.SOFT_CLAIM.value,
+        "a soft_claim goal cannot bootstrap into shared authority: its"
+        " declared mode rejects lease minting, which shared claim_work"
+        " performs on every accepted claim",
+    )
+    projected = parse_active_state_todos(state_text)
+    skipped: dict[str, str] = {}
+    todos: dict[str, Any] = {}
+    for item in projected["agent_todos"]["items"]:
+        todo_id = normalize_todo_id(item.get("todo_id"))
+        if not todo_id:
+            continue
+        if item.get("done"):
+            skipped[todo_id] = "done"
+            continue
+        if normalize_todo_claimed_by(item.get("claimed_by")):
+            skipped[todo_id] = "claimed"
+            continue
+        todos[todo_id] = {
+            "todo_revision": 0,
+            "status": "open",
+            "claimed_by": None,
+            "eligibility": {
+                "authorization_projection_revision": 0,
+                "authorization_projection_digest": _static_projection_digest(
+                    allowed_agent_ids
+                ),
+                "allowed_agent_ids": list(allowed_agent_ids),
+                "dependencies_satisfied": True,
+                "dependency_revision": 0,
+                "gates_open": True,
+                "gate_revision": 0,
+            },
+            "repository": repository,
+            "code_revision": code_revision,
+            "last_lease_epoch": 0,
+        }
+    head = bootstrap_head(goal_id, todos)
+    if not with_report:
+        return head
+    report = {
+        "skipped": skipped,
+        "source_handoff_mode": source_mode,
+        "admitted": sorted(todos),
+    }
+    return head, report
+
+
+def claim_snapshot_for_todo(
+    head: dict[str, Any],
+    todo_id: str,
+    *,
+    lease_active: bool = False,
+) -> CoordinationSnapshot:
+    """Project one todo's aggregate facts into the Stage 1 core snapshot.
+
+    The aggregate's ``allowed_agent_ids`` play the registered-agent role for
+    the core's actor and owner checks; dependency/gate booleans and every
+    revision stay execution-layer preconditions because the core owns neither
+    (Stage 1 boundary). ``handoff_mode`` comes from the head itself, where it
+    is revision-covered by the aggregate CAS; v0 validation pins it to
+    hard_lease, under which a claim and its lease travel together and the
+    core's holder gate is a real invariant, not a vacuous branch. When the
+    todo carries no lease the snapshot holds a non-present tombstone at the
+    todo's ``last_lease_epoch`` so the core mints the next epoch monotonically
+    (no-ABA); ``lease_active`` is the executor's clock decision, never
+    computed here.
+    """
+
+    todo = head["coordination"]["todos"].get(todo_id)
+    _require(todo is not None, f"head has no todo {todo_id!r}")
+    lease = head["coordination"]["leases"].get(todo_id)
+    if lease is not None:
+        lease_snapshot = LeaseSnapshot(
+            present=True,
+            active=lease_active,
+            status="active" if lease_active else "expired",
+            owner=lease["owner"],
+            idempotency_key=lease["lease_id"],
+            version=lease["lease_epoch"],
+            lease_epoch=lease["lease_epoch"],
+            write_scopes=tuple(lease["write_scopes"]),
+        )
+    else:
+        lease_snapshot = LeaseSnapshot(
+            present=False,
+            active=False,
+            version=todo["last_lease_epoch"],
+            lease_epoch=todo["last_lease_epoch"],
+        )
+    return CoordinationSnapshot(
+        handoff_mode=HandoffMode(head["handoff_mode"]),
+        registered_agents=tuple(todo["eligibility"]["allowed_agent_ids"]),
+        todo=TodoSnapshot(
+            todo_id=todo_id,
+            status=todo["status"],
+            role="agent",
+            claimed_by=todo["claimed_by"],
+        ),
+        lease=lease_snapshot,
+    )

--- a/loopx/control_plane/coordination/head.py
+++ b/loopx/control_plane/coordination/head.py
@@ -17,11 +17,10 @@ import copy
 import hashlib
 import json
 import re
+from datetime import datetime
 from pathlib import PurePosixPath, PureWindowsPath
 from typing import Any, cast
 
-from ..todos.contract import normalize_todo_claimed_by, normalize_todo_id
-from ..todos.handoff_mode import goal_handoff_mode
 from .authority_core import (
     CoordinationSnapshot,
     HandoffMode,
@@ -66,8 +65,25 @@ _ELIGIBILITY_REVISION_FIELDS = (
     "gate_revision",
 )
 _LEASE_FIELDS = {"lease_id", "owner", "lease_epoch", "expires_at", "write_scopes"}
+_RECEIPT_ENTRY_FIELDS = {"request_digest", "original_receipt"}
+_RECEIPT_FIELDS = {
+    "schema_version",
+    "operation_id",
+    "request_digest",
+    "command",
+    "actor",
+    "todo_id",
+    "accepted_authority_revision",
+    "accepted_todo_revision",
+    "applied_at",
+    "lease_id",
+    "lease_epoch",
+    "expires_at",
+}
+_RECEIPT_ACTOR_FIELDS = {"agent_id", "device_id"}
 _REPOSITORY_PATTERN = re.compile(r"git:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)+")
 _CODE_REVISION_PATTERN = re.compile(r"[0-9a-fA-F]{7,64}")
+_REQUEST_DIGEST_PATTERN = re.compile(r"sha256:[0-9a-f]{64}")
 
 
 class HeadValidationError(ValueError):
@@ -110,6 +126,23 @@ def _require(condition: bool, message: str) -> None:
 def _is_count(value: Any, *, minimum: int = 0) -> bool:
     # bool is an int subclass; a True epoch would silently mint True+1.
     return isinstance(value, int) and not isinstance(value, bool) and value >= minimum
+
+
+def _is_timestamp(value: Any) -> bool:
+    # The executor parses these fields unconditionally (expiry decisions,
+    # authorization status); an unparseable persisted timestamp must fail
+    # closed here instead of escaping as a bare ValueError later.
+    if not isinstance(value, str) or not value:
+        return False
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return True
+
+
+def _is_request_digest(value: Any) -> bool:
+    return isinstance(value, str) and _REQUEST_DIGEST_PATTERN.fullmatch(value) is not None
 
 
 def _validated_todo(todo_id: str, source: Any) -> dict[str, Any]:
@@ -174,6 +207,81 @@ def _validated_todo(todo_id: str, source: Any) -> dict[str, Any]:
     return cast(dict[str, Any], source)
 
 
+def _validated_receipt_entry(
+    operation_id: Any,
+    entry: Any,
+    todos: dict[str, Any],
+) -> None:
+    """Fail closed unless one receipt-index entry is a complete v0 record.
+
+    The executor dereferences these fields unconditionally on the replay and
+    success paths, so this is part of the trust boundary persisted state must
+    cross before any of it is consumed.
+    """
+
+    _require(
+        isinstance(operation_id, str) and bool(operation_id),
+        "receipt index keys must be non-empty operation ids",
+    )
+    _require(
+        isinstance(entry, dict) and set(entry) == _RECEIPT_ENTRY_FIELDS,
+        f"receipt entry {operation_id!r} fields do not match v0",
+    )
+    _require(
+        _is_request_digest(entry["request_digest"]),
+        f"receipt entry {operation_id!r} request_digest is invalid",
+    )
+    receipt = entry["original_receipt"]
+    _require(
+        isinstance(receipt, dict) and set(receipt) == _RECEIPT_FIELDS,
+        f"receipt {operation_id!r} fields do not match v0",
+    )
+    _require(
+        receipt["schema_version"] == RECEIPT_SCHEMA_VERSION,
+        f"receipt {operation_id!r} schema_version is invalid",
+    )
+    _require(
+        receipt["operation_id"] == operation_id,
+        f"receipt {operation_id!r} does not record its own operation id",
+    )
+    _require(
+        receipt["request_digest"] == entry["request_digest"],
+        f"receipt {operation_id!r} digest disagrees with its index entry",
+    )
+    _require(
+        receipt["command"] == "claim_work",
+        f"receipt {operation_id!r} command is outside the v0 slice",
+    )
+    actor = receipt["actor"]
+    _require(
+        isinstance(actor, dict)
+        and set(actor) == _RECEIPT_ACTOR_FIELDS
+        and all(isinstance(actor[key], str) and actor[key] for key in _RECEIPT_ACTOR_FIELDS),
+        f"receipt {operation_id!r} actor identity is invalid",
+    )
+    _require(
+        isinstance(receipt["todo_id"], str) and receipt["todo_id"] in todos,
+        f"receipt {operation_id!r} names a todo the head does not carry",
+    )
+    _require(
+        _is_count(receipt["accepted_authority_revision"], minimum=1)
+        and _is_count(receipt["accepted_todo_revision"], minimum=1),
+        f"receipt {operation_id!r} accepted revisions are invalid",
+    )
+    _require(
+        isinstance(receipt["lease_id"], str) and bool(receipt["lease_id"]),
+        f"receipt {operation_id!r} lease_id is invalid",
+    )
+    _require(
+        _is_count(receipt["lease_epoch"], minimum=1),
+        f"receipt {operation_id!r} lease_epoch must be a positive integer",
+    )
+    _require(
+        _is_timestamp(receipt["applied_at"]) and _is_timestamp(receipt["expires_at"]),
+        f"receipt {operation_id!r} timestamps are invalid",
+    )
+
+
 def validated_head(head: Any, *, goal_id: str) -> dict[str, Any]:
     """Fail closed unless ``head`` is a complete v0 aggregate for ``goal_id``."""
 
@@ -224,14 +332,16 @@ def validated_head(head: Any, *, goal_id: str) -> dict[str, Any]:
             f"lease {todo_id!r} lease_epoch must be a positive integer",
         )
         _require(
-            isinstance(lease["expires_at"], str) and bool(lease["expires_at"]),
-            f"lease {todo_id!r} expires_at must be a timestamp string",
+            _is_timestamp(lease["expires_at"]),
+            f"lease {todo_id!r} expires_at must be a parseable timestamp",
         )
         _require(
             lease["write_scopes"] == [],
             f"lease {todo_id!r} write_scopes must be empty in v0",
         )
     _require(isinstance(head["receipt_index"], dict), "receipt_index must be an object")
+    for operation_id, entry in head["receipt_index"].items():
+        _validated_receipt_entry(operation_id, entry, coordination["todos"])
     _require(head["receipt_retention"] == RETAIN_ALL, "v0 requires retain_all_v0")
     return cast(dict[str, Any], head)
 
@@ -276,80 +386,6 @@ def bootstrap_head(goal_id: str, todos: dict[str, Any]) -> dict[str, Any]:
         "receipt_index": {},
         "receipt_retention": copy.deepcopy(RETAIN_ALL),
     }
-
-
-def _static_projection_digest(allowed_agent_ids: list[str]) -> str:
-    encoded = json.dumps(sorted(allowed_agent_ids), separators=(",", ":"))
-    return "sha256:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()
-
-
-def bootstrap_head_from_goal_state(
-    state_text: str,
-    *,
-    goal_id: str,
-    repository: str,
-    code_revision: str,
-    allowed_agent_ids: list[str],
-    with_report: bool = False,
-) -> dict[str, Any] | tuple[dict[str, Any], dict[str, Any]]:
-    """Shadow the current Markdown active state into a bootstrap head.
-
-    Reads the goal state through loopx's own projection and admits exactly the
-    open, unclaimed agent todos (the only shape v0 bootstrap accepts); claimed
-    and done todos are reported, never silently dropped. This is the read side
-    of the RFC section 11 shadow; nothing is written back.
-    """
-
-    from ..todos.active_state_todo_parser import parse_active_state_todos
-
-    source_mode = goal_handoff_mode(state_text)
-    _require(
-        source_mode != HandoffMode.SOFT_CLAIM.value,
-        "a soft_claim goal cannot bootstrap into shared authority: its"
-        " declared mode rejects lease minting, which shared claim_work"
-        " performs on every accepted claim",
-    )
-    projected = parse_active_state_todos(state_text)
-    skipped: dict[str, str] = {}
-    todos: dict[str, Any] = {}
-    for item in projected["agent_todos"]["items"]:
-        todo_id = normalize_todo_id(item.get("todo_id"))
-        if not todo_id:
-            continue
-        if item.get("done"):
-            skipped[todo_id] = "done"
-            continue
-        if normalize_todo_claimed_by(item.get("claimed_by")):
-            skipped[todo_id] = "claimed"
-            continue
-        todos[todo_id] = {
-            "todo_revision": 0,
-            "status": "open",
-            "claimed_by": None,
-            "eligibility": {
-                "authorization_projection_revision": 0,
-                "authorization_projection_digest": _static_projection_digest(
-                    allowed_agent_ids
-                ),
-                "allowed_agent_ids": list(allowed_agent_ids),
-                "dependencies_satisfied": True,
-                "dependency_revision": 0,
-                "gates_open": True,
-                "gate_revision": 0,
-            },
-            "repository": repository,
-            "code_revision": code_revision,
-            "last_lease_epoch": 0,
-        }
-    head = bootstrap_head(goal_id, todos)
-    if not with_report:
-        return head
-    report = {
-        "skipped": skipped,
-        "source_handoff_mode": source_mode,
-        "admitted": sorted(todos),
-    }
-    return head, report
 
 
 def claim_snapshot_for_todo(

--- a/loopx/control_plane/coordination/head.py
+++ b/loopx/control_plane/coordination/head.py
@@ -17,7 +17,7 @@ import copy
 import hashlib
 import json
 import re
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import PurePosixPath, PureWindowsPath
 from typing import Any, cast
 
@@ -131,14 +131,18 @@ def _is_count(value: Any, *, minimum: int = 0) -> bool:
 def _is_timestamp(value: Any) -> bool:
     # The executor parses these fields unconditionally (expiry decisions,
     # authorization status); an unparseable persisted timestamp must fail
-    # closed here instead of escaping as a bare ValueError later.
+    # closed here instead of escaping as a bare ValueError later. The value
+    # must also be timezone-aware UTC: a naive timestamp is interpreted in
+    # the executing host's local timezone, so the same persisted bytes would
+    # read as active on one endpoint and expired on another, and v0 mints
+    # UTC only, so UTC is also what it accepts.
     if not isinstance(value, str) or not value:
         return False
     try:
-        datetime.fromisoformat(value.replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
         return False
-    return True
+    return parsed.tzinfo is not None and parsed.utcoffset() == timedelta(0)
 
 
 def _is_request_digest(value: Any) -> bool:

--- a/loopx/file_lock.py
+++ b/loopx/file_lock.py
@@ -309,7 +309,8 @@ class LockAcquireTimeoutError(TimeoutError):
         self.incident = incident
         self.incident_recorded = incident_recorded
         self.incident_channel = incident_channel
-        holder = incident.get("holder") if isinstance(incident.get("holder"), dict) else {}
+        raw_holder = incident.get("holder")
+        holder: dict[str, object] = raw_holder if isinstance(raw_holder, dict) else {}
         super().__init__(
             "file lock acquisition timed out"
             + (f" while waiting for holder pid {holder.get('pid')}" if holder.get("pid") else "")
@@ -349,7 +350,7 @@ def _timeout_error(
         "waited_seconds": round(waited_seconds, 3),
     }
     action = _operator_action(holder, retry_mode=LOCK_POLICIES[policy].retry_mode)
-    incident = {
+    incident: dict[str, object] = {
         "schema_version": LOCK_INCIDENT_SCHEMA_VERSION,
         "error_code": LOCK_ACQUIRE_TIMEOUT_ERROR_CODE,
         "recorded_at": _utc_now_iso(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,9 @@ python_version = "3.11"
 strict = true
 files = [
   "loopx/control_plane/__init__.py",
+  "loopx/control_plane/coordination/executor.py",
+  "loopx/control_plane/coordination/file_provider.py",
+  "loopx/control_plane/coordination/head.py",
   "loopx/control_plane/quota/effect_program.py",
   "loopx/control_plane/quota/states.py",
   "loopx/control_plane/runtime/event_store_migration_bridge.py",

--- a/tests/control_plane/test_coordination_executor.py
+++ b/tests/control_plane/test_coordination_executor.py
@@ -18,7 +18,10 @@ from loopx.control_plane.coordination.executor import (
     EnvelopeError,
     sample_claim_envelope,
 )
-from loopx.control_plane.coordination.head import bootstrap_head
+from loopx.control_plane.coordination.executor import (
+    MAX_LEASE_TTL_SECONDS,
+)
+from loopx.control_plane.coordination.head import HeadValidationError, bootstrap_head
 
 
 def eligibility(allowed=("agent-a", "agent-b")) -> dict:
@@ -441,3 +444,47 @@ def test_envelope_rejects_bool_disguised_integers() -> None:
         mutate(request["command"])
         with pytest.raises(EnvelopeError):
             executor.apply(request)
+
+def test_corrupt_stored_receipt_fails_typed_before_replay() -> None:
+    """A digest-matching receipt entry whose ``original_receipt`` was gutted
+    must surface as the typed head-validation failure at load, never as a
+    KeyError from inside the replay or success paths."""
+
+    provider = FakeProvider()
+    bootstrap(provider)
+    executor = executor_for(provider)
+    assert executor.apply(envelope("agent-a", "todo-1"))["result"] == "applied"
+    stored, generation = provider.load()
+    stored["receipt_index"]["op-agent-a-todo-1"]["original_receipt"] = {}
+    assert provider.compare_and_put(generation, stored)["result"] == "applied"
+    with pytest.raises(HeadValidationError, match="receipt"):
+        executor.apply(envelope("agent-a", "todo-1"))
+
+
+def test_lease_ttl_is_bounded_by_the_task_lease_ceiling() -> None:
+    """The shared envelope reuses the local task-lease TTL ceiling, so an
+    astronomical caller value is a typed rejection at the envelope boundary
+    and can never reach wall-clock arithmetic as an OverflowError."""
+
+    provider = FakeProvider()
+    bootstrap(provider)
+    executor = executor_for(provider)
+    for ttl in (10**100, MAX_LEASE_TTL_SECONDS + 1):
+        request = envelope("agent-a", "todo-1")
+        request["command"]["lease_ttl_seconds"] = ttl
+        with pytest.raises(EnvelopeError, match="between 1 and"):
+            executor.apply(request)
+    at_ceiling = envelope("agent-a", "todo-1")
+    at_ceiling["command"]["lease_ttl_seconds"] = MAX_LEASE_TTL_SECONDS
+    assert executor.apply(at_ceiling)["result"] == "applied"
+
+
+def test_lease_ttl_ceiling_matches_the_local_task_lease_authority() -> None:
+    """The executor mirrors the constant instead of importing the (untyped)
+    task-lease module; this pin keeps the two ceilings from drifting."""
+
+    from loopx.control_plane.work_items.task_lease import (
+        MAX_TASK_LEASE_TTL_SECONDS,
+    )
+
+    assert MAX_LEASE_TTL_SECONDS == MAX_TASK_LEASE_TTL_SECONDS

--- a/tests/control_plane/test_coordination_executor.py
+++ b/tests/control_plane/test_coordination_executor.py
@@ -1,0 +1,443 @@
+"""The authority execution layer over a coordination provider (RFC section 5).
+
+Covers the machine-verifiable acceptance checks of RFC section 10 that apply
+to the claim_work slice (1-5, 7-11), plus the Stage-2 harmony requirement:
+domain decisions are delegated to the Stage 1 core, never re-derived here.
+"""
+
+from __future__ import annotations
+
+import copy
+import threading
+
+import pytest
+
+from loopx.control_plane.coordination import authority_core
+from loopx.control_plane.coordination.executor import (
+    CoordinationAuthorityExecutor,
+    EnvelopeError,
+    sample_claim_envelope,
+)
+from loopx.control_plane.coordination.head import bootstrap_head
+
+
+def eligibility(allowed=("agent-a", "agent-b")) -> dict:
+    return {
+        "authorization_projection_revision": 3,
+        "authorization_projection_digest": "sha256:bootstrap-auth",
+        "allowed_agent_ids": list(allowed),
+        "dependencies_satisfied": True,
+        "dependency_revision": 12,
+        "gates_open": True,
+        "gate_revision": 5,
+    }
+
+
+def todo(**overrides) -> dict:
+    base = {
+        "todo_revision": 7,
+        "status": "open",
+        "claimed_by": None,
+        "eligibility": eligibility(),
+        "repository": "git:example/repo",
+        "code_revision": "0123456789abcdef",
+        "last_lease_epoch": 6,
+    }
+    base.update(overrides)
+    return base
+
+
+class FakeProvider:
+    """Deterministic in-memory provider with fault hooks for checks 7 and 9."""
+
+    def __init__(self, generation_step: int = 17):
+        self._head = None
+        self._generation = 0
+        self._step = generation_step
+        self._lock = threading.Lock()
+        self.fault = None
+        self.unrelated_advances = 0
+
+    def load(self):
+        with self._lock:
+            return copy.deepcopy(self._head), self._generation
+
+    def compare_and_put(self, expected_generation, head):
+        with self._lock:
+            if self.fault == "failed_before":
+                self.fault = None
+                return {"result": "failed", "error": "provider unavailable"}
+            if expected_generation != self._generation:
+                return {
+                    "result": "conflict",
+                    "current_provider_generation": self._generation,
+                }
+            if self.fault == "ambiguous_before":
+                self.fault = None
+                return {"result": "ambiguous"}
+            if self.unrelated_advances:
+                self.unrelated_advances -= 1
+                self._generation += self._step
+                return {
+                    "result": "conflict",
+                    "current_provider_generation": self._generation,
+                }
+            self._head = copy.deepcopy(head)
+            self._generation += self._step
+            if self.fault == "ambiguous_after":
+                self.fault = None
+                return {"result": "ambiguous"}
+            return {"result": "applied", "provider_generation": self._generation}
+
+
+def bootstrap(provider, todos=("todo-1", "todo-2")) -> dict:
+    head = bootstrap_head("goal-a", {todo_id: todo() for todo_id in todos})
+    assert provider.compare_and_put(0, head)["result"] == "applied"
+    return head
+
+
+def executor_for(provider) -> CoordinationAuthorityExecutor:
+    return CoordinationAuthorityExecutor(
+        provider, goal_id="goal-a", now=lambda: 1_800_000_000.0
+    )
+
+
+def envelope(agent="agent-a", todo_id="todo-1", operation_id=None, **overrides):
+    return sample_claim_envelope(
+        goal_id="goal-a",
+        operation_id=operation_id or f"op-{agent}-{todo_id}",
+        agent_id=agent,
+        device_id=f"dev-{agent}",
+        todo_id=todo_id,
+        expected_todo_revision=7,
+        expected_preconditions={
+            "authorization_projection_revision": 3,
+            "authorization_projection_digest": "sha256:bootstrap-auth",
+            "dependency_revision": 12,
+            "gate_revision": 5,
+        },
+        lease_ttl_seconds=600,
+        **overrides,
+    )
+
+
+# ---- check 1: same-todo competition has exactly one winner ------------------
+
+
+def test_same_todo_two_actors_one_winner() -> None:
+    provider = FakeProvider()
+    bootstrap(provider)
+    executor = executor_for(provider)
+
+    first = executor.apply(envelope("agent-a"))
+    second = executor.apply(envelope("agent-b"))
+
+    assert first["result"] == "applied"
+    receipt = first["original_receipt"]
+    assert receipt["schema_version"] == "loopx_authority_receipt_v0"
+    assert receipt["command"] == "claim_work"
+    assert receipt["accepted_authority_revision"] == 1
+    assert receipt["accepted_todo_revision"] == 8
+    assert receipt["lease_epoch"] == 7
+    assert second["result"] == "conflict"
+    assert second["reason"] == "todo_revision_mismatch"
+
+    head, _ = provider.load()
+    claimed = head["coordination"]["todos"]["todo-1"]
+    assert claimed["status"] == "open"
+    assert claimed["claimed_by"] == "agent-a"
+    assert claimed["todo_revision"] == 8
+    assert claimed["last_lease_epoch"] == 7
+    lease = head["coordination"]["leases"]["todo-1"]
+    assert lease["owner"] == "agent-a" and lease["lease_epoch"] == 7
+    assert len(head["receipt_index"]) == 1
+
+
+# ---- check 2: independent todos rebase internally and both apply ------------
+
+
+def test_independent_todos_both_apply_after_internal_rebase() -> None:
+    provider = FakeProvider()
+    bootstrap(provider)
+    executor_a = executor_for(provider)
+    executor_b = executor_for(provider)
+
+    provider.unrelated_advances = 0
+    first = executor_a.apply(envelope("agent-a", "todo-1"))
+    second = executor_b.apply(envelope("agent-b", "todo-2"))
+
+    assert first["result"] == "applied" and second["result"] == "applied"
+    head, _ = provider.load()
+    assert head["authority_revision"] == 2
+    assert head["coordination"]["todos"]["todo-1"]["todo_revision"] == 8
+    assert head["coordination"]["todos"]["todo-2"]["todo_revision"] == 8
+    accepted = sorted(
+        entry["original_receipt"]["accepted_authority_revision"]
+        for entry in head["receipt_index"].values()
+    )
+    assert accepted == [1, 2]
+
+
+# ---- checks 3 + 4: replay returns the original receipt ----------------------
+
+
+def test_replay_and_aba_recover_the_original_receipt() -> None:
+    provider = FakeProvider()
+    bootstrap(provider)
+    executor = executor_for(provider)
+
+    request = envelope("agent-a", "todo-1", operation_id="op-A")
+    first = executor.apply(request)
+    assert first["result"] == "applied"
+
+    immediate = executor.apply(copy.deepcopy(request))
+    assert immediate["result"] == "already_applied"
+    assert immediate["original_receipt"] == first["original_receipt"]
+
+    advanced = executor.apply(envelope("agent-b", "todo-2"))
+    assert advanced["result"] == "applied"
+
+    reconstructed = executor_for(provider)
+    replay = reconstructed.apply(copy.deepcopy(request))
+    assert replay["result"] == "already_applied"
+    assert replay["original_receipt"] == first["original_receipt"]
+    assert replay["observed_authority_revision"] == 2
+    assert replay["authorization_status"] == "active"
+
+    transported = copy.deepcopy(request)
+    transported["transport"] = {"attempt": 4}
+    assert reconstructed.apply(transported)["result"] == "already_applied"
+
+
+# ---- check 5: identity reuse with different semantics is rejected -----------
+
+
+def test_operation_identity_mismatch_changes_nothing() -> None:
+    provider = FakeProvider()
+    bootstrap(provider)
+    executor = executor_for(provider)
+    request = envelope("agent-a", "todo-1", operation_id="op-A")
+    assert executor.apply(request)["result"] == "applied"
+    before = provider.load()
+
+    mutated = copy.deepcopy(request)
+    mutated["command"]["lease_ttl_seconds"] = 601
+    outcome = executor.apply(mutated)
+    assert outcome["result"] == "rejected"
+    assert outcome["reason"] == "operation_identity_mismatch"
+    assert provider.load() == before
+
+
+# ---- check 7: crash windows and ambiguity ----------------------------------
+
+
+def test_ambiguous_with_commit_recovers_from_receipt() -> None:
+    provider = FakeProvider()
+    bootstrap(provider)
+    executor = executor_for(provider)
+    provider.fault = "ambiguous_after"
+    outcome = executor.apply(envelope("agent-a", "todo-1", operation_id="op-lost"))
+    assert outcome["result"] == "already_applied"
+    head, _ = provider.load()
+    assert head["authority_revision"] == 1
+    assert "op-lost" in head["receipt_index"]
+
+
+def test_ambiguous_without_commit_fails_unproved() -> None:
+    provider = FakeProvider()
+    bootstrap(provider)
+    executor = executor_for(provider)
+    provider.fault = "ambiguous_before"
+    outcome = executor.apply(envelope("agent-a", "todo-1"))
+    assert outcome["result"] == "failed"
+    assert outcome["reason"] == "provider_outcome_unproved"
+    head, _ = provider.load()
+    assert head["authority_revision"] == 0 and head["receipt_index"] == {}
+
+
+def test_provider_failed_before_cas_is_typed() -> None:
+    provider = FakeProvider()
+    bootstrap(provider)
+    executor = executor_for(provider)
+    provider.fault = "failed_before"
+    outcome = executor.apply(envelope("agent-a", "todo-1"))
+    assert outcome["result"] == "failed"
+    assert outcome["reason"] == "provider_failed_before_cas"
+
+
+# ---- check 8: rejections create no state ------------------------------------
+
+
+def test_rejections_and_stale_preconditions_change_nothing() -> None:
+    provider = FakeProvider()
+    bootstrap(provider)
+    executor = executor_for(provider)
+    before = provider.load()
+
+    unknown = executor.apply(envelope("agent-a", "todo-9"))
+    assert unknown["result"] == "rejected" and unknown["reason"] == "todo_not_found"
+
+    ineligible = executor.apply(envelope("agent-z", "todo-1"))
+    assert ineligible["result"] == "rejected"
+    assert ineligible["reason"] == "actor_ineligible"
+
+    stale_revision = envelope("agent-a", "todo-1")
+    stale_revision["command"]["expected_todo_revision"] = 6
+    stale = executor.apply(stale_revision)
+    assert stale["result"] == "conflict"
+    assert stale["reason"] == "todo_revision_mismatch"
+
+    stale_preconditions = envelope("agent-a", "todo-1")
+    stale_preconditions["command"]["expected_preconditions"][
+        "dependency_revision"
+    ] = 11
+    mismatch = executor.apply(stale_preconditions)
+    assert mismatch["result"] == "conflict"
+    assert mismatch["reason"] == "precondition_snapshot_mismatch"
+
+    blocked = bootstrap_head(
+        "goal-a", {"todo-3": todo(eligibility=eligibility() | {"gates_open": False})}
+    )
+    gated_provider = FakeProvider()
+    assert gated_provider.compare_and_put(0, blocked)["result"] == "applied"
+    gated = executor_for(gated_provider).apply(envelope("agent-a", "todo-3"))
+    assert gated["result"] == "rejected" and gated["reason"] == "gate_closed"
+
+    assert provider.load() == before
+
+
+# ---- check 9: sustained unrelated contention fails typed --------------------
+
+
+def test_sustained_unrelated_contention_returns_typed_failed() -> None:
+    provider = FakeProvider()
+    bootstrap(provider)
+    executor = executor_for(provider)
+    provider.unrelated_advances = 99
+    outcome = executor.apply(envelope("agent-a", "todo-1", operation_id="op-c"))
+    assert outcome["result"] == "failed"
+    assert outcome["reason"] == "provider_contention_exhausted"
+    head, _ = provider.load()
+    assert head["authority_revision"] == 0
+    assert "op-c" not in head["receipt_index"]
+
+
+# ---- checks 10 + 11: retention and version domains --------------------------
+
+
+def test_receipts_are_retained_and_version_domains_are_distinct() -> None:
+    provider = FakeProvider(generation_step=17)
+    bootstrap(provider)
+    executor = executor_for(provider)
+    assert executor.apply(envelope("agent-a", "todo-1"))["result"] == "applied"
+    assert executor.apply(envelope("agent-b", "todo-2"))["result"] == "applied"
+    head, generation = provider.load()
+    assert generation == 3 * 17
+    assert head["authority_revision"] == 2
+    assert head["coordination"]["leases"]["todo-1"]["lease_epoch"] == 7
+    assert len(head["receipt_index"]) == 2
+    assert head["receipt_retention"] == {"mode": "retain_all_v0"}
+
+
+# ---- harmony: domain decisions come from the Stage 1 core -------------------
+
+
+def test_domain_rules_are_delegated_to_the_stage1_core(monkeypatch) -> None:
+    """Flipping one core rule must flip the executor: no duplicated rules."""
+
+    provider = FakeProvider()
+    bootstrap(provider)
+    executor = executor_for(provider)
+
+    real_decide = authority_core.decide
+
+    def approving_decide(snapshot, command):
+        plan = real_decide(snapshot, command)
+        if plan.code in {"actor_not_registered", "owner_not_registered"}:
+            actor = getattr(command, "actor_agent_id", None) or getattr(
+                command, "owner", None
+            )
+            patched = real_decide(
+                authority_core.CoordinationSnapshot(
+                    handoff_mode=snapshot.handoff_mode,
+                    registered_agents=(*snapshot.registered_agents, actor),
+                    todo=snapshot.todo,
+                    lease=snapshot.lease,
+                ),
+                command,
+            )
+            return patched
+        return plan
+
+    import loopx.control_plane.coordination.executor as executor_module
+
+    monkeypatch.setattr(executor_module, "decide", approving_decide)
+    outcome = executor.apply(envelope("agent-z", "todo-1"))
+    assert outcome["result"] == "applied", (
+        "the executor must consult authority_core.decide for actor eligibility; "
+        "a re-derived local rule would still reject agent-z"
+    )
+
+
+def test_uninitialized_head_fails_closed() -> None:
+    provider = FakeProvider()
+    executor = executor_for(provider)
+    outcome = executor.apply(envelope("agent-a", "todo-1"))
+    assert outcome["result"] == "failed"
+    assert outcome["reason"] == "coordination_head_uninitialized"
+
+# ---- audit hardening: provider verdicts and envelope corruption -------------
+
+
+class MisreportingProvider:
+    """Lands the write, then reports the CAS as failed (a lying provider)."""
+
+    def __init__(self):
+        self.inner = FakeProvider()
+
+    def load(self):
+        return self.inner.load()
+
+    def compare_and_put(self, expected_generation, head):
+        outcome = self.inner.compare_and_put(expected_generation, head)
+        if outcome["result"] == "applied":
+            return {"result": "failed", "error": "spurious timeout"}
+        return outcome
+
+
+def test_provider_failed_verdict_is_verified_not_trusted() -> None:
+    """``failed`` claims the write provably never happened. The executor
+    verifies that claim against the receipt index instead of trusting it, so a
+    provider that misreports a landed write cannot manufacture a zombie claim
+    whose caller was told it failed."""
+
+    provider = MisreportingProvider()
+    bootstrap(provider.inner)
+    executor = CoordinationAuthorityExecutor(
+        provider, goal_id="goal-a", now=lambda: 1_800_000_000.0
+    )
+    outcome = executor.apply(envelope("agent-a", "todo-1"))
+    assert outcome["result"] == "already_applied"
+    stored_head, _ = provider.load()
+    stored = stored_head["receipt_index"]["op-agent-a-todo-1"]["original_receipt"]
+    assert outcome["original_receipt"] == stored
+
+
+def test_envelope_rejects_bool_disguised_integers() -> None:
+    """bool is an int subclass; a True revision or TTL must not pass the typed
+    integer gates and mint real state from a malformed envelope."""
+
+    provider = FakeProvider()
+    bootstrap(provider)
+    executor = executor_for(provider)
+    for mutate in (
+        lambda command: command.update(expected_todo_revision=True),
+        lambda command: command.update(lease_ttl_seconds=True),
+        lambda command: command["expected_preconditions"].update(
+            dependency_revision=True
+        ),
+    ):
+        request = envelope("agent-a", "todo-1")
+        mutate(request["command"])
+        with pytest.raises(EnvelopeError):
+            executor.apply(request)

--- a/tests/control_plane/test_coordination_file_provider.py
+++ b/tests/control_plane/test_coordination_file_provider.py
@@ -109,13 +109,17 @@ def test_corrupt_document_fails_closed(provider, tmp_path) -> None:
 def test_crash_after_temp_write_before_rename_changes_nothing(
     provider, monkeypatch
 ) -> None:
+    # Faults are injected through the provider's own commit seam, not the
+    # global os attributes: loopx.file_lock's Windows holder sidecar also
+    # calls os.replace, and a global patch would crash lock bookkeeping
+    # instead of the document commit under test.
     assert provider.compare_and_put(0, head())["result"] == "applied"
     import loopx.control_plane.coordination.file_provider as module
 
     def crash(_source, _target):
         raise OSError("simulated crash before rename")
 
-    monkeypatch.setattr(module.os, "replace", crash)
+    monkeypatch.setattr(module, "_replace_document", crash)
     outcome = provider.compare_and_put(1, head(1))
     assert outcome["result"] == "ambiguous"
     monkeypatch.undo()
@@ -130,13 +134,13 @@ def test_lost_response_after_rename_is_recoverable_by_reload(
     assert provider.compare_and_put(0, head())["result"] == "applied"
     import loopx.control_plane.coordination.file_provider as module
 
-    real_replace = module.os.replace
+    real_replace = module._replace_document
 
     def replace_then_crash(source, target):
         real_replace(source, target)
         raise OSError("simulated lost response after rename")
 
-    monkeypatch.setattr(module.os, "replace", replace_then_crash)
+    monkeypatch.setattr(module, "_replace_document", replace_then_crash)
     outcome = provider.compare_and_put(1, head(1))
     assert outcome["result"] == "ambiguous"
     monkeypatch.undo()
@@ -210,13 +214,13 @@ def test_commit_sequence_fsyncs_file_before_rename_and_directory_after(
     import loopx.control_plane.coordination.file_provider as module
 
     events = []
-    real_fsync = module.os.fsync
-    real_replace = module.os.replace
+    real_file_fsync = module._fsync_file
+    real_replace = module._replace_document
     real_directory_fsync = module._fsync_directory
 
-    def recording_fsync(descriptor):
+    def recording_file_fsync(descriptor):
         events.append("fsync")
-        return real_fsync(descriptor)
+        return real_file_fsync(descriptor)
 
     def recording_replace(source, target):
         events.append("replace")
@@ -226,12 +230,12 @@ def test_commit_sequence_fsyncs_file_before_rename_and_directory_after(
         events.append("dir_fsync")
         return real_directory_fsync(directory)
 
-    monkeypatch.setattr(module.os, "fsync", recording_fsync)
-    monkeypatch.setattr(module.os, "replace", recording_replace)
+    monkeypatch.setattr(module, "_fsync_file", recording_file_fsync)
+    monkeypatch.setattr(module, "_replace_document", recording_replace)
     monkeypatch.setattr(module, "_fsync_directory", recording_directory_fsync)
     assert provider.compare_and_put(0, head())["result"] == "applied"
     monkeypatch.undo()
-    assert events.index("fsync") < events.index("replace") < events.index("dir_fsync")
+    assert events == ["fsync", "replace", "dir_fsync"]
 
 
 def test_directory_fsync_fault_is_ambiguous_not_applied(

--- a/tests/control_plane/test_coordination_file_provider.py
+++ b/tests/control_plane/test_coordination_file_provider.py
@@ -152,6 +152,154 @@ def test_document_bytes_are_canonical_json(provider, tmp_path) -> None:
     assert envelope["head"] == head()
 
 
+def test_short_writes_are_continued_until_complete(
+    provider, tmp_path, monkeypatch
+) -> None:
+    """os.write may write fewer bytes than asked; the commit sequence must
+    continue until every byte landed, or a truncated document could be
+    reported as applied and fail to parse on the next load."""
+
+    import loopx.control_plane.coordination.file_provider as module
+
+    real_write = module.os.write
+    chunks = []
+
+    def short_write(descriptor, view):
+        chunk = bytes(view)[:7]
+        chunks.append(len(chunk))
+        return real_write(descriptor, chunk)
+
+    monkeypatch.setattr(module.os, "write", short_write)
+    outcome = provider.compare_and_put(0, head())
+    monkeypatch.undo()
+    assert outcome == {"result": "applied", "provider_generation": 1}
+    assert len(chunks) > 1
+    assert provider.load() == (head(), 1)
+
+
+def test_write_fault_after_short_write_is_ambiguous_and_document_intact(
+    provider, tmp_path, monkeypatch
+) -> None:
+    """A storage fault midway through the write must never surface as
+    applied: the document keeps its previous readable state and the verdict
+    is ambiguous, which the authority resolves by reload."""
+
+    import loopx.control_plane.coordination.file_provider as module
+
+    assert provider.compare_and_put(0, head())["result"] == "applied"
+    real_write = module.os.write
+    state = {"calls": 0}
+
+    def failing_write(descriptor, view):
+        state["calls"] += 1
+        if state["calls"] == 1:
+            return real_write(descriptor, bytes(view)[: max(1, len(view) // 2)])
+        raise OSError("simulated storage fault after a short write")
+
+    monkeypatch.setattr(module.os, "write", failing_write)
+    outcome = provider.compare_and_put(1, head(1))
+    monkeypatch.undo()
+    assert outcome == {"result": "ambiguous"}
+    assert provider.load() == (head(), 1)
+    assert not list((tmp_path / "coordination").glob("*.tmp-*"))
+
+
+def test_commit_sequence_fsyncs_file_before_rename_and_directory_after(
+    provider, monkeypatch
+) -> None:
+    import loopx.control_plane.coordination.file_provider as module
+
+    events = []
+    real_fsync = module.os.fsync
+    real_replace = module.os.replace
+    real_directory_fsync = module._fsync_directory
+
+    def recording_fsync(descriptor):
+        events.append("fsync")
+        return real_fsync(descriptor)
+
+    def recording_replace(source, target):
+        events.append("replace")
+        return real_replace(source, target)
+
+    def recording_directory_fsync(directory):
+        events.append("dir_fsync")
+        return real_directory_fsync(directory)
+
+    monkeypatch.setattr(module.os, "fsync", recording_fsync)
+    monkeypatch.setattr(module.os, "replace", recording_replace)
+    monkeypatch.setattr(module, "_fsync_directory", recording_directory_fsync)
+    assert provider.compare_and_put(0, head())["result"] == "applied"
+    monkeypatch.undo()
+    assert events.index("fsync") < events.index("replace") < events.index("dir_fsync")
+
+
+def test_directory_fsync_fault_is_ambiguous_not_applied(
+    provider, monkeypatch
+) -> None:
+    """Until the parent directory entry is flushed the rename is not provably
+    durable, so a fault there must stay ambiguous instead of applied."""
+
+    import loopx.control_plane.coordination.file_provider as module
+
+    def failing_directory_fsync(directory):
+        raise OSError("simulated directory fsync fault")
+
+    monkeypatch.setattr(module, "_fsync_directory", failing_directory_fsync)
+    outcome = provider.compare_and_put(0, head())
+    monkeypatch.undo()
+    assert outcome == {"result": "ambiguous"}
+    # The rename itself landed; reload recovers the write, which is exactly
+    # the ambiguous contract.
+    assert provider.load() == (head(), 1)
+
+
+def test_lock_timeout_is_typed_failed_without_write(tmp_path) -> None:
+    from loopx.file_lock import exclusive_file_lock
+
+    directory = tmp_path / "coordination"
+    provider = FileCoordinationProvider(
+        directory, "goal-a", lock_timeout_seconds=0.05
+    )
+    directory.mkdir(parents=True, exist_ok=True)
+    with exclusive_file_lock(directory / provider_document_name()):
+        outcome = provider.compare_and_put(0, head())
+    assert outcome["result"] == "failed"
+    assert provider.load() == (None, 0)
+    assert provider.compare_and_put(0, head())["result"] == "applied"
+
+
+def provider_document_name() -> str:
+    import hashlib
+
+    digest = hashlib.sha256(b"goal-a").hexdigest()[:16]
+    return f"coordination-head-{digest}.json"
+
+
+def test_module_imports_without_fcntl() -> None:
+    """The provider must stay importable on interpreters without ``fcntl``
+    (Windows); platform locking belongs to ``loopx.file_lock``, the one lock
+    owner with both backends."""
+
+    import importlib
+    import sys
+
+    import loopx.control_plane.coordination.file_provider as module
+
+    sentinel = object()
+    saved = sys.modules.pop("fcntl", sentinel)
+    sys.modules["fcntl"] = None  # type: ignore[assignment]
+    try:
+        reloaded = importlib.reload(module)
+        assert hasattr(reloaded, "FileCoordinationProvider")
+    finally:
+        if saved is sentinel:
+            sys.modules.pop("fcntl", None)
+        else:
+            sys.modules["fcntl"] = saved
+        importlib.reload(module)
+
+
 def test_unserializable_head_fails_typed_and_writes_nothing(
     provider, tmp_path
 ) -> None:

--- a/tests/control_plane/test_coordination_file_provider.py
+++ b/tests/control_plane/test_coordination_file_provider.py
@@ -96,6 +96,29 @@ def test_concurrent_cas_from_same_generation_has_one_winner(provider) -> None:
     assert loaded in (head(1), head(2))
 
 
+def test_bool_disguised_generations_fail_closed(provider, tmp_path) -> None:
+    """The provider generation is typed state exactly like revisions and
+    epochs: JSON ``true`` must not load as generation 1, and a bool expected
+    generation must not hit the CAS and silently repair a corrupt envelope
+    into a valid lineage."""
+
+    for expected in (True, False):
+        outcome = provider.compare_and_put(expected, head())
+        assert outcome["result"] == "failed"
+        assert "non-negative integer" in outcome["error"]
+    assert provider.compare_and_put(0, head())["result"] == "applied"
+    document = next((tmp_path / "coordination").glob("*.json"))
+    body = document.read_text(encoding="utf-8")
+    document.write_text(
+        body.replace('"provider_generation":1', '"provider_generation":true'),
+        encoding="utf-8",
+    )
+    with pytest.raises(ProviderProtocolError, match="v0 contract"):
+        provider.load()
+    with pytest.raises(ProviderProtocolError, match="v0 contract"):
+        provider.compare_and_put(1, head(1))
+
+
 def test_corrupt_document_fails_closed(provider, tmp_path) -> None:
     assert provider.compare_and_put(0, head())["result"] == "applied"
     document = next((tmp_path / "coordination").glob("*.json"))

--- a/tests/control_plane/test_coordination_file_provider.py
+++ b/tests/control_plane/test_coordination_file_provider.py
@@ -1,0 +1,168 @@
+"""The file-backed coordination provider: storage-only CAS with typed outcomes.
+
+RFC section 6.2: ``load() -> (head | None, provider_generation)`` and
+``compare_and_put(expected_provider_generation, head) -> applied | conflict |
+ambiguous | failed``. The provider never interprets the head; crash windows
+must map onto ``ambiguous`` (never a silent success or a lost document).
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+
+import pytest
+
+from loopx.control_plane.coordination.file_provider import (
+    FileCoordinationProvider,
+    ProviderProtocolError,
+)
+
+
+def head(revision: int = 0) -> dict:
+    return {
+        "schema_version": "loopx_coordination_head_v0",
+        "goal_id": "goal-a",
+        "handoff_mode": "hard_lease",
+        "authority_revision": revision,
+        "coordination": {"todos": {}, "leases": {}},
+        "receipt_index": {},
+        "receipt_retention": {"mode": "retain_all_v0"},
+    }
+
+
+@pytest.fixture
+def provider(tmp_path) -> FileCoordinationProvider:
+    return FileCoordinationProvider(tmp_path / "coordination", "goal-a")
+
+
+def test_load_uninitialized_returns_none_zero(provider) -> None:
+    assert provider.load() == (None, 0)
+
+
+def test_create_replace_conflict_cycle(provider) -> None:
+    created = provider.compare_and_put(0, head())
+    assert created == {"result": "applied", "provider_generation": 1}
+    loaded, generation = provider.load()
+    assert loaded == head() and generation == 1
+
+    replaced = provider.compare_and_put(1, head(1))
+    assert replaced == {"result": "applied", "provider_generation": 2}
+
+    stale = provider.compare_and_put(1, head(9))
+    assert stale == {"result": "conflict", "current_provider_generation": 2}
+    lost_create = provider.compare_and_put(0, head())
+    assert lost_create == {"result": "conflict", "current_provider_generation": 2}
+    assert provider.load() == (head(1), 2)
+
+
+def test_two_handles_share_one_document(tmp_path) -> None:
+    a = FileCoordinationProvider(tmp_path / "c", "goal-a")
+    b = FileCoordinationProvider(tmp_path / "c", "goal-a")
+    assert a.compare_and_put(0, head())["result"] == "applied"
+    assert b.load() == (head(), 1)
+    assert b.compare_and_put(1, head(1))["result"] == "applied"
+    assert a.compare_and_put(1, head(2))["result"] == "conflict"
+
+
+def test_goals_are_isolated_documents(tmp_path) -> None:
+    a = FileCoordinationProvider(tmp_path / "c", "goal-a")
+    b = FileCoordinationProvider(tmp_path / "c", "goal-b")
+    assert a.compare_and_put(0, head())["result"] == "applied"
+    assert b.load() == (None, 0)
+
+
+def test_concurrent_cas_from_same_generation_has_one_winner(provider) -> None:
+    assert provider.compare_and_put(0, head())["result"] == "applied"
+    barrier = threading.Barrier(2)
+    results = {}
+
+    def racer(name: str, revision: int) -> None:
+        barrier.wait()
+        results[name] = provider.compare_and_put(1, head(revision))
+
+    threads = [
+        threading.Thread(target=racer, args=("a", 1)),
+        threading.Thread(target=racer, args=("b", 2)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    outcomes = sorted(result["result"] for result in results.values())
+    assert outcomes in (["applied", "conflict"], ["ambiguous", "applied"]), results
+    loaded, generation = provider.load()
+    assert generation == 2
+    assert loaded in (head(1), head(2))
+
+
+def test_corrupt_document_fails_closed(provider, tmp_path) -> None:
+    assert provider.compare_and_put(0, head())["result"] == "applied"
+    document = next((tmp_path / "coordination").glob("*.json"))
+    document.write_text("{not json", encoding="utf-8")
+    with pytest.raises(ProviderProtocolError):
+        provider.load()
+    with pytest.raises(ProviderProtocolError):
+        provider.compare_and_put(1, head(1))
+
+
+def test_crash_after_temp_write_before_rename_changes_nothing(
+    provider, monkeypatch
+) -> None:
+    assert provider.compare_and_put(0, head())["result"] == "applied"
+    import loopx.control_plane.coordination.file_provider as module
+
+    def crash(_source, _target):
+        raise OSError("simulated crash before rename")
+
+    monkeypatch.setattr(module.os, "replace", crash)
+    outcome = provider.compare_and_put(1, head(1))
+    assert outcome["result"] == "ambiguous"
+    monkeypatch.undo()
+    assert provider.load() == (head(), 1)
+    retry = provider.compare_and_put(1, head(1))
+    assert retry == {"result": "applied", "provider_generation": 2}
+
+
+def test_lost_response_after_rename_is_recoverable_by_reload(
+    provider, monkeypatch
+) -> None:
+    assert provider.compare_and_put(0, head())["result"] == "applied"
+    import loopx.control_plane.coordination.file_provider as module
+
+    real_replace = module.os.replace
+
+    def replace_then_crash(source, target):
+        real_replace(source, target)
+        raise OSError("simulated lost response after rename")
+
+    monkeypatch.setattr(module.os, "replace", replace_then_crash)
+    outcome = provider.compare_and_put(1, head(1))
+    assert outcome["result"] == "ambiguous"
+    monkeypatch.undo()
+    assert provider.load() == (head(1), 2)
+
+
+def test_document_bytes_are_canonical_json(provider, tmp_path) -> None:
+    provider.compare_and_put(0, head())
+    document = next((tmp_path / "coordination").glob("*.json"))
+    envelope = json.loads(document.read_text(encoding="utf-8"))
+    assert set(envelope) == {"provider_generation", "head"}
+    assert envelope["provider_generation"] == 1
+    assert envelope["head"] == head()
+
+
+def test_unserializable_head_fails_typed_and_writes_nothing(
+    provider, tmp_path
+) -> None:
+    """A head with no faithful strict-JSON form must surface as the typed
+    ``failed`` verb (serialization runs before any write), never leak an
+    exception through the seam or leave partial bytes behind."""
+
+    for poison in ({"x": float("nan")}, {"x": object()}):
+        outcome = provider.compare_and_put(0, poison)
+        assert outcome["result"] == "failed"
+        assert "serializable" in outcome["error"]
+    assert provider.load() == (None, 0)
+    assert not list((tmp_path / "coordination").glob("*.tmp-*"))
+    assert provider.compare_and_put(0, head())["result"] == "applied"

--- a/tests/control_plane/test_coordination_head.py
+++ b/tests/control_plane/test_coordination_head.py
@@ -1,0 +1,376 @@
+"""The RFC ``loopx_coordination_head_v0`` aggregate: schema, canonical bytes, adapters.
+
+Stage 2 slice: the head is the one CAS document a coordination provider stores.
+This file pins the aggregate contract before any executor logic exists.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+
+from loopx.control_plane.coordination.authority_core import (
+    HandoffMode,
+    TodoSnapshot,
+)
+from loopx.control_plane.coordination.head import (
+    HEAD_SCHEMA_VERSION,
+    HeadValidationError,
+    bootstrap_head,
+    bootstrap_head_from_goal_state,
+    canonical_head_bytes,
+    claim_snapshot_for_todo,
+    head_digest,
+    validated_head,
+)
+
+
+def eligibility() -> dict:
+    return {
+        "authorization_projection_revision": 3,
+        "authorization_projection_digest": "sha256:bootstrap-auth",
+        "allowed_agent_ids": ["agent-a", "agent-b"],
+        "dependencies_satisfied": True,
+        "dependency_revision": 12,
+        "gates_open": True,
+        "gate_revision": 5,
+    }
+
+
+def todo(**overrides) -> dict:
+    base = {
+        "todo_revision": 7,
+        "status": "open",
+        "claimed_by": None,
+        "eligibility": eligibility(),
+        "repository": "git:example/repo",
+        "code_revision": "0123456789abcdef",
+        "last_lease_epoch": 6,
+    }
+    base.update(overrides)
+    return base
+
+
+def head() -> dict:
+    return bootstrap_head("goal-a", {"todo-1": todo(), "todo-2": todo()})
+
+
+# ---- bootstrap + validation -------------------------------------------------
+
+
+def test_bootstrap_head_matches_rfc_shape() -> None:
+    built = head()
+    assert built["schema_version"] == HEAD_SCHEMA_VERSION == "loopx_coordination_head_v0"
+    assert built["goal_id"] == "goal-a"
+    assert built["handoff_mode"] == "hard_lease"
+    assert built["authority_revision"] == 0
+    assert set(built["coordination"]) == {"todos", "leases"}
+    assert built["coordination"]["leases"] == {}
+    assert built["receipt_index"] == {}
+    assert built["receipt_retention"] == {"mode": "retain_all_v0"}
+    assert validated_head(built, goal_id="goal-a") is built
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (lambda h: h.pop("receipt_retention"), "fields"),
+        (lambda h: h.update(receipt_retention={"mode": "bounded"}), "retain_all_v0"),
+        (lambda h: h.update(schema_version="v1"), "identity"),
+        (lambda h: h.update(goal_id="other"), "identity"),
+        (lambda h: h.update(authority_revision="9"), "authority_revision"),
+        (lambda h: h.update(authority_revision=True), "authority_revision"),
+        (lambda h: h.update(handoff_mode="soft_claim"), "hard_lease"),
+        (lambda h: h.update(handoff_mode="legacy"), "hard_lease"),
+        (lambda h: h["coordination"].pop("leases"), "todos and leases"),
+        (lambda h: h.update(extra=True), "fields"),
+    ],
+)
+def test_validated_head_fails_closed(mutate, match) -> None:
+    broken = head()
+    mutate(broken)
+    with pytest.raises(HeadValidationError, match=match):
+        validated_head(broken, goal_id="goal-a")
+
+
+def test_bootstrap_rejects_non_portable_todo() -> None:
+    with pytest.raises(HeadValidationError, match="repository"):
+        bootstrap_head("goal-a", {"todo-1": todo(repository="/abs/path")})
+    with pytest.raises(HeadValidationError, match="open and unclaimed"):
+        bootstrap_head("goal-a", {"todo-1": todo(claimed_by="agent-a")})
+    with pytest.raises(HeadValidationError, match="fields"):
+        bad = todo()
+        bad.pop("last_lease_epoch")
+        bootstrap_head("goal-a", {"todo-1": bad})
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"todo_revision": True},
+        {"todo_revision": -1},
+        {"last_lease_epoch": True},
+        {"last_lease_epoch": -7},
+    ],
+)
+def test_bootstrap_rejects_bool_and_negative_counts(overrides) -> None:
+    """bool is an int subclass; a ``True`` epoch would mint ``True + 1`` and a
+    negative one would mint decreasing epochs, so both fail closed exactly like
+    the local core's corrupt_lease."""
+
+    with pytest.raises(HeadValidationError):
+        bootstrap_head("goal-a", {"todo-1": todo(**overrides)})
+
+
+def test_bootstrap_rejects_bool_eligibility_revision() -> None:
+    poisoned = eligibility()
+    poisoned["gate_revision"] = True
+    with pytest.raises(HeadValidationError, match="eligibility revisions"):
+        bootstrap_head("goal-a", {"todo-1": todo(eligibility=poisoned)})
+
+
+def leased_head() -> dict:
+    built = head()
+    built["coordination"]["leases"]["todo-1"] = {
+        "lease_id": "lease_abc",
+        "owner": "agent-a",
+        "lease_epoch": 7,
+        "expires_at": "2027-01-01T00:00:00.000Z",
+        "write_scopes": [],
+    }
+    return built
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (lambda lease: lease.update(lease_epoch=0), "positive"),
+        (lambda lease: lease.update(lease_epoch=True), "positive"),
+        (lambda lease: lease.update(owner=""), "identity"),
+        (lambda lease: lease.update(expires_at=123), "timestamp"),
+        (lambda lease: lease.update(write_scopes=["repo"]), "write_scopes"),
+    ],
+)
+def test_validated_head_rejects_corrupt_lease_records(mutate, match) -> None:
+    assert validated_head(leased_head(), goal_id="goal-a")
+    broken = leased_head()
+    mutate(broken["coordination"]["leases"]["todo-1"])
+    with pytest.raises(HeadValidationError, match=match):
+        validated_head(broken, goal_id="goal-a")
+
+
+# ---- canonical bytes + digest ----------------------------------------------
+
+
+def test_canonical_bytes_are_key_order_independent() -> None:
+    a = head()
+    b = json.loads(json.dumps(a))
+    b["coordination"] = dict(reversed(list(b["coordination"].items())))
+    assert canonical_head_bytes(a) == canonical_head_bytes(b)
+    assert head_digest(a) == head_digest(b)
+    assert head_digest(a).startswith("sha256:")
+
+
+def test_canonical_bytes_change_with_content() -> None:
+    a = head()
+    b = copy.deepcopy(a)
+    b["authority_revision"] = 1
+    assert canonical_head_bytes(a) != canonical_head_bytes(b)
+
+
+def test_canonical_bytes_fail_closed_on_unrepresentable_values() -> None:
+    """Non-finite floats would serialize into bytes a strict RFC 8259 reader
+    rejects, and non-JSON objects have no canonical form at all; neither may
+    ever become "canonical" bytes or an unclassified exception."""
+
+    poisoned = head()
+    poisoned["coordination"]["todos"]["todo-1"]["eligibility"][
+        "dependency_revision"
+    ] = float("nan")
+    with pytest.raises(HeadValidationError, match="serializable"):
+        canonical_head_bytes(poisoned)
+    with pytest.raises(HeadValidationError, match="serializable"):
+        canonical_head_bytes({"x": object()})
+
+
+# ---- snapshot adapter -------------------------------------------------------
+
+
+def test_claim_snapshot_maps_aggregate_facts_into_core_types() -> None:
+    built = head()
+    snapshot = claim_snapshot_for_todo(built, "todo-1")
+    # The shared head carries claim and lease together, so the core's
+    # hard-lease holder gate is a live invariant for it.
+    assert snapshot.handoff_mode is HandoffMode.HARD_LEASE
+    assert snapshot.registered_agents == ("agent-a", "agent-b")
+    assert isinstance(snapshot.todo, TodoSnapshot)
+    assert snapshot.todo.todo_id == "todo-1"
+    assert snapshot.todo.status == "open"
+    assert snapshot.todo.claimed_by is None
+    # No lease in the head projects the no-ABA tombstone: the epoch watermark
+    # from the todo, not an absent lease, so the core mints last+1.
+    assert snapshot.lease is not None
+    assert snapshot.lease.present is False and snapshot.lease.active is False
+    assert snapshot.lease.lease_epoch == 6 and snapshot.lease.version == 6
+    with pytest.raises(HeadValidationError, match="todo"):
+        claim_snapshot_for_todo(built, "todo-9")
+
+
+def test_snapshot_mode_is_read_from_the_head() -> None:
+    """The mode is the head's revision-covered fact, not an adapter constant:
+    v0 validation pins it to hard_lease, and the projection follows whatever
+    the (validated) document says rather than re-deciding it."""
+
+    built = head()
+    assert claim_snapshot_for_todo(built, "todo-1").handoff_mode is HandoffMode.HARD_LEASE
+    relaxed = {**built, "handoff_mode": "legacy"}
+    assert claim_snapshot_for_todo(relaxed, "todo-1").handoff_mode is HandoffMode.LEGACY
+
+
+# ---- shadow bootstrap from the local goal state -----------------------------
+#
+# Fixtures are written by loopx's own writers so the parity is against the real
+# on-disk format, not a hand-approximated markdown.
+
+
+def _shadow_workspace(tmp_path):
+    import json as _json
+
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    state = repo / "ACTIVE_GOAL_STATE.md"
+    state.write_text(
+        "---\ngoal_id: shadow-goal\nupdated_at: 2026-08-01T00:00:00+00:00\n"
+        "handoff_mode: hard_lease\n---\n\n## Agent Todo\n\n",
+        encoding="utf-8",
+    )
+    registry = tmp_path / "registry.global.json"
+    registry.write_text(
+        _json.dumps(
+            {
+                "common_runtime_root": str(tmp_path / "runtime"),
+                "goals": [
+                    {
+                        "id": "shadow-goal",
+                        "domain": "harness_self_improvement",
+                        "status": "active",
+                        "repo": str(repo),
+                        "state_file": state.name,
+                        "adapter": {"kind": "harness_self_improvement"},
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": ["agent-a", "agent-b"],
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return registry, state
+
+
+def _seed_todos(registry):
+    from loopx.control_plane.work_items.task_lease import acquire_task_lease
+    from loopx.todos import add_goal_todo, complete_goal_todo
+
+    claimed = add_goal_todo(
+        registry_path=registry, goal_id="shadow-goal", role="agent",
+        text="Ship the provider slice.", task_class="advancement_task",
+        claimed_by="agent-a",
+    )
+    open_todo = add_goal_todo(
+        registry_path=registry, goal_id="shadow-goal", role="agent",
+        text="Review the provider slice.", task_class="advancement_task",
+    )
+    done = add_goal_todo(
+        registry_path=registry, goal_id="shadow-goal", role="agent",
+        text="Land the prerequisite.", task_class="advancement_task",
+        claimed_by="agent-b",
+    )
+    acquire_task_lease(
+        registry_path=registry,
+        runtime_root=registry.parent / "runtime",
+        goal_id="shadow-goal",
+        todo_id=done["todo_id"],
+        owner="agent-b",
+        idempotency_key="turn-lease-1",
+        ttl_seconds=600,
+    )
+    complete_goal_todo(
+        registry_path=registry, goal_id="shadow-goal", todo_id=done["todo_id"],
+        agent_id="agent-b", evidence="landed", no_followup=True,
+        task_lease_idempotency_key="turn-lease-1",
+        task_lease_expected_version=1,
+    )
+    return claimed["todo_id"], open_todo["todo_id"], done["todo_id"]
+
+
+def test_bootstrap_from_goal_state_shadows_open_unclaimed_todos(tmp_path) -> None:
+    registry, state = _shadow_workspace(tmp_path)
+    claimed_id, open_id, done_id = _seed_todos(registry)
+
+    built, report = bootstrap_head_from_goal_state(
+        state.read_text(encoding="utf-8"),
+        goal_id="shadow-goal",
+        repository="git:example/repo",
+        code_revision="0123456789abcdef",
+        allowed_agent_ids=["agent-a", "agent-b"],
+        with_report=True,
+    )
+
+    todos = built["coordination"]["todos"]
+    assert set(todos) == {open_id}
+    entry = todos[open_id]
+    assert entry["status"] == "open" and entry["claimed_by"] is None
+    assert entry["todo_revision"] == 0 and entry["last_lease_epoch"] == 0
+    assert entry["eligibility"]["allowed_agent_ids"] == ["agent-a", "agent-b"]
+    assert validated_head(built, goal_id="shadow-goal") is built
+    assert report["skipped"] == {claimed_id: "claimed", done_id: "done"}
+    assert report["source_handoff_mode"] == "hard_lease"
+
+
+def test_bootstrap_from_goal_state_read_parity_with_the_projection(tmp_path) -> None:
+    """Every open unclaimed todo in the real projection lands in the head, and
+    nothing else does — the RFC section 11 shadow read-parity for this slice."""
+
+    from loopx.status import parse_active_state_todos
+
+    registry, state = _shadow_workspace(tmp_path)
+    _seed_todos(registry)
+    text = state.read_text(encoding="utf-8")
+    built = bootstrap_head_from_goal_state(
+        text,
+        goal_id="shadow-goal",
+        repository="git:example/repo",
+        code_revision="0123456789abcdef",
+        allowed_agent_ids=["agent-a"],
+    )
+    projected = parse_active_state_todos(text)["agent_todos"]["items"]
+    expected = {
+        item["todo_id"]
+        for item in projected
+        if not item.get("done") and not item.get("claimed_by")
+    }
+    assert set(built["coordination"]["todos"]) == expected
+
+
+def test_bootstrap_from_soft_claim_goal_fails_closed() -> None:
+    """A soft_claim goal's declared mode rejects lease minting locally; shared
+    claim_work mints a lease on every accepted claim, so migrating such a goal
+    would silently invert its semantics. Bootstrap refuses instead."""
+
+    state_text = (
+        "---\ngoal_id: shadow-goal\nupdated_at: 2026-08-01T00:00:00+00:00\n"
+        "handoff_mode: soft_claim\n---\n\n## Agent Todo\n\n"
+    )
+    with pytest.raises(HeadValidationError, match="soft_claim"):
+        bootstrap_head_from_goal_state(
+            state_text,
+            goal_id="shadow-goal",
+            repository="git:example/repo",
+            code_revision="0123456789abcdef",
+            allowed_agent_ids=["agent-a"],
+        )

--- a/tests/control_plane/test_coordination_head.py
+++ b/tests/control_plane/test_coordination_head.py
@@ -15,11 +15,13 @@ from loopx.control_plane.coordination.authority_core import (
     HandoffMode,
     TodoSnapshot,
 )
+from loopx.control_plane.coordination.goal_state_shadow import (
+    bootstrap_head_from_goal_state,
+)
 from loopx.control_plane.coordination.head import (
     HEAD_SCHEMA_VERSION,
     HeadValidationError,
     bootstrap_head,
-    bootstrap_head_from_goal_state,
     canonical_head_bytes,
     claim_snapshot_for_todo,
     head_digest,
@@ -150,6 +152,7 @@ def leased_head() -> dict:
         (lambda lease: lease.update(lease_epoch=True), "positive"),
         (lambda lease: lease.update(owner=""), "identity"),
         (lambda lease: lease.update(expires_at=123), "timestamp"),
+        (lambda lease: lease.update(expires_at="not-a-time"), "timestamp"),
         (lambda lease: lease.update(write_scopes=["repo"]), "write_scopes"),
     ],
 )
@@ -157,6 +160,83 @@ def test_validated_head_rejects_corrupt_lease_records(mutate, match) -> None:
     assert validated_head(leased_head(), goal_id="goal-a")
     broken = leased_head()
     mutate(broken["coordination"]["leases"]["todo-1"])
+    with pytest.raises(HeadValidationError, match=match):
+        validated_head(broken, goal_id="goal-a")
+
+
+_RECEIPT_DIGEST = "sha256:" + "0" * 64
+
+
+def receipted_head() -> dict:
+    built = leased_head()
+    built["receipt_index"]["op-1"] = {
+        "request_digest": _RECEIPT_DIGEST,
+        "original_receipt": {
+            "schema_version": "loopx_authority_receipt_v0",
+            "operation_id": "op-1",
+            "request_digest": _RECEIPT_DIGEST,
+            "command": "claim_work",
+            "actor": {"agent_id": "agent-a", "device_id": "dev-a"},
+            "todo_id": "todo-1",
+            "accepted_authority_revision": 1,
+            "accepted_todo_revision": 8,
+            "applied_at": "2027-01-01T00:00:00.000Z",
+            "lease_id": "lease_abc",
+            "lease_epoch": 7,
+            "expires_at": "2027-01-01T00:10:00.000Z",
+        },
+    }
+    return built
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (lambda e: e.update(original_receipt={}), "fields do not match"),
+        (lambda e: e.update(extra=True), "fields do not match"),
+        (lambda e: e.update(request_digest="sha256:bootstrap"), "request_digest"),
+        (
+            lambda e: e["original_receipt"].update(operation_id="op-2"),
+            "its own operation id",
+        ),
+        (
+            lambda e: e["original_receipt"].update(
+                request_digest="sha256:" + "1" * 64
+            ),
+            "disagrees with its index entry",
+        ),
+        (
+            lambda e: e["original_receipt"].update(todo_id="todo-9"),
+            "todo the head does not carry",
+        ),
+        (
+            lambda e: e["original_receipt"].update(accepted_todo_revision=0),
+            "accepted revisions",
+        ),
+        (lambda e: e["original_receipt"].update(lease_epoch=True), "lease_epoch"),
+        (
+            lambda e: e["original_receipt"].update(applied_at="not-a-time"),
+            "timestamps",
+        ),
+        (
+            lambda e: e["original_receipt"].update(actor={"agent_id": ""}),
+            "actor identity",
+        ),
+        (
+            lambda e: e["original_receipt"].update(command="release_work"),
+            "outside the v0 slice",
+        ),
+    ],
+)
+def test_validated_head_rejects_corrupt_receipt_entries(mutate, match) -> None:
+    """Persisted receipts cross the same trust boundary as todos and leases:
+    every field the executor later dereferences unconditionally is validated
+    here, so a digest-matching entry with a gutted ``original_receipt`` fails
+    closed instead of surfacing as a KeyError inside replay."""
+
+    assert validated_head(receipted_head(), goal_id="goal-a")
+    broken = receipted_head()
+    mutate(broken["receipt_index"]["op-1"])
     with pytest.raises(HeadValidationError, match=match):
         validated_head(broken, goal_id="goal-a")
 

--- a/tests/control_plane/test_coordination_head.py
+++ b/tests/control_plane/test_coordination_head.py
@@ -153,6 +153,14 @@ def leased_head() -> dict:
         (lambda lease: lease.update(owner=""), "identity"),
         (lambda lease: lease.update(expires_at=123), "timestamp"),
         (lambda lease: lease.update(expires_at="not-a-time"), "timestamp"),
+        # Naive timestamps read differently under each host's local timezone,
+        # so the same persisted bytes would be active on one endpoint and
+        # expired on another; v0 mints and accepts aware UTC only.
+        (lambda lease: lease.update(expires_at="2030-01-01T00:00:00"), "timestamp"),
+        (
+            lambda lease: lease.update(expires_at="2030-01-01T00:00:00+08:00"),
+            "timestamp",
+        ),
         (lambda lease: lease.update(write_scopes=["repo"]), "write_scopes"),
     ],
 )
@@ -216,6 +224,16 @@ def receipted_head() -> dict:
         (lambda e: e["original_receipt"].update(lease_epoch=True), "lease_epoch"),
         (
             lambda e: e["original_receipt"].update(applied_at="not-a-time"),
+            "timestamps",
+        ),
+        (
+            lambda e: e["original_receipt"].update(applied_at="2030-01-01T00:00:00"),
+            "timestamps",
+        ),
+        (
+            lambda e: e["original_receipt"].update(
+                expires_at="2030-01-01T00:00:00+08:00"
+            ),
             "timestamps",
         ),
         (


### PR DESCRIPTION
## What this is

The first Stage 2 slice of the shared-goal authority RFC (section 11): the real ledger contract behind one provider CAS, additively.

- `loopx/control_plane/coordination/head.py`: the `loopx_coordination_head_v0` aggregate codec. Closed-set fail-closed validation (bool-disguised integers, corrupt lease records, non-empty v0 write scopes all rejected); canonical bytes pinned as THE digest/parity basis (sorted keys, minimal separators, UTF-8, `allow_nan=False`); `handoff_mode` recorded in the head and pinned to `hard_lease` in v0, so a `soft_claim` goal fails bootstrap closed instead of having its declared semantics silently inverted; snapshot projection seeds lease epochs from the todo's `last_lease_epoch` watermark (no-ABA tombstone).
- `loopx/control_plane/coordination/file_provider.py`: storage plane only. One goal, one document; flock + exclusive temp create + fsync + atomic rename; typed verbs; crash windows report `ambiguous`; unserializable heads report typed `failed` before any byte lands.
- `loopx/control_plane/coordination/executor.py`: RFC section 5 steps 1-10 for `claim_work`. Every domain decision delegated to the Stage 1 core; composition is acquire -> hard-lease-gated claim (claim-first or legacy-mode composition silently bypasses the Appendix B holder gate; tests pin this). Provider `failed` verdicts are verified against the reloaded receipt index, not trusted.
- `examples/nokv-shadow-provider/live_e2e.py`: repeatable eight-scenario live qualification matrix (production executor over file and NoKV providers, public-safe parity table, green-with-unverified-rows when no stack is reachable).
- RFC mirrors + evidence note: dated Stage 2 status subsection with the measured boundaries below.

## Stacked on #3410

Based on and targeting `codex/authority-core-stage1-part2` (head `eba796ee`), because the executor delegates to the Stage 1 core that lands there. After #3410 merges I will retarget to `main` and rebase. Nothing in `main`'s behavior changes until then; every file here is new except the RFC/README doc updates.

## How the executor was chosen (not asserted)

Three candidates ran one scenario battery: (A) core-delegating executor, (B) the examples inline-rules reference, (C) a journal-style receipt log inside the same document. All pass the six functional scenarios; only A and C follow a flipped core rule without local edits (the harmony requirement from the Stage 1 boundary), and C's codec saves no meaningful bytes under `retain_all_v0` (~1.1 KB/receipt both ways). A ships.

## Evidence

Deterministic: 54 coordination tests (head 22, provider 10, executor 22); ruff and mypy clean on the new modules; full `tests/control_plane + tests/canary + tests/architecture`: 1764 passed, 4 failed - the same 4 environment-dependent tests fail identically on a pristine `main` checkout on the same machine (monitor followthrough, scheduler host binding x2, runtime readiness doctor), i.e. zero regressions from this slice.

Live (single-node NoKV dev stack at the v0.11.0 tag, driven through its Python SDK wheel): the eight-scenario matrix passes identically for the file provider and the NoKV provider (parity table: 8/8 rows, `identical_row_outcomes: true`), and a SIGKILL of the serving owner followed by an operator-style reopen preserved the head byte for byte, replayed the original receipt exactly through a fresh executor, and resumed CAS across all three version domains (generation 2->3, authority_revision 1->2, lease epochs minted 7/7).

## Measured boundaries recorded in the RFC (not silently engineered around)

- `retain_all_v0`: ~750 B/receipt in the one CAS document; claim latency grew ~7x across the first 120 receipts on the dev stack; cumulative republish bytes grow quadratically (~84x final head size after 120 claims). Section 12's retention decision is load-bearing before any canary.
- 12 concurrent independent-todo claims: 8 applied, the rest typed failures from the bounded rebase budget; the section 1 independence promise degrades beyond two endpoints.
- NoKV `provider_generation` restarts across remove/recreate and restore lineages (live-confirmed stale CAS applying on a recreated path). Confirms the Stage 1 boundary sentence: the restore/lineage binding fence needs an explicit provider-contract field in the next stage; `provider_generation` alone cannot carry it.
- `provider_outcome_unproved` is a real live terminal state (no fault injection needed). A bounded same-generation re-attempt would be safe because receipt replay makes re-submission idempotent; adopting that liveness amendment is left as an owner decision in section 11, not silently implemented.