### PR TITLE
feat(update): make installation ownership explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ loopx workflow-skills --install
 loopx doctor
 ```
 
+Existing installs can use `loopx update plan` and `loopx update apply`; LoopX
+keeps the detected pip, pipx, or archive owner instead of switching channels.
+
 On native Windows PowerShell 7, use the same PyPI release without a POSIX
 compatibility layer:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -220,6 +220,9 @@ loopx workflow-skills --install
 loopx doctor
 ```
 
+已有安装可使用 `loopx update plan` 与 `loopx update apply`；LoopX 会保留检测到
+的 pip、pipx 或 archive owner，不会在升级时暗中切换安装渠道。
+
 原生 Windows PowerShell 7 可直接使用同一 PyPI release，不需要 POSIX 兼容层：
 
 ```powershell

--- a/docs/book/chapters/appendix-reference.md
+++ b/docs/book/chapters/appendix-reference.md
@@ -95,14 +95,15 @@ identity 或 Host selection gate。选择后使用 packet 给出的精确命令�
 
 no-clone 安装的主路径是 `loopx update`，不是手工覆盖 release snapshot：
 
-先用 `loopx update --check` 只读检查，再用 `loopx update --dry-run` 预览；两步都不会安装。
+先用 `loopx update check` 只读检查 freshness 与安装 owner，再用 `loopx update plan`
+预览；两步都不会安装。
 
 正常升级只需要：
 
 ```bash
-loopx update --check
-loopx update --dry-run
-loopx update --execute
+loopx update check
+loopx update plan
+loopx update apply
 loopx doctor
 ```
 
@@ -115,13 +116,13 @@ loopx --version
 loopx --format json doctor > /tmp/loopx-doctor-before.json
 
 # 2. 检查 stable ref、freshness 与推荐动作
-loopx update --check
+loopx update check
 
 # 3. 预览将安装的 ref、release id 与回滚目标
-loopx update --dry-run
+loopx update plan
 
 # 4. 执行 archive installer，并由 update 运行 post-update doctor
-loopx update --execute
+loopx update apply
 
 # 5. 重验命令、skill、Host 与项目状态
 loopx --version
@@ -131,8 +132,9 @@ loopx slash-commands --install
 loopx status
 ```
 
-默认来源是公开 `stable` ref。`--ref main` 是 maintainer/dev qualification 路径，不应作为普通用户
-默认升级。`update --execute` 安装 release snapshot 并运行 doctor；成功退出不代表每个 Host
+archive 的默认来源是公开 `stable` ref。`--ref main` 是 maintainer/dev qualification 路径，
+不应作为普通用户默认升级。`update apply` 保留当前安装 owner：pip/pipx 继续管理 PyPI 环境，
+archive 继续管理 release snapshot，live checkout 仍需显式更新。成功退出不代表每个 Host
 automation、Goal migration 或 Extension Provider 都已更新。
 
 升级后按使用面继续验证：

--- a/docs/book/en/chapters/appendix-reference.md
+++ b/docs/book/en/chapters/appendix-reference.md
@@ -96,15 +96,16 @@ an existing identity only for an explicitly authorized takeover.
 For a no-clone installation, `loopx update` is the primary path. Do not overwrite a release snapshot by
 hand:
 
-Run `loopx update --check` for a read-only freshness check, then
-`loopx update --dry-run` for the install preview. Neither command installs.
+Run `loopx update check` for a read-only freshness and installation-owner
+check, then `loopx update plan` for the install preview. Neither command
+installs.
 
 A normal upgrade needs only:
 
 ```bash
-loopx update --check
-loopx update --dry-run
-loopx update --execute
+loopx update check
+loopx update plan
+loopx update apply
 loopx doctor
 ```
 
@@ -118,13 +119,13 @@ loopx --version
 loopx --format json doctor > /tmp/loopx-doctor-before.json
 
 # 2. Inspect stable ref, freshness, and the recommendation
-loopx update --check
+loopx update check
 
 # 3. Preview the ref, release id, and rollback target
-loopx update --dry-run
+loopx update plan
 
 # 4. Run the archive installer and post-update doctor
-loopx update --execute
+loopx update apply
 
 # 5. Recheck commands, skills, Host integration, and project state
 loopx --version
@@ -134,10 +135,11 @@ loopx slash-commands --install
 loopx status
 ```
 
-The public `stable` ref is the default source. `--ref main` is a maintainer or development qualification
-path, not the ordinary user default. `update --execute` installs a release snapshot and runs doctor; a
-successful exit does not prove that every Host automation, Goal migration, or Extension Provider is
-updated.
+The public `stable` ref is the default archive source. `--ref main` is a maintainer or development
+qualification path, not the ordinary user default. `update apply` preserves the active installation
+owner: pip and pipx keep the PyPI environment, archive installs keep the release snapshot, and live
+checkouts remain explicit. A successful exit does not prove that every Host automation, Goal migration,
+or Extension Provider is updated.
 
 Validate the surfaces you use:
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -376,9 +376,10 @@ loopx slash-commands --install
 loopx doctor
 ```
 
-The GitHub Pages archive installer remains available as a fallback. Archive
-installs keep their existing `loopx update --check|--dry-run|--execute` path;
-do not mix that updater with the active PyPI executable.
+The GitHub Pages archive installer remains available as a fallback. `loopx
+update` now projects the active installation owner: PyPI environments stay
+package-manager owned, archive snapshots stay LoopX owned, and live source
+checkouts stay Git owned.
 
 ## Contributor Install
 
@@ -417,13 +418,18 @@ checkout to the default local release.
 - the local manual page under `~/.local/share/man`;
 - the LoopX Codex skills under `~/.codex/skills`.
 
-For a no-clone install, use `loopx update` to refresh the release snapshot and
-skills:
+Use the named update actions so read-only inspection and mutation are visible:
 
 ```bash
-loopx update --check
-loopx update --execute
+loopx update check
+loopx update plan
+loopx update apply
 ```
+
+On PyPI installs, apply uses the owning pip or pipx environment and then
+refreshes host material and readbacks. On archive installs, it atomically
+replaces the release snapshot. A live checkout is never pulled or rewritten by
+this command; update Git explicitly and rerun the contributor installer.
 
 For a contributor checkout, re-run the installer to update both surfaces from
 the current clean `origin/main` checkout:
@@ -1039,7 +1045,7 @@ bootstrap / connect     connect a project-local goal
 new-project-prompt      generate a Codex prompt for project connection
 demo                    create a disposable local demo goal
 doctor                  diagnose installation and import health
-update                  check or execute a no-clone LoopX self-update
+update [check|plan|apply] inspect or apply through the active install owner
 registry                inspect registered goals
 registry-boundary       classify registry local/public boundary and push policy
 status                  show first-screen operator status

--- a/docs/guides/installing-loopx.md
+++ b/docs/guides/installing-loopx.md
@@ -10,6 +10,19 @@ loopx workflow-skills --install
 loopx doctor
 ```
 
+Choose one installation owner and keep it authoritative:
+
+| Use case | Owner | Install or acquire | Upgrade |
+| --- | --- | --- | --- |
+| Normal release | Python package environment | `python3 -m pip install loopx` | `loopx update apply` or the manual pip sequence below |
+| Isolated CLI on an externally managed machine | `pipx` | `pipx install loopx` | `pipx upgrade loopx`, then refresh LoopX host material |
+| Contributor or source qualification | Git checkout | clone/fetch plus `scripts/install-local.sh` | update the checkout explicitly, rerun the installer, validate `loopx-canary` before promotion |
+| No-clone recovery fallback | LoopX archive snapshot | published archive installer | `loopx update apply` |
+
+PyPI is the canonical source for normal releases. A source checkout is a
+development and qualification surface, not a second implicit package channel.
+The archive snapshot remains a recovery path rather than a competing default.
+
 LoopX's Effect Program core runs in a managed, idle-exiting TypeScript runtime
 and requires Node.js 22.6 or later. LoopX starts and reuses that local runtime
 automatically; users do not run a daemon manually. The runtime binds only to
@@ -118,8 +131,32 @@ gate.
 
 ## Upgrade And Repair
 
-Upgrade the Python distribution first, then refresh the host material from the
-same version:
+`loopx update` is the channel-aware upgrade entry point. Its actions have the
+same meaning for humans and agents:
+
+```bash
+loopx update check       # read-only freshness and installation-owner check
+loopx update plan        # read-only command, validation, and rollback plan
+loopx update apply       # explicit local-environment mutation
+```
+
+Bare `loopx update` remains a read-only plan. The older `--check`, `--dry-run`,
+and `--execute` spellings remain compatibility aliases, but new instructions
+should use the named actions.
+
+Human-readable output starts with **No update was applied** and a copyable
+**Next Action** command. JSON output exposes the same decision as
+`requested_action`, `changes_applied`, and a typed `next_action` object with
+mutation and authorization fields. Agents should inspect those fields instead
+of inferring authority from prose.
+
+For a PyPI distribution installed by pip, `update apply` asks the exact Python
+interpreter that owns LoopX to upgrade its environment, then starts fresh
+processes to install workflow skills and slash commands, runs doctor, revalidates
+enabled extensions, and restarts managed local LoopX services. It does not
+switch the installation to an archive snapshot.
+
+The equivalent manual sequence is:
 
 ```bash
 python3 -m pip install --upgrade loopx
@@ -127,6 +164,18 @@ loopx workflow-skills --install
 loopx slash-commands --install
 loopx doctor
 ```
+
+The first command is the package transaction; the remaining commands are the
+LoopX activation and readback contract. Running only `pip install` can leave
+host material from the previous version active. Conversely, `loopx update
+apply` does not replace pip as the owner of dependency resolution, environment
+policy, package indexes, or uninstall.
+
+For an installation owned by another Python package manager, `update plan`
+reports that owner and its command; LoopX fails closed instead of guessing a
+pip mutation. For a live source checkout, it reports the contributor installer
+and never performs `git pull` or rewrites the worktree. Source acquisition and
+repository mutation remain explicit human or authorized-agent actions.
 
 `loopx doctor` reports `install_kind: python_distribution` for this path and
 returns the same pip-native repair sequence when packaged skills are missing or
@@ -157,8 +206,18 @@ loopx doctor
 ```
 
 This fallback installs an archive snapshot, wrapper, man page, and host
-materials together. Its update path remains `loopx update`; do not mix the
-archive and PyPI upgrade mechanisms for the same active executable.
+materials together. LoopX owns that snapshot lifecycle, so its update path is:
+
+```bash
+loopx update check
+loopx update plan
+loopx update apply
+```
+
+Archive apply retains the atomic release pointer, doctor validation, extension
+readback, managed-service restart, and first-class snapshot rollback. The
+installation-owner projection prevents this path from being mixed with an
+active PyPI executable.
 
 ## Uninstall
 

--- a/docs/guides/installing-loopx.md
+++ b/docs/guides/installing-loopx.md
@@ -147,7 +147,7 @@ should use the named actions.
 Human-readable output starts with **No update was applied** and a copyable
 **Next Action** command. JSON output exposes the same decision as
 `requested_action`, `changes_applied`, and a typed `next_action` object with
-mutation and authorization fields. Agents should inspect those fields instead
+mutation and explicit-approval fields. Agents should inspect those fields instead
 of inferring authority from prose.
 
 For a PyPI distribution installed by pip, `update apply` asks the exact Python

--- a/docs/product/release-note-template.md
+++ b/docs/product/release-note-template.md
@@ -26,8 +26,8 @@ operator surface." Keep this readable in 15 seconds.>
 command. Full commands live in `## Install / Update` below.>
 
 ```bash
-loopx update --check       # 已是最新则无需操作
-loopx update --execute     # 升级到 vX.Y.Z
+loopx update check         # 只读检查安装 owner 与新版本
+loopx update apply         # 由当前安装 owner 升级到 vX.Y.Z
 loopx --version && loopx doctor
 ```
 
@@ -169,12 +169,13 @@ loopx slash-commands --install
 loopx doctor
 ```
 
-Archive-fallback users should preview and execute their archive update
-explicitly:
+All existing installs use explicit update intent; the command preserves the
+active pip, pipx, or archive owner:
 
 ```bash
-loopx update --check --ref stable
-loopx update --execute --ref stable
+loopx update check
+loopx update plan
+loopx update apply
 loopx doctor
 ```
 

--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -9,32 +9,33 @@ which control-plane surfaces are safe to build on.
 
 ## Supported Install And Update Paths
 
-For a first-time user, prefer the no-clone archive installer:
+For a first-time user, prefer the canonical PyPI release:
 
 ```bash
-curl -fsSL https://huangruiteng.github.io/loopx/install.sh | bash
-export PATH="$HOME/.local/bin:$PATH"
+python3 -m pip install --upgrade loopx
+loopx workflow-skills --install
 loopx doctor
 ```
 
-The installer and `loopx update` use the public `stable` ref by default. Use
-`LOOPX_REF=main` or `loopx update --ref main` only for maintainer/dev repair
-when you intentionally want the current repository head instead of the stable
-channel.
+PyPI owns normal release acquisition and dependency resolution. `loopx update
+apply` uses that same owning environment and then refreshes LoopX host material
+and readbacks; it does not switch channels.
 
-For a user who already installed from the archive, update through the explicit
-CLI flow:
+Use the same explicit intent flow for PyPI and archive installations:
 
 ```bash
-loopx update --check
-loopx update --dry-run
-loopx update --execute
+loopx update check
+loopx update plan
+loopx update apply
 loopx doctor
 ```
 
-Re-running the curl installer remains a repair/fallback path when the wrapper
-or local release snapshot is broken. It is not the primary update path for a
-healthy archive install.
+For a pip or pipx distribution, apply delegates to that owner. For an archive
+snapshot, apply uses the public `stable` ref by default and preserves atomic
+snapshot rollback. Use `loopx update plan --ref main` and `loopx update apply
+--ref main` only for maintainer/dev archive qualification. Re-running the curl
+installer remains a repair path when an archive wrapper is too broken to run
+its own updater.
 
 For contributors, keep the clone-plus-canary path:
 
@@ -45,8 +46,8 @@ loopx doctor
 loopx-canary doctor
 ```
 
-The no-clone path is the user default. The clone-plus-canary path is the
-maintainer validation path.
+The PyPI path is the user default. The clone-plus-canary path is the maintainer
+validation path, and the no-clone archive is the recovery fallback.
 
 Before promoting a stable install/update recommendation, maintainers must move
 the public `stable` ref to the release commit that passed this gate. Do not
@@ -59,7 +60,7 @@ prove that an installed LoopX runtime contains that commit. This distinction
 matters when a fix reaches `main` after the latest named release: package
 versions may still match while the installed source commit is behind.
 
-Use `loopx update --check --ref main` for maintainer qualification. Its
+Use `loopx update check --ref main` for archive maintainer qualification. Its
 `runtime_activation_qualification` result compares the release-manifest source
 commit with the trusted source lineage reported by `loopx doctor`:
 
@@ -75,7 +76,7 @@ must not say the fix is active in the installed runtime unless this receipt is
 `runtime_active`. Publishing a release remains a separate maintainer action.
 When the qualification command itself runs from newer source code, pass a local
 snapshot from the older installed CLI with `--installed-doctor-json`; this
-option is read-only and accepted only by `update --check`.
+option is read-only and accepted only by `update check`.
 
 ## Named Version Contract
 
@@ -89,10 +90,10 @@ Before moving `stable`, maintainers should:
   release behavior changes;
 - create or verify the matching Git tag, for example `v0.1.3`;
 - fast-forward `stable` to that tagged commit after the release canary passes;
-- confirm `release.json`, `loopx doctor`, and `loopx update --check` report the
+- confirm `release.json`, `loopx doctor`, and `loopx update check` report the
   same package version and tag;
-- tell existing users to run `loopx update --check`, then
-  `loopx update --execute` when the check recommends or when they want to
+- tell existing users to run `loopx update check`, then
+  `loopx update apply` when the check recommends or when they want to
   refresh to the named stable release.
 
 The release workflow builds a wheel and source distribution from the tagged

--- a/docs/product/runtimes/codex-cli/codex-cli-packaged-install.md
+++ b/docs/product/runtimes/codex-cli/codex-cli-packaged-install.md
@@ -85,29 +85,33 @@ loopx slash-commands --install
 loopx doctor
 ```
 
-For users installed through the archive fallback, keep the explicit archive
-update flow:
+The channel-aware update flow uses explicit intent for both PyPI and archive
+installs:
 
 ```bash
