### PR TITLE
fix(quota): replay settled terminal heartbeat receipts

### DIFF
--- a/loopx/control_plane/effect_program.py
+++ b/loopx/control_plane/effect_program.py
@@ -25,6 +25,12 @@ class ReceiptBoundMonitorPhase(StrEnum):
     SETTLED = "settled"
 
 
+class ReceiptBoundTerminalPhase(StrEnum):
+    OPEN = "open"
+    SETTLEMENT_PENDING = "settlement_pending"
+    SETTLED = "settled"
+
+
 def receipt_bound_monitor_phase(
     *,
     poll_present: bool,
@@ -44,6 +50,25 @@ def receipt_bound_monitor_phase(
     if result is None:
         return None
     return ReceiptBoundMonitorPhase(str(result))
+
+
+def receipt_bound_terminal_phase(
+    *,
+    terminal_closeout_present: bool,
+    durable_writeback_present: bool,
+    quota_spend_present: bool,
+) -> ReceiptBoundTerminalPhase | None:
+    result = effect_runtime_result(
+        "settlement.receipt_bound_terminal_phase",
+        {
+            "terminal_closeout_present": terminal_closeout_present,
+            "durable_writeback_present": durable_writeback_present,
+            "quota_spend_present": quota_spend_present,
+        },
+    )
+    if result is None:
+        return None
+    return ReceiptBoundTerminalPhase(str(result))
 
 
 @dataclass(frozen=True)

--- a/loopx/control_plane/effect_program.ts
+++ b/loopx/control_plane/effect_program.ts
@@ -120,6 +120,29 @@ export function receiptBoundMonitorPhase(
     : "settlement_pending";
 }
 
+export const RECEIPT_BOUND_TERMINAL_PHASES = [
+  "open",
+  "settlement_pending",
+  "settled",
+] as const;
+export type ReceiptBoundTerminalPhase =
+  (typeof RECEIPT_BOUND_TERMINAL_PHASES)[number];
+
+export interface ReceiptBoundTerminalSettlementState {
+  terminal_closeout_present: boolean;
+  durable_writeback_present: boolean;
+  quota_spend_present: boolean;
+}
+
+export function receiptBoundTerminalPhase(
+  state: ReceiptBoundTerminalSettlementState,
+): ReceiptBoundTerminalPhase {
+  if (!state.terminal_closeout_present) return "open";
+  return state.durable_writeback_present && state.quota_spend_present
+    ? "settled"
+    : "settlement_pending";
+}
+
 export interface SettlementIdentityInput {
   goal_id: string;
   agent_id: string;

--- a/loopx/control_plane/effect_runtime_handlers.ts
+++ b/loopx/control_plane/effect_runtime_handlers.ts
@@ -10,6 +10,7 @@ import {
   settlementIdentityPayload,
   settlementPlanPayload,
   receiptBoundMonitorPhase,
+  receiptBoundTerminalPhase,
   settlementResultPayload,
   SETTLEMENT_FAILURE_KINDS,
   SETTLEMENT_STEP_KINDS,
@@ -358,6 +359,14 @@ export function createEffectRuntimeHandlers(
       (params) => receiptBoundMonitorPhase({
         poll_present: params.poll_present === true,
         material_change: params.material_change === true,
+        durable_writeback_present: params.durable_writeback_present === true,
+        quota_spend_present: params.quota_spend_present === true,
+      }),
+    ],
+    [
+      "settlement.receipt_bound_terminal_phase",
+      (params) => receiptBoundTerminalPhase({
+        terminal_closeout_present: params.terminal_closeout_present === true,
         durable_writeback_present: params.durable_writeback_present === true,
         quota_spend_present: params.quota_spend_present === true,
       }),

--- a/loopx/control_plane/quota/effect_program.py
+++ b/loopx/control_plane/quota/effect_program.py
@@ -9,6 +9,7 @@ from ..effect_program import (
     SETTLEMENT_PLAN_SCHEMA_VERSION,
     SETTLEMENT_RECEIPT_SCHEMA_VERSION,
     ReceiptBoundMonitorPhase,
+    ReceiptBoundTerminalPhase,
     SettlementBindingKind,
     SettlementFailure,
     SettlementFailureKind,
@@ -19,6 +20,7 @@ from ..effect_program import (
     SettlementStep,
     SettlementStepKind,
     receipt_bound_monitor_phase,
+    receipt_bound_terminal_phase,
     settlement_result_payload,
 )
 
@@ -27,6 +29,7 @@ __all__ = [
     "SETTLEMENT_PLAN_SCHEMA_VERSION",
     "SETTLEMENT_RECEIPT_SCHEMA_VERSION",
     "ReceiptBoundMonitorPhase",
+    "ReceiptBoundTerminalPhase",
     "SettlementBindingKind",
     "SettlementFailure",
     "SettlementFailureKind",
@@ -39,6 +42,7 @@ __all__ = [
     "build_codex_app_settlement_plan",
     "build_turn_scoped_cli_settlement_plan",
     "receipt_bound_monitor_phase",
+    "receipt_bound_terminal_phase",
     "settlement_binding_args",
     "settlement_result_payload",
     "settlement_step_command",

--- a/loopx/control_plane/quota/live_decision.py
+++ b/loopx/control_plane/quota/live_decision.py
@@ -5,7 +5,10 @@ from pathlib import Path
 from typing import Any
 
 from ...quota import build_quota_should_run
-from .settlement import receipt_bound_monitor_settlement_phase
+from .settlement import (
+    receipt_bound_monitor_settlement_phase,
+    receipt_bound_terminal_settlement_phase,
+)
 from ..scheduler.execution_context import (
     SchedulerExecutionContextResolution,
     resolve_scheduler_execution_context,
@@ -133,6 +136,14 @@ def build_live_quota_should_run_decision(
         todo_id=receipt_bound_todo_id,
         turn_instance_id=turn_instance_id,
     )
+    receipt_bound_terminal_phase = receipt_bound_terminal_settlement_phase(
+        runtime_root,
+        goal_id=goal_id,
+        agent_id=agent_id,
+        todo_id=receipt_bound_todo_id,
+        replan_obligation_id=receipt_bound_replan_obligation_id,
+        turn_instance_id=turn_instance_id,
+    )
     payload = build_quota_should_run(
         decision_status_payload,
         goal_id=goal_id,
@@ -145,6 +156,7 @@ def build_live_quota_should_run_decision(
         operator_inbox_urgency_projector=operator_inbox_urgency_projector,
         receipt_bound_todo_id=receipt_bound_todo_id,
         receipt_bound_monitor_phase=receipt_bound_monitor_phase,
+        receipt_bound_terminal_phase=receipt_bound_terminal_phase,
         receipt_bound_replan_obligation_id=receipt_bound_replan_obligation_id,
         turn_instance_id=turn_instance_id,
     )

--- a/loopx/control_plane/quota/settlement.py
+++ b/loopx/control_plane/quota/settlement.py
@@ -29,10 +29,12 @@ from .effect_program import (
     SettlementStep,
     SettlementStepKind,
     ReceiptBoundMonitorPhase,
+    ReceiptBoundTerminalPhase,
     build_codex_app_settlement_plan,
     build_turn_scoped_cli_settlement_plan,
     settlement_binding_args,
     receipt_bound_monitor_phase,
+    receipt_bound_terminal_phase,
     settlement_result_payload,
     settlement_step_command,
 )
@@ -63,6 +65,7 @@ __all__ = [
     "find_settlement_writeback",
     "infer_persisted_heartbeat_settlement_identity",
     "receipt_bound_monitor_settlement_phase",
+    "receipt_bound_terminal_settlement_phase",
     "require_settlement_spend",
     "require_settlement_terminal_closeout",
     "require_settlement_writeback",
@@ -146,6 +149,50 @@ def receipt_bound_monitor_settlement_phase(
     return receipt_bound_monitor_phase(
         poll_present=True,
         material_change=True,
+        durable_writeback_present=durable_writeback_present,
+        quota_spend_present=quota_spend_present,
+    )
+
+
+def receipt_bound_terminal_settlement_phase(
+    runtime_root: Path,
+    *,
+    goal_id: str,
+    agent_id: str | None,
+    todo_id: str | None,
+    turn_instance_id: str | None,
+    replan_obligation_id: str | None = None,
+) -> ReceiptBoundTerminalPhase | None:
+    """Resolve terminal settlement for the exact persisted receipt identity.
+
+    Terminal replay is complete only after the identity has durable writeback,
+    quota-spend, and explicit no-follow-up closeout receipts.  An identity with
+    no terminal closeout remains open; a partial terminal chain remains pending
+    and therefore cannot suppress live work selection.
+    """
+
+    identity_result = resolve_heartbeat_settlement_identity(
+        runtime_root,
+        goal_id=goal_id,
+        agent_id=agent_id,
+        todo_id=todo_id,
+        turn_instance_id=turn_instance_id,
+        replan_obligation_id=replan_obligation_id,
+    )
+    identity = identity_result.value
+    if identity is None:
+        return None
+    terminal_closeout_present = (
+        require_settlement_terminal_closeout(runtime_root, identity).value is not None
+    )
+    durable_writeback_present = (
+        require_settlement_writeback(runtime_root, identity).value is not None
+    )
+    quota_spend_present = (
+        require_settlement_spend(runtime_root, identity).value is not None
+    )
+    return receipt_bound_terminal_phase(
+        terminal_closeout_present=terminal_closeout_present,
         durable_writeback_present=durable_writeback_present,
         quota_spend_present=quota_spend_present,
     )

--- a/loopx/control_plane/quota/settlement_precedence.py
+++ b/loopx/control_plane/quota/settlement_precedence.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from ..effect_program import ReceiptBoundTerminalPhase
+
+
+TERMINAL_HEARTBEAT_SETTLED_REASON = (
+    "the receipt-bound terminal closeout and required settlement receipts "
+    "are complete for this heartbeat turn; defer successor selection to a new turn"
+)
+
+_ACTION_PROJECTION_KEYS = (
+    "agent_command",
+    "action_portfolio",
+    "agent_lane_frontier_hint",
+    "agent_lane_next_action",
+    "agent_scope_frontier",
+    "autonomous_replan_decision",
+    "autonomous_replan_obligation",
+    "autonomous_replan_scope",
+    "blocked_priority_fallback",
+    "capability_gate",
+    "capability_monitor_fallback",
+    "external_evidence_observation",
+    "goal_route_hint",
+    "notify_user_on_capability_gate",
+    "notify_user_on_gate",
+    "notify_user_on_open_todo",
+    "open_todo_notification_policy",
+    "open_todo_notify_reason",
+    "required_reads",
+    "replan_action_packet",
+    "scoped_user_gate_fallback",
+    "stall_self_repair",
+    "vision_continuation_audit",
+    "vision_wait_state",
+    "workspace_guard",
+)
+
+
+class TerminalSettlementRoute(Protocol):
+    normal_delivery_allowed: bool
+    recovery_allowed: bool
+    self_repair_allowed: bool
+    capability_repair_allowed: bool
+    workspace_repair_allowed: bool
+    should_run: bool
+    effective_action: str
+    reason: str
+    replan_decision_allowed: bool
+    receipt_bound_replan_decision: bool
+    heartbeat_recommendation: dict[str, Any]
+    external_evidence_observation: dict[str, Any] | None
+    external_evidence_observation_recent: dict[str, Any] | None
+    selected_recommended_action: Any
+    agent_lane_next_action: dict[str, Any] | None
+    agent_scope_frontier: dict[str, Any] | None
+    agent_lane_frontier_hint: dict[str, Any] | None
+    state_action_projection_warning: dict[str, Any] | None
+    next_action_warning: dict[str, Any] | None
+    goal_route_hint: dict[str, Any] | None
+
+
+def apply_terminal_settlement_route_precedence(
+    route: TerminalSettlementRoute,
+    *,
+    terminal_phase: ReceiptBoundTerminalPhase | None,
+) -> None:
+    """Prevent a settled heartbeat identity from selecting work in the same turn."""
+
+    if terminal_phase is not ReceiptBoundTerminalPhase.SETTLED:
+        return
+    route.normal_delivery_allowed = False
+    route.recovery_allowed = False
+    route.self_repair_allowed = False
+    route.capability_repair_allowed = False
+    route.workspace_repair_allowed = False
+    route.should_run = False
+    route.effective_action = "heartbeat_settled_skip"
+    route.reason = TERMINAL_HEARTBEAT_SETTLED_REASON
+    route.replan_decision_allowed = False
+    route.receipt_bound_replan_decision = False
+    route.heartbeat_recommendation = {
+        **route.heartbeat_recommendation,
+        "recommended_mode": route.effective_action,
+        "notify": "DONT_NOTIFY",
+        "reason": route.reason,
+        "spend_policy": "no quota spend for an already-settled heartbeat turn",
+    }
+    route.external_evidence_observation = None
+    route.external_evidence_observation_recent = None
+    route.selected_recommended_action = route.reason
+    route.agent_lane_next_action = None
+    route.agent_scope_frontier = None
+    route.agent_lane_frontier_hint = None
+    route.state_action_projection_warning = None
+    route.next_action_warning = None
+    route.goal_route_hint = None
+
+
+def clear_quota_action_projections(
+    payload: dict[str, Any],
+    *,
+    additional_keys: tuple[str, ...] = (),
+) -> None:
+    for key in (*_ACTION_PROJECTION_KEYS, *additional_keys):
+        payload.pop(key, None)
+
+
+def apply_terminal_heartbeat_settlement_precedence(
+    payload: dict[str, Any],
+    *,
+    terminal_phase: ReceiptBoundTerminalPhase | None,
+) -> None:
+    """Keep late supporting projections from reopening a settled heartbeat turn."""
+
+    if terminal_phase is not ReceiptBoundTerminalPhase.SETTLED:
+        return
+    reason = TERMINAL_HEARTBEAT_SETTLED_REASON
+    payload.update(
+        {
+            "decision": "skip",
+            "should_run": False,
+            "normal_delivery_allowed": False,
+            "recovery_delivery_allowed": False,
+            "self_repair_allowed": False,
+            "capability_repair_allowed": False,
+            "workspace_repair_allowed": False,
+            "effective_action": "heartbeat_settled_skip",
+            "actionable_by_codex": False,
+            "reason": reason,
+            "requires_user_action": False,
+            "recommended_action": (
+                "Finish this heartbeat without another action; use a fresh turn "
+                "identity for successor selection."
+            ),
+            "heartbeat_recommendation": {
+                "recommended_mode": "heartbeat_settled_skip",
+                "notify": "DONT_NOTIFY",
+                "reason": reason,
+                "spend_policy": "no quota spend for an already-settled heartbeat turn",
+                "agent_must_attempt": False,
+            },
+            "execution_obligation": {
+                "must_attempt_work": False,
+                "kind": "heartbeat_settled_skip",
+                "delivery_allowed": False,
+                "notify_is_execution_gate": False,
+                "reason": reason,
+                "spend_policy": "no quota spend for an already-settled heartbeat turn",
+            },
+        }
+    )
+    frontier = payload.get("goal_frontier_projection")
+    if isinstance(frontier, dict):
+        payload["goal_frontier_projection"] = {
+            key: value
+            for key, value in frontier.items()
+            if key
+            not in {
+                "autonomous_replan_decision",
+                "replan_ack_feedback",
+                "replan_obligation",
+                "vision_continuation_audit",
+                "vision_wait_state",
+            }
+        }
+    clear_quota_action_projections(
+        payload,
+        additional_keys=(
+            "boundary_projection_gap",
+            "operator_question",
+            "selected_todo",
+            "state_projection_gap",
+            "task_orchestration_contract",
+            "todo_write_hint",
+        ),
+    )

--- a/loopx/control_plane/quota/should_run.py
+++ b/loopx/control_plane/quota/should_run.py
@@ -36,7 +36,7 @@ from ..work_items.interaction_contract import (
     build_interaction_contract,
     build_protocol_action_packet,
 )
-from .effect_program import ReceiptBoundMonitorPhase
+from .effect_program import ReceiptBoundMonitorPhase, ReceiptBoundTerminalPhase
 
 from .should_run_packet import (
     _QuotaDecisionRoute,
@@ -49,10 +49,22 @@ from .should_run_prepare import (
     _QuotaDecisionPreparation,
     _prepare_quota_should_run_item,
 )
+from .settlement_precedence import apply_terminal_settlement_route_precedence
 
 
 QUOTA_PAUSED_MODE = "quota_paused"
 GOAL_STOPPED_MODE = "goal_stopped"
+
+
+def _resolve_quota_route_with_terminal_precedence(
+    prepared: _QuotaDecisionPreparation,
+) -> _QuotaDecisionRoute:
+    route = _resolve_quota_should_run_route(prepared)
+    apply_terminal_settlement_route_precedence(
+        route,
+        terminal_phase=prepared.receipt_bound_terminal_phase,
+    )
+    return route
 
 
 def _apply_selected_todo_guards(
@@ -101,7 +113,7 @@ def _apply_selected_todo_guards(
         prepared.reason = str(
             boundary_projection_repair.get("reason") or prepared.reason
         )
-    return _resolve_quota_should_run_route(prepared)
+    return _resolve_quota_route_with_terminal_precedence(prepared)
 
 
 def build_quota_paused_should_run_payload(
@@ -226,6 +238,7 @@ def build_quota_should_run(
     operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
     receipt_bound_todo_id: str | None = None,
     receipt_bound_monitor_phase: ReceiptBoundMonitorPhase | None = None,
+    receipt_bound_terminal_phase: ReceiptBoundTerminalPhase | None = None,
     receipt_bound_replan_obligation_id: str | None = None,
     turn_instance_id: str | None = None,
 ) -> dict[str, Any]:
@@ -290,9 +303,10 @@ def build_quota_should_run(
             health_items=health_items,
             receipt_bound_todo_id=receipt_bound_todo_id,
             receipt_bound_monitor_phase=receipt_bound_monitor_phase,
+            receipt_bound_terminal_phase=receipt_bound_terminal_phase,
             receipt_bound_replan_obligation_id=receipt_bound_replan_obligation_id,
         )
-        route = _resolve_quota_should_run_route(prepared)
+        route = _resolve_quota_route_with_terminal_precedence(prepared)
         route = _apply_selected_todo_guards(prepared, route)
         return _build_quota_should_run_payload(
             prepared,

--- a/loopx/control_plane/quota/should_run_packet.py
+++ b/loopx/control_plane/quota/should_run_packet.py
@@ -113,6 +113,10 @@ from ..work_items.work_lane import (
 )
 
 from .should_run_prepare import _QuotaDecisionPreparation
+from .settlement_precedence import (
+    apply_terminal_heartbeat_settlement_precedence,
+    clear_quota_action_projections,
+)
 
 
 def _compact_autonomous_candidate_context(
@@ -406,34 +410,7 @@ def _apply_agent_monitor_only_precedence(
     frontier = payload.get("goal_frontier_projection")
     if isinstance(frontier, dict):
         frontier.pop("vision_continuation_audit", None)
-    for key in (
-        "agent_command",
-        "action_portfolio",
-        "agent_lane_frontier_hint",
-        "agent_lane_next_action",
-        "agent_scope_frontier",
-        "autonomous_replan_decision",
-        "autonomous_replan_obligation",
-        "autonomous_replan_scope",
-        "blocked_priority_fallback",
-        "capability_gate",
-        "capability_monitor_fallback",
-        "external_evidence_observation",
-        "goal_route_hint",
-        "notify_user_on_capability_gate",
-        "notify_user_on_gate",
-        "notify_user_on_open_todo",
-        "open_todo_notification_policy",
-        "open_todo_notify_reason",
-        "required_reads",
-        "replan_action_packet",
-        "scoped_user_gate_fallback",
-        "stall_self_repair",
-        "vision_continuation_audit",
-        "vision_wait_state",
-        "workspace_guard",
-    ):
-        payload.pop(key, None)
+    clear_quota_action_projections(payload)
 
 
 def _attach_truthy_fields(payload: dict[str, Any], **fields: Any) -> None:
@@ -1379,6 +1356,10 @@ def _build_quota_should_run_payload(
         payload,
         monitor_only=prepared.agent_monitor_only,
         inbox_reply_due=prepared.inbox_reply_due,
+    )
+    apply_terminal_heartbeat_settlement_precedence(
+        payload,
+        terminal_phase=prepared.receipt_bound_terminal_phase,
     )
     if isinstance(payload.get("autonomous_replan_obligation"), dict):
         payload["replan_action_packet"] = build_replan_action_packet(

--- a/loopx/control_plane/quota/should_run_prepare.py
+++ b/loopx/control_plane/quota/should_run_prepare.py
@@ -84,7 +84,7 @@ from ..todos.user_gate import (
 from ..work_items.capability_monitor_fallback import (
     build_capability_gate_with_monitor_fallback,
 )
-from ..effect_program import ReceiptBoundMonitorPhase
+from ..effect_program import ReceiptBoundMonitorPhase, ReceiptBoundTerminalPhase
 from ..work_items.primary_action import protocol_action_text as _protocol_action_text
 from ..work_items.work_lane import (
     lark_inbox_reply_due_work_lane_contract,
@@ -114,6 +114,7 @@ class _QuotaDecisionPreparation:
     runtime_available_capabilities: Any
     receipt_bound_todo_id: str | None
     receipt_bound_monitor_phase: ReceiptBoundMonitorPhase | None
+    receipt_bound_terminal_phase: ReceiptBoundTerminalPhase | None
     user_todo_summary: dict[str, Any] | None
     agent_todo_summary: dict[str, Any] | None
     agent_scoped_user_todo_override: dict[str, Any] | None
@@ -409,6 +410,7 @@ def _prepare_quota_should_run_item(
     health_items: list[Any],
     receipt_bound_todo_id: str | None,
     receipt_bound_monitor_phase: ReceiptBoundMonitorPhase | None,
+    receipt_bound_terminal_phase: ReceiptBoundTerminalPhase | None,
     receipt_bound_replan_obligation_id: str | None,
 ) -> _QuotaDecisionPreparation:
     quota = item.get("quota") if isinstance(item.get("quota"), dict) else {}
@@ -735,6 +737,7 @@ def _prepare_quota_should_run_item(
         runtime_available_capabilities=available_capabilities,
         receipt_bound_todo_id=receipt_bound_todo_id,
         receipt_bound_monitor_phase=receipt_bound_monitor_phase,
+        receipt_bound_terminal_phase=receipt_bound_terminal_phase,
         user_todo_summary=user_todo_summary,
         agent_todo_summary=agent_todo_summary,
         agent_scoped_user_todo_override=agent_scoped_user_todo_override,

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -18,7 +18,10 @@ from .control_plane.quota.heartbeat_recommendation import (
 from .control_plane.quota.decision_summary import (
     goal_status_health_ok as _goal_status_health_ok,
 )
-from .control_plane.effect_program import ReceiptBoundMonitorPhase
+from .control_plane.effect_program import (
+    ReceiptBoundMonitorPhase,
+    ReceiptBoundTerminalPhase,
+)
 from .control_plane.quota.error_codes import HeartbeatReceiptIdentityConflictError
 from .control_plane.quota.goal_boundary import registry_goal_by_id as _registry_goal_by_id
 from .control_plane.quota.policy_constants import (
@@ -826,6 +829,7 @@ def build_quota_should_run(
     operator_inbox_urgency_projector: Callable[..., dict[str, Any]] | None = None,
     receipt_bound_todo_id: str | None = None,
     receipt_bound_monitor_phase: ReceiptBoundMonitorPhase | None = None,
+    receipt_bound_terminal_phase: ReceiptBoundTerminalPhase | None = None,
     receipt_bound_replan_obligation_id: str | None = None,
     turn_instance_id: str | None = None,
 ) -> dict[str, Any]:
@@ -845,6 +849,7 @@ def build_quota_should_run(
         operator_inbox_urgency_projector=operator_inbox_urgency_projector,
         receipt_bound_todo_id=receipt_bound_todo_id,
         receipt_bound_monitor_phase=receipt_bound_monitor_phase,
+        receipt_bound_terminal_phase=receipt_bound_terminal_phase,
         receipt_bound_replan_obligation_id=receipt_bound_replan_obligation_id,
         turn_instance_id=turn_instance_id,
     )

--- a/tests/control_plane/test_quota_settlement_cli.py
+++ b/tests/control_plane/test_quota_settlement_cli.py
@@ -1792,6 +1792,116 @@ def test_read_only_settlement_omits_non_causal_delivery_workspace(
     assert len(replayed_completion_events) == 2
 
 
+def test_same_turn_terminal_receipt_replay_preempts_autonomous_replan(
+    tmp_path: Path,
+) -> None:
+    project, runtime, registry_path = _write_fixture(tmp_path)
+    _configure_read_only_todo(project)
+    guard_args = (
+        "quota",
+        "should-run",
+        "--codex-app",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--turn-instance-id",
+        TURN_ID,
+        "--scan-path",
+        str(project),
+    )
+    binding = (
+        "--agent-id",
+        AGENT_ID,
+        "--todo-id",
+        TODO_ID,
+        "--turn-instance-id",
+        TURN_ID,
+    )
+
+    first_rc, first = _run_cli(registry_path, runtime, *guard_args)
+    assert first_rc == 0, first
+    assert first["selected_todo"]["todo_id"] == TODO_ID
+
+    refresh_rc, refresh = _run_cli(
+        registry_path,
+        runtime,
+        "refresh-state",
+        "--goal-id",
+        GOAL_ID,
+        "--classification",
+        "terminal_receipt_replay_characterized",
+        "--delivery-batch-scale",
+        "single_surface",
+        "--delivery-outcome",
+        "outcome_progress",
+        *binding,
+        "--no-global-sync",
+        "--suppress-external-sinks",
+    )
+    assert refresh_rc == 0, refresh
+
+    spend_rc, spend = _run_cli(
+        registry_path,
+        runtime,
+        "quota",
+        "spend-slot",
+        "--goal-id",
+        GOAL_ID,
+        "--slots",
+        "1",
+        "--source",
+        "heartbeat",
+        "--execute",
+        *binding,
+        "--scan-path",
+        str(project),
+    )
+    assert spend_rc == 0, spend
+
+    complete_rc, complete = _run_cli(
+        registry_path,
+        runtime,
+        "todo",
+        "complete",
+        "--goal-id",
+        GOAL_ID,
+        *binding,
+        "--claimed-by",
+        AGENT_ID,
+        "--evidence",
+        "terminal receipt replay characterized",
+        "--no-follow-up",
+    )
+    assert complete_rc == 0, complete
+    assert complete["completion_continuation"] == "no_followup"
+
+    replay_rc, replay = _run_cli(registry_path, runtime, *guard_args)
+
+    assert replay_rc == 0, replay
+    assert replay["decision"] == "skip", replay
+    assert replay["should_run"] is False
+    assert replay["effective_action"] == "heartbeat_settled_skip"
+    assert replay["execution_obligation"]["must_attempt_work"] is False
+    assert replay.get("selected_todo") is None
+    assert replay.get("replan_action_packet") is None
+    assert replay.get("autonomous_replan_obligation") is None
+    assert replay["heartbeat_receipt"]["status"] == "replayed"
+    assert replay["heartbeat_receipt"]["settlement_identity"]["todo_id"] == TODO_ID
+    assert _heartbeat_receipt_count(runtime, TURN_ID) == 1
+    assert _spend_run_count(runtime) == 1
+
+    fresh_turn_args = tuple(
+        "turn-settlement-cli-2" if value == TURN_ID else value
+        for value in guard_args
+    )
+    fresh_rc, fresh = _run_cli(registry_path, runtime, *fresh_turn_args)
+    assert fresh_rc == 0, fresh
+    assert fresh["decision"] == "autonomous_replan_required", fresh
+    assert fresh["should_run"] is True
+    assert fresh["replan_action_packet"]["obligation_id"]
+
+
 def test_legacy_read_only_workspace_mismatch_fails_then_corrects_from_todo_contract(
     tmp_path: Path,
 ) -> None:

--- a/tests/control_plane_ts/effect_program.test.ts
+++ b/tests/control_plane_ts/effect_program.test.ts
@@ -13,6 +13,7 @@ import {
   settlementIdentityFromPlan,
   settlementNextAction,
   receiptBoundMonitorPhase,
+  receiptBoundTerminalPhase,
   settlementPure,
   settlementResultPayload,
 } from "../../loopx/control_plane/effect_program.ts";
@@ -107,6 +108,33 @@ test("receipt-bound monitor settlement phase is derived from typed receipts", ()
     receiptBoundMonitorPhase({
       poll_present: true,
       material_change: true,
+      durable_writeback_present: true,
+      quota_spend_present: true,
+    }),
+    "settled",
+  );
+});
+
+test("receipt-bound terminal settlement requires the full closeout chain", () => {
+  assert.equal(
+    receiptBoundTerminalPhase({
+      terminal_closeout_present: false,
+      durable_writeback_present: true,
+      quota_spend_present: true,
+    }),
+    "open",
+  );
+  assert.equal(
+    receiptBoundTerminalPhase({
+      terminal_closeout_present: true,
+      durable_writeback_present: true,
+      quota_spend_present: false,
+    }),
+    "settlement_pending",
+  );
+  assert.equal(
+    receiptBoundTerminalPhase({
+      terminal_closeout_present: true,
       durable_writeback_present: true,
       quota_spend_present: true,
     }),


### PR DESCRIPTION
## Summary

- derive a typed receipt-bound terminal settlement phase from the existing terminal-closeout, durable-writeback, and quota-spend receipts
- make a fully settled heartbeat authoritative for its exact turn so late Todo/replan projections cannot replace the committed receipt identity
- keep successor selection available on a fresh turn and preserve fail-closed behavior for partial or contradictory receipt chains
- isolate settlement precedence in the quota bounded context and reuse the existing action-projection cleanup seam

## Why

After a Todo completed with terminal no-follow-up, replaying the same heartbeat turn could discover a newly available autonomous replan. Receipt reconciliation then rejected that different identity with `heartbeat_receipt_identity_conflict`. A settled turn should replay quietly and without another spend; any successor belongs to a fresh turn identity.

## Validation

- `npm run typecheck:control-plane`
- `npm run test:control-plane` — 111 passed
- `uv run pytest -q tests/control_plane/test_quota_settlement_cli.py` — 14 passed
- `uv run pytest -q tests/control_plane/test_monitor_followthrough_contract.py` — 20 passed
- changed Python paths: ruff and py_compile passed
- `python3 examples/control_plane/control-plane-maintainability-ratchet-smoke.py`
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` — 17/17 selected checks passed, no manual holds, self-merge allowed
- exact change-quality receipt: `cqr_78a13ea3cb0b9f03b705`

Repository-wide mypy remains baseline-red and was not represented as passing; the changed TypeScript boundary, focused Python behavior, lint, compile, maintainability, and risk-selected canaries are green.

## Future-facing pass

Applied in this PR: terminal settlement precedence moved out of the already-hot packet assembly module. This restores the existing route function to its baseline complexity while keeping TypeScript as the typed phase owner and Python as the adapter/projection boundary.

## Boundary

No scoring, benchmark semantics, permissions, production operation, credentials, private state, raw traces, or generated logs are changed or included.
