### PR TITLE
Recover extension doctor readiness across LoopX releases

### DIFF
--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -279,6 +279,18 @@ loopx extension enable openviking-semantic-preference --execute --format json
 loopx extension install --bundled loopx-lark --execute --format json
 ```
 
+After an install, update, or rollback changes the active LoopX release,
+revalidate all enabled extension runtimes as one bounded read-only batch:
+
+```bash
+loopx extension doctor --all-enabled --execute --format json
+```
+
+The local installer runs this batch automatically. A passing doctor refreshes
+only the local runtime-identity proof; it grants no new provider permission and
+performs no connector write. Failed providers remain fail closed and the batch
+names the exact repair command.
+
 For a separately distributed provider, pass `--manifest <extension.toml>`.
 `upgrade` validates and probes the new manifest before changing the active
 revision. `rollback` probes the previous revision before switching back. A
@@ -524,10 +536,11 @@ authorization.
 `disable` is reversible, but `enable` never trusts an earlier readiness result:
 it reruns the configured doctor and changes the enabled bit only after that
 probe succeeds. A successful doctor binds readiness to both the active manifest
-revision and the resolved runtime identity. Missing or replaced executables,
-interpreters, or Python module sources fail closed until a new executed doctor
-succeeds; a failed executed doctor clears the stale proof without switching
-revisions.
+revision and a content-addressed runtime identity. Moving an unchanged release
+to a new install root, inode, or equivalent interpreter path preserves that
+identity; changed executable, interpreter, or Python module content fails closed
+until a new executed doctor succeeds. A failed executed doctor clears the stale
+proof without switching revisions.
 
 An enabled implementation is resolved by capability id and versioned protocol,
 then checked against its declared permission, current revision, and current

--- a/loopx/cli_commands/extension.py
+++ b/loopx/cli_commands/extension.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Callable
 import json
-from pathlib import Path
 import sys
+from collections.abc import Callable
+from pathlib import Path
 
 from ..extensions.bundled import BUNDLED_EXTENSION_IDS, bundled_extension_manifest
 from ..extensions.presentation import publish_extension_projection
-from ..extensions.scaffold import scaffold_extension
 from ..extensions.runtime import (
     MAX_EXTENSION_REQUEST_BYTES,
     default_extension_state_file,
     disable_extension,
+    doctor_enabled_extensions,
     doctor_installed_extension,
     enable_extension,
     extension_status,
@@ -20,7 +20,7 @@ from ..extensions.runtime import (
     rollback_extension,
     run_standalone_extension,
 )
-
+from ..extensions.scaffold import scaffold_extension
 
 PrintPayload = Callable[
     [dict[str, object], str, Callable[[dict[str, object]], str]],
@@ -128,10 +128,21 @@ def register_extension_commands(
     for command in ("enable", "disable", "rollback", "doctor"):
         operation = commands.add_parser(command)
         _add_common(operation, add_subcommand_format)
-        operation.add_argument("extension_id")
+        if command == "doctor":
+            operation.add_argument("extension_id", nargs="?")
+        else:
+            operation.add_argument("extension_id")
         if command != "doctor":
             operation.add_argument("--execute", action="store_true")
         else:
+            operation.add_argument(
+                "--all-enabled",
+                action="store_true",
+                help=(
+                    "Revalidate every enabled extension after an install, update, "
+                    "or rollback."
+                ),
+            )
             operation.add_argument(
                 "--execute",
                 action="store_true",
@@ -253,11 +264,22 @@ def handle_extension_command(
                 execute=args.execute,
             )
         else:
-            payload = doctor_installed_extension(
-                args.extension_id,
-                state_file=state_file,
-                execute=args.execute,
-            )
+            if bool(args.extension_id) == bool(args.all_enabled):
+                raise ValueError(
+                    "extension doctor requires exactly one extension_id or "
+                    "--all-enabled"
+                )
+            if args.all_enabled:
+                payload = doctor_enabled_extensions(
+                    state_file=state_file,
+                    execute=args.execute,
+                )
+            else:
+                payload = doctor_installed_extension(
+                    args.extension_id,
+                    state_file=state_file,
+                    execute=args.execute,
+                )
     except ValueError as exc:
         payload = {
             "ok": False,

--- a/loopx/extensions/readiness.py
+++ b/loopx/extensions/readiness.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
-from dataclasses import dataclass
 import hashlib
 import importlib.util
 import json
-from pathlib import Path
 import shutil
 import subprocess
 import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
-
 EXTENSION_DOCTOR_SCHEMA_VERSION = "loopx_extension_doctor_v0"
+RUNTIME_ENTRYPOINT_IDENTITY_SCHEMA_VERSION = "loopx_runtime_entrypoint_identity_v1"
 
 
 @dataclass(frozen=True)
@@ -39,11 +39,10 @@ def _file_identity(path: Path, *, executable: bool) -> tuple[Path, str] | None:
     except OSError:
         return None
     identity = {
-        "path": str(path),
-        "device": stat.st_dev,
-        "inode": stat.st_ino,
+        "schema_version": RUNTIME_ENTRYPOINT_IDENTITY_SCHEMA_VERSION,
+        "kind": "file_artifact",
+        "executable": executable,
         "size": stat.st_size,
-        "mtime_ns": stat.st_mtime_ns,
         "content_sha256": content_digest,
     }
     serialized = json.dumps(identity, sort_keys=True, separators=(",", ":"))

--- a/loopx/extensions/runtime.py
+++ b/loopx/extensions/runtime.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping, Sequence
-from contextlib import nullcontext
-from copy import deepcopy
 import hashlib
 import json
 import os
+from collections.abc import Iterable, Mapping, Sequence
+from contextlib import nullcontext
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
 from ..file_lock import exclusive_file_lock
-from .process_runtime import run_capped_process
 from .manifest import load_extension_manifest
+from .process_runtime import run_capped_process
 from .readiness import (
     EXTENSION_DOCTOR_SCHEMA_VERSION,
     ResolvedRuntimeEntrypoint,
@@ -20,12 +20,12 @@ from .readiness import (
     resolve_runtime_entrypoint,
 )
 
-
 EXTENSION_STATE_SCHEMA_VERSION = "loopx_extension_state_v0"
 EXTENSION_OPERATION_SCHEMA_VERSION = "loopx_extension_operation_v0"
 EXTENSION_BINDING_SCHEMA_VERSION = "loopx_extension_runtime_binding_v0"
 EXTENSION_ACTIVATION_SCHEMA_VERSION = "loopx_extension_activation_v0"
 EXTENSION_RUN_SCHEMA_VERSION = "loopx_extension_run_receipt_v0"
+EXTENSION_DOCTOR_BATCH_SCHEMA_VERSION = "loopx_extension_doctor_batch_v0"
 MAX_REVISIONS = 5
 MAX_EXTENSION_REQUEST_BYTES = 1_000_000
 MAX_EXTENSION_RESPONSE_BYTES = 1_000_000
@@ -443,6 +443,57 @@ def doctor_installed_extension(
     return doctor
 
 
+def doctor_enabled_extensions(
+    *,
+    state_file: str | Path,
+    execute: bool = False,
+) -> dict[str, Any]:
+    """Revalidate every enabled extension after a runtime release transition.
+
+    Extension doctors are declared read-only provider probes. Running them as
+    one bounded batch lets installers and rollback paths refresh the runtime
+    identity without weakening the fail-closed activation fence.
+    """
+
+    path = Path(state_file).expanduser()
+    state = _read_state(path)
+    extension_ids = sorted(
+        str(extension_id)
+        for extension_id, entry in state["extensions"].items()
+        if isinstance(entry, Mapping) and entry.get("enabled")
+    )
+    doctors = [
+        doctor_installed_extension(
+            extension_id,
+            state_file=path,
+            execute=execute,
+        )
+        for extension_id in extension_ids
+    ]
+    verified_count = sum(bool(doctor.get("verified")) for doctor in doctors)
+    blocked_count = len(doctors) - verified_count if execute else 0
+    return {
+        "ok": blocked_count == 0,
+        "schema_version": EXTENSION_DOCTOR_BATCH_SCHEMA_VERSION,
+        "status": (
+            "ready"
+            if execute and blocked_count == 0
+            else "blocked"
+            if execute
+            else "probe_required"
+            if doctors
+            else "ready"
+        ),
+        "execute": execute,
+        "enabled_count": len(doctors),
+        "verified_count": verified_count,
+        "blocked_count": blocked_count,
+        "extensions": doctors,
+        "local_state_write_performed": execute and bool(doctors),
+        "external_writes_performed": False,
+    }
+
+
 def _verified_entrypoint(
     entry: Mapping[str, Any],
 ) -> ResolvedRuntimeEntrypoint | None:
@@ -577,7 +628,10 @@ def _resolved_active_extension(
     active_revision = str(entry.get("active_revision") or "")
     verified_entrypoint = _verified_entrypoint(entry)
     if verified_entrypoint is None:
-        raise ValueError(f"extension `{extension_id}` doctor readiness is stale")
+        raise ValueError(
+            f"extension `{extension_id}` doctor readiness is stale; run "
+            f"`loopx extension doctor {extension_id} --execute`"
+        )
     manifest = _active_manifest(entry)
     return active_revision, verified_entrypoint, manifest
 

--- a/loopx/self_update.py
+++ b/loopx/self_update.py
@@ -623,11 +623,44 @@ def execute_update_plan(payload: dict[str, Any], *, timeout_seconds: int = 600) 
         "doctor_stdout_tail": doctor_result.stdout[-2000:],
         "doctor_stderr_tail": doctor_result.stderr[-2000:],
     }
+    extension_doctor_result = None
+    if install_result.returncode == 0 and doctor_result.returncode == 0:
+        extension_doctor_result = subprocess.run(
+            [
+                str(loopx_bin),
+                "--format",
+                "json",
+                "extension",
+                "doctor",
+                "--all-enabled",
+                "--execute",
+            ],
+            text=True,
+            capture_output=True,
+            env=env,
+            timeout=timeout_seconds,
+        )
+        execution.update(
+            {
+                "extension_doctor_returncode": extension_doctor_result.returncode,
+                "extension_doctor_stdout_tail": extension_doctor_result.stdout[-2000:],
+                "extension_doctor_stderr_tail": extension_doctor_result.stderr[-2000:],
+            }
+        )
+    else:
+        execution["extension_doctor_status"] = "skipped_release_update_failed"
     updated = dict(payload)
     updated["execution"] = execution
-    updated["ok"] = install_result.returncode == 0 and doctor_result.returncode == 0
+    updated["ok"] = (
+        install_result.returncode == 0
+        and doctor_result.returncode == 0
+        and extension_doctor_result is not None
+        and extension_doctor_result.returncode == 0
+    )
     if not updated["ok"]:
-        updated["recommended_action"] = "inspect update execution tails and restore from rollback plan if needed"
+        updated["recommended_action"] = (
+            "inspect update execution tails and restore from rollback plan if needed"
+        )
         return updated
     execution["restarted_services"] = restart_managed_loopx_services()
     return updated

--- a/loopx/self_update.py
+++ b/loopx/self_update.py
@@ -686,8 +686,37 @@ def execute_rollback_plan(
                 "doctor_stderr_tail": doctor_result.stderr[-2000:],
             }
         )
-        updated["ok"] = doctor_result.returncode == 0
-        if not updated["ok"] and previous_link_target:
+        if doctor_result.returncode == 0:
+            extension_doctor_result = subprocess.run(
+                [
+                    str(loopx_bin),
+                    "--format",
+                    "json",
+                    "extension",
+                    "doctor",
+                    "--all-enabled",
+                    "--execute",
+                ],
+                text=True,
+                capture_output=True,
+                timeout=timeout_seconds,
+            )
+            execution.update(
+                {
+                    "extension_doctor_returncode": extension_doctor_result.returncode,
+                    "extension_doctor_stdout_tail": extension_doctor_result.stdout[
+                        -2000:
+                    ],
+                    "extension_doctor_stderr_tail": extension_doctor_result.stderr[
+                        -2000:
+                    ],
+                }
+            )
+            updated["ok"] = extension_doctor_result.returncode == 0
+        else:
+            execution["extension_doctor_status"] = "skipped_core_doctor_failed"
+            updated["ok"] = False
+        if doctor_result.returncode != 0 and previous_link_target:
             restore_link = loopx_bin.with_name(f".{loopx_bin.name}.rollback.restore.{os.getpid()}")
             if restore_link.exists() or restore_link.is_symlink():
                 restore_link.unlink()
@@ -713,11 +742,21 @@ def execute_rollback_plan(
         if "restore_link" in locals() and (restore_link.exists() or restore_link.is_symlink()):
             restore_link.unlink()
     updated["execution"] = execution
-    updated["recommended_action"] = (
-        "rollback complete; review doctor output"
-        if updated["ok"]
-        else "rollback failed; inspect execution error before retrying"
-    )
+    if updated["ok"]:
+        updated["recommended_action"] = "rollback complete; review doctor output"
+    elif (
+        execution.get("doctor_returncode") == 0
+        and execution.get("extension_doctor_returncode") not in {None, 0}
+    ):
+        updated["recommended_action"] = (
+            "rollback activated, but one or more enabled extensions remain fail "
+            "closed; repair the provider and run `loopx extension doctor "
+            "--all-enabled --execute`"
+        )
+    else:
+        updated["recommended_action"] = (
+            "rollback failed; inspect execution error before retrying"
+        )
     return updated
 
 

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -769,6 +769,10 @@ fi
 
 export PATH="$bin_dir:$PATH"
 "$bin_dir/loopx" doctor >/dev/null
