### PR TITLE
fix(ci): pin Node for full public smokes

### DIFF
--- a/.github/workflows/full-public-smokes.yml
+++ b/.github/workflows/full-public-smokes.yml
@@ -65,6 +65,11 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22.6"
+
       - name: Install smoke runtime dependencies
         run: python -m pip install --disable-pip-version-check "jsonschema>=4.23,<5"
 

--- a/examples/full-public-smokes-workflow-smoke.py
+++ b/examples/full-public-smokes-workflow-smoke.py
@@ -38,6 +38,8 @@ def main() -> int:
         "timeout-minutes: 120",
         "actions/setup-python@",
         "python-version: \"3.11\"",
+        "actions/setup-node@v6",
+        "node-version: \"22.6\"",
         "python3 examples/run-smokes.py",
         "--suite full-public",
         "--offset \"${{ matrix.offset }}\"",


### PR DESCRIPTION
## Summary

- pin Node.js 22.6 in the full-public smoke job before any smoke invokes the managed Effect runtime
- extend the existing workflow contract smoke so the required Node setup cannot silently regress

## Root cause

The scheduled `Full Public Smokes` run on main failed in `status-collection-readmodel-smoke.py` because the job relied on the runner's ambient `node`, while the managed Effect runtime requires Node.js 22.6 or newer. The same workflow had no explicit Node setup, so runner/toolcache variance made the scheduled sweep nondeterministic.

## Validation

- `python3 examples/full-public-smokes-workflow-smoke.py`
- `python3 examples/github-actions-runtime-smoke.py`
- `uv run --isolated --python 3.11 --with 'jsonschema>=4.23,<5' python examples/control_plane/status-collection-readmodel-smoke.py`
- affected 110-check full-public shard: the previously failing status smoke passed; 109/110 checks passed, with an unrelated experimental `traex-probe-smoke.py` local timeout under parallel load
- `loopx canary premerge --from-git-diff --git-diff-base origin/main --goal-id loopx-meta --no-progress` (passed; no manual holds)
- public/private boundary scan clean

## Change quality

- exact-scope receipt: `cqr_23ec9b46de635e93d3a9`
- scope fingerprint: `23ec9b46de635e93d3a99fcf1b9646cb7a7c565f66fdd283071ade83111aa180`
- no safe-fix pass was needed

## Scope

Only the public smoke workflow and its durable contract smoke are included. No private state, credentials, local paths, generated logs, or unrelated worktree changes are part of this PR.

Future-facing pass: the established workflow runtime pattern was reused; no related refactor was necessary.
