### PR TITLE
fix(quota): settle repaired todo delivery contracts

### DIFF
--- a/loopx/control_plane/quota/settlement_workspace_causality.py
+++ b/loopx/control_plane/quota/settlement_workspace_causality.py
@@ -292,8 +292,9 @@ def completed_todo_workspace_causality(
     *,
     goal_id: str,
     todo_id: str,
+    source: str = "completed_todo_contract_fallback",
 ) -> dict[str, str] | None:
-    """Recover a legacy effect's causality from its exact completed Todo."""
+    """Recover an effect's causality from its exact projected Todo contract."""
 
     queue = status_payload.get("attention_queue")
     queue_items = queue.get("items") if isinstance(queue, Mapping) else []
@@ -320,6 +321,6 @@ def completed_todo_workspace_causality(
                         continue
                     return build_delivery_workspace_causality(
                         item,
-                        source="completed_todo_contract_fallback",
+                        source=source,
                     )
     return None

--- a/loopx/control_plane/quota/slot_accounting.py
+++ b/loopx/control_plane/quota/slot_accounting.py
@@ -169,6 +169,31 @@ def _resolve_preview_settlement(
     }
 
 
+def _repair_settlement_workspace_causality(
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+    settlement_identity: SettlementIdentity | None,
+    causality: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    requirement = str((causality or {}).get("requirement") or "")
+    if settlement_identity is None or requirement not in {"", "unknown"}:
+        return causality
+    repaired = completed_todo_workspace_causality(
+        status_payload,
+        goal_id=goal_id,
+        todo_id=settlement_identity.todo_id,
+        source=(
+            "current_todo_contract_repair"
+            if requirement == "unknown"
+            else "completed_todo_contract_fallback"
+        ),
+    )
+    if str((repaired or {}).get("requirement") or "") == "unknown":
+        return causality
+    return repaired or causality
+
+
 def _now_local() -> str:
     return now_local_iso()
 
@@ -461,12 +486,12 @@ def build_quota_slot_preview_for_decision(
         if raw_runtime_root
         else None
     )
-    if settlement_identity is not None and not delivery_workspace_causality:
-        delivery_workspace_causality = completed_todo_workspace_causality(
-            status_payload,
-            goal_id=safe_goal_id,
-            todo_id=settlement_identity.todo_id,
-        )
+    delivery_workspace_causality = _repair_settlement_workspace_causality(
+        status_payload,
+        goal_id=safe_goal_id,
+        settlement_identity=settlement_identity,
+        causality=delivery_workspace_causality,
+    )
     safe_bypass_without_delivery = (
         safe_bypass_requested and delivery_completion_run is None
     )

--- a/tests/control_plane/test_quota_slot_accounting.py
+++ b/tests/control_plane/test_quota_slot_accounting.py
@@ -733,6 +733,62 @@ def test_current_unknown_workspace_causality_fails_closed_without_snapshot(
     assert preview["delivery_workspace_validated"] is False
 
 
+def test_unknown_workspace_causality_reloads_repaired_todo_contract(
+    tmp_path: Path,
+) -> None:
+    runtime = tmp_path / "runtime"
+    original_todo_id = "todo_repaired_delivery"
+    turn_instance_id = "turn-repaired-delivery"
+    _write_typed_settlement_fixture(
+        runtime,
+        todo_id=original_todo_id,
+        turn_instance_id=turn_instance_id,
+        workspace_requirement="unknown",
+    )
+    before = _normal_run_before(todo_id="todo_new_successor")
+    status = _normal_run_status(runtime)
+    status["attention_queue"]["items"][0]["project_asset"] = {
+        "agent_todos": {
+            "items": [
+                {
+                    "todo_id": original_todo_id,
+                    "task_repository": "git:github.com/example/loopx",
+                    "required_write_scopes": ["loopx/**"],
+                }
+            ]
+        }
+    }
+
+    preview = build_quota_slot_preview_for_decision(
+        status,
+        goal_id=GOAL_ID,
+        before=before,
+        after_decision=lambda _: {
+            **before,
+            "quota": {**before["quota"], "spent_slots": 1},
+        },
+        quota_status_builder=lambda goal, **_: goal["quota"],
+        self_repair_spend_actions=frozenset(),
+        agent_id=AGENT_A,
+        todo_id=original_todo_id,
+        turn_instance_id=turn_instance_id,
+        source="heartbeat",
+    )
+
+    assert preview["ok"] is False
+    assert "requires a valid delivery workspace snapshot" in preview["reason"]
+    assert preview["delivery_workspace_causality"] == {
+        "schema_version": "delivery_workspace_causality_v0",
+        "todo_id": original_todo_id,
+        "requirement": "required",
+        "source": "current_todo_contract_repair",
+        "reason": "declared_repository_or_write_contract",
+    }
+    assert preview["delivery_workspace_resolution"]["decision"] == (
+        "require_snapshot"
+    )
+
+
 def test_implicit_heartbeat_identity_fails_closed_on_persisted_effect_drift(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- re-resolve an unknown heartbeat receipt causality from the exact current Todo contract
- preserve the immutable turn identity while accepting only typed repository/write or explicit non-delivery repairs
- keep unknown or missing repairs fail-closed and add focused regression coverage

## Root cause
A turn receipt intentionally freezes the original Todo causality. When a legacy or underspecified Todo was repaired after the guard, `quota spend-slot` kept reading the immutable `unknown` snapshot and could never observe the accepted contract repair named in its own error guidance.

## Validation
- 63 focused quota settlement/workspace causality tests passed
- Ruff and Python compile checks passed
- control-plane maintainability and peer runtime smokes passed under Python 3.11
- risk-based premerge canary passed all selected checks with no manual holds
- exact change-quality receipt: `cqr_01ee11c549d91adcae26`
- live exact-turn retry validated the independent worktree and committed one quota spend receipt

## Scope
The repair stays in the typed quota settlement boundary. It does not rewrite heartbeat receipts, weaken workspace validation, or change scheduling, scoring, permissions, or production behavior outside settlement re-entry.