### PR TITLE
feat(benchmark): record orchestrator runtime provenance

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -671,8 +671,12 @@ loopx benchmark experiment-board-upsert \
 The default ledger is locked, atomically updated, and keyed by benchmark, study,
 case, and run identity. A compact row carries arm role, exact and comparison
 protocol ids, model, score metrics, countability, treatment fidelity, bounded
-effort, and an optional insight status or public-safe handle. Unknown fields and
-path-like references fail closed.
+effort, and an optional insight status or public-safe handle. When an arm uses an
+orchestration/control runtime, record its public-safe `provider_id`, exact
+`revision`, and optional package `version` in `orchestrator_runtime`; keep this
+separate from `runner_revision`, which identifies the benchmark runner. The board
+summary groups rows by that exact runtime identity so version cohorts are not
+silently pooled. Unknown fields and path-like references fail closed.
 
 Every non-baseline row names an exact `comparison_anchor_run_id`. Standard control
 or treatment rows anchor to a baseline. Explore rows use `diagnostic_only` claim

--- a/loopx/capabilities/benchmark_toolkit/catalog_entry.py
+++ b/loopx/capabilities/benchmark_toolkit/catalog_entry.py
@@ -147,7 +147,8 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
             ),
             "purpose": (
                 "Idempotently record one planned, running, or terminal compact run "
-                "row; omit --execute for a no-write preview."
+                "row, including optional provider-neutral orchestrator runtime "
+                "revision provenance; omit --execute for a no-write preview."
             ),
             "write_boundary": (
                 "explicit project-local domain-state write; rejects raw paths, "

--- a/loopx/capabilities/benchmark_toolkit/experiment_board.py
+++ b/loopx/capabilities/benchmark_toolkit/experiment_board.py
@@ -44,6 +44,7 @@ _ROW_FIELDS = {
     "protocol_id",
     "comparison_protocol_id",
     "runner_revision",
+    "orchestrator_runtime",
     "comparison_anchor_run_id",
     "claim_scope",
     "primary_metric",
@@ -218,6 +219,32 @@ def _insight(value: Any) -> dict[str, Any]:
     return result
 
 
+def _orchestrator_runtime(value: Any) -> dict[str, str] | None:
+    if value in (None, {}):
+        return None
+    if not isinstance(value, Mapping):
+        raise TypeError("orchestrator_runtime must be an object")
+    _reject_unknown_fields(
+        value,
+        allowed={"provider_id", "version", "revision"},
+        field="orchestrator_runtime",
+    )
+    result = {
+        "provider_id": _token(
+            value.get("provider_id"), field="orchestrator_runtime.provider_id"
+        ),
+        "revision": _token(
+            value.get("revision"), field="orchestrator_runtime.revision"
+        ),
+    }
+    version = _optional_token(
+        value.get("version"), field="orchestrator_runtime.version"
+    )
+    if version is not None:
+        result["version"] = version
+    return result
+
+
 def normalize_benchmark_experiment_board_row(
     payload: Mapping[str, Any],
 ) -> dict[str, Any]:
@@ -319,6 +346,9 @@ def normalize_benchmark_experiment_board_row(
     )
     if runner_revision is not None:
         row["runner_revision"] = runner_revision
+    orchestrator_runtime = _orchestrator_runtime(payload.get("orchestrator_runtime"))
+    if orchestrator_runtime is not None:
+        row["orchestrator_runtime"] = orchestrator_runtime
     if comparison_anchor_run_id is not None:
         row["comparison_anchor_run_id"] = comparison_anchor_run_id
     return row
@@ -706,6 +736,16 @@ def _comparison_lane_counts(
     }
 
 
+def _orchestrator_runtime_key(row: Mapping[str, Any]) -> str:
+    runtime = row.get("orchestrator_runtime")
+    if not isinstance(runtime, Mapping):
+        return "none"
+    provider_id = str(runtime.get("provider_id") or "unknown")
+    version = str(runtime.get("version") or "unversioned")
+    revision = str(runtime.get("revision") or "unknown")
+    return f"{provider_id}@{version}@{revision}"
+
+
 def build_benchmark_experiment_board(
     rows: Iterable[Mapping[str, Any]],
     *,
@@ -746,6 +786,12 @@ def build_benchmark_experiment_board(
     case_keys = {
         (row["benchmark_id"], row["study_id"], row["case_id"]) for row in normalized
     }
+    orchestrator_runtime_counts: dict[str, int] = {}
+    for row in normalized:
+        runtime_key = _orchestrator_runtime_key(row)
+        orchestrator_runtime_counts[runtime_key] = (
+            orchestrator_runtime_counts.get(runtime_key, 0) + 1
+        )
     return {
         "ok": True,
         "schema_version": BENCHMARK_EXPERIMENT_BOARD_SCHEMA_VERSION,
@@ -767,6 +813,9 @@ def build_benchmark_experiment_board(
             "arm_role_counts": role_counts,
             "comparison_arm_role_counts": comparison_arm_role_counts,
             "comparison_claim_scope_counts": comparison_claim_scope_counts,
+            "orchestrator_runtime_counts": dict(
+                sorted(orchestrator_runtime_counts.items())
+            ),
         },
         "runs": normalized,
         "comparisons": comparisons,
@@ -810,6 +859,16 @@ def _format_metric(metric: Mapping[str, Any] | None) -> str:
     return f"{value}/{total}" if total is not None else str(value)
 
 
+def _format_orchestrator_runtime(value: Any) -> str:
+    if not isinstance(value, Mapping):
+        return "n/a"
+    provider_id = str(value.get("provider_id") or "unknown")
+    version = str(value.get("version") or "")
+    revision = str(value.get("revision") or "unknown")
+    identity = f"{provider_id}@{version}" if version else provider_id
+    return f"{identity}:{revision[:12]}"
+
+
 def render_benchmark_experiment_board_markdown(payload: Mapping[str, Any]) -> str:
     summary = (
         payload.get("summary") if isinstance(payload.get("summary"), Mapping) else {}
@@ -841,8 +900,8 @@ def render_benchmark_experiment_board_markdown(payload: Mapping[str, Any]) -> st
         "",
         "## Runs",
         "",
-        "| Benchmark | Study | Case | Role | Arm | Status | Primary | Reward | Integrity | Countable | Fidelity | Steps | Cost USD | Insight |",
-        "| --- | --- | --- | --- | --- | --- | ---: | ---: | --- | --- | --- | ---: | ---: | --- |",
+        "| Benchmark | Study | Case | Role | Arm | Orchestrator | Status | Primary | Reward | Integrity | Countable | Fidelity | Steps | Cost USD | Insight |",
+        "| --- | --- | --- | --- | --- | --- | --- | ---: | ---: | --- | --- | --- | ---: | ---: | --- |",
     ]
     for row in payload.get("runs", []) or []:
         if not isinstance(row, Mapping):
@@ -866,6 +925,7 @@ def render_benchmark_experiment_board_markdown(payload: Mapping[str, Any]) -> st
                     str(row.get("case_id")),
                     str(row.get("arm_role")),
                     str(row.get("arm_id")),
+                    _format_orchestrator_runtime(row.get("orchestrator_runtime")),
                     str(row.get("status")),
                     _format_metric(primary if isinstance(primary, Mapping) else None),
                     _format_metric(reward if isinstance(reward, Mapping) else None),
@@ -881,7 +941,7 @@ def render_benchmark_experiment_board_markdown(payload: Mapping[str, Any]) -> st
         )
     if not payload.get("runs"):
         lines.append(
-            "| n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |"
+            "| n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |"
         )
 
     lines.extend(

--- a/tests/capabilities/test_benchmark_experiment_board.py
+++ b/tests/capabilities/test_benchmark_experiment_board.py
@@ -39,6 +39,7 @@ def _row(
     score_countable: bool = True,
     fidelity: str = "qualified",
     insight_status: str = "complete",
+    orchestrator_runtime: dict[str, str] | None = None,
 ) -> dict[str, object]:
     payload: dict[str, object] = {
         "schema_version": BENCHMARK_EXPERIMENT_BOARD_ROW_SCHEMA_VERSION,
@@ -89,6 +90,8 @@ def _row(
     }
     if comparison_anchor_run_id is not None:
         payload["comparison_anchor_run_id"] = comparison_anchor_run_id
+    if orchestrator_runtime is not None:
+        payload["orchestrator_runtime"] = orchestrator_runtime
     return payload
 
 
@@ -221,6 +224,11 @@ def test_board_keeps_standard_and_explore_lanes_and_compares_explicit_anchor() -
         observed_at="2026-08-18T00:20:00+00:00",
         f2p=64,
         comparison_anchor_run_id="baseline-12",
+        orchestrator_runtime={
+            "provider_id": "loopx",
+            "version": "0.5.2",
+            "revision": "0123456789abcdef",
+        },
     )
     explore = _row(
         run_id="explore-12",
@@ -242,6 +250,10 @@ def test_board_keeps_standard_and_explore_lanes_and_compares_explicit_anchor() -
         "treatment": 0,
     }
     assert board["summary"]["matched_pair_countable_count"] == 2
+    assert board["summary"]["orchestrator_runtime_counts"] == {
+        "loopx@0.5.2@0123456789abcdef": 1,
+        "none": 2,
+    }
     assert board["summary"]["comparison_arm_role_counts"] == {
         "control": {"all": 1, "matched_pair_countable": 1},
         "explore": {"all": 1, "matched_pair_countable": 1},
@@ -263,6 +275,12 @@ def test_board_keeps_standard_and_explore_lanes_and_compares_explicit_anchor() -
     assert comparisons["control"]["warning_codes"] == [
         "exact_protocol_revision_differs"
     ]
+    assert board["runs"][1]["orchestrator_runtime"] == {
+        "provider_id": "loopx",
+        "revision": "0123456789abcdef",
+        "version": "0.5.2",
+    }
+    assert "loopx@0.5.2:0123456789ab" in rendered
     assert comparisons["explore"]["claim_scope"] == "diagnostic_only"
     assert comparisons["explore"]["comparison_anchor_arm_role"] == "control"
     assert comparisons["explore"]["metric_deltas"]["feature_pass"]["delta"] == 2
@@ -296,6 +314,21 @@ def test_locked_jsonl_upsert_updates_one_stable_run_row(tmp_path: Path) -> None:
     assert rows[0]["status"] == "completed"
     assert rows[0]["arm_id"] == "corrected-native-goal"
     assert "domain_state_key" not in rows[0]
+
+
+def test_row_rejects_incomplete_or_path_like_orchestrator_runtime() -> None:
+    missing_revision = _baseline(orchestrator_runtime={"provider_id": "loopx"})
+    with pytest.raises(ValueError, match="orchestrator_runtime.revision"):
+        normalize_benchmark_experiment_board_row(missing_revision)
+
+    path_revision = _baseline(
+        orchestrator_runtime={
+            "provider_id": "loopx",
+            "revision": "/private/runtime",
+        }
+    )
+    with pytest.raises(ValueError, match="compact public-safe token"):
+        normalize_benchmark_experiment_board_row(path_revision)
 
 
 def test_upsert_rejects_stale_transition_after_terminal_state(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add an optional provider-neutral orchestrator runtime identity to benchmark experiment rows
- keep solver orchestration provenance distinct from runner revision
- summarize and render runtime cohorts without requiring private run artifacts

## Why

Matched benchmark results can otherwise silently mix runs produced by different orchestration revisions. Recording provider, version, and exact revision makes cohort changes visible and supports revision-fenced comparisons.

## Validation

- 115 benchmark-toolkit tests passed
- focused experiment-board tests: 14 passed
- Ruff check and format passed
- LoopX public-boundary scan passed
- standard premerge canary: 18 selected checks passed; benchmark-sensitive manual review hold remains

## Boundaries

The field is optional and provider-neutral. It contains public-safe runtime identity only; no task text, trajectories, credentials, verifier output, or local paths are stored. This does not change scoring or runner behavior.