### PR TITLE
fix(benchmark): accept namespaced public case ids

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -399,6 +399,10 @@ a loopback socket.
 `benchmark_id`, `case_id`, and a custom policy's `policy_id` are public labels, not
 paths. Path-like values fail closed and are emitted only as `redacted`, so a runner
 cannot move an operator directory into the public receipt through identifier fields.
+`case_id` alone may use the canonical two-segment `namespace/name` form used by
+public benchmark catalogs. Absolute paths, dot segments, backslashes, whitespace,
+and deeper path shapes remain rejected; benchmark and policy ids remain single-token
+labels.
 
 ### Exact-job container binding
 

--- a/loopx/capabilities/benchmark_toolkit/integrity.py
+++ b/loopx/capabilities/benchmark_toolkit/integrity.py
@@ -112,6 +112,9 @@ _SENSITIVE_VALUE_PATTERN = re.compile(r"(?<![A-Za-z0-9_-])sk-[A-Za-z0-9_-]{12,}"
 _PATH_LIKE_LABEL_PATTERN = re.compile(
     r"(?i)^(?:[~/\\]|[a-z]:[\\/])|(?:^|[\\/])\.\.(?:[\\/]|$)|[\\/]"
 )
+_NAMESPACED_PUBLIC_IDENTIFIER_PATTERN = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,79}/[A-Za-z0-9][A-Za-z0-9_.-]{0,119}$"
+)
 _NETWORK_COMMAND_PATTERN = re.compile(r"(?is)\b(?:curl|wget)\b|\bgit\s+clone\b")
 _HTTP_URL_PATTERN = re.compile(r"(?is)https?://[^\s\"'<>]+")
 _GIT_CLONE_COMMAND_PATTERN = re.compile(r"(?is)\bgit\s+clone\b")
@@ -160,11 +163,16 @@ def _public_identifier(
     field: str,
     structural_failures: list[str],
     limit: int,
+    allow_namespaced: bool = False,
 ) -> str:
-    if _path_like_label(value):
+    text = str(value or "").strip()
+    namespaced = allow_namespaced and bool(
+        _NAMESPACED_PUBLIC_IDENTIFIER_PATTERN.fullmatch(text)
+    )
+    if _path_like_label(text) and not namespaced:
         structural_failures.append(f"{field}_path_like")
         return "redacted"
-    return _safe_label(value, limit=limit)
+    return _safe_label(text, limit=limit)
 
 
 def _marker_present(text: str, marker: str) -> bool:
@@ -424,6 +432,7 @@ def build_benchmark_integrity_qualification(
         field="runtime_attestation_case_id",
         structural_failures=structural_failures,
         limit=120,
+        allow_namespaced=True,
     )
     schema_version = str(trajectory.get("schema_version") or "")
     if not schema_version.startswith("ATIF-v1."):

--- a/tests/capabilities/test_benchmark_toolkit.py
+++ b/tests/capabilities/test_benchmark_toolkit.py
@@ -644,6 +644,43 @@ def test_path_like_attestation_labels_fail_closed_without_leaking(
     assert private_path not in json.dumps(receipt, sort_keys=True)
 
 
+def test_namespaced_public_case_id_qualifies_without_weakening_path_gate() -> None:
+    attestation = _attestation()
+    attestation["case_id"] = "public-suite/case-1"
+
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(),
+        runtime_attestation=attestation,
+    )
+
+    assert receipt["integrity_qualified"] is True
+    assert receipt["case_id"] == "public-suite/case-1"
+    assert receipt["blockers"] == []
+
+
+@pytest.mark.parametrize(
+    "case_id",
+    [
+        "public-suite/nested/case-1",
+        "public-suite/../case-1",
+        "public suite/case-1",
+        "public-suite\\case-1",
+    ],
+)
+def test_noncanonical_namespaced_case_id_still_fails_closed(case_id: str) -> None:
+    attestation = _attestation()
+    attestation["case_id"] = case_id
+
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(),
+        runtime_attestation=attestation,
+    )
+
+    assert receipt["integrity_qualified"] is False
+    assert receipt["case_id"] == "redacted"
+    assert "runtime_attestation_case_id_path_like" in receipt["blockers"]
+
+
 def test_path_like_policy_id_fails_closed_without_leaking() -> None:
     private_path = "C:\\Users\\private-user\\policy.json"
     receipt = build_benchmark_integrity_qualification(


### PR DESCRIPTION
## Summary

- accept canonical two-segment `namespace/name` values for runtime-attested benchmark case ids
- keep benchmark ids, policy ids, absolute paths, dot segments, backslashes, whitespace, and deeper path shapes fail-closed
- document and test the public identifier boundary

## Why

Some benchmark catalogs use a public namespaced case identifier. The integrity reducer previously treated every slash as a local path, so a qualified runner attestation could become uncountable even though no private path was present.

## Validation

- `PYTHONPATH=$PWD python3 -m pytest -q tests/capabilities/test_benchmark_toolkit.py tests/capabilities/test_benchmark_experiment_board.py` (102 passed)
- `python3 -m ruff check loopx/capabilities/benchmark_toolkit/integrity.py tests/capabilities/test_benchmark_toolkit.py`
- `python3 -m ruff format --check loopx/capabilities/benchmark_toolkit/integrity.py tests/capabilities/test_benchmark_toolkit.py`
- `python3 examples/cli-benchmark-boundary-command-modularization-smoke.py`
- `python3 examples/benchmark-artifact-path-filter-smoke.py`
- `python3 examples/benchmark-candidate-source-boundary-smoke.py`
- exercised the reducer against one private namespaced-id trajectory; only the compact qualification receipt was inspected and no private evidence is included here

Signed-off-by: Ruiteng Huang <huangrt01@163.com>