### PR TITLE
fix(runtime): fingerprint packaged control-plane sources

### DIFF
--- a/loopx/control_plane/effect_runtime.py
+++ b/loopx/control_plane/effect_runtime.py
@@ -9,9 +9,11 @@ import shutil
 import socket
 import subprocess
 import tempfile
+import threading
 import time
 import uuid
 from collections.abc import Mapping
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -28,6 +30,13 @@ STARTUP_READY_TIMEOUT_SECONDS = 15.0
 STARTUP_POLL_SECONDS = 0.025
 _NODE_VERSION_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$")
 _RUNTIME_SOURCE_SUFFIXES = frozenset({".json", ".ts"})
+_RuntimeSourceSnapshot = tuple[tuple[str, int, int, int], ...]
+_RuntimeDirectorySnapshot = tuple[tuple[str, int, int], ...]
+_RuntimeSourceTopology = tuple[
+    tuple[str, ...], tuple[str, ...], _RuntimeDirectorySnapshot
+]
+_RUNTIME_SOURCE_TOPOLOGIES: dict[str, _RuntimeSourceTopology] = {}
+_RUNTIME_SOURCE_TOPOLOGY_LOCK = threading.Lock()
 
 
 class EffectRuntimeRejected(RuntimeError):
@@ -46,26 +55,120 @@ def _control_plane_root() -> Path:
     return Path(__file__).resolve().parent
 
 
