### PR TITLE
[Bug] Make refresh-state settlement receipt writeback atomic

### DIFF
--- a/loopx/cli_commands/project_lifecycle.py
+++ b/loopx/cli_commands/project_lifecycle.py
@@ -16,6 +16,8 @@ from ..control_plane.goals.goal_vision_policy import (
     GOAL_VISION_ADVANCEMENT_POLICY_CHOICES,
 )
 from ..control_plane.quota.settlement import (
+    SettlementIdentity,
+    find_settlement_step_event,
     require_settlement_writeback,
     resolve_heartbeat_settlement_identity,
     settlement_result_payload,
@@ -78,6 +80,82 @@ PROJECT_LIFECYCLE_COMMANDS = {
     "reward",
     "operator-gate",
 }
+
+
+def _append_refresh_state_receipt(
+    payload: dict[str, object],
+    *,
+    args: argparse.Namespace,
+    registry_path: Path,
+    append_cli_rollout_event: AppendCliRolloutEvent,
+    status: str,
+    settlement_identity: SettlementIdentity | None = None,
+) -> None:
+    append_cli_rollout_event(
+        payload,
+        registry_path=registry_path,
+        runtime_root_arg=args.runtime_root,
+        event_kind="refresh_state",
+        agent_id=args.agent_id,
+        todo_id=getattr(args, "todo_id", None),
+        run_id=getattr(args, "turn_instance_id", None),
+        status=status,
+        summary=(
+            "refresh-state appended compact control-plane state with "
+            f"classification={payload.get('classification')}"
+        ),
+        details={
+            "command": "refresh-state",
+            "progress_scope": payload.get("progress_scope") or "",
+            "agent_lane": payload.get("agent_lane") or "",
+            "autonomous_replan_recorded": bool(
+                payload.get("autonomous_replan_recorded")
+            ),
+            "global_sync_wrote": bool(
+                isinstance(payload.get("global_sync"), dict)
+                and payload["global_sync"].get("wrote")
+            ),
+            "settlement_effect_id": (
+                payload.get("settlement_identity", {}).get("effect_id")
+                if isinstance(payload.get("settlement_identity"), dict)
+                else None
+            ),
+            "replan_obligation_id": getattr(
+                args, "replan_obligation_id", None
+            )
+            or "",
+        },
+        idempotency_fields=(
+            [
+                "goal_id",
+                "event_kind",
+                "agent_id",
+                *(
+                    ["todo_id"]
+                    if getattr(args, "todo_id", None)
+                    else []
+                ),
+                "run_id",
+            ]
+            if getattr(args, "turn_instance_id", None)
+            else None
+        ),
+    )
+    if settlement_identity is None:
+        return
+    if payload.get("rollout_event_log_error"):
+        raise OSError("failed to persist refresh-state settlement receipt")
+    runtime_root = Path(str(payload.get("runtime_root") or "")).expanduser()
+    if find_settlement_step_event(
+        runtime_root,
+        settlement_identity,
+        event_kind="refresh_state",
+    ) is None:
+        raise OSError(
+            "failed to persist a refresh-state receipt matching the original "
+            "settlement identity"
+        )
+
 
 INLINE_VISION_FIELDS = {
     "vision_summary": "vision_summary",
@@ -623,6 +701,20 @@ def handle_project_lifecycle_command(
         agent_vision_packet: dict[str, object] | None = None
         progress_observation: dict[str, object] | None = None
         merge_agent_vision_patch = False
+
+        def precommit_settlement_receipt(
+            precommit_payload: dict[str, object],
+            settlement_identity: SettlementIdentity,
+        ) -> None:
+            _append_refresh_state_receipt(
+                precommit_payload,
+                args=args,
+                registry_path=registry_path,
+                append_cli_rollout_event=append_cli_rollout_event,
+                status="appended",
+                settlement_identity=settlement_identity,
+            )
+
         try:
             inline_agent_vision_packet = _inline_agent_vision_packet(args)
             if args.agent_vision_json and inline_agent_vision_packet:
@@ -684,6 +776,7 @@ def handle_project_lifecycle_command(
                 merge_agent_vision_patch=merge_agent_vision_patch,
                 vision_unchanged_reason=args.vision_unchanged_reason,
                 progress_observation=progress_observation,
+                settlement_receipt_precommit=precommit_settlement_receipt,
                 dry_run=bool(args.dry_run),
                 sync_global=not bool(args.no_global_sync),
             )
@@ -734,58 +827,15 @@ def handle_project_lifecycle_command(
             )
         )
         if material_refresh_ready or settlement_receipt_repair:
-            append_cli_rollout_event(
+            _append_refresh_state_receipt(
                 payload,
+                args=args,
                 registry_path=registry_path,
-                runtime_root_arg=args.runtime_root,
-                event_kind="refresh_state",
-                agent_id=args.agent_id,
-                todo_id=getattr(args, "todo_id", None),
-                run_id=getattr(args, "turn_instance_id", None),
+                append_cli_rollout_event=append_cli_rollout_event,
                 status=(
                     "receipt_repaired"
                     if settlement_receipt_repair
                     else "appended"
-                ),
-                summary=(
-                    "refresh-state appended compact control-plane state with "
-                    f"classification={payload.get('classification')}"
-                ),
-                details={
-                    "command": "refresh-state",
-                    "progress_scope": payload.get("progress_scope") or "",
-                    "agent_lane": payload.get("agent_lane") or "",
-                    "autonomous_replan_recorded": bool(
-                        payload.get("autonomous_replan_recorded")
-                    ),
-                    "global_sync_wrote": bool(
-                        isinstance(payload.get("global_sync"), dict)
-                        and payload["global_sync"].get("wrote")
-                    ),
-                    "settlement_effect_id": (
-                        payload.get("settlement_identity", {}).get("effect_id")
-                        if isinstance(payload.get("settlement_identity"), dict)
-                        else None
-                    ),
-                    "replan_obligation_id": getattr(
-                        args, "replan_obligation_id", None
-                    )
-                    or "",
-                },
-                idempotency_fields=(
-                    [
-                        "goal_id",
-                        "event_kind",
-                        "agent_id",
-                        *(
-                            ["todo_id"]
-                            if getattr(args, "todo_id", None)
-                            else []
-                        ),
-                        "run_id",
-                    ]
-                    if getattr(args, "turn_instance_id", None)
-                    else None
                 ),
             )
             if getattr(args, "turn_instance_id", None) and (

--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -352,6 +352,30 @@ def handle_turn_command(
                 if event_payload.get("rollout_event_log_error"):
                     raise OSError(f"failed to persist {event_kind} settlement receipt")
 
+            def precommit_refresh_receipt(
+                refresh_payload: dict[str, Any],
+                identity: SettlementIdentity,
+            ) -> None:
+                if identity.effect_id != settlement_identity.effect_id:
+                    raise ValueError(
+                        "refresh-state receipt identity does not match Turn identity"
+                    )
+                append_settlement_event(
+                    refresh_payload,
+                    event_kind="refresh_state",
+                    status="appended",
+                    details={"command": "turn run-once"},
+                )
+                if find_settlement_step_event(
+                    runtime_root,
+                    identity,
+                    event_kind="refresh_state",
+                ) is None:
+                    raise OSError(
+                        "failed to persist a refresh-state receipt matching the "
+                        "original settlement identity"
+                    )
+
             writeback_contract = (
                 envelope.get("writeback")
                 if isinstance(envelope.get("writeback"), dict)
@@ -420,6 +444,7 @@ def handle_turn_command(
                     ),
                     completion_todo_id=completion_todo_id,
                     completion_turn_key=completion_turn_key,
+                    settlement_receipt_precommit=precommit_refresh_receipt,
                     dry_run=False,
                     sync_global=not bool(args.no_global_sync),
                 )

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -878,6 +879,9 @@ def refresh_state_run(
     progress_observation: dict[str, Any] | None = None,
     completion_todo_id: str | None = None,
     completion_turn_key: str | None = None,
+    settlement_receipt_precommit: (
+        Callable[[dict[str, Any], SettlementIdentity], None] | None
+    ) = None,
     dry_run: bool,
     sync_global: bool = True,
 ) -> dict[str, Any]:
@@ -1255,19 +1259,6 @@ def refresh_state_run(
             delivery_workspace["repository_source"] = (
                 "refresh_state.delivery_workspace_path"
             )
-    if (
-        active_state_next_action_update
-        and active_state_next_action_update.get("would_update")
-        and not dry_run
-    ):
-        with exclusive_file_lock(resolved_state_file):
-            current_state_text = resolved_state_file.read_text(encoding="utf-8")
-            if current_state_text != expected_write_state_text:
-                raise ValueError(
-                    "active goal state changed while refresh-state was qualifying "
-                    "its semantic writeback; retry from the current state"
-                )
-            resolved_state_file.write_text(state_text, encoding="utf-8")
     record = build_state_refresh_record(
         goal_id=safe_goal_id,
         state_file=resolved_state_file,
@@ -1347,6 +1338,26 @@ def refresh_state_run(
         dry_run=dry_run,
         autonomous_replan_recorded_requested=bool(autonomous_replan_recorded),
     )
+    if not dry_run and settlement_identity is not None:
+        if settlement_receipt_precommit is None:
+            raise ValueError(
+                "turn-scoped refresh-state requires a durable settlement receipt "
+                "before writeback"
+            )
+        settlement_receipt_precommit(payload, settlement_identity)
+    if (
+        active_state_next_action_update
+        and active_state_next_action_update.get("would_update")
+        and not dry_run
+    ):
+        with exclusive_file_lock(resolved_state_file):
+            current_state_text = resolved_state_file.read_text(encoding="utf-8")
+            if current_state_text != expected_write_state_text:
+                raise ValueError(
+                    "active goal state changed while refresh-state was qualifying "
+                    "its semantic writeback; retry from the current state"
+                )
+            resolved_state_file.write_text(state_text, encoding="utf-8")
     if dry_run:
         expected_write_scopes = ["runtime_history"]
         if active_state_next_action_update and active_state_next_action_update.get("would_update"):

--- a/tests/control_plane/test_quota_settlement_cli.py
+++ b/tests/control_plane/test_quota_settlement_cli.py
@@ -8,6 +8,14 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import pytest
+
+from loopx import cli as loopx_cli
+from loopx.control_plane.status.autonomous_replan_projection import (
+    AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD,
+)
+from loopx.status import autonomous_replan_periodic_review_from_runs
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 GOAL_ID = "settlement-cli-fixture"
 AGENT_ID = "codex-settlement-cli"
@@ -153,6 +161,21 @@ def _heartbeat_receipt_count(runtime: Path, turn_instance_id: str) -> int:
         for line in log_path.read_text(encoding="utf-8").splitlines()
         if (
             (event := json.loads(line)).get("event_kind") == "quota_should_run"
+            and event.get("run_id") == turn_instance_id
+            and event.get("agent_id") == AGENT_ID
+        )
+    )
+
+
+def _refresh_receipt_count(runtime: Path, turn_instance_id: str) -> int:
+    log_path = runtime / "goals" / GOAL_ID / "rollout-event-log.jsonl"
+    if not log_path.exists():
+        return 0
+    return sum(
+        1
+        for line in log_path.read_text(encoding="utf-8").splitlines()
+        if (
+            (event := json.loads(line)).get("event_kind") == "refresh_state"
             and event.get("run_id") == turn_instance_id
             and event.get("agent_id") == AGENT_ID
         )
@@ -1166,6 +1189,231 @@ def test_todo_bound_autonomous_replan_uses_one_binding_for_refresh_and_spend(
         receipt["step_kind"] for receipt in spend["settlement_result"]["receipts"]
     ] == ["validation", "durable_writeback", "quota_spend"]
     assert _spend_run_count(runtime) == 1
+
+
+def test_todo_bound_periodic_replan_writeback_is_receipted_atomically(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    project, runtime, registry_path = _write_fixture(tmp_path)
+    state_path = project / f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_path.write_text(
+        state_path.read_text(encoding="utf-8")
+        .replace("status: active-read-only", "status: active")
+        .replace(
+            "task_class=advancement_task action_kind=validate",
+            (
+                "task_class=advancement_task action_kind=validate "
+                f"claimed_by={AGENT_ID}"
+            ),
+        ),
+        encoding="utf-8",
+    )
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    registry["goals"][0]["status"] = "active"
+    registry_path.write_text(
+        json.dumps(registry, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    runs_dir = runtime / "goals" / GOAL_ID / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    durable_runs = [
+        {
+            "generated_at": f"2026-08-13T00:{index:02d}:00+00:00",
+            "goal_id": GOAL_ID,
+            "agent_id": AGENT_ID,
+            "classification": "source_audit_progress",
+            "progress_scope": "agent_lane",
+            "delivery_batch_scale": "single_surface",
+            "delivery_outcome": "surface_only",
+        }
+        for index in range(AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD)
+    ]
+    (runs_dir / "index.jsonl").write_text(
+        "".join(json.dumps(run) + "\n" for run in durable_runs),
+        encoding="utf-8",
+    )
+    turn_instance_id = "turn-todo-bound-periodic-replan-1"
+
+    guard_rc, guard = _run_cli(
+        registry_path,
+        runtime,
+        "quota",
+        "should-run",
+        "--codex-app",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--turn-instance-id",
+        turn_instance_id,
+        "--scan-path",
+        str(project),
+    )
+
+    assert guard_rc == 0, json.dumps(guard, indent=2)
+    assert guard["decision"] == "autonomous_replan_required", guard
+    assert guard["selected_todo"]["todo_id"] == TODO_ID
+    assert guard["autonomous_replan_obligation"]["triggers"][0]["kind"] == (
+        "periodic_review_due"
+    )
+
+    successor_id = "todo_periodic_review_successor"
+    state_text = state_path.read_text(encoding="utf-8")
+    state_text = state_text.replace("- [ ] [P1]", "- [x] [P1]", 1).replace(
+        (
+            f"todo_id={TODO_ID} status=open task_class=advancement_task "
+            f"action_kind=validate claimed_by={AGENT_ID}"
+        ),
+        (
+            f"todo_id={TODO_ID} status=done task_class=advancement_task "
+            f"action_kind=validate claimed_by={AGENT_ID} "
+            f"successor_todo_ids={successor_id} "
+            "completed_at=2026-08-13T01%3A00%3A00%2B00%3A00"
+        ),
+    )
+    state_path.write_text(
+        state_text
+        + "\n- [ ] [P1] Continue the bounded periodic-review successor.\n"
+        + (
+            "  <!-- loopx:todo "
+            f"todo_id={successor_id} status=open "
+            "task_class=advancement_task action_kind=implement "
+            f"claimed_by={AGENT_ID} -->\n"
+        ),
+        encoding="utf-8",
+    )
+    (project / "periodic-review-evidence.md").write_text(
+        "# Periodic review evidence\n\nValidated the next bounded slice.\n",
+        encoding="utf-8",
+    )
+    _initialize_git_checkout(project)
+    subprocess.run(["git", "add", "-A"], cwd=project, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=LoopX Test",
+            "-c",
+            "user.email=loopx-test@example.invalid",
+            "commit",
+            "--quiet",
+            "-m",
+            "fixture: record periodic review successor",
+        ],
+        cwd=project,
+        check=True,
+    )
+
+    refresh_args = (
+        "refresh-state",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--turn-instance-id",
+        turn_instance_id,
+        "--todo-id",
+        TODO_ID,
+        "--delivery-workspace-path",
+        str(project),
+        "--autonomous-replan-recorded",
+        "--repair-delta-kind",
+        "successor_or_supersede",
+        "--delivery-outcome",
+        "outcome_progress",
+        "--classification",
+        "validated_progress",
+        "--progress-result-class",
+        "advanced",
+        "--progress-surface-id",
+        "surface-periodic-review",
+        "--progress-evidence-id",
+        "evidence-periodic-review",
+        "--no-global-sync",
+        "--suppress-external-sinks",
+    )
+
+    mismatched_args = list(refresh_args)
+    todo_flag_index = mismatched_args.index("--todo-id")
+    mismatched_args[todo_flag_index : todo_flag_index + 2] = [
+        "--replan-obligation-id",
+        guard["replan_action_packet"]["obligation_id"],
+    ]
+    mismatched_rc, mismatched = _run_cli(
+        registry_path,
+        runtime,
+        *mismatched_args,
+    )
+
+    assert mismatched_rc == 1, mismatched
+    assert mismatched["appended"] is False
+    assert "does not match" in mismatched["error"]
+    assert _classification_count(runtime, "validated_progress") == 0
+    assert _refresh_receipt_count(runtime, turn_instance_id) == 0
+
+    monkeypatch.setattr(
+        loopx_cli,
+        "append_cli_rollout_event",
+        lambda payload, **_kwargs: payload,
+    )
+    failed_rc = loopx_cli.main(
+        [
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime),
+            "--format",
+            "json",
+            *refresh_args,
+        ]
+    )
+    failed = json.loads(capsys.readouterr().out)
+
+    assert failed_rc == 1, failed
+    assert failed["ok"] is False
+    assert failed["appended"] is False
+    assert "matching the original settlement identity" in failed["error"]
+    assert _classification_count(runtime, "validated_progress") == 0
+    assert _refresh_receipt_count(runtime, turn_instance_id) == 0
+
+    persisted_runs = [
+        json.loads(line)
+        for line in (runs_dir / "index.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    surviving_obligation = autonomous_replan_periodic_review_from_runs(
+        list(reversed(persisted_runs)),
+        agent_todos=None,
+    )
+    assert surviving_obligation is not None
+    assert surviving_obligation["triggers"][0]["kind"] == "periodic_review_due"
+
+    refresh_rc, refresh = _run_cli(
+        registry_path,
+        runtime,
+        *refresh_args,
+    )
+    replay_rc, replay = _run_cli(
+        registry_path,
+        runtime,
+        *refresh_args,
+    )
+
+    assert refresh_rc == 0, json.dumps(refresh, indent=2)
+    assert refresh["ok"] is True
+    assert refresh["appended"] is True
+    assert refresh["settlement_result"]["ok"] is True
+    assert [
+        receipt["step_kind"] for receipt in refresh["settlement_result"]["receipts"]
+    ] == ["validation", "durable_writeback"]
+    assert replay_rc == 0, replay
+    assert replay["idempotent_replay"] is True
+    assert replay["appended"] is False
+    assert _classification_count(runtime, "validated_progress") == 1
+    assert _refresh_receipt_count(runtime, turn_instance_id) == 1
 
 
 def test_runtime_capability_reentry_preserves_receipt_bound_todo_and_rejects_explicit_conflict(


### PR DESCRIPTION
## Summary

- Require turn-scoped `refresh-state` to persist and read back the exact settlement receipt before Active State, ACK, or run-history writes.
- Apply the same receipt-first boundary to direct CLI refreshes and the Turn driver, while preserving receipt repair and idempotent replay.
- Add an end-to-end periodic-review regression covering receipt persistence failure, mismatched replan binding, obligation preservation, and retry idempotency.

## Issue Or Task

- Closes #3528
- Contributor task ID: N/A

## Validation

- [x] Python compile check for all four changed files
- [ ] `loopx check --scan-root .` (not run; focused control-plane regression set used)
- [x] 136 focused tests passed across settlement CLI, refresh/replan gate, Turn driver, and typed settlement suites

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes outside the receipt-ordering fix)
- [ ] Documentation update
- [x] Test update

## LoopX Area

- [x] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [ ] Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
- [ ] Capability or extension (providers, adapters, skills)
- [ ] Public docs or presentation surface (README, protocols, dashboard)
- [ ] Build, packaging, installer, or CI
- [x] Host or runtime integration

## Technical Direction

- [x] Core control-plane hardening
- [ ] Long-horizon benchmark evidence
- [ ] Operator surface and IM integration
- [ ] Shared Goal Authority and cross-host coordination
- [ ] Architecture and research incubator

- Target base branch: `main`
- Direction tracker or promotion unit: #3528

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).

Bounded future-facing pass: the duplicated refresh receipt projection was centralized in the existing lifecycle owner; no broader control-plane migration was needed.