+if ! "$bin_dir/loopx" --format json extension doctor --all-enabled --execute >/dev/null; then
+  echo "loopx installer warning: one or more enabled extensions failed post-install doctor revalidation" >&2
+  echo "Run 'loopx extension doctor --all-enabled --execute' after repairing the provider." >&2
+fi
 if [[ "$install_canary" != "0" ]]; then
   "$bin_dir/loopx-canary" doctor >/dev/null
 fi

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -47,6 +47,12 @@ try {
     $env:PYTHONPATH = $previousPythonPath
 }
 
+$loopxLauncher = Join-Path $BinDir "loopx.ps1"
+& $loopxLauncher --format json extension doctor --all-enabled --execute *> $null
+if ($LASTEXITCODE -ne 0) {
+    Write-Warning "One or more enabled extensions failed post-install doctor revalidation. Run 'loopx extension doctor --all-enabled --execute' after repairing the provider."
+}
+
 if ($AddToUserPath) {
     $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
     $entries = @($userPath -split ";" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })

--- a/tests/extensions/test_extension_presentation.py
+++ b/tests/extensions/test_extension_presentation.py
@@ -441,7 +441,11 @@ def test_active_presentation_surfaces_hide_disabled_or_stale_extension(
         now=datetime(2026, 1, 20, tzinfo=timezone.utc),
     )["ready_count"] == 1
 
