### PR TITLE
fix(control-plane): make autonomous replan settlement atomic

### DIFF
--- a/loopx/control_plane/work_items/replan_settlement.ts
+++ b/loopx/control_plane/work_items/replan_settlement.ts
@@ -17,6 +17,50 @@ export const TODO_LIFECYCLE_REENTRY_REQUEST_SCHEMA =
 export const TODO_LIFECYCLE_REENTRY_SCHEMA =
   "todo_lifecycle_settlement_reentry_v0";
 
+interface TodoSettlementBinding extends JsonObject {
+  kind: "todo";
+  id: string;
+  cli_argument: "--todo-id";
+}
+
+interface DirectReplanSettlementBinding extends JsonObject {
+  kind: "autonomous_replan";
+  id: string;
+  cli_argument: "--replan-obligation-id";
+}
+
+interface TodoBoundSemanticObligation extends JsonObject {
+  kind: "autonomous_replan";
+  id: string;
+  settlement_bound: false;
+  discharge: "todo_bound_writeback";
+}
+
+interface DirectSemanticObligation extends JsonObject {
+  kind: "autonomous_replan";
+  id: string;
+  settlement_bound: true;
+  discharge: "direct_settlement";
+}
+
+interface TodoBoundReplanSettlementContract extends JsonObject {
+  schema_version: typeof REPLAN_SETTLEMENT_CONTRACT_SCHEMA;
+  single_binding_required: true;
+  settlement_binding: TodoSettlementBinding;
+  semantic_obligation: TodoBoundSemanticObligation;
+}
+
+interface DirectReplanSettlementContract extends JsonObject {
+  schema_version: typeof REPLAN_SETTLEMENT_CONTRACT_SCHEMA;
+  single_binding_required: true;
+  settlement_binding: DirectReplanSettlementBinding;
+  semantic_obligation: DirectSemanticObligation;
+}
+
+export type ReplanSettlementContract =
+  | TodoBoundReplanSettlementContract
+  | DirectReplanSettlementContract;
+
 function shellArgument(value: string): string {
   if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(value)) return value;
   return `'${value.replaceAll("'", `'"'"'`)}'`;
@@ -116,7 +160,9 @@ export function projectTodoLifecycleSettlementReentry(value: unknown): JsonObjec
   };
 }
 
