### PR TITLE
fix(todos): verify repository delivery before completion

### DIFF
--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -203,6 +203,11 @@ loopx todo update \
 workspace isolation, not write authority; claim/lease, capabilities, the goal
 boundary, and repository policy continue to apply.
 
+For an accountable Git delivery, `delivery_workspace_v1` is emitted only from
+a clean worktree. Untracked or modified files keep the writeback unsettled;
+the snapshot still proves repository/worktree identity only, not that a
+specific commit or pull request reached a remote branch.
+
 `quota should-run --agent-id <agent-id>` is the preflight for every peer. When
 the selected task writes repository state and the peer is in a non-git,
 unrelated, or non-isolated workspace, it returns `workspace_guard` and blocks
@@ -369,7 +374,10 @@ This succession decision is durable Todo state. A later progress observation,
 vision ACK, coverage-exhausted result, or rewritten rationale cannot substitute
 for it. Every new completion therefore retains an opaque completion identity.
 A quota-bound completion still permits only the receipt-backed same-turn
-`todo complete --no-follow-up` recovery. An ordinary unscoped completion gets a
+`todo complete` transition for agent advancement work. Complete the matching
+accountable `refresh-state` and `quota spend-slot` first; explicit
+`same_agent_non_delivery` work, monitors, user actions, and user gates keep
+their existing lifecycle paths. An ordinary unscoped completion gets a
 stable `local_completion_*` identity; if a later `refresh-state` discovers that
 the finished Goal has no real successor, its typed rejection may project
 `--completion-identity-key` for one direct lifecycle reentry. That command is

--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -203,11 +203,6 @@ loopx todo update \
 workspace isolation, not write authority; claim/lease, capabilities, the goal
 boundary, and repository policy continue to apply.
 
-For an accountable Git delivery, `delivery_workspace_v1` is emitted only from
-a clean worktree. Untracked or modified files keep the writeback unsettled;
-the snapshot still proves repository/worktree identity only, not that a
-specific commit or pull request reached a remote branch.
-
 `quota should-run --agent-id <agent-id>` is the preflight for every peer. When
 the selected task writes repository state and the peer is in a non-git,
 unrelated, or non-isolated workspace, it returns `workspace_guard` and blocks
@@ -386,6 +381,12 @@ valid only for the exact already-completed Todo, its matching local identity,
 It cannot be supplied for an open Todo or used as a quota turn identity.
 Otherwise add/link a real successor. Do not create a user gate merely to
 silence a succession warning.
+
+Compatibility host adapters whose established transaction completes the Todo
+before writing the same-turn refresh and quota receipts must explicitly mark
+their non-repository work `same_agent_non_delivery`. Repository advancement
+through those adapters fails closed with a typed settlement blocker until the
+adapter adopts a writeback-and-spend-before-completion transaction.
 
 This keeps the active checklist honest without making LoopX a heavyweight
 project-management state machine.

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -6,10 +6,14 @@ from pathlib import Path
 
 from ..control_plane.todos.contract import (
     TODO_CONTINUATION_POLICY_VALUES,
+    TODO_TASK_CLASS_ADVANCEMENT,
+    normalize_todo_continuation_policy,
+    normalize_todo_task_class,
     replan_successor_semantic_binding,
 )
 from ..control_plane.capability_hooks import PostWritebackHookRegistration
 from ..control_plane.quota.settlement import (
+    QuotaSettlementReadback,
     read_heartbeat_settlement,
     settlement_result_payload,
 )
@@ -65,6 +69,48 @@ PrintPayload = Callable[
     [dict[str, object], str, Callable[[dict[str, object]], str]],
     None,
 ]
