### PR TITLE
fix(chat): serialize queued turn creation

### DIFF
--- a/loopx/chat_store.py
+++ b/loopx/chat_store.py
@@ -134,6 +134,8 @@ class ChatSessionStore:
     def __init__(self, runtime_root: Path) -> None:
         self.root = runtime_root.expanduser().resolve() / "chat"
         self.sessions_root = self.root / "sessions"
+        self._session_lock_guard = threading.Lock()
+        self._session_locks: dict[str, threading.Lock] = {}
         self._event_lock = threading.RLock()
         self._event_cache: dict[tuple[str, str], list[dict[str, Any]]] = {}
         self._event_pending: dict[tuple[str, str], list[dict[str, Any]]] = {}
@@ -148,6 +150,11 @@ class ChatSessionStore:
 
     def _session_path(self, session_id: str) -> Path:
         return self._session_dir(session_id) / "session.json"
+
+    def _session_lock(self, session_id: str) -> threading.Lock:
+        token = _opaque_id(session_id, field="session_id")
+        with self._session_lock_guard:
+            return self._session_locks.setdefault(token, threading.Lock())
 
     def _turn_path(self, session_id: str, turn_id: str) -> Path:
         return self._session_dir(session_id) / "turns" / f"{_opaque_id(turn_id, field='turn_id')}.json"
@@ -242,29 +249,34 @@ class ChatSessionStore:
 
     def update_session(self, session_id: str, **changes: Any) -> dict[str, Any]:
         path = self._session_path(session_id)