-def _runtime_source_files(root: Path | None = None) -> tuple[str, ...]:
-    """Return the packaged source boundary owned by the managed runtime."""
-
-    source_root = root or _control_plane_root()
+def _runtime_directory_snapshot(
+    root: Path,
+    directories: tuple[str, ...],
+) -> _RuntimeDirectorySnapshot:
     return tuple(
-        sorted(
-            path.relative_to(source_root).as_posix()
-            for path in source_root.rglob("*")
-            if path.is_file() and path.suffix in _RUNTIME_SOURCE_SUFFIXES
+        (
+            relative,
+            (metadata := (root / relative).stat()).st_mtime_ns,
+            metadata.st_ctime_ns,
         )
+        for relative in directories
     )
 
 
-def _runtime_fingerprint() -> str:
+def _scan_runtime_source_topology(root: Path) -> _RuntimeSourceTopology:
+    files: list[str] = []
+    directories = [""]
+    for directory, child_directories, filenames in os.walk(root):
+        child_directories.sort()
+        relative_directory = os.path.relpath(directory, root)
+        if relative_directory == ".":
+            relative_directory = ""
+        directories.extend(
+            Path(relative_directory, child).as_posix() for child in child_directories
+        )
+        files.extend(
+            Path(relative_directory, filename).as_posix()
+            for filename in sorted(filenames)
+            if Path(filename).suffix in _RUNTIME_SOURCE_SUFFIXES
+            and Path(directory, filename).is_file()
+        )
+    directory_tuple = tuple(sorted(directories))
+    return (
+        tuple(sorted(files)),
+        directory_tuple,
+        _runtime_directory_snapshot(root, directory_tuple),
+    )
+
+
+def _runtime_file_snapshot(
+    root: Path,
+    files: tuple[str, ...],
+) -> _RuntimeSourceSnapshot:
+    return tuple(
+        (
+            relative,
+            (metadata := (root / relative).stat()).st_mtime_ns,
+            metadata.st_ctime_ns,
+            metadata.st_size,
+        )
+        for relative in files
+    )
+
+
+def _runtime_source_snapshot(root: Path | None = None) -> _RuntimeSourceSnapshot:
+    """Return cheap metadata that invalidates the packaged-source hash."""
+
+    source_root = (root or _control_plane_root()).resolve()
+    root_key = os.fspath(source_root)
+    with _RUNTIME_SOURCE_TOPOLOGY_LOCK:
+        topology = _RUNTIME_SOURCE_TOPOLOGIES.get(root_key)
+        if topology is not None:
+            files, directories, previous_directory_snapshot = topology
+            try:
+                current_directory_snapshot = _runtime_directory_snapshot(
+                    source_root, directories
+                )
+            except FileNotFoundError:
+                current_directory_snapshot = ()
+            if current_directory_snapshot != previous_directory_snapshot:
+                topology = None
+        if topology is None:
+            topology = _scan_runtime_source_topology(source_root)
+            if (
+                root_key not in _RUNTIME_SOURCE_TOPOLOGIES
+                and len(_RUNTIME_SOURCE_TOPOLOGIES) >= 8
+            ):
+                _RUNTIME_SOURCE_TOPOLOGIES.pop(next(iter(_RUNTIME_SOURCE_TOPOLOGIES)))
+            _RUNTIME_SOURCE_TOPOLOGIES[root_key] = topology
+        files, _directories, _directory_snapshot = topology
+        try:
+            return _runtime_file_snapshot(source_root, files)
+        except FileNotFoundError:
+            topology = _scan_runtime_source_topology(source_root)
+            _RUNTIME_SOURCE_TOPOLOGIES[root_key] = topology
+            files, _directories, _directory_snapshot = topology
+            return _runtime_file_snapshot(source_root, files)
+
+
+def _runtime_source_files(root: Path | None = None) -> tuple[str, ...]:
+    """Return the packaged source boundary owned by the managed runtime."""
+
+    return tuple(relative for relative, *_metadata in _runtime_source_snapshot(root))
+
+
+@lru_cache(maxsize=8)
+def _runtime_fingerprint_for_snapshot(
+    root: str,
+    snapshot: _RuntimeSourceSnapshot,
+) -> str:
     digest = hashlib.sha256()
-    root = _control_plane_root()
-    for relative in _runtime_source_files(root):
+    source_root = Path(root)
+    for relative, *_metadata in snapshot:
         digest.update(relative.encode("utf-8"))
-        digest.update((root / relative).read_bytes())
+        digest.update((source_root / relative).read_bytes())
     return digest.hexdigest()
+
+
+def _runtime_fingerprint() -> str:
+    root = _control_plane_root()
+    return _runtime_fingerprint_for_snapshot(
+        os.fspath(root.resolve()),
+        _runtime_source_snapshot(root),
+    )
 
 
 def _runtime_dir() -> Path:

--- a/loopx/control_plane/effect_runtime.py
+++ b/loopx/control_plane/effect_runtime.py
@@ -12,10 +12,8 @@ import tempfile
 import time
 import uuid
 from collections.abc import Mapping
-from functools import lru_cache
 from pathlib import Path
 from typing import Any
-
 
 EFFECT_RUNTIME_REQUEST_SCHEMA_VERSION = "loopx_effect_runtime_request_v0"
 EFFECT_RUNTIME_RESPONSE_SCHEMA_VERSION = "loopx_effect_runtime_response_v0"
@@ -29,30 +27,7 @@ STARTUP_LOCK_TIMEOUT_SECONDS = 15.0
 STARTUP_READY_TIMEOUT_SECONDS = 15.0
 STARTUP_POLL_SECONDS = 0.025
 _NODE_VERSION_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$")
-_SOURCE_FILES = (
-    "effect_program.ts",
-    "governed_capability.ts",
-    "effect_runtime_handlers.ts",
-    "effect_runtime_io.ts",
-    "effect_runtime_server.ts",
-    "goals/vision_checkpoint.ts",
-    "quota/settlement_workspace_causality.ts",
-    "scheduler/state_store.ts",
-    "scheduler/state_transition_rules.ts",
-    "todos/completion_fence.ts",
-    "todos/completion_state.ts",
-    "todos/completion_transaction.ts",
-    "todos/completion_validation_plan.ts",
-    "todos/next_action.ts",
-    "turn_driver/turn_journal.ts",
-    "turn_driver/turn_journal_effects.ts",
-    "turn_driver/delivery_continuity.ts",
-    "turn_driver/settlement.ts",
-    "work_items/delivery_outcome.ts",
-    "work_items/action_portfolio.ts",
-    "work_items/replan_settlement.ts",
-    "turn_transaction_contract.json",
-)
+_RUNTIME_SOURCE_SUFFIXES = frozenset({".json", ".ts"})
 
 
 class EffectRuntimeRejected(RuntimeError):
@@ -71,11 +46,23 @@ def _control_plane_root() -> Path:
     return Path(__file__).resolve().parent
 
 
-@lru_cache(maxsize=1)
+def _runtime_source_files(root: Path | None = None) -> tuple[str, ...]:
+    """Return the packaged source boundary owned by the managed runtime."""
+
+    source_root = root or _control_plane_root()
+    return tuple(
+        sorted(
+            path.relative_to(source_root).as_posix()
+            for path in source_root.rglob("*")
+            if path.is_file() and path.suffix in _RUNTIME_SOURCE_SUFFIXES
+        )
+    )
+
+
 def _runtime_fingerprint() -> str:
     digest = hashlib.sha256()
     root = _control_plane_root()
-    for relative in _SOURCE_FILES:
+    for relative in _runtime_source_files(root):
         digest.update(relative.encode("utf-8"))
         digest.update((root / relative).read_bytes())
     return digest.hexdigest()

--- a/tests/control_plane/test_effect_runtime_integration.py
+++ b/tests/control_plane/test_effect_runtime_integration.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-import json
 import hashlib
+import json
 import os
+import shutil
 import signal
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -103,6 +104,47 @@ def test_managed_runtime_is_reused_and_restart_safe_for_typed_write(
         {},
         retry_safe=False,
     )
+
+
+def test_runtime_decode_change_rotates_identity_and_starts_replacement(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_root = Path(effect_runtime.__file__).resolve().parent
+    staged_root = tmp_path / "control_plane"
+    for relative in effect_runtime._runtime_source_files(source_root):
+        source = source_root / relative
+        target = staged_root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+
+    runtime_dir = tmp_path / "runtime"
+    monkeypatch.setattr(effect_runtime, "_control_plane_root", lambda: staged_root)
+    monkeypatch.setattr(effect_runtime, "_runtime_dir", lambda: runtime_dir)
+    monkeypatch.setenv("LOOPX_EFFECT_RUNTIME_IDLE_MS", "250")
+
+    original_fingerprint = effect_runtime._runtime_fingerprint()
+    original = effect_runtime.effect_runtime_result("runtime.ping", {})
+    decoder = staged_root / "runtime_decode.ts"
+    decoder.write_bytes(decoder.read_bytes() + b"\n// decoder-fingerprint-probe\n")
+    replacement_fingerprint = effect_runtime._runtime_fingerprint()
+    replacement = effect_runtime.effect_runtime_result("runtime.ping", {})
+
+    assert replacement_fingerprint != original_fingerprint
+    assert int(replacement["pid"]) != int(original["pid"])
+    original_info = effect_runtime._runtime_info_path(original_fingerprint)
+    replacement_info = effect_runtime._runtime_info_path(replacement_fingerprint)
+    assert original_info != replacement_info
+    assert replacement_info.exists()
+
+    effect_runtime.effect_runtime_result("runtime.shutdown", {}, retry_safe=False)
+    deadline = time.monotonic() + 2
+    while (
+        original_info.exists() or replacement_info.exists()
+    ) and time.monotonic() < deadline:
+        time.sleep(0.025)
+    assert not original_info.exists()
+    assert not replacement_info.exists()
 
 
 def test_typed_write_rejects_cross_effect_overwrite(

--- a/tests/control_plane/test_turn_journal_runtime_readiness.py
+++ b/tests/control_plane/test_turn_journal_runtime_readiness.py
@@ -41,6 +41,38 @@ def test_runtime_fingerprint_rotates_when_any_owned_source_changes(
     assert effect_runtime._runtime_fingerprint() == original
 
 
+def test_runtime_fingerprint_reuses_hash_until_source_snapshot_changes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "runtime_decode.ts").write_text("export {};\n", encoding="utf-8")
+    (tmp_path / "turn_transaction_contract.json").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setattr(effect_runtime, "_control_plane_root", lambda: tmp_path)
+    original_read_bytes = Path.read_bytes
+    reads: list[Path] = []
+
+    def counted_read_bytes(path: Path) -> bytes:
+        reads.append(path)
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", counted_read_bytes)
+
+    original = effect_runtime._runtime_fingerprint()
+    assert len(reads) == 2
+    assert effect_runtime._runtime_fingerprint() == original
+    assert len(reads) == 2
+
+    added = tmp_path / "new_runtime_dependency.ts"
+    added.write_text("export const added = true;\n", encoding="utf-8")
+    expanded = effect_runtime._runtime_fingerprint()
+    assert expanded != original
+    assert len(reads) == 5
+
+    added.unlink()
+    assert effect_runtime._runtime_fingerprint() == original
+    assert len(reads) == 5
+
+
 def test_missing_node_blocks_the_typescript_control_plane_and_is_actionable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/control_plane/test_turn_journal_runtime_readiness.py
+++ b/tests/control_plane/test_turn_journal_runtime_readiness.py
@@ -20,23 +20,24 @@ def test_runtime_fingerprint_rotates_when_any_owned_source_changes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     source_root = Path(effect_runtime.__file__).resolve().parent
-    for relative in effect_runtime._SOURCE_FILES:
+    source_files = effect_runtime._runtime_source_files(source_root)
+    assert "effect_runtime_server.ts" in source_files
+    assert "runtime_decode.ts" in source_files
+    assert "turn_transaction_contract.json" in source_files
+    for relative in source_files:
         source = source_root / relative
         target = tmp_path / relative
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(source.read_bytes())
     monkeypatch.setattr(effect_runtime, "_control_plane_root", lambda: tmp_path)
 
-    effect_runtime._runtime_fingerprint.cache_clear()
     original = effect_runtime._runtime_fingerprint()
-    for index, relative in enumerate(effect_runtime._SOURCE_FILES):
+    for index, relative in enumerate(source_files):
         target = tmp_path / relative
         original_bytes = target.read_bytes()
         target.write_bytes(original_bytes + f"\n// fingerprint-{index}\n".encode())
-        effect_runtime._runtime_fingerprint.cache_clear()
         assert effect_runtime._runtime_fingerprint() != original
         target.write_bytes(original_bytes)
-    effect_runtime._runtime_fingerprint.cache_clear()
     assert effect_runtime._runtime_fingerprint() == original
 
 


### PR DESCRIPTION
## Summary

- replace the hand-maintained managed-runtime source list with the complete packaged TypeScript/JSON control-plane boundary
- recompute runtime identity from current source bytes so decoder-only changes rotate identity in the same client process
- cache unchanged source topology/content metadata so warm RPC calls do not recursively reread every source file
- prove modify/add/delete invalidation and distinct managed Node runtime startup while keeping the source-tree and installed-wheel boundary aligned

Related to #3533. This is a bounded stage; issue lifecycle remains owner-managed.

## Validation

- `npm run test:control-plane` — 123 passed
- `npm run typecheck:control-plane` — passed
- focused runtime integration/readiness suites — 23 passed
- warm fingerprint benchmark — median about 0.22 ms over 500 unchanged calls (about 19 ms before the cache locally)
- `loopx canary premerge --from-git-diff` — 1 catalog canary + 8 risk-profile smokes passed; 0 failures, 0 warnings, 0 manual holds; `self_merge_allowed=true`
- GitHub Linux and native Windows lifecycle checks — passed on exact head `79924c0ec5dc08669df5caff4b2353a852ef8746`

## Boundary and placement

The built-in Effect Runtime remains the capability owner. The bounded future-facing refactor removes duplicate per-file authority from the Python adapter: the packaged control-plane source boundary is the single conservative invalidation unit, while the cache remains local, bounded, and invalidated by file and directory metadata. It restarts the managed runtime for any packaged control-plane TypeScript/JSON change, including newly added transitive modules, without imposing a recursive content read on every RPC.

All changed paths are public runtime code or durable validation. No private state, credentials, raw logs, generated artifacts, or local paths are included.
