### PR TITLE
feat(periodic-report): promote durable runtime milestones

### DIFF
--- a/examples/periodic-report-runtime-producer-smoke.py
+++ b/examples/periodic-report-runtime-producer-smoke.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.periodic_report import (  # noqa: E402
+    build_periodic_report_run,
+    build_periodic_report_runtime_trigger_decision,
+)
+from loopx.rollout_event_log import build_rollout_event  # noqa: E402
+
+
+def main() -> None:
+    events = [
+        build_rollout_event(
+            goal_id="sample-long-goal",
+            event_kind="todo_complete",
+            todo_id=f"todo-{index}",
+            recorded_at=f"2026-08-{20 + index:02d}T09:00:00Z",
+        )
+        for index in range(3)
+    ]
+    decision = build_periodic_report_runtime_trigger_decision(
+        {
+            "schema_version": "periodic_report_runtime_trigger_request_v0",
+            "evaluated_at": "2026-08-24T12:00:00Z",
+            "goal_id": "sample-long-goal",
+            "profile": {"profile_id": "weekly_progress", "profile_version": "v1"},
+            "trigger_policy": {
+                "enabled_kinds": ["bounded_segment_milestone"],
+                "minimum_interval_seconds": 0,
+                "aggregation": {
+                    "window_seconds": 604800,
+                    "todo_completed_threshold": 3,
+                    "promote_replan": True,
+                },
+            },
+            "segment": {
+                "segment_ref": "week-2026-w34",
+                "start_at": "2026-08-18T12:00:00Z",
+                "end_at": "2026-08-24T12:00:00Z",
+                "remaining_todo_count": 8,
+            },
+        },
+        rollout_events=events,
+    )
+    run = build_periodic_report_run(
+        {
+            "schema_version": "periodic_report_run_request_v0",
+            "generated_at": "2026-08-24T12:05:00Z",
+            "period_window": {
+                "start_at": "2026-08-18T12:00:00Z",
+                "end_at": "2026-08-24T12:00:00Z",
+            },
+            "profile": {"profile_id": "weekly_progress", "profile_version": "v1"},
+            "trigger_receipt": decision,
+            "source_snapshots": [
+                {
+                    "source_id": "project_progress",
+                    "source_kind": "validated_project_progress",
+                    "status": "complete",
+                    "observed_at": "2026-08-24T12:00:00Z",
+                    "snapshot_digest": "sha256:sample-progress",
+                }
+            ],
+            "artifact_receipt": {
+                "artifact_id": "weekly_progress",
+                "renderer_id": "markdown_v0",
+                "renderer_kind": "markdown",
+                "status": "pending",
+            },
+            "sink_receipts": [
+                {
+                    "sink_id": "archive",
+                    "sink_kind": "resource_store",
+                    "sink_role": "archive",
+                    "status": "pending",
+                },
+                {
+                    "sink_id": "delivery",
+                    "sink_kind": "message_channel",
+                    "sink_role": "delivery",
+                    "status": "pending",
+                },
+            ],
+        }
+    )
+    assert decision["producer_receipt"]["status"] == "promoted"
+    assert run["trigger_receipt"]["report_kind"] == "milestone_update"
+    assert run["boundary"]["external_writes_performed"] is False
+    print("periodic-report-runtime-producer-smoke: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/periodic-report-runtime-producer-smoke.py
+++ b/examples/periodic-report-runtime-producer-smoke.py
@@ -8,8 +8,8 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
-from loopx.capabilities.periodic_report import (  # noqa: E402
-    build_periodic_report_run,
+from loopx.capabilities.periodic_report import build_periodic_report_run  # noqa: E402
+from loopx.capabilities.periodic_report.runtime_producer import (  # noqa: E402
     build_periodic_report_runtime_trigger_decision,
 )
 from loopx.rollout_event_log import build_rollout_event  # noqa: E402

--- a/loopx/capabilities/periodic_report/README.md
+++ b/loopx/capabilities/periodic_report/README.md
@@ -6,7 +6,7 @@ presentation, and destinations to profiles and adapters.
 
 | Surface | Value |
 | --- | --- |
-| CLI | `loopx periodic-report inspect-profile --preset weekly`, custom `--profile-json <path>`, `evaluate-trigger`, `compose-run`, and optional `archive-openviking` |
+| CLI | `loopx periodic-report inspect-profile --preset weekly`, custom `--profile-json <path>`, `evaluate-trigger`, `evaluate-runtime-trigger`, `compose-run`, and optional `archive-openviking` |
 | Protocol | [`periodic_report_v0`](../../../docs/reference/protocols/periodic-report-v0.md) |
 | Smokes | `python3 examples/periodic-report-smoke.py`, `periodic-report-profile-smoke.py`, `periodic-report-html-smoke.py`, `periodic-report-bindings-smoke.py`, and `openviking-periodic-report-extension-smoke.py` |
 
@@ -86,6 +86,16 @@ Profiles can enable trigger kinds and set a minimum interval; urgent outcome,
 closure, blocker, and manual triggers may bypass that interval. Concurrent
 material facts are coalesced into one report and previously covered trigger
 ids are deduplicated.
+
+An enabled custom profile may also declare `trigger_policy.aggregation` with a
+bounded `window_seconds`, an optional `todo_completed_threshold`, and
+`promote_replan`. The `evaluate-runtime-trigger` command reads the durable
+public-safe rollout event log supplied by the caller, deduplicates completed
+Todo ids, and promotes either the threshold crossing or a durable
+`autonomous_replan_recorded` refresh into the normal
+`bounded_segment_milestone` decision. The producer performs no provider call or
+external write; an eligible receipt continues through the existing
+`compose-run`, renderer, and separately authorized sink boundaries.
 
 Project-specific scheduled reports should be layered as profiles and adapters.
 For example, a maintenance profile may choose a local timezone and weekly

--- a/loopx/capabilities/periodic_report/README.md
+++ b/loopx/capabilities/periodic_report/README.md
@@ -96,6 +96,9 @@ Todo ids, and promotes either the threshold crossing or a durable
 `bounded_segment_milestone` decision. The producer performs no provider call or
 external write; an eligible receipt continues through the existing
 `compose-run`, renderer, and separately authorized sink boundaries.
+The CLI streams the append-only log and applies the 4,096-row capacity limit
+only after goal, segment-window, and relevant-kind filtering. Malformed durable
+rows and an oversized relevant window fail closed.
 
 Project-specific scheduled reports should be layered as profiles and adapters.
 For example, a maintenance profile may choose a local timezone and weekly

--- a/loopx/capabilities/periodic_report/__init__.py
+++ b/loopx/capabilities/periodic_report/__init__.py
@@ -24,10 +24,6 @@ from .bindings import (
     normalize_periodic_report_sink_bindings,
 )
 from .core import build_periodic_report_run
-from .profile import (
-    build_periodic_report_activation,
-    normalize_periodic_report_profile,
-)
 from .presets import (
     PERIODIC_REPORT_PROFILE_PRESET_ALIASES,
     PERIODIC_REPORT_PROFILE_PRESET_IDS,
@@ -35,11 +31,16 @@ from .presets import (
     build_periodic_report_preset_activation,
     resolve_periodic_report_profile_preset,
 )
+from .profile import (
+    build_periodic_report_activation,
+    normalize_periodic_report_profile,
+)
 from .project_progress import (
     PROJECT_PROGRESS_PROJECTION_SCHEMA,
     build_project_progress_periodic_report_source,
     project_progress_periodic_report_source_adapter,
 )
+from .runtime_producer import build_periodic_report_runtime_trigger_decision
 from .triggers import (
     build_periodic_report_trigger_decision,
     normalize_periodic_report_trigger_policy,
@@ -65,6 +66,7 @@ __all__ = [
     "build_project_progress_periodic_report_source",
     "build_periodic_report_archive_bundle",
     "build_periodic_report_run",
+    "build_periodic_report_runtime_trigger_decision",
     "build_periodic_report_source_result",
     "build_periodic_report_trigger_decision",
     "normalize_periodic_report_profile",

--- a/loopx/capabilities/periodic_report/__init__.py
+++ b/loopx/capabilities/periodic_report/__init__.py
@@ -40,7 +40,6 @@ from .project_progress import (
     build_project_progress_periodic_report_source,
     project_progress_periodic_report_source_adapter,
 )
-from .runtime_producer import build_periodic_report_runtime_trigger_decision
 from .triggers import (
     build_periodic_report_trigger_decision,
     normalize_periodic_report_trigger_policy,
@@ -66,7 +65,6 @@ __all__ = [
     "build_project_progress_periodic_report_source",
     "build_periodic_report_archive_bundle",
     "build_periodic_report_run",
-    "build_periodic_report_runtime_trigger_decision",
     "build_periodic_report_source_result",
     "build_periodic_report_trigger_decision",
     "normalize_periodic_report_profile",

--- a/loopx/capabilities/periodic_report/cli.py
+++ b/loopx/capabilities/periodic_report/cli.py
@@ -11,7 +11,7 @@ from typing import Any
 from ...extensions.runtime import (
     execute_extension_runtime_binding,
 )
-from ...rollout_event_log import load_rollout_events
+from ...rollout_event_log import iter_rollout_events
 from .core import build_periodic_report_run
 from .extension_envelope import build_openviking_archive_execution_envelope
 from .presets import (
@@ -319,8 +319,9 @@ def handle_periodic_report_command(
             request = _load_json_object(args.request_json)
             payload = build_periodic_report_runtime_trigger_decision(
                 request,
-                rollout_events=load_rollout_events(
-                    Path(args.rollout_events_jsonl).expanduser()
+                rollout_events=iter_rollout_events(
+                    Path(args.rollout_events_jsonl).expanduser(),
+                    strict=True,
                 ),
             )
         else:

--- a/loopx/capabilities/periodic_report/cli.py
+++ b/loopx/capabilities/periodic_report/cli.py
@@ -11,6 +11,7 @@ from typing import Any
 from ...extensions.runtime import (
     execute_extension_runtime_binding,
 )
+from ...rollout_event_log import load_rollout_events
 from .core import build_periodic_report_run
 from .extension_envelope import build_openviking_archive_execution_envelope
 from .presets import (
@@ -18,6 +19,7 @@ from .presets import (
     build_periodic_report_preset_activation,
 )
 from .profile import build_periodic_report_activation
+from .runtime_producer import build_periodic_report_runtime_trigger_decision
 from .triggers import build_periodic_report_trigger_decision
 
 PrintPayload = Callable[
@@ -73,6 +75,21 @@ def register_periodic_report_commands(
         "--request-json",
         required=True,
         help="Path to periodic_report_trigger_request_v0 JSON; use '-' for stdin.",
+    )
+    evaluate_runtime = commands.add_parser(
+        "evaluate-runtime-trigger",
+        help="Promote durable rollout events into a periodic-report trigger.",
+    )
+    add_subcommand_format(evaluate_runtime)
+    evaluate_runtime.add_argument(
+        "--request-json",
+        required=True,
+        help="Path to periodic_report_runtime_trigger_request_v0 JSON.",
+    )
+    evaluate_runtime.add_argument(
+        "--rollout-events-jsonl",
+        required=True,
+        help="Durable LoopX rollout-event-log.jsonl to evaluate.",
     )
     inspect_profile = commands.add_parser(
         "inspect-profile",
@@ -298,6 +315,14 @@ def handle_periodic_report_command(
         elif args.periodic_report_command == "evaluate-trigger":
             request = _load_json_object(args.request_json)
             payload = build_periodic_report_trigger_decision(request)
+        elif args.periodic_report_command == "evaluate-runtime-trigger":
+            request = _load_json_object(args.request_json)
+            payload = build_periodic_report_runtime_trigger_decision(
+                request,
+                rollout_events=load_rollout_events(
+                    Path(args.rollout_events_jsonl).expanduser()
+                ),
+            )
         else:
             request = _load_json_object(args.request_json)
             payload = build_periodic_report_run(request)

--- a/loopx/capabilities/periodic_report/core.py
+++ b/loopx/capabilities/periodic_report/core.py
@@ -326,6 +326,39 @@ def _normalize_trigger_receipt(raw: object) -> dict[str, Any] | None:
             maximum=31 * 24 * 60 * 60,
         ),
     }
+    if raw_policy.get("aggregation") is not None:
+        raw_aggregation = _object(
+            raw_policy.get("aggregation"),
+            "trigger_receipt.trigger_policy.aggregation",
+        )
+        aggregation: dict[str, Any] = {
+            "window_seconds": _integer(
+                raw_aggregation.get("window_seconds"),
+                "trigger_receipt.trigger_policy.aggregation.window_seconds",
+                minimum=1,
+                maximum=31 * 24 * 60 * 60,
+            ),
+            "promote_replan": _boolean(
+                raw_aggregation.get("promote_replan"),
+                "trigger_receipt.trigger_policy.aggregation.promote_replan",
+            ),
+        }
+        if raw_aggregation.get("todo_completed_threshold") is not None:
+            aggregation["todo_completed_threshold"] = _integer(
+                raw_aggregation.get("todo_completed_threshold"),
+                "trigger_receipt.trigger_policy.aggregation.todo_completed_threshold",
+                minimum=1,
+                maximum=64,
+            )
+        if (
+            "todo_completed_threshold" not in aggregation
+            and not aggregation["promote_replan"]
+        ):
+            raise ValueError(
+                "trigger_receipt.trigger_policy.aggregation must enable "
+                "a todo threshold or replan promotion"
+            )
+        trigger_policy["aggregation"] = aggregation
     expected_report_key = _digest(
         {
             "profile": profile,

--- a/loopx/capabilities/periodic_report/runtime_producer.py
+++ b/loopx/capabilities/periodic_report/runtime_producer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from datetime import datetime
 from typing import Any
 
@@ -23,6 +23,7 @@ from .triggers import (
 
 RUNTIME_TRIGGER_REQUEST_SCHEMA = "periodic_report_runtime_trigger_request_v0"
 RUNTIME_PRODUCER_RECEIPT_SCHEMA = "periodic_report_runtime_producer_v0"
+_MAX_RELEVANT_ROLLOUT_EVENTS = 4096
 
 _SAFE_BOUNDARY_FIELDS = (
     "raw_task_text_recorded",
@@ -51,28 +52,23 @@ def _safe_durable_event(
     raw: Mapping[str, Any],
     *,
     goal_id: str,
-    start_at: str,
-    end_at: str,
+    window_start: datetime,
+    window_end: datetime,
     index: int,
 ) -> dict[str, Any] | None:
     label = f"rollout_events[{index}]"
     event = _object(raw, label)
     if event.get("schema_version") != ROLLOUT_EVENT_SCHEMA_VERSION:
         raise ValueError(f"{label} must use {ROLLOUT_EVENT_SCHEMA_VERSION}")
-    event_goal_id = _token(event.get("goal_id"), f"{label}.goal_id")
-    if event_goal_id != goal_id:
-        raise ValueError(f"{label}.goal_id must match request.goal_id")
-    event_id = _text(event.get("event_id"), f"{label}.event_id", maximum=128)
-    recorded_at = _timestamp(event.get("recorded_at"), f"{label}.recorded_at")
-    if not (
-        _parsed_timestamp(start_at)
-        <= _parsed_timestamp(recorded_at)
-        <= _parsed_timestamp(end_at)
-    ):
+    if event.get("goal_id") != goal_id:
         return None
     kind = str(event.get("event_kind") or "").strip()
     if kind not in {"todo_complete", "refresh_state"}:
         return None
+    recorded_at = _timestamp(event.get("recorded_at"), f"{label}.recorded_at")
+    if not window_start <= _parsed_timestamp(recorded_at) <= window_end:
+        return None
+    event_id = _text(event.get("event_id"), f"{label}.event_id", maximum=128)
     boundary = _object(event.get("boundary"), f"{label}.boundary")
     if any(boundary.get(field) is not False for field in _SAFE_BOUNDARY_FIELDS):
         raise ValueError(f"{label}.boundary does not prove a public-safe event")
@@ -93,7 +89,7 @@ def _safe_durable_event(
 def build_periodic_report_runtime_trigger_decision(
     request: Mapping[str, Any],
     *,
-    rollout_events: Sequence[Mapping[str, Any]],
+    rollout_events: Iterable[Mapping[str, Any]],
 ) -> dict[str, Any]:
     """Promote durable control-plane events into one normal trigger decision.
 
@@ -133,13 +129,13 @@ def build_periodic_report_runtime_trigger_decision(
     segment_ref = _token(segment.get("segment_ref"), "segment.segment_ref")
     start_at = _timestamp(segment.get("start_at"), "segment.start_at")
     end_at = _timestamp(segment.get("end_at"), "segment.end_at")
-    if _parsed_timestamp(start_at) >= _parsed_timestamp(end_at):
+    window_start = _parsed_timestamp(start_at)
+    window_end = _parsed_timestamp(end_at)
+    if window_start >= window_end:
         raise ValueError("segment.start_at must be earlier than segment.end_at")
     if end_at != evaluated_at:
         raise ValueError("segment.end_at must match evaluated_at")
-    duration = int(
-        (_parsed_timestamp(end_at) - _parsed_timestamp(start_at)).total_seconds()
-    )
+    duration = int((window_end - window_start).total_seconds())
     if duration > int(aggregation["window_seconds"]):
         raise ValueError("segment window exceeds trigger_policy.aggregation.window_seconds")
     remaining_todo_count = _integer(
@@ -147,24 +143,28 @@ def build_periodic_report_runtime_trigger_decision(
         "segment.remaining_todo_count",
         maximum=1_000_000,
     )
-    if isinstance(rollout_events, (str, bytes)):
-        raise ValueError("rollout_events must be a bounded object list")
-    values = list(rollout_events)
-    if len(values) > 4096:
-        raise ValueError("rollout_events must contain at most 4096 items")
+    if isinstance(rollout_events, (str, bytes, Mapping)):
+        raise ValueError("rollout_events must be an iterable of objects")
 
     relevant: list[dict[str, Any]] = []
+    relevant_count = 0
     seen_event_ids: set[str] = set()
-    for index, raw_event in enumerate(values):
+    for index, raw_event in enumerate(rollout_events):
         event = _safe_durable_event(
             raw_event,
             goal_id=goal_id,
-            start_at=start_at,
-            end_at=end_at,
+            window_start=window_start,
+            window_end=window_end,
             index=index,
         )
         if event is None:
             continue
+        relevant_count += 1
+        if relevant_count > _MAX_RELEVANT_ROLLOUT_EVENTS:
+            raise ValueError(
+                "rollout_events must contain at most "
+                f"{_MAX_RELEVANT_ROLLOUT_EVENTS} relevant window items"
+            )
         event_id = str(event["event_id"])
         if event_id in seen_event_ids:
             continue

--- a/loopx/capabilities/periodic_report/runtime_producer.py
+++ b/loopx/capabilities/periodic_report/runtime_producer.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from typing import Any
+
+from ...rollout_event_log import ROLLOUT_EVENT_SCHEMA_VERSION
+from .core import (
+    _integer,
+    _object,
+    _reject_raw_keys,
+    _text,
+    _timestamp,
+    _token,
+)
+from .triggers import (
+    build_periodic_report_trigger_decision,
+    normalize_periodic_report_trigger_policy,
+)
+
+
+RUNTIME_TRIGGER_REQUEST_SCHEMA = "periodic_report_runtime_trigger_request_v0"
+RUNTIME_PRODUCER_RECEIPT_SCHEMA = "periodic_report_runtime_producer_v0"
+
+_SAFE_BOUNDARY_FIELDS = (
+    "raw_task_text_recorded",
+    "raw_logs_recorded",
+    "raw_trajectory_recorded",
+    "raw_session_transcript_recorded",
+    "credential_values_recorded",
+    "absolute_paths_recorded",
+)
+
+
+def _parsed_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _event_digest(event_ids: Sequence[str]) -> str:
+    encoded = json.dumps(
+        sorted(event_ids),
+        ensure_ascii=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _safe_durable_event(
+    raw: Mapping[str, Any],
+    *,
+    goal_id: str,
+    start_at: str,
+    end_at: str,
+    index: int,
+) -> dict[str, Any] | None:
+    label = f"rollout_events[{index}]"
+    event = _object(raw, label)
+    if event.get("schema_version") != ROLLOUT_EVENT_SCHEMA_VERSION:
+        raise ValueError(f"{label} must use {ROLLOUT_EVENT_SCHEMA_VERSION}")
+    event_goal_id = _token(event.get("goal_id"), f"{label}.goal_id")
+    if event_goal_id != goal_id:
+        raise ValueError(f"{label}.goal_id must match request.goal_id")
+    event_id = _text(event.get("event_id"), f"{label}.event_id", maximum=128)
+    recorded_at = _timestamp(event.get("recorded_at"), f"{label}.recorded_at")
+    if not (
+        _parsed_timestamp(start_at)
+        <= _parsed_timestamp(recorded_at)
+        <= _parsed_timestamp(end_at)
+    ):
+        return None
+    kind = str(event.get("event_kind") or "").strip()
+    if kind not in {"todo_complete", "refresh_state"}:
+        return None
+    boundary = _object(event.get("boundary"), f"{label}.boundary")
+    if any(boundary.get(field) is not False for field in _SAFE_BOUNDARY_FIELDS):
+        raise ValueError(f"{label}.boundary does not prove a public-safe event")
+    details = (
+        dict(event["details"])
+        if isinstance(event.get("details"), Mapping)
+        else {}
+    )
+    return {
+        "event_id": event_id,
+        "event_kind": kind,
+        "recorded_at": recorded_at,
+        "todo_id": str(event.get("todo_id") or "").strip() or None,
+        "replan_recorded": details.get("autonomous_replan_recorded") is True,
+    }
+
+
+def build_periodic_report_runtime_trigger_decision(
+    request: Mapping[str, Any],
+    *,
+    rollout_events: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Promote durable control-plane events into one normal trigger decision.
+
+    This is the provider-neutral post-writeback producer seam. It reads no files
+    and performs no writes; the CLI adapter supplies events read from the durable
+    rollout log, then the existing trigger decision remains authoritative.
+    """
+
+    payload = _object(request, "request")
+    _reject_raw_keys(payload, "request")
+    unknown = sorted(
+        set(payload)
+        - {
+            "schema_version",
+            "evaluated_at",
+            "goal_id",
+            "profile",
+            "trigger_policy",
+            "segment",
+            "last_report",
+        }
+    )
+    if unknown:
+        raise ValueError("request contains unsupported fields: " + ", ".join(unknown))
+    if payload.get("schema_version") != RUNTIME_TRIGGER_REQUEST_SCHEMA:
+        raise ValueError(f"schema_version must be {RUNTIME_TRIGGER_REQUEST_SCHEMA!r}")
+    evaluated_at = _timestamp(payload.get("evaluated_at"), "evaluated_at")
+    goal_id = _token(payload.get("goal_id"), "goal_id")
+    policy = normalize_periodic_report_trigger_policy(
+        payload.get("trigger_policy", {})
+    )
+    aggregation = policy.get("aggregation")
+    if not isinstance(aggregation, Mapping):
+        raise ValueError("trigger_policy.aggregation is required for runtime promotion")
+
+    segment = _object(payload.get("segment"), "segment")
+    segment_ref = _token(segment.get("segment_ref"), "segment.segment_ref")
+    start_at = _timestamp(segment.get("start_at"), "segment.start_at")
+    end_at = _timestamp(segment.get("end_at"), "segment.end_at")
+    if _parsed_timestamp(start_at) >= _parsed_timestamp(end_at):
+        raise ValueError("segment.start_at must be earlier than segment.end_at")
+    if end_at != evaluated_at:
+        raise ValueError("segment.end_at must match evaluated_at")
+    duration = int(
+        (_parsed_timestamp(end_at) - _parsed_timestamp(start_at)).total_seconds()
+    )
+    if duration > int(aggregation["window_seconds"]):
+        raise ValueError("segment window exceeds trigger_policy.aggregation.window_seconds")
+    remaining_todo_count = _integer(
+        segment.get("remaining_todo_count"),
+        "segment.remaining_todo_count",
+        maximum=1_000_000,
+    )
+    if isinstance(rollout_events, (str, bytes)):
+        raise ValueError("rollout_events must be a bounded object list")
+    values = list(rollout_events)
+    if len(values) > 4096:
+        raise ValueError("rollout_events must contain at most 4096 items")
+
+    relevant: list[dict[str, Any]] = []
+    seen_event_ids: set[str] = set()
+    for index, raw_event in enumerate(values):
+        event = _safe_durable_event(
+            raw_event,
+            goal_id=goal_id,
+            start_at=start_at,
+            end_at=end_at,
+            index=index,
+        )
+        if event is None:
+            continue
+        event_id = str(event["event_id"])
+        if event_id in seen_event_ids:
+            continue
+        seen_event_ids.add(event_id)
+        relevant.append(event)
+    relevant.sort(key=lambda item: (item["recorded_at"], item["event_id"]))
+
+    completions: list[dict[str, Any]] = []
+    seen_completion_keys: set[str] = set()
+    replans: list[dict[str, Any]] = []
+    for event in relevant:
+        if event["event_kind"] == "todo_complete":
+            completion_key = str(event.get("todo_id") or event["event_id"])
+            if completion_key not in seen_completion_keys:
+                seen_completion_keys.add(completion_key)
+                completions.append(event)
+        elif event["replan_recorded"]:
+            replans.append(event)
+
+    transition: str | None = None
+    contributing: list[dict[str, Any]] = []
+    delivered_count = 0
+    if aggregation["promote_replan"] and replans:
+        boundary_event = replans[0]
+        transition = "replan_entered"
+        contributing = [boundary_event]
+        delivered_count = sum(
+            event["recorded_at"] <= boundary_event["recorded_at"]
+            for event in completions
+        )
+    else:
+        threshold = aggregation.get("todo_completed_threshold")
+        if threshold is not None and len(completions) >= int(threshold):
+            transition = "segment_completed"
+            contributing = completions[: int(threshold)]
+            delivered_count = int(threshold)
+
+    source_ref = f"rollout-window:{goal_id}:{segment_ref}"
+    if transition:
+        evidence_ids = [str(event["event_id"]) for event in contributing]
+        candidate = {
+            "trigger_kind": "bounded_segment_milestone",
+            "observed_at": str(contributing[-1]["recorded_at"]),
+            "source_ref": source_ref,
+            "evidence_digest": _event_digest(evidence_ids),
+            "facts": {
+                "segment_ref": segment_ref,
+                "transition": transition,
+                "delivered_count": delivered_count,
+                "remaining_todo_count": remaining_todo_count,
+                "durable_writeback": True,
+            },
+        }
+        status = "promoted"
+        reason = (
+            "durable_replan_observed"
+            if transition == "replan_entered"
+            else "todo_completion_threshold_reached"
+        )
+    else:
+        evidence_ids = [str(event["event_id"]) for event in relevant]
+        candidate = {
+            "trigger_kind": "state_refreshed",
+            "observed_at": end_at,
+            "source_ref": source_ref,
+            "evidence_digest": _event_digest(evidence_ids or [segment_ref]),
+            "facts": {},
+        }
+        status = "not_promoted"
+        reason = "promotion_conditions_not_met"
+
+    trigger_request: dict[str, Any] = {
+        "schema_version": "periodic_report_trigger_request_v0",
+        "evaluated_at": evaluated_at,
+        "profile": payload.get("profile"),
+        "trigger_policy": policy,
+        "candidates": [candidate],
+    }
+    if payload.get("last_report") is not None:
+        trigger_request["last_report"] = payload["last_report"]
+    decision = build_periodic_report_trigger_decision(trigger_request)
+    decision["producer_receipt"] = {
+        "schema_version": RUNTIME_PRODUCER_RECEIPT_SCHEMA,
+        "status": status,
+        "reason": reason,
+        "goal_id": goal_id,
+        "segment_ref": segment_ref,
+        "window": {"start_at": start_at, "end_at": end_at},
+        "todo_completed_count": len(completions),
+        "replan_event_count": len(replans),
+        "contributing_event_ids": evidence_ids,
+        "transition": transition,
+        "boundary": {
+            "durable_rollout_events_required": True,
+            "provider_neutral": True,
+            "external_writes_performed": False,
+            "raw_content_persisted": False,
+        },
+    }
+    return decision

--- a/loopx/capabilities/periodic_report/triggers.py
+++ b/loopx/capabilities/periodic_report/triggers.py
@@ -94,7 +94,7 @@ def _normalize_policy(raw: object) -> dict[str, Any]:
             enabled.append(kind)
     if not enabled:
         raise ValueError("trigger_policy.enabled_kinds must not be empty")
-    return {
+    normalized: dict[str, Any] = {
         "enabled_kinds": sorted(enabled),
         "minimum_interval_seconds": _integer(
             policy.get("minimum_interval_seconds", 0),
@@ -102,6 +102,44 @@ def _normalize_policy(raw: object) -> dict[str, Any]:
             maximum=31 * 24 * 60 * 60,
         ),
     }
+    if policy.get("aggregation") is not None:
+        aggregation = _object(policy.get("aggregation"), "trigger_policy.aggregation")
+        _reject_unknown_facts(
+            aggregation,
+            allowed={
+                "promote_replan",
+                "todo_completed_threshold",
+                "window_seconds",
+            },
+            label="trigger_policy.aggregation",
+        )
+        threshold = aggregation.get("todo_completed_threshold")
+        promote_replan = _boolean(
+            aggregation.get("promote_replan", False),
+            "trigger_policy.aggregation.promote_replan",
+        )
+        normalized_aggregation: dict[str, Any] = {
+            "window_seconds": _integer(
+                aggregation.get("window_seconds", 7 * 24 * 60 * 60),
+                "trigger_policy.aggregation.window_seconds",
+                minimum=1,
+                maximum=31 * 24 * 60 * 60,
+            ),
+            "promote_replan": promote_replan,
+        }
+        if threshold is not None:
+            normalized_aggregation["todo_completed_threshold"] = _integer(
+                threshold,
+                "trigger_policy.aggregation.todo_completed_threshold",
+                minimum=1,
+                maximum=64,
+            )
+        if threshold is None and not promote_replan:
+            raise ValueError(
+                "trigger_policy.aggregation must enable a todo threshold or replan promotion"
+            )
+        normalized["aggregation"] = normalized_aggregation
+    return normalized
 
 
 def normalize_periodic_report_trigger_policy(raw: object) -> dict[str, Any]:

--- a/loopx/rollout_event_log.py
+++ b/loopx/rollout_event_log.py
@@ -5,7 +5,7 @@ import json
 from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any, Iterable, Iterator, Mapping, Sequence
 
 from .file_lock import exclusive_file_lock
 
@@ -432,23 +432,47 @@ def append_rollout_event_once(
     return payload, True
 
 
-def load_rollout_events(log_path: Path, *, limit: int | None = None) -> list[dict[str, Any]]:
+def iter_rollout_events(
+    log_path: Path,
+    *,
+    strict: bool = False,
+) -> Iterator[dict[str, Any]]:
     try:
-        lines = log_path.read_text(encoding="utf-8").splitlines()
+        handle = log_path.open(encoding="utf-8")
     except OSError:
-        return []
+        return
+    with handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError:
+                if strict:
+                    raise ValueError(
+                        f"rollout event log line {line_number} must contain valid JSON"
+                    ) from None
+                continue
+            if not isinstance(parsed, dict):
+                if strict:
+                    raise ValueError(
+                        f"rollout event log line {line_number} must contain an object"
+                    )
+                continue
+            if parsed.get("schema_version") != ROLLOUT_EVENT_SCHEMA_VERSION:
+                if strict:
+                    raise ValueError(
+                        f"rollout event log line {line_number} must use "
+                        f"{ROLLOUT_EVENT_SCHEMA_VERSION}"
+                    )
+                continue
+            yield parsed
+
+
+def load_rollout_events(log_path: Path, *, limit: int | None = None) -> list[dict[str, Any]]:
+    events = list(iter_rollout_events(log_path))
     if limit is not None:
-        lines = lines[-max(0, limit) :]
-    events: list[dict[str, Any]] = []
-    for line in lines:
-        if not line.strip():
-            continue
-        try:
-            parsed = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if isinstance(parsed, dict) and parsed.get("schema_version") == ROLLOUT_EVENT_SCHEMA_VERSION:
-            events.append(parsed)
+        events = events[-max(0, limit) :]
     return events
 
 

--- a/tests/capabilities/test_periodic_report_runtime_producer.py
+++ b/tests/capabilities/test_periodic_report_runtime_producer.py
@@ -204,3 +204,87 @@ def test_runtime_producer_cli_reads_durable_rollout_log(tmp_path, capsys) -> Non
     payload = json.loads(capsys.readouterr().out)
     assert payload["eligible"] is True
     assert payload["producer_receipt"]["status"] == "promoted"
+
+
+def test_runtime_producer_cli_streams_large_history_before_bounded_window(
+    tmp_path, capsys
+) -> None:
+    request_path = tmp_path / "request.json"
+    event_log = tmp_path / "rollout-event-log.jsonl"
+    request_path.write_text(json.dumps(_request(threshold=1)), encoding="utf-8")
+    old_event = _event(
+        "quota_should_run",
+        event_at="2026-08-17T09:00:00Z",
+    )
+    current_event = _event(
+        "todo_complete",
+        event_at="2026-08-20T09:00:00Z",
+        todo_id="todo-current",
+    )
+    rows = [
+        json.dumps({**old_event, "event_id": f"old-{index}"})
+        for index in range(4096)
+    ]
+    rows.append(json.dumps(current_event))
+    event_log.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+    assert main(
+        [
+            "--format",
+            "json",
+            "periodic-report",
+            "evaluate-runtime-trigger",
+            "--request-json",
+            str(request_path),
+            "--rollout-events-jsonl",
+            str(event_log),
+        ]
+    ) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["eligible"] is True
+    assert payload["producer_receipt"]["todo_completed_count"] == 1
+
+
+def test_runtime_producer_rejects_relevant_window_over_capacity() -> None:
+    event = _event(
+        "todo_complete",
+        event_at="2026-08-20T09:00:00Z",
+        todo_id="todo-template",
+    )
+    events = (
+        {
+            **event,
+            "event_id": f"current-{index}",
+            "todo_id": f"todo-{index}",
+        }
+        for index in range(4097)
+    )
+
+    with pytest.raises(ValueError, match="4096 relevant window items"):
+        build_periodic_report_runtime_trigger_decision(
+            _request(threshold=1),
+            rollout_events=events,
+        )
+
+
+def test_runtime_producer_cli_rejects_malformed_durable_row(tmp_path, capsys) -> None:
+    request_path = tmp_path / "request.json"
+    event_log = tmp_path / "rollout-event-log.jsonl"
+    request_path.write_text(json.dumps(_request(threshold=1)), encoding="utf-8")
+    event_log.write_text("{not-json}\n", encoding="utf-8")
+
+    assert main(
+        [
+            "--format",
+            "json",
+            "periodic-report",
+            "evaluate-runtime-trigger",
+            "--request-json",
+            str(request_path),
+            "--rollout-events-jsonl",
+            str(event_log),
+        ]
+    ) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["error"] == "rollout event log line 1 must contain valid JSON"

--- a/tests/capabilities/test_periodic_report_runtime_producer.py
+++ b/tests/capabilities/test_periodic_report_runtime_producer.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from loopx.capabilities.periodic_report import (
+    build_periodic_report_run,
+    build_periodic_report_runtime_trigger_decision,
+)
+from loopx.cli import main
+from loopx.rollout_event_log import append_rollout_event, build_rollout_event
+
+
+def _request(*, threshold: int = 2, promote_replan: bool = True) -> dict[str, object]:
+    return {
+        "schema_version": "periodic_report_runtime_trigger_request_v0",
+        "evaluated_at": "2026-08-24T12:00:00Z",
+        "goal_id": "long-research",
+        "profile": {
+            "profile_id": "weekly_progress",
+            "profile_version": "v1",
+        },
+        "trigger_policy": {
+            "enabled_kinds": ["bounded_segment_milestone"],
+            "minimum_interval_seconds": 0,
+            "aggregation": {
+                "window_seconds": 604800,
+                "todo_completed_threshold": threshold,
+                "promote_replan": promote_replan,
+            },
+        },
+        "segment": {
+            "segment_ref": "week-2026-w34",
+            "start_at": "2026-08-18T12:00:00Z",
+            "end_at": "2026-08-24T12:00:00Z",
+            "remaining_todo_count": 12,
+        },
+    }
+
+
+def _event(
+    kind: str,
+    *,
+    event_at: str,
+    todo_id: str | None = None,
+    replan: bool = False,
+) -> dict[str, object]:
+    return build_rollout_event(
+        goal_id="long-research",
+        event_kind=kind,
+        todo_id=todo_id,
+        recorded_at=event_at,
+        details={"autonomous_replan_recorded": replan},
+    )
+
+
+def _run_request(trigger: dict[str, object]) -> dict[str, object]:
+    return {
+        "schema_version": "periodic_report_run_request_v0",
+        "generated_at": "2026-08-24T12:05:00Z",
+        "period_window": {
+            "start_at": "2026-08-18T12:00:00Z",
+            "end_at": "2026-08-24T12:00:00Z",
+        },
+        "profile": {
+            "profile_id": "weekly_progress",
+            "profile_version": "v1",
+        },
+        "trigger_receipt": trigger,
+        "source_snapshots": [
+            {
+                "source_id": "project_progress",
+                "source_kind": "validated_project_progress",
+                "status": "complete",
+                "observed_at": "2026-08-24T12:00:00Z",
+                "snapshot_digest": "sha256:progress",
+            }
+        ],
+        "artifact_receipt": {
+            "artifact_id": "weekly_progress",
+            "renderer_id": "markdown_v0",
+            "renderer_kind": "markdown",
+            "status": "pending",
+        },
+        "sink_receipts": [
+            {
+                "sink_id": "archive",
+                "sink_kind": "resource_store",
+                "sink_role": "archive",
+                "status": "pending",
+            },
+            {
+                "sink_id": "delivery",
+                "sink_kind": "message_channel",
+                "sink_role": "delivery",
+                "status": "pending",
+            },
+        ],
+    }
+
+
+def test_todo_threshold_promotes_durable_window_and_composes_run() -> None:
+    events = [
+        _event("todo_complete", event_at="2026-08-20T09:00:00Z", todo_id="todo-a"),
+        _event("todo_complete", event_at="2026-08-21T09:00:00Z", todo_id="todo-b"),
+        _event("todo_complete", event_at="2026-08-22T09:00:00Z", todo_id="todo-c"),
+    ]
+
+    decision = build_periodic_report_runtime_trigger_decision(
+        _request(), rollout_events=events
+    )
+    run = build_periodic_report_run(_run_request(decision))
+
+    assert decision["eligible"] is True
+    assert decision["selected_trigger_kind"] == "bounded_segment_milestone"
+    assert decision["producer_receipt"]["reason"] == "todo_completion_threshold_reached"
+    assert len(decision["producer_receipt"]["contributing_event_ids"]) == 2
+    assert run["trigger_receipt"]["trigger_policy"]["aggregation"] == {
+        "window_seconds": 604800,
+        "promote_replan": True,
+        "todo_completed_threshold": 2,
+    }
+
+
+def test_durable_replan_precedes_threshold_and_deduplicates_todos() -> None:
+    duplicate = _event(
+        "todo_complete", event_at="2026-08-20T09:00:00Z", todo_id="todo-a"
+    )
+    events = [
+        duplicate,
+        dict(duplicate),
+        _event(
+            "refresh_state",
+            event_at="2026-08-21T10:00:00Z",
+            replan=True,
+        ),
+    ]
+
+    decision = build_periodic_report_runtime_trigger_decision(
+        _request(threshold=4), rollout_events=events
+    )
+
+    assert decision["eligible"] is True
+    assert decision["producer_receipt"]["transition"] == "replan_entered"
+    assert decision["producer_receipt"]["todo_completed_count"] == 1
+    assert decision["producer_receipt"]["replan_event_count"] == 1
+
+
+def test_below_threshold_stays_non_reportable() -> None:
+    decision = build_periodic_report_runtime_trigger_decision(
+        _request(threshold=3, promote_replan=False),
+        rollout_events=[
+            _event(
+                "todo_complete",
+                event_at="2026-08-20T09:00:00Z",
+                todo_id="todo-a",
+            )
+        ],
+    )
+
+    assert decision["eligible"] is False
+    assert decision["producer_receipt"]["status"] == "not_promoted"
+    assert decision["suppressed_triggers"][0]["trigger_kind"] == "state_refreshed"
+
+
+def test_runtime_producer_rejects_unproven_public_boundary() -> None:
+    event = _event(
+        "todo_complete", event_at="2026-08-20T09:00:00Z", todo_id="todo-a"
+    )
+    event["boundary"]["raw_logs_recorded"] = True
+
+    with pytest.raises(ValueError, match="public-safe event"):
+        build_periodic_report_runtime_trigger_decision(
+            _request(threshold=1), rollout_events=[event]
+        )
+
+
+def test_runtime_producer_cli_reads_durable_rollout_log(tmp_path, capsys) -> None:
+    request_path = tmp_path / "request.json"
+    event_log = tmp_path / "rollout-event-log.jsonl"
+    request_path.write_text(json.dumps(_request(threshold=1)), encoding="utf-8")
+    append_rollout_event(
+        event_log,
+        _event(
+            "todo_complete",
+            event_at="2026-08-20T09:00:00Z",
+            todo_id="todo-a",
+        ),
+    )
+
+    assert main(
+        [
+            "--format",
+            "json",
+            "periodic-report",
+            "evaluate-runtime-trigger",
+            "--request-json",
+            str(request_path),
+            "--rollout-events-jsonl",
+            str(event_log),
+        ]
+    ) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["eligible"] is True
+    assert payload["producer_receipt"]["status"] == "promoted"

--- a/tests/capabilities/test_periodic_report_runtime_producer.py
+++ b/tests/capabilities/test_periodic_report_runtime_producer.py
@@ -4,8 +4,8 @@ import json
 
 import pytest
 
-from loopx.capabilities.periodic_report import (
-    build_periodic_report_run,
+from loopx.capabilities.periodic_report import build_periodic_report_run
+from loopx.capabilities.periodic_report.runtime_producer import (
     build_periodic_report_runtime_trigger_decision,
 )
 from loopx.cli import main


### PR DESCRIPTION
## Summary

- add a provider-neutral runtime producer that consumes a bounded, durable rollout-event window
- promote deduplicated `todo_complete` thresholds or durable `autonomous_replan_recorded` refreshes into the existing `bounded_segment_milestone` trigger path
- add `periodic-report evaluate-runtime-trigger`, preserve aggregation identity through `compose-run`, and document the capability boundary
- keep provider calls and external writes outside the producer; renderer/sink authority remains unchanged

## Why

This is the minimal producer follow-up discussed after #3527 and advances the remaining automatic-promotion work in #3479. It opens one narrow post-writeback seam without coupling the execution loop to a report provider or delivery destination.

## Boundary / non-goals

- the caller supplies the durable public-safe rollout-event log and bounded segment
- the producer validates the window, public-safe boundary, goal identity, and aggregation limits
- this PR does not register a scheduler or perform renderer/sink effects

## Validation

- `122 passed` across periodic-report capability, presentation, and extension tests
- runtime producer smoke passed
- Python syntax, Ruff E/F checks, secret scan, and `git diff --check` passed

Signed-off-by: cmyk-labs <263870852+cmyk-labs@users.noreply.github.com>