-        with exclusive_file_lock(path, agent_id="loopx-chat", operation="update_chat_session"):
-            payload = self.load_session(session_id)
-            if payload is None:
-                raise KeyError("chat session was not found")
-            allowed = {
-                "status",
-                "active_turn_id",
-                "last_activity_at",
-                "last_error_code",
-                "upstream_thread_id",
-                "upstream_mode",
-            }
-            unknown = set(changes) - allowed
-            if unknown:
-                raise ValueError(f"unsupported chat session fields: {sorted(unknown)}")
-            if "upstream_thread_id" in changes:
-                changes["upstream_thread_id"] = _upstream_id(changes["upstream_thread_id"])
-            if "upstream_mode" in changes:
-                changes["upstream_mode"] = _opaque_id(changes["upstream_mode"], field="upstream_mode")
-            payload.update(changes)
-            payload["updated_at"] = utc_now()
-            _atomic_write_json(path, payload, preserve_mode=True)
-            return payload
+        with self._session_lock(session_id):
+            with exclusive_file_lock(
+                path,
+                agent_id="loopx-chat",
+                operation="update_chat_session",
+            ):
+                payload = self.load_session(session_id)
+                if payload is None:
+                    raise KeyError("chat session was not found")
+                allowed = {
+                    "status",
+                    "active_turn_id",
+                    "last_activity_at",
+                    "last_error_code",
+                    "upstream_thread_id",
+                    "upstream_mode",
+                }
+                unknown = set(changes) - allowed
+                if unknown:
+                    raise ValueError(f"unsupported chat session fields: {sorted(unknown)}")
+                if "upstream_thread_id" in changes:
+                    changes["upstream_thread_id"] = _upstream_id(changes["upstream_thread_id"])
+                if "upstream_mode" in changes:
+                    changes["upstream_mode"] = _opaque_id(changes["upstream_mode"], field="upstream_mode")
+                payload.update(changes)
+                payload["updated_at"] = utc_now()
+                _atomic_write_json(path, payload, preserve_mode=True)
+                return payload
 
     def release_active_turn(
         self,
@@ -277,27 +289,28 @@ class ChatSessionStore:
         """Make a Session ready only while the completing Turn still owns it."""
 
         path = self._session_path(session_id)
-        with exclusive_file_lock(
-            path,
-            agent_id="loopx-chat",
-            operation="release_active_chat_turn",
-        ):
-            payload = self.load_session(session_id)
-            if payload is None:
-                raise KeyError("chat session was not found")
-            if payload.get("active_turn_id") != turn_id:
-                return False
-            payload.update(
-                {
-                    "status": "ready",
-                    "active_turn_id": None,
-                    "last_activity_at": last_activity_at,
-                    "last_error_code": last_error_code,
-                    "updated_at": utc_now(),
-                }
-            )
-            _atomic_write_json(path, payload, preserve_mode=True)
-            return True
+        with self._session_lock(session_id):
+            with exclusive_file_lock(
+                path,
+                agent_id="loopx-chat",
+                operation="release_active_chat_turn",
+            ):
+                payload = self.load_session(session_id)
+                if payload is None:
+                    raise KeyError("chat session was not found")
+                if payload.get("active_turn_id") != turn_id:
+                    return False
+                payload.update(
+                    {
+                        "status": "ready",
+                        "active_turn_id": None,
+                        "last_activity_at": last_activity_at,
+                        "last_error_code": last_error_code,
+                        "updated_at": utc_now(),
+                    }
+                )
+                _atomic_write_json(path, payload, preserve_mode=True)
+                return True
 
     def latest_session(
         self,
@@ -455,66 +468,67 @@ class ChatSessionStore:
     ) -> tuple[dict[str, Any], bool]:
         client_id = _opaque_id(client_turn_id, field="client_turn_id")
         session_path = self._session_path(session_id)
-        with exclusive_file_lock(
-            session_path,
-            agent_id="loopx-chat",
-            operation="create_chat_turn",
-        ):
-            existing = self.turn_for_client(session_id, client_id)
-            if existing is not None:
-                return existing, False
-            session = self.load_session(session_id)
-            if session is None:
-                raise KeyError("chat session was not found")
-            active_turn_id = session.get("active_turn_id")
-            if active_turn_id:
-                active = self.load_turn(session_id, str(active_turn_id))
-                if active and active.get("status") in {"queued", "starting", "running", "interrupting"}:
-                    raise RuntimeError(str(active_turn_id))
-            now = utc_now()
-            turn_id = uuid.uuid4().hex
-            payload = {
-                "schema_version": CHAT_TURN_SCHEMA_VERSION,
-                "turn_id": turn_id,
-                "session_id": session_id,
-                "client_turn_id": client_id,
-                "status": "queued",
-                "message": str(message),
-                "origin": _opaque_id(origin, field="origin"),
-                "upstream_turn_id": None,
-                "response": None,
-                "error_code": None,
-                "error": None,
-                "created_at": now,
-                "started_at": None,
-                "first_event_at": None,
-                "completed_at": None,
-                "last_activity_at": now,
-                "delta_count": 0,
-                "sse_reconnect_count": 0,
-            }
-            path = self._turn_path(session_id, turn_id)
-            _atomic_write_json(path, payload)
-            os.chmod(path, 0o600)
-            session.update(
-                {
-                    "status": "busy",
-                    "active_turn_id": turn_id,
+        with self._session_lock(session_id):
+            with exclusive_file_lock(
+                session_path,
+                agent_id="loopx-chat",
+                operation="create_chat_turn",
+            ):
+                existing = self.turn_for_client(session_id, client_id)
+                if existing is not None:
+                    return existing, False
+                session = self.load_session(session_id)
+                if session is None or session.get("status") == "closed":
+                    raise KeyError("chat session was not found")
+                active_turn_id = session.get("active_turn_id")
+                if active_turn_id:
+                    active = self.load_turn(session_id, str(active_turn_id))
+                    if active and active.get("status") in {"queued", "starting", "running", "interrupting"}:
+                        raise RuntimeError(str(active_turn_id))
+                now = utc_now()
+                turn_id = uuid.uuid4().hex
+                payload = {
+                    "schema_version": CHAT_TURN_SCHEMA_VERSION,
+                    "turn_id": turn_id,
+                    "session_id": session_id,
+                    "client_turn_id": client_id,
+                    "status": "queued",
+                    "message": str(message),
+                    "origin": _opaque_id(origin, field="origin"),
+                    "upstream_turn_id": None,
+                    "response": None,
+                    "error_code": None,
+                    "error": None,
+                    "created_at": now,
+                    "started_at": None,
+                    "first_event_at": None,
+                    "completed_at": None,
                     "last_activity_at": now,
-                    "updated_at": utc_now(),
+                    "delta_count": 0,
+                    "sse_reconnect_count": 0,
                 }
+                path = self._turn_path(session_id, turn_id)
+                _atomic_write_json(path, payload)
+                os.chmod(path, 0o600)
+                session.update(
+                    {
+                        "status": "busy",
+                        "active_turn_id": turn_id,
+                        "last_activity_at": now,
+                        "updated_at": utc_now(),
+                    }
+                )
+                _atomic_write_json(session_path, session, preserve_mode=True)
+            self.append_message(
+                session_id,
+                role="user",
+                text=message,
+                turn_id=turn_id,
+                attachments=attachments,
+                origin=origin,
             )
-            _atomic_write_json(session_path, session, preserve_mode=True)
-        self.append_message(
-            session_id,
-            role="user",
-            text=message,
-            turn_id=turn_id,
-            attachments=attachments,
-            origin=origin,
-        )
-        self.append_event(session_id, turn_id, kind="turn.queued", payload={})
-        return payload, True
+            self.append_event(session_id, turn_id, kind="turn.queued", payload={})
+            return payload, True
 
     def create_queued_turn(
         self,
@@ -528,60 +542,76 @@ class ChatSessionStore:
         """Persist one bounded follow-up without replacing the active Turn."""
 
         client_id = _opaque_id(client_turn_id, field="client_turn_id")
-        existing = self.turn_for_client(session_id, client_id)
-        if existing is not None:
-            return existing, False
-        if self.load_session(session_id) is None:
-            raise KeyError("chat session was not found")
-        now = datetime.now(timezone.utc)
-        queued = [
-            turn
-            for turn in self.queued_turns(session_id)
-            if (_instant(turn.get("expires_at")) or now + timedelta(seconds=1)) > now
-        ]
-        if len(queued) >= SESSION_QUEUE_MAX_PENDING:
-            raise RuntimeError("session_queue_full")
-        turn_id = uuid.uuid4().hex
-        payload = {
-            "schema_version": CHAT_TURN_SCHEMA_VERSION,
-            "turn_id": turn_id,
-            "session_id": session_id,
-            "client_turn_id": client_id,
-            "status": "queued",
-            "message": str(message),
-            "origin": _opaque_id(origin, field="origin"),
-            "upstream_turn_id": None,
-            "response": None,
-            "error_code": None,
-            "error": None,
-            "created_at": now.isoformat().replace("+00:00", "Z"),
-            "expires_at": (now + timedelta(seconds=max(1, ttl_seconds)))
-            .isoformat()
-            .replace("+00:00", "Z"),
-            "started_at": None,
-            "first_event_at": None,
-            "completed_at": None,
-            "last_activity_at": now.isoformat().replace("+00:00", "Z"),
-            "delta_count": 0,
-            "sse_reconnect_count": 0,
-        }
-        path = self._turn_path(session_id, turn_id)
-        _atomic_write_json(path, payload)
-        os.chmod(path, 0o600)
-        self.append_message(
-            session_id,
-            role="user",
-            text=message,
-            turn_id=turn_id,
-            origin=origin,
-        )
-        self.append_event(
-            session_id,
-            turn_id,
-            kind="turn.queued",
-            payload={"delivery_mode": "session_queue"},
-        )
-        return payload, True
+        session_path = self._session_path(session_id)
+        with self._session_lock(session_id):
+            with exclusive_file_lock(
+                session_path,
+                agent_id="loopx-chat",
+                operation="create_chat_queued_turn",
+            ):
+                existing = self.turn_for_client(session_id, client_id)
+                if existing is not None:
+                    return existing, False
+                session = self.load_session(session_id)
+                if session is None or session.get("status") == "closed":
+                    raise KeyError("chat session was not found")
+                now = datetime.now(timezone.utc)
+                queued = [
+                    turn
+                    for turn in self.queued_turns(session_id)
+                    if (_instant(turn.get("expires_at")) or now + timedelta(seconds=1)) > now
+                ]
+                if len(queued) >= SESSION_QUEUE_MAX_PENDING:
+                    raise RuntimeError("session_queue_full")
+                turn_id = uuid.uuid4().hex
+                now_text = now.isoformat().replace("+00:00", "Z")
+                payload = {
+                    "schema_version": CHAT_TURN_SCHEMA_VERSION,
+                    "turn_id": turn_id,
+                    "session_id": session_id,
+                    "client_turn_id": client_id,
+                    "status": "queued",
+                    "message": str(message),
+                    "origin": _opaque_id(origin, field="origin"),
+                    "upstream_turn_id": None,
+                    "response": None,
+                    "error_code": None,
+                    "error": None,
+                    "created_at": now_text,
+                    "expires_at": (now + timedelta(seconds=max(1, ttl_seconds)))
+                    .isoformat()
+                    .replace("+00:00", "Z"),
+                    "started_at": None,
+                    "first_event_at": None,
+                    "completed_at": None,
+                    "last_activity_at": now_text,
+                    "delta_count": 0,
+                    "sse_reconnect_count": 0,
+                }
+                path = self._turn_path(session_id, turn_id)
+                _atomic_write_json(path, payload)
+                os.chmod(path, 0o600)
+                session.update(
+                    {
+                        "last_activity_at": now_text,
+                        "updated_at": utc_now(),
+                    }
+                )
+                _atomic_write_json(session_path, session, preserve_mode=True)
+            self.append_message(
+                session_id,
+                role="user",
+                text=message,
+                turn_id=turn_id,
+                origin=origin,
+            )
+            self.append_event(
+                session_id,
+                turn_id,
+                kind="turn.queued",
+                payload={"delivery_mode": "session_queue"},
+            )
+            return payload, True
 
     def queued_turns(self, session_id: str) -> list[dict[str, Any]]:
         session = self.load_session(session_id)
@@ -617,84 +647,90 @@ class ChatSessionStore:
         """Atomically make the oldest live queued Turn active for its Session."""
 
         session_path = self._session_path(session_id)
-        with exclusive_file_lock(
-            session_path,
-            agent_id="loopx-chat",
-            operation="claim_session_queue_turn",
-        ):
-            session = self.load_session(session_id)
-            if session is None:
-                raise KeyError("chat session was not found")
-            if session.get("status") == "closed":
-                return None
-            active_turn_id = str(session.get("active_turn_id") or "")
-            if active_turn_id:
-                active = self.load_turn(session_id, active_turn_id)
-                if (
-                    active
-                    and host_claim_id
-                    and active.get("host_claim_id") == host_claim_id
-                    and active.get("status") in {"starting", "running"}
-                ):
-                    return active
-                return None
-            now = datetime.now(timezone.utc)
-            for turn in self.queued_turns(session_id):
-                turn_id = str(turn["turn_id"])
-                expires_at = _instant(turn.get("expires_at"))
-                if expires_at is not None and expires_at <= now:
-                    completed = utc_now()
-                    self.update_turn(
-                        session_id,
-                        turn_id,
-                        status="timed_out",
-                        error_code="session_queue_expired",
-                        error="Queued Agent ingress expired before dispatch.",
-                        completed_at=completed,
-                        last_activity_at=completed,
-                    )
-                    self.append_event(
-                        session_id,
-                        turn_id,
-                        kind="turn.failed",
-                        payload={"error_code": "session_queue_expired"},
-                    )
-                    continue
-                if host_claim_id:
-                    now_text = utc_now()
-                    turn.update(
+        with self._session_lock(session_id):
+            with exclusive_file_lock(
+                session_path,
+                agent_id="loopx-chat",
+                operation="claim_session_queue_turn",
+            ):
+                session = self.load_session(session_id)
+                if session is None:
+                    raise KeyError("chat session was not found")
+                if session.get("status") == "closed":
+                    return None
+                active_turn_id = str(session.get("active_turn_id") or "")
+                if active_turn_id:
+                    active = self.load_turn(session_id, active_turn_id)
+                    if (
+                        active
+                        and host_claim_id
+                        and active.get("host_claim_id") == host_claim_id
+                        and active.get("status") in {"starting", "running"}
+                    ):
+                        return active
+                    return None
+                now = datetime.now(timezone.utc)
+                for turn in self.queued_turns(session_id):
+                    turn_id = str(turn["turn_id"])
+                    expires_at = _instant(turn.get("expires_at"))
+                    if expires_at is not None and expires_at <= now:
+                        completed = utc_now()
+                        turn.update(
+                            {
+                                "status": "timed_out",
+                                "error_code": "session_queue_expired",
+                                "error": "Queued Agent ingress expired before dispatch.",
+                                "completed_at": completed,
+                                "last_activity_at": completed,
+                            }
+                        )
+                        _atomic_write_json(
+                            self._turn_path(session_id, turn_id),
+                            turn,
+                            preserve_mode=True,
+                        )
+                        self.append_event(
+                            session_id,
+                            turn_id,
+                            kind="turn.failed",
+                            payload={"error_code": "session_queue_expired"},
+                        )
+                        continue
+                    if host_claim_id:
+                        now_text = utc_now()
+                        turn.update(
+                            {
+                                "status": "running",
+                                "host_claim_id": _opaque_id(
+                                    host_claim_id,
+                                    field="host_claim_id",
+                                ),
+                                "started_at": turn.get("started_at") or now_text,
+                                "last_activity_at": now_text,
+                            }
+                        )
+                        _atomic_write_json(
+                            self._turn_path(session_id, turn_id),
+                            turn,
+                            preserve_mode=True,
+                        )
+                        self.append_event(
+                            session_id,
+                            turn_id,
+                            kind="turn.claimed_by_attached_host",
+                            payload={"host_claim_id": host_claim_id},
+                        )
+                    session.update(
                         {
-                            "status": "running",
-                            "host_claim_id": _opaque_id(
-                                host_claim_id,
-                                field="host_claim_id",
-                            ),
-                            "started_at": turn.get("started_at") or now_text,
-                            "last_activity_at": now_text,
+                            "status": "busy",
+                            "active_turn_id": turn_id,
+                            "last_activity_at": utc_now(),
+                            "updated_at": utc_now(),
                         }
                     )
-                    _atomic_write_json(
-                        self._turn_path(session_id, turn_id),
-                        turn,
-                        preserve_mode=True,
-                    )
-                    self.append_event(
-                        session_id,
-                        turn_id,
-                        kind="turn.claimed_by_attached_host",
-                        payload={"host_claim_id": host_claim_id},
-                    )
-                session.update(
-                    {
-                        "status": "busy",
-                        "active_turn_id": turn_id,
-                        "last_activity_at": utc_now(),
-                        "updated_at": utc_now(),
-                    }
-                )
-                _atomic_write_json(session_path, session, preserve_mode=True)
-                return turn
-            return None
+                    _atomic_write_json(session_path, session, preserve_mode=True)
+                    return turn
+                return None
 
     def turn_for_client(self, session_id: str, client_turn_id: str) -> dict[str, Any] | None:
         turns_dir = self._session_dir(session_id) / "turns"
@@ -852,39 +888,40 @@ class ChatSessionStore:
         """Close an idle attached Session without stranding a claimed Turn."""
 
         session_path = self._session_path(session_id)
-        with exclusive_file_lock(
-            session_path,
-            agent_id="loopx-chat",
-            operation="close_attached_chat_session",
-        ):
-            session = self.load_session(session_id)
-            if session is None:
-                return False
-            if session.get("session_mode") != CHAT_SESSION_MODE_ATTACHED:
-                raise ValueError("the selected Session is not an attached host session")
-            if session.get("status") == "closed":
+        with self._session_lock(session_id):
+            with exclusive_file_lock(
+                session_path,
+                agent_id="loopx-chat",
+                operation="close_attached_chat_session",
+            ):
+                session = self.load_session(session_id)
+                if session is None:
+                    return False
+                if session.get("session_mode") != CHAT_SESSION_MODE_ATTACHED:
+                    raise ValueError("the selected Session is not an attached host session")
+                if session.get("status") == "closed":
+                    return True
+                active_turn_id = str(session.get("active_turn_id") or "")
+                if active_turn_id:
+                    active_turn = self.load_turn(session_id, active_turn_id)
+                    if active_turn and active_turn.get("status") not in {
+                        "completed",
+                        "interrupted",
+                        "timed_out",
+                        "failed",
+                    }:
+                        raise RuntimeError("attached_session_turn_active")
+                now = utc_now()
+                session.update(
+                    {
+                        "status": "closed",
+                        "active_turn_id": None,
+                        "last_activity_at": now,
+                        "updated_at": now,
+                    }
+                )
+                _atomic_write_json(session_path, session, preserve_mode=True)
                 return True
-            active_turn_id = str(session.get("active_turn_id") or "")
-            if active_turn_id:
-                active_turn = self.load_turn(session_id, active_turn_id)
-                if active_turn and active_turn.get("status") not in {
-                    "completed",
-                    "interrupted",
-                    "timed_out",
-                    "failed",
-                }:
-                    raise RuntimeError("attached_session_turn_active")
-            now = utc_now()
-            session.update(
-                {
-                    "status": "closed",
-                    "active_turn_id": None,
-                    "last_activity_at": now,
-                    "updated_at": now,
-                }
-            )
-            _atomic_write_json(session_path, session, preserve_mode=True)
-            return True
 
     def _event_rows_locked(self, session_id: str, turn_id: str) -> list[dict[str, Any]]:
         key = (session_id, turn_id)

--- a/tests/test_chat_session_active_turn.py
+++ b/tests/test_chat_session_active_turn.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from pathlib import Path
 import threading
 import time
@@ -36,31 +37,15 @@ def _slow_new_turn_writes(monkeypatch) -> set[str]:
     return turn_write_threads
 
 
-def test_concurrent_managed_turn_creation_claims_active_once(
-    tmp_path: Path,
-    monkeypatch,
-) -> None:
-    store = ChatSessionStore(tmp_path)
-    session = store.create_session(
-        goal_id="goal-one",
-        agent_id="codex",
-        executor_endpoint_id="codex",
-        adapter_kind="codex_app_server",
-        upstream_thread_id="thread-one",
-        upstream_mode="chat",
-    )
-    session_id = str(session["session_id"])
-    turn_write_threads = _slow_new_turn_writes(monkeypatch)
+def _run_two_client_turn_creators(
+    create_turn: Callable[[str], tuple[dict[str, object], bool]],
+) -> tuple[list[tuple[str, str, bool]], list[str]]:
     results: list[tuple[str, str, bool]] = []
     errors: list[str] = []
 
     def create(client_turn_id: str) -> None:
         try:
-            turn, created = store.create_turn(
-                session_id,
-                client_turn_id=client_turn_id,
-                message=f"message from {client_turn_id}",
-            )
+            turn, created = create_turn(client_turn_id)
             results.append((client_turn_id, str(turn["turn_id"]), created))
         except RuntimeError as exc:
             errors.append(str(exc))
@@ -79,6 +64,32 @@ def test_concurrent_managed_turn_creation_claims_active_once(
         thread.join(timeout=3)
 
     assert not any(thread.is_alive() for thread in threads)
+    return results, errors
+
+
+def test_concurrent_managed_turn_creation_claims_active_once(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    store = ChatSessionStore(tmp_path)
+    session = store.create_session(
+        goal_id="goal-one",
+        agent_id="codex",
+        executor_endpoint_id="codex",
+        adapter_kind="codex_app_server",
+        upstream_thread_id="thread-one",
+        upstream_mode="chat",
+    )
+    session_id = str(session["session_id"])
+    turn_write_threads = _slow_new_turn_writes(monkeypatch)
+    results, errors = _run_two_client_turn_creators(
+        lambda client_turn_id: store.create_turn(
+            session_id,
+            client_turn_id=client_turn_id,
+            message=f"message from {client_turn_id}",
+        )
+    )
+
     assert len(results) == 1
     assert len(errors) == 1
     active_turn_id = results[0][1]
@@ -169,34 +180,14 @@ def test_concurrent_queued_turn_creation_is_atomic(
         assert created
         assert queued["status"] == "queued"
     turn_write_threads = _slow_new_turn_writes(monkeypatch)
-    results: list[tuple[str, str, bool]] = []
-    errors: list[str] = []
-
-    def create(client_turn_id: str) -> None:
-        try:
-            turn, created = store.create_queued_turn(
-                session_id,
-                client_turn_id=client_turn_id,
-                message=f"message from {client_turn_id}",
-            )
-            results.append((client_turn_id, str(turn["turn_id"]), created))
-        except RuntimeError as exc:
-            errors.append(str(exc))
-
-    threads = [
-        threading.Thread(
-            target=create,
-            args=(f"client-{index}",),
-            name=f"creator-{index}",
+    results, errors = _run_two_client_turn_creators(
+        lambda client_turn_id: store.create_queued_turn(
+            session_id,
+            client_turn_id=client_turn_id,
+            message=f"message from {client_turn_id}",
         )
-        for index in (1, 2)
-    ]
-    for thread in threads:
-        thread.start()
-    for thread in threads:
-        thread.join(timeout=3)
+    )
 
-    assert not any(thread.is_alive() for thread in threads)
     assert len(results) == 1
     assert len(errors) == 1
     assert errors == ["session_queue_full"]

--- a/tests/test_chat_session_active_turn.py
+++ b/tests/test_chat_session_active_turn.py
@@ -3,23 +3,10 @@ import threading
 import time
 
 import loopx.chat_store as chat_store
-from loopx.chat_store import ChatSessionStore
+from loopx.chat_store import ChatSessionStore, SESSION_QUEUE_MAX_PENDING
 
 
-def test_concurrent_managed_turn_creation_claims_active_once(
-    tmp_path: Path,
-    monkeypatch,
-) -> None:
-    store = ChatSessionStore(tmp_path)
-    session = store.create_session(
-        goal_id="goal-one",
-        agent_id="codex",
-        executor_endpoint_id="codex",
-        adapter_kind="codex_app_server",
-        upstream_thread_id="thread-one",
-        upstream_mode="chat",
-    )
-    session_id = str(session["session_id"])
+def _slow_new_turn_writes(monkeypatch) -> set[str]:
     original_atomic_write = chat_store._atomic_write_json
     turn_write_threads: set[str] = set()
     condition = threading.Condition()
@@ -46,6 +33,24 @@ def test_concurrent_managed_turn_creation_claims_active_once(
         original_atomic_write(path, payload, preserve_mode=preserve_mode)
 
     monkeypatch.setattr(chat_store, "_atomic_write_json", slow_new_turn_write)
+    return turn_write_threads
+
+
+def test_concurrent_managed_turn_creation_claims_active_once(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    store = ChatSessionStore(tmp_path)
+    session = store.create_session(
+        goal_id="goal-one",
+        agent_id="codex",
+        executor_endpoint_id="codex",
+        adapter_kind="codex_app_server",
+        upstream_thread_id="thread-one",
+        upstream_mode="chat",
+    )
+    session_id = str(session["session_id"])
+    turn_write_threads = _slow_new_turn_writes(monkeypatch)
     results: list[tuple[str, str, bool]] = []
     errors: list[str] = []
 
@@ -139,3 +144,140 @@ def test_completed_turn_cannot_release_a_newer_active_turn(tmp_path: Path) -> No
     assert current is not None
     assert current["status"] == "ready"
     assert current["active_turn_id"] is None
+
+
+def test_concurrent_queued_turn_creation_is_atomic(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    store = ChatSessionStore(tmp_path)
+    session = store.create_session(
+        goal_id="goal-one",
+        agent_id="codex",
+        executor_endpoint_id="codex",
+        adapter_kind="codex_app_server",
+        upstream_thread_id="thread-one",
+        upstream_mode="chat",
+    )
+    session_id = str(session["session_id"])
+    for index in range(SESSION_QUEUE_MAX_PENDING - 1):
+        queued, created = store.create_queued_turn(
+            session_id,
+            client_turn_id=f"prefill-{index}",
+            message=f"prefill message {index}",
+        )
+        assert created
+        assert queued["status"] == "queued"
+    turn_write_threads = _slow_new_turn_writes(monkeypatch)
+    results: list[tuple[str, str, bool]] = []
+    errors: list[str] = []
+
+    def create(client_turn_id: str) -> None:
+        try:
+            turn, created = store.create_queued_turn(
+                session_id,
+                client_turn_id=client_turn_id,
+                message=f"message from {client_turn_id}",
+            )
+            results.append((client_turn_id, str(turn["turn_id"]), created))
+        except RuntimeError as exc:
+            errors.append(str(exc))
+
+    threads = [
+        threading.Thread(
+            target=create,
+            args=(f"client-{index}",),
+            name=f"creator-{index}",
+        )
+        for index in (1, 2)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=3)
+
+    assert not any(thread.is_alive() for thread in threads)
+    assert len(results) == 1
+    assert len(errors) == 1
+    assert errors == ["session_queue_full"]
+    assert len(turn_write_threads) == 1
+    assert [
+        item["text"] for item in store.messages(session_id) if item["role"] == "user"
+    ][-2:] == [f"prefill message {SESSION_QUEUE_MAX_PENDING - 2}", f"message from {results[0][0]}"]
+    current = store.load_session(session_id)
+    assert current is not None
+    assert current["status"] == "ready"
+    assert current["active_turn_id"] is None
+
+
+def test_concurrent_queued_turn_creation_is_idempotent(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    store = ChatSessionStore(tmp_path)
+    session = store.create_session(
+        goal_id="goal-one",
+        agent_id="codex",
+        executor_endpoint_id="codex",
+        adapter_kind="codex_app_server",
+        upstream_thread_id="thread-one",
+        upstream_mode="chat",
+    )
+    session_id = str(session["session_id"])
+    turn_write_threads = _slow_new_turn_writes(monkeypatch)
+    results: list[tuple[str, str, bool]] = []
+
+    def create() -> None:
+        turn, created = store.create_queued_turn(
+            session_id,
+            client_turn_id="shared-client",
+            message="same message",
+        )
+        results.append((str(turn["turn_id"]), created))
+
+    threads = [
+        threading.Thread(target=create, name=f"creator-{index}")
+        for index in (1, 2)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=3)
+
+    assert not any(thread.is_alive() for thread in threads)
+    assert len(results) == 2
+    assert {created for _turn_id, created in results} == {True, False}
+    assert len({turn_id for turn_id, _created in results}) == 1
+    assert len(turn_write_threads) == 1
+    assert [
+        item["text"] for item in store.messages(session_id) if item["role"] == "user"
+    ] == ["same message"]
+    current = store.load_session(session_id)
+    assert current is not None
+    assert current["status"] == "ready"
+    assert current["active_turn_id"] is None
+
+
+def test_queued_turn_rejects_closed_session(tmp_path: Path) -> None:
+    store = ChatSessionStore(tmp_path)
+    session = store.create_session(
+        goal_id="goal-one",
+        agent_id="codex",
+        executor_endpoint_id="codex",
+        adapter_kind="codex_app_server",
+        upstream_thread_id="thread-one",
+        upstream_mode="chat",
+    )
+    session_id = str(session["session_id"])
+    store.update_session(session_id, status="closed", active_turn_id=None)
+
+    try:
+        store.create_queued_turn(
+            session_id,
+            client_turn_id="closed-session",
+            message="should not queue",
+        )
+    except KeyError as exc:
+        assert str(exc) == "'chat session was not found'"
+    else:  # pragma: no cover - safety net for unexpected passes.
+        raise AssertionError("closed session should not accept queued turns")


### PR DESCRIPTION
## Summary

- add a session-scoped in-process mutex around chat session mutations while keeping the existing filesystem lock for cross-process protection
- make queued turn creation atomic for idempotency, queue-cap enforcement, session activity updates, and closed-session rejection
- cover concurrent queued creates with regression tests for queue overflow, duplicate client_turn_id, and closed sessions

## Why

I hit this while exercising the attached chat runtime: the local server can accept concurrent follow-up messages for the same session from the same Python process. `exclusive_file_lock` protects separate processes, but POSIX file locks do not serialize threads inside one process. That left a real window where two queued-turn creates could both read the same session/queue snapshot, both write a new turn, and then append duplicate transcript rows.

The visible symptom is not just a test-only race: users can see extra queued messages, duplicated idempotent submissions, queue limits not holding under pressure, or a closed attached session still accepting a queued follow-up.

## Approach

I kept the authority in `ChatSessionStore` and did not add a new dependency or protocol field. Session-owned mutations now take a per-session Python mutex before the existing file lock. That keeps same-session state transitions serialized in-process, preserves cross-process locking, and still allows different sessions to proceed independently.

The queued create path now checks idempotency, live session status, queue capacity, turn write, session activity, message append, and queued event append under the same per-session critical section. The attached close path also re-reads and writes under the same session/file-lock ordering so it cannot race stale session state.

## Validation

- `uv run --extra test pytest tests/test_chat_session_active_turn.py::test_concurrent_queued_turn_creation_is_atomic tests/test_chat_session_active_turn.py::test_concurrent_queued_turn_creation_is_idempotent tests/test_chat_session_active_turn.py::test_queued_turn_rejects_closed_session -q` -> `3 passed`
- `uv run --extra test pytest tests/test_chat_session_active_turn.py tests/test_attached_session_broker.py tests/test_attached_session_cli.py tests/test_chat_server_cors.py tests/test_chat_image_attachments.py tests/test_chat_lark_api_contract.py -q` -> `36 passed`
- `uv run --extra test ruff check loopx/chat_store.py tests/test_chat_session_active_turn.py` -> passed
- `uv run --extra test python -m compileall -q loopx/chat_store.py tests/test_chat_session_active_turn.py` -> passed
- `uv run --extra test loopx canary premerge --from-git-diff` -> passed
- `npm run test:control-plane` -> `121 passed`
- `git diff --check` -> passed

Full `uv run --extra test pytest -q` result on this branch: `4240 passed, 10 skipped, 6 failed`. The failures are all in `tests/test_dashboard_command.py` launcher expectations that look for `-m loopx.cli serve-status`; the command log contains `status http://127.0.0.1:8766/healthz` and `Chat http://127.0.0.1:8767/api/chat/capabilities` instead. I do not see a call path from this chat-store queue serialization patch into those dashboard launcher fixtures.

Signed-off-by: duang777 <duangjl007@gmail.com>