-loopx update --check
-loopx update --dry-run
-loopx update --execute
+loopx update check
+loopx update plan
+loopx update apply
 loopx doctor
 ```
 
-The update command plans the source archive, reports the installed release
-snapshot, preserves runtime state under `~/.codex/loopx`, and refreshes the
-executable and skills together when `--execute` is accepted.
+The update command reports the installation owner before mutation. For a pip
+or pipx PyPI distribution, apply delegates the package transaction to that
+same environment and then refreshes skills, slash commands, doctor, enabled
+extensions, and managed services. For an archive install, apply plans the
+source archive, preserves runtime state under `~/.codex/loopx`, and atomically
+refreshes the executable and host material. It never rewrites a live source
+checkout.
 
-For the normal GitHub repo/ref source, `--check` compares the installed package
+For the normal GitHub repo/ref archive source, `update check` compares the installed package
 version with that exact ref using a short, read-only network probe. Offline
 checks still report local install health and make the missing remote comparison
 explicit. Custom archive URLs skip this comparison rather than guessing which
 version they contain.
 
-`loopx update` uses the same `stable` ref by default. Use `loopx update --ref
-main` only when you intentionally want a dev/head refresh instead of the stable
-channel.
+Archive updates use the `stable` ref by default. Use `loopx update plan --ref
+main` and `loopx update apply --ref main` only when you intentionally want a
+dev/head refresh instead of the stable channel.
 
 Re-running the curl installer is still the repair/fallback path when the local
 wrapper or release snapshot is broken enough that `loopx update` cannot run.

--- a/examples/loopx-update-smoke.py
+++ b/examples/loopx-update-smoke.py
@@ -167,7 +167,7 @@ def test_module_plan() -> None:
     assert payload["requested_action"] == "plan", payload
     assert payload["changes_applied"] is False, payload
     assert payload["next_action"]["command"].startswith("loopx update apply"), payload
-    assert payload["next_action"]["requires_authorization"] is True, payload
+    assert payload["next_action"]["requires_explicit_approval"] is True, payload
     assert payload["current"]["requires_upgrade"] is True, payload
     assert payload["current"]["current_version"] == __version__, payload
     assert payload["current"]["current_version_tag"] == release_version_tag(), payload

--- a/examples/loopx-update-smoke.py
+++ b/examples/loopx-update-smoke.py
@@ -164,6 +164,10 @@ def test_module_plan() -> None:
     assert payload["mode"] == "update", payload
     assert payload["dry_run"] is True, payload
     assert payload["execute_requested"] is False, payload
+    assert payload["requested_action"] == "plan", payload
+    assert payload["changes_applied"] is False, payload
+    assert payload["next_action"]["command"].startswith("loopx update apply"), payload
+    assert payload["next_action"]["requires_authorization"] is True, payload
     assert payload["current"]["requires_upgrade"] is True, payload
     assert payload["current"]["current_version"] == __version__, payload
     assert payload["current"]["current_version_tag"] == release_version_tag(), payload
@@ -181,6 +185,9 @@ def test_module_plan() -> None:
     assert "ln -sfn" not in payload["plan"]["backup"]["rollback_command"], payload
     assert "LOOPX_ARCHIVE_URL=https://example.invalid/loopx.tar.gz" in payload["plan"]["install_command"], payload
     rendered = render_update_plan_markdown(payload)
+    assert "**No update was applied.**" in rendered, rendered
+    assert "## Next Action" in rendered, rendered
+    assert "loopx update apply" in rendered, rendered
     assert f"Current version tag: `{release_version_tag()}`" in rendered, rendered
     assert f"Manifest package version tag: `{release_version_tag()}`" in rendered, rendered
 

--- a/examples/release/release-readiness-doc-smoke.py
+++ b/examples/release/release-readiness-doc-smoke.py
@@ -371,9 +371,9 @@ def main() -> None:
     for required in [
         "Status: v0.x maintainer contract.",
         "## Supported Install And Update Paths",
-        "loopx update --check",
-        "loopx update --dry-run",
-        "loopx update --execute",
+        "loopx update check",
+        "loopx update plan",
+        "loopx update apply",
         "## Named Version Contract",
         "The version source is `loopx.__version__`, mirrored by `pyproject.toml`",
         "examples/release/release-version-contract-smoke.py",

--- a/loopx/cli_commands/support_control.py
+++ b/loopx/cli_commands/support_control.py
@@ -43,11 +43,13 @@ from ..registry import (
     render_registry_markdown,
 )
 from ..self_update import (
+    UpdateAction,
     build_rollback_plan,
     build_update_plan,
     execute_rollback_plan,
     execute_update_plan,
     render_update_plan_markdown,
+    resolve_update_action,
 )
 from ..status_server import (
     DEFAULT_STATUS_HOST,
@@ -110,7 +112,9 @@ def register_support_control_commands(
         help="Generate a guarded heartbeat or visible-goal host-loop task body.",
     )
     add_subcommand_format(heartbeat_prompt_parser)
-    heartbeat_prompt_parser.add_argument("--goal-id", required=True, help="Stable LoopX goal id.")
+    heartbeat_prompt_parser.add_argument(
+        "--goal-id", required=True, help="Stable LoopX goal id."
+    )
     heartbeat_prompt_parser.add_argument(
         "--active-state",
         help="Active goal state file the heartbeat should read and write back. Defaults to the registry goal state_file.",
@@ -299,7 +303,12 @@ def register_support_control_commands(
         help="Plan local default upgrade propagation for managed heartbeat automations.",
     )
     add_subcommand_format(upgrade_plan_parser)
-    upgrade_plan_parser.add_argument("--goal-id", action="append", default=[], help="Only include one goal id. Repeatable.")
+    upgrade_plan_parser.add_argument(
+        "--goal-id",
+        action="append",
+        default=[],
+        help="Only include one goal id. Repeatable.",
+    )
     upgrade_plan_parser.add_argument(
         "--installed-manifest",
         help=(
@@ -323,13 +332,36 @@ def register_support_control_commands(
 
     update_parser = subparsers.add_parser(
         "update",
-        help="Check or execute a no-clone LoopX self-update.",
+        help="Inspect or apply an update using the active installation owner.",
+        description=(
+            "Use `update check` for a read-only freshness probe, `update plan` for the "
+            "full no-write plan, or `update apply` for an explicit archive-snapshot "
+            "mutation. Bare `update` remains a read-only plan."
+        ),
     )
     add_subcommand_format(update_parser)
+    update_parser.add_argument(
+        "update_action",
+        nargs="?",
+        choices=tuple(action.value for action in UpdateAction),
+        help="Explicit intent: check (read only), plan (read only), or apply (mutating).",
+    )
     update_mode = update_parser.add_mutually_exclusive_group()
-    update_mode.add_argument("--check", action="store_true", help="Only report install freshness and update source.")
-    update_mode.add_argument("--dry-run", action="store_true", help="Preview the update plan without installing.")
-    update_mode.add_argument("--execute", action="store_true", help="Run the installer and validate with loopx doctor.")
+    update_mode.add_argument(
+        "--check",
+        action="store_true",
+        help="Compatibility alias for `loopx update check`.",
+    )
+    update_mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Compatibility alias for `loopx update plan`.",
+    )
+    update_mode.add_argument(
+        "--execute",
+        action="store_true",
+        help="Compatibility alias for `loopx update apply`; prefer the explicit action.",
+    )
     update_mode.add_argument(
         "--rollback",
         metavar="RELEASE_ID",
@@ -358,10 +390,12 @@ def register_support_control_commands(
         "--timeout-seconds",
         type=int,
         default=600,
-        help="Timeout for --execute installer and post-update doctor commands.",
+        help="Timeout for `update apply` installer and post-update doctor commands.",
     )
 
-    subparsers.add_parser("registry", help="Inspect registry goals and adapter declarations.")
+    subparsers.add_parser(
+        "registry", help="Inspect registry goals and adapter declarations."
+    )
     registry_boundary_parser = subparsers.add_parser(
         "registry-boundary",
         help="Classify a registry file as local-only, global-local, public projection, or public fixture.",
@@ -381,10 +415,18 @@ def register_support_control_commands(
         help="Return non-zero if the registry should be ignored but is neither ignored nor tracked.",
     )
 
-    serve_status_parser = subparsers.add_parser("serve-status", help="Serve live status JSON for the local dashboard.")
-    serve_status_parser.add_argument("--host", default=DEFAULT_STATUS_HOST, help="Bind host. Defaults to localhost only.")
+    serve_status_parser = subparsers.add_parser(
+        "serve-status", help="Serve live status JSON for the local dashboard."
+    )
+    serve_status_parser.add_argument(
+        "--host",
+        default=DEFAULT_STATUS_HOST,
+        help="Bind host. Defaults to localhost only.",
+    )
     serve_status_parser.add_argument("--port", type=int, default=DEFAULT_STATUS_PORT)
-    serve_status_parser.add_argument("--path", default=DEFAULT_STATUS_PATH, help="Status JSON route.")
+    serve_status_parser.add_argument(
+        "--path", default=DEFAULT_STATUS_PATH, help="Status JSON route."
+    )
     serve_status_parser.add_argument(
         "--scan-root",
         default=default_public_scan_root(),
@@ -412,14 +454,20 @@ def register_support_control_commands(
         action="store_true",
         help="Serve the shared global registry view even when invoked from a project directory.",
     )
-    serve_status_parser.add_argument("--verbose", action="store_true", help="Print HTTP request logs.")
+    serve_status_parser.add_argument(
+        "--verbose", action="store_true", help="Print HTTP request logs."
+    )
 
     chat_parser = subparsers.add_parser(
         "chat",
         help="Open the local Goal Studio and review Agent-proposed LoopX Todos.",
     )
-    chat_parser.add_argument("--goal-id", help="Goal to select when the local workspace opens.")
-    chat_parser.add_argument("--host", default=DEFAULT_CHAT_HOST, help="Loopback bind host.")
+    chat_parser.add_argument(
+        "--goal-id", help="Goal to select when the local workspace opens."
+    )
+    chat_parser.add_argument(
+        "--host", default=DEFAULT_CHAT_HOST, help="Loopback bind host."
+    )
     chat_parser.add_argument("--port", type=int, default=DEFAULT_CHAT_PORT)
     chat_parser.add_argument(
         "--codex-bin",
@@ -482,7 +530,9 @@ def register_support_control_commands(
         action="store_true",
         help="Start the local server without opening a browser.",
     )
-    chat_parser.add_argument("--verbose", action="store_true", help="Print HTTP request logs.")
+    chat_parser.add_argument(
+        "--verbose", action="store_true", help="Print HTTP request logs."
+    )
 
     register_chat_endpoint_command(subparsers, add_subcommand_format)
 
@@ -490,8 +540,12 @@ def register_support_control_commands(
         "dashboard",
         help="Start the local LoopX dashboard, status service, and Chat service.",
     )
-    dashboard_parser.add_argument("--goal-id", help="Goal to select when the local workspace opens.")
-    dashboard_parser.add_argument("--host", default=DEFAULT_CHAT_HOST, help="Loopback bind host.")
+    dashboard_parser.add_argument(
+        "--goal-id", help="Goal to select when the local workspace opens."
+    )
+    dashboard_parser.add_argument(
+        "--host", default=DEFAULT_CHAT_HOST, help="Loopback bind host."
+    )
     dashboard_parser.add_argument("--port", type=int, default=DEFAULT_CHAT_PORT)
     dashboard_parser.add_argument(
         "--codex-bin",
@@ -541,7 +595,9 @@ def register_support_control_commands(
         action="store_true",
         help="Prefer the Vite HMR dev launcher if running from a local repository checkout.",
     )
-    dashboard_parser.add_argument("--verbose", action="store_true", help="Print HTTP request logs.")
+    dashboard_parser.add_argument(
+        "--verbose", action="store_true", help="Print HTTP request logs."
+    )
 
 
 def handle_support_control_command(
@@ -608,8 +664,12 @@ def handle_support_control_command(
             )
             agent_registry_path = registry_path
             if active_state_source.startswith("registry:"):
-                agent_registry_path = Path(active_state_source.removeprefix("registry:"))
-            registered_agents = registered_agent_ids_from_registry(agent_registry_path, args.goal_id)
+                agent_registry_path = Path(
+                    active_state_source.removeprefix("registry:")
+                )
+            registered_agents = registered_agent_ids_from_registry(
+                agent_registry_path, args.goal_id
+            )
             registry_goal = load_goal_from_registry(
                 agent_registry_path,
                 args.goal_id,
@@ -627,7 +687,9 @@ def handle_support_control_command(
                     agent_id=args.agent_id,
                     field="agent_id",
                 )
-                agent_profile = agent_profile_from_registry(agent_registry_path, args.goal_id, effective_agent_id)
+                agent_profile = agent_profile_from_registry(
+                    agent_registry_path, args.goal_id, effective_agent_id
+                )
             explicit_scheduler_fields = (
                 args.host_surface,
                 args.scheduler_owner,
@@ -687,8 +749,12 @@ def handle_support_control_command(
             fallback_active_state_source = active_state_source
             if fallback_active_state is None and args.active_state:
                 fallback_active_state = Path(args.active_state).expanduser()
-                fallback_resolved_active_state = fallback_resolved_active_state or fallback_active_state
-                fallback_active_state_source = fallback_active_state_source or "explicit"
+                fallback_resolved_active_state = (
+                    fallback_resolved_active_state or fallback_active_state
+                )
+                fallback_active_state_source = (
+                    fallback_active_state_source or "explicit"
+                )
             elif fallback_active_state_source is None:
                 fallback_active_state_source = "registry"
             payload = build_heartbeat_prompt_error_payload(
@@ -774,7 +840,9 @@ def handle_support_control_command(
             payload = build_upgrade_plan(
                 registry_path=registry_path,
                 runtime_root_override=args.runtime_root,
-                installed_manifest=Path(args.installed_manifest).expanduser() if args.installed_manifest else None,
+                installed_manifest=Path(args.installed_manifest).expanduser()
+                if args.installed_manifest
+                else None,
                 cli_bin=args.cli_bin,
                 modes=args.mode or None,
                 goal_ids=args.goal_id or None,
@@ -806,41 +874,63 @@ def handle_support_control_command(
         return 0 if payload.get("ok") else 1
 
     if args.command == "update":
+        update_action = UpdateAction.PLAN
         try:
-            if args.installed_doctor_json and not args.check:
-                raise ValueError("--installed-doctor-json requires update --check")
+            update_action = resolve_update_action(
+                args.update_action,
+                check=args.check,
+                dry_run=args.dry_run,
+                execute=args.execute,
+            )
+            if args.rollback and args.update_action:
+                raise ValueError(
+                    "update rollback cannot be combined with check, plan, or apply"
+                )
+            if args.installed_doctor_json and update_action is not UpdateAction.CHECK:
+                raise ValueError(
+                    "--installed-doctor-json requires `loopx update check`"
+                )
             if args.rollback:
                 payload = build_rollback_plan(release_id=args.rollback)
-                payload = execute_rollback_plan(payload, timeout_seconds=args.timeout_seconds)
+                payload = execute_rollback_plan(
+                    payload, timeout_seconds=args.timeout_seconds
+                )
             else:
                 doctor_payload = None
                 if args.installed_doctor_json:
                     doctor_path = Path(args.installed_doctor_json).expanduser()
                     loaded_doctor = json.loads(doctor_path.read_text(encoding="utf-8"))
                     if not isinstance(loaded_doctor, dict):
-                        raise ValueError("--installed-doctor-json must contain a JSON object")
+                        raise ValueError(
+                            "--installed-doctor-json must contain a JSON object"
+                        )
                     doctor_payload = loaded_doctor
                 payload = build_update_plan(
                     repo=args.repo,
                     ref=args.ref,
                     archive_url=args.archive_url,
-                    check_only=args.check,
-                    execute=args.execute,
+                    action=update_action,
                     doctor_payload=doctor_payload,
                 )
                 payload["installed_doctor_source"] = (
                     "explicit_json" if doctor_payload is not None else "current_runtime"
                 )
-                if args.execute:
-                    payload = execute_update_plan(payload, timeout_seconds=args.timeout_seconds)
+                if update_action is UpdateAction.APPLY and payload.get("plan", {}).get(
+                    "apply_supported"
+                ):
+                    payload = execute_update_plan(
+                        payload, timeout_seconds=args.timeout_seconds
+                    )
         except Exception as exc:
             payload = {
                 "ok": False,
                 "schema_version": "loopx_update_plan_v0",
                 "mode": "update",
-                "check_only": bool(getattr(args, "check", False)),
-                "dry_run": not bool(getattr(args, "execute", False)),
-                "execute_requested": bool(getattr(args, "execute", False)),
+                "requested_action": update_action.value,
+                "check_only": update_action is UpdateAction.CHECK,
+                "dry_run": update_action is not UpdateAction.APPLY,
+                "execute_requested": update_action is UpdateAction.APPLY,
+                "changes_applied": False,
                 "error": str(exc),
                 "recommended_action": "fix update planning or installation before retrying",
             }
@@ -856,14 +946,27 @@ def handle_support_control_command(
         boundary_path = Path(args.path).expanduser() if args.path else registry_path
         payload = inspect_registry_boundary(boundary_path)
         git = payload.get("git") if isinstance(payload.get("git"), dict) else {}
-        if args.require_not_tracked and payload.get("ok") and git.get("tracked") and not payload.get(
-            "github_push_allowed"
+        if (
+            args.require_not_tracked
+            and payload.get("ok")
+            and git.get("tracked")
+            and not payload.get("github_push_allowed")
         ):
             payload = dict(payload)
             payload["ok"] = False
-            payload.setdefault("risks", []).append("registry_tracked_but_not_push_allowed")
-        if args.require_gitignored and payload.get("ok") and payload.get("should_be_gitignored"):
-            if git.get("inside_worktree") and not git.get("ignored") and not git.get("tracked"):
+            payload.setdefault("risks", []).append(
+                "registry_tracked_but_not_push_allowed"
+            )
+        if (
+            args.require_gitignored
+            and payload.get("ok")
+            and payload.get("should_be_gitignored")
+        ):
+            if (
+                git.get("inside_worktree")
+                and not git.get("ignored")
+                and not git.get("tracked")
+            ):
                 payload = dict(payload)
                 payload["ok"] = False
                 payload.setdefault("risks", []).append("registry_should_be_gitignored")
@@ -872,7 +975,11 @@ def handle_support_control_command(
 
     if args.command == "serve-status":
         try:
-            status_registry_path = explicit_global_registry(args.runtime_root) if args.global_registry else registry_path
+            status_registry_path = (
+                explicit_global_registry(args.runtime_root)
+                if args.global_registry
+                else registry_path
+            )
             scan_roots = [Path(item).expanduser() for item in args.scan_path]
             if not scan_roots:
                 scan_roots = [Path(args.scan_root).expanduser()]
@@ -885,13 +992,19 @@ def handle_support_control_command(
                 port=args.port,
                 status_path=args.path,
                 enable_reward_write_api=bool(args.enable_reward_write_api),
-                enable_control_plane_write_api=bool(args.enable_control_plane_write_api),
+                enable_control_plane_write_api=bool(
+                    args.enable_control_plane_write_api
+                ),
                 verbose=bool(args.verbose),
             )
         except Exception as exc:
             payload = {
                 "ok": False,
-                "registry": str(status_registry_path if "status_registry_path" in locals() else registry_path),
+                "registry": str(
+                    status_registry_path
+                    if "status_registry_path" in locals()
+                    else registry_path
+                ),
                 "runtime_root": args.runtime_root,
                 "error": str(exc),
             }
@@ -901,8 +1014,14 @@ def handle_support_control_command(
 
     if args.command == "dashboard":
         try:
-            dashboard_registry_path = explicit_global_registry(args.runtime_root) if getattr(args, "global_registry", False) else registry_path
-            scan_roots = [Path(item).expanduser() for item in getattr(args, "scan_path", []) or []]
+            dashboard_registry_path = (
+                explicit_global_registry(args.runtime_root)
+                if getattr(args, "global_registry", False)
+                else registry_path
+            )
+            scan_roots = [
+                Path(item).expanduser() for item in getattr(args, "scan_path", []) or []
+            ]
             if not scan_roots and getattr(args, "scan_root", None):
                 scan_roots = [Path(args.scan_root).expanduser()]
             return launch_dashboard(
@@ -916,7 +1035,9 @@ def handle_support_control_command(
                 codex_bin=getattr(args, "codex_bin", "codex"),
                 claude_bin=getattr(args, "claude_bin", "claude"),
                 lark_cli_bin=getattr(args, "lark_cli_bin", None),
-                assets_dir=Path(args.assets_dir).expanduser().resolve() if getattr(args, "assets_dir", None) else None,
+                assets_dir=Path(args.assets_dir).expanduser().resolve()
+                if getattr(args, "assets_dir", None)
+                else None,
                 verbose=getattr(args, "verbose", False),
                 open_browser=not getattr(args, "no_open", False),
                 prefer_dev=getattr(args, "dev", False),
@@ -932,7 +1053,11 @@ def handle_support_control_command(
 
     if args.command == "chat":
         try:
-            chat_registry_path = explicit_global_registry(args.runtime_root) if args.global_registry else registry_path
+            chat_registry_path = (
+                explicit_global_registry(args.runtime_root)
+                if args.global_registry
+                else registry_path
+            )
             scan_roots = [Path(item).expanduser() for item in args.scan_path]
             if not scan_roots:
                 scan_roots = [Path(args.scan_root).expanduser()]
@@ -950,7 +1075,9 @@ def handle_support_control_command(
                 startup_timeout_sec=max(0.1, float(args.startup_timeout_seconds)),
                 idle_timeout_sec=max(0.1, float(args.idle_timeout_seconds)),
                 hard_timeout_sec=max(0.1, float(args.hard_timeout_seconds)),
-                assets_dir=Path(args.assets_dir).expanduser() if args.assets_dir else None,
+                assets_dir=Path(args.assets_dir).expanduser()
+                if args.assets_dir
+                else None,
                 open_browser=not bool(args.no_open),
                 verbose=bool(args.verbose),
             )

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -20,6 +20,7 @@ from .control_plane.runtime.promotion_readiness import (
 )
 from .install_contract import NO_CLONE_INSTALL_URL
 from .paths import DEFAULT_RUNTIME_ROOT, global_registry_path
+from .python_install_owner import PythonInstallOwner, python_distribution_upgrade_command, resolve_python_install_owner
 from .capabilities.project_skill_delivery import discover_project_scoped_skill_ids
 from .registry_writability import probe_registry_write_path
 from .release_manifest import load_release_manifest, release_version_tag
@@ -123,7 +124,9 @@ def no_clone_upgrade_command(
     ref = str(source_ref or "").strip()
     installer = f"curl -fsSL {NO_CLONE_INSTALL_URL}"
     doctor_agent_arg = (
-        f" --agent-type {shlex.quote(doctor_agent_type)}" if doctor_agent_type else ""
+        f" --agent-type {shlex.quote(doctor_agent_type)}"
+        if doctor_agent_type
+        else ""
     )
     install_env: list[str] = []
     if ref and ref != "stable":
@@ -203,30 +206,13 @@ def python_distribution_install(module_path: Path) -> dict[str, Any]:
     )
     if not owns_module:
         return {"available": False}
-    pipx_metadata_path = Path(sys.prefix) / "pipx_metadata.json"
-    pipx_environment = None
-    if pipx_metadata_path.is_file():
-        try:
-            pipx_metadata = json.loads(pipx_metadata_path.read_text(encoding="utf-8"))
-        except (OSError, ValueError):
-            pipx_metadata = {}
-        recorded_environment = (
-            pipx_metadata.get("environment")
-            if isinstance(pipx_metadata, dict)
-            else None
-        )
-        pipx_environment = (
-            recorded_environment
-            if isinstance(recorded_environment, str) and recorded_environment
-            else Path(sys.prefix).name
-        )
-        installer = "pipx"
+    owner = resolve_python_install_owner(default_installer=installer, prefix=Path(sys.prefix))
     return {
         "available": True,
         "kind": "python_distribution",
         "version": installed.version,
-        "installer": installer,
-        "installer_environment": pipx_environment,
+        "installer": owner.manager,
+        "installer_environment": owner.environment,
         "root": str(Path(installed.locate_file("")).resolve()),
     }
 
@@ -255,9 +241,7 @@ def parse_release_id_time(release_id: str | None) -> datetime | None:
     if not release_id or not RELEASE_ID_TIMESTAMP_RE.match(release_id):
         return None
     try:
-        return datetime.strptime(release_id, "%Y%m%dT%H%M%SZ").replace(
-            tzinfo=timezone.utc
-        )
+        return datetime.strptime(release_id, "%Y%m%dT%H%M%SZ").replace(tzinfo=timezone.utc)
     except ValueError:
         return None
 
@@ -309,11 +293,7 @@ def git_metadata_for_root(root: Path | None) -> dict[str, Any]:
     branch = _run(["symbolic-ref", "--quiet", "--short", "HEAD"])
     tag = _run(["describe", "--tags", "--exact-match"])
     status = _run(["status", "--porcelain"])
-    dirty = (
-        None
-        if commit is None and branch is None and tag is None and status is None
-        else bool(status)
-    )
+    dirty = None if commit is None and branch is None and tag is None and status is None else bool(status)
     return {
         "root": str(source_root),
         "git_commit": commit,
@@ -384,9 +364,7 @@ def git_revision_relation(
 
 def _github_repository_from_remote_url(value: Any) -> str | None:
     text = str(value or "").strip().removesuffix(".git")
-    match = re.search(
-        r"github\.com(?::|/)([^/\s]+/[^/\s]+)$", text, flags=re.IGNORECASE
-    )
+    match = re.search(r"github\.com(?::|/)([^/\s]+/[^/\s]+)$", text, flags=re.IGNORECASE)
     return match.group(1).lower() if match else None
 
 
@@ -437,20 +415,12 @@ def trusted_release_ref_for_root(
             continue
         if (
             remote_url.returncode != 0
-            or _github_repository_from_remote_url(remote_url.stdout)
-            != expected_repository
+            or _github_repository_from_remote_url(remote_url.stdout) != expected_repository
         ):
             continue
         trusted_ref = f"refs/remotes/{remote}/{expected_ref}"
         resolved = subprocess.run(
-            [
-                "git",
-                "-C",
-                str(source_root),
-                "rev-parse",
-                "--verify",
-                f"{trusted_ref}^{{commit}}",
-            ],
+            ["git", "-C", str(source_root), "rev-parse", "--verify", f"{trusted_ref}^{{commit}}"],
             check=False,
             capture_output=True,
             text=True,
@@ -485,11 +455,7 @@ def build_install_freshness(
     release_time = parse_release_id_time(release_id)
     age_hours: float | None = None
     if release_time:
-        age_hours = round(
-            max(0, (reference - release_time.astimezone(timezone.utc)).total_seconds())
-            / 3600,
-            2,
-        )
+        age_hours = round(max(0, (reference - release_time.astimezone(timezone.utc)).total_seconds()) / 3600, 2)
 
     skills_ready = bool(skills) and all(
         skill.get("exists")
@@ -499,8 +465,7 @@ def build_install_freshness(
     )
     distribution_install = (
         python_distribution
-        if isinstance(python_distribution, dict)
-        and python_distribution.get("available")
+        if isinstance(python_distribution, dict) and python_distribution.get("available")
         else None
     )
     externally_managed_skills = skills_ready and any(
@@ -519,11 +484,7 @@ def build_install_freshness(
         status = "python_distribution"
         reason = "LoopX is installed as a managed Python distribution"
         requires_upgrade = False
-    elif (
-        release_id
-        and age_hours is not None
-        and age_hours > INSTALL_FRESHNESS_STALE_HOURS
-    ):
+    elif release_id and age_hours is not None and age_hours > INSTALL_FRESHNESS_STALE_HOURS:
         status = "stale"
         reason = f"default release snapshot is older than {INSTALL_FRESHNESS_STALE_HOURS} hours"
         requires_upgrade = True
@@ -541,13 +502,9 @@ def build_install_freshness(
         requires_upgrade = False
 
     manifest = release_manifest if isinstance(release_manifest, dict) else {}
-    manifest_body = (
-        manifest.get("manifest") if isinstance(manifest.get("manifest"), dict) else {}
-    )
+    manifest_body = manifest.get("manifest") if isinstance(manifest.get("manifest"), dict) else {}
     manifest_package = (
-        manifest_body.get("package")
-        if isinstance(manifest_body.get("package"), dict)
-        else {}
+        manifest_body.get("package") if isinstance(manifest_body.get("package"), dict) else {}
     )
     manifest_package_version = manifest_package.get("version")
     manifest_package_version_tag = manifest_package.get("version_tag") or (
@@ -562,9 +519,7 @@ def build_install_freshness(
         else None
     )
     manifest_source = (
-        manifest_body.get("source")
-        if isinstance(manifest_body.get("source"), dict)
-        else {}
+        manifest_body.get("source") if isinstance(manifest_body.get("source"), dict) else {}
     )
     no_clone_command = no_clone_upgrade_command(
         manifest_source.get("ref"),
@@ -572,33 +527,23 @@ def build_install_freshness(
         skip_skills=externally_managed_skills,
     )
     doctor_agent_arg = (
-        f" --agent-type {shlex.quote(doctor_agent_type)}" if doctor_agent_type else ""
+        f" --agent-type {shlex.quote(doctor_agent_type)}"
+        if doctor_agent_type
+        else ""
     )
     contributor_upgrade_command = (
         f"{local_install_command(repo_root, skip_skills=externally_managed_skills)}\n"
         f"loopx doctor{doctor_agent_arg}"
     )
-    distribution_installer = (
-        distribution_install.get("installer") if distribution_install else None
-    )
-    distribution_environment = (
-        distribution_install.get("installer_environment")
-        if distribution_install
-        else None
-    )
-    package_upgrade_command = (
-        f"pipx upgrade {shlex.quote(str(distribution_environment or 'loopx'))}"
-        if distribution_installer == "pipx"
-        else f"{shlex.quote(sys.executable)} -m pip install --upgrade loopx"
-    )
-    upgrade_command = (
-        f"{package_upgrade_command}\n"
-        "loopx workflow-skills --install\n"
-        "loopx slash-commands --install\n"
-        f"loopx doctor{doctor_agent_arg}"
-        if distribution_install
-        else no_clone_command
-    )
+    distribution_owner = PythonInstallOwner(
+        str(distribution_install.get("installer") or "unknown"),
+        distribution_install.get("installer_environment"),
+    ) if distribution_install else None
+    upgrade_command = python_distribution_upgrade_command(
+        owner=distribution_owner,
+        python_executable=sys.executable,
+        doctor_command=f"loopx doctor{doctor_agent_arg}",
+    ) if distribution_owner else no_clone_command
     manifest_source_git_commit = manifest_source.get("git_commit")
     manifest_source_revision = (
         manifest_source_git_commit
@@ -636,9 +581,7 @@ def build_install_freshness(
         and not skill_problem
     ):
         status = "stale"
-        reason = (
-            f"release manifest source commit is behind {freshness_source_label} commit"
-        )
+        reason = f"release manifest source commit is behind {freshness_source_label} commit"
         requires_upgrade = True
 
     if (
@@ -652,9 +595,7 @@ def build_install_freshness(
         requires_upgrade = True
 
     manifest_skills = (
-        manifest_body.get("skills")
-        if isinstance(manifest_body.get("skills"), dict)
-        else {}
+        manifest_body.get("skills") if isinstance(manifest_body.get("skills"), dict) else {}
     )
     return {
         "schema_version": "loopx_install_freshness_v0",
@@ -680,7 +621,9 @@ def build_install_freshness(
         "python_distribution_installer": (
             distribution_install.get("installer") if distribution_install else None
         ),
-        "python_distribution_installer_environment": distribution_environment,
+        "python_distribution_installer_environment": (
+            distribution_install.get("installer_environment") if distribution_install else None
+        ),
         "externally_managed_skills": externally_managed_skills,
         "release_manifest_available": manifest.get("available"),
         "release_manifest_path": manifest.get("path"),
@@ -700,9 +643,7 @@ def build_install_freshness(
         "comparison_source_label": comparison_source_label if comparison else None,
         "comparison_source_root": comparison.get("root"),
         "comparison_source_git_commit": comparison_source_git_commit,
-        "comparison_source_git_commit_short": short_revision(
-            comparison_source_git_commit
-        ),
+        "comparison_source_git_commit_short": short_revision(comparison_source_git_commit),
         "comparison_source_git_ref": comparison.get("git_ref"),
         "comparison_source_git_dirty": comparison.get("git_dirty"),
         "manifest_source_matches_comparison": manifest_source_matches_comparison,
@@ -714,9 +655,7 @@ def build_install_freshness(
         "freshness_source_label": freshness_source_label if trusted else None,
         "freshness_source_root": trusted.get("root"),
         "freshness_source_git_commit": freshness_source_git_commit,
-        "freshness_source_git_commit_short": short_revision(
-            freshness_source_git_commit
-        ),
+        "freshness_source_git_commit_short": short_revision(freshness_source_git_commit),
         "freshness_source_git_ref": trusted.get("git_ref"),
         "manifest_source_matches_freshness_source": manifest_source_matches_freshness_source,
         "manifest_source_freshness_relation": (
@@ -802,9 +741,7 @@ def skill_has_required_phrases(skill_path: Path, phrases: tuple[str, ...]) -> bo
     return all(phrase in text for phrase in phrases)
 
 
-def installed_skill_summary(
-    skills_roots: tuple[Path, ...],
-) -> dict[str, dict[str, Any]]:
+def installed_skill_summary(skills_roots: tuple[Path, ...]) -> dict[str, dict[str, Any]]:
     if not skills_roots:
         raise ValueError("at least one Codex skill root is required")
     primary_root = skills_roots[0]
@@ -854,9 +791,7 @@ def installed_skill_check(
     }
 
 
-def latest_promotion_readiness_event(
-    runtime_root: Path, goal_id: str | None = None
-) -> dict[str, Any]:
+def latest_promotion_readiness_event(runtime_root: Path, goal_id: str | None = None) -> dict[str, Any]:
     goals_dir = runtime_root / "goals"
     runtime_index = runtime_root / PROMOTION_READINESS_RUNTIME_INDEX
     if not goals_dir.exists() and not runtime_index.is_file():
@@ -897,28 +832,24 @@ def latest_promotion_readiness_event(
             json_path = Path(str(item.get("json_path") or ""))
             markdown_path = Path(str(item.get("markdown_path") or ""))
             target_matches = (
-                runtime_matches
-                if source == "runtime_release_ledger"
-                else legacy_matches
+                runtime_matches if source == "runtime_release_ledger" else legacy_matches
             )
             target_matches.append(
                 {
                     "available": True,
                     "source": source,
-                    "goal_id": str(item.get("goal_id") or current_goal_id or "")
-                    or None,
+                    "goal_id": str(item.get("goal_id") or current_goal_id or "") or None,
                     "generated_at": item.get("generated_at"),
                     "classification": classification,
-                    "evidence_scope": item.get("evidence_scope")
-                    or ("goal_run_history" if current_goal_id else "runtime_release"),
+                    "evidence_scope": item.get("evidence_scope") or (
+                        "goal_run_history" if current_goal_id else "runtime_release"
+                    ),
                     "dashboard_readiness": item.get("dashboard_readiness"),
                     "delivery_batch_scale": item.get("delivery_batch_scale"),
                     "delivery_outcome": item.get("delivery_outcome"),
                     "recommended_action": item.get("recommended_action"),
                     "json_exists": json_path.exists() if str(json_path) else False,
-                    "markdown_exists": markdown_path.exists()
-                    if str(markdown_path)
-                    else False,
+                    "markdown_exists": markdown_path.exists() if str(markdown_path) else False,
                 }
             )
 
@@ -983,13 +914,11 @@ def collect_doctor(
     python_distribution = python_distribution_install(module_path)
     package_dir = module_path.parent
     repo_root = package_dir.parent
-    install_script = (
-        repo_root
-        / "scripts"
-        / ("install-windows.ps1" if os.name == "nt" else "install-local.sh")
+    install_script = repo_root / "scripts" / (
+        "install-windows.ps1" if os.name == "nt" else "install-local.sh"
     )
-    wrapper_script = (
-        repo_root / "scripts" / ("loopx.ps1" if os.name == "nt" else "loopx")
+    wrapper_script = repo_root / "scripts" / (
+        "loopx.ps1" if os.name == "nt" else "loopx"
     )
     active_release_root_text = os.environ.get("LOOPX_RELEASE_ROOT")
     release_root = (
@@ -1009,7 +938,9 @@ def collect_doctor(
     skills = installed_skill_summary(skill_roots)
     project_skill = skills["loopx-project"]
     skill_path = Path(str(project_skill["path"]))
-    project_scoped_skill_ids = discover_project_scoped_skill_ids(repo_root / "skills")
+    project_scoped_skill_ids = discover_project_scoped_skill_ids(
+        repo_root / "skills"
+    )
     globally_visible_project_skills = [
         skill_name
         for skill_name in project_scoped_skill_ids
@@ -1058,11 +989,7 @@ def collect_doctor(
         "default_release": default_release,
         "live_canary": {
             **command_root_summary(canary_path, canary_realpath),
-            "separate_from_default": bool(
-                canary_realpath
-                and command_realpath
-                and canary_realpath != command_realpath
-            ),
+            "separate_from_default": bool(canary_realpath and command_realpath and canary_realpath != command_realpath),
         },
         "current_invocation": {
             "module_path": str(module_path),
@@ -1091,7 +1018,9 @@ def collect_doctor(
         doctor_agent_type=canonical_agent_type,
         python_distribution=python_distribution,
     )
-    externally_managed_skills = bool(install_freshness.get("externally_managed_skills"))
+    externally_managed_skills = bool(
+        install_freshness.get("externally_managed_skills")
+    )
     external_skill_delivery = externally_managed_skills and all(
         skill.get("managed_externally") for skill in skills.values()
     )
@@ -1136,9 +1065,7 @@ def collect_doctor(
         ),
     }
     default_global_registry = global_registry_path(DEFAULT_RUNTIME_ROOT)
-    global_registry_writability = probe_registry_write_path(
-        default_global_registry, create_parent=True
-    )
+    global_registry_writability = probe_registry_write_path(default_global_registry, create_parent=True)
     runtime_projection_routes = (
         collect_runtime_projection_route_diagnostics(
             registry_path=default_global_registry,
@@ -1194,34 +1121,24 @@ def collect_doctor(
             "id": "command_resolves",
             "required": True,
             "ok": bool(command_realpath and command_realpath.exists()),
-            "detail": str(command_realpath)
-            if command_realpath
-            else "no command realpath",
+            "detail": str(command_realpath) if command_realpath else "no command realpath",
         },
         {
             "id": "default_command_is_release_snapshot",
             "required": False,
             "ok": bool(release_root and "releases" in release_root.parts),
-            "detail": str(release_root)
-            if release_root
-            else "default command is not a release snapshot",
+            "detail": str(release_root) if release_root else "default command is not a release snapshot",
         },
         {
             "id": "canary_command_on_path",
             "required": False,
             "ok": canary_path is not None,
-            "detail": str(canary_path)
-            if canary_path
-            else "loopx-canary was not found on PATH",
+            "detail": str(canary_path) if canary_path else "loopx-canary was not found on PATH",
         },
         {
             "id": "canary_separate_from_default",
             "required": False,
-            "ok": bool(
-                canary_realpath
-                and command_realpath
-                and canary_realpath != command_realpath
-            ),
+            "ok": bool(canary_realpath and command_realpath and canary_realpath != command_realpath),
             "detail": str(canary_realpath) if canary_realpath else "no canary realpath",
         },
         {
@@ -1308,9 +1225,7 @@ def collect_doctor(
             "ok": bool(global_registry_writability.get("ok")),
             "detail": str(default_global_registry)
             if global_registry_writability.get("ok")
-            else str(
-                global_registry_writability.get("error") or default_global_registry
-            ),
+            else str(global_registry_writability.get("error") or default_global_registry),
         },
         {
             "id": "runtime_projection_routes_healthy",
@@ -1345,9 +1260,7 @@ def collect_doctor(
             "loopx_on_path": str(loopx_path) if loopx_path else None,
             "current_invocation": str(invocation_path) if invocation_path else None,
             "loopx_canary": str(loopx_canary_path) if loopx_canary_path else None,
-            "loopx_canary_realpath": str(loopx_canary_realpath)
-            if loopx_canary_realpath
-            else None,
+            "loopx_canary_realpath": str(loopx_canary_realpath) if loopx_canary_realpath else None,
             "user_local_bin": str(local_bin),
             "user_local_bin_on_path": str(local_bin) in path_entries,
         },
@@ -1411,7 +1324,7 @@ def collect_doctor(
                         f"Ensure `{local_bin}` is on the Windows user PATH."
                         if os.name == "nt"
                         else (
-                            f'Or export PATH="{local_bin}:$PATH". For no-clone repair, run '
+                            f"Or export PATH=\"{local_bin}:$PATH\". For no-clone repair, run "
                             f"`curl -fsSL {NO_CLONE_INSTALL_URL} | bash`."
                         )
                     )
@@ -1466,30 +1379,12 @@ def render_doctor_markdown(payload: dict[str, Any]) -> str:
     ]
     for check in payload.get("checks") or []:
         required = "required" if check.get("required") else "optional"
-        lines.append(
-            f"- {check.get('id')} ({required}): `{check.get('ok')}` - {check.get('detail')}"
-        )
-    provenance = (
-        payload.get("release_provenance")
-        if isinstance(payload.get("release_provenance"), dict)
-        else {}
-    )
+        lines.append(f"- {check.get('id')} ({required}): `{check.get('ok')}` - {check.get('detail')}")
+    provenance = payload.get("release_provenance") if isinstance(payload.get("release_provenance"), dict) else {}
     if provenance:
-        default_release = (
-            provenance.get("default_release")
-            if isinstance(provenance.get("default_release"), dict)
-            else {}
-        )
-        live_canary = (
-            provenance.get("live_canary")
-            if isinstance(provenance.get("live_canary"), dict)
-            else {}
-        )
-        current = (
-            provenance.get("current_invocation")
-            if isinstance(provenance.get("current_invocation"), dict)
-            else {}
-        )
+        default_release = provenance.get("default_release") if isinstance(provenance.get("default_release"), dict) else {}
+        live_canary = provenance.get("live_canary") if isinstance(provenance.get("live_canary"), dict) else {}
+        current = provenance.get("current_invocation") if isinstance(provenance.get("current_invocation"), dict) else {}
         readiness = (
             provenance.get("promotion_readiness")
             if isinstance(provenance.get("promotion_readiness"), dict)
@@ -1528,15 +1423,9 @@ def render_doctor_markdown(payload: dict[str, Any]) -> str:
                 ),
             ]
         )
-    freshness = (
-        payload.get("install_freshness")
-        if isinstance(payload.get("install_freshness"), dict)
-        else {}
-    )
+    freshness = payload.get("install_freshness") if isinstance(payload.get("install_freshness"), dict) else {}
     if freshness:
-        manifest_source_repo = freshness.get("manifest_source_repo") or freshness.get(
-            "manifest_source_kind"
-        )
+        manifest_source_repo = freshness.get("manifest_source_repo") or freshness.get("manifest_source_kind")
         manifest_source_ref = (
             freshness.get("manifest_source_git_ref")
             or freshness.get("manifest_source_ref")
@@ -1604,10 +1493,6 @@ def render_doctor_markdown(payload: dict[str, Any]) -> str:
     if not payload.get("ok"):
         lines.extend(["", "## Fix", str(payload.get("fix"))])
         writable = payload.get("global_registry_writability")
-        if (
-            isinstance(writable, dict)
-            and not writable.get("ok")
-            and writable.get("recommended_action")
-        ):
+        if isinstance(writable, dict) and not writable.get("ok") and writable.get("recommended_action"):
             lines.append(str(writable.get("recommended_action")))
     return "\n".join(lines)

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -123,9 +123,7 @@ def no_clone_upgrade_command(
     ref = str(source_ref or "").strip()
     installer = f"curl -fsSL {NO_CLONE_INSTALL_URL}"
     doctor_agent_arg = (
-        f" --agent-type {shlex.quote(doctor_agent_type)}"
-        if doctor_agent_type
-        else ""
+        f" --agent-type {shlex.quote(doctor_agent_type)}" if doctor_agent_type else ""
     )
     install_env: list[str] = []
     if ref and ref != "stable":
@@ -205,11 +203,30 @@ def python_distribution_install(module_path: Path) -> dict[str, Any]:
     )
     if not owns_module:
         return {"available": False}
+    pipx_metadata_path = Path(sys.prefix) / "pipx_metadata.json"
+    pipx_environment = None
+    if pipx_metadata_path.is_file():
+        try:
+            pipx_metadata = json.loads(pipx_metadata_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            pipx_metadata = {}
+        recorded_environment = (
+            pipx_metadata.get("environment")
+            if isinstance(pipx_metadata, dict)
+            else None
+        )
+        pipx_environment = (
+            recorded_environment
+            if isinstance(recorded_environment, str) and recorded_environment
+            else Path(sys.prefix).name
+        )
+        installer = "pipx"
     return {
         "available": True,
         "kind": "python_distribution",
         "version": installed.version,
         "installer": installer,
+        "installer_environment": pipx_environment,
         "root": str(Path(installed.locate_file("")).resolve()),
     }
 
@@ -238,7 +255,9 @@ def parse_release_id_time(release_id: str | None) -> datetime | None:
     if not release_id or not RELEASE_ID_TIMESTAMP_RE.match(release_id):
         return None
     try:
-        return datetime.strptime(release_id, "%Y%m%dT%H%M%SZ").replace(tzinfo=timezone.utc)
+        return datetime.strptime(release_id, "%Y%m%dT%H%M%SZ").replace(
+            tzinfo=timezone.utc
+        )
     except ValueError:
         return None
 
@@ -290,7 +309,11 @@ def git_metadata_for_root(root: Path | None) -> dict[str, Any]:
     branch = _run(["symbolic-ref", "--quiet", "--short", "HEAD"])
     tag = _run(["describe", "--tags", "--exact-match"])
     status = _run(["status", "--porcelain"])
-    dirty = None if commit is None and branch is None and tag is None and status is None else bool(status)
+    dirty = (
+        None
+        if commit is None and branch is None and tag is None and status is None
+        else bool(status)
+    )
     return {
         "root": str(source_root),
         "git_commit": commit,
@@ -361,7 +384,9 @@ def git_revision_relation(
 
 def _github_repository_from_remote_url(value: Any) -> str | None:
     text = str(value or "").strip().removesuffix(".git")
-    match = re.search(r"github\.com(?::|/)([^/\s]+/[^/\s]+)$", text, flags=re.IGNORECASE)
+    match = re.search(
+        r"github\.com(?::|/)([^/\s]+/[^/\s]+)$", text, flags=re.IGNORECASE
+    )
     return match.group(1).lower() if match else None
 
 
@@ -412,12 +437,20 @@ def trusted_release_ref_for_root(
             continue
         if (
             remote_url.returncode != 0
-            or _github_repository_from_remote_url(remote_url.stdout) != expected_repository
+            or _github_repository_from_remote_url(remote_url.stdout)
+            != expected_repository
         ):
             continue
         trusted_ref = f"refs/remotes/{remote}/{expected_ref}"
         resolved = subprocess.run(
-            ["git", "-C", str(source_root), "rev-parse", "--verify", f"{trusted_ref}^{{commit}}"],
+            [
+                "git",
+                "-C",
+                str(source_root),
+                "rev-parse",
+                "--verify",
+                f"{trusted_ref}^{{commit}}",
+            ],
             check=False,
             capture_output=True,
             text=True,
@@ -452,7 +485,11 @@ def build_install_freshness(
     release_time = parse_release_id_time(release_id)
     age_hours: float | None = None
     if release_time:
-        age_hours = round(max(0, (reference - release_time.astimezone(timezone.utc)).total_seconds()) / 3600, 2)
+        age_hours = round(
+            max(0, (reference - release_time.astimezone(timezone.utc)).total_seconds())
+            / 3600,
+            2,
+        )
 
     skills_ready = bool(skills) and all(
         skill.get("exists")
@@ -462,7 +499,8 @@ def build_install_freshness(
     )
     distribution_install = (
         python_distribution
-        if isinstance(python_distribution, dict) and python_distribution.get("available")
+        if isinstance(python_distribution, dict)
+        and python_distribution.get("available")
         else None
     )
     externally_managed_skills = skills_ready and any(
@@ -481,7 +519,11 @@ def build_install_freshness(
         status = "python_distribution"
         reason = "LoopX is installed as a managed Python distribution"
         requires_upgrade = False
-    elif release_id and age_hours is not None and age_hours > INSTALL_FRESHNESS_STALE_HOURS:
+    elif (
+        release_id
+        and age_hours is not None
+        and age_hours > INSTALL_FRESHNESS_STALE_HOURS
+    ):
         status = "stale"
         reason = f"default release snapshot is older than {INSTALL_FRESHNESS_STALE_HOURS} hours"
         requires_upgrade = True
@@ -499,9 +541,13 @@ def build_install_freshness(
         requires_upgrade = False
 
     manifest = release_manifest if isinstance(release_manifest, dict) else {}
-    manifest_body = manifest.get("manifest") if isinstance(manifest.get("manifest"), dict) else {}
+    manifest_body = (
+        manifest.get("manifest") if isinstance(manifest.get("manifest"), dict) else {}
+    )
     manifest_package = (
-        manifest_body.get("package") if isinstance(manifest_body.get("package"), dict) else {}
+        manifest_body.get("package")
+        if isinstance(manifest_body.get("package"), dict)
+        else {}
     )
     manifest_package_version = manifest_package.get("version")
     manifest_package_version_tag = manifest_package.get("version_tag") or (
@@ -516,7 +562,9 @@ def build_install_freshness(
         else None
     )
     manifest_source = (
-        manifest_body.get("source") if isinstance(manifest_body.get("source"), dict) else {}
+        manifest_body.get("source")
+        if isinstance(manifest_body.get("source"), dict)
+        else {}
     )
     no_clone_command = no_clone_upgrade_command(
         manifest_source.get("ref"),
@@ -524,16 +572,27 @@ def build_install_freshness(
         skip_skills=externally_managed_skills,
     )
     doctor_agent_arg = (
-        f" --agent-type {shlex.quote(doctor_agent_type)}"
-        if doctor_agent_type
-        else ""
+        f" --agent-type {shlex.quote(doctor_agent_type)}" if doctor_agent_type else ""
     )
     contributor_upgrade_command = (
         f"{local_install_command(repo_root, skip_skills=externally_managed_skills)}\n"
         f"loopx doctor{doctor_agent_arg}"
     )
+    distribution_installer = (
+        distribution_install.get("installer") if distribution_install else None
+    )
+    distribution_environment = (
+        distribution_install.get("installer_environment")
+        if distribution_install
+        else None
+    )
+    package_upgrade_command = (
+        f"pipx upgrade {shlex.quote(str(distribution_environment or 'loopx'))}"
+        if distribution_installer == "pipx"
+        else f"{shlex.quote(sys.executable)} -m pip install --upgrade loopx"
+    )
     upgrade_command = (
-        f"{shlex.quote(sys.executable)} -m pip install --upgrade loopx\n"
+        f"{package_upgrade_command}\n"
         "loopx workflow-skills --install\n"
         "loopx slash-commands --install\n"
         f"loopx doctor{doctor_agent_arg}"
@@ -577,7 +636,9 @@ def build_install_freshness(
         and not skill_problem
     ):
         status = "stale"
-        reason = f"release manifest source commit is behind {freshness_source_label} commit"
+        reason = (
+            f"release manifest source commit is behind {freshness_source_label} commit"
+        )
         requires_upgrade = True
 
     if (
@@ -591,7 +652,9 @@ def build_install_freshness(
         requires_upgrade = True
 
     manifest_skills = (
-        manifest_body.get("skills") if isinstance(manifest_body.get("skills"), dict) else {}
+        manifest_body.get("skills")
+        if isinstance(manifest_body.get("skills"), dict)
+        else {}
     )
     return {
         "schema_version": "loopx_install_freshness_v0",
@@ -617,6 +680,7 @@ def build_install_freshness(
         "python_distribution_installer": (
             distribution_install.get("installer") if distribution_install else None
         ),
+        "python_distribution_installer_environment": distribution_environment,
         "externally_managed_skills": externally_managed_skills,
         "release_manifest_available": manifest.get("available"),
         "release_manifest_path": manifest.get("path"),
@@ -636,7 +700,9 @@ def build_install_freshness(
         "comparison_source_label": comparison_source_label if comparison else None,
         "comparison_source_root": comparison.get("root"),
         "comparison_source_git_commit": comparison_source_git_commit,
-        "comparison_source_git_commit_short": short_revision(comparison_source_git_commit),
+        "comparison_source_git_commit_short": short_revision(
+            comparison_source_git_commit
+        ),
         "comparison_source_git_ref": comparison.get("git_ref"),
         "comparison_source_git_dirty": comparison.get("git_dirty"),
         "manifest_source_matches_comparison": manifest_source_matches_comparison,
@@ -648,7 +714,9 @@ def build_install_freshness(
         "freshness_source_label": freshness_source_label if trusted else None,
         "freshness_source_root": trusted.get("root"),
         "freshness_source_git_commit": freshness_source_git_commit,
-        "freshness_source_git_commit_short": short_revision(freshness_source_git_commit),
+        "freshness_source_git_commit_short": short_revision(
+            freshness_source_git_commit
+        ),
         "freshness_source_git_ref": trusted.get("git_ref"),
         "manifest_source_matches_freshness_source": manifest_source_matches_freshness_source,
         "manifest_source_freshness_relation": (
@@ -734,7 +802,9 @@ def skill_has_required_phrases(skill_path: Path, phrases: tuple[str, ...]) -> bo
     return all(phrase in text for phrase in phrases)
 
 
-def installed_skill_summary(skills_roots: tuple[Path, ...]) -> dict[str, dict[str, Any]]:
+def installed_skill_summary(
+    skills_roots: tuple[Path, ...],
+) -> dict[str, dict[str, Any]]:
     if not skills_roots:
         raise ValueError("at least one Codex skill root is required")
     primary_root = skills_roots[0]
@@ -784,7 +854,9 @@ def installed_skill_check(
     }
 
 
-def latest_promotion_readiness_event(runtime_root: Path, goal_id: str | None = None) -> dict[str, Any]:
+def latest_promotion_readiness_event(
+    runtime_root: Path, goal_id: str | None = None
+) -> dict[str, Any]:
     goals_dir = runtime_root / "goals"
     runtime_index = runtime_root / PROMOTION_READINESS_RUNTIME_INDEX
     if not goals_dir.exists() and not runtime_index.is_file():
@@ -825,24 +897,28 @@ def latest_promotion_readiness_event(runtime_root: Path, goal_id: str | None = N
             json_path = Path(str(item.get("json_path") or ""))
             markdown_path = Path(str(item.get("markdown_path") or ""))
             target_matches = (
-                runtime_matches if source == "runtime_release_ledger" else legacy_matches
+                runtime_matches
+                if source == "runtime_release_ledger"
+                else legacy_matches
             )
             target_matches.append(
                 {
                     "available": True,
                     "source": source,
-                    "goal_id": str(item.get("goal_id") or current_goal_id or "") or None,
+                    "goal_id": str(item.get("goal_id") or current_goal_id or "")
+                    or None,
                     "generated_at": item.get("generated_at"),
                     "classification": classification,
-                    "evidence_scope": item.get("evidence_scope") or (
-                        "goal_run_history" if current_goal_id else "runtime_release"
-                    ),
+                    "evidence_scope": item.get("evidence_scope")
+                    or ("goal_run_history" if current_goal_id else "runtime_release"),
                     "dashboard_readiness": item.get("dashboard_readiness"),
                     "delivery_batch_scale": item.get("delivery_batch_scale"),
                     "delivery_outcome": item.get("delivery_outcome"),
                     "recommended_action": item.get("recommended_action"),
                     "json_exists": json_path.exists() if str(json_path) else False,
-                    "markdown_exists": markdown_path.exists() if str(markdown_path) else False,
+                    "markdown_exists": markdown_path.exists()
+                    if str(markdown_path)
+                    else False,
                 }
             )
 
@@ -907,11 +983,13 @@ def collect_doctor(
     python_distribution = python_distribution_install(module_path)
     package_dir = module_path.parent
     repo_root = package_dir.parent
-    install_script = repo_root / "scripts" / (
-        "install-windows.ps1" if os.name == "nt" else "install-local.sh"
+    install_script = (
+        repo_root
+        / "scripts"
+        / ("install-windows.ps1" if os.name == "nt" else "install-local.sh")
     )
-    wrapper_script = repo_root / "scripts" / (
-        "loopx.ps1" if os.name == "nt" else "loopx"
+    wrapper_script = (
+        repo_root / "scripts" / ("loopx.ps1" if os.name == "nt" else "loopx")
     )
     active_release_root_text = os.environ.get("LOOPX_RELEASE_ROOT")
     release_root = (
@@ -931,9 +1009,7 @@ def collect_doctor(
     skills = installed_skill_summary(skill_roots)
     project_skill = skills["loopx-project"]
     skill_path = Path(str(project_skill["path"]))
-    project_scoped_skill_ids = discover_project_scoped_skill_ids(
-        repo_root / "skills"
-    )
+    project_scoped_skill_ids = discover_project_scoped_skill_ids(repo_root / "skills")
     globally_visible_project_skills = [
         skill_name
         for skill_name in project_scoped_skill_ids
@@ -982,7 +1058,11 @@ def collect_doctor(
         "default_release": default_release,
         "live_canary": {
             **command_root_summary(canary_path, canary_realpath),
-            "separate_from_default": bool(canary_realpath and command_realpath and canary_realpath != command_realpath),
+            "separate_from_default": bool(
+                canary_realpath
+                and command_realpath
+                and canary_realpath != command_realpath
+            ),
         },
         "current_invocation": {
             "module_path": str(module_path),
@@ -1011,9 +1091,7 @@ def collect_doctor(
         doctor_agent_type=canonical_agent_type,
         python_distribution=python_distribution,
     )
-    externally_managed_skills = bool(
-        install_freshness.get("externally_managed_skills")
-    )
+    externally_managed_skills = bool(install_freshness.get("externally_managed_skills"))
     external_skill_delivery = externally_managed_skills and all(
         skill.get("managed_externally") for skill in skills.values()
     )
@@ -1058,7 +1136,9 @@ def collect_doctor(
         ),
     }
     default_global_registry = global_registry_path(DEFAULT_RUNTIME_ROOT)
-    global_registry_writability = probe_registry_write_path(default_global_registry, create_parent=True)
+    global_registry_writability = probe_registry_write_path(
+        default_global_registry, create_parent=True
+    )
     runtime_projection_routes = (
         collect_runtime_projection_route_diagnostics(
             registry_path=default_global_registry,
@@ -1114,24 +1194,34 @@ def collect_doctor(
             "id": "command_resolves",
             "required": True,
             "ok": bool(command_realpath and command_realpath.exists()),
-            "detail": str(command_realpath) if command_realpath else "no command realpath",
+            "detail": str(command_realpath)
+            if command_realpath
+            else "no command realpath",
         },
         {
             "id": "default_command_is_release_snapshot",
             "required": False,
             "ok": bool(release_root and "releases" in release_root.parts),
-            "detail": str(release_root) if release_root else "default command is not a release snapshot",
+            "detail": str(release_root)
+            if release_root
+            else "default command is not a release snapshot",
         },
         {
             "id": "canary_command_on_path",
             "required": False,
             "ok": canary_path is not None,
-            "detail": str(canary_path) if canary_path else "loopx-canary was not found on PATH",
+            "detail": str(canary_path)
+            if canary_path
+            else "loopx-canary was not found on PATH",
         },
         {
             "id": "canary_separate_from_default",
             "required": False,
-            "ok": bool(canary_realpath and command_realpath and canary_realpath != command_realpath),
+            "ok": bool(
+                canary_realpath
+                and command_realpath
+                and canary_realpath != command_realpath
+            ),
             "detail": str(canary_realpath) if canary_realpath else "no canary realpath",
         },
         {
@@ -1218,7 +1308,9 @@ def collect_doctor(
             "ok": bool(global_registry_writability.get("ok")),
             "detail": str(default_global_registry)
             if global_registry_writability.get("ok")
-            else str(global_registry_writability.get("error") or default_global_registry),
+            else str(
+                global_registry_writability.get("error") or default_global_registry
+            ),
         },
         {
             "id": "runtime_projection_routes_healthy",
@@ -1253,7 +1345,9 @@ def collect_doctor(
             "loopx_on_path": str(loopx_path) if loopx_path else None,
             "current_invocation": str(invocation_path) if invocation_path else None,
             "loopx_canary": str(loopx_canary_path) if loopx_canary_path else None,
-            "loopx_canary_realpath": str(loopx_canary_realpath) if loopx_canary_realpath else None,
+            "loopx_canary_realpath": str(loopx_canary_realpath)
+            if loopx_canary_realpath
+            else None,
             "user_local_bin": str(local_bin),
             "user_local_bin_on_path": str(local_bin) in path_entries,
         },
@@ -1317,7 +1411,7 @@ def collect_doctor(
                         f"Ensure `{local_bin}` is on the Windows user PATH."
                         if os.name == "nt"
                         else (
-                            f"Or export PATH=\"{local_bin}:$PATH\". For no-clone repair, run "
+                            f'Or export PATH="{local_bin}:$PATH". For no-clone repair, run '
                             f"`curl -fsSL {NO_CLONE_INSTALL_URL} | bash`."
                         )
                     )
@@ -1372,12 +1466,30 @@ def render_doctor_markdown(payload: dict[str, Any]) -> str:
     ]
     for check in payload.get("checks") or []:
         required = "required" if check.get("required") else "optional"
-        lines.append(f"- {check.get('id')} ({required}): `{check.get('ok')}` - {check.get('detail')}")
-    provenance = payload.get("release_provenance") if isinstance(payload.get("release_provenance"), dict) else {}
+        lines.append(
+            f"- {check.get('id')} ({required}): `{check.get('ok')}` - {check.get('detail')}"
+        )
+    provenance = (
+        payload.get("release_provenance")
+        if isinstance(payload.get("release_provenance"), dict)
+        else {}
+    )
     if provenance:
-        default_release = provenance.get("default_release") if isinstance(provenance.get("default_release"), dict) else {}
-        live_canary = provenance.get("live_canary") if isinstance(provenance.get("live_canary"), dict) else {}
-        current = provenance.get("current_invocation") if isinstance(provenance.get("current_invocation"), dict) else {}
+        default_release = (
+            provenance.get("default_release")
+            if isinstance(provenance.get("default_release"), dict)
+            else {}
+        )
+        live_canary = (
+            provenance.get("live_canary")
+            if isinstance(provenance.get("live_canary"), dict)
+            else {}
+        )
+        current = (
+            provenance.get("current_invocation")
+            if isinstance(provenance.get("current_invocation"), dict)
+            else {}
+        )
         readiness = (
             provenance.get("promotion_readiness")
             if isinstance(provenance.get("promotion_readiness"), dict)
@@ -1416,9 +1528,15 @@ def render_doctor_markdown(payload: dict[str, Any]) -> str:
                 ),
             ]
         )
-    freshness = payload.get("install_freshness") if isinstance(payload.get("install_freshness"), dict) else {}
+    freshness = (
+        payload.get("install_freshness")
+        if isinstance(payload.get("install_freshness"), dict)
+        else {}
+    )
     if freshness:
-        manifest_source_repo = freshness.get("manifest_source_repo") or freshness.get("manifest_source_kind")
+        manifest_source_repo = freshness.get("manifest_source_repo") or freshness.get(
+            "manifest_source_kind"
+        )
         manifest_source_ref = (
             freshness.get("manifest_source_git_ref")
             or freshness.get("manifest_source_ref")
@@ -1486,6 +1604,10 @@ def render_doctor_markdown(payload: dict[str, Any]) -> str:
     if not payload.get("ok"):
         lines.extend(["", "## Fix", str(payload.get("fix"))])
         writable = payload.get("global_registry_writability")
-        if isinstance(writable, dict) and not writable.get("ok") and writable.get("recommended_action"):
+        if (
+            isinstance(writable, dict)
+            and not writable.get("ok")
+            and writable.get("recommended_action")
+        ):
             lines.append(str(writable.get("recommended_action")))
     return "\n".join(lines)

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -195,7 +195,10 @@ COMMAND_GROUPS: list[dict[str, object]] = [
                 "purpose": "Preview, append, or read supervisor proposals and host execution receipts.",
             },
             {"command": "loopx upgrade-plan", "purpose": "Plan default heartbeat upgrade propagation."},
-            {"command": "loopx update", "purpose": "Check, dry-run, or execute the no-clone update path."},
+            {
+                "command": "loopx update [check|plan|apply]",
+                "purpose": "Inspect installation ownership, then explicitly apply archive updates.",
+            },
             {
                 "command": "loopx project-skill --help",
                 "purpose": "Install, inspect, or remove release-owned skills in selected project agent hosts.",

--- a/loopx/python_install_owner.py
+++ b/loopx/python_install_owner.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import shlex
+
+
+@dataclass(frozen=True)
+class PythonInstallOwner:
+    manager: str
+    environment: str | None = None
+
+
+def resolve_python_install_owner(
+    *,
+    default_installer: str,
+    prefix: Path,
+) -> PythonInstallOwner:
+    """Preserve pipx ownership instead of treating its internal pip as plain pip."""
+
+    metadata_path = prefix / "pipx_metadata.json"
+    if not metadata_path.is_file():
+        return PythonInstallOwner(manager=default_installer)
+    try:
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        metadata = {}
+    recorded_environment = metadata.get("environment") if isinstance(metadata, dict) else None
+    environment = (
+        recorded_environment
+        if isinstance(recorded_environment, str) and recorded_environment
+        else prefix.name
+    )
+    return PythonInstallOwner(manager="pipx", environment=environment)
+
+
+def python_distribution_upgrade_command(
+    *,
+    owner: PythonInstallOwner,
+    python_executable: str,
+    doctor_command: str,
+) -> str:
+    package_command = (
+        f"pipx upgrade {shlex.quote(owner.environment or 'loopx')}"
+        if owner.manager == "pipx"
+        else f"{shlex.quote(python_executable)} -m pip install --upgrade loopx"
+    )
+    return (
+        f"{package_command}\n"
+        "loopx workflow-skills --install\n"
+        "loopx slash-commands --install\n"
+        f"{doctor_command}"
+    )

--- a/loopx/python_install_owner.py
+++ b/loopx/python_install_owner.py
@@ -40,12 +40,13 @@ def python_distribution_upgrade_command(
     owner: PythonInstallOwner,
     python_executable: str,
     doctor_command: str,
-) -> str:
-    package_command = (
-        f"pipx upgrade {shlex.quote(owner.environment or 'loopx')}"
-        if owner.manager == "pipx"
-        else f"{shlex.quote(python_executable)} -m pip install --upgrade loopx"
-    )
+) -> str | None:
+    if owner.manager == "pipx":
+        package_command = f"pipx upgrade {shlex.quote(owner.environment or 'loopx')}"
+    elif owner.manager == "pip":
+        package_command = f"{shlex.quote(python_executable)} -m pip install --upgrade loopx"
+    else:
+        return None
     return (
         f"{package_command}\n"
         "loopx workflow-skills --install\n"

--- a/loopx/self_update.py
+++ b/loopx/self_update.py
@@ -782,7 +782,7 @@ def build_update_plan(
         "apply": apply_command,
         "owner_upgrade": owner_upgrade_command,
     }
-    if execute:
+    if execute and apply_supported:
         next_action = {
             "kind": "review_execution",
             "command": "loopx doctor",

--- a/loopx/self_update.py
+++ b/loopx/self_update.py
@@ -787,7 +787,7 @@ def build_update_plan(
             "kind": "review_execution",
             "command": "loopx doctor",
             "mutating": False,
-            "requires_authorization": False,
+            "requires_explicit_approval": False,
             "reason": recommended_action,
         }
     elif apply_command:
@@ -795,7 +795,7 @@ def build_update_plan(
             "kind": "apply_update",
             "command": apply_command,
             "mutating": True,
-            "requires_authorization": True,
+            "requires_explicit_approval": True,
             "reason": recommended_action,
         }
     else:
@@ -803,7 +803,7 @@ def build_update_plan(
             "kind": "use_installation_owner",
             "command": owner_upgrade_command,
             "mutating": bool(owner_upgrade_command),
-            "requires_authorization": bool(owner_upgrade_command),
+            "requires_explicit_approval": bool(owner_upgrade_command),
             "reason": recommended_action,
         }
     return {
@@ -1026,7 +1026,7 @@ def _execute_python_distribution_update(
             "kind": "use_updated_runtime",
             "command": "loopx doctor",
             "mutating": False,
-            "requires_authorization": False,
+            "requires_explicit_approval": False,
             "reason": updated["recommended_action"],
         }
     else:
@@ -1047,7 +1047,7 @@ def _execute_python_distribution_update(
             "kind": "review_or_rollback",
             "command": rollback_command,
             "mutating": bool(rollback_command),
-            "requires_authorization": bool(rollback_command),
+            "requires_explicit_approval": bool(rollback_command),
             "reason": updated["recommended_action"],
         }
     return updated
@@ -1175,7 +1175,7 @@ def execute_update_plan(
             "kind": "review_or_rollback",
             "command": rollback_command,
             "mutating": bool(rollback_command),
-            "requires_authorization": bool(rollback_command),
+            "requires_explicit_approval": bool(rollback_command),
             "reason": updated["recommended_action"],
         }
         return updated
@@ -1187,7 +1187,7 @@ def execute_update_plan(
         "kind": "use_updated_runtime",
         "command": "loopx doctor",
         "mutating": False,
-        "requires_authorization": False,
+        "requires_explicit_approval": False,
         "reason": updated["recommended_action"],
     }
     return updated
@@ -1394,7 +1394,7 @@ def render_update_plan_markdown(payload: dict[str, Any]) -> str:
         "",
         f"- Kind: `{next_action.get('kind')}`",
         f"- Mutating: `{next_action.get('mutating')}`",
-        f"- Requires authorization: `{next_action.get('requires_authorization')}`",
+        f"- Requires explicit approval: `{next_action.get('requires_explicit_approval')}`",
     ]
     next_command = next_action.get("command")
     if next_command:

--- a/loopx/self_update.py
+++ b/loopx/self_update.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from enum import StrEnum
 from pathlib import Path
 import os
 import re
@@ -28,6 +29,44 @@ PERSISTED_PYTHON_FILENAME = ".loopx-python"
 _PACKAGE_VERSION_PATTERN = re.compile(r'^__version__\s*=\s*"([^"]+)"$', re.MULTILINE)
 
 
+class UpdateAction(StrEnum):
+    """Stable operator intent for the self-update boundary."""
+
+    CHECK = "check"
+    PLAN = "plan"
+    APPLY = "apply"
+
+
+def resolve_update_action(
+    action: UpdateAction | str | None = None,
+    *,
+    check: bool = False,
+    dry_run: bool = False,
+    execute: bool = False,
+) -> UpdateAction:
+    """Resolve explicit actions and legacy flag aliases without ambiguity."""
+
+    explicit = UpdateAction(action) if action is not None else None
+    legacy_actions = [
+        candidate
+        for enabled, candidate in (
+            (check, UpdateAction.CHECK),
+            (dry_run, UpdateAction.PLAN),
+            (execute, UpdateAction.APPLY),
+        )
+        if enabled
+    ]
+    if len(legacy_actions) > 1:
+        raise ValueError("choose one update action: check, plan, or apply")
+    legacy = legacy_actions[0] if legacy_actions else None
+    if explicit is not None and legacy is not None and explicit != legacy:
+        raise ValueError(
+            f"update action `{explicit.value}` conflicts with the legacy option for "
+            f"`{legacy.value}`; use `loopx update {explicit.value}` alone"
+        )
+    return explicit or legacy or UpdateAction.PLAN
+
+
 def _source_config(
     *,
     repo: str | None,
@@ -40,7 +79,9 @@ def _source_config(
     archive_url_override = archive_url or os.environ.get("LOOPX_ARCHIVE_URL")
     selected_archive_url = archive_url_override
     if not selected_archive_url:
-        selected_archive_url = f"https://codeload.github.com/{selected_repo}/tar.gz/{selected_ref}"
+        selected_archive_url = (
+            f"https://codeload.github.com/{selected_repo}/tar.gz/{selected_ref}"
+        )
     if archive_url_override:
         channel = "github_archive_url_override"
     elif ref_override:
@@ -104,7 +145,9 @@ def _installer_env_for_source(
         env["LOOPX_PYTHON"] = persisted_python
     env["LOOPX_REPO"] = str(source.get("repo") or DEFAULT_UPDATE_REPO)
     env["LOOPX_REF"] = str(source.get("ref") or DEFAULT_UPDATE_REF)
-    if source.get("channel") == "github_archive_url_override" and source.get("archive_url"):
+    if source.get("channel") == "github_archive_url_override" and source.get(
+        "archive_url"
+    ):
         env["LOOPX_ARCHIVE_URL"] = str(source["archive_url"])
     else:
         env.pop("LOOPX_ARCHIVE_URL", None)
@@ -270,11 +313,19 @@ def _runtime_activation_qualification(
 
 
 def _release_root_from_doctor(doctor_payload: dict[str, Any]) -> str | None:
-    package = doctor_payload.get("package") if isinstance(doctor_payload.get("package"), dict) else {}
+    package = (
+        doctor_payload.get("package")
+        if isinstance(doctor_payload.get("package"), dict)
+        else {}
+    )
     release_root = package.get("release_root")
     if isinstance(release_root, str) and release_root:
         return release_root
-    path = doctor_payload.get("path") if isinstance(doctor_payload.get("path"), dict) else {}
+    path = (
+        doctor_payload.get("path")
+        if isinstance(doctor_payload.get("path"), dict)
+        else {}
+    )
     realpath = path.get("loopx_realpath")
     if isinstance(realpath, str) and realpath:
         realpath_path = Path(realpath)
@@ -332,6 +383,144 @@ def _rollback_plan(doctor_payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _install_lifecycle(doctor_payload: dict[str, Any]) -> dict[str, Any]:
+    package = (
+        doctor_payload.get("package")
+        if isinstance(doctor_payload.get("package"), dict)
+        else {}
+    )
+    freshness = (
+        doctor_payload.get("install_freshness")
+        if isinstance(doctor_payload.get("install_freshness"), dict)
+        else {}
+    )
+    install_kind = package.get("install_kind")
+    if not isinstance(install_kind, str) or not install_kind:
+        if freshness.get("install_kind") == "python_distribution":
+            install_kind = "python_distribution"
+        elif _release_root_from_doctor(doctor_payload):
+            install_kind = "release_snapshot"
+        else:
+            install_kind = "live_checkout"
+
+    installer = None
+    installer_environment = None
+    if install_kind == "release_snapshot":
+        owner = "loopx_release_snapshot"
+        apply_supported = os.name != "nt"
+        execution_driver = "archive_snapshot" if apply_supported else None
+        reason = (
+            "LoopX owns this archive release snapshot and can atomically replace it"
+            if apply_supported
+            else "native Windows snapshot updates remain owned by install-windows.ps1"
+        )
+        owner_command = None
+    elif install_kind == "python_distribution":
+        owner = "python_package_manager"
+        installer = freshness.get("python_distribution_installer")
+        installer_environment = freshness.get(
+            "python_distribution_installer_environment"
+        )
+        if not isinstance(installer, str) or not installer:
+            distribution = (
+                package.get("python_distribution")
+                if isinstance(package.get("python_distribution"), dict)
+                else {}
+            )
+            installer = distribution.get("installer")
+            installer_environment = distribution.get("installer_environment")
+        apply_supported = installer in {"pip", "pipx"}
+        execution_driver = (
+            "python_pipx"
+            if installer == "pipx"
+            else "python_pip"
+            if installer == "pip"
+            else None
+        )
+        reason = (
+            "LoopX can ask the owning Python interpreter's pip to upgrade the same environment"
+            if installer == "pip"
+            else "LoopX can ask pipx to upgrade its recorded LoopX environment"
+            if installer == "pipx"
+            else (
+                f"the active Python environment is owned by {installer or 'an unknown installer'}; "
+                "use that package manager directly"
+            )
+        )
+        owner_command = freshness.get("upgrade_command")
+    else:
+        owner = "source_checkout"
+        apply_supported = False
+        execution_driver = None
+        reason = (
+            "the active checkout owns contributor updates; LoopX must not replace it with "
+            "an archive snapshot"
+        )
+        owner_command = freshness.get("contributor_upgrade_command")
+
+    return {
+        "install_kind": install_kind,
+        "owner": owner,
+        "loopx_apply_supported": apply_supported,
+        "execution_driver": execution_driver,
+        "package_manager": installer if install_kind == "python_distribution" else None,
+        "package_manager_environment": (
+            installer_environment if install_kind == "python_distribution" else None
+        ),
+        "reason": reason,
+        "owner_upgrade_command": owner_command,
+    }
+
+
+def _update_action_command(action: UpdateAction, source: dict[str, Any]) -> str:
+    parts = ["loopx", "update", action.value]
+    default_source = (
+        source.get("repo") == DEFAULT_UPDATE_REPO
+        and source.get("ref") == DEFAULT_UPDATE_REF
+        and source.get("channel") == "github_archive_stable"
+    )
+    if not default_source:
+        parts.extend(["--repo", str(source.get("repo") or DEFAULT_UPDATE_REPO)])
+        parts.extend(["--ref", str(source.get("ref") or DEFAULT_UPDATE_REF)])
+        if source.get("channel") == "github_archive_url_override":
+            parts.extend(["--archive-url", str(source.get("archive_url") or "")])
+    return shlex.join(parts)
+
+
+def _python_distribution_rollback_plan(
+    current_version: object,
+    lifecycle: dict[str, Any],
+) -> dict[str, Any]:
+    if lifecycle.get("execution_driver") == "python_pipx":
+        return {
+            "available": False,
+            "reason": (
+                "pipx owns its environment metadata; inspect the recorded spec before "
+                "requesting a version rollback with pipx"
+            ),
+            "rollback_command": None,
+        }
+    if not isinstance(current_version, str) or not current_version:
+        return {
+            "available": False,
+            "reason": "the installed Python distribution version is unavailable",
+            "rollback_command": None,
+        }
+    command = (
+        f"{shlex.quote(sys.executable)} -m pip install "
+        f"{shlex.quote(f'loopx=={current_version}')}\n"
+        "loopx workflow-skills --install\n"
+        "loopx slash-commands --install\n"
+        "loopx doctor"
+    )
+    return {
+        "available": True,
+        "reason": "pip can request the previously installed LoopX version",
+        "rollback_version": current_version,
+        "rollback_command": command,
+    }
+
+
 def build_rollback_plan(
     *,
     release_id: str,
@@ -342,7 +531,9 @@ def build_rollback_plan(
     current_release_root = _release_root_from_doctor(doctor)
     releases_dir = _user_releases_dir(home)
     releases = _list_release_roots(releases_dir)
-    current_root_path = Path(current_release_root).resolve() if current_release_root else None
+    current_root_path = (
+        Path(current_release_root).resolve() if current_release_root else None
+    )
     requested_release_id = release_id.strip()
     selected: Path | None = None
     reason = None
@@ -406,10 +597,18 @@ def build_update_plan(
     repo: str | None = None,
     ref: str | None = None,
     archive_url: str | None = None,
+    action: UpdateAction | str | None = None,
     check_only: bool = False,
     execute: bool = False,
     doctor_payload: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
+    requested_action = resolve_update_action(
+        action,
+        check=check_only,
+        execute=execute,
+    )
+    check_only = requested_action is UpdateAction.CHECK
+    execute = requested_action is UpdateAction.APPLY
     doctor = doctor_payload or collect_doctor()
     install_freshness = (
         doctor.get("install_freshness")
@@ -427,21 +626,34 @@ def build_update_plan(
         else {}
     )
     source = _source_config(repo=repo, ref=ref, archive_url=archive_url)
-    install_command = _command_for_source(source)
+    lifecycle = _install_lifecycle(doctor)
+    archive_install_command = _command_for_source(source)
     dry_run = not execute
     path = doctor.get("path") if isinstance(doctor.get("path"), dict) else {}
     requires_upgrade = install_freshness.get("requires_upgrade")
     current_version = install_freshness.get("current_version")
-    source_version_check = _source_version_check(source) if check_only else {
-        "schema_version": SOURCE_VERSION_CHECK_SCHEMA_VERSION,
-        "attempted": False,
-        "status": "not_requested",
-        "version": None,
-        "version_tag": None,
-        "matches_current": None,
-        "source_url": None,
-        "reason": "remote source comparison runs only for update --check",
-    }
+    source_version_check = (
+        _source_version_check(source)
+        if check_only and lifecycle["owner"] == "loopx_release_snapshot"
+        else {
+            "schema_version": SOURCE_VERSION_CHECK_SCHEMA_VERSION,
+            "attempted": False,
+            "status": (
+                "delegated"
+                if check_only and lifecycle["owner"] != "loopx_release_snapshot"
+                else "not_requested"
+            ),
+            "version": None,
+            "version_tag": None,
+            "matches_current": None,
+            "source_url": None,
+            "reason": (
+                f"update availability is owned by {lifecycle['owner']}"
+                if check_only and lifecycle["owner"] != "loopx_release_snapshot"
+                else "remote source comparison runs only for `loopx update check`"
+            ),
+        }
+    )
     source_version = source_version_check.get("version")
     if source_version_check.get("status") == "available":
         source_version_check["matches_current"] = (
@@ -449,12 +661,59 @@ def build_update_plan(
             if isinstance(current_version, str) and current_version
             else None
         )
-    runtime_activation = _runtime_activation_qualification(
-        install_freshness=install_freshness,
-        source=source,
+    runtime_activation = (
+        _runtime_activation_qualification(
+            install_freshness=install_freshness,
+            source=source,
+        )
+        if lifecycle["owner"] == "loopx_release_snapshot"
+        else {
+            "schema_version": RUNTIME_ACTIVATION_QUALIFICATION_SCHEMA_VERSION,
+            "decision": "not_applicable",
+            "runtime_active": None,
+            "successor": {"required": False, "kind": None},
+            "reason": (
+                f"runtime activation is governed by {lifecycle['owner']}, not an archive snapshot"
+            ),
+        }
     )
-    if execute:
+    apply_supported = bool(lifecycle["loopx_apply_supported"])
+    owner_upgrade_command = lifecycle.get("owner_upgrade_command")
+    install_command = (
+        archive_install_command
+        if lifecycle["owner"] == "loopx_release_snapshot"
+        else owner_upgrade_command
+    )
+    backup = (
+        _python_distribution_rollback_plan(current_version, lifecycle)
+        if lifecycle["execution_driver"] in {"python_pip", "python_pipx"}
+        else _rollback_plan(doctor)
+    )
+    if execute and not apply_supported:
+        recommended_action = (
+            f"use the active {lifecycle['owner']} upgrade path:\n{owner_upgrade_command}"
+            if owner_upgrade_command
+            else f"use the active {lifecycle['owner']} upgrade path"
+        )
+    elif execute:
         recommended_action = "review execution result and post-update doctor output"
+    elif check_only and lifecycle["owner"] != "loopx_release_snapshot":
+        recommended_action = (
+            f"use the active {lifecycle['owner']} upgrade path:\n{owner_upgrade_command}"
+            if owner_upgrade_command
+            else f"use the active {lifecycle['owner']} upgrade path"
+        )
+    elif lifecycle["owner"] != "loopx_release_snapshot":
+        recommended_action = (
+            "run `loopx update apply` to use the active Python package manager, "
+            "then review host-material readback"
+            if apply_supported
+            else (
+                f"use the active {lifecycle['owner']} upgrade path:\n{owner_upgrade_command}"
+                if owner_upgrade_command
+                else f"use the active {lifecycle['owner']} upgrade path"
+            )
+        )
     elif (
         check_only
         and runtime_activation.get("decision")
@@ -462,22 +721,22 @@ def build_update_plan(
     ):
         recommended_action = (
             "installed runtime does not contain the trusted target source; "
-            "project a release/install successor, then run `loopx update --dry-run`"
+            "project a release/install successor, then run `loopx update plan`"
         )
     elif check_only and source_version_check.get("matches_current") is False:
         recommended_action = (
             f"source version v{source_version} differs from installed version "
-            f"v{current_version}; run `loopx update --dry-run`, then `loopx update --execute`"
+            f"v{current_version}; run `loopx update plan`, then `loopx update apply`"
         )
     elif check_only and source_version_check.get("status") == "unavailable":
         recommended_action = (
             "local install health is known, but the selected source version could not be checked; "
-            "retry online or run `loopx update --execute` to refresh"
+            "retry online or run `loopx update apply` to refresh"
         )
     elif check_only and source_version_check.get("status") == "skipped":
         recommended_action = (
             "local install health is known, but source version comparison was skipped; "
-            "run `loopx update --dry-run` to review the source"
+            "run `loopx update plan` to review the source"
         )
     elif (
         check_only
@@ -487,26 +746,78 @@ def build_update_plan(
             "installed runtime activation is not proven; refresh trusted source lineage "
             "before claiming the merged behavior is active"
         )
-    elif check_only and source_version_check.get("matches_current") is True and requires_upgrade is False:
-        recommended_action = "installed version and trusted source lineage match; no update needed"
+    elif (
+        check_only
+        and source_version_check.get("matches_current") is True
+        and requires_upgrade is False
+    ):
+        recommended_action = (
+            "installed version and trusted source lineage match; no update needed"
+        )
     elif check_only and requires_upgrade is True:
-        recommended_action = "run `loopx update --dry-run` to review the source and rollback plan"
+        recommended_action = (
+            "run `loopx update plan` to review the source and rollback plan"
+        )
     elif requires_upgrade is False:
         recommended_action = (
-            "no update needed; use `loopx update --dry-run` or "
-            "`loopx update --execute` only to force a refresh"
+            "no update needed; use `loopx update plan` or "
+            "`loopx update apply` only to force a refresh"
         )
     elif check_only:
-        recommended_action = "run `loopx update --dry-run` to review the source and rollback plan"
+        recommended_action = (
+            "run `loopx update plan` to review the source and rollback plan"
+        )
     else:
-        recommended_action = "run `loopx update --execute` if you accept the source and rollback plan"
+        recommended_action = (
+            "run `loopx update apply` if you accept the source and rollback plan"
+        )
+    apply_command = (
+        _update_action_command(UpdateAction.APPLY, source)
+        if apply_supported
+        else None
+    )
+    commands = {
+        "check": _update_action_command(UpdateAction.CHECK, source),
+        "plan": _update_action_command(UpdateAction.PLAN, source),
+        "apply": apply_command,
+        "owner_upgrade": owner_upgrade_command,
+    }
+    if execute:
+        next_action = {
+            "kind": "review_execution",
+            "command": "loopx doctor",
+            "mutating": False,
+            "requires_authorization": False,
+            "reason": recommended_action,
+        }
+    elif apply_command:
+        next_action = {
+            "kind": "apply_update",
+            "command": apply_command,
+            "mutating": True,
+            "requires_authorization": True,
+            "reason": recommended_action,
+        }
+    else:
+        next_action = {
+            "kind": "use_installation_owner",
+            "command": owner_upgrade_command,
+            "mutating": bool(owner_upgrade_command),
+            "requires_authorization": bool(owner_upgrade_command),
+            "reason": recommended_action,
+        }
     return {
-        "ok": True,
+        "ok": not execute or apply_supported,
         "schema_version": UPDATE_PLAN_SCHEMA_VERSION,
         "mode": "update",
+        "requested_action": requested_action.value,
         "check_only": check_only,
         "dry_run": dry_run,
         "execute_requested": execute,
+        "changes_applied": False,
+        "install_lifecycle": lifecycle,
+        "commands": commands,
+        "next_action": next_action,
         "source": source,
         "source_version_check": source_version_check,
         "runtime_activation_qualification": runtime_activation,
@@ -515,8 +826,12 @@ def build_update_plan(
             "loopx_realpath": path.get("loopx_realpath"),
             "current_version": current_version,
             "current_version_tag": install_freshness.get("current_version_tag"),
-            "manifest_package_version": install_freshness.get("manifest_package_version"),
-            "manifest_package_version_tag": install_freshness.get("manifest_package_version_tag"),
+            "manifest_package_version": install_freshness.get(
+                "manifest_package_version"
+            ),
+            "manifest_package_version_tag": install_freshness.get(
+                "manifest_package_version_tag"
+            ),
             "manifest_package_version_matches_runtime": install_freshness.get(
                 "manifest_package_version_matches_runtime"
             ),
@@ -529,14 +844,27 @@ def build_update_plan(
             "release_manifest": release_manifest_body,
         },
         "plan": {
-            "action": "check_only" if check_only else "execute_installer" if execute else "dry_run",
+            "action": "check_only"
+            if check_only
+            else "execute_installer"
+            if execute
+            else "dry_run",
+            "apply_supported": apply_supported,
+            "blocked_reason": lifecycle["reason"]
+            if execute and not apply_supported
+            else None,
             "install_command": install_command,
             "post_update_validation": "loopx doctor",
             "mutates_loopx_runtime_state": False,
-            "mutates_release_install": execute,
-            "backup": _rollback_plan(doctor),
+            "mutates_release_install": execute and apply_supported,
+            "backup": backup,
         },
         "execution": None,
+        "error": (
+            f"`loopx update apply` cannot mutate an installation owned by {lifecycle['owner']}"
+            if execute and not apply_supported
+            else None
+        ),
         "recommended_action": recommended_action,
     }
 
@@ -576,7 +904,183 @@ def restart_managed_loopx_services() -> list[str]:
     return restarted
 
 
-def execute_update_plan(payload: dict[str, Any], *, timeout_seconds: int = 600) -> dict[str, Any]:
+def _execute_python_distribution_update(
+    payload: dict[str, Any],
+    *,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    lifecycle = (
+        payload.get("install_lifecycle")
+        if isinstance(payload.get("install_lifecycle"), dict)
+        else {}
+    )
+    driver = lifecycle.get("execution_driver")
+    package_manager_environment = lifecycle.get("package_manager_environment")
+    install_command = (
+        ["pipx", "upgrade", str(package_manager_environment or "loopx")]
+        if driver == "python_pipx"
+        else [sys.executable, "-m", "pip", "install", "--upgrade", "loopx"]
+    )
+    commands = {
+        "install": install_command,
+        "workflow_skills": [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "workflow-skills",
+            "--install",
+            "--format",
+            "json",
+        ],
+        "slash_commands": [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "slash-commands",
+            "--install",
+            "--format",
+            "json",
+        ],
+        "doctor": [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "doctor",
+            "--format",
+            "json",
+        ],
+        "extension_doctor": [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "extension",
+            "doctor",
+            "--all-enabled",
+            "--execute",
+            "--format",
+            "json",
+        ],
+    }
+    results: dict[str, subprocess.CompletedProcess[str]] = {}
+    results["install"] = subprocess.run(
+        commands["install"],
+        text=True,
+        capture_output=True,
+        timeout=timeout_seconds,
+    )
+    if results["install"].returncode == 0:
+        for step in ("workflow_skills", "slash_commands", "doctor"):
+            results[step] = subprocess.run(
+                commands[step],
+                text=True,
+                capture_output=True,
+                timeout=timeout_seconds,
+            )
+        if all(
+            results[step].returncode == 0
+            for step in ("workflow_skills", "slash_commands", "doctor")
+        ):
+            results["extension_doctor"] = subprocess.run(
+                commands["extension_doctor"],
+                text=True,
+                capture_output=True,
+                timeout=timeout_seconds,
+            )
+
+    execution: dict[str, Any] = {
+        "driver": driver,
+        "python_executable": sys.executable,
+        "install_returncode": results["install"].returncode,
+        "install_stdout_tail": results["install"].stdout[-2000:],
+        "install_stderr_tail": results["install"].stderr[-2000:],
+    }
+    for step in ("workflow_skills", "slash_commands", "doctor", "extension_doctor"):
+        result = results.get(step)
+        if result is None:
+            execution[f"{step}_status"] = "skipped_prior_step_failed"
+            continue
+        execution[f"{step}_returncode"] = result.returncode
+        execution[f"{step}_stdout_tail"] = result.stdout[-2000:]
+        execution[f"{step}_stderr_tail"] = result.stderr[-2000:]
+
+    required_steps = (
+        "install",
+        "workflow_skills",
+        "slash_commands",
+        "doctor",
+        "extension_doctor",
+    )
+    ok = all(
+        step in results and results[step].returncode == 0 for step in required_steps
+    )
+    updated = dict(payload)
+    updated["execution"] = execution
+    updated["ok"] = ok
+    updated["changes_applied"] = results["install"].returncode == 0
+    if ok:
+        execution["restarted_services"] = restart_managed_loopx_services()
+        updated["recommended_action"] = (
+            "PyPI update and host-material readback passed; use the new LoopX process"
+        )
+        updated["next_action"] = {
+            "kind": "use_updated_runtime",
+            "command": "loopx doctor",
+            "mutating": False,
+            "requires_authorization": False,
+            "reason": updated["recommended_action"],
+        }
+    else:
+        backup = (
+            payload.get("plan", {}).get("backup")
+            if isinstance(payload.get("plan"), dict)
+            else {}
+        )
+        rollback_command = (
+            backup.get("rollback_command") if isinstance(backup, dict) else None
+        )
+        updated["recommended_action"] = (
+            "inspect the failed update step, then use the recorded package rollback command"
+            if rollback_command
+            else "inspect the failed package-manager or host-material update step"
+        )
+        updated["next_action"] = {
+            "kind": "review_or_rollback",
+            "command": rollback_command,
+            "mutating": bool(rollback_command),
+            "requires_authorization": bool(rollback_command),
+            "reason": updated["recommended_action"],
+        }
+    return updated
+
+
+def execute_update_plan(
+    payload: dict[str, Any], *, timeout_seconds: int = 600
+) -> dict[str, Any]:
+    lifecycle = (
+        payload.get("install_lifecycle")
+        if isinstance(payload.get("install_lifecycle"), dict)
+        else {}
+    )
+    driver = lifecycle.get("execution_driver")
+    if driver is None and isinstance(payload.get("source"), dict):
+        # Compatibility for callers that persisted the v0 archive plan before
+        # install_lifecycle became explicit.
+        driver = "archive_snapshot"
+    if driver in {"python_pip", "python_pipx"}:
+        return _execute_python_distribution_update(
+            payload,
+            timeout_seconds=timeout_seconds,
+        )
+    if driver != "archive_snapshot":
+        updated = dict(payload)
+        updated["ok"] = False
+        updated["changes_applied"] = False
+        updated["execution"] = {
+            "status": "unsupported_install_owner",
+            "owner": lifecycle.get("owner"),
+            "reason": lifecycle.get("reason"),
+        }
+        return updated
     if os.name == "nt":
         updated = dict(payload)
         updated["execution"] = {
@@ -601,7 +1105,11 @@ def execute_update_plan(payload: dict[str, Any], *, timeout_seconds: int = 600) 
         ),
     )
     install_result = subprocess.run(
-        ["bash", "-lc", f"set -o pipefail; curl -fsSL {shlex.quote(installer_url)} | bash"],
+        [
+            "bash",
+            "-lc",
+            f"set -o pipefail; curl -fsSL {shlex.quote(installer_url)} | bash",
+        ],
         text=True,
         capture_output=True,
         env=env,
@@ -657,12 +1165,31 @@ def execute_update_plan(payload: dict[str, Any], *, timeout_seconds: int = 600) 
         and extension_doctor_result is not None
         and extension_doctor_result.returncode == 0
     )
+    updated["changes_applied"] = install_result.returncode == 0
     if not updated["ok"]:
         updated["recommended_action"] = (
             "inspect update execution tails and restore from rollback plan if needed"
         )
+        rollback_command = backup.get("rollback_command")
+        updated["next_action"] = {
+            "kind": "review_or_rollback",
+            "command": rollback_command,
+            "mutating": bool(rollback_command),
+            "requires_authorization": bool(rollback_command),
+            "reason": updated["recommended_action"],
+        }
         return updated
     execution["restarted_services"] = restart_managed_loopx_services()
+    updated["recommended_action"] = (
+        "archive update and readback passed; use the new LoopX process"
+    )
+    updated["next_action"] = {
+        "kind": "use_updated_runtime",
+        "command": "loopx doctor",
+        "mutating": False,
+        "requires_authorization": False,
+        "reason": updated["recommended_action"],
+    }
     return updated
 
 
@@ -750,7 +1277,9 @@ def execute_rollback_plan(
             execution["extension_doctor_status"] = "skipped_core_doctor_failed"
             updated["ok"] = False
         if doctor_result.returncode != 0 and previous_link_target:
-            restore_link = loopx_bin.with_name(f".{loopx_bin.name}.rollback.restore.{os.getpid()}")
+            restore_link = loopx_bin.with_name(
+                f".{loopx_bin.name}.rollback.restore.{os.getpid()}"
+            )
             if restore_link.exists() or restore_link.is_symlink():
                 restore_link.unlink()
             restore_link.symlink_to(previous_link_target)
@@ -760,7 +1289,9 @@ def execute_rollback_plan(
         execution["error"] = str(exc)
         updated["ok"] = False
         if previous_link_target:
-            restore_link = loopx_bin.with_name(f".{loopx_bin.name}.rollback.restore.{os.getpid()}")
+            restore_link = loopx_bin.with_name(
+                f".{loopx_bin.name}.rollback.restore.{os.getpid()}"
+            )
             try:
                 if restore_link.exists() or restore_link.is_symlink():
                     restore_link.unlink()
@@ -772,15 +1303,16 @@ def execute_rollback_plan(
     finally:
         if "temp_link" in locals() and (temp_link.exists() or temp_link.is_symlink()):
             temp_link.unlink()
-        if "restore_link" in locals() and (restore_link.exists() or restore_link.is_symlink()):
+        if "restore_link" in locals() and (
+            restore_link.exists() or restore_link.is_symlink()
+        ):
             restore_link.unlink()
     updated["execution"] = execution
     if updated["ok"]:
         updated["recommended_action"] = "rollback complete; review doctor output"
-    elif (
-        execution.get("doctor_returncode") == 0
-        and execution.get("extension_doctor_returncode") not in {None, 0}
-    ):
+    elif execution.get("doctor_returncode") == 0 and execution.get(
+        "extension_doctor_returncode"
+    ) not in {None, 0}:
         updated["recommended_action"] = (
             "rollback activated, but one or more enabled extensions remain fail "
             "closed; repair the provider and run `loopx extension doctor "