-export function projectReplanSettlementContract(value: unknown): JsonObject {
+export function projectReplanSettlementContract(
+  value: unknown,
+): ReplanSettlementContract {
   const request = requireJsonObject(value, "work_item.replan_settlement params");
   if (request.schema_version !== REPLAN_SETTLEMENT_REQUEST_SCHEMA) {
     throw new Error("Replan settlement request schema mismatch");
@@ -129,29 +175,37 @@ export function projectReplanSettlementContract(value: unknown): JsonObject {
     request.semantic_replan_obligation_id,
     "semantic_replan_obligation_id",
   );
-  const semanticObligationSettlementBound = selectedTodoId === null;
-  const settlementBindingKind = semanticObligationSettlementBound
-    ? "autonomous_replan"
-    : "todo";
-  const settlementBindingId = selectedTodoId ?? semanticObligationId;
+  if (selectedTodoId !== null) {
+    return {
+      schema_version: REPLAN_SETTLEMENT_CONTRACT_SCHEMA,
+      single_binding_required: true,
+      settlement_binding: {
+        kind: "todo",
+        id: selectedTodoId,
+        cli_argument: "--todo-id",
+      },
+      semantic_obligation: {
+        kind: "autonomous_replan",
+        id: semanticObligationId,
+        settlement_bound: false,
+        discharge: "todo_bound_writeback",
+      },
+    };
+  }
 
   return {
     schema_version: REPLAN_SETTLEMENT_CONTRACT_SCHEMA,
     single_binding_required: true,
     settlement_binding: {
-      kind: settlementBindingKind,
-      id: settlementBindingId,
-      cli_argument: semanticObligationSettlementBound
-        ? "--replan-obligation-id"
-        : "--todo-id",
+      kind: "autonomous_replan",
+      id: semanticObligationId,
+      cli_argument: "--replan-obligation-id",
     },
     semantic_obligation: {
       kind: "autonomous_replan",
       id: semanticObligationId,
-      settlement_bound: semanticObligationSettlementBound,
-      discharge: semanticObligationSettlementBound
-        ? "direct_settlement"
-        : "todo_bound_writeback",
+      settlement_bound: true,
+      discharge: "direct_settlement",
     },
   };
 }

--- a/loopx/control_plane/work_items/semantic_replan_writeback.py
+++ b/loopx/control_plane/work_items/semantic_replan_writeback.py
@@ -31,7 +31,6 @@ from .autonomous_replan_obligation import (
     build_autonomous_replan_cli_actions,
     project_todo_lifecycle_settlement_reentry,
 )
-from .delivery_outcome import ACCOUNTABLE_DELIVERY_OUTCOMES
 from .progress_observation import semantic_delta_from_writeback
 from .repair_delta import (
     build_repair_delta_contract,
@@ -376,7 +375,6 @@ def qualify_refresh_replan_writeback(
     agent_id: str,
     dry_run: bool,
     settlement_todo_id: str | None,
-    settlement_bound: bool,
     newest_first_runs: list[dict[str, Any]],
     state_text: str,
     goal_id: str,
@@ -450,11 +448,6 @@ def qualify_refresh_replan_writeback(
         effective_recorded = True
         classification = requested_classification
         delivery_outcome = requested_delivery_outcome
-    if settlement_bound and delivery_outcome not in ACCOUNTABLE_DELIVERY_OUTCOMES:
-        raise ValueError(
-            "turn-scoped refresh-state produced no accountable semantic delta; "
-            "no state or settlement receipt was written"
-        )
     return RefreshReplanQualification(
         repair_delta_contract=repair_delta_contract,
         semantic_delta=semantic_delta,

--- a/loopx/control_plane/work_items/semantic_replan_writeback.py
+++ b/loopx/control_plane/work_items/semantic_replan_writeback.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import shlex
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Any
 
 from ...agent_registry import registered_agent_ids_for_goal
@@ -22,15 +23,34 @@ from ..todos.quota_summary import (
     select_quota_todo_summary,
 )
 from ..todos.succession_warning import todo_succession_gap_items
+from .autonomous_replan_ack import (
+    latest_monitor_replan_frontier_identity,
+    watch_lane_continuation_todo_ids,
+)
 from .autonomous_replan_obligation import (
     build_autonomous_replan_cli_actions,
     project_todo_lifecycle_settlement_reentry,
 )
+from .delivery_outcome import ACCOUNTABLE_DELIVERY_OUTCOMES
 from .progress_observation import semantic_delta_from_writeback
+from .repair_delta import (
+    build_repair_delta_contract,
+    repair_delta_kinds_have_accountable_progress,
+)
 from .work_lane_context import build_work_lane_context_contract
 
 
 REPLAN_WRITEBACK_REJECTION_SCHEMA_VERSION = "replan_writeback_rejection_v0"
+
+
+@dataclass(frozen=True)
+class RefreshReplanQualification:
+    repair_delta_contract: dict[str, Any] | None
+    semantic_delta: dict[str, Any] | None
+    frontier_identity: str | None
+    classification: str
+    delivery_outcome: str | None
+    autonomous_replan_recorded: bool
 
 
 class ReplanWritebackRejected(ValueError):
@@ -343,4 +363,103 @@ def enforce_open_replan_writeback(
         ),
         obligation=obligation,
         semantic_delta=semantic_delta,
+    )
+
+
+def qualify_refresh_replan_writeback(
+    *,
+    autonomous_replan_recorded: bool,
+    requested_delta_kinds: list[str],
+    active_state_next_action_update: dict[str, Any] | None,
+    agent_vision: dict[str, Any] | None,
+    existing_agent_vision: dict[str, Any] | None,
+    agent_id: str,
+    dry_run: bool,
+    settlement_todo_id: str | None,
+    settlement_bound: bool,
+    newest_first_runs: list[dict[str, Any]],
+    state_text: str,
+    goal_id: str,
+    progress_observation: dict[str, Any] | None,
+    registry_goal: dict[str, Any] | None,
+    completion_todo_id: str | None,
+    completion_turn_key: str | None,
+    classification: str,
+    delivery_outcome: str | None,
+) -> RefreshReplanQualification:
+    """Qualify one refresh's replan delta and accountable settlement outcome."""
+
+    requested_classification = classification
+    requested_delivery_outcome = delivery_outcome
+    repair_delta_contract = None
+    frontier_identity = None
+    effective_recorded = bool(autonomous_replan_recorded)
+    if autonomous_replan_recorded:
+        repair_delta_contract = build_repair_delta_contract(
+            requested_delta_kinds=requested_delta_kinds,
+            active_state_next_action_update=active_state_next_action_update,
+            agent_vision=agent_vision,
+            existing_agent_vision=existing_agent_vision,
+            agent_todo_summary=parse_active_state_todos(
+                state_text, item_limit=None
+            ).get("agent_todos"),
+            agent_id=agent_id or None,
+            dry_run=dry_run,
+            selected_todo_id=settlement_todo_id,
+            newest_first_runs=newest_first_runs,
+        )
+        validated_delta_kinds = list(repair_delta_contract.get("delta_kinds") or [])
+        if not repair_delta_contract["delta_present"]:
+            normalized = str(classification or "").strip().lower()
+            classification = (
+                "repair_noop"
+                if "repair" in normalized and "replan" not in normalized
+                else "replan_noop"
+            )
+            effective_recorded = False
+            if delivery_outcome in {"outcome_progress", "primary_goal_outcome"}:
+                delivery_outcome = "outcome_gap"
+        elif (
+            delivery_outcome in {"outcome_progress", "primary_goal_outcome"}
+            and not repair_delta_kinds_have_accountable_progress(
+                validated_delta_kinds
+            )
+        ):
+            delivery_outcome = "outcome_gap"
+        if effective_recorded and agent_id:
+            frontier_identity = latest_monitor_replan_frontier_identity(
+                newest_first_runs,
+                agent_id=agent_id,
+                watch_todo_ids=watch_lane_continuation_todo_ids(
+                    repair_delta_contract
+                ),
+            )
+
+    semantic_delta = enforce_open_replan_writeback(
+        newest_first_runs=newest_first_runs,
+        state_text=state_text,
+        agent_id=agent_id,
+        goal_id=goal_id,
+        progress_observation=progress_observation,
+        registry_goal=registry_goal,
+        agent_vision=agent_vision,
+        completion_todo_id=completion_todo_id,
+        completion_turn_key=completion_turn_key,
+    )
+    if semantic_delta:
+        effective_recorded = True
+        classification = requested_classification
+        delivery_outcome = requested_delivery_outcome
+    if settlement_bound and delivery_outcome not in ACCOUNTABLE_DELIVERY_OUTCOMES:
+        raise ValueError(
+            "turn-scoped refresh-state produced no accountable semantic delta; "
+            "no state or settlement receipt was written"
+        )
+    return RefreshReplanQualification(
+        repair_delta_contract=repair_delta_contract,
+        semantic_delta=semantic_delta,
+        frontier_identity=frontier_identity,
+        classification=classification,
+        delivery_outcome=delivery_outcome,
+        autonomous_replan_recorded=effective_recorded,
     )

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -1144,7 +1144,6 @@ def refresh_state_run(
         agent_id=normalized_agent_id,
         dry_run=dry_run,
         settlement_todo_id=(settlement_identity.todo_id if settlement_identity else None),
-        settlement_bound=settlement_identity is not None,
         newest_first_runs=newest_first_runs,
         state_text=state_text,
         goal_id=safe_goal_id,

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -1151,6 +1151,7 @@ def refresh_state_run(
     repair_delta_contract: dict[str, Any] | None = None
     validated_repair_delta_kinds: list[str] = []
     requested_classification = classification
+    requested_delivery_outcome = normalized_delivery_outcome
     effective_autonomous_replan_recorded = bool(autonomous_replan_recorded)
     if autonomous_replan_recorded:
         repair_delta_contract = build_repair_delta_contract(
@@ -1204,6 +1205,21 @@ def refresh_state_run(
     )
     if replan_semantic_delta:
         effective_autonomous_replan_recorded = True
+        # The semantic gate is authoritative for an open replan obligation.
+        # A repair-delta label may fail to describe the state change while the
+        # same writeback still carries a fresh accepted typed observation. In
+        # that case this is not a noop: preserve the caller's accountable
+        # settlement outcome so the durable run and receipt remain one chain.
+        classification = requested_classification
+        normalized_delivery_outcome = requested_delivery_outcome
+    if (
+        settlement_identity is not None
+        and normalized_delivery_outcome not in ACCOUNTABLE_DELIVERY_OUTCOMES
+    ):
+        raise ValueError(
+            "turn-scoped refresh-state produced no accountable semantic delta; "
+            "no state or settlement receipt was written"
+        )
     vision_checkpoint = build_vision_checkpoint(
         agent_id=normalized_agent_id or None,
         agent_vision=agent_vision,

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -31,19 +31,13 @@ from .control_plane.quota.settlement import (
 from .control_plane.work_items.repair_delta import (
     REPAIR_DELTA_CONTRACT_SCHEMA_VERSION as REPAIR_DELTA_CONTRACT_SCHEMA_VERSION,
     REPAIR_DELTA_KIND_CHOICES as REPAIR_DELTA_KIND_CHOICES,
-    build_repair_delta_contract,
     normalize_repair_delta_kinds,
-    repair_delta_kinds_have_accountable_progress,
-)
-from .control_plane.work_items.autonomous_replan_ack import (
-    latest_monitor_replan_frontier_identity,
-    watch_lane_continuation_todo_ids,
 )
 from .control_plane.work_items.progress_observation import (
     normalize_progress_observation,
 )
 from .control_plane.work_items.semantic_replan_writeback import (
-    enforce_open_replan_writeback,
+    qualify_refresh_replan_writeback,
 )
 from .control_plane.runtime.shared_runtime_refresh_projection import (
     build_shared_runtime_projection,
@@ -84,7 +78,6 @@ from .control_plane.todos.contract import (
     normalize_todo_claimed_by,
     normalize_todo_replan_obligation_id,
 )
-from .control_plane.todos.active_state_todo_parser import parse_active_state_todos
 from .control_plane.todos.completion_validation_accountability import (
     require_accountable_completion_validation,
 )
@@ -230,13 +223,6 @@ def normalize_progress_scope(value: str | None) -> str:
             "--progress-scope must be one of: " + ", ".join(PROGRESS_SCOPE_CHOICES)
         )
     return normalized
-
-
-def _noop_classification_for(classification: str) -> str:
-    normalized = str(classification or "").strip().lower()
-    if "repair" in normalized and "replan" not in normalized:
-        return "repair_noop"
-    return "replan_noop"
 
 
 def next_action_section_bounds(lines: list[str]) -> tuple[int, int] | None:
@@ -1148,78 +1134,35 @@ def refresh_state_run(
     else:
         action, recommended_action_source = derive_recommended_action_with_source(state_text)
     validate_local_control_text("recommended_action", action)
-    repair_delta_contract: dict[str, Any] | None = None
-    validated_repair_delta_kinds: list[str] = []
     requested_classification = classification
-    requested_delivery_outcome = normalized_delivery_outcome
-    effective_autonomous_replan_recorded = bool(autonomous_replan_recorded)
-    if autonomous_replan_recorded:
-        repair_delta_contract = build_repair_delta_contract(
-            requested_delta_kinds=normalized_repair_delta_kinds,
-            active_state_next_action_update=active_state_next_action_update,
-            agent_vision=agent_vision,
-            existing_agent_vision=existing_agent_vision,
-            agent_todo_summary=parse_active_state_todos(
-                state_text, item_limit=None
-            ).get("agent_todos"),
-            agent_id=normalized_agent_id or None,
-            dry_run=dry_run,
-            selected_todo_id=(settlement_identity.todo_id if settlement_identity else None),
-            newest_first_runs=newest_first_runs,
-        )
-        validated_repair_delta_kinds = list(
-            repair_delta_contract.get("delta_kinds") or []
-        )
-        if not repair_delta_contract["delta_present"]:
-            classification = _noop_classification_for(classification)
-            effective_autonomous_replan_recorded = False
-            if normalized_delivery_outcome in {"outcome_progress", "primary_goal_outcome"}:
-                normalized_delivery_outcome = "outcome_gap"
-        elif (
-            normalized_delivery_outcome in {"outcome_progress", "primary_goal_outcome"}
-            and not repair_delta_kinds_have_accountable_progress(
-                validated_repair_delta_kinds
-            )
-        ):
-            normalized_delivery_outcome = "outcome_gap"
-        if effective_autonomous_replan_recorded and normalized_agent_id:
-            autonomous_replan_frontier_identity = (
-                latest_monitor_replan_frontier_identity(
-                    newest_first_runs,
-                    agent_id=normalized_agent_id,
-                    watch_todo_ids=watch_lane_continuation_todo_ids(
-                        repair_delta_contract
-                    ),
-                )
-            )
-    replan_semantic_delta = enforce_open_replan_writeback(
+    replan_qualification = qualify_refresh_replan_writeback(
+        autonomous_replan_recorded=autonomous_replan_recorded,
+        requested_delta_kinds=normalized_repair_delta_kinds,
+        active_state_next_action_update=active_state_next_action_update,
+        agent_vision=agent_vision,
+        existing_agent_vision=existing_agent_vision,
+        agent_id=normalized_agent_id,
+        dry_run=dry_run,
+        settlement_todo_id=(settlement_identity.todo_id if settlement_identity else None),
+        settlement_bound=settlement_identity is not None,
         newest_first_runs=newest_first_runs,
         state_text=state_text,
-        agent_id=normalized_agent_id,
         goal_id=safe_goal_id,
         progress_observation=normalized_progress_observation,
         registry_goal=registry_goal,
-        agent_vision=agent_vision,
         completion_todo_id=completion_todo_id,
         completion_turn_key=completion_turn_key,
+        classification=classification,
+        delivery_outcome=normalized_delivery_outcome,
     )
-    if replan_semantic_delta:
-        effective_autonomous_replan_recorded = True
-        # The semantic gate is authoritative for an open replan obligation.
-        # A repair-delta label may fail to describe the state change while the
-        # same writeback still carries a fresh accepted typed observation. In
-        # that case this is not a noop: preserve the caller's accountable
-        # settlement outcome so the durable run and receipt remain one chain.
-        classification = requested_classification
-        normalized_delivery_outcome = requested_delivery_outcome
-    if (
-        settlement_identity is not None
-        and normalized_delivery_outcome not in ACCOUNTABLE_DELIVERY_OUTCOMES
-    ):
-        raise ValueError(
-            "turn-scoped refresh-state produced no accountable semantic delta; "
-            "no state or settlement receipt was written"
-        )
+    repair_delta_contract = replan_qualification.repair_delta_contract
+    replan_semantic_delta = replan_qualification.semantic_delta
+    autonomous_replan_frontier_identity = replan_qualification.frontier_identity
+    classification = replan_qualification.classification
+    normalized_delivery_outcome = replan_qualification.delivery_outcome
+    effective_autonomous_replan_recorded = (
+        replan_qualification.autonomous_replan_recorded
+    )
     vision_checkpoint = build_vision_checkpoint(
         agent_id=normalized_agent_id or None,
         agent_vision=agent_vision,

--- a/tests/control_plane/test_quota_settlement_cli.py
+++ b/tests/control_plane/test_quota_settlement_cli.py
@@ -1299,8 +1299,11 @@ def test_autonomous_replan_semantic_delta_keeps_accountable_receipt_chain(
     assert obligation_id not in json.dumps(next_guard, sort_keys=True)
 
 
-def test_turn_scoped_replan_noop_fails_before_durable_write(tmp_path: Path) -> None:
+def test_open_replan_rejects_missing_semantic_delta_before_durable_write(
+    tmp_path: Path,
+) -> None:
     project, runtime, registry_path = _write_fixture(tmp_path)
+    _configure_selected_todo_replan_fixture(project, registry_path)
     _initialize_git_checkout(project)
     turn_instance_id = "turn-autonomous-replan-noop-1"
 
@@ -1320,7 +1323,8 @@ def test_turn_scoped_replan_noop_fails_before_durable_write(tmp_path: Path) -> N
         str(project),
     )
     assert guard_rc == 0, guard
-    assert guard["selected_todo"]["todo_id"] == TODO_ID
+    assert guard["decision"] == "autonomous_replan_required", guard
+    assert guard["selected_todo"]["todo_id"] == SELECTED_REPLAN_TODO_ID
 
     refresh_rc, refresh = _run_cli(
         registry_path,
@@ -1333,7 +1337,7 @@ def test_turn_scoped_replan_noop_fails_before_durable_write(tmp_path: Path) -> N
         "--turn-instance-id",
         turn_instance_id,
         "--todo-id",
-        TODO_ID,
+        SELECTED_REPLAN_TODO_ID,
         "--delivery-workspace-path",
         str(project),
         "--autonomous-replan-recorded",
@@ -1352,7 +1356,7 @@ def test_turn_scoped_replan_noop_fails_before_durable_write(tmp_path: Path) -> N
     assert refresh_rc == 1, refresh
     assert refresh["ok"] is False
     assert refresh["appended"] is False
-    assert "no accountable semantic delta" in refresh["error"]
+    assert "requires a typed semantic delta" in refresh["error"]
     assert _classification_count(runtime, "validated_progress") == 0
     assert _classification_count(runtime, "replan_noop") == 0
 

--- a/tests/control_plane/test_quota_settlement_cli.py
+++ b/tests/control_plane/test_quota_settlement_cli.py
@@ -1168,6 +1168,195 @@ def test_todo_bound_autonomous_replan_uses_one_binding_for_refresh_and_spend(
     assert _spend_run_count(runtime) == 1
 
 
+def test_autonomous_replan_semantic_delta_keeps_accountable_receipt_chain(
+    tmp_path: Path,
+) -> None:
+    """Regression for #3528's real Todo-bound replan path.
+
+    A stale repair-delta label does not itself prove a successor, but a fresh
+    typed progress observation can still satisfy the open obligation. The
+    accepted semantic ACK must remain in the accountable refresh/receipt chain
+    instead of being mislabeled as a noop after it discharges the obligation.
+    """
+
+    project, runtime, registry_path = _write_fixture(tmp_path)
+    _configure_selected_todo_replan_fixture(project, registry_path)
+    _initialize_git_checkout(project)
+    turn_instance_id = "turn-autonomous-replan-semantic-1"
+
+    guard_rc, guard = _run_cli(
+        registry_path,
+        runtime,
+        "quota",
+        "should-run",
+        "--codex-app",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--turn-instance-id",
+        turn_instance_id,
+        "--scan-path",
+        str(project),
+    )
+    assert guard_rc == 0, guard
+    assert guard["decision"] == "autonomous_replan_required", guard
+    assert guard["selected_todo"]["todo_id"] == SELECTED_REPLAN_TODO_ID
+    obligation_id = guard["replan_action_packet"]["obligation_id"]
+
+    refresh_args = (
+        "refresh-state",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--turn-instance-id",
+        turn_instance_id,
+        "--todo-id",
+        SELECTED_REPLAN_TODO_ID,
+        "--delivery-workspace-path",
+        str(project),
+        "--autonomous-replan-recorded",
+        "--repair-delta-kind",
+        "successor_or_supersede",
+        "--delivery-outcome",
+        "outcome_progress",
+        "--classification",
+        "validated_progress",
+        "--progress-result-class",
+        "advanced",
+        "--progress-surface-id",
+        "surface:periodic-review",
+        "--progress-hypothesis-id",
+        "hypothesis:periodic-review",
+        "--progress-probe-kind",
+        "probe:periodic-review",
+        "--progress-evidence-id",
+        "evidence:periodic-review",
+    )
+    mismatched_args = list(refresh_args)
+    todo_flag_index = mismatched_args.index("--todo-id")
+    mismatched_args[todo_flag_index : todo_flag_index + 2] = [
+        "--replan-obligation-id",
+        obligation_id,
+    ]
+    mismatch_rc, mismatch = _run_cli(
+        registry_path,
+        runtime,
+        *mismatched_args,
+    )
+    assert mismatch_rc == 1, mismatch
+    assert mismatch["ok"] is False
+    assert mismatch["appended"] is False
+    assert "settlement binding does not match" in mismatch["error"]
+
+    refresh_rc, refresh = _run_cli(
+        registry_path,
+        runtime,
+        *refresh_args,
+    )
+
+    assert refresh_rc == 0, refresh.get("error") or refresh
+    assert refresh["ok"] is True
+    assert refresh["appended"] is True
+    assert refresh["classification"] == "validated_progress"
+    assert refresh["delivery_outcome"] == "outcome_progress"
+    assert refresh["autonomous_replan_recorded"] is True
+    assert refresh["autonomous_replan_ack"]["semantic_delta"]["accepted"] is True
+    assert refresh["settlement_result"]["ok"] is True
+    assert [
+        receipt["step_kind"] for receipt in refresh["settlement_result"]["receipts"]
+    ] == ["validation", "durable_writeback"]
+
+    replay_rc, replay = _run_cli(
+        registry_path,
+        runtime,
+        *refresh_args,
+    )
+    assert replay_rc == 0, replay
+    assert replay["idempotent_replay"] is True
+    assert replay["appended"] is False
+    assert _classification_count(runtime, "validated_progress") == 1
+
+    next_guard_rc, next_guard = _run_cli(
+        registry_path,
+        runtime,
+        "quota",
+        "should-run",
+        "--codex-app",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--turn-instance-id",
+        "turn-after-autonomous-replan-semantic-1",
+        "--scan-path",
+        str(project),
+    )
+    assert next_guard_rc == 0, next_guard
+    assert next_guard.get("autonomous_replan_obligation") is None
+    assert next_guard.get("decision") != "autonomous_replan_required"
+    assert obligation_id not in json.dumps(next_guard, sort_keys=True)
+
+
+def test_turn_scoped_replan_noop_fails_before_durable_write(tmp_path: Path) -> None:
+    project, runtime, registry_path = _write_fixture(tmp_path)
+    _initialize_git_checkout(project)
+    turn_instance_id = "turn-autonomous-replan-noop-1"
+
+    guard_rc, guard = _run_cli(
+        registry_path,
+        runtime,
+        "quota",
+        "should-run",
+        "--codex-app",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--turn-instance-id",
+        turn_instance_id,
+        "--scan-path",
+        str(project),
+    )
+    assert guard_rc == 0, guard
+    assert guard["selected_todo"]["todo_id"] == TODO_ID
+
+    refresh_rc, refresh = _run_cli(
+        registry_path,
+        runtime,
+        "refresh-state",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--turn-instance-id",
+        turn_instance_id,
+        "--todo-id",
+        TODO_ID,
+        "--delivery-workspace-path",
+        str(project),
+        "--autonomous-replan-recorded",
+        "--repair-delta-kind",
+        "successor_or_supersede",
+        "--delivery-outcome",
+        "outcome_progress",
+        "--classification",
+        "validated_progress",
+        "--progress-result-class",
+        "advanced",
+        "--progress-evidence-id",
+        "evidence:periodic-review",
+    )
+
+    assert refresh_rc == 1, refresh
+    assert refresh["ok"] is False
+    assert refresh["appended"] is False
+    assert "no accountable semantic delta" in refresh["error"]
+    assert _classification_count(runtime, "validated_progress") == 0
+    assert _classification_count(runtime, "replan_noop") == 0
+
+
 def test_runtime_capability_reentry_preserves_receipt_bound_todo_and_rejects_explicit_conflict(
     tmp_path: Path,
 ) -> None:

--- a/tests/control_plane/test_refresh_state_replan_gate.py
+++ b/tests/control_plane/test_refresh_state_replan_gate.py
@@ -16,13 +16,11 @@ from loopx.control_plane.status.autonomous_replan_projection import (
 from loopx.control_plane.work_items.semantic_replan_writeback import (
     ReplanWritebackRejected,
     _obligation_was_created_by_current_completion,
+    enforce_open_replan_writeback,
     qualify_replan_writeback,
     project_replan_writeback_rejection,
 )
-from loopx.state_refresh import (
-    enforce_open_replan_writeback,
-    refresh_state_run,
-)
+from loopx.state_refresh import refresh_state_run
 from loopx.todos import add_goal_todo
 
 GOAL_ID = "replan-gate-fixture"

--- a/tests/control_plane_ts/replan_settlement.test.ts
+++ b/tests/control_plane_ts/replan_settlement.test.ts
@@ -42,6 +42,12 @@ test("Todo-bound replan keeps semantic obligation outside settlement identity", 
 
 test("Todo-less replan binds the semantic obligation directly", () => {
   const contract = projectReplanSettlementContract(request());
+  assert.equal(contract.settlement_binding.kind, "autonomous_replan");
+  // The binding kind is the discriminant: after this check TypeScript knows
+  // the matching settlement flag and discharge semantics without casts.
+  assert.equal(contract.settlement_binding.cli_argument, "--replan-obligation-id");
+  assert.equal(contract.semantic_obligation.settlement_bound, true);
+  assert.equal(contract.semantic_obligation.discharge, "direct_settlement");
   assert.deepEqual(contract.settlement_binding, {
     kind: "autonomous_replan",
     id: "replan-0000000000000001",


### PR DESCRIPTION
## Summary

Fixes #3528's non-atomic autonomous-replan settlement and adds a bounded
TypeScript refactor at the existing replan-settlement ownership boundary.

The extension-doctor half of the original PR was superseded by #3556 while
this review was in progress. After rebasing onto current `main`, all overlapping
extension code and tests were dropped from this PR rather than retaining a
duplicate implementation.

## Root cause and fix

`build_repair_delta_contract` could downgrade a claimed repair delta to
`replan_noop` / `outcome_gap`. Later in the same refresh, a fresh typed progress
or vision observation could still satisfy and discharge the open replan
obligation. The old flow did not reconcile those decisions, so it appended a
semantic ACK without an accountable outcome and then failed receipt readback.

`qualify_refresh_replan_writeback` now owns that transaction-level decision:

- repair-delta validation may provisionally downgrade a claim;
- an accepted typed semantic delta is authoritative and restores the caller's
  accountable classification/outcome before persistence;
- an open obligation without an accepted semantic delta fails before a state
  or receipt write;
- Todo-bound settlement keeps `--todo-id` as its only receipt binding while the
  autonomous replan id remains the semantic obligation being discharged;
- no new gate is applied when there is no open obligation, preserving the
  built-in Turn `replan_required` contract;
- exact replay remains idempotent and mismatched direct binding fails closed.

Thus successful discharge and its accountable receipt are one chain;
otherwise the open obligation remains intact.

## Bounded TypeScript refactor

The original unused delivery-outcome TS leaf was removed because it duplicated
Python authority without a production consumer. Instead, the already TS-owned
`replan_settlement.ts` projection now returns a discriminated union. Todo-bound
and direct-replan bindings carry their matching CLI argument,
`settlement_bound`, and discharge mode as one type-level pair. Projected JSON
and cross-runtime calls are unchanged.

The Python orchestration was extracted from the 1,489-line `state_refresh.py`
hot module into the semantic-replan owner; the hot module is now below its
maintainability baseline without adding an exception.

## Validation

- quota settlement suite: 16 passed
- replan writeback gate suite: 31 passed
- TS typecheck + full control-plane TS suite: 117 passed
- premerge canary before the final scope narrowing: 17/17 passed, no warnings
  or manual holds
- final-head focused readback after rebase: #3528 success/failure cases 2
  passed; built-in Turn `replan_required` regression 1 passed; TS projection 7
  passed; ruff, diff hygiene, and maintainability ratchet passed
- public/private scan: clean

Fixes #3528.
