### PR TITLE
fix(runtime): preserve typed RPC failures

### DIFF
--- a/loopx/control_plane/effect_program.ts
+++ b/loopx/control_plane/effect_program.ts
@@ -1,3 +1,4 @@
+import { EffectRuntimeRequestError } from "./effect_runtime_errors.ts";
 import { isStringLiteral } from "./runtime_decode.ts";
 
 export const SETTLEMENT_IDENTITY_SCHEMA_VERSION =
@@ -260,7 +261,7 @@ function stringArray(value: unknown): string[] {
 function requireStepKind(value: unknown): SettlementStepKind {
   const rendered = pythonString(value);
   if (!isStringLiteral(rendered, SETTLEMENT_STEP_KINDS)) {
-    throw new Error(`unsupported settlement step kind: ${rendered}`);
+    throw new EffectRuntimeRequestError("unsupported settlement step kind");
   }
   return rendered;
 }
@@ -268,7 +269,7 @@ function requireStepKind(value: unknown): SettlementStepKind {
 function requireFailureKind(value: unknown): SettlementFailureKind {
   const rendered = pythonString(value);
   if (!isStringLiteral(rendered, SETTLEMENT_FAILURE_KINDS)) {
-    throw new Error(`unsupported settlement failure kind: ${rendered}`);
+    throw new EffectRuntimeRequestError("unsupported settlement failure kind");
   }
   return rendered;
 }
@@ -429,7 +430,7 @@ export function settlementIdentity(
   const replanObligationId =
     truthyString(input.replan_obligation_id).trim() || null;
   if (todoId && replanObligationId) {
-    throw new Error(
+    throw new EffectRuntimeRequestError(
       "settlement identity cannot bind both todo_id and replan_obligation_id",
     );
   }
@@ -905,7 +906,7 @@ export function commitStepPayload(options: {
   }
   const phaseIndex = options.transaction_phases.indexOf(stepKind);
   if (phaseIndex < 0) {
-    throw new Error(`transaction phases do not contain ${stepKind}`);
+    throw new EffectRuntimeRequestError(`transaction phases do not contain ${stepKind}`);
   }
   const completedPhases = options.transaction_phases.slice(0, phaseIndex + 1);
   const sourcePrefix = options.source_ref_prefix ?? "turn_journal";

--- a/loopx/control_plane/effect_runtime.py
+++ b/loopx/control_plane/effect_runtime.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any
 
 EFFECT_RUNTIME_REQUEST_SCHEMA_VERSION = "loopx_effect_runtime_request_v0"
-EFFECT_RUNTIME_RESPONSE_SCHEMA_VERSION = "loopx_effect_runtime_response_v0"
+EFFECT_RUNTIME_RESPONSE_SCHEMA_VERSION = "loopx_effect_runtime_response_v1"
 EFFECT_RUNTIME_INFO_SCHEMA_VERSION = "loopx_effect_runtime_info_v0"
 EFFECT_RUNTIME_READINESS_SCHEMA_VERSION = "loopx_effect_runtime_readiness_v0"
 MINIMUM_NODE_VERSION = (22, 6, 0)
@@ -39,8 +39,111 @@ _RUNTIME_SOURCE_TOPOLOGIES: dict[str, _RuntimeSourceTopology] = {}
 _RUNTIME_SOURCE_TOPOLOGY_LOCK = threading.Lock()
 
 
-class EffectRuntimeRejected(RuntimeError):
+class EffectRuntimeRemoteError(RuntimeError):
+    """A typed exception returned by the managed TypeScript runtime."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        error_kind: str,
+        diagnostic_code: str,
+    ) -> None:
+        super().__init__(message)
+        self.error_kind = error_kind
+        self.diagnostic_code = diagnostic_code
+
+
+class EffectRuntimeRejected(EffectRuntimeRemoteError):
     """A typed request reached the runtime but failed semantic validation."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        diagnostic_code: str = "invalid_request",
+    ) -> None:
+        super().__init__(
+            message,
+            error_kind="request_rejected",
+            diagnostic_code=diagnostic_code,
+        )
+
+
+class EffectRuntimeConflict(EffectRuntimeRemoteError):
+    """The request conflicted with newer persisted state."""
+
+    def __init__(self, message: str, *, diagnostic_code: str) -> None:
+        super().__init__(
+            message,
+            error_kind="conflict",
+            diagnostic_code=diagnostic_code,
+        )
+
+
+class EffectRuntimeIOError(EffectRuntimeRemoteError):
+    """A managed runtime filesystem operation failed."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        error_kind: str,
+        diagnostic_code: str,
+        transient: bool,
+    ) -> None:
+        super().__init__(
+            message,
+            error_kind=error_kind,
+            diagnostic_code=diagnostic_code,
+        )
+        self.transient = transient
+
+
+class EffectRuntimeTransientIOError(EffectRuntimeIOError):
+    """A retryable managed runtime filesystem operation failed."""
+
+    def __init__(self, message: str, *, diagnostic_code: str) -> None:
+        super().__init__(
+            message,
+            error_kind="io_transient",
+            diagnostic_code=diagnostic_code,
+            transient=True,
+        )
+
+
+class EffectRuntimePermanentIOError(EffectRuntimeIOError):
+    """A non-retryable managed runtime filesystem operation failed."""
+
+    def __init__(self, message: str, *, diagnostic_code: str) -> None:
+        super().__init__(
+            message,
+            error_kind="io_permanent",
+            diagnostic_code=diagnostic_code,
+            transient=False,
+        )
+
+
+class EffectRuntimeLockTimeout(EffectRuntimeRemoteError):
+    """A managed mutation lock could not be acquired before its deadline."""
+
+    def __init__(self, message: str, *, diagnostic_code: str) -> None:
+        super().__init__(
+            message,
+            error_kind="lock_timeout",
+            diagnostic_code=diagnostic_code,
+        )
+
+
+class EffectRuntimeInternalError(EffectRuntimeRemoteError):
+    """The managed handler failed outside a declared request or I/O error."""
+
+    def __init__(self, message: str, *, diagnostic_code: str) -> None:
+        super().__init__(
+            message,
+            error_kind="internal_failure",
+            diagnostic_code=diagnostic_code,
+        )
 
 
 class EffectRuntimeStartupError(RuntimeError):
@@ -312,7 +415,10 @@ def _request_with_info(
     }
     encoded = (json.dumps(request, separators=(",", ":")) + "\n").encode()
     if len(encoded) > MAX_REQUEST_BYTES:
-        raise EffectRuntimeRejected("TypeScript Effect runtime request is oversized")
+        raise EffectRuntimeRejected(
+            "TypeScript Effect runtime request is oversized",
+            diagnostic_code="request_too_large",
+        )
     chunks: list[bytes] = []
     size = 0
     with socket.create_connection(
@@ -343,12 +449,49 @@ def _request_with_info(
     ):
         raise RuntimeError("TypeScript Effect runtime response shape mismatch")
     if response.get("ok") is not True:
-        error = response.get("error")
-        message = error.get("message") if isinstance(error, Mapping) else None
-        raise EffectRuntimeRejected(
-            str(message or "TypeScript Effect runtime request failed")
-        )
+        raise _remote_runtime_error(response.get("error"))
     return response
+
+
+def _remote_runtime_error(value: object) -> EffectRuntimeRemoteError:
+    if not isinstance(value, Mapping):
+        return EffectRuntimeInternalError(
+            "TypeScript Effect runtime returned an invalid error envelope",
+            diagnostic_code="invalid_error_envelope",
+        )
+    kind = value.get("kind")
+    code = value.get("code")
+    message = value.get("message")
+    if (
+        not isinstance(kind, str)
+        or not kind
+        or not isinstance(code, str)
+        or not code
+    ):
+        return EffectRuntimeInternalError(
+            "TypeScript Effect runtime returned an invalid error envelope",
+            diagnostic_code="invalid_error_envelope",
+        )
+    rendered = " ".join(
+        str(message or "TypeScript Effect runtime request failed").split()
+    )
+    rendered = rendered[:240] or "TypeScript Effect runtime request failed"
+    if kind == "request_rejected":
+        return EffectRuntimeRejected(rendered, diagnostic_code=code)
+    if kind == "conflict":
+        return EffectRuntimeConflict(rendered, diagnostic_code=code)
+    if kind == "io_transient":
+        return EffectRuntimeTransientIOError(rendered, diagnostic_code=code)
+    if kind == "io_permanent":
+        return EffectRuntimePermanentIOError(rendered, diagnostic_code=code)
+    if kind == "lock_timeout":
+        return EffectRuntimeLockTimeout(rendered, diagnostic_code=code)
+    if kind == "internal_failure":
+        return EffectRuntimeInternalError(rendered, diagnostic_code=code)
+    return EffectRuntimeInternalError(
+        "TypeScript Effect runtime returned an unsupported error kind",
+        diagnostic_code="unsupported_error_kind",
+    )
 
 
 def _start_runtime(*, fingerprint: str, info_path: Path) -> dict[str, Any]:
@@ -475,6 +618,8 @@ def effect_runtime_request(
                 timeout=timeout,
             )
         except EffectRuntimeRejected:
+            raise
+        except EffectRuntimeRemoteError:
             raise
         except (OSError, RuntimeError) as exc:
             last_error = exc

--- a/loopx/control_plane/effect_runtime_errors.ts
+++ b/loopx/control_plane/effect_runtime_errors.ts
@@ -1,0 +1,129 @@
+export const EFFECT_RUNTIME_ERROR_KINDS = [
+  "request_rejected",
+  "conflict",
+  "io_transient",
+  "io_permanent",
+  "lock_timeout",
+  "internal_failure",
+] as const;
+
+export type EffectRuntimeErrorKind =
+  (typeof EFFECT_RUNTIME_ERROR_KINDS)[number];
+
+export interface EffectRuntimeErrorPayload {
+  kind: EffectRuntimeErrorKind;
+  code: string;
+  message: string;
+}
+
+abstract class EffectRuntimeBoundaryError extends Error {
+  abstract readonly kind: EffectRuntimeErrorKind;
+  readonly code: string;
+
+  constructor(message: string, code: string) {
+    super(message);
+    this.name = new.target.name;
+    this.code = code;
+  }
+}
+
+export class EffectRuntimeRequestError extends EffectRuntimeBoundaryError {
+  readonly kind = "request_rejected" as const;
+
+  constructor(message: string, code = "invalid_request") {
+    super(message, code);
+  }
+}
+
+export class EffectRuntimeConflictError extends EffectRuntimeBoundaryError {
+  readonly kind = "conflict" as const;
+
+  constructor(message: string, code = "state_conflict") {
+    super(message, code);
+  }
+}
+
+export class EffectRuntimeLockTimeoutError extends EffectRuntimeBoundaryError {
+  readonly kind = "lock_timeout" as const;
+
+  constructor(message = "Effect runtime mutation lock timed out") {
+    super(message, "mutation_lock_timeout");
+  }
+}
+
+const TRANSIENT_IO_CODES: Readonly<Record<string, string>> = {
+  EAGAIN: "io_temporarily_unavailable",
+  EBUSY: "io_busy",
+  EMFILE: "io_process_descriptor_limit",
+  ENFILE: "io_system_descriptor_limit",
+  ETIMEDOUT: "io_timed_out",
+};
+
+const PERMANENT_IO_CODES: Readonly<Record<string, string>> = {
+  EACCES: "io_permission_denied",
+  EDQUOT: "io_quota_exhausted",
+  EINVAL: "io_invalid_operation",
+  EISDIR: "io_is_directory",
+  ENAMETOOLONG: "io_name_too_long",
+  ENOENT: "io_not_found",
+  ENOSPC: "io_space_exhausted",
+  ENOTDIR: "io_not_directory",
+  EPERM: "io_permission_denied",
+  EROFS: "io_read_only",
+};
+
+function boundedMessage(value: string, fallback: string): string {
+  const singleLine = value.replace(/\s+/g, " ").trim();
+  return (singleLine || fallback).slice(0, 240);
+}
+
+function nodeErrorCode(error: unknown): string | null {
+  if (typeof error !== "object" || error === null) return null;
+  const code = (error as NodeJS.ErrnoException).code;
+  return typeof code === "string" ? code : null;
+}
+
+function isNodeSystemError(error: unknown): boolean {
+  return typeof error === "object" &&
+    error !== null &&
+    typeof (error as NodeJS.ErrnoException).syscall === "string";
+}
+
+export function effectRuntimeErrorPayload(
+  error: unknown,
+): EffectRuntimeErrorPayload {
+  if (error instanceof EffectRuntimeBoundaryError) {
+    return {
+      kind: error.kind,
+      code: error.code,
+      message: boundedMessage(error.message, "Effect runtime request failed"),
+    };
+  }
+  const ioCode = nodeErrorCode(error);
+  if (ioCode && TRANSIENT_IO_CODES[ioCode]) {
+    return {
+      kind: "io_transient",
+      code: TRANSIENT_IO_CODES[ioCode],
+      message: "Effect runtime filesystem operation is temporarily unavailable",
+    };
+  }
+  if (ioCode && PERMANENT_IO_CODES[ioCode]) {
+    return {
+      kind: "io_permanent",
+      code: PERMANENT_IO_CODES[ioCode],
+      message: "Effect runtime filesystem operation failed",
+    };
+  }
+  if (ioCode && isNodeSystemError(error)) {
+    return {
+      kind: "io_permanent",
+      code: "io_failure",
+      message: "Effect runtime filesystem operation failed",
+    };
+  }
+  return {
+    kind: "internal_failure",
+    code: "unexpected_handler_error",
+    message: "Effect runtime handler failed unexpectedly",
+  };
+}

--- a/loopx/control_plane/effect_runtime_handlers.ts
+++ b/loopx/control_plane/effect_runtime_handlers.ts
@@ -24,6 +24,7 @@ import {
   type SettlementStep,
   type SettlementStepKind,
 } from "./effect_program.ts";
+import { EffectRuntimeRequestError } from "./effect_runtime_errors.ts";
 import {
   optionalNonEmptyString as optionalString,
   requireJsonObject as requiredObject,
@@ -159,7 +160,7 @@ function settlementFailureInput(value: unknown, label: string): SettlementFailur
 function settlementResultInput(value: unknown, label: string): SettlementResult {
   const result = requiredObject(value, label);
   if (!Array.isArray(result.receipts)) {
-    throw new Error(`${label}.receipts must be an array`);
+    throw new EffectRuntimeRequestError(`${label}.receipts must be an array`);
   }
   const receipts = result.receipts.map((receipt, index) =>
     settlementReceiptInput(receipt, `${label}.receipts[${index}]`)
@@ -168,7 +169,7 @@ function settlementResultInput(value: unknown, label: string): SettlementResult 
     return { value: result.value, receipts, failure: null };
   }
   if (result.value !== null) {
-    throw new Error(`${label} cannot carry both a value and a failure`);
+    throw new EffectRuntimeRequestError(`${label} cannot carry both a value and a failure`);
   }
   return {
     value: null,
@@ -180,7 +181,7 @@ function settlementResultInput(value: unknown, label: string): SettlementResult 
 function settlementStepInput(value: unknown, label: string): SettlementStep {
   const step = requiredObject(value, label);
   if (step.conditional !== undefined && step.conditional !== true) {
-    throw new Error(`${label}.conditional must be true when present`);
+    throw new EffectRuntimeRequestError(`${label}.conditional must be true when present`);
   }
   return {
     kind: settlementStepKind(step.kind, `${label}.kind`),
@@ -209,7 +210,7 @@ function settlementStepInput(value: unknown, label: string): SettlementStep {
 function settlementPlanInput(value: unknown, label: string): SettlementPlan {
   const plan = requiredObject(value, label);
   if (!Array.isArray(plan.steps)) {
-    throw new Error(`${label}.steps must be an array`);
+    throw new EffectRuntimeRequestError(`${label}.steps must be an array`);
   }
   return {
     identity: settlementIdentity(settlementIdentityInput(plan.identity, `${label}.identity`)),
@@ -227,7 +228,7 @@ function turnJournalInspectionRequest(
     request.schema_version !==
       "loopx_turn_journal_interpretation_request_v0"
   ) {
-    throw new Error("Turn-journal interpretation request schema mismatch");
+    throw new EffectRuntimeRequestError("Turn-journal interpretation request schema mismatch");
   }
   return {
     schema_version: request.schema_version,
@@ -416,6 +417,11 @@ export async function dispatchEffectRuntimeMethod(
   params: JsonObject,
 ): Promise<unknown> {
   const handler = handlers.get(method);
-  if (!handler) throw new Error("unsupported Effect runtime method");
+  if (!handler) {
+    throw new EffectRuntimeRequestError(
+      "unsupported Effect runtime method",
+      "unsupported_method",
+    );
+  }
   return await handler(params);
 }

--- a/loopx/control_plane/effect_runtime_io.ts
+++ b/loopx/control_plane/effect_runtime_io.ts
@@ -3,6 +3,7 @@ import { mkdir, open, readFile, rename, rm, stat } from "node:fs/promises";
 import { dirname } from "node:path";
 
 import type { JsonObject } from "./effect_program.ts";
+import { EffectRuntimeLockTimeoutError } from "./effect_runtime_errors.ts";
 
 const MUTATION_LOCK_TIMEOUT_MS = 5_000;
 const MUTATION_LOCK_POLL_MS = 25;
@@ -88,7 +89,7 @@ export async function withFileMutationLock<T>(
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
       await reclaimStaleMutationLock(lockPath);
       if (Date.now() >= deadline) {
-        throw new Error("Effect runtime mutation lock timed out");
+        throw new EffectRuntimeLockTimeoutError();
       }
       await new Promise((resolve) => setTimeout(resolve, MUTATION_LOCK_POLL_MS));
     }

--- a/loopx/control_plane/effect_runtime_server.ts
+++ b/loopx/control_plane/effect_runtime_server.ts
@@ -11,7 +11,10 @@ import {
   effectRuntimeErrorPayload,
 } from "./effect_runtime_errors.ts";
 import { atomicWriteJson } from "./effect_runtime_io.ts";
-import { requireNonEmptyString as requiredString } from "./runtime_decode.ts";
+import {
+  requireJsonObject as requiredObject,
+  requireNonEmptyString as requiredString,
+} from "./runtime_decode.ts";
 
 const REQUEST_SCHEMA = "loopx_effect_runtime_request_v0";
 const RESPONSE_SCHEMA = "loopx_effect_runtime_response_v1";
@@ -19,14 +22,6 @@ const INFO_SCHEMA = "loopx_effect_runtime_info_v0";
 const MAX_REQUEST_BYTES = 2 * 1024 * 1024;
 const DEFAULT_IDLE_MS = 5 * 60 * 1_000;
 let shutdownRequested = false;
-
-interface RuntimeRequest {
-  schema_version: typeof REQUEST_SCHEMA;
-  token: string;
-  request_id: string;
-  method: string;
-  params: JsonObject;
-}
 
 function asObject(value: unknown): JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -79,17 +74,18 @@ const server = createServer((socket) => {
     void (async () => {
       let requestId = "unknown";
       try {
-        let request: RuntimeRequest;
+        let parsed: unknown;
         try {
-          request = JSON.parse(
+          parsed = JSON.parse(
             raw.slice(0, raw.indexOf("\n")),
-          ) as RuntimeRequest;
+          );
         } catch {
           throw new EffectRuntimeRequestError(
             "Effect runtime request is not valid JSON",
             "malformed_json",
           );
         }
+        const request = requiredObject(parsed, "Effect runtime request");
         requestId = requiredString(request.request_id, "request_id");
         if (request.schema_version !== REQUEST_SCHEMA || request.token !== token) {
           throw new EffectRuntimeRequestError(

--- a/loopx/control_plane/effect_runtime_server.ts
+++ b/loopx/control_plane/effect_runtime_server.ts
@@ -6,11 +6,15 @@ import {
   createEffectRuntimeHandlers,
   dispatchEffectRuntimeMethod,
 } from "./effect_runtime_handlers.ts";
+import {
+  EffectRuntimeRequestError,
+  effectRuntimeErrorPayload,
+} from "./effect_runtime_errors.ts";
 import { atomicWriteJson } from "./effect_runtime_io.ts";
 import { requireNonEmptyString as requiredString } from "./runtime_decode.ts";
 
 const REQUEST_SCHEMA = "loopx_effect_runtime_request_v0";
-const RESPONSE_SCHEMA = "loopx_effect_runtime_response_v0";
+const RESPONSE_SCHEMA = "loopx_effect_runtime_response_v1";
 const INFO_SCHEMA = "loopx_effect_runtime_info_v0";
 const MAX_REQUEST_BYTES = 2 * 1024 * 1024;
 const DEFAULT_IDLE_MS = 5 * 60 * 1_000;
@@ -75,10 +79,23 @@ const server = createServer((socket) => {
     void (async () => {
       let requestId = "unknown";
       try {
-        const request = JSON.parse(raw.slice(0, raw.indexOf("\n"))) as RuntimeRequest;
+        let request: RuntimeRequest;
+        try {
+          request = JSON.parse(
+            raw.slice(0, raw.indexOf("\n")),
+          ) as RuntimeRequest;
+        } catch {
+          throw new EffectRuntimeRequestError(
+            "Effect runtime request is not valid JSON",
+            "malformed_json",
+          );
+        }
         requestId = requiredString(request.request_id, "request_id");
         if (request.schema_version !== REQUEST_SCHEMA || request.token !== token) {
-          throw new Error("Effect runtime request authentication failed");
+          throw new EffectRuntimeRequestError(
+            "Effect runtime request authentication failed",
+            "authentication_failed",
+          );
         }
         const result = await dispatchEffectRuntimeMethod(
           handlers,
@@ -97,10 +114,7 @@ const server = createServer((socket) => {
           schema_version: RESPONSE_SCHEMA,
           request_id: requestId,
           ok: false,
-          error: {
-            kind: "runtime_request_failed",
-            message: error instanceof Error ? error.message : String(error),
-          },
+          error: effectRuntimeErrorPayload(error),
         });
       }
     })();

--- a/loopx/control_plane/goals/vision_checkpoint.ts
+++ b/loopx/control_plane/goals/vision_checkpoint.ts
@@ -1,4 +1,5 @@
 import type { JsonObject } from "../effect_program.ts";
+import { EffectRuntimeRequestError } from "../effect_runtime_errors.ts";
 import {
   DELIVERY_BOUNDARIES,
   type DeliveryBoundary,
@@ -40,7 +41,7 @@ interface ExistingVisionContinuityBasis extends JsonObject {
 
 function requiredObject(value: unknown, label: string): JsonObject {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new Error(`${label} must be an object`);
+    throw new EffectRuntimeRequestError(`${label} must be an object`);
   }
   return value as JsonObject;
 }
@@ -53,14 +54,14 @@ function optionalObject(value: unknown, label: string): JsonObject | null {
 function optionalString(value: unknown, label: string): string | null {
   if (value === null || value === undefined || value === "") return null;
   if (typeof value !== "string" || !value.trim()) {
-    throw new Error(`${label} must be a non-empty string or null`);
+    throw new EffectRuntimeRequestError(`${label} must be a non-empty string or null`);
   }
   return value.trim();
 }
 
 function requiredBoolean(value: unknown, label: string): boolean {
   if (typeof value !== "boolean") {
-    throw new Error(`${label} must be a boolean`);
+    throw new EffectRuntimeRequestError(`${label} must be a boolean`);
   }
   return value;
 }
@@ -84,7 +85,7 @@ function deliveryBoundary(value: unknown): DeliveryBoundary {
   if (DELIVERY_BOUNDARIES.some((candidate) => candidate === value)) {
     return value as DeliveryBoundary;
   }
-  throw new Error("delivery_boundary is unsupported");
+  throw new EffectRuntimeRequestError("delivery_boundary is unsupported");
 }
 
 export function decodeVisionCheckpointRequest(
@@ -92,7 +93,7 @@ export function decodeVisionCheckpointRequest(
 ): VisionCheckpointRequest {
   const request = requiredObject(value, "goal.vision_checkpoint params");
   if (request.schema_version !== VISION_CHECKPOINT_REQUEST_SCHEMA) {
-    throw new Error("Vision checkpoint request schema mismatch");
+    throw new EffectRuntimeRequestError("Vision checkpoint request schema mismatch");
   }
   return {
     schema_version: VISION_CHECKPOINT_REQUEST_SCHEMA,
@@ -127,27 +128,27 @@ export function decodeVisionCheckpointRequest(
 function validateInFlightBoundary(request: VisionCheckpointRequest): void {
   if (request.delivery_boundary !== "in_flight_continuation") return;
   if (request.delivery_outcome !== "outcome_progress") {
-    throw new Error(
+    throw new EffectRuntimeRequestError(
       "in_flight_continuation requires delivery_outcome=outcome_progress",
     );
   }
   if (request.agent_id === null || request.todo_id === null) {
-    throw new Error(
+    throw new EffectRuntimeRequestError(
       "in_flight_continuation requires an agent-bound Todo settlement",
     );
   }
   if (request.completion_todo_id !== null) {
-    throw new Error(
+    throw new EffectRuntimeRequestError(
       "in_flight_continuation conflicts with Todo completion closeout",
     );
   }
   if (request.active_state_next_action_would_update) {
-    throw new Error(
+    throw new EffectRuntimeRequestError(
       "in_flight_continuation conflicts with a durable Next Action update",
     );
   }
   if (request.autonomous_replan_recorded) {
-    throw new Error(
+    throw new EffectRuntimeRequestError(
       "in_flight_continuation conflicts with autonomous replan writeback",
     );
   }

--- a/loopx/control_plane/governed_capability.ts
+++ b/loopx/control_plane/governed_capability.ts
@@ -1,4 +1,5 @@
 import type { JsonObject } from "./effect_program.ts";
+import { EffectRuntimeRequestError } from "./effect_runtime_errors.ts";
 import {
   assertNever,
   requireNonEmptyString as requiredString,
@@ -81,14 +82,14 @@ const ACTION_KIND_RE = /^[a-z][a-z0-9_]{0,63}$/;
 
 function requiredObject(value: unknown, label: string): JsonObject {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new Error(`${label} must be an object`);
+    throw new EffectRuntimeRequestError(`${label} must be an object`);
   }
   return { ...(value as JsonObject) };
 }
 
 function boundedArray(value: unknown, label: string): unknown[] {
   if (!Array.isArray(value) || value.length > 64) {
-    throw new Error(`${label} must be an array with at most 64 items`);
+    throw new EffectRuntimeRequestError(`${label} must be an array with at most 64 items`);
   }
   return [...value];
 }
@@ -96,7 +97,7 @@ function boundedArray(value: unknown, label: string): unknown[] {
 function boundedString(value: unknown, label: string, limit: number): string {
   const result = requiredString(value, label);
   if (result.length > limit || result.includes("\n") || result.includes("\r")) {
-    throw new Error(`${label} must be bounded single-line text`);
+    throw new EffectRuntimeRequestError(`${label} must be bounded single-line text`);
   }
   return result;
 }
@@ -111,7 +112,7 @@ function boundedStringArray(
     result.length > limit ||
     result.some((item) => typeof item !== "string" || item.length === 0)
   ) {
-    throw new Error(`${label} must contain bounded non-empty strings`);
+    throw new EffectRuntimeRequestError(`${label} must contain bounded non-empty strings`);
   }
   return result as string[];
 }
@@ -126,7 +127,7 @@ function requireExactFields(
     actual.length !== expected.size ||
     actual.some((field) => !expected.has(field))
   ) {
-    throw new Error(`${label} fields are invalid`);
+    throw new EffectRuntimeRequestError(`${label} fields are invalid`);
   }
 }
 
@@ -142,18 +143,18 @@ function externalEffectReceipt(
     "external capability effect_receipt",
   );
   if (receipt.schema_version !== EXTERNAL_EFFECT_RECEIPT_SCHEMA_VERSION) {
-    throw new Error("external capability effect_receipt schema is invalid");
+    throw new EffectRuntimeRequestError("external capability effect_receipt schema is invalid");
   }
   if (receipt.invocation_id !== invocationId) {
-    throw new Error("external capability effect_receipt invocation_id is invalid");
+    throw new EffectRuntimeRequestError("external capability effect_receipt invocation_id is invalid");
   }
   if (receipt.idempotency_key !== effectId) {
-    throw new Error(
+    throw new EffectRuntimeRequestError(
       "external capability effect_receipt idempotency_key is invalid",
     );
   }
   if (receipt.status !== "committed" && receipt.status !== "no_change") {
-    throw new Error("external capability effect_receipt status is invalid");
+    throw new EffectRuntimeRequestError("external capability effect_receipt status is invalid");
   }
   requiredString(
     receipt.external_ref,
@@ -223,13 +224,13 @@ function validateTransitionProposals(input: {
       `${label} kind is unsupported`,
     );
     if (!allowedKinds.includes(kind)) {
-      throw new Error(`${label} kind is not admitted by transition_contract`);
+      throw new EffectRuntimeRequestError(`${label} kind is not admitted by transition_contract`);
     }
     if (input.status === "running" && kind !== "continuous_monitor_upsert") {
-      throw new Error(`${label} running result may only upsert a monitor`);
+      throw new EffectRuntimeRequestError(`${label} running result may only upsert a monitor`);
     }
     if (proposal.schema_version !== CONTINUOUS_MONITOR_PROPOSAL_SCHEMA_VERSION) {
-      throw new Error(`${label} schema_version is invalid`);
+      throw new EffectRuntimeRequestError(`${label} schema_version is invalid`);
     }
     const proposalId = boundedString(
       proposal.proposal_id,
@@ -237,7 +238,7 @@ function validateTransitionProposals(input: {
       96,
     );
     if (!PROPOSAL_ID_RE.test(proposalId) || seenProposalIds.has(proposalId)) {
-      throw new Error(`${label} proposal_id is invalid or duplicated`);
+      throw new EffectRuntimeRequestError(`${label} proposal_id is invalid or duplicated`);
     }
     seenProposalIds.add(proposalId);
     const monitorKey = boundedString(
@@ -246,10 +247,10 @@ function validateTransitionProposals(input: {
       128,
     );
     if (!MONITOR_KEY_RE.test(monitorKey)) {
-      throw new Error(`${label} monitor_key is invalid`);
+      throw new EffectRuntimeRequestError(`${label} monitor_key is invalid`);
     }
     if (!allowedMonitorKeyPrefixes.some((prefix) => monitorKey.startsWith(prefix))) {
-      throw new Error(`${label} monitor_key is not admitted`);
+      throw new EffectRuntimeRequestError(`${label} monitor_key is not admitted`);
     }
     switch (kind) {
       case "continuous_monitor_upsert": {
@@ -260,7 +261,7 @@ function validateTransitionProposals(input: {
           64,
         );
         if (!ACTION_KIND_RE.test(actionKind) || !allowedActions.includes(actionKind)) {
-          throw new Error(`${label} action_kind is not admitted`);
+          throw new EffectRuntimeRequestError(`${label} action_kind is not admitted`);
         }
         const targetKey = boundedString(
           proposal.target_key,
@@ -268,7 +269,7 @@ function validateTransitionProposals(input: {
           128,
         );
         if (!allowedTargetPrefixes.some((prefix) => targetKey.startsWith(prefix))) {
-          throw new Error(`${label} target_key is not admitted`);
+          throw new EffectRuntimeRequestError(`${label} target_key is not admitted`);
         }
         const requiredCapabilities = boundedStringArray(
           proposal.required_capabilities,
@@ -281,7 +282,7 @@ function validateTransitionProposals(input: {
             !ACTION_KIND_RE.test(capability) || !allowedCapabilities.includes(capability)
           )
         ) {
-          throw new Error(`${label} required_capabilities are not admitted`);
+          throw new EffectRuntimeRequestError(`${label} required_capabilities are not admitted`);
         }
         return {
           ...proposal,
@@ -334,12 +335,12 @@ export function validateGovernedCapabilityAdmission(input: {
     "governed capability selected_todo",
   );
   if (selectedTodo.todo_id !== input.todo_id) {
-    throw new Error(
+    throw new EffectRuntimeRequestError(
       "governed capability selected_todo does not match the settlement Todo",
     );
   }
   if (selectedTodo.role !== "agent" || selectedTodo.status !== "open") {
-    throw new Error(
+    throw new EffectRuntimeRequestError(
       "governed capability selected_todo must be an open agent Todo",
     );
   }
@@ -365,7 +366,7 @@ export function validateGovernedCapabilityAdmission(input: {
     actionKinds.some((value) => typeof value !== "string") ||
     !actionKinds.includes(selectedTodo.action_kind)
   ) {
-    throw new Error(
+    throw new EffectRuntimeRequestError(
       "governed capability operation is not authorized by selected_todo action_kind",
     );
   }
@@ -378,7 +379,7 @@ export function validateGovernedCapabilityAdmission(input: {
     targetKeyPrefixes.some((value) => typeof value !== "string") ||
     !targetKeyPrefixes.some((prefix) => targetKey.startsWith(prefix as string))
   ) {
-    throw new Error(
+    throw new EffectRuntimeRequestError(
       "governed capability operation is not authorized by selected_todo target_key",
     );
   }
@@ -394,22 +395,22 @@ export function validateGovernedCapabilityResult(input: {
   transition_contract?: unknown;
 }): { result: JsonObject; journal_status: "running" | "ready_to_settle" } {
   if (input.effect_class !== "external_write") {
-    throw new Error("governed capability execution requires external_write");
+    throw new EffectRuntimeRequestError("governed capability execution requires external_write");
   }
   const result = requiredObject(input.value, "external capability result");
   requireExactFields(result, RESULT_FIELDS, "external capability result");
   if (result.schema_version !== input.result_schema) {
-    throw new Error("external capability result schema_version is invalid");
+    throw new EffectRuntimeRequestError("external capability result schema_version is invalid");
   }
   if (result.invocation_id !== input.invocation_id) {
-    throw new Error("external capability result invocation_id is invalid");
+    throw new EffectRuntimeRequestError("external capability result invocation_id is invalid");
   }
   if (
     result.status !== "running" &&
     result.status !== "succeeded" &&
     result.status !== "no_change"
   ) {
-    throw new Error("external capability result status is invalid");
+    throw new EffectRuntimeRequestError("external capability result status is invalid");
   }
   for (const field of [
     "observations",
@@ -429,7 +430,7 @@ export function validateGovernedCapabilityResult(input: {
   );
   if (result.status === "running") {
     if (result.effect_receipt !== null) {
-      throw new Error(
+      throw new EffectRuntimeRequestError(
         "running external capability cannot claim an effect receipt",
       );
     }
@@ -438,7 +439,7 @@ export function validateGovernedCapabilityResult(input: {
       "domain_transition_receipts",
     ]) {
       if ((result[field] as unknown[]).length > 0) {
-        throw new Error(
+        throw new EffectRuntimeRequestError(
           `running external capability must leave ${field} empty`,
         );
       }
@@ -452,7 +453,7 @@ export function validateGovernedCapabilityResult(input: {
   );
   if (result.status === "no_change") {
     if (receipt.status !== "no_change") {
-      throw new Error(
+      throw new EffectRuntimeRequestError(
         "no-change external capability requires a no-change effect receipt",
       );
     }
@@ -462,13 +463,13 @@ export function validateGovernedCapabilityResult(input: {
       "transition_proposals",
     ]) {
       if ((result[field] as unknown[]).length > 0) {
-        throw new Error(
+        throw new EffectRuntimeRequestError(
           `no-change external capability must leave ${field} empty`,
         );
       }
     }
   } else if (receipt.status !== "committed") {
-    throw new Error(
+    throw new EffectRuntimeRequestError(
       "succeeded external capability requires a committed effect receipt",
     );
   }

--- a/loopx/control_plane/quota/settlement_workspace_causality.ts
+++ b/loopx/control_plane/quota/settlement_workspace_causality.ts
@@ -1,4 +1,5 @@
 import type { JsonObject } from "../effect_program.ts";
+import { EffectRuntimeRequestError } from "../effect_runtime_errors.ts";
 import { requireJsonObject as requiredObject } from "../runtime_decode.ts";
 
 export const DELIVERY_WORKSPACE_CAUSALITY_SCHEMA_VERSION =
@@ -67,7 +68,7 @@ function optionalObject(value: unknown, label: string): JsonObject | null {
 }
 
 function requiredString(value: unknown, label: string): string {
-  if (typeof value !== "string") throw new Error(`${label} must be a string`);
+  if (typeof value !== "string") throw new EffectRuntimeRequestError(`${label} must be a string`);
   return value;
 }
 
@@ -78,7 +79,7 @@ function optionalString(value: unknown, label: string): string | null {
 
 function stringArray(value: unknown, label: string): readonly string[] {
   if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
-    throw new Error(`${label} must be an array of strings`);
+    throw new EffectRuntimeRequestError(`${label} must be an array of strings`);
   }
   return value;
 }
@@ -89,13 +90,13 @@ function operation(value: unknown): DeliveryWorkspaceCausalityOperation {
     value === "event_fields" || value === "missing_workspace" ||
     value === "from_event"
   ) return value;
-  throw new Error("delivery workspace causality operation is unsupported");
+  throw new EffectRuntimeRequestError("delivery workspace causality operation is unsupported");
 }
 
 function requestObject(value: unknown): JsonObject {
   const request = requiredObject(value, "delivery workspace causality request");
   if (request.schema_version !== DELIVERY_WORKSPACE_CAUSALITY_REQUEST_SCHEMA) {
-    throw new Error("delivery workspace causality request schema mismatch");
+    throw new EffectRuntimeRequestError("delivery workspace causality request schema mismatch");
   }
   return request;
 }

--- a/loopx/control_plane/runtime_decode.ts
+++ b/loopx/control_plane/runtime_decode.ts
@@ -1,4 +1,5 @@
 import type { JsonObject } from "./effect_program.ts";
+import { EffectRuntimeRequestError } from "./effect_runtime_errors.ts";
 
 export function jsonObject(value: unknown): JsonObject | null {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -8,27 +9,27 @@ export function jsonObject(value: unknown): JsonObject | null {
 
 export function requireJsonObject(value: unknown, label: string): JsonObject {
   const result = jsonObject(value);
-  if (!result) throw new Error(`${label} must be an object`);
+  if (!result) throw new EffectRuntimeRequestError(`${label} must be an object`);
   return result;
 }
 
 export function requireBoolean(value: unknown, label: string): boolean {
   if (typeof value !== "boolean") {
-    throw new Error(`${label} must be a boolean`);
+    throw new EffectRuntimeRequestError(`${label} must be a boolean`);
   }
   return value;
 }
 
 export function requireInteger(value: unknown, label: string): number {
   if (typeof value !== "number" || !Number.isInteger(value)) {
-    throw new Error(`${label} must be an integer`);
+    throw new EffectRuntimeRequestError(`${label} must be an integer`);
   }
   return value;
 }
 
 export function requireNonEmptyString(value: unknown, label: string): string {
   if (typeof value !== "string" || !value.trim()) {
-    throw new Error(`${label} must be a non-empty string`);
+    throw new EffectRuntimeRequestError(`${label} must be a non-empty string`);
   }
   return value;
 }
@@ -43,7 +44,7 @@ export function optionalNonEmptyString(
 
 export function requireStringArray(value: unknown, label: string): string[] {
   if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
-    throw new Error(`${label} must be an array of strings`);
+    throw new EffectRuntimeRequestError(`${label} must be an array of strings`);
   }
   return [...value];
 }
@@ -63,11 +64,12 @@ export function requireStringLiteral<const Values extends readonly string[]>(
 ): Values[number] {
   const candidate = requireNonEmptyString(value, label);
   if (!isStringLiteral(candidate, allowed)) {
-    throw new Error(unsupportedMessage);
+    throw new EffectRuntimeRequestError(unsupportedMessage);
   }
   return candidate;
 }
 
 export function assertNever(value: never, message: string): never {
-  throw new Error(`${message}: ${String(value)}`);
+  void value;
+  throw new EffectRuntimeRequestError(message);
 }

--- a/loopx/control_plane/runtime_decode.ts
+++ b/loopx/control_plane/runtime_decode.ts
@@ -71,5 +71,5 @@ export function requireStringLiteral<const Values extends readonly string[]>(
 
 export function assertNever(value: never, message: string): never {
   void value;
-  throw new EffectRuntimeRequestError(message);
+  throw new Error(message);
 }

--- a/loopx/control_plane/scheduler/state_store.ts
+++ b/loopx/control_plane/scheduler/state_store.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 import type { JsonObject } from "../effect_program.ts";
+import { EffectRuntimeRequestError } from "../effect_runtime_errors.ts";
 import {
   atomicWriteJson,
   withFileMutationLock,
@@ -123,7 +124,7 @@ function pythonInteger(value: unknown): number | null {
 
 export function rruleForMinutes(value: unknown): string {
   const minutes = pythonInteger(value);
-  if (minutes === null) throw new Error("scheduler minutes must be an integer");
+  if (minutes === null) throw new EffectRuntimeRequestError("scheduler minutes must be an integer");
   return `FREQ=MINUTELY;INTERVAL=${Math.max(1, minutes)}`;
 }
 
@@ -235,7 +236,7 @@ export function mergeSchedulerHostUpdateFailure(
   referenceTime: unknown = null,
 ): JsonObject[] {
   const normalized = normalizeSchedulerHostUpdateFailure(failure);
-  if (!normalized) throw new Error("scheduler host update failure is invalid");
+  if (!normalized) throw new EffectRuntimeRequestError("scheduler host update failure is invalid");
   const retained = retainedSchedulerHostUpdateFailures(
     value,
     referenceTime,
@@ -338,7 +339,7 @@ export function buildSchedulerState(params: JsonObject): JsonObject {
   if (pythonTruthy(params.source)) state.source = pythonString(params.source);
   const normalized = normalizeSchedulerState(state, scope);
   if (!normalized) {
-    throw new Error("scheduler state is missing required persisted-state fields");
+    throw new EffectRuntimeRequestError("scheduler state is missing required persisted-state fields");
   }
   return normalized;
 }
@@ -405,7 +406,7 @@ function legacySchedulerStatePath(
 function operationRequest(value: unknown): JsonObject {
   const request = requiredObject(value, "scheduler.state params");
   if (request.schema_version !== SCHEDULER_STATE_OPERATION_REQUEST_SCHEMA) {
-    throw new Error("Scheduler state operation request schema mismatch");
+    throw new EffectRuntimeRequestError("Scheduler state operation request schema mismatch");
   }
   return request;
 }
@@ -484,7 +485,7 @@ function storeRequest(value: unknown, operation: "load" | "write"): {
 } {
   const request = requiredObject(value, `scheduler.state.${operation} params`);
   if (request.schema_version !== SCHEDULER_STATE_STORE_REQUEST_SCHEMA) {
-    throw new Error("Scheduler state store request schema mismatch");
+    throw new EffectRuntimeRequestError("Scheduler state store request schema mismatch");
   }
   const scope = schedulerScope(request);
   const runtimeRoot = requiredString(request.runtime_root, "runtime_root");
@@ -582,7 +583,7 @@ export async function writeSchedulerState(
 ): Promise<SchedulerStateWriteResult> {
   const { request, scope, path } = storeRequest(value, "write");
   const state = normalizeSchedulerState(request.state, scope);
-  if (!state) throw new Error("scheduler state does not match target scope or schema");
+  if (!state) throw new EffectRuntimeRequestError("scheduler state does not match target scope or schema");
   return await withFileMutationLock(path, async () => {
     try {
       const existing = normalizeSchedulerState(

--- a/loopx/control_plane/scheduler/state_transition_rules.ts
+++ b/loopx/control_plane/scheduler/state_transition_rules.ts
@@ -1,4 +1,5 @@
 import type { JsonObject } from "../effect_program.ts";
+import { EffectRuntimeRequestError } from "../effect_runtime_errors.ts";
 import {
   requireBoolean as requiredBoolean,
   requireInteger as requiredInteger,
@@ -91,7 +92,7 @@ function requiredPositiveIntegerList(value: unknown, label: string): number[] {
       typeof item !== "number" || !Number.isInteger(item) || item <= 0
     )
   ) {
-    throw new Error(`${label} must be a non-empty array of positive integers`);
+    throw new EffectRuntimeRequestError(`${label} must be a non-empty array of positive integers`);
   }
   return [...value] as number[];
 }
@@ -99,7 +100,7 @@ function requiredPositiveIntegerList(value: unknown, label: string): number[] {
 function requestObject(value: unknown): JsonObject {
   const request = requiredObject(value, "scheduler.state_transition params");
   if (request.schema_version !== SCHEDULER_STATE_TRANSITION_REQUEST_SCHEMA) {
-    throw new Error("Scheduler state transition request schema mismatch");
+    throw new EffectRuntimeRequestError("Scheduler state transition request schema mismatch");
   }
   return request;
 }
@@ -110,7 +111,7 @@ function evaluateCadence(request: JsonObject): SchedulerCadenceTransitionResult 
     "progression_size",
   );
   if (progressionSize < 1) {
-    throw new Error("scheduler cadence progression must not be empty");
+    throw new EffectRuntimeRequestError("scheduler cadence progression must not be empty");
   }
   if (!requiredBoolean(request.state_present, "state_present")) {
     return {
@@ -267,7 +268,7 @@ function evaluateBackoff(request: JsonObject): SchedulerBackoffTransitionResult 
     "stale_tolerance_minutes",
   );
   if (staleToleranceMinutes < 0) {
-    throw new Error("stale_tolerance_minutes must not be negative");
+    throw new EffectRuntimeRequestError("stale_tolerance_minutes must not be negative");
   }
 
   const allHostUpdateFailures = retainedSchedulerHostUpdateFailures(
@@ -391,5 +392,5 @@ export function evaluateSchedulerStateTransition(
   if (request.operation === "cadence") return evaluateCadence(request);
   if (request.operation === "host") return evaluateHost(request);
   if (request.operation === "backoff") return evaluateBackoff(request);
-  throw new Error("Scheduler state transition operation is unsupported");
+  throw new EffectRuntimeRequestError("Scheduler state transition operation is unsupported");
 }

--- a/loopx/control_plane/todos/completion_fence.ts
+++ b/loopx/control_plane/todos/completion_fence.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 
 import type { JsonObject } from "../effect_program.ts";
+import { EffectRuntimeRequestError } from "../effect_runtime_errors.ts";
 import {
   requireBoolean as requiredBoolean,
   requireJsonObject as requiredObject,
@@ -71,7 +72,7 @@ export type TodoCompletionFenceResult =
 function optionalOpaqueString(value: unknown, label: string): string | null {
   if (value === null || value === undefined || value === "") return null;
   if (typeof value !== "string") {
-    throw new Error(`${label} must be a string or null`);
+    throw new EffectRuntimeRequestError(`${label} must be a string or null`);
   }
   return value;
 }
@@ -86,7 +87,7 @@ function completionIdentitySource(
   ) {
     return value;
   }
-  throw new Error("requested_completion_identity_source is unsupported");
+  throw new EffectRuntimeRequestError("requested_completion_identity_source is unsupported");
 }
 
 export function localTodoCompletionIdentity(
@@ -104,7 +105,7 @@ function todoNoFollowup(value: unknown): boolean | null {
     value !== null && value !== undefined &&
     typeof value !== "boolean" && typeof value !== "string"
   ) {
-    throw new Error("todo.no_followup must be a boolean, string, or null");
+    throw new EffectRuntimeRequestError("todo.no_followup must be a boolean, string, or null");
   }
   return normalizeTodoNoFollowup(value);
 }
@@ -116,32 +117,32 @@ function todoCompletionContinuation(
     value !== null && value !== undefined && value !== "" &&
     typeof value !== "string"
   ) {
-    throw new Error("todo.completion_continuation must be a string or null");
+    throw new EffectRuntimeRequestError("todo.completion_continuation must be a string or null");
   }
   return normalizeTodoCompletionContinuation(value);
 }
 
 function todoStatus(value: unknown): TodoStatus {
   if (typeof value !== "string") {
-    throw new Error("todo.status must be a supported string");
+    throw new EffectRuntimeRequestError("todo.status must be a supported string");
   }
   const normalized = value.trim().toLowerCase();
   if (!TODO_STATUSES.some((status) => status === normalized)) {
-    throw new Error("todo.status is unsupported");
+    throw new EffectRuntimeRequestError("todo.status is unsupported");
   }
   return normalized as TodoStatus;
 }
 
 function projectionSource(value: unknown): TodoCompletionProjectionSource {
   if (value === "materialized" || value === "event_log") return value;
-  throw new Error("projection_source is unsupported");
+  throw new EffectRuntimeRequestError("projection_source is unsupported");
 }
 
 function successorTodoIds(value: unknown): string[] {
   if (value === null || value === undefined) return [];
   const values = Array.isArray(value) ? value : [value];
   if (values.some((item) => typeof item !== "string")) {
-    throw new Error("todo.successor_todo_ids must contain only strings");
+    throw new EffectRuntimeRequestError("todo.successor_todo_ids must contain only strings");
   }
   const result: string[] = [];
   for (const raw of values as string[]) {
@@ -164,7 +165,7 @@ export function decodeTodoCompletionFenceRequest(
 ): TodoCompletionFenceRequest {
   const request = requiredObject(value, "todo.completion_fence params");
   if (request.schema_version !== TODO_COMPLETION_FENCE_REQUEST_SCHEMA) {
-    throw new Error("Todo completion fence request schema mismatch");
+    throw new EffectRuntimeRequestError("Todo completion fence request schema mismatch");
   }
   const todo = requiredObject(request.todo, "todo.completion_fence todo");
   return {
@@ -223,14 +224,14 @@ export function evaluateTodoCompletionFence(
     request.requested_completion_identity_source === "lifecycle_reentry" &&
     !done
   ) {
-    throw new Error("Todo lifecycle reentry requires an already completed Todo");
+    throw new EffectRuntimeRequestError("Todo lifecycle reentry requires an already completed Todo");
   }
 
   if (
     done && requestedKey !== null && requestedKey !== storedKey &&
     !unscopedIdentityRepair
   ) {
-    throw new Error(
+    throw new EffectRuntimeRequestError(
       "todo is already completed under a different completion_turn_key",
     );
   }
@@ -239,19 +240,19 @@ export function evaluateTodoCompletionFence(
     normalizeTodoNoFollowup(request.todo.no_followup) !== true;
   if (terminalUpgrade) {
     if (request.todo.successor_todo_ids.length > 0) {
-      throw new Error(
+      throw new EffectRuntimeRequestError(
         "todo terminal closeout cannot replace an existing successor",
       );
     }
     if (continuation === null) {
-      throw new Error(
+      throw new EffectRuntimeRequestError(
         "completed todo is missing completion_continuation; repair the " +
           "Todo with `loopx todo complete` without --no-follow-up before terminal " +
           "closeout",
       );
     }
     if (continuation !== "active_goal") {
-      throw new Error(
+      throw new EffectRuntimeRequestError(
         "todo terminal closeout recovery requires " +
           "completion_continuation=active_goal",
       );
@@ -260,7 +261,7 @@ export function evaluateTodoCompletionFence(
       requestedKey === null ||
       (requestedKey !== storedKey && !unscopedIdentityRepair)
     ) {
-      throw new Error(
+      throw new EffectRuntimeRequestError(
         "todo terminal closeout requires the original completion_turn_key",
       );
     }

--- a/loopx/control_plane/todos/completion_state.ts
+++ b/loopx/control_plane/todos/completion_state.ts
@@ -1,4 +1,5 @@
 import type { JsonObject } from "../effect_program.ts";
+import { EffectRuntimeRequestError } from "../effect_runtime_errors.ts";
 import {
   requireBoolean as requiredBoolean,
   requireJsonObject as requiredObject,
@@ -43,7 +44,7 @@ function optionalBoolean(value: unknown, label: string): boolean | null {
 function optionalString(value: unknown, label: string): string | null {
   if (value === null || value === undefined) return null;
   if (typeof value !== "string") {
-    throw new Error(`${label} must be a string or null`);
+    throw new EffectRuntimeRequestError(`${label} must be a string or null`);
   }
   return value;
 }
@@ -51,7 +52,7 @@ function optionalString(value: unknown, label: string): string | null {
 function requestObject(value: unknown, operation: string): JsonObject {
   const request = requiredObject(value, `todo.completion_state.${operation} params`);
   if (request.schema_version !== TODO_COMPLETION_STATE_REQUEST_SCHEMA) {
-    throw new Error("Todo completion state request schema mismatch");
+    throw new EffectRuntimeRequestError("Todo completion state request schema mismatch");
   }
   return request;
 }
@@ -60,7 +61,7 @@ export function normalizeTodoNoFollowup(value: unknown): boolean | null {
   if (typeof value === "boolean") return value;
   if (value === null || value === undefined) return null;
   if (typeof value !== "string") {
-    throw new Error("no_followup must be a boolean, string, or null");
+    throw new EffectRuntimeRequestError("no_followup must be a boolean, string, or null");
   }
   const candidate = value.trim().toLowerCase();
   if (["1", "true", "yes", "y", "no_followup", "no-followup"].includes(candidate)) {
@@ -75,7 +76,7 @@ export function normalizeTodoCompletionContinuation(
 ): TodoCompletionContinuation | null {
   if (value === null || value === undefined) return null;
   if (typeof value !== "string") {
-    throw new Error("completion_continuation must be a string or null");
+    throw new EffectRuntimeRequestError("completion_continuation must be a string or null");
   }
   const candidate = value.trim().toLowerCase();
   return TODO_COMPLETION_CONTINUATIONS.some((item) => item === candidate)
@@ -88,7 +89,7 @@ export function requireTodoCompletionContinuation(
 ): TodoCompletionContinuation {
   const normalized = normalizeTodoCompletionContinuation(value);
   if (normalized !== null) return normalized;
-  throw new Error(
+  throw new EffectRuntimeRequestError(
     "completion_continuation must be one of: active_goal, successor, no_followup",
   );
 }
@@ -98,7 +99,7 @@ export function normalizeTodoCompletionRecovery(
 ): TodoCompletionRecovery | null {
   if (value === null || value === undefined) return null;
   if (typeof value !== "string") {
-    throw new Error("completion_recovery must be a string or null");
+    throw new EffectRuntimeRequestError("completion_recovery must be a string or null");
   }
   const candidate = value.trim().toLowerCase();
   return TODO_COMPLETION_RECOVERIES.some((item) => item === candidate)
@@ -117,7 +118,7 @@ export function requireTodoCompletionMetadata(
   if (normalized !== null || value === null || value === undefined || value === "") {
     return normalized;
   }
-  throw new Error(
+  throw new EffectRuntimeRequestError(
     "completion_recovery must be same_turn_terminal_closeout or " +
       "lifecycle_reentry_terminal_closeout",
   );
@@ -128,7 +129,7 @@ export function completionContinuationForWrite(
   hasSuccessor: boolean,
 ): TodoCompletionContinuation {
   if (noFollowup && hasSuccessor) {
-    throw new Error("todo completion cannot record both no_followup and a successor");
+    throw new EffectRuntimeRequestError("todo completion cannot record both no_followup and a successor");
   }
   if (noFollowup) return "no_followup";
   if (hasSuccessor) return "successor";
@@ -139,7 +140,7 @@ export function normalizeTodoCompletionValue(value: unknown): JsonObject {
   const request = requestObject(value, "normalize");
   const kind = request.kind;
   if (kind !== "no_followup" && kind !== "continuation" && kind !== "recovery") {
-    throw new Error("completion normalization kind is unsupported");
+    throw new EffectRuntimeRequestError("completion normalization kind is unsupported");
   }
   const raw = request.value;
   const normalized = kind === "no_followup"
@@ -157,7 +158,7 @@ export function normalizeTodoCompletionValue(value: unknown): JsonObject {
 export function requireTodoCompletionMetadataValue(value: unknown): JsonObject {
   const request = requestObject(value, "require_metadata");
   const key = optionalString(request.key, "key");
-  if (key === null) throw new Error("key must be a string");
+  if (key === null) throw new EffectRuntimeRequestError("key must be a string");
   return {
     schema_version: TODO_COMPLETION_STATE_RESULT_SCHEMA,
     value: requireTodoCompletionMetadata(key, request.value),
@@ -198,7 +199,7 @@ export function selectTodoCompletionState(value: unknown): TodoCompletionStateRe
     completionIdentitySource !== "unscoped_completion" &&
     completionIdentitySource !== "lifecycle_reentry"
   ) {
-    throw new Error("completion_identity_source is unsupported");
+    throw new EffectRuntimeRequestError("completion_identity_source is unsupported");
   }
   const recovery = String(todo.status ?? "") === "done" &&
       requestedNoFollowup &&

--- a/loopx/control_plane/todos/completion_transaction.ts
+++ b/loopx/control_plane/todos/completion_transaction.ts
@@ -1,4 +1,5 @@
 import type { JsonObject } from "../effect_program.ts";
+import { EffectRuntimeRequestError } from "../effect_runtime_errors.ts";
 import {
   optionalNonEmptyString,
   requireBoolean,
@@ -138,14 +139,14 @@ function optionalInteger(value: unknown, label: string): number | null {
 function optionalString(value: unknown, label: string): string | null {
   if (value === null || value === undefined) return null;
   if (typeof value !== "string") {
-    throw new Error(`${label} must be a string or null`);
+    throw new EffectRuntimeRequestError(`${label} must be a string or null`);
   }
   return value;
 }
 
 function requireFalse(value: unknown, label: string): false {
   if (requireBoolean(value, label) !== false) {
-    throw new Error(`${label} must be false`);
+    throw new EffectRuntimeRequestError(`${label} must be false`);
   }
   return false;
 }
@@ -169,7 +170,7 @@ function decodeValidationReceipt(
     "validation_receipt.passed",
   );
   if ((passed && exitCode !== 0) || (!passed && exitCode === 0)) {
-    throw new Error(
+    throw new EffectRuntimeRequestError(
       "validation_receipt exit_code and passed must describe the same outcome",
     );
   }
@@ -317,7 +318,7 @@ export function reduceTodoCompletionTransaction(
 
   if (fence.outcome === "replay") {
     if (request.validation_receipt !== null) {
-      throw new Error("terminal replay must not carry a validation_receipt");
+      throw new EffectRuntimeRequestError("terminal replay must not carry a validation_receipt");
     }
     return { ...base, decision: "replay" };
   }
@@ -353,7 +354,7 @@ export function reduceTodoCompletionTransaction(
     const expectedLabel = validationPlan.validation_label ??
       "todo completion validation";
     if (request.validation_receipt.command_label !== expectedLabel) {
-      throw new Error(
+      throw new EffectRuntimeRequestError(
         "validation_receipt.command_label does not match the authorized effect",
       );
     }
@@ -371,7 +372,7 @@ export function reduceTodoCompletionTransaction(
       };
     }
   } else if (request.validation_receipt !== null) {
-    throw new Error(
+    throw new EffectRuntimeRequestError(
       "validation_receipt requires a declared completion validation effect",
     );
   }

--- a/loopx/control_plane/todos/completion_validation_plan.ts
+++ b/loopx/control_plane/todos/completion_validation_plan.ts
@@ -1,4 +1,5 @@
 import type { JsonObject } from "../effect_program.ts";
+import { EffectRuntimeRequestError } from "../effect_runtime_errors.ts";
 import {
   requireBoolean,
   requireJsonObject,
@@ -50,7 +51,7 @@ function projectionSource(value: unknown): TodoCompletionProjectionSource {
 function optionalOpaqueString(value: unknown, label: string): string | null {
   if (value === null || value === undefined || value === "") return null;
   if (typeof value !== "string") {
-    throw new Error(`${label} must be a string or null`);
+    throw new EffectRuntimeRequestError(`${label} must be a string or null`);
   }
   return value;
 }
@@ -144,7 +145,7 @@ export function evaluateTodoCompletionValidationPlan(
     "todo.completion_validation_plan params",
   );
   if (request.schema_version !== TODO_COMPLETION_VALIDATION_PLAN_REQUEST_SCHEMA) {
-    throw new Error("Todo completion validation plan request schema mismatch");
+    throw new EffectRuntimeRequestError("Todo completion validation plan request schema mismatch");
   }
   const todo = requireJsonObject(
     request.todo,

--- a/loopx/control_plane/todos/next_action.ts
+++ b/loopx/control_plane/todos/next_action.ts
@@ -1,4 +1,5 @@
 import type { JsonObject } from "../effect_program.ts";
+import { EffectRuntimeRequestError } from "../effect_runtime_errors.ts";
 import {
   optionalNonEmptyString as optionalString,
   requireJsonObject as requiredObject,
@@ -88,7 +89,7 @@ function nullableTodoPriority(
   if (value === null) return null;
   const priority = requiredString(value, label).trim().toUpperCase();
   if (!TODO_PRIORITY_PATTERN.test(priority)) {
-    throw new Error(`${label} must start with P0, P1, P2, P3, or P4`);
+    throw new EffectRuntimeRequestError(`${label} must start with P0, P1, P2, P3, or P4`);
   }
   return priority as TodoPriority;
 }
@@ -96,7 +97,7 @@ function nullableTodoPriority(
 function normalizedTodoId(value: unknown, label: string): string {
   const candidate = requiredString(value, label).trim().toLowerCase();
   if (!TODO_ID_PATTERN.test(candidate)) {
-    throw new Error(`${label} must be a valid todo_id`);
+    throw new EffectRuntimeRequestError(`${label} must be a valid todo_id`);
   }
   return candidate;
 }
@@ -106,10 +107,10 @@ function todoSnapshot(value: unknown, index: number): TodoNextActionSnapshot {
   const item = requiredObject(value, label);
   const status = requiredString(item.status, `${label}.status`).trim().toLowerCase();
   if (!TODO_STATUSES.has(status)) {
-    throw new Error(`${label}.status is unsupported`);
+    throw new EffectRuntimeRequestError(`${label}.status is unsupported`);
   }
   if (!Number.isSafeInteger(item.index) || Number(item.index) < 1) {
-    throw new Error(`${label}.index must be a positive integer`);
+    throw new EffectRuntimeRequestError(`${label}.index must be a positive integer`);
   }
   return {
     todo_id: normalizedTodoId(item.todo_id, `${label}.todo_id`),
@@ -137,7 +138,7 @@ export function decodeTodoNextActionRequest(
 ): TodoNextActionRequest {
   const request = requiredObject(value, "todo.next_action params");
   if (request.schema_version !== TODO_NEXT_ACTION_REQUEST_SCHEMA) {
-    throw new Error("Todo Next Action request schema mismatch");
+    throw new EffectRuntimeRequestError("Todo Next Action request schema mismatch");
   }
   const operation = requiredString(
     request.operation,
@@ -154,10 +155,10 @@ export function decodeTodoNextActionRequest(
     };
   }
   if (operation !== "reconcile_added" && operation !== "settle_completion") {
-    throw new Error("Todo Next Action operation is unsupported");
+    throw new EffectRuntimeRequestError("Todo Next Action operation is unsupported");
   }
   if (!Array.isArray(request.agent_todos)) {
-    throw new Error("todo.next_action agent_todos must be an array");
+    throw new EffectRuntimeRequestError("todo.next_action agent_todos must be an array");
   }
   if (operation === "reconcile_added") {
     return {
@@ -432,7 +433,7 @@ function settleCompletedTodo(
     (todo) => todo.todo_id === request.todo_id,
   );
   if (!completed) {
-    throw new Error("completed Todo is absent from the Agent Todo projection");
+    throw new EffectRuntimeRequestError("completed Todo is absent from the Agent Todo projection");
   }
   if (completed.status !== "done") {
     return unchangedResult(

--- a/loopx/control_plane/turn_driver/delivery_continuity.ts
+++ b/loopx/control_plane/turn_driver/delivery_continuity.ts
@@ -1,4 +1,5 @@
 import type { JsonObject } from "../effect_program.ts";
+import { EffectRuntimeRequestError } from "../effect_runtime_errors.ts";
 import {
   optionalNonEmptyString,
   requireBoolean,
@@ -136,7 +137,7 @@ function todoStatus(value: unknown, label: string): TodoStatus {
 
 function preemptions(value: unknown): DeliveryContinuityPreemption[] {
   if (!Array.isArray(value)) {
-    throw new Error("preemptions must be an array");
+    throw new EffectRuntimeRequestError("preemptions must be an array");
   }
   const result: DeliveryContinuityPreemption[] = [];
   for (const item of value) {
@@ -144,7 +145,7 @@ function preemptions(value: unknown): DeliveryContinuityPreemption[] {
       typeof item !== "string" ||
       !DELIVERY_CONTINUITY_PREEMPTIONS.some((candidate) => candidate === item)
     ) {
-      throw new Error("preemptions contains an unsupported reason");
+      throw new EffectRuntimeRequestError("preemptions contains an unsupported reason");
     }
     const reason = item as DeliveryContinuityPreemption;
     if (!result.includes(reason)) result.push(reason);
@@ -292,7 +293,7 @@ function resolveDeliveryBoundary(
 function decodeDeliveryRoutingRequest(value: unknown): DeliveryRoutingRequest {
   const request = requireJsonObject(value, "turn.delivery_route params");
   if (request.schema_version !== DELIVERY_ROUTING_REQUEST_SCHEMA) {
-    throw new Error("Delivery routing request schema mismatch");
+    throw new EffectRuntimeRequestError("Delivery routing request schema mismatch");
   }
   return {
     schema_version: DELIVERY_ROUTING_REQUEST_SCHEMA,

--- a/loopx/control_plane/turn_driver/settlement.ts
+++ b/loopx/control_plane/turn_driver/settlement.ts
@@ -14,6 +14,7 @@ import {
   type SettlementResult,
   type SettlementStepKind,
 } from "../effect_program.ts";
+import { EffectRuntimeRequestError } from "../effect_runtime_errors.ts";
 import {
   optionalNonEmptyString,
   requireBoolean,
@@ -309,7 +310,7 @@ function providerFailure(
     payload: attempt.payload,
   });
   if (committed.result.failure === null) {
-    throw new Error(
+    throw new EffectRuntimeRequestError(
       `failed_provider_attempt for ${stepKind} unexpectedly committed`,
     );
   }
@@ -331,7 +332,7 @@ function pendingProviderEffects(
     if (step === "validation" || completed.has(step)) continue;
     const phaseIndex = request.transaction_phases.indexOf(step);
     if (phaseIndex < 0) {
-      throw new Error(`transaction phases do not contain ${step}`);
+      throw new EffectRuntimeRequestError(`transaction phases do not contain ${step}`);
     }
     effects.push({
       step_kind: step,
@@ -341,7 +342,7 @@ function pendingProviderEffects(
     });
   }
   if (effects[0]?.step_kind !== firstStep) {
-    throw new Error(`Turn settlement next provider is not ${firstStep}`);
+    throw new EffectRuntimeRequestError(`Turn settlement next provider is not ${firstStep}`);
   }
   if (request.terminal_closeout_required) {
     effects.push({
@@ -461,7 +462,7 @@ function providerExecution(
 
   const effect = effects.find((candidate) => candidate.step_kind === firstStep);
   if (!effect) {
-    throw new Error(`Turn settlement has no provider effect for ${firstStep}`);
+    throw new EffectRuntimeRequestError(`Turn settlement has no provider effect for ${firstStep}`);
   }
   return execution([
     {
@@ -517,7 +518,7 @@ export function reduceTurnSettlementTransaction(
   if (base.decision === "failed") return failedState(base.result);
   if (base.decision === "execute") {
     if (base.step_kind === "validation" || base.step_kind === "terminal_closeout") {
-      throw new Error(`unsupported base settlement step ${base.step_kind}`);
+      throw new EffectRuntimeRequestError(`unsupported base settlement step ${base.step_kind}`);
     }
     const effects = pendingProviderEffects(request, identity, base.step_kind);
     return request.failed_provider_attempt === null
@@ -601,7 +602,7 @@ export function reduceTurnSettlementTransaction(
   }
 
   if (request.failed_provider_attempt !== null) {
-    throw new Error(
+    throw new EffectRuntimeRequestError(
       "failed_provider_attempt remains after all required settlement effects committed",
     );
   }

--- a/loopx/control_plane/turn_driver/settlement.ts
+++ b/loopx/control_plane/turn_driver/settlement.ts
@@ -14,7 +14,6 @@ import {
   type SettlementResult,
   type SettlementStepKind,
 } from "../effect_program.ts";
-import { EffectRuntimeRequestError } from "../effect_runtime_errors.ts";
 import {
   optionalNonEmptyString,
   requireBoolean,
@@ -310,7 +309,7 @@ function providerFailure(
     payload: attempt.payload,
   });
   if (committed.result.failure === null) {
-    throw new EffectRuntimeRequestError(
+    throw new Error(
       `failed_provider_attempt for ${stepKind} unexpectedly committed`,
     );
   }
@@ -332,7 +331,7 @@ function pendingProviderEffects(
     if (step === "validation" || completed.has(step)) continue;
     const phaseIndex = request.transaction_phases.indexOf(step);
     if (phaseIndex < 0) {
-      throw new EffectRuntimeRequestError(`transaction phases do not contain ${step}`);
+      throw new Error(`transaction phases do not contain ${step}`);
     }
     effects.push({
       step_kind: step,
@@ -342,7 +341,7 @@ function pendingProviderEffects(
     });
   }
   if (effects[0]?.step_kind !== firstStep) {
-    throw new EffectRuntimeRequestError(`Turn settlement next provider is not ${firstStep}`);
+    throw new Error(`Turn settlement next provider is not ${firstStep}`);
   }
   if (request.terminal_closeout_required) {
     effects.push({
@@ -462,7 +461,7 @@ function providerExecution(
 
   const effect = effects.find((candidate) => candidate.step_kind === firstStep);
   if (!effect) {
-    throw new EffectRuntimeRequestError(`Turn settlement has no provider effect for ${firstStep}`);
+    throw new Error(`Turn settlement has no provider effect for ${firstStep}`);
   }
   return execution([
     {
@@ -518,7 +517,7 @@ export function reduceTurnSettlementTransaction(
   if (base.decision === "failed") return failedState(base.result);
   if (base.decision === "execute") {
     if (base.step_kind === "validation" || base.step_kind === "terminal_closeout") {
-      throw new EffectRuntimeRequestError(`unsupported base settlement step ${base.step_kind}`);
+      throw new Error(`unsupported base settlement step ${base.step_kind}`);
     }
     const effects = pendingProviderEffects(request, identity, base.step_kind);
     return request.failed_provider_attempt === null
@@ -602,7 +601,7 @@ export function reduceTurnSettlementTransaction(
   }
 
   if (request.failed_provider_attempt !== null) {
-    throw new EffectRuntimeRequestError(
+    throw new Error(
       "failed_provider_attempt remains after all required settlement effects committed",
     );
   }

--- a/loopx/control_plane/turn_driver/turn_journal.ts
+++ b/loopx/control_plane/turn_driver/turn_journal.ts
@@ -3,6 +3,7 @@ import transactionContract from "../turn_transaction_contract.json" with {
 };
 
 import type { EffectTurn } from "../effect_program.ts";
+import { EffectRuntimeRequestError } from "../effect_runtime_errors.ts";
 
 export const TURN_JOURNAL_INSPECTION_SCHEMA_VERSION =
   "loopx_turn_journal_inspection_v0";
@@ -90,7 +91,7 @@ export function interpretTurnJournalEffect(
   request: TurnJournalInspectionRequest,
 ): TurnJournalEffect {
   if (request.schema_version !== "loopx_turn_journal_interpretation_request_v0") {
-    throw new Error("Turn-journal interpretation request schema mismatch");
+    throw new EffectRuntimeRequestError("Turn-journal interpretation request schema mismatch");
   }
   const journal = asObject(request.journal);
   const plan = asObject(journal.plan);

--- a/loopx/control_plane/turn_driver/turn_journal_effects.ts
+++ b/loopx/control_plane/turn_driver/turn_journal_effects.ts
@@ -4,6 +4,10 @@ import { isAbsolute } from "node:path";
 
 import type { JsonObject } from "../effect_program.ts";
 import {
+  EffectRuntimeConflictError,
+  EffectRuntimeRequestError,
+} from "../effect_runtime_errors.ts";
+import {
   atomicWriteJson,
   withFileMutationLock,
 } from "../effect_runtime_io.ts";
@@ -49,22 +53,28 @@ export async function commitTurnJournal(
 ): Promise<JsonObject> {
   const path = requiredString(params.path, "path");
   if (!isAbsolute(path)) {
-    throw new Error("Turn journal path must be absolute");
+    throw new EffectRuntimeRequestError("Turn journal path must be absolute");
   }
   const journal = asObject(params.journal);
   if (journal.schema_version !== "loopx_turn_journal_v0") {
-    throw new Error("Turn journal has an unsupported schema");
+    throw new EffectRuntimeRequestError(
+      "Turn journal has an unsupported schema",
+    );
   }
   const expectedEffectId = typeof params.expected_effect_id === "string"
     ? params.expected_effect_id.trim()
     : "";
   const incomingEffectId = journalEffectId(journal);
   if (expectedEffectId && incomingEffectId !== expectedEffectId) {
-    throw new Error("Turn journal does not carry the expected settlement effect");
+    throw new EffectRuntimeRequestError(
+      "Turn journal does not carry the expected settlement effect",
+    );
   }
   const expectedPreviousSha256 = params.expected_previous_sha256;
   if (expectedPreviousSha256 !== null && typeof expectedPreviousSha256 !== "string") {
-    throw new Error("expected_previous_sha256 must be a string or null");
+    throw new EffectRuntimeRequestError(
+      "expected_previous_sha256 must be a string or null",
+    );
   }
   const incomingOperationId = operationId(journal);
   return await withFileMutationLock(path, async () => {
@@ -80,7 +90,10 @@ export async function commitTurnJournal(
         incomingEffectId &&
         existingEffectId !== incomingEffectId
       ) {
-        throw new Error("Turn journal belongs to another settlement effect");
+        throw new EffectRuntimeConflictError(
+          "Turn journal belongs to another settlement effect",
+          "journal_effect_conflict",
+        );
       }
       if (operationId(existing) === incomingOperationId) {
         return {
@@ -95,7 +108,10 @@ export async function commitTurnJournal(
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
     }
     if (existingSha256 !== expectedPreviousSha256) {
-      throw new Error("Turn journal compare-and-swap precondition failed");
+      throw new EffectRuntimeConflictError(
+        "Turn journal compare-and-swap precondition failed",
+        "compare_and_swap_conflict",
+      );
     }
     await atomicWriteJson(path, journal);
     return {

--- a/loopx/control_plane/work_items/action_portfolio.ts
+++ b/loopx/control_plane/work_items/action_portfolio.ts
@@ -1,3 +1,4 @@
+import { EffectRuntimeRequestError } from "../effect_runtime_errors.ts";
 import {
   optionalNonEmptyString,
   requireInteger,
@@ -60,10 +61,10 @@ function requireRunnableAdvancement(
   label: string,
 ): void {
   if (candidate.status !== "open") {
-    throw new Error(`${label}.status must be open`);
+    throw new EffectRuntimeRequestError(`${label}.status must be open`);
   }
   if (candidate.task_class !== "advancement_task") {
-    throw new Error(`${label}.task_class must be advancement_task`);
+    throw new EffectRuntimeRequestError(`${label}.task_class must be advancement_task`);
   }
 }
 
@@ -124,7 +125,7 @@ function unavailableProjection(candidate: ActionCandidate): JsonObject {
 export function projectQuotaActionPortfolio(value: unknown): JsonObject | null {
   const request = requireJsonObject(value, "action_portfolio_request");
   if (request.schema_version !== ACTION_PORTFOLIO_REQUEST_SCHEMA_VERSION) {
-    throw new Error(
+    throw new EffectRuntimeRequestError(
       `action_portfolio_request.schema_version must be ${ACTION_PORTFOLIO_REQUEST_SCHEMA_VERSION}`,
     );
   }
@@ -137,7 +138,7 @@ export function projectQuotaActionPortfolio(value: unknown): JsonObject | null {
       "action_portfolio_request.max_alternative_actions",
     );
   if (maximum < 1 || maximum > MAX_ALTERNATIVE_ACTIONS) {
-    throw new Error(
+    throw new EffectRuntimeRequestError(
       `action_portfolio_request.max_alternative_actions must be between 1 and ${MAX_ALTERNATIVE_ACTIONS}`,
     );
   }
@@ -172,7 +173,7 @@ export function projectQuotaActionPortfolio(value: unknown): JsonObject | null {
       `action_portfolio_request.unavailable_higher_priority[${index}]`,
     );
     if (!candidate.availability_reason) {
-      throw new Error(
+      throw new EffectRuntimeRequestError(
         `action_portfolio_request.unavailable_higher_priority[${index}].availability_reason must be a non-empty string`,
       );
     }

--- a/loopx/control_plane/work_items/delivery_outcome.ts
+++ b/loopx/control_plane/work_items/delivery_outcome.ts
@@ -1,3 +1,5 @@
+import { EffectRuntimeRequestError } from "../effect_runtime_errors.ts";
+
 export const DELIVERY_OUTCOMES = [
   "surface_only",
   "outcome_gap",
@@ -23,7 +25,7 @@ export function decodeOptionalDeliveryOutcome(
   if (DELIVERY_OUTCOMES.some((candidate) => candidate === value)) {
     return value as DeliveryOutcome;
   }
-  throw new Error(`${label} is unsupported`);
+  throw new EffectRuntimeRequestError(`${label} is unsupported`);
 }
 
 export function decodeOptionalMaterialDeliveryOutcome(
@@ -37,7 +39,7 @@ export function decodeOptionalMaterialDeliveryOutcome(
   ) {
     return outcome as MaterialDeliveryOutcome | null;
   }
-  throw new Error(`${label} is not a material delivery outcome`);
+  throw new EffectRuntimeRequestError(`${label} is not a material delivery outcome`);
 }
 
 export function isMaterialDeliveryOutcome(

--- a/loopx/control_plane/work_items/replan_settlement.ts
+++ b/loopx/control_plane/work_items/replan_settlement.ts
@@ -1,4 +1,5 @@
 import type { JsonObject } from "../effect_program.ts";
+import { EffectRuntimeRequestError } from "../effect_runtime_errors.ts";
 import {
   optionalNonEmptyString,
   requireJsonObject,
@@ -75,7 +76,7 @@ function argumentSuffix(values: readonly string[]): string {
 function lifecycleTrigger(value: unknown, index: number): JsonObject {
   const trigger = requireJsonObject(value, `triggers[${index}]`);
   if (trigger.kind !== "completed_advancement_without_successor") {
-    throw new Error(`triggers[${index}].kind is unsupported`);
+    throw new EffectRuntimeRequestError(`triggers[${index}].kind is unsupported`);
   }
   return {
     kind: trigger.kind,
@@ -96,11 +97,11 @@ export function projectTodoLifecycleSettlementReentry(value: unknown): JsonObjec
     "work_item.replan_settlement.reentry params",
   );
   if (request.schema_version !== TODO_LIFECYCLE_REENTRY_REQUEST_SCHEMA) {
-    throw new Error("Todo lifecycle reentry request schema mismatch");
+    throw new EffectRuntimeRequestError("Todo lifecycle reentry request schema mismatch");
   }
   const goalId = requireNonEmptyString(request.goal_id, "goal_id");
   if (!Array.isArray(request.triggers) || request.triggers.length === 0) {
-    throw new Error("triggers must be a non-empty array");
+    throw new EffectRuntimeRequestError("triggers must be a non-empty array");
   }
   const triggers = request.triggers.slice(0, 3).map(lifecycleTrigger).map(
     (trigger) => {
@@ -165,7 +166,7 @@ export function projectReplanSettlementContract(
 ): ReplanSettlementContract {
   const request = requireJsonObject(value, "work_item.replan_settlement params");
   if (request.schema_version !== REPLAN_SETTLEMENT_REQUEST_SCHEMA) {
-    throw new Error("Replan settlement request schema mismatch");
+    throw new EffectRuntimeRequestError("Replan settlement request schema mismatch");
   }
   const selectedTodoId = optionalNonEmptyString(
     request.selected_todo_id,

--- a/tests/control_plane/test_effect_runtime_integration.py
+++ b/tests/control_plane/test_effect_runtime_integration.py
@@ -5,6 +5,7 @@ import json
 import os
 import shutil
 import signal
+import socket
 import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -33,6 +34,26 @@ def _digest(path: Path) -> str | None:
         return hashlib.sha256(path.read_bytes()).hexdigest()
     except FileNotFoundError:
         return None
+
+
+def _raw_runtime_response(
+    info: dict[str, object],
+    payload: bytes,
+) -> dict[str, object]:
+    response = b""
+    with socket.create_connection(
+        (str(info["host"]), int(info["port"])), timeout=2
+    ) as connection:
+        connection.settimeout(2)
+        connection.sendall(payload)
+        while b"\n" not in response:
+            chunk = connection.recv(64 * 1024)
+            if not chunk:
+                break
+            response += chunk
+    decoded = json.loads(response.split(b"\n", 1)[0])
+    assert isinstance(decoded, dict)
+    return decoded
 
 
 def test_windows_pid_liveness_uses_a_non_signaling_probe(monkeypatch) -> None:
@@ -525,6 +546,65 @@ def test_oversized_request_is_rejected_before_runtime_dispatch(
         {},
         retry_safe=False,
     )
+
+
+def test_non_object_json_request_is_rejected_at_the_socket_boundary(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime_dir = tmp_path / "runtime"
+    monkeypatch.setattr(effect_runtime, "_runtime_dir", lambda: runtime_dir)
+    monkeypatch.setenv("LOOPX_EFFECT_RUNTIME_IDLE_MS", "1000")
+
+    ping = effect_runtime.effect_runtime_result("runtime.ping", {})
+    fingerprint = effect_runtime._runtime_fingerprint()
+    info = effect_runtime._read_info(
+        effect_runtime._runtime_info_path(fingerprint),
+        fingerprint=fingerprint,
+    )
+    assert info is not None
+
+    response = _raw_runtime_response(info, b"null\n")
+
+    assert response["request_id"] == "unknown"
+    assert response["ok"] is False
+    assert response["error"] == {
+        "kind": "request_rejected",
+        "code": "invalid_request",
+        "message": "Effect runtime request must be an object",
+    }
+    assert (
+        effect_runtime.effect_runtime_result("runtime.ping", {})["pid"]
+        == ping["pid"]
+    )
+    effect_runtime.effect_runtime_result("runtime.shutdown", {}, retry_safe=False)
+
+
+def test_corrupt_persisted_journal_maps_to_bounded_internal_failure(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime_dir = tmp_path / "runtime"
+    monkeypatch.setattr(effect_runtime, "_runtime_dir", lambda: runtime_dir)
+    monkeypatch.setenv("LOOPX_EFFECT_RUNTIME_IDLE_MS", "1000")
+    journal_path = tmp_path / "corrupt-turn-journal.json"
+    journal_path.write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(effect_runtime.EffectRuntimeInternalError) as caught:
+        effect_runtime.effect_runtime_result(
+            "turn_journal.write",
+            {
+                "path": str(journal_path),
+                "journal": _journal("effect-one"),
+                "expected_effect_id": "effect-one",
+                "expected_previous_sha256": _digest(journal_path),
+            },
+        )
+
+    assert caught.value.diagnostic_code == "unexpected_handler_error"
+    assert str(caught.value) == "Effect runtime handler failed unexpectedly"
+    assert str(journal_path) not in str(caught.value)
+    effect_runtime.effect_runtime_result("runtime.shutdown", {}, retry_safe=False)
 
 
 @pytest.mark.parametrize(

--- a/tests/control_plane/test_effect_runtime_integration.py
+++ b/tests/control_plane/test_effect_runtime_integration.py
@@ -10,6 +10,8 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from loopx.control_plane import effect_runtime
 
 
@@ -176,8 +178,10 @@ def test_typed_write_rejects_cross_effect_overwrite(
                 "expected_previous_sha256": _digest(journal_path),
             },
         )
-    except RuntimeError as exc:
+    except effect_runtime.EffectRuntimeConflict as exc:
         assert "belongs to another settlement effect" in str(exc)
+        assert exc.error_kind == "conflict"
+        assert exc.diagnostic_code == "journal_effect_conflict"
     else:
         raise AssertionError("cross-effect overwrite must fail closed")
     assert json.loads(journal_path.read_text(encoding="utf-8")) == first
@@ -231,6 +235,9 @@ def test_typed_write_serializes_same_effect_checkpoints_with_cas(
 
     assert sum(isinstance(outcome, RuntimeError) for outcome in outcomes) == 1
     failure = next(outcome for outcome in outcomes if isinstance(outcome, RuntimeError))
+    assert isinstance(failure, effect_runtime.EffectRuntimeConflict)
+    assert failure.error_kind == "conflict"
+    assert failure.diagnostic_code == "compare_and_swap_conflict"
     assert "compare-and-swap precondition failed" in str(failure)
     assert json.loads(journal_path.read_text(encoding="utf-8")) in (first, second)
     success = next(outcome for outcome in outcomes if isinstance(outcome, dict))
@@ -518,3 +525,71 @@ def test_oversized_request_is_rejected_before_runtime_dispatch(
         {},
         retry_safe=False,
     )
+
+
+@pytest.mark.parametrize(
+    ("payload", "exception_type", "transient"),
+    [
+        (
+            {"kind": "request_rejected", "code": "invalid_request", "message": "bad"},
+            effect_runtime.EffectRuntimeRejected,
+            None,
+        ),
+        (
+            {"kind": "conflict", "code": "state_conflict", "message": "stale"},
+            effect_runtime.EffectRuntimeConflict,
+            None,
+        ),
+        (
+            {"kind": "io_transient", "code": "io_busy", "message": "busy"},
+            effect_runtime.EffectRuntimeTransientIOError,
+            True,
+        ),
+        (
+            {"kind": "io_permanent", "code": "io_not_found", "message": "gone"},
+            effect_runtime.EffectRuntimePermanentIOError,
+            False,
+        ),
+        (
+            {
+                "kind": "lock_timeout",
+                "code": "mutation_lock_timeout",
+                "message": "waited",
+            },
+            effect_runtime.EffectRuntimeLockTimeout,
+            None,
+        ),
+        (
+            {
+                "kind": "internal_failure",
+                "code": "unexpected_handler_error",
+                "message": "failed",
+            },
+            effect_runtime.EffectRuntimeInternalError,
+            None,
+        ),
+    ],
+)
+def test_remote_error_envelope_preserves_typed_exception(
+    payload: dict[str, str],
+    exception_type: type[effect_runtime.EffectRuntimeRemoteError],
+    transient: bool | None,
+) -> None:
+    error = effect_runtime._remote_runtime_error(payload)
+
+    assert isinstance(error, exception_type)
+    assert error.error_kind == payload["kind"]
+    assert error.diagnostic_code == payload["code"]
+    if transient is not None:
+        assert isinstance(error, effect_runtime.EffectRuntimeIOError)
+        assert error.transient is transient
+
+
+def test_invalid_remote_error_envelope_fails_as_bounded_internal_error() -> None:
+    error = effect_runtime._remote_runtime_error(
+        {"kind": "internal_failure", "message": "/private/path\nstack"}
+    )
+
+    assert isinstance(error, effect_runtime.EffectRuntimeInternalError)
+    assert error.diagnostic_code == "invalid_error_envelope"
+    assert "/private/path" not in str(error)

--- a/tests/control_plane/test_scheduler_state_runtime_integration.py
+++ b/tests/control_plane/test_scheduler_state_runtime_integration.py
@@ -218,3 +218,63 @@ def test_scheduler_state_scope_mismatch_is_rejected_before_disk_write(
         agent_id=AGENT_ID,
     ).exists()
     _shutdown_runtime()
+
+
+def test_scheduler_state_facade_preserves_permanent_io_failure(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime_dir = tmp_path / "effect-runtime"
+    invalid_root = tmp_path / "not-a-directory"
+    invalid_root.write_text("occupied", encoding="utf-8")
+    monkeypatch.setattr(effect_runtime, "_runtime_dir", lambda: runtime_dir)
+    monkeypatch.setenv("LOOPX_EFFECT_RUNTIME_IDLE_MS", "1000")
+
+    with pytest.raises(effect_runtime.EffectRuntimePermanentIOError) as captured:
+        write_scheduler_state(
+            invalid_root,
+            _state(),
+            goal_id=GOAL_ID,
+            agent_id=AGENT_ID,
+        )
+
+    assert captured.value.error_kind == "io_permanent"
+    assert captured.value.diagnostic_code in {"io_not_directory", "io_not_found"}
+    assert captured.value.transient is False
+    assert str(invalid_root) not in str(captured.value)
+    _shutdown_runtime()
+
+
+def test_scheduler_state_mutation_lock_timeout_remains_typed(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime_dir = tmp_path / "effect-runtime"
+    state_root = tmp_path / "state"
+    monkeypatch.setattr(effect_runtime, "_runtime_dir", lambda: runtime_dir)
+    monkeypatch.setenv("LOOPX_EFFECT_RUNTIME_IDLE_MS", "10000")
+    runtime = effect_runtime.effect_runtime_result("runtime.ping", {})
+    target = scheduler_state_path(
+        state_root,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    lock = Path(f"{target}.ts-effect.lock")
+    lock.write_text(
+        json.dumps({"pid": runtime["pid"], "token": "live-writer"}),
+        encoding="utf-8",
+    )
+
+    try:
+        with pytest.raises(effect_runtime.EffectRuntimeLockTimeout) as captured:
+            effect_runtime.effect_runtime_result(
+                "scheduler.state.write",
+                _store_request(state_root, _state()),
+                timeout=7,
+            )
+        assert captured.value.error_kind == "lock_timeout"
+        assert captured.value.diagnostic_code == "mutation_lock_timeout"
+    finally:
+        lock.unlink(missing_ok=True)
+        _shutdown_runtime()

--- a/tests/control_plane_ts/effect_runtime_errors.test.ts
+++ b/tests/control_plane_ts/effect_runtime_errors.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  EffectRuntimeConflictError,
+  EffectRuntimeLockTimeoutError,
+  EffectRuntimeRequestError,
+  effectRuntimeErrorPayload,
+} from "../../loopx/control_plane/effect_runtime_errors.ts";
+
+test("runtime failures reduce to stable public-safe taxonomy", () => {
+  assert.deepEqual(
+    effectRuntimeErrorPayload(new EffectRuntimeRequestError("schema mismatch")),
+    {
+      kind: "request_rejected",
+      code: "invalid_request",
+      message: "schema mismatch",
+    },
+  );
+  assert.deepEqual(
+    effectRuntimeErrorPayload(
+      new EffectRuntimeConflictError("compare-and-swap failed"),
+    ),
+    {
+      kind: "conflict",
+      code: "state_conflict",
+      message: "compare-and-swap failed",
+    },
+  );
+  assert.equal(
+    effectRuntimeErrorPayload(new EffectRuntimeLockTimeoutError()).kind,
+    "lock_timeout",
+  );
+});
+
+test("filesystem and unexpected failures do not expose private diagnostics", () => {
+  const permanent = new Error("ENOTDIR: private path");
+  Object.assign(permanent, { code: "ENOTDIR" });
+  assert.deepEqual(effectRuntimeErrorPayload(permanent), {
+    kind: "io_permanent",
+    code: "io_not_directory",
+    message: "Effect runtime filesystem operation failed",
+  });
+
+  const transient = new Error("EAGAIN: private path");
+  Object.assign(transient, { code: "EAGAIN" });
+  assert.equal(effectRuntimeErrorPayload(transient).kind, "io_transient");
+
+  const genericIo = new Error("EIO: private path");
+  Object.assign(genericIo, { code: "EIO", syscall: "write" });
+  assert.deepEqual(effectRuntimeErrorPayload(genericIo), {
+    kind: "io_permanent",
+    code: "io_failure",
+    message: "Effect runtime filesystem operation failed",
+  });
+
+  assert.deepEqual(effectRuntimeErrorPayload(new TypeError("private stack")), {
+    kind: "internal_failure",
+    code: "unexpected_handler_error",
+    message: "Effect runtime handler failed unexpectedly",
+  });
+});

--- a/tests/control_plane_ts/runtime_decode.test.ts
+++ b/tests/control_plane_ts/runtime_decode.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { effectRuntimeErrorPayload } from "../../loopx/control_plane/effect_runtime_errors.ts";
 import {
+  assertNever,
   jsonObject,
   optionalNonEmptyString,
   requireBoolean,
@@ -45,6 +47,20 @@ test("runtime decoder rejects malformed primitive boundary values", () => {
     () => requireStringArray(["ok", 1], "value"),
     /value must be an array of strings/,
   );
+});
+
+test("internal exhaustiveness assertions do not become request rejection", () => {
+  let caught: unknown;
+  try {
+    assertNever("unexpected" as never, "internal assertion failed");
+  } catch (error) {
+    caught = error;
+  }
+  assert.deepEqual(effectRuntimeErrorPayload(caught), {
+    kind: "internal_failure",
+    code: "unexpected_handler_error",
+    message: "Effect runtime handler failed unexpectedly",
+  });
 });
 
 test("literal decoder narrows only values present in the runtime allowlist", () => {

--- a/tests/control_plane_ts/turn_settlement.test.ts
+++ b/tests/control_plane_ts/turn_settlement.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { effectRuntimeErrorPayload } from "../../loopx/control_plane/effect_runtime_errors.ts";
 import { settlementIdentity } from "../../loopx/control_plane/effect_program.ts";
 import {
   reduceTurnSettlementTransaction,
@@ -127,6 +128,31 @@ test("writeback rejection retains validation receipt and typed failure", () => {
     reduced.result.receipts.map((receipt) => receipt.step_kind),
     ["validation"],
   );
+});
+
+test("internal settlement contradictions remain internal failures", () => {
+  let caught: unknown;
+  try {
+    reduceTurnSettlementTransaction(
+      request({
+        completed_phases: [...phases.slice(0, 3)],
+        writeback_payload: null,
+        quota_spend_payload: null,
+        failed_provider_attempt: {
+          step_kind: "durable_writeback",
+          payload: { ok: true, appended: true, record: "writeback" },
+        },
+      }),
+    );
+  } catch (error) {
+    caught = error;
+  }
+
+  assert.deepEqual(effectRuntimeErrorPayload(caught), {
+    kind: "internal_failure",
+    code: "unexpected_handler_error",
+    message: "Effect runtime handler failed unexpectedly",
+  });
 });
 
 test("terminal closeout joins the same transaction after spend", () => {

--- a/tsconfig.control-plane.json
+++ b/tsconfig.control-plane.json
@@ -13,6 +13,7 @@
   },
   "include": [
     "loopx/control_plane/effect_program.ts",
+    "loopx/control_plane/effect_runtime_errors.ts",
     "loopx/control_plane/effect_runtime_handlers.ts",
     "loopx/control_plane/effect_runtime_io.ts",
     "loopx/control_plane/effect_runtime_server.ts",
@@ -30,6 +31,7 @@
     "loopx/control_plane/turn_driver/delivery_continuity.ts",
     "loopx/control_plane/work_items/delivery_outcome.ts",
     "tests/control_plane_ts/effect_program.test.ts",
+    "tests/control_plane_ts/effect_runtime_errors.test.ts",
     "tests/control_plane_ts/runtime_decode.test.ts",
     "tests/control_plane_ts/delivery_continuity.test.ts",
     "tests/control_plane_ts/settlement_workspace_causality.test.ts",


### PR DESCRIPTION
## Summary

- add a versioned RPC failure envelope with stable kind/code taxonomy and bounded public-safe messages
- make TypeScript request validation, conflict, I/O, lock-timeout, and internal failures explicit at their owning runtime boundaries
- validate the top-level JSON request as an object before field access and keep exhaustiveness/settlement contradictions classified as internal failures
- preserve typed remote failures in Python while converting only request rejection to `ValueError` in existing facades
- rebase onto the current action-portfolio v1 authority without restoring the retired fallback contract

Related to #3534. This is a bounded stage; issue lifecycle remains owner-managed.

## Validation

- `npm run test:control-plane` — 127 passed after the action-portfolio v1 conflict resolution
- `npm run typecheck:control-plane` — passed
- `uv run --no-project --with pytest python -m pytest -q tests/control_plane/test_*runtime*.py` — 135 passed
- direct socket regression for a JSON `null` request and a real corrupt-journal server→Python internal failure — passed
- final `loopx canary premerge --from-git-diff` — 9 catalog canaries + 8 risk-profile smokes passed; 0 failures, 0 warnings, 0 manual holds; `self_merge_allowed=true`
- GitHub Linux pytest and native Windows lifecycle checks — passed on exact head `64fd5570de64a5de31c42db48568572d9dc63f2b`

## Boundary and placement

Effect Runtime RPC remains the built-in capability owner. `effect_runtime_errors.ts` is the nearest shared TypeScript boundary for server, handler, journal, lock, and I/O classification; Python remains a thin typed adapter. Request decoders emit `request_rejected`, durable CAS and lock boundaries retain their own kinds, and implementation contradictions stay ordinary errors so the server reduces them to a bounded `internal_failure` without exposing stack, path, or raw exception text.

The future-facing pass was applied at the existing error authority and the current action-portfolio v1 boundary; no second state authority or speculative abstraction was added. This PR contains only public runtime code and durable tests; no private state, credentials, raw logs, or local paths are included.