@@ -796,7 +1328,11 @@ def execute_rollback_plan(
 def render_update_plan_markdown(payload: dict[str, Any]) -> str:
     if payload.get("mode") == "rollback":
         plan = payload.get("plan") if isinstance(payload.get("plan"), dict) else {}
-        execution = payload.get("execution") if isinstance(payload.get("execution"), dict) else None
+        execution = (
+            payload.get("execution")
+            if isinstance(payload.get("execution"), dict)
+            else None
+        )
         lines = [
             "# LoopX Update Rollback",
             "",
@@ -811,7 +1347,9 @@ def render_update_plan_markdown(payload: dict[str, Any]) -> str:
         ]
         rollback_command = plan.get("rollback_command")
         if rollback_command:
-            lines.extend(["", "## Rollback Command", "", "```bash", str(rollback_command), "```"])
+            lines.extend(
+                ["", "## Rollback Command", "", "```bash", str(rollback_command), "```"]
+            )
         if execution:
             lines.extend(
                 [
@@ -837,45 +1375,92 @@ def render_update_plan_markdown(payload: dict[str, Any]) -> str:
     current = payload.get("current") if isinstance(payload.get("current"), dict) else {}
     plan = payload.get("plan") if isinstance(payload.get("plan"), dict) else {}
     backup = plan.get("backup") if isinstance(plan.get("backup"), dict) else {}
+    next_action = (
+        payload.get("next_action")
+        if isinstance(payload.get("next_action"), dict)
+        else {}
+    )
+    notice = (
+        "> **No update was applied.** This is a read-only check/plan."
+        if not payload.get("execute_requested")
+        else "> **Apply was requested.** Review the execution and validation result below."
+    )
     lines = [
         "# LoopX Update",
         "",
-        f"- OK: `{payload.get('ok')}`",
-        f"- Mode: `{plan.get('action')}`",
-        f"- Dry run: `{payload.get('dry_run')}`",
-        f"- Source: `{source.get('repo')}` @ `{source.get('ref')}`",
-        f"- Source version check: `{source_version_check.get('status')}`",
-        f"- Source version: `{source_version_check.get('version')}`",
-        f"- Source version tag: `{source_version_check.get('version_tag')}`",
-        f"- Source version matches current: `{source_version_check.get('matches_current')}`",
-        f"- Source version check reason: `{source_version_check.get('reason')}`",
-        f"- Runtime activation decision: `{runtime_activation.get('decision')}`",
-        f"- Runtime active: `{runtime_activation.get('runtime_active')}`",
-        f"- Installed source commit: `{runtime_activation.get('installed_source_commit')}`",
-        f"- Target source commit: `{runtime_activation.get('target_source_commit')}`",
-        f"- Source revision relation: `{runtime_activation.get('revision_relation')}`",
-        f"- Runtime activation reason: `{runtime_activation.get('reason')}`",
-        f"- Current version: `{current.get('current_version')}`",
-        f"- Current version tag: `{current.get('current_version_tag')}`",
-        f"- Manifest package version: `{current.get('manifest_package_version')}`",
-        f"- Manifest package version tag: `{current.get('manifest_package_version_tag')}`",
-        f"- Manifest package matches runtime: `{current.get('manifest_package_version_matches_runtime')}`",
-        f"- Freshness: `{current.get('install_freshness_status')}`",
-        f"- Requires upgrade: `{current.get('requires_upgrade')}`",
-        f"- Runtime state mutation: `{plan.get('mutates_loopx_runtime_state')}`",
-        f"- Release install mutation: `{plan.get('mutates_release_install')}`",
-        f"- Rollback available: `{backup.get('available')}`",
-        f"- Recommended action: {payload.get('recommended_action')}",
+        notice,
         "",
-        "## Install Command",
+        "## Next Action",
         "",
-        "```bash",
-        str(plan.get("install_command") or ""),
-        "```",
+        f"- Kind: `{next_action.get('kind')}`",
+        f"- Mutating: `{next_action.get('mutating')}`",
+        f"- Requires authorization: `{next_action.get('requires_authorization')}`",
     ]
+    next_command = next_action.get("command")
+    if next_command:
+        lines.extend(["", "```bash", str(next_command), "```"])
+    lines.extend(
+        [
+            "",
+            "## Details",
+            "",
+            f"- OK: `{payload.get('ok')}`",
+            f"- Requested action: `{payload.get('requested_action')}`",
+            f"- Changes applied: `{payload.get('changes_applied')}`",
+            f"- Mode: `{plan.get('action')}`",
+            f"- Dry run: `{payload.get('dry_run')}`",
+            f"- Source: `{source.get('repo')}` @ `{source.get('ref')}`",
+            f"- Source version check: `{source_version_check.get('status')}`",
+            f"- Source version: `{source_version_check.get('version')}`",
+            f"- Source version tag: `{source_version_check.get('version_tag')}`",
+            f"- Source version matches current: `{source_version_check.get('matches_current')}`",
+            f"- Source version check reason: {source_version_check.get('reason')}",
+            f"- Runtime activation decision: `{runtime_activation.get('decision')}`",
+            f"- Runtime active: `{runtime_activation.get('runtime_active')}`",
+            f"- Installed source commit: `{runtime_activation.get('installed_source_commit')}`",
+            f"- Target source commit: `{runtime_activation.get('target_source_commit')}`",
+            f"- Source revision relation: `{runtime_activation.get('revision_relation')}`",
+            f"- Runtime activation reason: {runtime_activation.get('reason')}",
+            f"- Current version: `{current.get('current_version')}`",
+            f"- Current version tag: `{current.get('current_version_tag')}`",
+            f"- Manifest package version: `{current.get('manifest_package_version')}`",
+            f"- Manifest package version tag: `{current.get('manifest_package_version_tag')}`",
+            f"- Manifest package matches runtime: `{current.get('manifest_package_version_matches_runtime')}`",
+            f"- Freshness: `{current.get('install_freshness_status')}`",
+            f"- Requires upgrade: `{current.get('requires_upgrade')}`",
+            f"- Runtime state mutation: `{plan.get('mutates_loopx_runtime_state')}`",
+            f"- Release install mutation: `{plan.get('mutates_release_install')}`",
+            f"- Install kind: `{(payload.get('install_lifecycle') or {}).get('install_kind')}`",
+            f"- Install owner: `{(payload.get('install_lifecycle') or {}).get('owner')}`",
+            f"- Apply supported: `{plan.get('apply_supported')}`",
+            f"- Rollback available: `{backup.get('available')}`",
+            f"- Recommended action: {payload.get('recommended_action')}",
+            "",
+            "## Planned Installation-owner Command",
+            "",
+            "```bash",
+            str(plan.get("install_command") or ""),
+            "```",
+        ]
+    )
+    commands = (
+        payload.get("commands") if isinstance(payload.get("commands"), dict) else {}
+    )
+    lines.extend(
+        [
+            "",
+            "## Intent Commands",
+            "",
+            f"- Check: `{commands.get('check')}`",
+            f"- Plan: `{commands.get('plan')}`",
+            f"- Apply: `{commands.get('apply')}`",
+        ]
+    )
     rollback_command = backup.get("rollback_command")
     if rollback_command:
-        lines.extend(["", "## Rollback Command", "", "```bash", str(rollback_command), "```"])
+        lines.extend(
+            ["", "## Rollback Command", "", "```bash", str(rollback_command), "```"]
+        )
     execution = payload.get("execution")
     if isinstance(execution, dict):
         lines.extend(

--- a/man/loopx.1
+++ b/man/loopx.1
@@ -164,8 +164,8 @@ Preview, append, or read supervisor proposals and host execution receipts.
 \fBloopx upgrade\-plan\fR
 Plan default heartbeat upgrade propagation.
 .TP
-\fBloopx update\fR
-Check, dry\-run, or execute the no\-clone update path.
+\fBloopx update [check|plan|apply]\fR
+Inspect installation ownership, then explicitly apply archive updates.
 .TP
 \fBloopx project\-skill \-\-help\fR
 Install, inspect, or remove release\-owned skills in selected project agent hosts.

--- a/tests/test_doctor_install_freshness.py
+++ b/tests/test_doctor_install_freshness.py
@@ -387,6 +387,24 @@ def test_pipx_distribution_preserves_the_pipx_owner(tmp_path: Path) -> None:
     assert "python -m pip" not in freshness["upgrade_command"]
 
 
+def test_unknown_distribution_installer_has_no_guessed_upgrade_command(tmp_path: Path) -> None:
+    freshness = build_install_freshness(
+        command_path=tmp_path / "loopx",
+        release_root=None,
+        repo_root=tmp_path,
+        skills={"loopx-project": {"exists": True, "required_phrases": True}},
+        python_distribution={
+            "available": True,
+            "kind": "python_distribution",
+            "version": "0.4.8",
+            "installer": "custom-manager",
+        },
+    )
+
+    assert freshness["python_distribution_installer"] == "custom-manager"
+    assert freshness["upgrade_command"] is None
+
+
 def test_python_distribution_detects_pipx_metadata_owner(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_doctor_install_freshness.py
+++ b/tests/test_doctor_install_freshness.py
@@ -5,6 +5,8 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from loopx import __version__
 from loopx.doctor import (
     REQUIRED_INSTALLED_SKILL_PHRASES,
@@ -12,8 +14,35 @@ from loopx.doctor import (
     current_script_invocation_path,
     git_revision_relation,
     installed_skill_summary,
+    python_distribution_install,
     trusted_release_ref_for_root,
 )
+
+
+class _FakeDistributionFile:
+    def __init__(self, module_path: Path) -> None:
+        self._module_path = module_path
+
+    def as_posix(self) -> str:
+        return "loopx/doctor.py"
+
+    def locate(self) -> Path:
+        return self._module_path
+
+
+class _FakeDistribution:
+    version = "0.4.8"
+
+    def __init__(self, module_path: Path, root: Path) -> None:
+        self.files = [_FakeDistributionFile(module_path)]
+        self._root = root
+
+    def read_text(self, name: str) -> str:
+        assert name == "INSTALLER"
+        return "pip"
+
+    def locate_file(self, _name: str) -> Path:
+        return self._root
 
 
 def _git(root: Path, *args: str) -> str:
@@ -208,7 +237,9 @@ def test_stable_channel_upgrade_command_keeps_public_default(tmp_path: Path) -> 
     assert freshness["upgrade_command"] == command
 
 
-def test_unknown_canary_relation_does_not_stale_current_default_release(tmp_path: Path) -> None:
+def test_unknown_canary_relation_does_not_stale_current_default_release(
+    tmp_path: Path,
+) -> None:
     current = "a" * 40
     freshness = _freshness(
         tmp_path,
@@ -327,9 +358,58 @@ def test_python_distribution_uses_pip_native_upgrade_path(tmp_path: Path) -> Non
     if os.name == "nt":
         assert "install-windows.ps1" in str(freshness["no_clone_upgrade_command"])
     else:
-        assert "huangruiteng.github.io" in str(
-            freshness["no_clone_upgrade_command"]
-        )
+        assert "huangruiteng.github.io" in str(freshness["no_clone_upgrade_command"])
+
+
+def test_pipx_distribution_preserves_the_pipx_owner(tmp_path: Path) -> None:
+    freshness = build_install_freshness(
+        command_path=tmp_path / "loopx",
+        release_root=None,
+        repo_root=tmp_path,
+        skills={
+            "loopx-project": {
+                "exists": True,
+                "required_phrases": True,
+            }
+        },
+        python_distribution={
+            "available": True,
+            "kind": "python_distribution",
+            "version": "0.4.8",
+            "installer": "pipx",
+            "installer_environment": "loopx-preview",
+        },
+    )
+
+    assert freshness["python_distribution_installer"] == "pipx"
+    assert freshness["python_distribution_installer_environment"] == "loopx-preview"
+    assert freshness["upgrade_command"].startswith("pipx upgrade loopx-preview\n")
+    assert "python -m pip" not in freshness["upgrade_command"]
+
+
+def test_python_distribution_detects_pipx_metadata_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    venv = tmp_path / "venvs" / "loopx-preview"
+    module_path = venv / "lib" / "python" / "site-packages" / "loopx" / "doctor.py"
+    module_path.parent.mkdir(parents=True)
+    module_path.write_text("# fixture\n", encoding="utf-8")
+    (venv / "pipx_metadata.json").write_text(
+        '{"pipx_metadata_version":"0.12","environment":"loopx-preview"}\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "loopx.doctor.distribution",
+        lambda _name: _FakeDistribution(module_path, module_path.parents[2]),
+    )
+    monkeypatch.setattr("loopx.doctor.sys.prefix", str(venv))
+
+    installed = python_distribution_install(module_path)
+
+    assert installed["available"] is True
+    assert installed["installer"] == "pipx"
+    assert installed["installer_environment"] == "loopx-preview"
 
 
 def test_python_distribution_ignores_archive_manifest_version(tmp_path: Path) -> None:

--- a/tests/test_self_update_runtime_activation.py
+++ b/tests/test_self_update_runtime_activation.py
@@ -10,7 +10,13 @@ from unittest import mock
 from loopx import __version__
 import pytest
 
-from loopx.self_update import build_update_plan, execute_update_plan, restart_managed_loopx_services
+from loopx.self_update import (
+    UpdateAction,
+    build_update_plan,
+    execute_update_plan,
+    resolve_update_action,
+    restart_managed_loopx_services,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -126,7 +132,9 @@ def test_missing_commit_lineage_never_proves_runtime_active() -> None:
 
 def test_different_selected_source_never_reuses_unrelated_lineage() -> None:
     payload = build_check(
-        doctor_payload(target_commit=INSTALLED_COMMIT, relation="same", source_ref="stable"),
+        doctor_payload(
+            target_commit=INSTALLED_COMMIT, relation="same", source_ref="stable"
+        ),
         ref="main",
     )
 
@@ -148,9 +156,9 @@ def test_cli_check_qualifies_explicit_installed_doctor_snapshot(tmp_path: Path) 
             "-m",
             "loopx.cli",
             "update",
+            "check",
             "--format",
             "json",
-            "--check",
             "--repo",
             "example/loopx",
             "--ref",
@@ -173,6 +181,171 @@ def test_cli_check_qualifies_explicit_installed_doctor_snapshot(tmp_path: Path) 
     assert activation["decision"] == "release_or_install_successor_required"
     assert activation["installed_source_commit"] == INSTALLED_COMMIT
     assert activation["target_source_commit"] == TARGET_COMMIT
+
+
+def test_update_actions_are_explicit_and_legacy_flags_remain_compatible() -> None:
+    assert resolve_update_action("check") is UpdateAction.CHECK
+    assert resolve_update_action("plan") is UpdateAction.PLAN
+    assert resolve_update_action("apply") is UpdateAction.APPLY
+    assert resolve_update_action(check=True) is UpdateAction.CHECK
+    assert resolve_update_action(dry_run=True) is UpdateAction.PLAN
+    assert resolve_update_action(execute=True) is UpdateAction.APPLY
+    assert resolve_update_action() is UpdateAction.PLAN
+
+    with pytest.raises(ValueError, match="conflicts with the legacy option"):
+        resolve_update_action("check", execute=True)
+
+
+def test_python_distribution_apply_uses_the_owning_interpreter_pip() -> None:
+    doctor = doctor_payload()
+    doctor["package"] = {
+        "install_kind": "python_distribution",
+        "release_root": None,
+    }
+    doctor["install_freshness"]["install_kind"] = "python_distribution"
+    doctor["install_freshness"]["python_distribution_installer"] = "pip"
+    doctor["install_freshness"]["upgrade_command"] = (
+        "/managed/python -m pip install --upgrade loopx\n"
+        "loopx workflow-skills --install\n"
+        "loopx slash-commands --install\n"
+        "loopx doctor"
+    )
+
+    payload = build_update_plan(action="apply", doctor_payload=doctor)
+
+    assert payload["ok"] is True
+    assert payload["requested_action"] == "apply"
+    assert payload["changes_applied"] is False
+    assert payload["install_lifecycle"] == {
+        "install_kind": "python_distribution",
+        "owner": "python_package_manager",
+        "loopx_apply_supported": True,
+        "execution_driver": "python_pip",
+        "package_manager": "pip",
+        "package_manager_environment": None,
+        "reason": (
+            "LoopX can ask the owning Python interpreter's pip to upgrade the same environment"
+        ),
+        "owner_upgrade_command": doctor["install_freshness"]["upgrade_command"],
+    }
+    assert payload["commands"]["apply"] == "loopx update apply"
+    assert payload["commands"]["owner_upgrade"].startswith("/managed/python -m pip")
+    assert payload["plan"]["install_command"] == payload["commands"]["owner_upgrade"]
+    assert payload["plan"]["mutates_release_install"] is True
+    assert payload["plan"]["backup"]["rollback_version"] == __version__
+    assert f"loopx=={__version__}" in payload["plan"]["backup"]["rollback_command"]
+    assert payload["error"] is None
+
+    passed = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout='{"ok": true}',
+        stderr="",
+    )
+    with (
+        mock.patch(
+            "loopx.self_update.subprocess.run",
+            side_effect=[passed, passed, passed, passed, passed],
+        ) as run,
+        mock.patch(
+            "loopx.self_update.restart_managed_loopx_services",
+            return_value=["com.loopx.status"],
+        ),
+    ):
+        result = execute_update_plan(payload)
+
+    assert result["ok"] is True
+    assert result["changes_applied"] is True
+    assert result["execution"]["driver"] == "python_pip"
+    assert result["execution"]["restarted_services"] == ["com.loopx.status"]
+    assert run.call_args_list[0].args[0] == [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--upgrade",
+        "loopx",
+    ]
+    assert run.call_args_list[1].args[0][3:5] == ["workflow-skills", "--install"]
+    assert run.call_args_list[2].args[0][3:5] == ["slash-commands", "--install"]
+
+
+def test_pipx_distribution_apply_preserves_the_pipx_environment() -> None:
+    doctor = doctor_payload()
+    doctor["package"] = {"install_kind": "python_distribution"}
+    doctor["install_freshness"].update(
+        {
+            "install_kind": "python_distribution",
+            "python_distribution_installer": "pipx",
+            "python_distribution_installer_environment": "loopx-preview",
+            "upgrade_command": "pipx upgrade loopx-preview\nloopx doctor",
+        }
+    )
+    payload = build_update_plan(action="apply", doctor_payload=doctor)
+
+    assert payload["install_lifecycle"]["execution_driver"] == "python_pipx"
+    assert (
+        payload["install_lifecycle"]["package_manager_environment"] == "loopx-preview"
+    )
+    assert payload["plan"]["backup"]["available"] is False
+
+    passed = subprocess.CompletedProcess([], 0, '{"ok": true}', "")
+    with (
+        mock.patch(
+            "loopx.self_update.subprocess.run",
+            side_effect=[passed, passed, passed, passed, passed],
+        ) as run,
+        mock.patch(
+            "loopx.self_update.restart_managed_loopx_services",
+            return_value=[],
+        ),
+    ):
+        result = execute_update_plan(payload)
+
+    assert result["ok"] is True
+    assert run.call_args_list[0].args[0] == ["pipx", "upgrade", "loopx-preview"]
+
+
+def test_live_checkout_apply_never_mutates_git_or_switches_install_channels() -> None:
+    doctor = doctor_payload()
+    doctor["package"] = {"install_kind": "live_checkout", "release_root": None}
+    doctor["install_freshness"]["contributor_upgrade_command"] = (
+        "/workspace/loopx/scripts/install-local.sh\nloopx doctor"
+    )
+
+    payload = build_update_plan(action="apply", doctor_payload=doctor)
+
+    assert payload["ok"] is False
+    assert payload["install_lifecycle"]["owner"] == "source_checkout"
+    assert payload["install_lifecycle"]["execution_driver"] is None
+    assert payload["commands"]["apply"] is None
+    assert payload["plan"]["install_command"].startswith("/workspace/loopx/")
+    assert "git pull" not in payload["plan"]["install_command"]
+    assert payload["changes_applied"] is False
+
+
+def test_cli_rejects_conflicting_named_and_legacy_actions() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "update",
+            "check",
+            "--execute",
+            "--format",
+            "json",
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1, (result.stdout, result.stderr)
+    payload = json.loads(result.stdout)
+    assert payload["changes_applied"] is False
+    assert "conflicts with the legacy option" in payload["error"]
 
 
 def test_cli_rejects_installed_doctor_snapshot_outside_check(tmp_path: Path) -> None:
@@ -200,7 +373,7 @@ def test_cli_rejects_installed_doctor_snapshot_outside_check(tmp_path: Path) -> 
     assert result.returncode == 1, (result.stdout, result.stderr)
     payload = json.loads(result.stdout)
     assert payload["ok"] is False
-    assert payload["error"] == "--installed-doctor-json requires update --check"
+    assert payload["error"] == "--installed-doctor-json requires `loopx update check`"
 
 
 def test_restart_managed_loopx_services_restarts_only_loopx_launchagents(
@@ -228,7 +401,11 @@ def test_restart_managed_loopx_services_restarts_only_loopx_launchagents(
     monkeypatch.setattr("loopx.self_update.subprocess.run", fake_run)
 
     restarted = restart_managed_loopx_services()
-    assert set(restarted) == {"com.loopx.status", "com.loopx.chat", "com.goal-harness.status"}
+    assert set(restarted) == {
+        "com.loopx.status",
+        "com.loopx.chat",
+        "com.goal-harness.status",
+    }
     assert len(calls) == 3
     assert all(call[0] == "launchctl" for call in calls)
 

--- a/tests/test_self_update_runtime_activation.py
+++ b/tests/test_self_update_runtime_activation.py
@@ -324,6 +324,27 @@ def test_live_checkout_apply_never_mutates_git_or_switches_install_channels() ->
     assert payload["changes_applied"] is False
 
 
+def test_unknown_package_manager_apply_fails_without_guessing_pip() -> None:
+    doctor = doctor_payload()
+    doctor["package"] = {"install_kind": "python_distribution"}
+    doctor["install_freshness"].update(
+        {
+            "install_kind": "python_distribution",
+            "python_distribution_installer": "custom-manager",
+            "upgrade_command": None,
+        }
+    )
+
+    payload = build_update_plan(action="apply", doctor_payload=doctor)
+
+    assert payload["ok"] is False
+    assert payload["install_lifecycle"]["execution_driver"] is None
+    assert payload["commands"]["apply"] is None
+    assert payload["commands"]["owner_upgrade"] is None
+    assert payload["next_action"]["command"] is None
+    assert "pip install" not in payload["recommended_action"]
+
+
 def test_cli_rejects_conflicting_named_and_legacy_actions() -> None:
     result = subprocess.run(
         [

--- a/tests/test_self_update_runtime_activation.py
+++ b/tests/test_self_update_runtime_activation.py
@@ -431,6 +431,10 @@ def test_restart_managed_loopx_services_restarts_only_loopx_launchagents(
     assert all(call[0] == "launchctl" for call in calls)
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="archive snapshot updates require the POSIX installer path",
+)
 def test_successful_update_revalidates_enabled_extensions(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- replace the ambiguous `--execute`-first UX with explicit `loopx update check|plan|apply` actions while retaining legacy flag aliases
- route apply through the detected installation owner: pip, pipx, or atomic archive snapshot; fail closed for live source checkouts and unknown package managers
- make bare human output state that no update occurred and show a copyable Next Action; expose the same decision as typed JSON fields for agents
- define PyPI as the normal release channel, Git checkout/canary as the source-development path, and archive snapshots as recovery fallback

## Runtime ownership

- pip: use the owning `sys.executable -m pip`, then refresh workflow skills, slash commands, doctor, enabled extensions, and managed services
- pipx: preserve `pipx_metadata.json` environment ownership and call `pipx upgrade`
- archive: retain atomic snapshot activation and recorded rollback
- live checkout: never run `git pull` or switch install channels; project the contributor installer instead

No TypeScript migration is included: installation/environment mutation is Python-owned, while the TypeScript Effect runtime remains a validated artifact of the installed release rather than the installer authority.

## Validation

- `ruff check` on changed Python boundaries
- `pytest tests/test_self_update_runtime_activation.py tests/test_doctor_install_freshness.py -q` (29 passed, 1 platform skip)
- `pytest tests/control_plane/test_cli_output_budget.py tests/control_plane/test_cli_output_differential.py -q` (38 passed)
- `examples/loopx-update-smoke.py`
- `examples/cli-support-control-command-modularization-smoke.py`
- `examples/cli-help-manpage-smoke.py`
- `examples/release/release-readiness-doc-smoke.py`
- `examples/control_plane/control-plane-maintainability-ratchet-smoke.py`
- public/private boundary scan: clean
- premerge risk matrix: all install/release/risk-profile checks passed; the aggregate local run was non-green only because the differential smoke could not create its detached base worktree under the local repository change-window hook. The underlying 38 CLI budget/differential tests passed directly; GitHub checks remain required before merge.

## Future-facing pass

Applied: pip/pipx detection and upgrade command construction now live in `python_install_owner.py`, keeping `doctor.py` below its maintainability ceiling and preventing a second package-owner rule inside CLI dispatch.