-    _projection_provider(tmp_path / "provider")
+    provider = tmp_path / "provider"
+    provider.write_text(
+        provider.read_text(encoding="utf-8") + "# changed provider content\n",
+        encoding="utf-8",
+    )
     assert collect_active_extension_presentation_surfaces(
         state_file=state_file
     )["items"] == []

--- a/tests/extensions/test_extension_runtime.py
+++ b/tests/extensions/test_extension_runtime.py
@@ -2,14 +2,15 @@ from __future__ import annotations
 
 import argparse
 import ast
-from collections.abc import Callable
 import io
 import json
 import os
-from pathlib import Path
 import subprocess
 import sys
 import time
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -23,10 +24,18 @@ from loopx.capabilities.semantic_preference.cli import (
 from loopx.capabilities.semantic_preference.contract import provider_doctor, recall
 from loopx.cli import main
 from loopx.extensions.manifest import load_extension_manifest
+from loopx.extensions.openviking_semantic_preference.provider import (
+    register_openviking_provider_arguments,
+)
+from loopx.extensions.readiness import (
+    resolve_runtime_entrypoint,
+    resolved_entrypoint_identity,
+)
 from loopx.extensions.runtime import (
     MAX_EXTENSION_REQUEST_BYTES,
     MAX_EXTENSION_RESPONSE_BYTES,
     disable_extension,
+    doctor_enabled_extensions,
     doctor_installed_extension,
     enable_extension,
     execute_extension_runtime_binding,
@@ -39,9 +48,6 @@ from loopx.extensions.runtime import (
     resolve_extension_runtime_binding,
     rollback_extension,
     run_standalone_extension,
-)
-from loopx.extensions.openviking_semantic_preference.provider import (
-    register_openviking_provider_arguments,
 )
 
 
@@ -526,6 +532,60 @@ def test_python_module_runtime_uses_current_interpreter_without_console_script(
             "test-lark-module-extension",
             state_file=state_file,
         )
+
+
+def test_runtime_identity_survives_unchanged_release_root_move(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    release_a = tmp_path / "release-a"
+    release_b = tmp_path / "release-b"
+    release_a.mkdir()
+    release_b.mkdir()
+    module_a = release_a / "fixture_provider.py"
+    module_b = release_b / "fixture_provider.py"
+    module_a.write_text("VALUE = 1\n", encoding="utf-8")
+    module_b.write_text(module_a.read_text(encoding="utf-8"), encoding="utf-8")
+    current_origin = module_a
+    monkeypatch.setattr(
+        "loopx.extensions.readiness.importlib.util.find_spec",
+        lambda _module: SimpleNamespace(origin=str(current_origin)),
+    )
+    runtime = {"python_module": "fixture_provider"}
+
+    identity_a = resolve_runtime_entrypoint(runtime)
+    current_origin = module_b
+    identity_b = resolve_runtime_entrypoint(runtime)
+
+    assert identity_a is not None and identity_b is not None
+    assert identity_a.argv_prefix == identity_b.argv_prefix
+    assert identity_a.identity == identity_b.identity
+
+    module_b.write_text("VALUE = 2\n", encoding="utf-8")
+    changed = resolve_runtime_entrypoint(runtime)
+    assert changed is not None
+    assert changed.identity != identity_a.identity
+
+
+def test_executable_identity_is_content_addressed_across_paths(tmp_path: Path) -> None:
+    provider_a = _provider(tmp_path / "release-a-provider")
+    provider_b = tmp_path / "release-b-provider"
+    provider_b.write_bytes(provider_a.read_bytes())
+    provider_b.chmod(0o755)
+
+    identity_a = resolved_entrypoint_identity(str(provider_a))
+    identity_b = resolved_entrypoint_identity(str(provider_b))
+
+    assert identity_a is not None and identity_b is not None
+    assert identity_a[1] == identity_b[1]
+
+    provider_b.write_text(
+        provider_b.read_text(encoding="utf-8") + "# changed\n",
+        encoding="utf-8",
+    )
+    changed = resolved_entrypoint_identity(str(provider_b))
+    assert changed is not None
+    assert changed[1] != identity_a[1]
 
 
 def test_standalone_runtime_does_not_require_a_capability_contract(
@@ -1101,6 +1161,77 @@ def test_failed_executed_doctor_clears_stale_readiness_proof(
         )
 
 
+def test_enabled_extension_doctor_batch_migrates_stale_identity(
+    tmp_path: Path,
+) -> None:
+    provider = _provider(tmp_path / "provider")
+    manifest = _manifest(
+        tmp_path / "extension.toml",
+        entrypoint=provider,
+        version="1.0.0",
+    )
+    state_file = tmp_path / "extensions.json"
+    install_extension(manifest, state_file=state_file, execute=True)
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    state["extensions"]["test-semantic-extension"][
+        "doctor_verified_entrypoint_identity"
+    ] = "legacy-release-identity"
+    state_file.write_text(json.dumps(state), encoding="utf-8")
+
+    preview = doctor_enabled_extensions(state_file=state_file)
+    assert preview["ok"] is True
+    assert preview["status"] == "probe_required"
+    assert preview["enabled_count"] == 1
+    assert preview["local_state_write_performed"] is False
+    assert (
+        json.loads(state_file.read_text(encoding="utf-8"))["extensions"][
+            "test-semantic-extension"
+        ]["doctor_verified_entrypoint_identity"]
+        == "legacy-release-identity"
+    )
+
+    repaired = doctor_enabled_extensions(state_file=state_file, execute=True)
+    assert repaired["ok"] is True
+    assert repaired["status"] == "ready"
+    assert repaired["verified_count"] == 1
+    assert repaired["blocked_count"] == 0
+    assert repaired["external_writes_performed"] is False
+    assert (
+        resolve_extension_activation(
+            "test-semantic-extension",
+            state_file=state_file,
+        )["doctor_verified"]
+        is True
+    )
+
+
+def test_enabled_extension_doctor_batch_keeps_failed_provider_closed(
+    tmp_path: Path,
+) -> None:
+    provider = _provider(tmp_path / "provider")
+    manifest = _manifest(
+        tmp_path / "extension.toml",
+        entrypoint=provider,
+        version="1.0.0",
+    )
+    state_file = tmp_path / "extensions.json"
+    install_extension(manifest, state_file=state_file, execute=True)
+    _provider(provider, doctor_exit=2)
+
+    repaired = doctor_enabled_extensions(state_file=state_file, execute=True)
+
+    assert repaired["ok"] is False
+    assert repaired["status"] == "blocked"
+    assert repaired["verified_count"] == 0
+    assert repaired["blocked_count"] == 1
+    assert repaired["extensions"][0]["failure_kind"] == "probe_nonzero_exit"
+    with pytest.raises(ValueError, match="extension doctor .* --execute"):
+        resolve_extension_activation(
+            "test-semantic-extension",
+            state_file=state_file,
+        )
+
+
 def test_executed_doctor_rebinds_revision_only_legacy_proof(tmp_path: Path) -> None:
     provider = _provider(tmp_path / "provider")
     manifest = _manifest(
@@ -1443,6 +1574,26 @@ def test_extension_cli_installs_preinstalled_runtime(
     enabled = json.loads(capsys.readouterr().out)
     assert enabled["enabled"] is True
     assert enabled["doctor"]["verified"] is True
+
+    assert (
+        main(
+            [
+                "--runtime-root",
+                str(runtime_root),
+                "--format",
+                "json",
+                "extension",
+                "doctor",
+                "--all-enabled",
+                "--execute",
+            ]
+        )
+        == 0
+    )
+    batch = json.loads(capsys.readouterr().out)
+    assert batch["schema_version"] == "loopx_extension_doctor_batch_v0"
+    assert batch["status"] == "ready"
+    assert batch["verified_count"] == 1
 
 
 def test_extension_cli_rejects_implements_provider_direct_run(

--- a/tests/test_self_update_runtime_activation.py
+++ b/tests/test_self_update_runtime_activation.py
@@ -233,6 +233,49 @@ def test_restart_managed_loopx_services_restarts_only_loopx_launchagents(
     assert all(call[0] == "launchctl" for call in calls)
 
 
+def test_successful_update_revalidates_enabled_extensions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "source": {"installer_url": "https://example.invalid/install.sh"},
+        "plan": {"backup": {}},
+    }
+    completed = [
+        subprocess.CompletedProcess([], 0, "installed", ""),
+        subprocess.CompletedProcess([], 0, '{"ok": true}', ""),
+        subprocess.CompletedProcess([], 0, '{"ok": true}', ""),
+    ]
+    calls: list[list[str]] = []
+
+    def fake_run(
+        args: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(list(args))
+        return completed[len(calls) - 1]
+
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(
+        "loopx.self_update._installer_env_for_source",
+        lambda *_args, **_kwargs: {},
+    )
+    monkeypatch.setattr("loopx.self_update.subprocess.run", fake_run)
+
+    updated = execute_update_plan(payload)
+
+    assert updated["ok"] is True
+    assert updated["execution"]["extension_doctor_returncode"] == 0
+    assert calls[2] == [
+        str(tmp_path / ".local" / "bin" / "loopx"),
+        "--format",
+        "json",
+        "extension",
+        "doctor",
+        "--all-enabled",
+        "--execute",
+    ]
+
+
 @pytest.mark.skipif(os.name != "nt", reason="native Windows update boundary")
 def test_windows_execute_update_fails_closed_without_launching_bash() -> None:
     payload = {"ok": True, "source": {}, "plan": {}}


### PR DESCRIPTION
## Summary

- make extension runtime identity content-addressed so unchanged providers survive release-root, inode, and equivalent interpreter-path changes
- add `loopx extension doctor --all-enabled --execute` for bounded post-release revalidation of enabled extensions
- run the batch after Unix and Windows installs and after rollback activation, while keeping failed providers fail-closed
- return the exact recovery command when a doctor proof is stale

## Safety boundary

The batch only invokes doctor commands already declared by enabled extension manifests. Doctors remain read-only provider probes: the batch performs no connector write and grants no new provider permission. Changed executable, interpreter, or Python module content still invalidates readiness until an executed doctor passes.

## Validation

- `python -m pytest -q tests/extensions/test_extension_runtime.py tests/test_self_update_runtime_activation.py` — 63 passed, 1 platform skip
- `python examples/loopx-update-smoke.py` — passed
- `bash -n scripts/install-local.sh` — passed
- `loopx canary premerge --from-git-diff --tier standard` under system Python 3.11 — 18/18 passed; no warnings or manual holds
- public/private boundary scan — clean across all 8 changed files

An initial premerge run under a locally incomplete Python 3.13 failed before the changed surface because `_sqlite3` was unavailable in the existing fallback wrapper smoke. Re-running the exact gate under the supported system Python 3.11 passed the real local-install smoke and the full 18-check gate.

## Future-facing review

Applied a bounded ownership improvement: one batch lifecycle API now owns release-transition revalidation for installers and rollback instead of duplicating per-extension state mutation. No broader extension framework was added.

Closes #3526