+
+
+def _completion_settlement_requirement(
+    todo: dict[str, object],
+    *,
+    no_follow_up: bool,
+) -> str | None:
+    if no_follow_up:
+        return "terminal no-follow-up closeout"
+    task_class = normalize_todo_task_class(
+        todo.get("task_class"),
+        text=str(todo.get("text") or ""),
+        action_kind=todo.get("action_kind"),
+    )
+    continuation_policy = normalize_todo_continuation_policy(
+        todo.get("continuation_policy")
+    )
+    if (
+        str(todo.get("role") or "") == "agent"
+        and task_class == TODO_TASK_CLASS_ADVANCEMENT
+        and continuation_policy != "same_agent_non_delivery"
+    ):
+        return "turn-scoped advancement completion"
+    return None
+
+
+def _completion_settlement_error(
+    todo: dict[str, object],
+    settlement_readback: QuotaSettlementReadback,
+    *,
+    no_follow_up: bool,
+) -> str | None:
+    requirement = _completion_settlement_requirement(
+        todo,
+        no_follow_up=no_follow_up,
+    )
+    if requirement is None or settlement_readback.settlement.failure is None:
+        return None
+    return (
+        f"{requirement} requires matching writeback and quota spend receipts: "
+        + settlement_readback.settlement.failure.reason
+    )
 
 
 def _validated_replan_successor_obligation(
@@ -776,6 +822,7 @@ def handle_todo_command(
             settlement_result = None
             settlement_identity = None
             settlement_readback = None
+            completion_requires_settlement = False
             completion_turn_key = None
             completion_identity_source = None
             if getattr(args, "turn_instance_id", None):
@@ -801,14 +848,40 @@ def handle_todo_command(
                     raise ValueError("turn-scoped Todo completion has no identity")
                 identity = settlement_result.value
                 settlement_identity = identity
-                if args.no_follow_up:
+                todo_payload = list_goal_todos(
+                    registry_path=registry_path,
+                    goal_id=args.goal_id,
+                    todo_id=args.todo_id,
+                    project=Path(args.project).expanduser() if args.project else None,
+                    state_file=(
+                        Path(args.state_file).expanduser()
+                        if args.state_file
+                        else None
+                    ),
+                    runtime_root_arg=runtime_root_arg,
+                )
+                todo = (
+                    todo_payload.get("todo")
+                    if isinstance(todo_payload.get("todo"), dict)
+                    else None
+                )
+                if todo is None:
+                    raise ValueError(
+                        "turn-scoped Todo completion requires one durable Todo"
+                    )
+                completion_requirement = _completion_settlement_requirement(
+                    todo,
+                    no_follow_up=bool(args.no_follow_up),
+                )
+                completion_requires_settlement = completion_requirement is not None
+                completion_error = _completion_settlement_error(
+                    todo,
+                    settlement_readback=settlement_readback,
+                    no_follow_up=bool(args.no_follow_up),
+                )
+                if completion_error is not None:
                     settlement_result = settlement_readback.settlement
-                    if settlement_result.failure is not None:
-                        raise ValueError(
-                            "terminal no-follow-up closeout requires matching "
-                            "writeback and quota spend receipts: "
-                            + settlement_result.failure.reason
-                        )
+                    raise ValueError(completion_error)
                 completion_turn_key = identity.effect_id
                 completion_identity_source = "turn_settlement"
             elif getattr(args, "completion_identity_key", None):
@@ -966,6 +1039,8 @@ def handle_todo_command(
         settlement_result = (
             settlement_readback.terminal_settlement
             if args.no_follow_up and settlement_identity is not None
+            else settlement_readback.settlement
+            if completion_requires_settlement
             else settlement_readback.identity
         )
         payload["settlement_result"] = settlement_result_payload(

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -823,6 +823,7 @@ def handle_todo_command(
             settlement_identity = None
             settlement_readback = None
             completion_requires_settlement = False
+            completion_error = None
             completion_turn_key = None
             completion_identity_source = None
             if getattr(args, "turn_instance_id", None):
@@ -881,49 +882,63 @@ def handle_todo_command(
                 )
                 if completion_error is not None:
                     settlement_result = settlement_readback.settlement
-                    raise ValueError(completion_error)
+                    payload = {
+                        "ok": False,
+                        "dry_run": bool(args.dry_run),
+                        "completed": False,
+                        "changed": False,
+                        "goal_id": args.goal_id,
+                        "todo_id": args.todo_id,
+                        "settlement_blocked_completion": True,
+                        "settlement_identity": identity.as_dict(),
+                        "settlement_result": settlement_result_payload(
+                            settlement_result
+                        ),
+                        "error": completion_error,
+                    }
                 completion_turn_key = identity.effect_id
                 completion_identity_source = "turn_settlement"
             elif getattr(args, "completion_identity_key", None):
                 completion_turn_key = str(args.completion_identity_key)
                 completion_identity_source = "lifecycle_reentry"
-            payload = complete_goal_todo(
-                registry_path=registry_path,
-                goal_id=args.goal_id,
-                todo_id=args.todo_id,
-                role=args.role,
-                decision_outcome=args.decision_outcome,
-                evidence=args.evidence,
-                completion_turn_key=completion_turn_key,
-                completion_identity_source=completion_identity_source,
-                task_lease_idempotency_key=args.task_lease_idempotency_key,
-                task_lease_expected_version=args.task_lease_expected_version,
-                note=args.note,
-                no_followup=bool(args.no_follow_up),
-                successor_todo_ids=args.successor_todo_ids,
-                claimed_by=args.claimed_by,
-                clear_claim=bool(args.clear_claim),
-                next_agent_todo=args.next_agent_todo,
-                next_user_todo=args.next_user_todo,
-                next_user_task_class=args.next_user_task_class,
-                next_claimed_by=args.next_claimed_by,
-                next_task_class=args.next_task_class,
-                next_action_kind=args.next_action_kind,
-                next_task_repository=args.next_task_repository,
-                next_required_capabilities=args.next_required_capabilities,
-                next_continuation_policy=args.next_continuation_policy,
-                next_excluded_agents=args.next_excluded_agents,
-                self_merged=bool(args.self_merged),
-                agent_id=args.agent_id,
-                authority_reason=args.authority_reason,
-                **_todo_path_args(args),
-                dry_run=bool(args.dry_run),
-            )
-            if settlement_identity is not None:
-                payload["settlement_identity"] = settlement_identity.as_dict()
-                payload["settlement_result"] = settlement_result_payload(
-                    settlement_result
+            if completion_error is None:
+                payload = complete_goal_todo(
+                    registry_path=registry_path,
+                    goal_id=args.goal_id,
+                    todo_id=args.todo_id,
+                    role=args.role,
+                    decision_outcome=args.decision_outcome,
+                    evidence=args.evidence,
+                    completion_turn_key=completion_turn_key,
+                    completion_identity_source=completion_identity_source,
+                    task_lease_idempotency_key=args.task_lease_idempotency_key,
+                    task_lease_expected_version=args.task_lease_expected_version,
+                    note=args.note,
+                    no_followup=bool(args.no_follow_up),
+                    successor_todo_ids=args.successor_todo_ids,
+                    claimed_by=args.claimed_by,
+                    clear_claim=bool(args.clear_claim),
+                    next_agent_todo=args.next_agent_todo,
+                    next_user_todo=args.next_user_todo,
+                    next_user_task_class=args.next_user_task_class,
+                    next_claimed_by=args.next_claimed_by,
+                    next_task_class=args.next_task_class,
+                    next_action_kind=args.next_action_kind,
+                    next_task_repository=args.next_task_repository,
+                    next_required_capabilities=args.next_required_capabilities,
+                    next_continuation_policy=args.next_continuation_policy,
+                    next_excluded_agents=args.next_excluded_agents,
+                    self_merged=bool(args.self_merged),
+                    agent_id=args.agent_id,
+                    authority_reason=args.authority_reason,
+                    **_todo_path_args(args),
+                    dry_run=bool(args.dry_run),
                 )
+                if settlement_identity is not None:
+                    payload["settlement_identity"] = settlement_identity.as_dict()
+                    payload["settlement_result"] = settlement_result_payload(
+                        settlement_result
+                    )
         elif args.todo_command == "supersede":
             validate_todo_supersede_options(args)
             payload = supersede_goal_todo(

--- a/loopx/control_plane/agents/workspace_guard.py
+++ b/loopx/control_plane/agents/workspace_guard.py
@@ -103,32 +103,6 @@ def _git_repository_identity(path: Path) -> str | None:
         return None
 
 
-def _git_worktree_is_clean(path: Path) -> bool:
-    try:
-        result = subprocess.run(
-            [
-                "git",
-                "-C",
-                str(path),
-                "status",
-                "--porcelain=v1",
-                "--untracked-files=all",
-                "--",
-                ".",
-                ":(exclude).codex/**",
-                ":(exclude).loopx/**",
-            ],
-            check=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            text=True,
-            timeout=1.5,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return False
-    return result.returncode == 0 and not result.stdout.strip()
-
-
 def capture_delivery_workspace(
     current_path: Path | None = None,
     *,
@@ -244,8 +218,6 @@ def build_delivery_workspace_guard(
         current_workspace = "not_git_worktree"
     elif current_repository != task_repository:
         current_workspace = "foreign_git_worktree"
-    elif not _git_worktree_is_clean(current_path or Path.cwd()):
-        current_workspace = "dirty_git_worktree"
     elif (
         recorded_workspace == "independent_git_worktree"
         and current_workspace != "independent_git_worktree"
@@ -277,8 +249,8 @@ def build_delivery_workspace_guard(
         "delivery_run_generated_at": delivery_run.get("generated_at"),
         "delivery_run_classification": delivery_run.get("classification"),
         "reason": (
-            "quota spend requires the clean workspace that produced the latest "
-            "unspent accountable delivery"
+            "quota spend workspace does not match the latest unspent accountable "
+            "delivery workspace"
         ),
         "required_action": (
             "run quota spend-slot from the workspace that produced the latest "

--- a/loopx/control_plane/agents/workspace_guard.py
+++ b/loopx/control_plane/agents/workspace_guard.py
@@ -103,6 +103,32 @@ def _git_repository_identity(path: Path) -> str | None:
         return None
 
 
+def _git_worktree_is_clean(path: Path) -> bool:
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(path),
+                "status",
+                "--porcelain=v1",
+                "--untracked-files=all",
+                "--",
+                ".",
+                ":(exclude).codex/**",
+                ":(exclude).loopx/**",
+            ],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=1.5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0 and not result.stdout.strip()
+
+
 def capture_delivery_workspace(
     current_path: Path | None = None,
     *,
@@ -146,7 +172,11 @@ def capture_delivery_workspace(
     current_common = _git_common_dir(path)
     current_git_dir = _git_dir(path)
     task_repository = _git_repository_identity(path)
-    if not task_repository or current_common is None or current_git_dir is None:
+    if (
+        not task_repository
+        or current_common is None
+        or current_git_dir is None
+    ):
         return None
     workspace_kind = (
         "independent_git_worktree"
@@ -214,6 +244,8 @@ def build_delivery_workspace_guard(
         current_workspace = "not_git_worktree"
     elif current_repository != task_repository:
         current_workspace = "foreign_git_worktree"
+    elif not _git_worktree_is_clean(current_path or Path.cwd()):
+        current_workspace = "dirty_git_worktree"
     elif (
         recorded_workspace == "independent_git_worktree"
         and current_workspace != "independent_git_worktree"
@@ -245,8 +277,8 @@ def build_delivery_workspace_guard(
         "delivery_run_generated_at": delivery_run.get("generated_at"),
         "delivery_run_classification": delivery_run.get("classification"),
         "reason": (
-            "quota spend workspace does not match the latest unspent accountable "
-            "delivery workspace"
+            "quota spend requires the clean workspace that produced the latest "
+            "unspent accountable delivery"
         ),
         "required_action": (
             "run quota spend-slot from the workspace that produced the latest "

--- a/tests/control_plane/test_delivery_workspace.py
+++ b/tests/control_plane/test_delivery_workspace.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 from loopx.control_plane.agents.workspace_guard import (
@@ -73,3 +74,88 @@ def test_legacy_git_workspace_remains_accepted() -> None:
 
     assert delivery_workspace_identity(legacy) == "git:github.com/example/loopx"
     assert delivery_workspace_repository(legacy) == "git:github.com/example/loopx"
+
+
+def test_git_workspace_capture_requires_a_clean_worktree(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    project.mkdir()
+    subprocess.run(
+        ["git", "init", "--quiet"],
+        cwd=project,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    (project / "tracked.txt").write_text("tracked\n", encoding="utf-8")
+    subprocess.run(
+        [
+            "git",
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/example/loopx.git",
+        ],
+        cwd=project,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "add", "."],
+        cwd=project,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=LoopX Test",
+            "-c",
+            "user.email=loopx-test@example.invalid",
+            "commit",
+            "--quiet",
+            "-m",
+            "fixture",
+        ],
+        cwd=project,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    snapshot = capture_delivery_workspace(project)
+    assert snapshot == {
+        "schema_version": "delivery_workspace_v1",
+        "workspace_identity": "git:github.com/example/loopx",
+        "identity_kind": "git_repository",
+        "task_repository": "git:github.com/example/loopx",
+        "repository_source": "current_git_origin",
+        "workspace_kind": "canonical_checkout",
+        "peer_independent_worktree_required": False,
+    }
+
+    (project / "uncommitted.txt").write_text("local only\n", encoding="utf-8")
+
+    assert capture_delivery_workspace(project) is not None
+    guard = build_delivery_workspace_guard(
+        {"delivery_workspace": snapshot},
+        current_path=project,
+    )
+    assert guard is not None
+    assert guard["current_workspace"] == "dirty_git_worktree"
+    assert guard["blocks_delivery"] is True
+
+    (project / "uncommitted.txt").unlink()
+    state_file = project / ".codex/goals/example/ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text("local control state\n", encoding="utf-8")
+
+    assert (
+        build_delivery_workspace_guard(
+            {"delivery_workspace": snapshot},
+            current_path=project,
+        )
+        is None
+    )

--- a/tests/control_plane/test_delivery_workspace.py
+++ b/tests/control_plane/test_delivery_workspace.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import subprocess
 from pathlib import Path
 
 from loopx.control_plane.agents.workspace_guard import (
@@ -74,88 +73,3 @@ def test_legacy_git_workspace_remains_accepted() -> None:
 
     assert delivery_workspace_identity(legacy) == "git:github.com/example/loopx"
     assert delivery_workspace_repository(legacy) == "git:github.com/example/loopx"
-
-
-def test_git_workspace_capture_requires_a_clean_worktree(tmp_path: Path) -> None:
-    project = tmp_path / "repo"
-    project.mkdir()
-    subprocess.run(
-        ["git", "init", "--quiet"],
-        cwd=project,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    (project / "tracked.txt").write_text("tracked\n", encoding="utf-8")
-    subprocess.run(
-        [
-            "git",
-            "remote",
-            "add",
-            "origin",
-            "https://github.com/example/loopx.git",
-        ],
-        cwd=project,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    subprocess.run(
-        ["git", "add", "."],
-        cwd=project,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    subprocess.run(
-        [
-            "git",
-            "-c",
-            "user.name=LoopX Test",
-            "-c",
-            "user.email=loopx-test@example.invalid",
-            "commit",
-            "--quiet",
-            "-m",
-            "fixture",
-        ],
-        cwd=project,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-
-    snapshot = capture_delivery_workspace(project)
-    assert snapshot == {
-        "schema_version": "delivery_workspace_v1",
-        "workspace_identity": "git:github.com/example/loopx",
-        "identity_kind": "git_repository",
-        "task_repository": "git:github.com/example/loopx",
-        "repository_source": "current_git_origin",
-        "workspace_kind": "canonical_checkout",
-        "peer_independent_worktree_required": False,
-    }
-
-    (project / "uncommitted.txt").write_text("local only\n", encoding="utf-8")
-
-    assert capture_delivery_workspace(project) is not None
-    guard = build_delivery_workspace_guard(
-        {"delivery_workspace": snapshot},
-        current_path=project,
-    )
-    assert guard is not None
-    assert guard["current_workspace"] == "dirty_git_worktree"
-    assert guard["blocks_delivery"] is True
-
-    (project / "uncommitted.txt").unlink()
-    state_file = project / ".codex/goals/example/ACTIVE_GOAL_STATE.md"
-    state_file.parent.mkdir(parents=True)
-    state_file.write_text("local control state\n", encoding="utf-8")
-
-    assert (
-        build_delivery_workspace_guard(
-            {"delivery_workspace": snapshot},
-            current_path=project,
-        )
-        is None
-    )

--- a/tests/control_plane/test_quota_settlement.py
+++ b/tests/control_plane/test_quota_settlement.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -39,6 +40,7 @@ from loopx.control_plane.work_items.interaction_contract import (
     build_interaction_contract,
     interaction_next_cli_actions,
 )
+from loopx.cli_commands.todo import _completion_settlement_error
 from loopx.rollout_event_log import rollout_event_log_path
 
 GOAL_ID = "settlement-goal"
@@ -269,6 +271,78 @@ def test_quota_settlement_readback_returns_the_complete_typed_chain(
         SettlementStepKind.QUOTA_SPEND,
     ]
     assert readback.spend_run is not None
+
+
+def test_advancement_completion_requires_the_complete_settlement_chain(
+    tmp_path: Path,
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    identity = SettlementIdentity(GOAL_ID, AGENT_ID, TODO_ID, TURN_ID)
+    _append_guard_receipt(runtime_root, effect_id=identity.effect_id)
+
+    incomplete = read_heartbeat_settlement(
+        runtime_root,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        todo_id=TODO_ID,
+        turn_instance_id=TURN_ID,
+    )
+    assert incomplete is not None
+    error = _completion_settlement_error(
+        {
+            "role": "agent",
+            "task_class": "advancement_task",
+            "action_kind": "implement",
+            "text": "Ship the repository change.",
+        },
+        incomplete,
+        no_follow_up=False,
+    )
+    assert error is not None
+    assert error.startswith(
+        "turn-scoped advancement completion requires matching writeback and "
+        "quota spend receipts:"
+    )
+
+    settled = replace(
+        incomplete,
+        settlement=SettlementResult(
+            value={},
+            receipts=(
+                _receipt(SettlementStepKind.VALIDATION, "validation"),
+                _receipt(SettlementStepKind.DURABLE_WRITEBACK, "writeback"),
+                _receipt(SettlementStepKind.QUOTA_SPEND, "spend"),
+            ),
+            failure=None,
+        ),
+    )
+    assert (
+        _completion_settlement_error(
+            {
+                "role": "agent",
+                "task_class": "advancement_task",
+                "action_kind": "implement",
+                "text": "Ship the repository change.",
+            },
+            settled,
+            no_follow_up=False,
+        )
+        is None
+    )
+    assert (
+        _completion_settlement_error(
+            {
+                "role": "agent",
+                "task_class": "advancement_task",
+                "action_kind": "research",
+                "continuation_policy": "same_agent_non_delivery",
+                "text": "Analyze the evidence.",
+            },
+            incomplete,
+            no_follow_up=False,
+        )
+        is None
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/control_plane/test_quota_settlement_cli.py
+++ b/tests/control_plane/test_quota_settlement_cli.py
@@ -846,6 +846,7 @@ def test_standard_codex_app_settlement_is_receipted_and_idempotent(
     tmp_path: Path,
 ) -> None:
     project, runtime, registry_path = _write_fixture(tmp_path)
+    _configure_read_only_todo(project)
     binding = (
         "--agent-id",
         AGENT_ID,
@@ -1224,6 +1225,14 @@ def test_same_turn_identityless_guard_upgrades_and_settles_full_chain(
     project, runtime, registry_path = _write_fixture(
         tmp_path,
         required_capability="network",
+    )
+    state_path = project / f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_path.write_text(
+        state_path.read_text(encoding="utf-8").replace(
+            "action_kind=validate ",
+            "action_kind=validate continuation_policy=same_agent_non_delivery ",
+        ),
+        encoding="utf-8",
     )
     binding = (
         "--agent-id",
@@ -3163,6 +3172,7 @@ def test_same_turn_receipt_replay_defers_newly_due_higher_priority_monitor(
     tmp_path: Path,
 ) -> None:
     project, runtime, registry_path = _write_fixture(tmp_path)
+    _configure_read_only_todo(project)
     guard_args = (
         "quota",
         "should-run",

--- a/tests/test_goal_mode_mcp_completion_validation.py
+++ b/tests/test_goal_mode_mcp_completion_validation.py
@@ -68,6 +68,7 @@ def _add_todo(registry: Path, *, validation_command: str | None = None) -> str:
         text="Deliver one bounded change.",
         task_class="advancement_task",
         claimed_by=AGENT,
+        continuation_policy="same_agent_non_delivery",
         validation_command=validation_command,
     )
     return str(todo["todo_id"])
@@ -121,6 +122,35 @@ def test_mcp_complete_task_fails_closed_on_failing_declared_validation(
     assert payload["validation"]["passed"] is False
     assert "spend-slot" not in output
     assert "refresh-state" not in output
+    assert _agent_todo_status(state, todo_id) != "done"
+
+
+def test_mcp_advancement_completion_returns_typed_settlement_blocker(
+    tmp_path: Path,
+) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo = add_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="agent",
+        text="Deliver one repository advancement.",
+        task_class="advancement_task",
+        claimed_by=AGENT,
+    )
+    todo_id = str(todo["todo_id"])
+
+    payload = _first_json_blob(
+        _control(registry).complete_task(todo_id, AGENT, "claimed done")
+    )
+
+    assert payload["ok"] is False
+    assert payload["completed"] is False
+    assert payload["changed"] is False
+    assert payload["settlement_blocked_completion"] is True
+    assert payload["settlement_identity"]["todo_id"] == todo_id
+    assert payload["settlement_result"]["failure"]["kind"] == (
+        "writeback_missing"
+    )
     assert _agent_todo_status(state, todo_id) != "done"
 
 def test_expected_lease_version_annotation_rejects_bool_at_the_boundary() -> None:

--- a/tests/test_goal_mode_mcp_settlement.py
+++ b/tests/test_goal_mode_mcp_settlement.py
@@ -266,6 +266,7 @@ def test_real_mcp_settlement_rejects_missing_writeback_then_commits_same_identit
         text="Deliver the bounded fixture change.",
         task_class="advancement_task",
         claimed_by=AGENT_ID,
+        continuation_policy="same_agent_non_delivery",
     )
     todo_id = str(added["todo_id"])
     request = HostTodoSettlementRequest(


### PR DESCRIPTION
## Summary

- reset the PR from the former 26-file claim-baseline protocol to the existing Todo settlement boundary;
- require turn-scoped agent advancement completion to consume the matching durable writeback and quota-spend receipt chain;
- preserve explicit `same_agent_non_delivery`, monitor, user-action, user-gate, and unscoped lifecycle paths.
- keep compatibility MCP fixtures explicitly non-delivery and return a typed settlement blocker for unsupported advancement completion.

## Why this is the minimum

The confirmed failure involved an advancement Todo marked complete before the accountable writeback and quota-spend chain existed. Current `main` already owns typed settlement identity, accountable writeback, quota spend, workspace causality, and delivery-workspace matching. This rewrite reuses those owners instead of adding claim-time baselines, caller-supplied delivery commits, remote/default-branch ancestry rules, Todo metadata fields, projection expansion, or caller-specific plumbing.

This PR intentionally does **not** claim that a workspace receipt proves a particular commit or pull request reached `main`, and it does not treat a dirty worktree at spend time as a generic settlement failure. That stronger delivery-provenance contract is deferred unless frequency/severity evidence proves it necessary.

## Validation

- adjacent settlement/Turn/MCP/model-tool suites: `189 passed`;
- the 14 exact failures from the previous Linux run: all passed locally;
- focused MCP completion checks: `4 passed`;
- Ruff and `git diff --check`: passed;
- maintainability ratchet: passed, zero unreviewed findings;
- standard premerge: `18/18` passed, zero failures, warnings, or manual holds;
- public/private boundary scan: passed.
- exact-head GitHub CI: all applicable checks passed, including Linux pytest,
  Windows lifecycle, DCO, dependency review, Pages/release builds, and SonarCloud.

## Scope comparison

- previous head: 26 files, `+2532/-114`, including a 553-line Git verifier and claim-baseline state/projection protocol;
- current head: 7 files, `+263/-45`, no new state field, CLI flag, capability, caller plumbing, or Git ancestry protocol.

## Future-facing pass

Applied by deletion: completion remains in the existing Todo/settlement boundary, while the invalid spend-time whole-worktree cleanliness rule was removed after parity tests proved it conflicted with existing Turn output lifecycles. No parallel source of truth or speculative compatibility layer remains.
