### PR TITLE
fix(desktop): replace stale LoopX listeners safely

### DIFF
--- a/apps/desktop/loopx-control-plane/README.md
+++ b/apps/desktop/loopx-control-plane/README.md
@@ -30,8 +30,12 @@ services are reused only after a successful response exposes both the exact
 top-level JSON fingerprint and the same installed release identity as the
 selected `loopx` command. Marker-like text in headers or nested values is not
 accepted. A service left running by an older installation is reported as stale
-with a restart instruction instead of silently handling current control-plane
-writes with old code.
+and is replaced automatically only after the shell resolves the listener PID
+and confirms that its command is the expected `loopx serve-status` or
+`loopx chat` invocation on the matching port. If process ownership cannot be
+confirmed, startup fails closed without sending a termination signal. Unknown
+services remain a hard error. Windows currently keeps this owner-facing error
+path instead of terminating an existing process automatically.
 
 The WebView is pinned to the loopback Chat origin served by the installed
 LoopX release. Dashboard requests to the status and Chat services remain

--- a/apps/desktop/loopx-control-plane/src-tauri/src/services.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/services.rs
@@ -152,8 +152,8 @@ impl ServiceSet {
                     // service (KeepAlive + throttle) has time to restart on the
                     // current release; unknown (Foreign) processes keep the
                     // hard error.
+                    terminate_stale_listener(kind, &executable, kind.port())?;
                     self.healed = true;
-                    terminate_listener(kind.port());
                     if Instant::now() >= stale_deadline {
                         return Err(ServiceError(format!(
                             "port {} is serving LoopX {} from a different installed runtime and could not be restarted",
@@ -193,8 +193,8 @@ impl ServiceSet {
                     )));
                 }
                 Probe::Stale => {
+                    terminate_stale_listener(kind, &executable, kind.port())?;
                     self.healed = true;
-                    terminate_listener(kind.port());
                     thread::sleep(Duration::from_millis(200));
                 }
                 Probe::Unavailable => thread::sleep(Duration::from_millis(100)),
@@ -221,24 +221,207 @@ impl Drop for ServiceSet {
     }
 }
 
-fn terminate_listener(port: u16) {
+#[derive(Debug, Eq, PartialEq)]
+struct ListenerProcess {
+    pid: i32,
+    command_line: String,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum LoopxProcessInvocation {
+    DirectExecutable,
+    PythonModule,
+    ManagedReleaseLauncher,
+}
+
+const MANAGED_RELEASE_LAUNCHER_MARKER: &str =
+    r#"runpy.run_module("loopx.cli", run_name="__main__")"#;
+
+fn terminate_stale_listener(
+    kind: ServiceKind,
+    loopx_executable: &str,
+    port: u16,
+) -> Result<(), ServiceError> {
     #[cfg(not(windows))]
     {
-        let output = Command::new("lsof")
-            .args(["-tiTCP", &format!(":{port}"), "-sTCP:LISTEN"])
-            .output();
-        if let Ok(output) = output {
-            for line in String::from_utf8_lossy(&output.stdout).lines() {
-                if let Ok(pid) = line.trim().parse::<i32>() {
-                    let _ = Command::new("kill").arg(pid.to_string()).status();
-                }
+        let processes = listener_processes(port)?;
+        let pids = verified_loopx_listener_pids(kind, loopx_executable, port, &processes)?;
+        for pid in pids {
+            let current = inspect_process(pid, port)?;
+            verified_loopx_listener_pids(kind, loopx_executable, port, &[current])?;
+            let status = Command::new("kill")
+                .arg(pid.to_string())
+                .status()
+                .map_err(|error| {
+                    ServiceError(format!(
+                        "could not stop stale LoopX {} listener on port {port}: {error}",
+                        kind.label()
+                    ))
+                })?;
+            if !status.success() {
+                return Err(ServiceError(format!(
+                    "could not stop stale LoopX {} listener on port {port}",
+                    kind.label()
+                )));
             }
         }
+        Ok(())
     }
     #[cfg(windows)]
     {
-        // Windows keeps the owner-facing error path; no process is terminated.
+        let _ = (kind, loopx_executable, port);
+        Err(ServiceError(format!(
+            "port {port} is serving stale LoopX {}; automatic replacement is unavailable on Windows",
+            kind.label()
+        )))
     }
+}
+
+#[cfg(not(windows))]
+fn listener_processes(port: u16) -> Result<Vec<ListenerProcess>, ServiceError> {
+    let selector = format!("-iTCP:{port}");
+    let output = Command::new("lsof")
+        .args(["-nP", "-t", "-a", selector.as_str(), "-sTCP:LISTEN"])
+        .output()
+        .map_err(|error| {
+            ServiceError(format!(
+                "could not inspect the listener on port {port}: {error}"
+            ))
+        })?;
+    if !output.status.success() {
+        return Err(ServiceError(format!(
+            "could not identify the stale LoopX listener on port {port}"
+        )));
+    }
+
+    let mut pids = Vec::new();
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let pid = line.trim().parse::<i32>().map_err(|_| {
+            ServiceError(format!(
+                "could not parse the listener process on port {port}"
+            ))
+        })?;
+        if !pids.contains(&pid) {
+            pids.push(pid);
+        }
+    }
+    if pids.is_empty() {
+        return Err(ServiceError(format!(
+            "could not identify the stale LoopX listener on port {port}"
+        )));
+    }
+
+    pids.into_iter()
+        .map(|pid| inspect_process(pid, port))
+        .collect()
+}
+
+#[cfg(not(windows))]
+fn inspect_process(pid: i32, port: u16) -> Result<ListenerProcess, ServiceError> {
+    let output = Command::new("ps")
+        .args(["-ww", "-p", &pid.to_string(), "-o", "args="])
+        .output()
+        .map_err(|error| {
+            ServiceError(format!(
+                "could not inspect the stale listener process on port {port}: {error}"
+            ))
+        })?;
+    let command_line = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !output.status.success() || command_line.is_empty() {
+        return Err(ServiceError(format!(
+            "could not inspect the stale listener process on port {port}"
+        )));
+    }
+    Ok(ListenerProcess { pid, command_line })
+}
+
+fn verified_loopx_listener_pids(
+    kind: ServiceKind,
+    loopx_executable: &str,
+    port: u16,
+    processes: &[ListenerProcess],
+) -> Result<Vec<i32>, ServiceError> {
+    if processes.is_empty()
+        || processes.iter().any(|process| {
+            !is_expected_loopx_listener_command(kind, loopx_executable, port, &process.command_line)
+        })
+    {
+        return Err(ServiceError(format!(
+            "refusing to stop the listener on port {port} because its process is not a confirmed LoopX {} command",
+            kind.label()
+        )));
+    }
+    Ok(processes.iter().map(|process| process.pid).collect())
+}
+
+fn is_expected_loopx_listener_command(
+    kind: ServiceKind,
+    loopx_executable: &str,
+    port: u16,
+    command_line: &str,
+) -> bool {
+    let arguments = command_line.split_ascii_whitespace().collect::<Vec<_>>();
+    let is_loopx =
+        classify_loopx_process_invocation(loopx_executable, command_line, &arguments).is_some();
+    let expected_command = match kind {
+        ServiceKind::Status => "serve-status",
+        ServiceKind::Chat => "chat",
+    };
+    let has_command = arguments.contains(&expected_command);
+    let expected_port = port.to_string();
+    let has_port = arguments
+        .windows(2)
+        .any(|pair| pair[0] == "--port" && pair[1] == expected_port)
+        || arguments
+            .iter()
+            .any(|argument| *argument == format!("--port={port}"));
+    is_loopx && has_command && has_port
+}
+
+fn classify_loopx_process_invocation(
+    loopx_executable: &str,
+    command_line: &str,
+    arguments: &[&str],
+) -> Option<LoopxProcessInvocation> {
+    let interpreter_is_python = arguments
+        .first()
+        .and_then(|argument| Path::new(argument).file_name())
+        .and_then(OsStr::to_str)
+        .is_some_and(|name| name.to_ascii_lowercase().starts_with("python"));
+    let executable_is_direct = arguments
+        .first()
+        .is_some_and(|argument| paths_refer_to_same_file(argument, loopx_executable))
+        || (interpreter_is_python
+            && arguments
+                .get(1)
+                .is_some_and(|argument| paths_refer_to_same_file(argument, loopx_executable)));
+    if executable_is_direct {
+        return Some(LoopxProcessInvocation::DirectExecutable);
+    }
+    if interpreter_is_python && arguments.windows(2).any(|pair| pair == ["-m", "loopx.cli"]) {
+        return Some(LoopxProcessInvocation::PythonModule);
+    }
+
+    // Installed LoopX wrappers intentionally exec Python with a stable `-c`
+    // bootstrap. `ps` exposes that bootstrap instead of the wrapper path, so
+    // the exact module-launch statement and release-root contract are the
+    // durable positive fingerprint for this typed invocation variant.
+    if interpreter_is_python
+        && arguments.contains(&"-c")
+        && command_line.contains(MANAGED_RELEASE_LAUNCHER_MARKER)
+        && command_line.contains("LOOPX_RELEASE_ROOT")
+    {
+        return Some(LoopxProcessInvocation::ManagedReleaseLauncher);
+    }
+    None
+}
+
+fn paths_refer_to_same_file(candidate: &str, expected: &str) -> bool {
+    candidate == expected
+        || fs::canonicalize(candidate)
+            .ok()
+            .zip(fs::canonicalize(expected).ok())
+            .is_some_and(|(candidate, expected)| candidate == expected)
 }
 
 fn loopx_executable() -> String {
@@ -321,7 +504,15 @@ fn runtime_identity_for_executable_with_path(
 }
 
 fn probe(kind: ServiceKind, expected_runtime_identity: Option<&serde_json::Value>) -> Probe {
-    let address = SocketAddr::from(([127, 0, 0, 1], kind.port()));
+    probe_on_port(kind, kind.port(), expected_runtime_identity)
+}
+
+fn probe_on_port(
+    kind: ServiceKind,
+    port: u16,
+    expected_runtime_identity: Option<&serde_json::Value>,
+) -> Probe {
+    let address = SocketAddr::from(([127, 0, 0, 1], port));
     let mut stream = match TcpStream::connect_timeout(&address, PROBE_TIMEOUT) {
         Ok(stream) => stream,
         Err(_) => return Probe::Unavailable,
@@ -331,7 +522,7 @@ fn probe(kind: ServiceKind, expected_runtime_identity: Option<&serde_json::Value
     let request = format!(
         "GET {} HTTP/1.1\r\nHost: 127.0.0.1:{}\r\nConnection: close\r\n\r\n",
         kind.probe_path(),
-        kind.port()
+        port
     );
     if stream.write_all(request.as_bytes()).is_err() {
         return Probe::Foreign;
@@ -565,3 +756,7 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+#[path = "services_tests.rs"]
+mod supervisor_tests;

--- a/apps/desktop/loopx-control-plane/src-tauri/src/services_tests.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/services_tests.rs
@@ -1,0 +1,288 @@
+use super::*;
+
+#[cfg(not(windows))]
+fn spawn_listener_fixture(
+    executable: &Path,
+    command: &str,
+    port: u16,
+    payload: &str,
+) -> std::process::Child {
+    use std::os::unix::fs::PermissionsExt;
+
+    let source = format!(
+        r#"#!/usr/bin/env python3
+import socket
+
+payload = {payload:?}.encode("utf-8")
+server = socket.socket()
+server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+server.bind(("127.0.0.1", {port}))
+server.listen(8)
+while True:
+    connection, _ = server.accept()
+    connection.recv(65536)
+    response = (
+        b"HTTP/1.1 200 OK\r\n"
+        b"Content-Type: application/json\r\n"
+        + f"Content-Length: {{len(payload)}}\r\n".encode("ascii")
+        + b"Connection: close\r\n\r\n"
+        + payload
+    )
+    connection.sendall(response)
+    connection.close()
+"#
+    );
+    fs::write(executable, source).expect("write listener fixture");
+    let mut permissions = fs::metadata(executable)
+        .expect("listener fixture metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(executable, permissions).expect("make listener fixture executable");
+    Command::new(executable)
+        .args([command, "--host", "127.0.0.1", "--port", &port.to_string()])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn listener fixture")
+}
+
+#[cfg(not(windows))]
+fn reserve_loopback_port() -> u16 {
+    std::net::TcpListener::bind(("127.0.0.1", 0))
+        .expect("reserve loopback port")
+        .local_addr()
+        .expect("reserved loopback address")
+        .port()
+}
+
+#[cfg(not(windows))]
+fn wait_for_probe(
+    kind: ServiceKind,
+    port: u16,
+    expected_runtime_identity: Option<&serde_json::Value>,
+    expected_probe: Probe,
+) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if probe_on_port(kind, port, expected_runtime_identity) == expected_probe {
+            return;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    panic!("fixture on port {port} did not reach {expected_probe:?}");
+}
+
+#[test]
+fn stale_listener_process_must_match_loopx_command_and_port() {
+    let executable = "/fixture/bin/loopx";
+    assert!(is_expected_loopx_listener_command(
+        ServiceKind::Status,
+        executable,
+        8766,
+        "/usr/bin/python3 /fixture/bin/loopx serve-status --global-registry --host 127.0.0.1 --port 8766",
+    ));
+    assert!(is_expected_loopx_listener_command(
+        ServiceKind::Chat,
+        executable,
+        8767,
+        "/usr/bin/python3 -m loopx.cli chat --global-registry --host 127.0.0.1 --port=8767 --no-open",
+    ));
+    assert!(is_expected_loopx_listener_command(
+        ServiceKind::Status,
+        executable,
+        8766,
+        r#"/opt/loopx/bin/python -c import os\012import runpy\012release_root = os.environ["LOOPX_RELEASE_ROOT"]\012runpy.run_module("loopx.cli", run_name="__main__")\012 --registry /tmp/registry.json serve-status --global-registry --host 127.0.0.1 --port 8766 --limit 80"#,
+    ));
+    assert!(!is_expected_loopx_listener_command(
+        ServiceKind::Status,
+        executable,
+        8766,
+        "/tmp/not-loopx serve-status --port 8766",
+    ));
+    assert!(!is_expected_loopx_listener_command(
+        ServiceKind::Status,
+        executable,
+        8766,
+        "/tmp/not-loopx --config /fixture/bin/loopx serve-status --port 8766",
+    ));
+    assert!(!is_expected_loopx_listener_command(
+        ServiceKind::Status,
+        executable,
+        8766,
+        "/bin/sh -m loopx.cli serve-status --port 8766",
+    ));
+    assert!(!is_expected_loopx_listener_command(
+        ServiceKind::Status,
+        executable,
+        8766,
+        "/usr/bin/python3 /fixture/bin/loopx chat --port 8766",
+    ));
+    assert!(!is_expected_loopx_listener_command(
+        ServiceKind::Status,
+        executable,
+        8766,
+        "/usr/bin/python3 /fixture/bin/loopx serve-status --port 8767",
+    ));
+    assert!(!is_expected_loopx_listener_command(
+        ServiceKind::Status,
+        executable,
+        8766,
+        r#"/opt/loopx/bin/python -c runpy.run_module("other.cli", run_name="__main__") serve-status --port 8766"#,
+    ));
+}
+
+#[test]
+fn stale_listener_verification_rejects_the_entire_pid_set_on_mismatch() {
+    let executable = "/fixture/bin/loopx";
+    let confirmed = ListenerProcess {
+        pid: 11,
+        command_line: format!("{executable} serve-status --port 8766"),
+    };
+    assert_eq!(
+        verified_loopx_listener_pids(ServiceKind::Status, executable, 8766, &[confirmed])
+            .expect("confirmed LoopX listener"),
+        vec![11]
+    );
+
+    let mixed = [
+        ListenerProcess {
+            pid: 11,
+            command_line: format!("{executable} serve-status --port 8766"),
+        },
+        ListenerProcess {
+            pid: 12,
+            command_line: "foreign-server --port 8766".to_string(),
+        },
+    ];
+    let error = verified_loopx_listener_pids(ServiceKind::Status, executable, 8766, &mixed)
+        .expect_err("mixed ownership must fail closed");
+    assert!(error.to_string().contains("refusing to stop"));
+}
+
+#[cfg(not(windows))]
+#[test]
+fn service_supervisor_reuses_matching_replaces_stale_and_rejects_foreign() {
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock must follow the Unix epoch")
+        .as_nanos();
+    let fixture_root = env::temp_dir().join(format!(
+        "loopx-service-supervisor-{}-{unique}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&fixture_root).expect("create service supervisor fixture");
+    let current_identity = serde_json::json!({
+        "schema_version": "loopx_runtime_identity_v1",
+        "package_version": "0.5.1",
+        "release_id": "current-release",
+        "source_revision": "current-revision",
+    });
+
+    let matching_port = reserve_loopback_port();
+    let matching_executable = fixture_root.join("matching-loopx");
+    let matching_payload = serde_json::json!({
+        "source": "serve-status",
+        "runtime_identity": current_identity,
+    })
+    .to_string();
+    let mut matching = spawn_listener_fixture(
+        &matching_executable,
+        "serve-status",
+        matching_port,
+        &matching_payload,
+    );
+    wait_for_probe(
+        ServiceKind::Status,
+        matching_port,
+        Some(&current_identity),
+        Probe::Matching,
+    );
+    assert!(matching
+        .try_wait()
+        .expect("matching fixture status")
+        .is_none());
+    matching.kill().expect("stop matching fixture");
+    matching.wait().expect("reap matching fixture");
+
+    let stale_port = reserve_loopback_port();
+    let stale_executable = fixture_root.join("loopx");
+    let stale_payload = serde_json::json!({
+        "source": "serve-status",
+        "runtime_identity": {
+            "schema_version": "loopx_runtime_identity_v1",
+            "package_version": "0.5.0",
+            "release_id": "stale-release",
+            "source_revision": "stale-revision",
+        },
+    })
+    .to_string();
+    let mut stale = spawn_listener_fixture(
+        &stale_executable,
+        "serve-status",
+        stale_port,
+        &stale_payload,
+    );
+    wait_for_probe(
+        ServiceKind::Status,
+        stale_port,
+        Some(&current_identity),
+        Probe::Stale,
+    );
+    let stale_processes = listener_processes(stale_port).expect("inspect stale listener fixture");
+    assert!(
+        stale_processes
+            .iter()
+            .all(|process| is_expected_loopx_listener_command(
+                ServiceKind::Status,
+                stale_executable.to_string_lossy().as_ref(),
+                stale_port,
+                &process.command_line,
+            )),
+        "fixture process must classify as LoopX: {stale_processes:?}"
+    );
+    terminate_stale_listener(
+        ServiceKind::Status,
+        stale_executable.to_string_lossy().as_ref(),
+        stale_port,
+    )
+    .expect("replace confirmed stale LoopX listener");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline && stale.try_wait().expect("stale fixture status").is_none() {
+        thread::sleep(Duration::from_millis(50));
+    }
+    assert!(stale
+        .try_wait()
+        .expect("stale fixture final status")
+        .is_some());
+
+    let foreign_port = reserve_loopback_port();
+    let foreign_executable = fixture_root.join("foreign-server");
+    let mut foreign = spawn_listener_fixture(
+        &foreign_executable,
+        "serve-status",
+        foreign_port,
+        r#"{"source":"other"}"#,
+    );
+    wait_for_probe(
+        ServiceKind::Status,
+        foreign_port,
+        Some(&current_identity),
+        Probe::Foreign,
+    );
+    let error = terminate_stale_listener(
+        ServiceKind::Status,
+        stale_executable.to_string_lossy().as_ref(),
+        foreign_port,
+    )
+    .expect_err("foreign listener must be rejected");
+    assert!(error.to_string().contains("refusing to stop"));
+    assert!(foreign
+        .try_wait()
+        .expect("foreign fixture status")
+        .is_none());
+    foreign.kill().expect("stop foreign fixture");
+    foreign.wait().expect("reap foreign fixture");
+
+    fs::remove_dir_all(&fixture_root).expect("remove service supervisor fixture");
+}


### PR DESCRIPTION
## Summary

- fix the malformed lsof listener lookup that prevented desktop startup from replacing services left by an older installed release
- verify the exact LoopX service command and matching port, then recheck process ownership immediately before sending TERM
- fail closed for foreign or unconfirmed listeners and document the platform behavior

## Root cause

The previous auto-heal path invoked lsof with a split selector that lsof interpreted as a filesystem path. It therefore returned no listener PID, so increasing the startup retry window could never replace the stale service.

## Validation

- cargo fmt --check
- cargo test: 10 passed
- cargo clippy --all-targets -- -D warnings
- npm run typecheck:control-plane
- npm run test:control-plane: 117 passed
- tauri app bundle build
- packaged macOS cold start against old installed status and chat listeners; both ports moved to the selected current release without an error dialog
- LoopX premerge canary: 17 checks passed
- public boundary scan clean
- change-quality receipt cqr_1819b173d4542dd9844b

## Future-facing pass

Applied a bounded companion refactor at the existing desktop supervisor boundary: stale-listener discovery, ownership validation, and termination now share one typed fail-closed path. No broader lifecycle abstraction was added.