### PR TITLE
fix(cli): accept doctor subcommand output format

### DIFF
--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -235,7 +235,7 @@ def build_parser() -> LoopXArgumentParser:
 
     register_starter_commands(sub)
 
-    register_doctor_command(sub)
+    register_doctor_command(sub, add_subcommand_format)
 
     register_first_run_report_command(sub)
 

--- a/loopx/cli_commands/doctor.py
+++ b/loopx/cli_commands/doctor.py
@@ -11,13 +11,18 @@ PrintPayload = Callable[
     [dict[str, object], str, Callable[[dict[str, object]], str]],
     None,
 ]
+AddFormat = Callable[[argparse.ArgumentParser], None]
 
 
-def register_doctor_command(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
+def register_doctor_command(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: AddFormat,
+) -> argparse.ArgumentParser:
     parser = subparsers.add_parser(
         "doctor",
         help="Diagnose local CLI installation, PATH, wrapper, and import health.",
     )
+    add_subcommand_format(parser)
     parser.add_argument(
         "--deep",
         action="store_true",
@@ -39,5 +44,6 @@ def handle_doctor_command(args: argparse.Namespace, print_payload: PrintPayload)
         deep=bool(args.deep),
         agent_type=args.agent_type,
     )
-    print_payload(payload, args.format, render_doctor_markdown)
+    output_format = getattr(args, "subcommand_format", None) or args.format
+    print_payload(payload, output_format, render_doctor_markdown)
     return 0 if payload.get("ok") else 1

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from loopx.cli import build_parser, main, output_format, resolve_global_output_format
+from loopx.cli_commands import doctor as doctor_command
 from loopx.cli_commands import todo as todo_command
 from loopx.cli_commands.quota_request import validate_quota_command_request
 from loopx.cli_commands.todo_argument_validation import (
@@ -1101,3 +1102,24 @@ def test_subcommand_format_keeps_precedence_over_resolved_global_default() -> No
     args.format = resolve_global_output_format(args)
 
     assert output_format(args) == "json"
+
+
+def test_doctor_accepts_subcommand_json_format(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        doctor_command,
+        "collect_doctor",
+        lambda *, deep=False, agent_type=None: {
+            "ok": True,
+            "deep": deep,
+            "agent_type": agent_type,
+        },
+    )
+
+    exit_code = main(["doctor", "--format", "json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {"ok": True, "deep": False, "agent_type": None}


### PR DESCRIPTION
## Summary
- allow `loopx doctor --format json` / `markdown`, matching the common subcommand format contract used by status, todo, and other operator commands
- keep the existing global form `loopx --format json doctor` working
- add an end-to-end CLI regression through `main(["doctor", "--format", "json"])`

## Why
During a first-run/deep usage pass, `loopx doctor --format json` failed at argparse even though `doctor` is the primary install and repair diagnostic. That makes the diagnostic surface feel inconsistent with the rest of the CLI and blocks copy-paste automation patterns.

## Validation
- `uv run --extra test pytest tests/test_cli_argument_diagnostics.py -q`
- `uv run --extra test pytest tests/test_cli_argument_diagnostics.py tests/control_plane/test_turn_journal_runtime_readiness.py tests/test_doctor_install_freshness.py tests/test_windows_install.py -q`
- `uv run --extra test ruff check loopx/cli.py loopx/cli_commands/doctor.py tests/test_cli_argument_diagnostics.py`
- `uv run python -m compileall -q loopx/cli.py loopx/cli_commands/doctor.py tests/test_cli_argument_diagnostics.py`
- `npm run test:control-plane`
- `npm run typecheck:control-plane`
- `uv run loopx canary premerge --from-git-diff`
- manual: `uv run loopx doctor --format json` and `uv run loopx --format json doctor`

Known local baseline: `uv run --extra test pytest tests/test_dashboard_command.py -q` still fails 6 existing dashboard launcher assertions on latest main; the failures are unrelated to this CLI format change and reproduce without touching dashboard code.