### PR TITLE
fix(chat): serialize managed turn creation

### DIFF
--- a/loopx/chat_store.py
+++ b/loopx/chat_store.py
@@ -454,43 +454,57 @@ class ChatSessionStore:
         origin: str = "web",
     ) -> tuple[dict[str, Any], bool]:
         client_id = _opaque_id(client_turn_id, field="client_turn_id")
-        existing = self.turn_for_client(session_id, client_id)
-        if existing is not None:
-            return existing, False
-        session = self.load_session(session_id)
-        if session is None:
-            raise KeyError("chat session was not found")
-        active_turn_id = session.get("active_turn_id")
-        if active_turn_id:
-            active = self.load_turn(session_id, str(active_turn_id))
-            if active and active.get("status") in {"queued", "starting", "running", "interrupting"}:
-                raise RuntimeError(str(active_turn_id))
-        now = utc_now()
-        turn_id = uuid.uuid4().hex
-        payload = {
-            "schema_version": CHAT_TURN_SCHEMA_VERSION,
-            "turn_id": turn_id,
-            "session_id": session_id,
-            "client_turn_id": client_id,
-            "status": "queued",
-            "message": str(message),
-            "origin": _opaque_id(origin, field="origin"),
-            "upstream_turn_id": None,
-            "response": None,
-            "error_code": None,
-            "error": None,
-            "created_at": now,
-            "started_at": None,
-            "first_event_at": None,
-            "completed_at": None,
-            "last_activity_at": now,
-            "delta_count": 0,
-            "sse_reconnect_count": 0,
-        }
-        path = self._turn_path(session_id, turn_id)
-        _atomic_write_json(path, payload)
-        os.chmod(path, 0o600)
-        self.update_session(session_id, status="busy", active_turn_id=turn_id, last_activity_at=now)
+        session_path = self._session_path(session_id)
+        with exclusive_file_lock(
+            session_path,
+            agent_id="loopx-chat",
+            operation="create_chat_turn",
+        ):
+            existing = self.turn_for_client(session_id, client_id)
+            if existing is not None:
+                return existing, False
+            session = self.load_session(session_id)
+            if session is None:
+                raise KeyError("chat session was not found")
+            active_turn_id = session.get("active_turn_id")
+            if active_turn_id:
+                active = self.load_turn(session_id, str(active_turn_id))
+                if active and active.get("status") in {"queued", "starting", "running", "interrupting"}:
+                    raise RuntimeError(str(active_turn_id))
+            now = utc_now()
+            turn_id = uuid.uuid4().hex
+            payload = {
+                "schema_version": CHAT_TURN_SCHEMA_VERSION,
+                "turn_id": turn_id,
+                "session_id": session_id,
+                "client_turn_id": client_id,
+                "status": "queued",
+                "message": str(message),
+                "origin": _opaque_id(origin, field="origin"),
+                "upstream_turn_id": None,
+                "response": None,
+                "error_code": None,
+                "error": None,
+                "created_at": now,
+                "started_at": None,
+                "first_event_at": None,
+                "completed_at": None,
+                "last_activity_at": now,
+                "delta_count": 0,
+                "sse_reconnect_count": 0,
+            }
+            path = self._turn_path(session_id, turn_id)
+            _atomic_write_json(path, payload)
+            os.chmod(path, 0o600)
+            session.update(
+                {
+                    "status": "busy",
+                    "active_turn_id": turn_id,
+                    "last_activity_at": now,
+                    "updated_at": utc_now(),
+                }
+            )
+            _atomic_write_json(session_path, session, preserve_mode=True)
         self.append_message(
             session_id,
             role="user",

--- a/tests/test_chat_session_active_turn.py
+++ b/tests/test_chat_session_active_turn.py
@@ -1,6 +1,91 @@
 from pathlib import Path
+import threading
+import time
 
+import loopx.chat_store as chat_store
 from loopx.chat_store import ChatSessionStore
+
+
+def test_concurrent_managed_turn_creation_claims_active_once(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    store = ChatSessionStore(tmp_path)
+    session = store.create_session(
+        goal_id="goal-one",
+        agent_id="codex",
+        executor_endpoint_id="codex",
+        adapter_kind="codex_app_server",
+        upstream_thread_id="thread-one",
+        upstream_mode="chat",
+    )
+    session_id = str(session["session_id"])
+    original_atomic_write = chat_store._atomic_write_json
+    turn_write_threads: set[str] = set()
+    condition = threading.Condition()
+
+    def slow_new_turn_write(
+        path: Path,
+        payload: dict[str, object],
+        *,
+        preserve_mode: bool = False,
+    ) -> None:
+        is_new_turn_file = (
+            path.parent.name == "turns"
+            and path.name.endswith(".json")
+            and not path.name.endswith(".events.json")
+            and not preserve_mode
+        )
+        if is_new_turn_file and threading.current_thread().name.startswith("creator-"):
+            with condition:
+                turn_write_threads.add(threading.current_thread().name)
+                condition.notify_all()
+                deadline = time.monotonic() + 0.25
+                while len(turn_write_threads) < 2 and time.monotonic() < deadline:
+                    condition.wait(timeout=deadline - time.monotonic())
+        original_atomic_write(path, payload, preserve_mode=preserve_mode)
+
+    monkeypatch.setattr(chat_store, "_atomic_write_json", slow_new_turn_write)
+    results: list[tuple[str, str, bool]] = []
+    errors: list[str] = []
+
+    def create(client_turn_id: str) -> None:
+        try:
+            turn, created = store.create_turn(
+                session_id,
+                client_turn_id=client_turn_id,
+                message=f"message from {client_turn_id}",
+            )
+            results.append((client_turn_id, str(turn["turn_id"]), created))
+        except RuntimeError as exc:
+            errors.append(str(exc))
+
+    threads = [
+        threading.Thread(
+            target=create,
+            args=(f"client-{index}",),
+            name=f"creator-{index}",
+        )
+        for index in (1, 2)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=3)
+
+    assert not any(thread.is_alive() for thread in threads)
+    assert len(results) == 1
+    assert len(errors) == 1
+    active_turn_id = results[0][1]
+    assert errors == [active_turn_id]
+    assert len(turn_write_threads) == 1
+    assert [
+        item["text"] for item in store.messages(session_id) if item["role"] == "user"
+    ] == [f"message from {results[0][0]}"]
+    current = store.load_session(session_id)
+    assert current is not None
+    assert current["status"] == "busy"
+    assert current["active_turn_id"] == active_turn_id
 
 
 def test_completed_turn_cannot_release_a_newer_active_turn(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Serialize managed Chat turn creation on the durable session file lock.
- Keep the existing single-active-turn contract in `ChatSessionStore` instead of relying on controller-side timing.
- Add a deterministic regression test for two concurrent client sends against the same managed session.

## Why

While exercising Chat runtime behavior, I found that two near-simultaneous sends to the same managed session could both pass the `active_turn_id` check before either request claimed the session. That meant both turns were accepted and both workers could run against the same upstream adapter/runtime, which breaks the visible single-turn session model and can produce mixed streams or stale active-turn ownership.

The adjacent queued-turn path already claims a turn under the session file lock. This change applies the same ownership boundary to managed turn creation: check existing `client_turn_id`, inspect active turn state, write the new turn, and update `session.active_turn_id` inside one session-lock critical section. Message/event append stays after the claim so the lock remains focused on state ownership.

## Validation

- `uv run --extra test pytest tests/test_chat_session_active_turn.py::test_concurrent_managed_turn_creation_claims_active_once -q`
- `uv run --extra test pytest tests/test_chat_session_active_turn.py tests/test_attached_session_broker.py tests/test_attached_session_cli.py tests/test_chat_server_cors.py tests/test_chat_image_attachments.py tests/test_chat_lark_api_contract.py -q`
- `uv run --extra test ruff check loopx/chat_store.py tests/test_chat_session_active_turn.py`
- `uv run --extra test python -m compileall -q loopx/chat_store.py tests/test_chat_session_active_turn.py`
- `git diff --check`
- `uv run --extra test loopx canary premerge --from-git-diff`
- `npm run test:control-plane`
- `uv run --extra test pytest -q` currently reaches `4224 passed, 10 skipped` and fails only in the unrelated dashboard launcher tests expecting `-m loopx.cli ...` logging while the test stub records the launcher health-check calls. I did not include that dashboard test issue in this Chat runtime PR.
